### PR TITLE
Removed gRPC server to communicate between querier and BucketStore

### DIFF
--- a/pkg/querier/blocks_bucket_store_inmemory_server.go
+++ b/pkg/querier/blocks_bucket_store_inmemory_server.go
@@ -1,0 +1,42 @@
+package querier
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+)
+
+// bucketStoreSeriesServer is an fake in-memory gRPC server used to
+// call Thanos BucketStore.Series() without having to go through the
+// gRPC networking stack.
+type bucketStoreSeriesServer struct {
+	// This field just exist to pseudo-implement the unused methods of the interface.
+	storepb.Store_SeriesServer
+
+	ctx context.Context
+
+	SeriesSet []*storepb.Series
+	Warnings  storage.Warnings
+}
+
+func newBucketStoreSeriesServer(ctx context.Context) *bucketStoreSeriesServer {
+	return &bucketStoreSeriesServer{ctx: ctx}
+}
+
+func (s *bucketStoreSeriesServer) Send(r *storepb.SeriesResponse) error {
+	if r.GetWarning() != "" {
+		s.Warnings = append(s.Warnings, errors.New(r.GetWarning()))
+	}
+
+	if r.GetSeries() != nil {
+		s.SeriesSet = append(s.SeriesSet, r.GetSeries())
+	}
+
+	return nil
+}
+
+func (s *bucketStoreSeriesServer) Context() context.Context {
+	return s.ctx
+}


### PR DESCRIPTION
**What this PR does**:
Currently, the querier starts a gRPC server binded to localhost just to talk to the Thanos `BucketStore` (which is running within the same process). In this PR I'm proposing to get rid of this hack and just use a mocked `storepb.Store_SeriesServer` buffering the response `storepb.Series` in memory (which is what we were already doing anyway).

Notes:
- I haven't added new tests cause the existing ones should already cover it.
- `Info()`, `LabelNames()` and `LabelValues()` have been removed because unused (metadata is fetched from ingesters only, `Info()` is a Thanos-specific thing)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
