### PR TITLE
Doing an initial synch and then sleep to space out subsequent cycles.…

### DIFF
--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -167,9 +167,6 @@ func (m *TableManager) Stop() {
 func (m *TableManager) loop() {
 	defer m.wait.Done()
 
-	// Sleep for a bit to spread the sync load across different times if the tablemanagers are all started at once.
-	time.Sleep(time.Duration(rand.Int63n(int64(m.cfg.DynamoDBPollInterval))))
-
 	ticker := time.NewTicker(m.cfg.DynamoDBPollInterval)
 	defer ticker.Stop()
 
@@ -178,6 +175,9 @@ func (m *TableManager) loop() {
 	}); err != nil {
 		level.Error(util.Logger).Log("msg", "error syncing tables", "err", err)
 	}
+
+	// Sleep for a bit to spread the sync load across different times if the tablemanagers are all started at once.
+	time.Sleep(time.Duration(rand.Int63n(int64(m.cfg.DynamoDBPollInterval))))
 
 	for {
 		select {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adding sleep after initial SynchTable operation to spread out subsequent synch.
**Which issue(s) this PR fixes**:
Fixes #1618 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
