### PR TITLE
Flexible schema config in yaml

### DIFF
--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -79,19 +79,12 @@ func main() {
 	}
 	defer server.Shutdown()
 
-	storageOpts, err := storage.Opts(storageConfig, schemaConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing storage client", "err", err)
-		os.Exit(1)
-	}
-
 	overrides, err := validation.NewOverrides(limits)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error initializing overrides", "err", err)
 		os.Exit(1)
 	}
-
-	chunkStore, err := chunk.NewStore(chunkStoreConfig, schemaConfig, storageOpts, overrides)
+	chunkStore, err := storage.NewStore(storageConfig, chunkStoreConfig, schemaConfig, overrides)
 	if err != nil {
 		level.Error(util.Logger).Log("err", err)
 		os.Exit(1)

--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -90,15 +90,9 @@ func main() {
 	defer server.Shutdown()
 	server.HTTP.Handle("/ring", r)
 
-	storageOpts, err := storage.Opts(storageConfig, schemaConfig)
+	chunkStore, err := storage.NewStore(storageConfig, chunkStoreConfig, schemaConfig, overrides)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error initializing storage client", "err", err)
-		os.Exit(1)
-	}
-
-	chunkStore, err := chunk.NewStore(chunkStoreConfig, schemaConfig, storageOpts, overrides)
-	if err != nil {
-		level.Error(util.Logger).Log("err", err)
 		os.Exit(1)
 	}
 	defer chunkStore.Stop()

--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -54,19 +54,12 @@ func main() {
 
 	util.InitLogger(&serverConfig)
 
-	storageOpts, err := storage.Opts(storageConfig, schemaConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing storage client", "err", err)
-		os.Exit(1)
-	}
-
 	overrides, err := validation.NewOverrides(limits)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error initializing overrides", "err", err)
 		os.Exit(1)
 	}
-
-	chunkStore, err := chunk.NewStore(chunkStoreConfig, schemaConfig, storageOpts, overrides)
+	chunkStore, err := storage.NewStore(storageConfig, chunkStoreConfig, schemaConfig, overrides)
 	if err != nil {
 		level.Error(util.Logger).Log("err", err)
 		os.Exit(1)

--- a/pkg/chunk/aws/fixtures.go
+++ b/pkg/chunk/aws/fixtures.go
@@ -37,13 +37,15 @@ var Fixtures = []testutils.Fixture{
 			table := &dynamoTableClient{
 				DynamoDB: dynamoDB,
 			}
-			storage := &storageClient{
-				DynamoDB:                dynamoDB,
-				S3:                      newMockS3(),
-				queryRequestFn:          dynamoDB.queryRequest,
-				batchGetItemRequestFn:   dynamoDB.batchGetItemRequest,
-				batchWriteItemRequestFn: dynamoDB.batchWriteItemRequest,
-				schemaCfg:               schemaConfig,
+			storage := &s3storageClient{
+				S3: newMockS3(),
+				storageClient: storageClient{
+					DynamoDB:                dynamoDB,
+					queryRequestFn:          dynamoDB.queryRequest,
+					batchGetItemRequestFn:   dynamoDB.batchGetItemRequest,
+					batchWriteItemRequestFn: dynamoDB.batchWriteItemRequest,
+					schemaCfg:               schemaConfig,
+				},
 			}
 			return storage, table, schemaConfig, nil
 		},
@@ -70,19 +72,16 @@ func dynamoDBFixture(provisionedErr, gangsize, maxParallelism int) testutils.Fix
 				DynamoDB: dynamoDB,
 			}
 			storage := &storageClient{
-				cfg: StorageConfig{
-					DynamoDBConfig: DynamoDBConfig{
-						ChunkGangSize:          gangsize,
-						ChunkGetMaxParallelism: maxParallelism,
-						backoffConfig: util.BackoffConfig{
-							MinBackoff: 1 * time.Millisecond,
-							MaxBackoff: 5 * time.Millisecond,
-							MaxRetries: 20,
-						},
+				cfg: DynamoDBConfig{
+					ChunkGangSize:          gangsize,
+					ChunkGetMaxParallelism: maxParallelism,
+					backoffConfig: util.BackoffConfig{
+						MinBackoff: 1 * time.Millisecond,
+						MaxBackoff: 5 * time.Millisecond,
+						MaxRetries: 20,
 					},
 				},
 				DynamoDB:                dynamoDB,
-				S3:                      newMockS3(),
 				queryRequestFn:          dynamoDB.queryRequest,
 				batchGetItemRequestFn:   dynamoDB.batchGetItemRequest,
 				batchWriteItemRequestFn: dynamoDB.batchWriteItemRequest,

--- a/pkg/chunk/aws/fixtures.go
+++ b/pkg/chunk/aws/fixtures.go
@@ -62,11 +62,14 @@ func dynamoDBFixture(provisionedErr, gangsize, maxParallelism int) testutils.Fix
 		clients: func() (chunk.StorageClient, chunk.TableClient, chunk.SchemaConfig, error) {
 			dynamoDB := newMockDynamoDB(0, provisionedErr)
 			schemaCfg := chunk.SchemaConfig{
-				ChunkTables: chunk.PeriodicTableConfig{
-					From:   util.NewDayValue(model.Now()),
-					Period: 10 * time.Minute,
-					Prefix: "chunks",
-				},
+				Configs: []chunk.PeriodConfig{{
+					Store: "aws",
+					From:  model.Now(),
+					ChunkTables: chunk.PeriodicTableConfig{
+						Prefix: "chunks",
+						Period: 10 * time.Minute,
+					},
+				}},
 			}
 			table := &dynamoTableClient{
 				DynamoDB: dynamoDB,

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -38,14 +38,27 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 
 	// Set up table-manager config
 	cfg := chunk.SchemaConfig{
-		OriginalTableName:   "a",
-		UsePeriodicTables:   true,
-		IndexTables:         fixturePeriodicTableConfig(tablePrefix, 2, indexWriteScale, inactiveWriteScale),
-		ChunkTables:         fixturePeriodicTableConfig(chunkTablePrefix, 2, chunkWriteScale, inactiveWriteScale),
+		Configs: []chunk.PeriodConfig{
+			{
+				Store: "aws-dynamo",
+				IndexTables: chunk.PeriodicTableConfig{
+					Prefix:                  "a",
+					InactiveReadThroughput:  inactiveRead,
+					InactiveWriteThroughput: inactiveWrite,
+				},
+			},
+			{
+				Store:       "aws-dynamo",
+				IndexTables: fixturePeriodicTableConfig(tablePrefix, 2, indexWriteScale, inactiveWriteScale),
+				ChunkTables: fixturePeriodicTableConfig(chunkTablePrefix, 2, chunkWriteScale, inactiveWriteScale),
+			},
+		},
+	}
+	tbm := chunk.TableManagerConfig{
 		CreationGracePeriod: gracePeriod,
 	}
 
-	tableManager, err := chunk.NewTableManager(cfg, maxChunkAge, client)
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -1,11 +1,9 @@
 package aws
 
 import (
-	"bytes"
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"strings"
 	"time"
@@ -21,8 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
@@ -89,12 +85,6 @@ var (
 		Help:      "Number of retries per DynamoDB operation.",
 		Buckets:   prometheus.LinearBuckets(0, 1, 21),
 	}, []string{"operation"})
-	s3RequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "cortex",
-		Name:      "s3_request_duration_seconds",
-		Help:      "Time spent doing S3 requests.",
-		Buckets:   []float64{.025, .05, .1, .25, .5, 1, 2},
-	}, []string{"operation", "status_code"})
 )
 
 func init() {
@@ -103,7 +93,6 @@ func init() {
 	prometheus.MustRegister(dynamoFailures)
 	prometheus.MustRegister(dynamoQueryPagesCount)
 	prometheus.MustRegister(dynamoQueryRetryCount)
-	prometheus.MustRegister(s3RequestDuration)
 	prometheus.MustRegister(dynamoDroppedRequests)
 }
 
@@ -147,12 +136,10 @@ func (cfg *StorageConfig) RegisterFlags(f *flag.FlagSet) {
 }
 
 type storageClient struct {
-	cfg       StorageConfig
+	cfg       DynamoDBConfig
 	schemaCfg chunk.SchemaConfig
 
-	DynamoDB   dynamodbiface.DynamoDBAPI
-	S3         s3iface.S3API
-	bucketName string
+	DynamoDB dynamodbiface.DynamoDBAPI
 
 	// These functions exists for mocking, so we don't have to write a whole load
 	// of boilerplate.
@@ -163,40 +150,39 @@ type storageClient struct {
 
 // Opts returns the chunk.StorageOpt's for the config.
 func Opts(cfg StorageConfig, schemaCfg chunk.SchemaConfig) ([]chunk.StorageOpt, error) {
-	client, err := NewStorageClient(cfg, schemaCfg)
+	client, err := NewS3StorageClient(cfg, schemaCfg)
 	if err != nil {
 		return nil, err
 	}
-	return []chunk.StorageOpt{{
-		From:   model.Time(0),
-		Client: client,
-	}}, err
+
+	opts := []chunk.StorageOpt{}
+	opts = append(opts, chunk.StorageOpt{From: model.Time(0), Client: client})
+	if schemaCfg.ChunkTables.From.IsSet() {
+		client, err = NewStorageClient(cfg.DynamoDBConfig, schemaCfg)
+		if err != nil {
+			return nil, err
+		}
+
+		opts = append(opts, chunk.StorageOpt{
+			From:   schemaCfg.ChunkTables.From.Time,
+			Client: client,
+		})
+	}
+
+	return opts, nil
 }
 
 // NewStorageClient makes a new AWS-backed StorageClient.
-func NewStorageClient(cfg StorageConfig, schemaCfg chunk.SchemaConfig) (chunk.StorageClient, error) {
+func NewStorageClient(cfg DynamoDBConfig, schemaCfg chunk.SchemaConfig) (chunk.StorageClient, error) {
 	dynamoDB, err := dynamoClientFromURL(cfg.DynamoDB.URL)
 	if err != nil {
 		return nil, err
 	}
 
-	if cfg.S3.URL == nil {
-		return nil, fmt.Errorf("no URL specified for S3")
-	}
-	s3Config, err := awscommon.ConfigFromURL(cfg.S3.URL)
-	if err != nil {
-		return nil, err
-	}
-	s3Config = s3Config.WithMaxRetries(0) // We do our own retries, so we can monitor them
-	s3Client := s3.New(session.New(s3Config))
-	bucketName := strings.TrimPrefix(cfg.S3.URL.Path, "/")
-
 	client := storageClient{
-		cfg:        cfg,
-		schemaCfg:  schemaCfg,
-		DynamoDB:   dynamoDB,
-		S3:         s3Client,
-		bucketName: bucketName,
+		cfg:       cfg,
+		schemaCfg: schemaCfg,
+		DynamoDB:  dynamoDB,
 	}
 	client.queryRequestFn = client.queryRequest
 	client.batchGetItemRequestFn = client.batchGetItemRequest
@@ -482,33 +468,12 @@ type chunksPlusError struct {
 }
 
 func (a storageClient) GetChunks(ctx context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
-	sp, ctx := ot.StartSpanFromContext(ctx, "GetChunks")
+	sp, ctx := ot.StartSpanFromContext(ctx, "GetChunks.DynamoDB")
 	defer sp.Finish()
 	sp.LogFields(otlog.Int("chunks requested", len(chunks)))
 
-	var (
-		s3Chunks       []chunk.Chunk
-		dynamoDBChunks []chunk.Chunk
-	)
-
-	for _, chunk := range chunks {
-		if !a.schemaCfg.ChunkTables.From.IsSet() || chunk.From.Before(a.schemaCfg.ChunkTables.From.Time) {
-			s3Chunks = append(s3Chunks, chunk)
-		} else {
-			dynamoDBChunks = append(dynamoDBChunks, chunk)
-		}
-	}
-
-	// Get chunks from S3, then get chunks from DynamoDB.  I don't expect us to be
-	// doing both simultaneously except for when we migrate, when it will only
-	// occur for a couple or hours. So I didn't think it is worth the extra code
-	// to parallelise.
-
+	dynamoDBChunks := chunks
 	var err error
-	s3Chunks, err = a.getS3Chunks(ctx, s3Chunks)
-	if err != nil {
-		return s3Chunks, err
-	}
 
 	gangSize := a.cfg.ChunkGangSize * dynamoDBMaxReadBatchSize
 	if gangSize == 0 { // zero means turn feature off
@@ -530,7 +495,7 @@ func (a storageClient) GetChunks(ctx context.Context, chunks []chunk.Chunk) ([]c
 			results <- chunksPlusError{outChunks, err}
 		}(i)
 	}
-	finalChunks := s3Chunks
+	finalChunks := []chunk.Chunk{}
 	for i := 0; i < len(dynamoDBChunks); i += gangSize {
 		in := <-results
 		if in.err != nil {
@@ -545,62 +510,6 @@ func (a storageClient) GetChunks(ctx context.Context, chunks []chunk.Chunk) ([]c
 
 	// Return any chunks we did receive: a partial result may be useful
 	return finalChunks, err
-}
-
-func (a storageClient) getS3Chunks(ctx context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
-	incomingChunks := make(chan chunk.Chunk)
-	incomingErrors := make(chan error)
-	for _, c := range chunks {
-		go func(c chunk.Chunk) {
-			c, err := a.getS3Chunk(ctx, c)
-			if err != nil {
-				incomingErrors <- err
-				return
-			}
-			incomingChunks <- c
-		}(c)
-	}
-
-	result := []chunk.Chunk{}
-	errors := []error{}
-	for i := 0; i < len(chunks); i++ {
-		select {
-		case chunk := <-incomingChunks:
-			result = append(result, chunk)
-		case err := <-incomingErrors:
-			errors = append(errors, err)
-		}
-	}
-	if len(errors) > 0 {
-		// Return any chunks we did receive: a partial result may be useful
-		return result, errors[0]
-	}
-	return result, nil
-}
-
-func (a storageClient) getS3Chunk(ctx context.Context, c chunk.Chunk) (chunk.Chunk, error) {
-	var resp *s3.GetObjectOutput
-	err := instrument.TimeRequestHistogram(ctx, "S3.GetObject", s3RequestDuration, func(ctx context.Context) error {
-		var err error
-		resp, err = a.S3.GetObjectWithContext(ctx, &s3.GetObjectInput{
-			Bucket: aws.String(a.bucketName),
-			Key:    aws.String(c.ExternalKey()),
-		})
-		return err
-	})
-	if err != nil {
-		return chunk.Chunk{}, err
-	}
-	defer resp.Body.Close()
-	buf, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return chunk.Chunk{}, err
-	}
-	decodeContext := chunk.NewDecodeContext()
-	if err := c.Decode(decodeContext, buf); err != nil {
-		return chunk.Chunk{}, err
-	}
-	return c, nil
 }
 
 // As we're re-using the DynamoDB schema from the index for the chunk tables,
@@ -730,8 +639,6 @@ func processChunkResponse(response *dynamodb.BatchGetItemOutput, chunksByKey map
 
 func (a storageClient) PutChunks(ctx context.Context, chunks []chunk.Chunk) error {
 	var (
-		s3ChunkKeys    []string
-		s3ChunkBufs    [][]byte
 		dynamoDBWrites = dynamoDBWriteBatch{}
 	)
 
@@ -743,54 +650,11 @@ func (a storageClient) PutChunks(ctx context.Context, chunks []chunk.Chunk) erro
 		}
 		key := chunks[i].ExternalKey()
 
-		if !a.schemaCfg.ChunkTables.From.IsSet() || chunks[i].From.Before(a.schemaCfg.ChunkTables.From.Time) {
-			s3ChunkKeys = append(s3ChunkKeys, key)
-			s3ChunkBufs = append(s3ChunkBufs, buf)
-		} else {
-			table := a.schemaCfg.ChunkTables.TableFor(chunks[i].From)
-			dynamoDBWrites.Add(table, key, placeholder, buf)
-		}
-	}
-
-	// Put chunks to S3, then put chunks to DynamoDB.  I don't expect us to be
-	// doing both simultaneously except for when we migrate, when it will only
-	// occur for a couple or hours. So I didn't think it is worth the extra code
-	// to parallelise.
-
-	if err := a.putS3Chunks(ctx, s3ChunkKeys, s3ChunkBufs); err != nil {
-		return err
+		table := a.schemaCfg.ChunkTables.TableFor(chunks[i].From)
+		dynamoDBWrites.Add(table, key, placeholder, buf)
 	}
 
 	return a.BatchWrite(ctx, dynamoDBWrites)
-}
-
-func (a storageClient) putS3Chunks(ctx context.Context, keys []string, bufs [][]byte) error {
-	incomingErrors := make(chan error)
-	for i := range bufs {
-		go func(i int) {
-			incomingErrors <- a.putS3Chunk(ctx, keys[i], bufs[i])
-		}(i)
-	}
-
-	var lastErr error
-	for range keys {
-		err := <-incomingErrors
-		if err != nil {
-			lastErr = err
-		}
-	}
-	return lastErr
-}
-
-func (a storageClient) putS3Chunk(ctx context.Context, key string, buf []byte) error {
-	return instrument.TimeRequestHistogram(ctx, "S3.PutObject", s3RequestDuration, func(ctx context.Context) error {
-		_, err := a.S3.PutObjectWithContext(ctx, &s3.PutObjectInput{
-			Body:   bytes.NewReader(buf),
-			Bucket: aws.String(a.bucketName),
-			Key:    aws.String(key),
-		})
-		return err
-	})
 }
 
 // Slice of values returned; map key is attribute name

--- a/pkg/chunk/aws/storage_client_s3.go
+++ b/pkg/chunk/aws/storage_client_s3.go
@@ -1,0 +1,183 @@
+package aws
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	ot "github.com/opentracing/opentracing-go"
+	otlog "github.com/opentracing/opentracing-go/log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+	awscommon "github.com/weaveworks/common/aws"
+	"github.com/weaveworks/common/instrument"
+)
+
+var (
+	s3RequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "cortex",
+		Name:      "s3_request_duration_seconds",
+		Help:      "Time spent doing S3 requests.",
+		Buckets:   []float64{.025, .05, .1, .25, .5, 1, 2},
+	}, []string{"operation", "status_code"})
+)
+
+func init() {
+	prometheus.MustRegister(s3RequestDuration)
+}
+
+type s3storageClient struct {
+	storageClient
+	bucketName string
+	S3         s3iface.S3API
+}
+
+// NewS3StorageClient makes a new AWS-backed StorageClient.
+func NewS3StorageClient(cfg StorageConfig, schemaCfg chunk.SchemaConfig) (chunk.StorageClient, error) {
+	dynamoDB, err := dynamoClientFromURL(cfg.DynamoDB.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.S3.URL == nil {
+		return nil, fmt.Errorf("no URL specified for S3")
+	}
+	s3Config, err := awscommon.ConfigFromURL(cfg.S3.URL)
+	if err != nil {
+		return nil, err
+	}
+	s3Config = s3Config.WithMaxRetries(0) // We do our own retries, so we can monitor them
+	s3Client := s3.New(session.New(s3Config))
+	bucketName := strings.TrimPrefix(cfg.S3.URL.Path, "/")
+
+	client := s3storageClient{
+		storageClient: storageClient{
+			cfg:       cfg.DynamoDBConfig,
+			schemaCfg: schemaCfg,
+			DynamoDB:  dynamoDB,
+		},
+		S3:         s3Client,
+		bucketName: bucketName,
+	}
+	client.queryRequestFn = client.queryRequest
+	client.batchGetItemRequestFn = client.batchGetItemRequest
+	client.batchWriteItemRequestFn = client.batchWriteItemRequest
+	return client, nil
+}
+
+func (a s3storageClient) GetChunks(ctx context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
+	sp, ctx := ot.StartSpanFromContext(ctx, "GetChunks.S3")
+	defer sp.Finish()
+	sp.LogFields(otlog.Int("chunks requested", len(chunks)))
+
+	incomingChunks := make(chan chunk.Chunk)
+	incomingErrors := make(chan error)
+	for _, c := range chunks {
+		go func(c chunk.Chunk) {
+			c, err := a.getS3Chunk(ctx, c)
+			if err != nil {
+				incomingErrors <- err
+				return
+			}
+			incomingChunks <- c
+		}(c)
+	}
+
+	result := []chunk.Chunk{}
+	errors := []error{}
+	for i := 0; i < len(chunks); i++ {
+		select {
+		case chunk := <-incomingChunks:
+			result = append(result, chunk)
+		case err := <-incomingErrors:
+			errors = append(errors, err)
+		}
+	}
+
+	sp.LogFields(otlog.Int("chunks fetched", len(result)))
+	if len(errors) > 0 {
+		sp.LogFields(otlog.String("error", errors[0].Error()))
+		// Return any chunks we did receive: a partial result may be useful
+		return result, errors[0]
+	}
+	return result, nil
+}
+
+func (a s3storageClient) getS3Chunk(ctx context.Context, c chunk.Chunk) (chunk.Chunk, error) {
+	var resp *s3.GetObjectOutput
+	err := instrument.TimeRequestHistogram(ctx, "S3.GetObject", s3RequestDuration, func(ctx context.Context) error {
+		var err error
+		resp, err = a.S3.GetObjectWithContext(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(a.bucketName),
+			Key:    aws.String(c.ExternalKey()),
+		})
+		return err
+	})
+	if err != nil {
+		return chunk.Chunk{}, err
+	}
+	defer resp.Body.Close()
+	buf, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return chunk.Chunk{}, err
+	}
+	decodeContext := chunk.NewDecodeContext()
+	if err := c.Decode(decodeContext, buf); err != nil {
+		return chunk.Chunk{}, err
+	}
+	return c, nil
+}
+
+func (a s3storageClient) PutChunks(ctx context.Context, chunks []chunk.Chunk) error {
+	var (
+		s3ChunkKeys []string
+		s3ChunkBufs [][]byte
+	)
+
+	for i := range chunks {
+		// Encode the chunk first - checksum is calculated as a side effect.
+		buf, err := chunks[i].Encode()
+		if err != nil {
+			return err
+		}
+		key := chunks[i].ExternalKey()
+
+		s3ChunkKeys = append(s3ChunkKeys, key)
+		s3ChunkBufs = append(s3ChunkBufs, buf)
+	}
+
+	incomingErrors := make(chan error)
+	for i := range s3ChunkBufs {
+		go func(i int) {
+			incomingErrors <- a.putS3Chunk(ctx, s3ChunkKeys[i], s3ChunkBufs[i])
+		}(i)
+	}
+
+	var lastErr error
+	for range s3ChunkKeys {
+		err := <-incomingErrors
+		if err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+func (a s3storageClient) putS3Chunk(ctx context.Context, key string, buf []byte) error {
+	return instrument.TimeRequestHistogram(ctx, "S3.PutObject", s3RequestDuration, func(ctx context.Context) error {
+		_, err := a.S3.PutObjectWithContext(ctx, &s3.PutObjectInput{
+			Body:   bytes.NewReader(buf),
+			Bucket: aws.String(a.bucketName),
+			Key:    aws.String(key),
+		})
+		return err
+	})
+}

--- a/pkg/chunk/cassandra/fixtures.go
+++ b/pkg/chunk/cassandra/fixtures.go
@@ -2,12 +2,10 @@ package cassandra
 
 import (
 	"context"
-	"flag"
 	"os"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/testutils"
-	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/prometheus/common/model"
 )
 
@@ -50,15 +48,7 @@ func Fixtures() ([]testutils.Fixture, error) {
 	}
 
 	// Get a SchemaConfig with the defaults.
-	flagSet := flag.NewFlagSet("flags", flag.PanicOnError)
-	schemaConfig := chunk.SchemaConfig{}
-	schemaConfig.RegisterFlags(flagSet)
-	err := flagSet.Parse([]string{})
-	if err != nil {
-		return nil, err
-	}
-	schemaConfig.IndexTables.From = util.NewDayValue(model.Now())
-	schemaConfig.ChunkTables.From = util.NewDayValue(model.Now())
+	schemaConfig := chunk.DefaultSchemaConfig("cassandra", "v1", model.Now())
 
 	storageClient, err := NewStorageClient(cfg, schemaConfig)
 	if err != nil {

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 
-	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
@@ -19,8 +18,12 @@ type Store interface {
 	Stop()
 }
 
-// compositeStore is a Store which delegates to various stores depending
+// CompositeStore is a Store which delegates to various stores depending
 // on when they were activated.
+type CompositeStore struct {
+	compositeStore
+}
+
 type compositeStore struct {
 	stores []compositeStoreEntry
 }
@@ -30,157 +33,28 @@ type compositeStoreEntry struct {
 	Store
 }
 
-type byStart []compositeStoreEntry
-
-func (a byStart) Len() int           { return len(a) }
-func (a byStart) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a byStart) Less(i, j int) bool { return a[i].start < a[j].start }
-
-// SchemaOpt stores when a schema starts.
-type SchemaOpt struct {
-	From     model.Time
-	NewStore func(StorageClient) (Store, error)
-}
-
-// SchemaOpts returns the schemas and the times when they activate.
-func SchemaOpts(cfg StoreConfig, schemaCfg SchemaConfig, limits *validation.Overrides) []SchemaOpt {
-	opts := []SchemaOpt{{
-		From: 0,
-		NewStore: func(storage StorageClient) (Store, error) {
-			return newStore(cfg, v1Schema(schemaCfg), storage, limits)
-		},
-	}}
-
-	if schemaCfg.DailyBucketsFrom.IsSet() {
-		opts = append(opts, SchemaOpt{
-			From: schemaCfg.DailyBucketsFrom.Time,
-			NewStore: func(storage StorageClient) (Store, error) {
-				return newStore(cfg, v2Schema(schemaCfg), storage, limits)
-			},
-		})
-	}
-
-	if schemaCfg.Base64ValuesFrom.IsSet() {
-		opts = append(opts, SchemaOpt{
-			From: schemaCfg.Base64ValuesFrom.Time,
-			NewStore: func(storage StorageClient) (Store, error) {
-				return newStore(cfg, v3Schema(schemaCfg), storage, limits)
-			},
-		})
-	}
-
-	if schemaCfg.V4SchemaFrom.IsSet() {
-		opts = append(opts, SchemaOpt{
-			From: schemaCfg.V4SchemaFrom.Time,
-			NewStore: func(storage StorageClient) (Store, error) {
-				return newStore(cfg, v4Schema(schemaCfg), storage, limits)
-			},
-		})
-	}
-
-	if schemaCfg.V5SchemaFrom.IsSet() {
-		opts = append(opts, SchemaOpt{
-			From: schemaCfg.V5SchemaFrom.Time,
-			NewStore: func(storage StorageClient) (Store, error) {
-				return newStore(cfg, v5Schema(schemaCfg), storage, limits)
-			},
-		})
-	}
-
-	if schemaCfg.V6SchemaFrom.IsSet() {
-		opts = append(opts, SchemaOpt{
-			From: schemaCfg.V6SchemaFrom.Time,
-			NewStore: func(storage StorageClient) (Store, error) {
-				return newStore(cfg, v6Schema(schemaCfg), storage, limits)
-			},
-		})
-	}
-
-	if schemaCfg.V9SchemaFrom.IsSet() {
-		opts = append(opts, SchemaOpt{
-			From: schemaCfg.V9SchemaFrom.Time,
-			NewStore: func(storage StorageClient) (Store, error) {
-				return newSeriesStore(cfg, v9Schema(schemaCfg), storage, limits)
-			},
-		})
-	}
-
-	return opts
-}
-
-// StorageOpt stores when a StorageClient is to be used.
-type StorageOpt struct {
-	From   model.Time
-	Client StorageClient
-}
-
-func latest(a, b model.Time) model.Time {
-	if a.Before(b) {
-		return b
-	}
-	return a
-}
-
-// NewStore creates a new Store which delegates to different stores depending
+// NewCompositeStore creates a new Store which delegates to different stores depending
 // on time.
-func NewStore(cfg StoreConfig, schemaCfg SchemaConfig, storageOpts []StorageOpt, limits *validation.Overrides) (Store, error) {
-	cache, err := cache.New(cfg.ChunkCacheConfig)
-	if err != nil {
-		return nil, err
-	}
-	cfg.ChunkCacheConfig.Cache = cache
-
-	schemaOpts := SchemaOpts(cfg, schemaCfg, limits)
-
-	return newCompositeStore(cfg, schemaCfg, schemaOpts, storageOpts)
+func NewCompositeStore() CompositeStore {
+	return CompositeStore{}
 }
 
-func newCompositeStore(cfg StoreConfig, schemaCfg SchemaConfig, schemaOpts []SchemaOpt, storageOpts []StorageOpt) (Store, error) {
-	stores := []compositeStoreEntry{}
-	add := func(i, j int) error {
-		schemaOpt := schemaOpts[i]
-		storageOpt := storageOpts[j]
-		store, err := schemaOpt.NewStore(storageOpt.Client)
-		stores = append(stores, compositeStoreEntry{latest(schemaOpt.From, storageOpt.From), store})
+// AddPeriod adds the configuration for a period of time to the CompositeStore
+func (c *CompositeStore) AddPeriod(storeCfg StoreConfig, cfg PeriodConfig, storage StorageClient, limits *validation.Overrides) error {
+	schema := cfg.createSchema()
+	var store Store
+	var err error
+	switch cfg.Schema {
+	case "v9":
+		store, err = newSeriesStore(storeCfg, schema, storage, limits)
+	default:
+		store, err = newStore(storeCfg, schema, storage, limits)
+	}
+	if err != nil {
 		return err
 	}
-
-	i, j := 0, 0
-	for i+1 < len(schemaOpts) && j+1 < len(storageOpts) {
-		if err := add(i, j); err != nil {
-			return nil, err
-		}
-
-		// Increment the interval that finished first.
-		nextSchemaOpt := schemaOpts[i+1]
-		nextStorageOpt := storageOpts[j+1]
-		if nextSchemaOpt.From.Before(nextStorageOpt.From) {
-			i++
-		} else if nextSchemaOpt.From.After(nextStorageOpt.From) {
-			j++
-		} else {
-			i++
-			j++
-		}
-	}
-
-	for ; i+1 < len(schemaOpts); i++ {
-		if err := add(i, j); err != nil {
-			return nil, err
-		}
-	}
-
-	for ; j+1 < len(storageOpts); j++ {
-		if err := add(i, j); err != nil {
-			return nil, err
-		}
-	}
-
-	if err := add(i, j); err != nil {
-		return nil, err
-	}
-
-	return compositeStore{stores}, nil
+	c.stores = append(c.stores, compositeStoreEntry{start: cfg.From, Store: store})
+	return nil
 }
 
 func (c compositeStore) Put(ctx context.Context, chunks []Chunk) error {

--- a/pkg/chunk/fixtures.go
+++ b/pkg/chunk/fixtures.go
@@ -1,6 +1,10 @@
 package chunk
 
-import "github.com/prometheus/common/model"
+import (
+	"time"
+
+	"github.com/prometheus/common/model"
+)
 
 // BenchmarkMetric is a real example from Kubernetes' embedded cAdvisor metrics, lightly obfuscated
 var BenchmarkMetric = model.Metric{
@@ -21,4 +25,23 @@ var BenchmarkMetric = model.Metric{
 	"name":                   "k8s_some-name_some-other-name-5j8s8_kube-system_6e91c467-e4c5-11e7-ace3-0a97ed59c75e_0",
 	"namespace":              "kube-system",
 	"pod_name":               "some-other-name-5j8s8",
+}
+
+// DefaultSchemaConfig creates a simple schema config for testing
+func DefaultSchemaConfig(store, schema string, from model.Time) SchemaConfig {
+	return SchemaConfig{
+		Configs: []PeriodConfig{{
+			Store:  store,
+			Schema: schema,
+			From:   from,
+			ChunkTables: PeriodicTableConfig{
+				Prefix: "cortex",
+				Period: 7 * 24 * time.Hour,
+			},
+			IndexTables: PeriodicTableConfig{
+				Prefix: "cortex_chunks",
+				Period: 7 * 24 * time.Hour,
+			},
+		}},
+	}
 }

--- a/pkg/chunk/gcp/fixtures.go
+++ b/pkg/chunk/gcp/fixtures.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/testutils"
-	"github.com/cortexproject/cortex/pkg/util"
 )
 
 const (
@@ -56,11 +55,14 @@ func (f *fixture) Clients() (
 	}
 
 	schemaConfig = chunk.SchemaConfig{
-		ChunkTables: chunk.PeriodicTableConfig{
-			From:   util.NewDayValue(model.Now()),
-			Period: 10 * time.Minute,
-			Prefix: "chunks",
-		},
+		Configs: []chunk.PeriodConfig{{
+			Store: "gcp",
+			From:  model.Now(),
+			ChunkTables: chunk.PeriodicTableConfig{
+				Prefix: "chunks",
+				Period: 10 * time.Minute,
+			},
+		}},
 	}
 	tClient = &tableClient{
 		client: adminClient,

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log/level"
-	"github.com/prometheus/common/model"
 )
 
 // MockStorage is a fake in-memory StorageClient.
@@ -29,16 +28,6 @@ type mockTable struct {
 type mockItem struct {
 	rangeValue []byte
 	value      []byte
-}
-
-// Opts returns the chunk.StorageOpt's for the config.
-func Opts() ([]StorageOpt, error) {
-	client := NewMockStorage()
-
-	return []StorageOpt{{
-		From:   model.Time(0),
-		Client: client,
-	}}, nil
 }
 
 // NewMockStorage creates a new MockStorage.

--- a/pkg/chunk/schema_config_test.go
+++ b/pkg/chunk/schema_config_test.go
@@ -13,8 +13,8 @@ func TestHourlyBuckets(t *testing.T) {
 		metricName = model.LabelValue("name")
 		tableName  = "table"
 	)
-	var cfg = SchemaConfig{
-		OriginalTableName: tableName,
+	var cfg = PeriodConfig{
+		IndexTables: PeriodicTableConfig{Prefix: tableName},
 	}
 
 	type args struct {
@@ -99,8 +99,8 @@ func TestDailyBuckets(t *testing.T) {
 		metricName = model.LabelValue("name")
 		tableName  = "table"
 	)
-	var cfg = SchemaConfig{
-		OriginalTableName: tableName,
+	var cfg = PeriodConfig{
+		IndexTables: PeriodicTableConfig{Prefix: tableName},
 	}
 
 	type args struct {

--- a/pkg/chunk/schema_test.go
+++ b/pkg/chunk/schema_test.go
@@ -7,9 +7,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
-	"time"
 
-	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/test"
@@ -34,6 +32,15 @@ func mergeResults(rss ...[]IndexEntry) []IndexEntry {
 	return results
 }
 
+const table = "table"
+
+func makeSchema(schemaName string) Schema {
+	return PeriodConfig{
+		Schema:      schemaName,
+		IndexTables: PeriodicTableConfig{Prefix: table},
+	}.createSchema()
+}
+
 func TestSchemaHashKeys(t *testing.T) {
 	mkResult := func(tableName, fmtStr string, from, through int) []IndexEntry {
 		want := []IndexEntry{}
@@ -48,22 +55,12 @@ func TestSchemaHashKeys(t *testing.T) {
 
 	const (
 		userID         = "userid"
-		table          = "table"
 		periodicPrefix = "periodicPrefix"
 	)
 
-	cfg := SchemaConfig{
-		OriginalTableName: table,
-		UsePeriodicTables: true,
-		IndexTables: PeriodicTableConfig{
-			Prefix: periodicPrefix,
-			Period: 2 * 24 * time.Hour,
-			From:   util.NewDayValue(model.TimeFromUnix(5 * 24 * 60 * 60)),
-		},
-	}
-	hourlyBuckets := v1Schema(cfg)
-	dailyBuckets := v3Schema(cfg)
-	labelBuckets := v4Schema(cfg)
+	hourlyBuckets := makeSchema("v1")
+	dailyBuckets := makeSchema("v3")
+	labelBuckets := makeSchema("v4")
 	metric := model.Metric{
 		model.MetricNameLabel: "foo",
 		"bar": "baz",
@@ -178,21 +175,17 @@ func parseRangeValueType(rangeValue []byte) (int, error) {
 func TestSchemaRangeKey(t *testing.T) {
 	const (
 		userID     = "userid"
-		table      = "table"
 		metricName = "foo"
 		chunkID    = "chunkID"
 	)
 
 	var (
-		cfg = SchemaConfig{
-			OriginalTableName: table,
-		}
-		hourlyBuckets = v1Schema(cfg)
-		dailyBuckets  = v2Schema(cfg)
-		base64Keys    = v3Schema(cfg)
-		labelBuckets  = v4Schema(cfg)
-		tsRangeKeys   = v5Schema(cfg)
-		v6RangeKeys   = v6Schema(cfg)
+		hourlyBuckets = makeSchema("v1")
+		dailyBuckets  = makeSchema("v2")
+		base64Keys    = makeSchema("v3")
+		labelBuckets  = makeSchema("v4")
+		tsRangeKeys   = makeSchema("v5")
+		v6RangeKeys   = makeSchema("v6")
 		metric        = model.Metric{
 			model.MetricNameLabel: metricName,
 			"bar": "bary",

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -308,7 +308,7 @@ func ExpectTables(ctx context.Context, client TableClient, expected []TableDesc)
 		}
 
 		if !desc.Equals(expect) {
-			return fmt.Errorf("Expected '%v', found '%v' for table '%s'", expect, desc, desc.Name)
+			return fmt.Errorf("Expected '%#v', found '%#v' for table '%s'", expect, desc, desc.Name)
 		}
 	}
 

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 const (
@@ -24,12 +25,14 @@ type Fixture interface {
 
 // Setup a fixture with initial tables
 func Setup(fixture Fixture, tableName string) (chunk.StorageClient, error) {
+	var tbmConfig chunk.TableManagerConfig
+	util.DefaultValues(&tbmConfig)
 	storageClient, tableClient, schemaConfig, err := fixture.Clients()
 	if err != nil {
 		return nil, err
 	}
 
-	tableManager, err := chunk.NewTableManager(schemaConfig, 12*time.Hour, tableClient)
+	tableManager, err := chunk.NewTableManager(tbmConfig, schemaConfig, 12*time.Hour, tableClient)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #1014 
Fixes #320 

The schema config in yaml looks like this:

```
configs:
- from: 0
  store: aws
  schema: v1
  index:
    prefix: dev_chunks_2
- from: 1484006400000
  store: aws
  schema: v2
  index:
    prefix: dev_chunks_2
- from: 1486339200000
  store: aws
  schema: v4
  index:
    prefix: dev_chunks_weekly_
    period: 168h
- from: 1502928000000
  store: aws-dynamo
  schema: v9
  index:
    prefix: dev_chunk_index_
    period: 168h
  chunks:
    prefix: dev_chunk_data_weekly_
    period: 168h
- from: 1508371200000
  store: aws-dynamo
  schema: v6
  index:
    prefix: dev_chunks_weekly_
    period: 168h
  chunks:
    prefix: dev_chunk_data_weekly_
    period: 168h
```

If you don't specify a `Period` then all data goes in one table and `prefix` is the entire name of that table.

At present `model.Time` does not unmarshal from a human-readable format.

`StorageOpts` are gone: all the work to create objects from the config is done in `storage/factory`. ~I would prefer that `CompositeStoreEntry` did not get exported, but the collusion between chunk and storage requires it.~

`schema` and `compositeStoreEntry` are still somewhat parallel - I might fix that later.

The legacy command-line option for the storage client - "aws", "cassandra", etc., moves from storage package into the schema area, because it is used during initialization.

I haven't squashed commits at all.  Includes the change in #1063 