### PR TITLE
Fix wait time on DynamoDB throttling

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -271,7 +271,7 @@ func (a dynamoDBStorageClient) BatchWrite(ctx context.Context, input chunk.Write
 
 		// If there are unprocessed items, retry those items.
 		unprocessedItems := dynamoDBWriteBatch(resp.UnprocessedItems)
-		if unprocessedItems != nil && len(unprocessedItems) > 0 {
+		if len(unprocessedItems) > 0 {
 			logWriteRetry(ctx, unprocessedItems)
 			a.writeThrottle.WaitN(ctx, unprocessedItems.Len())
 			unprocessed.TakeReqs(unprocessedItems, -1)

--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -270,9 +270,10 @@ func (a dynamoDBStorageClient) BatchWrite(ctx context.Context, input chunk.Write
 		}
 
 		// If there are unprocessed items, retry those items.
-		if unprocessedItems := resp.UnprocessedItems; unprocessedItems != nil && dynamoDBWriteBatch(unprocessedItems).Len() > 0 {
-			logWriteRetry(ctx, dynamoDBWriteBatch(unprocessedItems))
-			a.writeThrottle.WaitN(ctx, len(unprocessedItems))
+		unprocessedItems := dynamoDBWriteBatch(resp.UnprocessedItems)
+		if unprocessedItems != nil && len(unprocessedItems) > 0 {
+			logWriteRetry(ctx, unprocessedItems)
+			a.writeThrottle.WaitN(ctx, unprocessedItems.Len())
 			unprocessed.TakeReqs(unprocessedItems, -1)
 		}
 


### PR DESCRIPTION
Slight bug in #1361: the `UnprocessedItems` field that comes back is a map from table to items, so we need to count all the items and wait that long, rather than just waiting one unit per table.
