### PR TITLE
fix integration tests for alternative image prefixes

### DIFF
--- a/integration-tests/common.sh
+++ b/integration-tests/common.sh
@@ -3,6 +3,7 @@
 TEST_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 
 IMAGE_TAG=${CIRCLE_TAG:-$($TEST_DIR/../tools/image-tag)}
+IMAGE_PREFIX="${IMAGE_PREFIX:-quay.io/cortexproject/}"
 
 COMMON_ARGS="-consul.hostname=consul:8500"
 STORAGE_ARGS="-config-yaml=/tests/schema1.yaml -dynamodb.url=dynamodb://u:p@dynamodb.cortex.:8000"

--- a/integration-tests/start-components.sh
+++ b/integration-tests/start-components.sh
@@ -9,4 +9,4 @@ docker network create cortex
 
 docker run $RUN_ARGS -d --name=consul --hostname=consul consul:0.9 agent -ui -server -client=0.0.0.0 -bootstrap
 docker run $RUN_ARGS -d --name=dynamodb --hostname=dynamodb amazon/dynamodb-local:1.11.477 -jar DynamoDBLocal.jar -inMemory -sharedDb
-docker run $RUN_ARGS -d --name=distributor --hostname=distributor -p 8080:80 quay.io/cortexproject/cortex:$IMAGE_TAG -target=distributor $COMMON_ARGS -distributor.replication-factor=1
+docker run $RUN_ARGS -d --name=distributor --hostname=distributor -p 8080:80 "$IMAGE_PREFIX"cortex:$IMAGE_TAG -target=distributor $COMMON_ARGS -distributor.replication-factor=1

--- a/integration-tests/test-flush.sh
+++ b/integration-tests/test-flush.sh
@@ -9,10 +9,10 @@ set -e
 # TODO: wait for DynamoDB ready
 sleep 5
 echo Start table-manager
-docker run $RUN_ARGS -d --name=tm --hostname=tm --restart=always quay.io/cortexproject/cortex:$IMAGE_TAG -target=table-manager $STORAGE_ARGS -table-manager.retention-period=168h -dynamodb.poll-interval=5s
+docker run $RUN_ARGS -d --name=tm --hostname=tm --restart=always "$IMAGE_PREFIX"cortex:$IMAGE_TAG -target=table-manager $STORAGE_ARGS -table-manager.retention-period=168h -dynamodb.poll-interval=5s
 
 echo Start ingester
-docker run $RUN_ARGS -d --name=i1 --hostname=i1 quay.io/cortexproject/cortex:$IMAGE_TAG -target=ingester $INGESTER_ARGS
+docker run $RUN_ARGS -d --name=i1 --hostname=i1 "$IMAGE_PREFIX"cortex:$IMAGE_TAG -target=ingester $INGESTER_ARGS
 
 sleep 5
 I1_ADDR=$(container_ip i1)

--- a/integration-tests/test-handover.sh
+++ b/integration-tests/test-handover.sh
@@ -9,7 +9,7 @@ set -e
 # Note we haven't created any tables in the DB yet - we aren't going to run long enough to flush anything
 
 echo Start first ingester
-docker run $RUN_ARGS -d --name=i1 --hostname=i1 quay.io/cortexproject/cortex:$IMAGE_TAG -target=ingester $INGESTER_ARGS -ingester.claim-on-rollout=true
+docker run $RUN_ARGS -d --name=i1 --hostname=i1 "$IMAGE_PREFIX"cortex:$IMAGE_TAG -target=ingester $INGESTER_ARGS -ingester.claim-on-rollout=true
 
 I1_ADDR=$(container_ip i1)
 wait_for "curl -s -f -m 3 $I1_ADDR/ready" "ingester ready"
@@ -23,7 +23,7 @@ wait_for "has_tokens_owned $DIST_ADDR" "distributor to see ingester in ring"
 docker run $RUN_ARGS --rm $AVALANCHE_IMAGE --metric-count=2 --label-count=2 --series-count=2 --remote-requests-count=1 --remote-url=http://distributor/api/prom/push
 
 echo Start second ingester, waiting for first
-docker run $RUN_ARGS -d --name=i2 --hostname=i2 quay.io/cortexproject/cortex:$IMAGE_TAG -target=ingester $INGESTER_ARGS -ingester.join-after=300s -ingester.claim-on-rollout=true
+docker run $RUN_ARGS -d --name=i2 --hostname=i2 "$IMAGE_PREFIX"cortex:$IMAGE_TAG -target=ingester $INGESTER_ARGS -ingester.join-after=300s -ingester.claim-on-rollout=true
 
 echo Stop first ingester so it should hand over
 docker stop i1


### PR DESCRIPTION
This PR makes the image prefix configurable for the integration test scripts. The default will remain `quay.io/cortexproject/`. However, if the `IMAGE_PREFIX` is set in the env, that will be used instead. This was causing issues for PRs from the grafana/cortex repo which uses a different image prefix in circleci.

Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>