### PR TITLE
Add admin page for HA tracker information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master / unreleased
 
 * [FEATURE] Add option to use jump hashing to load balance requests to memcached #1554
+* [FEATURE] Add status page for HA tracker to distributors #1546
 
 ## 0.1.0 / 2019-08-07
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -170,6 +170,7 @@ func (t *Cortex) initDistributor(cfg *Config) (err error) {
 
 	t.server.HTTP.HandleFunc("/all_user_stats", t.distributor.AllUserStatsHandler)
 	t.server.HTTP.Handle("/api/prom/push", t.httpAuthMiddleware.Wrap(http.HandlerFunc(t.distributor.PushHandler)))
+	t.server.HTTP.Handle("/ha-tracker", t.distributor.Replicas)
 	return
 }
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -139,7 +139,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.BillingConfig.RegisterFlags(f)
 	cfg.PoolConfig.RegisterFlags(f)
-	cfg.HATrackerConfig.RegisterFlags(f)
+	cfg.HATrackerConfig.RegisterFlags("distributor", f)
 
 	f.BoolVar(&cfg.EnableBilling, "distributor.enable-billing", false, "Report number of ingested samples to billing system.")
 	f.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -108,7 +108,7 @@ type Distributor struct {
 	billingClient *billing.Client
 
 	// For handling HA replicas.
-	replicas *haTracker
+	Replicas *haTracker
 
 	// Per-user rate limiters.
 	ingestLimitersMtx sync.RWMutex
@@ -185,7 +185,7 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 		if err != nil {
 			return nil, err
 		}
-		d.replicas = replicas
+		d.Replicas = replicas
 	}
 
 	go d.loop()
@@ -279,7 +279,7 @@ func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica 
 
 	// At this point we know we have both HA labels, we should lookup
 	// the cluster/instance here to see if we want to accept this sample.
