### PR TITLE
Refactor: change index key markers from slice to single byte

### DIFF
--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -163,10 +163,11 @@ func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
 		} else {
 			// Return error if duplicate write and not metric name entry or series entry
 			itemComponents := decodeRangeKey(items[i].rangeValue)
-			if !bytes.Equal(itemComponents[3], metricNameRangeKeyV1) &&
-				!bytes.Equal(itemComponents[3], seriesRangeKeyV1) &&
-				!bytes.Equal(itemComponents[3], labelNamesRangeKeyV1) &&
-				!bytes.Equal(itemComponents[3], labelSeriesRangeKeyV1) {
+			keyType := itemComponents[3][0]
+			if keyType != metricNameRangeKeyV1 &&
+				keyType != seriesRangeKeyV1 &&
+				keyType != labelNamesRangeKeyV1 &&
+				keyType != labelSeriesRangeKeyV1 {
 				return fmt.Errorf("Dupe write")
 			}
 		}

--- a/pkg/chunk/schema_test.go
+++ b/pkg/chunk/schema_test.go
@@ -147,32 +147,33 @@ func parseRangeValueType(rangeValue []byte) (int, error) {
 		return ChunkTimeRangeValue, nil
 
 	// chunk time range values
-	case bytes.Equal(components[3], chunkTimeRangeKeyV1):
-		return ChunkTimeRangeValue, nil
+	case len(components[3]) == 1:
+		switch components[3][0] {
+		case chunkTimeRangeKeyV1:
+			return ChunkTimeRangeValue, nil
 
-	case bytes.Equal(components[3], chunkTimeRangeKeyV2):
-		return ChunkTimeRangeValue, nil
+		case chunkTimeRangeKeyV2:
+			return ChunkTimeRangeValue, nil
 
-	case bytes.Equal(components[3], chunkTimeRangeKeyV3):
-		return ChunkTimeRangeValue, nil
+		case chunkTimeRangeKeyV3:
+			return ChunkTimeRangeValue, nil
 
-	case bytes.Equal(components[3], chunkTimeRangeKeyV4):
-		return ChunkTimeRangeValue, nil
+		case chunkTimeRangeKeyV4:
+			return ChunkTimeRangeValue, nil
 
-	case bytes.Equal(components[3], chunkTimeRangeKeyV5):
-		return ChunkTimeRangeValue, nil
+		case chunkTimeRangeKeyV5:
+			return ChunkTimeRangeValue, nil
 
-	// metric name range values
-	case bytes.Equal(components[3], metricNameRangeKeyV1):
-		return MetricNameRangeValue, nil
+		// metric name range values
+		case metricNameRangeKeyV1:
+			return MetricNameRangeValue, nil
 
-	// series range values
-	case bytes.Equal(components[3], seriesRangeKeyV1):
-		return SeriesRangeValue, nil
-
-	default:
-		return 0, fmt.Errorf("unrecognised range value type. version: %q", string(components[3]))
+		// series range values
+		case seriesRangeKeyV1:
+			return SeriesRangeValue, nil
+		}
 	}
+	return 0, fmt.Errorf("unrecognised range value type. version: %q", string(components[3]))
 }
 
 func TestSchemaRangeKey(t *testing.T) {

--- a/pkg/chunk/schema_util.go
+++ b/pkg/chunk/schema_util.go
@@ -1,7 +1,6 @@
 package chunk
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
@@ -58,17 +57,29 @@ func sha256bytes(s string) []byte {
 	return encodeBase64Bytes(h[:])
 }
 
-func encodeRangeKey(ss ...[]byte) []byte {
-	length := 0
+// Build an index key, encoded as multiple parts separated by a 0 byte, with extra space at the end.
+func buildRangeValue(extra int, ss ...[]byte) []byte {
+	length := extra
 	for _, s := range ss {
 		length += len(s) + 1
 	}
 	output, i := make([]byte, length, length), 0
 	for _, s := range ss {
-		copy(output[i:i+len(s)], s)
-		i += len(s) + 1
+		i += copy(output[i:], s) + 1
 	}
 	return output
+}
+
+// Encode a complete key including type marker (which goes at the end)
+func encodeRangeKey(keyType byte, ss ...[]byte) []byte {
+	output := buildRangeValue(2, ss...)
+	output[len(output)-2] = keyType
+	return output
+}
+
+// Prefix values are used in querying the database, e.g. find all the records with a specific label value
+func rangeValuePrefix(ss ...[]byte) []byte {
+	return buildRangeValue(0, ss...)
 }
 
 func decodeRangeKey(value []byte) [][]byte {
@@ -135,7 +146,7 @@ func parseMetricNameRangeValue(rangeValue []byte, value []byte) (model.LabelValu
 		return "", fmt.Errorf("invalid metric name range value: %x", rangeValue)
 
 	// v1 has the metric name as the value (with the hash as the first component)
-	case bytes.Equal(components[3], metricNameRangeKeyV1):
+	case len(components[3]) == 1 && components[3][0] == metricNameRangeKeyV1:
 		return model.LabelValue(value), nil
 
 	default:
@@ -152,7 +163,7 @@ func parseSeriesRangeValue(rangeValue []byte, value []byte) (model.Metric, error
 		return nil, fmt.Errorf("invalid metric range value: %x", rangeValue)
 
 	// v1 has the encoded json metric as the value (with the fingerprint as the first component)
-	case bytes.Equal(components[3], seriesRangeKeyV1):
+	case len(components[3]) == 1 && components[3][0] == seriesRangeKeyV1:
 		var series model.Metric
 		if err := json.Unmarshal(value, &series); err != nil {
 			return nil, err
@@ -183,54 +194,53 @@ func parseChunkTimeRangeValue(rangeValue []byte, value []byte) (
 		labelValue = model.LabelValue(components[1])
 		return
 
-	// v3 schema had four components - label name, label value, chunk ID and version.
-	// "version" is 1 and label value is base64 encoded.
-	// (older code wrote "version" as 1, not '1')
-	case bytes.Equal(components[3], chunkTimeRangeKeyV1a):
-		fallthrough
-	case bytes.Equal(components[3], chunkTimeRangeKeyV1):
-		chunkID = string(components[2])
-		labelValue, err = decodeBase64Value(components[1])
-		return
+	case len(components[3]) == 1:
+		switch components[3][0] {
+		// v3 schema had four components - label name, label value, chunk ID and version.
+		// "version" is 1 and label value is base64 encoded.
+		// (older code wrote "version" as 1, not '1')
+		case chunkTimeRangeKeyV1a, chunkTimeRangeKeyV1:
+			chunkID = string(components[2])
+			labelValue, err = decodeBase64Value(components[1])
+			return
 
-	// v4 schema wrote v3 range keys and a new range key - version 2,
-	// with four components - <empty>, <empty>, chunk ID and version.
-	case bytes.Equal(components[3], chunkTimeRangeKeyV2):
-		chunkID = string(components[2])
-		return
+		// v4 schema wrote v3 range keys and a new range key - version 2,
+		// with four components - <empty>, <empty>, chunk ID and version.
+		case chunkTimeRangeKeyV2:
+			chunkID = string(components[2])
+			return
 
-	// v5 schema version 3 range key is chunk end time, <empty>, chunk ID, version
-	case bytes.Equal(components[3], chunkTimeRangeKeyV3):
-		chunkID = string(components[2])
-		return
+		// v5 schema version 3 range key is chunk end time, <empty>, chunk ID, version
+		case chunkTimeRangeKeyV3:
+			chunkID = string(components[2])
+			return
 
-	// v5 schema version 4 range key is chunk end time, label value, chunk ID, version
-	case bytes.Equal(components[3], chunkTimeRangeKeyV4):
-		chunkID = string(components[2])
-		labelValue, err = decodeBase64Value(components[1])
-		return
+		// v5 schema version 4 range key is chunk end time, label value, chunk ID, version
+		case chunkTimeRangeKeyV4:
+			chunkID = string(components[2])
+			labelValue, err = decodeBase64Value(components[1])
+			return
 
-	// v6 schema added version 5 range keys, which have the label value written in
-	// to the value, not the range key. So they are [chunk end time, <empty>, chunk ID, version].
-	case bytes.Equal(components[3], chunkTimeRangeKeyV5):
-		chunkID = string(components[2])
-		labelValue = model.LabelValue(value)
-		return
+		// v6 schema added version 5 range keys, which have the label value written in
+		// to the value, not the range key. So they are [chunk end time, <empty>, chunk ID, version].
+		case chunkTimeRangeKeyV5:
+			chunkID = string(components[2])
+			labelValue = model.LabelValue(value)
+			return
 
-	// v9 schema actually return series IDs
-	case bytes.Equal(components[3], seriesRangeKeyV1):
-		chunkID = string(components[0])
-		isSeriesID = true
-		return
+		// v9 schema actually return series IDs
+		case seriesRangeKeyV1:
+			chunkID = string(components[0])
+			isSeriesID = true
+			return
 
-	case bytes.Equal(components[3], labelSeriesRangeKeyV1):
-		chunkID = string(components[1])
-		labelValue = model.LabelValue(value)
-		isSeriesID = true
-		return
-
-	default:
-		err = fmt.Errorf("unrecognised chunkTimeRangeKey version: %q", string(components[3]))
-		return
+		case labelSeriesRangeKeyV1:
+			chunkID = string(components[1])
+			labelValue = model.LabelValue(value)
+			isSeriesID = true
+			return
+		}
 	}
+	err = fmt.Errorf("unrecognised chunkTimeRangeKey version: %q", string(components[3]))
+	return
 }

--- a/pkg/chunk/schema_util_test.go
+++ b/pkg/chunk/schema_util_test.go
@@ -108,7 +108,7 @@ func TestParseMetricNameRangeValue(t *testing.T) {
 		// version 1 (id 6) metric name range keys (used in v7 Schema) have
 		// metric name hash in first 'dimension', however just returns the value
 		{[]byte("a1b2c3d4\x00\x00\x006\x00"), "foo", "foo"},
-		{encodeRangeKey([]byte("bar"), nil, nil, metricNameRangeKeyV1), "bar", "bar"},
+		{encodeRangeKey(metricNameRangeKeyV1, []byte("bar"), nil, nil), "bar", "bar"},
 	} {
 		metricName, err := parseMetricNameRangeValue(c.encoded, []byte(c.value))
 		require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestParseSeriesRangeValue(t *testing.T) {
 		value     []byte
 		expMetric model.Metric
 	}{
-		{encodeRangeKey(fingerprintBytes, nil, nil, seriesRangeKeyV1), metricBytes, metric},
+		{encodeRangeKey(seriesRangeKeyV1, fingerprintBytes, nil, nil), metricBytes, metric},
 	} {
 		metric, err := parseSeriesRangeValue(c.encoded, c.value)
 		require.NoError(t, err)


### PR DESCRIPTION
I was concerned that `parseChunkTimeRangeValue()` is getting slower and slower as it linear-searches the choices with the newest ones at the end.

This is more idiomatic Go and more efficient because it doesn't have to loop over the slice.
