### PR TITLE
Send chunks writes to DynamoDB in the same request as index entries

### DIFF
--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -22,6 +22,11 @@ type ObjectClient interface {
 	GetChunks(ctx context.Context, chunks []Chunk) ([]Chunk, error)
 }
 
+// ObjectAndIndexClient allows optimisations where the same client handles both
+type ObjectAndIndexClient interface {
+	PutChunkAndIndex(ctx context.Context, c Chunk, index WriteBatch) error
+}
+
 // WriteBatch represents a batch of writes.
 type WriteBatch interface {
 	Add(tableName, hashValue string, rangeValue []byte, value []byte)


### PR DESCRIPTION
A call to `PutChunks()` is always followed by a call to `BatchWrite()`; we can save CPU time and network roundtrips by putting both into the same batch sent to DynamoDB.

This brought CPU usage down around 20% when I tried it in a batch process.