### PR TITLE
Add back some logging on each request in query-frontend

### DIFF
--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -97,6 +97,7 @@ func (q roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	request.LogToSpan(r.Context())
 
 	userid, err := user.ExtractOrgID(r.Context())
 	if err != nil {


### PR DESCRIPTION
Seeing the individual request parameters is helpful to understand how what query-frontend has done.

Code was removed [here](https://github.com/cortexproject/cortex/pull/1437/files#diff-a3c5f793878e4a5ee5d4ebdbbf81a8c0L130) without explanation.

