### PR TITLE
Improve index cardinality limiting.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ $(foreach exe, $(EXES), $(eval $(call dep_exe, $(exe))))
 pkg/ingester/client/cortex.pb.go: pkg/ingester/client/cortex.proto
 pkg/ring/ring.pb.go: pkg/ring/ring.proto
 pkg/querier/frontend/frontend.pb.go: pkg/querier/frontend/frontend.proto
+pkg/chunk/storage/caching_index_client.pb.go: pkg/chunk/storage/caching_index_client.proto
 all: $(UPTODATE_FILES)
 test: $(PROTO_GOS)
 protos: $(PROTO_GOS)

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -60,7 +60,6 @@ type StoreConfig struct {
 	MinChunkAge              time.Duration
 	CardinalityCacheSize     int
 	CardinalityCacheValidity time.Duration
-	CardinalityLimit         int
 
 	CacheLookupsOlderThan time.Duration
 }
@@ -74,7 +73,6 @@ func (cfg *StoreConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.MinChunkAge, "store.min-chunk-age", 0, "Minimum time between chunk update and being saved to the store.")
 	f.IntVar(&cfg.CardinalityCacheSize, "store.cardinality-cache-size", 0, "Size of in-memory cardinality cache, 0 to disable.")
 	f.DurationVar(&cfg.CardinalityCacheValidity, "store.cardinality-cache-validity", 1*time.Hour, "Period for which entries in the cardinality cache are valid.")
-	f.IntVar(&cfg.CardinalityLimit, "store.cardinality-limit", 1e5, "Cardinality limit for index queries.")
 	f.DurationVar(&cfg.CacheLookupsOlderThan, "store.cache-lookups-older-than", 0, "Cache index entries older than this period. 0 to disable.")
 }
 

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/extract"
+	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/weaveworks/common/httpgrpc"
@@ -70,8 +71,8 @@ func (cfg *StoreConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.CacheLookupsOlderThan, "store.cache-lookups-older-than", 0, "Cache index entries older than this period. 0 to disable.")
 
 	// Deprecated.
-	f.Int("store.cardinality-cache-size", 0, "DEPRECATED. store.cardinality-cache.enable-fifocache and store.cardinality-cache.fifocache.size.")
-	f.Duration("store.cardinality-cache-validity", 1*time.Hour, "DEPRECATED. store.cardinality-cache.enable-fifocache and store.cardinality-cache.fifocache.duration.")
+	flagext.DeprecatedFlag(f, "store.cardinality-cache-size", "DEPRECATED. Use store.index-cache-size.enable-fifocache and store.cardinality-cache.fifocache.size instead.")
+	flagext.DeprecatedFlag(f, "store.cardinality-cache-validity", "DEPRECATED. Use store.index-cache-size.enable-fifocache and store.cardinality-cache.fifocache.duration instead.")
 }
 
 // store implements Store

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -57,23 +57,21 @@ type StoreConfig struct {
 	ChunkCacheConfig       cache.Config
 	WriteDedupeCacheConfig cache.Config
 
-	MinChunkAge              time.Duration
-	CardinalityCacheSize     int
-	CardinalityCacheValidity time.Duration
-
+	MinChunkAge           time.Duration
 	CacheLookupsOlderThan time.Duration
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *StoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.ChunkCacheConfig.RegisterFlagsWithPrefix("", "Cache config for chunks. ", f)
-
 	cfg.WriteDedupeCacheConfig.RegisterFlagsWithPrefix("store.index-cache-write.", "Cache config for index entry writing. ", f)
 
 	f.DurationVar(&cfg.MinChunkAge, "store.min-chunk-age", 0, "Minimum time between chunk update and being saved to the store.")
-	f.IntVar(&cfg.CardinalityCacheSize, "store.cardinality-cache-size", 0, "Size of in-memory cardinality cache, 0 to disable.")
-	f.DurationVar(&cfg.CardinalityCacheValidity, "store.cardinality-cache-validity", 1*time.Hour, "Period for which entries in the cardinality cache are valid.")
 	f.DurationVar(&cfg.CacheLookupsOlderThan, "store.cache-lookups-older-than", 0, "Cache index entries older than this period. 0 to disable.")
+
+	// Deprecated.
+	f.Int("store.cardinality-cache-size", 0, "DEPRECATED. store.cardinality-cache.enable-fifocache and store.cardinality-cache.fifocache.size.")
+	f.Duration("store.cardinality-cache-validity", 1*time.Hour, "DEPRECATED. store.cardinality-cache.enable-fifocache and store.cardinality-cache.fifocache.duration.")
 }
 
 // store implements Store

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -263,7 +263,7 @@ func (c *seriesStore) lookupSeriesByMetricNameMatcher(ctx context.Context, from,
 			continue
 		}
 		cardinality := value.(int)
