### PR TITLE
Limit concurrent replays of TSDB on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 * [FEATURE] EXPERIMENTAL: Added `/series` API endpoint support with TSDB blocks storage. #1830
 * [FEATURE] Added "multi" KV store that can interact with two other KV stores, primary one for all reads and writes, and secondary one, which only receives writes. Primary/secondary store can be modified in runtime via runtime-config mechanism (previously "overrides"). #1749
 * [ENHANCEMENT] Added `password` and `enable_tls` options to redis cache configuration. Enables usage of Microsoft Azure Cache for Redis service.
+* [ENHANCEMENT] Experimental TSDB: Open existing TSDB on startup to prevent ingester from becoming ready before it can accept writes. #1917
+  * `--experimental.tsdb.max-tsdb-opening-concurrency-on-startup`
 * [BUGFIX] Fixed unnecessary CAS operations done by the HA tracker when the jitter is enabled. #1861
 * [BUGFIX] Fixed #1904 ingesters getting stuck in a LEAVING state after coming up from an ungraceful exit. #1921
 * [BUGFIX] TSDB: Fixed handling of out of order/bound samples in ingesters with the experimental TSDB blocks storage. #1864

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -744,4 +745,81 @@ func newIngesterMockWithTSDBStorage(ingesterCfg Config, registerer prometheus.Re
 	}
 
 	return ingester, cleanup, nil
+}
+
+func TestIngester_v2LoadTSDBOnStartup(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		setup func(*testing.T, string)
+		check func(*testing.T, *Ingester)
+	}{
+		"empty user dir": {
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.Mkdir(filepath.Join(dir, "user0"), 0700))
+			},
+			check: func(t *testing.T, i *Ingester) {
+				require.Empty(t, i.getTSDB("user0"), "tsdb created for empty user dir")
+			},
+		},
+		"empty tsdbs": {
+			setup: func(t *testing.T, dir string) {},
+			check: func(t *testing.T, i *Ingester) {
+				require.Zero(t, len(i.TSDBState.dbs), "user tsdb's were created on empty dir")
+			},
+		},
+		"missing tsdb dir": {
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.Remove(dir))
+			},
+			check: func(t *testing.T, i *Ingester) {
+				require.Zero(t, len(i.TSDBState.dbs), "user tsdb's were created on missing dir")
+			},
+		},
+		"populated user dirs with unpopulated": {
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "user0", "dummy"), 0700))
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "user1", "dummy"), 0700))
+				require.NoError(t, os.Mkdir(filepath.Join(dir, "user2"), 0700))
+			},
+			check: func(t *testing.T, i *Ingester) {
+				require.NotNil(t, i.getTSDB("user0"), "tsdb not created for non-empty user dir")
+				require.NotNil(t, i.getTSDB("user1"), "tsdb not created for non-empty user dir")
+				require.Empty(t, i.getTSDB("user2"), "tsdb created for empty user dir")
+			},
+		},
+	}
+
+	for name, test := range tests {
+		testName := name
+		testData := test
+		t.Run(testName, func(t *testing.T) {
+			clientCfg := defaultClientTestConfig()
+			limits := defaultLimitsTestConfig()
+
+			overrides, err := validation.NewOverrides(limits, nil)
+			require.NoError(t, err)
+
+			// Create a temporary directory for TSDB
+			tempDir, err := ioutil.TempDir("", "tsdb")
+			require.NoError(t, err)
+			defer os.RemoveAll(tempDir)
+
+			ingesterCfg := defaultIngesterTestConfig()
+			ingesterCfg.TSDBEnabled = true
+			ingesterCfg.TSDBConfig.Dir = tempDir
+			ingesterCfg.TSDBConfig.Backend = "s3"
+			ingesterCfg.TSDBConfig.S3.Endpoint = "localhost"
+
+			// setup the tsdbs dir
+			testData.setup(t, tempDir)
+
+			ingester, err := NewV2(ingesterCfg, clientCfg, overrides, nil)
+			require.NoError(t, err)
+
+			defer ingester.Shutdown()
+
+			testData.check(t, ingester)
+		})
+	}
 }

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -37,6 +37,9 @@ type Config struct {
 	Backend      string            `yaml:"backend"`
 	BucketStore  BucketStoreConfig `yaml:"bucket_store"`
 
+	// MaxTSDBOpeningConcurrencyOnStartup limits the number of concurrently opening TSDB's during startup
+	MaxTSDBOpeningConcurrencyOnStartup int `yaml:"max_tsdb_opening_concurrency_on_startup"`
+
 	// Backends
 	S3  s3.Config  `yaml:"s3"`
 	GCS gcs.Config `yaml:"gcs"`
@@ -87,6 +90,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.Retention, "experimental.tsdb.retention-period", 6*time.Hour, "TSDB block retention")
 	f.DurationVar(&cfg.ShipInterval, "experimental.tsdb.ship-interval", 30*time.Second, "the frequency at which tsdb blocks are scanned for shipping. 0 means shipping is disabled.")
 	f.StringVar(&cfg.Backend, "experimental.tsdb.backend", "s3", "TSDB storage backend to use")
+	f.IntVar(&cfg.MaxTSDBOpeningConcurrencyOnStartup, "experimental.tsdb.max-tsdb-opening-concurrency-on-startup", 10, "limit the number of concurrently opening TSDB's on startup")
 }
 
 // Validate the config


### PR DESCRIPTION
**What this PR does**: Experimental TSDB change only. On startup walk the TSDB dir, and open a TSDB under each user dir. Limiting the number of concurrently opening TSDB. 

Large memory spikes were observed when Ingesters would startup that had a large number of users with WALs. 
![image](https://user-images.githubusercontent.com/8681572/70936384-16be8c80-203a-11ea-8acc-c27368c1c93b.png)

This was causing oom kills on ingesters that would otherwise be able to run just fine. This change limits the number of TSDBs that can be opening at once, by opening all pre-existing user TSDBs at startup.

It does not open a TSDB for an empty user dir, which means it has no interaction with a transfer, since transfers delete empty dirs, and error out on non-empty user dirs.

Edit: While this change is still useful it doesn't address the memory usage spikes seen above, and because of a missed lock when looking over the code WAL's weren't being replayed in parallel. WAL replay still eats a large amount of memory regardless of how many are happening in parallel.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
