### PR TITLE
Clarify HA options for prometheus config

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -144,7 +144,7 @@ HA tracking has two of it's own flags:
 - `distributor.ha-tracker.cluster`
    Prometheus label to look for in samples to identify a Prometheus HA cluster. (default "cluster")
 - `distributor.ha-tracker.replica`
-   Prometheus label to look for in samples to identify a Prometheus HA replica. (default "__replica__")
+   Prometheus label to look for in samples to identify a Prometheus HA replica. (default "\_\_replica\_\_")
 
 It's reasonable to assume people probably already have a `cluster` label, or something similar. If not, they should add one along with `__replica__` via external labels in their Prometheus config. If you stick to these default values your Prometheus config could look like this (`POD_NAME` is an environment variable which must be set by you):
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -146,8 +146,14 @@ HA tracking has two of it's own flags:
 - `distributor.ha-tracker.replica`
    Prometheus label to look for in samples to identify a Prometheus HA replica. (default "__replica__")
 
-It's reasonable to assume people probably already have a `cluster` label, or something similar. If not, they should add one along with `__replica__`
-via external labels in their Prometheus config.
+It's reasonable to assume people probably already have a `cluster` label, or something similar. If not, they should add one along with `__replica__` via external labels in their Prometheus config. If you stick to these default values your Prometheus config could look like this (`POD_NAME` is an environment variable which must be set by you):
+
+```yaml
+global:
+  external_labels:
+    cluster: clustername
+    __replica__: $POD_NAME
+```
 
 HA Tracking looks for the two labels (which can be overwritten per user)
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -144,7 +144,7 @@ HA tracking has two of it's own flags:
 - `distributor.ha-tracker.cluster`
    Prometheus label to look for in samples to identify a Prometheus HA cluster. (default "cluster")
 - `distributor.ha-tracker.replica`
-   Prometheus label to look for in samples to identify a Prometheus HA replica. (default "\_\_replica\_\_")
+   Prometheus label to look for in samples to identify a Prometheus HA replica. (default "`__replica__`")
 
 It's reasonable to assume people probably already have a `cluster` label, or something similar. If not, they should add one along with `__replica__` via external labels in their Prometheus config. If you stick to these default values your Prometheus config could look like this (`POD_NAME` is an environment variable which must be set by you):
 


### PR DESCRIPTION
Currently the documentation implies that we should specify "replica" for `distributor.ha-tracker.replica` but use the  `__replica__` name as external label in your prometheus config. That is because the defaults in the documentation currently do not represent the actual defaults, see: https://github.com/cortexproject/cortex/blob/3c4f80441910cb4b5d9f94f939e257cf365d8e84/pkg/util/validation/limits.go#L51-L52

Signed-off-by: unknown <weeco91@gmail.com>