### PR TITLE
Set IMAGE_TAG to CIRCLE_TAG in Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,9 +95,6 @@ jobs:
         name: Build
         command: |
           touch build-image/.uptodate
-          if [ -n "$CIRCLE_TAG" ]; then
-            export IMAGE_TAG=$CIRCLE_TAG
-          fi
           make BUILD_IN_CONTAINER=false
 
     - store_artifacts:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 # Boiler plate for bulding Docker containers.
 # All this must go at top of file I'm afraid.
 IMAGE_PREFIX ?= quay.io/cortexproject/
-IMAGE_TAG ?= $(shell ./tools/image-tag)
+# Use CIRCLE_TAG if present for releases.
+IMAGE_TAG ?= $(if $(CIRCLE_TAG),$(CIRCLE_TAG),$(shell ./tools/image-tag))
 GIT_REVISION := $(shell git rev-parse HEAD)
 UPTODATE := .uptodate
 


### PR DESCRIPTION
There are other steps in the build and deploy jobs that need IMAGE_TAG set to the CIRCLE_TAG. It will be easiest if the Makefile just knows to use CIRCLE_TAG if it is present.