### PR TITLE
Fixed flaky test

### DIFF
--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -592,7 +592,12 @@ func TestIngester_v2LabelNames_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) 
 }
 
 func TestIngester_v2Push_ShouldNotCreateTSDBIfNotInActiveState(t *testing.T) {
-	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
+	// Configure the lifecycler to not immediately join the ring, to make sure
+	// the ingester will NOT be in the ACTIVE state when we'll push samples.
+	cfg := defaultIngesterTestConfig()
+	cfg.LifecyclerConfig.JoinAfter = 10*time.Second
+
+	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
 	require.NoError(t, err)
 	defer i.Shutdown()
 	defer cleanup()

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -595,7 +595,7 @@ func TestIngester_v2Push_ShouldNotCreateTSDBIfNotInActiveState(t *testing.T) {
 	// Configure the lifecycler to not immediately join the ring, to make sure
 	// the ingester will NOT be in the ACTIVE state when we'll push samples.
 	cfg := defaultIngesterTestConfig()
-	cfg.LifecyclerConfig.JoinAfter = 10*time.Second
+	cfg.LifecyclerConfig.JoinAfter = 10 * time.Second
 
 	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does**:
Today I've seen the test `TestIngester_v2Push_ShouldNotCreateTSDBIfNotInActiveState` failing with a panic. This PR fixes it.

```
--- FAIL: TestIngester_v2Push_ShouldNotCreateTSDBIfNotInActiveState (0.04s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x17ffd57]

goroutine 1506 [running]:
testing.tRunner.func1(0xc00017ee00)
	/usr/local/go/src/testing/testing.go:874 +0x69f
panic(0x19c1480, 0x2910650)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/cortexproject/cortex/pkg/ingester.TestIngester_v2Push_ShouldNotCreateTSDBIfNotInActiveState(0xc00017ee00)
	/go/src/github.com/cortexproject/cortex/pkg/ingester/ingester_v2_test.go:607 +0x3f7
testing.tRunner(0xc00017ee00, 0x1c018b8)
	/usr/local/go/src/testing/testing.go:909 +0x19a
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:960 +0x652
FAIL	github.com/cortexproject/cortex/pkg/ingester	3.351s
FAIL
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
