### PR TITLE
Check ingester has tokens before reporting ready

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -572,6 +572,6 @@ func (i *Ingester) ReadinessHandler(w http.ResponseWriter, r *http.Request) {
 	if err := i.lifecycler.CheckReady(r.Context()); err == nil {
 		w.WriteHeader(http.StatusNoContent)
 	} else {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		http.Error(w, "Not ready: "+err.Error(), http.StatusServiceUnavailable)
 	}
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -569,9 +569,9 @@ func (i *Ingester) Watch(in *grpc_health_v1.HealthCheckRequest, stream grpc_heal
 // the addition removal of another ingester. Returns 204 when the ingester is
 // ready, 500 otherwise.
 func (i *Ingester) ReadinessHandler(w http.ResponseWriter, r *http.Request) {
-	if i.lifecycler.IsReady(r.Context()) {
+	if err := i.lifecycler.CheckReady(r.Context()); err == nil {
 		w.WriteHeader(http.StatusNoContent)
 	} else {
-		w.WriteHeader(http.StatusServiceUnavailable)
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 	}
 }

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -167,17 +167,17 @@ func (i *Lifecycler) CheckReady(ctx context.Context) error {
 	// Ingester always take at least minReadyDuration to become ready to work
 	// around race conditions with ingesters exiting and updating the ring
 	if time.Now().Sub(i.startTime) < i.cfg.MinReadyDuration {
-		return fmt.Errorf("Not ready: waiting for %v after startup", i.cfg.MinReadyDuration)
+		return fmt.Errorf("waiting for %v after startup", i.cfg.MinReadyDuration)
 	}
 
 	ringDesc, err := i.KVStore.Get(ctx, ConsulKey)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error talking to consul", "err", err)
-		return fmt.Errorf("Not ready: error talking to consul: %s", err)
+		return fmt.Errorf("error talking to consul: %s", err)
 	}
 
 	if len(i.getTokens()) == 0 {
-		return fmt.Errorf("Not ready: this ingester owns no tokens")
+		return fmt.Errorf("this ingester owns no tokens")
 	}
 	if err := ringDesc.(*Desc).Ready(i.cfg.RingConfig.HeartbeatTimeout); err != nil {
 		return err

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -176,6 +176,9 @@ func (i *Lifecycler) CheckReady(ctx context.Context) error {
 		return fmt.Errorf("Not ready: error talking to consul: %s", err)
 	}
 
+	if len(i.getTokens()) == 0 {
+		return fmt.Errorf("Not ready: this ingester owns no tokens")
+	}
 	if err := ringDesc.(*Desc).Ready(i.cfg.RingConfig.HeartbeatTimeout); err != nil {
 		return err
 	}

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -121,9 +121,9 @@ func (d *Desc) Ready(heartbeatTimeout time.Duration) error {
 	numTokens := len(d.Tokens)
 	for id, ingester := range d.Ingesters {
 		if time.Now().Sub(time.Unix(ingester.Timestamp, 0)) > heartbeatTimeout {
-			return fmt.Errorf("Not ready: ingester %s past heartbeat timeout", id)
+			return fmt.Errorf("ingester %s past heartbeat timeout", id)
 		} else if ingester.State != ACTIVE {
-			return fmt.Errorf("Not ready: ingester %s in state %v", id, ingester.State)
+			return fmt.Errorf("ingester %s in state %v", id, ingester.State)
 		}
 		numTokens += len(ingester.Tokens)
 	}

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -1,6 +1,7 @@
 package ring
 
 import (
+	"fmt"
 	"sort"
 	"time"
 
@@ -115,19 +116,22 @@ func (d *Desc) FindIngestersByState(state IngesterState) []IngesterDesc {
 	return result
 }
 
-// Ready is true when all ingesters are active and healthy.
-func (d *Desc) Ready(heartbeatTimeout time.Duration) bool {
+// Ready returns no error when all ingesters are active and healthy.
+func (d *Desc) Ready(heartbeatTimeout time.Duration) error {
 	numTokens := len(d.Tokens)
-	for _, ingester := range d.Ingesters {
+	for id, ingester := range d.Ingesters {
 		if time.Now().Sub(time.Unix(ingester.Timestamp, 0)) > heartbeatTimeout {
-			return false
+			return fmt.Errorf("Not ready: ingester %s past heartbeat timeout", id)
 		} else if ingester.State != ACTIVE {
-			return false
+			return fmt.Errorf("Not ready: ingester %s in state %v", id, ingester.State)
 		}
 		numTokens += len(ingester.Tokens)
 	}
 
-	return numTokens > 0
+	if numTokens == 0 {
+		return fmt.Errorf("Not ready: no tokens in ring")
+	}
+	return nil
 }
 
 // TokensFor partitions the tokens into those for the given ID, and those for others.


### PR DESCRIPTION
Fixes #1112 

Also state the reason why an ingester is not reporting ready - the reason will be visible if you curl the `/ready` endpoint. This is to remove some head-scratching when debugging.
