### PR TITLE
Limit parallelism in a single query to 14 sub queries.

### DIFF
--- a/pkg/querier/frontend/results_cache.go
+++ b/pkg/querier/frontend/results_cache.go
@@ -110,7 +110,7 @@ func (s resultsCache) handleHit(ctx context.Context, r *QueryRangeRequest, exten
 		return response, nil, err
 	}
 
-	reqResps, err = doRequests(ctx, s.next, requests)
+	reqResps, err = doRequests(ctx, s.next, requests, len(requests))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/querier/frontend/results_cache.go
+++ b/pkg/querier/frontend/results_cache.go
@@ -110,7 +110,7 @@ func (s resultsCache) handleHit(ctx context.Context, r *QueryRangeRequest, exten
 		return response, nil, err
 	}
 
-	reqResps, err = doRequests(ctx, s.next, requests, len(requests))
+	reqResps, err = doRequests(ctx, s.next, requests)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/querier/frontend/split_by_day.go
+++ b/pkg/querier/frontend/split_by_day.go
@@ -29,7 +29,7 @@ func (s splitByDay) Do(ctx context.Context, r *QueryRangeRequest) (*APIResponse,
 	// to line up the boundaries with step.
 	reqs := splitQuery(r)
 
-	reqResps, err := doRequests(ctx, s.next, reqs, maxParallelism)
+	reqResps, err := doRequests(ctx, s.next, reqs)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ type requestResponse struct {
 	resp *APIResponse
 }
 
-func doRequests(ctx context.Context, downstream queryRangeHandler, reqs []*QueryRangeRequest, maxParallelism int) ([]requestResponse, error) {
+func doRequests(ctx context.Context, downstream queryRangeHandler, reqs []*QueryRangeRequest) ([]requestResponse, error) {
 	// If one of the requests fail, we want to be able to cancel the rest of them.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
There is a limit of 100 outstanding queries at once per customer.  Due to day splitting, this makes queries longer than 100 days fail.
This PR limits the number of 'sub queries' per query that can be executed in parallel to 14.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>

Fixes #1148