### PR TITLE
404 handling and DeleteObject implementations (GCS & S3)

### DIFF
--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -64,7 +64,8 @@ func (s *GCSObjectClient) Stop() {
 	s.client.Close()
 }
 
-// Get object from the store
+// GetObject returns a reader for the specified object key from the configured GCS bucket. If the
+// key does not exist a generic chunk.ErrStorageObjectNotFound error is returned.
 func (s *GCSObjectClient) GetObject(ctx context.Context, objectKey string) (io.ReadCloser, error) {
 	if s.cfg.RequestTimeout > 0 {
 		// The context will be cancelled with the timeout or when the parent context is cancelled, whichever occurs first.
@@ -73,10 +74,19 @@ func (s *GCSObjectClient) GetObject(ctx context.Context, objectKey string) (io.R
 		defer cancel()
 	}
 
-	return s.bucket.Object(objectKey).NewReader(ctx)
+	reader, err := s.bucket.Object(objectKey).NewReader(ctx)
+
+	if err != nil {
+		if err == storage.ErrObjectNotExist {
+			return nil, chunk.ErrStorageObjectNotFound
+		}
+		return nil, err
+	}
+
+	return reader, nil
 }
 
-// Put object into the store
+// PutObject puts the specified bytes into the configured GCS bucket at the provided key
 func (s *GCSObjectClient) PutObject(ctx context.Context, objectKey string, object io.ReadSeeker) error {
 	writer := s.bucket.Object(objectKey).NewWriter(ctx)
 	// Default GCSChunkSize is 8M and for each call, 8M is allocated xD
@@ -128,7 +138,17 @@ func (s *GCSObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stor
 	return storageObjects, nil
 }
 
-func (s *GCSObjectClient) DeleteObject(ctx context.Context, chunkID string) error {
-	// ToDo: implement this to support deleting chunks from GCS
-	return chunk.ErrMethodNotImplemented
+// DeleteObject deletes the specified object key from the configured GCS bucket. If the
+// key does not exist a generic chunk.ErrStorageObjectNotFound error is returned.
+func (s *GCSObjectClient) DeleteObject(ctx context.Context, objectKey string) error {
+	err := s.bucket.Object(objectKey).Delete(ctx)
+
+	if err != nil {
+		if err == storage.ErrObjectNotExist {
+			return chunk.ErrStorageObjectNotFounds
+		}
+		return err
+	}
+
+	return nil
 }

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -145,7 +145,7 @@ func (s *GCSObjectClient) DeleteObject(ctx context.Context, objectKey string) er
 
 	if err != nil {
 		if err == storage.ErrObjectNotExist {
-			return chunk.ErrStorageObjectNotFounds
+			return chunk.ErrStorageObjectNotFound
 		}
 		return err
 	}


### PR DESCRIPTION
**What this PR does**:

This PR implements the `DeleteObject` method for both the S3 and GCS object clients. It also ensures the generic `chunk.ErrStorageObjectNotFound` error is returned for both of these clients in the get and delete functions to allow for more refined error handling.