### PR TITLE
fix cassandra storage test fixture, set a correct From parameter

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -523,7 +523,10 @@ func (a dynamoDBStorageClient) getDynamoDBChunks(ctx context.Context, chunks []c
 	for _, chunk := range chunks {
 		key := chunk.ExternalKey()
 		chunksByKey[key] = chunk
-		tableName := a.schemaCfg.ChunkTableFor(chunk.From)
+		tableName, err := a.schemaCfg.ChunkTableFor(chunk.From)
+		if err != nil {
+			return nil, err
+		}
 		outstanding.Add(tableName, key, placeholder)
 	}
 
@@ -646,7 +649,11 @@ func (a dynamoDBStorageClient) PutChunks(ctx context.Context, chunks []chunk.Chu
 		}
 		key := chunks[i].ExternalKey()
 
-		table := a.schemaCfg.ChunkTableFor(chunks[i].From)
+		table, err := a.schemaCfg.ChunkTableFor(chunks[i].From)
+		if err != nil {
+			return err
+		}
+
 		dynamoDBWrites.Add(table, key, placeholder, buf)
 	}
 

--- a/pkg/chunk/aws/dynamodb_storage_client_test.go
+++ b/pkg/chunk/aws/dynamodb_storage_client_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/common/model"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/chunk/testutils"
@@ -26,7 +28,7 @@ func TestChunksPartialError(t *testing.T) {
 	}
 	ctx := context.Background()
 	// Create more chunks than we can read in one batch
-	_, chunks, err := testutils.CreateChunks(0, dynamoDBMaxReadBatchSize+50)
+	_, chunks, err := testutils.CreateChunks(0, dynamoDBMaxReadBatchSize+50, model.Now())
 	require.NoError(t, err)
 	err = client.PutChunks(ctx, chunks)
 	require.NoError(t, err)

--- a/pkg/chunk/aws/fixtures.go
+++ b/pkg/chunk/aws/fixtures.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/testutils"
 	"github.com/cortexproject/cortex/pkg/util"
-	"github.com/prometheus/common/model"
 )
 
 type fixture struct {
@@ -32,7 +31,7 @@ var Fixtures = []testutils.Fixture{
 	fixture{
 		name: "S3 chunks",
 		clients: func() (chunk.IndexClient, chunk.ObjectClient, chunk.TableClient, chunk.SchemaConfig, error) {
-			schemaConfig := chunk.SchemaConfig{} // Defaults == S3
+			schemaConfig := testutils.DefaultSchemaConfig("s3")
 			dynamoDB := newMockDynamoDB(0, 0)
 			table := &dynamoTableClient{
 				DynamoDB: dynamoDB,
@@ -61,16 +60,7 @@ func dynamoDBFixture(provisionedErr, gangsize, maxParallelism int) testutils.Fix
 			provisionedErr, gangsize, maxParallelism),
 		clients: func() (chunk.IndexClient, chunk.ObjectClient, chunk.TableClient, chunk.SchemaConfig, error) {
 			dynamoDB := newMockDynamoDB(0, provisionedErr)
-			schemaCfg := chunk.SchemaConfig{
-				Configs: []chunk.PeriodConfig{{
-					IndexType: "aws",
-					From:      model.Now(),
-					ChunkTables: chunk.PeriodicTableConfig{
-						Prefix: "chunks",
-						Period: 10 * time.Minute,
-					},
-				}},
-			}
+			schemaCfg := testutils.DefaultSchemaConfig("aws")
 			table := &dynamoTableClient{
 				DynamoDB: dynamoDB,
 			}

--- a/pkg/chunk/cassandra/fixtures.go
+++ b/pkg/chunk/cassandra/fixtures.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/testutils"
-	"github.com/prometheus/common/model"
 )
 
 // GOCQL doesn't provide nice mocks, so we use a real Cassandra instance.
@@ -49,7 +48,7 @@ func Fixtures() ([]testutils.Fixture, error) {
 	}
 
 	// Get a SchemaConfig with the defaults.
-	schemaConfig := chunk.DefaultSchemaConfig("cassandra", "v1", model.Now())
+	schemaConfig := testutils.DefaultSchemaConfig("cassandra")
 
 	storageClient, err := NewStorageClient(cfg, schemaConfig)
 	if err != nil {

--- a/pkg/chunk/gcp/bigtable_object_client.go
+++ b/pkg/chunk/gcp/bigtable_object_client.go
@@ -52,7 +52,10 @@ func (s *bigtableObjectClient) PutChunks(ctx context.Context, chunks []chunk.Chu
 			return err
 		}
 		key := chunks[i].ExternalKey()
-		tableName := s.schemaCfg.ChunkTableFor(chunks[i].From)
+		tableName, err := s.schemaCfg.ChunkTableFor(chunks[i].From)
+		if err != nil {
+			return err
+		}
 		keys[tableName] = append(keys[tableName], key)
 
 		mut := bigtable.NewMutation()
@@ -83,7 +86,10 @@ func (s *bigtableObjectClient) GetChunks(ctx context.Context, input []chunk.Chun
 	chunks := map[string]map[string]chunk.Chunk{}
 	keys := map[string]bigtable.RowList{}
 	for _, c := range input {
-		tableName := s.schemaCfg.ChunkTableFor(c.From)
+		tableName, err := s.schemaCfg.ChunkTableFor(c.From)
+		if err != nil {
+			return nil, err
+		}
 		key := c.ExternalKey()
 		keys[tableName] = append(keys[tableName], key)
 		if _, ok := chunks[tableName]; !ok {

--- a/pkg/chunk/gcp/fixtures.go
+++ b/pkg/chunk/gcp/fixtures.go
@@ -2,12 +2,10 @@ package gcp
 
 import (
 	"context"
-	"time"
 
 	"cloud.google.com/go/bigtable"
 	"cloud.google.com/go/bigtable/bttest"
 	"github.com/fsouza/fake-gcs-server/fakestorage"
-	"github.com/prometheus/common/model"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 
@@ -56,16 +54,7 @@ func (f *fixture) Clients() (
 		return
 	}
 
-	schemaConfig = chunk.SchemaConfig{
-		Configs: []chunk.PeriodConfig{{
-			IndexType: "gcp",
-			From:      model.Now(),
-			ChunkTables: chunk.PeriodicTableConfig{
-				Prefix: "chunks",
-				Period: 10 * time.Minute,
-			},
-		}},
-	}
+	schemaConfig = testutils.DefaultSchemaConfig("gcp-columnkey")
 	tClient = &tableClient{
 		client: adminClient,
 	}

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -422,13 +422,13 @@ func (cfg *PeriodicTableConfig) periodicTables(from, through model.Time, pCfg Pr
 }
 
 // ChunkTableFor calculates the chunk table shard for a given point in time.
-func (cfg SchemaConfig) ChunkTableFor(t model.Time) string {
+func (cfg SchemaConfig) ChunkTableFor(t model.Time) (string, error) {
 	for i := range cfg.Configs {
 		if t > cfg.Configs[i].From && (i+1 == len(cfg.Configs) || t < cfg.Configs[i+1].From) {
-			return cfg.Configs[i].ChunkTables.TableFor(t)
+			return cfg.Configs[i].ChunkTables.TableFor(t), nil
 		}
 	}
-	return ""
+	return "", fmt.Errorf("no chunk table found for time %v", t)
 }
 
 // TableFor calculates the table shard for a given point in time.

--- a/pkg/chunk/storage/object_client_test.go
+++ b/pkg/chunk/storage/object_client_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/testutils"
+	"github.com/prometheus/common/model"
 )
 
 func TestChunksBasic(t *testing.T) {
@@ -23,7 +24,7 @@ func TestChunksBasic(t *testing.T) {
 		// Write a few batches of chunks.
 		written := []string{}
 		for i := 0; i < 5; i++ {
-			keys, chunks, err := testutils.CreateChunks(i, batchSize)
+			keys, chunks, err := testutils.CreateChunks(i, batchSize, model.Now())
 			require.NoError(t, err)
 			written = append(written, keys...)
 			err = client.PutChunks(ctx, chunks)

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -23,6 +23,12 @@ type Fixture interface {
 	Teardown() error
 }
 
+// DefaultSchemaConfig returns default schema for use in test fixtures
+func DefaultSchemaConfig(kind string) chunk.SchemaConfig {
+	schemaConfig := chunk.DefaultSchemaConfig(kind, "v1", model.Now().Add(-time.Hour*2))
+	return schemaConfig
+}
+
 // Setup a fixture with initial tables
 func Setup(fixture Fixture, tableName string) (chunk.IndexClient, chunk.ObjectClient, error) {
 	var tbmConfig chunk.TableManagerConfig
@@ -49,11 +55,11 @@ func Setup(fixture Fixture, tableName string) (chunk.IndexClient, chunk.ObjectCl
 }
 
 // CreateChunks creates some chunks for testing
-func CreateChunks(startIndex, batchSize int) ([]string, []chunk.Chunk, error) {
+func CreateChunks(startIndex, batchSize int, start model.Time) ([]string, []chunk.Chunk, error) {
 	keys := []string{}
 	chunks := []chunk.Chunk{}
 	for j := 0; j < batchSize; j++ {
-		chunk := dummyChunkFor(model.Now(), model.Metric{
+		chunk := dummyChunkFor(start, model.Metric{
 			model.MetricNameLabel: "foo",
 			"index":               model.LabelValue(strconv.Itoa(startIndex*batchSize + j)),
 		})


### PR DESCRIPTION
The current cassandra fixture is causing cassandra storage tests to fail. The schema is being set to current time but the chunks used in the test have a start timestamp of current time minus an hour. This commit updates the cassandra fixture to use a schema with an acceptable timestamp.
Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>