### PR TITLE
Query frontend optimisations.

### DIFF
--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -297,7 +297,7 @@ func init() {
 		sample := (*Sample)(ptr)
 
 		stream.WriteArrayStart()
-		stream.WriteRaw(model.Time(sample.TimestampMs).String())
+		stream.WriteFloat64(float64(sample.TimestampMs) / float64(time.Second/time.Millisecond))
 		stream.WriteMore()
 		stream.WriteString(model.SampleValue(sample.Value).String())
 		stream.WriteArrayEnd()
@@ -322,7 +322,7 @@ func init() {
 		ss := *(*string)(unsafe.Pointer(&bs))
 		v, err := strconv.ParseFloat(ss, 64)
 		if err != nil {
-			iter.ReportError("client.Sample", "expected ,")
+			iter.ReportError("client.Sample", err.Error())
 			return
 		}
 

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -108,7 +108,7 @@ func New(cfg Config, log log.Logger) (*Frontend, error) {
 		if err != nil {
 			return nil, err
 		}
-		queryRangeMiddleware = append(queryRangeMiddleware, queryCacheMiddleware)
+		queryRangeMiddleware = append(queryRangeMiddleware, instrument("results_cache"), queryCacheMiddleware)
 	}
 
 	// Finally, if the user selected any query range middleware, stitch it in.

--- a/pkg/querier/frontend/instrumentation.go
+++ b/pkg/querier/frontend/instrumentation.go
@@ -1,0 +1,30 @@
+package frontend
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	instr "github.com/weaveworks/common/instrument"
+)
+
+var queryRangeDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "cortex",
+	Name:      "frontend_query_range_duration_seconds",
+	Help:      "Total time spent in seconds doing query range requests.",
+	Buckets:   prometheus.DefBuckets,
+}, []string{"method", "status_code"})
+
+func instrument(name string) queryRangeMiddleware {
+	return queryRangeMiddlewareFunc(func(next queryRangeHandler) queryRangeHandler {
+		return queryRangeHandlerFunc(func(ctx context.Context, req *QueryRangeRequest) (*APIResponse, error) {
+			var resp *APIResponse
+			err := instr.TimeRequestHistogram(ctx, name, queryRangeDuration, func(ctx context.Context) error {
+				var err error
+				resp, err = next.Do(ctx, req)
+				return err
+			})
+			return resp, err
+		})
+	})
+}

--- a/pkg/querier/frontend/marshaling_test.go
+++ b/pkg/querier/frontend/marshaling_test.go
@@ -1,0 +1,33 @@
+package frontend
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkMarshalling(b *testing.B) {
+	jsonfile := os.Getenv("JSON")
+	buf, err := ioutil.ReadFile(jsonfile)
+	require.NoError(b, err)
+
+	for n := 0; n < b.N; n++ {
+		apiResp, err := parseQueryRangeResponse(context.Background(), &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader(buf)),
+		})
+		require.NoError(b, err)
+
+		resp, err := apiResp.toHTTPResponse(context.Background())
+		require.NoError(b, err)
+
+		buf2, err := ioutil.ReadAll(resp.Body)
+		require.NoError(b, err)
+		require.Equal(b, string(buf), string(buf2))
+	}
+}

--- a/pkg/querier/frontend/query_range_test.go
+++ b/pkg/querier/frontend/query_range_test.go
@@ -123,7 +123,7 @@ func TestQueryRangeResponse(t *testing.T) {
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 				Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(tc.body))),
 			}
-			resp, err := parseQueryRangeResponse(response)
+			resp, err := parseQueryRangeResponse(context.Background(), response)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, resp)
 
@@ -133,7 +133,7 @@ func TestQueryRangeResponse(t *testing.T) {
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 				Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(tc.body))),
 			}
-			resp2, err := resp.toHTTPResponse()
+			resp2, err := resp.toHTTPResponse(context.Background())
 			require.NoError(t, err)
 			assert.Equal(t, response, resp2)
 		})

