### PR TITLE
Add a timeout option for Cassandra access

### DIFF
--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -33,6 +33,7 @@ type Config struct {
 	auth                     bool
 	username                 string
 	password                 string
+	timeout                  time.Duration
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -49,6 +50,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.auth, "cassandra.auth", false, "Enable password authentication when connecting to cassandra.")
 	f.StringVar(&cfg.username, "cassandra.username", "", "Username to use when connecting to cassandra.")
 	f.StringVar(&cfg.password, "cassandra.password", "", "Password to use when connecting to cassandra.")
+	f.DurationVar(&cfg.timeout, "cassandra.timeout", 600*time.Millisecond, "Timeout when connecting to cassandra.")
 }
 
 func (cfg *Config) session() (*gocql.Session, error) {
@@ -67,7 +69,7 @@ func (cfg *Config) session() (*gocql.Session, error) {
 	cluster.Consistency = consistency
 	cluster.BatchObserver = observer{}
 	cluster.QueryObserver = observer{}
-
+	cluster.Timeout = cfg.timeout
 	cfg.setClusterConfig(cluster)
 
 	return cluster.CreateSession()


### PR DESCRIPTION
Simply add a -cassandra.timeout option to Cortex, to handle slow table creations