### PR TITLE
Revert "pkg/distributor: shardByAllLabels didn't check for label names order correctly"

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -250,11 +250,10 @@ func shardByAllLabels(userID string, labels []client.LabelAdapter) (uint32, erro
 	var lastLabelName string
 	for _, label := range labels {
 		if strings.Compare(lastLabelName, label.Name) >= 0 {
-			return 0, fmt.Errorf("labels not sorted")
+			return 0, fmt.Errorf("Labels not sorted")
 		}
 		h = client.HashAdd32(h, label.Name)
 		h = client.HashAdd32(h, label.Value)
-		lastLabelName = label.Name
 	}
 	return h, nil
 }

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -434,13 +434,13 @@ func TestDistributor_Push_LabelRemoval(t *testing.T) {
 		{ // Don't remove any labels.
 			inputSeries: labels.Labels{
 				{Name: "__name__", Value: "some_metric"},
-				{Name: "__replica__", Value: "two"},
 				{Name: "cluster", Value: "one"},
+				{Name: "__replica__", Value: "two"},
 			},
 			expectedSeries: labels.Labels{
 				{Name: "__name__", Value: "some_metric"},
-				{Name: "__replica__", Value: "two"},
 				{Name: "cluster", Value: "one"},
+				{Name: "__replica__", Value: "two"},
 			},
 			removeReplica: false,
 		},
@@ -484,43 +484,43 @@ func TestDistributor_Push_ShouldGuaranteeShardingTokenConsistencyOverTheTime(t *
 		"metric_1 with value_1": {
 			inputSeries: labels.Labels{
 				{Name: "__name__", Value: "metric_1"},
-				{Name: "cluster", Value: "cluster_1"},
 				{Name: "key", Value: "value_1"},
+				{Name: "cluster", Value: "cluster_1"},
 			},
 			expectedSeries: labels.Labels{
 				{Name: "__name__", Value: "metric_1"},
-				{Name: "cluster", Value: "cluster_1"},
 				{Name: "key", Value: "value_1"},
+				{Name: "cluster", Value: "cluster_1"},
 			},
-			expectedToken: 0xec0a2e9d,
+			expectedToken: 0x58b1e325,
 		},
 		"metric_1 with value_1 and dropped label due to config": {
 			inputSeries: labels.Labels{
 				{Name: "__name__", Value: "metric_1"},
-				{Name: "cluster", Value: "cluster_1"},
 				{Name: "key", Value: "value_1"},
-				{Name: "dropped", Value: "unused"}, // will be dropped, doesn't need to be in correct order
+				{Name: "cluster", Value: "cluster_1"},
+				{Name: "dropped", Value: "unused"},
 			},
 			expectedSeries: labels.Labels{
 				{Name: "__name__", Value: "metric_1"},
-				{Name: "cluster", Value: "cluster_1"},
 				{Name: "key", Value: "value_1"},
+				{Name: "cluster", Value: "cluster_1"},
 			},
-			expectedToken: 0xec0a2e9d,
+			expectedToken: 0x58b1e325,
 		},
 		"metric_1 with value_1 and dropped HA replica label": {
 			inputSeries: labels.Labels{
 				{Name: "__name__", Value: "metric_1"},
-				{Name: "cluster", Value: "cluster_1"},
 				{Name: "key", Value: "value_1"},
+				{Name: "cluster", Value: "cluster_1"},
 				{Name: "__replica__", Value: "replica_1"},
 			},
 			expectedSeries: labels.Labels{
 				{Name: "__name__", Value: "metric_1"},
-				{Name: "cluster", Value: "cluster_1"},
 				{Name: "key", Value: "value_1"},
+				{Name: "cluster", Value: "cluster_1"},
 			},
-			expectedToken: 0xec0a2e9d,
+			expectedToken: 0x58b1e325,
 		},
 		"metric_2 with value_1": {
 			inputSeries: labels.Labels{
@@ -795,10 +795,10 @@ func makeWriteRequestHA(samples int, replica, cluster string) *client.WriteReque
 			TimeSeries: &client.TimeSeries{
 				Labels: []client.LabelAdapter{
 					{Name: "__name__", Value: "foo"},
-					{Name: "__replica__", Value: replica},
 					{Name: "bar", Value: "baz"},
-					{Name: "cluster", Value: cluster},
 					{Name: "sample", Value: fmt.Sprintf("%d", i)},
+					{Name: "__replica__", Value: replica},
+					{Name: "cluster", Value: cluster},
 				},
 			},
 		}
@@ -1181,24 +1181,4 @@ func TestRemoveReplicaLabel(t *testing.T) {
 		removeLabel(replicaLabel, &c.labelsIn)
 		assert.Equal(t, c.labelsOut, c.labelsIn)
 	}
-}
-
-func TestShardByAllLabelsChecksForSortedLabelNames(t *testing.T) {
-	val, err := shardByAllLabels("test", []client.LabelAdapter{
-		{Name: "__name__", Value: "foo"},
-		{Name: "bar", Value: "baz"},
-		{Name: "sample", Value: "1"},
-	})
-
-	assert.NotZero(t, val)
-	assert.NoError(t, err)
-
-	val, err = shardByAllLabels("test", []client.LabelAdapter{
-		{Name: "__name__", Value: "foo"},
-		{Name: "sample", Value: "1"},
-		{Name: "bar", Value: "baz"},
-	})
-
-	assert.Zero(t, val)
-	assert.Error(t, err)
 }


### PR DESCRIPTION
Reverts cortexproject/cortex#1957

We've deployed this into our env and are seeing 500s being thrown. Investigating.