### PR TITLE
Backport WAL config fix (#2071) to release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## master / unreleased
 
 
+## 0.6.1 / 2020-02-05
+
+* [BUGFIX] Fixed parsing of the WAL configuration when specified in the YAML config file. #2071
+
 ## 0.6.0 / 2020-01-28
 
 Note that the ruler flags need to be changed in this upgrade. You're moving from a single node ruler to something that might need to be sharded.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -42,7 +42,7 @@ var (
 
 // Config for an Ingester.
 type Config struct {
-	WALConfig        WALConfig
+	WALConfig        WALConfig             `yaml:"walconfig,omitempty"`
 	LifecyclerConfig ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
 
 	// Config for transferring chunks. Zero or negative = no retries.
@@ -141,7 +141,7 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 		return NewV2(cfg, clientConfig, limits, registerer)
 	}
 
-	if cfg.WALConfig.walEnabled {
+	if cfg.WALConfig.WALEnabled {
 		// If WAL is enabled, we don't transfer out the data to any ingester.
 		// Either the next ingester which takes it's place should recover from WAL
 		// or the data has to be flushed during scaledown.
@@ -167,14 +167,14 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 	var err error
 	// During WAL recovery, it will create new user states which requires the limiter.
 	// Hence initialise the limiter before creating the WAL.
-	// The '!cfg.WALConfig.walEnabled' argument says don't flush on shutdown if the WAL is enabled.
-	i.lifecycler, err = ring.NewLifecycler(cfg.LifecyclerConfig, i, "ingester", ring.IngesterRingKey, !cfg.WALConfig.walEnabled)
+	// The '!cfg.WALConfig.WALEnabled' argument says don't flush on shutdown if the WAL is enabled.
+	i.lifecycler, err = ring.NewLifecycler(cfg.LifecyclerConfig, i, "ingester", ring.IngesterRingKey, !cfg.WALConfig.WALEnabled)
 	if err != nil {
 		return nil, err
 	}
 	i.limiter = NewSeriesLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor, cfg.ShardByAllLabels)
 
-	if cfg.WALConfig.recover {
+	if cfg.WALConfig.Recover {
 		level.Info(util.Logger).Log("msg", "recovering from WAL")
 		start := time.Now()
 		if err := recoverFromWAL(i); err != nil {
@@ -286,7 +286,7 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 
 	var lastPartialErr *validationError
 	var record *Record
-	if i.cfg.WALConfig.walEnabled {
+	if i.cfg.WALConfig.WALEnabled {
 		record = recordPool.Get().(*Record)
 		record.UserId = userID
 		// Assuming there is not much churn in most cases, there is no use

--- a/pkg/ingester/wal_test.go
+++ b/pkg/ingester/wal_test.go
@@ -20,11 +20,11 @@ func TestWAL(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := defaultIngesterTestConfig()
-	cfg.WALConfig.walEnabled = true
-	cfg.WALConfig.checkpointEnabled = true
-	cfg.WALConfig.recover = true
-	cfg.WALConfig.dir = dirname
-	cfg.WALConfig.checkpointDuration = 100 * time.Millisecond
+	cfg.WALConfig.WALEnabled = true
+	cfg.WALConfig.CheckpointEnabled = true
+	cfg.WALConfig.Recover = true
+	cfg.WALConfig.Dir = dirname
+	cfg.WALConfig.CheckpointDuration = 100 * time.Millisecond
 
 	numSeries := 100
 	numSamplesPerSeriesPerPush := 10
@@ -37,8 +37,8 @@ func TestWAL(t *testing.T) {
 
 	for r := 0; r < numRestarts; r++ {
 		if r == numRestarts-1 {
-			cfg.WALConfig.walEnabled = false
-			cfg.WALConfig.checkpointEnabled = false
+			cfg.WALConfig.WALEnabled = false
+			cfg.WALConfig.CheckpointEnabled = false
 		}
 		// Start a new ingester and recover the WAL.
 		_, ing = newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig())


### PR DESCRIPTION
**What this PR does**:
The PR #2071 has fixed the WAL config file. I would like to backport it to the `release-0.6` and release Cortex `0.6.1`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
