### PR TITLE
Fix table lookup when chunk time aligns with table

### DIFF
--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -434,7 +434,7 @@ func (cfg *PeriodicTableConfig) periodicTables(from, through model.Time, pCfg Pr
 // ChunkTableFor calculates the chunk table shard for a given point in time.
 func (cfg SchemaConfig) ChunkTableFor(t model.Time) (string, error) {
 	for i := range cfg.Configs {
-		if t > cfg.Configs[i].From && (i+1 == len(cfg.Configs) || t < cfg.Configs[i+1].From) {
+		if t >= cfg.Configs[i].From && (i+1 == len(cfg.Configs) || t < cfg.Configs[i+1].From) {
 			return cfg.Configs[i].ChunkTables.TableFor(t), nil
 		}
 	}

--- a/pkg/chunk/schema_config_test.go
+++ b/pkg/chunk/schema_config_test.go
@@ -3,8 +3,10 @@ package chunk
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHourlyBuckets(t *testing.T) {
@@ -176,5 +178,101 @@ func TestDailyBuckets(t *testing.T) {
 				t.Errorf("SchemaConfig.dailyBuckets() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestChunkTableFor(t *testing.T) {
+	tablePeriod, err := time.ParseDuration("168h")
+	require.NoError(t, err)
+
+	periodConfigs := []PeriodConfig{
+		{
+			FromStr: "1970-01-01",
+			IndexTables: PeriodicTableConfig{
+				Prefix: "index_1_",
+				Period: tablePeriod,
+			},
+			ChunkTables: PeriodicTableConfig{
+				Prefix: "chunks_1_",
+				Period: tablePeriod,
+			},
+		},
+		{
+			FromStr: "2019-01-02",
+			IndexTables: PeriodicTableConfig{
+				Prefix: "index_2_",
+				Period: tablePeriod,
+			},
+			ChunkTables: PeriodicTableConfig{
+				Prefix: "chunks_2_",
+				Period: tablePeriod,
+			},
+		},
+		{
+			FromStr: "2019-03-06",
+			IndexTables: PeriodicTableConfig{
+				Prefix: "index_3_",
+				Period: tablePeriod,
+			},
+			ChunkTables: PeriodicTableConfig{
+				Prefix: "chunks_3_",
+				Period: tablePeriod,
+			},
+		},
+	}
+
+	for i, cfg := range periodConfigs {
+		ts, err := time.Parse("2006-01-02", cfg.FromStr)
+		require.NoError(t, err)
+
+		periodConfigs[i].From = model.TimeFromUnix(ts.Unix())
+	}
+
+	schemaCfg := SchemaConfig{
+		Configs: periodConfigs,
+	}
+
+	testCases := []struct {
+		timeStr    string // RFC3339
+		chunkTable string
+	}{
+		{
+			timeStr:    "1970-01-01T00:00:00Z",
+			chunkTable: "chunks_1_0",
+		},
+		{
+			timeStr:    "1970-01-01T00:00:01Z",
+			chunkTable: "chunks_1_0",
+		},
+		{
+			timeStr:    "2019-01-01T00:00:00Z",
+			chunkTable: "chunks_1_2556",
+		},
+		{
+			timeStr:    "2019-01-01T23:59:59Z",
+			chunkTable: "chunks_1_2556",
+		},
+		{
+			timeStr:    "2019-01-02T00:00:00Z",
+			chunkTable: "chunks_2_2556",
+		},
+		{
+			timeStr:    "2019-03-06T00:00:00Z",
+			chunkTable: "chunks_3_2565",
+		},
+		{
+			timeStr:    "2020-03-06T00:00:00Z",
+			chunkTable: "chunks_3_2618",
+		},
+	}
+
+	for _, tc := range testCases {
+		ts, err := time.Parse(time.RFC3339, tc.timeStr)
+		require.NoError(t, err)
+
+		table, err := schemaCfg.ChunkTableFor(model.TimeFromUnix(ts.Unix()))
+		require.NoError(t, err)
+
+		require.Equal(t, tc.chunkTable, table)
 	}
 }


### PR DESCRIPTION
When `Chunk.From` and `Config.From` are same, then the current code fails with:
```
msg="failed to flush user" err="no chunk table found for time 1551830400"
```