### PR TITLE
Removes check for path in queryrange roundtripper.

### DIFF
--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -120,7 +120,7 @@ func NewTripperware(cfg Config, log log.Logger, limits Limits, codec Codec, cach
 		// Finally, if the user selected any query range middleware, stitch it in.
 		if len(queryRangeMiddleware) > 0 {
 			queryrange := NewRoundTripper(next, codec, queryRangeMiddleware...)
-			return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			return frontend.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 				if !strings.HasSuffix(r.URL.Path, "/query_range") {
 					return next.RoundTrip(r)
 				}
@@ -129,14 +129,6 @@ func NewTripperware(cfg Config, log log.Logger, limits Limits, codec Codec, cach
 		}
 		return next
 	}), c, nil
-}
-
-// RoundTripperFunc is a syntax sugar for declaring http.RoundTripper from a function.
-type RoundTripperFunc func(*http.Request) (*http.Response, error)
-
-// RoundTrip uses the function to roundtrip the request.
-func (fn RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return fn(req)
 }
 
 type roundTripper struct {

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/user"
@@ -18,10 +19,14 @@ func TestRoundTrip(t *testing.T) {
 	s := httptest.NewServer(
 		middleware.AuthenticateUser.Wrap(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var err error
 				if r.RequestURI == query {
-					w.Write([]byte(responseBody))
+					_, err = w.Write([]byte(responseBody))
 				} else {
-					w.Write([]byte("bar"))
+					_, err = w.Write([]byte("bar"))
+				}
+				if err != nil {
+					t.Fatal(err)
 				}
 			}),
 		),
@@ -36,7 +41,10 @@ func TestRoundTrip(t *testing.T) {
 		next: http.DefaultTransport,
 	}
 
-	roundtripper := NewRoundTripper(downstream, PrometheusCodec, LimitsMiddleware(fakeLimits{}))
+	tw, _, err := NewTripperware(Config{}, util.Logger, fakeLimits{}, PrometheusCodec, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for i, tc := range []struct {
 		path, expectedBody string
@@ -56,7 +64,7 @@ func TestRoundTrip(t *testing.T) {
 			err = user.InjectOrgIDIntoHTTPRequest(ctx, req)
 			require.NoError(t, err)
 
-			resp, err := roundtripper.RoundTrip(req)
+			resp, err := tw(downstream).RoundTrip(req)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.StatusCode)
 


### PR DESCRIPTION
This is now done in the queryrange tripperware, the idea is to be able to reuse
the roundtripper code for other endpoint like labels.

I think a natural next step would be to move all this generic code, that can be reused outside of the queryrange package.

This include interfaces like `Codec`,`Request`,`Middlewares`,`Reponse`, at the I was thinking inside the package frontend.