### PR TITLE
Removed metricsRegisterer from querier config

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -184,7 +184,7 @@ func (t *Cortex) initQuerier(cfg *Config) (serv services.Service, err error) {
 		tombstonesLoader = purger.NewTombstonesLoader(nil)
 	}
 
-	queryable, engine := querier.New(cfg.Querier, t.distributor, t.storeQueryable, tombstonesLoader)
+	queryable, engine := querier.New(cfg.Querier, t.distributor, t.storeQueryable, tombstonesLoader, prometheus.DefaultRegisterer)
 	api := v1.NewAPI(
 		engine,
 		queryable,
@@ -429,7 +429,7 @@ func (t *Cortex) initRuler(cfg *Config) (serv services.Service, err error) {
 
 	cfg.Ruler.Ring.ListenPort = cfg.Server.GRPCListenPort
 	cfg.Ruler.Ring.KVStore.MemberlistKV = t.memberlistKV.GetMemberlistKV
-	queryable, engine := querier.New(cfg.Querier, t.distributor, t.storeQueryable, tombstonesLoader)
+	queryable, engine := querier.New(cfg.Querier, t.distributor, t.storeQueryable, tombstonesLoader, prometheus.DefaultRegisterer)
 
 	t.ruler, err = ruler.NewRuler(cfg.Ruler, engine, queryable, t.distributor, prometheus.DefaultRegisterer, util.Logger)
 	if err != nil {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -139,12 +139,11 @@ func TestQuerier(t *testing.T) {
 					t.Run(fmt.Sprintf("%s/%s/streaming=%t/iterators=%t", query.query, encoding.name, streaming, iterators), func(t *testing.T) {
 						cfg.IngesterStreaming = streaming
 						cfg.Iterators = iterators
-						cfg.metricsRegisterer = nil
 
 						chunkStore, through := makeMockChunkStore(t, 24, encoding.e)
 						distributor := mockDistibutorFor(t, chunkStore, through)
 
-						queryable, _ := New(cfg, distributor, NewChunkStoreQueryable(cfg, chunkStore), purger.NewTombstonesLoader(nil))
+						queryable, _ := New(cfg, distributor, NewChunkStoreQueryable(cfg, chunkStore), purger.NewTombstonesLoader(nil), nil)
 						testQuery(t, queryable, through, query)
 					})
 				}
@@ -217,7 +216,7 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 				chunkStore, _ := makeMockChunkStore(t, 24, encodings[0].e)
 				distributor := &errDistributor{}
 
-				queryable, _ := New(cfg, distributor, NewChunkStoreQueryable(cfg, chunkStore), purger.NewTombstonesLoader(nil))
+				queryable, _ := New(cfg, distributor, NewChunkStoreQueryable(cfg, chunkStore), purger.NewTombstonesLoader(nil), nil)
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 
@@ -298,7 +297,6 @@ func TestNoFutureQueries(t *testing.T) {
 
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)
-	cfg.metricsRegisterer = nil
 
 	for _, ingesterStreaming := range []bool{true, false} {
 		cfg.IngesterStreaming = ingesterStreaming
@@ -308,7 +306,7 @@ func TestNoFutureQueries(t *testing.T) {
 				chunkStore := &errChunkStore{}
 				distributor := &errDistributor{}
 
-				queryable, _ := New(cfg, distributor, chunkStore, purger.NewTombstonesLoader(nil))
+				queryable, _ := New(cfg, distributor, chunkStore, purger.NewTombstonesLoader(nil), nil)
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 
@@ -485,7 +483,6 @@ func TestShortTermQueryToLTS(t *testing.T) {
 
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)
-	cfg.metricsRegisterer = nil
 
 	for _, ingesterStreaming := range []bool{true, false} {
 		cfg.IngesterStreaming = ingesterStreaming
@@ -496,7 +493,7 @@ func TestShortTermQueryToLTS(t *testing.T) {
 				chunkStore := &emptyChunkStore{}
 				distributor := &errDistributor{}
 
-				queryable, _ := New(cfg, distributor, NewChunkStoreQueryable(cfg, chunkStore), purger.NewTombstonesLoader(nil))
+				queryable, _ := New(cfg, distributor, NewChunkStoreQueryable(cfg, chunkStore), purger.NewTombstonesLoader(nil), nil)
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 


### PR DESCRIPTION
**What this PR does**:
To continue the effort of picking the `prometheus.Registerer` as function input and not passed as part of the config, I've removed `metricsRegisterer` from `querier.Config`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
