### PR TITLE
exclude generated protos from PR size bot

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/*.pb.go linguist-generated=true


### PR DESCRIPTION
**What this PR does**:

This excludes all generated proto files from the Pull Request Size bot we run on this repo. #2226 is marked XXL despite most of the LOC being generated files. This PR will ensure the PR Bot ignores generated protos.