### PR TITLE
Make Cortex release binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test clean images protos exes
+.PHONY: all test clean images protos exes dist
 .DEFAULT_GOAL := all
 
 # Boiler plate for bulding Docker containers.
@@ -205,3 +205,12 @@ check-doc: clean-doc doc
 
 web-serve:
 	cd website && hugo --config config.toml -v server
+
+# Generate binaries for a Cortex release
+dist:
+	rm -fr ./dist
+	mkdir -p ./dist
+	GOOS="linux"  GOARCH="amd64" CGO_ENABLED=0 go build $(GO_FLAGS) -o ./dist/cortex-linux-amd64   ./cmd/cortex
+	GOOS="darwin" GOARCH="amd64" CGO_ENABLED=0 go build $(GO_FLAGS) -o ./dist/cortex-darwin-amd64  ./cmd/cortex
+	shasum -a 256 ./dist/cortex-darwin-amd64 | cut -d ' ' -f 1 > ./dist/cortex-darwin-amd64-sha-256
+	shasum -a 256 ./dist/cortex-linux-amd64  | cut -d ' ' -f 1 > ./dist/cortex-linux-amd64-sha-256

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -76,3 +76,5 @@ $ git push --tags
 Signing a tag with a GPG key is appreciated, but in case you can't add a GPG key to your Github account using the following [procedure](https://help.github.com/articles/generating-a-gpg-key/), you can replace the `-s` flag by `-a` flag of the `git tag` command to only annotate the tag without signing.
 
 Once a tag is created, the release process through CircleCI will be triggered for this tag. If everything goes smoothly, create a release in the GitHub UI with the changelog for this release.
+
+Finally run `make dist` to build binaries into `./dist` and attach them to the release on GitHub.


### PR DESCRIPTION
**What this PR does**:
As requested by @tomwilkie, I've built the binaries for the Cortex `0.6.0` and added an entry to the `Makefile` to easily do it next time.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
