### PR TITLE
Recieving no series is a valid case

### DIFF
--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -105,11 +105,6 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 		receivedChunks.Add(float64(len(descs)))
 	}
 
-	if seriesReceived == 0 {
-		level.Error(util.Logger).Log("msg", "received TransferChunks request with no series", "from_ingester", fromIngesterID)
-		return fmt.Errorf("no series")
-	}
-
 	if fromIngesterID == "" {
 		level.Error(util.Logger).Log("msg", "received TransferChunks request with no ID from ingester")
 		return fmt.Errorf("no ingester id")


### PR DESCRIPTION
If we're doing an upgrade in a completely new cluster, the ingesters are
not going to send anything and this'll just slow the rollout process and
cause un-necessary alerts.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>