### PR TITLE
Removed support for writing denormalised tokens in the ring.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [FEATURE] The distributor can now drop labels from samples (similar to the removal of the replica label for HA ingestion) per user via the `distributor.drop-label` flag. #1726
 * [FEATURE] Added `global` ingestion rate limiter strategy. Deprecated `-distributor.limiter-reload-period` flag. #1766
 * [BUGFIX] Fixed unnecessary CAS operations done by the HA tracker when the jitter is enabled. #1861
+* [CHANGE] Ingesters now write only normalised tokens to the ring, although they can still read denormalised tokens used by other ingesters. `-ingester.normalise-tokens` is now deprecated, and ignored.
 
 ## 0.4.0 / 2019-12-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [FEATURE] The distributor can now drop labels from samples (similar to the removal of the replica label for HA ingestion) per user via the `distributor.drop-label` flag. #1726
 * [FEATURE] Added `global` ingestion rate limiter strategy. Deprecated `-distributor.limiter-reload-period` flag. #1766
 * [BUGFIX] Fixed unnecessary CAS operations done by the HA tracker when the jitter is enabled. #1861
-* [CHANGE] Ingesters now write only normalised tokens to the ring, although they can still read denormalised tokens used by other ingesters. `-ingester.normalise-tokens` is now deprecated, and ignored. #1809
+* [CHANGE] Ingesters now write only normalised tokens to the ring, although they can still read denormalised tokens used by other ingesters. `-ingester.normalise-tokens` is now deprecated, and ignored. If you want to switch back to using denormalised tokens, you need to downgrade to Cortex 0.4.0. Previous versions don't handle claiming tokens from normalised ingesters correctly. #1809
 
 ## 0.4.0 / 2019-12-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [FEATURE] The distributor can now drop labels from samples (similar to the removal of the replica label for HA ingestion) per user via the `distributor.drop-label` flag. #1726
 * [FEATURE] Added `global` ingestion rate limiter strategy. Deprecated `-distributor.limiter-reload-period` flag. #1766
 * [BUGFIX] Fixed unnecessary CAS operations done by the HA tracker when the jitter is enabled. #1861
-* [CHANGE] Ingesters now write only normalised tokens to the ring, although they can still read denormalised tokens used by other ingesters. `-ingester.normalise-tokens` is now deprecated, and ignored.
+* [CHANGE] Ingesters now write only normalised tokens to the ring, although they can still read denormalised tokens used by other ingesters. `-ingester.normalise-tokens` is now deprecated, and ignored. #1809
 
 ## 0.4.0 / 2019-12-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@
   * `ruler.poll-interval` has been added to specify the interval in which to poll new rule groups.
 * [CHANGE] Use relative links from /ring page to make it work when used behind reverse proxy. #1896
 * [CHANGE] Deprecated `-distributor.limiter-reload-period` flag. #1766
+* [CHANGE] Ingesters now write only normalised tokens to the ring, although they can still read denormalised tokens used by other ingesters. `-ingester.normalise-tokens` is now deprecated, and ignored. If you want to switch back to using denormalised tokens, you need to downgrade to Cortex 0.4.0. Previous versions don't handle claiming tokens from normalised ingesters correctly. #1809
 * [FEATURE] The distributor can now drop labels from samples (similar to the removal of the replica label for HA ingestion) per user via the `distributor.drop-label` flag. #1726
 * [FEATURE] Added `global` ingestion rate limiter strategy. Deprecated `-distributor.limiter-reload-period` flag. #1766
 * [BUGFIX] Fixed unnecessary CAS operations done by the HA tracker when the jitter is enabled. #1861
-* [CHANGE] Ingesters now write only normalised tokens to the ring, although they can still read denormalised tokens used by other ingesters. `-ingester.normalise-tokens` is now deprecated, and ignored. If you want to switch back to using denormalised tokens, you need to downgrade to Cortex 0.4.0. Previous versions don't handle claiming tokens from normalised ingesters correctly. #1809
 
 ## 0.4.0 / 2019-12-02
 

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -244,7 +244,9 @@ It also talks to a KVStore and has it's own copies of the same flags used by the
 
    Deprecated. New ingesters always write "normalised" tokens to the ring. Normalised tokens consume less memory to encode and decode; as the ring is unmarshalled regularly, this significantly reduces memory usage of anything that watches the ring.
 
