### PR TITLE
Track dropped metrics due to series limits too

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -33,10 +33,6 @@ import (
 	"github.com/weaveworks/common/user"
 )
 
-const (
-	rateLimited = "rate_limited"
-)
-
 var (
 	queryDuration = instrument.NewHistogramCollector(promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "cortex",
@@ -289,7 +285,7 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 	if !limiter.AllowN(time.Now(), numSamples) {
 		// Return a 4xx here to have the client discard the data and not retry. If a client
 		// is sending too much data consistently we will unlikely ever catch up otherwise.
-		validation.DiscardedSamples.WithLabelValues(rateLimited, userID).Add(float64(numSamples))
+		validation.DiscardedSamples.WithLabelValues(validation.RateLimited, userID).Add(float64(numSamples))
 		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, "ingestion rate limit (%v) exceeded while adding %d samples", limiter.Limit(), numSamples)
 	}
 

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -188,7 +188,7 @@ func (u *userState) getSeries(metric labelPairs) (model.Fingerprint, *memorySeri
 	// serially), and the overshoot in allowed series would be minimal.
 	if u.fpToSeries.length() >= u.limits.MaxSeriesPerUser(u.userID) {
 		u.fpLocker.Unlock(fp)
-		validation.DiscardedSamples.WithLabelValues("rate_limited", u.userID).Inc()
+		validation.DiscardedSamples.WithLabelValues(validation.RateLimited, u.userID).Inc()
 		return fp, nil, httpgrpc.Errorf(http.StatusTooManyRequests, "per-user series limit (%d) exceeded", u.limits.MaxSeriesPerUser(u.userID))
 	}
 
@@ -200,7 +200,7 @@ func (u *userState) getSeries(metric labelPairs) (model.Fingerprint, *memorySeri
 
 	if !u.canAddSeriesFor(string(metricName)) {
 		u.fpLocker.Unlock(fp)
-		validation.DiscardedSamples.WithLabelValues("rate_limited", u.userID).Inc()
+		validation.DiscardedSamples.WithLabelValues(validation.RateLimited, u.userID).Inc()
 		return fp, nil, httpgrpc.Errorf(http.StatusTooManyRequests, "per-metric series limit (%d) exceeded for %s: %s", u.limits.MaxSeriesPerMetric(u.userID), metricName, metric)
 	}
 

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -188,6 +188,7 @@ func (u *userState) getSeries(metric labelPairs) (model.Fingerprint, *memorySeri
 	// serially), and the overshoot in allowed series would be minimal.
 	if u.fpToSeries.length() >= u.limits.MaxSeriesPerUser(u.userID) {
 		u.fpLocker.Unlock(fp)
+		validation.DiscardedSamples.WithLabelValues("rate_limited", u.userID).Inc()
 		return fp, nil, httpgrpc.Errorf(http.StatusTooManyRequests, "per-user series limit (%d) exceeded", u.limits.MaxSeriesPerUser(u.userID))
 	}
 
@@ -199,6 +200,7 @@ func (u *userState) getSeries(metric labelPairs) (model.Fingerprint, *memorySeri
 
 	if !u.canAddSeriesFor(string(metricName)) {
 		u.fpLocker.Unlock(fp)
+		validation.DiscardedSamples.WithLabelValues("rate_limited", u.userID).Inc()
 		return fp, nil, httpgrpc.Errorf(http.StatusTooManyRequests, "per-metric series limit (%d) exceeded for %s: %s", u.limits.MaxSeriesPerMetric(u.userID), metricName, metric)
 	}
 

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -28,6 +28,10 @@ const (
 	invalidLabel            = "label_invalid"
 	labelNameTooLong        = "label_name_too_long"
 	labelValueTooLong       = "label_value_too_long"
+
+	// RateLimited is one of the values for the reason to discard samples.
+	// Declared here to avoid duplication in ingester and distributor.
+	RateLimited = "rate_limited"
 )
 
 // DiscardedSamples is a metric of the number of discarded samples, by reason.


### PR DESCRIPTION
We alert on our customers hitting limits but they don't trigger when the sample is dropped due to series limits being hit.