### PR TITLE
Fix website documentation edit links

### DIFF
--- a/tools/website/web-pre.sh
+++ b/tools/website/web-pre.sh
@@ -48,7 +48,7 @@ echo "$(cat <<EOT
 ---
 title: Contributing
 type: docs
-original_path: CONTRIBUTING.md
+originalpath: CONTRIBUTING.md
 menu:
   contributing:
     weight: 3

--- a/tools/website/web-pre.sh
+++ b/tools/website/web-pre.sh
@@ -22,6 +22,7 @@ echo "$(cat <<EOT
 ---
 title: Code of Conduct
 type: docs
+originalpath: code-of-conduct.md
 menu:
   contributing:
     weight: 1
@@ -34,6 +35,7 @@ echo "$(cat <<EOT
 ---
 title: Changelog
 type: docs
+originalpath: CHANGELOG.md
 menu:
   main:
     weight: 2
@@ -46,6 +48,7 @@ echo "$(cat <<EOT
 ---
 title: Contributing
 type: docs
+original_path: CONTRIBUTING.md
 menu:
   contributing:
     weight: 3

--- a/website/layouts/partials/page-meta-links.html
+++ b/website/layouts/partials/page-meta-links.html
@@ -1,0 +1,19 @@
+{{ if .Path }}
+{{ $gh_repo := ($.Param "github_repo") }}
+{{ $gh_project_repo := ($.Param "github_project_repo") }}
+{{ if $gh_repo }}
+<div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
+{{ $editURL := printf "%s/edit/master/%s" $gh_repo .Path }}
+{{ if (.Params.originalpath) }}
+{{ $editURL = printf "%s/edit/master/%s" $gh_repo .Params.originalpath }}
+{{ end }}
+{{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
+<a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+<a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+{{ if $gh_project_repo }}
+{{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
+<a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+{{ end }}
+</div>
+{{ end }}
+{{ end }}


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

The `edit this page` link as shown below

![image](https://user-images.githubusercontent.com/1053421/74612934-1002d300-50d8-11ea-9e73-454c4452e2f6.png)

was broken since I've started the website.

 This fixes it and also introduces a way to override the page original path `originalpath` using front matter variable. This is useful for files that are not using the same destination path.