### PR TITLE
Reduce tablemanager cycle time to avoid long sleep in integration tests

### DIFF
--- a/integration-tests/test-flush.sh
+++ b/integration-tests/test-flush.sh
@@ -9,7 +9,7 @@ set -e
 # TODO: wait for DynamoDB ready
 sleep 5
 echo Start table-manager
-docker run $RUN_ARGS -d --name=tm --hostname=tm --restart=always quay.io/cortexproject/cortex:$IMAGE_TAG -target=table-manager $STORAGE_ARGS -table-manager.retention-period=168h
+docker run $RUN_ARGS -d --name=tm --hostname=tm --restart=always quay.io/cortexproject/cortex:$IMAGE_TAG -target=table-manager $STORAGE_ARGS -table-manager.retention-period=168h -dynamodb.poll-interval=5s
 
 echo Start ingester
 docker run $RUN_ARGS -d --name=i1 --hostname=i1 quay.io/cortexproject/cortex:$IMAGE_TAG -target=ingester $INGESTER_ARGS


### PR DESCRIPTION
Now the tablemanager [does a sleep at startup](#1587), we don't want to wait up to 2 minutes in the test for it to create the first tables.
