### PR TITLE
Don't block lock in forSeriesMatching callback

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -409,6 +409,9 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 
 		return nil
 	}, func(ctx context.Context) error {
+		if len(batch) == 0 {
+			return nil
+		}
 		err = stream.Send(&client.QueryStreamResponse{
 			Timeseries: batch,
 		})
@@ -417,12 +420,6 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 	}, queryStreamBatchSize)
 	if err != nil {
 		return err
-	}
-
-	if len(batch) > 0 {
-		err = stream.Send(&client.QueryStreamResponse{
-			Timeseries: batch,
-		})
 	}
 
 	queriedSeries.Observe(float64(numSeries))


### PR DESCRIPTION
`stream.Send` here https://github.com/cortexproject/cortex/blob/05b35bbf0d9e545c58de0acce47b94983d567fc1/pkg/ingester/ingester.go#L411-L413 is time consuming, in-turn blocking the lock in `forSeriesMatching`. 

This PR breaks the callbacks into 2 callbacks, where second callback is called in intervals outside the critical sections of the lock. 

- [ ] Unit tests

/cc @tomwilkie 