### PR TITLE
Fix default_validity cache setting typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * `--store.min-chunk-age` has been removed
   * `--querier.query-store-after` has been added in it's place.
 * [CHANGE] Experimental Memberlist KV store can now be used in single-binary Cortex. Attempts to use it previously would fail with panic. This change also breaks existing binary protocol used to exchange gossip messages, so this version will not be able to understand gossiped Ring when used in combination with the previous version of Cortex. Easiest way to upgrade is to shutdown old Cortex installation, and restart it with new version. Incremental rollout works too, but with reduced functionality until all components run the same version. #2016
+* [CHANGE] Renamed the cache configuration setting `defaul_validity` to `default_validity`. #2140
 * [FEATURE] Added user sub rings to distribute users to a subset of ingesters. #1947
   * `--experimental.distributor.user-subring-size`
 * [FEATURE] Added flag `-experimental.ruler.enable-api` to enable the ruler api which implements the Prometheus API `/api/v1/rules` and `/api/v1/alerts` endpoints under the configured `-http.prefix`. #1999

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -604,7 +604,7 @@ results_cache:
 
     # The default validity of entries for caches unless overridden.
     # CLI flag: -frontend.default-validity
-    [defaul_validity: <duration> | default = 0s]
+    [default_validity: <duration> | default = 0s]
 
     background:
       # How many goroutines to use to write back to memcache.
@@ -1457,7 +1457,7 @@ index_queries_cache_config:
   # Cache config for index entry reading. The default validity of entries for
   # caches unless overridden.
   # CLI flag: -store.index-cache-read.default-validity
-  [defaul_validity: <duration> | default = 0s]
+  [default_validity: <duration> | default = 0s]
 
   background:
     # Cache config for index entry reading. How many goroutines to use to write
@@ -1502,7 +1502,7 @@ chunk_cache_config:
   # Cache config for chunks. The default validity of entries for caches unless
   # overridden.
   # CLI flag: -default-validity
-  [defaul_validity: <duration> | default = 0s]
+  [default_validity: <duration> | default = 0s]
 
   background:
     # Cache config for chunks. How many goroutines to use to write back to
@@ -1537,7 +1537,7 @@ write_dedupe_cache_config:
   # Cache config for index entry writing. The default validity of entries for
   # caches unless overridden.
   # CLI flag: -store.index-cache-write.default-validity
-  [defaul_validity: <duration> | default = 0s]
+  [default_validity: <duration> | default = 0s]
 
   background:
     # Cache config for index entry writing. How many goroutines to use to write

--- a/go.sum
+++ b/go.sum
@@ -709,6 +709,7 @@ github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e h1:uO75wNGioszj
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
 github.com/sercand/kuberesolver v2.1.0+incompatible h1:iJ1oCzPQ/aacsbCWLfJW1hPKkHMvCEgNSA9kvWcb9MY=
 github.com/sercand/kuberesolver v2.1.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
+github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24 h1:pntxY8Ary0t43dCZ5dqY4YTJCObLY1kIXl0uzMv+7DE=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=

--- a/pkg/chunk/cache/cache.go
+++ b/pkg/chunk/cache/cache.go
@@ -24,7 +24,7 @@ type Cache interface {
 type Config struct {
 	EnableFifoCache bool `yaml:"enable_fifocache,omitempty"`
 
-	DefaultValidity time.Duration `yaml:"defaul_validity,omitempty"`
+	DefaultValidity time.Duration `yaml:"default_validity,omitempty"`
 
 	Background     BackgroundConfig      `yaml:"background,omitempty"`
 	Memcache       MemcachedConfig       `yaml:"memcached,omitempty"`


### PR DESCRIPTION
Signed-off-by: Trevor Wood <Trevor.G.Wood@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Fixes a typo in the YAML configuration for caches. Currently, the setting is `defaul_validity`, but it should be `default_validity`.

**Which issue(s) this PR fixes**:
Fixes #1842 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
