### PR TITLE
Update code to fix almost all pre-existing lint errors

### DIFF
--- a/.errcheck-exclude
+++ b/.errcheck-exclude
@@ -1,3 +1,4 @@
 io/ioutil.WriteFile
 io/ioutil.ReadFile
 (github.com/go-kit/kit/log.Logger).Log
+io.Copy

--- a/.errcheck-exclude
+++ b/.errcheck-exclude
@@ -2,3 +2,4 @@ io/ioutil.WriteFile
 io/ioutil.ReadFile
 (github.com/go-kit/kit/log.Logger).Log
 io.Copy
+(github.com/opentracing/opentracing-go.Tracer).Inject

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ protos: $(PROTO_GOS)
 
 lint:
 	misspell -error docs
-	golangci-lint run --new-from-rev ed7c302fd968 --build-tags netgo --timeout=5m --enable golint --enable misspell --enable gofmt
+	golangci-lint run --build-tags netgo --timeout=5m --enable golint --enable misspell --enable gofmt
 
 	# Validate Kubernetes spec files. Requires:
 	# https://kubeval.instrumenta.dev

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -161,13 +161,13 @@ func captureOutput(t *testing.T) *capturedOutput {
 	co.wg.Add(1)
 	go func() {
 		defer co.wg.Done()
-		_, _ = io.Copy(&co.stdoutBuf, stdoutR)
+		io.Copy(&co.stdoutBuf, stdoutR)
 	}()
 
 	co.wg.Add(1)
 	go func() {
 		defer co.wg.Done()
-		_, _ = io.Copy(&co.stderrBuf, stderrR)
+		io.Copy(&co.stderrBuf, stderrR)
 	}()
 
 	return co

--- a/cmd/test-exporter/main.go
+++ b/cmd/test-exporter/main.go
@@ -52,5 +52,6 @@ func main() {
 	}))
 
 	prometheus.MustRegister(runner)
-	server.Run()
+	err = server.Run()
+	util.CheckFatal("running server", err)
 }

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -78,6 +78,7 @@ func init() {
 			// from disk, we just ignore web-based reload signals. Config updates are
 			// only applied externally via ApplyConfig().
 			case <-webReload:
+			default:
 			}
 		}
 	}()
