### PR TITLE
Avoid calling flag.Parse() twice.

### DIFF
--- a/pkg/util/flagext/ignored.go
+++ b/pkg/util/flagext/ignored.go
@@ -1,0 +1,22 @@
+package flagext
+
+import (
+	"flag"
+)
+
+type ignoredFlag struct {
+	name string
+}
+
+func (ignoredFlag) String() string {
+	return "ignored"
+}
+
+func (d ignoredFlag) Set(string) error {
+	return nil
+}
+
+// IgnoredFlag ignores set value, without any warning
+func IgnoredFlag(f *flag.FlagSet, name, message string) {
+	f.Var(ignoredFlag{name}, name, message)
+}


### PR DESCRIPTION
flag.Parse() was called twice previously, first to get `-config.file` value to parse the config file, and second to parse remaining command line parameters – overwriting values from config file.

Unfortunately that confuses command line parameters that accept multiple values (eg. `-memberlist.join` or `-experimental.tsdb.block-ranges-period` in #1942). In this PR we get `-config.file` via a separate FlagSet (which doesn't report any error or usage) to avoid calling `flag.Parse()` on default FlagSet twice.

This should not be visible to end user in any way.