### PR TITLE
Converted frontend worker to a service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [CHANGE] Utilize separate protos for rule state and storage. Experimental ruler API will not be functional until the rollout is complete. #2226
+* [CHANGE] Frontend worker in querier now starts after all Querier module dependencies are started. This fixes issue where frontend worker started to send queries to querier before it was ready to serve them (mostly visible when using experimental blocks storage). #2246
 * [FEATURE] Flusher target to flush the WAL.
   * `-flusher.wal-dir` for the WAL directory to recover from.
   * `-flusher.concurrent-flushes` for number of concurrent flushes.

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -182,7 +182,6 @@ type Cortex struct {
 	ingester      *ingester.Ingester
 	flusher       *flusher.Flusher
 	store         chunk.Store
-	worker        frontend.Worker
 	frontend      *frontend.Frontend
 	tableManager  *chunk.TableManager
 	cache         cache.Cache

--- a/pkg/querier/frontend/frontend_test.go
+++ b/pkg/querier/frontend/frontend_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 const (
@@ -197,7 +198,9 @@ func testFrontend(t *testing.T, handler http.Handler, test func(addr string)) {
 
 	worker, err := NewWorker(workerConfig, httpgrpc_server.NewServer(handler), logger)
 	require.NoError(t, err)
-	defer worker.Stop()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), worker))
 
 	test(httpListen.Addr().String())
+
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), worker))
 }

--- a/pkg/querier/frontend/worker.go
+++ b/pkg/querier/frontend/worker.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/httpgrpc/server"
 	"github.com/weaveworks/common/middleware"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 var (
@@ -46,31 +48,21 @@ func (cfg *WorkerConfig) RegisterFlags(f *flag.FlagSet) {
 }
 
 // Worker is the counter-part to the frontend, actually processing requests.
-type Worker interface {
-	Stop()
-}
-
 type worker struct {
 	cfg    WorkerConfig
 	log    log.Logger
 	server *server.Server
 
-	ctx     context.Context
-	cancel  context.CancelFunc
 	watcher naming.Watcher //nolint:staticcheck //Skipping for now. If you still see this more than likely issue https://github.com/cortexproject/cortex/issues/2015 has not yet been addressed.
 	wg      sync.WaitGroup
 }
 
-type noopWorker struct {
-}
-
-func (noopWorker) Stop() {}
-
-// NewWorker creates a new Worker.
-func NewWorker(cfg WorkerConfig, server *server.Server, log log.Logger) (Worker, error) {
+// NewWorker creates a new worker and returns a service that is wrapping it.
+// If no address is specified, it returns nil service (and no error).
+func NewWorker(cfg WorkerConfig, server *server.Server, log log.Logger) (services.Service, error) {
 	if cfg.Address == "" {
 		level.Info(log).Log("msg", "no address specified, not starting worker")
-		return noopWorker{}, nil
+		return nil, nil
 	}
 
 	resolver, err := naming.NewDNSResolverWithFreq(cfg.DNSLookupDuration)
@@ -83,52 +75,47 @@ func NewWorker(cfg WorkerConfig, server *server.Server, log log.Logger) (Worker,
 		return nil, err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-
 	w := &worker{
-		cfg:    cfg,
-		log:    log,
-		server: server,
-
-		ctx:     ctx,
-		cancel:  cancel,
+		cfg:     cfg,
+		log:     log,
+		server:  server,
 		watcher: watcher,
 	}
-	w.wg.Add(1)
-	go w.watchDNSLoop()
-	return w, nil
+	return services.NewBasicService(nil, w.watchDNSLoop, w.stopping), nil
 }
 
-// Stop the worker.
-func (w *worker) Stop() {
-	w.watcher.Close()
-	w.cancel()
+func (w *worker) stopping(_ error) error {
+	// wait until all per-address workers are done
 	w.wg.Wait()
+	return nil
 }
 
 // watchDNSLoop watches for changes in DNS and starts or stops workers.
-func (w *worker) watchDNSLoop() {
-	defer w.wg.Done()
+func (w *worker) watchDNSLoop(servCtx context.Context) error {
+	go func() {
+		// close the watcher, when this service is asked to stop
+		<-servCtx.Done()
+		w.watcher.Close()
+	}()
 
 	cancels := map[string]context.CancelFunc{}
-	defer func() {
-		for _, cancel := range cancels {
-			cancel()
-		}
-	}()
 
 	for {
 		updates, err := w.watcher.Next()
 		if err != nil {
-			level.Error(w.log).Log("msg", "error from DNS watcher", "err", err)
-			return
+			// watcher.Next returns error when Close is called, but we call Close when our context is done.
+			// we don't want to report error in that case.
+			if servCtx.Err() != nil {
+				return nil
+			}
+			return errors.Wrapf(err, "error from DNS watcher")
 		}
 
 		for _, update := range updates {
 			switch update.Op {
 			case naming.Add:
 				level.Debug(w.log).Log("msg", "adding connection", "addr", update.Addr)
-				ctx, cancel := context.WithCancel(w.ctx)
+				ctx, cancel := context.WithCancel(servCtx)
 				cancels[update.Addr] = cancel
 				w.runMany(ctx, update.Addr)
 
@@ -139,7 +126,7 @@ func (w *worker) watchDNSLoop() {
 				}
 
 			default:
-				panic("unknown op")
+				return fmt.Errorf("unknown op: %v", update.Op)
 			}
 		}
 	}


### PR DESCRIPTION
Issue: The query frontend worker in the querier was previously (before this PR) started in the init function. The side effect was that it started pulling jobs from the queue before the queryable is ready. This means queries fail during the rollout, until the queryable is ready.

This PR changes that. Frontend worker is now a service, and it is only started after all Querier module dependencies are started. This includes queryable.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
