### PR TITLE
Removed chunk.metadataInIndex because unused

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -206,7 +206,7 @@ func (c *store) LabelValuesForMetricName(ctx context.Context, userID string, fro
 
 	var result UniqueStrings
 	for _, entry := range entries {
-		_, labelValue, _, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
+		_, labelValue, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
 		if err != nil {
 			return nil, err
 		}
@@ -461,7 +461,7 @@ func (c *store) lookupEntriesByQueries(ctx context.Context, queries []IndexQuery
 func (c *store) parseIndexEntries(ctx context.Context, entries []IndexEntry, matcher *labels.Matcher) ([]string, error) {
 	result := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		chunkKey, labelValue, _, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
+		chunkKey, labelValue, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/chunk/schema_test.go
+++ b/pkg/chunk/schema_test.go
@@ -325,7 +325,7 @@ func TestSchemaRangeKey(t *testing.T) {
 					_, err := parseMetricNameRangeValue(entry.RangeValue, entry.Value)
 					require.NoError(t, err)
 				case ChunkTimeRangeValue:
-					_, _, _, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
+					_, _, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
 					require.NoError(t, err)
 				case SeriesRangeValue:
 					_, err := parseSeriesRangeValue(entry.RangeValue, entry.Value)

--- a/pkg/chunk/schema_util.go
+++ b/pkg/chunk/schema_util.go
@@ -164,11 +164,10 @@ func parseSeriesRangeValue(rangeValue []byte, value []byte) (model.Metric, error
 	}
 }
 
-// parseChunkTimeRangeValue returns the chunkKey, labelValue and metadataInIndex
-// for chunk time range values.
+// parseChunkTimeRangeValue returns the chunkID and labelValue for chunk time
+// range values.
 func parseChunkTimeRangeValue(rangeValue []byte, value []byte) (
-	chunkID string, labelValue model.LabelValue, metadataInIndex bool,
-	isSeriesID bool, err error,
+	chunkID string, labelValue model.LabelValue, isSeriesID bool, err error,
 ) {
 	components := decodeRangeKey(rangeValue)
 
@@ -182,7 +181,6 @@ func parseChunkTimeRangeValue(rangeValue []byte, value []byte) (
 	case len(components) == 3:
 		chunkID = string(components[2])
 		labelValue = model.LabelValue(components[1])
-		metadataInIndex = true
 		return
 
 	// v3 schema had four components - label name, label value, chunk ID and version.

--- a/pkg/chunk/schema_util_test.go
+++ b/pkg/chunk/schema_util_test.go
@@ -92,7 +92,7 @@ func TestParseChunkTimeRangeValue(t *testing.T) {
 		{[]byte("a1b2c3d4\x00Y29kZQ\x002:1484661279394:1484664879394\x004\x00"),
 			"code", "2:1484661279394:1484664879394"},
 	} {
-		chunkID, labelValue, _, _, err := parseChunkTimeRangeValue(c.encoded, nil)
+		chunkID, labelValue, _, err := parseChunkTimeRangeValue(c.encoded, nil)
 		require.NoError(t, err)
 		assert.Equal(t, model.LabelValue(c.value), labelValue)
 		assert.Equal(t, c.chunkID, chunkID)


### PR DESCRIPTION
**What this PR does**:
Removed `Chunk.metadataInIndex` because unused (it's never set since https://github.com/cortexproject/cortex/pull/873).

**Which issue(s) this PR fixes**:
Fixes #1795

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
