### PR TITLE
Modules can now start additional startup tasks, while server is starting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/weaveworks/common v0.0.0-20200201141823-27e183090ab1
 	go.etcd.io/bbolt v1.3.3
 	go.etcd.io/etcd v0.0.0-20190709142735-eb7dd97135a5
+	go.uber.org/atomic v1.5.0
 	golang.org/x/net v0.0.0-20191112182307-2180aed22343
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/api v0.14.0

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	go.etcd.io/etcd v0.0.0-20190709142735-eb7dd97135a5
 	go.uber.org/atomic v1.5.0
 	golang.org/x/net v0.0.0-20191112182307-2180aed22343
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/api v0.14.0
 	google.golang.org/grpc v1.25.1

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -256,6 +256,7 @@ func (t *Cortex) init(cfg *Config, m moduleName) error {
 // calls start functions of modules. Functions are called concurrently.
 func (t *Cortex) start(target moduleName) error {
 	deps := orderedDeps(target)
+	deps = append(deps, target) // target is not part of dependencies, make sure we call its start function too
 
 	grp, ctx := errgroup.WithContext(context.Background())
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log/level"
-	"github.com/gogo/status"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -19,6 +18,7 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
 
 	cortex_chunk "github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
@@ -296,7 +296,7 @@ func (i *Ingester) StopIncomingRequests() {
 // Push implements client.IngesterServer
 func (i *Ingester) Push(ctx context.Context, req *client.WriteRequest) (*client.WriteResponse, error) {
 	if !i.ingesterStarted() {
-		return nil, errIngesterNotStarted
+		return nil, status.Error(codes.Unavailable, errIngesterNotStarted.Error())
 	}
 
 	if i.cfg.TSDBEnabled {
@@ -436,7 +436,7 @@ func (i *Ingester) append(ctx context.Context, userID string, labels labelPairs,
 // Query implements service.IngesterServer
 func (i *Ingester) Query(ctx context.Context, req *client.QueryRequest) (*client.QueryResponse, error) {
 	if !i.ingesterStarted() {
-		return nil, errIngesterNotStarted
+		return nil, status.Error(codes.Unavailable, errIngesterNotStarted.Error())
 	}
 
 	if i.cfg.TSDBEnabled {
@@ -503,7 +503,7 @@ func (i *Ingester) Query(ctx context.Context, req *client.QueryRequest) (*client
 // QueryStream implements service.IngesterServer
 func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_QueryStreamServer) error {
 	if !i.ingesterStarted() {
-		return errIngesterNotStarted
+		return status.Error(codes.Unavailable, errIngesterNotStarted.Error())
 	}
 
 	if i.cfg.TSDBEnabled {
@@ -583,7 +583,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 // LabelValues returns all label values that are associated with a given label name.
 func (i *Ingester) LabelValues(ctx context.Context, req *client.LabelValuesRequest) (*client.LabelValuesResponse, error) {
 	if !i.ingesterStarted() {
-		return nil, errIngesterNotStarted
+		return nil, status.Error(codes.Unavailable, errIngesterNotStarted.Error())
 	}
 
 	if i.cfg.TSDBEnabled {
@@ -608,7 +608,7 @@ func (i *Ingester) LabelValues(ctx context.Context, req *client.LabelValuesReque
 // LabelNames return all the label names.
 func (i *Ingester) LabelNames(ctx context.Context, req *client.LabelNamesRequest) (*client.LabelNamesResponse, error) {
 	if !i.ingesterStarted() {
-		return nil, errIngesterNotStarted
+		return nil, status.Error(codes.Unavailable, errIngesterNotStarted.Error())
 	}
 
 	if i.cfg.TSDBEnabled {
@@ -633,7 +633,7 @@ func (i *Ingester) LabelNames(ctx context.Context, req *client.LabelNamesRequest
 // MetricsForLabelMatchers returns all the metrics which match a set of matchers.
 func (i *Ingester) MetricsForLabelMatchers(ctx context.Context, req *client.MetricsForLabelMatchersRequest) (*client.MetricsForLabelMatchersResponse, error) {
 	if !i.ingesterStarted() {
-		return nil, errIngesterNotStarted
+		return nil, status.Error(codes.Unavailable, errIngesterNotStarted.Error())
 	}
 
 	if i.cfg.TSDBEnabled {
@@ -680,7 +680,7 @@ func (i *Ingester) MetricsForLabelMatchers(ctx context.Context, req *client.Metr
 // UserStats returns ingestion statistics for the current user.
 func (i *Ingester) UserStats(ctx context.Context, req *client.UserStatsRequest) (*client.UserStatsResponse, error) {
 	if !i.ingesterStarted() {
-		return nil, errIngesterNotStarted
+		return nil, status.Error(codes.Unavailable, errIngesterNotStarted.Error())
 	}
 
 	if i.cfg.TSDBEnabled {
@@ -709,7 +709,7 @@ func (i *Ingester) UserStats(ctx context.Context, req *client.UserStatsRequest) 
 // AllUserStats returns ingestion statistics for all users known to this ingester.
 func (i *Ingester) AllUserStats(ctx context.Context, req *client.UserStatsRequest) (*client.UsersStatsResponse, error) {
 	if !i.ingesterStarted() {
-		return nil, errIngesterNotStarted
+		return nil, status.Error(codes.Unavailable, errIngesterNotStarted.Error())
 	}
 
 	if i.cfg.TSDBEnabled {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -45,6 +45,9 @@ func newTestStore(t require.TestingT, cfg Config, clientConfig client.Config, li
 	ing, err := New(cfg, clientConfig, overrides, store, nil)
 	require.NoError(t, err)
 
+	err = ing.Start(context.Background())
+	require.NoError(t, err)
+
 	return store, ing
 }
 

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -930,6 +930,10 @@ func newIngesterMockWithTSDBStorage(ingesterCfg Config, registerer prometheus.Re
 	if err != nil {
 		return nil, nil, err
 	}
+	err = ingester.Start(context.Background())
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// Create a cleanup function that the caller should call with defer
 	cleanup := func() {
@@ -1007,6 +1011,8 @@ func TestIngester_v2LoadTSDBOnStartup(t *testing.T) {
 			testData.setup(t, tempDir)
 
 			ingester, err := NewV2(ingesterCfg, clientCfg, overrides, nil)
+			require.NoError(t, err)
+			err = ingester.Start(context.Background())
 			require.NoError(t, err)
 
 			defer ingester.Shutdown()

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -104,6 +104,8 @@ func TestIngesterTransfer(t *testing.T) {
 	cfg1.MaxTransferRetries = 10
 	ing1, err := New(cfg1, defaultClientTestConfig(), limits, nil, nil)
 	require.NoError(t, err)
+	err = ing1.Start(context.Background())
+	require.NoError(t, err)
 
 	test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {
 		return ing1.lifecycler.GetState()
@@ -122,6 +124,8 @@ func TestIngesterTransfer(t *testing.T) {
 	cfg2.LifecyclerConfig.Addr = "ingester2"
 	cfg2.LifecyclerConfig.JoinAfter = 100 * time.Second
 	ing2, err := New(cfg2, defaultClientTestConfig(), limits, nil, nil)
+	require.NoError(t, err)
+	err = ing2.Start(context.Background())
 	require.NoError(t, err)
 
 	// Let ing2 send chunks to ing1
@@ -167,6 +171,8 @@ func TestIngesterBadTransfer(t *testing.T) {
 	cfg.LifecyclerConfig.Addr = "ingester1"
 	cfg.LifecyclerConfig.JoinAfter = 100 * time.Second
 	ing, err := New(cfg, defaultClientTestConfig(), limits, nil, nil)
+	require.NoError(t, err)
+	err = ing.Start(context.Background())
 	require.NoError(t, err)
 
 	test.Poll(t, 100*time.Millisecond, ring.PENDING, func() interface{} {
@@ -439,6 +445,8 @@ func TestV2IngesterTransfer(t *testing.T) {
 			cfg1.MaxTransferRetries = 10
 			ing1, err := New(cfg1, defaultClientTestConfig(), limits, nil, nil)
 			require.NoError(t, err)
+			err = ing1.Start(context.Background())
+			require.NoError(t, err)
 
 			test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {
 				return ing1.lifecycler.GetState()
@@ -465,6 +473,8 @@ func TestV2IngesterTransfer(t *testing.T) {
 			cfg2.LifecyclerConfig.Addr = "ingester2"
 			cfg2.LifecyclerConfig.JoinAfter = 100 * time.Second
 			ing2, err := New(cfg2, defaultClientTestConfig(), limits, nil, nil)
+			require.NoError(t, err)
+			err = ing2.Start(context.Background())
 			require.NoError(t, err)
 
 			// Let ing1 send blocks/wal to ing2

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -52,6 +52,10 @@ func NewBlockQuerier(cfg tsdb.Config, logLevel logging.Level, registerer prometh
 	return b, nil
 }
 
+func (b *BlockQuerier) Start(ctx context.Context) error {
+	return b.us.Start(ctx)
+}
+
 // Get implements the ChunkStore interface. It makes a block query and converts the response into chunks
 func (b *BlockQuerier) Get(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]chunk.Chunk, error) {
 	log, ctx := spanlogger.New(ctx, "BlockQuerier.Get")

--- a/pkg/querier/block_store.go
+++ b/pkg/querier/block_store.go
@@ -24,7 +24,9 @@ import (
 	"github.com/weaveworks/common/logging"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
@@ -253,7 +255,7 @@ func (u *UserStore) syncUserStores(ctx context.Context, f func(context.Context, 
 // Info makes an info request to the underlying user store
 func (u *UserStore) Info(ctx context.Context, req *storepb.InfoRequest) (*storepb.InfoResponse, error) {
 	if !u.storeStarted() {
-		return nil, errStoreNotStarted
+		return nil, status.Error(codes.Unavailable, errStoreNotStarted.Error())
 	}
 	log, ctx := spanlogger.New(ctx, "UserStore.Info")
 	defer log.Span.Finish()
@@ -279,7 +281,7 @@ func (u *UserStore) Info(ctx context.Context, req *storepb.InfoRequest) (*storep
 // Series makes a series request to the underlying user store
 func (u *UserStore) Series(req *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
 	if !u.storeStarted() {
-		return errStoreNotStarted
+		return status.Error(codes.Unavailable, errStoreNotStarted.Error())
 	}
 
 	log, ctx := spanlogger.New(srv.Context(), "UserStore.Series")
@@ -306,7 +308,7 @@ func (u *UserStore) Series(req *storepb.SeriesRequest, srv storepb.Store_SeriesS
 // LabelNames makes a labelnames request to the underlying user store
 func (u *UserStore) LabelNames(ctx context.Context, req *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
 	if !u.storeStarted() {
-		return nil, errStoreNotStarted
+		return nil, status.Error(codes.Unavailable, errStoreNotStarted.Error())
 	}
 
 	log, ctx := spanlogger.New(ctx, "UserStore.LabelNames")
@@ -333,7 +335,7 @@ func (u *UserStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReque
 // LabelValues makes a labelvalues request to the underlying user store
 func (u *UserStore) LabelValues(ctx context.Context, req *storepb.LabelValuesRequest) (*storepb.LabelValuesResponse, error) {
 	if !u.storeStarted() {
-		return nil, errStoreNotStarted
+		return nil, status.Error(codes.Unavailable, errStoreNotStarted.Error())
 	}
 
 	log, ctx := spanlogger.New(ctx, "UserStore.LabelValues")

--- a/pkg/querier/block_store_test.go
+++ b/pkg/querier/block_store_test.go
@@ -66,6 +66,8 @@ func TestUserStore_InitialSync(t *testing.T) {
 			us, err := NewUserStore(cfg, bucketClient, mockLoggingLevel(), log.NewNopLogger(), nil)
 			if us != nil {
 				defer us.Stop()
+
+				err = us.Start(context.Background())
 			}
 
 			require.Equal(t, err, testData.expectedErr)
@@ -87,6 +89,9 @@ func TestUserStore_syncUserStores(t *testing.T) {
 
 	us, err := NewUserStore(cfg, bucketClient, mockLoggingLevel(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
+	err = us.Start(context.Background())
+	require.NoError(t, err)
+
 	defer us.Stop()
 
 	// Sync user stores and count the number of times the callback is called.


### PR DESCRIPTION
Modules can now have start function for starting additional tasks on startup.

Start functions are called concurrently, and only after all modules are initialized. Server's HTTP service starts while modules are still starting, so modules must be able to handle that. Both ingester and queriers will return error.

This is currently used by blocks-based ingester (to replay WAL for locally stored TSDBs) and querier (to do initial fetch of blocks).

This is alternative to https://github.com/cortexproject/cortex/pull/2104.

Note: this is not ideal, but is relatively simple change. I think we should overhaul the lifecycle of our modules, and have separate NEW (instantiated, but nothing started yet), STARTING (replaying WALs, fetching blocks, whatever needs to be done for service to be ready) and RUNNING (service is running) states and make those states observable by other modules (for dependencies and for global view on the server, plus make those states observable via metrics / simple HTML page), but this PR doesn't go that far. I'll write a design document for that first.

Signed-off-by: Peter Štibraný <peter.stibrany@grafana.com>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
