### PR TITLE
stop index client while stopping store

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -102,6 +102,7 @@ func newStore(cfg StoreConfig, schema Schema, index IndexClient, chunks Client, 
 func (c *store) Stop() {
 	c.storage.Stop()
 	c.Fetcher.Stop()
+	c.index.Stop()
 }
 
 // Put implements ChunkStore

--- a/pkg/chunk/storage/caching_index_client.go
+++ b/pkg/chunk/storage/caching_index_client.go
@@ -63,6 +63,7 @@ func newCachingIndexClient(client chunk.IndexClient, c cache.Cache, validity tim
 
 func (s *cachingIndexClient) Stop() {
 	s.cache.Stop()
+	s.IndexClient.Stop()
 }
 
 func (s *cachingIndexClient) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) (shouldContinue bool)) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
It seems we are not calling `Stop` method on `IndexClient` while stopping the store.
This PR fixes that.
