### PR TITLE
Always push build-image

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -17,8 +17,6 @@ RUN GO111MODULE=on go get -tags netgo \
 		github.com/gogo/protobuf/protoc-gen-gogoslick@v1.2.1 \
 		github.com/gogo/protobuf/gogoproto@v1.2.1 && \
 	rm -rf /go/pkg /go/src
-RUN curl -Ls https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -o $GOPATH/bin/dep && \
-  chmod +x $GOPATH/bin/dep
 COPY build.sh /
 ENV GOCACHE=/go/cache
 ENTRYPOINT ["/build.sh"]

--- a/push-images
+++ b/push-images
@@ -45,8 +45,5 @@ push_image() {
 }
 
 for image in ${IMAGES}; do
-    if [[ "$image" == *"build"* ]]; then
-        continue
-    fi
     push_image "${image}"
 done


### PR DESCRIPTION
Also, remove dep as we don't need it. I've verified that cortex still
builds after removing dep.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>