### PR TITLE
Updating logo path in README to correct images folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="imgs/logo.png" alt="Cortex Logo"></p>
+<p align="center"><img src="images/logo.png" alt="Cortex Logo"></p>
 
 [![Circle CI](https://circleci.com/gh/cortexproject/cortex/tree/master.svg?style=shield)](https://circleci.com/gh/cortexproject/cortex/tree/master)
 [![GoDoc](https://godoc.org/github.com/cortexproject/cortex?status.svg)](https://godoc.org/github.com/cortexproject/cortex)


### PR DESCRIPTION
Signed-off-by: Matt Mendick <matt.mendick@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->
**What this PR does**:
Changing the readme logo path from `imgs` to `images` after the new website changes.

This seems to be the only such issue after the website changes, all the other docs paths were updated.