### PR TITLE
Reduce the headings in v1-guarantees from H1 to H2

### DIFF
--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -7,7 +7,7 @@ slug: v1guarantees
 
 For the v1.0 release, we want to provide the following guarantees:
 
-# Flags, Config and minor version upgrades
+## Flags, Config and minor version upgrades
 
 Upgrading cortex from one minor version to the next should "just work"; that being said, we don't want to bump the major version every time we remove a flag, so we will will keep deprecated flags around for 2 minor release.  There is a metric (`cortex_deprecated_flags_inuse_total`) you can alert on to find out if you're using a deprecated  flag.
 
@@ -15,11 +15,11 @@ Similarly to flags, minor version upgrades using config files should "just work"
 
 These guarantees don't apply for [experimental features](#experimental-features).
 
-# Reading old data
+## Reading old data
 
 The Cortex maintainers commit to ensuring future version of Cortex can read data written by versions up to two years old. In practice we expect to be able to read more, but this is our guarantee.
 
-# API Compatibility
+## API Compatibility
 
 Cortex strives to be 100% API compatible with Prometheus (under `/api/prom/*`); any deviation from this is considered a bug, except:
 
@@ -28,7 +28,7 @@ Cortex strives to be 100% API compatible with Prometheus (under `/api/prom/*`); 
 - Additional API around pushing metrics (under `/api/push`).
 - Additional API endpoints for management of Cortex itself, such as the ring.  These APIs are not part of the any compatibility guarantees.
 
-# Experimental features
+## Experimental features
 
 Cortex is an actively developed project and we want to encourage the introduction of new features and capability.  As such, not everything in each release of Cortex is considered "production-ready". We don't provide any backwards compatibility guarantees on these and the config and flags might break.
 


### PR DESCRIPTION
Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
