### PR TITLE
Add /series support to TSDB storage

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -565,6 +565,10 @@ func (i *Ingester) LabelNames(ctx old_ctx.Context, req *client.LabelNamesRequest
 
 // MetricsForLabelMatchers returns all the metrics which match a set of matchers.
 func (i *Ingester) MetricsForLabelMatchers(ctx old_ctx.Context, req *client.MetricsForLabelMatchersRequest) (*client.MetricsForLabelMatchersResponse, error) {
+	if i.cfg.TSDBEnabled {
+		return i.v2MetricsForLabelMatchers(ctx, req)
+	}
+
 	i.userStatesMtx.RLock()
 	defer i.userStatesMtx.RUnlock()
 	state, ok, err := i.userStates.getViaContext(ctx)

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb"
 	lbls "github.com/prometheus/prometheus/tsdb/labels"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -162,29 +161,12 @@ func (i *Ingester) v2Query(ctx old_ctx.Context, req *client.QueryRequest) (*clie
 	}
 	defer q.Close()
 
-	// two different versions of the labels package are being used, converting matchers must be done
-	var converted []lbls.Matcher
-	for _, m := range matchers {
-		switch m.Type {
-		case labels.MatchEqual:
-			converted = append(converted, lbls.NewEqualMatcher(m.Name, m.Value))
-		case labels.MatchNotEqual:
-			converted = append(converted, lbls.Not(lbls.NewEqualMatcher(m.Name, m.Value)))
-		case labels.MatchRegexp:
-			rm, err := lbls.NewRegexpMatcher(m.Name, "^(?:"+m.Value+")$")
-			if err != nil {
-				return nil, err
-			}
-			converted = append(converted, rm)
-		case labels.MatchNotRegexp:
-			rm, err := lbls.NewRegexpMatcher(m.Name, "^(?:"+m.Value+")$")
-			if err != nil {
-				return nil, err
-			}
-			converted = append(converted, lbls.Not(rm))
-		}
+	convertedMatchers, err := cortex_tsdb.FromLegacyLabelMatchersToMatchers(matchers)
+	if err != nil {
+		return nil, err
 	}
-	ss, err := q.Select(converted...)
+
+	ss, err := q.Select(convertedMatchers...)
 	if err != nil {
 		return nil, err
 	}
@@ -193,13 +175,8 @@ func (i *Ingester) v2Query(ctx old_ctx.Context, req *client.QueryRequest) (*clie
 	for ss.Next() {
 		series := ss.At()
 
-		// convert labels to LabelAdapter
-		var adapters []client.LabelAdapter
-		for _, l := range series.Labels() {
-			adapters = append(adapters, client.LabelAdapter(l))
-		}
 		ts := client.TimeSeries{
-			Labels: adapters,
+			Labels: cortex_tsdb.FromLabelsToLabelAdapters(series.Labels()),
 		}
 
 		it := series.Iterator()
@@ -270,6 +247,68 @@ func (i *Ingester) v2LabelNames(ctx old_ctx.Context, req *client.LabelNamesReque
 	return &client.LabelNamesResponse{
 		LabelNames: names,
 	}, nil
+}
+
+func (i *Ingester) v2MetricsForLabelMatchers(ctx old_ctx.Context, req *client.MetricsForLabelMatchersRequest) (*client.MetricsForLabelMatchersResponse, error) {
+	fmt.Println("v2MetricsForLabelMatchers() req.StartTimestampMs:", req.StartTimestampMs, "req.EndTimestampMs:", req.EndTimestampMs)
+	userID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	db := i.getTSDB(userID)
+	if db == nil {
+		return &client.MetricsForLabelMatchersResponse{}, nil
+	}
+
+	// Parse the request
+	from, through, matchersSet, err := client.FromMetricsForLabelMatchersRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new instance of the TSDB querier
+	q, err := db.Querier(from.Unix()*1000, through.Unix()*1000)
+	if err != nil {
+		return nil, err
+	}
+	defer q.Close()
+
+	// Run a query for each matchers set and collect all the results
+	result := &client.MetricsForLabelMatchersResponse{
+		Metric: make([]*client.Metric, 0),
+	}
+
+	for _, matchers := range matchersSet {
+		convertedMatchers, err := cortex_tsdb.FromLegacyLabelMatchersToMatchers(matchers)
+		if err != nil {
+			return nil, err
+		}
+
+		seriesSet, err := q.Select(convertedMatchers...)
+		if err != nil {
+			return nil, err
+		}
+
+		for seriesSet.Next() {
+			// TODO(pracucci): test the error case
+			if seriesSet.Err() != nil {
+				break
+			}
+
+			result.Metric = append(result.Metric, &client.Metric{
+				Labels: cortex_tsdb.FromLabelsToLabelAdapters(seriesSet.At().Labels()),
+			})
+		}
+
+		// In case of any error while iterating the series, we break
+		// the execution and return it
+		if err := seriesSet.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
 }
 
 func (i *Ingester) getTSDB(userID string) *tsdb.DB {

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -268,7 +268,7 @@ func (i *Ingester) v2MetricsForLabelMatchers(ctx old_ctx.Context, req *client.Me
 	}
 
 	// Create a new instance of the TSDB querier
-	q, err := db.Querier(from.Unix()*1000, to.Unix()*1000)
+	q, err := db.Querier(int64(from), int64(to))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -389,6 +389,155 @@ func Test_Ingester_v2Query(t *testing.T) {
 	}
 }
 
+func Test_Ingester_v2MetricsForLabelMatchers(t *testing.T) {
+	fixtures := []struct {
+		lbls      labels.Labels
+		value     float64
+		timestamp int64
+	}{
+		{labels.Labels{{Name: labels.MetricName, Value: "test_1"}, {Name: "status", Value: "200"}}, 1, 100000},
+		{labels.Labels{{Name: labels.MetricName, Value: "test_1"}, {Name: "status", Value: "500"}}, 1, 110000},
+		{labels.Labels{{Name: labels.MetricName, Value: "test_2"}}, 2, 200000},
+		// The two following series have the same FastFingerprint=e002a3a451262627
+		{labels.Labels{{Name: labels.MetricName, Value: "collision"}, {Name: "app", Value: "l"}, {Name: "uniq0", Value: "0"}, {Name: "uniq1", Value: "1"}}, 1, 300000},
+		{labels.Labels{{Name: labels.MetricName, Value: "collision"}, {Name: "app", Value: "m"}, {Name: "uniq0", Value: "1"}, {Name: "uniq1", Value: "1"}}, 1, 300000},
+	}
+
+	tests := map[string]struct {
+		from     int64
+		to       int64
+		matchers []*client.LabelMatchers
+		expected []*client.Metric
+	}{
+		"should return an empty response if no metric match": {
+			from: math.MinInt64,
+			to:   math.MaxInt64,
+			matchers: []*client.LabelMatchers{{
+				Matchers: []*client.LabelMatcher{
+					{Type: client.EQUAL, Name: model.MetricNameLabel, Value: "unknown"},
+				},
+			}},
+			expected: []*client.Metric{},
+		},
+		"should filter metrics by single matcher": {
+			from: math.MinInt64,
+			to:   math.MaxInt64,
+			matchers: []*client.LabelMatchers{{
+				Matchers: []*client.LabelMatcher{
+					{Type: client.EQUAL, Name: model.MetricNameLabel, Value: "test_1"},
+				},
+			}},
+			expected: []*client.Metric{
+				{Labels: client.FromLabelsToLabelAdapters(fixtures[0].lbls)},
+				{Labels: client.FromLabelsToLabelAdapters(fixtures[1].lbls)},
+			},
+		},
+		"should filter metrics by multiple matchers": {
+			from: math.MinInt64,
+			to:   math.MaxInt64,
+			matchers: []*client.LabelMatchers{
+				{
+					Matchers: []*client.LabelMatcher{
+						{Type: client.EQUAL, Name: "status", Value: "200"},
+					},
+				},
+				{
+					Matchers: []*client.LabelMatcher{
+						{Type: client.EQUAL, Name: model.MetricNameLabel, Value: "test_2"},
+					},
+				},
+			},
+			expected: []*client.Metric{
+				{Labels: client.FromLabelsToLabelAdapters(fixtures[0].lbls)},
+				{Labels: client.FromLabelsToLabelAdapters(fixtures[2].lbls)},
+			},
+		},
+		"should filter metrics by time range": {
+			from: 100000,
+			to:   100000,
+			matchers: []*client.LabelMatchers{{
+				Matchers: []*client.LabelMatcher{
+					{Type: client.EQUAL, Name: model.MetricNameLabel, Value: "test_1"},
+				},
+			}},
+			expected: []*client.Metric{
+				{Labels: client.FromLabelsToLabelAdapters(fixtures[0].lbls)},
+			},
+		},
+		"should not return duplicated metrics on overlapping matchers": {
+			from: math.MinInt64,
+			to:   math.MaxInt64,
+			matchers: []*client.LabelMatchers{
+				{
+					Matchers: []*client.LabelMatcher{
+						{Type: client.EQUAL, Name: model.MetricNameLabel, Value: "test_1"},
+					},
+				},
+				{
+					Matchers: []*client.LabelMatcher{
+						{Type: client.REGEX_MATCH, Name: model.MetricNameLabel, Value: "test.*"},
+					},
+				},
+			},
+			expected: []*client.Metric{
+				{Labels: client.FromLabelsToLabelAdapters(fixtures[0].lbls)},
+				{Labels: client.FromLabelsToLabelAdapters(fixtures[1].lbls)},
+				{Labels: client.FromLabelsToLabelAdapters(fixtures[2].lbls)},
+			},
+		},
+		"should return all matching metrics even if their FastFingerprint collide": {
+			from: math.MinInt64,
+			to:   math.MaxInt64,
+			matchers: []*client.LabelMatchers{{
+				Matchers: []*client.LabelMatcher{
+					{Type: client.EQUAL, Name: model.MetricNameLabel, Value: "collision"},
+				},
+			}},
+			expected: []*client.Metric{
+				{Labels: client.FromLabelsToLabelAdapters(fixtures[3].lbls)},
+				{Labels: client.FromLabelsToLabelAdapters(fixtures[4].lbls)},
+			},
+		},
+	}
+
+	// Create ingester
+	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
+	require.NoError(t, err)
+	defer i.Shutdown()
+	defer cleanup()
+
+	// Wait until it's ACTIVE
+	test.Poll(t, 1*time.Second, ring.ACTIVE, func() interface{} {
+		return i.lifecycler.GetState()
+	})
+
+	// Push fixtures
+	ctx := user.InjectOrgID(context.Background(), "test")
+
+	for _, series := range fixtures {
+		req, _ := mockWriteRequest(series.lbls, series.value, series.timestamp)
+		_, err := i.v2Push(ctx, req)
+		require.NoError(t, err)
+	}
+
+	// Run tests
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			req := &client.MetricsForLabelMatchersRequest{
+				StartTimestampMs: testData.from,
+				EndTimestampMs:   testData.to,
+				MatchersSet:      testData.matchers,
+			}
+
+			res, err := i.v2MetricsForLabelMatchers(ctx, req)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, testData.expected, res.Metric)
+		})
+	}
+}
+
 func mockWriteRequest(lbls labels.Labels, value float64, timestampMs int64) (*client.WriteRequest, *client.QueryResponse) {
 	samples := []client.Sample{
 		{

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -109,32 +109,9 @@ func TestIngesterTransfer(t *testing.T) {
 	})
 
 	// Now write a sample to this ingester
-	const ts = 123000
-	const val = 456
-	var (
-		l          = labels.Labels{{Name: labels.MetricName, Value: "foo"}}
-		sampleData = []client.Sample{
-			{
-				TimestampMs: ts,
-				Value:       val,
-			},
-		}
-		expectedResponse = &client.QueryResponse{
-			Timeseries: []client.TimeSeries{
-				{
-					Labels: client.FromLabelsToLabelAdapters(l),
-					Samples: []client.Sample{
-						{
-							Value:       val,
-							TimestampMs: ts,
-						},
-					},
-				},
-			},
-		}
-	)
+	req, expectedResponse := mockWriteRequest(labels.Labels{{Name: labels.MetricName, Value: "foo"}}, 456, 123000)
 	ctx := user.InjectOrgID(context.Background(), userID)
-	_, err = ing1.Push(ctx, client.ToWriteRequest([]labels.Labels{l}, sampleData, client.API))
+	_, err = ing1.Push(ctx, req)
 	require.NoError(t, err)
 
 	// Start a second ingester, but let it go into PENDING
@@ -171,7 +148,8 @@ func TestIngesterTransfer(t *testing.T) {
 	assert.Equal(t, expectedResponse, response)
 
 	// Check we can send the same sample again to the new ingester and get the same result
-	_, err = ing2.Push(ctx, client.ToWriteRequest([]labels.Labels{l}, sampleData, client.API))
+	req, _ = mockWriteRequest(labels.Labels{{Name: labels.MetricName, Value: "foo"}}, 456, 123000)
+	_, err = ing2.Push(ctx, req)
 	require.NoError(t, err)
 	response, err = ing2.Query(ctx, request)
 	require.NoError(t, err)
@@ -448,32 +426,9 @@ func TestV2IngesterTransfer(t *testing.T) {
 	})
 
 	// Now write a sample to this ingester
-	const ts = 123000
-	const val = 456
-	var (
-		l          = labels.Labels{{Name: labels.MetricName, Value: "foo"}}
-		sampleData = []client.Sample{
-			{
-				TimestampMs: ts,
-				Value:       val,
-			},
-		}
-		expectedResponse = &client.QueryResponse{
-			Timeseries: []client.TimeSeries{
-				{
-					Labels: client.FromLabelsToLabelAdapters(l),
-					Samples: []client.Sample{
-						{
-							Value:       val,
-							TimestampMs: ts,
-						},
-					},
-				},
-			},
-		}
-	)
+	req, expectedResponse := mockWriteRequest(labels.Labels{{Name: labels.MetricName, Value: "foo"}}, 456, 123000)
 	ctx := user.InjectOrgID(context.Background(), userID)
-	_, err = ing1.Push(ctx, client.ToWriteRequest([]labels.Labels{l}, sampleData, client.API))
+	_, err = ing1.Push(ctx, req)
 	require.NoError(t, err)
 
 	// Start a second ingester, but let it go into PENDING
@@ -518,7 +473,8 @@ func TestV2IngesterTransfer(t *testing.T) {
 	assert.Equal(t, expectedResponse, response)
 
 	// Check we can send the same sample again to the new ingester and get the same result
-	_, err = ing2.Push(ctx, client.ToWriteRequest([]labels.Labels{l}, sampleData, client.API))
+	req, _ = mockWriteRequest(labels.Labels{{Name: labels.MetricName, Value: "foo"}}, 456, 123000)
+	_, err = ing2.Push(ctx, req)
 	require.NoError(t, err)
 	response, err = ing2.Query(ctx, request)
 	require.NoError(t, err)

--- a/pkg/storage/tsdb/labels.go
+++ b/pkg/storage/tsdb/labels.go
@@ -14,6 +14,8 @@ const (
 )
 
 // FromLabelAdaptersToLabels converts []LabelAdapter to TSDB labels.Labels.
+// Do NOT use unsafe to convert between data types because this function may
+// get in input labels whose data structure is reused.
 func FromLabelAdaptersToLabels(input []client.LabelAdapter) labels.Labels {
 	result := make(labels.Labels, len(input))
 
@@ -28,14 +30,9 @@ func FromLabelAdaptersToLabels(input []client.LabelAdapter) labels.Labels {
 }
 
 // FromLabelsToLabelAdapters converts TSDB labels.labels to []LabelAdapter.
-func FromLabelsToLabelAdapters(labels labels.Labels) []client.LabelAdapter {
-	adapters := make([]client.LabelAdapter, 0, len(labels))
-
-	for _, label := range labels {
-		adapters = append(adapters, client.LabelAdapter(label))
-	}
-
-	return adapters
+// It uses unsafe, but as both struct are identical this should be safe.
+func FromLabelsToLabelAdapters(input labels.Labels) []client.LabelAdapter {
+	return *(*([]client.LabelAdapter))(unsafe.Pointer(&input))
 }
 
 // FromLabelsToLegacyLabels casts TSDB labels.Labels to legacy labels.Labels.

--- a/pkg/storage/tsdb/labels.go
+++ b/pkg/storage/tsdb/labels.go
@@ -1,6 +1,8 @@
 package tsdb
 
 import (
+	"unsafe"
+
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	legacy_labels "github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/labels"
@@ -34,6 +36,12 @@ func FromLabelsToLabelAdapters(labels labels.Labels) []client.LabelAdapter {
 	}
 
 	return adapters
+}
+
+// FromLabelsToLegacyLabels casts TSDB labels.Labels to legacy labels.Labels.
+// It uses unsafe, but as both struct are identical this should be safe.
+func FromLabelsToLegacyLabels(input labels.Labels) legacy_labels.Labels {
+	return *(*legacy_labels.Labels)(unsafe.Pointer(&input))
 }
 
 // FromLegacyLabelMatchersToMatchers converts legacy matchers to TSDB label matchers.

--- a/pkg/storage/tsdb/labels.go
+++ b/pkg/storage/tsdb/labels.go
@@ -25,7 +25,7 @@ func FromLabelAdaptersToLabels(input []client.LabelAdapter) labels.Labels {
 	return result
 }
 
-// TODO(pracucci) doc
+// FromLabelsToLabelAdapters converts TSDB labels.labels to []LabelAdapter.
 func FromLabelsToLabelAdapters(labels labels.Labels) []client.LabelAdapter {
 	adapters := make([]client.LabelAdapter, 0, len(labels))
 
@@ -36,9 +36,9 @@ func FromLabelsToLabelAdapters(labels labels.Labels) []client.LabelAdapter {
 	return adapters
 }
 
-// TODO(pracucci) doc
+// FromLegacyLabelMatchersToMatchers converts legacy matchers to TSDB label matchers.
 func FromLegacyLabelMatchersToMatchers(matchers []*legacy_labels.Matcher) ([]labels.Matcher, error) {
-	var converted []labels.Matcher
+	converted := make([]labels.Matcher, 0, len(matchers))
 
 	for _, m := range matchers {
 		switch m.Type {

--- a/pkg/storage/tsdb/labels_test.go
+++ b/pkg/storage/tsdb/labels_test.go
@@ -1,14 +1,19 @@
 package tsdb
 
 import (
+	"regexp/syntax"
 	"testing"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
+	legacy_labels "github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/labels"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_FromLabelAdaptersToLabels(t *testing.T) {
+	t.Parallel()
+
 	actual := FromLabelAdaptersToLabels([]client.LabelAdapter{
 		{Name: "app", Value: "test"},
 		{Name: "instance", Value: "i-1"},
@@ -20,4 +25,68 @@ func Test_FromLabelAdaptersToLabels(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, actual)
+}
+
+func Test_FromLabelsToLabelAdapters(t *testing.T) {
+	t.Parallel()
+
+	actual := FromLabelsToLabelAdapters(labels.Labels{
+		{Name: "app", Value: "test"},
+		{Name: "instance", Value: "i-1"},
+	})
+
+	expected := []client.LabelAdapter{
+		{Name: "app", Value: "test"},
+		{Name: "instance", Value: "i-1"},
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+func Test_FromLegacyLabelMatchersToMatchers(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input            []*legacy_labels.Matcher
+		expectedMatchers []labels.Matcher
+		expectedErr      error
+	}{
+		"empty matchers": {
+			input:            []*legacy_labels.Matcher{},
+			expectedMatchers: []labels.Matcher{},
+			expectedErr:      nil,
+		},
+		"multi matchers": {
+			input: []*legacy_labels.Matcher{
+				{Type: legacy_labels.MatchEqual, Name: "metric", Value: "value"},
+				{Type: legacy_labels.MatchNotEqual, Name: "metric", Value: "value"},
+				{Type: legacy_labels.MatchRegexp, Name: "metric", Value: "value.*"},
+				{Type: legacy_labels.MatchNotRegexp, Name: "metric", Value: "value.*"},
+			},
+			expectedMatchers: []labels.Matcher{
+				labels.NewEqualMatcher("metric", "value"),
+				labels.Not(labels.NewEqualMatcher("metric", "value")),
+				labels.NewMustRegexpMatcher("metric", "^(?:value.*)$"),
+				labels.Not(labels.NewMustRegexpMatcher("metric", "^(?:value.*)$")),
+			},
+			expectedErr: nil,
+		},
+		"invalid regex": {
+			input: []*legacy_labels.Matcher{
+				{Type: legacy_labels.MatchRegexp, Name: "metric", Value: "[0-9]++"},
+			},
+			expectedMatchers: nil,
+			expectedErr:      &syntax.Error{Code: syntax.ErrInvalidRepeatOp, Expr: "++"},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			actual, err := FromLegacyLabelMatchersToMatchers(testData.input)
+			require.Equal(t, testData.expectedErr, err)
+			assert.Equal(t, testData.expectedMatchers, actual)
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does**:
Currently the `/series` API endpoint doesn't work with the TSDB storage, due to missing implementation of `MetricsForLabelMatchers()`. In this PR I'm addressing this issue.

**Which issue(s) this PR fixes**:
_No issue created._

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
