### PR TITLE
Frontend: do not return 500 if the user request cancellation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [CHANGE] The frontend http server will now send 502 in case of deadline exceeded and 499 if the user requested cancellation. #2148
+* [CHANGE] The frontend http server will now send 502 in case of deadline exceeded and 499 if the user requested cancellation. #2156
 * [CHANGE] Config file changed to remove top level `config_store` field in favor of a nested `configdb` field. #2125
 * [CHANGE] Removed unnecessary `frontend.cache-split-interval` in favor of `querier.split-queries-by-interval` both to reduce configuration complexity and guarantee alignment of these two configs. Starting from now, `-querier.cache-results` may only be enabled in conjunction with `-querier.split-queries-by-interval` (previously the cache interval default was `24h` so if you want to preserve the same behaviour you should set `-querier.split-queries-by-interval=24h`). #2040
 * [CHANGE] Removed remaining support for using denormalised tokens in the ring. If you're still running ingesters with denormalised tokens (Cortex 0.4 or earlier, with `-ingester.normalise-tokens=false`), such ingesters will now be completely invisible to distributors and need to be either switched to Cortex 0.6.0 or later, or be configured to use normalised tokens. #2034

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] The frontend http server will now send 502 in case of deadline exceeded and 499 if the user requested cancellation. #2148
 * [CHANGE] Config file changed to remove top level `config_store` field in favor of a nested `configdb` field. #2125
 * [CHANGE] Removed unnecessary `frontend.cache-split-interval` in favor of `querier.split-queries-by-interval` both to reduce configuration complexity and guarantee alignment of these two configs. Starting from now, `-querier.cache-results` may only be enabled in conjunction with `-querier.split-queries-by-interval` (previously the cache interval default was `24h` so if you want to preserve the same behaviour you should set `-querier.split-queries-by-interval=24h`). #2040
 * [CHANGE] Removed remaining support for using denormalised tokens in the ring. If you're still running ingesters with denormalised tokens (Cortex 0.4 or earlier, with `-ingester.normalise-tokens=false`), such ingesters will now be completely invisible to distributors and need to be either switched to Cortex 0.6.0 or later, or be configured to use normalised tokens. #2034

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -38,8 +38,9 @@ var (
 		Help:      "Number of queries in the queue.",
 	})
 
-	errTooManyRequest     = httpgrpc.Errorf(http.StatusTooManyRequests, "too many outstanding requests")
-	statusRequestCanceled = 499
+	errTooManyRequest   = httpgrpc.Errorf(http.StatusTooManyRequests, "too many outstanding requests")
+	errCanceled         = httpgrpc.Errorf(499, context.Canceled.Error())
+	errDeadlineExceeded = httpgrpc.Errorf(http.StatusGatewayTimeout, context.DeadlineExceeded.Error())
 )
 
 // Config for a Frontend.
@@ -173,9 +174,9 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 func writeError(w http.ResponseWriter, err error) {
 	switch err {
 	case context.Canceled:
-		err = httpgrpc.Errorf(statusRequestCanceled, err.Error())
+		err = errCanceled
 	case context.DeadlineExceeded:
-		err = httpgrpc.Errorf(http.StatusGatewayTimeout, err.Error())
+		err = errDeadlineExceeded
 	default:
 	}
 	server.WriteError(w, err)

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -38,8 +38,11 @@ var (
 		Help:      "Number of queries in the queue.",
 	})
 
+	// StatusClientClosedRequest is the status code for when a client request cancellation of an http request
+	StatusClientClosedRequest = 499
+
 	errTooManyRequest   = httpgrpc.Errorf(http.StatusTooManyRequests, "too many outstanding requests")
-	errCanceled         = httpgrpc.Errorf(499, context.Canceled.Error())
+	errCanceled         = httpgrpc.Errorf(StatusClientClosedRequest, context.Canceled.Error())
 	errDeadlineExceeded = httpgrpc.Errorf(http.StatusGatewayTimeout, context.DeadlineExceeded.Error())
 )
 

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -38,8 +38,8 @@ var (
 		Help:      "Number of queries in the queue.",
 	})
 
