### PR TITLE
Use pools to reduce allocs in distributor write path

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -391,7 +391,7 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 			localCtx = opentracing.ContextWithSpan(localCtx, sp)
 		}
 		return d.sendSamples(localCtx, ingester, timeseries)
-	})
+	}, func() { client.ReuseTS(req.Timeseries) })
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -391,7 +391,7 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 			localCtx = opentracing.ContextWithSpan(localCtx, sp)
 		}
 		return d.sendSamples(localCtx, ingester, timeseries)
-	}, func() { client.ReuseTS(req.Timeseries) })
+	}, func() { client.ReuseSlice(req.Timeseries) })
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingester/client/timeseries.go
+++ b/pkg/ingester/client/timeseries.go
@@ -60,13 +60,6 @@ func (p *PreallocWriteRequest) Unmarshal(dAtA []byte) error {
 	return p.WriteRequest.Unmarshal(dAtA)
 }
 
-// XXX_Unmarshal implements proto.Message.
-// This exists as the decoder first checks for this method before
-// checking for `Unmarshal`.
-func (p *PreallocWriteRequest) XXX_Unmarshal(dAtA []byte) error {
-	return p.Unmarshal(dAtA)
-}
-
 // PreallocTimeseries is a TimeSeries which preallocs slices on Unmarshal.
 type PreallocTimeseries struct {
 	TimeSeries

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -87,7 +87,16 @@ func ParseProtoReader(ctx context.Context, reader io.Reader, req proto.Message, 
 		sp.LogFields(otlog.String("event", "util.ParseProtoRequest[unmarshal]"),
 			otlog.Int("size", len(body)))
 	}
-	if err := proto.Unmarshal(body, req); err != nil {
+
+	// We re-implement proto.Unmarshal here as it calls XXX_Unmarshal first,
+	// which we can't override without upsetting golint.
+	req.Reset()
+	if u, ok := req.(proto.Unmarshaler); ok {
+		err = u.Unmarshal(body)
+	} else {
+		err = proto.NewBuffer(body).Unmarshal(req)
+	}
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Motivated by:
```
(pprof) top
Showing nodes accounting for 12563.18GB, 75.10% of 16728.81GB total
Dropped 686 nodes (cum <= 83.64GB)
Showing top 10 nodes out of 107
      flat  flat%   sum%        cum   cum%
 3033.42GB 18.13% 18.13%  3033.42GB 18.13%  github.com/cortexproject/cortex/pkg/ingester/client.(*PreallocTimeseries).Unmarshal
 2412.37GB 14.42% 32.55%  2412.37GB 14.42%  github.com/cortexproject/cortex/pkg/ingester/client.(*WriteRequest).Marshal
 2264.33GB 13.54% 46.09%  2270.93GB 13.57%  github.com/cortexproject/cortex/vendor/google.golang.org/grpc/internal/transport.(*http2Client).Write
 1579.87GB  9.44% 55.53%  1579.87GB  9.44%  github.com/cortexproject/cortex/vendor/github.com/golang/snappy.Decode
  874.42GB  5.23% 60.76%   874.42GB  5.23%  bytes.makeSlice
  814.28GB  4.87% 65.63%   814.28GB  4.87%  regexp.(*bitState).reset
  465.64GB  2.78% 68.41%  3499.06GB 20.92%  github.com/cortexproject/cortex/pkg/ingester/client.(*WriteRequest).Unmarshal
  394.94GB  2.36% 70.77%  1184.50GB  7.08%  github.com/cortexproject/cortex/pkg/ring.DoBatch
  362.11GB  2.16% 72.94%   723.91GB  4.33%  github.com/cortexproject/cortex/pkg/ring.(*Ring).getInternal
  361.80GB  2.16% 75.10%   361.80GB  2.16%  github.com/cortexproject/cortex/pkg/ring.(*Ring).replicationStrategy
(pprof) list PreallocTimeseries
Total: 16.34TB
ROUTINE ======================== github.com/cortexproject/cortex/pkg/ingester/client.(*PreallocTimeseries).Unmarshal in github.com/cortexproject/cortex/pkg/ingester/client/timeseries.go
    2.96TB     2.96TB (flat, cum) 18.13% of Total
         .          .     43:	TimeSeries
         .          .     44:}
         .          .     45:
         .          .     46:// Unmarshal implements proto.Message.
         .          .     47:func (p *PreallocTimeseries) Unmarshal(dAtA []byte) error {
    2.37TB     2.37TB     48:	p.Labels = make([]LabelAdapter, 0, expectedLabels)
  606.91GB   606.91GB     49:	p.Samples = make([]Sample, 0, expectedSamplesPerSeries)
         .   512.62kB     50:	return p.TimeSeries.Unmarshal(dAtA)
         .          .     51:}
         .          .     52:
         .          .     53:// LabelAdapter is a labels.Label that can be marshalled to/from protos.
         .          .     54:type LabelAdapter labels.Label
```

This is from one of our distributor and it only gets worse as the traffic increases. I don't know if this is a sane approach though.