### PR TITLE
Fix reuse slice in distributor.Push()

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -353,6 +353,10 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 				// These samples have been deduped.
 				dedupedSamples.WithLabelValues(userID, cluster).Add(float64(numSamples))
 			}
+
+			// Ensure the request slice is reused if the series get deduped.
+			client.ReuseSlice(req.Timeseries)
+
 			return nil, err
 		}
 		// If there wasn't an error but removeReplica is false that means we didn't find both HA labels.
@@ -401,11 +405,17 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 	receivedSamples.WithLabelValues(userID).Add(float64(validatedSamples))
 
 	if len(keys) == 0 {
+		// Ensure the request slice is reused if there's no series passing the validation.
+		client.ReuseSlice(req.Timeseries)
+
 		return &client.WriteResponse{}, lastPartialErr
 	}
 
 	limiter := d.getOrCreateIngestLimiter(userID)
 	if !limiter.AllowN(time.Now(), validatedSamples) {
+		// Ensure the request slice is reused if the request is rate limited.
+		client.ReuseSlice(req.Timeseries)
+
 		// Return a 4xx here to have the client discard the data and not retry. If a client
 		// is sending too much data consistently we will unlikely ever catch up otherwise.
 		validation.DiscardedSamples.WithLabelValues(validation.RateLimited, userID).Add(float64(validatedSamples))


### PR DESCRIPTION
**What this PR does**:
While investigating the issue #1895, I've realized the request slice is not reused in case the request gets skipped because of HA dedup or rate limiting. In case all incoming requests have the HA enabled, it's 50% of requests. This PR fixes it.

**Which issue(s) this PR fixes**:
_No issue_

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
