### PR TITLE
Add a limits config option to allow for dropping of the cluster label

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -144,11 +144,13 @@ prefix these flags with `distributor.ha-tracker.`
 
 ### HA Tracker
 
-HA tracking has two of it's own flags:
+HA tracking has three of its own flags:
 - `distributor.ha-tracker.cluster`
    Prometheus label to look for in samples to identify a Prometheus HA cluster. (default "cluster")
 - `distributor.ha-tracker.replica`
    Prometheus label to look for in samples to identify a Prometheus HA replica. (default "`__replica__`")
+- `distributor.ha-tracker.drop-cluster-label`
+   Drops the cluster label before ingesting samples. The replica label is always dropped. This flag should only be used for users who already have some combination of more than two labels to uniquely identify a Prometheus replica, but for whom it is not feasible to switch over to a new set of just two labels.
 
 It's reasonable to assume people probably already have a `cluster` label, or something similar. If not, they should add one along with `__replica__` via external labels in their Prometheus config. If you stick to these default values your Prometheus config could look like this (`POD_NAME` is an environment variable which must be set by you):
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -108,6 +108,9 @@ The ingester query API was improved over time, but defaults to the old behaviour
 - `distributor.ha-tracker.enable` 
    Enable the distributors HA tracker so that it can accept samples from Prometheus HA replicas gracefully (requires labels). Global (for distributors), this ensures that the necessary internal data structures for the HA handling are created. The option `enable-for-all-users` is still needed to enable ingestion of HA samples for all users.
 
+- `distributor.drop-label`
+   This flag can be used to specify label names that to drop during sample ingestion within the distributor and can be repeated in order to drop multiple labels.
+
 ### Ring/HA Tracker Store
 
 The KVStore client is used by both the Ring and HA Tracker.
@@ -144,13 +147,11 @@ prefix these flags with `distributor.ha-tracker.`
 
 ### HA Tracker
 
-HA tracking has three of its own flags:
+HA tracking has two of its own flags:
 - `distributor.ha-tracker.cluster`
    Prometheus label to look for in samples to identify a Prometheus HA cluster. (default "cluster")
 - `distributor.ha-tracker.replica`
    Prometheus label to look for in samples to identify a Prometheus HA replica. (default "`__replica__`")
-- `distributor.ha-tracker.drop-cluster-label`
-   Drops the cluster label before ingesting samples. The replica label is always dropped. This flag should only be used for users who already have some combination of more than two labels to uniquely identify a Prometheus replica, but for whom it is not feasible to switch over to a new set of just two labels.
 
 It's reasonable to assume people probably already have a `cluster` label, or something similar. If not, they should add one along with `__replica__` via external labels in their Prometheus config. If you stick to these default values your Prometheus config could look like this (`POD_NAME` is an environment variable which must be set by you):
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -281,7 +281,6 @@ func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica 
 	return true, nil
 }
 
-
 // Validates a single series from a write request. Will remove HA labels if necessary.
 // Takes a pointer for a partial error so that we can get partial errors, errors during validation
 // of a single sample, back from the function without adding an additional return param.
