### PR TITLE
Fixed max_recv_msg_size distributor config option

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -119,7 +119,7 @@ type Config struct {
 
 	HATrackerConfig HATrackerConfig `yaml:"ha_tracker,omitempty"`
 
-	MaxRecvMsgSize      int           `yaml:"max_send_msg_size"`
+	MaxRecvMsgSize      int           `yaml:"max_recv_msg_size"`
 	RemoteTimeout       time.Duration `yaml:"remote_timeout,omitempty"`
 	ExtraQueryDelay     time.Duration `yaml:"extra_queue_delay,omitempty"`
 	LimiterReloadPeriod time.Duration `yaml:"limiter_reload_period,omitempty"`


### PR DESCRIPTION
The PR https://github.com/cortexproject/cortex/pull/1719 introduced a typo in the name of the YAML config option (send instead of recv). This PR fixes it.
