### PR TITLE
Fixed etcd client keepalive settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [ENHANCEMENT] Experimental TSDB: Add support for local `filesystem` backend. #2245
 * [ENHANCEMENT] Allow 1w (where w denotes week) and 1y (where y denotes year) when setting table period and retention. #2252 
 * [ENHANCEMENT] Added FIFO cache metrics for current number of entries and memory usage. #2270
+* [BUGFIX] Fixed etcd client keepalive settings. #2278
 * [BUGFIX] Fixed bug in updating last element of FIFO cache. #2270
 
 


### PR DESCRIPTION
**What this PR does**:
Today we experienced a (likely short) outage in one of our production clusters, due to some distributors unable to operate on etcd. The distributors where continuously logging this:
```
level=error ts=REDACTED caller=etcd.go:64 msg="error getting key" key=prom_ha/REDACTED/REDACTED err="context canceled"
```

After a long investigation, it turned out the issue has been caused by a dead TCP connection between the etcd client and the server which wasn't gracefully closed. The problem is that when the TCP connection is stuck (ie. the VM where etcd is running dies), the client will detect it only once the TCP keepalive will expire which (by default) is about 2 hours ([some ref](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html)).

Likely, the etcd client allows to configure the gRPC keepalive but unfortunately we didn't enable it. In this PR I'm enabling it, proposing to use some sane defaults instead of exposing yet another config options.

I've been able to reproduce the issue with `iptables -j DROP` and I've tested the fix in this PR in a dev cluster. With the fix in this PR, the etcd client quickly detect a dead connection and re-opens a new one. Once the new one succeed (ie. with etcd in HA the new connecton is routed to an healthy etcd instance) etcd client will recover. In the test cluster I've just seen a couple of the following errors and then it recovered:
`rpc error: code = Unavailable desc = transport is closing`

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
