### PR TITLE
Switch backoff implementation from a 'Full Jitter' to a 'Ranged Jitter'

### DIFF
--- a/pkg/util/backoff_test.go
+++ b/pkg/util/backoff_test.go
@@ -1,0 +1,103 @@
+package util
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestBackoff_nextDelay(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		minBackoff     time.Duration
+		maxBackoff     time.Duration
+		expectedRanges [][]time.Duration
+	}{
+		"exponential backoff with jitter honoring min and max": {
+			minBackoff: 100 * time.Millisecond,
+			maxBackoff: 10 * time.Second,
+			expectedRanges: [][]time.Duration{
+				{100 * time.Millisecond, 200 * time.Millisecond},
+				{200 * time.Millisecond, 400 * time.Millisecond},
+				{400 * time.Millisecond, 800 * time.Millisecond},
+				{800 * time.Millisecond, 1600 * time.Millisecond},
+				{1600 * time.Millisecond, 3200 * time.Millisecond},
+				{3200 * time.Millisecond, 6400 * time.Millisecond},
+				{6400 * time.Millisecond, 10000 * time.Millisecond},
+				{6400 * time.Millisecond, 10000 * time.Millisecond},
+			},
+		},
+		"exponential backoff with max equal to the end of a range": {
+			minBackoff: 100 * time.Millisecond,
+			maxBackoff: 800 * time.Millisecond,
+			expectedRanges: [][]time.Duration{
+				{100 * time.Millisecond, 200 * time.Millisecond},
+				{200 * time.Millisecond, 400 * time.Millisecond},
+				{400 * time.Millisecond, 800 * time.Millisecond},
+				{400 * time.Millisecond, 800 * time.Millisecond},
+			},
+		},
+		"exponential backoff with max equal to the end of a range + 1": {
+			minBackoff: 100 * time.Millisecond,
+			maxBackoff: 801 * time.Millisecond,
+			expectedRanges: [][]time.Duration{
+				{100 * time.Millisecond, 200 * time.Millisecond},
+				{200 * time.Millisecond, 400 * time.Millisecond},
+				{400 * time.Millisecond, 800 * time.Millisecond},
+				{800 * time.Millisecond, 801 * time.Millisecond},
+				{800 * time.Millisecond, 801 * time.Millisecond},
+			},
+		},
+		"exponential backoff with max equal to the end of a range - 1": {
+			minBackoff: 100 * time.Millisecond,
+			maxBackoff: 799 * time.Millisecond,
+			expectedRanges: [][]time.Duration{
+				{100 * time.Millisecond, 200 * time.Millisecond},
+				{200 * time.Millisecond, 400 * time.Millisecond},
+				{400 * time.Millisecond, 799 * time.Millisecond},
+				{400 * time.Millisecond, 799 * time.Millisecond},
+			},
+		},
+		"min backoff is equal to max": {
+			minBackoff: 100 * time.Millisecond,
+			maxBackoff: 100 * time.Millisecond,
+			expectedRanges: [][]time.Duration{
+				{100 * time.Millisecond, 100 * time.Millisecond},
+				{100 * time.Millisecond, 100 * time.Millisecond},
+				{100 * time.Millisecond, 100 * time.Millisecond},
+			},
+		},
+		"min backoff is greater then max": {
+			minBackoff: 200 * time.Millisecond,
+			maxBackoff: 100 * time.Millisecond,
+			expectedRanges: [][]time.Duration{
+				{200 * time.Millisecond, 200 * time.Millisecond},
+				{200 * time.Millisecond, 200 * time.Millisecond},
+				{200 * time.Millisecond, 200 * time.Millisecond},
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			b := NewBackoff(context.Background(), BackoffConfig{
+				MinBackoff: testData.minBackoff,
+				MaxBackoff: testData.maxBackoff,
+				MaxRetries: len(testData.expectedRanges),
+			})
+
+			for _, expectedRange := range testData.expectedRanges {
+				delay := b.nextDelay()
+
+				if delay < expectedRange[0] || delay > expectedRange[1] {
+					t.Errorf("%d expected to be within %d and %d", delay, expectedRange[0], expectedRange[1])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The current backoff algorithm doesn't honor `MinBackoff` and each sleep is basically a random between zero and a max range value starting from `MinBackoff` and doubling up to `MaxBackoff`.

Following up the discussion in https://github.com/cortexproject/cortex/issues/792, in this PR I'm proposing to switch to a different algorithm with both honors min and max, while keeping some jitter.

The proposed idea is to work with a ranged jitter. For each consecutive retry, the delay is picked as a random value between a range whose boundaries doubles each time.

## Simulation

I've run a simulation of 100 clients all starting the backoff at the same time `0` (should be the worst case scenario) with `10` max retries. The following chart shows the distribution over time (Y-axis, in milliseconds) of the retries, comparing the current and new algorithm.

### Current algorithm

- Y-axis: time in milliseconds
- X-axis: clients
- Colors: each different color identifies a retry for all clients (10 retries, 10 colors)

![Screen Shot 2019-08-21 at 18 56 52](https://user-images.githubusercontent.com/1701904/63451940-74a0e600-c445-11e9-99e0-6bd62cca7054.png)

### New algorithm

- Y-axis: time in milliseconds
- X-axis: clients
- Colors: each different color identifies a retry for all clients (10 retries, 10 colors)

![Screen Shot 2019-08-21 at 18 57 11](https://user-images.githubusercontent.com/1701904/63451969-7f5b7b00-c445-11e9-9ad5-cab64716d04c.png)
