### PR TITLE
support for cassandra in integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,7 @@ jobs:
           docker pull consul:0.9
           docker pull quay.io/cortexproject/cortex:v0.6.0
           docker pull shopify/bigtable-emulator:0.1.0
+          docker pull rinscy/cassandra:3.11.0
     - run:
         name: Integration Tests
         command: |

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -51,7 +51,7 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 	ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flagsForOldImage, "")
 	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flagsForOldImage, "")
 	// Old ring didn't have /ready probe, use /ring instead.
-	distributor.SetReadinessProbe(e2e.NewReadinessProbeHTTP(distributor.HTTPPort(), "/ring", 200))
+	distributor.SetReadinessProbe(e2e.NewHTTPReadinessProbe(distributor.HTTPPort(), "/ring", 200))
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester1))
 
 	// Wait until the distributor has updated the ring.

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -51,7 +51,7 @@ func TestBackwardCompatibilityWithChunksStorage(t *testing.T) {
 	ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flagsForOldImage, "")
 	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flagsForOldImage, "")
 	// Old ring didn't have /ready probe, use /ring instead.
-	distributor.SetReadinessProbe(e2e.NewReadinessProbe(distributor.HTTPPort(), "/ring", 200))
+	distributor.SetReadinessProbe(e2e.NewReadinessProbeHTTP(distributor.HTTPPort(), "/ring", 200))
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester1))
 
 	// Wait until the distributor has updated the ring.

--- a/integration/e2e/db/db.go
+++ b/integration/e2e/db/db.go
@@ -25,7 +25,7 @@ func NewMinio(port int, bktName string) *e2e.HTTPService {
 		"minio/minio:RELEASE.2019-12-30T05-45-39Z",
 		// Create the "cortex" bucket before starting minio
 		e2e.NewCommandWithoutEntrypoint("sh", "-c", fmt.Sprintf("mkdir -p /data/%s && minio server --address :%v --quiet /data", bktName, port)),
-		e2e.NewReadinessProbeHTTP(port, "/minio/health/ready", 200),
+		e2e.NewHTTPReadinessProbe(port, "/minio/health/ready", 200),
 		port,
 	)
 	m.SetEnvVars(map[string]string{
@@ -78,7 +78,7 @@ func NewDynamoDB() *e2e.HTTPService {
 		"amazon/dynamodb-local:1.11.477",
 		e2e.NewCommand("-jar", "DynamoDBLocal.jar", "-inMemory", "-sharedDb"),
 		// DynamoDB doesn't have a readiness probe, so we check if the / works even if returns 400
-		e2e.NewReadinessProbeHTTP(8000, "/", 400),
+		e2e.NewHTTPReadinessProbe(8000, "/", 400),
 		8000,
 	)
 }
@@ -104,7 +104,7 @@ func NewCassandra() *e2e.HTTPService {
 		"rinscy/cassandra:3.11.0",
 		nil,
 		// readiness probe inspired from https://github.com/kubernetes/examples/blob/b86c9d50be45eaf5ce74dee7159ce38b0e149d38/cassandra/image/files/ready-probe.sh
-		e2e.NewReadinessProbeCmd(e2e.NewCommand("bash", "-c", "nodetool status | grep UN")),
+		e2e.NewCmdReadinessProbe(e2e.NewCommand("bash", "-c", "nodetool status | grep UN")),
 		9042,
 	)
 }

