### PR TITLE
Update disk cache to shard lock, store keys in memory

### DIFF
--- a/pkg/chunk/cache/background.go
+++ b/pkg/chunk/cache/background.go
@@ -8,25 +8,21 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
-	droppedWriteBack = prometheus.NewCounter(prometheus.CounterOpts{
+	droppedWriteBack = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "cortex",
 		Name:      "cache_dropped_background_writes_total",
 		Help:      "Total count of dropped write backs to cache.",
-	})
-	queueLength = prometheus.NewGauge(prometheus.GaugeOpts{
+	}, []string{"name"})
+	queueLength = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "cortex",
 		Name:      "cache_background_queue_length",
 		Help:      "Length of the cache background write queue.",
-	})
+	}, []string{"name"})
 )
-
-func init() {
-	prometheus.MustRegister(droppedWriteBack)
-	prometheus.MustRegister(queueLength)
-}
 
 // BackgroundConfig is config for a Background Cache.
 type BackgroundConfig struct {
@@ -46,6 +42,10 @@ type backgroundCache struct {
 	wg       sync.WaitGroup
 	quit     chan struct{}
 	bgWrites chan backgroundWrite
+	name     string
+
+	droppedWriteBack prometheus.Counter
+	queueLength      prometheus.Gauge
 }
 
 type backgroundWrite struct {
@@ -54,11 +54,14 @@ type backgroundWrite struct {
 }
 
 // NewBackground returns a new Cache that does stores on background goroutines.
-func NewBackground(cfg BackgroundConfig, cache Cache) Cache {
+func NewBackground(name string, cfg BackgroundConfig, cache Cache) Cache {
 	c := &backgroundCache{
-		Cache:    cache,
-		quit:     make(chan struct{}),
-		bgWrites: make(chan backgroundWrite, cfg.WriteBackBuffer),
+		Cache:            cache,
+		quit:             make(chan struct{}),
+		bgWrites:         make(chan backgroundWrite, cfg.WriteBackBuffer),
+		name:             name,
+		droppedWriteBack: droppedWriteBack.WithLabelValues(name),
+		queueLength:      queueLength.WithLabelValues(name),
 	}
 
 	c.wg.Add(cfg.WriteBackGoroutines)
@@ -85,11 +88,11 @@ func (c *backgroundCache) Store(ctx context.Context, keys []string, bufs [][]byt
 	}
 	select {
 	case c.bgWrites <- bgWrite:
-		queueLength.Add(float64(len(keys)))
+		c.queueLength.Add(float64(len(keys)))
 	default:
 		sp := opentracing.SpanFromContext(ctx)
 		sp.LogFields(otlog.Int("dropped", len(keys)))
-		droppedWriteBack.Add(float64(len(keys)))
+		c.droppedWriteBack.Add(float64(len(keys)))
 	}
 }
 
@@ -102,7 +105,7 @@ func (c *backgroundCache) writeBackLoop() {
 			if !ok {
 				return
 			}
-			queueLength.Sub(float64(len(bgWrite.keys)))
+			c.queueLength.Sub(float64(len(bgWrite.keys)))
 			c.Cache.Store(context.Background(), bgWrite.keys, bgWrite.bufs)
 
 		case <-c.quit:

--- a/pkg/chunk/cache/background_test.go
+++ b/pkg/chunk/cache/background_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestBackground(t *testing.T) {
-	c := cache.NewBackground(cache.BackgroundConfig{
+	c := cache.NewBackground("mock", cache.BackgroundConfig{
 		WriteBackGoroutines: 1,
 		WriteBackBuffer:     100,
 	}, cache.NewMockCache())

--- a/pkg/chunk/cache/cache.go
+++ b/pkg/chunk/cache/cache.go
@@ -48,20 +48,18 @@ func New(cfg Config) (Cache, error) {
 		if err != nil {
 			return nil, err
 		}
-		caches = append(caches, Instrument("diskcache", cache))
+		caches = append(caches, NewBackground("diskcache", cfg.background, Instrument("diskcache", cache)))
 	}
 
 	if cfg.memcacheClient.Host != "" {
 		client := NewMemcachedClient(cfg.memcacheClient)
 		cache := NewMemcached(cfg.memcache, client)
-		caches = append(caches, Instrument("memcache", cache))
+		caches = append(caches, NewBackground("memcache", cfg.background, Instrument("memcache", cache)))
 	}
 
 	cache := NewTiered(caches)
 	if len(caches) > 1 {
 		cache = Instrument("tiered", cache)
 	}
-
-	cache = NewBackground(cfg.background, cache)
 	return cache, nil
 }

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+
+	"github.com/cortexproject/cortex/pkg/chunk/cache"
 )
 
 // Store for chunks.
@@ -121,6 +123,12 @@ func latest(a, b model.Time) model.Time {
 // NewStore creates a new Store which delegates to different stores depending
 // on time.
 func NewStore(cfg StoreConfig, schemaCfg SchemaConfig, storageOpts []StorageOpt) (Store, error) {
+	cache, err := cache.New(cfg.CacheConfig)
+	if err != nil {
+		return nil, err
+	}
+	cfg.CacheConfig.Cache = cache
+
 	schemaOpts := SchemaOpts(cfg, schemaCfg)
 
 	return newCompositeStore(cfg, schemaCfg, schemaOpts, storageOpts)

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -54,7 +54,7 @@ func Opts(cfg Config, schemaCfg chunk.SchemaConfig) ([]chunk.StorageOpt, error) 
 		memcache := cache.Instrument("memcache-index", cache.NewMemcached(cache.MemcachedConfig{
 			Expiration: cfg.IndexCacheValidity,
 		}, client))
-		caches = append(caches, cache.NewBackground(cache.BackgroundConfig{
+		caches = append(caches, cache.NewBackground("memcache-index", cache.BackgroundConfig{
 			WriteBackGoroutines: 10,
 			WriteBackBuffer:     100,
 		}, memcache))


### PR DESCRIPTION
Under high query load the disk-cache has been observed locking for a substantial amount of time. This PR retools the Disk-cache to use a sharded locking mechanism. It also stores the key name for each bucket in memory. This allows missed reads to never access the mmap buffer, which reduces the number of unnecessary page faults. 

Summary of Changes:
- Sharded Locks
- Keys in-memory index
- Added additional metrics to determine disk-cache usage