### PR TITLE
Exporting metrics for alerting when there is some problem with table manager creating table or enforcing retention

### DIFF
--- a/pkg/chunk/aws/dynamodb_table_client_test.go
+++ b/pkg/chunk/aws/dynamodb_table_client_test.go
@@ -167,7 +167,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 
 	// Check tables are created with autoscale
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -186,7 +186,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.OutCooldown = 200
 		tbm.ChunkTables.WriteScale.TargetValue = 90.0
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -205,7 +205,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.OutCooldown = 200
 		tbm.ChunkTables.WriteScale.TargetValue = 90.0
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,7 +225,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.Enabled = false
 		tbm.ChunkTables.WriteScale.Enabled = false
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -270,7 +270,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check legacy and latest tables do not autoscale with inactive autoscale enabled.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -286,7 +286,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check inactive tables are autoscaled even if there are less than the limit.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -303,7 +303,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check inactive tables past the limit do not autoscale but the latest N do.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -58,7 +58,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 		ChunkTables:         fixtureProvisionConfig(2, chunkWriteScale, inactiveWriteScale),
 	}
 
-	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +216,7 @@ func TestTableManagerMetricsReadAutoScaling(t *testing.T) {
 		ChunkTables:         fixtureReadProvisionConfig(chunkReadScale, inactiveReadScale),
 	}
 
-	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -70,7 +70,7 @@ func newTestChunkStoreConfig(t require.TestingT, schemaName string, storeCfg Sto
 	require.NoError(t, err)
 	flagext.DefaultValues(&tbmConfig)
 	storage := NewMockStorage()
-	tableManager, err := NewTableManager(tbmConfig, schemaCfg, maxChunkAge, storage, nil)
+	tableManager, err := NewTableManager(tbmConfig, schemaCfg, maxChunkAge, storage, nil, nil)
 	require.NoError(t, err)
 
 	err = tableManager.SyncTables(context.Background())

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -201,7 +200,7 @@ func (m *TableManager) loop(ctx context.Context) error {
 	ticker := time.NewTicker(m.cfg.DynamoDBPollInterval)
 	defer ticker.Stop()
 
-	if err := instrument.CollectedRequest(context.Background(), "TableManager.SyncTables", syncTableDuration, instrument.ErrorCode, func(ctx context.Context) error {
+	if err := instrument.CollectedRequest(context.Background(), "TableManager.SyncTables", instrument.NewHistogramCollector(m.metrics.syncTableDuration), instrument.ErrorCode, func(ctx context.Context) error {
 		return m.SyncTables(ctx)
 	}); err != nil {
 		level.Error(util.Logger).Log("msg", "error syncing tables", "err", err)
@@ -217,7 +216,7 @@ func (m *TableManager) loop(ctx context.Context) error {
 	for {
 		select {
 		case <-ticker.C:
-			if err := instrument.CollectedRequest(context.Background(), "TableManager.SyncTables", syncTableDuration, instrument.ErrorCode, func(ctx context.Context) error {
+			if err := instrument.CollectedRequest(context.Background(), "TableManager.SyncTables", instrument.NewHistogramCollector(m.metrics.syncTableDuration), instrument.ErrorCode, func(ctx context.Context) error {
 				return m.SyncTables(ctx)
 			}); err != nil {
 				level.Error(util.Logger).Log("msg", "error syncing tables", "err", err)

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -393,7 +393,7 @@ func (m *TableManager) createTables(ctx context.Context, descriptions []TableDes
 		level.Info(util.Logger).Log("msg", "creating table", "table", desc.Name)
 		err := m.client.CreateTable(ctx, desc)
 		if err != nil {
-			numFailures += 1
+			numFailures++
 			level.Error(util.Logger).Log("msg", "error creating table", "table", desc.Name, "err", err)
 			if firstErr == nil {
 				firstErr = err
@@ -418,7 +418,7 @@ func (m *TableManager) deleteTables(ctx context.Context, descriptions []TableDes
 		level.Info(util.Logger).Log("msg", "deleting table", "table", desc.Name)
 		err := m.client.DeleteTable(ctx, desc.Name)
 		if err != nil {
-			numFailures += 1
+			numFailures++
 			level.Error(util.Logger).Log("msg", "error deleting table", "table", desc.Name, "err", err)
 			if firstErr == nil {
 				firstErr = err

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -173,7 +173,7 @@ func TestTableManager(t *testing.T) {
 			InactiveReadThroughput:     inactiveRead,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +358,7 @@ func TestTableManagerAutoscaleInactiveOnly(t *testing.T) {
 			InactiveReadThroughput:     inactiveRead,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -446,7 +446,7 @@ func TestTableManagerDynamicIOModeInactiveOnly(t *testing.T) {
 			InactiveThroughputOnDemandMode: true,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -529,7 +529,7 @@ func TestTableManagerTags(t *testing.T) {
 				IndexTables: PeriodicTableConfig{},
 			}},
 		}
-		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, nil)
+		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -553,7 +553,7 @@ func TestTableManagerTags(t *testing.T) {
 				},
 			}},
 		}
-		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, nil)
+		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -607,7 +607,7 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 			InactiveReadThroughput:     inactiveRead,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -730,6 +730,6 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 
 	// Test table manager retention not multiple of periodic config
 	tbmConfig.RetentionPeriod++
-	_, err = NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
+	_, err = NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil)
 	require.Error(t, err)
 }

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -44,7 +44,7 @@ func Setup(fixture Fixture, tableName string) (chunk.IndexClient, chunk.Client, 
 		return nil, nil, err
 	}
 
-	tableManager, err := chunk.NewTableManager(tbmConfig, schemaConfig, 12*time.Hour, tableClient, nil)
+	tableManager, err := chunk.NewTableManager(tbmConfig, schemaConfig, 12*time.Hour, tableClient, nil, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -113,7 +113,7 @@ func SetupTestChunkStore() (chunk.Store, error) {
 	)
 	flagext.DefaultValues(&tbmConfig)
 	storage := chunk.NewMockStorage()
-	tableManager, err := chunk.NewTableManager(tbmConfig, schemaCfg, 12*time.Hour, storage, nil)
+	tableManager, err := chunk.NewTableManager(tbmConfig, schemaCfg, 12*time.Hour, storage, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -468,7 +468,7 @@ func (t *Cortex) initTableManager(cfg *Config) (services.Service, error) {
 	bucketClient, err := storage.NewBucketClient(cfg.Storage)
 	util.CheckFatal("initializing bucket client", err)
 
-	t.tableManager, err = chunk.NewTableManager(cfg.TableManager, cfg.Schema, cfg.Ingester.MaxChunkAge, tableClient, bucketClient)
+	t.tableManager, err = chunk.NewTableManager(cfg.TableManager, cfg.Schema, cfg.Ingester.MaxChunkAge, tableClient, bucketClient, prometheus.DefaultRegisterer)
 	return t.tableManager, err
 }
 


### PR DESCRIPTION
Exporting table numbers, retention period and periodic table config for alerting.
This would be helpful to setup alerts for missing required tables or existence of expired tables not deleted by table manager.

Signed-off-by: Sandeep Sukhani <sandeep.d.sukhani@gmail.com>