### PR TITLE
 Pass userID explicitly, not via context

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	awscommon "github.com/weaveworks/common/aws"
 	"github.com/weaveworks/common/instrument"
-	"github.com/weaveworks/common/user"
 )
 
 const (
@@ -193,7 +192,6 @@ func (a dynamoDBStorageClient) NewWriteBatch() chunk.WriteBatch {
 }
 
 func logWriteRetry(ctx context.Context, unprocessed dynamoDBWriteBatch) {
-	userID, _ := user.ExtractOrgID(ctx)
 	for table, reqs := range unprocessed {
 		dynamoThrottled.WithLabelValues("DynamoDB.BatchWriteItem", table).Add(float64(len(reqs)))
 		for _, req := range reqs {
@@ -207,7 +205,7 @@ func logWriteRetry(ctx context.Context, unprocessed dynamoDBWriteBatch) {
 			if rangeAttr, ok := item[rangeKey]; ok {
 				rnge = string(rangeAttr.B)
 			}
-			util.Event().Log("msg", "store retry", "table", table, "userID", userID, "hashKey", hash, "rangeKey", rnge)
+			util.Event().Log("msg", "store retry", "table", table, "hashKey", hash, "rangeKey", rnge)
 		}
 	}
 }

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -98,7 +98,7 @@ func newTestChunkStoreConfig(t require.TestingT, schemaName string, storeCfg Sto
 
 // TestChunkStore_Get tests results are returned correctly depending on the type of query
 func TestChunkStore_Get(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx := context.Background()
 	now := model.Now()
 
 	fooMetric1 := labels.Labels{
@@ -232,21 +232,21 @@ func TestChunkStore_Get(t *testing.T) {
 					}
 
 					// Query with ordinary time-range
-					chunks1, err := store.Get(ctx, now.Add(-time.Hour), now, matchers...)
+					chunks1, err := store.Get(ctx, userID, now.Add(-time.Hour), now, matchers...)
 					require.NoError(t, err)
 					if !reflect.DeepEqual(tc.expect, chunks1) {
 						t.Fatalf("%s: wrong chunks - %s", tc.query, test.Diff(tc.expect, chunks1))
 					}
 
 					// Pushing end of time-range into future should yield exact same resultset
-					chunks2, err := store.Get(ctx, now.Add(-time.Hour), now.Add(time.Hour*24*10), matchers...)
+					chunks2, err := store.Get(ctx, userID, now.Add(-time.Hour), now.Add(time.Hour*24*10), matchers...)
 					require.NoError(t, err)
 					if !reflect.DeepEqual(tc.expect, chunks2) {
 						t.Fatalf("%s: wrong chunks - %s", tc.query, test.Diff(tc.expect, chunks2))
 					}
 
 					// Query with both begin & end of time-range in future should yield empty resultset
-					chunks3, err := store.Get(ctx, now.Add(time.Hour), now.Add(time.Hour*2), matchers...)
+					chunks3, err := store.Get(ctx, userID, now.Add(time.Hour), now.Add(time.Hour*2), matchers...)
 					require.NoError(t, err)
 					if len(chunks3) != 0 {
 						t.Fatalf("%s: future query should yield empty resultset ... actually got %v chunks: %#v",
@@ -259,7 +259,7 @@ func TestChunkStore_Get(t *testing.T) {
 }
 
 func TestChunkStore_LabelValuesForMetricName(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx := context.Background()
 	now := model.Now()
 
 	fooMetric1 := labels.Labels{
@@ -341,7 +341,7 @@ func TestChunkStore_LabelValuesForMetricName(t *testing.T) {
 					}
 
 					// Query with ordinary time-range
-					labelValues1, err := store.LabelValuesForMetricName(ctx, now.Add(-time.Hour), now, tc.metricName, tc.labelName)
+					labelValues1, err := store.LabelValuesForMetricName(ctx, userID, now.Add(-time.Hour), now, tc.metricName, tc.labelName)
 					require.NoError(t, err)
 
 					if !reflect.DeepEqual(tc.expect, labelValues1) {
@@ -349,7 +349,7 @@ func TestChunkStore_LabelValuesForMetricName(t *testing.T) {
 					}
 
 					// Pushing end of time-range into future should yield exact same resultset
-					labelValues2, err := store.LabelValuesForMetricName(ctx, now.Add(-time.Hour), now.Add(time.Hour*24*10), tc.metricName, tc.labelName)
+					labelValues2, err := store.LabelValuesForMetricName(ctx, userID, now.Add(-time.Hour), now.Add(time.Hour*24*10), tc.metricName, tc.labelName)
 					require.NoError(t, err)
 
 					if !reflect.DeepEqual(tc.expect, labelValues2) {
@@ -357,7 +357,7 @@ func TestChunkStore_LabelValuesForMetricName(t *testing.T) {
 					}
 
 					// Query with both begin & end of time-range in future should yield empty resultset
-					labelValues3, err := store.LabelValuesForMetricName(ctx, now.Add(time.Hour), now.Add(time.Hour*2), tc.metricName, tc.labelName)
+					labelValues3, err := store.LabelValuesForMetricName(ctx, userID, now.Add(time.Hour), now.Add(time.Hour*2), tc.metricName, tc.labelName)
 					require.NoError(t, err)
 					if len(labelValues3) != 0 {
 						t.Fatalf("%s/%s: future query should yield empty resultset ... actually got %v label values: %#v",
@@ -371,7 +371,7 @@ func TestChunkStore_LabelValuesForMetricName(t *testing.T) {
 }
 
 func TestChunkStore_LabelNamesForMetricName(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx := context.Background()
 	now := model.Now()
 
 	fooMetric1 := labels.Labels{
@@ -443,7 +443,7 @@ func TestChunkStore_LabelNamesForMetricName(t *testing.T) {
 					}
 
 					// Query with ordinary time-range
-					labelNames1, err := store.LabelNamesForMetricName(ctx, now.Add(-time.Hour), now, tc.metricName)
+					labelNames1, err := store.LabelNamesForMetricName(ctx, userID, now.Add(-time.Hour), now, tc.metricName)
 					require.NoError(t, err)
 
 					if !reflect.DeepEqual(tc.expect, labelNames1) {
@@ -451,7 +451,7 @@ func TestChunkStore_LabelNamesForMetricName(t *testing.T) {
 					}
 
 					// Pushing end of time-range into future should yield exact same resultset
-					labelNames2, err := store.LabelNamesForMetricName(ctx, now.Add(-time.Hour), now.Add(time.Hour*24*10), tc.metricName)
+					labelNames2, err := store.LabelNamesForMetricName(ctx, userID, now.Add(-time.Hour), now.Add(time.Hour*24*10), tc.metricName)
 					require.NoError(t, err)
 
 					if !reflect.DeepEqual(tc.expect, labelNames2) {
@@ -459,7 +459,7 @@ func TestChunkStore_LabelNamesForMetricName(t *testing.T) {
 					}
 
 					// Query with both begin & end of time-range in future should yield empty resultset
-					labelNames3, err := store.LabelNamesForMetricName(ctx, now.Add(time.Hour), now.Add(time.Hour*2), tc.metricName)
+					labelNames3, err := store.LabelNamesForMetricName(ctx, userID, now.Add(time.Hour), now.Add(time.Hour*2), tc.metricName)
 					require.NoError(t, err)
 					if len(labelNames3) != 0 {
 						t.Fatalf("%s: future query should yield empty resultset ... actually got %v label names: %#v",
@@ -474,7 +474,7 @@ func TestChunkStore_LabelNamesForMetricName(t *testing.T) {
 
 // TestChunkStore_getMetricNameChunks tests if chunks are fetched correctly when we have the metric name
 func TestChunkStore_getMetricNameChunks(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx := context.Background()
 	now := model.Now()
 	chunk1 := dummyChunkFor(now, labels.Labels{
 		{Name: labels.MetricName, Value: "foo"},
@@ -547,7 +547,7 @@ func TestChunkStore_getMetricNameChunks(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					chunks, err := store.Get(ctx, now.Add(-time.Hour), now, matchers...)
+					chunks, err := store.Get(ctx, userID, now.Add(-time.Hour), now, matchers...)
 					require.NoError(t, err)
 
 					if !reflect.DeepEqual(tc.expect, chunks) {
@@ -568,7 +568,7 @@ func mustNewLabelMatcher(matchType labels.MatchType, name string, value string) 
 }
 
 func TestChunkStoreRandom(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx := context.Background()
 
 	for _, schema := range schemas {
 		t.Run(schema.name, func(t *testing.T) {
@@ -613,7 +613,7 @@ func TestChunkStoreRandom(t *testing.T) {
 					mustNewLabelMatcher(labels.MatchEqual, labels.MetricName, "foo"),
 					mustNewLabelMatcher(labels.MatchEqual, "bar", "baz"),
 				}
-				chunks, err := store.Get(ctx, startTime, endTime, matchers...)
+				chunks, err := store.Get(ctx, userID, startTime, endTime, matchers...)
 				require.NoError(t, err)
 
 				// We need to check that each chunk is in the time range
@@ -636,7 +636,7 @@ func TestChunkStoreRandom(t *testing.T) {
 
 func TestChunkStoreLeastRead(t *testing.T) {
 	// Test we don't read too much from the index
-	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx := context.Background()
 	store := newTestChunkStore(t, "v6")
 	defer store.Stop()
 
@@ -679,7 +679,7 @@ func TestChunkStoreLeastRead(t *testing.T) {
 			mustNewLabelMatcher(labels.MatchEqual, "bar", "baz"),
 		}
 
-		chunks, err := store.Get(ctx, startTime, endTime, matchers...)
+		chunks, err := store.Get(ctx, userID, startTime, endTime, matchers...)
 		require.NoError(t, err)
 
 		// We need to check that each chunk is in the time range
@@ -698,7 +698,7 @@ func TestChunkStoreLeastRead(t *testing.T) {
 }
 
 func TestIndexCachingWorks(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx := context.Background()
 	metric := labels.Labels{
 		{Name: labels.MetricName, Value: "foo"},
 		{Name: "bar", Value: "baz"},
@@ -728,7 +728,7 @@ func TestIndexCachingWorks(t *testing.T) {
 }
 
 func BenchmarkIndexCaching(b *testing.B) {
-	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx := context.Background()
 	storeMaker := stores[1]
 	storeCfg := storeMaker.configFn()
 
@@ -745,7 +745,7 @@ func BenchmarkIndexCaching(b *testing.B) {
 }
 
 func TestChunkStoreError(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx := context.Background()
 	for _, tc := range []struct {
 		query         string
 		from, through model.Time
@@ -785,7 +785,7 @@ func TestChunkStoreError(t *testing.T) {
 				require.NoError(t, err)
 
 				// Query with ordinary time-range
-				_, err = store.Get(ctx, tc.from, tc.through, matchers...)
+				_, err = store.Get(ctx, userID, tc.from, tc.through, matchers...)
 				require.EqualError(t, err, tc.err)
 			})
 		}
@@ -834,12 +834,12 @@ func TestStoreMaxLookBack(t *testing.T) {
 	}
 
 	// Both the chunks should be returned
-	chunks, err := storeWithoutLookBackLimit.Get(ctx, now.Add(-time.Hour), now, matchers...)
+	chunks, err := storeWithoutLookBackLimit.Get(ctx, userID, now.Add(-time.Hour), now, matchers...)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(chunks))
 
 	// Single chunk should be returned with newer timestamp
-	chunks, err = storeWithLookBackLimit.Get(ctx, now.Add(-time.Hour), now, matchers...)
+	chunks, err = storeWithLookBackLimit.Get(ctx, userID, now.Add(-time.Hour), now, matchers...)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(chunks))
 	chunks[0].Through.Equal(now)

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -14,12 +14,12 @@ import (
 type Store interface {
 	Put(ctx context.Context, chunks []Chunk) error
 	PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error
-	Get(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error)
+	Get(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error)
 	// GetChunkRefs returns the un-loaded chunks and the fetchers to be used to load them. You can load each slice of chunks ([]Chunk),
 	// using the corresponding Fetcher (fetchers[i].FetchChunks(ctx, chunks[i], ...)
-	GetChunkRefs(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([][]Chunk, []*Fetcher, error)
-	LabelValuesForMetricName(ctx context.Context, from, through model.Time, metricName string, labelName string) ([]string, error)
-	LabelNamesForMetricName(ctx context.Context, from, through model.Time, metricName string) ([]string, error)
+	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([][]Chunk, []*Fetcher, error)
+	LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string) ([]string, error)
+	LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error)
 	Stop()
 }
 
@@ -80,10 +80,10 @@ func (c compositeStore) PutOne(ctx context.Context, from, through model.Time, ch
 	})
 }
 
-func (c compositeStore) Get(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error) {
+func (c compositeStore) Get(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error) {
 	var results []Chunk
 	err := c.forStores(from, through, func(from, through model.Time, store Store) error {
-		chunks, err := store.Get(ctx, from, through, matchers...)
+		chunks, err := store.Get(ctx, userID, from, through, matchers...)
 		if err != nil {
 			return err
 		}
@@ -94,10 +94,10 @@ func (c compositeStore) Get(ctx context.Context, from, through model.Time, match
 }
 
 // LabelValuesForMetricName retrieves all label values for a single label name and metric name.
-func (c compositeStore) LabelValuesForMetricName(ctx context.Context, from, through model.Time, metricName string, labelName string) ([]string, error) {
+func (c compositeStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string) ([]string, error) {
 	var result []string
 	err := c.forStores(from, through, func(from, through model.Time, store Store) error {
-		labelValues, err := store.LabelValuesForMetricName(ctx, from, through, metricName, labelName)
+		labelValues, err := store.LabelValuesForMetricName(ctx, userID, from, through, metricName, labelName)
 		if err != nil {
 			return err
 		}
@@ -108,10 +108,10 @@ func (c compositeStore) LabelValuesForMetricName(ctx context.Context, from, thro
 }
 
 // LabelNamesForMetricName retrieves all label names for a metric name.
-func (c compositeStore) LabelNamesForMetricName(ctx context.Context, from, through model.Time, metricName string) ([]string, error) {
+func (c compositeStore) LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error) {
 	var result []string
 	err := c.forStores(from, through, func(from, through model.Time, store Store) error {
-		labelNames, err := store.LabelNamesForMetricName(ctx, from, through, metricName)
+		labelNames, err := store.LabelNamesForMetricName(ctx, userID, from, through, metricName)
 		if err != nil {
 			return err
 		}
@@ -121,11 +121,11 @@ func (c compositeStore) LabelNamesForMetricName(ctx context.Context, from, throu
 	return result, err
 }
 
-func (c compositeStore) GetChunkRefs(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([][]Chunk, []*Fetcher, error) {
+func (c compositeStore) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([][]Chunk, []*Fetcher, error) {
 	chunkIDs := [][]Chunk{}
 	fetchers := []*Fetcher{}
 	err := c.forStores(from, through, func(from, through model.Time, store Store) error {
-		ids, fetcher, err := store.GetChunkRefs(ctx, from, through, matchers...)
+		ids, fetcher, err := store.GetChunkRefs(ctx, userID, from, through, matchers...)
 		if err != nil {
 			return err
 		}

--- a/pkg/chunk/composite_store_test.go
+++ b/pkg/chunk/composite_store_test.go
@@ -21,18 +21,18 @@ func (m mockStore) PutOne(ctx context.Context, from, through model.Time, chunk C
 	return nil
 }
 
-func (m mockStore) Get(tx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error) {
+func (m mockStore) Get(tx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]Chunk, error) {
 	return nil, nil
 }
-func (m mockStore) LabelValuesForMetricName(ctx context.Context, from, through model.Time, metricName string, labelName string) ([]string, error) {
+func (m mockStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string) ([]string, error) {
 	return nil, nil
 }
 
-func (m mockStore) GetChunkRefs(tx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([][]Chunk, []*Fetcher, error) {
+func (m mockStore) GetChunkRefs(tx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([][]Chunk, []*Fetcher, error) {
 	return nil, nil, nil
 }
 
-func (m mockStore) LabelNamesForMetricName(ctx context.Context, from, through model.Time, metricName string) ([]string, error) {
+func (m mockStore) LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error) {
 	return nil, nil
 }
 

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/weaveworks/common/httpgrpc"
-	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/util"
@@ -99,17 +98,12 @@ func newSeriesStore(cfg StoreConfig, schema Schema, index IndexClient, chunks Ob
 }
 
 // Get implements Store
-func (c *seriesStore) Get(ctx context.Context, from, through model.Time, allMatchers ...*labels.Matcher) ([]Chunk, error) {
+func (c *seriesStore) Get(ctx context.Context, userID string, from, through model.Time, allMatchers ...*labels.Matcher) ([]Chunk, error) {
 	log, ctx := spanlogger.New(ctx, "SeriesStore.Get")
 	defer log.Span.Finish()
 	level.Debug(log).Log("from", from, "through", through, "matchers", len(allMatchers))
 
-	userID, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	chks, fetchers, err := c.GetChunkRefs(ctx, from, through, allMatchers...)
+	chks, fetchers, err := c.GetChunkRefs(ctx, userID, from, through, allMatchers...)
 	if err != nil {
 		return nil, err
 	}
@@ -142,17 +136,12 @@ func (c *seriesStore) Get(ctx context.Context, from, through model.Time, allMatc
 	return filteredChunks, nil
 }
 
-func (c *seriesStore) GetChunkRefs(ctx context.Context, from, through model.Time, allMatchers ...*labels.Matcher) ([][]Chunk, []*Fetcher, error) {
+func (c *seriesStore) GetChunkRefs(ctx context.Context, userID string, from, through model.Time, allMatchers ...*labels.Matcher) ([][]Chunk, []*Fetcher, error) {
 	log, ctx := spanlogger.New(ctx, "SeriesStore.GetChunkRefs")
 	defer log.Span.Finish()
 
-	userID, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	// Validate the query is within reasonable bounds.
-	metricName, matchers, shortcut, err := c.validateQuery(ctx, &from, &through, allMatchers)
+	metricName, matchers, shortcut, err := c.validateQuery(ctx, userID, &from, &through, allMatchers)
 	if err != nil {
 		return nil, nil, err
 	} else if shortcut {
@@ -192,16 +181,11 @@ func (c *seriesStore) GetChunkRefs(ctx context.Context, from, through model.Time
 }
 
 // LabelNamesForMetricName retrieves all label names for a metric name.
-func (c *seriesStore) LabelNamesForMetricName(ctx context.Context, from, through model.Time, metricName string) ([]string, error) {
+func (c *seriesStore) LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error) {
 	log, ctx := spanlogger.New(ctx, "SeriesStore.LabelNamesForMetricName")
 	defer log.Span.Finish()
 
-	userID, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	shortcut, err := c.validateQueryTimeRange(ctx, &from, &through)
+	shortcut, err := c.validateQueryTimeRange(ctx, userID, &from, &through)
 	if err != nil {
 		return nil, err
 	} else if shortcut {

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/util"
-	"github.com/weaveworks/common/user"
 )
 
 const (
@@ -295,8 +294,7 @@ func (i *Ingester) flushUserSeries(flushQueueIndex int, userID string, fp model.
 	}
 
 	// flush the chunks without locking the series, as we don't want to hold the series lock for the duration of the dynamo/s3 rpcs.
-	ctx := user.InjectOrgID(context.Background(), userID)
-	ctx, cancel := context.WithTimeout(ctx, i.cfg.FlushOpTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), i.cfg.FlushOpTimeout)
 	defer cancel() // releases resources if slowOperation completes before timeout elapses
 
 	sp, ctx := ot.StartSpanFromContext(ctx, "flushUserSeries")
@@ -304,7 +302,7 @@ func (i *Ingester) flushUserSeries(flushQueueIndex int, userID string, fp model.
 	sp.SetTag("organization", userID)
 
 	util.Event().Log("msg", "flush chunks", "userID", userID, "reason", reason, "numChunks", len(chunks), "firstTime", chunks[0].FirstTime, "fp", fp, "series", series.metric, "queue", flushQueueIndex)
-	err := i.flushChunks(ctx, fp, series.metric, chunks)
+	err := i.flushChunks(ctx, userID, fp, series.metric, chunks)
 	if err != nil {
 		return err
 	}
@@ -341,12 +339,7 @@ func (i *Ingester) removeFlushedChunks(userState *userState, fp model.Fingerprin
 	}
 }
 
-func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, metric labels.Labels, chunkDescs []*desc) error {
-	userID, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return err
-	}
-
+func (i *Ingester) flushChunks(ctx context.Context, userID string, fp model.Fingerprint, metric labels.Labels, chunkDescs []*desc) error {
 	wireChunks := make([]chunk.Chunk, 0, len(chunkDescs))
 	for _, chunkDesc := range chunkDescs {
 		c := chunk.NewChunk(userID, fp, metric, chunkDesc.C, chunkDesc.FirstTime, chunkDesc.LastTime)

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -293,23 +293,23 @@ func TestIngesterAppendOutOfOrderAndDuplicate(t *testing.T) {
 	m := labelPairs{
 		{Name: model.MetricNameLabel, Value: "testmetric"},
 	}
-	ctx := user.InjectOrgID(context.Background(), userID)
-	err := ing.append(ctx, m, 1, 0, client.API)
+	ctx := context.Background()
+	err := ing.append(ctx, userID, m, 1, 0, client.API)
 	require.NoError(t, err)
 
 	// Two times exactly the same sample (noop).
-	err = ing.append(ctx, m, 1, 0, client.API)
+	err = ing.append(ctx, userID, m, 1, 0, client.API)
 	require.NoError(t, err)
 
 	// Earlier sample than previous one.
-	err = ing.append(ctx, m, 0, 0, client.API)
+	err = ing.append(ctx, userID, m, 0, 0, client.API)
 	require.Contains(t, err.Error(), "sample timestamp out of order")
 	errResp, ok := httpgrpc.HTTPResponseFromError(err)
 	require.True(t, ok)
 	require.Equal(t, errResp.Code, int32(400))
 
 	// Same timestamp as previous sample, but different value.
-	err = ing.append(ctx, m, 1, 1, client.API)
+	err = ing.append(ctx, userID, m, 1, 1, client.API)
 	require.Contains(t, err.Error(), "sample with repeated timestamp but different value")
 	errResp, ok = httpgrpc.HTTPResponseFromError(err)
 	require.True(t, ok)
@@ -327,7 +327,7 @@ func TestIngesterAppendBlankLabel(t *testing.T) {
 		{Name: "bar", Value: ""},
 	}
 	ctx := user.InjectOrgID(context.Background(), userID)
-	err := ing.append(ctx, lp, 1, 0, client.API)
+	err := ing.append(ctx, userID, lp, 1, 0, client.API)
 	require.NoError(t, err)
 
 	res, _, err := runTestQuery(ctx, t, ing, labels.MatchEqual, model.MetricNameLabel, "testmetric")

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -55,13 +55,12 @@ func newDefaultTestStore(t require.TestingT) (*testStore, *Ingester) {
 }
 
 func (s *testStore) Put(ctx context.Context, chunks []chunk.Chunk) error {
+	if len(chunks) == 0 {
+		return nil
+	}
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	userID, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return err
-	}
 	for _, chunk := range chunks {
 		for _, v := range chunk.Metric {
 			if v.Value == "" {
@@ -69,6 +68,7 @@ func (s *testStore) Put(ctx context.Context, chunks []chunk.Chunk) error {
 			}
 		}
 	}
+	userID := chunks[0].UserID
 	s.chunks[userID] = append(s.chunks[userID], chunks...)
 	return nil
 }

--- a/pkg/ingester/query_test.go
+++ b/pkg/ingester/query_test.go
@@ -55,7 +55,7 @@ func BenchmarkQueryStream(b *testing.B) {
 			{Name: "cpu", Value: cpus[i%numCPUs]},
 		}
 
-		state, fp, series, err := ing.userStates.getOrCreateSeries(ctx, labels)
+		state, fp, series, err := ing.userStates.getOrCreateSeries(ctx, "1", labels)
 		require.NoError(b, err)
 
 		for j := 0; j < numSamples; j++ {

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -82,13 +82,12 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 			fromIngesterID = wireSeries.FromIngesterId
 			level.Info(util.Logger).Log("msg", "processing TransferChunks request", "from_ingester", fromIngesterID)
 		}
-		userCtx := user.InjectOrgID(stream.Context(), wireSeries.UserId)
 		descs, err := fromWireChunks(wireSeries.Chunks)
 		if err != nil {
 			return err
 		}
 
-		state, fp, series, err := userStates.getOrCreateSeries(userCtx, wireSeries.Labels)
+		state, fp, series, err := userStates.getOrCreateSeries(stream.Context(), wireSeries.UserId, wireSeries.Labels)
 		if err != nil {
 			return err
 		}

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -130,11 +130,7 @@ func (us *userStates) getViaContext(ctx context.Context) (*userState, bool, erro
 	return state, ok, nil
 }
 
-func (us *userStates) getOrCreateSeries(ctx context.Context, labels []client.LabelAdapter) (*userState, model.Fingerprint, *memorySeries, error) {
-	userID, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return nil, 0, nil, fmt.Errorf("no user id")
-	}
+func (us *userStates) getOrCreateSeries(ctx context.Context, userID string, labels []client.LabelAdapter) (*userState, model.Fingerprint, *memorySeries, error) {
 
 	state, ok := us.get(userID)
 	if !ok {

--- a/pkg/querier/chunk_store_queryable.go
+++ b/pkg/querier/chunk_store_queryable.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 )
@@ -34,7 +35,11 @@ type chunkStoreQuerier struct {
 }
 
 func (q *chunkStoreQuerier) Select(sp *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
-	chunks, err := q.store.Get(q.ctx, model.Time(sp.Start), model.Time(sp.End), matchers...)
+	userID, err := user.ExtractOrgID(q.ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	chunks, err := q.store.Get(q.ctx, userID, model.Time(sp.Start), model.Time(sp.End), matchers...)
 	if err != nil {
 		return nil, nil, promql.ErrStorage{Err: err}
 	}

--- a/pkg/querier/chunk_store_queryable_test.go
+++ b/pkg/querier/chunk_store_queryable_test.go
@@ -32,7 +32,7 @@ type mockChunkStore struct {
 	chunks []chunk.Chunk
 }
 
-func (m mockChunkStore) Get(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]chunk.Chunk, error) {
+func (m mockChunkStore) Get(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]chunk.Chunk, error) {
 	return m.chunks, nil
 }
 

--- a/pkg/querier/ingester_streaming_queryable.go
+++ b/pkg/querier/ingester_streaming_queryable.go
@@ -41,12 +41,7 @@ func (i ingesterQueryable) Querier(ctx context.Context, mint, maxt int64) (stora
 }
 
 // Get implements ChunkStore.
-func (i ingesterQueryable) Get(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]chunk.Chunk, error) {
-	userID, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return nil, promql.ErrStorage{Err: err}
-	}
-
+func (i ingesterQueryable) Get(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]chunk.Chunk, error) {
 	results, err := i.distributor.QueryStream(ctx, from, through, matchers...)
 	if err != nil {
 		return nil, promql.ErrStorage{Err: err}

--- a/pkg/querier/lazy_querier.go
+++ b/pkg/querier/lazy_querier.go
@@ -48,13 +48,13 @@ func (l lazyQuerier) Close() error {
 }
 
 // Get implements ChunkStore for the chunk tar HTTP handler.
-func (l lazyQuerier) Get(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]chunk.Chunk, error) {
+func (l lazyQuerier) Get(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]chunk.Chunk, error) {
 	store, ok := l.next.(ChunkStore)
 	if !ok {
 		return nil, fmt.Errorf("not supported")
 	}
 
-	return store.Get(ctx, from, through, matchers...)
+	return store.Get(ctx, userID, from, through, matchers...)
 }
 
 // errSeriesSet implements storage.SeriesSet, just returning an error.

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -55,7 +55,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 // ChunkStore is the read-interface to the Chunk Store.  Made an interface here
 // to reduce package coupling.
 type ChunkStore interface {
-	Get(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]chunk.Chunk, error)
+	Get(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]chunk.Chunk, error)
 }
 
 // New builds a queryable and promql engine.


### PR DESCRIPTION
Pull the extract of userID from context up as close as possible to where the request comes in, so we can error immediately if it's not there and avoid looking for userID at multiple points in the call stack.
Also avoid creating temporary contexts in chunk transfers.

This covers all of the write path, but some of the query path still fetches userID at a lower level.
