### PR TITLE
Export Unix timestamp of oldest unflushed chunk in the memory.

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -67,6 +67,10 @@ var (
 		Name: "cortex_ingester_dropped_chunks_total",
 		Help: "Total number of chunks dropped from flushing because they have too few samples.",
 	})
+	oldestUnflushedChunkTimestamp = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cortex_oldest_unflushed_chunk_timestamp",
+		Help: "Unix timestamp of the oldest unflushed chunk in the memory",
+	})
 )
 
 // Flush triggers a flush of all the chunks and closes the flush queues.
@@ -110,14 +114,23 @@ func (i *Ingester) sweepUsers(immediate bool) {
 		return
 	}
 
+	oldest := model.Time(0)
+
 	for id, state := range i.userStates.cp() {
 		for pair := range state.fpToSeries.iter() {
 			state.fpLocker.Lock(pair.fp)
 			i.sweepSeries(id, pair.fp, pair.series, immediate)
 			i.removeFlushedChunks(state, pair.fp, pair.series)
+			first := pair.series.firstUnflushedChunkTime()
 			state.fpLocker.Unlock(pair.fp)
+
+			if first > 0 && (oldest == 0 || first < oldest) {
+				oldest = first
+			}
 		}
 	}
+
+	oldestUnflushedChunkTimestamp.Set(float64(oldest.Unix()))
 }
 
 type flushReason int

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -68,7 +68,7 @@ var (
 		Help: "Total number of chunks dropped from flushing because they have too few samples.",
 	})
 	oldestUnflushedChunkTimestamp = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "cortex_oldest_unflushed_chunk_timestamp",
+		Name: "cortex_oldest_unflushed_chunk_timestamp_seconds",
 		Help: "Unix timestamp of the oldest unflushed chunk in the memory",
 	})
 )

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -155,10 +155,6 @@ func (s *memorySeries) firstTime() model.Time {
 // no chunks, or all chunks are flushed, returns 0.
 // The caller must have locked the fingerprint of the memorySeries.
 func (s *memorySeries) firstUnflushedChunkTime() model.Time {
-	if len(s.chunkDescs) == 0 {
-		return 0
-	}
-
 	for _, c := range s.chunkDescs {
 		if !c.flushed {
 			return c.FirstTime

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -151,6 +151,23 @@ func (s *memorySeries) firstTime() model.Time {
 	return s.chunkDescs[0].FirstTime
 }
 
+// Returns time of oldest chunk in the series, that isn't flushed. If there are
+// no chunks, or all chunks are flushed, returns 0.
+// The caller must have locked the fingerprint of the memorySeries.
+func (s *memorySeries) firstUnflushedChunkTime() model.Time {
+	if len(s.chunkDescs) == 0 {
+		return 0
+	}
+
+	for _, c := range s.chunkDescs {
+		if !c.flushed {
+			return c.FirstTime
+		}
+	}
+
+	return 0
+}
+
 // head returns a pointer to the head chunk descriptor. The caller must have
 // locked the fingerprint of the memorySeries. This method will panic if this
 // series has no chunk descriptors.


### PR DESCRIPTION
This PR implements a simple addition: export of timestamp of oldest unflushed chunk in memory. This can be used for alerting, if timestamp is older than expected.

Fixes #1386 