--- a/integration/e2e/db/db.go
+++ b/integration/e2e/db/db.go
@@ -25,7 +25,7 @@ func NewMinio(port int, bktName string) *e2e.HTTPService {
 		"minio/minio:RELEASE.2019-12-30T05-45-39Z",
 		// Create the "cortex" bucket before starting minio
 		e2e.NewCommandWithoutEntrypoint("sh", "-c", fmt.Sprintf("mkdir -p /data/%s && minio server --address :%v --quiet /data", bktName, port)),
-		e2e.NewReadinessProbe(port, "/minio/health/ready", 200),
+		e2e.NewReadinessProbeHTTP(port, "/minio/health/ready", 200),
 		port,
 	)
 	m.SetEnvVars(map[string]string{
@@ -78,7 +78,7 @@ func NewDynamoDB() *e2e.HTTPService {
 		"amazon/dynamodb-local:1.11.477",
 		e2e.NewCommand("-jar", "DynamoDBLocal.jar", "-inMemory", "-sharedDb"),
 		// DynamoDB doesn't have a readiness probe, so we check if the / works even if returns 400
-		e2e.NewReadinessProbe(8000, "/", 400),
+		e2e.NewReadinessProbeHTTP(8000, "/", 400),
 		8000,
 	)
 }
@@ -90,8 +90,21 @@ func NewBigtable() *e2e.HTTPService {
 		// If you change the image tag, remember to update it in the preloading done
 		// by CircleCI too (see .circleci/config.yml).
 		"shopify/bigtable-emulator:0.1.0",
-		e2e.NewCommand(""),
+		nil,
 		nil,
 		9035,
+	)
+}
+
+func NewCassandra() *e2e.HTTPService {
+	return e2e.NewHTTPService(
+		"cassandra",
+		// If you change the image tag, remember to update it in the preloading done
+		// by CircleCI too (see .circleci/config.yml).
+		"rinscy/cassandra:3.11.0",
+		nil,
+		// readiness probe inspired from https://github.com/kubernetes/examples/blob/b86c9d50be45eaf5ce74dee7159ce38b0e149d38/cassandra/image/files/ready-probe.sh
+		e2e.NewReadinessProbeCmd(e2e.NewCommand("bash", "-c", "nodetool status | grep UN")),
+		9042,
 	)
 }

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -354,22 +354,22 @@ type ReadinessProbe interface {
 	Ready(service *ConcreteService) (err error)
 }
 
