### PR TITLE
Fix wrong syntax for `url` in config-file-reference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 * [BUGFIX] The gauge `cortex_overrides_last_reload_successful` is now only exported by components that use a `RuntimeConfigManager`. Previously, for components that do not initialize a `RuntimeConfigManager` (such as the compactor) the gauge was initialized with 0 (indicating error state) and then never updated, resulting in a false-negative permanent error state. #2092
 * [BUGFIX] Fixed WAL metric names, added the `cortex_` prefix.
 * [BUGFIX] Restored histogram `cortex_configs_request_duration_seconds` #2138
-* [BUGFIX] Fix wrong syntax for `url` in config-file-reference.
+* [BUGFIX] Fix wrong syntax for `url` in config-file-reference. #2148
 
 Cortex 0.4.0 is the last version that can *write* denormalised tokens. Cortex 0.5.0 and above always write normalised tokens.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [BUGFIX] The gauge `cortex_overrides_last_reload_successful` is now only exported by components that use a `RuntimeConfigManager`. Previously, for components that do not initialize a `RuntimeConfigManager` (such as the compactor) the gauge was initialized with 0 (indicating error state) and then never updated, resulting in a false-negative permanent error state. #2092
 * [BUGFIX] Fixed WAL metric names, added the `cortex_` prefix.
 * [BUGFIX] Restored histogram `cortex_configs_request_duration_seconds` #2138
+* [BUGFIX] Fix wrong syntax for `url` in config-file-reference.
 
 Cortex 0.4.0 is the last version that can *write* denormalised tokens. Cortex 0.5.0 and above always write normalised tokens.
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -648,10 +648,9 @@ results_cache:
 The `ruler_config` configures the Cortex ruler.
 
 ```yaml
-externalurl:
-  # URL of alerts return path.
-  # CLI flag: -ruler.external.url
-  [url: <url> | default = ]
+# URL of alerts return path.
+# CLI flag: -ruler.external.url
+[externalurl: <url> | default = ]
 
 # How frequently to evaluate rules
 # CLI flag: -ruler.evaluation-interval
@@ -675,10 +674,9 @@ storeconfig:
 # CLI flag: -ruler.rule-path
 [rulepath: <string> | default = "/rules"]
 
-alertmanagerurl:
-  # URL of the Alertmanager to send notifications to.
-  # CLI flag: -ruler.alertmanager-url
-  [url: <url> | default = ]
+# URL of the Alertmanager to send notifications to.
+# CLI flag: -ruler.alertmanager-url
+[alertmanagerurl: <url> | default = ]
 
 # Use DNS SRV records to discover alertmanager hosts.
 # CLI flag: -ruler.alertmanager-discovery
@@ -779,15 +777,13 @@ The `alertmanager_config` configures the Cortex alertmanager.
 # CLI flag: -alertmanager.storage.retention
 [retention: <duration> | default = 120h0m0s]
 
-externalurl:
-  # The URL under which Alertmanager is externally reachable (for example, if
-  # Alertmanager is served via a reverse proxy). Used for generating relative
-  # and absolute links back to Alertmanager itself. If the URL has a path
-  # portion, it will be used to prefix all HTTP endpoints served by
-  # Alertmanager. If omitted, relevant URL components will be derived
-  # automatically.
-  # CLI flag: -alertmanager.web.external-url
-  [url: <url> | default = ]
+# The URL under which Alertmanager is externally reachable (for example, if
+# Alertmanager is served via a reverse proxy). Used for generating relative and
+# absolute links back to Alertmanager itself. If the URL has a path portion, it
+# will be used to prefix all HTTP endpoints served by Alertmanager. If omitted,
+# relevant URL components will be derived automatically.
+# CLI flag: -alertmanager.web.external-url
+[externalurl: <url> | default = ]
 
 # How frequently to poll Cortex configs
 # CLI flag: -alertmanager.configs.poll-interval
@@ -1176,12 +1172,11 @@ The `storage_config` configures where Cortex stores the data (chunks storage eng
 
 aws:
   dynamodbconfig:
-    dynamodb:
-      # DynamoDB endpoint URL with escaped Key and Secret encoded. If only
-      # region is specified as a host, proper endpoint will be deduced. Use
-      # inmemory:///<table-name> to use a mock in-memory implementation.
-      # CLI flag: -dynamodb.url
-      [url: <url> | default = ]
+    # DynamoDB endpoint URL with escaped Key and Secret encoded. If only region
+    # is specified as a host, proper endpoint will be deduced. Use
+    # inmemory:///<table-name> to use a mock in-memory implementation.
+    # CLI flag: -dynamodb.url
+    [dynamodb: <url> | default = ]
 
     # DynamoDB table management requests per second limit.
     # CLI flag: -dynamodb.api-limit
@@ -1191,10 +1186,9 @@ aws:
     # CLI flag: -dynamodb.throttle-limit
     [throttlelimit: <float> | default = 10]
 
-    applicationautoscaling:
-      # ApplicationAutoscaling endpoint URL with escaped Key and Secret encoded.
-      # CLI flag: -applicationautoscaling.url
-      [url: <url> | default = ]
+    # ApplicationAutoscaling endpoint URL with escaped Key and Secret encoded.
+    # CLI flag: -applicationautoscaling.url
+    [applicationautoscaling: <url> | default = ]
 
     metrics:
       # Use metrics-based autoscaling, via this query URL
@@ -1242,12 +1236,11 @@ aws:
     # CLI flag: -dynamodb.chunk.get.max.parallelism
     [chunkgetmaxparallelism: <int> | default = 32]
 
-  s3:
-    # S3 endpoint URL with escaped Key and Secret encoded. If only region is
-    # specified as a host, proper endpoint will be deduced. Use
-    # inmemory:///<bucket-name> to use a mock in-memory implementation.
-    # CLI flag: -s3.url
-    [url: <url> | default = ]
+  # S3 endpoint URL with escaped Key and Secret encoded. If only region is
+  # specified as a host, proper endpoint will be deduced. Use
+  # inmemory:///<bucket-name> to use a mock in-memory implementation.
+  # CLI flag: -s3.url
+  [s3: <url> | default = ]
 
   # Comma separated list of bucket names to evenly distribute chunks over.
   # Overrides any buckets specified in s3.url flag
@@ -2063,10 +2056,9 @@ The `configdb_config` configures the config database storing rules and alerts, a
 The `configstore_config` configures the config database storing rules and alerts, and is used by the Cortex alertmanager.
 
 ```yaml
