### PR TITLE
Renamed table-manager metrics to remove cortex_dynamo prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,6 @@
   * `-ruler.storage.(s3|gcs|azure)` flags exist to allow the configuration of object clients set for rule storage
 * [CHANGE] Renamed table manager metrics. #2307
   * `cortex_dynamo_sync_tables_seconds` -> `cortex_table_manager_sync_duration_seconds`
-  * `cortex_dynamo_table_capacity_units` -> `cortex_table_manager_table_capacity`
 * [FEATURE] Flusher target to flush the WAL.
   * `-flusher.wal-dir` for the WAL directory to recover from.
   * `-flusher.concurrent-flushes` for number of concurrent flushes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
   * `-ruler.storage.(s3|gcs|azure)` flags exist to allow the configuration of object clients set for rule storage
 * [CHANGE] Renamed table manager metrics. #2307
   * `cortex_dynamo_sync_tables_seconds` -> `cortex_table_manager_sync_duration_seconds`
-  * `cortex_dynamo_table_capacity_units` -> `cortex_table_manager_table_capacity_units`
+  * `cortex_dynamo_table_capacity_units` -> `cortex_table_manager_table_capacity`
 * [FEATURE] Flusher target to flush the WAL.
   * `-flusher.wal-dir` for the WAL directory to recover from.
   * `-flusher.concurrent-flushes` for number of concurrent flushes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 * [FEATURE] Added experimental storage API to the ruler service that is enabled when the `-experimental.ruler.enable-api` is set to true #2269
   * `-ruler.storage.type` flag now allows `s3`,`gcs`, and `azure` values
   * `-ruler.storage.(s3|gcs|azure)` flags exist to allow the configuration of object clients set for rule storage
-* [CHANGE] Renamed table manager metrics.
+* [CHANGE] Renamed table manager metrics. #2307
   * `cortex_dynamo_sync_tables_seconds` -> `cortex_table_manager_sync_duration_seconds`
   * `cortex_dynamo_table_capacity_units` -> `cortex_table_manager_table_capacity_units`
 * [FEATURE] Flusher target to flush the WAL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@
 * [FEATURE] Added experimental storage API to the ruler service that is enabled when the `-experimental.ruler.enable-api` is set to true #2269
   * `-ruler.storage.type` flag now allows `s3`,`gcs`, and `azure` values
   * `-ruler.storage.(s3|gcs|azure)` flags exist to allow the configuration of object clients set for rule storage
+* [CHANGE] Renamed table manager metrics.
+  * `cortex_dynamo_sync_tables_seconds` -> `cortex_table_manager_sync_duration_seconds`
+  * `cortex_dynamo_table_capacity_units` -> `cortex_table_manager_table_capacity_units`
 * [FEATURE] Flusher target to flush the WAL.
   * `-flusher.wal-dir` for the WAL directory to recover from.
   * `-flusher.concurrent-flushes` for number of concurrent flushes.

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -47,7 +47,7 @@ func newTableManagerMetrics(r prometheus.Registerer) *tableManagerMetrics {
 
 	m.tableCapacity = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "cortex",
-		Name:      "table_manager_table_capacity_units",
+		Name:      "table_manager_table_capacity",
 		Help:      "Per-table provisioned read and write capacity units.",
 	}, []string{"op", "table"})
 

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -47,8 +47,8 @@ func newTableManagerMetrics(r prometheus.Registerer) *tableManagerMetrics {
 
 	m.tableCapacity = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "cortex",
-		Name:      "table_manager_table_capacity",
-		Help:      "Per-table provisioned read and write capacity units.",
+		Name:      "dynamo_table_capacity_units",
+		Help:      "Per-table DynamoDB capacity, measured in DynamoDB capacity units.",
 	}, []string{"op", "table"})
 
 	m.createFailures = prometheus.NewGauge(prometheus.GaugeOpts{

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -41,7 +41,7 @@ func newTableManagerMetrics(r prometheus.Registerer) *tableManagerMetrics {
 	m.syncTableDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "cortex",
 		Name:      "table_manager_sync_duration_seconds",
-		Help:      "Time spent doing synching tables.",
+		Help:      "Time spent synching tables.",
 		Buckets:   prometheus.DefBuckets,
 	}, []string{"operation", "status_code"})
 

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -40,15 +40,15 @@ func newTableManagerMetrics(r prometheus.Registerer) *tableManagerMetrics {
 	m := tableManagerMetrics{}
 	m.syncTableDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "cortex",
-		Name:      "dynamo_sync_tables_seconds",
-		Help:      "Time spent doing SyncTables.",
+		Name:      "table_manager_sync_duration_seconds",
+		Help:      "Time spent doing synching tables.",
 		Buckets:   prometheus.DefBuckets,
 	}, []string{"operation", "status_code"})
 
 	m.tableCapacity = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "cortex",
-		Name:      "dynamo_table_capacity_units",
-		Help:      "Per-table DynamoDB capacity, measured in DynamoDB capacity units.",
+		Name:      "table_manager_table_capacity_units",
+		Help:      "Per-table provisioned read and write capacity units.",
 	}, []string{"op", "table"})
 
 	m.createFailures = prometheus.NewGauge(prometheus.GaugeOpts{


### PR DESCRIPTION
**What this PR does**:
I've noticed that a couple of table-manager metrics have the `cortex_dynamo` prefix. I'm proposing to rename them to the `cortex_table_manager` prefix for clarity.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
