### PR TITLE
Setup stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,11 @@ daysUntilClose: 15
 # Labels that prevent issues from being marked as stale
 exemptLabels:
   - keepalive
+  - type/bug
+  - type/performance
   - type/security
+  - help wanted
+  - CNCF migration
 
 # Label to use to identify a stale issue
 staleLabel: stale

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,24 @@
+# Days without any activity until an issue is labeled as stale
+daysUntilStale: 60
+
+# Days after having the stale label that the issue will be closed
+daysUntilClose: 15
+
+# Labels that prevent issues from being marked as stale
+exemptLabels:
+  - keepalive
+  - type/security
+
+# Label to use to identify a stale issue
+staleLabel: stale
+
+# Comment to post when marking an issue as stale. Leave as false
+# to disable.
+markComment: >
+  This issue has been automatically marked as stale because it has not had any
+  activity in the past 30 days. It will be closed in 7 days if no further
+  activity occurs. Thank you for your contributions.
+
+# Comment to post when closing a stale issue. Leave as
+# false to disable.
+closeComment: false


### PR DESCRIPTION
**What this PR does**:
In this PR I propose to setup the stale bot for the Cortex project, with the following relaxed settings:

- 60 days with no activity before an issue or PR is considered stale
- 15 days with further no activity before an issue or PR is automatically closed
- Never stale issues with the labels `type/security` or `keepalive` (this is a new label we can use to mark an issue/PR to never go stale)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
