### PR TITLE
Fix duration is zero

### DIFF
--- a/pkg/util/backoff.go
+++ b/pkg/util/backoff.go
@@ -74,7 +74,11 @@ func (b *Backoff) Wait() {
 	// Based on the "Full Jitter" approach from https://www.awsarchitectureblog.com/2015/03/backoff.html
 	// sleep = random_between(0, min(cap, base * 2 ** attempt))
 	if b.Ongoing() {
-		sleepTime := time.Duration(rand.Int63n(int64(b.duration)))
+		randTime := int64(0)
+		if b.duration != 0 {
+			randTime = rand.Int63n(int64(b.duration))
+		}
+		sleepTime := time.Duration(randTime)
 		select {
 		case <-b.ctx.Done():
 		case <-time.After(sleepTime):


### PR DESCRIPTION
When MaxBackoff not set, after one loop, duration is always bigger than
it, so duration set as zero, then following panic occur:
```
panic: invalid argument to Int63n

goroutine 169 [running]:
math/rand.(*Rand).Int63n(0xc0000cc150, 0x0, 0xc000719b58)
	/usr/lib/golang/src/math/rand/rand.go:111 +0x11e
math/rand.Int63n(...)
	/usr/lib/golang/src/math/rand/rand.go:319
```
Signed-off-by: Xiang Dai <764524258@qq.com>