### PR TITLE
Batch reading, writing and deleting of chunks

### DIFF
--- a/cmd/scanner/Dockerfile
+++ b/cmd/scanner/Dockerfile
@@ -1,0 +1,10 @@
+FROM       alpine:3.8
+RUN        apk add --no-cache ca-certificates
+COPY       scanner /bin/scanner
+EXPOSE     6060
+ENTRYPOINT [ "/bin/scanner" ]
+
+ARG revision
+LABEL org.opencontainers.image.title="scanner" \
+      org.opencontainers.image.source="https://github.com/bboreham/cortex/tree/master/cmd/querier" \
+      org.opencontainers.image.revision="${revision}"

--- a/cmd/scanner/job.yaml
+++ b/cmd/scanner/job.yaml
@@ -1,0 +1,62 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+  labels:
+    job-name: bryan-dynamodb-scanner
+    name: bryan-dynamodb-scanner
+  name: bryan-dynamodb-scanner
+  namespace: cortex
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        name: bryan-dynamodb-scanner
+    spec:
+      containers:
+      - args:
+        - -week=2498
+        - -delete-orgs-file=/config/delete-orgs
+        - -segments=64
+        - -writers=16
+        - -writer-rate-limit=400
+        - -dynamodb.url=dynamodb://us-east-1/
+        - -dynamodb.chunk-table.from=2017-05-19
+        - -dynamodb.chunk-table.prefix=prod_chunk_data_weekly_
+        - -s3.url=s3://not:used@xxxxxxxx:0
+        - -dynamodb.reindex-prefix=prod_chunk_index_
+        - -dynamodb.rechunk-prefix=prod_chunk_data_
+        - -dynamodb.use-periodic-tables=true
+        - -dynamodb.v9-schema-from=2017-01-10
+        - -memcache.write-back-goroutines=1
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          value: "redacted"
+        - name: AWS_SECRET_ACCESS_KEY
+          value: "redacted"
+        - name: AWS_SESSION_TOKEN
+          value: "redacted"
+        image: quay.io/weaveworks/cortex-scanner:dynamodb-scanning-6ed98674
+        imagePullPolicy: Always
+        name: scanner
+        ports:
+        - containerPort: 6060
+          protocol: TCP
+        resources:
+          requests:
+            cpu: "4"
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config-volume
+      imagePullSecrets:
+      - name: quay-secret
+      restartPolicy: Never
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: prune-config
+        name: config-volume

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/model"
 
 	"github.com/go-kit/kit/log/level"
@@ -44,7 +45,7 @@ func main() {
 	)
 
 	util.RegisterFlags(&storageConfig, &schemaConfig, &chunkStoreConfig)
-	flag.StringVar(&address, "address", "localhost:6060", "Address to listen on, for profiling, etc.")
+	flag.StringVar(&address, "address", ":6060", "Address to listen on, for profiling, etc.")
 	flag.Int64Var(&week, "week", 0, "Week number to scan, e.g. 2497 (0 means current week)")
 	flag.IntVar(&segments, "segments", 1, "Number of segments to read in parallel")
 	flag.StringVar(&orgsFile, "delete-orgs-file", "", "File containing IDs of orgs to delete")
