### PR TITLE
Deduplicate streamed samples from ingesters using blocks storage

### DIFF
--- a/pkg/distributor/query_test.go
+++ b/pkg/distributor/query_test.go
@@ -35,7 +35,7 @@ func TestMergeSamplesIntoFirstDuplicates(t *testing.T) {
 		{Value: 1.092038719, TimestampMs: 1583946882302},
 	}
 
-	a = mergeSamplesIntoFirst(a, b)
+	a = mergeSamples(a, b)
 
 	// should be the same
 	require.Equal(t, a, b)
@@ -61,7 +61,7 @@ func TestMergeSamplesIntoFirst(t *testing.T) {
 		{Value: 6, TimestampMs: 55},
 	}
 
-	a = mergeSamplesIntoFirst(a, b)
+	a = mergeSamples(a, b)
 
 	require.Equal(t, []ingester_client.Sample{
 		{Value: 1, TimestampMs: 5},
@@ -88,7 +88,7 @@ func TestMergeSamplesIntoFirstNilA(t *testing.T) {
 		{Value: 6, TimestampMs: 55},
 	}
 
-	a := mergeSamplesIntoFirst(nil, b)
+	a := mergeSamples(nil, b)
 
 	require.Equal(t, b, a)
 }
@@ -102,7 +102,7 @@ func TestMergeSamplesIntoFirstNilB(t *testing.T) {
 		{Value: 5, TimestampMs: 50},
 	}
 
-	b := mergeSamplesIntoFirst(a, nil)
+	b := mergeSamples(a, nil)
 
 	require.Equal(t, b, a)
 }

--- a/pkg/distributor/query_test.go
+++ b/pkg/distributor/query_test.go
@@ -1,0 +1,108 @@
+package distributor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ingester_client "github.com/cortexproject/cortex/pkg/ingester/client"
+)
+
+func TestMergeSamplesIntoFirstDuplicates(t *testing.T) {
+	a := []ingester_client.Sample{
+		{Value: 1.084537996, TimestampMs: 1583946732744},
+		{Value: 1.086111723, TimestampMs: 1583946750366},
+		{Value: 1.086111723, TimestampMs: 1583946768623},
+		{Value: 1.087776094, TimestampMs: 1583946795182},
+		{Value: 1.089301187, TimestampMs: 1583946810018},
+		{Value: 1.089301187, TimestampMs: 1583946825064},
+		{Value: 1.089301187, TimestampMs: 1583946835547},
+		{Value: 1.090722985, TimestampMs: 1583946846629},
+		{Value: 1.090722985, TimestampMs: 1583946857608},
+		{Value: 1.092038719, TimestampMs: 1583946882302},
+	}
+
+	b := []ingester_client.Sample{
+		{Value: 1.084537996, TimestampMs: 1583946732744},
+		{Value: 1.086111723, TimestampMs: 1583946750366},
+		{Value: 1.086111723, TimestampMs: 1583946768623},
+		{Value: 1.087776094, TimestampMs: 1583946795182},
+		{Value: 1.089301187, TimestampMs: 1583946810018},
+		{Value: 1.089301187, TimestampMs: 1583946825064},
+		{Value: 1.089301187, TimestampMs: 1583946835547},
+		{Value: 1.090722985, TimestampMs: 1583946846629},
+		{Value: 1.090722985, TimestampMs: 1583946857608},
+		{Value: 1.092038719, TimestampMs: 1583946882302},
+	}
+
+	a = mergeSamplesIntoFirst(a, b)
+
+	// should be the same
+	require.Equal(t, a, b)
+}
+
+func TestMergeSamplesIntoFirst(t *testing.T) {
+	a := []ingester_client.Sample{
+		{Value: 1, TimestampMs: 10},
+		{Value: 2, TimestampMs: 20},
+		{Value: 3, TimestampMs: 30},
+		{Value: 4, TimestampMs: 40},
+		{Value: 5, TimestampMs: 45},
+		{Value: 5, TimestampMs: 50},
+	}
+
+	b := []ingester_client.Sample{
+		{Value: 1, TimestampMs: 5},
+		{Value: 2, TimestampMs: 15},
+		{Value: 3, TimestampMs: 25},
+		{Value: 3, TimestampMs: 30},
+		{Value: 4, TimestampMs: 35},
+		{Value: 5, TimestampMs: 45},
+		{Value: 6, TimestampMs: 55},
+	}
+
+	a = mergeSamplesIntoFirst(a, b)
+
+	require.Equal(t, []ingester_client.Sample{
+		{Value: 1, TimestampMs: 5},
+		{Value: 1, TimestampMs: 10},
+		{Value: 2, TimestampMs: 15},
+		{Value: 2, TimestampMs: 20},
+		{Value: 3, TimestampMs: 25},
+		{Value: 3, TimestampMs: 30},
+		{Value: 4, TimestampMs: 35},
+		{Value: 4, TimestampMs: 40},
+		{Value: 5, TimestampMs: 45},
+		{Value: 5, TimestampMs: 50},
+		{Value: 6, TimestampMs: 55},
+	}, a)
+}
+
+func TestMergeSamplesIntoFirstNilA(t *testing.T) {
+	b := []ingester_client.Sample{
+		{Value: 1, TimestampMs: 5},
+		{Value: 2, TimestampMs: 15},
+		{Value: 3, TimestampMs: 25},
+		{Value: 4, TimestampMs: 35},
+		{Value: 5, TimestampMs: 45},
+		{Value: 6, TimestampMs: 55},
+	}
+
+	a := mergeSamplesIntoFirst(nil, b)
+
+	require.Equal(t, b, a)
+}
+
+func TestMergeSamplesIntoFirstNilB(t *testing.T) {
+	a := []ingester_client.Sample{
+		{Value: 1, TimestampMs: 10},
+		{Value: 2, TimestampMs: 20},
+		{Value: 3, TimestampMs: 30},
+		{Value: 4, TimestampMs: 40},
+		{Value: 5, TimestampMs: 50},
+	}
+
+	b := mergeSamplesIntoFirst(a, nil)
+
+	require.Equal(t, b, a)
+}

