### PR TITLE
Ingester gRPC servers should return context error if any

### DIFF
--- a/pkg/ingester/client/cortex_mock_test.go
+++ b/pkg/ingester/client/cortex_mock_test.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type IngesterServerMock struct {
+	mock.Mock
+}
+
+func (m *IngesterServerMock) Push(ctx context.Context, r *WriteRequest) (*WriteResponse, error) {
+	args := m.Called(ctx, r)
+	return args.Get(0).(*WriteResponse), args.Error(1)
+}
+
+func (m *IngesterServerMock) Query(ctx context.Context, r *QueryRequest) (*QueryResponse, error) {
+	args := m.Called(ctx, r)
+	return args.Get(0).(*QueryResponse), args.Error(1)
+}
+
+func (m *IngesterServerMock) QueryStream(r *QueryRequest, s Ingester_QueryStreamServer) error {
+	args := m.Called(r, s)
+	return args.Error(0)
+}
+
+func (m *IngesterServerMock) LabelValues(ctx context.Context, r *LabelValuesRequest) (*LabelValuesResponse, error) {
+	args := m.Called(ctx, r)
+	return args.Get(0).(*LabelValuesResponse), args.Error(1)
+}
+
+func (m *IngesterServerMock) LabelNames(ctx context.Context, r *LabelNamesRequest) (*LabelNamesResponse, error) {
+	args := m.Called(ctx, r)
+	return args.Get(0).(*LabelNamesResponse), args.Error(1)
+}
+
+func (m *IngesterServerMock) UserStats(ctx context.Context, r *UserStatsRequest) (*UserStatsResponse, error) {
+	args := m.Called(ctx, r)
+	return args.Get(0).(*UserStatsResponse), args.Error(1)
+}
+
+func (m *IngesterServerMock) AllUserStats(ctx context.Context, r *UserStatsRequest) (*UsersStatsResponse, error) {
+	args := m.Called(ctx, r)
+	return args.Get(0).(*UsersStatsResponse), args.Error(1)
+}
+
+func (m *IngesterServerMock) MetricsForLabelMatchers(ctx context.Context, r *MetricsForLabelMatchersRequest) (*MetricsForLabelMatchersResponse, error) {
+	args := m.Called(ctx, r)
+	return args.Get(0).(*MetricsForLabelMatchersResponse), args.Error(1)
+}
+
+func (m *IngesterServerMock) TransferChunks(s Ingester_TransferChunksServer) error {
+	args := m.Called(s)
+	return args.Error(0)
+}
+
+func (m *IngesterServerMock) TransferTSDB(s Ingester_TransferTSDBServer) error {
+	args := m.Called(s)
+	return args.Error(0)
+}

