### PR TITLE
Introduced a basic logger to the integration tests framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
           export CORTEX_IMAGE="${CORTEX_IMAGE_PREFIX}cortex:${CIRCLE_TAG:-$(./tools/image-tag)}"
           export CORTEX_CHECKOUT_DIR="/home/circleci/.go_workspace/src/github.com/cortexproject/cortex"
           echo "Running integration tests with image: $CORTEX_IMAGE"
-          go test -tags=requires_docker -timeout 300s -v -count=1 ./integration/...
+          go test -tags=requires_docker -timeout 600s -v -count=1 ./integration/...
 
   build:
     <<: *defaults

--- a/integration/e2e/logger.go
+++ b/integration/e2e/logger.go
@@ -38,6 +38,7 @@ func (l *Logger) Log(keyvals ...interface{}) error {
 	}
 
 	log.WriteString("\n")
-	l.w.Write([]byte(log.String()))
-	return nil
+
+	_, err := l.w.Write([]byte(log.String()))
+	return err
 }

--- a/integration/e2e/logger.go
+++ b/integration/e2e/logger.go
@@ -1,0 +1,43 @@
+package e2e
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-kit/kit/log"
+)
+
+// Global logger to use in integration tests. We use a global logger to simplify
+// writing integration tests and avoiding having to pass the logger instance
+// every time.
+var logger log.Logger
+
+func init() {
+	logger = NewLogger(os.Stdout)
+}
+
+type Logger struct {
+	w io.Writer
+}
+
+func NewLogger(w io.Writer) *Logger {
+	return &Logger{
+		w: w,
+	}
+}
+
+func (l *Logger) Log(keyvals ...interface{}) error {
+	log := strings.Builder{}
+	log.WriteString(time.Now().Format("15:04:05"))
+
+	for _, v := range keyvals {
+		log.WriteString(" " + fmt.Sprint(v))
+	}
+
+	log.WriteString("\n")
+	l.w.Write([]byte(log.String()))
+	return nil
+}


### PR DESCRIPTION
**What this PR does**:
We have some flaky integration tests in `query_frontend_test.go`. I can't understand the root cause but I've the feeling it's a timing issue. In this PR I'm adding a very simple logger to prefix each log with the time, so that we can have a better idea where the time is being spent when running in CI.

An example of the tests output is:
```
=== RUN   TestQueryFrontendWithChunksStorageViaConfigFile
10:00:47 Starting consul
10:00:48 consul: ==> Starting Consul agent...
10:00:48 consul: ==> Consul agent running!
10:00:48 consul: Version: 'v0.9.4'
10:00:48 consul: Node ID: 'b67d8cc8-029c-d764-dc65-a7205203b3cd'
10:00:48 consul: Node name: 'consul'
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
