### PR TITLE
Retention changes for boltdb and filesystem

### DIFF
--- a/pkg/chunk/aws/dynamodb_table_client_test.go
+++ b/pkg/chunk/aws/dynamodb_table_client_test.go
@@ -167,7 +167,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 
 	// Check tables are created with autoscale
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -186,7 +186,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.OutCooldown = 200
 		tbm.ChunkTables.WriteScale.TargetValue = 90.0
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -205,7 +205,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.OutCooldown = 200
 		tbm.ChunkTables.WriteScale.TargetValue = 90.0
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,7 +225,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.Enabled = false
 		tbm.ChunkTables.WriteScale.Enabled = false
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -270,7 +270,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check legacy and latest tables do not autoscale with inactive autoscale enabled.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -286,7 +286,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check inactive tables are autoscaled even if there are less than the limit.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -303,7 +303,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check inactive tables past the limit do not autoscale but the latest N do.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/chunk/aws/dynamodb_table_client_test.go
+++ b/pkg/chunk/aws/dynamodb_table_client_test.go
@@ -167,7 +167,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 
 	// Check tables are created with autoscale
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -186,7 +186,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.OutCooldown = 200
 		tbm.ChunkTables.WriteScale.TargetValue = 90.0
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -205,7 +205,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.OutCooldown = 200
 		tbm.ChunkTables.WriteScale.TargetValue = 90.0
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,7 +225,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.Enabled = false
 		tbm.ChunkTables.WriteScale.Enabled = false
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -270,7 +270,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check legacy and latest tables do not autoscale with inactive autoscale enabled.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -286,7 +286,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check inactive tables are autoscaled even if there are less than the limit.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -303,7 +303,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check inactive tables past the limit do not autoscale but the latest N do.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -58,7 +58,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 		ChunkTables:         fixtureProvisionConfig(2, chunkWriteScale, inactiveWriteScale),
 	}
 
-	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client)
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +216,7 @@ func TestTableManagerMetricsReadAutoScaling(t *testing.T) {
 		ChunkTables:         fixtureReadProvisionConfig(chunkReadScale, inactiveReadScale),
 	}
 
-	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client)
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -58,7 +58,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 		ChunkTables:         fixtureProvisionConfig(2, chunkWriteScale, inactiveWriteScale),
 	}
 
-	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +216,7 @@ func TestTableManagerMetricsReadAutoScaling(t *testing.T) {
 		ChunkTables:         fixtureReadProvisionConfig(chunkReadScale, inactiveReadScale),
 	}
 
-	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, "")
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chunk/bucket_client.go
+++ b/pkg/chunk/bucket_client.go
@@ -1,0 +1,11 @@
+package chunk
+
+import (
+	"context"
+	"time"
+)
+
+// BucketClient is used to enforce retention on chunk buckets.
+type BucketClient interface {
+	DeleteChunksBefore(ctx context.Context, ts time.Time) error
+}

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -79,7 +79,7 @@ func newTestChunkStoreConfig(t *testing.T, schemaName string, storeCfg StoreConf
 	)
 	flagext.DefaultValues(&tbmConfig)
 	storage := NewMockStorage()
-	tableManager, err := NewTableManager(tbmConfig, schemaCfg, maxChunkAge, storage)
+	tableManager, err := NewTableManager(tbmConfig, schemaCfg, maxChunkAge, storage, "")
 	require.NoError(t, err)
 
 	err = tableManager.SyncTables(context.Background())

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -79,7 +79,7 @@ func newTestChunkStoreConfig(t *testing.T, schemaName string, storeCfg StoreConf
 	)
 	flagext.DefaultValues(&tbmConfig)
 	storage := NewMockStorage()
-	tableManager, err := NewTableManager(tbmConfig, schemaCfg, maxChunkAge, storage, "")
+	tableManager, err := NewTableManager(tbmConfig, schemaCfg, maxChunkAge, storage, nil)
 	require.NoError(t, err)
 
 	err = tableManager.SyncTables(context.Background())

