### PR TITLE
Add support to log slow queries in Frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@
   * `-ingester.max-global-series-per-metric`
 * [FEATURE] Flush chunks with stale markers early with `ingester.max-stale-chunk-idle`. #1759
 * [FEATURE] EXPERIMENTAL: Added new KV Store backend based on memberlist library. Components can gossip about tokens and ingester states, instead of using Consul or Etcd. #1721
+* [FEATURE] Allow Query Frontend to log slow queries #1744
 * [ENHANCEMENT] Allocation improvements in adding samples to Chunk. #1706
 * [ENHANCEMENT] Consul client now follows recommended practices for blocking queries wrt returned Index value. #1708
 * [ENHANCEMENT] Consul client can optionally rate-limit itself during Watch (used e.g. by ring watchers) and WatchPrefix (used by HA feature) operations. Rate limiting is disabled by default. New flags added: `--consul.watch-rate-limit`, and `--consul.watch-burst-size`. #1708
-* [FEATURE] Allow Query Frontend to log slow queries #1744
 
 ## 0.3.0 / 2019-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [ENHANCEMENT] Allocation improvements in adding samples to Chunk. #1706
 * [ENHANCEMENT] Consul client now follows recommended practices for blocking queries wrt returned Index value. #1708
 * [ENHANCEMENT] Consul client can optionally rate-limit itself during Watch (used e.g. by ring watchers) and WatchPrefix (used by HA feature) operations. Rate limiting is disabled by default. New flags added: `--consul.watch-rate-limit`, and `--consul.watch-burst-size`. #1708
+* [FEATURE] Allow Query Frontend to log slow queries #1744
 
 ## 0.3.0 / 2019-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   * `-ingester.max-global-series-per-metric`
 * [FEATURE] Flush chunks with stale markers early with `ingester.max-stale-chunk-idle`. #1759
 * [FEATURE] EXPERIMENTAL: Added new KV Store backend based on memberlist library. Components can gossip about tokens and ingester states, instead of using Consul or Etcd. #1721
-* [FEATURE] Allow Query Frontend to log slow queries #1744
+* [FEATURE] Allow Query Frontend to log slow queries with `frontend.log-queries-longer-than`. #1744
 * [ENHANCEMENT] Allocation improvements in adding samples to Chunk. #1706
 * [ENHANCEMENT] Consul client now follows recommended practices for blocking queries wrt returned Index value. #1708
 * [ENHANCEMENT] Consul client can optionally rate-limit itself during Watch (used e.g. by ring watchers) and WatchPrefix (used by HA feature) operations. Rate limiting is disabled by default. New flags added: `--consul.watch-rate-limit`, and `--consul.watch-burst-size`. #1708

--- a/docs/prometheus-frontend.yml
+++ b/docs/prometheus-frontend.yml
@@ -16,7 +16,7 @@ server:
   http_listen_port: 9091
 
 frontend:
-  log_queries_longer_than: 1 # in seconds
+  log_queries_longer_than: 1s
   split_queries_by_day: true
   align_queries_with_step: true
   cache_results: true

--- a/docs/prometheus-frontend.yml
+++ b/docs/prometheus-frontend.yml
@@ -16,6 +16,7 @@ server:
   http_listen_port: 9091
 
 frontend:
+  log_queries_longer_than: 1 # in seconds
   split_queries_by_day: true
   align_queries_with_step: true
   cache_results: true

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -55,7 +55,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxOutstandingPerTenant, "querier.max-outstanding-requests-per-tenant", 100, "Maximum number of outstanding requests per tenant per frontend; requests beyond this error with HTTP 429.")
 	f.BoolVar(&cfg.CompressResponses, "querier.compress-http-responses", false, "Compress HTTP responses.")
 	f.StringVar(&cfg.DownstreamURL, "frontend.downstream-url", "", "URL of downstream Prometheus.")
-	f.DurationVar(&cfg.LogQueriesLongerThan, "querier.log-queries-longer-than", 1*time.Second, "Log slow queries")
+	f.DurationVar(&cfg.LogQueriesLongerThan, "querier.log-queries-longer-than", 0, "Log slow queries")
 }
 
 // Frontend queues HTTP requests, dispatches them to backends, and handles retries
@@ -153,7 +153,7 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if queryResponseTime > f.cfg.LogQueriesLongerThan {
+	if f.cfg.LogQueriesLongerThan > 0 && queryResponseTime > f.cfg.LogQueriesLongerThan {
 		level.Warn(f.log).Log("msg", "slow query", "orgID", userID, "url", fmt.Sprintf("http://%s", r.Host+r.RequestURI), "time-taken", queryResponseTime.String())
 	}
 

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -55,7 +55,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxOutstandingPerTenant, "querier.max-outstanding-requests-per-tenant", 100, "Maximum number of outstanding requests per tenant per frontend; requests beyond this error with HTTP 429.")
 	f.BoolVar(&cfg.CompressResponses, "querier.compress-http-responses", false, "Compress HTTP responses.")
 	f.StringVar(&cfg.DownstreamURL, "frontend.downstream-url", "", "URL of downstream Prometheus.")
