### PR TITLE
Make chunk size histogram buckets more useful

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -38,7 +38,7 @@ var (
 	chunkSize = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "cortex_ingester_chunk_size_bytes",
 		Help:    "Distribution of stored chunk sizes (when stored).",
-		Buckets: prometheus.ExponentialBuckets(10, 10, 5), // biggest bucket is 5*2^(11-1) = 5120
+		Buckets: prometheus.ExponentialBuckets(500, 2, 5), // biggest bucket is 500*2^(5-1) = 8000
 	})
 	chunkAge = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name: "cortex_ingester_chunk_age_seconds",


### PR DESCRIPTION
Small (v1) chunks are all around 1100-1500 bytes; bigchunks (v2) start around 400 bytes and go up to around 8K. Make the buckets provide more resolution around these sizes.

(also the comment was incorrect previously)