### PR TITLE
Fixing & Simplifying Azure Blob Download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [CHANGE] Removed unnecessary `frontend.cache-split-interval` in favor of `querier.split-queries-by-interval` both to reduce configuration complexity and guarantee alignment of these two configs. Starting from now, `-querier.cache-results` may only be enabled in conjunction with `-querier.split-queries-by-interval` (previously the cache interval default was `24h` so if you want to preserve the same behaviour you should set `-querier.split-queries-by-interval=24h`). #2040
 * [CHANGE] Removed remaining support for using denormalised tokens in the ring. If you're still running ingesters with denormalised tokens (Cortex 0.4 or earlier, with `-ingester.normalise-tokens=false`), such ingesters will now be completely invisible to distributors and need to be either switched to Cortex 0.6.0 or later, or be configured to use normalised tokens. #2034
-* [CHANGE] Moved `--store.min-chunk-age` to the Querier config as `--querier.query-store-after`, allowing the store to be skipped during query time if the metrics wouldn't be found. The YAML config option `ingestermaxquerylookback` has been renamed to `query_ingesters_within` to match its CLI flag. #1893 
+* [CHANGE] Moved `--store.min-chunk-age` to the Querier config as `--querier.query-store-after`, allowing the store to be skipped during query time if the metrics wouldn't be found. The YAML config option `ingestermaxquerylookback` has been renamed to `query_ingesters_within` to match its CLI flag. #1893
   * `--store.min-chunk-age` has been removed
   * `--querier.query-store-after` has been added in it's place.
 * [FEATURE] Added user sub rings to distribute users to a subset of ingesters. #1947
@@ -17,13 +17,14 @@
   * `-server.http-listen-address`
   * `-server.http-conn-limit`
   * `-server.grpc-listen-address`
-  * `-server.grpc-conn-limit` 
+  * `-server.grpc-conn-limit`
   * `-server.grpc.keepalive.max-connection-idle`
   * `-server.grpc.keepalive.max-connection-age`
   * `-server.grpc.keepalive.max-connection-age-grace`
   * `-server.grpc.keepalive.time`
   * `-server.grpc.keepalive.timeout`
 * [BUGFIX] Experimental TSDB: fixed `/all_user_stats` and `/api/prom/user_stats` endpoints when using the experimental TSDB blocks storage. #2042
+* [BUGFIX] Azure Blob ChunkStore: Fixed issue causing `invalid chunk checksum` errors. #2074
 
 Cortex 0.4.0 is the last version that can *write* denormalised tokens. Cortex 0.5.0 and above always write normalised tokens.
 
@@ -70,7 +71,7 @@ Further, if you're using the configs service, we've upgraded the migration libra
 * [ENHANCEMENT] Added `password` and `enable_tls` options to redis cache configuration. Enables usage of Microsoft Azure Cache for Redis service. #1923
 * [ENHANCEMENT] Upgraded Kubernetes API version for deployments from `extensions/v1beta1` to `apps/v1`. #1941
 * [ENHANCEMENT] Experimental TSDB: Open existing TSDB on startup to prevent ingester from becoming ready before it can accept writes. The max concurrency is set via `--experimental.tsdb.max-tsdb-opening-concurrency-on-startup`. #1917
-* [ENHANCEMENT] Experimental TSDB: Querier now exports aggregate metrics from Thanos bucket store and in memory index cache (many metrics to list, but all have `cortex_querier_bucket_store_` or `cortex_querier_blocks_index_cache_` prefix). #1996 
+* [ENHANCEMENT] Experimental TSDB: Querier now exports aggregate metrics from Thanos bucket store and in memory index cache (many metrics to list, but all have `cortex_querier_bucket_store_` or `cortex_querier_blocks_index_cache_` prefix). #1996
 * [ENHANCEMENT] Experimental TSDB: Improved multi-tenant bucket store. #1991
   * Allowed to configure the blocks sync interval via `-experimental.tsdb.bucket-store.sync-interval` (0 disables the sync)
   * Limited the number of tenants concurrently synched by `-experimental.tsdb.bucket-store.block-sync-concurrency`
@@ -86,20 +87,19 @@ Further, if you're using the configs service, we've upgraded the migration libra
 
 ### Upgrading PostgreSQL (if you're using configs service)
 
