### PR TITLE
Add user_stats handler back on querier

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -168,7 +168,6 @@ func (t *Cortex) initDistributor(cfg *Config) (err error) {
 		return
 	}
 
-	t.server.HTTP.HandleFunc("/user_stats", t.distributor.UserStatsHandler)
 	t.server.HTTP.HandleFunc("/all_user_stats", t.distributor.AllUserStatsHandler)
 	t.server.HTTP.Handle("/api/prom/push", t.httpAuthMiddleware.Wrap(http.HandlerFunc(t.distributor.PushHandler)))
 	return
@@ -209,6 +208,7 @@ func (t *Cortex) initQuerier(cfg *Config) (err error) {
 	subrouter.Path("/read").Handler(t.httpAuthMiddleware.Wrap(querier.RemoteReadHandler(queryable)))
 	subrouter.Path("/validate_expr").Handler(t.httpAuthMiddleware.Wrap(http.HandlerFunc(t.distributor.ValidateExprHandler)))
 	subrouter.Path("/chunks").Handler(t.httpAuthMiddleware.Wrap(querier.ChunksHandler(queryable)))
+	subrouter.Path("/user_stats").Handler(middleware.AuthenticateUser.Wrap(http.HandlerFunc(t.distributor.UserStatsHandler)))
 	return
 }
 


### PR DESCRIPTION
It moved accidentally to distributor in the single-binary change https://github.com/cortexproject/cortex/pull/1262

I don't think it would work without the "authenticator" wrapper, so have removed the incorrect version.