### PR TITLE
Change chunkSize metric to include metadata overhead

### DIFF
--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -240,6 +240,11 @@ func (c *Chunk) Encode() ([]byte, error) {
 	return c.encoded, nil
 }
 
+// EncodedSize returns the number of bytes in the encoded data for this chunk
+func (c *Chunk) EncodedSize() int {
+	return len(c.encoded)
+}
+
 // DecodeContext holds data that can be re-used between decodes of different chunks
 type DecodeContext struct {
 	reader *snappy.Reader

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -316,8 +316,9 @@ func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, metric
 	}
 
 	// Record statistsics only when actual put request did not return error.
-	for _, chunkDesc := range chunkDescs {
-		utilization, length, size := chunkDesc.C.Utilization(), chunkDesc.C.Len(), chunkDesc.C.Size()
+	for i, chunkDesc := range chunkDescs {
+		utilization, length := chunkDesc.C.Utilization(), chunkDesc.C.Len()
+		size := wireChunks[i].EncodedSize()
 		util.Event().Log("msg", "chunk flushed", "userID", userID, "fp", fp, "series", metric, "utilization", utilization, "length", length, "size", size, "firstTime", chunkDesc.FirstTime, "lastTime", chunkDesc.LastTime)
 		chunkUtilization.Observe(utilization)
 		chunkLength.Observe(float64(length))


### PR DESCRIPTION
The value of `cortex_ingester_chunk_size_bytes` will be a few hundred bytes higher after this change.

I am open to creating a new metric for this, but don't really want to since the old one is not very useful compared to this one.
