### PR TITLE
Add LabelNamesForMetricName for the series store

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -250,12 +250,12 @@ func (c *store) LabelNamesForMetricName(ctx context.Context, from, through model
 	if err != nil {
 		return nil, err
 	}
-	level.Debug(log).Log("Chunks in index", len(chunks))
+	level.Debug(log).Log("msg", "Chunks in index", "chunks", len(chunks))
 
 	// Filter out chunks that are not in the selected time range and keep a single chunk per fingerprint
 	filtered := filterChunksByTime(from, through, chunks)
-	filtered, keys := filterChunksByUniqueFingerPrint(filtered)
-	level.Debug(log).Log("Chunks post filtering", len(chunks))
+	filtered, keys := filterChunksByUniqueFingerprint(filtered)
+	level.Debug(log).Log("msg", "Chunks post filtering", "chunks", len(chunks))
 
 	// Now fetch the actual chunk data from Memcache / S3
 	allChunks, err := c.FetchChunks(ctx, filtered, keys)

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -263,17 +263,7 @@ func (c *store) LabelNamesForMetricName(ctx context.Context, from, through model
 		level.Error(log).Log("msg", "FetchChunks", "err", err)
 		return nil, err
 	}
-	var result []string
-	for _, c := range allChunks {
-		for _, l := range c.Metric {
-			if l.Name != model.MetricNameLabel {
-				result = append(result, string(l.Name))
-			}
-		}
-	}
-	sort.Strings(result)
-	result = uniqueStrings(result)
-	return result, nil
+	return labelNamesFromChunks(allChunks), nil
 }
 
 func (c *store) validateQueryTimeRange(ctx context.Context, from *model.Time, through *model.Time) (bool, error) {

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -228,7 +228,49 @@ func (c *store) LabelValuesForMetricName(ctx context.Context, from, through mode
 		}
 		result = append(result, string(labelValue))
 	}
+	sort.Strings(result)
+	result = uniqueStrings(result)
+	return result, nil
+}
 
