### PR TITLE
Fix chunk reading from ancient v3 schema

### DIFF
--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -288,7 +288,9 @@ func (c *Chunk) Decode(decodeContext *DecodeContext, input []byte) error {
 	if err != nil {
 		return errors.Wrap(err, "when decoding chunk metadata")
 	}
-	if len(input)-r.Len() != int(metadataLen) {
+	metadataRead := len(input) - r.Len()
+	// Older versions of Cortex included the initial length word; newer versions do not.
+	if !(metadataRead == int(metadataLen) || metadataRead == int(metadataLen)+4) {
 		return ErrMetadataLength
 	}
 

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -13,6 +13,7 @@ import (
 )
 
 var (
+	chunkTimeRangeKeyV1a = []byte{1}
 	chunkTimeRangeKeyV1  = []byte{'1'}
 	chunkTimeRangeKeyV2  = []byte{'2'}
 	chunkTimeRangeKeyV3  = []byte{'3'}

--- a/pkg/chunk/schema_util.go
+++ b/pkg/chunk/schema_util.go
@@ -187,6 +187,9 @@ func parseChunkTimeRangeValue(rangeValue []byte, value []byte) (
 
 	// v3 schema had four components - label name, label value, chunk ID and version.
 	// "version" is 1 and label value is base64 encoded.
+	// (older code wrote "version" as 1, not '1')
+	case bytes.Equal(components[3], chunkTimeRangeKeyV1a):
+		fallthrough
 	case bytes.Equal(components[3], chunkTimeRangeKeyV1):
 		chunkID = string(components[2])
 		labelValue, err = decodeBase64Value(components[1])


### PR DESCRIPTION
Empirically, from data stored at Weaveworks, the code used a different version marker and a different size calculation.

Allow that data to be read without affecting chunks written more recently.