-		if cardinality > c.cfg.CardinalityLimit {
+		if cardinality > c.limits.CardinalityLimit(userID) {
 			return nil, errCardinalityExceeded
 		}
 	}
@@ -283,7 +283,7 @@ func (c *seriesStore) lookupSeriesByMetricNameMatcher(ctx context.Context, from,
 	}
 	c.cardinalityCache.Put(ctx, keys, values)
 
-	if len(entries) > c.cfg.CardinalityLimit {
+	if len(entries) > c.limits.CardinalityLimit(userID) {
 		return nil, errCardinalityExceeded
 	}
 

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -23,7 +23,9 @@ import (
 )
 
 var (
-	errCardinalityExceeded = errors.New("cardinality limit exceeded")
+	// ErrCardinalityExceeded is returned when the user reads a row that
+	// is too large.
+	ErrCardinalityExceeded = errors.New("cardinality limit exceeded")
 
 	indexLookupsPerQuery = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "cortex",
@@ -57,8 +59,6 @@ var (
 // seriesStore implements Store
 type seriesStore struct {
 	store
-	cardinalityCache *cache.FifoCache
-
 	writeDedupeCache cache.Cache
 }
 
@@ -89,10 +89,6 @@ func newSeriesStore(cfg StoreConfig, schema Schema, index IndexClient, chunks Ob
 			limits:  limits,
 			Fetcher: fetcher,
 		},
-		cardinalityCache: cache.NewFifoCache("cardinality", cache.FifoCacheConfig{
-			Size:     cfg.CardinalityCacheSize,
-			Validity: cfg.CardinalityCacheValidity,
-		}),
 		writeDedupeCache: writeDedupeCache,
 	}, nil
 }
@@ -214,7 +210,7 @@ func (c *seriesStore) lookupSeriesByMetricNameMatchers(ctx context.Context, from
 			// series and the other returns only 10 (a few), we don't lookup the first one at all.
 			// We just manually filter through the 10 series again using "filterChunksByMatchers",
 			// saving us from looking up and intersecting a lot of series.
-			if err == errCardinalityExceeded {
+			if err == ErrCardinalityExceeded {
 				cardinalityExceededErrors++
 			} else {
 				lastErr = err
@@ -224,7 +220,7 @@ func (c *seriesStore) lookupSeriesByMetricNameMatchers(ctx context.Context, from
 
 	// But if every single matcher returns a lot of series, then it makes sense to abort the query.
 	if cardinalityExceededErrors == len(matchers) {
-		return nil, errCardinalityExceeded
+		return nil, ErrCardinalityExceeded
 	} else if lastErr != nil {
 		return nil, lastErr
 	}
@@ -257,35 +253,11 @@ func (c *seriesStore) lookupSeriesByMetricNameMatcher(ctx context.Context, from,
 	}
 	level.Debug(log).Log("queries", len(queries))
 
-	for _, query := range queries {
-		value, ok := c.cardinalityCache.Get(ctx, query.HashValue)
-		if !ok {
-			continue
-		}
-		cardinality := value.(int)
-		if cardinality > c.limits.CardinalityLimit(userID) {
-			return nil, errCardinalityExceeded
-		}
-	}
-
 	entries, err := c.lookupEntriesByQueries(ctx, queries)
 	if err != nil {
 		return nil, err
 	}
 	level.Debug(log).Log("entries", len(entries))
-
-	// TODO This is not correct, will overcount for queries > 24hrs
-	keys := make([]string, 0, len(queries))
-	values := make([]interface{}, 0, len(queries))
-	for _, query := range queries {
-		keys = append(keys, query.HashValue)
-		values = append(values, len(entries))
-	}
-	c.cardinalityCache.Put(ctx, keys, values)
-
-	if len(entries) > c.limits.CardinalityLimit(userID) {
-		return nil, errCardinalityExceeded
-	}
 
 	ids, err := c.parseIndexEntries(ctx, entries, matcher)
 	if err != nil {

--- a/pkg/chunk/storage/caching_fixtures.go
+++ b/pkg/chunk/storage/caching_fixtures.go
@@ -3,6 +3,9 @@ package storage
 import (
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/validation"
+
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/chunk/gcp"
 
@@ -16,11 +19,15 @@ type fixture struct {
 
 func (f fixture) Name() string { return "caching-store" }
 func (f fixture) Clients() (chunk.IndexClient, chunk.ObjectClient, chunk.TableClient, chunk.SchemaConfig, error) {
+	limits, err := defaultLimits()
+	if err != nil {
+		return nil, nil, nil, chunk.SchemaConfig{}, err
+	}
 	indexClient, objectClient, tableClient, schemaConfig, err := f.fixture.Clients()
 	indexClient = newCachingIndexClient(indexClient, cache.NewFifoCache("index-fifo", cache.FifoCacheConfig{
 		Size:     500,
 		Validity: 5 * time.Minute,
-	}), 5*time.Minute)
+	}), 5*time.Minute, limits)
 	return indexClient, objectClient, tableClient, schemaConfig, err
 }
 func (f fixture) Teardown() error { return f.fixture.Teardown() }
@@ -28,4 +35,10 @@ func (f fixture) Teardown() error { return f.fixture.Teardown() }
 // Fixtures for unit testing the caching storage.
 var Fixtures = []testutils.Fixture{
 	fixture{gcp.Fixtures[0]},
+}
+
+func defaultLimits() (*validation.Overrides, error) {
+	var defaults validation.Limits
+	flagext.DefaultValues(&defaults)
+	return validation.NewOverrides(defaults)
 }

--- a/pkg/chunk/storage/caching_index_client.go
+++ b/pkg/chunk/storage/caching_index_client.go
@@ -150,18 +150,18 @@ func (s *cachingIndexClient) QueryPages(ctx context.Context, queries []chunk.Ind
 		defer resultsMtx.Unlock()
 		keys := make([]string, 0, len(results))
 		batches := make([]ReadBatch, 0, len(results))
-		var cadinalityErr error
+		var cardinalityErr error
 		for key, batch := range results {
 			cardinality := int32(len(batch.Entries))
 			if cardinalityLimit > 0 && cardinality > cardinalityLimit {
 				batch.Cardinality = cardinality
 				batch.Entries = nil
-				cadinalityErr = chunk.ErrCardinalityExceeded
+				cardinalityErr = chunk.ErrCardinalityExceeded
 			}
 
 			keys = append(keys, key)
 			batches = append(batches, batch)
-			if cadinalityErr != nil {
+			if cardinalityErr != nil {
 				continue
 			}
 
@@ -171,7 +171,7 @@ func (s *cachingIndexClient) QueryPages(ctx context.Context, queries []chunk.Ind
 			}
 		}
 		s.cacheStore(ctx, keys, batches)
-		return cadinalityErr
+		return cardinalityErr
 	}
 }
 

--- a/pkg/chunk/storage/caching_index_client.proto
+++ b/pkg/chunk/storage/caching_index_client.proto
@@ -18,4 +18,8 @@ message ReadBatch {
 
     // The time at which the key expires.
     int64 expiry = 3;
+
+    // The number of entries; used for cardinality limiting.
+    // entries will be empty when this is set.
+    int32 cardinality = 4;
 }

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -98,7 +98,7 @@ func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConf
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating index client")
 		}
-		index = newCachingIndexClient(index, tieredCache, cfg.IndexCacheValidity)
+		index = newCachingIndexClient(index, tieredCache, cfg.IndexCacheValidity, limits)
 
 		objectStoreType := s.ObjectType
 		if objectStoreType == "" {

--- a/pkg/chunk/storage/index_client_test.go
+++ b/pkg/chunk/storage/index_client_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -16,7 +15,7 @@ func TestIndexBasic(t *testing.T) {
 		for i := 0; i < 30; i++ {
 			batch.Add(tableName, fmt.Sprintf("hash%d", i), []byte(fmt.Sprintf("range%d", i)), nil)
 		}
-		err := client.BatchWrite(context.Background(), batch)
+		err := client.BatchWrite(ctx, batch)
 		require.NoError(t, err)
 
 		// Make sure we get back the correct entries by hash value.
@@ -28,7 +27,7 @@ func TestIndexBasic(t *testing.T) {
 				},
 			}
 			var have []chunk.IndexEntry
-			err := client.QueryPages(context.Background(), entries, func(_ chunk.IndexQuery, read chunk.ReadBatch) bool {
+			err := client.QueryPages(ctx, entries, func(_ chunk.IndexQuery, read chunk.ReadBatch) bool {
 				iter := read.Iterator()
 				for iter.Next() {
 					have = append(have, chunk.IndexEntry{
@@ -103,7 +102,7 @@ func TestQueryPages(t *testing.T) {
 			batch.Add(entry.TableName, entry.HashValue, entry.RangeValue, entry.Value)
 		}
 
-		err := client.BatchWrite(context.Background(), batch)
+		err := client.BatchWrite(ctx, batch)
 		require.NoError(t, err)
 
 		tests := []struct {
@@ -170,7 +169,7 @@ func TestQueryPages(t *testing.T) {
 				run := true
 				for run {
 					var have []chunk.IndexEntry
-					err = client.QueryPages(context.Background(), []chunk.IndexQuery{tt.query}, func(_ chunk.IndexQuery, read chunk.ReadBatch) bool {
+					err = client.QueryPages(ctx, []chunk.IndexQuery{tt.query}, func(_ chunk.IndexQuery, read chunk.ReadBatch) bool {
 						iter := read.Iterator()
 						for iter.Next() {
 							have = append(have, chunk.IndexEntry{

--- a/pkg/util/flagext/deprecated.go
+++ b/pkg/util/flagext/deprecated.go
@@ -1,0 +1,26 @@
+package flagext
+
+import (
+	"flag"
+
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/go-kit/kit/log/level"
+)
+
+type deprecatedFlag struct {
+	name string
+}
+
+func (deprecatedFlag) String() string {
+	return "deprecated"
+}
+
+func (d deprecatedFlag) Set(string) error {
+	level.Warn(util.Logger).Log("msg", "flag disabled", "flag", d.name)
+	return nil
+}
+
+// DeprecatedFlag logs a warning when you try to use it.
+func DeprecatedFlag(f *flag.FlagSet, name, message string) {
+	f.Var(deprecatedFlag{name}, name, message)
+}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -29,6 +29,7 @@ type Limits struct {
 	MaxChunksPerQuery   int           `yaml:"max_chunks_per_query"`
 	MaxQueryLength      time.Duration `yaml:"max_query_length"`
 	MaxQueryParallelism int           `yaml:"max_query_parallelism"`
+	CardinalityLimit    int           `yaml:"cardinality_limit"`
 
 	// Config for overrides, convenient if it goes here.
 	PerTenantOverrideConfig string
@@ -55,6 +56,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxChunksPerQuery, "store.query-chunk-limit", 2e6, "Maximum number of chunks that can be fetched in a single query.")
 	f.DurationVar(&l.MaxQueryLength, "store.max-query-length", 0, "Limit to length of chunk store queries, 0 to disable.")
 	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of queries will be scheduled in parallel by the frontend.")
+	f.IntVar(&l.CardinalityLimit, "store.cardinality-limit", 1e5, "Cardinality limit for index queries.")
 
 	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "File name of per-user overrides.")
 	f.DurationVar(&l.PerTenantOverridePeriod, "limits.per-user-override-period", 10*time.Second, "Period with this to reload the overrides.")

--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -267,3 +267,10 @@ func (o *Overrides) EnforceMetricName(userID string) bool {
 		return l.EnforceMetricName
 	})
 }
+
+// CardinalityLimit whether to enforce the presence of a metric name.
+func (o *Overrides) CardinalityLimit(userID string) int {
+	return o.getInt(userID, func(l *Limits) int {
+		return l.CardinalityLimit
+	})
+}


### PR DESCRIPTION
We currently have a way of limiting load on the backends by caching the size of rows and preventing re-reading of very large rows. This is called the cardinality cache, and is currently in-process. As you add more queriers, it becomes less useful.

This PR adds support for "external" cardinality caching using the index read cache.  We also make query cardinality limit configurable per user. 

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>