### PR TITLE
Fixed on-demand billing mode on DynamoDB table creation

### DIFF
--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -151,11 +151,18 @@ func (d dynamoTableClient) CreateTable(ctx context.Context, desc chunk.TableDesc
 						KeyType:       aws.String(dynamodb.KeyTypeRange),
 					},
 				},
-				ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+			}
+
+			if desc.UseOnDemandIOMode {
+				input.BillingMode = aws.String(dynamodb.BillingModePayPerRequest)
+			} else {
+				input.BillingMode = aws.String(dynamodb.BillingModeProvisioned)
+				input.ProvisionedThroughput = &dynamodb.ProvisionedThroughput{
 					ReadCapacityUnits:  aws.Int64(desc.ProvisionedRead),
 					WriteCapacityUnits: aws.Int64(desc.ProvisionedWrite),
-				},
+				}
 			}
+
 			output, err := d.DynamoDB.CreateTableWithContext(ctx, input)
 			if err != nil {
 				return err


### PR DESCRIPTION
There's a Loki issue https://github.com/grafana/loki/issues/1101 reporting that on DynamoDB table creation, the table is always created with the provisioned billing mode, even if the on-demand one has been enabled in the config (then, the next table manager loop reconcile will fix it).

This PR fixes it.
