### PR TITLE
Ruler API and ObjectStore Backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * [CHANGE] Utilize separate protos for rule state and storage. Experimental ruler API will not be functional until the rollout is complete. #2226
 * [CHANGE] Frontend worker in querier now starts after all Querier module dependencies are started. This fixes issue where frontend worker started to send queries to querier before it was ready to serve them (mostly visible when using experimental blocks storage). #2246
 * [CHANGE] Lifecycler component now enters Failed state on errors, and doesn't exit the process. (Important if you're vendoring Cortex and use Lifecycler) #2251
+* [FEATURE] Added experimental storage API to the ruler service that is enabled when the `-experimental.ruler.enable-api` is set to true #2269
+  * `-ruler.storage.type` flag now allows `s3`,`gcs`, and `azure` values
+  * `-ruler.storage.(s3|gcs|azure)` flags exist to allow the configuration of object clients set for rule storage
 * [FEATURE] Flusher target to flush the WAL.
   * `-flusher.wal-dir` for the WAL directory to recover from.
   * `-flusher.concurrent-flushes` for number of concurrent flushes.

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ pkg/querier/queryrange/queryrange.pb.go: pkg/querier/queryrange/queryrange.proto
 pkg/chunk/storage/caching_index_client.pb.go: pkg/chunk/storage/caching_index_client.proto
 pkg/distributor/ha_tracker.pb.go: pkg/distributor/ha_tracker.proto
 pkg/ruler/rules/rules.pb.go: pkg/ruler/rules/rules.proto
+pkg/ruler/ruler.pb.go: pkg/ruler/rules/rules.proto
 pkg/ring/kv/memberlist/kv.pb.go: pkg/ring/kv/memberlist/kv.proto
 
 all: $(UPTODATE_FILES)

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -708,7 +708,7 @@ The `ruler_config` configures the Cortex ruler.
 [pollinterval: <duration> | default = 1m0s]
 
 storeconfig:
-  # Method to use for backend rule storage (configdb)
+  # Method to use for backend rule storage (configdb, azure, gcs, s3)
   # CLI flag: -ruler.storage.type
   [type: <string> | default = "configdb"]
 
@@ -716,6 +716,79 @@ storeconfig:
   # alerts, and is used by the Cortex alertmanager.
   # The CLI flags prefix for this block config is: ruler
   [configdb: <configstore_config>]
+
+  azure:
+    # Name of the blob container used to store chunks. Defaults to `cortex`.
+    # This container must be created before running cortex.
+    # CLI flag: -ruler.storage.azure.container-name
+    [container_name: <string> | default = "cortex"]
+
+    # The Microsoft Azure account name to be used
+    # CLI flag: -ruler.storage.azure.account-name
+    [account_name: <string> | default = ""]
+
+    # The Microsoft Azure account key to use.
+    # CLI flag: -ruler.storage.azure.account-key
+    [account_key: <string> | default = ""]
+
+    # Preallocated buffer size for downloads (default is 512KB)
+    # CLI flag: -ruler.storage.azure.download-buffer-size
+    [download_buffer_size: <int> | default = 512000]
+
+    # Preallocated buffer size for up;oads (default is 256KB)
+    # CLI flag: -ruler.storage.azure.upload-buffer-size
+    [upload_buffer_size: <int> | default = 256000]
+
+    # Number of buffers used to used to upload a chunk. (defaults to 1)
+    # CLI flag: -ruler.storage.azure.download-buffer-count
+    [upload_buffer_count: <int> | default = 1]
+
+    # Timeout for requests made against azure blob storage. Defaults to 30
+    # seconds.
+    # CLI flag: -ruler.storage.azure.request-timeout
+    [request_timeout: <duration> | default = 30s]
+
+    # Number of retries for a request which times out.
+    # CLI flag: -ruler.storage.azure.max-retries
+    [max_retries: <int> | default = 5]
+
+    # Minimum time to wait before retrying a request.
+    # CLI flag: -ruler.storage.azure.min-retry-delay
+    [min_retry_delay: <duration> | default = 10ms]
+
+    # Maximum time to wait before retrying a request.
+    # CLI flag: -ruler.storage.azure.max-retry-delay
+    [max_retry_delay: <duration> | default = 500ms]
+
+  gcs:
+    # Name of GCS bucket to put chunks in.
+    # CLI flag: -ruler.storage.gcs.bucketname
+    [bucket_name: <string> | default = ""]
+
+    # The size of the buffer that GCS client for each PUT request. 0 to disable
+    # buffering.
+    # CLI flag: -ruler.storage.gcs.chunk-buffer-size
+    [chunk_buffer_size: <int> | default = 0]
+
+    # The duration after which the requests to GCS should be timed out.
+    # CLI flag: -ruler.storage.gcs.request-timeout
+    [request_timeout: <duration> | default = 0s]
+
+  s3:
+    # S3 endpoint URL with escaped Key and Secret encoded. If only region is
+    # specified as a host, proper endpoint will be deduced. Use
+    # inmemory:///<bucket-name> to use a mock in-memory implementation.
+    # CLI flag: -ruler.storage.s3.url
+    [s3: <url> | default = ]
+
+    # Comma separated list of bucket names to evenly distribute chunks over.
+    # Overrides any buckets specified in s3.url flag
+    # CLI flag: -ruler.storage.s3.buckets
+    [bucketnames: <string> | default = ""]
+
+    # Set this to `true` to force the request to use path-style addressing.
+    # CLI flag: -ruler.storage.s3.force-path-style
+    [s3forcepathstyle: <boolean> | default = false]
 
 # file path to store temporary rule files for the prometheus rule managers
 # CLI flag: -ruler.rule-path

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -23,7 +23,7 @@ func TestAlertmanager(t *testing.T) {
 	require.NoError(t, s.StartAndWaitReady(alertmanager))
 	require.NoError(t, alertmanager.WaitSumMetrics(e2e.Equals(1), "cortex_alertmanager_configs"))
 
-	c, err := e2ecortex.NewClient("", "", alertmanager.HTTPEndpoint(), "user-1")
+	c, err := e2ecortex.NewClient("", "", alertmanager.HTTPEndpoint(), "", "user-1")
 	require.NoError(t, err)
 
 	cfg, err := c.GetAlertmanagerConfig(context.Background())

--- a/integration/api_ruler_test.go
+++ b/integration/api_ruler_test.go
@@ -1,0 +1,64 @@
+// +build requires_docker
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/integration/e2e"
+	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
+	"github.com/cortexproject/cortex/integration/e2ecortex"
+	rulefmt "github.com/cortexproject/cortex/pkg/ruler/legacy_rulefmt"
+)
+
+func TestRulerAPI(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Start dependencies.
+	dynamo := e2edb.NewDynamoDB()
+	minio := e2edb.NewMinio(9000, RulerConfigs["-ruler.storage.s3.buckets"])
+	require.NoError(t, s.StartAndWaitReady(minio, dynamo))
+
+	// Start Cortex components.
+	require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
+	ruler := e2ecortex.NewRuler("ruler", mergeFlags(ChunksStorageFlags, RulerConfigs), "")
+	require.NoError(t, s.StartAndWaitReady(ruler))
+
+	c, err := e2ecortex.NewClient("", "", "", ruler.HTTPEndpoint(), "user-1")
+	require.NoError(t, err)
+
+	namespace := "test_namespace"
+	rg := rulefmt.RuleGroup{
+		Name:     "test_group",
+		Interval: 100,
+		Rules: []rulefmt.Rule{
+			rulefmt.Rule{
+				Record: "test_rule",
+				Expr:   "up",
+			},
+		},
+	}
+
+	require.NoError(t, c.SetRuleGroup(rg, namespace))
+
+	rgs, err := c.GetRuleGroups()
+	require.NoError(t, err)
+
+	retrievedNamespace, exists := rgs[namespace]
+	require.True(t, exists)
+	require.Len(t, retrievedNamespace, 1)
+	require.Equal(t, retrievedNamespace[0].Name, rg.Name)
+
+	// Ensure the rule group is loaded by the per-tenant Prometheus rules manager
+	require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(1), "cortex_cortex_ruler_managers_total"))
+	require.NoError(t, c.DeleteRuleGroup(namespace, rg.Name))
+
+	require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(2), "cortex_ruler_config_updates_total"))
+
+	_, err = c.GetRuleGroups()
+	require.Error(t, err)
+}

