### PR TITLE
Proposal: Implement Prometheus Metadata API

### DIFF
--- a/docs/proposals/receiving_metadata.md
+++ b/docs/proposals/receiving_metadata.md
@@ -1,0 +1,49 @@
+# Support /api/v1/metadata in Cortex
+
+- Author: @gotjosh
+- Reviewers: @tomwilkie, @pracucci
+- Date: March 2020
+
+## Problem Statement
+Prometheus holds metric metadata alongside the contents of a scrape. This metadata (`HELP`, `TYPE`, `UNIT` and `METRIC_NAME`) enables [some Prometheus API](https://github.com/prometheus/prometheus/issues/6395) endpoints to output the metadata for integrations (e.g. [Grafana](https://github.com/grafana/grafana/pull/21124)) to consume it. 
+
+At the moment of writing, Cortex does not support the `api/v1/metadata` endpoint that Prometheus implements as metadata was never propagated via remote write. Recent [work is done in Prometheus](https://github.com/prometheus/prometheus/pull/6815/files) enables the propagation of metadata.
+
+With this in place, remote write integrations such as Cortex can now receive this data and implement the API endpoint. This result in Cortex users being able to enjoy a tiny bit more insight on their metrics.
+
+## Potential Solutions
+Before we delve into the solutions, let's set a baseline about how the data is received. This applies almost equally for the two.
+
+Metadata from Prometheus is sent in the same `WriteRequest` proto message that the samples use. It is part of a different field (#3 given #2 is already used), the data is a set identified by the metric name - that means it is aggregated across targets, and finally it is sent all at once. It is also important to note that this current process is an intermediary step. Eventually, metadata in a request will be sent alongside samples and only for those included. The solutions proposed, take this nuance into account to avoid coupling between the current and future state of Prometheus, and hopefully do something now that also works for the future. 
+
+As a reference, these are some key numbers regarding the size (and send timings) of the data at hand from our clusters at GL:
+
+- On average, metadata (a combination of `HELP`, `TYPE`, `UNIT` and `METRIC_NAME`) is ~55 bytes uncompressed.
+- at GL, on an instance with about 2.6M active series, we hold ~1241 unique metrics in total.
+- with that, we can assume that on a worst-case scenario the metadata set for that instance is ~68 kilobytes uncompressed.
+- by default, this data is only propagated once every minute (aligning with the default scrape interval), but this can be adjusted.
+- Finally, what this gives us is a baseline worst-case scenario formula for the data to store per tenant: `~68KB * Replication Factor * # of Instances`. Keeping in mind that typically, there's a very high overlap of metadata across instances, and we plan to deduplicate in the ingesters.
+
+### Write Path
+
+1. Store the metadata directly from the distributors into a cache (e.g. Memcached)
+
+Since metadata is received all at once, we could directly store into an external cache using the tenant ID as a key, and still, avoid a read-modify-write.  However, a very common use case of Cortex is to have multiple Prometheus sending data for the same tenant ID. This complicates things, as it adds a need to have an intermediary merging phase and thus making a read-modify-write inevitable.
+
+2. Keep metadata in memory within the distributors
+
+Similarly to what we do with sample data, we can keep the metadata in-memory in the ingestors and apply similar semantics. I propose to use the tenant ID as a hash key, distribute it to the ingesters (taking into account the replication factor), using a hash map to keep a set of the metadata across all instances for a single tenant, and implement a configurable time-based purge process to deal with metadata churn. Given, we need to ensure fair-use we also propose implementing limits for both the number of metadata entries we can receive and the size of entry(s).
+
+### Read Path
+
+In my eyes, the read path seems to only have one option. At the moment of writing, Cortex uses a [`DummyTargetRetriever`](https://github.com/cortexproject/cortex/blob/master/pkg/querier/dummy.go#L11-L20) as a way to signal that these API endpoints are not implemented. We'd need to modify the Prometheus interface to support a `Context` and extract the tenant ID from there. Then, use the tenant ID to query the ingesters for the data, deduplicate it and serve it.
+
+## Conclusions
+
+I conclude that solution #2 is ideal for this work on the write path. It allows us to use similar semantics to samples, thus reducing operational complexity, and lays a groundwork for when we start receiving metadata alongside samples.
+
+There's one last piece to address: Allowing metadata to survive rolling restarts. Option #1 handles this well, given the aim would be to use an external cache such as Memcached. Option #2 lacks this, as it does not include any plans to persist this data. I'm open to opinions here, but I can see a world where we allow this data to be flushed/recovered on shutdown/startup.
+
+## References
+- [Prometheus Propagate metadata via Remote Write Design Doc](https://docs.google.com/document/d/1LoCWPAIIbGSq59NG3ZYyvkeNb8Ymz28PUKbg_yhAzvE/edit#)
+- [Prometheus Propagate metadata via Remote Write Design Issue](https://github.com/prometheus/prometheus/issues/6395)

--- a/docs/proposals/receiving_metadata.md
+++ b/docs/proposals/receiving_metadata.md
@@ -1,8 +1,16 @@
+---
+title: "Support metadata API"
+linkTitle: "Support metadata API"
+weight: 1
+slug: support-metadata-api
+---
+
 # Support /api/v1/metadata in Cortex
 
 - Author: @gotjosh
 - Reviewers: @gouthamve, @pracucci
 - Date: March 2020
+- Status: Accepted
 
 ## Problem Statement
 Prometheus holds metric metadata alongside the contents of a scrape. This metadata (`HELP`, `TYPE`, `UNIT` and `METRIC_NAME`) enables [some Prometheus API](https://github.com/prometheus/prometheus/issues/6395) endpoints to output the metadata for integrations (e.g. [Grafana](https://github.com/grafana/grafana/pull/21124)) to consume it. 
@@ -44,7 +52,7 @@ In my eyes, the read path seems to only have one option. At the moment of writin
 
 I conclude that solution #2 is ideal for this work on the write path. It allows us to use similar semantics to samples, thus reducing operational complexity, and lays a groundwork for when we start receiving metadata alongside samples.
 
-There's one last piece to address: Allowing metadata to survive rolling restarts. Option #1 handles this well, given the aim would be to use an external cache such as Memcached. Option #2 lacks this, as it does not include any plans to persist this data. I'm open to opinions here, but I can see a world where we allow this data to be flushed/recovered on shutdown/startup.
+There's one last piece to address: Allowing metadata to survive rolling restarts. Option #1 handles this well, given the aim would be to use an external cache such as Memcached. Option #2 lacks this, as it does not include any plans to persist this data. Given Prometheus (by default) sends metadata every minute, and we don't need a high level of consistency. We expect that an eventual consistency of up to 1 minute on the default case is deemed acceptable.
 
 ## References
 - [Prometheus Propagate metadata via Remote Write Design Doc](https://docs.google.com/document/d/1LoCWPAIIbGSq59NG3ZYyvkeNb8Ymz28PUKbg_yhAzvE/edit#)

--- a/docs/proposals/receiving_metadata.md
+++ b/docs/proposals/receiving_metadata.md
@@ -32,7 +32,7 @@ Since metadata is received all at once, we could directly store into an external
 
 2. Keep metadata in memory within the ingesters
 
-Similarly to what we do with sample data, we can keep the metadata in-memory in the ingestors and apply similar semantics. I propose to use the tenant ID as a hash key, distribute it to the ingesters (taking into account the replication factor), using a hash map to keep a set of the metadata across all instances for a single tenant, and implement a configurable time-based purge process to deal with metadata churn. Given, we need to ensure fair-use we also propose implementing limits for both the number of metadata entries we can receive and the size of entry(s).
+Similarly to what we do with sample data, we can keep the metadata in-memory in the ingesters and apply similar semantics. I propose to use the tenant ID as a hash key, distribute it to the ingesters (taking into account the replication factor), using a hash map to keep a set of the metadata across all instances for a single tenant, and implement a configurable time-based purge process to deal with metadata churn. Given, we need to ensure fair-use we also propose implementing limits for both the number of metadata entries we can receive and the size of a single entry.
 
 ### Read Path
 

--- a/docs/proposals/receiving_metadata.md
+++ b/docs/proposals/receiving_metadata.md
@@ -30,7 +30,7 @@ As a reference, these are some key numbers regarding the size (and send timings)
 
 Since metadata is received all at once, we could directly store into an external cache using the tenant ID as a key, and still, avoid a read-modify-write.  However, a very common use case of Cortex is to have multiple Prometheus sending data for the same tenant ID. This complicates things, as it adds a need to have an intermediary merging phase and thus making a read-modify-write inevitable.
 
-2. Keep metadata in memory within the distributors
+2. Keep metadata in memory within the ingesters
 
 Similarly to what we do with sample data, we can keep the metadata in-memory in the ingestors and apply similar semantics. I propose to use the tenant ID as a hash key, distribute it to the ingesters (taking into account the replication factor), using a hash map to keep a set of the metadata across all instances for a single tenant, and implement a configurable time-based purge process to deal with metadata churn. Given, we need to ensure fair-use we also propose implementing limits for both the number of metadata entries we can receive and the size of entry(s).
 


### PR DESCRIPTION
**What this PR does**: Introduces a proposal for a feature of Cortex

Hi everyone 👋,

Loving the work done on Cortex! As of lately, I've been trying to do some work on Prometheus that enables users to consume the metadata of their metrics. Now that the work there is done (or close to 🤞), I would like to discuss the possibility of bringing this into cortex too.

I have briefly discussed this with @pracucci, and he kindly asked to kick-start the discussion in the form of a proposal so that everyone can get involved. I know that at some point, I have also briefly discussed this with @tomwilkie, so I've added them both as reviewers, but if anyone else has comments, they're very welcome.

I understand the proposal is a bit light on the details, this is intentional, and it was encouraged upon me. If you'd like me to expand on something - I'd be happy too, just let me know.
