### PR TITLE
remove unused variables from the ruler package

### DIFF
--- a/pkg/ruler/lifecycle.go
+++ b/pkg/ruler/lifecycle.go
@@ -8,10 +8,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 )
 
-const (
-	pendingSearchIterations = 10
-)
-
 // TransferOut is a noop for the ruler
 func (r *Ruler) TransferOut(ctx context.Context) error {
 	return nil

--- a/pkg/ruler/lifecycle_test.go
+++ b/pkg/ruler/lifecycle_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/test"
 )
 
-const userID = "1"
-
 // TestRulerShutdown tests shutting down ruler unregisters correctly
 func TestRulerShutdown(t *testing.T) {
 	config := defaultRulerConfig()

--- a/pkg/ruler/scheduler_test.go
+++ b/pkg/ruler/scheduler_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 type fakeHasher struct {
-	something uint32
-	data      *[]byte
+	data *[]byte
 }
 
 func (h *fakeHasher) Write(data []byte) (int, error) {


### PR DESCRIPTION
This just removes some unused variables from the Ruler.

Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>