### PR TITLE
Added / support to query-tee for health checking

### DIFF
--- a/cmd/query-tee/proxy.go
+++ b/cmd/query-tee/proxy.go
@@ -92,8 +92,14 @@ func (p *Proxy) Start() error {
 		return err
 	}
 
-	// Read endpoints.
 	router := mux.NewRouter()
+
+	// Health check endpoint.
+	router.Path("/").Methods("GET").Handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Read endpoints.
 	router.Path("/api/v1/query").Methods("GET").Handler(NewProxyEndpoint(p.backends, "api_v1_query", p.metrics, p.logger))
 	router.Path("/api/v1/query_range").Methods("GET").Handler(NewProxyEndpoint(p.backends, "api_v1_query_range", p.metrics, p.logger))
 	router.Path("/api/v1/labels").Methods("GET").Handler(NewProxyEndpoint(p.backends, "api_v1_labels", p.metrics, p.logger))


### PR DESCRIPTION
**What this PR does**:
When the `query-tee` is deployed with a load balancer in front of it, it needs a route that return 200 for health checking.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
