### PR TITLE
Avoid query results cache for very recent queries

### DIFF
--- a/pkg/querier/frontend/results_cache.go
+++ b/pkg/querier/frontend/results_cache.go
@@ -73,14 +73,14 @@ func (s resultsCache) Do(ctx context.Context, r *queryRangeRequest) (*apiRespons
 
 	maxCacheTime := int64(model.Now().Add(-s.cfg.MaxCacheFreshness))
 	if r.start > maxCacheTime {
-		response, extents, err = s.handleFresh(ctx, r)
+		return s.next.Do(ctx, r)
+	}
+
+	cached, ok := s.get(ctx, key)
+	if ok {
+		response, extents, err = s.handleHit(ctx, r, cached)
 	} else {
-		cached, ok := s.get(ctx, key)
-		if ok {
-			response, extents, err = s.handleHit(ctx, r, cached)
-		} else {
-			response, extents, err = s.handleMiss(ctx, r)
-		}
+		response, extents, err = s.handleMiss(ctx, r)
 	}
 
 	if err == nil && len(extents) > 0 {
@@ -89,18 +89,6 @@ func (s resultsCache) Do(ctx context.Context, r *queryRangeRequest) (*apiRespons
 	}
 
 	return response, err
-}
-
-func (s resultsCache) handleFresh(ctx context.Context, r *queryRangeRequest) (*apiResponse, []extent, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "handle_fresh")
-	defer span.Finish()
-
-	response, err := s.next.Do(ctx, r)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return response, nil, nil
 }
 
 func (s resultsCache) handleMiss(ctx context.Context, r *queryRangeRequest) (*apiResponse, []extent, error) {


### PR DESCRIPTION
@jtlisi  I've been away for last few days so don't know the background on this one.  I believe we were seeing a frequent query for the last ~5mins of data that was _very_ large (ie 30MB) in cache, and taking a few seconds to decode the JSON.   Can you confirm?

This change skips the cache lookup for very recent queries.