### PR TITLE
Added tool to automatically generate config file documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,9 @@ jobs:
     - run:
         name: Check protos are consistent.
         command: make BUILD_IN_CONTAINER=false check-protos
+    - run:
+        name: Check generated documentation is consistent.
+        command: make BUILD_IN_CONTAINER=false check-doc
 
   test:
     <<: *defaults

--- a/Makefile
+++ b/Makefile
@@ -186,5 +186,16 @@ prime-minikube: save-images
 		fi \
 	done
 
+# Generates the config file documentation.
+doc:
+	cp ./docs/configuration/config-file-reference.template ./docs/configuration/config-file-reference.md
+	go run ./tools/doc-generator/ >> ./docs/configuration/config-file-reference.md
+
+clean-doc:
+	rm -f ./docs/configuration/config-file-reference.md
+
+check-doc: clean-doc doc
+	@git diff --exit-code -- ./docs/configuration/config-file-reference.md
+
 web-serve:
 	cd website && hugo --config config.toml -v server

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -1,7 +1,7 @@
 ---
 title: "Cortex Arguments"
 linkTitle: "Cortex Arguments Explained"
-weight: 1
+weight: 2
 slug: arguments
 ---
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -26,7 +26,7 @@ Supported contents and default values of the config file:
 # The Cortex service to run. Supported values are: all, distributor, ingester,
 # querier, query-frontend, table-manager, ruler, alertmanager, configs.
 # CLI flag: -target
-[target: <int> | default = all]
+[target: <string> | default = "all"]
 
 # Set to false to disable auth.
 # CLI flag: -auth.enabled

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -220,7 +220,7 @@ ha_tracker:
 
     # The prefix for the keys in the store. Should end with a /.
     # CLI flag: -distributor.ha-tracker.prefix
