### PR TITLE
Make NewServerService generic again

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -196,9 +196,9 @@ func (t *Cortex) initServer(cfg *Config) (services.Service, error) {
 		return svs
 	}
 
-	s := NewServerService(cfg, t.server, servicesToWaitFor)
-	serv.HTTP.HandleFunc("/", s.indexHandler)
-	serv.HTTP.HandleFunc("/config", s.configHandler)
+	s := NewServerService(t.server, servicesToWaitFor)
+	serv.HTTP.HandleFunc("/", indexHandler)
+	serv.HTTP.HandleFunc("/config", configHandler(cfg))
 
 	return s, nil
 }

--- a/pkg/cortex/server_service_test.go
+++ b/pkg/cortex/server_service_test.go
@@ -26,7 +26,7 @@ func TestServerStopViaContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
-	s := NewServerService(&Config{}, serv, func() []services.Service { return nil })
+	s := NewServerService(serv, func() []services.Service { return nil })
 	require.NoError(t, s.StartAsync(ctx))
 
 	// should terminate soon, since context has short timeout
@@ -44,7 +44,7 @@ func TestServerStopViaShutdown(t *testing.T) {
 	serv, err := server.New(server.Config{})
 	require.NoError(t, err)
 
-	s := NewServerService(&Config{}, serv, func() []services.Service { return nil })
+	s := NewServerService(serv, func() []services.Service { return nil })
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), s))
 
 	// we stop HTTP/gRPC Servers here... that should make server stop.
@@ -64,7 +64,7 @@ func TestServerStopViaStop(t *testing.T) {
 	serv, err := server.New(server.Config{})
 	require.NoError(t, err)
 
-	s := NewServerService(&Config{}, serv, func() []services.Service { return nil })
+	s := NewServerService(serv, func() []services.Service { return nil })
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), s))
 
 	serv.Stop()


### PR DESCRIPTION
**What this PR does**: this PR removes Cortex-specific bits from NewServerService, so that it can be reused by Loki. Config and index handlers are now simple functions.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
