### PR TITLE
Move call of stopIncomingRequests before lifecycler shutdown.

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -242,6 +242,9 @@ func (i *Ingester) loop(ctx context.Context) error {
 func (i *Ingester) stopping() error {
 	i.wal.Stop()
 
+	// This will prevent us accepting any more samples
+	i.stopIncomingRequests()
+
 	// Next initiate our graceful exit from the ring.
 	return services.StopAndAwaitTerminated(context.Background(), i.lifecycler)
 }
@@ -258,8 +261,8 @@ func (i *Ingester) ShutdownHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// StopIncomingRequests is called during the shutdown process.
-func (i *Ingester) StopIncomingRequests() {
+// stopIncomingRequests is called during the shutdown process.
+func (i *Ingester) stopIncomingRequests() {
 	i.userStatesMtx.Lock()
 	defer i.userStatesMtx.Unlock()
 	i.stopped = true

--- a/pkg/ring/flush.go
+++ b/pkg/ring/flush.go
@@ -9,8 +9,12 @@ import (
 var ErrTransferDisabled = errors.New("transfers disabled")
 
 // FlushTransferer controls the shutdown of an instance in the ring.
+// Methods on this interface are called when lifecycler is stopping.
+// At that point, it no longer runs the "actor loop", but it keeps updating heartbeat in the ring.
+// Ring entry is in LEAVING state.
+// After calling TransferOut and then Flush, lifecycler stops.
 type FlushTransferer interface {
-	StopIncomingRequests()
+	// StopIncomingRequests()
 	Flush()
 	TransferOut(ctx context.Context) error
 }
@@ -23,9 +27,6 @@ type NoopFlushTransferer struct{}
 func NewNoopFlushTransferer() *NoopFlushTransferer {
 	return &NoopFlushTransferer{}
 }
-
-// StopIncomingRequests is a noop
-func (t *NoopFlushTransferer) StopIncomingRequests() {}
 
 // Flush is a noop
 func (t *NoopFlushTransferer) Flush() {}

--- a/pkg/ring/flush.go
+++ b/pkg/ring/flush.go
@@ -14,7 +14,6 @@ var ErrTransferDisabled = errors.New("transfers disabled")
 // Ring entry is in LEAVING state.
 // After calling TransferOut and then Flush, lifecycler stops.
 type FlushTransferer interface {
-	// StopIncomingRequests()
 	Flush()
 	TransferOut(ctx context.Context) error
 }

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -426,9 +426,6 @@ func (i *Lifecycler) loop(ctx context.Context) error {
 // - otherwise, flush chunks to the chunk store.
 // - remove config from Consul.
 func (i *Lifecycler) stopping() error {
-	// This will prevent us accepting any more samples
-	i.flushTransferer.StopIncomingRequests()
-
 	heartbeatTicker := time.NewTicker(i.cfg.HeartbeatPeriod)
 	defer heartbeatTicker.Stop()
 

--- a/pkg/ring/lifecycler_test.go
+++ b/pkg/ring/lifecycler_test.go
@@ -21,8 +21,7 @@ type flushTransferer struct {
 	lifecycler *Lifecycler
 }
 
-func (f *flushTransferer) StopIncomingRequests() {}
-func (f *flushTransferer) Flush()                {}
+func (f *flushTransferer) Flush() {}
 func (f *flushTransferer) TransferOut(ctx context.Context) error {
 	if err := f.lifecycler.ClaimTokensFor(ctx, "ing1"); err != nil {
 		return err
@@ -154,8 +153,7 @@ func TestLifecycler_TwoRingsWithDifferentKeysOnTheSameKVStore(t *testing.T) {
 
 type nopFlushTransferer struct{}
 
-func (f *nopFlushTransferer) StopIncomingRequests() {}
-func (f *nopFlushTransferer) Flush()                {}
+func (f *nopFlushTransferer) Flush() {}
 func (f *nopFlushTransferer) TransferOut(ctx context.Context) error {
 	panic("should not be called")
 }
@@ -267,7 +265,6 @@ func TestCheckReady(t *testing.T) {
 type noopFlushTransferer struct {
 }
 
-func (f *noopFlushTransferer) StopIncomingRequests()                 {}
 func (f *noopFlushTransferer) Flush()                                {}
 func (f *noopFlushTransferer) TransferOut(ctx context.Context) error { return nil }
 

--- a/pkg/ruler/lifecycle.go
+++ b/pkg/ruler/lifecycle.go
@@ -9,12 +9,6 @@ func (r *Ruler) TransferOut(ctx context.Context) error {
 	return nil
 }
 
-// StopIncomingRequests is called during the shutdown process.
-// Ensure no new rules are scheduled on this Ruler
-// Currently the api is decoupled from the scheduler, no action
-// is required.
-func (r *Ruler) StopIncomingRequests() {}
-
 // Flush triggers a flush of all the work items currently
 // scheduled by the ruler, currently every ruler will
 // query a backend rule store for it's rules so no


### PR DESCRIPTION
Lifecycler was recently refactored (by #2166), which unfortunately breaks some expectations in Loki. This PR makes fixing Loki possible.

Before #2166, [Lifecycler's `Shutdown` method](https://github.com/cortexproject/cortex/blob/f0fb4b7eb50a60b848b6b685c29b445be15134ac/pkg/ring/lifecycler.go#L330) called `flushTransferer.StopIncomingRequests()` and only then stopped lifecycler's loop.

After #2166, this has been modified. Lifecycler is now stopped via `StopAsync` method (through embedded BasicService), which cancels context used by `loop()` method, which makes `loop()` exit. [`stopping()` method](https://github.com/cortexproject/cortex/blob/9c1f44d0900649f9a78de1b796fdd65df76d250e/pkg/ring/lifecycler.go#L428) is called afterwards. This method still calls `flushTransferer.StopIncomingRequests()`, but by this time, `loop` has already finished.

In Cortex, this doesn't make much difference – only Ingester implements `StopIncomingRequests` method with non-empty body, and it simply sets the readonly flag. In Loki, `StopIncomingRequests` blocks until data transfer has finished, but it expects loop to be still running.

Solution to the issue is removing `StopIncomingRequests` from `FlushTransferer` interface – logically, it doesn't belong there anyway – and let Ingester call it explicitely *before* stopping the lifecycler. This reverts the method call order back to original.

Why doesn't `StopIncomingRequests` belong to `FlushTransferer`? All other `FlushTransferer` methods are called by lifecycler after main lifecycler loop has exited, during lifecycler's shutdown process. `StopIncomingRequests` was the only method that was called *before* triggering lifecycler's shutdown procedure.

(Fix in Loki is the same – call StopIncomingRequests from Ingester's shutdown method, before stopping the lifecycler. I have patch, incl. Cortex update ready.)

cc @rfratto 