### PR TITLE
Improve `unauthenticated` mode in cortex-lite for devbox use 

### DIFF
--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -198,7 +198,7 @@ func main() {
 		middleware.Func(func(handler http.Handler) http.Handler {
 			return nethttp.Middleware(opentracing.GlobalTracer(), handler, operationNameFunc)
 		}),
-		middleware.AuthenticateUser,
+		activeMiddleware,
 	).Wrap(http.HandlerFunc(dist.PushHandler)))
 	server.Run()
 }


### PR DESCRIPTION
Sets the middleware for /api/prom/push in cortex-lite to the middleware enabled by the `unauthenticated` command flag. Fixes #1087

Signed-off-by: Ken Haines <khaines@ea.com>