### PR TITLE
Protect against nil when dereferencing request Retryable field

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -454,7 +454,7 @@ func (a dynamoDBRequestAdapter) HasNextPage() bool {
 }
 
 func (a dynamoDBRequestAdapter) Retryable() bool {
-	return *a.request.Retryable
+	return aws.BoolValue(a.request.Retryable)
 }
 
 type chunksPlusError struct {


### PR DESCRIPTION
The request `Send` function can return an error with `nil` Retryable. Test the value of the field using the same helper function used internally by the client library.

Fixes #1211.