### PR TITLE
Use Amazon's own dynamodb-local image in example config

### DIFF
--- a/k8s/dynamodb-dep.yaml
+++ b/k8s/dynamodb-dep.yaml
@@ -14,7 +14,8 @@ spec:
     spec:
       containers:
       - name: dynamodb
-        image: deangiberson/aws-dynamodb-local
+        image: amazon/dynamodb-local:1.11.477
         imagePullPolicy: IfNotPresent
+        args: ['-jar', 'DynamoDBLocal.jar', '-inMemory', '-sharedDb']
         ports:
         - containerPort: 8000


### PR DESCRIPTION
Necessary for #1486 to work as intended.
This is the version and arguments that I used while developing integration tests.

It gives a better error message than `deangiberson/aws-dynamodb-local` in #1484 
