### PR TITLE
Fix redirects on /ring page by using relative targets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@
   * `ruler.rule-path` has been added to specify where the prometheus rule manager will sync rule files
   * `ruler.storage.type` has beem added to specify the rule store backend type, currently only the configdb.
   * `ruler.poll-interval` has been added to specify the interval in which to poll new rule groups.
+* [CHANGE] Use relative links from /ring page to make it work when used behind reverse proxy. #1896
 * [FEATURE] The distributor can now drop labels from samples (similar to the removal of the replica label for HA ingestion) per user via the `distributor.drop-label` flag. #1726
 * [BUGFIX] Fixed unnecessary CAS operations done by the HA tracker when the jitter is enabled. #1861
-* [CHANGE] Use relative links from /ring page to make it work when used behind reverse proxy. #1896
 
 ## 0.4.0 / 2019-12-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * `ruler.poll-interval` has been added to specify the interval in which to poll new rule groups.
 * [FEATURE] The distributor can now drop labels from samples (similar to the removal of the replica label for HA ingestion) per user via the `distributor.drop-label` flag. #1726
 * [BUGFIX] Fixed unnecessary CAS operations done by the HA tracker when the jitter is enabled. #1861
+* [CHANGE] Use relative links from /ring page to make it work when used behind reverse proxy. #1896
 
 ## 0.4.0 / 2019-12-02
 

--- a/pkg/ring/http.go
+++ b/pkg/ring/http.go
@@ -101,7 +101,7 @@ func (r *Ring) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		// http.Redirect() would convert our relative URL to absolute, which is not what we want.
 		// Browser knows how to do that, and it also knows real URL. Furthermore it will also preserve tokens parameter.
-		// Note that relative Location URLs are explicitely allowed by specification, so we're not doing anything wrong here.
+		// Note that relative Location URLs are explicitly allowed by specification, so we're not doing anything wrong here.
 		w.Header().Set("Location", "#")
 		w.WriteHeader(http.StatusFound)
 

--- a/pkg/ring/http.go
+++ b/pkg/ring/http.go
@@ -59,9 +59,9 @@ const tpl = `
 			</table>
 			<br>
 			{{ if .ShowTokens }}
-			<input type="button" value="Hide Ingester Tokens" onclick="window.location.href = '/ring'" />
+			<input type="button" value="Hide Ingester Tokens" onclick="window.location.href = '?tokens=false' " />
 			{{ else }}
-			<input type="button" value="Show Ingester Tokens" onclick="window.location.href = '/ring?tokens=true'" />
+			<input type="button" value="Show Ingester Tokens" onclick="window.location.href = '?tokens=true'" />
 			{{ end }}
 			<pre>{{ .Ring }}</pre>
 		</form>
@@ -98,7 +98,13 @@ func (r *Ring) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		// Implement PRG pattern to prevent double-POST and work with CSRF middleware.
 		// https://en.wikipedia.org/wiki/Post/Redirect/Get
-		http.Redirect(w, req, req.RequestURI, http.StatusFound)
+
+		// http.Redirect() would convert our relative URL to absolute, which is not what we want.
+		// Browser knows how to do that, and it also knows real URL. Furthermore it will also preserve tokens parameter.
+		// Note that relative Location URLs are explicitely allowed by specification, so we're not doing anything wrong here.
+		w.Header().Set("Location", "#")
+		w.WriteHeader(http.StatusFound)
+
 		return
 	}
 


### PR DESCRIPTION
**What this PR does**: This PR changes redirects from /ring page to use relative links, instead of path-absolute. This is useful when running distributor HTTP server behind reverse proxy, which maps it to a different path than root.

**Checklist**
- [ ] Tests updated - nope, tested manually
- [ ] Documentation added - nope
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
