### PR TITLE
Return error instead of os.Exit when initializing Alertmanager

### DIFF
--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/cluster"
 	amconfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/client_golang/prometheus"
@@ -188,8 +189,7 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig, cfgCfg confi
 			cluster.DefaultProbeInterval,
 		)
 		if err != nil {
-			level.Error(util.Logger).Log("msg", "unable to initialize gossip mesh", "err", err)
-			os.Exit(1)
+			return nil, errors.Wrap(err, "unable to initialize gossip mesh")
 		}
 		err = peer.Join(cluster.DefaultReconnectInterval, cluster.DefaultReconnectTimeout)
 		if err != nil {

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -448,7 +448,7 @@ func (t *Cortex) stopConfigs() error {
 func (t *Cortex) initAlertmanager(cfg *Config) (err error) {
 	t.alertmanager, err = alertmanager.NewMultitenantAlertmanager(&cfg.Alertmanager, cfg.ConfigStore)
 	if err != nil {
-		return
+		return err
 	}
 	go t.alertmanager.Run()
 


### PR DESCRIPTION
**What this PR does**:

Instead of calling `os.Exit` the Alertmanager will return an error when it is being initialized.