### PR TITLE
Track separate ingestion rates for API and Rules

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -592,8 +592,11 @@ func (d *Distributor) UserStats(ctx context.Context) (*UserStats, error) {
 
 	totalStats := &UserStats{}
 	for _, resp := range resps {
-		totalStats.IngestionRate += resp.(*client.UserStatsResponse).IngestionRate
-		totalStats.NumSeries += resp.(*client.UserStatsResponse).NumSeries
+		r := resp.(*client.UserStatsResponse)
+		totalStats.IngestionRate += r.IngestionRate
+		totalStats.APIIngestionRate += r.ApiIngestionRate
+		totalStats.RuleIngestionRate += r.RuleIngestionRate
+		totalStats.NumSeries += r.NumSeries
 	}
 
 	totalStats.IngestionRate /= float64(d.ring.ReplicationFactor())
@@ -633,6 +636,8 @@ func (d *Distributor) AllUserStats(ctx context.Context) ([]UserIDStats, error) {
 		for _, u := range resp.Stats {
 			s := perUserTotals[u.UserId]
 			s.IngestionRate += u.Data.IngestionRate
+			s.APIIngestionRate += u.Data.ApiIngestionRate
+			s.RuleIngestionRate += u.Data.RuleIngestionRate
 			s.NumSeries += u.Data.NumSeries
 			perUserTotals[u.UserId] = s
 		}
@@ -644,8 +649,10 @@ func (d *Distributor) AllUserStats(ctx context.Context) ([]UserIDStats, error) {
 		response = append(response, UserIDStats{
 			UserID: id,
 			UserStats: UserStats{
-				IngestionRate: stats.IngestionRate,
-				NumSeries:     stats.NumSeries,
+				IngestionRate:     stats.IngestionRate,
+				APIIngestionRate:  stats.APIIngestionRate,
+				RuleIngestionRate: stats.RuleIngestionRate,
+				NumSeries:         stats.NumSeries,
 			},
 		})
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -480,7 +480,7 @@ func TestDistributorValidation(t *testing.T) {
 			d.limits.Defaults.RejectOldSamplesMaxAge = 24 * time.Hour
 			d.limits.Defaults.MaxLabelNamesPerSeries = 2
 
-			_, err := d.Push(ctx, client.ToWriteRequest(tc.samples))
+			_, err := d.Push(ctx, client.ToWriteRequest(tc.samples, client.API))
 			require.Equal(t, tc.err, err)
 		})
 	}

--- a/pkg/distributor/http_server.go
+++ b/pkg/distributor/http_server.go
@@ -16,6 +16,7 @@ import (
 func (d *Distributor) PushHandler(w http.ResponseWriter, r *http.Request) {
 	compressionType := util.CompressionTypeFor(r.Header.Get("X-Prometheus-Remote-Write-Version"))
 	var req client.PreallocWriteRequest
+	req.Source = client.API
 	buf, err := util.ParseProtoReader(r.Context(), r.Body, &req, compressionType)
 	logger := util.WithContext(r.Context(), util.Logger)
 	if err != nil {
@@ -47,8 +48,10 @@ func (d *Distributor) PushHandler(w http.ResponseWriter, r *http.Request) {
 
 // UserStats models ingestion statistics for one user.
 type UserStats struct {
-	IngestionRate float64 `json:"ingestionRate"`
-	NumSeries     uint64  `json:"numSeries"`
+	IngestionRate     float64 `json:"ingestionRate"`
+	NumSeries         uint64  `json:"numSeries"`
+	APIIngestionRate  float64 `json:"APIIngestionRate"`
+	RuleIngestionRate float64 `json:"RuleIngestionRate"`
 }
 
 // UserStatsHandler handles user stats to the Distributor.

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -24,9 +24,10 @@ func FromWriteRequest(req *WriteRequest) []model.Sample {
 }
 
 // ToWriteRequest converts an array of samples into a WriteRequest proto.
-func ToWriteRequest(samples []model.Sample) *WriteRequest {
+func ToWriteRequest(samples []model.Sample, source WriteRequest_SourceEnum) *WriteRequest {
 	req := &WriteRequest{
 		Timeseries: make([]PreallocTimeseries, 0, len(samples)),
+		Source:     source,
 	}
 
 	for _, s := range samples {

--- a/pkg/ingester/client/compat_test.go
+++ b/pkg/ingester/client/compat_test.go
@@ -24,7 +24,7 @@ func TestWriteRequest(t *testing.T) {
 		})
 	}
 
-	have := FromWriteRequest(ToWriteRequest(want))
+	have := FromWriteRequest(ToWriteRequest(want, API))
 
 	if !reflect.DeepEqual(want, have) {
 		t.Fatalf(test.Diff(want, have))

--- a/pkg/ingester/client/cortex.proto
+++ b/pkg/ingester/client/cortex.proto
@@ -25,6 +25,11 @@ service Ingester {
 
 message WriteRequest {
   repeated TimeSeries timeseries = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "PreallocTimeseries"];
+  enum SourceEnum {
+    API = 0;
+    RULE = 1;
+  }
+  SourceEnum Source = 2;
 }
 
 message WriteResponse {}
@@ -60,6 +65,8 @@ message UserStatsRequest {}
 message UserStatsResponse {
   double ingestion_rate = 1;
   uint64 num_series = 2;
+  double api_ingestion_rate = 3;
+  double rule_ingestion_rate = 4;
 }
 
 message UserIDStatsResponse {

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -105,7 +105,7 @@ func TestIngesterTransfer(t *testing.T) {
 			Timestamp: ts,
 			Value:     val,
 		},
-	}))
+	}, client.API))
 	require.NoError(t, err)
 
 	// Start a second ingester, but let it go into PENDING
@@ -289,7 +289,7 @@ func TestIngesterFlush(t *testing.T) {
 			Timestamp: ts,
 			Value:     val,
 		},
-	}))
+	}, client.API))
 	require.NoError(t, err)
 
 	// We add a 100ms sleep into the flush loop, such that we can reliably detect

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -51,7 +51,7 @@ func (a *appendableAppender) AddFast(l labels.Labels, ref uint64, t int64, v flo
 }
 
 func (a *appendableAppender) Commit() error {
-	_, err := a.pusher.Push(a.ctx, client.ToWriteRequest(a.samples))
+	_, err := a.pusher.Push(a.ctx, client.ToWriteRequest(a.samples, client.RULE))
 	a.samples = nil
 	return err
 }


### PR DESCRIPTION
Allow us to tell if a user is still sending samples, or if they just have some rules using `absent(...)`