### PR TITLE
TableClient for each PeriodConfig in Schema

### DIFF
--- a/pkg/chunk/aws/dynamodb_table_client_test.go
+++ b/pkg/chunk/aws/dynamodb_table_client_test.go
@@ -167,7 +167,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 
 	// Check tables are created with autoscale
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -186,7 +186,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.OutCooldown = 200
 		tbm.ChunkTables.WriteScale.TargetValue = 90.0
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -205,7 +205,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.OutCooldown = 200
 		tbm.ChunkTables.WriteScale.TargetValue = 90.0
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,7 +225,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.Enabled = false
 		tbm.ChunkTables.WriteScale.Enabled = false
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -270,7 +270,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check legacy and latest tables do not autoscale with inactive autoscale enabled.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -286,7 +286,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check inactive tables are autoscaled even if there are less than the limit.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -303,7 +303,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check inactive tables past the limit do not autoscale but the latest N do.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/chunk/aws/dynamodb_table_client_test.go
+++ b/pkg/chunk/aws/dynamodb_table_client_test.go
@@ -142,6 +142,10 @@ func test(t *testing.T, client dynamoTableClient, tableManager *chunk.TableManag
 func TestTableManagerAutoScaling(t *testing.T) {
 	dynamoDB := newMockDynamoDB(0, 0)
 	applicationAutoScaling := newMockApplicationAutoScaling()
+	clientOld := dynamoTableClient{
+		DynamoDB:  dynamoDB,
+		autoscale: &awsAutoscale{ApplicationAutoScaling: applicationAutoScaling},
+	}
 	client := dynamoTableClient{
 		DynamoDB:  dynamoDB,
 		autoscale: &awsAutoscale{ApplicationAutoScaling: applicationAutoScaling},
@@ -167,7 +171,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 
 	// Check tables are created with autoscale
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{clientOld, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -186,7 +190,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.OutCooldown = 200
 		tbm.ChunkTables.WriteScale.TargetValue = 90.0
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{clientOld, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -205,7 +209,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.OutCooldown = 200
 		tbm.ChunkTables.WriteScale.TargetValue = 90.0
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{clientOld, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,7 +229,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		tbm.IndexTables.WriteScale.Enabled = false
 		tbm.ChunkTables.WriteScale.Enabled = false
 
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{clientOld, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -244,6 +248,10 @@ func TestTableManagerAutoScaling(t *testing.T) {
 func TestTableManagerInactiveAutoScaling(t *testing.T) {
 	dynamoDB := newMockDynamoDB(0, 0)
 	applicationAutoScaling := newMockApplicationAutoScaling()
+	clientOld := dynamoTableClient{
+		DynamoDB:  dynamoDB,
+		autoscale: &awsAutoscale{ApplicationAutoScaling: applicationAutoScaling},
+	}
 	client := dynamoTableClient{
 		DynamoDB:  dynamoDB,
 		autoscale: &awsAutoscale{ApplicationAutoScaling: applicationAutoScaling},
@@ -270,7 +278,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check legacy and latest tables do not autoscale with inactive autoscale enabled.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{clientOld, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -286,7 +294,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check inactive tables are autoscaled even if there are less than the limit.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{clientOld, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -303,7 +311,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check inactive tables past the limit do not autoscale but the latest N do.
 	{
-		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
+		tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{clientOld, client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -58,7 +58,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 		ChunkTables:         fixtureProvisionConfig(2, chunkWriteScale, inactiveWriteScale),
 	}
 
-	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +216,7 @@ func TestTableManagerMetricsReadAutoScaling(t *testing.T) {
 		ChunkTables:         fixtureReadProvisionConfig(chunkReadScale, inactiveReadScale),
 	}
 
-	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil)
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -17,6 +17,17 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 	dynamoDB := newMockDynamoDB(0, 0)
 	mockProm := mockPrometheus{}
 
+	clientOld := dynamoTableClient{
+		DynamoDB: dynamoDB,
+		autoscale: &metricsData{
+			promAPI: &mockProm,
+			cfg: MetricsAutoScalingConfig{
+				TargetQueueLen: 100000,
+				ScaleUpFactor:  1.2,
+			},
+			tableLastUpdated: make(map[string]time.Time),
+		},
+	}
 	client := dynamoTableClient{
 		DynamoDB: dynamoDB,
 		autoscale: &metricsData{
@@ -58,7 +69,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 		ChunkTables:         fixtureProvisionConfig(2, chunkWriteScale, inactiveWriteScale),
 	}
 
-	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{clientOld, client}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,6 +187,18 @@ func TestTableManagerMetricsReadAutoScaling(t *testing.T) {
 	dynamoDB := newMockDynamoDB(0, 0)
 	mockProm := mockPrometheus{}
 
+	clientOld := dynamoTableClient{
+		DynamoDB: dynamoDB,
+		autoscale: &metricsData{
+			promAPI: &mockProm,
+			cfg: MetricsAutoScalingConfig{
+				TargetQueueLen: 100000,
+				ScaleUpFactor:  1.2,
+			},
+			tableLastUpdated:     make(map[string]time.Time),
+			tableReadLastUpdated: make(map[string]time.Time),
+		},
+	}
 	client := dynamoTableClient{
 		DynamoDB: dynamoDB,
 		autoscale: &metricsData{
@@ -216,7 +239,7 @@ func TestTableManagerMetricsReadAutoScaling(t *testing.T) {
 		ChunkTables:         fixtureReadProvisionConfig(chunkReadScale, inactiveReadScale),
 	}
 
-	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{client, client}, nil)
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, []chunk.TableClient{clientOld, client}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -78,7 +78,7 @@ func newTestChunkStoreConfig(t require.TestingT, schemaName string, storeCfg Sto
 	)
 	flagext.DefaultValues(&tbmConfig)
 	storage := NewMockStorage()
-	tableManager, err := NewTableManager(tbmConfig, schemaCfg, maxChunkAge, storage, nil)
+	tableManager, err := NewTableManager(tbmConfig, schemaCfg, maxChunkAge, []TableClient{storage}, nil)
 	require.NoError(t, err)
 
 	err = tableManager.SyncTables(context.Background())

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -120,6 +120,8 @@ var inactiveScalingConfig = AutoScalingConfig{
 }
 
 func TestTableManager(t *testing.T) {
+	clientOld1 := newMockTableClient()
+	clientOld2 := newMockTableClient()
 	client := newMockTableClient()
 
 	cfg := SchemaConfig{
@@ -174,7 +176,7 @@ func TestTableManager(t *testing.T) {
 			InactiveReadThroughput:     inactiveRead,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, []TableClient{client}, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, []TableClient{clientOld1, clientOld2, client}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,6 +305,7 @@ func TestTableManager(t *testing.T) {
 }
 
 func TestTableManagerAutoscaleInactiveOnly(t *testing.T) {
+	clientOld := newMockTableClient()
 	client := newMockTableClient()
 
 	cfg := SchemaConfig{
@@ -344,7 +347,7 @@ func TestTableManagerAutoscaleInactiveOnly(t *testing.T) {
 			InactiveReadThroughput:     inactiveRead,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, []TableClient{client}, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, []TableClient{clientOld, client}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -389,6 +392,7 @@ func TestTableManagerAutoscaleInactiveOnly(t *testing.T) {
 }
 
 func TestTableManagerDynamicIOModeInactiveOnly(t *testing.T) {
+	clientOld := newMockTableClient()
 	client := newMockTableClient()
 
 	cfg := SchemaConfig{
@@ -432,7 +436,7 @@ func TestTableManagerDynamicIOModeInactiveOnly(t *testing.T) {
 			InactiveThroughputOnDemandMode: true,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, []TableClient{client}, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, []TableClient{clientOld, client}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -174,7 +174,7 @@ func TestTableManager(t *testing.T) {
 			InactiveReadThroughput:     inactiveRead,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, []TableClient{client}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -344,7 +344,7 @@ func TestTableManagerAutoscaleInactiveOnly(t *testing.T) {
 			InactiveReadThroughput:     inactiveRead,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, []TableClient{client}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +432,7 @@ func TestTableManagerDynamicIOModeInactiveOnly(t *testing.T) {
 			InactiveThroughputOnDemandMode: true,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, []TableClient{client}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -515,7 +515,7 @@ func TestTableManagerTags(t *testing.T) {
 				IndexTables: PeriodicTableConfig{},
 			}},
 		}
-		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, nil)
+		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, []TableClient{client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -539,7 +539,7 @@ func TestTableManagerTags(t *testing.T) {
 				},
 			}},
 		}
-		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, nil)
+		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, []TableClient{client}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -593,7 +593,7 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 			InactiveReadThroughput:     inactiveRead,
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, []TableClient{client}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -40,7 +40,7 @@ func Setup(fixture Fixture, tableName string) (chunk.IndexClient, chunk.ObjectCl
 		return nil, nil, err
 	}
 
-	tableManager, err := chunk.NewTableManager(tbmConfig, schemaConfig, 12*time.Hour, tableClient, nil)
+	tableManager, err := chunk.NewTableManager(tbmConfig, schemaConfig, 12*time.Hour, []chunk.TableClient{tableClient}, nil)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Attempt to fix https://github.com/cortexproject/cortex/issues/1382

This PR creates a TableClient for all the past configs and deletes tables from all the clients in `SyncTables`.