### PR TITLE
Fix comment on CardinalityLimit()

### DIFF
--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -224,7 +224,7 @@ func (o *Overrides) EnforceMetricName(userID string) bool {
 	return o.overridesManager.GetLimits(userID).(*Limits).EnforceMetricName
 }
 
-// CardinalityLimit whether to enforce the presence of a metric name.
+// CardinalityLimit returns the maximum number of timeseries allowed in a query.
 func (o *Overrides) CardinalityLimit(userID string) int {
 	return o.overridesManager.GetLimits(userID).(*Limits).CardinalityLimit
 }


### PR DESCRIPTION
I'm not sure this wording is entirely accurate, but it's better than what we had before.
