### PR TITLE
Remove unused /validate_expr endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * `--querier.query-store-after` has been added in it's place.
 * [CHANGE] Experimental Memberlist KV store can now be used in single-binary Cortex. Attempts to use it previously would fail with panic. This change also breaks existing binary protocol used to exchange gossip messages, so this version will not be able to understand gossiped Ring when used in combination with the previous version of Cortex. Easiest way to upgrade is to shutdown old Cortex installation, and restart it with new version. Incremental rollout works too, but with reduced functionality until all components run the same version. #2016
 * [CHANGE] Renamed the cache configuration setting `defaul_validity` to `default_validity`. #2140
+* [CHANGE] Removed unused /validate_expr endpoint. #2152
 * [FEATURE] Added a read-only local alertmanager config store using files named corresponding to their tenant id. #2125
 * [FEATURE] Added user sub rings to distribute users to a subset of ingesters. #1947
   * `--experimental.distributor.user-subring-size`

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -262,7 +262,6 @@ func (t *Cortex) initQuerier(cfg *Config) (err error) {
 	subrouter := t.server.HTTP.PathPrefix("/api/prom").Subrouter()
 	subrouter.PathPrefix("/api/v1").Handler(t.httpAuthMiddleware.Wrap(promRouter))
 	subrouter.Path("/read").Handler(t.httpAuthMiddleware.Wrap(querier.RemoteReadHandler(queryable)))
-	subrouter.Path("/validate_expr").Handler(t.httpAuthMiddleware.Wrap(http.HandlerFunc(t.distributor.ValidateExprHandler)))
 	subrouter.Path("/chunks").Handler(t.httpAuthMiddleware.Wrap(querier.ChunksHandler(queryable)))
 	subrouter.Path("/user_stats").Handler(middleware.AuthenticateUser.Wrap(http.HandlerFunc(t.distributor.UserStatsHandler)))
 

--- a/pkg/distributor/http_server.go
+++ b/pkg/distributor/http_server.go
@@ -1,11 +1,9 @@
 package distributor
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/go-kit/kit/log/level"
-	"github.com/prometheus/prometheus/promql"
 	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
@@ -65,44 +63,4 @@ func (d *Distributor) UserStatsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	util.WriteJSONResponse(w, stats)
-}
-
-// ValidateExprHandler validates a PromQL expression.
-func (d *Distributor) ValidateExprHandler(w http.ResponseWriter, r *http.Request) {
-	_, err := promql.ParseExpr(r.FormValue("expr"))
-
-	// We mimick the response format of Prometheus's official API here for
-	// consistency, but unfortunately its private types (string consts etc.)
-	// aren't reusable.
-	if err == nil {
-		util.WriteJSONResponse(w, map[string]string{
-			"status": "success",
-		})
-		return
-	}
-
-	parseErr, ok := err.(*promql.ParseErr)
-	if !ok {
-		// This should always be a promql.ParseErr.
-		http.Error(w, fmt.Sprintf("unexpected error returned from PromQL parser: %v", err), http.StatusInternalServerError)
-		return
-	}
-
-	// If the parsing input was a single line, parseErr.Line is 0
-	// and the generated error string omits the line entirely. But we
-	// want to report line numbers consistently, no matter how many
-	// lines there are (starting at 1).
-	if parseErr.Line == 0 {
-		parseErr.Line = 1
-	}
-	w.WriteHeader(http.StatusBadRequest)
-	util.WriteJSONResponse(w, map[string]interface{}{
-		"status":    "error",
-		"errorType": "bad_data",
-		"error":     err.Error(),
-		"location": map[string]int{
-			"line": parseErr.Line,
-			"pos":  parseErr.Pos,
-		},
-	})
 }


### PR DESCRIPTION
**What this PR does**: This PR removes unused `/validate_expr` endpoint, introduced by https://github.com/cortexproject/cortex/pull/184. It has never been used, and is not documented, and its output is changing because of changes in Prometheus error reporting (https://github.com/cortexproject/cortex/pull/2088 for details). Instead of fixing it, let's remove it. (If we need it again, we can introduce it again).
