### PR TITLE
Fix frontend CLI flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CHANGE] The frontend component has been refactored to be easier to re-use. When upgrading the frontend, cache entries will be discarded and re-created with the new protobuf schema. #1734
 * [CHANGE] Remove direct DB/API access from the ruler
 * [CHANGE] Removed `Delta` encoding. Any old chunks with `Delta` encoding cannot be read anymore. If `ingester.chunk-encoding` is set to `Delta` the ingester will fail to start. #1706
+* [CHANGE] Move frontend CLI flag from querier to frontend #1774
 * [FEATURE] Global limit on the max series per user and metric #1760
   * `-ingester.max-global-series-per-user`
   * `-ingester.max-global-series-per-metric`

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -61,8 +61,6 @@ The ingester query API was improved over time, but defaults to the old behaviour
 
    Time since the last sample after which a time series is considered stale and ignored by expression evaluations.
 
-## Query Frontend
-
 - `-querier.align-querier-with-step`
 
    If set to true, will cause the query frontend to mutate incoming queries and align their start and end parameters to the step parameter of the query.  This improves the cacheability of the query results.
@@ -86,6 +84,20 @@ The ingester query API was improved over time, but defaults to the old behaviour
 - `-redis.{endpoint, timeout}`
 
    Use these flags to specify the location and timeout of the Redis service used to cache query results.
+
+## Query Frontend
+
+- `-frontend.max-outstanding-requests-per-tenant`
+
+   Maximum number of outstanding requests per tenant per frontend; requests beyond this error with HTTP 429.
+
+- `-frontend.compress-http-responses`
+
+   If set to true, will cause the frontend to compress HTTP responses
+
+- `frontend.downstream-url`
+
+   URL of downstream Prometheus. This flag is used when you want to use frontend in front of standalone Prometheus to leverage the frontend features like - [queueing](https://github.com/cortexproject/cortex/blob/master/docs/architecture.md#queueing), [splitting](https://github.com/cortexproject/cortex/blob/master/docs/architecture.md#splitting), [caching](https://github.com/cortexproject/cortex/blob/master/docs/architecture.md#caching) and [parallelism](https://github.com/cortexproject/cortex/blob/master/docs/architecture.md#parallelism).
 
 ## Distributor
 

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -49,8 +49,8 @@ type Config struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.IntVar(&cfg.MaxOutstandingPerTenant, "querier.max-outstanding-requests-per-tenant", 100, "Maximum number of outstanding requests per tenant per frontend; requests beyond this error with HTTP 429.")
-	f.BoolVar(&cfg.CompressResponses, "querier.compress-http-responses", false, "Compress HTTP responses.")
+	f.IntVar(&cfg.MaxOutstandingPerTenant, "frontend.max-outstanding-requests-per-tenant", 100, "Maximum number of outstanding requests per tenant per frontend; requests beyond this error with HTTP 429.")
+	f.BoolVar(&cfg.CompressResponses, "frontend.compress-http-responses", false, "Compress HTTP responses.")
 	f.StringVar(&cfg.DownstreamURL, "frontend.downstream-url", "", "URL of downstream Prometheus.")
 }
 


### PR DESCRIPTION
Signed-off-by: Praveen Shukla <praveen.shukla.c42@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Move `max-outstanding-requests-per-tenant` and `compress-http-responses` CLI flags from `querier` to `frontend`.

**Which issue(s) this PR fixes**:
Fixes #1774 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated

cc @pracucci 