--- a/pkg/chunk/local/boltdb_index_client.go
+++ b/pkg/chunk/local/boltdb_index_client.go
@@ -10,13 +10,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/util"
-	"github.com/go-kit/kit/log/level"
-
 	"github.com/etcd-io/bbolt"
+	"github.com/go-kit/kit/log/level"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 var bucketName = []byte("index")

--- a/pkg/chunk/local/boltdb_reload_test.go
+++ b/pkg/chunk/local/boltdb_reload_test.go
@@ -1,0 +1,72 @@
+package local
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/etcd-io/bbolt"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testKey  = []byte("test-key")
+	testValue  = []byte("test-value")
+)
+
+func setupDb(t *testing.T, boltdbIndexClient *boltIndexClient, dbname string) {
+	db, err := boltdbIndexClient.getDB(dbname)
+	require.NoError(t, err)
+
+	err = db.Update(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(bucketName)
+		if err != nil {
+			return err
+		}
+
+		return b.Put(testKey, testValue)
+	})
+	require.NoError(t, err)
+}
+
+func TestBoltDBReload(t *testing.T) {
+	dirname, err := ioutil.TempDir(os.TempDir(), "boltdb")
+	if err != nil {
+		return
+	}
+
+	indexClient, err := NewBoltDBIndexClient(BoltDBConfig{
+		Directory: dirname,
+	})
+
+	testDb1 := "test1"
+	testDb2 := "test2"
+
+	boltdbIndexClient := indexClient.(*boltIndexClient)
+	setupDb(t, boltdbIndexClient, testDb1)
+	setupDb(t, boltdbIndexClient, testDb2)
+
+	boltdbIndexClient.reload()
+	require.Equal(t, 2, len(boltdbIndexClient.dbs), "There should be 2 boltdbs open")
+
+	require.NoError(t, os.Remove(filepath.Join(dirname, testDb1)))
+
+	droppedDb, err := boltdbIndexClient.getDB(testDb1)
+	require.NoError(t, err)
+
+	valueFromDb := []byte{}
+	_ = droppedDb.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketName)
+		valueFromDb = b.Get(testKey)
+		return nil
+	})
+	require.Equal(t, testValue, valueFromDb, "should match value from db")
+
+	boltdbIndexClient.reload()
+
+	require.Equal(t, 1, len(boltdbIndexClient.dbs), "There should be 1 boltdb open")
+
+	boltdbIndexClient.Stop()
+	require.NoError(t, os.RemoveAll(dirname))
+}

