### PR TITLE
Optimise ring.DoBatch()

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -464,9 +464,10 @@ type mockRing struct {
 	replicationFactor uint32
 }
 
-func (r mockRing) Get(key uint32, op ring.Operation) (ring.ReplicationSet, error) {
+func (r mockRing) Get(key uint32, op ring.Operation, buf []ring.IngesterDesc) (ring.ReplicationSet, error) {
 	result := ring.ReplicationSet{
 		MaxErrors: 1,
+		Ingesters: buf[:0],
 	}
 	for i := uint32(0); i < r.replicationFactor; i++ {
 		n := (key + i) % uint32(len(r.ingesters))

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -475,18 +475,6 @@ func (r mockRing) Get(key uint32, op ring.Operation) (ring.ReplicationSet, error
 	return result, nil
 }
 
-func (r mockRing) BatchGet(keys []uint32, op ring.Operation) ([]ring.ReplicationSet, error) {
-	result := []ring.ReplicationSet{}
-	for i := 0; i < len(keys); i++ {
-		rs, err := r.Get(keys[i], op)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, rs)
-	}
-	return result, nil
-}
-
 func (r mockRing) GetAll() (ring.ReplicationSet, error) {
 	return ring.ReplicationSet{
 		Ingesters: r.ingesters,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -486,6 +486,10 @@ func (r mockRing) ReplicationFactor() int {
 	return int(r.replicationFactor)
 }
 
+func (r mockRing) IngesterCount() int {
+	return len(r.ingesters)
+}
+
 type mockIngester struct {
 	sync.Mutex
 	client.IngesterClient

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -68,7 +68,7 @@ func (d *Distributor) queryPrep(ctx context.Context, from, to model.Time, matche
 	// Get ingesters by metricName if one exists, otherwise get all ingesters
 	metricNameMatcher, _, ok := extract.MetricNameMatcherFromMatchers(matchers)
 	if !d.cfg.ShardByAllLabels && ok && metricNameMatcher.Type == labels.MatchEqual {
-		replicationSet, err = d.ring.Get(shardByMetricName(userID, metricNameMatcher.Value), ring.Read)
+		replicationSet, err = d.ring.Get(shardByMetricName(userID, metricNameMatcher.Value), ring.Read, nil)
 	} else {
 		replicationSet, err = d.ring.GetAll()
 	}

--- a/pkg/ring/batch.go
+++ b/pkg/ring/batch.go
@@ -37,14 +37,14 @@ type itemTracker struct {
 //
 // Not implemented as a method on Ring so we can test separately.
 func DoBatch(ctx context.Context, r ReadRing, keys []uint32, callback func(IngesterDesc, []int) error, cleanup func()) error {
-	replicationSets, err := r.BatchGet(keys, Write)
-	if err != nil {
-		return err
-	}
-
 	itemTrackers := make([]itemTracker, len(keys))
 	ingesters := map[string]ingester{}
-	for i, replicationSet := range replicationSets {
+
+	for i, key := range keys {
+		replicationSet, err := r.Get(key, Write)
+		if err != nil {
+			return err
+		}
 		itemTrackers[i].minSuccess = len(replicationSet.Ingesters) - replicationSet.MaxErrors
 		itemTrackers[i].maxFailures = replicationSet.MaxErrors
 

--- a/pkg/ring/batch.go
+++ b/pkg/ring/batch.go
@@ -40,8 +40,10 @@ func DoBatch(ctx context.Context, r ReadRing, keys []uint32, callback func(Inges
 	itemTrackers := make([]itemTracker, len(keys))
 	ingesters := make(map[string]ingester, r.IngesterCount())
 
+	const maxExpectedReplicationSet = 5 // typical replication factor 3 plus one for inactive plus one for luck
+	var descs [maxExpectedReplicationSet]IngesterDesc
 	for i, key := range keys {
-		replicationSet, err := r.Get(key, Write)
+		replicationSet, err := r.Get(key, Write, descs[:0])
 		if err != nil {
 			return err
 		}

--- a/pkg/ring/batch.go
+++ b/pkg/ring/batch.go
@@ -38,7 +38,7 @@ type itemTracker struct {
 // Not implemented as a method on Ring so we can test separately.
 func DoBatch(ctx context.Context, r ReadRing, keys []uint32, callback func(IngesterDesc, []int) error, cleanup func()) error {
 	itemTrackers := make([]itemTracker, len(keys))
-	ingesters := map[string]ingester{}
+	ingesters := make(map[string]ingester, r.IngesterCount())
 
 	for i, key := range keys {
 		replicationSet, err := r.Get(key, Write)

--- a/pkg/ring/batch.go
+++ b/pkg/ring/batch.go
@@ -41,7 +41,7 @@ func DoBatch(ctx context.Context, r ReadRing, keys []uint32, callback func(Inges
 	itemTrackers := make([]itemTracker, len(keys))
 	ingesters := make(map[string]ingester, r.IngesterCount())
 
-	const maxExpectedReplicationSet = 5 // typical replication factor 3 plus one for inactive plus one for luck
+	const maxExpectedReplicationSet = 5 // Typical replication factor 3, plus one for inactive plus one for luck.
 	var descs [maxExpectedReplicationSet]IngesterDesc
 	for i, key := range keys {
 		replicationSet, err := r.Get(key, Write, descs[:0])

--- a/pkg/ring/replication_strategy.go
+++ b/pkg/ring/replication_strategy.go
@@ -11,8 +11,7 @@ import (
 // - Filters out dead ingesters so the one doesn't even try to write to them.
 // - Checks there is enough ingesters for an operation to succeed.
 // The ingesters argument may be overwritten.
-func (r *Ring) replicationStrategy(ingesters []IngesterDesc, op Operation) (
-	[]IngesterDesc, int, error) {
+func (r *Ring) replicationStrategy(ingesters []IngesterDesc, op Operation) ([]IngesterDesc, int, error) {
 	// We need a response from a quorum of ingesters, which is n/2 + 1.  In the
 	// case of a node joining/leaving, the actual replica set might be bigger
 	// than the replication factor, so use the bigger or the two.

--- a/pkg/ring/replication_strategy.go
+++ b/pkg/ring/replication_strategy.go
@@ -62,3 +62,11 @@ func (r *Ring) IsHealthy(ingester *IngesterDesc, op Operation) bool {
 func (r *Ring) ReplicationFactor() int {
 	return r.cfg.ReplicationFactor
 }
+
+// IngesterCount is number of ingesters in the ring
+func (r *Ring) IngesterCount() int {
+	r.mtx.Lock()
+	c := len(r.ringDesc.Ingesters)
+	r.mtx.Unlock()
+	return c
+}

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -32,7 +32,6 @@ type ReadRing interface {
 	prometheus.Collector
 
 	Get(key uint32, op Operation) (ReplicationSet, error)
-	BatchGet(keys []uint32, op Operation) ([]ReplicationSet, error)
 	GetAll() (ReplicationSet, error)
 	ReplicationFactor() int
 }
@@ -185,23 +184,6 @@ func (r *Ring) Get(key uint32, op Operation) (ReplicationSet, error) {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 	return r.getInternal(key, op)
-}
-
-// BatchGet returns ReplicationFactor (or more) ingesters which form the replicas
-// for the given keys. The order of the result matches the order of the input.
-func (r *Ring) BatchGet(keys []uint32, op Operation) ([]ReplicationSet, error) {
-	r.mtx.RLock()
-	defer r.mtx.RUnlock()
-
-	result := make([]ReplicationSet, len(keys), len(keys))
-	for i, key := range keys {
-		rs, err := r.getInternal(key, op)
-		if err != nil {
-			return nil, err
-		}
-		result[i] = rs
-	}
-	return result, nil
 }
 
 func (r *Ring) getInternal(key uint32, op Operation) (ReplicationSet, error) {

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -34,6 +34,7 @@ type ReadRing interface {
 	Get(key uint32, op Operation) (ReplicationSet, error)
 	GetAll() (ReplicationSet, error)
 	ReplicationFactor() int
+	IngesterCount() int
 }
 
 // Operation can be Read or Write

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -2,7 +2,9 @@ package ring
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
@@ -10,6 +12,7 @@ import (
 const (
 	numIngester = 100
 	numTokens   = 512
+	numKeys     = 100
 )
 
 func BenchmarkRing(b *testing.B) {
@@ -30,10 +33,18 @@ func BenchmarkRing(b *testing.B) {
 		ringDesc: desc,
 	}
 
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	keys := make([]uint32, numKeys)
 	// Generate a batch of N random keys, and look them up
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		keys := GenerateTokens(100, nil)
+		generateKeys(rnd, numKeys, keys)
 		r.BatchGet(keys, Write)
+	}
+}
+
+func generateKeys(r *rand.Rand, numTokens int, dest []uint32) {
+	for i := 0; i < numTokens; i++ {
+		dest[i] = r.Uint32()
 	}
 }

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -13,12 +13,22 @@ import (
 )
 
 const (
-	numIngester = 100
-	numTokens   = 512
-	numKeys     = 100
+	numTokens = 512
 )
 
-func BenchmarkBatch(b *testing.B) {
+func BenchmarkBatch10x100(b *testing.B) {
+	benchmarkBatch(b, 10, 100)
+}
+
+func BenchmarkBatch100x100(b *testing.B) {
+	benchmarkBatch(b, 100, 100)
+}
+
+func BenchmarkBatch100x1000(b *testing.B) {
+	benchmarkBatch(b, 100, 1000)
+}
+
+func benchmarkBatch(b *testing.B, numIngester, numKeys int) {
 	// Make a random ring with N ingesters, and M tokens per ingests
 	desc := NewDesc()
 	takenTokens := []uint32{}

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -330,7 +330,7 @@ func (r *Ruler) Evaluate(userID string, item *workItem) {
 }
 
 func (r *Ruler) ownsRule(hash uint32) bool {
-	rlrs, err := r.ring.Get(hash, ring.Read)
+	rlrs, err := r.ring.Get(hash, ring.Read, nil)
 	// If an error occurs evaluate a rule as if it is owned
 	// better to have extra datapoints for a rule than none at all
 	// TODO: add a temporary cache of owned rule values or something to fall back on


### PR DESCRIPTION
`ring.DoBatch` contributes 20% of the memory allocation in my production distributors.

I started looking at this and realised the existing benchmark was not exercising the functionality - the `cas()` didn't update the ring so it was actually empty, and some test fixture code was also quite far up the profile.

Having fixed all that and made the benchmark call the higher-level function `DoBatch()`, the numbers before are:

```
BenchmarkBatch10x100-2     	   10000	    175156 ns/op	   56648 B/op	     334 allocs/op
BenchmarkBatch100x100-2    	    5000	    256146 ns/op	   87675 B/op	     720 allocs/op
BenchmarkBatch100x1000-2   	    1000	   1838020 ns/op	  578726 B/op	    3278 allocs/op
```

after:

```
BenchmarkBatch10x100-2     	   10000	    149385 ns/op	   12061 B/op	      29 allocs/op
BenchmarkBatch100x100-2    	   10000	    208285 ns/op	   30909 B/op	     238 allocs/op
BenchmarkBatch100x1000-2   	    1000	   1558331 ns/op	  112601 B/op	     217 allocs/op
```

The `ReadRing` function signatures have changed a bit, which may impact downstream projects using this code.