-    [prefix: <string> | default = "collectors/"]
+    [prefix: <string> | default = "ha-tracker/"]
 
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: distributor.ha-tracker

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1,0 +1,1909 @@
+---
+title: "Configuration file"
+linkTitle: "Configuration file"
+weight: 1
+slug: configuration-file
+---
+
+Cortex can be configured using a YAML file - specified using the `-config.file` flag - or CLI flags. In case you combine both, CLI flags take precedence over the YAML config file.
+
+## Reference
+
+To specify which configuration file to load, pass the `-config.file` flag at the command line. The file is written in [YAML format](https://en.wikipedia.org/wiki/YAML), defined by the scheme below. Brackets indicate that a parameter is optional.
+
+Generic placeholders are defined as follows:
+
+* `<boolean>`: a boolean that can take the values `true` or `false`
+* `<int>`: any integer matching the regular expression `[1-9]+[0-9]*`
+* `<duration>`: a duration matching the regular expression `[0-9]+(ns|us|µs|ms|[smh])`
+* `<string>`: a regular string
+* `<url>`: an URL
+* `<prefix>`: a CLI flag prefix based on the context (look at the parent configuration block to see which CLI flags prefix should be used)
+
+Supported contents and default values of the config file:
+
+```yaml
+# The Cortex service to run. Supported values are: all, distributor, ingester,
+# querier, query-frontend, table-manager, ruler, alertmanager, configs.
+# CLI flag: -target
+[target: <int> | default = all]
+
+# Set to false to disable auth.
+# CLI flag: -auth.enabled
+[auth_enabled: <boolean> | default = true]
+
+# HTTP path prefix for Cortex API.
+# CLI flag: -http.prefix
+[http_prefix: <string> | default = "/api/prom"]
+
+# The server_config configures the HTTP and gRPC server of the launched
+# service(s).
+[server: <server_config>]
+
+# The distributor_config configures the Cortex distributor.
+[distributor: <distributor_config>]
+
+# The querier_config configures the Cortex querier.
+[querier: <querier_config>]
+
+# The ingester_client_config configures how the Cortex distributors connect to
+# the ingesters.
+[ingester_client: <ingester_client_config>]
+
+# The ingester_config configures the Cortex ingester.
+[ingester: <ingester_config>]
+
+# The storage_config configures where Cortex stores the data (chunks storage
+# engine).
+[storage: <storage_config>]
+
+# The chunk_store_config configures how Cortex stores the data (chunks storage
+# engine).
+[chunk_store: <chunk_store_config>]
+
+# The limits_config configures default and per-tenant limits imposed by Cortex
+# services (ie. distributor, ingester, ...).
+[limits: <limits_config>]
+
+# The frontend_worker_config configures the worker - running within the Cortex
+# ingester - picking up and executing queries enqueued by the query-frontend.
+[frontend_worker: <frontend_worker_config>]
+
+# The query_frontend_config configures the Cortex query-frontend.
+[frontend: <query_frontend_config>]
+
+# The queryrange_config configures the query splitting and caching in the Cortex
+# query-frontend.
+[query_range: <queryrange_config>]
+
+# The table_manager_config configures the Cortex table-manager.
+[table_manager: <table_manager_config>]
+
+# The ruler_config configures the Cortex ruler.
+[ruler: <ruler_config>]
+
+# The configdb_config configures the config database storing rules and alerts,
+# and used by the 'configs' service to expose APIs to manage them.
+[configdb: <configdb_config>]
+
+# The configstore_config configures the config database storing rules and
+# alerts, and is used by the Cortex alertmanager.
+# The CLI flags prefix for this block config is: alertmanager
+[config_store: <configstore_config>]
+
+# The alertmanager_config configures the Cortex alertmanager.
+[alertmanager: <alertmanager_config>]
+```
+
+## `server_config`
+
+The `server_config` configures the HTTP and gRPC server of the launched service(s).
+
+```yaml
+# HTTP server listen port.
+# CLI flag: -server.http-listen-port
+[http_listen_port: <int> | default = 80]
+
+# gRPC server listen port.
+# CLI flag: -server.grpc-listen-port
+[grpc_listen_port: <int> | default = 9095]
+
+# Register the intrumentation handlers (/metrics etc).
+# CLI flag: -server.register-instrumentation
+[register_instrumentation: <boolean> | default = true]
+
+# Timeout for graceful shutdowns
+# CLI flag: -server.graceful-shutdown-timeout
+[graceful_shutdown_timeout: <duration> | default = 30s]
+
+# Read timeout for HTTP server
+# CLI flag: -server.http-read-timeout
+[http_server_read_timeout: <duration> | default = 30s]
+
+# Write timeout for HTTP server
+# CLI flag: -server.http-write-timeout
+[http_server_write_timeout: <duration> | default = 30s]
+
+# Idle timeout for HTTP server
+# CLI flag: -server.http-idle-timeout
+[http_server_idle_timeout: <duration> | default = 2m0s]
+
+# Limit on the size of a gRPC message this server can receive (bytes).
+# CLI flag: -server.grpc-max-recv-msg-size-bytes
+[grpc_server_max_recv_msg_size: <int> | default = 4194304]
+
+# Limit on the size of a gRPC message this server can send (bytes).
+# CLI flag: -server.grpc-max-send-msg-size-bytes
+[grpc_server_max_send_msg_size: <int> | default = 4194304]
+
+# Limit on the number of concurrent streams for gRPC calls (0 = unlimited)
+# CLI flag: -server.grpc-max-concurrent-streams
+[grpc_server_max_concurrent_streams: <int> | default = 100]
+
+# Only log messages with the given severity or above. Valid levels: [debug,
+# info, warn, error]
+# CLI flag: -log.level
+[log_level: <string> | default = "info"]
+
+# Base path to serve all API routes from (e.g. /v1/)
+# CLI flag: -server.path-prefix
+[http_path_prefix: <string> | default = ""]
+```
+
+## `distributor_config`
+
+The `distributor_config` configures the Cortex distributor.
+
+```yaml
+# Report number of ingested samples to billing system.
+# CLI flag: -distributor.enable-billing
+[enable_billing: <boolean> | default = false]
+
+billing:
+  # Maximum number of billing events to buffer in memory
+  # CLI flag: -billing.max-buffered-events
+  [maxbufferedevents: <int> | default = 1024]
+
+  # How often to retry sending events to the billing ingester.
+  # CLI flag: -billing.retry-delay
+  [retrydelay: <duration> | default = 500ms]
+
+  # points to the billing ingester sidecar (should be on localhost)
+  # CLI flag: -billing.ingester
+  [ingesterhostport: <string> | default = "localhost:24225"]
+
+pool:
+  # How frequently to clean up clients for ingesters that have gone away.
+  # CLI flag: -distributor.client-cleanup-period
+  [client_cleanup_period: <duration> | default = 15s]
+
+  # Run a health check on each ingester client during periodic cleanup.
+  # CLI flag: -distributor.health-check-ingesters
+  [health_check_ingesters: <boolean> | default = false]
+
+ha_tracker:
+  # Enable the distributors HA tracker so that it can accept samples from
+  # Prometheus HA replicas gracefully (requires labels).
+  # CLI flag: -distributor.ha-tracker.enable
+  [enable_ha_tracker: <boolean> | default = false]
+
+  # Update the timestamp in the KV store for a given cluster/replica only after
+  # this amount of time has passed since the current stored timestamp.
+  # CLI flag: -distributor.ha-tracker.update-timeout
+  [ha_tracker_update_timeout: <duration> | default = 15s]
+
+  # Maximum jitter applied to the update timeout, in order to spread the HA
+  # heartbeats over time.
+  # CLI flag: -distributor.ha-tracker.update-timeout-jitter-max
+  [ha_tracker_update_timeout_jitter_max: <duration> | default = 5s]
+
+  # If we don't receive any samples from the accepted replica for a cluster in
+  # this amount of time we will failover to the next replica we receive a sample
+  # from. This value must be greater than the update timeout
+  # CLI flag: -distributor.ha-tracker.failover-timeout
+  [ha_tracker_failover_timeout: <duration> | default = 30s]
+
+  kvstore:
+    # Backend storage to use for the ring. Supported values are: consul, etcd,
+    # inmemory, memberlist (experimental).
+    # CLI flag: -distributor.ha-tracker.store
+    [store: <string> | default = "consul"]
+
+    # The consul_config configures the consul client.
+    # The CLI flags prefix for this block config is: distributor.ha-tracker
+    [consul: <consul_config>]
+
+    # The etcd_config configures the etcd client.
+    # The CLI flags prefix for this block config is: distributor.ha-tracker
+    [etcd: <etcd_config>]
+
+    # The memberlist_config configures the Gossip memberlist.
+    # The CLI flags prefix for this block config is: distributor.ha-tracker
+    [memberlist: <memberlist_config>]
+
+    # The prefix for the keys in the store. Should end with a /.
+    # CLI flag: -distributor.ha-tracker.prefix
+    [prefix: <string> | default = "collectors/"]
+
+# remote_write API max receive message size (bytes).
+# CLI flag: -distributor.max-recv-msg-size
+[max_recv_msg_size: <int> | default = 104857600]
+
+# Timeout for downstream ingesters.
+# CLI flag: -distributor.remote-timeout
+[remote_timeout: <duration> | default = 2s]
+
+# Time to wait before sending more than the minimum successful query requests.
+# CLI flag: -distributor.extra-query-delay
+[extra_queue_delay: <duration> | default = 0s]
+
+# Distribute samples based on all labels, as opposed to solely by user and
+# metric name.
+# CLI flag: -distributor.shard-by-all-labels
+[shard_by_all_labels: <boolean> | default = false]
+
+ring:
+  kvstore:
+    # Backend storage to use for the ring. Supported values are: consul, etcd,
+    # inmemory, memberlist (experimental).
+    # CLI flag: -distributor.ring.store
+    [store: <string> | default = "consul"]
+
+    # The consul_config configures the consul client.
+    # The CLI flags prefix for this block config is: distributor.ring
+    [consul: <consul_config>]
+
+    # The etcd_config configures the etcd client.
+    # The CLI flags prefix for this block config is: distributor.ring
+    [etcd: <etcd_config>]
+
+    # The memberlist_config configures the Gossip memberlist.
+    # The CLI flags prefix for this block config is: distributor.ring
+    [memberlist: <memberlist_config>]
+
+    # The prefix for the keys in the store. Should end with a /.
+    # CLI flag: -distributor.ring.prefix
+    [prefix: <string> | default = "collectors/"]
+
+  # Period at which to heartbeat to the ring.
+  # CLI flag: -distributor.ring.heartbeat-period
+  [heartbeat_period: <duration> | default = 5s]
+
+  # The heartbeat timeout after which distributors are considered unhealthy
+  # within the ring.
+  # CLI flag: -distributor.ring.heartbeat-timeout
+  [heartbeat_timeout: <duration> | default = 1m0s]
+```
+
+## `ingester_config`
+
+The `ingester_config` configures the Cortex ingester.
+
+```yaml
+lifecycler:
+  ring:
+    kvstore:
+      # Backend storage to use for the ring. Supported values are: consul, etcd,
+      # inmemory, memberlist (experimental).
+      # CLI flag: -ring.store
+      [store: <string> | default = "consul"]
+
+      # The consul_config configures the consul client.
+      [consul: <consul_config>]
+
+      # The etcd_config configures the etcd client.
+      [etcd: <etcd_config>]
+
+      # The memberlist_config configures the Gossip memberlist.
+      [memberlist: <memberlist_config>]
+
+      # The prefix for the keys in the store. Should end with a /.
+      # CLI flag: -ring.prefix
+      [prefix: <string> | default = "collectors/"]
+
+    # The heartbeat timeout after which ingesters are skipped for reads/writes.
+    # CLI flag: -ring.heartbeat-timeout
+    [heartbeat_timeout: <duration> | default = 1m0s]
+
+    # The number of ingesters to write to and read from.
+    # CLI flag: -distributor.replication-factor
+    [replication_factor: <int> | default = 3]
+
+  # Number of tokens for each ingester.
+  # CLI flag: -ingester.num-tokens
+  [num_tokens: <int> | default = 128]
+
+  # Period at which to heartbeat to consul.
+  # CLI flag: -ingester.heartbeat-period
+  [heartbeat_period: <duration> | default = 5s]
+
+  # Observe tokens after generating to resolve collisions. Useful when using
+  # gossiping ring.
+  # CLI flag: -ingester.observe-period
+  [observe_period: <duration> | default = 0s]
+
+  # Period to wait for a claim from another member; will join automatically
+  # after this.
+  # CLI flag: -ingester.join-after
+  [join_after: <duration> | default = 0s]
+
+  # Minimum duration to wait before becoming ready. This is to work around race
+  # conditions with ingesters exiting and updating the ring.
+  # CLI flag: -ingester.min-ready-duration
+  [min_ready_duration: <duration> | default = 1m0s]
+
+  # Name of network interface to read address from.
+  # CLI flag: -ingester.lifecycler.interface
+  [interface_names: <list of string> | default = [eth0 en0]]
+
+  # Duration to sleep for before exiting, to ensure metrics are scraped.
+  # CLI flag: -ingester.final-sleep
+  [final_sleep: <duration> | default = 30s]
+
+  # File path where tokens are stored. If empty, tokens are not stored at
+  # shutdown and restored at startup.
+  # CLI flag: -ingester.tokens-file-path
+  [tokens_file_path: <string> | default = ""]
+
+# Number of times to try and transfer chunks before falling back to flushing.
+# Negative value or zero disables hand-over.
+# CLI flag: -ingester.max-transfer-retries
+[max_transfer_retries: <int> | default = 10]
+
+# Period with which to attempt to flush chunks.
+# CLI flag: -ingester.flush-period
+[flushcheckperiod: <duration> | default = 1m0s]
+
+# Period chunks will remain in memory after flushing.
+# CLI flag: -ingester.retain-period
+[retainperiod: <duration> | default = 5m0s]
+
+# Maximum chunk idle time before flushing.
+# CLI flag: -ingester.max-chunk-idle
+[maxchunkidle: <duration> | default = 5m0s]
+
+# Maximum chunk idle time for chunks terminating in stale markers before
+# flushing. 0 disables it and a stale series is not flushed until the
+# max-chunk-idle timeout is reached.
+# CLI flag: -ingester.max-stale-chunk-idle
+[maxstalechunkidle: <duration> | default = 0s]
+
+# Timeout for individual flush operations.
+# CLI flag: -ingester.flush-op-timeout
+[flushoptimeout: <duration> | default = 1m0s]
+
+# Maximum chunk age before flushing.
+# CLI flag: -ingester.max-chunk-age
+[maxchunkage: <duration> | default = 12h0m0s]
+
+# Range of time to subtract from MaxChunkAge to spread out flushes
+# CLI flag: -ingester.chunk-age-jitter
+[chunkagejitter: <duration> | default = 20m0s]
+
+# Number of concurrent goroutines flushing to dynamodb.
+# CLI flag: -ingester.concurrent-flushes
+[concurrentflushes: <int> | default = 50]
+
+# If true, spread series flushes across the whole period of MaxChunkAge
+# CLI flag: -ingester.spread-flushes
+[spreadflushes: <boolean> | default = false]
+
+# Period with which to update the per-user ingestion rates.
+# CLI flag: -ingester.rate-update-period
+[rateupdateperiod: <duration> | default = 15s]
+```
+
+## `querier_config`
+
+The `querier_config` configures the Cortex querier.
+
+```yaml
+# The maximum number of concurrent queries.
+# CLI flag: -querier.max-concurrent
+[maxconcurrent: <int> | default = 20]
+
+# The timeout for a query.
+# CLI flag: -querier.timeout
+[timeout: <duration> | default = 2m0s]
+
+# Use iterators to execute query, as opposed to fully materialising the series
+# in memory.
+# CLI flag: -querier.iterators
+[iterators: <boolean> | default = false]
+
+# Use batch iterators to execute query, as opposed to fully materialising the
+# series in memory.  Takes precedent over the -querier.iterators flag.
+# CLI flag: -querier.batch-iterators
+[batchiterators: <boolean> | default = false]
+
+# Use streaming RPCs to query ingester.
+# CLI flag: -querier.ingester-streaming
+[ingesterstreaming: <boolean> | default = false]
+
+# Maximum number of samples a single query can load into memory.
+# CLI flag: -querier.max-samples
+[maxsamples: <int> | default = 50000000]
+
+# Maximum lookback beyond which queries are not sent to ingester. 0 means all
+# queries are sent to ingester.
+# CLI flag: -querier.query-ingesters-within
+[ingestermaxquerylookback: <duration> | default = 0s]
+
+# The default evaluation interval or step size for subqueries.
+# CLI flag: -querier.default-evaluation-interval
+[defaultevaluationinterval: <duration> | default = 1m0s]
+```
+
+## `query_frontend_config`
+
+The `query_frontend_config` configures the Cortex query-frontend.
+
+```yaml
+# Maximum number of outstanding requests per tenant per frontend; requests
+# beyond this error with HTTP 429.
+# CLI flag: -querier.max-outstanding-requests-per-tenant
+[max_outstanding_per_tenant: <int> | default = 100]
+
+# Compress HTTP responses.
+# CLI flag: -querier.compress-http-responses
+[compress_responses: <boolean> | default = false]
+
+# URL of downstream Prometheus.
+# CLI flag: -frontend.downstream-url
+[downstream: <string> | default = ""]
+
+# Log queries that are slower than the specified duration. 0 to disable.
+# CLI flag: -frontend.log-queries-longer-than
+[log_queries_longer_than: <duration> | default = 0s]
+```
+
+## `queryrange_config`
+
+The `queryrange_config` configures the query splitting and caching in the Cortex query-frontend.
+
+```yaml
+# Split queries by an interval and execute in parallel, 0 disables it. You
+# should use an a multiple of 24 hours (same as the storage bucketing scheme),
+# to avoid queriers downloading and processing the same chunks.
+# CLI flag: -querier.split-queries-by-interval
+[split_queries_by_interval: <duration> | default = 0s]
+
+# Deprecated: Split queries by day and execute in parallel.
+# CLI flag: -querier.split-queries-by-day
+[split_queries_by_day: <boolean> | default = false]
+
+# Mutate incoming queries to align their start and end with their step.
+# CLI flag: -querier.align-querier-with-step
+[align_queries_with_step: <boolean> | default = false]
+
+results_cache:
+  cache:
+    # Enable in-memory cache.
+    # CLI flag: -frontend.cache.enable-fifocache
+    [enable_fifocache: <boolean> | default = false]
+
+    # The default validity of entries for caches unless overridden.
+    # CLI flag: -frontend.default-validity
+    [defaul_validity: <duration> | default = 0s]
+
+    background:
+      # How many goroutines to use to write back to memcache.
+      # CLI flag: -frontend.memcache.write-back-goroutines
+      [writeback_goroutines: <int> | default = 10]
+
+      # How many chunks to buffer for background write back.
+      # CLI flag: -frontend.memcache.write-back-buffer
+      [writeback_buffer: <int> | default = 10000]
+
+    # The memcached_config block configures how data is stored in Memcached (ie.
+    # expiration).
+    # The CLI flags prefix for this block config is: frontend
+    [memcached: <memcached_config>]
+
+    # The memcached_client_config configures the client used to connect to
+    # Memcached.
+    # The CLI flags prefix for this block config is: frontend
+    [memcached_client: <memcached_client_config>]
+
+    # The redis_config configures the Redis backend cache.
+    # The CLI flags prefix for this block config is: frontend
+    [redis: <redis_config>]
+
+    # The fifo_cache_config configures the local in-memory cache.
+    # The CLI flags prefix for this block config is: frontend
+    [fifocache: <fifo_cache_config>]
+
+  # Most recent allowed cacheable result, to prevent caching very recent results
+  # that might still be in flux.
+  # CLI flag: -frontend.max-cache-freshness
+  [max_freshness: <duration> | default = 1m0s]
+
+  # The maximum interval expected for each request, results will be cached per
+  # single interval.
+  # CLI flag: -frontend.cache-split-interval
+  [cache_split_interval: <duration> | default = 24h0m0s]
+
+# Cache query results.
+# CLI flag: -querier.cache-results
+[cache_results: <boolean> | default = false]
+
+# Maximum number of retries for a single request; beyond this, the downstream
+# error is returned.
+# CLI flag: -querier.max-retries-per-request
+[max_retries: <int> | default = 5]
+```
+
+## `ruler_config`
+
+The `ruler_config` configures the Cortex ruler.
+
+```yaml
+externalurl:
+  # URL of alerts return path.
+  # CLI flag: -ruler.external.url
+  [url: <url> | default = ]
+
+# How frequently to evaluate rules
+# CLI flag: -ruler.evaluation-interval
+[evaluationinterval: <duration> | default = 1m0s]
+
+# How frequently to poll for rule changes
+# CLI flag: -ruler.poll-interval
+[pollinterval: <duration> | default = 1m0s]
+
+storeconfig:
+  # Method to use for backend rule storage (configdb)
+  # CLI flag: -ruler.storage.type
+  [type: <string> | default = "configdb"]
+
+  # The configstore_config configures the config database storing rules and
+  # alerts, and is used by the Cortex alertmanager.
+  # The CLI flags prefix for this block config is: ruler
+  [configdb: <configstore_config>]
+
+# file path to store temporary rule files for the prometheus rule managers
+# CLI flag: -ruler.rule-path
+[rulepath: <string> | default = "/rules"]
+
+alertmanagerurl:
+  # URL of the Alertmanager to send notifications to.
+  # CLI flag: -ruler.alertmanager-url
+  [url: <url> | default = ]
+
+# Use DNS SRV records to discover alertmanager hosts.
+# CLI flag: -ruler.alertmanager-discovery
+[alertmanagerdiscovery: <boolean> | default = false]
+
+# How long to wait between refreshing alertmanager hosts.
+# CLI flag: -ruler.alertmanager-refresh-interval
+[alertmanagerrefreshinterval: <duration> | default = 1m0s]
+
+# If enabled requests to alertmanager will utilize the V2 API.
+# CLI flag: -ruler.alertmanager-use-v2
+[alertmanangerenablev2api: <boolean> | default = false]
+
+# Capacity of the queue for notifications to be sent to the Alertmanager.
+# CLI flag: -ruler.notification-queue-capacity
+[notificationqueuecapacity: <int> | default = 10000]
+
+# HTTP timeout duration when sending notifications to the Alertmanager.
+# CLI flag: -ruler.notification-timeout
+[notificationtimeout: <duration> | default = 10s]
+
+# Distribute rule evaluation using ring backend
+# CLI flag: -ruler.enable-sharding
+[enablesharding: <boolean> | default = false]
+
+# Time to spend searching for a pending ruler when shutting down.
+# CLI flag: -ruler.search-pending-for
+[searchpendingfor: <duration> | default = 5m0s]
+
+lifecyclerconfig:
+  ring:
+    kvstore:
+      # Backend storage to use for the ring. Supported values are: consul, etcd,
+      # inmemory, memberlist (experimental).
+      # CLI flag: -ruler.store
+      [store: <string> | default = "consul"]
+
+      # The consul_config configures the consul client.
+      # The CLI flags prefix for this block config is: ruler
+      [consul: <consul_config>]
+
+      # The etcd_config configures the etcd client.
+      # The CLI flags prefix for this block config is: ruler
+      [etcd: <etcd_config>]
+
+      # The memberlist_config configures the Gossip memberlist.
+      # The CLI flags prefix for this block config is: ruler
+      [memberlist: <memberlist_config>]
+
+      # The prefix for the keys in the store. Should end with a /.
+      # CLI flag: -ruler.prefix
+      [prefix: <string> | default = "collectors/"]
+
+    # The heartbeat timeout after which ingesters are skipped for reads/writes.
+    # CLI flag: -ruler.ring.heartbeat-timeout
+    [heartbeat_timeout: <duration> | default = 1m0s]
+
+    # The number of ingesters to write to and read from.
+    # CLI flag: -ruler.distributor.replication-factor
+    [replication_factor: <int> | default = 3]
+
+  # Number of tokens for each ingester.
+  # CLI flag: -ruler.num-tokens
+  [num_tokens: <int> | default = 128]
+
+  # Period at which to heartbeat to consul.
+  # CLI flag: -ruler.heartbeat-period
+  [heartbeat_period: <duration> | default = 5s]
+
+  # Observe tokens after generating to resolve collisions. Useful when using
+  # gossiping ring.
+  # CLI flag: -ruler.observe-period
+  [observe_period: <duration> | default = 0s]
+
+  # Period to wait for a claim from another member; will join automatically
+  # after this.
+  # CLI flag: -ruler.join-after
+  [join_after: <duration> | default = 0s]
+
+  # Minimum duration to wait before becoming ready. This is to work around race
+  # conditions with ingesters exiting and updating the ring.
+  # CLI flag: -ruler.min-ready-duration
+  [min_ready_duration: <duration> | default = 1m0s]
+
+  # Name of network interface to read address from.
+  # CLI flag: -ruler.lifecycler.interface
+  [interface_names: <list of string> | default = [eth0 en0]]
+
+  # Duration to sleep for before exiting, to ensure metrics are scraped.
+  # CLI flag: -ruler.final-sleep
+  [final_sleep: <duration> | default = 30s]
+
+  # File path where tokens are stored. If empty, tokens are not stored at
+  # shutdown and restored at startup.
+  # CLI flag: -ruler.tokens-file-path
+  [tokens_file_path: <string> | default = ""]
+
+# Period with which to attempt to flush rule groups.
+# CLI flag: -ruler.flush-period
+[flushcheckperiod: <duration> | default = 1m0s]
+```
+
+## `alertmanager_config`
+
+The `alertmanager_config` configures the Cortex alertmanager.
+
+```yaml
+# Base path for data storage.
+# CLI flag: -alertmanager.storage.path
+[datadir: <string> | default = "data/"]
+
+# How long to keep data for.
+# CLI flag: -alertmanager.storage.retention
+[retention: <duration> | default = 120h0m0s]
+
+externalurl:
+  # The URL under which Alertmanager is externally reachable (for example, if
+  # Alertmanager is served via a reverse proxy). Used for generating relative
+  # and absolute links back to Alertmanager itself. If the URL has a path
+  # portion, it will be used to prefix all HTTP endpoints served by
+  # Alertmanager. If omitted, relevant URL components will be derived
+  # automatically.
+  # CLI flag: -alertmanager.web.external-url
+  [url: <url> | default = ]
+
+# How frequently to poll Cortex configs
+# CLI flag: -alertmanager.configs.poll-interval
+[pollinterval: <duration> | default = 15s]
+
+# Listen address for cluster.
+# CLI flag: -cluster.listen-address
+[clusterbindaddr: <string> | default = "0.0.0.0:9094"]
+
+# Explicit address to advertise in cluster.
+# CLI flag: -cluster.advertise-address
+[clusteradvertiseaddr: <string> | default = ""]
+
+# Initial peers (may be repeated).
+# CLI flag: -cluster.peer
+[peers: <list of string> | default = ]
+
+# Time to wait between peers to send notifications.
+# CLI flag: -cluster.peer-timeout
+[peertimeout: <duration> | default = 15s]
+
+# Filename of fallback config to use if none specified for instance.
+# CLI flag: -alertmanager.configs.fallback
+[fallbackconfigfile: <string> | default = ""]
+
+# Root of URL to generate if config is http://internal.monitor
+# CLI flag: -alertmanager.configs.auto-webhook-root
+[autowebhookroot: <string> | default = ""]
+```
+
+## `table_manager_config`
+
+The `table_manager_config` configures the Cortex table-manager.
+
+```yaml
+# If true, disable all changes to DB capacity
+# CLI flag: -table-manager.throughput-updates-disabled
+[throughput_updates_disabled: <boolean> | default = false]
+
+# If true, enables retention deletes of DB tables
+# CLI flag: -table-manager.retention-deletes-enabled
+[retention_deletes_enabled: <boolean> | default = false]
+
+# Tables older than this retention period are deleted. Note: This setting is
+# destructive to data!(default: 0, which disables deletion)
+# CLI flag: -table-manager.retention-period
+[retention_period: <duration> | default = 0s]
+
+# How frequently to poll DynamoDB to learn our capacity.
+# CLI flag: -dynamodb.poll-interval
+[dynamodb_poll_interval: <duration> | default = 2m0s]
+
+# DynamoDB periodic tables grace period (duration which table will be
+# created/deleted before/after it's needed).
+# CLI flag: -dynamodb.periodic-table.grace-period
+[creation_grace_period: <duration> | default = 10m0s]
+
+index_tables_provisioning:
+  # Enables on demand throughput provisioning for the storage provider (if
+  # supported). Applies only to tables which are not autoscaled
+  # CLI flag: -dynamodb.periodic-table.enable-ondemand-throughput-mode
+  [provisioned_throughput_on_demand_mode: <boolean> | default = false]
+
+  # DynamoDB table default write throughput.
+  # CLI flag: -dynamodb.periodic-table.write-throughput
+  [provisioned_write_throughput: <int> | default = 1000]
+
+  # DynamoDB table default read throughput.
+  # CLI flag: -dynamodb.periodic-table.read-throughput
+  [provisioned_read_throughput: <int> | default = 300]
+
+  # Enables on demand throughput provisioning for the storage provider (if
+  # supported). Applies only to tables which are not autoscaled
+  # CLI flag: -dynamodb.periodic-table.inactive-enable-ondemand-throughput-mode
+  [inactive_throughput_on_demand_mode: <boolean> | default = false]
+
+  # DynamoDB table write throughput for inactive tables.
+  # CLI flag: -dynamodb.periodic-table.inactive-write-throughput
+  [inactive_write_throughput: <int> | default = 1]
+
+  # DynamoDB table read throughput for inactive tables.
+  # CLI flag: -dynamodb.periodic-table.inactive-read-throughput
+  [inactive_read_throughput: <int> | default = 300]
+
+  write_scale:
+    # Should we enable autoscale for the table.
+    # CLI flag: -dynamodb.periodic-table.write-throughput.scale.enabled
+    [enabled: <boolean> | default = false]
+
+    # AWS AutoScaling role ARN
+    # CLI flag: -dynamodb.periodic-table.write-throughput.scale.role-arn
+    [role_arn: <string> | default = ""]
+
+    # DynamoDB minimum provision capacity.
+    # CLI flag: -dynamodb.periodic-table.write-throughput.scale.min-capacity
+    [min_capacity: <int> | default = 3000]
+
+    # DynamoDB maximum provision capacity.
+    # CLI flag: -dynamodb.periodic-table.write-throughput.scale.max-capacity
+    [max_capacity: <int> | default = 6000]
+
+    # DynamoDB minimum seconds between each autoscale up.
+    # CLI flag: -dynamodb.periodic-table.write-throughput.scale.out-cooldown
+    [out_cooldown: <int> | default = 1800]
+
+    # DynamoDB minimum seconds between each autoscale down.
+    # CLI flag: -dynamodb.periodic-table.write-throughput.scale.in-cooldown
+    [in_cooldown: <int> | default = 1800]
+
+    # DynamoDB target ratio of consumed capacity to provisioned capacity.
+    # CLI flag: -dynamodb.periodic-table.write-throughput.scale.target-value
+    [target: <float> | default = 80]
+
+  inactive_write_scale:
+    # Should we enable autoscale for the table.
+    # CLI flag: -dynamodb.periodic-table.inactive-write-throughput.scale.enabled
+    [enabled: <boolean> | default = false]
+
+    # AWS AutoScaling role ARN
+    # CLI flag: -dynamodb.periodic-table.inactive-write-throughput.scale.role-arn
+    [role_arn: <string> | default = ""]
+
+    # DynamoDB minimum provision capacity.
+    # CLI flag: -dynamodb.periodic-table.inactive-write-throughput.scale.min-capacity
+    [min_capacity: <int> | default = 3000]
+
+    # DynamoDB maximum provision capacity.
+    # CLI flag: -dynamodb.periodic-table.inactive-write-throughput.scale.max-capacity
+    [max_capacity: <int> | default = 6000]
+
+    # DynamoDB minimum seconds between each autoscale up.
+    # CLI flag: -dynamodb.periodic-table.inactive-write-throughput.scale.out-cooldown
+    [out_cooldown: <int> | default = 1800]
+
+    # DynamoDB minimum seconds between each autoscale down.
+    # CLI flag: -dynamodb.periodic-table.inactive-write-throughput.scale.in-cooldown
+    [in_cooldown: <int> | default = 1800]
+
+    # DynamoDB target ratio of consumed capacity to provisioned capacity.
+    # CLI flag: -dynamodb.periodic-table.inactive-write-throughput.scale.target-value
+    [target: <float> | default = 80]
+
+  # Number of last inactive tables to enable write autoscale.
+  # CLI flag: -dynamodb.periodic-table.inactive-write-throughput.scale-last-n
+  [inactive_write_scale_lastn: <int> | default = 4]
+
+  read_scale:
+    # Should we enable autoscale for the table.
+    # CLI flag: -dynamodb.periodic-table.read-throughput.scale.enabled
+    [enabled: <boolean> | default = false]
+
+    # AWS AutoScaling role ARN
+    # CLI flag: -dynamodb.periodic-table.read-throughput.scale.role-arn
+    [role_arn: <string> | default = ""]
+
+    # DynamoDB minimum provision capacity.
+    # CLI flag: -dynamodb.periodic-table.read-throughput.scale.min-capacity
+    [min_capacity: <int> | default = 3000]
+
+    # DynamoDB maximum provision capacity.
+    # CLI flag: -dynamodb.periodic-table.read-throughput.scale.max-capacity
+    [max_capacity: <int> | default = 6000]
+
+    # DynamoDB minimum seconds between each autoscale up.
+    # CLI flag: -dynamodb.periodic-table.read-throughput.scale.out-cooldown
+    [out_cooldown: <int> | default = 1800]
+
+    # DynamoDB minimum seconds between each autoscale down.
+    # CLI flag: -dynamodb.periodic-table.read-throughput.scale.in-cooldown
+    [in_cooldown: <int> | default = 1800]
+
+    # DynamoDB target ratio of consumed capacity to provisioned capacity.
+    # CLI flag: -dynamodb.periodic-table.read-throughput.scale.target-value
+    [target: <float> | default = 80]
+
+  inactive_read_scale:
+    # Should we enable autoscale for the table.
+    # CLI flag: -dynamodb.periodic-table.inactive-read-throughput.scale.enabled
+    [enabled: <boolean> | default = false]
+
+    # AWS AutoScaling role ARN
+    # CLI flag: -dynamodb.periodic-table.inactive-read-throughput.scale.role-arn
+    [role_arn: <string> | default = ""]
+
+    # DynamoDB minimum provision capacity.
+    # CLI flag: -dynamodb.periodic-table.inactive-read-throughput.scale.min-capacity
+    [min_capacity: <int> | default = 3000]
+
+    # DynamoDB maximum provision capacity.
+    # CLI flag: -dynamodb.periodic-table.inactive-read-throughput.scale.max-capacity
+    [max_capacity: <int> | default = 6000]
+
+    # DynamoDB minimum seconds between each autoscale up.
+    # CLI flag: -dynamodb.periodic-table.inactive-read-throughput.scale.out-cooldown
+    [out_cooldown: <int> | default = 1800]
+
+    # DynamoDB minimum seconds between each autoscale down.
+    # CLI flag: -dynamodb.periodic-table.inactive-read-throughput.scale.in-cooldown
+    [in_cooldown: <int> | default = 1800]
+
+    # DynamoDB target ratio of consumed capacity to provisioned capacity.
+    # CLI flag: -dynamodb.periodic-table.inactive-read-throughput.scale.target-value
+    [target: <float> | default = 80]
+
+  # Number of last inactive tables to enable read autoscale.
+  # CLI flag: -dynamodb.periodic-table.inactive-read-throughput.scale-last-n
+  [inactive_read_scale_lastn: <int> | default = 4]
+
+chunk_tables_provisioning:
+  # Enables on demand throughput provisioning for the storage provider (if
+  # supported). Applies only to tables which are not autoscaled
+  # CLI flag: -dynamodb.chunk-table.enable-ondemand-throughput-mode
+  [provisioned_throughput_on_demand_mode: <boolean> | default = false]
+
+  # DynamoDB table default write throughput.
+  # CLI flag: -dynamodb.chunk-table.write-throughput
+  [provisioned_write_throughput: <int> | default = 1000]
+
+  # DynamoDB table default read throughput.
+  # CLI flag: -dynamodb.chunk-table.read-throughput
+  [provisioned_read_throughput: <int> | default = 300]
+
+  # Enables on demand throughput provisioning for the storage provider (if
+  # supported). Applies only to tables which are not autoscaled
+  # CLI flag: -dynamodb.chunk-table.inactive-enable-ondemand-throughput-mode
+  [inactive_throughput_on_demand_mode: <boolean> | default = false]
+
+  # DynamoDB table write throughput for inactive tables.
+  # CLI flag: -dynamodb.chunk-table.inactive-write-throughput
+  [inactive_write_throughput: <int> | default = 1]
+
+  # DynamoDB table read throughput for inactive tables.
+  # CLI flag: -dynamodb.chunk-table.inactive-read-throughput
+  [inactive_read_throughput: <int> | default = 300]
+
+  write_scale:
+    # Should we enable autoscale for the table.
+    # CLI flag: -dynamodb.chunk-table.write-throughput.scale.enabled
+    [enabled: <boolean> | default = false]
+
+    # AWS AutoScaling role ARN
+    # CLI flag: -dynamodb.chunk-table.write-throughput.scale.role-arn
+    [role_arn: <string> | default = ""]
+
+    # DynamoDB minimum provision capacity.
+    # CLI flag: -dynamodb.chunk-table.write-throughput.scale.min-capacity
+    [min_capacity: <int> | default = 3000]
+
+    # DynamoDB maximum provision capacity.
+    # CLI flag: -dynamodb.chunk-table.write-throughput.scale.max-capacity
+    [max_capacity: <int> | default = 6000]
+
+    # DynamoDB minimum seconds between each autoscale up.
+    # CLI flag: -dynamodb.chunk-table.write-throughput.scale.out-cooldown
+    [out_cooldown: <int> | default = 1800]
+
+    # DynamoDB minimum seconds between each autoscale down.
+    # CLI flag: -dynamodb.chunk-table.write-throughput.scale.in-cooldown
+    [in_cooldown: <int> | default = 1800]
+
+    # DynamoDB target ratio of consumed capacity to provisioned capacity.
+    # CLI flag: -dynamodb.chunk-table.write-throughput.scale.target-value
+    [target: <float> | default = 80]
+
+  inactive_write_scale:
+    # Should we enable autoscale for the table.
+    # CLI flag: -dynamodb.chunk-table.inactive-write-throughput.scale.enabled
+    [enabled: <boolean> | default = false]
+
+    # AWS AutoScaling role ARN
+    # CLI flag: -dynamodb.chunk-table.inactive-write-throughput.scale.role-arn
+    [role_arn: <string> | default = ""]
+
+    # DynamoDB minimum provision capacity.
+    # CLI flag: -dynamodb.chunk-table.inactive-write-throughput.scale.min-capacity
+    [min_capacity: <int> | default = 3000]
+
+    # DynamoDB maximum provision capacity.
+    # CLI flag: -dynamodb.chunk-table.inactive-write-throughput.scale.max-capacity
+    [max_capacity: <int> | default = 6000]
+
+    # DynamoDB minimum seconds between each autoscale up.
+    # CLI flag: -dynamodb.chunk-table.inactive-write-throughput.scale.out-cooldown
+    [out_cooldown: <int> | default = 1800]
+
+    # DynamoDB minimum seconds between each autoscale down.
+    # CLI flag: -dynamodb.chunk-table.inactive-write-throughput.scale.in-cooldown
+    [in_cooldown: <int> | default = 1800]
+
+    # DynamoDB target ratio of consumed capacity to provisioned capacity.
+    # CLI flag: -dynamodb.chunk-table.inactive-write-throughput.scale.target-value
+    [target: <float> | default = 80]
+
+  # Number of last inactive tables to enable write autoscale.
+  # CLI flag: -dynamodb.chunk-table.inactive-write-throughput.scale-last-n
+  [inactive_write_scale_lastn: <int> | default = 4]
+
+  read_scale:
+    # Should we enable autoscale for the table.
+    # CLI flag: -dynamodb.chunk-table.read-throughput.scale.enabled
+    [enabled: <boolean> | default = false]
+
+    # AWS AutoScaling role ARN
+    # CLI flag: -dynamodb.chunk-table.read-throughput.scale.role-arn
+    [role_arn: <string> | default = ""]
+
+    # DynamoDB minimum provision capacity.
+    # CLI flag: -dynamodb.chunk-table.read-throughput.scale.min-capacity
+    [min_capacity: <int> | default = 3000]
+
+    # DynamoDB maximum provision capacity.
+    # CLI flag: -dynamodb.chunk-table.read-throughput.scale.max-capacity
+    [max_capacity: <int> | default = 6000]
+
+    # DynamoDB minimum seconds between each autoscale up.
+    # CLI flag: -dynamodb.chunk-table.read-throughput.scale.out-cooldown
+    [out_cooldown: <int> | default = 1800]
+
+    # DynamoDB minimum seconds between each autoscale down.
+    # CLI flag: -dynamodb.chunk-table.read-throughput.scale.in-cooldown
+    [in_cooldown: <int> | default = 1800]
+
+    # DynamoDB target ratio of consumed capacity to provisioned capacity.
+    # CLI flag: -dynamodb.chunk-table.read-throughput.scale.target-value
+    [target: <float> | default = 80]
+
+  inactive_read_scale:
+    # Should we enable autoscale for the table.
+    # CLI flag: -dynamodb.chunk-table.inactive-read-throughput.scale.enabled
+    [enabled: <boolean> | default = false]
+
+    # AWS AutoScaling role ARN
+    # CLI flag: -dynamodb.chunk-table.inactive-read-throughput.scale.role-arn
+    [role_arn: <string> | default = ""]
+
+    # DynamoDB minimum provision capacity.
+    # CLI flag: -dynamodb.chunk-table.inactive-read-throughput.scale.min-capacity
+    [min_capacity: <int> | default = 3000]
+
+    # DynamoDB maximum provision capacity.
+    # CLI flag: -dynamodb.chunk-table.inactive-read-throughput.scale.max-capacity
+    [max_capacity: <int> | default = 6000]
+
+    # DynamoDB minimum seconds between each autoscale up.
+    # CLI flag: -dynamodb.chunk-table.inactive-read-throughput.scale.out-cooldown
+    [out_cooldown: <int> | default = 1800]
+
+    # DynamoDB minimum seconds between each autoscale down.
+    # CLI flag: -dynamodb.chunk-table.inactive-read-throughput.scale.in-cooldown
+    [in_cooldown: <int> | default = 1800]
+
+    # DynamoDB target ratio of consumed capacity to provisioned capacity.
+    # CLI flag: -dynamodb.chunk-table.inactive-read-throughput.scale.target-value
+    [target: <float> | default = 80]
+
+  # Number of last inactive tables to enable read autoscale.
+  # CLI flag: -dynamodb.chunk-table.inactive-read-throughput.scale-last-n
+  [inactive_read_scale_lastn: <int> | default = 4]
+```
+
+## `storage_config`
+
+The `storage_config` configures where Cortex stores the data (chunks storage engine).
+
+```yaml
+# The storage engine to use: chunks or tsdb. Be aware tsdb is experimental and
+# shouldn't be used in production.
+# CLI flag: -store.engine
+[engine: <string> | default = "chunks"]
+
+aws:
+  dynamodbconfig:
+    dynamodb:
+      # DynamoDB endpoint URL with escaped Key and Secret encoded. If only
+      # region is specified as a host, proper endpoint will be deduced. Use
+      # inmemory:///<table-name> to use a mock in-memory implementation.
+      # CLI flag: -dynamodb.url
+      [url: <url> | default = ]
+
+    # DynamoDB table management requests per second limit.
+    # CLI flag: -dynamodb.api-limit
+    [apilimit: <float> | default = 2]
+
+    # DynamoDB rate cap to back off when throttled.
+    # CLI flag: -dynamodb.throttle-limit
+    [throttlelimit: <float> | default = 10]
+
+    applicationautoscaling:
+      # ApplicationAutoscaling endpoint URL with escaped Key and Secret encoded.
+      # CLI flag: -applicationautoscaling.url
+      [url: <url> | default = ]
+
+    metrics:
+      # Use metrics-based autoscaling, via this query URL
+      # CLI flag: -metrics.url
+      [url: <string> | default = ""]
+
+      # Queue length above which we will scale up capacity
+      # CLI flag: -metrics.target-queue-length
+      [targetqueuelen: <int> | default = 100000]
+
+      # Scale up capacity by this multiple
+      # CLI flag: -metrics.scale-up-factor
+      [scaleupfactor: <float> | default = 1.3]
+
+      # Ignore throttling below this level (rate per second)
+      # CLI flag: -metrics.ignore-throttle-below
+      [minthrottling: <float> | default = 1]
+
+      # query to fetch ingester queue length
+      # CLI flag: -metrics.queue-length-query
+      [queuelengthquery: <string> | default = "sum(avg_over_time(cortex_ingester_flush_queue_length{job=\"cortex/ingester\"}[2m]))"]
+
+      # query to fetch throttle rates per table
+      # CLI flag: -metrics.write-throttle-query
+      [throttlequery: <string> | default = "sum(rate(cortex_dynamo_throttled_total{operation=\"DynamoDB.BatchWriteItem\"}[1m])) by (table) > 0"]
+
+      # query to fetch write capacity usage per table
+      # CLI flag: -metrics.usage-query
+      [usagequery: <string> | default = "sum(rate(cortex_dynamo_consumed_capacity_total{operation=\"DynamoDB.BatchWriteItem\"}[15m])) by (table) > 0"]
+
+      # query to fetch read capacity usage per table
+      # CLI flag: -metrics.read-usage-query
+      [readusagequery: <string> | default = "sum(rate(cortex_dynamo_consumed_capacity_total{operation=\"DynamoDB.QueryPages\"}[1h])) by (table) > 0"]
+
+      # query to fetch read errors per table
+      # CLI flag: -metrics.read-error-query
+      [readerrorquery: <string> | default = "sum(increase(cortex_dynamo_failures_total{operation=\"DynamoDB.QueryPages\",error=\"ProvisionedThroughputExceededException\"}[1m])) by (table) > 0"]
+
+    # Number of chunks to group together to parallelise fetches (zero to
+    # disable)
+    # CLI flag: -dynamodb.chunk.gang.size
+    [chunkgangsize: <int> | default = 10]
+
+    # Max number of chunk-get operations to start in parallel
+    # CLI flag: -dynamodb.chunk.get.max.parallelism
+    [chunkgetmaxparallelism: <int> | default = 32]
+
+  s3:
+    # S3 endpoint URL with escaped Key and Secret encoded. If only region is
+    # specified as a host, proper endpoint will be deduced. Use
+    # inmemory:///<bucket-name> to use a mock in-memory implementation.
+    # CLI flag: -s3.url
+    [url: <url> | default = ]
+
+  # Comma separated list of bucket names to evenly distribute chunks over.
+  # Overrides any buckets specified in s3.url flag
+  # CLI flag: -s3.buckets
+  [bucketnames: <string> | default = ""]
+
+  # Set this to `true` to force the request to use path-style addressing.
+  # CLI flag: -s3.force-path-style
+  [s3forcepathstyle: <boolean> | default = false]
+
+azure:
+  # Name of the blob container used to store chunks. Defaults to `cortex`. This
+  # container must be created before running cortex.
+  # CLI flag: -azure.container-name
+  [container_name: <string> | default = "cortex"]
+
+  # The Microsoft Azure account name to be used
+  # CLI flag: -azure.account-name
+  [account_name: <string> | default = ""]
+
+  # The Microsoft Azure account key to use.
+  # CLI flag: -azure.account-key
+  [account_key: <string> | default = ""]
+
+  # Preallocated buffer size for downloads (default is 512KB)
+  # CLI flag: -azure.download-buffer-size
+  [download_buffer_size: <int> | default = 512000]
+
+  # Preallocated buffer size for up;oads (default is 256KB)
+  # CLI flag: -azure.upload-buffer-size
+  [upload_buffer_size: <int> | default = 256000]
+
+  # Number of buffers used to used to upload a chunk. (defaults to 1)
+  # CLI flag: -azure.download-buffer-count
+  [upload_buffer_count: <int> | default = 1]
+
+  # Timeout for requests made against azure blob storage. Defaults to 30
+  # seconds.
+  # CLI flag: -azure.request-timeout
+  [request_timeout: <duration> | default = 30s]
+
+  # Number of retries for a request which times out.
+  # CLI flag: -azure.max-retries
+  [max_retries: <int> | default = 5]
+
+  # Minimum time to wait before retrying a request.
+  # CLI flag: -azure.min-retry-delay
+  [min_retry_delay: <duration> | default = 10ms]
+
+  # Maximum time to wait before retrying a request.
+  # CLI flag: -azure.max-retry-delay
+  [max_retry_delay: <duration> | default = 500ms]
+
+bigtable:
+  # Bigtable project ID.
+  # CLI flag: -bigtable.project
+  [project: <string> | default = ""]
+
+  # Bigtable instance ID.
+  # CLI flag: -bigtable.instance
+  [instance: <string> | default = ""]
+
+  grpc_client_config:
+    # gRPC client max receive message size (bytes).
+    # CLI flag: -bigtable.grpc-max-recv-msg-size
+    [max_recv_msg_size: <int> | default = 104857600]
+
+    # gRPC client max send message size (bytes).
+    # CLI flag: -bigtable.grpc-max-send-msg-size
+    [max_send_msg_size: <int> | default = 16777216]
+
+    # Use compression when sending messages.
+    # CLI flag: -bigtable.grpc-use-gzip-compression
+    [use_gzip_compression: <boolean> | default = false]
+
+    # Rate limit for gRPC client; 0 means disabled.
+    # CLI flag: -bigtable.grpc-client-rate-limit
+    [rate_limit: <float> | default = 0]
+
+    # Rate limit burst for gRPC client.
+    # CLI flag: -bigtable.grpc-client-rate-limit-burst
+    [rate_limit_burst: <int> | default = 0]
+
+    # Enable backoff and retry when we hit ratelimits.
+    # CLI flag: -bigtable.backoff-on-ratelimits
+    [backoff_on_ratelimits: <boolean> | default = false]
+
+    backoff_config:
+      # Minimum delay when backing off.
+      # CLI flag: -bigtable.backoff-min-period
+      [minbackoff: <duration> | default = 100ms]
+
+      # Maximum delay when backing off.
+      # CLI flag: -bigtable.backoff-max-period
+      [maxbackoff: <duration> | default = 10s]
+
+      # Number of times to backoff and retry before failing.
+      # CLI flag: -bigtable.backoff-retries
+      [maxretries: <int> | default = 10]
+
+  # If enabled, once a tables info is fetched, it is cached.
+  # CLI flag: -bigtable.table-cache.enabled
+  [tablecacheenabled: <boolean> | default = true]
+
+  # Duration to cache tables before checking again.
+  # CLI flag: -bigtable.table-cache.expiration
+  [tablecacheexpiration: <duration> | default = 30m0s]
+
+gcs:
+  # Name of GCS bucket to put chunks in.
+  # CLI flag: -gcs.bucketname
+  [bucket_name: <string> | default = ""]
+
+  # The size of the buffer that GCS client for each PUT request. 0 to disable
+  # buffering.
+  # CLI flag: -gcs.chunk-buffer-size
+  [chunk_buffer_size: <int> | default = 0]
+
+  # The duration after which the requests to GCS should be timed out.
+  # CLI flag: -gcs.request-timeout
+  [request_timeout: <duration> | default = 0s]
+
+cassandra:
+  # Comma-separated hostnames or IPs of Cassandra instances.
+  # CLI flag: -cassandra.addresses
+  [addresses: <string> | default = ""]
+
+  # Port that Cassandra is running on
+  # CLI flag: -cassandra.port
+  [port: <int> | default = 9042]
+
+  # Keyspace to use in Cassandra.
+  # CLI flag: -cassandra.keyspace
+  [keyspace: <string> | default = ""]
+
+  # Consistency level for Cassandra.
+  # CLI flag: -cassandra.consistency
+  [consistency: <string> | default = "QUORUM"]
+
+  # Replication factor to use in Cassandra.
+  # CLI flag: -cassandra.replication-factor
+  [replication_factor: <int> | default = 1]
+
+  # Instruct the cassandra driver to not attempt to get host info from the
+  # system.peers table.
+  # CLI flag: -cassandra.disable-initial-host-lookup
+  [disable_initial_host_lookup: <boolean> | default = false]
+
+  # Use SSL when connecting to cassandra instances.
+  # CLI flag: -cassandra.ssl
+  [SSL: <boolean> | default = false]
+
+  # Require SSL certificate validation.
+  # CLI flag: -cassandra.host-verification
+  [host_verification: <boolean> | default = true]
+
+  # Path to certificate file to verify the peer.
+  # CLI flag: -cassandra.ca-path
+  [CA_path: <string> | default = ""]
+
+  # Enable password authentication when connecting to cassandra.
+  # CLI flag: -cassandra.auth
+  [auth: <boolean> | default = false]
+
+  # Username to use when connecting to cassandra.
+  # CLI flag: -cassandra.username
+  [username: <string> | default = ""]
+
+  # Password to use when connecting to cassandra.
+  # CLI flag: -cassandra.password
+  [password: <string> | default = ""]
+
+  # Timeout when connecting to cassandra.
+  # CLI flag: -cassandra.timeout
+  [timeout: <duration> | default = 600ms]
+
+  # Initial connection timeout, used during initial dial to server.
+  # CLI flag: -cassandra.connect-timeout
+  [connect_timeout: <duration> | default = 600ms]
+
+boltdb:
+  # Location of BoltDB index files.
+  # CLI flag: -boltdb.dir
+  [directory: <string> | default = ""]
+
+filesystem:
+  # Directory to store chunks in.
+  # CLI flag: -local.chunk-directory
+  [directory: <string> | default = ""]
+
+# Cache validity for active index entries. Should be no higher than
+# -ingester.max-chunk-idle.
+# CLI flag: -store.index-cache-validity
+[indexcachevalidity: <duration> | default = 5m0s]
+
+index_queries_cache_config:
+  # Cache config for index entry reading. Enable in-memory cache.
+  # CLI flag: -store.index-cache-read.cache.enable-fifocache
+  [enable_fifocache: <boolean> | default = false]
+
+  # Cache config for index entry reading. The default validity of entries for
+  # caches unless overridden.
+  # CLI flag: -store.index-cache-read.default-validity
+  [defaul_validity: <duration> | default = 0s]
+
+  background:
+    # Cache config for index entry reading. How many goroutines to use to write
+    # back to memcache.
+    # CLI flag: -store.index-cache-read.memcache.write-back-goroutines
+    [writeback_goroutines: <int> | default = 10]
+
+    # Cache config for index entry reading. How many chunks to buffer for
+    # background write back.
+    # CLI flag: -store.index-cache-read.memcache.write-back-buffer
+    [writeback_buffer: <int> | default = 10000]
+
+  # The memcached_config block configures how data is stored in Memcached (ie.
+  # expiration).
+  # The CLI flags prefix for this block config is: store.index-cache-read
+  [memcached: <memcached_config>]
+
+  # The memcached_client_config configures the client used to connect to
+  # Memcached.
+  # The CLI flags prefix for this block config is: store.index-cache-read
+  [memcached_client: <memcached_client_config>]
+
+  # The redis_config configures the Redis backend cache.
+  # The CLI flags prefix for this block config is: store.index-cache-read
+  [redis: <redis_config>]
+
+  # The fifo_cache_config configures the local in-memory cache.
+  # The CLI flags prefix for this block config is: store.index-cache-read
+  [fifocache: <fifo_cache_config>]
+```
+
+## `chunk_store_config`
+
+The `chunk_store_config` configures how Cortex stores the data (chunks storage engine).
+
+```yaml
+chunk_cache_config:
+  # Cache config for chunks. Enable in-memory cache.
+  # CLI flag: -cache.enable-fifocache
+  [enable_fifocache: <boolean> | default = false]
+
+  # Cache config for chunks. The default validity of entries for caches unless
+  # overridden.
+  # CLI flag: -default-validity
+  [defaul_validity: <duration> | default = 0s]
+
+  background:
+    # Cache config for chunks. How many goroutines to use to write back to
+    # memcache.
+    # CLI flag: -memcache.write-back-goroutines
+    [writeback_goroutines: <int> | default = 10]
+
+    # Cache config for chunks. How many chunks to buffer for background write
+    # back.
+    # CLI flag: -memcache.write-back-buffer
+    [writeback_buffer: <int> | default = 10000]
+
+  # The memcached_config block configures how data is stored in Memcached (ie.
+  # expiration).
+  [memcached: <memcached_config>]
+
+  # The memcached_client_config configures the client used to connect to
+  # Memcached.
+  [memcached_client: <memcached_client_config>]
+
+  # The redis_config configures the Redis backend cache.
+  [redis: <redis_config>]
+
+  # The fifo_cache_config configures the local in-memory cache.
+  [fifocache: <fifo_cache_config>]
+
+write_dedupe_cache_config:
+  # Cache config for index entry writing. Enable in-memory cache.
+  # CLI flag: -store.index-cache-write.cache.enable-fifocache
+  [enable_fifocache: <boolean> | default = false]
+
+  # Cache config for index entry writing. The default validity of entries for
+  # caches unless overridden.
+  # CLI flag: -store.index-cache-write.default-validity
+  [defaul_validity: <duration> | default = 0s]
+
+  background:
+    # Cache config for index entry writing. How many goroutines to use to write
+    # back to memcache.
+    # CLI flag: -store.index-cache-write.memcache.write-back-goroutines
+    [writeback_goroutines: <int> | default = 10]
+
+    # Cache config for index entry writing. How many chunks to buffer for
+    # background write back.
+    # CLI flag: -store.index-cache-write.memcache.write-back-buffer
+    [writeback_buffer: <int> | default = 10000]
+
+  # The memcached_config block configures how data is stored in Memcached (ie.
+  # expiration).
+  # The CLI flags prefix for this block config is: store.index-cache-write
+  [memcached: <memcached_config>]
+
+  # The memcached_client_config configures the client used to connect to
+  # Memcached.
+  # The CLI flags prefix for this block config is: store.index-cache-write
+  [memcached_client: <memcached_client_config>]
+
+  # The redis_config configures the Redis backend cache.
+  # The CLI flags prefix for this block config is: store.index-cache-write
+  [redis: <redis_config>]
+
+  # The fifo_cache_config configures the local in-memory cache.
+  # The CLI flags prefix for this block config is: store.index-cache-write
+  [fifocache: <fifo_cache_config>]
+
+# Minimum time between chunk update and being saved to the store.
+# CLI flag: -store.min-chunk-age
+[min_chunk_age: <duration> | default = 0s]
+
+# Cache index entries older than this period. 0 to disable.
+# CLI flag: -store.cache-lookups-older-than
+[cache_lookups_older_than: <duration> | default = 0s]
+
+# Limit how long back data can be queried
+# CLI flag: -store.max-look-back-period
+[max_look_back_period: <duration> | default = 0s]
+```
+
+## `ingester_client_config`
+
+The `ingester_client_config` configures how the Cortex distributors connect to the ingesters.
+
+```yaml
+grpc_client_config:
+  # gRPC client max receive message size (bytes).
+  # CLI flag: -ingester.client.grpc-max-recv-msg-size
+  [max_recv_msg_size: <int> | default = 104857600]
+
+  # gRPC client max send message size (bytes).
+  # CLI flag: -ingester.client.grpc-max-send-msg-size
+  [max_send_msg_size: <int> | default = 16777216]
+
+  # Use compression when sending messages.
+  # CLI flag: -ingester.client.grpc-use-gzip-compression
+  [use_gzip_compression: <boolean> | default = false]
+
+  # Rate limit for gRPC client; 0 means disabled.
+  # CLI flag: -ingester.client.grpc-client-rate-limit
+  [rate_limit: <float> | default = 0]
+
+  # Rate limit burst for gRPC client.
+  # CLI flag: -ingester.client.grpc-client-rate-limit-burst
+  [rate_limit_burst: <int> | default = 0]
+
+  # Enable backoff and retry when we hit ratelimits.
+  # CLI flag: -ingester.client.backoff-on-ratelimits
+  [backoff_on_ratelimits: <boolean> | default = false]
+
+  backoff_config:
+    # Minimum delay when backing off.
+    # CLI flag: -ingester.client.backoff-min-period
+    [minbackoff: <duration> | default = 100ms]
+
+    # Maximum delay when backing off.
+    # CLI flag: -ingester.client.backoff-max-period
+    [maxbackoff: <duration> | default = 10s]
+
+    # Number of times to backoff and retry before failing.
+    # CLI flag: -ingester.client.backoff-retries
+    [maxretries: <int> | default = 10]
+```
+
+## `frontend_worker_config`
+
+The `frontend_worker_config` configures the worker - running within the Cortex ingester - picking up and executing queries enqueued by the query-frontend.
+
+```yaml
+# Address of query frontend service.
+# CLI flag: -querier.frontend-address
+[address: <string> | default = ""]
+
+# Number of simultaneous queries to process.
+# CLI flag: -querier.worker-parallelism
+[parallelism: <int> | default = 10]
+
+# How often to query DNS.
+# CLI flag: -querier.dns-lookup-period
+[dnslookupduration: <duration> | default = 10s]
+
+grpc_client_config:
+  # gRPC client max receive message size (bytes).
+  # CLI flag: -querier.frontend-client.grpc-max-recv-msg-size
+  [max_recv_msg_size: <int> | default = 104857600]
+
+  # gRPC client max send message size (bytes).
+  # CLI flag: -querier.frontend-client.grpc-max-send-msg-size
+  [max_send_msg_size: <int> | default = 16777216]
+
+  # Use compression when sending messages.
+  # CLI flag: -querier.frontend-client.grpc-use-gzip-compression
+  [use_gzip_compression: <boolean> | default = false]
+
+  # Rate limit for gRPC client; 0 means disabled.
+  # CLI flag: -querier.frontend-client.grpc-client-rate-limit
+  [rate_limit: <float> | default = 0]
+
+  # Rate limit burst for gRPC client.
+  # CLI flag: -querier.frontend-client.grpc-client-rate-limit-burst
+  [rate_limit_burst: <int> | default = 0]
+
+  # Enable backoff and retry when we hit ratelimits.
+  # CLI flag: -querier.frontend-client.backoff-on-ratelimits
+  [backoff_on_ratelimits: <boolean> | default = false]
+
+  backoff_config:
+    # Minimum delay when backing off.
+    # CLI flag: -querier.frontend-client.backoff-min-period
+    [minbackoff: <duration> | default = 100ms]
+
+    # Maximum delay when backing off.
+    # CLI flag: -querier.frontend-client.backoff-max-period
+    [maxbackoff: <duration> | default = 10s]
+
+    # Number of times to backoff and retry before failing.
+    # CLI flag: -querier.frontend-client.backoff-retries
+    [maxretries: <int> | default = 10]
+```
+
+## `etcd_config`
+
+The `etcd_config` configures the etcd client.
+
+```yaml
+# The etcd endpoints to connect to.
+# CLI flag: -<prefix>.etcd.endpoints
+[endpoints: <list of string> | default = []]
+
+# The dial timeout for the etcd connection.
+# CLI flag: -<prefix>.etcd.dial-timeout
+[dial_timeout: <duration> | default = 10s]
+
+# The maximum number of retries to do for failed ops.
+# CLI flag: -<prefix>.etcd.max-retries
+[max_retries: <int> | default = 10]
+```
+
+## `consul_config`
+
+The `consul_config` configures the consul client.
+
+```yaml
+# Hostname and port of Consul.
+# CLI flag: -<prefix>.consul.hostname
+[host: <string> | default = "localhost:8500"]
+
+# ACL Token used to interact with Consul.
+# CLI flag: -<prefix>.consul.acltoken
+[acltoken: <string> | default = ""]
+
+# HTTP timeout when talking to Consul
+# CLI flag: -<prefix>.consul.client-timeout
+[httpclienttimeout: <duration> | default = 20s]
+
+# Enable consistent reads to Consul.
+# CLI flag: -<prefix>.consul.consistent-reads
+[consistentreads: <boolean> | default = true]
+
+# Rate limit when watching key or prefix in Consul, in requests per second. 0
+# disables the rate limit.
+# CLI flag: -<prefix>.consul.watch-rate-limit
+[watchkeyratelimit: <float> | default = 0]
+
+# Burst size used in rate limit. Values less than 1 are treated as 1.
+# CLI flag: -<prefix>.consul.watch-burst-size
+[watchkeyburstsize: <int> | default = 1]
+```
+
+## `memberlist_config`
+
+The `memberlist_config` configures the Gossip memberlist.
+
+```yaml
+# Name of the node in memberlist cluster. Defaults to hostname.
+# CLI flag: -<prefix>.memberlist.nodename
+[node_name: <string> | default = ""]
+
+# The timeout for establishing a connection with a remote node, and for
+# read/write operations. Uses memberlist LAN defaults if 0.
+# CLI flag: -<prefix>.memberlist.stream-timeout
+[stream_timeout: <duration> | default = 0s]
+
+# Multiplication factor used when sending out messages (factor * log(N+1)).
+# CLI flag: -<prefix>.memberlist.retransmit-factor
+[retransmit_factor: <int> | default = 0]
+
+# How often to use pull/push sync. Uses memberlist LAN defaults if 0.
+# CLI flag: -<prefix>.memberlist.pullpush-interval
+[pull_push_interval: <duration> | default = 0s]
+
+# How often to gossip. Uses memberlist LAN defaults if 0.
+# CLI flag: -<prefix>.memberlist.gossip-interval
+[gossip_interval: <duration> | default = 0s]
+
+# How many nodes to gossip to. Uses memberlist LAN defaults if 0.
+# CLI flag: -<prefix>.memberlist.gossip-nodes
+[gossip_nodes: <int> | default = 0]
+
+# Other cluster members to join. Can be specified multiple times. Memberlist
+# store is EXPERIMENTAL.
+# CLI flag: -<prefix>.memberlist.join
+[join_members: <list of string> | default = ]
+
+# If this node fails to join memberlist cluster, abort.
+# CLI flag: -<prefix>.memberlist.abort-if-join-fails
+[abort_if_cluster_join_fails: <boolean> | default = true]
+
+# How long to keep LEFT ingesters in the ring.
+# CLI flag: -<prefix>.memberlist.left-ingesters-timeout
+[left_ingesters_timeout: <duration> | default = 5m0s]
+
+# Timeout for leaving memberlist cluster.
+# CLI flag: -<prefix>.memberlist.leave-timeout
+[leave_timeout: <duration> | default = 5s]
+```
+
+## `limits_config`
+
+The `limits_config` configures default and per-tenant limits imposed by Cortex services (ie. distributor, ingester, ...).
+
+```yaml
+# Per-user ingestion rate limit in samples per second.
+# CLI flag: -distributor.ingestion-rate-limit
+[ingestion_rate: <float> | default = 25000]
+
+# Whether the ingestion rate limit should be applied individually to each
+# distributor instance (local), or evenly shared across the cluster (global).
+# CLI flag: -distributor.ingestion-rate-limit-strategy
+[ingestion_rate_strategy: <string> | default = "local"]
+
+# Per-user allowed ingestion burst size (in number of samples).
+# CLI flag: -distributor.ingestion-burst-size
+[ingestion_burst_size: <int> | default = 50000]
+
+# Flag to enable, for all users, handling of samples with external labels
+# identifying replicas in an HA Prometheus setup.
+# CLI flag: -distributor.ha-tracker.enable-for-all-users
+[accept_ha_samples: <boolean> | default = false]
+
+# Prometheus label to look for in samples to identify a Prometheus HA cluster.
+# CLI flag: -distributor.ha-tracker.cluster
+[ha_cluster_label: <string> | default = "cluster"]
+
+# Prometheus label to look for in samples to identify a Prometheus HA replica.
+# CLI flag: -distributor.ha-tracker.replica
+[ha_replica_label: <string> | default = "__replica__"]
+
+# This flag can be used to specify label names that to drop during sample
+# ingestion within the distributor and can be repeated in order to drop multiple
+# labels.
+# CLI flag: -distributor.drop-label
+[drop_labels: <list of string> | default = ]
+
+# Maximum length accepted for label names
+# CLI flag: -validation.max-length-label-name
+[max_label_name_length: <int> | default = 1024]
+
+# Maximum length accepted for label value. This setting also applies to the
+# metric name
+# CLI flag: -validation.max-length-label-value
+[max_label_value_length: <int> | default = 2048]
+
+# Maximum number of label names per series.
+# CLI flag: -validation.max-label-names-per-series
+[max_label_names_per_series: <int> | default = 30]
+
+# Reject old samples.
+# CLI flag: -validation.reject-old-samples
+[reject_old_samples: <boolean> | default = false]
+
+# Maximum accepted sample age before rejecting.
+# CLI flag: -validation.reject-old-samples.max-age
+[reject_old_samples_max_age: <duration> | default = 336h0m0s]
+
+# Duration which table will be created/deleted before/after it's needed; we
+# won't accept sample from before this time.
+# CLI flag: -validation.create-grace-period
+[creation_grace_period: <duration> | default = 10m0s]
+
+# Enforce every sample has a metric name.
+# CLI flag: -validation.enforce-metric-name
+[enforce_metric_name: <boolean> | default = true]
+
+# The maximum number of series that a query can return.
+# CLI flag: -ingester.max-series-per-query
+[max_series_per_query: <int> | default = 100000]
+
+# The maximum number of samples that a query can return.
+# CLI flag: -ingester.max-samples-per-query
+[max_samples_per_query: <int> | default = 1000000]
+
+# The maximum number of active series per user, per ingester. 0 to disable.
+# CLI flag: -ingester.max-series-per-user
+[max_series_per_user: <int> | default = 5000000]
+
+# The maximum number of active series per metric name, per ingester. 0 to
+# disable.
+# CLI flag: -ingester.max-series-per-metric
+[max_series_per_metric: <int> | default = 50000]
+
+# The maximum number of active series per user, across the cluster. 0 to
+# disable. Supported only if -distributor.shard-by-all-labels is true.
+# CLI flag: -ingester.max-global-series-per-user
+[max_global_series_per_user: <int> | default = 0]
+
+# The maximum number of active series per metric name, across the cluster. 0 to
+# disable.
+# CLI flag: -ingester.max-global-series-per-metric
+[max_global_series_per_metric: <int> | default = 0]
+
+# Minimum number of samples in an idle chunk to flush it to the store. Use with
+# care, if chunks are less than this size they will be discarded.
+# CLI flag: -ingester.min-chunk-length
+[min_chunk_length: <int> | default = 0]
+
+# Maximum number of chunks that can be fetched in a single query.
+# CLI flag: -store.query-chunk-limit
+[max_chunks_per_query: <int> | default = 2000000]
+
+# Limit to length of chunk store queries, 0 to disable.
+# CLI flag: -store.max-query-length
+[max_query_length: <duration> | default = 0s]
+
+# Maximum number of queries will be scheduled in parallel by the frontend.
+# CLI flag: -querier.max-query-parallelism
+[max_query_parallelism: <int> | default = 14]
+
+# Cardinality limit for index queries.
+# CLI flag: -store.cardinality-limit
+[cardinality_limit: <int> | default = 100000]
+
+# File name of per-user overrides.
+# CLI flag: -limits.per-user-override-config
+[per_tenant_override_config: <string> | default = ""]
+
+# Period with which to reload the overrides.
+# CLI flag: -limits.per-user-override-period
+[per_tenant_override_period: <duration> | default = 10s]
+```
+
+## `redis_config`
+
+The `redis_config` configures the Redis backend cache.
+
+```yaml
+# Redis service endpoint to use when caching chunks. If empty, no redis will be
+# used.
+# CLI flag: -<prefix>.redis.endpoint
+[endpoint: <string> | default = ""]
+
+# Maximum time to wait before giving up on redis requests.
+# CLI flag: -<prefix>.redis.timeout
+[timeout: <duration> | default = 100ms]
+
+# How long keys stay in the redis.
+# CLI flag: -<prefix>.redis.expiration
+[expiration: <duration> | default = 0s]
+
+# Maximum number of idle connections in pool.
+# CLI flag: -<prefix>.redis.max-idle-conns
+[max_idle_conns: <int> | default = 80]
+
+# Maximum number of active connections in pool.
+# CLI flag: -<prefix>.redis.max-active-conns
+[max_active_conns: <int> | default = 0]
+```
+
+## `memcached_config`
+
+The `memcached_config` block configures how data is stored in Memcached (ie. expiration).
+
+```yaml
+# How long keys stay in the memcache.
+# CLI flag: -<prefix>.memcached.expiration
+[expiration: <duration> | default = 0s]
+
+# How many keys to fetch in each batch.
+# CLI flag: -<prefix>.memcached.batchsize
+[batch_size: <int> | default = 0]
+
+# Maximum active requests to memcache.
+# CLI flag: -<prefix>.memcached.parallelism
+[parallelism: <int> | default = 100]
+```
+
+## `memcached_client_config`
+
+The `memcached_client_config` configures the client used to connect to Memcached.
+
+```yaml
+# Hostname for memcached service to use when caching chunks. If empty, no
+# memcached will be used.
+# CLI flag: -<prefix>.memcached.hostname
+[host: <string> | default = ""]
+
+# SRV service used to discover memcache servers.
+# CLI flag: -<prefix>.memcached.service
+[service: <string> | default = "memcached"]
+
+# Maximum time to wait before giving up on memcached requests.
+# CLI flag: -<prefix>.memcached.timeout
+[timeout: <duration> | default = 100ms]
+
+# Maximum number of idle connections in pool.
+# CLI flag: -<prefix>.memcached.max-idle-conns
+[max_idle_conns: <int> | default = 16]
+
+# Period with which to poll DNS for memcache servers.
+# CLI flag: -<prefix>.memcached.update-interval
+[update_interval: <duration> | default = 1m0s]
+
+# Use consistent hashing to distribute to memcache servers.
+# CLI flag: -<prefix>.memcached.consistent-hash
+[consistent_hash: <boolean> | default = false]
+```
+
+## `fifo_cache_config`
+
+The `fifo_cache_config` configures the local in-memory cache.
+
+```yaml
+# The number of entries to cache.
+# CLI flag: -<prefix>.fifocache.size
+[size: <int> | default = 0]
+
+# The expiry duration for the cache.
+# CLI flag: -<prefix>.fifocache.duration
+[validity: <duration> | default = 0s]
+```
+
+## `configdb_config`
+
+The `configdb_config` configures the config database storing rules and alerts, and used by the 'configs' service to expose APIs to manage them.
+
+```yaml
+# URI where the database can be found (for dev you can use memory://)
+# CLI flag: -database.uri
+[uri: <string> | default = "postgres://postgres@configs-db.weave.local/configs?sslmode=disable"]
+
+# Path where the database migration files can be found
+# CLI flag: -database.migrations
+[migrationsdir: <string> | default = ""]
+
+# File containing password (username goes in URI)
+# CLI flag: -database.password-file
+[passwordfile: <string> | default = ""]
+```
+
+## `configstore_config`
+
+The `configstore_config` configures the config database storing rules and alerts, and is used by the Cortex alertmanager.
+
+```yaml
+configsapiurl:
+  # URL of configs API server.
+  # CLI flag: -<prefix>.configs.url
+  [url: <url> | default = ]
+
+# Timeout for requests to Weave Cloud configs service.
+# CLI flag: -<prefix>.configs.client-timeout
+[clienttimeout: <duration> | default = 5s]
+```

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1810,6 +1810,14 @@ The `redis_config` configures the Redis backend cache.
 # Maximum number of active connections in pool.
 # CLI flag: -<prefix>.redis.max-active-conns
 [max_active_conns: <int> | default = 0]
+
+# Password to use when connecting to redis.
+# CLI flag: -<prefix>.redis.password
+[password: <string> | default = ""]
+
+# Enables connecting to redis with TLS.
+# CLI flag: -<prefix>.redis.enable-tls
+[enable_tls: <boolean> | default = false]
 ```
 
 ## `memcached_config`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -93,6 +93,15 @@ Supported contents and default values of the config file:
 
 # The alertmanager_config configures the Cortex alertmanager.
 [alertmanager: <alertmanager_config>]
+
+runtime_config:
+  # How often to check runtime config file.
+  # CLI flag: -runtime-config.reload-period
+  [period: <duration> | default = 10s]
+
+  # File with the configuration that can be updated in runtime.
+  # CLI flag: -runtime-config.file
+  [file: <string> | default = ""]
 ```
 
 ## `server_config`
@@ -205,9 +214,13 @@ ha_tracker:
 
   kvstore:
     # Backend storage to use for the ring. Supported values are: consul, etcd,
-    # inmemory, memberlist (experimental).
+    # inmemory, multi, memberlist (experimental).
     # CLI flag: -distributor.ha-tracker.store
     [store: <string> | default = "consul"]
+
+    # The prefix for the keys in the store. Should end with a /.
+    # CLI flag: -distributor.ha-tracker.prefix
+    [prefix: <string> | default = "collectors/"]
 
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: distributor.ha-tracker
@@ -221,9 +234,22 @@ ha_tracker:
     # The CLI flags prefix for this block config is: distributor.ha-tracker
     [memberlist: <memberlist_config>]
 
-    # The prefix for the keys in the store. Should end with a /.
-    # CLI flag: -distributor.ha-tracker.prefix
-    [prefix: <string> | default = "collectors/"]
+    multi:
+      # Primary backend storage used by multi-client.
+      # CLI flag: -distributor.ha-tracker.multi.primary
+      [primary: <string> | default = ""]
+
+      # Secondary backend storage used by multi-client.
+      # CLI flag: -distributor.ha-tracker.multi.secondary
+      [secondary: <string> | default = ""]
+
+      # Mirror writes to secondary store.
+      # CLI flag: -distributor.ha-tracker.multi.mirror-enabled
+      [mirror_enabled: <boolean> | default = false]
+
+      # Timeout for storing value to secondary store.
+      # CLI flag: -distributor.ha-tracker.multi.mirror-timeout
+      [mirror_timeout: <duration> | default = 2s]
 
 # remote_write API max receive message size (bytes).
 # CLI flag: -distributor.max-recv-msg-size
@@ -245,9 +271,13 @@ ha_tracker:
 ring:
   kvstore:
     # Backend storage to use for the ring. Supported values are: consul, etcd,
-    # inmemory, memberlist (experimental).
+    # inmemory, multi, memberlist (experimental).
     # CLI flag: -distributor.ring.store
     [store: <string> | default = "consul"]
+
+    # The prefix for the keys in the store. Should end with a /.
+    # CLI flag: -distributor.ring.prefix
+    [prefix: <string> | default = "collectors/"]
 
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: distributor.ring
@@ -261,9 +291,22 @@ ring:
     # The CLI flags prefix for this block config is: distributor.ring
     [memberlist: <memberlist_config>]
 
-    # The prefix for the keys in the store. Should end with a /.
-    # CLI flag: -distributor.ring.prefix
-    [prefix: <string> | default = "collectors/"]
+    multi:
+      # Primary backend storage used by multi-client.
+      # CLI flag: -distributor.ring.multi.primary
+      [primary: <string> | default = ""]
+
+      # Secondary backend storage used by multi-client.
+      # CLI flag: -distributor.ring.multi.secondary
+      [secondary: <string> | default = ""]
+
+      # Mirror writes to secondary store.
+      # CLI flag: -distributor.ring.multi.mirror-enabled
+      [mirror_enabled: <boolean> | default = false]
+
+      # Timeout for storing value to secondary store.
+      # CLI flag: -distributor.ring.multi.mirror-timeout
+      [mirror_timeout: <duration> | default = 2s]
 
   # Period at which to heartbeat to the ring.
   # CLI flag: -distributor.ring.heartbeat-period
@@ -284,9 +327,13 @@ lifecycler:
   ring:
     kvstore:
       # Backend storage to use for the ring. Supported values are: consul, etcd,
-      # inmemory, memberlist (experimental).
+      # inmemory, multi, memberlist (experimental).
       # CLI flag: -ring.store
       [store: <string> | default = "consul"]
+
+      # The prefix for the keys in the store. Should end with a /.
+      # CLI flag: -ring.prefix
+      [prefix: <string> | default = "collectors/"]
 
       # The consul_config configures the consul client.
       [consul: <consul_config>]
@@ -297,9 +344,22 @@ lifecycler:
       # The memberlist_config configures the Gossip memberlist.
       [memberlist: <memberlist_config>]
 
-      # The prefix for the keys in the store. Should end with a /.
-      # CLI flag: -ring.prefix
-      [prefix: <string> | default = "collectors/"]
+      multi:
+        # Primary backend storage used by multi-client.
+        # CLI flag: -multi.primary
+        [primary: <string> | default = ""]
+
+        # Secondary backend storage used by multi-client.
+        # CLI flag: -multi.secondary
+        [secondary: <string> | default = ""]
+
+        # Mirror writes to secondary store.
+        # CLI flag: -multi.mirror-enabled
+        [mirror_enabled: <boolean> | default = false]
+
+        # Timeout for storing value to secondary store.
+        # CLI flag: -multi.mirror-timeout
+        [mirror_timeout: <duration> | default = 2s]
 
     # The heartbeat timeout after which ingesters are skipped for reads/writes.
     # CLI flag: -ring.heartbeat-timeout
@@ -602,9 +662,13 @@ lifecyclerconfig:
   ring:
     kvstore:
       # Backend storage to use for the ring. Supported values are: consul, etcd,
-      # inmemory, memberlist (experimental).
+      # inmemory, multi, memberlist (experimental).
       # CLI flag: -ruler.store
       [store: <string> | default = "consul"]
+
+      # The prefix for the keys in the store. Should end with a /.
+      # CLI flag: -ruler.prefix
+      [prefix: <string> | default = "collectors/"]
 
       # The consul_config configures the consul client.
       # The CLI flags prefix for this block config is: ruler
@@ -618,9 +682,22 @@ lifecyclerconfig:
       # The CLI flags prefix for this block config is: ruler
       [memberlist: <memberlist_config>]
 
-      # The prefix for the keys in the store. Should end with a /.
-      # CLI flag: -ruler.prefix
-      [prefix: <string> | default = "collectors/"]
+      multi:
+        # Primary backend storage used by multi-client.
+        # CLI flag: -ruler.multi.primary
+        [primary: <string> | default = ""]
+
+        # Secondary backend storage used by multi-client.
+        # CLI flag: -ruler.multi.secondary
+        [secondary: <string> | default = ""]
+
+        # Mirror writes to secondary store.
+        # CLI flag: -ruler.multi.mirror-enabled
+        [mirror_enabled: <boolean> | default = false]
+
+        # Timeout for storing value to secondary store.
+        # CLI flag: -ruler.multi.mirror-timeout
+        [mirror_timeout: <duration> | default = 2s]
 
     # The heartbeat timeout after which ingesters are skipped for reads/writes.
     # CLI flag: -ruler.ring.heartbeat-timeout
@@ -1659,6 +1736,23 @@ The `memberlist_config` configures the Gossip memberlist.
 # Timeout for leaving memberlist cluster.
 # CLI flag: -<prefix>.memberlist.leave-timeout
 [leave_timeout: <duration> | default = 5s]
+
+# IP address to listen on for gossip messages. Multiple addresses may be
+# specified. Defaults to 0.0.0.0
+# CLI flag: -<prefix>.memberlist.bind-addr
+[bind_addr: <list of string> | default = ]
+
+# Port to listen on for gossip messages.
+# CLI flag: -<prefix>.memberlist.bind-port
+[bind_port: <int> | default = 7946]
+
+# Timeout used when connecting to other nodes to send packet.
+# CLI flag: -<prefix>.memberlist.packet-dial-timeout
+[packet_dial_timeout: <duration> | default = 5s]
+
+# Timeout for writing 'packet' data.
+# CLI flag: -<prefix>.memberlist.packet-write-timeout
+[packet_write_timeout: <duration> | default = 5s]
 ```
 
 ## `limits_config`
@@ -1776,11 +1870,13 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -store.cardinality-limit
 [cardinality_limit: <int> | default = 100000]
 
-# File name of per-user overrides.
+# File name of per-user overrides. [deprecated, use -runtime-config.file
+# instead]
 # CLI flag: -limits.per-user-override-config
 [per_tenant_override_config: <string> | default = ""]
 
-# Period with which to reload the overrides.
+# Period with which to reload the overrides. [deprecated, use
+# -runtime-config.reload-period instead]
 # CLI flag: -limits.per-user-override-period
 [per_tenant_override_period: <duration> | default = 10s]
 ```

--- a/docs/configuration/config-file-reference.template
+++ b/docs/configuration/config-file-reference.template
@@ -1,0 +1,24 @@
+---
+title: "Configuration file"
+linkTitle: "Configuration file"
+weight: 1
+slug: configuration-file
+---
+
+Cortex can be configured using a YAML file - specified using the `-config.file` flag - or CLI flags. In case you combine both, CLI flags take precedence over the YAML config file.
+
+## Reference
+
+To specify which configuration file to load, pass the `-config.file` flag at the command line. The file is written in [YAML format](https://en.wikipedia.org/wiki/YAML), defined by the scheme below. Brackets indicate that a parameter is optional.
+
+Generic placeholders are defined as follows:
+
+* `<boolean>`: a boolean that can take the values `true` or `false`
+* `<int>`: any integer matching the regular expression `[1-9]+[0-9]*`
+* `<duration>`: a duration matching the regular expression `[0-9]+(ns|us|µs|ms|[smh])`
+* `<string>`: a regular string
+* `<url>`: an URL
+* `<prefix>`: a CLI flag prefix based on the context (look at the parent configuration block to see which CLI flags prefix should be used)
+
+Supported contents and default values of the config file:
+

--- a/docs/configuration/prometheus-frontend.md
+++ b/docs/configuration/prometheus-frontend.md
@@ -1,7 +1,7 @@
 ---
 title: "Prometheus Frontend"
 linkTitle: "Prometheus Frontend"
-weight: 2
+weight: 3
 slug: prometheus-frontend
 ---
 

--- a/docs/configuration/single-process-config.md
+++ b/docs/configuration/single-process-config.md
@@ -1,7 +1,7 @@
 ---
 title: "Single-process"
 linkTitle: "Single-process"
-weight: 3
+weight: 4
 slug: single-process-config
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/lann/builder v0.0.0-20150808151131-f22ce00fd939 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.0.0
+	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/oklog/ulid v1.3.1
 	github.com/opentracing-contrib/go-grpc v0.0.0-20180928155321-4b5a12d3ff02
 	github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9

--- a/go.sum
+++ b/go.sum
@@ -553,6 +553,7 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -241,7 +241,10 @@ func (am *MultitenantAlertmanager) Stop() {
 		am.Stop()
 	}
 	am.alertmanagersMtx.Unlock()
-	am.peer.Leave(am.cfg.PeerTimeout)
+	err := am.peer.Leave(am.cfg.PeerTimeout)
+	if err != nil {
+		level.Warn(util.Logger).Log("msg", "MultitenantAlertmanager: failed to leave the cluster", "err", err)
+	}
 	level.Debug(util.Logger).Log("msg", "MultitenantAlertmanager stopped")
 }
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -93,10 +93,10 @@ type MultitenantAlertmanagerConfig struct {
 	ExternalURL  flagext.URLValue
 	PollInterval time.Duration
 
-	clusterBindAddr      string
-	clusterAdvertiseAddr string
-	peers                flagext.StringSlice
-	peerTimeout          time.Duration
+	ClusterBindAddr      string
+	ClusterAdvertiseAddr string
+	Peers                flagext.StringSlice
+	PeerTimeout          time.Duration
 
 	FallbackConfigFile string
 	AutoWebhookRoot    string
@@ -106,19 +106,19 @@ const defaultClusterAddr = "0.0.0.0:9094"
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet) {
-	flag.StringVar(&cfg.DataDir, "alertmanager.storage.path", "data/", "Base path for data storage.")
-	flag.DurationVar(&cfg.Retention, "alertmanager.storage.retention", 5*24*time.Hour, "How long to keep data for.")
+	f.StringVar(&cfg.DataDir, "alertmanager.storage.path", "data/", "Base path for data storage.")
+	f.DurationVar(&cfg.Retention, "alertmanager.storage.retention", 5*24*time.Hour, "How long to keep data for.")
 
-	flag.Var(&cfg.ExternalURL, "alertmanager.web.external-url", "The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager. If omitted, relevant URL components will be derived automatically.")
+	f.Var(&cfg.ExternalURL, "alertmanager.web.external-url", "The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager. If omitted, relevant URL components will be derived automatically.")
 
-	flag.StringVar(&cfg.FallbackConfigFile, "alertmanager.configs.fallback", "", "Filename of fallback config to use if none specified for instance.")
-	flag.StringVar(&cfg.AutoWebhookRoot, "alertmanager.configs.auto-webhook-root", "", "Root of URL to generate if config is "+autoWebhookURL)
-	flag.DurationVar(&cfg.PollInterval, "alertmanager.configs.poll-interval", 15*time.Second, "How frequently to poll Cortex configs")
+	f.StringVar(&cfg.FallbackConfigFile, "alertmanager.configs.fallback", "", "Filename of fallback config to use if none specified for instance.")
+	f.StringVar(&cfg.AutoWebhookRoot, "alertmanager.configs.auto-webhook-root", "", "Root of URL to generate if config is "+autoWebhookURL)
+	f.DurationVar(&cfg.PollInterval, "alertmanager.configs.poll-interval", 15*time.Second, "How frequently to poll Cortex configs")
 
-	flag.StringVar(&cfg.clusterBindAddr, "cluster.listen-address", defaultClusterAddr, "Listen address for cluster.")
-	flag.StringVar(&cfg.clusterAdvertiseAddr, "cluster.advertise-address", "", "Explicit address to advertise in cluster.")
-	flag.Var(&cfg.peers, "cluster.peer", "Initial peers (may be repeated).")
-	flag.DurationVar(&cfg.peerTimeout, "cluster.peer-timeout", time.Second*15, "Time to wait between peers to send notifications.")
+	f.StringVar(&cfg.ClusterBindAddr, "cluster.listen-address", defaultClusterAddr, "Listen address for cluster.")
+	f.StringVar(&cfg.ClusterAdvertiseAddr, "cluster.advertise-address", "", "Explicit address to advertise in cluster.")
+	f.Var(&cfg.Peers, "cluster.peer", "Initial peers (may be repeated).")
+	f.DurationVar(&cfg.PeerTimeout, "cluster.peer-timeout", time.Second*15, "Time to wait between peers to send notifications.")
 }
 
 // A MultitenantAlertmanager manages Alertmanager instances for multiple
@@ -173,13 +173,13 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig, cfgCfg confi
 	}
 
 	var peer *cluster.Peer
