### PR TITLE
Lower log level for query time range validation

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -265,7 +265,7 @@ func (c *store) validateQueryTimeRange(ctx context.Context, userID string, from 
 
 	if from.After(now) {
 		// time-span start is in future ... regard as legal
-		level.Error(log).Log("msg", "whole timerange in future, yield empty resultset", "through", through, "from", from, "now", now)
+		level.Info(log).Log("msg", "whole timerange in future, yield empty resultset", "through", through, "from", from, "now", now)
 		return true, nil
 	}
 
@@ -283,7 +283,7 @@ func (c *store) validateQueryTimeRange(ctx context.Context, userID string, from 
 
 	if through.After(now.Add(5 * time.Minute)) {
 		// time-span end is in future ... regard as legal
-		level.Error(log).Log("msg", "adjusting end timerange from future to now", "old_through", through, "new_through", now)
+		level.Info(log).Log("msg", "adjusting end timerange from future to now", "old_through", through, "new_through", now)
 		*through = now // Avoid processing future part - otherwise some schemas could fail with eg non-existent table gripes
 	}
 


### PR DESCRIPTION
**What this PR does**:
If a query contains an "out of bounds" time range, we currently log with the error level, but it's not something actionable. For this reason, I propose to lower these two log messages to info level.

**Which issue(s) this PR fixes**:
_No issue_

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
