### PR TITLE
Removed unused code

### DIFF
--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -72,8 +71,7 @@ var (
 		Name:      "alertmanager_configs",
 		Help:      "How many configs the multitenant alertmanager knows about.",
 	})
-	statusTemplate      *template.Template
-	allConnectionStates = []string{"established", "pending", "retrying", "failed", "connecting"}
+	statusTemplate *template.Template
 )
 
 func init() {
@@ -86,17 +84,6 @@ func init() {
 			return "disabled"
 		},
 	}).Parse(statusPage))
-}
-
-// Print counts in a specified order
-func counts(counts map[string]int, keys []string) string {
-	var stringCounts []string
-	for _, key := range keys {
-		if count, ok := counts[key]; ok {
-			stringCounts = append(stringCounts, fmt.Sprintf("%d %s", count, key))
-		}
-	}
-	return strings.Join(stringCounts, ", ")
 }
 
 // MultitenantAlertmanagerConfig is the configuration for a multitenant Alertmanager.

--- a/pkg/chunk/cache/redis_cache.go
+++ b/pkg/chunk/cache/redis_cache.go
@@ -141,14 +141,3 @@ func (c *RedisCache) ping(ctx context.Context) error {
 	}
 	return err
 }
-
-func redisStatusCode(err error) string {
-	switch err {
-	case nil:
-		return "200"
-	case redis.ErrNil:
-		return "404"
-	default:
-		return "500"
-	}
-}

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -14,10 +14,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/util"
 )
 
