### PR TITLE
Convert Cortex components to services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [CHANGE] Experimental TSDB: TSDB head compaction interval and concurrency is now configurable (defaults to 1 min interval and 5 concurrent head compactions). New options: `-experimental.tsdb.head-compaction-interval` and `-experimental.tsdb.head-compaction-concurrency`. #2172
 * [CHANGE] Remove fluentd-based billing infrastructure and flags such as `-distributor.enable-billing`. #1491
 * [CHANGE] Experimental TSDB: the querier in-memory index cache used by the experimental blocks storage shifted from per-tenant to per-querier. The `-experimental.tsdb.bucket-store.index-cache-size-bytes` now configures the per-querier index cache max size instead of a per-tenant cache and its default has been increased to 1GB. #2189
+* [CHANGE] If you are vendoring Cortex and use its components in your project, be aware that many Cortex components no longer start automatically when they are created. You may want to review PR and attached document. #2166
 * [FEATURE] Added a read-only local alertmanager config store using files named corresponding to their tenant id. #2125
 * [FEATURE] Added user sub rings to distribute users to a subset of ingesters. #1947
   * `--experimental.distributor.user-subring-size`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [CHANGE] Remove fluentd-based billing infrastructure and flags such as `-distributor.enable-billing`. #1491
 * [CHANGE] Experimental TSDB: the querier in-memory index cache used by the experimental blocks storage shifted from per-tenant to per-querier. The `-experimental.tsdb.bucket-store.index-cache-size-bytes` now configures the per-querier index cache max size instead of a per-tenant cache and its default has been increased to 1GB. #2189
 * [CHANGE] If you are vendoring Cortex and use its components in your project, be aware that many Cortex components no longer start automatically when they are created. You may want to review PR and attached document. #2166
+* [CHANGE] Cortex now has /ready probe for all services, not just ingester and querier as before. In single-binary mode, /ready reports 204 only if all components are running properly. #2166
 * [FEATURE] Added a read-only local alertmanager config store using files named corresponding to their tenant id. #2125
 * [FEATURE] Added user sub rings to distribute users to a subset of ingesters. #1947
   * `--experimental.distributor.user-subring-size`

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -110,7 +110,6 @@ func main() {
 	}
 
 	runtime.KeepAlive(ballast)
-	util.CheckFatal("stopping cortex", err)
 }
 
 // Parse -config.file and -config.expand-env option via separate flag set, to avoid polluting default one and calling flag.Parse on it twice.

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -34,8 +34,12 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 	// Start Cortex components (ingester running on previous version).
 	require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
 	tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorageFlags, previousVersionImage)
+	// Old table-manager doesn't expose a readiness probe, so we just check if the / returns 404
+	tableManager.SetReadinessProbe(e2e.NewReadinessProbe(e2ecortex.HttpPort, "/", 404))
 	ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, "")
 	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, "")
+	// Old ring didn't have /ready probe, use /ring instead.
+	distributor.SetReadinessProbe(e2e.NewReadinessProbe(e2ecortex.HttpPort, "/ring", 200))
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester1, tableManager))
 
 	// Wait until the first table-manager sync has completed, so that we're

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -35,11 +35,11 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 	require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
 	tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorageFlags, previousVersionImage)
 	// Old table-manager doesn't expose a readiness probe, so we just check if the / returns 404
-	tableManager.SetReadinessProbe(e2e.NewReadinessProbe(e2ecortex.HTTPPort, "/", 404))
+	tableManager.SetReadinessProbe(e2e.NewReadinessProbe(tableManager.HTTPPort(), "/", 404))
 	ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, "")
 	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, "")
 	// Old ring didn't have /ready probe, use /ring instead.
-	distributor.SetReadinessProbe(e2e.NewReadinessProbe(e2ecortex.HTTPPort, "/ring", 200))
+	distributor.SetReadinessProbe(e2e.NewReadinessProbe(distributor.HTTPPort(), "/ring", 200))
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester1, tableManager))
 
 	// Wait until the first table-manager sync has completed, so that we're

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -35,11 +35,11 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 	require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
 	tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorageFlags, previousVersionImage)
 	// Old table-manager doesn't expose a readiness probe, so we just check if the / returns 404
-	tableManager.SetReadinessProbe(e2e.NewReadinessProbe(e2ecortex.HttpPort, "/", 404))
+	tableManager.SetReadinessProbe(e2e.NewReadinessProbe(e2ecortex.HTTPPort, "/", 404))
 	ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, "")
 	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, "")
 	// Old ring didn't have /ready probe, use /ring instead.
-	distributor.SetReadinessProbe(e2e.NewReadinessProbe(e2ecortex.HttpPort, "/ring", 200))
+	distributor.SetReadinessProbe(e2e.NewReadinessProbe(e2ecortex.HTTPPort, "/ring", 200))
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester1, tableManager))
 
 	// Wait until the first table-manager sync has completed, so that we're

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -218,6 +218,10 @@ func (s *ConcreteService) NetworkEndpointFor(networkName string, port int) strin
 	return fmt.Sprintf("%s:%d", containerName(networkName, s.name), port)
 }
 
+func (s *ConcreteService) SetReadinessProbe(probe *ReadinessProbe) {
+	s.readiness = probe
+}
+
 func (s *ConcreteService) Ready() error {
 	if !s.isExpectedRunning() {
 		return fmt.Errorf("service %s is stopped", s.Name())

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -429,6 +429,10 @@ func (s *HTTPService) metrics() (_ string, err error) {
 	return string(body), err
 }
 
+func (s *HTTPService) HTTPPort() int {
+	return s.httpPort
+}
+
 func (s *HTTPService) HTTPEndpoint() string {
 	return s.Endpoint(s.httpPort)
 }

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -48,7 +48,7 @@ func NewDistributorWithConfigFile(name, consulAddress, configFile string, flags 
 			"-ring.store":      "consul",
 			"-consul.hostname": consulAddress,
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ring", 200),
+		e2e.NewReadinessProbe(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -143,8 +143,7 @@ func NewTableManagerWithConfigFile(name, configFile string, flags map[string]str
 			"-target":    "table-manager",
 			"-log.level": "warn",
 		}, flags))...),
-		// The table-manager doesn't expose a readiness probe, so we just check if the / returns 404
-		e2e.NewReadinessProbe(httpPort, "/", 404),
+		e2e.NewReadinessProbe(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -170,8 +169,7 @@ func NewQueryFrontendWithConfigFile(name, configFile string, flags map[string]st
 			"-target":    "query-frontend",
 			"-log.level": "warn",
 		}, flags))...),
-		// The query-frontend doesn't expose a readiness probe, so we just check if the / returns 404
-		e2e.NewReadinessProbe(httpPort, "/", 404),
+		e2e.NewReadinessProbe(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -207,8 +205,7 @@ func NewAlertmanager(name string, flags map[string]string, image string) *Cortex
 			"-target":    "alertmanager",
 			"-log.level": "warn",
 		}, flags))...),
-		// The alertmanager doesn't expose a readiness probe, so we just check if the / returns 404
-		e2e.NewReadinessProbe(httpPort, "/", 404),
+		e2e.NewReadinessProbe(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	httpPort = 80
+	HttpPort = 80
 	grpcPort = 9095
 )
 
@@ -48,8 +48,8 @@ func NewDistributorWithConfigFile(name, consulAddress, configFile string, flags 
 			"-ring.store":      "consul",
 			"-consul.hostname": consulAddress,
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
-		httpPort,
+		e2e.NewReadinessProbe(HttpPort, "/ready", 204),
+		HttpPort,
 		grpcPort,
 	)
 }
@@ -83,8 +83,8 @@ func NewQuerierWithConfigFile(name, consulAddress, configFile string, flags map[
 			"-querier.frontend-client.backoff-retries":    "1",
 			"-querier.worker-parallelism":                 "1",
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
-		httpPort,
+		e2e.NewReadinessProbe(HttpPort, "/ready", 204),
+		HttpPort,
 		grpcPort,
 	)
 }
@@ -117,8 +117,8 @@ func NewIngesterWithConfigFile(name, consulAddress, configFile string, flags map
 			"-ring.store":      "consul",
 			"-consul.hostname": consulAddress,
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
-		httpPort,
+		e2e.NewReadinessProbe(HttpPort, "/ready", 204),
+		HttpPort,
 		grpcPort,
 	)
 }
@@ -143,8 +143,8 @@ func NewTableManagerWithConfigFile(name, configFile string, flags map[string]str
 			"-target":    "table-manager",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
-		httpPort,
+		e2e.NewReadinessProbe(HttpPort, "/ready", 204),
+		HttpPort,
 		grpcPort,
 	)
 }
@@ -169,8 +169,8 @@ func NewQueryFrontendWithConfigFile(name, configFile string, flags map[string]st
 			"-target":    "query-frontend",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
-		httpPort,
+		e2e.NewReadinessProbe(HttpPort, "/ready", 204),
+		HttpPort,
 		grpcPort,
 	)
 }
@@ -205,8 +205,8 @@ func NewAlertmanager(name string, flags map[string]string, image string) *Cortex
 			"-target":    "alertmanager",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
-		httpPort,
+		e2e.NewReadinessProbe(HttpPort, "/ready", 204),
+		HttpPort,
 		grpcPort,
 	)
 }

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	HttpPort = 80
+	HTTPPort = 80
 	grpcPort = 9095
 )
 
@@ -48,8 +48,8 @@ func NewDistributorWithConfigFile(name, consulAddress, configFile string, flags 
 			"-ring.store":      "consul",
 			"-consul.hostname": consulAddress,
 		}, flags))...),
-		e2e.NewReadinessProbe(HttpPort, "/ready", 204),
-		HttpPort,
+		e2e.NewReadinessProbe(HTTPPort, "/ready", 204),
+		HTTPPort,
 		grpcPort,
 	)
 }
@@ -83,8 +83,8 @@ func NewQuerierWithConfigFile(name, consulAddress, configFile string, flags map[
 			"-querier.frontend-client.backoff-retries":    "1",
 			"-querier.worker-parallelism":                 "1",
 		}, flags))...),
-		e2e.NewReadinessProbe(HttpPort, "/ready", 204),
-		HttpPort,
+		e2e.NewReadinessProbe(HTTPPort, "/ready", 204),
+		HTTPPort,
 		grpcPort,
 	)
 }
@@ -117,8 +117,8 @@ func NewIngesterWithConfigFile(name, consulAddress, configFile string, flags map
 			"-ring.store":      "consul",
 			"-consul.hostname": consulAddress,
 		}, flags))...),
-		e2e.NewReadinessProbe(HttpPort, "/ready", 204),
-		HttpPort,
+		e2e.NewReadinessProbe(HTTPPort, "/ready", 204),
+		HTTPPort,
 		grpcPort,
 	)
 }
@@ -143,8 +143,8 @@ func NewTableManagerWithConfigFile(name, configFile string, flags map[string]str
 			"-target":    "table-manager",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(HttpPort, "/ready", 204),
-		HttpPort,
+		e2e.NewReadinessProbe(HTTPPort, "/ready", 204),
+		HTTPPort,
 		grpcPort,
 	)
 }
@@ -169,8 +169,8 @@ func NewQueryFrontendWithConfigFile(name, configFile string, flags map[string]st
 			"-target":    "query-frontend",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(HttpPort, "/ready", 204),
-		HttpPort,
+		e2e.NewReadinessProbe(HTTPPort, "/ready", 204),
+		HTTPPort,
 		grpcPort,
 	)
 }
@@ -205,8 +205,8 @@ func NewAlertmanager(name string, flags map[string]string, image string) *Cortex
 			"-target":    "alertmanager",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(HttpPort, "/ready", 204),
-		HttpPort,
+		e2e.NewReadinessProbe(HTTPPort, "/ready", 204),
+		HTTPPort,
 		grpcPort,
 	)
 }

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	HTTPPort = 80
+	httpPort = 80
 	grpcPort = 9095
 )
 
@@ -48,8 +48,8 @@ func NewDistributorWithConfigFile(name, consulAddress, configFile string, flags 
 			"-ring.store":      "consul",
 			"-consul.hostname": consulAddress,
 		}, flags))...),
-		e2e.NewReadinessProbe(HTTPPort, "/ready", 204),
-		HTTPPort,
+		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		httpPort,
 		grpcPort,
 	)
 }
@@ -83,8 +83,8 @@ func NewQuerierWithConfigFile(name, consulAddress, configFile string, flags map[
 			"-querier.frontend-client.backoff-retries":    "1",
 			"-querier.worker-parallelism":                 "1",
 		}, flags))...),
-		e2e.NewReadinessProbe(HTTPPort, "/ready", 204),
-		HTTPPort,
+		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		httpPort,
 		grpcPort,
 	)
 }
@@ -117,8 +117,8 @@ func NewIngesterWithConfigFile(name, consulAddress, configFile string, flags map
 			"-ring.store":      "consul",
 			"-consul.hostname": consulAddress,
 		}, flags))...),
-		e2e.NewReadinessProbe(HTTPPort, "/ready", 204),
-		HTTPPort,
+		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		httpPort,
 		grpcPort,
 	)
 }
@@ -143,8 +143,8 @@ func NewTableManagerWithConfigFile(name, configFile string, flags map[string]str
 			"-target":    "table-manager",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(HTTPPort, "/ready", 204),
-		HTTPPort,
+		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		httpPort,
 		grpcPort,
 	)
 }
@@ -169,8 +169,8 @@ func NewQueryFrontendWithConfigFile(name, configFile string, flags map[string]st
 			"-target":    "query-frontend",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(HTTPPort, "/ready", 204),
-		HTTPPort,
+		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		httpPort,
 		grpcPort,
 	)
 }
@@ -205,8 +205,8 @@ func NewAlertmanager(name string, flags map[string]string, image string) *Cortex
 			"-target":    "alertmanager",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(HTTPPort, "/ready", 204),
-		HTTPPort,
+		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		httpPort,
 		grpcPort,
 	)
 }

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -19,12 +19,12 @@ import (
 	"github.com/prometheus/alertmanager/cluster"
 	amconfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/pstibrany/services"
 	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 var backoffConfig = util.BackoffConfig{
@@ -129,7 +129,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet) {
 // A MultitenantAlertmanager manages Alertmanager instances for multiple
 // organizations.
 type MultitenantAlertmanager struct {
-	services.BasicService
+	services.Service
 
 	cfg *MultitenantAlertmanagerConfig
 
@@ -220,7 +220,7 @@ func createMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig, fallbackC
 		registerer.MustRegister(am.metrics)
 	}
 
-	services.InitTimerService(&am.BasicService, am.cfg.PollInterval, am.starting, am.stopping, am.iteration)
+	am.Service = services.NewTimerService(am.cfg.PollInterval, am.starting, am.iteration, am.stopping)
 	return am
 }
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -235,6 +235,8 @@ func (am *MultitenantAlertmanager) iteration(ctx context.Context) error {
 	if err != nil {
 		level.Warn(am.logger).Log("msg", "error updating configs", "err", err)
 	}
+	// Returning error here would stop "MultitenantAlertmanager" service completely,
+	// so we return nil to keep service running.
 	return nil
 }
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -201,6 +201,10 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig, logger log.L
 		return nil, err
 	}
 
