### PR TITLE
Add additional buckets to Bigtable request duration histogram

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -52,9 +52,9 @@ var (
 		Name:      "dynamo_request_duration_seconds",
 		Help:      "Time spent doing DynamoDB requests.",
 
-		// DynamoDB latency seems to range from a few ms to a few sec and is
-		// important.  So use 8 buckets from 128us to 2s.
-		Buckets: prometheus.ExponentialBuckets(0.000128, 4, 8),
+		// DynamoDB latency seems to range from a few ms to a several seconds and is
+		// important.  So use 9 buckets from 1ms to just over 1 minute (65s).
+		Buckets: prometheus.ExponentialBuckets(0.001, 4, 9),
 	}, []string{"operation", "status_code"}))
 	dynamoConsumedCapacity = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "cortex",

--- a/pkg/chunk/cassandra/instrumentation.go
+++ b/pkg/chunk/cassandra/instrumentation.go
@@ -12,7 +12,7 @@ var requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Namespace: "cortex",
 	Name:      "cassandra_request_duration_seconds",
 	Help:      "Time spent doing Cassandra requests.",
-	Buckets:   prometheus.ExponentialBuckets(0.001, 4, 6),
+	Buckets:   prometheus.ExponentialBuckets(0.001, 4, 9),
 }, []string{"operation", "status_code"})
 
 func init() {

--- a/pkg/chunk/gcp/instrumentation.go
+++ b/pkg/chunk/gcp/instrumentation.go
@@ -23,9 +23,9 @@ var (
 		Name:      "bigtable_request_duration_seconds",
 		Help:      "Time spent doing Bigtable requests.",
 
-		// Bigtable latency seems to range from a few ms to a few hundred ms and is
-		// important.  So use 6 buckets from 1ms to 1s.
-		Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
+		// Bigtable latency seems to range from a few ms to a several seconds and is
+		// important.  So use 9 buckets from 1ms to just over 1 minute (65s).
+		Buckets: prometheus.ExponentialBuckets(0.001, 4, 9),
 	}, []string{"operation", "status_code"})
 
 	gcsRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

We see bigtable requests longer than 1s and it's hard to get a good idea with the current histogram buckets just how long these requests are taking, adding a few more buckets.


Signed-off-by: Edward Welch <edward.welch@grafana.com>
