### PR TITLE
Fix querystream batching

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -93,7 +93,7 @@ func buildTestMatrix(numSeries int, samplesPerSeries int, offset int) model.Matr
 		ss := model.SampleStream{
 			Metric: model.Metric{
 				model.MetricNameLabel: model.LabelValue(fmt.Sprintf("testmetric_%d", i)),
-				model.JobLabel:        "testjob",
+				model.JobLabel:        model.LabelValue(fmt.Sprintf("testjob%d", i%2)),
 			},
 			Values: make([]model.SamplePair, 0, samplesPerSeries),
 		}

--- a/pkg/ingester/user_state_test.go
+++ b/pkg/ingester/user_state_test.go
@@ -15,17 +15,33 @@ import (
 
 // Test forSeriesMatching correctly batches up series.
 func TestForSeriesMatchingBatching(t *testing.T) {
+	matchAllNames, err := labels.NewMatcher(labels.MatchRegexp, model.MetricNameLabel, ".+")
+	require.NoError(t, err)
+	// We rely on pushTestSamples() creating jobs "testjob0" and "testjob1" in equal parts
+	matchNotJob0, err := labels.NewMatcher(labels.MatchNotEqual, model.JobLabel, "testjob0")
+	require.NoError(t, err)
+	matchNotJob1, err := labels.NewMatcher(labels.MatchNotEqual, model.JobLabel, "testjob1")
+	require.NoError(t, err)
+
 	for _, tc := range []struct {
 		numSeries, batchSize int
+		matchers             []*labels.Matcher
+		expected             int
 	}{
-		{100, 10},
-		{99, 10},
-		{98, 10},
-		{5, 10},
-		{10, 1},
-		{1, 1},
+		{100, 10, []*labels.Matcher{matchAllNames}, 100},
+		{99, 10, []*labels.Matcher{matchAllNames}, 99},
+		{98, 10, []*labels.Matcher{matchAllNames}, 98},
+		{5, 10, []*labels.Matcher{matchAllNames}, 5},
+		{10, 1, []*labels.Matcher{matchAllNames}, 10},
+		{1, 1, []*labels.Matcher{matchAllNames}, 1},
+		{10, 10, []*labels.Matcher{matchAllNames, matchNotJob0}, 5},
+		{10, 10, []*labels.Matcher{matchAllNames, matchNotJob1}, 5},
+		{100, 10, []*labels.Matcher{matchAllNames, matchNotJob0}, 50},
+		{100, 10, []*labels.Matcher{matchAllNames, matchNotJob1}, 50},
+		{99, 10, []*labels.Matcher{matchAllNames, matchNotJob0}, 49},
+		{99, 10, []*labels.Matcher{matchAllNames, matchNotJob1}, 50},
 	} {
-		t.Run(fmt.Sprintf("numSeries=%d,batchSize=%d", tc.numSeries, tc.batchSize), func(t *testing.T) {
+		t.Run(fmt.Sprintf("numSeries=%d,batchSize=%d,matchers=%s", tc.numSeries, tc.batchSize, tc.matchers), func(t *testing.T) {
 			_, ing := newDefaultTestStore(t)
 			userIDs, _ := pushTestSamples(t, ing, tc.numSeries, 100)
 
@@ -35,26 +51,23 @@ func TestForSeriesMatchingBatching(t *testing.T) {
 				require.NoError(t, err)
 				require.True(t, ok)
 
-				matcher, err := labels.NewMatcher(labels.MatchRegexp, model.MetricNameLabel, ".+")
-				require.NoError(t, err)
-
 				total, batch, batches := 0, 0, 0
-				err = instance.forSeriesMatching(ctx, []*labels.Matcher{matcher},
+				err = instance.forSeriesMatching(ctx, tc.matchers,
 					func(_ context.Context, _ model.Fingerprint, s *memorySeries) error {
-						total++
 						batch++
 						return nil
 					},
 					func(context.Context) error {
 						require.True(t, batch <= tc.batchSize)
+						total += batch
 						batch = 0
 						batches++
 						return nil
 					},
 					tc.batchSize)
 				require.NoError(t, err)
-				require.Equal(t, tc.numSeries, total)
-				require.Equal(t, int(math.Ceil(float64(tc.numSeries)/float64(tc.batchSize))), batches)
+				require.Equal(t, tc.expected, total)
+				require.Equal(t, int(math.Ceil(float64(tc.expected)/float64(tc.batchSize))), batches)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #1457 

Triggering the bug requires a "filter", i.e. a condition that will match the empty string, so I extended the test and test data to allow that.  Also made the test check that the batches added up to the expected total.

Then in `forSeriesMatching()`, simply counting series _sent_ instead of _checked_ gives the correct result in all the cases I could think of.