### PR TITLE
querier: Use select params for mint and maxt

### DIFF
--- a/pkg/querier/chunk_store_queryable.go
+++ b/pkg/querier/chunk_store_queryable.go
@@ -32,8 +32,8 @@ type chunkStoreQuerier struct {
 	mint, maxt        int64
 }
 
-func (q *chunkStoreQuerier) Select(_ *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, error) {
-	chunks, err := q.store.Get(q.ctx, model.Time(q.mint), model.Time(q.maxt), matchers...)
+func (q *chunkStoreQuerier) Select(sp *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, error) {
+	chunks, err := q.store.Get(q.ctx, model.Time(sp.Start), model.Time(sp.End), matchers...)
 	if err != nil {
 		return nil, promql.ErrStorage(err)
 	}

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -38,8 +38,14 @@ type distributorQuerier struct {
 	mint, maxt  int64
 }
 
-func (q *distributorQuerier) Select(_ *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, error) {
-	matrix, err := q.distributor.Query(q.ctx, model.Time(q.mint), model.Time(q.maxt), matchers...)
+func (q *distributorQuerier) Select(sp *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, error) {
+	mint, maxt := q.mint, q.maxt
+	if sp != nil {
+		mint = sp.Start
+		maxt = sp.End
+	}
+
+	matrix, err := q.distributor.Query(q.ctx, model.Time(mint), model.Time(maxt), matchers...)
 	if err != nil {
 		return nil, promql.ErrStorage(err)
 	}

--- a/pkg/querier/unified_querier.go
+++ b/pkg/querier/unified_querier.go
@@ -50,7 +50,7 @@ func (q *unifiedChunkQuerier) Select(sp *storage.SelectParams, matchers ...*labe
 	errs := make(chan error, len(q.stores))
 	for _, store := range q.stores {
 		go func(store ChunkStore) {
-			cs, err := store.Get(q.ctx, model.Time(q.mint), model.Time(q.maxt), matchers...)
+			cs, err := store.Get(q.ctx, model.Time(sp.Start), model.Time(sp.End), matchers...)
 			if err != nil {
 				errs <- err
 			} else {


### PR DESCRIPTION
TLDR; So turns out, if there was query like `up offset 4w` but `start-end = 15s`, we would end up getting all the chunks from `start-4w` to `end`. This PR makes sure only the relevant chunks are requested.


This is because when we create a `Querier` due to TSDB constraints (and maybe for other reasons), we need a single querier for a query. Which means if we `X / Y` where `X` has `offset 4w` and `Y` doesn't, the `q.minTime`, and `q.maxTime` will need to span the entire `4w`.

But this is mitigated by setting the appropriate parameters on `SelectParams` which this PR makes sure we use.

Relevant promQL code:
https://github.com/prometheus/prometheus/blob/master/promql/engine.go#L465-L467
https://github.com/prometheus/prometheus/blob/master/promql/engine.go#L472
https://github.com/prometheus/prometheus/blob/master/promql/engine.go#L491-L495