### PR TITLE
In query-frontend, log details of each request to OpenTracing

### DIFF
--- a/pkg/querier/frontend/query_range.go
+++ b/pkg/querier/frontend/query_range.go
@@ -94,10 +94,10 @@ func (q QueryRangeRequest) toHTTPRequest(ctx context.Context) (*http.Request, er
 
 func (q QueryRangeRequest) logToSpan(ctx context.Context) {
 	if span := opentracing.SpanFromContext(ctx); span != nil {
-		span.LogFields(otlog.String("query", q.Query))
-		span.LogFields(otlog.String("start", timestamp.Time(q.Start).String()))
-		span.LogFields(otlog.String("end", timestamp.Time(q.End).String()))
-		span.LogFields(otlog.Int64("step (ms)", q.Step))
+		span.LogFields(otlog.String("query", q.Query),
+			otlog.String("start", timestamp.Time(q.Start).String()),
+			otlog.String("end", timestamp.Time(q.End).String()),
+			otlog.Int64("step (ms)", q.Step))
 	}
 }
 

--- a/pkg/querier/frontend/query_range.go
+++ b/pkg/querier/frontend/query_range.go
@@ -16,6 +16,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/weaveworks/common/httpgrpc"
 
 	client "github.com/cortexproject/cortex/pkg/ingester/client"
@@ -89,6 +90,15 @@ func (q QueryRangeRequest) toHTTPRequest(ctx context.Context) (*http.Request, er
 	}
 
 	return req.WithContext(ctx), nil
+}
+
+func (q QueryRangeRequest) logToSpan(ctx context.Context) {
+	if span := opentracing.SpanFromContext(ctx); span != nil {
+		span.LogFields(otlog.String("query", q.Query))
+		span.LogFields(otlog.String("start", timestamp.Time(q.Start).String()))
+		span.LogFields(otlog.String("end", timestamp.Time(q.End).String()))
+		span.LogFields(otlog.Int64("step (ms)", q.Step))
+	}
 }
 
 // ParseTime parses the string into an int64, milliseconds since epoch.

--- a/pkg/querier/frontend/roundtrip.go
+++ b/pkg/querier/frontend/roundtrip.go
@@ -85,6 +85,7 @@ func (q queryRangeRoundTripper) RoundTrip(r *http.Request) (*http.Response, erro
 	if err != nil {
 		return nil, err
 	}
+	request.logToSpan(r.Context())
 
 	response, err := q.queryRangeMiddleware.Do(r.Context(), request)
 	if err != nil {
@@ -111,6 +112,7 @@ func (q queryRangeTerminator) Do(ctx context.Context, r *QueryRangeRequest) (*AP
 		return nil, err
 	}
 
+	r.logToSpan(ctx)
 	response, err := q.next.RoundTrip(request)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is to help with debugging: the top-level request that comes in and what is sent to queriers are logged to the current span, so you can see the effects of splitting, caching, etc.

