### PR TITLE
Add an ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,9 @@
+# Cortex Adopters
+
+This is the list of organisations that are using Cortex in **production environments** to power their metrics and monitoring systems. Please send PRs to add or remove organisations.
+
+* [Aspen Mesh](https://aspenmesh.io/)
+* [Electronic Arts](https://www.ea.com/)
+* [GrafanaLabs](https://grafana.com/)
+* [MayaData](https://mayadata.io/)
+* [Weaveworks](https://www.weave.works/)


### PR DESCRIPTION
Some inspiration from: https://github.com/rook/rook/blob/master/ADOPTERS.md and https://github.com/jaegertracing/jaeger/blob/master/ADOPTERS.md

We can also split it into service providers and end users, but I prefer it this way tbh. I've added Aspen Mesh (blog post), EA and MayaData (CNCF presentation) as they are already public but, pinging @nrjpoddar @khaines @kmova for permission.

I'll ping others I know are using it for permission too.