### PR TITLE
Introduce faillint in the CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
   docker:
     # IMPORTANT: whenever you change the build-image version tag, remember to replace it
     #            across the entire file (there are multiple references).
-    - image: quay.io/cortexproject/build-image:update-gogoproto-9a1b26ac6
+    - image: quay.io/cortexproject/build-image:introduce-faillint-to-ci-ca69fd09b-WIP
   working_directory: /go/src/github.com/cortexproject/cortex
 
 filters: &filters
@@ -88,7 +88,7 @@ jobs:
 
   test:
     docker:
-      - image: quay.io/cortexproject/build-image:update-gogoproto-9a1b26ac6
+      - image: quay.io/cortexproject/build-image:introduce-faillint-to-ci-ca69fd09b-WIP
       - image: cassandra:3.11
         environment:
           JVM_OPTS: "-Xms1024M -Xmx1024M"
@@ -112,7 +112,7 @@ jobs:
         name: Integration Test
         command: |
           touch build-image/.uptodate
-          MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations make BUILD_IMAGE=quay.io/cortexproject/build-image:update-gogoproto-9a1b26ac6 configs-integration-test
+          MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations make BUILD_IMAGE=quay.io/cortexproject/build-image:introduce-faillint-to-ci-ca69fd09b-WIP configs-integration-test
 
   integration:
     machine:

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,9 @@ lint:
 	misspell -error docs
 	golangci-lint run --build-tags netgo --timeout=5m --enable golint --enable misspell --enable gofmt
 
+	# Ensure no blacklisted package is imported.
+	faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert" ./pkg/... ./cmd/... ./tools/... ./integration/...
+
 	# Validate Kubernetes spec files. Requires:
 	# https://kubeval.instrumenta.dev
 	kubeval ./k8s/*

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -31,6 +31,11 @@ COPY build.sh /
 ENV GOCACHE=/go/cache
 ENTRYPOINT ["/build.sh"]
 
+# Install faillint used to lint go imports in CI.
+ENV FAILLINT_VERSION=1.2.0
+RUN GO111MODULE=on go get github.com/fatih/faillint@v${FAILLINT_VERSION} && \
+    rm -rf /go/pkg /go/src
+
 ARG revision
 LABEL org.opencontainers.image.title="build-image" \
       org.opencontainers.image.source="https://github.com/cortexproject/cortex/tree/master/build-image" \


### PR DESCRIPTION
**What this PR does**:
A common mistake (I did it too) is to import `github.com/bmizerany/assert` instead of `github.com/stretchr/testify/assert`. In this PR I've introduced `faillint` as further lint step to ensure no blacklisted package is imported. Of you try to use `github.com/bmizerany/assert` the linter will fail, suggesting which package should be used instead:

```
/go/src/github.com/cortexproject/cortex/pkg/storage/tsdb/config_test.go:8:2: package "github.com/bmizerany/assert" shouldn't be imported, suggested: "github.com/stretchr/testify/assert"
```

`faillint` will also be useful in the future to enforce some design patterns (ie. once completed the Prometheus metrics refactoring, we'll be able to forbid the usage of `prometheus.NewGauge()` in favor of `promauth.With(reg).NewGauge()` and so on).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
