### PR TITLE
Fix Rulers Lifecycle

### DIFF
--- a/pkg/ruler/worker.go
+++ b/pkg/ruler/worker.go
@@ -46,10 +46,6 @@ func newWorker(ruler *Ruler) worker {
 }
 
 func (w *worker) Run() {
-	// Register worker with ruler wait group and report done when returned
-	w.ruler.workerWG.Add(1)
-	defer w.ruler.workerWG.Done()
-
 	for {
 		waitStart := time.Now()
 		blockedWorkers.Inc()

--- a/pkg/ruler/worker.go
+++ b/pkg/ruler/worker.go
@@ -36,28 +36,21 @@ type Worker interface {
 type worker struct {
 	scheduler *scheduler
 	ruler     *Ruler
-
-	quit chan struct{}
-	done chan struct{}
 }
 
 func newWorker(ruler *Ruler) worker {
 	return worker{
 		scheduler: ruler.scheduler,
 		ruler:     ruler,
-		quit:      make(chan struct{}),
-		done:      make(chan struct{}),
 	}
 }
 
 func (w *worker) Run() {
-	defer close(w.done)
+	// Register worker with ruler wait group and report done when returned
+	w.ruler.workerWG.Add(1)
+	defer w.ruler.workerWG.Done()
+
 	for {
-		select {
-		case <-w.quit:
-			return
-		default:
-		}
 		waitStart := time.Now()
 		blockedWorkers.Inc()
 		level.Debug(util.Logger).Log("msg", "waiting for next work item")
@@ -75,9 +68,4 @@ func (w *worker) Run() {
 		w.scheduler.workItemDone(*item)
 		level.Debug(util.Logger).Log("msg", "item handed back to queue", "item", item)
 	}
-}
-
-func (w *worker) Stop() {
-	close(w.quit)
-	<-w.done
 }


### PR DESCRIPTION
This fixes a bug in the ruler which caused it to panic when shutting down and not exit the ring. When I rebased the HA ruler PR onto the single binary PR I added back a channel that wasn't meant to be added.

This PR refactors the ruler shutdown to use a WaitGroup to ensure all of the workers can complete before returning. Instead of having a shutdown process for each worker, the workers will be signaled to shutdown by the scheduler.

Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>