-configsapiurl:
-  # URL of configs API server.
-  # CLI flag: -<prefix>.configs.url
-  [url: <url> | default = ]
+# URL of configs API server.
+# CLI flag: -<prefix>.configs.url
+[configsapiurl: <url> | default = ]
 
 # Timeout for requests to Weave Cloud configs service.
 # CLI flag: -<prefix>.configs.client-timeout

--- a/tools/doc-generator/parser.go
+++ b/tools/doc-generator/parser.go
@@ -316,6 +316,22 @@ func getCustomFieldEntry(field reflect.StructField, fieldValue reflect.Value, fl
 			fieldDefault: fieldFlag.DefValue,
 		}, nil
 	}
+	if field.Type == reflect.TypeOf(flagext.URLValue{}) {
+		fieldFlag, err := getFieldFlag(field, fieldValue, flags)
+		if err != nil {
+			return nil, err
+		}
+
+		return &configEntry{
+			kind:         "field",
+			name:         getFieldName(field),
+			required:     isFieldRequired(field),
+			fieldFlag:    fieldFlag.Name,
+			fieldDesc:    fieldFlag.Usage,
+			fieldType:    "url",
+			fieldDefault: fieldFlag.DefValue,
+		}, nil
+	}
 
 	return nil, nil
 }


### PR DESCRIPTION
Signed-off-by: Wing924 <weihe924stephen@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

git push --set-upstream origin fix-docs-url

AS IS:
```
externalurl:
  # URL of alerts return path.
  # CLI flag: -ruler.external.url
  [url: <url> | default = ]
```

TO BE:

```
# URL of alerts return path.
# CLI flag: -ruler.external.url
[externalurl: <url> | default = ]
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