+// LabelNamesForMetricName retrieves all label names for a metric name.
+func (c *store) LabelNamesForMetricName(ctx context.Context, from, through model.Time, metricName string) ([]string, error) {
+	log, ctx := spanlogger.New(ctx, "ChunkStore.LabelNamesForMetricName")
+	defer log.Span.Finish()
+	level.Debug(log).Log("from", from, "through", through, "metricName", metricName)
+
+	shortcut, err := c.validateQueryTimeRange(ctx, &from, &through)
+	if err != nil {
+		return nil, err
+	} else if shortcut {
+		return nil, nil
+	}
+
+	chunks, err := c.lookupChunksByMetricName(ctx, from, through, nil, metricName)
+	if err != nil {
+		return nil, err
+	}
+	level.Debug(log).Log("Chunks in index", len(chunks))
+
+	// Filter out chunks that are not in the selected time range and keep a single chunk per fingerprint
+	filtered := filterChunksByTime(from, through, chunks)
+	filtered, keys := filterChunksByUniqueFingerPrint(filtered)
+	level.Debug(log).Log("Chunks post filtering", len(chunks))
+
+	// Now fetch the actual chunk data from Memcache / S3
+	allChunks, err := c.FetchChunks(ctx, filtered, keys)
+	if err != nil {
+		level.Error(log).Log("msg", "FetchChunks", "err", err)
+		return nil, err
+	}
+	var result []string
+	for _, c := range allChunks {
+		for _, l := range c.Metric {
+			if l.Name != model.MetricNameLabel {
+				result = append(result, string(l.Name))
+			}
+		}
+	}
 	sort.Strings(result)
 	result = uniqueStrings(result)
 	return result, nil

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -36,7 +36,7 @@ func keysFromChunks(chunks []Chunk) []string {
 	return keys
 }
 
-func filterChunksByUniqueFingerPrint(chunks []Chunk) ([]Chunk, []string) {
+func filterChunksByUniqueFingerprint(chunks []Chunk) ([]Chunk, []string) {
 	filtered := make([]Chunk, 0, len(chunks))
 	keys := make([]string, 0, len(chunks))
 	uniqueFp := map[model.Fingerprint]struct{}{}

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -38,7 +38,7 @@ func keysFromChunks(chunks []Chunk) []string {
 }
 
 func labelNamesFromChunks(chunks []Chunk) []string {
-	keys := make(map[string]struct{})
+	keys := map[string]struct{}{}
 	var result []string
 	for _, c := range chunks {
 		for _, l := range c.Metric {

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -36,6 +36,22 @@ func keysFromChunks(chunks []Chunk) []string {
 	return keys
 }
 
+func filterChunksByUniqueFingerPrint(chunks []Chunk) ([]Chunk, []string) {
+	filtered := make([]Chunk, 0, len(chunks))
+	keys := make([]string, 0, len(chunks))
+	uniqueFp := map[model.Fingerprint]struct{}{}
+
+	for _, chunk := range chunks {
+		if _, ok := uniqueFp[chunk.Fingerprint]; ok {
+			continue
+		}
+		filtered = append(filtered, chunk)
+		keys = append(keys, chunk.ExternalKey())
+		uniqueFp[chunk.Fingerprint] = struct{}{}
+	}
+	return filtered, keys
+}
+
 func filterChunksByMatchers(chunks []Chunk, filters []*labels.Matcher) []Chunk {
 	filteredChunks := make([]Chunk, 0, len(chunks))
 outer:

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"context"
+	"sort"
 	"sync"
 
 	"github.com/go-kit/kit/log/level"
@@ -34,6 +35,23 @@ func keysFromChunks(chunks []Chunk) []string {
 	}
 
 	return keys
+}
+
+func labelNamesFromChunks(chunks []Chunk) []string {
+	keys := make(map[string]struct{})
+	var result []string
+	for _, c := range chunks {
+		for _, l := range c.Metric {
+			if l.Name != model.MetricNameLabel {
+				if _, ok := keys[string(l.Name)]; !ok {
+					keys[string(l.Name)] = struct{}{}
+					result = append(result, string(l.Name))
+				}
+			}
+		}
+	}
+	sort.Strings(result)
+	return result
 }
 
 func filterChunksByUniqueFingerprint(chunks []Chunk) ([]Chunk, []string) {

--- a/pkg/chunk/composite_store_test.go
+++ b/pkg/chunk/composite_store_test.go
@@ -32,6 +32,10 @@ func (m mockStore) GetChunkRefs(tx context.Context, from, through model.Time, ma
 	return nil, nil, nil
 }
 
+func (m mockStore) LabelNamesForMetricName(ctx context.Context, from, through model.Time, metricName string) ([]string, error) {
+	return nil, nil
+}
+
 func (m mockStore) Stop() {}
 
 func TestCompositeStore(t *testing.T) {

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -189,6 +190,72 @@ func (c *seriesStore) GetChunkRefs(ctx context.Context, from, through model.Time
 	chunksPerQuery.Observe(float64(len(chunks)))
 
 	return [][]Chunk{chunks}, []*Fetcher{c.store.Fetcher}, nil
+}
+
+// LabelNamesForMetricName retrieves all label names for a metric name.
+func (c *seriesStore) LabelNamesForMetricName(ctx context.Context, from, through model.Time, metricName string) ([]string, error) {
+	log, ctx := spanlogger.New(ctx, "SeriesStore.LabelNamesForMetricName")
+	defer log.Span.Finish()
+
+	userID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	shortcut, err := c.validateQueryTimeRange(ctx, &from, &through)
+	if err != nil {
+		return nil, err
+	} else if shortcut {
+		return nil, nil
+	}
+	level.Debug(log).Log("metric", metricName)
+
+	// Fetch the series IDs from the index
+	seriesIDs, err := c.lookupSeriesByMetricNameMatchers(ctx, from, through, userID, metricName, nil)
+	if err != nil {
+		return nil, err
+	}
+	level.Debug(log).Log("series-ids", len(seriesIDs))
+
+	// Lookup the series in the index to get the chunks.
+	chunkIDs, err := c.lookupChunksBySeries(ctx, from, through, userID, seriesIDs)
+	if err != nil {
+		level.Error(log).Log("msg", "lookupChunksBySeries", "err", err)
+		return nil, err
+	}
+	level.Debug(log).Log("chunk-ids", len(chunkIDs))
+
+	chunks, err := c.convertChunkIDsToChunks(ctx, userID, chunkIDs)
+	if err != nil {
+		level.Error(log).Log("err", "convertChunkIDsToChunks", "err", err)
+		return nil, err
+	}
+
+	// Filter out chunks that are not in the selected time range and keep a single chunk per fingerprint
+	filtered := filterChunksByTime(from, through, chunks)
+	filtered, keys := filterChunksByUniqueFingerPrint(filtered)
+	level.Debug(log).Log("Chunks post filtering", len(chunks))
+
+	chunksPerQuery.Observe(float64(len(filtered)))
+
+	// Now fetch the actual chunk data from Memcache / S3
+	allChunks, err := c.FetchChunks(ctx, filtered, keys)
+	if err != nil {
+		level.Error(log).Log("msg", "FetchChunks", "err", err)
+		return nil, err
+	}
+
+	var result []string
+	for _, c := range allChunks {
+		for _, l := range c.Metric {
+			if l.Name != model.MetricNameLabel {
+				result = append(result, string(l.Name))
+			}
+		}
+	}
+	sort.Strings(result)
+	result = uniqueStrings(result)
+	return result, nil
 }
 
 func (c *seriesStore) lookupSeriesByMetricNameMatchers(ctx context.Context, from, through model.Time, userID, metricName string, matchers []*labels.Matcher) ([]string, error) {

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sort"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -244,18 +243,7 @@ func (c *seriesStore) LabelNamesForMetricName(ctx context.Context, from, through
 		level.Error(log).Log("msg", "FetchChunks", "err", err)
 		return nil, err
 	}
-
-	var result []string
-	for _, c := range allChunks {
-		for _, l := range c.Metric {
-			if l.Name != model.MetricNameLabel {
-				result = append(result, string(l.Name))
-			}
-		}
-	}
-	sort.Strings(result)
-	result = uniqueStrings(result)
-	return result, nil
+	return labelNamesFromChunks(allChunks), nil
 }
 
 func (c *seriesStore) lookupSeriesByMetricNameMatchers(ctx context.Context, from, through model.Time, userID, metricName string, matchers []*labels.Matcher) ([]string, error) {

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -233,7 +233,7 @@ func (c *seriesStore) LabelNamesForMetricName(ctx context.Context, from, through
 
 	// Filter out chunks that are not in the selected time range and keep a single chunk per fingerprint
 	filtered := filterChunksByTime(from, through, chunks)
-	filtered, keys := filterChunksByUniqueFingerPrint(filtered)
+	filtered, keys := filterChunksByUniqueFingerprint(filtered)
 	level.Debug(log).Log("Chunks post filtering", len(chunks))
 
 	chunksPerQuery.Observe(float64(len(filtered)))


### PR DESCRIPTION
This adds LabelNamesForMetricName for the series store only, I wanted to first get your feedback if this seems correct.

- I'm getting all series ids for a given metric name
- lookupSingleChunkBySeries which takes the first index query and lookup index entries then take the first index entry and parse the chunk key.
- fetch a single chunk for each series
- merge all label names possible except metric name.

I would like a special attention to that lookupSingleChunkBySeries and its usage, not sure if this is the right way to approach the problem. (May be I should loop though queries and entries until I get a result ?)

I still need to implement this for the chunk store but I'm not sure what would be the most efficient way of doing this.

The PR is rebased on my other work to include the split of the time range validation. So don't mind the two other commit they won't be part of this PR.

Thank you !