### PR TITLE
Run single table-manager among multiple single binary cortex instances.

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -457,6 +457,10 @@ func (t *Cortex) initTableManager(cfg *Config) error {
 	if err != nil {
 		return err
 	}
+
+	t.tableManager.TargetModule = cfg.Target.String()
+	t.tableManager.Ring = t.ring
+	t.tableManager.Lifecycler = cfg.Ingester.LifecyclerConfig
 	t.tableManager.Start()
 	return nil
 }
@@ -638,7 +642,7 @@ var modules = map[moduleName]module{
 	},
 
 	TableManager: {
-		deps: []moduleName{Server},
+		deps: []moduleName{Server, Ring, Ingester},
 		init: (*Cortex).initTableManager,
 		stop: (*Cortex).stopTableManager,
 	},


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting: 

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**: When multiple single binary cortex instances are running every cortex instance is running it's own table-manager. This PR aims to achieve single table-manager at any point in time irrespective of any number of cortex instances running.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

@gouthamve 