### PR TITLE
Historical queries shouldn't hit the ingesters

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -42,7 +42,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.BatchIterators, "querier.batch-iterators", false, "Use batch iterators to execute query, as opposed to fully materialising the series in memory.  Takes precedent over the -querier.iterators flag.")
 	f.BoolVar(&cfg.IngesterStreaming, "querier.ingester-streaming", false, "Use streaming RPCs to query ingester.")
 	f.IntVar(&cfg.MaxSamples, "querier.max-samples", 50e6, "Maximum number of samples a single query can load into memory.")
-	f.DurationVar(&cfg.IngesterMaxQueryLookback, "querier.query-ingesters-within", 0, "Maximum lookback beyond which queries are not sent to ingester.")
+	f.DurationVar(&cfg.IngesterMaxQueryLookback, "querier.query-ingesters-within", 0, "Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester.")
 	cfg.metricsRegisterer = prometheus.DefaultRegisterer
 }
 
@@ -106,7 +106,7 @@ func NewQueryable(dq, cq storage.Queryable, distributor Distributor, ingesterMax
 		}
 
 		// Include ingester only if maxt is within ingesterMaxQueryLookback w.r.t. current time.
-		if maxt >= time.Now().Add(-ingesterMaxQueryLookback).UnixNano()/1e6 {
+		if ingesterMaxQueryLookback == 0 || maxt >= time.Now().Add(-ingesterMaxQueryLookback).UnixNano()/1e6 {
 			dqr, err := dq.Querier(ctx, mint, maxt)
 			if err != nil {
 				return nil, err

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -42,7 +42,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.BatchIterators, "querier.batch-iterators", false, "Use batch iterators to execute query, as opposed to fully materialising the series in memory.  Takes precedent over the -querier.iterators flag.")
 	f.BoolVar(&cfg.IngesterStreaming, "querier.ingester-streaming", false, "Use streaming RPCs to query ingester.")
 	f.IntVar(&cfg.MaxSamples, "querier.max-samples", 50e6, "Maximum number of samples a single query can load into memory.")
-	f.DurationVar(&cfg.IngesterMaxQueryLookback, "querier.ingester-max-query-lookback", 24*time.Hour, "Maximum lookback beyond which queries are not sent to ingester.")
+	f.DurationVar(&cfg.IngesterMaxQueryLookback, "querier.query-ingesters-within", 24*time.Hour, "Maximum lookback beyond which queries are not sent to ingester.")
 	cfg.metricsRegisterer = prometheus.DefaultRegisterer
 }
 
@@ -64,7 +64,7 @@ func New(cfg Config, distributor Distributor, chunkStore ChunkStore) (storage.Qu
 	var queryable storage.Queryable
 	if cfg.IngesterStreaming {
 		dq := newIngesterStreamingQueryable(distributor, iteratorFunc)
-		queryable = newUnifiedChunkQueryable(chunkStore, dq, distributor, iteratorFunc, cfg.IngesterMaxQueryLookback)
+		queryable = newUnifiedChunkQueryable(dq, chunkStore, distributor, iteratorFunc, cfg.IngesterMaxQueryLookback)
 	} else {
 		cq := newChunkStoreQueryable(chunkStore, iteratorFunc)
 		dq := newDistributorQueryable(distributor)
@@ -105,7 +105,7 @@ func NewQueryable(dq, cq storage.Queryable, distributor Distributor, ingesterMax
 			maxt:        maxt,
 		}
 
-		// Include ingester only if maxt is within 2 times ingester chunk age w.r.t. current time.
+		// Include ingester only if maxt is within ingesterMaxQueryLookback w.r.t. current time.
 		if maxt >= time.Now().Add(-ingesterMaxQueryLookback).UnixNano()/1e6 {
 			dqr, err := dq.Querier(ctx, mint, maxt)
 			if err != nil {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -42,7 +42,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.BatchIterators, "querier.batch-iterators", false, "Use batch iterators to execute query, as opposed to fully materialising the series in memory.  Takes precedent over the -querier.iterators flag.")
 	f.BoolVar(&cfg.IngesterStreaming, "querier.ingester-streaming", false, "Use streaming RPCs to query ingester.")
 	f.IntVar(&cfg.MaxSamples, "querier.max-samples", 50e6, "Maximum number of samples a single query can load into memory.")
-	f.DurationVar(&cfg.IngesterMaxQueryLookback, "querier.query-ingesters-within", 24*time.Hour, "Maximum lookback beyond which queries are not sent to ingester.")
+	f.DurationVar(&cfg.IngesterMaxQueryLookback, "querier.query-ingesters-within", 0, "Maximum lookback beyond which queries are not sent to ingester.")
 	cfg.metricsRegisterer = prometheus.DefaultRegisterer
 }
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -19,12 +19,13 @@ import (
 
 // Config contains the configuration require to create a querier
 type Config struct {
-	MaxConcurrent     int
-	Timeout           time.Duration
-	Iterators         bool
-	BatchIterators    bool
-	IngesterStreaming bool
-	MaxSamples        int
+	MaxConcurrent       int
+	Timeout             time.Duration
+	Iterators           bool
+	BatchIterators      bool
+	IngesterStreaming   bool
+	MaxSamples          int
+	IngesterMaxChunkAge time.Duration
 
 	// For testing, to prevent re-registration of metrics in the promql engine.
 	metricsRegisterer prometheus.Registerer
@@ -41,6 +42,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.BatchIterators, "querier.batch-iterators", false, "Use batch iterators to execute query, as opposed to fully materialising the series in memory.  Takes precedent over the -querier.iterators flag.")
 	f.BoolVar(&cfg.IngesterStreaming, "querier.ingester-streaming", false, "Use streaming RPCs to query ingester.")
 	f.IntVar(&cfg.MaxSamples, "querier.max-samples", 50e6, "Maximum number of samples a single query can load into memory.")
+	f.DurationVar(&cfg.IngesterMaxChunkAge, "querier.ingester-max-chunk-age", 12*time.Hour, "Maximum chunk age in ingester before flushing.")
 	cfg.metricsRegisterer = prometheus.DefaultRegisterer
 }
 
@@ -62,11 +64,11 @@ func New(cfg Config, distributor Distributor, chunkStore ChunkStore) (storage.Qu
 	var queryable storage.Queryable
 	if cfg.IngesterStreaming {
 		dq := newIngesterStreamingQueryable(distributor, iteratorFunc)
-		queryable = newUnifiedChunkQueryable(chunkStore, dq, distributor, iteratorFunc)
+		queryable = newUnifiedChunkQueryable(chunkStore, dq, distributor, iteratorFunc, cfg.IngesterMaxChunkAge)
 	} else {
 		cq := newChunkStoreQueryable(chunkStore, iteratorFunc)
 		dq := newDistributorQueryable(distributor)
-		queryable = NewQueryable(dq, cq, distributor)
+		queryable = NewQueryable(dq, cq, distributor, cfg.IngesterMaxChunkAge)
 	}
 
 	lazyQueryable := storage.QueryableFunc(func(ctx context.Context, mint int64, maxt int64) (storage.Querier, error) {
@@ -88,11 +90,13 @@ func New(cfg Config, distributor Distributor, chunkStore ChunkStore) (storage.Qu
 }
 
 // NewQueryable creates a new Queryable for cortex.
-func NewQueryable(dq, cq storage.Queryable, distributor Distributor) storage.Queryable {
+func NewQueryable(dq, cq storage.Queryable, distributor Distributor, ingesterMaxChunkAge time.Duration) storage.Queryable {
 	return storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
-		dqr, err := dq.Querier(ctx, mint, maxt)
-		if err != nil {
-			return nil, err
+		q := querier{
+			distributor: distributor,
+			ctx:         ctx,
+			mint:        mint,
+			maxt:        maxt,
 		}
 
 		cqr, err := cq.Querier(ctx, mint, maxt)
@@ -100,13 +104,18 @@ func NewQueryable(dq, cq storage.Queryable, distributor Distributor) storage.Que
 			return nil, err
 		}
 
-		return querier{
-			queriers:    []storage.Querier{dqr, cqr},
-			distributor: distributor,
-			ctx:         ctx,
-			mint:        mint,
-			maxt:        maxt,
-		}, nil
+		// Include ingester only if maxt is within 2 times ingester chunk age w.r.t. current time.
+		if maxt >= time.Now().Add(-2*ingesterMaxChunkAge).UnixNano()/1e6 {
+			dqr, err := dq.Querier(ctx, mint, maxt)
+			if err != nil {
+				return nil, err
+			}
+			q.queriers = []storage.Querier{dqr, cqr}
+		} else {
+			q.queriers = []storage.Querier{cqr}
+		}
+
+		return q, nil
 	})
 }
 

--- a/pkg/querier/unified_querier.go
+++ b/pkg/querier/unified_querier.go
@@ -30,7 +30,7 @@ func newUnifiedChunkQueryable(ds, cs ChunkStore, distributor Distributor, chunkI
 		}
 
 		// Include ingester only if maxt is within ingesterMaxQueryLookback w.r.t. current time.
-		if maxt >= time.Now().Add(-ingesterMaxQueryLookback).UnixNano()/1e6 {
+		if ingesterMaxQueryLookback == 0 || maxt >= time.Now().Add(-ingesterMaxQueryLookback).UnixNano()/1e6 {
 			ucq.stores = append(ucq.stores, ds)
 		}
 

--- a/pkg/querier/unified_querier.go
+++ b/pkg/querier/unified_querier.go
@@ -29,7 +29,7 @@ func newUnifiedChunkQueryable(ds, cs ChunkStore, distributor Distributor, chunkI
 			},
 		}
 
-		// Include ingester only if maxt is within 2 times ingester chunk age w.r.t. current time.
+		// Include ingester only if maxt is within ingesterMaxQueryLookback w.r.t. current time.
 		if maxt >= time.Now().Add(-ingesterMaxQueryLookback).UnixNano()/1e6 {
 			ucq.stores = append(ucq.stores, ds)
 		}

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -33,7 +33,7 @@ func newTestRuler(t *testing.T, alertmanagerURL string) *Ruler {
 		MaxConcurrent: 20,
 		Timeout:       2 * time.Minute,
 	})
-	queryable := querier.NewQueryable(nil, nil, nil)
+	queryable := querier.NewQueryable(nil, nil, nil, 0)
 	ruler, err := NewRuler(cfg, engine, queryable, nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Closes https://github.com/cortexproject/cortex/issues/984

A rather small PR.

There can be better way to pass `IngesterMaxChunkAge` to the querier, but this is what I have come up with for now.

TODO
- [x] Tests
- [ ] See if it helps in https://github.com/cortexproject/cortex/issues/1158