### PR TITLE
pkg/ring/kv/memberlist: Increase max number of CAS retries when running with multiple goroutines using same KV.

### DIFF
--- a/pkg/ring/kv/memberlist/memberlist_client_test.go
+++ b/pkg/ring/kv/memberlist/memberlist_client_test.go
@@ -405,6 +405,7 @@ func TestMultipleCAS(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to setup KV client", err)
 	}
+	kv.maxCasRetries = 20
 	defer kv.Stop()
 
 	wg := &sync.WaitGroup{}
@@ -419,7 +420,7 @@ func TestMultipleCAS(t *testing.T) {
 			defer wg.Done()
 			<-start
 			up := updateFn(name)
-			cas(t, kv, "test", up) // PENDING state
+			cas(t, kv, "test", up) // JOINING state
 			cas(t, kv, "test", up) // ACTIVE state
 		}(fmt.Sprintf(namePattern, i))
 	}


### PR DESCRIPTION
Make max CAS retries configurable for tests. Default value is fine for normal usage where updates are coming from network, but when running tests with many goroutines using same KV, default can be too low. Fixes failed tests seen in CI system.

**Checklist**
- [x] Tests updated
- [ ] No documentation change
- [ ] No changelog change