-const (
-	maxRowReads = 100
-)
-
 // Config for a StorageClient
 type Config struct {
 	Addresses                string        `yaml:"addresses,omitempty"`

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -128,13 +128,6 @@ func TestChunkCodec(t *testing.T) {
 
 const fixedTimestamp = model.Time(1557654321000)
 
-func encodeForCompatibilityTest(t *testing.T) {
-	dummy := dummyChunkForEncoding(fixedTimestamp, labelsForDummyChunks, encoding.Bigchunk, 1)
-	encoded, err := dummy.Encoded()
-	require.NoError(t, err)
-	fmt.Printf("%q\n%q\n", dummy.ExternalKey(), encoded)
-}
-
 func TestChunkDecodeBackwardsCompatibility(t *testing.T) {
 	// Chunk encoded using code at commit b1777a50ab19
 	rawData := []byte("\x00\x00\x00\xb7\xff\x06\x00\x00sNaPpY\x01\xa5\x00\x00\x04\xc7a\xba{\"fingerprint\":18245339272195143978,\"userID\":\"userID\",\"from\":1557650721,\"through\":1557654321,\"metric\":{\"bar\":\"baz\",\"toms\":\"code\",\"__name__\":\"foo\"},\"encoding\":3}\n\x00\x00\x00\x15\x01\x00\x11\x00\x00\x01\xd0\xdd\xf5\xb6\xd5Z\x00\x00\x00\x00\x00\x00\x00\x00\x00")

--- a/pkg/chunk/encoding/chunk.go
+++ b/pkg/chunk/encoding/chunk.go
@@ -31,7 +31,6 @@ const ChunkLen = 1024
 
 var (
 	errChunkBoundsExceeded = errors.New("attempted access outside of chunk boundaries")
-	errAddedToEvictedChunk = errors.New("attempted to add sample to evicted chunk")
 )
 
 // Chunk is the interface for all chunks. Chunks are generally not

--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -27,7 +27,6 @@ const (
 	column       = "c"
 	separator    = "\000"
 	maxRowReads  = 100
-	null         = string('\xff')
 )
 
 // Config for a StorageClient

--- a/pkg/chunk/local/boltdb_index_client.go
+++ b/pkg/chunk/local/boltdb_index_client.go
@@ -22,7 +22,6 @@ var bucketName = []byte("index")
 
 const (
 	separator      = "\000"
-	null           = string('\xff')
 	dbReloadPeriod = 10 * time.Minute
 )
 

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -71,14 +71,6 @@ func CreateChunks(startIndex, batchSize int, start model.Time) ([]string, []chun
 	return keys, chunks, nil
 }
 
-func dummyChunk(now model.Time) chunk.Chunk {
-	return dummyChunkFor(now, labels.Labels{
-		{Name: model.MetricNameLabel, Value: "foo"},
-		{Name: "bar", Value: "baz"},
-		{Name: "toms", Value: "code"},
-	})
-}
-
 func dummyChunkFor(now model.Time, metric labels.Labels) chunk.Chunk {
 	cs, _ := promchunk.New().Add(model.SamplePair{Timestamp: now, Value: 0})
 	chunk := chunk.NewChunk(

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -59,12 +59,6 @@ var (
 		Name:      "distributor_deduped_samples_total",
 		Help:      "The total number of deduplicated samples.",
 	}, []string{"user", "cluster"})
-	sendDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "cortex",
-		Name:      "distributor_send_duration_seconds",
-		Help:      "Time spent sending a sample batch to multiple replicated ingesters.",
-		Buckets:   []float64{.001, .0025, .005, .01, .025, .05, .1, .25, .5, 1},
-	}, []string{"method", "status_code"})
 	labelsHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "cortex",
 		Name:      "labels_per_sample",

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -59,10 +59,6 @@ func NewReplicaDesc() *ReplicaDesc {
 	return &ReplicaDesc{}
 }
 
-const (
-	longPollDuration = 10 * time.Second
-)
-
 // Track the replica we're accepting samples from
 // for each HA cluster we know about.
 type haTracker struct {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -30,10 +30,6 @@ import (
 )
 
 const (
-	// Reasons to discard samples.
-	outOfOrderTimestamp = "timestamp_out_of_order"
-	duplicateSample     = "multiple_values_for_timestamp"
-
 	// Number of timeseries to return in each batch of a QueryStream.
 	queryStreamBatchSize = 128
 )

--- a/pkg/querier/batch/non_overlapping.go
+++ b/pkg/querier/batch/non_overlapping.go
@@ -5,8 +5,6 @@ import (
 	promchunk "github.com/cortexproject/cortex/pkg/chunk/encoding"
 )
 
-const bufferBatches = 4
-
 type nonOverlappingIterator struct {
 	curr   int
 	chunks []chunk.Chunk

--- a/pkg/querier/batch/stream.go
+++ b/pkg/querier/batch/stream.go
@@ -118,37 +118,3 @@ func mergeStreams(left, right batchStream, result batchStream, size int) batchSt
 	result.reset()
 	return result
 }
-
-func mergeBatchTimes(a, b promchunk.Batch, size int) promchunk.Batch {
-	i, j, k := 0, 0, 0
-	var result promchunk.Batch
-	for i < a.Length && j < b.Length && k < size {
-		t1, t2 := a.Timestamps[i], b.Timestamps[j]
-		if t1 < t2 {
-			result.Timestamps[k] = t1
-			i++
-			k++
-		} else if t1 > t2 {
-			result.Timestamps[k] = t2
-			j++
-			k++
-		} else {
-			result.Timestamps[k] = t2
-			i++
-			j++
-			k++
-		}
-	}
-	for i < a.Length && k < size {
-		result.Timestamps[k] = a.Timestamps[i]
-		i++
-		k++
-	}
-	for j < b.Length && k < size {
-		result.Timestamps[k] = b.Timestamps[j]
-		j++
-		k++
-	}
-	result.Length = k
-	return result
-}

--- a/pkg/querier/correctness/runner.go
+++ b/pkg/querier/correctness/runner.go
@@ -15,7 +15,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/api"
-	"github.com/prometheus/client_golang/api/prometheus/v1"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/model"
@@ -270,18 +270,4 @@ func (r *Runner) valueEpsilonCorrect(f func(time.Time) float64, pair model.Sampl
 func epsilonCorrect(actual, expected, epsilon float64) bool {
 	delta := math.Abs((actual - expected) / expected)
 	return delta < epsilon
-}
-
-func maxDuration(a, b time.Duration) time.Duration {
-	if a < b {
-		return b
-	}
-	return a
-}
-
-func minDuration(a, b time.Duration) time.Duration {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -45,7 +45,6 @@ var (
 		Buckets:   prometheus.DefBuckets,
 	}, []string{"method", "status_code"})
 
-	errServerClosing  = httpgrpc.Errorf(http.StatusTeapot, "server closing down")
 	errTooManyRequest = httpgrpc.Errorf(http.StatusTooManyRequests, "too many outstanding requests")
 	errCanceled       = httpgrpc.Errorf(http.StatusInternalServerError, "context cancelled")
 )

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -49,26 +49,6 @@ var (
 	}
 )
 
-var dummyResponse = &APIResponse{
-	Status: statusSuccess,
-	Data: Response{
-		ResultType: matrix,
-		Result: []SampleStream{
-			{
-				Labels: []client.LabelAdapter{
-					{Name: "foo", Value: "bar"},
-				},
-				Samples: []client.Sample{
-					{
-						TimestampMs: 60,
-						Value:       60,
-					},
-				},
-			},
-		},
-	},
-}
-
 func mkAPIResponse(start, end, step int64) *APIResponse {
 	var samples []client.Sample
 	for i := start; i <= end; i += step {


### PR DESCRIPTION
While reviewing the distributor implementation, I've noticed the `sendDuration` metric was defined but unused. I've took the chance to quickly run a linter to remove unused variables and code.

_Don't know how this kind of PRs are seen, but in case there's any interest, here it is._