### PR TITLE
Added tool to dump frontend querier memcache values

### DIFF
--- a/cmd/memcached-dump/main.go
+++ b/cmd/memcached-dump/main.go
@@ -37,7 +37,7 @@ func main() {
 	throttle := time.Tick(rate)
 
 	mc := memcache.New(address)
-	mc.Timeout = time.Second
+	mc.Timeout = 2 * time.Second
 	for _, key := range keys {
 		item, err := mc.Get(key)
 		if err != nil {

--- a/cmd/memcached-dump/main.go
+++ b/cmd/memcached-dump/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+
+	"github.com/bradfitz/gomemcache/memcache"
+)
+
+var (
+	address string
+	keyfile string
+	rate    time.Duration
+)
+
+func init() {
+	flag.StringVar(&address, "address", "localhost:11211", "Hostname to connect to and dump values.")
+	flag.StringVar(&keyfile, "keyfile", "keys.txt", "File to parse for keys.  Expected to be newline delimited.")
+	flag.DurationVar(&rate, "rate", 500*time.Millisecond, "Query rate.")
+}
+
+func main() {
+	flag.Parse()
+
+	keys, err := readLines(keyfile)
+	if err != nil {
+		log.Fatalf("Failed to readfile: %v", err)
+	}
+
+	throttle := time.Tick(rate)
+
+	mc := memcache.New(address)
+	mc.Timeout = time.Second
+	for _, key := range keys {
+		item, err := mc.Get(key)
+		if err != nil {
+			log.Fatalf("Failed to get key: %v", err)
+		}
+
+		req := &queryrange.CachedResponse{}
+		err = req.XXX_Unmarshal(item.Value)
+		if err != nil {
+			log.Fatalf("Failed to unmarshal from protobuf: %v", err)
+		}
+
+		bytes, err := json.Marshal(req)
+		if err != nil {
+			log.Fatalf("Failed to marshal to json: %v", err)
+		}
+
+		fmt.Println(string(bytes))
+
+		<-throttle
+	}
+}
+
+func readLines(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return lines, scanner.Err()
+}

--- a/cmd/memcached-dump/main.go
+++ b/cmd/memcached-dump/main.go
@@ -29,12 +29,13 @@ const (
 )
 
 var (
-	address  string
-	keyfile  string
-	rate     time.Duration
-	mode     string
-	keyOrder string
-	minGap   time.Duration
+	address        string
+	keyfile        string
+	rate           time.Duration
+	mode           string
+	keyOrder       string
+	minGap         time.Duration
+	querierAddress string
 )
 
 func init() {
@@ -44,6 +45,7 @@ func init() {
 	flag.StringVar(&mode, "mode", "dump", "Specify mode for memcached tool [dump, gaps, gaps-validate].")
 	flag.StringVar(&keyOrder, "key-order", "random", "Specify order to consider keys [forward, reverse, random].")
 	flag.DurationVar(&minGap, "min-gap", 0, "Minimum gap to report.")
+	flag.StringVar(&querierAddress, "querier-address", "localhost:8080", "In gaps-validate mode the querier to validate against.")
 }
 
 func main() {
@@ -61,6 +63,8 @@ func main() {
 		loop(keys, mc, rate, processDump)
 	} else if mode == modeGapSearch {
 		loop(keys, mc, rate, buildProcessGaps(minGap))
+	} else if mode == modeGapValidate {
+		loop(keys, mc, rate, buildValidateGaps(minGap, querierAddress))
 	}
 }
 

--- a/cmd/memcached-dump/main.go
+++ b/cmd/memcached-dump/main.go
@@ -126,14 +126,9 @@ func buildProcessGaps() processFunc {
 
 	return func(req *queryrange.CachedResponse, b []byte) {
 		hasGaps := false
-		fmt.Println("Considering key: ", req.Key)
 
 		for _, e := range req.Extents {
-			fmt.Println("Considering extent: ", e.TraceId)
-
 			for _, d := range e.Response.Data.Result {
-				fmt.Println("Consider sample stream: ", d.Labels)
-
 				if len(d.Samples) > 1 {
 					expectedInterval := d.Samples[1].TimestampMs - d.Samples[0].TimestampMs
 
@@ -142,6 +137,10 @@ func buildProcessGaps() processFunc {
 
 						if actualInterval != expectedInterval {
 							hasGaps = true
+							fmt.Println("Gap Found: ")
+							fmt.Println("extent: ", e.TraceId)
+							fmt.Println("stream: ", d.Labels)
+
 							fmt.Printf("Found gap from sample %d to %d.  Expected %d.  Found %d.\n", i, i+1, expectedInterval, actualInterval)
 						}
 					}
@@ -152,7 +151,7 @@ func buildProcessGaps() processFunc {
 		totalQueries++
 		if hasGaps {
 			totalGaps++
-			fmt.Printf("Gap Found: %d/%d\n", totalQueries, totalGaps)
+			fmt.Printf("Gaps/Total: %d/%d\n", totalGaps, totalQueries)
 			fmt.Println(string(b))
 		}
 	}

--- a/cmd/memcached-dump/main.go
+++ b/cmd/memcached-dump/main.go
@@ -56,6 +56,10 @@ func main() {
 	mc.Timeout = 2 * time.Second
 	for _, key := range keys {
 		item, err := mc.Get(key)
+		if err == memcache.ErrCacheMiss {
+			log.Printf("Failed to get key: %v", err)
+			continue
+		}
 		if err != nil {
 			log.Fatalf("Failed to get key: %v", err)
 		}
@@ -73,6 +77,8 @@ func main() {
 
 		if mode == modeDump {
 			fmt.Println(string(bytes))
+		} else if mode == modeGapSearch {
+			printGaps(req)
 		}
 
 		<-throttle
@@ -106,4 +112,12 @@ func readKeys(path string, order string) ([]string, error) {
 	}
 
 	return lines, nil
+}
+
+func printGaps(req *queryrange.CachedResponse) {
+	fmt.Println("Considering key: ", req.Key)
+
+	for _, e := range req.Extents {
+		fmt.Println("Considering extent: ", e.TraceId)
+	}
 }

--- a/cmd/memcached-dump/main.go
+++ b/cmd/memcached-dump/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"time"
 
@@ -14,22 +15,37 @@ import (
 	"github.com/bradfitz/gomemcache/memcache"
 )
 
+const (
+	modeDump      = "dump"
+	modeGapSearch = "gaps"
+)
+
+const (
+	keyOrderNormal  = "forward"
+	keyOrderReverse = "reverse"
+	keyOrderRandom  = "random"
+)
+
 var (
-	address string
-	keyfile string
-	rate    time.Duration
+	address  string
+	keyfile  string
+	rate     time.Duration
+	mode     string
+	keyOrder string
 )
 
 func init() {
 	flag.StringVar(&address, "address", "localhost:11211", "Hostname to connect to and dump values.")
 	flag.StringVar(&keyfile, "keyfile", "keys.txt", "File to parse for keys.  Expected to be newline delimited.")
 	flag.DurationVar(&rate, "rate", 500*time.Millisecond, "Query rate.")
+	flag.StringVar(&mode, "mode", "dump", "Specify mode for memcached tool [dump, gaps].")
+	flag.StringVar(&keyOrder, "key-order", "random", "Specify order to consider keys [forward, reverse, random].")
 }
 
 func main() {
 	flag.Parse()
 
-	keys, err := readLines(keyfile)
+	keys, err := readKeys(keyfile, keyOrder)
 	if err != nil {
 		log.Fatalf("Failed to readfile: %v", err)
 	}
@@ -55,13 +71,15 @@ func main() {
 			log.Fatalf("Failed to marshal to json: %v", err)
 		}
 
-		fmt.Println(string(bytes))
+		if mode == modeDump {
+			fmt.Println(string(bytes))
+		}
 
 		<-throttle
 	}
 }
 
-func readLines(path string) ([]string, error) {
+func readKeys(path string, order string) ([]string, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -73,5 +91,19 @@ func readLines(path string) ([]string, error) {
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}
-	return lines, scanner.Err()
+
+	if err != nil {
+		return nil, err
+	}
+
+	if order == keyOrderRandom {
+		rand.Seed(time.Now().UnixNano())
+		rand.Shuffle(len(lines), func(i, j int) { lines[i], lines[j] = lines[j], lines[i] })
+	} else if order == keyOrderReverse {
+		for left, right := 0, len(lines)-1; left < right; left, right = left+1, right-1 {
+			lines[left], lines[right] = lines[right], lines[left]
+		}
+	}
+
+	return lines, nil
 }

--- a/cmd/memcached-dump/processDump.go
+++ b/cmd/memcached-dump/processDump.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+)
+
+func processDump(req *queryrange.CachedResponse, b []byte) {
+	fmt.Println(string(b))
+}

--- a/cmd/memcached-dump/processGaps.go
+++ b/cmd/memcached-dump/processGaps.go
@@ -14,11 +14,16 @@ func buildProcessGaps(minGap time.Duration) processFunc {
 	return func(req *queryrange.CachedResponse, b []byte) {
 		hasGaps := false
 
+		_, _, expectedIntervalMs, _, err := parseCacheKey(req.Key)
+		if err != nil {
+			fmt.Println("Error parsing cache key: ", err)
+			return
+		}
+
 		for _, e := range req.Extents {
 			for _, d := range e.Response.Data.Result {
 				if len(d.Samples) > 1 {
 
-					expectedIntervalMs := d.Samples[1].TimestampMs - d.Samples[0].TimestampMs
 					for i := 0; i < len(d.Samples)-2; i++ {
 						actualIntervalMs := d.Samples[i+1].TimestampMs - d.Samples[i].TimestampMs
 
@@ -38,7 +43,7 @@ func buildProcessGaps(minGap time.Duration) processFunc {
 		totalQueries++
 		if hasGaps {
 			totalGaps++
-			fmt.Printf("Gaps/Total: %d/%d\n", totalGaps, totalQueries)
+			fmt.Printf("Gaps/Total: %d/%d (%f)\n", totalGaps, totalQueries, float64(totalGaps)/float64(totalQueries))
 			fmt.Println(string(b))
 		}
 	}

--- a/cmd/memcached-dump/processGaps.go
+++ b/cmd/memcached-dump/processGaps.go
@@ -22,19 +22,16 @@ func buildProcessGaps(minGap time.Duration) processFunc {
 
 		for _, e := range req.Extents {
 			for _, d := range e.Response.Data.Result {
-				if len(d.Samples) > 1 {
+				for i := 0; i < len(d.Samples)-1; i++ {
+					actualIntervalMs := d.Samples[i+1].TimestampMs - d.Samples[i].TimestampMs
 
-					for i := 0; i < len(d.Samples)-2; i++ {
-						actualIntervalMs := d.Samples[i+1].TimestampMs - d.Samples[i].TimestampMs
+					if actualIntervalMs > expectedIntervalMs && time.Duration(actualIntervalMs)*time.Millisecond > minGap {
+						hasGaps = true
+						fmt.Println("Gap Found: ")
+						fmt.Println("extent: ", e.TraceId)
+						fmt.Println("stream: ", d.Labels)
 
-						if actualIntervalMs > expectedIntervalMs && time.Duration(actualIntervalMs)*time.Millisecond > minGap {
-							hasGaps = true
-							fmt.Println("Gap Found: ")
-							fmt.Println("extent: ", e.TraceId)
-							fmt.Println("stream: ", d.Labels)
-
-							fmt.Printf("Found gap from sample %d to %d.  Expected %d.  Found %d.\n", i, i+1, expectedIntervalMs, actualIntervalMs)
-						}
+						fmt.Printf("Found gap from sample %d to %d.  Expected %d.  Found %d.\n", i, i+1, expectedIntervalMs, actualIntervalMs)
 					}
 				}
 			}

--- a/cmd/memcached-dump/processGaps.go
+++ b/cmd/memcached-dump/processGaps.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+)
+
+func buildProcessGaps(minGap time.Duration) processFunc {
+	totalQueries := 0
+	totalGaps := 0
+
+	return func(req *queryrange.CachedResponse, b []byte) {
+		hasGaps := false
+
+		for _, e := range req.Extents {
+			for _, d := range e.Response.Data.Result {
+				if len(d.Samples) > 1 {
+
+					expectedIntervalMs := d.Samples[1].TimestampMs - d.Samples[0].TimestampMs
+					for i := 0; i < len(d.Samples)-2; i++ {
+						actualIntervalMs := d.Samples[i+1].TimestampMs - d.Samples[i].TimestampMs
+
+						if actualIntervalMs > expectedIntervalMs && time.Duration(actualIntervalMs)*time.Millisecond > minGap {
+							hasGaps = true
+							fmt.Println("Gap Found: ")
+							fmt.Println("extent: ", e.TraceId)
+							fmt.Println("stream: ", d.Labels)
+
+							fmt.Printf("Found gap from sample %d to %d.  Expected %d.  Found %d.\n", i, i+1, expectedIntervalMs, actualIntervalMs)
+						}
+					}
+				}
+			}
+		}
+
+		totalQueries++
+		if hasGaps {
+			totalGaps++
+			fmt.Printf("Gaps/Total: %d/%d\n", totalGaps, totalQueries)
+			fmt.Println(string(b))
+		}
+	}
+}

--- a/cmd/memcached-dump/readme.md
+++ b/cmd/memcached-dump/readme.md
@@ -10,5 +10,6 @@ This cli program dumps all values from the a Cortex frontend memcached server.  
   - `kubectl port-forward <memcached-pod> 11211:11211`
 - Run memcdump
   - `memcdump --servers=localhost > keys.txt`
+  - Note that this pulls keys in slab order from smallest to largest.  This means the values for the keys at the start of the file are very small and the values for the keys at the end of the file are very large.
 - Run memcached-dump to start dumping json versions of CachedResponses to console.  By default it will have a query rate of 2/sec.
   - `./memcached-dump > values.txt`

--- a/cmd/memcached-dump/readme.md
+++ b/cmd/memcached-dump/readme.md
@@ -13,3 +13,17 @@ This cli program dumps all values from the a Cortex frontend memcached server.  
   - Note that this pulls keys in slab order from smallest to largest.  This means the values for the keys at the start of the file are very small and the values for the keys at the end of the file are very large.
 - Run memcached-dump to start dumping json versions of CachedResponses to console.  By default it will have a query rate of 2/sec.
   - `./memcached-dump > values.txt`
+
+### gap analysis
+
+Search for and print found gaps:
+
+```
+./main -mode=gaps -min-gap=30m
+```
+
+After finding a gap, kill the memcached key, requery and determine if there's a difference.
+
+```
+./main -mode=gaps-validate
+```

--- a/cmd/memcached-dump/readme.md
+++ b/cmd/memcached-dump/readme.md
@@ -16,7 +16,7 @@ This cli program dumps all values from the a Cortex frontend memcached server.  
 
 ### gap analysis
 
-Search for and print found gaps:
+Search for and print found gaps.  Streams are considered to have gaps when the difference between any two data points is greater than the requested step.
 
 ```
 ./main -mode=gaps -min-gap=30m

--- a/cmd/memcached-dump/readme.md
+++ b/cmd/memcached-dump/readme.md
@@ -22,7 +22,7 @@ Search for and print found gaps:
 ./main -mode=gaps -min-gap=30m
 ```
 
-After finding a gap, kill the memcached key, requery and determine if there's a difference.
+After finding a gap, re-execute the query directly on a querier and look for differences.
 
 ```
 ./main -mode=gaps-validate

--- a/cmd/memcached-dump/readme.md
+++ b/cmd/memcached-dump/readme.md
@@ -1,0 +1,14 @@
+# memcached-dump
+
+This cli program dumps all values from the a Cortex frontend memcached server.  It requires as input an address, a list of keys and a duration.
+
+## to use
+
+- Install memcdump
+  - `apt-get install libmemcached-tools`
+- Port forward to a pod
+  - `kubectl port-forward <memcached-pod> 11211:11211`
+- Run memcdump
+  - `memcdump --servers=localhost > keys.txt`
+- Run memcached-dump to start dumping json versions of CachedResponses to console.  By default it will have a query rate of 2/sec.
+  - `./memcached-dump > values.txt`

--- a/cmd/memcached-dump/validateGaps.go
+++ b/cmd/memcached-dump/validateGaps.go
@@ -57,7 +57,7 @@ func buildValidateGaps(minGap time.Duration, querierAddress string) processFunc 
 		totalQueries++
 		if hasGaps {
 			cached := e.Response
-			uncached, err := requery(cache, e.Start, e.End, querierAddress)
+			uncached, err := requery(cache, e.Start/1000, e.End/1000, querierAddress)
 
 			if err != nil {
 				fmt.Println(err)
@@ -67,7 +67,6 @@ func buildValidateGaps(minGap time.Duration, querierAddress string) processFunc 
 			jsonCached, _ := json.Marshal(cached)
 			jsonUncached, _ := json.Marshal(uncached)
 
-			// if reflect.DeepEqual(cached, uncached) {
 			if string(jsonCached) == string(jsonUncached) {
 				fakeGaps++
 			} else {
@@ -102,7 +101,7 @@ func requery(cache *queryrange.CachedResponse, startSeconds int64, endSeconds in
 
 	u.RawQuery = q.Encode()
 
-	fmt.Println(query)
+	fmt.Println("Requery: ", u.String())
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", u.String(), nil)

--- a/cmd/memcached-dump/validateGaps.go
+++ b/cmd/memcached-dump/validateGaps.go
@@ -13,8 +13,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 )
 
-const secondsPerDay = 86400
-
 func buildValidateGaps(minGap time.Duration, querierAddress string) processFunc {
 	totalQueries := 0
 	totalGaps := 0
@@ -23,7 +21,7 @@ func buildValidateGaps(minGap time.Duration, querierAddress string) processFunc 
 	return func(cache *queryrange.CachedResponse, b []byte) {
 		hasGaps := false
 
-		userId, _, expectedIntervalMs, _, err := parseCacheKey(cache.Key)
+		userID, _, expectedIntervalMs, _, err := parseCacheKey(cache.Key)
 		if err != nil {
 			fmt.Println("Error parsing cache key: ", err)
 			return
@@ -63,7 +61,7 @@ func buildValidateGaps(minGap time.Duration, querierAddress string) processFunc 
 					totalGaps++
 
 					fmt.Println("Gap Found: ")
-					fmt.Println("User        : ", userId)
+					fmt.Println("User        : ", userID)
 					fmt.Println("Trace       : ", e.TraceId)
 					fmt.Println("requery url : ", url)
 					fmt.Println("cached: ")

--- a/cmd/memcached-dump/validateGaps.go
+++ b/cmd/memcached-dump/validateGaps.go
@@ -45,7 +45,7 @@ func buildValidateGaps(minGap time.Duration, querierAddress string) processFunc 
 			totalQueries++
 			if hasGaps {
 				cached := e.Response
-				uncached, url, err := requery(cache, e.Start/1000, e.End/1000, querierAddress)
+				uncached, url, err := requery(cache, e.Start/1000, e.End/1000, e.TraceId, querierAddress)
 
 				if err != nil {
 					fmt.Println(err)
@@ -76,7 +76,7 @@ func buildValidateGaps(minGap time.Duration, querierAddress string) processFunc 
 	}
 }
 
-func requery(cache *queryrange.CachedResponse, startSeconds int64, endSeconds int64, address string) (*queryrange.APIResponse, string, error) {
+func requery(cache *queryrange.CachedResponse, startSeconds int64, endSeconds int64, traceid string, address string) (*queryrange.APIResponse, string, error) {
 	userID, query, step, _, err := parseCacheKey(cache.Key)
 	if err != nil {
 		return nil, "", err
@@ -99,6 +99,7 @@ func requery(cache *queryrange.CachedResponse, startSeconds int64, endSeconds in
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", u.String(), nil)
 	req.Header.Add("X-Scope-OrgID", userID)
+	req.Header.Add("jaeger-debug-id", traceid)
 
 	resp, err := client.Do(req)
 

--- a/cmd/memcached-dump/validateGaps.go
+++ b/cmd/memcached-dump/validateGaps.go
@@ -2,20 +2,25 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
-	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 )
 
-func buildValidateGaps(minGap time.Duration, mc *memcache.Client) processFunc {
+const secondsPerDay = 86400
+
+func buildValidateGaps(minGap time.Duration, querierAddress string) processFunc {
 	totalQueries := 0
 	totalGaps := 0
 
-	return func(req *queryrange.CachedResponse, b []byte) {
+	return func(cache *queryrange.CachedResponse, b []byte) {
 		hasGaps := false
 
-		for _, e := range req.Extents {
+		for _, e := range cache.Extents {
 			for _, d := range e.Response.Data.Result {
 				if len(d.Samples) > 1 {
 
@@ -33,11 +38,65 @@ func buildValidateGaps(minGap time.Duration, mc *memcache.Client) processFunc {
 
 		totalQueries++
 		if hasGaps {
-			// kill the old key and requery to see if the same results come back
+
+			err := requery(cache, querierAddress)
+
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
 
 			totalGaps++
 			fmt.Printf("Gaps/Total: %d/%d\n", totalGaps, totalQueries)
-			fmt.Println(string(b))
+			//fmt.Println(string(b))
 		}
 	}
+}
+
+func requery(cache *queryrange.CachedResponse, address string) error {
+	// build a query string from the cache key
+	parts := strings.Split(cache.Key, ":")
+
+	if len(parts) != 4 {
+		return fmt.Errorf("unable to parse key %s", cache.Key)
+	}
+
+	userID := parts[0]
+	query := parts[1]
+	step := parts[2]
+
+	day, err := strconv.ParseInt(parts[3], 10, 64)
+	if err != nil {
+		return fmt.Errorf("unable to parse day %s", parts[3])
+	}
+
+	u := url.URL{}
+
+	u.Scheme = "http"
+	u.Host = address
+	u.Path = "/api/prom/api/v1/query_range"
+
+	q := u.Query()
+	q.Set("query", query)
+	q.Set("start", fmt.Sprint(day*secondsPerDay))
+	q.Set("end", fmt.Sprint((day+1)*secondsPerDay))
+	q.Set("step", step)
+
+	u.RawQuery = q.Encode()
+
+	fmt.Println(query)
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	req.Header.Add("X-Scope-OrgID", userID)
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(resp)
+
+	return nil
 }

--- a/cmd/memcached-dump/validateGaps.go
+++ b/cmd/memcached-dump/validateGaps.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -28,6 +27,7 @@ func buildValidateGaps(minGap time.Duration, querierAddress string) processFunc 
 		if len(cache.Extents) != 1 {
 			fmt.Println("Support multiple extents.  Found ", len(cache.Extents))
 			totalSkips++
+			return
 		}
 
 		e := cache.Extents[0]
@@ -64,18 +64,20 @@ func buildValidateGaps(minGap time.Duration, querierAddress string) processFunc 
 				return
 			}
 
-			if !reflect.DeepEqual(cached, uncached) {
+			jsonCached, _ := json.Marshal(cached)
+			jsonUncached, _ := json.Marshal(uncached)
+
+			// if reflect.DeepEqual(cached, uncached) {
+			if string(jsonCached) == string(jsonUncached) {
+				fakeGaps++
+			} else {
 				totalGaps++
 
-				jsonCached, _ := json.Marshal(cached)
-				jsonUncached, _ := json.Marshal(uncached)
 				fmt.Println(string(jsonCached))
 				fmt.Println(string(jsonUncached))
-			} else {
-				fakeGaps++
 			}
 
-			fmt.Printf("Skips/Fake/Real/Total: %d/%d/%d/%d/%d (%f) \n", totalSkips, fakeGaps, totalGaps, totalQueries, float64(totalGaps)/float64(totalQueries))
+			fmt.Printf("Skips/Fake/Real/Total: %d/%d/%d/%d (%f) \n", totalSkips, fakeGaps, totalGaps, totalQueries, float64(totalGaps)/float64(totalQueries))
 		}
 	}
 }

--- a/cmd/memcached-dump/validateGaps.go
+++ b/cmd/memcached-dump/validateGaps.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+)
+
+func buildValidateGaps(minGap time.Duration, mc *memcache.Client) processFunc {
+	totalQueries := 0
+	totalGaps := 0
+
+	return func(req *queryrange.CachedResponse, b []byte) {
+		hasGaps := false
+
+		for _, e := range req.Extents {
+			for _, d := range e.Response.Data.Result {
+				if len(d.Samples) > 1 {
+
+					expectedIntervalMs := d.Samples[1].TimestampMs - d.Samples[0].TimestampMs
+					for i := 0; i < len(d.Samples)-2; i++ {
+						actualIntervalMs := d.Samples[i+1].TimestampMs - d.Samples[i].TimestampMs
+
+						if actualIntervalMs > expectedIntervalMs && time.Duration(actualIntervalMs)*time.Millisecond > minGap {
+							hasGaps = true
+						}
+					}
+				}
+			}
+		}
+
+		totalQueries++
+		if hasGaps {
+			// kill the old key and requery to see if the same results come back
+
+			totalGaps++
+			fmt.Printf("Gaps/Total: %d/%d\n", totalGaps, totalQueries)
+			fmt.Println(string(b))
+		}
+	}
+}

--- a/cmd/memcached-dump/validateGaps.go
+++ b/cmd/memcached-dump/validateGaps.go
@@ -43,27 +43,28 @@ func buildValidateGaps(minGap time.Duration, querierAddress string) processFunc 
 		totalQueries++
 		if hasGaps {
 			if len(cache.Extents) > 1 {
-				fmt.Println("Oh no!  More than 1 extent!")
-				return
-			}
-
-			cached := cache.Extents[0].Response
-			uncached, err := requery(cache, querierAddress)
-
-			if err != nil {
-				fmt.Println(err)
-				return
-			}
-
-			if !reflect.DeepEqual(cached, uncached) {
+				fmt.Println("Oh no!  More than 1 extent!  Assume Real Gap.")
 				totalGaps++
-
-				jsonCached, _ := json.Marshal(cached)
-				jsonUncached, _ := json.Marshal(uncached)
-				fmt.Println(string(jsonCached))
-				fmt.Println(string(jsonUncached))
 			} else {
-				fakeGaps++
+
+				cached := cache.Extents[0].Response
+				uncached, err := requery(cache, querierAddress)
+
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
+
+				if !reflect.DeepEqual(cached, uncached) {
+					totalGaps++
+
+					jsonCached, _ := json.Marshal(cached)
+					jsonUncached, _ := json.Marshal(uncached)
+					fmt.Println(string(jsonCached))
+					fmt.Println(string(jsonUncached))
+				} else {
+					fakeGaps++
+				}
 			}
 
 			fmt.Printf("Fake/Real/Total: %d/%d/%d (%f) \n", fakeGaps, totalGaps, totalQueries, float64(totalGaps)/float64(totalQueries))

--- a/cmd/memcached-dump/validateGaps.go
+++ b/cmd/memcached-dump/validateGaps.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -96,7 +98,21 @@ func requery(cache *queryrange.CachedResponse, address string) error {
 		return err
 	}
 
-	fmt.Println(resp)
+	jsonBytes, err := ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		return err
+	}
+
+	var value map[string]interface{}
+
+	err = json.Unmarshal(jsonBytes, &value)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(value)
 
 	return nil
 }


### PR DESCRIPTION
This tool will dump memcached entries given a list of keys.  Steps to grab keys included in readme.md.

Currently it only supports the frontend querier cache, but could easily be extended to include different caches.