### PR TITLE
Improve ClaimTokens() code for normalised case

### DIFF
--- a/pkg/ring/lifecycler_test.go
+++ b/pkg/ring/lifecycler_test.go
@@ -85,7 +85,6 @@ func TestRingNormaliseMigration(t *testing.T) {
 			len(desc.Ingesters) == 1 &&
 			desc.Ingesters["ing2"].State == ACTIVE &&
 			len(desc.Ingesters["ing2"].Tokens) == 1 &&
-			desc.Ingesters["ing2"].Tokens[0] == token &&
-			len(desc.Tokens) == 0
+			desc.Ingesters["ing2"].Tokens[0] == token
 	})
 }


### PR DESCRIPTION
I started looking at this code because I saw ingesters reporting their tokens were half-owned by the new ingester and half by the old, at the end of handover.

If the ingester we are claiming from is normalising, we need to blank out its tokens.

Simplify the rest of the claim logic since we hold a denormalised ring all the time - `loop()` calls `migrateRing()` to make it, and the `get()` functions depend on it.

Stop checking for an empty denormalised ring after migration in unit test.
