### PR TITLE
Rename chunk.ObjectClient and implement generic object store chunk client

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -154,12 +154,12 @@ func NewDynamoDBIndexClient(cfg DynamoDBConfig, schemaCfg chunk.SchemaConfig) (c
 	return newDynamoDBStorageClient(cfg, schemaCfg)
 }
 
-// NewDynamoDBObjectClient makes a new DynamoDB-backed ObjectClient.
-func NewDynamoDBObjectClient(cfg DynamoDBConfig, schemaCfg chunk.SchemaConfig) (chunk.Client, error) {
+// NewDynamoDBChunkClient makes a new DynamoDB-backed chunk.Client.
+func NewDynamoDBChunkClient(cfg DynamoDBConfig, schemaCfg chunk.SchemaConfig) (chunk.Client, error) {
 	return newDynamoDBStorageClient(cfg, schemaCfg)
 }
 
-// newDynamoDBStorageClient makes a new DynamoDB-backed IndexClient and ObjectClient.
+// newDynamoDBStorageClient makes a new DynamoDB-backed IndexClient and chunk.Client.
 func newDynamoDBStorageClient(cfg DynamoDBConfig, schemaCfg chunk.SchemaConfig) (*dynamoDBStorageClient, error) {
 	dynamoDB, err := dynamoClientFromURL(cfg.DynamoDB.URL)
 	if err != nil {

--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -155,7 +155,7 @@ func NewDynamoDBIndexClient(cfg DynamoDBConfig, schemaCfg chunk.SchemaConfig) (c
 }
 
 // NewDynamoDBObjectClient makes a new DynamoDB-backed ObjectClient.
-func NewDynamoDBObjectClient(cfg DynamoDBConfig, schemaCfg chunk.SchemaConfig) (chunk.ObjectClient, error) {
+func NewDynamoDBObjectClient(cfg DynamoDBConfig, schemaCfg chunk.SchemaConfig) (chunk.Client, error) {
 	return newDynamoDBStorageClient(cfg, schemaCfg)
 }
 
@@ -461,7 +461,7 @@ type chunksPlusError struct {
 	err    error
 }
 
-// GetChunks implements chunk.ObjectClient.
+// GetChunks implements chunk.Client.
 func (a dynamoDBStorageClient) GetChunks(ctx context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
 	log, ctx := spanlogger.New(ctx, "GetChunks.DynamoDB", ot.Tag{Key: "numChunks", Value: len(chunks)})
 	defer log.Span.Finish()
@@ -639,7 +639,7 @@ func (a dynamoDBStorageClient) PutChunkAndIndex(ctx context.Context, c chunk.Chu
 	return a.BatchWrite(ctx, dynamoDBWrites)
 }
 
-// PutChunks implements chunk.ObjectClient.
+// PutChunks implements chunk.Client.
 func (a dynamoDBStorageClient) PutChunks(ctx context.Context, chunks []chunk.Chunk) error {
 	dynamoDBWrites, err := a.writesForChunks(chunks)
 	if err != nil {

--- a/pkg/chunk/cassandra/fixtures.go
+++ b/pkg/chunk/cassandra/fixtures.go
@@ -16,7 +16,7 @@ import (
 type fixture struct {
 	name         string
 	indexClient  chunk.IndexClient
-	objectClient chunk.ObjectClient
+	objectClient chunk.Client
 	tableClient  chunk.TableClient
 	schemaConfig chunk.SchemaConfig
 }
@@ -25,7 +25,7 @@ func (f fixture) Name() string {
 	return f.name
 }
 
-func (f fixture) Clients() (chunk.IndexClient, chunk.ObjectClient, chunk.TableClient, chunk.SchemaConfig, error) {
+func (f fixture) Clients() (chunk.IndexClient, chunk.Client, chunk.TableClient, chunk.SchemaConfig, error) {
 	return f.indexClient, f.objectClient, f.tableClient, f.schemaConfig, nil
 }
 

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -73,13 +73,13 @@ type store struct {
 	cfg StoreConfig
 
 	index  IndexClient
-	chunks ObjectClient
+	chunks Client
 	schema Schema
 	limits StoreLimits
 	*Fetcher
 }
 
-func newStore(cfg StoreConfig, schema Schema, index IndexClient, chunks ObjectClient, limits StoreLimits) (Store, error) {
+func newStore(cfg StoreConfig, schema Schema, index IndexClient, chunks Client, limits StoreLimits) (Store, error) {
 	fetcher, err := NewChunkFetcher(cfg.ChunkCacheConfig, cfg.chunkCacheStubs, chunks)
 	if err != nil {
 		return nil, err

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -80,7 +80,7 @@ outer:
 // and writing back any misses to the cache.  Also responsible for decoding
 // chunks from the cache, in parallel.
 type Fetcher struct {
-	storage    ObjectClient
+	storage    Client
 	cache      cache.Cache
 	cacheStubs bool
 
@@ -99,7 +99,7 @@ type decodeResponse struct {
 }
 
 // NewChunkFetcher makes a new ChunkFetcher.
-func NewChunkFetcher(cfg cache.Config, cacheStubs bool, storage ObjectClient) (*Fetcher, error) {
+func NewChunkFetcher(cfg cache.Config, cacheStubs bool, storage Client) (*Fetcher, error) {
 	cfg.Prefix = "chunks"
 	cache, err := cache.New(cfg)
 	if err != nil {

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -50,7 +50,7 @@ func NewCompositeStore() CompositeStore {
 }
 
 // AddPeriod adds the configuration for a period of time to the CompositeStore
-func (c *CompositeStore) AddPeriod(storeCfg StoreConfig, cfg PeriodConfig, index IndexClient, chunks ObjectClient, limits StoreLimits) error {
+func (c *CompositeStore) AddPeriod(storeCfg StoreConfig, cfg PeriodConfig, index IndexClient, chunks Client, limits StoreLimits) error {
 	schema := cfg.CreateSchema()
 	var store Store
 	var err error

--- a/pkg/chunk/gcp/bigtable_object_client.go
+++ b/pkg/chunk/gcp/bigtable_object_client.go
@@ -19,9 +19,9 @@ type bigtableObjectClient struct {
 	client    *bigtable.Client
 }
 
-// NewBigtableObjectClient makes a new chunk.ObjectClient that stores chunks in
+// NewBigtableObjectClient makes a new chunk.Client that stores chunks in
 // Bigtable.
-func NewBigtableObjectClient(ctx context.Context, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.ObjectClient, error) {
+func NewBigtableObjectClient(ctx context.Context, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.Client, error) {
 	opts := toOptions(cfg.GRPCClientConfig.DialOption(bigtableInstrumentation()))
 	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, opts...)
 	if err != nil {
@@ -30,7 +30,7 @@ func NewBigtableObjectClient(ctx context.Context, cfg Config, schemaCfg chunk.Sc
 	return newBigtableObjectClient(cfg, schemaCfg, client), nil
 }
 
-func newBigtableObjectClient(cfg Config, schemaCfg chunk.SchemaConfig, client *bigtable.Client) chunk.ObjectClient {
+func newBigtableObjectClient(cfg Config, schemaCfg chunk.SchemaConfig, client *bigtable.Client) chunk.Client {
 	return &bigtableObjectClient{
 		cfg:       cfg,
 		schemaCfg: schemaCfg,

--- a/pkg/chunk/gcp/fixtures.go
+++ b/pkg/chunk/gcp/fixtures.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/chunk/objectclient"
 	"github.com/cortexproject/cortex/pkg/chunk/testutils"
 )
 
@@ -34,7 +35,7 @@ func (f *fixture) Name() string {
 }
 
 func (f *fixture) Clients() (
-	iClient chunk.IndexClient, cClient chunk.ObjectClient, tClient chunk.TableClient,
+	iClient chunk.IndexClient, cClient chunk.Client, tClient chunk.TableClient,
 	schemaConfig chunk.SchemaConfig, err error,
 ) {
 	f.btsrv, err = bttest.NewServer("localhost:0")
@@ -76,9 +77,9 @@ func (f *fixture) Clients() (
 	}
 
 	if f.gcsObjectClient {
-		cClient = newGCSObjectClient(GCSConfig{
+		cClient = objectclient.NewClient(newGCSObjectClient(GCSConfig{
 			BucketName: "chunks",
-		}, f.gcssrv.Client())
+		}, f.gcssrv.Client()), nil)
 	} else {
 		cClient = newBigtableObjectClient(Config{}, schemaConfig, client)
 	}

--- a/pkg/chunk/local/fixtures.go
+++ b/pkg/chunk/local/fixtures.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/chunk/objectclient"
 	"github.com/cortexproject/cortex/pkg/chunk/testutils"
 )
 
@@ -21,7 +22,7 @@ func (f *fixture) Name() string {
 }
 
 func (f *fixture) Clients() (
-	indexClient chunk.IndexClient, objectClient chunk.ObjectClient, tableClient chunk.TableClient,
+	indexClient chunk.IndexClient, chunkClient chunk.Client, tableClient chunk.TableClient,
 	schemaConfig chunk.SchemaConfig, err error,
 ) {
 	f.dirname, err = ioutil.TempDir(os.TempDir(), "boltdb")
@@ -36,12 +37,14 @@ func (f *fixture) Clients() (
 		return
 	}
 
-	objectClient, err = NewFSObjectClient(FSConfig{
+	oClient, err := NewFSObjectClient(FSConfig{
 		Directory: f.dirname,
 	})
 	if err != nil {
 		return
 	}
+
+	chunkClient = objectclient.NewClient(oClient, objectclient.Base64Encoder)
 
 	tableClient, err = NewTableClient(f.dirname)
 	if err != nil {

--- a/pkg/chunk/objectclient/client.go
+++ b/pkg/chunk/objectclient/client.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"io/ioutil"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/util"
-	"github.com/pkg/errors"
 )
 
 // KeyEncoder is used to encode chunk keys before writing/retrieving chunks

--- a/pkg/chunk/objectclient/client.go
+++ b/pkg/chunk/objectclient/client.go
@@ -1,0 +1,108 @@
+package objectclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"io/ioutil"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/chunk/util"
+)
+
+// KeyEncoder is used to encode chunk keys before writing/retrieving chunks
+// from the underlying ObjectClient
+type KeyEncoder func(string) string
+
+// Base64Encoder is used to encode chunk keys in base64 before storing/retrieving
+// them from the ObjectClient
+var Base64Encoder = func(key string) string {
+	return base64.StdEncoding.EncodeToString([]byte(key))
+}
+
+// Client is used to store chunks in object store backends
+type Client struct {
+	store      chunk.ObjectClient
+	keyEncoder KeyEncoder
+}
+
+// NewClient wraps the provided ObjectClient with a chunk.Client implementation
+func NewClient(store chunk.ObjectClient, encoder KeyEncoder) *Client {
+	return &Client{
+		store:      store,
+		keyEncoder: encoder,
+	}
+}
+
+// Stop shuts down the object store and any underlying clients
+func (o *Client) Stop() {
+	o.store.Stop()
+}
+
+// PutChunks stores the provided chunks in the configured backend. If multiple errors are
+// returned, the last one sequentially will be propagated up.
+func (o *Client) PutChunks(ctx context.Context, chunks []chunk.Chunk) error {
+	var (
+		chunkKeys []string
+		chunkBufs [][]byte
+	)
+
+	for i := range chunks {
+		buf, err := chunks[i].Encoded()
+		if err != nil {
+			return err
+		}
+		key := chunks[i].ExternalKey()
+		if o.keyEncoder != nil {
+			key = o.keyEncoder(key)
+		}
+
+		chunkKeys = append(chunkKeys, key)
+		chunkBufs = append(chunkBufs, buf)
+	}
+
+	incomingErrors := make(chan error)
+	for i := range chunkBufs {
+		go func(i int) {
+			incomingErrors <- o.store.PutObject(ctx, chunkKeys[i], bytes.NewReader(chunkBufs[i]))
+		}(i)
+	}
+
+	var lastErr error
+	for range chunkKeys {
+		err := <-incomingErrors
+		if err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+// GetChunks retrieves the specified chunks from the configured backend
+func (o *Client) GetChunks(ctx context.Context, chunks []chunk.Chunk) ([]chunk.Chunk, error) {
+	return util.GetParallelChunks(ctx, chunks, o.getChunk)
+}
+
+func (o *Client) getChunk(ctx context.Context, decodeContext *chunk.DecodeContext, c chunk.Chunk) (chunk.Chunk, error) {
+	key := c.ExternalKey()
+	if o.keyEncoder != nil {
+		key = o.keyEncoder(key)
+	}
+
+	readCloser, err := o.store.GetObject(ctx, key)
+	if err != nil {
+		return chunk.Chunk{}, err
+	}
+
+	defer readCloser.Close()
+
+	buf, err := ioutil.ReadAll(readCloser)
+	if err != nil {
+		return chunk.Chunk{}, err
+	}
+
+	if err := c.Decode(decodeContext, buf); err != nil {
+		return chunk.Chunk{}, err
+	}
+	return c, nil
+}

--- a/pkg/chunk/objectclient/client.go
+++ b/pkg/chunk/objectclient/client.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"errors"
 	"io/ioutil"
+
+	"github.com/pkg/errors"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/util"

--- a/pkg/chunk/objectclient/client.go
+++ b/pkg/chunk/objectclient/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/util"
+	"github.com/pkg/errors"
 )
 
 // KeyEncoder is used to encode chunk keys before writing/retrieving chunks
@@ -91,18 +92,18 @@ func (o *Client) getChunk(ctx context.Context, decodeContext *chunk.DecodeContex
 
 	readCloser, err := o.store.GetObject(ctx, key)
 	if err != nil {
-		return chunk.Chunk{}, err
+		return chunk.Chunk{}, errors.WithStack(err)
 	}
 
 	defer readCloser.Close()
 
 	buf, err := ioutil.ReadAll(readCloser)
 	if err != nil {
-		return chunk.Chunk{}, err
+		return chunk.Chunk{}, errors.WithStack(err)
 	}
 
 	if err := c.Decode(decodeContext, buf); err != nil {
-		return chunk.Chunk{}, err
+		return chunk.Chunk{}, errors.WithStack(err)
 	}
 	return c, nil
 }

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -66,7 +66,7 @@ type seriesStore struct {
 	writeDedupeCache cache.Cache
 }
 
-func newSeriesStore(cfg StoreConfig, schema Schema, index IndexClient, chunks ObjectClient, limits StoreLimits) (Store, error) {
+func newSeriesStore(cfg StoreConfig, schema Schema, index IndexClient, chunks Client, limits StoreLimits) (Store, error) {
 	fetcher, err := NewChunkFetcher(cfg.ChunkCacheConfig, cfg.chunkCacheStubs, chunks)
 	if err != nil {
 		return nil, err

--- a/pkg/chunk/storage/caching_fixtures.go
+++ b/pkg/chunk/storage/caching_fixtures.go
@@ -18,17 +18,17 @@ type fixture struct {
 }
 
 func (f fixture) Name() string { return "caching-store" }
-func (f fixture) Clients() (chunk.IndexClient, chunk.ObjectClient, chunk.TableClient, chunk.SchemaConfig, error) {
+func (f fixture) Clients() (chunk.IndexClient, chunk.Client, chunk.TableClient, chunk.SchemaConfig, error) {
 	limits, err := defaultLimits()
 	if err != nil {
 		return nil, nil, nil, chunk.SchemaConfig{}, err
 	}
-	indexClient, objectClient, tableClient, schemaConfig, err := f.fixture.Clients()
+	indexClient, chunkClient, tableClient, schemaConfig, err := f.fixture.Clients()
 	indexClient = newCachingIndexClient(indexClient, cache.NewFifoCache("index-fifo", cache.FifoCacheConfig{
 		Size:     500,
 		Validity: 5 * time.Minute,
 	}), 5*time.Minute, limits)
-	return indexClient, objectClient, tableClient, schemaConfig, err
+	return indexClient, chunkClient, tableClient, schemaConfig, err
 }
 func (f fixture) Teardown() error { return f.fixture.Teardown() }
 

--- a/pkg/chunk/storage/chunk_client_test.go
+++ b/pkg/chunk/storage/chunk_client_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestChunksBasic(t *testing.T) {
-	forAllFixtures(t, func(t *testing.T, _ chunk.IndexClient, client chunk.ObjectClient) {
+	forAllFixtures(t, func(t *testing.T, _ chunk.IndexClient, client chunk.Client) {
 		const batchSize = 5
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/cassandra"
 	"github.com/cortexproject/cortex/pkg/chunk/gcp"
 	"github.com/cortexproject/cortex/pkg/chunk/local"
+	"github.com/cortexproject/cortex/pkg/chunk/objectclient"
 	"github.com/cortexproject/cortex/pkg/util"
 )
 
@@ -164,13 +165,12 @@ func NewIndexClient(name string, cfg Config, schemaCfg chunk.SchemaConfig) (chun
 }
 
 // NewObjectClient makes a new ObjectClient of the desired types.
-func NewObjectClient(name string, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.ObjectClient, error) {
+func NewObjectClient(name string, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.Client, error) {
 	switch name {
 	case "inmemory":
-		store := chunk.NewMockStorage()
-		return store, nil
+		return chunk.NewMockStorage(), nil
 	case "aws", "s3":
-		return aws.NewS3ObjectClient(cfg.AWSStorageConfig.S3Config)
+		return newChunkClientFromStore(aws.NewS3ObjectClient(cfg.AWSStorageConfig.S3Config))
 	case "aws-dynamo":
 		if cfg.AWSStorageConfig.DynamoDB.URL == nil {
 			return nil, fmt.Errorf("Must set -dynamodb.url in aws mode")
@@ -181,20 +181,31 @@ func NewObjectClient(name string, cfg Config, schemaCfg chunk.SchemaConfig) (chu
 		}
 		return aws.NewDynamoDBObjectClient(cfg.AWSStorageConfig.DynamoDBConfig, schemaCfg)
 	case "azure":
-		return azure.NewBlobStorage(&cfg.AzureStorageConfig)
+		return newChunkClientFromStore(azure.NewBlobStorage(&cfg.AzureStorageConfig))
 	case "gcp":
 		return gcp.NewBigtableObjectClient(context.Background(), cfg.GCPStorageConfig, schemaCfg)
 	case "gcp-columnkey", "bigtable", "bigtable-hashed":
 		return gcp.NewBigtableObjectClient(context.Background(), cfg.GCPStorageConfig, schemaCfg)
 	case "gcs":
-		return gcp.NewGCSObjectClient(context.Background(), cfg.GCSConfig)
+		return newChunkClientFromStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCSConfig))
 	case "cassandra":
 		return cassandra.NewStorageClient(cfg.CassandraStorageConfig, schemaCfg)
 	case "filesystem":
-		return local.NewFSObjectClient(cfg.FSConfig)
+		store, err := local.NewFSObjectClient(cfg.FSConfig)
+		if err != nil {
+			return nil, err
+		}
+		return objectclient.NewClient(store, objectclient.Base64Encoder), nil
 	default:
 		return nil, fmt.Errorf("Unrecognized storage client %v, choose one of: aws, azure, cassandra, inmemory, gcp, bigtable, bigtable-hashed", name)
 	}
+}
+
+func newChunkClientFromStore(store chunk.ObjectClient, err error) (chunk.Client, error) {
+	if err != nil {
+		return nil, err
+	}
+	return objectclient.NewClient(store, nil), nil
 }
 
 // NewTableClient makes a new table client based on the configuration.

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -115,7 +115,7 @@ func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConf
 		if objectStoreType == "" {
 			objectStoreType = s.IndexType
 		}
-		chunks, err := NewObjectClient(objectStoreType, cfg, schemaCfg)
+		chunks, err := NewChunkClient(objectStoreType, cfg, schemaCfg)
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating object client")
 		}
@@ -164,8 +164,8 @@ func NewIndexClient(name string, cfg Config, schemaCfg chunk.SchemaConfig) (chun
 	}
 }
 
-// NewObjectClient makes a new ObjectClient of the desired types.
-func NewObjectClient(name string, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.Client, error) {
+// NewChunkClient makes a new chunk.Client of the desired types.
+func NewChunkClient(name string, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.Client, error) {
 	switch name {
 	case "inmemory":
 		return chunk.NewMockStorage(), nil
@@ -179,7 +179,7 @@ func NewObjectClient(name string, cfg Config, schemaCfg chunk.SchemaConfig) (chu
 		if len(path) > 0 {
 			level.Warn(util.Logger).Log("msg", "ignoring DynamoDB URL path", "path", path)
 		}
-		return aws.NewDynamoDBObjectClient(cfg.AWSStorageConfig.DynamoDBConfig, schemaCfg)
+		return aws.NewDynamoDBChunkClient(cfg.AWSStorageConfig.DynamoDBConfig, schemaCfg)
 	case "azure":
 		return newChunkClientFromStore(azure.NewBlobStorage(&cfg.AzureStorageConfig))
 	case "gcp":

--- a/pkg/chunk/storage/index_client_test.go
+++ b/pkg/chunk/storage/index_client_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIndexBasic(t *testing.T) {
-	forAllFixtures(t, func(t *testing.T, client chunk.IndexClient, _ chunk.ObjectClient) {
+	forAllFixtures(t, func(t *testing.T, client chunk.IndexClient, _ chunk.Client) {
 		// Write out 30 entries, into different hash and range values.
 		batch := client.NewWriteBatch()
 		for i := 0; i < 30; i++ {
@@ -100,7 +100,7 @@ var entries = []chunk.IndexEntry{
 }
 
 func TestQueryPages(t *testing.T) {
-	forAllFixtures(t, func(t *testing.T, client chunk.IndexClient, _ chunk.ObjectClient) {
+	forAllFixtures(t, func(t *testing.T, client chunk.IndexClient, _ chunk.Client) {
 		batch := client.NewWriteBatch()
 		for _, entry := range entries {
 			batch.Add(entry.TableName, entry.HashValue, entry.RangeValue, entry.Value)
@@ -200,7 +200,7 @@ func TestQueryPages(t *testing.T) {
 }
 
 func TestCardinalityLimit(t *testing.T) {
-	forAllFixtures(t, func(t *testing.T, client chunk.IndexClient, _ chunk.ObjectClient) {
+	forAllFixtures(t, func(t *testing.T, client chunk.IndexClient, _ chunk.Client) {
 		limits, err := defaultLimits()
 		require.NoError(t, err)
 

--- a/pkg/chunk/storage/utils_test.go
+++ b/pkg/chunk/storage/utils_test.go
@@ -18,7 +18,7 @@ const (
 	tableName = "test"
 )
 
-type storageClientTest func(*testing.T, chunk.IndexClient, chunk.ObjectClient)
+type storageClientTest func(*testing.T, chunk.IndexClient, chunk.Client)
 
 func forAllFixtures(t *testing.T, storageClientTest storageClientTest) {
 	var fixtures []testutils.Fixture

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"context"
+	"io"
 	"time"
 )
 
@@ -20,8 +21,8 @@ type IndexClient interface {
 	QueryPages(ctx context.Context, queries []IndexQuery, callback func(IndexQuery, ReadBatch) (shouldContinue bool)) error
 }
 
-// ObjectClient is for storing and retrieving chunks.
-type ObjectClient interface {
+// Client is for storing and retrieving chunks.
+type Client interface {
 	Stop()
 
 	PutChunks(ctx context.Context, chunks []Chunk) error
@@ -50,6 +51,15 @@ type ReadBatchIterator interface {
 	Value() []byte
 }
 
+// ObjectClient is used to store arbitrary data in Object Store (S3/GCS/Azure/Etc)
+type ObjectClient interface {
+	PutObject(ctx context.Context, objectKey string, object io.ReadSeeker) error
+	GetObject(ctx context.Context, objectKey string) (io.ReadCloser, error)
+	List(ctx context.Context, prefix string) ([]StorageObject, error)
+	Stop()
+}
+
+// StorageObject represents an object being stored in an Object Store
 type StorageObject struct {
 	Key        string
 	ModifiedAt time.Time

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -22,7 +22,7 @@ const (
 // Fixture type for per-backend testing.
 type Fixture interface {
 	Name() string
-	Clients() (chunk.IndexClient, chunk.ObjectClient, chunk.TableClient, chunk.SchemaConfig, error)
+	Clients() (chunk.IndexClient, chunk.Client, chunk.TableClient, chunk.SchemaConfig, error)
 	Teardown() error
 }
 
@@ -33,10 +33,10 @@ func DefaultSchemaConfig(kind string) chunk.SchemaConfig {
 }
 
 // Setup a fixture with initial tables
-func Setup(fixture Fixture, tableName string) (chunk.IndexClient, chunk.ObjectClient, error) {
+func Setup(fixture Fixture, tableName string) (chunk.IndexClient, chunk.Client, error) {
 	var tbmConfig chunk.TableManagerConfig
 	flagext.DefaultValues(&tbmConfig)
-	indexClient, objectClient, tableClient, schemaConfig, err := fixture.Clients()
+	indexClient, chunkClient, tableClient, schemaConfig, err := fixture.Clients()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -54,7 +54,8 @@ func Setup(fixture Fixture, tableName string) (chunk.IndexClient, chunk.ObjectCl
 	err = tableClient.CreateTable(context.Background(), chunk.TableDesc{
 		Name: tableName,
 	})
-	return indexClient, objectClient, err
+
+	return indexClient, chunkClient, err
 }
 
 // CreateChunks creates some chunks for testing


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
* Rename the chunk `ObjectClient` to `Client` 
* Create a new ObjectClient interface with simple methods implemented in #2049 
* Create generic object store chunk client in `pkg/chunk/object`
* Update fixtures to detect and utilize generic chunk object client during tests
* Utilize the generic `object.ChunkClient` when S3/GCS/AzureBlobStore/LocalFS is specified as a chunk store, all of these backends already implement the `ObjectClient` interface.

**Which issue(s) this PR fixes**:
Fixes #2107 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
