### PR TITLE
Add a Code of Conduct referencing the CNCF Code of Conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+## Cortex Community Code of Conduct
+
+Cortex follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
Shamelessly copied the format from other CNCF projects

Signed-off-by: Chris Marchbanks <csmarchbanks@gmail.com>