--- a/pkg/ingester/client/cortex_util.go
+++ b/pkg/ingester/client/cortex_util.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	context "context"
+)
+
+// SendQueryStream wraps the stream's Send() checking if the context is done
+// before calling Send().
+func SendQueryStream(s Ingester_QueryStreamServer, m *QueryStreamResponse) error {
+	return sendWithContextErrChecking(s.Context(), func() error {
+		return s.Send(m)
+	})
+}
+
+// SendTimeSeriesChunk wraps the stream's Send() checking if the context is done
+// before calling Send().
+func SendTimeSeriesChunk(s Ingester_TransferChunksClient, m *TimeSeriesChunk) error {
+	return sendWithContextErrChecking(s.Context(), func() error {
+		return s.Send(m)
+	})
+}
+
+// SendTimeSeriesFile wraps the stream's Send() checking if the context is done
+// before calling Send().
+func SendTimeSeriesFile(s Ingester_TransferTSDBClient, m *TimeSeriesFile) error {
+	return sendWithContextErrChecking(s.Context(), func() error {
+		return s.Send(m)
+	})
+}
+
+func sendWithContextErrChecking(ctx context.Context, send func() error) error {
+	// If the context has been canceled or its deadline exceeded, we should return it
+	// instead of the cryptic error the Send() will return.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+
+	if err := send(); err != nil {
+		// Experimentally, we've seen the context switching to done after the Send()
+		// has been  called, so here we do recheck the context in case of error.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/pkg/ingester/client/cortex_util_test.go
+++ b/pkg/ingester/client/cortex_util_test.go
@@ -1,0 +1,78 @@
+package client
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+
+	grpc_util "github.com/cortexproject/cortex/pkg/util/grpc"
+	"github.com/cortexproject/cortex/pkg/util/test"
+)
+
+func TestSendQueryStream(t *testing.T) {
+	// Create a new gRPC server with in-memory communication.
+	listen := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer()
+	bufDialer := func(context.Context, string) (net.Conn, error) {
+		return listen.Dial()
+	}
+
+	conn, err := grpc.DialContext(context.Background(), "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithInsecure())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Create a cancellable context for the client.
+	clientCtx, clientCancel := context.WithCancel(context.Background())
+
+	// Create a WaitGroup used to wait until the mocked server assertions
+	// complete before returning.
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	serverMock := &IngesterServerMock{}
+	serverMock.On("QueryStream", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		defer wg.Done()
+
+		stream := args.Get(1).(grpc.ServerStream)
+
+		// Cancel the client request.
+		clientCancel()
+
+		// Wait until the cancelling has been propagated to the server.
+		test.Poll(t, time.Second, context.Canceled, func() interface{} {
+			return stream.Context().Err()
+		})
+
+		// Try to send the response and assert the error we get is the context.Canceled
+		// and not transport.ErrIllegalHeaderWrite. This is the assertion we care about
+		// in this test.
+		err = SendQueryStream(stream.(Ingester_QueryStreamServer), &QueryStreamResponse{})
+		assert.Equal(t, context.Canceled, err)
+	})
+
+	RegisterIngesterServer(server, serverMock)
+
+	go func() {
+		require.NoError(t, server.Serve(listen))
+	}()
+
+	client := NewIngesterClient(conn)
+	stream, err := client.QueryStream(clientCtx, &QueryRequest{})
+	require.NoError(t, err)
+
+	// Try to receive the response and assert the error we get is the context.Canceled
+	// wrapped within a gRPC error.
+	_, err = stream.Recv()
+	assert.Equal(t, true, grpc_util.IsGRPCContextCanceled(err))
+
+	// Wait until the assertions in the server mock have completed.
+	wg.Wait()
+}

--- a/pkg/ingester/client/cortex_util_test.go
+++ b/pkg/ingester/client/cortex_util_test.go
@@ -54,7 +54,7 @@ func TestSendQueryStream(t *testing.T) {
 		// Try to send the response and assert the error we get is the context.Canceled
 		// and not transport.ErrIllegalHeaderWrite. This is the assertion we care about
 		// in this test.
-		err = SendQueryStream(stream.(Ingester_QueryStreamServer), &QueryStreamResponse{})
+		err := SendQueryStream(stream.(Ingester_QueryStreamServer), &QueryStreamResponse{})
 		assert.Equal(t, context.Canceled, err)
 	})
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -607,7 +607,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 		if len(batch) == 0 {
 			return nil
 		}
