### PR TITLE
Allow ingester initialization to continue in background.

### DIFF
--- a/pkg/ingester/error_future.go
+++ b/pkg/ingester/error_future.go
@@ -1,0 +1,61 @@
+package ingester
+
+import (
+	"context"
+	"sync"
+)
+
+// NewErrorFuture creates unfinished future. Must be finished by calling Finish method eventually.
+func NewErrorFuture() *ErrorFuture {
+	return &ErrorFuture{
+		ch: make(chan struct{}),
+	}
+}
+
+// NewFinishedErrorFuture creates finished future with given (possibly nil) error.
+func NewFinishedErrorFuture(err error) *ErrorFuture {
+	ef := NewErrorFuture()
+	ef.Finish(err)
+	return ef
+}
+
+// This is a Future object, for holding error.
+type ErrorFuture struct {
+	mu   sync.Mutex
+	done bool
+	err  error
+	ch   chan struct{} // used by waiters
+}
+
+// Returns true if this future is done, and associated error. If future is not done yet, returns false.
+func (f *ErrorFuture) Get() (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.done, f.err
+}
+
+// Waits for future to finish, and returns true and associated error set via Finish method.
+// If context is finished first, returns false and error from context instead.
+func (f *ErrorFuture) WaitAndGet(ctx context.Context) (bool, error) {
+	d, err := f.Get()
+	if d {
+		return true, err
+	}
+
+	select {
+	case <-f.ch:
+		return f.Get() // must return true now
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+}
+
+// Mark this future as finished. Can only be called once.
+func (f *ErrorFuture) Finish(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.done = true
+	f.err = err
+	close(f.ch) // will panic, if called twice, which is fine.
+}

--- a/pkg/ingester/error_future_test.go
+++ b/pkg/ingester/error_future_test.go
@@ -1,0 +1,90 @@
+package ingester
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/ssa/interp/testdata/src/errors"
+)
+
+func TestBasicErrorFuture(t *testing.T) {
+	ef := NewErrorFuture()
+
+	done, err := ef.Get()
+	require.False(t, done)
+	require.NoError(t, err)
+
+	ef.Finish(nil)
+
+	done, err = ef.Get()
+	require.True(t, done)
+	require.NoError(t, err)
+}
+
+func TestAsyncErrorFutureWithSuccess(t *testing.T) {
+	ef := NewErrorFuture()
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		ef.Finish(nil)
+	}()
+
+	done, err := ef.WaitAndGet(context.Background())
+	require.True(t, done)
+	require.NoError(t, err)
+}
+
+func TestAsyncErrorFutureWithError(t *testing.T) {
+	initError := errors.New("test error")
+	ef := NewErrorFuture()
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		ef.Finish(initError)
+	}()
+
+	done, err := ef.WaitAndGet(context.Background())
+	require.True(t, done)
+	require.Equal(t, initError, err)
+}
+
+func TestAsyncErrorFutureWithTimeout(t *testing.T) {
+	ef := NewErrorFuture()
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		ef.Finish(nil)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done, err := ef.WaitAndGet(ctx)
+	require.False(t, done)
+	require.Equal(t, context.DeadlineExceeded, err)
+
+	// wait for finish
+	done, err = ef.WaitAndGet(context.Background())
+	require.True(t, done)
+	require.Equal(t, nil, err)
+}
+
+func TestDoubleFinishPanics(t *testing.T) {
+	var recovered interface{}
+
+	defer func() {
+		// make sure we have recovered from panic.
+		if recovered == nil {
+			t.Fatal("no recovered panic")
+		}
+	}()
+
+	defer func() {
+		recovered = recover()
+	}()
+
+	ef := NewErrorFuture()
+	ef.Finish(nil)
+	ef.Finish(nil)
+	// if we get here, there was no panic.
+	t.Fatal("no panic")
+}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -44,7 +44,9 @@ func newTestStore(t require.TestingT, cfg Config, clientConfig client.Config, li
 	overrides, err := validation.NewOverrides(limits, nil)
 	require.NoError(t, err)
 
-	ing, err := New(cfg, clientConfig, overrides, store, nil)
+	ing, errfut := New(cfg, clientConfig, overrides, store, nil)
+	initDone, err := errfut.WaitAndGet(context.Background())
+	require.True(t, initDone)
 	require.NoError(t, err)
 
 	return store, ing

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -103,7 +103,9 @@ func TestIngesterTransfer(t *testing.T) {
 	cfg1.LifecyclerConfig.Addr = "ingester1"
 	cfg1.LifecyclerConfig.JoinAfter = 0 * time.Second
 	cfg1.MaxTransferRetries = 10
-	ing1, err := New(cfg1, defaultClientTestConfig(), limits, nil, nil)
+	ing1, errfut := New(cfg1, defaultClientTestConfig(), limits, nil, nil)
+	initDone, err := errfut.WaitAndGet(context.Background())
+	require.True(t, initDone)
 	require.NoError(t, err)
 
 	test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {
@@ -122,7 +124,9 @@ func TestIngesterTransfer(t *testing.T) {
 	cfg2.LifecyclerConfig.ID = "ingester2"
 	cfg2.LifecyclerConfig.Addr = "ingester2"
 	cfg2.LifecyclerConfig.JoinAfter = 100 * time.Second
-	ing2, err := New(cfg2, defaultClientTestConfig(), limits, nil, nil)
+	ing2, errfut := New(cfg2, defaultClientTestConfig(), limits, nil, nil)
+	initDone, err = errfut.WaitAndGet(context.Background())
+	require.True(t, initDone)
 	require.NoError(t, err)
 
 	// Let ing2 send chunks to ing1
@@ -167,7 +171,9 @@ func TestIngesterBadTransfer(t *testing.T) {
 	cfg.LifecyclerConfig.ID = "ingester1"
 	cfg.LifecyclerConfig.Addr = "ingester1"
 	cfg.LifecyclerConfig.JoinAfter = 100 * time.Second
-	ing, err := New(cfg, defaultClientTestConfig(), limits, nil, nil)
+	ing, errfut := New(cfg, defaultClientTestConfig(), limits, nil, nil)
+	initDone, err := errfut.WaitAndGet(context.Background())
+	require.True(t, initDone)
 	require.NoError(t, err)
 
 	test.Poll(t, 100*time.Millisecond, ring.PENDING, func() interface{} {
@@ -438,7 +444,9 @@ func TestV2IngesterTransfer(t *testing.T) {
 			cfg1.LifecyclerConfig.Addr = "ingester1"
 			cfg1.LifecyclerConfig.JoinAfter = 0 * time.Second
 			cfg1.MaxTransferRetries = 10
-			ing1, err := New(cfg1, defaultClientTestConfig(), limits, nil, nil)
+			ing1, errfut1 := New(cfg1, defaultClientTestConfig(), limits, nil, nil)
+			initDone, err := errfut1.WaitAndGet(context.Background())
+			require.True(t, initDone)
 			require.NoError(t, err)
 
 			test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {
@@ -465,7 +473,9 @@ func TestV2IngesterTransfer(t *testing.T) {
 			cfg2.LifecyclerConfig.ID = "ingester2"
 			cfg2.LifecyclerConfig.Addr = "ingester2"
 			cfg2.LifecyclerConfig.JoinAfter = 100 * time.Second
-			ing2, err := New(cfg2, defaultClientTestConfig(), limits, nil, nil)
+			ing2, errfut2 := New(cfg2, defaultClientTestConfig(), limits, nil, nil)
+			initDone, err = errfut2.WaitAndGet(context.Background())
+			require.True(t, initDone)
 			require.NoError(t, err)
 
 			// Let ing1 send blocks/wal to ing2


### PR DESCRIPTION
This PR solves problem with slow ingester initialization when doing WAL replays on block databases.

By allowing ingester initialization to continue in the background, the rest of Cortex binary can start in the meantime, especially readiness and metrics handlers. Until ingester initialization has finished, it will return errors to most (but not all, like Flush) API requests.

There may be implications for returning errors from API calls. Alternatively, we can delay registration of handlers until ingester initialization has finished. That would be easy to do, but I'm not sure about the right approach.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
