### PR TITLE
Adds v11 schema

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,4 +145,4 @@ The interface works somewhat differently across the supported databases:
 
 A set of schemas are used to map the matchers and label sets used on reads and writes to the chunk store into appropriate operations on the index. Schemas have been added as Cortex has evolved, mainly in an attempt to better load balance writes and improve query performance.
 
-> The current schema recommendation is the **v10 schema**.
+> The current schema recommendation is the **v10 schema**. v11 schema is an experimental schema.

--- a/docs/single-process-config.yaml
+++ b/docs/single-process-config.yaml
@@ -54,7 +54,7 @@ schema:
   - from: 2019-07-29
     store: boltdb
     object_store: filesystem
-    schema: v11
+    schema: v10
     index:
       prefix: index_
       period: 168h

--- a/docs/single-process-config.yaml
+++ b/docs/single-process-config.yaml
@@ -51,10 +51,10 @@ ingester:
 # for the chunks.
 schema:
   configs:
-  - from: 2019-03-25
+  - from: 2019-07-29
     store: boltdb
     object_store: filesystem
-    schema: v10
+    schema: v11
     index:
       prefix: index_
       period: 168h
@@ -65,4 +65,3 @@ storage:
 
   filesystem:
     directory: /tmp/cortex/chunks
-

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -37,6 +37,7 @@ var schemas = []struct {
 	{"v6", true},
 	{"v9", true},
 	{"v10", true},
+	{"v11", true},
 }
 
 var stores = []struct {
@@ -416,11 +417,11 @@ func TestChunkStore_LabelNamesForMetricName(t *testing.T) {
 	}{
 		{
 			`foo`,
-			[]string{"bar", "flip", "toms"},
+			[]string{labels.MetricName, "bar", "flip", "toms"},
 		},
 		{
 			`bar`,
-			[]string{"bar", "toms"},
+			[]string{labels.MetricName, "bar", "toms"},
 		},
 	} {
 		for _, schema := range schemas {

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -42,11 +42,9 @@ func labelNamesFromChunks(chunks []Chunk) []string {
 	var result []string
 	for _, c := range chunks {
 		for _, l := range c.Metric {
-			if l.Name != model.MetricNameLabel {
-				if _, ok := keys[string(l.Name)]; !ok {
-					keys[string(l.Name)] = struct{}{}
-					result = append(result, string(l.Name))
-				}
+			if _, ok := keys[string(l.Name)]; !ok {
+				keys[string(l.Name)] = struct{}{}
+				result = append(result, string(l.Name))
 			}
 		}
 	}

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -55,7 +55,7 @@ func (c *CompositeStore) AddPeriod(storeCfg StoreConfig, cfg PeriodConfig, index
 	var store Store
 	var err error
 	switch cfg.Schema {
-	case "v9", "v10":
+	case "v9", "v10", "v11":
 		store, err = newSeriesStore(storeCfg, schema, index, chunks, limits)
 	default:
 		store, err = newStore(storeCfg, schema, index, chunks, limits)

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -165,6 +165,7 @@ func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
 			itemComponents := decodeRangeKey(items[i].rangeValue)
 			if !bytes.Equal(itemComponents[3], metricNameRangeKeyV1) &&
 				!bytes.Equal(itemComponents[3], seriesRangeKeyV1) &&
+				!bytes.Equal(itemComponents[3], metricConstRangeKeyV1) &&
 				!bytes.Equal(itemComponents[3], labelSeriesRangeKeyV1) {
 				return fmt.Errorf("Dupe write")
 			}

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -165,7 +165,7 @@ func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
 			itemComponents := decodeRangeKey(items[i].rangeValue)
 			if !bytes.Equal(itemComponents[3], metricNameRangeKeyV1) &&
 				!bytes.Equal(itemComponents[3], seriesRangeKeyV1) &&
-				!bytes.Equal(itemComponents[3], metricConstRangeKeyV1) &&
+				!bytes.Equal(itemComponents[3], labelNamesRangeKeyV1) &&
 				!bytes.Equal(itemComponents[3], labelSeriesRangeKeyV1) {
 				return fmt.Errorf("Dupe write")
 			}

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 )
@@ -22,6 +23,8 @@ var (
 	// For v9 schema
 	seriesRangeKeyV1      = []byte{'7'}
 	labelSeriesRangeKeyV1 = []byte{'8'}
+	// For v11 schema
+	metricConstRangeKeyV1 = []byte{'9'}
 
 	// ErrNotSupported when a schema doesn't support that particular lookup.
 	ErrNotSupported = errors.New("not supported")
@@ -45,6 +48,8 @@ type Schema interface {
 
 	// If the query resulted in series IDs, use this method to find chunks.
 	GetChunksForSeries(from, through model.Time, userID string, seriesID []byte) ([]IndexQuery, error)
+	// Returns queries to retrieve all labels of multiple series by id.
+	GetLabelNamesForSeries(from, through model.Time, userID string, seriesID []byte) ([]IndexQuery, error)
 }
 
 // IndexQuery describes a query for entries
@@ -196,6 +201,20 @@ func (s schema) GetChunksForSeries(from, through model.Time, userID string, seri
 	return result, nil
 }
 
+func (s schema) GetLabelNamesForSeries(from, through model.Time, userID string, seriesID []byte) ([]IndexQuery, error) {
+	var result []IndexQuery
+
+	buckets := s.buckets(from, through, userID)
+	for _, bucket := range buckets {
+		entries, err := s.entries.GetLabelNamesForSeries(bucket, seriesID)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, entries...)
+	}
+	return result, nil
+}
+
 type entries interface {
 	GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
 	GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
@@ -205,6 +224,7 @@ type entries interface {
 	GetReadMetricLabelQueries(bucket Bucket, metricName string, labelName string) ([]IndexQuery, error)
 	GetReadMetricLabelValueQueries(bucket Bucket, metricName string, labelName string, labelValue string) ([]IndexQuery, error)
 	GetChunksForSeries(bucket Bucket, seriesID []byte) ([]IndexQuery, error)
+	GetLabelNamesForSeries(bucket Bucket, seriesID []byte) ([]IndexQuery, error)
 }
 
 // original entries:
@@ -273,6 +293,10 @@ func (originalEntries) GetReadMetricLabelValueQueries(bucket Bucket, metricName 
 }
 
 func (originalEntries) GetChunksForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
+	return nil, ErrNotSupported
+}
+
+func (originalEntries) GetLabelNamesForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
 	return nil, ErrNotSupported
 }
 
@@ -391,6 +415,10 @@ func (labelNameInHashKeyEntries) GetChunksForSeries(_ Bucket, _ []byte) ([]Index
 	return nil, ErrNotSupported
 }
 
+func (labelNameInHashKeyEntries) GetLabelNamesForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
+	return nil, ErrNotSupported
+}
+
 // v5 schema is an extension of v4, with the chunk end time in the
 // range key to improve query latency.  However, it did it wrong
 // so the chunk end times are ignored.
@@ -458,6 +486,10 @@ func (v5Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string
 }
 
 func (v5Entries) GetChunksForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
+	return nil, ErrNotSupported
+}
+
+func (v5Entries) GetLabelNamesForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
 	return nil, ErrNotSupported
 }
 
@@ -534,6 +566,10 @@ func (v6Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string
 }
 
 func (v6Entries) GetChunksForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
+	return nil, ErrNotSupported
+}
+
+func (v6Entries) GetLabelNamesForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
 	return nil, ErrNotSupported
 }
 
