### PR TITLE
Simplify index by using 'string' instead of LabelValue/LabelName types

### DIFF
--- a/pkg/ingester/index/index.go
+++ b/pkg/ingester/index/index.go
@@ -24,7 +24,7 @@ type InvertedIndex struct {
 func New() *InvertedIndex {
 	shards := make([]indexShard, indexShards)
 	for i := 0; i < indexShards; i++ {
-		shards[i].idx = map[model.LabelName]indexEntry{}
+		shards[i].idx = map[string]indexEntry{}
 	}
 	return &InvertedIndex{
 		shards: shards,
@@ -54,27 +54,27 @@ func (ii *InvertedIndex) Lookup(matchers []*labels.Matcher) []model.Fingerprint 
 }
 
 // LabelNames returns all label names.
-func (ii *InvertedIndex) LabelNames() model.LabelNames {
-	results := make([]model.LabelNames, 0, indexShards)
+func (ii *InvertedIndex) LabelNames() []string {
+	results := make([][]string, 0, indexShards)
 
 	for i := range ii.shards {
 		shardResult := ii.shards[i].labelNames()
 		results = append(results, shardResult)
 	}
 
-	return mergeLabelNameLists(results)
+	return mergeStringSlices(results)
 }
 
 // LabelValues returns the values for the given label.
-func (ii *InvertedIndex) LabelValues(name model.LabelName) model.LabelValues {
-	results := make([]model.LabelValues, 0, indexShards)
+func (ii *InvertedIndex) LabelValues(name string) []string {
+	results := make([][]string, 0, indexShards)
 
 	for i := range ii.shards {
 		shardResult := ii.shards[i].labelValues(name)
 		results = append(results, shardResult)
 	}
 
-	return mergeLabelValueLists(results)
+	return mergeStringSlices(results)
 }
 
 // Delete a fingerprint with the given label pairs.
@@ -85,16 +85,16 @@ func (ii *InvertedIndex) Delete(labels labels.Labels, fp model.Fingerprint) {
 
 // NB slice entries are sorted in fp order.
 type indexEntry struct {
-	name model.LabelName
-	fps  map[model.LabelValue]indexValueEntry
+	name string
+	fps  map[string]indexValueEntry
 }
 
 type indexValueEntry struct {
-	value model.LabelValue
+	value string
 	fps   []model.Fingerprint
 }
 
-type unlockIndex map[model.LabelName]indexEntry
+type unlockIndex map[string]indexEntry
 
 // This is the prevalent value for Intel and AMD CPUs as-at 2018.
 const cacheLineSize = 64
@@ -113,17 +113,17 @@ func (shard *indexShard) add(metric []client.LabelPair, fp model.Fingerprint) la
 	internedLabels := make(labels.Labels, len(metric))
 
 	for i, pair := range metric {
-		values, ok := shard.idx[model.LabelName(pair.Name)]
+		values, ok := shard.idx[string(pair.Name)]
 		if !ok {
 			values = indexEntry{
-				name: model.LabelName(pair.Name),
-				fps:  map[model.LabelValue]indexValueEntry{},
+				name: string(pair.Name),
+				fps:  map[string]indexValueEntry{},
 			}
 			shard.idx[values.name] = values
 		}
-		fingerprints, ok := values.fps[model.LabelValue(pair.Value)]
+		fingerprints, ok := values.fps[string(pair.Value)]
 		if !ok {
-			fingerprints = indexValueEntry{value: model.LabelValue(pair.Value)}
+			fingerprints = indexValueEntry{value: string(pair.Value)}
 		}
 		// Insert into the right position to keep fingerprints sorted
 		j := sort.Search(len(fingerprints.fps), func(i int) bool {
@@ -150,13 +150,13 @@ func (shard *indexShard) lookup(matchers []*labels.Matcher) []model.Fingerprint 
 	// loop invariant: result is sorted
 	var result []model.Fingerprint
 	for _, matcher := range matchers {
-		values, ok := shard.idx[model.LabelName(matcher.Name)]
+		values, ok := shard.idx[matcher.Name]
 		if !ok {
 			return nil
 		}
 		var toIntersect model.Fingerprints
 		if matcher.Type == labels.MatchEqual {
-			fps := values.fps[model.LabelValue(matcher.Value)]
+			fps := values.fps[matcher.Value]
 			toIntersect = append(toIntersect, fps.fps...) // deliberate copy
 		} else {
 			// accumulate the matching fingerprints (which are all distinct)
@@ -177,20 +177,20 @@ func (shard *indexShard) lookup(matchers []*labels.Matcher) []model.Fingerprint 
 	return result
 }
 
-func (shard *indexShard) labelNames() model.LabelNames {
+func (shard *indexShard) labelNames() []string {
 	shard.mtx.RLock()
 	defer shard.mtx.RUnlock()
 
-	results := make(model.LabelNames, 0, len(shard.idx))
+	results := make([]string, 0, len(shard.idx))
 	for name := range shard.idx {
 		results = append(results, name)
 	}
 
-	sort.Sort(labelNames(results))
+	sort.Strings(results)
 	return results
 }
 
-func (shard *indexShard) labelValues(name model.LabelName) model.LabelValues {
+func (shard *indexShard) labelValues(name string) []string {
 	shard.mtx.RLock()
 	defer shard.mtx.RUnlock()
 
@@ -199,12 +199,12 @@ func (shard *indexShard) labelValues(name model.LabelName) model.LabelValues {
 		return nil
 	}
 
-	results := make(model.LabelValues, 0, len(values.fps))
+	results := make([]string, 0, len(values.fps))
 	for val := range values.fps {
 		results = append(results, val)
 	}
 
-	sort.Sort(labelValues(results))
+	sort.Strings(results)
 	return results
 }
 
@@ -213,7 +213,7 @@ func (shard *indexShard) delete(labels labels.Labels, fp model.Fingerprint) {
 	defer shard.mtx.Unlock()
 
 	for _, pair := range labels {
-		name, value := model.LabelName(pair.Name), model.LabelValue(pair.Value)
+		name, value := string(pair.Name), string(pair.Value)
 		values, ok := shard.idx[name]
 		if !ok {
 			continue
@@ -262,42 +262,31 @@ func intersect(a, b []model.Fingerprint) []model.Fingerprint {
 	return result
 }
 
-type labelValues model.LabelValues
-
-func (a labelValues) Len() int           { return len(a) }
-func (a labelValues) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a labelValues) Less(i, j int) bool { return a[i] < a[j] }
-
-type labelNames model.LabelNames
-
-func (a labelNames) Len() int           { return len(a) }
-func (a labelNames) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a labelNames) Less(i, j int) bool { return a[i] < a[j] }
-
 type fingerprints []model.Fingerprint
 
 func (a fingerprints) Len() int           { return len(a) }
 func (a fingerprints) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a fingerprints) Less(i, j int) bool { return a[i] < a[j] }
 
-func mergeLabelValueLists(lvss []model.LabelValues) model.LabelValues {
-	switch len(lvss) {
+func mergeStringSlices(ss [][]string) []string {
+	switch len(ss) {
 	case 0:
 		return nil
 	case 1:
-		return lvss[0]
+		return ss[0]
 	case 2:
-		return mergeTwoLabelValueLists(lvss[0], lvss[1])
+		return mergeTwoStringSlices(ss[0], ss[1])
 	default:
-		n := len(lvss) / 2
-		left := mergeLabelValueLists(lvss[:n])
-		right := mergeLabelValueLists(lvss[n:])
-		return mergeTwoLabelValueLists(left, right)
+		halfway := len(ss) / 2
+		return mergeTwoStringSlices(
+			mergeStringSlices(ss[:halfway]),
+			mergeStringSlices(ss[halfway:]),
+		)
 	}
 }
 
-func mergeTwoLabelValueLists(a, b model.LabelValues) model.LabelValues {
-	result := make(model.LabelValues, 0, len(a)+len(b))
+func mergeTwoStringSlices(a, b []string) []string {
+	result := make([]string, 0, len(a)+len(b))
 	i, j := 0, 0
 	for i < len(a) && j < len(b) {
 		if a[i] < b[j] {
@@ -307,44 +296,7 @@ func mergeTwoLabelValueLists(a, b model.LabelValues) model.LabelValues {
 			result = append(result, b[j])
 			j++
 		} else {
-			result = append(result, b[j])
-			i++
-			j++
-		}
-	}
-	result = append(result, a[i:]...)
-	result = append(result, b[j:]...)
-	return result
-}
-
-func mergeLabelNameLists(lnss []model.LabelNames) model.LabelNames {
-	switch len(lnss) {
-	case 0:
-		return nil
-	case 1:
-		return lnss[0]
-	case 2:
-		return mergeTwoLabelNameLists(lnss[0], lnss[1])
-	default:
-		n := len(lnss) / 2
-		left := mergeLabelNameLists(lnss[:n])
-		right := mergeLabelNameLists(lnss[n:])
-		return mergeTwoLabelNameLists(left, right)
-	}
-}
-
-func mergeTwoLabelNameLists(a, b model.LabelNames) model.LabelNames {
-	result := make(model.LabelNames, 0, len(a)+len(b))
-	i, j := 0, 0
-	for i < len(a) && j < len(b) {
-		if a[i] < b[j] {
 			result = append(result, a[i])
-			i++
-		} else if a[i] > b[j] {
-			result = append(result, b[j])
-			j++
-		} else {
-			result = append(result, b[j])
 			i++
 			j++
 		}

--- a/pkg/ingester/index/index_test.go
+++ b/pkg/ingester/index/index_test.go
@@ -46,9 +46,9 @@ func TestIndex(t *testing.T) {
 		assert.Equal(t, tc.fps, index.Lookup(tc.matchers))
 	}
 
-	assert.Equal(t, model.LabelNames{"flip", "foo"}, index.LabelNames())
-	assert.Equal(t, model.LabelValues{"bar", "baz"}, index.LabelValues("foo"))
-	assert.Equal(t, model.LabelValues{"flap", "flop"}, index.LabelValues("flip"))
+	assert.Equal(t, []string{"flip", "foo"}, index.LabelNames())
+	assert.Equal(t, []string{"bar", "baz"}, index.LabelValues("foo"))
+	assert.Equal(t, []string{"flap", "flop"}, index.LabelValues("flip"))
 }
 
 func mustParseMatcher(s string) []*labels.Matcher {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -442,8 +442,8 @@ func (i *Ingester) LabelValues(ctx old_ctx.Context, req *client.LabelValuesReque
 	}
 
 	resp := &client.LabelValuesResponse{}
-	for _, v := range state.index.LabelValues(model.LabelName(req.LabelName)) {
-		resp.LabelValues = append(resp.LabelValues, string(v))
+	for _, v := range state.index.LabelValues(req.LabelName) {
+		resp.LabelValues = append(resp.LabelValues, v)
 	}
 
 	return resp, nil
@@ -462,7 +462,7 @@ func (i *Ingester) LabelNames(ctx old_ctx.Context, req *client.LabelNamesRequest
 
 	resp := &client.LabelNamesResponse{}
 	for _, v := range state.index.LabelNames() {
-		resp.LabelNames = append(resp.LabelNames, string(v))
+		resp.LabelNames = append(resp.LabelNames, v)
 	}
 
 	return resp, nil


### PR DESCRIPTION
Less casting, less code.
