### PR TITLE
20190523 add prom ruler endpoints

### DIFF
--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -5,15 +5,51 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 
 	"github.com/cortexproject/cortex/pkg/configs"
 	"github.com/cortexproject/cortex/pkg/configs/db"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/rules"
 	"github.com/weaveworks/common/user"
 )
+
+type status string
+
+const (
+	statusSuccess status = "success"
+	statusError   status = "error"
+)
+
+type errorType string
+
+const (
+	errorNone        errorType = ""
+	errorTimeout     errorType = "timeout"
+	errorCanceled    errorType = "canceled"
+	errorExec        errorType = "execution"
+	errorBadData     errorType = "bad_data"
+	errorInternal    errorType = "internal"
+	errorUnavailable errorType = "unavailable"
+	errorNotFound    errorType = "not_found"
+)
+
+type apiError struct {
+	typ errorType
+	err error
+}
+
+func (e *apiError) Error() string {
+	return fmt.Sprintf("%s: %s", e.typ, e.err)
+}
 
 // API implements the configs api.
 type API struct {
@@ -47,8 +83,65 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	}{
 		{"get_rules", "GET", "/api/prom/rules", a.getConfig},
 		{"cas_rules", "POST", "/api/prom/rules", a.casConfig},
+		{"get_rules_prom", "GET", "/api/prom/api/v1/rules", a.rules},
 	} {
 		r.Handle(route.path, route.handler).Methods(route.method).Name(route.name)
+	}
+}
+
+func (a *API) respond(logger log.Logger, w http.ResponseWriter, data interface{}) {
+	statusMessage := statusSuccess
+
+	b, err := json.Marshal(&response{
+		Status: statusMessage,
+		Data:   data,
+	})
+	if err != nil {
+		level.Error(logger).Log("msg", "error marshaling json response", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if n, err := w.Write(b); err != nil {
+		level.Error(logger).Log("msg", "error writing response", "bytesWritten", n, "err", err)
+	}
+}
+
+func (a *API) respondError(logger log.Logger, w http.ResponseWriter, apiErr *apiError, data interface{}) {
+	b, err := json.Marshal(&response{
+		Status:    statusError,
+		ErrorType: apiErr.typ,
+		Error:     apiErr.err.Error(),
+		Data:      data,
+	})
+	if err != nil {
+		level.Error(logger).Log("msg", "error marshaling json response", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var code int
+	switch apiErr.typ {
+	case errorBadData:
+		code = http.StatusBadRequest
+	case errorExec:
+		code = 422
+	case errorCanceled, errorTimeout:
+		code = http.StatusServiceUnavailable
+	case errorInternal:
+		code = http.StatusInternalServerError
+	case errorNotFound:
+		code = http.StatusNotFound
+	default:
+		code = http.StatusInternalServerError
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if n, err := w.Write(b); err != nil {
+		level.Error(logger).Log("msg", "error writing response", "bytesWritten", n, "err", err)
 	}
 }
 
@@ -115,4 +208,149 @@ func (a *API) casConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Supplied configuration doesn't match current configuration", http.StatusConflict)
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+type response struct {
+	Status    status      `json:"status"`
+	Data      interface{} `json:"data,omitempty"`
+	ErrorType errorType   `json:"errorType,omitempty"`
+	Error     string      `json:"error,omitempty"`
+}
+
+// Alert has info for an alert.
+type Alert struct {
+	Labels      labels.Labels `json:"labels"`
+	Annotations labels.Labels `json:"annotations"`
+	State       string        `json:"state"`
+	ActiveAt    *time.Time    `json:"activeAt,omitempty"`
+	Value       string        `json:"value"`
+}
+
+// RuleDiscovery has info for all rules
+type RuleDiscovery struct {
+	RuleGroups []*RuleGroup `json:"groups"`
+}
+
+// RuleGroup has info for rules which are part of a group
+type RuleGroup struct {
+	Name string `json:"name"`
+	File string `json:"file"`
+	// In order to preserve rule ordering, while exposing type (alerting or recording)
+	// specific properties, both alerting and recording rules are exposed in the
+	// same array.
+	Rules    []rule  `json:"rules"`
+	Interval float64 `json:"interval"`
+}
+
+type rule interface{}
+
+type alertingRule struct {
+	Name        string           `json:"name"`
+	Query       string           `json:"query"`
+	Duration    float64          `json:"duration"`
+	Labels      labels.Labels    `json:"labels"`
+	Annotations labels.Labels    `json:"annotations"`
+	Alerts      []*Alert         `json:"alerts"`
+	Health      rules.RuleHealth `json:"health"`
+	LastError   string           `json:"lastError,omitempty"`
+	// Type of an alertingRule is always "alerting".
+	Type string `json:"type"`
+}
+
+type recordingRule struct {
+	Name      string           `json:"name"`
+	Query     string           `json:"query"`
+	Labels    labels.Labels    `json:"labels,omitempty"`
+	Health    rules.RuleHealth `json:"health"`
+	LastError string           `json:"lastError,omitempty"`
+	// Type of a recordingRule is always "recording".
+	Type string `json:"type"`
+}
+
+func rulesAlertsToAPIAlerts(rulesAlerts []*rules.Alert) []*Alert {
+	apiAlerts := make([]*Alert, len(rulesAlerts))
+	for i, ruleAlert := range rulesAlerts {
+		apiAlerts[i] = &Alert{
+			Labels:      ruleAlert.Labels,
+			Annotations: ruleAlert.Annotations,
+			State:       ruleAlert.State.String(),
+			ActiveAt:    &ruleAlert.ActiveAt,
+			Value:       strconv.FormatFloat(ruleAlert.Value, 'e', -1, 64),
+		}
+	}
+
+	return apiAlerts
+}
+
+func (a *API) rules(w http.ResponseWriter, r *http.Request) {
+	userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	logger := util.WithContext(r.Context(), util.Logger)
+	ruleConfig, err := a.db.GetRulesConfig(userID)
+
+	if err != nil {
+		a.respondError(logger, w, &apiError{errorInternal, err}, nil)
+	}
+	ruleGroups, err := ruleConfig.Config.Parse()
+	if err != nil {
+		a.respondError(logger, w, &apiError{errorInternal, err}, nil)
+	}
+
+	res := &RuleDiscovery{RuleGroups: []*RuleGroup{}}
+	for i, grp := range ruleGroups {
+		meta := strings.SplitN(i, ";", 1)
+		if len(meta) != 2 {
+			level.Warn(logger).Log("msg", "rulegroup does not have filename and group name", "key", i)
+			continue
+		}
+		apiRuleGroup := &RuleGroup{
+			Name:  meta[1],
+			File:  meta[0],
+			Rules: []rule{},
+		}
+
+		for _, r := range grp {
+			var enrichedRule rule
+
+			lastError := ""
+			if r.LastError() != nil {
+				lastError = r.LastError().Error()
+			}
+
+			switch rule := r.(type) {
+			case *rules.AlertingRule:
+				enrichedRule = alertingRule{
+					Name:        rule.Name(),
+					Query:       rule.Query().String(),
+					Duration:    rule.Duration().Seconds(),
+					Labels:      rule.Labels(),
+					Annotations: rule.Annotations(),
+					Alerts:      rulesAlertsToAPIAlerts(rule.ActiveAlerts()),
+					Health:      rule.Health(),
+					LastError:   lastError,
+					Type:        "alerting",
+				}
+			case *rules.RecordingRule:
+				enrichedRule = recordingRule{
+					Name:      rule.Name(),
+					Query:     rule.Query().String(),
+					Labels:    rule.Labels(),
+					Health:    rule.Health(),
+					LastError: lastError,
+					Type:      "recording",
+				}
+			default:
+				err := errors.Errorf("failed to assert type of rule '%v'", rule.Name())
+				a.respondError(logger, w, &apiError{errorInternal, err}, nil)
+			}
+
+			apiRuleGroup.Rules = append(apiRuleGroup.Rules, enrichedRule)
+		}
+		res.RuleGroups = append(res.RuleGroups, apiRuleGroup)
+	}
+
+	a.respond(logger, w, res)
 }

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -301,7 +301,7 @@ func (a *API) rules(w http.ResponseWriter, r *http.Request) {
 
 	res := &RuleDiscovery{RuleGroups: []*RuleGroup{}}
 	for i, grp := range ruleGroups {
-		meta := strings.SplitN(i, ";", 1)
+		meta := strings.SplitN(i, ";", 2)
 		if len(meta) != 2 {
 			level.Warn(logger).Log("msg", "rulegroup does not have filename and group name", "key", i)
 			continue


### PR DESCRIPTION
Currently the ruler does not have an endpoint that returns rules in the same format as prometheus. This PR adds a rules endpoint with a return format like that of prometheus. Currently it is not complete compared to the prometheus endpoint. It does not include the state of the rules since they are returned directly from the DB and not the ruler itself.

Updating this PR to include the state of rules and alerts will require refactoring certain aspects of the HA ruler and would be better suited for another PR.