@@ -176,7 +177,7 @@ func clusterWait(p *cluster.Peer, timeout time.Duration) func() time.Duration {
 
 // ApplyConfig applies a new configuration to an Alertmanager.
 func (am *Alertmanager) ApplyConfig(userID string, conf *config.Config) error {
-	templateFiles := make([]string, len(conf.Templates), len(conf.Templates))
+	templateFiles := make([]string, len(conf.Templates))
 	if len(conf.Templates) > 0 {
 		for i, t := range conf.Templates {
 			templateFiles[i] = filepath.Join(am.cfg.DataDir, "templates", userID, t)

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -79,6 +79,7 @@ func init() {
 			// only applied externally via ApplyConfig().
 			case <-webReload:
 			default:
+				continue
 			}
 		}
 	}()

--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -245,7 +245,7 @@ func (a dynamoDBStorageClient) BatchWrite(ctx context.Context, input chunk.Write
 			if awsErr, ok := err.(awserr.Error); ok && ((awsErr.Code() == dynamodb.ErrCodeProvisionedThroughputExceededException) || request.Retryable()) {
 				logWriteRetry(ctx, requests)
 				unprocessed.TakeReqs(requests, -1)
-				a.writeThrottle.WaitN(ctx, len(requests))
+				_ = a.writeThrottle.WaitN(ctx, len(requests))
 				backoff.Wait()
 				continue
 			} else if ok && awsErr.Code() == validationException {
@@ -269,7 +269,7 @@ func (a dynamoDBStorageClient) BatchWrite(ctx context.Context, input chunk.Write
 		unprocessedItems := dynamoDBWriteBatch(resp.UnprocessedItems)
 		if len(unprocessedItems) > 0 {
 			logWriteRetry(ctx, unprocessedItems)
-			a.writeThrottle.WaitN(ctx, unprocessedItems.Len())
+			_ = a.writeThrottle.WaitN(ctx, unprocessedItems.Len())
 			unprocessed.TakeReqs(unprocessedItems, -1)
 		}
 

--- a/pkg/chunk/aws/dynamodb_storage_client_test.go
+++ b/pkg/chunk/aws/dynamodb_storage_client_test.go
@@ -17,10 +17,8 @@ const (
 
 func TestChunksPartialError(t *testing.T) {
 	fixture := dynamoDBFixture(0, 10, 20)
-	defer func() {
-		err := fixture.Teardown()
-		require.NoError(t, err)
-	}()
+	defer require.NoError(t, fixture.Teardown())
+
 	_, client, err := testutils.Setup(fixture, tableName)
 	require.NoError(t, err)
 

--- a/pkg/chunk/aws/dynamodb_storage_client_test.go
+++ b/pkg/chunk/aws/dynamodb_storage_client_test.go
@@ -17,7 +17,10 @@ const (
 
 func TestChunksPartialError(t *testing.T) {
 	fixture := dynamoDBFixture(0, 10, 20)
-	defer fixture.Teardown()
+	defer func() {
+		err := fixture.Teardown()
+		require.NoError(t, err)
+	}()
 	_, client, err := testutils.Setup(fixture, tableName)
 	require.NoError(t, err)
 

--- a/pkg/chunk/aws/dynamodb_storage_client_test.go
+++ b/pkg/chunk/aws/dynamodb_storage_client_test.go
@@ -17,7 +17,7 @@ const (
 
 func TestChunksPartialError(t *testing.T) {
 	fixture := dynamoDBFixture(0, 10, 20)
-	defer require.NoError(t, fixture.Teardown())
+	defer testutils.TeardownFixture(t, fixture)
 
 	_, client, err := testutils.Setup(fixture, tableName)
 	require.NoError(t, err)

--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -80,7 +80,7 @@ func (d dynamoTableClient) backoffAndRetry(ctx context.Context, fn func(context.
 
 func (d callManager) backoffAndRetry(ctx context.Context, fn func(context.Context) error) error {
 	if d.limiter != nil { // Tests will have a nil limiter.
-		d.limiter.Wait(ctx)
+		_ = d.limiter.Wait(ctx)
 	}
 
 	backoff := util.NewBackoff(ctx, d.backoffConfig)

--- a/pkg/chunk/aws/mock.go
+++ b/pkg/chunk/aws/mock.go
@@ -56,6 +56,7 @@ func (a dynamoDBStorageClient) setErrorParameters(provisionedErr, errAfter int) 
 	}
 }
 
+//nolint:unused //Leaving this around in the case we need to create a table via mock this is useful.
 func (m *mockDynamoDBClient) createTable(name string) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()

--- a/pkg/chunk/cache/fifo_cache.go
+++ b/pkg/chunk/cache/fifo_cache.go
@@ -228,7 +228,7 @@ func (c *FifoCache) Get(ctx context.Context, key string) (interface{}, bool) {
 	index, ok := c.index[key]
 	if ok {
 		updated := c.entries[index].updated
-		if c.validity == 0 || time.Now().Sub(updated) < c.validity {
+		if c.validity == 0 || time.Since(updated) < c.validity {
 			return c.entries[index].value, true
 		}
 

--- a/pkg/chunk/cache/fifo_cache_test.go
+++ b/pkg/chunk/cache/fifo_cache_test.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -87,11 +86,4 @@ func TestFifoCacheExpiry(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 	_, ok = c.Get(ctx, strconv.Itoa(0))
 	require.False(t, ok)
-}
-
-func (c *FifoCache) print() {
-	fmt.Println("first", c.first, "last", c.last)
-	for i, entry := range c.entries {
-		fmt.Printf("  %d -> key: %s, value: %v, next: %d, prev: %d\n", i, entry.key, entry.value, entry.next, entry.prev)
-	}
 }

--- a/pkg/chunk/cache/instrumented.go
+++ b/pkg/chunk/cache/instrumented.go
@@ -75,7 +75,7 @@ func (i *instrumentedCache) Store(ctx context.Context, keys []string, bufs [][]b
 	}
 
 	method := i.name + ".store"
-	instr.CollectedRequest(ctx, method, requestDuration, instr.ErrorCode, func(ctx context.Context) error {
+	_ = instr.CollectedRequest(ctx, method, requestDuration, instr.ErrorCode, func(ctx context.Context) error {
 		sp := ot.SpanFromContext(ctx)
 		sp.LogFields(otlog.Int("keys", len(keys)))
 		i.Cache.Store(ctx, keys, bufs)
@@ -91,7 +91,7 @@ func (i *instrumentedCache) Fetch(ctx context.Context, keys []string) ([]string,
 		method  = i.name + ".fetch"
 	)
 
-	instr.CollectedRequest(ctx, method, requestDuration, instr.ErrorCode, func(ctx context.Context) error {
+	_ = instr.CollectedRequest(ctx, method, requestDuration, instr.ErrorCode, func(ctx context.Context) error {
 		sp := ot.SpanFromContext(ctx)
 		sp.LogFields(otlog.Int("keys requested", len(keys)))
 

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -135,7 +135,7 @@ func memcacheStatusCode(err error) string {
 
 // Fetch gets keys from the cache. The keys that are found must be in the order of the keys requested.
 func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missed []string) {
-	instr.CollectedRequest(ctx, "Memcache.Get", c.requestDuration, memcacheStatusCode, func(ctx context.Context) error {
+	_ = instr.CollectedRequest(ctx, "Memcache.Get", c.requestDuration, memcacheStatusCode, func(ctx context.Context) error {
 		if c.cfg.BatchSize == 0 {
 			found, bufs, missed = c.fetch(ctx, keys)
 			return nil
@@ -149,7 +149,7 @@ func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, b
 
 func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missed []string) {
 	var items map[string]*memcache.Item
-	instr.CollectedRequest(ctx, "Memcache.GetMulti", c.requestDuration, memcacheStatusCode, func(_ context.Context) error {
+	_ = instr.CollectedRequest(ctx, "Memcache.GetMulti", c.requestDuration, memcacheStatusCode, func(_ context.Context) error {
 		sp := opentracing.SpanFromContext(ctx)
 		sp.LogFields(otlog.Int("keys requested", len(keys)))
 
@@ -248,7 +248,7 @@ func (c *Memcached) Stop() {
 // HashKey hashes key into something you can store in memcached.
 func HashKey(key string) string {
 	hasher := fnv.New64a()
-	hasher.Write([]byte(key)) // This'll never error.
+	_, _ = hasher.Write([]byte(key)) // This'll never error.
 
 	// Hex because memcache errors for the bytes produced by the hash.
 	return hex.EncodeToString(hasher.Sum(nil))

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -36,7 +36,7 @@ type observableVecCollector struct {
 func (observableVecCollector) Register()                             {}
 func (observableVecCollector) Before(method string, start time.Time) {}
 func (o observableVecCollector) After(method, statusCode string, start time.Time) {
-	o.v.WithLabelValues(method, statusCode).Observe(time.Now().Sub(start).Seconds())
+	o.v.WithLabelValues(method, statusCode).Observe(time.Since(start).Seconds())
 }
 
 // MemcachedConfig is config to make a Memcached

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -149,7 +149,7 @@ func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, b
 
 func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missed []string) {
 	var items map[string]*memcache.Item
-	_ = instr.CollectedRequest(ctx, "Memcache.GetMulti", c.requestDuration, memcacheStatusCode, func(_ context.Context) error {
+	err := instr.CollectedRequest(ctx, "Memcache.GetMulti", c.requestDuration, memcacheStatusCode, func(_ context.Context) error {
 		sp := opentracing.SpanFromContext(ctx)
 		sp.LogFields(otlog.Int("keys requested", len(keys)))
 
@@ -165,6 +165,10 @@ func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, b
 		}
 		return err
 	})
+
+	if err != nil {
+		return found, bufs, keys
+	}
 
 	for _, key := range keys {
 		item, ok := items[key]

--- a/pkg/chunk/cache/redis_cache_test.go
+++ b/pkg/chunk/cache/redis_cache_test.go
@@ -19,9 +19,9 @@ func TestRedisCache(t *testing.T) {
 
 	conn := redigomock.NewConn()
 	conn.Clear()
-	pool := redis.NewPool(func() (redis.Conn, error) {
+	pool := &redis.Pool{Dial: func() (redis.Conn, error) {
 		return conn, nil
-	}, 10)
+	}, MaxIdle: 10}
 
 	keys := []string{"key1", "key2", "key3"}
 	bufs := [][]byte{[]byte("data1"), []byte("data2"), []byte("data3")}

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -294,7 +294,6 @@ func (s *StorageClient) query(ctx context.Context, query chunk.IndexQuery, callb
 
 // readBatch represents a batch of rows read from Cassandra.
 type readBatch struct {
-	consumed   bool
 	rangeValue []byte
 	value      []byte
 }

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -125,7 +125,7 @@ func (c *store) PutOne(ctx context.Context, from, through model.Time, chunk Chun
 		return err
 	}
 
-	c.writeBackCache(ctx, chunks)
+	_ = c.writeBackCache(ctx, chunks)
 
 	writeReqs, err := c.calculateIndexEntries(chunk.UserID, from, through, chunk)
 	if err != nil {

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -255,7 +255,8 @@ func (c *store) LabelNamesForMetricName(ctx context.Context, userID string, from
 }
 
 func (c *store) validateQueryTimeRange(ctx context.Context, userID string, from *model.Time, through *model.Time) (bool, error) {
-	log, _ := spanlogger.New(ctx, "store.validateQueryTimeRange")
+	//nolint:ineffassign,staticcheck //Leaving ctx even though we don't currently use it, we want to make it available for when we might need it and hopefully will ensure us using the correct context at that time
+	log, ctx := spanlogger.New(ctx, "store.validateQueryTimeRange")
 	defer log.Span.Finish()
 
 	if *through < *from {

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -252,7 +252,7 @@ func (c *store) LabelNamesForMetricName(ctx context.Context, userID string, from
 }
 
 func (c *store) validateQueryTimeRange(ctx context.Context, userID string, from *model.Time, through *model.Time) (bool, error) {
-	log, ctx := spanlogger.New(ctx, "store.validateQueryTimeRange")
+	log, _ := spanlogger.New(ctx, "store.validateQueryTimeRange")
 	defer log.Span.Finish()
 
 	if *through < *from {

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -711,7 +711,8 @@ func BenchmarkIndexCaching(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		store.Put(ctx, []Chunk{fooChunk1})
+		err := store.Put(ctx, []Chunk{fooChunk1})
+		require.NoError(b, err)
 	}
 }
 

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -814,7 +814,7 @@ func TestStoreMaxLookBack(t *testing.T) {
 	chunks, err = storeWithLookBackLimit.Get(ctx, userID, now.Add(-time.Hour), now, matchers...)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(chunks))
-	chunks[0].Through.Equal(now)
+	require.Equal(t, now, chunks[0].Through)
 }
 
 func benchmarkParseIndexEntries(i int64, b *testing.B) {

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -268,7 +268,8 @@ func BenchmarkEncode(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		chunk.encoded = nil
-		chunk.Encode()
+		err := chunk.Encode()
+		require.NoError(b, err)
 	}
 }
 

--- a/pkg/chunk/composite_store_test.go
+++ b/pkg/chunk/composite_store_test.go
@@ -3,9 +3,10 @@ package chunk
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"

--- a/pkg/chunk/composite_store_test.go
+++ b/pkg/chunk/composite_store_test.go
@@ -180,7 +180,10 @@ func TestCompositeStore(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			have := []result{}
-			tc.cs.forStores(model.TimeFromUnix(tc.from), model.TimeFromUnix(tc.through), collect(&have))
+			err := tc.cs.forStores(model.TimeFromUnix(tc.from), model.TimeFromUnix(tc.through), collect(&have))
+			if err != nil {
+				t.Fatal(err)
+			}
 			if !reflect.DeepEqual(tc.want, have) {
 				t.Fatalf("wrong stores - %s", test.Diff(tc.want, have))
 			}

--- a/pkg/chunk/composite_store_test.go
+++ b/pkg/chunk/composite_store_test.go
@@ -3,6 +3,7 @@ package chunk
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
 
@@ -181,9 +182,7 @@ func TestCompositeStore(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			have := []result{}
 			err := tc.cs.forStores(model.TimeFromUnix(tc.from), model.TimeFromUnix(tc.through), collect(&have))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			if !reflect.DeepEqual(tc.want, have) {
 				t.Fatalf("wrong stores - %s", test.Diff(tc.want, have))
 			}
@@ -234,16 +233,12 @@ func TestCompositeStoreLabels(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			have, err := cs.LabelNamesForMetricName(context.Background(), "", model.TimeFromUnix(tc.from), model.TimeFromUnix(tc.through), "")
-			if err != nil {
-				t.Fatalf("err - %s", err)
-			}
+			require.NoError(t, err)
 			if !reflect.DeepEqual(tc.want, have) {
 				t.Fatalf("wrong label names - %s", test.Diff(tc.want, have))
 			}
 			have, err = cs.LabelValuesForMetricName(context.Background(), "", model.TimeFromUnix(tc.from), model.TimeFromUnix(tc.through), "", "")
-			if err != nil {
-				t.Fatalf("err - %s", err)
-			}
+			require.NoError(t, err)
 			if !reflect.DeepEqual(tc.want, have) {
 				t.Fatalf("wrong label values - %s", test.Diff(tc.want, have))
 			}

--- a/pkg/chunk/encoding/bigchunk_test.go
+++ b/pkg/chunk/encoding/bigchunk_test.go
@@ -84,7 +84,7 @@ func BenchmarkBiggerChunkMemory(b *testing.B) {
 // printSize calculates various sizes of the chunk when encoded, and in memory.
 func (b *bigchunk) printSize() {
 	var buf bytes.Buffer
-	b.Marshal(&buf)
+	_ = b.Marshal(&buf)
 
 	var size, allocd int
 	for _, c := range b.chunks {

--- a/pkg/chunk/encoding/chunk_test.go
+++ b/pkg/chunk/encoding/chunk_test.go
@@ -117,6 +117,8 @@ func testChunkEncoding(t *testing.T, encoding Encoding, samples int) {
 
 	bs1 := buf.Bytes()
 	chunk, err = NewForEncoding(encoding)
+	require.NoError(t, err)
+
 	err = chunk.UnmarshalFromBuf(bs1)
 	require.NoError(t, err)
 

--- a/pkg/chunk/encoding/varbit.go
+++ b/pkg/chunk/encoding/varbit.go
@@ -13,7 +13,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//nolint //Since this was copied from Prometheus leave it as is
 package encoding
 
 import (

--- a/pkg/chunk/encoding/varbit_helpers.go
+++ b/pkg/chunk/encoding/varbit_helpers.go
@@ -13,7 +13,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//nolint //Since this was copied from Prometheus leave it as is
 package encoding
 
 import "github.com/prometheus/common/model"

--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -60,8 +60,6 @@ type storageClientColumnKey struct {
 	schemaCfg chunk.SchemaConfig
 	client    *bigtable.Client
 	keysFn    keysFn
-
-	distributeKeys bool
 }
 
 // storageClientV1 implements chunk.storageClient for GCP.

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -323,7 +323,7 @@ func (cfg *SchemaConfig) Load() error {
 // PrintYaml dumps the yaml to stdout, to aid in migration
 func (cfg SchemaConfig) PrintYaml() {
 	encoder := yaml.NewEncoder(os.Stdout)
-	encoder.Encode(cfg)
+	_ = encoder.Encode(cfg)
 }
 
 // Bucket describes a range of time with a tableName and hashKey

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -320,12 +320,6 @@ func (cfg *SchemaConfig) Load() error {
 	return cfg.Validate()
 }
 
-// PrintYaml dumps the yaml to stdout, to aid in migration
-func (cfg SchemaConfig) PrintYaml() {
-	encoder := yaml.NewEncoder(os.Stdout)
-	_ = encoder.Encode(cfg)
-}
-
 // Bucket describes a range of time with a tableName and hashKey
 type Bucket struct {
 	from       uint32

--- a/pkg/chunk/schema_util.go
+++ b/pkg/chunk/schema_util.go
@@ -132,7 +132,7 @@ func encodeTime(t uint32) []byte {
 
 func decodeTime(bs []byte) uint32 {
 	buf := make([]byte, 4)
-	hex.Decode(buf, bs)
+	_, _ = hex.Decode(buf, bs)
 	return binary.BigEndian.Uint32(buf)
 }
 

--- a/pkg/chunk/schema_util.go
+++ b/pkg/chunk/schema_util.go
@@ -130,12 +130,6 @@ func encodeTime(t uint32) []byte {
 	return encodedThroughBytes
 }
 
-func decodeTime(bs []byte) uint32 {
-	buf := make([]byte, 4)
-	_, _ = hex.Decode(buf, bs)
-	return binary.BigEndian.Uint32(buf)
-}
-
 // parseMetricNameRangeValue returns the metric name stored in metric name
 // range values. Currently checks range value key and returns the value as the
 // metric name.

--- a/pkg/chunk/schema_util.go
+++ b/pkg/chunk/schema_util.go
@@ -63,7 +63,7 @@ func buildRangeValue(extra int, ss ...[]byte) []byte {
 	for _, s := range ss {
 		length += len(s) + 1
 	}
-	output, i := make([]byte, length, length), 0
+	output, i := make([]byte, length), 0
 	for _, s := range ss {
 		i += copy(output[i:], s) + 1
 	}
@@ -99,21 +99,21 @@ func decodeRangeKey(value []byte) [][]byte {
 
 func encodeBase64Bytes(bytes []byte) []byte {
 	encodedLen := base64.RawStdEncoding.EncodedLen(len(bytes))
-	encoded := make([]byte, encodedLen, encodedLen)
+	encoded := make([]byte, encodedLen)
 	base64.RawStdEncoding.Encode(encoded, bytes)
 	return encoded
 }
 
 func encodeBase64Value(value string) []byte {
 	encodedLen := base64.RawStdEncoding.EncodedLen(len(value))
-	encoded := make([]byte, encodedLen, encodedLen)
+	encoded := make([]byte, encodedLen)
 	base64.RawStdEncoding.Encode(encoded, []byte(value))
 	return encoded
 }
 
 func decodeBase64Value(bs []byte) (model.LabelValue, error) {
 	decodedLen := base64.RawStdEncoding.DecodedLen(len(bs))
-	decoded := make([]byte, decodedLen, decodedLen)
+	decoded := make([]byte, decodedLen)
 	if _, err := base64.RawStdEncoding.Decode(decoded, bs); err != nil {
 		return "", err
 	}
@@ -123,15 +123,15 @@ func decodeBase64Value(bs []byte) (model.LabelValue, error) {
 func encodeTime(t uint32) []byte {
 	// timestamps are hex encoded such that it doesn't contain null byte,
 	// but is still lexicographically sortable.
-	throughBytes := make([]byte, 4, 4)
+	throughBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(throughBytes, t)
-	encodedThroughBytes := make([]byte, 8, 8)
+	encodedThroughBytes := make([]byte, 8)
 	hex.Encode(encodedThroughBytes, throughBytes)
 	return encodedThroughBytes
 }
 
 func decodeTime(bs []byte) uint32 {
-	buf := make([]byte, 4, 4)
+	buf := make([]byte, 4)
 	hex.Decode(buf, bs)
 	return binary.BigEndian.Uint32(buf)
 }

--- a/pkg/chunk/schema_util_test.go
+++ b/pkg/chunk/schema_util_test.go
@@ -3,6 +3,7 @@ package chunk
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"math"
 	"math/rand"
@@ -139,4 +140,10 @@ func TestParseSeriesRangeValue(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, c.expMetric, metric)
 	}
+}
+
+func decodeTime(bs []byte) uint32 {
+	buf := make([]byte, 4)
+	_, _ = hex.Decode(buf, bs)
+	return binary.BigEndian.Uint32(buf)
 }

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -457,6 +457,7 @@ func (c *seriesStore) Put(ctx context.Context, chunks []Chunk) error {
 
 // PutOne implements ChunkStore
 func (c *seriesStore) PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error {
+	log, ctx := spanlogger.New(ctx, "SeriesStore.PutOne")
 	// If this chunk is in cache it must already be in the database so we don't need to write it again
 	found, _, _ := c.cache.Fetch(ctx, []string{chunk.ExternalKey()})
 	if len(found) > 0 {
@@ -483,7 +484,9 @@ func (c *seriesStore) PutOne(ctx context.Context, from, through model.Time, chun
 			return err
 		}
 	}
-	_ = c.writeBackCache(ctx, chunks)
+	if cacheErr := c.writeBackCache(ctx, chunks); cacheErr != nil {
+		level.Warn(log).Log("msg", "could not store chunks in chunk cache", "err", cacheErr)
+	}
 
 	bufs := make([][]byte, len(keysToCache))
 	c.writeDedupeCache.Store(ctx, keysToCache, bufs)

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -483,7 +483,7 @@ func (c *seriesStore) PutOne(ctx context.Context, from, through model.Time, chun
 			return err
 		}
 	}
-	c.writeBackCache(ctx, chunks)
+	_ = c.writeBackCache(ctx, chunks)
 
 	bufs := make([][]byte, len(keysToCache))
 	c.writeDedupeCache.Store(ctx, keysToCache, bufs)

--- a/pkg/chunk/storage/utils_test.go
+++ b/pkg/chunk/storage/utils_test.go
@@ -35,7 +35,10 @@ func forAllFixtures(t *testing.T, storageClientTest storageClientTest) {
 		t.Run(fixture.Name(), func(t *testing.T) {
 			indexClient, objectClient, err := testutils.Setup(fixture, tableName)
 			require.NoError(t, err)
-			defer fixture.Teardown() //nolint:errcheck
+			defer func() {
+				err = fixture.Teardown()
+				require.NoError(t, err)
+			}()
 
 			storageClientTest(t, indexClient, objectClient)
 		})

--- a/pkg/chunk/storage/utils_test.go
+++ b/pkg/chunk/storage/utils_test.go
@@ -35,10 +35,7 @@ func forAllFixtures(t *testing.T, storageClientTest storageClientTest) {
 		t.Run(fixture.Name(), func(t *testing.T) {
 			indexClient, objectClient, err := testutils.Setup(fixture, tableName)
 			require.NoError(t, err)
-			defer func() {
-				err = fixture.Teardown()
-				require.NoError(t, err)
-			}()
+			defer require.NoError(t, fixture.Teardown())
 
 			storageClientTest(t, indexClient, objectClient)
 		})

--- a/pkg/chunk/storage/utils_test.go
+++ b/pkg/chunk/storage/utils_test.go
@@ -35,7 +35,7 @@ func forAllFixtures(t *testing.T, storageClientTest storageClientTest) {
 		t.Run(fixture.Name(), func(t *testing.T) {
 			indexClient, objectClient, err := testutils.Setup(fixture, tableName)
 			require.NoError(t, err)
-			defer fixture.Teardown()
+			defer fixture.Teardown() //nolint:errcheck
 
 			storageClientTest(t, indexClient, objectClient)
 		})

--- a/pkg/chunk/storage/utils_test.go
+++ b/pkg/chunk/storage/utils_test.go
@@ -35,7 +35,7 @@ func forAllFixtures(t *testing.T, storageClientTest storageClientTest) {
 		t.Run(fixture.Name(), func(t *testing.T) {
 			indexClient, objectClient, err := testutils.Setup(fixture, tableName)
 			require.NoError(t, err)
-			defer require.NoError(t, fixture.Teardown())
+			defer testutils.TeardownFixture(t, fixture)
 
 			storageClientTest(t, indexClient, objectClient)
 		})

--- a/pkg/chunk/strings.go
+++ b/pkg/chunk/strings.go
@@ -41,6 +41,7 @@ func intersectStrings(left, right []string) []string {
 	return result
 }
 
+//nolint:unused //Ignoring linting as this might be useful
 func nWayIntersectStrings(sets [][]string) []string {
 	l := len(sets)
 	switch l {

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -679,8 +679,12 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 	// Verify that without RetentionDeletesEnabled no tables are removed
 	tableManager.cfg.RetentionDeletesEnabled = false
 	// Retention > 0 will prevent older tables from being created so we need to create the old tables manually for the test
-	client.CreateTable(nil, TableDesc{Name: tablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite, WriteScale: inactiveScalingConfig})
-	client.CreateTable(nil, TableDesc{Name: chunkTablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite})
+	err = client.CreateTable(nil, TableDesc{Name: tablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite, WriteScale: inactiveScalingConfig})
+	require.NoError(t, err)
+
+	err = client.CreateTable(nil, TableDesc{Name: chunkTablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite})
+	require.NoError(t, err)
+
 	tmTest(t, client, tableManager,
 		"Move forward by three table periods (no deletes)",
 		baseTableStart.Add(tablePeriod*3),
@@ -703,8 +707,12 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 	tableManager.cfg.RetentionPeriod = 0
 	tableManager.schemaCfg.Configs[0].From = DayTime{model.TimeFromUnix(baseTableStart.Add(tablePeriod).Unix())}
 	// Retention > 0 will prevent older tables from being created so we need to create the old tables manually for the test
-	client.CreateTable(nil, TableDesc{Name: tablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite, WriteScale: inactiveScalingConfig})
-	client.CreateTable(nil, TableDesc{Name: chunkTablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite})
+	err = client.CreateTable(nil, TableDesc{Name: tablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite, WriteScale: inactiveScalingConfig})
+	require.NoError(t, err)
+
+	err = client.CreateTable(nil, TableDesc{Name: chunkTablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite})
+	require.NoError(t, err)
+
 	tmTest(t, client, tableManager,
 		"Move forward by three table periods (no deletes) and move From one table forward",
 		baseTableStart.Add(tablePeriod*3),

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -679,10 +679,10 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 	// Verify that without RetentionDeletesEnabled no tables are removed
 	tableManager.cfg.RetentionDeletesEnabled = false
 	// Retention > 0 will prevent older tables from being created so we need to create the old tables manually for the test
-	err = client.CreateTable(nil, TableDesc{Name: tablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite, WriteScale: inactiveScalingConfig})
+	err = client.CreateTable(context.Background(), TableDesc{Name: tablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite, WriteScale: inactiveScalingConfig})
 	require.NoError(t, err)
 
-	err = client.CreateTable(nil, TableDesc{Name: chunkTablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite})
+	err = client.CreateTable(context.Background(), TableDesc{Name: chunkTablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite})
 	require.NoError(t, err)
 
 	tmTest(t, client, tableManager,
@@ -707,10 +707,10 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 	tableManager.cfg.RetentionPeriod = 0
 	tableManager.schemaCfg.Configs[0].From = DayTime{model.TimeFromUnix(baseTableStart.Add(tablePeriod).Unix())}
 	// Retention > 0 will prevent older tables from being created so we need to create the old tables manually for the test
-	err = client.CreateTable(nil, TableDesc{Name: tablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite, WriteScale: inactiveScalingConfig})
+	err = client.CreateTable(context.Background(), TableDesc{Name: tablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite, WriteScale: inactiveScalingConfig})
 	require.NoError(t, err)
 
-	err = client.CreateTable(nil, TableDesc{Name: chunkTablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite})
+	err = client.CreateTable(context.Background(), TableDesc{Name: chunkTablePrefix + "0", ProvisionedRead: inactiveRead, ProvisionedWrite: inactiveWrite})
 	require.NoError(t, err)
 
 	tmTest(t, client, tableManager,

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -2,10 +2,11 @@ package testutils
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -2,7 +2,9 @@ package testutils
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"strconv"
+	"testing"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -93,4 +95,8 @@ func dummyChunkFor(now model.Time, metric labels.Labels) chunk.Chunk {
 		panic(err)
 	}
 	return chunk
+}
+
+func TeardownFixture(t *testing.T, fixture Fixture) {
+	require.NoError(t, fixture.Teardown())
 }

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -75,7 +75,10 @@ func CreateChunks(startIndex, batchSize int, start model.Time) ([]string, []chun
 
 func dummyChunkFor(now model.Time, metric labels.Labels) chunk.Chunk {
 	cs := promchunk.New()
-	cs.Add(model.SamplePair{Timestamp: now, Value: 0})
+	_, err := cs.Add(model.SamplePair{Timestamp: now, Value: 0})
+	if err != nil {
+		panic(err)
+	}
 	chunk := chunk.NewChunk(
 		userID,
 		client.Fingerprint(metric),
@@ -85,7 +88,7 @@ func dummyChunkFor(now model.Time, metric labels.Labels) chunk.Chunk {
 		now,
 	)
 	// Force checksum calculation.
-	err := chunk.Encode()
+	err = chunk.Encode()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/configs/api/helpers_test.go
+++ b/pkg/configs/api/helpers_test.go
@@ -51,7 +51,8 @@ func requestAsUser(t *testing.T, userID string, method, urlStr string, body io.R
 	r, err := http.NewRequest(method, urlStr, body)
 	require.NoError(t, err)
 	r = r.WithContext(user.InjectOrgID(r.Context(), userID))
-	user.InjectOrgIDIntoHTTPRequest(r.Context(), r)
+	err = user.InjectOrgIDIntoHTTPRequest(r.Context(), r)
+	require.NoError(t, err)
 	app.ServeHTTP(w, r)
 	return w
 }

--- a/pkg/configs/db/timed.go
+++ b/pkg/configs/db/timed.go
@@ -48,7 +48,7 @@ func (t timed) GetAllConfigs(ctx context.Context) (map[string]configs.View, erro
 		cfgs map[string]configs.View
 		err  error
 	)
-	instrument.CollectedRequest(ctx, "DB.GetAllConfigs", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+	_ = instrument.CollectedRequest(ctx, "DB.GetAllConfigs", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 		cfgs, err = t.d.GetAllConfigs(ctx)
 		return err
 	})

--- a/pkg/configs/db/timed.go
+++ b/pkg/configs/db/timed.go
@@ -44,11 +44,9 @@ func (t timed) SetConfig(ctx context.Context, userID string, cfg configs.Config)
 }
 
 func (t timed) GetAllConfigs(ctx context.Context) (map[string]configs.View, error) {
-	var (
-		cfgs map[string]configs.View
-		err  error
-	)
-	_ = instrument.CollectedRequest(ctx, "DB.GetAllConfigs", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+	var cfgs map[string]configs.View
+	err := instrument.CollectedRequest(ctx, "DB.GetAllConfigs", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+		var err error
 		cfgs, err = t.d.GetAllConfigs(ctx)
 		return err
 	})
@@ -57,9 +55,7 @@ func (t timed) GetAllConfigs(ctx context.Context) (map[string]configs.View, erro
 }
 
 func (t timed) GetConfigs(ctx context.Context, since configs.ID) (map[string]configs.View, error) {
-	var (
-		cfgs map[string]configs.View
-	)
+	var cfgs map[string]configs.View
 	err := instrument.CollectedRequest(ctx, "DB.GetConfigs", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 		var err error
 		cfgs, err = t.d.GetConfigs(ctx, since)

--- a/pkg/configs/db/timed.go
+++ b/pkg/configs/db/timed.go
@@ -27,15 +27,6 @@ type timed struct {
 	d DB
 }
 
-func (t timed) errorCode(err error) string {
-	switch err {
-	case nil:
-		return "200"
-	default:
-		return "500"
-	}
-}
-
 func (t timed) GetConfig(ctx context.Context, userID string) (configs.View, error) {
 	var cfg configs.View
 	err := instrument.CollectedRequest(ctx, "DB.GetConfigs", databaseRequestDuration, instrument.ErrorCode, func(ctx context.Context) error {

--- a/pkg/configs/legacy_promql/ast.go
+++ b/pkg/configs/legacy_promql/ast.go
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//nolint //Since this was copied from Prometheus leave it as is
 package promql
 
 import (

--- a/pkg/configs/legacy_promql/engine.go
+++ b/pkg/configs/legacy_promql/engine.go
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//nolint //Since this was copied from Prometheus leave it as is
 package promql
 
 import (

--- a/pkg/configs/legacy_promql/functions_test.go
+++ b/pkg/configs/legacy_promql/functions_test.go
@@ -35,8 +35,11 @@ func TestDeriv(t *testing.T) {
 	testutil.Ok(t, err)
 
 	metric := labels.FromStrings("__name__", "foo")
-	a.Add(metric, 1493712816939, 1.0)
-	a.Add(metric, 1493712846939, 1.0)
+	_, err = a.Add(metric, 1493712816939, 1.0)
+	testutil.Ok(t, err)
+
+	_, err = a.Add(metric, 1493712846939, 1.0)
+	testutil.Ok(t, err)
 
 	err = a.Commit()
 	testutil.Ok(t, err)

--- a/pkg/configs/legacy_promql/parse.go
+++ b/pkg/configs/legacy_promql/parse.go
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//nolint //Since this was copied from Prometheus leave it as is
 package promql
 
 import (

--- a/pkg/configs/legacy_promql/test.go
+++ b/pkg/configs/legacy_promql/test.go
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//nolint //Since this was copied from Prometheus leave it as is
 package promql
 
 import (

--- a/pkg/distributor/billing.go
+++ b/pkg/distributor/billing.go
@@ -22,7 +22,7 @@ func (d *Distributor) emitBillingRecord(ctx context.Context, buf []byte, samples
 
 	now := time.Now().UTC()
 	hasher := sha256.New()
-	hasher.Write(buf)
+	_, _ = hasher.Write(buf)
 	hash := "sha256:" + base64.URLEncoding.EncodeToString(hasher.Sum(nil))
 	amounts := billing.Amounts{
 		billing.Samples: samples,

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -397,16 +397,6 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 			continue
 		}
 
-		metricName, _ := extract.MetricNameFromLabelAdapters(ts.Labels)
-		samples := make([]client.Sample, 0, len(ts.Samples))
-		for _, s := range ts.Samples {
-			if err := validation.ValidateSample(d.limits, userID, metricName, s); err != nil {
-				lastPartialErr = err
-				continue
-			}
-			samples = append(samples, s)
-		}
-
 		keys = append(keys, key)
 		validatedTimeseries = append(validatedTimeseries, validatedSeries)
 		validatedSamples += len(ts.Samples)

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -196,6 +196,7 @@ func TestCheckReplicaMultiCluster(t *testing.T) {
 		UpdateTimeoutJitterMax: 0,
 		FailoverTimeout:        time.Second,
 	})
+	assert.NoError(t, err)
 
 	// Write the first time.
 	err = c.checkReplica(context.Background(), "user", "c1", replica1)

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -136,7 +136,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 			ingesterQueryFailures.WithLabelValues(ing.Addr).Inc()
 			return nil, err
 		}
-		defer stream.CloseSend()
+		defer stream.CloseSend() //nolint:errcheck
 
 		var result []*ingester_client.QueryStreamResponse
 		for {

--- a/pkg/ingester/client/pool_test.go
+++ b/pkg/ingester/client/pool_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/gogo/status"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/ring"
 )

--- a/pkg/ingester/client/pool_test.go
+++ b/pkg/ingester/client/pool_test.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"context"
-	"fmt"
+	fmt "fmt"
 	"testing"
 	"time"
 
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/ring"
 )
@@ -81,17 +82,20 @@ func TestIngesterCache(t *testing.T) {
 	}, mockReadRing{}, factory, log.NewNopLogger())
 	defer pool.Stop()
 
-	pool.GetClientFor("1")
+	_, err := pool.GetClientFor("1")
+	require.NoError(t, err)
 	if buildCount != 1 {
 		t.Errorf("Did not create client")
 	}
 
-	pool.GetClientFor("1")
+	_, err = pool.GetClientFor("1")
+	require.NoError(t, err)
 	if buildCount != 1 {
 		t.Errorf("Created client that should have been cached")
 	}
 
-	pool.GetClientFor("2")
+	_, err = pool.GetClientFor("2")
+	require.NoError(t, err)
 	if pool.Count() != 2 {
 		t.Errorf("Expected Count() = 2, got %d", pool.Count())
 	}
@@ -101,12 +105,13 @@ func TestIngesterCache(t *testing.T) {
 		t.Errorf("Expected Count() = 1, got %d", pool.Count())
 	}
 
-	pool.GetClientFor("1")
+	_, err = pool.GetClientFor("1")
+	require.NoError(t, err)
 	if buildCount != 3 || pool.Count() != 2 {
 		t.Errorf("Did not re-create client correctly")
 	}
 
-	_, err := pool.GetClientFor("bad")
+	_, err = pool.GetClientFor("bad")
 	if err == nil {
 		t.Errorf("Bad create should have thrown an error")
 	}

--- a/pkg/ingester/client/timeseries.go
+++ b/pkg/ingester/client/timeseries.go
@@ -265,7 +265,7 @@ func ReuseSlice(slice []PreallocTimeseries) {
 	for i := range slice {
 		ReuseTimeseries(slice[i].TimeSeries)
 	}
-	slicePool.Put(slice[:0])
+	slicePool.Put(slice[:0]) //nolint:staticcheck
 }
 
 // ReuseTimeseries puts the timeseries back into a sync.Pool for reuse.

--- a/pkg/ingester/client/timeseries.go
+++ b/pkg/ingester/client/timeseries.go
@@ -16,6 +16,11 @@ var (
 	expectedLabels           = 20
 	expectedSamplesPerSeries = 10
 
+	/*
+		We cannot pool these as pointer-to-slice because the place we use them is in WriteRequest which is generated from Protobuf
+		and we don't have an option to make it a pointer. There is overhead here 24 bytes of garbage every time a PreallocTimeseries
+		is re-used. But since the slices are far far larger, we come out ahead.
+	*/
 	slicePool = sync.Pool{
 		New: func() interface{} {
 			return make([]PreallocTimeseries, 0, expectedTimeseries)
@@ -265,7 +270,7 @@ func ReuseSlice(slice []PreallocTimeseries) {
 	for i := range slice {
 		ReuseTimeseries(slice[i].TimeSeries)
 	}
-	slicePool.Put(slice[:0]) //nolint:staticcheck
+	slicePool.Put(slice[:0]) //nolint:staticcheck //see comment on slicePool for more details
 }
 
 // ReuseTimeseries puts the timeseries back into a sync.Pool for reuse.

--- a/pkg/ingester/index/index.go
+++ b/pkg/ingester/index/index.go
@@ -101,6 +101,7 @@ const cacheLineSize = 64
 type indexShard struct {
 	mtx sync.RWMutex
 	idx unlockIndex
+	//nolint:structcheck,unused
 	pad [cacheLineSize - unsafe.Sizeof(sync.Mutex{}) - unsafe.Sizeof(unlockIndex{})]byte
 }
 

--- a/pkg/ingester/index/index.go
+++ b/pkg/ingester/index/index.go
@@ -267,12 +267,6 @@ func intersect(a, b []model.Fingerprint) []model.Fingerprint {
 	return result
 }
 
-type fingerprints []model.Fingerprint
-
-func (a fingerprints) Len() int           { return len(a) }
-func (a fingerprints) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a fingerprints) Less(i, j int) bool { return a[i] < a[j] }
-
 func mergeStringSlices(ss [][]string) []string {
 	switch len(ss) {
 	case 0:

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -158,7 +158,7 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 		limits:       limits,
 		chunkStore:   chunkStore,
 		quit:         make(chan struct{}),
-		flushQueues:  make([]*util.PriorityQueue, cfg.ConcurrentFlushes, cfg.ConcurrentFlushes),
+		flushQueues:  make([]*util.PriorityQueue, cfg.ConcurrentFlushes),
 	}
 
 	var err error

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -520,7 +520,7 @@ func createUserStats(db *userTSDB) *client.UserStatsResponse {
 func (i *Ingester) getTSDB(userID string) *userTSDB {
 	i.userStatesMtx.RLock()
 	defer i.userStatesMtx.RUnlock()
-	db, _ := i.TSDBState.dbs[userID]
+	db := i.TSDBState.dbs[userID]
 	return db
 }
 

--- a/pkg/ingester/locker.go
+++ b/pkg/ingester/locker.go
@@ -16,6 +16,7 @@ const (
 // Avoid false sharing when using array of mutexes.
 type paddedMutex struct {
 	sync.Mutex
+	//nolint:structcheck,unused
 	pad [cacheLineSize - unsafe.Sizeof(sync.Mutex{})]byte
 }
 

--- a/pkg/ingester/query_test.go
+++ b/pkg/ingester/query_test.go
@@ -74,14 +74,14 @@ func BenchmarkQueryStream(b *testing.B) {
 
 	l, err := net.Listen("tcp", "localhost:0")
 	require.NoError(b, err)
-	go server.Serve(l)
+	go server.Serve(l) //nolint:errcheck
 
 	b.ResetTimer()
 	for iter := 0; iter < b.N; iter++ {
 		b.Run("QueryStream", func(b *testing.B) {
 			c, err := client.MakeIngesterClient(l.Addr().String(), clientCfg)
 			require.NoError(b, err)
-			defer c.Close()
+			defer c.Close() //nolint:errcheck
 
 			s, err := c.QueryStream(ctx, &client.QueryRequest{
 				StartTimestampMs: 0,

--- a/pkg/ingester/series_map.go
+++ b/pkg/ingester/series_map.go
@@ -23,7 +23,7 @@ type seriesMap struct {
 type shard struct {
 	mtx sync.Mutex
 	m   map[model.Fingerprint]*memorySeries
-	// Align this struct.
+	//nolint:structcheck,unused // Align this struct.
 	pad [cacheLineSize - unsafe.Sizeof(sync.Mutex{}) - unsafe.Sizeof(map[model.Fingerprint]*memorySeries{})]byte
 }
 

--- a/pkg/ingester/transfer_test.go
+++ b/pkg/ingester/transfer_test.go
@@ -30,7 +30,8 @@ type testUserTSDB struct {
 func createTSDB(t *testing.T, dir string, users []*testUserTSDB) {
 	for _, user := range users {
 
-		os.MkdirAll(filepath.Join(dir, user.userID), 0777)
+		err := os.MkdirAll(filepath.Join(dir, user.userID), 0777)
+		require.NoError(t, err)
 
 		for i := 0; i < user.numBlocks; i++ {
 			u, err := ulid.New(uint64(time.Now().Unix()*1000), rand.Reader)
@@ -181,13 +182,14 @@ func TestTransferUser(t *testing.T) {
 
 	var original []string
 	var xferfiles []string
-	filepath.Walk(xfer, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(xfer, func(path string, info os.FileInfo, err error) error {
 		p, _ := filepath.Rel(xfer, path)
 		xferfiles = append(xferfiles, p)
 		return nil
 	})
+	require.NoError(t, err)
 
-	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if info.Name() == "thanos.shipper.json" {
 			return nil
 		}
@@ -195,6 +197,7 @@ func TestTransferUser(t *testing.T) {
 		original = append(original, p)
 		return nil
 	})
+	require.NoError(t, err)
 
 	require.Equal(t, original, xferfiles)
 }

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -79,6 +79,7 @@ func (us *userStates) cp() map[string]*userState {
 	return states
 }
 
+//nolint:unused
 func (us *userStates) gc() {
 	us.states.Range(func(key, value interface{}) bool {
 		state := value.(*userState)

--- a/pkg/ingester/util.go
+++ b/pkg/ingester/util.go
@@ -1,7 +1,0 @@
-package ingester
-
-type sortableUint32 []uint32
-
-func (ts sortableUint32) Len() int           { return len(ts) }
-func (ts sortableUint32) Swap(i, j int)      { ts[i], ts[j] = ts[j], ts[i] }
-func (ts sortableUint32) Less(i, j int) bool { return ts[i] < ts[j] }

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -29,10 +29,6 @@ type iterator interface {
 	Err() error
 }
 
-func print(b promchunk.Batch) {
-	fmt.Println("  ", b.Timestamps, b.Index, b.Length)
-}
-
 // NewChunkMergeIterator returns a storage.SeriesIterator that merges chunks together.
 func NewChunkMergeIterator(chunks []chunk.Chunk, _, _ model.Time) storage.SeriesIterator {
 	iter := newMergeIterator(chunks)

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -1,8 +1,6 @@
 package batch
 
 import (
-	"fmt"
-
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/storage"
 

--- a/pkg/querier/batch/non_overlapping.go
+++ b/pkg/querier/batch/non_overlapping.go
@@ -9,8 +9,6 @@ type nonOverlappingIterator struct {
 	curr   int
 	chunks []chunk.Chunk
 	iter   chunkIterator
-	input  batchStream
-	output batchStream
 }
 
 // newNonOverlappingIterator returns a single iterator over an slice of sorted,

--- a/pkg/querier/batch/stream.go
+++ b/pkg/querier/batch/stream.go
@@ -1,8 +1,6 @@
 package batch
 
 import (
-	"fmt"
-
 	promchunk "github.com/cortexproject/cortex/pkg/chunk/encoding"
 )
 
@@ -10,14 +8,6 @@ import (
 // and building new slices of non-overlapping batches.  Designed to be used
 // without allocations.
 type batchStream []promchunk.Batch
-
-func (bs batchStream) print() {
-	fmt.Println("[")
-	for _, b := range bs {
-		print(b)
-	}
-	fmt.Println("]")
-}
 
 // reset, hasNext, next, atTime etc are all inlined in go1.11.
 

--- a/pkg/querier/block_store.go
+++ b/pkg/querier/block_store.go
@@ -89,7 +89,7 @@ func NewUserStore(cfg tsdb.Config, bucketClient objstore.Bucket, logLevel loggin
 	if err != nil {
 		return nil, err
 	}
-	go serv.Serve(l)
+	go serv.Serve(l) //nolint:errcheck
 
 	cc, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure())
 	if err != nil {

--- a/pkg/querier/correctness/runner.go
+++ b/pkg/querier/correctness/runner.go
@@ -112,7 +112,7 @@ func NewRunner(cfg RunnerConfig) (*Runner, error) {
 	if cfg.userID != "" {
 		apiCfg.RoundTripper = &nethttp.Transport{
 			RoundTripper: promhttp.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				user.InjectOrgIDIntoHTTPRequest(user.InjectOrgID(context.Background(), cfg.userID), req)
+				_ = user.InjectOrgIDIntoHTTPRequest(user.InjectOrgID(context.Background(), cfg.userID), req)
 				return api.DefaultRoundTripper.RoundTrip(req)
 			}),
 		}

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -171,7 +171,7 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 		hs[h] = vs
 	}
 	w.WriteHeader(resp.StatusCode)
-	_, _ = io.Copy(w, resp.Body)
+	io.Copy(w, resp.Body)
 }
 
 func writeError(w http.ResponseWriter, err error) {

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -171,7 +171,7 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 		hs[h] = vs
 	}
 	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
+	_, _ = io.Copy(w, resp.Body)
 }
 
 func writeError(w http.ResponseWriter, err error) {
@@ -225,7 +225,7 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, req *ProcessRequest) (*Pro
 	tracer, span := opentracing.GlobalTracer(), opentracing.SpanFromContext(ctx)
 	if tracer != nil && span != nil {
 		carrier := (*httpgrpcHeadersCarrier)(req.HttpRequest)
-		tracer.Inject(span.Context(), opentracing.HTTPHeaders, carrier)
+		_ = tracer.Inject(span.Context(), opentracing.HTTPHeaders, carrier)
 	}
 
 	request := request{

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -225,7 +225,7 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, req *ProcessRequest) (*Pro
 	tracer, span := opentracing.GlobalTracer(), opentracing.SpanFromContext(ctx)
 	if tracer != nil && span != nil {
 		carrier := (*httpgrpcHeadersCarrier)(req.HttpRequest)
-		_ = tracer.Inject(span.Context(), opentracing.HTTPHeaders, carrier)
+		tracer.Inject(span.Context(), opentracing.HTTPHeaders, carrier)
 	}
 
 	request := request{

--- a/pkg/querier/frontend/frontend_test.go
+++ b/pkg/querier/frontend/frontend_test.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 const (
@@ -152,14 +151,6 @@ func TestFrontendCancelStatusCode(t *testing.T) {
 			require.Equal(t, test.status, w.Result().StatusCode)
 		})
 	}
-}
-
-func defaultOverrides(t *testing.T) *validation.Overrides {
-	var limits validation.Limits
-	flagext.DefaultValues(&limits)
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
-	return overrides
 }
 
 func testFrontend(t *testing.T, handler http.Handler, test func(addr string)) {

--- a/pkg/querier/frontend/worker.go
+++ b/pkg/querier/frontend/worker.go
@@ -57,7 +57,7 @@ type worker struct {
 
 	ctx     context.Context
 	cancel  context.CancelFunc
-	watcher naming.Watcher
+	watcher naming.Watcher //nolint:staticcheck //Skipping for now. If you still see this more than likely issue https://github.com/cortexproject/cortex/issues/2015 has not yet been addressed.
 	wg      sync.WaitGroup
 }
 

--- a/pkg/querier/queryrange/instrumentation.go
+++ b/pkg/querier/queryrange/instrumentation.go
@@ -34,7 +34,7 @@ func InstrumentMiddleware(name string) Middleware {
 	return MiddlewareFunc(func(next Handler) Handler {
 		return HandlerFunc(func(ctx context.Context, req Request) (Response, error) {
 			var resp Response
-			err := instrument.TimeRequestHistogram(ctx, name, queryRangeDuration, func(ctx context.Context) error {
+			err := instrument.CollectedRequest(ctx, name, instrument.NewHistogramCollector(queryRangeDuration), instrument.ErrorCode, func(ctx context.Context) error {
 				var err error
 				resp, err = next.Do(ctx, req)
 				return err

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -57,26 +57,6 @@ var (
 	}
 )
 
-var dummyResponse = &PrometheusResponse{
-	Status: StatusSuccess,
-	Data: PrometheusData{
-		ResultType: matrix,
-		Result: []SampleStream{
-			{
-				Labels: []client.LabelAdapter{
-					{Name: "foo", Value: "bar"},
-				},
-				Samples: []client.Sample{
-					{
-						TimestampMs: 60,
-						Value:       60,
-					},
-				},
-			},
-		},
-	},
-}
-
 func mkAPIResponse(start, end, step int64) *PrometheusResponse {
 	var samples []client.Sample
 	for i := start; i <= end; i += step {
@@ -300,7 +280,7 @@ func TestResultsCache(t *testing.T) {
 
 	// Doing request with new end time should do one more query.
 	req := parsedRequest.WithStartEnd(parsedRequest.GetStart(), parsedRequest.GetEnd()+100)
-	resp, err = rc.Do(ctx, req)
+	_, err = rc.Do(ctx, req)
 	require.NoError(t, err)
 	require.Equal(t, 2, calls)
 }

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -266,8 +266,7 @@ func TestSplitByDay(t *testing.T) {
 				middleware.AuthenticateUser.Wrap(
 					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 						atomic.AddInt32(&actualCount, 1)
-						_, err = w.Write([]byte(responseBody))
-						require.NoError(t, err)
+						_, _ = w.Write([]byte(responseBody))
 					}),
 				),
 			)

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -266,7 +266,8 @@ func TestSplitByDay(t *testing.T) {
 				middleware.AuthenticateUser.Wrap(
 					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 						atomic.AddInt32(&actualCount, 1)
-						w.Write([]byte(responseBody))
+						_, err = w.Write([]byte(responseBody))
+						require.NoError(t, err)
 					}),
 				),
 			)

--- a/pkg/querier/queryrange/step_align_test.go
+++ b/pkg/querier/queryrange/step_align_test.go
@@ -46,7 +46,8 @@ func TestStepAlign(t *testing.T) {
 					return nil, nil
 				}),
 			}
-			s.Do(context.Background(), tc.input)
+			_, err := s.Do(context.Background(), tc.input)
+			require.NoError(t, err)
 			require.Equal(t, tc.expected, result)
 		})
 	}

--- a/pkg/ring/kv/consul/client.go
+++ b/pkg/ring/kv/consul/client.go
@@ -103,7 +103,6 @@ func (c *Client) cas(ctx context.Context, key string, f func(in interface{}) (ou
 	var (
 		index   = uint64(0)
 		retries = 10
-		retry   = true
 	)
 	for i := 0; i < retries; i++ {
 		options := &consul.QueryOptions{
@@ -127,7 +126,7 @@ func (c *Client) cas(ctx context.Context, key string, f func(in interface{}) (ou
 			intermediate = out
 		}
 
-		intermediate, retry, err = f(intermediate)
+		intermediate, retry, err := f(intermediate)
 		if err != nil {
 			if !retry {
 				return err

--- a/pkg/ring/kv/consul/client_test.go
+++ b/pkg/ring/kv/consul/client_test.go
@@ -156,10 +156,7 @@ func TestWatchKeyWithNoStartValue(t *testing.T) {
 	reported := 0
 	c.WatchKey(ctx, key, func(i interface{}) bool {
 		reported++
-		if reported == 2 {
-			return false
-		}
-		return true
+		return reported != 2
 	})
 
 	// we should see both start and end values.

--- a/pkg/ring/kv/memberlist/memberlist_client_test.go
+++ b/pkg/ring/kv/memberlist/memberlist_client_test.go
@@ -644,7 +644,7 @@ func runClient(t *testing.T, kv *Client, name string, ringKey string, portToConn
 			if portToConnect > 0 {
 				_, err := kv.kv.JoinMembers([]string{fmt.Sprintf("127.0.0.1:%d", portToConnect)})
 				if err != nil {
-					t.Fatalf("%s failed to join the cluster: %v", name, err)
+					t.Errorf("%s failed to join the cluster: %v", name, err)
 					return
 				}
 			}

--- a/pkg/ring/kv/memberlist/tcp_transport.go
+++ b/pkg/ring/kv/memberlist/tcp_transport.go
@@ -270,7 +270,7 @@ func (t *TCPTransport) handleConnection(conn *net.TCPConn) {
 
 		expectedDigest := md5.Sum(buf)
 
-		if bytes.Compare(receivedDigest, expectedDigest[:]) != 0 {
+		if !bytes.Equal(receivedDigest, expectedDigest[:]) {
 			t.receivedPacketsErrors.Inc()
 			level.Warn(util.Logger).Log("msg", "TCPTransport: packet digest mismatch", "expected", fmt.Sprintf("%x", expectedDigest), "received", fmt.Sprintf("%x", receivedDigest))
 		}

--- a/pkg/ring/kv/metrics.go
+++ b/pkg/ring/kv/metrics.go
@@ -52,14 +52,14 @@ func (m metrics) CAS(ctx context.Context, key string, f func(in interface{}) (ou
 }
 
 func (m metrics) WatchKey(ctx context.Context, key string, f func(interface{}) bool) {
-	instrument.CollectedRequest(ctx, "WatchKey", requestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+	_ = instrument.CollectedRequest(ctx, "WatchKey", requestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 		m.c.WatchKey(ctx, key, f)
 		return nil
 	})
 }
 
 func (m metrics) WatchPrefix(ctx context.Context, prefix string, f func(string, interface{}) bool) {
-	instrument.CollectedRequest(ctx, "WatchPrefix", requestDuration, instrument.ErrorCode, func(ctx context.Context) error {
+	_ = instrument.CollectedRequest(ctx, "WatchPrefix", requestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 		m.c.WatchPrefix(ctx, prefix, f)
 		return nil
 	})

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -422,7 +422,7 @@ loop:
 	}
 
 	// Mark ourselved as Leaving so no more samples are send to us.
-	i.changeState(context.Background(), LEAVING)
+	_ = i.changeState(context.Background(), LEAVING)
 
 	// Do the transferring / flushing on a background goroutine so we can continue
 	// to heartbeat to consul.

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -207,7 +207,7 @@ func (i *Lifecycler) CheckReady(ctx context.Context) error {
 
 	// Ingester always take at least minReadyDuration to become ready to work
 	// around race conditions with ingesters exiting and updating the ring
-	if time.Now().Sub(i.startTime) < i.cfg.MinReadyDuration {
+	if time.Since(i.startTime) < i.cfg.MinReadyDuration {
 		return fmt.Errorf("waiting for %v after startup", i.cfg.MinReadyDuration)
 	}
 

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -422,7 +422,10 @@ loop:
 	}
 
 	// Mark ourselved as Leaving so no more samples are send to us.
-	_ = i.changeState(context.Background(), LEAVING)
+	err := i.changeState(context.Background(), LEAVING)
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "failed to set state to LEAVING", "ring", i.RingName, "err", err)
+	}
 
 	// Do the transferring / flushing on a background goroutine so we can continue
 	// to heartbeat to consul.

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -59,12 +59,6 @@ const (
 	Reporting // Special value for inquiring about health
 )
 
-type uint32s []uint32
-
-func (x uint32s) Len() int           { return len(x) }
-func (x uint32s) Less(i, j int) bool { return x[i] < x[j] }
-func (x uint32s) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
-
 // ErrEmptyRing is the error returned when trying to get an element when nothing has been added to hash.
 var ErrEmptyRing = errors.New("empty ring")
 

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -272,7 +272,7 @@ func (r *Ruler) getOrCreateNotifier(userID string) (*notifier.Manager, error) {
 			sp := ot.GlobalTracer().StartSpan("notify", ot.Tag{Key: "organization", Value: userID})
 			defer sp.Finish()
 			ctx = ot.ContextWithSpan(ctx, sp)
-			ot.GlobalTracer().Inject(sp.Context(), ot.HTTPHeaders, ot.HTTPHeadersCarrier(req.Header))
+			_ = ot.GlobalTracer().Inject(sp.Context(), ot.HTTPHeaders, ot.HTTPHeadersCarrier(req.Header))
 			return ctxhttp.Do(ctx, client, req)
 		},
 	}, util.Logger)

--- a/pkg/util/flagext/register.go
+++ b/pkg/util/flagext/register.go
@@ -20,5 +20,5 @@ func DefaultValues(rs ...Registerer) {
 	for _, r := range rs {
 		r.RegisterFlags(fs)
 	}
-	fs.Parse([]string{})
+	_ = fs.Parse([]string{})
 }

--- a/pkg/util/grpcclient/backoff_retry.go
+++ b/pkg/util/grpcclient/backoff_retry.go
@@ -2,6 +2,7 @@ package grpcclient
 
 import (
 	"context"
+	"google.golang.org/grpc/status"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -19,7 +20,7 @@ func NewBackoffRetry(cfg util.BackoffConfig) grpc.UnaryClientInterceptor {
 				return nil
 			}
 
-			if grpc.Code(err) != codes.ResourceExhausted {
+			if status.Code(err) != codes.ResourceExhausted {
 				return err
 			}
 

--- a/pkg/util/grpcclient/backoff_retry.go
+++ b/pkg/util/grpcclient/backoff_retry.go
@@ -2,10 +2,10 @@ package grpcclient
 
 import (
 	"context"
-	"google.golang.org/grpc/status"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/cortexproject/cortex/pkg/util"
 )

--- a/pkg/util/grpcclient/ratelimit.go
+++ b/pkg/util/grpcclient/ratelimit.go
@@ -15,7 +15,7 @@ func NewRateLimiter(cfg *Config) grpc.UnaryClientInterceptor {
 	}
 	limiter := rate.NewLimiter(rate.Limit(cfg.RateLimit), burst)
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		limiter.Wait(ctx)
+		_ = limiter.Wait(ctx)
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 }

--- a/pkg/util/grpcclient/ratelimit.go
+++ b/pkg/util/grpcclient/ratelimit.go
@@ -5,6 +5,8 @@ import (
 
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // NewRateLimiter creates a UnaryClientInterceptor for client side rate limiting.
@@ -17,7 +19,7 @@ func NewRateLimiter(cfg *Config) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		err := limiter.Wait(ctx)
 		if err != nil {
-			return err
+			return status.Error(codes.ResourceExhausted, err.Error())
 		}
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}

--- a/pkg/util/grpcclient/ratelimit.go
+++ b/pkg/util/grpcclient/ratelimit.go
@@ -15,7 +15,10 @@ func NewRateLimiter(cfg *Config) grpc.UnaryClientInterceptor {
 	}
 	limiter := rate.NewLimiter(rate.Limit(cfg.RateLimit), burst)
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		_ = limiter.Wait(ctx)
+		err := limiter.Wait(ctx)
+		if err != nil {
+			return err
+		}
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 }

--- a/pkg/util/grpcclient/ratelimit_test.go
+++ b/pkg/util/grpcclient/ratelimit_test.go
@@ -1,0 +1,36 @@
+package grpcclient_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	
+	"github.com/cortexproject/cortex/pkg/util/grpcclient"
+)
+
+func TestRateLimiterFailureResultsInResourceExhaustedError(t *testing.T) {
+	config := grpcclient.Config{
+		RateLimitBurst: 0,
+		RateLimit:      0,
+	}
+	conn := grpc.ClientConn{}
+	invoker := func(currentCtx context.Context, currentMethod string, currentReq, currentRepl interface{}, currentConn *grpc.ClientConn, currentOpts ...grpc.CallOption) error {
+		return nil
+	}
+
+	limiter := grpcclient.NewRateLimiter(&config)
+	err := limiter(context.Background(), "methodName", "", "expectedReply", &conn, invoker)
+
+	if se, ok := err.(interface {
+		GRPCStatus() *status.Status
+	}); ok {
+		assert.Equal(t, se.GRPCStatus().Code(), codes.ResourceExhausted)
+		assert.Equal(t, se.GRPCStatus().Message(), "rate: Wait(n=1) exceeds limiter's burst 0")
+	} else {
+		assert.Fail(t, "Could not convert error into expected Status type")
+	}
+}

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -129,7 +129,9 @@ func SerializeProtoResponse(w http.ResponseWriter, resp proto.Message, compressi
 	case NoCompression:
 	case FramedSnappy:
 		buf := bytes.Buffer{}
-		if _, err := snappy.NewWriter(&buf).Write(data); err != nil {
+		writer := snappy.NewBufferedWriter(&buf)
+		defer writer.Close()
+		if _, err := writer.Write(data); err != nil {
 			return err
 		}
 		data = buf.Bytes()

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -130,10 +130,10 @@ func SerializeProtoResponse(w http.ResponseWriter, resp proto.Message, compressi
 	case FramedSnappy:
 		buf := bytes.Buffer{}
 		writer := snappy.NewBufferedWriter(&buf)
-		defer writer.Close()
 		if _, err := writer.Write(data); err != nil {
 			return err
 		}
+		writer.Close()
 		data = buf.Bytes()
 	case RawSnappy:
 		data = snappy.Encode(nil, data)

--- a/pkg/util/middleware/grpc.go
+++ b/pkg/util/middleware/grpc.go
@@ -16,7 +16,7 @@ func PrometheusGRPCUnaryInstrumentation(metric *prometheus.HistogramVec) grpc.Un
 	return func(ctx context.Context, method string, req, resp interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		start := time.Now()
 		err := invoker(ctx, method, req, resp, cc, opts...)
-		metric.WithLabelValues(method, instrument.ErrorCode(err)).Observe(time.Now().Sub(start).Seconds())
+		metric.WithLabelValues(method, instrument.ErrorCode(err)).Observe(time.Since(start).Seconds())
 		return err
 	}
 }
@@ -51,9 +51,9 @@ func (s *instrumentedClientStream) SendMsg(m interface{}) error {
 	}
 
 	if err == io.EOF {
-		s.metric.WithLabelValues(s.method, instrument.ErrorCode(nil)).Observe(time.Now().Sub(s.start).Seconds())
+		s.metric.WithLabelValues(s.method, instrument.ErrorCode(nil)).Observe(time.Since(s.start).Seconds())
 	} else {
-		s.metric.WithLabelValues(s.method, instrument.ErrorCode(err)).Observe(time.Now().Sub(s.start).Seconds())
+		s.metric.WithLabelValues(s.method, instrument.ErrorCode(err)).Observe(time.Since(s.start).Seconds())
 	}
 
 	return err
@@ -66,9 +66,9 @@ func (s *instrumentedClientStream) RecvMsg(m interface{}) error {
 	}
 
 	if err == io.EOF {
-		s.metric.WithLabelValues(s.method, instrument.ErrorCode(nil)).Observe(time.Now().Sub(s.start).Seconds())
+		s.metric.WithLabelValues(s.method, instrument.ErrorCode(nil)).Observe(time.Since(s.start).Seconds())
 	} else {
-		s.metric.WithLabelValues(s.method, instrument.ErrorCode(err)).Observe(time.Now().Sub(s.start).Seconds())
+		s.metric.WithLabelValues(s.method, instrument.ErrorCode(err)).Observe(time.Since(s.start).Seconds())
 	}
 
 	return err
@@ -77,7 +77,7 @@ func (s *instrumentedClientStream) RecvMsg(m interface{}) error {
 func (s *instrumentedClientStream) Header() (metadata.MD, error) {
 	md, err := s.ClientStream.Header()
 	if err != nil {
-		s.metric.WithLabelValues(s.method, instrument.ErrorCode(err)).Observe(time.Now().Sub(s.start).Seconds())
+		s.metric.WithLabelValues(s.method, instrument.ErrorCode(err)).Observe(time.Since(s.start).Seconds())
 	}
 	return md, err
 }

--- a/pkg/util/priority_queue_test.go
+++ b/pkg/util/priority_queue_test.go
@@ -19,20 +19,6 @@ func (i simpleItem) Key() string {
 	return strconv.FormatInt(int64(i), 10)
 }
 
-type richItem struct {
-	priority int64
-	key      string
-	value    string
-}
-
-func (r richItem) Priority() int64 {
-	return r.priority
-}
-
-func (r richItem) Key() string {
-	return r.key
-}
-
 func TestPriorityQueueBasic(t *testing.T) {
 	queue := NewPriorityQueue(nil)
 	assert.Equal(t, 0, queue.Length(), "Expected length = 0")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Cleanups all but one of the lint errors that were found when the hash was in place. 

Last outstanding issue is as follows
```
pkg/querier/frontend/worker.go:60:10: SA1019: naming.Watcher is deprecated: please use package resolver.  (staticcheck)
	watcher naming.Watcher
```

Not 100% clear yet on path forward on this. From what i can tell even the underlying library is still using naming.Watcher. Wondering if for now we put a //nolint:staticcheck and open an issue to fix just that issue.

**Which issue(s) this PR fixes**:
Fixes #1912 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
