### PR TITLE
Adding Cassandra retries & updating the flush order of chunks/series when they use different storage layers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * [ENHANCEMENT] Experimental TSDB: Export TSDB Syncer metrics from Compactor component, they are prefixed with `cortex_compactor_`. #2023
 * [ENHANCEMENT] Experimental TSDB: Added dedicated flag `-experimental.tsdb.bucket-store.tenant-sync-concurrency` to configure the maximum number of concurrent tenants for which blocks are synched. #2026
 * [ENHANCEMENT] Experimental TSDB: Expose metrics for objstore operations (prefixed with `cortex_<component>_thanos_objstore_`, component being one of `ingester`, `querier` and `compactor`). #2027
+* [ENHANCEMENT] Cassanda Storage: added `retry_count`, `retry_min_backoff` and `retry_max_backoff` configuration options to enable retrying recoverable errors. #2010
+* [ENHANCEMENT] Reversing the order of write operations in order to only attempt a chunk write if the series index succeeds first. Reduces redundant chunk writes operations. #2009 
 * [BUGFIX] Experimental TSDB: fixed `/all_user_stats` and `/api/prom/user_stats` endpoints when using the experimental TSDB blocks storage. #2042
 
 Cortex 0.4.0 is the last version that can *write* denormalised tokens. Cortex 0.5.0 and above always write normalised tokens.

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1388,6 +1388,18 @@ cassandra:
   # CLI flag: -cassandra.connect-timeout
   [connect_timeout: <duration> | default = 600ms]
 
+  # Number of retries to perform on a request. (Default is 0: no retries)
+  # CLI flag: -cassandra.retry-count
+  [retry_count: <int> | default = 0]
+
+  # Maximum time to wait before retrying a failed request. (Default = 10s)
+  # CLI flag: -cassandra.retry-max-backoff
+  [retry_max_backoff: <duration> | default = 10s]
+
+  # Minimum time to wait before retrying a failed request. (Default = 100ms)
+  # CLI flag: -cassandra.retry-min-backoff
+  [retry_min_backoff: <duration> | default = 100ms]
+
 boltdb:
   # Location of BoltDB index files.
   # CLI flag: -boltdb.dir

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -30,6 +30,9 @@ type Config struct {
 	Password                 string        `yaml:"password,omitempty"`
 	Timeout                  time.Duration `yaml:"timeout,omitempty"`
 	ConnectTimeout           time.Duration `yaml:"connect_timeout,omitempty"`
+	Retries                  int           `yaml:"retry_count"`
+	MaxBackoff               time.Duration `yaml:"retry_max_backoff"`
+	MinBackoff               time.Duration `yaml:"retry_min_backoff"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -48,6 +51,9 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.Password, "cassandra.password", "", "Password to use when connecting to cassandra.")
 	f.DurationVar(&cfg.Timeout, "cassandra.timeout", 600*time.Millisecond, "Timeout when connecting to cassandra.")
 	f.DurationVar(&cfg.ConnectTimeout, "cassandra.connect-timeout", 600*time.Millisecond, "Initial connection timeout, used during initial dial to server.")
+	f.IntVar(&cfg.Retries, "cassandra.retry-count", 0, "Number of retries to perform on a request. (Default is 0: no retries)")
+	f.DurationVar(&cfg.MinBackoff, "cassandra.retry-min-backoff", 100*time.Millisecond, "Minimum time to wait before retrying a failed request. (Default = 100ms)")
+	f.DurationVar(&cfg.MaxBackoff, "cassandra.retry-max-backoff", 10*time.Second, "Maximum time to wait before retrying a failed request. (Default = 10s)")
 }
 
 func (cfg *Config) session() (*gocql.Session, error) {
@@ -68,6 +74,13 @@ func (cfg *Config) session() (*gocql.Session, error) {
 	cluster.QueryObserver = observer{}
 	cluster.Timeout = cfg.Timeout
 	cluster.ConnectTimeout = cfg.ConnectTimeout
+	if cfg.Retries > 0 {
+		cluster.RetryPolicy = &gocql.ExponentialBackoffRetryPolicy{
+			NumRetries: cfg.Retries,
+			Min:        cfg.MinBackoff,
+			Max:        cfg.MaxBackoff,
+		}
+	}
 	cfg.setClusterConfig(cluster)
 
 	return cluster.CreateSession()


### PR DESCRIPTION

**What this PR does**: This PR addresses 2 items in the code base.
1. The Cassandra storage provider did not currently support retrying requests where the error is recoverable (timeout, etc). This adds settings for the number of retries to perform as well as values to control the exponential backoff details (min/max wait time).
2. Reverses the order in which series and chunks are flushed. Prior to this change the order was to write the chunk first and then the series. Since most blob storage services that can be used for chunks (S3, GCS and Azure) all charge a fee for writing data, if the series index write fails after a chunk write due to error or throttling; the cost for writing the chunk is wasted as it will be written again when the flush is retried. Since the ingesters will retry failed flushes immediately, this cost can escalate quickly if the error condition of the index store is sustained for long periods.

**Which issue(s) this PR fixes**:
Fixes #2009 
Fixes #2010 

**Checklist**
- [x]  ran `make doc`
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
