### PR TITLE
Periodically clear out limiters in the distributor.

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -64,7 +64,7 @@ Valid fields are (with their corresponding flags for default values):
 
   The per-tenant rate limit (and burst size), in samples per second. Enforced on a per distributor basis, actual effective rate limit will be N times higher, where N is the number of distributor replicas.
 
-  **NB** Changing these values currently require restarting the distributor.
+  **NB** Limits are reset every `-distributor.limiter-reload-period`, as such if you set a very high burst limit it will never be hit.
 
 - `max_label_name_length` / `-validation.max-length-label-name`
 - `max_label_value_length` / `-validation.max-length-label-value`

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -93,6 +93,7 @@ type Distributor struct {
 	// Per-user rate limiters.
 	ingestLimitersMtx sync.RWMutex
 	ingestLimiters    map[string]*rate.Limiter
+	quit              chan struct{}
 }
 
 // Config contains the configuration require to
@@ -102,8 +103,9 @@ type Config struct {
 	BillingConfig billing.Config
 	PoolConfig    ingester_client.PoolConfig
 
-	RemoteTimeout   time.Duration
-	ExtraQueryDelay time.Duration
+	RemoteTimeout       time.Duration
+	ExtraQueryDelay     time.Duration
+	LimiterReloadPeriod time.Duration
 
 	ShardByAllLabels bool
 
@@ -119,6 +121,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.EnableBilling, "distributor.enable-billing", false, "Report number of ingested samples to billing system.")
 	f.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")
 	f.DurationVar(&cfg.ExtraQueryDelay, "distributor.extra-query-delay", 0, "Time to wait before sending more than the minimum successful query requests.")
+	f.DurationVar(&cfg.LimiterReloadPeriod, "distributor.limiter-reload-period", 5*time.Minute, "Period at which to reload user ingestion limits.")
 	f.BoolVar(&cfg.ShardByAllLabels, "distributor.shard-by-all-labels", false, "Distribute samples based on all labels, as opposed to solely by user and metric name.")
 }
 
@@ -149,12 +152,38 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 		billingClient:  billingClient,
 		limits:         limits,
 		ingestLimiters: map[string]*rate.Limiter{},
+		quit:           make(chan struct{}),
 	}
+
+	go d.loop()
+
 	return d, nil
+}
+
+func (d *Distributor) loop() {
+	if d.cfg.LimiterReloadPeriod == 0 {
+		return
+	}
+
+	ticker := time.NewTicker(d.cfg.LimiterReloadPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			d.ingestLimitersMtx.Lock()
+			d.ingestLimiters = make(map[string]*rate.Limiter, len(d.ingestLimiters))
+			d.ingestLimitersMtx.Unlock()
+
+		case <-d.quit:
+			return
+		}
+	}
 }
 
 // Stop stops the distributor's maintenance loop.
 func (d *Distributor) Stop() {
+	close(d.quit)
 	d.limits.Stop()
 	d.ingesterPool.Stop()
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -38,7 +38,7 @@ type Limits struct {
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&l.IngestionRate, "distributor.ingestion-rate-limit", 25000, "Per-user ingestion rate limit in samples per second.")
-	f.IntVar(&l.IngestionBurstSize, "distributor.ingestion-burst-size", 50000, "Per-user allowed ingestion burst size (in number of samples).")
+	f.IntVar(&l.IngestionBurstSize, "distributor.ingestion-burst-size", 50000, "Per-user allowed ingestion burst size (in number of samples). Warning, very high limits will be reset every -distributor.limiter-reload-period.")
 	f.IntVar(&l.MaxLabelNameLength, "validation.max-length-label-name", 1024, "Maximum length accepted for label names")
 	f.IntVar(&l.MaxLabelValueLength, "validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
 	f.IntVar(&l.MaxLabelNamesPerSeries, "validation.max-label-names-per-series", 30, "Maximum number of label names per series.")


### PR DESCRIPTION
Periodically clear out any cached ingestion rate limiters, such that updates to the overrides YAML take ~5mins to apply.

Fixes #1095