-	if cfg.clusterBindAddr != "" {
+	if cfg.ClusterBindAddr != "" {
 		peer, err = cluster.Create(
 			log.With(util.Logger, "component", "cluster"),
 			prometheus.DefaultRegisterer,
-			cfg.clusterBindAddr,
-			cfg.clusterAdvertiseAddr,
-			cfg.peers,
+			cfg.ClusterBindAddr,
+			cfg.ClusterAdvertiseAddr,
+			cfg.Peers,
 			true,
 			cluster.DefaultPushPullInterval,
 			cluster.DefaultGossipInterval,
@@ -241,7 +241,7 @@ func (am *MultitenantAlertmanager) Stop() {
 		am.Stop()
 	}
 	am.alertmanagersMtx.Unlock()
-	am.peer.Leave(am.cfg.peerTimeout)
+	am.peer.Leave(am.cfg.PeerTimeout)
 	level.Debug(util.Logger).Log("msg", "MultitenantAlertmanager stopped")
 }
 
@@ -433,7 +433,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *amco
 		DataDir:     am.cfg.DataDir,
 		Logger:      util.Logger,
 		Peer:        am.peer,
-		PeerTimeout: am.cfg.peerTimeout,
+		PeerTimeout: am.cfg.PeerTimeout,
 		Retention:   am.cfg.Retention,
 		ExternalURL: am.cfg.ExternalURL.URL,
 	})