+	return createMultitenantAlertmanager(cfg, fallbackConfig, peer, store, logger, registerer), nil
+}
+
+func createMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig, fallbackConfig []byte, peer *cluster.Peer, store AlertStore, logger log.Logger, registerer prometheus.Registerer) *MultitenantAlertmanager {
 	am := &MultitenantAlertmanager{
 		cfg:            cfg,
 		fallbackConfig: string(fallbackConfig),
@@ -217,7 +221,7 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig, logger log.L
 	}
 
 	services.InitTimerService(&am.BasicService, am.cfg.PollInterval, am.starting, am.stopping, am.iteration)
-	return am, nil
+	return am
 }
 
 func (am *MultitenantAlertmanager) starting(ctx context.Context) error {
@@ -231,6 +235,7 @@ func (am *MultitenantAlertmanager) iteration(ctx context.Context) error {
 	if err != nil {
 		level.Warn(am.logger).Log("msg", "error updating configs", "err", err)
 	}
+	return nil
 }
 
 // Stop stops the MultitenantAlertmanager.

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -238,7 +238,7 @@ func (am *MultitenantAlertmanager) iteration(ctx context.Context) error {
 	return nil
 }
 
-// Stop stops the MultitenantAlertmanager.
+// stopping runs when MultitenantAlertmanager transitions to Stopping state.
 func (am *MultitenantAlertmanager) stopping() error {
 	am.alertmanagersMtx.Lock()
 	for _, am := range am.alertmanagers {

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -112,7 +112,7 @@ func TestLoadAllConfigs(t *testing.T) {
 
 	userAM, exists := am.alertmanagers["user3"]
 	require.True(t, exists)
-	require.False(t, userAM.isActive())
+	require.False(t, userAM.IsActive())
 
 	// Ensure when a 3rd config is re-added, it is synced correctly
 	mockStore.configs["user3"] = alerts.AlertConfigDesc{
@@ -129,5 +129,5 @@ func TestLoadAllConfigs(t *testing.T) {
 
 	userAM, exists = am.alertmanagers["user3"]
 	require.True(t, exists)
-	require.True(t, userAM.isActive())
+	require.True(t, userAM.IsActive())
 }

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/go-kit/kit/log"
@@ -65,20 +64,10 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 
-	am := &MultitenantAlertmanager{
-		cfg: &MultitenantAlertmanagerConfig{
-			ExternalURL: externalURL,
-			DataDir:     tempDir,
-		},
-		store:            mockStore,
-		cfgs:             map[string]alerts.AlertConfigDesc{},
-		alertmanagersMtx: sync.Mutex{},
-		alertmanagers:    map[string]*Alertmanager{},
-		logger:           log.NewNopLogger(),
-		stop:             make(chan struct{}),
-		done:             make(chan struct{}),
-		metrics:          newAlertmanagerMetrics(),
-	}
+	am := createMultitenantAlertmanager(&MultitenantAlertmanagerConfig{
+		ExternalURL: externalURL,
+		DataDir:     tempDir,
+	}, nil, nil, mockStore, log.NewNopLogger(), nil)
 
 	// Ensure the configs are synced correctly
 	require.NoError(t, am.updateConfigs())

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -163,7 +163,7 @@ func (m *TableManager) starting(ctx context.Context) error {
 // Stop the TableManager
 func (m *TableManager) stopping() error {
 	if m.bucketRetentionLoop != nil {
-		_ = services.StopAndAwaitTerminated(context.Background(), m.bucketRetentionLoop)
+		return services.StopAndAwaitTerminated(context.Background(), m.bucketRetentionLoop)
 	}
 	return nil
 }

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -206,6 +206,8 @@ func (m *TableManager) bucketRetentionIteration(ctx context.Context) error {
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error enforcing filesystem retention", "err", err)
 	}
+
+	// don't return error, otherwise timer service would stop.
 	return nil
 }
 

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -201,7 +201,7 @@ func (m *TableManager) loop(ctx context.Context) error {
 
 // single iteration of bucket retention loop
 func (m *TableManager) bucketRetentionIteration(ctx context.Context) error {
-	err := m.bucketClient.DeleteChunksBefore(context.Background(), mtime.Now().Add(-m.cfg.RetentionPeriod))
+	err := m.bucketClient.DeleteChunksBefore(ctx, mtime.Now().Add(-m.cfg.RetentionPeriod))
 
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error enforcing filesystem retention", "err", err)

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -13,11 +13,11 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"github.com/pstibrany/services"
 	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/mtime"
 
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 const (
@@ -116,7 +116,7 @@ func (cfg *ProvisionConfig) RegisterFlags(argPrefix string, f *flag.FlagSet) {
 
 // TableManager creates and manages the provisioned throughput on DynamoDB tables
 type TableManager struct {
-	services.BasicService
+	services.Service
 
 	client       TableClient
 	cfg          TableManagerConfig
@@ -147,7 +147,7 @@ func NewTableManager(cfg TableManagerConfig, schemaCfg SchemaConfig, maxChunkAge
 		bucketClient: objectClient,
 	}
 
-	services.InitBasicService(&tm.BasicService, tm.starting, tm.loop, tm.stopping)
+	tm.Service = services.NewBasicService(tm.starting, tm.loop, tm.stopping)
 	return tm, nil
 }
 

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -154,8 +154,12 @@ func NewTableManager(cfg TableManagerConfig, schemaCfg SchemaConfig, maxChunkAge
 // Start the TableManager
 func (m *TableManager) starting(ctx context.Context) error {
 	if m.bucketClient != nil && m.cfg.RetentionPeriod != 0 && m.cfg.RetentionDeletesEnabled {
-		m.bucketRetentionLoop = services.NewTimerService(bucketRetentionEnforcementInterval, nil, nil, m.bucketRetentionIteration)
-		return m.bucketRetentionLoop.StartAsync(ctx)
+		m.bucketRetentionLoop = services.NewTimerService(bucketRetentionEnforcementInterval, nil, m.bucketRetentionIteration, nil)
+		err := m.bucketRetentionLoop.StartAsync(ctx)
+		if err == nil {
+			err = m.bucketRetentionLoop.AwaitRunning(ctx)
+		}
+		return err
 	}
 	return nil
 }

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -155,11 +155,7 @@ func NewTableManager(cfg TableManagerConfig, schemaCfg SchemaConfig, maxChunkAge
 func (m *TableManager) starting(ctx context.Context) error {
 	if m.bucketClient != nil && m.cfg.RetentionPeriod != 0 && m.cfg.RetentionDeletesEnabled {
 		m.bucketRetentionLoop = services.NewTimerService(bucketRetentionEnforcementInterval, nil, m.bucketRetentionIteration, nil)
-		err := m.bucketRetentionLoop.StartAsync(ctx)
-		if err == nil {
-			err = m.bucketRetentionLoop.AwaitRunning(ctx)
-		}
-		return err
+		return services.StartAndAwaitRunning(ctx, m.bucketRetentionLoop)
 	}
 	return nil
 }
@@ -167,8 +163,7 @@ func (m *TableManager) starting(ctx context.Context) error {
 // Stop the TableManager
 func (m *TableManager) stopping() error {
 	if m.bucketRetentionLoop != nil {
-		m.bucketRetentionLoop.StopAsync()
-		_ = m.bucketRetentionLoop.AwaitTerminated(context.Background())
+		_ = services.StopAndAwaitTerminated(context.Background(), m.bucketRetentionLoop)
 	}
 	return nil
 }

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -200,9 +200,8 @@ func (c *Compactor) starting(ctx context.Context) error {
 
 func (c *Compactor) stopping() error {
 	if c.subservices != nil {
-		_ = services.StopManagerAndAwaitStopped(context.Background(), c.subservices)
+		return services.StopManagerAndAwaitStopped(context.Background(), c.subservices)
 	}
-
 	return nil
 }
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/tsdb"
-	"github.com/pstibrany/services"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/compact"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
@@ -23,6 +22,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring"
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 // Config holds the Compactor config.
@@ -66,7 +66,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 // Compactor is a multi-tenant TSDB blocks compactor based on Thanos.
 type Compactor struct {
-	services.BasicService
+	services.Service
 
 	compactorCfg Config
 	storageCfg   cortex_tsdb.Config
@@ -155,7 +155,7 @@ func newCompactor(
 		c.syncerMetrics = newSyncerMetrics(registerer)
 	}
 
-	services.InitBasicService(&c.BasicService, c.starting, c.running, c.stopping)
+	c.Service = services.NewBasicService(c.starting, c.running, c.stopping)
 
 	return c, nil
 }

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -73,7 +73,7 @@ type Compactor struct {
 	logger       log.Logger
 
 	// function that creates bucket client and TSDB compactor using the context.
-	// Useful for injecting mock compactor.
+	// Useful for injecting mock objects from tests.
 	createBucketClientAndTsdbCompactor func(ctx context.Context) (objstore.Bucket, tsdb.Compactor, error)
 
 	// Underlying compactor used to compact TSDB blocks.

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -181,10 +181,7 @@ func (c *Compactor) starting(ctx context.Context) error {
 
 		c.subservices, err = services.NewManager(c.ringLifecycler, c.ring)
 		if err == nil {
-			err = c.subservices.StartAsync(ctx)
-			if err == nil {
-				err = c.subservices.AwaitHealthy(ctx)
-			}
+			err = services.StartManagerAndAwaitHealthy(ctx, c.subservices)
 		}
 
 		if err != nil {
@@ -203,8 +200,7 @@ func (c *Compactor) starting(ctx context.Context) error {
 
 func (c *Compactor) stopping() error {
 	if c.subservices != nil {
-		c.subservices.StopAsync()
-		_ = c.subservices.AwaitStopped(context.Background())
+		_ = services.StopManagerAndAwaitStopped(context.Background(), c.subservices)
 	}
 
 	return nil

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -133,6 +133,7 @@ func newCompactor(
 		compactorCfg:                       compactorCfg,
 		storageCfg:                         storageCfg,
 		logger:                             logger,
+		syncerMetrics:                      newSyncerMetrics(registerer),
 		createBucketClientAndTsdbCompactor: createBucketClientAndTsdbCompactor,
 
 		compactionRunsStarted: prometheus.NewCounter(prometheus.CounterOpts{
@@ -152,7 +153,6 @@ func newCompactor(
 	// Register metrics.
 	if registerer != nil {
 		registerer.MustRegister(c.compactionRunsStarted, c.compactionRunsCompleted, c.compactionRunsFailed)
-		c.syncerMetrics = newSyncerMetrics(registerer)
 	}
 
 	c.Service = services.NewBasicService(c.starting, c.running, c.stopping)

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/pstibrany/services"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/compact"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
@@ -66,9 +67,15 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 // Compactor is a multi-tenant TSDB blocks compactor based on Thanos.
 type Compactor struct {
+	services.BasicService
+
 	compactorCfg Config
 	storageCfg   cortex_tsdb.Config
 	logger       log.Logger
+
+	// function that craeates TSDB compactor using the context.
+	// Useful for injecting mock compactor.
+	createTsdbCompactor func(ctx context.Context) (tsdb.Compactor, error)
 
 	// Underlying compactor used to compact TSDB blocks.
 	tsdbCompactor tsdb.Compactor
@@ -79,14 +86,12 @@ type Compactor struct {
 	// Wait group used to wait until the internal go routine completes.
 	runner sync.WaitGroup
 
-	// Context used to run compaction and its cancel function to
-	// safely interrupt it on shutdown.
-	ctx       context.Context
-	cancelCtx context.CancelFunc
-
 	// Ring used for sharding compactions.
 	ringLifecycler *ring.Lifecycler
 	ring           *ring.Ring
+
+	// Manager sub-services (ring, lifecycler)
+	servMgr *services.Manager
 
 	// Metrics.
 	compactionRunsStarted   prometheus.Counter
@@ -111,13 +116,9 @@ func NewCompactor(compactorCfg Config, storageCfg cortex_tsdb.Config, logger log
 		bucketClient = objstore.BucketWithMetrics( /* bucket label value */ "", bucketClient, prometheus.WrapRegistererWithPrefix("cortex_compactor_", registerer))
 	}
 
-	tsdbCompactor, err := tsdb.NewLeveledCompactor(ctx, registerer, logger, compactorCfg.BlockRanges.ToMilliseconds(), downsample.NewPool())
-	if err != nil {
-		cancelCtx()
-		return nil, errors.Wrap(err, "failed to create TSDB compactor")
-	}
-
-	cortexCompactor, err := newCompactor(ctx, cancelCtx, compactorCfg, storageCfg, bucketClient, tsdbCompactor, logger, registerer)
+	cortexCompactor, err := newCompactor(compactorCfg, storageCfg, bucketClient, logger, registerer, func(ctx context.Context) (tsdb.Compactor, error) {
+		return tsdb.NewLeveledCompactor(ctx, registerer, logger, compactorCfg.BlockRanges.ToMilliseconds(), downsample.NewPool())
+	})
 	if err != nil {
 		cancelCtx()
 		return nil, errors.Wrap(err, "failed to create Cortex blocks compactor")
@@ -127,23 +128,20 @@ func NewCompactor(compactorCfg Config, storageCfg cortex_tsdb.Config, logger log
 }
 
 func newCompactor(
-	ctx context.Context,
-	cancelCtx context.CancelFunc,
 	compactorCfg Config,
 	storageCfg cortex_tsdb.Config,
 	bucketClient objstore.Bucket,
-	tsdbCompactor tsdb.Compactor,
 	logger log.Logger,
 	registerer prometheus.Registerer,
+	createTsdbCompactor func(ctx context.Context) (tsdb.Compactor, error),
 ) (*Compactor, error) {
 	c := &Compactor{
-		compactorCfg:  compactorCfg,
-		storageCfg:    storageCfg,
-		logger:        logger,
-		bucketClient:  bucketClient,
-		tsdbCompactor: tsdbCompactor,
-		ctx:           ctx,
-		cancelCtx:     cancelCtx,
+		compactorCfg:        compactorCfg,
+		storageCfg:          storageCfg,
+		logger:              logger,
+		createTsdbCompactor: createTsdbCompactor,
+		bucketClient:        bucketClient,
+
 		compactionRunsStarted: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "cortex_compactor_runs_started_total",
 			Help: "Total number of compaction runs started.",
@@ -158,80 +156,76 @@ func newCompactor(
 		}),
 	}
 
-	// Initialize the compactors ring if sharding is enabled.
-	if compactorCfg.ShardingEnabled {
-		lifecyclerCfg := compactorCfg.ShardingRing.ToLifecyclerConfig()
-		lifecycler, err := ring.NewLifecycler(lifecyclerCfg, ring.NewNoopFlushTransferer(), "compactor", ring.CompactorRingKey, false)
-		if err == nil {
-			err = lifecycler.StartAsync(context.Background())
-		}
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to initialize compactor ring lifecycler")
-		}
-
-		c.ringLifecycler = lifecycler
-
-		ring, err := ring.New(lifecyclerCfg.RingConfig, "compactor", ring.CompactorRingKey)
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to initialize compactor ring")
-		}
-		err = ring.StartAsync(context.Background())
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to start compactor ring")
-		}
-
-		c.ring = ring
-	}
-
 	// Register metrics.
 	if registerer != nil {
 		registerer.MustRegister(c.compactionRunsStarted, c.compactionRunsCompleted, c.compactionRunsFailed)
 		c.syncerMetrics = newSyncerMetrics(registerer)
 	}
 
+	services.InitBasicService(&c.BasicService, c.starting, c.running, c.stopping)
+
 	return c, nil
 }
 
 // Start the compactor.
-func (c *Compactor) Start() {
-	// Start the compactor loop.
-	c.runner.Add(1)
-	go c.run()
-}
+func (c *Compactor) starting(ctx context.Context) error {
+	// Initialize the compactors ring if sharding is enabled.
+	if c.compactorCfg.ShardingEnabled {
+		lifecyclerCfg := c.compactorCfg.ShardingRing.ToLifecyclerConfig()
+		lifecycler, err := ring.NewLifecycler(lifecyclerCfg, ring.NewNoopFlushTransferer(), "compactor", ring.CompactorRingKey, false)
+		if err != nil {
+			return errors.Wrap(err, "unable to initialize compactor ring lifecycler")
+		}
 
-// Stop the compactor and waits until done. This may take some time
-// if there's a on-going compaction.
-func (c *Compactor) Stop() {
-	c.cancelCtx()
-	c.runner.Wait()
+		c.ringLifecycler = lifecycler
 
-	// Shutdown the ring lifecycler (if any)
-	if c.ringLifecycler != nil {
-		c.ringLifecycler.StopAsync()
-		_ = c.ringLifecycler.AwaitTerminated(context.Background())
+		ring, err := ring.New(lifecyclerCfg.RingConfig, "compactor", ring.CompactorRingKey)
+		if err != nil {
+			return errors.Wrap(err, "unable to initialize compactor ring")
+		}
+
+		c.ring = ring
+
+		c.servMgr, err = services.NewManager(c.ringLifecycler, c.ring)
+		if err == nil {
+			err = c.servMgr.StartAsync(ctx)
+			if err == nil {
+				err = c.servMgr.AwaitHealthy(ctx)
+			}
+		}
+
+		if err != nil {
+			return errors.Wrap(err, "unable to initialize service manager")
+		}
 	}
 
-	if c.ring != nil {
-		c.ring.StopAsync()
-		_ = c.ring.AwaitTerminated(context.Background())
-	}
+	var err error
+	c.tsdbCompactor, err = c.createTsdbCompactor(ctx)
+	return errors.Wrap(err, "failed to create TSDB compactor")
 }
 
-func (c *Compactor) run() {
-	defer c.runner.Done()
+func (c *Compactor) stopping() error {
+	if c.servMgr != nil {
+		c.servMgr.StopAsync()
+		_ = c.servMgr.AwaitStopped(context.Background())
+	}
 
+	return nil
+}
+
+func (c *Compactor) running(ctx context.Context) error {
 	// If sharding is enabled we should wait until this instance is
 	// ACTIVE within the ring.
 	if c.compactorCfg.ShardingEnabled {
 		level.Info(c.logger).Log("msg", "waiting until compactor is ACTIVE in the ring")
-		if err := c.waitRingActive(); err != nil {
-			return
+		if err := c.waitRingActive(ctx); err != nil {
+			return err
 		}
 		level.Info(c.logger).Log("msg", "compactor is ACTIVE in the ring")
 	}
 
 	// Run an initial compaction before starting the interval.
-	c.compactUsersWithRetries(c.ctx)
+	c.compactUsersWithRetries(ctx)
 
 	ticker := time.NewTicker(c.compactorCfg.CompactionInterval)
 	defer ticker.Stop()
@@ -239,9 +233,9 @@ func (c *Compactor) run() {
 	for {
 		select {
 		case <-ticker.C:
-			c.compactUsersWithRetries(c.ctx)
-		case <-c.ctx.Done():
-			return
+			c.compactUsersWithRetries(ctx)
+		case <-ctx.Done():
+			return nil
 		}
 	}
 }
@@ -391,7 +385,7 @@ func (c *Compactor) ownUser(userID string) (bool, error) {
 	return rs.Ingesters[0].Addr == c.ringLifecycler.Addr, nil
 }
 
-func (c *Compactor) waitRingActive() error {
+func (c *Compactor) waitRingActive(ctx context.Context) error {
 	for {
 		// Check if the ingester is ACTIVE in the ring and our ring client
 		// has detected it.
@@ -406,8 +400,8 @@ func (c *Compactor) waitRingActive() error {
 		select {
 		case <-time.After(time.Second):
 			// Nothing to do
-		case <-c.ctx.Done():
-			return c.ctx.Err()
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 }

--- a/pkg/compactor/compactor_http.go
+++ b/pkg/compactor/compactor_http.go
@@ -1,13 +1,17 @@
 package compactor
 
 import (
+	"html/template"
 	"net/http"
 
 	"github.com/go-kit/kit/log/level"
+	"github.com/pstibrany/services"
+
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
-const (
-	shardingDisabledPage = `
+var (
+	compactorStatusPageTemplate = template.Must(template.New("main").Parse(`
 	<!DOCTYPE html>
 	<html>
 		<head>
@@ -16,20 +20,34 @@ const (
 		</head>
 		<body>
 			<h1>Cortex Compactor Ring</h1>
-			<p>Compactor has no ring because sharding is disabled.</p>
+			<p>{{ .Message }}</p>
 		</body>
-	</html>
-	`
+	</html>`))
 )
 
+func writeMessage(w http.ResponseWriter, message string) {
+	w.WriteHeader(http.StatusOK)
+	err := compactorStatusPageTemplate.Execute(w, struct {
+		Message string
+	}{Message: message})
+
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "unable to serve compactor ring page", "err", err)
+	}
+}
+
 func (c *Compactor) RingHandler(w http.ResponseWriter, req *http.Request) {
-	if c.compactorCfg.ShardingEnabled {
-		c.ring.ServeHTTP(w, req)
+	if !c.compactorCfg.ShardingEnabled {
+		writeMessage(w, "Compactor has no ring because sharding is disabled.")
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write([]byte(shardingDisabledPage)); err != nil {
-		level.Error(c.logger).Log("msg", "unable to serve compactor ring page", "err", err)
+	if c.State() != services.Running {
+		// we cannot read the ring before Compactor is in Running state,
+		// because that would lead to race condition.
+		writeMessage(w, "Compactor is not running yet.")
+		return
 	}
+
+	c.ring.ServeHTTP(w, req)
 }

--- a/pkg/compactor/compactor_http.go
+++ b/pkg/compactor/compactor_http.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 
 	"github.com/go-kit/kit/log/level"
-	"github.com/pstibrany/services"
 
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 var (

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/services"
 	cortex_testutil "github.com/cortexproject/cortex/pkg/util/test"
 )
 
@@ -82,8 +83,7 @@ func TestCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 
 	c, _, logs, registry, cleanup := prepare(t, prepareConfig(), bucketClient)
 	defer cleanup()
-	require.NoError(t, c.StartAsync(context.Background()))
-	require.NoError(t, c.AwaitRunning(context.Background()))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
 	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
@@ -174,8 +174,7 @@ func TestCompactor_ShouldRetryOnFailureWhileDiscoveringUsersFromBucket(t *testin
 
 	c, _, logs, registry, cleanup := prepare(t, prepareConfig(), bucketClient)
 	defer cleanup()
-	require.NoError(t, c.StartAsync(context.Background()))
-	require.NoError(t, c.AwaitRunning(context.Background()))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until all retry attempts have completed.
 	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
@@ -277,8 +276,7 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 
 	c, tsdbCompactor, logs, registry, cleanup := prepare(t, prepareConfig(), bucketClient)
 	defer cleanup()
-	require.NoError(t, c.StartAsync(context.Background()))
-	require.NoError(t, c.AwaitRunning(context.Background()))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Mock the compactor as if there's no compaction to do,
 	// in order to simplify tests (all in all, we just want to
@@ -351,8 +349,7 @@ func TestCompactor_ShouldCompactAllUsersOnShardingEnabledButOnlyOneInstanceRunni
 
 	c, tsdbCompactor, logs, _, cleanup := prepare(t, cfg, bucketClient)
 	defer cleanup()
-	require.NoError(t, c.StartAsync(context.Background()))
-	require.NoError(t, c.AwaitRunning(context.Background()))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Mock the compactor as if there's no compaction to do,
 	// in order to simplify tests (all in all, we just want to
@@ -440,8 +437,7 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 
 	// Start all compactors
 	for _, c := range compactors {
-		require.NoError(t, c.StartAsync(context.Background()))
-		require.NoError(t, c.AwaitRunning(context.Background()))
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 	}
 
 	// Wait until each compactor sees all ACTIVE compactors in the ring

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/objstore"
 	"gopkg.in/yaml.v2"
 
 	"github.com/cortexproject/cortex/pkg/ring"
@@ -546,8 +547,8 @@ func prepare(t *testing.T, compactorCfg Config, bucketClient *cortex_tsdb.Bucket
 	logger := log.NewLogfmtLogger(logs)
 	registry := prometheus.NewRegistry()
 
-	c, err := newCompactor(compactorCfg, storageCfg, bucketClient, logger, registry, func(ctx context.Context) (tsdb.Compactor, error) {
-		return tsdbCompactor, nil
+	c, err := newCompactor(compactorCfg, storageCfg, logger, registry, func(ctx context.Context) (objstore.Bucket, tsdb.Compactor, error) {
+		return bucketClient, tsdbCompactor, nil
 	})
 	require.NoError(t, err)
 

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -418,7 +418,7 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 		cfg.ShardingRing.KVStore.Mock = kvstore
 
 		c, tsdbCompactor, l, _, cleanup := prepare(t, cfg, bucketClient)
-		defer services.StopAndAwaitTerminated(context.Background(), c)
+		defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
 		defer cleanup()
 
 		compactors = append(compactors, c)

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -90,8 +90,7 @@ func TestCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 		return prom_testutil.ToFloat64(c.compactionRunsCompleted)
 	})
 
-	c.StopAsync()
-	require.NoError(t, c.AwaitTerminated(context.Background()))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
 
 	assert.Equal(t, []string{
 		`level=info msg="discovering users from bucket"`,
@@ -181,8 +180,7 @@ func TestCompactor_ShouldRetryOnFailureWhileDiscoveringUsersFromBucket(t *testin
 		return prom_testutil.ToFloat64(c.compactionRunsFailed)
 	})
 
-	c.StopAsync()
-	require.NoError(t, c.AwaitTerminated(context.Background()))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
 
 	// Ensure the bucket iteration has been retried the configured number of times.
 	bucketClient.AssertNumberOfCalls(t, "Iter", 3)
@@ -289,8 +287,7 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 		return prom_testutil.ToFloat64(c.compactionRunsCompleted)
 	})
 
-	c.StopAsync()
-	require.NoError(t, c.AwaitTerminated(context.Background()))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
 
 	// Ensure a plan has been executed for the blocks of each user.
 	tsdbCompactor.AssertNumberOfCalls(t, "Plan", 2)
@@ -362,8 +359,7 @@ func TestCompactor_ShouldCompactAllUsersOnShardingEnabledButOnlyOneInstanceRunni
 		return prom_testutil.ToFloat64(c.compactionRunsCompleted)
 	})
 
-	c.StopAsync()
-	require.NoError(t, c.AwaitTerminated(context.Background()))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
 
 	// Ensure a plan has been executed for the blocks of each user.
 	tsdbCompactor.AssertNumberOfCalls(t, "Plan", 2)
@@ -422,7 +418,7 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 		cfg.ShardingRing.KVStore.Mock = kvstore
 
 		c, tsdbCompactor, l, _, cleanup := prepare(t, cfg, bucketClient)
-		defer c.StopAsync()
+		defer services.StopAndAwaitTerminated(context.Background(), c)
 		defer cleanup()
 
 		compactors = append(compactors, c)

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -275,7 +275,9 @@ func (t *Cortex) initModuleServices(cfg *Config, target moduleName) (map[moduleN
 				return nil, errors.Wrap(err, fmt.Sprintf("error initialising module: %s", n))
 			}
 			if s != nil {
-				serv = newModuleServiceWrapper(t, n, s, mod.deps, findReverseDeps(n, deps[ix+1:]))
+				// We pass servicesMap, which isn't yet finished. By the time service starts,
+				// it will be fully built, so there is no need for extra synchronization.
+				serv = newModuleServiceWrapper(servicesMap, n, s, mod.deps, findReverseDeps(n, deps[ix+1:]))
 			}
 		}
 

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -11,11 +11,12 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	prom_storage "github.com/prometheus/prometheus/storage"
-	"github.com/pstibrany/services"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"
+
+	"github.com/cortexproject/cortex/pkg/util/services"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager"
 	"github.com/cortexproject/cortex/pkg/chunk"

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -16,8 +16,6 @@ import (
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"
 
-	"github.com/cortexproject/cortex/pkg/util/services"
-
 	"github.com/cortexproject/cortex/pkg/alertmanager"
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
@@ -40,6 +38,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
+	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
@@ -278,7 +277,7 @@ func (t *Cortex) initModuleServices(cfg *Config, target moduleName) (map[moduleN
 			if s != nil {
 				// We pass servicesMap, which isn't yet finished. By the time service starts,
 				// it will be fully built, so there is no need for extra synchronization.
-				serv = newModuleServiceWrapper(servicesMap, n, s, mod.deps, findReverseDeps(n, deps[ix+1:]))
+				serv = newModuleServiceWrapper(servicesMap, n, s, mod.deps, findInverseDependencies(n, deps[ix+1:]))
 			}
 		}
 
@@ -396,7 +395,7 @@ func orderedDeps(m moduleName) []moduleName {
 }
 
 // find modules in the supplied list, that depend on mod
-func findReverseDeps(mod moduleName, mods []moduleName) []moduleName {
+func findInverseDependencies(mod moduleName, mods []moduleName) []moduleName {
 	result := []moduleName(nil)
 
 	for _, n := range mods {

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -359,7 +359,7 @@ func (t *Cortex) readyHandler(sm *services.Manager) http.HandlerFunc {
 
 			byState := sm.ServicesByState()
 			for st, ls := range byState {
-				msg.WriteString(fmt.Sprintf("%v: %d\n", st, ls))
+				msg.WriteString(fmt.Sprintf("%v: %d\n", st, len(ls)))
 			}
 
 			http.Error(w, msg.String(), http.StatusServiceUnavailable)

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -290,7 +290,7 @@ func (t *Cortex) initModuleServices(cfg *Config, target moduleName) (map[moduleN
 	return servicesMap, nil
 }
 
-// Run starts Cortex running, and blocks until a signal is received.
+// Run starts Cortex running, and blocks until a Cortex stops.
 func (t *Cortex) Run() error {
 	// get all services, create service manager and tell it to start
 	servs := []services.Service(nil)

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -329,7 +329,7 @@ func (t *Cortex) Run() error {
 	// Currently it's the Server that reacts on signal handler,
 	// so get Server service, and wait until it ends.
 	// It will also be stopped via service manager if any service fails (see attached service listener)
-	err = t.serviceMap[Server].AwaitTerminated(context.Background())
+	_ = t.serviceMap[Server].AwaitTerminated(context.Background())
 
 	// Stop all the other services.
 	sm.StopAsync()

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -304,7 +304,7 @@ func (t *Cortex) Run() error {
 	}
 
 	// before starting servers, register /ready handler. It should reflect entire Cortex.
-	t.server.HTTP.Path("/ready").Handler(t.healthyHandler(sm))
+	t.server.HTTP.Path("/ready").Handler(t.readyHandler(sm))
 
 	// Let's listen for events from this manager, and log them.
 	healthy := func() { level.Info(util.Logger).Log("msg", "Cortex started") }
@@ -351,7 +351,7 @@ func (t *Cortex) Run() error {
 	return err
 }
 
-func (t *Cortex) healthyHandler(sm *services.Manager) http.HandlerFunc {
+func (t *Cortex) readyHandler(sm *services.Manager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !sm.IsHealthy() {
 			msg := bytes.Buffer{}
@@ -363,6 +363,7 @@ func (t *Cortex) healthyHandler(sm *services.Manager) http.HandlerFunc {
 			}
 
 			http.Error(w, msg.String(), http.StatusServiceUnavailable)
+			return
 		}
 
 		// Ingester has a special check that makes sure that it was able to register into the ring,

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -342,9 +342,8 @@ func (t *Cortex) Run() error {
 	}
 
 	// Stop all the services, and wait until they are all done.
-	sm.StopAsync()
-	// this can only return error if context is Done... ignore
-	_ = sm.AwaitStopped(context.Background())
+	// We don't care about this error, as it cannot really fail. `err` has error from startup, which is more important.
+	_ = services.StopManagerAndAwaitStopped(context.Background(), sm)
 	return err
 }
 

--- a/pkg/cortex/cortex_test.go
+++ b/pkg/cortex/cortex_test.go
@@ -1,0 +1,70 @@
+package cortex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/chunk/storage"
+	"github.com/cortexproject/cortex/pkg/ingester"
+	"github.com/cortexproject/cortex/pkg/ring"
+	"github.com/cortexproject/cortex/pkg/ring/kv"
+	"github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/storage/tsdb/backend/s3"
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+func TestCortex(t *testing.T) {
+	cfg := Config{
+		Storage: storage.Config{
+			Engine: storage.StorageEngineTSDB, // makes config easier
+		},
+		Ingester: ingester.Config{
+			TSDBConfig: tsdb.Config{
+				Backend: tsdb.BackendS3,
+				S3: s3.Config{
+					Endpoint: "localhost",
+				},
+			},
+			LifecyclerConfig: ring.LifecyclerConfig{
+				RingConfig: ring.Config{
+					KVStore: kv.Config{
+						Store: "inmemory",
+					},
+					ReplicationFactor: 3,
+				},
+				InfNames: []string{"en0", "eth0", "lo0"},
+			},
+		},
+		TSDB: tsdb.Config{
+			Backend: tsdb.BackendS3,
+			S3: s3.Config{
+				Endpoint: "localhost",
+			},
+		},
+		Target: All,
+	}
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, c.serviceMap)
+
+	for m, s := range c.serviceMap {
+		// make sure each service is still New
+		require.Equal(t, services.New, s.State(), "module: %s", m)
+	}
+
+	// check random modules that we expect to be configured when using Target=All
+	require.NotNil(t, c.serviceMap[Server])
+	require.NotNil(t, c.serviceMap[Ingester])
+	require.NotNil(t, c.serviceMap[Ring])
+	require.NotNil(t, c.serviceMap[Distributor])
+
+	r, ok := c.serviceMap[Ring].(*moduleServiceWrapper)
+	require.True(t, ok)
+
+	require.ElementsMatch(t, []moduleName{Server, RuntimeConfig, MemberlistKV}, r.startDeps)
+
+	// querier and distributor depend on Ring
+	require.ElementsMatch(t, []moduleName{Distributor, Querier}, r.stopDeps)
+}

--- a/pkg/cortex/module_service_wrapper.go
+++ b/pkg/cortex/module_service_wrapper.go
@@ -88,7 +88,7 @@ func (w *moduleServiceWrapper) stop() error {
 	w.service.StopAsync()
 	err := w.service.AwaitTerminated(context.Background())
 	if err != nil {
-		level.Info(util.Logger).Log("msg", "error stopping module", "module", w.module, "err", err)
+		level.Warn(util.Logger).Log("msg", "error stopping module", "module", w.module, "err", err)
 	} else {
 		level.Info(util.Logger).Log("msg", "module stopped", "module", w.module)
 	}

--- a/pkg/cortex/module_service_wrapper.go
+++ b/pkg/cortex/module_service_wrapper.go
@@ -48,7 +48,7 @@ func (w *moduleServiceWrapper) start(serviceContext context.Context) error {
 
 		err := s.AwaitRunning(serviceContext)
 		if err != nil {
-			return fmt.Errorf("failed to start %v, because dependant service %v has failed: %v", w.module, m, err)
+			return fmt.Errorf("failed to start %v, because it depends on module %v, which has failed: %w", w.module, m, err)
 		}
 	}
 
@@ -65,11 +65,9 @@ func (w *moduleServiceWrapper) start(serviceContext context.Context) error {
 
 func (w *moduleServiceWrapper) run(serviceContext context.Context) error {
 	// wait until service stops, or context is canceled, whatever happens first.
-	err := w.service.AwaitTerminated(serviceContext)
-	if err == context.Canceled {
-		return nil
-	}
-	return err
+	// We don't care about exact error here
+	_ = w.service.AwaitTerminated(serviceContext)
+	return w.service.FailureCase()
 }
 
 func (w *moduleServiceWrapper) stop() error {

--- a/pkg/cortex/module_service_wrapper.go
+++ b/pkg/cortex/module_service_wrapper.go
@@ -6,15 +6,15 @@ import (
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
-	"github.com/pstibrany/services"
 
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 // This service wraps module service, and adds waiting for dependencies to start before starting,
 // and dependant modules to stop before stopping this module service.
 type moduleServiceWrapper struct {
-	services.BasicService
+	services.Service
 
 	serviceMap map[moduleName]services.Service
 	module     moduleName
@@ -32,7 +32,7 @@ func newModuleServiceWrapper(serviceMap map[moduleName]services.Service, mod mod
 		stopDeps:   stopDeps,
 	}
 
-	services.InitBasicService(&w.BasicService, w.start, w.run, w.stop)
+	w.Service = services.NewBasicService(w.start, w.run, w.stop)
 	return w
 }
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -241,7 +241,8 @@ func (t *Cortex) initRuntimeConfig(cfg *Config) (services.Service, error) {
 
 func (t *Cortex) initOverrides(cfg *Config) (serv services.Service, err error) {
 	t.overrides, err = validation.NewOverrides(cfg.LimitsConfig, tenantLimitsFromRuntimeConfig(t.runtimeConfig))
-	// overrides don't have operational state, no need to return any service.
+	// overrides don't have operational state, nor do they need to do anything more in starting/stopping phase,
+	// so there is no need to return any service.
 	return nil, err
 }
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -650,7 +650,7 @@ type module struct {
 	// service for this module (can return nil)
 	service func(t *Cortex, cfg *Config) (services.Service, error)
 
-	// service that will be wrapped into module_service_wrapper, to wait for dependencies to start / end
+	// service that will be wrapped into moduleServiceWrapper, to wait for dependencies to start / end
 	// (can return nil)
 	wrappedService func(t *Cortex, cfg *Config) (services.Service, error)
 }

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -743,6 +743,6 @@ var modules = map[moduleName]module{
 	},
 
 	All: {
-		deps: []moduleName{Querier, Ingester, Distributor, TableManager, Compactor},
+		deps: []moduleName{Querier, Ingester, Distributor, TableManager},
 	},
 }

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/promql"
 	v1 "github.com/prometheus/prometheus/web/api/v1"
-	"github.com/pstibrany/services"
 	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
@@ -41,6 +40,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/push"
 	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
+	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
@@ -241,7 +241,7 @@ func (t *Cortex) initServer(cfg *Config) (services.Service, error) {
 		}
 	})
 
-	return services.NewService(nil, runFn, stoppingFn), nil
+	return services.NewBasicService(nil, runFn, stoppingFn), nil
 }
 
 func (t *Cortex) initRing(cfg *Config) (serv services.Service, err error) {

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -301,12 +301,6 @@ func (t *Cortex) initQuerier(cfg *Config) (serv services.Service, err error) {
 		return
 	}
 
-	// Once the execution reaches this point, all synchronous initialization has been
-	// done and the querier is ready to serve queries, so we're just returning a 202.
-	t.server.HTTP.Path("/ready").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	}))
-
 	// TODO: If queryable returned from querier.New was a service, it could actually wait for storeQueryable
 	// (if it also implemented Service) to finish starting... and return error if it's not in Running state.
 	// This requires extra work, which is out of scope for this proof-of-concept...
@@ -366,7 +360,6 @@ func (t *Cortex) initIngester(cfg *Config) (serv services.Service, err error) {
 
 	client.RegisterIngesterServer(t.server.GRPC, t.ingester)
 	grpc_health_v1.RegisterHealthServer(t.server.GRPC, t.ingester)
-	t.server.HTTP.Path("/ready").Handler(http.HandlerFunc(t.ingester.ReadinessHandler))
 	t.server.HTTP.Path("/flush").Handler(http.HandlerFunc(t.ingester.FlushHandler))
 	t.server.HTTP.Path("/shutdown").Handler(http.HandlerFunc(t.ingester.ShutdownHandler))
 	t.server.HTTP.Handle("/push", t.httpAuthMiddleware.Wrap(push.Handler(cfg.Distributor, t.ingester.Push)))

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -205,6 +205,7 @@ func (t *Cortex) initServer(cfg *Config) (services.Service, error) {
 		case <-ctx.Done():
 			return nil
 		case err := <-serverDone:
+			level.Info(util.Logger).Log("msg", "server failed", "err", err)
 			return err
 		}
 	}
@@ -222,6 +223,7 @@ func (t *Cortex) initServer(cfg *Config) (services.Service, error) {
 		t.server.Shutdown()
 		// if not closed yet, wait until server stops.
 		<-serverDone
+		level.Info(util.Logger).Log("msg", "server stopped")
 		return nil
 	}
 

--- a/pkg/cortex/server_service.go
+++ b/pkg/cortex/server_service.go
@@ -27,7 +27,7 @@ func NewServerService(serv *server.Server, servicesToWaitFor func() []services.S
 			return nil
 		case err := <-serverDone:
 			if err != nil {
-				level.Info(util.Logger).Log("msg", "server failed", "err", err)
+				level.Error(util.Logger).Log("msg", "server failed", "err", err)
 			}
 			return err
 		}

--- a/pkg/cortex/server_service.go
+++ b/pkg/cortex/server_service.go
@@ -1,0 +1,55 @@
+package cortex
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/weaveworks/common/server"
+
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+// NewServerService constructs service from Server component.
+// servicesToWaitFor is called when server is stopping, and should return all
+// services that need to terminate before server actually stops.
+func NewServerService(serv *server.Server, servicesToWaitFor func() []services.Service) services.Service {
+	serverDone := make(chan error, 1)
+
+	runFn := func(ctx context.Context) error {
+		go func() {
+			defer close(serverDone)
+			serverDone <- serv.Run()
+		}()
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-serverDone:
+			if err != nil {
+				level.Info(util.Logger).Log("msg", "server failed", "err", err)
+			}
+			return err
+		}
+	}
+
+	stoppingFn := func() error {
+		// wait until all modules are done, and then shutdown server.
+		for _, s := range servicesToWaitFor() {
+			_ = s.AwaitTerminated(context.Background())
+		}
+
+		// unblock Run, if it's still running (e.g. service was asked to stop via StopAsync)
+		serv.Stop()
+
+		// shutdown HTTP and gRPC servers
+		serv.Shutdown()
+
+		// if not closed yet, wait until server stops.
+		<-serverDone
+		level.Info(util.Logger).Log("msg", "server stopped")
+		return nil
+	}
+
+	return services.NewBasicService(nil, runFn, stoppingFn)
+}

--- a/pkg/cortex/server_service.go
+++ b/pkg/cortex/server_service.go
@@ -39,10 +39,7 @@ func NewServerService(serv *server.Server, servicesToWaitFor func() []services.S
 			_ = s.AwaitTerminated(context.Background())
 		}
 
-		// unblock Run, if it's still running (e.g. service was asked to stop via StopAsync)
-		serv.Stop()
-
-		// shutdown HTTP and gRPC servers
+		// shutdown HTTP and gRPC servers (this also unblocks Run)
 		serv.Shutdown()
 
 		// if not closed yet, wait until server stops.

--- a/pkg/cortex/server_service_test.go
+++ b/pkg/cortex/server_service_test.go
@@ -1,0 +1,54 @@
+package cortex
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/server"
+
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+func TestServerStopViaContext(t *testing.T) {
+	// server registers some metrics to default registry
+	savedRegistry := prometheus.DefaultRegisterer
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	defer func() {
+		prometheus.DefaultRegisterer = savedRegistry
+	}()
+
+	serv, err := server.New(server.Config{})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	s := NewServerService(serv, func() []services.Service { return nil })
+	require.NoError(t, s.StartAsync(ctx))
+
+	// should terminate soon, since context has short timeout
+	require.NoError(t, s.AwaitTerminated(context.Background()))
+}
+
+func TestServerStop(t *testing.T) {
+	// server registers some metrics to default registry
+	savedRegistry := prometheus.DefaultRegisterer
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	defer func() {
+		prometheus.DefaultRegisterer = savedRegistry
+	}()
+
+	serv, err := server.New(server.Config{})
+	require.NoError(t, err)
+
+	s := NewServerService(serv, func() []services.Service { return nil })
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), s))
+
+	// we stop HTTP/gRPC Servers here... that should make server stop.
+	serv.Shutdown()
+
+	require.NoError(t, s.AwaitTerminated(context.Background()))
+}

--- a/pkg/cortex/status.go
+++ b/pkg/cortex/status.go
@@ -9,6 +9,7 @@ func (t *Cortex) servicesHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
 	w.Header().Set("Content-Type", "text/plain")
 
+	// TODO: this could be extended to also print sub-services, if given service has any
 	for mod := moduleName(0); mod < All; mod++ {
 		s := t.serviceMap[mod]
 		if s != nil {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -8,9 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pstibrany/services"
-	"google.golang.org/grpc/health/grpc_health_v1"
-
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -19,6 +16,7 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/user"
+	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	ingester_client "github.com/cortexproject/cortex/pkg/ingester/client"
@@ -28,6 +26,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/extract"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/limiter"
+	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
@@ -95,7 +94,7 @@ var (
 // Distributor is a storage.SampleAppender and a client.Querier which
 // forwards appends and queries to individual ingesters.
 type Distributor struct {
-	services.BasicService
+	services.Service
 
 	cfg           Config
 	ingestersRing ring.ReadRing
@@ -210,8 +209,7 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 		return nil, err
 	}
 
-	services.InitIdleService(&d.BasicService, d.starting, d.stopping)
-
+	d.Service = services.NewIdleService(d.starting, d.stopping)
 	return d, nil
 }
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -214,20 +214,13 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 }
 
 func (d *Distributor) starting(ctx context.Context) error {
-	err := d.subservices.StartAsync(ctx)
-	if err != nil {
-		return err
-	}
-
 	// Only report success if all sub-services start properly
-	return d.subservices.AwaitHealthy(ctx)
+	return services.StartManagerAndAwaitHealthy(ctx, d.subservices)
 }
 
 // Called after distributor is asked to stop via StopAsync.
 func (d *Distributor) stopping() error {
-	// just stop everything, and wait until it has stopped.
-	d.subservices.StopAsync()
-	return d.subservices.AwaitStopped(context.Background())
+	return services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
 }
 
 func (d *Distributor) tokenForLabels(userID string, labels []client.LabelAdapter) (uint32, error) {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -226,7 +226,7 @@ func (d *Distributor) starting(ctx context.Context) error {
 	return d.servManager.AwaitHealthy(ctx)
 }
 
-// Stop stops the distributor's maintenance loop.
+// Called after distributor is asked to stop via StopAsync.
 func (d *Distributor) stopping() error {
 	// just stop everything, and wait until it has stopped.
 	d.servManager.StopAsync()

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/chunkcompat"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/test"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
@@ -96,7 +97,7 @@ func TestDistributor_Push(t *testing.T) {
 				limits.IngestionBurstSize = 20
 
 				d, _ := prepare(t, tc.numIngesters, tc.happyIngesters, 0, shardByAllLabels, limits, nil)
-				defer d.StopAsync()
+				defer services.StopAndAwaitTerminated(context.Background(), d)
 
 				request := makeWriteRequest(tc.samples)
 				response, err := d.Push(ctx, request)
@@ -175,7 +176,7 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			distributors := make([]*Distributor, testData.distributors)
 			for i := 0; i < testData.distributors; i++ {
 				distributors[i], _ = prepare(t, 1, 1, 0, true, limits, kvStore)
-				defer distributors[i].StopAsync()
+				defer services.StopAndAwaitTerminated(context.Background(), distributors[i])
 			}
 
 			// If the distributors ring is setup, wait until the first distributor
@@ -260,7 +261,7 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 						FailoverTimeout: time.Second,
 					})
 					require.NoError(t, err)
-					require.NoError(t, r.StartAsync(context.Background()))
+					require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
 					d.Replicas = r
 				}
 
@@ -372,7 +373,7 @@ func TestDistributor_PushQuery(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			d, _ := prepare(t, tc.numIngesters, tc.happyIngesters, 0, tc.shardByAllLabels, nil, nil)
-			defer d.StopAsync()
+			defer services.StopAndAwaitTerminated(context.Background(), d)
 
 			request := makeWriteRequest(tc.samples)
 			writeResponse, err := d.Push(ctx, request)
@@ -455,7 +456,7 @@ func TestDistributor_Push_LabelRemoval(t *testing.T) {
 		limits.AcceptHASamples = tc.removeReplica
 
 		d, ingesters := prepare(t, 1, 1, 0, true, &limits, nil)
-		defer d.StopAsync()
+		defer services.StopAndAwaitTerminated(context.Background(), d)
 
 		// Push the series to the distributor
 		req := mockWriteRequest(tc.inputSeries, 1, 1)
@@ -557,7 +558,7 @@ func TestDistributor_Push_ShouldGuaranteeShardingTokenConsistencyOverTheTime(t *
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			d, ingesters := prepare(t, 1, 1, 0, true, &limits, nil)
-			defer d.StopAsync()
+			defer services.StopAndAwaitTerminated(context.Background(), d)
 
 			// Push the series to the distributor
 			req := mockWriteRequest(testData.inputSeries, 1, 1)
@@ -594,7 +595,7 @@ func TestSlowQueries(t *testing.T) {
 				expectedErr = promql.ErrStorage{Err: errFail}
 			}
 			d, _ := prepare(t, nIngesters, happy, 100*time.Millisecond, shardByAllLabels, nil, nil)
-			defer d.StopAsync()
+			defer services.StopAndAwaitTerminated(context.Background(), d)
 
 			_, err := d.Query(ctx, 0, 10, nameMatcher)
 			assert.Equal(t, expectedErr, err)
@@ -660,7 +661,7 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 
 	// Create distributor
 	d, _ := prepare(t, 3, 3, time.Duration(0), true, nil, nil)
-	defer d.StopAsync()
+	defer services.StopAndAwaitTerminated(context.Background(), d)
 
 	// Push fixtures
 	ctx := user.InjectOrgID(context.Background(), "test")
@@ -762,8 +763,7 @@ func prepare(t *testing.T, numIngesters, happyIngesters int, queryDelay time.Dur
 
 	d, err := New(cfg, clientConfig, overrides, ingestersRing, true)
 	require.NoError(t, err)
-	require.NoError(t, d.StartAsync(context.Background()))
-	require.NoError(t, d.AwaitRunning(context.Background()))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), d))
 
 	return d, ingesters
 }
@@ -1138,7 +1138,7 @@ func TestDistributorValidation(t *testing.T) {
 			limits.MaxLabelNamesPerSeries = 2
 
 			d, _ := prepare(t, 3, 3, 0, true, &limits, nil)
-			defer d.StopAsync()
+			defer services.StopAndAwaitTerminated(context.Background(), d)
 
 			_, err := d.Push(ctx, client.ToWriteRequest(tc.labels, tc.samples, client.API))
 			require.Equal(t, tc.err, err)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -763,6 +763,7 @@ func prepare(t *testing.T, numIngesters, happyIngesters int, queryDelay time.Dur
 	d, err := New(cfg, clientConfig, overrides, ingestersRing, true)
 	require.NoError(t, err)
 	require.NoError(t, d.StartAsync(context.Background()))
+	require.NoError(t, d.AwaitRunning(context.Background()))
 
 	return d, ingesters
 }

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -97,7 +97,7 @@ func TestDistributor_Push(t *testing.T) {
 				limits.IngestionBurstSize = 20
 
 				d, _ := prepare(t, tc.numIngesters, tc.happyIngesters, 0, shardByAllLabels, limits, nil)
-				defer services.StopAndAwaitTerminated(context.Background(), d)
+				defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 
 				request := makeWriteRequest(tc.samples)
 				response, err := d.Push(ctx, request)
@@ -176,7 +176,7 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			distributors := make([]*Distributor, testData.distributors)
 			for i := 0; i < testData.distributors; i++ {
 				distributors[i], _ = prepare(t, 1, 1, 0, true, limits, kvStore)
-				defer services.StopAndAwaitTerminated(context.Background(), distributors[i])
+				defer services.StopAndAwaitTerminated(context.Background(), distributors[i]) //nolint:errcheck
 			}
 
 			// If the distributors ring is setup, wait until the first distributor
@@ -373,7 +373,7 @@ func TestDistributor_PushQuery(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			d, _ := prepare(t, tc.numIngesters, tc.happyIngesters, 0, tc.shardByAllLabels, nil, nil)
-			defer services.StopAndAwaitTerminated(context.Background(), d)
+			defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 
 			request := makeWriteRequest(tc.samples)
 			writeResponse, err := d.Push(ctx, request)
@@ -456,7 +456,7 @@ func TestDistributor_Push_LabelRemoval(t *testing.T) {
 		limits.AcceptHASamples = tc.removeReplica
 
 		d, ingesters := prepare(t, 1, 1, 0, true, &limits, nil)
-		defer services.StopAndAwaitTerminated(context.Background(), d)
+		defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 
 		// Push the series to the distributor
 		req := mockWriteRequest(tc.inputSeries, 1, 1)
@@ -558,7 +558,7 @@ func TestDistributor_Push_ShouldGuaranteeShardingTokenConsistencyOverTheTime(t *
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			d, ingesters := prepare(t, 1, 1, 0, true, &limits, nil)
-			defer services.StopAndAwaitTerminated(context.Background(), d)
+			defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 
 			// Push the series to the distributor
 			req := mockWriteRequest(testData.inputSeries, 1, 1)
@@ -595,7 +595,7 @@ func TestSlowQueries(t *testing.T) {
 				expectedErr = promql.ErrStorage{Err: errFail}
 			}
 			d, _ := prepare(t, nIngesters, happy, 100*time.Millisecond, shardByAllLabels, nil, nil)
-			defer services.StopAndAwaitTerminated(context.Background(), d)
+			defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 
 			_, err := d.Query(ctx, 0, 10, nameMatcher)
 			assert.Equal(t, expectedErr, err)
@@ -661,7 +661,7 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 
 	// Create distributor
 	d, _ := prepare(t, 3, 3, time.Duration(0), true, nil, nil)
-	defer services.StopAndAwaitTerminated(context.Background(), d)
+	defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 
 	// Push fixtures
 	ctx := user.InjectOrgID(context.Background(), "test")
@@ -1138,7 +1138,7 @@ func TestDistributorValidation(t *testing.T) {
 			limits.MaxLabelNamesPerSeries = 2
 
 			d, _ := prepare(t, 3, 3, 0, true, &limits, nil)
-			defer services.StopAndAwaitTerminated(context.Background(), d)
+			defer services.StopAndAwaitTerminated(context.Background(), d) //nolint:errcheck
 
 			_, err := d.Push(ctx, client.ToWriteRequest(tc.labels, tc.samples, client.API))
 			require.Equal(t, tc.err, err)

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -17,9 +17,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/pkg/timestamp"
-	"github.com/pstibrany/services"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/mtime"
+
+	"github.com/cortexproject/cortex/pkg/util/services"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ring/kv"
@@ -67,7 +68,7 @@ func NewReplicaDesc() *ReplicaDesc {
 // Track the replica we're accepting samples from
 // for each HA cluster we know about.
 type haTracker struct {
-	services.BasicService
+	services.Service
 
 	logger              log.Logger
 	cfg                 HATrackerConfig
@@ -164,7 +165,7 @@ func newClusterTracker(cfg HATrackerConfig) (*haTracker, error) {
 		t.client = client
 	}
 
-	services.InitBasicService(&t.BasicService, nil, t.loop, nil)
+	t.Service = services.NewBasicService(nil, t.loop, nil)
 	return t, nil
 }
 

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -20,12 +20,11 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/mtime"
 
-	"github.com/cortexproject/cortex/pkg/util/services"
-
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ring/kv"
 	"github.com/cortexproject/cortex/pkg/ring/kv/codec"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 var (

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -138,7 +138,7 @@ func TestWatchPrefixAssignment(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
-	defer services.StopAndAwaitTerminated(context.Background(), c)
+	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
 
 	// Write the first time.
 	mtime.NowForce(start)
@@ -168,7 +168,7 @@ func TestCheckReplicaOverwriteTimeout(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
-	defer services.StopAndAwaitTerminated(context.Background(), c)
+	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
 
 	// Write the first time.
 	err = c.checkReplica(context.Background(), "user", "test", replica1)
@@ -203,7 +203,7 @@ func TestCheckReplicaMultiCluster(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
-	defer services.StopAndAwaitTerminated(context.Background(), c)
+	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
 
 	// Write the first time.
 	err = c.checkReplica(context.Background(), "user", "c1", replica1)
@@ -238,7 +238,7 @@ func TestCheckReplicaMultiClusterTimeout(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
-	defer services.StopAndAwaitTerminated(context.Background(), c)
+	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
 
 	// Write the first time.
 	err = c.checkReplica(context.Background(), "user", "c1", replica1)
@@ -289,7 +289,7 @@ func TestCheckReplicaUpdateTimeout(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
-	defer services.StopAndAwaitTerminated(context.Background(), c)
+	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
 
 	// Write the first time.
 	mtime.NowForce(startTime)
@@ -350,7 +350,7 @@ func TestCheckReplicaMultiUser(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
-	defer services.StopAndAwaitTerminated(context.Background(), c)
+	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
 
 	// Write the first time for user 1.
 	mtime.NowForce(start)
@@ -433,7 +433,7 @@ func TestCheckReplicaUpdateTimeoutJitter(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
-			defer services.StopAndAwaitTerminated(context.Background(), c)
+			defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
 
 			// Init context used by the test
 			ctx, cancel := context.WithTimeout(ctxUser1, time.Second)

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring/kv"
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 var (
@@ -136,8 +137,8 @@ func TestWatchPrefixAssignment(t *testing.T) {
 		FailoverTimeout:        time.Millisecond * 2,
 	})
 	require.NoError(t, err)
-	require.NoError(t, c.StartAsync(context.Background()))
-	defer c.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
+	defer services.StopAndAwaitTerminated(context.Background(), c)
 
 	// Write the first time.
 	mtime.NowForce(start)
@@ -166,8 +167,8 @@ func TestCheckReplicaOverwriteTimeout(t *testing.T) {
 		FailoverTimeout:        time.Second,
 	})
 	require.NoError(t, err)
-	require.NoError(t, c.StartAsync(context.Background()))
-	defer c.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
+	defer services.StopAndAwaitTerminated(context.Background(), c)
 
 	// Write the first time.
 	err = c.checkReplica(context.Background(), "user", "test", replica1)
@@ -201,8 +202,8 @@ func TestCheckReplicaMultiCluster(t *testing.T) {
 		FailoverTimeout:        time.Second,
 	})
 	require.NoError(t, err)
-	require.NoError(t, c.StartAsync(context.Background()))
-	defer c.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
+	defer services.StopAndAwaitTerminated(context.Background(), c)
 
 	// Write the first time.
 	err = c.checkReplica(context.Background(), "user", "c1", replica1)
@@ -236,8 +237,8 @@ func TestCheckReplicaMultiClusterTimeout(t *testing.T) {
 		FailoverTimeout:        time.Second,
 	})
 	require.NoError(t, err)
-	require.NoError(t, c.StartAsync(context.Background()))
-	defer c.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
+	defer services.StopAndAwaitTerminated(context.Background(), c)
 
 	// Write the first time.
 	err = c.checkReplica(context.Background(), "user", "c1", replica1)
@@ -287,8 +288,8 @@ func TestCheckReplicaUpdateTimeout(t *testing.T) {
 		FailoverTimeout:        time.Second,
 	})
 	require.NoError(t, err)
-	require.NoError(t, c.StartAsync(context.Background()))
-	defer c.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
+	defer services.StopAndAwaitTerminated(context.Background(), c)
 
 	// Write the first time.
 	mtime.NowForce(startTime)
@@ -348,8 +349,8 @@ func TestCheckReplicaMultiUser(t *testing.T) {
 		FailoverTimeout:        time.Second,
 	})
 	require.NoError(t, err)
-	require.NoError(t, c.StartAsync(context.Background()))
-	defer c.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
+	defer services.StopAndAwaitTerminated(context.Background(), c)
 
 	// Write the first time for user 1.
 	mtime.NowForce(start)
@@ -431,8 +432,8 @@ func TestCheckReplicaUpdateTimeoutJitter(t *testing.T) {
 				FailoverTimeout:        time.Second,
 			})
 			require.NoError(t, err)
-			require.NoError(t, c.StartAsync(context.Background()))
-			defer c.StopAsync()
+			require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
+			defer services.StopAndAwaitTerminated(context.Background(), c)
 
 			// Init context used by the test
 			ctx, cancel := context.WithTimeout(ctxUser1, time.Second)

--- a/pkg/ingester/client/pool_test.go
+++ b/pkg/ingester/client/pool_test.go
@@ -82,7 +82,7 @@ func TestIngesterCache(t *testing.T) {
 		ClientCleanupPeriod: 10 * time.Second,
 	}, mockReadRing{}, factory, log.NewNopLogger())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), pool))
-	defer services.StopAndAwaitTerminated(context.Background(), pool)
+	defer services.StopAndAwaitTerminated(context.Background(), pool) //nolint:errcheck
 
 	_, err := pool.GetClientFor("1")
 	require.NoError(t, err)

--- a/pkg/ingester/client/pool_test.go
+++ b/pkg/ingester/client/pool_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/cortexproject/cortex/pkg/ring"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 type mockIngester struct {
@@ -80,8 +81,8 @@ func TestIngesterCache(t *testing.T) {
 		RemoteTimeout:       50 * time.Millisecond,
 		ClientCleanupPeriod: 10 * time.Second,
 	}, mockReadRing{}, factory, log.NewNopLogger())
-	require.NoError(t, pool.StartAsync(context.Background()))
-	defer pool.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), pool))
+	defer services.StopAndAwaitTerminated(context.Background(), pool)
 
 	_, err := pool.GetClientFor("1")
 	require.NoError(t, err)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -700,11 +700,9 @@ func (i *Ingester) Watch(in *grpc_health_v1.HealthCheckRequest, stream grpc_heal
 // ReadinessHandler is used to indicate to k8s when the ingesters are ready for
 // the addition removal of another ingester. Returns 204 when the ingester is
 // ready, 500 otherwise.
-func (i *Ingester) ReadinessHandler(w http.ResponseWriter, r *http.Request) {
-	// TODO: should check if service is Running
-	if err := i.lifecycler.CheckReady(r.Context()); err == nil {
-		w.WriteHeader(http.StatusNoContent)
-	} else {
-		http.Error(w, "Not ready: "+err.Error(), http.StatusServiceUnavailable)
+func (i *Ingester) CheckReady(ctx context.Context) error {
+	if s := i.State(); s != services.Running {
+		return fmt.Errorf("service not Running: %v", s)
 	}
+	return i.lifecycler.CheckReady(ctx)
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -200,7 +200,7 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 
 func (i *Ingester) starting(ctx context.Context) error {
 	// Now that user states have been created, we can start the lifecycler.
-	// we want to keep lifecycler running until we ask it to stop, so we need to give it independent context
+	// Important: we want to keep lifecycler running until we ask it to stop, so we need to give it independent context
 	if err := i.lifecycler.StartAsync(context.Background()); err != nil {
 		return errors.Wrap(err, "failed to start lifecycler")
 	}
@@ -243,9 +243,7 @@ func (i *Ingester) stopping() error {
 	i.wal.Stop()
 
 	// Next initiate our graceful exit from the ring.
-	i.lifecycler.StopAsync()
-	_ = i.lifecycler.AwaitTerminated(context.Background())
-	return i.lifecycler.FailureCase()
+	return services.StopAndAwaitTerminated(context.Background(), i.lifecycler)
 }
 
 // ShutdownHandler triggers the following set of operations in order:

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/pstibrany/services"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc/codes"
@@ -25,6 +24,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
@@ -93,7 +93,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 // Ingester deals with "in flight" chunks.  Based on Prometheus 1.x
 // MemorySeriesStorage.
 type Ingester struct {
-	services.BasicService
+	services.Service
 
 	cfg          Config
 	clientConfig client.Config
@@ -194,7 +194,7 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 	}
 
 	// TODO: lot more stuff can be put into startingFn (esp. WAL replay), but for now keep it in New
-	services.InitBasicService(&i.BasicService, i.starting, i.loop, i.stopping)
+	i.Service = services.NewBasicService(i.starting, i.loop, i.stopping)
 	return i, nil
 }
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -253,8 +253,7 @@ func (i *Ingester) ShutdownHandler(w http.ResponseWriter, r *http.Request) {
 	originalState := i.lifecycler.FlushOnShutdown()
 	// We want to flush the chunks if transfer fails irrespective of original flag.
 	i.lifecycler.SetFlushOnShutdown(true)
-	i.StopAsync()
-	_ = i.AwaitTerminated(context.Background())
+	_ = services.StopAndAwaitTerminated(context.Background(), i)
 	i.lifecycler.SetFlushOnShutdown(originalState)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -244,7 +244,7 @@ func (i *Ingester) stopping() error {
 	// Next initiate our graceful exit from the ring.
 	i.lifecycler.StopAsync()
 	_ = i.lifecycler.AwaitTerminated(context.Background())
-	return nil
+	return i.lifecycler.FailureCase()
 }
 
 // ShutdownHandler triggers the following set of operations in order:

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -203,8 +203,7 @@ func TestIngesterAppend(t *testing.T) {
 	retrieveTestSamples(t, ing, userIDs, testData)
 
 	// Read samples back via chunk store.
-	ing.StopAsync()
-	require.NoError(t, ing.AwaitTerminated(context.Background()))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), ing))
 	store.checkData(t, userIDs, testData)
 }
 
@@ -230,8 +229,7 @@ func TestIngesterSendsOnlySeriesWithData(t *testing.T) {
 	}
 
 	// Read samples back via chunk store.
-	ing.StopAsync()
-	require.NoError(t, ing.AwaitTerminated(context.Background()))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), ing))
 }
 
 func TestIngesterIdleFlush(t *testing.T) {
@@ -306,7 +304,7 @@ func (s *stream) Send(response *client.QueryStreamResponse) error {
 
 func TestIngesterAppendOutOfOrderAndDuplicate(t *testing.T) {
 	_, ing := newDefaultTestStore(t)
-	defer ing.StopAsync()
+	defer services.StopAndAwaitTerminated(context.Background(), ing)
 
 	m := labelPairs{
 		{Name: model.MetricNameLabel, Value: "testmetric"},
@@ -337,7 +335,7 @@ func TestIngesterAppendOutOfOrderAndDuplicate(t *testing.T) {
 // Test that blank labels are removed by the ingester
 func TestIngesterAppendBlankLabel(t *testing.T) {
 	_, ing := newDefaultTestStore(t)
-	defer ing.StopAsync()
+	defer services.StopAndAwaitTerminated(context.Background(), ing)
 
 	lp := labelPairs{
 		{Name: model.MetricNameLabel, Value: "testmetric"},
@@ -368,7 +366,7 @@ func TestIngesterUserSeriesLimitExceeded(t *testing.T) {
 	limits.MaxLocalSeriesPerUser = 1
 
 	_, ing := newTestStore(t, defaultIngesterTestConfig(), defaultClientTestConfig(), limits)
-	defer ing.StopAsync()
+	defer services.StopAndAwaitTerminated(context.Background(), ing)
 
 	userID := "1"
 	labels1 := labels.Labels{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}}
@@ -425,7 +423,7 @@ func TestIngesterMetricSeriesLimitExceeded(t *testing.T) {
 	limits.MaxLocalSeriesPerMetric = 1
 
 	_, ing := newTestStore(t, defaultIngesterTestConfig(), defaultClientTestConfig(), limits)
-	defer ing.StopAsync()
+	defer services.StopAndAwaitTerminated(context.Background(), ing)
 
 	userID := "1"
 	labels1 := labels.Labels{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}}
@@ -489,7 +487,7 @@ func BenchmarkIngesterSeriesCreationLocking(b *testing.B) {
 
 func benchmarkIngesterSeriesCreationLocking(b *testing.B, parallelism int) {
 	_, ing := newDefaultTestStore(b)
-	defer ing.StopAsync()
+	defer services.StopAndAwaitTerminated(context.Background(), ing)
 
 	var (
 		wg     sync.WaitGroup

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -26,6 +26,7 @@ import (
 	promchunk "github.com/cortexproject/cortex/pkg/chunk/encoding"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/util/chunkcompat"
+	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
@@ -44,8 +45,7 @@ func newTestStore(t require.TestingT, cfg Config, clientConfig client.Config, li
 
 	ing, err := New(cfg, clientConfig, overrides, store, nil)
 	require.NoError(t, err)
-	require.NoError(t, ing.StartAsync(context.Background()))
-	require.NoError(t, ing.AwaitRunning(context.Background()))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ing))
 
 	return store, ing
 }

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -304,7 +304,7 @@ func (s *stream) Send(response *client.QueryStreamResponse) error {
 
 func TestIngesterAppendOutOfOrderAndDuplicate(t *testing.T) {
 	_, ing := newDefaultTestStore(t)
-	defer services.StopAndAwaitTerminated(context.Background(), ing)
+	defer services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
 
 	m := labelPairs{
 		{Name: model.MetricNameLabel, Value: "testmetric"},
@@ -335,7 +335,7 @@ func TestIngesterAppendOutOfOrderAndDuplicate(t *testing.T) {
 // Test that blank labels are removed by the ingester
 func TestIngesterAppendBlankLabel(t *testing.T) {
 	_, ing := newDefaultTestStore(t)
-	defer services.StopAndAwaitTerminated(context.Background(), ing)
+	defer services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
 
 	lp := labelPairs{
 		{Name: model.MetricNameLabel, Value: "testmetric"},
@@ -366,7 +366,7 @@ func TestIngesterUserSeriesLimitExceeded(t *testing.T) {
 	limits.MaxLocalSeriesPerUser = 1
 
 	_, ing := newTestStore(t, defaultIngesterTestConfig(), defaultClientTestConfig(), limits)
-	defer services.StopAndAwaitTerminated(context.Background(), ing)
+	defer services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
 
 	userID := "1"
 	labels1 := labels.Labels{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}}
@@ -423,7 +423,7 @@ func TestIngesterMetricSeriesLimitExceeded(t *testing.T) {
 	limits.MaxLocalSeriesPerMetric = 1
 
 	_, ing := newTestStore(t, defaultIngesterTestConfig(), defaultClientTestConfig(), limits)
-	defer services.StopAndAwaitTerminated(context.Background(), ing)
+	defer services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
 
 	userID := "1"
 	labels1 := labels.Labels{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}}
@@ -487,7 +487,7 @@ func BenchmarkIngesterSeriesCreationLocking(b *testing.B) {
 
 func benchmarkIngesterSeriesCreationLocking(b *testing.B, parallelism int) {
 	_, ing := newDefaultTestStore(b)
-	defer services.StopAndAwaitTerminated(context.Background(), ing)
+	defer services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
 
 	var (
 		wg     sync.WaitGroup

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -45,6 +45,7 @@ func newTestStore(t require.TestingT, cfg Config, clientConfig client.Config, li
 	ing, err := New(cfg, clientConfig, overrides, store, nil)
 	require.NoError(t, err)
 	require.NoError(t, ing.StartAsync(context.Background()))
+	require.NoError(t, ing.AwaitRunning(context.Background()))
 
 	return store, ing
 }

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -584,7 +584,7 @@ func benchmarkIngesterPush(b *testing.B, limits validation.Limits, errorsExpecte
 						require.NoError(b, err)
 					}
 				}
-				ing.StopAsync()
+				_ = services.StopAndAwaitTerminated(context.Background(), ing)
 			}
 		})
 	}

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -141,7 +141,8 @@ func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides,
 }
 
 func (i *Ingester) startingV2(ctx context.Context) error {
-	if err := i.lifecycler.StartAsync(ctx); err != nil {
+	// we want to keep lifecycler running until we ask it to stop, so we need to give it independent context
+	if err := i.lifecycler.StartAsync(context.Background()); err != nil {
 		return errors.Wrap(err, "failed to start lifecycler")
 	}
 	if err := i.lifecycler.AwaitRunning(ctx); err != nil {

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -160,12 +160,11 @@ func (i *Ingester) startingV2(ctx context.Context) error {
 // runs when V2 ingester is stopping
 func (i *Ingester) stoppingV2() error {
 	if i.TSDBState.shippingService != nil {
-		// It's important to add the shipper loop to the "done" wait group,
+		// It's important to wait until shipper is finished,
 		// because the blocks transfer should start only once it's guaranteed
 		// there's no shipping on-going.
 
 		i.TSDBState.shippingService.StopAsync()
-		// wait until shipping stops
 		_ = i.TSDBState.shippingService.AwaitTerminated(context.Background())
 	}
 
@@ -175,7 +174,7 @@ func (i *Ingester) stoppingV2() error {
 	// Next initiate our graceful exit from the ring.
 	i.lifecycler.StopAsync()
 	_ = i.lifecycler.AwaitTerminated(context.Background())
-	return nil
+	return i.lifecycler.FailureCase()
 }
 
 func (i *Ingester) updateLoop(ctx context.Context) error {

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -22,12 +22,11 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 
-	"github.com/cortexproject/cortex/pkg/util/services"
-
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ring"
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -207,7 +207,7 @@ func TestIngester_v2Push(t *testing.T) {
 			i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, registry)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-			defer services.StopAndAwaitTerminated(context.Background(), i)
+			defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 			defer cleanup()
 
 			ctx := user.InjectOrgID(context.Background(), userID)
@@ -259,7 +259,7 @@ func TestIngester_v2Push_ShouldHandleTheCaseTheCachedReferenceIsInvalid(t *testi
 	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 
 	ctx := user.InjectOrgID(context.Background(), userID)
@@ -325,7 +325,7 @@ func TestIngester_v2Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *tes
 	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, registry)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 
 	// Wait until the ingester is ACTIVE
@@ -397,7 +397,7 @@ func Test_Ingester_v2LabelNames(t *testing.T) {
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 
 	// Wait until it's ACTIVE
@@ -442,7 +442,7 @@ func Test_Ingester_v2LabelValues(t *testing.T) {
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 
 	// Wait until it's ACTIVE
@@ -562,7 +562,7 @@ func Test_Ingester_v2Query(t *testing.T) {
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 
 	// Wait until it's ACTIVE
@@ -598,7 +598,7 @@ func TestIngester_v2Query_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 
 	// Mock request
@@ -619,7 +619,7 @@ func TestIngester_v2LabelValues_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T)
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 
 	// Mock request
@@ -640,7 +640,7 @@ func TestIngester_v2LabelNames_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) 
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 
 	// Mock request
@@ -666,7 +666,7 @@ func TestIngester_v2Push_ShouldNotCreateTSDBIfNotInActiveState(t *testing.T) {
 	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 	require.Equal(t, ring.PENDING, i.lifecycler.GetState())
 
@@ -715,7 +715,7 @@ func TestIngester_getOrCreateTSDB_ShouldNotAllowToCreateTSDBIfIngesterStateIsNot
 			i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-			defer services.StopAndAwaitTerminated(context.Background(), i)
+			defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 			defer cleanup()
 
 			// Switch ingester state to the expected one in the test
@@ -861,7 +861,7 @@ func Test_Ingester_v2MetricsForLabelMatchers(t *testing.T) {
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 
 	// Wait until it's ACTIVE
@@ -1023,7 +1023,7 @@ func TestIngester_v2LoadTSDBOnStartup(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), ingester))
 
-			defer services.StopAndAwaitTerminated(context.Background(), ingester)
+			defer services.StopAndAwaitTerminated(context.Background(), ingester) //nolint:errcheck
 
 			testData.check(t, ingester)
 		})
@@ -1039,7 +1039,7 @@ func TestIngester_shipBlocks(t *testing.T) {
 	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 
 	// Wait until it's ACTIVE
@@ -1094,7 +1094,7 @@ func Test_Ingester_v2UserStats(t *testing.T) {
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 
 	// Wait until it's ACTIVE
@@ -1143,7 +1143,7 @@ func Test_Ingester_v2AllUserStats(t *testing.T) {
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
 	defer cleanup()
 
 	// Wait until it's ACTIVE

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -715,7 +715,7 @@ func TestIngester_getOrCreateTSDB_ShouldNotAllowToCreateTSDBIfIngesterStateIsNot
 			i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-			defer i.StopAsync()
+			defer services.StopAndAwaitTerminated(context.Background(), i)
 			defer cleanup()
 
 			// Switch ingester state to the expected one in the test

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -714,6 +714,7 @@ func TestIngester_getOrCreateTSDB_ShouldNotAllowToCreateTSDBIfIngesterStateIsNot
 			i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
 			require.NoError(t, err)
 			require.NoError(t, i.StartAsync(context.Background()))
+			require.NoError(t, i.AwaitRunning(context.Background()))
 			defer i.StopAsync()
 			defer cleanup()
 

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ring"
+	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/test"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
@@ -205,8 +206,8 @@ func TestIngester_v2Push(t *testing.T) {
 
 			i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, registry)
 			require.NoError(t, err)
-			require.NoError(t, i.StartAsync(context.Background()))
-			defer i.StopAsync()
+			require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+			defer services.StopAndAwaitTerminated(context.Background(), i)
 			defer cleanup()
 
 			ctx := user.InjectOrgID(context.Background(), userID)
@@ -257,8 +258,8 @@ func TestIngester_v2Push_ShouldHandleTheCaseTheCachedReferenceIsInvalid(t *testi
 
 	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 
 	ctx := user.InjectOrgID(context.Background(), userID)
@@ -323,8 +324,8 @@ func TestIngester_v2Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *tes
 
 	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, registry)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 
 	// Wait until the ingester is ACTIVE
@@ -395,8 +396,8 @@ func Test_Ingester_v2LabelNames(t *testing.T) {
 	// Create ingester
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 
 	// Wait until it's ACTIVE
@@ -440,8 +441,8 @@ func Test_Ingester_v2LabelValues(t *testing.T) {
 	// Create ingester
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 
 	// Wait until it's ACTIVE
@@ -560,8 +561,8 @@ func Test_Ingester_v2Query(t *testing.T) {
 	// Create ingester
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 
 	// Wait until it's ACTIVE
@@ -596,8 +597,8 @@ func Test_Ingester_v2Query(t *testing.T) {
 func TestIngester_v2Query_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 
 	// Mock request
@@ -617,8 +618,8 @@ func TestIngester_v2Query_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {
 func TestIngester_v2LabelValues_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 
 	// Mock request
@@ -638,8 +639,8 @@ func TestIngester_v2LabelValues_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T)
 func TestIngester_v2LabelNames_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 
 	// Mock request
@@ -664,8 +665,8 @@ func TestIngester_v2Push_ShouldNotCreateTSDBIfNotInActiveState(t *testing.T) {
 
 	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 	require.Equal(t, ring.PENDING, i.lifecycler.GetState())
 
@@ -713,8 +714,7 @@ func TestIngester_getOrCreateTSDB_ShouldNotAllowToCreateTSDBIfIngesterStateIsNot
 
 			i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
 			require.NoError(t, err)
-			require.NoError(t, i.StartAsync(context.Background()))
-			require.NoError(t, i.AwaitRunning(context.Background()))
+			require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 			defer i.StopAsync()
 			defer cleanup()
 
@@ -860,8 +860,8 @@ func Test_Ingester_v2MetricsForLabelMatchers(t *testing.T) {
 	// Create ingester
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 
 	// Wait until it's ACTIVE
@@ -1021,10 +1021,9 @@ func TestIngester_v2LoadTSDBOnStartup(t *testing.T) {
 
 			ingester, err := NewV2(ingesterCfg, clientCfg, overrides, nil)
 			require.NoError(t, err)
-			require.NoError(t, ingester.StartAsync(context.Background()))
-			require.NoError(t, ingester.AwaitRunning(context.Background()))
+			require.NoError(t, services.StartAndAwaitRunning(context.Background(), ingester))
 
-			defer ingester.StopAsync()
+			defer services.StopAndAwaitTerminated(context.Background(), ingester)
 
 			testData.check(t, ingester)
 		})
@@ -1039,8 +1038,8 @@ func TestIngester_shipBlocks(t *testing.T) {
 	// Create ingester
 	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 
 	// Wait until it's ACTIVE
@@ -1063,7 +1062,7 @@ func TestIngester_shipBlocks(t *testing.T) {
 	}
 
 	// Ship blocks and assert on the mocked shipper
-	i.shipBlocks()
+	i.shipBlocks(context.Background())
 
 	for _, m := range mocks {
 		m.AssertNumberOfCalls(t, "Sync", 1)
@@ -1094,8 +1093,8 @@ func Test_Ingester_v2UserStats(t *testing.T) {
 	// Create ingester
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 
 	// Wait until it's ACTIVE
@@ -1143,8 +1142,8 @@ func Test_Ingester_v2AllUserStats(t *testing.T) {
 	// Create ingester
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
 	require.NoError(t, err)
-	require.NoError(t, i.StartAsync(context.Background()))
-	defer i.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i)
 	defer cleanup()
 
 	// Wait until it's ACTIVE

--- a/pkg/ingester/wal_test.go
+++ b/pkg/ingester/wal_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 func TestWAL(t *testing.T) {
@@ -27,8 +29,7 @@ func TestWAL(t *testing.T) {
 	// Build an ingester, add some samples, then shut it down.
 	_, ing := newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig())
 	userIDs, testData := pushTestSamples(t, ing, numSeries, numSamplesPerSeriesPerPush, 0)
-	ing.StopAsync()
-	require.NoError(t, ing.AwaitTerminated(context.Background()))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), ing))
 
 	for r := 0; r < numRestarts; r++ {
 		if r == numRestarts-1 {
@@ -48,6 +49,6 @@ func TestWAL(t *testing.T) {
 			userIDs, testData = pushTestSamples(t, ing, numSeries, numSamplesPerSeriesPerPush, (r+1)*numSamplesPerSeriesPerPush)
 		}
 
-		ing.StopAsync()
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), ing))
 	}
 }

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -55,17 +55,11 @@ func NewBlockQueryable(cfg tsdb.Config, logLevel logging.Level, registerer prome
 }
 
 func (b *BlockQueryable) starting(ctx context.Context) error {
-	err := b.us.StartAsync(ctx)
-	if err != nil {
-		return err
-	}
-
-	return errors.Wrap(b.us.AwaitRunning(ctx), "failed to start UserStore")
+	return errors.Wrap(services.StartAndAwaitRunning(ctx, b.us), "failed to start UserStore")
 }
 
 func (b *BlockQueryable) stopping() error {
-	b.us.StopAsync()
-	return errors.Wrap(b.us.AwaitTerminated(context.Background()), "stopping UserStore")
+	return errors.Wrap(services.StopAndAwaitTerminated(context.Background(), b.us), "stopping UserStore")
 }
 
 // Querier returns a new Querier on the storage.

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -65,7 +65,7 @@ func (b *BlockQueryable) stopping() error {
 // Querier returns a new Querier on the storage.
 func (b *BlockQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 	if s := b.State(); s != services.Running {
-		return nil, errors.Errorf("BlockQueryable is in invalid state: %v", s)
+		return nil, errors.Errorf("BlockQueryable is not running: %v", s)
 	}
 
 	userID, err := user.ExtractOrgID(ctx)

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -65,7 +65,7 @@ func (b *BlockQueryable) stopping() error {
 // Querier returns a new Querier on the storage.
 func (b *BlockQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 	if s := b.State(); s != services.Running {
-		return nil, errors.Errorf("BlockQueryable is not running: %v", s)
+		return nil, promql.ErrStorage{Err: errors.Errorf("BlockQueryable is not running: %v", s)}
 	}
 
 	userID, err := user.ExtractOrgID(ctx)

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	"github.com/pstibrany/services"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/weaveworks/common/logging"
@@ -22,12 +21,13 @@ import (
 	"github.com/cortexproject/cortex/pkg/querier/series"
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
 // BlockQueryable is a storage.Queryable implementation for blocks storage
 type BlockQueryable struct {
-	services.BasicService
+	services.Service
 
 	us *UserStore
 }
@@ -49,7 +49,7 @@ func NewBlockQueryable(cfg tsdb.Config, logLevel logging.Level, registerer prome
 	}
 
 	b := &BlockQueryable{us: us}
-	services.InitIdleService(&b.BasicService, b.starting, b.stopping)
+	b.Service = services.NewIdleService(b.starting, b.stopping)
 
 	return b, nil
 }

--- a/pkg/querier/block_store.go
+++ b/pkg/querier/block_store.go
@@ -107,7 +107,12 @@ func (u *UserStore) starting(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	go u.serv.Serve(l) //nolint:errcheck
+	go func() {
+		err := u.serv.Serve(l)
+		if err != nil {
+			level.Error(u.logger).Log("msg", "block store grpc server failed", "err", err)
+		}
+	}()
 
 	cc, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure())
 	if err != nil {

--- a/pkg/querier/block_store.go
+++ b/pkg/querier/block_store.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/pstibrany/services"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/model"
 	"github.com/thanos-io/thanos/pkg/objstore"
@@ -28,12 +27,13 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
 // UserStore is a multi-tenant version of Thanos BucketStore
 type UserStore struct {
-	services.BasicService
+	services.Service
 
 	logger             log.Logger
 	cfg                tsdb.Config
@@ -96,7 +96,7 @@ func NewUserStore(cfg tsdb.Config, bucketClient objstore.Bucket, logLevel loggin
 		registerer.MustRegister(u.syncTimes, u.bucketStoreMetrics, u.indexCacheMetrics)
 	}
 
-	services.InitBasicService(&u.BasicService, u.starting, u.syncStoresLoop, u.stopping)
+	u.Service = services.NewBasicService(u.starting, u.syncStoresLoop, u.stopping)
 	return u, nil
 }
 

--- a/pkg/querier/block_store_test.go
+++ b/pkg/querier/block_store_test.go
@@ -66,15 +66,8 @@ func TestUserStore_InitialSync(t *testing.T) {
 
 			us, err := NewUserStore(cfg, bucketClient, mockLoggingLevel(), log.NewNopLogger(), nil)
 			if err == nil {
-				err = us.StartAsync(context.Background())
-				if err == nil {
-					err = us.AwaitRunning(context.Background())
-					if us.FailureCase() != nil {
-						err = us.FailureCase()
-					}
-				}
-
-				defer us.StopAsync()
+				err = services.StartAndAwaitRunning(context.Background(), us)
+				defer services.StopAndAwaitTerminated(context.Background(), us)
 			}
 
 			require.Equal(t, testData.expectedErr, err)

--- a/pkg/querier/block_store_test.go
+++ b/pkg/querier/block_store_test.go
@@ -67,7 +67,7 @@ func TestUserStore_InitialSync(t *testing.T) {
 			us, err := NewUserStore(cfg, bucketClient, mockLoggingLevel(), log.NewNopLogger(), nil)
 			if err == nil {
 				err = services.StartAndAwaitRunning(context.Background(), us)
-				defer services.StopAndAwaitTerminated(context.Background(), us)
+				defer services.StopAndAwaitTerminated(context.Background(), us) //nolint:errcheck
 			}
 
 			require.Equal(t, testData.expectedErr, err)
@@ -90,7 +90,7 @@ func TestUserStore_syncUserStores(t *testing.T) {
 	us, err := NewUserStore(cfg, bucketClient, mockLoggingLevel(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), us))
-	defer services.StopAndAwaitTerminated(context.Background(), us)
+	defer services.StopAndAwaitTerminated(context.Background(), us) //nolint:errcheck
 
 	// Sync user stores and count the number of times the callback is called.
 	storesCount := int32(0)

--- a/pkg/querier/block_store_test.go
+++ b/pkg/querier/block_store_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 func TestUserStore_InitialSync(t *testing.T) {
@@ -95,9 +96,8 @@ func TestUserStore_syncUserStores(t *testing.T) {
 
 	us, err := NewUserStore(cfg, bucketClient, mockLoggingLevel(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
-	require.NoError(t, us.StartAsync(context.Background()))
-	require.NoError(t, us.AwaitRunning(context.Background()))
-	defer us.StopAsync()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), us))
+	defer services.StopAndAwaitTerminated(context.Background(), us)
 
 	// Sync user stores and count the number of times the callback is called.
 	storesCount := int32(0)

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -13,11 +13,11 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/pstibrany/services"
 
 	"github.com/cortexproject/cortex/pkg/ring/kv"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 var (
@@ -106,7 +106,7 @@ func (cfg *LifecyclerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.Flag
 
 // Lifecycler is responsible for managing the lifecycle of entries in the ring.
 type Lifecycler struct {
-	services.BasicService
+	*services.BasicService
 
 	cfg             LifecyclerConfig
 	flushTransferer FlushTransferer
@@ -184,7 +184,7 @@ func NewLifecycler(cfg LifecyclerConfig, flushTransferer FlushTransferer, ringNa
 
 	tokensToOwn.WithLabelValues(l.RingName).Set(float64(cfg.NumTokens))
 
-	services.InitBasicService(&l.BasicService, nil, l.loop, l.stopping)
+	l.BasicService = services.NewBasicService(nil, l.loop, l.stopping)
 
 	return l, nil
 }

--- a/pkg/ring/lifecycler_test.go
+++ b/pkg/ring/lifecycler_test.go
@@ -60,7 +60,7 @@ func TestLifecycler_HealthyInstancesCount(t *testing.T) {
 	r, err := New(ringConfig, "ingester", IngesterRingKey)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
-	defer services.StopAndAwaitTerminated(context.Background(), r)
+	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	// Add the first ingester to the ring
 	lifecyclerConfig1 := testLifecyclerConfig(ringConfig, "ing1")
@@ -134,12 +134,12 @@ func TestLifecycler_TwoRingsWithDifferentKeysOnTheSameKVStore(t *testing.T) {
 	lifecycler1, err := NewLifecycler(lifecyclerConfig1, nil, "service-1", "ring-1", true)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), lifecycler1))
-	defer services.StopAndAwaitTerminated(context.Background(), lifecycler1)
+	defer services.StopAndAwaitTerminated(context.Background(), lifecycler1) //nolint:errcheck
 
 	lifecycler2, err := NewLifecycler(lifecyclerConfig2, nil, "service-2", "ring-2", true)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), lifecycler2))
-	defer services.StopAndAwaitTerminated(context.Background(), lifecycler2)
+	defer services.StopAndAwaitTerminated(context.Background(), lifecycler2) //nolint:errcheck
 
 	// Ensure each lifecycler reports 1 healthy instance, because they're
 	// in a different ring
@@ -169,7 +169,7 @@ func TestRingRestart(t *testing.T) {
 	r, err := New(ringConfig, "ingester", IngesterRingKey)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
-	defer services.StopAndAwaitTerminated(context.Background(), r)
+	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	// Add an 'ingester' with normalised tokens.
 	lifecyclerConfig1 := testLifecyclerConfig(ringConfig, "ing1")
@@ -279,7 +279,7 @@ func TestTokensOnDisk(t *testing.T) {
 	r, err := New(ringConfig, "ingester", IngesterRingKey)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
-	defer services.StopAndAwaitTerminated(context.Background(), r)
+	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	tokenDir, err := ioutil.TempDir(os.TempDir(), "tokens_on_disk")
 	require.NoError(t, err)
@@ -318,7 +318,7 @@ func TestTokensOnDisk(t *testing.T) {
 	l2, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "ingester", IngesterRingKey, true)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), l2))
-	defer services.StopAndAwaitTerminated(context.Background(), l2)
+	defer services.StopAndAwaitTerminated(context.Background(), l2) //nolint:errcheck
 
 	// Check this ingester joined, is active, and has 512 token.
 	var actTokens []uint32
@@ -353,7 +353,7 @@ func TestJoinInLeavingState(t *testing.T) {
 	r, err := New(ringConfig, "ingester", IngesterRingKey)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
-	defer services.StopAndAwaitTerminated(context.Background(), r)
+	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	cfg := testLifecyclerConfig(ringConfig, "ing1")
 	cfg.NumTokens = 2

--- a/pkg/ring/replication_strategy_test.go
+++ b/pkg/ring/replication_strategy_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/ring/kv"
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 func TestReplicationStrategy(t *testing.T) {
@@ -94,8 +95,8 @@ func TestReplicationStrategy(t *testing.T) {
 			ReplicationFactor: tc.RF,
 		}, "ingester", IngesterRingKey)
 		require.NoError(t, err)
-		require.NoError(t, r.StartAsync(context.Background()))
-		defer r.StopAsync()
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
+		defer services.StopAndAwaitTerminated(context.Background(), r)
 
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
 			liveIngesters, maxFailure, err := r.replicationStrategy(ingesters, tc.op)

--- a/pkg/ring/replication_strategy_test.go
+++ b/pkg/ring/replication_strategy_test.go
@@ -96,7 +96,7 @@ func TestReplicationStrategy(t *testing.T) {
 		}, "ingester", IngesterRingKey)
 		require.NoError(t, err)
 		require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
-		defer services.StopAndAwaitTerminated(context.Background(), r)
+		defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
 			liveIngesters, maxFailure, err := r.replicationStrategy(ingesters, tc.op)

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/pstibrany/services"
 
 	"github.com/cortexproject/cortex/pkg/ring/kv"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 const (
@@ -85,7 +85,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 
 // Ring holds the information about the members of the consistent hash ring.
 type Ring struct {
-	services.BasicService
+	services.Service
 
 	name     string
 	key      string
@@ -147,7 +147,7 @@ func New(cfg Config, name, key string) (*Ring, error) {
 		),
 	}
 
-	services.InitBasicService(&r.BasicService, nil, r.loop, nil)
+	r.Service = services.NewBasicService(nil, r.loop, nil)
 	return r, nil
 }
 

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -20,7 +20,7 @@ func TestRuler_rules(t *testing.T) {
 
 	r, rcleanup := newTestRuler(t, cfg)
 	defer rcleanup()
-	defer services.StopAndAwaitTerminated(context.Background(), r)
+	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	req := httptest.NewRequest("GET", "https://localhost:8080/api/prom/api/v1/rules", nil)
 	req.Header.Add(user.OrgIDHeaderName, "user1")

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -1,6 +1,7 @@
 package ruler
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -9,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 func TestRuler_rules(t *testing.T) {
@@ -17,7 +20,7 @@ func TestRuler_rules(t *testing.T) {
 
 	r, rcleanup := newTestRuler(t, cfg)
 	defer rcleanup()
-	defer r.StopAsync()
+	defer services.StopAndAwaitTerminated(context.Background(), r)
 
 	req := httptest.NewRequest("GET", "https://localhost:8080/api/prom/api/v1/rules", nil)
 	req.Header.Add(user.OrgIDHeaderName, "user1")

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -17,7 +17,7 @@ func TestRuler_rules(t *testing.T) {
 
 	r, rcleanup := newTestRuler(t, cfg)
 	defer rcleanup()
-	defer r.Stop()
+	defer r.StopAsync()
 
 	req := httptest.NewRequest("GET", "https://localhost:8080/api/prom/api/v1/rules", nil)
 	req.Header.Add(user.OrgIDHeaderName, "user1")
@@ -73,7 +73,7 @@ func TestRuler_alerts(t *testing.T) {
 
 	r, rcleanup := newTestRuler(t, cfg)
 	defer rcleanup()
-	defer r.Stop()
+	defer r.StopAsync()
 
 	req := httptest.NewRequest("GET", "https://localhost:8080/api/prom/api/v1/alerts", nil)
 	req.Header.Add(user.OrgIDHeaderName, "user1")

--- a/pkg/ruler/lifecycle_test.go
+++ b/pkg/ruler/lifecycle_test.go
@@ -1,10 +1,12 @@
 package ruler
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/ring/testutils"
@@ -26,7 +28,8 @@ func TestRulerShutdown(t *testing.T) {
 		return testutils.NumTokens(config.Ring.KVStore.Mock, "localhost", ring.RulerRingKey)
 	})
 
-	r.Stop()
+	r.StopAsync()
+	require.NoError(t, r.AwaitTerminated(context.Background()))
 
 	// Wait until the tokens are unregistered from the ring
 	test.Poll(t, 100*time.Millisecond, 0, func() interface{} {
@@ -50,7 +53,8 @@ func TestRulerRestart(t *testing.T) {
 	})
 
 	// Stop the ruler. Doesn't actually unregister due to skipUnregister: true
-	r.Stop()
+	r.StopAsync()
+	require.NoError(t, r.AwaitTerminated(context.Background()))
 
 	// We expect the tokens are preserved in the ring.
 	assert.Equal(t, config.Ring.NumTokens, testutils.NumTokens(config.Ring.KVStore.Mock, "localhost", ring.RulerRingKey))
@@ -58,7 +62,7 @@ func TestRulerRestart(t *testing.T) {
 	// Create a new ruler which is expected to pick up tokens from the ring.
 	r, rcleanup = newTestRuler(t, config)
 	defer rcleanup()
-	defer r.Stop()
+	defer r.StopAsync()
 
 	// Wait until the ruler is ACTIVE in the ring.
 	test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {

--- a/pkg/ruler/lifecycle_test.go
+++ b/pkg/ruler/lifecycle_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/ring/testutils"
+	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/test"
 )
 
@@ -28,8 +29,7 @@ func TestRulerShutdown(t *testing.T) {
 		return testutils.NumTokens(config.Ring.KVStore.Mock, "localhost", ring.RulerRingKey)
 	})
 
-	r.StopAsync()
-	require.NoError(t, r.AwaitTerminated(context.Background()))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), r))
 
 	// Wait until the tokens are unregistered from the ring
 	test.Poll(t, 100*time.Millisecond, 0, func() interface{} {
@@ -62,7 +62,7 @@ func TestRulerRestart(t *testing.T) {
 	// Create a new ruler which is expected to pick up tokens from the ring.
 	r, rcleanup = newTestRuler(t, config)
 	defer rcleanup()
-	defer r.StopAsync()
+	defer services.StopAndAwaitTerminated(context.Background(), r)
 
 	// Wait until the ruler is ACTIVE in the ring.
 	test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {

--- a/pkg/ruler/lifecycle_test.go
+++ b/pkg/ruler/lifecycle_test.go
@@ -62,7 +62,7 @@ func TestRulerRestart(t *testing.T) {
 	// Create a new ruler which is expected to pick up tokens from the ring.
 	r, rcleanup = newTestRuler(t, config)
 	defer rcleanup()
-	defer services.StopAndAwaitTerminated(context.Background(), r)
+	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	// Wait until the ruler is ACTIVE in the ring.
 	test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -24,7 +24,6 @@ import (
 	promRules "github.com/prometheus/prometheus/rules"
 	promStorage "github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/strutil"
-	"github.com/pstibrany/services"
 	"github.com/weaveworks/common/user"
 	"golang.org/x/net/context/ctxhttp"
 	"google.golang.org/grpc"
@@ -35,6 +34,7 @@ import (
 	store "github.com/cortexproject/cortex/pkg/ruler/rules"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 var (
@@ -105,7 +105,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 // Ruler evaluates rules.
 type Ruler struct {
-	services.BasicService
+	services.Service
 
 	cfg         Config
 	engine      *promql.Engine
@@ -158,7 +158,7 @@ func NewRuler(cfg Config, engine *promql.Engine, queryable promStorage.Queryable
 		logger:       logger,
 	}
 
-	services.InitBasicService(&ruler.BasicService, ruler.starting, ruler.run, ruler.stopping)
+	ruler.Service = services.NewBasicService(ruler.starting, ruler.run, ruler.stopping)
 	return ruler, nil
 }
 

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -179,12 +179,8 @@ func (r *Ruler) starting(ctx context.Context) error {
 		}
 
 		r.subservices, err = services.NewManager(r.lifecycler, r.ring)
-		if err != nil {
-			return err
-		}
-		err = r.subservices.StartAsync(ctx)
 		if err == nil {
-			err = r.subservices.AwaitHealthy(ctx)
+			err = services.StartManagerAndAwaitHealthy(ctx, r.subservices)
 		}
 		return errors.Wrap(err, "failed to start ruler's services")
 	}
@@ -204,8 +200,7 @@ func (r *Ruler) stopping() error {
 
 	if r.subservices != nil {
 		// subservices manages ring and lifecycler, if sharding was enabled.
-		r.subservices.StopAsync()
-		_ = r.subservices.AwaitStopped(context.Background())
+		_ = services.StopManagerAndAwaitStopped(context.Background(), r.subservices)
 	}
 
 	level.Info(r.logger).Log("msg", "stopping user managers")

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -113,7 +113,7 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 
 	r, rcleanup := newTestRuler(t, cfg)
 	defer rcleanup()
-	defer services.StopAndAwaitTerminated(context.Background(), r)
+	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	n, err := r.getOrCreateNotifier("1")
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestRuler_Rules(t *testing.T) {
 
 	r, rcleanup := newTestRuler(t, cfg)
 	defer rcleanup()
-	defer services.StopAndAwaitTerminated(context.Background(), r)
+	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
 	// test user1
 	ctx := user.InjectOrgID(context.Background(), "user1")

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ruler/rules"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 func defaultRulerConfig(store rules.RuleStore) (Config, func()) {
@@ -81,8 +82,7 @@ func newTestRuler(t *testing.T, cfg Config) (*Ruler, func()) {
 	l = level.NewFilter(l, level.AllowInfo())
 	ruler, err := NewRuler(cfg, engine, noopQueryable, pusher, prometheus.NewRegistry(), l)
 	require.NoError(t, err)
-	require.NoError(t, ruler.StartAsync(context.Background()))
-	require.NoError(t, ruler.AwaitRunning(context.Background()))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ruler))
 
 	// Ensure all rules are loaded before usage
 	ruler.loadRules(context.Background())

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -81,6 +81,8 @@ func newTestRuler(t *testing.T, cfg Config) (*Ruler, func()) {
 	l = level.NewFilter(l, level.AllowInfo())
 	ruler, err := NewRuler(cfg, engine, noopQueryable, pusher, prometheus.NewRegistry(), l)
 	require.NoError(t, err)
+	require.NoError(t, ruler.StartAsync(context.Background()))
+	require.NoError(t, ruler.AwaitRunning(context.Background()))
 
 	// Ensure all rules are loaded before usage
 	ruler.loadRules(context.Background())
@@ -111,7 +113,7 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 
 	r, rcleanup := newTestRuler(t, cfg)
 	defer rcleanup()
-	defer r.Stop()
+	defer r.StopAsync()
 	n, err := r.getOrCreateNotifier("1")
 	require.NoError(t, err)
 
@@ -135,7 +137,7 @@ func TestRuler_Rules(t *testing.T) {
 
 	r, rcleanup := newTestRuler(t, cfg)
 	defer rcleanup()
-	defer r.Stop()
+	defer r.StopAsync()
 
 	// test user1
 	ctx := user.InjectOrgID(context.Background(), "user1")

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -113,7 +113,8 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 
 	r, rcleanup := newTestRuler(t, cfg)
 	defer rcleanup()
-	defer r.StopAsync()
+	defer services.StopAndAwaitTerminated(context.Background(), r)
+
 	n, err := r.getOrCreateNotifier("1")
 	require.NoError(t, err)
 
@@ -137,7 +138,7 @@ func TestRuler_Rules(t *testing.T) {
 
 	r, rcleanup := newTestRuler(t, cfg)
 	defer rcleanup()
-	defer r.StopAsync()
+	defer services.StopAndAwaitTerminated(context.Background(), r)
 
 	// test user1
 	ctx := user.InjectOrgID(context.Background(), "user1")

--- a/pkg/util/runtimeconfig/manager.go
+++ b/pkg/util/runtimeconfig/manager.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/pstibrany/services"
 
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 // Loader loads the configuration from file.
@@ -33,7 +33,7 @@ func (mc *ManagerConfig) RegisterFlags(f *flag.FlagSet) {
 // Manager periodically reloads the configuration from a file, and keeps this
 // configuration available for clients.
 type Manager struct {
-	services.BasicService
+	services.Service
 
 	cfg ManagerConfig
 
@@ -60,7 +60,7 @@ func NewRuntimeConfigManager(cfg ManagerConfig, registerer prometheus.Registerer
 		registerer.MustRegister(mgr.configLoadSuccess)
 	}
 
-	services.InitBasicService(&mgr.BasicService, mgr.start, mgr.loop, mgr.stop)
+	mgr.Service = services.NewBasicService(mgr.start, mgr.loop, mgr.stop)
 	return &mgr, nil
 }
 

--- a/pkg/util/runtimeconfig/manager_test.go
+++ b/pkg/util/runtimeconfig/manager_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"gopkg.in/yaml.v2"
+
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 type TestLimits struct {
@@ -77,11 +79,10 @@ func TestNewOverridesManager(t *testing.T) {
 
 	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, nil)
 	require.NoError(t, err)
-	require.NoError(t, overridesManager.StartAsync(context.Background()))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
 
 	// Cleaning up
-	overridesManager.StopAsync()
-	require.NoError(t, overridesManager.AwaitTerminated(context.Background()))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager))
 
 	// Make sure test limits were loaded.
 	require.NotNil(t, overridesManager.GetConfig())
@@ -113,7 +114,7 @@ func TestOverridesManager_ListenerWithDefaultLimits(t *testing.T) {
 
 	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, nil)
 	require.NoError(t, err)
-	require.NoError(t, overridesManager.StartAsync(context.Background()))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
 
 	// need to use buffer, otherwise loadConfig will throw away update
 	ch := overridesManager.CreateListenerChannel(1)
@@ -141,8 +142,7 @@ func TestOverridesManager_ListenerWithDefaultLimits(t *testing.T) {
 	require.Equal(t, 100, to.Overrides["user2"].Limit1) // from defaults
 
 	// Cleaning up
-	overridesManager.StopAsync()
-	require.NoError(t, overridesManager.AwaitTerminated(context.Background()))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager))
 
 	// Make sure test limits were loaded.
 	require.NotNil(t, overridesManager.GetConfig())
@@ -163,8 +163,7 @@ func TestOverridesManager_ListenerChannel(t *testing.T) {
 
 	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, nil)
 	require.NoError(t, err)
-	require.NoError(t, overridesManager.StartAsync(context.Background()))
-	require.NoError(t, overridesManager.AwaitRunning(context.Background()))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
 
 	// need to use buffer, otherwise loadConfig will throw away update
 	ch := overridesManager.CreateListenerChannel(1)

--- a/pkg/util/runtimeconfig/manager_test.go
+++ b/pkg/util/runtimeconfig/manager_test.go
@@ -164,6 +164,7 @@ func TestOverridesManager_ListenerChannel(t *testing.T) {
 	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, nil)
 	require.NoError(t, err)
 	require.NoError(t, overridesManager.StartAsync(context.Background()))
+	require.NoError(t, overridesManager.AwaitRunning(context.Background()))
 
 	// need to use buffer, otherwise loadConfig will throw away update
 	ch := overridesManager.CreateListenerChannel(1)

--- a/pkg/util/runtimeconfig/manager_test.go
+++ b/pkg/util/runtimeconfig/manager_test.go
@@ -213,13 +213,12 @@ func TestOverridesManager_StopClosesListenerChannels(t *testing.T) {
 
 	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, nil)
 	require.NoError(t, err)
-	require.NoError(t, overridesManager.StartAsync(context.Background()))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
 
 	// need to use buffer, otherwise loadConfig will throw away update
 	ch := overridesManager.CreateListenerChannel(0)
 
-	overridesManager.StopAsync()
-	require.NoError(t, overridesManager.AwaitTerminated(context.Background()))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), overridesManager))
 
 	select {
 	case _, ok := <-ch:

--- a/pkg/util/services/basic_service.go
+++ b/pkg/util/services/basic_service.go
@@ -101,6 +101,8 @@ func (b *BasicService) StartAsync(parentContext context.Context) error {
 	return nil
 }
 
+// Returns true, if state switch succeeds, false if it fails. Returned state is current state before switch.
+// if state switching succeeds, stateFn is run with lock held.
 func (b *BasicService) switchState(from, to State, stateFn func()) (bool, State) {
 	b.stateMu.Lock()
 	defer b.stateMu.Unlock()

--- a/pkg/util/services/basic_service.go
+++ b/pkg/util/services/basic_service.go
@@ -101,8 +101,8 @@ func (b *BasicService) StartAsync(parentContext context.Context) error {
 	return nil
 }
 
-// Returns true, if state switch succeeds, false if it fails. Returned state is current state before switch.
-// if state switching succeeds, stateFn is run with lock held.
+// Returns true, if state switch succeeds, false if it fails. Returned state is the state before switch.
+// if state switching succeeds, stateFn runs with lock held.
 func (b *BasicService) switchState(from, to State, stateFn func()) (bool, State) {
 	b.stateMu.Lock()
 	defer b.stateMu.Unlock()

--- a/pkg/util/services/manager.go
+++ b/pkg/util/services/manager.go
@@ -306,3 +306,24 @@ func (f funcBasedManagerListener) Failure(service Service) {
 		f.failure(service)
 	}
 }
+
+// StartManagerAndAwaitHealthy starts the manager (which in turns starts all services managed by it), and then waits
+// until it reaches Running state. All services that this manager manages must be in New state, otherwise starting
+// will fail.
+//
+// Notice that context passed to the manager for starting its services is the same as context used for waiting!
+func StartManagerAndAwaitHealthy(ctx context.Context, manager *Manager) error {
+	err := manager.StartAsync(ctx)
+	if err != nil {
+		return err
+	}
+
+	return manager.AwaitHealthy(ctx)
+}
+
+// StopManagerAndAwaitStopped asks manager to stop its services, and then waits
+// until manager reaches the stopped state or context is stopped.
+func StopManagerAndAwaitStopped(ctx context.Context, manager *Manager) error {
+	manager.StopAsync()
+	return manager.AwaitStopped(ctx)
+}

--- a/pkg/util/services/services.go
+++ b/pkg/util/services/services.go
@@ -98,6 +98,7 @@ func (f funcBasedListener) Failed(from State, failure error) {
 // Service must be in New state when this function is called.
 //
 // Notice that context passed to the service for starting is the same as context used for waiting!
+// If you need these contexts to be different, please use StartAsync and AwaitRunning directly.
 func StartAndAwaitRunning(ctx context.Context, service Service) error {
 	err := service.StartAsync(ctx)
 	if err != nil {

--- a/pkg/util/services/services.go
+++ b/pkg/util/services/services.go
@@ -107,8 +107,8 @@ func StartAndAwaitRunning(ctx context.Context, service Service) error {
 }
 
 // StopAndAwaitTerminated asks service to stop, and then waits until service reaches Terminated
-// or Failed state. On Terminated state, this function returns error. On Failed state, it returns
-// the failure case.
+// or Failed state. If service ends in Terminated state, this function returns error. On Failed state,
+// it returns the failure case. Other errors are possible too (eg. if context stops before service does).
 func StopAndAwaitTerminated(ctx context.Context, service Service) error {
 	service.StopAsync()
 	err := service.AwaitTerminated(ctx)
@@ -120,6 +120,6 @@ func StopAndAwaitTerminated(ctx context.Context, service Service) error {
 		return e
 	}
 
-	// should not happen, but just in case...
+	// can happen e.g. if context was canceled
 	return err
 }

--- a/pkg/util/services/services.go
+++ b/pkg/util/services/services.go
@@ -94,6 +94,7 @@ func (f funcBasedListener) Failed(from State, failure error) {
 }
 
 // StartAndAwaitRunning starts the service, and then waits until it reaches Running state.
+// If service fails to start, its failure case is returned.
 // Service must be in New state when this function is called.
 //
 // Notice that context passed to the service for starting is the same as context used for waiting!
@@ -103,7 +104,12 @@ func StartAndAwaitRunning(ctx context.Context, service Service) error {
 		return err
 	}
 
-	return service.AwaitRunning(ctx)
+	err = service.AwaitRunning(ctx)
+	if e := service.FailureCase(); e != nil {
+		return e
+	}
+
+	return err
 }
 
 // StopAndAwaitTerminated asks service to stop, and then waits until service reaches Terminated


### PR DESCRIPTION
This PR is a supplement to [proposal document](https://docs.google.com/document/d/1GMpNK4EuQ1IQQOLZuub5vTWXCUMZdSMNgKrAEeq1Cy0/edit?usp=sharing) to revamp service model used by Cortex.

The document and this PR are based on the concept of "Service", as used in [Google Guava library](https://github.com/google/guava/wiki/ServiceExplained): Service is an object with operational state, with methods to start/stop the service, well-defined and observable state, methods for waiting for state transitions. Google Guava is a Java library, here we use reimplementation of [Services concept in Go](https://github.com/pstibrany/services). **Update: now part of Cortex, as of PR #2188.**

In this PR, Cortex components like ingester, ruler, ring or lifecycler are converted to such services.
During startup Cortex collects all the services from modules that are supposed to run (based on target module), and then starts them in parallel. Module can either contribute a service directly, or use so-called "wrapped" service – wrapped services will make sure that services are still started and stopped in a correct order based on module dependencies.

**Important change** in module initialization code is that services are returned in "New" state – they are not supposed to start any background tasks until started. That means that initialization is faster.

Main Cortex Run method now simply starts all services, and then waits until "Server" service stops or any service fails, and then initiates shutdown. "Server" service is special because it reacts on SIGTERM signal (this is how Cortex always worked). It also runs HTTP and gRPC servers.

Not all benefits of services model are implemented, but some are: for example Blocks-based StoreQueryable now fetches indexes in the background, while other services start (most importantly "Server" itself with HTTP server, for collecting metrics). Until StoreQueryable is done, Cortex doesn't transition to "Started" phase, but since HTTP server already runs, we can collect its metrics.

WAL replays in ingester are not done in background in this PR... while it would be trivial to do this change, ingester would need more changes to check if it's running already or not, and it seemed like out of scope for this PR.

Another possible area for cleanups is Lifecycler -- now it has a way to return errors, instead of just doing `os.Exit`. We should use that.

Please familiarize yourself with [services concept](https://github.com/google/guava/wiki/ServiceExplained), [Go implementation (Service interface, BasicService implementation and ServiceManager](https://github.com/pstibrany/services). This PR touches many places, but "conversion" to services was pretty straightforward.

This is an alternative to PR #2119.
