### PR TITLE
added interfaces for store specific limits

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -78,11 +78,11 @@ type store struct {
 	index  IndexClient
 	chunks ObjectClient
 	schema Schema
-	limits CompositeStoreLimits
+	limits StoreLimits
 	*Fetcher
 }
 
-func newStore(cfg StoreConfig, schema Schema, index IndexClient, chunks ObjectClient, limits CompositeStoreLimits) (Store, error) {
+func newStore(cfg StoreConfig, schema Schema, index IndexClient, chunks ObjectClient, limits StoreLimits) (Store, error) {
 	fetcher, err := NewChunkFetcher(cfg.ChunkCacheConfig, cfg.chunkCacheStubs, chunks)
 	if err != nil {
 		return nil, err

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -78,11 +78,11 @@ type store struct {
 	index  IndexClient
 	chunks ObjectClient
 	schema Schema
-	limits *validation.Overrides
+	limits CompositeStoreLimits
 	*Fetcher
 }
 
-func newStore(cfg StoreConfig, schema Schema, index IndexClient, chunks ObjectClient, limits *validation.Overrides) (Store, error) {
+func newStore(cfg StoreConfig, schema Schema, index IndexClient, chunks ObjectClient, limits CompositeStoreLimits) (Store, error) {
 	fetcher, err := NewChunkFetcher(cfg.ChunkCacheConfig, cfg.chunkCacheStubs, chunks)
 	if err != nil {
 		return nil, err

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -3,12 +3,17 @@ package chunk
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
-
-	"github.com/cortexproject/cortex/pkg/util/validation"
 )
+
+// CompositeStoreLimits helps get Limits specific to Queries for Stores in CompositeStore
+type CompositeStoreLimits interface {
+	MaxChunksPerQuery(userID string) int
+	MaxQueryLength(userID string) time.Duration
+}
 
 // Store for chunks.
 type Store interface {
@@ -45,7 +50,7 @@ func NewCompositeStore() CompositeStore {
 }
 
 // AddPeriod adds the configuration for a period of time to the CompositeStore
-func (c *CompositeStore) AddPeriod(storeCfg StoreConfig, cfg PeriodConfig, index IndexClient, chunks ObjectClient, limits *validation.Overrides) error {
+func (c *CompositeStore) AddPeriod(storeCfg StoreConfig, cfg PeriodConfig, index IndexClient, chunks ObjectClient, limits CompositeStoreLimits) error {
 	schema := cfg.CreateSchema()
 	var store Store
 	var err error

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -9,8 +9,8 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
-// CompositeStoreLimits helps get Limits specific to Queries for Stores in CompositeStore
-type CompositeStoreLimits interface {
+// StoreLimits helps get Limits specific to Queries for Stores
+type StoreLimits interface {
 	MaxChunksPerQuery(userID string) int
 	MaxQueryLength(userID string) time.Duration
 }
@@ -50,7 +50,7 @@ func NewCompositeStore() CompositeStore {
 }
 
 // AddPeriod adds the configuration for a period of time to the CompositeStore
-func (c *CompositeStore) AddPeriod(storeCfg StoreConfig, cfg PeriodConfig, index IndexClient, chunks ObjectClient, limits CompositeStoreLimits) error {
+func (c *CompositeStore) AddPeriod(storeCfg StoreConfig, cfg PeriodConfig, index IndexClient, chunks ObjectClient, limits StoreLimits) error {
 	schema := cfg.CreateSchema()
 	var store Store
 	var err error

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
-	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 // CardinalityExceededError is returned when the user reads a row that
@@ -67,7 +66,7 @@ type seriesStore struct {
 	writeDedupeCache cache.Cache
 }
 
-func newSeriesStore(cfg StoreConfig, schema Schema, index IndexClient, chunks ObjectClient, limits *validation.Overrides) (Store, error) {
+func newSeriesStore(cfg StoreConfig, schema Schema, index IndexClient, chunks ObjectClient, limits CompositeStoreLimits) (Store, error) {
 	fetcher, err := NewChunkFetcher(cfg.ChunkCacheConfig, cfg.chunkCacheStubs, chunks)
 	if err != nil {
 		return nil, err

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -66,7 +66,7 @@ type seriesStore struct {
 	writeDedupeCache cache.Cache
 }
 
-func newSeriesStore(cfg StoreConfig, schema Schema, index IndexClient, chunks ObjectClient, limits CompositeStoreLimits) (Store, error) {
+func newSeriesStore(cfg StoreConfig, schema Schema, index IndexClient, chunks ObjectClient, limits StoreLimits) (Store, error) {
 	fetcher, err := NewChunkFetcher(cfg.ChunkCacheConfig, cfg.chunkCacheStubs, chunks)
 	if err != nil {
 		return nil, err

--- a/pkg/chunk/storage/caching_index_client.go
+++ b/pkg/chunk/storage/caching_index_client.go
@@ -16,7 +16,6 @@ import (
 	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
-	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 var (
@@ -46,10 +45,10 @@ type cachingIndexClient struct {
 	chunk.IndexClient
 	cache    cache.Cache
 	validity time.Duration
-	limits   *validation.Overrides
+	limits   StoreLimits
 }
 
-func newCachingIndexClient(client chunk.IndexClient, c cache.Cache, validity time.Duration, limits *validation.Overrides) chunk.IndexClient {
+func newCachingIndexClient(client chunk.IndexClient, c cache.Cache, validity time.Duration, limits StoreLimits) chunk.IndexClient {
 	if c == nil {
 		return client
 	}

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -14,10 +14,16 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/gcp"
 	"github.com/cortexproject/cortex/pkg/chunk/local"
 	"github.com/cortexproject/cortex/pkg/util"
-	"github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 )
+
+// StoreLimits helps get Limits specific to Queries for Stores
+type StoreLimits interface {
+	CardinalityLimit(userID string) int
+	MaxChunksPerQuery(userID string) int
+	MaxQueryLength(userID string) time.Duration
+}
 
 // Config chooses which storage client to use.
 type Config struct {
@@ -47,7 +53,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 // NewStore makes the storage clients based on the configuration.
-func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConfig, limits *validation.Overrides) (chunk.Store, error) {
+func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConfig, limits StoreLimits) (chunk.Store, error) {
 	tieredCache, err := cache.New(cfg.IndexQueriesCacheConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`NewStore` method in `pkg/storage` uses Overrides type defined in Cortex itself.
Added an interface to let consumers of that method pass any type which implements required methods returning Store specific limits.
This is done as part of way to let projects using Cortex, define their own limits

Signed-off-by: Sandeep Sukhani <sandeep.d.sukhani@gmail.com>