### PR TITLE
Doc website: lighter left sidebar

### DIFF
--- a/website/assets/scss/_styles_project.scss
+++ b/website/assets/scss/_styles_project.scss
@@ -1,0 +1,42 @@
+//
+// Top navigation bar
+//
+
+.td-navbar {
+    .nav-link {
+        font-weight: $font-weight-normal;
+    }
+}
+
+//
+// Left sidebar
+//
+
+.td-sidebar-nav {
+    &__section {
+        ul {
+            margin-left: 5px;
+        }
+    }
+    
+    .td-sidebar-link {
+        padding: 0.5rem 0;
+
+        &__page {
+            font-weight: $font-weight-normal;
+        }
+    }
+    
+    // Display a left border on the active page
+    a {
+        font-size: 0.9rem;
+        font-weight: $font-weight-normal;
+        padding-left: 13px !important;
+
+        &.active {
+            border-left: 3px solid $primary;
+            font-weight: $font-weight-bold;
+            padding-left: 10px !important;
+        }
+    }
+}


### PR DESCRIPTION
**What this PR does**:
In this PR I'm proposing to style the doc website's left sidebar (and top navigation) with a ligther style that - in my opinion - helps the readability.

Before:

![Screen Shot 2020-01-02 at 17 08 04](https://user-images.githubusercontent.com/1701904/71677200-7b8c1d80-2d82-11ea-857c-d5982fc2168f.png)

After:

![Screen Shot 2020-01-02 at 17 08 14](https://user-images.githubusercontent.com/1701904/71677201-7dee7780-2d82-11ea-933b-6da3ae47b4b1.png)


**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
