### PR TITLE
Make it nicer to test locally with minikube in 2019

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,3 +160,14 @@ load-images:
 			docker load -i images/$$(echo $$image_name | tr "/" _):$(IMAGE_TAG); \
 		fi \
 	done
+
+# Loads the built Docker images into the minikube environmen, and tags them with
+# "latest" so the k8s manifests shipped with this code work.
+prime-minikube: save-images
+	eval $$(minikube docker-env) ; \
+	for image_name in $(IMAGE_NAMES); do \
+		if ! echo $$image_name | grep build; then \
+			docker load -i images/$$(echo $$image_name | tr "/" _):$(IMAGE_TAG); \
+			docker tag $$image_name:$(IMAGE_TAG) $$image_name:latest ; \
+		fi \
+	done

--- a/README.md
+++ b/README.md
@@ -59,9 +59,20 @@ To run the test suite:
 make test
 ```
 
-To checkout Cortex in minikube:
+## Playing in `minikube`
+
+First, start `minikube`.
+
+You may need to load the Docker images into your minikube environment. There is
+a convenience rule in the Makefile to do this:
+
 ```
-kubectl create -f ./k8s
+make prime-minikube
+```
+
+Then run Cortex in minikube:
+```
+kubectl apply -f ./k8s
 ```
 
 (these manifests use `latest` tags, i.e. this will work if you have

--- a/k8s/retrieval-config.yaml
+++ b/k8s/retrieval-config.yaml
@@ -9,7 +9,7 @@ data:
       scrape_interval: 30s # By default, scrape targets every 15 seconds.
 
     remote_write:
-      url: http://nginx.default.svc.cluster.local:80/api/prom/push
+      - url: http://nginx.default.svc.cluster.local:80/api/prom/push
 
     scrape_configs:
     - job_name: 'kubernetes-pods'

--- a/k8s/retrieval-dep.yaml
+++ b/k8s/retrieval-dep.yaml
@@ -1,3 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: retrieval
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: retrieval
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: retrieval
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: retrieval
+subjects:
+- kind: ServiceAccount
+  name: retrieval
+  namespace: default
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -10,15 +44,15 @@ spec:
       labels:
         name: retrieval
     spec:
+      serviceAccountName: retrieval
       containers:
       - name: retrieval
-        image: prom/prometheus:v1.4.1
+        image: prom/prometheus:v2.8.0
         imagePullPolicy: IfNotPresent
         args:
-        - -config.file=/etc/prometheus/prometheus.yml
-        - -web.listen-address=:80
+        - --config.file=/etc/prometheus/prometheus.yml
         ports:
-        - containerPort: 80
+        - containerPort: 9090
         volumeMounts:
         - name: config-volume
           mountPath: /etc/prometheus

--- a/k8s/retrieval-svc.yaml
+++ b/k8s/retrieval-svc.yaml
@@ -5,6 +5,6 @@ metadata:
   name: retrieval
 spec:
   ports:
-    - port: 80
+    - port: 9090
   selector:
     name: retrieval


### PR DESCRIPTION
This change modernizes the version of Prometheus used in the manifests and updates the configuration to match. It also adds RBAC to run it on modern k8s, and moves Prometheus back to its standard port.

Finally, update the Makefile with a rule to make it easier to prime the minikube Docker with images built locally and reflect the changes in README.md.

Signed-off-by: Christian Funkhouser <cfunkhouser@heroku.com>