### PR TITLE
 Change Chunk.Metric from a map to a slice, for performance

### DIFF
--- a/pkg/chunk/cache/cache_test.go
+++ b/pkg/chunk/cache/cache_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	prom_chunk "github.com/cortexproject/cortex/pkg/chunk/encoding"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,9 +36,9 @@ func fillCache(t *testing.T, cache cache.Cache) ([]string, []chunk.Chunk) {
 		c := chunk.NewChunk(
 			userID,
 			model.Fingerprint(1),
-			model.Metric{
-				model.MetricNameLabel: "foo",
-				"bar":                 "baz",
+			labels.Labels{
+				{Name: model.MetricNameLabel, Value: "foo"},
+				{Name: "bar", Value: "baz"},
 			},
 			promChunk[0],
 			ts,

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -2,7 +2,6 @@ package chunk
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
@@ -14,13 +13,10 @@ import (
 	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
 	"github.com/golang/snappy"
 	jsoniter "github.com/json-iterator/go"
-	ot "github.com/opentracing/opentracing-go"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 
-	"github.com/cortexproject/cortex/pkg/util"
 	errs "github.com/weaveworks/common/errors"
 )
 
@@ -336,37 +332,6 @@ func (c *Chunk) Decode(decodeContext *DecodeContext, input []byte) error {
 func equalByKey(a, b Chunk) bool {
 	return a.UserID == b.UserID && a.Fingerprint == b.Fingerprint &&
 		a.From == b.From && a.Through == b.Through && a.Checksum == b.Checksum
-}
-
-// ChunksToMatrix converts a set of chunks to a model.Matrix.
-func ChunksToMatrix(ctx context.Context, chunks []Chunk, from, through model.Time) (model.Matrix, error) {
-	sp, ctx := ot.StartSpanFromContext(ctx, "chunksToMatrix")
-	defer sp.Finish()
-	sp.LogFields(otlog.Int("chunks", len(chunks)))
-
-	// Group chunks by series, sort and dedupe samples.
-	metrics := map[model.Fingerprint]model.Metric{}
-	samplesBySeries := map[model.Fingerprint][][]model.SamplePair{}
-	for _, c := range chunks {
-		ss, err := c.Samples(from, through)
-		if err != nil {
-			return nil, err
-		}
-
-		metrics[c.Fingerprint] = util.LabelsToMetric(c.Metric)
-		samplesBySeries[c.Fingerprint] = append(samplesBySeries[c.Fingerprint], ss)
-	}
-	sp.LogFields(otlog.Int("series", len(samplesBySeries)))
-
-	matrix := make(model.Matrix, 0, len(samplesBySeries))
-	for fp, ss := range samplesBySeries {
-		matrix = append(matrix, &model.SampleStream{
-			Metric: metrics[fp],
-			Values: util.MergeNSampleSets(ss...),
-		})
-	}
-
-	return matrix, nil
 }
 
 // Samples returns all SamplePairs for the chunk.

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -18,6 +18,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 
 	"github.com/cortexproject/cortex/pkg/util"
 	errs "github.com/weaveworks/common/errors"
@@ -45,9 +46,9 @@ type Chunk struct {
 	UserID      string            `json:"userID"`
 
 	// These fields will be in all chunks, including old ones.
-	From    model.Time   `json:"from"`
-	Through model.Time   `json:"through"`
-	Metric  model.Metric `json:"metric"`
+	From    model.Time    `json:"from"`
+	Through model.Time    `json:"through"`
+	Metric  labels.Labels `json:"metric"`
 
 	// The hash is not written to the external storage either.  We use
 	// crc32, Castagnoli table.  See http://www.evanjones.ca/crc32c.html.
@@ -69,7 +70,7 @@ type Chunk struct {
 }
 
 // NewChunk creates a new chunk
-func NewChunk(userID string, fp model.Fingerprint, metric model.Metric, c prom_chunk.Chunk, from, through model.Time) Chunk {
+func NewChunk(userID string, fp model.Fingerprint, metric labels.Labels, c prom_chunk.Chunk, from, through model.Time) Chunk {
 	return Chunk{
 		Fingerprint: fp,
 		UserID:      userID,
@@ -352,7 +353,7 @@ func ChunksToMatrix(ctx context.Context, chunks []Chunk, from, through model.Tim
 			return nil, err
 		}
 
-		metrics[c.Fingerprint] = c.Metric
+		metrics[c.Fingerprint] = util.LabelsToMetric(c.Metric)
 		samplesBySeries[c.Fingerprint] = append(samplesBySeries[c.Fingerprint], ss)
 	}
 	sp.LogFields(otlog.Int("series", len(samplesBySeries)))

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -141,9 +141,9 @@ func (c *store) PutOne(ctx context.Context, from, through model.Time, chunk Chun
 func (c *store) calculateIndexEntries(userID string, from, through model.Time, chunk Chunk) (WriteBatch, error) {
 	seenIndexEntries := map[string]struct{}{}
 
-	metricName, err := extract.MetricNameFromMetric(chunk.Metric)
-	if err != nil {
-		return nil, err
+	metricName := chunk.Metric.Get(labels.MetricName)
+	if metricName == "" {
+		return nil, fmt.Errorf("no MetricNameLabel for chunk")
 	}
 
 	entries, err := c.schema.GetWriteEntries(from, through, userID, metricName, chunk.Metric, chunk.ExternalKey())
@@ -201,7 +201,7 @@ func (c *store) LabelValuesForMetricName(ctx context.Context, from, through mode
 		return nil, nil
 	}
 
-	queries, err := c.schema.GetReadQueriesForMetricLabel(from, through, userID, model.LabelValue(metricName), model.LabelName(labelName))
+	queries, err := c.schema.GetReadQueriesForMetricLabel(from, through, userID, metricName, labelName)
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +336,7 @@ func (c *store) lookupChunksByMetricName(ctx context.Context, from, through mode
 
 	// Just get chunks for metric if there are no matchers
 	if len(matchers) == 0 {
-		queries, err := c.schema.GetReadQueriesForMetric(from, through, userID, model.LabelValue(metricName))
+		queries, err := c.schema.GetReadQueriesForMetric(from, through, userID, metricName)
 		if err != nil {
 			return nil, err
 		}
@@ -366,9 +366,9 @@ func (c *store) lookupChunksByMetricName(ctx context.Context, from, through mode
 			var queries []IndexQuery
 			var err error
 			if matcher.Type != labels.MatchEqual {
-				queries, err = c.schema.GetReadQueriesForMetricLabel(from, through, userID, model.LabelValue(metricName), model.LabelName(matcher.Name))
+				queries, err = c.schema.GetReadQueriesForMetricLabel(from, through, userID, metricName, matcher.Name)
 			} else {
-				queries, err = c.schema.GetReadQueriesForMetricLabelValue(from, through, userID, model.LabelValue(metricName), model.LabelName(matcher.Name), model.LabelValue(matcher.Value))
+				queries, err = c.schema.GetReadQueriesForMetricLabelValue(from, through, userID, metricName, matcher.Name, matcher.Value)
 			}
 			if err != nil {
 				incomingErrors <- err

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -34,7 +34,7 @@ func filterChunksByMatchers(chunks []Chunk, filters []*labels.Matcher) []Chunk {
 outer:
 	for _, chunk := range chunks {
 		for _, filter := range filters {
-			if !filter.Matches(string(chunk.Metric[model.LabelName(filter.Name)])) {
+			if !filter.Matches(chunk.Metric.Get(filter.Name)) {
 				continue outer
 			}
 		}

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -22,12 +22,14 @@ func init() {
 	encoding.DefaultEncoding = encoding.Varbit
 }
 
+var labelsForDummyChunks = labels.Labels{
+	{Name: labels.MetricName, Value: "foo"},
+	{Name: "bar", Value: "baz"},
+	{Name: "toms", Value: "code"},
+}
+
 func dummyChunk(now model.Time) Chunk {
-	return dummyChunkFor(now, labels.Labels{
-		{Name: labels.MetricName, Value: "foo"},
-		{Name: "bar", Value: "baz"},
-		{Name: "toms", Value: "code"},
-	})
+	return dummyChunkFor(now, labelsForDummyChunks)
 }
 
 func dummyChunkForEncoding(now model.Time, metric labels.Labels, enc encoding.Encoding, samples int) Chunk {
@@ -156,16 +158,11 @@ func TestParseExternalKey(t *testing.T) {
 
 func TestChunksToMatrix(t *testing.T) {
 	// Create 2 chunks which have the same metric
-	metric := labels.Labels{
-		{Name: model.MetricNameLabel, Value: "foo"},
-		{Name: "bar", Value: "baz"},
-		{Name: "toms", Value: "code"},
-	}
 	now := model.Now()
-	chunk1 := dummyChunkFor(now, metric)
+	chunk1 := dummyChunkFor(now, labelsForDummyChunks)
 	chunk1Samples, err := chunk1.Samples(chunk1.From, chunk1.Through)
 	require.NoError(t, err)
-	chunk2 := dummyChunkFor(now, metric)
+	chunk2 := dummyChunkFor(now, labelsForDummyChunks)
 	chunk2Samples, err := chunk2.Samples(chunk2.From, chunk2.Through)
 	require.NoError(t, err)
 

--- a/pkg/chunk/fixtures.go
+++ b/pkg/chunk/fixtures.go
@@ -4,27 +4,28 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 )
 
-// BenchmarkMetric is a real example from Kubernetes' embedded cAdvisor metrics, lightly obfuscated
-var BenchmarkMetric = model.Metric{
-	model.MetricNameLabel:                      "container_cpu_usage_seconds_total",
-	"beta_kubernetes_io_arch":                  "amd64",
-	"beta_kubernetes_io_instance_type":         "c3.somesize",
-	"beta_kubernetes_io_os":                    "linux",
-	"container_name":                           "some-name",
-	"cpu":                                      "cpu01",
-	"failure_domain_beta_kubernetes_io_region": "somewhere-1",
-	"failure_domain_beta_kubernetes_io_zone":   "somewhere-1b",
-	"id":                                       "/kubepods/burstable/pod6e91c467-e4c5-11e7-ace3-0a97ed59c75e/a3c8498918bd6866349fed5a6f8c643b77c91836427fb6327913276ebc6bde28",
-	"image":                                    "registry/organisation/name@sha256:dca3d877a80008b45d71d7edc4fd2e44c0c8c8e7102ba5cbabec63a374d1d506",
-	"instance":                                 "ip-111-11-1-11.ec2.internal",
-	"job":                                      "kubernetes-cadvisor",
-	"kubernetes_io_hostname":                   "ip-111-11-1-11",
-	"monitor":                                  "prod",
-	"name":                                     "k8s_some-name_some-other-name-5j8s8_kube-system_6e91c467-e4c5-11e7-ace3-0a97ed59c75e_0",
-	"namespace":                                "kube-system",
-	"pod_name":                                 "some-other-name-5j8s8",
+// BenchmarkLabels is a real example from Kubernetes' embedded cAdvisor metrics, lightly obfuscated
+var BenchmarkLabels = labels.Labels{
+	{Name: model.MetricNameLabel, Value: "container_cpu_usage_seconds_total"},
+	{Name: "beta_kubernetes_io_arch", Value: "amd64"},
+	{Name: "beta_kubernetes_io_instance_type", Value: "c3.somesize"},
+	{Name: "beta_kubernetes_io_os", Value: "linux"},
+	{Name: "container_name", Value: "some-name"},
+	{Name: "cpu", Value: "cpu01"},
+	{Name: "failure_domain_beta_kubernetes_io_region", Value: "somewhere-1"},
+	{Name: "failure_domain_beta_kubernetes_io_zone", Value: "somewhere-1b"},
+	{Name: "id", Value: "/kubepods/burstable/pod6e91c467-e4c5-11e7-ace3-0a97ed59c75e/a3c8498918bd6866349fed5a6f8c643b77c91836427fb6327913276ebc6bde28"},
+	{Name: "image", Value: "registry/organisation/name@sha256:dca3d877a80008b45d71d7edc4fd2e44c0c8c8e7102ba5cbabec63a374d1d506"},
+	{Name: "instance", Value: "ip-111-11-1-11.ec2.internal"},
+	{Name: "job", Value: "kubernetes-cadvisor"},
+	{Name: "kubernetes_io_hostname", Value: "ip-111-11-1-11"},
+	{Name: "monitor", Value: "prod"},
+	{Name: "name", Value: "k8s_some-name_some-other-name-5j8s8_kube-system_6e91c467-e4c5-11e7-ace3-0a97ed59c75e_0"},
+	{Name: "namespace", Value: "kube-system"},
+	{Name: "pod_name", Value: "some-other-name-5j8s8"},
 }
 
 // DefaultSchemaConfig creates a simple schema config for testing

--- a/pkg/chunk/json_helpers.go
+++ b/pkg/chunk/json_helpers.go
@@ -5,24 +5,45 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 )
 
 func init() {
-	jsoniter.RegisterTypeDecoderFunc("model.Metric", decodeMetric)
+	jsoniter.RegisterTypeDecoderFunc("labels.Labels", decodeLabels)
+	jsoniter.RegisterTypeEncoderFunc("labels.Labels", encodeLabels, labelsIsEmpty)
 	jsoniter.RegisterTypeDecoderFunc("model.Time", decodeModelTime)
 	jsoniter.RegisterTypeEncoderFunc("model.Time", encodeModelTime, modelTimeIsEmpty)
 }
 
-// decoding model.Metric via ReadMapCB is faster than the generic jsoniter
-// decoder because the latter allocates memory for each string via reflect.
-func decodeMetric(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-	mapPtr := (*model.Metric)(ptr)
-	*mapPtr = make(model.Metric, 10)
+// Override Prometheus' labels.Labels decoder which goes via a map
+func decodeLabels(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+	labelsPtr := (*labels.Labels)(ptr)
+	*labelsPtr = make(labels.Labels, 0, 10)
 	iter.ReadMapCB(func(iter *jsoniter.Iterator, key string) bool {
 		value := iter.ReadString()
-		(*mapPtr)[model.LabelName(key)] = model.LabelValue(value)
+		*labelsPtr = append(*labelsPtr, labels.Label{Name: key, Value: value})
 		return true
 	})
+}
+
+// Override Prometheus' labels.Labels encoder which goes via a map
+func encodeLabels(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	labelsPtr := (*labels.Labels)(ptr)
+	stream.WriteObjectStart()
+	for i, v := range *labelsPtr {
+		if i != 0 {
+			stream.WriteMore()
+		}
+		stream.WriteString(v.Name)
+		stream.WriteRaw(`:`)
+		stream.WriteString(v.Value)
+	}
+	stream.WriteObjectEnd()
+}
+
+func labelsIsEmpty(ptr unsafe.Pointer) bool {
+	labelsPtr := (*labels.Labels)(ptr)
+	return len(*labelsPtr) == 0
 }
 
 // Decode via jsoniter's float64 routine is faster than getting the string data and decoding as two integers

--- a/pkg/chunk/json_helpers.go
+++ b/pkg/chunk/json_helpers.go
@@ -1,6 +1,7 @@
 package chunk
 
 import (
+	"sort"
 	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
@@ -24,6 +25,9 @@ func decodeLabels(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 		*labelsPtr = append(*labelsPtr, labels.Label{Name: key, Value: value})
 		return true
 	})
+	// Labels are always sorted, but earlier Cortex using a map would
+	// output in any order so we have to sort on read in
+	sort.Sort(*labelsPtr)
 }
 
 // Override Prometheus' labels.Labels encoder which goes via a map

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 )
 
 var (
@@ -29,17 +30,17 @@ var (
 // to write or read chunks from the external index.
 type Schema interface {
 	// When doing a write, use this method to return the list of entries you should write to.
-	GetWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error)
+	GetWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
 
 	// Should only be used with the seriesStore. TODO: Make seriesStore implement a different interface altogether.
-	GetLabelWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error)
-	GetChunkWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error)
-	GetLabelEntryCacheKeys(from, through model.Time, userID string, labels model.Metric) []string
+	GetLabelWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
+	GetChunkWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
+	GetLabelEntryCacheKeys(from, through model.Time, userID string, labels labels.Labels) []string
 
 	// When doing a read, use these methods to return the list of entries you should query
-	GetReadQueriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexQuery, error)
-	GetReadQueriesForMetricLabel(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName) ([]IndexQuery, error)
-	GetReadQueriesForMetricLabelValue(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexQuery, error)
+	GetReadQueriesForMetric(from, through model.Time, userID string, metricName string) ([]IndexQuery, error)
+	GetReadQueriesForMetricLabel(from, through model.Time, userID string, metricName string, labelName string) ([]IndexQuery, error)
+	GetReadQueriesForMetricLabelValue(from, through model.Time, userID string, metricName string, labelName string, labelValue string) ([]IndexQuery, error)
 
 	// If the query resulted in series IDs, use this method to find chunks.
 	GetChunksForSeries(from, through model.Time, userID string, seriesID []byte) ([]IndexQuery, error)
@@ -82,7 +83,7 @@ type schema struct {
 	entries entries
 }
 
-func (s schema) GetWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (s schema) GetWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	var result []IndexEntry
 
 	for _, bucket := range s.buckets(from, through, userID) {
@@ -95,7 +96,7 @@ func (s schema) GetWriteEntries(from, through model.Time, userID string, metricN
 	return result, nil
 }
 
-func (s schema) GetLabelWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (s schema) GetLabelWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	var result []IndexEntry
 
 	for _, bucket := range s.buckets(from, through, userID) {
@@ -108,7 +109,7 @@ func (s schema) GetLabelWriteEntries(from, through model.Time, userID string, me
 	return result, nil
 }
 
-func (s schema) GetChunkWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (s schema) GetChunkWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	var result []IndexEntry
 
 	for _, bucket := range s.buckets(from, through, userID) {
@@ -123,7 +124,7 @@ func (s schema) GetChunkWriteEntries(from, through model.Time, userID string, me
 }
 
 // Should only used for v9Schema
-func (s schema) GetLabelEntryCacheKeys(from, through model.Time, userID string, labels model.Metric) []string {
+func (s schema) GetLabelEntryCacheKeys(from, through model.Time, userID string, labels labels.Labels) []string {
 	var result []string
 	for _, bucket := range s.buckets(from, through, userID) {
 		key := strings.Join([]string{
@@ -140,7 +141,7 @@ func (s schema) GetLabelEntryCacheKeys(from, through model.Time, userID string, 
 	return result
 }
 
-func (s schema) GetReadQueriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexQuery, error) {
+func (s schema) GetReadQueriesForMetric(from, through model.Time, userID string, metricName string) ([]IndexQuery, error) {
 	var result []IndexQuery
 
 	buckets := s.buckets(from, through, userID)
@@ -154,7 +155,7 @@ func (s schema) GetReadQueriesForMetric(from, through model.Time, userID string,
 	return result, nil
 }
 
-func (s schema) GetReadQueriesForMetricLabel(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName) ([]IndexQuery, error) {
+func (s schema) GetReadQueriesForMetricLabel(from, through model.Time, userID string, metricName string, labelName string) ([]IndexQuery, error) {
 	var result []IndexQuery
 
 	buckets := s.buckets(from, through, userID)
@@ -168,7 +169,7 @@ func (s schema) GetReadQueriesForMetricLabel(from, through model.Time, userID st
 	return result, nil
 }
 
-func (s schema) GetReadQueriesForMetricLabelValue(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexQuery, error) {
+func (s schema) GetReadQueriesForMetricLabelValue(from, through model.Time, userID string, metricName string, labelName string, labelValue string) ([]IndexQuery, error) {
 	var result []IndexQuery
 
 	buckets := s.buckets(from, through, userID)
@@ -197,13 +198,13 @@ func (s schema) GetChunksForSeries(from, through model.Time, userID string, seri
 }
 
 type entries interface {
-	GetWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error)
-	GetLabelWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error)
-	GetChunkWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error)
+	GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
+	GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
+	GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
 
-	GetReadMetricQueries(bucket Bucket, metricName model.LabelValue) ([]IndexQuery, error)
-	GetReadMetricLabelQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName) ([]IndexQuery, error)
-	GetReadMetricLabelValueQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexQuery, error)
+	GetReadMetricQueries(bucket Bucket, metricName string) ([]IndexQuery, error)
+	GetReadMetricLabelQueries(bucket Bucket, metricName string, labelName string) ([]IndexQuery, error)
+	GetReadMetricLabelValueQueries(bucket Bucket, metricName string, labelName string, labelValue string) ([]IndexQuery, error)
 	GetChunksForSeries(bucket Bucket, seriesID []byte) ([]IndexQuery, error)
 }
 
@@ -213,60 +214,60 @@ type entries interface {
 
 type originalEntries struct{}
 
-func (originalEntries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (originalEntries) GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	chunkIDBytes := []byte(chunkID)
 	result := []IndexEntry{}
-	for key, value := range labels {
-		if key == model.MetricNameLabel {
+	for _, v := range labels {
+		if v.Name == model.MetricNameLabel {
 			continue
 		}
-		if strings.ContainsRune(string(value), '\x00') {
+		if strings.ContainsRune(string(v.Value), '\x00') {
 			return nil, fmt.Errorf("label values cannot contain null byte")
 		}
 		result = append(result, IndexEntry{
 			TableName:  bucket.tableName,
-			HashValue:  bucket.hashKey + ":" + string(metricName),
-			RangeValue: encodeRangeKey([]byte(key), []byte(value), chunkIDBytes),
+			HashValue:  bucket.hashKey + ":" + metricName,
+			RangeValue: encodeRangeKey([]byte(v.Name), []byte(v.Value), chunkIDBytes),
 		})
 	}
 	return result, nil
 }
 
-func (originalEntries) GetLabelWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (originalEntries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	return nil, ErrNotSupported
 }
-func (originalEntries) GetChunkWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (originalEntries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	return nil, ErrNotSupported
 }
 
-func (originalEntries) GetReadMetricQueries(bucket Bucket, metricName model.LabelValue) ([]IndexQuery, error) {
+func (originalEntries) GetReadMetricQueries(bucket Bucket, metricName string) ([]IndexQuery, error) {
 	return []IndexQuery{
 		{
 			TableName:        bucket.tableName,
-			HashValue:        bucket.hashKey + ":" + string(metricName),
+			HashValue:        bucket.hashKey + ":" + metricName,
 			RangeValuePrefix: nil,
 		},
 	}, nil
 }
 
-func (originalEntries) GetReadMetricLabelQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName) ([]IndexQuery, error) {
+func (originalEntries) GetReadMetricLabelQueries(bucket Bucket, metricName string, labelName string) ([]IndexQuery, error) {
 	return []IndexQuery{
 		{
 			TableName:        bucket.tableName,
-			HashValue:        bucket.hashKey + ":" + string(metricName),
+			HashValue:        bucket.hashKey + ":" + metricName,
 			RangeValuePrefix: encodeRangeKey([]byte(labelName)),
 		},
 	}, nil
 }
 
-func (originalEntries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexQuery, error) {
+func (originalEntries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string, labelName string, labelValue string) ([]IndexQuery, error) {
 	if strings.ContainsRune(string(labelValue), '\x00') {
 		return nil, fmt.Errorf("label values cannot contain null byte")
 	}
 	return []IndexQuery{
 		{
 			TableName:        bucket.tableName,
-			HashValue:        bucket.hashKey + ":" + string(metricName),
+			HashValue:        bucket.hashKey + ":" + metricName,
 			RangeValuePrefix: encodeRangeKey([]byte(labelName), []byte(labelValue)),
 		},
 	}, nil
@@ -283,37 +284,37 @@ type base64Entries struct {
 	originalEntries
 }
 
-func (base64Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (base64Entries) GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	chunkIDBytes := []byte(chunkID)
 	result := []IndexEntry{}
-	for key, value := range labels {
-		if key == model.MetricNameLabel {
+	for _, v := range labels {
+		if v.Name == model.MetricNameLabel {
 			continue
 		}
 
-		encodedBytes := encodeBase64Value(value)
+		encodedBytes := encodeBase64Value(v.Value)
 		result = append(result, IndexEntry{
 			TableName:  bucket.tableName,
-			HashValue:  bucket.hashKey + ":" + string(metricName),
-			RangeValue: encodeRangeKey([]byte(key), encodedBytes, chunkIDBytes, chunkTimeRangeKeyV1),
+			HashValue:  bucket.hashKey + ":" + metricName,
+			RangeValue: encodeRangeKey([]byte(v.Name), encodedBytes, chunkIDBytes, chunkTimeRangeKeyV1),
 		})
 	}
 	return result, nil
 }
 
-func (base64Entries) GetLabelWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (base64Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	return nil, ErrNotSupported
 }
-func (base64Entries) GetChunkWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (base64Entries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	return nil, ErrNotSupported
 }
 
-func (base64Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexQuery, error) {
+func (base64Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string, labelName string, labelValue string) ([]IndexQuery, error) {
 	encodedBytes := encodeBase64Value(labelValue)
 	return []IndexQuery{
 		{
 			TableName:        bucket.tableName,
-			HashValue:        bucket.hashKey + ":" + string(metricName),
+			HashValue:        bucket.hashKey + ":" + metricName,
 			RangeValuePrefix: encodeRangeKey([]byte(labelName), encodedBytes),
 		},
 	}, nil
@@ -326,24 +327,24 @@ func (base64Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName mo
 //    - range key: \0\0<chunk name>\0<version 3>
 type labelNameInHashKeyEntries struct{}
 
-func (labelNameInHashKeyEntries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (labelNameInHashKeyEntries) GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	chunkIDBytes := []byte(chunkID)
 	entries := []IndexEntry{
 		{
 			TableName:  bucket.tableName,
-			HashValue:  bucket.hashKey + ":" + string(metricName),
+			HashValue:  bucket.hashKey + ":" + metricName,
 			RangeValue: encodeRangeKey(nil, nil, chunkIDBytes, chunkTimeRangeKeyV2),
 		},
 	}
 
-	for key, value := range labels {
-		if key == model.MetricNameLabel {
+	for _, v := range labels {
+		if v.Name == model.MetricNameLabel {
 			continue
 		}
-		encodedBytes := encodeBase64Value(value)
+		encodedBytes := encodeBase64Value(v.Value)
 		entries = append(entries, IndexEntry{
 			TableName:  bucket.tableName,
-			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, key),
+			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, v.Name),
 			RangeValue: encodeRangeKey(nil, encodedBytes, chunkIDBytes, chunkTimeRangeKeyV1),
 		})
 	}
@@ -351,23 +352,23 @@ func (labelNameInHashKeyEntries) GetWriteEntries(bucket Bucket, metricName model
 	return entries, nil
 }
 
-func (labelNameInHashKeyEntries) GetLabelWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (labelNameInHashKeyEntries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	return nil, ErrNotSupported
 }
-func (labelNameInHashKeyEntries) GetChunkWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (labelNameInHashKeyEntries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	return nil, ErrNotSupported
 }
 
-func (labelNameInHashKeyEntries) GetReadMetricQueries(bucket Bucket, metricName model.LabelValue) ([]IndexQuery, error) {
+func (labelNameInHashKeyEntries) GetReadMetricQueries(bucket Bucket, metricName string) ([]IndexQuery, error) {
 	return []IndexQuery{
 		{
 			TableName: bucket.tableName,
-			HashValue: bucket.hashKey + ":" + string(metricName),
+			HashValue: bucket.hashKey + ":" + metricName,
 		},
 	}, nil
 }
 
-func (labelNameInHashKeyEntries) GetReadMetricLabelQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName) ([]IndexQuery, error) {
+func (labelNameInHashKeyEntries) GetReadMetricLabelQueries(bucket Bucket, metricName string, labelName string) ([]IndexQuery, error) {
 	return []IndexQuery{
 		{
 			TableName: bucket.tableName,
@@ -376,7 +377,7 @@ func (labelNameInHashKeyEntries) GetReadMetricLabelQueries(bucket Bucket, metric
 	}, nil
 }
 
-func (labelNameInHashKeyEntries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexQuery, error) {
+func (labelNameInHashKeyEntries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string, labelName string, labelValue string) ([]IndexQuery, error) {
 	encodedBytes := encodeBase64Value(labelValue)
 	return []IndexQuery{
 		{
@@ -396,26 +397,26 @@ func (labelNameInHashKeyEntries) GetChunksForSeries(_ Bucket, _ []byte) ([]Index
 // so the chunk end times are ignored.
 type v5Entries struct{}
 
-func (v5Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v5Entries) GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	chunkIDBytes := []byte(chunkID)
 	encodedThroughBytes := encodeTime(bucket.through)
 
 	entries := []IndexEntry{
 		{
 			TableName:  bucket.tableName,
-			HashValue:  bucket.hashKey + ":" + string(metricName),
+			HashValue:  bucket.hashKey + ":" + metricName,
 			RangeValue: encodeRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV3),
 		},
 	}
 
-	for key, value := range labels {
-		if key == model.MetricNameLabel {
+	for _, v := range labels {
+		if v.Name == model.MetricNameLabel {
 			continue
 		}
-		encodedValueBytes := encodeBase64Value(value)
+		encodedValueBytes := encodeBase64Value(v.Value)
 		entries = append(entries, IndexEntry{
 			TableName:  bucket.tableName,
-			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, key),
+			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, v.Name),
 			RangeValue: encodeRangeKey(encodedThroughBytes, encodedValueBytes, chunkIDBytes, chunkTimeRangeKeyV4),
 		})
 	}
@@ -423,23 +424,23 @@ func (v5Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, lab
 	return entries, nil
 }
 
-func (v5Entries) GetLabelWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v5Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	return nil, ErrNotSupported
 }
-func (v5Entries) GetChunkWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v5Entries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	return nil, ErrNotSupported
 }
 
-func (v5Entries) GetReadMetricQueries(bucket Bucket, metricName model.LabelValue) ([]IndexQuery, error) {
+func (v5Entries) GetReadMetricQueries(bucket Bucket, metricName string) ([]IndexQuery, error) {
 	return []IndexQuery{
 		{
 			TableName: bucket.tableName,
-			HashValue: bucket.hashKey + ":" + string(metricName),
+			HashValue: bucket.hashKey + ":" + metricName,
 		},
 	}, nil
 }
 
-func (v5Entries) GetReadMetricLabelQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName) ([]IndexQuery, error) {
+func (v5Entries) GetReadMetricLabelQueries(bucket Bucket, metricName string, labelName string) ([]IndexQuery, error) {
 	return []IndexQuery{
 		{
 			TableName: bucket.tableName,
@@ -448,7 +449,7 @@ func (v5Entries) GetReadMetricLabelQueries(bucket Bucket, metricName model.Label
 	}, nil
 }
 
-func (v5Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName, _ model.LabelValue) ([]IndexQuery, error) {
+func (v5Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string, labelName string, _ string) ([]IndexQuery, error) {
 	return []IndexQuery{
 		{
 			TableName: bucket.tableName,
@@ -465,52 +466,52 @@ func (v5Entries) GetChunksForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
 // moves label value out of range key (see #199).
 type v6Entries struct{}
 
-func (v6Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v6Entries) GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	chunkIDBytes := []byte(chunkID)
 	encodedThroughBytes := encodeTime(bucket.through)
 
 	entries := []IndexEntry{
 		{
 			TableName:  bucket.tableName,
-			HashValue:  bucket.hashKey + ":" + string(metricName),
+			HashValue:  bucket.hashKey + ":" + metricName,
 			RangeValue: encodeRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV3),
 		},
 	}
 
-	for key, value := range labels {
-		if key == model.MetricNameLabel {
+	for _, v := range labels {
+		if v.Name == model.MetricNameLabel {
 			continue
 		}
 		entries = append(entries, IndexEntry{
 			TableName:  bucket.tableName,
-			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, key),
+			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, v.Name),
 			RangeValue: encodeRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV5),
-			Value:      []byte(value),
+			Value:      []byte(v.Value),
 		})
 	}
 
 	return entries, nil
 }
 
-func (v6Entries) GetLabelWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v6Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	return nil, ErrNotSupported
 }
-func (v6Entries) GetChunkWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v6Entries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	return nil, ErrNotSupported
 }
 
-func (v6Entries) GetReadMetricQueries(bucket Bucket, metricName model.LabelValue) ([]IndexQuery, error) {
+func (v6Entries) GetReadMetricQueries(bucket Bucket, metricName string) ([]IndexQuery, error) {
 	encodedFromBytes := encodeTime(bucket.from)
 	return []IndexQuery{
 		{
 			TableName:       bucket.tableName,
-			HashValue:       bucket.hashKey + ":" + string(metricName),
+			HashValue:       bucket.hashKey + ":" + metricName,
 			RangeValueStart: encodeRangeKey(encodedFromBytes),
 		},
 	}, nil
 }
 
-func (v6Entries) GetReadMetricLabelQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName) ([]IndexQuery, error) {
+func (v6Entries) GetReadMetricLabelQueries(bucket Bucket, metricName string, labelName string) ([]IndexQuery, error) {
 	encodedFromBytes := encodeTime(bucket.from)
 	return []IndexQuery{
 		{
@@ -521,7 +522,7 @@ func (v6Entries) GetReadMetricLabelQueries(bucket Bucket, metricName model.Label
 	}, nil
 }
 
-func (v6Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexQuery, error) {
+func (v6Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string, labelName string, labelValue string) ([]IndexQuery, error) {
 	encodedFromBytes := encodeTime(bucket.from)
 	return []IndexQuery{
 		{
@@ -541,41 +542,41 @@ func (v6Entries) GetChunksForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
 type v9Entries struct {
 }
 
-func (v9Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v9Entries) GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	return nil, ErrNotSupported
 }
 
-func (v9Entries) GetLabelWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v9Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	seriesID := sha256bytes(labels.String())
 
 	entries := []IndexEntry{
 		// Entry for metricName -> seriesID
 		{
 			TableName:  bucket.tableName,
-			HashValue:  bucket.hashKey + ":" + string(metricName),
+			HashValue:  bucket.hashKey + ":" + metricName,
 			RangeValue: encodeRangeKey(seriesID, nil, nil, seriesRangeKeyV1),
 		},
 	}
 
 	// Entries for metricName:labelName -> hash(value):seriesID
 	// We use a hash of the value to limit its length.
-	for key, value := range labels {
-		if key == model.MetricNameLabel {
+	for _, v := range labels {
+		if v.Name == model.MetricNameLabel {
 			continue
 		}
-		valueHash := sha256bytes(string(value))
+		valueHash := sha256bytes(v.Value)
 		entries = append(entries, IndexEntry{
 			TableName:  bucket.tableName,
-			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, key),
+			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, v.Name),
 			RangeValue: encodeRangeKey(valueHash, seriesID, nil, labelSeriesRangeKeyV1),
-			Value:      []byte(value),
+			Value:      []byte(v.Value),
 		})
 	}
 
 	return entries, nil
 }
 
-func (v9Entries) GetChunkWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v9Entries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	seriesID := sha256bytes(labels.String())
 	encodedThroughBytes := encodeTime(bucket.through)
 
@@ -591,16 +592,16 @@ func (v9Entries) GetChunkWriteEntries(bucket Bucket, metricName model.LabelValue
 	return entries, nil
 }
 
-func (v9Entries) GetReadMetricQueries(bucket Bucket, metricName model.LabelValue) ([]IndexQuery, error) {
+func (v9Entries) GetReadMetricQueries(bucket Bucket, metricName string) ([]IndexQuery, error) {
 	return []IndexQuery{
 		{
 			TableName: bucket.tableName,
-			HashValue: bucket.hashKey + ":" + string(metricName),
+			HashValue: bucket.hashKey + ":" + metricName,
 		},
 	}, nil
 }
 
-func (v9Entries) GetReadMetricLabelQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName) ([]IndexQuery, error) {
+func (v9Entries) GetReadMetricLabelQueries(bucket Bucket, metricName string, labelName string) ([]IndexQuery, error) {
 	return []IndexQuery{
 		{
 			TableName: bucket.tableName,
@@ -609,8 +610,8 @@ func (v9Entries) GetReadMetricLabelQueries(bucket Bucket, metricName model.Label
 	}, nil
 }
 
-func (v9Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexQuery, error) {
-	valueHash := sha256bytes(string(labelValue))
+func (v9Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string, labelName string, labelValue string) ([]IndexQuery, error) {
+	valueHash := sha256bytes(labelValue)
 	return []IndexQuery{
 		{
 			TableName:       bucket.tableName,
@@ -637,11 +638,11 @@ type v10Entries struct {
 	rowShards uint32
 }
 
-func (v10Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v10Entries) GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	return nil, ErrNotSupported
 }
 
-func (s v10Entries) GetLabelWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (s v10Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	seriesID := sha256bytes(labels.String())
 
 	// read first 32 bits of the hash and use this to calculate the shard
@@ -651,30 +652,30 @@ func (s v10Entries) GetLabelWriteEntries(bucket Bucket, metricName model.LabelVa
 		// Entry for metricName -> seriesID
 		{
 			TableName:  bucket.tableName,
-			HashValue:  fmt.Sprintf("%02d:%s:%s", shard, bucket.hashKey, string(metricName)),
+			HashValue:  fmt.Sprintf("%02d:%s:%s", shard, bucket.hashKey, metricName),
 			RangeValue: encodeRangeKey(seriesID, nil, nil, seriesRangeKeyV1),
 		},
 	}
 
 	// Entries for metricName:labelName -> hash(value):seriesID
 	// We use a hash of the value to limit its length.
-	for key, value := range labels {
-		if key == model.MetricNameLabel {
+	for _, v := range labels {
+		if v.Name == model.MetricNameLabel {
 			continue
 		}
-		valueHash := sha256bytes(string(value))
+		valueHash := sha256bytes(v.Value)
 		entries = append(entries, IndexEntry{
 			TableName:  bucket.tableName,
-			HashValue:  fmt.Sprintf("%02d:%s:%s:%s", shard, bucket.hashKey, metricName, key),
+			HashValue:  fmt.Sprintf("%02d:%s:%s:%s", shard, bucket.hashKey, metricName, v.Name),
 			RangeValue: encodeRangeKey(valueHash, seriesID, nil, labelSeriesRangeKeyV1),
-			Value:      []byte(value),
+			Value:      []byte(v.Value),
 		})
 	}
 
 	return entries, nil
 }
 
-func (v10Entries) GetChunkWriteEntries(bucket Bucket, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v10Entries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	seriesID := sha256bytes(labels.String())
 	encodedThroughBytes := encodeTime(bucket.through)
 
@@ -690,18 +691,18 @@ func (v10Entries) GetChunkWriteEntries(bucket Bucket, metricName model.LabelValu
 	return entries, nil
 }
 
-func (s v10Entries) GetReadMetricQueries(bucket Bucket, metricName model.LabelValue) ([]IndexQuery, error) {
+func (s v10Entries) GetReadMetricQueries(bucket Bucket, metricName string) ([]IndexQuery, error) {
 	result := make([]IndexQuery, 0, s.rowShards)
 	for i := uint32(0); i < s.rowShards; i++ {
 		result = append(result, IndexQuery{
 			TableName: bucket.tableName,
-			HashValue: fmt.Sprintf("%02d:%s:%s", i, bucket.hashKey, string(metricName)),
+			HashValue: fmt.Sprintf("%02d:%s:%s", i, bucket.hashKey, metricName),
 		})
 	}
 	return result, nil
 }
 
-func (s v10Entries) GetReadMetricLabelQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName) ([]IndexQuery, error) {
+func (s v10Entries) GetReadMetricLabelQueries(bucket Bucket, metricName string, labelName string) ([]IndexQuery, error) {
 	result := make([]IndexQuery, 0, s.rowShards)
 	for i := uint32(0); i < s.rowShards; i++ {
 		result = append(result, IndexQuery{
@@ -712,8 +713,8 @@ func (s v10Entries) GetReadMetricLabelQueries(bucket Bucket, metricName model.La
 	return result, nil
 }
 
-func (s v10Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexQuery, error) {
-	valueHash := sha256bytes(string(labelValue))
+func (s v10Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string, labelName string, labelValue string) ([]IndexQuery, error) {
+	valueHash := sha256bytes(labelValue)
 	result := make([]IndexQuery, 0, s.rowShards)
 	for i := uint32(0); i < s.rowShards; i++ {
 		result = append(result, IndexQuery{

--- a/pkg/chunk/schema_caching.go
+++ b/pkg/chunk/schema_caching.go
@@ -13,7 +13,7 @@ type schemaCaching struct {
 	cacheOlderThan time.Duration
 }
 
-func (s *schemaCaching) GetReadQueriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexQuery, error) {
+func (s *schemaCaching) GetReadQueriesForMetric(from, through model.Time, userID string, metricName string) ([]IndexQuery, error) {
 	cFrom, cThrough, from, through := splitTimesByCacheability(from, through, model.TimeFromUnix(mtime.Now().Add(-s.cacheOlderThan).Unix()))
 
 	cacheableQueries, err := s.Schema.GetReadQueriesForMetric(cFrom, cThrough, userID, metricName)
@@ -29,7 +29,7 @@ func (s *schemaCaching) GetReadQueriesForMetric(from, through model.Time, userID
 	return mergeCacheableAndActiveQueries(cacheableQueries, activeQueries), nil
 }
 
-func (s *schemaCaching) GetReadQueriesForMetricLabel(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName) ([]IndexQuery, error) {
+func (s *schemaCaching) GetReadQueriesForMetricLabel(from, through model.Time, userID string, metricName string, labelName string) ([]IndexQuery, error) {
 	cFrom, cThrough, from, through := splitTimesByCacheability(from, through, model.TimeFromUnix(mtime.Now().Add(-s.cacheOlderThan).Unix()))
 
 	cacheableQueries, err := s.Schema.GetReadQueriesForMetricLabel(cFrom, cThrough, userID, metricName, labelName)
@@ -45,7 +45,7 @@ func (s *schemaCaching) GetReadQueriesForMetricLabel(from, through model.Time, u
 	return mergeCacheableAndActiveQueries(cacheableQueries, activeQueries), nil
 }
 
-func (s *schemaCaching) GetReadQueriesForMetricLabelValue(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexQuery, error) {
+func (s *schemaCaching) GetReadQueriesForMetricLabelValue(from, through model.Time, userID string, metricName string, labelName string, labelValue string) ([]IndexQuery, error) {
 	cFrom, cThrough, from, through := splitTimesByCacheability(from, through, model.TimeFromUnix(mtime.Now().Add(-s.cacheOlderThan).Unix()))
 
 	cacheableQueries, err := s.Schema.GetReadQueriesForMetricLabelValue(cFrom, cThrough, userID, metricName, labelName, labelValue)

--- a/pkg/chunk/schema_caching_test.go
+++ b/pkg/chunk/schema_caching_test.go
@@ -58,7 +58,7 @@ func TestCachingSchema(t *testing.T) {
 	} {
 		have, err := schema.GetReadQueriesForMetric(
 			model.TimeFromUnix(tc.from.Unix()), model.TimeFromUnix(tc.through.Unix()),
-			userID, model.LabelValue("foo"),
+			userID, "foo",
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/chunk/schema_util.go
+++ b/pkg/chunk/schema_util.go
@@ -59,7 +59,7 @@ func encodeBase64Bytes(bytes []byte) []byte {
 	return encoded
 }
 
-func encodeBase64Value(value model.LabelValue) []byte {
+func encodeBase64Value(value string) []byte {
 	encodedLen := base64.RawStdEncoding.EncodedLen(len(value))
 	encoded := make([]byte, encodedLen, encodedLen)
 	base64.RawStdEncoding.Encode(encoded, []byte(value))

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/util"
-	"github.com/cortexproject/cortex/pkg/util/extract"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
@@ -252,13 +251,13 @@ func (c *seriesStore) lookupSeriesByMetricNameMatcher(ctx context.Context, from,
 	var queries []IndexQuery
 	var labelName string
 	if matcher == nil {
-		queries, err = c.schema.GetReadQueriesForMetric(from, through, userID, model.LabelValue(metricName))
+		queries, err = c.schema.GetReadQueriesForMetric(from, through, userID, metricName)
 	} else if matcher.Type != labels.MatchEqual {
 		labelName = matcher.Name
-		queries, err = c.schema.GetReadQueriesForMetricLabel(from, through, userID, model.LabelValue(metricName), model.LabelName(matcher.Name))
+		queries, err = c.schema.GetReadQueriesForMetricLabel(from, through, userID, metricName, matcher.Name)
 	} else {
 		labelName = matcher.Name
-		queries, err = c.schema.GetReadQueriesForMetricLabelValue(from, through, userID, model.LabelValue(metricName), model.LabelName(matcher.Name), model.LabelValue(matcher.Value))
+		queries, err = c.schema.GetReadQueriesForMetricLabelValue(from, through, userID, metricName, matcher.Name, matcher.Value)
 	}
 	if err != nil {
 		return nil, err
@@ -355,11 +354,10 @@ func (c *seriesStore) calculateIndexEntries(from, through model.Time, chunk Chun
 	entries := []IndexEntry{}
 	keysToCache := []string{}
 
-	metricName, err := extract.MetricNameFromMetric(chunk.Metric)
-	if err != nil {
-		return nil, nil, err
+	metricName := chunk.Metric.Get(labels.MetricName)
+	if metricName == "" {
+		return nil, nil, fmt.Errorf("no MetricNameLabel for chunk")
 	}
-
 	keys := c.schema.GetLabelEntryCacheKeys(from, through, chunk.UserID, chunk.Metric)
 
 	cacheKeys := make([]string, 0, len(keys)) // Keys which translate to the strings stored in the cache.

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -8,8 +8,10 @@ import (
 	promchunk "github.com/cortexproject/cortex/pkg/chunk/encoding"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/ingester/client"
 )
 
 const (
@@ -59,9 +61,9 @@ func CreateChunks(startIndex, batchSize int, start model.Time) ([]string, []chun
 	keys := []string{}
 	chunks := []chunk.Chunk{}
 	for j := 0; j < batchSize; j++ {
-		chunk := dummyChunkFor(start, model.Metric{
-			model.MetricNameLabel: "foo",
-			"index":               model.LabelValue(strconv.Itoa(startIndex*batchSize + j)),
+		chunk := dummyChunkFor(start, labels.Labels{
+			{Name: model.MetricNameLabel, Value: "foo"},
+			{Name: "index", Value: strconv.Itoa(startIndex*batchSize + j)},
 		})
 		chunks = append(chunks, chunk)
 		keys = append(keys, chunk.ExternalKey())
@@ -70,18 +72,18 @@ func CreateChunks(startIndex, batchSize int, start model.Time) ([]string, []chun
 }
 
 func dummyChunk(now model.Time) chunk.Chunk {
-	return dummyChunkFor(now, model.Metric{
-		model.MetricNameLabel: "foo",
-		"bar":                 "baz",
-		"toms":                "code",
+	return dummyChunkFor(now, labels.Labels{
+		{Name: model.MetricNameLabel, Value: "foo"},
+		{Name: "bar", Value: "baz"},
+		{Name: "toms", Value: "code"},
 	})
 }
 
-func dummyChunkFor(now model.Time, metric model.Metric) chunk.Chunk {
+func dummyChunkFor(now model.Time, metric labels.Labels) chunk.Chunk {
 	cs, _ := promchunk.New().Add(model.SamplePair{Timestamp: now, Value: 0})
 	chunk := chunk.NewChunk(
 		userID,
-		metric.Fingerprint(),
+		client.Fingerprint(metric),
 		metric,
 		cs[0],
 		now.Add(-time.Hour),

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -12,6 +12,8 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
@@ -209,11 +211,7 @@ func FromLabelsToLabelAdapaters(ls labels.Labels) []LabelAdapter {
 // FromLabelAdaptersToMetric converts []LabelAdapter to a model.Metric.
 // Don't do this on any performance sensitive paths.
 func FromLabelAdaptersToMetric(ls []LabelAdapter) model.Metric {
-	result := make(model.Metric, len(ls))
-	for _, l := range ls {
-		result[model.LabelName(l.Name)] = model.LabelValue(l.Value)
-	}
-	return result
+	return util.LabelsToMetric(FromLabelAdaptersToLabels(ls))
 }
 
 // FromMetricsToLabelAdapters converts model.Metric to []LabelAdapter.

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -252,6 +252,18 @@ func FastFingerprint(ls []LabelAdapter) model.Fingerprint {
 	return model.Fingerprint(result)
 }
 
+// Fingerprint runs the same algorithm as Prometheus labelSetToFingerprint()
+func Fingerprint(labels labels.Labels) model.Fingerprint {
+	sum := hashNew()
+	for _, label := range labels {
+		sum = hashAddString(sum, label.Name)
+		sum = hashAddByte(sum, model.SeparatorByte)
+		sum = hashAddString(sum, label.Value)
+		sum = hashAddByte(sum, model.SeparatorByte)
+	}
+	return model.Fingerprint(sum)
+}
+
 // MarshalJSON implements json.Marshaler.
 func (s Sample) MarshalJSON() ([]byte, error) {
 	t, err := json.Marshal(model.Time(s.TimestampMs))

--- a/pkg/ingester/client/fnv.go
+++ b/pkg/ingester/client/fnv.go
@@ -38,6 +38,15 @@ func hashAdd(h uint64, s string) uint64 {
 	return h
 }
 
+// hashAdd adds a string to a fnv64a hash value, returning the updated hash.
+func hashAddString(h uint64, s string) uint64 {
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= prime64
+	}
+	return h
+}
+
 // hashAddByte adds a byte to a fnv64a hash value, returning the updated hash.
 func hashAddByte(h uint64, b byte) uint64 {
 	h ^= uint64(b)

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -12,9 +12,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
-	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/weaveworks/common/user"
 )
@@ -277,7 +277,7 @@ func (i *Ingester) flushUserSeries(flushQueueIndex int, userID string, fp model.
 	sp.SetTag("organization", userID)
 
 	util.Event().Log("msg", "flush chunks", "userID", userID, "reason", reason, "numChunks", len(chunks), "firstTime", chunks[0].FirstTime, "fp", fp, "series", series.metric, "queue", flushQueueIndex)
-	err := i.flushChunks(ctx, fp, client.FromLabelAdaptersToMetric(client.FromLabelsToLabelAdapaters(series.metric)), chunks)
+	err := i.flushChunks(ctx, fp, series.metric, chunks)
 	if err != nil {
 		return err
 	}
@@ -314,7 +314,7 @@ func (i *Ingester) removeFlushedChunks(userState *userState, fp model.Fingerprin
 	}
 }
 
-func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, metric model.Metric, chunkDescs []*desc) error {
+func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, metric labels.Labels, chunkDescs []*desc) error {
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return err

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/chunkcompat"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/weaveworks/common/httpgrpc"
@@ -62,9 +63,9 @@ func (s *testStore) Put(ctx context.Context, chunks []chunk.Chunk) error {
 		return err
 	}
 	for _, chunk := range chunks {
-		for k, v := range chunk.Metric {
-			if v == "" {
-				return fmt.Errorf("Chunk has blank label %q", k)
+		for _, v := range chunk.Metric {
+			if v.Value == "" {
+				return fmt.Errorf("Chunk has blank label %q", v.Name)
 			}
 		}
 	}
@@ -502,7 +503,7 @@ func BenchmarkIngesterPush(b *testing.B) {
 	)
 
 	// Construct a set of realistic-looking samples, all with slightly different label sets
-	labels := chunk.BenchmarkMetric.Clone()
+	labels := util.LabelsToMetric(chunk.BenchmarkLabels).Clone()
 	ts := make([]client.PreallocTimeseries, 0, series)
 	for j := 0; j < series; j++ {
 		labels["cpu"] = model.LabelValue(fmt.Sprintf("cpu%02d", j))

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/require"
 
@@ -40,8 +41,8 @@ func forEncodings(t *testing.T, f func(t *testing.T, enc promchunk.Encoding)) {
 }
 
 func mkChunk(t require.TestingT, from model.Time, points int, enc promchunk.Encoding) chunk.Chunk {
-	metric := model.Metric{
-		model.MetricNameLabel: "foo",
+	metric := labels.Labels{
+		{Name: model.MetricNameLabel, Value: "foo"},
 	}
 	pc, err := promchunk.NewForEncoding(enc)
 	require.NoError(t, err)

--- a/pkg/querier/chunk_store_queryable.go
+++ b/pkg/querier/chunk_store_queryable.go
@@ -3,6 +3,7 @@ package querier
 import (
 	"context"
 
+	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -44,14 +45,14 @@ func (q *chunkStoreQuerier) Select(sp *storage.SelectParams, matchers ...*labels
 func (q *chunkStoreQuerier) partitionChunks(chunks []chunk.Chunk) storage.SeriesSet {
 	chunksBySeries := map[model.Fingerprint][]chunk.Chunk{}
 	for _, c := range chunks {
-		fp := c.Metric.Fingerprint()
+		fp := client.Fingerprint(c.Metric)
 		chunksBySeries[fp] = append(chunksBySeries[fp], c)
 	}
 
 	series := make([]storage.Series, 0, len(chunksBySeries))
 	for i := range chunksBySeries {
 		series = append(series, &chunkSeries{
-			labels:            metricToLabels(chunksBySeries[i][0].Metric),
+			labels:            chunksBySeries[i][0].Metric,
 			chunks:            chunksBySeries[i],
 			chunkIteratorFunc: q.chunkIteratorFunc,
 			mint:              q.mint,

--- a/pkg/querier/chunk_store_queryable_test.go
+++ b/pkg/querier/chunk_store_queryable_test.go
@@ -50,8 +50,8 @@ func makeMockChunkStore(t require.TestingT, numChunks int, encoding promchunk.En
 }
 
 func mkChunk(t require.TestingT, mint, maxt model.Time, step time.Duration, encoding promchunk.Encoding) chunk.Chunk {
-	metric := model.Metric{
-		model.MetricNameLabel: "foo",
+	metric := labels.Labels{
+		{Name: model.MetricNameLabel, Value: "foo"},
 	}
 	pc, err := promchunk.NewForEncoding(encoding)
 	require.NoError(t, err)

--- a/pkg/querier/ingester_streaming_queryable.go
+++ b/pkg/querier/ingester_streaming_queryable.go
@@ -59,7 +59,7 @@ func (i ingesterQueryable) Get(ctx context.Context, from, through model.Time, ma
 			continue
 		}
 
-		metric := client.FromLabelAdaptersToMetric(result.Labels)
+		metric := client.FromLabelAdaptersToLabels(result.Labels)
 		cs, err := chunkcompat.FromChunks(userID, metric, result.Chunks)
 		if err != nil {
 			return nil, promql.ErrStorage{Err: err}

--- a/pkg/querier/iterators/chunk_merge_iterator_test.go
+++ b/pkg/querier/iterators/chunk_merge_iterator_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -95,8 +96,8 @@ func TestChunkMergeIteratorSeek(t *testing.T) {
 }
 
 func mkChunk(t require.TestingT, mint, maxt model.Time, step time.Duration, encoding promchunk.Encoding) chunk.Chunk {
-	metric := model.Metric{
-		model.MetricNameLabel: "foo",
+	metric := labels.Labels{
+		{Name: model.MetricNameLabel, Value: "foo"},
 	}
 	pc, err := promchunk.NewForEncoding(encoding)
 	require.NoError(t, err)

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -100,7 +100,7 @@ func seriesSetToMatrix(s storage.SeriesSet) (model.Matrix, error) {
 			return nil, err
 		}
 		result = append(result, &model.SampleStream{
-			Metric: labelsToMetric(series.Labels()),
+			Metric: util.LabelsToMetric(series.Labels()),
 			Values: values,
 		})
 	}

--- a/pkg/querier/series_set.go
+++ b/pkg/querier/series_set.go
@@ -164,14 +164,6 @@ func metricToLabels(m model.Metric) labels.Labels {
 	return ls
 }
 
-func labelsToMetric(ls labels.Labels) model.Metric {
-	m := make(model.Metric, len(ls))
-	for _, l := range ls {
-		m[model.LabelName(l.Name)] = model.LabelValue(l.Value)
-	}
-	return m
-}
-
 type byLabels []storage.Series
 
 func (b byLabels) Len() int           { return len(b) }

--- a/pkg/util/chunkcompat/compat.go
+++ b/pkg/util/chunkcompat/compat.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	prom_chunk "github.com/cortexproject/cortex/pkg/chunk/encoding"
@@ -34,7 +35,7 @@ func SeriesChunksToMatrix(from, through model.Time, serieses []client.TimeSeries
 	result := model.Matrix{}
 	for _, series := range serieses {
 		metric := client.FromLabelAdaptersToMetric(series.Labels)
-		chunks, err := FromChunks("", metric, series.Chunks)
+		chunks, err := FromChunks("", client.FromLabelAdaptersToLabels(series.Labels), series.Chunks)
 		if err != nil {
 			return nil, err
 		}
@@ -57,7 +58,7 @@ func SeriesChunksToMatrix(from, through model.Time, serieses []client.TimeSeries
 }
 
 // FromChunks converts []client.Chunk to []chunk.Chunk.
-func FromChunks(userID string, metric model.Metric, in []client.Chunk) ([]chunk.Chunk, error) {
+func FromChunks(userID string, metric labels.Labels, in []client.Chunk) ([]chunk.Chunk, error) {
 	out := make([]chunk.Chunk, 0, len(in))
 	for _, i := range in {
 		o, err := prom_chunk.NewForEncoding(prom_chunk.Encoding(byte(i.Encoding)))

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// LabelsToMetric converts a Labels to Metric
+// Don't do this on any performance sensitive paths.
+func LabelsToMetric(ls labels.Labels) model.Metric {
+	m := make(model.Metric, len(ls))
+	for _, l := range ls {
+		m[model.LabelName(l.Name)] = model.LabelValue(l.Value)
+	}
+	return m
+}


### PR DESCRIPTION
This continues what was started in #1007, so now we never create a `map` for labels in the ingester.

I started on this when I noticed that index caching was taking a lot of time in `Metric.String()`.  This PR reduces that a bit, but there are further improvements that can be made to `Labels.String()`.

While fixing up the tests I noticed we go through all kinds of indirections, from chunks to matrix to series set and back again, and I started to remove some of those.  That's a tough job though, so I stopped after a few.

Benchmarks (best of 3):
Before:
```
BenchmarkEncode      	  300000	      4137 ns/op	    2978 B/op	      10 allocs/op
BenchmarkDecode1     	   50000	     29984 ns/op	  152483 B/op	      57 allocs/op
BenchmarkDecode100   	    2000	    692953 ns/op	  619859 B/op	    5234 allocs/op
BenchmarkDecode10000 	      20	 102851651 ns/op	49305985 B/op	  543190 allocs/op
BenchmarkIndexCaching 	   30000	     60016 ns/op	   12816 B/op	     188 allocs/op
```

After:
```
BenchmarkEncode      	  500000	      3699 ns/op	    2850 B/op	       8 allocs/op
BenchmarkDecode1     	   50000	     24661 ns/op	  151576 B/op	      56 allocs/op
BenchmarkDecode100   	    2000	    543184 ns/op	  548370 B/op	    5303 allocs/op
BenchmarkDecode10000 	      20	  73501908 ns/op	40227785 B/op	  530003 allocs/op
BenchmarkIndexCaching 	   30000	     43642 ns/op	   14209 B/op	     128 allocs/op
```