### PR TITLE
limits: distributor user subrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * [CHANGE] Moved `--store.min-chunk-age` to the Querier config as `--querier.query-store-after`, allowing the store to be skipped during query time if the metrics wouldn't be found. The YAML config option `ingestermaxquerylookback` has been renamed to `query_ingesters_within` to match its CLI flag. #1893 
   * `--store.min-chunk-age` has been removed
   * `--querier.query-store-after` has been added in it's place.
+* [FEATURE] Added user sub rings to distribute users to a subset of ingesters. #1947
+  * `--experimental.distributor.user-subring-size`
 * [ENHANCEMENT] Experimental TSDB: Export TSDB Syncer metrics from Compactor component, they are prefixed with `cortex_compactor_`. #2023
 * [ENHANCEMENT] Experimental TSDB: Added dedicated flag `-experimental.tsdb.bucket-store.tenant-sync-concurrency` to configure the maximum number of concurrent tenants for which blocks are synched. #2026
 * [ENHANCEMENT] Experimental TSDB: Expose metrics for objstore operations (prefixed with `cortex_<component>_thanos_objstore_`, component being one of `ingester`, `querier` and `compactor`). #2027

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1812,6 +1812,10 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -validation.enforce-metric-name
 [enforce_metric_name: <boolean> | default = true]
 
+# Per-user subring to shard metrics to ingesters. 0 is disabled.
+# CLI flag: -experimental.distributor.user-subring-size
+[user_subring_size: <int> | default = 0]
+
 # The maximum number of series that a query can return.
 # CLI flag: -ingester.max-series-per-query
 [max_series_per_query: <int> | default = 100000]

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -850,6 +850,10 @@ type mockRing struct {
 	replicationFactor uint32
 }
 
