### PR TITLE
Fixed cortex_distributor_ingester_query_failures_total metric if an error occurr in the stream.Recv()

### DIFF
--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -145,6 +145,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 			if err == io.EOF {
 				break
 			} else if err != nil {
+				ingesterQueryFailures.WithLabelValues(ing.Addr).Inc()
 				return nil, err
 			}
 


### PR DESCRIPTION
**What this PR does**:
Fixed `cortex_distributor_ingester_query_failures_total` metric if an error occurr in the `stream.Recv()`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