-	f.DurationVar(&cfg.LogQueriesLongerThan, "frontend.log-queries-longer-than", 0, "Log slow queries")
+	f.DurationVar(&cfg.LogQueriesLongerThan, "frontend.log-queries-longer-than", 0, "Log queries that are slower than the specified duration. 0 to disable.")
 }
 
 // Frontend queues HTTP requests, dispatches them to backends, and handles retries
@@ -154,7 +154,7 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 	queryResponseTime := time.Now().Sub(startTime)
 
 	if f.cfg.LogQueriesLongerThan > 0 && queryResponseTime > f.cfg.LogQueriesLongerThan {
-		level.Warn(f.log).Log("msg", "slow query", "orgID", userID, "url", fmt.Sprintf("http://%s", r.Host+r.RequestURI), "time-taken", queryResponseTime.String())
+		level.Warn(f.log).Log("msg", "slow query", "org_id", userID, "url", fmt.Sprintf("http://%s", r.Host+r.RequestURI), "time_taken", queryResponseTime.String())
 	}
 
 	if err != nil {

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"flag"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -42,9 +44,10 @@ var (
 
 // Config for a Frontend.
 type Config struct {
-	MaxOutstandingPerTenant int    `yaml:"max_outstanding_per_tenant"`
-	CompressResponses       bool   `yaml:"compress_responses"`
-	DownstreamURL           string `yaml:"downstream"`
+	MaxOutstandingPerTenant int           `yaml:"max_outstanding_per_tenant"`
+	CompressResponses       bool          `yaml:"compress_responses"`
+	DownstreamURL           string        `yaml:"downstream"`
+	LogQueriesLongerThan    time.Duration `yaml:"log_queries_longer_than"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -52,6 +55,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxOutstandingPerTenant, "querier.max-outstanding-requests-per-tenant", 100, "Maximum number of outstanding requests per tenant per frontend; requests beyond this error with HTTP 429.")
 	f.BoolVar(&cfg.CompressResponses, "querier.compress-http-responses", false, "Compress HTTP responses.")
 	f.StringVar(&cfg.DownstreamURL, "frontend.downstream-url", "", "URL of downstream Prometheus.")
+	f.DurationVar(&cfg.LogQueriesLongerThan, "querier.log-queries-longer-than", 1*time.Second, "Log slow queries")
 }
 
 // Frontend queues HTTP requests, dispatches them to backends, and handles retries
@@ -139,7 +143,14 @@ func (f *Frontend) Handler() http.Handler {
 }
 
 func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
+	startTime := time.Now()
 	resp, err := f.roundTripper.RoundTrip(r)
+	queryResponseTime := time.Now().Sub(startTime)
+
+	if queryResponseTime > f.cfg.LogQueriesLongerThan {
+		level.Info(f.log).Log("msg", "slow query", "url", fmt.Sprintf("http://%s/", r.URL.Host+r.URL.Path+r.URL.RawQuery), "time", queryResponseTime.String())
+	}
+
 	if err != nil {
 		server.WriteError(w, err)
 		return
@@ -187,7 +198,7 @@ func (c *httpgrpcHeadersCarrier) Set(key, val string) {
 	})
 }
 
-// RoundTripGRPC round trips a proto (instread of a HTTP request).
+// RoundTripGRPC round trips a proto (instead of a HTTP request).
 func (f *Frontend) RoundTripGRPC(ctx context.Context, req *ProcessRequest) (*ProcessResponse, error) {
 	// Propagate trace context in gRPC too - this will be ignored if using HTTP.
 	tracer, span := opentracing.GlobalTracer(), opentracing.SpanFromContext(ctx)

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -147,8 +147,14 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 	resp, err := f.roundTripper.RoundTrip(r)
 	queryResponseTime := time.Now().Sub(startTime)
 
+	userID, err := user.ExtractOrgID(r.Context())
+	if err != nil {
+		server.WriteError(w, err)
+		return
+	}
+
 	if queryResponseTime > f.cfg.LogQueriesLongerThan {
-		level.Info(f.log).Log("msg", "slow query", "url", fmt.Sprintf("http://%s/", r.URL.Host+r.URL.Path+r.URL.RawQuery), "time", queryResponseTime.String())
+		level.Warn(f.log).Log("msg", "slow query", "orgID", userID, "url", fmt.Sprintf("http://%s", r.Host+r.RequestURI), "time-taken", queryResponseTime.String())
 	}
 
 	if err != nil {

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -154,7 +154,7 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 	queryResponseTime := time.Now().Sub(startTime)
 
 	if f.cfg.LogQueriesLongerThan > 0 && queryResponseTime > f.cfg.LogQueriesLongerThan {
-		level.Warn(f.log).Log("msg", "slow query", "org_id", userID, "url", fmt.Sprintf("http://%s", r.Host+r.RequestURI), "time_taken", queryResponseTime.String())
+		level.Info(f.log).Log("msg", "slow query", "org_id", userID, "url", fmt.Sprintf("http://%s", r.Host+r.RequestURI), "time_taken", queryResponseTime.String())
 	}
 
 	if err != nil {


### PR DESCRIPTION
This PR has a feature to log slow queries in Frontend based on `querier.log-queries-longer-than` parameter. As per this discussion on issue [1567](https://github.com/cortexproject/cortex/issues/1567)
cc @gouthamve 