### PR TITLE
Apply jitter to chunk ages so the queue doesn't jump instantly

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -85,6 +85,7 @@ type Config struct {
 	MaxChunkIdle      time.Duration
 	FlushOpTimeout    time.Duration
 	MaxChunkAge       time.Duration
+	ChunkAgeJitter    time.Duration
 	ConcurrentFlushes int
 	ChunkEncoding     string
 
@@ -104,6 +105,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.FlushOpTimeout, "ingester.flush-op-timeout", 1*time.Minute, "Timeout for individual flush operations.")
 	f.DurationVar(&cfg.MaxChunkIdle, "ingester.max-chunk-idle", 5*time.Minute, "Maximum chunk idle time before flushing.")
 	f.DurationVar(&cfg.MaxChunkAge, "ingester.max-chunk-age", 12*time.Hour, "Maximum chunk age before flushing.")
+	f.DurationVar(&cfg.ChunkAgeJitter, "ingester.chunk-age-jitter", 20*time.Minute, "Range of time to subtract from MaxChunkAge to spread out flushes")
 	f.IntVar(&cfg.ConcurrentFlushes, "ingester.concurrent-flushes", 50, "Number of concurrent goroutines flushing to dynamodb.")
 	f.StringVar(&cfg.ChunkEncoding, "ingester.chunk-encoding", "1", "Encoding version to use for chunks.")
 	f.DurationVar(&cfg.RateUpdatePeriod, "ingester.rate-update-period", 15*time.Second, "Period with which to update the per-user ingestion rates.")


### PR DESCRIPTION
When there are a lot of timeseries that go on for days, all of them will age out at around the same time, 12 hours after the ingester started.

This change smears out that timing, using the series fingerprint as a handy random number, so the effect isn't so pronounced.  At the cost of slightly more chunks saved.
