### PR TITLE
Fixes regression introduced by recent change to avoid double call to flag.Parse()

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -115,7 +115,19 @@ func parseConfigFileParameter() string {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.SetOutput(ioutil.Discard)
 	fs.StringVar(&configFile, configFileOption, "", "") // usage not used in this function.
-	_ = fs.Parse(os.Args[1:])
+
+	// Try to find -config.file option in the flags. As Parsing stops on the first error, eg. unknown flag, we simply
+	// try remaining parameters until we find config flag, or there are no params left.
+	// (ContinueOnError just means that flag.Parse doesn't call panic or os.Exit, but it returns error, which we ignore)
+	args := os.Args[1:]
+	for len(args) > 0 {
+		_ = fs.Parse(args)
+		if configFile != "" {
+			// found (!)
+			break
+		}
+		args = args[1:]
+	}
 
 	return configFile
 }

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -40,6 +40,12 @@ func TestFlagParsing(t *testing.T) {
 			stderrMessage: "-unknown.flag",
 		},
 
+		"new flag, with config": {
+			arguments:     []string{"-mem-ballast-size-bytes=100000"},
+			yaml:          "target: ingester",
+			stdoutMessage: "target: ingester",
+		},
+
 		"config with wrong argument override": {
 			yaml:          "target: ingester",
 			arguments:     []string{"-target=unknown"},
@@ -90,7 +96,7 @@ func testSingle(t *testing.T, arguments []string, yaml string, stdoutMessage, st
 		_, err = tempFile.WriteString(yaml)
 		require.NoError(t, err)
 
-		arguments = append([]string{"-" + configFileOption, tempFile.Name()}, arguments...)
+		arguments = append(arguments, "-"+configFileOption, tempFile.Name())
 	}
 
 	arguments = append([]string{"./cortex"}, arguments...)


### PR DESCRIPTION
This PR fixes regression introduced by #1997.

When using `flag.ContinueOnError`, `Parse()` method on `*flag.FlagSet` returns errors, instead of panicking or exiting the program.

My assumption was that it actually continues, but that's not the case. When cortex was called with `./cortex -target=distributor -server.http-listen-port=8001 -server.grpc-listen-port=9001 -config.file=./config.yaml`, `Parse()` method returned error on first unknown parameter (which is `-target=...` here, as we only look for `-config.file` at first), and then config file parameter was not found.

To actually find the `-config.file` parameter, we now call flag.Parse repeatedly with reduced set of arguments, until configFile is set to non-zero string or we run out of arguments.