--- a/pkg/chunk/local/boltdb_reload_test.go
+++ b/pkg/chunk/local/boltdb_reload_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	testKey  = []byte("test-key")
-	testValue  = []byte("test-value")
+	testKey   = []byte("test-key")
+	testValue = []byte("test-value")
 )
 
 func setupDb(t *testing.T, boltdbIndexClient *boltIndexClient, dbname string) {

--- a/pkg/chunk/local/boltdb_table_client.go
+++ b/pkg/chunk/local/boltdb_table_client.go
@@ -19,12 +19,19 @@ func NewTableClient(directory string) (chunk.TableClient, error) {
 
 func (c *tableClient) ListTables(ctx context.Context) ([]string, error) {
 	boltDbFiles := []string{}
-	_ = filepath.Walk(c.directory, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(c.directory, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !info.IsDir() {
 			boltDbFiles = append(boltDbFiles, info.Name())
 		}
 		return nil
 	})
+
+	if err != nil {
+		return nil, err
+	}
 	return boltDbFiles, nil
 }
 

--- a/pkg/chunk/local/boltdb_table_client.go
+++ b/pkg/chunk/local/boltdb_table_client.go
@@ -2,19 +2,30 @@ package local
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 )
 
-type tableClient struct{}
+type tableClient struct {
+	directory string
+}
 
 // NewTableClient returns a new TableClient.
-func NewTableClient() (chunk.TableClient, error) {
-	return &tableClient{}, nil
+func NewTableClient(directory string) (chunk.TableClient, error) {
+	return &tableClient{directory: directory}, nil
 }
 
 func (c *tableClient) ListTables(ctx context.Context) ([]string, error) {
-	return nil, nil
+	boltDbFiles := []string{}
+	_ = filepath.Walk(c.directory, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			boltDbFiles = append(boltDbFiles, info.Name())
+		}
+		return nil
+	})
+	return boltDbFiles, nil
 }
 
 func (c *tableClient) CreateTable(ctx context.Context, desc chunk.TableDesc) error {
@@ -22,7 +33,7 @@ func (c *tableClient) CreateTable(ctx context.Context, desc chunk.TableDesc) err
 }
 
 func (c *tableClient) DeleteTable(ctx context.Context, name string) error {
-	return nil
+	return os.Remove(filepath.Join(c.directory, name))
 }
 
 func (c *tableClient) DescribeTable(ctx context.Context, name string) (desc chunk.TableDesc, isActive bool, err error) {

--- a/pkg/chunk/local/fixtures.go
+++ b/pkg/chunk/local/fixtures.go
@@ -43,7 +43,7 @@ func (f *fixture) Clients() (
 		return
 	}
 
-	tableClient, err = NewTableClient()
+	tableClient, err = NewTableClient(f.dirname)
 	if err != nil {
 		return
 	}

--- a/pkg/chunk/local/fs_object_client_test.go
+++ b/pkg/chunk/local/fs_object_client_test.go
@@ -1,0 +1,58 @@
+package local
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFsObjectClient_DeleteChunksBefore(t *testing.T) {
+	deleteFilesOlderThan := 10 * time.Minute
+
+	fsChunksDir, err := ioutil.TempDir(os.TempDir(), "fs-chunks")
+	require.NoError(t, err)
+
+	bucketClient, err := NewBucketClient(FSConfig{
+		Directory: fsChunksDir,
+	})
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, os.RemoveAll(fsChunksDir))
+	}()
+
+	file1 := "file1"
+	file2 := "file2"
+
+	// Creating dummy files
+	require.NoError(t, os.Chdir(fsChunksDir))
+
+	f, err := os.Create(file1)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	f, err = os.Create(file2)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Verify whether all files are created
+	files, _ := ioutil.ReadDir(".")
+	require.Equal(t, 2, len(files), "Number of files should be 2")
+
+	// No files should be deleted, since all of them are not much older
+	require.NoError(t, bucketClient.DeleteChunksBefore(context.Background(), time.Now().Add(-deleteFilesOlderThan)))
+	files, _ = ioutil.ReadDir(".")
+	require.Equal(t, 2, len(files), "Number of files should be 2")
+
+	// Changing mtime of file1 to make it look older
+	require.NoError(t, os.Chtimes(file1, time.Now().Add(-deleteFilesOlderThan), time.Now().Add(-deleteFilesOlderThan)))
+	require.NoError(t, bucketClient.DeleteChunksBefore(context.Background(), time.Now().Add(-deleteFilesOlderThan)))
+
+	// Verifying whether older file got deleted
+	files, _ = ioutil.ReadDir(".")
+	require.Equal(t, 1, len(files), "Number of files should be 1 after enforcing retention")
+}

