### PR TITLE
memberlist: Use advertised address when sending packets

### DIFF
--- a/pkg/ring/kv/memberlist/memberlist_client.go
+++ b/pkg/ring/kv/memberlist/memberlist_client.go
@@ -35,8 +35,6 @@ type Config struct {
 	PushPullInterval time.Duration `yaml:"pull_push_interval"`
 	GossipInterval   time.Duration `yaml:"gossip_interval"`
 	GossipNodes      int           `yaml:"gossip_nodes"`
-	ProbeInterval    time.Duration
-	ProbeTimeout     time.Duration
 
 	// List of members to join
 	JoinMembers      flagext.StringSlice `yaml:"join_members"`
@@ -67,8 +65,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, prefix string) {
 	f.DurationVar(&cfg.GossipInterval, prefix+"memberlist.gossip-interval", 0, "How often to gossip. Uses memberlist LAN defaults if 0.")
 	f.IntVar(&cfg.GossipNodes, prefix+"memberlist.gossip-nodes", 0, "How many nodes to gossip to. Uses memberlist LAN defaults if 0.")
 	f.DurationVar(&cfg.PushPullInterval, prefix+"memberlist.pullpush-interval", 0, "How often to use pull/push sync. Uses memberlist LAN defaults if 0.")
-	f.DurationVar(&cfg.ProbeInterval, prefix+"memberlist.probe-interval", 0, "How often to probe random nodes. Uses memberlist LAN defaults if 0.")
-	f.DurationVar(&cfg.ProbeTimeout, prefix+"memberlist.probe-timeout", 0, "Timeout to wait for an ack from a probed node before assuming it is unhealthy.")
 
 	cfg.TCPTransport.RegisterFlags(f, prefix)
 }
@@ -163,12 +159,6 @@ func NewMemberlistClient(cfg Config, codec codec.Codec) (*Client, error) {
 	}
 	if cfg.NodeName != "" {
 		mlCfg.Name = cfg.NodeName
-	}
-	if cfg.ProbeInterval != 0 {
-		mlCfg.ProbeInterval = cfg.ProbeInterval
-	}
-	if cfg.ProbeTimeout != 0 {
-		mlCfg.ProbeTimeout = cfg.ProbeTimeout
 	}
 
 	mlCfg.LogOutput = newMemberlistLoggerAdapter(util.Logger, false)

--- a/pkg/ring/kv/memberlist/memberlist_client.go
+++ b/pkg/ring/kv/memberlist/memberlist_client.go
@@ -35,6 +35,8 @@ type Config struct {
 	PushPullInterval time.Duration `yaml:"pull_push_interval"`
 	GossipInterval   time.Duration `yaml:"gossip_interval"`
 	GossipNodes      int           `yaml:"gossip_nodes"`
+	ProbeInterval    time.Duration
+	ProbeTimeout     time.Duration
 
 	// List of members to join
 	JoinMembers      flagext.StringSlice `yaml:"join_members"`
@@ -65,6 +67,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, prefix string) {
 	f.DurationVar(&cfg.GossipInterval, prefix+"memberlist.gossip-interval", 0, "How often to gossip. Uses memberlist LAN defaults if 0.")
 	f.IntVar(&cfg.GossipNodes, prefix+"memberlist.gossip-nodes", 0, "How many nodes to gossip to. Uses memberlist LAN defaults if 0.")
 	f.DurationVar(&cfg.PushPullInterval, prefix+"memberlist.pullpush-interval", 0, "How often to use pull/push sync. Uses memberlist LAN defaults if 0.")
+	f.DurationVar(&cfg.ProbeInterval, prefix+"memberlist.probe-interval", 0, "How often to probe random nodes. Uses memberlist LAN defaults if 0.")
+	f.DurationVar(&cfg.ProbeTimeout, prefix+"memberlist.probe-timeout", 0, "Timeout to wait for an ack from a probed node before assuming it is unhealthy.")
 
 	cfg.TCPTransport.RegisterFlags(f, prefix)
 }
@@ -159,6 +163,12 @@ func NewMemberlistClient(cfg Config, codec codec.Codec) (*Client, error) {
 	}
 	if cfg.NodeName != "" {
 		mlCfg.Name = cfg.NodeName
+	}
+	if cfg.ProbeInterval != 0 {
+		mlCfg.ProbeInterval = cfg.ProbeInterval
+	}
+	if cfg.ProbeTimeout != 0 {
+		mlCfg.ProbeTimeout = cfg.ProbeTimeout
 	}
 
 	mlCfg.LogOutput = newMemberlistLoggerAdapter(util.Logger, false)

