### PR TITLE
When we share a cache amongst multiple stores, ensure it is only stopped once.

### DIFF
--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -69,6 +69,9 @@ func NewDynamoDBTableClient(cfg DynamoDBConfig) (chunk.TableClient, error) {
 	}, nil
 }
 
+func (d *dynamoTableClient) Stop() {
+}
+
 func (d dynamoTableClient) backoffAndRetry(ctx context.Context, fn func(context.Context) error) error {
 	return d.callManager.backoffAndRetry(ctx, fn)
 }

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -165,6 +165,9 @@ func NewStorageClient(cfg DynamoDBConfig, schemaCfg chunk.SchemaConfig) (chunk.S
 	return client, nil
 }
 
+func (a storageClient) Stop() {
+}
+
 func (a storageClient) NewWriteBatch() chunk.WriteBatch {
 	return dynamoDBWriteBatch(map[string][]*dynamodb.WriteRequest{})
 }

--- a/pkg/chunk/aws/storage_client_s3.go
+++ b/pkg/chunk/aws/storage_client_s3.go
@@ -73,6 +73,9 @@ func NewS3StorageClient(cfg StorageConfig, schemaCfg chunk.SchemaConfig) (chunk.
 	return client, nil
 }
 
+func (a s3storageClient) Stop() {
+}
+
 func (a s3storageClient) GetChunks(ctx context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
 	sp, ctx := ot.StartSpanFromContext(ctx, "GetChunks.S3")
 	defer sp.Finish()

--- a/pkg/chunk/cache/stop_once.go
+++ b/pkg/chunk/cache/stop_once.go
@@ -1,0 +1,23 @@
+package cache
+
+import "sync"
+
+type stopOnce struct {
+	once sync.Once
+	Cache
+}
+
+// StopOnce wraps a Cache and ensures its only stopped once.
+func StopOnce(cache Cache) Cache {
+	return &stopOnce{
+		Cache: cache,
+	}
+}
+
+func (s *stopOnce) Stop() error {
+	var err error
+	s.once.Do(func() {
+		err = s.Cache.Stop()
+	})
+	return err
+}

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -138,7 +138,7 @@ func NewStorageClient(cfg Config, schemaCfg chunk.SchemaConfig) (chunk.StorageCl
 	}, nil
 }
 
-func (s *storageClient) Close() {
+func (s *storageClient) Stop() {
 	s.session.Close()
 }
 

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -102,6 +102,7 @@ func newStore(cfg StoreConfig, schema Schema, storage StorageClient, limits *val
 
 // Stop any background goroutines (ie in the cache.)
 func (c *store) Stop() {
+	c.storage.Stop()
 	c.Fetcher.Stop()
 }
 

--- a/pkg/chunk/gcp/storage_client.go
+++ b/pkg/chunk/gcp/storage_client.go
@@ -98,6 +98,10 @@ func newStorageClientColumnKey(cfg Config, client *bigtable.Client, schemaCfg ch
 	}
 }
 
+func (s *storageClientColumnKey) Stop() {
+	s.client.Close()
+}
+
 func (s *storageClientColumnKey) NewWriteBatch() chunk.WriteBatch {
 	return bigtableWriteBatch{
 		tables: map[string]map[string]*bigtable.Mutation{},

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -38,6 +38,10 @@ func NewMockStorage() *MockStorage {
 	}
 }
 
+// Stop doesn't do anything.
+func (*MockStorage) Stop() {
+}
+
 // ListTables implements StorageClient.
 func (m *MockStorage) ListTables(_ context.Context) ([]string, error) {
 	m.mtx.RLock()

--- a/pkg/chunk/storage/caching_storage_client.go
+++ b/pkg/chunk/storage/caching_storage_client.go
@@ -56,6 +56,10 @@ func newCachingStorageClient(client chunk.StorageClient, c cache.Cache, validity
 	}
 }
 
+func (s *cachingStorageClient) Stop() {
+	s.cache.Stop()
+}
+
 func (s *cachingStorageClient) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) (shouldContinue bool)) error {
 	// We cache the entire row, so filter client side.
 	callback = chunk_util.QueryFilter(callback)

--- a/pkg/chunk/storage/factory_test.go
+++ b/pkg/chunk/storage/factory_test.go
@@ -1,0 +1,41 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/validation"
+)
+
+func TestFactoryStop(t *testing.T) {
+	var (
+		cfg          Config
+		storeConfig  chunk.StoreConfig
+		schemaConfig chunk.SchemaConfig
+		defaults     validation.Limits
+	)
+	util.DefaultValues(&cfg, &storeConfig, &schemaConfig, &defaults)
+	schemaConfig.Configs = []chunk.PeriodConfig{
+		{
+			From:  model.Time(0),
+			Store: "inmemory",
+		},
+		{
+			From:  model.Time(1),
+			Store: "inmemory",
+		},
+	}
+	cfg.memcacheClient.Host = "localhost" // Fake address that should at least resolve.
+
+	limits, err := validation.NewOverrides(defaults)
+	require.NoError(t, err)
+
+	store, err := NewStore(cfg, storeConfig, schemaConfig, limits)
+	require.NoError(t, err)
+
+	store.Stop()
+}

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -4,6 +4,8 @@ import "context"
 
 // StorageClient is a client for the persistent storage for Cortex. (e.g. DynamoDB + S3).
 type StorageClient interface {
+	Stop()
+
 	// For the write path.
 	NewWriteBatch() WriteBatch
 	BatchWrite(context.Context, WriteBatch) error


### PR DESCRIPTION
Fixes #1085 

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>