### PR TITLE
Updating default/example yaml file with expected ring config structure

### DIFF
--- a/cmd/cortex/single-process-config.yaml
+++ b/cmd/cortex/single-process-config.yaml
@@ -41,7 +41,8 @@ ingester:
 
     # Use an in memory ring store, so we don't need to launch a Consul.
     ring:
-      store: inmemory
+      kvstore:
+        store: inmemory
       replication_factor: 1
 
 # Use local storage - BoltDB for the index, and the filesystem


### PR DESCRIPTION
Small change to fix a fatal error in the default/demo yaml config for cortex. 

Addresses #1403 