--- a/pkg/ring/kv/memberlist/tcp_transport.go
+++ b/pkg/ring/kv/memberlist/tcp_transport.go
@@ -351,6 +351,7 @@ func (t *TCPTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, err
 		advertisePort = t.GetAutoBindPort()
 	}
 
+	level.Debug(util.Logger).Log("msg", "FinalAdvertiseAddr", "advertiseAddr", advertiseAddr.String(), "advertisePort", advertisePort)
 	return advertiseAddr, advertisePort, nil
 }
 

--- a/pkg/ring/kv/memberlist/tcp_transport.go
+++ b/pkg/ring/kv/memberlist/tcp_transport.go
@@ -421,13 +421,10 @@ func (t *TCPTransport) writeTo(b []byte, addr string) error {
 	buf.WriteByte(byte(packet))
 
 	// We need to send our address to the other side, otherwise other side can only see IP and port from TCP header.
-	// But that doesn't match our node address (source port is assigned automatically), which confuses memberlist.
-	// We will announce first listener's address as our address. This is what memberlist's net_transport.go does as well.
-	// ourAddr := t.tcpListeners[0].Addr().String()
+	// But that doesn't match our node address (new TCP connection has new random port), which confuses memberlist.
+	// So we send our advertised address, so that memberlist on the receiving side can match it with correct node.
+	// This seems to be important for node probes (pings) done by memberlist.
 	ourAddr := t.getAdvertisedAddr()
-	if ourAddr == "" {
-		ourAddr = t.tcpListeners[0].Addr().String()
-	}
 	if len(ourAddr) > 255 {
 		return fmt.Errorf("local address too long")
 	}

--- a/pkg/ring/kv/memberlist/tcp_transport.go
+++ b/pkg/ring/kv/memberlist/tcp_transport.go
@@ -81,6 +81,9 @@ type TCPTransport struct {
 
 	shutdown int32
 
+	advertiseMu   sync.RWMutex
+	advertiseAddr string
+
 	// metrics
 	incomingStreams      prometheus.Counter
 	outgoingStreams      prometheus.Counter
@@ -352,7 +355,22 @@ func (t *TCPTransport) FinalAdvertiseAddr(ip string, port int) (net.IP, int, err
 	}
 
 	level.Debug(util.Logger).Log("msg", "FinalAdvertiseAddr", "advertiseAddr", advertiseAddr.String(), "advertisePort", advertisePort)
+
+	t.setAdvertisedAddr(advertiseAddr, advertisePort)
 	return advertiseAddr, advertisePort, nil
+}
+
+func (t *TCPTransport) setAdvertisedAddr(advertiseAddr net.IP, advertisePort int) {
+	t.advertiseMu.Lock()
+	defer t.advertiseMu.Unlock()
+	addr := net.TCPAddr{IP: advertiseAddr, Port: advertisePort}
+	t.advertiseAddr = addr.String()
+}
+
+func (t *TCPTransport) getAdvertisedAddr() string {
+	t.advertiseMu.RLock()
+	defer t.advertiseMu.RUnlock()
+	return t.advertiseAddr
 }
 
 // WriteTo is a packet-oriented interface that fires off the given
@@ -405,7 +423,11 @@ func (t *TCPTransport) writeTo(b []byte, addr string) error {
 	// We need to send our address to the other side, otherwise other side can only see IP and port from TCP header.
 	// But that doesn't match our node address (source port is assigned automatically), which confuses memberlist.
 	// We will announce first listener's address as our address. This is what memberlist's net_transport.go does as well.
-	ourAddr := t.tcpListeners[0].Addr().String()
+	// ourAddr := t.tcpListeners[0].Addr().String()
+	ourAddr := t.getAdvertisedAddr()
+	if ourAddr == "" {
+		ourAddr = t.tcpListeners[0].Addr().String()
+	}
 	if len(ourAddr) > 255 {
 		return fmt.Errorf("local address too long")
 	}


### PR DESCRIPTION
Change TCP transport to use advertised address when sending "packets" (term used by memberlist lib). This was needed to stop memberlist complaining about not being able to ping other members of the cluster when running on internal Grafana k8s cluster.

(Memberlist is still experimental)