### PR TITLE
Make ingester transfer retries min and max duration configurable

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -103,7 +103,9 @@ type Config struct {
 	LifecyclerConfig ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
 
 	// Config for transferring chunks. Zero or negative = no retries.
-	MaxTransferRetries int `yaml:"max_transfer_retries,omitempty"`
+	MaxTransferRetries        int `yaml:"max_transfer_retries,omitempty"`
+	MinTransferRetriesBackOff int `yaml:"min_tranfer_retries_backoff,omitempty"`
+	MaxTransferRetriesBackOff int `yaml:"max_tranfer_retries_backoff,omitempty"`
 
 	// Config for chunk flushing.
 	FlushCheckPeriod  time.Duration
@@ -135,6 +137,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.LifecyclerConfig.RegisterFlags(f)
 
 	f.IntVar(&cfg.MaxTransferRetries, "ingester.max-transfer-retries", 10, "Number of times to try and transfer chunks before falling back to flushing. Negative value or zero disables hand-over.")
+	f.IntVar(&cfg.MinTransferRetriesBackOff, "ingester.min-transfer-retries-backoff", 100, "Minimum backoff period for transfers in milliseconds")
+	f.IntVar(&cfg.MaxTransferRetriesBackOff, "ingester.max-transfer-retries-backoff", 5000, "Maximum backoff period for transfers in milliseconds")
 	f.DurationVar(&cfg.FlushCheckPeriod, "ingester.flush-period", 1*time.Minute, "Period with which to attempt to flush chunks.")
 	f.DurationVar(&cfg.RetainPeriod, "ingester.retain-period", 5*time.Minute, "Period chunks will remain in memory after flushing.")
 	f.DurationVar(&cfg.FlushOpTimeout, "ingester.flush-op-timeout", 1*time.Minute, "Timeout for individual flush operations.")

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -352,9 +352,12 @@ func (i *Ingester) TransferOut(ctx context.Context) error {
 	if i.cfg.MaxTransferRetries <= 0 {
 		return fmt.Errorf("transfers disabled")
 	}
+	if i.cfg.MaxTransferRetriesBackOff < i.cfg.MinTransferRetriesBackOff {
+		return fmt.Errorf("min transfer retries duration should be higher than max transfer retries duration")
+	}
 	backoff := util.NewBackoff(ctx, util.BackoffConfig{
-		MinBackoff: 100 * time.Millisecond,
-		MaxBackoff: 5 * time.Second,
+		MinBackoff: time.Duration(i.cfg.MinTransferRetriesBackOff) * time.Millisecond,
+		MaxBackoff: time.Duration(i.cfg.MaxTransferRetriesBackOff) * time.Millisecond,
 		MaxRetries: i.cfg.MaxTransferRetries,
 	})
 


### PR DESCRIPTION
Signed-off-by: Ankit Goel <ankit.goel@go-jek.com>

**What this PR does**:
This PR makes the ingester retries backoff duration configurable.
**Which issue(s) this PR fixes**:
It helps the user deal with issue #1307 
