### PR TITLE
Pass Request to DecodeResponse in case it is required.

### DIFF
--- a/pkg/querier/queryrange/marshaling_test.go
+++ b/pkg/querier/queryrange/marshaling_test.go
@@ -19,7 +19,7 @@ func BenchmarkMarshalling(b *testing.B) {
 		apiResp, err := PrometheusCodec.DecodeResponse(context.Background(), &http.Response{
 			StatusCode: 200,
 			Body:       ioutil.NopCloser(bytes.NewReader(buf)),
-		})
+		}, nil)
 		require.NoError(b, err)
 
 		resp, err := PrometheusCodec.EncodeResponse(context.Background(), apiResp)

--- a/pkg/querier/queryrange/query_range.go
+++ b/pkg/querier/queryrange/query_range.go
@@ -40,7 +40,9 @@ type Codec interface {
 	Merger
 	// DecodeRequest decodes a Request from an http request.
 	DecodeRequest(context.Context, *http.Request) (Request, error)
-	// DecodeResponse decodes a Response from an http response..
+	// DecodeResponse decodes a Response from an http response.
+	// The original request is also passed as a parameter this is useful for implementation that needs the request
+	// to merge result or build the result correctly.
 	DecodeResponse(context.Context, *http.Response, Request) (Response, error)
 	// EncodeRequest encodes a Request into an http request.
 	EncodeRequest(context.Context, Request) (*http.Request, error)

--- a/pkg/querier/queryrange/query_range.go
+++ b/pkg/querier/queryrange/query_range.go
@@ -41,7 +41,7 @@ type Codec interface {
 	// DecodeRequest decodes a Request from an http request.
 	DecodeRequest(context.Context, *http.Request) (Request, error)
 	// DecodeResponse decodes a Response from an http response..
-	DecodeResponse(context.Context, *http.Response) (Response, error)
+	DecodeResponse(context.Context, *http.Response, Request) (Response, error)
 	// EncodeRequest encodes a Request into an http request.
 	EncodeRequest(context.Context, Request) (*http.Request, error)
 	// EncodeResponse encodes a Response into an http response.
@@ -198,7 +198,7 @@ func (prometheusCodec) EncodeRequest(ctx context.Context, r Request) (*http.Requ
 	return req.WithContext(ctx), nil
 }
 
-func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response) (Response, error) {
+func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ Request) (Response, error) {
 	if r.StatusCode/100 != 2 {
 		body, _ := ioutil.ReadAll(r.Body)
 		return nil, httpgrpc.Errorf(r.StatusCode, string(body))

--- a/pkg/querier/queryrange/query_range_test.go
+++ b/pkg/querier/queryrange/query_range_test.go
@@ -89,7 +89,7 @@ func TestResponse(t *testing.T) {
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 				Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(tc.body))),
 			}
-			resp, err := PrometheusCodec.DecodeResponse(context.Background(), response)
+			resp, err := PrometheusCodec.DecodeResponse(context.Background(), response, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, resp)
 

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -176,5 +176,5 @@ func (q roundTripper) Do(ctx context.Context, r Request) (Response, error) {
 	}
 	defer func() { _ = response.Body.Close() }()
 
-	return q.codec.DecodeResponse(ctx, response)
+	return q.codec.DecodeResponse(ctx, response, r)
 }


### PR DESCRIPTION
Loki has the concept of log Direction which is essential to know when
merging responses. This change allows Loki to inject the direction in the
response which can be then used when merging multiple responses.

Cortex doesn't need to use this.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>