### PR TITLE
Skip expired requests when popping the next request from the query-frontend queue

### DIFF
--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -324,12 +324,13 @@ func (f *Frontend) queueRequest(ctx context.Context, req *request) error {
 	}
 }
 
-// getQueue picks a random queue and takes the next request off of it, so we
+// getQueue picks a random queue and takes the next unexpired request off of it, so we
 // fairly process users queries.  Will block if there are no requests.
 func (f *Frontend) getNextRequest(ctx context.Context) (*request, error) {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 
+FindQueue:
 	for len(f.queues) == 0 && ctx.Err() == nil {
 		f.cond.Wait()
 	}
@@ -345,20 +346,35 @@ func (f *Frontend) getNextRequest(ctx context.Context) (*request, error) {
 			continue
 		}
 
-		request := <-queue
-		if len(queue) == 0 {
-			delete(f.queues, userID)
+		// Pick the first non-expired request from this user's queue (if any).
+		for {
+			lastRequest := false
+			request := <-queue
+			if len(queue) == 0 {
+				delete(f.queues, userID)
+				lastRequest = true
+			}
+
+			// Tell close() we've processed a request.
+			f.cond.Broadcast()
+
+			queueDuration.Observe(time.Now().Sub(request.enqueueTime).Seconds())
+			queueLength.Add(-1)
+			request.queueSpan.Finish()
+
+			// Ensure the request has not already expired.
+			if request.originalCtx.Err() == nil {
+				return request, nil
+			}
+
+			// Stop iterating on this queue if we've just consumed the last request.
+			if lastRequest {
+				break
+			}
 		}
-
-		// Tell close() we've processed a request.
-		f.cond.Broadcast()
-
-		queueDuration.Observe(time.Now().Sub(request.enqueueTime).Seconds())
-		queueLength.Add(-1)
-		request.queueSpan.Finish()
-
-		return request, nil
 	}
 
-	panic("should never happen")
+	// There are no unexpired requests, so we can get back
+	// and wait for more requests.
+	goto FindQueue
 }

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -358,7 +358,7 @@ FindQueue:
 			// Tell close() we've processed a request.
 			f.cond.Broadcast()
 
-			queueDuration.Observe(time.Now().Sub(request.enqueueTime).Seconds())
+			queueDuration.Observe(time.Since(request.enqueueTime).Seconds())
 			queueLength.Add(-1)
 			request.queueSpan.Finish()
 

--- a/pkg/querier/frontend/frontend_queue_test.go
+++ b/pkg/querier/frontend/frontend_queue_test.go
@@ -1,0 +1,86 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/util/flagext"
+)
+
+func setupFrontend(t *testing.T, config Config) *Frontend {
+	logger := log.NewNopLogger()
+
+	frontend, err := New(config, logger)
+	require.NoError(t, err)
+	defer frontend.Close()
+	return frontend
+}
+
+func testReq(ctx context.Context) *request {
+	return &request{
+		originalCtx: ctx,
+		err:         make(chan error, 1),
+		response:    make(chan *ProcessResponse, 1),
+	}
+}
+
+func TestDequeuesExpiredRequests(t *testing.T) {
+	var config Config
+	flagext.DefaultValues(&config)
+	config.MaxOutstandingPerTenant = 10
+	userID := "1"
+	userID2 := "2"
+
+	f := setupFrontend(t, config)
+
+	ctx := user.InjectOrgID(context.Background(), userID)
+	expired, cancel := context.WithCancel(ctx)
+	cancel()
+
+	for i := 0; i < config.MaxOutstandingPerTenant; i++ {
+		var err error
+		if i%5 == 0 {
+			err = f.queueRequest(ctx, testReq(ctx))
+		} else {
+			err = f.queueRequest(ctx, testReq(expired))
+		}
+
+		require.Nil(t, err)
+	}
+
+	// the first request shouldnt be expired
+	req, err := f.getNextRequest(ctx)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, 9, len(f.queues[userID]))
+
+	// the next unexpired request should be the 5th index
+	req, err = f.getNextRequest(ctx)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, 4, len(f.queues[userID]))
+
+	// add one request to a second tenant queue
+	ctx2 := user.InjectOrgID(context.Background(), userID2)
+	err = f.queueRequest(ctx2, testReq(ctx2))
+	require.Nil(t, err)
+
+	// there should be no more unexpired requests in queue until the second tenant enqueues one.
+	req, err = f.getNextRequest(ctx)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+
+	// ensure either one or two queues are fully drained, depending on which was requested first
+	_, ok := f.queues[userID]
+	if ok {
+		// if the second user's queue was chosen for the last request,
+		// the first queue should still contain 4 (expired) requests.
+		require.Equal(t, 4, len(f.queues[userID]))
+	}
+	_, ok = f.queues[userID2]
+	require.Equal(t, false, ok)
+}


### PR DESCRIPTION
**What this PR does**:
In this PR I propose an alternative approach to #2082 to skip expired requests when popping the next request from the query-frontend queue.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
