### PR TITLE
Remove flaky TestQueryTimeout test.

### DIFF
--- a/pkg/configs/legacy_promql/engine_test.go
+++ b/pkg/configs/legacy_promql/engine_test.go
@@ -78,25 +78,6 @@ func TestQueryConcurrency(t *testing.T) {
 	}
 }
 
-func TestQueryTimeout(t *testing.T) {
-	engine := NewEngine(nil, nil, 20, 5*time.Millisecond)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
-
-	query := engine.newTestQuery(func(ctx context.Context) error {
-		time.Sleep(50 * time.Millisecond)
-		return contextDone(ctx, "test statement execution")
-	})
-
-	res := query.Exec(ctx)
-	if res.Err == nil {
-		t.Fatalf("expected timeout error but got none")
-	}
-	if _, ok := res.Err.(ErrQueryTimeout); res.Err != nil && !ok {
-		t.Fatalf("expected timeout error but got: %s", res.Err)
-	}
-}
-
 func TestQueryCancel(t *testing.T) {
 	engine := NewEngine(nil, nil, 10, 10*time.Second)
 	ctx, cancelCtx := context.WithCancel(context.Background())


### PR DESCRIPTION
We don't use the legacy promql engine; we just use the parser.  This test is flaky, and instead of figuring out why, I suggest we just delete it.

Examples:
- https://circleci.com/gh/cortexproject/cortex/6459
- https://circleci.com/gh/cortexproject/cortex/6029
- https://circleci.com/gh/cortexproject/cortex/5861

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>