### PR TITLE
Shrink bigchunk data structure

### DIFF
--- a/pkg/chunk/encoding/bigchunk.go
+++ b/pkg/chunk/encoding/bigchunk.go
@@ -15,7 +15,7 @@ const samplesPerChunk = 120
 var errOutOfBounds = errors.New("out of bounds")
 
 type smallChunk struct {
-	*chunkenc.XORChunk
+	chunkenc.XORChunk
 	start int64
 	end   int64
 }
@@ -63,22 +63,20 @@ func (b *bigchunk) addNextChunk(start model.Time) error {
 			if err != nil {
 				return err
 			}
-			b.chunks[l-1].XORChunk = compacted.(*chunkenc.XORChunk)
+			b.chunks[l-1].XORChunk = *compacted.(*chunkenc.XORChunk)
 		}
 	}
 
-	chunk := chunkenc.NewXORChunk()
-	appender, err := chunk.Appender()
-	if err != nil {
-		return err
-	}
-
 	b.chunks = append(b.chunks, smallChunk{
-		XORChunk: chunk,
+		XORChunk: *chunkenc.NewXORChunk(),
 		start:    int64(start),
 		end:      int64(start),
 	})
 
+	appender, err := b.chunks[len(b.chunks)-1].Appender()
+	if err != nil {
+		return err
+	}
 	b.appender = appender
 	b.remainingSamples = samplesPerChunk
 	return nil
@@ -138,7 +136,7 @@ func (b *bigchunk) UnmarshalFromBuf(buf []byte) error {
 		}
 
 		b.chunks = append(b.chunks, smallChunk{
-			XORChunk: chunk.(*chunkenc.XORChunk),
+			XORChunk: *chunk.(*chunkenc.XORChunk),
 			start:    int64(start),
 			end:      int64(end),
 		})

--- a/pkg/chunk/encoding/bigchunk.go
+++ b/pkg/chunk/encoding/bigchunk.go
@@ -23,7 +23,6 @@ type smallChunk struct {
 // upperbound on number of samples it can contain.
 type bigchunk struct {
 	chunks []smallChunk
-	end    int64
 
 	appender         chunkenc.Appender
 	remainingSamples int
@@ -45,7 +44,6 @@ func (b *bigchunk) Add(sample model.SamplePair) ([]Chunk, error) {
 
 	b.appender.Append(int64(sample.Timestamp), float64(sample.Value))
 	b.remainingSamples--
-	b.end = int64(sample.Timestamp)
 	return []Chunk{b}, nil
 }
 
@@ -248,7 +246,7 @@ type bigchunkIterator struct {
 }
 
 func (it *bigchunkIterator) FindAtOrAfter(target model.Time) bool {
-	if it.i >= len(it.chunks) || int64(target) > it.end {
+	if it.i >= len(it.chunks) {
 		return false
 	}
 

--- a/pkg/chunk/encoding/bigchunk.go
+++ b/pkg/chunk/encoding/bigchunk.go
@@ -273,6 +273,14 @@ func (it *bigchunkIterator) FindAtOrAfter(target model.Time) bool {
 			return true
 		}
 	}
+	// Timestamp is after the end of that chunk - if there is another chunk
+	// then the position we need is at the beginning of it.
+	if it.i+1 < len(it.chunks) {
+		it.i++
+		it.curr = it.chunks[it.i].Iterator(it.curr)
+		it.curr.Next()
+		return true
+	}
 	return false
 }
 

--- a/pkg/chunk/encoding/bigchunk_test.go
+++ b/pkg/chunk/encoding/bigchunk_test.go
@@ -55,6 +55,13 @@ func TestSliceBiggerChunk(t *testing.T) {
 			require.Equal(t, sample.Value, model.SampleValue(j))
 			require.True(t, iter.Scan())
 		}
+
+		// Now try via seek
+		iter = s.NewIterator(iter)
+		require.True(t, iter.FindAtOrAfter(model.Time(i*step)))
+		sample := iter.Value()
+		require.Equal(t, sample.Timestamp, model.Time(i*step))
+		require.Equal(t, sample.Value, model.SampleValue(i))
 	}
 }
 

--- a/pkg/chunk/encoding/chunk_test.go
+++ b/pkg/chunk/encoding/chunk_test.go
@@ -147,6 +147,14 @@ func testChunkSeek(t *testing.T, encoding Encoding, samples int) {
 
 	iter := chunk.NewIterator(nil)
 	for i := 0; i < samples; i += samples / 10 {
+		if i > 0 {
+			// Seek one millisecond before the actual time
+			require.True(t, iter.FindAtOrAfter(model.Time(i*step-1)), "1ms before step %d not found", i)
+			sample := iter.Value()
+			require.EqualValues(t, model.Time(i*step), sample.Timestamp)
+			require.EqualValues(t, model.SampleValue(i), sample.Value)
+		}
+		// Now seek to exactly the right time
 		require.True(t, iter.FindAtOrAfter(model.Time(i*step)))
 		sample := iter.Value()
 		require.EqualValues(t, model.Time(i*step), sample.Timestamp)

--- a/pkg/chunk/encoding/chunk_test.go
+++ b/pkg/chunk/encoding/chunk_test.go
@@ -131,6 +131,12 @@ func testChunkEncoding(t *testing.T, encoding Encoding, samples int) {
 	require.False(t, iter.Scan())
 	require.NoError(t, iter.Err())
 
+	// Check seek works after unmarshal
+	iter = chunk.NewIterator(iter)
+	for i := 0; i < samples; i += samples / 10 {
+		require.True(t, iter.FindAtOrAfter(model.Time(i*step)))
+	}
+
 	// Check the byte representation after another Marshall is the same.
 	buf = bytes.Buffer{}
 	err = chunk.Marshal(&buf)
@@ -170,6 +176,8 @@ func testChunkSeek(t *testing.T, encoding Encoding, samples int) {
 		require.False(t, iter.Scan())
 		require.NoError(t, iter.Err())
 	}
+	// Check seek past the end of the chunk returns failure
+	require.False(t, iter.FindAtOrAfter(model.Time(samples*step+1)))
 }
 
 func testChunkSeekForward(t *testing.T, encoding Encoding, samples int) {


### PR DESCRIPTION
Remove pointer indirection on the underlying `XORChunk`, which will save memory and a few CPU cycles.
We have to be careful to create the Appender after the chunk is appended to our slice, since it has a pointer to the chunk memory.

And stop storing the end time of every small chunk - we can look at the start time of the next one since they don't overlap. This makes the data structure slightly smaller, and speeds up unmarshalling since we don't need to seek through every value.

We don't _need_ to store the start time either, since it can be fetched from the underlying chunk, but that takes longer.

Estimate of the impact:  Suppose chunks are avg 6 hours long then each one has 12 smallchunks and we save 16 bytes per = 192MB per million series, plus Go heap overheads.