### PR TITLE
Use remove-alertmanager-2.11 branch of Prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/prometheus/alertmanager v0.15.1
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/common v0.4.1
-	github.com/prometheus/prometheus v0.0.0-20190731144842-63ed2e28f1ac
+	github.com/prometheus/prometheus v0.0.0-20190820141915-363b523ee87e
 	github.com/prometheus/tsdb v0.9.1
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 	github.com/sercand/kuberesolver v2.1.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -423,8 +423,8 @@ github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1 h1:/K3IL0Z1quvmJ
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNGfs=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
-github.com/prometheus/prometheus v0.0.0-20190731144842-63ed2e28f1ac h1:nDONJ/OeNXNq7zDXYjuoPsvzf1WoT4cz9V32LsZE7Lo=
-github.com/prometheus/prometheus v0.0.0-20190731144842-63ed2e28f1ac/go.mod h1:0nIafMIZWDF3P7oq1Xf8HKRZ0I37hKmhYEAupBEaa4A=
+github.com/prometheus/prometheus v0.0.0-20190820141915-363b523ee87e h1:WtMWsG3EvUBI/qsDmgjsSsmJ7L2JEDIfgMX7WdKGvTY=
+github.com/prometheus/prometheus v0.0.0-20190820141915-363b523ee87e/go.mod h1:0nIafMIZWDF3P7oq1Xf8HKRZ0I37hKmhYEAupBEaa4A=
 github.com/prometheus/tsdb v0.9.1 h1:IWaAmWkYlgG7/S4iw4IpAQt5Y35QaZM6/GsZ7GsjAuk=
 github.com/prometheus/tsdb v0.9.1/go.mod h1:oi49uRhEe9dPUTlS3JRZOwJuVi6tmh10QSgwXEyGCt4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -334,7 +334,7 @@ github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 # github.com/prometheus/procfs v0.0.2
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
-# github.com/prometheus/prometheus v0.0.0-20190731144842-63ed2e28f1ac
+# github.com/prometheus/prometheus v0.0.0-20190820141915-363b523ee87e
 github.com/prometheus/prometheus/pkg/labels
 github.com/prometheus/prometheus/promql
 github.com/prometheus/prometheus/pkg/rulefmt


### PR DESCRIPTION
I updated `remove-alertmanager` branch of Prometheus for some other PR which cortex is using currently. This broke the vendoring.

I have created another branch `remove-alertmanager-2.11` with base version of Prometheus suffixed so that the same mistake is not repeated.

(Refer https://github.com/cortexproject/cortex/pull/1510#issuecomment-516895345 for the previous Prometheus vendoring)