### PR TITLE
add tags in manifests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,21 +51,6 @@ To run the test suite:
 make test
 ```
 
-## Playing in `minikube`
-
-First, start `minikube`.
-
-Then run Cortex in minikube:
-```
-kubectl apply -f ./k8s
-```
-
-Cortex will sit behind an nginx instance exposed on port 30080.  A job is deployed to scrape itself.  Try it:
-
-http://192.168.99.100:30080/api/prom/api/v1/query?query=up
-
-If that doesn't work, your Minikube might be using a different ip address. Check with `minikube status`.
-
 ### Dependency management
 
 We uses [Go modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) to manage dependencies on external packages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,21 +55,10 @@ make test
 
 First, start `minikube`.
 
-You may need to load the Docker images into your minikube environment. There is
-a convenient rule in the Makefile to do this:
-
-```
-make prime-minikube
-```
-
 Then run Cortex in minikube:
 ```
 kubectl apply -f ./k8s
 ```
-
-(these manifests use `latest` tags, i.e. this will work if you have
-just built the images and they are available on the node(s) in your
-Kubernetes cluster)
 
 Cortex will sit behind an nginx instance exposed on port 30080.  A job is deployed to scrape itself.  Try it:
 

--- a/Makefile
+++ b/Makefile
@@ -182,17 +182,6 @@ load-images:
 		fi \
 	done
 
-# Loads the built Docker images into the minikube environment, and tags them with
-# "latest" so the k8s manifests shipped with this code work.
-prime-minikube: save-images
-	eval $$(minikube docker-env) ; \
-	for image_name in $(IMAGE_NAMES); do \
-		if ! echo $$image_name | grep build; then \
-			docker load -i docker-images/$$(echo $$image_name | tr "/" _):$(IMAGE_TAG); \
-			docker tag $$image_name:$(IMAGE_TAG) $$image_name:latest ; \
-		fi \
-	done
-
 # Generates the config file documentation.
 doc: clean-doc
 	go run ./tools/doc-generator ./docs/configuration/config-file-reference.template >> ./docs/configuration/config-file-reference.md

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,7 +42,7 @@ Maintaining the release branches for older minor releases happens on a best effo
 
 ### Prepare your release
 
-Put the new version number into the file VERSION.
+Put the new version number into the file `VERSION` and Kubernetes manifests located at `k8s/`.
 
 For a patch release, work in the branch of the minor release you want to patch.
 

--- a/k8s/alertmanager-dep.yaml
+++ b/k8s/alertmanager-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        image: quay.io/cortexproject/cortex
+        image: quay.io/cortexproject/cortex:v0.6.0
         imagePullPolicy: IfNotPresent
         args:
         - -target=alertmanager

--- a/k8s/alertmanager-dep.yaml
+++ b/k8s/alertmanager-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        image: quay.io/cortexproject/cortex:v0.6.0
+        image: quay.io/cortexproject/cortex:v0.6.1
         imagePullPolicy: IfNotPresent
         args:
         - -target=alertmanager

--- a/k8s/configs-dep.yaml
+++ b/k8s/configs-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: configs
-        image: quay.io/cortexproject/cortex:v0.6.0
+        image: quay.io/cortexproject/cortex:v0.6.1
         imagePullPolicy: IfNotPresent
         args:
         - -target=configs

--- a/k8s/configs-dep.yaml
+++ b/k8s/configs-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: configs
-        image: quay.io/cortexproject/cortex
+        image: quay.io/cortexproject/cortex:v0.6.0
         imagePullPolicy: IfNotPresent
         args:
         - -target=configs

--- a/k8s/distributor-dep.yaml
+++ b/k8s/distributor-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: distributor
-        image: quay.io/cortexproject/cortex:v0.6.0
+        image: quay.io/cortexproject/cortex:v0.6.1
         imagePullPolicy: IfNotPresent
         args:
         - -target=distributor

--- a/k8s/distributor-dep.yaml
+++ b/k8s/distributor-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: distributor
-        image: quay.io/cortexproject/cortex
+        image: quay.io/cortexproject/cortex:v0.6.0
         imagePullPolicy: IfNotPresent
         args:
         - -target=distributor

--- a/k8s/ingester-dep.yaml
+++ b/k8s/ingester-dep.yaml
@@ -37,7 +37,7 @@ spec:
 
       containers:
       - name: ingester
-        image: quay.io/cortexproject/cortex
+        image: quay.io/cortexproject/cortex:v0.6.0
         imagePullPolicy: IfNotPresent
         args:
         - -target=ingester

--- a/k8s/ingester-dep.yaml
+++ b/k8s/ingester-dep.yaml
@@ -37,7 +37,7 @@ spec:
 
       containers:
       - name: ingester
-        image: quay.io/cortexproject/cortex:v0.6.0
+        image: quay.io/cortexproject/cortex:v0.6.1
         imagePullPolicy: IfNotPresent
         args:
         - -target=ingester

--- a/k8s/querier-dep.yaml
+++ b/k8s/querier-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: querier
-        image: quay.io/cortexproject/cortex
+        image: quay.io/cortexproject/cortex:v0.6.0
         imagePullPolicy: IfNotPresent
         args:
         - -target=querier

--- a/k8s/querier-dep.yaml
+++ b/k8s/querier-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: querier
-        image: quay.io/cortexproject/cortex:v0.6.0
+        image: quay.io/cortexproject/cortex:v0.6.1
         imagePullPolicy: IfNotPresent
         args:
         - -target=querier

--- a/k8s/query-frontend-dep.yaml
+++ b/k8s/query-frontend-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: query-frontend
-        image: quay.io/cortexproject/cortex:v0.6.0
+        image: quay.io/cortexproject/cortex:v0.6.1
         imagePullPolicy: IfNotPresent
         args:
         - -target=query-frontend

--- a/k8s/query-frontend-dep.yaml
+++ b/k8s/query-frontend-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: query-frontend
-        image: quay.io/cortexproject/cortex
+        image: quay.io/cortexproject/cortex:v0.6.0
         imagePullPolicy: IfNotPresent
         args:
         - -target=query-frontend

--- a/k8s/ruler-dep.yaml
+++ b/k8s/ruler-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: ruler
-        image: quay.io/cortexproject/cortex:v0.6.0
+        image: quay.io/cortexproject/cortex:v0.6.1
         imagePullPolicy: IfNotPresent
         args:
         - -target=ruler

--- a/k8s/ruler-dep.yaml
+++ b/k8s/ruler-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: ruler
-        image: quay.io/cortexproject/cortex
+        image: quay.io/cortexproject/cortex:v0.6.0
         imagePullPolicy: IfNotPresent
         args:
         - -target=ruler

--- a/k8s/table-manager-dep.yaml
+++ b/k8s/table-manager-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: table-manager
-        image: quay.io/cortexproject/cortex
+        image: quay.io/cortexproject/cortex:v0.6.0
         imagePullPolicy: IfNotPresent
         args:
         - -target=table-manager

--- a/k8s/table-manager-dep.yaml
+++ b/k8s/table-manager-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: table-manager
-        image: quay.io/cortexproject/cortex:v0.6.0
+        image: quay.io/cortexproject/cortex:v0.6.1
         imagePullPolicy: IfNotPresent
         args:
         - -target=table-manager


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

The manifests in /k8s don't have tag in the cortex image, and in quay.io/ortexproject/project there is no tag `latest`. Here add the tag v0.2.0 so users can deploy directly.