### PR TITLE
Lower log level on ingester transfer failed because no pending ingester is found

### DIFF
--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -3,7 +3,6 @@ package ingester
 import (
 	"bytes"
 	"context"
-	go_errors "errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
@@ -391,15 +389,7 @@ func (i *Ingester) TransferOut(ctx context.Context) error {
 			return nil
 		}
 
-		// Log just with an info level errors which are expected to happen
-		var lvl log.Logger
-		if go_errors.Is(err, errTransferNoPendingIngesters) {
-			lvl = level.Info(util.Logger)
-		} else {
-			lvl = level.Warn(util.Logger)
-		}
-
-		lvl.Log("msg", "transfer attempt failed", "err", err, "attempt", backoff.NumRetries()+1, "max_retries", i.cfg.MaxTransferRetries)
+		level.Warn(util.Logger).Log("msg", "transfer attempt failed", "err", err, "attempt", backoff.NumRetries()+1, "max_retries", i.cfg.MaxTransferRetries)
 
 		backoff.Wait()
 	}


### PR DESCRIPTION
**What this PR does**:
While rolling out ingesters it's usual to get a train of errors `no pending ingesters` while the leaving ingester has started the shutdown procedure but there's still no joining ingester. This is not really an issue, as far as the joining ingester is found before the end of all retries.

In this PR I'm suggesting to lower the log level to Warn while retrying, while logging it as error if persists once all retries have been done.

**Which issue(s) this PR fixes**:
_No issue_

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
