### PR TITLE
Default per-user limits to those specified on the command line.

### DIFF
--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -3,8 +3,6 @@ package validation
 import (
 	"flag"
 	"time"
-
-	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
 
 // Limits describe all the limits for users; can be used to describe global default
@@ -65,7 +63,7 @@ func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// We want to set c to the defaults and then overwrite it with the input.
 	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
 	// again, we have to hide it using a type indirection.  See prometheus/config.
-	flagext.DefaultValues(l)
+	*l = defaultLimits
 	type plain Limits
 	return unmarshal((*plain)(l))
 }

--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -18,6 +18,12 @@ var overridesReloadSuccess = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Whether the last overrides reload attempt was successful.",
 })
 
+// When we load YAML from disk, we want the various per-customer limits
+// to default to any values specified on the command line, not default
+// command line values.  This global contains those values.  I (Tom) cannot
+// find a nicer way I'm afraid.
+var defaultLimits Limits
+
 // Overrides periodically fetch a set of per-user overrides, and provides convenience
 // functions for fetching the correct value.
 type Overrides struct {
@@ -29,6 +35,8 @@ type Overrides struct {
 
 // NewOverrides makes a new Overrides.
 func NewOverrides(defaults Limits) (*Overrides, error) {
+	defaultLimits = defaults
+
 	if defaults.PerTenantOverrideConfig == "" {
 		level.Info(util.Logger).Log("msg", "per-tenant overides disabled")
 		return &Overrides{

--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -34,6 +34,9 @@ type Overrides struct {
 }
 
 // NewOverrides makes a new Overrides.
+// We store the supplied limits in a global variable to ensure per-tenant limits
+// are defaulted to those values.  As such, the last call to NewOverrides will
+// become the new global defaults.
 func NewOverrides(defaults Limits) (*Overrides, error) {
 	defaultLimits = defaults
 


### PR DESCRIPTION
Not to command line defaults.  Eg if I specify `-validation.reject-old-samples=true` on the CLI, I want this to apply to all users unless explicitly disabled.   

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>