### PR TITLE
Improve reporting of some chunk errors

### DIFF
--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -291,7 +291,7 @@ func (c *Chunk) Decode(decodeContext *DecodeContext, input []byte) error {
 	metadataRead := len(input) - r.Len()
 	// Older versions of Cortex included the initial length word; newer versions do not.
 	if !(metadataRead == int(metadataLen) || metadataRead == int(metadataLen)+4) {
-		return ErrMetadataLength
+		return errors.Wrapf(ErrMetadataLength, "expected %d, got %d", metadataLen, metadataRead)
 	}
 
 	// Next, confirm the chunks matches what we expected.  Easiest way to do this

--- a/pkg/chunk/schema_test.go
+++ b/pkg/chunk/schema_test.go
@@ -171,7 +171,7 @@ func parseRangeValueType(rangeValue []byte) (int, error) {
 		return SeriesRangeValue, nil
 
 	default:
-		return 0, fmt.Errorf("unrecognised range value type. version: '%v'", string(components[3]))
+		return 0, fmt.Errorf("unrecognised range value type. version: %q", string(components[3]))
 	}
 }
 

--- a/pkg/chunk/schema_util.go
+++ b/pkg/chunk/schema_util.go
@@ -139,7 +139,7 @@ func parseMetricNameRangeValue(rangeValue []byte, value []byte) (model.LabelValu
 		return model.LabelValue(value), nil
 
 	default:
-		return "", fmt.Errorf("unrecognised metricNameRangeKey version: '%v'", string(components[3]))
+		return "", fmt.Errorf("unrecognised metricNameRangeKey version: %q", string(components[3]))
 	}
 }
 
@@ -160,7 +160,7 @@ func parseSeriesRangeValue(rangeValue []byte, value []byte) (model.Metric, error
 		return series, nil
 
 	default:
-		return nil, fmt.Errorf("unrecognised seriesRangeKey version: '%v'", string(components[3]))
+		return nil, fmt.Errorf("unrecognised seriesRangeKey version: %q", string(components[3]))
 	}
 }
 
@@ -232,7 +232,7 @@ func parseChunkTimeRangeValue(rangeValue []byte, value []byte) (
 		return
 
 	default:
-		err = fmt.Errorf("unrecognised chunkTimeRangeKey version: '%v'", string(components[3]))
+		err = fmt.Errorf("unrecognised chunkTimeRangeKey version: %q", string(components[3]))
 		return
 	}
 }


### PR DESCRIPTION
I felt the need for this when working on #1779.
`%q` is better than `'%v'` because it will show unprintable characters as escape sequences.
