### PR TITLE
Add config file support to integration tests

### DIFF
--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -66,3 +66,6 @@ compactor:
       store: consul
       consul:
         host: consul:8500
+
+frontend_worker:
+  address: "query-frontend:9007"

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -108,3 +108,17 @@ services:
       - 8006:8006
     volumes:
       - ./config:/cortex/config
+
+  query-frontend:
+    build:
+      context:    .
+      dockerfile: dev.dockerfile
+    image: cortex
+    command: ["sh", "-c", "sleep 3 && exec ./cortex -config.file=./config/cortex.yaml -target=query-frontend -server.http-listen-port=8007 -server.grpc-listen-port=9007"]
+    depends_on:
+      - consul
+      - minio
+    ports:
+      - 8007:8007
+    volumes:
+      - ./config:/cortex/config

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -17,7 +17,7 @@ func TestAlertmanager(t *testing.T) {
 
 	require.NoError(t, writeFileToSharedDir(s, "alertmanager_configs/user-1.yaml", []byte(cortexAlertmanagerUserConfigYaml)))
 
-	alertmanager := e2ecortex.NewAlertmanager("alertmanager", AlertmanagerConfigs, "")
+	alertmanager := e2ecortex.NewAlertmanager("alertmanager", AlertmanagerFlags, "")
 	require.NoError(t, s.StartAndWaitReady(alertmanager))
 	require.NoError(t, alertmanager.WaitSumMetrics(e2e.Equals(1), "cortex_alertmanager_configs"))
 

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,14 +15,7 @@ func TestAlertmanager(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	alertmanagerDir := filepath.Join(s.SharedDir(), "alertmanager_configs")
-	require.NoError(t, os.Mkdir(alertmanagerDir, os.ModePerm))
-
-	require.NoError(t, ioutil.WriteFile(
-		filepath.Join(alertmanagerDir, "user-1.yaml"),
-		[]byte(cortexAlertmanagerUserConfigYaml),
-		os.ModePerm),
-	)
+	require.NoError(t, writeFileToSharedDir(s, "alertmanager_configs/user-1.yaml", []byte(cortexAlertmanagerUserConfigYaml)))
 
 	alertmanager := e2ecortex.NewAlertmanager("alertmanager", AlertmanagerConfigs, "")
 	require.NoError(t, s.StartAndWaitReady(alertmanager))

--- a/integration/api_config_test.go
+++ b/integration/api_config_test.go
@@ -25,7 +25,7 @@ func TestConfigAPIEndpoint(t *testing.T) {
 		"-config.file": filepath.Join(e2e.ContainerSharedDir, cortexConfigFile),
 	}
 
-	cortex1 := e2ecortex.NewSingleBinary("cortex-1", flags, "", 9009)
+	cortex1 := e2ecortex.NewSingleBinary("cortex-1", flags, "", 9009, 9095)
 	require.NoError(t, s.StartAndWaitReady(cortex1))
 
 	// Get config from /config API endpoint.
@@ -40,6 +40,6 @@ func TestConfigAPIEndpoint(t *testing.T) {
 	// Start again Cortex in single binary with the exported config
 	// and ensure it starts (pass the readiness probe).
 	require.NoError(t, writeFileToSharedDir(s, cortexConfigFile, body))
-	cortex2 := e2ecortex.NewSingleBinary("cortex-2", flags, "", 9009)
+	cortex2 := e2ecortex.NewSingleBinary("cortex-2", flags, "", 9009, 9095)
 	require.NoError(t, s.StartAndWaitReady(cortex2))
 }

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -31,9 +31,9 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 
 	// Start Cortex components (ingester running on previous version).
 	require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
-	tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorage, previousVersionImage)
-	ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), ChunksStorage, "")
-	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), ChunksStorage, "")
+	tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorageFlags, previousVersionImage)
+	ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, "")
+	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, "")
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester1, tableManager))
 
 	// Wait until the first table-manager sync has completed, so that we're
