### PR TITLE
Use session.NewSession in order to use AssumeRoleWithWebIdentity

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -861,5 +861,5 @@ func awsSessionFromURL(awsURL *url.URL) (client.ConfigProvider, error) {
 		return nil, err
 	}
 	config = config.WithMaxRetries(0) // We do our own retries, so we can monitor them
-	return session.New(config), nil
+	return session.NewSession(config)
 }

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -51,7 +51,11 @@ func NewS3ObjectClient(cfg StorageConfig, schemaCfg chunk.SchemaConfig) (chunk.O
 	s3Config = s3Config.WithS3ForcePathStyle(cfg.S3ForcePathStyle) // support for Path Style S3 url if has the flag
 
 	s3Config = s3Config.WithMaxRetries(0) // We do our own retries, so we can monitor them
-	s3Client := s3.New(session.New(s3Config))
+	sess, err := session.NewSession(s3Config)
+	if err != nil {
+		return nil, err
+	}
+	s3Client := s3.New(sess)
 	bucketNames := []string{strings.TrimPrefix(cfg.S3.URL.Path, "/")}
 	if cfg.BucketNames != "" {
 		bucketNames = strings.Split(cfg.BucketNames, ",") // comma separated list of bucket names


### PR DESCRIPTION
This PR replaces the deprecated session.New with session.NewSession which will enable support for using IAM roles for service accounts in AWS EKS

Fixes #1797, https://github.com/grafana/loki/issues/1241
