### PR TITLE
WIP: Compute remainingSamples when unmarshalling bigchunks

### DIFF
--- a/pkg/chunk/encoding/bigchunk.go
+++ b/pkg/chunk/encoding/bigchunk.go
@@ -128,7 +128,7 @@ func (b *bigchunk) UnmarshalFromBuf(buf []byte) error {
 		b.chunks = append(b.chunks, chunk)
 		b.starts = append(b.starts, start)
 		b.ends = append(b.ends, end)
-		if i == numChunks-1 {
+		if i == numChunks-1 && count < samplesPerChunk {
 			b.remainingSamples = samplesPerChunk - count
 		}
 	}

--- a/pkg/chunk/encoding/bigchunk.go
+++ b/pkg/chunk/encoding/bigchunk.go
@@ -118,7 +118,7 @@ func (b *bigchunk) UnmarshalFromBuf(buf []byte) error {
 			return err
 		}
 
-		start, end, err := firstAndLastTimes(chunk)
+		start, end, count, err := firstAndLastTimesAndCount(chunk)
 		if err != nil {
 			return err
 		}
@@ -126,6 +126,9 @@ func (b *bigchunk) UnmarshalFromBuf(buf []byte) error {
 		b.chunks = append(b.chunks, chunk)
 		b.starts = append(b.starts, start)
 		b.ends = append(b.ends, end)
+		if i == numChunks-1 {
+			b.remainingSamples = samplesPerChunk - count
+		}
 	}
 	return nil
 }
@@ -302,11 +305,12 @@ func (it *bigchunkIterator) Err() error {
 	return nil
 }
 
-func firstAndLastTimes(c chunkenc.Chunk) (int64, int64, error) {
+func firstAndLastTimesAndCount(c chunkenc.Chunk) (int64, int64, int, error) {
 	var (
 		first    int64
 		last     int64
 		firstSet bool
+		count    int
 		iter     = c.Iterator()
 	)
 	for iter.Next() {
@@ -316,6 +320,7 @@ func firstAndLastTimes(c chunkenc.Chunk) (int64, int64, error) {
 			firstSet = true
 		}
 		last = t
+		count++
 	}
-	return first, last, iter.Err()
+	return first, last, count, iter.Err()
 }

--- a/pkg/chunk/encoding/bigchunk.go
+++ b/pkg/chunk/encoding/bigchunk.go
@@ -35,6 +35,12 @@ func (b *bigchunk) Add(sample model.SamplePair) ([]Chunk, error) {
 			return nil, err
 		}
 	}
+	if b.appender == nil {
+		var err error
+		if b.appender, err = b.chunks[len(b.chunks)-1].Appender(); err != nil {
+			return nil, err
+		}
+	}
 
 	b.appender.Append(int64(sample.Timestamp), float64(sample.Value))
 	b.remainingSamples--
@@ -58,16 +64,12 @@ func (b *bigchunk) addNextChunk(start model.Time) error {
 	}
 
 	chunk := chunkenc.NewXORChunk()
-	appender, err := chunk.Appender()
-	if err != nil {
-		return err
-	}
 
 	b.starts = append(b.starts, int64(start))
 	b.ends = append(b.ends, int64(start))
 	b.chunks = append(b.chunks, chunk)
 
-	b.appender = appender
+	b.appender = nil
 	b.remainingSamples = samplesPerChunk
 	return nil
 }


### PR DESCRIPTION
Fixes #1220 

On handover this allows ingesters to continue adding samples to the last subchunk, rather than starting a new one.
