### PR TITLE
Declass ingester fingerprint hash collision log to debug level

### DIFF
--- a/pkg/ingester/mapper.go
+++ b/pkg/ingester/mapper.go
@@ -105,7 +105,7 @@ func (m *fpMapper) maybeAddMapping(
 		// A new mapping has to be created.
 		mappedFP = m.nextMappedFP()
 		mappedFPs[ms] = mappedFP
-		level.Info(util.Logger).Log(
+		level.Debug(util.Logger).Log(
 			"msg", "fingerprint collision detected, mapping to new fingerprint",
 			"old_fp", fp,
 			"new_fp", mappedFP,
@@ -119,7 +119,7 @@ func (m *fpMapper) maybeAddMapping(
 	m.mtx.Lock()
 	m.mappings[fp] = mappedFPs
 	m.mtx.Unlock()
-	level.Info(util.Logger).Log(
+	level.Debug(util.Logger).Log(
 		"msg", "fingerprint collision detected, mapping to new fingerprint",
 		"old_fp", fp,
 		"new_fp", mappedFP,


### PR DESCRIPTION
**What this PR does**:
We're aware that there are fingerprint hash collisions and we handle them through the mapper. Is it really worth log them as Info level or can we declass it to Debug?

_A train of these logs is quite common during ingesters rollout, logged by the joining ingester while receiving all series from the leaving one._

**Which issue(s) this PR fixes**:
_No issue_

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
