### PR TITLE
Fail query if an error occurs while converting TSDB series to chunks

### DIFF
--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -2,6 +2,7 @@ package querier
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -142,7 +143,7 @@ func seriesToChunks(userID string, series *storepb.Series) ([]chunk.Chunk, error
 
 		enc, err := chunkenc.FromData(chunkenc.EncXOR, c.Raw.Data)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to initialize chunk from XOR encoded raw data")
+			return nil, errors.Wrap(err, fmt.Sprintf("failed to initialize chunk from XOR encoded raw data (series: %v min time: %d max time: %d)", lbls, c.MinTime, c.MaxTime))
 		}
 
 		it := enc.Iterator(nil)
@@ -153,7 +154,7 @@ func seriesToChunks(userID string, series *storepb.Series) ([]chunk.Chunk, error
 				Value:     model.SampleValue(v),
 			})
 			if err != nil {
-				return nil, errors.Wrap(err, "failed adding sample to chunk")
+				return nil, errors.Wrap(err, fmt.Sprintf("failed adding sample to chunk (series: %v timestamp: %d value: %f)", lbls, ts, v))
 			}
 
 			if overflow != nil {
@@ -164,7 +165,7 @@ func seriesToChunks(userID string, series *storepb.Series) ([]chunk.Chunk, error
 
 		// Ensure the iteration has not been interrupted because of an error
 		if it.Err() != nil {
-			return nil, errors.Wrap(it.Err(), "failed reading sample from encoded chunk")
+			return nil, errors.Wrap(it.Err(), fmt.Sprintf("failed reading sample from encoded chunk (series: %v min time: %d max time: %d)", lbls, c.MinTime, c.MaxTime))
 		}
 
 		if ch.Len() > 0 {

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -113,6 +113,7 @@ func (b *BlockQuerier) Get(ctx context.Context, userID string, from, through mod
 		// Convert Thanos store series into Cortex chunks
 		convertedChunks, err := seriesToChunks(userID, resp.GetSeries())
 		if err != nil {
+			level.Error(util.Logger).Log("msg", "failed converting TSDB series to Cortex chunks", "err", err)
 			return nil, err
 		}
 

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -63,21 +63,21 @@ func Test_seriesToChunks(t *testing.T) {
 		},
 		"should return error on out of order samples": {
 			series: &storepb.Series{
-				Labels: []storepb.Label{},
+				Labels: []storepb.Label{{Name: "foo", Value: "bar"}},
 				Chunks: []storepb.AggrChunk{
 					{MinTime: minTimestamp.Unix() * 1000, MaxTime: maxTimestamp.Unix() * 1000, Raw: &storepb.Chunk{Type: storepb.Chunk_XOR, Data: mockTSDBChunkDataWithInvalidTimestampOrder()}},
 				},
 			},
-			expectedErr: "failed adding sample to chunk: base time delta is less than zero: -1",
+			expectedErr: `failed adding sample to chunk (series: {foo="bar"} timestamp: 0 value: 2.000000): base time delta is less than zero: -1`,
 		},
 		"should return error on failure while reading encoded chunk data": {
 			series: &storepb.Series{
-				Labels: []storepb.Label{},
+				Labels: []storepb.Label{{Name: "foo", Value: "bar"}},
 				Chunks: []storepb.AggrChunk{
 					{MinTime: minTimestamp.Unix() * 1000, MaxTime: maxTimestamp.Unix() * 1000, Raw: &storepb.Chunk{Type: storepb.Chunk_XOR, Data: []byte{0, 1}}},
 				},
 			},
-			expectedErr: "failed reading sample from encoded chunk: EOF",
+			expectedErr: `failed reading sample from encoded chunk (series: {foo="bar"} min time: 1000 max time: 10000): EOF`,
 		},
 	}
 

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -31,6 +31,7 @@ func Test_seriesToChunks(t *testing.T) {
 	tests := map[string]struct {
 		series         *storepb.Series
 		expectedChunks []expectedChunk
+		expectedErr    string
 	}{
 		"empty series": {
 			series:         &storepb.Series{},
@@ -60,13 +61,38 @@ func Test_seriesToChunks(t *testing.T) {
 				},
 			},
 		},
+		"should return error on out of order samples": {
+			series: &storepb.Series{
+				Labels: []storepb.Label{},
+				Chunks: []storepb.AggrChunk{
+					{MinTime: minTimestamp.Unix() * 1000, MaxTime: maxTimestamp.Unix() * 1000, Raw: &storepb.Chunk{Type: storepb.Chunk_XOR, Data: mockTSDBChunkDataWithInvalidTimestampOrder()}},
+				},
+			},
+			expectedErr: "failed adding sample to chunk: base time delta is less than zero: -1",
+		},
+		"should return error on failure while reading encoded chunk data": {
+			series: &storepb.Series{
+				Labels: []storepb.Label{},
+				Chunks: []storepb.AggrChunk{
+					{MinTime: minTimestamp.Unix() * 1000, MaxTime: maxTimestamp.Unix() * 1000, Raw: &storepb.Chunk{Type: storepb.Chunk_XOR, Data: []byte{0, 1}}},
+				},
+			},
+			expectedErr: "failed reading sample from encoded chunk: EOF",
+		},
 	}
 
 	for testName, testData := range tests {
 		testData := testData
 
 		t.Run(testName, func(t *testing.T) {
-			actualChunks := seriesToChunks("test", testData.series)
+			actualChunks, actualErr := seriesToChunks("test", testData.series)
+
+			if testData.expectedErr != "" {
+				require.EqualError(t, actualErr, testData.expectedErr)
+			} else {
+				require.NoError(t, actualErr)
+			}
+
 			require.Equal(t, len(testData.expectedChunks), len(actualChunks))
 
 			for i, actual := range actualChunks {
@@ -94,6 +120,19 @@ func mockTSDBChunkData() []byte {
 
 	appender.Append(time.Unix(1, 0).Unix()*1000, 1)
 	appender.Append(time.Unix(2, 0).Unix()*1000, 2)
+
+	return chunk.Bytes()
+}
+
+func mockTSDBChunkDataWithInvalidTimestampOrder() []byte {
+	chunk := chunkenc.NewXORChunk()
+	appender, err := chunk.Appender()
+	if err != nil {
+		panic(err)
+	}
+
+	appender.Append(time.Unix(1, 0).Unix()*1000, 1)
+	appender.Append(time.Unix(0, 0).Unix()*1000, 2)
 
 	return chunk.Bytes()
 }


### PR DESCRIPTION
**What this PR does**:
While doing tests on Cortex TSDB, I've realized a query doesn't fail if some series fail to be converted to chunks. There are a couple of warning logs, but from the user perspective we end up with a partial query result, which we would like to avoid in favour of correctness.

In this PR:
- Fail a query if an error occurs while converting TSDB series to chunks
- Handle `chunkend.Iterator.Err()` (was unchecked)

**Which issue(s) this PR fixes**:
_No issue was created_

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