-		err = stream.Send(&client.QueryStreamResponse{
+		err = client.SendQueryStream(stream, &client.QueryStreamResponse{
 			Chunkseries: batch,
 		})
 		batch = batch[:0]

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -622,7 +622,7 @@ func (i *Ingester) v2QueryStream(req *client.QueryRequest, stream client.Ingeste
 		numSeries++
 		batchSize++
 		if batchSize >= queryStreamBatchSize {
-			err = stream.Send(&client.QueryStreamResponse{
+			err = client.SendQueryStream(stream, &client.QueryStreamResponse{
 				Timeseries: timeseries,
 			})
 			if err != nil {
@@ -641,7 +641,7 @@ func (i *Ingester) v2QueryStream(req *client.QueryRequest, stream client.Ingeste
 
 	// Final flush any existing metrics
 	if batchSize != 0 {
-		err = stream.Send(&client.QueryStreamResponse{
+		err = client.SendQueryStream(stream, &client.QueryStreamResponse{
 			Timeseries: timeseries,
 		})
 		if err != nil {

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -473,7 +473,7 @@ func (i *Ingester) transferOut(ctx context.Context) error {
 				return errors.Wrap(err, "toWireChunks")
 			}
 
-			err = stream.Send(&client.TimeSeriesChunk{
+			err = client.SendTimeSeriesChunk(stream, &client.TimeSeriesChunk{
 				FromIngesterId: i.lifecycler.ID,
 				UserId:         userID,
 				Labels:         client.FromLabelsToLabelAdapters(pair.series.metric),
@@ -756,7 +756,7 @@ func batchSend(batch int, b []byte, stream client.Ingester_TransferTSDBClient, t
 	i := 0
 	for ; i+batch < len(b); i += batch {
 		tsfile.Data = b[i : i+batch]
-		err := stream.Send(tsfile)
+		err := client.SendTimeSeriesFile(stream, tsfile)
 		if err != nil {
 			return err
 		}
@@ -766,7 +766,7 @@ func batchSend(batch int, b []byte, stream client.Ingester_TransferTSDBClient, t
 	// Send final data
 	if i < len(b) {
 		tsfile.Data = b[i:]
-		err := stream.Send(tsfile)
+		err := client.SendTimeSeriesFile(stream, tsfile)
 		if err != nil {
 			return err
 		}

--- a/pkg/ingester/transfer_test.go
+++ b/pkg/ingester/transfer_test.go
@@ -155,6 +155,10 @@ func (m *MockTransferTSDBClient) CloseAndRecv() (*client.TransferTSDBResponse, e
 	return &client.TransferTSDBResponse{}, nil
 }
 
+func (m *MockTransferTSDBClient) Context() context.Context {
+	return context.Background()
+}
+
 func TestTransferUser(t *testing.T) {
 	dir, err := ioutil.TempDir("", "tsdb")
 	require.NoError(t, err)

--- a/pkg/util/grpc/util.go
+++ b/pkg/util/grpc/util.go
@@ -1,0 +1,17 @@
+package grpc
+
+import (
+	"github.com/gogo/status"
+	"google.golang.org/grpc/codes"
+)
+
+// IsGRPCContextCanceled returns whether the input error is a GRPC error wrapping
+// the context.Canceled error.
+func IsGRPCContextCanceled(err error) bool {
+	s, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+
+	return s.Code() == codes.Canceled
+}

--- a/vendor/github.com/weaveworks/common/grpc/cancel.go
+++ b/vendor/github.com/weaveworks/common/grpc/cancel.go
@@ -1,0 +1,20 @@
+package grpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IsCanceled checks whether an error comes from an operation being canceled
+func IsCanceled(err error) bool {
+	if err == context.Canceled {
+		return true
+	}
+	s, ok := status.FromError(err)
+	if ok && s.Code() == codes.Canceled {
+		return true
+	}
+	return false
+}

--- a/vendor/google.golang.org/grpc/test/bufconn/bufconn.go
+++ b/vendor/google.golang.org/grpc/test/bufconn/bufconn.go
@@ -1,0 +1,308 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package bufconn provides a net.Conn implemented by a buffer and related
+// dialing and listening functionality.
+package bufconn
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// Listener implements a net.Listener that creates local, buffered net.Conns
+// via its Accept and Dial method.
+type Listener struct {
+	mu   sync.Mutex
+	sz   int
+	ch   chan net.Conn
+	done chan struct{}
+}
+
+// Implementation of net.Error providing timeout
+type netErrorTimeout struct {
+	error
+}
+
+func (e netErrorTimeout) Timeout() bool   { return true }
+func (e netErrorTimeout) Temporary() bool { return false }
+
+var errClosed = fmt.Errorf("closed")
+var errTimeout net.Error = netErrorTimeout{error: fmt.Errorf("i/o timeout")}
+
+// Listen returns a Listener that can only be contacted by its own Dialers and
+// creates buffered connections between the two.
+func Listen(sz int) *Listener {
+	return &Listener{sz: sz, ch: make(chan net.Conn), done: make(chan struct{})}
+}
+
+// Accept blocks until Dial is called, then returns a net.Conn for the server
+// half of the connection.
+func (l *Listener) Accept() (net.Conn, error) {
+	select {
+	case <-l.done:
+		return nil, errClosed
+	case c := <-l.ch:
+		return c, nil
+	}
+}
+
+// Close stops the listener.
+func (l *Listener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	select {
+	case <-l.done:
+		// Already closed.
+		break
+	default:
+		close(l.done)
+	}
+	return nil
+}
+
+// Addr reports the address of the listener.
+func (l *Listener) Addr() net.Addr { return addr{} }
+
+// Dial creates an in-memory full-duplex network connection, unblocks Accept by
+// providing it the server half of the connection, and returns the client half
+// of the connection.
+func (l *Listener) Dial() (net.Conn, error) {
+	p1, p2 := newPipe(l.sz), newPipe(l.sz)
+	select {
+	case <-l.done:
+		return nil, errClosed
+	case l.ch <- &conn{p1, p2}:
+		return &conn{p2, p1}, nil
+	}
+}
+
+type pipe struct {
+	mu sync.Mutex
+
+	// buf contains the data in the pipe.  It is a ring buffer of fixed capacity,
+	// with r and w pointing to the offset to read and write, respsectively.
+	//
+	// Data is read between [r, w) and written to [w, r), wrapping around the end
+	// of the slice if necessary.
+	//
+	// The buffer is empty if r == len(buf), otherwise if r == w, it is full.
+	//
+	// w and r are always in the range [0, cap(buf)) and [0, len(buf)].
+	buf  []byte
+	w, r int
+
+	wwait sync.Cond
+	rwait sync.Cond
+
+	// Indicate that a write/read timeout has occurred
+	wtimedout bool
+	rtimedout bool
+
+	wtimer *time.Timer
+	rtimer *time.Timer
+
+	closed      bool
+	writeClosed bool
+}
+
+func newPipe(sz int) *pipe {
+	p := &pipe{buf: make([]byte, 0, sz)}
+	p.wwait.L = &p.mu
+	p.rwait.L = &p.mu
+
+	p.wtimer = time.AfterFunc(0, func() {})
+	p.rtimer = time.AfterFunc(0, func() {})
+	return p
+}
+
+func (p *pipe) empty() bool {
+	return p.r == len(p.buf)
+}
+
+func (p *pipe) full() bool {
+	return p.r < len(p.buf) && p.r == p.w
+}
+
+func (p *pipe) Read(b []byte) (n int, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Block until p has data.
+	for {
+		if p.closed {
+			return 0, io.ErrClosedPipe
+		}
+		if !p.empty() {
+			break
+		}
+		if p.writeClosed {
+			return 0, io.EOF
+		}
+		if p.rtimedout {
+			return 0, errTimeout
+		}
+
+		p.rwait.Wait()
+	}
+	wasFull := p.full()
+
+	n = copy(b, p.buf[p.r:len(p.buf)])
+	p.r += n
+	if p.r == cap(p.buf) {
+		p.r = 0
+		p.buf = p.buf[:p.w]
+	}
+
+	// Signal a blocked writer, if any
+	if wasFull {
+		p.wwait.Signal()
+	}
+
+	return n, nil
+}
+
+func (p *pipe) Write(b []byte) (n int, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return 0, io.ErrClosedPipe
+	}
+	for len(b) > 0 {
+		// Block until p is not full.
+		for {
+			if p.closed || p.writeClosed {
+				return 0, io.ErrClosedPipe
+			}
+			if !p.full() {
+				break
+			}
+			if p.wtimedout {
+				return 0, errTimeout
+			}
+
+			p.wwait.Wait()
+		}
+		wasEmpty := p.empty()
+
+		end := cap(p.buf)
+		if p.w < p.r {
+			end = p.r
+		}
+		x := copy(p.buf[p.w:end], b)
+		b = b[x:]
+		n += x
+		p.w += x
+		if p.w > len(p.buf) {
+			p.buf = p.buf[:p.w]
+		}
+		if p.w == cap(p.buf) {
+			p.w = 0
+		}
+
+		// Signal a blocked reader, if any.
+		if wasEmpty {
+			p.rwait.Signal()
+		}
+	}
+	return n, nil
+}
+
+func (p *pipe) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	// Signal all blocked readers and writers to return an error.
+	p.rwait.Broadcast()
+	p.wwait.Broadcast()
+	return nil
+}
+
+func (p *pipe) closeWrite() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.writeClosed = true
+	// Signal all blocked readers and writers to return an error.
+	p.rwait.Broadcast()
+	p.wwait.Broadcast()
+	return nil
+}
+
+type conn struct {
+	io.Reader
+	io.Writer
+}
+
+func (c *conn) Close() error {
+	err1 := c.Reader.(*pipe).Close()
+	err2 := c.Writer.(*pipe).closeWrite()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+func (c *conn) SetDeadline(t time.Time) error {
+	c.SetReadDeadline(t)
+	c.SetWriteDeadline(t)
+	return nil
+}
+
+func (c *conn) SetReadDeadline(t time.Time) error {
+	p := c.Reader.(*pipe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.rtimer.Stop()
+	p.rtimedout = false
+	if !t.IsZero() {
+		p.rtimer = time.AfterFunc(time.Until(t), func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.rtimedout = true
+			p.rwait.Broadcast()
+		})
+	}
+	return nil
+}
+
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	p := c.Writer.(*pipe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.wtimer.Stop()
+	p.wtimedout = false
+	if !t.IsZero() {
+		p.wtimer = time.AfterFunc(time.Until(t), func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.wtimedout = true
+			p.wwait.Broadcast()
+		})
+	}
+	return nil
+}
+
+func (*conn) LocalAddr() net.Addr  { return addr{} }
+func (*conn) RemoteAddr() net.Addr { return addr{} }
+
+type addr struct{}
+
+func (addr) Network() string { return "bufconn" }
+func (addr) String() string  { return "bufconn" }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -860,6 +860,7 @@ google.golang.org/grpc/serviceconfig
 google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
+google.golang.org/grpc/test/bufconn
 # gopkg.in/alecthomas/kingpin.v2 v2.2.6
 gopkg.in/alecthomas/kingpin.v2
 # gopkg.in/fsnotify/fsnotify.v1 v1.4.7


### PR DESCRIPTION
**What this PR does**:
Today I investigated the following warning log we see quite frequently on high-traffic clusters:
```
level=warn ts=2020-03-10T09:19:42.839335323Z caller=grpc_logging.go:54 method=/cortex.Ingester/QueryStream duration=981.401µs err="rpc error: code = Internal desc = transport: transport: the stream is done or WriteHeader was already called" msg="gRPC\n"
```

After some investigating, I found out this happens whenever a gRPC server calls `Send()` on a closed stream because the context has been closed (canceled / deadline exceeded). In this PR I propose to wrap the `Send()` in order to check whether the context has an error and, if so, returning that error instead of the cryptic `Send()` error.

After this PR changes the log is the following:
```
level=debug ts=2020-03-11T05:12:21.1804904Z caller=grpc_logging.go:53 method=/cortex.Ingester/QueryStream duration=301µs err="rpc error: code = Canceled desc = context canceled" msg="gRPC\n"
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
