### PR TITLE
Update metrics if transfer fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * [ENHANCEMENT] Added FIFO cache metrics for current number of entries and memory usage. #2270
 * [ENHANCEMENT] Output all config fields to /config API, including those with empty value. #2209
 * [ENHANCEMENT] Add "missing_metric_name" and "metric_name_invalid" reasons to cortex_discarded_samples_total metric. #2346
+* [BUGFIX] Ensure user state metrics are updated if a transfer fails. #2338
 * [BUGFIX] Fixed etcd client keepalive settings. #2278
 * [BUGFIX] Fixed bug in updating last element of FIFO cache. #2270
 * [BUGFIX] Register the metrics of the WAL. #2295

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -71,7 +71,7 @@ func TestIngesterRestart(t *testing.T) {
 	config.LifecyclerConfig.SkipUnregister = true
 
 	{
-		_, ingester := newTestStore(t, config, clientConfig, limits)
+		_, ingester := newTestStore(t, config, clientConfig, limits, nil)
 		time.Sleep(100 * time.Millisecond)
 		// doesn't actually unregister due to skipUnregister: true
 		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), ingester))
@@ -82,7 +82,7 @@ func TestIngesterRestart(t *testing.T) {
 	})
 
 	{
-		_, ingester := newTestStore(t, config, clientConfig, limits)
+		_, ingester := newTestStore(t, config, clientConfig, limits, nil)
 		time.Sleep(100 * time.Millisecond)
 		// doesn't actually unregister due to skipUnregister: true
 		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), ingester))

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -108,7 +108,8 @@ func (i *Ingester) fillUserStatesFromStream(userStates *userStates, stream clien
 	}
 
 	if err := i.lifecycler.ClaimTokensFor(stream.Context(), fromIngesterID); err != nil {
-		err = errors.Wrap(err, "TransferChunks: ClaimTokensFor")
+		retErr = errors.Wrap(err, "TransferChunks: ClaimTokensFor")
+		return
 	}
 
 	return

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -29,77 +29,93 @@ var (
 	errTransferNoPendingIngesters = errors.New("no pending ingesters")
 )
 
