### PR TITLE
Yaml schema config dates in human-readable form

### DIFF
--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -53,7 +53,7 @@ func (c *CompositeStore) AddPeriod(storeCfg StoreConfig, cfg PeriodConfig, stora
 	if err != nil {
 		return err
 	}
-	c.stores = append(c.stores, compositeStoreEntry{start: cfg.From, Store: store})
+	c.stores = append(c.stores, compositeStoreEntry{start: model.TimeFromUnixNano(cfg.From.UnixNano()), Store: store})
 	return nil
 }
 


### PR DESCRIPTION
yyyy-mm-dd instead of Unix epoch milliseconds

This was noted as something I should do in #1072 