### PR TITLE
Batch cache puts, simplify instrumentation, and don't return errors.

### DIFF
--- a/pkg/chunk/cache/background_test.go
+++ b/pkg/chunk/cache/background_test.go
@@ -13,14 +13,15 @@ type mockCache struct {
 	cache map[string][]byte
 }
 
-func (m *mockCache) Store(_ context.Context, key string, buf []byte) error {
+func (m *mockCache) Store(_ context.Context, keys []string, bufs [][]byte) {
 	m.Lock()
 	defer m.Unlock()
-	m.cache[key] = buf
-	return nil
+	for i := range keys {
+		m.cache[keys[i]] = bufs[i]
+	}
 }
 
-func (m *mockCache) Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string, err error) {
+func (m *mockCache) Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string) {
 	m.Lock()
 	defer m.Unlock()
 	for _, key := range keys {

--- a/pkg/chunk/cache/cache.go
+++ b/pkg/chunk/cache/cache.go
@@ -7,8 +7,8 @@ import (
 
 // Cache byte arrays by key.
 type Cache interface {
-	Store(ctx context.Context, key string, buf []byte) error
-	Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string, err error)
+	Store(ctx context.Context, key []string, buf [][]byte)
+	Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string)
 	Stop() error
 }
 

--- a/pkg/chunk/cache/cache_test.go
+++ b/pkg/chunk/cache/cache_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -162,5 +163,10 @@ func TestDiskcache(t *testing.T) {
 		Size: 100 * 1024 * 1024,
 	})
 	require.NoError(t, err)
+	testCache(t, cache)
+}
+
+func TestFifoCache(t *testing.T) {
+	cache := cache.NewFifoCache("test", 1e3, 1*time.Hour)
 	testCache(t, cache)
 }

