### PR TITLE
[WIP] Batch up the WAL records before writing

### DIFF
--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -48,6 +48,7 @@ func defaultIngesterTestConfig() Config {
 	cfg.LifecyclerConfig.ID = "localhost"
 	cfg.LifecyclerConfig.FinalSleep = 0
 	cfg.MaxTransferRetries = 0
+	cfg.WALConfig.BatchSize = 1
 	return cfg
 }
 

--- a/pkg/ingester/wal_test.go
+++ b/pkg/ingester/wal_test.go
@@ -94,7 +94,7 @@ func TestCheckpointRepair(t *testing.T) {
 				// Shutdown creates a checkpoint. This is only for the last checkpoint.
 				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), ing))
 			} else {
-				require.NoError(t, w.performCheckpoint())
+				require.NoError(t, w.performCheckpoint(true))
 			}
 		}
 

--- a/pkg/ingester/wal_test.go
+++ b/pkg/ingester/wal_test.go
@@ -37,7 +37,6 @@ func TestWAL(t *testing.T) {
 	_, ing := newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig())
 	userIDs, testData := pushTestSamples(t, ing, numSeries, numSamplesPerSeriesPerPush, 0)
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), ing))
-
 	for r := 0; r < numRestarts; r++ {
 		if r == numRestarts-1 {
 			cfg.WALConfig.WALEnabled = false


### PR DESCRIPTION
As the WAL logging uses a mutex, due to disk throttling or in general latency from disk, writes get stuck at the mutex waiting for other writes to finish.

Updated Design: Batch up WAL records and write in batches to reduce disk IO, and an ingester returns only when the batch is written.

Old Design:

In this PR, we hold the records in a channel and log it to the WAL in parallel by not locking the ingestion path.

One con of the proposed solution in this PR is that we are no longer returning the WAL log error to the ingestion call.