### PR TITLE
runtimeconfig: initialize overridesReloadSuccess gauge in success state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [BUGFIX] Experimental TSDB: fixed `/all_user_stats` and `/api/prom/user_stats` endpoints when using the experimental TSDB blocks storage. #2042
 * [BUGFIX] Experimental TSDB: fixed ruler to correctly work with the experimental TSDB blocks storage. #2101
 * [BUGFIX] Azure Blob ChunkStore: Fixed issue causing `invalid chunk checksum` errors. #2074
+* [BUGFIX] The gauge `cortex_overrides_last_reload_successful` is now initialized in success state, so that the system does not appear to be in an error state anymore when no dynamic runtime configuration is being used. #2092
 
 Cortex 0.4.0 is the last version that can *write* denormalised tokens. Cortex 0.5.0 and above always write normalised tokens.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 * [BUGFIX] Experimental TSDB: fixed `/all_user_stats` and `/api/prom/user_stats` endpoints when using the experimental TSDB blocks storage. #2042
 * [BUGFIX] Experimental TSDB: fixed ruler to correctly work with the experimental TSDB blocks storage. #2101
 * [BUGFIX] Azure Blob ChunkStore: Fixed issue causing `invalid chunk checksum` errors. #2074
-* [BUGFIX] The gauge `cortex_overrides_last_reload_successful` is now initialized in success state, so that the system does not appear to be in an error state anymore when no dynamic runtime configuration is being used. #2092
+* [BUGFIX] The gauge `cortex_overrides_last_reload_successful` is now only exported by components that use a `RuntimeConfigManager`. Previously, for components that do not initialize a `RuntimeConfigManager` (such as the compactor) the gauge was initialized with 0 (indicating error state) and then never updated, resulting in a false-negative permanent error state. #2092
 
 Cortex 0.4.0 is the last version that can *write* denormalised tokens. Cortex 0.5.0 and above always write normalised tokens.
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -193,7 +193,7 @@ func (t *Cortex) initRuntimeConfig(cfg *Config) (err error) {
 	// make sure to set default limits before we start loading configuration into memory
 	validation.SetDefaultLimitsForYAMLUnmarshalling(cfg.LimitsConfig)
 
-	t.runtimeConfig, err = runtimeconfig.NewRuntimeConfigManager(cfg.RuntimeConfig)
+	t.runtimeConfig, err = runtimeconfig.NewRuntimeConfigManager(cfg.RuntimeConfig, prometheus.DefaultRegisterer)
 	return err
 }
 

--- a/pkg/util/runtimeconfig/manager.go
+++ b/pkg/util/runtimeconfig/manager.go
@@ -17,6 +17,13 @@ var overridesReloadSuccess = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Whether the last config reload attempt was successful.",
 })
 
+// Initialize gauge in success state (1). That is, require
+// explicit transitioning into the error state (0). That helps
+// e.g. when `NewRuntimeConfigManager()` never gets called.
+func init() {
+	overridesReloadSuccess.Set(1)
+}
+
 // Loader loads the configuration from file.
 type Loader func(filename string) (interface{}, error)
 

--- a/pkg/util/runtimeconfig/manager.go
+++ b/pkg/util/runtimeconfig/manager.go
@@ -44,18 +44,18 @@ type Manager struct {
 }
 
 // NewRuntimeConfigManager creates an instance of Manager and starts reload config loop based on config
-func NewRuntimeConfigManager(cfg ManagerConfig, metricsRegisterer prometheus.Registerer) (*Manager, error) {
+func NewRuntimeConfigManager(cfg ManagerConfig, registerer prometheus.Registerer) (*Manager, error) {
 	mgr := Manager{
 		cfg:  cfg,
 		quit: make(chan struct{}),
 		configLoadSuccess: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_overrides_last_reload_successful",
-			Help: "Whether the last config reload attempt was successful (0: error, 1: successful).",
+			Help: "Whether the last config reload attempt was successful.",
 		}),
 	}
 
-	if metricsRegisterer != nil {
-		metricsRegisterer.MustRegister(mgr.configLoadSuccess)
+	if registerer != nil {
+		registerer.MustRegister(mgr.configLoadSuccess)
 	}
 
 	if cfg.LoadPath != "" {

--- a/pkg/util/runtimeconfig/manager.go
+++ b/pkg/util/runtimeconfig/manager.go
@@ -54,13 +54,9 @@ func NewRuntimeConfigManager(cfg ManagerConfig, metricsRegisterer prometheus.Reg
 		}),
 	}
 