--- a/pkg/querier/frontend/results_cache.go
+++ b/pkg/querier/frontend/results_cache.go
@@ -197,7 +197,7 @@ func (s resultsCache) filterRecentExtents(req *QueryRangeRequest, extents []Exte
 }
 
 func (s resultsCache) get(ctx context.Context, key string) ([]Extent, bool) {
-	found, buf, _ := s.cache.Fetch(ctx, []string{cache.HashKey(key)})
+	found, bufs, _ := s.cache.Fetch(ctx, []string{cache.HashKey(key)})
 	if len(found) != 1 {
 		return nil, false
 	}
@@ -206,7 +206,9 @@ func (s resultsCache) get(ctx context.Context, key string) ([]Extent, bool) {
 	sp, _ := opentracing.StartSpanFromContext(ctx, "unmarshal-extent")
 	defer sp.Finish()
 
-	if err := proto.Unmarshal(buf[0], &resp); err != nil {
+	sp.LogFields(otlog.Int("bytes", len(bufs[0])))
+
+	if err := proto.Unmarshal(bufs[0], &resp); err != nil {
 		level.Error(util.Logger).Log("msg", "error unmarshaling cached value", "err", err)
 		sp.LogFields(otlog.Error(err))
 		return nil, false

--- a/pkg/querier/frontend/roundtrip.go
+++ b/pkg/querier/frontend/roundtrip.go
@@ -91,7 +91,7 @@ func (q queryRangeRoundTripper) RoundTrip(r *http.Request) (*http.Response, erro
 		return nil, err
 	}
 
-	return response.toHTTPResponse()
+	return response.toHTTPResponse(r.Context())
 }
 
 type queryRangeTerminator struct {
@@ -117,5 +117,5 @@ func (q queryRangeTerminator) Do(ctx context.Context, r *QueryRangeRequest) (*AP
 	}
 	defer response.Body.Close()
 
-	return parseQueryRangeResponse(response)
+	return parseQueryRangeResponse(ctx, response)
 }

--- a/pkg/querier/frontend/split_by_day.go
+++ b/pkg/querier/frontend/split_by_day.go
@@ -7,11 +7,11 @@ import (
 
 const millisecondPerDay = int64(24 * time.Hour / time.Millisecond)
 
-var splitByDayMiddleware queryRangeMiddlewareFunc = func(next queryRangeHandler) queryRangeHandler {
-	return splitByDay{
+var splitByDayMiddleware = queryRangeMiddlewareFunc(func(next queryRangeHandler) queryRangeHandler {
+	return instrument("split_by_day").Wrap(splitByDay{
 		next: next,
-	}
-}
+	})
+})
 
 type splitByDay struct {
 	next queryRangeHandler

--- a/pkg/querier/frontend/split_by_day_test.go
+++ b/pkg/querier/frontend/split_by_day_test.go
@@ -154,7 +154,7 @@ func TestSplitByDay(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	mergedHTTPResponse, err := mergedResponse.toHTTPResponse()
+	mergedHTTPResponse, err := mergedResponse.toHTTPResponse(context.Background())
 	require.NoError(t, err)
 
 	mergedHTTPResponseBody, err := ioutil.ReadAll(mergedHTTPResponse.Body)

--- a/pkg/querier/frontend/step_align.go
+++ b/pkg/querier/frontend/step_align.go
@@ -4,11 +4,11 @@ import (
 	"context"
 )
 
-var stepAlignMiddleware queryRangeMiddlewareFunc = func(next queryRangeHandler) queryRangeHandler {
-	return stepAlign{
+var stepAlignMiddleware = queryRangeMiddlewareFunc(func(next queryRangeHandler) queryRangeHandler {
+	return instrument("step_align").Wrap(stepAlign{
 		next: next,
-	}
-}
+	})
+})
 
 type stepAlign struct {
 	next queryRangeHandler


### PR DESCRIPTION
We were seeing the query frontend adding 500ms - 1s to some queries, for instance when the query results JSON is large (1-5MB).  The query itself is only taking ~200ms on the querier.

- Add various spans to the query frontend to see where the latency was.  Its mostly in the JSON marshaling / unmarshaling.
- Switch some more JSON code over to jsoniter, and write a zero-copy marshal / unmarshal function for Samples.

End result is reducing query latency of this particular case by about 50%.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>