### PR TITLE
Move ingester.spread-flushes from flush time to sample add time

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -191,17 +191,6 @@ func (i *Ingester) shouldFlushChunk(c *desc, fp model.Fingerprint) flushReason {
 		return noFlush
 	}
 
-	if i.cfg.SpreadFlushes {
-		now := model.Now()
-		// Map from the fingerprint hash to a fixed point in the cycle of period MaxChunkAge
-		startOfCycle := now.Add(-(now.Sub(model.Time(0)) % i.cfg.MaxChunkAge))
-		slot := startOfCycle.Add(time.Duration(fp) % i.cfg.MaxChunkAge)
-		// If that point is now, to the resolution of FlushCheckPeriod, flush the chunk.
-		if slot >= now && slot < now.Add(i.cfg.FlushCheckPeriod) {
-			return reasonAged
-		}
-		// If we missed the slot due to timing it will get caught by the MaxChunkAge check below, some time later.
-	}
 	// Adjust max age slightly to spread flushes out over time
 	var jitter time.Duration
 	if i.cfg.ChunkAgeJitter != 0 {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -145,13 +145,13 @@ func runTestQueryTimes(ctx context.Context, t *testing.T, ing *Ingester, ty labe
 	return res, req, nil
 }
 
-func pushTestSamples(t *testing.T, ing *Ingester, numSeries, samplesPerSeries int) ([]string, map[string]model.Matrix) {
+func pushTestSamples(t *testing.T, ing *Ingester, numSeries, samplesPerSeries, offset int) ([]string, map[string]model.Matrix) {
 	userIDs := []string{"1", "2", "3"}
 
 	// Create test samples.
 	testData := map[string]model.Matrix{}
 	for i, userID := range userIDs {
-		testData[userID] = buildTestMatrix(numSeries, samplesPerSeries, i)
+		testData[userID] = buildTestMatrix(numSeries, samplesPerSeries, i+offset)
 	}
 
 	// Append samples.
@@ -166,7 +166,7 @@ func pushTestSamples(t *testing.T, ing *Ingester, numSeries, samplesPerSeries in
 
 func TestIngesterAppend(t *testing.T) {
 	store, ing := newDefaultTestStore(t)
-	userIDs, testData := pushTestSamples(t, ing, 10, 1000)
+	userIDs, testData := pushTestSamples(t, ing, 10, 1000, 0)
 
 	// Read samples back via ingester queries.
 	for _, userID := range userIDs {
@@ -194,7 +194,7 @@ func TestIngesterAppend(t *testing.T) {
 func TestIngesterSendsOnlySeriesWithData(t *testing.T) {
 	_, ing := newDefaultTestStore(t)
 
-	userIDs, _ := pushTestSamples(t, ing, 10, 1000)
+	userIDs, _ := pushTestSamples(t, ing, 10, 1000, 0)
 
 	// Read samples back via ingester queries.
 	for _, userID := range userIDs {
@@ -224,7 +224,7 @@ func TestIngesterIdleFlush(t *testing.T) {
 	cfg.RetainPeriod = 500 * time.Millisecond
 	store, ing := newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig())
 
-	userIDs, testData := pushTestSamples(t, ing, 4, 100)
+	userIDs, testData := pushTestSamples(t, ing, 4, 100, 0)
 
 	// wait beyond idle time so samples flush
 	time.Sleep(cfg.MaxChunkIdle * 2)

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -59,9 +59,7 @@ func newMemorySeries(m labels.Labels) *memorySeries {
 	}
 }
 
-// add adds a sample pair to the series. It returns the number of newly
-// completed chunks (which are now eligible for persistence).
-//
+// add adds a sample pair to the series, possibly creating a new chunk.
 // The caller must have locked the fingerprint of the series.
 func (s *memorySeries) add(v model.SamplePair) error {
 	// If sender has repeated the same timestamp, check more closely and perhaps return error.

--- a/pkg/ingester/user_state_test.go
+++ b/pkg/ingester/user_state_test.go
@@ -43,7 +43,7 @@ func TestForSeriesMatchingBatching(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("numSeries=%d,batchSize=%d,matchers=%s", tc.numSeries, tc.batchSize, tc.matchers), func(t *testing.T) {
 			_, ing := newDefaultTestStore(t)
-			userIDs, _ := pushTestSamples(t, ing, tc.numSeries, 100)
+			userIDs, _ := pushTestSamples(t, ing, tc.numSeries, 100, 0)
 
 			for _, userID := range userIDs {
 				ctx := user.InjectOrgID(context.Background(), userID)


### PR DESCRIPTION
So that all ingesters will make the same decision, hence chunks flushed to the DB are more likely to overlap.  This is a replacement for #1414, keeping the option name but implementing it differently.

Also add a test and fix an incorrect comment on `memorySeries.add()`.

Trying this out in staging environment, I see that the 'reason' stats are less helpful because the chunks that hit their timeslot are reported as "multiple chunks in series".  We could add more metadata to report the different cases accurately.