### PR TITLE
CHANGELOG: changed ShipInterval to the cli flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * [BUGFIX] TSDB: Fixed querying ingesters in `LEAVING` state with the experimental TSDB blocks storage. #1854
 * [BUGFIX] TSDB: Fixed error handling in the series to chunks conversion with the experimental TSDB blocks storage. #1837
 * [BUGFIX] TSDB: Fixed TSDB creation conflict with blocks transfer in a `JOINING` ingester with the experimental TSDB blocks storage. #1818
-* [BUGFIX] TSDB: ShipInterval of <=0 treated as disabled instead of allowing panic. #1975
+* [BUGFIX] TSDB: `experimental.tsdb.ship-interval` of <=0 treated as disabled instead of allowing panic. #1975
 
 ## 0.4.0 / 2019-12-02
 


### PR DESCRIPTION
as requested in this PR: https://github.com/cortexproject/cortex/pull/1975/files/09e37606e8f5bb3c0ff23759bd786cb4ed34e007#r366242541

**What this PR does**: Updates the internal name in the changelog to the external flag.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
