### PR TITLE
Remove error return from Cache.Stop()

### DIFF
--- a/pkg/chunk/cache/background.go
+++ b/pkg/chunk/cache/background.go
@@ -73,11 +73,11 @@ func NewBackground(name string, cfg BackgroundConfig, cache Cache) Cache {
 }
 
 // Stop the background flushing goroutines.
-func (c *backgroundCache) Stop() error {
+func (c *backgroundCache) Stop() {
 	close(c.quit)
 	c.wg.Wait()
 
-	return c.Cache.Stop()
+	c.Cache.Stop()
 }
 
 // Store writes keys for the cache in the background.

--- a/pkg/chunk/cache/cache.go
+++ b/pkg/chunk/cache/cache.go
@@ -17,7 +17,7 @@ import (
 type Cache interface {
 	Store(ctx context.Context, key []string, buf [][]byte)
 	Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string)
-	Stop() error
+	Stop()
 }
 
 // Config for building Caches.

--- a/pkg/chunk/cache/fifo_cache.go
+++ b/pkg/chunk/cache/fifo_cache.go
@@ -139,8 +139,7 @@ func (c *FifoCache) Store(ctx context.Context, keys []string, bufs [][]byte) {
 }
 
 // Stop implements Cache.
-func (c *FifoCache) Stop() error {
-	return nil
+func (c *FifoCache) Stop() {
 }
 
 // Put stores the value against the key.

--- a/pkg/chunk/cache/instrumented.go
+++ b/pkg/chunk/cache/instrumented.go
@@ -109,6 +109,6 @@ func (i *instrumentedCache) Fetch(ctx context.Context, keys []string) ([]string,
 	return found, bufs, missing
 }
 
-func (i *instrumentedCache) Stop() error {
-	return i.Cache.Stop()
+func (i *instrumentedCache) Stop() {
+	i.Cache.Stop()
 }

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -235,14 +235,13 @@ func (c *Memcached) Store(ctx context.Context, keys []string, bufs [][]byte) {
 }
 
 // Stop does nothing.
-func (c *Memcached) Stop() error {
+func (c *Memcached) Stop() {
 	if c.inputCh == nil {
-		return nil
+		return
 	}
 
 	close(c.inputCh)
 	c.wg.Wait()
-	return nil
 }
 
 // HashKey hashes key into something you can store in memcached.

--- a/pkg/chunk/cache/mock.go
+++ b/pkg/chunk/cache/mock.go
@@ -33,8 +33,7 @@ func (m *mockCache) Fetch(ctx context.Context, keys []string) (found []string, b
 	return
 }
 
-func (m *mockCache) Stop() error {
-	return nil
+func (m *mockCache) Stop() {
 }
 
 // NewMockCache makes a new MockCache

--- a/pkg/chunk/cache/redis_cache.go
+++ b/pkg/chunk/cache/redis_cache.go
@@ -109,8 +109,8 @@ func (c *RedisCache) Store(ctx context.Context, keys []string, bufs [][]byte) {
 }
 
 // Stop stops the redis client.
-func (c *RedisCache) Stop() error {
-	return c.pool.Close()
+func (c *RedisCache) Stop() {
+	_ = c.pool.Close()
 }
 
 // mset adds key-value pairs to the cache.

--- a/pkg/chunk/cache/snappy.go
+++ b/pkg/chunk/cache/snappy.go
@@ -42,6 +42,6 @@ func (s *snappyCache) Fetch(ctx context.Context, keys []string) ([]string, [][]b
 	return found, ds, missing
 }
 
-func (s *snappyCache) Stop() error {
-	return s.next.Stop()
+func (s *snappyCache) Stop() {
+	s.next.Stop()
 }

--- a/pkg/chunk/cache/stop_once.go
+++ b/pkg/chunk/cache/stop_once.go
@@ -14,10 +14,8 @@ func StopOnce(cache Cache) Cache {
 	}
 }
 
-func (s *stopOnce) Stop() error {
-	var err error
+func (s *stopOnce) Stop() {
 	s.once.Do(func() {
-		err = s.Cache.Stop()
+		s.Cache.Stop()
 	})
-	return err
 }

--- a/pkg/chunk/cache/tiered.go
+++ b/pkg/chunk/cache/tiered.go
@@ -56,11 +56,8 @@ func (t tiered) Fetch(ctx context.Context, keys []string) ([]string, [][]byte, [
 	return resultKeys, resultBufs, missing
 }
 
-func (t tiered) Stop() error {
+func (t tiered) Stop() {
 	for _, c := range []Cache(t) {
-		if err := c.Stop(); err != nil {
-			return err
-		}
+		c.Stop()
 	}
-	return nil
 }

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -355,7 +355,7 @@ func (t *Cortex) initQueryFrontend(cfg *Config) (err error) {
 func (t *Cortex) stopQueryFrontend() (err error) {
 	t.frontend.Close()
 	if t.cache != nil {
-		_ = t.cache.Stop()
+		t.cache.Stop()
 		t.cache = nil
 	}
 	return


### PR DESCRIPTION
All code paths return nil as the error, so we can simplify the code.

(Redis is the only one that looks as if it might, but if you go one level down it doesn't)
