### PR TITLE
Count samples silently discarded for duplicate timestamp

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -276,6 +276,9 @@ func (i *Ingester) append(ctx context.Context, labels labelPairs, timestamp mode
 	}); err != nil {
 		if mse, ok := err.(*memorySeriesError); ok {
 			state.discardedSamples.WithLabelValues(mse.errorType).Inc()
+			if mse.noReport {
+				return nil
+			}
 			// Use a dumb string template to avoid the message being parsed as a template
 			err = httpgrpc.Errorf(http.StatusBadRequest, "%s", mse.message)
 		}


### PR DESCRIPTION
Make sure all cases where ingesters discard data are covered in counters.

I have a case where distributors are seeing data but it's not showing up in queries, so trying to cover all possibilities I can think of why it could be discarded.
