### PR TITLE
k8s: fix dynamodb.periodic-table.start parameters

### DIFF
--- a/k8s/ingester-dep.yaml
+++ b/k8s/ingester-dep.yaml
@@ -44,7 +44,7 @@ spec:
         - -dynamodb.original-table-name=cortex
         - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
         - -dynamodb.periodic-table.prefix=cortex_weekly_
-        - -dynamodb.periodic-table.start=2017-01-06
+        - -dynamodb.periodic-table.from=2017-01-06
         - -dynamodb.daily-buckets-from=2017-01-10
         - -dynamodb.base64-buckets-from=2017-01-17
         - -dynamodb.v4-schema-from=2017-02-05

--- a/k8s/querier-dep.yaml
+++ b/k8s/querier-dep.yaml
@@ -22,7 +22,7 @@ spec:
         - -dynamodb.original-table-name=cortex
         - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
         - -dynamodb.periodic-table.prefix=cortex_weekly_
-        - -dynamodb.periodic-table.start=2017-01-06
+        - -dynamodb.periodic-table.from=2017-01-06
         - -dynamodb.daily-buckets-from=2017-01-10
         - -dynamodb.base64-buckets-from=2017-01-17
         - -dynamodb.v4-schema-from=2017-02-05

--- a/k8s/ruler-dep.yaml
+++ b/k8s/ruler-dep.yaml
@@ -24,7 +24,7 @@ spec:
         - -dynamodb.original-table-name=cortex
         - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
         - -dynamodb.periodic-table.prefix=cortex_weekly_
-        - -dynamodb.periodic-table.start=2017-01-06
+        - -dynamodb.periodic-table.from=2017-01-06
         - -dynamodb.daily-buckets-from=2017-01-10
         - -dynamodb.base64-buckets-from=2017-01-17
         - -dynamodb.v4-schema-from=2017-02-05

--- a/k8s/table-manager-dep.yaml
+++ b/k8s/table-manager-dep.yaml
@@ -19,7 +19,7 @@ spec:
         - -dynamodb.original-table-name=cortex
         - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
         - -dynamodb.periodic-table.prefix=cortex_weekly_
-        - -dynamodb.periodic-table.start=2017-01-06
+        - -dynamodb.periodic-table.from=2017-01-06
         - -dynamodb.chunk-table.from=2017-04-17
         ports:
         - containerPort: 80


### PR DESCRIPTION
If I understand correctly, support for .start has been removed in
6e923f31d1678612faf39ca120f7178a6463a568, so examples should use
.from.

Signed-off-by: Mateusz Gozdek <mateusz.gozdek@dunnhumby.com>