### PR TITLE
memberlist: fix metric names and expose internal memberlist metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Masterminds/squirrel v0.0.0-20161115235646-20f192218cf5
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+	github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878
 	github.com/aws/aws-sdk-go v1.25.22
 	github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 // indirect
 	github.com/blang/semver v3.5.0+incompatible

--- a/pkg/ring/kv/memberlist/memberlist_client.go
+++ b/pkg/ring/kv/memberlist/memberlist_client.go
@@ -106,9 +106,8 @@ type Client struct {
 	storeValuesDesc *prometheus.Desc
 	storeSizesDesc  *prometheus.Desc
 
-	memberlistMembersCount    prometheus.GaugeFunc
-	memberlistHealthScore     prometheus.GaugeFunc
-	memberlistMembersInfoDesc *prometheus.Desc
+	memberlistMembersCount prometheus.GaugeFunc
+	memberlistHealthScore  prometheus.GaugeFunc
 }
 
 type valueDesc struct {

--- a/pkg/ring/kv/memberlist/metrics.go
+++ b/pkg/ring/kv/memberlist/metrics.go
@@ -17,7 +17,7 @@ func (m *Client) createAndRegisterMetrics() {
 	m.totalSizeOfReceivedMessages = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: m.cfg.MetricsNamespace,
 		Subsystem: subsystem,
-		Name:      "received_broadcasts_size",
+		Name:      "received_broadcasts_bytes",
 		Help:      "Total size of received broadcast user messages",
 	})
 
@@ -68,7 +68,7 @@ func (m *Client) createAndRegisterMetrics() {
 	m.totalSizeOfBroadcastMessagesInQueue = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: m.cfg.MetricsNamespace,
 		Subsystem: subsystem,
-		Name:      "messages_in_broadcast_size_total",
+		Name:      "messages_in_broadcast_queue_bytes",
 		Help:      "Total size of messages waiting in the broadcast queue",
 	})
 
@@ -96,11 +96,10 @@ func (m *Client) createAndRegisterMetrics() {
 	m.storeValuesDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(m.cfg.MetricsNamespace, subsystem, "kv_store_count"),
 		"Number of values in KV Store",
-		nil, nil,
-	)
+		nil, nil)
 
 	m.storeSizesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(m.cfg.MetricsNamespace, subsystem, "kv_store_value_size"),
+		prometheus.BuildFQName(m.cfg.MetricsNamespace, subsystem, "kv_store_value_bytes"),
 		"Sizes of values in KV Store in bytes",
 		[]string{"key"}, nil)
 
@@ -117,15 +116,10 @@ func (m *Client) createAndRegisterMetrics() {
 		Namespace: m.cfg.MetricsNamespace,
 		Subsystem: subsystem,
 		Name:      "cluster_node_health_score",
-		Help:      "Health score of this cluster. Lower the better. 0 = totally health",
+		Help:      "Health score of this cluster. Lower value is better. 0 = healthy",
 	}, func() float64 {
 		return float64(m.memberlist.GetHealthScore())
 	})
-
-	m.memberlistMembersInfoDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(m.cfg.MetricsNamespace, subsystem, "cluster_members_last_timestamp"),
-		"State information about memberlist cluster members",
-		[]string{"name", "address"}, nil)
 
 	m.watchPrefixDroppedNotifications = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: m.cfg.MetricsNamespace,
@@ -167,7 +161,6 @@ func (m *Client) createAndRegisterMetrics() {
 func (m *Client) Describe(ch chan<- *prometheus.Desc) {
 	ch <- m.storeValuesDesc
 	ch <- m.storeSizesDesc
-	ch <- m.memberlistMembersInfoDesc
 }
 
 // Collect returns extra metrics via supplied channel

--- a/pkg/ring/kv/memberlist/tcp_transport.go
+++ b/pkg/ring/kv/memberlist/tcp_transport.go
@@ -496,75 +496,75 @@ func (t *TCPTransport) Shutdown() error {
 }
 
 func (t *TCPTransport) registerMetrics() {
-	const subsystem = "tcp_transport"
+	const subsystem = "memberlist_tcp_transport"
 
 	t.incomingStreams = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: t.cfg.MetricsNamespace,
 		Subsystem: subsystem,
-		Name:      "incoming_memberlist_streams",
+		Name:      "incoming_streams_total",
 		Help:      "Number of incoming memberlist streams",
 	})
 
 	t.outgoingStreams = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: t.cfg.MetricsNamespace,
 		Subsystem: subsystem,
-		Name:      "outgoing_memberlist_streams",
+		Name:      "outgoing_streams_total",
 		Help:      "Number of outgoing streams",
 	})
 
 	t.outgoingStreamErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: t.cfg.MetricsNamespace,
 		Subsystem: subsystem,
-		Name:      "outgoing_memberlist_stream_errors",
+		Name:      "outgoing_stream_errors_total",
 		Help:      "Number of errors when opening memberlist stream to another node",
 	})
 
 	t.receivedPackets = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: t.cfg.MetricsNamespace,
 		Subsystem: subsystem,
-		Name:      "memberlist_packets_received",
+		Name:      "packets_received_total",
 		Help:      "Number of received memberlist packets",
 	})
 
 	t.receivedPacketsBytes = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: t.cfg.MetricsNamespace,
 		Subsystem: subsystem,
-		Name:      "memberlist_packets_received_bytes",
+		Name:      "packets_received_bytes_total",
 		Help:      "Total bytes received as packets",
 	})
 
 	t.receivedPacketsErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: t.cfg.MetricsNamespace,
 		Subsystem: subsystem,
-		Name:      "memberlist_packets_received_errors",
+		Name:      "packets_received_errors_total",
 		Help:      "Number of errors when receiving memberlist packets",
 	})
 
 	t.sentPackets = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: t.cfg.MetricsNamespace,
 		Subsystem: subsystem,
-		Name:      "memberlist_packets_sent",
+		Name:      "packets_sent_total",
 		Help:      "Number of memberlist packets sent",
 	})
 
 	t.sentPacketsBytes = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: t.cfg.MetricsNamespace,
 		Subsystem: subsystem,
-		Name:      "memberlist_packets_sent_bytes",
+		Name:      "packets_sent_bytes_total",
 		Help:      "Total bytes sent as packets",
 	})
 
 	t.sentPacketsErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: t.cfg.MetricsNamespace,
 		Subsystem: subsystem,
-		Name:      "memberlist_packets_sent_errors",
+		Name:      "packets_sent_errors_total",
 		Help:      "Number of errors when sending memberlist packets",
 	})
 
 	t.unknownConnections = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: t.cfg.MetricsNamespace,
 		Subsystem: subsystem,
-		Name:      "unknown_connections",
+		Name:      "unknown_connections_total",
 		Help:      "Number of unknown TCP connections (not a packet or stream)",
 	})
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -41,6 +41,7 @@ github.com/alecthomas/template/parse
 github.com/alecthomas/units
 # github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878
 github.com/armon/go-metrics
+github.com/armon/go-metrics/prometheus
 # github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 github.com/asaskevich/govalidator
 # github.com/aws/aws-sdk-go v1.25.22


### PR DESCRIPTION
This PR fixes some metrics names used by `memberlist.Client` (eg. `_size` -> `_bytes`), and configures "github.com/armon/go-metrics" library used by memberlist to write its metrics to Prometheus.

