### PR TITLE
Allow extra space to add new bigchunk data after Unmarshal

### DIFF
--- a/pkg/chunk/encoding/bigchunk.go
+++ b/pkg/chunk/encoding/bigchunk.go
@@ -110,7 +110,7 @@ func (b *bigchunk) UnmarshalFromBuf(buf []byte) error {
 		return err
 	}
 
-	b.chunks = make([]smallChunk, 0, numChunks)
+	b.chunks = make([]smallChunk, 0, numChunks+1) // allow one extra space in case we want to add new data
 	for i := uint16(0); i < numChunks; i++ {
 		chunkLen, err := r.ReadUint16()
 		if err != nil {


### PR DESCRIPTION
As noted at #1220, after a transfer of chunks from one ingester to another, a new `smallChunk` is created immediately for any new samples that arrive. Allowing room for this avoids a copy and doubling in size of the slice of `smallChunk`s.

We go through the same code path on queries, so they will get slightly larger in memory - 24 bytes per chunk.

This change wouldn't be so useful if #1221 could be made to work.