### PR TITLE
Update the example frontend config, the fields have moved.

### DIFF
--- a/docs/prometheus-frontend.yml
+++ b/docs/prometheus-frontend.yml
@@ -15,12 +15,10 @@ http_prefix:
 server:
   http_listen_port: 9091
 
-frontend:
-  log_queries_longer_than: 1s
+query_range:
   split_queries_by_day: true
   align_queries_with_step: true
   cache_results: true
-  compress_responses: true
 
   results_cache:
     max_freshness: 1m
@@ -42,3 +40,8 @@ frontend:
       #     host: memcached.default.svc.cluster.local
       #     service: memcached
       #     consistent_hash: true
+
+
+frontend:
+  log_queries_longer_than: 1s
+  compress_responses: true


### PR DESCRIPTION
Signed-off-by: Tom Wilkie <tom@grafana.com>

Config for the frontend pipeline stages moved to separate config, this fixes it.
