### PR TITLE
Fix calls to Log() from Alertmanager mesh

### DIFF
--- a/pkg/alertmanager/mesh.go
+++ b/pkg/alertmanager/mesh.go
@@ -38,7 +38,7 @@ type promLog struct{}
 
 // Printf implements the mesh.Logger interface.
 func (p promLog) Printf(format string, args ...interface{}) {
-	level.Info(util.Logger).Log(fmt.Sprintf(format, args...))
+	level.Info(util.Logger).Log("msg", fmt.Sprintf(format, args...))
 }
 
 func initMesh(addr, hwaddr, nickname, pw string) *mesh.Router {


### PR DESCRIPTION
`Log()` requires that arguments are name-value pairs.