-	errTooManyRequest = httpgrpc.Errorf(http.StatusTooManyRequests, "too many outstanding requests")
-	errCanceled       = httpgrpc.Errorf(http.StatusInternalServerError, "context cancelled")
+	errTooManyRequest     = httpgrpc.Errorf(http.StatusTooManyRequests, "too many outstanding requests")
+	statusRequestCanceled = 499
 )
 
 // Config for a Frontend.
@@ -151,14 +151,14 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 
 	startTime := time.Now()
 	resp, err := f.roundTripper.RoundTrip(r)
-	queryResponseTime := time.Now().Sub(startTime)
+	queryResponseTime := time.Since(startTime)
 
 	if f.cfg.LogQueriesLongerThan > 0 && queryResponseTime > f.cfg.LogQueriesLongerThan {
 		level.Info(f.log).Log("msg", "slow query", "org_id", userID, "url", fmt.Sprintf("http://%s", r.Host+r.RequestURI), "time_taken", queryResponseTime.String())
 	}
 
 	if err != nil {
-		server.WriteError(w, err)
+		writeError(w, err)
 		return
 	}
 
@@ -168,6 +168,17 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(resp.StatusCode)
 	io.Copy(w, resp.Body)
+}
+
+func writeError(w http.ResponseWriter, err error) {
+	switch err {
+	case context.Canceled:
+		err = httpgrpc.Errorf(statusRequestCanceled, err.Error())
+	case context.DeadlineExceeded:
+		err = httpgrpc.Errorf(http.StatusGatewayTimeout, err.Error())
+	default:
+	}
+	server.WriteError(w, err)
 }
 
 // RoundTrip implement http.Transport.
@@ -230,7 +241,7 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, req *ProcessRequest) (*Pro
 
 	select {
 	case <-ctx.Done():
-		return nil, errCanceled
+		return nil, ctx.Err()
 
 	case resp := <-request.response:
 		return resp, nil

--- a/pkg/querier/frontend/frontend_test.go
+++ b/pkg/querier/frontend/frontend_test.go
@@ -143,7 +143,7 @@ func TestFrontendCancelStatusCode(t *testing.T) {
 	}{
 		{http.StatusInternalServerError, errors.New("unknown")},
 		{http.StatusGatewayTimeout, context.DeadlineExceeded},
-		{499, context.Canceled},
+		{StatusClientClosedRequest, context.Canceled},
 		{http.StatusBadRequest, httpgrpc.Errorf(http.StatusBadRequest, "")},
 	} {
 		t.Run(test.err.Error(), func(t *testing.T) {

--- a/pkg/querier/frontend/frontend_test.go
+++ b/pkg/querier/frontend/frontend_test.go
@@ -142,7 +142,7 @@ func TestFrontendCancelStatusCode(t *testing.T) {
 	}{
 		{http.StatusInternalServerError, errors.New("unknown")},
 		{http.StatusGatewayTimeout, context.DeadlineExceeded},
-		{statusRequestCanceled, context.Canceled},
+		{499, context.Canceled},
 	} {
 		t.Run(test.err.Error(), func(t *testing.T) {
 			w := httptest.NewRecorder()

--- a/pkg/querier/frontend/frontend_test.go
+++ b/pkg/querier/frontend/frontend_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	jaeger "github.com/uber/jaeger-client-go"
 	"github.com/uber/jaeger-client-go/config"
+	"github.com/weaveworks/common/httpgrpc"
 	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/user"
@@ -143,6 +144,7 @@ func TestFrontendCancelStatusCode(t *testing.T) {
 		{http.StatusInternalServerError, errors.New("unknown")},
 		{http.StatusGatewayTimeout, context.DeadlineExceeded},
 		{499, context.Canceled},
+		{http.StatusBadRequest, httpgrpc.Errorf(http.StatusBadRequest, "")},
 	} {
 		t.Run(test.err.Error(), func(t *testing.T) {
 			w := httptest.NewRecorder()


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

As discussed with @pracucci , This change how the frontend handle cancellation/timeout. 

If the user request/upstream cancellation, then we don't throw a 5xx but a 499 instead (I'm happy to choose another code).

However in case of deadline exceeded/timeout, or unknown error we're sending back a 500.

The reason for this change is because if a user quickly cancel a request (page refresh) before it has time to answer the frontend will register this as an error (500) which I don't think we should.
