### PR TITLE
Export queryrange doRequests.

### DIFF
--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -152,7 +152,7 @@ func (s resultsCache) handleMiss(ctx context.Context, r Request) (Response, []Ex
 
 func (s resultsCache) handleHit(ctx context.Context, r Request, extents []Extent) (Response, []Extent, error) {
 	var (
-		reqResps []requestResponse
+		reqResps []RequestResponse
 		err      error
 	)
 	log, ctx := spanlogger.New(ctx, "handleHit")
@@ -168,14 +168,14 @@ func (s resultsCache) handleHit(ctx context.Context, r Request, extents []Extent
 		return response, nil, err
 	}
 
-	reqResps, err = doRequests(ctx, s.next, requests, s.limits)
+	reqResps, err = DoRequests(ctx, s.next, requests, s.limits)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	for _, reqResp := range reqResps {
-		responses = append(responses, reqResp.resp)
-		extent, err := toExtent(ctx, reqResp.req, reqResp.resp)
+		responses = append(responses, reqResp.Response)
+		extent, err := toExtent(ctx, reqResp.Request, reqResp.Response)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -29,14 +29,14 @@ func (s splitByInterval) Do(ctx context.Context, r Request) (Response, error) {
 	// to line up the boundaries with step.
 	reqs := splitQuery(r, s.interval)
 
-	reqResps, err := doRequests(ctx, s.next, reqs, s.limits)
+	reqResps, err := DoRequests(ctx, s.next, reqs, s.limits)
 	if err != nil {
 		return nil, err
 	}
 
 	resps := make([]Response, 0, len(reqResps))
 	for _, reqResp := range reqResps {
-		resps = append(resps, reqResp.resp)
+		resps = append(resps, reqResp.Response)
 	}
 
 	response, err := s.merger.MergeResponse(resps...)


### PR DESCRIPTION
This makes the function `doRequests` externally accessible and reusable by the Loki frontend.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
