### PR TITLE
TSDB: metrics for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [BUGFIX] TSDB: Fixed error handling in the series to chunks conversion with the experimental TSDB blocks storage. #1837
 * [BUGFIX] TSDB: Fixed TSDB creation conflict with blocks transfer in a `JOINING` ingester with the experimental TSDB blocks storage. #1818
 * [BUGFIX] TSDB: `experimental.tsdb.ship-interval` of <=0 treated as disabled instead of allowing panic. #1975
+* [BUGFIX] TSDB: Fixed `cortex_ingester_queried_samples`, `cortex_ingester_queried_series` and `cortex_ingester_memory_users` when using block storage. #1981
 
 ## 0.4.0 / 2019-12-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 * [BUGFIX] TSDB: Fixed error handling in the series to chunks conversion with the experimental TSDB blocks storage. #1837
 * [BUGFIX] TSDB: Fixed TSDB creation conflict with blocks transfer in a `JOINING` ingester with the experimental TSDB blocks storage. #1818
 * [BUGFIX] TSDB: `experimental.tsdb.ship-interval` of <=0 treated as disabled instead of allowing panic. #1975
-* [BUGFIX] TSDB: Fixed `cortex_ingester_queried_samples`, `cortex_ingester_queried_series` when using block storage. #1981
+* [BUGFIX] TSDB: Fixed `cortex_ingester_queried_samples` and `cortex_ingester_queried_series` metrics when using block storage. #1981
 
 ## 0.4.0 / 2019-12-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 * [BUGFIX] TSDB: Fixed error handling in the series to chunks conversion with the experimental TSDB blocks storage. #1837
 * [BUGFIX] TSDB: Fixed TSDB creation conflict with blocks transfer in a `JOINING` ingester with the experimental TSDB blocks storage. #1818
 * [BUGFIX] TSDB: `experimental.tsdb.ship-interval` of <=0 treated as disabled instead of allowing panic. #1975
-* [BUGFIX] TSDB: Fixed `cortex_ingester_queried_samples`, `cortex_ingester_queried_series` and `cortex_ingester_memory_users` when using block storage. #1981
+* [BUGFIX] TSDB: Fixed `cortex_ingester_queried_samples`, `cortex_ingester_queried_series` when using block storage. #1981
 
 ## 0.4.0 / 2019-12-02
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -194,12 +194,10 @@ func (i *Ingester) v2Query(ctx old_ctx.Context, req *client.QueryRequest) (*clie
 		return nil, err
 	}
 
-	numSeries := 0
 	numSamples := 0
 
 	result := &client.QueryResponse{}
 	for ss.Next() {
-		numSeries++
 		series := ss.At()
 
 		ts := client.TimeSeries{
@@ -208,15 +206,15 @@ func (i *Ingester) v2Query(ctx old_ctx.Context, req *client.QueryRequest) (*clie
 
 		it := series.Iterator()
 		for it.Next() {
-			numSamples++
 			t, v := it.At()
 			ts.Samples = append(ts.Samples, client.Sample{Value: v, TimestampMs: t})
 		}
 
+		numSamples += len(ts.Samples)
 		result.Timeseries = append(result.Timeseries, ts)
 	}
 
-	i.metrics.queriedSeries.Observe(float64(numSeries))
+	i.metrics.queriedSeries.Observe(float64(len(result.Timeseries)))
 	i.metrics.queriedSamples.Observe(float64(numSamples))
 
 	return result, ss.Err()

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -419,7 +419,6 @@ func (i *Ingester) getOrCreateTSDB(userID string, force bool) (*tsdb.DB, error) 
 	}
 
 	i.TSDBState.dbs[userID] = db
-	memUsers.Inc()
 
 	return db, nil
 }

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -421,6 +421,7 @@ func (i *Ingester) getOrCreateTSDB(userID string, force bool) (*tsdb.DB, error) 
 	}
 
 	i.TSDBState.dbs[userID] = db
+	memUsers.Inc()
 
 	return db, nil
 }


### PR DESCRIPTION
This PR updates some existing ingester metrics from blocks code. Specifically:

We already update ingestion metrics from blocks code (`cortex_ingester_ingested_samples_total`, `cortex_ingester_ingested_samples_failures_total`)

Querying:
- `cortex_ingester_queries_total` (this was already tracked before this PR)
- `cortex_ingester_queried_samples` (added by this PR)
- `cortex_ingester_queried_series` (added by this PR)
- Ignored metric: `cortex_ingester_queried_chunks` – chunks-specific

User state:
- `cortex_ingester_memory_users` (~added by this PR~ [update: now removed again, in favor of PR #1982), basically equals to number of open TSDB databases in Cortex)
- Ignored: `cortex_ingester_memory_series` – cannot see easy way to get this, not even in TSDB metrics
- Ignored: `cortex_ingester_memory_series_created_total`, `cortex_ingester_memory_series_removed_total` (these are per-user) – again, no obvious/easy way to get this from TSDB

There are some more metrics that are updated when flushing chunks. This PR doesn't update these metrics and there seems to be no obvious way how we could do that:
- `cortex_ingester_chunk_age_seconds`
- `cortex_ingester_chunk_length`
- `cortex_ingester_chunk_size_bytes`
- `cortex_ingester_chunk_utilization`
- `cortex_ingester_chunks_created_total`
- `cortex_ingester_dropped_chunks_total`
- `cortex_ingester_memory_chunks` (total chunks in memory)

Additional cortex_ingester metrics are related to transfer of data between ingesters. This PR doesn't change them, but for completeness, here they are:
- `cortex_ingester_received_bytes_total`, `cortex_ingester_received_files`, `cortex_ingester_sent_bytes_total`, `cortex_ingester_sent_files` - updated when transferring TSDB's between ingesters
- `cortex_ingester_received_chunks`, `cortex_ingester_sent_chunks` - updated when transferring chunks between ingesters