### PR TITLE
Validate schema config to ensure table period is a multiple of buckets period

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -49,6 +49,14 @@ func main() {
 	// Parse a second time, as command line flags should take precedent over the config file.
 	flag.Parse()
 
+	// Validate the config once both the config file has been loaded
+	// and CLI flags parsed.
+	err := cfg.Validate()
+	if err != nil {
+		fmt.Printf("error validating config: %v\n", err)
+		os.Exit(1)
+	}
+
 	// Allocate a block of memory to alter GC behaviour. See https://github.com/golang/go/issues/23044
 	ballast := make([]byte, ballastBytes)
 
@@ -86,11 +94,6 @@ func LoadConfig(filename string, cfg *cortex.Config) error {
 	err = yaml.UnmarshalStrict(buf, cfg)
 	if err != nil {
 		return errors.Wrap(err, "Error parsing config file")
-	}
-
-	err = cfg.Validate()
-	if err != nil {
-		return errors.Wrap(err, "Error validating config file")
 	}
 
 	return nil

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -77,11 +77,21 @@ func main() {
 }
 
 // LoadConfig read YAML-formatted config from filename into cfg.
-func LoadConfig(filename string, cfg interface{}) error {
+func LoadConfig(filename string, cfg *cortex.Config) error {
 	buf, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return errors.Wrap(err, "Error reading config file")
 	}
 
-	return yaml.UnmarshalStrict(buf, cfg)
+	err = yaml.UnmarshalStrict(buf, cfg)
+	if err != nil {
+		return errors.Wrap(err, "Error parsing config file")
+	}
+
+	err = cfg.Validate()
+	if err != nil {
+		return errors.Wrap(err, "Error validating config file")
+	}
+
+	return nil
 }

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -78,9 +78,11 @@ type IndexEntry struct {
 	Value []byte
 }
 
+type schemaBucketsFunc func(from, through model.Time, userID string) []Bucket
+
 // schema implements Schema given a bucketing function and and set of range key callbacks
 type schema struct {
-	buckets func(from, through model.Time, userID string) []Bucket
+	buckets schemaBucketsFunc
 	entries entries
 }
 

--- a/pkg/chunk/schema_config_test.go
+++ b/pkg/chunk/schema_config_test.go
@@ -288,6 +288,119 @@ func TestChunkTableFor(t *testing.T) {
 	}
 }
 
+func TestSchemaConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		config   *SchemaConfig
+		expected error
+	}{
+		"should pass the default config (ie. used cortex runs with a target not requiring the schema config)": {
+			config:   &SchemaConfig{},
+			expected: nil,
+		},
+		"should fail on invalid schema version": {
+			config: &SchemaConfig{
+				Configs: []PeriodConfig{
+					{Schema: "v0"},
+				},
+			},
+			expected: errInvalidSchemaVersion,
+		},
+		"should fail on index table period not multiple of 1h for schema v1": {
+			config: &SchemaConfig{
+				Configs: []PeriodConfig{
+					{
+						Schema:      "v1",
+						IndexTables: PeriodicTableConfig{Period: 30 * time.Minute},
+					},
+				},
+			},
+			expected: errInvalidTablePeriod,
+		},
+		"should fail on chunk table period not multiple of 1h for schema v1": {
+			config: &SchemaConfig{
+				Configs: []PeriodConfig{
+					{
+						Schema:      "v1",
+						IndexTables: PeriodicTableConfig{Period: 6 * time.Hour},
+						ChunkTables: PeriodicTableConfig{Period: 30 * time.Minute},
+					},
+				},
+			},
+			expected: errInvalidTablePeriod,
+		},
+		"should pass on index and chunk table period multiple of 1h for schema v1": {
+			config: &SchemaConfig{
+				Configs: []PeriodConfig{
+					{
+						Schema:      "v1",
+						IndexTables: PeriodicTableConfig{Period: 6 * time.Hour},
+						ChunkTables: PeriodicTableConfig{Period: 6 * time.Hour},
+					},
+				},
+			},
+			expected: nil,
+		},
+		"should fail on index table period not multiple of 24h for schema v10": {
+			config: &SchemaConfig{
+				Configs: []PeriodConfig{
+					{
+						Schema:      "v10",
+						IndexTables: PeriodicTableConfig{Period: 6 * time.Hour},
+					},
+				},
+			},
+			expected: errInvalidTablePeriod,
+		},
+		"should fail on chunk table period not multiple of 24h for schema v10": {
+			config: &SchemaConfig{
+				Configs: []PeriodConfig{
+					{
+						Schema:      "v10",
+						IndexTables: PeriodicTableConfig{Period: 24 * time.Hour},
+						ChunkTables: PeriodicTableConfig{Period: 6 * time.Hour},
+					},
+				},
+			},
+			expected: errInvalidTablePeriod,
+		},
+		"should pass on index and chunk table period multiple of 24h for schema v10": {
+			config: &SchemaConfig{
+				Configs: []PeriodConfig{
+					{
+						Schema:      "v10",
+						IndexTables: PeriodicTableConfig{Period: 24 * time.Hour},
+						ChunkTables: PeriodicTableConfig{Period: 24 * time.Hour},
+					},
+				},
+			},
+			expected: nil,
+		},
+		"should pass on index and chunk table period set to zero (no period tables)": {
+			config: &SchemaConfig{
+				Configs: []PeriodConfig{
+					{
+						Schema:      "v10",
+						IndexTables: PeriodicTableConfig{Period: 0},
+						ChunkTables: PeriodicTableConfig{Period: 0},
+					},
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			actual := testData.config.Validate()
+			assert.Equal(t, testData.expected, actual)
+		})
+	}
+}
+
 func MustParseDayTime(s string) DayTime {
 	t, err := time.Parse("2006-01-02", s)
 	if err != nil {

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -108,6 +108,17 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	flag.IntVar(&chunk_util.QueryParallelism, "querier.query-parallelism", 100, "Max subqueries run in parallel per higher-level query.")
 }
 
+// Validate the cortex config and returns an error if the validation
+// doesn't pass
+func (c *Config) Validate() error {
+	err := c.Schema.Validate()
+	if err != nil {
+		return errors.Wrap(err, "invalid schema config")
+	}
+
+	return nil
+}
+
 // Cortex is the root datastructure for Cortex.
 type Cortex struct {
 	target             moduleName


### PR DESCRIPTION
The `schema_config` uses `dailyBuckets()` (starting from `v2`) to generate the buckets where indexes/chunks should be stored. The bucket also contains `tableName`, so it effectively drives to which table data is read//written.

Due to how `dailyBuckets()` is implemented, it constructs the `tableName` as function of the day bucket (with time `00:00:00`). Because of this, reads/writes occurs on index/chunk tables whose name is constructed with a daily-approximated numbering.

If the table period is not a multiple of `24h`, the table manager will create/update/delete tables with a naming not matching the real one (generated by `dailyBuckets()`).

After a [brief discussion with Brian on Slack](https://cloud-native.slack.com/archives/CCYDASBLP/p1570008064266600), in this PR I'm proposing to introduce a validation which prevents cortex to start if the table period is not a multiple of the buckets period.
