### PR TITLE
TSDB: fix user metrics when using blocks storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ instructions below to upgrade your Postgres.
 * [BUGFIX] TSDB: `experimental.tsdb.ship-interval` of <=0 treated as disabled instead of allowing panic. #1975
 * [BUGFIX] TSDB: Fixed `cortex_ingester_queried_samples` and `cortex_ingester_queried_series` metrics when using block storage. #1981
 * [BUGFIX] TSDB: Fixed `cortex_ingester_memory_series` and `cortex_ingester_memory_users` metrics when using with the experimental TSDB blocks storage. #1982
+* [BUGFIX] TSDB: Fixed `cortex_ingester_memory_series_created_total` and `cortex_ingester_memory_series_removed_total` metrics when using TSDB blocks storage. #1990
 
 ### Upgrading Postgres (if you're using configs service)
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -134,7 +134,7 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 	i := &Ingester{
 		cfg:          cfg,
 		clientConfig: clientConfig,
-		metrics:      newIngesterMetrics(registerer),
+		metrics:      newIngesterMetrics(registerer, true),
 		limits:       limits,
 		chunkStore:   chunkStore,
 		quit:         make(chan struct{}),

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -46,7 +46,7 @@ type TSDBState struct {
 	// transferring to a joining ingester
 	transferOnce sync.Once
 
-	shipperMetrics *shipperMetrics
+	tsdbMetrics *tsdbMetrics
 }
 
 // NewV2 returns a new Ingester that uses prometheus block storage instead of chunk storage
@@ -59,15 +59,15 @@ func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides,
 	i := &Ingester{
 		cfg:          cfg,
 		clientConfig: clientConfig,
-		metrics:      newIngesterMetrics(registerer),
+		metrics:      newIngesterMetrics(registerer, false),
 		limits:       limits,
 		chunkStore:   nil,
 		quit:         make(chan struct{}),
 
 		TSDBState: TSDBState{
-			dbs:            make(map[string]*tsdb.DB),
-			bucket:         bucketClient,
-			shipperMetrics: newShipperMetrics(registerer),
+			dbs:         make(map[string]*tsdb.DB),
+			bucket:      bucketClient,
+			tsdbMetrics: newTsdbMetrics(registerer),
 		},
 	}
 
@@ -419,10 +419,12 @@ func (i *Ingester) getOrCreateTSDB(userID string, force bool) (*tsdb.DB, error) 
 
 // createTSDB creates a TSDB for a given userID, and returns the created db.
 func (i *Ingester) createTSDB(userID string) (*tsdb.DB, error) {
+	tsdbPromReg := i.TSDBState.tsdbMetrics.newRegistryForUser(userID)
+
 	udir := i.cfg.TSDBConfig.BlocksDir(userID)
 
 	// Create a new user database
-	db, err := tsdb.Open(udir, util.Logger, nil, &tsdb.Options{
+	db, err := tsdb.Open(udir, util.Logger, tsdbPromReg, &tsdb.Options{
 		RetentionDuration: uint64(i.cfg.TSDBConfig.Retention / time.Millisecond),
 		BlockRanges:       i.cfg.TSDBConfig.BlockRanges.ToMillisecondRanges(),
 		NoLockfile:        true,
@@ -443,7 +445,7 @@ func (i *Ingester) createTSDB(userID string) (*tsdb.DB, error) {
 
 	// Create a new shipper for this database
 	if i.cfg.TSDBConfig.ShipInterval > 0 {
-		s := shipper.New(util.Logger, i.TSDBState.shipperMetrics.newRegistryForUser(userID), udir, &Bucket{userID, i.TSDBState.bucket}, func() labels.Labels { return l }, metadata.ReceiveSource)
+		s := shipper.New(util.Logger, tsdbPromReg, udir, &Bucket{userID, i.TSDBState.bucket}, func() labels.Labels { return l }, metadata.ReceiveSource)
 		i.done.Add(1)
 		go func() {
 			defer i.done.Done()

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -67,7 +67,7 @@ func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides,
 		TSDBState: TSDBState{
 			dbs:         make(map[string]*tsdb.DB),
 			bucket:      bucketClient,
-			tsdbMetrics: newTsdbMetrics(registerer),
+			tsdbMetrics: newTSDBMetrics(registerer),
 		},
 	}
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -419,7 +419,7 @@ func (i *Ingester) getOrCreateTSDB(userID string, force bool) (*tsdb.DB, error) 
 
 // createTSDB creates a TSDB for a given userID, and returns the created db.
 func (i *Ingester) createTSDB(userID string) (*tsdb.DB, error) {
-	tsdbPromReg := i.TSDBState.tsdbMetrics.newRegistryForUser(userID)
+	tsdbPromReg := prometheus.NewRegistry()
 
 	udir := i.cfg.TSDBConfig.BlocksDir(userID)
 
@@ -460,6 +460,7 @@ func (i *Ingester) createTSDB(userID string) (*tsdb.DB, error) {
 		}()
 	}
 
+	i.TSDBState.tsdbMetrics.setRegistryForUser(userID, tsdbPromReg)
 	return db, nil
 }
 

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -36,6 +36,8 @@ func TestIngester_v2Push(t *testing.T) {
 		"cortex_ingester_ingested_samples_failures_total",
 		"cortex_ingester_memory_series",
 		"cortex_ingester_memory_users",
+		"cortex_ingester_memory_series_created_total",
+		"cortex_ingester_memory_series_removed_total",
 	}
 	userID := "test"
 
@@ -73,6 +75,12 @@ func TestIngester_v2Push(t *testing.T) {
 				# HELP cortex_ingester_memory_series The current number of series in memory.
 				# TYPE cortex_ingester_memory_series gauge
 				cortex_ingester_memory_series 1
+				# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
+				# TYPE cortex_ingester_memory_series_created_total counter
+				cortex_ingester_memory_series_created_total{user="test"} 1
+				# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
+				# TYPE cortex_ingester_memory_series_removed_total counter
+				cortex_ingester_memory_series_removed_total{user="test"} 0
 			`,
 		},
 		"should soft fail on sample out of order": {
@@ -103,6 +111,12 @@ func TestIngester_v2Push(t *testing.T) {
 				# HELP cortex_ingester_memory_series The current number of series in memory.
 				# TYPE cortex_ingester_memory_series gauge
 				cortex_ingester_memory_series 1
+				# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
+				# TYPE cortex_ingester_memory_series_created_total counter
+				cortex_ingester_memory_series_created_total{user="test"} 1
+				# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
+				# TYPE cortex_ingester_memory_series_removed_total counter
+				cortex_ingester_memory_series_removed_total{user="test"} 0
 			`,
 		},
 		"should soft fail on sample out of bound": {
@@ -133,6 +147,12 @@ func TestIngester_v2Push(t *testing.T) {
 				# HELP cortex_ingester_memory_series The current number of series in memory.
 				# TYPE cortex_ingester_memory_series gauge
 				cortex_ingester_memory_series 1
+				# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
+				# TYPE cortex_ingester_memory_series_created_total counter
+				cortex_ingester_memory_series_created_total{user="test"} 1
+				# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
+				# TYPE cortex_ingester_memory_series_removed_total counter
+				cortex_ingester_memory_series_removed_total{user="test"} 0
 			`,
 		},
 		"should soft fail on two different sample values at the same timestamp": {
@@ -163,6 +183,12 @@ func TestIngester_v2Push(t *testing.T) {
 				# HELP cortex_ingester_memory_series The current number of series in memory.
 				# TYPE cortex_ingester_memory_series gauge
 				cortex_ingester_memory_series 1
+				# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
+				# TYPE cortex_ingester_memory_series_created_total counter
+				cortex_ingester_memory_series_created_total{user="test"} 1
+				# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
+				# TYPE cortex_ingester_memory_series_removed_total counter
+				cortex_ingester_memory_series_removed_total{user="test"} 0
 			`,
 		},
 	}
@@ -226,6 +252,8 @@ func TestIngester_v2Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *tes
 		"cortex_ingester_ingested_samples_failures_total",
 		"cortex_ingester_memory_series",
 		"cortex_ingester_memory_users",
+		"cortex_ingester_memory_series_created_total",
+		"cortex_ingester_memory_series_removed_total",
 	}
 
 	registry := prometheus.NewRegistry()
@@ -278,6 +306,14 @@ func TestIngester_v2Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *tes
 		# HELP cortex_ingester_memory_series The current number of series in memory.
 		# TYPE cortex_ingester_memory_series gauge
 		cortex_ingester_memory_series 2
+		# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
+		# TYPE cortex_ingester_memory_series_created_total counter
+		cortex_ingester_memory_series_created_total{user="test-1"} 1
+		cortex_ingester_memory_series_created_total{user="test-2"} 1
+		# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
+		# TYPE cortex_ingester_memory_series_removed_total counter
+		cortex_ingester_memory_series_removed_total{user="test-1"} 0
+		cortex_ingester_memory_series_removed_total{user="test-2"} 0
 	`
 
 	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), metricNames...))

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -209,12 +209,10 @@ func (sm *tsdbMetrics) registries() map[string]*prometheus.Registry {
 	return regs
 }
 
-func (sm *tsdbMetrics) newRegistryForUser(userID string) prometheus.Registerer {
-	reg := prometheus.NewRegistry()
+func (sm *tsdbMetrics) setRegistryForUser(userID string, registry *prometheus.Registry) {
 	sm.regsMu.Lock()
-	sm.regs[userID] = reg
+	sm.regs[userID] = registry
 	sm.regsMu.Unlock()
-	return reg
 }
 
 func sumCounters(mfs []*dto.MetricFamily) float64 {

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -130,7 +130,7 @@ type tsdbMetrics struct {
 	regs   map[string]*prometheus.Registry // One prometheus registry per tenant
 }
 
-func newTsdbMetrics(r prometheus.Registerer) *tsdbMetrics {
+func newTSDBMetrics(r prometheus.Registerer) *tsdbMetrics {
 	m := &tsdbMetrics{
 		regs: make(map[string]*prometheus.Registry),
 

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -202,8 +202,8 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	}
 
 	for metric, desc := range sm.sumCountersPerUser {
-		memSeriesRemoved := data.sumCountersPerUser(metric)
-		for user, val := range memSeriesRemoved {
+		userValues := data.sumCountersPerUser(metric)
+		for user, val := range userValues {
 			out <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, val, user)
 		}
 	}

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -9,6 +9,14 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
+const (
+	memSeriesCreatedTotalName = "cortex_ingester_memory_series_created_total"
+	memSeriesCreatedTotalHelp = "The total number of series that were created per user."
+
+	memSeriesRemovedTotalName = "cortex_ingester_memory_series_removed_total"
+	memSeriesRemovedTotalHelp = "The total number of series that were removed per user."
+)
+
 type ingesterMetrics struct {
 	flushQueueLength      prometheus.Gauge
 	ingestedSamples       prometheus.Counter
@@ -23,7 +31,7 @@ type ingesterMetrics struct {
 	memSeriesRemovedTotal *prometheus.CounterVec
 }
 
-func newIngesterMetrics(r prometheus.Registerer) *ingesterMetrics {
+func newIngesterMetrics(r prometheus.Registerer, registerMetricsConflictingWithTSDB bool) *ingesterMetrics {
 	m := &ingesterMetrics{
 		flushQueueLength: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_flush_queue_length",
@@ -68,12 +76,12 @@ func newIngesterMetrics(r prometheus.Registerer) *ingesterMetrics {
 			Help: "The current number of users in memory.",
 		}),
 		memSeriesCreatedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ingester_memory_series_created_total",
-			Help: "The total number of series that were created per user.",
+			Name: memSeriesCreatedTotalName,
+			Help: memSeriesCreatedTotalHelp,
 		}, []string{"user"}),
 		memSeriesRemovedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ingester_memory_series_removed_total",
-			Help: "The total number of series that were removed per user.",
+			Name: memSeriesRemovedTotalName,
+			Help: memSeriesRemovedTotalHelp,
 		}, []string{"user"}),
 	}
 
@@ -88,28 +96,38 @@ func newIngesterMetrics(r prometheus.Registerer) *ingesterMetrics {
 			m.queriedChunks,
 			m.memSeries,
 			m.memUsers,
-			m.memSeriesCreatedTotal,
-			m.memSeriesRemovedTotal,
 		)
+
+		if registerMetricsConflictingWithTSDB {
+			r.MustRegister(
+				m.memSeriesCreatedTotal,
+				m.memSeriesRemovedTotal,
+			)
+		}
 	}
 
 	return m
 }
 
-// TSDB shipper metrics. We aggregate metrics from individual TSDB shippers into
-// a single set of counters, which are exposed as Cortex metrics.
-type shipperMetrics struct {
+// TSDB metrics. Each tenant has its own registry, that TSDB code uses.
+type tsdbMetrics struct {
+	// We aggregate metrics from individual TSDB registries into
+	// a single set of counters, which are exposed as Cortex metrics.
 	dirSyncs        *prometheus.Desc // sum(thanos_shipper_dir_syncs_total)
 	dirSyncFailures *prometheus.Desc // sum(thanos_shipper_dir_sync_failures_total)
 	uploads         *prometheus.Desc // sum(thanos_shipper_uploads_total)
 	uploadFailures  *prometheus.Desc // sum(thanos_shipper_upload_failures_total)
 
+	// These two metrics replace metrics in ingesterMetrics, as we count them differently
+	memSeriesCreatedTotal *prometheus.Desc
+	memSeriesRemovedTotal *prometheus.Desc
+
 	regsMu sync.RWMutex                    // custom mutex for shipper registry, to avoid blocking main user state mutex on collection
-	regs   map[string]*prometheus.Registry // One prometheus registry (used by shipper) per tenant
+	regs   map[string]*prometheus.Registry // One prometheus registry per tenant
 }
 
-func newShipperMetrics(r prometheus.Registerer) *shipperMetrics {
-	m := &shipperMetrics{
+func newTsdbMetrics(r prometheus.Registerer) *tsdbMetrics {
+	m := &tsdbMetrics{
 		regs: make(map[string]*prometheus.Registry),
 
 		dirSyncs: prometheus.NewDesc(
@@ -128,6 +146,9 @@ func newShipperMetrics(r prometheus.Registerer) *shipperMetrics {
 			"cortex_ingester_shipper_upload_failures_total",
 			"TSDB: Total number of failed object uploads",
 			nil, nil),
+
+		memSeriesCreatedTotal: prometheus.NewDesc(memSeriesCreatedTotalName, memSeriesCreatedTotalHelp, []string{"user"}, nil),
+		memSeriesRemovedTotal: prometheus.NewDesc(memSeriesRemovedTotalName, memSeriesRemovedTotalHelp, []string{"user"}, nil),
 	}
 
 	if r != nil {
@@ -136,17 +157,19 @@ func newShipperMetrics(r prometheus.Registerer) *shipperMetrics {
 	return m
 }
 
-func (sm *shipperMetrics) Describe(out chan<- *prometheus.Desc) {
+func (sm *tsdbMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- sm.dirSyncs
 	out <- sm.dirSyncFailures
 	out <- sm.uploads
 	out <- sm.uploadFailures
+	out <- sm.memSeriesCreatedTotal
+	out <- sm.memSeriesRemovedTotal
 }
 
-func (sm *shipperMetrics) Collect(out chan<- prometheus.Metric) {
-	gathered := make(map[string][]*dto.MetricFamily)
+func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
+	regs := sm.registries()
+	data := gatheredMetricsPerUser{}
 
-	regs := sm.shipperRegistries()
 	for userID, r := range regs {
 		m, err := r.Gather()
 		if err != nil {
@@ -154,28 +177,39 @@ func (sm *shipperMetrics) Collect(out chan<- prometheus.Metric) {
 			continue
 		}
 
-		addToGatheredMap(gathered, m)
+		data.addGatheredDataForUser(userID, m)
 	}
 
 	// OK, we have it all. Let's build results.
-	out <- prometheus.MustNewConstMetric(sm.dirSyncs, prometheus.CounterValue, sumCounters(gathered["thanos_shipper_dir_syncs_total"]))
-	out <- prometheus.MustNewConstMetric(sm.dirSyncFailures, prometheus.CounterValue, sumCounters(gathered["thanos_shipper_dir_sync_failures_total"]))
-	out <- prometheus.MustNewConstMetric(sm.uploads, prometheus.CounterValue, sumCounters(gathered["thanos_shipper_uploads_total"]))
-	out <- prometheus.MustNewConstMetric(sm.uploadFailures, prometheus.CounterValue, sumCounters(gathered["thanos_shipper_upload_failures_total"]))
+	out <- prometheus.MustNewConstMetric(sm.dirSyncs, prometheus.CounterValue, data.sumCountersAcrossAllUsers("thanos_shipper_dir_syncs_total"))
+	out <- prometheus.MustNewConstMetric(sm.dirSyncFailures, prometheus.CounterValue, data.sumCountersAcrossAllUsers("thanos_shipper_dir_sync_failures_total"))
+	out <- prometheus.MustNewConstMetric(sm.uploads, prometheus.CounterValue, data.sumCountersAcrossAllUsers("thanos_shipper_uploads_total"))
+	out <- prometheus.MustNewConstMetric(sm.uploadFailures, prometheus.CounterValue, data.sumCountersAcrossAllUsers("thanos_shipper_upload_failures_total"))
+
+	memSeriesCreated := data.sumCountersPerUser("prometheus_tsdb_head_series_created_total")
+	for user, val := range memSeriesCreated {
+		out <- prometheus.MustNewConstMetric(sm.memSeriesCreatedTotal, prometheus.CounterValue, val, user)
+	}
+
+	memSeriesRemoved := data.sumCountersPerUser("prometheus_tsdb_head_series_removed_total")
+	for user, val := range memSeriesRemoved {
+		out <- prometheus.MustNewConstMetric(sm.memSeriesRemovedTotal, prometheus.CounterValue, val, user)
+	}
 }
 
-func (sm *shipperMetrics) shipperRegistries() []*prometheus.Registry {
+// make a copy of the map, so that metrics can be gathered while the new registry is being added.
+func (sm *tsdbMetrics) registries() map[string]*prometheus.Registry {
 	sm.regsMu.RLock()
 	defer sm.regsMu.RUnlock()
 
-	regs := make([]*prometheus.Registry, 0, len(sm.regs))
-	for _, r := range sm.regs {
-		regs = append(regs, r)
+	regs := make(map[string]*prometheus.Registry, len(sm.regs))
+	for u, r := range sm.regs {
+		regs[u] = r
 	}
 	return regs
 }
 
-func (sm *shipperMetrics) newRegistryForUser(userID string) prometheus.Registerer {
+func (sm *tsdbMetrics) newRegistryForUser(userID string) prometheus.Registerer {
 	reg := prometheus.NewRegistry()
 	sm.regsMu.Lock()
 	sm.regs[userID] = reg
@@ -201,11 +235,37 @@ func sumCounters(mfs []*dto.MetricFamily) float64 {
 	return result
 }
 
-func addToGatheredMap(all map[string][]*dto.MetricFamily, mfs []*dto.MetricFamily) {
-	for _, m := range mfs {
+// first key = userID, second key = metric name. Value = slice of gathered values with the same metric name.
+type gatheredMetricsPerUser map[string]map[string][]*dto.MetricFamily
+
+func (d gatheredMetricsPerUser) addGatheredDataForUser(userID string, metrics []*dto.MetricFamily) {
+	// first, create new map which maps metric names to a slice of MetricFamily instances.
+	// That makes it easier to do searches later.
+	perMetricName := map[string][]*dto.MetricFamily{}
+
+	for _, m := range metrics {
 		if m.Name == nil {
 			continue
 		}
-		all[*m.Name] = append(all[*m.Name], m)
+		perMetricName[*m.Name] = append(perMetricName[*m.Name], m)
 	}
+
+	d[userID] = perMetricName
+}
+
+func (d gatheredMetricsPerUser) sumCountersAcrossAllUsers(counter string) float64 {
+	result := float64(0)
+	for _, perMetric := range d {
+		result += sumCounters(perMetric[counter])
+	}
+	return result
+}
+
+func (d gatheredMetricsPerUser) sumCountersPerUser(counter string) map[string]float64 {
+	result := map[string]float64{}
+	for user, perMetric := range d {
+		v := sumCounters(perMetric[counter])
+		result[user] = v
+	}
+	return result
 }

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -12,11 +12,11 @@ import (
 func TestShipperMetrics(t *testing.T) {
 	mainReg := prometheus.NewRegistry()
 
-	shipper := newTsdbMetrics(mainReg)
+	tsdbMetrics := newTsdbMetrics(mainReg)
 
-	populateShipperMetrics(shipper.getOrCreateRegistryForUser("user1"), 12345)
-	populateShipperMetrics(shipper.getOrCreateRegistryForUser("user2"), 85787)
-	populateShipperMetrics(shipper.getOrCreateRegistryForUser("user3"), 999)
+	tsdbMetrics.setRegistryForUser("user1", populateShipperMetrics(12345))
+	tsdbMetrics.setRegistryForUser("user2", populateShipperMetrics(85787))
+	tsdbMetrics.setRegistryForUser("user3", populateShipperMetrics(999))
 
 	err := testutil.GatherAndCompare(mainReg, bytes.NewBufferString(`
 			# HELP cortex_ingester_shipper_dir_syncs_total TSDB: Total dir sync attempts
@@ -42,7 +42,8 @@ func TestShipperMetrics(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func populateShipperMetrics(r prometheus.Registerer, base float64) {
+func populateShipperMetrics(base float64) *prometheus.Registry {
+	r := prometheus.NewRegistry()
 	dirSyncs := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "thanos_shipper_dir_syncs_total",
 		Help: "Total dir sync attempts",
@@ -71,4 +72,6 @@ func populateShipperMetrics(r prometheus.Registerer, base float64) {
 	r.MustRegister(dirSyncFailures)
 	r.MustRegister(uploads)
 	r.MustRegister(uploadFailures)
+
+	return r
 }

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -9,14 +9,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestShipperMetrics(t *testing.T) {
+func TestTSDBMetrics(t *testing.T) {
 	mainReg := prometheus.NewRegistry()
 
 	tsdbMetrics := newTSDBMetrics(mainReg)
 
-	tsdbMetrics.setRegistryForUser("user1", populateShipperMetrics(12345))
-	tsdbMetrics.setRegistryForUser("user2", populateShipperMetrics(85787))
-	tsdbMetrics.setRegistryForUser("user3", populateShipperMetrics(999))
+	tsdbMetrics.setRegistryForUser("user1", populateTSDBMetrics(12345))
+	tsdbMetrics.setRegistryForUser("user2", populateTSDBMetrics(85787))
+	tsdbMetrics.setRegistryForUser("user3", populateTSDBMetrics(999))
+
+	metricNames := []string{
+		"cortex_ingester_shipper_dir_syncs_total",
+		"cortex_ingester_shipper_dir_sync_failures_total",
+		"cortex_ingester_shipper_uploads_total",
+		"cortex_ingester_shipper_upload_failures_total",
+		"cortex_ingester_memory_series_created_total",
+		"cortex_ingester_memory_series_removed_total",
+	}
 
 	err := testutil.GatherAndCompare(mainReg, bytes.NewBufferString(`
 			# HELP cortex_ingester_shipper_dir_syncs_total TSDB: Total dir sync attempts
@@ -38,12 +47,28 @@ func TestShipperMetrics(t *testing.T) {
 			# TYPE cortex_ingester_shipper_upload_failures_total counter
 			# 4*(12345 + 85787 + 999)
 			cortex_ingester_shipper_upload_failures_total 396524
-	`), "cortex_ingester_shipper_dir_syncs_total", "cortex_ingester_shipper_dir_sync_failures_total", "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_upload_failures_total")
+
+			# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
+			# TYPE cortex_ingester_memory_series_created_total counter
+			# 5 * (12345, 85787 and 999 respectively)
+			cortex_ingester_memory_series_created_total{user="user1"} 61725
+			cortex_ingester_memory_series_created_total{user="user2"} 428935
+			cortex_ingester_memory_series_created_total{user="user3"} 4995
+
+			# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
+			# TYPE cortex_ingester_memory_series_removed_total counter
+			# 6 * (12345, 85787 and 999 respectively)
+			cortex_ingester_memory_series_removed_total{user="user1"} 74070
+			cortex_ingester_memory_series_removed_total{user="user2"} 514722
+			cortex_ingester_memory_series_removed_total{user="user3"} 5994
+	`), metricNames...)
 	require.NoError(t, err)
 }
 
-func populateShipperMetrics(base float64) *prometheus.Registry {
+func populateTSDBMetrics(base float64) *prometheus.Registry {
 	r := prometheus.NewRegistry()
+
+	// shipper
 	dirSyncs := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "thanos_shipper_dir_syncs_total",
 		Help: "Total dir sync attempts",
@@ -68,10 +93,23 @@ func populateShipperMetrics(base float64) *prometheus.Registry {
 	})
 	uploadFailures.Add(4 * base)
 
+	// TSDB Head
+	seriesCreated := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_head_series_created_total",
+	})
+	seriesCreated.Add(5 * base)
+
+	seriesRemoved := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_head_series_removed_total",
+	})
+	seriesRemoved.Add(6 * base)
+
 	r.MustRegister(dirSyncs)
 	r.MustRegister(dirSyncFailures)
 	r.MustRegister(uploads)
 	r.MustRegister(uploadFailures)
+	r.MustRegister(seriesCreated)
+	r.MustRegister(seriesRemoved)
 
 	return r
 }

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -12,7 +12,7 @@ import (
 func TestShipperMetrics(t *testing.T) {
 	mainReg := prometheus.NewRegistry()
 
-	tsdbMetrics := newTsdbMetrics(mainReg)
+	tsdbMetrics := newTSDBMetrics(mainReg)
 
 	tsdbMetrics.setRegistryForUser("user1", populateShipperMetrics(12345))
 	tsdbMetrics.setRegistryForUser("user2", populateShipperMetrics(85787))

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -12,11 +12,11 @@ import (
 func TestShipperMetrics(t *testing.T) {
 	mainReg := prometheus.NewRegistry()
 
-	shipper := newShipperMetrics(mainReg)
+	shipper := newTsdbMetrics(mainReg)
 
-	populateShipperMetrics(shipper.newRegistryForUser("user1"), 12345)
-	populateShipperMetrics(shipper.newRegistryForUser("user2"), 85787)
-	populateShipperMetrics(shipper.newRegistryForUser("user3"), 999)
+	populateShipperMetrics(shipper.getOrCreateRegistryForUser("user1"), 12345)
+	populateShipperMetrics(shipper.getOrCreateRegistryForUser("user2"), 85787)
+	populateShipperMetrics(shipper.getOrCreateRegistryForUser("user3"), 999)
 
 	err := testutil.GatherAndCompare(mainReg, bytes.NewBufferString(`
 			# HELP cortex_ingester_shipper_dir_syncs_total TSDB: Total dir sync attempts


### PR DESCRIPTION
When using TSDB, we get per-user created and removed series from TSDB metrics.

This affects `cortex_ingester_memory_series_created_total` and `cortex_ingester_memory_series_removed_total`.
    
This PR also renames `shipperMetrics` to `tsdbMetrics`, and registers the same registry to TSDB and TSDB shipper component.

Registration of prometheus registry now happens only after TSDB initialization is finished, in order to fix a panic where metrics were collected while TSDB was still initialized.


This PR builds on PR #1983, so "Files changed" also shows changes from there. I'll rebase once (if) #1983 is merged. Update: now rebased.