### PR TITLE
Add mock LabelNames() method to fix broken test

### DIFF
--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -295,6 +295,9 @@ func (m *errDistributor) QueryStream(ctx context.Context, from, to model.Time, m
 func (m *errDistributor) LabelValuesForLabelName(context.Context, model.LabelName) ([]string, error) {
 	return nil, errDistributorError
 }
+func (m *errDistributor) LabelNames(context.Context) ([]string, error) {
+	return nil, errDistributorError
+}
 func (m *errDistributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]metric.Metric, error) {
 	return nil, errDistributorError
 }


### PR DESCRIPTION
Tests started breaking when #1190 was merged.
