### PR TITLE
ingester v2: supports statistics in blocks storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [ENHANCEMENT] Experimental TSDB: Export TSDB Syncer metrics from Compactor component, they are prefixed with `cortex_compactor_`. #2023
 * [ENHANCEMENT] Experimental TSDB: Added dedicated flag `-experimental.tsdb.bucket-store.tenant-sync-concurrency` to configure the maximum number of concurrent tenants for which blocks are synched. #2026
 * [ENHANCEMENT] Experimental TSDB: Expose metrics for objstore operations (prefixed with `cortex_<component>_thanos_objstore_`, component being one of `ingester`, `querier` and `compactor`). #2027
+* [BUGFIX] Experimental TSDB: fixed `/all_user_stats` and `/api/prom/user_stats` endpoints when using the experimental TSDB blocks storage. #2042
 
 Cortex 0.4.0 is the last version that can *write* denormalised tokens. Cortex 0.5.0 and above always write normalised tokens.
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -633,6 +633,10 @@ func (i *Ingester) MetricsForLabelMatchers(ctx old_ctx.Context, req *client.Metr
 
 // UserStats returns ingestion statistics for the current user.
 func (i *Ingester) UserStats(ctx old_ctx.Context, req *client.UserStatsRequest) (*client.UserStatsResponse, error) {
+	if i.cfg.TSDBEnabled {
+		return i.v2UserStats(ctx, req)
+	}
+
 	i.userStatesMtx.RLock()
 	defer i.userStatesMtx.RUnlock()
 	state, ok, err := i.userStates.getViaContext(ctx)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -654,6 +654,10 @@ func (i *Ingester) UserStats(ctx old_ctx.Context, req *client.UserStatsRequest) 
 
 // AllUserStats returns ingestion statistics for all users known to this ingester.
 func (i *Ingester) AllUserStats(ctx old_ctx.Context, req *client.UserStatsRequest) (*client.UsersStatsResponse, error) {
+	if i.cfg.TSDBEnabled {
+		return i.v2AllUserStats(ctx, req)
+	}
+
 	i.userStatesMtx.RLock()
 	defer i.userStatesMtx.RUnlock()
 	users := i.userStates.cp()

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -45,6 +45,10 @@ type userTSDB struct {
 	shipper       Shipper
 	shipperCtx    context.Context
 	shipperCancel context.CancelFunc
+
+	// for statistics
+	ingestedAPISamples  *ewmaRate
+	ingestedRuleSamples *ewmaRate
 }
 
 // TSDBState holds data structures used by the TSDB storage engine
@@ -121,7 +125,31 @@ func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides,
 		go i.shipBlocksLoop()
 	}
 
+	i.done.Add(1)
+	go i.rateUpdateLoop()
+
 	return i, nil
+}
+
+func (i *Ingester) rateUpdateLoop() {
+	defer i.done.Done()
+
+	rateUpdateTicker := time.NewTicker(i.cfg.RateUpdatePeriod)
+	defer rateUpdateTicker.Stop()
+
+	for {
+		select {
+		case <-rateUpdateTicker.C:
+			i.userStatesMtx.RLock()
+			for _, state := range i.TSDBState.dbs {
+				state.ingestedAPISamples.tick()
+				state.ingestedRuleSamples.tick()
+			}
+			i.userStatesMtx.RUnlock()
+		case <-i.quit:
+			return
+		}
+	}
 }
 
 // v2Push adds metrics to a block
@@ -207,6 +235,15 @@ func (i *Ingester) v2Push(ctx old_ctx.Context, req *client.WriteRequest) (*clien
 	// which will be converted into an HTTP 5xx and the client should/will retry.
 	i.metrics.ingestedSamples.Add(float64(succeededSamplesCount))
 	i.metrics.ingestedSamplesFail.Add(float64(failedSamplesCount))
+
+	switch req.Source {
+	case client.RULE:
+		db.ingestedRuleSamples.add(int64(succeededSamplesCount))
+	case client.API:
+		fallthrough
+	default:
+		db.ingestedAPISamples.add(int64(succeededSamplesCount))
+	}
 
 	if firstPartialErr != nil {
 		return &client.WriteResponse{}, httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(firstPartialErr, userID).Error())
@@ -394,6 +431,31 @@ func (i *Ingester) v2MetricsForLabelMatchers(ctx old_ctx.Context, req *client.Me
 	return result, nil
 }
 
+func (i *Ingester) v2AllUserStats(ctx old_ctx.Context, req *client.UserStatsRequest) (*client.UsersStatsResponse, error) {
+	i.userStatesMtx.RLock()
+	defer i.userStatesMtx.RUnlock()
+
+	users := i.TSDBState.dbs
+
+	response := &client.UsersStatsResponse{
+		Stats: make([]*client.UserIDStatsResponse, 0, len(users)),
+	}
+	for userID, db := range users {
+		apiRate := db.ingestedAPISamples.rate()
+		ruleRate := db.ingestedRuleSamples.rate()
+		response.Stats = append(response.Stats, &client.UserIDStatsResponse{
+			UserId: userID,
+			Data: &client.UserStatsResponse{
+				IngestionRate:     apiRate + ruleRate,
+				ApiIngestionRate:  apiRate,
+				RuleIngestionRate: ruleRate,
+				NumSeries:         db.Head().NumSeries(),
+			},
+		})
+	}
+	return response, nil
+}
+
 func (i *Ingester) getTSDB(userID string) *userTSDB {
 	i.userStatesMtx.RLock()
 	defer i.userStatesMtx.RUnlock()
@@ -471,7 +533,9 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 	}
 
 	userDB := &userTSDB{
-		DB: db,
+		DB:                  db,
+		ingestedAPISamples:  newEWMARate(0.2, i.cfg.RateUpdatePeriod),
+		ingestedRuleSamples: newEWMARate(0.2, i.cfg.RateUpdatePeriod),
 	}
 
 	// Thanos shipper requires at least 1 external label to be set. For this reason,

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -1002,3 +1002,114 @@ func (m *shipperMock) Sync(ctx context.Context) (uploaded int, err error) {
 	args := m.Called(ctx)
 	return args.Int(0), args.Error(1)
 }
+
+func Test_Ingester_v2UserStats(t *testing.T) {
+	series := []struct {
+		lbls      labels.Labels
+		value     float64
+		timestamp int64
+	}{
+		{labels.Labels{{Name: labels.MetricName, Value: "test_1"}, {Name: "status", Value: "200"}, {Name: "route", Value: "get_user"}}, 1, 100000},
+		{labels.Labels{{Name: labels.MetricName, Value: "test_1"}, {Name: "status", Value: "500"}, {Name: "route", Value: "get_user"}}, 1, 110000},
+		{labels.Labels{{Name: labels.MetricName, Value: "test_2"}}, 2, 200000},
+	}
+
+	// Create ingester
+	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
+	require.NoError(t, err)
+	defer i.Shutdown()
+	defer cleanup()
+
+	// Wait until it's ACTIVE
+	test.Poll(t, 1*time.Second, ring.ACTIVE, func() interface{} {
+		return i.lifecycler.GetState()
+	})
+
+	// Push series
+	ctx := user.InjectOrgID(context.Background(), "test")
+
+	for _, series := range series {
+		req, _ := mockWriteRequest(series.lbls, series.value, series.timestamp)
+		_, err := i.v2Push(ctx, req)
+		require.NoError(t, err)
+	}
+
+	// force update statistics
+	for _, db := range i.TSDBState.dbs {
+		db.ingestedAPISamples.tick()
+		db.ingestedRuleSamples.tick()
+	}
+
+	// Get label names
+	res, err := i.v2UserStats(ctx, &client.UserStatsRequest{})
+	require.NoError(t, err)
+	assert.InDelta(t, 0.2, res.ApiIngestionRate, 0.0001)
+	assert.InDelta(t, float64(0), res.RuleIngestionRate, 0.0001)
+	assert.Equal(t, uint64(3), res.NumSeries)
+}
+
+func Test_Ingester_v2AllUserStats(t *testing.T) {
+	series := []struct {
+		user      string
+		lbls      labels.Labels
+		value     float64
+		timestamp int64
+	}{
+		{"user-1", labels.Labels{{Name: labels.MetricName, Value: "test_1_1"}, {Name: "status", Value: "200"}, {Name: "route", Value: "get_user"}}, 1, 100000},
+		{"user-1", labels.Labels{{Name: labels.MetricName, Value: "test_1_1"}, {Name: "status", Value: "500"}, {Name: "route", Value: "get_user"}}, 1, 110000},
+		{"user-1", labels.Labels{{Name: labels.MetricName, Value: "test_1_2"}}, 2, 200000},
+		{"user-2", labels.Labels{{Name: labels.MetricName, Value: "test_2_1"}}, 2, 200000},
+		{"user-2", labels.Labels{{Name: labels.MetricName, Value: "test_2_2"}}, 2, 200000},
+		{"user-2", labels.Labels{{Name: labels.MetricName, Value: "test_2_3"}}, 2, 200000},
+	}
+
+	// Create ingester
+	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
+	require.NoError(t, err)
+	defer i.Shutdown()
+	defer cleanup()
+
+	// Wait until it's ACTIVE
+	test.Poll(t, 1*time.Second, ring.ACTIVE, func() interface{} {
+		return i.lifecycler.GetState()
+	})
+	for _, series := range series {
+		ctx := user.InjectOrgID(context.Background(), series.user)
+		req, _ := mockWriteRequest(series.lbls, series.value, series.timestamp)
+		_, err := i.v2Push(ctx, req)
+		require.NoError(t, err)
+	}
+
+	// force update statistics
+	for _, db := range i.TSDBState.dbs {
+		db.ingestedAPISamples.tick()
+		db.ingestedRuleSamples.tick()
+	}
+
+	// Get label names
+	res, err := i.v2AllUserStats(context.Background(), &client.UserStatsRequest{})
+	require.NoError(t, err)
+	t.Logf("res: %v", res)
+
+	expect := []*client.UserIDStatsResponse{
+		{
+			UserId: "user-1",
+			Data: &client.UserStatsResponse{
+				IngestionRate:     0.2,
+				NumSeries:         3,
+				ApiIngestionRate:  0.2,
+				RuleIngestionRate: 0,
+			},
+		},
+		{
+			UserId: "user-2",
+			Data: &client.UserStatsResponse{
+				IngestionRate:     0.2,
+				NumSeries:         3,
+				ApiIngestionRate:  0.2,
+				RuleIngestionRate: 0,
+			},
+		},
+	}
+	assert.Equal(t, expect, res.Stats)
+}

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -1060,7 +1060,6 @@ func Test_Ingester_v2AllUserStats(t *testing.T) {
 		{"user-1", labels.Labels{{Name: labels.MetricName, Value: "test_1_2"}}, 2, 200000},
 		{"user-2", labels.Labels{{Name: labels.MetricName, Value: "test_2_1"}}, 2, 200000},
 		{"user-2", labels.Labels{{Name: labels.MetricName, Value: "test_2_2"}}, 2, 200000},
-		{"user-2", labels.Labels{{Name: labels.MetricName, Value: "test_2_3"}}, 2, 200000},
 	}
 
 	// Create ingester
@@ -1089,7 +1088,6 @@ func Test_Ingester_v2AllUserStats(t *testing.T) {
 	// Get label names
 	res, err := i.v2AllUserStats(context.Background(), &client.UserStatsRequest{})
 	require.NoError(t, err)
-	t.Logf("res: %v", res)
 
 	expect := []*client.UserIDStatsResponse{
 		{
@@ -1104,12 +1102,12 @@ func Test_Ingester_v2AllUserStats(t *testing.T) {
 		{
 			UserId: "user-2",
 			Data: &client.UserStatsResponse{
-				IngestionRate:     0.2,
-				NumSeries:         3,
-				ApiIngestionRate:  0.2,
+				IngestionRate:     0.13333333333333333,
+				NumSeries:         2,
+				ApiIngestionRate:  0.13333333333333333,
 				RuleIngestionRate: 0,
 			},
 		},
 	}
-	assert.Equal(t, expect, res.Stats)
+	assert.ElementsMatch(t, expect, res.Stats)
 }

--- a/pkg/ingester/rate.go
+++ b/pkg/ingester/rate.go
@@ -51,3 +51,8 @@ func (r *ewmaRate) tick() {
 func (r *ewmaRate) inc() {
 	atomic.AddInt64(&r.newEvents, 1)
 }
+
+// add counts some event.
+func (r *ewmaRate) add(delta int64) {
+	atomic.AddInt64(&r.newEvents, delta)
+}

--- a/pkg/ingester/rate.go
+++ b/pkg/ingester/rate.go
@@ -52,7 +52,6 @@ func (r *ewmaRate) inc() {
 	atomic.AddInt64(&r.newEvents, 1)
 }
 
-// add counts some event.
 func (r *ewmaRate) add(delta int64) {
 	atomic.AddInt64(&r.newEvents, delta)
 }

--- a/pkg/ingester/rate_test.go
+++ b/pkg/ingester/rate_test.go
@@ -33,4 +33,14 @@ func TestRate(t *testing.T) {
 			t.Fatalf("%d. unexpected rate: want %v, got %v", i, tick.want, r.rate())
 		}
 	}
+
+	r = newEWMARate(0.2, time.Minute)
+
+	for i, tick := range ticks {
+		r.add(int64(tick.events))
+		r.tick()
+		if r.rate() != tick.want {
+			t.Fatalf("%d. unexpected rate: want %v, got %v", i, tick.want, r.rate())
+		}
+	}
 }


### PR DESCRIPTION
**What this PR does**:

Make `/all_user_stats` page available when using BlocksStorage.


**Which issue(s) this PR fixes**:
Fixes #1825

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
