### PR TITLE
Remove 'work in progress' from architecture doc

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,5 @@
 # Cortex Architecture
 
-> This document is a work in progress. Check back for updates in the coming weeks.
-
 Cortex consists of multiple horizontally scalable microservices. Each microservice uses the most appropriate technique for horizontal scaling; most are stateless and can handle requests for any users while some (namely the [ingesters](#ingester)) are semi-stateful and depend on consistent hashing. This document provides a basic overview of Cortex's architecture.
 
 <p align="center"><img src="architecture.png" alt="Cortex Architecture"></p>


### PR DESCRIPTION
It's ok as it stands, and nobody is actively working on it.
