### PR TITLE
Added integration test for Cortex 0.7.0 backward compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,7 @@ jobs:
           docker pull amazon/dynamodb-local:1.11.477
           docker pull consul:0.9
           docker pull quay.io/cortexproject/cortex:v0.6.0
+          docker pull quay.io/cortexproject/cortex:v0.7.0
           docker pull shopify/bigtable-emulator:0.1.0
           docker pull rinscy/cassandra:3.11.0
           docker pull memcached:1.6.1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -87,6 +87,7 @@ To publish a stable release:
    - Temporarily disable "Include administrators" in the [`master` branch protection rule](https://github.com/cortexproject/cortex/settings/branch_protection_rules)
    - Push changes to upstream (please double check before pushing!)
    - Re-enable "Include administrators" in the [`master` branch protection rule](https://github.com/cortexproject/cortex/settings/branch_protection_rules)
+7. Open a PR to add the new version to the backward compatibility integration test (`integration/backward_compatibility_test.go`)
 
 ### How to tag a release
 


### PR DESCRIPTION
**What this PR does**:
Now that Cortex `0.7.0` we can add an integration test to check backward compatibility with that as well, like we had for `0.6.0`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
