### PR TITLE
check for retention period to be a multiple of periodic table duration and relevant test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE] Add option to use jump hashing to load balance requests to memcached #1554
 * [FEATURE] Add status page for HA tracker to distributors #1546
+* [CHANGE] Added check for retention period to be a multiple of periodic table duration #1564
 
 ## 0.1.0 / 2019-08-07
 
@@ -13,3 +14,4 @@
 * [FEATURE] You can specify "heap ballast" to reduce Go GC Churn #1489
 * [BUGFIX] HA Tracker no longer always makes a request to Consul/Etcd when a request is not from the active replica #1516
 * [BUGFIX] Queries are now correctly cancelled by the query-frontend #1508
+* [CHANGE] Added check for retention period to be a multiple of periodic table duration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## master / unreleased
 
+* [CHANGE] Retention period should now be a multiple of periodic table duration #1564
 * [FEATURE] Add option to use jump hashing to load balance requests to memcached #1554
 * [FEATURE] Add status page for HA tracker to distributors #1546
-* [CHANGE] Retention period should now be a multiple of periodic table duration #1564
 
 ## 0.1.0 / 2019-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [FEATURE] Add option to use jump hashing to load balance requests to memcached #1554
 * [FEATURE] Add status page for HA tracker to distributors #1546
-* [CHANGE] Added check for retention period to be a multiple of periodic table duration #1564
+* [CHANGE] Retention period should now be a multiple of periodic table duration #1564
 
 ## 0.1.0 / 2019-08-07
 
@@ -14,4 +14,3 @@
 * [FEATURE] You can specify "heap ballast" to reduce Go GC Churn #1489
 * [BUGFIX] HA Tracker no longer always makes a request to Consul/Etcd when a request is not from the active replica #1516
 * [BUGFIX] Queries are now correctly cancelled by the query-frontend #1508
-* [CHANGE] Added check for retention period to be a multiple of periodic table duration

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"sort"
@@ -126,6 +127,11 @@ type TableManager struct {
 // NewTableManager makes a new TableManager
 func NewTableManager(cfg TableManagerConfig, schemaCfg SchemaConfig, maxChunkAge time.Duration, tableClient TableClient,
 	objectClient BucketClient) (*TableManager, error) {
+	// Assume the newest config is the one to use for validation of retention
+	if cfg.RetentionPeriod != 0 && cfg.RetentionPeriod%schemaCfg.Configs[len(schemaCfg.Configs)-1].IndexTables.Period != 0 {
+		return nil, errors.New("retention period should now be a multiple of periodic table duration")
+	}
+
 	return &TableManager{
 		cfg:          cfg,
 		schemaCfg:    schemaCfg,

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -127,9 +127,13 @@ type TableManager struct {
 // NewTableManager makes a new TableManager
 func NewTableManager(cfg TableManagerConfig, schemaCfg SchemaConfig, maxChunkAge time.Duration, tableClient TableClient,
 	objectClient BucketClient) (*TableManager, error) {
-	// Assume the newest config is the one to use for validation of retention
-	if cfg.RetentionPeriod != 0 && cfg.RetentionPeriod%schemaCfg.Configs[len(schemaCfg.Configs)-1].IndexTables.Period != 0 {
-		return nil, errors.New("retention period should now be a multiple of periodic table duration")
+
+	if cfg.RetentionPeriod != 0 {
+		// Assume the newest config is the one to use for validation of retention
+		indexTablesPeriod := schemaCfg.Configs[len(schemaCfg.Configs)-1].IndexTables.Period
+		if indexTablesPeriod != 0 && cfg.RetentionPeriod%indexTablesPeriod != 0 {
+			return nil, errors.New("retention period should now be a multiple of periodic table duration")
+		}
 	}
 
 	return &TableManager{

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -691,4 +691,9 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 			{Name: chunkTablePrefix + "3", ProvisionedRead: read, ProvisionedWrite: write},
 		},
 	)
+
+	// Test table manager retention not multiple of periodic config
+	tbmConfig.RetentionPeriod++
+	_, err = NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil)
+	require.Error(t, err)
 }


### PR DESCRIPTION
When the retention period is not a multiple of periodic table duration, we need to error out since Cortex doesn't yet support partial deletion of tables.
Added a check to validate retention against the latest config(assuming the last one is the latest) and relevant test.

Signed-off-by: Sandeep Sukhani <sandeep.d.sukhani@gmail.com>