### PR TITLE
Support consistent hashing in cache.NewMemcachedClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master / unreleased
 
+* [FEATURE] Add option to use jump hashing to load balance requests to memcached #1554
+
 ## 0.1.0 / 2019-08-07
 
 * [CHANGE] HA Tracker flags were renamed to provide more clarity #1465

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d
 	github.com/cenkalti/backoff v1.0.0 // indirect
+	github.com/cespare/xxhash v1.1.0
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/cznic/ql v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/cznic/ql v1.2.0 // indirect
+	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/fluent/fluent-logger-golang v1.2.1 // indirect
 	github.com/fsouza/fake-gcs-server v1.3.0
 	github.com/go-kit/kit v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo
 github.com/evanphx/json-patch v4.1.0+incompatible h1:K1MDoo4AZ4wU0GIU/fPmtZg7VpzLjCxu+UwBD1FvwOc=
 github.com/evanphx/json-patch v4.1.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
+github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb h1:IT4JYU7k4ikYg1SCxNI1/Tieq/NFvh6dzLdgi7eu0tM=
+github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:bH6Xx7IW64qjjJq8M2u4dxNaBiDfKK+z/3eGDpXEQhc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fluent/fluent-logger-golang v1.2.1 h1:CMA+mw2zMiOGEOarZtaqM3GBWT1IVLNncNi0nKELtmU=
 github.com/fluent/fluent-logger-golang v1.2.1/go.mod h1:2/HCT/jTy78yGyeNGQLGQsjF3zzzAuy6Xlk6FCMV5eU=

