### PR TITLE
Fix BenchmarkQueryStream

### DIFF
--- a/pkg/ingester/query_test.go
+++ b/pkg/ingester/query_test.go
@@ -25,8 +25,8 @@ func BenchmarkQueryStream(b *testing.B) {
 	limits := defaultLimitsTestConfig()
 
 	const (
-		numSeries  = 1e6 // Put 1 million timeseries, each with 100 samples.
-		numSamples = 100
+		numSeries  = 1e6 // Put 1 million timeseries, each with 10 samples.
+		numSamples = 10
 		numCPUs    = 32
 	)
 
@@ -60,8 +60,8 @@ func BenchmarkQueryStream(b *testing.B) {
 
 		for j := 0; j < numSamples; j++ {
 			err = series.add(model.SamplePair{
-				Value:     model.SampleValue(float64(i)),
-				Timestamp: model.Time(int64(i)),
+				Value:     model.SampleValue(float64(j)),
+				Timestamp: model.Time(int64(j)),
 			})
 			require.NoError(b, err)
 		}

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -47,6 +47,9 @@ type memorySeriesError struct {
 }
 
 func (error *memorySeriesError) Error() string {
+	if error.message == "" {
+		return error.errorType
+	}
 	return error.message
 }
 


### PR DESCRIPTION
It was erroring, and I couldn't see why until I made the error code more helpful.
This told me the benchmark was sending all samples with the same value and timestamp so it wasn't testing what it claimed.  And when I fixed that it ran for several minutes so I cut the size of the test data.