### PR TITLE
Various fixes in Consul client and mockKV ("inmemory" KV store)

### DIFF
--- a/pkg/ring/kv/consul/client.go
+++ b/pkg/ring/kv/consul/client.go
@@ -168,8 +168,7 @@ func (c *Client) cas(ctx context.Context, key string, f func(in interface{}) (ou
 // under said key changes, the f callback is called with the deserialised
 // value. To construct the deserialised value, a factory function should be
 // supplied which generates an empty struct for WatchKey to deserialise
-// into. Values in Consul are assumed to be JSON. This function blocks until
-// the context is cancelled.
+// into. This function blocks until the context is cancelled or f returns false.
 func (c *Client) WatchKey(ctx context.Context, key string, f func(interface{}) bool) {
 	var (
 		backoff = util.NewBackoff(ctx, backoffConfig)

--- a/pkg/ring/kv/consul/client.go
+++ b/pkg/ring/kv/consul/client.go
@@ -208,15 +208,18 @@ func (c *Client) WatchKey(ctx context.Context, key string, f func(interface{}) b
 			continue
 		}
 
-		if kvp != nil {
-			out, err := c.codec.Decode(kvp.Value)
-			if err != nil {
-				level.Error(util.Logger).Log("msg", "error decoding key", "key", key, "err", err)
-				continue
-			}
-			if !f(out) {
-				return
-			}
+		if kvp == nil {
+			level.Info(util.Logger).Log("msg", "value is nil", "key", key, "index", index)
+			continue
+		}
+
+		out, err := c.codec.Decode(kvp.Value)
+		if err != nil {
+			level.Error(util.Logger).Log("msg", "error decoding key", "key", key, "err", err)
+			continue
+		}
+		if !f(out) {
+			return
 		}
 	}
 }

--- a/pkg/ring/kv/consul/client.go
+++ b/pkg/ring/kv/consul/client.go
@@ -247,7 +247,9 @@ func (c *Client) WatchPrefix(ctx context.Context, prefix string, f func(string, 
 		}
 
 		kvps, meta, err := c.kv.List(prefix, queryOptions.WithContext(ctx))
-		if err != nil || kvps == nil {
+		// kvps being nil here is not an error -- quite the opposite. Consul returns index,
+		// which makes next query blocking, so there is no need to detect this and act on it.
+		if err != nil {
 			level.Error(util.Logger).Log("msg", "error getting path", "prefix", prefix, "err", err)
 			backoff.Wait()
 			continue

--- a/pkg/ring/kv/etcd/mock.go
+++ b/pkg/ring/kv/etcd/mock.go
@@ -27,6 +27,7 @@ func Mock(codec codec.Codec) (*Client, io.Closer, error) {
 	}
 
 	cfg := embed.NewConfig()
+	cfg.Logger = "zap"
 	cfg.Dir = dir
 	lpurl, _ := url.Parse("http://localhost:0")
 	lcurl, _ := url.Parse("http://localhost:0")

--- a/pkg/ring/kv/kv_test.go
+++ b/pkg/ring/kv/kv_test.go
@@ -99,11 +99,13 @@ func TestWatchKey(t *testing.T) {
 		go func() {
 			defer close(ch)
 			for i := 0; i < max; i++ {
+				// Start with sleeping, so that watching client see empty KV store at the beginning.
+				time.Sleep(sleep)
+
 				err := client.CAS(ctx, key, func(in interface{}) (out interface{}, retry bool, err error) {
 					return fmt.Sprintf("%d", i), true, nil
 				})
 				require.NoError(t, err)
-				time.Sleep(sleep)
 			}
 		}()
 
@@ -151,12 +153,14 @@ func TestWatchPrefix(t *testing.T) {
 		go func() {
 			defer close(ch)
 			for i := 0; i < max; i++ {
+				// Start with sleeping, so that watching client see empty KV store at the beginning.
+				time.Sleep(sleep)
+
 				key := fmt.Sprintf("%s%d", prefix, i)
 				err := client.CAS(ctx, key, func(in interface{}) (out interface{}, retry bool, err error) {
 					return key, true, nil
 				})
 				require.NoError(t, err)
-				time.Sleep(sleep)
 			}
 		}()
 

--- a/pkg/ring/kv/kv_test.go
+++ b/pkg/ring/kv/kv_test.go
@@ -2,9 +2,11 @@ package kv
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -84,5 +86,99 @@ func TestNilCAS(t *testing.T) {
 		value, err := client.Get(ctx, key)
 		require.NoError(t, err)
 		require.EqualValues(t, "0", value)
+	})
+}
+
+func TestWatchKey(t *testing.T) {
+	const key = "test"
+	const max = 100
+	const sleep = 10 * time.Millisecond
+
+	withFixtures(t, func(t *testing.T, client Client) {
+		ch := make(chan struct{})
+		go func() {
+			defer close(ch)
+			for i := 0; i < max; i++ {
+				err := client.CAS(ctx, key, func(in interface{}) (out interface{}, retry bool, err error) {
+					return fmt.Sprintf("%d", i), true, nil
+				})
+				require.NoError(t, err)
+				time.Sleep(sleep)
+			}
+		}()
+
+		observedValues := map[string]time.Time{}
+		ctx, cancel := context.WithTimeout(context.Background(), 1.5*max*sleep)
+		defer cancel()
+
+		client.WatchKey(ctx, key, func(i interface{}) bool {
+			observedValues[i.(string)] = time.Now()
+			return true
+		})
+
+		// wait until updater finishes (should be done by now)
+		<-ch
+
+		// We should have seen some values, observed at increasing times
+		count := 0
+		lastVal := ""
+		lastTime := time.Time{}
+		for i := 0; i < max; i++ {
+			val := fmt.Sprintf("%d", i)
+			ot, ok := observedValues[val]
+			if ok {
+				count++
+				if lastTime.After(ot) {
+					t.Errorf("value %s observed at %s, before previous value %s observed at %s", val, ot, lastVal, lastTime)
+				}
+			}
+		}
+
+		const expectedFactor = 0.9
+		if count < expectedFactor*max {
+			t.Errorf("expected at least %.0f%% observed values, got %.0f%% (observed count: %d)", 100*expectedFactor, 100*float64(count)/max, count)
+		}
+	})
+}
+
+func TestWatchPrefix(t *testing.T) {
+	withFixtures(t, func(t *testing.T, client Client) {
+		const prefix = "test/"
+		const max = 100
+		const sleep = time.Millisecond * 10
+
+		ch := make(chan struct{})
+		go func() {
+			defer close(ch)
+			for i := 0; i < max; i++ {
+				key := fmt.Sprintf("%s%d", prefix, i)
+				err := client.CAS(ctx, key, func(in interface{}) (out interface{}, retry bool, err error) {
+					return key, true, nil
+				})
+				require.NoError(t, err)
+				time.Sleep(sleep)
+			}
+		}()
+
+		observedKeys := map[string]int{}
+		ctx, cfn := context.WithTimeout(context.Background(), 1.5*max*sleep)
+		defer cfn()
+
+		client.WatchPrefix(ctx, prefix, func(key string, val interface{}) bool {
+			observedKeys[key] = observedKeys[key] + 1
+			return true
+		})
+
+		// wait until updater finishes (should be done by now)
+		<-ch
+
+		// verify that each key was reported once
+		for i := 0; i < max; i++ {
+			key := fmt.Sprintf("%s%d", prefix, i)
+
+			if observedKeys[key] != 1 {
+				t.Errorf("key %s has incorrect value %d", key, observedKeys[key])
+			}
+		}
 	})
 }


### PR DESCRIPTION
- Added tests for WatchKey and WatchKeyPrefix kv.Client methods.
- Removed backoff from Consul client when Consul reports no value for given key or prefix. Since Consul also reports index, next query blocks as expected, and no backoff is necessary. (Introduced by #560, see also next item)
- Fixed Get call in mockKV to block for non-existant key if WaitIndex > 0. This is how Consul works, and this inconsistency was primary reason for PR #560, which introduced backoff in such case instead (which then delays everything, especially tests). Added test for this.
- Changed WatchKeyPrefix in Consul client to not report values that were not modified. Consul returns them even if they haven't changed.
- Fixed mockKV to always start with Index 1. This in line with how Consul works and what our client expects. It treats returned index 0 as invalid value (per Hashicorps recommendations).
- Respect context deadline in mockKV.List function
- mockKV.List only returns values with supplied prefix now

Signed-off-by: Peter Štibraný <peter.stibrany@grafana.com>