### PR TITLE
Improved comment explaining an unlock logic in the ingester

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -341,7 +341,10 @@ func (i *Ingester) append(ctx context.Context, userID string, labels labelPairs,
 		if ve, ok := err.(*validationError); ok {
 			state.discardedSamples.WithLabelValues(ve.errorType).Inc()
 		}
-		state = nil // don't want to unlock the fp if there is an error
+
+		// Reset the state so that the defer will not try to unlock the fpLocker
+		// in case of error, because that lock has already been released on error.
+		state = nil
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does**:
Today I've been tricked by the `state = nil` statement in `ingester.append()` and thought it could be worth to better explain it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
