### PR TITLE
Vendor tsdb and reuse iterators

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/common v0.4.1
 	github.com/prometheus/prometheus v0.0.0-20190731144842-63ed2e28f1ac
-	github.com/prometheus/tsdb v0.9.1
+	github.com/prometheus/tsdb v0.10.0
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 	github.com/sercand/kuberesolver v2.1.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,8 @@ github.com/prometheus/prometheus v0.0.0-20190731144842-63ed2e28f1ac h1:nDONJ/OeN
 github.com/prometheus/prometheus v0.0.0-20190731144842-63ed2e28f1ac/go.mod h1:0nIafMIZWDF3P7oq1Xf8HKRZ0I37hKmhYEAupBEaa4A=
 github.com/prometheus/tsdb v0.9.1 h1:IWaAmWkYlgG7/S4iw4IpAQt5Y35QaZM6/GsZ7GsjAuk=
 github.com/prometheus/tsdb v0.9.1/go.mod h1:oi49uRhEe9dPUTlS3JRZOwJuVi6tmh10QSgwXEyGCt4=
+github.com/prometheus/tsdb v0.10.0 h1:If5rVCMTp6W2SiRAQFlbpJNgVlgMEd+U2GZckwK38ic=
+github.com/prometheus/tsdb v0.10.0/go.mod h1:oi49uRhEe9dPUTlS3JRZOwJuVi6tmh10QSgwXEyGCt4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rlmcpherson/s3gof3r v0.5.0/go.mod h1:s7vv7SMDPInkitQMuZzH615G7yWHdrU2r/Go7Bo71Rs=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -336,7 +336,7 @@ func equalByKey(a, b Chunk) bool {
 
 // Samples returns all SamplePairs for the chunk.
 func (c *Chunk) Samples(from, through model.Time) ([]model.SamplePair, error) {
-	it := c.Data.NewIterator()
+	it := c.Data.NewIterator(nil)
 	interval := metric.Interval{OldestInclusive: from, NewestInclusive: through}
 	return prom_chunk.RangeValues(it, interval)
 }

--- a/pkg/chunk/encoding/bigchunk.go
+++ b/pkg/chunk/encoding/bigchunk.go
@@ -171,12 +171,17 @@ func (b *bigchunk) Size() int {
 	return sum
 }
 
-func (b *bigchunk) NewIterator() Iterator {
+func (b *bigchunk) NewIterator(reuseIter Iterator) Iterator {
 	var it chunkenc.Iterator
 	if len(b.chunks) > 0 {
 		it = b.chunks[0].Iterator(it)
 	} else {
 		it = chunkenc.NewNopIterator()
+	}
+	if bci, ok := reuseIter.(*bigchunkIterator); ok {
+		bci.bigchunk = b
+		bci.curr = it
+		bci.i = 0
 	}
 	return &bigchunkIterator{
 		bigchunk: b,

--- a/pkg/chunk/encoding/bigchunk.go
+++ b/pkg/chunk/encoding/bigchunk.go
@@ -114,6 +114,8 @@ func (b *bigchunk) UnmarshalFromBuf(buf []byte) error {
 	}
 
 	b.chunks = make([]smallChunk, 0, numChunks+1) // allow one extra space in case we want to add new data
+	var reuseIter chunkenc.Iterator
+	var start, end int64
 	for i := uint16(0); i < numChunks; i++ {
 		chunkLen, err := r.ReadUint16()
 		if err != nil {
@@ -130,7 +132,7 @@ func (b *bigchunk) UnmarshalFromBuf(buf []byte) error {
 			return err
 		}
 
-		start, end, err := firstAndLastTimes(chunk)
+		start, end, reuseIter, err = firstAndLastTimes(chunk, reuseIter)
 		if err != nil {
 			return err
 		}
@@ -172,7 +174,7 @@ func (b *bigchunk) Size() int {
 func (b *bigchunk) NewIterator() Iterator {
 	var it chunkenc.Iterator
 	if len(b.chunks) > 0 {
-		it = b.chunks[0].Iterator()
+		it = b.chunks[0].Iterator(it)
 	} else {
 		it = chunkenc.NewNopIterator()
 	}
@@ -257,9 +259,9 @@ func (it *bigchunkIterator) FindAtOrAfter(target model.Time) bool {
 	}
 
 	if it.curr == nil {
-		it.curr = it.chunks[it.i].Iterator()
+		it.curr = it.chunks[it.i].Iterator(it.curr)
 	} else if t, _ := it.curr.At(); int64(target) <= t {
-		it.curr = it.chunks[it.i].Iterator()
+		it.curr = it.chunks[it.i].Iterator(it.curr)
 	}
 
 	for it.curr.Next() {
@@ -281,7 +283,7 @@ func (it *bigchunkIterator) Scan() bool {
 
 	for it.i < len(it.chunks)-1 {
 		it.i++
-		it.curr = it.chunks[it.i].Iterator()
+		it.curr = it.chunks[it.i].Iterator(it.curr)
 		if it.curr.Next() {
 			return true
 		}
@@ -321,13 +323,13 @@ func (it *bigchunkIterator) Err() error {
 	return nil
 }
 
-func firstAndLastTimes(c chunkenc.Chunk) (int64, int64, error) {
+func firstAndLastTimes(c chunkenc.Chunk, iter chunkenc.Iterator) (int64, int64, chunkenc.Iterator, error) {
 	var (
 		first    int64
 		last     int64
 		firstSet bool
-		iter     = c.Iterator()
 	)
+	iter = c.Iterator(iter)
 	for iter.Next() {
 		t, _ := iter.At()
 		if !firstSet {
@@ -336,5 +338,5 @@ func firstAndLastTimes(c chunkenc.Chunk) (int64, int64, error) {
 		}
 		last = t
 	}
-	return first, last, iter.Err()
+	return first, last, iter, iter.Err()
 }

--- a/pkg/chunk/encoding/bigchunk_test.go
+++ b/pkg/chunk/encoding/bigchunk_test.go
@@ -24,7 +24,7 @@ func TestSliceBiggerChunk(t *testing.T) {
 
 	for i := 0; i < (12*3600/15)-480; i += 120 {
 		s := c.Slice(model.Time(i*step), model.Time((i+479)*step))
-		iter := s.NewIterator()
+		iter := s.NewIterator(nil)
 		for j := i; j < i+480; j++ {
 			require.True(t, iter.Scan())
 			sample := iter.Value()
@@ -38,7 +38,7 @@ func TestSliceBiggerChunk(t *testing.T) {
 	// Test for when the slice does not align perfectly with the sub-chunk boundaries.
 	for i := 0; i < (12*3600/15)-500; i += 100 {
 		s := c.Slice(model.Time(i*step), model.Time((i+500)*step))
-		iter := s.NewIterator()
+		iter := s.NewIterator(nil)
 
 		// Consume some samples until we get to where we want to be.
 		for {

--- a/pkg/chunk/encoding/chunk.go
+++ b/pkg/chunk/encoding/chunk.go
@@ -44,7 +44,7 @@ type Chunk interface {
 	// or a newly allocated version. In any case, take the returned chunk as
 	// the relevant one and discard the original chunk.
 	Add(sample model.SamplePair) ([]Chunk, error)
-	NewIterator() Iterator
+	NewIterator(Iterator) Iterator
 	Marshal(io.Writer) error
 	UnmarshalFromBuf([]byte) error
 	Encoding() Encoding
@@ -141,7 +141,7 @@ func transcodeAndAdd(dst Chunk, src Chunk, s model.SamplePair) ([]Chunk, error) 
 		err             error
 	)
 
-	it := src.NewIterator()
+	it := src.NewIterator(nil)
 	for it.Scan() {
 		if NewChunks, err = head.Add(it.Value()); err != nil {
 			return nil, err

--- a/pkg/chunk/encoding/chunk_test.go
+++ b/pkg/chunk/encoding/chunk_test.go
@@ -121,7 +121,7 @@ func testChunkEncoding(t *testing.T, encoding Encoding, samples int) {
 	require.NoError(t, err)
 
 	// Check all the samples are in there.
-	iter := chunk.NewIterator()
+	iter := chunk.NewIterator(nil)
 	for i := 0; i < samples; i++ {
 		require.True(t, iter.Scan())
 		sample := iter.Value()
@@ -145,7 +145,7 @@ func testChunkEncoding(t *testing.T, encoding Encoding, samples int) {
 func testChunkSeek(t *testing.T, encoding Encoding, samples int) {
 	chunk := mkChunk(t, encoding, samples)
 
-	iter := chunk.NewIterator()
+	iter := chunk.NewIterator(nil)
 	for i := 0; i < samples; i += samples / 10 {
 		require.True(t, iter.FindAtOrAfter(model.Time(i*step)))
 		sample := iter.Value()
@@ -167,7 +167,7 @@ func testChunkSeek(t *testing.T, encoding Encoding, samples int) {
 func testChunkSeekForward(t *testing.T, encoding Encoding, samples int) {
 	chunk := mkChunk(t, encoding, samples)
 
-	iter := chunk.NewIterator()
+	iter := chunk.NewIterator(nil)
 	for i := 0; i < samples; i += samples / 10 {
 		require.True(t, iter.FindAtOrAfter(model.Time(i*step)))
 		sample := iter.Value()
@@ -190,7 +190,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 	chunk := mkChunk(t, encoding, samples)
 
 	// Check all the samples are in there.
-	iter := chunk.NewIterator()
+	iter := chunk.NewIterator(nil)
 	for i := 0; i < samples; {
 		require.True(t, iter.Scan())
 		batch := iter.Batch(BatchSize)

--- a/pkg/chunk/encoding/delta.go
+++ b/pkg/chunk/encoding/delta.go
@@ -185,7 +185,7 @@ func (c *deltaEncodedChunk) Slice(_, _ model.Time) Chunk {
 }
 
 // NewIterator implements chunk.
-func (c *deltaEncodedChunk) NewIterator() Iterator {
+func (c *deltaEncodedChunk) NewIterator(_ Iterator) Iterator {
 	return newIndexAccessingChunkIterator(c.Len(), &deltaEncodedIndexAccessor{
 		c:      *c,
 		baseT:  c.baseTime(),

--- a/pkg/chunk/encoding/doubledelta.go
+++ b/pkg/chunk/encoding/doubledelta.go
@@ -193,7 +193,7 @@ func (c doubleDeltaEncodedChunk) FirstTime() model.Time {
 }
 
 // NewIterator( implements chunk.
-func (c *doubleDeltaEncodedChunk) NewIterator() Iterator {
+func (c *doubleDeltaEncodedChunk) NewIterator(_ Iterator) Iterator {
 	return newIndexAccessingChunkIterator(c.Len(), &doubleDeltaEncodedIndexAccessor{
 		c:      *c,
 		baseT:  c.baseTime(),

--- a/pkg/chunk/encoding/varbit.go
+++ b/pkg/chunk/encoding/varbit.go
@@ -276,7 +276,7 @@ func (c *varbitChunk) Add(s model.SamplePair) ([]Chunk, error) {
 }
 
 // NewIterator implements chunk.
-func (c varbitChunk) NewIterator() Iterator {
+func (c varbitChunk) NewIterator(_ Iterator) Iterator {
 	return newVarbitChunkIterator(c)
 }
 
@@ -329,7 +329,7 @@ func (c varbitChunk) marshalLen() int {
 
 // Len implements chunk.  Runs in O(n).
 func (c varbitChunk) Len() int {
-	it := c.NewIterator()
+	it := c.NewIterator(nil)
 	i := 0
 	for ; it.Scan(); i++ {
 	}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -274,22 +274,22 @@ func TestIngesterAppendOutOfOrderAndDuplicate(t *testing.T) {
 		{Name: model.MetricNameLabel, Value: "testmetric"},
 	}
 	ctx := user.InjectOrgID(context.Background(), userID)
-	err := ing.append(ctx, m, 1, 0, client.API)
+	_, err := ing.append(ctx, m, 1, 0, client.API, nil)
 	require.NoError(t, err)
 
 	// Two times exactly the same sample (noop).
-	err = ing.append(ctx, m, 1, 0, client.API)
+	_, err = ing.append(ctx, m, 1, 0, client.API, nil)
 	require.NoError(t, err)
 
 	// Earlier sample than previous one.
-	err = ing.append(ctx, m, 0, 0, client.API)
+	_, err = ing.append(ctx, m, 0, 0, client.API, nil)
 	require.Contains(t, err.Error(), "sample timestamp out of order")
 	errResp, ok := httpgrpc.HTTPResponseFromError(err)
 	require.True(t, ok)
 	require.Equal(t, errResp.Code, int32(400))
 
 	// Same timestamp as previous sample, but different value.
-	err = ing.append(ctx, m, 1, 1, client.API)
+	_, err = ing.append(ctx, m, 1, 1, client.API, nil)
 	require.Contains(t, err.Error(), "sample with repeated timestamp but different value")
 	errResp, ok = httpgrpc.HTTPResponseFromError(err)
 	require.True(t, ok)
@@ -307,7 +307,7 @@ func TestIngesterAppendBlankLabel(t *testing.T) {
 		{Name: "bar", Value: ""},
 	}
 	ctx := user.InjectOrgID(context.Background(), userID)
-	err := ing.append(ctx, lp, 1, 0, client.API)
+	_, err := ing.append(ctx, lp, 1, 0, client.API, nil)
 	require.NoError(t, err)
 
 	res, _, err := runTestQuery(ctx, t, ing, labels.MatchEqual, model.MetricNameLabel, "testmetric")

--- a/pkg/ingester/query_test.go
+++ b/pkg/ingester/query_test.go
@@ -47,6 +47,7 @@ func BenchmarkQueryStream(b *testing.B) {
 		cpus[i] = fmt.Sprintf("cpu%02d", i)
 	}
 
+	var reuseIter encoding.Iterator
 	for i := 0; i < numSeries; i++ {
 		labels := labelPairs{
 			{Name: model.MetricNameLabel, Value: "node_cpu"},
@@ -59,10 +60,10 @@ func BenchmarkQueryStream(b *testing.B) {
 		require.NoError(b, err)
 
 		for j := 0; j < numSamples; j++ {
-			err = series.add(model.SamplePair{
+			reuseIter, err = series.add(model.SamplePair{
 				Value:     model.SampleValue(float64(i)),
 				Timestamp: model.Time(int64(i)),
-			})
+			}, reuseIter)
 			require.NoError(b, err)
 		}
 

--- a/pkg/querier/batch/chunk.go
+++ b/pkg/querier/batch/chunk.go
@@ -16,7 +16,7 @@ type chunkIterator struct {
 
 func (i *chunkIterator) reset(chunk chunk.Chunk) {
 	i.chunk = chunk
-	i.it = chunk.Data.NewIterator()
+	i.it = chunk.Data.NewIterator(i.it)
 	i.batch.Length = 0
 	i.batch.Index = 0
 }

--- a/pkg/querier/iterators/chunk_merge_iterator.go
+++ b/pkg/querier/iterators/chunk_merge_iterator.go
@@ -48,7 +48,7 @@ func buildIterators(cs []chunk.Chunk) []*nonOverlappingIterator {
 	for i := range cs {
 		chunks[i] = &chunkIterator{
 			Chunk: cs[i],
-			it:    cs[i].Data.NewIterator(),
+			it:    cs[i].Data.NewIterator(nil),
 		}
 	}
 	sort.Sort(byFrom(chunks))

--- a/vendor/github.com/prometheus/tsdb/CHANGELOG.md
+++ b/vendor/github.com/prometheus/tsdb/CHANGELOG.md
@@ -1,4 +1,11 @@
-## Master / unreleased
+## master / unreleased
+
+## 0.10.0
+
+ - [FEATURE] Added `DBReadOnly` to allow opening a database in read only mode.
+    - `DBReadOnly.Blocks()` exposes a slice of `BlockReader`s.
+    - `BlockReader` interface - removed MinTime/MaxTime methods and now exposes the full block meta via `Meta()`.
+ - [FEATURE] `chunckenc.Chunk.Iterator` method now takes a `chunckenc.Iterator` interface as an argument for reuse.
 
 ## 0.9.1
 
@@ -18,6 +25,7 @@
  - [ENHANCEMENT] Improved postings intersection matching.
  - [ENHANCEMENT] Reduced disk usage for WAL for small setups.
  - [ENHANCEMENT] Optimize queries using regexp for set lookups.
+
 
 ## 0.8.0
 

--- a/vendor/github.com/prometheus/tsdb/Makefile.common
+++ b/vendor/github.com/prometheus/tsdb/Makefile.common
@@ -74,7 +74,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.16.0
+GOLANGCI_LINT_VERSION ?= v1.17.1
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))

--- a/vendor/github.com/prometheus/tsdb/block.go
+++ b/vendor/github.com/prometheus/tsdb/block.go
@@ -138,11 +138,8 @@ type BlockReader interface {
 	// Tombstones returns a TombstoneReader over the block's deleted data.
 	Tombstones() (TombstoneReader, error)
 
-	// MinTime returns the min time of the block.
-	MinTime() int64
-
-	// MaxTime returns the max time of the block.
-	MaxTime() int64
+	// Meta provides meta information about the block reader.
+	Meta() BlockMeta
 }
 
 // Appendable defines an entity to which data can be appended.

--- a/vendor/github.com/prometheus/tsdb/chunkenc/chunk.go
+++ b/vendor/github.com/prometheus/tsdb/chunkenc/chunk.go
@@ -44,7 +44,10 @@ type Chunk interface {
 	Bytes() []byte
 	Encoding() Encoding
 	Appender() (Appender, error)
-	Iterator() Iterator
+	// The iterator passed as argument is for re-use.
+	// Depending on implementation, the iterator can
+	// be re-used or a new iterator can be allocated.
+	Iterator(Iterator) Iterator
 	NumSamples() int
 }
 

--- a/vendor/github.com/prometheus/tsdb/chunks/chunks.go
+++ b/vendor/github.com/prometheus/tsdb/chunks/chunks.go
@@ -57,8 +57,9 @@ type Meta struct {
 }
 
 // writeHash writes the chunk encoding and raw data into the provided hash.
-func (cm *Meta) writeHash(h hash.Hash) error {
-	if _, err := h.Write([]byte{byte(cm.Chunk.Encoding())}); err != nil {
+func (cm *Meta) writeHash(h hash.Hash, buf []byte) error {
+	buf = append(buf[:0], byte(cm.Chunk.Encoding()))
+	if _, err := h.Write(buf[:1]); err != nil {
 		return err
 	}
 	if _, err := h.Write(cm.Chunk.Bytes()); err != nil {
@@ -97,6 +98,7 @@ type Writer struct {
 	wbuf    *bufio.Writer
 	n       int64
 	crc32   hash.Hash
+	buf     [binary.MaxVarintLen32]byte
 
 	segmentSize int64
 }
@@ -245,8 +247,8 @@ func MergeChunks(a, b chunkenc.Chunk) (*chunkenc.XORChunk, error) {
 	if err != nil {
 		return nil, err
 	}
-	ait := a.Iterator()
-	bit := b.Iterator()
+	ait := a.Iterator(nil)
+	bit := b.Iterator(nil)
 	aok, bok := ait.Next(), bit.Next()
 	for aok && bok {
 		at, av := ait.At()
@@ -299,22 +301,19 @@ func (w *Writer) WriteChunks(chks ...Meta) error {
 		}
 	}
 
-	var (
-		b   = [binary.MaxVarintLen32]byte{}
-		seq = uint64(w.seq()) << 32
-	)
+	var seq = uint64(w.seq()) << 32
 	for i := range chks {
 		chk := &chks[i]
 
 		chk.Ref = seq | uint64(w.n)
 
-		n := binary.PutUvarint(b[:], uint64(len(chk.Chunk.Bytes())))
+		n := binary.PutUvarint(w.buf[:], uint64(len(chk.Chunk.Bytes())))
 
-		if err := w.write(b[:n]); err != nil {
+		if err := w.write(w.buf[:n]); err != nil {
 			return err
 		}
-		b[0] = byte(chk.Chunk.Encoding())
-		if err := w.write(b[:1]); err != nil {
+		w.buf[0] = byte(chk.Chunk.Encoding())
+		if err := w.write(w.buf[:1]); err != nil {
 			return err
 		}
 		if err := w.write(chk.Chunk.Bytes()); err != nil {
@@ -322,10 +321,10 @@ func (w *Writer) WriteChunks(chks ...Meta) error {
 		}
 
 		w.crc32.Reset()
-		if err := chk.writeHash(w.crc32); err != nil {
+		if err := chk.writeHash(w.crc32, w.buf[:]); err != nil {
 			return err
 		}
-		if err := w.write(w.crc32.Sum(b[:0])); err != nil {
+		if err := w.write(w.crc32.Sum(w.buf[:0])); err != nil {
 			return err
 		}
 	}
@@ -366,7 +365,7 @@ func (b realByteSlice) Sub(start, end int) ByteSlice {
 	return b[start:end]
 }
 
-// Reader implements a SeriesReader for a serialized byte stream
+// Reader implements a ChunkReader for a serialized byte stream
 // of series data.
 type Reader struct {
 	bs   []ByteSlice // The underlying bytes holding the encoded series data.
@@ -503,11 +502,11 @@ func sequenceFiles(dir string) ([]string, error) {
 	return res, nil
 }
 
-func closeAll(cs []io.Closer) (err error) {
+func closeAll(cs []io.Closer) error {
+	var merr tsdb_errors.MultiError
+
 	for _, c := range cs {
-		if e := c.Close(); e != nil {
-			err = e
-		}
+		merr.Add(c.Close())
 	}
-	return err
+	return merr.Err()
 }

--- a/vendor/github.com/prometheus/tsdb/compact.go
+++ b/vendor/github.com/prometheus/tsdb/compact.go
@@ -662,7 +662,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 	}()
 	c.metrics.populatingBlocks.Set(1)
 
-	globalMaxt := blocks[0].MaxTime()
+	globalMaxt := blocks[0].Meta().MaxTime
 	for i, b := range blocks {
 		select {
 		case <-c.ctx.Done():
@@ -671,13 +671,13 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		}
 
 		if !overlapping {
-			if i > 0 && b.MinTime() < globalMaxt {
+			if i > 0 && b.Meta().MinTime < globalMaxt {
 				c.metrics.overlappingBlocks.Inc()
 				overlapping = true
 				level.Warn(c.logger).Log("msg", "found overlapping blocks during compaction", "ulid", meta.ULID)
 			}
-			if b.MaxTime() > globalMaxt {
-				globalMaxt = b.MaxTime()
+			if b.Meta().MaxTime > globalMaxt {
+				globalMaxt = b.Meta().MaxTime
 			}
 		}
 
@@ -736,6 +736,7 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 		return errors.Wrap(err, "add symbols")
 	}
 
+	delIter := &deletedIterator{}
 	for set.Next() {
 		select {
 		case <-c.ctx.Done():
@@ -788,17 +789,18 @@ func (c *LeveledCompactor) populateBlock(blocks []BlockReader, meta *BlockMeta, 
 					return err
 				}
 
-				it := &deletedIterator{it: chk.Chunk.Iterator(), intervals: dranges}
+				delIter.it = chk.Chunk.Iterator(delIter.it)
+				delIter.intervals = dranges
 
 				var (
 					t int64
 					v float64
 				)
-				for it.Next() {
-					t, v = it.At()
+				for delIter.Next() {
+					t, v = delIter.At()
 					app.Append(t, v)
 				}
-				if err := it.Err(); err != nil {
+				if err := delIter.Err(); err != nil {
 					return errors.Wrap(err, "iterate chunk while re-encoding")
 				}
 

--- a/vendor/github.com/prometheus/tsdb/db.go
+++ b/vendor/github.com/prometheus/tsdb/db.go
@@ -250,6 +250,178 @@ func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
 	return m
 }
 
+// ErrClosed is returned when the db is closed.
+var ErrClosed = errors.New("db already closed")
+
+// DBReadOnly provides APIs for read only operations on a database.
+// Current implementation doesn't support concurency so
+// all API calls should happen in the same go routine.
+type DBReadOnly struct {
+	logger  log.Logger
+	dir     string
+	closers []io.Closer
+	closed  chan struct{}
+}
+
+// OpenDBReadOnly opens DB in the given directory for read only operations.
+func OpenDBReadOnly(dir string, l log.Logger) (*DBReadOnly, error) {
+	if _, err := os.Stat(dir); err != nil {
+		return nil, errors.Wrap(err, "openning the db dir")
+	}
+
+	if l == nil {
+		l = log.NewNopLogger()
+	}
+
+	return &DBReadOnly{
+		logger: l,
+		dir:    dir,
+		closed: make(chan struct{}),
+	}, nil
+}
+
+// Querier loads the wal and returns a new querier over the data partition for the given time range.
+// Current implementation doesn't support multiple Queriers.
+func (db *DBReadOnly) Querier(mint, maxt int64) (Querier, error) {
+	select {
+	case <-db.closed:
+		return nil, ErrClosed
+	default:
+	}
+	blocksReaders, err := db.Blocks()
+	if err != nil {
+		return nil, err
+	}
+	blocks := make([]*Block, len(blocksReaders))
+	for i, b := range blocksReaders {
+		b, ok := b.(*Block)
+		if !ok {
+			return nil, errors.New("unable to convert a read only block to a normal block")
+		}
+		blocks[i] = b
+	}
+
+	head, err := NewHead(nil, db.logger, nil, 1)
+	if err != nil {
+		return nil, err
+	}
+	maxBlockTime := int64(math.MinInt64)
+	if len(blocks) > 0 {
+		maxBlockTime = blocks[len(blocks)-1].Meta().MaxTime
+	}
+
+	// Also add the WAL if the current blocks don't cover the requestes time range.
+	if maxBlockTime <= maxt {
+		w, err := wal.Open(db.logger, nil, filepath.Join(db.dir, "wal"))
+		if err != nil {
+			return nil, err
+		}
+		head, err = NewHead(nil, db.logger, w, 1)
+		if err != nil {
+			return nil, err
+		}
+		// Set the min valid time for the ingested wal samples
+		// to be no lower than the maxt of the last block.
+		if err := head.Init(maxBlockTime); err != nil {
+			return nil, errors.Wrap(err, "read WAL")
+		}
+		// Set the wal to nil to disable all wal operations.
+		// This is mainly to avoid blocking when closing the head.
+		head.wal = nil
+
+		db.closers = append(db.closers, head)
+	}
+
+	// TODO: Refactor so that it is possible to obtain a Querier without initializing a writable DB instance.
+	// Option 1: refactor DB to have the Querier implementation using the DBReadOnly.Querier implementation not the opposite.
+	// Option 2: refactor Querier to use another independent func which
+	// can than be used by a read only and writable db instances without any code duplication.
+	dbWritable := &DB{
+		dir:    db.dir,
+		logger: db.logger,
+		blocks: blocks,
+		head:   head,
+	}
+
+	return dbWritable.Querier(mint, maxt)
+}
+
+// Blocks returns a slice of block readers for persisted blocks.
+func (db *DBReadOnly) Blocks() ([]BlockReader, error) {
+	select {
+	case <-db.closed:
+		return nil, ErrClosed
+	default:
+	}
+	loadable, corrupted, err := openBlocks(db.logger, db.dir, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Corrupted blocks that have been superseded by a loadable block can be safely ignored.
+	for _, block := range loadable {
+		for _, b := range block.Meta().Compaction.Parents {
+			delete(corrupted, b.ULID)
+		}
+	}
+	if len(corrupted) > 0 {
+		for _, b := range loadable {
+			if err := b.Close(); err != nil {
+				level.Warn(db.logger).Log("msg", "closing a block", err)
+			}
+		}
+		return nil, errors.Errorf("unexpected corrupted block:%v", corrupted)
+	}
+
+	if len(loadable) == 0 {
+		return nil, errors.New("no blocks found")
+	}
+
+	sort.Slice(loadable, func(i, j int) bool {
+		return loadable[i].Meta().MinTime < loadable[j].Meta().MinTime
+	})
+
+	blockMetas := make([]BlockMeta, 0, len(loadable))
+	for _, b := range loadable {
+		blockMetas = append(blockMetas, b.Meta())
+	}
+	if overlaps := OverlappingBlocks(blockMetas); len(overlaps) > 0 {
+		level.Warn(db.logger).Log("msg", "overlapping blocks found during opening", "detail", overlaps.String())
+	}
+
+	// Close all previously open readers and add the new ones to the cache.
+	for _, closer := range db.closers {
+		closer.Close()
+	}
+
+	blockClosers := make([]io.Closer, len(loadable))
+	blockReaders := make([]BlockReader, len(loadable))
+	for i, b := range loadable {
+		blockClosers[i] = b
+		blockReaders[i] = b
+	}
+	db.closers = blockClosers
+
+	return blockReaders, nil
+}
+
+// Close all block readers.
+func (db *DBReadOnly) Close() error {
+	select {
+	case <-db.closed:
+		return ErrClosed
+	default:
+	}
+	close(db.closed)
+
+	var merr tsdb_errors.MultiError
+
+	for _, b := range db.closers {
+		merr.Add(b.Close())
+	}
+	return merr.Err()
+}
+
 // Open returns a new DB in the given directory.
 func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db *DB, err error) {
 	if err := os.MkdirAll(dir, 0777); err != nil {
@@ -514,8 +686,10 @@ func (db *DB) compact() (err error) {
 	return nil
 }
 
-func (db *DB) getBlock(id ulid.ULID) (*Block, bool) {
-	for _, b := range db.blocks {
+// getBlock iterates a given block range to find a block by a given id.
+// If found it returns the block itself and a boolean to indicate that it was found.
+func getBlock(allBlocks []*Block, id ulid.ULID) (*Block, bool) {
+	for _, b := range allBlocks {
 		if b.Meta().ULID == id {
 			return b, true
 		}
@@ -533,14 +707,14 @@ func (db *DB) reload() (err error) {
 		db.metrics.reloads.Inc()
 	}()
 
-	loadable, corrupted, err := db.openBlocks()
+	loadable, corrupted, err := openBlocks(db.logger, db.dir, db.blocks, db.chunkPool)
 	if err != nil {
 		return err
 	}
 
 	deletable := db.deletableBlocks(loadable)
 
-	// Corrupted blocks that have been replaced by parents can be safely ignored and deleted.
+	// Corrupted blocks that have been superseded by a loadable block can be safely ignored.
 	// This makes it resilient against the process crashing towards the end of a compaction.
 	// Creation of a new block and deletion of its parents cannot happen atomically.
 	// By creating blocks with their parents, we can pick up the deletion where it left off during a crash.
@@ -553,7 +727,7 @@ func (db *DB) reload() (err error) {
 	if len(corrupted) > 0 {
 		// Close all new blocks to release the lock for windows.
 		for _, block := range loadable {
-			if _, loaded := db.getBlock(block.Meta().ULID); !loaded {
+			if _, open := getBlock(db.blocks, block.Meta().ULID); !open {
 				block.Close()
 			}
 		}
@@ -621,24 +795,24 @@ func (db *DB) reload() (err error) {
 	return errors.Wrap(db.head.Truncate(maxt), "head truncate failed")
 }
 
-func (db *DB) openBlocks() (blocks []*Block, corrupted map[ulid.ULID]error, err error) {
-	dirs, err := blockDirs(db.dir)
+func openBlocks(l log.Logger, dir string, loaded []*Block, chunkPool chunkenc.Pool) (blocks []*Block, corrupted map[ulid.ULID]error, err error) {
+	bDirs, err := blockDirs(dir)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "find blocks")
 	}
 
 	corrupted = make(map[ulid.ULID]error)
-	for _, dir := range dirs {
-		meta, _, err := readMetaFile(dir)
+	for _, bDir := range bDirs {
+		meta, _, err := readMetaFile(bDir)
 		if err != nil {
-			level.Error(db.logger).Log("msg", "not a block dir", "dir", dir)
+			level.Error(l).Log("msg", "not a block dir", "dir", bDir)
 			continue
 		}
 
 		// See if we already have the block in memory or open it otherwise.
-		block, ok := db.getBlock(meta.ULID)
-		if !ok {
-			block, err = OpenBlock(db.logger, dir, db.chunkPool)
+		block, open := getBlock(loaded, meta.ULID)
+		if !open {
+			block, err = OpenBlock(l, bDir, chunkPool)
 			if err != nil {
 				corrupted[meta.ULID] = err
 				continue

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -361,7 +361,7 @@ github.com/prometheus/prometheus/discovery/zookeeper
 github.com/prometheus/prometheus/discovery/refresh
 github.com/prometheus/prometheus/pkg/logging
 github.com/prometheus/prometheus/util/treecache
-# github.com/prometheus/tsdb v0.9.1
+# github.com/prometheus/tsdb v0.10.0
 github.com/prometheus/tsdb/chunkenc
 github.com/prometheus/tsdb/labels
 github.com/prometheus/tsdb


### PR DESCRIPTION
This includes https://github.com/prometheus/tsdb/pull/642. I have added similar re-use of iterators here. There is a possibility of allocs improvements in ingester push and I am trying to realize that.

I will post the benchmark results soon.