### PR TITLE
Remove a very spammy debug line

### DIFF
--- a/pkg/chunk/storage/caching_index_client.go
+++ b/pkg/chunk/storage/caching_index_client.go
@@ -276,7 +276,6 @@ func (s *cachingIndexClient) cacheFetch(ctx context.Context, keys []string) (bat
 		}
 
 		if readBatch.Expiry != 0 && time.Now().After(time.Unix(0, readBatch.Expiry)) {
-			level.Debug(log).Log("msg", "dropping index cache entry due to expiration", "key", key, "readBatch.Key", readBatch.Key, "expiry", time.Unix(0, readBatch.Expiry))
 			continue
 		}
 


### PR DESCRIPTION
With us caching entries for 15mins only and doing client side
validation after introducing permanent caching of older entries, this
debug is expected to print for millions of keys. It's not a very useful
line.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>