### PR TITLE
Add jitter to HA deduping heartbeats (#1543)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [ENHANCEMENT] Allocation improvements in adding samples to Chunk. #1706
 * [ENHANCEMENT] Consul client now follows recommended practices for blocking queries wrt returned Index value. #1708
 * [ENHANCEMENT] Consul client can optionally rate-limit itself during Watch (used e.g. by ring watchers) and WatchPrefix (used by HA feature) operations. Rate limiting is disabled by default. New flags added: `--consul.watch-rate-limit`, and `--consul.watch-burst-size`. #1708
+* [ENHANCEMENT] Added jitter to HA deduping heartbeats, configure using `distributor.ha-tracker.update-timeout-jitter-max` #1534
 
 ## 0.3.0 / 2019-10-11
 

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -134,6 +134,9 @@ func (c *Config) Validate() error {
 	if err := c.LimitsConfig.Validate(c.Distributor.ShardByAllLabels); err != nil {
 		return errors.Wrap(err, "invalid limits config")
 	}
+	if err := c.Distributor.Validate(); err != nil {
+		return errors.Wrap(err, "invalid distributor config")
+	}
 	return nil
 }
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -144,6 +144,11 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.ShardByAllLabels, "distributor.shard-by-all-labels", false, "Distribute samples based on all labels, as opposed to solely by user and metric name.")
 }
 
+// Validate config and returns error on failure
+func (cfg *Config) Validate() error {
+	return cfg.HATrackerConfig.Validate()
+}
+
 // New constructs a new Distributor
 func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Overrides, ring ring.ReadRing) (*Distributor, error) {
 	if cfg.ingesterClientFactory == nil {

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -73,7 +73,7 @@ func TestFailoverGreaterUpdate(t *testing.T) {
 			in: HATrackerConfig{
 				EnableHATracker: true,
 				UpdateTimeout:   time.Second,
-				FailoverTimeout: 999 * time.Millisecond,
+				FailoverTimeout: 1999 * time.Millisecond,
 				KVStore: kv.Config{
 					Store: "inmemory",
 				},
@@ -84,7 +84,18 @@ func TestFailoverGreaterUpdate(t *testing.T) {
 			in: HATrackerConfig{
 				EnableHATracker: true,
 				UpdateTimeout:   time.Second,
-				FailoverTimeout: 1001 * time.Millisecond,
+				FailoverTimeout: 2000 * time.Millisecond,
+				KVStore: kv.Config{
+					Store: "inmemory",
+				},
+			},
+			fail: false,
+		},
+		{
+			in: HATrackerConfig{
+				EnableHATracker: true,
+				UpdateTimeout:   time.Second,
+				FailoverTimeout: 2001 * time.Millisecond,
 				KVStore: kv.Config{
 					Store: "inmemory",
 				},
@@ -94,7 +105,7 @@ func TestFailoverGreaterUpdate(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		_, err := newClusterTracker(c.in)
+		err := c.in.Validate()
 		fail := err != nil
 		assert.Equal(t, c.fail, fail, "unexpected result: %s", err)
 	}


### PR DESCRIPTION
addresses #1534, adds a new `distributor.ha-tracker.update-timeout-jitter` config to add a +/- jitter to the UpdateTimeout for the HA dedupe heartbeat.