### PR TITLE
Add admin pages to example proxy config

### DIFF
--- a/k8s/nginx-config.yaml
+++ b/k8s/nginx-config.yaml
@@ -27,7 +27,6 @@ data:
         listen 80;
         proxy_set_header X-Scope-OrgID 0;
 
-        # pass requests for dynamic content to rails/turbogears/zope, et al
         location = /api/prom/push {
           proxy_pass      http://distributor.default.svc.cluster.local$request_uri;
         }

--- a/k8s/nginx-config.yaml
+++ b/k8s/nginx-config.yaml
@@ -32,6 +32,13 @@ data:
           proxy_pass      http://distributor.default.svc.cluster.local$request_uri;
         }
 
+        location = /ring {
+          proxy_pass      http://distributor.cortex.svc.cluster.local$request_uri;
+        }
+        location = /all_user_stats {
+          proxy_pass      http://distributor.cortex.svc.cluster.local$request_uri;
+        }
+
         location ~ /api/prom/.* {
           proxy_pass      http://query-frontend.default.svc.cluster.local$request_uri;
         }


### PR DESCRIPTION
Expose `/ring` and `/all_user_stats` in the nginx config, so they can be called from outside the cluster.

Also drop a comment that doesn't apply - seems to be left over from somewhere else.
