### PR TITLE
Avoid writing duplicate chunks by checking the cache first

### DIFF
--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -341,6 +341,12 @@ func (c *seriesStore) Put(ctx context.Context, chunks []Chunk) error {
 
 // PutOne implements ChunkStore
 func (c *seriesStore) PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error {
+	// If this chunk is in cache it must already be in the database so we don't need to write it again
+	found, _, _ := c.cache.Fetch(ctx, []string{chunk.ExternalKey()})
+	if len(found) > 0 {
+		return nil
+	}
+
 	chunks := []Chunk{chunk}
 
 	writeReqs, keysToCache, err := c.calculateIndexEntries(from, through, chunk)


### PR DESCRIPTION
In the case where two ingesters have chunks for the same series, with the same start and end times and same contents, this change will skip one of the writes, which saves effort, and money with DynamoDB.

How often does this happen?  It depends on the type of timeseries data Cortex is handling.  It is most likely for short chunks, e.g. cAdvisor metrics from containers that run just a few minutes.  It is least likely for long-running series as they will be flushed at a time relative to the start of the ingester process, so the end-time is unlikely to match.  (But I'm working on that via `-ingester.spread-flushes`).

I thought about adding a metric to count the chunks saved, but you can see this via the hit-rate of the cache inside ingesters.