### PR TITLE
Use golang proxy for go modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,10 +145,10 @@ configs-integration-test:
 	/bin/bash -c "go test -v -tags 'netgo integration' -timeout 30s ./pkg/configs/... ./pkg/ruler/..."
 
 mod-check:
-	GO111MODULE=on go mod download
-	GO111MODULE=on go mod verify
-	GO111MODULE=on go mod tidy
-	GO111MODULE=on go mod vendor
+	GO111MODULE=on GOPROXY=https://proxy.golang.org go mod download
+	GO111MODULE=on GOPROXY=https://proxy.golang.org go mod verify
+	GO111MODULE=on GOPROXY=https://proxy.golang.org go mod tidy
+	GO111MODULE=on GOPROXY=https://proxy.golang.org go mod vendor
 	@git diff --exit-code -- go.sum go.mod vendor/
 
 check-protos: clean-protos protos


### PR DESCRIPTION
This should help speed up all the go module fetch. It is the default proxy from go1.13 onwards but would be good to have now this till we switch to go1.13.