### PR TITLE
fix k8s nginx config

### DIFF
--- a/k8s/nginx-config.yaml
+++ b/k8s/nginx-config.yaml
@@ -32,10 +32,10 @@ data:
         }
 
         location = /ring {
-          proxy_pass      http://distributor.cortex.svc.cluster.local$request_uri;
+          proxy_pass      http://distributor.default.svc.cluster.local$request_uri;
         }
         location = /all_user_stats {
-          proxy_pass      http://distributor.cortex.svc.cluster.local$request_uri;
+          proxy_pass      http://distributor.default.svc.cluster.local$request_uri;
         }
 
         location ~ /api/prom/.* {


### PR DESCRIPTION
the proxied destinations for the requests `/ring` and `/all_user_stats` were 502-ing.

With this patch, they are working again. 

Since it's my first contribution, feel free to tell me if I'm doing something wrong ;) 

Cheers

Signed-off-by: Guillaume Winter <gwinter@heroku.com>