### PR TITLE
Fix duplicated series when querying both ingesters and TSDB storage

### DIFF
--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -81,17 +81,14 @@ func (i *Ingester) v2Push(ctx old_ctx.Context, req *client.WriteRequest) (*clien
 	// Walk the samples, appending them to the users database
 	app := db.Appender()
 	for _, ts := range req.Timeseries {
+		// Convert labels to the type expected by TSDB
+		lset := cortex_tsdb.FromLabelAdaptersToLabels(ts.Labels)
+
 		for _, s := range ts.Samples {
 			if i.stopped {
 				return nil, fmt.Errorf("ingester stopping")
 			}
-			lset := make(lbls.Labels, len(ts.Labels))
-			for i := range ts.Labels {
-				lset[i] = lbls.Label{
-					Name:  ts.Labels[i].Name,
-					Value: ts.Labels[i].Value,
-				}
-			}
+
 			if _, err := app.Add(lset, s.TimestampMs, s.Value); err != nil {
 				if err := app.Rollback(); err != nil {
 					level.Warn(util.Logger).Log("failed to rollback on error", "userID", userID, "err", err)
@@ -274,13 +271,17 @@ func (i *Ingester) getOrCreateTSDB(userID string) (*tsdb.DB, error) {
 				return nil, err
 			}
 
-			// Create a new shipper for this database
+			// Thanos shipper requires at least 1 external label to be set. For this reason,
+			// we set the tenant ID as external label and we'll filter it out when reading
+			// the series from the storage.
 			l := lbls.Labels{
 				{
-					Name:  "user",
+					Name:  cortex_tsdb.TenantIDExternalLabel,
 					Value: userID,
 				},
 			}
+
+			// Create a new shipper for this database
 			s := shipper.New(util.Logger, nil, udir, &Bucket{userID, i.TSDBState.bucket}, func() lbls.Labels { return l }, metadata.ReceiveSource)
 			i.done.Add(1)
 			go func() {

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -89,9 +89,10 @@ func (b *BlockQuerier) Get(ctx context.Context, userID string, from, through mod
 
 	ctx = metadata.AppendToOutgoingContext(ctx, "user", userID)
 	seriesClient, err := client.Series(ctx, &storepb.SeriesRequest{
-		MinTime:  int64(from),
-		MaxTime:  int64(through),
-		Matchers: converted,
+		MinTime:                 int64(from),
+		MaxTime:                 int64(through),
+		Matchers:                converted,
+		PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 	})
 	if err != nil {
 		return nil, err
@@ -107,7 +108,6 @@ func (b *BlockQuerier) Get(ctx context.Context, userID string, from, through mod
 			return nil, err
 		}
 
-		// TODO(pracucci) resp.GetWarning() ?
 		chunks = append(chunks, seriesToChunks(userID, resp.GetSeries())...)
 	}
 

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -114,7 +114,6 @@ func (b *BlockQuerier) Get(ctx context.Context, userID string, from, through mod
 	return chunks, nil
 }
 
-// TODO(pracucci) with only 1 series, why is it called twice?
 func seriesToChunks(userID string, series *storepb.Series) []chunk.Chunk {
 	var lbls labels.Labels
 	for _, label := range series.Labels {

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -1,0 +1,99 @@
+package querier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+)
+
+func Test_seriesToChunks(t *testing.T) {
+	t.Parallel()
+
+	// Define a struct used to hold the expected chunk data we wanna assert on
+	type expectedChunk struct {
+		from    model.Time
+		through model.Time
+		metric  labels.Labels
+		samples []model.SamplePair
+	}
+
+	// Init some test fixtures
+	minTimestamp := time.Unix(1, 0)
+	maxTimestamp := time.Unix(10, 0)
+
+	tests := map[string]struct {
+		series         *storepb.Series
+		expectedChunks []expectedChunk
+	}{
+		"empty series": {
+			series:         &storepb.Series{},
+			expectedChunks: []expectedChunk{},
+		},
+		"should remove the external label added by the shipper": {
+			series: &storepb.Series{
+				Labels: []storepb.Label{
+					{Name: tsdb.TenantIDExternalLabel, Value: "test"},
+					{Name: "foo", Value: "bar"},
+				},
+				Chunks: []storepb.AggrChunk{
+					{MinTime: minTimestamp.Unix() * 1000, MaxTime: maxTimestamp.Unix() * 1000, Raw: &storepb.Chunk{Type: storepb.Chunk_XOR, Data: mockTSDBChunkData()}},
+				},
+			},
+			expectedChunks: []expectedChunk{
+				{
+					from:    model.TimeFromUnixNano(minTimestamp.UnixNano()),
+					through: model.TimeFromUnixNano(maxTimestamp.UnixNano()),
+					metric: labels.Labels{
+						{Name: "foo", Value: "bar"},
+					},
+					samples: []model.SamplePair{
+						{Timestamp: model.TimeFromUnixNano(time.Unix(1, 0).UnixNano()), Value: model.SampleValue(1)},
+						{Timestamp: model.TimeFromUnixNano(time.Unix(2, 0).UnixNano()), Value: model.SampleValue(2)},
+					},
+				},
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			actualChunks := seriesToChunks("test", testData.series)
+			require.Equal(t, len(testData.expectedChunks), len(actualChunks))
+
+			for i, actual := range actualChunks {
+				expected := testData.expectedChunks[i]
+
+				assert.Equal(t, "test", actual.UserID)
+				assert.Equal(t, expected.from, actual.From)
+				assert.Equal(t, expected.through, actual.Through)
+				assert.Equal(t, expected.metric, actual.Metric)
+
+				samples, err := actual.Samples(actual.From, actual.Through)
+				require.NoError(t, err)
+				assert.Equal(t, expected.samples, samples)
+			}
+		})
+	}
+}
+
+func mockTSDBChunkData() []byte {
+	chunk := chunkenc.NewXORChunk()
+	appender, err := chunk.Appender()
+	if err != nil {
+		panic(err)
+	}
+
+	appender.Append(time.Unix(1, 0).Unix()*1000, 1)
+	appender.Append(time.Unix(2, 0).Unix()*1000, 2)
+
+	return chunk.Bytes()
+}

--- a/pkg/storage/tsdb/labels.go
+++ b/pkg/storage/tsdb/labels.go
@@ -1,8 +1,6 @@
 package tsdb
 
 import (
-	"unsafe"
-
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/prometheus/prometheus/tsdb/labels"
 )
@@ -12,8 +10,16 @@ const (
 	TenantIDExternalLabel = "__org_id__"
 )
 
-// FromLabelAdaptersToLabels casts []LabelAdapter to TSDB labels.Labels.
-// It uses unsafe, but as LabelAdapter == labels.Label this should be safe.
+// FromLabelAdaptersToLabels converts []LabelAdapter to TSDB labels.Labels.
 func FromLabelAdaptersToLabels(input []client.LabelAdapter) labels.Labels {
-	return *(*labels.Labels)(unsafe.Pointer(&input))
+	result := make(labels.Labels, len(input))
+
+	for i, l := range input {
+		result[i] = labels.Label{
+			Name:  l.Name,
+			Value: l.Value,
+		}
+	}
+
+	return result
 }

--- a/pkg/storage/tsdb/labels.go
+++ b/pkg/storage/tsdb/labels.go
@@ -1,0 +1,19 @@
+package tsdb
+
+import (
+	"unsafe"
+
+	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/prometheus/prometheus/tsdb/labels"
+)
+
+const (
+	// TenantIDExternalLabel is the external label set when shipping blocks to the storage
+	TenantIDExternalLabel = "__org_id__"
+)
+
+// FromLabelAdaptersToLabels casts []LabelAdapter to TSDB labels.Labels.
+// It uses unsafe, but as LabelAdapter == labels.Label this should be safe.
+func FromLabelAdaptersToLabels(input []client.LabelAdapter) labels.Labels {
+	return *(*labels.Labels)(unsafe.Pointer(&input))
+}

--- a/pkg/storage/tsdb/labels_test.go
+++ b/pkg/storage/tsdb/labels_test.go
@@ -1,0 +1,23 @@
+package tsdb
+
+import (
+	"testing"
+
+	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/prometheus/prometheus/tsdb/labels"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_FromLabelAdaptersToLabels(t *testing.T) {
+	actual := FromLabelAdaptersToLabels([]client.LabelAdapter{
+		{Name: "app", Value: "test"},
+		{Name: "instance", Value: "i-1"},
+	})
+
+	expected := labels.Labels{
+		{Name: "app", Value: "test"},
+		{Name: "instance", Value: "i-1"},
+	}
+
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
**What this PR does**:
The current (experimental) TSDB integration has two issues related to the external label added by the shipper:

1. The label name is `"user"`, which can overlap with a metric label
2. The external label is not removed when querying the TSDB storage, thus leading to duplicated series: the series read from the storage have the `"user"` label, while the series read by ingesters don't

In this PR, I'm proposing to:
1. Rename `"user"` external label to `__org_id__` to avoid collisions
2. Remove the external label when querying the storage
3. Abort a TSDB query in case of partial response (we want full consistency)

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