@@ -60,6 +61,7 @@ func main() {
 
 	// HTTP listener for profiling
 	go func() {
+		http.Handle("/metrics", promhttp.Handler())
 		checkFatal(http.ListenAndServe(address, nil))
 	}()
 

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/common/model"
+
 	"github.com/go-kit/kit/log/level"
 	"github.com/weaveworks/common/logging"
 
@@ -103,7 +105,8 @@ func main() {
 		callbacks[segment] = handlers[segment].handlePage
 	}
 
-	err = storageClient.ScanTable(context.Background(), tableName, reindexTablePrefix != "", callbacks)
+	tableTime := model.TimeFromUnix(int64(week) * 7 * 24 * 3600)
+	err = chunkStore.Scan(context.Background(), tableTime, reindexTablePrefix != "", callbacks)
 	checkFatal(err)
 
 	if reindexStore != nil {

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -86,7 +86,7 @@ func main() {
 		callbacks[segment] = handler.handlePage
 	}
 
-	err = storageClient.ScanTable(context.Background(), tableName, callbacks)
+	err = storageClient.ScanTable(context.Background(), tableName, false, callbacks)
 	checkFatal(err)
 }
 

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -9,15 +10,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/go-kit/kit/log/level"
-	awscommon "github.com/weaveworks/common/aws"
 	"github.com/weaveworks/common/logging"
 
 	"github.com/weaveworks/cortex/pkg/chunk"
@@ -25,44 +20,29 @@ import (
 	"github.com/weaveworks/cortex/pkg/util"
 )
 
-type scanner struct {
-	week            int
-	segments        int
-	deleters        int
-	deleteBatchSize int
-	tableName       string
-	address         string
-
-	dynamoDB *dynamodb.DynamoDB
-
-	// Readers send items on this chan to be deleted
-	delete chan map[string]*dynamodb.AttributeValue
-	retry  chan map[string]*dynamodb.AttributeValue
-	// Deleters read batches of items from this chan
-	batched chan []*dynamodb.WriteRequest
-}
-
 var (
 	pagesPerDot int
 )
 
 func main() {
 	var (
+		writerConfig  chunk.WriterConfig
 		schemaConfig  chunk.SchemaConfig
 		storageConfig storage.Config
 
 		orgsFile string
 
-		scanner  scanner
-		loglevel string
+		week      int
+		segments  int
+		tableName string
+		loglevel  string
+		address   string
 	)
 
-	util.RegisterFlags(&storageConfig, &schemaConfig)
-	flag.IntVar(&scanner.week, "week", 0, "Week number to scan, e.g. 2497 (0 means current week)")
-	flag.IntVar(&scanner.segments, "segments", 1, "Number of segments to run in parallel")
-	flag.IntVar(&scanner.deleters, "deleters", 1, "Number of deleters to run in parallel")
-	flag.IntVar(&scanner.deleteBatchSize, "delete-batch-size", 25, "Number of delete requests to batch up")
-	flag.StringVar(&scanner.address, "address", "localhost:6060", "Address to listen on, for profiling, etc.")
+	util.RegisterFlags(&writerConfig, &storageConfig, &schemaConfig)
+	flag.StringVar(&address, "address", "localhost:6060", "Address to listen on, for profiling, etc.")
+	flag.IntVar(&week, "week", 0, "Week number to scan, e.g. 2497 (0 means current week)")
+	flag.IntVar(&segments, "segments", 1, "Number of segments to read in parallel")
 	flag.StringVar(&orgsFile, "delete-orgs-file", "", "File containing IDs of orgs to delete")
 	flag.StringVar(&loglevel, "log-level", "info", "Debug level: debug, info, warning, error")
 	flag.IntVar(&pagesPerDot, "pages-per-dot", 10, "Print a dot per N pages in DynamoDB (0 to disable)")
@@ -75,7 +55,7 @@ func main() {
 
 	// HTTP listener for profiling
 	go func() {
-		checkFatal(http.ListenAndServe(scanner.address, nil))
+		checkFatal(http.ListenAndServe(address, nil))
 	}()
 
 	orgs := map[int]struct{}{}
@@ -89,92 +69,28 @@ func main() {
 		}
 	}
 
-	if scanner.week == 0 {
-		scanner.week = int(time.Now().Unix() / int64(7*24*time.Hour/time.Second))
+	if week == 0 {
+		week = int(time.Now().Unix() / int64(7*24*time.Hour/time.Second))
 	}
 
-	config, err := awscommon.ConfigFromURL(storageConfig.AWSStorageConfig.DynamoDB.URL)
+	storageOpts, err := storage.Opts(storageConfig, schemaConfig)
 	checkFatal(err)
-	session := session.New(config)
-	scanner.dynamoDB = dynamodb.New(session)
+	writer := chunk.NewWriter(writerConfig, storageClient)
 
-	scanner.tableName = fmt.Sprintf("%s%d", schemaConfig.ChunkTables.Prefix, scanner.week)
-	fmt.Printf("table %s\n", scanner.tableName)
+	tableName = fmt.Sprintf("%s%d", schemaConfig.ChunkTables.Prefix, week)
+	fmt.Printf("table %s\n", tableName)
 
-	// Unbuffered chan so we can tell when batcher has received all items
-	scanner.delete = make(chan map[string]*dynamodb.AttributeValue)
-	scanner.retry = make(chan map[string]*dynamodb.AttributeValue, 100)
-	scanner.batched = make(chan []*dynamodb.WriteRequest)
-
-	var deleteGroup sync.WaitGroup
-	deleteGroup.Add(1 + scanner.deleters)
-	var pending sync.WaitGroup
-	go func() {
-		scanner.batcher(&pending)
-		deleteGroup.Done()
-	}()
-	for i := 0; i < scanner.deleters; i++ {
-		go func() {
-			scanner.deleteLoop(&pending)
-			deleteGroup.Done()
-		}()
+	callbacks := make([]func(result chunk.ReadBatch), segments)
+	for segment := 0; segment < segments; segment++ {
+		handler := newHandler(storageClient, tableName, orgs, writer.Write)
+		callbacks[segment] = handler.handlePage
 	}
 
-	var readerGroup sync.WaitGroup
-	readerGroup.Add(scanner.segments)
-	totals := newSummary()
-	var totalsMutex sync.Mutex
-
-	for segment := 0; segment < scanner.segments; segment++ {
-		go func(segment int) {
-			handler := newHandler(orgs)
-			handler.requests = scanner.delete
-			err := scanner.segmentScan(segment, handler)
-			checkFatal(err)
-			totalsMutex.Lock()
-			totals.accumulate(handler.summary)
-			totalsMutex.Unlock()
-			readerGroup.Done()
-		}(segment)
-	}
-	// Wait until all reader segments have finished
-	readerGroup.Wait()
-	// Ensure that batcher has received all items so it won't call Add() any more
-	scanner.delete <- nil
-	// Wait for pending items to be sent to DynamoDB
-	pending.Wait()
-	// Close chans to signal deleter(s) and batcher to terminate
-	close(scanner.batched)
-	close(scanner.retry)
-	deleteGroup.Wait()
-
-	fmt.Printf("\n")
-	totals.print()
-}
-
-func (sc *scanner) segmentScan(segment int, handler handler) error {
-	input := &dynamodb.ScanInput{
-		TableName:            aws.String(sc.tableName),
-		ProjectionExpression: aws.String(hashKey + "," + rangeKey),
-		Segment:              aws.Int64(int64(segment)),
-		TotalSegments:        aws.Int64(int64(sc.segments)),
-		//ReturnConsumedCapacity: aws.String(dynamodb.ReturnConsumedCapacityTotal),
-	}
-
-	err := sc.dynamoDB.ScanPages(input, handler.handlePage)
-	if err != nil {
-		return err
-	}
-	return nil
+	err = storageClient.ScanTable(context.Background(), tableName, callbacks)
+	checkFatal(err)
 }
 
 /* TODO: delete v8 schema rows for all instances */
-
-const (
-	hashKey  = "h"
-	rangeKey = "r"
-	valueKey = "c"
-)
 
 type summary struct {
 	counts map[int]int
@@ -199,145 +115,47 @@ func (s summary) print() {
 }
 
 type handler struct {
-	pages    int
-	orgs     map[int]struct{}
-	requests chan map[string]*dynamodb.AttributeValue
+	storageClient chunk.StorageClient
+	tableName     string
+	pages         int
+	orgs          map[int]struct{}
+	requests      chan chunk.WriteBatch
 	summary
 }
 
-func newHandler(orgs map[int]struct{}) handler {
+func newHandler(storageClient chunk.StorageClient, tableName string, orgs map[int]struct{}, requests chan chunk.WriteBatch) handler {
 	return handler{
-		orgs:    orgs,
-		summary: newSummary(),
+		storageClient: storageClient,
+		tableName:     tableName,
+		orgs:          orgs,
+		summary:       newSummary(),
+		requests:      requests,
 	}
 }
 
-func (h *handler) handlePage(page *dynamodb.ScanOutput, lastPage bool) bool {
+func (h *handler) handlePage(page chunk.ReadBatch) {
 	h.pages++
 	if pagesPerDot > 0 && h.pages%pagesPerDot == 0 {
 		fmt.Printf(".")
 	}
-	for _, m := range page.Items {
-		org := orgFromHash(m[hashKey].S)
+	for i := 0; i < page.Len(); i++ {
+		hashValue := page.HashValue(i)
+		org := chunk.OrgFromHash(hashValue)
 		if org <= 0 {
 			continue
 		}
 		h.counts[org]++
 		if _, found := h.orgs[org]; found {
-			h.requests <- m // Send attributes to the chan
+			request := h.storageClient.NewWriteBatch()
+			request.AddDelete(h.tableName, hashValue, page.RangeValue(i))
+			h.requests <- request
 		}
 	}
-	return true
-}
-
-func orgFromHash(hashVal *string) int {
-	hashStr := aws.StringValue(hashVal)
-	if hashStr == "" {
-		return -1
-	}
-	pos := strings.Index(hashStr, "/")
-	if pos < 0 { // try index table format
-		pos = strings.Index(hashStr, ":")
-	}
-	if pos < 0 { // unrecognized format
-		return -1
-	}
-	org, err := strconv.Atoi(hashStr[:pos])
-	if err != nil {
-		return -1
-	}
-	return org
 }
 
 func checkFatal(err error) {
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "fatal error", "err", err)
 		os.Exit(1)
-	}
-}
-
-func throttled(err error) bool {
-	awsErr, ok := err.(awserr.Error)
-	return ok && (awsErr.Code() == dynamodb.ErrCodeProvisionedThroughputExceededException)
-}
-
-func (sc *scanner) deleteLoop(pending *sync.WaitGroup) {
-	for {
-		batch, ok := <-sc.batched
-		if !ok {
-			return
-		}
-		level.Debug(util.Logger).Log("msg", "about to delete", "num_requests", len(batch))
-		ret, err := sc.dynamoDB.BatchWriteItem(&dynamodb.BatchWriteItemInput{
-			RequestItems: map[string][]*dynamodb.WriteRequest{
-				sc.tableName: batch,
-			},
-		})
-		if err != nil {
-			if throttled(err) {
-				// Send the whole request back into the batcher
-				for _, item := range batch {
-					sc.retry <- item.DeleteRequest.Key
-				}
-			} else {
-				level.Error(util.Logger).Log("msg", "unable to delete", "err", err)
-				pending.Add(-len(batch))
-			}
-			continue
-		}
-		count := 0
-		// Send unprocessed items back into the batcher
-		for _, items := range ret.UnprocessedItems {
-			count += len(items)
-			for _, item := range items {
-				sc.retry <- item.DeleteRequest.Key
-			}
-		}
-		pending.Add(-(len(batch) - count))
-	}
-}
-
-// Receive individual requests, and batch them up into groups to send to DynamoDB
-func (sc *scanner) batcher(pending *sync.WaitGroup) {
-	finished := false
-	var requests []*dynamodb.WriteRequest
-	for {
-		// We will allow in new data if the queue isn't too long
-		var in chan map[string]*dynamodb.AttributeValue
-		if len(requests) < 1000 {
-			in = sc.delete
-		}
-		// We will send out a batch if the queue is big enough, or if we're finishing
-		var out chan []*dynamodb.WriteRequest
-		outlen := len(requests)
-		if len(requests) >= sc.deleteBatchSize {
-			out = sc.batched
-			outlen = sc.deleteBatchSize
-		} else if finished && len(requests) > 0 {
-			out = sc.batched
-		}
-		var keyMap map[string]*dynamodb.AttributeValue
-		var ok bool
-		select {
-		case keyMap = <-in:
-			if keyMap == nil { // Nil used as interlock to know we received all previous values
-				finished = true
-			} else {
-				pending.Add(1)
-			}
-		case keyMap, ok = <-sc.retry:
-			if !ok {
-				return
-			}
-		case out <- requests[:outlen]:
-			requests = requests[outlen:]
-		}
-		if keyMap != nil {
-			requests = append(requests, &dynamodb.WriteRequest{
-				DeleteRequest: &dynamodb.DeleteRequest{
-					Key: keyMap,
-				},
-			})
-		}
 	}
 }

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -31,6 +31,8 @@ var (
 		Name:      "pages_scanned_total",
 		Help:      "Total count of pages scanned from a table",
 	}, []string{"table"})
+
+	reEncodeChunks bool
 )
 
 func main() {
@@ -39,7 +41,8 @@ func main() {
 		storageConfig    storage.Config
 		chunkStoreConfig chunk.StoreConfig
 
-		orgsFile string
+		deleteOrgsFile string
+		includeOrgsStr string
 
 		week      int64
 		segments  int
@@ -55,10 +58,12 @@ func main() {
 	flag.StringVar(&address, "address", ":6060", "Address to listen on, for profiling, etc.")
 	flag.Int64Var(&week, "week", 0, "Week number to scan, e.g. 2497 (0 means current week)")
 	flag.IntVar(&segments, "segments", 1, "Number of segments to read in parallel")
-	flag.StringVar(&orgsFile, "delete-orgs-file", "", "File containing IDs of orgs to delete")
+	flag.StringVar(&deleteOrgsFile, "delete-orgs-file", "", "File containing IDs of orgs to delete")
+	flag.StringVar(&includeOrgsStr, "include-orgs", "", "IDs of orgs to include (space-separated)")
 	flag.StringVar(&loglevel, "log-level", "info", "Debug level: debug, info, warning, error")
 	flag.StringVar(&rechunkTablePrefix, "dynamodb.rechunk-prefix", "", "Prefix of new chunk table (blank to disable)")
 	flag.StringVar(&reindexTablePrefix, "dynamodb.reindex-prefix", "", "Prefix of new index table (blank to disable)")
+	flag.BoolVar(&reEncodeChunks, "re-encode-chunks", false, "Enable re-encoding of chunks to save on storing zeros")
 
 	flag.Parse()
 
@@ -72,14 +77,23 @@ func main() {
 		checkFatal(http.ListenAndServe(address, nil))
 	}()
 
-	orgs := map[int]struct{}{}
-	if orgsFile != "" {
-		content, err := ioutil.ReadFile(orgsFile)
+	deleteOrgs := map[int]struct{}{}
+	if deleteOrgsFile != "" {
+		content, err := ioutil.ReadFile(deleteOrgsFile)
 		checkFatal(err)
 		for _, arg := range strings.Fields(string(content)) {
 			org, err := strconv.Atoi(arg)
 			checkFatal(err)
-			orgs[org] = struct{}{}
+			deleteOrgs[org] = struct{}{}
+		}
+	}
+
+	includeOrgs := map[int]struct{}{}
+	if includeOrgsStr != "" {
+		for _, arg := range strings.Fields(includeOrgsStr) {
+			org, err := strconv.Atoi(arg)
+			checkFatal(err)
+			includeOrgs[org] = struct{}{}
 		}
 	}
 
@@ -111,7 +125,7 @@ func main() {
 	handlers := make([]handler, segments)
 	callbacks := make([]func(result chunk.ReadBatch), segments)
 	for segment := 0; segment < segments; segment++ {
-		handlers[segment] = newHandler(reindexStore, rechunkTablePrefix, reindexTablePrefix, orgs)
+		handlers[segment] = newHandler(reindexStore, rechunkTablePrefix, reindexTablePrefix, includeOrgs, deleteOrgs)
 		callbacks[segment] = handlers[segment].handlePage
 	}
 
@@ -127,30 +141,42 @@ func main() {
 	for segment := 0; segment < segments; segment++ {
 		totals.accumulate(handlers[segment].summary)
 	}
-	totals.print()
+	totals.print(deleteOrgs)
 }
 
 /* TODO: delete v8 schema rows for all instances */
 
 type summary struct {
-	counts map[int]int
+	// Map from instance to (metric->count)
+	counts map[int]map[string]int
 }
 
 func newSummary() summary {
 	return summary{
-		counts: map[int]int{},
+		counts: map[int]map[string]int{},
 	}
 }
 
 func (s *summary) accumulate(b summary) {
-	for k, v := range b.counts {
-		s.counts[k] += v
+	for instance, m := range b.counts {
+		if s.counts[instance] == nil {
+			s.counts[instance] = make(map[string]int)
+		}
+		for metric, c := range m {
+			s.counts[instance][metric] += c
+		}
 	}
 }
 
-func (s summary) print() {
-	for user, count := range s.counts {
-		fmt.Printf("%d, %d\n", user, count)
+func (s summary) print(deleteOrgs map[int]struct{}) {
+	for instance, m := range s.counts {
+		deleted := ""
+		if _, found := deleteOrgs[instance]; found {
+			deleted = "deleted"
+		}
+		for metric, c := range m {
+			fmt.Printf("%d, %s, %d, %s\n", instance, metric, c, deleted)
+		}
 	}
 }
 
@@ -158,16 +184,21 @@ type handler struct {
 	store              chunk.Store
 	tableName          string
 	pages              int
-	orgs               map[int]struct{}
+	includeOrgs        map[int]struct{}
+	deleteOrgs         map[int]struct{}
 	reindexTablePrefix string
 	summary
 }
 
-func newHandler(store chunk.Store, tableName string, reindexTablePrefix string, orgs map[int]struct{}) handler {
+func newHandler(store chunk.Store, tableName string, reindexTablePrefix string, includeOrgs map[int]struct{}, deleteOrgs map[int]struct{}) handler {
+	if len(includeOrgs) == 0 {
+		includeOrgs = nil
+	}
 	return handler{
 		store:              store,
 		tableName:          tableName,
-		orgs:               orgs,
+		includeOrgs:        includeOrgs,
+		deleteOrgs:         deleteOrgs,
 		summary:            newSummary(),
 		reindexTablePrefix: reindexTablePrefix,
 	}
@@ -183,8 +214,16 @@ func (h *handler) handlePage(page chunk.ReadBatch) {
 		if org <= 0 {
 			continue
 		}
-		h.counts[org]++
-		if _, found := h.orgs[org]; found {
+		if h.includeOrgs != nil {
+			if _, found := h.includeOrgs[org]; !found {
+				continue
+			}
+		}
+		if h.counts[org] == nil {
+			h.counts[org] = make(map[string]int)
+		}
+		h.counts[org][""]++
+		if _, found := h.deleteOrgs[org]; found {
 			//request := h.storageClient.NewWriteBatch()
 			//request.AddDelete(h.tableName, hashValue, i.RangeValue())
 			//			h.requests <- request
@@ -195,6 +234,7 @@ func (h *handler) handlePage(page chunk.ReadBatch) {
 				level.Error(util.Logger).Log("msg", "chunk decode error", "err", err)
 				continue
 			}
+			h.counts[org][string(ch.Metric[model.MetricNameLabel])]++
 			if h.tableName == "" { // just write index entries
 				err = h.store.IndexChunk(ctx, ch)
 				if err != nil {
@@ -202,6 +242,13 @@ func (h *handler) handlePage(page chunk.ReadBatch) {
 					continue
 				}
 			} else {
+				if reEncodeChunks {
+					err = ch.ForceEncode()
+					if err != nil {
+						level.Error(util.Logger).Log("msg", "forceencode error", "err", err)
+						continue
+					}
+				}
 				err = h.store.Put(ctx, []chunk.Chunk{ch})
 				if err != nil {
 					level.Error(util.Logger).Log("msg", "put error", "err", err)

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -103,7 +103,7 @@ func main() {
 	}
 
 	tableTime := model.TimeFromUnix(int64(week) * 7 * 24 * 3600)
-	err = chunkStore.Scan(context.Background(), tableTime, reindexTablePrefix != "", callbacks)
+	err = chunkStore.Scan(context.Background(), tableTime, tableTime, reindexTablePrefix != "", callbacks)
 	checkFatal(err)
 
 	if reindexStore != nil {

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -138,8 +138,8 @@ func (h *handler) handlePage(page chunk.ReadBatch) {
 	if pagesPerDot > 0 && h.pages%pagesPerDot == 0 {
 		fmt.Printf(".")
 	}
-	for i := 0; i < page.Len(); i++ {
-		hashValue := page.HashValue(i)
+	for i := page.Iterator(); i.Next(); {
+		hashValue := i.HashValue()
 		org := chunk.OrgFromHash(hashValue)
 		if org <= 0 {
 			continue
@@ -147,7 +147,7 @@ func (h *handler) handlePage(page chunk.ReadBatch) {
 		h.counts[org]++
 		if _, found := h.orgs[org]; found {
 			request := h.storageClient.NewWriteBatch()
-			request.AddDelete(h.tableName, hashValue, page.RangeValue(i))
+			request.AddDelete(h.tableName, hashValue, i.RangeValue())
 			h.requests <- request
 		}
 	}

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/go-kit/kit/log/level"
+	awscommon "github.com/weaveworks/common/aws"
+	"github.com/weaveworks/common/logging"
+
+	"github.com/weaveworks/cortex/pkg/chunk"
+	"github.com/weaveworks/cortex/pkg/chunk/storage"
+	"github.com/weaveworks/cortex/pkg/util"
+)
+
+type scanner struct {
+	week      int
+	segments  int
+	tableName string
+	address   string
+
+	dynamoDB *dynamodb.DynamoDB
+}
+
+var (
+	pagesPerDot int
+)
+
+func main() {
+	var (
+		schemaConfig  chunk.SchemaConfig
+		storageConfig storage.Config
+
+		scanner  scanner
+		loglevel string
+	)
+
+	util.RegisterFlags(&storageConfig, &schemaConfig)
+	flag.IntVar(&scanner.week, "week", 0, "Week number to scan, e.g. 2497 (0 means current week)")
+	flag.IntVar(&scanner.segments, "segments", 1, "Number of segments to run in parallel")
+	flag.StringVar(&scanner.address, "address", "localhost:6060", "Address to listen on, for profiling, etc.")
+	flag.StringVar(&loglevel, "log-level", "info", "Debug level: debug, info, warning, error")
+	flag.IntVar(&pagesPerDot, "pages-per-dot", 10, "Print a dot per N pages in DynamoDB (0 to disable)")
+
+	flag.Parse()
+
+	var l logging.Level
+	l.Set(loglevel)
+	util.Logger, _ = util.NewPrometheusLogger(l)
+
+	// HTTP listener for profiling
+	go func() {
+		checkFatal(http.ListenAndServe(scanner.address, nil))
+	}()
+
+	if scanner.week == 0 {
+		scanner.week = int(time.Now().Unix() / int64(7*24*time.Hour/time.Second))
+	}
+
+	config, err := awscommon.ConfigFromURL(storageConfig.AWSStorageConfig.DynamoDB.URL)
+	checkFatal(err)
+	session := session.New(config)
+	scanner.dynamoDB = dynamodb.New(session)
+
+	var group sync.WaitGroup
+	group.Add(scanner.segments)
+	totals := newSummary()
+	var totalsMutex sync.Mutex
+
+	scanner.tableName = fmt.Sprintf("%s%d", schemaConfig.ChunkTables.Prefix, scanner.week)
+	fmt.Printf("table %s\n", scanner.tableName)
+	for segment := 0; segment < scanner.segments; segment++ {
+		go func(segment int) {
+			handler := newHandler()
+			err := scanner.segmentScan(segment, handler)
+			checkFatal(err)
+			totalsMutex.Lock()
+			totals.accumulate(handler.summary)
+			totalsMutex.Unlock()
+			group.Done()
+		}(segment)
+	}
+	group.Wait()
+	fmt.Printf("\n")
+	totals.print()
+}
+
+func (sc scanner) segmentScan(segment int, handler handler) error {
+	input := &dynamodb.ScanInput{
+		TableName:            aws.String(sc.tableName),
+		ProjectionExpression: aws.String(hashKey),
+		Segment:              aws.Int64(int64(segment)),
+		TotalSegments:        aws.Int64(int64(sc.segments)),
+		//ReturnConsumedCapacity: aws.String(dynamodb.ReturnConsumedCapacityTotal),
+	}
+
+	for _, arg := range flag.Args() {
+		org, err := strconv.Atoi(arg)
+		checkFatal(err)
+		handler.orgs[org] = struct{}{}
+	}
+
+	err := sc.dynamoDB.ScanPages(input, handler.handlePage)
+	if err != nil {
+		return err
+	}
+
+	delete := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]*dynamodb.WriteRequest{
+			sc.tableName: handler.requests,
+		},
+	}
+	_ = delete
+	//_, err = dynamoDB.BatchWriteItem(delete)
+	return err
+}
+
+/* TODO: delete v8 schema rows for all instances */
+
+const (
+	hashKey  = "h"
+	rangeKey = "r"
+	valueKey = "c"
+)
+
+type summary struct {
+	counts map[int]int
+}
+
+func newSummary() summary {
+	return summary{
+		counts: map[int]int{},
+	}
+}
+
+func (s *summary) accumulate(b summary) {
+	for k, v := range b.counts {
+		s.counts[k] += v
+	}
+}
+
+func (s summary) print() {
+	for user, count := range s.counts {
+		fmt.Printf("%d, %d\n", user, count)
+	}
+}
+
+type handler struct {
+	pages    int
+	orgs     map[int]struct{}
+	requests []*dynamodb.WriteRequest
+	summary
+}
+
+func newHandler() handler {
+	return handler{
+		orgs:    map[int]struct{}{},
+		summary: newSummary(),
+	}
+}
+
+func (h *handler) reset() {
+	h.requests = nil
+	h.counts = map[int]int{}
+}
+
+func (h *handler) handlePage(page *dynamodb.ScanOutput, lastPage bool) bool {
+	h.pages++
+	if pagesPerDot > 0 && h.pages%pagesPerDot == 0 {
+		fmt.Printf(".")
+	}
+	for _, m := range page.Items {
+		hashVal := m[hashKey].S
+		org := orgFromHash(hashVal)
+		if org <= 0 { // unrecognized format
+			continue
+		}
+		h.counts[org]++
+		if _, found := h.orgs[org]; found {
+			fmt.Printf("%s\n", *hashVal)
+			h.requests = append(h.requests, &dynamodb.WriteRequest{
+				DeleteRequest: &dynamodb.DeleteRequest{
+					Key: map[string]*dynamodb.AttributeValue{
+						hashKey: {S: hashVal},
+					},
+				},
+			})
+		}
+	}
+	return true
+}
+
+func orgFromHash(hashVal *string) int {
+	hashStr := aws.StringValue(hashVal)
+	if hashStr == "" {
+		return -1
+	}
+	pos := strings.Index(hashStr, "/")
+	if pos < 0 { // try index table format
+		pos = strings.Index(hashStr, ":")
+	}
+	if pos < 0 { // unrecognized format
+		return -1
+	}
+	org, err := strconv.Atoi(hashStr[:pos])
+	if err != nil {
+		return -1
+	}
+	return org
+}
+
+func checkFatal(err error) {
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "fatal error", "err", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -20,9 +20,10 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/weaveworks/common/logging"
 
-	"github.com/weaveworks/cortex/pkg/chunk"
-	"github.com/weaveworks/cortex/pkg/chunk/storage"
-	"github.com/weaveworks/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/chunk/storage"
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 var (
@@ -102,24 +103,22 @@ func main() {
 		week = time.Now().Unix() / secondsInWeek
 	}
 
-	storageOpts, err := storage.Opts(storageConfig, schemaConfig)
-	checkFatal(err)
-	chunkStore, err := chunk.NewStore(chunkStoreConfig, schemaConfig, storageOpts)
+	overrides := &validation.Overrides{}
+	chunkStore, err := storage.NewStore(storageConfig, chunkStoreConfig, schemaConfig, overrides)
 	checkFatal(err)
 	defer chunkStore.Stop()
 
 	var reindexStore chunk.Store
 	if reindexTablePrefix != "" || rechunkTablePrefix != "" {
 		reindexSchemaConfig := schemaConfig
-		reindexSchemaConfig.ChunkTables.Prefix = rechunkTablePrefix
-		reindexSchemaConfig.IndexTables.Prefix = reindexTablePrefix
-		reindexOpts, err := storage.Opts(storageConfig, reindexSchemaConfig)
-		checkFatal(err)
-		reindexStore, err = chunk.NewStore(chunkStoreConfig, reindexSchemaConfig, reindexOpts)
+		//FIXME
+		//reindexSchemaConfig.ChunkTables.Prefix = rechunkTablePrefix
+		//reindexSchemaConfig.IndexTables.Prefix = reindexTablePrefix
+		reindexStore, err = storage.NewStore(storageConfig, chunkStoreConfig, reindexSchemaConfig, overrides)
 		checkFatal(err)
 	}
 
-	tableName = fmt.Sprintf("%s%d", schemaConfig.ChunkTables.Prefix, week)
+	tableName = "FIXME" //fmt.Sprintf("%s%d", schemaConfig.ChunkTables.Prefix, week)
 	fmt.Printf("table %s\n", tableName)
 
 	handlers := make([]handler, segments)

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -209,7 +209,7 @@ func (h *handler) handlePage(page chunk.ReadBatch) {
 	decodeContext := chunk.NewDecodeContext()
 	for i := page.Iterator(); i.Next(); {
 		hashValue := i.HashValue()
-		org := chunk.OrgFromHash(hashValue)
+		org := orgFromHash(hashValue)
 		if org <= 0 {
 			continue
 		}
@@ -256,6 +256,24 @@ func (h *handler) handlePage(page chunk.ReadBatch) {
 			}
 		}
 	}
+}
+
+func orgFromHash(hashStr string) int {
+	if hashStr == "" {
+		return -1
+	}
+	pos := strings.Index(hashStr, "/")
+	if pos < 0 { // try index table format
+		pos = strings.Index(hashStr, ":")
+	}
+	if pos < 0 { // unrecognized format
+		return -1
+	}
+	org, err := strconv.Atoi(hashStr[:pos])
+	if err != nil {
+		return -1
+	}
+	return org
 }
 
 func checkFatal(err error) {

--- a/pkg/chunk/aws/scanner.go
+++ b/pkg/chunk/aws/scanner.go
@@ -30,7 +30,7 @@ func (a storageClient) ScanTable(ctx context.Context, tableName string, withValu
 				TotalSegments:          aws.Int64(int64(len(callbacks))),
 				ReturnConsumedCapacity: aws.String(dynamodb.ReturnConsumedCapacityTotal),
 			}
-			err := a.DynamoDB.ScanPages(input, func(page *dynamodb.ScanOutput, lastPage bool) bool {
+			err := a.DynamoDB.ScanPagesWithContext(ctx, input, func(page *dynamodb.ScanOutput, lastPage bool) bool {
 				if cc := page.ConsumedCapacity; cc != nil {
 					dynamoConsumedCapacity.WithLabelValues("DynamoDB.ScanTable", *cc.TableName).
 						Add(float64(*cc.CapacityUnits))

--- a/pkg/chunk/aws/scanner.go
+++ b/pkg/chunk/aws/scanner.go
@@ -10,13 +10,26 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk"
 )
 
+// ScanTable reads the whole of a table on multiple goroutines in
+// parallel, calling back with batches of results on one of the
+// callbacks for each goroutine.
 func (a storageClient) ScanTable(ctx context.Context, tableName string, callbacks []func(result chunk.ReadBatch)) error {
 	var outerErr error
 	var readerGroup sync.WaitGroup
 	readerGroup.Add(len(callbacks))
 	for segment, callback := range callbacks {
 		go func(segment int, callback func(result chunk.ReadBatch)) {
-			err := a.segmentScan(segment, len(callbacks), tableName, callback)
+			input := &dynamodb.ScanInput{
+				TableName:            aws.String(tableName),
+				ProjectionExpression: aws.String(hashKey + "," + rangeKey),
+				Segment:              aws.Int64(int64(segment)),
+				TotalSegments:        aws.Int64(int64(len(callbacks))),
+				//ReturnConsumedCapacity: aws.String(dynamodb.ReturnConsumedCapacityTotal),
+			}
+			err := a.DynamoDB.ScanPages(input, func(page *dynamodb.ScanOutput, lastPage bool) bool {
+				callback(&dynamoDBReadResponse{items: page.Items})
+				return true
+			})
 			if err != nil {
 				outerErr = err
 				// TODO: abort all segments
@@ -27,23 +40,4 @@ func (a storageClient) ScanTable(ctx context.Context, tableName string, callback
 	// Wait until all reader segments have finished
 	readerGroup.Wait()
 	return outerErr
-}
-
-func (a storageClient) segmentScan(segment, totalSegments int, tableName string, callback func(result chunk.ReadBatch)) error {
-	input := &dynamodb.ScanInput{
-		TableName:            aws.String(tableName),
-		ProjectionExpression: aws.String(hashKey + "," + rangeKey),
-		Segment:              aws.Int64(int64(segment)),
-		TotalSegments:        aws.Int64(int64(totalSegments)),
-		//ReturnConsumedCapacity: aws.String(dynamodb.ReturnConsumedCapacityTotal),
-	}
-
-	err := a.DynamoDB.ScanPages(input, func(page *dynamodb.ScanOutput, lastPage bool) bool {
-		callback(&dynamoDBReadResponse{items: page.Items})
-		return true
-	})
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/pkg/chunk/aws/scanner.go
+++ b/pkg/chunk/aws/scanner.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/prometheus/common/model"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 )
@@ -15,7 +16,8 @@ import (
 // ScanTable reads the whole of a table on multiple goroutines in
 // parallel, calling back with batches of results on one of the
 // callbacks for each goroutine.
-func (a storageClient) ScanTable(ctx context.Context, tableName string, withValue bool, callbacks []func(result chunk.ReadBatch)) error {
+func (a storageClient) Scan(ctx context.Context, from, through model.Time, withValue bool, callbacks []func(result chunk.ReadBatch)) error {
+	tableName := a.schemaCfg.ChunkTableFor(from) // FIXME ignoring 'through'
 	var outerErr error
 	projection := hashKey + "," + rangeKey
 	if withValue {

--- a/pkg/chunk/aws/scanner.go
+++ b/pkg/chunk/aws/scanner.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"context"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+)
+
+func (a storageClient) ScanTable(ctx context.Context, tableName string, callbacks []func(result chunk.ReadBatch)) error {
+	var outerErr error
+	var readerGroup sync.WaitGroup
+	readerGroup.Add(len(callbacks))
+	for segment, callback := range callbacks {
+		go func(segment int, callback func(result chunk.ReadBatch)) {
+			err := a.segmentScan(segment, len(callbacks), tableName, callback)
+			if err != nil {
+				outerErr = err
+				// TODO: abort all segments
+			}
+			readerGroup.Done()
+		}(segment, callback)
+	}
+	// Wait until all reader segments have finished
+	readerGroup.Wait()
+	return outerErr
+}
+
+func (a storageClient) segmentScan(segment, totalSegments int, tableName string, callback func(result chunk.ReadBatch)) error {
+	input := &dynamodb.ScanInput{
+		TableName:            aws.String(tableName),
+		ProjectionExpression: aws.String(hashKey + "," + rangeKey),
+		Segment:              aws.Int64(int64(segment)),
+		TotalSegments:        aws.Int64(int64(totalSegments)),
+		//ReturnConsumedCapacity: aws.String(dynamodb.ReturnConsumedCapacityTotal),
+	}
+
+	err := a.DynamoDB.ScanPages(input, func(page *dynamodb.ScanOutput, lastPage bool) bool {
+		callback(&dynamoDBReadResponse{items: page.Items})
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -787,7 +787,7 @@ func (b dynamoDBWriteBatch) AddBatch(a chunk.WriteBatch) {
 	}
 }
 
-func (b dynamoDBWriteBatch) Take(undersizedOK bool) chunk.WriteBatch {
+func (b dynamoDBWriteBatch) Take(undersizedOK bool) (chunk.WriteBatch, int) {
 	// We only take a batch from one table, to avoid one table holding up another
 	for tableName, fromReqs := range b {
 		count := len(fromReqs)
@@ -798,10 +798,10 @@ func (b dynamoDBWriteBatch) Take(undersizedOK bool) chunk.WriteBatch {
 			}
 			b[tableName] = fromReqs[taken:]
 			ret.deDuplicate()
-			return ret
+			return ret, taken
 		}
 	}
-	return nil
+	return nil, 0
 }
 
 func (b dynamoDBWriteBatch) deDuplicate() bool {

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -285,9 +285,8 @@ func (a storageClient) BatchWriteNoRetry(ctx context.Context, batch chunk.WriteB
 		if throttled(err) || request.Retryable() {
 			// Send the whole request back
 			return requests, nil
-		} else {
-			return nil, err
 		}
+		return nil, err
 	}
 	for tableName, items := range resp.UnprocessedItems {
 		dynamoThrottledItems.WithLabelValues("DynamoDB.BatchWriteItem", tableName).Add(float64(len(items)))

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -696,6 +696,17 @@ func (b dynamoDBWriteBatch) Len() int {
 	return result
 }
 
+func stringForReq(req *dynamodb.WriteRequest) string {
+	switch {
+	case req.DeleteRequest != nil:
+		return fmt.Sprintf("%s:%x", aws.StringValue(req.DeleteRequest.Key[hashKey].S), req.DeleteRequest.Key[rangeKey].B)
+	case req.PutRequest != nil:
+		return fmt.Sprintf("%s:%x", aws.StringValue(req.PutRequest.Item[hashKey].S), req.PutRequest.Item[rangeKey].B)
+	default:
+		return "empty"
+	}
+}
+
 func (b dynamoDBWriteBatch) String() string {
 	var sb strings.Builder
 	sb.WriteByte('{')
@@ -748,13 +759,38 @@ func (b dynamoDBWriteBatch) AddBatch(a chunk.WriteBatch) {
 
 func (b dynamoDBWriteBatch) Take(undersizedOK bool) chunk.WriteBatch {
 	var ret = dynamoDBWriteBatch{}
-	if b.Len() >= dynamoDBMaxWriteBatchSize || undersizedOK {
-		ret.TakeReqs(b, dynamoDBMaxWriteBatchSize)
-	}
-	if len(ret) == 0 {
-		return nil
+	for {
+		if b.Len() >= dynamoDBMaxWriteBatchSize || undersizedOK {
+			ret.TakeReqs(b, dynamoDBMaxWriteBatchSize)
+		}
+		if len(ret) == 0 {
+			return nil
+		}
+		if !ret.deDuplicate() {
+			break
+		}
 	}
 	return ret
+}
+
+func (b dynamoDBWriteBatch) deDuplicate() bool {
+	changed := false
+	for tableName, reqs := range b {
+		// Remove duplicate entries based on hashValue:rangeValue
+		seenIndexEntries := map[string]struct{}{}
+		for i := 0; i < len(reqs); {
+			key := stringForReq(reqs[i])
+			if _, found := seenIndexEntries[key]; found {
+				reqs = append(reqs[:i], reqs[i+1:]...)
+				changed = true
+			} else {
+				seenIndexEntries[key] = struct{}{}
+				i++
+			}
+		}
+		b[tableName] = reqs
+	}
+	return changed
 }
 
 // Fill 'b' with WriteRequests from 'from' until 'b' has at most max requests. Remove those requests from 'from'.

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -714,7 +714,7 @@ func (b dynamoDBWriteBatch) String() string {
 		sb.WriteString(k)
 		sb.WriteString(": [")
 		for _, req := range reqs {
-			sb.WriteString(req.String())
+			sb.WriteString(stringForReq(req))
 			sb.WriteByte(',')
 		}
 		sb.WriteString("], ")

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -766,19 +766,20 @@ func (b dynamoDBWriteBatch) AddBatch(a chunk.WriteBatch) {
 }
 
 func (b dynamoDBWriteBatch) Take(undersizedOK bool) chunk.WriteBatch {
-	var ret = dynamoDBWriteBatch{}
-	for {
-		if b.Len() >= dynamoDBMaxWriteBatchSize || undersizedOK {
-			ret.TakeReqs(b, dynamoDBMaxWriteBatchSize)
-		}
-		if len(ret) == 0 {
-			return nil
-		}
-		if !ret.deDuplicate() {
-			break
+	// We only take a batch from one table, to avoid one table holding up another
+	for tableName, fromReqs := range b {
+		count := len(fromReqs)
+		if count >= dynamoDBMaxWriteBatchSize || (undersizedOK && count > 0) {
+			taken := util.Min(count, dynamoDBMaxWriteBatchSize)
+			ret := dynamoDBWriteBatch{
+				tableName: fromReqs[:taken:taken],
+			}
+			b[tableName] = fromReqs[taken:]
+			ret.deDuplicate()
+			return ret
 		}
 	}
-	return ret
+	return nil
 }
 
 func (b dynamoDBWriteBatch) deDuplicate() bool {

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -207,35 +207,10 @@ func (a storageClient) BatchWrite(ctx context.Context, input chunk.WriteBatch) e
 		requests := dynamoDBWriteBatch{}
 		requests.TakeReqs(outstanding, dynamoDBMaxWriteBatchSize)
 		requests.TakeReqs(unprocessed, dynamoDBMaxWriteBatchSize)
-
-		request := a.batchWriteItemRequestFn(ctx, &dynamodb.BatchWriteItemInput{
-			RequestItems:           requests,
-			ReturnConsumedCapacity: aws.String(dynamodb.ReturnConsumedCapacityTotal),
-		})
-
-		err := instrument.TimeRequestHistogram(ctx, "DynamoDB.BatchWriteItem", dynamoRequestDuration, func(ctx context.Context) error {
-			return request.Send()
-		})
-		resp := request.Data().(*dynamodb.BatchWriteItemOutput)
-
-		for _, cc := range resp.ConsumedCapacity {
-			dynamoConsumedCapacity.WithLabelValues("DynamoDB.BatchWriteItem", *cc.TableName).
-				Add(float64(*cc.CapacityUnits))
-		}
+		unprocessedItems, err := a.BatchWriteNoRetry(ctx, requests)
 
 		if err != nil {
-			for tableName := range requests {
-				recordDynamoError(tableName, err, "DynamoDB.BatchWriteItem")
-			}
-
-			// If we get provisionedThroughputExceededException, then no items were processed,
-			// so back off and retry all.
-			if awsErr, ok := err.(awserr.Error); ok && ((awsErr.Code() == dynamodb.ErrCodeProvisionedThroughputExceededException) || request.Retryable()) {
-				logRetry(ctx, requests)
-				unprocessed.TakeReqs(requests, -1)
-				backoff.Wait()
-				continue
-			} else if ok && awsErr.Code() == validationException {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == validationException {
 				// this write will never work, so the only option is to drop the offending items and continue.
 				level.Warn(util.Logger).Log("msg", "Data lost while flushing to Dynamo", "err", awsErr)
 				level.Debug(util.Logger).Log("msg", "Dropped request details", "requests", requests)
@@ -253,18 +228,55 @@ func (a storageClient) BatchWrite(ctx context.Context, input chunk.WriteBatch) e
 		}
 
 		// If there are unprocessed items, retry those items.
-		if unprocessedItems := resp.UnprocessedItems; unprocessedItems != nil && dynamoDBWriteBatch(unprocessedItems).Len() > 0 {
-			logRetry(ctx, dynamoDBWriteBatch(unprocessedItems))
-			unprocessed.TakeReqs(unprocessedItems, -1)
+		if unprocessedItems != nil && unprocessedItems.(dynamoDBWriteBatch).Len() > 0 {
+			backoff.Wait()
+			unprocessed.TakeReqs(unprocessedItems.(dynamoDBWriteBatch), -1)
+		} else {
+			backoff.Reset()
 		}
-
-		backoff.Reset()
 	}
 
 	if valuesLeft := outstanding.Len() + unprocessed.Len(); valuesLeft > 0 {
 		return fmt.Errorf("failed to write chunk, %d values remaining: %s", valuesLeft, backoff.Err())
 	}
 	return backoff.Err()
+}
+
+func (a storageClient) BatchWriteNoRetry(ctx context.Context, batch chunk.WriteBatch) (retry chunk.WriteBatch, err error) {
+	requests := batch.(dynamoDBWriteBatch)
+	request := a.batchWriteItemRequestFn(ctx, &dynamodb.BatchWriteItemInput{
+		RequestItems:           requests,
+		ReturnConsumedCapacity: aws.String(dynamodb.ReturnConsumedCapacityTotal),
+	})
+
+	err = instrument.TimeRequestHistogram(ctx, "DynamoDB.BatchWriteItem", dynamoRequestDuration, func(ctx context.Context) error {
+		return request.Send()
+	})
+	resp := request.Data().(*dynamodb.BatchWriteItemOutput)
+
+	for _, cc := range resp.ConsumedCapacity {
+		dynamoConsumedCapacity.WithLabelValues("DynamoDB.BatchWriteItem", *cc.TableName).
+			Add(float64(*cc.CapacityUnits))
+	}
+
+	if err != nil {
+		for tableName := range requests {
+			recordDynamoError(tableName, err, "DynamoDB.BatchWriteItem")
+		}
+		if throttled(err) || request.Retryable() {
+			// Send the whole request back
+			return requests, nil
+		} else {
+			return nil, err
+		}
+	}
+	// Send unprocessed items back
+	return dynamoDBWriteBatch(resp.UnprocessedItems), nil
+}
+
+func throttled(err error) bool {
+	awsErr, ok := err.(awserr.Error)
+	return ok && (awsErr.Code() == dynamodb.ErrCodeProvisionedThroughputExceededException)
 }
 
 func (a storageClient) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) bool) error {

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -751,6 +751,9 @@ func (b dynamoDBWriteBatch) Take(undersizedOK bool) chunk.WriteBatch {
 	if b.Len() >= dynamoDBMaxWriteBatchSize || undersizedOK {
 		ret.TakeReqs(b, dynamoDBMaxWriteBatchSize)
 	}
+	if len(ret) == 0 {
+		return nil
+	}
 	return ret
 }
 

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -740,6 +740,14 @@ func (b dynamoDBWriteBatch) Add(tableName, hashValue string, rangeValue []byte, 
 	})
 }
 
+// FIXME: temporary hack passing in storageClient so we can get at the schemaCfg
+func (b dynamoDBWriteBatch) AddChunk(s chunk.StorageClient, chunk chunk.Chunk, encoded []byte) {
+	key := chunk.ExternalKey()
+	a := s.(storageClient)
+	table := a.schemaCfg.ChunkTableFor(chunk.From)
+	b.Add(table, key, placeholder, encoded)
+}
+
 func (b dynamoDBWriteBatch) AddDelete(tableName, hashValue string, rangeValue []byte) {
 	b[tableName] = append(b[tableName], &dynamodb.WriteRequest{
 		DeleteRequest: &dynamodb.DeleteRequest{

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -178,11 +178,11 @@ func (b *writeBatch) AddBatch(a chunk.WriteBatch) {
 	b.entries = append(b.entries, a.(*writeBatch).entries...)
 }
 
-func (b *writeBatch) Take(undersizedOK bool) chunk.WriteBatch {
+func (b *writeBatch) Take(undersizedOK bool) (chunk.WriteBatch, int) {
 	// Not sure what is a good batch size - just return everything
 	ret := *b
 	*b = writeBatch{}
-	return &ret
+	return &ret, ret.Len()
 }
 
 func (s *storageClient) BatchWrite(ctx context.Context, batch chunk.WriteBatch) error {

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -161,6 +161,25 @@ func (b *writeBatch) Add(tableName, hashValue string, rangeValue []byte, value [
 	})
 }
 
+func (b *writeBatch) Len() int {
+	return len(b.entries)
+}
+
+func (b *writeBatch) AddDelete(tableName, hashValue string, rangeValue []byte) {
+	panic("not implemented")
+}
+
+func (b *writeBatch) AddBatch(a chunk.WriteBatch) {
+	b.entries = append(b.entries, a.(*writeBatch).entries...)
+}
+
+func (b *writeBatch) Take(undersizedOK bool) chunk.WriteBatch {
+	// Not sure what is a good batch size - just return everything
+	ret := *b
+	*b = writeBatch{}
+	return &ret
+}
+
 func (s *storageClient) BatchWrite(ctx context.Context, batch chunk.WriteBatch) error {
 	b := batch.(*writeBatch)
 
@@ -173,6 +192,10 @@ func (s *storageClient) BatchWrite(ctx context.Context, batch chunk.WriteBatch) 
 	}
 
 	return nil
+}
+
+func (s *storageClient) BatchWriteNoRetry(ctx context.Context, batch chunk.WriteBatch) (chunk.WriteBatch, error) {
+	return nil, s.BatchWrite(ctx, batch)
 }
 
 func (s *storageClient) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) bool) error {
@@ -212,7 +235,7 @@ func (s *storageClient) query(ctx context.Context, query chunk.IndexQuery, callb
 	defer iter.Close()
 	scanner := iter.Scanner()
 	for scanner.Next() {
-		b := &readBatch{}
+		var b = &readBatch{hashValue: query.HashValue}
 		if err := scanner.Scan(&b.rangeValue, &b.value); err != nil {
 			return errors.WithStack(err)
 		}
@@ -226,6 +249,7 @@ func (s *storageClient) query(ctx context.Context, query chunk.IndexQuery, callb
 // readBatch represents a batch of rows read from Cassandra.
 type readBatch struct {
 	consumed   bool
+	hashValue  string
 	rangeValue []byte
 	value      []byte
 }
@@ -247,6 +271,10 @@ func (b *readBatchIter) Next() bool {
 	}
 	b.consumed = true
 	return true
+}
+
+func (b readBatch) HashValue() string {
+	return b.hashValue
 }
 
 func (b *readBatchIter) RangeValue() []byte {
@@ -317,4 +345,8 @@ func (s *storageClient) getChunk(ctx context.Context, input chunk.Chunk) (chunk.
 	decodeContext := chunk.NewDecodeContext()
 	err := input.Decode(decodeContext, buf)
 	return input, err
+}
+
+func (s *storageClient) ScanTable(ctx context.Context, tableName string, callbacks []func(result chunk.ReadBatch)) error {
+	panic("not implemented")
 }

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -278,7 +278,7 @@ func (b *readBatchIter) Next() bool {
 	return true
 }
 
-func (b readBatch) HashValue() string {
+func (b readBatchIter) HashValue() string {
 	return b.hashValue
 }
 

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gocql/gocql"
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/util"
@@ -347,6 +348,6 @@ func (s *storageClient) getChunk(ctx context.Context, input chunk.Chunk) (chunk.
 	return input, err
 }
 
-func (s *storageClient) ScanTable(ctx context.Context, tableName string, withValue bool, callbacks []func(result chunk.ReadBatch)) error {
+func (s *storageClient) Scan(ctx context.Context, from, through model.Time, withValue bool, callbacks []func(result chunk.ReadBatch)) error {
 	panic("not implemented")
 }

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -166,6 +166,10 @@ func (b *writeBatch) Len() int {
 	return len(b.entries)
 }
 
+func (b *writeBatch) AddChunk(s chunk.StorageClient, chunk chunk.Chunk, encoded []byte) {
+	panic("not implemented")
+}
+
 func (b *writeBatch) AddDelete(tableName, hashValue string, rangeValue []byte) {
 	panic("not implemented")
 }

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -347,6 +347,6 @@ func (s *storageClient) getChunk(ctx context.Context, input chunk.Chunk) (chunk.
 	return input, err
 }
 
-func (s *storageClient) ScanTable(ctx context.Context, tableName string, callbacks []func(result chunk.ReadBatch)) error {
+func (s *storageClient) ScanTable(ctx context.Context, tableName string, withValue bool, callbacks []func(result chunk.ReadBatch)) error {
 	panic("not implemented")
 }

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -188,6 +188,12 @@ var writerPool = sync.Pool{
 	New: func() interface{} { return snappy.NewBufferedWriter(nil) },
 }
 
+func (c *Chunk) ForceEncode() error {
+	c.encoded = nil
+	_, err := c.Encode()
+	return err
+}
+
 // Encode writes the chunk out to a big write buffer, then calculates the checksum.
 func (c *Chunk) Encode() ([]byte, error) {
 	if c.encoded != nil {

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -188,6 +188,7 @@ var writerPool = sync.Pool{
 	New: func() interface{} { return snappy.NewBufferedWriter(nil) },
 }
 
+// ForceEncode re-encodes a chunk rather than using the cached encoding
 func (c *Chunk) ForceEncode() error {
 	c.encoded = nil
 	_, err := c.Encode()
@@ -376,22 +377,4 @@ func (c *Chunk) Samples(from, through model.Time) ([]model.SamplePair, error) {
 	it := c.Data.NewIterator()
 	interval := metric.Interval{OldestInclusive: from, NewestInclusive: through}
 	return prom_chunk.RangeValues(it, interval)
-}
-
-func OrgFromHash(hashStr string) int {
-	if hashStr == "" {
-		return -1
-	}
-	pos := strings.Index(hashStr, "/")
-	if pos < 0 { // try index table format
-		pos = strings.Index(hashStr, ":")
-	}
-	if pos < 0 { // unrecognized format
-		return -1
-	}
-	org, err := strconv.Atoi(hashStr[:pos])
-	if err != nil {
-		return -1
-	}
-	return org
 }

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -268,7 +268,8 @@ func (c *Chunk) Decode(decodeContext *DecodeContext, input []byte) error {
 
 	// First, calculate the checksum of the chunk and confirm it matches
 	// what we expected.
-	if c.ChecksumSet && c.Checksum != crc32.Checksum(input, castagnoliTable) {
+	calculatedChecksum := crc32.Checksum(input, castagnoliTable)
+	if c.ChecksumSet && c.Checksum != calculatedChecksum {
 		return errors.WithStack(ErrInvalidChecksum)
 	}
 
@@ -297,6 +298,8 @@ func (c *Chunk) Decode(decodeContext *DecodeContext, input []byte) error {
 		if !equalByKey(*c, tempMetadata) {
 			return errors.WithStack(ErrWrongMetadata)
 		}
+	} else {
+		tempMetadata.Checksum, tempMetadata.ChecksumSet = calculatedChecksum, true
 	}
 	*c = tempMetadata
 

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -368,3 +368,21 @@ func (c *Chunk) Samples(from, through model.Time) ([]model.SamplePair, error) {
 	interval := metric.Interval{OldestInclusive: from, NewestInclusive: through}
 	return prom_chunk.RangeValues(it, interval)
 }
+
+func OrgFromHash(hashStr string) int {
+	if hashStr == "" {
+		return -1
+	}
+	pos := strings.Index(hashStr, "/")
+	if pos < 0 { // try index table format
+		pos = strings.Index(hashStr, ":")
+	}
+	if pos < 0 { // unrecognized format
+		return -1
+	}
+	org, err := strconv.Atoi(hashStr[:pos])
+	if err != nil {
+		return -1
+	}
+	return org
+}

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -151,7 +151,8 @@ func (c *store) PutOne(ctx context.Context, from, through model.Time, chunk Chun
 		return err
 	}
 
-	return c.storage.BatchWrite(ctx, writeReqs)
+	c.writer.Write <- writeReqs
+	return nil
 }
 
 // calculateIndexEntries creates a set of batched WriteRequests for all the chunks it is given.

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -129,24 +129,19 @@ func (c *store) Put(ctx context.Context, chunks []Chunk) error {
 
 // PutOne implements ChunkStore
 func (c *store) PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error {
-	userID, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return err
-	}
-
 	// Horribly, PutChunks mutates the chunk by setting its checksum.  By putting
 	// the chunk in a slice we are in fact passing by reference, so below we
 	// need to make sure we pick the chunk back out the slice.
 	chunks := []Chunk{chunk}
 
-	err = c.storage.PutChunks(ctx, chunks)
+	err := c.storage.PutChunks(ctx, chunks)
 	if err != nil {
 		return err
 	}
 
 	c.writeBackCache(ctx, chunks)
 
-	writeReqs, err := c.calculateIndexEntries(userID, from, through, chunks[0])
+	writeReqs, err := c.calculateIndexEntries(chunk.UserID, from, through, chunks[0])
 	if err != nil {
 		return err
 	}

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -199,9 +199,8 @@ func (c *store) Get(ctx context.Context, from, through model.Time, allMatchers .
 	return c.getMetricNameChunks(ctx, from, through, matchers, metricName)
 }
 
-func (c *store) Scan(ctx context.Context, time model.Time, withValue bool, callbacks []func(result ReadBatch)) error {
-	tableName := "dev_chunk_data_weekly_2478" // hard-coded as it's too hard...
-	return c.storage.ScanTable(ctx, tableName, withValue, callbacks)
+func (c *store) Scan(ctx context.Context, from, through model.Time, withValue bool, callbacks []func(result ReadBatch)) error {
+	return c.storage.Scan(ctx, from, through, withValue, callbacks)
 }
 
 func (c *store) validateQuery(ctx context.Context, from model.Time, through *model.Time, matchers []*labels.Matcher) (string, []*labels.Matcher, bool, error) {

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -46,6 +46,11 @@ var (
 		Name:      "cache_corrupt_chunks_total",
 		Help:      "Total count of corrupt chunks found in cache.",
 	})
+	writerQueueLength = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "cortex",
+		Name:      "writer_queue_length",
+		Help:      "Number of entries in the writer queue.",
+	})
 )
 
 func init() {

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -114,6 +114,7 @@ func newStore(cfg StoreConfig, schema Schema, storage StorageClient, limits *val
 func (c *store) Stop() {
 	c.storage.Stop()
 	c.Fetcher.Stop()
+	c.writer.Stop()
 }
 
 // Put implements ChunkStore

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -134,19 +134,19 @@ func (c *store) Put(ctx context.Context, chunks []Chunk) error {
 
 // PutOne implements ChunkStore
 func (c *store) PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error {
-	// Horribly, PutChunks mutates the chunk by setting its checksum.  By putting
-	// the chunk in a slice we are in fact passing by reference, so below we
-	// need to make sure we pick the chunk back out the slice.
-	chunks := []Chunk{chunk}
-
-	err := c.storage.PutChunks(ctx, chunks)
+	// Encode the chunk first - checksum is calculated as a side effect.
+	buf, err := chunk.Encode()
 	if err != nil {
 		return err
 	}
+	batch := c.storage.NewWriteBatch()
+	batch.AddChunk(c.storage, chunk, buf)
+	c.writer.Write <- batch
 
-	c.writeBackCache(ctx, chunks)
+	// FIXME: shouldn't send chunk to the cache until it has gone to the real store
+	c.writeBackCache(ctx, []Chunk{chunk})
 
-	writeReqs, err := c.calculateIndexEntries(chunk.UserID, from, through, chunks[0])
+	writeReqs, err := c.calculateIndexEntries(chunk.UserID, from, through, chunk)
 	if err != nil {
 		return err
 	}

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -194,6 +194,11 @@ func (c *store) Get(ctx context.Context, from, through model.Time, allMatchers .
 	return c.getMetricNameChunks(ctx, from, through, matchers, metricName)
 }
 
+func (c *store) Scan(ctx context.Context, time model.Time, withValue bool, callbacks []func(result ReadBatch)) error {
+	tableName := "dev_chunk_data_weekly_2478" // hard-coded as it's too hard...
+	return c.storage.ScanTable(ctx, tableName, withValue, callbacks)
+}
+
 func (c *store) validateQuery(ctx context.Context, from model.Time, through *model.Time, matchers []*labels.Matcher) (string, []*labels.Matcher, bool, error) {
 	log, ctx := spanlogger.New(ctx, "store.validateQuery")
 	defer log.Span.Finish()

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -110,6 +110,11 @@ func newStore(cfg StoreConfig, schema Schema, storage StorageClient, limits *val
 	}, nil
 }
 
+// Flush all pending items to the backing store
+func (c *store) Flush() {
+	c.writer.Flush()
+}
+
 // Stop any background goroutines (ie in the cache.)
 func (c *store) Stop() {
 	c.storage.Stop()

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -61,6 +61,7 @@ func init() {
 type StoreConfig struct {
 	ChunkCacheConfig       cache.Config
 	WriteDedupeCacheConfig cache.Config
+	WriterConfig           WriterConfig
 
 	MinChunkAge              time.Duration
 	CardinalityCacheSize     int
@@ -74,6 +75,7 @@ func (cfg *StoreConfig) RegisterFlags(f *flag.FlagSet) {
 
 	cfg.WriteDedupeCacheConfig.RegisterFlagsWithPrefix("store.index-cache-write.", "Cache config for index entry writing. ", f)
 
+	cfg.WriterConfig.RegisterFlags(f)
 	f.DurationVar(&cfg.MinChunkAge, "store.min-chunk-age", 0, "Minimum time between chunk update and being saved to the store.")
 	f.IntVar(&cfg.CardinalityCacheSize, "store.cardinality-cache-size", 0, "Size of in-memory cardinality cache, 0 to disable.")
 	f.DurationVar(&cfg.CardinalityCacheValidity, "store.cardinality-cache-validity", 1*time.Hour, "Period for which entries in the cardinality cache are valid.")
@@ -88,6 +90,7 @@ type store struct {
 	schema  Schema
 	limits  *validation.Overrides
 	*Fetcher
+	writer *Writer
 }
 
 func newStore(cfg StoreConfig, schema Schema, storage StorageClient, limits *validation.Overrides) (Store, error) {
@@ -95,6 +98,7 @@ func newStore(cfg StoreConfig, schema Schema, storage StorageClient, limits *val
 	if err != nil {
 		return nil, err
 	}
+	writer := NewWriter(cfg.WriterConfig, storage)
 
 	return &store{
 		cfg:     cfg,
@@ -102,6 +106,7 @@ func newStore(cfg StoreConfig, schema Schema, storage StorageClient, limits *val
 		schema:  schema,
 		limits:  limits,
 		Fetcher: fetcher,
+		writer:  writer,
 	}, nil
 }
 

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -128,11 +128,7 @@ func (bfp ByFingerprint) Less(i, j int) bool {
 	return bfp[i].Metric.Fingerprint() < bfp[j].Metric.Fingerprint()
 }
 
-// TestChunkStore_Get tests results are returned correctly depending on the type of query
-func TestChunkStore_Get(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), userID)
-	now := model.Now()
-
+func dummyChunks(now model.Time) (Chunk, Chunk, Chunk, Chunk) {
 	fooMetric1 := model.Metric{
 		model.MetricNameLabel: "foo",
 		"bar":  "baz",
@@ -161,6 +157,15 @@ func TestChunkStore_Get(t *testing.T) {
 
 	barChunk1 := dummyChunkFor(now, barMetric1)
 	barChunk2 := dummyChunkFor(now, barMetric2)
+
+	return fooChunk1, fooChunk2, barChunk1, barChunk2
+}
+
+// TestChunkStore_Get tests results are returned correctly depending on the type of query
+func TestChunkStore_Get(t *testing.T) {
+	ctx := user.InjectOrgID(context.Background(), userID)
+	now := model.Now()
+	fooChunk1, fooChunk2, barChunk1, barChunk2 := dummyChunks(now)
 
 	fooSampleStream1, err := createSampleStreamFrom(fooChunk1)
 	require.NoError(t, err)
@@ -313,17 +318,7 @@ func TestChunkStore_Get(t *testing.T) {
 func TestChunkStore_getMetricNameChunks(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), userID)
 	now := model.Now()
-	chunk1 := dummyChunkFor(now, model.Metric{
-		model.MetricNameLabel: "foo",
-		"bar":  "baz",
-		"toms": "code",
-		"flip": "flop",
-	})
-	chunk2 := dummyChunkFor(now, model.Metric{
-		model.MetricNameLabel: "foo",
-		"bar":  "beep",
-		"toms": "code",
-	})
+	chunk1, chunk2, _, _ := dummyChunks(now)
 
 	for _, tc := range []struct {
 		query  string

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -266,6 +266,7 @@ func TestChunkStore_Get(t *testing.T) {
 					}); err != nil {
 						t.Fatal(err)
 					}
+					store.Flush()
 
 					matchers, err := promql.ParseMetricSelector(tc.query)
 					if err != nil {
@@ -372,6 +373,7 @@ func TestChunkStore_getMetricNameChunks(t *testing.T) {
 					if err := store.Put(ctx, []Chunk{chunk1, chunk2}); err != nil {
 						t.Fatal(err)
 					}
+					store.Flush()
 
 					matchers, err := promql.ParseMetricSelector(tc.query)
 					if err != nil {
@@ -429,6 +431,7 @@ func TestChunkStoreRandom(t *testing.T) {
 				err := store.Put(ctx, []Chunk{chunk})
 				require.NoError(t, err)
 			}
+			store.Flush()
 
 			// pick two random numbers and do a query
 			for i := 0; i < 100; i++ {
@@ -493,6 +496,7 @@ func TestChunkStoreLeastRead(t *testing.T) {
 		err := store.Put(ctx, []Chunk{chunk})
 		require.NoError(t, err)
 	}
+	store.Flush()
 
 	// pick a random numbers and do a query to end of row
 	for i := 1; i < 24; i++ {

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -16,6 +16,10 @@ import (
 
 const userID = "userID"
 
+func init() {
+	encoding.DefaultEncoding = encoding.Varbit
+}
+
 func dummyChunk(now model.Time) Chunk {
 	return dummyChunkFor(now, model.Metric{
 		model.MetricNameLabel: "foo",

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -14,7 +14,7 @@ import (
 type Store interface {
 	Put(ctx context.Context, chunks []Chunk) error
 	PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error
-	IndexChunk(ctx context.Context, writer *Writer, chunk Chunk) error
+	IndexChunk(ctx context.Context, chunk Chunk) error
 	Scan(ctx context.Context, time model.Time, withValue bool, callbacks []func(result ReadBatch)) error
 	Get(tx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error)
 	Stop()
@@ -83,9 +83,9 @@ func (c compositeStore) Scan(ctx context.Context, time model.Time, withValue boo
 	})
 }
 
-func (c compositeStore) IndexChunk(ctx context.Context, writer *Writer, chunk Chunk) error {
+func (c compositeStore) IndexChunk(ctx context.Context, chunk Chunk) error {
 	return c.forStores(chunk.From, chunk.Through, func(from, through model.Time, store Store) error {
-		return store.IndexChunk(ctx, writer, chunk)
+		return store.IndexChunk(ctx, chunk)
 	})
 }
 

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -15,7 +15,7 @@ type Store interface {
 	Put(ctx context.Context, chunks []Chunk) error
 	PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error
 	IndexChunk(ctx context.Context, chunk Chunk) error
-	Scan(ctx context.Context, time model.Time, withValue bool, callbacks []func(result ReadBatch)) error
+	Scan(ctx context.Context, from, through model.Time, withValue bool, callbacks []func(result ReadBatch)) error
 	Get(tx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error)
 	Stop()
 }
@@ -77,9 +77,9 @@ func (c compositeStore) PutOne(ctx context.Context, from, through model.Time, ch
 	})
 }
 
-func (c compositeStore) Scan(ctx context.Context, time model.Time, withValue bool, callbacks []func(result ReadBatch)) error {
-	return c.forStores(time, time, func(from, through model.Time, store Store) error {
-		return store.Scan(ctx, time, withValue, callbacks)
+func (c compositeStore) Scan(ctx context.Context, from, through model.Time, withValue bool, callbacks []func(result ReadBatch)) error {
+	return c.forStores(from, through, func(from, through model.Time, store Store) error {
+		return store.Scan(ctx, from, through, withValue, callbacks)
 	})
 }
 

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -15,6 +15,7 @@ type Store interface {
 	Put(ctx context.Context, chunks []Chunk) error
 	PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error
 	IndexChunk(ctx context.Context, writer *Writer, chunk Chunk) error
+	Scan(ctx context.Context, time model.Time, withValue bool, callbacks []func(result ReadBatch)) error
 	Get(tx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error)
 	Stop()
 }
@@ -73,6 +74,12 @@ func (c compositeStore) Put(ctx context.Context, chunks []Chunk) error {
 func (c compositeStore) PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error {
 	return c.forStores(from, through, func(from, through model.Time, store Store) error {
 		return store.PutOne(ctx, from, through, chunk)
+	})
+}
+
+func (c compositeStore) Scan(ctx context.Context, time model.Time, withValue bool, callbacks []func(result ReadBatch)) error {
+	return c.forStores(time, time, func(from, through model.Time, store Store) error {
+		return store.Scan(ctx, time, withValue, callbacks)
 	})
 }
 

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -14,6 +14,7 @@ import (
 type Store interface {
 	Put(ctx context.Context, chunks []Chunk) error
 	PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error
+	IndexChunk(ctx context.Context, writer *Writer, chunk Chunk) error
 	Get(tx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error)
 	Stop()
 }
@@ -72,6 +73,12 @@ func (c compositeStore) Put(ctx context.Context, chunks []Chunk) error {
 func (c compositeStore) PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error {
 	return c.forStores(from, through, func(from, through model.Time, store Store) error {
 		return store.PutOne(ctx, from, through, chunk)
+	})
+}
+
+func (c compositeStore) IndexChunk(ctx context.Context, writer *Writer, chunk Chunk) error {
+	return c.forStores(chunk.From, chunk.Through, func(from, through model.Time, store Store) error {
+		return store.IndexChunk(ctx, writer, chunk)
 	})
 }
 

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -17,6 +17,7 @@ type Store interface {
 	IndexChunk(ctx context.Context, chunk Chunk) error
 	Scan(ctx context.Context, from, through model.Time, withValue bool, callbacks []func(result ReadBatch)) error
 	Get(tx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error)
+	Flush()
 	Stop()
 }
 
@@ -100,6 +101,12 @@ func (c compositeStore) Get(ctx context.Context, from, through model.Time, match
 		return nil
 	})
 	return results, err
+}
+
+func (c compositeStore) Flush() {
+	for _, store := range c.stores {
+		store.Flush()
+	}
 }
 
 func (c compositeStore) Stop() {

--- a/pkg/chunk/composite_store_test.go
+++ b/pkg/chunk/composite_store_test.go
@@ -21,7 +21,7 @@ func (m mockStore) PutOne(ctx context.Context, from, through model.Time, chunk C
 	return nil
 }
 
-func (m mockStore) IndexChunk(ctx context.Context, writer *Writer, chunk Chunk) error {
+func (m mockStore) IndexChunk(ctx context.Context, chunk Chunk) error {
 	return nil
 }
 

--- a/pkg/chunk/composite_store_test.go
+++ b/pkg/chunk/composite_store_test.go
@@ -25,6 +25,10 @@ func (m mockStore) IndexChunk(ctx context.Context, writer *Writer, chunk Chunk) 
 	return nil
 }
 
+func (m mockStore) Scan(ctx context.Context, time model.Time, withValue bool, callbacks []func(result ReadBatch)) error {
+	return nil
+}
+
 func (m mockStore) Get(tx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error) {
 	return nil, nil
 }

--- a/pkg/chunk/composite_store_test.go
+++ b/pkg/chunk/composite_store_test.go
@@ -21,6 +21,10 @@ func (m mockStore) PutOne(ctx context.Context, from, through model.Time, chunk C
 	return nil
 }
 
+func (m mockStore) IndexChunk(ctx context.Context, writer *Writer, chunk Chunk) error {
+	return nil
+}
+
 func (m mockStore) Get(tx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error) {
 	return nil, nil
 }

--- a/pkg/chunk/composite_store_test.go
+++ b/pkg/chunk/composite_store_test.go
@@ -33,7 +33,8 @@ func (m mockStore) Get(tx context.Context, from, through model.Time, matchers ..
 	return nil, nil
 }
 
-func (m mockStore) Stop() {}
+func (m mockStore) Stop()  {}
+func (m mockStore) Flush() {}
 
 func TestCompositeStore(t *testing.T) {
 	type result struct {

--- a/pkg/chunk/composite_store_test.go
+++ b/pkg/chunk/composite_store_test.go
@@ -25,7 +25,7 @@ func (m mockStore) IndexChunk(ctx context.Context, chunk Chunk) error {
 	return nil
 }
 
-func (m mockStore) Scan(ctx context.Context, time model.Time, withValue bool, callbacks []func(result ReadBatch)) error {
+func (m mockStore) Scan(ctx context.Context, from, through model.Time, withValue bool, callbacks []func(result ReadBatch)) error {
 	return nil
 }
 

--- a/pkg/chunk/gcp/storage_client.go
+++ b/pkg/chunk/gcp/storage_client.go
@@ -10,6 +10,7 @@ import (
 	"cloud.google.com/go/bigtable"
 	ot "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/prometheus/common/model"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
@@ -489,7 +490,7 @@ func (s *storageClientColumnKey) GetChunks(ctx context.Context, input []chunk.Ch
 	return output, nil
 }
 
-func (s *storageClientColumnKey) ScanTable(ctx context.Context, tableName string, withValue bool, callbacks []func(result chunk.ReadBatch)) error {
+func (s *storageClientColumnKey) Scan(ctx context.Context, from, through model.Time, withValue bool, callbacks []func(result chunk.ReadBatch)) error {
 	panic("not implemented")
 }
 
@@ -541,7 +542,7 @@ func (s *storageClientV1) query(ctx context.Context, query chunk.IndexQuery, cal
 	return nil
 }
 
-func (s *storageClientV1) ScanTable(ctx context.Context, tableName string, withValue bool, callbacks []func(result chunk.ReadBatch)) error {
+func (s *storageClientV1) Scan(ctx context.Context, from, through model.Time, withValue bool, callbacks []func(result chunk.ReadBatch)) error {
 	panic("not implemented")
 }
 

--- a/pkg/chunk/gcp/storage_client.go
+++ b/pkg/chunk/gcp/storage_client.go
@@ -489,7 +489,7 @@ func (s *storageClientColumnKey) GetChunks(ctx context.Context, input []chunk.Ch
 	return output, nil
 }
 
-func (s *storageClientColumnKey) ScanTable(ctx context.Context, tableName string, callbacks []func(result chunk.ReadBatch)) error {
+func (s *storageClientColumnKey) ScanTable(ctx context.Context, tableName string, withValue bool, callbacks []func(result chunk.ReadBatch)) error {
 	panic("not implemented")
 }
 
@@ -541,7 +541,7 @@ func (s *storageClientV1) query(ctx context.Context, query chunk.IndexQuery, cal
 	return nil
 }
 
-func (s *storageClientV1) ScanTable(ctx context.Context, tableName string, callbacks []func(result chunk.ReadBatch)) error {
+func (s *storageClientV1) ScanTable(ctx context.Context, tableName string, withValue bool, callbacks []func(result chunk.ReadBatch)) error {
 	panic("not implemented")
 }
 

--- a/pkg/chunk/gcp/storage_client.go
+++ b/pkg/chunk/gcp/storage_client.go
@@ -164,7 +164,7 @@ func (b bigtableWriteBatch) AddBatch(a chunk.WriteBatch) {
 	}
 }
 
-func (b bigtableWriteBatch) Take(undersizedOK bool) chunk.WriteBatch {
+func (b bigtableWriteBatch) Take(undersizedOK bool) (chunk.WriteBatch, int) {
 	ret := bigtableWriteBatch{
 		tables: map[string]map[string]*bigtable.Mutation{},
 	}
@@ -182,7 +182,7 @@ func (b bigtableWriteBatch) Take(undersizedOK bool) chunk.WriteBatch {
 			delete(fromRows, rowKey)
 			count++
 			if count >= batchSize {
-				return ret
+				return ret, ret.Len()
 			}
 		}
 		if len(fromRows) == 0 {
@@ -190,7 +190,7 @@ func (b bigtableWriteBatch) Take(undersizedOK bool) chunk.WriteBatch {
 		}
 	}
 
-	return ret
+	return ret, ret.Len()
 }
 
 func (s *storageClientColumnKey) BatchWrite(ctx context.Context, batch chunk.WriteBatch) error {

--- a/pkg/chunk/gcp/storage_client.go
+++ b/pkg/chunk/gcp/storage_client.go
@@ -143,6 +143,10 @@ func (b bigtableWriteBatch) Len() int {
 	return result
 }
 
+func (b bigtableWriteBatch) AddChunk(s chunk.StorageClient, chunk chunk.Chunk, encoded []byte) {
+	panic("not implemented")
+}
+
 func (b bigtableWriteBatch) AddDelete(tableName, hashValue string, rangeValue []byte) {
 	panic("not implemented")
 }

--- a/pkg/chunk/gcp/storage_client.go
+++ b/pkg/chunk/gcp/storage_client.go
@@ -134,6 +134,60 @@ func (b bigtableWriteBatch) Add(tableName, hashValue string, rangeValue []byte, 
 	mutation.Set(columnFamily, columnKey, 0, value)
 }
 
+func (b bigtableWriteBatch) Len() int {
+	result := 0
+	for _, rows := range b.tables {
+		result += len(rows)
+	}
+	return result
+}
+
+func (b bigtableWriteBatch) AddDelete(tableName, hashValue string, rangeValue []byte) {
+	panic("not implemented")
+}
+
+func (b bigtableWriteBatch) AddBatch(a chunk.WriteBatch) {
+	for tableName, addRows := range a.(bigtableWriteBatch).tables {
+		rows, ok := b.tables[tableName]
+		if !ok {
+			rows = map[string]*bigtable.Mutation{}
+			b.tables[tableName] = rows
+		}
+		for rowKey, mut := range addRows {
+			rows[rowKey] = mut
+		}
+	}
+}
+
+func (b bigtableWriteBatch) Take(undersizedOK bool) chunk.WriteBatch {
+	ret := bigtableWriteBatch{
+		tables: map[string]map[string]*bigtable.Mutation{},
+	}
+
+	const batchSize = 25 // Not sure if...
+	count := 0
+	for tableName, fromRows := range b.tables {
+		rows, ok := ret.tables[tableName]
+		if !ok {
+			rows = map[string]*bigtable.Mutation{}
+			b.tables[tableName] = rows
+		}
+		for rowKey, mut := range fromRows {
+			rows[rowKey] = mut
+			delete(fromRows, rowKey)
+			count++
+			if count >= batchSize {
+				return ret
+			}
+		}
+		if len(fromRows) == 0 {
+			delete(b.tables, tableName)
+		}
+	}
+
+	return ret
+}
+
 func (s *storageClientColumnKey) BatchWrite(ctx context.Context, batch chunk.WriteBatch) error {
 	bigtableBatch := batch.(bigtableWriteBatch)
 
@@ -158,6 +212,10 @@ func (s *storageClientColumnKey) BatchWrite(ctx context.Context, batch chunk.Wri
 	}
 
 	return nil
+}
+
+func (s *storageClientColumnKey) BatchWriteNoRetry(ctx context.Context, batch chunk.WriteBatch) (chunk.WriteBatch, error) {
+	return nil, s.BatchWrite(ctx, batch)
 }
 
 func (s *storageClientColumnKey) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) bool) error {
@@ -305,6 +363,10 @@ func (c *columnKeyIterator) Next() bool {
 	return c.i < len(c.items)
 }
 
+func (c *columnKeyIterator) HashValue() string {
+	panic("not implemented")
+}
+
 func (c *columnKeyIterator) RangeValue() []byte {
 	return []byte(strings.TrimPrefix(c.items[c.i].Column, columnPrefix))
 }
@@ -427,6 +489,10 @@ func (s *storageClientColumnKey) GetChunks(ctx context.Context, input []chunk.Ch
 	return output, nil
 }
 
+func (s *storageClientColumnKey) ScanTable(ctx context.Context, tableName string, callbacks []func(result chunk.ReadBatch)) error {
+	panic("not implemented")
+}
+
 func (s *storageClientV1) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) bool) error {
 	return chunk_util.DoParallelQueries(ctx, s.query, queries, callback)
 }
@@ -475,6 +541,10 @@ func (s *storageClientV1) query(ctx context.Context, query chunk.IndexQuery, cal
 	return nil
 }
 
+func (s *storageClientV1) ScanTable(ctx context.Context, tableName string, callbacks []func(result chunk.ReadBatch)) error {
+	panic("not implemented")
+}
+
 // rowBatch represents a batch of rows read from Bigtable.  As the
 // bigtable interface gives us rows one-by-one, a batch always only contains
 // a single row.
@@ -499,6 +569,12 @@ func (b *rowBatchIterator) Next() bool {
 	}
 	b.consumed = true
 	return true
+}
+
+func (b *rowBatchIterator) HashValue() string {
+	// String before the first separator is the hashkey
+	parts := strings.SplitN(b.row.Key(), separator, 2)
+	return parts[0]
 }
 
 func (b *rowBatchIterator) RangeValue() []byte {

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -176,6 +176,7 @@ func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
 	return nil
 }
 
+// BatchWriteNoRetry implements StorageClient.
 func (m *MockStorage) BatchWriteNoRetry(ctx context.Context, batch WriteBatch) (retry WriteBatch, err error) {
 	mockBatch := *batch.(*mockWriteBatch)
 	retryLen := len(mockBatch) / 3
@@ -186,6 +187,7 @@ func (m *MockStorage) BatchWriteNoRetry(ctx context.Context, batch WriteBatch) (
 	return &toRetry, err
 }
 
+// Scan implements StorageClient.
 func (m *MockStorage) Scan(ctx context.Context, from, through model.Time, withValue bool, callbacks []func(result ReadBatch)) error {
 	return nil
 }

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -114,6 +114,9 @@ func (m *MockStorage) NewWriteBatch() WriteBatch {
 	return &mockWriteBatch{}
 }
 
+// Denotes chunk value inserted into write batch
+const chunkFakeTable = "__chunk__"
+
 // BatchWrite implements StorageClient.
 func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
 	m.mtx.Lock()
@@ -125,6 +128,11 @@ func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
 	m.numWrites += len(mockBatch)
 
 	for _, req := range mockBatch {
+		if req.tableName == chunkFakeTable { // chunk in batch
+			m.objects[req.hashValue] = req.value
+			continue
+		}
+
 		table, ok := m.tables[req.tableName]
 		if !ok {
 			return fmt.Errorf("table not found")
@@ -325,6 +333,10 @@ func (b *mockWriteBatch) Add(tableName, hashValue string, rangeValue []byte, val
 		rangeValue           []byte
 		value                []byte
 	}{tableName, hashValue, rangeValue, value})
+}
+
+func (b *mockWriteBatch) AddChunk(s StorageClient, chunk Chunk, encoded []byte) {
+	b.Add(chunkFakeTable, chunk.ExternalKey(), nil, encoded)
 }
 
 func (b *mockWriteBatch) AddDelete(tableName, hashValue string, rangeValue []byte) {

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -367,11 +367,11 @@ func (b *mockWriteBatch) AddBatch(a WriteBatch) {
 	*b = append(*b, *a.(*mockWriteBatch)...)
 }
 
-func (b *mockWriteBatch) Take(undersizedOK bool) WriteBatch {
+func (b *mockWriteBatch) Take(undersizedOK bool) (WriteBatch, int) {
 	// Not a very full implementation - just return everything
 	ret := *b
 	*b = nil
-	return &ret
+	return &ret, len(ret)
 }
 
 func (b *mockReadBatchIter) Next() bool {

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -26,6 +26,7 @@ type mockTable struct {
 }
 
 type mockItem struct {
+	hashValue  string
 	rangeValue []byte
 	value      []byte
 }
@@ -156,12 +157,21 @@ func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
 			}
 		}
 		items[i] = mockItem{
+			hashValue:  req.hashValue,
 			rangeValue: req.rangeValue,
 			value:      req.value,
 		}
 
 		table.items[req.hashValue] = items
 	}
+	return nil
+}
+
+func (m *MockStorage) BatchWriteNoRetry(ctx context.Context, batch WriteBatch) (retry WriteBatch, err error) {
+	return nil, nil
+}
+
+func (m *MockStorage) ScanTable(ctx context.Context, tableName string, callbacks []func(result ReadBatch)) error {
 	return nil
 }
 
@@ -310,6 +320,14 @@ func (b *mockWriteBatch) Add(tableName, hashValue string, rangeValue []byte, val
 	}{tableName, hashValue, rangeValue, value})
 }
 
+func (b *mockWriteBatch) AddDelete(tableName, hashValue string, rangeValue []byte) {
+	panic("TODO")
+}
+
+func (b mockWriteBatch) Len() int {
+	return len(b)
+}
+
 type mockReadBatch struct {
 	items []mockItem
 }
@@ -326,9 +344,24 @@ type mockReadBatchIter struct {
 	*mockReadBatch
 }
 
+func (b *mockWriteBatch) AddBatch(a WriteBatch) {
+	*b = append(*b, *a.(*mockWriteBatch)...)
+}
+
+func (b *mockWriteBatch) Take(undersizedOK bool) WriteBatch {
+	// Not a very full implementation - just return everything
+	ret := *b
+	*b = nil
+	return &ret
+}
+
 func (b *mockReadBatchIter) Next() bool {
 	b.index++
 	return b.index < len(b.items)
+}
+
+func (b mockReadBatchIter) HashValue() string {
+	return b.items[b.index].hashValue
 }
 
 func (b *mockReadBatchIter) RangeValue() []byte {

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/common/model"
 )
 
 // MockStorage is a fake in-memory StorageClient.
@@ -177,7 +178,7 @@ func (m *MockStorage) BatchWriteNoRetry(ctx context.Context, batch WriteBatch) (
 	return &toRetry, err
 }
 
-func (m *MockStorage) ScanTable(ctx context.Context, tableName string, withValue bool, callbacks []func(result ReadBatch)) error {
+func (m *MockStorage) Scan(ctx context.Context, from, through model.Time, withValue bool, callbacks []func(result ReadBatch)) error {
 	return nil
 }
 

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -168,7 +168,13 @@ func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
 }
 
 func (m *MockStorage) BatchWriteNoRetry(ctx context.Context, batch WriteBatch) (retry WriteBatch, err error) {
-	return nil, nil
+	mockBatch := *batch.(*mockWriteBatch)
+	retryLen := len(mockBatch) / 3
+	sendLen := len(mockBatch) - retryLen
+	toSend := mockBatch[:sendLen]
+	err = m.BatchWrite(ctx, &toSend)
+	toRetry := mockBatch[sendLen:]
+	return &toRetry, err
 }
 
 func (m *MockStorage) ScanTable(ctx context.Context, tableName string, withValue bool, callbacks []func(result ReadBatch)) error {

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -171,7 +171,7 @@ func (m *MockStorage) BatchWriteNoRetry(ctx context.Context, batch WriteBatch) (
 	return nil, nil
 }
 
-func (m *MockStorage) ScanTable(ctx context.Context, tableName string, callbacks []func(result ReadBatch)) error {
+func (m *MockStorage) ScanTable(ctx context.Context, tableName string, withValue bool, callbacks []func(result ReadBatch)) error {
 	return nil
 }
 

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -72,6 +72,7 @@ func newSeriesStore(cfg StoreConfig, schema Schema, storage StorageClient, limit
 	if err != nil {
 		return nil, err
 	}
+	writer := NewWriter(cfg.WriterConfig, storage)
 
 	return &seriesStore{
 		store: store{
@@ -80,6 +81,7 @@ func newSeriesStore(cfg StoreConfig, schema Schema, storage StorageClient, limit
 			schema:  schema,
 			limits:  limits,
 			Fetcher: fetcher,
+			writer:  writer,
 		},
 		cardinalityCache: cache.NewFifoCache("cardinality", cache.FifoCacheConfig{
 			Size:     cfg.CardinalityCacheSize,

--- a/pkg/chunk/storage/caching_storage_client.go
+++ b/pkg/chunk/storage/caching_storage_client.go
@@ -153,6 +153,9 @@ type readBatchIterator struct {
 	readBatch ReadBatch
 }
 
+// HashValue implements chunk.ReadBatchIterator.
+func (b readBatchIterator) HashValue() string { panic("not implemented") }
+
 // Len implements chunk.ReadBatchIterator.
 func (b *readBatchIterator) Next() bool {
 	b.index++

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -29,6 +29,7 @@ type StorageClient interface {
 // WriteBatch represents a batch of writes.
 type WriteBatch interface {
 	Add(tableName, hashValue string, rangeValue []byte, value []byte)
+	AddChunk(StorageClient, Chunk, []byte)
 	AddDelete(tableName, hashValue string, rangeValue []byte)
 	AddBatch(WriteBatch)
 	Len() int

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -9,9 +9,13 @@ type StorageClient interface {
 	// For the write path.
 	NewWriteBatch() WriteBatch
 	BatchWrite(context.Context, WriteBatch) error
+	BatchWriteNoRetry(context.Context, WriteBatch) (retry WriteBatch, err error)
 
 	// For the read path.
 	QueryPages(ctx context.Context, queries []IndexQuery, callback func(IndexQuery, ReadBatch) (shouldContinue bool)) error
+
+	// Iterate through every row in a table, for batch jobs
+	ScanTable(ctx context.Context, tableName string, callbacks []func(result ReadBatch)) error
 
 	// For storing and retrieving chunks.
 	PutChunks(ctx context.Context, chunks []Chunk) error
@@ -21,6 +25,10 @@ type StorageClient interface {
 // WriteBatch represents a batch of writes.
 type WriteBatch interface {
 	Add(tableName, hashValue string, rangeValue []byte, value []byte)
+	AddDelete(tableName, hashValue string, rangeValue []byte)
+	AddBatch(WriteBatch)
+	Len() int
+	Take(undersizedOK bool) WriteBatch
 }
 
 // ReadBatch represents the results of a QueryPages.
@@ -31,6 +39,7 @@ type ReadBatch interface {
 // ReadBatchIterator is an iterator over a ReadBatch.
 type ReadBatchIterator interface {
 	Next() bool
+	HashValue() string
 	RangeValue() []byte
 	Value() []byte
 }

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -15,7 +15,7 @@ type StorageClient interface {
 	QueryPages(ctx context.Context, queries []IndexQuery, callback func(IndexQuery, ReadBatch) (shouldContinue bool)) error
 
 	// Iterate through every row in a table, for batch jobs
-	ScanTable(ctx context.Context, tableName string, callbacks []func(result ReadBatch)) error
+	ScanTable(ctx context.Context, tableName string, withValue bool, callbacks []func(result ReadBatch)) error
 
 	// For storing and retrieving chunks.
 	PutChunks(ctx context.Context, chunks []Chunk) error

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -33,7 +33,7 @@ type WriteBatch interface {
 	AddDelete(tableName, hashValue string, rangeValue []byte)
 	AddBatch(WriteBatch)
 	Len() int
-	Take(undersizedOK bool) WriteBatch
+	Take(undersizedOK bool) (WriteBatch, int)
 }
 
 // ReadBatch represents the results of a QueryPages.

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -1,6 +1,10 @@
 package chunk
 
-import "context"
+import (
+	"context"
+
+	"github.com/prometheus/common/model"
+)
 
 // StorageClient is a client for the persistent storage for Cortex. (e.g. DynamoDB + S3).
 type StorageClient interface {
@@ -14,8 +18,8 @@ type StorageClient interface {
 	// For the read path.
 	QueryPages(ctx context.Context, queries []IndexQuery, callback func(IndexQuery, ReadBatch) (shouldContinue bool)) error
 
-	// Iterate through every row in a table, for batch jobs
-	ScanTable(ctx context.Context, tableName string, withValue bool, callbacks []func(result ReadBatch)) error
+	// Iterate through every row in the tables in time range, for batch jobs
+	Scan(ctx context.Context, from, through model.Time, withValue bool, callbacks []func(result ReadBatch)) error
 
 	// For storing and retrieving chunks.
 	PutChunks(ctx context.Context, chunks []Chunk) error

--- a/pkg/chunk/writer.go
+++ b/pkg/chunk/writer.go
@@ -53,6 +53,15 @@ func NewWriter(cfg WriterConfig, storage StorageClient) *Writer {
 	return writer
 }
 
+func (c *store) IndexChunk(ctx context.Context, writer *Writer, chunk Chunk) error {
+	writeReqs, err := c.calculateIndexEntries(chunk.UserID, chunk.From, chunk.Through, chunk)
+	if err != nil {
+		return err
+	}
+	writer.Write <- writeReqs
+	return nil
+}
+
 func (writer *Writer) Run() {
 	writer.group.Add(1 + writer.writers)
 	go func() {

--- a/pkg/chunk/writer.go
+++ b/pkg/chunk/writer.go
@@ -102,9 +102,11 @@ func (sc *Writer) batcher() {
 	var queue, outBatch WriteBatch
 	queue = sc.storage.NewWriteBatch()
 	for {
+		queueLen := queue.Len()
+		writerQueueLength.Set(float64(queueLen)) // Prometheus metric
 		var in, out chan WriteBatch
 		// We will allow in new data if the queue isn't too long
-		if queue.Len() < sc.maxQueueSize {
+		if queueLen < sc.maxQueueSize {
 			in = sc.Write
 		}
 		// We will send out a batch if the queue is big enough, or if we're finishing

--- a/pkg/chunk/writer.go
+++ b/pkg/chunk/writer.go
@@ -112,11 +112,13 @@ func (sc *Writer) writeLoop(ctx context.Context) {
 			sc.pending.Add(-batchLen)
 			continue
 		}
-		// Send unprocessed items back into the batcher
-		sc.retry <- retry
+		if retry != nil {
+			// Wait before retry
+			limiter.WaitN(ctx, retry.Len())
+			// Send unprocessed items back into the batcher
+			sc.retry <- retry
+		}
 		sc.pending.Add(-(batchLen - retry.Len()))
-		// Wait before accepting the next batch
-		limiter.WaitN(ctx, batchLen)
 	}
 }
 

--- a/pkg/chunk/writer.go
+++ b/pkg/chunk/writer.go
@@ -6,13 +6,16 @@ import (
 	"sync"
 
 	"github.com/go-kit/kit/log/level"
+	"golang.org/x/time/rate"
 
 	"github.com/cortexproject/cortex/pkg/util"
 )
 
 type WriterConfig struct {
-	writers      int
-	maxQueueSize int
+	writers      int     // Number of writers to run in parallel
+	maxQueueSize int     // Max rows to allow in writer queue
+	rateLimit    float64 // Max rate to send rows to storage back-end, per writer
+	// (In some sense the rate we send should relate to the provisioned capacity in the back-end)
 }
 
 type Writer struct {
@@ -35,6 +38,7 @@ type Writer struct {
 func (cfg *WriterConfig) RegisterFlags(f *flag.FlagSet) {
 	flag.IntVar(&cfg.writers, "writers", 1, "Number of writers to run in parallel")
 	flag.IntVar(&cfg.maxQueueSize, "writers-queue-limit", 1000, "Max rows to allow in writer queue")
+	flag.Float64Var(&cfg.rateLimit, "writer-rate-limit", 1000, "Max rate to send rows to storage back-end, per writer")
 }
 
 func NewWriter(cfg WriterConfig, storage StorageClient) *Writer {
@@ -77,6 +81,7 @@ func (writer *Writer) Stop() {
 // writeLoop receives on the 'batched' chan, sends to store, and
 // passes anything that was throttled to the 'retry' chan.
 func (sc *Writer) writeLoop(ctx context.Context) {
+	limiter := rate.NewLimiter(rate.Limit(sc.rateLimit), 100) // burst size should be the largest batch
 	for {
 		batch, ok := <-sc.batched
 		if !ok {
@@ -93,6 +98,8 @@ func (sc *Writer) writeLoop(ctx context.Context) {
 		// Send unprocessed items back into the batcher
 		sc.retry <- retry
 		sc.pending.Add(-(batchLen - retry.Len()))
+		// Wait before accepting the next batch
+		limiter.WaitN(ctx, batchLen)
 	}
 }
 

--- a/pkg/chunk/writer.go
+++ b/pkg/chunk/writer.go
@@ -1,0 +1,143 @@
+package chunk
+
+import (
+	"context"
+	"flag"
+	"sync"
+
+	"github.com/go-kit/kit/log/level"
+
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+type WriterConfig struct {
+	writers        int
+	writeBatchSize int
+}
+
+type storageItem struct {
+	tableName  string
+	hashValue  string
+	rangeValue []byte
+	value      []byte
+}
+
+type Writer struct {
+	WriterConfig
+
+	storage StorageClient
+
+	group   sync.WaitGroup
+	pending sync.WaitGroup
+
+	// Clients send items on this chan to be written
+	Write chan WriteBatch
+	// internally we send items on this chan to be retried
+	retry chan WriteBatch
+	// Writers read batches of items from this chan
+	batched chan WriteBatch
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet
+func (cfg *WriterConfig) RegisterFlags(f *flag.FlagSet) {
+	flag.IntVar(&cfg.writers, "writers", 1, "Number of writers to run in parallel")
+	flag.IntVar(&cfg.writeBatchSize, "write-batch-size", 25, "Number of write requests to batch up")
+}
+
+func NewWriter(cfg WriterConfig, storage StorageClient) *Writer {
+	writer := &Writer{
+		WriterConfig: cfg,
+		storage:      storage,
+		// Unbuffered chan so we can tell when batcher has received all items
+		Write:   make(chan WriteBatch),
+		retry:   make(chan WriteBatch, 100),
+		batched: make(chan WriteBatch),
+	}
+	return writer
+}
+
+func (writer *Writer) Run() {
+	writer.group.Add(1 + writer.writers)
+	go func() {
+		writer.batcher()
+		writer.group.Done()
+	}()
+	for i := 0; i < writer.writers; i++ {
+		go func() {
+			writer.writeLoop()
+			writer.group.Done()
+		}()
+	}
+}
+
+func (writer *Writer) Stop() {
+	// Ensure that batcher has received all items so it won't call Add() any more
+	writer.Write <- nil
+	// Wait for pending items to be sent to store
+	writer.pending.Wait()
+	// Close chans to signal writer(s) and batcher to terminate
+	close(writer.batched)
+	close(writer.retry)
+	writer.group.Wait()
+}
+
+func (sc *Writer) writeLoop() {
+	for {
+		batch, ok := <-sc.batched
+		if !ok {
+			return
+		}
+		level.Debug(util.Logger).Log("msg", "about to write", "num_requests", batch.Len())
+		retry, err := sc.storage.BatchWriteNoRetry(context.TODO(), batch)
+		if err != nil {
+			level.Error(util.Logger).Log("msg", "unable to write; dropping data", "err", err, "batch", batch)
+			sc.pending.Add(-batch.Len())
+			continue
+		}
+		// Send unprocessed items back into the batcher
+		sc.retry <- retry
+		sc.pending.Add(-(batch.Len() - retry.Len()))
+	}
+}
+
+// Receive individual requests, and batch them up into groups to send to the store
+func (sc *Writer) batcher() {
+	finished := false
+	var requests WriteBatch
+	for {
+		// We will allow in new data if the queue isn't too long
+		var in chan WriteBatch
+		if requests.Len() < 1000 {
+			in = sc.Write
+		}
+		// We will send out a batch if the queue is big enough, or if we're finishing
+		var out chan WriteBatch
+		outBatch := requests.Take(finished)
+		if outBatch != nil {
+			out = sc.batched
+		}
+		var inBatch WriteBatch
+		var ok bool
+		select {
+		case inBatch = <-in:
+			if inBatch == nil { // Nil used as interlock to know we received all previous values
+				finished = true
+			} else {
+				requests.AddBatch(inBatch)
+				sc.pending.Add(inBatch.Len())
+			}
+		case inBatch, ok = <-sc.retry:
+			if !ok {
+				return
+			}
+		case out <- outBatch:
+			outBatch = nil
+		}
+		if inBatch != nil {
+			requests.AddBatch(inBatch)
+		}
+		if outBatch != nil {
+			requests.AddBatch(outBatch)
+		}
+	}
+}

--- a/pkg/chunk/writer_test.go
+++ b/pkg/chunk/writer_test.go
@@ -27,7 +27,6 @@ func TestWriter(t *testing.T) {
 	var cfg WriterConfig
 	util.DefaultValues(&cfg)
 	writer := NewWriter(cfg, store.storage)
-	writer.Run()
 
 	sendChunk := func(chunk Chunk) {
 		// can't use writer to store chunks with mock storage as it isn't flexible enough

--- a/pkg/chunk/writer_test.go
+++ b/pkg/chunk/writer_test.go
@@ -1,0 +1,30 @@
+package chunk
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+func TestWriter(t *testing.T) {
+	now := model.Now()
+	fooChunk1, _, _, _ := dummyChunks(now)
+
+	st := newTestChunkStore(t, "v6")
+	defer st.Stop()
+	store := st.(CompositeStore).stores[0].Store.(*store)
+
+	var cfg WriterConfig
+	util.DefaultValues(&cfg)
+	writer := NewWriter(cfg, store.storage)
+	writer.Run()
+
+	writeReqs, err := store.calculateIndexEntries(userID, fooChunk1.From, fooChunk1.Through, fooChunk1)
+	require.NoError(t, err)
+	writer.Write <- writeReqs
+
+	writer.Stop()
+}

--- a/pkg/chunk/writer_test.go
+++ b/pkg/chunk/writer_test.go
@@ -1,17 +1,24 @@
 package chunk
 
 import (
+	"context"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/test"
+	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/util"
 )
 
 func TestWriter(t *testing.T) {
+	ctx := user.InjectOrgID(context.Background(), userID)
 	now := model.Now()
-	fooChunk1, _, _, _ := dummyChunks(now)
+	chunk1, chunk2, _, _ := dummyChunks(now)
 
 	st := newTestChunkStore(t, "v6")
 	defer st.Stop()
@@ -22,9 +29,29 @@ func TestWriter(t *testing.T) {
 	writer := NewWriter(cfg, store.storage)
 	writer.Run()
 
-	writeReqs, err := store.calculateIndexEntries(userID, fooChunk1.From, fooChunk1.Through, fooChunk1)
-	require.NoError(t, err)
-	writer.Write <- writeReqs
+	sendChunk := func(chunk Chunk) {
+		// can't use writer to store chunks with mock storage as it isn't flexible enough
+		err := store.storage.PutChunks(ctx, []Chunk{chunk})
+		require.NoError(t, err)
+		writeReqs, err := store.calculateIndexEntries(userID, chunk.From, chunk.Through, chunk)
+		require.NoError(t, err)
+		writer.Write <- writeReqs
+	}
 
+	sendChunk(chunk1)
+	sendChunk(chunk2)
+
+	// Ensure chunks are flushed to store
 	writer.Stop()
+
+	// Now read back the data
+	matchers, err := promql.ParseMetricSelector("foo")
+	require.NoError(t, err)
+	chunks, err := store.Get(ctx, now.Add(-time.Hour), now, matchers...)
+	require.NoError(t, err)
+
+	expect := []Chunk{chunk1, chunk2}
+	if !reflect.DeepEqual(expect, chunks) {
+		t.Fatalf("wrong chunks - %s", test.Diff(expect, chunks))
+	}
 }


### PR DESCRIPTION
This rather large PR is almost everything I did to be able to re-index a year of data on DynamoDB.

Because of the way DynamoDB is priced, the best way to do a batch run is to go at a very steady speed.  Here I have made a lot of use of rate-limiters and stopped using exponential backoff.

I have taken out most of the janky bits and blind alleys, but left in quite a lot of the journey in case it helps understanding.  I may have lost something vital from the `scanner` program in the rebase against master - it came from a long way back - but tests are passing.

I'm not expecting this to be merged as-is: I put it here for visibility and because I think the batched writer is a better way to do chunk writes from the Ingester but I haven't plumbed them together yet.