### PR TITLE
Compile code in vendor dir; don't download modules again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,8 +118,6 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
 
-    # Make sure the working directory is within the GOPATH, otherwise
-    # "go test" will not download module dependencies.
     working_directory: ~/.go_workspace/src/github.com/cortexproject/cortex
     steps:
     - run:
@@ -155,7 +153,7 @@ jobs:
           export CORTEX_IMAGE="${CORTEX_IMAGE_PREFIX}cortex:${CIRCLE_TAG:-$(./tools/image-tag)}"
           export CORTEX_CHECKOUT_DIR="/home/circleci/.go_workspace/src/github.com/cortexproject/cortex"
           echo "Running integration tests with image: $CORTEX_IMAGE"
-          go test -tags=requires_docker -timeout 300s -v -count=1 ./integration/...
+          go test -mod=vendor -tags=requires_docker -timeout 300s -v -count=1 ./integration/...
 
   build:
     <<: *defaults

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ RM := --rm
 # as it currently disallows TTY devices. This value needs to be overridden
 # in any custom cloudbuild.yaml files
 TTY := --tty
-GO_FLAGS := -ldflags "-extldflags \"-static\" -s -w" -tags netgo
+GO_FLAGS := -mod=vendor -ldflags "-extldflags \"-static\" -s -w" -tags netgo
 
 ifeq ($(BUILD_IN_CONTAINER),true)
 
@@ -162,7 +162,7 @@ endif
 clean:
 	$(SUDO) docker rmi $(IMAGE_NAMES) >/dev/null 2>&1 || true
 	rm -rf $(UPTODATE_FILES) $(EXES) .cache
-	go clean ./...
+	go clean -mod=vendor ./...
 
 clean-protos:
 	rm -rf $(PROTO_GOS)

--- a/tools/test
+++ b/tools/test
@@ -60,7 +60,7 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-GO_TEST_ARGS=(-tags "${TAGS[@]}" -cpu 4 -timeout $TIMEOUT $VERBOSE)
+GO_TEST_ARGS=(-tags "${TAGS[@]}" -mod=vendor -cpu 4 -timeout $TIMEOUT $VERBOSE)
 
 if [ -n "$SLOW" ] || [ -n "$CIRCLECI" ]; then
     SLOW=true


### PR DESCRIPTION
**What this PR does**:
Tells Go to use the code we have checked in under `vendor`.

**Which issue(s) this PR fixes**:
Fixes #1710 
Fixes #1795

**Checklist**
N/A