--- a/pkg/chunk/cache/cache_test.go
+++ b/pkg/chunk/cache/cache_test.go
@@ -37,7 +37,7 @@ func fillCache(t *testing.T, cache cache.Cache) ([]string, []chunk.Chunk) {
 			model.Fingerprint(1),
 			model.Metric{
 				model.MetricNameLabel: "foo",
-				"bar":                 "baz",
+				"bar": "baz",
 			},
 			promChunk[0],
 			ts,

--- a/pkg/chunk/cache/cache_test.go
+++ b/pkg/chunk/cache/cache_test.go
@@ -23,6 +23,7 @@ func fillCache(t *testing.T, cache cache.Cache) ([]string, []chunk.Chunk) {
 
 	// put 100 chunks from 0 to 99
 	keys := []string{}
+	bufs := [][]byte{}
 	chunks := []chunk.Chunk{}
 	for i := 0; i < 100; i++ {
 		ts := model.TimeFromUnix(int64(i * chunkLen))
@@ -35,7 +36,7 @@ func fillCache(t *testing.T, cache cache.Cache) ([]string, []chunk.Chunk) {
 			model.Fingerprint(1),
 			model.Metric{
 				model.MetricNameLabel: "foo",
-				"bar": "baz",
+				"bar":                 "baz",
 			},
 			promChunk[0],
 			ts,
@@ -45,14 +46,12 @@ func fillCache(t *testing.T, cache cache.Cache) ([]string, []chunk.Chunk) {
 		buf, err := c.Encode()
 		require.NoError(t, err)
 
-		key := c.ExternalKey()
-		err = cache.Store(context.Background(), key, buf)
-		require.NoError(t, err)
-
-		keys = append(keys, key)
+		keys = append(keys, c.ExternalKey())
+		bufs = append(bufs, buf)
 		chunks = append(chunks, c)
 	}
 
+	cache.Store(context.Background(), keys, bufs)
 	return keys, chunks
 }
 
@@ -61,8 +60,7 @@ func testCacheSingle(t *testing.T, cache cache.Cache, keys []string, chunks []ch
 		index := rand.Intn(len(keys))
 		key := keys[index]
 
-		found, bufs, missingKeys, err := cache.Fetch(context.Background(), []string{key})
-		require.NoError(t, err)
+		found, bufs, missingKeys := cache.Fetch(context.Background(), []string{key})
 		require.Len(t, found, 1)
 		require.Len(t, bufs, 1)
 		require.Len(t, missingKeys, 0)
@@ -77,8 +75,7 @@ func testCacheSingle(t *testing.T, cache cache.Cache, keys []string, chunks []ch
 
 func testCacheMultiple(t *testing.T, cache cache.Cache, keys []string, chunks []chunk.Chunk) {
 	// test getting them all
-	found, bufs, missingKeys, err := cache.Fetch(context.Background(), keys)
-	require.NoError(t, err)
+	found, bufs, missingKeys := cache.Fetch(context.Background(), keys)
 	require.Len(t, found, len(keys))
 	require.Len(t, bufs, len(keys))
 	require.Len(t, missingKeys, 0)
@@ -117,8 +114,7 @@ func (a byExternalKey) Less(i, j int) bool { return a[i].ExternalKey() < a[j].Ex
 func testCacheMiss(t *testing.T, cache cache.Cache) {
 	for i := 0; i < 100; i++ {
 		key := strconv.Itoa(rand.Int())
-		found, bufs, missing, err := cache.Fetch(context.Background(), []string{key})
-		require.NoError(t, err)
+		found, bufs, missing := cache.Fetch(context.Background(), []string{key})
 		require.Empty(t, found)
 		require.Empty(t, bufs)
 		require.Len(t, missing, 1)

--- a/pkg/chunk/cache/fifo_cache_test.go
+++ b/pkg/chunk/cache/fifo_cache_test.go
@@ -18,10 +18,13 @@ func TestFifoCache(t *testing.T) {
 	ctx := context.Background()
 
 	// Check put / get works
+	keys := []string{}
+	values := []interface{}{}
 	for i := 0; i < size; i++ {
-		c.Put(ctx, strconv.Itoa(i), i)
-		//c.print()
+		keys = append(keys, strconv.Itoa(i))
+		values = append(values, i)
 	}
+	c.Put(ctx, keys, values)
 	require.Len(t, c.index, size)
 	require.Len(t, c.entries, size)
 
@@ -32,10 +35,13 @@ func TestFifoCache(t *testing.T) {
 	}
 
 	// Check evictions
+	keys = []string{}
+	values = []interface{}{}
 	for i := size; i < size+overwrite; i++ {
-		c.Put(ctx, strconv.Itoa(i), i)
-		//c.print()
+		keys = append(keys, strconv.Itoa(i))
+		values = append(values, i)
 	}
+	c.Put(ctx, keys, values)
 	require.Len(t, c.index, size)
 	require.Len(t, c.entries, size)
 
@@ -50,10 +56,13 @@ func TestFifoCache(t *testing.T) {
 	}
 
 	// Check updates work
+	keys = []string{}
+	values = []interface{}{}
 	for i := size; i < size+overwrite; i++ {
-		c.Put(ctx, strconv.Itoa(i), i*2)
-		//c.print()
+		keys = append(keys, strconv.Itoa(i))
+		values = append(values, i*2)
 	}
+	c.Put(ctx, keys, values)
 	require.Len(t, c.index, size)
 	require.Len(t, c.entries, size)
 
@@ -68,7 +77,7 @@ func TestFifoCacheExpiry(t *testing.T) {
 	c := NewFifoCache("test", size, 5*time.Millisecond)
 	ctx := context.Background()
 
-	c.Put(ctx, "0", 0)
+	c.Put(ctx, []string{"0"}, []interface{}{0})
 
 	value, ok := c.Get(ctx, "0")
 	require.True(t, ok)

--- a/pkg/chunk/cache/instrumented.go
+++ b/pkg/chunk/cache/instrumented.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"context"
-	"time"
 
 	ot "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -44,17 +43,6 @@ func Instrument(name string, cache Cache) Cache {
 		name:        name,
 		fetchedKeys: fetchedKeys.WithLabelValues(name),
 		hits:        hits.WithLabelValues(name),
-		trace:       true,
-		Cache:       cache,
-	}
-}
-
-// MetricsInstrument returns an instrumented cache that only tracks metrics and not traces.
-func MetricsInstrument(name string, cache Cache) Cache {
-	return &instrumentedCache{
-		name:        name,
-		fetchedKeys: fetchedKeys.WithLabelValues(name),
-		hits:        hits.WithLabelValues(name),
 		Cache:       cache,
 	}
 }
@@ -62,73 +50,41 @@ func MetricsInstrument(name string, cache Cache) Cache {
 type instrumentedCache struct {
 	name              string
 	fetchedKeys, hits prometheus.Counter
-	trace             bool
 	Cache
 }
 
-func (i *instrumentedCache) Store(ctx context.Context, key string, buf []byte) error {
+func (i *instrumentedCache) Store(ctx context.Context, keys []string, bufs [][]byte) {
 	method := i.name + ".store"
-	if i.trace {
-		return instr.TimeRequestHistogram(ctx, method, requestDuration, func(ctx context.Context) error {
-			sp := ot.SpanFromContext(ctx)
-			sp.LogFields(otlog.String("key", key))
-
-			return i.Cache.Store(ctx, key, buf)
-		})
-	}
-
-	return UntracedCollectedRequest(ctx, method, instr.NewHistogramCollector(requestDuration), instr.ErrorCode, func(ctx context.Context) error {
-		return i.Cache.Store(ctx, key, buf)
+	instr.TimeRequestHistogram(ctx, method, requestDuration, func(ctx context.Context) error {
+		sp := ot.SpanFromContext(ctx)
+		sp.LogFields(otlog.Int("keys", len(keys)))
+		i.Cache.Store(ctx, keys, bufs)
+		return nil
 	})
 }
 
-func (i *instrumentedCache) Fetch(ctx context.Context, keys []string) ([]string, [][]byte, []string, error) {
+func (i *instrumentedCache) Fetch(ctx context.Context, keys []string) ([]string, [][]byte, []string) {
 	var (
 		found   []string
 		bufs    [][]byte
 		missing []string
-		err     error
 		method  = i.name + ".fetch"
 	)
 
-	if i.trace {
-		err = instr.TimeRequestHistogram(ctx, method, requestDuration, func(ctx context.Context) error {
-			sp := ot.SpanFromContext(ctx)
-			sp.LogFields(otlog.Int("keys requested", len(keys)))
+	instr.TimeRequestHistogram(ctx, method, requestDuration, func(ctx context.Context) error {
+		sp := ot.SpanFromContext(ctx)
+		sp.LogFields(otlog.Int("keys requested", len(keys)))
 
-			var err error
-			found, bufs, missing, err = i.Cache.Fetch(ctx, keys)
-
-			if err == nil {
-				sp.LogFields(otlog.Int("keys found", len(found)), otlog.Int("keys missing", len(keys)-len(found)))
-			}
-
-			return err
-		})
-	} else {
-		err = UntracedCollectedRequest(ctx, method, instr.NewHistogramCollector(requestDuration), instr.ErrorCode, func(ctx context.Context) error {
-			var err error
-			found, bufs, missing, err = i.Cache.Fetch(ctx, keys)
-
-			return err
-		})
-	}
+		found, bufs, missing = i.Cache.Fetch(ctx, keys)
+		sp.LogFields(otlog.Int("keys found", len(found)), otlog.Int("keys missing", len(keys)-len(found)))
+		return nil
+	})
 
 	i.fetchedKeys.Add(float64(len(keys)))
 	i.hits.Add(float64(len(found)))
-	return found, bufs, missing, err
+	return found, bufs, missing
 }
 
 func (i *instrumentedCache) Stop() error {
 	return i.Cache.Stop()
-}
-
-// UntracedCollectedRequest is the same as instr.CollectedRequest but without any tracing.
-func UntracedCollectedRequest(ctx context.Context, method string, col instr.Collector, toStatusCode func(error) string, f func(context.Context) error) error {
-	start := time.Now()
-	col.Before(method, start)
-	err := f(ctx)
-	col.After(method, toStatusCode(err), start)
-
-	return err
 }

--- a/pkg/chunk/cache/memcached_test.go
+++ b/pkg/chunk/cache/memcached_test.go
@@ -34,19 +34,23 @@ func testMemcache(t *testing.T, memcache *cache.Memcached) {
 	numKeys := 1000
 
 	ctx := context.Background()
+	keysIncMissing := make([]string, 0, numKeys)
 	keys := make([]string, 0, numKeys)
+	bufs := make([][]byte, 0, numKeys)
+
 	// Insert 1000 keys skipping all multiples of 5.
 	for i := 0; i < numKeys; i++ {
-		keys = append(keys, string(i))
+		keysIncMissing = append(keysIncMissing, string(i))
 		if i%5 == 0 {
 			continue
 		}
 
-		require.NoError(t, memcache.Store(ctx, string(i), []byte(string(i))))
+		keys = append(keys, string(i))
+		bufs = append(bufs, []byte(string(i)))
 	}
+	memcache.Store(ctx, keys, bufs)
 
-	found, bufs, missing, err := memcache.Fetch(ctx, keys)
-	require.NoError(t, err)
+	found, bufs, missing := memcache.Fetch(ctx, keysIncMissing)
 	for i := 0; i < numKeys; i++ {
 		if i%5 == 0 {
 			require.Equal(t, string(i), missing[0])
@@ -105,19 +109,22 @@ func testMemcacheFailing(t *testing.T, memcache *cache.Memcached) {
 	numKeys := 1000
 
 	ctx := context.Background()
+	keysIncMissing := make([]string, 0, numKeys)
 	keys := make([]string, 0, numKeys)
+	bufs := make([][]byte, 0, numKeys)
 	// Insert 1000 keys skipping all multiples of 5.
 	for i := 0; i < numKeys; i++ {
-		keys = append(keys, string(i))
+		keysIncMissing = append(keysIncMissing, string(i))
 		if i%5 == 0 {
 			continue
 		}
-
-		require.NoError(t, memcache.Store(ctx, string(i), []byte(string(i))))
+		keys = append(keys, string(i))
+		bufs = append(bufs, []byte(string(i)))
 	}
+	memcache.Store(ctx, keys, bufs)
 
 	for i := 0; i < 10; i++ {
-		found, bufs, missing, _ := memcache.Fetch(ctx, keys)
+		found, bufs, missing := memcache.Fetch(ctx, keysIncMissing)
 
 		require.Equal(t, len(found), len(bufs))
 		for i := range found {

--- a/pkg/chunk/cache/tiered_test.go
+++ b/pkg/chunk/cache/tiered_test.go
@@ -23,14 +23,10 @@ func TestTiered(t *testing.T) {
 	level1, level2 := newMockCache(), newMockCache()
 	cache := cache.NewTiered([]cache.Cache{level1, level2})
 
-	err := level1.Store(context.Background(), "key1", []byte("hello"))
-	require.NoError(t, err)
+	level1.Store(context.Background(), []string{"key1"}, [][]byte{[]byte("hello")})
+	level2.Store(context.Background(), []string{"key2"}, [][]byte{[]byte("world")})
 
-	err = level2.Store(context.Background(), "key2", []byte("world"))
-	require.NoError(t, err)
-
-	keys, bufs, missing, err := cache.Fetch(context.Background(), []string{"key1", "key2", "key3"})
-	require.NoError(t, err)
+	keys, bufs, missing := cache.Fetch(context.Background(), []string{"key1", "key2", "key3"})
 	require.Equal(t, []string{"key1", "key2"}, keys)
 	require.Equal(t, [][]byte{[]byte("hello"), []byte("world")}, bufs)
 	require.Equal(t, []string{"key3"}, missing)

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -241,9 +241,14 @@ func (c *seriesStore) lookupSeriesByMetricNameMatcher(ctx context.Context, from,
 	level.Debug(log).Log("entries", len(entries))
 
 	// TODO This is not correct, will overcount for queries > 24hrs
+	keys := make([]string, 0, len(queries))
+	values := make([]interface{}, 0, len(queries))
 	for _, query := range queries {
-		c.cardinalityCache.Put(ctx, query.HashValue, len(entries))
+		keys = append(keys, query.HashValue)
+		values = append(values, len(entries))
 	}
+	c.cardinalityCache.Put(ctx, keys, values)
+
 	if len(entries) > c.cfg.CardinalityLimit {
 		return nil, errCardinalityExceeded
 	}

--- a/pkg/chunk/storage/caching_storage_client.go
+++ b/pkg/chunk/storage/caching_storage_client.go
@@ -61,7 +61,7 @@ func (c *indexCache) Store(ctx context.Context, key string, val ReadBatch) {
 
 	// We're doing the hashing to handle unicode and key len properly.
 	// Memcache fails for unicode keys and keys longer than 250 Bytes.
-	c.Cache.Store(ctx, hashKey(key), out)
+	c.Cache.Store(ctx, []string{hashKey(key)}, [][]byte{out})
 	return
 }
 
@@ -84,11 +84,7 @@ func (c *indexCache) Fetch(ctx context.Context, keys []string) (batches []ReadBa
 	// Look up the hashes in a single batch.  If we get an error, we just "miss" all
 	// of the keys.  Eventually I want to push all the errors to the leafs of the cache
 	// tree, to the caches only return found & missed.
-	foundHashes, bufs, _, err := c.Cache.Fetch(ctx, hashes)
-	if err != nil {
-		level.Warn(util.Logger).Log("msg", "error fetching index entries", "err", err)
-		return nil, keys
-	}
+	foundHashes, bufs, _ := c.Cache.Fetch(ctx, hashes)
 
 	// Reverse the hash, unmarshal the index entries, check we got what we expected
 	// and that its still valid.

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -45,13 +45,13 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func Opts(cfg Config, schemaCfg chunk.SchemaConfig) ([]chunk.StorageOpt, error) {
 	var caches []cache.Cache
 	if cfg.IndexCacheSize > 0 {
-		fifocache := cache.MetricsInstrument("fifo-index", cache.NewFifoCache("index", cfg.IndexCacheSize, cfg.IndexCacheValidity))
+		fifocache := cache.Instrument("fifo-index", cache.NewFifoCache("index", cfg.IndexCacheSize, cfg.IndexCacheValidity))
 		caches = append(caches, fifocache)
 	}
 
 	if cfg.memcacheClient.Host != "" {
 		client := cache.NewMemcachedClient(cfg.memcacheClient)
-		memcache := cache.MetricsInstrument("memcache-index", cache.NewMemcached(cache.MemcachedConfig{
+		memcache := cache.Instrument("memcache-index", cache.NewMemcached(cache.MemcachedConfig{
 			Expiration: cfg.IndexCacheValidity,
 		}, client))
 		caches = append(caches, cache.NewBackground(cache.BackgroundConfig{


### PR DESCRIPTION
Batch up the cache put interface, so traces are not completely dominated by cache puts.

Also, don't return errors from caches - just log (and add them to traces) in the leafs.

Fixes #1003