### PR TITLE
Switch pkg/ingester to promauto.With(reg)

### DIFF
--- a/integration/asserts.go
+++ b/integration/asserts.go
@@ -28,7 +28,7 @@ var (
 	// Service-specific metrics prefixes which shouldn't be used by any other service.
 	serviceMetricsPrefixes = map[ServiceType][]string{
 		Distributor:   []string{},
-		Ingester:      []string{},
+		Ingester:      []string{"!cortex_ingester_client", "cortex_ingester"}, // The metrics prefix cortex_ingester_client may be used by other components so we ignore it.
 		Querier:       []string{},
 		QueryFrontend: []string{"cortex_frontend", "cortex_query_frontend"},
 		TableManager:  []string{},
@@ -57,6 +57,11 @@ func assertServiceMetricsPrefixes(t *testing.T, serviceType ServiceType, service
 		}
 
 		for _, prefix := range blacklist {
+			// Skip the metric if it matches an ignored prefix.
+			if prefix[0] == '!' && strings.HasPrefix(metricLine, prefix[1:]) {
+				break
+			}
+
 			assert.NotRegexp(t, "^"+prefix, metricLine, "service: %s", service.Name())
 		}
 	}

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -21,6 +21,7 @@ const (
 	bucketName             = "cortex"
 	cortexConfigFile       = "config.yaml"
 	cortexSchemaConfigFile = "schema.yaml"
+	blocksStorageEngine    = "tsdb"
 	storeConfigTemplate    = `
 - from: {{.From}}
   store: {{.IndexStore}}
@@ -61,7 +62,7 @@ var (
 	}
 
 	BlocksStorageFlags = map[string]string{
-		"-store.engine":                                 "tsdb",
+		"-store.engine":                                 blocksStorageEngine,
 		"-experimental.tsdb.backend":                    "s3",
 		"-experimental.tsdb.block-ranges-period":        "1m",
 		"-experimental.tsdb.bucket-store.sync-interval": "5s",

--- a/integration/ingester_flush_test.go
+++ b/integration/ingester_flush_test.go
@@ -33,7 +33,7 @@ func TestIngesterFlushWithChunksStorage(t *testing.T) {
 	require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
 
 	tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorageFlags, "")
-	ingester := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), mergeFlags(ChunksStorageFlags, map[string]string{
+	ingester := e2ecortex.NewIngester("ingester", consul.NetworkHTTPEndpoint(), mergeFlags(ChunksStorageFlags, map[string]string{
 		"-ingester.max-transfer-retries": "0",
 	}), "")
 	querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, "")
@@ -61,6 +61,9 @@ func TestIngesterFlushWithChunksStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 200, res.StatusCode)
 	}
+
+	// Ensure ingester metrics are tracked correctly.
+	require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(2), "cortex_ingester_chunks_created_total"))
 
 	// Query the series.
 	result, err := c.Query("series_1", now)

--- a/integration/ingester_hand_over_test.go
+++ b/integration/ingester_hand_over_test.go
@@ -75,6 +75,11 @@ func runIngesterHandOverTest(t *testing.T, flags map[string]string, setup func(t
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
 
+	// Ensure 1st ingester metrics are tracked correctly.
+	if flags["-store.engine"] != blocksStorageEngine {
+		require.NoError(t, ingester1.WaitSumMetrics(e2e.Equals(1), "cortex_ingester_chunks_created_total"))
+	}
+
 	// Start ingester-2.
 	ingester2 := e2ecortex.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), mergeFlags(flags, map[string]string{
 		"-ingester.join-after": "10s",

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -472,7 +472,7 @@ func (i *Ingester) append(ctx context.Context, userID string, labels labelPairs,
 		})
 	}
 
-	memoryChunks.Add(float64(len(series.chunkDescs) - prevNumChunks))
+	i.metrics.memoryChunks.Add(float64(len(series.chunkDescs) - prevNumChunks))
 	i.metrics.ingestedSamples.Inc()
 	switch source {
 	case client.RULE:

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -54,7 +54,7 @@ type ingesterMetrics struct {
 	oldestUnflushedChunkTimestamp prometheus.Gauge
 }
 
-func newIngesterMetrics(r prometheus.Registerer, registerMetricsConflictingWithTSDB bool) *ingesterMetrics {
+func newIngesterMetrics(r prometheus.Registerer, createMetricsConflictingWithTSDB bool) *ingesterMetrics {
 	m := &ingesterMetrics{
 		flushQueueLength: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_flush_queue_length",
@@ -186,7 +186,7 @@ func newIngesterMetrics(r prometheus.Registerer, registerMetricsConflictingWithT
 		}),
 	}
 
-	if registerMetricsConflictingWithTSDB {
+	if createMetricsConflictingWithTSDB {
 		m.memSeriesCreatedTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Name: memSeriesCreatedTotalName,
 			Help: memSeriesCreatedTotalHelp,

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/cortexproject/cortex/pkg/util"
 )
@@ -28,93 +29,173 @@ type ingesterMetrics struct {
 	memUsers              prometheus.Gauge
 	memSeriesCreatedTotal *prometheus.CounterVec
 	memSeriesRemovedTotal *prometheus.CounterVec
+	createdChunks         prometheus.Counter
 	walReplayDuration     prometheus.Gauge
 	walCorruptionsTotal   prometheus.Counter
+
+	// Chunks / blocks transfer.
+	sentChunks     prometheus.Counter
+	receivedChunks prometheus.Counter
+	sentFiles      prometheus.Counter
+	receivedFiles  prometheus.Counter
+	receivedBytes  prometheus.Counter
+	sentBytes      prometheus.Counter
+
+	// Chunks flushing.
+	chunkUtilization              prometheus.Histogram
+	chunkLength                   prometheus.Histogram
+	chunkSize                     prometheus.Histogram
+	chunksPerUser                 *prometheus.CounterVec
+	chunkSizePerUser              *prometheus.CounterVec
+	chunkAge                      prometheus.Histogram
+	memoryChunks                  prometheus.Gauge
+	flushReasons                  *prometheus.CounterVec
+	droppedChunks                 prometheus.Counter
+	oldestUnflushedChunkTimestamp prometheus.Gauge
 }
 
 func newIngesterMetrics(r prometheus.Registerer, registerMetricsConflictingWithTSDB bool) *ingesterMetrics {
 	m := &ingesterMetrics{
-		flushQueueLength: prometheus.NewGauge(prometheus.GaugeOpts{
+		flushQueueLength: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_flush_queue_length",
 			Help: "The total number of series pending in the flush queue.",
 		}),
-		ingestedSamples: prometheus.NewCounter(prometheus.CounterOpts{
+		ingestedSamples: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_ingester_ingested_samples_total",
 			Help: "The total number of samples ingested.",
 		}),
-		ingestedSamplesFail: prometheus.NewCounter(prometheus.CounterOpts{
+		ingestedSamplesFail: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_ingester_ingested_samples_failures_total",
 			Help: "The total number of samples that errored on ingestion.",
 		}),
-		queries: prometheus.NewCounter(prometheus.CounterOpts{
+		queries: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_ingester_queries_total",
 			Help: "The total number of queries the ingester has handled.",
 		}),
-		queriedSamples: prometheus.NewHistogram(prometheus.HistogramOpts{
+		queriedSamples: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name: "cortex_ingester_queried_samples",
 			Help: "The total number of samples returned from queries.",
 			// Could easily return 10m samples per query - 10*(8^(8-1)) = 20.9m.
 			Buckets: prometheus.ExponentialBuckets(10, 8, 8),
 		}),
-		queriedSeries: prometheus.NewHistogram(prometheus.HistogramOpts{
+		queriedSeries: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name: "cortex_ingester_queried_series",
 			Help: "The total number of series returned from queries.",
 			// A reasonable upper bound is around 100k - 10*(8^(6-1)) = 327k.
 			Buckets: prometheus.ExponentialBuckets(10, 8, 6),
 		}),
-		queriedChunks: prometheus.NewHistogram(prometheus.HistogramOpts{
+		queriedChunks: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name: "cortex_ingester_queried_chunks",
 			Help: "The total number of chunks returned from queries.",
 			// A small number of chunks per series - 10*(8^(7-1)) = 2.6m.
 			Buckets: prometheus.ExponentialBuckets(10, 8, 7),
 		}),
-		memSeries: prometheus.NewGauge(prometheus.GaugeOpts{
+		memSeries: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_memory_series",
 			Help: "The current number of series in memory.",
 		}),
-		memUsers: prometheus.NewGauge(prometheus.GaugeOpts{
+		memUsers: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_memory_users",
 			Help: "The current number of users in memory.",
 		}),
-		memSeriesCreatedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: memSeriesCreatedTotalName,
-			Help: memSeriesCreatedTotalHelp,
-		}, []string{"user"}),
-		memSeriesRemovedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: memSeriesRemovedTotalName,
-			Help: memSeriesRemovedTotalHelp,
-		}, []string{"user"}),
-		walReplayDuration: prometheus.NewGauge(prometheus.GaugeOpts{
+		createdChunks: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_chunks_created_total",
+			Help: "The total number of chunks the ingester has created.",
+		}),
+		walReplayDuration: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_wal_replay_duration_seconds",
 			Help: "Time taken to replay the checkpoint and the WAL.",
 		}),
-		walCorruptionsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+		walCorruptionsTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_ingester_wal_corruptions_total",
 			Help: "Total number of WAL corruptions encountered.",
 		}),
+
+		// Chunks / blocks transfer.
+		sentChunks: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_sent_chunks",
+			Help: "The total number of chunks sent by this ingester whilst leaving.",
+		}),
+		receivedChunks: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_received_chunks",
+			Help: "The total number of chunks received by this ingester whilst joining",
+		}),
+		sentFiles: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_sent_files",
+			Help: "The total number of files sent by this ingester whilst leaving.",
+		}),
+		receivedFiles: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_received_files",
+			Help: "The total number of files received by this ingester whilst joining",
+		}),
+		receivedBytes: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_received_bytes_total",
+			Help: "The total number of bytes received by this ingester whilst joining",
+		}),
+		sentBytes: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_sent_bytes_total",
+			Help: "The total number of bytes sent by this ingester whilst leaving",
+		}),
+
+		// Chunks flushing.
+		chunkUtilization: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_chunk_utilization",
+			Help:    "Distribution of stored chunk utilization (when stored).",
+			Buckets: prometheus.LinearBuckets(0, 0.2, 6),
+		}),
+		chunkLength: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_chunk_length",
+			Help:    "Distribution of stored chunk lengths (when stored).",
+			Buckets: prometheus.ExponentialBuckets(5, 2, 11), // biggest bucket is 5*2^(11-1) = 5120
+		}),
+		chunkSize: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_chunk_size_bytes",
+			Help:    "Distribution of stored chunk sizes (when stored).",
+			Buckets: prometheus.ExponentialBuckets(500, 2, 5), // biggest bucket is 500*2^(5-1) = 8000
+		}),
+		chunksPerUser: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_ingester_chunks_stored_total",
+			Help: "Total stored chunks per user.",
+		}, []string{"user"}),
+		chunkSizePerUser: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_ingester_chunk_stored_bytes_total",
+			Help: "Total bytes stored in chunks per user.",
+		}, []string{"user"}),
+		chunkAge: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name: "cortex_ingester_chunk_age_seconds",
+			Help: "Distribution of chunk ages (when stored).",
+			// with default settings chunks should flush between 5 min and 12 hours
+			// so buckets at 1min, 5min, 10min, 30min, 1hr, 2hr, 4hr, 10hr, 12hr, 16hr
+			Buckets: []float64{60, 300, 600, 1800, 3600, 7200, 14400, 36000, 43200, 57600},
+		}),
+		memoryChunks: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_ingester_memory_chunks",
+			Help: "The total number of chunks in memory.",
+		}),
+		flushReasons: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_ingester_flush_reasons",
+			Help: "Total number of series scheduled for flushing, with reasons.",
+		}, []string{"reason"}),
+		droppedChunks: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_dropped_chunks_total",
+			Help: "Total number of chunks dropped from flushing because they have too few samples.",
+		}),
+		oldestUnflushedChunkTimestamp: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_oldest_unflushed_chunk_timestamp_seconds",
+			Help: "Unix timestamp of the oldest unflushed chunk in the memory",
+		}),
 	}
 
-	if r != nil {
-		r.MustRegister(
-			m.flushQueueLength,
-			m.ingestedSamples,
-			m.ingestedSamplesFail,
-			m.queries,
-			m.queriedSamples,
-			m.queriedSeries,
-			m.queriedChunks,
-			m.memSeries,
-			m.memUsers,
-			m.walReplayDuration,
-			m.walCorruptionsTotal,
-		)
+	if registerMetricsConflictingWithTSDB {
+		m.memSeriesCreatedTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: memSeriesCreatedTotalName,
+			Help: memSeriesCreatedTotalHelp,
+		}, []string{"user"})
 
-		if registerMetricsConflictingWithTSDB {
-			r.MustRegister(
-				m.memSeriesCreatedTotal,
-				m.memSeriesRemovedTotal,
-			)
-		}
+		m.memSeriesRemovedTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: memSeriesRemovedTotalName,
+			Help: memSeriesRemovedTotalHelp,
+		}, []string{"user"})
 	}
 
 	return m

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -60,47 +61,40 @@ func populateTSDBMetrics(base float64) *prometheus.Registry {
 	r := prometheus.NewRegistry()
 
 	// shipper
-	dirSyncs := prometheus.NewCounter(prometheus.CounterOpts{
+	dirSyncs := promauto.With(r).NewCounter(prometheus.CounterOpts{
 		Name: "thanos_shipper_dir_syncs_total",
 		Help: "Total number of dir syncs",
 	})
 	dirSyncs.Add(1 * base)
 
-	dirSyncFailures := prometheus.NewCounter(prometheus.CounterOpts{
+	dirSyncFailures := promauto.With(r).NewCounter(prometheus.CounterOpts{
 		Name: "thanos_shipper_dir_sync_failures_total",
 		Help: "Total number of failed dir syncs",
 	})
 	dirSyncFailures.Add(2 * base)
 
-	uploads := prometheus.NewCounter(prometheus.CounterOpts{
+	uploads := promauto.With(r).NewCounter(prometheus.CounterOpts{
 		Name: "thanos_shipper_uploads_total",
 		Help: "Total number of uploaded blocks",
 	})
 	uploads.Add(3 * base)
 
-	uploadFailures := prometheus.NewCounter(prometheus.CounterOpts{
+	uploadFailures := promauto.With(r).NewCounter(prometheus.CounterOpts{
 		Name: "thanos_shipper_upload_failures_total",
 		Help: "Total number of block upload failures",
 	})
 	uploadFailures.Add(4 * base)
 
 	// TSDB Head
-	seriesCreated := prometheus.NewCounter(prometheus.CounterOpts{
+	seriesCreated := promauto.With(r).NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_head_series_created_total",
 	})
 	seriesCreated.Add(5 * base)
 
-	seriesRemoved := prometheus.NewCounter(prometheus.CounterOpts{
+	seriesRemoved := promauto.With(r).NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_head_series_removed_total",
 	})
 	seriesRemoved.Add(6 * base)
-
-	r.MustRegister(dirSyncs)
-	r.MustRegister(dirSyncFailures)
-	r.MustRegister(uploads)
-	r.MustRegister(uploadFailures)
-	r.MustRegister(seriesCreated)
-	r.MustRegister(seriesRemoved)
 
 	return r
 }

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/thanos/pkg/shipper"
 	"github.com/weaveworks/common/user"
@@ -26,41 +25,8 @@ import (
 )
 
 var (
-	sentChunks = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "cortex_ingester_sent_chunks",
-		Help: "The total number of chunks sent by this ingester whilst leaving.",
-	})
-	receivedChunks = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "cortex_ingester_received_chunks",
-		Help: "The total number of chunks received by this ingester whilst joining",
-	})
-	sentFiles = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "cortex_ingester_sent_files",
-		Help: "The total number of files sent by this ingester whilst leaving.",
-	})
-	receivedFiles = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "cortex_ingester_received_files",
-		Help: "The total number of files received by this ingester whilst joining",
-	})
-	receivedBytes = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "cortex_ingester_received_bytes_total",
-		Help: "The total number of bytes received by this ingester whilst joining",
-	})
-	sentBytes = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "cortex_ingester_sent_bytes_total",
-		Help: "The total number of bytes sent by this ingester whilst leaving",
-	})
 	errTransferNoPendingIngesters = errors.New("no pending ingesters")
 )
-
-func init() {
-	prometheus.MustRegister(sentChunks)
-	prometheus.MustRegister(receivedChunks)
-	prometheus.MustRegister(sentFiles)
-	prometheus.MustRegister(receivedBytes)
-	prometheus.MustRegister(receivedFiles)
-	prometheus.MustRegister(sentBytes)
-}
 
 // TransferChunks receives all the chunks from another ingester.
 func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) error {
@@ -109,8 +75,8 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 			}
 
 			seriesReceived++
-			memoryChunks.Add(float64(len(series.chunkDescs) - prevNumChunks))
-			receivedChunks.Add(float64(len(descs)))
+			i.metrics.memoryChunks.Add(float64(len(series.chunkDescs) - prevNumChunks))
+			i.metrics.receivedChunks.Add(float64(len(descs)))
 		}
 
 		if seriesReceived == 0 {
@@ -296,8 +262,8 @@ func (i *Ingester) TransferTSDB(stream client.Ingester_TransferTSDBServer) error
 			return errors.Wrap(err, "TransferTSDB: ClaimTokensFor")
 		}
 
-		receivedBytes.Add(float64(bytesXfer))
-		receivedFiles.Add(float64(filesXfer))
+		i.metrics.receivedBytes.Add(float64(bytesXfer))
+		i.metrics.receivedFiles.Add(float64(filesXfer))
 		level.Info(util.Logger).Log("msg", "Total xfer", "from_ingester", fromIngesterID, "files", filesXfer, "bytes", bytesXfer)
 
 		// Move the tmpdir to the final location
@@ -484,7 +450,7 @@ func (i *Ingester) transferOut(ctx context.Context) error {
 				return errors.Wrap(err, "Send")
 			}
 
-			sentChunks.Add(float64(len(chunks)))
+			i.metrics.sentChunks.Add(float64(len(chunks)))
 		}
 	}
 
@@ -583,7 +549,7 @@ func (i *Ingester) v2TransferOut(ctx context.Context) error {
 	for user, blockIDs := range blocks {
 		// Transfer the users TSDB
 		// TODO(thor) transferring users can be done concurrently
-		transferUser(ctx, stream, i.cfg.TSDBConfig.Dir, i.lifecycler.ID, user, blockIDs)
+		i.transferUser(ctx, stream, i.cfg.TSDBConfig.Dir, i.lifecycler.ID, user, blockIDs)
 	}
 
 	_, err = stream.CloseAndRecv()
@@ -672,7 +638,7 @@ func unshippedBlocks(dir string) (map[string][]string, error) {
 	return blocks, nil
 }
 
-func transferUser(ctx context.Context, stream client.Ingester_TransferTSDBClient, dir, ingesterID, userID string, blocks []string) {
+func (i *Ingester) transferUser(ctx context.Context, stream client.Ingester_TransferTSDBClient, dir, ingesterID, userID string, blocks []string) {
 	level.Info(util.Logger).Log("msg", "transferring user blocks", "user", userID)
 	// Transfer all blocks
 	for _, blk := range blocks {
@@ -695,15 +661,18 @@ func transferUser(ctx context.Context, stream client.Ingester_TransferTSDBClient
 				return err
 			}
 
-			if err := batchSend(1024*1024, b, stream, &client.TimeSeriesFile{
+			bytesSent, err := batchSend(1024*1024, b, stream, &client.TimeSeriesFile{
 				FromIngesterId: ingesterID,
 				UserId:         userID,
 				Filename:       p,
-			}); err != nil {
+			})
+
+			if err != nil {
 				return err
 			}
 
-			sentFiles.Add(1)
+			i.metrics.sentBytes.Add(float64(bytesSent))
+			i.metrics.sentFiles.Add(1)
 			return nil
 		})
 		if err != nil {
@@ -732,15 +701,18 @@ func transferUser(ctx context.Context, stream client.Ingester_TransferTSDBClient
 			return err
 		}
 
-		if err := batchSend(1024*1024, b, stream, &client.TimeSeriesFile{
+		bytesSent, err := batchSend(1024*1024, b, stream, &client.TimeSeriesFile{
 			FromIngesterId: ingesterID,
 			UserId:         userID,
 			Filename:       p,
-		}); err != nil {
+		})
+
+		if err != nil {
 			return err
 		}
 
-		sentFiles.Add(1)
+		i.metrics.sentBytes.Add(float64(bytesSent))
+		i.metrics.sentFiles.Add(1)
 		return nil
 	})
 
@@ -751,16 +723,16 @@ func transferUser(ctx context.Context, stream client.Ingester_TransferTSDBClient
 	level.Info(util.Logger).Log("msg", "user blocks and WAL transfer completed", "user", userID)
 }
 
-func batchSend(batch int, b []byte, stream client.Ingester_TransferTSDBClient, tsfile *client.TimeSeriesFile) error {
+func batchSend(batch int, b []byte, stream client.Ingester_TransferTSDBClient, tsfile *client.TimeSeriesFile) (bytesSent int64, err error) {
 	// Split file into smaller blocks for xfer
 	i := 0
 	for ; i+batch < len(b); i += batch {
 		tsfile.Data = b[i : i+batch]
 		err := client.SendTimeSeriesFile(stream, tsfile)
 		if err != nil {
-			return err
+			return bytesSent, err
 		}
-		sentBytes.Add(float64(len(tsfile.Data)))
+		bytesSent += int64(len(tsfile.Data))
 	}
 
 	// Send final data
@@ -768,12 +740,12 @@ func batchSend(batch int, b []byte, stream client.Ingester_TransferTSDBClient, t
 		tsfile.Data = b[i:]
 		err := client.SendTimeSeriesFile(stream, tsfile)
 		if err != nil {
-			return err
+			return bytesSent, err
 		}
-		sentBytes.Add(float64(len(tsfile.Data)))
+		bytesSent += int64(len(tsfile.Data))
 	}
 
-	return nil
+	return bytesSent, nil
 }
 
 func removeEmptyDir(dir string) error {

--- a/pkg/ingester/transfer_test.go
+++ b/pkg/ingester/transfer_test.go
@@ -8,10 +8,14 @@ import (
 	rnd "math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/oklog/ulid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/thanos/pkg/shipper"
 	"google.golang.org/grpc"
@@ -28,26 +32,27 @@ type testUserTSDB struct {
 }
 
 func createTSDB(t *testing.T, dir string, users []*testUserTSDB) {
-	for _, user := range users {
+	createAndWrite := func(t *testing.T, path string) {
+		f, err := os.Create(path)
+		require.NoError(t, err)
+		defer f.Close()
+		_, err = f.Write([]byte("a man a plan a canal panama"))
+		require.NoError(t, err)
+	}
 
-		err := os.MkdirAll(filepath.Join(dir, user.userID), 0777)
+	for _, user := range users {
+		userDir := filepath.Join(dir, user.userID)
+
+		err := os.MkdirAll(userDir, 0777)
 		require.NoError(t, err)
 
+		// Generate blocks.
 		for i := 0; i < user.numBlocks; i++ {
 			u, err := ulid.New(uint64(time.Now().Unix()*1000), rand.Reader)
 			require.NoError(t, err)
 
-			userdir := filepath.Join(dir, user.userID)
-			blockDir := filepath.Join(userdir, u.String())
+			blockDir := filepath.Join(userDir, u.String())
 			require.NoError(t, os.MkdirAll(filepath.Join(blockDir, "chunks"), 0777))
-
-			createAndWrite := func(t *testing.T, path string) {
-				f, err := os.Create(path)
-				require.NoError(t, err)
-				defer f.Close()
-				_, err = f.Write([]byte("a man a plan a canal panama"))
-				require.NoError(t, err)
-			}
 
 			for i := 0; i < 2; i++ {
 				createAndWrite(t, filepath.Join(blockDir, "chunks", fmt.Sprintf("00000%v", i)))
@@ -58,10 +63,6 @@ func createTSDB(t *testing.T, dir string, users []*testUserTSDB) {
 				createAndWrite(t, filepath.Join(blockDir, name))
 			}
 
-			require.NoError(t, os.MkdirAll(filepath.Join(userdir, "wal", "checkpoint.000419"), 0777))
-			createAndWrite(t, filepath.Join(userdir, "wal", "000001"))
-			createAndWrite(t, filepath.Join(userdir, "wal", "checkpoint.000419", "000000"))
-
 			// Record if this block is to be "shipped"
 			if rnd.Intn(100) < user.shipPercent {
 				user.meta.Uploaded = append(user.meta.Uploaded, u)
@@ -69,6 +70,11 @@ func createTSDB(t *testing.T, dir string, users []*testUserTSDB) {
 				user.unshipped = append(user.unshipped, u.String())
 			}
 		}
+
+		// Generate WAL.
+		require.NoError(t, os.MkdirAll(filepath.Join(userDir, "wal", "checkpoint.000419"), 0777))
+		createAndWrite(t, filepath.Join(userDir, "wal", "000001"))
+		createAndWrite(t, filepath.Join(userDir, "wal", "checkpoint.000419", "000000"))
 
 		require.NoError(t, shipper.WriteMetaFile(nil, filepath.Join(dir, user.userID), user.meta))
 	}
@@ -160,6 +166,14 @@ func (m *MockTransferTSDBClient) Context() context.Context {
 }
 
 func TestTransferUser(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+
+	// Create an ingester without starting it (not needed).
+	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), reg)
+	require.NoError(t, err)
+	defer cleanup()
+
+	// Create a fake TSDB on disk.
 	dir, err := ioutil.TempDir("", "tsdb")
 	require.NoError(t, err)
 
@@ -182,7 +196,7 @@ func TestTransferUser(t *testing.T) {
 	m := &MockTransferTSDBClient{
 		Dir: xfer,
 	}
-	transferUser(context.Background(), m, dir, "test", "0", blks["0"])
+	i.transferUser(context.Background(), m, dir, "test", "0", blks["0"])
 
 	var original []string
 	var xferfiles []string
@@ -204,4 +218,27 @@ func TestTransferUser(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, original, xferfiles)
+
+	// Assert exported metrics (3 blocks, 5 files per block, 2 files WAL).
+	metricNames := []string{
+		"cortex_ingester_sent_files",
+		"cortex_ingester_received_files",
+		"cortex_ingester_received_bytes_total",
+		"cortex_ingester_sent_bytes_total",
+	}
+
+	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_ingester_sent_files The total number of files sent by this ingester whilst leaving.
+		# TYPE cortex_ingester_sent_files counter
+		cortex_ingester_sent_files 17
+		# HELP cortex_ingester_received_files The total number of files received by this ingester whilst joining
+		# TYPE cortex_ingester_received_files counter
+		cortex_ingester_received_files 0
+		# HELP cortex_ingester_received_bytes_total The total number of bytes received by this ingester whilst joining
+		# TYPE cortex_ingester_received_bytes_total counter
+		cortex_ingester_received_bytes_total 0
+		# HELP cortex_ingester_sent_bytes_total The total number of bytes sent by this ingester whilst leaving
+		# TYPE cortex_ingester_sent_bytes_total counter
+		cortex_ingester_sent_bytes_total 459
+	`), metricNames...))
 }


### PR DESCRIPTION
**What this PR does**:
Following the work related to https://github.com/cortexproject/cortex/issues/2204 to get rid of global metrics and registerer, in this PR I've migrated `pkg/ingester` metrics to `promauto.With(registerer)`.

Few notes:
- There's still a global metric in `pkg/ingester/client` which I will address in a separate PR
- Not much happy with the path followed for the WAL and `memorySeries`. The problem is that the initial design doesn't look much clean in regards of global variables and I had to deal with that in order to keep the changeset small (but I admit there's much room for improvement design-wise there)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
