### PR TITLE
feat(gcs): Add Service Account Support

### DIFF
--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -36,7 +36,7 @@ func (cfg *GCSConfig) RegisterFlags(f *flag.FlagSet) {
 
 // NewGCSObjectClient makes a new chunk.ObjectClient that writes chunks to GCS.
 func NewGCSObjectClient(ctx context.Context, cfg GCSConfig, schemaCfg chunk.SchemaConfig) (chunk.ObjectClient, error) {
-	option, err := gcsInstrumentation(ctx)
+	option, err := gcsInstrumentation(ctx, storage.ScopeReadWrite)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chunk/gcp/instrumentation.go
+++ b/pkg/chunk/gcp/instrumentation.go
@@ -50,8 +50,8 @@ func bigtableInstrumentation() ([]grpc.UnaryClientInterceptor, []grpc.StreamClie
 		}
 }
 
-func gcsInstrumentation(ctx context.Context) (option.ClientOption, error) {
-	transport, err := google_http.NewTransport(ctx, http.DefaultTransport)
+func gcsInstrumentation(ctx context.Context, scope string) (option.ClientOption, error) {
+	transport, err := google_http.NewTransport(ctx, http.DefaultTransport, option.WithScopes(scope))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To use GCP service accounts, the scope needs to be provided in the transport options.

Currently when trying to use this GCS client via Loki, by mounting the service account `credentials.json` file from a secret and using the `GOOGLE_APPLICATION_CREDENTIALS` environment variable, results in the following error response:

```
err="Post https://www.googleapis.com/upload/storage/v1/b/my-loki-bucket/o?alt=json&prettyPrint=false&projection=full&uploadType=multipart: oauth2: cannot fetch token: 400 Bad Request\nResponse: {\n  \"error\": \"invalid_scope\",\n  \"error_description\": \"Empty or missing scope not allowed.\"\n}"
```

Signed-off-by: Graham Rhodes <1964861+grahamar@users.noreply.github.com>