### PR TITLE
Website: fix Twitter / Facebook link image

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -65,7 +65,7 @@ weight = 1
 [params]
 
 # First one is picked as the Twitter card image if not set on page.
-# images = ["images/project-illustration.png"]
+images = ["https://cncf-branding.netlify.com/img/projects/cortex/horizontal/color/cortex-horizontal-color.png"]
 
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [params.versions] set.


### PR DESCRIPTION
**What this PR does**:
I shared a link on Twitter and I've realized there's no image in the Twitter Card (see below). This PR fixes it, displaying the Cortex logo.

![Screen Shot 2020-01-07 at 15 32 22](https://user-images.githubusercontent.com/1701904/71902717-ebbfe800-3162-11ea-82e7-61a5fc1c9c48.png)


**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
