### PR TITLE
Jonathan Lange is no longer a maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,7 +1,6 @@
 Bryan Boreham, Weaveworks <bryan@weave.works> (@bboreham)
 Chris Marchbanks, independent <csmarchbanks@gmail.com> (@csmarchbanks)
 Cody Boggs, independent <strofcon@gmail.com> (@cboggs)
-Jonathan Lange, Weaveworks <jml@weave.works> (@jml)
 Julius Volz, independent <julius.volz@gmail.com> (@juliusv)
 Ken Haines, EA <khaines@ea.com> (@khaines)
 Tom Wilkie, Grafana Labs <tom.wilkie@gmail.com> (@tomwilkie)


### PR DESCRIPTION
I have discussed offline with @jml - he is no longer at Weaveworks and not planning further work on Cortex.
