### PR TITLE
e2e: Simplifying and making tests more reliable (by using structs vs handwritten names in string).

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -3,3 +3,7 @@
 ## Supported environment variables
 
 - `CORTEX_IMAGE`: Docker image used to run Cortex in integration tests (defaults to `quay.io/cortexproject/cortex:latest`)
+
+## Owners
+
+This package is used by other pojects than Cortex. When modifying please ask @pracucci @bwplotka for review.

--- a/integration/README.md
+++ b/integration/README.md
@@ -6,4 +6,4 @@
 
 ## Owners
 
-This package is used by other pojects than Cortex. When modifying please ask @pracucci @bwplotka for review.
+This package is used by other projects than Cortex. When modifying please ask @pracucci @bwplotka for review.

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -17,20 +17,21 @@ import (
 )
 
 const (
+	networkName = "e2e-cortex-test"
 	// If you change the image tag, remember to update it in the preloading done
 	// by CircleCI too (see .circleci/config.yml).
 	previousVersionImage = "quay.io/cortexproject/cortex:v0.6.0"
 )
 
 func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
-	s, err := e2e.NewScenario()
+	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()
 
 	// Start dependencies.
-	require.NoError(t, s.StartService(e2edb.NewDynamoDB()))
-	require.NoError(t, s.StartService(e2edb.NewConsul()))
-	require.NoError(t, s.WaitReady("consul", "dynamodb"))
+	dynamo := e2edb.NewDynamoDB()
+	consul := e2edb.NewConsul()
+	require.NoError(t, s.StartAndWaitReady(dynamo, consul))
 
 	// Start Cortex components (ingester running on previous version).
 	require.NoError(t, ioutil.WriteFile(
@@ -38,48 +39,49 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 		[]byte(cortexSchemaConfigYaml),
 		os.ModePerm),
 	)
-	require.NoError(t, s.StartService(e2ecortex.NewTableManager("table-manager", ChunksStorage, "")))
-	require.NoError(t, s.StartService(e2ecortex.NewIngester("ingester-1", ChunksStorage, previousVersionImage)))
-	require.NoError(t, s.StartService(e2ecortex.NewDistributor("distributor", ChunksStorage, "")))
-	require.NoError(t, s.WaitReady("distributor", "ingester-1", "table-manager"))
+	tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorage, previousVersionImage)
+	ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(networkName), ChunksStorage, "")
+	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(networkName), ChunksStorage, "")
+	require.NoError(t, s.StartAndWaitReady(distributor, ingester1, tableManager))
 
 	// Wait until the first table-manager sync has completed, so that we're
 	// sure the tables have been created.
-	require.NoError(t, s.Service("table-manager").WaitMetric("cortex_dynamo_sync_tables_seconds", 1))
+	require.NoError(t, tableManager.WaitMetric("cortex_dynamo_sync_tables_seconds", 1))
 
-	// Wait until the distributor has updated the ring.
-	require.NoError(t, s.Service("distributor").WaitMetric("cortex_ring_tokens_total", 512))
+	// Wait until both the distributor and querier have updated the ring.
+	require.NoError(t, distributor.WaitMetric("cortex_ring_tokens_total", 512))
 
 	// Push some series to Cortex.
 	now := time.Now()
 	series, expectedVector := generateSeries("series_1", now)
 
-	c, err := e2ecortex.NewClient(s.Endpoint("distributor", 80), "", "user-1")
+	c, err := e2ecortex.NewClient(distributor.Endpoint(80), "", "user-1")
 	require.NoError(t, err)
 
 	res, err := c.Push(series)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	// Start ingester-2 on new version, to ensure the transfer is backward compatible.
-	require.NoError(t, s.StartService(e2ecortex.NewIngester("ingester-2", mergeFlags(ChunksStorage, map[string]string{
+	ingester2 := e2ecortex.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(networkName), mergeFlags(ChunksStorage, map[string]string{
 		"-ingester.join-after": "10s",
-	}), "")))
+	}), "")
+	// Start ingester-2 on new version, to ensure the transfer is backward compatible.
+	require.NoError(t, s.Start(ingester2))
 
 	// Stop ingester-1. This function will return once the ingester-1 is successfully
 	// stopped, which means the transfer to ingester-2 is completed.
-	require.NoError(t, s.StopService("ingester-1"))
+	require.NoError(t, s.Stop(ingester1))
 
 	// Query the new ingester both with the old and the new querier.
 	for _, image := range []string{previousVersionImage, ""} {
-		require.NoError(t, s.StartService(e2ecortex.NewQuerier("querier", ChunksStorage, image)))
-		require.NoError(t, s.WaitReady("querier"))
+		querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(networkName), ChunksStorage, image)
+		require.NoError(t, s.StartAndWaitReady(querier))
 
 		// Wait until the querier has updated the ring.
-		require.NoError(t, s.Service("querier").WaitMetric("cortex_ring_tokens_total", 512))
+		require.NoError(t, querier.WaitMetric("cortex_ring_tokens_total", 512))
 
 		// Query the series
-		c, err := e2ecortex.NewClient(s.Endpoint("distributor", 80), s.Endpoint("querier", 80), "user-1")
+		c, err := e2ecortex.NewClient(distributor.Endpoint(80), querier.Endpoint(80), "user-1")
 		require.NoError(t, err)
 
 		result, err := c.Query("series_1", now)
@@ -88,7 +90,6 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 		assert.Equal(t, expectedVector, result.(model.Vector))
 
 		// Stop the querier, so that the test on the next image will work.
-		err = s.StopService("querier")
-		require.NoError(t, err)
+		require.NoError(t, s.Stop(querier))
 	}
 }

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -48,7 +48,7 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 	// sure the tables have been created.
 	require.NoError(t, tableManager.WaitMetric("cortex_dynamo_sync_tables_seconds", 1))
 
-	// Wait until both the distributor and querier have updated the ring.
+	// Wait until the distributor has updated the ring.
 	require.NoError(t, distributor.WaitMetric("cortex_ring_tokens_total", 512))
 
 	// Push some series to Cortex.

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -46,10 +46,10 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 
 	// Wait until the first table-manager sync has completed, so that we're
 	// sure the tables have been created.
-	require.NoError(t, tableManager.WaitMetric("cortex_dynamo_sync_tables_seconds", 1))
+	require.NoError(t, tableManager.WaitSumMetric("cortex_dynamo_sync_tables_seconds", 1))
 
 	// Wait until the distributor has updated the ring.
-	require.NoError(t, distributor.WaitMetric("cortex_ring_tokens_total", 512))
+	require.NoError(t, distributor.WaitSumMetric("cortex_ring_tokens_total", 512))
 
 	// Push some series to Cortex.
 	now := time.Now()
@@ -78,7 +78,7 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 		require.NoError(t, s.StartAndWaitReady(querier))
 
 		// Wait until the querier has updated the ring.
