### PR TITLE
Reduced memory allocations in the ingesters for the blocks storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [ENHANCEMENT] Experimental TSDB: Added dedicated flag `-experimental.tsdb.bucket-store.tenant-sync-concurrency` to configure the maximum number of concurrent tenants for which blocks are synched. #2026
 * [ENHANCEMENT] Experimental TSDB: Expose metrics for objstore operations (prefixed with `cortex_<component>_thanos_objstore_`, component being one of `ingester`, `querier` and `compactor`). #2027
 * [ENHANCEMENT] Experiemental TSDB: Added support for Azure Storage to be used for block storage, in addition to S3 and GCS. #2083
+* [ENHANCEMENT] Experimental TSDB: Reduced memory allocations in the ingesters when using the experimental blocks storage. #2057
 * [ENHANCEMENT] Cassanda Storage: added `max_retries`, `retry_min_backoff` and `retry_max_backoff` configuration options to enable retrying recoverable errors. #2054
 * [ENHANCEMENT] Allow to configure HTTP and gRPC server listen address, maximum number of simultaneous connections and connection keepalive settings.
   * `-server.http-listen-address`

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/gate"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb"
@@ -40,6 +41,7 @@ type Shipper interface {
 
 type userTSDB struct {
 	*tsdb.DB
+	refCache *cortex_tsdb.RefCache
 
 	// Thanos shipper used to ship blocks to the storage.
 	shipper       Shipper
@@ -126,16 +128,21 @@ func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides,
 	}
 
 	i.done.Add(1)
-	go i.rateUpdateLoop()
+	go i.updateLoop()
 
 	return i, nil
 }
 
