### PR TITLE
roll back embedded metrics change

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -219,7 +219,7 @@ func (t *Cortex) stopQuerier() error {
 
 func (t *Cortex) initIngester(cfg *Config) (err error) {
 	cfg.Ingester.LifecyclerConfig.ListenPort = &cfg.Server.GRPCListenPort
-	t.ingester, err = ingester.New(cfg.Ingester, cfg.IngesterClient, t.overrides, t.store, prometheus.DefaultRegisterer)
+	t.ingester, err = ingester.New(cfg.Ingester, cfg.IngesterClient, t.overrides, t.store)
 	if err != nil {
 		return
 	}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -41,7 +41,7 @@ func newTestStore(t require.TestingT, cfg Config, clientConfig client.Config, li
 	overrides, err := validation.NewOverrides(limits)
 	require.NoError(t, err)
 
-	ing, err := New(cfg, clientConfig, overrides, store, nil)
+	ing, err := New(cfg, clientConfig, overrides, store)
 	require.NoError(t, err)
 
 	return store, ing

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -96,7 +96,7 @@ func TestIngesterTransfer(t *testing.T) {
 	cfg1.LifecyclerConfig.Addr = "ingester1"
 	cfg1.LifecyclerConfig.ClaimOnRollout = true
 	cfg1.LifecyclerConfig.JoinAfter = 0 * time.Second
-	ing1, err := New(cfg1, defaultClientTestConfig(), limits, nil, nil)
+	ing1, err := New(cfg1, defaultClientTestConfig(), limits, nil)
 	require.NoError(t, err)
 
 	test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {
@@ -141,7 +141,7 @@ func TestIngesterTransfer(t *testing.T) {
 	cfg2.LifecyclerConfig.ID = "ingester2"
 	cfg2.LifecyclerConfig.Addr = "ingester2"
 	cfg2.LifecyclerConfig.JoinAfter = 100 * time.Second
-	ing2, err := New(cfg2, defaultClientTestConfig(), limits, nil, nil)
+	ing2, err := New(cfg2, defaultClientTestConfig(), limits, nil)
 	require.NoError(t, err)
 
 	// Let ing2 send chunks to ing1
@@ -186,7 +186,7 @@ func TestIngesterBadTransfer(t *testing.T) {
 	cfg.LifecyclerConfig.Addr = "ingester1"
 	cfg.LifecyclerConfig.ClaimOnRollout = true
 	cfg.LifecyclerConfig.JoinAfter = 100 * time.Second
-	ing, err := New(cfg, defaultClientTestConfig(), limits, nil, nil)
+	ing, err := New(cfg, defaultClientTestConfig(), limits, nil)
 	require.NoError(t, err)
 
 	test.Poll(t, 100*time.Millisecond, ring.PENDING, func() interface{} {


### PR DESCRIPTION
This rolls back #1527, since this will lead to 3 separate approaches for instrumentation in cortex and this should be something discussed and agreed upon before moving forward with it.

Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>