### PR TITLE
Fix bucket bounds on query metrics

### DIFF
--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -42,21 +42,21 @@ var (
 		Namespace: "cortex",
 		Name:      "chunk_store_series_pre_intersection_per_query",
 		Help:      "Distribution of #series (pre intersection) per query.",
-		// A reasonable upper bound is around 100k - 10*(8^5) = 327k.
+		// A reasonable upper bound is around 100k - 10*(8^(6-1)) = 327k.
 		Buckets: prometheus.ExponentialBuckets(10, 8, 6),
 	})
 	postIntersectionPerQuery = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "cortex",
 		Name:      "chunk_store_series_post_intersection_per_query",
 		Help:      "Distribution of #series (post intersection) per query.",
-		// A reasonable upper bound is around 100k - 10*(8^5) = 327k.
+		// A reasonable upper bound is around 100k - 10*(8^(6-1)) = 327k.
 		Buckets: prometheus.ExponentialBuckets(10, 8, 6),
 	})
 	chunksPerQuery = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "cortex",
 		Name:      "chunk_store_chunks_per_query",
 		Help:      "Distribution of #chunks per query.",
-		// For 100k series for 7 week, could be 1.2m - 10*(8^6) = 2.6m.
+		// For 100k series for 7 week, could be 1.2m - 10*(8^(7-1)) = 2.6m.
 		Buckets: prometheus.ExponentialBuckets(10, 8, 7),
 	})
 )

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -43,21 +43,21 @@ var (
 		Name:      "chunk_store_series_pre_intersection_per_query",
 		Help:      "Distribution of #series (pre intersection) per query.",
 		// A reasonable upper bound is around 100k - 10*(8^5) = 327k.
-		Buckets: prometheus.ExponentialBuckets(10, 8, 5),
+		Buckets: prometheus.ExponentialBuckets(10, 8, 6),
 	})
 	postIntersectionPerQuery = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "cortex",
 		Name:      "chunk_store_series_post_intersection_per_query",
 		Help:      "Distribution of #series (post intersection) per query.",
 		// A reasonable upper bound is around 100k - 10*(8^5) = 327k.
-		Buckets: prometheus.ExponentialBuckets(10, 8, 5),
+		Buckets: prometheus.ExponentialBuckets(10, 8, 6),
 	})
 	chunksPerQuery = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "cortex",
 		Name:      "chunk_store_chunks_per_query",
 		Help:      "Distribution of #chunks per query.",
 		// For 100k series for 7 week, could be 1.2m - 10*(8^6) = 2.6m.
-		Buckets: prometheus.ExponentialBuckets(10, 8, 6),
+		Buckets: prometheus.ExponentialBuckets(10, 8, 7),
 	})
 )
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -59,20 +59,20 @@ var (
 	queriedSamples = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name: "cortex_ingester_queried_samples",
 		Help: "The total number of samples returned from queries.",
-		// Could easily return 10m samples per query - 10*(8^7) = 20.9m.
-		Buckets: prometheus.ExponentialBuckets(10, 8, 7),
+		// Could easily return 10m samples per query - 10*(8^(8-1)) = 20.9m.
+		Buckets: prometheus.ExponentialBuckets(10, 8, 8),
 	})
 	queriedSeries = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name: "cortex_ingester_queried_series",
 		Help: "The total number of series returned from queries.",
-		// A reasonable upper bound is around 100k - 10*(8^5) = 327k.
-		Buckets: prometheus.ExponentialBuckets(10, 8, 5),
+		// A reasonable upper bound is around 100k - 10*(8^(6-1)) = 327k.
+		Buckets: prometheus.ExponentialBuckets(10, 8, 6),
 	})
 	queriedChunks = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name: "cortex_ingester_queried_chunks",
 		Help: "The total number of chunks returned from queries.",
-		// A small number of chunks per series - 10*(8^6) = 2.6m.
-		Buckets: prometheus.ExponentialBuckets(10, 8, 6),
+		// A small number of chunks per series - 10*(8^(7-1)) = 2.6m.
+		Buckets: prometheus.ExponentialBuckets(10, 8, 7),
 	})
 )
 


### PR DESCRIPTION
Previously we aren't having as many buckets as we wanted to have in the comments.