### PR TITLE
Use human-readable names for chunk encodings

### DIFF
--- a/pkg/chunk/encoding/factory.go
+++ b/pkg/chunk/encoding/factory.go
@@ -28,6 +28,9 @@ func (Config) RegisterFlags(f *flag.FlagSet) {
 
 // String implements flag.Value.
 func (e Encoding) String() string {
+	if known, found := encodings[e]; found {
+		return known.Name
+	}
 	return fmt.Sprintf("%d", e)
 }
 


### PR DESCRIPTION
I did this so I could get nicer test names, but it also changes the help text from:

```
  -ingester.chunk-encoding value
    	Encoding version to use for chunks. (default 1)
```

to:

```
  -ingester.chunk-encoding value
    	Encoding version to use for chunks. (default DoubleDelta)
```