### PR TITLE
Parallelise calls from the querier -> ingester in an attempt to reduce latency.

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -104,7 +104,8 @@ type Config struct {
 	ExtraQueryDelay     time.Duration
 	LimiterReloadPeriod time.Duration
 
-	ShardByAllLabels bool
+	ShardByAllLabels  bool
+	QueryStreamShards int
 
 	// for testing
 	ingesterClientFactory client.Factory
@@ -120,6 +121,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.ExtraQueryDelay, "distributor.extra-query-delay", 0, "Time to wait before sending more than the minimum successful query requests.")
 	f.DurationVar(&cfg.LimiterReloadPeriod, "distributor.limiter-reload-period", 5*time.Minute, "Period at which to reload user ingestion limits.")
 	f.BoolVar(&cfg.ShardByAllLabels, "distributor.shard-by-all-labels", false, "Distribute samples based on all labels, as opposed to solely by user and metric name.")
+	f.IntVar(&cfg.QueryStreamShards, "distributor.query-stream-shards", 1, "Number of parallel calls to use for queries to the ingesters.")
 }
 
 // New constructs a new Distributor

--- a/pkg/ingester/client/cortex.proto
+++ b/pkg/ingester/client/cortex.proto
@@ -47,6 +47,9 @@ message QueryRequest {
   int64 start_timestamp_ms = 1;
   int64 end_timestamp_ms = 2;
   repeated LabelMatcher matchers = 3;
+
+  uint32 shard_index = 4;
+  uint32 total_shards = 5;
 }
 
 message QueryResponse {


### PR DESCRIPTION
Even after #1233, we're still seeing long tail latencies on QueryStream calls to the ingester.  This PR splits calls from the queries to the the ingesters up into a configurable number of parallel calls.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>