### PR TITLE
Spread checkpoint writing

### DIFF
--- a/pkg/ingester/wal_test.go
+++ b/pkg/ingester/wal_test.go
@@ -94,7 +94,7 @@ func TestCheckpointRepair(t *testing.T) {
 				// Shutdown creates a checkpoint. This is only for the last checkpoint.
 				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), ing))
 			} else {
-				require.NoError(t, w.performCheckpoint())
+				require.NoError(t, w.performCheckpoint(true))
 			}
 		}
 


### PR DESCRIPTION
Due to a burst of disk writes during checkpoint, we were facing some heavy disk I/O throttling. This has a big effect on ingestion latency as we write to WAL (north of 60s in worst cases for around 500k series). Hence spread the writing of checkpoint to the entire checkpoint duration.