### PR TITLE
Report the stack-trace from errors at top level

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -15,14 +15,12 @@ package main
 
 import (
 	"flag"
-	"os"
 
 	"google.golang.org/grpc"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	"github.com/go-kit/kit/log/level"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
 )
@@ -43,18 +41,12 @@ func main() {
 	util.InitLogger(&serverConfig)
 
 	multiAM, err := alertmanager.NewMultitenantAlertmanager(&alertmanagerConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing MultitenantAlertmanager", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing MultitenantAlertmanager", err)
 	go multiAM.Run()
 	defer multiAM.Stop()
 
 	server, err := server.New(serverConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing server", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing server", err)
 	defer server.Shutdown()
 
 	server.HTTP.PathPrefix("/status").Handler(multiAM.GetStatusHandler())

--- a/cmd/configs/main.go
+++ b/cmd/configs/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"flag"
-	"os"
 
-	"github.com/go-kit/kit/log/level"
 	"google.golang.org/grpc"
 
 	"github.com/cortexproject/cortex/pkg/configs/api"
@@ -33,19 +31,13 @@ func main() {
 	util.InitLogger(&serverConfig)
 
 	db, err := db.New(dbConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing database", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing database", err)
 	defer db.Close()
 
 	a := api.New(db)
 
 	server, err := server.New(serverConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing server", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing server", err)
 	defer server.Shutdown()
 
 	a.RegisterRoutes(server.HTTP)

--- a/cmd/distributor/main.go
+++ b/cmd/distributor/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"flag"
 	"net/http"
-	"os"
 
-	"github.com/go-kit/kit/log/level"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -65,31 +63,19 @@ func main() {
 	defer trace.Close()
 
 	r, err := ring.New(ringConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing ring", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing ring", err)
 	prometheus.MustRegister(r)
 	defer r.Stop()
 
 	overrides, err := validation.NewOverrides(limits)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing overrides", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing overrides", err)
 
 	dist, err := distributor.New(distributorConfig, clientConfig, overrides, r)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing distributor", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing distributor", err)
 	defer dist.Stop()
 
 	server, err := server.New(serverConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing server", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing server", err)
 	defer server.Shutdown()
 
 	// Administrator functions

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"flag"
 	"net/http"
-	"os"
 
-	"github.com/go-kit/kit/log/level"
 	"google.golang.org/grpc"
 	_ "google.golang.org/grpc/encoding/gzip" // get gzip compressor registered
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -76,29 +74,17 @@ func main() {
 	}
 
 	server, err := server.New(serverConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing server", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing server", err)
 	defer server.Shutdown()
 
 	overrides, err := validation.NewOverrides(limits)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing overrides", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing overrides", err)
 	chunkStore, err := storage.NewStore(storageConfig, chunkStoreConfig, schemaConfig, overrides)
-	if err != nil {
-		level.Error(util.Logger).Log("err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("", err)
 	defer chunkStore.Stop()
 
 	ingester, err := ingester.New(ingesterConfig, clientConfig, overrides, chunkStore)
-	if err != nil {
-		level.Error(util.Logger).Log("err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("", err)
 	defer ingester.Shutdown()
 
 	client.RegisterIngesterServer(server.GRPC, ingester)

--- a/cmd/query-frontend/main.go
+++ b/cmd/query-frontend/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"flag"
-	"os"
 
-	"github.com/go-kit/kit/log/level"
 	"google.golang.org/grpc"
 
 	"github.com/cortexproject/cortex/pkg/querier/frontend"
@@ -38,17 +36,11 @@ func main() {
 
 	serverConfig.GRPCOptions = append(serverConfig.GRPCOptions, grpc.MaxRecvMsgSize(maxMessageSize))
 	server, err := server.New(serverConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing server", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing server", err)
 	defer server.Shutdown()
 
 	f, err := frontend.New(frontendConfig, util.Logger)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing frontend", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing frontend", err)
 	defer f.Close()
 
 	frontend.RegisterFrontendServer(server.GRPC, f)

--- a/cmd/table-manager/main.go
+++ b/cmd/table-manager/main.go
@@ -36,10 +36,7 @@ func main() {
 	util.InitLogger(&serverConfig)
 
 	err := schemaConfig.Load()
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error loading schema config", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("loading schema config", err)
 	// Assume the newest config is the one to use
 	lastConfig := &schemaConfig.Configs[len(schemaConfig.Configs)-1]
 
@@ -57,24 +54,15 @@ func main() {
 	}
 
 	tableClient, err := storage.NewTableClient(lastConfig.IndexType, storageConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing DynamoDB table client", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing table client", err)
 
 	tableManager, err := chunk.NewTableManager(tbmConfig, schemaConfig, ingesterConfig.MaxChunkAge, tableClient)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing DynamoDB table manager", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing table manager", err)
 	tableManager.Start()
 	defer tableManager.Stop()
 
 	server, err := server.New(serverConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing server", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing server", err)
 	defer server.Shutdown()
 
 	server.Run()

--- a/cmd/test-exporter/main.go
+++ b/cmd/test-exporter/main.go
@@ -3,10 +3,8 @@ package main
 import (
 	"flag"
 	"math"
-	"os"
 	"time"
 
-	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/server"
 	"github.com/weaveworks/common/tracing"
@@ -35,17 +33,11 @@ func main() {
 	util.InitLogger(&serverConfig)
 
 	server, err := server.New(serverConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing server", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing server", err)
 	defer server.Shutdown()
 
 	runner, err := correctness.NewRunner(runnerConfig)
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing runner", "err", err)
-		os.Exit(1)
-	}
+	util.CheckFatal("initializing runner", err)
 	defer runner.Stop()
 
 	runner.Add(correctness.NewSimpleTestCase("now_seconds", func(t time.Time) float64 {

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/go-kit/kit/log"
@@ -121,4 +122,17 @@ func WithUserID(userID string, l log.Logger) log.Logger {
 func WithTraceID(traceID string, l log.Logger) log.Logger {
 	// See note in WithContext.
 	return log.With(l, "trace_id", traceID)
+}
+
+// CheckFatal prints an error and exits with error code 1 if err is non-nil
+func CheckFatal(location string, err error) {
+	if err != nil {
+		logger := level.Error(Logger)
+		if location != "" {
+			logger = log.With(logger, "msg", "error "+location)
+		}
+		// %+v gets the stack trace from errors using github.com/pkg/errors
+		logger.Log("err", fmt.Sprintf("%+v", err))
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Errors created with `github.com/pkg/errors` may have extra info such as a stack trace, but we need to ask for it specially.

Localise this code in one place in the `utils` package.

Sweet sweet -145 lines of code.