@@ -292,6 +291,9 @@ func (d *Distributor) validateSeries(key uint32, ts ingester_client.PreallocTime
 	// series we're trying to dedupe when HA tracking moves over to a different replica.
 	if removeReplica {
 		removeLabel(d.limits.HAReplicaLabel(userID), &ts.Labels)
+		if d.limits.HADropClusterLabel(userID) {
+			removeLabel(d.limits.HAClusterLabel(userID), &ts.Labels)
+		}
 	}
 
 	labelsHistogram.Observe(float64(len(ts.Labels)))

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -249,11 +249,11 @@ func shardByAllLabels(userID string, labels []client.LabelAdapter) (uint32, erro
 	return h, nil
 }
 
-// Remove the replica label from a slice of LabelPairs if it exists.
-func removeReplicaLabel(replica string, labels *[]client.LabelAdapter) {
+// Remove the label labelname from a slice of LabelPairs if it exists.
+func removeLabel(labelName string, labels *[]client.LabelAdapter) {
 	for i := 0; i < len(*labels); i++ {
 		pair := (*labels)[i]
-		if pair.Name == replica {
+		if pair.Name == labelName {
 			*labels = append((*labels)[:i], (*labels)[i+1:]...)
 			return
 		}
@@ -323,7 +323,7 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 		// storing series in Cortex. If we kept the replica label we would end up with another series for the same
 		// series we're trying to dedupe when HA tracking moves over to a different replica.
 		if removeReplica {
-			removeReplicaLabel(d.limits.HAReplicaLabel(userID), &ts.Labels)
+			removeLabel(d.limits.HAReplicaLabel(userID), &ts.Labels)
 		}
 		key, err := d.tokenForLabels(userID, ts.Labels)
 		if err != nil {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -291,9 +291,13 @@ func (d *Distributor) validateSeries(key uint32, ts ingester_client.PreallocTime
 	// series we're trying to dedupe when HA tracking moves over to a different replica.
 	if removeReplica {
 		removeLabel(d.limits.HAReplicaLabel(userID), &ts.Labels)
-		if d.limits.HADropClusterLabel(userID) {
-			removeLabel(d.limits.HAClusterLabel(userID), &ts.Labels)
-		}
+	}
+	for _, s := range d.limits.DropLabels(userID) {
+		removeLabel(s, &ts.Labels)
+	}
+	key, err := d.tokenForLabels(userID, ts.Labels)
+	if err != nil {
+		return emptyPreallocSeries, err
 	}
 
 	labelsHistogram.Observe(float64(len(ts.Labels)))

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"sort"
 	"strconv"
 	"sync"
@@ -296,6 +297,80 @@ func TestDistributorPushQuery(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedResponse.String(), response.String())
 		})
+	}
+}
+
+func TestDistributorValidateSeriesLabelRemoval(t *testing.T) {
+	ctx = user.InjectOrgID(context.Background(), "user")
+
+	type testcase struct {
+		series        client.PreallocTimeseries
+		outputSeries  client.PreallocTimeseries
+		removeReplica bool
+	}
+
+	cases := []testcase{
+		{ // Remove replica label.
+			series: client.PreallocTimeseries{
+				TimeSeries: &client.TimeSeries{
+					Labels: []client.LabelAdapter{
+						{Name: "__name__", Value: "some_metric"},
+						{Name: "cluster", Value: "one"},
+						{Name: "__replica__", Value: "two"}},
+				},
+			},
+			outputSeries: client.PreallocTimeseries{
+				TimeSeries: &client.TimeSeries{
+					Labels: []client.LabelAdapter{
+						{Name: "__name__", Value: "some_metric"},
+						{Name: "cluster", Value: "one"},
+					},
+					Samples: []client.Sample{},
+				},
+			},
+			removeReplica: true,
+		},
+		{ // Don't remove either HA.
+			series: client.PreallocTimeseries{
+				TimeSeries: &client.TimeSeries{
+					Labels: []client.LabelAdapter{
+						{Name: "__name__", Value: "some_metric"},
+						{Name: "cluster", Value: "one"},
+						{Name: "__replica__", Value: "two"}},
+				},
+			},
+			outputSeries: client.PreallocTimeseries{
+				TimeSeries: &client.TimeSeries{
+					Labels: []client.LabelAdapter{
+						{Name: "__name__", Value: "some_metric"},
+						{Name: "cluster", Value: "one"},
+						{Name: "__replica__", Value: "two"},
+					},
+					Samples: []client.Sample{},
+				},
+			},
+			removeReplica: false,
+		},
+	}
+
+	for _, tc := range cases {
+		var err error
+		var limits validation.Limits
+		flagext.DefaultValues(&limits)
+		d := prepare(t, 1, 1, 0, true, &limits)
+
+		userID, err := user.ExtractOrgID(ctx)
+		assert.NoError(t, err)
+
+		key, err := d.tokenForLabels(userID, tc.series.Labels)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		series, err := d.validateSeries(key, tc.series, userID, tc.removeReplica)
+		if !reflect.DeepEqual(series, tc.outputSeries) {
+			t.Fatalf("output of validate series did not match expected output:\n\texpected: %+v\n\t got: %+v", tc.outputSeries, series)
+		}
 	}
 }
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -307,7 +307,7 @@ func TestDistributorValidateSeriesLabelRemoval(t *testing.T) {
 		series        client.PreallocTimeseries
 		outputSeries  client.PreallocTimeseries
 		removeReplica bool
-		removeCluster bool
+		removeLabels  []string
 	}
 
 	cases := []testcase{
@@ -329,15 +329,17 @@ func TestDistributorValidateSeriesLabelRemoval(t *testing.T) {
 				},
 			},
 			removeReplica: true,
-			removeCluster: true,
+			removeLabels:  []string{"cluster"},
 		},
-		{ // Remove replica label.
+		{ // Remove multiple labels and replica.
 			series: client.PreallocTimeseries{
 				TimeSeries: &client.TimeSeries{
 					Labels: []client.LabelAdapter{
 						{Name: "__name__", Value: "some_metric"},
 						{Name: "cluster", Value: "one"},
-						{Name: "__replica__", Value: "two"}},
+						{Name: "__replica__", Value: "two"},
+						{Name: "foo", Value: "bar"},
+						{Name: "some", Value: "thing"}},
 				},
 			},
 			outputSeries: client.PreallocTimeseries{
@@ -350,9 +352,9 @@ func TestDistributorValidateSeriesLabelRemoval(t *testing.T) {
 				},
 			},
 			removeReplica: true,
-			removeCluster: false,
+			removeLabels:  []string{"foo", "some"},
 		},
-		{ // Don't remove either HA.
+		{ // Don't remove any labels.
 			series: client.PreallocTimeseries{
 				TimeSeries: &client.TimeSeries{
 					Labels: []client.LabelAdapter{
@@ -372,7 +374,6 @@ func TestDistributorValidateSeriesLabelRemoval(t *testing.T) {
 				},
 			},
 			removeReplica: false,
-			removeCluster: false,
 		},
 	}
 
@@ -380,7 +381,7 @@ func TestDistributorValidateSeriesLabelRemoval(t *testing.T) {
 		var err error
 		var limits validation.Limits
 		flagext.DefaultValues(&limits)
-		limits.HADropClusterLabel = tc.removeCluster
+		limits.DropLabels = tc.removeLabels
 		d := prepare(t, 1, 1, 0, true, &limits)
 
 		userID, err := user.ExtractOrgID(ctx)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -751,7 +751,7 @@ func TestRemoveReplicaLabel(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		removeReplicaLabel(replicaLabel, &c.labelsIn)
+		removeLabel(replicaLabel, &c.labelsIn)
 		assert.Equal(t, c.labelsOut, c.labelsIn)
 	}
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -156,7 +156,7 @@ func (o *Overrides) HAReplicaLabel(userID string) string {
 	return o.overridesManager.GetLimits(userID).(*Limits).HAReplicaLabel
 }
 
-// DropLabels returns whether the cluster label should be dropped when ingesting HA samples for the user.
+// DropLabels returns the list of labels to be dropped when ingesting HA samples for the user.
 func (o *Overrides) DropLabels(userID string) flagext.StringSlice {
 	return o.overridesManager.GetLimits(userID).(*Limits).DropLabels
 }


### PR DESCRIPTION
Fixes #1724 

Adds an optional flag per user to drop the cluster label, in addition to dropping the replica label, when ingesting HA samples. Should only be used if that user has their own set of more than two labels that they use to uniquely identify Prometheus replicas.

There's a bit of a refactor here as well:
- I noticed that in the config the ordering of the values was cluster label then replica label, but in RegisterFlags the order is replica then cluster. I moved them around in RegisterFlags to match the order in the struct.
- `distributor.Push` was getting pretty long, I moved the internals of the validation loop into a function `validateSeries`. This also had the side effect of making that portion of the code testable. I've only added tests for the label removal bits. I assume the actual validation functions `ValidateLabels` and `ValidateSamples` are tested already.
- renamed removeReplicaLabel -> removeLabel, it wasn't doing anything replica label specific anyways

Signed-off-by: Callum Styan <callumstyan@gmail.com>
cc @tomwilkie @gouthamve 