### PR TITLE
Reference CLI flags <prefix> in generated doc

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1743,7 +1743,15 @@ grpc_client_config:
 
 ### `etcd_config`
 
-The `etcd_config` configures the etcd client.
+The `etcd_config` configures the etcd client. The supported CLI flags `<prefix>` used to reference this config block are:
+
+- _no prefix_
+- `compactor.ring`
+- `distributor.ha-tracker`
+- `distributor.ring`
+- `ruler.ring`
+
+&nbsp;
 
 ```yaml
 # The etcd endpoints to connect to.
@@ -1761,7 +1769,15 @@ The `etcd_config` configures the etcd client.
 
 ### `consul_config`
 
-The `consul_config` configures the consul client.
+The `consul_config` configures the consul client. The supported CLI flags `<prefix>` used to reference this config block are:
+
+- _no prefix_
+- `compactor.ring`
+- `distributor.ha-tracker`
+- `distributor.ring`
+- `ruler.ring`
+
+&nbsp;
 
 ```yaml
 # Hostname and port of Consul.
@@ -1997,7 +2013,14 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 
 ### `redis_config`
 
-The `redis_config` configures the Redis backend cache.
+The `redis_config` configures the Redis backend cache. The supported CLI flags `<prefix>` used to reference this config block are:
+
+- _no prefix_
+- `frontend`
+- `store.index-cache-read`
+- `store.index-cache-write`
+
+&nbsp;
 
 ```yaml
 # Redis service endpoint to use when caching chunks. If empty, no redis will be
@@ -2032,7 +2055,14 @@ The `redis_config` configures the Redis backend cache.
 
 ### `memcached_config`
 
-The `memcached_config` block configures how data is stored in Memcached (ie. expiration).
+The `memcached_config` block configures how data is stored in Memcached (ie. expiration). The supported CLI flags `<prefix>` used to reference this config block are:
+
+- _no prefix_
+- `frontend`
+- `store.index-cache-read`
+- `store.index-cache-write`
+
+&nbsp;
 
 ```yaml
 # How long keys stay in the memcache.
@@ -2050,7 +2080,14 @@ The `memcached_config` block configures how data is stored in Memcached (ie. exp
 
 ### `memcached_client_config`
 
-The `memcached_client_config` configures the client used to connect to Memcached.
+The `memcached_client_config` configures the client used to connect to Memcached. The supported CLI flags `<prefix>` used to reference this config block are:
+
+- _no prefix_
+- `frontend`
+- `store.index-cache-read`
+- `store.index-cache-write`
+
+&nbsp;
 
 ```yaml
 # Hostname for memcached service to use when caching chunks. If empty, no
@@ -2081,7 +2118,14 @@ The `memcached_client_config` configures the client used to connect to Memcached
 
 ### `fifo_cache_config`
 
-The `fifo_cache_config` configures the local in-memory cache.
+The `fifo_cache_config` configures the local in-memory cache. The supported CLI flags `<prefix>` used to reference this config block are:
+
+- _no prefix_
+- `frontend`
+- `store.index-cache-read`
+- `store.index-cache-write`
+
+&nbsp;
 
 ```yaml
 # The number of entries to cache.
@@ -2124,7 +2168,12 @@ api:
 
 ### `configstore_config`
 
-The `configstore_config` configures the config database storing rules and alerts, and is used by the Cortex alertmanager.
+The `configstore_config` configures the config database storing rules and alerts, and is used by the Cortex alertmanager. The supported CLI flags `<prefix>` used to reference this config block are:
+
+- `alertmanager`
+- `ruler`
+
+&nbsp;
 
 ```yaml
 # URL of configs API server.

--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -221,8 +221,16 @@ func annotateFlagPrefix(blocks []*configBlock) {
 			}
 		}
 
+		allPrefixes := []string{}
 		for i, prefix := range findFlagsPrefix(flags) {
 			group[i].flagsPrefix = prefix
+			allPrefixes = append(allPrefixes, prefix)
+		}
+
+		// Store all found prefixes into each block so that when we generate the
+		// markdown we also know which are all the prefixes for each root block.
+		for _, block := range group {
+			block.flagsPrefixes = allPrefixes
 		}
 	}
 

--- a/tools/doc-generator/parser.go
+++ b/tools/doc-generator/parser.go
@@ -20,10 +20,11 @@ var (
 )
 
 type configBlock struct {
-	name        string
-	desc        string
-	entries     []*configEntry
-	flagsPrefix string
+	name          string
+	desc          string
+	entries       []*configEntry
+	flagsPrefix   string
+	flagsPrefixes []string
 }
 
 func (b *configBlock) Add(entry *configEntry) {

--- a/tools/doc-generator/writer.go
+++ b/tools/doc-generator/writer.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -136,6 +137,27 @@ func (w *markdownWriter) writeConfigBlock(block *configBlock) {
 			desc = regexp.MustCompile(regexp.QuoteMeta(block.name)).ReplaceAllStringFunc(desc, func(input string) string {
 				return "`" + input + "`"
 			})
+		}
+
+		// List of all prefixes used to reference this config block.
+		if len(block.flagsPrefixes) > 1 {
+			sortedPrefixes := sort.StringSlice(block.flagsPrefixes)
+			sortedPrefixes.Sort()
+
+			desc += " The supported CLI flags `<prefix>` used to reference this config block are:\n\n"
+
+			for _, prefix := range sortedPrefixes {
+				if prefix == "" {
+					desc += "- _no prefix_\n"
+				} else {
+					desc += fmt.Sprintf("- `%s`\n", prefix)
+				}
+			}
+
+			// Unfortunately the markdown compiler used by the website generator has a bug
+			// when there's a list followed by a code block (no matter know many newlines
+			// in between). To workaround it we add a non-breaking space.
+			desc += "\n&nbsp;"
 		}
 
 		w.out.WriteString(desc + "\n")


### PR DESCRIPTION
**What this PR does**:
The issue #2253 made me think we could actually list the CLI flags `<prefix>` for each root config block which does have multiple prefixes. This PR does not solve #2253 (that issue mention the caching doc) but applies a similar concept to the config file reference doc.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
