### PR TITLE
Stop blocking batchTracker on chan when DoBatch() gets cancelled

### DIFF
--- a/pkg/ring/batch.go
+++ b/pkg/ring/batch.go
@@ -60,8 +60,8 @@ func DoBatch(ctx context.Context, r ReadRing, keys []uint32, callback func(Inges
 
 	tracker := batchTracker{
 		rpcsPending: int32(len(itemTrackers)),
-		done:        make(chan struct{}),
-		err:         make(chan error),
+		done:        make(chan struct{}, 1),
+		err:         make(chan error, 1),
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
Fixes #1640 

`batchTracker.record()` is written so there will only be one send on each chan, but if `ctx.Done()` happens before either then `DoBatch()` returns so we need 1 slot in each chan to be able to send without blocking when nobody is receiving.
