### PR TITLE
Fix readme logo path to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="imgs/logo.png" alt="Cortex Logo"></p>
+<p align="center"><img src="images/logo.png" alt="Cortex Logo"></p>
 
 [![Circle CI](https://circleci.com/gh/cortexproject/cortex/tree/master.svg?style=shield)](https://circleci.com/gh/cortexproject/cortex/tree/master)
 [![GoDoc](https://godoc.org/github.com/cortexproject/cortex?status.svg)](https://godoc.org/github.com/cortexproject/cortex)


### PR DESCRIPTION
**What this PR does**:
Changing the readme logo path from `imgs` to `images` after the new website changes.

This seems to be the only such issue after the website changes, all the other docs paths were updated.