### PR TITLE
Add Prometheus to local dev env setup

### DIFF
--- a/development/tsdb-blocks-storage-s3-single-binary/.dockerignore
+++ b/development/tsdb-blocks-storage-s3-single-binary/.dockerignore
@@ -1,0 +1,3 @@
+.data-ingester-1
+.data-ingester-2
+.data-minio

--- a/development/tsdb-blocks-storage-s3-single-binary/config/prometheus.yaml
+++ b/development/tsdb-blocks-storage-s3-single-binary/config/prometheus.yaml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: cortex-1
+    static_configs:
+      - targets: ['cortex-1:8001']
+        labels:
+          container: 'cortex-1'
+  - job_name: cortex-2
+    static_configs:
+      - targets: ['cortex-2:8002']
+        labels:
+          container: 'cortex-2'
+
+remote_write:
+  - url: http://cortex-1:8001/api/prom/push

--- a/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
@@ -18,6 +18,14 @@ services:
     volumes:
       - .data-minio:/data:delegated
 
+  prometheus:
+    image: prom/prometheus:v2.16.0
+    command: ["--config.file=/etc/prometheus/prometheus.yaml"]
+    volumes:
+      - ./config:/etc/prometheus
+    ports:
+      - 8010:8010
+
   cortex-1:
     build:
       context:    .

--- a/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - ./config:/etc/prometheus
     ports:
-      - 8010:8010
+      - 9090:9090
 
   cortex-1:
     build:

--- a/development/tsdb-blocks-storage-s3/.dockerignore
+++ b/development/tsdb-blocks-storage-s3/.dockerignore
@@ -1,0 +1,4 @@
+.data-configstore
+.data-ingester-1
+.data-ingester-2
+.data-minio

--- a/development/tsdb-blocks-storage-s3/config/prometheus.yaml
+++ b/development/tsdb-blocks-storage-s3/config/prometheus.yaml
@@ -1,0 +1,42 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: cortex-distributor
+    static_configs:
+      - targets: ['distributor:8001']
+        labels:
+          container: 'distributor'
+  - job_name: cortex-ingester-1
+    static_configs:
+      - targets: ['ingester-1:8002']
+        labels:
+          container: 'ingester-1'
+  - job_name: cortex-ingester-2
+    static_configs:
+      - targets: ['ingester-2:8003']
+        labels:
+          container: 'ingester-2'
+  - job_name: cortex-querier
+    static_configs:
+      - targets: ['querier:8004']
+        labels:
+          container: 'querier'
+  - job_name: cortex-ruler
+    static_configs:
+      - targets: ['ruler:8005']
+        labels:
+          container: 'ruler'
+  - job_name: cortex-compactor
+    static_configs:
+      - targets: ['compactor:8006']
+        labels:
+          container: 'compactor'
+  - job_name: cortex-query-frontend
+    static_configs:
+      - targets: ['query-frontend:8007']
+        labels:
+          container: 'query-frontend'
+
+remote_write:
+  - url: http://distributor:8001/api/prom/push

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     volumes:
       - ./config:/etc/prometheus
     ports:
-      - 8010:8010
+      - 9090:9090
 
   distributor:
     build:

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -26,6 +26,14 @@ services:
     volumes:
       - .data-configstore:/usr/share/nginx/html/private:ro
 
+  prometheus:
+    image: prom/prometheus:v2.16.0
+    command: ["--config.file=/etc/prometheus/prometheus.yaml"]
+    volumes:
+      - ./config:/etc/prometheus
+    ports:
+      - 8010:8010
+
   distributor:
     build:
       context:    .


### PR DESCRIPTION
**What this PR does**:
The easiest way to locally run Cortex with the experimental blocks storage is using the development setup and running `./development/tsdb-blocks-storage-s3/compose-up.sh`. This is also the same way I use to locally run Cortex while developing it.

A missing thing is that the local dev setup doesn't scrape Cortex metrics itself, so it's not easy to manually test exported metrics. In this PR I'm setting up Prometheus to scrape Cortex metrics from containers and push them to Cortex via remote write.

Notes:
- I've added some `.dockerignore` to speed up building the Cortex container on OSX if the volumes are big (because the entire content of shared dirs need to be transferred to the Docker context if not ignored)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
