### PR TITLE
Ensure TSDB blocks transfer work even if a spurious file is in the TSDB blocks directory

### DIFF
--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -418,6 +419,10 @@ func TestV2IngesterTransfer(t *testing.T) {
 			dir2, err := ioutil.TempDir("", "tsdb")
 			require.NoError(t, err)
 			require.NoError(t, os.Remove(dir2)) // remove the destination dir so there isn't a move conflict
+
+			// Add a spurious file to the ing1 TSDB directory, in order to ensure
+			// the transfer successfully work anyway.
+			ioutil.WriteFile(filepath.Join(dir1, ".DS_Store"), []byte("{}"), 0644)
 
 			// Start the first ingester, and get it into ACTIVE state.
 			cfg1 := defaultIngesterTestConfig()

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -225,7 +225,7 @@ func (i *Ingester) TransferTSDB(stream client.Ingester_TransferTSDBServer) error
 
 		tmpDir, err := ioutil.TempDir("", "tsdb_xfer")
 		if err != nil {
-			return errors.Wrap(err, "unable to create temporary directory storing transferred TSDB blocks")
+			return errors.Wrap(err, "unable to create temporary directory to store transferred TSDB blocks")
 		}
 		defer os.RemoveAll(tmpDir)
 
@@ -279,7 +279,7 @@ func (i *Ingester) TransferTSDB(stream client.Ingester_TransferTSDBServer) error
 			if !ok {
 				file, err = createfile(f)
 				if err != nil {
-					return errors.Wrap(err, "unable to create file storing incoming TSDB block received from LEAVING ingester")
+					return errors.Wrap(err, fmt.Sprintf("unable to create the file %s to store incoming TSDB block", f))
 				}
 				filesXfer++
 				files[f.Filename] = file
@@ -629,10 +629,11 @@ func unshippedBlocks(dir string) (map[string][]string, error) {
 		// Ensure the user dir is actually a directory. There may be spurious files
 		// in the storage, especially when using Minio in the local development environment.
 		if stat, err := os.Stat(userDir); err == nil && !stat.IsDir() {
+			level.Warn(util.Logger).Log("msg", "skipping entry while transferring TSDB blocks because not a directory", "path", userDir)
 			continue
 		}
 
-		// Seed the map with the userID to ensure we xfer the WAL, even if all blocks are shipped.
+		// Seed the map with the userID to ensure we transfer the WAL, even if all blocks are shipped.
 		blocks[userID] = []string{}
 
 		blockIDs, err := ioutil.ReadDir(userDir)

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -225,7 +225,7 @@ func (i *Ingester) TransferTSDB(stream client.Ingester_TransferTSDBServer) error
 
 		tmpDir, err := ioutil.TempDir("", "tsdb_xfer")
 		if err != nil {
-			return err
+			return errors.Wrap(err, "unable to create temporary directory storing transferred TSDB blocks")
 		}
 		defer os.RemoveAll(tmpDir)
 
@@ -279,7 +279,7 @@ func (i *Ingester) TransferTSDB(stream client.Ingester_TransferTSDBServer) error
 			if !ok {
 				file, err = createfile(f)
 				if err != nil {
-					return err
+					return errors.Wrap(err, "unable to create file storing incoming TSDB block received from LEAVING ingester")
 				}
 				filesXfer++
 				files[f.Filename] = file
@@ -618,20 +618,29 @@ func (i *Ingester) findTargetIngester(ctx context.Context) (*ring.IngesterDesc, 
 func unshippedBlocks(dir string) (map[string][]string, error) {
 	userIDs, err := ioutil.ReadDir(dir)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to list the directory containing TSDB blocks")
 	}
 
 	blocks := make(map[string][]string, len(userIDs))
 	for _, user := range userIDs {
 		userID := user.Name()
-		blocks[userID] = []string{} // seed the map with the userID to ensure we xfer the WAL, even if all blocks are shipped
+		userDir := filepath.Join(dir, userID)
 
-		blockIDs, err := ioutil.ReadDir(filepath.Join(dir, userID))
+		// Ensure the user dir is actually a directory. There may be spurious files
+		// in the storage, especially when using Minio in the local development environment.
+		if stat, err := os.Stat(userDir); err == nil && !stat.IsDir() {
+			continue
+		}
+
+		// Seed the map with the userID to ensure we xfer the WAL, even if all blocks are shipped.
+		blocks[userID] = []string{}
+
+		blockIDs, err := ioutil.ReadDir(userDir)
 		if err != nil {
 			return nil, err
 		}
 
-		m, err := shipper.ReadMetaFile(filepath.Join(dir, userID))
+		m, err := shipper.ReadMetaFile(userDir)
 		if err != nil {
 			if !os.IsNotExist(err) {
 				return nil, err

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -279,7 +279,7 @@ func (i *Ingester) TransferTSDB(stream client.Ingester_TransferTSDBServer) error
 			if !ok {
 				file, err = createfile(f)
 				if err != nil {
-					return errors.Wrap(err, fmt.Sprintf("unable to create the file %s to store incoming TSDB block", f))
+					return errors.Wrapf(err, "unable to create file %s to store incoming TSDB block", f)
 				}
 				filesXfer++
 				files[f.Filename] = file

--- a/pkg/ingester/wal_test.go
+++ b/pkg/ingester/wal_test.go
@@ -2,18 +2,11 @@ package ingester
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/util"
-	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/require"
 )
-
-func init() {
-	util.Logger = log.NewLogfmtLogger(os.Stdout)
-}
 
 func TestWAL(t *testing.T) {
 	dirname, err := ioutil.TempDir("", "cortex-wal")

--- a/pkg/ingester/wal_test.go
+++ b/pkg/ingester/wal_test.go
@@ -2,11 +2,18 @@ package ingester
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	util.Logger = log.NewLogfmtLogger(os.Stdout)
+}
 
 func TestWAL(t *testing.T) {
 	dirname, err := ioutil.TempDir("", "cortex-wal")


### PR DESCRIPTION
**What this PR does**:
In the local development environment may happen that a spurious file is in the TSDB blocks directory. This shouldn't happen in production, but if that happens for any reason I believe it's safer to just skip it instead of having the ingester transfer breaking.

In this PR:
- Ensure TSDB blocks transfer work even if a spurious file is in the TSDB blocks directory
- Wrap more errors that could occur during the transfer, in order to easily identify issues

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