-// ReadinessProbeHTTP checks readiness by making HTTP call and checking for expected HTTP status code
-type ReadinessProbeHTTP struct {
+// HTTPReadinessProbe checks readiness by making HTTP call and checking for expected HTTP status code
+type HTTPReadinessProbe struct {
 	port           int
 	path           string
 	expectedStatus int
 }
 
-func NewReadinessProbeHTTP(port int, path string, expectedStatus int) *ReadinessProbeHTTP {
-	return &ReadinessProbeHTTP{
+func NewHTTPReadinessProbe(port int, path string, expectedStatus int) *HTTPReadinessProbe {
+	return &HTTPReadinessProbe{
 		port:           port,
 		path:           path,
 		expectedStatus: expectedStatus,
 	}
 }
 
-func (p *ReadinessProbeHTTP) Ready(service *ConcreteService) (err error) {
+func (p *HTTPReadinessProbe) Ready(service *ConcreteService) (err error) {
 	// Map the container port to the local port
 	localPort, ok := service.networkPortsContainerToLocal[p.port]
 	if !ok {
@@ -390,16 +390,16 @@ func (p *ReadinessProbeHTTP) Ready(service *ConcreteService) (err error) {
 	return fmt.Errorf("got no expected status code: %v, expected: %v", res.StatusCode, p.expectedStatus)
 }
 
-// ReadinessProbeCmd checks readiness by `Exec`ing a command which returns 0 to consider status being ready
-type ReadinessProbeCmd struct {
+// CmdReadinessProbe checks readiness by `Exec`ing a command (within container) which returns 0 to consider status being ready
+type CmdReadinessProbe struct {
 	cmd *Command
 }
 
-func NewReadinessProbeCmd(cmd *Command) *ReadinessProbeCmd {
-	return &ReadinessProbeCmd{cmd: cmd}
+func NewCmdReadinessProbe(cmd *Command) *CmdReadinessProbe {
+	return &CmdReadinessProbe{cmd: cmd}
 }
 
-func (p *ReadinessProbeCmd) Ready(service *ConcreteService) error {
+func (p *CmdReadinessProbe) Ready(service *ConcreteService) error {
 	_, err := service.Exec(p.cmd)
 	return err
 }

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -37,7 +38,7 @@ type ConcreteService struct {
 	env          map[string]string
 	user         string
 	command      *Command
-	readiness    *ReadinessProbe
+	readiness    ReadinessProbe
 
 	// Maps container ports to dynamically binded local ports.
 	networkPortsContainerToLocal map[int]int
@@ -54,7 +55,7 @@ func NewConcreteService(
 	name string,
 	image string,
 	command *Command,
-	readiness *ReadinessProbe,
+	readiness ReadinessProbe,
 	networkPorts ...int,
 ) *ConcreteService {
 	return &ConcreteService{
@@ -218,7 +219,7 @@ func (s *ConcreteService) NetworkEndpointFor(networkName string, port int) strin
 	return fmt.Sprintf("%s:%d", containerName(networkName, s.name), port)
 }
 
-func (s *ConcreteService) SetReadinessProbe(probe *ReadinessProbe) {
+func (s *ConcreteService) SetReadinessProbe(probe ReadinessProbe) {
 	s.readiness = probe
 }
 
@@ -232,13 +233,7 @@ func (s *ConcreteService) Ready() error {
 		return nil
 	}
 
-	// Map the container port to the local port
-	localPort, ok := s.networkPortsContainerToLocal[s.readiness.port]
-	if !ok {
-		return fmt.Errorf("unknown port %d configured in the readiness probe", s.readiness.port)
-	}
-
-	return s.readiness.Ready(localPort)
+	return s.readiness.Ready(s)
 }
 
 func containerName(netName string, name string) string {
@@ -303,14 +298,35 @@ func (s *ConcreteService) buildDockerRunArgs(networkName, sharedDir string) []st
 	}
 
 	// Disable entrypoint if required
-	if s.command.entrypointDisabled {
+	if s.command != nil && s.command.entrypointDisabled {
 		args = append(args, "--entrypoint", "")
 	}
 
 	args = append(args, s.image)
-	args = append(args, s.command.cmd)
-	args = append(args, s.command.args...)
+
+	if s.command != nil {
+		args = append(args, s.command.cmd)
+		args = append(args, s.command.args...)
+	}
+
 	return args
+}
+
+func (s *ConcreteService) Exec(command *Command) (string, error) {
+	args := []string{"exec", s.containerName()}
+	args = append(args, command.cmd)
+	args = append(args, command.args...)
+
+	cmd := exec.Command("docker", args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+
+	return stdout.String(), nil
 }
 
 type Command struct {
@@ -334,21 +350,32 @@ func NewCommandWithoutEntrypoint(cmd string, args ...string) *Command {
 	}
 }
 
-type ReadinessProbe struct {
+type ReadinessProbe interface {
+	Ready(service *ConcreteService) (err error)
+}
+
+// ReadinessProbeHTTP checks readiness by making HTTP call and checking for expected HTTP status code
+type ReadinessProbeHTTP struct {
 	port           int
 	path           string
 	expectedStatus int
 }
 
-func NewReadinessProbe(port int, path string, expectedStatus int) *ReadinessProbe {
-	return &ReadinessProbe{
+func NewReadinessProbeHTTP(port int, path string, expectedStatus int) *ReadinessProbeHTTP {
+	return &ReadinessProbeHTTP{
 		port:           port,
 		path:           path,
 		expectedStatus: expectedStatus,
 	}
 }
 
-func (p *ReadinessProbe) Ready(localPort int) (err error) {
+func (p *ReadinessProbeHTTP) Ready(service *ConcreteService) (err error) {
+	// Map the container port to the local port
+	localPort, ok := service.networkPortsContainerToLocal[p.port]
+	if !ok {
+		return fmt.Errorf("unknown port %d configured in the readiness probe", p.port)
+	}
+
 	res, err := GetRequest(fmt.Sprintf("http://localhost:%d%s", localPort, p.path))
 	if err != nil {
 		return err
@@ -361,6 +388,20 @@ func (p *ReadinessProbe) Ready(localPort int) (err error) {
 	}
 
 	return fmt.Errorf("got no expected status code: %v, expected: %v", res.StatusCode, p.expectedStatus)
+}
+
+// ReadinessProbeCmd checks readiness by `Exec`ing a command which returns 0 to consider status being ready
+type ReadinessProbeCmd struct {
+	cmd *Command
+}
+
+func NewReadinessProbeCmd(cmd *Command) *ReadinessProbeCmd {
+	return &ReadinessProbeCmd{cmd: cmd}
+}
+
+func (p *ReadinessProbeCmd) Ready(service *ConcreteService) error {
+	_, err := service.Exec(p.cmd)
+	return err
 }
 
 type LinePrefixWriter struct {
@@ -398,7 +439,7 @@ func NewHTTPService(
 	name string,
 	image string,
 	command *Command,
-	readiness *ReadinessProbe,
+	readiness ReadinessProbe,
 	httpPort int,
 	otherPorts ...int,
 ) *HTTPService {

--- a/integration/e2ecortex/service.go
+++ b/integration/e2ecortex/service.go
@@ -13,7 +13,7 @@ func NewCortexService(
 	name string,
 	image string,
 	command *e2e.Command,
-	readiness *e2e.ReadinessProbe,
+	readiness *e2e.ReadinessProbeHTTP,
 	httpPort int,
 	grpcPort int,
 	otherPorts ...int,

--- a/integration/e2ecortex/service.go
+++ b/integration/e2ecortex/service.go
@@ -13,7 +13,7 @@ func NewCortexService(
 	name string,
 	image string,
 	command *e2e.Command,
-	readiness *e2e.ReadinessProbeHTTP,
+	readiness e2e.ReadinessProbe,
 	httpPort int,
 	grpcPort int,
 	otherPorts ...int,

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -48,7 +48,7 @@ func NewDistributorWithConfigFile(name, consulAddress, configFile string, flags 
 			"-ring.store":      "consul",
 			"-consul.hostname": consulAddress,
 		}, flags))...),
-		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
+		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -83,7 +83,7 @@ func NewQuerierWithConfigFile(name, consulAddress, configFile string, flags map[
 			"-querier.frontend-client.backoff-retries":    "1",
 			"-querier.worker-parallelism":                 "1",
 		}, flags))...),
-		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
+		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -117,7 +117,7 @@ func NewIngesterWithConfigFile(name, consulAddress, configFile string, flags map
 			"-ring.store":      "consul",
 			"-consul.hostname": consulAddress,
 		}, flags))...),
-		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
+		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -143,7 +143,7 @@ func NewTableManagerWithConfigFile(name, configFile string, flags map[string]str
 			"-target":    "table-manager",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
+		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -169,7 +169,7 @@ func NewQueryFrontendWithConfigFile(name, configFile string, flags map[string]st
 			"-target":    "query-frontend",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
+		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -186,7 +186,7 @@ func NewSingleBinary(name string, flags map[string]string, image string, httpPor
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
+		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 		otherPorts...,
@@ -205,7 +205,7 @@ func NewAlertmanager(name string, flags map[string]string, image string) *Cortex
 			"-target":    "alertmanager",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
+		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -48,7 +48,7 @@ func NewDistributorWithConfigFile(name, consulAddress, configFile string, flags 
 			"-ring.store":      "consul",
 			"-consul.hostname": consulAddress,
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -83,7 +83,7 @@ func NewQuerierWithConfigFile(name, consulAddress, configFile string, flags map[
 			"-querier.frontend-client.backoff-retries":    "1",
 			"-querier.worker-parallelism":                 "1",
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -117,7 +117,7 @@ func NewIngesterWithConfigFile(name, consulAddress, configFile string, flags map
 			"-ring.store":      "consul",
 			"-consul.hostname": consulAddress,
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -143,7 +143,7 @@ func NewTableManagerWithConfigFile(name, configFile string, flags map[string]str
 			"-target":    "table-manager",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -169,7 +169,7 @@ func NewQueryFrontendWithConfigFile(name, configFile string, flags map[string]st
 			"-target":    "query-frontend",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)
@@ -186,7 +186,7 @@ func NewSingleBinary(name string, flags map[string]string, image string, httpPor
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 		otherPorts...,
@@ -205,7 +205,7 @@ func NewAlertmanager(name string, flags map[string]string, image string) *Cortex
 			"-target":    "alertmanager",
 			"-log.level": "warn",
 		}, flags))...),
-		e2e.NewReadinessProbe(httpPort, "/ready", 204),
+		e2e.NewReadinessProbeHTTP(httpPort, "/ready", 204),
 		httpPort,
 		grpcPort,
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds support of cassandra in integration tests

I have used an optimized docker image for integration tests. Here is the repo for it https://github.com/saidbouras/cassandra-docker-unit.
There is also a community maintained docker image https://hub.docker.com/_/cassandra, which is slow to start and takes about 10-15 additional seconds.
Cassandra version in image built by saidbouras is 3.11 while community build docker has 3.11.6 which I feel is okay. We can use community maintained docker image as well if we want if that is not okay.

Since Cassandra is slow to start and does not have an HTTP readiness probe, I have added support for command based probe. An example of readiness probe for Cassandra can be found here: https://github.com/kubernetes/examples/blob/b86c9d50be45eaf5ce74dee7159ce38b0e149d38/cassandra/image/files/ready-probe.sh
