### PR TITLE
Optionally limit size of queries to the chunk store.

### DIFF
--- a/cmd/distributor/main.go
+++ b/cmd/distributor/main.go
@@ -71,7 +71,13 @@ func main() {
 	prometheus.MustRegister(r)
 	defer r.Stop()
 
-	dist, err := distributor.New(distributorConfig, clientConfig, limits, r)
+	overrides, err := validation.NewOverrides(limits)
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "error initializing overrides", "err", err)
+		os.Exit(1)
+	}
+
+	dist, err := distributor.New(distributorConfig, clientConfig, overrides, r)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error initializing distributor", "err", err)
 		os.Exit(1)

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -85,14 +85,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	chunkStore, err := chunk.NewStore(chunkStoreConfig, schemaConfig, storageOpts)
+	overrides, err := validation.NewOverrides(limits)
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "error initializing overrides", "err", err)
+		os.Exit(1)
+	}
+
+	chunkStore, err := chunk.NewStore(chunkStoreConfig, schemaConfig, storageOpts, overrides)
 	if err != nil {
 		level.Error(util.Logger).Log("err", err)
 		os.Exit(1)
 	}
 	defer chunkStore.Stop()
 
-	ingester, err := ingester.New(ingesterConfig, clientConfig, limits, chunkStore)
+	ingester, err := ingester.New(ingesterConfig, clientConfig, overrides, chunkStore)
 	if err != nil {
 		level.Error(util.Logger).Log("err", err)
 		os.Exit(1)

--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -70,7 +70,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	chunkStore, err := chunk.NewStore(chunkStoreConfig, schemaConfig, storageOpts)
+	overrides, err := validation.NewOverrides(limitsConfig)
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "error initializing overrides", "err", err)
+		os.Exit(1)
+	}
+
+	chunkStore, err := chunk.NewStore(chunkStoreConfig, schemaConfig, storageOpts, overrides)
 	if err != nil {
 		level.Error(util.Logger).Log("err", err)
 		os.Exit(1)
@@ -86,14 +92,14 @@ func main() {
 	defer r.Stop()
 	ingesterConfig.LifecyclerConfig.KVClient = r.KVClient
 
-	dist, err := distributor.New(distributorConfig, ingesterClientConfig, limitsConfig, r)
+	dist, err := distributor.New(distributorConfig, ingesterClientConfig, overrides, r)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error initializing distributor", "err", err)
 		os.Exit(1)
 	}
 	defer dist.Stop()
 
-	ingester, err := ingester.New(ingesterConfig, ingesterClientConfig, limitsConfig, chunkStore)
+	ingester, err := ingester.New(ingesterConfig, ingesterClientConfig, overrides, chunkStore)
 	if err != nil {
 		level.Error(util.Logger).Log("err", err)
 		os.Exit(1)

--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -69,7 +69,13 @@ func main() {
 	prometheus.MustRegister(r)
 	defer r.Stop()
 
-	dist, err := distributor.New(distributorConfig, clientConfig, limits, r)
+	overrides, err := validation.NewOverrides(limits)
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "error initializing overrides", "err", err)
+		os.Exit(1)
+	}
+
+	dist, err := distributor.New(distributorConfig, clientConfig, overrides, r)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error initializing distributor", "err", err)
 		os.Exit(1)
@@ -90,7 +96,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	chunkStore, err := chunk.NewStore(chunkStoreConfig, schemaConfig, storageOpts)
+	chunkStore, err := chunk.NewStore(chunkStoreConfig, schemaConfig, storageOpts, overrides)
 	if err != nil {
 		level.Error(util.Logger).Log("err", err)
 		os.Exit(1)

--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -59,7 +59,14 @@ func main() {
 		level.Error(util.Logger).Log("msg", "error initializing storage client", "err", err)
 		os.Exit(1)
 	}
-	chunkStore, err := chunk.NewStore(chunkStoreConfig, schemaConfig, storageOpts)
+
+	overrides, err := validation.NewOverrides(limits)
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "error initializing overrides", "err", err)
+		os.Exit(1)
+	}
+
+	chunkStore, err := chunk.NewStore(chunkStoreConfig, schemaConfig, storageOpts, overrides)
 	if err != nil {
 		level.Error(util.Logger).Log("err", err)
 		os.Exit(1)
@@ -74,7 +81,7 @@ func main() {
 	prometheus.MustRegister(r)
 	defer r.Stop()
 
-	dist, err := distributor.New(distributorConfig, clientConfig, limits, r)
+	dist, err := distributor.New(distributorConfig, clientConfig, overrides, r)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error initializing distributor", "err", err)
 		os.Exit(1)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -123,7 +123,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 // New constructs a new Distributor
-func New(cfg Config, clientConfig ingester_client.Config, limitsCfg validation.Limits, ring ring.ReadRing) (*Distributor, error) {
+func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Overrides, ring ring.ReadRing) (*Distributor, error) {
 	if cfg.ingesterClientFactory == nil {
 		cfg.ingesterClientFactory = func(addr string) (grpc_health_v1.HealthClient, error) {
 			return ingester_client.MakeIngesterClient(addr, clientConfig)
@@ -137,11 +137,6 @@ func New(cfg Config, clientConfig ingester_client.Config, limitsCfg validation.L
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	limits, err := validation.NewOverrides(limitsCfg)
-	if err != nil {
-		return nil, err
 	}
 
 	replicationFactor.Set(float64(ring.ReplicationFactor()))

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -284,10 +284,12 @@ func prepare(t *testing.T, numIngesters, happyIngesters int, queryDelay time.Dur
 	cfg.ShardByAllLabels = shardByAllLabels
 	cfg.ExtraQueryDelay = 50 * time.Millisecond
 
-	d, err := New(cfg, clientConfig, limits, ring)
-	if err != nil {
-		t.Fatal(err)
-	}
+	overrides, err := validation.NewOverrides(limits)
+	require.NoError(t, err)
+
+	d, err := New(cfg, clientConfig, overrides, ring)
+	require.NoError(t, err)
+
 	return d
 }
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -147,17 +147,12 @@ type ChunkStore interface {
 }
 
 // New constructs a new Ingester.
-func New(cfg Config, clientConfig client.Config, limitsCfg validation.Limits, chunkStore ChunkStore) (*Ingester, error) {
+func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, chunkStore ChunkStore) (*Ingester, error) {
 	if cfg.ingesterClientFactory == nil {
 		cfg.ingesterClientFactory = client.MakeIngesterClient
 	}
 
 	if err := chunk.DefaultEncoding.Set(cfg.ChunkEncoding); err != nil {
-		return nil, err
-	}
-
-	limits, err := validation.NewOverrides(limitsCfg)
-	if err != nil {
 		return nil, err
 	}
 
@@ -173,6 +168,7 @@ func New(cfg Config, clientConfig client.Config, limitsCfg validation.Limits, ch
 		flushQueues: make([]*util.PriorityQueue, cfg.ConcurrentFlushes, cfg.ConcurrentFlushes),
 	}
 
+	var err error
 	i.lifecycler, err = ring.NewLifecycler(cfg.LifecyclerConfig, i)
 	if err != nil {
 		return nil, err

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -37,8 +37,12 @@ func newTestStore(t require.TestingT, cfg Config, clientConfig client.Config, li
 	store := &testStore{
 		chunks: map[string][]chunk.Chunk{},
 	}
-	ing, err := New(cfg, clientConfig, limits, store)
+	overrides, err := validation.NewOverrides(limits)
 	require.NoError(t, err)
+
+	ing, err := New(cfg, clientConfig, overrides, store)
+	require.NoError(t, err)
+
 	return store, ing
 }
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -20,11 +20,15 @@ type Limits struct {
 	RejectOldSamplesMaxAge time.Duration `yaml:"reject_old_samples_max_age"`
 	CreationGracePeriod    time.Duration `yaml:"creation_grace_period"`
 
-	// Ingester enforces limits.
+	// Ingester enforced limits.
 	MaxSeriesPerQuery  int `yaml:"max_series_per_query"`
 	MaxSamplesPerQuery int `yaml:"max_samples_per_query"`
 	MaxSeriesPerUser   int `yaml:"max_series_per_user"`
 	MaxSeriesPerMetric int `yaml:"max_series_per_metric"`
+
+	// Querier enforced limits.
+	MaxChunksPerQuery int           `yaml:"max_chunks_per_query"`
+	MaxQueryLength    time.Duration `yaml:"max_query_length"`
 
 	// Config for overrides, convenient if it goes here.
 	PerTenantOverrideConfig string
@@ -46,6 +50,9 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxSamplesPerQuery, "ingester.max-samples-per-query", 1000000, "The maximum number of samples that a query can return.")
 	f.IntVar(&l.MaxSeriesPerUser, "ingester.max-series-per-user", 5000000, "Maximum number of active series per user.")
 	f.IntVar(&l.MaxSeriesPerMetric, "ingester.max-series-per-metric", 50000, "Maximum number of active series per metric name.")
+
+	f.IntVar(&l.MaxChunksPerQuery, "store.query-chunk-limit", 2e6, "Maximum number of chunks that can be fetched in a single query.")
+	f.DurationVar(&l.MaxQueryLength, "store.max-query-length", 0, "Limit to length of chunk store queries, 0 to disable.")
 
 	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "File name of per-user overrides.")
 	f.DurationVar(&l.PerTenantOverridePeriod, "limits.per-user-override-period", 10*time.Second, "Period with this to reload the overrides.")

--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -227,3 +227,17 @@ func (o *Overrides) MaxSeriesPerMetric(userID string) int {
 		return l.MaxSeriesPerMetric
 	})
 }
+
+// MaxChunksPerQuery returns the maximum number of chunks allowed per query.
+func (o *Overrides) MaxChunksPerQuery(userID string) int {
+	return o.getInt(userID, func(l *Limits) int {
+		return l.MaxChunksPerQuery
+	})
+}
+
+// MaxQueryLength returns the limit of the length (in time) of a query.
+func (o *Overrides) MaxQueryLength(userID string) time.Duration {
+	return o.getDuration(userID, func(l *Limits) time.Duration {
+		return l.MaxQueryLength
+	})
+}


### PR DESCRIPTION
Fixes #1057 

When combined with day-by-day query parallelism in the query frontend, this limit in the chunk store will limit vector windows (ie `rate(foo[20d])`) whilst not limit query lengths (ie still being able to do 1yr range queries).

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>