### PR TITLE
Log as debug if etcd CAS comparison does not succeed.

### DIFF
--- a/pkg/ring/kv/etcd/etcd.go
+++ b/pkg/ring/kv/etcd/etcd.go
@@ -109,8 +109,9 @@ func (c *Client) CAS(ctx context.Context, key string, f func(in interface{}) (ou
 			lastErr = err
 			continue
 		}
+		// result is not Succeeded if the the comparison was false, meaning if the modify indexes did not match.
 		if !result.Succeeded {
-			level.Error(util.Logger).Log("msg", "failed to CAS", "key", key)
+			level.Debug(util.Logger).Log("msg", "failed to CAS, revision and version did not match in etcd", "key", key, "revision", revision)
 			continue
 		}
 


### PR DESCRIPTION
I think the etcd `!result.Succeed` case (the revision/key comparison failing) is the same case as this in Consul: https://github.com/cortexproject/cortex/blob/master/pkg/ring/kv/consul/client.go#L158-L162 Though I'm not 100% sure, I haven't tracked all the way through the Consul API to say for certain what CAS is supposed to return if the modify indexes don't match.

In any case, this doesn't need to be an error log. The distributors in the cluster where we're testing HA tracking with etcd are spamming this log line.

cc @tomwilkie @gouthamve @csmarchbanks  

Signed-off-by: Callum Styan <callumstyan@gmail.com>