### PR TITLE
multiple changes (ring/ingester)

### DIFF
--- a/pkg/ingester/client/pool.go
+++ b/pkg/ingester/client/pool.go
@@ -193,6 +193,7 @@ func (p *Pool) cleanUnhealthy() {
 			err := healthCheck(client, p.cfg.RemoteTimeout)
 			if err != nil {
 				level.Warn(util.Logger).Log("msg", "removing ingester failing healtcheck", "addr", addr, "reason", err)
+				p.ring.ForgetIngester(addr)
 				p.RemoveClientFor(addr)
 			}
 		}

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -389,8 +389,12 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 			return ringDesc, true, nil
 		}
 
-		// We exist in the ring, so assume the ring is right and copy out tokens & state out of there.
-		i.setState(ingesterDesc.State)
+		// We exist in the ring, so assume the ring is right and copy out tokens & state out of there. (except when it's in LEAVING state meaning)
+		if ingesterDesc.State == LEAVING {
+			i.setState(PENDING)
+		} else {
+			i.setState(ingesterDesc.State)
+		}
 		tokens, _ := ringDesc.TokensFor(i.ID)
 		i.setTokens(tokens)
 

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -129,6 +129,18 @@ func (d *Desc) FindIngestersByState(state IngesterState) []IngesterDesc {
 	return result
 }
 
+// FindIngesterIdByAddr returns the ingesterId for the given address
+func (d *Desc) FindIngesterIdByAddr(addr string) string {
+	var result string
+	for id, ing := range d.Ingesters {
+		if ing.Addr == addr {
+			result = id
+			return result
+		}
+	}
+	return result
+}
+
 // Ready returns no error when all ingesters are active and healthy.
 func (d *Desc) Ready(heartbeatTimeout time.Duration) error {
 	numTokens := len(d.Tokens)


### PR DESCRIPTION
- ingester: client/pool now calls ring.ForgetIngester before RemoveClientFor
- ring: ReadRing now has a method implemented for ForgetIngester
- ring: model now has a helper method to find ingesterId by address
- ring: lifecycler initRing now only copies state if it was not LEAVING
(to handle situations when an ingester comes back on the same identity)