### PR TITLE
use tempdir when xfering tsdb

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -3,8 +3,11 @@ package ingester
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"math"
+	"math/rand"
 	"net/http"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"sync"
@@ -571,4 +574,22 @@ func BenchmarkIngesterPush(b *testing.B) {
 		})
 	}
 
+}
+
+func TestRemoveEmptyDir(t *testing.T) {
+
+	// remove dir that dne
+	require.NoError(t, removeEmptyDir(fmt.Sprintf("%v", rand.Int63())))
+
+	// remove empty dir
+	dir, err := ioutil.TempDir("", "TestRemoveEmptyDir")
+	require.NoError(t, err)
+	require.NoError(t, removeEmptyDir(dir))
+
+	// remove non-empty dir
+	dir, err = ioutil.TempDir("", "TestRemoveEmptyDir")
+	require.NoError(t, err)
+
+	ioutil.WriteFile(filepath.Join(dir, "tempfile"), []byte("hello world"), 0777)
+	require.NotNil(t, removeEmptyDir(dir))
 }

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -1,9 +1,12 @@
 package ingester
 
 import (
+	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -419,10 +422,8 @@ func TestV2IngesterTransfer(t *testing.T) {
 	limits, err := validation.NewOverrides(defaultLimitsTestConfig())
 	require.NoError(t, err)
 
-	dir1, err := ioutil.TempDir("", "tsdb")
-	require.NoError(t, err)
-	dir2, err := ioutil.TempDir("", "tsdb")
-	require.NoError(t, err)
+	dir1 := filepath.Join(os.TempDir(), fmt.Sprintf("TestV2IngesterTransfer-%v", rand.Int63()))
+	dir2 := filepath.Join(os.TempDir(), fmt.Sprintf("TestV2IngesterTransfer-%v", rand.Int63()))
 
 	// Start the first ingester, and get it into ACTIVE state.
 	cfg1 := defaultIngesterTestConfig()


### PR DESCRIPTION
Signed-off-by: Thor <thansen@digitalocean.com>

Uses a temp directory when writing a transfer, to avoid corruptions errors. Will use a different temp dir during each xfer retry. 
