### PR TITLE
Fixed ruler to run with blocks storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
   * `-server.grpc.keepalive.time`
   * `-server.grpc.keepalive.timeout`
 * [BUGFIX] Experimental TSDB: fixed `/all_user_stats` and `/api/prom/user_stats` endpoints when using the experimental TSDB blocks storage. #2042
+* [BUGFIX] Experimental TSDB: fixed ruler to correctly work with the experimental TSDB blocks storage. #2101
 * [BUGFIX] Azure Blob ChunkStore: Fixed issue causing `invalid chunk checksum` errors. #2074
 
 Cortex 0.4.0 is the last version that can *write* denormalised tokens. Cortex 0.5.0 and above always write normalised tokens.

--- a/development/tsdb-blocks-storage-s3/.data-configstore/api/prom/configs/rules
+++ b/development/tsdb-blocks-storage-s3/.data-configstore/api/prom/configs/rules
@@ -1,0 +1,14 @@
+{
+    "since": 2,
+    "configs": {
+        "fake": {
+            "id": 1,
+            "config": {
+                "rule_format_version": "2",
+                "rules_files": {
+                    "test": "groups:\n    - name: group-1\n      rules:\n      - record: avalanche_metric_mmmmm_0_0:count\n        expr: count(avalanche_metric_mmmmm_0_0)\n    - name: group-2\n      rules:\n      - record: avalanche_metric_mmmmm_0:count\n        expr: |\n          count(avalanche_metric_mmmmm_0_0) +\n          count(avalanche_metric_mmmmm_0_1)\n      - alert: alert-1\n        expr: |\n          count(avalanche_metric_mmmmm_0_0) > 1000\n      - alert: alert-2\n        expr:  count(avalanche_metric_mmmmm_0_0) > 100\n        for:   5m\n        labels:\n          label1: value1\n          label2: value2\n        annotations:\n          annotation1: value1\n          annotation2: value2\n"
+                }
+            }
+        }
+    }
+}

--- a/development/tsdb-blocks-storage-s3/.data-configstore/api/prom/configs/rules.yaml
+++ b/development/tsdb-blocks-storage-s3/.data-configstore/api/prom/configs/rules.yaml
@@ -1,0 +1,23 @@
+groups:
+    - name: group-1
+      rules:
+      - record: avalanche_metric_mmmmm_0_0:count
+        expr: count(avalanche_metric_mmmmm_0_0)
+    - name: group-2
+      rules:
+      - record: avalanche_metric_mmmmm_0:count
+        expr: |
+          count(avalanche_metric_mmmmm_0_0) +
+          count(avalanche_metric_mmmmm_0_1)
+      - alert: alert-1
+        expr: |
+          count(avalanche_metric_mmmmm_0_0) > 1000
+      - alert: alert-2
+        expr:  count(avalanche_metric_mmmmm_0_0) > 100
+        for:   5m
+        labels:
+          label1: value1
+          label2: value2
+        annotations:
+          annotation1: value1
+          annotation2: value2

--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -46,5 +46,12 @@ tsdb:
     secret_access_key: supersecret
     insecure:          true
 
+ruler:
+  enable_api: true
+  storeconfig:
+    type: configdb
+    configdb:
+      configsapiurl: http://configstore:80/
+
 storage:
   engine: tsdb

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -18,6 +18,11 @@ services:
     volumes:
       - .data-minio:/data:delegated
 
+  configstore:
+    image: nginx
+    volumes:
+      - .data-configstore:/usr/share/nginx/html/private:ro
+
   distributor:
     build:
       context:    .
@@ -73,5 +78,19 @@ services:
       - minio
     ports:
       - 8004:8004
+    volumes:
+      - ./config:/cortex/config
+    
+  ruler:
+    build:
+      context:    .
+      dockerfile: dev.dockerfile
+    image: cortex
+    command: ["sh", "-c", "sleep 3 && exec ./cortex -config.file=./config/cortex.yaml -target=ruler -server.http-listen-port=8005 -server.grpc-listen-port=9005"]
+    depends_on:
+      - consul
+      - minio
+    ports:
+      - 8005:8005
     volumes:
       - ./config:/cortex/config

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -176,6 +176,10 @@ type Cortex struct {
 	configDB     db.DB
 	alertmanager *alertmanager.MultitenantAlertmanager
 	compactor    *compactor.Compactor
+
+	// The chunk store that the querier should use to query the long
+	// term storage. It depends on the storage engine used.
+	querierChunkStore querier.ChunkStore
 }
 
 // New makes a new Cortex.


### PR DESCRIPTION
**What this PR does**:
The ruler currently panics with the following trace when running with the experimental blocks storage because the querier is initialized with a `nil` store instead of blocks querier store. This PR fixes it.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x2834554]

goroutine 397 [running]:
github.com/cortexproject/cortex/pkg/querier.(*chunkStoreQuerier).Select(0xc000af1600, 0xc00064a500, 0xc00017e370, 0x1, 0x1, 0x1, 0x0, 0x0, 0x0, 0xc00029d5c0, ...)
	/workspace/src/github.com/cortexproject/cortex/pkg/querier/chunk_store_queryable.go:42 +0xa4
github.com/cortexproject/cortex/pkg/querier.querier.Select.func1(0xc00064a500, 0xc00017e370, 0x1, 0x1, 0xc000088600, 0xc000088240, 0x398fca0, 0xc000af1600)
	/workspace/src/github.com/cortexproject/cortex/pkg/querier/querier.go:175 +0x8a
created by github.com/cortexproject/cortex/pkg/querier.querier.Select
	/workspace/src/github.com/cortexproject/cortex/pkg/querier/querier.go:174 +0x152
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
