### PR TITLE
ingester v2: add MaxSeriesPerUser limit

### DIFF
--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -70,6 +70,11 @@ func (l *SeriesLimiter) MaxSeriesPerQuery(userID string) int {
 	return l.limits.MaxSeriesPerQuery(userID)
 }
 
+// MaxSamplesPerQuery returns the maximum number of sample a query is allowed to hit.
+func (l *SeriesLimiter) MaxSamplesPerQuery(userID string) int {
+	return l.limits.MaxSamplesPerQuery(userID)
+}
+
 func (l *SeriesLimiter) maxSeriesPerMetric(userID string) int {
 	localLimit := l.limits.MaxLocalSeriesPerMetric(userID)
 	globalLimit := l.limits.MaxGlobalSeriesPerMetric(userID)


### PR DESCRIPTION
**What this PR does**:
This is part of the Limit Support work in TSDB. Limit the number of recent series per user. Configure by `-ingester.max-series-per-user`, etc.

**Which issue(s) this PR fixes**:
#1823 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
