### PR TITLE
Explicitly reallocate bigchunk slice to avoid up to 2x overhead

### DIFF
--- a/pkg/chunk/encoding/bigchunk.go
+++ b/pkg/chunk/encoding/bigchunk.go
@@ -65,6 +65,12 @@ func (b *bigchunk) addNextChunk(start model.Time) error {
 		}
 	}
 
+	// Explicitly reallocate slice to avoid up to 2x overhead if we let append() do it
+	if len(b.chunks)+1 > cap(b.chunks) {
+		newChunks := make([]smallChunk, len(b.chunks), len(b.chunks)+1)
+		copy(newChunks, b.chunks)
+		b.chunks = newChunks
+	}
 	b.chunks = append(b.chunks, smallChunk{
 		XORChunk: *chunkenc.NewXORChunk(),
 		start:    int64(start),


### PR DESCRIPTION
`append()` doubles the size every time it needs more space, which is quite noticeable after #1649.

These slices are only extended every 120 samples, which is 30 minutes at 15-second sampling, and we're already copying the chunk buffer itself for similar reasons.
