### PR TITLE
Fixed integration tests with a custom IMAGE_PREFIX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,8 +139,10 @@ jobs:
     - run:
         name: Integration Tests
         command: |
-          export CORTEX_IMAGE="quay.io/cortexproject/cortex:${CIRCLE_TAG:-$(./tools/image-tag)}"
+          export CORTEX_IMAGE_PREFIX="${IMAGE_PREFIX:-quay.io/cortexproject/}"
+          export CORTEX_IMAGE="${CORTEX_IMAGE_PREFIX}cortex:${CIRCLE_TAG:-$(./tools/image-tag)}"
           export CORTEX_INTEGRATION_DIR="/home/circleci/.go_workspace/src/github.com/cortexproject/cortex/integration"
+          echo "Running integration tests with image: $CORTEX_IMAGE"
           go test -timeout 300s -v -count=1 ./integration
 
   build:


### PR DESCRIPTION
**What this PR does**:
If a CircleCI setup customize the `IMAGE_PREFIX`, then integration tests fail. This PR fixes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
