### PR TITLE
Exclude vendor/ from PR size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 **/*.pb.go linguist-generated=true
+vendor/**/* linguist-generated=true


### PR DESCRIPTION
**What this PR does**:
Following what @jtlisi did in #2227, I would suggest to not consider the whole `vendor/` when calculating the PR size.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
