### PR TITLE
Fixed linter

### DIFF
--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/integration/framework"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/integration/framework"
 )
 
 const (

--- a/integration/framework/service.go
+++ b/integration/framework/service.go
@@ -12,9 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/expfmt"
+
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 var (

--- a/integration/ingester_flush_test.go
+++ b/integration/ingester_flush_test.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/cortexproject/cortex/integration/framework"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/integration/framework"
 )
 
 func TestIngesterFlushWithChunksStorage(t *testing.T) {

--- a/integration/ingester_hand_over_test.go
+++ b/integration/ingester_hand_over_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/integration/framework"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/integration/framework"
 )
 
 func TestIngesterHandOverWithBlocksStorage(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
I've just merged the PR #1839 (whose tests in CI didn't run after the recent changes to `goimports`) and now the linter on `master` fails because of the `goimports` changes. This PR should fix it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
