### PR TITLE
Remove parallelism from push-images.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,9 +114,9 @@ jobs:
         name: Deploy
         command: |
           if [ -n "$DOCKER_REGISTRY_PASSWORD" ]; then
-            docker login -e "$DOCKER_REGISTRY_EMAIL" -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD"
+            docker login -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD"
           fi
           if [ -n "$QUAY_PASSWORD" ]; then
-            docker login -e '.' -u "$QUAY_USER" -p "$QUAY_PASSWORD" quay.io;
+            docker login -u "$QUAY_USER" -p "$QUAY_PASSWORD" quay.io;
           fi
           ./push-images $NOQUAY

--- a/push-images
+++ b/push-images
@@ -48,7 +48,5 @@ for image in ${IMAGES}; do
     if [[ "$image" == *"build"* ]]; then
         continue
     fi
-    push_image "${image}" &
+    push_image "${image}"
 done
-
-wait


### PR DESCRIPTION
This way, it should fail correctly.  Also, remove email addresses from the docker login, that deprecated.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>