### PR TITLE
Speed up labelPairs.equal() when sorted

### DIFF
--- a/pkg/ingester/label_pairs.go
+++ b/pkg/ingester/label_pairs.go
@@ -104,9 +104,20 @@ func (a labelPairs) equal(b labels.Labels) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	for _, pair := range a {
-		v, found := valueForName(b, pair.Name)
-		if !found || v != string(pair.Value) {
+	// Check as many as we can where the two sets are in the same order
+	i := 0
+	for ; i < len(a); i++ {
+		if b[i].Name != string(a[i].Name) {
+			break
+		}
+		if b[i].Value != string(a[i].Value) {
+			return false
+		}
+	}
+	// Now check remaining values using binary search
+	for ; i < len(a); i++ {
+		v, found := valueForName(b, a[i].Name)
+		if !found || v != string(a[i].Value) {
 			return false
 		}
 	}

--- a/pkg/ingester/label_pairs_test.go
+++ b/pkg/ingester/label_pairs_test.go
@@ -1,0 +1,106 @@
+package ingester
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+func TestLabelPairsEqual(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		a     labelPairs
+		b     labels.Labels
+		equal bool
+	}{
+		{
+			name:  "both blank",
+			a:     labelPairs{},
+			b:     labels.Labels{},
+			equal: true,
+		},
+		{
+			name: "labelPairs nonblank; labels blank",
+			a: labelPairs{
+				{Name: []byte("foo"), Value: []byte("a")},
+			},
+			b:     labels.Labels{},
+			equal: false,
+		},
+		{
+			name: "labelPairs blank; labels nonblank",
+			a:    labelPairs{},
+			b: labels.Labels{
+				{Name: "foo", Value: "a"},
+			},
+			equal: false,
+		},
+		{
+			name: "same contents; labelPairs not sorted",
+			a: labelPairs{
+				{Name: []byte("foo"), Value: []byte("a")},
+				{Name: []byte("bar"), Value: []byte("b")},
+			},
+			b: labels.Labels{
+				{Name: "bar", Value: "b"},
+				{Name: "foo", Value: "a"},
+			},
+			equal: true,
+		},
+		{
+			name: "same contents",
+			a: labelPairs{
+				{Name: []byte("bar"), Value: []byte("b")},
+				{Name: []byte("foo"), Value: []byte("a")},
+			},
+			b: labels.Labels{
+				{Name: "bar", Value: "b"},
+				{Name: "foo", Value: "a"},
+			},
+			equal: true,
+		},
+		{
+			name: "same names, different value",
+			a: labelPairs{
+				{Name: []byte("bar"), Value: []byte("b")},
+				{Name: []byte("foo"), Value: []byte("c")},
+			},
+			b: labels.Labels{
+				{Name: "bar", Value: "b"},
+				{Name: "foo", Value: "a"},
+			},
+			equal: false,
+		},
+		{
+			name: "labels has one extra value",
+			a: labelPairs{
+				{Name: []byte("bar"), Value: []byte("b")},
+				{Name: []byte("foo"), Value: []byte("a")},
+			},
+			b: labels.Labels{
+				{Name: "bar", Value: "b"},
+				{Name: "foo", Value: "a"},
+				{Name: "firble", Value: "c"},
+			},
+			equal: false,
+		},
+		{
+			name: "labelPairs has one extra value",
+			a: labelPairs{
+				{Name: []byte("bar"), Value: []byte("b")},
+				{Name: []byte("foo"), Value: []byte("a")},
+				{Name: []byte("firble"), Value: []byte("c")},
+			},
+			b: labels.Labels{
+				{Name: "bar", Value: "b"},
+				{Name: "foo", Value: "a"},
+				{Name: "firble", Value: "a"},
+			},
+			equal: false,
+		},
+	} {
+		if test.a.equal(test.b) != test.equal {
+			t.Errorf("%s: expected equal=%t", test.name, test.equal)
+		}
+	}
+}


### PR DESCRIPTION
Many `remote_write` clients (including Prometheus) will send samples with labels already sorted, and we can do the comparison much faster in that case. 

If they are not in order we do one extra name comparison.

Added a test.

Benchmarks (Go 1.12; best of 5 runs):
Before:
```
BenchmarkIngesterPush-2   	      20	  87524048 ns/op	 3086538 B/op	   13751 allocs/op
```
After:
```
BenchmarkIngesterPush-2   	      20	  56911377 ns/op	 3041616 B/op	   13759 allocs/op
```