### PR TITLE
Use buffered channel to unblock lazySet's goroutine

### DIFF
--- a/pkg/querier/lazy_querier.go
+++ b/pkg/querier/lazy_querier.go
@@ -21,7 +21,9 @@ func newLazyQuerier(next storage.Querier) storage.Querier {
 }
 
 func (l lazyQuerier) Select(params *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
-	future := make(chan storage.SeriesSet)
+	// make sure there is space in the buffer, to unblock the goroutine and let it die even if nobody is
+	// waiting for the result yet (or anymore).
+	future := make(chan storage.SeriesSet, 1)
 	go func() {
 		set, _, err := l.next.Select(params, matchers...)
 		if err != nil {


### PR DESCRIPTION
**What this PR does**: This PR makes `lazyQuerier` cancellable via context.

**Which issue(s) this PR fixes**:
Fixes #1832

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
