### PR TITLE
enforce sharding defaults in period configs

### DIFF
--- a/pkg/chunk/fixtures.go
+++ b/pkg/chunk/fixtures.go
@@ -35,7 +35,7 @@ var BenchmarkLabels = labels.Labels{
 
 // DefaultSchemaConfig creates a simple schema config for testing
 func DefaultSchemaConfig(store, schema string, from model.Time) SchemaConfig {
-	return SchemaConfig{
+	s := SchemaConfig{
 		Configs: []PeriodConfig{{
 			IndexType: store,
 			Schema:    schema,
@@ -50,6 +50,10 @@ func DefaultSchemaConfig(store, schema string, from model.Time) SchemaConfig {
 			},
 		}},
 	}
+	if err := s.Validate(); err != nil {
+		panic(err)
+	}
+	return s
 }
 
 // ChunksToMatrix converts a set of chunks to a model.Matrix.

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -107,7 +107,9 @@ func (cfg *SchemaConfig) loadFromFile() error {
 // Validate the schema config and returns an error if the validation
 // doesn't pass
 func (cfg *SchemaConfig) Validate() error {
-	for _, periodCfg := range cfg.Configs {
+	for i, _ := range cfg.Configs {
+		periodCfg := &cfg.Configs[i]
+		periodCfg.applyDefaults()
 		if err := periodCfg.validate(); err != nil {
 			return err
 		}
@@ -142,10 +144,6 @@ func (cfg *SchemaConfig) ForEachAfter(t model.Time, f func(config *PeriodConfig)
 
 // CreateSchema returns the schema defined by the PeriodConfig
 func (cfg PeriodConfig) CreateSchema() Schema {
-	rowShards := defaultRowShards(cfg.Schema)
-	if cfg.RowShards > 0 {
-		rowShards = cfg.RowShards
-	}
 
 	var e entries
 	switch cfg.Schema {
@@ -165,12 +163,12 @@ func (cfg PeriodConfig) CreateSchema() Schema {
 		e = v9Entries{}
 	case "v10":
 		e = v10Entries{
-			rowShards: rowShards,
+			rowShards: cfg.RowShards,
 		}
 	case "v11":
 		e = v11Entries{
 			v10Entries: v10Entries{
-				rowShards: rowShards,
+				rowShards: cfg.RowShards,
 			},
 		}
 	default:
@@ -191,6 +189,13 @@ func (cfg PeriodConfig) createBucketsFunc() (schemaBucketsFunc, time.Duration) {
 	}
 }
 
+func (cfg *PeriodConfig) applyDefaults() {
+	// apply default shard values
+	if cfg.RowShards == 0 {
+		cfg.RowShards = defaultRowShards(cfg.Schema)
+	}
+}
+
 // validate the period config
 func (cfg PeriodConfig) validate() error {
 	// Ensure the schema version exists
@@ -208,6 +213,17 @@ func (cfg PeriodConfig) validate() error {
 
 	if cfg.ChunkTables.Period > 0 && cfg.ChunkTables.Period%bucketsPeriod != 0 {
 		return errInvalidTablePeriod
+	}
+
+	switch cfg.Schema {
+	case "v1", "v2", "v3", "v4", "v5", "v6", "v9":
+	case "v10", "v11":
+		if cfg.RowShards == 0 {
+			return fmt.Errorf("Must have row_shards > 0 (current: %d) for schema (%s)", cfg.RowShards, cfg.Schema)
+		}
+	default:
+		// protects us from adding schemas and not updating this block
+		return fmt.Errorf("unexpected schema (%s)", cfg.Schema)
 	}
 
 	return nil

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -190,13 +190,12 @@ func (cfg PeriodConfig) createBucketsFunc() (schemaBucketsFunc, time.Duration) {
 }
 
 func (cfg *PeriodConfig) applyDefaults() {
-	// apply default shard values
 	if cfg.RowShards == 0 {
 		cfg.RowShards = defaultRowShards(cfg.Schema)
 	}
 }
 
-// validate the period config
+// Validate the period config.
 func (cfg PeriodConfig) validate() error {
 	// Ensure the schema version exists
 	schema := cfg.CreateSchema()
@@ -222,7 +221,7 @@ func (cfg PeriodConfig) validate() error {
 			return fmt.Errorf("Must have row_shards > 0 (current: %d) for schema (%s)", cfg.RowShards, cfg.Schema)
 		}
 	default:
-		// protects us from adding schemas and not updating this block
+		// This generally unreachable path protects us from adding schemas and not handling them in this function.
 		return fmt.Errorf("unexpected schema (%s)", cfg.Schema)
 	}
 

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -107,7 +107,7 @@ func (cfg *SchemaConfig) loadFromFile() error {
 // Validate the schema config and returns an error if the validation
 // doesn't pass
 func (cfg *SchemaConfig) Validate() error {
-	for i, _ := range cfg.Configs {
+	for i := range cfg.Configs {
 		periodCfg := &cfg.Configs[i]
 		periodCfg.applyDefaults()
 		if err := periodCfg.validate(); err != nil {


### PR DESCRIPTION
**What this PR does**:
This fixes a bug where the default shard factors were not set properly on `PeriodConfigs`. It caused us to never update the period config’s shard factor (although the derived Schema, which is used in the store, has the default shard values applied — 16 starting in v10+).

I introduced this bug while addressing the following:
https://github.com/cortexproject/cortex/pull/1878#discussion_r363884225

**Discovery**

We discovered this bug when we tried to enable `querier.parallelise-shardable-queries`. It effectively turned that code path into a no-op because it didn't register any shard-able `PeriodConfigs` (we don't specify overrides and use the derived default).

**The Fix**

- Introduces a `func (cfg *PeriodConfig) applyDefaults()` function which mutates the associated `PeriodConfig` by applying default values (currently only shard factor for appropriate schemas).
- Errors in the case of an invalid sharding configuration in each `PeriodConfig.Validate()`
- Adds a number of test cases to ensure these guarantees

This should ensure that once validated , configs are safe for further use. 

/cc @gouthamve @cyriltovena 

Signed-off-by: Owen Diehl <ow.diehl@gmail.com>