### PR TITLE
Don't return 500's for KV CAS calls if the CAS returned an HTTP status code.

### DIFF
--- a/pkg/ring/kv/metrics.go
+++ b/pkg/ring/kv/metrics.go
@@ -2,8 +2,10 @@ package kv
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/instrument"
 )
 
@@ -16,6 +18,17 @@ var requestDuration = instrument.NewHistogramCollector(prometheus.NewHistogramVe
 
 func init() {
 	requestDuration.Register()
+}
+
+// errorCode converts an error into an HTTP status code, modified from weaveworks/common/instrument
+func errorCode(err error) string {
+	if err == nil {
+		return "200"
+	}
+	if resp, ok := httpgrpc.HTTPResponseFromError(err); ok {
+		return strconv.Itoa(int(resp.GetCode()))
+	}
+	return "500"
 }
 
 type metrics struct {
@@ -33,7 +46,7 @@ func (m metrics) Get(ctx context.Context, key string) (interface{}, error) {
 }
 
 func (m metrics) CAS(ctx context.Context, key string, f func(in interface{}) (out interface{}, retry bool, err error)) error {
-	return instrument.CollectedRequest(ctx, "CAS", requestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+	return instrument.CollectedRequest(ctx, "CAS", requestDuration, errorCode, func(ctx context.Context) error {
 		return m.c.CAS(ctx, key, f)
 	})
 }


### PR DESCRIPTION
CAS calls to the KV store can return HTTP status codes since the addition of the HA tracking code. 

If the return error of the CAS has an HTTP status code, we should return that. This will resolve the issue of the KV metrics showing 500's for all writes from the non-elected Prometheus replicas.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

@tomwilkie 

