### PR TITLE
Log opening of span at debug level

### DIFF
--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	opentracing "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 
@@ -24,7 +25,7 @@ func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, 
 		Span:   span,
 	}
 	if len(kvps) > 0 {
-		logger.Log(kvps...)
+		level.Debug(logger).Log(kvps...)
 	}
 	return logger, ctx
 }


### PR DESCRIPTION
Otherwise we get thousands of log lines like this:

```
ts=2018-10-16T12:54:33.484363284Z caller=spanlogger.go:35 org_id=1 trace_id=768be160665ad7d6 method=SeriesStore.lookupSeriesByMetricNameMatcher metricName=kube_pod_container_status_restarts_total matcher=null
ts=2018-10-16T12:54:33.503513416Z caller=spanlogger.go:35 org_id=2 trace_id=234771d1d0ad5b5f method=SeriesStore.lookupSeriesByMetricNameMatchers metricName=kube_pod_container_status_restarts_total matchers=0
ts=2018-10-16T12:54:33.503567361Z caller=spanlogger.go:35 org_id=2 trace_id=234771d1d0ad5b5f method=SeriesStore.lookupSeriesByMetricNameMatcher metricName=kube_pod_container_status_restarts_total matcher=null
ts=2018-10-16T12:54:33.524284935Z caller=spanlogger.go:35 org_id=2 trace_id=4695890a7cda052c method=SeriesStore.lookupSeriesByMetricNameMatchers metricName=http_server_request_duration_seconds_bucket matchers=2
ts=2018-10-16T12:54:33.52442466Z caller=spanlogger.go:35 org_id=2 trace_id=4695890a7cda052c method=SeriesStore.lookupSeriesByMetricNameMatcher metricName=http_server_request_duration_seconds_bucket matcher="le=\"0.5\""
```

which are not very interesting to read.