### PR TITLE
Remove deprecated global tags setting

### DIFF
--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -165,7 +165,7 @@ func (m *TableManager) calculateExpectedTables() []TableDesc {
 		Name:             m.cfg.OriginalTableName,
 		ProvisionedRead:  m.cfg.IndexTables.InactiveReadThroughput,
 		ProvisionedWrite: m.cfg.IndexTables.InactiveWriteThroughput,
-		Tags:             m.cfg.IndexTables.GetTags(),
+		Tags:             m.cfg.IndexTables.Tags,
 	}
 
 	if m.cfg.UsePeriodicTables {


### PR DESCRIPTION
This was added in July 2017 as a backwards-compatibility measure; removing now everybody is in the new world.
