### PR TITLE
Improve doc for max series per user/metric global limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [FEATURE] Global limit on the max series per user and metric #1760
   * `-ingester.max-global-series-per-user`
   * `-ingester.max-global-series-per-metric`
+  * Requires `-distributor.replication-factor` and `-distributor.shard-by-all-labels` set for the ingesters too
 * [FEATURE] Flush chunks with stale markers early with `ingester.max-stale-chunk-idle`. #1759
 * [FEATURE] EXPERIMENTAL: Added new KV Store backend based on memberlist library. Components can gossip about tokens and ingester states, instead of using Consul or Etcd. #1721
 * [ENHANCEMENT] Allocation improvements in adding samples to Chunk. #1706

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -314,6 +314,13 @@ Valid fields are (with their corresponding flags for default values):
 
   An active series is a series to which a sample has been written in the last `-ingester.max-chunk-idle` duration, which defaults to 5 minutes.
 
+- `max_global_series_per_user` / `-ingester.max-global-series-per-user`
+- `max_global_series_per_metric` / `-ingester.max-global-series-per-metric`
+
+   Like `max_series_per_user` and `max_series_per_metric`, but the limit is enforced across the cluster. Each ingester is configured with a local limit based on the replication factor, the `-distributor.shard-by-all-labels` setting and the current number of healthy ingesters, and is kept updated whenever the number of ingesters change.
+
+   Requires `-distributor.replication-factor` and `-distributor.shard-by-all-labels` set for the ingesters too.
+
 - `max_series_per_query` / `-ingester.max-series-per-query`
 - `max_samples_per_query` / `-ingester.max-samples-per-query`
 


### PR DESCRIPTION
**What this PR does**:

The PR #1760 (merged) introduced a global limit on the max series per user/metric, without updating the documentation. This PR does it.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated
