### PR TITLE
Prevents panic using freed slice in pool

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -226,6 +226,8 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 		return i.v2Push(ctx, req)
 	}
 
+	defer client.ReuseSlice(req.Timeseries)
+
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id")
@@ -248,7 +250,6 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 			return nil, wrapWithUser(err, userID)
 		}
 	}
-	client.ReuseSlice(req.Timeseries)
 
 	if lastPartialErr != nil {
 		return &client.WriteResponse{}, lastPartialErr.WrapWithUser(userID).WrappedError()


### PR DESCRIPTION
This defers putting a slice back into the pool (ingester push path) to prevent panicking Error() calls which reference the underlying labels.

This defers returning an allocated slice to its pool until after use. Previously we saw panics on `Error()` calls which held references to the underlying timeseries label set.