### PR TITLE
Ensure Limits Overrides metric is registered explicitly once

### DIFF
--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -18,6 +18,10 @@ var overridesReloadSuccess = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Whether the last overrides reload attempt was successful.",
 })
 
+func init() {
+	overridesReloadSuccess.Set(1) // Default to 1
+}
+
 // When we load YAML from disk, we want the various per-customer limits
 // to default to any values specified on the command line, not default
 // command line values.  This global contains those values.  I (Tom) cannot


### PR DESCRIPTION
This metric should not be registered by default. It is an important metric that signals an error and it is in a widely imported package. This code ensure this metric is not registered automatically. It allows for mutliple calls to NewOverrides instead of causing a panic to allow for tests to function correctly. However, it signals a warning because multiple override structs should not be instantiated since they act as a singleton.

Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>