### PR TITLE
fix routing change for alertmanager

### DIFF
--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -144,7 +144,7 @@ func New(cfg *Config) (*Alertmanager, error) {
 
 	webReload := make(chan chan error)
 	ui.Register(am.router.WithPrefix(am.cfg.ExternalURL.Path), webReload, log.With(am.logger, "component", "ui"))
-	am.api.Register(am.router, am.cfg.ExternalURL.Path)
+	am.api.Register(am.router.WithPrefix(am.cfg.ExternalURL.Path), "")
 
 	go func() {
 		for {


### PR DESCRIPTION
#1597 ended up breaking the routing in the alertmanager. This because the route prefix provided in the function is only meant to be . added to the `v2` alertmanager api. In the cortex use case both `v1` and `v2` need to be prefixed with the external url. This pr fixes the issue.

Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>