### PR TITLE
fix flags using existing pattern from `SetClientConfig`

### DIFF
--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -56,7 +56,7 @@ func main() {
 		&ingesterConfig, &configStoreConfig, &rulerConfig, &storageConfig, &schemaConfig)
 	flag.BoolVar(&unauthenticated, "unauthenticated", false, "Set to true to disable multitenancy.")
 	flag.Parse()
-	ingesterConfig.SetClientConfig(distributorConfig.IngesterClientConfig)
+	ingesterConfig.SetClientConfig(distributorConfig.IngesterClientConfig, distributorConfig.Limits)
 
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
 	trace := tracing.NewFromEnv("ingester")

--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -56,7 +56,7 @@ func main() {
 		&ingesterConfig, &configStoreConfig, &rulerConfig, &storageConfig, &schemaConfig)
 	flag.BoolVar(&unauthenticated, "unauthenticated", false, "Set to true to disable multitenancy.")
 	flag.Parse()
-	ingesterConfig.SetClientConfig(distributorConfig.IngesterClientConfig, distributorConfig.Limits)
+	ingesterConfig.SetSharedConfigs(distributorConfig.IngesterClientConfig, distributorConfig.Limits)
 
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
 	trace := tracing.NewFromEnv("ingester")

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -102,7 +102,7 @@ type Config struct {
 	BillingConfig        billing.Config
 	IngesterClientConfig ingester_client.Config
 	PoolConfig           ingester_client.PoolConfig
-	limits               validation.Limits
+	Limits               validation.Limits
 
 	RemoteTimeout   time.Duration
 	ExtraQueryDelay time.Duration
@@ -118,7 +118,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.BillingConfig.RegisterFlags(f)
 	cfg.IngesterClientConfig.RegisterFlags(f)
 	cfg.PoolConfig.RegisterFlags(f)
-	cfg.limits.RegisterFlags(f)
+	cfg.Limits.RegisterFlags(f)
 
 	f.BoolVar(&cfg.EnableBilling, "distributor.enable-billing", false, "Report number of ingested samples to billing system.")
 	f.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")
@@ -143,7 +143,7 @@ func New(cfg Config, ring ring.ReadRing) (*Distributor, error) {
 		}
 	}
 
-	limits, err := validation.NewOverrides(cfg.limits)
+	limits, err := validation.NewOverrides(cfg.Limits)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -275,8 +275,8 @@ func prepare(t *testing.T, numIngesters, happyIngesters int, queryDelay time.Dur
 
 	var cfg Config
 	util.DefaultValues(&cfg)
-	cfg.limits.IngestionRate = 20
-	cfg.limits.IngestionBurstSize = 20
+	cfg.Limits.IngestionRate = 20
+	cfg.Limits.IngestionBurstSize = 20
 	cfg.ingesterClientFactory = factory
 	cfg.ShardByAllLabels = shardByAllLabels
 	cfg.ExtraQueryDelay = 50 * time.Millisecond

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -74,7 +74,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	// lite uses both ingester.Config and distributor.Config.
 	// Both of them has IngesterClientConfig, so calling RegisterFlags on them triggers panic.
-	// This check ignores second call to RegisterFlags on IngesterClientConfig and then populates it manually with SetClientConfig
+	// This check ignores second call to RegisterFlags on IngesterClientConfig and then populates it manually with SetSharedConfigs
 	if flag.Lookup("ingester.client.max-recv-message-size") != nil {
 		return
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -95,7 +95,7 @@ type Config struct {
 	ingesterClientFactory func(addr string, cfg client.Config) (client.IngesterClient, error)
 }
 
-// SetSharedConfigs sets clientConfig in config
+// SetSharedConfigs sets clientConfig and limits in config
 func (cfg *Config) SetSharedConfigs(clientConfig client.Config, limits validation.Limits) {
 	cfg.clientConfig = clientConfig
 	cfg.limits = limits

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -96,8 +96,9 @@ type Config struct {
 }
 
 // SetClientConfig sets clientConfig in config
-func (cfg *Config) SetClientConfig(clientConfig client.Config) {
+func (cfg *Config) SetClientConfig(clientConfig client.Config, limits validation.Limits) {
 	cfg.clientConfig = clientConfig
+	cfg.limits = limits
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -95,8 +95,8 @@ type Config struct {
 	ingesterClientFactory func(addr string, cfg client.Config) (client.IngesterClient, error)
 }
 
-// SetClientConfig sets clientConfig in config
-func (cfg *Config) SetClientConfig(clientConfig client.Config, limits validation.Limits) {
+// SetSharedConfigs sets clientConfig in config
+func (cfg *Config) SetSharedConfigs(clientConfig client.Config, limits validation.Limits) {
 	cfg.clientConfig = clientConfig
 	cfg.limits = limits
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -33,6 +33,13 @@ type Limits struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (l *Limits) RegisterFlags(f *flag.FlagSet) {
+	// lite uses both ingester.Config and distributor.Config.
+	// Both of them has Limits, so calling RegisterFlags on them triggers panic.
+	// This check ignores second call to RegisterFlags on IngesterClientConfig and then populates it manually with SetClientConfig
+	if exist := f.Lookup("distributor.ingestion-rate-limit"); exist != nil {
+		return
+	}
+
 	f.Float64Var(&l.IngestionRate, "distributor.ingestion-rate-limit", 25000, "Per-user ingestion rate limit in samples per second.")
 	f.IntVar(&l.IngestionBurstSize, "distributor.ingestion-burst-size", 50000, "Per-user allowed ingestion burst size (in number of samples).")
 	f.IntVar(&l.MaxLabelNameLength, "validation.max-length-label-name", 1024, "Maximum length accepted for label names")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -35,7 +35,7 @@ type Limits struct {
 func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	// lite uses both ingester.Config and distributor.Config.
 	// Both of them has Limits, so calling RegisterFlags on them triggers panic.
-	// This check ignores second call to RegisterFlags on IngesterClientConfig and then populates it manually with SetClientConfig
+	// This check ignores second call to RegisterFlags and then populates it manually with SetSharedConfigs
 	if exist := f.Lookup("distributor.ingestion-rate-limit"); exist != nil {
 		return
 	}


### PR DESCRIPTION
This is a solution to the panic documented in Issue #1009 .

Other refactoring could be done to tween these configs apart, but I'm new to this codebase and thought it better to follow the existing solution to a very similar issue. See `SetClientConfig` in 'pkg/ingester/ingester.go'

@csmarchbanks mentioned that the method name `SetClientConfig` should be renamed since it is now also taking the Limits struct - I've done this in most recent commits.