### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing to Cortex
+
+Welcome! We're excited that you're interested in contributing. Below are some basic guidelines.
+
+## Workflow
+
+Cortex follows a standard GitHub pull request workflow. If you're unfamiliar with this workflow, read the very helpful [Understanding the GitHub flow](https://guides.github.com/introduction/flow/) guide from GitHub.
+
+## Developer Certificates of Origin (DCOs)
+
+Before submitting your work in a pull request, make sure that *all* commits are signed off with a **Developer Certificate of Origin** (DCO). Here's an example:
+
+```shell
+git commit -s -m "Here is my signed commit"
+```
+
+You can find further instructions [here](https://github.com/probot/dco#how-it-works).

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ To use Cortex as part of Grafana Cloud, sign up for [GrafanaCloud](https://grafa
 by clicking "Log In" in the top right and then "Sign Up Now".  Cortex is included
 as part of the Starter and Basic Hosted Grafana plans.
 
+## Contributing
+
+For a guide to contributing to Cortex, see the [contributor guidelines](CONTRIBUTING.md).
+
 ## For Developers
 
 To build:
@@ -67,10 +71,6 @@ Kubernetes cluster)
 Cortex will sit behind an nginx instance exposed on port 30080.  A job is deployed to scrape it itself.  Try it:
 
 http://192.168.99.100:30080/api/prom/api/v1/query?query=up
-
-### Sign your work
-
-Before submitting your work in a pull request, make sure all commits are signed off. See [DCO](https://github.com/probot/dco#how-it-works) for more information.
 
 ### Vendoring
 


### PR DESCRIPTION
An emerging best practice is to include a `CONTRIBUTING.md` file in the root of OSS projects. This PR adds a very basic one that can be expanded later.