### PR TITLE
 Return request data to the pool in Ingester.Push()

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -348,7 +348,7 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 
 		keys = append(keys, key)
 		validatedTimeseries = append(validatedTimeseries, client.PreallocTimeseries{
-			TimeSeries: client.TimeSeries{
+			TimeSeries: &client.TimeSeries{
 				Labels:  ts.Labels,
 				Samples: samples,
 			},

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -384,7 +384,7 @@ func makeWriteRequest(samples int) *client.WriteRequest {
 	request := &client.WriteRequest{}
 	for i := 0; i < samples; i++ {
 		ts := client.PreallocTimeseries{
-			TimeSeries: client.TimeSeries{
+			TimeSeries: &client.TimeSeries{
 				Labels: []client.LabelAdapter{
 					{Name: model.MetricNameLabel, Value: "foo"},
 					{Name: "bar", Value: "baz"},
@@ -407,7 +407,7 @@ func makeWriteRequestHA(samples int, replica, cluster string) *client.WriteReque
 	request := &client.WriteRequest{}
 	for i := 0; i < samples; i++ {
 		ts := client.PreallocTimeseries{
-			TimeSeries: client.TimeSeries{
+			TimeSeries: &client.TimeSeries{
 				Labels: []client.LabelAdapter{
 					{Name: "__name__", Value: "foo"},
 					{Name: "bar", Value: "baz"},
@@ -548,7 +548,7 @@ func (i *mockIngester) Query(ctx context.Context, req *client.QueryRequest, opts
 	response := client.QueryResponse{}
 	for _, ts := range i.timeseries {
 		if match(ts.Labels, matchers) {
-			response.Timeseries = append(response.Timeseries, ts.TimeSeries)
+			response.Timeseries = append(response.Timeseries, *ts.TimeSeries)
 		}
 	}
 	return &response, nil

--- a/pkg/ingester/client/client_test.go
+++ b/pkg/ingester/client/client_test.go
@@ -17,7 +17,7 @@ func TestMarshall(t *testing.T) {
 		req := WriteRequest{}
 		for i := 0; i < 10; i++ {
 			req.Timeseries = append(req.Timeseries, PreallocTimeseries{
-				TimeSeries{
+				&TimeSeries{
 					Labels: []LabelAdapter{
 						{"foo", strconv.Itoa(i)},
 					},

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -27,7 +27,7 @@ func ToWriteRequest(lbls []labels.Labels, samples []Sample, source WriteRequest_
 	}
 
 	for i, s := range samples {
-		ts := timeSeriesPool.Get().(TimeSeries)
+		ts := timeSeriesPool.Get().(*TimeSeries)
 		ts.Labels = append(ts.Labels, FromLabelsToLabelAdapters(lbls[i])...)
 		ts.Samples = append(ts.Samples, s)
 		req.Timeseries = append(req.Timeseries, PreallocTimeseries{TimeSeries: ts})

--- a/pkg/ingester/client/timeseries.go
+++ b/pkg/ingester/client/timeseries.go
@@ -24,7 +24,7 @@ var (
 
 	timeSeriesPool = sync.Pool{
 		New: func() interface{} {
-			return TimeSeries{
+			return &TimeSeries{
 				Labels:  make([]LabelAdapter, 0, expectedLabels),
 				Samples: make([]Sample, 0, expectedSamplesPerSeries),
 			}
@@ -56,12 +56,12 @@ func (p *PreallocWriteRequest) Unmarshal(dAtA []byte) error {
 
 // PreallocTimeseries is a TimeSeries which preallocs slices on Unmarshal.
 type PreallocTimeseries struct {
-	TimeSeries
+	*TimeSeries
 }
 
 // Unmarshal implements proto.Message.
 func (p *PreallocTimeseries) Unmarshal(dAtA []byte) error {
-	p.TimeSeries = timeSeriesPool.Get().(TimeSeries)
+	p.TimeSeries = timeSeriesPool.Get().(*TimeSeries)
 	return p.TimeSeries.Unmarshal(dAtA)
 }
 
@@ -249,7 +249,7 @@ func ReuseSlice(slice []PreallocTimeseries) {
 }
 
 // ReuseTimeseries puts the timeseries back into a sync.Pool for reuse.
-func ReuseTimeseries(ts TimeSeries) {
+func ReuseTimeseries(ts *TimeSeries) {
 	ts.Labels = ts.Labels[:0]
 	ts.Samples = ts.Samples[:0]
 	timeSeriesPool.Put(ts)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -279,6 +279,7 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 			return nil, err
 		}
 	}
+	client.ReuseSlice(req.Timeseries)
 
 	return &client.WriteResponse{}, lastPartialErr
 }

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -498,7 +498,7 @@ func benchmarkIngesterSeriesCreationLocking(b *testing.B, parallelism int) {
 				_, err := ing.Push(ctx, &client.WriteRequest{
 					Timeseries: []client.PreallocTimeseries{
 						{
-							TimeSeries: client.TimeSeries{
+							TimeSeries: &client.TimeSeries{
 								Labels: []client.LabelAdapter{
 									{Name: model.MetricNameLabel, Value: fmt.Sprintf("metric_%d", j)},
 								},


### PR DESCRIPTION
After #1526 the unmarshall code is trying to get memory out of the pool, but in ingesters it is never returned so the `pool.Get()` call just slows things down.

After making this change it still wasn't that great, because the pool was boxing `TimeSeries` objects.  So change those to `*TimeSeries`.

before:
```
BenchmarkIngesterPush-2   	     100	  23525939 ns/op	 3881766 B/op	   42317 allocs/op
```

after:
```
BenchmarkIngesterPush-2   	     100	  22937648 ns/op	 3273382 B/op	   32482 allocs/op
```

(note out of the 3-4MB per iteration, 1MB is overhead from the `FingerprintLocker`)