--- a/integration/api_ruler_test.go
+++ b/integration/api_ruler_test.go
@@ -54,10 +54,9 @@ func TestRulerAPI(t *testing.T) {
 	require.Equal(t, retrievedNamespace[0].Name, rg.Name)
 
 	// Ensure the rule group is loaded by the per-tenant Prometheus rules manager
-	require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(1), "cortex_cortex_ruler_managers_total"))
+	require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(1), "cortex_ruler_managers_total"))
 	require.NoError(t, c.DeleteRuleGroup(namespace, rg.Name))
-
-	require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(2), "cortex_ruler_config_updates_total"))
+	require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(0), "cortex_ruler_managers_total"))
 
 	_, err = c.GetRuleGroups()
 	require.Error(t, err)

--- a/integration/api_ruler_test.go
+++ b/integration/api_ruler_test.go
@@ -32,10 +32,11 @@ func TestRulerAPI(t *testing.T) {
 	c, err := e2ecortex.NewClient("", "", "", ruler.HTTPEndpoint(), "user-1")
 	require.NoError(t, err)
 
-	// Create example namespace and rule group to use for tests
-	namespace := "test_namespace"
+	// Create example namespace and rule group to use for tests, using strings that
+	// require url escaping.
+	namespace := "test_encoded_+namespace?"
 	rg := rulefmt.RuleGroup{
-		Name:     "test_group",
+		Name:     "test_encoded_+\"+group_name?",
 		Interval: 100,
 		Rules: []rulefmt.Rule{
 			rulefmt.Rule{

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -61,7 +61,7 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 	now := time.Now()
 	series, expectedVector := generateSeries("series_1", now)
 
-	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "user-1")
+	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", "user-1")
 	require.NoError(t, err)
 
 	res, err := c.Push(series)
@@ -91,7 +91,7 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 		require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 
 		// Query the series
-		c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "user-1")
+		c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", "user-1")
 		require.NoError(t, err)
 
 		result, err := c.Query("series_1", now)

--- a/integration/chunks_storage_backends_test.go
+++ b/integration/chunks_storage_backends_test.go
@@ -77,7 +77,7 @@ func TestChunksStorageAllIndexBackends(t *testing.T) {
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 
-	client, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "user-1")
+	client, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
 	// Push and Query some series from Cortex for each day starting from oldest start time from configs until now so that we test all the Index Stores

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -50,6 +50,16 @@ var (
 		"-alertmanager.web.external-url":   "http://localhost/api/prom",
 	}
 
+	RulerConfigs = map[string]string{
+		"-ruler.enable-sharding":             "false",
+		"-ruler.poll-interval":               "5s",
+		"-experimental.ruler.enable-api":     "true",
+		"-ruler.storage.type":                "s3",
+		"-ruler.storage.s3.buckets":          "cortex-rules",
+		"-ruler.storage.s3.force-path-style": "true",
+		"-ruler.storage.s3.url":              fmt.Sprintf("s3://%s:%s@%s-minio-9000.:9000", e2edb.MinioAccessKey, e2edb.MinioSecretKey, networkName),
+	}
+
 	BlocksStorageFlags = map[string]string{
 		"-store.engine":                                 "tsdb",
 		"-experimental.tsdb.backend":                    "s3",

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -52,7 +52,7 @@ var (
 
 	RulerConfigs = map[string]string{
 		"-ruler.enable-sharding":             "false",
-		"-ruler.poll-interval":               "5s",
+		"-ruler.poll-interval":               "2s",
 		"-experimental.ruler.enable-api":     "true",
 		"-ruler.storage.type":                "s3",
 		"-ruler.storage.s3.buckets":          "cortex-rules",

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -199,7 +200,7 @@ func (c *Client) SetRuleGroup(rulegroup rulefmt.RuleGroup, namespace string) err
 	}
 
 	// Create HTTP request
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://%s/api/prom/rules/%s", c.rulerAddress, namespace), bytes.NewReader(data))
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://%s/api/prom/rules/%s", c.rulerAddress, url.PathEscape(namespace)), bytes.NewReader(data))
 	if err != nil {
 		return err
 	}
@@ -223,7 +224,7 @@ func (c *Client) SetRuleGroup(rulegroup rulefmt.RuleGroup, namespace string) err
 // DeleteRuleGroup gets the status of an alertmanager instance
 func (c *Client) DeleteRuleGroup(namespace string, groupName string) error {
 	// Create HTTP request
-	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s/api/prom/rules/%s/%s", c.rulerAddress, namespace, groupName), nil)
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s/api/prom/rules/%s/%s", c.rulerAddress, url.PathEscape(namespace), url.PathEscape(groupName)), nil)
 	if err != nil {
 		return err
 	}

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -16,11 +17,14 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	yaml "gopkg.in/yaml.v2"
+
+	rulefmt "github.com/cortexproject/cortex/pkg/ruler/legacy_rulefmt"
 )
 
 // Client is a client used to interact with Cortex in integration tests
 type Client struct {
 	alertmanagerClient promapi.Client
+	rulerAddress       string
 	distributorAddress string
 	timeout            time.Duration
 	httpClient         *http.Client
@@ -29,7 +33,13 @@ type Client struct {
 }
 
 // NewClient makes a new Cortex client
-func NewClient(distributorAddress string, querierAddress string, alertmanagerAddress string, orgID string) (*Client, error) {
+func NewClient(
+	distributorAddress string,
+	querierAddress string,
+	alertmanagerAddress string,
+	rulerAddress string,
+	orgID string,
+) (*Client, error) {
 	// Create querier API client
 	querierAPIClient, err := promapi.NewClient(promapi.Config{
 		Address:      "http://" + querierAddress + "/api/prom",
@@ -41,6 +51,7 @@ func NewClient(distributorAddress string, querierAddress string, alertmanagerAdd
 
 	c := &Client{
 		distributorAddress: distributorAddress,
+		rulerAddress:       rulerAddress,
 		timeout:            5 * time.Second,
 		httpClient:         &http.Client{},
 		querierClient:      promv1.NewAPI(querierAPIClient),
@@ -143,4 +154,92 @@ func (c *Client) GetAlertmanagerConfig(ctx context.Context) (*alertConfig.Config
 	err = yaml.Unmarshal([]byte(ss.Data.ConfigYaml), cfg)
 
 	return cfg, err
+}
+
+// GetRuleGroups gets the status of an alertmanager instance
+func (c *Client) GetRuleGroups() (map[string][]rulefmt.RuleGroup, error) {
+	// Create HTTP request
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/api/prom/rules", c.rulerAddress), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Scope-OrgID", c.orgID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	// Execute HTTP request
+	res, err := c.httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	rgs := map[string][]rulefmt.RuleGroup{}
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal(data, rgs)
+	if err != nil {
+		return nil, err
+	}
+
+	return rgs, nil
+}
+
+// SetRuleGroup gets the status of an alertmanager instance
+func (c *Client) SetRuleGroup(rulegroup rulefmt.RuleGroup, namespace string) error {
+	// Create write request
+	data, err := yaml.Marshal(rulegroup)
+	if err != nil {
+		return err
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://%s/api/prom/rules/%s", c.rulerAddress, namespace), bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/yaml")
+	req.Header.Set("X-Scope-OrgID", c.orgID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	// Execute HTTP request
+	res, err := c.httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+	return nil
+}
+
+// DeleteRuleGroup gets the status of an alertmanager instance
+func (c *Client) DeleteRuleGroup(namespace string, groupName string) error {
+	// Create HTTP request
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s/api/prom/rules/%s/%s", c.rulerAddress, namespace, groupName), nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/yaml")
+	req.Header.Set("X-Scope-OrgID", c.orgID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	// Execute HTTP request
+	res, err := c.httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+	return nil
 }

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -210,3 +210,22 @@ func NewAlertmanager(name string, flags map[string]string, image string) *Cortex
 		grpcPort,
 	)
 }
+
+func NewRuler(name string, flags map[string]string, image string) *CortexService {
+	if image == "" {
+		image = GetDefaultImage()
+	}
+
+	return NewCortexService(
+		name,
+		image,
+		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
+			"-target":    "ruler",
+			"-log.level": "warn",
+		}, flags))...),
+		// The alertmanager doesn't expose a readiness probe, so we just check if the / returns 200
+		e2e.NewReadinessProbe(httpPort, "/", 200),
+		httpPort,
+		grpcPort,
+	)
+}

--- a/integration/getting_started_single_process_config_test.go
+++ b/integration/getting_started_single_process_config_test.go
@@ -33,7 +33,7 @@ func TestGettingStartedSingleProcessConfigWithChunksStorage(t *testing.T) {
 	cortex := e2ecortex.NewSingleBinary("cortex-1", flags, "", 9009, 9095)
 	require.NoError(t, s.StartAndWaitReady(cortex))
 
-	c, err := e2ecortex.NewClient(cortex.HTTPEndpoint(), cortex.HTTPEndpoint(), "", "user-1")
+	c, err := e2ecortex.NewClient(cortex.HTTPEndpoint(), cortex.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
 	// Push some series to Cortex.
@@ -77,7 +77,7 @@ func TestGettingStartedSingleProcessConfigWithBlocksStorage(t *testing.T) {
 	cortex := e2ecortex.NewSingleBinary("cortex-1", flags, "", 9009, 9095)
 	require.NoError(t, s.StartAndWaitReady(cortex))
 
-	c, err := e2ecortex.NewClient(cortex.HTTPEndpoint(), cortex.HTTPEndpoint(), "", "user-1")
+	c, err := e2ecortex.NewClient(cortex.HTTPEndpoint(), cortex.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
 	// Push some series to Cortex.

--- a/integration/ingester_flush_test.go
+++ b/integration/ingester_flush_test.go
@@ -48,7 +48,7 @@ func TestIngesterFlushWithChunksStorage(t *testing.T) {
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 
-	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "user-1")
+	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
 	// Push some series to Cortex.

--- a/integration/ingester_hand_over_test.go
+++ b/integration/ingester_hand_over_test.go
@@ -58,7 +58,7 @@ func runIngesterHandOverTest(t *testing.T, flags map[string]string, setup func(t
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 
-	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "user-1")
+	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
 	// Push some series to Cortex.

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -54,7 +54,7 @@ func TestExportedMetrics(t *testing.T) {
 	now := time.Now()
 	series, expectedVector := generateSeries("series_1", now)
 
-	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "user-1")
+	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", "user-1")
 	require.NoError(t, err)
 
 	res, err := c.Push(series)
@@ -63,7 +63,7 @@ func TestExportedMetrics(t *testing.T) {
 
 	// Query the series both from the querier and query-frontend (to hit the read path).
 	for _, endpoint := range []string{querier.HTTPEndpoint(), queryFrontend.HTTPEndpoint()} {
-		c, err := e2ecortex.NewClient("", endpoint, "", "user-1")
+		c, err := e2ecortex.NewClient("", endpoint, "", "", "user-1")
 		require.NoError(t, err)
 
 		result, err := c.Query("series_1", now)

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -63,7 +63,7 @@ func TestQuerierWithBlocksStorage(t *testing.T) {
 			require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 			require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 
-			c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "user-1")
+			c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", "user-1")
 			require.NoError(t, err)
 
 			// Push some series to Cortex.
@@ -167,7 +167,7 @@ func TestQuerierWithBlocksStorageOnMissingBlocksFromStorage(t *testing.T) {
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 
 	// Push some series to Cortex.
-	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "user-1")
+	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", "user-1")
 	require.NoError(t, err)
 
 	series1Timestamp := time.Now()
@@ -200,7 +200,7 @@ func TestQuerierWithBlocksStorageOnMissingBlocksFromStorage(t *testing.T) {
 	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 
 	// Query back the series.
-	c, err = e2ecortex.NewClient("", querier.HTTPEndpoint(), "", "user-1")
+	c, err = e2ecortex.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
 	result, err := c.Query("series_1", series1Timestamp)

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -112,7 +112,7 @@ func runQueryFrontendTest(t *testing.T, setup queryFrontendSetup) {
 	expectedVectors := make([]model.Vector, numUsers)
 
 	for u := 0; u < numUsers; u++ {
-		c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", fmt.Sprintf("user-%d", u))
+		c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", fmt.Sprintf("user-%d", u))
 		require.NoError(t, err)
 
 		var series []prompb.TimeSeries
@@ -130,7 +130,7 @@ func runQueryFrontendTest(t *testing.T, setup queryFrontendSetup) {
 	for u := 0; u < numUsers; u++ {
 		userID := u
 
-		c, err := e2ecortex.NewClient("", queryFrontend.HTTPEndpoint(), "", fmt.Sprintf("user-%d", userID))
+		c, err := e2ecortex.NewClient("", queryFrontend.HTTPEndpoint(), "", "", fmt.Sprintf("user-%d", userID))
 		require.NoError(t, err)
 
 		for q := 0; q < numQueriesPerUser; q++ {

--- a/pkg/chunk/aws/fixtures.go
+++ b/pkg/chunk/aws/fixtures.go
@@ -47,7 +47,8 @@ var Fixtures = []testutils.Fixture{
 				schemaCfg:               schemaConfig,
 			}
 			object := objectclient.NewClient(&S3ObjectClient{
-				S3: newMockS3(),
+				S3:        newMockS3(),
+				delimiter: chunk.DirDelim,
 			}, nil)
 			return index, object, table, schemaConfig, nil
 		},

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -57,10 +57,11 @@ func (cfg *S3Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 type S3ObjectClient struct {
 	bucketNames []string
 	S3          s3iface.S3API
+	delimiter   string
 }
 
 // NewS3ObjectClient makes a new S3-backed ObjectClient.
-func NewS3ObjectClient(cfg S3Config) (*S3ObjectClient, error) {
+func NewS3ObjectClient(cfg S3Config, delimiter string) (*S3ObjectClient, error) {
 	if cfg.S3.URL == nil {
 		return nil, fmt.Errorf("no URL specified for S3")
 	}
@@ -84,6 +85,7 @@ func NewS3ObjectClient(cfg S3Config) (*S3ObjectClient, error) {
 	client := S3ObjectClient{
 		S3:          s3Client,
 		bucketNames: bucketNames,
+		delimiter:   delimiter,
 	}
 	return &client, nil
 }
@@ -173,7 +175,7 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stora
 			input := s3.ListObjectsV2Input{
 				Bucket:    aws.String(a.bucketNames[i]),
 				Prefix:    aws.String(prefix),
-				Delimiter: aws.String(chunk.DirDelim),
+				Delimiter: aws.String(a.delimiter),
 			}
 
 			for {

--- a/pkg/chunk/gcp/fixtures.go
+++ b/pkg/chunk/gcp/fixtures.go
@@ -79,7 +79,7 @@ func (f *fixture) Clients() (
 	if f.gcsObjectClient {
 		cClient = objectclient.NewClient(newGCSObjectClient(GCSConfig{
 			BucketName: "chunks",
-		}, f.gcssrv.Client()), nil)
+		}, f.gcssrv.Client(), chunk.DirDelim), nil)
 	} else {
 		cClient = newBigtableObjectClient(Config{}, schemaConfig, client)
 	}

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -175,7 +175,7 @@ func NewChunkClient(name string, cfg Config, schemaCfg chunk.SchemaConfig) (chun
 	case "inmemory":
 		return chunk.NewMockStorage(), nil
 	case "aws", "s3":
-		return newChunkClientFromStore(aws.NewS3ObjectClient(cfg.AWSStorageConfig.S3Config))
+		return newChunkClientFromStore(aws.NewS3ObjectClient(cfg.AWSStorageConfig.S3Config, chunk.DirDelim))
 	case "aws-dynamo":
 		if cfg.AWSStorageConfig.DynamoDB.URL == nil {
 			return nil, fmt.Errorf("Must set -dynamodb.url in aws mode")
@@ -186,13 +186,13 @@ func NewChunkClient(name string, cfg Config, schemaCfg chunk.SchemaConfig) (chun
 		}
 		return aws.NewDynamoDBChunkClient(cfg.AWSStorageConfig.DynamoDBConfig, schemaCfg)
 	case "azure":
-		return newChunkClientFromStore(azure.NewBlobStorage(&cfg.AzureStorageConfig))
+		return newChunkClientFromStore(azure.NewBlobStorage(&cfg.AzureStorageConfig, chunk.DirDelim))
 	case "gcp":
 		return gcp.NewBigtableObjectClient(context.Background(), cfg.GCPStorageConfig, schemaCfg)
 	case "gcp-columnkey", "bigtable", "bigtable-hashed":
 		return gcp.NewBigtableObjectClient(context.Background(), cfg.GCPStorageConfig, schemaCfg)
 	case "gcs":
-		return newChunkClientFromStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCSConfig))
+		return newChunkClientFromStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCSConfig, chunk.DirDelim))
 	case "cassandra":
 		return cassandra.NewStorageClient(cfg.CassandraStorageConfig, schemaCfg)
 	case "filesystem":

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -402,7 +402,7 @@ func (t *Cortex) initRuler(cfg *Config) (serv services.Service, err error) {
 
 	if cfg.Ruler.EnableAPI {
 		subrouter := t.server.HTTP.PathPrefix(cfg.HTTPPrefix).Subrouter()
-		t.ruler.RegisterRoutes(subrouter)
+		t.ruler.RegisterRoutes(subrouter, t.httpAuthMiddleware)
 		ruler.RegisterRulerServer(t.server.GRPC, t.ruler)
 	}
 

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -287,7 +287,7 @@ var (
 	// ErrNoNamespace signals the requested namespace does not exist
 	ErrNoNamespace = errors.New("a namespace must be provided in the url")
 	// ErrNoGroupName signals a group name url parameter was not found
-	ErrNoGroupName = errors.New("a matching group name must be provided in the url")
+	ErrNoGroupName = errors.New("a matching group name must be provided in the request")
 	// ErrNoRuleGroups signals the rule group requested does not exist
 	ErrNoRuleGroups = errors.New("no rule groups found")
 	// ErrNoUserID is returned when no user ID is provided

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -2,7 +2,9 @@ package ruler
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"time"
@@ -10,22 +12,33 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/weaveworks/common/user"
+	"gopkg.in/yaml.v2"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
+	rulefmt "github.com/cortexproject/cortex/pkg/ruler/legacy_rulefmt"
+	"github.com/cortexproject/cortex/pkg/ruler/rules"
+	store "github.com/cortexproject/cortex/pkg/ruler/rules"
 	"github.com/cortexproject/cortex/pkg/util"
 )
 
 // RegisterRoutes registers the ruler API HTTP routes with the provided Router.
 func (r *Ruler) RegisterRoutes(router *mux.Router) {
+	router = router.UseEncodedPath()
 	for _, route := range []struct {
 		name, method, path string
 		handler            http.HandlerFunc
 	}{
 		{"get_rules", "GET", "/api/v1/rules", r.rules},
 		{"get_alerts", "GET", "/api/v1/alerts", r.alerts},
+		{"list_rules", "GET", "/rules", r.listRules},
+		{"list_rules_namespace", "GET", "/rules/{namespace}", r.listRules},
+		{"get_rulegroup", "GET", "/rules/{namespace}/{groupName}", r.getRuleGroup},
+		{"set_rulegroup", "POST", "/rules/{namespace}", r.createRuleGroup},
+		{"delete_rulegroup", "DELETE", "/rules/{namespace}/{groupName}", r.deleteRuleGroup},
 	} {
 		level.Debug(util.Logger).Log("msg", "ruler: registering route", "name", route.name, "method", route.method, "path", route.path)
 		router.Handle(route.path, route.handler).Methods(route.method).Name(route.name)
@@ -267,4 +280,281 @@ func (r *Ruler) alerts(w http.ResponseWriter, req *http.Request) {
 	if n, err := w.Write(b); err != nil {
 		level.Error(logger).Log("msg", "error writing response", "bytesWritten", n, "err", err)
 	}
+}
+
+var (
+	// ErrNoNamespace signals the requested namespace does not exist
+	ErrNoNamespace = errors.New("a namespace must be provided in the url")
+	// ErrNoGroupName signals a group name url parameter was not found
+	ErrNoGroupName = errors.New("a matching group name must be provided in the url")
+	// ErrNoRuleGroups signals the rule group requested does not exist
+	ErrNoRuleGroups = errors.New("no rule groups found")
+	// ErrNoUserID is returned when no user ID is provided
+	ErrNoUserID = errors.New("no id provided")
+)
+
+// ValidateRuleGroup validates a rulegroup
+func ValidateRuleGroup(g rulefmt.RuleGroup) []error {
+	var errs []error
+	for i, r := range g.Rules {
+		for _, err := range r.Validate() {
+			var ruleName string
+			if r.Alert != "" {
+				ruleName = r.Alert
+			} else {
+				ruleName = r.Record
+			}
+			errs = append(errs, &rulefmt.Error{
+				Group:    g.Name,
+				Rule:     i,
+				RuleName: ruleName,
+				Err:      err,
+			})
+		}
+	}
+
+	return errs
+}
+
+func (r *Ruler) listRules(w http.ResponseWriter, req *http.Request) {
+	logger := util.WithContext(req.Context(), util.Logger)
+	userID, _, err := user.ExtractOrgIDFromHTTPRequest(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	if userID == "" {
+		http.Error(w, ErrNoUserID.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	vars := mux.Vars(req)
+
+	namespace := vars["namespace"]
+	if namespace != "" {
+		namespace, err = url.PathUnescape(namespace) // namespaces need to be unescaped if in the URL
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		level.Debug(logger).Log("msg", "retrieving rule groups with namespace", "userID", userID, "namespace", namespace)
+	}
+
+	level.Debug(logger).Log("msg", "retrieving rule groups from rule store", "userID", userID)
+	rgs, err := r.store.ListRuleGroups(req.Context(), userID, namespace)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	level.Debug(logger).Log("msg", "retrieved rule groups from rule store", "userID", userID, "num_namespaces", len(rgs))
+
+	if len(rgs) == 0 {
+		level.Info(logger).Log("msg", "no rule groups found", "userID", userID)
+		http.Error(w, ErrNoRuleGroups.Error(), http.StatusNotFound)
+		return
+	}
+
+	formatted := rgs.Formatted()
+
+	d, err := yaml.Marshal(&formatted)
+	if err != nil {
+		level.Error(logger).Log("msg", "error marshalling yaml rule groups", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/yaml")
+	if _, err := w.Write(d); err != nil {
+		level.Error(logger).Log("msg", "error writing yaml response", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (r *Ruler) getRuleGroup(w http.ResponseWriter, req *http.Request) {
+	logger := util.WithContext(req.Context(), util.Logger)
+
+	userID, _, err := user.ExtractOrgIDFromHTTPRequest(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	if userID == "" {
+		http.Error(w, ErrNoUserID.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	vars := mux.Vars(req)
+	namespace, exists := vars["namespace"]
+	if !exists {
+		http.Error(w, ErrNoNamespace.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	namespace, err = url.PathUnescape(namespace) // namespaces need to be unescaped if in the URL
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	groupName, exists := vars["groupName"]
+	if !exists {
+		http.Error(w, ErrNoGroupName.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	groupName, err = url.PathUnescape(groupName) // groupName need to be unescaped if in the URL
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	rg, err := r.store.GetRuleGroup(req.Context(), userID, namespace, groupName)
+	if err != nil {
+		if err == store.ErrGroupNotFound {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	formattedRG := store.FromProto(rg)
+
+	d, err := yaml.Marshal(&formattedRG)
+	if err != nil {
+		level.Error(logger).Log("msg", "error marshalling yaml rule groups", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/yaml")
+	if _, err := w.Write(d); err != nil {
+		level.Error(logger).Log("msg", "error writing yaml response", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (r *Ruler) createRuleGroup(w http.ResponseWriter, req *http.Request) {
+	logger := util.WithContext(req.Context(), util.Logger)
+	userID, _, err := user.ExtractOrgIDFromHTTPRequest(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	if userID == "" {
+		http.Error(w, ErrNoUserID.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	vars := mux.Vars(req)
+
+	namespace := vars["namespace"]
+	if namespace == "" {
+		level.Error(logger).Log("err", "no namespace provided with rule group")
+		http.Error(w, ErrNoNamespace.Error(), http.StatusBadRequest)
+		return
+	}
+
+	namespace, err = url.PathUnescape(namespace) // namespaces need to be unescaped if in the URL
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	payload, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	level.Debug(logger).Log("msg", "attempting to unmarshal rulegroup", "userID", userID, "group", string(payload))
+
+	rg := rulefmt.RuleGroup{}
+	err = yaml.Unmarshal(payload, &rg)
+	if err != nil {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	errs := ValidateRuleGroup(rg)
+	if len(errs) > 0 {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, errs[0].Error(), http.StatusBadRequest)
+		return
+	}
+
+	rgProto := store.ToProto(userID, namespace, rg)
+
+	level.Debug(logger).Log("msg", "attempting to store rulegroup", "userID", userID, "group", rgProto.String())
+	err = r.store.SetRuleGroup(req.Context(), userID, namespace, rgProto)
+	if err != nil {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Return a status accepted because the rule has been stored and queued for polling, but is not currently active
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (r *Ruler) deleteRuleGroup(w http.ResponseWriter, req *http.Request) {
+	logger := util.WithContext(req.Context(), util.Logger)
+	userID, _, err := user.ExtractOrgIDFromHTTPRequest(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	if userID == "" {
+		http.Error(w, ErrNoUserID.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	vars := mux.Vars(req)
+	namespace, exists := vars["namespace"]
+	if !exists {
+		http.Error(w, ErrNoNamespace.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	namespace, err = url.PathUnescape(namespace)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	groupName, exists := vars["groupName"]
+	if !exists {
+		http.Error(w, ErrNoGroupName.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	groupName, err = url.PathUnescape(groupName)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	err = r.store.DeleteRuleGroup(req.Context(), userID, namespace, groupName)
+	if err != nil {
+		if err == rules.ErrGroupNotFound {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Return a status accepted because the rule has been stored and queued for polling, but is not currently active
+	w.WriteHeader(http.StatusAccepted)
 }

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/user"
 	"gopkg.in/yaml.v2"
 
@@ -26,7 +27,7 @@ import (
 )
 
 // RegisterRoutes registers the ruler API HTTP routes with the provided Router.
-func (r *Ruler) RegisterRoutes(router *mux.Router) {
+func (r *Ruler) RegisterRoutes(router *mux.Router, middleware middleware.Interface) {
 	router = router.UseEncodedPath()
 	for _, route := range []struct {
 		name, method, path string
@@ -41,7 +42,7 @@ func (r *Ruler) RegisterRoutes(router *mux.Router) {
 		{"delete_rulegroup", "DELETE", "/rules/{namespace}/{groupName}", r.deleteRuleGroup},
 	} {
 		level.Debug(util.Logger).Log("msg", "ruler: registering route", "name", route.name, "method", route.method, "path", route.path)
-		router.Handle(route.path, route.handler).Methods(route.method).Name(route.name)
+		router.Handle(route.path, middleware.Wrap(route.handler)).Methods(route.method).Name(route.name)
 	}
 }
 

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -48,6 +48,11 @@ var (
 		Name:      "ruler_config_updates_total",
 		Help:      "Total number of config updates triggered by a user",
 	}, []string{"user"})
+	managersTotal = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "cortex",
+		Name:      "ruler_managers_total",
+		Help:      "Total number of managers registered and running in the ruler",
+	})
 )
 
 // Config is the configuration for the recording rules server.
@@ -343,6 +348,9 @@ func (r *Ruler) run(ctx context.Context) error {
 			return nil
 		case <-tick.C:
 			r.loadRules(ctx)
+			r.userManagerMtx.Lock()
+			managersTotal.Set(float64(len(r.userManagers)))
+			r.userManagerMtx.Unlock()
 		}
 	}
 }

--- a/pkg/ruler/rules/objectclient/rule_store.go
+++ b/pkg/ruler/rules/objectclient/rule_store.go
@@ -1,0 +1,164 @@
+package objectclient
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	strings "strings"
+
+	"github.com/go-kit/kit/log/level"
+	proto "github.com/gogo/protobuf/proto"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/ruler/rules"
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+// Object Rule Storage Schema
+// =======================
+// Object Name: "rules/<user_id>/<namespace>/<group_name>"
+// Storage Format: Encoded RuleGroupDesc
+
+const (
+	rulePrefix = "rules/"
+)
+
+// RuleStore allows cortex rules to be stored using an object store backend.
+type RuleStore struct {
+	client chunk.ObjectClient
+}
+
+// NewRuleStore returns a new RuleStore
+func NewRuleStore(client chunk.ObjectClient) *RuleStore {
+	return &RuleStore{
+		client: client,
+	}
+}
+
+func (o *RuleStore) getRuleGroup(ctx context.Context, objectKey string) (*rules.RuleGroupDesc, error) {
+	reader, err := o.client.GetObject(ctx, objectKey)
+	if err == chunk.ErrStorageObjectNotFound {
+		level.Debug(util.Logger).Log("msg", "rule group does not exist", "name", objectKey)
+		return nil, rules.ErrGroupNotFound
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	buf, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	rg := &rules.RuleGroupDesc{}
+
+	err = proto.Unmarshal(buf, rg)
+	if err != nil {
+		return nil, err
+	}
+
+	return rg, nil
+}
+
+// ListAllRuleGroups returns all the active rule groups
+func (o *RuleStore) ListAllRuleGroups(ctx context.Context) (map[string]rules.RuleGroupList, error) {
+	ruleGroupObjects, err := o.client.List(ctx, generateRuleObjectKey("", "", ""))
+	if err != nil {
+		return nil, err
+	}
+
+	userGroupMap := map[string]rules.RuleGroupList{}
+	for _, obj := range ruleGroupObjects {
+
+		user := decomposeRuleObjectKey(obj.Key)
+		if user == "" {
+			continue
+		}
+
+		rg, err := o.getRuleGroup(ctx, obj.Key)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, exists := userGroupMap[user]; !exists {
+			userGroupMap[user] = rules.RuleGroupList{}
+		}
+		userGroupMap[user] = append(userGroupMap[user], rg)
+	}
+
+	return userGroupMap, nil
+}
+
+// ListRuleGroups returns all the active rule groups for a user
+func (o *RuleStore) ListRuleGroups(ctx context.Context, userID, namespace string) (rules.RuleGroupList, error) {
+	ruleGroupObjects, err := o.client.List(ctx, generateRuleObjectKey(userID, namespace, ""))
+	if err != nil {
+		return nil, err
+	}
+
+	groups := []*rules.RuleGroupDesc{}
+	for _, obj := range ruleGroupObjects {
+		level.Debug(util.Logger).Log("msg", "listing rule group", "key", obj.Key)
+
+		rg, err := o.getRuleGroup(ctx, obj.Key)
+		if err != nil {
+			level.Error(util.Logger).Log("msg", "unable to retrieve rule group", "err", err, "key", obj.Key)
+			return nil, err
+		}
+		groups = append(groups, rg)
+	}
+	return groups, nil
+}
+
+// GetRuleGroup returns the requested rule group
+func (o *RuleStore) GetRuleGroup(ctx context.Context, userID string, namespace string, grp string) (*rules.RuleGroupDesc, error) {
+	handle := generateRuleObjectKey(userID, namespace, grp)
+	rg, err := o.getRuleGroup(ctx, handle)
+	if err != nil {
+		return nil, err
+	}
+
+	return rg, nil
+}
+
+// SetRuleGroup sets provided rule group
+func (o *RuleStore) SetRuleGroup(ctx context.Context, userID string, namespace string, group *rules.RuleGroupDesc) error {
+	data, err := proto.Marshal(group)
+	if err != nil {
+		return err
+	}
+
+	objectKey := generateRuleObjectKey(userID, namespace, group.Name)
+	return o.client.PutObject(ctx, objectKey, bytes.NewReader(data))
+}
+
+// DeleteRuleGroup deletes the specified rule group
+func (o *RuleStore) DeleteRuleGroup(ctx context.Context, userID string, namespace string, groupName string) error {
+	objectKey := generateRuleObjectKey(userID, namespace, groupName)
+	err := o.client.DeleteObject(ctx, objectKey)
+	if err == chunk.ErrStorageObjectNotFound {
+		return rules.ErrGroupNotFound
+	}
+	return err
+}
+
+func generateRuleObjectKey(id, namespace, name string) string {
+	if id == "" {
+		return rulePrefix
+	}
+	prefix := rulePrefix + id + "/"
+	if namespace == "" {
+		return prefix
+	}
+	return prefix + namespace + "/" + name
+}
+
+func decomposeRuleObjectKey(handle string) string {
+	components := strings.Split(handle, "/")
+	if len(components) != 4 {
+		return ""
+	}
+	return components[1]
+}

--- a/pkg/ruler/rules/store.go
+++ b/pkg/ruler/rules/store.go
@@ -23,6 +23,10 @@ var (
 // RuleStore is used to store and retrieve rules
 type RuleStore interface {
 	ListAllRuleGroups(ctx context.Context) (map[string]RuleGroupList, error)
+	ListRuleGroups(ctx context.Context, userID string, namespace string) (RuleGroupList, error)
+	GetRuleGroup(ctx context.Context, userID, namespace, group string) (*RuleGroupDesc, error)
+	SetRuleGroup(ctx context.Context, userID, namespace string, group *RuleGroupDesc) error
+	DeleteRuleGroup(ctx context.Context, userID, namespace string, group string) error
 }
 
 // RuleGroupList contains a set of rule groups
@@ -105,4 +109,24 @@ func getLatestConfigID(cfgs map[string]userconfig.VersionedRulesConfig, latest u
 		}
 	}
 	return ret
+}
+
+// ListRuleGroups is not implemented
+func (c *ConfigRuleStore) ListRuleGroups(ctx context.Context, userID string, namespace string) (RuleGroupList, error) {
+	return nil, errors.New("not implemented by the config service rule store")
+}
+
+// GetRuleGroup is not implemented
+func (c *ConfigRuleStore) GetRuleGroup(ctx context.Context, userID, namespace, group string) (*RuleGroupDesc, error) {
+	return nil, errors.New("not implemented by the config service rule store")
+}
+
+// SetRuleGroup is not implemented
+func (c *ConfigRuleStore) SetRuleGroup(ctx context.Context, userID, namespace string, group *RuleGroupDesc) error {
+	return errors.New("not implemented by the config service rule store")
+}
+
+// DeleteRuleGroup is not implemented
+func (c *ConfigRuleStore) DeleteRuleGroup(ctx context.Context, userID, namespace string, group string) error {
+	return errors.New("not implemented by the config service rule store")
 }

--- a/pkg/ruler/storage.go
+++ b/pkg/ruler/storage.go
@@ -16,15 +16,15 @@ import (
 
 // RuleStoreConfig conigures a rule store
 type RuleStoreConfig struct {
-	Type     string `yaml:"type"`
-	ConfigDB client.Config
+	Type     string        `yaml:"type"`
+	ConfigDB client.Config `yaml:"configdb"`
 
 	// Object Storage Configs
-	Azure azure.BlobStorageConfig `yaml:"azure,omitempty"`
-	GCS   gcp.GCSConfig           `yaml:"gcs,omitempty"`
-	S3    aws.S3Config            `yaml:"s3,omitempty"`
+	Azure azure.BlobStorageConfig `yaml:"azure"`
+	GCS   gcp.GCSConfig           `yaml:"gcs"`
+	S3    aws.S3Config            `yaml:"s3"`
 
-	mock rules.RuleStore
+	mock rules.RuleStore `yaml:"-"`
 }
 
 // RegisterFlags registers flags.

--- a/pkg/ruler/storage.go
+++ b/pkg/ruler/storage.go
@@ -1,11 +1,17 @@
 package ruler
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
+	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/chunk/aws"
+	"github.com/cortexproject/cortex/pkg/chunk/azure"
+	"github.com/cortexproject/cortex/pkg/chunk/gcp"
 	"github.com/cortexproject/cortex/pkg/configs/client"
 	"github.com/cortexproject/cortex/pkg/ruler/rules"
+	"github.com/cortexproject/cortex/pkg/ruler/rules/objectclient"
 )
 
 // RuleStoreConfig conigures a rule store
@@ -13,13 +19,21 @@ type RuleStoreConfig struct {
 	Type     string `yaml:"type"`
 	ConfigDB client.Config
 
+	// Object Storage Configs
+	Azure azure.BlobStorageConfig `yaml:"azure,omitempty"`
+	GCS   gcp.GCSConfig           `yaml:"gcs,omitempty"`
+	S3    aws.S3Config            `yaml:"s3,omitempty"`
+
 	mock rules.RuleStore
 }
 
 // RegisterFlags registers flags.
 func (cfg *RuleStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.ConfigDB.RegisterFlagsWithPrefix("ruler.", f)
-	f.StringVar(&cfg.Type, "ruler.storage.type", "configdb", "Method to use for backend rule storage (configdb)")
+	cfg.Azure.RegisterFlagsWithPrefix("ruler.storage.", f)
+	cfg.GCS.RegisterFlagsWithPrefix("ruler.storage.", f)
+	cfg.S3.RegisterFlagsWithPrefix("ruler.storage.", f)
+	f.StringVar(&cfg.Type, "ruler.storage.type", "configdb", "Method to use for backend rule storage (configdb, azure, gcs, s3)")
 }
 
 // NewRuleStorage returns a new rule storage backend poller and store
@@ -37,7 +51,20 @@ func NewRuleStorage(cfg RuleStoreConfig) (rules.RuleStore, error) {
 		}
 
 		return rules.NewConfigRuleStore(c), nil
+	case "azure":
+		return newObjRuleStore(azure.NewBlobStorage(&cfg.Azure, ""))
+	case "gcs":
+		return newObjRuleStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCS, ""))
+	case "s3":
+		return newObjRuleStore(aws.NewS3ObjectClient(cfg.S3, ""))
 	default:
-		return nil, fmt.Errorf("Unrecognized rule storage mode %v, choose one of: configdb", cfg.Type)
+		return nil, fmt.Errorf("Unrecognized rule storage mode %v, choose one of: configdb, gcs", cfg.Type)
 	}
+}
+
+func newObjRuleStore(client chunk.ObjectClient, err error) (rules.RuleStore, error) {
+	if err != nil {
+		return nil, err
+	}
+	return objectclient.NewRuleStore(client), nil
 }

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -58,3 +58,90 @@ func newMockRuleStore(rules map[string]rules.RuleGroupList) *mockRuleStore {
 func (m *mockRuleStore) ListAllRuleGroups(ctx context.Context) (map[string]rules.RuleGroupList, error) {
 	return m.rules, nil
 }
+
+func (m *mockRuleStore) ListRuleGroups(ctx context.Context, userID, namespace string) (rules.RuleGroupList, error) {
+	userRules, exists := m.rules[userID]
+	if !exists {
+		return nil, rules.ErrUserNotFound
+	}
+
+	if namespace == "" {
+		return userRules, nil
+	}
+
+	namespaceRules := rules.RuleGroupList{}
+
+	for _, rg := range userRules {
+		if rg.Namespace == namespace {
+			namespaceRules = append(namespaceRules, rg)
+		}
+	}
+
+	if len(namespaceRules) == 0 {
+		return nil, rules.ErrGroupNamespaceNotFound
+	}
+
+	return namespaceRules, nil
+}
+
+func (m *mockRuleStore) GetRuleGroup(ctx context.Context, userID string, namespace string, group string) (*rules.RuleGroupDesc, error) {
+	userRules, exists := m.rules[userID]
+	if !exists {
+		return nil, rules.ErrUserNotFound
+	}
+
+	if namespace == "" {
+		return nil, rules.ErrGroupNamespaceNotFound
+	}
+
+	for _, rg := range userRules {
+		if rg.Namespace == namespace && rg.Name == group {
+			return rg, nil
+		}
+	}
+
+	return nil, rules.ErrGroupNotFound
+}
+
+func (m *mockRuleStore) SetRuleGroup(ctx context.Context, userID string, namespace string, group *rules.RuleGroupDesc) error {
+	userRules, exists := m.rules[userID]
+	if !exists {
+		userRules = rules.RuleGroupList{}
+		m.rules[userID] = userRules
+	}
+
+	if namespace == "" {
+		return rules.ErrGroupNamespaceNotFound
+	}
+
+	for i, rg := range userRules {
+		if rg.Namespace == namespace && rg.Name == group.Name {
+			userRules[i] = group
+			return nil
+		}
+	}
+
+	m.rules[userID] = append(userRules, group)
+	return nil
+}
+
+func (m *mockRuleStore) DeleteRuleGroup(ctx context.Context, userID string, namespace string, group string) error {
+	userRules, exists := m.rules[userID]
+	if !exists {
+		userRules = rules.RuleGroupList{}
+		m.rules[userID] = userRules
+	}
+
+	if namespace == "" {
+		return rules.ErrGroupNamespaceNotFound
+	}
+
+	for i, rg := range userRules {
+		if rg.Namespace == namespace && rg.Name == group {
+			m.rules[userID] = append(userRules[:i], userRules[:i+1]...)
+			return nil
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
### API Changes

This PR adds an API to the ruler service based on this design document (https://docs.google.com/document/d/1gNKiC5L_zWQ4GGgtdhJJ6FnaZXyJJBvdGTUmF0wgEFg/edit?usp=sharing)

### Object Storage Changes

* It creates a generic storage client for rules based on our `chunk.ObjectClient` interface
* The delimiter was made a configurable option for the object storage clients to make this possible. The delimiter is set at the construction of the object storage client

### Integration Tests

* A ruler integration test was added that ensures a rule group can be set, is running in a Prometheus manager, and can be deleted
* A ruler address was added to the integration test cortex client

**Which issue(s) this PR fixes**:
Related #1547 #1244

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md`
