### PR TITLE
Upgrade Golang version used in integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
     - run:
         name: Upgrade golang
         command: |
-          cd tmp && \
+          cd /tmp && \
           wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && \
           tar -zxvf go1.13.3.linux-amd64.tar.gz && \
           sudo rm -fr /usr/local/go && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,15 @@ jobs:
     # "go test" will not download module dependencies.
     working_directory: ~/.go_workspace/src/github.com/cortexproject/cortex
     steps:
+    - run:
+        name: Upgrade golang
+        command: |
+          cd tmp && \
+          wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && \
+          tar -zxvf go1.13.3.linux-amd64.tar.gz && \
+          sudo rm -fr /usr/local/go && \
+          sudo mv /tmp/go /usr/local/go && \
+          cd -
     - checkout
     - restore_cache:
         key: v1-cortex-{{ .Branch }}-{{ .Revision }}

--- a/docs/contributing/how-to-upgrade-golang-version.md
+++ b/docs/contributing/how-to-upgrade-golang-version.md
@@ -1,0 +1,20 @@
+---
+title: "How to upgrade Golang version"
+linkTitle: "How to upgrade Golang version"
+weight: 3
+slug: how-to-upgrade-golang-version
+---
+
+To upgrade the Golang version:
+
+1. Upgrade build image version
+   - Upgrade Golang version in `build-image/Dockerfile`
+   - Build new image `make build-image/.uptodate`
+   - Publish the new image to `quay.io` (requires a maintainer)
+   - Update the Docker image tag in `.circleci/config.yml`
+2. Upgrade integration tests version
+   - Update the Golang version installed in the `integration` job in `.circleci/config.yml` 
+
+If the minimum support Golang version should be upgraded as well:
+
+1. Upgrade `go` version in `go.mod` 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cortexproject/cortex
 
-go 1.12
+go 1.13
 
 require (
 	cloud.google.com/go/bigtable v1.1.0


### PR DESCRIPTION
**What this PR does**:
In this PR:
- Upgrade Golang version used in integration tests
- Bump minimum go version from `1.12` to `1.13`
- Added doc how to upgrade Golang version

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
