### PR TITLE
Cache Bigtable Table Info

### DIFF
--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -38,12 +38,15 @@ type Config struct {
 
 	ColumnKey      bool
 	DistributeKeys bool
+
+	CacheTableInfo bool
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.Project, "bigtable.project", "", "Bigtable project ID.")
 	f.StringVar(&cfg.Instance, "bigtable.instance", "", "Bigtable instance ID.")
+	f.BoolVar(&cfg.CacheTableInfo, "bigtable.cache-table-info", true, "If enabled, once a tables info is fetched, it is cached indefinitely.")
 
 	cfg.GRPCClientConfig.RegisterFlags("bigtable", f)
 }

--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/bigtable"
 	ot "github.com/opentracing/opentracing-go"
@@ -39,14 +40,16 @@ type Config struct {
 	ColumnKey      bool
 	DistributeKeys bool
 
-	CacheTableInfo bool
+	TableCacheEnabled    bool
+	TableCacheExpiration time.Duration
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.Project, "bigtable.project", "", "Bigtable project ID.")
 	f.StringVar(&cfg.Instance, "bigtable.instance", "", "Bigtable instance ID.")
-	f.BoolVar(&cfg.CacheTableInfo, "bigtable.cache-table-info", true, "If enabled, once a tables info is fetched, it is cached indefinitely.")
+	f.BoolVar(&cfg.TableCacheEnabled, "bigtable.table-cache.enabled", true, "If enabled, once a tables info is fetched, it is cached.")
+	f.DurationVar(&cfg.TableCacheExpiration, "bigtable.table-cache.expiration", 30*time.Minute, "Duration to cache tables before checking again.")
 
 	cfg.GRPCClientConfig.RegisterFlags("bigtable", f)
 }

--- a/pkg/chunk/gcp/table_client.go
+++ b/pkg/chunk/gcp/table_client.go
@@ -56,12 +56,13 @@ func (c *tableClient) ListTables(ctx context.Context) ([]string, error) {
 			if err != nil {
 				return nil, errors.Wrap(err, "client.TableInfo")
 			}
-			c.tableInfo[table] = info
 		}
 
 		if hasColumnFamily(info.FamilyInfos) {
 			output = append(output, table)
+			continue
 		}
+		c.tableInfo[table] = info
 	}
 
 	return output, nil

--- a/pkg/chunk/gcp/table_client.go
+++ b/pkg/chunk/gcp/table_client.go
@@ -36,6 +36,7 @@ func NewTableClient(ctx context.Context, cfg Config) (chunk.TableClient, error) 
 	}, nil
 }
 
+// ListTables lists all of the correctly specified cortex tables in bigtable
 func (c *tableClient) ListTables(ctx context.Context) ([]string, error) {
 	tables, err := c.client.Tables(ctx)
 	if err != nil {


### PR DESCRIPTION
Continuation of #1648 which I closed because I didn't fully understand the issue I was trying to solve.

### Overview
* Bigtable has a global rate limit for admin operations across a project.
  * Each operation counts towards this limit which can very quickly choke the endpoint if multiple . table managers request info within a few minutes.
* To ensure a schema is properly constructed in bigtable, a call to bigtable is required per table.
* We utilize a static consistent schema config across all of our services and creating a one off schema for the table manager is not desirable
* Once created a cortex table in bigtable does not need to be updated unless it is changed externally

Based on these parameters, caching is the best solution because it dramatically reduces the number of admin operations to bigtable. Whereas, rate limiting will only spread them out. Currently there is rate-limiting/backoff in the bigtable grpc client library, which has not been able to alleviate the problem.