### PR TITLE
Make module service wrapper reusable from other projects

### DIFF
--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -322,7 +322,7 @@ func (t *Cortex) Run() error {
 		// let's find out which module failed
 		for m, s := range t.serviceMap {
 			if s == service {
-				if service.FailureCase() == util.ErrStopCortex {
+				if service.FailureCase() == util.ErrStopProcess {
 					level.Info(util.Logger).Log("msg", "received stop signal via return error", "module", m, "error", service.FailureCase())
 				} else {
 					level.Error(util.Logger).Log("msg", "module failed", "module", m, "error", service.FailureCase())
@@ -363,7 +363,7 @@ func (t *Cortex) Run() error {
 	if err == nil {
 		if failed := sm.ServicesByState()[services.Failed]; len(failed) > 0 {
 			for _, f := range failed {
-				if f.FailureCase() != util.ErrStopCortex {
+				if f.FailureCase() != util.ErrStopProcess {
 					// Details were reported via failure listener before
 					err = errors.New("failed services")
 					break

--- a/pkg/cortex/cortex_test.go
+++ b/pkg/cortex/cortex_test.go
@@ -60,11 +60,6 @@ func TestCortex(t *testing.T) {
 	require.NotNil(t, c.serviceMap[Ring])
 	require.NotNil(t, c.serviceMap[Distributor])
 
-	r, ok := c.serviceMap[Ring].(*moduleServiceWrapper)
-	require.True(t, ok)
-
-	require.ElementsMatch(t, []moduleName{Server, RuntimeConfig, MemberlistKV}, r.startDeps)
-
-	// querier and distributor depend on Ring
-	require.ElementsMatch(t, []moduleName{Distributor, Querier}, r.stopDeps)
+	// check that findInverseDependencie for Ring -- querier and distributor depend on Ring, so should be returned.
+	require.ElementsMatch(t, []moduleName{Distributor, Querier}, findInverseDependencies(Ring, modules[cfg.Target].deps))
 }

--- a/pkg/cortex/module_service_wrapper.go
+++ b/pkg/cortex/module_service_wrapper.go
@@ -1,95 +1,30 @@
 package cortex
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/go-kit/kit/log/level"
-	"github.com/pkg/errors"
-
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
-// This service wraps module service, and adds waiting for dependencies to start before starting,
+// This function wraps module service, and adds waiting for dependencies to start before starting,
 // and dependant modules to stop before stopping this module service.
-type moduleServiceWrapper struct {
-	services.Service
-
-	serviceMap map[moduleName]services.Service
-	module     moduleName
-	service    services.Service
-	startDeps  []moduleName
-	stopDeps   []moduleName
-}
-
-func newModuleServiceWrapper(serviceMap map[moduleName]services.Service, mod moduleName, modServ services.Service, startDeps []moduleName, stopDeps []moduleName) *moduleServiceWrapper {
-	w := &moduleServiceWrapper{
-		serviceMap: serviceMap,
-		module:     mod,
-		service:    modServ,
-		startDeps:  startDeps,
-		stopDeps:   stopDeps,
-	}
-
-	w.Service = services.NewBasicService(w.start, w.run, w.stop)
-	return w
-}
-
-func (w *moduleServiceWrapper) start(serviceContext context.Context) error {
-	// wait until all startDeps are running
-	for _, m := range w.startDeps {
-		s := w.serviceMap[m]
-		if s == nil {
-			continue
+func newModuleServiceWrapper(serviceMap map[moduleName]services.Service, mod moduleName, modServ services.Service, startDeps []moduleName, stopDeps []moduleName) services.Service {
+	getDeps := func(deps []moduleName) map[string]services.Service {
+		r := map[string]services.Service{}
+		for _, m := range deps {
+			s := serviceMap[m]
+			if s != nil {
+				r[string(m)] = s
+			}
 		}
-
-		level.Debug(util.Logger).Log("msg", "module waiting for initialization", "module", w.module, "waiting_for", m)
-
-		err := s.AwaitRunning(serviceContext)
-		if err != nil {
-			return fmt.Errorf("failed to start %v, because it depends on module %v, which has failed: %w", w.module, m, err)
-		}
+		return r
 	}
 
-	// we don't want to let service to stop until we stop all dependant services,
-	// so we use new context
-	level.Info(util.Logger).Log("msg", "initialising", "module", w.module)
-	err := w.service.StartAsync(context.Background())
-	if err != nil {
-		return errors.Wrapf(err, "error starting module: %s", w.module)
-	}
-
-	return w.service.AwaitRunning(serviceContext)
-}
-
-func (w *moduleServiceWrapper) run(serviceContext context.Context) error {
-	// wait until service stops, or context is canceled, whatever happens first.
-	// We don't care about exact error here
-	_ = w.service.AwaitTerminated(serviceContext)
-	return w.service.FailureCase()
-}
-
-func (w *moduleServiceWrapper) stop(_ error) error {
-	// wait until all stopDeps have stopped
-	for _, m := range w.stopDeps {
-		s := w.serviceMap[m]
-		if s == nil {
-			continue
-		}
-
-		// Passed context isn't canceled, so we can only get error here, if service
-		// fails. But we don't care *how* service stops, as long as it is done.
-		_ = s.AwaitTerminated(context.Background())
-	}
-
-	level.Debug(util.Logger).Log("msg", "stopping", "module", w.module)
-
-	err := services.StopAndAwaitTerminated(context.Background(), w.service)
-	if err != nil && err != util.ErrStopCortex {
-		level.Warn(util.Logger).Log("msg", "error stopping module", "module", w.module, "err", err)
-	} else {
-		level.Info(util.Logger).Log("msg", "module stopped", "module", w.module)
-	}
-	return err
+	return util.NewModuleService(string(mod), modServ,
+		func(_ string) map[string]services.Service {
+			return getDeps(startDeps)
+		},
+		func(_ string) map[string]services.Service {
+			return getDeps(stopDeps)
+		},
+	)
 }

--- a/pkg/flusher/flusher.go
+++ b/pkg/flusher/flusher.go
@@ -89,5 +89,5 @@ func (f *Flusher) running(ctx context.Context) error {
 	if err := services.StopAndAwaitTerminated(ctx, ing); err != nil {
 		return errors.Wrap(err, "stop and await terminated ingester")
 	}
-	return util.ErrStopCortex
+	return util.ErrStopProcess
 }

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -2,5 +2,5 @@ package util
 
 import "errors"
 
-// ErrStopCortex is the error returned by a service as a hint to stop the Cortex server entirely.
-var ErrStopCortex = errors.New("stop cortex")
+// ErrStopProcess is the error returned by a service as a hint to stop the server entirely.
+var ErrStopProcess = errors.New("stop process")

--- a/pkg/util/module_service.go
+++ b/pkg/util/module_service.go
@@ -75,6 +75,10 @@ func (w *moduleService) stop(_ error) error {
 	// wait until all stopDeps have stopped
 	stopDeps := w.stopDeps(w.name)
 	for _, s := range stopDeps {
+		if s == nil {
+			continue
+		}
+
 		// Passed context isn't canceled, so we can only get error here, if service
 		// fails. But we don't care *how* service stops, as long as it is done.
 		_ = s.AwaitTerminated(context.Background())

--- a/pkg/util/module_service.go
+++ b/pkg/util/module_service.go
@@ -24,8 +24,8 @@ type moduleService struct {
 
 // NewModuleService wraps a module service, and makes sure that dependencies are started/stopped before module service starts or stops.
 // If any dependency fails to start, this service fails as well.
-// On stop, errors from failed dependendies are ignored.
-func NewModuleService(name string, service services.Service, startDeps, stopDeps func(string) map[string]services.Service) *moduleService {
+// On stop, errors from failed dependencies are ignored.
+func NewModuleService(name string, service services.Service, startDeps, stopDeps func(string) map[string]services.Service) services.Service {
 	w := &moduleService{
 		name:      name,
 		service:   service,

--- a/pkg/util/module_service.go
+++ b/pkg/util/module_service.go
@@ -1,0 +1,92 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+// This service wraps module service, and adds waiting for dependencies to start before starting,
+// and dependant modules to stop before stopping this module service.
+type moduleService struct {
+	services.Service
+
+	service services.Service
+	name    string
+
+	// startDeps, stopDeps return map of service names to services
+	startDeps, stopDeps func(string) map[string]services.Service
+}
+
+// NewModuleService wraps a module service, and makes sure that dependencies are started/stopped before module service starts or stops.
+// If any dependency fails to start, this service fails as well.
+// On stop, errors from failed dependendies are ignored.
+func NewModuleService(name string, service services.Service, startDeps, stopDeps func(string) map[string]services.Service) *moduleService {
+	w := &moduleService{
+		name:      name,
+		service:   service,
+		startDeps: startDeps,
+		stopDeps:  stopDeps,
+	}
+
+	w.Service = services.NewBasicService(w.start, w.run, w.stop)
+	return w
+}
+
+func (w *moduleService) start(serviceContext context.Context) error {
+	// wait until all startDeps are running
+	startDeps := w.startDeps(w.name)
+	for m, s := range startDeps {
+		if s == nil {
+			continue
+		}
+
+		level.Debug(Logger).Log("msg", "module waiting for initialization", "module", w.name, "waiting_for", m)
+
+		err := s.AwaitRunning(serviceContext)
+		if err != nil {
+			return fmt.Errorf("failed to start %v, because it depends on module %v, which has failed: %w", w.name, m, err)
+		}
+	}
+
+	// we don't want to let this service to stop until all dependant services are stopped,
+	// so we use independent context here
+	level.Info(Logger).Log("msg", "initialising", "module", w.name)
+	err := w.service.StartAsync(context.Background())
+	if err != nil {
+		return errors.Wrapf(err, "error starting module: %s", w.name)
+	}
+
+	return w.service.AwaitRunning(serviceContext)
+}
+
+func (w *moduleService) run(serviceContext context.Context) error {
+	// wait until service stops, or context is canceled, whatever happens first.
+	// We don't care about exact error here
+	_ = w.service.AwaitTerminated(serviceContext)
+	return w.service.FailureCase()
+}
+
+func (w *moduleService) stop(_ error) error {
+	// wait until all stopDeps have stopped
+	stopDeps := w.stopDeps(w.name)
+	for _, s := range stopDeps {
+		// Passed context isn't canceled, so we can only get error here, if service
+		// fails. But we don't care *how* service stops, as long as it is done.
+		_ = s.AwaitTerminated(context.Background())
+	}
+
+	level.Debug(Logger).Log("msg", "stopping", "module", w.name)
+
+	err := services.StopAndAwaitTerminated(context.Background(), w.service)
+	if err != nil && err != ErrStopCortex {
+		level.Warn(Logger).Log("msg", "error stopping module", "module", w.name, "err", err)
+	} else {
+		level.Info(Logger).Log("msg", "module stopped", "module", w.name)
+	}
+	return err
+}

--- a/pkg/util/module_service.go
+++ b/pkg/util/module_service.go
@@ -83,7 +83,7 @@ func (w *moduleService) stop(_ error) error {
 	level.Debug(Logger).Log("msg", "stopping", "module", w.name)
 
 	err := services.StopAndAwaitTerminated(context.Background(), w.service)
-	if err != nil && err != ErrStopCortex {
+	if err != nil && err != ErrStopProcess {
 		level.Warn(Logger).Log("msg", "error stopping module", "module", w.name, "err", err)
 	} else {
 		level.Info(Logger).Log("msg", "module stopped", "module", w.name)


### PR DESCRIPTION
This PR moves `moduleServiceWrapper` from Cortex main package to util package. It is now available via `NewModuleService` function, which is also bit more generic, to make it reusable between projects. (Going to use it in Loki)

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
