### PR TITLE
tsdb: record a histogram of replay tsdb times

### DIFF
--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -75,6 +75,7 @@ type TSDBState struct {
 	// Head compactions metrics.
 	compactionsTriggered prometheus.Counter
 	compactionsFailed    prometheus.Counter
+	walReplayTime        prometheus.Histogram
 }
 
 // NewV2 returns a new Ingester that uses prometheus block storage instead of chunk storage
@@ -108,6 +109,11 @@ func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides,
 			compactionsFailed: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
 				Name: "cortex_ingester_tsdb_compactions_failed_total",
 				Help: "Total number of compactions that failed.",
+			}),
+			walReplayTime: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+				Name:    "cortex_ingester_tsdb_wal_replay_duration_seconds",
+				Help:    "The total time it takes to open and replay a TSDB WAL.",
+				Buckets: prometheus.DefBuckets,
 			}),
 		},
 	}
@@ -847,6 +853,10 @@ func (i *Ingester) openExistingTSDB(ctx context.Context) error {
 		go func(userID string) {
 			defer wg.Done()
 			defer openGate.Done()
+			defer func(ts time.Time) {
+				i.TSDBState.walReplayTime.Observe(time.Since(ts).Seconds())
+			}(time.Now())
+
 			db, err := i.createTSDB(userID)
 			if err != nil {
 				level.Error(util.Logger).Log("msg", "unable to open user TSDB", "err", err, "user", userID)


### PR DESCRIPTION
Signed-off-by: Thor <thansen@digitalocean.com>

**What this PR does**:
Adds a histogram to record tsdb replay timings.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
