### PR TITLE
Report chunks flushed by spread-flushes option under separate label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [ENHANCEMENT] metric `cortex_ingester_flush_reasons` gets a new `reason` value: `Spread`, when `-ingester.spread-flushes` option is enabled.
+
 * [CHANGE] Flags changed with transition to upstream Prometheus rules manager:
   * `ruler.client-timeout` is now `ruler.configs.client-timeout` in order to match `ruler.configs.url`
   * `ruler.group-timeout`has been removed

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -355,7 +355,7 @@ func (i *Ingester) append(ctx context.Context, userID string, labels labelPairs,
 		slot := startOfCycle.Add(time.Duration(uint64(fp) % uint64(i.cfg.MaxChunkAge)))
 		// If adding this sample means the head chunk will span that point in time, close so it will get flushed
 		if series.head().FirstTime < slot && timestamp >= slot {
-			series.closeHead()
+			series.closeHead(reasonSpreadFlush)
 		}
 	}
 


### PR DESCRIPTION
This improves observability of flushing, creating separate labels for chunks that overflowed versus to series that reached their time under spread-flushes behaviour.

Fixes the point noted in #1578 "the 'reason' stats are less helpful".

The flushReason type shrinks to int8 to avoid bloating the chunk desc object.

**Checklist**
- [x] `CHANGELOG.md` updated
