### PR TITLE
s3: force tls

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -128,6 +128,7 @@ type StorageConfig struct {
 	DynamoDBConfig
 	S3               flagext.URLValue
 	S3ForcePathStyle bool
+	S3ForceTLS       bool
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -137,6 +138,7 @@ func (cfg *StorageConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.S3, "s3.url", "S3 endpoint URL with escaped Key and Secret encoded. "+
 		"If only region is specified as a host, proper endpoint will be deduced. Use inmemory:///<bucket-name> to use a mock in-memory implementation.")
 	f.BoolVar(&cfg.S3ForcePathStyle, "s3.force-path-style", false, "Set this to `true` to force the request to use path-style addressing.")
+	f.BoolVar(&cfg.S3ForceTLS, "s3.force-tls", false, "Set this to `true` to force s3 requests to be made over https")
 }
 
 type dynamoDBStorageClient struct {

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -47,6 +47,12 @@ func NewS3ObjectClient(cfg StorageConfig, schemaCfg chunk.SchemaConfig) (chunk.O
 		return nil, err
 	}
 
+	if cfg.S3ForceTLS {
+		if strings.Contains(cfg.S3.URL.Host, ".") {
+			s3Config = s3Config.WithEndpoint(fmt.Sprintf("https://%s", cfg.S3.URL.Host))
+		}
+	}
+
 	s3Config = s3Config.WithS3ForcePathStyle(cfg.S3ForcePathStyle) // support for Path Style S3 url if has the flag
 
 	s3Config = s3Config.WithMaxRetries(0) // We do our own retries, so we can monitor them


### PR DESCRIPTION
DigitalOcean spaces while S3 compatible doesn't play nice with using http as the scheme with which it is accessed.

This changes adds a `s3.force-tls` flag to change the s3config endpoint from `http` to `https`

Flag turned off by default for backwards compatibility. 