--- a/pkg/chunk/cache/memcached_client_selector.go
+++ b/pkg/chunk/cache/memcached_client_selector.go
@@ -1,0 +1,126 @@
+package cache
+
+import (
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/cespare/xxhash"
+)
+
+// MemcachedJumpHashSelector implements the memcache.ServerSelector
+// interface. MemcachedJumpHashSelector utilizes a jump hash to
+// distribute keys to servers.
+//
+// While adding or removing servers only requires 1/N keys to move,
+// servers are treated as a stack and can only be pushed/popped.
+// Therefore, MemcachedJumpHashSelector works best for servers
+// with consistent DNS names where the order doesn't arbitrarily
+// change.
+type MemcachedJumpHashSelector struct {
+	mu    sync.RWMutex
+	addrs []net.Addr
+}
+
+// staticAddr caches the Network() and String() values from
+// any net.Addr.
+//
+// Copied from github.com/bradfitz/gomemcache/selector.go.
+type staticAddr struct {
+	network, str string
+}
+
+func newStaticAddr(a net.Addr) net.Addr {
+	return &staticAddr{
+		network: a.Network(),
+		str:     a.String(),
+	}
+}
+
+func (a *staticAddr) Network() string { return a.network }
+func (a *staticAddr) String() string  { return a.str }
+
+// SetServers changes a MemcachedJumpHashSelector's set of servers at
+// runtime and is safe for concurrent use by multiple goroutines.
+//
+// Each server is given equal weight. A server is given more weight
+// if it's listed multiple times.
+//
+// SetServers returns an error if any of the server names fail to
+// resolve. No attempt is made to connect to the server. If any
+// error occurs, no changes are made to the internal server list.
+//
+// To minimize number of rehashes for keys when growing or shrinking
+// the number of servers, servers should be provided in as consistent
+// of an order as possible between invocations.
+func (s *MemcachedJumpHashSelector) SetServers(servers ...string) error {
+	naddrs := make([]net.Addr, len(servers))
+	for i, server := range servers {
+		if strings.Contains(server, "/") {
+			addr, err := net.ResolveUnixAddr("unix", server)
+			if err != nil {
+				return err
+			}
+			naddrs[i] = newStaticAddr(addr)
+		} else {
+			tcpAddr, err := net.ResolveTCPAddr("tcp", server)
+			if err != nil {
+				return err
+			}
+			naddrs[i] = newStaticAddr(tcpAddr)
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.addrs = naddrs
+	return nil
+}
+
+// jumpHash consistently chooses a hash bucket number in the range [0, numBuckets) for the given key.
+// numBuckets must be >= 1.
+//
+// Copied from github.com/dgryski/go-jump/blob/master/jump.go
+func jumpHash(key uint64, numBuckets int) int32 {
+
+	var b int64 = -1
+	var j int64
+
+	for j < int64(numBuckets) {
+		b = j
+		key = key*2862933555777941757 + 1
+		j = int64(float64(b+1) * (float64(int64(1)<<31) / float64((key>>33)+1)))
+	}
+
+	return int32(b)
+}
+
+// PickServer returns the server address that a given item
+// should be shared onto.
+func (s *MemcachedJumpHashSelector) PickServer(key string) (net.Addr, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.addrs) == 0 {
+		return nil, memcache.ErrNoServers
+	} else if len(s.addrs) == 1 {
+		return s.addrs[0], nil
+	}
+	cs := xxhash.Sum64String(key)
+	idx := jumpHash(cs, len(s.addrs))
+	return s.addrs[idx], nil
+}
+
+// Each iterates over each server and calls the given function.
+// If f returns a non-nil error, iteration will stop and that
+// error will be returned.
+func (s *MemcachedJumpHashSelector) Each(f func(net.Addr) error) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, def := range s.addrs {
+		if err := f(def); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/chunk/cache/memcached_client_selector_test.go
+++ b/pkg/chunk/cache/memcached_client_selector_test.go
@@ -1,0 +1,40 @@
+package cache_test
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/cortexproject/cortex/pkg/chunk/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemcachedJumpHashSelector_PickSever(t *testing.T) {
+	s := cache.MemcachedJumpHashSelector{}
+	err := s.SetServers("google.com:80", "microsoft.com:80", "duckduckgo.com:80")
+	require.NoError(t, err)
+
+	distribution := make(map[net.Addr]int)
+
+	for i := 0; i < 100; i++ {
+		key := fmt.Sprintf("key-%d", i)
+		addr, err := s.PickServer(key)
+		if assert.NoError(t, err) {
+			distribution[addr]++
+		}
+	}
+
+	// All of the servers should have been returned at least
+	// once
+	for _, v := range distribution {
+		assert.NotZero(t, v)
+	}
+}
+
+func TestMemcachedJumpHashSelector_PickSever_ErrNoServers(t *testing.T) {
+	s := cache.MemcachedJumpHashSelector{}
+	_, err := s.PickServer("foo")
+	assert.Error(t, memcache.ErrNoServers, err)
+}

--- a/pkg/chunk/cache/memcached_client_selector_test.go
+++ b/pkg/chunk/cache/memcached_client_selector_test.go
@@ -6,8 +6,33 @@ import (
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
+	"github.com/facette/natsort"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNatSort(t *testing.T) {
+	// Validate that the order of SRV records returned by a DNS
+	// lookup for a k8s StatefulSet are ordered as expected when
+	// a natsort is done.
+	input := []string{
+		"memcached-10.memcached.cortex.svc.cluster.local.",
+		"memcached-1.memcached.cortex.svc.cluster.local.",
+		"memcached-6.memcached.cortex.svc.cluster.local.",
+		"memcached-3.memcached.cortex.svc.cluster.local.",
+		"memcached-25.memcached.cortex.svc.cluster.local.",
+	}
+
+	expected := []string{
+		"memcached-1.memcached.cortex.svc.cluster.local.",
+		"memcached-3.memcached.cortex.svc.cluster.local.",
+		"memcached-6.memcached.cortex.svc.cluster.local.",
+		"memcached-10.memcached.cortex.svc.cluster.local.",
+		"memcached-25.memcached.cortex.svc.cluster.local.",
+	}
+
+	natsort.Sort(input)
+	require.Equal(t, expected, input)
+}
 
 func TestMemcachedJumpHashSelector_PickSever(t *testing.T) {
 	s := cache.MemcachedJumpHashSelector{}

--- a/vendor/github.com/facette/natsort/LICENSE
+++ b/vendor/github.com/facette/natsort/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2015, Vincent Batoufflet and Marc Falzon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+ * Neither the name of the authors nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/facette/natsort/README.md
+++ b/vendor/github.com/facette/natsort/README.md
@@ -1,0 +1,104 @@
+# natsort: natural strings sorting in Go
+
+This is an implementation of the "Alphanum Algorithm" by [Dave Koelle][0] in Go.
+
+[![GoDoc](https://godoc.org/facette.io/natsort?status.svg)](https://godoc.org/facette.io/natsort)
+
+## Usage
+
+```go
+package main
+
+import (
+    "fmt"
+    "strings"
+
+    "facette.io/natsort"
+)
+
+func main() {
+    list := []string{
+        "1000X Radonius Maximus",
+        "10X Radonius",
+        "200X Radonius",
+        "20X Radonius",
+        "20X Radonius Prime",
+        "30X Radonius",
+        "40X Radonius",
+        "Allegia 50 Clasteron",
+        "Allegia 500 Clasteron",
+        "Allegia 50B Clasteron",
+        "Allegia 51 Clasteron",
+        "Allegia 6R Clasteron",
+        "Alpha 100",
+        "Alpha 2",
+        "Alpha 200",
+        "Alpha 2A",
+        "Alpha 2A-8000",
+        "Alpha 2A-900",
+        "Callisto Morphamax",
+        "Callisto Morphamax 500",
+        "Callisto Morphamax 5000",
+        "Callisto Morphamax 600",
+        "Callisto Morphamax 6000 SE",
+        "Callisto Morphamax 6000 SE2",
+        "Callisto Morphamax 700",
+        "Callisto Morphamax 7000",
+        "Xiph Xlater 10000",
+        "Xiph Xlater 2000",
+        "Xiph Xlater 300",
+        "Xiph Xlater 40",
+        "Xiph Xlater 5",
+        "Xiph Xlater 50",
+        "Xiph Xlater 500",
+        "Xiph Xlater 5000",
+        "Xiph Xlater 58",
+    }
+
+    natsort.Sort(list)
+
+    fmt.Println(strings.Join(list, "\n"))
+}
+```
+
+Output:
+
+```
+10X Radonius
+20X Radonius
+20X Radonius Prime
+30X Radonius
+40X Radonius
+200X Radonius
+1000X Radonius Maximus
+Allegia 6R Clasteron
+Allegia 50 Clasteron
+Allegia 50B Clasteron
+Allegia 51 Clasteron
+Allegia 500 Clasteron
+Alpha 2
+Alpha 2A
+Alpha 2A-900
+Alpha 2A-8000
+Alpha 100
+Alpha 200
+Callisto Morphamax
+Callisto Morphamax 500
+Callisto Morphamax 600
+Callisto Morphamax 700
+Callisto Morphamax 5000
+Callisto Morphamax 6000 SE
+Callisto Morphamax 6000 SE2
+Callisto Morphamax 7000
+Xiph Xlater 5
+Xiph Xlater 40
+Xiph Xlater 50
+Xiph Xlater 58
+Xiph Xlater 300
+Xiph Xlater 500
+Xiph Xlater 2000
+Xiph Xlater 5000
+Xiph Xlater 10000
+```
+
+[0]: http://davekoelle.com/alphanum.html

--- a/vendor/github.com/facette/natsort/natsort.go
+++ b/vendor/github.com/facette/natsort/natsort.go
@@ -1,0 +1,85 @@
+// Package natsort implements natural strings sorting
+package natsort
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+)
+
+type stringSlice []string
+
+func (s stringSlice) Len() int {
+	return len(s)
+}
+
+func (s stringSlice) Less(a, b int) bool {
+	return Compare(s[a], s[b])
+}
+
+func (s stringSlice) Swap(a, b int) {
+	s[a], s[b] = s[b], s[a]
+}
+
+var chunkifyRegexp = regexp.MustCompile(`(\d+|\D+)`)
+
+func chunkify(s string) []string {
+	return chunkifyRegexp.FindAllString(s, -1)
+}
+
+// Sort sorts a list of strings in a natural order
+func Sort(l []string) {
+	sort.Sort(stringSlice(l))
+}
+
+// Compare returns true if the first string precedes the second one according to natural order
+func Compare(a, b string) bool {
+	chunksA := chunkify(a)
+	chunksB := chunkify(b)
+
+	nChunksA := len(chunksA)
+	nChunksB := len(chunksB)
+
+	for i := range chunksA {
+		if i >= nChunksB {
+			return false
+		}
+
+		aInt, aErr := strconv.Atoi(chunksA[i])
+		bInt, bErr := strconv.Atoi(chunksB[i])
+
+		// If both chunks are numeric, compare them as integers
+		if aErr == nil && bErr == nil {
+			if aInt == bInt {
+				if i == nChunksA-1 {
+					// We reached the last chunk of A, thus B is greater than A
+					return true
+				} else if i == nChunksB-1 {
+					// We reached the last chunk of B, thus A is greater than B
+					return false
+				}
+
+				continue
+			}
+
+			return aInt < bInt
+		}
+
+		// So far both strings are equal, continue to next chunk
+		if chunksA[i] == chunksB[i] {
+			if i == nChunksA-1 {
+				// We reached the last chunk of A, thus B is greater than A
+				return true
+			} else if i == nChunksB-1 {
+				// We reached the last chunk of B, thus A is greater than B
+				return false
+			}
+
+			continue
+		}
+
+		return chunksA[i] < chunksB[i]
+	}
+
+	return false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -112,6 +112,8 @@ github.com/davecgh/go-spew/spew
 github.com/dgrijalva/jwt-go
 # github.com/dustin/go-humanize v1.0.0
 github.com/dustin/go-humanize
+# github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
+github.com/facette/natsort
 # github.com/fluent/fluent-logger-golang v1.2.1
 github.com/fluent/fluent-logger-golang/fluent
 # github.com/fsouza/fake-gcs-server v1.3.0


### PR DESCRIPTION
This PR adds support for consistent hashing of memcached servers by server DNS name. 
Support for this is behind a boolean configuration variable in the client config, available in the flags as `-memcached.consistent-hash` 

The use of jump hash enables consistent hashing when adding or removing a memcached server only requires 1/N keys being moved. A downside to jump hash in particular is that the order of DNS names used for the servers must be predictable to maximize efficiency. A good example of a predictable DNS name is `memcached-[pod index].cortex.svc.cluster.local`, which is what Kubernetes would create when running memcached as a StatefulSet on a headless service. 

/cc @tomwilkie 