### PR TITLE
Increment discarded samples for invalid metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@
 * [ENHANCEMENT] Better re-use of connections to DynamoDB and S3. #2268
 * [ENHANCEMENT] Experimental TSDB: Add support for local `filesystem` backend. #2245
 * [ENHANCEMENT] Experimental TSDB: Added memcached support for the TSDB index cache. #2290
-* [ENHANCEMENT] Allow 1w (where w denotes week) and 1y (where y denotes year) when setting table period and retention. #2252 
+* [ENHANCEMENT] Allow 1w (where w denotes week) and 1y (where y denotes year) when setting table period and retention. #2252
 * [ENHANCEMENT] Added FIFO cache metrics for current number of entries and memory usage. #2270
 * [ENHANCEMENT] Output all config fields to /config API, including those with empty value. #2209
+* [ENHANCEMENT] Add "missing_metric_name" and "metric_name_invalid" reasons to cortex_discarded_samples_total metric. #2338
 * [BUGFIX] Fixed etcd client keepalive settings. #2278
 * [BUGFIX] Fixed bug in updating last element of FIFO cache. #2270
 * [BUGFIX] Register the metrics of the WAL. #2295

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -31,6 +31,7 @@ const (
 	// ErrQueryTooLong is used in chunk store and query frontend.
 	ErrQueryTooLong = "invalid query, length > limit (%s > %s)"
 
+	missingMetricName       = "missing_metric_name"
 	invalidMetricName       = "metric_name_invalid"
 	greaterThanMaxSampleAge = "greater_than_max_sample_age"
 	maxLabelNamesPerSeries  = "max_label_names_per_series"
@@ -94,7 +95,7 @@ func ValidateLabels(cfg LabelValidationConfig, userID string, ls []client.LabelA
 	metricName, err := extract.MetricNameFromLabelAdapters(ls)
 	if cfg.EnforceMetricName(userID) {
 		if err != nil {
-			DiscardedSamples.WithLabelValues(invalidMetricName, userID).Inc()
+			DiscardedSamples.WithLabelValues(missingMetricName, userID).Inc()
 			return httpgrpc.Errorf(http.StatusBadRequest, errMissingMetricName)
 		}
 

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -31,6 +31,7 @@ const (
 	// ErrQueryTooLong is used in chunk store and query frontend.
 	ErrQueryTooLong = "invalid query, length > limit (%s > %s)"
 
+	invalidMetricName       = "metric_name_invalid"
 	greaterThanMaxSampleAge = "greater_than_max_sample_age"
 	maxLabelNamesPerSeries  = "max_label_names_per_series"
 	tooFarInFuture          = "too_far_in_future"
@@ -93,10 +94,12 @@ func ValidateLabels(cfg LabelValidationConfig, userID string, ls []client.LabelA
 	metricName, err := extract.MetricNameFromLabelAdapters(ls)
 	if cfg.EnforceMetricName(userID) {
 		if err != nil {
+			DiscardedSamples.WithLabelValues(invalidMetricName, userID).Inc()
 			return httpgrpc.Errorf(http.StatusBadRequest, errMissingMetricName)
 		}
 
 		if !model.IsValidMetricName(model.LabelValue(metricName)) {
+			DiscardedSamples.WithLabelValues(invalidMetricName, userID).Inc()
 			return httpgrpc.Errorf(http.StatusBadRequest, errInvalidMetricName, metricName)
 		}
 	}


### PR DESCRIPTION
**What this PR does**:

When enabled, in the distributors, we consider metrics with an invalid
metric name a failure and discard the corresponding sample. When it
happens for this reason, the discarded samples metric appears to not be
incremented.

This commit fixes that by incrementing the counter.

Signed-off-by: gotjosh <josue@grafana.com>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
