### PR TITLE
Bounded parallelism for DoParallelQueries

### DIFF
--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/storage"
+	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
 	"github.com/cortexproject/cortex/pkg/distributor"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/querier"
@@ -46,10 +47,13 @@ func main() {
 		schemaConfig      chunk.SchemaConfig
 		storageConfig     storage.Config
 		workerConfig      frontend.WorkerConfig
+		queryParallelism  int
 	)
 	util.RegisterFlags(&serverConfig, &ringConfig, &distributorConfig, &clientConfig, &limits,
 		&querierConfig, &chunkStoreConfig, &schemaConfig, &storageConfig, &workerConfig)
+	flag.IntVar(&queryParallelism, "querier.query-parallelism", 100, "Max subqueries run in parallel per higher-level query.")
 	flag.Parse()
+	chunk_util.QueryParallelism = queryParallelism
 
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
 	trace := tracing.NewFromEnv("querier")

--- a/pkg/chunk/util/util.go
+++ b/pkg/chunk/util/util.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"context"
 
+	ot "github.com/opentracing/opentracing-go"
+
 	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 // DoSingleQuery is the interface for indexes that don't support batching yet.
@@ -13,20 +16,42 @@ type DoSingleQuery func(
 	callback func(chunk.ReadBatch) bool,
 ) error
 
+const maxParallelism = 100
+
 // DoParallelQueries translates between our interface for query batching,
 // and indexes that don't yet support batching.
 func DoParallelQueries(
 	ctx context.Context, doSingleQuery DoSingleQuery, queries []chunk.IndexQuery,
 	callback func(chunk.IndexQuery, chunk.ReadBatch) bool,
 ) error {
+	queue := make(chan chunk.IndexQuery)
 	incomingErrors := make(chan error)
-	for _, query := range queries {
-		go func(query chunk.IndexQuery) {
-			incomingErrors <- doSingleQuery(ctx, query, func(r chunk.ReadBatch) bool {
-				return callback(query, r)
-			})
-		}(query)
+	n := util.Min(len(queries), maxParallelism)
+	// Run n parallel goroutines fetching queries from the queue
+	for i := 0; i < n; i++ {
+		go func() {
+			sp, ctx := ot.StartSpanFromContext(ctx, "DoParallelQueries-worker")
+			defer sp.Finish()
+			for {
+				query, ok := <-queue
+				if !ok {
+					return
+				}
+				incomingErrors <- doSingleQuery(ctx, query, func(r chunk.ReadBatch) bool {
+					return callback(query, r)
+				})
+			}
+		}()
 	}
+	// Send all the queries into the queue
+	go func() {
+		for _, query := range queries {
+			queue <- query
+		}
+		close(queue)
+	}()
+
+	// Now receive all the results.
 	var lastErr error
 	for i := 0; i < len(queries); i++ {
 		err := <-incomingErrors

--- a/pkg/chunk/util/util.go
+++ b/pkg/chunk/util/util.go
@@ -16,7 +16,9 @@ type DoSingleQuery func(
 	callback func(chunk.ReadBatch) bool,
 ) error
 
-const maxParallelism = 100
+// QueryParallelism is the maximum number of subqueries run in
+// parallel per higher-level query
+var QueryParallelism = 100
 
 // DoParallelQueries translates between our interface for query batching,
 // and indexes that don't yet support batching.
@@ -26,7 +28,7 @@ func DoParallelQueries(
 ) error {
 	queue := make(chan chunk.IndexQuery)
 	incomingErrors := make(chan error)
-	n := util.Min(len(queries), maxParallelism)
+	n := util.Min(len(queries), QueryParallelism)
 	// Run n parallel goroutines fetching queries from the queue
 	for i := 0; i < n; i++ {
 		go func() {


### PR DESCRIPTION
Limit the number of queries we will send in parallel to the back-end, in case we have tens of thousands of series to fetch.

In my tests, the DynamoDB back-end cannot be used with schema v9 without a change like this.

I couldn't see a nice way to make the "100" limit configurable.  Suggestions welcome.
