### PR TITLE
Documented how to add a new maintainer

### DIFF
--- a/docs/governance/how-to-add-a-maintainer.md
+++ b/docs/governance/how-to-add-a-maintainer.md
@@ -1,0 +1,14 @@
+---
+title: "How to add a maintainer"
+linkTitle: "How to add a maintainer"
+weight: 2
+slug: how-to-add-a-maintainer
+---
+
+New maintainers are proposed by an existing maintainer and are elected by [majority vote](./_index.md#changes-in-maintainership). Once the vote passed, the following steps should be done to add a new member to the maintainers team:
+
+1. Submit a PR to add the new member to `MAINTAINERS`
+2. Invite to [GitHub organization](https://github.com/orgs/cortexproject/people)
+3. Invite to [`cortex-team` group](https://groups.google.com/forum/#!forum/cortex-team)
+4. Invite to [Quay.io repository](https://quay.io/organization/cortexproject?tab=teams)
+5. Invite to [CNCF `cncf-cortex-maintainers` mailing list](https://lists.cncf.io/g/cncf-cortex-maintainers) (via [CNCF Service Desk](https://servicedesk.cncf.io))

--- a/tools/website/web-pre.sh
+++ b/tools/website/web-pre.sh
@@ -15,6 +15,7 @@ mkdir -p ${OUTPUT_CONTENT_DIR}
 # Copy original content.
 cp -r ${ORIGINAL_CONTENT_DIR}/* ${OUTPUT_CONTENT_DIR}
 cp -r CONTRIBUTING.md code-of-conduct.md CHANGELOG.md ${OUTPUT_CONTENT_DIR}
+cp GOVERNANCE.md ${OUTPUT_CONTENT_DIR}/governance/_index.md
 cp images/* ${WEBSITE_DIR}/static/images
 
 # Add headers to special CODE_OF_CONDUCT.md, CONTRIBUTING.md and CHANGELOG.md files.
@@ -23,9 +24,7 @@ echo "$(cat <<EOT
 title: Code of Conduct
 type: docs
 originalpath: code-of-conduct.md
-menu:
-  contributing:
-    weight: 1
+weight: 13
 ---
 EOT
 )" > ${OUTPUT_CONTENT_DIR}/code-of-conduct.md
@@ -36,9 +35,7 @@ echo "$(cat <<EOT
 title: Changelog
 type: docs
 originalpath: CHANGELOG.md
-menu:
-  main:
-    weight: 2
+weight: 12
 ---
 EOT
 )" > ${OUTPUT_CONTENT_DIR}/CHANGELOG.md
@@ -49,13 +46,22 @@ echo "$(cat <<EOT
 title: Contributing
 type: docs
 originalpath: CONTRIBUTING.md
-menu:
-  contributing:
-    weight: 3
+weight: 10
 ---
 EOT
 )" > ${OUTPUT_CONTENT_DIR}/CONTRIBUTING.md
 tail -n +2 CONTRIBUTING.md >> ${OUTPUT_CONTENT_DIR}/CONTRIBUTING.md
+
+echo "$(cat <<EOT
+---
+title: Governance
+type: docs
+originalpath: GOVERNANCE.md
+weight: 11
+---
+EOT
+)" > ${OUTPUT_CONTENT_DIR}/governance/_index.md
+tail -n +2 GOVERNANCE.md >> ${OUTPUT_CONTENT_DIR}/governance/_index.md
 
 ALL_DOC_CONTENT_FILES=`echo "${OUTPUT_CONTENT_DIR}/**/*.md ${OUTPUT_CONTENT_DIR}/*.md"`
 for file in $(find ${OUTPUT_CONTENT_DIR} -name '*.md')


### PR DESCRIPTION
**What this PR does**:
- Add governance to the doc website
- Add "How to add a maintainer" to doc

This will add a new "Governance" menu item in the website. The "Governance" index page is the `GOVERNANCE.md` content, while there's a sub-page "How to add a maintainer":

![Screen Shot 2020-03-03 at 10 22 46](https://user-images.githubusercontent.com/1701904/75761202-f3ea6d00-5d38-11ea-8bdd-07a356cafdcd.png)


**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
