### PR TITLE
 Check that the last sample value is valid before complaining about it

### DIFF
--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -63,16 +63,19 @@ func newMemorySeries(m labels.Labels) *memorySeries {
 //
 // The caller must have locked the fingerprint of the series.
 func (s *memorySeries) add(v model.SamplePair) error {
-	// Don't report "no-op appends", i.e. where timestamp and sample
-	// value are the same as for the last append, as they are a
-	// common occurrence when using client-side timestamps
-	// (e.g. Pushgateway or federation).
-	if s.lastSampleValueSet &&
-		v.Timestamp == s.lastTime &&
-		v.Value.Equal(s.lastSampleValue) {
-		return nil
-	}
 	if v.Timestamp == s.lastTime {
+		// Don't report "no-op appends", i.e. where timestamp and sample
+		// value are the same as for the last append, as they are a
+		// common occurrence when using client-side timestamps
+		// (e.g. Pushgateway or federation).
+		if s.lastSampleValueSet && v.Value.Equal(s.lastSampleValue) {
+			return nil
+		}
+		// If we don't know what the last sample value is, silently discard as for no-op.
+		// This will mask some errors but better than complaining when we don't really know.
+		if !s.lastSampleValueSet {
+			return nil
+		}
 		return &memorySeriesError{
 			message:   fmt.Sprintf("sample with repeated timestamp but different value for series %v; last value: %v, incoming value: %v", s.metric, s.lastSampleValue, v.Value),
 			errorType: "new-value-for-timestamp",


### PR DESCRIPTION
The `lastSampleValue` member may not be initialized, e.g. after a transfer from one ingester to another.  We already have a flag which is set when the value is valid, so use it.

Fixes #1438 