@@ -54,7 +54,7 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	ingester2 := e2ecortex.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), mergeFlags(ChunksStorage, map[string]string{
+	ingester2 := e2ecortex.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), mergeFlags(ChunksStorageFlags, map[string]string{
 		"-ingester.join-after": "10s",
 	}), "")
 	// Start ingester-2 on new version, to ensure the transfer is backward compatible.
@@ -66,7 +66,7 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 
 	// Query the new ingester both with the old and the new querier.
 	for _, image := range []string{previousVersionImage, ""} {
-		querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(), ChunksStorage, image)
+		querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, image)
 		require.NoError(t, s.StartAndWaitReady(querier))
 
 		// Wait until the querier has updated the ring.

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
+	"text/template"
 
 	"github.com/cortexproject/cortex/integration/e2e"
 	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
@@ -33,13 +35,13 @@ receivers:
 )
 
 var (
-	AlertmanagerConfigs = map[string]string{
+	AlertmanagerFlags = map[string]string{
 		"-alertmanager.storage.local.path": filepath.Join(e2e.ContainerSharedDir, "alertmanager_configs"),
 		"-alertmanager.storage.type":       "local",
 		"-alertmanager.web.external-url":   "http://localhost/api/prom",
 	}
 
-	BlocksStorage = map[string]string{
+	BlocksStorageFlags = map[string]string{
 		"-store.engine":                                 "tsdb",
 		"-experimental.tsdb.backend":                    "s3",
 		"-experimental.tsdb.block-ranges-period":        "1m",
@@ -53,10 +55,90 @@ var (
 		"-experimental.tsdb.s3.insecure":                "true",
 	}
 
-	ChunksStorage = map[string]string{
+	BlocksStorageConfig = buildConfigFromTemplate(`
+storage:
+  engine: tsdb
+
+tsdb:
+  backend:             s3
+  block_ranges_period: ["1m"]
+  retention_period:    5m
+  ship_interval:       1m
+
+  bucket_store:
+    sync_interval: 5s
+
+  s3:
+    bucket_name:       cortex
+    access_key_id:     {{.MinioAccessKey}}
+    secret_access_key: {{.MinioSecretKey}}
+    endpoint:          {{.MinioEndpoint}}
+    insecure:          true
+`, struct {
+		MinioAccessKey string
+		MinioSecretKey string
+		MinioEndpoint  string
+	}{
+		MinioAccessKey: e2edb.MinioAccessKey,
+		MinioSecretKey: e2edb.MinioSecretKey,
+		MinioEndpoint:  fmt.Sprintf("%s-minio-9000:9000", networkName),
+	})
+
+	ChunksStorageFlags = map[string]string{
 		"-dynamodb.url":                   fmt.Sprintf("dynamodb://u:p@%s-dynamodb.:8000", networkName),
 		"-dynamodb.poll-interval":         "1m",
 		"-config-yaml":                    filepath.Join(e2e.ContainerSharedDir, cortexSchemaConfigFile),
 		"-table-manager.retention-period": "168h",
 	}
+
+	ChunksStorageConfig = buildConfigFromTemplate(`
+storage:
+  aws:
+    dynamodbconfig:
+      dynamodb: {{.DynamoDBURL}}
+
+table_manager:
+  dynamodb_poll_interval: 1m
+  retention_period:       168h
+
+schema:
+{{.SchemaConfig}}
+`, struct {
+		DynamoDBURL  string
+		SchemaConfig string
+	}{
+		DynamoDBURL:  fmt.Sprintf("dynamodb://u:p@%s-dynamodb.:8000", networkName),
+		SchemaConfig: indentConfig(cortexSchemaConfigYaml, 2),
+	})
 )
+
+func buildConfigFromTemplate(tmpl string, data interface{}) string {
+	t, err := template.New("config").Parse(tmpl)
+	if err != nil {
+		panic(err)
+	}
+
+	w := &strings.Builder{}
+	if err = t.Execute(w, data); err != nil {
+		panic(err)
+	}
+
+	return w.String()
+}
+
+func indentConfig(config string, indentation int) string {
+	output := strings.Builder{}
+
+	for _, line := range strings.Split(config, "\n") {
+		if line == "" {
+			output.WriteString("\n")
+			continue
+		}
+
+		output.WriteString(strings.Repeat(" ", indentation))
+		output.WriteString(line)
+		output.WriteString("\n")
+	}
+
+	return output.String()
+}

--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -17,6 +17,10 @@ func RunCommandAndGetOutput(name string, args ...string) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
+func EmptyFlags() map[string]string {
+	return map[string]string{}
+}
+
 func MergeFlags(inputs ...map[string]string) map[string]string {
 	output := map[string]string{}
 

--- a/integration/e2ecortex/service.go
+++ b/integration/e2ecortex/service.go
@@ -1,0 +1,33 @@
+package e2ecortex
+
+import "github.com/cortexproject/cortex/integration/e2e"
+
+// CortexService represents a Cortex service with at least an HTTP and GRPC port exposed.
+type CortexService struct {
+	*e2e.HTTPService
+
+	grpcPort int
+}
+
+func NewCortexService(
+	name string,
+	image string,
+	command *e2e.Command,
+	readiness *e2e.ReadinessProbe,
+	httpPort int,
+	grpcPort int,
+	otherPorts ...int,
+) *CortexService {
+	return &CortexService{
+		HTTPService: e2e.NewHTTPService(name, image, command, readiness, httpPort, otherPorts...),
+		grpcPort:    grpcPort,
+	}
+}
+
+func (s *CortexService) GRPCEndpoint() string {
+	return s.Endpoint(s.grpcPort)
+}
+
+func (s *CortexService) NetworkGRPCEndpoint() string {
+	return s.NetworkEndpoint(s.grpcPort)
+}

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -2,6 +2,7 @@ package e2ecortex
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/cortexproject/cortex/integration/e2e"
 )
@@ -23,6 +24,14 @@ func GetDefaultImage() string {
 }
 
 func NewDistributor(name string, consulAddress string, flags map[string]string, image string) *CortexService {
+	return NewDistributorWithConfigFile(name, consulAddress, "", flags, image)
+}
+
+func NewDistributorWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string) *CortexService {
+	if configFile != "" {
+		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
+	}
+
 	if image == "" {
 		image = GetDefaultImage()
 	}
@@ -46,6 +55,14 @@ func NewDistributor(name string, consulAddress string, flags map[string]string, 
 }
 
 func NewQuerier(name string, consulAddress string, flags map[string]string, image string) *CortexService {
+	return NewQuerierWithConfigFile(name, consulAddress, "", flags, image)
+}
+
+func NewQuerierWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string) *CortexService {
+	if configFile != "" {
+		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
+	}
+
 	if image == "" {
 		image = GetDefaultImage()
 	}
@@ -55,7 +72,7 @@ func NewQuerier(name string, consulAddress string, flags map[string]string, imag
 		image,
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-target":                         "querier",
-			"-log.level":                      "info", // TODO warn
+			"-log.level":                      "warn",
 			"-distributor.replication-factor": "1",
 			// Configure the ingesters ring backend
 			"-ring.store":      "consul",
@@ -73,6 +90,13 @@ func NewQuerier(name string, consulAddress string, flags map[string]string, imag
 }
 
 func NewIngester(name string, consulAddress string, flags map[string]string, image string) *CortexService {
+	return NewIngesterWithConfigFile(name, consulAddress, "", flags, image)
+}
+
+func NewIngesterWithConfigFile(name, consulAddress, configFile string, flags map[string]string, image string) *CortexService {
+	if configFile != "" {
+		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
+	}
 	if image == "" {
 		image = GetDefaultImage()
 	}
@@ -100,6 +124,14 @@ func NewIngester(name string, consulAddress string, flags map[string]string, ima
 }
 
 func NewTableManager(name string, flags map[string]string, image string) *CortexService {
+	return NewTableManagerWithConfigFile(name, "", flags, image)
+}
+
+func NewTableManagerWithConfigFile(name, configFile string, flags map[string]string, image string) *CortexService {
+	if configFile != "" {
+		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
+	}
+
 	if image == "" {
 		image = GetDefaultImage()
 	}
@@ -119,6 +151,14 @@ func NewTableManager(name string, flags map[string]string, image string) *Cortex
 }
 
 func NewQueryFrontend(name string, flags map[string]string, image string) *CortexService {
+	return NewQueryFrontendWithConfigFile(name, "", flags, image)
+}
+
+func NewQueryFrontendWithConfigFile(name, configFile string, flags map[string]string, image string) *CortexService {
+	if configFile != "" {
+		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
+	}
+
 	if image == "" {
 		image = GetDefaultImage()
 	}
@@ -128,7 +168,7 @@ func NewQueryFrontend(name string, flags map[string]string, image string) *Corte
 		image,
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-target":    "query-frontend",
-			"-log.level": "info", // TODO warn
+			"-log.level": "warn",
 		}, flags))...),
 		// The query-frontend doesn't expose a readiness probe, so we just check if the / returns 404
 		e2e.NewReadinessProbe(httpPort, "/", 404),

--- a/integration/getting_started_single_process_config_test.go
+++ b/integration/getting_started_single_process_config_test.go
@@ -26,10 +26,10 @@ func TestGettingStartedSingleProcessConfig(t *testing.T) {
 		"-config.file": filepath.Join(e2e.ContainerSharedDir, cortexConfigFile),
 	}
 
-	cortex := e2ecortex.NewSingleBinary("cortex-1", flags, "", 9009)
+	cortex := e2ecortex.NewSingleBinary("cortex-1", flags, "", 9009, 9095)
 	require.NoError(t, s.StartAndWaitReady(cortex))
 
-	c, err := e2ecortex.NewClient(cortex.Endpoint(9009), cortex.Endpoint(9009), "", "user-1")
+	c, err := e2ecortex.NewClient(cortex.HTTPEndpoint(), cortex.HTTPEndpoint(), "", "user-1")
 	require.NoError(t, err)
 
 	// Push some series to Cortex.

--- a/integration/ingester_flush_test.go
+++ b/integration/ingester_flush_test.go
@@ -30,12 +30,12 @@ func TestIngesterFlushWithChunksStorage(t *testing.T) {
 	// Start Cortex components.
 	require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
 
-	tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorage, "")
-	ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), mergeFlags(ChunksStorage, map[string]string{
+	tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorageFlags, "")
+	ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), mergeFlags(ChunksStorageFlags, map[string]string{
 		"-ingester.max-transfer-retries": "0",
 	}), "")
-	querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(), ChunksStorage, "")
-	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), ChunksStorage, "")
+	querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, "")
+	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, "")
 	require.NoError(t, s.StartAndWaitReady(distributor, querier, ingester1, tableManager))
 
 	// Wait until the first table-manager sync has completed, so that we're

