### PR TITLE
Make sure span exists when logging

### DIFF
--- a/pkg/chunk/cache/background.go
+++ b/pkg/chunk/cache/background.go
@@ -90,9 +90,11 @@ func (c *backgroundCache) Store(ctx context.Context, keys []string, bufs [][]byt
 	case c.bgWrites <- bgWrite:
 		c.queueLength.Add(float64(len(keys)))
 	default:
-		sp := opentracing.SpanFromContext(ctx)
-		sp.LogFields(otlog.Int("dropped", len(keys)))
 		c.droppedWriteBack.Add(float64(len(keys)))
+		sp := opentracing.SpanFromContext(ctx)
+		if sp != nil {
+			sp.LogFields(otlog.Int("dropped", len(keys)))
+		}
 	}
 }
 

--- a/pkg/chunk/cache/diskcache.go
+++ b/pkg/chunk/cache/diskcache.go
@@ -165,8 +165,6 @@ func (d *Diskcache) Store(ctx context.Context, keys []string, bufs [][]byte) {
 }
 
 func (d *Diskcache) store(ctx context.Context, key string, value []byte) {
-	sp := opentracing.SpanFromContext(ctx)
-
 	bucket := hash(key) % d.buckets
 	shard := bucket % numMutexes // Get the index of the mutex associated with this bucket
 	d.entryMutexes[shard].Lock()
@@ -185,8 +183,12 @@ func (d *Diskcache) store(ctx context.Context, key string, value []byte) {
 	_, err := put(value, buf, 0)
 	if err != nil {
 		d.entries[bucket] = ""
-		sp.LogFields(otlog.Error(err))
 		level.Error(util.Logger).Log("msg", "failed to put key to diskcache", "err", err)
+
+		sp := opentracing.SpanFromContext(ctx)
+		if sp != nil {
+			sp.LogFields(otlog.Error(err))
+		}
 		return
 	}
 

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -211,8 +211,6 @@ func (c *Memcached) Store(ctx context.Context, keys []string, bufs [][]byte) {
 			return c.memcache.Set(&item)
 		})
 		if err != nil {
-			sp := opentracing.SpanFromContext(ctx)
-			sp.LogFields(otlog.Error(err))
 			level.Error(util.Logger).Log("msg", "failed to put to memcached", "err", err)
 		}
 	}


### PR DESCRIPTION
We just had an outage where ingester crashed with:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0xa0a5a2]

goroutine 566 [running]:
github.com/cortexproject/cortex/pkg/chunk/cache.(*backgroundCache).Store(0xc4200e2ba0, 0x11c05a0, 0xc51b5758c0, 0xc6ec69cbd0, 0x1, 0x1, 0xc44d14a880, 0x1, 0x1)
    /go/src/github.com/cortexproject/cortex/pkg/chunk/cache/background.go:103 +0x252
github.com/cortexproject/cortex/pkg/chunk.(*Fetcher).writeBackCache(0xc42083a6c0, 0x11c05a0, 0xc51b5758c0, 0xc7e6bd25b0, 0x1, 0x1, 0x0, 0x0)
    /go/src/github.com/cortexproject/cortex/pkg/chunk/chunk_store_utils.go:155 +0x3a6
github.com/cortexproject/cortex/pkg/chunk.(*seriesStore).PutOne(0xc42074c000, 0x11c05a0, 0xc51b5758c0, 0x1667fffa212, 0x166820d2552, 0x68a9da6e1d90858d, 0xc420724efc, 0x3, 0x1667fffa212, 0x166820d2552, ...)
    /go/src/github.com/cortexproject/cortex/pkg/chunk/series_store.go:329 +0x1a4
github.com/cortexproject/cortex/pkg/chunk.compositeStore.Put.func1(0x1667fffa212, 0x166820d2552, 0x11c07a0, 0xc42074c000, 0x0, 0x1a0)
    /go/src/github.com/cortexproject/cortex/pkg/chunk/composite_store.go:188 +0x91
github.com/cortexproject/cortex/pkg/chunk.compositeStore.forStores(0xc42088a360, 0x4, 0x4, 0x1667fffa212, 0x166820d2552, 0xc44e837b08, 0x11, 0xc44e837cc0)
    /go/src/github.com/cortexproject/cortex/pkg/chunk/composite_store.go:265 +0x1de
github.com/cortexproject/cortex/pkg/chunk.compositeStore.Put(0xc42088a360, 0x4, 0x4, 0x11c05a0, 0xc51b5758c0, 0xc7e6bd2540, 0x1, 0x1, 0x0, 0x11c05a0)
    /go/src/github.com/cortexproject/cortex/pkg/chunk/composite_store.go:187 +0x131
github.com/cortexproject/cortex/pkg/ingester.(*Ingester).flushChunks(0xc42033fb80, 0x7f3b65e5c6b0, 0xc51b5758c0, 0x68a9da6e1d90858d, 0xc70f9faf60, 0xc5de36f718, 0x1, 0x1, 0x40ce34, 0xc44e837ef8)
    /go/src/github.com/cortexproject/cortex/pkg/ingester/flush.go:283 +0x33d
github.com/cortexproject/cortex/pkg/ingester.(*Ingester).flushUserSeries(0xc42033fb80, 0x17, 0xc420724efc, 0x3, 0x68a9da6e1d90858d, 0x0, 0x0, 0x0)
    /go/src/github.com/cortexproject/cortex/pkg/ingester/flush.go:253 +0x73e
github.com/cortexproject/cortex/pkg/ingester.(*Ingester).flushLoop(0xc42033fb80, 0x17)
    /go/src/github.com/cortexproject/cortex/pkg/ingester/flush.go:198 +0xec
created by github.com/cortexproject/cortex/pkg/ingester.New
    /go/src/github.com/cortexproject/cortex/pkg/ingester/ingester.go:190 +0x3a5
```


The documentation for SpanFromContext:
```
// SpanFromContext returns the `Span` previously associated with `ctx`, or
// `nil` if no such `Span` could be found.
```

I think the best solution would be to check: `if sp != nil` everytime we try to access the span but this should cover all the in the current codebase.