### PR TITLE
Copy label values to avoid unsafe memory use

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -295,6 +295,8 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 	}
 	var lastPartialErr *validationError
 
+	// NOTE: because we use `unsafe` in deserialisation, we must not
+	// retain anything from `req` past the call to ReuseSlice
 	for _, ts := range req.Timeseries {
 		for _, s := range ts.Samples {
 			err := i.append(ctx, userID, ts.Labels, model.Time(s.TimestampMs), model.SampleValue(s.Value), req.Source)
@@ -319,6 +321,8 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 	return &client.WriteResponse{}, nil
 }
 
+// NOTE: memory for `labels` is unsafe; anything retained beyond the
+// life of this function must be copied
 func (i *Ingester) append(ctx context.Context, userID string, labels labelPairs, timestamp model.Time, value model.SampleValue, source client.WriteRequest_SourceEnum) error {
 	labels.removeBlanks()
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -299,6 +299,7 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 	// retain anything from `req` past the call to ReuseSlice
 	for _, ts := range req.Timeseries {
 		for _, s := range ts.Samples {
+			// append() copies the memory in `ts.Labels`
 			err := i.append(ctx, userID, ts.Labels, model.Time(s.TimestampMs), model.SampleValue(s.Value), req.Source)
 			if err == nil {
 				continue
@@ -340,6 +341,7 @@ func (i *Ingester) append(ctx context.Context, userID string, labels labelPairs,
 	if i.stopped {
 		return fmt.Errorf("ingester stopping")
 	}
+	// getOrCreateSeries copies the memory for `labels`.
 	state, fp, series, err := i.userStates.getOrCreateSeries(ctx, userID, labels)
 	if err != nil {
 		if ve, ok := err.(*validationError); ok {

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -213,7 +213,8 @@ func (u *userState) getSeries(metric labelPairs) (model.Fingerprint, *memorySeri
 	err = u.canAddSeriesFor(string(metricName))
 	if err != nil {
 		u.fpLocker.Unlock(fp)
-		return fp, nil, makeMetricLimitError(perMetricSeriesLimit, client.FromLabelAdaptersToLabels(metric), err)
+		// note we copy `metric` as retaining a reference is unsafe.
+		return fp, nil, makeMetricLimitError(perMetricSeriesLimit, client.FromLabelAdaptersToLabelsWithCopy(metric), err)
 	}
 
 	u.memSeriesCreatedTotal.Inc()


### PR DESCRIPTION
This is an alternative solution to #2000 (and #2004) where we do more copying on the error path but need fewer comments to avoid mistakes.

Benchmarks show this alternative is significantly more expensive on the error path:
Before #2000 
```
BenchmarkIngesterPush/encoding=DoubleDelta	   20165041 ns/op  2590736 B/op	   12441 allocs/op
BenchmarkIngesterPushErrors/encoding=DoubleDelta   26534724 ns/op  5270153 B/op	   85194 allocs/op
```

After #2000 
```
BenchmarkIngesterPush/encoding=DoubleDelta	   20305149 ns/op  2591191 B/op	   12444 allocs/op
BenchmarkIngesterPushErrors/encoding=DoubleDelta   27959445 ns/op  5276005 B/op	   85189 allocs/op
```

This branch:
```
BenchmarkIngesterPush/encoding=DoubleDelta	   20074468 ns/op  2591331 B/op	   12598 allocs/op
BenchmarkIngesterPushErrors/encoding=DoubleDelta   35415601 ns/op 11072246 B/op	   95055 allocs/op
```


