### PR TITLE
Run kubeval to validate K8S spec files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 defaults: &defaults
   docker:
-    - image: cortexproject/build-image:validate-k8s-specs-76bd5da0a
+    - image: quay.io/cortexproject/build-image:validate-k8s-specs-76bd5da0a
   working_directory: /go/src/github.com/cortexproject/cortex
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 defaults: &defaults
   docker:
-    - image: quay.io/cortexproject/build-image:validate-k8s-specs-76bd5da0a
+    - image: quay.io/cortexproject/build-image:validate-k8s-specs-7c217ee7
   working_directory: /go/src/github.com/cortexproject/cortex
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 defaults: &defaults
   docker:
-    - image: quay.io/cortexproject/build-image:update-lint-ae47f740a
+    - image: cortexproject/build-image:validate-k8s-specs-76bd5da0a
   working_directory: /go/src/github.com/cortexproject/cortex
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ lint:
 	misspell -error docs
 	golangci-lint run --new-from-rev ed7c302fd968 --build-tags netgo --timeout=5m --enable golint --enable misspell --enable gofmt
 
+	# Validate Kubernetes spec files. Requires:
+	# https://kubeval.instrumenta.dev
+	kubeval ./k8s/*
+
 test:
 	./tools/test -netgo
 

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -20,6 +20,12 @@ RUN GO111MODULE=on go get -tags netgo \
 		github.com/gogo/protobuf/gogoproto@v1.2.1 && \
 	rm -rf /go/pkg /go/src
 
+ENV KUBEVAL_VERSION=0.14.0
+RUN curl -Ls https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz -o /tmp/kubeval-linux-amd64.tar.gz && \
+	tar -xf /tmp/kubeval-linux-amd64.tar.gz -C /tmp && \
+	cp /tmp/kubeval /usr/local/bin && \
+	rm -f /tmp/kubeval*
+
 ENV NODE_PATH=/usr/lib/node_modules
 COPY build.sh /
 ENV GOCACHE=/go/cache


### PR DESCRIPTION
**What this PR does**:
While reviewing the PR #1941, I've realized we don't run any validation on K8S spec files in CI. I think it could be useful as signal to spot trivial issues during the review process.

In this PR, I'm proposing to run [`kubeval`](https://kubeval.instrumenta.dev/installation/) in CI. This would require to publish a new `build-image` (for which I don't have privileges), but first I would like to scout if this is a desired change.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
