### PR TITLE
Make Ruler Push() call get timeseries from the pool

### DIFF
--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -201,10 +201,10 @@ func FromLabelAdaptersToLabels(ls []LabelAdapter) labels.Labels {
 	return *(*labels.Labels)(unsafe.Pointer(&ls))
 }
 
-// FromLabelsToLabelAdapaters casts labels.Labels to []LabelAdapter.
+// FromLabelsToLabelAdapters casts labels.Labels to []LabelAdapter.
 // It uses unsafe, but as LabelAdapter == labels.Label this should be safe.
 // This allows us to use labels.Labels directly in protos.
-func FromLabelsToLabelAdapaters(ls labels.Labels) []LabelAdapter {
+func FromLabelsToLabelAdapters(ls labels.Labels) []LabelAdapter {
 	return *(*[]LabelAdapter)(unsafe.Pointer(&ls))
 }
 

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -18,23 +18,18 @@ import (
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
-// ToWriteRequest converts an array of samples into a WriteRequest proto.
-func ToWriteRequest(samples []model.Sample, source WriteRequest_SourceEnum) *WriteRequest {
+// ToWriteRequest converts matched slices of Labels and Samples into a WriteRequest proto.
+func ToWriteRequest(lbls []labels.Labels, samples []Sample, source WriteRequest_SourceEnum) *WriteRequest {
 	req := &WriteRequest{
 		Timeseries: make([]PreallocTimeseries, 0, len(samples)),
 		Source:     source,
 	}
 
-	for _, s := range samples {
+	for i, s := range samples {
 		ts := PreallocTimeseries{
 			TimeSeries: TimeSeries{
-				Labels: FromMetricsToLabelAdapters(s.Metric),
-				Samples: []Sample{
-					{
-						Value:       float64(s.Value),
-						TimestampMs: int64(s.Timestamp),
-					},
-				},
+				Labels:  FromLabelsToLabelAdapters(lbls[i]),
+				Samples: []Sample{s},
 			},
 		}
 		req.Timeseries = append(req.Timeseries, ts)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -384,7 +384,7 @@ func (i *Ingester) Query(ctx old_ctx.Context, req *client.QueryRequest) (*client
 		}
 
 		ts := client.TimeSeries{
-			Labels:  client.FromLabelsToLabelAdapaters(series.metric),
+			Labels:  client.FromLabelsToLabelAdapters(series.metric),
 			Samples: make([]client.Sample, 0, len(values)),
 		}
 		for _, s := range values {
@@ -447,7 +447,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 
 		numChunks += len(wireChunks)
 		batch = append(batch, client.TimeSeriesChunk{
-			Labels: client.FromLabelsToLabelAdapaters(series.metric),
+			Labels: client.FromLabelsToLabelAdapters(series.metric),
 			Chunks: wireChunks,
 		})
 
@@ -544,7 +544,7 @@ func (i *Ingester) MetricsForLabelMatchers(ctx old_ctx.Context, req *client.Metr
 		Metric: make([]*client.Metric, 0, len(lss)),
 	}
 	for _, ls := range lss {
-		result.Metric = append(result.Metric, &client.Metric{Labels: client.FromLabelsToLabelAdapaters(ls)})
+		result.Metric = append(result.Metric, &client.Metric{Labels: client.FromLabelsToLabelAdapters(ls)})
 	}
 
 	return result, nil

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -109,18 +109,28 @@ func buildTestMatrix(numSeries int, samplesPerSeries int, offset int) model.Matr
 	return m
 }
 
-func matrixToSamples(m model.Matrix) []model.Sample {
-	var samples []model.Sample
+func matrixToSamples(m model.Matrix) []client.Sample {
+	var samples []client.Sample
 	for _, ss := range m {
 		for _, sp := range ss.Values {
-			samples = append(samples, model.Sample{
-				Metric:    ss.Metric,
-				Timestamp: sp.Timestamp,
-				Value:     sp.Value,
+			samples = append(samples, client.Sample{
+				TimestampMs: int64(sp.Timestamp),
+				Value:       float64(sp.Value),
 			})
 		}
 	}
 	return samples
+}
+
+// Return one copy of the labels per sample
+func matrixToLables(m model.Matrix) []labels.Labels {
+	var labels []labels.Labels
+	for _, ss := range m {
+		for range ss.Values {
+			labels = append(labels, client.FromLabelAdaptersToLabels(client.FromMetricsToLabelAdapters(ss.Metric)))
+		}
+	}
+	return labels
 }
 
 func runTestQuery(ctx context.Context, t *testing.T, ing *Ingester, ty labels.MatchType, n, v string) (model.Matrix, *client.QueryRequest, error) {
@@ -157,7 +167,7 @@ func pushTestSamples(t *testing.T, ing *Ingester, numSeries, samplesPerSeries, o
 	// Append samples.
 	for _, userID := range userIDs {
 		ctx := user.InjectOrgID(context.Background(), userID)
-		_, err := ing.Push(ctx, client.ToWriteRequest(matrixToSamples(testData[userID]), client.API))
+		_, err := ing.Push(ctx, client.ToWriteRequest(matrixToLables(testData[userID]), matrixToSamples(testData[userID]), client.API))
 		require.NoError(t, err)
 	}
 
@@ -330,12 +340,12 @@ func TestIngesterAppendBlankLabel(t *testing.T) {
 	err := ing.append(ctx, userID, lp, 1, 0, client.API)
 	require.NoError(t, err)
 
-	res, _, err := runTestQuery(ctx, t, ing, labels.MatchEqual, model.MetricNameLabel, "testmetric")
+	res, _, err := runTestQuery(ctx, t, ing, labels.MatchEqual, labels.MetricName, "testmetric")
 	require.NoError(t, err)
 
 	expected := model.Matrix{
 		{
-			Metric: model.Metric{model.MetricNameLabel: "testmetric"},
+			Metric: model.Metric{labels.MetricName: "testmetric"},
 			Values: []model.SamplePair{
 				{Timestamp: 1, Value: 0},
 			},
@@ -353,29 +363,28 @@ func TestIngesterUserSeriesLimitExceeded(t *testing.T) {
 	defer ing.Shutdown()
 
 	userID := "1"
-	sample1 := model.Sample{
-		Metric:    model.Metric{model.MetricNameLabel: "testmetric", "foo": "bar"},
-		Timestamp: 0,
-		Value:     1,
+	labels1 := labels.Labels{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}}
+	sample1 := client.Sample{
+		TimestampMs: 0,
+		Value:       1,
 	}
-	sample2 := model.Sample{
-		Metric:    model.Metric{model.MetricNameLabel: "testmetric", "foo": "bar"},
-		Timestamp: 1,
-		Value:     2,
+	sample2 := client.Sample{
+		TimestampMs: 1,
+		Value:       2,
 	}
-	sample3 := model.Sample{
-		Metric:    model.Metric{model.MetricNameLabel: "testmetric", "foo": "biz"},
-		Timestamp: 1,
-		Value:     3,
+	labels3 := labels.Labels{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "biz"}}
+	sample3 := client.Sample{
+		TimestampMs: 1,
+		Value:       3,
 	}
 
 	// Append only one series first, expect no error.
 	ctx := user.InjectOrgID(context.Background(), userID)
-	_, err := ing.Push(ctx, client.ToWriteRequest([]model.Sample{sample1}, client.API))
+	_, err := ing.Push(ctx, client.ToWriteRequest([]labels.Labels{labels1}, []client.Sample{sample1}, client.API))
 	require.NoError(t, err)
 
 	// Append to two series, expect series-exceeded error.
-	_, err = ing.Push(ctx, client.ToWriteRequest([]model.Sample{sample2, sample3}, client.API))
+	_, err = ing.Push(ctx, client.ToWriteRequest([]labels.Labels{labels1, labels3}, []client.Sample{sample2, sample3}, client.API))
 	if resp, ok := httpgrpc.HTTPResponseFromError(err); !ok || resp.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected error about exceeding metrics per user, got %v", err)
 	}
@@ -386,15 +395,15 @@ func TestIngesterUserSeriesLimitExceeded(t *testing.T) {
 
 	expected := model.Matrix{
 		{
-			Metric: sample1.Metric,
+			Metric: client.FromLabelAdaptersToMetric(client.FromLabelsToLabelAdapters(labels1)),
 			Values: []model.SamplePair{
 				{
-					Timestamp: sample1.Timestamp,
-					Value:     sample1.Value,
+					Timestamp: model.Time(sample1.TimestampMs),
+					Value:     model.SampleValue(sample1.Value),
 				},
 				{
-					Timestamp: sample2.Timestamp,
-					Value:     sample2.Value,
+					Timestamp: model.Time(sample2.TimestampMs),
+					Value:     model.SampleValue(sample2.Value),
 				},
 			},
 		},
@@ -411,29 +420,28 @@ func TestIngesterMetricSeriesLimitExceeded(t *testing.T) {
 	defer ing.Shutdown()
 
 	userID := "1"
-	sample1 := model.Sample{
-		Metric:    model.Metric{model.MetricNameLabel: "testmetric", "foo": "bar"},
-		Timestamp: 0,
-		Value:     1,
+	labels1 := labels.Labels{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}}
+	sample1 := client.Sample{
+		TimestampMs: 0,
+		Value:       1,
 	}
-	sample2 := model.Sample{
-		Metric:    model.Metric{model.MetricNameLabel: "testmetric", "foo": "bar"},
-		Timestamp: 1,
-		Value:     2,
+	sample2 := client.Sample{
+		TimestampMs: 1,
+		Value:       2,
 	}
-	sample3 := model.Sample{
-		Metric:    model.Metric{model.MetricNameLabel: "testmetric", "foo": "biz"},
-		Timestamp: 1,
-		Value:     3,
+	labels3 := labels.Labels{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "biz"}}
+	sample3 := client.Sample{
+		TimestampMs: 1,
+		Value:       3,
 	}
 
 	// Append only one series first, expect no error.
 	ctx := user.InjectOrgID(context.Background(), userID)
-	_, err := ing.Push(ctx, client.ToWriteRequest([]model.Sample{sample1}, client.API))
+	_, err := ing.Push(ctx, client.ToWriteRequest([]labels.Labels{labels1}, []client.Sample{sample1}, client.API))
 	require.NoError(t, err)
 
 	// Append to two series, expect series-exceeded error.
-	_, err = ing.Push(ctx, client.ToWriteRequest([]model.Sample{sample2, sample3}, client.API))
+	_, err = ing.Push(ctx, client.ToWriteRequest([]labels.Labels{labels1, labels3}, []client.Sample{sample2, sample3}, client.API))
 	if resp, ok := httpgrpc.HTTPResponseFromError(err); !ok || resp.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected error about exceeding series per metric, got %v", err)
 	}
@@ -444,15 +452,15 @@ func TestIngesterMetricSeriesLimitExceeded(t *testing.T) {
 
 	expected := model.Matrix{
 		{
-			Metric: sample1.Metric,
+			Metric: client.FromLabelAdaptersToMetric(client.FromLabelsToLabelAdapters(labels1)),
 			Values: []model.SamplePair{
 				{
-					Timestamp: sample1.Timestamp,
-					Value:     sample1.Value,
+					Timestamp: model.Time(sample1.TimestampMs),
+					Value:     model.SampleValue(sample1.Value),
 				},
 				{
-					Timestamp: sample2.Timestamp,
-					Value:     sample2.Value,
+					Timestamp: model.Time(sample2.TimestampMs),
+					Value:     model.SampleValue(sample2.Value),
 				},
 			},
 		},

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -248,7 +248,7 @@ func (i *Ingester) transferOut(ctx context.Context) error {
 			err = stream.Send(&client.TimeSeriesChunk{
 				FromIngesterId: i.lifecycler.ID,
 				UserId:         userID,
-				Labels:         client.FromLabelsToLabelAdapaters(pair.series.metric),
+				Labels:         client.FromLabelsToLabelAdapters(pair.series.metric),
 				Chunks:         chunks,
 			})
 			state.fpLocker.Unlock(pair.fp)


### PR DESCRIPTION
Because `Distributor.Push()` returns them to the pool (after #1526).

In a typical deployment this doesn't actually break, since nothing in `Ruler` gets things out of the pool and the pool is emptied on GC, but it's clearly wrong and also inefficient.

The main change in this PR is to make `ToWriteRequest()` get from the pool - besides the one call in Ruler this is only used in tests, where it doesn't matter that the memory is never returned to the pool.

Along the way I re-coded `ToWriteRequest()` to not go via `Metric` - we were creating a map on every ruler sample just to read the data back out again.

Oh, and a drive-by spelling correction.