### PR TITLE
Return a NopIterator when bigchunk is empty

### DIFF
--- a/pkg/chunk/encoding/bigchunk.go
+++ b/pkg/chunk/encoding/bigchunk.go
@@ -170,9 +170,15 @@ func (b *bigchunk) Size() int {
 }
 
 func (b *bigchunk) NewIterator() Iterator {
+	var it chunkenc.Iterator
+	if len(b.chunks) > 0 {
+		it = b.chunks[0].Iterator()
+	} else {
+		it = chunkenc.NewNopIterator()
+	}
 	return &bigchunkIterator{
 		bigchunk: b,
-		curr:     b.chunks[0].Iterator(),
+		curr:     it,
 	}
 }
 


### PR DESCRIPTION
This is an alternative to #1355 
Fixes #1354 (although that is already marked as fixed)