### PR TITLE
Fix wrong err check

### DIFF
--- a/pkg/configs/api/api.go
+++ b/pkg/configs/api/api.go
@@ -186,35 +186,27 @@ type ConfigsView struct {
 	Configs map[string]configs.View `json:"configs"`
 }
 
-// getConfigsHelper returns configs started from ID = since and all configs if since = -1
-func (a *API) getConfigsHelper(since int64) (map[string]configs.View, error) {
-	if since == -1 {
-		return a.db.GetAllConfigs()
-	}
-	return a.db.GetConfigs(configs.ID(since))
-}
-
 func (a *API) getConfigs(w http.ResponseWriter, r *http.Request) {
+	var cfgs map[string]configs.View
+	var cfgErr error
 	logger := util.WithContext(r.Context(), util.Logger)
-	var sinceID int64
 	rawSince := r.FormValue("since")
 	if rawSince == "" {
-		sinceID = -1
+		cfgs, cfgErr = a.db.GetAllConfigs()
 	} else {
-		id, err := strconv.ParseUint(rawSince, 10, 0)
+		since, err := strconv.ParseUint(rawSince, 10, 0)
 		if err != nil {
 			level.Info(logger).Log("msg", "invalid config ID", "err", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		sinceID = int64(id)
+		cfgs, cfgErr = a.db.GetConfigs(configs.ID(since))
 	}
 
-	cfgs, err := a.getConfigsHelper(sinceID)
-	if err != nil {
+	if cfgErr != nil {
 		// XXX: Untested
-		level.Error(logger).Log("msg", "error getting configs", "err", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		level.Error(logger).Log("msg", "error getting configs", "err", cfgErr)
+		http.Error(w, cfgErr.Error(), http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
Otherwise we use err from inner block with `ParseUint` instead of err from `a.db.GetConfigs`

Signed-off-by: Elena Morozova <lelenanam@gmail.com>