### PR TITLE
Added Noop service implementation

### DIFF
--- a/pkg/util/services/noop_service.go
+++ b/pkg/util/services/noop_service.go
@@ -1,0 +1,106 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+type noopService struct {
+	listeners *serviceListeners
+
+	stateMu sync.Mutex
+	state   State
+
+	runningCh, terminatedCh chan struct{}
+}
+
+// This service does nothing, except going through state transitions based on Start/Stop calls.
+// It will only be in New, Running or Terminated state, although it also reports Starting/Stopping to listeners.
+// It will never fail. It also doesn't react on context passed to it from outside.
+// It is useful when implementing some kind of "noop" type, which also needs to be a Service.
+func NewNoopService() Service {
+	return &noopService{
+		state:        New,
+		listeners:    newServiceListeners(),
+		runningCh:    make(chan struct{}),
+		terminatedCh: make(chan struct{}),
+	}
+}
+
+func (n *noopService) StartAsync(ctx context.Context) error {
+	n.stateMu.Lock()
+	defer n.stateMu.Unlock()
+
+	if n.state != New {
+		return errors.New("not New")
+	}
+
+	n.state = Running
+	n.listeners.notify(func(l Listener) { l.Starting(); l.Running() }, false)
+	close(n.runningCh)
+	return nil
+}
+
+func (n *noopService) StopAsync() {
+	n.stateMu.Lock()
+	defer n.stateMu.Unlock()
+
+	if n.state == New {
+		n.listeners.notify(func(l Listener) { l.Terminated(New) }, true)
+		close(n.runningCh)
+		close(n.terminatedCh)
+	} else if n.state == Running {
+		n.listeners.notify(func(l Listener) {
+			l.Stopping(Running)
+			l.Terminated(Stopping)
+		}, true)
+		close(n.terminatedCh)
+	}
+
+	n.state = Terminated
+}
+
+func (n *noopService) AwaitRunning(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-n.runningCh:
+		s := n.State()
+		if s != Running {
+			return invalidServiceStateError(s, Running)
+		}
+		return nil
+	}
+}
+
+func (n *noopService) AwaitTerminated(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-n.terminatedCh:
+		return nil
+	}
+}
+
+func (n *noopService) FailureCase() error {
+	return nil
+}
+
+func (n *noopService) State() State {
+	n.stateMu.Lock()
+	defer n.stateMu.Unlock()
+
+	return n.state
+}
+
+func (n *noopService) AddListener(listener Listener) {
+	n.stateMu.Lock()
+	defer n.stateMu.Unlock()
+
+	if n.state == Terminated {
+		return
+	}
+
+	n.listeners.add(listener)
+}

--- a/pkg/util/services/noop_service_test.go
+++ b/pkg/util/services/noop_service_test.go
@@ -1,0 +1,48 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoopService(t *testing.T) {
+	l := newServiceListener()
+	require.NoError(t, StartAndAwaitRunning(context.Background(), l))
+
+	n := NewNoopService()
+	n.AddListener(l)
+
+	require.NoError(t, n.StartAsync(context.Background()))
+	require.Error(t, n.StartAsync(context.Background()))
+
+	require.NoError(t, n.AwaitRunning(context.Background()))
+	require.NoError(t, n.AwaitRunning(context.Background()))
+
+	// calling it multiple times should work fine
+	n.StopAsync()
+	n.StopAsync()
+	n.StopAsync()
+
+	require.NoError(t, n.AwaitTerminated(context.Background()))
+	require.NoError(t, n.FailureCase())
+
+	require.NoError(t, StopAndAwaitTerminated(context.Background(), l))
+	require.Equal(t, []string{"starting", "running", "stopping: Running", "terminated: Stopping"}, l.log)
+}
+
+func TestNoopServiceNewToTerminated(t *testing.T) {
+	l := newServiceListener()
+	require.NoError(t, StartAndAwaitRunning(context.Background(), l))
+
+	n := NewNoopService()
+	n.AddListener(l)
+
+	require.NoError(t, StopAndAwaitTerminated(context.Background(), n))
+	n.StopAsync()
+	require.NoError(t, n.FailureCase())
+
+	require.NoError(t, StopAndAwaitTerminated(context.Background(), l))
+	require.Equal(t, []string{"terminated: New"}, l.log)
+}

--- a/pkg/util/services/service_listeners.go
+++ b/pkg/util/services/service_listeners.go
@@ -1,0 +1,43 @@
+package services
+
+import "sync"
+
+type serviceListeners struct {
+	mu        sync.Mutex
+	listeners []chan func(l Listener)
+}
+
+func newServiceListeners() *serviceListeners {
+	return &serviceListeners{}
+}
+
+// each added listener starts a new goroutine to handle notifications.
+// if no more notifications are expected, don't add the listener.
+func (ls *serviceListeners) add(listener Listener) {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	// There are max 4 state transitions. We use buffer to avoid blocking the sender,
+	// which holds service lock.
+	ch := make(chan func(l Listener), 4)
+	ls.listeners = append(ls.listeners, ch)
+
+	// each listener has its own goroutine, processing events.
+	go func() {
+		for lfn := range ch {
+			lfn(listener)
+		}
+	}()
+}
+
+func (ls *serviceListeners) notify(lfn func(l Listener), closeChan bool) {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	for _, ch := range ls.listeners {
+		ch <- lfn
+		if closeChan {
+			close(ch)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does**: Added service implementation that does nothing. It is useful when some "noop" type also needs to be a service. There is no need to keep extra goroutine running in such case. (I've come across this need when trying to convert WAL component into a Service. There is "noop" wal implementation that could use this).

This PR also extracts services listener type, shared between basicService and noopService.