### PR TITLE
Stop table-manager loop early, if it is done

### DIFF
--- a/integration/framework/service.go
+++ b/integration/framework/service.go
@@ -221,6 +221,8 @@ func (s *Service) WaitReady() error {
 }
 
 func (s *Service) WaitMetric(port int, metric string, value float64) error {
+	lastFoundValue := 0.0
+
 	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
 		metrics, err := s.Metrics(80)
 		if err != nil {
@@ -237,12 +239,26 @@ func (s *Service) WaitMetric(port int, metric string, value float64) error {
 		mf, ok := families[metric]
 		if ok {
 			for _, m := range mf.Metric {
-				if m.GetGauge() != nil && m.GetGauge().GetValue() == value {
-					return nil
-				} else if m.GetCounter() != nil && m.GetCounter().GetValue() == value {
-					return nil
-				} else if m.GetHistogram() != nil && float64(m.GetHistogram().GetSampleCount()) == value {
-					return nil
+				// ignore metrics with labels. Labels are not supported at the moment.
+				if len(m.Label) > 0 {
+					continue
+				}
+
+				if m.GetGauge() != nil {
+					lastFoundValue = m.GetGauge().GetValue()
+					if lastFoundValue == value {
+						return nil
+					}
+				} else if m.GetCounter() != nil {
+					lastFoundValue = m.GetCounter().GetValue()
+					if lastFoundValue == value {
+						return nil
+					}
+				} else if m.GetHistogram() != nil {
+					lastFoundValue = float64(m.GetHistogram().GetSampleCount())
+					if lastFoundValue == value {
+						return nil
+					}
 				}
 			}
 		}
@@ -250,7 +266,7 @@ func (s *Service) WaitMetric(port int, metric string, value float64) error {
 		s.retryBackoff.Wait()
 	}
 
-	return fmt.Errorf("unable to find a metric %s with value %v", metric, value)
+	return fmt.Errorf("unable to find a metric %s with value %v. Last value found: %v", metric, value, lastFoundValue)
 }
 
 func (s *Service) buildDockerRunArgs() []string {

--- a/integration/framework/service.go
+++ b/integration/framework/service.go
@@ -239,11 +239,6 @@ func (s *Service) WaitMetric(port int, metric string, value float64) error {
 		mf, ok := families[metric]
 		if ok {
 			for _, m := range mf.Metric {
-				// ignore metrics with labels. Labels are not supported at the moment.
-				if len(m.Label) > 0 {
-					continue
-				}
-
 				if m.GetGauge() != nil {
 					lastFoundValue = m.GetGauge().GetValue()
 					if lastFoundValue == value {

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -177,7 +177,11 @@ func (m *TableManager) loop() {
 	}
 
 	// Sleep for a bit to spread the sync load across different times if the tablemanagers are all started at once.
-	time.Sleep(time.Duration(rand.Int63n(int64(m.cfg.DynamoDBPollInterval))))
+	select {
+	case <-time.After(time.Duration(rand.Int63n(int64(m.cfg.DynamoDBPollInterval)))):
+	case <-m.done:
+		return
+	}
 
 	for {
 		select {


### PR DESCRIPTION
This is trivial fix that helps integration tests to run slightly faster, as discussed at https://github.com/cortexproject/cortex/pull/2016#pullrequestreview-357570026.

If table-manager is stopped during initial wait, it now exits early.
