### PR TITLE
Instrument test exporter for OpenTracing.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1413,7 +1413,6 @@
     "github.com/prometheus/tsdb",
     "github.com/prometheus/tsdb/fileutil",
     "github.com/segmentio/fasthash/fnv1a",
-    "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "github.com/uber/jaeger-client-go",

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/extract"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/weaveworks/common/user"
 )
 
@@ -165,7 +166,7 @@ func (c *store) calculateIndexEntries(userID string, from, through model.Time, c
 
 // Get implements Store
 func (c *store) Get(ctx context.Context, from, through model.Time, allMatchers ...*labels.Matcher) ([]Chunk, error) {
-	log, ctx := newSpanLogger(ctx, "ChunkStore.Get")
+	log, ctx := spanlogger.New(ctx, "ChunkStore.Get")
 	defer log.Span.Finish()
 	level.Debug(log).Log("from", from, "through", through, "matchers", len(allMatchers))
 
@@ -188,7 +189,7 @@ func (c *store) Get(ctx context.Context, from, through model.Time, allMatchers .
 }
 
 func (c *store) validateQuery(ctx context.Context, from model.Time, through *model.Time) (shortcut bool, err error) {
-	log, ctx := newSpanLogger(ctx, "store.validateQuery")
+	log, ctx := spanlogger.New(ctx, "store.validateQuery")
 	defer log.Span.Finish()
 
 	now := model.Now()
@@ -221,7 +222,7 @@ func (c *store) validateQuery(ctx context.Context, from model.Time, through *mod
 }
 
 func (c *store) getMetricNameChunks(ctx context.Context, from, through model.Time, allMatchers []*labels.Matcher, metricName string) ([]Chunk, error) {
-	log, ctx := newSpanLogger(ctx, "ChunkStore.getMetricNameChunks")
+	log, ctx := spanlogger.New(ctx, "ChunkStore.getMetricNameChunks")
 	defer log.Finish()
 	level.Debug(log).Log("from", from, "through", through, "metricName", metricName, "matchers", len(allMatchers))
 
@@ -254,7 +255,7 @@ func (c *store) getMetricNameChunks(ctx context.Context, from, through model.Tim
 }
 
 func (c *store) lookupChunksByMetricName(ctx context.Context, from, through model.Time, matchers []*labels.Matcher, metricName string) ([]Chunk, error) {
-	log, ctx := newSpanLogger(ctx, "ChunkStore.lookupChunksByMetricName")
+	log, ctx := spanlogger.New(ctx, "ChunkStore.lookupChunksByMetricName")
 	defer log.Finish()
 
 	userID, err := user.ExtractOrgID(ctx)

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -4,16 +4,14 @@ import (
 	"context"
 	"sync"
 
-	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	ot "github.com/opentracing/opentracing-go"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
 const chunkDecodeParallelism = 16
@@ -43,34 +41,6 @@ outer:
 		filteredChunks = append(filteredChunks, chunk)
 	}
 	return filteredChunks
-}
-
-// spanLogger unifies tracing and logging, to reduce repetition.
-type spanLogger struct {
-	log.Logger
-	ot.Span
-}
-
-func newSpanLogger(ctx context.Context, method string, kvps ...interface{}) (*spanLogger, context.Context) {
-	span, ctx := ot.StartSpanFromContext(ctx, method)
-	logger := &spanLogger{
-		Logger: log.With(util.WithContext(ctx, util.Logger), "method", method),
-		Span:   span,
-	}
-	if len(kvps) > 0 {
-		logger.Log(kvps...)
-	}
-	return logger, ctx
-}
-
-func (s *spanLogger) Log(kvps ...interface{}) error {
-	s.Logger.Log(kvps...)
-	fields, err := otlog.InterleavedKVToFields(kvps...)
-	if err != nil {
-		return err
-	}
-	s.Span.LogFields(fields...)
-	return nil
 }
 
 // Fetcher deals with fetching chunk contents from the cache/store,
@@ -139,7 +109,7 @@ func (c *Fetcher) worker() {
 
 // FetchChunks fetchers a set of chunks from cache and store.
 func (c *Fetcher) FetchChunks(ctx context.Context, chunks []Chunk, keys []string) ([]Chunk, error) {
-	log, ctx := newSpanLogger(ctx, "ChunkStore.fetchChunks")
+	log, ctx := spanlogger.New(ctx, "ChunkStore.fetchChunks")
 	defer log.Span.Finish()
 
 	// Now fetch the actual chunk data from Memcache / S3

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/extract"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/weaveworks/common/user"
 )
 
@@ -74,7 +75,7 @@ func newSeriesStore(cfg StoreConfig, schema Schema, storage StorageClient) (Stor
 
 // Get implements Store
 func (c *seriesStore) Get(ctx context.Context, from, through model.Time, allMatchers ...*labels.Matcher) ([]Chunk, error) {
-	log, ctx := newSpanLogger(ctx, "SeriesStore.Get")
+	log, ctx := spanlogger.New(ctx, "SeriesStore.Get")
 	defer log.Span.Finish()
 	level.Debug(log).Log("from", from, "through", through, "matchers", len(allMatchers))
 
@@ -138,7 +139,7 @@ func (c *seriesStore) Get(ctx context.Context, from, through model.Time, allMatc
 }
 
 func (c *seriesStore) lookupSeriesByMetricNameMatchers(ctx context.Context, from, through model.Time, metricName string, matchers []*labels.Matcher) ([]string, error) {
-	log, ctx := newSpanLogger(ctx, "SeriesStore.lookupSeriesByMetricNameMatchers", "metricName", metricName, "matchers", len(matchers))
+	log, ctx := spanlogger.New(ctx, "SeriesStore.lookupSeriesByMetricNameMatchers", "metricName", metricName, "matchers", len(matchers))
 	defer log.Span.Finish()
 
 	// Just get series for metric if there are no matchers
@@ -202,7 +203,7 @@ func (c *seriesStore) lookupSeriesByMetricNameMatchers(ctx context.Context, from
 }
 
 func (c *seriesStore) lookupSeriesByMetricNameMatcher(ctx context.Context, from, through model.Time, metricName string, matcher *labels.Matcher) ([]string, error) {
-	log, ctx := newSpanLogger(ctx, "SeriesStore.lookupSeriesByMetricNameMatcher", "metricName", metricName, "matcher", matcher)
+	log, ctx := spanlogger.New(ctx, "SeriesStore.lookupSeriesByMetricNameMatcher", "metricName", metricName, "matcher", matcher)
 	defer log.Span.Finish()
 
 	userID, err := user.ExtractOrgID(ctx)
@@ -263,7 +264,7 @@ func (c *seriesStore) lookupSeriesByMetricNameMatcher(ctx context.Context, from,
 }
 
 func (c *seriesStore) lookupChunksBySeries(ctx context.Context, from, through model.Time, seriesIDs []string) ([]string, error) {
-	log, ctx := newSpanLogger(ctx, "SeriesStore.lookupChunksBySeries")
+	log, ctx := spanlogger.New(ctx, "SeriesStore.lookupChunksBySeries")
 	defer log.Span.Finish()
 
 	userID, err := user.ExtractOrgID(ctx)

--- a/pkg/querier/correctness/case.go
+++ b/pkg/querier/correctness/case.go
@@ -13,6 +13,7 @@ import (
 type Case interface {
 	prometheus.Collector
 
+	Name() string
 	Query(ctx context.Context, client v1.API, selectors string, start time.Time, duration time.Duration) ([]model.SamplePair, error)
 	ExpectedValueAt(time.Time) float64
 	Quantized(time.Duration) time.Duration

--- a/pkg/querier/correctness/runner.go
+++ b/pkg/querier/correctness/runner.go
@@ -126,7 +126,7 @@ func NewRunner(cfg RunnerConfig) (*Runner, error) {
 	tc := &Runner{
 		cfg:    cfg,
 		quit:   make(chan struct{}),
-		client: v1.NewAPI(client),
+		client: v1.NewAPI(tracingClient{client}),
 	}
 	tc.wg.Add(1)
 	go tc.verifyLoop()
@@ -137,7 +137,7 @@ type tracingClient struct {
 	api.Client
 }
 
-func (t *tracingClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
+func (t tracingClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
 	req, tr := nethttp.TraceRequest(opentracing.GlobalTracer(), req)
 	defer tr.Finish()
 	return t.Client.Do(ctx, req)

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -1,0 +1,40 @@
+package spanlogger
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/log"
+	opentracing "github.com/opentracing/opentracing-go"
+	otlog "github.com/opentracing/opentracing-go/log"
+
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+// SpanLogger unifies tracing and logging, to reduce repetition.
+type SpanLogger struct {
+	log.Logger
+	opentracing.Span
+}
+
+// New makes a new SpanLogger.
+func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, context.Context) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, method)
+	logger := &SpanLogger{
+		Logger: log.With(util.WithContext(ctx, util.Logger), "method", method),
+		Span:   span,
+	}
+	if len(kvps) > 0 {
+		logger.Log(kvps...)
+	}
+	return logger, ctx
+}
+
+func (s *SpanLogger) Log(kvps ...interface{}) error {
+	s.Logger.Log(kvps...)
+	fields, err := otlog.InterleavedKVToFields(kvps...)
+	if err != nil {
+		return err
+	}
+	s.Span.LogFields(fields...)
+	return nil
+}

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -29,6 +29,8 @@ func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, 
 	return logger, ctx
 }
 
+// Log implements gokit's Logger interface; sends logs to underlying logger and
+// also puts the on the spans.
 func (s *SpanLogger) Log(kvps ...interface{}) error {
 	s.Logger.Log(kvps...)
 	fields, err := otlog.InterleavedKVToFields(kvps...)


### PR DESCRIPTION
Also:
- Move `SpanLogger` out of `chunk` package and reuse it.
- Update the logging in the test-exporter to use gokit.

~Vendor modified in place, don't merge until https://github.com/prometheus/client_golang/pull/469/files is in.~

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>