### PR TITLE
Reduce memory usage from ingester Push() errors

### DIFF
--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -1,0 +1,68 @@
+package ingester
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/weaveworks/common/httpgrpc"
+)
+
+type validationError struct {
+	err       error // underlying error
+	errorType string
+	code      int
+	noReport  bool // if true, error will be counted but not reported to caller
+	labels    labels.Labels
+}
+
+func makeLimitError(errorType string, err error) error {
+	return &validationError{
+		errorType: errorType,
+		err:       err,
+		code:      http.StatusTooManyRequests,
+	}
+}
+
+func makeNoReportError(errorType string) error {
+	return &validationError{
+		errorType: errorType,
+		noReport:  true,
+	}
+}
+
+func makeMetricValidationError(errorType string, labels labels.Labels, err error) error {
+	return &validationError{
+		errorType: errorType,
+		err:       err,
+		code:      http.StatusBadRequest,
+		labels:    labels,
+	}
+}
+
+func makeMetricLimitError(errorType string, labels labels.Labels, err error) error {
+	return &validationError{
+		errorType: errorType,
+		err:       err,
+		code:      http.StatusTooManyRequests,
+		labels:    labels,
+	}
+}
+
+func (e *validationError) Error() string {
+	if e.err == nil {
+		return e.errorType
+	}
+	if e.labels == nil {
+		return e.err.Error()
+	}
+	return fmt.Sprintf("%s for series %s", e.err.Error(), e.labels.String())
+}
+
+// WrappedError returns a HTTP gRPC error than is correctly forwarded over gRPC.
+func (e *validationError) WrappedError() error {
+	return httpgrpc.ErrorFromHTTPResponse(&httpgrpc.HTTPResponse{
+		Code: int32(e.code),
+		Body: []byte(e.Error()),
+	})
+}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -317,16 +317,16 @@ func TestIngesterAppendOutOfOrderAndDuplicate(t *testing.T) {
 	// Earlier sample than previous one.
 	err = ing.append(ctx, userID, m, 0, 0, client.API)
 	require.Contains(t, err.Error(), "sample timestamp out of order")
-	errResp, ok := httpgrpc.HTTPResponseFromError(err)
+	errResp, ok := err.(*validationError)
 	require.True(t, ok)
-	require.Equal(t, errResp.Code, int32(400))
+	require.Equal(t, errResp.code, 400)
 
 	// Same timestamp as previous sample, but different value.
 	err = ing.append(ctx, userID, m, 1, 1, client.API)
 	require.Contains(t, err.Error(), "sample with repeated timestamp but different value")
-	errResp, ok = httpgrpc.HTTPResponseFromError(err)
+	errResp, ok = err.(*validationError)
 	require.True(t, ok)
-	require.Equal(t, errResp.Code, int32(400))
+	require.Equal(t, errResp.code, 400)
 }
 
 // Test that blank labels are removed by the ingester

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -41,19 +41,6 @@ type memorySeries struct {
 	lastSampleValue    model.SampleValue
 }
 
-type memorySeriesError struct {
-	message   string
-	errorType string
-	noReport  bool // if true, error will be counted but not reported to caller
-}
-
-func (error *memorySeriesError) Error() string {
-	if error.message == "" {
-		return error.errorType
-	}
-	return error.message
-}
-
 // newMemorySeries returns a pointer to a newly allocated memorySeries for the
 // given metric.
 func newMemorySeries(m labels.Labels) *memorySeries {
@@ -71,24 +58,20 @@ func (s *memorySeries) add(v model.SamplePair) error {
 		// If we don't know what the last sample value is, silently discard.
 		// This will mask some errors but better than complaining when we don't really know.
 		if !s.lastSampleValueSet {
-			return &memorySeriesError{errorType: "duplicate-timestamp", noReport: true}
+			return makeNoReportError("duplicate-timestamp")
 		}
 		// If both timestamp and sample value are the same as for the last append,
 		// ignore as they are a common occurrence when using client-side timestamps
 		// (e.g. Pushgateway or federation).
 		if v.Value.Equal(s.lastSampleValue) {
-			return &memorySeriesError{errorType: "duplicate-sample", noReport: true}
+			return makeNoReportError("duplicate-sample")
 		}
-		return &memorySeriesError{
-			message:   fmt.Sprintf("sample with repeated timestamp but different value for series %v; last value: %v, incoming value: %v", s.metric, s.lastSampleValue, v.Value),
-			errorType: "new-value-for-timestamp",
-		}
+		return makeMetricValidationError("new-value-for-timestamp", s.metric,
+			fmt.Errorf("sample with repeated timestamp but different value; last value: %v, incoming value: %v", s.lastSampleValue, v.Value))
 	}
 	if v.Timestamp < s.lastTime {
-		return &memorySeriesError{
-			message:   fmt.Sprintf("sample timestamp out of order for series %v; last timestamp: %v, incoming timestamp: %v", s.metric, s.lastTime, v.Timestamp),
-			errorType: "sample-out-of-order",
-		}
+		return makeMetricValidationError("sample-out-of-order", s.metric,
+			fmt.Errorf("sample timestamp out of order; last timestamp: %v, incoming timestamp: %v", s.lastTime, v.Timestamp))
 	}
 
 	if len(s.chunkDescs) == 0 || s.headChunkClosed {


### PR DESCRIPTION
Fixes #1301 

There is quite a lot of refactoring here, pulling out various things into helper functions in a new file `errors.go`.  Also I moved a couple of places that the discarded samples metric is incremented for consistency.

I'm not very clear why we need "httpgrpc" at all here, as `Push()` is only called over gRPC, but left that for another day.

Benchmark before:
```
BenchmarkIngesterPushErrors  10  154925847 ns/op  137223744 B/op  516830 allocs/op
```

after:
```
BenchmarkIngesterPushErrors  50  33549567 ns/op    4411341 B/op    64796 allocs/op
```