### PR TITLE
Refactored limits to be able to define them dynamically when Cortex is vendored in another project

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -331,7 +331,7 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 		}
 
 		labelsHistogram.Observe(float64(len(ts.Labels)))
-		if err := d.limits.ValidateLabels(userID, ts.Labels); err != nil {
+		if err := validation.ValidateLabels(d.limits, userID, ts.Labels); err != nil {
 			lastPartialErr = err
 			continue
 		}
@@ -339,7 +339,7 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 		metricName, _ := extract.MetricNameFromLabelAdapters(ts.Labels)
 		samples := make([]client.Sample, 0, len(ts.Samples))
 		for _, s := range ts.Samples {
-			if err := d.limits.ValidateSample(userID, metricName, s); err != nil {
+			if err := validation.ValidateSample(d.limits, userID, metricName, s); err != nil {
 				lastPartialErr = err
 				continue
 			}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -232,6 +232,8 @@ func (o *Overrides) CardinalityLimit(userID string) int {
 // Loads overrides and returns the limits as an interface to store them in OverridesManager.
 // We need to implement it here since OverridesManager must store type Limits in an interface but
 // it doesn't know its definition to initialize it.
+// We could have used yamlv3.Node for this but there is no way to enforce strict decoding due to a bug in it
+// TODO: Use yamlv3.Node to move this to OverridesManager after https://github.com/go-yaml/yaml/issues/460 is fixed
 func loadOverrides(filename string) (map[string]interface{}, error) {
 	f, err := os.Open(filename)
 	if err != nil {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -76,6 +76,8 @@ func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// We want to set c to the defaults and then overwrite it with the input.
 	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
 	// again, we have to hide it using a type indirection.  See prometheus/config.
+
+	// During startup we wont have a default value so we don't want to overwrite them
 	if defaultLimits != nil {
 		*l = *defaultLimits
 	}
@@ -222,6 +224,9 @@ func (o *Overrides) CardinalityLimit(userID string) int {
 	return o.overridesManager.GetLimits(userID).(*Limits).CardinalityLimit
 }
 
+// Loads overrides and returns the limits as an interface to store them in OverridesManager.
+// We need to implement it here since OverridesManager must store type Limits in an interface but
+// it doesn't know its definition to initialize it.
 func loadOverrides(filename string) (map[string]interface{}, error) {
 	f, err := os.Open(filename)
 	if err != nil {
@@ -239,8 +244,8 @@ func loadOverrides(filename string) (map[string]interface{}, error) {
 	}
 
 	overridesAsInterface := map[string]interface{}{}
-	for k := range overrides.Overrides {
-		overridesAsInterface[k] = overrides.Overrides[k]
+	for userID := range overrides.Overrides {
+		overridesAsInterface[userID] = overrides.Overrides[userID]
 	}
 
 	return overridesAsInterface, nil

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -103,9 +103,14 @@ type Overrides struct {
 // become the new global defaults.
 func NewOverrides(defaults Limits) (*Overrides, error) {
 	defaultLimits = &defaults
+	overridesManagerConfig := OverridesManagerConfig{
+		OverridesReloadPeriod: defaults.PerTenantOverridePeriod,
+		OverridesLoadPath:     defaults.PerTenantOverrideConfig,
+		OverridesLoader:       loadOverrides,
+		Defaults:              &defaults,
+	}
 
-	overridesManager, err := NewOverridesManager(defaults.PerTenantOverridePeriod, defaults.PerTenantOverrideConfig,
-		loadOverrides, &defaults)
+	overridesManager, err := NewOverridesManager(overridesManagerConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -2,7 +2,10 @@ package validation
 
 import (
 	"flag"
+	"os"
 	"time"
+
+	"gopkg.in/yaml.v2"
 )
 
 // Limits describe all the limits for users; can be used to describe global default
@@ -73,7 +76,172 @@ func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// We want to set c to the defaults and then overwrite it with the input.
 	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
 	// again, we have to hide it using a type indirection.  See prometheus/config.
-	*l = defaultLimits
+	if defaultLimits != nil {
+		*l = *defaultLimits
+	}
 	type plain Limits
 	return unmarshal((*plain)(l))
+}
+
+// When we load YAML from disk, we want the various per-customer limits
+// to default to any values specified on the command line, not default
+// command line values.  This global contains those values.  I (Tom) cannot
+// find a nicer way I'm afraid.
+var defaultLimits *Limits
+
+// Overrides periodically fetch a set of per-user overrides, and provides convenience
+// functions for fetching the correct value.
+type Overrides struct {
+	overridesManager *OverridesManager
+}
+
+// NewOverrides makes a new Overrides.
+// We store the supplied limits in a global variable to ensure per-tenant limits
+// are defaulted to those values.  As such, the last call to NewOverrides will
+// become the new global defaults.
+func NewOverrides(defaults Limits) (*Overrides, error) {
+	defaultLimits = &defaults
+
+	overridesManager, err := NewOverridesManager(defaults.PerTenantOverridePeriod, defaults.PerTenantOverrideConfig,
+		loadOverrides, &defaults)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Overrides{
+		overridesManager: overridesManager,
+	}, nil
+}
+
+// Stop background reloading of overrides.
+func (o *Overrides) Stop() {
+	o.overridesManager.Stop()
+}
+
+// IngestionRate returns the limit on ingester rate (samples per second).
+func (o *Overrides) IngestionRate(userID string) float64 {
+	return o.overridesManager.GetLimits(userID).(*Limits).IngestionRate
+}
+
+// IngestionBurstSize returns the burst size for ingestion rate.
+func (o *Overrides) IngestionBurstSize(userID string) int {
+	return o.overridesManager.GetLimits(userID).(*Limits).IngestionBurstSize
+}
+
+// AcceptHASamples returns whether the distributor should track and accept samples from HA replicas for this user.
+func (o *Overrides) AcceptHASamples(userID string) bool {
+	return o.overridesManager.GetLimits(userID).(*Limits).AcceptHASamples
+}
+
+// HAReplicaLabel returns the replica label to look for when deciding whether to accept a sample from a Prometheus HA replica.
+func (o *Overrides) HAReplicaLabel(userID string) string {
+	return o.overridesManager.GetLimits(userID).(*Limits).HAReplicaLabel
+}
+
+// HAClusterLabel returns the cluster label to look for when deciding whether to accept a sample from a Prometheus HA replica.
+func (o *Overrides) HAClusterLabel(userID string) string {
+	return o.overridesManager.GetLimits(userID).(*Limits).HAClusterLabel
+}
+
+// MaxLabelNameLength returns maximum length a label name can be.
+func (o *Overrides) MaxLabelNameLength(userID string) int {
+	return o.overridesManager.GetLimits(userID).(*Limits).MaxLabelNameLength
+}
+
+// MaxLabelValueLength returns maximum length a label value can be. This also is
+// the maximum length of a metric name.
+func (o *Overrides) MaxLabelValueLength(userID string) int {
+	return o.overridesManager.GetLimits(userID).(*Limits).MaxLabelValueLength
+}
+
+// MaxLabelNamesPerSeries returns maximum number of label/value pairs timeseries.
+func (o *Overrides) MaxLabelNamesPerSeries(userID string) int {
+	return o.overridesManager.GetLimits(userID).(*Limits).MaxLabelNamesPerSeries
+}
+
+// RejectOldSamples returns true when we should reject samples older than certain
+// age.
+func (o *Overrides) RejectOldSamples(userID string) bool {
+	return o.overridesManager.GetLimits(userID).(*Limits).RejectOldSamples
+}
+
+// RejectOldSamplesMaxAge returns the age at which samples should be rejected.
+func (o *Overrides) RejectOldSamplesMaxAge(userID string) time.Duration {
+	return o.overridesManager.GetLimits(userID).(*Limits).RejectOldSamplesMaxAge
+}
+
+// CreationGracePeriod is misnamed, and actually returns how far into the future
+// we should accept samples.
+func (o *Overrides) CreationGracePeriod(userID string) time.Duration {
+	return o.overridesManager.GetLimits(userID).(*Limits).CreationGracePeriod
+}
+
+// MaxSeriesPerQuery returns the maximum number of series a query is allowed to hit.
+func (o *Overrides) MaxSeriesPerQuery(userID string) int {
+	return o.overridesManager.GetLimits(userID).(*Limits).MaxSeriesPerQuery
+}
+
+// MaxSamplesPerQuery returns the maximum number of samples in a query (from the ingester).
+func (o *Overrides) MaxSamplesPerQuery(userID string) int {
+	return o.overridesManager.GetLimits(userID).(*Limits).MaxSamplesPerQuery
+}
+
+// MaxSeriesPerUser returns the maximum number of series a user is allowed to store.
+func (o *Overrides) MaxSeriesPerUser(userID string) int {
+	return o.overridesManager.GetLimits(userID).(*Limits).MaxSeriesPerUser
+}
+
+// MaxSeriesPerMetric returns the maximum number of series allowed per metric.
+func (o *Overrides) MaxSeriesPerMetric(userID string) int {
+	return o.overridesManager.GetLimits(userID).(*Limits).MaxSeriesPerMetric
+}
+
+// MaxChunksPerQuery returns the maximum number of chunks allowed per query.
+func (o *Overrides) MaxChunksPerQuery(userID string) int {
+	return o.overridesManager.GetLimits(userID).(*Limits).MaxChunksPerQuery
+}
+
+// MaxQueryLength returns the limit of the length (in time) of a query.
+func (o *Overrides) MaxQueryLength(userID string) time.Duration {
+	return o.overridesManager.GetLimits(userID).(*Limits).MaxQueryLength
+}
+
+// MaxQueryParallelism returns the limit to the number of sub-queries the
+// frontend will process in parallel.
+func (o *Overrides) MaxQueryParallelism(userID string) int {
+	return o.overridesManager.GetLimits(userID).(*Limits).MaxQueryParallelism
+}
+
+// EnforceMetricName whether to enforce the presence of a metric name.
+func (o *Overrides) EnforceMetricName(userID string) bool {
+	return o.overridesManager.GetLimits(userID).(*Limits).EnforceMetricName
+}
+
+// CardinalityLimit whether to enforce the presence of a metric name.
+func (o *Overrides) CardinalityLimit(userID string) int {
+	return o.overridesManager.GetLimits(userID).(*Limits).CardinalityLimit
+}
+
+func loadOverrides(filename string) (map[string]interface{}, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var overrides struct {
+		Overrides map[string]*Limits `yaml:"overrides"`
+	}
+
+	decoder := yaml.NewDecoder(f)
+	decoder.SetStrict(true)
+	if err := decoder.Decode(&overrides); err != nil {
+		return nil, err
+	}
+
+	overridesAsInterface := map[string]interface{}{}
+	for k := range overrides.Overrides {
+		overridesAsInterface[k] = overrides.Overrides[k]
+	}
+
+	return overridesAsInterface, nil
 }

--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -19,19 +19,15 @@ func init() {
 	overridesReloadSuccess.Set(1) // Default to 1
 }
 
-type overridesLoader func(string) (map[string]interface{}, error)
-
-// LimitsUnmarshaler helps in unmarshaling limits from yaml
-type LimitsUnmarshaler interface {
-	UnmarshalYAML(unmarshal func(interface{}) error) error
-}
+// OverridesLoader loads the overrides
+type OverridesLoader func(string) (map[string]interface{}, error)
 
 // OverridesManager manages default and per user limits i.e overrides.
 // It can periodically keep reloading overrides based on config.
 type OverridesManager struct {
 	overridesReloadPeriod time.Duration
 	overridesReloadPath   string
-	overridesLoader       overridesLoader
+	overridesLoader       OverridesLoader
 
 	defaults     interface{}
 	overrides    map[string]interface{}
@@ -40,7 +36,7 @@ type OverridesManager struct {
 }
 
 // NewOverridesManager creates an instance of OverridesManager and starts reload overrides loop based on config
-func NewOverridesManager(perTenantOverridePeriod time.Duration, overridesReloadPath string, overridesLoader overridesLoader,
+func NewOverridesManager(perTenantOverridePeriod time.Duration, overridesReloadPath string, overridesLoader OverridesLoader,
 	defaults interface{}) (*OverridesManager, error) {
 	overridesManager := OverridesManager{
 		overridesLoader:       overridesLoader,

--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -1,16 +1,13 @@
 package validation
 
 import (
-	"os"
 	"sync"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	yaml "gopkg.in/yaml.v2"
-
-	"github.com/cortexproject/cortex/pkg/util"
 )
 
 var overridesReloadSuccess = promauto.NewGauge(prometheus.GaugeOpts{
@@ -22,290 +19,90 @@ func init() {
 	overridesReloadSuccess.Set(1) // Default to 1
 }
 
-// When we load YAML from disk, we want the various per-customer limits
-// to default to any values specified on the command line, not default
-// command line values.  This global contains those values.  I (Tom) cannot
-// find a nicer way I'm afraid.
-var defaultLimits Limits
+type overridesLoader func(string) (map[string]interface{}, error)
 
-// Overrides periodically fetch a set of per-user overrides, and provides convenience
-// functions for fetching the correct value.
-type Overrides struct {
-	Defaults     Limits
+// LimitsUnmarshaler helps in unmarshaling limits from yaml
+type LimitsUnmarshaler interface {
+	UnmarshalYAML(unmarshal func(interface{}) error) error
+}
+
+// OverridesManager manages default and per user limits i.e overrides.
+// It can periodically keep reloading overrides based on config.
+type OverridesManager struct {
+	overridesReloadPeriod time.Duration
+	overridesReloadPath   string
+	overridesLoader       overridesLoader
+
+	defaults     interface{}
+	overrides    map[string]interface{}
 	overridesMtx sync.RWMutex
-	overrides    map[string]*Limits
 	quit         chan struct{}
 }
 
-// NewOverrides makes a new Overrides.
-// We store the supplied limits in a global variable to ensure per-tenant limits
-// are defaulted to those values.  As such, the last call to NewOverrides will
-// become the new global defaults.
-func NewOverrides(defaults Limits) (*Overrides, error) {
-	defaultLimits = defaults
+// NewOverridesManager creates an instance of OverridesManager and starts reload overrides loop based on config
+func NewOverridesManager(perTenantOverridePeriod time.Duration, overridesReloadPath string, overridesLoader overridesLoader,
+	defaults interface{}) (*OverridesManager, error) {
+	overridesManager := OverridesManager{
+		overridesLoader:       overridesLoader,
+		overridesReloadPeriod: perTenantOverridePeriod,
+		overridesReloadPath:   overridesReloadPath,
+		defaults:              defaults,
+	}
 
-	if defaults.PerTenantOverrideConfig == "" {
+	if overridesReloadPath != "" {
+		overridesManager.loop()
+	} else {
 		level.Info(util.Logger).Log("msg", "per-tenant overrides disabled")
-		return &Overrides{
-			Defaults:  defaults,
-			overrides: map[string]*Limits{},
-			quit:      make(chan struct{}),
-		}, nil
 	}
 
-	overrides, err := loadOverrides(defaults.PerTenantOverrideConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	o := &Overrides{
-		Defaults:  defaults,
-		overrides: overrides,
-		quit:      make(chan struct{}),
-	}
-
-	go o.loop()
-	return o, nil
+	return &overridesManager, nil
 }
 
-func (o *Overrides) loop() {
-	ticker := time.NewTicker(o.Defaults.PerTenantOverridePeriod)
+func (lm *OverridesManager) loop() {
+	ticker := time.NewTicker(lm.overridesReloadPeriod)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			overrides, err := loadOverrides(o.Defaults.PerTenantOverrideConfig)
+			err := lm.loadOverrides()
 			if err != nil {
-				overridesReloadSuccess.Set(0)
-				level.Error(util.Logger).Log("msg", "failed to reload overrides", "err", err)
-				continue
+				level.Error(util.Logger).Log("msg", "failed to load limit overrides", "err", err)
 			}
-			overridesReloadSuccess.Set(1)
-
-			o.overridesMtx.Lock()
-			o.overrides = overrides
-			o.overridesMtx.Unlock()
-		case <-o.quit:
+		case <-lm.quit:
 			return
 		}
 	}
 }
 
-// Stop background reloading of overrides.
-func (o *Overrides) Stop() {
-	close(o.quit)
-}
-
-func loadOverrides(filename string) (map[string]*Limits, error) {
-	f, err := os.Open(filename)
+func (lm *OverridesManager) loadOverrides() error {
+	overrides, err := lm.overridesLoader(lm.overridesReloadPath)
 	if err != nil {
-		return nil, err
+		overridesReloadSuccess.Set(0)
+		return err
 	}
+	overridesReloadSuccess.Set(1)
 
-	var overrides struct {
-		Overrides map[string]*Limits `yaml:"overrides"`
-	}
-
-	decoder := yaml.NewDecoder(f)
-	decoder.SetStrict(true)
-	if err := decoder.Decode(&overrides); err != nil {
-		return nil, err
-	}
-
-	return overrides.Overrides, nil
+	lm.overridesMtx.Lock()
+	defer lm.overridesMtx.Unlock()
+	lm.overrides = overrides
+	return nil
 }
 
-func (o *Overrides) getBool(userID string, f func(*Limits) bool) bool {
-	o.overridesMtx.RLock()
-	defer o.overridesMtx.RUnlock()
-	override, ok := o.overrides[userID]
+// Stop stops the OverridesManager
+func (lm *OverridesManager) Stop() {
+	close(lm.quit)
+}
+
+// GetLimits returns Limits for a specific userID if its set otherwise the default Limits
+func (lm *OverridesManager) GetLimits(userID string) interface{} {
+	lm.overridesMtx.RLock()
+	defer lm.overridesMtx.RUnlock()
+
+	override, ok := lm.overrides[userID]
 	if !ok {
-		return f(&o.Defaults)
+		return lm.defaults
 	}
-	return f(override)
-}
 
-func (o *Overrides) getInt(userID string, f func(*Limits) int) int {
-	o.overridesMtx.RLock()
-	defer o.overridesMtx.RUnlock()
-	override, ok := o.overrides[userID]
-	if !ok {
-		return f(&o.Defaults)
-	}
-	return f(override)
-}
-
-func (o *Overrides) getFloat(userID string, f func(*Limits) float64) float64 {
-	o.overridesMtx.RLock()
-	defer o.overridesMtx.RUnlock()
-	override, ok := o.overrides[userID]
-	if !ok {
-		return f(&o.Defaults)
-	}
-	return f(override)
-}
-
-func (o *Overrides) getDuration(userID string, f func(*Limits) time.Duration) time.Duration {
-	o.overridesMtx.RLock()
-	defer o.overridesMtx.RUnlock()
-	override, ok := o.overrides[userID]
-	if !ok {
-		return f(&o.Defaults)
-	}
-	return f(override)
-}
-
-func (o *Overrides) getString(userID string, f func(*Limits) string) string {
-	o.overridesMtx.RLock()
-	defer o.overridesMtx.RUnlock()
-	override, ok := o.overrides[userID]
-	if !ok {
-		return f(&o.Defaults)
-	}
-	return f(override)
-}
-
-// IngestionRate returns the limit on ingester rate (samples per second).
-func (o *Overrides) IngestionRate(userID string) float64 {
-	return o.getFloat(userID, func(l *Limits) float64 {
-		return l.IngestionRate
-	})
-}
-
-// IngestionBurstSize returns the burst size for ingestion rate.
-func (o *Overrides) IngestionBurstSize(userID string) int {
-	return o.getInt(userID, func(l *Limits) int {
-		return l.IngestionBurstSize
-	})
-}
-
-// AcceptHASamples returns whether the distributor should track and accept samples from HA replicas for this user.
-func (o *Overrides) AcceptHASamples(userID string) bool {
-	return o.getBool(userID, func(l *Limits) bool {
-		return l.AcceptHASamples
-	})
-}
-
-// HAReplicaLabel returns the replica label to look for when deciding whether to accept a sample from a Prometheus HA replica.
-func (o *Overrides) HAReplicaLabel(userID string) string {
-	return o.getString(userID, func(l *Limits) string {
-		return l.HAReplicaLabel
-	})
-}
-
-// HAClusterLabel returns the cluster label to look for when deciding whether to accept a sample from a Prometheus HA replica.
-func (o *Overrides) HAClusterLabel(userID string) string {
-	return o.getString(userID, func(l *Limits) string {
-		return l.HAClusterLabel
-	})
-}
-
-// MaxLabelNameLength returns maximum length a label name can be.
-func (o *Overrides) MaxLabelNameLength(userID string) int {
-	return o.getInt(userID, func(l *Limits) int {
-		return l.MaxLabelNameLength
-	})
-}
-
-// MaxLabelValueLength returns maximum length a label value can be. This also is
-// the maximum length of a metric name.
-func (o *Overrides) MaxLabelValueLength(userID string) int {
-	return o.getInt(userID, func(l *Limits) int {
-		return l.MaxLabelValueLength
-	})
-}
-
-// MaxLabelNamesPerSeries returns maximum number of label/value pairs timeseries.
-func (o *Overrides) MaxLabelNamesPerSeries(userID string) int {
-	return o.getInt(userID, func(l *Limits) int {
-		return l.MaxLabelNamesPerSeries
-	})
-}
-
-// RejectOldSamples returns true when we should reject samples older than certain
-// age.
-func (o *Overrides) RejectOldSamples(userID string) bool {
-	return o.getBool(userID, func(l *Limits) bool {
-		return l.RejectOldSamples
-	})
-}
-
-// RejectOldSamplesMaxAge returns the age at which samples should be rejected.
-func (o *Overrides) RejectOldSamplesMaxAge(userID string) time.Duration {
-	return o.getDuration(userID, func(l *Limits) time.Duration {
-		return l.RejectOldSamplesMaxAge
-	})
-}
-
-// CreationGracePeriod is misnamed, and actually returns how far into the future
-// we should accept samples.
-func (o *Overrides) CreationGracePeriod(userID string) time.Duration {
-	return o.getDuration(userID, func(l *Limits) time.Duration {
-		return l.CreationGracePeriod
-	})
-}
-
-// MaxSeriesPerQuery returns the maximum number of series a query is allowed to hit.
-func (o *Overrides) MaxSeriesPerQuery(userID string) int {
-	return o.getInt(userID, func(l *Limits) int {
-		return l.MaxSeriesPerQuery
-	})
-}
-
-// MaxSamplesPerQuery returns the maximum number of samples in a query (from the ingester).
-func (o *Overrides) MaxSamplesPerQuery(userID string) int {
-	return o.getInt(userID, func(l *Limits) int {
-		return l.MaxSamplesPerQuery
-	})
-}
-
-// MaxSeriesPerUser returns the maximum number of series a user is allowed to store.
-func (o *Overrides) MaxSeriesPerUser(userID string) int {
-	return o.getInt(userID, func(l *Limits) int {
-		return l.MaxSeriesPerUser
-	})
-}
-
-// MaxSeriesPerMetric returns the maximum number of series allowed per metric.
-func (o *Overrides) MaxSeriesPerMetric(userID string) int {
-	return o.getInt(userID, func(l *Limits) int {
-		return l.MaxSeriesPerMetric
-	})
-}
-
-// MaxChunksPerQuery returns the maximum number of chunks allowed per query.
-func (o *Overrides) MaxChunksPerQuery(userID string) int {
-	return o.getInt(userID, func(l *Limits) int {
-		return l.MaxChunksPerQuery
-	})
-}
-
-// MaxQueryLength returns the limit of the length (in time) of a query.
-func (o *Overrides) MaxQueryLength(userID string) time.Duration {
-	return o.getDuration(userID, func(l *Limits) time.Duration {
-		return l.MaxQueryLength
-	})
-}
-
-// MaxQueryParallelism returns the limit to the number of sub-queries the
-// frontend will process in parallel.
-func (o *Overrides) MaxQueryParallelism(userID string) int {
-	return o.getInt(userID, func(l *Limits) int {
-		return l.MaxQueryParallelism
-	})
-}
-
-// EnforceMetricName whether to enforce the presence of a metric name.
-func (o *Overrides) EnforceMetricName(userID string) bool {
-	return o.getBool(userID, func(l *Limits) bool {
-		return l.EnforceMetricName
-	})
-}
-
-// CardinalityLimit whether to enforce the presence of a metric name.
-func (o *Overrides) CardinalityLimit(userID string) int {
-	return o.getInt(userID, func(l *Limits) int {
-		return l.CardinalityLimit
-	})
+	return override
 }

--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -58,50 +58,50 @@ func NewOverridesManager(perTenantOverridePeriod time.Duration, overridesReloadP
 	return &overridesManager, nil
 }
 
-func (lm *OverridesManager) loop() {
-	ticker := time.NewTicker(lm.overridesReloadPeriod)
+func (om *OverridesManager) loop() {
+	ticker := time.NewTicker(om.overridesReloadPeriod)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			err := lm.loadOverrides()
+			err := om.loadOverrides()
 			if err != nil {
 				level.Error(util.Logger).Log("msg", "failed to load limit overrides", "err", err)
 			}
-		case <-lm.quit:
+		case <-om.quit:
 			return
 		}
 	}
 }
 
-func (lm *OverridesManager) loadOverrides() error {
-	overrides, err := lm.overridesLoader(lm.overridesReloadPath)
+func (om *OverridesManager) loadOverrides() error {
+	overrides, err := om.overridesLoader(om.overridesReloadPath)
 	if err != nil {
 		overridesReloadSuccess.Set(0)
 		return err
 	}
 	overridesReloadSuccess.Set(1)
 
-	lm.overridesMtx.Lock()
-	defer lm.overridesMtx.Unlock()
-	lm.overrides = overrides
+	om.overridesMtx.Lock()
+	defer om.overridesMtx.Unlock()
+	om.overrides = overrides
 	return nil
 }
 
 // Stop stops the OverridesManager
-func (lm *OverridesManager) Stop() {
-	close(lm.quit)
+func (om *OverridesManager) Stop() {
+	close(om.quit)
 }
 
 // GetLimits returns Limits for a specific userID if its set otherwise the default Limits
-func (lm *OverridesManager) GetLimits(userID string) interface{} {
-	lm.overridesMtx.RLock()
-	defer lm.overridesMtx.RUnlock()
+func (om *OverridesManager) GetLimits(userID string) interface{} {
+	om.overridesMtx.RLock()
+	defer om.overridesMtx.RUnlock()
 
-	override, ok := lm.overrides[userID]
+	override, ok := om.overrides[userID]
 	if !ok {
-		return lm.defaults
+		return om.defaults
 	}
 
 	return override

--- a/pkg/util/validation/override_test.go
+++ b/pkg/util/validation/override_test.go
@@ -51,7 +51,14 @@ func testLoadOverrides(filename string) (map[string]interface{}, error) {
 
 func TestOverridesManager_GetLimits(t *testing.T) {
 	defaultTestLimits = &TestLimits{Limit1: 100}
-	overridesManager, err := NewOverridesManager(0, "", testLoadOverrides, defaultTestLimits)
+	overridesManagerConfig := OverridesManagerConfig{
+		OverridesReloadPeriod: 0,
+		OverridesLoadPath:     "",
+		OverridesLoader:       testLoadOverrides,
+		Defaults:              defaultTestLimits,
+	}
+
+	overridesManager, err := NewOverridesManager(overridesManagerConfig)
 	require.NoError(t, err)
 
 	require.Equal(t, 100, overridesManager.GetLimits("user1").(*TestLimits).Limit1)
@@ -66,7 +73,7 @@ func TestOverridesManager_GetLimits(t *testing.T) {
     limit2: 150`)
 	require.NoError(t, err)
 
-	overridesManager.overridesReloadPath = tempFile.Name()
+	overridesManager.cfg.OverridesLoadPath = tempFile.Name()
 	require.NoError(t, overridesManager.loadOverrides())
 
 	// Checking whether overrides were enforced

--- a/pkg/util/validation/override_test.go
+++ b/pkg/util/validation/override_test.go
@@ -1,0 +1,82 @@
+package validation
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+type TestLimits struct {
+	Limit1 int `json:"limit1"`
+	Limit2 int `json:"limit2"`
+}
+
+var defaultTestLimits *TestLimits
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (l *TestLimits) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// We want to set c to the defaults and then overwrite it with the input.
+	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
+	// again, we have to hide it using a type indirection.  See prometheus/config.
+	if defaultLimits != nil {
+		*l = *defaultTestLimits
+	}
+	type plain TestLimits
+	return unmarshal((*plain)(l))
+}
+
+func testLoadOverrides(filename string) (map[string]interface{}, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var overrides struct {
+		Overrides map[string]*TestLimits `yaml:"overrides"`
+	}
+
+	decoder := yaml.NewDecoder(f)
+	decoder.SetStrict(true)
+	if err := decoder.Decode(&overrides); err != nil {
+		return nil, err
+	}
+
+	overridesAsInterface := map[string]interface{}{}
+	for k := range overrides.Overrides {
+		overridesAsInterface[k] = overrides.Overrides[k]
+	}
+
+	return overridesAsInterface, nil
+}
+
+func TestOverridesManager_GetLimits(t *testing.T) {
+	defaultTestLimits = &TestLimits{Limit1: 100}
+	overridesManager, err := NewOverridesManager(0, "", testLoadOverrides, defaultTestLimits)
+	require.NoError(t, err)
+
+	require.Equal(t, 100, overridesManager.GetLimits("user1").(*TestLimits).Limit1)
+	require.Equal(t, 0, overridesManager.GetLimits("user1").(*TestLimits).Limit2)
+
+	// Setting up perTenantOverrides for user user1
+	tempFile, err := ioutil.TempFile("", "test-validation")
+	require.NoError(t, err)
+
+	_, err = tempFile.WriteString(`overrides:
+  user1:
+    limit2: 150`)
+	require.NoError(t, err)
+
+	overridesManager.overridesReloadPath = tempFile.Name()
+	require.NoError(t, overridesManager.loadOverrides())
+
+	// Checking whether overrides were enforced
+	require.Equal(t, 150, overridesManager.GetLimits("user1").(*TestLimits).Limit2)
+	require.Equal(t, 0, overridesManager.GetLimits("user2").(*TestLimits).Limit2)
+
+	// Cleaning up
+	require.NoError(t, tempFile.Close())
+	require.NoError(t, os.Remove(tempFile.Name()))
+}

--- a/pkg/util/validation/override_test.go
+++ b/pkg/util/validation/override_test.go
@@ -18,9 +18,6 @@ var defaultTestLimits *TestLimits
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (l *TestLimits) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// We want to set c to the defaults and then overwrite it with the input.
-	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
-	// again, we have to hide it using a type indirection.  See prometheus/config.
 	if defaultLimits != nil {
 		*l = *defaultTestLimits
 	}


### PR DESCRIPTION
This would be useful to define limits specific to Loki while still being able to use the same code for managing limits and per tenant overwrites.

Changes include:
1. Limits are now stored as key-value pairs, where the key is a string and values are interfaces for being able to support dynamic limits
2. Limits need to be registered before being able to use them
3. Sample and Labels validation methods now accept any type which implements required methods to get required limits for validation
4. Added Setter methods to change default limit values at runtime for testing purpose

Signed-off-by: Sandeep Sukhani <sandeep.d.sukhani@gmail.com>