### PR TITLE
Support custom endpoint for S3

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -156,3 +156,9 @@ Valid fields are (with their corresponding flags for default values):
 - `max_samples_per_query` / `-ingester.max-samples-per-query`
 
   Limits on the number of timeseries and samples returns by a single ingester during a query.
+
+## Storage
+
+- `s3.force-path-style`
+
+  Set this to `true` to force the request to use path-style addressing (`http://s3.amazonaws.com/BUCKET/KEY`). By default, the S3 client will use virtual hosted bucket addressing when possible (`http://BUCKET.s3.amazonaws.com/KEY`).

--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -126,7 +126,8 @@ func (cfg *DynamoDBConfig) RegisterFlags(f *flag.FlagSet) {
 // StorageConfig specifies config for storing data on AWS.
 type StorageConfig struct {
 	DynamoDBConfig
-	S3 flagext.URLValue
+	S3               flagext.URLValue
+	S3ForcePathStyle bool
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -135,6 +136,7 @@ func (cfg *StorageConfig) RegisterFlags(f *flag.FlagSet) {
 
 	f.Var(&cfg.S3, "s3.url", "S3 endpoint URL with escaped Key and Secret encoded. "+
 		"If only region is specified as a host, proper endpoint will be deduced. Use inmemory:///<bucket-name> to use a mock in-memory implementation.")
+	f.BoolVar(&cfg.S3ForcePathStyle, "s3.force-path-style", false, "Set this to `true` to force the request to use path-style addressing.")
 }
 
 type dynamoDBStorageClient struct {

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -47,6 +47,8 @@ func NewS3ObjectClient(cfg StorageConfig, schemaCfg chunk.SchemaConfig) (chunk.O
 		return nil, err
 	}
 
+	s3Config = s3Config.WithS3ForcePathStyle(cfg.S3ForcePathStyle) // support for Path Style S3 url if has the flag
+
 	s3Config = s3Config.WithMaxRetries(0) // We do our own retries, so we can monitor them
 	s3Client := s3.New(session.New(s3Config))
 	bucketName := strings.TrimPrefix(cfg.S3.URL.Path, "/")


### PR DESCRIPTION
Feature for https://github.com/grafana/loki/issues/699, support custom endpoint which is using `Path Style URL` of S3.