### PR TITLE
Allow smaller varbit chunks on read

### DIFF
--- a/pkg/chunk/encoding/varbit.go
+++ b/pkg/chunk/encoding/varbit.go
@@ -287,7 +287,7 @@ func (c *varbitChunk) Slice(_, _ model.Time) Chunk {
 
 // Marshal implements chunk.
 func (c varbitChunk) Marshal(w io.Writer) error {
-	size := c.marshalLen()
+	size := c.Size()
 	n, err := w.Write(c[:size])
 	if err != nil {
 		return err
@@ -327,9 +327,6 @@ func (MarshalConfig) RegisterFlags(f *flag.FlagSet) {
 
 // marshalLen returns the number of bytes that should be marshalled for this chunk
 func (c varbitChunk) marshalLen() int {
-	if alwaysMarshalFullsizeChunks {
-		return cap(c)
-	}
 	bits := c.nextSampleOffset()
 	if bits < varbitThirdSampleBitOffset {
 		bits = varbitThirdSampleBitOffset
@@ -351,6 +348,9 @@ func (c varbitChunk) Len() int {
 }
 
 func (c varbitChunk) Size() int {
+	if alwaysMarshalFullsizeChunks {
+		return cap(c)
+	}
 	return c.marshalLen()
 }
 


### PR DESCRIPTION
The flag `-store.fullsize-chunks` should control writing only; on the reading side either size should be allowed.

Fixes the problem observed at https://github.com/cortexproject/cortex/pull/1044#issuecomment-443133535