+// returns source ingesterID, number of received series, added chunks and error
+func (i *Ingester) fillUserStatesFromStream(userStates *userStates, stream client.Ingester_TransferChunksServer) (fromIngesterID string, seriesReceived int, chunksAdded float64, err error) {
+	for {
+		var wireSeries *client.TimeSeriesChunk
+
+		wireSeries, err = stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			err = errors.Wrap(err, "TransferChunks: Recv")
+			return
+		}
+
+		// We can't send "extra" fields with a streaming call, so we repeat
+		// wireSeries.FromIngesterId and assume it is the same every time
+		// round this loop.
+		if fromIngesterID == "" {
+			fromIngesterID = wireSeries.FromIngesterId
+			level.Info(util.Logger).Log("msg", "processing TransferChunks request", "from_ingester", fromIngesterID)
+
+			// Before transfer, make sure 'from' ingester is in correct state to call ClaimTokensFor later
+			err := i.checkFromIngesterIsInLeavingState(stream.Context(), fromIngesterID)
+			if err != nil {
+				err = errors.Wrap(err, "TransferChunks: checkFromIngesterIsInLeavingState")
+				return
+			}
+		}
+		descs, err := fromWireChunks(wireSeries.Chunks)
+		if err != nil {
+			err = errors.Wrap(err, "TransferChunks: fromWireChunks")
+			return
+		}
+
+		state, fp, series, err := userStates.getOrCreateSeries(stream.Context(), wireSeries.UserId, wireSeries.Labels, nil)
+		if err != nil {
+			err = errors.Wrapf(err, "TransferChunks: getOrCreateSeries: user %s series %s", wireSeries.UserId, wireSeries.Labels)
+			return
+		}
+		prevNumChunks := len(series.chunkDescs)
+
+		err = series.setChunks(descs)
+		state.fpLocker.Unlock(fp) // acquired in getOrCreateSeries
+		if err != nil {
+			err = errors.Wrapf(err, "TransferChunks: setChunks: user %s series %s", wireSeries.UserId, wireSeries.Labels)
+			return
+		}
+
+		seriesReceived++
+		chunksDelta := float64(len(series.chunkDescs) - prevNumChunks)
+		chunksAdded += chunksDelta
+		i.metrics.memoryChunks.Add(chunksDelta)
+		i.metrics.receivedChunks.Add(float64(len(descs)))
+	}
+
+	if seriesReceived == 0 {
+		level.Error(util.Logger).Log("msg", "received TransferChunks request with no series", "from_ingester", fromIngesterID)
+		err = fmt.Errorf("TransferChunks: no series")
+		return
+	}
+
+	if fromIngesterID == "" {
+		level.Error(util.Logger).Log("msg", "received TransferChunks request with no ID from ingester")
+		err = fmt.Errorf("no ingester id")
+		return
+	}
+
+	if err := i.lifecycler.ClaimTokensFor(stream.Context(), fromIngesterID); err != nil {
+		err = errors.Wrap(err, "TransferChunks: ClaimTokensFor")
+	}
+
+	return
+}
+
 // TransferChunks receives all the chunks from another ingester.
 func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) error {
 	fromIngesterID := ""
 	seriesReceived := 0
+
 	xfer := func() error {
 		userStates := newUserStates(i.limiter, i.cfg, i.metrics)
-		var chunksAdded float64
-		// run as an anonymous function so only a single error needs handling if returned
-		err := func() error {
-			for {
-				wireSeries, err := stream.Recv()
-				if err == io.EOF {
-					break
-				}
-				if err != nil {
-					return errors.Wrap(err, "TransferChunks: Recv")
-				}
+		var (
+			chunksAdded float64
+			err         error
+		)
 
-				// We can't send "extra" fields with a streaming call, so we repeat
-				// wireSeries.FromIngesterId and assume it is the same every time
-				// round this loop.
-				if fromIngesterID == "" {
-					fromIngesterID = wireSeries.FromIngesterId
-					level.Info(util.Logger).Log("msg", "processing TransferChunks request", "from_ingester", fromIngesterID)
-
-					// Before transfer, make sure 'from' ingester is in correct state to call ClaimTokensFor later
-					err := i.checkFromIngesterIsInLeavingState(stream.Context(), fromIngesterID)
-					if err != nil {
-						return errors.Wrap(err, "TransferChunks: checkFromIngesterIsInLeavingState")
-					}
-				}
-				descs, err := fromWireChunks(wireSeries.Chunks)
-				if err != nil {
-					return errors.Wrap(err, "TransferChunks: fromWireChunks")
-				}
-
-				state, fp, series, err := userStates.getOrCreateSeries(stream.Context(), wireSeries.UserId, wireSeries.Labels, nil)
-				if err != nil {
-					return errors.Wrapf(err, "TransferChunks: getOrCreateSeries: user %s series %s", wireSeries.UserId, wireSeries.Labels)
-				}
-				prevNumChunks := len(series.chunkDescs)
-
-				err = series.setChunks(descs)
-				state.fpLocker.Unlock(fp) // acquired in getOrCreateSeries
-				if err != nil {
-					return errors.Wrapf(err, "TransferChunks: setChunks: user %s series %s", wireSeries.UserId, wireSeries.Labels)
-				}
-
-				seriesReceived++
-				chunksAdded += float64(len(series.chunkDescs) - prevNumChunks)
-				i.metrics.memoryChunks.Add(float64(len(series.chunkDescs) - prevNumChunks))
-				i.metrics.receivedChunks.Add(float64(len(descs)))
-			}
-
-			if seriesReceived == 0 {
-				level.Error(util.Logger).Log("msg", "received TransferChunks request with no series", "from_ingester", fromIngesterID)
-				return fmt.Errorf("TransferChunks: no series")
-			}
-
-			if fromIngesterID == "" {
-				level.Error(util.Logger).Log("msg", "received TransferChunks request with no ID from ingester")
-				return fmt.Errorf("no ingester id")
-			}
-
-			if err := i.lifecycler.ClaimTokensFor(stream.Context(), fromIngesterID); err != nil {
-				return errors.Wrap(err, "TransferChunks: ClaimTokensFor")
-			}
-
-			return nil
-		}()
-
+		fromIngesterID, seriesReceived, chunksAdded, err = i.fillUserStatesFromStream(userStates, stream)
 		if err != nil {
 			// Ensure the in memory chunks are updated to reflect the number of dropped chunks from the transfer
 			i.metrics.memoryChunks.Sub(chunksAdded)

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -35,7 +35,7 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 	seriesReceived := 0
 	xfer := func() error {
 		userStates := newUserStates(i.limiter, i.cfg, i.metrics)
-		chunksAdded := 0
+		var chunksAdded float64
 		// run as an anonymous function so only a single error needs handling if returned
 		err := func() error {
 			for {
@@ -102,7 +102,7 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 
 		if err != nil {
 			// Ensure the in memory chunks are updated to reflect the number of dropped chunks from the transfer
-			i.metrics.memoryChunks.Dec(chunksAdded)
+			i.metrics.memoryChunks.Sub(chunksAdded)
 
 			// If an error occurs during the transfer and the user state is to be discarded,
 			// ensure the metrics it exports reflect this.

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -149,6 +149,15 @@ func (us *userStates) getOrCreate(userID string) *userState {
 	return state
 }
 
+// teardown ensures metrics are accurately updated if a userStates struct is discarded
+func (us *userStates) teardown() {
+	for _, u := range us.cp() {
+		u.memSeriesRemovedTotal.Add(float64(u.fpToSeries.length()))
+		u.memSeries.Sub(float64(u.fpToSeries.length()))
+		us.metrics.memUsers.Dec()
+	}
+}
+
 func (us *userStates) getViaContext(ctx context.Context) (*userState, bool, error) {
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {

--- a/pkg/ingester/user_state_test.go
+++ b/pkg/ingester/user_state_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 )
@@ -70,4 +74,66 @@ func TestForSeriesMatchingBatching(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTeardDown ensures metrics are updated correctly if the userState is discarded
+func TestTeardDown(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	_, ing := newTestStore(t,
+		defaultIngesterTestConfig(),
+		defaultClientTestConfig(),
+		defaultLimitsTestConfig(),
+		reg)
+
+	pushTestSamples(t, ing, 100, 100, 0)
+
+	// Assert exported metrics (3 blocks, 5 files per block, 2 files WAL).
+	metricNames := []string{
+		"cortex_ingester_memory_series_created_total",
+		"cortex_ingester_memory_series_removed_total",
+		"cortex_ingester_memory_series",
+		"cortex_ingester_memory_users",
+	}
+
+	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
+			# TYPE cortex_ingester_memory_series_removed_total counter
+			cortex_ingester_memory_series_removed_total{user="1"} 0
+			cortex_ingester_memory_series_removed_total{user="2"} 0
+			cortex_ingester_memory_series_removed_total{user="3"} 0
+			# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
+			# TYPE cortex_ingester_memory_series_created_total counter
+			cortex_ingester_memory_series_created_total{user="1"} 100
+			cortex_ingester_memory_series_created_total{user="2"} 100
+			cortex_ingester_memory_series_created_total{user="3"} 100
+			# HELP cortex_ingester_memory_series The current number of series in memory.
+			# TYPE cortex_ingester_memory_series gauge
+			cortex_ingester_memory_series 300
+			# HELP cortex_ingester_memory_users The current number of users in memory.
+			# TYPE cortex_ingester_memory_users gauge
+			cortex_ingester_memory_users 3
+		`), metricNames...))
+
+	ing.userStatesMtx.Lock()
+	defer ing.userStatesMtx.Unlock()
+	ing.userStates.teardown()
+
+	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+	# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
+	# TYPE cortex_ingester_memory_series_removed_total counter
+	cortex_ingester_memory_series_removed_total{user="1"} 100
+	cortex_ingester_memory_series_removed_total{user="2"} 100
+	cortex_ingester_memory_series_removed_total{user="3"} 100
+	# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
+	# TYPE cortex_ingester_memory_series_created_total counter
+	cortex_ingester_memory_series_created_total{user="1"} 100
+	cortex_ingester_memory_series_created_total{user="2"} 100
+	cortex_ingester_memory_series_created_total{user="3"} 100
+	# HELP cortex_ingester_memory_series The current number of series in memory.
+	# TYPE cortex_ingester_memory_series gauge
+	cortex_ingester_memory_series 0
+	# HELP cortex_ingester_memory_users The current number of users in memory.
+	# TYPE cortex_ingester_memory_users gauge
+	cortex_ingester_memory_users 0
+	`), metricNames...))
 }

--- a/pkg/ingester/user_state_test.go
+++ b/pkg/ingester/user_state_test.go
@@ -76,8 +76,8 @@ func TestForSeriesMatchingBatching(t *testing.T) {
 	}
 }
 
-// TestTeardDown ensures metrics are updated correctly if the userState is discarded
-func TestTeardDown(t *testing.T) {
+// TestTeardown ensures metrics are updated correctly if the userState is discarded
+func TestTeardown(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	_, ing := newTestStore(t,
 		defaultIngesterTestConfig(),

--- a/pkg/ingester/wal_test.go
+++ b/pkg/ingester/wal_test.go
@@ -34,7 +34,7 @@ func TestWAL(t *testing.T) {
 	numRestarts := 3
 
 	// Build an ingester, add some samples, then shut it down.
-	_, ing := newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig())
+	_, ing := newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig(), nil)
 	userIDs, testData := pushTestSamples(t, ing, numSeries, numSamplesPerSeriesPerPush, 0)
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), ing))
 
@@ -44,7 +44,7 @@ func TestWAL(t *testing.T) {
 			cfg.WALConfig.CheckpointEnabled = false
 		}
 		// Start a new ingester and recover the WAL.
-		_, ing = newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig())
+		_, ing = newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig(), nil)
 
 		for i, userID := range userIDs {
 			testData[userID] = buildTestMatrix(numSeries, (r+1)*numSamplesPerSeriesPerPush, i)
@@ -78,7 +78,7 @@ func TestCheckpointRepair(t *testing.T) {
 		cfg.WALConfig.Dir = dirname
 
 		// Build an ingester, add some samples, then shut it down.
-		_, ing := newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig())
+		_, ing := newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig(), nil)
 
 		w, ok := ing.wal.(*walWrapper)
 		require.True(t, ok)
@@ -132,7 +132,7 @@ func TestCheckpointRepair(t *testing.T) {
 		}
 
 		// Open an ingester for the repair.
-		_, ing = newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig())
+		_, ing = newTestStore(t, cfg, defaultClientTestConfig(), defaultLimitsTestConfig(), nil)
 		w, ok = ing.wal.(*walWrapper)
 		require.True(t, ok)
 		// defer in case we hit an error though we explicitly close it later.


### PR DESCRIPTION
**What this PR does**:

This PR ensures the UserState metrics are updated if a transfer fails. A `teardown` function is added to the `userState` struct and it is called if a transfer fails.

**Which issue(s) this PR fixes**:
Fixes #2337 

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated
