### PR TITLE
Fixed TSDB shipper GCS cli flags registration

### DIFF
--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -37,6 +37,7 @@ type Config struct {
 // RegisterFlags registers the TSDB flags
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.S3.RegisterFlags(f)
+	cfg.GCS.RegisterFlags(f)
 
 	f.StringVar(&cfg.Dir, "experimental.tsdb.dir", "tsdb", "directory to place all TSDB's into")
 	f.StringVar(&cfg.SyncDir, "experimental.tsdb.sync-dir", "tsdb-sync", "directory to place synced tsdb indicies")


### PR DESCRIPTION
**What this PR does**:
In the PR #1772 I've introduced GCS config support to TSDB shipper, but I've forgot to register the cli flags (the config was working via yaml, but not flags). In this PR I'm fixing it.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