@@ -632,6 +668,10 @@ func (v9Entries) GetChunksForSeries(bucket Bucket, seriesID []byte) ([]IndexQuer
 	}, nil
 }
 
+func (v9Entries) GetLabelNamesForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
+	return nil, ErrNotSupported
+}
+
 // v10Entries builds on v9 by sharding index rows to reduce their size.
 type v10Entries struct {
 	rowShards uint32
@@ -647,12 +687,30 @@ func (s v10Entries) GetLabelWriteEntries(bucket Bucket, metricName string, label
 	// read first 32 bits of the hash and use this to calculate the shard
 	shard := binary.BigEndian.Uint32(seriesID) % s.rowShards
 
+	labelNames := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if l.Name == model.MetricNameLabel {
+			continue
+		}
+		labelNames = append(labelNames, l.Name)
+	}
+	data, err := jsoniter.ConfigFastest.Marshal(labelNames)
+	if err != nil {
+		return nil, err
+	}
 	entries := []IndexEntry{
 		// Entry for metricName -> seriesID
 		{
 			TableName:  bucket.tableName,
 			HashValue:  fmt.Sprintf("%02d:%s:%s", shard, bucket.hashKey, metricName),
 			RangeValue: encodeRangeKey(seriesID, nil, nil, seriesRangeKeyV1),
+		},
+		// Entry for seriesID -> labels
+		{
+			TableName:  bucket.tableName,
+			HashValue:  string(seriesID),
+			RangeValue: encodeRangeKey(nil, nil, nil, metricConstRangeKeyV1),
+			Value:      data,
 		},
 	}
 
@@ -733,6 +791,24 @@ func (v10Entries) GetChunksForSeries(bucket Bucket, seriesID []byte) ([]IndexQue
 			TableName:       bucket.tableName,
 			HashValue:       bucket.hashKey + ":" + string(seriesID),
 			RangeValueStart: encodeRangeKey(encodedFromBytes),
+		},
+	}, nil
+}
+
+func (v10Entries) GetLabelNamesForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
+	return nil, ErrNotSupported
+}
+
+// v11Entries builds on v10 but adds index entries for each series to store respective labels.
+type v11Entries struct {
+	v10Entries
+}
+
+func (v11Entries) GetLabelNamesForSeries(bucket Bucket, seriesID []byte) ([]IndexQuery, error) {
+	return []IndexQuery{
+		{
+			TableName: bucket.tableName,
+			HashValue: string(seriesID),
 		},
 	}, nil
 }

