### PR TITLE
Use current directory for integration test shared dir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docker-images/
 website/public
 website/resources
 website/content/en/docs
+e2e_integration_test*

--- a/integration/e2e/scenario.go
+++ b/integration/e2e/scenario.go
@@ -34,7 +34,11 @@ type Scenario struct {
 func NewScenario(networkName string) (*Scenario, error) {
 	s := &Scenario{networkName: networkName}
 
-	tmpDir, err := ioutil.TempDir("", "e2e_integration_test")
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	tmpDir, err := ioutil.TempDir(dir, "e2e_integration_test")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Otherwise, you get the following error when using docker for mac:

```
alertmanager: docker: Error response from daemon: Mounts denied:
alertmanager: The path /var/folders/g5/3pb5_td927l61zm9xfmmtcp80000gn/T/e2e_integration_test388308663
alertmanager: is not shared from OS X and is not known to Docker.
alertmanager: You can configure shared paths from Docker -> Preferences... -> File Sharing.
alertmanager: See https://docs.docker.com/docker-for-mac/osxfs/#namespaces for more info.
alertmanager: .
alertmanager: time="2020-02-19T10:32:42Z" level=error msg="error waiting for container: context canceled"
```

Signed-off-by: Tom Wilkie <tom@grafana.com>