### PR TITLE
[WIP] Add gRPC connection pooling for distributor->ingester connections.

### DIFF
--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -11,11 +11,11 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 	"github.com/pkg/errors"
 )
 
@@ -33,7 +33,7 @@ type Config struct {
 	Project  string `yaml:"project"`
 	Instance string `yaml:"instance"`
 
-	grpcMaxRecvMsgSize int
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config"`
 
 	ColumnKey bool
 }
@@ -42,7 +42,11 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.Project, "bigtable.project", "", "Bigtable project ID.")
 	f.StringVar(&cfg.Instance, "bigtable.instance", "", "Bigtable instance ID.")
-	f.IntVar(&cfg.grpcMaxRecvMsgSize, "bigtable.max-recv-msg-size", 100<<20, "Bigtable grpc max receive message size.")
+
+	cfg.GRPCClientConfig.RegisterFlags("bigtable", f)
+
+	// Deprecated.
+	f.Int("bigtable.max-recv-msg-size", 100<<20, "DEPRECATED. Bigtable grpc max receive message size.")
 }
 
 // storageClientColumnKey implements chunk.storageClient for GCP.
@@ -61,7 +65,7 @@ type storageClientV1 struct {
 // NewStorageClientV1 returns a new v1 StorageClient.
 func NewStorageClientV1(ctx context.Context, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.IndexClient, error) {
 	opts := instrumentation()
-	opts = append(opts, option.WithGRPCDialOption(grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(cfg.grpcMaxRecvMsgSize))))
+	opts = append(opts, option.WithGRPCDialOption(cfg.GRPCClientConfig.DialOption()))
 
 	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, opts...)
 	if err != nil {

--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -65,7 +65,9 @@ type storageClientV1 struct {
 // NewStorageClientV1 returns a new v1 StorageClient.
 func NewStorageClientV1(ctx context.Context, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.IndexClient, error) {
 	opts := instrumentation()
-	opts = append(opts, option.WithGRPCDialOption(cfg.GRPCClientConfig.DialOption()))
+	for _, dialOption := range cfg.GRPCClientConfig.DialOptions() {
+		opts = append(opts, option.WithGRPCDialOption(dialOption))
+	}
 
 	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, opts...)
 	if err != nil {

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -50,9 +50,8 @@ func MakeIngesterClient(addr string, cfg Config) (HealthAndIngesterClient, error
 			middleware.StreamClientUserHeaderInterceptor,
 			cortex_middleware.PrometheusGRPCStreamInstrumentation(ingesterClientRequestDuration),
 		)),
-		cfg.GRPCClientConfig.DialOption(),
-		grpc.WithBalancer(grpc.RoundRobin(grpcclient.NewPoolResolver(10))),
 	}
+	opts = append(opts, cfg.GRPCClientConfig.DialOptions()...)
 	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -51,6 +51,7 @@ func MakeIngesterClient(addr string, cfg Config) (HealthAndIngesterClient, error
 			cortex_middleware.PrometheusGRPCStreamInstrumentation(ingesterClientRequestDuration),
 		)),
 		cfg.GRPCClientConfig.DialOption(),
+		grpc.WithBalancer(grpc.RoundRobin(grpcclient.NewPoolResolver(10))),
 	}
 	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {

--- a/pkg/querier/frontend/worker.go
+++ b/pkg/querier/frontend/worker.go
@@ -212,14 +212,14 @@ func (w *worker) process(ctx context.Context, c Frontend_ProcessClient) error {
 }
 
 func (w *worker) connect(address string) (FrontendClient, error) {
-	conn, err := grpc.Dial(
-		address,
+	opts := []grpc.DialOption{
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(
 			middleware.ClientUserHeaderInterceptor,
 		)),
-		w.cfg.GRPCClientConfig.DialOption(),
-	)
+	}
+	opts = append(opts, w.cfg.GRPCClientConfig.DialOptions()...)
+	conn, err := grpc.Dial(address, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/grpcclient/grpcclient.go
+++ b/pkg/util/grpcclient/grpcclient.go
@@ -11,6 +11,7 @@ type Config struct {
 	MaxRecvMsgSize     int  `yaml:"max_recv_msg_size"`
 	MaxSendMsgSize     int  `yaml:"max_send_msg_size"`
 	UseGzipCompression bool `yaml:"use_gzip_compression"`
+	ConnectionPoolSize int  `yaml:"connect_pool_size"`
 }
 
 // RegisterFlags registers flags.
@@ -18,6 +19,7 @@ func (cfg *Config) RegisterFlags(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxRecvMsgSize, prefix+".grpc-max-recv-msg-size", 100<<20, "gRPC client max receive message size (bytes).")
 	f.IntVar(&cfg.MaxSendMsgSize, prefix+".grpc-max-send-msg-size", 16<<20, "gRPC client max send message size (bytes).")
 	f.BoolVar(&cfg.UseGzipCompression, prefix+".grpc-use-gzip-compression", false, "Use compression when sending messages.")
+	f.IntVar(&cfg.ConnectionPoolSize, prefix+".grpc-connection-pool-size", 1, "Number of connections to keep active per endpoint.")
 }
 
 // CallOptions returns the config in terms of CallOptions.
@@ -31,7 +33,10 @@ func (cfg *Config) CallOptions() []grpc.CallOption {
 	return opts
 }
 
-// DialOption returns the config as a grpc.DialOptions.
-func (cfg *Config) DialOption() grpc.DialOption {
-	return grpc.WithDefaultCallOptions(cfg.CallOptions()...)
+// DialOptions returns the config as a grpc.DialOptions.
+func (cfg *Config) DialOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithDefaultCallOptions(cfg.CallOptions()...),
+		grpc.WithBalancer(grpc.RoundRobin(NewPoolResolver(cfg.ConnectionPoolSize))),
+	}
 }

