### PR TITLE
fix calculation of expected tables and create tables from upcoming schema considering grace period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ instructions below to upgrade your Postgres.
 * [BUGFIX] TSDB: Fixed `cortex_ingester_queried_samples` and `cortex_ingester_queried_series` metrics when using block storage. #1981
 * [BUGFIX] TSDB: Fixed `cortex_ingester_memory_series` and `cortex_ingester_memory_users` metrics when using with the experimental TSDB blocks storage. #1982
 * [BUGFIX] TSDB: Fixed `cortex_ingester_memory_series_created_total` and `cortex_ingester_memory_series_removed_total` metrics when using TSDB blocks storage. #1990
+* [BUGFIX] Table Manager: Fixed calculation of expected tables and creation of tables from next active schema considering grace period. #1976
 
 ### Upgrading Postgres (if you're using configs service)
 

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -424,7 +424,7 @@ func (cfg *PeriodicTableConfig) periodicTables(from, through model.Time, pCfg Pr
 		nowWeek        = now / periodSecs
 		result         = []TableDesc{}
 	)
-	// Make sure we don't have an extra table
+	// If interval ends exactly on a period boundary, don’t include the upcoming period
 	if through.Unix()%periodSecs == 0 {
 		lastTable--
 	}

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -424,8 +424,8 @@ func (cfg *PeriodicTableConfig) periodicTables(from, through model.Time, pCfg Pr
 		nowWeek        = now / periodSecs
 		result         = []TableDesc{}
 	)
-	// If through ends on 00:00 of the day, don't include the upcoming day
-	if through.Unix()%secondsInDay == 0 {
+	// Make sure we don't have an extra table
+	if through.Unix()%periodSecs == 0 {
 		lastTable--
 	}
 	// Don't make tables further back than the configured retention

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -239,7 +239,8 @@ func (m *TableManager) calculateExpectedTables() []TableDesc {
 	result := []TableDesc{}
 
 	for i, config := range m.schemaCfg.Configs {
-		if config.From.Time.Time().After(mtime.Now()) {
+		// Consider configs which we are about to hit and requires tables to be created due to grace period
+		if config.From.Time.Time().After(mtime.Now().Add(m.cfg.CreationGracePeriod)) {
 			continue
 		}
 		if config.IndexTables.Period == 0 { // non-periodic table

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -285,6 +285,21 @@ func TestTableManager(t *testing.T) {
 		},
 	)
 
+	// Move ahead where we are short by just grace period before hitting next section
+	tmTest(t, client, tableManager,
+		"Move ahead where we are short by just grace period before hitting next section",
+		weeklyTable2Start.Add(-gracePeriod+time.Second),
+		[]TableDesc{
+			{Name: baseTableName, ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite},
+			{Name: tablePrefix + week1Suffix, ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite, WriteScale: inactiveScalingConfig},
+			{Name: tablePrefix + week2Suffix, ProvisionedRead: read, ProvisionedWrite: write, WriteScale: activeScalingConfig},
+			{Name: table2Prefix + "5", ProvisionedRead: read, ProvisionedWrite: write, WriteScale: activeScalingConfig},
+			{Name: chunkTablePrefix + week1Suffix, ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite},
+			{Name: chunkTablePrefix + week2Suffix, ProvisionedRead: read, ProvisionedWrite: write},
+			{Name: chunkTable2Prefix + "5", ProvisionedRead: read, ProvisionedWrite: write},
+		},
+	)
+
 	// Move to the next section of the config
 	tmTest(t, client, tableManager,
 		"Move forward to next section of schema config",
@@ -644,6 +659,20 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 			{Name: tablePrefix + "3", ProvisionedRead: read, ProvisionedWrite: write},
 			{Name: chunkTablePrefix + "1", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite},
 			{Name: chunkTablePrefix + "2", ProvisionedRead: read, ProvisionedWrite: write},
+			{Name: chunkTablePrefix + "3", ProvisionedRead: read, ProvisionedWrite: write},
+		},
+	)
+
+	// Check after three weeks and a day short by grace period, we have three tables (two previous periods and the new one), table 0 was deleted
+	tmTest(t, client, tableManager,
+		"Move forward by three table periods and a day short by grace period",
+		baseTableStart.Add(tablePeriod*3+24*time.Hour-gracePeriod),
+		[]TableDesc{
+			{Name: tablePrefix + "1", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite, WriteScale: inactiveScalingConfig},
+			{Name: tablePrefix + "2", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite, WriteScale: inactiveScalingConfig},
+			{Name: tablePrefix + "3", ProvisionedRead: read, ProvisionedWrite: write},
+			{Name: chunkTablePrefix + "1", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite},
+			{Name: chunkTablePrefix + "2", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite},
 			{Name: chunkTablePrefix + "3", ProvisionedRead: read, ProvisionedWrite: write},
 		},
 	)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR includes following to fixes:

1. Fix calculation of expected tables:
While calculating periodic tables for a given duration, the end time of the duration was used to find what the last table number would be. To avoid creating an extra table, there was a check whether end duration was ending exactly at end of the day which was causing the whole table to be omitted. Instead of checking against a days duration, this PR uses periodic table duration to check whether we have an extra table.

2. Create tables from upcoming schema considering grace period:
We skip creating tables for configs whose start time is after `now()` which means tables would not be created until we already are past the start time of config. This can cause writes to fail since tables won't be created already for writing data to it.
This PR checks whether the config start time is before `now() + gracePeriod` when creating tables.

**Which issue(s) this PR fixes**:
Fixes: https://github.com/cortexproject/cortex/issues/1920
In #1920, the start time of config was not set to the day when tables would rotate. When the time was just short by grace period before hitting next config, [this](https://github.com/cortexproject/cortex/blob/8310aa24fe176c27de9bd51fb92bdb55b524abad/pkg/chunk/table_manager.go#L287-L290) block started calculating tables for duration from `start-of-active-schema` to `start-of-next-schema`. Since the end was not a multiple of table duration but was a multiple of a days duration, issue 1 above was causing table manager to unexpectedly drop the active table.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`