### PR TITLE
Nuke some old deprecated flags

### DIFF
--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -46,9 +46,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.Instance, "bigtable.instance", "", "Bigtable instance ID.")
 
 	cfg.GRPCClientConfig.RegisterFlags("bigtable", f)
-
-	// Deprecated.
-	f.Int("bigtable.max-recv-msg-size", 100<<20, "DEPRECATED. Bigtable grpc max receive message size.")
 }
 
 // storageClientColumnKey implements chunk.storageClient for GCP.

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -28,9 +28,7 @@ type Config struct {
 	BoltDBConfig           local.BoltDBConfig `yaml:"boltdb"`
 	FSConfig               local.FSConfig     `yaml:"filesystem"`
 
-	IndexCacheSize     int
 	IndexCacheValidity time.Duration
-	memcacheClient     cache.MemcachedClientConfig
 
 	indexQueriesCacheConfig cache.Config
 }
@@ -44,10 +42,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.BoltDBConfig.RegisterFlags(f)
 	cfg.FSConfig.RegisterFlags(f)
 
-	// Deprecated flags!!
-	f.IntVar(&cfg.IndexCacheSize, "store.index-cache-size", 0, "Deprecated: Use -store.index-cache-read.*; Size of in-memory index cache, 0 to disable.")
-	cfg.memcacheClient.RegisterFlagsWithPrefix("index.", "Deprecated: Use -store.index-cache-read.*;", f)
-
 	cfg.indexQueriesCacheConfig.RegisterFlagsWithPrefix("store.index-cache-read.", "Cache config for index entry reading. ", f)
 	f.DurationVar(&cfg.IndexCacheValidity, "store.index-cache-validity", 5*time.Minute, "Cache validity for active index entries. Should be no higher than -ingester.max-chunk-idle.")
 }
@@ -56,31 +50,9 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConfig, limits *validation.Overrides) (chunk.Store, error) {
 	var err error
 
-	// Building up from deprecated flags.
-	var caches []cache.Cache
-	if cfg.IndexCacheSize > 0 {
-		fifocache := cache.Instrument("fifo-index", cache.NewFifoCache("index", cache.FifoCacheConfig{Size: cfg.IndexCacheSize}))
-		caches = append(caches, fifocache)
-	}
-	if cfg.memcacheClient.Host != "" {
-		client := cache.NewMemcachedClient(cfg.memcacheClient)
-		memcache := cache.Instrument("memcache-index", cache.NewMemcached(cache.MemcachedConfig{
-			Expiration: cfg.IndexCacheValidity,
-		}, client, "memcache-index"))
-		caches = append(caches, cache.NewBackground("memcache-index", cache.BackgroundConfig{
-			WriteBackGoroutines: 10,
-			WriteBackBuffer:     100,
-		}, memcache))
-	}
-
-	var tieredCache cache.Cache
-	if len(caches) > 0 {
-		tieredCache = cache.NewTiered(caches)
-	} else {
-		tieredCache, err = cache.New(cfg.indexQueriesCacheConfig)
-		if err != nil {
-			return nil, err
-		}
+	tieredCache, err := cache.New(cfg.indexQueriesCacheConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	// Cache is shared by multiple stores, which means they will try and Stop

--- a/pkg/chunk/storage/factory_test.go
+++ b/pkg/chunk/storage/factory_test.go
@@ -29,7 +29,6 @@ func TestFactoryStop(t *testing.T) {
 			IndexType: "inmemory",
 		},
 	}
-	cfg.memcacheClient.Host = "localhost" // Fake address that should at least resolve.
 
 	limits, err := validation.NewOverrides(defaults)
 	require.NoError(t, err)

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -75,9 +75,4 @@ type Config struct {
 // RegisterFlags registers configuration settings used by the ingester client config.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.GRPCClientConfig.RegisterFlags("ingester.client", f)
-
-	// Deprecated.
-	f.Int("ingester.client.max-recv-message-size", 64*1024*1024, "DEPRECATED. Maximum message size, in bytes, this client will receive.")
-	f.Bool("ingester.client.compress-to-ingester", false, "DEPRECATED. Compress data in calls to ingesters.")
-	f.Bool("distributor.compress-to-ingester", false, "DEPRECATED. Compress data in calls to ingesters. (DEPRECATED: use ingester.client.compress-to-ingester instead")
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -111,14 +111,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.ChunkAgeJitter, "ingester.chunk-age-jitter", 20*time.Minute, "Range of time to subtract from MaxChunkAge to spread out flushes")
 	f.IntVar(&cfg.ConcurrentFlushes, "ingester.concurrent-flushes", 50, "Number of concurrent goroutines flushing to dynamodb.")
 	f.DurationVar(&cfg.RateUpdatePeriod, "ingester.rate-update-period", 15*time.Second, "Period with which to update the per-user ingestion rates.")
-
-	// DEPRECATED, no-op
-	f.Duration("ingester.search-pending-for", 30*time.Second, "DEPRECATED. Time to spend searching for a pending ingester when shutting down.")
-	f.Bool("ingester.reject-old-samples", false, "DEPRECATED. Reject old samples.")
-	f.Duration("ingester.reject-old-samples.max-age", 0, "DEPRECATED. Maximum accepted sample age before rejecting.")
-	f.Int("ingester.validation.max-length-label-name", 0, "DEPRECATED. Maximum length accepted for label names.")
-	f.Int("ingester.validation.max-length-label-value", 0, "DEPRECATED. Maximum length accepted for label value. This setting also applies to the metric name.")
-	f.Int("ingester.max-label-names-per-series", 0, "DEPRECATED. Maximum number of label names per series.")
 }
 
 // Ingester deals with "in flight" chunks.  Based on Prometheus 1.x


### PR DESCRIPTION
We have some deprecated flags in our code base for long and I think it's time we cleaned up some of them :)

Deleted the useless flags (they do nothing even if set):
```
bigtable.max-recv-msg-size
ingester.client.max-recv-message-size
ingester.client.compress-to-ingester
distributor.compress-to-ingester
ingester.search-pending-for
ingester.reject-old-samples
ingester.reject-old-samples.max-age
ingester.validation.max-length-label-name
ingester.validation.max-length-label-value
ingester.max-label-names-per-series
```

Other flags (use `-store.index-cache-read.*`):
```
store.index-cache-size
index.memcached.*
```


```

