### PR TITLE
Blocks querier: don't reencode TSDB chunks to Cortex chunks during querying

### DIFF
--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
+	prom_storage "github.com/prometheus/prometheus/storage"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
 	"google.golang.org/grpc"
@@ -181,9 +182,9 @@ type Cortex struct {
 	compactor         *compactor.Compactor
 	memberlistKVState *memberlistKVState
 
-	// The chunk store that the querier should use to query the long
+	// Queryable that the querier should use to query the long
 	// term storage. It depends on the storage engine used.
-	querierChunkStore querier.ChunkStore
+	storeQueryable prom_storage.Queryable
 }
 
 // New makes a new Cortex.

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -49,7 +49,7 @@ const (
 	Distributor
 	Ingester
 	Querier
-	QuerierChunkStore
+	StoreQueryable
 	QueryFrontend
 	Store
 	TableManager
@@ -79,8 +79,8 @@ func (m moduleName) String() string {
 		return "ingester"
 	case Querier:
 		return "querier"
-	case QuerierChunkStore:
-		return "querier-chunk-store"
+	case StoreQueryable:
+		return "store-queryable"
 	case QueryFrontend:
 		return "query-frontend"
 	case TableManager:
@@ -125,8 +125,8 @@ func (m *moduleName) Set(s string) error {
 	case "querier":
 		*m = Querier
 		return nil
-	case "querier-chunk-store":
-		*m = QuerierChunkStore
+	case "store-queryable":
+		*m = StoreQueryable
 		return nil
 	case "query-frontend":
 		*m = QueryFrontend
@@ -238,7 +238,7 @@ func (t *Cortex) stopDistributor() (err error) {
 }
 
 func (t *Cortex) initQuerier(cfg *Config) (err error) {
-	queryable, engine := querier.New(cfg.Querier, t.distributor, querier.NewChunkStoreQueryable(cfg.Querier, t.querierChunkStore))
+	queryable, engine := querier.New(cfg.Querier, t.distributor, t.storeQueryable)
 	api := v1.NewAPI(
 		engine,
 		queryable,
@@ -287,26 +287,25 @@ func (t *Cortex) stopQuerier() error {
 	return nil
 }
 
-func (t *Cortex) initQuerierChunkStore(cfg *Config) error {
+func (t *Cortex) initStoreQueryable(cfg *Config) error {
 	if cfg.Storage.Engine == storage.StorageEngineChunks {
-		t.querierChunkStore = t.store
+		t.storeQueryable = querier.NewChunkStoreQueryable(cfg.Querier, t.store)
 		return nil
 	}
 
 	if cfg.Storage.Engine == storage.StorageEngineTSDB {
-		store, err := querier.NewBlockQuerier(cfg.TSDB, cfg.Server.LogLevel, prometheus.DefaultRegisterer)
+		storeQueryable, err := querier.NewBlockQueryable(cfg.TSDB, cfg.Server.LogLevel, prometheus.DefaultRegisterer)
 		if err != nil {
 			return err
 		}
-
-		t.querierChunkStore = store
+		t.storeQueryable = storeQueryable
 		return nil
 	}
 
 	return fmt.Errorf("unknown storage engine '%s'", cfg.Storage.Engine)
 }
 
-func (t *Cortex) stopQuerierChunkStore() error {
+func (t *Cortex) stopStoreQueryable() error {
 	return nil
 }
 
@@ -439,7 +438,7 @@ func (t *Cortex) stopTableManager() error {
 func (t *Cortex) initRuler(cfg *Config) (err error) {
 	cfg.Ruler.Ring.ListenPort = cfg.Server.GRPCListenPort
 	cfg.Ruler.Ring.KVStore.MemberlistKV = t.memberlistKVState.getMemberlistKV
-	queryable, engine := querier.New(cfg.Querier, t.distributor, querier.NewChunkStoreQueryable(cfg.Querier, t.querierChunkStore))
+	queryable, engine := querier.New(cfg.Querier, t.distributor, t.storeQueryable)
 
 	t.ruler, err = ruler.NewRuler(cfg.Ruler, engine, queryable, t.distributor, prometheus.DefaultRegisterer, util.Logger)
 	if err != nil {
@@ -587,15 +586,15 @@ var modules = map[moduleName]module{
 	},
 
 	Querier: {
-		deps: []moduleName{Distributor, Store, Ring, Server, QuerierChunkStore},
+		deps: []moduleName{Distributor, Store, Ring, Server, StoreQueryable},
 		init: (*Cortex).initQuerier,
 		stop: (*Cortex).stopQuerier,
 	},
 
-	QuerierChunkStore: {
+	StoreQueryable: {
 		deps: []moduleName{Store},
-		init: (*Cortex).initQuerierChunkStore,
-		stop: (*Cortex).stopQuerierChunkStore,
+		init: (*Cortex).initStoreQueryable,
+		stop: (*Cortex).stopStoreQueryable,
 	},
 
 	QueryFrontend: {
@@ -611,7 +610,7 @@ var modules = map[moduleName]module{
 	},
 
 	Ruler: {
-		deps: []moduleName{Distributor, Store, QuerierChunkStore},
+		deps: []moduleName{Distributor, Store, StoreQueryable},
 		init: (*Cortex).initRuler,
 		stop: (*Cortex).stopRuler,
 	},

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -129,36 +129,13 @@ func convertMatchersToLabelMatcher(matchers []*labels.Matcher) []storepb.LabelMa
 }
 
 func (b *blocksQuerier) LabelValues(name string) ([]string, storage.Warnings, error) {
-	log, ctx := spanlogger.New(b.ctx, "blocksQuerier.LabelValues")
-	defer log.Span.Finish()
-
-	ctx = b.addUserToContext(ctx)
-	resp, err := b.client.LabelValues(ctx, &storepb.LabelValuesRequest{
-		Label:                   name,
-		PartialResponseDisabled: false,
-		PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return resp.Values, nil, nil
+	// Cortex doesn't use this. It will ask ingesters for metadata.
+	return nil, nil, errors.New("not implemented")
 }
 
 func (b *blocksQuerier) LabelNames() ([]string, storage.Warnings, error) {
-	log, ctx := spanlogger.New(b.ctx, "blocksQuerier.LabelValues")
-	defer log.Span.Finish()
-
-	ctx = b.addUserToContext(ctx)
-	resp, err := b.client.LabelNames(ctx, &storepb.LabelNamesRequest{
-		PartialResponseDisabled: false,
-		PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return resp.Names, nil, nil
+	// Cortex doesn't use this. It will ask ingesters for metadata.
+	return nil, nil, errors.New("not implemented")
 }
 
 func (b *blocksQuerier) Close() error {

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -2,35 +2,33 @@ package querier
 
 import (
 	"context"
-	"fmt"
 	"io"
+	"sort"
 
-	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/weaveworks/common/logging"
+	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/cortexproject/cortex/pkg/chunk"
-	"github.com/cortexproject/cortex/pkg/chunk/encoding"
-	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
-// BlockQuerier is a querier of thanos blocks
-type BlockQuerier struct {
+// BlockQueryable is a storage.Queryable implementation for blocks storage
+type BlockQueryable struct {
 	us *UserStore
 }
 
-// NewBlockQuerier returns a client to query a block store
-func NewBlockQuerier(cfg tsdb.Config, logLevel logging.Level, registerer prometheus.Registerer) (*BlockQuerier, error) {
+// NewBlockQueryable returns a client to query a block store
+func NewBlockQueryable(cfg tsdb.Config, logLevel logging.Level, registerer prometheus.Registerer) (*BlockQueryable, error) {
 	bucketClient, err := tsdb.NewBucketClient(context.Background(), cfg, "cortex-userstore", util.Logger)
 	if err != nil {
 		return nil, err
@@ -45,21 +43,67 @@ func NewBlockQuerier(cfg tsdb.Config, logLevel logging.Level, registerer prometh
 		return nil, err
 	}
 
-	b := &BlockQuerier{
-		us: us,
-	}
+	b := &BlockQueryable{us: us}
 
 	return b, nil
 }
 
-// Get implements the ChunkStore interface. It makes a block query and converts the response into chunks
-func (b *BlockQuerier) Get(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]chunk.Chunk, error) {
-	log, ctx := spanlogger.New(ctx, "BlockQuerier.Get")
+// Querier returns a new Querier on the storage.
+func (b *BlockQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+	userID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, promql.ErrStorage{Err: err}
+	}
+
+	return &blocksQuerier{
+		ctx:    ctx,
+		client: b.us.client,
+		mint:   mint,
+		maxt:   maxt,
+		userID: userID,
+	}, nil
+}
+
+type blocksQuerier struct {
+	ctx        context.Context
+	client     storepb.StoreClient
+	mint, maxt int64
+	userID     string
+}
+
+func (b *blocksQuerier) addUserToContext(ctx context.Context) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, "user", b.userID)
+}
+
+func (b *blocksQuerier) Select(sp *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	log, ctx := spanlogger.New(b.ctx, "blocksQuerier.Select")
 	defer log.Span.Finish()
 
-	client := b.us.client
+	mint, maxt := b.mint, b.maxt
+	if sp != nil {
+		mint, maxt = sp.Start, sp.End
+	}
+	converted := convertMatchersToLabelMatcher(matchers)
 
-	// Convert matchers to LabelMatcher
+	ctx = b.addUserToContext(ctx)
+	// returned series are sorted
+	seriesClient, err := b.client.Series(ctx, &storepb.SeriesRequest{
+		MinTime:                 mint,
+		MaxTime:                 maxt,
+		Matchers:                converted,
+		PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &blockQuerierSeriesSet{
+		ctx:          ctx,
+		seriesClient: seriesClient,
+	}, nil, nil
+}
+
+func convertMatchersToLabelMatcher(matchers []*labels.Matcher) []storepb.LabelMatcher {
 	var converted []storepb.LabelMatcher
 	for _, m := range matchers {
 		var t storepb.LabelMatcher_Type
@@ -80,91 +124,237 @@ func (b *BlockQuerier) Get(ctx context.Context, userID string, from, through mod
 			Value: m.Value,
 		})
 	}
+	return converted
+}
 
-	ctx = metadata.AppendToOutgoingContext(ctx, "user", userID)
-	seriesClient, err := client.Series(ctx, &storepb.SeriesRequest{
-		MinTime:                 int64(from),
-		MaxTime:                 int64(through),
-		Matchers:                converted,
+func (b *blocksQuerier) LabelValues(name string) ([]string, storage.Warnings, error) {
+	log, ctx := spanlogger.New(b.ctx, "blocksQuerier.LabelValues")
+	defer log.Span.Finish()
+
+	ctx = b.addUserToContext(ctx)
+	resp, err := b.client.LabelValues(ctx, &storepb.LabelValuesRequest{
+		Label:                   name,
+		PartialResponseDisabled: false,
 		PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	var chunks []chunk.Chunk
-	for {
-		resp, err := seriesClient.Recv()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
-		}
-
-		// Convert Thanos store series into Cortex chunks
-		convertedChunks, err := seriesToChunks(userID, resp.GetSeries())
-		if err != nil {
-			level.Error(log).Log("msg", "failed converting TSDB series to Cortex chunks", "err", err)
-			return nil, err
-		}
-
-		chunks = append(chunks, convertedChunks...)
-	}
-
-	return chunks, nil
+	return resp.Values, nil, nil
 }
 
-func seriesToChunks(userID string, series *storepb.Series) ([]chunk.Chunk, error) {
-	var lbls labels.Labels
-	for _, label := range series.Labels {
-		// We have to remove the external label set by the shipper
-		if label.Name == tsdb.TenantIDExternalLabel {
+func (b *blocksQuerier) LabelNames() ([]string, storage.Warnings, error) {
+	log, ctx := spanlogger.New(b.ctx, "blocksQuerier.LabelValues")
+	defer log.Span.Finish()
+
+	ctx = b.addUserToContext(ctx)
+	resp, err := b.client.LabelNames(ctx, &storepb.LabelNamesRequest{
+		PartialResponseDisabled: false,
+		PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return resp.Names, nil, nil
+}
+
+func (b *blocksQuerier) Close() error {
+	// nothing to do here.
+	return nil
+}
+
+// implementation of storage.SeriesSet, based streamed responses from store client.
+type blockQuerierSeriesSet struct {
+	ctx          context.Context
+	seriesClient storepb.Store_SeriesClient
+
+	err error
+
+	currSeries *storepb.Series
+	currChunks []storepb.AggrChunk
+
+	nextSeries *storepb.Series
+}
+
+func (bqss *blockQuerierSeriesSet) Next() bool {
+	if bqss.err != nil {
+		return false
+	}
+
+	bqss.currSeries, bqss.currChunks = nil, nil
+
+	// if there was any cached 'next' series, let's use it.
+	if bqss.nextSeries != nil {
+		bqss.currSeries = bqss.nextSeries
+		bqss.currChunks = append(bqss.currChunks, bqss.currSeries.Chunks...)
+		bqss.nextSeries = nil
+	}
+
+	// collect chunks for current series. Chunks may come in multiple responses, but as soon
+	// as the response has chunks for a new series, we can stop searching. Series are sorted.
+	// See documentation for StoreClient.Series call for details.
+	for {
+		r, err := bqss.seriesClient.Recv()
+		if err != nil {
+			bqss.err = err
+			break
+		}
+
+		s := r.GetSeries()
+		// response may either contain series or warning. If it's warning, we get nil here. We ignore warnings, as it's
+		// too late to return them.
+		if s == nil {
 			continue
 		}
 
-		lbls = append(lbls, labels.Label{
-			Name:  label.Name,
-			Value: label.Value,
-		})
-	}
-
-	chunks := make([]chunk.Chunk, 0, len(series.Chunks))
-
-	for _, c := range series.Chunks {
-		ch := encoding.New()
-
-		enc, err := chunkenc.FromData(chunkenc.EncXOR, c.Raw.Data)
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("failed to initialize chunk from XOR encoded raw data (series: %v min time: %d max time: %d)", lbls, c.MinTime, c.MaxTime))
-		}
-
-		it := enc.Iterator(nil)
-		for it.Next() {
-			ts, v := it.At()
-			overflow, err := ch.Add(model.SamplePair{
-				Timestamp: model.Time(ts),
-				Value:     model.SampleValue(v),
-			})
-			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("failed adding sample to chunk (series: %v timestamp: %d value: %f)", lbls, ts, v))
-			}
-
-			if overflow != nil {
-				chunks = append(chunks, chunk.NewChunk(userID, client.Fingerprint(lbls), lbls, ch, model.Time(c.MinTime), model.Time(c.MaxTime)))
-				ch = overflow
-			}
-		}
-
-		// Ensure the iteration has not been interrupted because of an error
-		if it.Err() != nil {
-			return nil, errors.Wrap(it.Err(), fmt.Sprintf("failed reading sample from encoded chunk (series: %v min time: %d max time: %d)", lbls, c.MinTime, c.MaxTime))
-		}
-
-		if ch.Len() > 0 {
-			chunks = append(chunks, chunk.NewChunk(userID, client.Fingerprint(lbls), lbls, ch, model.Time(c.MinTime), model.Time(c.MaxTime)))
+		// check if it's still the same series as the 'current' one
+		if bqss.currSeries == nil {
+			bqss.currSeries = s
+			bqss.currChunks = append(bqss.currChunks, s.Chunks...)
+			// Scan for more chunks in subsequent responses
+		} else if storepb.CompareLabels(bqss.currSeries.Labels, s.Labels) == 0 {
+			bqss.currChunks = append(bqss.currChunks, bqss.currSeries.Chunks...)
+		} else {
+			// We have received chunks for next series. Keep it for later, and
+			// stop collecting chunks for the current one.
+			bqss.nextSeries = s
+			break
 		}
 	}
 
-	return chunks, nil
+	if bqss.err != nil && bqss.err != io.EOF {
+		return false
+	}
+
+	return bqss.currSeries != nil && len(bqss.currChunks) > 0
 }
+
+func (bqss *blockQuerierSeriesSet) At() storage.Series {
+	if bqss.currSeries == nil {
+		return nil
+	}
+
+	return newBlockQuerierSeries(bqss.currSeries.Labels, bqss.currChunks)
+}
+
+func (bqss *blockQuerierSeriesSet) Err() error {
+	if bqss.err != nil && bqss.err != io.EOF {
+		return bqss.err
+	}
+
+	return nil
+}
+
+func newBlockQuerierSeries(labels []storepb.Label, chunks []storepb.AggrChunk) *blockQuerierSeries {
+	sort.Slice(chunks, func(i, j int) bool {
+		return chunks[i].MinTime < chunks[j].MinTime
+	})
+
+	return &blockQuerierSeries{labels: labels, chunks: chunks}
+}
+
+type blockQuerierSeries struct {
+	labels []storepb.Label
+	chunks []storepb.AggrChunk
+}
+
+func (bqs *blockQuerierSeries) Labels() labels.Labels {
+	res := make(labels.Labels, 0, len(bqs.labels))
+	for _, l := range bqs.labels {
+		// We have to remove the external label set by the shipper
+		if l.Name == tsdb.TenantIDExternalLabel {
+			continue
+		}
+		res = append(res, labels.Label{Name: l.Name, Value: l.Value})
+	}
+	return res
+}
+
+func (bqs *blockQuerierSeries) Iterator() storage.SeriesIterator {
+	if len(bqs.chunks) == 0 {
+		// should not happen in practice, but we have a unit test for it
+		return errSeriesIterator{err: errors.New("no chunks")}
+	}
+
+	its := make([]chunkenc.Iterator, 0, len(bqs.chunks))
+
+	for _, c := range bqs.chunks {
+		ch, err := chunkenc.FromData(chunkenc.EncXOR, c.Raw.Data)
+		if err != nil {
+			return errSeriesIterator{err: errors.Wrapf(err, "failed to initialize chunk from XOR encoded raw data (series: %v min time: %d max time: %d)", bqs.Labels(), c.MinTime, c.MaxTime)}
+		}
+
+		it := ch.Iterator(nil)
+		its = append(its, it)
+	}
+
+	return &blockQuerierSeriesIterator{series: bqs, iterators: its}
+}
+
+// blockQuerierSeriesIterator implements a series iterator on top
+// of a list of time-sorted, non-overlapping chunks.
+type blockQuerierSeriesIterator struct {
+	// only used for reporting errors
+	series *blockQuerierSeries
+
+	iterators []chunkenc.Iterator
+	i         int
+}
+
+func (it *blockQuerierSeriesIterator) Seek(t int64) (ok bool) {
+	// We generally expect the chunks already to be cut down
+	// to the range we are interested in. There's not much to be gained from
+	// hopping across chunks so we just call next until we reach t.
+	for {
+		ct, _ := it.At()
+		if ct >= t {
+			return true
+		}
+		if !it.Next() {
+			return false
+		}
+	}
+}
+
+func (it *blockQuerierSeriesIterator) At() (t int64, v float64) {
+	return it.iterators[it.i].At()
+}
+
+func (it *blockQuerierSeriesIterator) Next() bool {
+	lastT, _ := it.At()
+
+	if it.iterators[it.i].Next() {
+		return true
+	}
+	if it.Err() != nil {
+		return false
+	}
+	if it.i >= len(it.iterators)-1 {
+		return false
+	}
+	// Chunks are guaranteed to be ordered but not generally guaranteed to not overlap.
+	// We must ensure to skip any overlapping range between adjacent chunks.
+	it.i++
+	return it.Seek(lastT + 1)
+}
+
+func (it *blockQuerierSeriesIterator) Err() error {
+	err := it.iterators[it.i].Err()
+	if err != nil {
+		c := it.series.chunks[it.i]
+		return errors.Wrapf(err, "cannot iterate chunk for series: %v min time: %d max time: %d", it.series.Labels(), c.MinTime, c.MaxTime)
+	}
+	return nil
+}
+
+// iterator that only returns error
+type errSeriesIterator struct {
+	err error
+}
+
+func (errSeriesIterator) Seek(int64) bool      { return false }
+func (errSeriesIterator) Next() bool           { return false }
+func (errSeriesIterator) At() (int64, float64) { return 0, 0 }
+func (it errSeriesIterator) Err() error        { return it.err }

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -275,7 +275,7 @@ func (bqs *blockQuerierSeries) Labels() labels.Labels {
 func (bqs *blockQuerierSeries) Iterator() storage.SeriesIterator {
 	if len(bqs.chunks) == 0 {
 		// should not happen in practice, but we have a unit test for it
-		return errSeriesIterator{err: errors.New("no chunks")}
+		return errIterator{err: errors.New("no chunks")}
 	}
 
 	its := make([]chunkenc.Iterator, 0, len(bqs.chunks))
@@ -283,7 +283,7 @@ func (bqs *blockQuerierSeries) Iterator() storage.SeriesIterator {
 	for _, c := range bqs.chunks {
 		ch, err := chunkenc.FromData(chunkenc.EncXOR, c.Raw.Data)
 		if err != nil {
-			return errSeriesIterator{err: errors.Wrapf(err, "failed to initialize chunk from XOR encoded raw data (series: %v min time: %d max time: %d)", bqs.Labels(), c.MinTime, c.MaxTime)}
+			return errIterator{err: errors.Wrapf(err, "failed to initialize chunk from XOR encoded raw data (series: %v min time: %d max time: %d)", bqs.Labels(), c.MinTime, c.MaxTime)}
 		}
 
 		it := ch.Iterator(nil)
@@ -348,13 +348,3 @@ func (it *blockQuerierSeriesIterator) Err() error {
 	}
 	return nil
 }
-
-// iterator that only returns error
-type errSeriesIterator struct {
-	err error
-}
-
-func (errSeriesIterator) Seek(int64) bool      { return false }
-func (errSeriesIterator) Next() bool           { return false }
-func (errSeriesIterator) At() (int64, float64) { return 0, 0 }
-func (it errSeriesIterator) Err() error        { return it.err }

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 )
 
-func Test_seriesToChunks(t *testing.T) {
+func TestBlockQuerierSeries(t *testing.T) {
 	t.Parallel()
 
 	// Init some test fixtures

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -31,7 +31,7 @@ func TestBlockQuerierSeries(t *testing.T) {
 	}{
 		"empty series": {
 			series:         &storepb.Series{},
-			expectedMetric: labels.Labels{},
+			expectedMetric: labels.Labels(nil),
 			expectedErr:    "no chunks",
 		},
 		"should remove the external label added by the shipper": {
@@ -82,6 +82,8 @@ func TestBlockQuerierSeries(t *testing.T) {
 				assert.Equal(t, float64(testData.expectedSamples[sampleIx].Value), val)
 				sampleIx++
 			}
+			// make sure we've got all expected samples
+			require.Equal(t, sampleIx, len(testData.expectedSamples))
 
 			if testData.expectedErr != "" {
 				require.EqualError(t, it.Err(), testData.expectedErr)

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -102,16 +102,3 @@ func mockTSDBChunkData() []byte {
 
 	return chunk.Bytes()
 }
-
-func mockTSDBChunkDataWithInvalidTimestampOrder() []byte {
-	chunk := chunkenc.NewXORChunk()
-	appender, err := chunk.Appender()
-	if err != nil {
-		panic(err)
-	}
-
-	appender.Append(time.Unix(1, 0).Unix()*1000, 1)
-	appender.Append(time.Unix(0, 0).Unix()*1000, 2)
-
-	return chunk.Bytes()
-}

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -17,26 +17,20 @@ import (
 func Test_seriesToChunks(t *testing.T) {
 	t.Parallel()
 
-	// Define a struct used to hold the expected chunk data we wanna assert on
-	type expectedChunk struct {
-		from    model.Time
-		through model.Time
-		metric  labels.Labels
-		samples []model.SamplePair
-	}
-
 	// Init some test fixtures
 	minTimestamp := time.Unix(1, 0)
 	maxTimestamp := time.Unix(10, 0)
 
 	tests := map[string]struct {
-		series         *storepb.Series
-		expectedChunks []expectedChunk
-		expectedErr    string
+		series          *storepb.Series
+		expectedMetric  labels.Labels
+		expectedSamples []model.SamplePair
+		expectedErr     string
 	}{
 		"empty series": {
 			series:         &storepb.Series{},
-			expectedChunks: []expectedChunk{},
+			expectedMetric: labels.Labels{},
+			expectedErr:    "no chunks",
 		},
 		"should remove the external label added by the shipper": {
 			series: &storepb.Series{
@@ -48,28 +42,13 @@ func Test_seriesToChunks(t *testing.T) {
 					{MinTime: minTimestamp.Unix() * 1000, MaxTime: maxTimestamp.Unix() * 1000, Raw: &storepb.Chunk{Type: storepb.Chunk_XOR, Data: mockTSDBChunkData()}},
 				},
 			},
-			expectedChunks: []expectedChunk{
-				{
-					from:    model.TimeFromUnixNano(minTimestamp.UnixNano()),
-					through: model.TimeFromUnixNano(maxTimestamp.UnixNano()),
-					metric: labels.Labels{
-						{Name: "foo", Value: "bar"},
-					},
-					samples: []model.SamplePair{
-						{Timestamp: model.TimeFromUnixNano(time.Unix(1, 0).UnixNano()), Value: model.SampleValue(1)},
-						{Timestamp: model.TimeFromUnixNano(time.Unix(2, 0).UnixNano()), Value: model.SampleValue(2)},
-					},
-				},
+			expectedMetric: labels.Labels{
+				{Name: "foo", Value: "bar"},
 			},
-		},
-		"should return error on out of order samples": {
-			series: &storepb.Series{
-				Labels: []storepb.Label{{Name: "foo", Value: "bar"}},
-				Chunks: []storepb.AggrChunk{
-					{MinTime: minTimestamp.Unix() * 1000, MaxTime: maxTimestamp.Unix() * 1000, Raw: &storepb.Chunk{Type: storepb.Chunk_XOR, Data: mockTSDBChunkDataWithInvalidTimestampOrder()}},
-				},
+			expectedSamples: []model.SamplePair{
+				{Timestamp: model.TimeFromUnixNano(time.Unix(1, 0).UnixNano()), Value: model.SampleValue(1)},
+				{Timestamp: model.TimeFromUnixNano(time.Unix(2, 0).UnixNano()), Value: model.SampleValue(2)},
 			},
-			expectedErr: `failed adding sample to chunk (series: {foo="bar"} timestamp: 0 value: 2.000000): base time delta is less than zero: -1`,
 		},
 		"should return error on failure while reading encoded chunk data": {
 			series: &storepb.Series{
@@ -78,7 +57,8 @@ func Test_seriesToChunks(t *testing.T) {
 					{MinTime: minTimestamp.Unix() * 1000, MaxTime: maxTimestamp.Unix() * 1000, Raw: &storepb.Chunk{Type: storepb.Chunk_XOR, Data: []byte{0, 1}}},
 				},
 			},
-			expectedErr: `failed reading sample from encoded chunk (series: {foo="bar"} min time: 1000 max time: 10000): EOF`,
+			expectedMetric: labels.Labels{labels.Label{Name: "foo", Value: "bar"}},
+			expectedErr:    `cannot iterate chunk for series: {foo="bar"} min time: 1000 max time: 10000: EOF`,
 		},
 	}
 
@@ -86,27 +66,25 @@ func Test_seriesToChunks(t *testing.T) {
 		testData := testData
 
 		t.Run(testName, func(t *testing.T) {
-			actualChunks, actualErr := seriesToChunks("test", testData.series)
+			series := newBlockQuerierSeries(testData.series.Labels, testData.series.Chunks)
 
-			if testData.expectedErr != "" {
-				require.EqualError(t, actualErr, testData.expectedErr)
-			} else {
-				require.NoError(t, actualErr)
+			assert.Equal(t, testData.expectedMetric, series.Labels())
+
+			sampleIx := 0
+
+			it := series.Iterator()
+			for it.Next() {
+				ts, val := it.At()
+				require.True(t, sampleIx < len(testData.expectedSamples))
+				assert.Equal(t, int64(testData.expectedSamples[sampleIx].Timestamp), ts)
+				assert.Equal(t, float64(testData.expectedSamples[sampleIx].Value), val)
+				sampleIx++
 			}
 
-			require.Equal(t, len(testData.expectedChunks), len(actualChunks))
-
-			for i, actual := range actualChunks {
-				expected := testData.expectedChunks[i]
-
-				assert.Equal(t, "test", actual.UserID)
-				assert.Equal(t, expected.from, actual.From)
-				assert.Equal(t, expected.through, actual.Through)
-				assert.Equal(t, expected.metric, actual.Metric)
-
-				samples, err := actual.Samples(actual.From, actual.Through)
-				require.NoError(t, err)
-				assert.Equal(t, expected.samples, samples)
+			if testData.expectedErr != "" {
+				require.EqualError(t, it.Err(), testData.expectedErr)
+			} else {
+				require.NoError(t, it.Err())
 			}
 		})
 	}

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -1,11 +1,15 @@
 package querier
 
 import (
+	"errors"
+	"io"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -101,4 +105,111 @@ func mockTSDBChunkData() []byte {
 	appender.Append(time.Unix(2, 0).Unix()*1000, 2)
 
 	return chunk.Bytes()
+}
+
+func TestBlockQuerierSeriesSet(t *testing.T) {
+	now := time.Now()
+
+	bss := &blockQuerierSeriesSet{
+		seriesClient: &mockSeriesClient{responses: []*storepb.SeriesResponse{
+			storepb.NewSeriesResponse(&storepb.Series{
+				Labels: mkLabels("__name__", "first"),
+				Chunks: []storepb.AggrChunk{
+					createChunkWithSineSamples(now, now.Add(100*time.Second), 3*time.Millisecond), // ceil(100 / 0.003) samples (= 33334)
+				},
+			}),
+
+			// warning series response is ignored
+			storepb.NewWarnSeriesResponse(errors.New("test error")),
+
+			// continuation of previous series
+			storepb.NewSeriesResponse(&storepb.Series{
+				Labels: mkLabels("__name__", "first"),
+				Chunks: []storepb.AggrChunk{
+					createChunkWithSineSamples(now.Add(100*time.Second), now.Add(200*time.Second), 3*time.Millisecond), // ceil(100 / 0.003) samples more, 66668 in total
+				},
+			}),
+
+			// new series
+			storepb.NewSeriesResponse(&storepb.Series{
+				Labels: mkLabels("__name__", "second"),
+				Chunks: []storepb.AggrChunk{
+					createChunkWithSineSamples(now, now.Add(200*time.Second), 5*time.Millisecond), // 200 / 0.005 (= 40000 samples)
+				},
+			}),
+		}},
+	}
+
+	verifyNextSeries(t, bss, labels.FromStrings("__name__", "first"), 66668)
+	verifyNextSeries(t, bss, labels.FromStrings("__name__", "second"), 40000)
+	require.False(t, bss.Next())
+}
+
+func verifyNextSeries(t *testing.T, ss storage.SeriesSet, labels labels.Labels, samples int) {
+	require.True(t, ss.Next())
+
+	s := ss.At()
+	require.Equal(t, labels, s.Labels())
+
+	count := 0
+	for it := s.Iterator(); it.Next(); {
+		count++
+		ts, v := it.At()
+		require.Equal(t, math.Sin(float64(ts)), v)
+	}
+
+	require.Equal(t, samples, count)
+}
+
+type mockSeriesClient struct {
+	responses []*storepb.SeriesResponse
+
+	ix int
+}
+
+func (m *mockSeriesClient) Recv() (*storepb.SeriesResponse, error) {
+	if m.ix < len(m.responses) {
+		ix := m.ix
+		m.ix++
+		return m.responses[ix], nil
+	}
+	return nil, io.EOF
+}
+
+func createChunkWithSineSamples(minTime, maxTime time.Time, step time.Duration) storepb.AggrChunk {
+	chunk := chunkenc.NewXORChunk()
+	appender, err := chunk.Appender()
+	if err != nil {
+		panic(err)
+	}
+
+	minT := minTime.Unix() * 1000
+	maxT := maxTime.Unix() * 1000
+	stepMillis := step.Milliseconds()
+
+	for t := minT; t < maxT; t += stepMillis {
+		appender.Append(t, math.Sin(float64(t)))
+	}
+
+	return storepb.AggrChunk{
+		MinTime: minT,
+		MaxTime: maxT,
+		Raw: &storepb.Chunk{
+			Type: storepb.Chunk_XOR,
+			Data: chunk.Bytes(),
+		},
+	}
+}
+
+func mkLabels(s ...string) []storepb.Label {
+	result := []storepb.Label{}
+
+	for i := 0; i+1 < len(s); i = i + 2 {
+		result = append(result, storepb.Label{
+			Name:  s[i],
+			Value: s[i+1],
+		})
+	}
+
+	return result
 }


### PR DESCRIPTION
This rewrites BlocksQuerier to implement `Queryable` interface. It does that by implementing `storage.SeriesSet` on top of returned ~streamed~ response from `StoreClient.Series` call.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
