### PR TITLE
Add a name parameter to the memcache client, so we can see where the errors come from.

### DIFF
--- a/pkg/chunk/cache/cache.go
+++ b/pkg/chunk/cache/cache.go
@@ -81,7 +81,7 @@ func New(cfg Config) (Cache, error) {
 		}
 
 		client := NewMemcachedClient(cfg.memcacheClient)
-		cache := NewMemcached(cfg.memcache, client)
+		cache := NewMemcached(cfg.memcache, client, cfg.prefix)
 
 		cacheName := cfg.prefix + "memcache"
 		caches = append(caches, NewBackground(cacheName, cfg.background, Instrument(cacheName, cache)))

--- a/pkg/chunk/cache/cache_test.go
+++ b/pkg/chunk/cache/cache_test.go
@@ -140,7 +140,7 @@ func testCache(t *testing.T, cache cache.Cache) {
 
 func TestMemcache(t *testing.T) {
 	t.Run("Unbatched", func(t *testing.T) {
-		cache := cache.NewMemcached(cache.MemcachedConfig{}, newMockMemcache())
+		cache := cache.NewMemcached(cache.MemcachedConfig{}, newMockMemcache(), "test")
 		testCache(t, cache)
 	})
 
@@ -148,7 +148,7 @@ func TestMemcache(t *testing.T) {
 		cache := cache.NewMemcached(cache.MemcachedConfig{
 			BatchSize:   10,
 			Parallelism: 3,
-		}, newMockMemcache())
+		}, newMockMemcache(), "test")
 		testCache(t, cache)
 	})
 }

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -14,21 +14,28 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	instr "github.com/weaveworks/common/instrument"
 )
 
 var (
-	memcacheRequestDuration = instr.NewHistogramCollector(prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	memcacheRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "cortex",
 		Name:      "memcache_request_duration_seconds",
 		Help:      "Total time spent in seconds doing memcache requests.",
 		// Memecache requests are very quick: smallest bucket is 16us, biggest is 1s
 		Buckets: prometheus.ExponentialBuckets(0.000016, 4, 8),
-	}, []string{"method", "status_code"}))
+	}, []string{"method", "status_code", "name"})
 )
 
