### PR TITLE
Embed Ingester metrics into struct

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -219,7 +219,7 @@ func (t *Cortex) stopQuerier() error {
 
 func (t *Cortex) initIngester(cfg *Config) (err error) {
 	cfg.Ingester.LifecyclerConfig.ListenPort = &cfg.Server.GRPCListenPort
-	t.ingester, err = ingester.New(cfg.Ingester, cfg.IngesterClient, t.overrides, t.store)
+	t.ingester, err = ingester.New(cfg.Ingester, cfg.IngesterClient, t.overrides, t.store, prometheus.DefaultRegisterer)
 	if err != nil {
 		return
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -39,42 +39,56 @@ const (
 	queryStreamBatchSize = 128
 )
 
-var (
-	flushQueueLength = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "cortex_ingester_flush_queue_length",
-		Help: "The total number of series pending in the flush queue.",
-	})
-	ingestedSamples = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "cortex_ingester_ingested_samples_total",
-		Help: "The total number of samples ingested.",
-	})
-	ingestedSamplesFail = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "cortex_ingester_ingested_samples_failures_total",
-		Help: "The total number of samples that errored on ingestion.",
-	})
-	queries = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "cortex_ingester_queries_total",
-		Help: "The total number of queries the ingester has handled.",
-	})
-	queriedSamples = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name: "cortex_ingester_queried_samples",
-		Help: "The total number of samples returned from queries.",
-		// Could easily return 10m samples per query - 10*(8^(8-1)) = 20.9m.
-		Buckets: prometheus.ExponentialBuckets(10, 8, 8),
-	})
-	queriedSeries = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name: "cortex_ingester_queried_series",
-		Help: "The total number of series returned from queries.",
-		// A reasonable upper bound is around 100k - 10*(8^(6-1)) = 327k.
-		Buckets: prometheus.ExponentialBuckets(10, 8, 6),
-	})
-	queriedChunks = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name: "cortex_ingester_queried_chunks",
-		Help: "The total number of chunks returned from queries.",
-		// A small number of chunks per series - 10*(8^(7-1)) = 2.6m.
-		Buckets: prometheus.ExponentialBuckets(10, 8, 7),
-	})
-)
+type ingesterMetrics struct {
+	flushQueueLength    prometheus.Gauge
+	ingestedSamples     prometheus.Counter
+	ingestedSamplesFail prometheus.Counter
+	queries             prometheus.Counter
+	queriedSamples      prometheus.Histogram
+	queriedSeries       prometheus.Histogram
+	queriedChunks       prometheus.Histogram
+}
+
+func newIngesterMetrics() *ingesterMetrics {
+	m := &ingesterMetrics{
+		flushQueueLength: promauto.NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_ingester_flush_queue_length",
+			Help: "The total number of series pending in the flush queue.",
+		}),
+		ingestedSamples: promauto.NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_ingested_samples_total",
+			Help: "The total number of samples ingested.",
+		}),
+		ingestedSamplesFail: promauto.NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_ingested_samples_failures_total",
+			Help: "The total number of samples that errored on ingestion.",
+		}),
+		queries: promauto.NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_queries_total",
+			Help: "The total number of queries the ingester has handled.",
+		}),
+		queriedSamples: promauto.NewHistogram(prometheus.HistogramOpts{
+			Name: "cortex_ingester_queried_samples",
+			Help: "The total number of samples returned from queries.",
+			// Could easily return 10m samples per query - 10*(8^(8-1)) = 20.9m.
+			Buckets: prometheus.ExponentialBuckets(10, 8, 8),
+		}),
+		queriedSeries: promauto.NewHistogram(prometheus.HistogramOpts{
+			Name: "cortex_ingester_queried_series",
+			Help: "The total number of series returned from queries.",
+			// A reasonable upper bound is around 100k - 10*(8^(6-1)) = 327k.
+			Buckets: prometheus.ExponentialBuckets(10, 8, 6),
+		}),
+		queriedChunks: promauto.NewHistogram(prometheus.HistogramOpts{
+			Name: "cortex_ingester_queried_chunks",
+			Help: "The total number of chunks returned from queries.",
+			// A small number of chunks per series - 10*(8^(7-1)) = 2.6m.
+			Buckets: prometheus.ExponentialBuckets(10, 8, 7),
+		}),
+	}
+
+	return m
+}
 
 // Config for an Ingester.
 type Config struct {
@@ -121,6 +135,8 @@ type Ingester struct {
 	cfg          Config
 	clientConfig client.Config
 
+	metrics *ingesterMetrics
+
 	chunkStore ChunkStore
 	lifecycler *ring.Lifecycler
 	limits     *validation.Overrides
@@ -157,6 +173,8 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 		cfg:          cfg,
 		clientConfig: clientConfig,
 
+		metrics: newIngesterMetrics(),
+
 		limits:     limits,
 		chunkStore: chunkStore,
 		userStates: newUserStates(limits, cfg),
@@ -173,7 +191,7 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 
 	i.flushQueuesDone.Add(cfg.ConcurrentFlushes)
 	for j := 0; j < cfg.ConcurrentFlushes; j++ {
-		i.flushQueues[j] = util.NewPriorityQueue(flushQueueLength)
+		i.flushQueues[j] = util.NewPriorityQueue(i.metrics.flushQueueLength)
 		go i.flushLoop(j)
 	}
 
@@ -234,7 +252,7 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 				continue
 			}
 
-			ingestedSamplesFail.Inc()
+			i.metrics.ingestedSamplesFail.Inc()
 			if httpResp, ok := httpgrpc.HTTPResponseFromError(err); ok {
 				switch httpResp.Code {
 				case http.StatusBadRequest, http.StatusTooManyRequests:
@@ -286,7 +304,7 @@ func (i *Ingester) append(ctx context.Context, labels labelPairs, timestamp mode
 	}
 
 	memoryChunks.Add(float64(len(series.chunkDescs) - prevNumChunks))
-	ingestedSamples.Inc()
+	i.metrics.ingestedSamples.Inc()
 	switch source {
 	case client.RULE:
 		state.ingestedRuleSamples.inc()
@@ -311,7 +329,7 @@ func (i *Ingester) Query(ctx old_ctx.Context, req *client.QueryRequest) (*client
 		return nil, err
 	}
 
-	queries.Inc()
+	i.metrics.queries.Inc()
 
 	i.userStatesMtx.RLock()
 	state, ok, err := i.userStates.getViaContext(ctx)
@@ -353,8 +371,8 @@ func (i *Ingester) Query(ctx old_ctx.Context, req *client.QueryRequest) (*client
 		result.Timeseries = append(result.Timeseries, ts)
 		return nil
 	}, nil, 0)
-	queriedSeries.Observe(float64(numSeries))
-	queriedSamples.Observe(float64(numSamples))
+	i.metrics.queriedSeries.Observe(float64(numSeries))
+	i.metrics.queriedSamples.Observe(float64(numSamples))
 	return result, err
 }
 
@@ -367,7 +385,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 		return err
 	}
 
-	queries.Inc()
+	i.metrics.queries.Inc()
 
 	i.userStatesMtx.RLock()
 	state, ok, err := i.userStates.getViaContext(ctx)
@@ -423,8 +441,8 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 		return err
 	}
 