-   Cortex 0.4.0 is the last version that can use denormalised tokens. It's perfectly OK to have mix of ingesters running denormalised (<= 0.4.0) and normalised tokens (either by using `-ingester.normalise-tokens` in Cortex <= 0.4.0, or Cortex 0.5.0+). 
+   Cortex 0.4.0 is the last version that can *write* denormalised tokens. Cortex 0.5.0 and later will always *write* normalised tokens, although it can still *read* denormalised tokens written by older ingesters.
+   
+   It's perfectly OK to have a mix of ingesters running denormalised (<= 0.4.0) and normalised tokens (either by using `-ingester.normalise-tokens` in Cortex <= 0.4.0, or Cortex 0.5.0+) during upgrades. 
 
 - `-ingester.chunk-encoding`
 

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -242,9 +242,9 @@ It also talks to a KVStore and has it's own copies of the same flags used by the
 
 - `-ingester.normalise-tokens`
 
-   Write out "normalised" tokens to the ring.  Normalised tokens consume less memory to encode and decode; as the ring is unmarshalled regularly, this significantly reduces memory usage of anything that watches the ring.
+   Deprecated. New ingesters always write "normalised" tokens to the ring. Normalised tokens consume less memory to encode and decode; as the ring is unmarshalled regularly, this significantly reduces memory usage of anything that watches the ring.
 
-   Before enabling, rollout a version of Cortex that supports normalised token for all jobs that interact with the ring, then rollout with this flag set to `true` on the ingesters.  The new ring code can still read and write the old ring format, so is backwards compatible.
+   Cortex 0.4.0 is the last version that can use denormalised tokens. It's perfectly OK to have mix of ingesters running denormalised (<= 0.4.0) and normalised tokens (either by using `-ingester.normalise-tokens` in Cortex <= 0.4.0, or Cortex 0.5.0+). 
 
 - `-ingester.chunk-encoding`
 

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -50,7 +50,7 @@ type LifecyclerConfig struct {
 	JoinAfter        time.Duration `yaml:"join_after,omitempty"`
 	MinReadyDuration time.Duration `yaml:"min_ready_duration,omitempty"`
 	UnusedFlag       bool          `yaml:"claim_on_rollout,omitempty"` // DEPRECATED - left for backwards-compatibility
-	NormaliseTokens  bool          `yaml:"normalise_tokens,omitempty"`
+	UnusedFlag2      bool          `yaml:"normalise_tokens,omitempty"` // DEPRECATED - left for backwards-compatibility
 	InfNames         []string      `yaml:"interface_names"`
 	FinalSleep       time.Duration `yaml:"final_sleep"`
 	TokensFilePath   string        `yaml:"tokens_file_path,omitempty"`
@@ -83,7 +83,7 @@ func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.Flag
 	f.DurationVar(&cfg.ObservePeriod, prefix+"observe-period", 0*time.Second, "Observe tokens after generating to resolve collisions. Useful when using gossiping ring.")
 	f.DurationVar(&cfg.MinReadyDuration, prefix+"min-ready-duration", 1*time.Minute, "Minimum duration to wait before becoming ready. This is to work around race conditions with ingesters exiting and updating the ring.")
 	flagext.DeprecatedFlag(f, prefix+"claim-on-rollout", "DEPRECATED. This feature is no longer optional.")
-	f.BoolVar(&cfg.NormaliseTokens, prefix+"normalise-tokens", false, "Store tokens in a normalised fashion to reduce allocations.")
+	flagext.DeprecatedFlag(f, prefix+"normalise-tokens", "DEPRECATED. This feature is no longer optional")
 	f.DurationVar(&cfg.FinalSleep, prefix+"final-sleep", 30*time.Second, "Duration to sleep for before exiting, to ensure metrics are scraped.")
 	f.StringVar(&cfg.TokensFilePath, prefix+"tokens-file-path", "", "File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.")
 
@@ -287,7 +287,7 @@ func (i *Lifecycler) ClaimTokensFor(ctx context.Context, ingesterID string) erro
 				return nil, false, fmt.Errorf("Cannot claim tokens in an empty ring")
 			}
 
