### PR TITLE
Fixed HA Tracker jitter causing unnecessary CAS operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [BUGFIX] Fixed unnecessary CAS operations done by the HA tracker when the jitter is enabled. #1861
+
 ## 0.4.0 / 2019-12-02
 
 * [CHANGE] The frontend component has been refactored to be easier to re-use. When upgrading the frontend, cache entries will be discarded and re-created with the new protobuf schema. #1734

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -207,7 +207,7 @@ func (c *haTracker) checkReplica(ctx context.Context, userID, cluster, replica s
 	c.electedLock.RLock()
 	entry, ok := c.elected[key]
 	c.electedLock.RUnlock()
-	if ok && now.Sub(timestamp.Time(entry.ReceivedAt)) < c.cfg.UpdateTimeout {
+	if ok && now.Sub(timestamp.Time(entry.ReceivedAt)) < c.cfg.UpdateTimeout+c.updateTimeoutJitter {
 		if entry.Replica != replica {
 			return replicasNotMatchError(replica, entry.Replica)
 		}

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -2,6 +2,7 @@ package distributor
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -48,6 +49,9 @@ var (
 		Name:      "ha_tracker_kv_store_cas_total",
 		Help:      "The total number of CAS calls to the KV store for a user ID/cluster.",
 	}, []string{"user", "cluster"})
+
+	errNegativeUpdateTimeoutJitterMax = errors.New("HA tracker max update timeout jitter shouldn't be negative")
+	errInvalidFailoverTimeout         = "HA Tracker failover timeout (%v) must be at least 1s greater than update timeout - max jitter (%v)"
 )
 
 // ProtoReplicaDescFactory makes new InstanceDescs
@@ -117,10 +121,15 @@ func (cfg *HATrackerConfig) RegisterFlags(f *flag.FlagSet) {
 
 // Validate config and returns error on failure
 func (cfg *HATrackerConfig) Validate() error {
-	if cfg.FailoverTimeout < cfg.UpdateTimeout+cfg.UpdateTimeoutJitterMax+time.Second {
-		return fmt.Errorf("HA Tracker failover timeout (%v) must be at least 1s greater than update timeout (%v)",
-			cfg.FailoverTimeout, cfg.UpdateTimeout+cfg.UpdateTimeoutJitterMax+time.Second)
+	if cfg.UpdateTimeoutJitterMax < 0 {
+		return errNegativeUpdateTimeoutJitterMax
 	}
+
+	minFailureTimeout := cfg.UpdateTimeout + cfg.UpdateTimeoutJitterMax + time.Second
+	if cfg.FailoverTimeout < minFailureTimeout {
+		return fmt.Errorf(errInvalidFailoverTimeout, cfg.FailoverTimeout, minFailureTimeout)
+	}
+
 	return nil
 }
 

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -46,7 +46,8 @@ outer:
 			if r.GetReplica() != replica {
 				err = fmt.Errorf("replicas did not match: %s != %s", r.GetReplica(), replica)
 				continue outer
-			} else if !timestamp.Time(r.GetReceivedAt()).Equal(expected) {
+			}
+			if !timestamp.Time(r.GetReceivedAt()).Equal(expected) {
 				err = fmt.Errorf("timestamps did not match: %+v != %+v", timestamp.Time(r.GetReceivedAt()), expected)
 				continue outer
 			}


### PR DESCRIPTION
**What this PR does**:
Today me and @pstibrany spent few hours debugging an expected pattern on the number of CAS operations done by the distributors when the HA tracker is enabled.

We found out that the PR #1748 - which introduced the update timeout jitter - also introduced a time window (long as much as the jitter) during which every request does a CAS but the CAS operation itself doesn't update the replica updated timestamp, because the CAS is triggered if `now - receivedAt >= updateTimeout` but then the CAS function is a noop if `now - receivedAt < updateTimeout + jitter`.

While adding tests, I've also realized that the `checkReplicaTimestamp()` was broken (tests were actually failing) so I've fixed it.

**Which issue(s) this PR fixes**:
_No issue_

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
