### PR TITLE
Export createSchema function

### DIFF
--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -46,7 +46,7 @@ func NewCompositeStore() CompositeStore {
 
 // AddPeriod adds the configuration for a period of time to the CompositeStore
 func (c *CompositeStore) AddPeriod(storeCfg StoreConfig, cfg PeriodConfig, index IndexClient, chunks ObjectClient, limits *validation.Overrides) error {
-	schema := cfg.createSchema()
+	schema := cfg.CreateSchema()
 	var store Store
 	var err error
 	switch cfg.Schema {

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -188,7 +188,8 @@ func (cfg *SchemaConfig) ForEachAfter(t model.Time, f func(config *PeriodConfig)
 	}
 }
 
-func (cfg PeriodConfig) createSchema() Schema {
+// CreateSchema returns the schema defined by the PeriodConfig
+func (cfg PeriodConfig) CreateSchema() Schema {
 	var s schema
 	switch cfg.Schema {
 	case "v1":

--- a/pkg/chunk/schema_test.go
+++ b/pkg/chunk/schema_test.go
@@ -39,7 +39,7 @@ func makeSchema(schemaName string) Schema {
 	return PeriodConfig{
 		Schema:      schemaName,
 		IndexTables: PeriodicTableConfig{Prefix: table},
-	}.createSchema()
+	}.CreateSchema()
 }
 
 func TestSchemaHashKeys(t *testing.T) {


### PR DESCRIPTION
It is handy to export the createSchema function so that I can make tools that can interact with cortex chunks and index entries with only a PeriodConfig yaml file required to configure it. Exporting this makes building tools for interacting with cortex storage backends much easier.
Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>