### PR TITLE
Added integration build tag to integration tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
           export CORTEX_IMAGE="${CORTEX_IMAGE_PREFIX}cortex:${CIRCLE_TAG:-$(./tools/image-tag)}"
           export CORTEX_CHECKOUT_DIR="/home/circleci/.go_workspace/src/github.com/cortexproject/cortex"
           echo "Running integration tests with image: $CORTEX_IMAGE"
-          go test -tags integration -timeout 300s -v -count=1 ./integration/...
+          go test -tags=integration -timeout 300s -v -count=1 ./integration/...
 
   build:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
           export CORTEX_IMAGE="${CORTEX_IMAGE_PREFIX}cortex:${CIRCLE_TAG:-$(./tools/image-tag)}"
           export CORTEX_CHECKOUT_DIR="/home/circleci/.go_workspace/src/github.com/cortexproject/cortex"
           echo "Running integration tests with image: $CORTEX_IMAGE"
-          go test -timeout 300s -v -count=1 ./integration/...
+          go test -tags integration -timeout 300s -v -count=1 ./integration/...
 
   build:
     <<: *defaults

--- a/integration/README.md
+++ b/integration/README.md
@@ -5,6 +5,12 @@
 - `CORTEX_IMAGE`: Docker image used to run Cortex in integration tests (defaults to `quay.io/cortexproject/cortex:latest`)
 - `CORTEX_CHECKOUT_DIR`: The absolute path of the Cortex repository local checkout (defaults to `$GOPATH/src/github.com/cortexproject/cortex`)
 
+## Running
+
+Integration tests have `integration` tag (`// +build integration` line followed by empty line on top of Go files), to avoid running them unintentionally, e.g. by `go test ./...` in main Cortex package.
+
+To run integration tests, one needs to run `go test -tags=integration ./integration/...` (or just `go test -tags=integration ./...` to run unit tests as well).
+
 ## Owners
 
 This package is used by other projects than Cortex. When modifying please ask @pracucci @bwplotka for review.

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/integration/api_config_test.go
+++ b/integration/api_config_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/integration/e2e/scenario_test.go
+++ b/integration/e2e/scenario_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package e2e_test
 
 import (

--- a/integration/e2e/service_test.go
+++ b/integration/e2e/service_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package e2e
 
 import (

--- a/integration/getting_started_single_process_config_test.go
+++ b/integration/getting_started_single_process_config_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/integration/ingester_flush_test.go
+++ b/integration/ingester_flush_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/integration/ingester_hand_over_test.go
+++ b/integration/ingester_hand_over_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/integration/package.go
+++ b/integration/package.go
@@ -1,0 +1,3 @@
+// This file doesn't have integration flag, and only exists to tell Go tooling the name of the package.
+
+package main

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/integration/util.go
+++ b/integration/util.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (


### PR DESCRIPTION
**What this PR does**: This PR adds `integration` tag to Cortex integration tests, so that they don't run by default when doing simple `go test ./...` in main Cortex directory.

To run integration tests too, one needs to use `-tags=integration` flag to `go test`.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