-			tokens = ringDesc.ClaimTokens(ingesterID, i.ID, i.cfg.NormaliseTokens)
+			tokens = ringDesc.ClaimTokens(ingesterID, i.ID)
 			// update timestamp to give gossiping client a chance register ring change.
 			ing := ringDesc.Ingesters[i.ID]
 			ing.Timestamp = time.Now().Unix()
@@ -484,14 +484,14 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 				if len(tokensFromFile) >= i.cfg.NumTokens {
 					i.setState(ACTIVE)
 				}
-				ringDesc.AddIngester(i.ID, i.Addr, tokensFromFile, i.GetState(), i.cfg.NormaliseTokens)
+				ringDesc.AddIngester(i.ID, i.Addr, tokensFromFile, i.GetState())
 				i.setTokens(tokensFromFile)
 				return ringDesc, true, nil
 			}
 
 			// Either we are a new ingester, or consul must have restarted
 			level.Info(util.Logger).Log("msg", "instance not found in ring, adding with no tokens", "ring", i.RingName)
-			ringDesc.AddIngester(i.ID, i.Addr, []uint32{}, i.GetState(), i.cfg.NormaliseTokens)
+			ringDesc.AddIngester(i.ID, i.Addr, []uint32{}, i.GetState())
 			return ringDesc, true, nil
 		}
 
