### PR TITLE
Fix ruler flaky tests

### DIFF
--- a/pkg/ring/testutils/testutils.go
+++ b/pkg/ring/testutils/testutils.go
@@ -13,7 +13,10 @@ import (
 // address
 func NumTokens(c kv.Client, name, ringKey string) int {
 	ringDesc, err := c.Get(context.Background(), ringKey)
-	if err != nil {
+
+	// The ringDesc may be null if the lifecycler hasn't stored the ring
+	// to the KVStore yet.
+	if ringDesc == nil || err != nil {
 		level.Error(util.Logger).Log("msg", "error reading consul", "err", err)
 		return 0
 	}

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,12 +12,8 @@ import (
 )
 
 func TestRuler_rules(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "ruler-tests")
-	defer os.RemoveAll(dir)
-	require.NoError(t, err)
-
-	cfg := defaultRulerConfig()
-	cfg.RulePath = dir
+	cfg, cleanup := defaultRulerConfig(newMockRuleStore(mockRules))
+	defer cleanup()
 
 	r := newTestRuler(t, cfg)
 	defer r.Stop()
@@ -33,7 +28,7 @@ func TestRuler_rules(t *testing.T) {
 
 	// Check status code and status response
 	responseJSON := response{}
-	err = json.Unmarshal(body, &responseJSON)
+	err := json.Unmarshal(body, &responseJSON)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Equal(t, responseJSON.Status, "success")
@@ -72,12 +67,8 @@ func TestRuler_rules(t *testing.T) {
 }
 
 func TestRuler_alerts(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "ruler-tests")
-	defer os.RemoveAll(dir)
-	require.NoError(t, err)
-
-	cfg := defaultRulerConfig()
-	cfg.RulePath = dir
+	cfg, cleanup := defaultRulerConfig(newMockRuleStore(mockRules))
+	defer cleanup()
 
 	r := newTestRuler(t, cfg)
 	defer r.Stop()
@@ -92,7 +83,7 @@ func TestRuler_alerts(t *testing.T) {
 
 	// Check status code and status response
 	responseJSON := response{}
-	err = json.Unmarshal(body, &responseJSON)
+	err := json.Unmarshal(body, &responseJSON)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Equal(t, responseJSON.Status, "success")

--- a/pkg/ruler/lifecycle_test.go
+++ b/pkg/ruler/lifecycle_test.go
@@ -11,8 +11,9 @@ import (
 
 // TestRulerShutdown tests shutting down ruler unregisters correctly
 func TestRulerShutdown(t *testing.T) {
-	config := defaultRulerConfig()
+	config, cleanup := defaultRulerConfig(newMockRuleStore(mockRules))
 	config.EnableSharding = true
+	defer cleanup()
 
 	{
 		r := newTestRuler(t, config)
@@ -27,9 +28,10 @@ func TestRulerShutdown(t *testing.T) {
 
 // TestRulerRestart tests a restarting ruler doesn't keep adding more tokens.
 func TestRulerRestart(t *testing.T) {
-	config := defaultRulerConfig()
+	config, cleanup := defaultRulerConfig(newMockRuleStore(mockRules))
 	config.Ring.SkipUnregister = true
 	config.EnableSharding = true
+	defer cleanup()
 
 	{
 		r := newTestRuler(t, config)

--- a/pkg/ruler/lifecycle_test.go
+++ b/pkg/ruler/lifecycle_test.go
@@ -7,20 +7,26 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/ring/testutils"
 	"github.com/cortexproject/cortex/pkg/util/test"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestRulerShutdown tests shutting down ruler unregisters correctly
 func TestRulerShutdown(t *testing.T) {
 	config, cleanup := defaultRulerConfig(newMockRuleStore(mockRules))
 	config.EnableSharding = true
+	config.Ring.SkipUnregister = false
 	defer cleanup()
 
-	{
-		r := newTestRuler(t, config)
-		time.Sleep(100 * time.Millisecond)
-		r.Stop() // doesn't actually unregister due to skipUnregister: true
-	}
+	r := newTestRuler(t, config)
 
+	// Wait until the tokens are registered in the ring
+	test.Poll(t, 100*time.Millisecond, config.Ring.NumTokens, func() interface{} {
+		return testutils.NumTokens(config.Ring.KVStore.Mock, "localhost", ring.RulerRingKey)
+	})
+
+	r.Stop()
+
+	// Wait until the tokens are unregistered from the ring
 	test.Poll(t, 100*time.Millisecond, 0, func() interface{} {
 		return testutils.NumTokens(config.Ring.KVStore.Mock, "localhost", ring.RulerRingKey)
 	})
@@ -33,25 +39,28 @@ func TestRulerRestart(t *testing.T) {
 	config.EnableSharding = true
 	defer cleanup()
 
-	{
-		r := newTestRuler(t, config)
-		time.Sleep(100 * time.Millisecond)
-		r.Stop() // doesn't actually unregister due to skipUnregister: true
-	}
+	r := newTestRuler(t, config)
 
-	test.Poll(t, 100*time.Millisecond, 1, func() interface{} {
+	// Wait until the tokens are registered in the ring
+	test.Poll(t, 100*time.Millisecond, config.Ring.NumTokens, func() interface{} {
 		return testutils.NumTokens(config.Ring.KVStore.Mock, "localhost", ring.RulerRingKey)
 	})
 
-	{
-		r := newTestRuler(t, config)
-		time.Sleep(100 * time.Millisecond)
-		r.Stop() // doesn't actually unregister due to skipUnregister: true
-	}
+	// Stop the ruler. Doesn't actually unregister due to skipUnregister: true
+	r.Stop()
 
-	time.Sleep(200 * time.Millisecond)
+	// We expect the tokens are preserved in the ring.
+	assert.Equal(t, config.Ring.NumTokens, testutils.NumTokens(config.Ring.KVStore.Mock, "localhost", ring.RulerRingKey))
 
-	test.Poll(t, 100*time.Millisecond, 1, func() interface{} {
-		return testutils.NumTokens(config.Ring.KVStore.Mock, "localhost", ring.RulerRingKey)
+	// Create a new ruler which is expected to pick up tokens from the ring.
+	r = newTestRuler(t, config)
+	defer r.Stop()
+
+	// Wait until the ruler is ACTIVE in the ring.
+	test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {
+		return r.lifecycler.GetState()
 	})
+
+	// We expect no new tokens have been added to the ring.
+	assert.Equal(t, config.Ring.NumTokens, testutils.NumTokens(config.Ring.KVStore.Mock, "localhost", ring.RulerRingKey))
 }

--- a/pkg/ruler/pusher_mock_test.go
+++ b/pkg/ruler/pusher_mock_test.go
@@ -1,0 +1,25 @@
+package ruler
+
+import (
+	"context"
+
+	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/stretchr/testify/mock"
+)
+
+type pusherMock struct {
+	mock.Mock
+}
+
+func newPusherMock() *pusherMock {
+	return &pusherMock{}
+}
+
+func (m *pusherMock) Push(ctx context.Context, req *client.WriteRequest) (*client.WriteResponse, error) {
+	args := m.Called(ctx, req)
+	return args.Get(0).(*client.WriteResponse), args.Error(1)
+}
+
+func (m *pusherMock) MockPush(res *client.WriteResponse, err error) {
+	m.On("Push", mock.Anything, mock.Anything).Return(res, err)
+}

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/distributor"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/ruler/rules"
@@ -132,7 +131,7 @@ type Ruler struct {
 }
 
 // NewRuler creates a new ruler from a distributor and chunk store.
-func NewRuler(cfg Config, engine *promql.Engine, queryable promStorage.Queryable, d *distributor.Distributor, reg prometheus.Registerer, logger log.Logger) (*Ruler, error) {
+func NewRuler(cfg Config, engine *promql.Engine, queryable promStorage.Queryable, pusher Pusher, reg prometheus.Registerer, logger log.Logger) (*Ruler, error) {
 	ncfg, err := buildNotifierConfig(&cfg)
 	if err != nil {
 		return nil, err
@@ -151,7 +150,7 @@ func NewRuler(cfg Config, engine *promql.Engine, queryable promStorage.Queryable
 		notifierCfg:  ncfg,
 		notifiers:    map[string]*rulerNotifier{},
 		store:        ruleStore,
-		pusher:       d,
+		pusher:       pusher,
 		mapper:       newMapper(cfg.RulePath, logger),
 		userManagers: map[string]*promRules.Manager{},
 		done:         make(chan struct{}),

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -28,22 +28,29 @@ import (
 	"github.com/weaveworks/common/user"
 )
 
-func defaultRulerConfig() Config {
+func defaultRulerConfig(store rules.RuleStore) (Config, func()) {
+	// Create a new temporary directory for the rules, so that
+	// each test will run in isolation.
+	rulesDir, _ := ioutil.TempDir("/tmp", "ruler-tests")
+
 	codec := codec.Proto{Factory: ring.ProtoDescFactory}
 	consul := consul.NewInMemoryClient(codec)
-	cfg := Config{
-		StoreConfig: RuleStoreConfig{
-			mock: newMockRuleStore(),
-		},
-	}
+	cfg := Config{}
 	flagext.DefaultValues(&cfg)
-	flagext.DefaultValues(&cfg.Ring)
+	cfg.RulePath = rulesDir
+	cfg.StoreConfig.mock = store
 	cfg.Ring.KVStore.Mock = consul
 	cfg.Ring.NumTokens = 1
 	cfg.Ring.ListenPort = 0
 	cfg.Ring.InstanceAddr = "localhost"
 	cfg.Ring.InstanceID = "localhost"
-	return cfg
+
+	// Create a cleanup function that will be called at the end of the test
+	cleanup := func() {
+		defer os.RemoveAll(rulesDir)
+	}
+
+	return cfg, cleanup
 }
 
 func newTestRuler(t *testing.T, cfg Config) *Ruler {
@@ -73,7 +80,9 @@ func newTestRuler(t *testing.T, cfg Config) *Ruler {
 
 func TestNotifierSendsUserIDHeader(t *testing.T) {
 	var wg sync.WaitGroup
-	wg.Add(1) // We want one request to our test HTTP server.
+
+	// We do expect 1 API call for the user create with the getOrCreateNotifier()
+	wg.Add(1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
 		assert.NoError(t, err)
@@ -82,7 +91,9 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	cfg := defaultRulerConfig()
+	cfg, cleanup := defaultRulerConfig(newMockRuleStore(nil))
+	defer cleanup()
+
 	err := cfg.AlertmanagerURL.Set(ts.URL)
 	require.NoError(t, err)
 	cfg.AlertmanagerDiscovery = false
@@ -107,13 +118,8 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 }
 
 func TestRuler_Rules(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "ruler-tests")
-	defer os.RemoveAll(dir)
-
-	require.NoError(t, err)
-
-	cfg := defaultRulerConfig()
-	cfg.RulePath = dir
+	cfg, cleanup := defaultRulerConfig(newMockRuleStore(mockRules))
+	defer cleanup()
 
 	r := newTestRuler(t, cfg)
 	defer r.Stop()

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -49,9 +49,9 @@ var (
 	}
 )
 
-func newMockRuleStore() *mockRuleStore {
+func newMockRuleStore(rules map[string]rules.RuleGroupList) *mockRuleStore {
 	return &mockRuleStore{
-		rules: mockRules,
+		rules: rules,
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:
Recent changes to the ruler have apparently introduced flaky tests. This PR should fix them, at least fixes the one I've seen.

1. `TestNotifierSendsUserIDHeader` fails because multiple requests can be sent to the HTTP endpoint, one for each tenant. There were 3 in the test: "1", "user1", "user2". The last two were configured in the mocked store.

```
2020-02-04 17:32:30.918777 I | http: panic serving 127.0.0.1:34862: sync: negative WaitGroup counter
goroutine 546 [running]:
net/http.(*conn).serve.func1(0xc000151180)
	/usr/local/go/src/net/http/server.go:1767 +0x147
panic(0x3032f20, 0x3accee0)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
sync.(*WaitGroup).Add(0xc000855e90, 0xffffffffffffffff)
	/usr/local/go/src/sync/waitgroup.go:74 +0x22f
sync.(*WaitGroup).Done(...)
	/usr/local/go/src/sync/waitgroup.go:99
github.com/cortexproject/cortex/pkg/ruler.TestNotifierSendsUserIDHeader.func1(0x3b6aa40, 0xc00057c000, 0xc0001a0d00)
	/go/src/github.com/cortexproject/cortex/pkg/ruler/ruler_test.go:83 +0x134
net/http.HandlerFunc.ServeHTTP(0xc000885000, 0x3b6aa40, 0xc00057c000, 0xc0001a0d00)
	/usr/local/go/src/net/http/server.go:2007 +0x52
net/http.serverHandler.ServeHTTP(0xc00018c1c0, 0x3b6aa40, 0xc00057c000, 0xc0001a0d00)
	/usr/local/go/src/net/http/server.go:2802 +0xcf
net/http.(*conn).serve(0xc000151180, 0x3b75e40, 0xc00020d100)
	/usr/local/go/src/net/http/server.go:1890 +0x838
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2927 +0x5bf
```

2. Any ruler test can randomly fail because the distributor is `nil`. They fail when the test is not fast enough to `Stop()` it. I've changed `NewRuler()` to accept a `Pusher` instead of `*distributor.Distributor`, so that we can mock it in tests.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x398f4bd]

goroutine 423 [running]:
github.com/cortexproject/cortex/pkg/distributor.(*Distributor).Push(0x0, 0x47805a0, 0xc00077a330, 0xc000a9aee0, 0x0, 0x0, 0x1)
	/workspace/src/github.com/cortexproject/cortex/pkg/distributor/distributor.go:332 +0x27d
github.com/cortexproject/cortex/pkg/ruler.(*appender).Commit(0xc00036c870, 0x0, 0xc0008b1a28)
	/workspace/src/github.com/cortexproject/cortex/pkg/ruler/compat.go:39 +0x1ea
github.com/prometheus/prometheus/rules.(*Group).Eval.func1(0x47805a0, 0xc00062b470, 0xc0006f40d0, 0x3b232dca, 0xed5cc7244, 0x5cb5060, 0x0, 0x47ca5e0, 0xc000800000)
	/workspace/pkg/mod/github.com/prometheus/prometheus@v1.8.2-0.20191126064551-80ba03c67da1/rules/manager.go:583 +0x163f
github.com/prometheus/prometheus/rules.(*Group).Eval(0xc0006f40d0, 0x47805a0, 0xc00062b470, 0x3b232dca, 0xed5cc7244, 0x5cb5060)
	/workspace/pkg/mod/github.com/prometheus/prometheus@v1.8.2-0.20191126064551-80ba03c67da1/rules/manager.go:588 +0x186
github.com/prometheus/prometheus/rules.(*Group).run.func1()
	/workspace/pkg/mod/github.com/prometheus/prometheus@v1.8.2-0.20191126064551-80ba03c67da1/rules/manager.go:294 +0x13f
github.com/prometheus/prometheus/rules.(*Group).run(0xc0006f40d0, 0x47805a0, 0xc00062b470)
	/workspace/pkg/mod/github.com/prometheus/prometheus@v1.8.2-0.20191126064551-80ba03c67da1/rules/manager.go:308 +0x398
github.com/prometheus/prometheus/rules.(*Manager).Update.func1.1(0xc000170e10, 0xc0006f40d0)
	/workspace/pkg/mod/github.com/prometheus/prometheus@v1.8.2-0.20191126064551-80ba03c67da1/rules/manager.go:859 +0xad
created by github.com/prometheus/prometheus/rules.(*Manager).Update.func1
	/workspace/pkg/mod/github.com/prometheus/prometheus@v1.8.2-0.20191126064551-80ba03c67da1/rules/manager.go:854 +0x64
FAIL	github.com/cortexproject/cortex/pkg/ruler	10.796s
```

3. Tests didn't run in isolation because of the shared `RulePath` directory when wasn't configured in the config. I've done changes to always configure it with a new temporary directory, which changes on each test (and gets cleaned up at the end of the test).

4. Reduced the max `WaitTime` for the in-memory consul client so that some tests run faster (from 10s to 1s).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