--- a/pkg/chunk/local/fs_object_client_test.go
+++ b/pkg/chunk/local/fs_object_client_test.go
@@ -16,7 +16,7 @@ func TestFsObjectClient_DeleteChunksBefore(t *testing.T) {
 	fsChunksDir, err := ioutil.TempDir(os.TempDir(), "fs-chunks")
 	require.NoError(t, err)
 
-	bucketClient, err := NewBucketClient(FSConfig{
+	bucketClient, err := NewFSObjectClient(FSConfig{
 		Directory: fsChunksDir,
 	})
 	require.NoError(t, err)

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -172,3 +172,13 @@ func NewTableClient(name string, cfg Config) (chunk.TableClient, error) {
 		return nil, fmt.Errorf("Unrecognized storage client %v, choose one of: aws, cassandra, inmemory, gcp, bigtable, bigtable-hashed", name)
 	}
 }
+
+// NewBucketClient makes a new bucket client based on the configuration.
+func NewBucketClient(name string, storageConfig Config) (chunk.BucketClient, error) {
+	switch name {
+	case "filesystem":
+		return local.NewBucketClient(storageConfig.FSConfig)
+	default:
+		return nil, fmt.Errorf("Unrecognized bucket client %v, choose one of: filesystem", name)
+	}
+}

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -174,11 +174,10 @@ func NewTableClient(name string, cfg Config) (chunk.TableClient, error) {
 }
 
 // NewBucketClient makes a new bucket client based on the configuration.
-func NewBucketClient(name string, storageConfig Config) (chunk.BucketClient, error) {
-	switch name {
-	case "filesystem":
-		return local.NewBucketClient(storageConfig.FSConfig)
-	default:
-		return nil, fmt.Errorf("Unrecognized bucket client %v, choose one of: filesystem", name)
+func NewBucketClient(storageConfig Config) (chunk.BucketClient, error) {
+	if storageConfig.FSConfig.Directory != "" {
+		return local.NewFSObjectClient(storageConfig.FSConfig)
 	}
+
+	return nil, nil
 }

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -167,7 +167,7 @@ func NewTableClient(name string, cfg Config) (chunk.TableClient, error) {
 	case "cassandra":
 		return cassandra.NewTableClient(context.Background(), cfg.CassandraStorageConfig)
 	case "boltdb":
-		return local.NewTableClient()
+		return local.NewTableClient(cfg.BoltDBConfig.Directory)
 	default:
 		return nil, fmt.Errorf("Unrecognized storage client %v, choose one of: aws, cassandra, inmemory, gcp, bigtable, bigtable-hashed", name)
 	}

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -21,6 +23,8 @@ import (
 const (
 	readLabel  = "read"
 	writeLabel = "write"
+
+	fsRetentionEnforcementInterval = 12 * time.Hour
 )
 
 var (
@@ -112,22 +116,24 @@ func (cfg *ProvisionConfig) RegisterFlags(argPrefix string, f *flag.FlagSet) {
 
 // TableManager creates and manages the provisioned throughput on DynamoDB tables
 type TableManager struct {
-	client      TableClient
-	cfg         TableManagerConfig
-	schemaCfg   SchemaConfig
-	maxChunkAge time.Duration
-	done        chan struct{}
-	wait        sync.WaitGroup
+	client                TableClient
+	cfg                   TableManagerConfig
+	schemaCfg             SchemaConfig
+	maxChunkAge           time.Duration
+	done                  chan struct{}
+	wait                  sync.WaitGroup
+	directoryFromFsConfig string
 }
 
 // NewTableManager makes a new TableManager
-func NewTableManager(cfg TableManagerConfig, schemaCfg SchemaConfig, maxChunkAge time.Duration, tableClient TableClient) (*TableManager, error) {
+func NewTableManager(cfg TableManagerConfig, schemaCfg SchemaConfig, maxChunkAge time.Duration, tableClient TableClient, directoryFromFsConfig string) (*TableManager, error) {
 	return &TableManager{
-		cfg:         cfg,
-		schemaCfg:   schemaCfg,
-		maxChunkAge: maxChunkAge,
-		client:      tableClient,
-		done:        make(chan struct{}),
+		cfg:                   cfg,
+		schemaCfg:             schemaCfg,
+		maxChunkAge:           maxChunkAge,
+		client:                tableClient,
+		done:                  make(chan struct{}),
+		directoryFromFsConfig: directoryFromFsConfig,
 	}, nil
 }
 
@@ -135,6 +141,15 @@ func NewTableManager(cfg TableManagerConfig, schemaCfg SchemaConfig, maxChunkAge
 func (m *TableManager) Start() {
 	m.wait.Add(1)
 	go m.loop()
+
+	if m.isFSRetentionEnforcementRequired() {
+		if m.directoryFromFsConfig == "" {
+			level.Error(util.Logger).Log("msg", "can't enforce filesystem retention with empty diretory path in config")
+			return
+		}
+		m.wait.Add(1)
+		go m.fsRetentionEnforcementLoop()
+	}
 }
 
 // Stop the TableManager
@@ -167,6 +182,55 @@ func (m *TableManager) loop() {
 			return
 		}
 	}
+}
+
+func (m *TableManager) fsRetentionEnforcementLoop() {
+	defer m.wait.Done()
+
+	ticker := time.NewTicker(fsRetentionEnforcementInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			err := m.enforceFSRetention()
+
+			if err != nil {
+				level.Error(util.Logger).Log("msg", "error enforcing filesystem retention", "err", err)
+			}
+		case <-m.done:
+			return
+		}
+	}
+}
+
+func (m *TableManager) isFSRetentionEnforcementRequired() bool {
+	if m.cfg.RetentionPeriod == 0 || m.cfg.RetentionDeletesEnabled {
+		return false
+	}
+
+	for _, config := range m.schemaCfg.Configs {
+		if config.ObjectType == "filesystem" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *TableManager) enforceFSRetention() error {
+	if m.isFSRetentionEnforcementRequired() {
+		return nil
+	}
+	return filepath.Walk(m.directoryFromFsConfig, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() && info.ModTime().Before(mtime.Now().Add(-m.cfg.RetentionPeriod)) {
+			level.Info(util.Logger).Log("msg", "file has exceeded the retention period, removing it", "filepath", info.Name())
+			if err := os.Remove(path); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // SyncTables will calculate the tables expected to exist, create those that do

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -2,8 +2,6 @@ package chunk
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -176,7 +174,7 @@ func TestTableManager(t *testing.T) {
 			InactiveReadThroughput:     inactiveRead,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, "")
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,7 +344,7 @@ func TestTableManagerAutoscaleInactiveOnly(t *testing.T) {
 			InactiveReadThroughput:     inactiveRead,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, "")
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -434,7 +432,7 @@ func TestTableManagerDynamicIOModeInactiveOnly(t *testing.T) {
 			InactiveThroughputOnDemandMode: true,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, "")
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -517,7 +515,7 @@ func TestTableManagerTags(t *testing.T) {
 				IndexTables: PeriodicTableConfig{},
 			}},
 		}
-		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, "")
+		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -541,7 +539,7 @@ func TestTableManagerTags(t *testing.T) {
 				},
 			}},
 		}
-		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, "")
+		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -595,7 +593,7 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 			InactiveReadThroughput:     inactiveRead,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, "")
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -693,73 +691,4 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 			{Name: chunkTablePrefix + "3", ProvisionedRead: read, ProvisionedWrite: write},
 		},
 	)
