### PR TITLE
Improve tracing info on DynamoDB query errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1490,6 +1490,7 @@
     "github.com/opentracing-contrib/go-grpc",
     "github.com/opentracing-contrib/go-stdlib/nethttp",
     "github.com/opentracing/opentracing-go",
+    "github.com/opentracing/opentracing-go/ext",
     "github.com/opentracing/opentracing-go/log",
     "github.com/pkg/errors",
     "github.com/prometheus/alertmanager/api",

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/cortexproject/cortex/pkg/util"
@@ -40,4 +41,14 @@ func (s *SpanLogger) Log(kvps ...interface{}) error {
 	}
 	s.Span.LogFields(fields...)
 	return nil
+}
+
+// Error sets error flag and logs the error, if non-nil.  Returns the err passed in.
+func (s *SpanLogger) Error(err error) error {
+	if err == nil {
+		return nil
+	}
+	ext.Error.Set(s.Span, true)
+	s.Span.LogFields(otlog.Error(err))
+	return err
 }


### PR DESCRIPTION
Use `spanLogger` to unify logging and tracing, then pass it errors so they can be viewed in the trace.

Also stop sending `ValidationException` to event-logging, since the info is in tracing now.
