### PR TITLE
Make sure generated tokens are unique

### DIFF
--- a/pkg/ring/util.go
+++ b/pkg/ring/util.go
@@ -10,18 +10,18 @@ import (
 func GenerateTokens(numTokens int, takenTokens []uint32) []uint32 {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	added := make(map[uint32]bool)
+	used := make(map[uint32]bool)
 	for _, v := range takenTokens {
-		added[v] = true
+		used[v] = true
 	}
 
 	tokens := []uint32{}
 	for i := 0; i < numTokens; {
 		candidate := r.Uint32()
-		if added[candidate] {
+		if used[candidate] {
 			continue
 		}
-		added[candidate] = true
+		used[candidate] = true
 		tokens = append(tokens, candidate)
 		i++
 	}

--- a/pkg/ring/util.go
+++ b/pkg/ring/util.go
@@ -2,24 +2,22 @@ package ring
 
 import (
 	"math/rand"
-	"sort"
 	"time"
 )
 
 // GenerateTokens make numTokens unique random tokens, none of which clash
-// with takenTokens.  Assumes takenTokens is sorted.
+// with takenTokens.
 func GenerateTokens(numTokens int, takenTokens []uint32) []uint32 {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
 	added := make(map[uint32]bool)
+	for _, v := range takenTokens {
+		added[v] = true
+	}
+
 	tokens := []uint32{}
 	for i := 0; i < numTokens; {
 		candidate := r.Uint32()
-		j := sort.Search(len(takenTokens), func(i int) bool {
-			return takenTokens[i] >= candidate
-		})
-		if j < len(takenTokens) && takenTokens[j] == candidate {
-			continue
-		}
 		if added[candidate] {
 			continue
 		}

--- a/pkg/ring/util.go
+++ b/pkg/ring/util.go
@@ -6,10 +6,11 @@ import (
 	"time"
 )
 
-// GenerateTokens make numTokens random tokens, none of which clash
+// GenerateTokens make numTokens unique random tokens, none of which clash
 // with takenTokens.  Assumes takenTokens is sorted.
 func GenerateTokens(numTokens int, takenTokens []uint32) []uint32 {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	added := make(map[uint32]bool)
 	tokens := []uint32{}
 	for i := 0; i < numTokens; {
 		candidate := r.Uint32()
@@ -19,6 +20,10 @@ func GenerateTokens(numTokens int, takenTokens []uint32) []uint32 {
 		if j < len(takenTokens) && takenTokens[j] == candidate {
 			continue
 		}
+		if added[candidate] {
+			continue
+		}
+		added[candidate] = true
 		tokens = append(tokens, candidate)
 		i++
 	}

--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -17,3 +17,20 @@ func TestGenerateTokens(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateTokensIgnoresOldTokens(t *testing.T) {
+	first := GenerateTokens(1000000, nil)
+	second := GenerateTokens(1000000, first)
+
+	dups := make(map[uint32]bool)
+
+	for _, v := range first {
+		dups[v] = true
+	}
+
+	for _, v := range second {
+		if dups[v] {
+			t.Fatal("GenerateTokens returned old token")
+		}
+	}
+}

--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -1,0 +1,19 @@
+package ring
+
+import (
+	"testing"
+)
+
+func TestGenerateTokens(t *testing.T) {
+	tokens := GenerateTokens(1000000, nil)
+
+	dups := make(map[uint32]int)
+
+	for ix, v := range tokens {
+		if ox, ok := dups[v]; ok {
+			t.Errorf("Found duplicate token %d, tokens[%d]=%d, tokens[%d]=%d", v, ix, tokens[ix], ox, tokens[ox])
+		} else {
+			dups[v] = ix
+		}
+	}
+}


### PR DESCRIPTION
GenerateTokens could generate duplicate tokens previously, which kind of defeats the purpose I guess. This patch fixes it.

Signed-off-by: Peter Štibraný <peter.stibrany@grafana.com>