### PR TITLE
Wait for rate-limit instead of bailing out immediately

### DIFF
--- a/pkg/util/limiter/rate_limiter.go
+++ b/pkg/util/limiter/rate_limiter.go
@@ -1,6 +1,7 @@
 package limiter
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -45,6 +46,13 @@ func NewRateLimiter(strategy RateLimiterStrategy, recheckPeriod time.Duration) *
 // AllowN reports whether n tokens may be consumed happen at time now.
 func (l *RateLimiter) AllowN(now time.Time, tenantID string, n int) bool {
 	return l.getTenantLimiter(now, tenantID).AllowN(now, n)
+}
+
+// WaitN blocks until n tokens can be consumed, or returns an error if
+// n exceeds the burst size, the Context is canceled, or the expected
+// wait time exceeds the Context's Deadline.
+func (l *RateLimiter) WaitN(ctx context.Context, now time.Time, tenantID string, n int) error {
+	return l.getTenantLimiter(now, tenantID).WaitN(ctx, n)
 }
 
 // Limit returns the currently configured maximum overall tokens rate.


### PR DESCRIPTION
This allows for temporary peaks to be smoothed out without dropping data.

Fixes #879 - see description there for more detail on the idea.
Probably needs further discussion - I suspect that, as coded here, if the sender just has too much data we will never catch up.  EDIT and the tests don't match the new behaviour hence fail.

I deployed this to my production in the catch-up phase after an outage, and subjectively the behaviour is vastly preferrable.  Smooth catch-up at the maximum allowed rate, no data dropped due to rate-limiting.

See also #2037  

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