-Reference: https://github.com/golang-migrate/migrate/tree/master/database/postgres#upgrading-from-v1
+Reference: <https://github.com/golang-migrate/migrate/tree/master/database/postgres#upgrading-from-v1>
 
-1. Install the migrate package cli tool: https://github.com/golang-migrate/migrate/tree/master/cmd/migrate#installation
+1. Install the migrate package cli tool: <https://github.com/golang-migrate/migrate/tree/master/cmd/migrate#installation>
 2. Drop the `schema_migrations` table: `DROP TABLE schema_migrations;`.
 2. Run the migrate command:
 
 ```bash
-migrate  -path <absolute_path_to_cortex>/cmd/cortex/migrations -database postgres://localhost:5432/database force 2 
+migrate  -path <absolute_path_to_cortex>/cmd/cortex/migrations -database postgres://localhost:5432/database force 2
 ```
 
 ### Known issues
 
 - The `cortex_prometheus_rule_group_last_evaluation_timestamp_seconds` metric, tracked by the ruler, is not unregistered for rule groups not being used anymore. This issue will be fixed in the next Cortex release (see [2033](https://github.com/cortexproject/cortex/issues/2033)).
-
 
 ## 0.4.0 / 2019-12-02
 
@@ -133,6 +133,7 @@ migrate  -path <absolute_path_to_cortex>/cmd/cortex/migrations -database postgre
 * [BUGFIX] Fixed duplicated series returned when querying both ingesters and store with the experimental TSDB blocks storage. #1778
 
 In this release we updated the following dependencies:
+
 - gRPC v1.25.0  (resulted in a drop of 30% CPU usage when compression is on)
 - jaeger-client v2.20.0
 - aws-sdk-go to v1.25.22
@@ -141,21 +142,20 @@ In this release we updated the following dependencies:
 
 This release adds support for Redis as an alternative to Memcached, and also includes many optimisations which reduce CPU and memory usage.
 
-* [CHANGE] Gauge metrics were renamed to drop the `_total` suffix.	#1685
+* [CHANGE] Gauge metrics were renamed to drop the `_total` suffix. #1685
   * In Alertmanager, `alertmanager_configs_total` is now `alertmanager_configs`
   * In Ruler, `scheduler_configs_total` is now `scheduler_configs`
   * `scheduler_groups_total` is now `scheduler_groups`.
 * [CHANGE] `--alertmanager.configs.auto-slack-root` flag was dropped as auto Slack root is not supported anymore. #1597
 * [CHANGE] In table-manager, default DynamoDB capacity was reduced from 3,000 units to 1,000 units. We recommend you do not run with the defaults: find out what figures are needed for your environment and set that via `-dynamodb.periodic-table.write-throughput` and `-dynamodb.chunk-table.write-throughput`.
 * [FEATURE] Add Redis support for caching #1612
-* [FEATURE] Allow spreading chunk writes across multiple S3 buckets	#1625
+* [FEATURE] Allow spreading chunk writes across multiple S3 buckets #1625
 * [FEATURE] Added `/shutdown` endpoint for ingester to shutdown all operations of the ingester. #1746
 * [ENHANCEMENT] Upgraded Prometheus to 2.12.0 and Alertmanager to 0.19.0. #1597
 * [ENHANCEMENT] Cortex is now built with Go 1.13 #1675, #1676, #1679
 * [ENHANCEMENT] Many optimisations, mostly impacting ingester and querier: #1574, #1624, #1638, #1644, #1649, #1654, #1702
 
-Full list of changes: https://github.com/cortexproject/cortex/compare/v0.2.0...v0.3.0
-
+Full list of changes: <https://github.com/cortexproject/cortex/compare/v0.2.0...v0.3.0>
 
 ## 0.2.0 / 2019-09-05
 


### PR DESCRIPTION
**What this PR does**:  Main change was to fix an annoying bug noted in #2024 where the checksum of the downloaded blob was not valid. The underlying problem was that a buffer was passed by value instead of value. The secondary change here is to use a simpler API for downloading blobs from Azure. The previous used API used, opened multiple connections to download blobs in parallel, however this is somewhat unneeded. Even with BigChunk encoding, a given chunk is still measured in KB, plus the chunk store package already manages parallel downloading of separate chunk files. 

**Which issue(s) this PR fixes**:
Fixes #2024

**Checklist**
- [ x ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
