### PR TITLE
services: add failure case to Stopping function

### DIFF
--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -241,7 +241,7 @@ func (am *MultitenantAlertmanager) iteration(ctx context.Context) error {
 }
 
 // stopping runs when MultitenantAlertmanager transitions to Stopping state.
-func (am *MultitenantAlertmanager) stopping() error {
+func (am *MultitenantAlertmanager) stopping(_ error) error {
 	am.alertmanagersMtx.Lock()
 	for _, am := range am.alertmanagers {
 		am.Stop()

--- a/pkg/chunk/purger/purger.go
+++ b/pkg/chunk/purger/purger.go
@@ -114,7 +114,7 @@ func (dp *DataPurger) init(ctx context.Context) error {
 }
 
 // Stop waits until all background tasks stop.
-func (dp *DataPurger) stop() error {
+func (dp *DataPurger) stop(_ error) error {
 	dp.wg.Wait()
 	return nil
 }

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -190,7 +190,7 @@ func (m *TableManager) starting(ctx context.Context) error {
 }
 
 // Stop the TableManager
-func (m *TableManager) stopping() error {
+func (m *TableManager) stopping(_ error) error {
 	if m.bucketRetentionLoop != nil {
 		return services.StopAndAwaitTerminated(context.Background(), m.bucketRetentionLoop)
 	}

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -198,7 +198,7 @@ func (c *Compactor) starting(ctx context.Context) error {
 	return errors.Wrap(err, "failed to initialize compactor objects")
 }
 
-func (c *Compactor) stopping() error {
+func (c *Compactor) stopping(_ error) error {
 	if c.subservices != nil {
 		return services.StopManagerAndAwaitStopped(context.Background(), c.subservices)
 	}

--- a/pkg/cortex/module_service_wrapper.go
+++ b/pkg/cortex/module_service_wrapper.go
@@ -70,7 +70,7 @@ func (w *moduleServiceWrapper) run(serviceContext context.Context) error {
 	return w.service.FailureCase()
 }
 
-func (w *moduleServiceWrapper) stop() error {
+func (w *moduleServiceWrapper) stop(_ error) error {
 	// wait until all stopDeps have stopped
 	for _, m := range w.stopDeps {
 		s := w.serviceMap[m]

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -307,7 +307,7 @@ func (t *Cortex) initQuerier(cfg *Config) (serv services.Service, err error) {
 	// BUT this extra functionality is ONE OF THE REASONS to introduce entire "Services" concept into Cortex.
 	// For now, only return service that stops the worker, and Querier will be used even before storeQueryable has finished starting.
 
-	return services.NewIdleService(nil, func() error {
+	return services.NewIdleService(nil, func(_ error) error {
 		t.worker.Stop()
 		return nil
 	}), nil
@@ -380,7 +380,7 @@ func (t *Cortex) initStore(cfg *Config) (serv services.Service, err error) {
 		return
 	}
 
-	return services.NewIdleService(nil, func() error {
+	return services.NewIdleService(nil, func(_ error) error {
 		t.store.Stop()
 		return nil
 	}), nil
@@ -425,7 +425,7 @@ func (t *Cortex) initQueryFrontend(cfg *Config) (serv services.Service, err erro
 			t.frontend.Handler(),
 		),
 	)
-	return services.NewIdleService(nil, func() error {
+	return services.NewIdleService(nil, func(_ error) error {
 		t.frontend.Close()
 		if t.cache != nil {
 			t.cache.Stop()
@@ -501,7 +501,7 @@ func (t *Cortex) initConfig(cfg *Config) (serv services.Service, err error) {
 
 	t.configAPI = api.New(t.configDB, cfg.Configs.API)
 	t.configAPI.RegisterRoutes(t.server.HTTP)
-	return services.NewIdleService(nil, func() error {
+	return services.NewIdleService(nil, func(_ error) error {
 		t.configDB.Close()
 		return nil
 	}), nil
@@ -542,7 +542,7 @@ func (t *Cortex) initMemberlistKV(cfg *Config) (services.Service, error) {
 	}
 	t.memberlistKVState = newMemberlistKVState(&cfg.MemberlistKV)
 
-	return services.NewIdleService(nil, func() error {
+	return services.NewIdleService(nil, func(_ error) error {
 		kv := t.memberlistKVState.kv
 		if kv != nil {
 			kv.Stop()

--- a/pkg/cortex/server_service.go
+++ b/pkg/cortex/server_service.go
@@ -33,7 +33,7 @@ func NewServerService(serv *server.Server, servicesToWaitFor func() []services.S
 		}
 	}
 
-	stoppingFn := func() error {
+	stoppingFn := func(_ error) error {
 		// wait until all modules are done, and then shutdown server.
 		for _, s := range servicesToWaitFor() {
 			_ = s.AwaitTerminated(context.Background())

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -219,7 +219,7 @@ func (d *Distributor) starting(ctx context.Context) error {
 }
 
 // Called after distributor is asked to stop via StopAsync.
-func (d *Distributor) stopping() error {
+func (d *Distributor) stopping(_ error) error {
 	return services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
 }
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -239,7 +239,7 @@ func (i *Ingester) loop(ctx context.Context) error {
 }
 
 // stopping is run when ingester is asked to stop
-func (i *Ingester) stopping() error {
+func (i *Ingester) stopping(_ error) error {
 	i.wal.Stop()
 
 	// This will prevent us accepting any more samples

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -169,7 +169,7 @@ func (i *Ingester) startingV2(ctx context.Context) error {
 }
 
 // runs when V2 ingester is stopping
-func (i *Ingester) stoppingV2() error {
+func (i *Ingester) stoppingV2(_ error) error {
 	// It's important to wait until shipper is finished,
 	// because the blocks transfer should start only once it's guaranteed
 	// there's no shipping on-going.

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -58,7 +58,7 @@ func (b *BlockQueryable) starting(ctx context.Context) error {
 	return errors.Wrap(services.StartAndAwaitRunning(ctx, b.us), "failed to start UserStore")
 }
 
-func (b *BlockQueryable) stopping() error {
+func (b *BlockQueryable) stopping(_ error) error {
 	return errors.Wrap(services.StopAndAwaitTerminated(context.Background(), b.us), "stopping UserStore")
 }
 

--- a/pkg/querier/block_store.go
+++ b/pkg/querier/block_store.go
@@ -120,7 +120,7 @@ func (u *UserStore) starting(ctx context.Context) error {
 	return nil
 }
 
-func (u *UserStore) stopping() error {
+func (u *UserStore) stopping(_ error) error {
 	u.serv.Stop()
 	return nil
 }

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -425,7 +425,7 @@ func (i *Lifecycler) loop(ctx context.Context) error {
 // - send chunks to another ingester, if it can.
 // - otherwise, flush chunks to the chunk store.
 // - remove config from Consul.
-func (i *Lifecycler) stopping() error {
+func (i *Lifecycler) stopping(_ error) error {
 	heartbeatTicker := time.NewTicker(i.cfg.HeartbeatPeriod)
 	defer heartbeatTicker.Stop()
 

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -191,7 +191,7 @@ func (r *Ruler) starting(ctx context.Context) error {
 
 // Stop stops the Ruler.
 // Each function of the ruler is terminated before leaving the ring
-func (r *Ruler) stopping() error {
+func (r *Ruler) stopping(_ error) error {
 	r.notifiersMtx.Lock()
 	for _, n := range r.notifiers {
 		n.stop()

--- a/pkg/util/runtimeconfig/manager.go
+++ b/pkg/util/runtimeconfig/manager.go
@@ -165,7 +165,7 @@ func (om *Manager) callListeners(newValue interface{}) {
 }
 
 // Stop stops the Manager
-func (om *Manager) stop() error {
+func (om *Manager) stop(_ error) error {
 	om.listenersMtx.Lock()
 	defer om.listenersMtx.Unlock()
 

--- a/pkg/util/services/basic_service.go
+++ b/pkg/util/services/basic_service.go
@@ -22,7 +22,8 @@ type RunningFn func(serviceContext context.Context) error
 // StoppingFn function is called when service enters Stopping state. When it returns, service moves to Terminated or Failed state,
 // depending on whether there was any error returned from previous RunningFn (if it was called) and this StoppingFn function. If both return error,
 // RunningFn's error will be saved as failure case for Failed state.
-type StoppingFn func() error
+// Parameter is error from Running function, or nil if there was no error.
+type StoppingFn func(failureCase error) error
 
 // BasicService implements contract of Service interface, using three supplied functions: StartingFn, RunningFn and StoppingFn.
 // When service is started, these three functions are called as service transitions to Starting, Running and Stopping state.
@@ -180,7 +181,7 @@ stop:
 	b.serviceCancel()
 
 	if b.stoppingFn != nil {
-		err = b.stoppingFn()
+		err = b.stoppingFn(failure)
 		if failure == nil {
 			failure = err
 		}

--- a/pkg/util/services/basic_service_test.go
+++ b/pkg/util/services/basic_service_test.go
@@ -60,7 +60,7 @@ func (s *serv) run(ctx context.Context) error {
 	return s.conf.runRetVal
 }
 
-func (s *serv) shutDown() error {
+func (s *serv) shutDown(_ error) error {
 	return s.conf.stopRetVal
 }
 

--- a/pkg/util/services/services_test.go
+++ b/pkg/util/services/services_test.go
@@ -19,7 +19,7 @@ func TestIdleService(t *testing.T) {
 	s := NewIdleService(func(ctx context.Context) error {
 		started = true
 		return nil
-	}, func() error {
+	}, func(_ error) error {
 		stopped = true
 		return nil
 	})
@@ -109,7 +109,7 @@ func TestHelperFunctionsStopError(t *testing.T) {
 	t.Parallel()
 
 	e := errors.New("some error")
-	s := NewIdleService(nil, func() error { return e })
+	s := NewIdleService(nil, func(_ error) error { return e })
 
 	require.NoError(t, StartAndAwaitRunning(context.Background(), s))
 	require.Equal(t, e, StopAndAwaitTerminated(context.Background(), s))
@@ -118,7 +118,7 @@ func TestHelperFunctionsStopError(t *testing.T) {
 func TestHelperFunctionsStopTooSlow(t *testing.T) {
 	t.Parallel()
 
-	s := NewIdleService(nil, func() error { time.Sleep(1 * time.Second); return nil })
+	s := NewIdleService(nil, func(_ error) error { time.Sleep(1 * time.Second); return nil })
 
 	require.NoError(t, StartAndAwaitRunning(context.Background(), s))
 


### PR DESCRIPTION
**What this PR does**: While working on a change to remove `os.Exit` from lifecycler, I came across a need to know (in stopping fn) whether lifecycler's running function has failed or not. This PR adds `failureCase` parameter to the stopping function. Since stopping function is used at many different places in Cortex now, this PR changes all those places, but code logic is unchanged – failureCase is simply ignored everywhere (for now).

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
