### PR TITLE
Add a cap on bigChunk size

### DIFF
--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -49,8 +49,7 @@ func main() {
 		ingesterConfig   ingester.Config
 		preallocConfig   client.PreallocConfig
 		clientConfig     client.Config
-		marshalConfig    encoding.MarshalConfig
-		bigchunkConfig   encoding.BigchunkConfig
+		encodingConfig   encoding.Config
 		limits           validation.Limits
 		eventSampleRate  int
 		maxStreams       uint
@@ -64,7 +63,7 @@ func main() {
 	ingesterConfig.LifecyclerConfig.ListenPort = &serverConfig.GRPCListenPort
 
 	flagext.RegisterFlags(&serverConfig, &chunkStoreConfig, &storageConfig,
-		&schemaConfig, &ingesterConfig, &clientConfig, &limits, &preallocConfig, &marshalConfig, &bigchunkConfig)
+		&schemaConfig, &ingesterConfig, &clientConfig, &limits, &preallocConfig, &encodingConfig)
 	flag.UintVar(&maxStreams, "ingester.max-concurrent-streams", 1000, "Limit on the number of concurrent streams for gRPC calls (0 = unlimited)")
 	flag.IntVar(&eventSampleRate, "event.sample-rate", 0, "How often to sample observability events (0 = never).")
 	flag.Parse()

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -50,6 +50,7 @@ func main() {
 		preallocConfig   client.PreallocConfig
 		clientConfig     client.Config
 		marshalConfig    encoding.MarshalConfig
+		bigchunkConfig   encoding.BigchunkConfig
 		limits           validation.Limits
 		eventSampleRate  int
 		maxStreams       uint
@@ -63,7 +64,7 @@ func main() {
 	ingesterConfig.LifecyclerConfig.ListenPort = &serverConfig.GRPCListenPort
 
 	flagext.RegisterFlags(&serverConfig, &chunkStoreConfig, &storageConfig,
-		&schemaConfig, &ingesterConfig, &clientConfig, &limits, &preallocConfig, &marshalConfig)
+		&schemaConfig, &ingesterConfig, &clientConfig, &limits, &preallocConfig, &marshalConfig, &bigchunkConfig)
 	flag.UintVar(&maxStreams, "ingester.max-concurrent-streams", 1000, "Limit on the number of concurrent streams for gRPC calls (0 = unlimited)")
 	flag.IntVar(&eventSampleRate, "event.sample-rate", 0, "How often to sample observability events (0 = never).")
 	flag.Parse()

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -100,6 +100,10 @@ The ingester query API was improved over time, but defaults to the old behaviour
 
    Before enabling, rollout a version of Cortex that supports normalised token for all jobs that interact with the ring, then rollout with this flag set to `true` on the ingesters.  The new ring code can still read and write the old ring format, so is backwards compatible.
 
+- `-store.bigchunk-size-cap-bytes`
+
+   When using bigchunks, start a new bigchunk and flush the old one if the old one reaches this size. Use this setting to limit memory growth of ingesters with a lot of timeseries that last for days.
+
 ## Ingester, Distributor & Querier limits.
 
 Cortex implements various limits on the requests it can process, in order to prevent a single tenant overwhelming the cluster.  There are various default global limits which apply to all tenants which can be set on the command line.  These limits can also be overridden on a per-tenant basis, using a configuration file.  Specify the filename for the override configuration file using the `-limits.per-user-override-config=<filename>` flag.  The override file will be re-read every 10 seconds by default - this can also be controlled using the `-limits.per-user-override-period=10s` flag.

--- a/pkg/chunk/encoding/bigchunk.go
+++ b/pkg/chunk/encoding/bigchunk.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"flag"
 	"io"
 
 	"github.com/prometheus/common/model"
@@ -14,16 +13,6 @@ import (
 const samplesPerChunk = 120
 
 var errOutOfBounds = errors.New("out of bounds")
-
-// BigchunkConfig configures the behaviour of bigchunks
-type BigchunkConfig struct{}
-
-var bigchunkSizeCapBytes = 0
-
-// RegisterFlags registers configuration settings.
-func (BigchunkConfig) RegisterFlags(f *flag.FlagSet) {
-	flag.IntVar(&bigchunkSizeCapBytes, "store.bigchunk-size-cap-bytes", bigchunkSizeCapBytes, "When using bigchunk encoding, start a new bigchunk if over this size (0 = unlimited)")
-}
 
 // bigchunk is a set of prometheus/tsdb chunks.  It grows over time and has no
 // upperbound on number of samples it can contain.

--- a/pkg/chunk/encoding/factory.go
+++ b/pkg/chunk/encoding/factory.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"flag"
 	"fmt"
 	"strconv"
 )
@@ -8,8 +9,22 @@ import (
 // Encoding defines which encoding we are using, delta, doubledelta, or varbit
 type Encoding byte
 
-// DefaultEncoding can be changed via a flag.
-var DefaultEncoding = DoubleDelta
+// Config configures the behaviour of chunk encoding
+type Config struct{}
+
+var (
+	// DefaultEncoding exported for use in unit tests elsewhere
+	DefaultEncoding             = DoubleDelta
+	alwaysMarshalFullsizeChunks = true
+	bigchunkSizeCapBytes        = 0
+)
+
+// RegisterFlags registers configuration settings.
+func (Config) RegisterFlags(f *flag.FlagSet) {
+	f.Var(&DefaultEncoding, "ingester.chunk-encoding", "Encoding version to use for chunks.")
+	flag.BoolVar(&alwaysMarshalFullsizeChunks, "store.fullsize-chunks", alwaysMarshalFullsizeChunks, "When saving varbit chunks, pad to 1024 bytes")
+	flag.IntVar(&bigchunkSizeCapBytes, "store.bigchunk-size-cap-bytes", bigchunkSizeCapBytes, "When using bigchunk encoding, start a new bigchunk if over this size (0 = unlimited)")
+}
 
 // String implements flag.Value.
 func (e Encoding) String() string {

--- a/pkg/chunk/encoding/varbit.go
+++ b/pkg/chunk/encoding/varbit.go
@@ -18,7 +18,6 @@ package encoding
 
 import (
 	"encoding/binary"
-	"flag"
 	"fmt"
 	"io"
 	"math"
@@ -313,16 +312,6 @@ func (c varbitChunk) Encoding() Encoding { return Varbit }
 func (c varbitChunk) Utilization() float64 {
 	// 15 bytes is the length of the chunk footer.
 	return math.Min(float64(c.nextSampleOffset()/8+15)/float64(cap(c)), 1)
-}
-
-// MarshalConfig configures the behaviour of marshalling
-type MarshalConfig struct{}
-
-var alwaysMarshalFullsizeChunks = true
-
-// RegisterFlags registers configuration settings.
-func (MarshalConfig) RegisterFlags(f *flag.FlagSet) {
-	flag.BoolVar(&alwaysMarshalFullsizeChunks, "store.fullsize-chunks", alwaysMarshalFullsizeChunks, "When saving varbit chunks, pad to 1024 bytes")
 }
 
 // marshalLen returns the number of bytes that should be marshalled for this chunk

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -13,7 +13,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/cortexproject/cortex/pkg/chunk/encoding"
 	"github.com/go-kit/kit/log/level"
 	"github.com/gogo/status"
 	"github.com/prometheus/client_golang/prometheus"
@@ -91,7 +90,6 @@ type Config struct {
 	MaxChunkAge       time.Duration
 	ChunkAgeJitter    time.Duration
 	ConcurrentFlushes int
-	ChunkEncoding     string
 
 	RateUpdatePeriod time.Duration
 
@@ -111,7 +109,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.MaxChunkAge, "ingester.max-chunk-age", 12*time.Hour, "Maximum chunk age before flushing.")
 	f.DurationVar(&cfg.ChunkAgeJitter, "ingester.chunk-age-jitter", 20*time.Minute, "Range of time to subtract from MaxChunkAge to spread out flushes")
 	f.IntVar(&cfg.ConcurrentFlushes, "ingester.concurrent-flushes", 50, "Number of concurrent goroutines flushing to dynamodb.")
-	f.StringVar(&cfg.ChunkEncoding, "ingester.chunk-encoding", "1", "Encoding version to use for chunks.")
 	f.DurationVar(&cfg.RateUpdatePeriod, "ingester.rate-update-period", 15*time.Second, "Period with which to update the per-user ingestion rates.")
 
 	// DEPRECATED, no-op
@@ -158,10 +155,6 @@ type ChunkStore interface {
 func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, chunkStore ChunkStore) (*Ingester, error) {
 	if cfg.ingesterClientFactory == nil {
 		cfg.ingesterClientFactory = client.MakeIngesterClient
-	}
-
-	if err := encoding.DefaultEncoding.Set(cfg.ChunkEncoding); err != nil {
-		return nil, err
 	}
 
 	i := &Ingester{


### PR DESCRIPTION
Only check the size when adding a new sub-chunk, to limit the cost of checking.

Fixes #1201 

Also consolidate existing chunk-encoding flags `-store.fullsize-chunks` and `-ingester.chunk-encoding` in one place.