### PR TITLE
Add context parameter to DB interface functions

### DIFF
--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -351,7 +351,7 @@ func (am *MultitenantAlertmanager) updateConfigs(now time.Time) error {
 // poll the configuration server. Not re-entrant.
 func (am *MultitenantAlertmanager) poll() (map[string]configs.View, error) {
 	configID := am.latestConfig
-	cfgs, err := am.configsAPI.GetAlerts(configID)
+	cfgs, err := am.configsAPI.GetAlerts(context.Background(), configID)
 	if err != nil {
 		level.Warn(util.Logger).Log("msg", "MultitenantAlertmanager: configs server poll failed", "err", err)
 		return nil, err

--- a/pkg/configs/api/api.go
+++ b/pkg/configs/api/api.go
@@ -82,7 +82,7 @@ func (a *API) getConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	logger := util.WithContext(r.Context(), util.Logger)
 
-	cfg, err := a.db.GetConfig(userID)
+	cfg, err := a.db.GetConfig(r.Context(), userID)
 	if err == sql.ErrNoRows {
 		http.Error(w, "No configuration", http.StatusNotFound)
 		return
@@ -132,7 +132,7 @@ func (a *API) setConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Invalid templates: %v", err), http.StatusBadRequest)
 		return
 	}
-	if err := a.db.SetConfig(userID, cfg); err != nil {
+	if err := a.db.SetConfig(r.Context(), userID, cfg); err != nil {
 		// XXX: Untested
 		level.Error(logger).Log("msg", "error storing config", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -206,7 +206,7 @@ func (a *API) getConfigs(w http.ResponseWriter, r *http.Request) {
 	logger := util.WithContext(r.Context(), util.Logger)
 	rawSince := r.FormValue("since")
 	if rawSince == "" {
-		cfgs, cfgErr = a.db.GetAllConfigs()
+		cfgs, cfgErr = a.db.GetAllConfigs(r.Context())
 	} else {
 		since, err := strconv.ParseUint(rawSince, 10, 0)
 		if err != nil {
@@ -214,7 +214,7 @@ func (a *API) getConfigs(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		cfgs, cfgErr = a.db.GetConfigs(configs.ID(since))
+		cfgs, cfgErr = a.db.GetConfigs(r.Context(), configs.ID(since))
 	}
 
 	if cfgErr != nil {
@@ -241,7 +241,7 @@ func (a *API) deactivateConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	logger := util.WithContext(r.Context(), util.Logger)
 
-	if err := a.db.DeactivateConfig(userID); err != nil {
+	if err := a.db.DeactivateConfig(r.Context(), userID); err != nil {
 		if err == sql.ErrNoRows {
 			level.Info(logger).Log("msg", "deactivate config - no configuration", "userID", userID)
 			http.Error(w, "No configuration", http.StatusNotFound)
@@ -263,7 +263,7 @@ func (a *API) restoreConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	logger := util.WithContext(r.Context(), util.Logger)
 
-	if err := a.db.RestoreConfig(userID); err != nil {
+	if err := a.db.RestoreConfig(r.Context(), userID); err != nil {
 		if err == sql.ErrNoRows {
 			level.Info(logger).Log("msg", "restore config - no configuration", "userID", userID)
 			http.Error(w, "No configuration", http.StatusNotFound)

--- a/pkg/configs/client/config.go
+++ b/pkg/configs/client/config.go
@@ -49,21 +49,21 @@ type instrumented struct {
 	next Client
 }
 
-func (i instrumented) GetRules(since configs.ID) (map[string]configs.VersionedRulesConfig, error) {
+func (i instrumented) GetRules(ctx context.Context, since configs.ID) (map[string]configs.VersionedRulesConfig, error) {
 	var cfgs map[string]configs.VersionedRulesConfig
 	err := instrument.CollectedRequest(context.Background(), "Configs.GetConfigs", configsRequestDuration, instrument.ErrorCode, func(_ context.Context) error {
 		var err error
-		cfgs, err = i.next.GetRules(since) // Warning: this will produce an incorrect result if the configID ever overflows
+		cfgs, err = i.next.GetRules(ctx, since) // Warning: this will produce an incorrect result if the configID ever overflows
 		return err
 	})
 	return cfgs, err
 }
 
-func (i instrumented) GetAlerts(since configs.ID) (*ConfigsResponse, error) {
+func (i instrumented) GetAlerts(ctx context.Context, since configs.ID) (*ConfigsResponse, error) {
 	var cfgs *ConfigsResponse
 	err := instrument.CollectedRequest(context.Background(), "Configs.GetConfigs", configsRequestDuration, instrument.ErrorCode, func(_ context.Context) error {
 		var err error
-		cfgs, err = i.next.GetAlerts(since) // Warning: this will produce an incorrect result if the configID ever overflows
+		cfgs, err = i.next.GetAlerts(ctx, since) // Warning: this will produce an incorrect result if the configID ever overflows
 		return err
 	})
 	return cfgs, err

--- a/pkg/configs/db/db.go
+++ b/pkg/configs/db/db.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -31,28 +32,28 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 // DB is the interface for the database.
 type DB interface {
 	// GetRulesConfig gets the user's ruler config
-	GetRulesConfig(userID string) (configs.VersionedRulesConfig, error)
+	GetRulesConfig(ctx context.Context, userID string) (configs.VersionedRulesConfig, error)
 
 	// SetRulesConfig does a compare-and-swap (CAS) on the user's rules config.
 	// `oldConfig` must precisely match the current config in order to change the config to `newConfig`.
 	// Will return `true` if the config was updated, `false` otherwise.
-	SetRulesConfig(userID string, oldConfig, newConfig configs.RulesConfig) (bool, error)
+	SetRulesConfig(ctx context.Context, userID string, oldConfig, newConfig configs.RulesConfig) (bool, error)
 
 	// GetAllRulesConfigs gets all of the ruler configs
-	GetAllRulesConfigs() (map[string]configs.VersionedRulesConfig, error)
+	GetAllRulesConfigs(ctx context.Context) (map[string]configs.VersionedRulesConfig, error)
 
 	// GetRulesConfigs gets all of the configs that have been added or have
 	// changed since the provided config.
-	GetRulesConfigs(since configs.ID) (map[string]configs.VersionedRulesConfig, error)
+	GetRulesConfigs(ctx context.Context, since configs.ID) (map[string]configs.VersionedRulesConfig, error)
 
-	GetConfig(userID string) (configs.View, error)
-	SetConfig(userID string, cfg configs.Config) error
+	GetConfig(ctx context.Context, userID string) (configs.View, error)
+	SetConfig(ctx context.Context, userID string, cfg configs.Config) error
 
-	GetAllConfigs() (map[string]configs.View, error)
-	GetConfigs(since configs.ID) (map[string]configs.View, error)
+	GetAllConfigs(ctx context.Context) (map[string]configs.View, error)
+	GetConfigs(ctx context.Context, since configs.ID) (map[string]configs.View, error)
 
-	DeactivateConfig(userID string) error
-	RestoreConfig(userID string) error
+	DeactivateConfig(ctx context.Context, userID string) error
+	RestoreConfig(ctx context.Context, userID string) error
 
 	Close() error
 }

--- a/pkg/configs/db/postgres/postgres.go
+++ b/pkg/configs/db/postgres/postgres.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -122,7 +123,7 @@ func (d DB) findConfigs(filter squirrel.Sqlizer) (map[string]configs.View, error
 }
 
 // GetConfig gets a configuration.
-func (d DB) GetConfig(userID string) (configs.View, error) {
+func (d DB) GetConfig(ctx context.Context, userID string) (configs.View, error) {
 	var cfgView configs.View
 	var cfgBytes []byte
 	var deletedAt pq.NullTime
@@ -141,7 +142,7 @@ func (d DB) GetConfig(userID string) (configs.View, error) {
 }
 
 // SetConfig sets a configuration.
-func (d DB) SetConfig(userID string, cfg configs.Config) error {
+func (d DB) SetConfig(ctx context.Context, userID string, cfg configs.Config) error {
 	if !cfg.RulesConfig.FormatVersion.IsValid() {
 		return fmt.Errorf("invalid rule format version %v", cfg.RulesConfig.FormatVersion)
 	}
@@ -158,12 +159,12 @@ func (d DB) SetConfig(userID string, cfg configs.Config) error {
 }
 
 // GetAllConfigs gets all of the configs.
-func (d DB) GetAllConfigs() (map[string]configs.View, error) {
+func (d DB) GetAllConfigs(ctx context.Context) (map[string]configs.View, error) {
 	return d.findConfigs(allConfigs)
 }
 
 // GetConfigs gets all of the configs that have changed recently.
-func (d DB) GetConfigs(since configs.ID) (map[string]configs.View, error) {
+func (d DB) GetConfigs(ctx context.Context, since configs.ID) (map[string]configs.View, error) {
 	return d.findConfigs(squirrel.And{
 		allConfigs,
 		squirrel.Gt{"id": since},
@@ -171,8 +172,8 @@ func (d DB) GetConfigs(since configs.ID) (map[string]configs.View, error) {
 }
 
 // GetRulesConfig gets the latest alertmanager config for a user.
-func (d DB) GetRulesConfig(userID string) (configs.VersionedRulesConfig, error) {
-	current, err := d.GetConfig(userID)
+func (d DB) GetRulesConfig(ctx context.Context, userID string) (configs.VersionedRulesConfig, error) {
+	current, err := d.GetConfig(ctx, userID)
 	if err != nil {
 		return configs.VersionedRulesConfig{}, err
 	}
@@ -184,10 +185,10 @@ func (d DB) GetRulesConfig(userID string) (configs.VersionedRulesConfig, error) 
 }
 
 // SetRulesConfig sets the current alertmanager config for a user.
-func (d DB) SetRulesConfig(userID string, oldConfig, newConfig configs.RulesConfig) (bool, error) {
+func (d DB) SetRulesConfig(ctx context.Context, userID string, oldConfig, newConfig configs.RulesConfig) (bool, error) {
 	updated := false
 	err := d.Transaction(func(tx DB) error {
-		current, err := d.GetConfig(userID)
+		current, err := d.GetConfig(ctx, userID)
 		if err != nil && err != sql.ErrNoRows {
 			return err
 		}
@@ -202,7 +203,7 @@ func (d DB) SetRulesConfig(userID string, oldConfig, newConfig configs.RulesConf
 			RulesConfig:        newConfig,
 		}
 		updated = true
-		return d.SetConfig(userID, new)
+		return d.SetConfig(ctx, userID, new)
 	})
 	return updated, err
 }
@@ -260,12 +261,12 @@ func (d DB) findRulesConfigs(filter squirrel.Sqlizer) (map[string]configs.Versio
 }
 
 // GetAllRulesConfigs gets all alertmanager configs for all users.
-func (d DB) GetAllRulesConfigs() (map[string]configs.VersionedRulesConfig, error) {
+func (d DB) GetAllRulesConfigs(ctx context.Context) (map[string]configs.VersionedRulesConfig, error) {
 	return d.findRulesConfigs(allConfigs)
 }
 
 // GetRulesConfigs gets all the alertmanager configs that have changed since a given config.
-func (d DB) GetRulesConfigs(since configs.ID) (map[string]configs.VersionedRulesConfig, error) {
+func (d DB) GetRulesConfigs(ctx context.Context, since configs.ID) (map[string]configs.VersionedRulesConfig, error) {
 	return d.findRulesConfigs(squirrel.And{
 		allConfigs,
 		squirrel.Gt{"id": since},
@@ -275,7 +276,7 @@ func (d DB) GetRulesConfigs(since configs.ID) (map[string]configs.VersionedRules
 // SetDeletedAtConfig sets a deletedAt for configuration
 // by adding a single new row with deleted_at set
 // the same as SetConfig is actually insert
-func (d DB) SetDeletedAtConfig(userID string, deletedAt pq.NullTime, cfg configs.Config) error {
+func (d DB) SetDeletedAtConfig(ctx context.Context, userID string, deletedAt pq.NullTime, cfg configs.Config) error {
 	cfgBytes, err := json.Marshal(cfg)
 	if err != nil {
 		return err
@@ -288,21 +289,21 @@ func (d DB) SetDeletedAtConfig(userID string, deletedAt pq.NullTime, cfg configs
 }
 
 // DeactivateConfig deactivates a configuration.
-func (d DB) DeactivateConfig(userID string) error {
-	cfg, err := d.GetConfig(userID)
+func (d DB) DeactivateConfig(ctx context.Context, userID string) error {
+	cfg, err := d.GetConfig(ctx, userID)
 	if err != nil {
 		return err
 	}
-	return d.SetDeletedAtConfig(userID, pq.NullTime{Time: time.Now(), Valid: true}, cfg.Config)
+	return d.SetDeletedAtConfig(ctx, userID, pq.NullTime{Time: time.Now(), Valid: true}, cfg.Config)
 }
 
 // RestoreConfig restores configuration.
-func (d DB) RestoreConfig(userID string) error {
-	cfg, err := d.GetConfig(userID)
+func (d DB) RestoreConfig(ctx context.Context, userID string) error {
+	cfg, err := d.GetConfig(ctx, userID)
 	if err != nil {
 		return err
 	}
-	return d.SetDeletedAtConfig(userID, pq.NullTime{}, cfg.Config)
+	return d.SetDeletedAtConfig(ctx, userID, pq.NullTime{}, cfg.Config)
 }
 
 // Transaction runs the given function in a postgres transaction. If fn returns

--- a/pkg/configs/db/timed.go
+++ b/pkg/configs/db/timed.go
@@ -35,86 +35,106 @@ func (t timed) errorCode(err error) string {
 	}
 }
 
-func (t timed) timeRequest(method string, f func(context.Context) error) error {
-	return instrument.CollectedRequest(context.TODO(), method, databaseRequestDuration, t.errorCode, f)
-}
-
-func (t timed) GetConfig(userID string) (cfg configs.View, err error) {
-	t.timeRequest("GetConfig", func(_ context.Context) error {
-		cfg, err = t.d.GetConfig(userID)
+func (t timed) GetConfig(ctx context.Context, userID string) (configs.View, error) {
+	var cfg configs.View
+	err := instrument.CollectedRequest(ctx, "DB.GetConfigs", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		var err error
+		cfg, err = t.d.GetConfig(ctx, userID) // Warning: this will produce an incorrect result if the configID ever overflows
 		return err
 	})
-	return
+	return cfg, err
 }
 
-func (t timed) SetConfig(userID string, cfg configs.Config) (err error) {
-	return t.timeRequest("SetConfig", func(_ context.Context) error {
-		return t.d.SetConfig(userID, cfg)
+func (t timed) SetConfig(ctx context.Context, userID string, cfg configs.Config) error {
+	return instrument.CollectedRequest(ctx, "DB.SetConfig", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		return t.d.SetConfig(ctx, userID, cfg) // Warning: this will produce an incorrect result if the configID ever overflows
 	})
 }
 
-func (t timed) GetAllConfigs() (cfgs map[string]configs.View, err error) {
-	t.timeRequest("GetAllConfigs", func(_ context.Context) error {
-		cfgs, err = t.d.GetAllConfigs()
+func (t timed) GetAllConfigs(ctx context.Context) (map[string]configs.View, error) {
+	var (
+		cfgs map[string]configs.View
+		err  error
+	)
+	instrument.CollectedRequest(ctx, "DB.GetAllConfigs", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		cfgs, err = t.d.GetAllConfigs(ctx)
 		return err
 	})
-	return
+
+	return cfgs, err
 }
 
-func (t timed) GetConfigs(since configs.ID) (cfgs map[string]configs.View, err error) {
-	t.timeRequest("GetConfigs", func(_ context.Context) error {
-		cfgs, err = t.d.GetConfigs(since)
+func (t timed) GetConfigs(ctx context.Context, since configs.ID) (map[string]configs.View, error) {
+	var (
+		cfgs map[string]configs.View
+	)
+	err := instrument.CollectedRequest(ctx, "DB.GetConfigs", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		var err error
+		cfgs, err = t.d.GetConfigs(ctx, since)
 		return err
 	})
-	return
+
+	return cfgs, err
 }
 
-func (t timed) DeactivateConfig(userID string) (err error) {
-	return t.timeRequest("DeactivateConfig", func(_ context.Context) error {
-		return t.d.DeactivateConfig(userID)
+func (t timed) DeactivateConfig(ctx context.Context, userID string) error {
+	return instrument.CollectedRequest(ctx, "DB.DeactivateConfig", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		return t.d.DeactivateConfig(ctx, userID)
 	})
 }
 
-func (t timed) RestoreConfig(userID string) (err error) {
-	return t.timeRequest("RestoreConfig", func(_ context.Context) error {
-		return t.d.RestoreConfig(userID)
+func (t timed) RestoreConfig(ctx context.Context, userID string) (err error) {
+	return instrument.CollectedRequest(ctx, "DB.RestoreConfig", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		return t.d.RestoreConfig(ctx, userID)
 	})
 }
 
 func (t timed) Close() error {
-	return t.timeRequest("Close", func(_ context.Context) error {
+	return instrument.CollectedRequest(context.Background(), "DB.Close", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 		return t.d.Close()
 	})
 }
 
-func (t timed) GetRulesConfig(userID string) (cfg configs.VersionedRulesConfig, err error) {
-	t.timeRequest("GetRulesConfig", func(_ context.Context) error {
-		cfg, err = t.d.GetRulesConfig(userID)
+func (t timed) GetRulesConfig(ctx context.Context, userID string) (configs.VersionedRulesConfig, error) {
+	var cfg configs.VersionedRulesConfig
+	err := instrument.CollectedRequest(ctx, "DB.GetRulesConfig", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		var err error
+		cfg, err = t.d.GetRulesConfig(ctx, userID)
 		return err
 	})
-	return
+
+	return cfg, err
 }
 
-func (t timed) SetRulesConfig(userID string, oldCfg, newCfg configs.RulesConfig) (updated bool, err error) {
-	t.timeRequest("SetRulesConfig", func(_ context.Context) error {
-		updated, err = t.d.SetRulesConfig(userID, oldCfg, newCfg)
+func (t timed) SetRulesConfig(ctx context.Context, userID string, oldCfg, newCfg configs.RulesConfig) (bool, error) {
+	var updated bool
+	err := instrument.CollectedRequest(ctx, "DB.SetRulesConfig", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		var err error
+		updated, err = t.d.SetRulesConfig(ctx, userID, oldCfg, newCfg)
 		return err
 	})
-	return
+
+	return updated, err
 }
 
-func (t timed) GetAllRulesConfigs() (cfgs map[string]configs.VersionedRulesConfig, err error) {
-	t.timeRequest("GetAllRulesConfigs", func(_ context.Context) error {
-		cfgs, err = t.d.GetAllRulesConfigs()
+func (t timed) GetAllRulesConfigs(ctx context.Context) (map[string]configs.VersionedRulesConfig, error) {
+	var cfgs map[string]configs.VersionedRulesConfig
+	err := instrument.CollectedRequest(ctx, "DB.GetAllRulesConfigs", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		var err error
+		cfgs, err = t.d.GetAllRulesConfigs(ctx)
 		return err
 	})
-	return
+
+	return cfgs, err
 }
 
-func (t timed) GetRulesConfigs(since configs.ID) (cfgs map[string]configs.VersionedRulesConfig, err error) {
-	t.timeRequest("GetRulesConfigs", func(_ context.Context) error {
-		cfgs, err = t.d.GetRulesConfigs(since)
+func (t timed) GetRulesConfigs(ctx context.Context, since configs.ID) (map[string]configs.VersionedRulesConfig, error) {
+	var cfgs map[string]configs.VersionedRulesConfig
+	err := instrument.CollectedRequest(ctx, "DB.GetRulesConfigs", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		var err error
+		cfgs, err = t.d.GetRulesConfigs(ctx, since)
 		return err
 	})
-	return
+
+	return cfgs, err
 }

--- a/pkg/configs/db/traced.go
+++ b/pkg/configs/db/traced.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cortexproject/cortex/pkg/configs"
@@ -17,34 +18,34 @@ func (t traced) trace(name string, args ...interface{}) {
 	level.Debug(util.Logger).Log("msg", fmt.Sprintf("%s: %#v", name, args))
 }
 
-func (t traced) GetConfig(userID string) (cfg configs.View, err error) {
+func (t traced) GetConfig(ctx context.Context, userID string) (cfg configs.View, err error) {
 	defer func() { t.trace("GetConfig", userID, cfg, err) }()
-	return t.d.GetConfig(userID)
+	return t.d.GetConfig(ctx, userID)
 }
 
-func (t traced) SetConfig(userID string, cfg configs.Config) (err error) {
+func (t traced) SetConfig(ctx context.Context, userID string, cfg configs.Config) (err error) {
 	defer func() { t.trace("SetConfig", userID, cfg, err) }()
-	return t.d.SetConfig(userID, cfg)
+	return t.d.SetConfig(ctx, userID, cfg)
 }
 
-func (t traced) GetAllConfigs() (cfgs map[string]configs.View, err error) {
+func (t traced) GetAllConfigs(ctx context.Context) (cfgs map[string]configs.View, err error) {
 	defer func() { t.trace("GetAllConfigs", cfgs, err) }()
-	return t.d.GetAllConfigs()
+	return t.d.GetAllConfigs(ctx)
 }
 
-func (t traced) GetConfigs(since configs.ID) (cfgs map[string]configs.View, err error) {
+func (t traced) GetConfigs(ctx context.Context, since configs.ID) (cfgs map[string]configs.View, err error) {
 	defer func() { t.trace("GetConfigs", since, cfgs, err) }()
-	return t.d.GetConfigs(since)
+	return t.d.GetConfigs(ctx, since)
 }
 
-func (t traced) DeactivateConfig(userID string) (err error) {
+func (t traced) DeactivateConfig(ctx context.Context, userID string) (err error) {
 	defer func() { t.trace("DeactivateConfig", userID, err) }()
-	return t.d.DeactivateConfig(userID)
+	return t.d.DeactivateConfig(ctx, userID)
 }
 
-func (t traced) RestoreConfig(userID string) (err error) {
+func (t traced) RestoreConfig(ctx context.Context, userID string) (err error) {
 	defer func() { t.trace("RestoreConfig", userID, err) }()
-	return t.d.RestoreConfig(userID)
+	return t.d.RestoreConfig(ctx, userID)
 }
 
 func (t traced) Close() (err error) {
@@ -52,22 +53,22 @@ func (t traced) Close() (err error) {
 	return t.d.Close()
 }
 
-func (t traced) GetRulesConfig(userID string) (cfg configs.VersionedRulesConfig, err error) {
+func (t traced) GetRulesConfig(ctx context.Context, userID string) (cfg configs.VersionedRulesConfig, err error) {
 	defer func() { t.trace("GetRulesConfig", userID, cfg, err) }()
-	return t.d.GetRulesConfig(userID)
+	return t.d.GetRulesConfig(ctx, userID)
 }
 
-func (t traced) SetRulesConfig(userID string, oldCfg, newCfg configs.RulesConfig) (updated bool, err error) {
+func (t traced) SetRulesConfig(ctx context.Context, userID string, oldCfg, newCfg configs.RulesConfig) (updated bool, err error) {
 	defer func() { t.trace("SetRulesConfig", userID, oldCfg, newCfg, updated, err) }()
-	return t.d.SetRulesConfig(userID, oldCfg, newCfg)
+	return t.d.SetRulesConfig(ctx, userID, oldCfg, newCfg)
 }
 
-func (t traced) GetAllRulesConfigs() (cfgs map[string]configs.VersionedRulesConfig, err error) {
+func (t traced) GetAllRulesConfigs(ctx context.Context) (cfgs map[string]configs.VersionedRulesConfig, err error) {
 	defer func() { t.trace("GetAllRulesConfigs", cfgs, err) }()
-	return t.d.GetAllRulesConfigs()
+	return t.d.GetAllRulesConfigs(ctx)
 }
 
-func (t traced) GetRulesConfigs(since configs.ID) (cfgs map[string]configs.VersionedRulesConfig, err error) {
+func (t traced) GetRulesConfigs(ctx context.Context, since configs.ID) (cfgs map[string]configs.VersionedRulesConfig, err error) {
 	defer func() { t.trace("GetConfigs", since, cfgs, err) }()
-	return t.d.GetRulesConfigs(since)
+	return t.d.GetRulesConfigs(ctx, since)
 }

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -61,7 +61,7 @@ func (a *API) getConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	logger := util.WithContext(r.Context(), util.Logger)
 
-	cfg, err := a.db.GetRulesConfig(userID)
+	cfg, err := a.db.GetRulesConfig(r.Context(), userID)
 	if err == sql.ErrNoRows {
 		http.Error(w, "No configuration", http.StatusNotFound)
 		return
@@ -105,7 +105,7 @@ func (a *API) casConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updated, err := a.db.SetRulesConfig(userID, updateReq.OldConfig, updateReq.NewConfig)
+	updated, err := a.db.SetRulesConfig(r.Context(), userID, updateReq.OldConfig, updateReq.NewConfig)
 	if err != nil {
 		level.Error(logger).Log("msg", "error storing config", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -2,6 +2,7 @@ package ruler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -347,7 +348,7 @@ func Test_GetAllConfigs_Empty(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	configs, err := privateAPI.GetRules(0)
+	configs, err := privateAPI.GetRules(context.Background(), 0)
 	assert.NoError(t, err, "error getting configs")
 	assert.Equal(t, 0, len(configs))
 }
@@ -361,7 +362,7 @@ func Test_GetAllConfigs(t *testing.T) {
 	config := makeRulerConfig(configs.RuleFormatV2)
 	view := post(t, userID, configs.RulesConfig{}, config)
 
-	found, err := privateAPI.GetRules(0)
+	found, err := privateAPI.GetRules(context.Background(), 0)
 	assert.NoError(t, err, "error getting configs")
 	assert.Equal(t, map[string]configs.VersionedRulesConfig{
 		userID: view,
@@ -379,7 +380,7 @@ func Test_GetAllConfigs_Newest(t *testing.T) {
 	config2 := post(t, userID, config1.Config, makeRulerConfig(configs.RuleFormatV2))
 	lastCreated := post(t, userID, config2.Config, makeRulerConfig(configs.RuleFormatV2))
 
-	found, err := privateAPI.GetRules(0)
+	found, err := privateAPI.GetRules(context.Background(), 0)
 	assert.NoError(t, err, "error getting configs")
 	assert.Equal(t, map[string]configs.VersionedRulesConfig{
 		userID: lastCreated,
@@ -395,7 +396,7 @@ func Test_GetConfigs_IncludesNewerConfigsAndExcludesOlder(t *testing.T) {
 	userID3 := makeUserID()
 	config3 := post(t, userID3, configs.RulesConfig{}, makeRulerConfig(configs.RuleFormatV2))
 
-	found, err := privateAPI.GetRules(config2.ID)
+	found, err := privateAPI.GetRules(context.Background(), config2.ID)
 	assert.NoError(t, err, "error getting configs")
 	assert.Equal(t, map[string]configs.VersionedRulesConfig{
 		userID3: config3,
@@ -440,7 +441,7 @@ func Test_AlertmanagerConfig_NotInAllConfigs(t *testing.T) {
             - name: noop`)
 	postAlertmanagerConfig(t, makeUserID(), config)
 
-	found, err := privateAPI.GetRules(0)
+	found, err := privateAPI.GetRules(context.Background(), 0)
 	assert.NoError(t, err, "error getting configs")
 	assert.Equal(t, map[string]configs.VersionedRulesConfig{}, found)
 }

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -1,6 +1,7 @@
 package ruler
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -22,11 +23,11 @@ import (
 
 type mockRuleStore struct{}
 
-func (m *mockRuleStore) GetRules(since configs.ID) (map[string]configs.VersionedRulesConfig, error) {
+func (m *mockRuleStore) GetRules(ctx context.Context, since configs.ID) (map[string]configs.VersionedRulesConfig, error) {
 	return map[string]configs.VersionedRulesConfig{}, nil
 }
 
-func (m *mockRuleStore) GetAlerts(since configs.ID) (*client_config.ConfigsResponse, error) {
+func (m *mockRuleStore) GetAlerts(ctx context.Context, since configs.ID) (*client_config.ConfigsResponse, error) {
 	return nil, nil
 }
 

--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -170,7 +170,7 @@ func (s *scheduler) poll() (map[string]configs.VersionedRulesConfig, error) {
 	configID := s.latestConfig
 	s.Unlock()
 
-	cfgs, err := s.ruleStore.GetRules(configID) // Warning: this will produce an incorrect result if the configID ever overflows
+	cfgs, err := s.ruleStore.GetRules(context.Background(), configID) // Warning: this will produce an incorrect result if the configID ever overflows
 	if err != nil {
 		level.Warn(util.Logger).Log("msg", "scheduler: configs server poll failed", "err", err)
 		return nil, err


### PR DESCRIPTION
This does not change the functionality of the DB in any way. It only passes the context as a parameter. I am working on an object store backend for rules files in GCS and want to pass a context variable. I also think it is useful to have the context in postgres if we want to add lower level instrumentation.

Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>