### PR TITLE
Added user ID to ingester push soft/hard errors

### DIFF
--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/weaveworks/common/httpgrpc"
 )
@@ -49,6 +50,11 @@ func makeMetricLimitError(errorType string, labels labels.Labels, err error) err
 	}
 }
 
+func (e *validationError) WrapWithUser(userID string) *validationError {
+	e.err = wrapWithUser(e.err, userID)
+	return e
+}
+
 func (e *validationError) Error() string {
 	if e.err == nil {
 		return e.errorType
@@ -65,4 +71,8 @@ func (e *validationError) WrappedError() error {
 		Code: int32(e.code),
 		Body: []byte(e.Error()),
 	})
+}
+
+func wrapWithUser(err error, userID string) error {
+	return errors.Wrapf(err, "user=%s", userID)
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -308,13 +308,13 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 				continue
 			}
 
-			return nil, err
+			return nil, wrapWithUser(err, userID)
 		}
 	}
 	client.ReuseSlice(req.Timeseries)
 
 	if lastPartialErr != nil {
-		return &client.WriteResponse{}, lastPartialErr.WrappedError()
+		return &client.WriteResponse{}, lastPartialErr.WrapWithUser(userID).WrappedError()
 	}
 	return &client.WriteResponse{}, nil
 }

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -89,7 +89,7 @@ func (i *Ingester) v2Push(ctx old_ctx.Context, req *client.WriteRequest) (*clien
 
 	db, err := i.getOrCreateTSDB(userID, false)
 	if err != nil {
-		return nil, err
+		return nil, wrapWithUser(err, userID)
 	}
 
 	// Ensure the ingester shutdown procedure hasn't started
@@ -141,14 +141,14 @@ func (i *Ingester) v2Push(ctx old_ctx.Context, req *client.WriteRequest) (*clien
 
 			// The error looks an issue on our side, so we should rollback
 			if rollbackErr := app.Rollback(); rollbackErr != nil {
-				level.Warn(util.Logger).Log("msg", "failed to rollback on error", "userID", userID, "err", rollbackErr)
+				level.Warn(util.Logger).Log("msg", "failed to rollback on error", "user", userID, "err", rollbackErr)
 			}
 
-			return nil, err
+			return nil, wrapWithUser(err, userID)
 		}
 	}
 	if err := app.Commit(); err != nil {
-		return nil, err
+		return nil, wrapWithUser(err, userID)
 	}
 
 	// Increment metrics only if the samples have been successfully committed.
@@ -160,7 +160,7 @@ func (i *Ingester) v2Push(ctx old_ctx.Context, req *client.WriteRequest) (*clien
 	client.ReuseSlice(req.Timeseries)
 
 	if lastPartialErr != nil {
-		return &client.WriteResponse{}, httpgrpc.Errorf(http.StatusBadRequest, lastPartialErr.Error())
+		return &client.WriteResponse{}, httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(lastPartialErr, userID).Error())
 	}
 	return &client.WriteResponse{}, nil
 }


### PR DESCRIPTION
**What this PR does**:
Today I was investigating the cause of the error `sample with repeated timestamp but different value for series` and I couldn't find the related user because it's not logged. In this PR, I'm suggesting to wrap any ingester Push error with the user ID.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