--- a/pkg/querier/duplicates_test.go
+++ b/pkg/querier/duplicates_test.go
@@ -49,7 +49,7 @@ func TestDuplicatesSamples(t *testing.T) {
 	}
 
 	{
-		out := runPromQLAndGetJsonResult(t, "rate(metr[1m])", ts, 10*time.Second)
+		out := runPromQLAndGetJSONResult(t, "rate(metr[1m])", ts, 10*time.Second)
 		require.Contains(t, out, "\"NaN\"")
 	}
 
@@ -65,7 +65,7 @@ func TestDuplicatesSamples(t *testing.T) {
 	}
 
 	{
-		out := runPromQLAndGetJsonResult(t, "rate(metr[1m])", deduped, 10*time.Second)
+		out := runPromQLAndGetJSONResult(t, "rate(metr[1m])", deduped, 10*time.Second)
 		require.NotContains(t, out, "\"NaN\"")
 	}
 }
@@ -84,7 +84,7 @@ func dedupeSorted(samples []client.Sample) []client.Sample {
 	return out
 }
 
-func runPromQLAndGetJsonResult(t *testing.T, query string, ts client.TimeSeries, step time.Duration) string {
+func runPromQLAndGetJSONResult(t *testing.T, query string, ts client.TimeSeries, step time.Duration) string {
 	tq := &testQueryable{ts: newTimeSeriesSeriesSet([]client.TimeSeries{ts})}
 
 	engine := promql.NewEngine(promql.EngineOpts{

--- a/pkg/querier/duplicates_test.go
+++ b/pkg/querier/duplicates_test.go
@@ -1,0 +1,141 @@
+package querier
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+func TestDuplicatesSamples(t *testing.T) {
+	ts := client.TimeSeries{
+		Labels: []client.LabelAdapter{
+			{
+				Name:  "lbl",
+				Value: "val",
+			},
+		},
+		Samples: []client.Sample{
+			{Value: 0.948569891, TimestampMs: 1583946731937},
+			{Value: 0.948569891, TimestampMs: 1583946731937},
+			{Value: 0.949927461, TimestampMs: 1583946751878},
+			{Value: 0.949927461, TimestampMs: 1583946751878},
+			{Value: 0.951334505, TimestampMs: 1583946769353},
+			{Value: 0.951334505, TimestampMs: 1583946769353},
+			{Value: 0.951334505, TimestampMs: 1583946779855},
+			{Value: 0.951334505, TimestampMs: 1583946779855},
+			{Value: 0.952676231, TimestampMs: 1583946820080},
+			{Value: 0.952676231, TimestampMs: 1583946820080},
+			{Value: 0.954158847, TimestampMs: 1583946844857},
+			{Value: 0.954158847, TimestampMs: 1583946844857},
+			{Value: 0.955572384, TimestampMs: 1583946858609},
+			{Value: 0.955572384, TimestampMs: 1583946858609},
+			{Value: 0.955572384, TimestampMs: 1583946869878},
+			{Value: 0.955572384, TimestampMs: 1583946869878},
+			{Value: 0.955572384, TimestampMs: 1583946885903},
+			{Value: 0.955572384, TimestampMs: 1583946885903},
+			{Value: 0.956823037, TimestampMs: 1583946899767},
+			{Value: 0.956823037, TimestampMs: 1583946899767},
+		},
+	}
+
+	{
+		out := runPromQLAndGetJsonResult(t, "rate(metr[1m])", ts, 10*time.Second)
+		require.Contains(t, out, "\"NaN\"")
+	}
+
+	// run same query, but with deduplicated samples
+	deduped := client.TimeSeries{
+		Labels: []client.LabelAdapter{
+			{
+				Name:  "lbl",
+				Value: "val",
+			},
+		},
+		Samples: dedupeSorted(ts.Samples),
+	}
+
+	{
+		out := runPromQLAndGetJsonResult(t, "rate(metr[1m])", deduped, 10*time.Second)
+		require.NotContains(t, out, "\"NaN\"")
+	}
+}
+
+func dedupeSorted(samples []client.Sample) []client.Sample {
+	out := []client.Sample(nil)
+	lastTs := int64(0)
+	for _, s := range samples {
+		if s.TimestampMs == lastTs {
+			continue
+		}
+
+		out = append(out, s)
+		lastTs = s.TimestampMs
+	}
+	return out
+}
+
+func runPromQLAndGetJsonResult(t *testing.T, query string, ts client.TimeSeries, step time.Duration) string {
+	tq := &testQueryable{ts: newTimeSeriesSeriesSet([]client.TimeSeries{ts})}
+
+	engine := promql.NewEngine(promql.EngineOpts{
+		Logger:     util.Logger,
+		Timeout:    10 * time.Second,
+		MaxSamples: 1e6,
+	})
+
+	start := model.Time(ts.Samples[0].TimestampMs).Time()
+	end := model.Time(ts.Samples[len(ts.Samples)-1].TimestampMs).Time()
+
+	q, err := engine.NewRangeQuery(tq, query, start, end, step)
+	require.NoError(t, err)
+
+	res := q.Exec(context.Background())
+	require.NoError(t, err)
+
+	out, err := json.Marshal(res)
+	require.NoError(t, err)
+
+	return string(out)
+}
+
+type testQueryable struct {
+	ts *timeSeriesSeriesSet
+}
+
+func (t *testQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+	return testQuerier{ts: t.ts}, nil
+}
+
+type testQuerier struct {
+	ts *timeSeriesSeriesSet
+}
+
+func (m testQuerier) SelectSorted(sp *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	return m.ts, nil, nil
+}
+
+func (m testQuerier) Select(sp *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	return m.SelectSorted(sp, matchers...)
+}
+
+func (m testQuerier) LabelValues(name string) ([]string, storage.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (m testQuerier) LabelNames() ([]string, storage.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (testQuerier) Close() error {
+	return nil
+}


### PR DESCRIPTION
**What this PR does**: this PR adds deduplication of streamed samples coming from different ingesters that use blocks storage.

Merge function stores result into first slice to avoid extra allocations if not needed. We can use more straightforward merge implementation.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
