### PR TITLE
fix crashing OverridesManager and updated the tests

### DIFF
--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -48,7 +48,7 @@ func NewOverridesManager(cfg OverridesManagerConfig) (*OverridesManager, error) 
 	}
 
 	if cfg.OverridesLoadPath != "" {
-		overridesManager.loop()
+		go overridesManager.loop()
 	} else {
 		level.Info(util.Logger).Log("msg", "per-tenant overrides disabled")
 	}

--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -43,7 +43,8 @@ type OverridesManager struct {
 // NewOverridesManager creates an instance of OverridesManager and starts reload overrides loop based on config
 func NewOverridesManager(cfg OverridesManagerConfig) (*OverridesManager, error) {
 	overridesManager := OverridesManager{
-		cfg: cfg,
+		cfg:  cfg,
+		quit: make(chan struct{}),
 	}
 
 	if cfg.OverridesLoadPath != "" {

--- a/pkg/util/validation/override_test.go
+++ b/pkg/util/validation/override_test.go
@@ -18,7 +18,7 @@ var defaultTestLimits *TestLimits
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (l *TestLimits) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	if defaultLimits != nil {
+	if defaultTestLimits != nil {
 		*l = *defaultTestLimits
 	}
 	type plain TestLimits
@@ -77,10 +77,15 @@ func TestOverridesManager_GetLimits(t *testing.T) {
 	require.NoError(t, overridesManager.loadOverrides())
 
 	// Checking whether overrides were enforced
+	require.Equal(t, 100, overridesManager.GetLimits("user1").(*TestLimits).Limit1)
 	require.Equal(t, 150, overridesManager.GetLimits("user1").(*TestLimits).Limit2)
+
+	// Verifying user2 limits are not impacted by overrides
+	require.Equal(t, 100, overridesManager.GetLimits("user2").(*TestLimits).Limit1)
 	require.Equal(t, 0, overridesManager.GetLimits("user2").(*TestLimits).Limit2)
 
 	// Cleaning up
 	require.NoError(t, tempFile.Close())
 	require.NoError(t, os.Remove(tempFile.Name()))
+	overridesManager.Stop()
 }

--- a/pkg/util/validation/override_test.go
+++ b/pkg/util/validation/override_test.go
@@ -15,6 +15,7 @@ type TestLimits struct {
 	Limit2 int `json:"limit2"`
 }
 
+// WARNING: THIS GLOBAL VARIABLE COULD LEAD TO UNEXPECTED BEHAVIOUR WHEN RUNNING MULTIPLE DIFFERENT TESTS
 var defaultTestLimits *TestLimits
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -78,17 +79,13 @@ func TestNewOverridesManager(t *testing.T) {
 	var overridesManager *OverridesManager
 	done := make(chan struct{})
 
-	// timeout for getting a response from NewOverridesManager()
-	timeout := time.NewTicker(1 * time.Second)
-	defer timeout.Stop()
-
 	go func() {
 		overridesManager, err = NewOverridesManager(overridesManagerConfig)
 		close(done)
 	}()
 
 	select {
-	case <-timeout.C:
+	case <-time.After(time.Second):
 		t.Fatal("failed to get a response from NewOverridesManager() before timeout")
 	case <-done:
 	}


### PR DESCRIPTION
OverridesManager was crashing while stopping because its quit channel was not initialized. Fixed it and updated some tests including calling Stop method of OverridesManager

Signed-off-by: Sandeep Sukhani <sandeep.d.sukhani@gmail.com>