### PR TITLE
Improve nextDayBoundary calculation

### DIFF
--- a/pkg/querier/frontend/split_by_day.go
+++ b/pkg/querier/frontend/split_by_day.go
@@ -63,9 +63,13 @@ func splitQuery(r *QueryRangeRequest) []*QueryRangeRequest {
 
 // Round up to the step before the next day boundary.
 func nextDayBoundary(t, step int64) int64 {
-	offsetToDayBoundary := step - (t % millisecondPerDay % step)
-	t = ((t / millisecondPerDay) + 1) * millisecondPerDay
-	return t - offsetToDayBoundary
+	startOfNextDay := ((t / millisecondPerDay) + 1) * millisecondPerDay
+	// ensure that target is a multiple of steps away from the start time
+	target := startOfNextDay - ((startOfNextDay - t) % step)
+	if target == startOfNextDay {
+		target -= step
+	}
+	return target
 }
 
 type requestResponse struct {

--- a/pkg/querier/frontend/split_by_day_test.go
+++ b/pkg/querier/frontend/split_by_day_test.go
@@ -20,13 +20,22 @@ func TestNextDayBoundary(t *testing.T) {
 	for i, tc := range []struct {
 		in, step, out int64
 	}{
+		// Smallest possible period is 1 millisecond
 		{0, 1, millisecondPerDay - 1},
+		// A more standard example
 		{0, 15 * seconds, millisecondPerDay - 15*seconds},
+		// Move start time forward 1 second; end time moves the same
 		{1 * seconds, 15 * seconds, millisecondPerDay - (15-1)*seconds},
+		// Move start time forward 14 seconds; end time moves the same
 		{14 * seconds, 15 * seconds, millisecondPerDay - (15-14)*seconds},
+		// Now some examples where the period does not divide evenly into a day:
+		// 1 day modulus 35 seconds = 20 seconds
 		{0, 35 * seconds, millisecondPerDay - 20*seconds},
+		// Move start time forward 1 second; end time moves the same
 		{1 * seconds, 35 * seconds, millisecondPerDay - (20-1)*seconds},
+		// If the end time lands exactly on midnight we stop one period before that
 		{20 * seconds, 35 * seconds, millisecondPerDay - 35*seconds},
+		// This example starts 35 seconds after the 5th one ends
 		{millisecondPerDay + 15*seconds, 35 * seconds, 2*millisecondPerDay - 5*seconds},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/pkg/querier/frontend/split_by_day_test.go
+++ b/pkg/querier/frontend/split_by_day_test.go
@@ -23,6 +23,11 @@ func TestNextDayBoundary(t *testing.T) {
 		{0, 1, millisecondPerDay - 1},
 		{0, 15 * seconds, millisecondPerDay - 15*seconds},
 		{1 * seconds, 15 * seconds, millisecondPerDay - (15-1)*seconds},
+		{14 * seconds, 15 * seconds, millisecondPerDay - (15-14)*seconds},
+		{0, 35 * seconds, millisecondPerDay - 20*seconds},
+		{1 * seconds, 35 * seconds, millisecondPerDay - (20-1)*seconds},
+		{20 * seconds, 35 * seconds, millisecondPerDay - 35*seconds},
+		{millisecondPerDay + 15*seconds, 35 * seconds, 2*millisecondPerDay - 5*seconds},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			require.Equal(t, tc.out, nextDayBoundary(tc.in, tc.step))


### PR DESCRIPTION
Fixes #1287

Find the time which is before the beginning of the next day, and a
multiple of `step` away from the start time. 