### PR TITLE
Put Distributor hash algorithm back the way it was before 922a3b989a

### DIFF
--- a/pkg/ingester/client/fnv.go
+++ b/pkg/ingester/client/fnv.go
@@ -29,6 +29,7 @@ func hashNew() uint64 {
 }
 
 // hashAdd adds a string to a fnv64a hash value, returning the updated hash.
+// Note this is the same algorithm as Go stdlib `sum64a.Write()`
 func hashAdd(h uint64, s string) uint64 {
 	for i := 0; i < len(s); i++ {
 		h ^= uint64(s[i])
@@ -50,10 +51,11 @@ func HashNew32() uint32 {
 }
 
 // HashAdd32 adds a string to a fnv64a hash value, returning the updated hash.
+// Note this is the same algorithm as Go stdlib `sum32.Write()`
 func HashAdd32(h uint32, s string) uint32 {
 	for i := 0; i < len(s); i++ {
-		h ^= uint32(s[i])
 		h *= prime32
+		h ^= uint32(s[i])
 	}
 	return h
 }

--- a/pkg/ingester/client/fnv.go
+++ b/pkg/ingester/client/fnv.go
@@ -45,12 +45,12 @@ func hashAddByte(h uint64, b byte) uint64 {
 	return h
 }
 
-// HashNew32 initializies a new fnv64a hash value.
+// HashNew32 initializies a new fnv32 hash value.
 func HashNew32() uint32 {
 	return offset32
 }
 
-// HashAdd32 adds a string to a fnv64a hash value, returning the updated hash.
+// HashAdd32 adds a string to a fnv32 hash value, returning the updated hash.
 // Note this is the same algorithm as Go stdlib `sum32.Write()`
 func HashAdd32(h uint32, s string) uint32 {
 	for i := 0; i < len(s); i++ {


### PR DESCRIPTION
#1306 moved the hash implementation, but at the same time flipped it from FNV-1 to FNV-1a.
Put it back the way it was before, and add some comments noting the difference.

Note: without this, the effect is to re-shard all series to a different ingester, causing a spike in active series and (in shard-by-metric-name mode) breaking queries.