### PR TITLE
Fixed per-series sharding token generation in the distributor

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -389,12 +389,7 @@ func TestDistributorValidateSeriesLabelRemoval(t *testing.T) {
 		userID, err := user.ExtractOrgID(ctx)
 		assert.NoError(t, err)
 
-		key, err := d.tokenForLabels(userID, tc.series.Labels)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-
-		series, err := d.validateSeries(key, tc.series, userID, tc.removeReplica)
+		_, series, err := d.validateSeries(tc.series, userID, tc.removeReplica)
 		if !reflect.DeepEqual(series, tc.outputSeries) {
 			t.Fatalf("output of validate series did not match expected output:\n\texpected: %+v\n\t got: %+v", tc.outputSeries, series)
 		}


### PR DESCRIPTION
**What this PR does**:
The PR #1726 introduced some changes in the distributor to allow to drop labels on a per-tenant basis. These changes also unintentionally changed the actual per-series sharding token: we noticed it while rolling out in one of our clusters, where an almost full resharding occurred (switching the cluster from 5M active series to 9M active series until the old sharing chunks have been flushed).

Before the PR #1726, the token was generated based on the labels **without** the HA replica label. After the PR #1726, the token is generated based on the labels **with** the HA replica label.

In this PR I'm fixing it, rolling back to the old behaviour, while honoring the intention of the PR #1726: the token should be generated based on the labels **without** the HA replica label **and without** the dropped ones.

_I haven't updated the changelog because the PR #1726 has been merged after the `0.4.0` release, so it's still in the unreleased limbo._

**Which issue(s) this PR fixes**:
_No issue_

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
