### PR TITLE
Make sure the HA tracker only handles valid keys

### DIFF
--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -150,6 +150,13 @@ func (c *haTracker) loop(ctx context.Context) {
 		c.electedLock.Lock()
 		defer c.electedLock.Unlock()
 		chunks := strings.SplitN(key, "/", 2)
+
+		// The prefix has already been stripped, so a valid key would look like cluster/replica,
+		// and a key without a / such as `ring` would be invalid.
+		if len(chunks) != 2 {
+			return true
+		}
+
 		if replica.Replica != c.elected[key].Replica {
 			electedReplicaChanges.WithLabelValues(chunks[0], chunks[1]).Inc()
 		}


### PR DESCRIPTION
If the ring and the HA tracker share the same prefix then we will end up
handling invalid keys.

Fixes #1652 and #1628

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>