-}
-
-func TestTableManagerFSRetention(t *testing.T) {
-	fsChunksDir, err := ioutil.TempDir(os.TempDir(), "fs-chunks")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(fsChunksDir))
-	}()
-
-	file1 := "file1"
-	file2 := "file2"
-
-	tbmConfig := TableManagerConfig{
-		RetentionPeriod:         tableRetention,
-		RetentionDeletesEnabled: true,
-	}
-
-	cfg := SchemaConfig{
-		Configs: []PeriodConfig{
-			{
-				From:       model.TimeFromUnix(baseTableStart.Unix()),
-				ObjectType: "filesystem",
-			},
-		},
-	}
-
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, newMockTableClient(), fsChunksDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tableManager.cfg.RetentionPeriod = tableRetention
-	tableManager.cfg.RetentionDeletesEnabled = true
-
-	// Creating dummy files
-	require.NoError(t, os.Chdir(fsChunksDir))
-
-	f, err := os.Create(file1)
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-
-	f, err = os.Create(file2)
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-
-	// Verify whether all files are created
-	files, _ := ioutil.ReadDir(".")
-	require.Equal(t, 2, len(files), "Number of files should be 2")
-
-	// No files should be deleted after enforcing retention
-	require.NoError(t, tableManager.enforceFSRetention())
-	files, _ = ioutil.ReadDir(".")
-	require.Equal(t, 2, len(files), "Number of files should be 2")
-
-	// Changing mtime of file to expire them
-	require.NoError(t, os.Chtimes(file1, time.Now().Add(-tableRetention), time.Now().Add(-tableRetention)))
-	require.NoError(t, tableManager.enforceFSRetention())
-
-	// Verifying whether expired file got deleted
-	files, _ = ioutil.ReadDir(".")
-	require.Equal(t, 1, len(files), "Number of files should be 1 after enforcing retention")
-
-	// Disabling retention deletes and checking whether retention deletes file
-	tableManager.cfg.RetentionDeletesEnabled = false
-	require.NoError(t, os.Chtimes(file2, time.Now().Add(-tableRetention), time.Now().Add(-tableRetention)))
-	require.NoError(t, tableManager.enforceFSRetention())
-	files, _ = ioutil.ReadDir(".")
-	require.Equal(t, 1, len(files), "Number of files should be 1 after enforcing retention")
-
 }

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -38,7 +38,7 @@ func Setup(fixture Fixture, tableName string) (chunk.IndexClient, chunk.ObjectCl
 		return nil, nil, err
 	}
 
