### PR TITLE
Fixed a typo (synching -> syncing) in difflib.go and table_manager.go

### DIFF
--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -217,7 +217,7 @@ func (m *TableManager) bucketRetentionLoop() {
 // not and update those that need it.  It is exposed for testing.
 func (m *TableManager) SyncTables(ctx context.Context) error {
 	expected := m.calculateExpectedTables()
-	level.Info(util.Logger).Log("msg", "synching tables", "num_expected_tables", len(expected), "expected_tables", len(expected))
+	level.Info(util.Logger).Log("msg", "syncing tables", "num_expected_tables", len(expected), "expected_tables", len(expected))
 
 	toCreate, toCheckThroughput, toDelete, err := m.partitionTables(ctx, expected)
 	if err != nil {

--- a/vendor/github.com/pmezard/go-difflib/difflib/difflib.go
+++ b/vendor/github.com/pmezard/go-difflib/difflib/difflib.go
@@ -75,7 +75,7 @@ type OpCode struct {
 // notion, pairing up elements that appear uniquely in each sequence.
 // That, and the method here, appear to yield more intuitive difference
 // reports than does diff.  This method appears to be the least vulnerable
-// to synching up on blocks of "junk lines", though (like blank lines in
+// to syncing up on blocks of "junk lines", though (like blank lines in
 // ordinary text files, or maybe "<P>" lines in HTML files).  That may be
 // because this is the only method of the 3 that has a *concept* of
 // "junk" <wink>.


### PR DESCRIPTION
Signed-off-by: Piyush Baderia <piyush.baderia@outlook.com>