### PR TITLE
Do not log to stdout in ingester tests

### DIFF
--- a/pkg/ingester/wal_test.go
+++ b/pkg/ingester/wal_test.go
@@ -2,18 +2,11 @@ package ingester
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/util"
-	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/require"
 )
-
-func init() {
-	util.Logger = log.NewLogfmtLogger(os.Stdout)
-}
 
 func TestWAL(t *testing.T) {
 	dirname, err := ioutil.TempDir("", "cortex-wal")


### PR DESCRIPTION
**What this PR does**:
As per the #2048 discussion, I'm removing the override to log to stdout in `pkg/ingester` tests. If required, we'll figure out a better way to conditionally turn on the stdout logger in unit tests.

**Which issue(s) this PR fixes**:
Fixes #2048

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
