### PR TITLE
Do not consider PENDING state as healthy

### DIFF
--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -184,7 +184,7 @@ func (d *Desc) TokensFor(id string) (tokens, other []uint32) {
 func (i *IngesterDesc) IsHealthy(op Operation, heartbeatTimeout time.Duration) bool {
 	if op == Write && i.State != ACTIVE {
 		return false
-	} else if op == Read && i.State == JOINING {
+	} else if op == Read && i.State != ACTIVE && i.State != LEAVING {
 		return false
 	}
 	return time.Now().Sub(time.Unix(i.Timestamp, 0)) <= heartbeatTimeout

--- a/pkg/ring/model_test.go
+++ b/pkg/ring/model_test.go
@@ -40,6 +40,18 @@ func TestIngesterDesc_IsHealthy(t *testing.T) {
 			writeExpected: false,
 			readExpected:  true,
 		},
+		"PENDING ingester with last keepalive newer than timeout": {
+			ingester:      &IngesterDesc{State: PENDING, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
+			timeout:       time.Minute,
+			writeExpected: false,
+			readExpected:  false,
+		},
+		"LEFT ingester with last keepalive newer than timeout": {
+			ingester:      &IngesterDesc{State: LEFT, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
+			timeout:       time.Minute,
+			writeExpected: false,
+			readExpected:  false,
+		},
 	}
 
 	for testName, testData := range tests {


### PR DESCRIPTION
**What this PR does**:
While working on the PR #1818 I've realized that an ingester is considered healthy for read operations while `PENDING` but not while `JOINING`. From my perspective, an ingester shouldn't be considered healthy while `PENDING`, so I'm suggesting to:

1. Do not consider `PENDING` state as healthy
2. Explicitly enumerate healthy ingester states for the read path

In the read path, there are some API endpoints like `LabelNames` and `LabelValuesForLabelName` for which we query all healthy ingesters (see `distributor.forAllIngesters()`). A `PENDING` ingester shouldn't hold any data yet, so shouldn't be required to be hit.

A comment I've received in a previous discussion on this topic is that this change may introduce quorum issues during ingesters rollout. However, I can't see a real difference compared to when the ingester switches from `PENDING` to `JOINING`, considered that we already consider the `JOINING` state as unhealthy.

**Which issue(s) this PR fixes**:
_No issue_

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
