### PR TITLE
Spread the sync load over time

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -4,8 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
@@ -56,6 +58,9 @@ func main() {
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
 	trace := tracing.NewFromEnv("cortex-" + cfg.Target.String())
 	defer trace.Close()
+
+	// Initialise seed for randomness usage.
+	rand.Seed(time.Now().UnixNano())
 
 	t, err := cortex.New(cfg)
 	util.CheckFatal("initializing cortex", err)

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math/rand"
 	"sort"
 	"strings"
 	"sync"
@@ -165,6 +166,10 @@ func (m *TableManager) Stop() {
 
 func (m *TableManager) loop() {
 	defer m.wait.Done()
+
+	// Sleep for a bit to spread the sync load across different times if the tablemanagers are all started at once.
+	rand.Seed(time.Now().UnixNano())
+	time.Sleep(time.Duration(rand.Int63n(int64(m.cfg.DynamoDBPollInterval))))
 
 	ticker := time.NewTicker(m.cfg.DynamoDBPollInterval)
 	defer ticker.Stop()

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -168,7 +168,6 @@ func (m *TableManager) loop() {
 	defer m.wait.Done()
 
 	// Sleep for a bit to spread the sync load across different times if the tablemanagers are all started at once.
-	rand.Seed(time.Now().UnixNano())
 	time.Sleep(time.Duration(rand.Int63n(int64(m.cfg.DynamoDBPollInterval))))
 
 	ticker := time.NewTicker(m.cfg.DynamoDBPollInterval)


### PR DESCRIPTION
If we have several table-managers that start at the same time, they will all start syncing at once causing limits to be hit. This adds some randomness so that the load is spread evenly.