-func (i *Ingester) rateUpdateLoop() {
+func (i *Ingester) updateLoop() {
 	defer i.done.Done()
 
 	rateUpdateTicker := time.NewTicker(i.cfg.RateUpdatePeriod)
 	defer rateUpdateTicker.Stop()
+
+	// We use an hardcoded value for this ticket because there should be no
+	// real value in customizing it.
+	refCachePurgeTicker := time.NewTicker(5 * time.Minute)
+	defer refCachePurgeTicker.Stop()
 
 	for {
 		select {
@@ -146,6 +153,13 @@ func (i *Ingester) rateUpdateLoop() {
 				db.ingestedRuleSamples.tick()
 			}
 			i.userStatesMtx.RUnlock()
+		case <-refCachePurgeTicker.C:
+			for _, userID := range i.getTSDBUsers() {
+				userDB := i.getTSDB(userID)
+				if userDB != nil {
+					userDB.refCache.Purge(time.Now().UnixNano(), cortex_tsdb.DefaultRefCacheTTL)
+				}
+			}
 		case <-i.quit:
 			return
 		}
@@ -190,18 +204,45 @@ func (i *Ingester) v2Push(ctx old_ctx.Context, req *client.WriteRequest) (*clien
 	// successfully committed
 	succeededSamplesCount := 0
 	failedSamplesCount := 0
+	now := model.Now().UnixNano()
 
 	// Walk the samples, appending them to the users database
 	app := db.Appender()
 	for _, ts := range req.Timeseries {
-		// Convert labels to the type expected by TSDB
-		lset := client.FromLabelAdaptersToLabelsWithCopy(ts.Labels)
+		// Check if we already have a cached reference for this series. Be aware
+		// that even if we have a reference it's not guaranteed to be still valid.
+		cachedRef, cachedRefExists := db.refCache.GetRef(now, client.FromLabelAdaptersToLabels(ts.Labels))
 
 		for _, s := range ts.Samples {
-			_, err := app.Add(lset, s.TimestampMs, s.Value)
-			if err == nil {
-				succeededSamplesCount++
-				continue
+			var err error
+
+			// If the cached reference exists, we try to use it.
+			if cachedRefExists {
+				if err = app.AddFast(cachedRef, s.TimestampMs, s.Value); err == nil {
+					succeededSamplesCount++
+					continue
+				}
+
+				if err == tsdb.ErrNotFound {
+					cachedRefExists = false
+				}
+			}
+
+			// If the cached reference doesn't exist, we (re)try without using the reference.
+			if !cachedRefExists {
+				var ref uint64
+
+				// Copy the label set because both TSDB and the cache may retain it.
+				copiedLabels := client.FromLabelAdaptersToLabelsWithCopy(ts.Labels)
+
+				if ref, err = app.Add(copiedLabels, s.TimestampMs, s.Value); err == nil {
+					db.refCache.SetRef(now, copiedLabels, ref)
+					cachedRef = ref
+					cachedRefExists = true
+
+					succeededSamplesCount++
+					continue
+				}
 			}
 
 			failedSamplesCount++
@@ -212,7 +253,7 @@ func (i *Ingester) v2Push(ctx old_ctx.Context, req *client.WriteRequest) (*clien
 			// we actually ingested all samples which haven't failed.
 			if err == tsdb.ErrOutOfBounds || err == tsdb.ErrOutOfOrderSample || err == tsdb.ErrAmendSample {
 				if firstPartialErr == nil {
-					firstPartialErr = errors.Wrapf(err, "series=%s", lset.String())
+					firstPartialErr = errors.Wrapf(err, "series=%s", client.FromLabelAdaptersToLabels(ts.Labels).String())
 				}
 
 				continue
@@ -552,6 +593,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 
 	userDB := &userTSDB{
 		DB:                  db,
+		refCache:            cortex_tsdb.NewRefCache(),
 		ingestedAPISamples:  newEWMARate(0.2, i.cfg.RateUpdatePeriod),
 		ingestedRuleSamples: newEWMARate(0.2, i.cfg.RateUpdatePeriod),
 	}

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -156,7 +156,7 @@ func (i *Ingester) updateLoop() {
 			for _, userID := range i.getTSDBUsers() {
 				userDB := i.getTSDB(userID)
 				if userDB != nil {
-					userDB.refCache.Purge(time.Now().Add(time.Duration(-cortex_tsdb.DefaultRefCacheTTL)))
+					userDB.refCache.Purge(time.Now().Add(-cortex_tsdb.DefaultRefCacheTTL))
 				}
 			}
 		case <-i.quit:

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -138,7 +138,7 @@ func (i *Ingester) updateLoop() {
 	rateUpdateTicker := time.NewTicker(i.cfg.RateUpdatePeriod)
 	defer rateUpdateTicker.Stop()
 
-	// We use an hardcoded value for this ticket because there should be no
+	// We use an hardcoded value for this ticker because there should be no
 	// real value in customizing it.
 	refCachePurgeTicker := time.NewTicker(5 * time.Minute)
 	defer refCachePurgeTicker.Stop()
@@ -210,7 +210,7 @@ func (i *Ingester) v2Push(ctx old_ctx.Context, req *client.WriteRequest) (*clien
 	for _, ts := range req.Timeseries {
 		// Check if we already have a cached reference for this series. Be aware
 		// that even if we have a reference it's not guaranteed to be still valid.
-		cachedRef, cachedRefExists := db.refCache.GetRef(now, client.FromLabelAdaptersToLabels(ts.Labels))
+		cachedRef, cachedRefExists := db.refCache.Ref(now, client.FromLabelAdaptersToLabels(ts.Labels))
 
 		for _, s := range ts.Samples {
 			var err error

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -226,6 +226,7 @@ func (i *Ingester) v2Push(ctx old_ctx.Context, req *client.WriteRequest) (*clien
 
 				if err == tsdb.ErrNotFound {
 					cachedRefExists = false
+					err = nil
 				}
 			}
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/gate"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb"
@@ -157,7 +156,7 @@ func (i *Ingester) updateLoop() {
 			for _, userID := range i.getTSDBUsers() {
 				userDB := i.getTSDB(userID)
 				if userDB != nil {
-					userDB.refCache.Purge(time.Now().UnixNano(), cortex_tsdb.DefaultRefCacheTTL)
+					userDB.refCache.Purge(time.Now().Add(time.Duration(-cortex_tsdb.DefaultRefCacheTTL)))
 				}
 			}
 		case <-i.quit:
@@ -204,7 +203,7 @@ func (i *Ingester) v2Push(ctx old_ctx.Context, req *client.WriteRequest) (*clien
 	// successfully committed
 	succeededSamplesCount := 0
 	failedSamplesCount := 0
-	now := model.Now().UnixNano()
+	now := time.Now()
 
 	// Walk the samples, appending them to the users database
 	app := db.Appender()

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -210,6 +210,8 @@ func (i *Ingester) v2Push(ctx old_ctx.Context, req *client.WriteRequest) (*clien
 	for _, ts := range req.Timeseries {
 		// Check if we already have a cached reference for this series. Be aware
 		// that even if we have a reference it's not guaranteed to be still valid.
+		// The labels must be sorted (in our case, it's guaranteed a write request
+		// has sorted labels once hit the ingester).
 		cachedRef, cachedRefExists := db.refCache.Ref(now, client.FromLabelAdaptersToLabels(ts.Labels))
 
 		for _, s := range ts.Samples {

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -245,6 +245,61 @@ func TestIngester_v2Push(t *testing.T) {
 	}
 }
 
+func TestIngester_v2Push_ShouldHandleTheCaseTheCachedReferenceIsInvalid(t *testing.T) {
+	metricLabelAdapters := []client.LabelAdapter{{Name: labels.MetricName, Value: "test"}}
+	metricLabels := client.FromLabelAdaptersToLabels(metricLabelAdapters)
+
+	// Create a mocked ingester
+	cfg := defaultIngesterTestConfig()
+	cfg.LifecyclerConfig.JoinAfter = 0
+
+	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
+	require.NoError(t, err)
+	defer i.Shutdown()
+	defer cleanup()
+
+	ctx := user.InjectOrgID(context.Background(), userID)
+
+	// Wait until the ingester is ACTIVE
+	test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {
+		return i.lifecycler.GetState()
+	})
+
+	// Set a wrong cached reference for the series we're going to push.
+	db, err := i.getOrCreateTSDB(userID, false)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	db.refCache.SetRef(model.Now().UnixNano(), metricLabels, 12345)
+
+	// Push the same series multiple times, each time with an increasing timestamp
+	for j := 1; j <= 3; j++ {
+		req := client.ToWriteRequest(
+			[]labels.Labels{metricLabels},
+			[]client.Sample{{Value: float64(j), TimestampMs: int64(j)}},
+			client.API)
+
+		_, err := i.v2Push(ctx, req)
+		require.NoError(t, err)
+	}
+
+	// Read back samples to see what has been really ingested
+	res, err := i.v2Query(ctx, &client.QueryRequest{
+		StartTimestampMs: math.MinInt64,
+		EndTimestampMs:   math.MaxInt64,
+		Matchers:         []*client.LabelMatcher{{Type: client.REGEX_MATCH, Name: labels.MetricName, Value: ".*"}},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, []client.TimeSeries{
+		{Labels: metricLabelAdapters, Samples: []client.Sample{
+			{Value: 1, TimestampMs: 1},
+			{Value: 2, TimestampMs: 2},
+			{Value: 3, TimestampMs: 3},
+		}},
+	}, res.Timeseries)
+}
+
 func TestIngester_v2Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *testing.T) {
 	metricLabelAdapters := []client.LabelAdapter{{Name: labels.MetricName, Value: "test"}}
 	metricLabels := client.FromLabelAdaptersToLabels(metricLabelAdapters)

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -269,7 +269,7 @@ func TestIngester_v2Push_ShouldHandleTheCaseTheCachedReferenceIsInvalid(t *testi
 	db, err := i.getOrCreateTSDB(userID, false)
 	require.NoError(t, err)
 	require.NotNil(t, db)
-	db.refCache.SetRef(model.Now().UnixNano(), metricLabels, 12345)
+	db.refCache.SetRef(time.Now(), metricLabels, 12345)
 
 	// Push the same series multiple times, each time with an increasing timestamp
 	for j := 1; j <= 3; j++ {

--- a/pkg/storage/tsdb/ref_cache.go
+++ b/pkg/storage/tsdb/ref_cache.go
@@ -60,8 +60,8 @@ func NewRefCache() *RefCache {
 
 // GetRef returns the cached series reference, and guarantees the input labels set
 // is NOT retained.
-func (c *RefCache) GetRef(now time.Time, series []labels.Label) (uint64, bool) {
-	fp := client.FastFingerprint(client.FromLabelsToLabelAdapters(series))
+func (c *RefCache) GetRef(now time.Time, series labels.Labels) (uint64, bool) {
+	fp := client.Fingerprint(series)
 
 	// Get the related stripe
 	stripeID := uint8(util.HashFP(fp) % refCacheStripes)
@@ -92,8 +92,8 @@ func (c *RefCache) GetRef(now time.Time, series []labels.Label) (uint64, bool) {
 }
 
 // SetRef sets/updates the cached series reference. The input labels set IS retained.
-func (c *RefCache) SetRef(now time.Time, series []labels.Label, ref uint64) {
-	fp := client.FastFingerprint(client.FromLabelsToLabelAdapters(series))
+func (c *RefCache) SetRef(now time.Time, series labels.Labels, ref uint64) {
+	fp := client.Fingerprint(series)
 
 	// Get the related stripe
 	stripeID := uint8(util.HashFP(fp) % refCacheStripes)

--- a/pkg/storage/tsdb/ref_cache.go
+++ b/pkg/storage/tsdb/ref_cache.go
@@ -1,0 +1,164 @@
+package tsdb
+
+import (
+	"sync"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+const (
+	// DefaultRefCacheTTL is the default RefCache purge TTL. We use a reasonable
+	// value that should cover most use cases. The cache would be ineffective if
+	// the scrape interval of a series is greater than this TTL.
+	DefaultRefCacheTTL = int64(5 * time.Minute)
+
+	refCacheStripes = 128
+)
+
+// RefCache is a single-tenant cache mapping a labels set with the reference
+// ID in TSDB, in order to be able to append samples to the TSDB head without having
+// to copy write request series labels each time (because the memory buffers used to
+// unmarshal the write request is reused).
+type RefCache struct {
+	// The cache is splitted into stripes, each one with a dedicated lock, in
+	// order to reduce lock contention.
+	stripes map[uint8]*refCacheStripe
+}
+
+// refCacheStripe holds a subset of the series references for a single tenant.
+type refCacheStripe struct {
+	refsMu sync.Mutex
+	refs   map[model.Fingerprint][]*refCacheEntry
+}
+
+// refCacheEntry holds a single series reference.
+type refCacheEntry struct {
+	lbs       labels.Labels
+	ref       uint64
+	touchedAt int64
+}
+
+// NewRefCache makes a new RefCache.
+func NewRefCache() *RefCache {
+	c := &RefCache{
+		stripes: make(map[uint8]*refCacheStripe, refCacheStripes),
+	}
+
+	// Stripes are pre-allocated so that we only read on them and no lock is required.
+	for i := uint8(0); i < refCacheStripes; i++ {
+		c.stripes[i] = &refCacheStripe{
+			refs: map[model.Fingerprint][]*refCacheEntry{},
+		}
+	}
+
+	return c
+}
+
+// GetRef returns the cached series reference, and guarantees the input labels set
+// is NOT retained.
+func (c *RefCache) GetRef(now int64, series []labels.Label) (uint64, bool) {
+	fp := client.FastFingerprint(client.FromLabelsToLabelAdapters(series))
+
+	// Get the related stripe
+	stripeID := uint8(util.HashFP(fp) % refCacheStripes)
+	stripe := c.stripes[stripeID]
+
+	// Look for series within the stripe
+	stripe.refsMu.Lock()
+
+	entries, ok := stripe.refs[fp]
+	if !ok {
+		stripe.refsMu.Unlock()
+		return 0, false
+	}
+
+	for _, entry := range entries {
+		if labels.Equal(entry.lbs, series) {
+			// Get the reference and touch the timestamp before releasing the lock
+			ref := entry.ref
+			entry.touchedAt = now
+			stripe.refsMu.Unlock()
+
+			return ref, true
+		}
+	}
+
+	stripe.refsMu.Unlock()
+	return 0, false
+}
+
+// SetRef sets/updates the cached series reference. The input labels set IS retained.
+func (c *RefCache) SetRef(now int64, series []labels.Label, ref uint64) {
+	fp := client.FastFingerprint(client.FromLabelsToLabelAdapters(series))
+
+	// Get the related stripe
+	stripeID := uint8(util.HashFP(fp) % refCacheStripes)
+	stripe := c.stripes[stripeID]
+
+	stripe.refsMu.Lock()
+
+	// Check if already exists within the entries.
+	entries := stripe.refs[fp]
+	if entries != nil {
+		for _, entry := range entries {
+			if !labels.Equal(entry.lbs, series) {
+				continue
+			}
+
+			entry.ref = ref
+			entry.touchedAt = now
+			stripe.refsMu.Unlock()
+			return
+		}
+	}
+
+	// The entry doesn't exist, so we have to add a new one.
+	stripe.refs[fp] = append(stripe.refs[fp], &refCacheEntry{lbs: series, ref: ref, touchedAt: now})
+	stripe.refsMu.Unlock()
+}
+
+// Purge removes expired entries from the cache. This function should be called
+// periodically to avoid memory leaks.
+func (c *RefCache) Purge(now int64, ttl int64) {
+	for s := uint8(0); s < refCacheStripes; s++ {
+		c.purgeStripe(now, ttl, c.stripes[s])
+	}
+}
+
+func (c *RefCache) purgeStripe(now int64, ttl int64, stripe *refCacheStripe) {
+	stripe.refsMu.Lock()
+	defer stripe.refsMu.Unlock()
+
+	for fp, entries := range stripe.refs {
+		// Since we do expect very few fingerprint collisions, we
+		// have an optimized implementation for the common case.
+		if len(entries) == 1 {
+			if entries[0].touchedAt < now-ttl {
+				delete(stripe.refs, fp)
+			}
+
+			continue
+		}
+
+		// We have more entries, which means there's a collision,
+		// so we have to iterate over the entries.
+		for i := 0; i < len(entries); {
+			if entries[i].touchedAt < now-ttl {
+				entries = append(entries[:i], entries[i+1:]...)
+			} else {
+				i++
+			}
+		}
+
+		// Either update or delete the entries in the map
+		if len(entries) == 0 {
+			delete(stripe.refs, fp)
+		} else {
+			stripe.refs[fp] = entries
+		}
+	}
+}

--- a/pkg/storage/tsdb/ref_cache.go
+++ b/pkg/storage/tsdb/ref_cache.go
@@ -14,7 +14,7 @@ const (
 	// DefaultRefCacheTTL is the default RefCache purge TTL. We use a reasonable
 	// value that should cover most use cases. The cache would be ineffective if
 	// the scrape interval of a series is greater than this TTL.
-	DefaultRefCacheTTL = int64(5 * time.Minute)
+	DefaultRefCacheTTL = 5 * time.Minute
 
 	refCacheStripes = 128
 )

--- a/pkg/storage/tsdb/ref_cache.go
+++ b/pkg/storage/tsdb/ref_cache.go
@@ -102,18 +102,15 @@ func (c *RefCache) SetRef(now int64, series []labels.Label, ref uint64) {
 	stripe.refsMu.Lock()
 
 	// Check if already exists within the entries.
-	entries := stripe.refs[fp]
-	if entries != nil {
-		for _, entry := range entries {
-			if !labels.Equal(entry.lbs, series) {
-				continue
-			}
-
-			entry.ref = ref
-			entry.touchedAt = now
-			stripe.refsMu.Unlock()
-			return
+	for _, entry := range stripe.refs[fp] {
+		if !labels.Equal(entry.lbs, series) {
+			continue
 		}
+
+		entry.ref = ref
+		entry.touchedAt = now
+		stripe.refsMu.Unlock()
+		return
 	}
 
 	// The entry doesn't exist, so we have to add a new one.

--- a/pkg/storage/tsdb/ref_cache.go
+++ b/pkg/storage/tsdb/ref_cache.go
@@ -24,9 +24,9 @@ const (
 // to copy write request series labels each time (because the memory buffers used to
 // unmarshal the write request is reused).
 type RefCache struct {
-	// The cache is splitted into stripes, each one with a dedicated lock, in
+	// The cache is split into stripes, each one with a dedicated lock, in
 	// order to reduce lock contention.
-	stripes map[uint8]*refCacheStripe
+	stripes []*refCacheStripe
 }
 
 // refCacheStripe holds a subset of the series references for a single tenant.
@@ -45,7 +45,7 @@ type refCacheEntry struct {
 // NewRefCache makes a new RefCache.
 func NewRefCache() *RefCache {
 	c := &RefCache{
-		stripes: make(map[uint8]*refCacheStripe, refCacheStripes),
+		stripes: make([]*refCacheStripe, refCacheStripes, refCacheStripes),
 	}
 
 	// Stripes are pre-allocated so that we only read on them and no lock is required.
@@ -58,9 +58,9 @@ func NewRefCache() *RefCache {
 	return c
 }
 
-// GetRef returns the cached series reference, and guarantees the input labels set
+// Ref returns the cached series reference, and guarantees the input labels set
 // is NOT retained.
-func (c *RefCache) GetRef(now time.Time, series labels.Labels) (uint64, bool) {
+func (c *RefCache) Ref(now time.Time, series labels.Labels) (uint64, bool) {
 	fp := client.Fingerprint(series)
 
 	// Get the related stripe

--- a/pkg/storage/tsdb/ref_cache.go
+++ b/pkg/storage/tsdb/ref_cache.go
@@ -26,7 +26,7 @@ const (
 type RefCache struct {
 	// The cache is split into stripes, each one with a dedicated lock, in
 	// order to reduce lock contention.
-	stripes []*refCacheStripe
+	stripes [refCacheStripes]*refCacheStripe
 }
 
 // refCacheStripe holds a subset of the series references for a single tenant.
@@ -44,9 +44,7 @@ type refCacheEntry struct {
 
 // NewRefCache makes a new RefCache.
 func NewRefCache() *RefCache {
-	c := &RefCache{
-		stripes: make([]*refCacheStripe, refCacheStripes, refCacheStripes),
-	}
+	c := &RefCache{}
 
 	// Stripes are pre-allocated so that we only read on them and no lock is required.
 	for i := uint8(0); i < refCacheStripes; i++ {

--- a/pkg/storage/tsdb/ref_cache.go
+++ b/pkg/storage/tsdb/ref_cache.go
@@ -39,7 +39,7 @@ type refCacheStripe struct {
 type refCacheEntry struct {
 	lbs       labels.Labels
 	ref       uint64
-	touchedAt int64
+	touchedAt time.Time
 }
 
 // NewRefCache makes a new RefCache.
@@ -60,7 +60,7 @@ func NewRefCache() *RefCache {
 
 // GetRef returns the cached series reference, and guarantees the input labels set
 // is NOT retained.
-func (c *RefCache) GetRef(now int64, series []labels.Label) (uint64, bool) {
+func (c *RefCache) GetRef(now time.Time, series []labels.Label) (uint64, bool) {
 	fp := client.FastFingerprint(client.FromLabelsToLabelAdapters(series))
 
 	// Get the related stripe
@@ -92,7 +92,7 @@ func (c *RefCache) GetRef(now int64, series []labels.Label) (uint64, bool) {
 }
 
 // SetRef sets/updates the cached series reference. The input labels set IS retained.
-func (c *RefCache) SetRef(now int64, series []labels.Label, ref uint64) {
+func (c *RefCache) SetRef(now time.Time, series []labels.Label, ref uint64) {
 	fp := client.FastFingerprint(client.FromLabelsToLabelAdapters(series))
 
 	// Get the related stripe
@@ -120,13 +120,13 @@ func (c *RefCache) SetRef(now int64, series []labels.Label, ref uint64) {
 
 // Purge removes expired entries from the cache. This function should be called
 // periodically to avoid memory leaks.
-func (c *RefCache) Purge(now int64, ttl int64) {
+func (c *RefCache) Purge(keepUntil time.Time) {
 	for s := uint8(0); s < refCacheStripes; s++ {
-		c.purgeStripe(now, ttl, c.stripes[s])
+		c.purgeStripe(keepUntil, c.stripes[s])
 	}
 }
 
-func (c *RefCache) purgeStripe(now int64, ttl int64, stripe *refCacheStripe) {
+func (c *RefCache) purgeStripe(keepUntil time.Time, stripe *refCacheStripe) {
 	stripe.refsMu.Lock()
 	defer stripe.refsMu.Unlock()
 
@@ -134,7 +134,7 @@ func (c *RefCache) purgeStripe(now int64, ttl int64, stripe *refCacheStripe) {
 		// Since we do expect very few fingerprint collisions, we
 		// have an optimized implementation for the common case.
 		if len(entries) == 1 {
-			if entries[0].touchedAt < now-ttl {
+			if entries[0].touchedAt.Before(keepUntil) {
 				delete(stripe.refs, fp)
 			}
 
@@ -144,7 +144,7 @@ func (c *RefCache) purgeStripe(now int64, ttl int64, stripe *refCacheStripe) {
 		// We have more entries, which means there's a collision,
 		// so we have to iterate over the entries.
 		for i := 0; i < len(entries); {
-			if entries[i].touchedAt < now-ttl {
+			if entries[i].touchedAt.Before(keepUntil) {
 				entries = append(entries[:i], entries[i+1:]...)
 			} else {
 				i++

--- a/pkg/storage/tsdb/ref_cache_test.go
+++ b/pkg/storage/tsdb/ref_cache_test.go
@@ -2,56 +2,59 @@ package tsdb
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRefCache_GetAndSetReferences(t *testing.T) {
+	now := time.Now()
 	ls1 := []labels.Label{{Name: "a", Value: "1"}}
 	ls2 := []labels.Label{{Name: "a", Value: "2"}}
 
 	c := NewRefCache()
-	_, ok := c.GetRef(0, ls1)
+	_, ok := c.GetRef(now, ls1)
 	assert.Equal(t, false, ok)
 
-	_, ok = c.GetRef(0, ls2)
+	_, ok = c.GetRef(now, ls2)
 	assert.Equal(t, false, ok)
 
-	c.SetRef(0, ls1, 1)
-	ref, ok := c.GetRef(0, ls1)
+	c.SetRef(now, ls1, 1)
+	ref, ok := c.GetRef(now, ls1)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, uint64(1), ref)
 
-	_, ok = c.GetRef(0, ls2)
+	_, ok = c.GetRef(now, ls2)
 	assert.Equal(t, false, ok)
 
-	c.SetRef(0, ls2, 2)
-	ref, ok = c.GetRef(0, ls2)
+	c.SetRef(now, ls2, 2)
+	ref, ok = c.GetRef(now, ls2)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, uint64(2), ref)
 
 	// Overwrite a value with a new one
-	c.SetRef(0, ls2, 3)
-	ref, ok = c.GetRef(0, ls2)
+	c.SetRef(now, ls2, 3)
+	ref, ok = c.GetRef(now, ls2)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, uint64(3), ref)
 }
 
 func TestRefCache_ShouldCorrectlyHandleFingerprintCollisions(t *testing.T) {
+	now := time.Now()
 	// The two following series have the same FastFingerprint=e002a3a451262627
 	ls1 := []labels.Label{{Name: labels.MetricName, Value: "fast_fingerprint_collision"}, {Name: "app", Value: "l"}, {Name: "uniq0", Value: "0"}, {Name: "uniq1", Value: "1"}}
 	ls2 := []labels.Label{{Name: labels.MetricName, Value: "fast_fingerprint_collision"}, {Name: "app", Value: "m"}, {Name: "uniq0", Value: "1"}, {Name: "uniq1", Value: "1"}}
 
 	c := NewRefCache()
-	c.SetRef(0, ls1, 1)
-	c.SetRef(0, ls2, 2)
+	c.SetRef(now, ls1, 1)
+	c.SetRef(now, ls2, 2)
 
-	ref, ok := c.GetRef(0, ls1)
+	ref, ok := c.GetRef(now, ls1)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, uint64(1), ref)
 
-	ref, ok = c.GetRef(0, ls2)
+	ref, ok = c.GetRef(now, ls2)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, uint64(2), ref)
 }
@@ -67,15 +70,15 @@ func TestRefCache_Purge(t *testing.T) {
 
 	// Run the same test for increasing TTL values
 	for ttl := 0; ttl <= len(series); ttl++ {
-		now := int64(100)
+		now := time.Unix(100, 0)
 		c := NewRefCache()
 
 		// Set the series to the cache with decreasing timestamps
 		for i := 0; i < len(series); i++ {
-			c.SetRef(now-int64(i), series[i], uint64(i))
+			c.SetRef(now.Add(time.Duration(-i)*time.Second), series[i], uint64(i))
 		}
 
-		c.Purge(now, int64(ttl))
+		c.Purge(now.Add(time.Duration(-ttl) * time.Second))
 
 		// Check retained and purged entries
 		for i := 0; i <= ttl && i < len(series); i++ {
@@ -92,22 +95,24 @@ func TestRefCache_Purge(t *testing.T) {
 }
 
 func BenchmarkRefCache_SetRef(b *testing.B) {
+	now := time.Now()
 	ls := []labels.Label{{Name: "a", Value: "1"}}
 	c := NewRefCache()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.SetRef(0, ls, uint64(i))
+		c.SetRef(now, ls, uint64(i))
 	}
 }
 
 func BenchmarkRefCache_GetRef(b *testing.B) {
+	now := time.Now()
 	ls := []labels.Label{{Name: "a", Value: "1"}}
 	c := NewRefCache()
-	c.SetRef(0, ls, 1)
+	c.SetRef(now, ls, 1)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.GetRef(0, ls)
+		c.GetRef(now, ls)
 	}
 }

--- a/pkg/storage/tsdb/ref_cache_test.go
+++ b/pkg/storage/tsdb/ref_cache_test.go
@@ -1,6 +1,7 @@
 package tsdb
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -95,24 +96,42 @@ func TestRefCache_Purge(t *testing.T) {
 }
 
 func BenchmarkRefCache_SetRef(b *testing.B) {
+	const numSeries = 10000
+
+	// Prepare series
+	series := [numSeries]labels.Labels{}
+	for s := 0; s < numSeries; s++ {
+		series[s] = labels.Labels{{Name: "a", Value: strconv.Itoa(s)}}
+	}
+
 	now := time.Now()
-	ls := []labels.Label{{Name: "a", Value: "1"}}
 	c := NewRefCache()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.SetRef(now, ls, uint64(i))
+		for s := 0; s < numSeries; s++ {
+			c.SetRef(now, series[0], uint64(i))
+		}
 	}
 }
 
 func BenchmarkRefCache_Ref(b *testing.B) {
+	const numSeries = 10000
+
 	now := time.Now()
-	ls := []labels.Label{{Name: "a", Value: "1"}}
 	c := NewRefCache()
-	c.SetRef(now, ls, 1)
+
+	// Prepare series
+	series := [numSeries]labels.Labels{}
+	for s := 0; s < numSeries; s++ {
+		series[s] = labels.Labels{{Name: "a", Value: strconv.Itoa(s)}}
+		c.SetRef(now, series[s], uint64(s))
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.Ref(now, ls)
+		for s := 0; s < numSeries; s++ {
+			c.Ref(now, series[s])
+		}
 	}
 }

--- a/pkg/storage/tsdb/ref_cache_test.go
+++ b/pkg/storage/tsdb/ref_cache_test.go
@@ -14,28 +14,28 @@ func TestRefCache_GetAndSetReferences(t *testing.T) {
 	ls2 := []labels.Label{{Name: "a", Value: "2"}}
 
 	c := NewRefCache()
-	_, ok := c.GetRef(now, ls1)
+	_, ok := c.Ref(now, ls1)
 	assert.Equal(t, false, ok)
 
-	_, ok = c.GetRef(now, ls2)
+	_, ok = c.Ref(now, ls2)
 	assert.Equal(t, false, ok)
 
 	c.SetRef(now, ls1, 1)
-	ref, ok := c.GetRef(now, ls1)
+	ref, ok := c.Ref(now, ls1)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, uint64(1), ref)
 
-	_, ok = c.GetRef(now, ls2)
+	_, ok = c.Ref(now, ls2)
 	assert.Equal(t, false, ok)
 
 	c.SetRef(now, ls2, 2)
-	ref, ok = c.GetRef(now, ls2)
+	ref, ok = c.Ref(now, ls2)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, uint64(2), ref)
 
 	// Overwrite a value with a new one
 	c.SetRef(now, ls2, 3)
-	ref, ok = c.GetRef(now, ls2)
+	ref, ok = c.Ref(now, ls2)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, uint64(3), ref)
 }
@@ -50,11 +50,11 @@ func TestRefCache_ShouldCorrectlyHandleFingerprintCollisions(t *testing.T) {
 	c.SetRef(now, ls1, 1)
 	c.SetRef(now, ls2, 2)
 
-	ref, ok := c.GetRef(now, ls1)
+	ref, ok := c.Ref(now, ls1)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, uint64(1), ref)
 
-	ref, ok = c.GetRef(now, ls2)
+	ref, ok = c.Ref(now, ls2)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, uint64(2), ref)
 }
@@ -82,13 +82,13 @@ func TestRefCache_Purge(t *testing.T) {
 
 		// Check retained and purged entries
 		for i := 0; i <= ttl && i < len(series); i++ {
-			ref, ok := c.GetRef(now, series[i])
+			ref, ok := c.Ref(now, series[i])
 			assert.Equal(t, true, ok)
 			assert.Equal(t, uint64(i), ref)
 		}
 
 		for i := ttl + 1; i < len(series); i++ {
-			_, ok := c.GetRef(now, series[i])
+			_, ok := c.Ref(now, series[i])
 			assert.Equal(t, false, ok)
 		}
 	}
@@ -105,7 +105,7 @@ func BenchmarkRefCache_SetRef(b *testing.B) {
 	}
 }
 
-func BenchmarkRefCache_GetRef(b *testing.B) {
+func BenchmarkRefCache_Ref(b *testing.B) {
 	now := time.Now()
 	ls := []labels.Label{{Name: "a", Value: "1"}}
 	c := NewRefCache()
@@ -113,6 +113,6 @@ func BenchmarkRefCache_GetRef(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.GetRef(now, ls)
+		c.Ref(now, ls)
 	}
 }


### PR DESCRIPTION
**What this PR does**:
In this PR I'm proposing a solution to reduce memory allocations in the ingesters for the blocks storage, introducing `RefCache` to hold TSDB series references.

Looking at our blocks storage test cluster, we can observe 25% of memory allocations is done by `FromLabelAdaptersToLabelsWithCopy`. Contrary to the chunks storage, whenever we call TSDB `appender.Add()` we have to pass a copy of the labels because they may be retained by TSDB (the request labels are reused to reduce memory allocations).

This PR introduces a series reference cache, so that we can use `appender.AddFast()` instead of `Add()` passing the series reference ID (which is a `uint64`) instead of the labels each time we have the reference cached.

Some notes about the `RefCache` design:
1. It's per-tenant, so we have 1 for each tenant
2. It stripes the cache into 128 buckets to reduce lock contention (128 is a trade-off to not use too much memory on clusters with many tenants but few series, like @thorfour use case)
3. It's intentional having no cap on the max number of series cached in the cache, but there's a purge mechanism to quickly remove stale series. If there would be a cap, once the cap is reached other series would have labels being copied every time, which would allocate that memory anyway until the next GC runs, so keeping all active series references in memory looks a win-win to me.

I'm running this change in our test cluster and memory allocations have been reduced by -25%. In the chart below I'm not showing memory allocation rate > 20 MB/s to hide away the noise every 2 hours when all TSDBs compact the head at the same time (it's another issue, see https://github.com/cortexproject/cortex/issues/2003).

![Screen Shot 2020-01-31 at 08 39 57](https://user-images.githubusercontent.com/1701904/73521400-28030300-4406-11ea-9a6a-aff6b7657d65.png)

I've **not** observed any difference in GC duration time or ingesters response time, neither in the ingesters `go_memstats_heap_inuse_bytes` except that it grows a bit slower because of the reduced allocations, as shown below (same time range):

![Screen Shot 2020-01-31 at 08 50 02](https://user-images.githubusercontent.com/1701904/73521588-b11a3a00-4406-11ea-83a2-07e7fc21b023.png)


**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
