### PR TITLE
Make build job will use IMAGE_TAG if present

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,9 @@ jobs:
         name: Build
         command: |
           touch build-image/.uptodate
+          if [ -n "$CIRCLE_TAG" ]; then
+            export IMAGE_TAG=$CIRCLE_TAG
+          fi
           make BUILD_IN_CONTAINER=false
 
     - store_artifacts:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Boiler plate for bulding Docker containers.
 # All this must go at top of file I'm afraid.
 IMAGE_PREFIX ?= quay.io/cortexproject/
-IMAGE_TAG := $(shell ./tools/image-tag)
+IMAGE_TAG ?= $(shell ./tools/image-tag)
 GIT_REVISION := $(shell git rev-parse HEAD)
 UPTODATE := .uptodate
 


### PR DESCRIPTION
The deploy job for the tag failed because the images were built without the proper IMAGE_TAG (they were HEAD-<sha>), and the deploy job tried to upload them as v0.1.0-rc.0

See https://circleci.com/gh/cortexproject/cortex/8195