### PR TITLE
Reduce allocations during fingerprint hash

### DIFF
--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -257,9 +257,9 @@ func FastFingerprint(labelPairs []LabelPair) model.Fingerprint {
 	var result uint64
 	for _, pair := range labelPairs {
 		sum := hashNew()
-		sum = hashAdd(sum, string(pair.Name))
+		sum = hashAdd(sum, pair.Name)
 		sum = hashAddByte(sum, model.SeparatorByte)
-		sum = hashAdd(sum, string(pair.Value))
+		sum = hashAdd(sum, pair.Value)
 		result ^= sum
 	}
 	return model.Fingerprint(result)

--- a/pkg/ingester/client/fnv.go
+++ b/pkg/ingester/client/fnv.go
@@ -1,4 +1,4 @@
-// Copied from github.com/prometheus/common/model/fnv.go
+// Modified from github.com/prometheus/common/model/fnv.go
 // Copyright 2015 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ func hashNew() uint64 {
 }
 
 // hashAdd adds a string to a fnv64a hash value, returning the updated hash.
-func hashAdd(h uint64, s string) uint64 {
+func hashAdd(h uint64, s []byte) uint64 {
 	for i := 0; i < len(s); i++ {
 		h ^= uint64(s[i])
 		h *= prime64


### PR DESCRIPTION
This was missed from #1007: the conversion to string was unnecessary but forced an allocation.

Before:

    BenchmarkIngesterPush-2   10	 113901108 ns/op	 7113553 B/op	   79116 allocs/op

After:

    BenchmarkIngesterPush-2   20	  95770295 ns/op	 2313013 B/op	   19108 allocs/op
