### PR TITLE
Ensure -dynamodb.url is set when calling NewTableClient() in aws mode

### DIFF
--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -157,6 +157,9 @@ func NewTableClient(name string, cfg Config) (chunk.TableClient, error) {
 	case "inmemory":
 		return chunk.NewMockStorage(), nil
 	case "aws", "aws-dynamo":
+		if cfg.AWSStorageConfig.DynamoDB.URL == nil {
+			return nil, fmt.Errorf("Must set -dynamodb.url in aws mode")
+		}
 		path := strings.TrimPrefix(cfg.AWSStorageConfig.DynamoDB.URL.Path, "/")
 		if len(path) > 0 {
 			level.Warn(util.Logger).Log("msg", "ignoring DynamoDB URL path", "path", path)


### PR DESCRIPTION
Loki depends on Cortex. When loki is started without `-dynamodb.url` (or a properly configured config file) it panics in `NewTableClient()` (`aws` is the default mode). This PR fixes it.

Fixes https://github.com/grafana/loki/issues/714.