--- a/integration/ingester_hand_over_test.go
+++ b/integration/ingester_hand_over_test.go
@@ -14,20 +14,20 @@ import (
 )
 
 func TestIngesterHandOverWithBlocksStorage(t *testing.T) {
-	runIngesterHandOverTest(t, BlocksStorage, func(t *testing.T, s *e2e.Scenario) {
-		minio := e2edb.NewMinio(9000, BlocksStorage["-experimental.tsdb.s3.bucket-name"])
+	runIngesterHandOverTest(t, BlocksStorageFlags, func(t *testing.T, s *e2e.Scenario) {
+		minio := e2edb.NewMinio(9000, BlocksStorageFlags["-experimental.tsdb.s3.bucket-name"])
 		require.NoError(t, s.StartAndWaitReady(minio))
 	})
 }
 
 func TestIngesterHandOverWithChunksStorage(t *testing.T) {
-	runIngesterHandOverTest(t, ChunksStorage, func(t *testing.T, s *e2e.Scenario) {
+	runIngesterHandOverTest(t, ChunksStorageFlags, func(t *testing.T, s *e2e.Scenario) {
 		dynamo := e2edb.NewDynamoDB()
 		require.NoError(t, s.StartAndWaitReady(dynamo))
 
 		require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
 
-		tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorage, "")
+		tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorageFlags, "")
 		require.NoError(t, s.StartAndWaitReady(tableManager))
 
 		// Wait until the first table-manager sync has completed, so that we're

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -77,7 +77,7 @@ func newSingleBinary(name string, join string) *e2ecortex.CortexService {
 
 	serv := e2ecortex.NewSingleBinary(
 		name,
-		mergeFlags(ChunksStorage, flags),
+		mergeFlags(ChunksStorageFlags, flags),
 		"",
 		80,
 		8000,

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -55,7 +55,7 @@ func TestSingleBinaryWithMemberlist(t *testing.T) {
 	require.NoError(t, s.Stop(cortex3))
 }
 
-func newSingleBinary(name string, join string) *e2e.HTTPService {
+func newSingleBinary(name string, join string) *e2ecortex.CortexService {
 	flags := map[string]string{
 		"-target":                        "all", // single-binary mode
 		"-log.level":                     "warn",

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -16,30 +16,66 @@ import (
 	"github.com/cortexproject/cortex/integration/e2ecortex"
 )
 
-func TestQueryFrontendWithBlocksStorage(t *testing.T) {
-	runQueryFrontendTest(t, BlocksStorage, func(t *testing.T, s *e2e.Scenario) {
-		minio := e2edb.NewMinio(9000, BlocksStorage["-experimental.tsdb.s3.bucket-name"])
+type queryFrontendSetup func(t *testing.T, s *e2e.Scenario) (configFile string, flags map[string]string)
+
+func TestQueryFrontendWithBlocksStorageViaFlags(t *testing.T) {
+	runQueryFrontendTest(t, func(t *testing.T, s *e2e.Scenario) (configFile string, flags map[string]string) {
+		minio := e2edb.NewMinio(9000, BlocksStorageFlags["-experimental.tsdb.s3.bucket-name"])
 		require.NoError(t, s.StartAndWaitReady(minio))
+
+		return "", BlocksStorageFlags
 	})
 }
 
-func TestQueryFrontendWithChunksStorage(t *testing.T) {
-	runQueryFrontendTest(t, ChunksStorage, func(t *testing.T, s *e2e.Scenario) {
+func TestQueryFrontendWithBlocksStorageViaConfigFile(t *testing.T) {
+	runQueryFrontendTest(t, func(t *testing.T, s *e2e.Scenario) (configFile string, flags map[string]string) {
+		require.NoError(t, writeFileToSharedDir(s, cortexConfigFile, []byte(BlocksStorageConfig)))
+
+		minio := e2edb.NewMinio(9000, BlocksStorageFlags["-experimental.tsdb.s3.bucket-name"])
+		require.NoError(t, s.StartAndWaitReady(minio))
+
+		return cortexConfigFile, e2e.EmptyFlags()
+	})
+}
+
+func TestQueryFrontendWithChunksStorageViaFlags(t *testing.T) {
+	runQueryFrontendTest(t, func(t *testing.T, s *e2e.Scenario) (configFile string, flags map[string]string) {
+		require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
+
 		dynamo := e2edb.NewDynamoDB()
 		require.NoError(t, s.StartAndWaitReady(dynamo))
 
-		require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
-
-		tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorage, "")
+		tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorageFlags, "")
 		require.NoError(t, s.StartAndWaitReady(tableManager))
 
 		// Wait until the first table-manager sync has completed, so that we're
 		// sure the tables have been created.
 		require.NoError(t, tableManager.WaitSumMetrics(e2e.Greater(0), "cortex_dynamo_sync_tables_seconds"))
+
+		return "", ChunksStorageFlags
 	})
 }
 
-func runQueryFrontendTest(t *testing.T, flags map[string]string, setup func(t *testing.T, s *e2e.Scenario)) {
+func TestQueryFrontendWithChunksStorageViaConfigFile(t *testing.T) {
+	runQueryFrontendTest(t, func(t *testing.T, s *e2e.Scenario) (configFile string, flags map[string]string) {
+		require.NoError(t, writeFileToSharedDir(s, cortexConfigFile, []byte(ChunksStorageConfig)))
+		require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
+
+		dynamo := e2edb.NewDynamoDB()
+		require.NoError(t, s.StartAndWaitReady(dynamo))
+
+		tableManager := e2ecortex.NewTableManagerWithConfigFile("table-manager", cortexConfigFile, e2e.EmptyFlags(), "")
+		require.NoError(t, s.StartAndWaitReady(tableManager))
+
+		// Wait until the first table-manager sync has completed, so that we're
+		// sure the tables have been created.
+		require.NoError(t, tableManager.WaitSumMetrics(e2e.Greater(0), "cortex_dynamo_sync_tables_seconds"))
+
+		return cortexConfigFile, e2e.EmptyFlags()
+	})
+}
+
+func runQueryFrontendTest(t *testing.T, setup queryFrontendSetup) {
 	const numUsers = 10
 	const numQueriesPerUser = 10
 
@@ -50,17 +86,17 @@ func runQueryFrontendTest(t *testing.T, flags map[string]string, setup func(t *t
 	consul := e2edb.NewConsul()
 	require.NoError(t, s.StartAndWaitReady(consul))
 
-	setup(t, s)
+	configFile, flags := setup(t, s)
 
 	// Start Cortex components.
-	queryFrontend := e2ecortex.NewQueryFrontend("query-frontend", flags, "")
-	ingester := e2ecortex.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, "")
-	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
+	queryFrontend := e2ecortex.NewQueryFrontendWithConfigFile("query-frontend", configFile, flags, "")
+	ingester := e2ecortex.NewIngesterWithConfigFile("ingester", consul.NetworkHTTPEndpoint(), configFile, flags, "")
+	distributor := e2ecortex.NewDistributorWithConfigFile("distributor", consul.NetworkHTTPEndpoint(), configFile, flags, "")
 	require.NoError(t, s.StartAndWaitReady(queryFrontend, distributor, ingester))
 
 	// Start the querier after the query-frontend otherwise we're not
 	// able to get the query-frontend network endpoint.
-	querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(), mergeFlags(flags, map[string]string{
+	querier := e2ecortex.NewQuerierWithConfigFile("querier", consul.NetworkHTTPEndpoint(), configFile, mergeFlags(flags, map[string]string{
 		"-querier.frontend-address": queryFrontend.NetworkGRPCEndpoint(),
 	}), "")
 	require.NoError(t, s.StartAndWaitReady(querier))

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -61,7 +61,7 @@ func runQueryFrontendTest(t *testing.T, flags map[string]string, setup func(t *t
 	// Start the querier after the query-frontend otherwise we're not
 	// able to get the query-frontend network endpoint.
 	querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(), mergeFlags(flags, map[string]string{
-		"-querier.frontend-address": queryFrontend.NetworkEndpoint(e2ecortex.GRPCPort),
+		"-querier.frontend-address": queryFrontend.NetworkGRPCEndpoint(),
 	}), "")
 	require.NoError(t, s.StartAndWaitReady(querier))
 

--- a/integration/util.go
+++ b/integration/util.go
@@ -28,8 +28,15 @@ func getCortexProjectDir() string {
 }
 
 func writeFileToSharedDir(s *e2e.Scenario, dst string, content []byte) error {
+	dst = filepath.Join(s.SharedDir(), dst)
+
+	// Ensure the entire path of directories exist.
+	if err := os.MkdirAll(filepath.Dir(dst), os.ModePerm); err != nil {
+		return err
+	}
+
 	return ioutil.WriteFile(
-		filepath.Join(s.SharedDir(), dst),
+		dst,
 		content,
 		os.ModePerm)
 }


### PR DESCRIPTION
**What this PR does**:
While reviewing the PR #1878 it popped up that the PR may change the `query-frontend` config requirements (discussion still on-going). This made me realise that we don't have any integration test running with the config instead of CLI flags.

This PR is a first step to ease writing tests where Cortex gets started with a config file (CLI flags are still used for some overrides).

In particular:
- Added `query-frontend` support to local `tsdb-blocks-storage-s3` dev env
- Introduced `CortexService` to have cleaner integration tests 
- Added to `writeFileToSharedDir()` the ability to create the path of directories
- Enhanced `query-frontend` tests to run with config file too

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
