### PR TITLE
Add options for client-side rate limiting and backoff on all gRPC clients.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1495,6 +1495,7 @@
     "golang.org/x/time/rate",
     "golang.org/x/tools/cover",
     "google.golang.org/api/option",
+    "google.golang.org/api/transport/http",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/encoding/gzip",

--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -63,8 +63,8 @@ type storageClientV1 struct {
 
 // NewStorageClientV1 returns a new v1 StorageClient.
 func NewStorageClientV1(ctx context.Context, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.IndexClient, error) {
-	opts := cfg.GRPCClientConfig.DialOption(instrumentation())
-	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, toBigtableOpts(opts)...)
+	opts := toOptions(cfg.GRPCClientConfig.DialOption(bigtableInstrumentation()))
+	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func newStorageClientV1(cfg Config, schemaCfg chunk.SchemaConfig, client *bigtab
 
 // NewStorageClientColumnKey returns a new v2 StorageClient.
 func NewStorageClientColumnKey(ctx context.Context, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.IndexClient, error) {
-	opts := toBigtableOpts(cfg.GRPCClientConfig.DialOption(instrumentation()))
+	opts := toOptions(cfg.GRPCClientConfig.DialOption(bigtableInstrumentation()))
 	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -10,7 +10,6 @@ import (
 	"cloud.google.com/go/bigtable"
 	ot "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
-	"google.golang.org/api/option"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
@@ -64,10 +63,8 @@ type storageClientV1 struct {
 
 // NewStorageClientV1 returns a new v1 StorageClient.
 func NewStorageClientV1(ctx context.Context, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.IndexClient, error) {
-	opts := instrumentation()
-	opts = append(opts, option.WithGRPCDialOption(cfg.GRPCClientConfig.DialOption()))
-
-	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, opts...)
+	opts := cfg.GRPCClientConfig.DialOption(instrumentation())
+	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, toBigtableOpts(opts)...)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +87,8 @@ func newStorageClientV1(cfg Config, schemaCfg chunk.SchemaConfig, client *bigtab
 
 // NewStorageClientColumnKey returns a new v2 StorageClient.
 func NewStorageClientColumnKey(ctx context.Context, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.IndexClient, error) {
-	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, instrumentation()...)
+	opts := toBigtableOpts(cfg.GRPCClientConfig.DialOption(instrumentation()))
+	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chunk/gcp/bigtable_object_client.go
+++ b/pkg/chunk/gcp/bigtable_object_client.go
@@ -22,7 +22,8 @@ type bigtableObjectClient struct {
 // NewBigtableObjectClient makes a new chunk.ObjectClient that stores chunks in
 // Bigtable.
 func NewBigtableObjectClient(ctx context.Context, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.ObjectClient, error) {
-	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, instrumentation()...)
+	opts := toBigtableOpts(cfg.GRPCClientConfig.DialOption(instrumentation()))
+	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chunk/gcp/bigtable_object_client.go
+++ b/pkg/chunk/gcp/bigtable_object_client.go
@@ -22,7 +22,7 @@ type bigtableObjectClient struct {
 // NewBigtableObjectClient makes a new chunk.ObjectClient that stores chunks in
 // Bigtable.
 func NewBigtableObjectClient(ctx context.Context, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.ObjectClient, error) {
-	opts := toBigtableOpts(cfg.GRPCClientConfig.DialOption(instrumentation()))
+	opts := toOptions(cfg.GRPCClientConfig.DialOption(bigtableInstrumentation()))
 	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -64,6 +64,11 @@ func (s *gcsObjectClient) PutChunks(ctx context.Context, chunks []chunk.Chunk) e
 			return err
 		}
 		writer := s.bucket.Object(chunk.ExternalKey()).NewWriter(ctx)
+		// Default GCSChunkSize is 8M and for each call, 8M is allocated xD
+		// By setting it to 0, we just upload the object in a single a request
+		// which should work for our chunk sizes.
+		writer.ChunkSize = 0
+
 		if _, err := writer.Write(buf); err != nil {
 			return err
 		}

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -31,7 +31,7 @@ func (cfg *GCSConfig) RegisterFlags(f *flag.FlagSet) {
 
 // NewGCSObjectClient makes a new chunk.ObjectClient that writes chunks to GCS.
 func NewGCSObjectClient(ctx context.Context, cfg GCSConfig, schemaCfg chunk.SchemaConfig) (chunk.ObjectClient, error) {
-	client, err := storage.NewClient(ctx, instrumentation()...)
+	client, err := storage.NewClient(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -21,12 +21,14 @@ type gcsObjectClient struct {
 
 // GCSConfig is config for the GCS Chunk Client.
 type GCSConfig struct {
-	BucketName string `yaml:"bucket_name"`
+	BucketName      string `yaml:"bucket_name"`
+	ChunkBufferSize int    `yaml:"chunk_buffer_size"`
 }
 
 // RegisterFlags registers flags.
 func (cfg *GCSConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.BucketName, "gcs.bucketname", "", "Name of GCS bucket to put chunks in.")
+	f.IntVar(&cfg.ChunkBufferSize, "gcs.chunk-buffer-size", 0, "The size of the buffer that GCS client for each PUT request. 0 to disable buffering.")
 }
 
 // NewGCSObjectClient makes a new chunk.ObjectClient that writes chunks to GCS.
@@ -67,7 +69,7 @@ func (s *gcsObjectClient) PutChunks(ctx context.Context, chunks []chunk.Chunk) e
 		// Default GCSChunkSize is 8M and for each call, 8M is allocated xD
 		// By setting it to 0, we just upload the object in a single a request
 		// which should work for our chunk sizes.
-		writer.ChunkSize = 0
+		writer.ChunkSize = s.cfg.ChunkBufferSize
 
 		if _, err := writer.Write(buf); err != nil {
 			return err

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -31,7 +31,12 @@ func (cfg *GCSConfig) RegisterFlags(f *flag.FlagSet) {
 
 // NewGCSObjectClient makes a new chunk.ObjectClient that writes chunks to GCS.
 func NewGCSObjectClient(ctx context.Context, cfg GCSConfig, schemaCfg chunk.SchemaConfig) (chunk.ObjectClient, error) {
-	client, err := storage.NewClient(ctx)
+	option, err := gcsInstrumentation(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := storage.NewClient(ctx, option)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chunk/gcp/instrumentation.go
+++ b/pkg/chunk/gcp/instrumentation.go
@@ -81,7 +81,7 @@ func (i instrumentedTransport) RoundTrip(req *http.Request) (*http.Response, err
 	start := time.Now()
 	resp, err := i.next.RoundTrip(req)
 	if err == nil {
-		i.observer.WithLabelValues(req.URL.Path, strconv.Itoa(resp.StatusCode)).Observe(time.Since(start).Seconds())
+		i.observer.WithLabelValues(req.Method, strconv.Itoa(resp.StatusCode)).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }

--- a/pkg/chunk/gcp/instrumentation.go
+++ b/pkg/chunk/gcp/instrumentation.go
@@ -1,27 +1,45 @@
 package gcp
 
 import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
 	otgrpc "github.com/opentracing-contrib/go-grpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/api/option"
+	google_http "google.golang.org/api/transport/http"
 	"google.golang.org/grpc"
 
 	"github.com/cortexproject/cortex/pkg/util/middleware"
 )
 
-var bigtableRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "cortex",
-	Name:      "bigtable_request_duration_seconds",
-	Help:      "Time spent doing Bigtable requests.",
+var (
+	bigtableRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "cortex",
+		Name:      "bigtable_request_duration_seconds",
+		Help:      "Time spent doing Bigtable requests.",
 
-	// Bigtable latency seems to range from a few ms to a few hundred ms and is
-	// important.  So use 6 buckets from 1ms to 1s.
-	Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
-}, []string{"operation", "status_code"})
+		// Bigtable latency seems to range from a few ms to a few hundred ms and is
+		// important.  So use 6 buckets from 1ms to 1s.
+		Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
+	}, []string{"operation", "status_code"})
 
-func instrumentation() ([]grpc.UnaryClientInterceptor, []grpc.StreamClientInterceptor) {
+	gcsRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "cortex",
+		Name:      "gcs_request_duration_seconds",
+		Help:      "Time spent doing GCS requests.",
+
+		// Bigtable latency seems to range from a few ms to a few hundred ms and is
+		// important.  So use 6 buckets from 1ms to 1s.
+		Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
+	}, []string{"operation", "status_code"})
+)
+
+func bigtableInstrumentation() ([]grpc.UnaryClientInterceptor, []grpc.StreamClientInterceptor) {
 	return []grpc.UnaryClientInterceptor{
 			otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()),
 			middleware.PrometheusGRPCUnaryInstrumentation(bigtableRequestDuration),
@@ -32,10 +50,38 @@ func instrumentation() ([]grpc.UnaryClientInterceptor, []grpc.StreamClientInterc
 		}
 }
 
-func toBigtableOpts(opts []grpc.DialOption) []option.ClientOption {
+func gcsInstrumentation(ctx context.Context) (option.ClientOption, error) {
+	transport, err := google_http.NewTransport(ctx, http.DefaultTransport)
+	if err != nil {
+		return nil, err
+	}
+	client := &http.Client{
+		Transport: instrumentedTransport{
+			observer: gcsRequestDuration,
+			next:     transport,
+		},
+	}
+	return option.WithHTTPClient(client), nil
+}
+
+func toOptions(opts []grpc.DialOption) []option.ClientOption {
 	result := make([]option.ClientOption, 0, len(opts))
 	for _, opt := range opts {
 		result = append(result, option.WithGRPCDialOption(opt))
 	}
 	return result
+}
+
+type instrumentedTransport struct {
+	observer prometheus.ObserverVec
+	next     http.RoundTripper
+}
+
+func (i instrumentedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	resp, err := i.next.RoundTrip(req)
+	if err == nil {
+		i.observer.WithLabelValues(req.URL.Path, strconv.Itoa(resp.StatusCode)).Observe(time.Since(start).Seconds())
+	}
+	return resp, err
 }

--- a/pkg/chunk/gcp/table_client.go
+++ b/pkg/chunk/gcp/table_client.go
@@ -17,7 +17,8 @@ type tableClient struct {
 
 // NewTableClient returns a new TableClient.
 func NewTableClient(ctx context.Context, cfg Config) (chunk.TableClient, error) {
-	client, err := bigtable.NewAdminClient(ctx, cfg.Project, cfg.Instance, instrumentation()...)
+	opts := toBigtableOpts(cfg.GRPCClientConfig.DialOption(instrumentation()))
+	client, err := bigtable.NewAdminClient(ctx, cfg.Project, cfg.Instance, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chunk/gcp/table_client.go
+++ b/pkg/chunk/gcp/table_client.go
@@ -17,7 +17,7 @@ type tableClient struct {
 
 // NewTableClient returns a new TableClient.
 func NewTableClient(ctx context.Context, cfg Config) (chunk.TableClient, error) {
-	opts := toBigtableOpts(cfg.GRPCClientConfig.DialOption(instrumentation()))
+	opts := toOptions(cfg.GRPCClientConfig.DialOption(bigtableInstrumentation()))
 	client, err := bigtable.NewAdminClient(ctx, cfg.Project, cfg.Instance, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/chunk/gcp/table_client.go
+++ b/pkg/chunk/gcp/table_client.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/pkg/errors"
 )
 
 type tableClient struct {
@@ -31,7 +32,7 @@ func NewTableClient(ctx context.Context, cfg Config) (chunk.TableClient, error) 
 func (c *tableClient) ListTables(ctx context.Context) ([]string, error) {
 	tables, err := c.client.Tables(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "client.Tables")
 	}
 
 	// Check each table has the right column family.  If not, omit it.
@@ -39,7 +40,7 @@ func (c *tableClient) ListTables(ctx context.Context) ([]string, error) {
 	for _, table := range tables {
 		info, err := c.client.TableInfo(ctx, table)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "client.TableInfo")
 		}
 
 		if hasColumnFamily(info.FamilyInfos) {
@@ -62,10 +63,15 @@ func hasColumnFamily(infos []bigtable.FamilyInfo) bool {
 func (c *tableClient) CreateTable(ctx context.Context, desc chunk.TableDesc) error {
 	if err := c.client.CreateTable(ctx, desc.Name); err != nil {
 		if !alreadyExistsError(err) {
-			return err
+			return errors.Wrap(err, "client.CreateTable")
 		}
 	}
-	return c.client.CreateColumnFamily(ctx, desc.Name, columnFamily)
+
+	if err := c.client.CreateColumnFamily(ctx, desc.Name, columnFamily); err != nil {
+		return errors.Wrap(err, "client.CreateColumnFamily")
+	}
+
+	return nil
 }
 
 func alreadyExistsError(err error) bool {
@@ -77,7 +83,7 @@ func alreadyExistsError(err error) bool {
 
 func (c *tableClient) DeleteTable(ctx context.Context, name string) error {
 	if err := c.client.DeleteTable(ctx, name); err != nil {
-		return err
+		return errors.Wrap(err, "client.DeleteTable")
 	}
 
 	return nil

--- a/pkg/querier/frontend/worker.go
+++ b/pkg/querier/frontend/worker.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/naming"
 
@@ -212,14 +211,9 @@ func (w *worker) process(ctx context.Context, c Frontend_ProcessClient) error {
 }
 
 func (w *worker) connect(address string) (FrontendClient, error) {
-	conn, err := grpc.Dial(
-		address,
-		grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(
-			middleware.ClientUserHeaderInterceptor,
-		)),
-		w.cfg.GRPCClientConfig.DialOption(),
-	)
+	opts := []grpc.DialOption{grpc.WithInsecure()}
+	opts = append(opts, w.cfg.GRPCClientConfig.DialOption([]grpc.UnaryClientInterceptor{middleware.ClientUserHeaderInterceptor}, nil)...)
+	conn, err := grpc.Dial(address, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/backoff.go
+++ b/pkg/util/backoff.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"math/rand"
 	"time"
@@ -12,6 +13,13 @@ type BackoffConfig struct {
 	MinBackoff time.Duration // start backoff at this level
 	MaxBackoff time.Duration // increase exponentially to this level
 	MaxRetries int           // give up after this many; zero means infinite retries
+}
+
+// RegisterFlags for BackoffConfig.
+func (cfg *BackoffConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
+	f.DurationVar(&cfg.MinBackoff, prefix+".backoff-min-period", 100*time.Millisecond, "Minimum delay when backing off.")
+	f.DurationVar(&cfg.MaxBackoff, prefix+".backoff-max-period", 10*time.Second, "Maximum delay when backing off.")
+	f.IntVar(&cfg.MaxRetries, prefix+".backoff-retries", 10, "Number of times to backoff and retry before failing.")
 }
 
 // Backoff implements exponential backoff with randomized wait times

--- a/pkg/util/grpcclient/backoff_retry.go
+++ b/pkg/util/grpcclient/backoff_retry.go
@@ -1,0 +1,30 @@
+package grpcclient
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+// NewBackoffRetry gRPC middleware.
+func NewBackoffRetry(cfg util.BackoffConfig) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		backoff := util.NewBackoff(ctx, cfg)
+		for backoff.Ongoing() {
+			err := invoker(ctx, method, req, reply, cc, opts...)
+			if err == nil {
+				return nil
+			}
+
+			if grpc.Code(err) != codes.ResourceExhausted {
+				return err
+			}
+
+			backoff.Wait()
+		}
+		return backoff.Err()
+	}
+}

--- a/pkg/util/grpcclient/grpcclient.go
+++ b/pkg/util/grpcclient/grpcclient.go
@@ -50,7 +50,7 @@ func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientIntercep
 	}
 
 	if cfg.RateLimit > 0 {
-		unaryClientInterceptors = append([]grpc.UnaryClientInterceptor{NewRateLimiter(cfg.RateLimit, cfg.RateLimitBurst)}, unaryClientInterceptors...)
+		unaryClientInterceptors = append([]grpc.UnaryClientInterceptor{NewRateLimiter(cfg)}, unaryClientInterceptors...)
 	}
 
 	return []grpc.DialOption{

--- a/pkg/util/grpcclient/grpcclient.go
+++ b/pkg/util/grpcclient/grpcclient.go
@@ -3,14 +3,17 @@ package grpcclient
 import (
 	"flag"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"google.golang.org/grpc"
 )
 
 // Config for a gRPC client.
 type Config struct {
-	MaxRecvMsgSize     int  `yaml:"max_recv_msg_size"`
-	MaxSendMsgSize     int  `yaml:"max_send_msg_size"`
-	UseGzipCompression bool `yaml:"use_gzip_compression"`
+	MaxRecvMsgSize     int     `yaml:"max_recv_msg_size"`
+	MaxSendMsgSize     int     `yaml:"max_send_msg_size"`
+	UseGzipCompression bool    `yaml:"use_gzip_compression"`
+	RateLimit          float64 `yaml:"rate_limit"`
+	RateLimitBurst     int     `yaml:"rate_limit_burst"`
 }
 
 // RegisterFlags registers flags.
@@ -18,6 +21,8 @@ func (cfg *Config) RegisterFlags(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxRecvMsgSize, prefix+".grpc-max-recv-msg-size", 100<<20, "gRPC client max receive message size (bytes).")
 	f.IntVar(&cfg.MaxSendMsgSize, prefix+".grpc-max-send-msg-size", 16<<20, "gRPC client max send message size (bytes).")
 	f.BoolVar(&cfg.UseGzipCompression, prefix+".grpc-use-gzip-compression", false, "Use compression when sending messages.")
+	f.Float64Var(&cfg.RateLimit, prefix+".grpc-client-rate-limit", 0., "Rate limit for gRPC client; 0 means disabled.")
+	f.IntVar(&cfg.RateLimitBurst, prefix+".grpc-client-rate-limit-burst", 0, "Rate limit burst for gRPC client.")
 }
 
 // CallOptions returns the config in terms of CallOptions.
@@ -32,6 +37,14 @@ func (cfg *Config) CallOptions() []grpc.CallOption {
 }
 
 // DialOption returns the config as a grpc.DialOptions.
-func (cfg *Config) DialOption() grpc.DialOption {
-	return grpc.WithDefaultCallOptions(cfg.CallOptions()...)
+func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientInterceptor, streamClientInterceptors []grpc.StreamClientInterceptor) []grpc.DialOption {
+	if cfg.RateLimit > 0 {
+		unaryClientInterceptors = append(unaryClientInterceptors, NewRateLimiter(cfg.RateLimit, cfg.RateLimitBurst))
+	}
+
+	return []grpc.DialOption{
+		grpc.WithDefaultCallOptions(cfg.CallOptions()...),
+		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(unaryClientInterceptors...)),
+		grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(streamClientInterceptors...)),
+	}
 }

--- a/pkg/util/grpcclient/ratelimit.go
+++ b/pkg/util/grpcclient/ratelimit.go
@@ -8,8 +8,12 @@ import (
 )
 
 // NewRateLimiter creates a UnaryClientInterceptor for client side rate limiting.
-func NewRateLimiter(r float64, b int) grpc.UnaryClientInterceptor {
-	limiter := rate.NewLimiter(rate.Limit(r), b)
+func NewRateLimiter(cfg *Config) grpc.UnaryClientInterceptor {
+	burst := cfg.RateLimitBurst
+	if burst == 0 {
+		burst = int(cfg.RateLimit)
+	}
+	limiter := rate.NewLimiter(rate.Limit(cfg.RateLimit), burst)
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		limiter.Wait(ctx)
 		return invoker(ctx, method, req, reply, cc, opts...)

--- a/pkg/util/grpcclient/ratelimit.go
+++ b/pkg/util/grpcclient/ratelimit.go
@@ -1,0 +1,17 @@
+package grpcclient
+
+import (
+	"context"
+
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+)
+
+// NewRateLimiter creates a UnaryClientInterceptor for client side rate limiting.
+func NewRateLimiter(r float64, b int) grpc.UnaryClientInterceptor {
+	limiter := rate.NewLimiter(rate.Limit(r), b)
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		limiter.Wait(ctx)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}


### PR DESCRIPTION
The Bigtable table client does O(n) `TableInfo` calls for every `ListTables`, to check the column family exists.  Run it for long enough and Google starts rate limiting you when you have 100s of tables.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>