### PR TITLE
Connecting the logger instance used in Ruler to the underlying prom code

### DIFF
--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -289,7 +289,7 @@ func (r *Ruler) newGroup(userID string, groupName string, rls []rules.Rule) (*gr
 		Context:     context.Background(),
 		ExternalURL: r.alertURL,
 		NotifyFunc:  sendAlerts(notifier, r.alertURL.String()),
-		Logger:      gklog.NewNopLogger(),
+		Logger:      util.Logger,
 		Metrics:     r.metrics,
 	}
 	return newGroup(groupName, rls, appendable, opts), nil


### PR DESCRIPTION
Noticed this little surprise when troubleshooting some rule evaluation failures. This really large and complex change permits the undying prometheus rule processing code to log information out via the logger instance used by the ruler.