### PR TITLE
Replace 'ingesters' with 'replicas' in error message

### DIFF
--- a/pkg/ring/replication_strategy.go
+++ b/pkg/ring/replication_strategy.go
@@ -36,7 +36,7 @@ func (r *Ring) replicationStrategy(ingesters []IngesterDesc, op Operation) ([]In
 	// This is just a shortcut - if there are not minSuccess available ingesters,
 	// after filtering out dead ones, don't even bother trying.
 	if maxFailure < 0 || len(ingesters) < minSuccess {
-		err := fmt.Errorf("at least %d live ingesters required, could only find %d",
+		err := fmt.Errorf("at least %d live replicas required, could only find %d",
 			minSuccess, len(ingesters))
 		return nil, 0, err
 	}

--- a/pkg/ring/replication_strategy_test.go
+++ b/pkg/ring/replication_strategy_test.go
@@ -28,7 +28,7 @@ func TestReplicationStrategy(t *testing.T) {
 		{
 			RF:            1,
 			DeadIngesters: 1,
-			ExpectedError: "at least 1 live ingesters required, could only find 0",
+			ExpectedError: "at least 1 live replicas required, could only find 0",
 		},
 
 		// Ensure it works for the default production config.
@@ -49,7 +49,7 @@ func TestReplicationStrategy(t *testing.T) {
 			RF:            3,
 			LiveIngesters: 1,
 			DeadIngesters: 2,
-			ExpectedError: "at least 2 live ingesters required, could only find 1",
+			ExpectedError: "at least 2 live replicas required, could only find 1",
 		},
 
 		// Ensure it works when adding / removing nodes.
@@ -72,7 +72,7 @@ func TestReplicationStrategy(t *testing.T) {
 			RF:            3,
 			LiveIngesters: 2,
 			DeadIngesters: 2,
-			ExpectedError: "at least 3 live ingesters required, could only find 2",
+			ExpectedError: "at least 3 live replicas required, could only find 2",
 		},
 	} {
 		ingesters := []IngesterDesc{}


### PR DESCRIPTION
This error will appear in contexts where we are not talking about ingesters, e.g. when running sharded rulers.

An example of the error message is at #2058 .

(Do we need to mention this in CHANGELOG?  Do we care about people parsing the text of error messages?)