### PR TITLE
Reduce allocations in validation.

### DIFF
--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -23,7 +23,7 @@ var overridesReloadSuccess = promauto.NewGauge(prometheus.GaugeOpts{
 type Overrides struct {
 	Defaults     Limits
 	overridesMtx sync.RWMutex
-	overrides    map[string]Limits
+	overrides    map[string]*Limits
 	quit         chan struct{}
 }
 
@@ -33,7 +33,7 @@ func NewOverrides(defaults Limits) (*Overrides, error) {
 		level.Info(util.Logger).Log("msg", "per-tenant overides disabled")
 		return &Overrides{
 			Defaults:  defaults,
-			overrides: map[string]Limits{},
+			overrides: map[string]*Limits{},
 			quit:      make(chan struct{}),
 		}, nil
 	}
@@ -82,14 +82,14 @@ func (o *Overrides) Stop() {
 	close(o.quit)
 }
 
-func loadOverrides(filename string) (map[string]Limits, error) {
+func loadOverrides(filename string) (map[string]*Limits, error) {
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 
 	var overrides struct {
-		Overrides map[string]Limits `yaml:"overrides"`
+		Overrides map[string]*Limits `yaml:"overrides"`
 	}
 
 	decoder := yaml.NewDecoder(f)
@@ -108,7 +108,7 @@ func (o *Overrides) getBool(userID string, f func(*Limits) bool) bool {
 	if !ok {
 		return f(&o.Defaults)
 	}
-	return f(&override)
+	return f(override)
 }
 
 func (o *Overrides) getInt(userID string, f func(*Limits) int) int {
@@ -118,7 +118,7 @@ func (o *Overrides) getInt(userID string, f func(*Limits) int) int {
 	if !ok {
 		return f(&o.Defaults)
 	}
-	return f(&override)
+	return f(override)
 }
 
 func (o *Overrides) getFloat(userID string, f func(*Limits) float64) float64 {
@@ -128,7 +128,7 @@ func (o *Overrides) getFloat(userID string, f func(*Limits) float64) float64 {
 	if !ok {
 		return f(&o.Defaults)
 	}
-	return f(&override)
+	return f(override)
 }
 
 func (o *Overrides) getDuration(userID string, f func(*Limits) time.Duration) time.Duration {
@@ -138,7 +138,7 @@ func (o *Overrides) getDuration(userID string, f func(*Limits) time.Duration) ti
 	if !ok {
 		return f(&o.Defaults)
 	}
-	return f(&override)
+	return f(override)
 }
 
 // IngestionRate returns the limit on ingester rate (samples per second).


### PR DESCRIPTION
Before:

```
(pprof) top10
Showing nodes accounting for 4343572166, 59.54% of 7295471498 total
Dropped 557 nodes (cum <= 36477357)
Showing top 10 nodes out of 116
      flat  flat%   sum%        cum   cum%
1061747260 14.55% 14.55% 1061747260 14.55%  github.com/weaveworks/cortex/pkg/util/validation.(*Overrides).getInt
 709873883  9.73% 24.28%  709874396  9.73%  github.com/weaveworks/cortex/pkg/ingester/client.(*PreallocTimeseries).Unmarshal
 496604314  6.81% 31.09% 3511179146 48.13%  github.com/weaveworks/cortex/pkg/distributor.(*Distributor).Push
 356625027  4.89% 35.98%  356625027  4.89%  github.com/weaveworks/cortex/pkg/ring.(*Ring).replicationStrategy
 356440563  4.89% 40.86%  356440563  4.89%  github.com/weaveworks/cortex/pkg/util/validation.(*Overrides).getDuration
 355942406  4.88% 45.74%  712567433  9.77%  github.com/weaveworks/cortex/pkg/ring.(*Ring).getInternal
 353618074  4.85% 50.59%  353618074  4.85%  github.com/weaveworks/cortex/pkg/util/validation.(*Overrides).getBool
 323621706  4.44% 55.03%  355145003  4.87%  github.com/weaveworks/cortex/pkg/distributor.shardByAllLabels
 171530738  2.35% 57.38% 1233277998 16.90%  github.com/weaveworks/cortex/pkg/util/validation.(*Overrides).ValidateLabels
 157568195  2.16% 59.54%  157568195  2.16%  strings.ToLower
```

After

```
(pprof) top10
Showing nodes accounting for 46443985, 54.37% of 85424760 total
Dropped 330 nodes (cum <= 427123)
Showing top 10 nodes out of 119
      flat  flat%   sum%        cum   cum%
  11054244 12.94% 12.94%   11054244 12.94%  github.com/weaveworks/cortex/pkg/ingester/client.(*PreallocTimeseries).Unmarshal
   7755127  9.08% 22.02%   27193278 31.83%  github.com/weaveworks/cortex/pkg/distributor.(*Distributor).Push
   5669037  6.64% 28.65%    5669037  6.64%  github.com/weaveworks/cortex/pkg/ring.(*Ring).replicationStrategy
   5292193  6.20% 34.85%   10961230 12.83%  github.com/weaveworks/cortex/pkg/ring.(*Ring).getInternal
   5275728  6.18% 41.03%    5668950  6.64%  github.com/weaveworks/cortex/pkg/distributor.shardByAllLabels
   2752096  3.22% 44.25%    2752096  3.22%  github.com/weaveworks/cortex/pkg/util/validation.(*Overrides).ValidateLabels
   2506800  2.93% 47.18%    2506800  2.93%  strings.ToLower
   2293826  2.69% 49.87%    2293826  2.69%  github.com/weaveworks/cortex/vendor/google.golang.org/grpc/transport.(*itemList).enqueue
   1977088  2.31% 52.18%    1977088  2.31%  context.WithValue
   1867846  2.19% 54.37%    2940517  3.44%  github.com/weaveworks/cortex/vendor/golang.org/x/net/http2.(*Framer).readMetaFrame
```

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>