### PR TITLE
Fixed execution of integration tests framework's unit tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
           export CORTEX_IMAGE="${CORTEX_IMAGE_PREFIX}cortex:${CIRCLE_TAG:-$(./tools/image-tag)}"
           export CORTEX_CHECKOUT_DIR="/home/circleci/.go_workspace/src/github.com/cortexproject/cortex"
           echo "Running integration tests with image: $CORTEX_IMAGE"
-          go test -timeout 300s -v -count=1 ./integration
+          go test -timeout 300s -v -count=1 ./integration/...
 
   build:
     <<: *defaults

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -223,7 +223,7 @@ func (s *ConcreteService) WaitStarted(networkName string) (err error) {
 		s.retryBackoff.Wait()
 	}
 
-	return fmt.Errorf("docker container %s failed to start: %w", s.name, err)
+	return fmt.Errorf("docker container %s failed to start: %v", s.name, err)
 }
 
 func (s *ConcreteService) WaitReady() (err error) {

--- a/tools/test
+++ b/tools/test
@@ -83,7 +83,7 @@ fail=0
 
 if [ -z "$TESTDIRS" ]; then
     # NB: Relies on paths being prefixed with './'.
-    TESTDIRS=($(git ls-files -- '*_test.go' | grep -vE '^(vendor|experimental|integration)/' | xargs -n1 dirname | sort -u | sed -e 's|^|./|'))
+    TESTDIRS=($(git ls-files -- 'cmd/*_test.go' 'pkg/*_test.go' 'tools/*_test.go' 'integration/e2e*_test.go' | xargs -n1 dirname | sort -u | sed -e 's|^|./|'))
 else
     # TESTDIRS on the right side is not really an array variable, it
     # is just a string with spaces, but it is written like that to

--- a/tools/test
+++ b/tools/test
@@ -83,7 +83,7 @@ fail=0
 
 if [ -z "$TESTDIRS" ]; then
     # NB: Relies on paths being prefixed with './'.
-    TESTDIRS=($(git ls-files -- 'cmd/*_test.go' 'pkg/*_test.go' 'tools/*_test.go' 'integration/e2e*_test.go' | xargs -n1 dirname | sort -u | sed -e 's|^|./|'))
+    TESTDIRS=($(git ls-files -- 'cmd/*_test.go' 'pkg/*_test.go' 'tools/*_test.go' | xargs -n1 dirname | sort -u | sed -e 's|^|./|'))
 else
     # TESTDIRS on the right side is not really an array variable, it
     # is just a string with spaces, but it is written like that to


### PR DESCRIPTION
**What this PR does**:
In this PR:
- Run integration tests framework's unit tests along with integration tests (cause some of them require Docker)
- Remove `grep -v` from unit tests discovery (may be risky)
- Fixed `WaitSumMetric()` flaky tests

Here is the proof that the list of unit tests hasn't changed:

```
$ git ls-files -- '*_test.go' | grep -vE '^(vendor|experimental|integration)/' > before.txt
$ git ls-files -- 'cmd/*_test.go' 'pkg/*_test.go' 'tools/*_test.go' > after.txt
$ diff before.txt after.txt
No diff
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
