### PR TITLE
Make chunk encoding an explicit operation

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -637,8 +637,7 @@ func (a dynamoDBStorageClient) PutChunks(ctx context.Context, chunks []chunk.Chu
 	)
 
 	for i := range chunks {
-		// Encode the chunk first - checksum is calculated as a side effect.
-		buf, err := chunks[i].Encode()
+		buf, err := chunks[i].Encoded()
 		if err != nil {
 			return err
 		}

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -95,8 +95,7 @@ func (a s3ObjectClient) PutChunks(ctx context.Context, chunks []chunk.Chunk) err
 	)
 
 	for i := range chunks {
-		// Encode the chunk first - checksum is calculated as a side effect.
-		buf, err := chunks[i].Encode()
+		buf, err := chunks[i].Encoded()
 		if err != nil {
 			return err
 		}

--- a/pkg/chunk/cache/cache_test.go
+++ b/pkg/chunk/cache/cache_test.go
@@ -44,7 +44,9 @@ func fillCache(t *testing.T, cache cache.Cache) ([]string, []chunk.Chunk) {
 			ts.Add(chunkLen),
 		)
 
-		buf, err := c.Encode()
+		err := c.Encode()
+		require.NoError(t, err)
+		buf, err := c.Encoded()
 		require.NoError(t, err)
 
 		keys = append(keys, c.ExternalKey())

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -265,8 +265,7 @@ func (b *readBatchIter) Value() []byte {
 // PutChunks implements chunk.ObjectClient.
 func (s *StorageClient) PutChunks(ctx context.Context, chunks []chunk.Chunk) error {
 	for i := range chunks {
-		// Encode the chunk first - checksum is calculated as a side effect.
-		buf, err := chunks[i].Encode()
+		buf, err := chunks[i].Encoded()
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -29,7 +29,6 @@ const (
 	ErrWrongMetadata   = errs.Error("wrong chunk metadata")
 	ErrMetadataLength  = errs.Error("chunk metadata wrong length")
 	ErrDataLength      = errs.Error("chunk data wrong length")
-	ErrNotEncoded      = errs.Error("Chunk not encoded")
 )
 
 var castagnoliTable = crc32.MakeTable(crc32.Castagnoli)
@@ -240,7 +239,9 @@ func (c *Chunk) Encode() error {
 // Encoded returns the buffer created by Encoded()
 func (c *Chunk) Encoded() ([]byte, error) {
 	if c.encoded == nil {
-		return nil, errors.WithStack(ErrNotEncoded)
+		if err := c.Encode(); err != nil {
+			return nil, err
+		}
 	}
 	return c.encoded, nil
 }

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -128,9 +128,6 @@ func (c *store) PutOne(ctx context.Context, from, through model.Time, chunk Chun
 		return err
 	}
 
-	// Horribly, PutChunks mutates the chunk by setting its checksum.  By putting
-	// the chunk in a slice we are in fact passing by reference, so below we
-	// need to make sure we pick the chunk back out the slice.
 	chunks := []Chunk{chunk}
 
 	err = c.storage.PutChunks(ctx, chunks)
@@ -140,7 +137,7 @@ func (c *store) PutOne(ctx context.Context, from, through model.Time, chunk Chun
 
 	c.writeBackCache(ctx, chunks)
 
-	writeReqs, err := c.calculateIndexEntries(userID, from, through, chunks[0])
+	writeReqs, err := c.calculateIndexEntries(userID, from, through, chunk)
 	if err != nil {
 		return err
 	}

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -430,8 +430,9 @@ func TestChunkStoreRandom(t *testing.T) {
 					ts,
 					ts.Add(chunkLen*time.Second),
 				)
-
-				err := store.Put(ctx, []Chunk{chunk})
+				err := chunk.Encode()
+				require.NoError(t, err)
+				err = store.Put(ctx, []Chunk{chunk})
 				require.NoError(t, err)
 			}
 
@@ -495,7 +496,9 @@ func TestChunkStoreLeastRead(t *testing.T) {
 			ts.Add(chunkLen*time.Second),
 		)
 		t.Logf("Loop %d", i)
-		err := store.Put(ctx, []Chunk{chunk})
+		err := chunk.Encode()
+		require.NoError(t, err)
+		err = store.Put(ctx, []Chunk{chunk})
 		require.NoError(t, err)
 	}
 
@@ -545,12 +548,16 @@ func TestIndexCachingWorks(t *testing.T) {
 	storage := store.(CompositeStore).stores[0].Store.(*seriesStore).storage.(*MockStorage)
 
 	fooChunk1 := dummyChunkFor(model.Time(0).Add(15*time.Second), metric)
-	err := store.Put(ctx, []Chunk{fooChunk1})
+	err := fooChunk1.Encode()
+	require.NoError(t, err)
+	err = store.Put(ctx, []Chunk{fooChunk1})
 	require.NoError(t, err)
 	n := storage.numWrites
 
 	// Only one extra entry for the new chunk of same series.
 	fooChunk2 := dummyChunkFor(model.Time(0).Add(30*time.Second), metric)
+	err = fooChunk2.Encode()
+	require.NoError(t, err)
 	err = store.Put(ctx, []Chunk{fooChunk2})
 	require.NoError(t, err)
 	require.Equal(t, n+1, storage.numWrites)

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -142,7 +142,7 @@ func (c *Fetcher) writeBackCache(ctx context.Context, chunks []Chunk) error {
 	keys := make([]string, 0, len(chunks))
 	bufs := make([][]byte, 0, len(chunks))
 	for i := range chunks {
-		encoded, err := chunks[i].Encode()
+		encoded, err := chunks[i].Encoded()
 		// TODO don't fail, just log and conitnue?
 		if err != nil {
 			return err

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -47,7 +47,7 @@ func dummyChunkForEncoding(now model.Time, metric model.Metric, enc encoding.Enc
 		now,
 	)
 	// Force checksum calculation.
-	_, err := chunk.Encode()
+	err := chunk.Encode()
 	if err != nil {
 		panic(err)
 	}
@@ -98,7 +98,9 @@ func TestChunkCodec(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
-			encoded, err := c.chunk.Encode()
+			err := c.chunk.Encode()
+			require.NoError(t, err)
+			encoded, err := c.chunk.Encoded()
 			require.NoError(t, err)
 
 			have, err := ParseExternalKey(userID, c.chunk.ExternalKey())
@@ -234,7 +236,9 @@ func BenchmarkDecode10000(b *testing.B) { benchmarkDecode(b, 10000) }
 
 func benchmarkDecode(b *testing.B, batchSize int) {
 	chunk := benchmarkChunk(model.Now())
-	buf, err := chunk.Encode()
+	err := chunk.Encode()
+	require.NoError(b, err)
+	buf, err := chunk.Encoded()
 	require.NoError(b, err)
 
 	b.ResetTimer()

--- a/pkg/chunk/gcp/bigtable_object_client.go
+++ b/pkg/chunk/gcp/bigtable_object_client.go
@@ -46,8 +46,7 @@ func (s *bigtableObjectClient) PutChunks(ctx context.Context, chunks []chunk.Chu
 	muts := map[string][]*bigtable.Mutation{}
 
 	for i := range chunks {
-		// Encode the chunk first - checksum is calculated as a side effect.
-		buf, err := chunks[i].Encode()
+		buf, err := chunks[i].Encoded()
 		if err != nil {
 			return err
 		}

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -54,7 +54,7 @@ func (s *gcsObjectClient) Stop() {
 
 func (s *gcsObjectClient) PutChunks(ctx context.Context, chunks []chunk.Chunk) error {
 	for _, chunk := range chunks {
-		buf, err := chunk.Encode()
+		buf, err := chunk.Encoded()
 		if err != nil {
 			return err
 		}

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -266,7 +266,7 @@ func (m *MockStorage) PutChunks(_ context.Context, chunks []Chunk) error {
 	defer m.mtx.Unlock()
 
 	for i := range chunks {
-		buf, err := chunks[i].Encode()
+		buf, err := chunks[i].Encoded()
 		if err != nil {
 			return err
 		}

--- a/pkg/chunk/local/fs_object_client.go
+++ b/pkg/chunk/local/fs_object_client.go
@@ -40,8 +40,7 @@ func (fsObjectClient) Stop() {}
 
 func (f *fsObjectClient) PutChunks(_ context.Context, chunks []chunk.Chunk) error {
 	for i := range chunks {
-		// Encode the chunk first - checksum is calculated as a side effect.
-		buf, err := chunks[i].Encode()
+		buf, err := chunks[i].Encoded()
 		if err != nil {
 			return err
 		}

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -337,9 +337,6 @@ func (c *seriesStore) PutOne(ctx context.Context, from, through model.Time, chun
 		return err
 	}
 
-	// Horribly, PutChunks mutates the chunk by setting its checksum.  By putting
-	// the chunk in a slice we are in fact passing by reference, so below we
-	// need to make sure we pick the chunk back out the slice.
 	chunks := []Chunk{chunk}
 
 	err = c.storage.PutChunks(ctx, chunks)
@@ -349,7 +346,7 @@ func (c *seriesStore) PutOne(ctx context.Context, from, through model.Time, chun
 
 	c.writeBackCache(ctx, chunks)
 
-	writeReqs, keysToCache, err := c.calculateIndexEntries(userID, from, through, chunks[0])
+	writeReqs, keysToCache, err := c.calculateIndexEntries(userID, from, through, chunk)
 	if err != nil {
 		return err
 	}

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -58,10 +58,6 @@ func CreateChunks(startIndex, batchSize int) ([]string, []chunk.Chunk, error) {
 			"index":               model.LabelValue(strconv.Itoa(startIndex*batchSize + j)),
 		})
 		chunks = append(chunks, chunk)
-		_, err := chunk.Encode() // Need to encode it, side effect calculates crc
-		if err != nil {
-			return nil, nil, err
-		}
 		keys = append(keys, chunk.ExternalKey())
 	}
 	return keys, chunks, nil
@@ -86,7 +82,7 @@ func dummyChunkFor(now model.Time, metric model.Metric) chunk.Chunk {
 		now,
 	)
 	// Force checksum calculation.
-	_, err := chunk.Encode()
+	err := chunk.Encode()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -312,7 +312,11 @@ func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, metric
 
 	wireChunks := make([]chunk.Chunk, 0, len(chunkDescs))
 	for _, chunkDesc := range chunkDescs {
-		wireChunks = append(wireChunks, chunk.NewChunk(userID, fp, metric, chunkDesc.C, chunkDesc.FirstTime, chunkDesc.LastTime))
+		c := chunk.NewChunk(userID, fp, metric, chunkDesc.C, chunkDesc.FirstTime, chunkDesc.LastTime)
+		if err := c.Encode(); err != nil {
+			return err
+		}
+		wireChunks = append(wireChunks, c)
 	}
 
 	if err := i.chunkStore.Put(ctx, wireChunks); err != nil {

--- a/pkg/querier/chunks_handler.go
+++ b/pkg/querier/chunks_handler.go
@@ -61,7 +61,7 @@ func ChunksHandler(queryable storage.Queryable) http.Handler {
 		defer writer.Close()
 
 		for _, chunk := range chunks {
-			buf, err := chunk.Encode()
+			buf, err := chunk.Encoded()
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return


### PR DESCRIPTION
Remove all the scary comments and make it more obvious where encoding happens

This should make the code in #1164 work again (has since been reverted)