### PR TITLE
Ensure metric name is not pointing into gRPC buffer

### DIFF
--- a/pkg/util/extract/extract.go
+++ b/pkg/util/extract/extract.go
@@ -12,7 +12,9 @@ import (
 func MetricNameFromLabelAdapters(labels []client.LabelAdapter) (string, error) {
 	for _, label := range labels {
 		if label.Name == model.MetricNameLabel {
-			return label.Value, nil
+			// Force a string copy since LabelAdapter is often a pointer into
+			// a large gRPC buffer which we don't want to keep alive on the heap.
+			return string([]byte(label.Value)), nil
 		}
 	}
 	return "", fmt.Errorf("No metric name label")


### PR DESCRIPTION
This relates to #1852 - not sure if it's the only problem but I think this will help.

The chain of ownership:
Strings are pulled directly from the gRPC buffer without copying: https://github.com/cortexproject/cortex/blob/fcbc186d495aea15650d353775677b787d53863c/pkg/ingester/client/timeseries.go#L188

This value is pulled out by `MetricNameFromLabelAdapters()`:
https://github.com/cortexproject/cortex/blob/fcbc186d495aea15650d353775677b787d53863c/pkg/util/extract/extract.go#L15

`metricName` is passed down: https://github.com/cortexproject/cortex/blob/fcbc186d495aea15650d353775677b787d53863c/pkg/ingester/user_state.go#L209

and used as a key into a map:
https://github.com/cortexproject/cortex/blob/fcbc186d495aea15650d353775677b787d53863c/pkg/ingester/user_state.go#L236