### PR TITLE
Updated k8s Cortex yaml files

### DIFF
--- a/k8s/alertmanager-dep.yaml
+++ b/k8s/alertmanager-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: alertmanager
@@ -22,3 +22,6 @@ spec:
         - -alertmanager.web.external-url=/api/prom/alertmanager
         ports:
         - containerPort: 80
+  selector:
+    matchLabels:
+      name: alertmanager

--- a/k8s/configs-db-dep.yaml
+++ b/k8s/configs-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: configs-db
@@ -22,3 +22,6 @@ spec:
             value: configs
         ports:
         - containerPort: 5432
+  selector:
+    matchLabels:
+      name: configs-db

--- a/k8s/configs-dep.yaml
+++ b/k8s/configs-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: configs
@@ -21,3 +21,6 @@ spec:
         - -database.migrations=/migrations
         ports:
         - containerPort: 80
+  selector:
+    matchLabels:
+      name: configs

--- a/k8s/consul-dep.yaml
+++ b/k8s/consul-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: consul
@@ -32,3 +32,6 @@ spec:
           containerPort: 8400
         - name: http-noscrape
           containerPort: 8500
+  selector:
+    matchLabels:
+      name: consul

--- a/k8s/distributor-dep.yaml
+++ b/k8s/distributor-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: distributor
@@ -22,3 +22,6 @@ spec:
         - -distributor.replication-factor=1
         ports:
         - containerPort: 80
+  selector:
+    matchLabels:
+      name: distributor

--- a/k8s/dynamodb-dep.yaml
+++ b/k8s/dynamodb-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dynamodb
@@ -19,3 +19,6 @@ spec:
         args: ['-jar', 'DynamoDBLocal.jar', '-inMemory', '-sharedDb']
         ports:
         - containerPort: 8000
+  selector:
+    matchLabels:
+      name: dynamodb

--- a/k8s/ingester-dep.yaml
+++ b/k8s/ingester-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ingester
@@ -63,3 +63,6 @@ spec:
             port: 80
           initialDelaySeconds: 15
           timeoutSeconds: 1
+  selector:
+    matchLabels:
+      name: ingester

--- a/k8s/memcached-dep.yaml
+++ b/k8s/memcached-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: memcached
@@ -22,3 +22,6 @@ spec:
         ports:
         - name: clients
           containerPort: 11211
+  selector:
+    matchLabels:
+      name: memcached

--- a/k8s/nginx-dep.yaml
+++ b/k8s/nginx-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx
@@ -26,3 +26,6 @@ spec:
         - name: config-volume
           configMap:
             name: nginx
+  selector:
+    matchLabels:
+      name: nginx

--- a/k8s/querier-dep.yaml
+++ b/k8s/querier-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: querier
@@ -36,3 +36,6 @@ spec:
         - -distributor.replication-factor=1
         ports:
         - containerPort: 80
+  selector:
+    matchLabels:
+      name: querier

--- a/k8s/query-frontend-dep.yaml
+++ b/k8s/query-frontend-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: query-frontend
@@ -24,3 +24,6 @@ spec:
           name: grpc
         - containerPort: 80
           name: http
+  selector:
+    matchLabels:
+      name: query-frontend

--- a/k8s/retrieval-dep.yaml
+++ b/k8s/retrieval-dep.yaml
@@ -33,7 +33,7 @@ subjects:
   name: retrieval
   namespace: default
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: retrieval
@@ -60,3 +60,6 @@ spec:
         - name: config-volume
           configMap:
             name: retrieval-config
+  selector:
+    matchLabels:
+      name: retrieval

--- a/k8s/ruler-dep.yaml
+++ b/k8s/ruler-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ruler
@@ -38,3 +38,6 @@ spec:
         - -distributor.replication-factor=1
         ports:
         - containerPort: 80
+  selector:
+    matchLabels:
+      name: ruler

--- a/k8s/s3-dep.yaml
+++ b/k8s/s3-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: s3
@@ -18,3 +18,6 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 4569
+  selector:
+    matchLabels:
+      name: s3

--- a/k8s/table-manager-dep.yaml
+++ b/k8s/table-manager-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: table-manager
@@ -24,3 +24,6 @@ spec:
         - -dynamodb.chunk-table.from=2017-04-17
         ports:
         - containerPort: 80
+  selector:
+    matchLabels:
+      name: table-manager


### PR DESCRIPTION
The yaml files seems to be older and as all the services are deployemnts. 
The deployments in Kubernetes have moved from **apiVersion: extensions/v1beta1 -> apiVersion: apps/v1**  and also added the selector field as it is mandatory to the deployment spec section.
Feel free to point me out if k8s yaml files need more changes which I may have missed.

Signed-off-by: vineeth <vineethpothulapati@outlook.com>

@gouthamve @pracucci 