### PR TITLE
Do not consider disabled transfer as failed transfer

### DIFF
--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -397,7 +397,7 @@ func fromWireChunks(wireChunks []client.Chunk) ([]*desc, error) {
 // Called as part of the ingester shutdown process.
 func (i *Ingester) TransferOut(ctx context.Context) error {
 	if i.cfg.MaxTransferRetries <= 0 {
-		return fmt.Errorf("transfers disabled")
+		return ring.ErrTransferDisabled
 	}
 	backoff := util.NewBackoff(ctx, util.BackoffConfig{
 		MinBackoff: 100 * time.Millisecond,

--- a/pkg/ring/flush.go
+++ b/pkg/ring/flush.go
@@ -1,6 +1,12 @@
 package ring
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrTransferDisabled is the error returned by TransferOut when the transfers are disabled.
+var ErrTransferDisabled = errors.New("transfers disabled")
 
 // FlushTransferer controls the shutdown of an instance in the ring.
 type FlushTransferer interface {


### PR DESCRIPTION
If transfers are disabled, a skipped transfer could result in a fake alert if alerting on the metric.

In this PR: If transfers are disabled, don't count that as a failure in the metric.

/cc @pracucci 