### PR TITLE
Added /ready endpoint to queriers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [FEATURE] The distributor can now drop labels from samples (similar to the removal of the replica label for HA ingestion) per user via the `distributor.drop-label` flag. #1726
 * [FEATURE] Added `global` ingestion rate limiter strategy. Deprecated `-distributor.limiter-reload-period` flag. #1766
 * [FEATURE] Added support for Microsoft Azure blob storage to be used for storing chunk data. #1913
+* [FEATURE] Added readiness probe endpoint`/ready` to queriers. #1934
 * [ENHANCEMENT] Added `password` and `enable_tls` options to redis cache configuration. Enables usage of Microsoft Azure Cache for Redis service.
 * [BUGFIX] Fixed unnecessary CAS operations done by the HA tracker when the jitter is enabled. #1861
 * [BUGFIX] Fixed #1904 ingesters getting stuck in a LEAVING state after coming up from an ungraceful exit. #1921

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -236,6 +236,13 @@ func (t *Cortex) initQuerier(cfg *Config) (err error) {
 	subrouter.Path("/validate_expr").Handler(t.httpAuthMiddleware.Wrap(http.HandlerFunc(t.distributor.ValidateExprHandler)))
 	subrouter.Path("/chunks").Handler(t.httpAuthMiddleware.Wrap(querier.ChunksHandler(queryable)))
 	subrouter.Path("/user_stats").Handler(middleware.AuthenticateUser.Wrap(http.HandlerFunc(t.distributor.UserStatsHandler)))
+
+	// Once the execution reaches this point, all synchronous initialization has been
+	// done and the querier is ready to serve queries, so we're just returning a 202.
+	t.server.HTTP.Path("/ready").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
 	return
 }
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -195,11 +195,6 @@ func (t *Cortex) stopDistributor() (err error) {
 }
 
 func (t *Cortex) initQuerier(cfg *Config) (err error) {
-	t.worker, err = frontend.NewWorker(cfg.Worker, httpgrpc_server.NewServer(t.server.HTTPServer.Handler), util.Logger)
-	if err != nil {
-		return
-	}
-
 	var store querier.ChunkStore
 
 	if cfg.Storage.Engine == storage.StorageEngineTSDB {
@@ -236,6 +231,13 @@ func (t *Cortex) initQuerier(cfg *Config) (err error) {
 	subrouter.Path("/validate_expr").Handler(t.httpAuthMiddleware.Wrap(http.HandlerFunc(t.distributor.ValidateExprHandler)))
 	subrouter.Path("/chunks").Handler(t.httpAuthMiddleware.Wrap(querier.ChunksHandler(queryable)))
 	subrouter.Path("/user_stats").Handler(middleware.AuthenticateUser.Wrap(http.HandlerFunc(t.distributor.UserStatsHandler)))
+
+	// Start the query frontend worker once the query engine and the store
+	// have been successfully initialized.
+	t.worker, err = frontend.NewWorker(cfg.Worker, httpgrpc_server.NewServer(t.server.HTTPServer.Handler), util.Logger)
+	if err != nil {
+		return
+	}
 
 	// Once the execution reaches this point, all synchronous initialization has been
 	// done and the querier is ready to serve queries, so we're just returning a 202.

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -47,9 +47,12 @@ func NewBlockQuerier(cfg tsdb.Config, logLevel logging.Level, r prometheus.Regis
 	}
 	b.us = us
 
+	level.Info(util.Logger).Log("msg", "synchronizing TSDB blocks for all users")
 	if err := us.InitialSync(context.Background()); err != nil {
-		level.Warn(util.Logger).Log("msg", "InitialSync failed", "err", err)
+		level.Warn(util.Logger).Log("msg", "failed to synchronize TSDB blocks", "err", err)
+		return nil, err
 	}
+	level.Info(util.Logger).Log("msg", "successfully synchronized TSDB blocks for all users")
 
 	stopc := make(chan struct{})
 	go runutil.Repeat(30*time.Second, stopc, func() error {

--- a/pkg/querier/block_store.go
+++ b/pkg/querier/block_store.go
@@ -99,7 +99,6 @@ func (u *UserStore) syncUserStores(ctx context.Context, f func(context.Context, 
 		var bs *store.BucketStore
 		var ok bool
 		if bs, ok = u.stores[user]; !ok {
-
 			level.Info(u.logger).Log("msg", "creating user bucket store", "user", user)
 
 			// Instance a new bucket used by this tenant's shipper. We're going


### PR DESCRIPTION
**What this PR does**:
The querier - when running with the TSDB experimental storage - does the initial sync of all TSDB blocks' index header, which may take some time (order of minutes). Until successfully completed, it will not be ready to serve queriers.

In this PR:
- Add `/ready` endpoint to the querier, which always return `204`, once the initialization has been done
- Start the query frontend worker only after the store and querier have been successfully initialized

**Which issue(s) this PR fixes**:
_N/A_

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
