### PR TITLE
Fix/lifecycler/stuck in leaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [FEATURE] Added `global` ingestion rate limiter strategy. Deprecated `-distributor.limiter-reload-period` flag. #1766
 * [FEATURE] Added support for Microsoft Azure blob storage to be used for storing chunk data. #1913
 * [BUGFIX] Fixed unnecessary CAS operations done by the HA tracker when the jitter is enabled. #1861
+* [BUGFIX] Fixed #1904 ingesters getting stuck in a LEAVING state after coming up from an ungraceful exit. #1921
   
 ## 0.4.0 / 2019-12-02
 

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -497,6 +497,12 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 			return ringDesc, true, nil
 		}
 
+		// If the ingester failed to clean it's ring entry up in can leave it's state in LEAVING.
+		// Move it into ACTIVE to ensure the ingester joins the ring.
+		if ingesterDesc.State == LEAVING && len(ingesterDesc.Tokens) == i.cfg.NumTokens {
+			ingesterDesc.State = ACTIVE
+		}
+
 		// We exist in the ring, so assume the ring is right and copy out tokens & state out of there.
 		i.setState(ingesterDesc.State)
 		tokens, _ := ringDesc.TokensFor(i.ID)


### PR DESCRIPTION
**What this PR does**: I've observed ingesters that were evicted and then rescheduled. They were unable to gracefully shutdown and left their state in the ring as LEAVING. On reschedule the ingester found itself in the LEAVING state. Set itself to the LEAVING state and was then unable to join the cluster. 

This allows an ingester that finds itself in the LEAVING state with tokens to mark itself as ACTIVE.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
