### PR TITLE
Allow ingesters to hand over chunks in example config

### DIFF
--- a/k8s/ingester-dep.yaml
+++ b/k8s/ingester-dep.yaml
@@ -38,7 +38,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - -ingester.join-after=30s
-        - -ingester.claim-on-rollout=false
+        - -ingester.claim-on-rollout=true
         - -consul.hostname=consul.default.svc.cluster.local:8500
         - -s3.url=s3://abc:123@s3.default.svc.cluster.local:4569
         - -dynamodb.original-table-name=cortex


### PR DESCRIPTION
By setting `-ingester.claim-on-rollout=true`.  I don't know why this flag was ever specified as `false` in the file, as it defaults that way.

Note that the bit in this file about stopping one ingester before starting another doesn't contradict this - Kubernetes will send SIGTERM to the old one before starting the new one, but it doesn't wait for it to stop. SIGTERM triggers the old ingester to look for a new one to hand over to.
