### PR TITLE
Move capacity info from PeriodicTableConfig to TableManagerConfig

### DIFF
--- a/cmd/table-manager/main.go
+++ b/cmd/table-manager/main.go
@@ -42,10 +42,10 @@ func main() {
 	// Assume the newest config is the one to use
 	lastConfig := &schemaConfig.Configs[len(schemaConfig.Configs)-1]
 
-	if (lastConfig.ChunkTables.WriteScale.Enabled ||
-		lastConfig.IndexTables.WriteScale.Enabled ||
-		lastConfig.ChunkTables.InactiveWriteScale.Enabled ||
-		lastConfig.IndexTables.InactiveWriteScale.Enabled) &&
+	if (tbmConfig.ChunkTables.WriteScale.Enabled ||
+		tbmConfig.IndexTables.WriteScale.Enabled ||
+		tbmConfig.ChunkTables.InactiveWriteScale.Enabled ||
+		tbmConfig.IndexTables.InactiveWriteScale.Enabled) &&
 		(storageConfig.AWSStorageConfig.ApplicationAutoScaling.URL == nil && storageConfig.AWSStorageConfig.Metrics.URL == "") {
 		level.Error(util.Logger).Log("msg", "WriteScale is enabled but no ApplicationAutoScaling or Metrics URL has been provided")
 		os.Exit(1)

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -42,20 +42,20 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 			{
 				Store: "aws-dynamo",
 				IndexTables: chunk.PeriodicTableConfig{
-					Prefix:                  "a",
-					InactiveReadThroughput:  inactiveRead,
-					InactiveWriteThroughput: inactiveWrite,
+					Prefix: "a",
 				},
 			},
 			{
 				Store:       "aws-dynamo",
-				IndexTables: fixturePeriodicTableConfig(tablePrefix, 2, indexWriteScale, inactiveWriteScale),
-				ChunkTables: fixturePeriodicTableConfig(chunkTablePrefix, 2, chunkWriteScale, inactiveWriteScale),
+				IndexTables: fixturePeriodicTableConfig(tablePrefix),
+				ChunkTables: fixturePeriodicTableConfig(chunkTablePrefix),
 			},
 		},
 	}
 	tbm := chunk.TableManagerConfig{
 		CreationGracePeriod: gracePeriod,
+		IndexTables:         fixtureProvisionConfig(2, indexWriteScale, inactiveWriteScale),
+		ChunkTables:         fixtureProvisionConfig(2, chunkWriteScale, inactiveWriteScale),
 	}
 
 	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client)

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -119,12 +119,6 @@ func TestTableManager(t *testing.T) {
 				From: model.TimeFromUnix(baseTableStart.Unix()),
 				IndexTables: PeriodicTableConfig{
 					Prefix: baseTableName,
-					ProvisionedWriteThroughput: write,
-					ProvisionedReadThroughput:  read,
-					InactiveWriteThroughput:    inactiveWrite,
-					InactiveReadThroughput:     inactiveRead,
-					WriteScale:                 activeScalingConfig,
-					InactiveWriteScale:         inactiveScalingConfig,
 				},
 			},
 			{
@@ -132,22 +126,11 @@ func TestTableManager(t *testing.T) {
 				IndexTables: PeriodicTableConfig{
 					Prefix: tablePrefix,
 					Period: tablePeriod,
-					ProvisionedWriteThroughput: write,
-					ProvisionedReadThroughput:  read,
-					InactiveWriteThroughput:    inactiveWrite,
-					InactiveReadThroughput:     inactiveRead,
-					WriteScale:                 activeScalingConfig,
-					InactiveWriteScale:         inactiveScalingConfig,
-					InactiveWriteScaleLastN:    autoScaleLastN,
 				},
 
 				ChunkTables: PeriodicTableConfig{
 					Prefix: chunkTablePrefix,
 					Period: tablePeriod,
-					ProvisionedWriteThroughput: write,
-					ProvisionedReadThroughput:  read,
-					InactiveWriteThroughput:    inactiveWrite,
-					InactiveReadThroughput:     inactiveRead,
 				},
 			},
 			{
@@ -155,28 +138,32 @@ func TestTableManager(t *testing.T) {
 				IndexTables: PeriodicTableConfig{
 					Prefix: table2Prefix,
 					Period: tablePeriod,
-					ProvisionedWriteThroughput: write,
-					ProvisionedReadThroughput:  read,
-					InactiveWriteThroughput:    inactiveWrite,
-					InactiveReadThroughput:     inactiveRead,
-					WriteScale:                 activeScalingConfig,
-					InactiveWriteScale:         inactiveScalingConfig,
-					InactiveWriteScaleLastN:    autoScaleLastN,
 				},
 
 				ChunkTables: PeriodicTableConfig{
 					Prefix: chunkTable2Prefix,
 					Period: tablePeriod,
-					ProvisionedWriteThroughput: write,
-					ProvisionedReadThroughput:  read,
-					InactiveWriteThroughput:    inactiveWrite,
-					InactiveReadThroughput:     inactiveRead,
 				},
 			},
 		},
 	}
 	tbmConfig := TableManagerConfig{
 		CreationGracePeriod: gracePeriod,
+		IndexTables: ProvisionConfig{
+			ProvisionedWriteThroughput: write,
+			ProvisionedReadThroughput:  read,
+			InactiveWriteThroughput:    inactiveWrite,
+			InactiveReadThroughput:     inactiveRead,
+			WriteScale:                 activeScalingConfig,
+			InactiveWriteScale:         inactiveScalingConfig,
+			InactiveWriteScaleLastN:    autoScaleLastN,
+		},
+		ChunkTables: ProvisionConfig{
+			ProvisionedWriteThroughput: write,
+			ProvisionedReadThroughput:  read,
+			InactiveWriteThroughput:    inactiveWrite,
+			InactiveReadThroughput:     inactiveRead,
+		},
 	}
 	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client)
 	if err != nil {
@@ -315,11 +302,6 @@ func TestTableManagerAutoscaleInactiveOnly(t *testing.T) {
 				From: model.TimeFromUnix(baseTableStart.Unix()),
 				IndexTables: PeriodicTableConfig{
 					Prefix: baseTableName,
-					ProvisionedWriteThroughput: write,
-					ProvisionedReadThroughput:  read,
-					InactiveWriteThroughput:    inactiveWrite,
-					InactiveReadThroughput:     inactiveRead,
-					InactiveWriteScale:         inactiveScalingConfig,
 				},
 			},
 			{
@@ -327,27 +309,31 @@ func TestTableManagerAutoscaleInactiveOnly(t *testing.T) {
 				IndexTables: PeriodicTableConfig{
 					Prefix: tablePrefix,
 					Period: tablePeriod,
-					ProvisionedWriteThroughput: write,
-					ProvisionedReadThroughput:  read,
-					InactiveWriteThroughput:    inactiveWrite,
-					InactiveReadThroughput:     inactiveRead,
-					InactiveWriteScale:         inactiveScalingConfig,
-					InactiveWriteScaleLastN:    autoScaleLastN,
 				},
 
 				ChunkTables: PeriodicTableConfig{
 					Prefix: chunkTablePrefix,
 					Period: tablePeriod,
-					ProvisionedWriteThroughput: write,
-					ProvisionedReadThroughput:  read,
-					InactiveWriteThroughput:    inactiveWrite,
-					InactiveReadThroughput:     inactiveRead,
 				},
 			},
 		},
 	}
 	tbmConfig := TableManagerConfig{
 		CreationGracePeriod: gracePeriod,
+		IndexTables: ProvisionConfig{
+			ProvisionedWriteThroughput: write,
+			ProvisionedReadThroughput:  read,
+			InactiveWriteThroughput:    inactiveWrite,
+			InactiveReadThroughput:     inactiveRead,
+			InactiveWriteScale:         inactiveScalingConfig,
+			InactiveWriteScaleLastN:    autoScaleLastN,
+		},
+		ChunkTables: ProvisionConfig{
+			ProvisionedWriteThroughput: write,
+			ProvisionedReadThroughput:  read,
+			InactiveWriteThroughput:    inactiveWrite,
+			InactiveReadThroughput:     inactiveRead,
+		},
 	}
 	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client)
 	if err != nil {


### PR DESCRIPTION
Having it configurable on every different section of the yaml config is too much - this change takes it out of the yaml completely, and there are just one set of command-line parameters.
