### PR TITLE
Ensure ingester.QueryStream stops early when the RPC is cancelled.

### DIFF
--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -263,15 +263,12 @@ func (u *userState) forSeriesMatching(ctx context.Context, allMatchers []*labels
 	}
 
 	level.Debug(log).Log("series", len(fps))
-	done := ctx.Done()
 
 	// fps is sorted, lock them in order to prevent deadlocks
 outer:
 	for _, fp := range fps {
-		select {
-		case <-done:
-			return ctx.Err()
-		default:
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 
 		u.fpLocker.Lock(fp)


### PR DESCRIPTION
Fixes #1149 

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>