### PR TITLE
Extract RetryMiddlewareMetrics from NewRetryMiddleware.

### DIFF
--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -173,7 +173,7 @@ func NewTripperware(
 	}
 
 	if cfg.MaxRetries > 0 {
-		queryRangeMiddleware = append(queryRangeMiddleware, InstrumentMiddleware("retry", metrics), NewRetryMiddleware(log, cfg.MaxRetries, registerer))
+		queryRangeMiddleware = append(queryRangeMiddleware, InstrumentMiddleware("retry", metrics), NewRetryMiddleware(log, cfg.MaxRetries, NewRetryMiddlewareMetrics(registerer)))
 	}
 
 	return frontend.Tripperware(func(next http.RoundTripper) http.RoundTripper {


### PR DESCRIPTION
Extract `RetryMiddlewareMetrics` from `NewRetryMiddleware`. This makes it possible to share same  metrics between multiple instances of "retry middleware". (Loki does this)
