### PR TITLE
Do not close and re-open TSDBs during ingester transfer

### DIFF
--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -435,7 +435,9 @@ func (i *Ingester) closeAllTSDB() {
 			}
 
 			// Now that the TSDB has been closed, we should remove it from the
-			// set of open ones.
+			// set of open ones. This lock acquisition doesn't deadlock with the
+			// outer one, because the outer one is released as soon as all go
+			// routines are started.
 			i.userStatesMtx.Lock()
 			delete(i.TSDBState.dbs, userID)
 			i.userStatesMtx.Unlock()

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -522,6 +522,12 @@ func TestV2IngesterTransfer(t *testing.T) {
 			response, err = ing2.Query(ctx, request)
 			require.NoError(t, err)
 			assert.Equal(t, expectedResponse, response)
+
+			// Assert the data is in the expected location of dir2
+			files, err := ioutil.ReadDir(dir2)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(files))
+			require.Equal(t, "1", files[0].Name())
 		})
 	}
 }

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -521,7 +521,10 @@ func (i *Ingester) v2TransferOut(ctx context.Context) error {
 		// requests will be accepted because the "stopped" flag has already been set.
 		level.Info(util.Logger).Log("msg", "waiting for in-flight write requests to complete")
 
-		if !util.WaitGroupWithTimeout(&i.TSDBState.inflightWriteReqs, 10*time.Second) {
+		waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Second)
+		defer waitCancel()
+
+		if !util.WaitGroup(waitCtx, &i.TSDBState.inflightWriteReqs) {
 			level.Warn(util.Logger).Log("msg", "timeout expired while waiting in-flight write requests to complete, transfer will continue anyway")
 		}
 

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -524,8 +524,8 @@ func (i *Ingester) v2TransferOut(ctx context.Context) error {
 		waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Second)
 		defer waitCancel()
 
-		if !util.WaitGroup(waitCtx, &i.TSDBState.inflightWriteReqs) {
-			level.Warn(util.Logger).Log("msg", "timeout expired while waiting in-flight write requests to complete, transfer will continue anyway")
+		if err := util.WaitGroup(waitCtx, &i.TSDBState.inflightWriteReqs); err != nil {
+			level.Warn(util.Logger).Log("msg", "timeout expired while waiting in-flight write requests to complete, transfer will continue anyway", "err", err)
 		}
 
 		// Before beginning transfer, we need to make sure no WAL compaction will occur.

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/tsdb"
 	"github.com/thanos-io/thanos/pkg/shipper"
 
 	"github.com/cortexproject/cortex/pkg/chunk/encoding"
@@ -50,14 +51,10 @@ var (
 		Name: "cortex_ingester_sent_bytes_total",
 		Help: "The total number of bytes sent by this ingester whilst leaving",
 	})
-
-	once *sync.Once
-
 	errTransferNoPendingIngesters = errors.New("no pending ingesters")
 )
 
 func init() {
-	once = &sync.Once{}
 	prometheus.MustRegister(sentChunks)
 	prometheus.MustRegister(receivedChunks)
 	prometheus.MustRegister(sentFiles)
@@ -415,6 +412,7 @@ func (i *Ingester) TransferOut(ctx context.Context) error {
 	for backoff.Ongoing() {
 		err = i.transferOut(ctx)
 		if err == nil {
+			level.Info(util.Logger).Log("msg", "transfer successfully completed")
 			return nil
 		}
 
@@ -502,32 +500,58 @@ func (i *Ingester) transferOut(ctx context.Context) error {
 }
 
 func (i *Ingester) v2TransferOut(ctx context.Context) error {
-	if len(i.TSDBState.dbs) == 0 {
-		level.Info(util.Logger).Log("msg", "nothing to transfer")
+	// Skip TSDB transfer if there are no DBs
+	i.userStatesMtx.RLock()
+	skip := len(i.TSDBState.dbs) == 0
+	i.userStatesMtx.RUnlock()
+
+	if skip {
+		level.Info(util.Logger).Log("msg", "the ingester has nothing to transfer")
 		return nil
 	}
 
-	// Close all user databases
-	wg := &sync.WaitGroup{}
-	// Only perform a shutdown once
-	once.Do(func() {
+	// This transfer function may be called multiple times in case of error,
+	// until the max number of retries is reached. For this reason, we run
+	// some initialization only once.
+	i.TSDBState.transferOnce.Do(func() {
+		// In order to transfer TSDB WAL without closing the TSDB itself - which is a
+		// pre-requisite to continue serving read requests while transferring - we need
+		// to make sure no more series will be written to the TSDB. For this reason, we
+		// wait until all in-flight write requests have been completed. No new write
+		// requests will be accepted because the "stopped" flag has already been set.
+		level.Info(util.Logger).Log("msg", "waiting for in-flight write requests to complete")
+
+		if !util.WaitGroupWithTimeout(&i.TSDBState.inflightWriteReqs, 10*time.Second) {
+			level.Warn(util.Logger).Log("msg", "timeout expired while waiting in-flight write requests to complete, transfer will continue anyway")
+		}
+
+		// Before beginning transfer, we need to make sure no WAL compaction will occur.
+		// If there's an on-going compaction, the DisableCompactions() will wait until
+		// completed.
+		level.Info(util.Logger).Log("msg", "disabling compaction on all TSDBs")
+
+		i.userStatesMtx.RLock()
+		wg := &sync.WaitGroup{}
 		wg.Add(len(i.TSDBState.dbs))
+
 		for _, db := range i.TSDBState.dbs {
-			go func(closer io.Closer) {
+			go func(db *tsdb.DB) {
 				defer wg.Done()
-				if err := closer.Close(); err != nil {
-					level.Warn(util.Logger).Log("msg", "failed to close db", "err", err)
-				}
+				db.DisableCompactions()
 			}(db)
 		}
+
+		i.userStatesMtx.RUnlock()
+		wg.Wait()
 	})
 
+	// Look for a joining ingester to transfer blocks and WAL to
 	targetIngester, err := i.findTargetIngester(ctx)
 	if err != nil {
-		return fmt.Errorf("cannot find ingester to transfer blocks to: %w", err)
+		return errors.Wrap(err, "cannot find ingester to transfer blocks to")
 	}
 
-	level.Info(util.Logger).Log("msg", "sending blocks", "to_ingester", targetIngester.Addr)
+	level.Info(util.Logger).Log("msg", "begin transferring TSDB blocks and WAL to joining ingester", "to_ingester", targetIngester.Addr)
 	c, err := i.cfg.ingesterClientFactory(targetIngester.Addr, i.clientConfig)
 	if err != nil {
 		return err
@@ -537,10 +561,8 @@ func (i *Ingester) v2TransferOut(ctx context.Context) error {
 	ctx = user.InjectOrgID(ctx, "-1")
 	stream, err := c.TransferTSDB(ctx)
 	if err != nil {
-		return errors.Wrap(err, "TransferTSDB")
+		return errors.Wrap(err, "TransferTSDB() has failed")
 	}
-
-	wg.Wait() // wait for all databases to have closed
 
 	// Grab a list of all blocks that need to be shipped
 	blocks, err := unshippedBlocks(i.cfg.TSDBConfig.Dir)
@@ -620,7 +642,7 @@ func unshippedBlocks(dir string) (map[string][]string, error) {
 }
 
 func transferUser(ctx context.Context, stream client.Ingester_TransferTSDBClient, dir, ingesterID, userID string, blocks []string) {
-	level.Info(util.Logger).Log("msg", "xfer user", "user", userID)
+	level.Info(util.Logger).Log("msg", "transferring user blocks", "user", userID)
 	// Transfer all blocks
 	for _, blk := range blocks {
 		err := filepath.Walk(filepath.Join(dir, userID, blk), func(path string, info os.FileInfo, err error) error {
@@ -659,6 +681,7 @@ func transferUser(ctx context.Context, stream client.Ingester_TransferTSDBClient
 	}
 
 	// Transfer WAL
+	level.Info(util.Logger).Log("msg", "transferring user WAL", "user", userID)
 	err := filepath.Walk(filepath.Join(dir, userID, "wal"), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
@@ -691,10 +714,10 @@ func transferUser(ctx context.Context, stream client.Ingester_TransferTSDBClient
 	})
 
 	if err != nil {
-		level.Warn(util.Logger).Log("msg", "failed to transfer user wal", "err", err)
+		level.Warn(util.Logger).Log("msg", "failed to transfer user WAL", "err", err)
 	}
 
-	level.Info(util.Logger).Log("msg", "xfer user complete", "user", userID)
+	level.Info(util.Logger).Log("msg", "user blocks and WAL transfer completed", "user", userID)
 }
 
 func batchSend(batch int, b []byte, stream client.Ingester_TransferTSDBClient, tsfile *client.TimeSeriesFile) error {

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -521,7 +521,10 @@ func (i *Ingester) v2TransferOut(ctx context.Context) error {
 		// requests will be accepted because the "stopped" flag has already been set.
 		level.Info(util.Logger).Log("msg", "waiting for in-flight write requests to complete")
 
-		waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Second)
+		// Do not use the parent context cause we don't want to interrupt while waiting
+		// for in-flight requests to complete if the parent context is cancelled, given
+		// this logic run only once.
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer waitCancel()
 
 		if err := util.WaitGroup(waitCtx, &i.TSDBState.inflightWriteReqs); err != nil {

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -581,6 +581,11 @@ func (i *Ingester) v2TransferOut(ctx context.Context) error {
 		return errors.Wrap(err, "CloseAndRecv")
 	}
 
+	// The transfer out has been successfully completed. Now we should close
+	// all open TSDBs: the Close() will wait until all on-going read operations
+	// will be completed.
+	i.closeAllTSDB()
+
 	return nil
 }
 

--- a/pkg/util/sync.go
+++ b/pkg/util/sync.go
@@ -1,14 +1,14 @@
 package util
 
 import (
+	"context"
 	"sync"
-	"time"
 )
 
-// WaitGroupWithTimeout calls Wait() on a sync.WaitGroup and return once the
-// Wait() completed or the timeout expires, whatever occurs first. Returns true
-// if the Wait() completed before the timeout expired, false otherwise.
-func WaitGroupWithTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+// WaitGroup calls Wait() on a sync.WaitGroup and return once the Wait() completed
+// or the context is cancelled or times out, whatever occurs first. Returns true if
+// the Wait() completed before the timeout expired, false otherwise.
+func WaitGroup(ctx context.Context, wg *sync.WaitGroup) bool {
 	c := make(chan struct{})
 
 	go func() {
@@ -19,7 +19,7 @@ func WaitGroupWithTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 	select {
 	case <-c:
 		return true
-	case <-time.After(timeout):
+	case <-ctx.Done():
 		return false
 	}
 }

--- a/pkg/util/sync.go
+++ b/pkg/util/sync.go
@@ -6,9 +6,10 @@ import (
 )
 
 // WaitGroup calls Wait() on a sync.WaitGroup and return once the Wait() completed
-// or the context is cancelled or times out, whatever occurs first. Returns true if
-// the Wait() completed before the timeout expired, false otherwise.
-func WaitGroup(ctx context.Context, wg *sync.WaitGroup) bool {
+// or the context is cancelled or times out, whatever occurs first. Returns the
+// specific context error if the context is cancelled or times out before Wait()
+// completes.
+func WaitGroup(ctx context.Context, wg *sync.WaitGroup) error {
 	c := make(chan struct{})
 
 	go func() {
@@ -18,8 +19,8 @@ func WaitGroup(ctx context.Context, wg *sync.WaitGroup) bool {
 
 	select {
 	case <-c:
-		return true
+		return nil
 	case <-ctx.Done():
-		return false
+		return ctx.Err()
 	}
 }

--- a/pkg/util/sync.go
+++ b/pkg/util/sync.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"sync"
+	"time"
+)
+
+// WaitGroupWithTimeout calls Wait() on a sync.WaitGroup and return once the
+// Wait() completed or the timeout expires, whatever occurs first. Returns true
+// if the Wait() completed before the timeout expired, false otherwise.
+func WaitGroupWithTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+
+	select {
+	case <-c:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}

--- a/pkg/util/sync_test.go
+++ b/pkg/util/sync_test.go
@@ -14,13 +14,13 @@ func TestWaitGroup(t *testing.T) {
 
 	tests := map[string]struct {
 		setup    func(wg *sync.WaitGroup) (context.Context, context.CancelFunc)
-		expected bool
+		expected error
 	}{
 		"WaitGroup is done": {
 			setup: func(wg *sync.WaitGroup) (context.Context, context.CancelFunc) {
 				return context.WithTimeout(context.Background(), 100*time.Millisecond)
 			},
-			expected: true,
+			expected: nil,
 		},
 		"WaitGroup is not done and timeout expires": {
 			setup: func(wg *sync.WaitGroup) (context.Context, context.CancelFunc) {
@@ -28,7 +28,7 @@ func TestWaitGroup(t *testing.T) {
 
 				return context.WithTimeout(context.Background(), 100*time.Millisecond)
 			},
-			expected: false,
+			expected: context.DeadlineExceeded,
 		},
 		"WaitGroup is not done and context is cancelled before timeout expires": {
 			setup: func(wg *sync.WaitGroup) (context.Context, context.CancelFunc) {
@@ -43,7 +43,7 @@ func TestWaitGroup(t *testing.T) {
 
 				return ctx, cancel
 			},
-			expected: false,
+			expected: context.Canceled,
 		},
 	}
 

--- a/pkg/util/sync_test.go
+++ b/pkg/util/sync_test.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitGroupWithTimeout(t *testing.T) {
+	wg := sync.WaitGroup{}
+
+	success := WaitGroupWithTimeout(&wg, 100*time.Millisecond)
+	assert.True(t, success)
+
+	wg.Add(1)
+	success = WaitGroupWithTimeout(&wg, 100*time.Millisecond)
+	assert.False(t, success)
+
+	wg.Done()
+	success = WaitGroupWithTimeout(&wg, 100*time.Millisecond)
+	assert.True(t, success)
+}


### PR DESCRIPTION
**What this PR does**:
The Cortex TSDB experimental integration currently close all TSDBs during the ingester shutdown, before blocks and WALs are transferred to a joining ingester. This has two main issues:
1. Query requests received while closing TSDBs fail with error `open index reader: block is closing`
2. Query requests received after the TSDBs have been closed issue a re-opening of TSDBs, which means re-playing the WAL (expensive operation)

Me and @codesome checked out the TSDB implementation and came to the conclusion which is safe to transfer blocks as WAL without closing the TSDB as far as:
1. No more writes occur
2. No compaction is on-going or will occur

In this PR I've introduced some changes to avoid closing and re-opening TSDBs on queries received during ingester blocks/WAL transfer, as well as some logic to guarantee no writes occur to the TSDB once the transfer starts.

I've tested the changes in our TSDB test cluster and looks working as expected (at least, experimentally).

**Suggestion to the reviewer**: enable "Hide whitespace changes" because there are a couple of large code blocks for which it has changed only the indentation.

**Which issue(s) this PR fixes**:
Fixes #1829

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
