### PR TITLE
Fixed HTTP status code on failed query because missing block

### DIFF
--- a/integration/e2ecortex/storage.go
+++ b/integration/e2ecortex/storage.go
@@ -1,0 +1,90 @@
+package e2ecortex
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/oklog/ulid"
+	"github.com/thanos-io/thanos/pkg/objstore"
+
+	"github.com/cortexproject/cortex/integration/e2e"
+	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
+	"github.com/cortexproject/cortex/pkg/storage/tsdb/backend/s3"
+	"github.com/cortexproject/cortex/pkg/util/flagext"
+)
+
+type S3Client struct {
+	writer objstore.Bucket
+	reader objstore.BucketReader
+}
+
+func NewS3Client(cfg s3.Config) (*S3Client, error) {
+	writer, err := s3.NewBucketClient(cfg, "test", log.NewNopLogger())
+	if err != nil {
+		return nil, err
+	}
+
+	reader, err := s3.NewBucketReaderClient(cfg, "test", log.NewNopLogger())
+	if err != nil {
+		return nil, err
+	}
+
+	return &S3Client{
+		writer: writer,
+		reader: reader,
+	}, nil
+}
+
+func NewS3ClientForMinio(minio *e2e.HTTPService, bucketName string) (*S3Client, error) {
+	return NewS3Client(s3.Config{
+		Endpoint:        minio.HTTPEndpoint(),
+		BucketName:      bucketName,
+		SecretAccessKey: flagext.Secret{Value: e2edb.MinioSecretKey},
+		AccessKeyID:     e2edb.MinioAccessKey,
+		Insecure:        true,
+	})
+}
+
+// DeleteBlocks deletes all blocks for a tenant.
+func (c *S3Client) DeleteBlocks(userID string) error {
+	prefix := fmt.Sprintf("%s/", userID)
+
+	return c.reader.Iter(context.Background(), prefix, func(entry string) error {
+		if !strings.HasPrefix(entry, prefix) {
+			return fmt.Errorf("unexpected key in the storage: %s", entry)
+		}
+
+		blockID := strings.TrimPrefix(entry, prefix)
+		blockID = strings.TrimSuffix(blockID, "/")
+
+		// Skip keys which are not block IDs
+		if _, err := ulid.Parse(blockID); err != nil {
+			return nil
+		}
+
+		return c.DeleteBlock(userID, blockID)
+	})
+}
+
+// DeleteBlock deletes a single block.
+func (c *S3Client) DeleteBlock(userID, blockID string) error {
+	return c.Delete(fmt.Sprintf("%s/%s/", userID, blockID))
+}
+
+// Delete recursively deletes every object within the input prefix.
+func (c *S3Client) Delete(prefix string) error {
+	return c.reader.Iter(context.Background(), prefix, func(entry string) error {
+		if !strings.HasPrefix(entry, prefix) {
+			return fmt.Errorf("unexpected key in the storage: %s", entry)
+		}
+
+		// Recursively delete if it's a prefix.
+		if strings.HasSuffix(entry, "/") {
+			return c.Delete(entry)
+		}
+
+		return c.writer.Delete(context.Background(), entry)
+	})
+}

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -116,7 +116,7 @@ func (b *blocksQuerier) SelectSorted(sp *storage.SelectParams, matchers ...*labe
 		PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, promql.ErrStorage{Err: err}
 	}
 
 	series := []*storepb.Series(nil)
@@ -130,7 +130,7 @@ func (b *blocksQuerier) SelectSorted(sp *storage.SelectParams, matchers ...*labe
 			break
 		}
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, promql.ErrStorage{Err: err}
 		}
 
 		// response may either contain series or warning. If it's warning, we get nil here.

--- a/pkg/storage/tsdb/backend/s3/bucket_client.go
+++ b/pkg/storage/tsdb/backend/s3/bucket_client.go
@@ -8,13 +8,20 @@ import (
 
 // NewBucketClient creates a new S3 bucket client
 func NewBucketClient(cfg Config, name string, logger log.Logger) (objstore.Bucket, error) {
-	bucketConfig := s3.Config{
+	return s3.NewBucketWithConfig(logger, newS3Config(cfg), name)
+}
+
+// NewBucketReaderClient creates a new S3 bucket client
+func NewBucketReaderClient(cfg Config, name string, logger log.Logger) (objstore.BucketReader, error) {
+	return s3.NewBucketWithConfig(logger, newS3Config(cfg), name)
+}
+
+func newS3Config(cfg Config) s3.Config {
+	return s3.Config{
 		Bucket:    cfg.BucketName,
 		Endpoint:  cfg.Endpoint,
 		AccessKey: cfg.AccessKeyID,
 		SecretKey: cfg.SecretAccessKey.Value,
 		Insecure:  cfg.Insecure,
 	}
-
-	return s3.NewBucketWithConfig(logger, bucketConfig, name)
 }


### PR DESCRIPTION
**What this PR does**:
While testing the blocks storage with the `query-tee` I've realized that if a query fails because of missing block, the query API returns `422` status code. The logic is deep into Prometheus API engine and, in order to have the API returning `500`, we need the error to be a `promql.ErrStorage`.

This PR is 2 lines of code for a fix, and few hundreds for an integration test (because I didn't find a safe way to test it just with unit tests, given the logic is deep into Prometheus).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