-	tableManager, err := chunk.NewTableManager(tbmConfig, schemaConfig, 12*time.Hour, tableClient)
+	tableManager, err := chunk.NewTableManager(tbmConfig, schemaConfig, 12*time.Hour, tableClient, "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -38,7 +38,7 @@ func Setup(fixture Fixture, tableName string) (chunk.IndexClient, chunk.ObjectCl
 		return nil, nil, err
 	}
 
-	tableManager, err := chunk.NewTableManager(tbmConfig, schemaConfig, 12*time.Hour, tableClient, "")
+	tableManager, err := chunk.NewTableManager(tbmConfig, schemaConfig, 12*time.Hour, tableClient, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -298,12 +298,8 @@ func (t *Cortex) initTableManager(cfg *Config) error {
 		return err
 	}
 
-	var bucketClient chunk.BucketClient
-	if cfg.Storage.FSConfig.Directory != "" {
-		var err error
-		bucketClient, err = storage.NewBucketClient("filesystem", cfg.Storage)
-		util.CheckFatal("initializing bucket client", err)
-	}
+	bucketClient, err := storage.NewBucketClient(cfg.Storage)
+	util.CheckFatal("initializing bucket client", err)
 
 	t.tableManager, err = chunk.NewTableManager(cfg.TableManager, cfg.Schema, cfg.Ingester.MaxChunkAge, tableClient, bucketClient)
 	if err != nil {

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -298,7 +298,14 @@ func (t *Cortex) initTableManager(cfg *Config) error {
 		return err
 	}
 
-	t.tableManager, err = chunk.NewTableManager(cfg.TableManager, cfg.Schema, cfg.Ingester.MaxChunkAge, tableClient)
+	var bucketClient chunk.BucketClient
+	if cfg.Storage.FSConfig.Directory != "" {
+		var err error
+		bucketClient, err = storage.NewBucketClient("filesystem", cfg.Storage)
+		util.CheckFatal("initializing bucket client", err)
+	}
+
+	t.tableManager, err = chunk.NewTableManager(cfg.TableManager, cfg.Schema, cfg.Ingester.MaxChunkAge, tableClient, bucketClient)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently, retention does not delete expired data from boltdb and filesystem.
Added retention support for boltdb by implementing methods in table client.
Table manager enforces retention periodically in a goroutine by checking mtime of all the files in the configured directory.
For object stores(GCS and S3), there is another issue open [here](https://github.com/cortexproject/cortex/issues/1381) which is under discussion.