### PR TITLE
Make series IDs backwards-compatible again

### DIFF
--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -131,7 +131,7 @@ func (s schema) GetLabelEntryCacheKeys(from, through model.Time, userID string, 
 		key := strings.Join([]string{
 			bucket.tableName,
 			bucket.hashKey,
-			string(sha256bytes(labels.String())),
+			string(labelsSeriesID(labels)),
 		},
 			"-",
 		)
@@ -551,7 +551,7 @@ func (v9Entries) GetWriteEntries(bucket Bucket, metricName string, labels labels
 }
 
 func (v9Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	seriesID := sha256bytes(labels.String())
+	seriesID := labelsSeriesID(labels)
 
 	entries := []IndexEntry{
 		// Entry for metricName -> seriesID
@@ -581,7 +581,7 @@ func (v9Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels l
 }
 
 func (v9Entries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	seriesID := sha256bytes(labels.String())
+	seriesID := labelsSeriesID(labels)
 	encodedThroughBytes := encodeTime(bucket.through)
 
 	entries := []IndexEntry{
@@ -647,7 +647,7 @@ func (v10Entries) GetWriteEntries(bucket Bucket, metricName string, labels label
 }
 
 func (s v10Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	seriesID := sha256bytes(labels.String())
+	seriesID := labelsSeriesID(labels)
 
 	// read first 32 bits of the hash and use this to calculate the shard
 	shard := binary.BigEndian.Uint32(seriesID) % s.rowShards
@@ -680,7 +680,7 @@ func (s v10Entries) GetLabelWriteEntries(bucket Bucket, metricName string, label
 }
 
 func (v10Entries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	seriesID := sha256bytes(labels.String())
+	seriesID := labelsSeriesID(labels)
 	encodedThroughBytes := encodeTime(bucket.through)
 
 	entries := []IndexEntry{

--- a/pkg/chunk/schema_util_test.go
+++ b/pkg/chunk/schema_util_test.go
@@ -8,45 +8,38 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/prometheus/prometheus/pkg/labels"
+
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestMetricSeriesID(t *testing.T) {
+func TestLabelSeriesID(t *testing.T) {
 	for _, c := range []struct {
-		metric   model.Metric
+		lbls     labels.Labels
 		expected string
 	}{
 		{
-			model.Metric{model.MetricNameLabel: "foo"},
+			labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}},
 			"LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564",
 		},
 		{
-			model.Metric{
-				model.MetricNameLabel: "foo",
-				"bar":                 "baz",
-				"toms":                "code",
-				"flip":                "flop",
+			labels.Labels{
+				{Name: model.MetricNameLabel, Value: "foo"},
+				{Name: "bar", Value: "baz"},
+				{Name: "flip", Value: "flop"},
+				{Name: "toms", Value: "code"},
 			},
 			"KrbXMezYneba+o7wfEdtzOdAWhbfWcDrlVfs1uOCX3M",
 		},
 		{
-			model.Metric{
-				"flip":                "flop",
-				"bar":                 "baz",
-				model.MetricNameLabel: "foo",
-				"toms":                "code",
-			},
-			"KrbXMezYneba+o7wfEdtzOdAWhbfWcDrlVfs1uOCX3M",
-		},
-		{
-			model.Metric{},
+			labels.Labels{},
 			"RBNvo1WzZ4oRRq0W9+hknpT7T8If536DEMBg9hyq/4o",
 		},
 	} {
-		seriesID := metricSeriesID(c.metric)
-		assert.Equal(t, c.expected, seriesID)
+		seriesID := string(labelsSeriesID(c.lbls))
+		assert.Equal(t, c.expected, seriesID, labelsString(c.lbls))
 	}
 }
 


### PR DESCRIPTION
#1377 caused an unforseen change in the formatting of label strings, which in turn means that the SHA is different so the series ID changes.  It's more efficient to continue with the same IDs across an
upgrade.

I noticed there was an unused function `metricSeriesID()` and a test for backwards-compatibility which would have caught this mistake, so have pressed them back into service.
