### PR TITLE
Diskcache Windows Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,12 @@ jobs:
         paths:
         - images/
 
+    - run:
+        name: Build on Windows
+        command: |
+          export GOOS=windows
+          make BUILD_IN_CONTAINER=false exes
+
   deploy:
     <<: *defaults
     steps:

--- a/pkg/chunk/cache/diskcache.go
+++ b/pkg/chunk/cache/diskcache.go
@@ -16,9 +16,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/tsdb/fileutil"
-	"golang.org/x/sys/unix"
 
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/mmap"
 )
 
 var (
@@ -102,7 +102,7 @@ func newDiskcache(cfg DiskcacheConfig) (*Diskcache, error) {
 		return nil, errors.Wrap(err, "stat")
 	}
 
-	buf, err := unix.Mmap(int(f.Fd()), 0, int(info.Size()), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	buf, err := mmap.Mmap(f.Fd(), 0, int(info.Size()), mmap.READ|mmap.WRITE, mmap.SHARED)
 	if err != nil {
 		f.Close()
 		return nil, err
@@ -122,7 +122,7 @@ func newDiskcache(cfg DiskcacheConfig) (*Diskcache, error) {
 
 // Stop closes the file.
 func (d *Diskcache) Stop() error {
-	if err := unix.Munmap(d.buf); err != nil {
+	if err := mmap.Unmap(d.buf); err != nil {
 		return err
 	}
 	return d.f.Close()

--- a/pkg/util/mmap/common.go
+++ b/pkg/util/mmap/common.go
@@ -1,0 +1,16 @@
+package mmap
+
+const (
+	// RDONLY maps the memory read-only.
+	// Attempts to write to the MMap object will result in undefined behavior.
+	READ = 0
+
+	// RDWR maps the memory as read-write. Writes to the MMap object will update the
+	// underlying file.
+	WRITE = 1 << iota
+
+	// Write changes back to original file
+	SHARED = 0
+)
+
+type MMap []byte

--- a/pkg/util/mmap/common.go
+++ b/pkg/util/mmap/common.go
@@ -5,14 +5,14 @@
 package mmap
 
 const (
-	// RDONLY maps the memory read-only.
+	// READ maps the memory read-only.
 	// Attempts to write to the MMap object will result in undefined behavior.
 	READ = 0
 
-	// RDWR maps the memory as read-write. Writes to the MMap object will update the
+	// WRITE maps the memory as read-write. Writes to the MMap object will update the
 	// underlying file.
 	WRITE = 1 << iota
 
-	// Write changes back to original file
+	// SHARED makes changes be written back to original file
 	SHARED = 0
 )

--- a/pkg/util/mmap/common.go
+++ b/pkg/util/mmap/common.go
@@ -1,3 +1,7 @@
+// Package mmap implements a portable mmap interface which works on UNIX alikes and especially windows.
+// common.go:   used by all platforms
+// unix.go:     basic wrapper around unix.Mmap()
+// windows.go:  same API as the unix one, but entirely different because of .. Windows
 package mmap
 
 const (
@@ -12,5 +16,3 @@ const (
 	// Write changes back to original file
 	SHARED = 0
 )
-
-type MMap []byte

--- a/pkg/util/mmap/unix.go
+++ b/pkg/util/mmap/unix.go
@@ -1,0 +1,31 @@
+// +build darwin dragonfly freebsd linux openbsd solaris netbsd
+
+package mmap
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func Mmap(fd uintptr, offset int64, length int, inprot, inflags int) ([]byte, error) {
+	if inflags != SHARED {
+		return nil, errors.New("flags other than mmap.SHARED are not implemented")
+	}
+	flags := unix.MAP_SHARED
+
+	prot := unix.PROT_READ
+	if inprot&WRITE != 0 {
+		prot |= unix.PROT_WRITE
+	}
+
+	buf, err := unix.Mmap(int(fd), offset, length, prot, flags)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func Unmap(buf []byte) error {
+	return unix.Munmap(buf)
+}

--- a/pkg/util/mmap/unix.go
+++ b/pkg/util/mmap/unix.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// Mmap creates a new mmap
 func Mmap(fd uintptr, offset int64, length int, inprot, inflags int) ([]byte, error) {
 	if inflags != SHARED {
 		return nil, errors.New("flags other than mmap.SHARED are not implemented")
@@ -26,6 +27,7 @@ func Mmap(fd uintptr, offset int64, length int, inprot, inflags int) ([]byte, er
 	return buf, nil
 }
 
+// Unmap removes the mmap
 func Unmap(buf []byte) error {
 	return unix.Munmap(buf)
 }

--- a/pkg/util/mmap/windows.go
+++ b/pkg/util/mmap/windows.go
@@ -1,0 +1,127 @@
+// +build windows
+
+// This code is taken from
+// https://github.com/edsrzf/mmap-go/blob/master/mmap_windows.go
+// and has been slightly refactored maintain API compatibility with unix.Mmap()
+// Originally licensed under BSD3 license, all credits belong to the original author Evan Shaw.
+
+package mmap
+
+import (
+	"errors"
+	"os"
+	"reflect"
+	"sync"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type addrinfo struct {
+	file     windows.Handle
+	mapview  windows.Handle
+	writable bool
+}
+
+var handleLock sync.Mutex
+var handleMap = map[uintptr]*addrinfo{}
+
+func Mmap(fd uintptr, offset int64, length int, inprot, inflags int) ([]byte, error) {
+	prot := uint32(windows.PAGE_READONLY)
+	flags := uint32(windows.FILE_MAP_READ)
+	writable := false
+
+	if prot&WRITE != 0 {
+		prot = windows.PAGE_READWRITE
+		flags = windows.FILE_MAP_WRITE
+		writable = true
+	}
+
+	maxSizeHigh := uint32((offset + int64(length)) >> 32)
+	maxSizeLow := uint32((offset + int64(length)) & 0xFFFFFFFF)
+
+	handle, errno := windows.CreateFileMapping(windows.Handle(fd), nil, prot, maxSizeHigh, maxSizeLow, nil)
+	if handle == 0 {
+		return nil, os.NewSyscallError("CreateFileMapping", errno)
+	}
+
+	fileOffsetHigh := uint32(offset >> 32)
+	fileOffsetLow := uint32(offset & 0xFFFFFFFF)
+
+	addr, errno := windows.MapViewOfFile(handle, flags, fileOffsetHigh, fileOffsetLow, uintptr(length))
+	if addr == 0 {
+		return nil, os.NewSyscallError("MapViewOfFile", errno)
+	}
+
+	handleLock.Lock()
+	handleMap[addr] = &addrinfo{
+		file:     windows.Handle(fd),
+		mapview:  handle,
+		writable: writable,
+	}
+	handleLock.Unlock()
+
+	m := MMap{}
+	dh := m.header()
+	dh.Data = addr
+	dh.Len = length
+	dh.Cap = length
+
+	return m, nil
+}
+
+func (m *MMap) header() *reflect.SliceHeader {
+	return (*reflect.SliceHeader)(unsafe.Pointer(m))
+}
+
+func (m *MMap) addrLen() (uintptr, uintptr) {
+	header := m.header()
+	return header.Data, uintptr(header.Len)
+}
+
+func (m MMap) flush() error {
+	addr, len := m.addrLen()
+	errno := windows.FlushViewOfFile(addr, len)
+	if errno != nil {
+		return os.NewSyscallError("FlushViewOfFile", errno)
+	}
+
+	handleLock.Lock()
+	defer handleLock.Unlock()
+	handle, ok := handleMap[addr]
+	if !ok {
+		// should be impossible; we would've errored above
+		return errors.New("unknown base address")
+	}
+
+	if handle.writable {
+		if err := windows.FlushFileBuffers(handle.file); err != nil {
+			return os.NewSyscallError("FlushFileBuffers", err)
+		}
+	}
+
+	return nil
+}
+
+func Unmap(buf MMap) error {
+	if err := buf.flush(); err != nil {
+		return err
+	}
+
+	addr := buf.header().Data
+	handleLock.Lock()
+	defer handleLock.Unlock()
+
+	if err := windows.UnmapViewOfFile(addr); err != nil {
+		return err
+	}
+
+	handle, ok := handleMap[addr]
+	if !ok {
+		return errors.New("unknown base address")
+	}
+	delete(handleMap, addr)
+
+	err := windows.CloseHandle(windows.Handle(handle.mapview))
+	return os.NewSyscallError("CloseHandle", err)
+}

--- a/pkg/util/mmap/windows.go
+++ b/pkg/util/mmap/windows.go
@@ -17,6 +17,16 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// mmap on Windows is a two-step process.
+// First, we call CreateFileMapping to get a handle.
+// Then, we call MapviewToFile to get an actual pointer into memory.
+// Because we want to emulate a POSIX-style mmap, we don't want to expose
+// the handle -- only the pointer. We also want to return only a byte slice,
+// not a struct, so it's convenient to manipulate.
+
+// winmmap is required because we need to store more data on windows than what can be put into a []byte
+type winmmap []byte
+
 type addrinfo struct {
 	file     windows.Handle
 	mapview  windows.Handle
@@ -26,6 +36,7 @@ type addrinfo struct {
 var handleLock sync.Mutex
 var handleMap = map[uintptr]*addrinfo{}
 
+// Mmap creates a new mmap (windows version)
 func Mmap(fd uintptr, offset int64, length int, inprot, inflags int) ([]byte, error) {
 	prot := uint32(windows.PAGE_READONLY)
 	flags := uint32(windows.FILE_MAP_READ)
@@ -37,6 +48,10 @@ func Mmap(fd uintptr, offset int64, length int, inprot, inflags int) ([]byte, er
 		writable = true
 	}
 
+	// The maximum size is the area of the file, starting from 0,
+	// that we wish to allow to be mappable. It is the sum of
+	// the length the user requested, plus the offset where that length
+	// is starting from. This does not map the data into memory.
 	maxSizeHigh := uint32((offset + int64(length)) >> 32)
 	maxSizeLow := uint32((offset + int64(length)) & 0xFFFFFFFF)
 
@@ -45,6 +60,8 @@ func Mmap(fd uintptr, offset int64, length int, inprot, inflags int) ([]byte, er
 		return nil, os.NewSyscallError("CreateFileMapping", errno)
 	}
 
+	// Actually map a view of the data into memory. The view's size
+	// is the length the user requested.
 	fileOffsetHigh := uint32(offset >> 32)
 	fileOffsetLow := uint32(offset & 0xFFFFFFFF)
 
@@ -61,7 +78,7 @@ func Mmap(fd uintptr, offset int64, length int, inprot, inflags int) ([]byte, er
 	}
 	handleLock.Unlock()
 
-	m := MMap{}
+	m := winmmap{}
 	dh := m.header()
 	dh.Data = addr
 	dh.Len = length
@@ -70,16 +87,16 @@ func Mmap(fd uintptr, offset int64, length int, inprot, inflags int) ([]byte, er
 	return m, nil
 }
 
-func (m *MMap) header() *reflect.SliceHeader {
+func (m *winmmap) header() *reflect.SliceHeader {
 	return (*reflect.SliceHeader)(unsafe.Pointer(m))
 }
 
-func (m *MMap) addrLen() (uintptr, uintptr) {
+func (m *winmmap) addrLen() (uintptr, uintptr) {
 	header := m.header()
 	return header.Data, uintptr(header.Len)
 }
 
-func (m MMap) flush() error {
+func (m winmmap) flush() error {
 	addr, len := m.addrLen()
 	errno := windows.FlushViewOfFile(addr, len)
 	if errno != nil {
@@ -103,7 +120,8 @@ func (m MMap) flush() error {
 	return nil
 }
 
-func Unmap(buf MMap) error {
+// Unmap remotes the mmap
+func Unmap(buf winmmap) error {
 	if err := buf.flush(); err != nil {
 		return err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -465,8 +465,8 @@ golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223
 golang.org/x/sys/unix
-golang.org/x/sys/cpu
 golang.org/x/sys/windows
+golang.org/x/sys/cpu
 # golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
 golang.org/x/text/secure/bidirule
 golang.org/x/text/unicode/bidi


### PR DESCRIPTION
This PR adds Windows `mmap()` support, make [diskcache.go](https://github.com/cortexproject/cortex/blob/master/pkg/chunk/cache/diskcache.go) (and thus Cortex) to compile on Windows. Closes #1336 

Previously, the file had a dependency on `unix.Mmap()`. This has been refactored into a separate package `util/mmap` and using built constrains either the original `golang.org/x/sys/unix` implementation or the windows specific `golang.org/x/sys/windows` one is used. 

The Windows implementation is based on https://github.com/edsrzf/mmap-go/blob/master/mmap_windows.go and has been slimmed down and refactored to keep API compatibility with the original `unix.Mmap` implementation.

The tests succeed when being run natively on Windows, so it looks like as if cortex is now Windows compatible .. in case somebody ever needs this.

The CircleCI Pipeline has been extended by a new target `build-windows`, which builds only the windows binary, just to see whether it works. No container, just the binary for now.

While it might not add a lot of value to cortex, it allows dependent projects to compile on Windows, for example Loki's `promtail` grafana/loki#567