### PR TITLE
Fixed integration-configs-db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ exes $(EXES) protos $(PROTO_GOS) lint test shell mod-check check-protos web-buil
 configs-integration-test: build-image/$(UPTODATE)
 	@mkdir -p $(shell pwd)/.pkg
 	@mkdir -p $(shell pwd)/.cache
-	@DB_CONTAINER="$$(docker run -d -e 'POSTGRES_DB=configs_test' postgres:9.6)"; \
+	@DB_CONTAINER="$$(docker run -d -e 'POSTGRES_DB=configs_test' postgres:9.6.16)"; \
 	echo ; \
 	echo ">>>> Entering build container: $@"; \
 	$(SUDO) docker run $(RM) $(TTY) -i $(GOVOLUMES) \


### PR DESCRIPTION
**What this PR does**:
A couple of days ago PostgreSQL `9.6.17` has been pushed out and its Docker image has changed (requires `POSTGRES_PASSWORD`). Since then, all config db integration tests are failing. I would suggest to get stick to `9.6.16` for the tests to unlock other PRs.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
