### PR TITLE
Optimize mergeStream

### DIFF
--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -16,7 +16,8 @@ type mergeIterator struct {
 	batches batchStream
 
 	// Buffers to merge in.
-	batchesBuf batchStream
+	batchesBuf   batchStream
+	nextBatchBuf [1]promchunk.Batch
 
 	currErr error
 }
@@ -109,12 +110,9 @@ func (c *mergeIterator) nextBatchEndTime() int64 {
 func (c *mergeIterator) buildNextBatch(size int) bool {
 	// All we need to do is get enough batches that our first batch's last entry
 	// is before all iterators next entry.
-	var nextBatchArr [1]promchunk.Batch
-	nextBatch := nextBatchArr[:]
-
 	for len(c.h) > 0 && (len(c.batches) == 0 || c.nextBatchEndTime() >= c.h[0].AtTime()) {
-		nextBatch[0] = c.h[0].Batch()
-		c.batchesBuf = mergeStreams(c.batches, nextBatch, c.batchesBuf, size)
+		c.nextBatchBuf[0] = c.h[0].Batch()
+		c.batchesBuf = mergeStreams(c.batches, c.nextBatchBuf[:], c.batchesBuf, size)
 		copy(c.batches[:len(c.batchesBuf)], c.batchesBuf)
 		c.batches = c.batches[:len(c.batchesBuf)]
 

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -32,7 +32,7 @@ func newMergeIterator(cs []chunk.Chunk) *mergeIterator {
 		its:        its,
 		h:          make(iteratorHeap, 0, len(its)),
 		batches:    make(batchStream, 0, len(its)*2*promchunk.BatchSize),
-		batchesBuf: make(batchStream, 0, len(its)*2*promchunk.BatchSize),
+		batchesBuf: make(batchStream, len(its)*2*promchunk.BatchSize),
 	}
 
 	for _, iter := range c.its {

--- a/pkg/querier/batch/stream.go
+++ b/pkg/querier/batch/stream.go
@@ -47,33 +47,6 @@ func (bs *batchStream) at() (int64, float64) {
 	return b.Timestamps[b.Index], b.Values[b.Index]
 }
 
-// mergeBatches assumes the contents of batches are overlapping and unsorted.
-// Merge them together into a sorted, non-overlapping stream in result.
-// Caller must guarantee result is big enough.  Return value will always be a
-// slice pointing to the same underly array as result, allowing mergeBatches
-// to call itself recursively.
-func mergeBatches(batches batchStream, result batchStream, size int) batchStream {
-	switch len(batches) {
-	case 0:
-		return nil
-	case 1:
-		copy(result[:1], batches)
-		return result[:1]
-	case 2:
-		return mergeStreams(batches[0:1], batches[1:2], result, size)
-	default:
-		n := len(batches) / 2
-		left := mergeBatches(batches[n:], result[n:], size)
-		right := mergeBatches(batches[:n], result[:n], size)
-
-		batches = mergeStreams(left, right, batches, size)
-		result = result[:len(batches)]
-		copy(result, batches)
-
-		return result[:len(batches)]
-	}
-}
-
 func mergeStreams(left, right batchStream, result batchStream, size int) batchStream {
 	// Reset the Index and Length of existing batches.
 	for i := range result {

--- a/pkg/querier/batch/stream_test.go
+++ b/pkg/querier/batch/stream_test.go
@@ -15,6 +15,11 @@ func TestStream(t *testing.T) {
 	}{
 		{
 			input1: []promchunk.Batch{mkBatch(0)},
+			output: []promchunk.Batch{mkBatch(0)},
+		},
+
+		{
+			input1: []promchunk.Batch{mkBatch(0)},
 			input2: []promchunk.Batch{mkBatch(0)},
 			output: []promchunk.Batch{mkBatch(0)},
 		},

--- a/pkg/querier/batch/stream_test.go
+++ b/pkg/querier/batch/stream_test.go
@@ -10,42 +10,36 @@ import (
 
 func TestStream(t *testing.T) {
 	for i, tc := range []struct {
-		input  []promchunk.Batch
-		output batchStream
+		input1, input2 []promchunk.Batch
+		output         batchStream
 	}{
 		{
-			input:  []promchunk.Batch{mkBatch(0)},
+			input1: []promchunk.Batch{mkBatch(0)},
+			input2: []promchunk.Batch{mkBatch(0)},
 			output: []promchunk.Batch{mkBatch(0)},
 		},
 
 		{
-			input:  []promchunk.Batch{mkBatch(0), mkBatch(0)},
-			output: []promchunk.Batch{mkBatch(0)},
-		},
-
-		{
-			input:  []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize)},
+			input1: []promchunk.Batch{mkBatch(0)},
+			input2: []promchunk.Batch{mkBatch(promchunk.BatchSize)},
 			output: []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize)},
 		},
 
 		{
-			input:  []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize), mkBatch(0), mkBatch(promchunk.BatchSize)},
-			output: []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize)},
-		},
-
-		{
-			input:  []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize / 2), mkBatch(promchunk.BatchSize)},
-			output: []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize)},
-		},
-
-		{
-			input:  []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize / 2), mkBatch(promchunk.BatchSize), mkBatch(3 * promchunk.BatchSize / 2), mkBatch(2 * promchunk.BatchSize)},
+			input1: []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize)},
+			input2: []promchunk.Batch{mkBatch(promchunk.BatchSize / 2), mkBatch(2 * promchunk.BatchSize)},
 			output: []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize), mkBatch(2 * promchunk.BatchSize)},
+		},
+
+		{
+			input1: []promchunk.Batch{mkBatch(promchunk.BatchSize / 2), mkBatch(3 * promchunk.BatchSize / 2), mkBatch(5 * promchunk.BatchSize / 2)},
+			input2: []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize), mkBatch(3 * promchunk.BatchSize)},
+			output: []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize), mkBatch(2 * promchunk.BatchSize), mkBatch(3 * promchunk.BatchSize)},
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			result := make(batchStream, len(tc.input))
-			result = mergeBatches(tc.input, result, promchunk.BatchSize)
+			result := make(batchStream, len(tc.input1)+len(tc.input2))
+			result = mergeStreams(tc.input1, tc.input2, result, promchunk.BatchSize)
 			require.Equal(t, batchStream(tc.output), result)
 		})
 	}


### PR DESCRIPTION
In my quest of optimizing query performance, I found that `result.append` was taking a significant amount of time in `mergeStream` (2s+ of around 4s of `mergeStream`).

The query and data in action is described here https://github.com/prometheus/prometheus/pull/5707#issuecomment-505440230

In this PR I have inlined the appending logic with the merging logic. This saves anywhere from `1s-2.5s` for the above data.