### PR TITLE
Explicit healty states

### DIFF
--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -182,12 +182,17 @@ func (d *Desc) TokensFor(id string) (tokens, other []uint32) {
 
 // IsHealthy checks whether the ingester appears to be alive and heartbeating
 func (i *IngesterDesc) IsHealthy(op Operation, heartbeatTimeout time.Duration) bool {
-	if op == Write && i.State != ACTIVE {
-		return false
-	} else if op == Read && i.State == JOINING {
-		return false
+	healthy := false
+
+	if op == Write && i.State == ACTIVE {
+		healthy = true
 	}
-	return time.Now().Sub(time.Unix(i.Timestamp, 0)) <= heartbeatTimeout
+
+	if op == Read && (i.State == ACTIVE || i.State == LEAVING || i.State == PENDING) {
+		healthy = true
+	}
+
+	return healthy && time.Now().Sub(time.Unix(i.Timestamp, 0)) <= heartbeatTimeout
 }
 
 // Merge merges other ring into this one. Returns sub-ring that represents the change,

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -184,15 +184,14 @@ func (d *Desc) TokensFor(id string) (tokens, other []uint32) {
 func (i *IngesterDesc) IsHealthy(op Operation, heartbeatTimeout time.Duration) bool {
 	healthy := false
 
-	if op == Write && i.State == ACTIVE {
-		healthy = true
-	}
+	switch op {
+	case Write:
+		healthy = i.State == ACTIVE
 
-	if op == Read && (i.State == ACTIVE || i.State == LEAVING || i.State == PENDING) {
-		healthy = true
-	}
+	case Read:
+		healthy = i.State == ACTIVE || i.State == LEAVING || i.State == PENDING
 
-	if op == Reporting {
+	case Reporting:
 		healthy = true
 	}
 

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -192,6 +192,10 @@ func (i *IngesterDesc) IsHealthy(op Operation, heartbeatTimeout time.Duration) b
 		healthy = true
 	}
 
+	if op == Reporting {
+		healthy = true
+	}
+
 	return healthy && time.Now().Sub(time.Unix(i.Timestamp, 0)) <= heartbeatTimeout
 }
 

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -186,10 +186,10 @@ func (i *IngesterDesc) IsHealthy(op Operation, heartbeatTimeout time.Duration) b
 
 	switch op {
 	case Write:
-		healthy = i.State == ACTIVE
+		healthy = (i.State == ACTIVE)
 
 	case Read:
-		healthy = i.State == ACTIVE || i.State == LEAVING || i.State == PENDING
+		healthy = (i.State == ACTIVE) || (i.State == LEAVING) || (i.State == PENDING)
 
 	case Reporting:
 		healthy = true

--- a/pkg/ring/model_test.go
+++ b/pkg/ring/model_test.go
@@ -11,34 +11,39 @@ func TestIngesterDesc_IsHealthy(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		ingester      *IngesterDesc
-		timeout       time.Duration
-		writeExpected bool
-		readExpected  bool
+		ingester       *IngesterDesc
+		timeout        time.Duration
+		writeExpected  bool
+		readExpected   bool
+		reportExpected bool
 	}{
 		"ALIVE ingester with last keepalive newer than timeout": {
-			ingester:      &IngesterDesc{State: ACTIVE, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
-			timeout:       time.Minute,
-			writeExpected: true,
-			readExpected:  true,
+			ingester:       &IngesterDesc{State: ACTIVE, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
+			timeout:        time.Minute,
+			writeExpected:  true,
+			readExpected:   true,
+			reportExpected: true,
 		},
 		"ALIVE ingester with last keepalive older than timeout": {
-			ingester:      &IngesterDesc{State: ACTIVE, Timestamp: time.Now().Add(-90 * time.Second).Unix()},
-			timeout:       time.Minute,
-			writeExpected: false,
-			readExpected:  false,
+			ingester:       &IngesterDesc{State: ACTIVE, Timestamp: time.Now().Add(-90 * time.Second).Unix()},
+			timeout:        time.Minute,
+			writeExpected:  false,
+			readExpected:   false,
+			reportExpected: false,
 		},
 		"JOINING ingester with last keepalive newer than timeout": {
-			ingester:      &IngesterDesc{State: JOINING, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
-			timeout:       time.Minute,
-			writeExpected: false,
-			readExpected:  false,
+			ingester:       &IngesterDesc{State: JOINING, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
+			timeout:        time.Minute,
+			writeExpected:  false,
+			readExpected:   false,
+			reportExpected: true,
 		},
 		"LEAVING ingester with last keepalive newer than timeout": {
-			ingester:      &IngesterDesc{State: LEAVING, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
-			timeout:       time.Minute,
-			writeExpected: false,
-			readExpected:  true,
+			ingester:       &IngesterDesc{State: LEAVING, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
+			timeout:        time.Minute,
+			writeExpected:  false,
+			readExpected:   true,
+			reportExpected: true,
 		},
 	}
 
@@ -51,6 +56,9 @@ func TestIngesterDesc_IsHealthy(t *testing.T) {
 
 			actual = testData.ingester.IsHealthy(Read, testData.timeout)
 			assert.Equal(t, testData.readExpected, actual)
+
+			actual = testData.ingester.IsHealthy(Reporting, testData.timeout)
+			assert.Equal(t, testData.reportExpected, actual)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:
Inspired by PR #1866, this PR changes `IsHealthy` function to be explicit about which states are healthy. There is no change in functionality.

**Which issue(s) this PR fixes**:
There is no bug.

**Checklist**
- [x] Tests updated
- [ ] No documentation changes
- [ ] `CHANGELOG.md` updated - no functionality change
