### PR TITLE
Use same directory for temporary tokens file

### DIFF
--- a/pkg/ring/tokens.go
+++ b/pkg/ring/tokens.go
@@ -22,7 +22,7 @@ func (t Tokens) StoreToFile(tokenFilePath string) error {
 
 	// If any operations failed further in the function, we keep the temporary
 	// file hanging around for debugging.
-	f, err := ioutil.TempFile(os.TempDir(), "tokens")
+	f, err := os.Create(tokenFilePath + ".tmp")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I got the following error with the tokens on disk
```
level=error ts=2019-12-06T11:11:31.769733413Z caller=lifecycler.go:268 msg="error storing tokens to disk" path=/wal_data/tokens err="rename /tmp/tokens513306766 /wal_data/tokens: invalid cross-device link"
```
So would be better to use the same volume/directory to have the temporary file as well.