@@ -540,7 +540,7 @@ func (i *Lifecycler) verifyTokens(ctx context.Context) bool {
 			ringTokens = append(ringTokens, newTokens...)
 			sort.Sort(ringTokens)
 
-			ringDesc.AddIngester(i.ID, i.Addr, ringTokens, i.GetState(), i.cfg.NormaliseTokens)
+			ringDesc.AddIngester(i.ID, i.Addr, ringTokens, i.GetState())
 
 			i.setTokens(ringTokens)
 
@@ -597,7 +597,7 @@ func (i *Lifecycler) autoJoin(ctx context.Context, targetState IngesterState) er
 
 		newTokens := GenerateTokens(i.cfg.NumTokens-len(myTokens), takenTokens)
 		i.setState(targetState)
-		ringDesc.AddIngester(i.ID, i.Addr, newTokens, i.GetState(), i.cfg.NormaliseTokens)
+		ringDesc.AddIngester(i.ID, i.Addr, newTokens, i.GetState())
 
 		myTokens = append(myTokens, newTokens...)
 		sort.Sort(myTokens)
@@ -630,7 +630,7 @@ func (i *Lifecycler) updateConsul(ctx context.Context) error {
 		if !ok {
 			// consul must have restarted
 			level.Info(util.Logger).Log("msg", "found empty ring, inserting tokens", "ring", i.RingName)
-			ringDesc.AddIngester(i.ID, i.Addr, i.getTokens(), i.GetState(), i.cfg.NormaliseTokens)
+			ringDesc.AddIngester(i.ID, i.Addr, i.getTokens(), i.GetState())
 		} else {
 			ingesterDesc.Timestamp = time.Now().Unix()
 			ingesterDesc.State = i.GetState()

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -83,7 +83,7 @@ func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.Flag
 	f.DurationVar(&cfg.ObservePeriod, prefix+"observe-period", 0*time.Second, "Observe tokens after generating to resolve collisions. Useful when using gossiping ring.")
 	f.DurationVar(&cfg.MinReadyDuration, prefix+"min-ready-duration", 1*time.Minute, "Minimum duration to wait before becoming ready. This is to work around race conditions with ingesters exiting and updating the ring.")
 	flagext.DeprecatedFlag(f, prefix+"claim-on-rollout", "DEPRECATED. This feature is no longer optional.")
-	flagext.DeprecatedFlag(f, prefix+"normalise-tokens", "DEPRECATED. This feature is no longer optional")
+	flagext.DeprecatedFlag(f, prefix+"normalise-tokens", "DEPRECATED. This feature is no longer optional.")
 	f.DurationVar(&cfg.FinalSleep, prefix+"final-sleep", 30*time.Second, "Duration to sleep for before exiting, to ensure metrics are scraped.")
 	f.StringVar(&cfg.TokensFilePath, prefix+"tokens-file-path", "", "File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.")
 

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -597,11 +597,12 @@ func (i *Lifecycler) autoJoin(ctx context.Context, targetState IngesterState) er
 
 		newTokens := GenerateTokens(i.cfg.NumTokens-len(myTokens), takenTokens)
 		i.setState(targetState)
-		ringDesc.AddIngester(i.ID, i.Addr, newTokens, i.GetState())
 
 		myTokens = append(myTokens, newTokens...)
 		sort.Sort(myTokens)
 		i.setTokens(myTokens)
+
+		ringDesc.AddIngester(i.ID, i.Addr, i.getTokens(), i.GetState())
 
 		return ringDesc, true, nil
 	})

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -49,8 +49,6 @@ type LifecyclerConfig struct {
 	ObservePeriod    time.Duration `yaml:"observe_period,omitempty"`
 	JoinAfter        time.Duration `yaml:"join_after,omitempty"`
 	MinReadyDuration time.Duration `yaml:"min_ready_duration,omitempty"`
-	UnusedFlag       bool          `yaml:"claim_on_rollout,omitempty"` // DEPRECATED - left for backwards-compatibility
-	UnusedFlag2      bool          `yaml:"normalise_tokens,omitempty"` // DEPRECATED - left for backwards-compatibility
 	InfNames         []string      `yaml:"interface_names"`
 	FinalSleep       time.Duration `yaml:"final_sleep"`
 	TokensFilePath   string        `yaml:"tokens_file_path,omitempty"`
@@ -60,6 +58,10 @@ type LifecyclerConfig struct {
 	Port           int
 	ID             string
 	SkipUnregister bool
+
+	// graveyard for unused flags.
+	UnusedFlag  bool `yaml:"claim_on_rollout,omitempty"` // DEPRECATED - left for backwards-compatibility
+	UnusedFlag2 bool `yaml:"normalise_tokens,omitempty"` // DEPRECATED - left for backwards-compatibility
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -35,7 +35,8 @@ func NewDesc() *Desc {
 	}
 }
 
-// AddIngester adds the given ingester to the ring.
+// AddIngester adds the given ingester to the ring. Ingester will only use supplied tokens,
+// any other tokens are removed.
 func (d *Desc) AddIngester(id, addr string, tokens []uint32, state IngesterState) {
 	if d.Ingesters == nil {
 		d.Ingesters = map[string]IngesterDesc{}

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -48,8 +48,9 @@ func (d *Desc) AddIngester(id, addr string, tokens []uint32, state IngesterState
 		Tokens:    tokens,
 	}
 
-	// delete any reference from d.Tokens (can happen if denormalized tokens for this ingester
-	// were found in the ring when joining)
+	// Since this ingester is only using normalised tokens, let's delete any denormalised
+	// tokens for this ingester. There may be such tokens eg. if previous instance
+	// of the same ingester was running with denormalized tokens.
 	for ix := 0; ix < len(d.Tokens); {
 		if d.Tokens[ix].Ingester == id {
 			d.Tokens = append(d.Tokens[:ix], d.Tokens[ix+1:]...)

--- a/pkg/ring/model_test.go
+++ b/pkg/ring/model_test.go
@@ -94,48 +94,18 @@ func normalizedOutput() *Desc {
 	}
 }
 
-func unnormalizedOutput() *Desc {
-	return &Desc{
-		Ingesters: map[string]IngesterDesc{
-			"first":  {},
-			"second": {},
-		},
-		Tokens: []TokenDesc{
-			{Token: 100, Ingester: "second"},
-			{Token: 200, Ingester: "second"},
-			{Token: 300, Ingester: "second"},
-		},
-	}
-}
-
 func TestClaimTokensFromNormalizedToNormalized(t *testing.T) {
 	r := normalizedSource()
-	result := r.ClaimTokens("first", "second", true)
+	result := r.ClaimTokens("first", "second")
 
 	assert.Equal(t, Tokens{100, 200, 300}, result)
 	assert.Equal(t, normalizedOutput(), r)
 }
 
-func TestClaimTokensFromNormalizedToUnnormalized(t *testing.T) {
-	r := normalizedSource()
-	result := r.ClaimTokens("first", "second", false)
-
-	assert.Equal(t, Tokens{100, 200, 300}, result)
-	assert.Equal(t, unnormalizedOutput(), r)
-}
-
-func TestClaimTokensFromUnnormalizedToUnnormalized(t *testing.T) {
-	r := unnormalizedSource()
-	result := r.ClaimTokens("first", "second", false)
-
-	assert.Equal(t, Tokens{100, 200, 300}, result)
-	assert.Equal(t, unnormalizedOutput(), r)
-}
-
 func TestClaimTokensFromUnnormalizedToNormalized(t *testing.T) {
 	r := unnormalizedSource()
 
-	result := r.ClaimTokens("first", "second", true)
+	result := r.ClaimTokens("first", "second")
 
 	assert.Equal(t, Tokens{100, 200, 300}, result)
 	assert.Equal(t, normalizedOutput(), r)

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -123,16 +123,15 @@ func TestAddIngester(t *testing.T) {
 func TestAddIngesterReplacesExistingTokens(t *testing.T) {
 	r := NewDesc()
 
-	const (
-		ing1Name = "ing1"
-	)
+	const ing1Name = "ing1"
 
-	newTokens := GenerateTokens(128, nil)
+	oldTokens := []uint32{11111, 22222, 33333}
+	// old tokens will be replaced
+	for _, t := range oldTokens {
+		r.Tokens = append(r.Tokens, TokenDesc{Token: t, Ingester: ing1Name})
+	}
 
-	// previous tokens for ingester1 will be replaced
-	r.Tokens = append(r.Tokens, TokenDesc{Token: 11111, Ingester: ing1Name})
-	r.Tokens = append(r.Tokens, TokenDesc{Token: 22222, Ingester: ing1Name})
-	r.Tokens = append(r.Tokens, TokenDesc{Token: 33333, Ingester: ing1Name})
+	newTokens := GenerateTokens(128, oldTokens)
 
 	r.AddIngester(ing1Name, "addr", newTokens, ACTIVE)
 

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -88,3 +88,34 @@ func TestDoBatchZeroIngesters(t *testing.T) {
 	}
 	require.Error(t, DoBatch(ctx, &r, keys, callback, cleanup))
 }
+
+func TestAddIngester(t *testing.T) {
+	r := NewDesc()
+
+	ing1 := GenerateTokens(128, nil)
+	ing2 := GenerateTokens(128, ing1)
+
+	for _, t := range ing1 {
+		r.Tokens = append(r.Tokens, TokenDesc{
+			Token:    t,
+			Ingester: "test",
+		})
+	}
+
+	for _, t := range ing2 {
+		r.Tokens = append(r.Tokens, TokenDesc{
+			Token:    t,
+			Ingester: "Ingester2",
+		})
+	}
+
+	r.AddIngester("test", "addr", ing1, ACTIVE)
+
+	require.Equal(t, "addr", r.Ingesters["test"].Addr)
+	require.Equal(t, ing1, r.Ingesters["test"].Tokens)
+
+	require.Equal(t, len(ing2), len(r.Tokens))
+	for _, tok := range r.Tokens {
+		require.NotEqual(t, "test", tok.Ingester)
+	}
+}

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -35,7 +35,7 @@ func benchmarkBatch(b *testing.B, numIngester, numKeys int) {
 	for i := 0; i < numIngester; i++ {
 		tokens := GenerateTokens(numTokens, takenTokens)
 		takenTokens = append(takenTokens, tokens...)
-		desc.AddIngester(fmt.Sprintf("%d", i), fmt.Sprintf("ingester%d", i), tokens, ACTIVE, false)
+		desc.AddIngester(fmt.Sprintf("%d", i), fmt.Sprintf("ingester%d", i), tokens, ACTIVE)
 	}
 
 	cfg := Config{}

--- a/pkg/ring/testutils/testutils.go
+++ b/pkg/ring/testutils/testutils.go
@@ -18,10 +18,11 @@ func NumTokens(c kv.Client, name, ringKey string) int {
 		return 0
 	}
 	count := 0
-	for _, token := range ringDesc.(*ring.Desc).Tokens {
+	rd := ringDesc.(*ring.Desc)
+	for _, token := range rd.Tokens {
 		if token.Ingester == name {
 			count++
 		}
 	}
-	return count
+	return count + len(rd.Ingesters[name].Tokens)
 }


### PR DESCRIPTION
Removed support for writing denormalised tokens in the ring.

Still supported:
- claiming tokens from another ingester, that is using denormalised tokens
- finding denormalised tokens in the ring, when joining

Other ingesters can still use denormalised tokens, migrateRing takes care of that.

Targeted for Cortex 0.5.0. ~No changelog written yet.~

Issue #1787
Fixes #1877 