--- a/pkg/chunk/schema_caching.go
+++ b/pkg/chunk/schema_caching.go
@@ -46,6 +46,14 @@ func (s *schemaCaching) GetChunksForSeries(from, through model.Time, userID stri
 	return s.setImmutability(from, through, queries), nil
 }
 
+func (s *schemaCaching) GetLabelNamesForSeries(from, through model.Time, userID string, seriesID []byte) ([]IndexQuery, error) {
+	queries, err := s.Schema.GetLabelNamesForSeries(from, through, userID, seriesID)
+	if err != nil {
+		return nil, err
+	}
+	return s.setImmutability(from, through, queries), nil
+}
+
 func (s *schemaCaching) setImmutability(from, through model.Time, queries []IndexQuery) []IndexQuery {
 	cacheBefore := model.TimeFromUnix(mtime.Now().Add(-s.cacheOlderThan).Unix())
 

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -219,8 +219,12 @@ func (cfg *SchemaConfig) ForEachAfter(t model.Time, f func(config *PeriodConfig)
 
 // CreateSchema returns the schema defined by the PeriodConfig
 func (cfg PeriodConfig) CreateSchema() Schema {
-	var e entries
+	rowShards := uint32(16)
+	if cfg.RowShards > 0 {
+		rowShards = cfg.RowShards
+	}
 
+	var e entries
 	switch cfg.Schema {
 	case "v1":
 		e = originalEntries{}
@@ -237,13 +241,14 @@ func (cfg PeriodConfig) CreateSchema() Schema {
 	case "v9":
 		e = v9Entries{}
 	case "v10":
-		rowShards := uint32(16)
-		if cfg.RowShards > 0 {
-			rowShards = cfg.RowShards
-		}
-
 		e = v10Entries{
 			rowShards: rowShards,
+		}
+	case "v11":
+		e = v11Entries{
+			v10Entries: v10Entries{
+				rowShards: rowShards,
+			},
 		}
 	default:
 		return nil

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -406,7 +406,8 @@ func (c *seriesStore) lookupLabelNamesBySeries(ctx context.Context, from, throug
 		return nil, err
 	}
 	level.Debug(log).Log("entries", len(entries))
-	uniqueLabelNames := map[string]struct{}{model.MetricNameLabel: struct{}{}}
+	result := []string{model.MetricNameLabel}
+	uniqueLabelNames := map[string]struct{}{model.MetricNameLabel: {}}
 	for _, entry := range entries {
 		lbs := []string{}
 		err := jsoniter.ConfigFastest.Unmarshal(entry.Value, &lbs)
@@ -416,12 +417,9 @@ func (c *seriesStore) lookupLabelNamesBySeries(ctx context.Context, from, throug
 		for _, l := range lbs {
 			if _, ok := uniqueLabelNames[l]; !ok {
 				uniqueLabelNames[l] = struct{}{}
+				result = append(result, l)
 			}
 		}
-	}
-	result := make([]string, 0, len(uniqueLabelNames))
-	for name := range uniqueLabelNames {
-		result = append(result, name)
 	}
 	sort.Strings(result)
 	return result, nil

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 
 	"github.com/go-kit/kit/log/level"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
@@ -199,6 +201,25 @@ func (c *seriesStore) LabelNamesForMetricName(ctx context.Context, userID string
 	}
 	level.Debug(log).Log("series-ids", len(seriesIDs))
 
+	// Lookup the series in the index to get label names.
+	labelNames, err := c.lookupLabelNamesBySeries(ctx, from, through, userID, seriesIDs)
+	if err != nil {
+		// looking up metrics by series is not supported falling back on chunks
+		if err == ErrNotSupported {
+			return c.lookupLabelNamesByChunks(ctx, from, through, userID, seriesIDs)
+		}
+		level.Error(log).Log("msg", "lookupLabelNamesBySeries", "err", err)
+		return nil, err
+	}
+	level.Debug(log).Log("labelNames", len(labelNames))
+
+	return labelNames, nil
+}
+
+func (c *seriesStore) lookupLabelNamesByChunks(ctx context.Context, from, through model.Time, userID string, seriesIDs []string) ([]string, error) {
+	log, ctx := spanlogger.New(ctx, "SeriesStore.lookupLabelNamesByChunks")
+	defer log.Span.Finish()
+
 	// Lookup the series in the index to get the chunks.
 	chunkIDs, err := c.lookupChunksBySeries(ctx, from, through, userID, seriesIDs)
 	if err != nil {
@@ -228,7 +249,6 @@ func (c *seriesStore) LabelNamesForMetricName(ctx context.Context, userID string
 	}
 	return labelNamesFromChunks(allChunks), nil
 }
-
 func (c *seriesStore) lookupSeriesByMetricNameMatchers(ctx context.Context, from, through model.Time, userID, metricName string, matchers []*labels.Matcher) ([]string, error) {
 	log, ctx := spanlogger.New(ctx, "SeriesStore.lookupSeriesByMetricNameMatchers", "metricName", metricName, "matchers", len(matchers))
 	defer log.Span.Finish()
@@ -365,6 +385,46 @@ func (c *seriesStore) lookupChunksBySeries(ctx context.Context, from, through mo
 
 	result, err := c.parseIndexEntries(ctx, entries, nil)
 	return result, err
+}
+
+func (c *seriesStore) lookupLabelNamesBySeries(ctx context.Context, from, through model.Time, userID string, seriesIDs []string) ([]string, error) {
+	log, ctx := spanlogger.New(ctx, "SeriesStore.lookupLabelNamesBySeries")
+	defer log.Span.Finish()
+
+	level.Debug(log).Log("seriesIDs", len(seriesIDs))
+	queries := make([]IndexQuery, 0, len(seriesIDs))
+	for _, seriesID := range seriesIDs {
+		qs, err := c.schema.GetLabelNamesForSeries(from, through, userID, []byte(seriesID))
+		if err != nil {
+			return nil, err
+		}
+		queries = append(queries, qs...)
+	}
+	level.Debug(log).Log("queries", len(queries))
+	entries, err := c.lookupEntriesByQueries(ctx, queries)
+	if err != nil {
+		return nil, err
+	}
+	level.Debug(log).Log("entries", len(entries))
+	uniqueLabelNames := map[string]struct{}{model.MetricNameLabel: struct{}{}}
+	for _, entry := range entries {
+		lbs := []string{}
+		err := jsoniter.ConfigFastest.Unmarshal(entry.Value, &lbs)
+		if err != nil {
+			return nil, err
+		}
+		for _, l := range lbs {
+			if _, ok := uniqueLabelNames[l]; !ok {
+				uniqueLabelNames[l] = struct{}{}
+			}
+		}
+	}
+	result := make([]string, 0, len(uniqueLabelNames))
+	for name := range uniqueLabelNames {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result, nil
 }
 
 // Put implements ChunkStore


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

We ran Loki for a while using the new `LabelNamesForMetricName` to retrieve all possibles labels. Turned out that it does pull too many chunks for a single query spanning over 6h (12k~)

This introduces a new schema where we store the metric (labels set) within the `IndexEntry.Value`. Other schema keep the same implementation.

Design doc & reason for this change: https://docs.google.com/document/d/1sVZHtQACLQZfiKnnFhXSiqyRx6YSX945s9jPjc2js6o/edit?usp=sharing

/cc @gouthamve 