### PR TITLE
Add BenchmarkChunkQueryableFromTar

### DIFF
--- a/pkg/querier/querier_benchmark_test.go
+++ b/pkg/querier/querier_benchmark_test.go
@@ -1,10 +1,18 @@
 package querier
 
 import (
+	"context"
 	"fmt"
+	"math"
+	"os"
 	"testing"
+	"time"
 
+	"github.com/cortexproject/cortex/pkg/querier/batch"
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
 )
 
 var result *promql.Result
@@ -27,4 +35,55 @@ func BenchmarkChunkQueryable(b *testing.B) {
 			}
 		}
 	}
+}
+
+func BenchmarkChunkQueryableFromTar(b *testing.B) {
+	chunksFilename := os.Getenv("CHUNKS")
+	if len(chunksFilename) == 0 {
+		return
+	}
+
+	query := os.Getenv("QUERY")
+	if len(query) == 0 {
+		return
+	}
+
+	userID := os.Getenv("USERID")
+	if len(query) == 0 {
+		return
+	}
+
+	from, err := parseTime(os.Getenv("FROM"))
+	require.NoError(b, err)
+
+	through, err := parseTime(os.Getenv("THROUGH"))
+	require.NoError(b, err)
+
+	step, err := parseDuration(os.Getenv("STEP"))
+	require.NoError(b, err)
+
+	chunks, err := loadChunks(userID, chunksFilename)
+	require.NoError(b, err)
+
+	store := mockChunkStore{chunks}
+
+	b.Run(fmt.Sprintf("file=\"%s\",query=%s,from=%d,to=%d,step=%f", chunksFilename, query, from.Unix(), through.Unix(), step.Seconds()), func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		queryable := newChunkStoreQueryable(store, batch.NewChunkMergeIterator)
+		engine := promql.NewEngine(promql.EngineOpts{
+			Logger:        util.Logger,
+			MaxConcurrent: 1,
+			MaxSamples:    math.MaxInt32,
+			Timeout:       10 * time.Minute,
+		})
+		rangeQuery, err := engine.NewRangeQuery(queryable, query, from, through, step)
+		require.NoError(b, err)
+
+		ctx := user.InjectOrgID(context.Background(), "0")
+		r := rangeQuery.Exec(ctx)
+		_, err = r.Matrix()
+		require.NoError(b, err)
+	})
 }

--- a/pkg/querier/querier_benchmark_test.go
+++ b/pkg/querier/querier_benchmark_test.go
@@ -1,18 +1,10 @@
 package querier
 
 import (
-	"context"
 	"fmt"
-	"math"
-	"os"
 	"testing"
-	"time"
 
-	"github.com/cortexproject/cortex/pkg/querier/batch"
-	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/stretchr/testify/require"
-	"github.com/weaveworks/common/user"
 )
 
 var result *promql.Result
@@ -38,52 +30,9 @@ func BenchmarkChunkQueryable(b *testing.B) {
 }
 
 func BenchmarkChunkQueryableFromTar(b *testing.B) {
-	chunksFilename := os.Getenv("CHUNKS")
-	if len(chunksFilename) == 0 {
-		return
-	}
-
-	query := os.Getenv("QUERY")
-	if len(query) == 0 {
-		return
-	}
-
-	userID := os.Getenv("USERID")
-	if len(query) == 0 {
-		return
-	}
-
-	from, err := parseTime(os.Getenv("FROM"))
-	require.NoError(b, err)
-
-	through, err := parseTime(os.Getenv("THROUGH"))
-	require.NoError(b, err)
-
-	step, err := parseDuration(os.Getenv("STEP"))
-	require.NoError(b, err)
-
-	chunks, err := loadChunks(userID, chunksFilename)
-	require.NoError(b, err)
-
-	store := mockChunkStore{chunks}
-
-	b.Run(fmt.Sprintf("file=\"%s\",query=%s,from=%d,to=%d,step=%f", chunksFilename, query, from.Unix(), through.Unix(), step.Seconds()), func(b *testing.B) {
+	query, from, through, step, store := getTarDataFromEnv(b)
+	b.Run(fmt.Sprintf("query=%s,from=%d,to=%d,step=%f", query, from.Unix(), through.Unix(), step.Seconds()), func(b *testing.B) {
 		b.ResetTimer()
-		b.ReportAllocs()
-
-		queryable := newChunkStoreQueryable(store, batch.NewChunkMergeIterator)
-		engine := promql.NewEngine(promql.EngineOpts{
-			Logger:        util.Logger,
-			MaxConcurrent: 1,
-			MaxSamples:    math.MaxInt32,
-			Timeout:       10 * time.Minute,
-		})
-		rangeQuery, err := engine.NewRangeQuery(queryable, query, from, through, step)
-		require.NoError(b, err)
-
-		ctx := user.InjectOrgID(context.Background(), "0")
-		r := rangeQuery.Exec(ctx)
-		_, err = r.Matrix()
-		require.NoError(b, err)
+		runRangeQuery(b, query, from, through, step, store)
 	})
 }


### PR DESCRIPTION
`BenchmarkChunkQueryableFromTar` is same as `TestChunkTar` in `pkg/querier/chunk_tar_test.go`. This benchmark would come handy in investigating a query offline.