### PR TITLE
Share goimports settings for VSCode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,11 @@ a piece of work is finished it should:
 
 Cortex projects uses `goimports` tool (`go get golang.org/x/tools/cmd/goimports` to install) to format the Go files, and sort imports. We use goimports with `-local github.com/cortexproject/cortex` parameter, to put Cortex internal imports into a separate group. We try to keep imports sorted into three groups: imports from standard library, imports of 3rd party packages and internal Cortex imports. Goimports will fix the order, but will keep existing newlines between imports in the groups. We try to avoid extra newlines like that.
 
+You're using an IDE you may find useful the following settings for the Cortex project:
+
+- [VSCode](https://cortexmetrics.io/docs/contributing/vscode-goimports-settings.json)
+
+
 ## Developer Certificates of Origin (DCOs)
 
 Before submitting your work in a pull request, make sure that *all* commits are signed off with a **Developer Certificate of Origin** (DCO). Here's an example:

--- a/docs/contributing/vscode-goimports-settings.json
+++ b/docs/contributing/vscode-goimports-settings.json
@@ -1,0 +1,18 @@
+{
+    "settings": {
+        "go.formatTool": "goimports",
+        "go.formatFlags": [
+            "-local",
+            "github.com/cortexproject/cortex"
+        ],
+        "go.languageServerExperimentalFeatures": {
+            "format": false
+        },
+        "[go]": {
+            "editor.codeActionsOnSave": {
+                "source.organizeImports": false
+            }
+        },
+        "editor.formatOnSave": true
+    }
+}


### PR DESCRIPTION
**What this PR does**:
Don't know what you think about this PR, but I've spent a good amount of time configuring VSCode to make it happy with the new `goimports` settings (because `goimports` clashes with `gopls` which is used for code intelligence), so I'm proposing to share the settings publicly.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