-	err := d.replicas.checkReplica(ctx, userID, cluster, replica)
+	err := d.Replicas.checkReplica(ctx, userID, cluster, replica)
 	// checkReplica should only have returned an error if there was a real error talking to Consul, or if the replica labels don't match.
 	if err != nil { // Don't accept the sample.
 		return false, err

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -139,7 +139,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.BillingConfig.RegisterFlags(f)
 	cfg.PoolConfig.RegisterFlags(f)
-	cfg.HATrackerConfig.RegisterFlags("distributor.", f)
+	cfg.HATrackerConfig.RegisterFlags(f)
 
 	f.BoolVar(&cfg.EnableBilling, "distributor.enable-billing", false, "Report number of ingested samples to billing system.")
 	f.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -139,7 +139,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.BillingConfig.RegisterFlags(f)
 	cfg.PoolConfig.RegisterFlags(f)
-	cfg.HATrackerConfig.RegisterFlags("distributor", f)
+	cfg.HATrackerConfig.RegisterFlags("distributor.", f)
 
 	f.BoolVar(&cfg.EnableBilling, "distributor.enable-billing", false, "Report number of ingested samples to billing system.")
 	f.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -168,6 +168,11 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 	replicationFactor.Set(float64(ring.ReplicationFactor()))
 	cfg.PoolConfig.RemoteTimeout = cfg.RemoteTimeout
 
+	replicas, err := newClusterTracker(cfg.HATrackerConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	d := &Distributor{
 		cfg:            cfg,
 		ring:           ring,
@@ -176,11 +181,6 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 		limits:         limits,
 		ingestLimiters: map[string]*rate.Limiter{},
 		quit:           make(chan struct{}),
-	}
-
-	replicas, err := newClusterTracker(cfg.HATrackerConfig)
-	if err != nil {
-		return nil, err
 	}
 	d.Replicas = replicas
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -181,9 +181,8 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 		limits:         limits,
 		ingestLimiters: map[string]*rate.Limiter{},
 		quit:           make(chan struct{}),
+		Replicas:       replicas,
 	}
-	d.Replicas = replicas
-
 	go d.loop()
 
 	return d, nil

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -139,7 +139,6 @@ func TestDistributorPushHAInstances(t *testing.T) {
 		for _, shardByAllLabels := range []bool{true, false} {
 			t.Run(fmt.Sprintf("[%d](shardByAllLabels=%v)", i, shardByAllLabels), func(t *testing.T) {
 				d := prepare(t, 1, 1, 0, shardByAllLabels)
-				d.cfg.EnableHATracker = true
 				d.limits.Defaults.AcceptHASamples = true
 				codec := codec.Proto{Factory: ProtoReplicaDescFactory}
 				mock := kv.PrefixClient(consul.NewInMemoryClient(codec), "prefix")

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -150,11 +150,11 @@ func TestDistributorPushHAInstances(t *testing.T) {
 					FailoverTimeout: time.Second,
 				})
 				assert.NoError(t, err)
-				d.replicas = r
+				d.Replicas = r
 
 				userID, err := user.ExtractOrgID(ctx)
 				assert.NoError(t, err)
-				err = d.replicas.checkReplica(ctx, userID, tc.cluster, tc.acceptedReplica)
+				err = d.Replicas.checkReplica(ctx, userID, tc.cluster, tc.acceptedReplica)
 				assert.NoError(t, err)
 
 				request := makeWriteRequestHA(tc.samples, tc.testReplica, tc.cluster)

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -97,15 +97,15 @@ type HATrackerConfig struct {
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *HATrackerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.EnableHATracker,
-		prefix+"ha-tracker.enable",
+		"distributor.ha-tracker.enable",
 		false,
 		"Enable the distributors HA tracker so that it can accept samples from Prometheus HA replicas gracefully (requires labels).")
 	f.DurationVar(&cfg.UpdateTimeout,
-		prefix+"ha-tracker.update-timeout",
+		"distributor.ha-tracker.update-timeout",
 		15*time.Second,
 		"Update the timestamp in the KV store for a given cluster/replica only after this amount of time has passed since the current stored timestamp.")
 	f.DurationVar(&cfg.FailoverTimeout,
-		prefix+"ha-tracker.failover-timeout",
+		"distributor.ha-tracker.failover-timeout",
 		30*time.Second,
 		"If we don't receive any samples from the accepted replica for a cluster in this amount of time we will failover to the next replica we receive a sample from. This value must be greater than the update timeout")
 	// We want the ability to use different Consul instances for the ring and for HA cluster tracking.

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -94,8 +94,8 @@ type HATrackerConfig struct {
 	KVStore kv.Config
 }
 
-// RegisterFlags adds the flags required to config this to the given FlagSet. If prefix is not an empty string it should end with a period.
-func (cfg *HATrackerConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
+// RegisterFlags adds the flags required to config this to the given FlagSet.
+func (cfg *HATrackerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.EnableHATracker,
 		prefix+"ha-tracker.enable",
 		false,

--- a/pkg/distributor/ha_tracker_http.go
+++ b/pkg/distributor/ha_tracker_http.go
@@ -26,8 +26,8 @@ const trackerTpl = `
 					<th>Cluster</th>
 					<th>Replica</th>
 					<th>Elected Time</th>
-					<th>Updates At</th>
-					<th>Failover At</th>
+					<th>Time Until Update</th>
+					<th>Time Until Failover</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -61,15 +61,16 @@ func (h *haTracker) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		chunks := strings.SplitN(key, "/", 2)
 
 		electedReplicas = append(electedReplicas, struct {
-			UserID, Cluster, Replica            string
-			ElectedAt, UpdateTime, FailoverTime time.Time
+			UserID, Cluster, Replica string
+			ElectedAt                time.Time
+			UpdateTime, FailoverTime time.Duration
 		}{
 			UserID:       chunks[0],
 			Cluster:      chunks[1],
 			Replica:      desc.Replica,
 			ElectedAt:    timestamp.Time(desc.ReceivedAt),
-			UpdateTime:   timestamp.Time(desc.ReceivedAt).Add(h.cfg.UpdateTimeout),
-			FailoverTime: timestamp.Time(desc.ReceivedAt).Add(h.cfg.FailoverTimeout),
+			UpdateTime:   time.Until(timestamp.Time(desc.ReceivedAt).Add(h.cfg.UpdateTimeout)),
+			FailoverTime: time.Until(timestamp.Time(desc.ReceivedAt).Add(h.cfg.FailoverTimeout)),
 		})
 	}
 

--- a/pkg/distributor/ha_tracker_http.go
+++ b/pkg/distributor/ha_tracker_http.go
@@ -1,0 +1,81 @@
+package distributor
+
+import (
+	"html/template"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const trackerTpl = `
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>Cortex HA Tracker Status</title>
+	</head>
+	<body>
+		<h1>Cortex HA Tracker Status</h1>
+		<p>Current time: {{ .Now }}</p>
+		<form action="" method="POST">
+			<input type="hidden" name="csrf_token" value="$__CSRF_TOKEN_PLACEHOLDER__">
+			<table width="100%" border="1">
+				<thead>
+					<tr>
+						<th>User ID</th>
+						<th>Cluster</th>
+						<th>Replica</th>
+						<th>Timestamp</th>
+					</tr>
+				</thead>
+				<tbody>
+					{{ range .Elected }}
+					<tr>
+						<td>{{ .UserID }}</td>
+						<td>{{ .Cluster }}</td>
+						<td>{{ .Replica }}</td>
+						<td>{{ .Timestamp }}</td>
+					</tr>
+					{{ end }}
+				</tbody>
+			</table>
+		</form>
+	</body>
+</html>`
+
+var trackerTmpl *template.Template
+
+func init() {
+	trackerTmpl = template.Must(template.New("ha-tracker").Parse(trackerTpl))
+}
+
+func (h *haTracker) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	h.electedLock.RLock()
+	defer h.electedLock.RUnlock()
+
+	electedReplicas := []interface{}{}
+	for key, desc := range h.elected {
+		chunks := strings.SplitN(key, "/", 2)
+
+		electedReplicas = append(electedReplicas, struct {
+			UserID, Cluster, Replica string
+			Timestamp                int64
+		}{
+			UserID:    chunks[0],
+			Cluster:   chunks[1],
+			Replica:   desc.Replica,
+			Timestamp: desc.ReceivedAt,
+		})
+	}
+
+	if err := trackerTmpl.Execute(w, struct {
+		Elected []interface{}
+		Now     time.Time
+	}{
+		Elected: electedReplicas,
+		Now:     time.Now(),
+	}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/pkg/distributor/ha_tracker_http.go
+++ b/pkg/distributor/ha_tracker_http.go
@@ -81,10 +81,10 @@ func (h *haTracker) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		first := electedReplicas[i].(replica)
 		second := electedReplicas[j].(replica)
 
-		if first.UserID == second.UserID {
-			return first.Cluster < second.Cluster
+		if first.UserID != second.UserID {
+			return first.UserID < second.UserID
 		}
-		return first.UserID < second.UserID
+		return first.Cluster < second.Cluster
 	})
 
 	if err := trackerTmpl.Execute(w, struct {

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -60,6 +60,7 @@ func TestFailoverGreaterUpdate(t *testing.T) {
 	cases := []testCase{
 		{
 			in: HATrackerConfig{
+				EnableHATracker: true,
 				UpdateTimeout:   time.Second,
 				FailoverTimeout: time.Second,
 				KVStore: kv.Config{
@@ -70,6 +71,7 @@ func TestFailoverGreaterUpdate(t *testing.T) {
 		},
 		{
 			in: HATrackerConfig{
+				EnableHATracker: true,
 				UpdateTimeout:   time.Second,
 				FailoverTimeout: 999 * time.Millisecond,
 				KVStore: kv.Config{
@@ -80,6 +82,7 @@ func TestFailoverGreaterUpdate(t *testing.T) {
 		},
 		{
 			in: HATrackerConfig{
+				EnableHATracker: true,
 				UpdateTimeout:   time.Second,
 				FailoverTimeout: 1001 * time.Millisecond,
 				KVStore: kv.Config{
@@ -106,6 +109,7 @@ func TestWatchPrefixAssignment(t *testing.T) {
 	codec := codec.Proto{Factory: ProtoReplicaDescFactory}
 	mock := kv.PrefixClient(consul.NewInMemoryClient(codec), "prefix")
 	c, err := newClusterTracker(HATrackerConfig{
+		EnableHATracker: true,
 		KVStore:         kv.Config{Mock: mock},
 		UpdateTimeout:   time.Millisecond,
 		FailoverTimeout: time.Millisecond * 2,
@@ -130,6 +134,7 @@ func TestCheckReplicaOverwriteTimeout(t *testing.T) {
 	start := mtime.Now()
 
 	c, err := newClusterTracker(HATrackerConfig{
+		EnableHATracker: true,
 		KVStore:         kv.Config{Store: "inmemory"},
 		UpdateTimeout:   100 * time.Millisecond,
 		FailoverTimeout: time.Second,
@@ -161,6 +166,7 @@ func TestCheckReplicaMultiCluster(t *testing.T) {
 	replica2 := "replica2"
 
 	c, err := newClusterTracker(HATrackerConfig{
+		EnableHATracker: true,
 		KVStore:         kv.Config{Store: "inmemory"},
 		UpdateTimeout:   100 * time.Millisecond,
 		FailoverTimeout: time.Second,
@@ -191,6 +197,7 @@ func TestCheckReplicaMultiClusterTimeout(t *testing.T) {
 	replica2 := "replica2"
 
 	c, err := newClusterTracker(HATrackerConfig{
+		EnableHATracker: true,
 		KVStore:         kv.Config{Store: "inmemory"},
 		UpdateTimeout:   100 * time.Millisecond,
 		FailoverTimeout: time.Second,
@@ -238,6 +245,7 @@ func TestCheckReplicaWriteTimeout(t *testing.T) {
 	codec := codec.Proto{Factory: ProtoReplicaDescFactory}
 	mock := kv.PrefixClient(consul.NewInMemoryClient(codec), "prefix")
 	c, err := newClusterTracker(HATrackerConfig{
+		EnableHATracker: true,
 		KVStore:         kv.Config{Mock: mock},
 		UpdateTimeout:   100 * time.Millisecond,
 		FailoverTimeout: time.Second,
@@ -289,6 +297,7 @@ func TestCheckReplicaMultiUser(t *testing.T) {
 	codec := codec.Proto{Factory: ProtoReplicaDescFactory}
 	mock := kv.PrefixClient(consul.NewInMemoryClient(codec), "prefix")
 	c, err := newClusterTracker(HATrackerConfig{
+		EnableHATracker: true,
 		KVStore:         kv.Config{Mock: mock},
 		UpdateTimeout:   100 * time.Millisecond,
 		FailoverTimeout: time.Second,


### PR DESCRIPTION
It wasn't clear to me what the right way to serve the page was, and whether for other pages (ex: the ring pages) if we serve the page from every distributor/ingester or not.

Signed-off-by: Callum Styan <callumstyan@gmail.com>