### PR TITLE
Ingester Push improvements

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -303,23 +303,24 @@ func TestIngesterAppendOutOfOrderAndDuplicate(t *testing.T) {
 	m := labelPairs{
 		{Name: model.MetricNameLabel, Value: "testmetric"},
 	}
-	ctx := context.Background()
-	err := ing.append(ctx, userID, m, 1, 0, client.API)
+	state := ing.userStates.getOrCreate(userID)
+	require.NotNil(t, state)
+	err := ing.append(state, m, 1, 0, client.API)
 	require.NoError(t, err)
 
 	// Two times exactly the same sample (noop).
-	err = ing.append(ctx, userID, m, 1, 0, client.API)
+	err = ing.append(state, m, 1, 0, client.API)
 	require.NoError(t, err)
 
 	// Earlier sample than previous one.
-	err = ing.append(ctx, userID, m, 0, 0, client.API)
+	err = ing.append(state, m, 0, 0, client.API)
 	require.Contains(t, err.Error(), "sample timestamp out of order")
 	errResp, ok := httpgrpc.HTTPResponseFromError(err)
 	require.True(t, ok)
 	require.Equal(t, errResp.Code, int32(400))
 
 	// Same timestamp as previous sample, but different value.
-	err = ing.append(ctx, userID, m, 1, 1, client.API)
+	err = ing.append(state, m, 1, 1, client.API)
 	require.Contains(t, err.Error(), "sample with repeated timestamp but different value")
 	errResp, ok = httpgrpc.HTTPResponseFromError(err)
 	require.True(t, ok)
@@ -337,7 +338,9 @@ func TestIngesterAppendBlankLabel(t *testing.T) {
 		{Name: "bar", Value: ""},
 	}
 	ctx := user.InjectOrgID(context.Background(), userID)
-	err := ing.append(ctx, userID, lp, 1, 0, client.API)
+	state := ing.userStates.getOrCreate(userID)
+	require.NotNil(t, state)
+	err := ing.append(state, lp, 1, 0, client.API)
 	require.NoError(t, err)
 
 	res, _, err := runTestQuery(ctx, t, ing, labels.MatchEqual, labels.MetricName, "testmetric")

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -310,21 +310,18 @@ func TestIngesterAppendOutOfOrderAndDuplicate(t *testing.T) {
 
 	// Two times exactly the same sample (noop).
 	err = ing.append(state, m, 1, 0, client.API)
-	require.NoError(t, err)
+	require.Error(t, err)
+	mse, ok := err.(*memorySeriesError)
+	require.True(t, ok)
+	require.True(t, mse.noReport)
 
 	// Earlier sample than previous one.
 	err = ing.append(state, m, 0, 0, client.API)
 	require.Contains(t, err.Error(), "sample timestamp out of order")
-	errResp, ok := httpgrpc.HTTPResponseFromError(err)
-	require.True(t, ok)
-	require.Equal(t, errResp.Code, int32(400))
 
 	// Same timestamp as previous sample, but different value.
 	err = ing.append(state, m, 1, 1, client.API)
 	require.Contains(t, err.Error(), "sample with repeated timestamp but different value")
-	errResp, ok = httpgrpc.HTTPResponseFromError(err)
-	require.True(t, ok)
-	require.Equal(t, errResp.Code, int32(400))
 }
 
 // Test that blank labels are removed by the ingester

--- a/pkg/ingester/rate.go
+++ b/pkg/ingester/rate.go
@@ -51,3 +51,8 @@ func (r *ewmaRate) tick() {
 func (r *ewmaRate) inc() {
 	atomic.AddInt64(&r.newEvents, 1)
 }
+
+// inc counts n events.
+func (r *ewmaRate) add(n int) {
+	atomic.AddInt64(&r.newEvents, int64(n))
+}

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -123,17 +123,7 @@ func (us *userStates) get(userID string) (*userState, bool) {
 	return state.(*userState), ok
 }
 
-func (us *userStates) getViaContext(ctx context.Context) (*userState, bool, error) {
-	userID, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return nil, false, fmt.Errorf("no user id")
-	}
-	state, ok := us.get(userID)
-	return state, ok, nil
-}
-
-func (us *userStates) getOrCreateSeries(ctx context.Context, userID string, labels []client.LabelAdapter) (*userState, model.Fingerprint, *memorySeries, error) {
-
+func (us *userStates) getOrCreate(userID string) *userState {
 	state, ok := us.get(userID)
 	if !ok {
 
@@ -169,6 +159,20 @@ func (us *userStates) getOrCreateSeries(ctx context.Context, userID string, labe
 		state = stored.(*userState)
 	}
 
+	return state
+}
+
+func (us *userStates) getViaContext(ctx context.Context) (*userState, bool, error) {
+	userID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("no user id")
+	}
+	state, ok := us.get(userID)
+	return state, ok, nil
+}
+
+func (us *userStates) getOrCreateSeries(ctx context.Context, userID string, labels []client.LabelAdapter) (*userState, model.Fingerprint, *memorySeries, error) {
+	state := us.getOrCreate(userID)
 	fp, series, err := state.getSeries(labels)
 	return state, fp, series, err
 }

--- a/pkg/old.txt
+++ b/pkg/old.txt
@@ -1,0 +1,8 @@
+goos: linux
+goarch: amd64
+pkg: github.com/cortexproject/cortex/pkg/ingester
+BenchmarkIngesterPush/encoding=DoubleDelta-8         	      72	  15219779 ns/op	 2782735 B/op	   12143 allocs/op
+BenchmarkIngesterPush/encoding=Varbit-8              	      69	  14814287 ns/op	 2778139 B/op	   12140 allocs/op
+BenchmarkIngesterPush/encoding=Bigchunk-8            	      79	  14791709 ns/op	 2764114 B/op	   12139 allocs/op
+PASS
+ok  	github.com/cortexproject/cortex/pkg/ingester	3.349s


### PR DESCRIPTION
Found some (small) possible optimization while debugging the WAL code. Reuse of some objects created in `ingester.append` by creating them in `ingester.Push` and passing them on has some improvements in push time (no changes in allocs or B/op). Along with that, updating metrics only once for `Push` call instead of in each `append` call.
```
benchmark                                        old ns/op     new ns/op     delta
BenchmarkIngesterPush/encoding=DoubleDelta-8     15628904      14997580      -4.04%
BenchmarkIngesterPush/encoding=Varbit-8          15608147      14949577      -4.22%
BenchmarkIngesterPush/encoding=Bigchunk-8        15625913      15132356      -3.16%
```
If the readability if getting bad with this change, we can only reuse the user state for now.