-		require.NoError(t, querier.WaitMetric("cortex_ring_tokens_total", 512))
+		require.NoError(t, querier.WaitSumMetric("cortex_ring_tokens_total", 512))
 
 		// Query the series
 		c, err := e2ecortex.NewClient(distributor.Endpoint(80), querier.Endpoint(80), "user-1")

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/cortexproject/cortex/integration/e2e"
@@ -33,12 +34,12 @@ var (
 		"-experimental.tsdb.s3.access-key-id":           e2edb.MinioAccessKey,
 		"-experimental.tsdb.s3.secret-access-key":       e2edb.MinioSecretKey,
 		"-experimental.tsdb.s3.bucket-name":             "cortex",
-		"-experimental.tsdb.s3.endpoint":                "minio:9000",
+		"-experimental.tsdb.s3.endpoint":                fmt.Sprintf("%s-minio-9000:9000", networkName),
 		"-experimental.tsdb.s3.insecure":                "true",
 	}
 
 	ChunksStorage = map[string]string{
-		"-dynamodb.url":                   "dynamodb://u:p@dynamodb.:8000",
+		"-dynamodb.url":                   fmt.Sprintf("dynamodb://u:p@%s-dynamodb.:8000", networkName),
 		"-dynamodb.poll-interval":         "1m",
 		"-config-yaml":                    filepath.Join(e2e.ContainerSharedDir, cortexSchemaConfigFile),
 		"-table-manager.retention-period": "168h",

--- a/integration/e2e/db/db.go
+++ b/integration/e2e/db/db.go
@@ -18,22 +18,23 @@ const (
 
 // NewMinio returns minio server, used as a local replacement for S3.
 func NewMinio(port int, bktName string) *e2e.HTTPService {
-	return e2e.NewHTTPService(
+	m := e2e.NewHTTPService(
 		fmt.Sprintf("minio-%v", port),
 		// If you change the image tag, remember to update it in the preloading done
 		// by CircleCI too (see .circleci/config.yml).
 		"minio/minio:RELEASE.2019-12-30T05-45-39Z",
-		map[string]string{
-			"MINIO_ACCESS_KEY": MinioAccessKey,
-			"MINIO_SECRET_KEY": MinioSecretKey,
-			"MINIO_BROWSER":    "off",
-			"ENABLE_HTTPS":     "0",
-		},
 		// Create the "cortex" bucket before starting minio
 		e2e.NewCommandWithoutEntrypoint("sh", "-c", fmt.Sprintf("mkdir -p /data/%s && minio server --address :%v --quiet /data", bktName, port)),
 		e2e.NewReadinessProbe(port, "/minio/health/ready", 200),
 		port,
 	)
+	m.SetEnvVars(map[string]string{
+		"MINIO_ACCESS_KEY": MinioAccessKey,
+		"MINIO_SECRET_KEY": MinioSecretKey,
+		"MINIO_BROWSER":    "off",
+		"ENABLE_HTTPS":     "0",
+	})
+	return m
 }
 
 func NewConsul() *e2e.HTTPService {
@@ -42,7 +43,6 @@ func NewConsul() *e2e.HTTPService {
 		// If you change the image tag, remember to update it in the preloading done
 		// by CircleCI too (see .circleci/config.yml).
 		"consul:0.9",
-		nil,
 		// Run consul in "dev" mode so that the initial leader election is immediate
 		e2e.NewCommand("agent", "-server", "-client=0.0.0.0", "-dev", "-log-level=err"),
 		nil,
@@ -76,7 +76,6 @@ func NewDynamoDB() *e2e.HTTPService {
 		// If you change the image tag, remember to update it in the preloading done
 		// by CircleCI too (see .circleci/config.yml).
 		"amazon/dynamodb-local:1.11.477",
-		nil,
 		e2e.NewCommand("-jar", "DynamoDBLocal.jar", "-inMemory", "-sharedDb"),
 		// DynamoDB doesn't have a readiness probe, so we check if the / works even if returns 400
 		e2e.NewReadinessProbe(8000, "/", 400),

--- a/integration/e2e/db/db.go
+++ b/integration/e2e/db/db.go
@@ -1,6 +1,7 @@
 package e2edb
 
 import (
+	"fmt"
 	"net/url"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -16,14 +17,12 @@ const (
 )
 
 // NewMinio returns minio server, used as a local replacement for S3.
-func NewMinio(bktName string) *e2e.Service {
-	return e2e.NewService(
-		"minio",
+func NewMinio(port int, bktName string) *e2e.HTTPService {
+	return e2e.NewHTTPService(
+		fmt.Sprintf("minio-%v", port),
 		// If you change the image tag, remember to update it in the preloading done
 		// by CircleCI too (see .circleci/config.yml).
 		"minio/minio:RELEASE.2019-12-30T05-45-39Z",
-		e2e.NetworkName,
-		[]int{9000},
 		map[string]string{
 			"MINIO_ACCESS_KEY": MinioAccessKey,
 			"MINIO_SECRET_KEY": MinioSecretKey,
@@ -31,23 +30,23 @@ func NewMinio(bktName string) *e2e.Service {
 			"ENABLE_HTTPS":     "0",
 		},
 		// Create the "cortex" bucket before starting minio
-		e2e.NewCommandWithoutEntrypoint("sh", "-c", "mkdir -p /data/"+bktName+" && minio server --quiet /data"),
-		e2e.NewReadinessProbe(9000, "/minio/health/ready", 200),
+		e2e.NewCommandWithoutEntrypoint("sh", "-c", fmt.Sprintf("mkdir -p /data/%s && minio server --address :%v --quiet /data", bktName, port)),
+		e2e.NewReadinessProbe(port, "/minio/health/ready", 200),
+		port,
 	)
 }
 
-func NewConsul() *e2e.Service {
-	return e2e.NewService(
+func NewConsul() *e2e.HTTPService {
+	return e2e.NewHTTPService(
 		"consul",
 		// If you change the image tag, remember to update it in the preloading done
 		// by CircleCI too (see .circleci/config.yml).
 		"consul:0.9",
-		e2e.NetworkName,
-		[]int{},
 		nil,
 		// Run consul in "dev" mode so that the initial leader election is immediate
 		e2e.NewCommand("agent", "-server", "-client=0.0.0.0", "-dev", "-log-level=err"),
 		nil,
+		8500,
 	)
 }
 
@@ -71,17 +70,16 @@ func NewDynamoClient(endpoint string) (*dynamodb.DynamoDB, error) {
 	return dynamodb.New(dynamoSession), nil
 }
 
-func NewDynamoDB() *e2e.Service {
-	return e2e.NewService(
+func NewDynamoDB() *e2e.HTTPService {
+	return e2e.NewHTTPService(
 		"dynamodb",
 		// If you change the image tag, remember to update it in the preloading done
 		// by CircleCI too (see .circleci/config.yml).
 		"amazon/dynamodb-local:1.11.477",
-		e2e.NetworkName,
-		[]int{8000},
 		nil,
 		e2e.NewCommand("-jar", "DynamoDBLocal.jar", "-inMemory", "-sharedDb"),
 		// DynamoDB doesn't have a readiness probe, so we check if the / works even if returns 400
 		e2e.NewReadinessProbe(8000, "/", 400),
+		8000,
 	)
 }

--- a/integration/e2e/scenario.go
+++ b/integration/e2e/scenario.go
@@ -121,7 +121,7 @@ func (s *Scenario) Stop(services ...Service) error {
 	return nil
 }
 
-// TODO: If service is not ready, test failed or service failed unexpectedly, we should show docker logs.
+// TODO: If service is not ready, test failed or service failed unexpectedly.
 func (s *Scenario) WaitReady(services ...Service) error {
 	for _, service := range services {
 		if !s.isRegistered(service.Name()) {

--- a/integration/e2e/scenario.go
+++ b/integration/e2e/scenario.go
@@ -121,7 +121,6 @@ func (s *Scenario) Stop(services ...Service) error {
 	return nil
 }
 
-// TODO: If service is not ready, test failed or service failed unexpectedly.
 func (s *Scenario) WaitReady(services ...Service) error {
 	for _, service := range services {
 		if !s.isRegistered(service.Name()) {

--- a/integration/e2e/scenario.go
+++ b/integration/e2e/scenario.go
@@ -11,20 +11,28 @@ import (
 )
 
 const (
-	NetworkName        = "e2e-test"
 	ContainerSharedDir = "/shared"
 )
 
-type Scenario struct {
-	services []*Service
+type Service interface {
+	Name() string
+	Start(networkName, dir string) error
+	WaitReady() error
 
-	sharedDir string
+	// It should be ok to Stop and Kill more than once, with next invokes being noop.
+	Kill(networkName string) error
+	Stop(networkName string) error
 }
 
-func NewScenario() (*Scenario, error) {
-	s := &Scenario{
-		services: []*Service{},
-	}
+type Scenario struct {
+	services []Service
+
+	networkName string
+	sharedDir   string
+}
+
+func NewScenario(networkName string) (*Scenario, error) {
+	s := &Scenario{networkName: networkName}
 
 	tmpDir, err := ioutil.TempDir("", "e2e_integration_test")
 	if err != nil {
@@ -37,14 +45,14 @@ func NewScenario() (*Scenario, error) {
 	}
 
 	// Force a shutdown in order to cleanup from a spurious situation in case
-	// the previous tests run didn't cleanup correctly
+	// the previous tests run didn't cleanup correctly.
 	s.shutdown()
 
-	// Setup the docker network
-	if out, err := RunCommandAndGetOutput("docker", "network", "create", NetworkName); err != nil {
+	// Setup the docker network.
+	if out, err := RunCommandAndGetOutput("docker", "network", "create", networkName); err != nil {
 		fmt.Println(string(out))
 		s.clean()
-		return nil, errors.Wrapf(err, "create docker network '%s'", NetworkName)
+		return nil, errors.Wrapf(err, "create docker network '%s'", networkName)
 	}
 
 	return s, nil
@@ -55,80 +63,74 @@ func (s *Scenario) SharedDir() string {
 	return s.sharedDir
 }
 
-func (s *Scenario) Service(name string) *Service {
+func (s *Scenario) isRegistered(name string) bool {
 	for _, service := range s.services {
-		if service.name == name {
-			return service
+		if service.Name() == name {
+			return true
 		}
 	}
-
-	return nil
+	return false
 }
 
-func (s *Scenario) Endpoint(name string, port int) string {
-	service := s.Service(name)
-	if service == nil {
-		return ""
-	}
-
-	return service.Endpoint(port)
-}
-
-func (s *Scenario) StartService(service *Service) error {
-	// TODO(bwplotka): Some basic logger would be nice.
-	fmt.Println("Starting", service.name)
-
-	// Ensure another service with the same name doesn't exist
-	if s.Service(service.name) != nil {
-		return fmt.Errorf("another service with the same name '%s' has already been started", service.name)
-	}
-
-	// Start the service
-	if err := service.start(s.SharedDir()); err != nil {
+func (s *Scenario) StartAndWaitReady(services ...Service) error {
+	if err := s.Start(services...); err != nil {
 		return err
 	}
+	return s.WaitReady(services...)
+}
 
-	// Add to the list of services
-	s.services = append(s.services, service)
+func (s *Scenario) Start(services ...Service) error {
+	for _, service := range services {
+		// TODO(bwplotka): Some basic logger would be nice.
+		fmt.Println("Starting", service.Name())
+
+		// Ensure another service with the same name doesn't exist.
+		if s.isRegistered(service.Name()) {
+			return fmt.Errorf("another service with the same name '%s' has already been started", service.Name())
+		}
+
+		// Start the service.
+		if err := service.Start(s.networkName, s.SharedDir()); err != nil {
+			return err
+		}
+
+		// Add to the list of services.
+		s.services = append(s.services, service)
+	}
+
 	return nil
 }
 
-func (s *Scenario) StopService(name string) error {
-	service := s.Service(name)
-	if service == nil {
-		return fmt.Errorf("unable to stop service %s because does not exist", name)
-	}
+func (s *Scenario) Stop(services ...Service) error {
+	for _, service := range services {
+		if !s.isRegistered(service.Name()) {
+			return fmt.Errorf("unable to stop service %s because it does not exist", service.Name())
+		}
+		if err := service.Stop(s.networkName); err != nil {
+			return err
+		}
 
-	if err := service.stop(); err != nil {
-		return err
-	}
-
-	// Remove the service from the list of services
-	for i, entry := range s.services {
-		if entry.name == name {
-			s.services = append(s.services[:i], s.services[i+1:]...)
-			break
+		// Remove the service from the list of services.
+		for i, entry := range s.services {
+			if entry.Name() == service.Name() {
+				s.services = append(s.services[:i], s.services[i+1:]...)
+				break
+			}
 		}
 	}
-
 	return nil
 }
 
-// WaitReady waits until one or more services are ready. A service
-// is ready when its readiness probe succeed. If a service has no
-// readiness probe, it's considered ready without doing any check.
-func (s *Scenario) WaitReady(services ...string) error {
-	for _, name := range services {
-		service := s.Service(name)
-		if service == nil {
-			return fmt.Errorf("unable to wait for service '%s' ready because the service does not exist", name)
+// TODO: If service is not ready, test failed or service failed unexpectedly, we should show docker logs.
+func (s *Scenario) WaitReady(services ...Service) error {
+	for _, service := range services {
+		if !s.isRegistered(service.Name()) {
+			return fmt.Errorf("unable to wait for service %s because it does not exist", service.Name())
 		}
-
 		if err := service.WaitReady(); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
@@ -136,7 +138,6 @@ func (s *Scenario) Close() {
 	if s == nil {
 		return
 	}
-
 	s.shutdown()
 	s.clean()
 }
@@ -149,21 +150,21 @@ func (s *Scenario) clean() {
 }
 
 func (s *Scenario) shutdown() {
-	// Kill the services in the opposite order
+	// Kill the services in the opposite order.
 	for i := len(s.services) - 1; i >= 0; i-- {
-		if err := s.services[i].kill(); err != nil {
-			fmt.Println("Unable to kill service", s.services[i].name, ":", err.Error())
+		if err := s.services[i].Kill(s.networkName); err != nil {
+			fmt.Println("Unable to kill service", s.services[i].Name(), ":", err.Error())
 		}
 	}
 
-	// Ensure there are no leftover containers
+	// Ensure there are no leftover containers.
 	if out, err := RunCommandAndGetOutput(
 		"docker",
 		"ps",
 		"-a",
 		"--quiet",
 		"--filter",
-		fmt.Sprintf("network=%s", NetworkName),
+		fmt.Sprintf("network=%s", s.networkName),
 	); err == nil {
 		for _, containerID := range strings.Split(string(out), "\n") {
 			containerID = strings.TrimSpace(containerID)
@@ -184,19 +185,19 @@ func (s *Scenario) shutdown() {
 	// Teardown the docker network. In case the network does not exists (ie. this function
 	// is called during the setup of the scenario) we skip the removal in order to not log
 	// an error which may be misleading.
-	if ok, err := existDockerNetwork(); ok || err != nil {
-		if out, err := RunCommandAndGetOutput("docker", "network", "rm", NetworkName); err != nil {
+	if ok, err := existDockerNetwork(s.networkName); ok || err != nil {
+		if out, err := RunCommandAndGetOutput("docker", "network", "rm", s.networkName); err != nil {
 			fmt.Println(string(out))
-			fmt.Println("Unable to remove docker network", NetworkName, ":", err.Error())
+			fmt.Println("Unable to remove docker network", s.networkName, ":", err.Error())
 		}
 	}
 }
 
-func existDockerNetwork() (bool, error) {
-	out, err := RunCommandAndGetOutput("docker", "network", "ls", "--quiet", "--filter", fmt.Sprintf("name=%s", NetworkName))
+func existDockerNetwork(networkName string) (bool, error) {
+	out, err := RunCommandAndGetOutput("docker", "network", "ls", "--quiet", "--filter", fmt.Sprintf("name=%s", networkName))
 	if err != nil {
 		fmt.Println(string(out))
-		fmt.Println("Unable to check if docker network", NetworkName, "exists:", err.Error())
+		fmt.Println("Unable to check if docker network", networkName, "exists:", err.Error())
 	}
 
 	return strings.TrimSpace(string(out)) != "", nil

--- a/integration/e2e/scenario_test.go
+++ b/integration/e2e/scenario_test.go
@@ -1,0 +1,145 @@
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/prometheus/util/testutil"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/objstore/s3"
+	"gopkg.in/yaml.v2"
+
+	"github.com/cortexproject/cortex/integration/e2e"
+	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
+)
+
+const bktName = "cheesecake"
+
+func spinup(t *testing.T, networkName string) (*e2e.Scenario, *e2e.HTTPService, *e2e.HTTPService) {
+	s, err := e2e.NewScenario(networkName)
+	testutil.Ok(t, err)
+
+	m1 := e2edb.NewMinio(9000, bktName)
+	m2 := e2edb.NewMinio(9001, bktName)
+
+	closePlease := true
+	defer func() {
+		if closePlease {
+			// You're welcome.
+			s.Close()
+		}
+	}()
+	require.NoError(t, s.StartAndWaitReady(m1, m2))
+	require.Error(t, s.Start(m1))
+	require.Error(t, s.Start(e2edb.NewMinio(9000, "cheescake")))
+
+	closePlease = false
+	return s, m1, m2
+}
+
+func testMinioWorking(t *testing.T, m *e2e.HTTPService) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	b, err := yaml.Marshal(s3.Config{
+		Endpoint:  m.HTTPEndpoint(),
+		Bucket:    bktName,
+		AccessKey: e2edb.MinioAccessKey,
+		SecretKey: e2edb.MinioSecretKey,
+		Insecure:  true, // WARNING: Our secret cheesecake recipes might leak.
+	})
+	require.NoError(t, err)
+
+	bkt, err := s3.NewBucket(log.NewNopLogger(), b, "test")
+	require.NoError(t, err)
+
+	require.NoError(t, bkt.Upload(ctx, "recipe", bytes.NewReader([]byte("Just go to Pastry Shop and buy."))))
+	require.NoError(t, bkt.Upload(ctx, "mom/recipe", bytes.NewReader([]byte("https://www.bbcgoodfood.com/recipes/strawberry-cheesecake-4-easy-steps"))))
+
+	r, err := bkt.Get(ctx, "recipe")
+	require.NoError(t, err)
+	b, err = ioutil.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, "Just go to Pastry Shop and buy.", string(b))
+
+	r, err = bkt.Get(ctx, "mom/recipe")
+	require.NoError(t, err)
+	b, err = ioutil.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, "https://www.bbcgoodfood.com/recipes/strawberry-cheesecake-4-easy-steps", string(b))
+}
+
+func TestScenario(t *testing.T) {
+	t.Parallel()
+
+	s, m1, m2 := spinup(t, "e2e-scenario-test")
+	defer s.Close()
+
+	t.Run("minio is working", func(t *testing.T) {
+		testMinioWorking(t, m1)
+		testMinioWorking(t, m2)
+	})
+
+	t.Run("concurrent nested scenario 1 is working just fine as well", func(t *testing.T) {
+		t.Parallel()
+
+		s, m1, m2 := spinup(t, "e2e-scenario-test1")
+		defer s.Close()
+
+		testMinioWorking(t, m1)
+		testMinioWorking(t, m2)
+	})
+	t.Run("concurrent nested scenario 2 is working just fine as well", func(t *testing.T) {
+		t.Parallel()
+
+		s, m1, m2 := spinup(t, "e2e-scenario-test2")
+		defer s.Close()
+
+		testMinioWorking(t, m1)
+		testMinioWorking(t, m2)
+	})
+
+	require.NoError(t, s.Stop(m1))
+
+	// Expect m1 not working.
+	b, err := yaml.Marshal(s3.Config{
+		Endpoint:  m1.Name(),
+		Bucket:    "cheescake",
+		AccessKey: e2edb.MinioAccessKey,
+		SecretKey: e2edb.MinioSecretKey,
+	})
+	require.NoError(t, err)
+	bkt, err := s3.NewBucket(log.NewNopLogger(), b, "test")
+	require.NoError(t, err)
+
+	_, err = bkt.Get(context.Background(), "recipe")
+	require.Error(t, err)
+
+	testMinioWorking(t, m2)
+
+	require.Error(t, s.Stop(m1))
+	// Should be noop.
+	require.NoError(t, m1.Stop("e2e-scenario-test"))
+	// I can run closes as many times I want.
+	s.Close()
+	s.Close()
+	s.Close()
+
+	// Expect m2 not working.
+	b, err = yaml.Marshal(s3.Config{
+		Endpoint:  m2.Name(),
+		Bucket:    "cheescake",
+		AccessKey: e2edb.MinioAccessKey,
+		SecretKey: e2edb.MinioSecretKey,
+	})
+	require.NoError(t, err)
+	bkt, err = s3.NewBucket(log.NewNopLogger(), b, "test")
+	require.NoError(t, err)
+
+	_, err = bkt.Get(context.Background(), "recipe")
+	require.Error(t, err)
+}

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -246,7 +246,7 @@ func (s *ConcreteService) buildDockerRunArgs(networkName, sharedDir string) []st
 	args := []string{"run", "--rm", "--net=" + networkName, "--name=" + networkName + "-" + s.name, "--hostname=" + s.name}
 
 	// Mount the shared/ directory into the container
-	args = append(args, "-v", fmt.Sprintf("%s:%s", sharedDir, ContainerSharedDir))
+	args = append(args, "-v", fmt.Sprintf("%s:%s:Z", sharedDir, ContainerSharedDir))
 
 	// Environment variables
 	for name, value := range s.env {

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -98,10 +98,6 @@ func (s *ConcreteService) Start(networkName, sharedDir string) (err error) {
 
 	// Get the dynamic local ports mapped to the container.
 	for _, containerPort := range s.networkPorts {
-		if containerPort == 0 {
-			continue
-		}
-
 		var out []byte
 		var localPort int
 

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/expfmt"
+	"github.com/thanos-io/thanos/pkg/runutil"
 
 	"github.com/cortexproject/cortex/pkg/util"
 )
@@ -22,10 +23,11 @@ var (
 	dockerPortPattern = regexp.MustCompile(`^.*:(\d+)$`)
 )
 
-type Service struct {
+// ConcreteService represents microservice with optional ports which will be discoverable from docker
+// with <name>:<port>. For connecting from test, use `Endpoint` method.
+type ConcreteService struct {
 	name         string
 	image        string
-	networkName  string
 	networkPorts []int
 	env          map[string]string
 	command      *Command
@@ -36,41 +38,42 @@ type Service struct {
 
 	// Generic retry backoff.
 	retryBackoff *util.Backoff
+
+	stopped bool
 }
 
-func NewService(
+func NewConcreteService(
 	name string,
 	image string,
-	networkName string,
-	networkPorts []int,
 	env map[string]string,
 	command *Command,
 	readiness *ReadinessProbe,
-) *Service {
-	return &Service{
+	networkPorts ...int,
+) *ConcreteService {
+	return &ConcreteService{
 		name:                         name,
 		image:                        image,
-		networkName:                  networkName,
 		networkPorts:                 networkPorts,
 		env:                          env,
 		command:                      command,
 		networkPortsContainerToLocal: map[int]int{},
 		readiness:                    readiness,
 		retryBackoff: util.NewBackoff(context.Background(), util.BackoffConfig{
-			MinBackoff: 100 * time.Millisecond,
-			MaxBackoff: 200 * time.Millisecond,
-			MaxRetries: 100, // Sometimes the CI is slow
+			MinBackoff: 300 * time.Millisecond,
+			MaxBackoff: 600 * time.Millisecond,
+			MaxRetries: 50, // Sometimes the CI is slow ¯\_(ツ)_/¯
 		}),
+		stopped: true,
 	}
 }
 
-func (s *Service) Name() string { return s.name }
+func (s *ConcreteService) Name() string { return s.name }
 
-func (s *Service) SetBackoff(cfg util.BackoffConfig) {
+func (s *ConcreteService) SetBackoff(cfg util.BackoffConfig) {
 	s.retryBackoff = util.NewBackoff(context.Background(), cfg)
 }
 
-func (s *Service) start(sharedDir string) (err error) {
+func (s *ConcreteService) Start(networkName, sharedDir string) (err error) {
 	// In case of any error, if the container was already created, we
 	// have to cleanup removing it. We ignore the error of the "docker rm"
 	// because we don't know if the container was created or not.
@@ -80,40 +83,46 @@ func (s *Service) start(sharedDir string) (err error) {
 		}
 	}()
 
-	cmd := exec.Command("docker", s.buildDockerRunArgs(sharedDir)...)
+	cmd := exec.Command("docker", s.buildDockerRunArgs(networkName, sharedDir)...)
 	cmd.Stdout = &LinePrefixWriter{prefix: s.name + ": ", wrapped: os.Stdout}
 	cmd.Stderr = &LinePrefixWriter{prefix: s.name + ": ", wrapped: os.Stderr}
 	if err = cmd.Start(); err != nil {
 		return err
 	}
+	s.stopped = false
 
-	// Wait until the container has been started
-	if err = s.WaitStarted(); err != nil {
+	// Wait until the container has been started.
+	if err = s.WaitStarted(networkName); err != nil {
 		return err
 	}
 
-	// Get the dynamic local ports mapped to the container
+	// Get the dynamic local ports mapped to the container.
 	for _, containerPort := range s.networkPorts {
+		if containerPort == 0 {
+			continue
+		}
+
 		var out []byte
 		var localPort int
 
-		out, err = RunCommandAndGetOutput("docker", "port", s.name, strconv.Itoa(containerPort))
+		out, err = RunCommandAndGetOutput("docker", "port", s.containerName(networkName), strconv.Itoa(containerPort))
 		if err != nil {
-			err = errors.Wrapf(err, "unable to get mapping for port %d", containerPort)
-			return err
+			// Catch init errors.
+			if werr := s.WaitStarted(networkName); werr != nil {
+				return errors.Wrapf(werr, "failed to get mapping for port as container %s exited: %v", s.containerName(networkName), err)
+			}
+			return errors.Wrapf(err, "unable to get mapping for port %d; service: %s", containerPort, s.name)
 		}
 
 		stdout := strings.TrimSpace(string(out))
 		matches := dockerPortPattern.FindStringSubmatch(stdout)
 		if len(matches) != 2 {
-			err = fmt.Errorf("unable to get mapping for port %d (output: %s)", containerPort, stdout)
-			return err
+			return fmt.Errorf("unable to get mapping for port %d (output: %s); service: %s", containerPort, stdout, s.name)
 		}
 
 		localPort, err = strconv.Atoi(matches[1])
 		if err != nil {
-			err = errors.Wrapf(err, "unable to get mapping for port %d", containerPort)
-			return err
+			return errors.Wrapf(err, "unable to get mapping for port %d; service: %s", containerPort, s.name)
 		}
 
 		s.networkPortsContainerToLocal[containerPort] = localPort
@@ -122,30 +131,44 @@ func (s *Service) start(sharedDir string) (err error) {
 	return nil
 }
 
-func (s *Service) stop() error {
+func (s *ConcreteService) Stop(networkName string) error {
+	if s.stopped {
+		return nil
+	}
+
 	fmt.Println("Stopping", s.name)
 
-	if out, err := RunCommandAndGetOutput("docker", "stop", "--time=30", s.name); err != nil {
+	if out, err := RunCommandAndGetOutput("docker", "stop", "--time=30", s.containerName(networkName)); err != nil {
 		fmt.Println(string(out))
 		return err
 	}
+	s.stopped = true
 
 	return nil
 }
 
-func (s *Service) kill() error {
+func (s *ConcreteService) Kill(networkName string) error {
+	if s.stopped {
+		return nil
+	}
+
 	fmt.Println("Killing", s.name)
 
-	if out, err := RunCommandAndGetOutput("docker", "stop", "--time=0", s.name); err != nil {
+	if out, err := RunCommandAndGetOutput("docker", "stop", "--time=0", s.containerName(networkName)); err != nil {
 		fmt.Println(string(out))
 		return err
 	}
+	s.stopped = true
 
 	return nil
 }
 
-func (s *Service) Endpoint(port int) string {
-	// Map the container port to the local port
+func (s *ConcreteService) Endpoint(port int) string {
+	if s.stopped {
+		return "stopped"
+	}
+
+	// Map the container port to the local port.
 	localPort, ok := s.networkPortsContainerToLocal[port]
 	if !ok {
 		return ""
@@ -155,119 +178,72 @@ func (s *Service) Endpoint(port int) string {
 	return fmt.Sprintf("127.0.0.1:%d", localPort)
 }
 
-func (s *Service) Ready() (bool, error) {
-	// Ensure the service has a readiness probe configure
+func (s *ConcreteService) NetworkEndpoint(networkName string, port int) string {
+	if s.stopped {
+		return "stopped"
+	}
+
+	return fmt.Sprintf("%s:%d", s.containerName(networkName), port)
+}
+
+func (s *ConcreteService) Ready() error {
+	if s.stopped {
+		return fmt.Errorf("service %s stopped", s.Name())
+	}
+
+	// Ensure the service has a readiness probe configure.
 	if s.readiness == nil {
-		return true, nil
+		return nil
 	}
 
 	// Map the container port to the local port
 	localPort, ok := s.networkPortsContainerToLocal[s.readiness.port]
 	if !ok {
-		return false, fmt.Errorf("unknown port %d configured in the readiness probe", s.readiness.port)
+		return fmt.Errorf("unknown port %d configured in the readiness probe", s.readiness.port)
 	}
 
-	return s.readiness.Ready(localPort), nil
+	return s.readiness.Ready(localPort)
 }
 
-func (s *Service) Metrics(port int) (string, error) {
-	// Map the container port to the local port
-	localPort, ok := s.networkPortsContainerToLocal[port]
-	if !ok {
-		return "", fmt.Errorf("unknown port %d", port)
-	}
-
-	// Fetch metrics
-	res, err := GetRequest(fmt.Sprintf("http://localhost:%d/metrics", localPort))
-	if err != nil {
-		return "", err
-	}
-
-	// Check the status code
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return "", fmt.Errorf("unexpected status code %d while fetching metrics", res.StatusCode)
-	}
-
-	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
-
-	return string(body), err
+func (s *ConcreteService) containerName(networkName string) string {
+	return fmt.Sprintf("%s-%s", networkName, s.name)
 }
 
-func (s *Service) WaitStarted() error {
+func (s *ConcreteService) WaitStarted(networkName string) (err error) {
+	if s.stopped {
+		return fmt.Errorf("service %s stopped", s.Name())
+	}
+
 	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
-		if err := exec.Command("docker", "inspect", s.name).Run(); err == nil {
+		err = exec.Command("docker", "inspect", s.containerName(networkName)).Run()
+		if err == nil {
+			return nil
+		}
+		s.retryBackoff.Wait()
+	}
+
+	return fmt.Errorf("docker container %s failed to start: %w", s.name, err)
+}
+
+func (s *ConcreteService) WaitReady() (err error) {
+	if s.stopped {
+		return fmt.Errorf("service %s stopped", s.Name())
+	}
+
+	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
+		err = s.Ready()
+		if err == nil {
 			return nil
 		}
 
 		s.retryBackoff.Wait()
 	}
 
-	return fmt.Errorf("docker container %s failed to start", s.name)
+	return fmt.Errorf("the service %s is not ready; err: %v", s.name, err)
 }
 
-func (s *Service) WaitReady() error {
-	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
-		ready, err := s.Ready()
-		if ready {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-
-		s.retryBackoff.Wait()
-	}
-
-	return fmt.Errorf("the service %s is not ready", s.name)
-}
-
-func (s *Service) WaitMetric(metric string, value float64) error {
-	lastFoundValue := 0.0
-
-	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
-		metrics, err := s.Metrics(80)
-		if err != nil {
-			return err
-		}
-
-		var tp expfmt.TextParser
-		families, err := tp.TextToMetricFamilies(strings.NewReader(metrics))
-		if err != nil {
-			return err
-		}
-
-		// Check if the metric is exported
-		mf, ok := families[metric]
-		if ok {
-			for _, m := range mf.Metric {
-				if m.GetGauge() != nil {
-					lastFoundValue = m.GetGauge().GetValue()
-					if lastFoundValue == value {
-						return nil
-					}
-				} else if m.GetCounter() != nil {
-					lastFoundValue = m.GetCounter().GetValue()
-					if lastFoundValue == value {
-						return nil
-					}
-				} else if m.GetHistogram() != nil {
-					lastFoundValue = float64(m.GetHistogram().GetSampleCount())
-					if lastFoundValue == value {
-						return nil
-					}
-				}
-			}
-		}
-
-		s.retryBackoff.Wait()
-	}
-
-	return fmt.Errorf("unable to find a metric %s with value %v. Last value found: %v", metric, value, lastFoundValue)
-}
-
-func (s *Service) buildDockerRunArgs(sharedDir string) []string {
-	args := []string{"run", "--rm", "--net=" + s.networkName, "--name=" + s.name, "--hostname=" + s.name}
+func (s *ConcreteService) buildDockerRunArgs(networkName, sharedDir string) []string {
+	args := []string{"run", "--rm", "--net=" + networkName, "--name=" + networkName + "-" + s.name, "--hostname=" + s.name}
 
 	// Mount the shared/ directory into the container
 	args = append(args, "-v", fmt.Sprintf("%s:%s", sharedDir, ContainerSharedDir))
@@ -328,15 +304,19 @@ func NewReadinessProbe(port int, path string, expectedStatus int) *ReadinessProb
 	}
 }
 
-func (p *ReadinessProbe) Ready(localPort int) bool {
+func (p *ReadinessProbe) Ready(localPort int) (err error) {
 	res, err := GetRequest(fmt.Sprintf("http://localhost:%d%s", localPort, p.path))
 	if err != nil {
-		return false
+		return err
 	}
 
-	res.Body.Close()
+	defer runutil.ExhaustCloseWithErrCapture(&err, res.Body, "response readiness")
 
-	return res.StatusCode == p.expectedStatus
+	if res.StatusCode == p.expectedStatus {
+		return nil
+	}
+
+	return fmt.Errorf("got no expected status code: %v, expected: %v", res.StatusCode, p.expectedStatus)
 }
 
 type LinePrefixWriter struct {
@@ -360,4 +340,100 @@ func (w *LinePrefixWriter) Write(p []byte) (n int, err error) {
 	}
 
 	return len(p), nil
+}
+
+// HTTPService represents opinionated microservice with at least HTTP port that as mandatory requirement,
+// serves metrics.
+type HTTPService struct {
+	*ConcreteService
+
+	httpPort int
+}
+
+func NewHTTPService(
+	name string,
+	image string,
+	env map[string]string,
+	command *Command,
+	readiness *ReadinessProbe,
+	httpPort int,
+	otherPorts ...int,
+) *HTTPService {
+	return &HTTPService{
+		ConcreteService: NewConcreteService(name, image, env, command, readiness, append(otherPorts, httpPort)...),
+		httpPort:        httpPort,
+	}
+}
+
+func (s *HTTPService) metrics() (_ string, err error) {
+	// Map the container port to the local port
+	localPort := s.networkPortsContainerToLocal[s.httpPort]
+
+	// Fetch metrics.
+	res, err := GetRequest(fmt.Sprintf("http://localhost:%d/metrics", localPort))
+	if err != nil {
+		return "", err
+	}
+
+	// Check the status code.
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return "", fmt.Errorf("unexpected status code %d while fetching metrics", res.StatusCode)
+	}
+
+	defer runutil.ExhaustCloseWithErrCapture(&err, res.Body, "metrics response")
+	body, err := ioutil.ReadAll(res.Body)
+
+	return string(body), err
+}
+
+func (s *HTTPService) HTTPEndpoint() string {
+	return s.Endpoint(s.httpPort)
+}
+
+func (s *HTTPService) NetworkHTTPEndpoint(networkName string) string {
+	return s.NetworkEndpoint(networkName, s.httpPort)
+}
+
+func (s *HTTPService) WaitMetric(metric string, value float64) error {
+	lastFoundValue := 0.0
+
+	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
+		metrics, err := s.metrics()
+		if err != nil {
+			return err
+		}
+
+		var tp expfmt.TextParser
+		families, err := tp.TextToMetricFamilies(strings.NewReader(metrics))
+		if err != nil {
+			return err
+		}
+
+		// Check if the metric is exported
+		mf, ok := families[metric]
+		if ok {
+			for _, m := range mf.Metric {
+				if m.GetGauge() != nil {
+					lastFoundValue = m.GetGauge().GetValue()
+					if lastFoundValue == value {
+						return nil
+					}
+				} else if m.GetCounter() != nil {
+					lastFoundValue = m.GetCounter().GetValue()
+					if lastFoundValue == value {
+						return nil
+					}
+				} else if m.GetHistogram() != nil {
+					lastFoundValue = float64(m.GetHistogram().GetSampleCount())
+					if lastFoundValue == value {
+						return nil
+					}
+				}
+			}
+		}
+
+		s.retryBackoff.Wait()
+	}
+
+	return fmt.Errorf("unable to find a metric %s with value %v. Last value found: %v", metric, value, lastFoundValue)
 }

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -184,10 +184,6 @@ func (s *ConcreteService) Endpoint(port int) string {
 }
 
 func (s *ConcreteService) NetworkEndpoint(networkName string, port int) string {
-	if s.stopped {
-		return "stopped"
-	}
-
 	return fmt.Sprintf("%s:%d", s.containerName(networkName), port)
 }
 

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -129,10 +129,9 @@ func (s *ConcreteService) Start(networkName, sharedDir string) (err error) {
 		if err != nil {
 			return errors.Wrapf(err, "unable to get mapping for port %d; service: %s", containerPort, s.name)
 		}
-
 		s.networkPortsContainerToLocal[containerPort] = localPort
 	}
-
+	fmt.Println("Ports for container:", s.containerName(networkName), "Mapping:", s.networkPortsContainerToLocal)
 	return nil
 }
 

--- a/integration/e2e/service_test.go
+++ b/integration/e2e/service_test.go
@@ -1,0 +1,141 @@
+package e2e
+
+import (
+	"fmt"
+	"math"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+// freePort returns port that is free now.
+func freePort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	return l.Addr().(*net.TCPAddr).Port, l.Close()
+}
+
+func TestWaitMetric(t *testing.T) {
+	p, err := freePort()
+	require.NoError(t, err)
+
+	srv := &http.Server{
+		Addr: net.JoinHostPort("localhost", fmt.Sprintf("%v", p)),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`
+# HELP metric_c cheescake
+# TYPE metric_c GAUGE
+metric_c 20
+# HELP metric_a cheescake
+# TYPE metric_a GAUGE
+metric_a 1
+metric_a{first="value1"} 10
+metric_a{first="value1", something="x"} 4
+metric_a{first="value1", something2="a"} 203
+metric_a{first="value2"} 2
+metric_a{second="value1"} 1
+# HELP metric_b cheescake
+# TYPE metric_b GAUGE
+metric_b 1000
+`))
+		}),
+	}
+	defer srv.Close()
+
+	go func() {
+		srv.ListenAndServe()
+	}()
+
+	s := &HTTPService{
+		httpPort: 0,
+		ConcreteService: &ConcreteService{
+			networkPortsContainerToLocal: map[int]int{
+				0: p,
+			},
+		},
+	}
+
+	s.SetBackoff(util.BackoffConfig{
+		MinBackoff: 300 * time.Millisecond,
+		MaxBackoff: 600 * time.Millisecond,
+		MaxRetries: 50,
+	})
+	require.NoError(t, s.WaitSumMetric("metric_a", 221))
+
+	// No retry.
+	s.SetBackoff(util.BackoffConfig{
+		MinBackoff: 0,
+		MaxBackoff: 0,
+		MaxRetries: 1,
+	})
+	require.Error(t, s.WaitSumMetric("metric_a", 16))
+}
+
+func TestWaitMetric_Nan(t *testing.T) {
+	p, err := freePort()
+	require.NoError(t, err)
+
+	srv := &http.Server{
+		Addr: net.JoinHostPort("localhost", fmt.Sprintf("%v", p)),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`
+# HELP metric_c cheescake
+# TYPE metric_c GAUGE
+metric_c 20
+# HELP metric_a cheescake
+# TYPE metric_a GAUGE
+metric_a 1
+metric_a{first="value1"} 10
+metric_a{first="value1", something="x"} 4
+metric_a{first="value1", something2="a"} 203
+metric_a{first="value1", something3="b"} Nan
+metric_a{first="value2"} 2
+metric_a{second="value1"} 1
+# HELP metric_b cheescake
+# TYPE metric_b GAUGE
+metric_b 1000
+`))
+		}),
+	}
+	defer srv.Close()
+
+	go func() {
+		srv.ListenAndServe()
+	}()
+
+	s := &HTTPService{
+		httpPort: 0,
+		ConcreteService: &ConcreteService{
+			networkPortsContainerToLocal: map[int]int{
+				0: p,
+			},
+		},
+	}
+
+	s.SetBackoff(util.BackoffConfig{
+		MinBackoff: 300 * time.Millisecond,
+		MaxBackoff: 600 * time.Millisecond,
+		MaxRetries: 50,
+	})
+	require.NoError(t, s.WaitSumMetric("metric_a", math.NaN()))
+
+	// No retry.
+	s.SetBackoff(util.BackoffConfig{
+		MinBackoff: 0,
+		MaxBackoff: 0,
+		MaxRetries: 1,
+	})
+	require.Error(t, s.WaitSumMetric("metric_a", 16))
+}

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -17,16 +17,14 @@ func GetDefaultImage() string {
 	return "quay.io/cortexproject/cortex:latest"
 }
 
-func NewDistributor(name string, flags map[string]string, image string) *e2e.Service {
+func NewDistributor(name string, consulAddress string, flags map[string]string, image string) *e2e.HTTPService {
 	if image == "" {
 		image = GetDefaultImage()
 	}
 
-	return e2e.NewService(
+	return e2e.NewHTTPService(
 		name,
 		image,
-		e2e.NetworkName,
-		[]int{80},
 		nil,
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-target":                         "distributor",
@@ -35,22 +33,21 @@ func NewDistributor(name string, flags map[string]string, image string) *e2e.Ser
 			"-distributor.replication-factor": "1",
 			// Configure the ingesters ring backend
 			"-ring.store":      "consul",
-			"-consul.hostname": "consul:8500",
+			"-consul.hostname": consulAddress,
 		}, flags))...),
 		e2e.NewReadinessProbe(80, "/ring", 200),
+		80,
 	)
 }
 
-func NewQuerier(name string, flags map[string]string, image string) *e2e.Service {
+func NewQuerier(name string, consulAddress string, flags map[string]string, image string) *e2e.HTTPService {
 	if image == "" {
 		image = GetDefaultImage()
 	}
 
-	return e2e.NewService(
+	return e2e.NewHTTPService(
 		name,
 		image,
-		e2e.NetworkName,
-		[]int{80},
 		nil,
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-target":                         "querier",
@@ -58,22 +55,21 @@ func NewQuerier(name string, flags map[string]string, image string) *e2e.Service
 			"-distributor.replication-factor": "1",
 			// Configure the ingesters ring backend
 			"-ring.store":      "consul",
-			"-consul.hostname": "consul:8500",
+			"-consul.hostname": consulAddress,
 		}, flags))...),
 		e2e.NewReadinessProbe(80, "/ready", 204),
+		80,
 	)
 }
 
-func NewIngester(name string, flags map[string]string, image string) *e2e.Service {
+func NewIngester(name string, consulAddress string, flags map[string]string, image string) *e2e.HTTPService {
 	if image == "" {
 		image = GetDefaultImage()
 	}
 
-	return e2e.NewService(
+	return e2e.NewHTTPService(
 		name,
 		image,
-		e2e.NetworkName,
-		[]int{80},
 		nil,
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-target":                        "ingester",
@@ -86,22 +82,21 @@ func NewIngester(name string, flags map[string]string, image string) *e2e.Servic
 			"-ingester.num-tokens":           "512",
 			// Configure the ingesters ring backend
 			"-ring.store":      "consul",
-			"-consul.hostname": "consul:8500",
+			"-consul.hostname": consulAddress,
 		}, flags))...),
 		e2e.NewReadinessProbe(80, "/ready", 204),
+		80,
 	)
 }
 
-func NewTableManager(name string, flags map[string]string, image string) *e2e.Service {
+func NewTableManager(name string, flags map[string]string, image string) *e2e.HTTPService {
 	if image == "" {
 		image = GetDefaultImage()
 	}
 
-	return e2e.NewService(
+	return e2e.NewHTTPService(
 		name,
 		image,
-		e2e.NetworkName,
-		[]int{80},
 		nil,
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-target":    "table-manager",
@@ -109,5 +104,6 @@ func NewTableManager(name string, flags map[string]string, image string) *e2e.Se
 		}, flags))...),
 		// The table-manager doesn't expose a readiness probe, so we just check if the / returns 404
 		e2e.NewReadinessProbe(80, "/", 404),
+		80,
 	)
 }

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -25,7 +25,6 @@ func NewDistributor(name string, consulAddress string, flags map[string]string, 
 	return e2e.NewHTTPService(
 		name,
 		image,
-		nil,
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-target":                         "distributor",
 			"-log.level":                      "warn",
@@ -48,7 +47,6 @@ func NewQuerier(name string, consulAddress string, flags map[string]string, imag
 	return e2e.NewHTTPService(
 		name,
 		image,
-		nil,
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-target":                         "querier",
 			"-log.level":                      "warn",
@@ -70,7 +68,6 @@ func NewIngester(name string, consulAddress string, flags map[string]string, ima
 	return e2e.NewHTTPService(
 		name,
 		image,
-		nil,
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-target":                        "ingester",
 			"-log.level":                     "warn",
@@ -97,7 +94,6 @@ func NewTableManager(name string, flags map[string]string, image string) *e2e.HT
 	return e2e.NewHTTPService(
 		name,
 		image,
-		nil,
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-target":    "table-manager",
 			"-log.level": "warn",

--- a/integration/ingester_flush_test.go
+++ b/integration/ingester_flush_test.go
@@ -21,41 +21,42 @@ import (
 )
 
 func TestIngesterFlushWithChunksStorage(t *testing.T) {
-	s, err := e2e.NewScenario()
+	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()
 
-	// Start dependencies
-	require.NoError(t, s.StartService(e2edb.NewDynamoDB()))
-	require.NoError(t, s.StartService(e2edb.NewConsul()))
-	require.NoError(t, s.WaitReady("consul", "dynamodb"))
+	// Start dependencies.
+	dynamo := e2edb.NewDynamoDB()
+	consul := e2edb.NewConsul()
+	require.NoError(t, s.StartAndWaitReady(dynamo, consul))
 
-	// Start Cortex components
+	// Start Cortex components.
 	require.NoError(t, ioutil.WriteFile(
 		filepath.Join(s.SharedDir(), cortexSchemaConfigFile),
 		[]byte(cortexSchemaConfigYaml),
 		os.ModePerm),
 	)
-	require.NoError(t, s.StartService(e2ecortex.NewTableManager("table-manager", ChunksStorage, "")))
-	require.NoError(t, s.StartService(e2ecortex.NewIngester("ingester-1", mergeFlags(ChunksStorage, map[string]string{
+
+	tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorage, "")
+	ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(networkName), mergeFlags(ChunksStorage, map[string]string{
 		"-ingester.max-transfer-retries": "0",
-	}), "")))
-	require.NoError(t, s.StartService(e2ecortex.NewQuerier("querier", ChunksStorage, "")))
-	require.NoError(t, s.StartService(e2ecortex.NewDistributor("distributor", ChunksStorage, "")))
-	require.NoError(t, s.WaitReady("distributor", "querier", "ingester-1", "table-manager"))
+	}), "")
+	querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(networkName), ChunksStorage, "")
+	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(networkName), ChunksStorage, "")
+	require.NoError(t, s.StartAndWaitReady(distributor, querier, ingester1, tableManager))
 
 	// Wait until the first table-manager sync has completed, so that we're
-	// sure the tables have been created
-	require.NoError(t, s.Service("table-manager").WaitMetric("cortex_dynamo_sync_tables_seconds", 1))
+	// sure the tables have been created.
+	require.NoError(t, tableManager.WaitMetric("cortex_dynamo_sync_tables_seconds", 1))
 
-	// Wait until both the distributor and querier have updated the ring
-	require.NoError(t, s.Service("distributor").WaitMetric("cortex_ring_tokens_total", 512))
-	require.NoError(t, s.Service("querier").WaitMetric("cortex_ring_tokens_total", 512))
+	// Wait until both the distributor and querier have updated the ring.
+	require.NoError(t, distributor.WaitMetric("cortex_ring_tokens_total", 512))
+	require.NoError(t, querier.WaitMetric("cortex_ring_tokens_total", 512))
 
-	c, err := e2ecortex.NewClient(s.Endpoint("distributor", 80), s.Endpoint("querier", 80), "user-1")
+	c, err := e2ecortex.NewClient(distributor.Endpoint(80), querier.Endpoint(80), "user-1")
 	require.NoError(t, err)
 
-	// Push some series to Cortex
+	// Push some series to Cortex.
 	now := time.Now()
 	series1, expectedVector1 := generateSeries("series_1", now)
 	series2, expectedVector2 := generateSeries("series_2", now)
@@ -66,7 +67,7 @@ func TestIngesterFlushWithChunksStorage(t *testing.T) {
 		require.Equal(t, 200, res.StatusCode)
 	}
 
-	// Query the series
+	// Query the series.
 	result, err := c.Query("series_1", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
@@ -79,14 +80,14 @@ func TestIngesterFlushWithChunksStorage(t *testing.T) {
 
 	// Stop ingester-1, so that it will flush all chunks to the storage. This function will return
 	// once the ingester-1 is successfully stopped, which means the flushing is completed.
-	require.NoError(t, s.StopService("ingester-1"))
+	require.NoError(t, s.Stop(ingester1))
 
 	// Ensure chunks have been uploaded to the storage (DynamoDB).
-	dynamoURL := "dynamodb://u:p@" + s.Service("dynamodb").Endpoint(8000)
+	dynamoURL := "dynamodb://u:p@" + dynamo.Endpoint(8000)
 	dynamoClient, err := newDynamoClient(dynamoURL)
 	require.NoError(t, err)
 
-	// We have pushed 2 series, so we do expect 2 chunks
+	// We have pushed 2 series, so we do expect 2 chunks.
 	period := now.Unix() / (168 * 3600)
 	indexTable := fmt.Sprintf("cortex_%d", period)
 	chunksTable := fmt.Sprintf("cortex_chunks_%d", period)

--- a/integration/ingester_flush_test.go
+++ b/integration/ingester_flush_test.go
@@ -47,11 +47,11 @@ func TestIngesterFlushWithChunksStorage(t *testing.T) {
 
 	// Wait until the first table-manager sync has completed, so that we're
 	// sure the tables have been created.
-	require.NoError(t, tableManager.WaitMetric("cortex_dynamo_sync_tables_seconds", 1))
+	require.NoError(t, tableManager.WaitSumMetric("cortex_dynamo_sync_tables_seconds", 1))
 
 	// Wait until both the distributor and querier have updated the ring.
-	require.NoError(t, distributor.WaitMetric("cortex_ring_tokens_total", 512))
-	require.NoError(t, querier.WaitMetric("cortex_ring_tokens_total", 512))
+	require.NoError(t, distributor.WaitSumMetric("cortex_ring_tokens_total", 512))
+	require.NoError(t, querier.WaitSumMetric("cortex_ring_tokens_total", 512))
 
 	c, err := e2ecortex.NewClient(distributor.Endpoint(80), querier.Endpoint(80), "user-1")
 	require.NoError(t, err)

--- a/integration/ingester_hand_over_test.go
+++ b/integration/ingester_hand_over_test.go
@@ -18,56 +18,51 @@ import (
 
 func TestIngesterHandOverWithBlocksStorage(t *testing.T) {
 	runIngesterHandOverTest(t, BlocksStorage, func(t *testing.T, s *e2e.Scenario) {
-		// Start dependencies.
-		require.NoError(t, s.StartService(e2edb.NewMinio(BlocksStorage["-experimental.tsdb.s3.bucket-name"])))
-		require.NoError(t, s.StartService(e2edb.NewConsul()))
-		require.NoError(t, s.WaitReady("consul", "minio"))
-
-		// Start Cortex components.
-		require.NoError(t, s.StartService(e2ecortex.NewIngester("ingester-1", BlocksStorage, "")))
-		require.NoError(t, s.StartService(e2ecortex.NewQuerier("querier", BlocksStorage, "")))
-		require.NoError(t, s.StartService(e2ecortex.NewDistributor("distributor", BlocksStorage, "")))
-		require.NoError(t, s.WaitReady("distributor", "querier", "ingester-1"))
+		minio := e2edb.NewMinio(9000, BlocksStorage["-experimental.tsdb.s3.bucket-name"])
+		require.NoError(t, s.StartAndWaitReady(minio))
 	})
 }
 
 func TestIngesterHandOverWithChunksStorage(t *testing.T) {
 	runIngesterHandOverTest(t, ChunksStorage, func(t *testing.T, s *e2e.Scenario) {
-		// Start dependencies.
-		require.NoError(t, s.StartService(e2edb.NewDynamoDB()))
-		require.NoError(t, s.StartService(e2edb.NewConsul()))
-		require.NoError(t, s.WaitReady("consul", "dynamodb"))
+		dynamo := e2edb.NewDynamoDB()
+		require.NoError(t, s.StartAndWaitReady(dynamo))
 
-		// Start Cortex components.
 		require.NoError(t, ioutil.WriteFile(
 			filepath.Join(s.SharedDir(), cortexSchemaConfigFile),
 			[]byte(cortexSchemaConfigYaml),
 			os.ModePerm),
 		)
-		require.NoError(t, s.StartService(e2ecortex.NewTableManager("table-manager", ChunksStorage, "")))
-		require.NoError(t, s.StartService(e2ecortex.NewIngester("ingester-1", ChunksStorage, "")))
-		require.NoError(t, s.StartService(e2ecortex.NewQuerier("querier", ChunksStorage, "")))
-		require.NoError(t, s.StartService(e2ecortex.NewDistributor("distributor", ChunksStorage, "")))
-		require.NoError(t, s.WaitReady("distributor", "querier", "ingester-1", "table-manager"))
+		tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorage, "")
+		require.NoError(t, s.StartAndWaitReady(tableManager))
 
 		// Wait until the first table-manager sync has completed, so that we're
 		// sure the tables have been created.
-		require.NoError(t, s.Service("table-manager").WaitMetric("cortex_dynamo_sync_tables_seconds", 1))
+		require.NoError(t, tableManager.WaitMetric("cortex_dynamo_sync_tables_seconds", 1))
 	})
 }
 
 func runIngesterHandOverTest(t *testing.T, flags map[string]string, setup func(t *testing.T, s *e2e.Scenario)) {
-	s, err := e2e.NewScenario()
+	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()
 
+	consul := e2edb.NewConsul()
+	require.NoError(t, s.StartAndWaitReady(consul))
+
 	setup(t, s)
 
-	// Wait until both the distributor and querier have updated the ring.
-	require.NoError(t, s.Service("distributor").WaitMetric("cortex_ring_tokens_total", 512))
-	require.NoError(t, s.Service("querier").WaitMetric("cortex_ring_tokens_total", 512))
+	// Start Cortex components.
+	ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(networkName), flags, "")
+	querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(networkName), flags, "")
+	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(networkName), flags, "")
+	require.NoError(t, s.StartAndWaitReady(distributor, querier, ingester1))
 
-	c, err := e2ecortex.NewClient(s.Endpoint("distributor", 80), s.Endpoint("querier", 80), "user-1")
+	// Wait until both the distributor and querier have updated the ring.
+	require.NoError(t, distributor.WaitMetric("cortex_ring_tokens_total", 512))
+	require.NoError(t, querier.WaitMetric("cortex_ring_tokens_total", 512))
+
+	c, err := e2ecortex.NewClient(distributor.Endpoint(80), querier.Endpoint(80), "user-1")
 	require.NoError(t, err)
 
 	// Push some series to Cortex.
@@ -85,13 +80,14 @@ func runIngesterHandOverTest(t *testing.T, flags map[string]string, setup func(t
 	assert.Equal(t, expectedVector, result.(model.Vector))
 
 	// Start ingester-2.
-	require.NoError(t, s.StartService(e2ecortex.NewIngester("ingester-2", mergeFlags(flags, map[string]string{
+	ingester2 := e2ecortex.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(networkName), mergeFlags(flags, map[string]string{
 		"-ingester.join-after": "10s",
-	}), "")))
+	}), "")
+	require.NoError(t, s.Start(ingester2))
 
 	// Stop ingester-1. This function will return once the ingester-1 is successfully
 	// stopped, which means the transfer to ingester-2 is completed.
-	require.NoError(t, s.StopService("ingester-1"))
+	require.NoError(t, s.Stop(ingester1))
 
 	// Query the series again.
 	result, err = c.Query("series_1", now)

--- a/integration/ingester_hand_over_test.go
+++ b/integration/ingester_hand_over_test.go
@@ -38,7 +38,7 @@ func TestIngesterHandOverWithChunksStorage(t *testing.T) {
 
 		// Wait until the first table-manager sync has completed, so that we're
 		// sure the tables have been created.
-		require.NoError(t, tableManager.WaitMetric("cortex_dynamo_sync_tables_seconds", 1))
+		require.NoError(t, tableManager.WaitSumMetric("cortex_dynamo_sync_tables_seconds", 1))
 	})
 }
 
@@ -59,8 +59,8 @@ func runIngesterHandOverTest(t *testing.T, flags map[string]string, setup func(t
 	require.NoError(t, s.StartAndWaitReady(distributor, querier, ingester1))
 
 	// Wait until both the distributor and querier have updated the ring.
-	require.NoError(t, distributor.WaitMetric("cortex_ring_tokens_total", 512))
-	require.NoError(t, querier.WaitMetric("cortex_ring_tokens_total", 512))
+	require.NoError(t, distributor.WaitSumMetric("cortex_ring_tokens_total", 512))
+	require.NoError(t, querier.WaitSumMetric("cortex_ring_tokens_total", 512))
 
 	c, err := e2ecortex.NewClient(distributor.Endpoint(80), querier.Endpoint(80), "user-1")
 	require.NoError(t, err)

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -38,24 +38,24 @@ func TestSingleBinaryWithMemberlist(t *testing.T) {
 	require.NoError(t, s.StartAndWaitReady(cortex1, cortex2, cortex3))
 
 	// All three Cortex serves should see each other.
-	require.NoError(t, cortex1.WaitMetric("memberlist_client_cluster_members_count", 3))
-	require.NoError(t, cortex2.WaitMetric("memberlist_client_cluster_members_count", 3))
-	require.NoError(t, cortex3.WaitMetric("memberlist_client_cluster_members_count", 3))
+	require.NoError(t, cortex1.WaitSumMetric("memberlist_client_cluster_members_count", 3))
+	require.NoError(t, cortex2.WaitSumMetric("memberlist_client_cluster_members_count", 3))
+	require.NoError(t, cortex3.WaitSumMetric("memberlist_client_cluster_members_count", 3))
 
 	// All Cortex servers should have 512 tokens, altogether 3 * 512.
-	require.NoError(t, cortex1.WaitMetric("cortex_ring_tokens_total", 3*512))
-	require.NoError(t, cortex2.WaitMetric("cortex_ring_tokens_total", 3*512))
-	require.NoError(t, cortex3.WaitMetric("cortex_ring_tokens_total", 3*512))
+	require.NoError(t, cortex1.WaitSumMetric("cortex_ring_tokens_total", 3*512))
+	require.NoError(t, cortex2.WaitSumMetric("cortex_ring_tokens_total", 3*512))
+	require.NoError(t, cortex3.WaitSumMetric("cortex_ring_tokens_total", 3*512))
 
 	require.NoError(t, s.Stop(cortex1))
-	require.NoError(t, cortex2.WaitMetric("cortex_ring_tokens_total", 2*512))
-	require.NoError(t, cortex2.WaitMetric("memberlist_client_cluster_members_count", 2))
-	require.NoError(t, cortex3.WaitMetric("cortex_ring_tokens_total", 2*512))
-	require.NoError(t, cortex3.WaitMetric("memberlist_client_cluster_members_count", 2))
+	require.NoError(t, cortex2.WaitSumMetric("cortex_ring_tokens_total", 2*512))
+	require.NoError(t, cortex2.WaitSumMetric("memberlist_client_cluster_members_count", 2))
+	require.NoError(t, cortex3.WaitSumMetric("cortex_ring_tokens_total", 2*512))
+	require.NoError(t, cortex3.WaitSumMetric("memberlist_client_cluster_members_count", 2))
 
 	require.NoError(t, s.Stop(cortex2))
-	require.NoError(t, cortex3.WaitMetric("cortex_ring_tokens_total", 1*512))
-	require.NoError(t, cortex3.WaitMetric("memberlist_client_cluster_members_count", 1))
+	require.NoError(t, cortex3.WaitSumMetric("cortex_ring_tokens_total", 1*512))
+	require.NoError(t, cortex3.WaitSumMetric("memberlist_client_cluster_members_count", 1))
 
 	require.NoError(t, s.Stop(cortex3))
 }

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -16,50 +16,51 @@ import (
 )
 
 func TestSingleBinaryWithMemberlist(t *testing.T) {
-	s, err := e2e.NewScenario()
+	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()
 
-	// Start dependencies.
-	require.NoError(t, s.StartService(e2edb.NewDynamoDB()))
+	// Start dependencies
+	dynamo := e2edb.NewDynamoDB()
 	// Look ma, no Consul!
-	require.NoError(t, s.WaitReady("dynamodb"))
+	require.NoError(t, s.StartAndWaitReady(dynamo))
 
 	require.NoError(t, ioutil.WriteFile(
 		filepath.Join(s.SharedDir(), cortexSchemaConfigFile),
 		[]byte(cortexSchemaConfigYaml),
 		os.ModePerm),
 	)
-	require.NoError(t, startSingleBinary(s, "cortex-1", ""))
-	require.NoError(t, startSingleBinary(s, "cortex-2", "cortex-1:8000"))
-	require.NoError(t, startSingleBinary(s, "cortex-3", "cortex-2:8000"))
 
-	require.NoError(t, s.WaitReady("cortex-1", "cortex-2", "cortex-3"))
+	cortex1 := newSingleBinary("cortex-1", "")
+	cortex2 := newSingleBinary("cortex-2", networkName+"-cortex-1:8000")
+	cortex3 := newSingleBinary("cortex-3", networkName+"-cortex-2:8000")
+
+	require.NoError(t, s.StartAndWaitReady(cortex1, cortex2, cortex3))
 
 	// All three Cortex serves should see each other.
-	require.NoError(t, s.Service("cortex-1").WaitMetric("memberlist_client_cluster_members_count", 3))
-	require.NoError(t, s.Service("cortex-2").WaitMetric("memberlist_client_cluster_members_count", 3))
-	require.NoError(t, s.Service("cortex-3").WaitMetric("memberlist_client_cluster_members_count", 3))
+	require.NoError(t, cortex1.WaitMetric("memberlist_client_cluster_members_count", 3))
+	require.NoError(t, cortex2.WaitMetric("memberlist_client_cluster_members_count", 3))
+	require.NoError(t, cortex3.WaitMetric("memberlist_client_cluster_members_count", 3))
 
 	// All Cortex servers should have 512 tokens, altogether 3 * 512.
-	require.NoError(t, s.Service("cortex-1").WaitMetric("cortex_ring_tokens_total", 3*512))
-	require.NoError(t, s.Service("cortex-2").WaitMetric("cortex_ring_tokens_total", 3*512))
-	require.NoError(t, s.Service("cortex-3").WaitMetric("cortex_ring_tokens_total", 3*512))
+	require.NoError(t, cortex1.WaitMetric("cortex_ring_tokens_total", 3*512))
+	require.NoError(t, cortex2.WaitMetric("cortex_ring_tokens_total", 3*512))
+	require.NoError(t, cortex3.WaitMetric("cortex_ring_tokens_total", 3*512))
 
-	require.NoError(t, s.StopService("cortex-1"))
-	require.NoError(t, s.Service("cortex-2").WaitMetric("cortex_ring_tokens_total", 2*512))
-	require.NoError(t, s.Service("cortex-2").WaitMetric("memberlist_client_cluster_members_count", 2))
-	require.NoError(t, s.Service("cortex-3").WaitMetric("cortex_ring_tokens_total", 2*512))
-	require.NoError(t, s.Service("cortex-3").WaitMetric("memberlist_client_cluster_members_count", 2))
+	require.NoError(t, s.Stop(cortex1))
+	require.NoError(t, cortex2.WaitMetric("cortex_ring_tokens_total", 2*512))
+	require.NoError(t, cortex2.WaitMetric("memberlist_client_cluster_members_count", 2))
+	require.NoError(t, cortex3.WaitMetric("cortex_ring_tokens_total", 2*512))
+	require.NoError(t, cortex3.WaitMetric("memberlist_client_cluster_members_count", 2))
 
-	require.NoError(t, s.StopService("cortex-2"))
-	require.NoError(t, s.Service("cortex-3").WaitMetric("cortex_ring_tokens_total", 1*512))
-	require.NoError(t, s.Service("cortex-3").WaitMetric("memberlist_client_cluster_members_count", 1))
+	require.NoError(t, s.Stop(cortex2))
+	require.NoError(t, cortex3.WaitMetric("cortex_ring_tokens_total", 1*512))
+	require.NoError(t, cortex3.WaitMetric("memberlist_client_cluster_members_count", 1))
 
-	require.NoError(t, s.StopService("cortex-3"))
+	require.NoError(t, s.Stop(cortex3))
 }
 
-func startSingleBinary(s *e2e.Scenario, name string, join string) error {
+func newSingleBinary(name string, join string) *e2e.HTTPService {
 	flags := map[string]string{
 		"-target":                        "all", // single-binary mode
 		"-log.level":                     "warn",
@@ -79,22 +80,22 @@ func startSingleBinary(s *e2e.Scenario, name string, join string) error {
 		flags["-memberlist.join"] = join
 	}
 
-	serv := e2e.NewService(
+	serv := e2e.NewHTTPService(
 		name,
 		e2ecortex.GetDefaultImage(),
-		e2e.NetworkName,
-		[]int{80, 8000},
 		nil,
 		e2e.NewCommandWithoutEntrypoint("cortex", buildArgs(mergeFlags(ChunksStorage, flags))...),
 		e2e.NewReadinessProbe(80, "/ready", 204),
+		80,
+		8000,
 	)
 
 	backOff := util.BackoffConfig{
-		MinBackoff: 100 * time.Millisecond,
+		MinBackoff: 200 * time.Millisecond,
 		MaxBackoff: 500 * time.Millisecond, // Bump max backoff... things take little longer with memberlist.
 		MaxRetries: 100,
 	}
 
 	serv.SetBackoff(backOff)
-	return s.StartService(serv)
+	return serv
 }

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -83,7 +83,6 @@ func newSingleBinary(name string, join string) *e2e.HTTPService {
 	serv := e2e.NewHTTPService(
 		name,
 		e2ecortex.GetDefaultImage(),
-		nil,
 		e2e.NewCommandWithoutEntrypoint("cortex", buildArgs(mergeFlags(ChunksStorage, flags))...),
 		e2e.NewReadinessProbe(80, "/ready", 204),
 		80,


### PR DESCRIPTION
## Changes

* New code also allows the different implementation of service (e.g you will see why it's needed for Thanos).
* Make more things type safe now instead of fragile handwritten strings as references.
* Also added customizing `networkName`. This allows using `t.Parallel` :heart: 
* Added tests to e2e package. 


...because testing, a testing package makes sense right? ;p

 ![](https://media1.giphy.com/media/7pHTiZYbAoq40/giphy.gif))

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>