-	metricsRegisterer.MustRegister(mgr.configLoadSuccess)
-	// The prometheus client library implicitly initializes gauges at 0.
-	// Initialize gauge in success state (require explicit transitioning into
-	// the error state) instead. Note: it could be better to change the meaning
-	// of 0 to success, or to introduce a third state, or to use an error
-	// counter instead of a gauge.
-	mgr.configLoadSuccess.Set(1)
+	if metricsRegisterer != nil {
+		metricsRegisterer.MustRegister(mgr.configLoadSuccess)
+	}
 
 	if cfg.LoadPath != "" {
 		if err := mgr.loadConfig(); err != nil {

--- a/pkg/util/runtimeconfig/manager_test.go
+++ b/pkg/util/runtimeconfig/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/atomic"
 	"gopkg.in/yaml.v2"
@@ -74,7 +75,9 @@ func TestNewOverridesManager(t *testing.T) {
 		Loader:       testLoadOverrides,
 	}
 
-	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig)
+	// registry implements both Registerer and Gatherer
+	registry := prometheus.NewRegistry()
+	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, registry)
 	require.NoError(t, err)
 
 	// Cleaning up
@@ -108,7 +111,8 @@ func TestOverridesManager_ListenerWithDefaultLimits(t *testing.T) {
 		Loader:       testLoadOverrides,
 	}
 
-	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig)
+	registry := prometheus.NewRegistry()
+	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, registry)
 	require.NoError(t, err)
 
 	// need to use buffer, otherwise loadConfig will throw away update
@@ -156,7 +160,8 @@ func TestOverridesManager_ListenerChannel(t *testing.T) {
 		},
 	}
 
-	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig)
+	registry := prometheus.NewRegistry()
+	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, registry)
 	require.NoError(t, err)
 
 	// need to use buffer, otherwise loadConfig will throw away update
@@ -204,8 +209,8 @@ func TestOverridesManager_StopClosesListenerChannels(t *testing.T) {
 			return val, nil
 		},
 	}
-
-	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig)
+	registry := prometheus.NewRegistry()
+	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, registry)
 	require.NoError(t, err)
 
 	// need to use buffer, otherwise loadConfig will throw away update

--- a/pkg/util/runtimeconfig/manager_test.go
+++ b/pkg/util/runtimeconfig/manager_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/atomic"
 	"gopkg.in/yaml.v2"
@@ -75,9 +74,7 @@ func TestNewOverridesManager(t *testing.T) {
 		Loader:       testLoadOverrides,
 	}
 
-	// registry implements both Registerer and Gatherer
-	registry := prometheus.NewRegistry()
-	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, registry)
+	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, nil)
 	require.NoError(t, err)
 
 	// Cleaning up
@@ -111,8 +108,7 @@ func TestOverridesManager_ListenerWithDefaultLimits(t *testing.T) {
 		Loader:       testLoadOverrides,
 	}
 
-	registry := prometheus.NewRegistry()
-	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, registry)
+	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, nil)
 	require.NoError(t, err)
 
 	// need to use buffer, otherwise loadConfig will throw away update
@@ -160,8 +156,7 @@ func TestOverridesManager_ListenerChannel(t *testing.T) {
 		},
 	}
 
-	registry := prometheus.NewRegistry()
-	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, registry)
+	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, nil)
 	require.NoError(t, err)
 
 	// need to use buffer, otherwise loadConfig will throw away update
@@ -209,8 +204,8 @@ func TestOverridesManager_StopClosesListenerChannels(t *testing.T) {
 			return val, nil
 		},
 	}
-	registry := prometheus.NewRegistry()
-	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, registry)
+
+	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, nil)
 	require.NoError(t, err)
 
 	// need to use buffer, otherwise loadConfig will throw away update


### PR DESCRIPTION
From the commit message:
```
There seem to be code paths where the overridesReloadSuccess gauge
gets initialized, but `NewRuntimeConfigManager()` never is called
(absence of both log lines: "failed to load config", "runtime config
disabled: file not specified").

promauto.NewGauge() seems to initialize the gauge with the value 0
(that seems to be common in Prometheus client libs).

In the current code, the value 0 is associated with the error
state, and the value 1 is associated with the success state.

Likewise, https://github.com/grafana/cortex-jsonnet/ defines
an alert that fires when this gauge is set to 0 for an extended
period of time.

That is, when `NewRuntimeConfigManager()` never gets called
the gauge indicates a false negative error state.

Starting in the success state is a pragmatic way to solve that
problem.

It might be better to use a counter for individual error or
-- if a gauge is preferred -- one could introduce a third
state referring to "initialized".
```
(work in progress, let's see what CI says)

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated -- note: all tests seem to have passed. I think I need some guidance if I am supposed to add a test.
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
