### PR TITLE
Remove claim-on-rollout option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.0 / 2019-08-07
 
+* [CHANGE] --claim-on-rollout flag deprecated; feature is now always on #1566
 * [CHANGE] HA Tracker flags were renamed to provide more clarity #1465
   * `distributor.accept-ha-labels` is now `distributor.ha-tracker.enable`
   * `distributor.accept-ha-samples` is now `distributor.ha-tracker.enable-for-all-users`

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -94,7 +94,6 @@ func TestIngesterTransfer(t *testing.T) {
 	cfg1 := defaultIngesterTestConfig()
 	cfg1.LifecyclerConfig.ID = "ingester1"
 	cfg1.LifecyclerConfig.Addr = "ingester1"
-	cfg1.LifecyclerConfig.ClaimOnRollout = true
 	cfg1.LifecyclerConfig.JoinAfter = 0 * time.Second
 	ing1, err := New(cfg1, defaultClientTestConfig(), limits, nil, nil)
 	require.NoError(t, err)
@@ -184,7 +183,6 @@ func TestIngesterBadTransfer(t *testing.T) {
 	cfg := defaultIngesterTestConfig()
 	cfg.LifecyclerConfig.ID = "ingester1"
 	cfg.LifecyclerConfig.Addr = "ingester1"
-	cfg.LifecyclerConfig.ClaimOnRollout = true
 	cfg.LifecyclerConfig.JoinAfter = 100 * time.Second
 	ing, err := New(cfg, defaultClientTestConfig(), limits, nil, nil)
 	require.NoError(t, err)

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -41,6 +41,7 @@ func defaultIngesterTestConfig() Config {
 	cfg.LifecyclerConfig.Addr = "localhost"
 	cfg.LifecyclerConfig.ID = "localhost"
 	cfg.LifecyclerConfig.FinalSleep = 0
+	cfg.MaxTransferRetries = -1
 	return cfg
 }
 
@@ -95,6 +96,7 @@ func TestIngesterTransfer(t *testing.T) {
 	cfg1.LifecyclerConfig.ID = "ingester1"
 	cfg1.LifecyclerConfig.Addr = "ingester1"
 	cfg1.LifecyclerConfig.JoinAfter = 0 * time.Second
+	cfg1.MaxTransferRetries = 10
 	ing1, err := New(cfg1, defaultClientTestConfig(), limits, nil, nil)
 	require.NoError(t, err)
 

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -184,6 +184,9 @@ func fromWireChunks(wireChunks []client.Chunk) ([]*desc, error) {
 // TransferOut finds an ingester in PENDING state and transfers our chunks to it.
 // Called as part of the ingester shutdown process.
 func (i *Ingester) TransferOut(ctx context.Context) error {
+	if i.cfg.MaxTransferRetries < 0 {
+		return fmt.Errorf("transfers disabled")
+	}
 	backoff := util.NewBackoff(ctx, util.BackoffConfig{
 		MinBackoff: 100 * time.Millisecond,
 		MaxBackoff: 5 * time.Second,

--- a/pkg/ring/lifecycler_test.go
+++ b/pkg/ring/lifecycler_test.go
@@ -32,7 +32,6 @@ func testLifecyclerConfig(ringConfig Config, id string) LifecyclerConfig {
 	lifecyclerConfig.Port = 1
 	lifecyclerConfig.RingConfig = ringConfig
 	lifecyclerConfig.NumTokens = 1
-	lifecyclerConfig.ClaimOnRollout = true
 	lifecyclerConfig.ID = id
 	lifecyclerConfig.FinalSleep = 0
 	return lifecyclerConfig


### PR DESCRIPTION
As discussed in [Slack](https://cloud-native.slack.com/archives/CCYDASBLP/p1565106143201700)

> **Chris Marchbanks**   Related to #1560, What do people think of defaulting the flag `-ingester.claim-on-rollout` to true, maybe even deprecating the flag. Does anyone run with that flag off?
> **Bryan Boreham**  I've just looked back to see that the flag came in with #325, where the whole rolling updates thing was added.
> So it was reasonable at the time to have a way to turn it off, but I think it's past its usefulness.

Leave the flag and yaml names for now to avoid crashing.