--- a/pkg/chunk/cache/cache.go
+++ b/pkg/chunk/cache/cache.go
@@ -33,10 +33,10 @@ type Config struct {
 	Fifocache      FifoCacheConfig       `yaml:"fifocache,omitempty"`
 
 	// This is to name the cache metrics properly.
-	Prefix string `yaml:"prefix,omitempty"`
+	Prefix string `yaml:"prefix,omitempty" doc:"hidden"`
 
 	// For tests to inject specific implementations.
-	Cache Cache
+	Cache Cache `yaml:"-"`
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet

--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -36,8 +36,8 @@ type Config struct {
 
 	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config"`
 
-	ColumnKey      bool
-	DistributeKeys bool
+	ColumnKey      bool `yaml:"-"`
+	DistributeKeys bool `yaml:"-"`
 
 	TableCacheEnabled    bool
 	TableCacheExpiration time.Duration

--- a/pkg/configs/db/db.go
+++ b/pkg/configs/db/db.go
@@ -19,14 +19,14 @@ type Config struct {
 	PasswordFile  string
 
 	// Allow injection of mock DBs for unit testing.
-	Mock DB
+	Mock DB `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to configure this to the given FlagSet.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	flag.StringVar(&cfg.URI, "database.uri", "postgres://postgres@configs-db.weave.local/configs?sslmode=disable", "URI where the database can be found (for dev you can use memory://)")
-	flag.StringVar(&cfg.MigrationsDir, "database.migrations", "", "Path where the database migration files can be found")
-	flag.StringVar(&cfg.PasswordFile, "database.password-file", "", "File containing password (username goes in URI)")
+	f.StringVar(&cfg.URI, "database.uri", "postgres://postgres@configs-db.weave.local/configs?sslmode=disable", "URI where the database can be found (for dev you can use memory://)")
+	f.StringVar(&cfg.MigrationsDir, "database.migrations", "", "Path where the database migration files can be found")
+	f.StringVar(&cfg.PasswordFile, "database.password-file", "", "File containing password (username goes in URI)")
 }
 
 // DB is the interface for the database.

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -66,7 +66,7 @@ type Config struct {
 	Ingester       ingester.Config          `yaml:"ingester,omitempty"`
 	Storage        storage.Config           `yaml:"storage,omitempty"`
 	ChunkStore     chunk.StoreConfig        `yaml:"chunk_store,omitempty"`
-	Schema         chunk.SchemaConfig       `yaml:"schema,omitempty" doc:"hidden"`
+	Schema         chunk.SchemaConfig       `yaml:"schema,omitempty" doc:"hidden"` // Doc generation tool doesn't support it because part of the SchemaConfig doesn't support CLI flags (needs manual documentation)
 	LimitsConfig   validation.Limits        `yaml:"limits,omitempty"`
 	Prealloc       client.PreallocConfig    `yaml:"prealloc,omitempty" doc:"hidden"`
 	Worker         frontend.WorkerConfig    `yaml:"frontend_worker,omitempty"`

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -66,15 +66,15 @@ type Config struct {
 	Ingester       ingester.Config          `yaml:"ingester,omitempty"`
 	Storage        storage.Config           `yaml:"storage,omitempty"`
 	ChunkStore     chunk.StoreConfig        `yaml:"chunk_store,omitempty"`
-	Schema         chunk.SchemaConfig       `yaml:"schema,omitempty"`
+	Schema         chunk.SchemaConfig       `yaml:"schema,omitempty" doc:"hidden"`
 	LimitsConfig   validation.Limits        `yaml:"limits,omitempty"`
-	Prealloc       client.PreallocConfig    `yaml:"prealloc,omitempty"`
+	Prealloc       client.PreallocConfig    `yaml:"prealloc,omitempty" doc:"hidden"`
 	Worker         frontend.WorkerConfig    `yaml:"frontend_worker,omitempty"`
 	Frontend       frontend.Config          `yaml:"frontend,omitempty"`
 	QueryRange     queryrange.Config        `yaml:"query_range,omitempty"`
 	TableManager   chunk.TableManagerConfig `yaml:"table_manager,omitempty"`
 	Encoding       encoding.Config          `yaml:"-"` // No yaml for this, it only works with flags.
-	TSDB           tsdb.Config              `yaml:"tsdb"`
+	TSDB           tsdb.Config              `yaml:"tsdb" doc:"hidden"`
 
 	Ruler         ruler.Config                               `yaml:"ruler,omitempty"`
 	ConfigDB      db.Config                                  `yaml:"configdb,omitempty"`
@@ -88,7 +88,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Server.MetricsNamespace = "cortex"
 	c.Target = All
 	c.Server.ExcludeRequestInLog = true
-	f.Var(&c.Target, "target", "target module (default All)")
+	f.Var(&c.Target, "target", "The Cortex service to run. Supported values are: all, distributor, ingester, querier, query-frontend, table-manager, ruler, alertmanager, configs.")
 	f.BoolVar(&c.AuthEnabled, "auth.enabled", true, "Set to false to disable auth.")
 	f.BoolVar(&c.PrintConfig, "print.config", false, "Print the config and exit.")
 	f.StringVar(&c.HTTPPrefix, "http.prefix", "/api/prom", "HTTP path prefix for Cortex API.")

--- a/pkg/distributor/distributor_ring.go
+++ b/pkg/distributor/distributor_ring.go
@@ -22,10 +22,10 @@ type RingConfig struct {
 	HeartbeatTimeout time.Duration `yaml:"heartbeat_timeout,omitempty"`
 
 	// Instance details
-	InstanceID             string   `yaml:"instance_id"`
-	InstanceInterfaceNames []string `yaml:"instance_interface_names"`
-	InstancePort           int      `yaml:"instance_port"`
-	InstanceAddr           string   `yaml:"instance_addr"`
+	InstanceID             string   `yaml:"instance_id" doc:"hidden"`
+	InstanceInterfaceNames []string `yaml:"instance_interface_names" doc:"hidden"`
+	InstancePort           int      `yaml:"instance_port" doc:"hidden"`
+	InstanceAddr           string   `yaml:"instance_addr" doc:"hidden"`
 
 	// Injected internally
 	ListenPort int `yaml:"-"`

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -110,7 +110,7 @@ func (cfg *HATrackerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.UpdateTimeoutJitterMax,
 		"distributor.ha-tracker.update-timeout-jitter-max",
 		5*time.Second,
-		"To spread the HA deduping heartbeats out over time.")
+		"Maximum jitter applied to the update timeout, in order to spread the HA heartbeats over time.")
 	f.DurationVar(&cfg.FailoverTimeout,
 		"distributor.ha-tracker.failover-timeout",
 		30*time.Second,

--- a/pkg/ingester/client/pool.go
+++ b/pkg/ingester/client/pool.go
@@ -32,7 +32,7 @@ type Factory func(addr string) (grpc_health_v1.HealthClient, error)
 type PoolConfig struct {
 	ClientCleanupPeriod  time.Duration `yaml:"client_cleanup_period,omitempty"`
 	HealthCheckIngesters bool          `yaml:"health_check_ingesters,omitempty"`
-	RemoteTimeout        time.Duration
+	RemoteTimeout        time.Duration `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -33,7 +33,7 @@ type Config struct {
 	DefaultEvaluationInterval time.Duration
 
 	// For testing, to prevent re-registration of metrics in the promql engine.
-	metricsRegisterer prometheus.Registerer
+	metricsRegisterer prometheus.Registerer `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.

--- a/pkg/ring/kv/client.go
+++ b/pkg/ring/kv/client.go
@@ -59,7 +59,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(flagsPrefix, defaultPrefix string, f 
 		flagsPrefix = "ring."
 	}
 	f.StringVar(&cfg.Prefix, flagsPrefix+"prefix", defaultPrefix, "The prefix for the keys in the store. Should end with a /.")
-	f.StringVar(&cfg.Store, flagsPrefix+"store", "consul", "Backend storage to use for the ring (consul, etcd, inmemory, multi, memberlist [experimental]).")
+	f.StringVar(&cfg.Store, flagsPrefix+"store", "consul", "Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, multi, memberlist (experimental).")
 }
 
 // Client is a high-level client for key-value stores (such as Etcd and

--- a/pkg/ring/kv/memberlist/memberlist_client.go
+++ b/pkg/ring/kv/memberlist/memberlist_client.go
@@ -50,14 +50,15 @@ type Config struct {
 	TCPTransport TCPTransportConfig `yaml:",inline"`
 
 	// Where to put custom metrics. Metrics are not registered, if this is nil.
-	MetricsRegisterer prometheus.Registerer
-	MetricsNamespace  string
+	MetricsRegisterer prometheus.Registerer `yaml:"-"`
+	MetricsNamespace  string                `yaml:"-"`
 }
 
 // RegisterFlags registers flags.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet, prefix string) {
 	// "Defaults to hostname" -- memberlist sets it to hostname by default.
 	f.StringVar(&cfg.NodeName, prefix+"memberlist.nodename", "", "Name of the node in memberlist cluster. Defaults to hostname.") // memberlist.DefaultLANConfig will put hostname here.
+	f.DurationVar(&cfg.StreamTimeout, prefix+"memberlist.stream-timeout", 0, "The timeout for establishing a connection with a remote node, and for read/write operations. Uses memberlist LAN defaults if 0.")
 	f.IntVar(&cfg.RetransmitMult, prefix+"memberlist.retransmit-factor", 0, "Multiplication factor used when sending out messages (factor * log(N+1)).")
 	f.Var(&cfg.JoinMembers, prefix+"memberlist.join", "Other cluster members to join. Can be specified multiple times. Memberlist store is EXPERIMENTAL.")
 	f.BoolVar(&cfg.AbortIfJoinFails, prefix+"memberlist.abort-if-join-fails", true, "If this node fails to join memberlist cluster, abort.")

--- a/pkg/ring/kv/memberlist/tcp_transport.go
+++ b/pkg/ring/kv/memberlist/tcp_transport.go
@@ -55,8 +55,8 @@ type TCPTransportConfig struct {
 	TransportDebug bool
 
 	// Where to put custom metrics. nil = don't register.
-	MetricsRegisterer prometheus.Registerer
-	MetricsNamespace  string
+	MetricsRegisterer prometheus.Registerer `yaml:"-"`
+	MetricsNamespace  string                `yaml:"-"`
 }
 
 // RegisterFlags registers flags.

--- a/pkg/ring/kv/memberlist/tcp_transport.go
+++ b/pkg/ring/kv/memberlist/tcp_transport.go
@@ -49,10 +49,10 @@ type TCPTransportConfig struct {
 
 	// WriteTo is used to send "UDP" packets. Since we use TCP, we can detect more errors,
 	// but memberlist doesn't seem to cope with that very well.
-	ReportWriteToErrors bool
+	ReportWriteToErrors bool `yaml:"-"`
 
 	// Transport logs lot of messages at debug level, so it deserves an extra flag for turning it on
-	TransportDebug bool
+	TransportDebug bool `yaml:"-"`
 
 	// Where to put custom metrics. nil = don't register.
 	MetricsRegisterer prometheus.Registerer `yaml:"-"`

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -43,7 +43,7 @@ type LifecyclerConfig struct {
 	RingConfig Config `yaml:"ring,omitempty"`
 
 	// Config for the ingester lifecycle control
-	ListenPort       *int
+	ListenPort       *int          `yaml:"-"`
 	NumTokens        int           `yaml:"num_tokens,omitempty"`
 	HeartbeatPeriod  time.Duration `yaml:"heartbeat_period,omitempty"`
 	ObservePeriod    time.Duration `yaml:"observe_period,omitempty"`
@@ -54,10 +54,10 @@ type LifecyclerConfig struct {
 	TokensFilePath   string        `yaml:"tokens_file_path,omitempty"`
 
 	// For testing, you can override the address and ID of this ingester
-	Addr           string `yaml:"address"`
-	Port           int
-	ID             string
-	SkipUnregister bool
+	Addr           string `yaml:"address" doc:"hidden"`
+	Port           int    `doc:"hidden"`
+	ID             string `doc:"hidden"`
+	SkipUnregister bool   `yaml:"-"`
 
 	// graveyard for unused flags.
 	UnusedFlag  bool `yaml:"claim_on_rollout,omitempty"` // DEPRECATED - left for backwards-compatibility

--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -224,7 +224,7 @@ func main() {
 	// Parse the config, mapping each config field with the related CLI flag.
 	blocks, err := parseConfig(nil, cfg, flags)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, fmt.Sprintf("An error occurred while generating the doc: %s\n", err.Error()))
+		fmt.Fprintf(os.Stderr, "An error occurred while generating the doc: %s\n", err.Error())
 		os.Exit(1)
 	}
 

--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/cortexproject/cortex/pkg/alertmanager"
+	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/chunk/cache"
+	"github.com/cortexproject/cortex/pkg/chunk/storage"
+	config_client "github.com/cortexproject/cortex/pkg/configs/client"
+	"github.com/cortexproject/cortex/pkg/configs/db"
+	"github.com/cortexproject/cortex/pkg/cortex"
+	"github.com/cortexproject/cortex/pkg/distributor"
+	"github.com/cortexproject/cortex/pkg/ingester"
+	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/cortexproject/cortex/pkg/querier"
+	"github.com/cortexproject/cortex/pkg/querier/frontend"
+	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
+	"github.com/cortexproject/cortex/pkg/ring/kv/etcd"
+	"github.com/cortexproject/cortex/pkg/ring/kv/memberlist"
+	"github.com/cortexproject/cortex/pkg/ruler"
+	"github.com/cortexproject/cortex/pkg/util/validation"
+	"github.com/weaveworks/common/server"
+)
+
+const (
+	maxLineWidth = 80
+	tabWidth     = 2
+)
+
+var (
+	// Ordered list of root blocks. The order is the same order that will
+	// follow the markdown generation.
+	rootBlocks = []rootBlock{
+		{
+			name:       "server_config",
+			structType: reflect.TypeOf(server.Config{}),
+			desc:       "The server_config configures the HTTP and gRPC server of the launched service(s).",
+		},
+		{
+			name:       "distributor_config",
+			structType: reflect.TypeOf(distributor.Config{}),
+			desc:       "The distributor_config configures the Cortex distributor.",
+		},
+		{
+			name:       "ingester_config",
+			structType: reflect.TypeOf(ingester.Config{}),
+			desc:       "The ingester_config configures the Cortex ingester.",
+		},
+		{
+			name:       "querier_config",
+			structType: reflect.TypeOf(querier.Config{}),
+			desc:       "The querier_config configures the Cortex querier.",
+		},
+		{
+			name:       "query_frontend_config",
+			structType: reflect.TypeOf(frontend.Config{}),
+			desc:       "The query_frontend_config configures the Cortex query-frontend.",
+		},
+		{
+			name:       "queryrange_config",
+			structType: reflect.TypeOf(queryrange.Config{}),
+			desc:       "The queryrange_config configures the query splitting and caching in the Cortex query-frontend.",
+		},
+		{
+			name:       "ruler_config",
+			structType: reflect.TypeOf(ruler.Config{}),
+			desc:       "The ruler_config configures the Cortex ruler.",
+		},
+		{
+			name:       "alertmanager_config",
+			structType: reflect.TypeOf(alertmanager.MultitenantAlertmanagerConfig{}),
+			desc:       "The alertmanager_config configures the Cortex alertmanager.",
+		},
+		{
+			name:       "table_manager_config",
+			structType: reflect.TypeOf(chunk.TableManagerConfig{}),
+			desc:       "The table_manager_config configures the Cortex table-manager.",
+		},
+		{
+			name:       "storage_config",
+			structType: reflect.TypeOf(storage.Config{}),
+			desc:       "The storage_config configures where Cortex stores the data (chunks storage engine).",
+		},
+		{
+			name:       "chunk_store_config",
+			structType: reflect.TypeOf(chunk.StoreConfig{}),
+			desc:       "The chunk_store_config configures how Cortex stores the data (chunks storage engine).",
+		},
+		{
+			name:       "ingester_client_config",
+			structType: reflect.TypeOf(client.Config{}),
+			desc:       "The ingester_client_config configures how the Cortex distributors connect to the ingesters.",
+		},
+		{
+			name:       "frontend_worker_config",
+			structType: reflect.TypeOf(frontend.WorkerConfig{}),
+			desc:       "The frontend_worker_config configures the worker - running within the Cortex ingester - picking up and executing queries enqueued by the query-frontend.",
+		},
+		{
+			name:       "etcd_config",
+			structType: reflect.TypeOf(etcd.Config{}),
+			desc:       "The etcd_config configures the etcd client.",
+		},
+		{
+			name:       "consul_config",
+			structType: reflect.TypeOf(consul.Config{}),
+			desc:       "The consul_config configures the consul client.",
+		},
+		{
+			name:       "memberlist_config",
+			structType: reflect.TypeOf(memberlist.Config{}),
+			desc:       "The memberlist_config configures the Gossip memberlist.",
+		},
+		{
+			name:       "limits_config",
+			structType: reflect.TypeOf(validation.Limits{}),
+			desc:       "The limits_config configures default and per-tenant limits imposed by Cortex services (ie. distributor, ingester, ...).",
+		},
+		{
+			name:       "redis_config",
+			structType: reflect.TypeOf(cache.RedisConfig{}),
+			desc:       "The redis_config configures the Redis backend cache.",
+		},
+		{
+			name:       "memcached_config",
+			structType: reflect.TypeOf(cache.MemcachedConfig{}),
+			desc:       "The memcached_config block configures how data is stored in Memcached (ie. expiration).",
+		},
+		{
+			name:       "memcached_client_config",
+			structType: reflect.TypeOf(cache.MemcachedClientConfig{}),
+			desc:       "The memcached_client_config configures the client used to connect to Memcached.",
+		},
+		{
+			name:       "fifo_cache_config",
+			structType: reflect.TypeOf(cache.FifoCacheConfig{}),
+			desc:       "The fifo_cache_config configures the local in-memory cache.",
+		},
+		{
+			name:       "configdb_config",
+			structType: reflect.TypeOf(db.Config{}),
+			desc:       "The configdb_config configures the config database storing rules and alerts, and used by the 'configs' service to expose APIs to manage them.",
+		},
+		{
+			name:       "configstore_config",
+			structType: reflect.TypeOf(config_client.Config{}),
+			desc:       "The configstore_config configures the config database storing rules and alerts, and is used by the Cortex alertmanager.",
+		},
+	}
+)
+
+func removeFlagPrefix(block *configBlock, prefix string) {
+	for _, entry := range block.entries {
+		switch entry.kind {
+		case "block":
+			// Skip root blocks
+			if !entry.root {
+				removeFlagPrefix(entry.block, prefix)
+			}
+		case "field":
+			if strings.HasPrefix(entry.fieldFlag, prefix) {
+				entry.fieldFlag = "<prefix>" + entry.fieldFlag[len(prefix):]
+			}
+		}
+	}
+}
+
+func annotateFlagPrefix(blocks []*configBlock) {
+	// Find duplicated blocks
+	groups := map[string][]*configBlock{}
+	for _, block := range blocks {
+		groups[block.name] = append(groups[block.name], block)
+	}
+
+	// For each duplicated block, we need to fix the CLI flags, because
+	// in the documentation each block will be displayed only once but
+	// since they're duplicated they will have a different CLI flag
+	// prefix, which we want to correctly document.
+	for _, group := range groups {
+		if len(group) == 1 {
+			continue
+		}
+
+		// We need to find the CLI flags prefix of each config block. To do it,
+		// we pick the first entry from each config block and then find the
+		// different prefix across all of them.
+		flags := []string{}
+		for _, block := range group {
+			for _, entry := range block.entries {
+				if entry.kind == "field" {
+					flags = append(flags, entry.fieldFlag)
+					break
+				}
+			}
+		}
+
+		for i, prefix := range findFlagsPrefix(flags) {
+			group[i].flagsPrefix = prefix
+		}
+	}
+
+	// Finally, we can remove the CLI flags prefix from the blocks
+	// which have one annotated.
+	for _, block := range blocks {
+		if block.flagsPrefix != "" {
+			removeFlagPrefix(block, block.flagsPrefix)
+		}
+	}
+}
+
+func main() {
+	cfg := &cortex.Config{}
+
+	// In order to match YAML config fields with CLI flags, we do map
+	// the memory address of the CLI flag variables and match them with
+	// the config struct fields address.
+	flags := parseFlags(cfg)
+
+	// Parse the config, mapping each config field with the related CLI flag.
+	blocks, err := parseConfig(nil, cfg, flags)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, fmt.Sprintf("An error occurred while generating the doc: %s\n", err.Error()))
+		os.Exit(1)
+	}
+
+	// Annotate the flags prefix for each root block, and remove the
+	// prefix wherever encountered in the config blocks.
+	annotateFlagPrefix(blocks)
+
+	// Generate markdown
+	md := &markdownWriter{}
+	md.writeConfigDoc(blocks)
+	fmt.Println(md.string())
+}

--- a/tools/doc-generator/parser.go
+++ b/tools/doc-generator/parser.go
@@ -236,6 +236,8 @@ func getFieldType(t reflect.Type) (string, error) {
 		return "url", nil
 	case "time.Duration":
 		return "duration", nil
+	case "cortex.moduleName":
+		return "string", nil
 	}
 
 	// Fallback to auto-detection of built-in data types

--- a/tools/doc-generator/parser.go
+++ b/tools/doc-generator/parser.go
@@ -177,10 +177,7 @@ func parseConfig(block *configBlock, cfg interface{}, flags map[uintptr]*flag.Fl
 				return nil, err
 			}
 
-			for _, otherBlock := range otherBlocks {
-				blocks = append(blocks, otherBlock)
-			}
-
+			blocks = append(blocks, otherBlocks...)
 			continue
 		}
 

--- a/tools/doc-generator/parser.go
+++ b/tools/doc-generator/parser.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/pkg/errors"
+	"github.com/weaveworks/common/logging"
+)
+
+var (
+	yamlFieldNameParser = regexp.MustCompile("^[^,]+")
+)
+
+type configBlock struct {
+	name        string
+	desc        string
+	entries     []*configEntry
+	flagsPrefix string
+}
+
+func (b *configBlock) Add(entry *configEntry) {
+	b.entries = append(b.entries, entry)
+}
+
+type configEntry struct {
+	kind     string
+	name     string
+	required bool
+
+	// In case the kind is "block"
+	block     *configBlock
+	blockDesc string
+	root      bool
+
+	// In case the kind is "field"
+	fieldFlag    string
+	fieldDesc    string
+	fieldType    string
+	fieldDefault string
+}
+
+type rootBlock struct {
+	name       string
+	desc       string
+	structType reflect.Type
+}
+
+func parseFlags(cfg flagext.Registerer) map[uintptr]*flag.Flag {
+	fs := flag.NewFlagSet("", flag.PanicOnError)
+	cfg.RegisterFlags(fs)
+
+	flags := map[uintptr]*flag.Flag{}
+	fs.VisitAll(func(f *flag.Flag) {
+		// Skip deprecated flags
+		if f.Value.String() == "deprecated" {
+			return
+		}
+
+		ptr := reflect.ValueOf(f.Value).Pointer()
+		flags[ptr] = f
+	})
+
+	return flags
+}
+
+func parseConfig(block *configBlock, cfg interface{}, flags map[uintptr]*flag.Flag) ([]*configBlock, error) {
+	blocks := []*configBlock{}
+
+	// If the input block is nil it means we're generating the doc for the top-level block
+	if block == nil {
+		block = &configBlock{}
+		blocks = append(blocks, block)
+	}
+
+	// The input config is expected to be addressable.
+	if reflect.TypeOf(cfg).Kind() != reflect.Ptr {
+		t := reflect.TypeOf(cfg)
+		return nil, fmt.Errorf("%s is a %s while a %s is expected", t, t.Kind(), reflect.Ptr)
+	}
+
+	// The input config is expected to be a pointer to struct.
+	v := reflect.ValueOf(cfg).Elem()
+	t := v.Type()
+
+	if v.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("%s is a %s while a %s is expected", v, v.Kind(), reflect.Struct)
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		fieldValue := v.FieldByIndex(field.Index)
+
+		// Skip fields explicitly marked as "hidden" in the doc
+		if isFieldHidden(field) {
+			continue
+		}
+
+		// Skip fields not exported via yaml
+		fieldName := getFieldName(field)
+		if fieldName == "" {
+			continue
+		}
+
+		// Skip field types which are non configurable
+		if field.Type.Kind() == reflect.Func {
+			continue
+		}
+
+		// Skip deprecated fields we're still keeping for backward compatibility
+		// reasons (by convention we prefix them by UnusedFlag)
+		if strings.HasPrefix(field.Name, "UnusedFlag") {
+			continue
+		}
+
+		// Handle custom fields in vendored libs upon which we have no control.
+		fieldEntry, err := getCustomFieldEntry(field, fieldValue, flags)
+		if err != nil {
+			return nil, err
+		}
+		if fieldEntry != nil {
+			block.Add(fieldEntry)
+			continue
+		}
+
+		// Recursively re-iterate if it's a struct
+		if field.Type.Kind() == reflect.Struct {
+			// Check whether the sub-block is a root config block
+			rootName, rootDesc, isRoot := isRootBlock(field.Type)
+
+			// Since we're going to recursively iterate, we need to create a new sub
+			// block and pass it to the doc generation function.
+			var blockName string
+			var blockDesc string
+
+			if isRoot {
+				blockName = rootName
+				blockDesc = rootDesc
+			} else {
+				blockName = fieldName
+				blockDesc = ""
+			}
+
+			subBlock := &configBlock{
+				name: blockName,
+				desc: blockDesc,
+			}
+
+			block.Add(&configEntry{
+				kind:      "block",
+				name:      fieldName,
+				required:  isFieldRequired(field),
+				block:     subBlock,
+				blockDesc: blockDesc,
+				root:      isRoot,
+			})
+
+			if isRoot {
+				blocks = append(blocks, subBlock)
+			}
+
+			// Recursively generate the doc for the sub-block
+			otherBlocks, err := parseConfig(subBlock, fieldValue.Addr().Interface(), flags)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, otherBlock := range otherBlocks {
+				blocks = append(blocks, otherBlock)
+			}
+
+			continue
+		}
+
+		fieldType, err := getFieldType(field.Type)
+		if err != nil {
+			return nil, errors.Wrapf(err, "config=%s.%s", t.PkgPath(), t.Name())
+		}
+
+		fieldFlag, err := getFieldFlag(field, fieldValue, flags)
+		if err != nil {
+			return nil, errors.Wrapf(err, "config=%s.%s", t.PkgPath(), t.Name())
+		}
+
+		block.Add(&configEntry{
+			kind:         "field",
+			name:         fieldName,
+			required:     isFieldRequired(field),
+			fieldFlag:    fieldFlag.Name,
+			fieldDesc:    fieldFlag.Usage,
+			fieldType:    fieldType,
+			fieldDefault: fieldFlag.DefValue,
+		})
+	}
+
+	return blocks, nil
+}
+
+func getFieldName(field reflect.StructField) string {
+	name := field.Name
+	tag := field.Tag.Get("yaml")
+
+	// If the tag is not specified, then an exported field can be
+	// configured via the field name (lowercase), while an unexported
+	// field can't be configured.
+	if tag == "" {
+		if unicode.IsLower(rune(name[0])) {
+			return ""
+		}
+
+		return strings.ToLower(name)
+	}
+
+	// Parse the field name
+	fieldName := yamlFieldNameParser.FindString(tag)
+	if fieldName == "-" {
+		return ""
+	}
+
+	return fieldName
+}
+
+func getFieldType(t reflect.Type) (string, error) {
+	// Handle custom data types used in the config
+	switch t.String() {
+	case "*url.URL":
+		return "url", nil
+	case "time.Duration":
+		return "duration", nil
+	}
+
+	// Fallback to auto-detection of built-in data types
+	switch t.Kind() {
+	case reflect.Bool:
+		return "boolean", nil
+
+	case reflect.Int:
+		fallthrough
+	case reflect.Int8:
+		fallthrough
+	case reflect.Int16:
+		fallthrough
+	case reflect.Int32:
+		fallthrough
+	case reflect.Int64:
+		fallthrough
+	case reflect.Uint:
+		fallthrough
+	case reflect.Uint8:
+		fallthrough
+	case reflect.Uint16:
+		fallthrough
+	case reflect.Uint32:
+		fallthrough
+	case reflect.Uint64:
+		return "int", nil
+
+	case reflect.Float32:
+		fallthrough
+	case reflect.Float64:
+		return "float", nil
+
+	case reflect.String:
+		return "string", nil
+
+	case reflect.Slice:
+		// Get the type of elements
+		elemType, err := getFieldType(t.Elem())
+		if err != nil {
+			return "", err
+		}
+
+		return "list of " + elemType, nil
+
+	default:
+		return "", fmt.Errorf("unsupported data type %s", t.Kind())
+	}
+}
+
+func getFieldFlag(field reflect.StructField, fieldValue reflect.Value, flags map[uintptr]*flag.Flag) (*flag.Flag, error) {
+	fieldPtr := fieldValue.Addr().Pointer()
+	fieldFlag, ok := flags[fieldPtr]
+	if !ok {
+		return nil, fmt.Errorf("unable to find CLI flag for '%s' config entry", field.Name)
+	}
+
+	return fieldFlag, nil
+}
+
+func getCustomFieldEntry(field reflect.StructField, fieldValue reflect.Value, flags map[uintptr]*flag.Flag) (*configEntry, error) {
+	if field.Type == reflect.TypeOf(logging.Level{}) {
+		fieldFlag, err := getFieldFlag(field, fieldValue, flags)
+		if err != nil {
+			return nil, err
+		}
+
+		return &configEntry{
+			kind:         "field",
+			name:         getFieldName(field),
+			required:     isFieldRequired(field),
+			fieldFlag:    fieldFlag.Name,
+			fieldDesc:    fieldFlag.Usage,
+			fieldType:    "string",
+			fieldDefault: fieldFlag.DefValue,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func isFieldHidden(f reflect.StructField) bool {
+	return strings.Contains(f.Tag.Get("doc"), "hidden")
+}
+
+func isFieldRequired(f reflect.StructField) bool {
+	return strings.Contains(f.Tag.Get("doc"), "required")
+}
+
+func isRootBlock(t reflect.Type) (string, string, bool) {
+	for _, rootBlock := range rootBlocks {
+		if t == rootBlock.structType {
+			return rootBlock.name, rootBlock.desc, true
+		}
+	}
+
+	return "", "", false
+}

--- a/tools/doc-generator/util.go
+++ b/tools/doc-generator/util.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"math"
+	"strings"
+)
+
+func findFlagsPrefix(flags []string) []string {
+	if len(flags) == 0 {
+		return flags
+	}
+
+	// Split the input flags input tokens separated by "."
+	// because the want to find the prefix where segments
+	// are dot-separated.
+	tokens := [][]string{}
+	for _, flag := range flags {
+		tokens = append(tokens, strings.Split(flag, "."))
+	}
+
+	// Find the shortest tokens.
+	minLength := math.MaxInt32
+	for _, t := range tokens {
+		if len(t) < minLength {
+			minLength = len(t)
+		}
+	}
+
+	// We iterate backward to find common suffixes. Each time
+	// a common suffix is found, we remove it from the tokens.
+outer:
+	for i := 0; i < minLength; i++ {
+		lastToken := tokens[0][len(tokens[0])-1]
+
+		// Interrupt if the last token is different across the flags.
+		for _, t := range tokens {
+			if t[len(t)-1] != lastToken {
+				break outer
+			}
+		}
+
+		// The suffix token is equal across all flags, so we
+		// remove it from all of them and re-iterate.
+		for i, t := range tokens {
+			tokens[i] = t[:len(t)-1]
+		}
+	}
+
+	// The remaining tokens are the different flags prefix, which we can
+	// now merge with the ".".
+	prefixes := []string{}
+	for _, t := range tokens {
+		prefixes = append(prefixes, strings.Join(t, "."))
+	}
+
+	return prefixes
+}

--- a/tools/doc-generator/util_test.go
+++ b/tools/doc-generator/util_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_findFlagsPrefix(t *testing.T) {
+	tests := []struct {
+		input    []string
+		expected []string
+	}{
+		{
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			input:    []string{""},
+			expected: []string{""},
+		},
+		{
+			input:    []string{"", ""},
+			expected: []string{"", ""},
+		},
+		{
+			input:    []string{"foo", "foo", "foo"},
+			expected: []string{"", "", ""},
+		},
+		{
+			input:    []string{"ruler.endpoint", "alertmanager.endpoint"},
+			expected: []string{"ruler", "alertmanager"},
+		},
+		{
+			input:    []string{"ruler.endpoint.address", "alertmanager.endpoint.address"},
+			expected: []string{"ruler", "alertmanager"},
+		},
+		{
+			input:    []string{"ruler.first.address", "ruler.second.address"},
+			expected: []string{"ruler.first", "ruler.second"},
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expected, findFlagsPrefix(test.input))
+	}
+}

--- a/tools/doc-generator/writer.go
+++ b/tools/doc-generator/writer.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	wordwrap "github.com/mitchellh/go-wordwrap"
+)
+
+type specWriter struct {
+	out strings.Builder
+}
+
+func (w *specWriter) writeConfigBlock(b *configBlock, indent int) {
+	if len(b.entries) == 0 {
+		return
+	}
+
+	for i, entry := range b.entries {
+		// Add a new line to separate from the previous entry
+		if i > 0 {
+			w.out.WriteString("\n")
+		}
+
+		w.writeConfigEntry(entry, indent)
+	}
+}
+
+func (w *specWriter) writeConfigEntry(e *configEntry, indent int) {
+	if e.kind == "block" {
+		// If the block is a root block it will have its dedicated section in the doc,
+		// so here we've just to write down the reference without re-iterating on it.
+		if e.root {
+			// Description
+			w.writeComment(e.blockDesc, indent)
+			if e.block.flagsPrefix != "" {
+				w.writeComment(fmt.Sprintf("The CLI flags prefix for this block config is: %s", e.block.flagsPrefix), indent)
+			}
+
+			// Block reference without entries, because it's a root block
+			w.out.WriteString(pad(indent) + "[" + e.name + ": <" + e.block.name + ">]\n")
+		} else {
+			// Description
+			w.writeComment(e.blockDesc, indent)
+
+			// Name
+			w.out.WriteString(pad(indent) + e.name + ":\n")
+
+			// Entries
+			w.writeConfigBlock(e.block, indent+tabWidth)
+		}
+	}
+
+	if e.kind == "field" {
+		// Description
+		w.writeComment(e.fieldDesc, indent)
+		w.writeFlag(e.fieldFlag, indent)
+
+		// Specification
+		fieldDefault := e.fieldDefault
+		if e.fieldType == "string" {
+			fieldDefault = strconv.Quote(fieldDefault)
+		}
+
+		if e.required {
+			w.out.WriteString(pad(indent) + e.name + ": <" + e.fieldType + "> | default = " + fieldDefault + "\n")
+		} else {
+			w.out.WriteString(pad(indent) + "[" + e.name + ": <" + e.fieldType + "> | default = " + fieldDefault + "]\n")
+		}
+	}
+}
+
+func (w *specWriter) writeFlag(name string, indent int) {
+	if name == "" {
+		return
+	}
+
+	w.out.WriteString(pad(indent) + "# CLI flag: -" + name + "\n")
+}
+
+func (w *specWriter) writeComment(comment string, indent int) {
+	if comment == "" {
+		return
+	}
+
+	wrapped := strings.TrimSpace(wordwrap.WrapString(comment, uint(maxLineWidth-indent-2)))
+	lines := strings.Split(wrapped, "\n")
+
+	for _, line := range lines {
+		w.out.WriteString(pad(indent) + "# " + line + "\n")
+	}
+}
+
+func (w *specWriter) string() string {
+	return strings.TrimSpace(w.out.String())
+}
+
+type markdownWriter struct {
+	out strings.Builder
+}
+
+func (w *markdownWriter) writeConfigDoc(blocks []*configBlock) {
+	// Deduplicate root blocks.
+	uniqueBlocks := map[string]*configBlock{}
+	for _, block := range blocks {
+		uniqueBlocks[block.name] = block
+	}
+
+	// Generate the markdown, honoring the root blocks order.
+	if topBlock, ok := uniqueBlocks[""]; ok {
+		w.writeConfigBlock(topBlock)
+	}
+
+	for _, rootBlock := range rootBlocks {
+		if block, ok := uniqueBlocks[rootBlock.name]; ok {
+			w.writeConfigBlock(block)
+		}
+	}
+}
+
+func (w *markdownWriter) writeConfigBlock(block *configBlock) {
+	// Title
+	if block.name != "" {
+		w.out.WriteString("## `" + block.name + "`\n")
+		w.out.WriteString("\n")
+	}
+
+	// Description
+	if block.desc != "" {
+		desc := block.desc
+
+		// Wrap the config block name with backticks
+		if block.name != "" {
+			desc = regexp.MustCompile(regexp.QuoteMeta(block.name)).ReplaceAllStringFunc(desc, func(input string) string {
+				return "`" + input + "`"
+			})
+		}
+
+		w.out.WriteString(desc + "\n")
+		w.out.WriteString("\n")
+	}
+
+	// Config specs
+	spec := &specWriter{}
+	spec.writeConfigBlock(block, 0)
+
+	w.out.WriteString("```yaml\n")
+	w.out.WriteString(spec.string() + "\n")
+	w.out.WriteString("```\n")
+	w.out.WriteString("\n")
+}
+
+func (w *markdownWriter) string() string {
+	return strings.TrimSpace(w.out.String())
+}
+
+func pad(length int) string {
+	return strings.Repeat(" ", length)
+}

--- a/vendor/github.com/mitchellh/go-wordwrap/LICENSE.md
+++ b/vendor/github.com/mitchellh/go-wordwrap/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/go-wordwrap/README.md
+++ b/vendor/github.com/mitchellh/go-wordwrap/README.md
@@ -1,0 +1,39 @@
+# go-wordwrap
+
+`go-wordwrap` (Golang package: `wordwrap`) is a package for Go that
+automatically wraps words into multiple lines. The primary use case for this
+is in formatting CLI output, but of course word wrapping is a generally useful
+thing to do.
+
+## Installation and Usage
+
+Install using `go get github.com/mitchellh/go-wordwrap`.
+
+Full documentation is available at
+http://godoc.org/github.com/mitchellh/go-wordwrap
+
+Below is an example of its usage ignoring errors:
+
+```go
+wrapped := wordwrap.WrapString("foo bar baz", 3)
+fmt.Println(wrapped)
+```
+
+Would output:
+
+```
+foo
+bar
+baz
+```
+
+## Word Wrap Algorithm
+
+This library doesn't use any clever algorithm for word wrapping. The wrapping
+is actually very naive: whenever there is whitespace or an explicit linebreak.
+The goal of this library is for word wrapping CLI output, so the input is
+typically pretty well controlled human language. Because of this, the naive
+approach typically works just fine.
+
+In the future, we'd like to make the algorithm more advanced. We would do
+so without breaking the API.

--- a/vendor/github.com/mitchellh/go-wordwrap/go.mod
+++ b/vendor/github.com/mitchellh/go-wordwrap/go.mod
@@ -1,0 +1,1 @@
+module github.com/mitchellh/go-wordwrap

--- a/vendor/github.com/mitchellh/go-wordwrap/wordwrap.go
+++ b/vendor/github.com/mitchellh/go-wordwrap/wordwrap.go
@@ -1,0 +1,73 @@
+package wordwrap
+
+import (
+	"bytes"
+	"unicode"
+)
+
+// WrapString wraps the given string within lim width in characters.
+//
+// Wrapping is currently naive and only happens at white-space. A future
+// version of the library will implement smarter wrapping. This means that
+// pathological cases can dramatically reach past the limit, such as a very
+// long word.
+func WrapString(s string, lim uint) string {
+	// Initialize a buffer with a slightly larger size to account for breaks
+	init := make([]byte, 0, len(s))
+	buf := bytes.NewBuffer(init)
+
+	var current uint
+	var wordBuf, spaceBuf bytes.Buffer
+
+	for _, char := range s {
+		if char == '\n' {
+			if wordBuf.Len() == 0 {
+				if current+uint(spaceBuf.Len()) > lim {
+					current = 0
+				} else {
+					current += uint(spaceBuf.Len())
+					spaceBuf.WriteTo(buf)
+				}
+				spaceBuf.Reset()
+			} else {
+				current += uint(spaceBuf.Len() + wordBuf.Len())
+				spaceBuf.WriteTo(buf)
+				spaceBuf.Reset()
+				wordBuf.WriteTo(buf)
+				wordBuf.Reset()
+			}
+			buf.WriteRune(char)
+			current = 0
+		} else if unicode.IsSpace(char) {
+			if spaceBuf.Len() == 0 || wordBuf.Len() > 0 {
+				current += uint(spaceBuf.Len() + wordBuf.Len())
+				spaceBuf.WriteTo(buf)
+				spaceBuf.Reset()
+				wordBuf.WriteTo(buf)
+				wordBuf.Reset()
+			}
+
+			spaceBuf.WriteRune(char)
+		} else {
+
+			wordBuf.WriteRune(char)
+
+			if current+uint(spaceBuf.Len()+wordBuf.Len()) > lim && uint(wordBuf.Len()) < lim {
+				buf.WriteRune('\n')
+				current = 0
+				spaceBuf.Reset()
+			}
+		}
+	}
+
+	if wordBuf.Len() == 0 {
+		if current+uint(spaceBuf.Len()) <= lim {
+			spaceBuf.WriteTo(buf)
+		}
+	} else {
+		spaceBuf.WriteTo(buf)
+		wordBuf.WriteTo(buf)
+	}
+
+	return buf.String()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -339,6 +339,8 @@ github.com/minio/minio-go/v6/pkg/set
 github.com/minio/sha256-simd
 # github.com/mitchellh/go-homedir v1.1.0
 github.com/mitchellh/go-homedir
+# github.com/mitchellh/go-wordwrap v1.0.0
+github.com/mitchellh/go-wordwrap
 # github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd


### PR DESCRIPTION
**What this PR does**:
Last Friday, I started to manually document the YAML config file and I suddenly realized that:
1. It's huge
2. Even if we pay the effort to manually write the doc, it will be very difficult to keep it updated PR-by-PR

So I've tried a different approach: automatically generate it navigating through the entire config using the Go reflection. In order to do it, I mix both the YAML tags in the config structs and the registered CLI flags. The CLI flags are particularly important because they carry the description of each entry in the config.

This is the result of this work. In particular:
- `make doc` generates the config file reference doc. It's intended to be manually run by a contributor whenever he/she changes the config / CLI flags. In this PR the generated doc is at `docs/configuration/config-file-reference.md`.
- `make check-doc` ensure consistency in the config file reference doc. It's intended to be run in CI as part of the linting process.

Out of the scope of this PR (but welcome in subsequent PRs):
- Significantly improve the quality of CLI flags usage (which is now the config entry description)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
