### PR TITLE
Make the max grpc receive message size configurable, in Bigtable client

### DIFF
--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -11,11 +11,11 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 	"github.com/pkg/errors"
 )
 
@@ -33,7 +33,7 @@ type Config struct {
 	Project  string `yaml:"project"`
 	Instance string `yaml:"instance"`
 
-	grpcMaxRecvMsgSize int
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config"`
 
 	ColumnKey bool
 }
@@ -42,7 +42,11 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.Project, "bigtable.project", "", "Bigtable project ID.")
 	f.StringVar(&cfg.Instance, "bigtable.instance", "", "Bigtable instance ID.")
-	f.IntVar(&cfg.grpcMaxRecvMsgSize, "bigtable.max-recv-msg-size", 100<<20, "Bigtable grpc max receive message size.")
+
+	cfg.GRPCClientConfig.RegisterFlags("bigtable", f)
+
+	// Deprecated.
+	f.Int("bigtable.max-recv-msg-size", 100<<20, "DEPRECATED. Bigtable grpc max receive message size.")
 }
 
 // storageClientColumnKey implements chunk.storageClient for GCP.
@@ -61,7 +65,7 @@ type storageClientV1 struct {
 // NewStorageClientV1 returns a new v1 StorageClient.
 func NewStorageClientV1(ctx context.Context, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.IndexClient, error) {
 	opts := instrumentation()
-	opts = append(opts, option.WithGRPCDialOption(grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(cfg.grpcMaxRecvMsgSize))))
+	opts = append(opts, option.WithGRPCDialOption(cfg.GRPCClientConfig.DialOption()))
 
 	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, opts...)
 	if err != nil {

--- a/pkg/util/grpcclient/grpcclient.go
+++ b/pkg/util/grpcclient/grpcclient.go
@@ -1,0 +1,37 @@
+package grpcclient
+
+import (
+	"flag"
+
+	"google.golang.org/grpc"
+)
+
+// Config for a gRPC client.
+type Config struct {
+	MaxRecvMsgSize     int  `yaml:"max_recv_msg_size"`
+	MaxSendMsgSize     int  `yaml:"max_send_msg_size"`
+	UseGzipCompression bool `yaml:"use_gzip_compression"`
+}
+
+// RegisterFlags registers flags.
+func (cfg *Config) RegisterFlags(prefix string, f *flag.FlagSet) {
+	f.IntVar(&cfg.MaxRecvMsgSize, prefix+".grpc-max-recv-msg-size", 100<<20, "gRPC client max receive message size (bytes).")
+	f.IntVar(&cfg.MaxSendMsgSize, prefix+".grpc-max-send-msg-size", 16<<20, "gRPC client max send message size (bytes).")
+	f.BoolVar(&cfg.UseGzipCompression, prefix+".grpc-use-gzip-compression", false, "Use compression when sending messages.")
+}
+
+// CallOptions returns the config in terms of CallOptions.
+func (cfg *Config) CallOptions() []grpc.CallOption {
+	var opts []grpc.CallOption
+	opts = append(opts, grpc.MaxCallRecvMsgSize(cfg.MaxRecvMsgSize))
+	opts = append(opts, grpc.MaxCallSendMsgSize(cfg.MaxSendMsgSize))
+	if cfg.UseGzipCompression {
+		opts = append(opts, grpc.UseCompressor("gzip"))
+	}
+	return opts
+}
+
+// DialOption returns the config as a grpc.DialOptions.
+func (cfg *Config) DialOption() grpc.DialOption {
+	return grpc.WithDefaultCallOptions(cfg.CallOptions()...)
+}


### PR DESCRIPTION
We're hitting this limit and `100 << 20` is the default in the bigtable SDK anyways.