### PR TITLE
Honor -consul.consistent-reads on watches too.

### DIFF
--- a/pkg/ring/consul_client.go
+++ b/pkg/ring/consul_client.go
@@ -179,7 +179,7 @@ func (c *consulClient) WatchKey(ctx context.Context, key string, f func(interfac
 	)
 	for backoff.Ongoing() {
 		queryOptions := &consul.QueryOptions{
-			RequireConsistent: true,
+			RequireConsistent: c.cfg.ConsistentReads,
 			WaitIndex:         index,
 			WaitTime:          longPollDuration,
 		}


### PR DESCRIPTION
We're only run Consul now - don't need the HA as its ephemeral state, and more outages came from consul clusters outages than anything else.

-consul.consistent-reads=false massively reduces the load on the Consul server, but most of GET load is from watches.  So we should honor this flag there.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>