--- a/pkg/util/grpcclient/grpcclient.go
+++ b/pkg/util/grpcclient/grpcclient.go
@@ -35,8 +35,9 @@ func (cfg *Config) CallOptions() []grpc.CallOption {
 
 // DialOptions returns the config as a grpc.DialOptions.
 func (cfg *Config) DialOptions() []grpc.DialOption {
-	return []grpc.DialOption{
-		grpc.WithDefaultCallOptions(cfg.CallOptions()...),
-		grpc.WithBalancer(grpc.RoundRobin(NewPoolResolver(cfg.ConnectionPoolSize))),
+	result := []grpc.DialOption{grpc.WithDefaultCallOptions(cfg.CallOptions()...)}
+	if cfg.ConnectionPoolSize > 1 {
+		result = append(result, grpc.WithBalancer(grpc.RoundRobin(NewPoolResolver(cfg.ConnectionPoolSize))))
 	}
+	return result
 }

--- a/pkg/util/grpcclient/grpcclient.go
+++ b/pkg/util/grpcclient/grpcclient.go
@@ -1,0 +1,37 @@
+package grpcclient
+
+import (
+	"flag"
+
+	"google.golang.org/grpc"
+)
+
+// Config for a gRPC client.
+type Config struct {
+	MaxRecvMsgSize     int  `yaml:"max_recv_msg_size"`
+	MaxSendMsgSize     int  `yaml:"max_send_msg_size"`
+	UseGzipCompression bool `yaml:"use_gzip_compression"`
+}
+
+// RegisterFlags registers flags.
+func (cfg *Config) RegisterFlags(prefix string, f *flag.FlagSet) {
+	f.IntVar(&cfg.MaxRecvMsgSize, prefix+".grpc-max-recv-msg-size", 100<<20, "gRPC client max receive message size (bytes).")
+	f.IntVar(&cfg.MaxSendMsgSize, prefix+".grpc-max-send-msg-size", 16<<20, "gRPC client max send message size (bytes).")
+	f.BoolVar(&cfg.UseGzipCompression, prefix+".grpc-use-gzip-compression", false, "Use compression when sending messages.")
+}
+
+// CallOptions returns the config in terms of CallOptions.
+func (cfg *Config) CallOptions() []grpc.CallOption {
+	var opts []grpc.CallOption
+	opts = append(opts, grpc.MaxCallRecvMsgSize(cfg.MaxRecvMsgSize))
+	opts = append(opts, grpc.MaxCallSendMsgSize(cfg.MaxSendMsgSize))
+	if cfg.UseGzipCompression {
+		opts = append(opts, grpc.UseCompressor("gzip"))
+	}
+	return opts
+}
+
+// DialOption returns the config as a grpc.DialOptions.
+func (cfg *Config) DialOption() grpc.DialOption {
+	return grpc.WithDefaultCallOptions(cfg.CallOptions()...)
+}

--- a/pkg/util/grpcclient/pool.go
+++ b/pkg/util/grpcclient/pool.go
@@ -41,7 +41,7 @@ func (w *poolWatcher) Next() ([]*naming.Update, error) {
 		return nil, err
 	}
 
-	result := make([]*naming.Update, 0, len(updates)*w.size)
+	result := make([]*naming.Update, len(updates)*w.size)
 	for i := 0; i < len(updates)*w.size; i++ {
 		result[i] = updates[i/w.size]
 	}

--- a/pkg/util/grpcclient/pool.go
+++ b/pkg/util/grpcclient/pool.go
@@ -1,0 +1,53 @@
+package grpcclient
+
+import (
+	"google.golang.org/grpc/naming"
+)
+
+type poolResolver struct {
+	size int
+	next naming.Resolver
+}
+
+// NewPoolResolver returns a PoolResolver.
+func NewPoolResolver(size int) naming.Resolver {
+	resolver, _ := naming.NewDNSResolver()
+	return &poolResolver{
+		size: size,
+		next: resolver,
+	}
+}
+
+func (r *poolResolver) Resolve(target string) (naming.Watcher, error) {
+	watcher, err := r.next.Resolve(target)
+	if err != nil {
+		return nil, err
+	}
+
+	return &poolWatcher{
+		size: r.size,
+		next: watcher,
+	}, nil
+}
+
+type poolWatcher struct {
+	size int
+	next naming.Watcher
+}
+
+func (w *poolWatcher) Next() ([]*naming.Update, error) {
+	updates, err := w.next.Next()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*naming.Update, 0, len(updates)*w.size)
+	for i := 0; i < len(updates)*w.size; i++ {
+		result[i] = updates[i/w.size]
+	}
+	return result, nil
+}
+
+func (w *poolWatcher) Close() {
+	w.next.Close()
+}


### PR DESCRIPTION
This is done inspired by a 'hack' in the bigtable client, where they use a resolver to return N copies of the same address.  This is a little more generic.

Hope is this will help combat some of the very high tail latencies we see for distributor pushes.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>