### PR TITLE
v10 schema builds on v9 but shards index rows to break up very big rows.

### DIFF
--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -37,6 +37,7 @@ var schemas = []struct {
 	{"v5", true},
 	{"v6", true},
 	{"v9", true},
+	{"v10", true},
 }
 
 var stores = []struct {

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -45,7 +45,7 @@ func (c *CompositeStore) AddPeriod(storeCfg StoreConfig, cfg PeriodConfig, index
 	var store Store
 	var err error
 	switch cfg.Schema {
-	case "v9":
+	case "v9", "v10":
 		store, err = newSeriesStore(storeCfg, schema, index, chunks, limits)
 	default:
 		store, err = newStore(storeCfg, schema, index, chunks, limits)

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -32,6 +32,7 @@ type PeriodConfig struct {
 	Schema      string              `yaml:"schema"`
 	IndexTables PeriodicTableConfig `yaml:"index"`
 	ChunkTables PeriodicTableConfig `yaml:"chunks,omitempty"`
+	RowShards   uint32              `yaml:"row_shards"`
 }
 
 // SchemaConfig contains the config for our chunk index schemas
@@ -182,7 +183,14 @@ func (cfg PeriodConfig) createSchema() Schema {
 	case "v9":
 		s = schema{cfg.dailyBuckets, v9Entries{}}
 	case "v10":
-		s = schema{cfg.dailyBuckets, v10Entries{}}
+		rowShards := uint32(16)
+		if cfg.RowShards > 0 {
+			rowShards = cfg.RowShards
+		}
+
+		s = schema{cfg.dailyBuckets, v10Entries{
+			rowShards: rowShards,
+		}}
 	}
 	return s
 }

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -3,17 +3,17 @@ package chunk
 import (
 	"flag"
 	"fmt"
-	"github.com/go-kit/kit/log/level"
 	"os"
 	"strconv"
 	"time"
 
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/common/model"
+	"github.com/weaveworks/common/mtime"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	"github.com/weaveworks/common/mtime"
 )
 
 const (
@@ -181,6 +181,8 @@ func (cfg PeriodConfig) createSchema() Schema {
 		s = schema{cfg.dailyBuckets, v6Entries{}}
 	case "v9":
 		s = schema{cfg.dailyBuckets, v9Entries{}}
+	case "v10":
+		s = schema{cfg.dailyBuckets, v10Entries{}}
 	}
 	return s
 }


### PR DESCRIPTION
We have some very-high-cardinality series; 300k+ series per metric.  This results in bigtable rows that are over 100MB in size.  This change splits all rows into 16 rows, distributing entries based on the series ID.  Each read becomes 16 reads, done in parallel.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>