### PR TITLE
Better trace op names for querier

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -936,7 +936,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:cb82650acf4059a7a4ea11a3206fedc6315564dc93ef53e7cb98fb28a956ede2"
+  digest = "1:6e4a66a9a768fc71e492bec9fafc4c387698a559af45087c731b25b1599497d3"
   name = "github.com/weaveworks/common"
   packages = [
     "aws",
@@ -956,7 +956,7 @@
     "user",
   ]
   pruneopts = "UT"
-  revision = "2a0cb6145a2f541de5ca19437fee675baf6a1985"
+  revision = "e017e7c69cfdc53d5d3bbd4115eb84aa8a180a82"
 
 [[projects]]
   digest = "1:efac30de93ca1ff38050f46dc34f1338ebc8778de488f919f79ad9e6188719d3"

--- a/vendor/github.com/weaveworks/common/middleware/instrument.go
+++ b/vendor/github.com/weaveworks/common/middleware/instrument.go
@@ -64,8 +64,17 @@ func (i Instrument) Wrap(next http.Handler) http.Handler {
 // We do all this as we do not wish to emit high cardinality labels to
 // prometheus.
 func (i Instrument) getRouteName(r *http.Request) string {
+	route := getRouteName(i.RouteMatcher, r)
+	if route == "" {
+		route = "other"
+	}
+
+	return route
+}
+
+func getRouteName(routeMatcher RouteMatcher, r *http.Request) string {
 	var routeMatch mux.RouteMatch
-	if i.RouteMatcher != nil && i.RouteMatcher.Match(r, &routeMatch) {
+	if routeMatcher != nil && routeMatcher.Match(r, &routeMatch) {
 		if name := routeMatch.Route.GetName(); name != "" {
 			return name
 		}
@@ -73,7 +82,8 @@ func (i Instrument) getRouteName(r *http.Request) string {
 			return MakeLabelValue(tmpl)
 		}
 	}
-	return "other"
+
+	return ""
 }
 
 var invalidChars = regexp.MustCompile(`[^a-zA-Z0-9]+`)

--- a/vendor/github.com/weaveworks/common/server/server.go
+++ b/vendor/github.com/weaveworks/common/server/server.go
@@ -139,7 +139,9 @@ func New(cfg Config) (*Server, error) {
 		RegisterInstrumentation(router)
 	}
 	httpMiddleware := []middleware.Interface{
-		middleware.Tracer{},
+		middleware.Tracer{
+			RouteMatcher: router,
+		},
 		middleware.Log{
 			Log: log,
 		},


### PR DESCRIPTION
~DON'T MERGE, depends on https://github.com/weaveworks/common/pull/126~

It separates the `/metrics` calls from queries now.