### PR TITLE
Ensure frontend response status code are correct.

### DIFF
--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -37,7 +37,7 @@ func LimitsMiddleware(l Limits) Middleware {
 func (l limits) Do(ctx context.Context, r Request) (Response, error) {
 	userid, err := user.ExtractOrgID(ctx)
 	if err != nil {
-		return nil, err
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 
 	maxQueryLen := l.MaxQueryLength(userid)
@@ -58,7 +58,7 @@ type RequestResponse struct {
 func DoRequests(ctx context.Context, downstream Handler, reqs []Request, limits Limits) ([]RequestResponse, error) {
 	userid, err := user.ExtractOrgID(ctx)
 	if err != nil {
-		return nil, err
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 
 	// If one of the requests fail, we want to be able to cancel the rest of them.

--- a/pkg/querier/queryrange/query_range.go
+++ b/pkg/querier/queryrange/query_range.go
@@ -180,7 +180,7 @@ func (prometheusCodec) DecodeRequest(_ context.Context, r *http.Request) (Reques
 func (prometheusCodec) EncodeRequest(ctx context.Context, r Request) (*http.Request, error) {
 	promReq, ok := r.(*PrometheusRequest)
 	if !ok {
-		return nil, httpgrpc.Errorf(http.StatusInternalServerError, "invalid request format")
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, "invalid request format")
 	}
 	params := url.Values{
 		"start": []string{encodeTime(promReq.Start)},
@@ -242,7 +242,7 @@ func (prometheusCodec) EncodeResponse(ctx context.Context, res Response) (*http.
 
 	b, err := json.Marshal(a)
 	if err != nil {
-		return nil, err
+		return nil, httpgrpc.Errorf(http.StatusInternalServerError, "error encoding response: %v", err)
 	}
 
 	sp.LogFields(otlog.Int("bytes", len(b)))

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/http"
 	"sort"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/common/model"
 	"github.com/uber/jaeger-client-go"
+	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
@@ -133,7 +135,7 @@ func NewResultsCacheMiddleware(
 func (s resultsCache) Do(ctx context.Context, r Request) (Response, error) {
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
-		return nil, err
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 
 	var (

--- a/pkg/querier/queryrange/retry.go
+++ b/pkg/querier/queryrange/retry.go
@@ -2,7 +2,6 @@ package queryrange
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -18,7 +17,6 @@ var (
 		Help:      "Number of times a request is retried.",
 		Buckets:   []float64{0, 1, 2, 3, 4, 5},
 	})
-	errCanceled = httpgrpc.Errorf(http.StatusInternalServerError, "context cancelled")
 )
 
 type retry struct {
@@ -46,7 +44,7 @@ func (r retry) Do(ctx context.Context, req Request) (Response, error) {
 	var lastErr error
 	for ; tries < r.maxRetries; tries++ {
 		if ctx.Err() != nil {
-			return nil, errCanceled
+			return nil, ctx.Err()
 		}
 		resp, err := r.next.Do(ctx, req)
 		if err == nil {

--- a/pkg/querier/queryrange/retry_test.go
+++ b/pkg/querier/queryrange/retry_test.go
@@ -78,7 +78,7 @@ func Test_RetryMiddlewareCancel(t *testing.T) {
 		}),
 	).Do(ctx, nil)
 	require.Equal(t, int32(0), try)
-	require.Equal(t, errCanceled, err)
+	require.Equal(t, ctx.Err(), err)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	_, err = NewRetryMiddleware(log.NewNopLogger(), 5).Wrap(
@@ -89,5 +89,5 @@ func Test_RetryMiddlewareCancel(t *testing.T) {
 		}),
 	).Do(ctx, nil)
 	require.Equal(t, int32(1), try)
-	require.Equal(t, errCanceled, err)
+	require.Equal(t, ctx.Err(), err)
 }

--- a/pkg/querier/queryrange/retry_test.go
+++ b/pkg/querier/queryrange/retry_test.go
@@ -78,7 +78,7 @@ func Test_RetryMiddlewareCancel(t *testing.T) {
 		}),
 	).Do(ctx, nil)
 	require.Equal(t, int32(0), try)
-	require.Equal(t, ctx.Err(), err)
+	require.Equal(t, errCanceled, err)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	_, err = NewRetryMiddleware(log.NewNopLogger(), 5).Wrap(
@@ -89,5 +89,5 @@ func Test_RetryMiddlewareCancel(t *testing.T) {
 		}),
 	).Do(ctx, nil)
 	require.Equal(t, int32(1), try)
-	require.Equal(t, ctx.Err(), err)
+	require.Equal(t, errCanceled, err)
 }

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
@@ -182,7 +183,7 @@ func (q roundTripper) Do(ctx context.Context, r Request) (Response, error) {
 	}
 
 	if err := user.InjectOrgIDIntoHTTPRequest(ctx, request); err != nil {
-		return nil, err
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 
 	response, err := q.next.RoundTrip(request)


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

There were some places where the frontend and middlewares were not using httpgrpc.Errorf which causes some 500 instead of 400.

I'm also wondering if the frontend should really send back a 500 in case of cancellation. Couldn't not find a status quo on this.