### PR TITLE
Register a histogram that was omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [BUGFIX] Azure Blob ChunkStore: Fixed issue causing `invalid chunk checksum` errors. #2074
 * [BUGFIX] The gauge `cortex_overrides_last_reload_successful` is now only exported by components that use a `RuntimeConfigManager`. Previously, for components that do not initialize a `RuntimeConfigManager` (such as the compactor) the gauge was initialized with 0 (indicating error state) and then never updated, resulting in a false-negative permanent error state. #2092
 * [BUGFIX] Fixed WAL metric names, added the `cortex_` prefix.
+* [BUGFIX] Restored histogram `cortex_configs_request_duration_seconds` #2138
 
 Cortex 0.4.0 is the last version that can *write* denormalised tokens. Cortex 0.5.0 and above always write normalised tokens.
 

--- a/pkg/configs/client/client.go
+++ b/pkg/configs/client/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/instrument"
 
 	"github.com/cortexproject/cortex/pkg/configs"
@@ -30,7 +31,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.ClientTimeout, prefix+"configs.client-timeout", 5*time.Second, "Timeout for requests to Weave Cloud configs service.")
 }
 
-var configsRequestDuration = instrument.NewHistogramCollector(prometheus.NewHistogramVec(prometheus.HistogramOpts{
+var configsRequestDuration = instrument.NewHistogramCollector(promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Namespace: "cortex",
 	Name:      "configs_request_duration_seconds",
 	Help:      "Time spent requesting configs.",


### PR DESCRIPTION
**What this PR does**:

Put back a metric that got lost in #1571.

Note I used `promauto` for shorter diff but most `HistogramCollector`s in the code registered via `init()` functions.  It's kinda relying on an implementation detail but `distributor.go` is already doing it and yolo.

**Checklist**
- [ ] Tests updated - it would be nice to test for metrics but that's a bigger job than I had planned
- [x] Documentation added - NA
- [x] `CHANGELOG.md` updated
