### PR TITLE
Reduce transfer allocations

### DIFF
--- a/pkg/ingester/index/index.go
+++ b/pkg/ingester/index/index.go
@@ -100,10 +100,11 @@ func (shard *indexShard) add(metric []client.LabelPair, fp model.Fingerprint) {
 	defer shard.mtx.Unlock()
 
 	for _, pair := range metric {
-		name, value := model.LabelName(pair.Name), model.LabelValue(pair.Value)
-		values, ok := shard.idx[name]
+		value := model.LabelValue(pair.Value)
+		values, ok := shard.idx[model.LabelName(pair.Name)]
 		if !ok {
 			values = map[model.LabelValue][]model.Fingerprint{}
+			shard.idx[model.LabelName(pair.Name)] = values
 		}
 		fingerprints := values[value]
 		// Insert into the right position to keep fingerprints sorted
@@ -114,7 +115,6 @@ func (shard *indexShard) add(metric []client.LabelPair, fp model.Fingerprint) {
 		copy(fingerprints[j+1:], fingerprints[j:])
 		fingerprints[j] = fp
 		values[value] = fingerprints
-		shard.idx[name] = values
 	}
 }
 

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -204,7 +204,6 @@ func (u *userState) getSeries(metric labelPairs) (model.Fingerprint, *memorySeri
 		return fp, nil, httpgrpc.Errorf(http.StatusTooManyRequests, "per-metric series limit (%d) exceeded for %s: %s", u.limits.MaxSeriesPerMetric(u.userID), metricName, metric)
 	}
 
-	util.Event().Log("msg", "new series", "userID", u.userID, "fp", fp, "series", metric)
 	u.memSeriesCreatedTotal.Inc()
 	memSeries.Inc()
 


### PR DESCRIPTION
Slightly flying a kite to get reactions...

I took a heap profile right after transfer, and about 20% of the allocations were in these lines.
The same pattern doesn't show up in current benchmarks.

The event log on new series was never hugely useful, and we have a metric now for the broad-brush picture.