### PR TITLE
Stop quantizing test sinewave to seconds

### DIFF
--- a/cmd/test-exporter/main.go
+++ b/cmd/test-exporter/main.go
@@ -54,8 +54,8 @@ func main() {
 
 	runner.Add(correctness.NewSimpleTestCase("sine_wave", func(t time.Time) float64 {
 		// With a 15-second scrape interval this gives a ten-minute period
-		period := 40 * runnerConfig.ScrapeInterval.Seconds()
-		radians := float64(t.Unix()) / period * 2 * math.Pi
+		period := float64(40 * runnerConfig.ScrapeInterval.Nanoseconds())
+		radians := float64(t.UnixNano()) / period * 2 * math.Pi
 		return math.Sin(radians)
 	}))
 

--- a/pkg/querier/correctness/runner.go
+++ b/pkg/querier/correctness/runner.go
@@ -228,7 +228,7 @@ func (r *Runner) runRandomTest() {
 		} else {
 			failures = true
 			sampleResult.WithLabelValues(fail).Inc()
-			level.Error(log).Log("msg", "wrong value", "expected", tc.ExpectedValueAt(pair.Timestamp.Time()), "actual", pair.Value)
+			level.Error(log).Log("msg", "wrong value", "at", pair.Timestamp, "expected", tc.ExpectedValueAt(pair.Timestamp.Time()), "actual", pair.Value)
 			log.LogFields(otlog.Error(fmt.Errorf("wrong value")))
 		}
 	}


### PR DESCRIPTION
Call `t.UnixNano()` instead of `t.Unix()`.

`t.Unix()` truncates to seconds, so if the scraping process and the checking process have slightly different time they may expect a value a whole second off. This truncation also defeats `timeEpsilonCorrect()`.

(full disclosure: [I broke it](http://github.com/weaveworks-experiments/prometheus-benchmarks/commit/e4cc465919e819bc5f926bc50eb86d24f1723679))

Also print the timestamp corresponding to the value, for ease of debugging next time.
