### PR TITLE
add options for boltdb_index_client to avoid dead loop

### DIFF
--- a/pkg/chunk/local/boltdb_index_client.go
+++ b/pkg/chunk/local/boltdb_index_client.go
@@ -140,7 +140,8 @@ func (b *boltIndexClient) getDB(name string) (*bbolt.DB, error) {
 	}
 
 	// Open the database.
-	db, err := bbolt.Open(path.Join(b.cfg.Directory, name), 0666, nil)
+	// Set Timeout to avoid obtaining file lock wait indefinitely.
+	db, err := bbolt.Open(path.Join(b.cfg.Directory, name), 0666, &bbolt.Options{Timeout: 5 * time.Second})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As part of solution for https://github.com/grafana/loki/issues/685, the purpose is to avoid opening boltdb fall into dead loop. 

