### PR TITLE
Small improvements to logging and error reporting of ingester transfers

### DIFF
--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -365,7 +365,7 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 		tokens, _ := ringDesc.TokensFor(i.ID)
 		i.setTokens(tokens)
 
-		level.Info(util.Logger).Log("msg", "existing entry found in ring", "state", i.GetState(), "tokens", tokens)
+		level.Info(util.Logger).Log("msg", "existing entry found in ring", "state", i.GetState(), "tokens", len(tokens))
 		return ringDesc, true, nil
 	})
 }


### PR DESCRIPTION
If an ingester has no chunks to transfer, do nothing explicitly.
(actually this is a check for a simpler condition - no user states)

Previously this would trigger a "no ingester id" error from the receiving end, so it's better to check for no series first.

And log the number of series received, which may be of interest.
