### PR TITLE
Adds FromContext to spanlogger package.

### DIFF
--- a/pkg/util/spanlogger/noop.go
+++ b/pkg/util/spanlogger/noop.go
@@ -1,0 +1,54 @@
+package spanlogger
+
+import (
+	"github.com/cortexproject/cortex/pkg/util"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+)
+
+type noopTracer struct{}
+
+type noopSpan struct{}
+type noopSpanContext struct{}
+
+var (
+	defaultNoopSpanContext = noopSpanContext{}
+	defaultNoopSpan        = noopSpan{}
+	defaultNoopTracer      = noopTracer{}
+	noop                   = &SpanLogger{Logger: util.Logger, Span: defaultNoopSpan}
+)
+
+const (
+	emptyString = ""
+)
+
+func (n noopSpanContext) ForeachBaggageItem(handler func(k, v string) bool) {}
+
+func (n noopSpan) Context() opentracing.SpanContext                       { return defaultNoopSpanContext }
+func (n noopSpan) SetBaggageItem(key, val string) opentracing.Span        { return defaultNoopSpan }
+func (n noopSpan) BaggageItem(key string) string                          { return emptyString }
+func (n noopSpan) SetTag(key string, value interface{}) opentracing.Span  { return n }
+func (n noopSpan) LogFields(fields ...log.Field)                          {}
+func (n noopSpan) LogKV(keyVals ...interface{})                           {}
+func (n noopSpan) Finish()                                                {}
+func (n noopSpan) FinishWithOptions(opts opentracing.FinishOptions)       {}
+func (n noopSpan) SetOperationName(operationName string) opentracing.Span { return n }
+func (n noopSpan) Tracer() opentracing.Tracer                             { return defaultNoopTracer }
+func (n noopSpan) LogEvent(event string)                                  {}
+func (n noopSpan) LogEventWithPayload(event string, payload interface{})  {}
+func (n noopSpan) Log(data opentracing.LogData)                           {}
+
+// StartSpan belongs to the Tracer interface.
+func (n noopTracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
+	return defaultNoopSpan
+}
+
+// Inject belongs to the Tracer interface.
+func (n noopTracer) Inject(sp opentracing.SpanContext, format interface{}, carrier interface{}) error {
+	return nil
+}
+
+// Extract belongs to the Tracer interface.
+func (n noopTracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
+	return nil, opentracing.ErrSpanContextNotFound
+}

--- a/pkg/util/spanlogger/noop.go
+++ b/pkg/util/spanlogger/noop.go
@@ -1,7 +1,6 @@
 package spanlogger
 
 import (
-	"github.com/cortexproject/cortex/pkg/util"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 )
@@ -15,7 +14,6 @@ var (
 	defaultNoopSpanContext = noopSpanContext{}
 	defaultNoopSpan        = noopSpan{}
 	defaultNoopTracer      = noopTracer{}
-	noop                   = &SpanLogger{Logger: util.Logger, Span: defaultNoopSpan}
 )
 
 const (

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -31,6 +31,8 @@ func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, 
 	return logger, ctx
 }
 
+// FromContext returns a span logger using the current parent span.
+// If there is no parent span, the Spanlogger will only log to stdout.
 func FromContext(ctx context.Context) *SpanLogger {
 	sp := opentracing.SpanFromContext(ctx)
 	if sp == nil {

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -31,6 +31,17 @@ func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, 
 	return logger, ctx
 }
 
+func FromContext(ctx context.Context) *SpanLogger {
+	sp := opentracing.SpanFromContext(ctx)
+	if sp == nil {
+		return noop
+	}
+	return &SpanLogger{
+		Logger: util.Logger,
+		Span:   sp,
+	}
+}
+
 // Log implements gokit's Logger interface; sends logs to underlying logger and
 // also puts the on the spans.
 func (s *SpanLogger) Log(kvps ...interface{}) error {

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -34,7 +34,10 @@ func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, 
 func FromContext(ctx context.Context) *SpanLogger {
 	sp := opentracing.SpanFromContext(ctx)
 	if sp == nil {
-		return noop
+		return &SpanLogger{
+			Logger: util.Logger,
+			Span:   defaultNoopSpan,
+		}
 	}
 	return &SpanLogger{
 		Logger: util.Logger,

--- a/pkg/util/spanlogger/spanlogger_test.go
+++ b/pkg/util/spanlogger/spanlogger_test.go
@@ -1,0 +1,21 @@
+package spanlogger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpanLogger_Log(t *testing.T) {
+	span, ctx := New(context.Background(), "test", "bar")
+	_ = span.Log("foo")
+	newSpan := FromContext(ctx)
+	require.Equal(t, span.Span, newSpan.Span)
+	_ = newSpan.Log("bar")
+	noSpan := FromContext(context.Background())
+	_ = noSpan.Log("foo")
+	require.Error(t, noSpan.Error(errors.New("err")))
+	require.NoError(t, noSpan.Error(nil))
+}


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

This allows to safely logs data inside a parent span without creating a new one, and to just log to the logger if no parent span exists.
