### PR TITLE
Exit with status code 1 if Cortex fails to start or any service fails

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -105,11 +105,10 @@ func main() {
 
 	level.Info(util.Logger).Log("msg", "Starting Cortex", "version", version.Info())
 
-	if err := t.Run(); err != nil {
-		level.Error(util.Logger).Log("msg", "error running Cortex", "err", err)
-	}
+	err = t.Run()
 
 	runtime.KeepAlive(ballast)
+	util.CheckFatal("running cortex", err)
 }
 
 // Parse -config.file and -config.expand-env option via separate flag set, to avoid polluting default one and calling flag.Parse on it twice.

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -348,8 +348,16 @@ func (t *Cortex) Run() error {
 	}
 
 	// Stop all the services, and wait until they are all done.
-	// We don't care about this error, as it cannot really fail. `err` has error from startup, which is more important.
+	// We don't care about this error, as it cannot really fail.
 	_ = services.StopManagerAndAwaitStopped(context.Background(), sm)
+
+	// if any service failed, report that as an error to caller
+	if err == nil {
+		if failed := sm.ServicesByState()[services.Failed]; len(failed) > 0 {
+			// Details were reported via failure listener before
+			err = errors.New("failed services")
+		}
+	}
 	return err
 }
 


### PR DESCRIPTION
Cortex used to exit with status code 1 before (when its "Stop" method reported error). Now it exits with code 1 if it fails to start, or any service fails during running or stopping state.
