### PR TITLE
Small optimisations to Ingester.append()

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -152,13 +152,12 @@ type Ingester struct {
 	lifecycler *ring.Lifecycler
 	limits     *validation.Overrides
 
-	stopLock sync.RWMutex
-	stopped  bool
-	quit     chan struct{}
-	done     sync.WaitGroup
+	quit chan struct{}
+	done sync.WaitGroup
 
-	userStatesMtx sync.RWMutex
+	userStatesMtx sync.RWMutex // protects userStates and stopped
 	userStates    *userStates
+	stopped       bool // protected by userStatesMtx
 
 	// One queue per flush thread.  Fingerprint is used to
 	// pick a queue.
@@ -247,8 +246,8 @@ func (i *Ingester) Shutdown() {
 
 // StopIncomingRequests is called during the shutdown process.
 func (i *Ingester) StopIncomingRequests() {
-	i.stopLock.Lock()
-	defer i.stopLock.Unlock()
+	i.userStatesMtx.Lock()
+	defer i.userStatesMtx.Unlock()
 	i.stopped = true
 }
 
@@ -286,14 +285,11 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 func (i *Ingester) append(ctx context.Context, userID string, labels labelPairs, timestamp model.Time, value model.SampleValue, source client.WriteRequest_SourceEnum) error {
 	labels.removeBlanks()
 
-	i.stopLock.RLock()
-	defer i.stopLock.RUnlock()
+	i.userStatesMtx.RLock()
+	defer i.userStatesMtx.RUnlock()
 	if i.stopped {
 		return fmt.Errorf("ingester stopping")
 	}
-
-	i.userStatesMtx.RLock()
-	defer i.userStatesMtx.RUnlock()
 	state, fp, series, err := i.userStates.getOrCreateSeries(ctx, userID, labels)
 	if err != nil {
 		return err


### PR DESCRIPTION
* Protect two data structures with one lock - since `stopped` is only used in one place, that is already taking a lock, re-use `userStatesMtx` and skip the effort to check the `stopLock` and `defer Unlock` it.
* Combine two `defer`s into one - each `defer` involves some memory allocation and housekeeping so we can save half the effort.
