### PR TITLE
Store series label-value sets as strings rather than slices

### DIFF
--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -248,6 +248,18 @@ func FromLabelPairsToLabels(labelPairs []LabelPair) labels.Labels {
 	return ls
 }
 
+// FromLabelsToLabelPairs converts labels.Labels to []LabelPair
+func FromLabelsToLabelPairs(s labels.Labels) []LabelPair {
+	labelPairs := make([]LabelPair, 0, len(s))
+	for _, v := range s {
+		labelPairs = append(labelPairs, LabelPair{
+			Name:  []byte(v.Name),
+			Value: []byte(v.Value),
+		})
+	}
+	return labelPairs // note already sorted
+}
+
 // FastFingerprint runs the same algorithm as Prometheus labelSetToFastFingerprint()
 func FastFingerprint(labelPairs []LabelPair) model.Fingerprint {
 	if len(labelPairs) == 0 {

--- a/pkg/ingester/index/index.go
+++ b/pkg/ingester/index/index.go
@@ -78,7 +78,7 @@ func (ii *InvertedIndex) LabelValues(name model.LabelName) model.LabelValues {
 }
 
 // Delete a fingerprint with the given label pairs.
-func (ii *InvertedIndex) Delete(labels []client.LabelPair, fp model.Fingerprint) {
+func (ii *InvertedIndex) Delete(labels labels.Labels, fp model.Fingerprint) {
 	shard := &ii.shards[util.HashFP(fp)%indexShards]
 	shard.delete(labels, fp)
 }
@@ -187,7 +187,7 @@ func (shard *indexShard) labelValues(name model.LabelName) model.LabelValues {
 	return results
 }
 
-func (shard *indexShard) delete(labels []client.LabelPair, fp model.Fingerprint) {
+func (shard *indexShard) delete(labels labels.Labels, fp model.Fingerprint) {
 	shard.mtx.Lock()
 	defer shard.mtx.Unlock()
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -344,7 +344,7 @@ func (i *Ingester) Query(ctx old_ctx.Context, req *client.QueryRequest) (*client
 		}
 
 		ts := client.TimeSeries{
-			Labels:  series.metric,
+			Labels:  client.FromLabelsToLabelPairs(series.metric),
 			Samples: make([]client.Sample, 0, len(values)),
 		}
 		for _, s := range values {
@@ -403,7 +403,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 
 		numChunks += len(wireChunks)
 		batch = append(batch, client.TimeSeriesChunk{
-			Labels: series.metric,
+			Labels: client.FromLabelsToLabelPairs(series.metric),
 			Chunks: wireChunks,
 		})
 
@@ -491,7 +491,7 @@ func (i *Ingester) MetricsForLabelMatchers(ctx old_ctx.Context, req *client.Metr
 	for _, matchers := range matchersSet {
 		if err := state.forSeriesMatching(ctx, matchers, func(ctx context.Context, fp model.Fingerprint, series *memorySeries) error {
 			if _, ok := metrics[fp]; !ok {
-				metrics[fp] = series.labels()
+				metrics[fp] = client.FromLabelsToLabelPairs(series.metric)
 			}
 			return nil
 		}); err != nil {

--- a/pkg/ingester/label_pairs.go
+++ b/pkg/ingester/label_pairs.go
@@ -1,11 +1,11 @@
 package ingester
 
 import (
-	"bytes"
 	"sort"
 	"strings"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/util/extract"
@@ -15,13 +15,13 @@ import (
 // pairs, which may arrive in any order over the wire
 type labelPairs []client.LabelPair
 
-// We sort the set for faster lookup, and use a separate type to let
-// the compiler check usage.
-type sortedLabelPairs []client.LabelPair
-
-func (s sortedLabelPairs) Len() int           { return len(s) }
-func (s sortedLabelPairs) Less(i, j int) bool { return bytes.Compare(s[i].Name, s[j].Name) < 0 }
-func (s sortedLabelPairs) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func labelsToMetric(s labels.Labels) model.Metric {
+	metric := make(model.Metric, len(s))
+	for _, l := range s {
+		metric[model.LabelName(l.Name)] = model.LabelValue(l.Value)
+	}
+	return metric
+}
 
 var labelNameBytes = []byte(model.MetricNameLabel)
 
@@ -52,10 +52,6 @@ func (a labelPairs) String() string {
 	return b.String()
 }
 
-func (s sortedLabelPairs) String() string {
-	return labelPairs(s).String()
-}
-
 // Remove any label where the value is "" - Prometheus 2+ will remove these
 // before sending, but other clients such as Prometheus 1.x might send us blanks.
 func (a *labelPairs) removeBlanks() {
@@ -70,45 +66,47 @@ func (a *labelPairs) removeBlanks() {
 	}
 }
 
-func (a labelPairs) copyValuesAndSort() sortedLabelPairs {
-	c := make(sortedLabelPairs, len(a))
+func (a labelPairs) copyValuesAndSort() labels.Labels {
+	c := make(labels.Labels, len(a))
 	// Since names and values may point into a much larger buffer,
 	// make a copy of all the names and values, in one block for efficiency
-	totalLength := 0
+	copyBytes := make([]byte, 0, len(a)*32) // guess at initial length
 	for _, pair := range a {
-		totalLength += len(pair.Name) + len(pair.Value)
+		copyBytes = append(copyBytes, pair.Name...)
+		copyBytes = append(copyBytes, pair.Value...)
 	}
-	copyBytes := make([]byte, totalLength)
+	// Now we need to copy the byte slice into a string for the values to point into
+	copyString := string(copyBytes)
 	pos := 0
-	copyByteSlice := func(val []byte) []byte {
+	stringSlice := func(val []byte) string {
 		start := pos
-		pos += copy(copyBytes[pos:], val)
-		return copyBytes[start:pos]
+		pos += len(val)
+		return copyString[start:pos]
 	}
 	for i, pair := range a {
-		c[i].Name = copyByteSlice(pair.Name)
-		c[i].Value = copyByteSlice(pair.Value)
+		c[i].Name = stringSlice(pair.Name)
+		c[i].Value = stringSlice(pair.Value)
 	}
 	sort.Sort(c)
 	return c
 }
 
-func (s sortedLabelPairs) valueForName(name []byte) []byte {
-	pos := sort.Search(len(s), func(i int) bool { return bytes.Compare(s[i].Name, name) >= 0 })
-	if pos == len(s) || !bytes.Equal(s[pos].Name, name) {
-		return nil
+func valueForName(s labels.Labels, name []byte) (string, bool) {
+	pos := sort.Search(len(s), func(i int) bool { return s[i].Name >= string(name) })
+	if pos == len(s) || s[pos].Name != string(name) {
+		return "", false
 	}
-	return s[pos].Value
+	return s[pos].Value, true
 }
 
-// Check if s and b contain the same name/value pairs
-func (s sortedLabelPairs) equal(b labelPairs) bool {
-	if len(s) != len(b) {
+// Check if a and b contain the same name/value pairs
+func (a labelPairs) equal(b labels.Labels) bool {
+	if len(a) != len(b) {
 		return false
 	}
-	for _, pair := range b {
-		found := s.valueForName(pair.Name)
-		if found == nil || !bytes.Equal(found, pair.Value) {
+	for _, pair := range a {
+		v, found := valueForName(b, pair.Name)
+		if !found || v != string(pair.Value) {
 			return false
 		}
 	}

--- a/pkg/ingester/mapper.go
+++ b/pkg/ingester/mapper.go
@@ -59,7 +59,7 @@ func (m *fpMapper) mapFP(fp model.Fingerprint, metric labelPairs) model.Fingerpr
 	s, ok := m.fpToSeries.get(fp)
 	if ok {
 		// FP exists in memory, but is it for the same metric?
-		if s.metric.equal(metric) {
+		if metric.equal(s.metric) {
 			// Yupp. We are done.
 			return fp
 		}

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 
 	"github.com/cortexproject/cortex/pkg/chunk/encoding"
 	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
@@ -23,7 +24,7 @@ func init() {
 }
 
 type memorySeries struct {
-	metric sortedLabelPairs
+	metric labels.Labels
 
 	// Sorted by start time, overlapping chunk ranges are forbidden.
 	chunkDescs []*desc
@@ -55,11 +56,6 @@ func newMemorySeries(m labelPairs) *memorySeries {
 		metric:   m.copyValuesAndSort(),
 		lastTime: model.Earliest,
 	}
-}
-
-// helper to extract the not-necessarily-sorted type used elsewhere, without casting everywhere.
-func (s *memorySeries) labels() labelPairs {
-	return labelPairs(s.metric)
 }
 
 // add adds a sample pair to the series. It returns the number of newly

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -223,7 +223,7 @@ func (i *Ingester) TransferOut(ctx context.Context) error {
 			err = stream.Send(&client.TimeSeriesChunk{
 				FromIngesterId: i.lifecycler.ID,
 				UserId:         userID,
-				Labels:         pair.series.metric,
+				Labels:         client.FromLabelsToLabelPairs(pair.series.metric),
 				Chunks:         chunks,
 			})
 			state.fpLocker.Unlock(pair.fp)


### PR DESCRIPTION
This should reduce the memory size of ingesters a bit: slices are 24 bytes plus contents while strings are 16 bytes.

It might not seem like much but there are typically 40 of them per series, so 300MB saved per million series.

This change does put more work onto the query side, where we will allocate byte slices in the process of serialising the answers.  Also when transferring chunks from a leaving to a joining ingester.