### PR TITLE
s3.buckets : allow spreading chunks across buckets

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -126,6 +126,7 @@ func (cfg *DynamoDBConfig) RegisterFlags(f *flag.FlagSet) {
 type StorageConfig struct {
 	DynamoDBConfig
 	S3               flagext.URLValue
+	BucketNames      string
 	S3ForcePathStyle bool
 }
 
@@ -136,6 +137,7 @@ func (cfg *StorageConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.S3, "s3.url", "S3 endpoint URL with escaped Key and Secret encoded. "+
 		"If only region is specified as a host, proper endpoint will be deduced. Use inmemory:///<bucket-name> to use a mock in-memory implementation.")
 	f.BoolVar(&cfg.S3ForcePathStyle, "s3.force-path-style", false, "Set this to `true` to force the request to use path-style addressing.")
+	f.StringVar(&cfg.BucketNames, "s3.buckets", "", "Comma separated list of bucket names to evenly distribute chunks over. Overrides any buckets specified in s3.url flag")
 }
 
 type dynamoDBStorageClient struct {


### PR DESCRIPTION
s3 buckets have per bucket API limits, to circumvent hitting API limits we can spread chunks across buckets. 

This PR introduces a new flag `s3.buckets` that takes a comma separated list of bucket names to spread chunks across. 