### PR TITLE
Intern label strings

### DIFF
--- a/pkg/ingester/label_pairs.go
+++ b/pkg/ingester/label_pairs.go
@@ -66,31 +66,6 @@ func (a *labelPairs) removeBlanks() {
 	}
 }
 
-func (a labelPairs) copyValuesAndSort() labels.Labels {
-	c := make(labels.Labels, len(a))
-	// Since names and values may point into a much larger buffer,
-	// make a copy of all the names and values, in one block for efficiency
-	copyBytes := make([]byte, 0, len(a)*32) // guess at initial length
-	for _, pair := range a {
-		copyBytes = append(copyBytes, pair.Name...)
-		copyBytes = append(copyBytes, pair.Value...)
-	}
-	// Now we need to copy the byte slice into a string for the values to point into
-	copyString := string(copyBytes)
-	pos := 0
-	stringSlice := func(val []byte) string {
-		start := pos
-		pos += len(val)
-		return copyString[start:pos]
-	}
-	for i, pair := range a {
-		c[i].Name = stringSlice(pair.Name)
-		c[i].Value = stringSlice(pair.Value)
-	}
-	sort.Sort(c)
-	return c
-}
-
 func valueForName(s labels.Labels, name []byte) (string, bool) {
 	pos := sort.Search(len(s), func(i int) bool { return s[i].Name >= string(name) })
 	if pos == len(s) || s[pos].Name != string(name) {

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -51,9 +51,9 @@ func (error *memorySeriesError) Error() string {
 
 // newMemorySeries returns a pointer to a newly allocated memorySeries for the
 // given metric.
-func newMemorySeries(m labelPairs) *memorySeries {
+func newMemorySeries(m labels.Labels) *memorySeries {
 	return &memorySeries{
-		metric:   m.copyValuesAndSort(),
+		metric:   m,
 		lastTime: model.Earliest,
 	}
 }

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -213,9 +213,9 @@ func (u *userState) getSeries(metric labelPairs) (model.Fingerprint, *memorySeri
 	u.memSeriesCreatedTotal.Inc()
 	memSeries.Inc()
 
-	series = newMemorySeries(metric)
+	labels := u.index.Add(metric, fp)
+	series = newMemorySeries(labels)
 	u.fpToSeries.put(fp, series)
-	u.index.Add(metric, fp)
 
 	return fp, series, nil
 }


### PR DESCRIPTION
Fixes #1257 (mostly)

Currently, we have a separate copy of each label names and value string (e.g. `instance`, `kubernetes_namespace`, `get`) for each timeseries.  This consumes about 25% of all ingester memory in profiles I've looked at.

The inverted index is keyed by those strings, so we have a ready-made place to reduce down to one copy (per index shard per user). 

Unfortunately Go doesn't let us access the key of a map on lookup, so we have to add another reference to the string in the map value.  This makes data access a bit more ugly, and also costs another 16 bytes per index entry, but unless you have a shedload of unique short label values I think we'll come out ahead.

Benchmarks (Go 1.12; best of 5 runs):
Before:
```
BenchmarkIngesterPush-2   	      20	  87524048 ns/op	 3086538 B/op	   13751 allocs/op
```
After:
```
BenchmarkIngesterPush-2   	      20	  86766945 ns/op	 2843284 B/op	   12347 allocs/op
```