### PR TITLE
tsdb/block_store: expose block store config settings

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -197,7 +197,7 @@ func (t *Cortex) initQuerier(cfg *Config) (err error) {
 	var store querier.ChunkStore
 
 	if cfg.Storage.Engine == storage.StorageEngineTSDB {
-		store, err = querier.NewBlockQuerier(cfg.TSDB, prometheus.DefaultRegisterer)
+		store, err = querier.NewBlockQuerier(cfg.TSDB, cfg.Server.LogLevel, prometheus.DefaultRegisterer)
 		if err != nil {
 			return err
 		}

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"github.com/weaveworks/common/logging"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -27,7 +28,7 @@ type BlockQuerier struct {
 }
 
 // NewBlockQuerier returns a client to query a block store
-func NewBlockQuerier(cfg tsdb.Config, r prometheus.Registerer) (*BlockQuerier, error) {
+func NewBlockQuerier(cfg tsdb.Config, logLevel logging.Level, r prometheus.Registerer) (*BlockQuerier, error) {
 	b := &BlockQuerier{
 		syncTimes: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_querier_sync_seconds",
@@ -38,7 +39,7 @@ func NewBlockQuerier(cfg tsdb.Config, r prometheus.Registerer) (*BlockQuerier, e
 
 	r.MustRegister(b.syncTimes)
 
-	us, err := NewUserStore(cfg, util.Logger)
+	us, err := NewUserStore(cfg, logLevel, util.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/querier/block_store.go
+++ b/pkg/querier/block_store.go
@@ -113,7 +113,7 @@ func (u *UserStore) syncUserStores(ctx context.Context, f func(context.Context, 
 				Bucket: bkt,
 			}
 
-			indexCacheSizeBytes := u.cfg.BucketStoreCfg.IndexCacheSizeBytes
+			indexCacheSizeBytes := u.cfg.BucketStore.IndexCacheSizeBytes
 			maxItemSizeBytes := indexCacheSizeBytes / 2
 			indexCache, err := storecache.NewIndexCache(u.logger, nil, storecache.Opts{
 				MaxSizeBytes:     indexCacheSizeBytes,
@@ -125,13 +125,13 @@ func (u *UserStore) syncUserStores(ctx context.Context, f func(context.Context, 
 			bs, err = store.NewBucketStore(u.logger,
 				nil,
 				userBkt,
-				filepath.Join(u.cfg.BucketStoreCfg.Dir, user),
+				filepath.Join(u.cfg.BucketStore.SyncDir, user),
 				indexCache,
-				uint64(u.cfg.BucketStoreCfg.MaxChunkPoolBytes),
-				u.cfg.BucketStoreCfg.MaxSampleCount,
-				u.cfg.BucketStoreCfg.MaxConcurrent,
-				u.cfg.BucketStoreCfg.DebugLogging,
-				u.cfg.BucketStoreCfg.BlockSyncConcurrency,
+				uint64(u.cfg.BucketStore.MaxChunkPoolBytes),
+				u.cfg.BucketStore.MaxSampleCount,
+				u.cfg.BucketStore.MaxConcurrent,
+				u.cfg.BucketStore.DebugLogging,
+				u.cfg.BucketStore.BlockSyncConcurrency,
 				&store.FilterConfig{
 					MinTime: *mint,
 					MaxTime: *maxt,

--- a/pkg/querier/block_store.go
+++ b/pkg/querier/block_store.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/alecthomas/units"
 	"github.com/cortexproject/cortex/pkg/ingester"
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/go-kit/kit/log"
@@ -114,7 +113,7 @@ func (u *UserStore) syncUserStores(ctx context.Context, f func(context.Context, 
 				Bucket: bkt,
 			}
 
-			indexCacheSizeBytes := uint64(250 * units.Mebibyte)
+			indexCacheSizeBytes := u.cfg.BucketStoreCfg.IndexCacheSizeBytes
 			maxItemSizeBytes := indexCacheSizeBytes / 2
 			indexCache, err := storecache.NewIndexCache(u.logger, nil, storecache.Opts{
 				MaxSizeBytes:     indexCacheSizeBytes,
@@ -126,13 +125,13 @@ func (u *UserStore) syncUserStores(ctx context.Context, f func(context.Context, 
 			bs, err = store.NewBucketStore(u.logger,
 				nil,
 				userBkt,
-				filepath.Join(u.cfg.SyncDir, user),
+				filepath.Join(u.cfg.BucketStoreCfg.Dir, user),
 				indexCache,
-				uint64(2*units.Gibibyte),
-				0,
-				20,
-				false,
-				20,
+				uint64(u.cfg.BucketStoreCfg.MaxChunkPoolBytes),
+				u.cfg.BucketStoreCfg.MaxSampleCount,
+				u.cfg.BucketStoreCfg.MaxConcurrent,
+				u.cfg.BucketStoreCfg.DebugLogging,
+				u.cfg.BucketStoreCfg.BlockSyncConcurrency,
 				&store.FilterConfig{
 					MinTime: *mint,
 					MaxTime: *maxt,

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -99,18 +99,16 @@ type BucketStoreConfig struct {
 	MaxChunkPoolBytes    uint64 `yaml:"max_chunk_pool_bytes"`
 	MaxSampleCount       uint64 `yaml:"max_sample_count"`
 	MaxConcurrent        int    `yaml:"max_concurrent"`
-	DebugLogging         bool   `yaml:"debug_logging"`
 	BlockSyncConcurrency int    `yaml:"block_sync_concurrency"`
 }
 
 // RegisterFlags registers the BucketStore flags
 func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 
-	f.StringVar(&cfg.Dir, "experimental.tsdb.bucket-store.sync-dir", "tsdb-sync", "Directory to place synced tsdb indicies.")
+	f.StringVar(&cfg.SyncDir, "experimental.tsdb.bucket-store.sync-dir", "tsdb-sync", "Directory to place synced tsdb indicies.")
 	f.Uint64Var(&cfg.IndexCacheSizeBytes, "experimental.tsdb.bucket-store.index-cache-size-bytes", uint64(250*units.Mebibyte), "Size of index cache in bytes per tenant.")
 	f.Uint64Var(&cfg.MaxChunkPoolBytes, "experimental.tsdb.bucket-store.max-chunk-pool-bytes", uint64(2*units.Gibibyte), "Max size of chunk pool in bytes per tenant.")
 	f.Uint64Var(&cfg.MaxSampleCount, "experimental.tsdb.bucket-store.max-sample-count", 0, "Max number of samples (0 is no limit) per query when loading series from storage.")
 	f.IntVar(&cfg.MaxConcurrent, "experimental.tsdb.bucket-store.max-concurrent", 20, "Max number of concurrent queries to the storage per tenant.")
-	f.BoolVar(&cfg.DebugLogging, "experimental.tsdb.bucket-store.debug-logging", false, "Turn on debug logging.")
 	f.IntVar(&cfg.BlockSyncConcurrency, "experimental.tsdb.bucket-store.block-sync-concurrency", 20, "Number of Go routines to use when syncing blocks from object storage per tenant.")
 }

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -24,12 +24,12 @@ var (
 
 // Config holds the config information for TSDB storage
 type Config struct {
-	Dir            string            `yaml:"dir"`
-	BlockRanges    DurationList      `yaml:"block_ranges_period"`
-	Retention      time.Duration     `yaml:"retention_period"`
-	ShipInterval   time.Duration     `yaml:"ship_interval"`
-	Backend        string            `yaml:"backend"`
-	BucketStoreCfg BucketStoreConfig `yaml:"bucket_store_config"`
+	Dir          string            `yaml:"dir"`
+	BlockRanges  DurationList      `yaml:"block_ranges_period"`
+	Retention    time.Duration     `yaml:"retention_period"`
+	ShipInterval time.Duration     `yaml:"ship_interval"`
+	Backend      string            `yaml:"backend"`
+	BucketStore  BucketStoreConfig `yaml:"bucket_store"`
 
 	// Backends
 	S3  s3.Config  `yaml:"s3"`
@@ -70,7 +70,7 @@ func (d DurationList) ToMillisecondRanges() []int64 {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.S3.RegisterFlags(f)
 	cfg.GCS.RegisterFlags(f)
-	cfg.BucketStoreCfg.RegisterFlags(f)
+	cfg.BucketStore.RegisterFlags(f)
 
 	if len(cfg.BlockRanges) == 0 {
 		cfg.BlockRanges = []time.Duration{2 * time.Hour} // Default 2h block
@@ -94,7 +94,7 @@ func (cfg *Config) Validate() error {
 
 // BucketStoreConfig holds the config information for Bucket Stores used by the querier
 type BucketStoreConfig struct {
-	Dir                  string `yaml:"dir"`
+	SyncDir              string `yaml:"sync_dir"`
 	IndexCacheSizeBytes  uint64 `yaml:"index_cache_size_bytes"`
 	MaxChunkPoolBytes    uint64 `yaml:"max_chunk_pool_bytes"`
 	MaxSampleCount       uint64 `yaml:"max_sample_count"`
@@ -106,11 +106,11 @@ type BucketStoreConfig struct {
 // RegisterFlags registers the BucketStore flags
 func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 
-	f.StringVar(&cfg.Dir, "experimental.tsdb.bucket-store-config.dir", "tsdb-sync", "directory to place synced tsdb indicies")
-	f.Uint64Var(&cfg.IndexCacheSizeBytes, "experimental.tsdb.bucket-store-config.index-cache-size", uint64(250*units.Mebibyte), "size of index cache in bytes")
-	f.Uint64Var(&cfg.MaxChunkPoolBytes, "experimental.tsdb.bucket-store-config.max-chunk-pool-bytes", uint64(2*units.Gibibyte), "max size of chunk pool in bytes")
-	f.Uint64Var(&cfg.MaxSampleCount, "experimental.tsdb.bucket-store-config.max-sample-count", 0, "max number of samples (0 is no limit)")
-	f.IntVar(&cfg.MaxConcurrent, "experimental.tsdb.bucket-store-config.max-concurrent", 20, "max number of concurrent go routines")
-	f.BoolVar(&cfg.DebugLogging, "experimental.tsdb.bucket-store-config.debug-logging", false, "turn on debug logging")
-	f.IntVar(&cfg.BlockSyncConcurrency, "experimental.tsdb.bucket-store-config.block-sync-concurrency", 20, "max number of go routines to perform block sync functions")
+	f.StringVar(&cfg.Dir, "experimental.tsdb.bucket-store.sync-dir", "tsdb-sync", "Directory to place synced tsdb indicies.")
+	f.Uint64Var(&cfg.IndexCacheSizeBytes, "experimental.tsdb.bucket-store.index-cache-size-bytes", uint64(250*units.Mebibyte), "Size of index cache in bytes per tenant.")
+	f.Uint64Var(&cfg.MaxChunkPoolBytes, "experimental.tsdb.bucket-store.max-chunk-pool-bytes", uint64(2*units.Gibibyte), "Max size of chunk pool in bytes per tenant.")
+	f.Uint64Var(&cfg.MaxSampleCount, "experimental.tsdb.bucket-store.max-sample-count", 0, "Max number of samples (0 is no limit) per query when loading series from storage.")
+	f.IntVar(&cfg.MaxConcurrent, "experimental.tsdb.bucket-store.max-concurrent", 20, "Max number of concurrent queries to the storage per tenant.")
+	f.BoolVar(&cfg.DebugLogging, "experimental.tsdb.bucket-store.debug-logging", false, "Turn on debug logging.")
+	f.IntVar(&cfg.BlockSyncConcurrency, "experimental.tsdb.bucket-store.block-sync-concurrency", 20, "Number of Go routines to use when syncing blocks from object storage per tenant.")
 }


### PR DESCRIPTION
Signed-off-by: Thor <thansen@digitalocean.com>

**What this PR does**: Exposes the bucket store configuration that was previously hardcoded to configurable values.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
