### PR TITLE
Make query-frontend service headless in example config

### DIFF
--- a/k8s/query-frontend-svc.yaml
+++ b/k8s/query-frontend-svc.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: query-frontend
 spec:
+  # clusterIP: None gives a "headless" service so DNS returns all endpoints.
+  clusterIP: None
   ports:
     - port: 9095
       name: grcp


### PR DESCRIPTION
The [code](https://github.com/cortexproject/cortex/blob/master/pkg/querier/frontend/worker.go#L110) connects once per address returned from DNS, so we need a headless service.

The example config only has 1 replica so it works either way, but it should illustrate what to do in larger deployments.
