### PR TITLE
Ignore expired requests in frontend scheduling

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -66,7 +66,7 @@ Supported contents and default values of the config file:
 [limits: <limits_config>]
 
 # The frontend_worker_config configures the worker - running within the Cortex
-# ingester - picking up and executing queries enqueued by the query-frontend.
+# querier - picking up and executing queries enqueued by the query-frontend.
 [frontend_worker: <frontend_worker_config>]
 
 # The query_frontend_config configures the Cortex query-frontend.
@@ -1631,7 +1631,7 @@ grpc_client_config:
 
 ## `frontend_worker_config`
 
-The `frontend_worker_config` configures the worker - running within the Cortex ingester - picking up and executing queries enqueued by the query-frontend.
+The `frontend_worker_config` configures the worker - running within the Cortex querier - picking up and executing queries enqueued by the query-frontend.
 
 ```yaml
 # Address of query frontend service.

--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"math"
+	"math/rand"
 	"net/http"
 	"os/exec"
 	"time"
@@ -59,6 +60,7 @@ func TimeToMilliseconds(t time.Time) int64 {
 
 func GenerateSeries(name string, ts time.Time) (series []prompb.TimeSeries, vector model.Vector) {
 	tsMillis := TimeToMilliseconds(ts)
+	value := rand.Float64()
 
 	// Generate the series
 	series = append(series, prompb.TimeSeries{
@@ -66,7 +68,7 @@ func GenerateSeries(name string, ts time.Time) (series []prompb.TimeSeries, vect
 			{Name: labels.MetricName, Value: name},
 		},
 		Samples: []prompb.Sample{
-			{Value: float64(1), Timestamp: tsMillis},
+			{Value: value, Timestamp: tsMillis},
 		},
 	})
 
@@ -76,7 +78,7 @@ func GenerateSeries(name string, ts time.Time) (series []prompb.TimeSeries, vect
 
 	vector = append(vector, &model.Sample{
 		Metric:    metric,
-		Value:     model.SampleValue(1),
+		Value:     model.SampleValue(value),
 		Timestamp: model.Time(tsMillis),
 	})
 

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -353,7 +353,7 @@ func (f *Frontend) getNextRequest(ctx context.Context) (*request, error) {
 		/*
 		  We want to dequeue the next unexpired request from the chosen tenant queue.
 		  The chance of choosing a particular tenant for dequeueing is (1/active_tenants).
-		  This is probelmatic under load, especially with other middleware enabled such as
+		  This is problematic under load, especially with other middleware enabled such as
 		  querier.split-by-interval, where one request may fan out into many.
 		  If expired requests aren't exhausted before checking another tenant, it would take
 		  n_active_tenants * n_expired_requests_at_front_of_queue requests being processed

--- a/pkg/querier/frontend/queue_test.go
+++ b/pkg/querier/frontend/queue_test.go
@@ -1,0 +1,71 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
+)
+
+func setupFrontend(t *testing.T, config Config) *Frontend {
+	logger := log.NewNopLogger()
+
+	frontend, err := New(config, logger)
+	require.NoError(t, err)
+	defer frontend.Close()
+	return frontend
+}
+
+func testReq(ctx context.Context) *request {
+	return &request{
+		originalCtx: ctx,
+		err:         make(chan error, 1),
+		response:    make(chan *ProcessResponse, 1),
+	}
+}
+
+func TestDequeuesExpiredRequests(t *testing.T) {
+	var config Config
+	flagext.DefaultValues(&config)
+	config.MaxOutstandingPerTenant = 10
+	userID := "1"
+
+	f := setupFrontend(t, config)
+
+	ctx := user.InjectOrgID(context.Background(), userID)
+	expired, cancel := context.WithCancel(ctx)
+	cancel()
+
+	for i := 0; i < config.MaxOutstandingPerTenant; i++ {
+		var err error
+		if i%5 == 0 {
+			err = f.queueRequest(ctx, testReq(ctx))
+		} else {
+			err = f.queueRequest(ctx, testReq(expired))
+		}
+
+		require.Nil(t, err)
+	}
+
+	// the first request shouldnt be expired
+	req, err := f.getNextRequest(ctx)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, 9, len(f.queues[userID]))
+
+	// the next unexpired request should be the 5th index
+	req, err = f.getNextRequest(ctx)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, 4, len(f.queues[userID]))
+
+	// there should be no more unexpired requests in queue
+	req, err = f.getNextRequest(ctx)
+	require.Nil(t, err)
+	require.Nil(t, req)
+	_, ok := f.queues[userID]
+	require.Equal(t, false, ok)
+}

--- a/pkg/querier/frontend/queue_test.go
+++ b/pkg/querier/frontend/queue_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
 
 func setupFrontend(t *testing.T, config Config) *Frontend {

--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -100,7 +100,7 @@ var (
 		{
 			name:       "frontend_worker_config",
 			structType: reflect.TypeOf(frontend.WorkerConfig{}),
-			desc:       "The frontend_worker_config configures the worker - running within the Cortex ingester - picking up and executing queries enqueued by the query-frontend.",
+			desc:       "The frontend_worker_config configures the worker - running within the Cortex querier - picking up and executing queries enqueued by the query-frontend.",
 		},
 		{
 			name:       "etcd_config",


### PR DESCRIPTION

**What this PR does**:
This PR does two things to improve scheduling for the per tenant queues in the query frontend. This is important for two reasons:
1)  To avoid certain cases where expired requests can hamper the fairness of scheduling in the frontend across multiple tenants. 
2) To short circuit expired requests and prevent them from being pulled by the querier workers.

**Checklist**
- [x] Tests updated