### PR TITLE
Change affiliation to Splunk for Chris and Cody

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,6 @@
 Bryan Boreham, Weaveworks <bryan@weave.works> (@bboreham)
-Chris Marchbanks, independent <csmarchbanks@gmail.com> (@csmarchbanks)
-Cody Boggs, independent <strofcon@gmail.com> (@cboggs)
+Chris Marchbanks, Splunk <csmarchbanks@gmail.com> (@csmarchbanks)
+Cody Boggs, Splunk <strofcon@gmail.com> (@cboggs)
 Jacob Lisi, Grafana Labs <jacob.t.lisi@gmail.com> (@jtlisi)
 Ken Haines, Microsoft <khaines@microsoft.com> (@khaines)
 Tom Wilkie, Grafana Labs <tom.wilkie@gmail.com> (@tomwilkie)


### PR DESCRIPTION
With the recent change in governance to limit votes for each company, it
is important for these affiliations to be officially recorded.