### PR TITLE
Use different colors for table rows on ring status page

### DIFF
--- a/pkg/ring/http.go
+++ b/pkg/ring/http.go
@@ -40,8 +40,12 @@ const tpl = `
 					</tr>
 				</thead>
 				<tbody>
-					{{ range .Ingesters }}
+					{{ range $i, $ing := .Ingesters }}
+					{{ if mod $i 2 }}
 					<tr>
+					{{ else }}
+					<tr bgcolor="#BEBEBE">
+					{{ end }}
 						<td>{{ .ID }}</td>
 						<td>{{ .State }}</td>
 						<td>{{ .Address }}</td>
@@ -61,7 +65,9 @@ const tpl = `
 var tmpl *template.Template
 
 func init() {
-	tmpl = template.Must(template.New("webpage").Parse(tpl))
+	t := template.New("webpage")
+	t.Funcs(template.FuncMap{"mod": func(i, j int) bool { return i%j == 0 }})
+	tmpl = template.Must(t.Parse(tpl))
 }
 
 func (r *Ring) forget(ctx context.Context, id string) error {


### PR DESCRIPTION
![Ring Status Page Table With Colors](https://user-images.githubusercontent.com/4493180/63654534-25d2b380-c799-11e9-9df3-cb9e350219c7.png)

This PR colors alternate table rows of the ingesters table on the ring status page.

Signed-off-by: Ankit Goel <ankit.goel@go-jek.com>