### PR TITLE
Fix panic while exiting ingester.

### DIFF
--- a/pkg/chunk/cache/background.go
+++ b/pkg/chunk/cache/background.go
@@ -74,6 +74,11 @@ func NewBackground(name string, cfg BackgroundConfig, cache Cache) Cache {
 
 // Stop the background flushing goroutines.
 func (c *backgroundCache) Stop() error {
+	// If we already Stopped, we should just no-op.
+	if c.quit == nil {
+		return nil
+	}
+
 	close(c.quit)
 	c.wg.Wait()
 


### PR DESCRIPTION
We should be able to call Stop() multiple times without erroring.

Fixes https://github.com/cortexproject/cortex/issues/1085