### PR TITLE
Use prometheus/tsdb in ingester.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/prometheus/common v0.3.0
 	github.com/prometheus/prometheus v0.0.0-20190417125241-3cc5f9d88062
-	github.com/prometheus/tsdb v0.7.2-0.20190506134726-2ae028114c89
+	github.com/prometheus/tsdb v0.8.0
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 	github.com/sercand/kuberesolver v2.1.0+incompatible // indirect
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,8 @@ github.com/prometheus/prometheus v0.0.0-20190417125241-3cc5f9d88062/go.mod h1:nq
 github.com/prometheus/tsdb v0.7.0/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.7.2-0.20190506134726-2ae028114c89 h1:r2TOLePIzxV3KQHQuFz5wPllXq+9Y3g0pjj989nizJo=
 github.com/prometheus/tsdb v0.7.2-0.20190506134726-2ae028114c89/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
+github.com/prometheus/tsdb v0.8.0 h1:w1tAGxsBMLkuGrFMhqgcCeBkM5d1YI24udArs+aASuQ=
+github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rlmcpherson/s3gof3r v0.5.0/go.mod h1:s7vv7SMDPInkitQMuZzH615G7yWHdrU2r/Go7Bo71Rs=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -129,7 +129,7 @@ func TestChunkCodec(t *testing.T) {
 const fixedTimestamp = model.Time(1557654321000)
 
 func encodeForCompatibilityTest(t *testing.T) {
-	dummy := dummyChunkForEncoding(fixedTimestamp, labelsForDummyChunks, encoding.Bigchunk, 1)
+	dummy := dummyChunkForEncoding(fixedTimestamp, labelsForDummyChunks, encoding.BigChunk, 1)
 	encoded, err := dummy.Encoded()
 	require.NoError(t, err)
 	fmt.Printf("%q\n%q\n", dummy.ExternalKey(), encoded)
@@ -142,7 +142,7 @@ func TestChunkDecodeBackwardsCompatibility(t *testing.T) {
 	have, err := ParseExternalKey(userID, "userID/fd3477666dacf92a:16aab37c8e8:16aab6eb768:38eb373c")
 	require.NoError(t, err)
 	require.NoError(t, have.Decode(decodeContext, rawData))
-	want := dummyChunkForEncoding(fixedTimestamp, labelsForDummyChunks, encoding.Bigchunk, 1)
+	want := dummyChunkForEncoding(fixedTimestamp, labelsForDummyChunks, encoding.BigChunk, 1)
 	// We can't just compare these two chunks, since the Bigchunk internals are different on construction and read-in.
 	// Compare the serialised version instead
 	require.NoError(t, have.Encode())

--- a/pkg/chunk/encoding/bigchunk_test.go
+++ b/pkg/chunk/encoding/bigchunk_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSliceBiggerChunk(t *testing.T) {
-	var c Chunk = newBigchunk()
+	var c Chunk = NewBigchunk()
 	for i := 0; i < 12*3600/15; i++ {
 		cs, err := c.Add(model.SamplePair{
 			Timestamp: model.Time(i * step),
@@ -60,7 +60,7 @@ func TestSliceBiggerChunk(t *testing.T) {
 
 func BenchmarkBiggerChunkMemory(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		var c Chunk = newBigchunk()
+		var c Chunk = NewBigchunk()
 		for i := 0; i < 12*3600/15; i++ {
 			cs, err := c.Add(model.SamplePair{
 				Timestamp: model.Time(i * step),
@@ -70,12 +70,12 @@ func BenchmarkBiggerChunkMemory(b *testing.B) {
 			c = cs[0]
 		}
 
-		c.(*bigchunk).printSize()
+		c.(*Bigchunk).printSize()
 	}
 }
 
 // printSize calculates various sizes of the chunk when encoded, and in memory.
-func (b *bigchunk) printSize() {
+func (b *Bigchunk) printSize() {
 	var buf bytes.Buffer
 	b.Marshal(&buf)
 

--- a/pkg/chunk/encoding/chunk_test.go
+++ b/pkg/chunk/encoding/chunk_test.go
@@ -62,7 +62,7 @@ func TestChunk(t *testing.T) {
 	}{
 		{DoubleDelta, 989},
 		{Varbit, 2048},
-		{Bigchunk, 4096},
+		{BigChunk, 4096},
 	} {
 		for samples := tc.maxSamples / 10; samples < tc.maxSamples; samples += tc.maxSamples / 10 {
 

--- a/pkg/chunk/encoding/factory.go
+++ b/pkg/chunk/encoding/factory.go
@@ -39,7 +39,7 @@ const (
 	// Varbit encoding
 	Varbit
 	// Bigchunk encoding
-	Bigchunk
+	BigChunk
 )
 
 type encoding struct {
@@ -66,10 +66,10 @@ var encodings = map[Encoding]encoding{
 			return newVarbitChunk(varbitZeroEncoding)
 		},
 	},
-	Bigchunk: {
+	BigChunk: {
 		Name: "Bigchunk",
 		New: func() Chunk {
-			return newBigchunk()
+			return NewBigchunk()
 		},
 	},
 }

--- a/pkg/ingester/query_test.go
+++ b/pkg/ingester/query_test.go
@@ -30,7 +30,7 @@ func BenchmarkQueryStream(b *testing.B) {
 		numCPUs    = 32
 	)
 
-	encoding.DefaultEncoding = encoding.Bigchunk
+	encoding.DefaultEncoding = encoding.BigChunk
 	limits.MaxSeriesPerMetric = numSeries
 	limits.MaxSeriesPerQuery = numSeries
 	cfg.FlushCheckPeriod = 15 * time.Minute
@@ -55,14 +55,14 @@ func BenchmarkQueryStream(b *testing.B) {
 			{Name: "cpu", Value: cpus[i%numCPUs]},
 		}
 
-		state, fp, series, err := ing.userStates.getOrCreateSeries(ctx, labels)
+		state, err := ing.userStates.getOrCreate(ctx)
+		require.NoError(b, err)
+
+		fp, series, err := state.getSeries(labels)
 		require.NoError(b, err)
 
 		for j := 0; j < numSamples; j++ {
-			err = series.add(model.SamplePair{
-				Value:     model.SampleValue(float64(i)),
-				Timestamp: model.Time(int64(i)),
-			})
+			err = series.add(int64(i), float64(i))
 			require.NoError(b, err)
 		}
 

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -82,27 +82,29 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 			fromIngesterID = wireSeries.FromIngesterId
 			level.Info(util.Logger).Log("msg", "processing TransferChunks request", "from_ingester", fromIngesterID)
 		}
-		userCtx := user.InjectOrgID(stream.Context(), wireSeries.UserId)
-		descs, err := fromWireChunks(wireSeries.Chunks)
-		if err != nil {
-			return err
-		}
+		/*
+			userCtx := user.InjectOrgID(stream.Context(), wireSeries.UserId)
+			descs, err := fromWireChunks(wireSeries.Chunks)
+			if err != nil {
+				return err
+			}
 
-		state, fp, series, err := userStates.getOrCreateSeries(userCtx, wireSeries.Labels)
-		if err != nil {
-			return err
-		}
-		prevNumChunks := len(series.chunkDescs)
+			state, fp, series, err := userStates.getOrCreateSeries(userCtx, wireSeries.Labels)
+			if err != nil {
+				return err
+			}
+			prevNumChunks := len(series.chunkDescs)
 
-		err = series.setChunks(descs)
-		state.fpLocker.Unlock(fp) // acquired in getOrCreateSeries
-		if err != nil {
-			return err
-		}
+			err = series.setChunks(descs)
+			state.fpLocker.Unlock(fp) // acquired in getOrCreateSeries
+			if err != nil {
+				return err
+			}
 
-		seriesReceived++
-		memoryChunks.Add(float64(len(series.chunkDescs) - prevNumChunks))
-		receivedChunks.Add(float64(len(descs)))
+			seriesReceived++
+			memoryChunks.Add(float64(len(series.chunkDescs) - prevNumChunks))
+			receivedChunks.Add(float64(len(descs)))
+		*/
 	}
 
 	if seriesReceived == 0 {

--- a/pkg/ingester/user_states.go
+++ b/pkg/ingester/user_states.go
@@ -1,0 +1,102 @@
+package ingester
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/cortexproject/cortex/pkg/util/validation"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/weaveworks/common/user"
+	"golang.org/x/net/context"
+)
+
+const metricCounterShards = 128
+
+var (
+	memUsers = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cortex_ingester_memory_users",
+		Help: "The current number of users in memory.",
+	})
+)
+
+type userStates struct {
+	states sync.Map
+	limits *validation.Overrides
+	cfg    Config
+}
+
+type metricCounterShard struct {
+	mtx sync.Mutex
+	m   map[string]int
+}
+
+func newUserStates(limits *validation.Overrides, cfg Config) *userStates {
+	return &userStates{
+		limits: limits,
+		cfg:    cfg,
+	}
+}
+
+func (us *userStates) cp() map[string]*userState {
+	states := map[string]*userState{}
+	us.states.Range(func(key, value interface{}) bool {
+		states[key.(string)] = value.(*userState)
+		return true
+	})
+	return states
+}
+
+func (us *userStates) gc() {
+	us.states.Range(func(key, value interface{}) bool {
+		state := value.(*userState)
+		if state.fpToSeries.length() == 0 {
+			us.states.Delete(key)
+		}
+		return true
+	})
+}
+
+func (us *userStates) updateRates() {
+	us.states.Range(func(key, value interface{}) bool {
+		state := value.(*userState)
+		state.ingestedAPISamples.tick()
+		state.ingestedRuleSamples.tick()
+		return true
+	})
+}
+
+func (us *userStates) get(userID string) (*userState, bool) {
+	state, ok := us.states.Load(userID)
+	if !ok {
+		return nil, ok
+	}
+	return state.(*userState), ok
+}
+
+func (us *userStates) getViaContext(ctx context.Context) (*userState, bool, error) {
+	userID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("no user id")
+	}
+	state, ok := us.get(userID)
+	return state, ok, nil
+}
+
+func (us *userStates) getOrCreate(ctx context.Context) (*userState, error) {
+	userID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("no user id")
+	}
+	state, ok := us.get(userID)
+	if !ok {
+		state := newUserState(us.cfg, userID, us.limits)
+		stored, ok := us.states.LoadOrStore(userID, state)
+		if !ok {
+			memUsers.Inc()
+		}
+		state = stored.(*userState)
+	}
+
+	return state, nil
+}

--- a/vendor/github.com/prometheus/tsdb/CHANGELOG.md
+++ b/vendor/github.com/prometheus/tsdb/CHANGELOG.md
@@ -1,7 +1,14 @@
 ## master / unreleased
- - [BUGFIX] Calling `Close` more than once on a querier returns an error instead of a panic.
- - [ENHANCEMENT] Add (again) FromData function to easily create a chunk from bytes.
 
+
+## 0.8.0
+ - [BUGFIX] Calling `Close` more than once on a querier returns an error instead of a panic.
+ - [BUGFIX] Don't panic and recover nicely when running out of disk space.
+ - [BUGFIX] Correctly handle empty labels.
+ - [BUGFIX] Don't crash on an unknown tombstone ref.
+ - [ENHANCEMENT] Re-add FromData function to create a chunk from bytes. It is used by Cortex and Thanos.
+ - [ENHANCEMENT] Simplify mergedPostings.Seek.
+ - [FEATURE]  Added `currentSegment` metric for the current WAL segment it is being written to.
 
 ## 0.7.1
  - [ENHANCEMENT] Reduce memory usage in mergedPostings.Seek

--- a/vendor/github.com/prometheus/tsdb/Makefile.common
+++ b/vendor/github.com/prometheus/tsdb/Makefile.common
@@ -69,7 +69,7 @@ else
 	GO_BUILD_PLATFORM ?= $(GOHOSTOS)-$(GOHOSTARCH)
 endif
 
-PROMU_VERSION ?= 0.3.0
+PROMU_VERSION ?= 0.4.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 GOLANGCI_LINT :=

--- a/vendor/github.com/prometheus/tsdb/head.go
+++ b/vendor/github.com/prometheus/tsdb/head.go
@@ -421,6 +421,10 @@ func (h *Head) loadWAL(r *wal.Reader) error {
 					if itv.Maxt < h.minValidTime {
 						continue
 					}
+					if m := h.series.getByID(s.ref); m == nil {
+						unknownRefs++
+						continue
+					}
 					allStones.addInterval(s.ref, itv)
 				}
 			}
@@ -754,6 +758,9 @@ func (a *headAppender) Add(lset labels.Labels, t int64, v float64) (uint64, erro
 	if t < a.minValidTime {
 		return 0, ErrOutOfBounds
 	}
+
+	// Ensure no empty labels have gotten through.
+	lset = lset.WithoutEmpty()
 
 	s, created := a.head.getOrCreate(lset.Hash(), lset)
 	if created {

--- a/vendor/github.com/prometheus/tsdb/labels/labels.go
+++ b/vendor/github.com/prometheus/tsdb/labels/labels.go
@@ -103,6 +103,23 @@ func (ls Labels) Map() map[string]string {
 	return m
 }
 
+// WithoutEmpty returns the labelset without empty labels.
+// May return the same labelset.
+func (ls Labels) WithoutEmpty() Labels {
+	for _, v := range ls {
+		if v.Value == "" {
+			els := make(Labels, 0, len(ls)-1)
+			for _, v := range ls {
+				if v.Value != "" {
+					els = append(els, v)
+				}
+			}
+			return els
+		}
+	}
+	return ls
+}
+
 // New returns a sorted Labels from the given labels.
 // The caller has to guarantee that all label names are unique.
 func New(ls ...Label) Labels {
@@ -119,7 +136,9 @@ func New(ls ...Label) Labels {
 func FromMap(m map[string]string) Labels {
 	l := make(Labels, 0, len(m))
 	for k, v := range m {
-		l = append(l, Label{Name: k, Value: v})
+		if v != "" {
+			l = append(l, Label{Name: k, Value: v})
+		}
 	}
 	sort.Sort(l)
 
@@ -133,7 +152,9 @@ func FromStrings(ss ...string) Labels {
 	}
 	var res Labels
 	for i := 0; i < len(ss); i += 2 {
-		res = append(res, Label{Name: ss[i], Value: ss[i+1]})
+		if ss[i+1] != "" {
+			res = append(res, Label{Name: ss[i], Value: ss[i+1]})
+		}
 	}
 
 	sort.Sort(res)

--- a/vendor/github.com/prometheus/tsdb/wal/wal.go
+++ b/vendor/github.com/prometheus/tsdb/wal/wal.go
@@ -171,6 +171,7 @@ type WAL struct {
 	pageCompletions prometheus.Counter
 	truncateFail    prometheus.Counter
 	truncateTotal   prometheus.Counter
+	currentSegment  prometheus.Gauge
 }
 
 // New returns a new WAL over the given directory.
@@ -218,8 +219,12 @@ func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSi
 		Name: "prometheus_tsdb_wal_truncations_total",
 		Help: "Total number of WAL truncations attempted.",
 	})
+	w.currentSegment = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_wal_segment_current",
+		Help: "WAL segment index that TSDB is currently writing to.",
+	})
 	if reg != nil {
-		reg.MustRegister(w.fsyncDuration, w.pageFlushes, w.pageCompletions, w.truncateFail, w.truncateTotal)
+		reg.MustRegister(w.fsyncDuration, w.pageFlushes, w.pageCompletions, w.truncateFail, w.truncateTotal, w.currentSegment)
 	}
 
 	_, j, err := w.Segments()
@@ -413,7 +418,7 @@ func (w *WAL) setSegment(segment *Segment) error {
 		return err
 	}
 	w.donePages = int(stat.Size() / pageSize)
-
+	w.currentSegment.Set(float64(segment.Index()))
 	return nil
 }
 
@@ -426,10 +431,10 @@ func (w *WAL) flushPage(clear bool) error {
 	p := w.page
 	clear = clear || p.full()
 
-	// No more data will fit into the page. Enqueue and clear it.
+	// No more data will fit into the page or an implicit clear.
+	// Enqueue and clear it.
 	if clear {
 		p.alloc = pageSize // Write till end of page.
-		w.pageCompletions.Inc()
 	}
 	n, err := w.segment.Write(p.buf[p.flushed:p.alloc])
 	if err != nil {
@@ -445,6 +450,7 @@ func (w *WAL) flushPage(clear bool) error {
 		p.alloc = 0
 		p.flushed = 0
 		w.donePages++
+		w.pageCompletions.Inc()
 	}
 	return nil
 }
@@ -495,10 +501,18 @@ func (w *WAL) Log(recs ...[]byte) error {
 	return nil
 }
 
-// log writes rec to the log and forces a flush of the current page if its
-// the final record of a batch, the record is bigger than the page size or
-// the current page is full.
+// log writes rec to the log and forces a flush of the current page if:
+// - the final record of a batch
+// - the record is bigger than the page size
+// - the current page is full.
 func (w *WAL) log(rec []byte, final bool) error {
+	// When the last page flush failed the page will remain full.
+	// When the page is full, need to flush it before trying to add more records to it.
+	if w.page.full() {
+		if err := w.flushPage(true); err != nil {
+			return err
+		}
+	}
 	// If the record is too big to fit within the active page in the current
 	// segment, terminate the active segment and advance to the next one.
 	// This ensures that records do not cross segment boundaries.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -343,17 +343,17 @@ github.com/prometheus/prometheus/discovery/zookeeper
 github.com/prometheus/prometheus/discovery/refresh
 github.com/prometheus/prometheus/pkg/logging
 github.com/prometheus/prometheus/util/treecache
-# github.com/prometheus/tsdb v0.7.2-0.20190506134726-2ae028114c89
+# github.com/prometheus/tsdb v0.8.0
 github.com/prometheus/tsdb/fileutil
 github.com/prometheus/tsdb/chunkenc
-github.com/prometheus/tsdb/labels
 github.com/prometheus/tsdb
-github.com/prometheus/tsdb/wal
+github.com/prometheus/tsdb/labels
 github.com/prometheus/tsdb/chunks
 github.com/prometheus/tsdb/encoding
 github.com/prometheus/tsdb/errors
 github.com/prometheus/tsdb/goversion
 github.com/prometheus/tsdb/index
+github.com/prometheus/tsdb/wal
 # github.com/samuel/go-zookeeper v0.0.0-20161028232340-1d7be4effb13
 github.com/samuel/go-zookeeper/zk
 # github.com/satori/go.uuid v1.2.0


### PR DESCRIPTION
This PR is the first attempt at using prometheus/tsdb in the ingester.

There is lots missing/TODO:
- [ ] Add series limits to TSDB to match existing Cortex limits.
- [ ] Upstream TSDB changes for exposing chunks on series interface.
- [ ] Figure out how to do per user metrics for TSDB (number of series, ingestion rate etc).
- [ ] Ensure TSDB errors for things like out-of-order etc are being handled correctly.
- [ ] Figure out how to handle transfers for TSDB.
- [ ] Figure out how to do upgrades.
- [ ] Implement flushing TSDB to object store
- [ ] Allow index entries to point to sub-objects
- [ ] Benchmark Bigtable vs in-object-store index.