### PR TITLE
Fix fmt.Errorf() error message

### DIFF
--- a/pkg/chunk/encoding/delta.go
+++ b/pkg/chunk/encoding/delta.go
@@ -224,7 +224,7 @@ func (c *deltaEncodedChunk) UnmarshalFromBuf(buf []byte) error {
 func (c *deltaEncodedChunk) setLen() error {
 	l := binary.LittleEndian.Uint16((*c)[deltaHeaderBufLenOffset:])
 	if int(l) > cap(*c) {
-		return fmt.Errorf("delta chunk length exceeded during unmarshaling: %d", l)
+		return fmt.Errorf("delta chunk length exceeded during unmarshalling: %d", l)
 	}
 	if int(l) < deltaHeaderBytes {
 		return fmt.Errorf("delta chunk length less than header size: %d < %d", l, deltaHeaderBytes)

--- a/pkg/chunk/encoding/delta_test.go
+++ b/pkg/chunk/encoding/delta_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-func TestUnmarshalingCorruptedDeltaReturnsAnError(t *testing.T) {
+func TestUnmarshallingCorruptedDeltaReturnsAnError(t *testing.T) {
 
 	var verifyUnmarshallingError = func(
 		err error,

--- a/pkg/chunk/encoding/doubledelta.go
+++ b/pkg/chunk/encoding/doubledelta.go
@@ -252,7 +252,7 @@ func (c *doubleDeltaEncodedChunk) UnmarshalFromBuf(buf []byte) error {
 func (c *doubleDeltaEncodedChunk) setLen() error {
 	l := binary.LittleEndian.Uint16((*c)[doubleDeltaHeaderBufLenOffset:])
 	if int(l) > cap(*c) {
-		return fmt.Errorf("doubledelta chunk length exceeded during unmarshaling: %d", l)
+		return fmt.Errorf("doubledelta chunk length exceeded during unmarshalling: %d", l)
 	}
 	if int(l) < doubleDeltaHeaderMinBytes {
 		return fmt.Errorf("doubledelta chunk length less than header size: %d < %d", l, doubleDeltaHeaderMinBytes)

--- a/pkg/chunk/encoding/varbit.go
+++ b/pkg/chunk/encoding/varbit.go
@@ -300,7 +300,7 @@ func (c varbitChunk) Marshal(w io.Writer) error {
 // UnmarshalFromBuf implements chunk.
 func (c varbitChunk) UnmarshalFromBuf(buf []byte) error {
 	if copied := copy(c, buf); copied != cap(c) && copied != c.marshalLen() {
-		return fmt.Errorf("incorrect byte count copied from buffer during unmarshaling, want %d or %d, got %d", c.marshalLen(), ChunkLen, copied)
+		return fmt.Errorf("incorrect byte count copied from buffer during unmarshalling, want %d or %d, got %d", c.marshalLen(), ChunkLen, copied)
 	}
 	return nil
 }

--- a/pkg/querier/frontend/results_cache.go
+++ b/pkg/querier/frontend/results_cache.go
@@ -209,7 +209,7 @@ func (s resultsCache) get(ctx context.Context, key string) ([]Extent, bool) {
 	sp.LogFields(otlog.Int("bytes", len(bufs[0])))
 
 	if err := proto.Unmarshal(bufs[0], &resp); err != nil {
-		level.Error(util.Logger).Log("msg", "error unmarshaling cached value", "err", err)
+		level.Error(util.Logger).Log("msg", "error unmarshalling cached value", "err", err)
 		sp.LogFields(otlog.Error(err))
 		return nil, false
 	}


### PR DESCRIPTION
"unmarshaling" to "unmarshalling".
"TestUnmarshalingCorruptedDeltaReturnsAnError" to "TestUnmarshallingCorruptedDeltaReturnsAnError".