### PR TITLE
fix logic in determining maximum concurrent chunk fetches

### DIFF
--- a/pkg/chunk/util/parallel_chunk_fetch.go
+++ b/pkg/chunk/util/parallel_chunk_fetch.go
@@ -29,7 +29,7 @@ func GetParallelChunks(ctx context.Context, chunks []chunk.Chunk, f func(context
 	processedChunks := make(chan chunk.Chunk)
 	errors := make(chan error)
 
-	for i := 0; i < max(maxParallel, len(chunks)); i++ {
+	for i := 0; i < min(maxParallel, len(chunks)); i++ {
 		go func() {
 			decodeContext := chunk.NewDecodeContext()
 			for c := range queuedChunks {
@@ -63,8 +63,8 @@ func GetParallelChunks(ctx context.Context, chunks []chunk.Chunk, f func(context
 	return result, lastErr
 }
 
-func max(a, b int) int {
-	if a > b {
+func min(a, b int) int {
+	if a < b {
 		return a
 	}
 	return b


### PR DESCRIPTION
Signed-off-by: Patrick McIlroy <patrick@platform9.com>

This change flips the logic in GetParallelChunks() to make `maxParallel` a hard maximum number of concurrent goroutines for chunk fetching rather than a minimum, which the surrounding comments indicate is its intention. Because there was no limit on the number of goroutines spawned for chunk fetching (rather, a minimum of 1000), we were seeing querier memory usage consistently balloon beyond what we allocate it (we run cortex in a kubernetes environment), resulting in them frequently getting OOMKilled. Applying this patch kept the memory footprint of fetching data for our longer 3 day graphs from 13GB to about 2GB.