-	queriedSeries.Observe(float64(numSeries))
-	queriedChunks.Observe(float64(numChunks))
+	i.metrics.queriedSeries.Observe(float64(numSeries))
+	i.metrics.queriedChunks.Observe(float64(numChunks))
 	level.Debug(log).Log("streams", numSeries)
 	level.Debug(log).Log("chunks", numChunks)
 	return err

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -41,7 +41,7 @@ func newTestStore(t require.TestingT, cfg Config, clientConfig client.Config, li
 	overrides, err := validation.NewOverrides(limits)
 	require.NoError(t, err)
 
-	ing, err := New(cfg, clientConfig, overrides, store)
+	ing, err := New(cfg, clientConfig, overrides, store, nil)
 	require.NoError(t, err)
 
 	return store, ing

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -96,7 +96,7 @@ func TestIngesterTransfer(t *testing.T) {
 	cfg1.LifecyclerConfig.Addr = "ingester1"
 	cfg1.LifecyclerConfig.ClaimOnRollout = true
 	cfg1.LifecyclerConfig.JoinAfter = 0 * time.Second
-	ing1, err := New(cfg1, defaultClientTestConfig(), limits, nil)
+	ing1, err := New(cfg1, defaultClientTestConfig(), limits, nil, nil)
 	require.NoError(t, err)
 
 	test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {
@@ -141,7 +141,7 @@ func TestIngesterTransfer(t *testing.T) {
 	cfg2.LifecyclerConfig.ID = "ingester2"
 	cfg2.LifecyclerConfig.Addr = "ingester2"
 	cfg2.LifecyclerConfig.JoinAfter = 100 * time.Second
-	ing2, err := New(cfg2, defaultClientTestConfig(), limits, nil)
+	ing2, err := New(cfg2, defaultClientTestConfig(), limits, nil, nil)
 	require.NoError(t, err)
 
 	// Let ing2 send chunks to ing1
@@ -186,7 +186,7 @@ func TestIngesterBadTransfer(t *testing.T) {
 	cfg.LifecyclerConfig.Addr = "ingester1"
 	cfg.LifecyclerConfig.ClaimOnRollout = true
 	cfg.LifecyclerConfig.JoinAfter = 100 * time.Second
-	ing, err := New(cfg, defaultClientTestConfig(), limits, nil)
+	ing, err := New(cfg, defaultClientTestConfig(), limits, nil, nil)
 	require.NoError(t, err)
 
 	test.Poll(t, 100*time.Millisecond, ring.PENDING, func() interface{} {


### PR DESCRIPTION
Relates To: #1512

This PR embeds the metrics from the ingester into the ingester struct. This means they will only be initialized if an ingester struct is initialized.

I avoided embedding a prometheus Registerer into the config and passing it because we do not currently use non-default registerers anywhere in cortex. Down the line we may want to consider this approach.

Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>