### PR TITLE
Fix modulo arithmetic to prevent ingesters OOMing.

### DIFF
--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -280,12 +280,14 @@ func (u *userState) forSeriesMatching(ctx context.Context, allMatchers []*labels
 	level.Debug(log).Log("series", len(fps))
 
 	// fps is sorted, lock them in order to prevent deadlocks
+	i := 0
 outer:
-	for i, fp := range fps {
+	for ; i < len(fps); i++ {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 
+		fp := fps[i]
 		u.fpLocker.Lock(fp)
 		series, ok := u.fpToSeries.get(fp)
 		if !ok {
@@ -306,14 +308,14 @@ outer:
 			return err
 		}
 
-		if batchSize > 0 && i+1%batchSize == 0 && send != nil {
+		if batchSize > 0 && (i+1)%batchSize == 0 && send != nil {
 			if err = send(ctx); err != nil {
 				return nil
 			}
 		}
 	}
 
-	if send != nil {
+	if batchSize > 0 && (i+1)%batchSize == 0 && send != nil {
 		return send(ctx)
 	}
 	return nil

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -315,7 +315,7 @@ outer:
 		}
 	}
 
-	if batchSize > 0 && (i+1)%batchSize == 0 && send != nil {
+	if batchSize > 0 && i%batchSize > 0 && send != nil {
 		return send(ctx)
 	}
 	return nil

--- a/pkg/ingester/user_state_test.go
+++ b/pkg/ingester/user_state_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Test forSeriesMatching correctly batches up series.
-func TestForSeriesMatching(t *testing.T) {
+func TestForSeriesMatchingBatching(t *testing.T) {
 	_, ing := newDefaultTestStore(t)
 	userIDs, _ := pushTestSamples(t, ing, 100, 100)
 

--- a/pkg/ingester/user_state_test.go
+++ b/pkg/ingester/user_state_test.go
@@ -1,0 +1,42 @@
+package ingester
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
+	"golang.org/x/net/context"
+)
+
+// Test forSeriesMatching correctly batches up series.
+func TestForSeriesMatching(t *testing.T) {
+	_, ing := newDefaultTestStore(t)
+	userIDs, _ := pushTestSamples(t, ing, 100, 100)
+
+	for _, userID := range userIDs {
+		ctx := user.InjectOrgID(context.Background(), userID)
+		instance, ok, err := ing.userStates.getViaContext(ctx)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		matcher, err := labels.NewMatcher(labels.MatchRegexp, model.MetricNameLabel, ".+")
+		require.NoError(t, err)
+
+		count := 0
+		err = instance.forSeriesMatching(ctx, []*labels.Matcher{matcher},
+			func(_ context.Context, _ model.Fingerprint, s *memorySeries) error {
+				count++
+				return nil
+			},
+			func(context.Context) error {
+				require.Equal(t, 10, count)
+				count = 0
+				return nil
+			},
+			10)
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
Previously would only call send at the end of the function, causing the batches to be massive.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>