### PR TITLE
Leave Server module running until end of shutdown

### DIFF
--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -221,17 +221,13 @@ func (t *Cortex) Run() error {
 
 // Stop gracefully stops a Cortex.
 func (t *Cortex) Stop() error {
-	t.stop(t.target)
-	return nil
-}
-
-func (t *Cortex) stop(m moduleName) {
-	t.stopModule(m)
-	deps := orderedDeps(m)
+	t.stopModule(t.target)
+	deps := orderedDeps(t.target)
 	// iterate over our deps in reverse order and call stopModule
 	for i := len(deps) - 1; i >= 0; i-- {
 		t.stopModule(deps[i])
 	}
+	return nil
 }
 
 func (t *Cortex) stopModule(m moduleName) {

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -221,7 +221,6 @@ func (t *Cortex) Run() error {
 
 // Stop gracefully stops a Cortex.
 func (t *Cortex) Stop() error {
-	t.server.Shutdown()
 	t.stop(t.target)
 	return nil
 }


### PR DESCRIPTION
Fixes #1447 

We want the process to answer requests (including status and metrics) until it has finished shutting down.

Every target depends on Server, so it will get shut down as a dependency.
