### PR TITLE
adding metrics for current number of entries and used memory in FIFO cache

### DIFF
--- a/pkg/chunk/cache/fifo_cache.go
+++ b/pkg/chunk/cache/fifo_cache.go
@@ -65,7 +65,7 @@ var (
 		Namespace: "querier",
 		Subsystem: "cache",
 		Name:      "memory_bytes",
-		Help:      "The total number of bytes",
+		Help:      "The current cache size in bytes",
 	}, []string{"cache"})
 )
 

--- a/pkg/chunk/cache/fifo_cache_test.go
+++ b/pkg/chunk/cache/fifo_cache_test.go
@@ -5,7 +5,10 @@ import (
 	"strconv"
 	"testing"
 	"time"
+	"unsafe"
 
+	"github.com/bmizerany/assert"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,7 +16,7 @@ const size = 10
 const overwrite = 5
 
 func TestFifoCache(t *testing.T) {
-	c := NewFifoCache("test", FifoCacheConfig{Size: size, Validity: 1 * time.Minute})
+	c := NewFifoCache("test1", FifoCacheConfig{Size: size, Validity: 1 * time.Minute})
 	ctx := context.Background()
 
 	// Check put / get works
@@ -72,18 +75,55 @@ func TestFifoCache(t *testing.T) {
 	}
 }
 
-func TestFifoCacheExpiry(t *testing.T) {
-	c := NewFifoCache("test", FifoCacheConfig{Size: size, Validity: 5 * time.Millisecond})
+func TestFifoCacheEvictionExpiry(t *testing.T) {
+	c := NewFifoCache("test2", FifoCacheConfig{Size: 3, Validity: 5 * time.Millisecond})
 	ctx := context.Background()
+	memorySz := int(unsafe.Sizeof(cacheEntry{})) * 3
 
-	c.Put(ctx, []string{"0"}, []interface{}{0})
+	assert.Equal(t, testutil.ToFloat64(c.entriesAdded), float64(0))
+	assert.Equal(t, testutil.ToFloat64(c.entriesAddedNew), float64(0))
+	assert.Equal(t, testutil.ToFloat64(c.entriesEvicted), float64(0))
+	assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(0))
+	assert.Equal(t, testutil.ToFloat64(c.totalGets), float64(0))
+	assert.Equal(t, testutil.ToFloat64(c.totalMisses), float64(0))
+	assert.Equal(t, testutil.ToFloat64(c.staleGets), float64(0))
+	assert.Equal(t, testutil.ToFloat64(c.memoryBytes), float64(memorySz))
 
-	value, ok := c.Get(ctx, "0")
+	key1, key2, key3, key4 := "key1", "key23", "key345", "key45676789"
+	data1, data2, data3 := []float64{1.0, 2.0, 3.0}, "testdata", []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	memorySz += len(key1) + len(key2) + len(key3) + len(data1)*8 + len(data2) + len(data3)
+
+	c.Put(ctx,
+		[]string{key1, key2, key4, key3, key2, key1},
+		[]interface{}{[]int32{1, 2, 3, 4}, "dummy", []int{5, 4, 3, 2, 1}, data3, data2, data1})
+
+	value, ok := c.Get(ctx, key1)
 	require.True(t, ok)
-	require.Equal(t, 0, value.(int))
+	require.Equal(t, data1, value.([]float64))
+
+	value, ok = c.Get(ctx, key4)
+	require.False(t, ok)
+
+	assert.Equal(t, testutil.ToFloat64(c.entriesAdded), float64(1))
+	assert.Equal(t, testutil.ToFloat64(c.entriesAddedNew), float64(5))
+	assert.Equal(t, testutil.ToFloat64(c.entriesEvicted), float64(2))
+	assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(3))
+	assert.Equal(t, testutil.ToFloat64(c.totalGets), float64(2))
+	assert.Equal(t, testutil.ToFloat64(c.totalMisses), float64(1))
+	assert.Equal(t, testutil.ToFloat64(c.staleGets), float64(0))
+	assert.Equal(t, testutil.ToFloat64(c.memoryBytes), float64(memorySz))
 
 	// Expire the entry.
 	time.Sleep(5 * time.Millisecond)
-	_, ok = c.Get(ctx, strconv.Itoa(0))
+	_, ok = c.Get(ctx, key1)
 	require.False(t, ok)
+
+	assert.Equal(t, testutil.ToFloat64(c.entriesAdded), float64(1))
+	assert.Equal(t, testutil.ToFloat64(c.entriesAddedNew), float64(5))
+	assert.Equal(t, testutil.ToFloat64(c.entriesEvicted), float64(2))
+	assert.Equal(t, testutil.ToFloat64(c.entriesCurrent), float64(3))
+	assert.Equal(t, testutil.ToFloat64(c.totalGets), float64(3))
+	assert.Equal(t, testutil.ToFloat64(c.totalMisses), float64(2))
+	assert.Equal(t, testutil.ToFloat64(c.staleGets), float64(1))
+	assert.Equal(t, testutil.ToFloat64(c.memoryBytes), float64(memorySz))
 }


### PR DESCRIPTION


Signed-off-by: Dmitry Shmulevich <dmitry.shmulevich@sysdig.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR adds metrics for current number of entries and used memory in FIFO cache
**Which issue(s) this PR fixes**:
Fixes #2258 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