+func (r mockRing) Subring(key uint32, n int) (ring.ReadRing, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
 func (r mockRing) Get(key uint32, op ring.Operation, buf []ring.IngesterDesc) (ring.ReplicationSet, error) {
 	result := ring.ReplicationSet{
 		MaxErrors: 1,

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -388,16 +388,18 @@ func (r *Ring) Subring(key uint32, n int) (ReadRing, error) {
 		return nil, ErrEmptyRing
 	}
 
-	if n > len(r.ringDesc.Ingesters) {
-		return nil, fmt.Errorf("subring too large")
-	}
-
 	var (
 		ingesters     = make(map[string]IngesterDesc, n)
 		distinctHosts = map[string]struct{}{}
 		start         = r.search(key)
 		iterations    = 0
 	)
+
+	// Subring exceeds number of ingesters, set to total ring size
+	if n > len(r.ringDesc.Ingesters) {
+		n = len(r.ringDesc.Ingesters)
+	}
+
 	for i := start; len(distinctHosts) < n && iterations < len(r.ringTokens); i++ {
 		iterations++
 		// Wrap i around in the ring.

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -44,6 +44,7 @@ type ReadRing interface {
 	GetAll() (ReplicationSet, error)
 	ReplicationFactor() int
 	IngesterCount() int
+	Subring(key uint32, n int) (ReadRing, error)
 }
 
 // Operation can be Read or Write
@@ -376,4 +377,67 @@ func (r *Ring) Collect(ch chan<- prometheus.Metric) {
 		float64(len(r.ringTokens)),
 		r.name,
 	)
+}
+
+// Subring returns a ring of n ingesters from the given ring
+// Subrings are meant only for ingestor lookup and should have their data externalized.
+func (r *Ring) Subring(key uint32, n int) (ReadRing, error) {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+	if r.ringDesc == nil || len(r.ringTokens) == 0 || n <= 0 {
+		return nil, ErrEmptyRing
+	}
+
+	if n > len(r.ringDesc.Ingesters) {
+		return nil, fmt.Errorf("subring too large")
+	}
+
+	var (
+		ingesters     = make(map[string]IngesterDesc, n)
+		distinctHosts = map[string]struct{}{}
+		start         = r.search(key)
+		iterations    = 0
+	)
+	for i := start; len(distinctHosts) < n && iterations < len(r.ringTokens); i++ {
+		iterations++
+		// Wrap i around in the ring.
+		i %= len(r.ringTokens)
+
+		// We want n *distinct* ingesters.
+		token := r.ringTokens[i]
+		if _, ok := distinctHosts[token.Ingester]; ok {
+			continue
+		}
+		distinctHosts[token.Ingester] = struct{}{}
+		ingester := r.ringDesc.Ingesters[token.Ingester]
+
+		ingesters[token.Ingester] = ingester
+	}
+
+	if n > len(ingesters) {
+		return nil, fmt.Errorf("too few ingesters found")
+	}
+
+	numTokens := 0
+	for _, ing := range ingesters {
+		numTokens += len(ing.Tokens)
+	}
+
+	sub := &Ring{
+		name: "subring",
+		cfg:  r.cfg,
+		ringDesc: &Desc{
+			Ingesters: ingesters,
+		},
+		ringTokens: make([]TokenDesc, 0, numTokens),
+	}
+
+	// add tokens for the ingesters in the subring, they should already be sorted, so no need to re-sort
+	for _, t := range r.ringTokens {
+		if _, ok := ingesters[t.Ingester]; ok {
+			sub.ringTokens = append(sub.ringTokens, t)
+		}
+	}
+
+	return sub, nil
 }

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sort"
 	"testing"
 	"time"
 
@@ -117,4 +118,108 @@ func TestAddIngesterReplacesExistingTokens(t *testing.T) {
 	r.AddIngester(ing1Name, "addr", newTokens, ACTIVE)
 
 	require.Equal(t, newTokens, r.Ingesters[ing1Name].Tokens)
+}
+
+func TestSubring(t *testing.T) {
+	r := NewDesc()
+
+	n := 16 // number of ingesters in ring
+	var prevTokens []uint32
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("ing%v", i)
+		ingTokens := GenerateTokens(128, prevTokens)
+
+		r.AddIngester(name, fmt.Sprintf("addr%v", i), ingTokens, ACTIVE)
+
+		prevTokens = append(prevTokens, ingTokens...)
+	}
+
+	// Create a ring with the ingesters
+	ring := Ring{
+		name: "main ring",
+		cfg: Config{
+			HeartbeatTimeout: time.Hour,
+		},
+		ringDesc:   r,
+		ringTokens: r.getTokens(),
+	}
+
+	// Subring of 0 invalid
+	_, err := ring.Subring(0, 0)
+	require.Error(t, err)
+
+	// Generate a sub ring for all possible valid ranges
+	for i := 1; i < n+1; i++ {
+		subr, err := ring.Subring(rand.Uint32(), i)
+		require.NoError(t, err)
+		require.Equal(t, i, len(subr.(*Ring).ringDesc.Ingesters))
+		require.Equal(t, i*128, len(subr.(*Ring).ringTokens))
+		require.True(t, sort.SliceIsSorted(subr.(*Ring).ringTokens, func(i, j int) bool {
+			return subr.(*Ring).ringTokens[i].Token < subr.(*Ring).ringTokens[j].Token
+		}))
+
+		// Obtain a replication slice
+		size := i - 1
+		if size <= 0 {
+			size = 1
+		}
+		subr.(*Ring).cfg.ReplicationFactor = size
+		set, err := subr.Get(rand.Uint32(), Write, nil)
+		require.NoError(t, err)
+		require.Equal(t, size, len(set.Ingesters))
+	}
+
+	// Subring larger than possible
+	_, err = ring.Subring(0, n+1)
+	require.Error(t, err)
+}
+
+func TestStableSubring(t *testing.T) {
+	r := NewDesc()
+
+	n := 16 // number of ingesters in ring
+	var prevTokens []uint32
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("ing%v", i)
+		ingTokens := GenerateTokens(128, prevTokens)
+
+		r.AddIngester(name, fmt.Sprintf("addr%v", i), ingTokens, ACTIVE)
+
+		prevTokens = append(prevTokens, ingTokens...)
+	}
+
+	// Create a ring with the ingesters
+	ring := Ring{
+		name: "main ring",
+		cfg: Config{
+			HeartbeatTimeout: time.Hour,
+		},
+		ringDesc:   r,
+		ringTokens: r.getTokens(),
+	}
+
+	// Generate the same subring multiple times
+	var subrings [][]TokenDesc
+	key := rand.Uint32()
+	subringsize := 4
+	for i := 1; i < 4; i++ {
+		subr, err := ring.Subring(key, subringsize)
+		require.NoError(t, err)
+		require.Equal(t, subringsize, len(subr.(*Ring).ringDesc.Ingesters))
+		require.Equal(t, subringsize*128, len(subr.(*Ring).ringTokens))
+		require.True(t, sort.SliceIsSorted(subr.(*Ring).ringTokens, func(i, j int) bool {
+			return subr.(*Ring).ringTokens[i].Token < subr.(*Ring).ringTokens[j].Token
+		}))
+
+		subrings = append(subrings, subr.(*Ring).ringTokens)
+	}
+
+	// Validate that the same subring is produced each time from the same ring
+	for i := 0; i < len(subrings); i++ {
+		next := i + 1
+		if next >= len(subrings) {
+			next = 0
+		}
+		require.Equal(t, subrings[i], subrings[next])
+	}
 }

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -149,11 +149,15 @@ func TestSubring(t *testing.T) {
 	require.Error(t, err)
 
 	// Generate a sub ring for all possible valid ranges
-	for i := 1; i < n+1; i++ {
+	for i := 1; i < n+2; i++ {
 		subr, err := ring.Subring(rand.Uint32(), i)
 		require.NoError(t, err)
-		require.Equal(t, i, len(subr.(*Ring).ringDesc.Ingesters))
-		require.Equal(t, i*128, len(subr.(*Ring).ringTokens))
+		subringSize := i
+		if i > n {
+			subringSize = n
+		}
+		require.Equal(t, subringSize, len(subr.(*Ring).ringDesc.Ingesters))
+		require.Equal(t, subringSize*128, len(subr.(*Ring).ringTokens))
 		require.True(t, sort.SliceIsSorted(subr.(*Ring).ringTokens, func(i, j int) bool {
 			return subr.(*Ring).ringTokens[i].Token < subr.(*Ring).ringTokens[j].Token
 		}))
@@ -168,10 +172,6 @@ func TestSubring(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, size, len(set.Ingesters))
 	}
-
-	// Subring larger than possible
-	_, err = ring.Subring(0, n+1)
-	require.Error(t, err)
 }
 
 func TestStableSubring(t *testing.T) {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -36,6 +36,7 @@ type Limits struct {
 	RejectOldSamplesMaxAge time.Duration       `yaml:"reject_old_samples_max_age"`
 	CreationGracePeriod    time.Duration       `yaml:"creation_grace_period"`
 	EnforceMetricName      bool                `yaml:"enforce_metric_name"`
+	SubringSize            int                 `yaml:"user_subring_size"`
 
 	// Ingester enforced limits.
 	MaxSeriesPerQuery        int `yaml:"max_series_per_query"`
@@ -59,6 +60,7 @@ type Limits struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (l *Limits) RegisterFlags(f *flag.FlagSet) {
+	f.IntVar(&l.SubringSize, "experimental.distributor.user-subring-size", 0, "Per-user subring to shard metrics to ingesters. 0 is disabled.")
 	f.Float64Var(&l.IngestionRate, "distributor.ingestion-rate-limit", 25000, "Per-user ingestion rate limit in samples per second.")
 	f.StringVar(&l.IngestionRateStrategy, "distributor.ingestion-rate-limit-strategy", "local", "Whether the ingestion rate limit should be applied individually to each distributor instance (local), or evenly shared across the cluster (global).")
 	f.IntVar(&l.IngestionBurstSize, "distributor.ingestion-burst-size", 50000, "Per-user allowed ingestion burst size (in number of samples).")
@@ -278,6 +280,11 @@ func (o *Overrides) CardinalityLimit(userID string) int {
 // MinChunkLength returns the minimum size of chunk that will be saved by ingesters
 func (o *Overrides) MinChunkLength(userID string) int {
 	return o.getOverridesForUser(userID).MinChunkLength
+}
+
+// SubringSize returns the size of the subring for a given user.
+func (o *Overrides) SubringSize(userID string) int {
+	return o.getOverridesForUser(userID).SubringSize
 }
 
 func (o *Overrides) getOverridesForUser(userID string) *Limits {


### PR DESCRIPTION
Signed-off-by: Thor <thansen@digitalocean.com>

**Experimental TSDB Change Only**

**What this PR does**:  Opening a TSDB per user on each Ingester presents a problem with memory consumption. The series hashtable that TSDB pre-allocates per user is roughly 1.5MB.
![image](https://user-images.githubusercontent.com/8681572/71681643-d60d8580-2d52-11ea-8f9f-2a5d1ab7ebf0.png)
 Which means that at a large user count it eats up a large amount of memory per Ingester. More importantly when the number of ingesters/nodes are scaled out the memory consumption stays the same per node since the same number of TSDB's are allocated on each node. 

Just as a demonstration I reduced the stripe size in the TSDB code. 
```
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head.go
@@ -1465,7 +1465,7 @@ type stripeSeries struct {
 }
 const (
-       stripeSize = 1 << 14
+       stripeSize = 1 << 8
        stripeMask = stripeSize - 1
 )
```
Which reduced overall memory consumption from ~94GiB to ~23Gib
![image](https://user-images.githubusercontent.com/8681572/71681821-62b84380-2d53-11ea-989a-0ce17bd84cf9.png)

Reducing the stripe size has performance implications, and doesn't resolve the root problem of metric footprint not scaling with node count. 

This change adds an optional step when distributing metrics, that first creates a subring of ingesters based on the user ID, and then uses that subring to hash as normal. This means that for any given user, that user only has an open TSDB on N given Ingesters reducing the overall memory footprint and horizontally scaling with nodes. The setting is apart of the util.Limits code to provide a default and importantly per-user limits to prevent hot-spots being created by extra heavy users. 

You can see in the image below the memory usage before (red arrow) with the reduced stripe size, and the memory usage after (green arrow) with a user sub ring of 4 and replication 3. So a user is allocated to 4 of the 16 nodes in the cluster. 

![image](https://user-images.githubusercontent.com/8681572/71682090-3f41c880-2d54-11ea-8f46-f62fa49c54e3.png)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
