### PR TITLE
modified concreteChunkIterator to behave like Prometheus with adding …

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	// EndMarkerInjectDelta determines how long after the last sample for a time serie within the
+	// EndMarkerDelta determines how long after the last sample for a time serie within the
 	// lookback delta to inject a NaN marker to stop repeating buffered datapoints
 	EndMarkerDelta = 1 * time.Minute
 )

--- a/pkg/querier/series_set.go
+++ b/pkg/querier/series_set.go
@@ -92,7 +92,7 @@ func (c *concreteSeriesIterator) Seek(t int64) bool {
 	c.cur = sort.Search(len(c.series.samples), func(n int) bool {
 		return c.series.samples[n].Timestamp >= model.Time(t)
 	})
-	return c.cur <= len(c.series.samples)
+	return c.cur < len(c.series.samples)
 }
 
 func (c *concreteSeriesIterator) At() (t int64, v float64) {


### PR DESCRIPTION
…an end marker to indicate stale metrics to avoid repeating buffered datapoints after the last sample

Signed-off-by: Roger Steneteg <roger@steneteg.org>