### PR TITLE
Fixes ARM build with const overflow.

### DIFF
--- a/pkg/ring/kv/memberlist/memberlist_client.go
+++ b/pkg/ring/kv/memberlist/memberlist_client.go
@@ -616,7 +616,7 @@ func (m *Client) LocalState(join bool) []byte {
 			level.Error(util.Logger).Log("msg", "key too long", "key", key)
 			continue
 		}
-		if len(val.value) > math.MaxUint32 {
+		if uint(len(val.value)) > math.MaxUint32 {
 			level.Error(util.Logger).Log("msg", "value too long", "key", key, "value_length", len(val.value))
 			continue
 		}


### PR DESCRIPTION
Since #1727  ARM build fails with an error:

```
# github.com/cortexproject/cortex/pkg/ring/kv/memberlist
--
130 | vendor/github.com/cortexproject/cortex/pkg/ring/kv/memberlist/memberlist_client.go:619:21: constant 4294967295 overflows int
```

see https://github.com/grpc/grpc-go/pull/1471, it seems that this is cause by missing int conversion with MaxUint32.

I also run all tests `GOARCH=386 make test` all good now.