-func init() {
-	memcacheRequestDuration.Register()
+type observableVecCollector struct {
+	v prometheus.ObserverVec
+}
+
+func (observableVecCollector) Register()                             {}
+func (observableVecCollector) Before(method string, start time.Time) {}
+func (o observableVecCollector) After(method, statusCode string, start time.Time) {
+	o.v.WithLabelValues(method, statusCode).Observe(time.Now().Sub(start).Seconds())
 }
 
 // MemcachedConfig is config to make a Memcached
@@ -50,16 +57,25 @@ func (cfg *MemcachedConfig) RegisterFlagsWithPrefix(prefix, description string, 
 type Memcached struct {
 	cfg      MemcachedConfig
 	memcache MemcachedClient
+	name     string
+
+	requestDuration observableVecCollector
 
 	wg      sync.WaitGroup
 	inputCh chan *work
 }
 
 // NewMemcached makes a new Memcache
-func NewMemcached(cfg MemcachedConfig, client MemcachedClient) *Memcached {
+func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string) *Memcached {
 	c := &Memcached{
 		cfg:      cfg,
 		memcache: client,
+		name:     name,
+		requestDuration: observableVecCollector{
+			v: memcacheRequestDuration.MustCurryWith(prometheus.Labels{
+				"name": name,
+			}),
+		},
 	}
 
 	if cfg.BatchSize == 0 || cfg.Parallelism == 0 {
@@ -116,7 +132,7 @@ func memcacheStatusCode(err error) string {
 
 // Fetch gets keys from the cache. The keys that are found must be in the order of the keys requested.
 func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missed []string) {
-	instr.CollectedRequest(ctx, "Memcache.Get", memcacheRequestDuration, memcacheStatusCode, func(ctx context.Context) error {
+	instr.CollectedRequest(ctx, "Memcache.Get", c.requestDuration, memcacheStatusCode, func(ctx context.Context) error {
 		if c.cfg.BatchSize == 0 {
 			found, bufs, missed = c.fetch(ctx, keys)
 			return nil
@@ -130,7 +146,7 @@ func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, b
 
 func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missed []string) {
 	var items map[string]*memcache.Item
-	instr.CollectedRequest(ctx, "Memcache.GetMulti", memcacheRequestDuration, memcacheStatusCode, func(_ context.Context) error {
+	instr.CollectedRequest(ctx, "Memcache.GetMulti", c.requestDuration, memcacheStatusCode, func(_ context.Context) error {
 		sp := opentracing.SpanFromContext(ctx)
 		sp.LogFields(otlog.Int("keys requested", len(keys)))
 
@@ -202,7 +218,7 @@ func (c *Memcached) fetchKeysBatched(ctx context.Context, keys []string) (found 
 // Store stores the key in the cache.
 func (c *Memcached) Store(ctx context.Context, keys []string, bufs [][]byte) {
 	for i := range keys {
-		err := instr.CollectedRequest(ctx, "Memcache.Put", memcacheRequestDuration, memcacheStatusCode, func(_ context.Context) error {
+		err := instr.CollectedRequest(ctx, "Memcache.Put", c.requestDuration, memcacheStatusCode, func(_ context.Context) error {
 			item := memcache.Item{
 				Key:        keys[i],
 				Value:      bufs[i],
@@ -211,7 +227,7 @@ func (c *Memcached) Store(ctx context.Context, keys []string, bufs [][]byte) {
 			return c.memcache.Set(&item)
 		})
 		if err != nil {
-			level.Error(util.Logger).Log("msg", "failed to put to memcached", "err", err)
+			level.Error(util.Logger).Log("msg", "failed to put to memcached", "name", c.name, "err", err)
 		}
 	}
 }

--- a/pkg/chunk/cache/memcached_test.go
+++ b/pkg/chunk/cache/memcached_test.go
@@ -14,7 +14,7 @@ import (
 func TestMemcached(t *testing.T) {
 	t.Run("unbatched", func(t *testing.T) {
 		client := newMockMemcache()
-		memcache := cache.NewMemcached(cache.MemcachedConfig{}, client)
+		memcache := cache.NewMemcached(cache.MemcachedConfig{}, client, "test")
 
 		testMemcache(t, memcache)
 	})
@@ -24,7 +24,7 @@ func TestMemcached(t *testing.T) {
 		memcache := cache.NewMemcached(cache.MemcachedConfig{
 			BatchSize:   10,
 			Parallelism: 5,
-		}, client)
+		}, client, "test")
 
 		testMemcache(t, memcache)
 	})
@@ -89,7 +89,7 @@ func (c *mockMemcacheFailing) GetMulti(keys []string) (map[string]*memcache.Item
 func TestMemcacheFailure(t *testing.T) {
 	t.Run("unbatched", func(t *testing.T) {
 		client := newMockMemcacheFailing()
-		memcache := cache.NewMemcached(cache.MemcachedConfig{}, client)
+		memcache := cache.NewMemcached(cache.MemcachedConfig{}, client, "test")
 
 		testMemcacheFailing(t, memcache)
 	})
@@ -99,7 +99,7 @@ func TestMemcacheFailure(t *testing.T) {
 		memcache := cache.NewMemcached(cache.MemcachedConfig{
 			BatchSize:   10,
 			Parallelism: 5,
-		}, client)
+		}, client, "test")
 
 		testMemcacheFailing(t, memcache)
 	})

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -59,7 +59,7 @@ func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConf
 		client := cache.NewMemcachedClient(cfg.memcacheClient)
 		memcache := cache.Instrument("memcache-index", cache.NewMemcached(cache.MemcachedConfig{
 			Expiration: cfg.IndexCacheValidity,
-		}, client))
+		}, client, "memcache-index"))
 		caches = append(caches, cache.NewBackground("memcache-index", cache.BackgroundConfig{
 			WriteBackGoroutines: 10,
 			WriteBackBuffer:     100,


### PR DESCRIPTION
We were seeing this in the logs:

```
level=error ts=2018-12-31T15:26:44.021869855Z caller=memcached.go:216 msg="failed to put to memcached" name=store.index-cache-read. err="memcache: unexpected response line from \"set\": \"SERVER_ERROR object too large for cache\\r\\n\""
```

And it wasn't clear whether this was the chunk memcache or the index memcache.  So I added the "cache name" to the logs and metrics.