### PR TITLE
Introduce BlocksScanner

### DIFF
--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -111,7 +111,7 @@ func (d *BlocksScanner) GetBlocks(userID string, minT, maxT int64) ([]*metadata.
 		}
 
 		// We can safely break the loop because metas are sorted by MaxTime.
-		if minT >= userMetas[i].MaxTime {
+		if userMetas[i].MaxTime <= minT {
 			break
 		}
 	}

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -83,7 +83,7 @@ func NewBlocksScanner(cfg BlocksScannerConfig, bucketClient objstore.Bucket, log
 }
 
 // GetBlocks returns known blocks for userID containing samples within the range minT
-// and maxT (both included).
+// and maxT (both included). Returned blocks are sorted by MaxTime descending.
 func (d *BlocksScanner) GetBlocks(userID string, minT, maxT int64) ([]*metadata.Meta, error) {
 	// We need to ensure the initial full bucket scan succeeded.
 	if d.State() != services.Running {

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -1,0 +1,315 @@
+package querier
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/objstore"
+
+	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+var (
+	errBlocksScannerNotRunning = errors.New("blocks scanner is not running")
+	errInvalidBlocksRange      = errors.New("invalid blocks time range")
+)
+
+type BlocksScannerConfig struct {
+	ScanInterval             time.Duration
+	TenantsConcurrency       int
+	MetasConcurrency         int
+	CacheDir                 string
+	ConsistencyDelay         time.Duration
+	IgnoreDeletionMarksDelay time.Duration
+}
+
+type BlocksScanner struct {
+	services.Service
+
+	cfg             BlocksScannerConfig
+	logger          log.Logger
+	bucketClient    objstore.Bucket
+	fetchersMetrics *metaFetcherMetrics
+
+	// We reuse the metadata fetcher instance for a given tenant both because of performance
+	// reasons (the fetcher keeps a in-memory cache) and being able to collect and group metrics.
+	fetchers   map[string]block.MetadataFetcher
+	fetchersMx sync.Mutex
+
+	// Keep the per-tenant metas found during the last run.
+	metas   map[string][]*metadata.Meta
+	metasMx sync.RWMutex
+
+	scanDuration prometheus.Histogram
+}
+
+func NewBlocksScanner(cfg BlocksScannerConfig, bucketClient objstore.Bucket, logger log.Logger, reg prometheus.Registerer) *BlocksScanner {
+	d := &BlocksScanner{
+		cfg:             cfg,
+		logger:          logger,
+		bucketClient:    bucketClient,
+		fetchers:        make(map[string]block.MetadataFetcher),
+		metas:           make(map[string][]*metadata.Meta),
+		fetchersMetrics: newMetaFetcherMetrics(),
+		scanDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_querier_blocks_scan_duration_seconds",
+			Help:    "The total time it takes to run a full blocks scan across the storage.",
+			Buckets: []float64{1, 10, 20, 30, 60, 120, 180, 240, 300, 600},
+		}),
+	}
+
+	if reg != nil {
+		reg.MustRegister(d.fetchersMetrics)
+	}
+
+	d.Service = services.NewTimerService(cfg.ScanInterval, d.starting, d.scan, nil)
+
+	return d
+}
+
+// GetBlocks returns known blocks for userID containing samples within the range minT
+// and maxT (both included).
+func (d *BlocksScanner) GetBlocks(userID string, minT, maxT int64) ([]*metadata.Meta, error) {
+	// We need to ensure the initial full bucket scan succeeded.
+	if d.State() != services.Running {
+		return nil, errBlocksScannerNotRunning
+	}
+	if maxT < minT {
+		return nil, errInvalidBlocksRange
+	}
+
+	d.metasMx.RLock()
+	defer d.metasMx.RUnlock()
+
+	userMetas, ok := d.metas[userID]
+	if !ok {
+		return nil, nil
+	}
+
+	// Given we do expect the large majority of queries to have a time range close
+	// to "now", we're going to find matching blocks iterating the list in reverse order.
+	var matchingMetas []*metadata.Meta
+	for i := len(userMetas) - 1; i >= 0; i-- {
+		// NOTE: Block intervals are half-open: [MinTime, MaxTime).
+		if minT < userMetas[i].MaxTime && maxT >= userMetas[i].MinTime {
+			matchingMetas = append(matchingMetas, userMetas[i])
+		}
+
+		// We can safely break the loop because metas are sorted by MaxTime.
+		if minT >= userMetas[i].MaxTime {
+			break
+		}
+	}
+
+	return matchingMetas, nil
+}
+
+func (d *BlocksScanner) starting(ctx context.Context) error {
+	// Before the service is in the running state it must have successfully
+	// complete the initial scan.
+	return d.scanBucket(ctx)
+}
+
+func (d *BlocksScanner) scan(ctx context.Context) error {
+	if err := d.scanBucket(ctx); err != nil {
+		level.Error(d.logger).Log("msg", "failed to scan bucket storage to find blocks", "err", err)
+	}
+
+	// Never return error, otherwise the service terminates.
+	return nil
+}
+
+func (d *BlocksScanner) scanBucket(ctx context.Context) error {
+	defer func(start time.Time) {
+		d.scanDuration.Observe(time.Since(start).Seconds())
+	}(time.Now())
+
+	jobsChan := make(chan string)
+	resMx := sync.Mutex{}
+	resMetas := map[string][]*metadata.Meta{}
+	resErrs := tsdb_errors.MultiError{}
+
+	// Create a pool of workers which will synchronize metas. The pool size
+	// is limited in order to avoid to concurrently sync a lot of tenants in
+	// a large cluster.
+	wg := &sync.WaitGroup{}
+	wg.Add(d.cfg.TenantsConcurrency)
+
+	for i := 0; i < d.cfg.TenantsConcurrency; i++ {
+		go func() {
+			defer wg.Done()
+
+			for userID := range jobsChan {
+				metas, err := d.scanUserBlocksWithRetries(ctx, userID)
+
+				resMx.Lock()
+				if err != nil {
+					resErrs.Add(err)
+				} else {
+					resMetas[userID] = metas
+				}
+				resMx.Unlock()
+			}
+		}()
+	}
+
+	// Iterate the bucket to discover users.
+	err := d.bucketClient.Iter(ctx, "", func(s string) error {
+		userID := strings.TrimSuffix(s, "/")
+		jobsChan <- userID
+		return nil
+	})
+
+	if err != nil {
+		resMx.Lock()
+		resErrs.Add(err)
+		resMx.Unlock()
+	}
+
+	// Wait until all workers completed.
+	close(jobsChan)
+	wg.Wait()
+
+	d.metasMx.Lock()
+	if len(resErrs) == 0 {
+		// Replace the map, so that we discard tenants fully deleted from storage.
+		d.metas = resMetas
+	} else {
+		// If an error occurred, we prefer to partially update the metas map instead of
+		// not updating it at all. At least we'll update blocks for the successful tenants.
+		for userID, metas := range resMetas {
+			d.metas[userID] = metas
+		}
+	}
+	d.metasMx.Unlock()
+
+	return resErrs.Err()
+}
+
+// scanUserBlocksWithRetries runs scanUserBlocks() retrying multiple times
+// in case of error.
+func (d *BlocksScanner) scanUserBlocksWithRetries(ctx context.Context, userID string) (metas []*metadata.Meta, err error) {
+	retries := util.NewBackoff(ctx, util.BackoffConfig{
+		MinBackoff: time.Second,
+		MaxBackoff: 30 * time.Second,
+		MaxRetries: 3,
+	})
+
+	for retries.Ongoing() {
+		metas, err = d.scanUserBlocks(ctx, userID)
+		if err == nil {
+			break
+		}
+
+		retries.Wait()
+	}
+
+	return
+}
+
+func (d *BlocksScanner) scanUserBlocks(ctx context.Context, userID string) ([]*metadata.Meta, error) {
+	fetcher, err := d.getOrCreateMetaFetcher(userID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "create meta fetcher for user %s", userID)
+	}
+
+	metas, partials, err := fetcher.Fetch(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "scan blocks for user %s", userID)
+	}
+
+	// In case we've found any partial block we log about it but continue cause we don't want
+	// to break the scanner just because there's a spurious block.
+	if len(partials) > 0 {
+		logPartialBlocks(userID, partials, d.logger)
+	}
+
+	return sortMetasByMaxTime(metas), nil
+}
+
+func (d *BlocksScanner) getOrCreateMetaFetcher(userID string) (block.MetadataFetcher, error) {
+	d.fetchersMx.Lock()
+	defer d.fetchersMx.Unlock()
+
+	if fetcher, ok := d.fetchers[userID]; ok {
+		return fetcher, nil
+	}
+
+	fetcher, err := d.createMetaFetcher(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	d.fetchers[userID] = fetcher
+	return fetcher, nil
+}
+
+func (d *BlocksScanner) createMetaFetcher(userID string) (block.MetadataFetcher, error) {
+	userLogger := util.WithUserID(userID, d.logger)
+	userBucket := cortex_tsdb.NewUserBucketClient(userID, d.bucketClient)
+	userReg := prometheus.NewRegistry()
+
+	var filters []block.MetadataFilter
+	// TODO(pracucci) I'm dubious we actually need NewConsistencyDelayMetaFilter here. I think we should remove it and move the
+	// 		consistency delay upwards, where we do the consistency check in the querier.
+	filters = append(filters, block.NewConsistencyDelayMetaFilter(userLogger, d.cfg.ConsistencyDelay, userReg))
+	filters = append(filters, block.NewIgnoreDeletionMarkFilter(userLogger, userBucket, d.cfg.IgnoreDeletionMarksDelay))
+	// TODO(pracucci) is this problematic due to the consistency check?
+	filters = append(filters, block.NewDeduplicateFilter())
+
+	f, err := block.NewMetaFetcher(
+		userLogger,
+		d.cfg.MetasConcurrency,
+		userBucket,
+		// The fetcher stores cached metas in the "meta-syncer/" sub directory.
+		filepath.Join(d.cfg.CacheDir, userID),
+		userReg,
+		filters,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	d.fetchersMetrics.addUserRegistry(userID, userReg)
+	return f, nil
+}
+
+func sortMetasByMaxTime(metas map[ulid.ULID]*metadata.Meta) []*metadata.Meta {
+	sorted := make([]*metadata.Meta, 0, len(metas))
+	for _, m := range metas {
+		sorted = append(sorted, m)
+	}
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].MaxTime < sorted[j].MaxTime
+	})
+
+	return sorted
+}
+
+func logPartialBlocks(userID string, partials map[ulid.ULID]error, logger log.Logger) {
+	ids := make([]string, 0, len(partials))
+	errs := make([]string, 0, len(partials))
+
+	for id, err := range partials {
+		ids = append(ids, id.String())
+		errs = append(errs, err.Error())
+	}
+
+	level.Warn(logger).Log("msg", "found partial blocks", "user", userID, "blocks", strings.Join(ids, ","), "err", strings.Join(errs, ","))
+}

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -106,7 +106,7 @@ func (d *BlocksScanner) GetBlocks(userID string, minT, maxT int64) ([]*metadata.
 	var matchingMetas []*metadata.Meta
 	for i := len(userMetas) - 1; i >= 0; i-- {
 		// NOTE: Block intervals are half-open: [MinTime, MaxTime).
-		if minT < userMetas[i].MaxTime && maxT >= userMetas[i].MinTime {
+		if userMetas[i].MinTime <= maxT && minT < userMetas[i].MaxTime {
 			matchingMetas = append(matchingMetas, userMetas[i])
 		}
 

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -213,7 +213,7 @@ func (d *BlocksScanner) scanUserBlocksWithRetries(ctx context.Context, userID st
 	for retries.Ongoing() {
 		metas, err = d.scanUserBlocks(ctx, userID)
 		if err == nil {
-			break
+			return
 		}
 
 		retries.Wait()

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -177,7 +177,6 @@ func (d *BlocksScanner) scanBucket(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		}
-		return nil
 	})
 
 	if err != nil {

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -171,7 +171,12 @@ func (d *BlocksScanner) scanBucket(ctx context.Context) error {
 	// Iterate the bucket to discover users.
 	err := d.bucketClient.Iter(ctx, "", func(s string) error {
 		userID := strings.TrimSuffix(s, "/")
-		jobsChan <- userID
+                select {
+                case jobsChan <- userID:
+                    return nil
+                case <-ctx.Done():
+                    return ctx.Err()
+                }
 		return nil
 	})
 

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -83,7 +83,7 @@ func NewBlocksScanner(cfg BlocksScannerConfig, bucketClient objstore.Bucket, log
 }
 
 // GetBlocks returns known blocks for userID containing samples within the range minT
-// and maxT (both included). Returned blocks are sorted by MaxTime descending.
+// and maxT (milliseconds, both included). Returned blocks are sorted by MaxTime descending.
 func (d *BlocksScanner) GetBlocks(userID string, minT, maxT int64) ([]*metadata.Meta, error) {
 	// We need to ensure the initial full bucket scan succeeded.
 	if d.State() != services.Running {
@@ -171,12 +171,12 @@ func (d *BlocksScanner) scanBucket(ctx context.Context) error {
 	// Iterate the bucket to discover users.
 	err := d.bucketClient.Iter(ctx, "", func(s string) error {
 		userID := strings.TrimSuffix(s, "/")
-                select {
-                case jobsChan <- userID:
-                    return nil
-                case <-ctx.Done():
-                    return ctx.Err()
-                }
+		select {
+		case jobsChan <- userID:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 		return nil
 	})
 

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -48,12 +48,12 @@ type BlocksScanner struct {
 
 	// We reuse the metadata fetcher instance for a given tenant both because of performance
 	// reasons (the fetcher keeps a in-memory cache) and being able to collect and group metrics.
-	fetchers   map[string]block.MetadataFetcher
 	fetchersMx sync.Mutex
+	fetchers   map[string]block.MetadataFetcher
 
 	// Keep the per-tenant metas found during the last run.
-	metas   map[string][]*metadata.Meta
 	metasMx sync.RWMutex
+	metas   map[string][]*metadata.Meta
 
 	scanDuration prometheus.Histogram
 }

--- a/pkg/querier/blocks_scanner_test.go
+++ b/pkg/querier/blocks_scanner_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/storage/backend/filesystem"
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 func TestBlocksScanner_InitialScan(t *testing.T) {
@@ -34,8 +35,7 @@ func TestBlocksScanner_InitialScan(t *testing.T) {
 	user1Block2 := mockStorageBlock(t, bucket, "user-1", 20, 30)
 	user2Block1 := mockStorageBlock(t, bucket, "user-2", 10, 20)
 
-	require.NoError(t, s.StartAsync(ctx))
-	require.NoError(t, s.AwaitRunning(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
 	blocks, err := s.GetBlocks("user-1", 0, 30)
 	require.NoError(t, err)
@@ -121,8 +121,7 @@ func TestBlocksScanner_PeriodicScanFindsNewUser(t *testing.T) {
 	s, bucket, _, _, cleanup := prepareBlocksScanner(t, prepareBlocksScannerConfig())
 	defer cleanup()
 
-	require.NoError(t, s.StartAsync(ctx))
-	require.NoError(t, s.AwaitRunning(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
 	blocks, err := s.GetBlocks("user-1", 0, 30)
 	require.NoError(t, err)
@@ -148,8 +147,7 @@ func TestBlocksScanner_PeriodicScanFindsNewBlock(t *testing.T) {
 
 	block1 := mockStorageBlock(t, bucket, "user-1", 10, 20)
 
-	require.NoError(t, s.StartAsync(ctx))
-	require.NoError(t, s.AwaitRunning(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
 	blocks, err := s.GetBlocks("user-1", 0, 30)
 	require.NoError(t, err)
@@ -176,8 +174,7 @@ func TestBlocksScanner_PeriodicScanFindsDeletedBlock(t *testing.T) {
 	block1 := mockStorageBlock(t, bucket, "user-1", 10, 20)
 	block2 := mockStorageBlock(t, bucket, "user-1", 20, 30)
 
-	require.NoError(t, s.StartAsync(ctx))
-	require.NoError(t, s.AwaitRunning(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
 	blocks, err := s.GetBlocks("user-1", 0, 30)
 	require.NoError(t, err)
@@ -204,8 +201,7 @@ func TestBlocksScanner_PeriodicScanFindsDeletedUser(t *testing.T) {
 	block1 := mockStorageBlock(t, bucket, "user-1", 10, 20)
 	block2 := mockStorageBlock(t, bucket, "user-1", 20, 30)
 
-	require.NoError(t, s.StartAsync(ctx))
-	require.NoError(t, s.AwaitRunning(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
 	blocks, err := s.GetBlocks("user-1", 0, 30)
 	require.NoError(t, err)
@@ -231,8 +227,7 @@ func TestBlocksScanner_PeriodicScanFindsUserWhichWasPreviouslyDeleted(t *testing
 	block1 := mockStorageBlock(t, bucket, "user-1", 10, 20)
 	block2 := mockStorageBlock(t, bucket, "user-1", 20, 30)
 
-	require.NoError(t, s.StartAsync(ctx))
-	require.NoError(t, s.AwaitRunning(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
 	blocks, err := s.GetBlocks("user-1", 0, 40)
 	require.NoError(t, err)
@@ -270,8 +265,7 @@ func TestBlocksScanner_GetBlocks(t *testing.T) {
 	block3 := mockStorageBlock(t, bucket, "user-1", 20, 30)
 	block4 := mockStorageBlock(t, bucket, "user-1", 30, 40)
 
-	require.NoError(t, s.StartAsync(ctx))
-	require.NoError(t, s.AwaitRunning(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
 	tests := map[string]struct {
 		minT     int64

--- a/pkg/querier/blocks_scanner_test.go
+++ b/pkg/querier/blocks_scanner_test.go
@@ -1,0 +1,394 @@
+package querier
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/objstore"
+
+	"github.com/cortexproject/cortex/pkg/storage/backend/filesystem"
+	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+)
+
+func TestBlocksScanner_InitialScan(t *testing.T) {
+	ctx := context.Background()
+	s, bucket, _, reg, cleanup := prepareBlocksScanner(t, prepareBlocksScannerConfig())
+	defer cleanup()
+
+	user1Block1 := mockStorageBlock(t, bucket, "user-1", 10, 20)
+	user1Block2 := mockStorageBlock(t, bucket, "user-1", 20, 30)
+	user2Block1 := mockStorageBlock(t, bucket, "user-2", 10, 20)
+
+	require.NoError(t, s.StartAsync(ctx))
+	require.NoError(t, s.AwaitRunning(ctx))
+
+	blocks, err := s.GetBlocks("user-1", 0, 30)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(blocks))
+	assert.Equal(t, user1Block2.ULID, blocks[0].ULID)
+	assert.Equal(t, user1Block1.ULID, blocks[1].ULID)
+
+	blocks, err = s.GetBlocks("user-2", 0, 30)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(blocks))
+	assert.Equal(t, user2Block1.ULID, blocks[0].ULID)
+
+	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_querier_blocks_meta_syncs_total Total blocks metadata synchronization attempts
+		# TYPE cortex_querier_blocks_meta_syncs_total counter
+		cortex_querier_blocks_meta_syncs_total 2
+
+		# HELP cortex_querier_blocks_meta_sync_failures_total Total blocks metadata synchronization failures
+		# TYPE cortex_querier_blocks_meta_sync_failures_total counter
+		cortex_querier_blocks_meta_sync_failures_total 0
+
+		# HELP cortex_querier_blocks_meta_sync_consistency_delay_seconds Configured consistency delay in seconds.
+		# TYPE cortex_querier_blocks_meta_sync_consistency_delay_seconds gauge
+		cortex_querier_blocks_meta_sync_consistency_delay_seconds 0
+	`),
+		"cortex_querier_blocks_meta_syncs_total",
+		"cortex_querier_blocks_meta_sync_failures_total",
+		"cortex_querier_blocks_meta_sync_consistency_delay_seconds",
+	))
+}
+
+func TestBlocksScanner_InitialScanFailure(t *testing.T) {
+	cacheDir, err := ioutil.TempDir(os.TempDir(), "blocks-scanner-test-cache")
+	require.NoError(t, err)
+	defer os.RemoveAll(cacheDir) //nolint: errcheck
+
+	ctx := context.Background()
+	bucket := &cortex_tsdb.BucketClientMock{}
+	reg := prometheus.NewPedanticRegistry()
+
+	cfg := prepareBlocksScannerConfig()
+	cfg.CacheDir = cacheDir
+
+	s := NewBlocksScanner(cfg, bucket, log.NewNopLogger(), reg)
+	defer func() {
+		s.StopAsync()
+		s.AwaitTerminated(context.Background()) //nolint: errcheck
+	}()
+
+	// Mock the storage to simulate a failure when reading objects.
+	bucket.MockIter("", []string{"user-1"}, nil)
+	bucket.MockIter("user-1/", []string{"user-1/01DTVP434PA9VFXSW2JKB3392D"}, nil)
+	bucket.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", "invalid", errors.New("mocked error"))
+
+	require.NoError(t, s.StartAsync(ctx))
+	require.Error(t, s.AwaitRunning(ctx))
+
+	blocks, err := s.GetBlocks("user-1", 0, 30)
+	assert.Equal(t, errBlocksScannerNotRunning, err)
+	assert.Nil(t, blocks)
+
+	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_querier_blocks_meta_syncs_total Total blocks metadata synchronization attempts
+		# TYPE cortex_querier_blocks_meta_syncs_total counter
+		cortex_querier_blocks_meta_syncs_total 3
+
+		# HELP cortex_querier_blocks_meta_sync_failures_total Total blocks metadata synchronization failures
+		# TYPE cortex_querier_blocks_meta_sync_failures_total counter
+		cortex_querier_blocks_meta_sync_failures_total 3
+
+		# HELP cortex_querier_blocks_meta_sync_consistency_delay_seconds Configured consistency delay in seconds.
+		# TYPE cortex_querier_blocks_meta_sync_consistency_delay_seconds gauge
+		cortex_querier_blocks_meta_sync_consistency_delay_seconds 0
+	`),
+		"cortex_querier_blocks_meta_syncs_total",
+		"cortex_querier_blocks_meta_sync_failures_total",
+		"cortex_querier_blocks_meta_sync_consistency_delay_seconds",
+	))
+}
+
+func TestBlocksScanner_PeriodicScanFindsNewUser(t *testing.T) {
+	ctx := context.Background()
+	s, bucket, _, _, cleanup := prepareBlocksScanner(t, prepareBlocksScannerConfig())
+	defer cleanup()
+
+	require.NoError(t, s.StartAsync(ctx))
+	require.NoError(t, s.AwaitRunning(ctx))
+
+	blocks, err := s.GetBlocks("user-1", 0, 30)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(blocks))
+
+	block1 := mockStorageBlock(t, bucket, "user-1", 10, 20)
+	block2 := mockStorageBlock(t, bucket, "user-1", 20, 30)
+
+	// Trigger a periodic sync
+	require.NoError(t, s.scan(ctx))
+
+	blocks, err = s.GetBlocks("user-1", 0, 30)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(blocks))
+	assert.Equal(t, block2.ULID, blocks[0].ULID)
+	assert.Equal(t, block1.ULID, blocks[1].ULID)
+}
+
+func TestBlocksScanner_PeriodicScanFindsNewBlock(t *testing.T) {
+	ctx := context.Background()
+	s, bucket, _, _, cleanup := prepareBlocksScanner(t, prepareBlocksScannerConfig())
+	defer cleanup()
+
+	block1 := mockStorageBlock(t, bucket, "user-1", 10, 20)
+
+	require.NoError(t, s.StartAsync(ctx))
+	require.NoError(t, s.AwaitRunning(ctx))
+
+	blocks, err := s.GetBlocks("user-1", 0, 30)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(blocks))
+	assert.Equal(t, block1.ULID, blocks[0].ULID)
+
+	block2 := mockStorageBlock(t, bucket, "user-1", 20, 30)
+
+	// Trigger a periodic sync
+	require.NoError(t, s.scan(ctx))
+
+	blocks, err = s.GetBlocks("user-1", 0, 30)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(blocks))
+	assert.Equal(t, block2.ULID, blocks[0].ULID)
+	assert.Equal(t, block1.ULID, blocks[1].ULID)
+}
+
+func TestBlocksScanner_PeriodicScanFindsDeletedBlock(t *testing.T) {
+	ctx := context.Background()
+	s, bucket, _, _, cleanup := prepareBlocksScanner(t, prepareBlocksScannerConfig())
+	defer cleanup()
+
+	block1 := mockStorageBlock(t, bucket, "user-1", 10, 20)
+	block2 := mockStorageBlock(t, bucket, "user-1", 20, 30)
+
+	require.NoError(t, s.StartAsync(ctx))
+	require.NoError(t, s.AwaitRunning(ctx))
+
+	blocks, err := s.GetBlocks("user-1", 0, 30)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(blocks))
+	assert.Equal(t, block2.ULID, blocks[0].ULID)
+	assert.Equal(t, block1.ULID, blocks[1].ULID)
+
+	require.NoError(t, bucket.Delete(ctx, fmt.Sprintf("%s/%s", "user-1", block1.ULID.String())))
+
+	// Trigger a periodic sync
+	require.NoError(t, s.scan(ctx))
+
+	blocks, err = s.GetBlocks("user-1", 0, 30)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(blocks))
+	assert.Equal(t, block2.ULID, blocks[0].ULID)
+}
+
+func TestBlocksScanner_PeriodicScanFindsDeletedUser(t *testing.T) {
+	ctx := context.Background()
+	s, bucket, _, _, cleanup := prepareBlocksScanner(t, prepareBlocksScannerConfig())
+	defer cleanup()
+
+	block1 := mockStorageBlock(t, bucket, "user-1", 10, 20)
+	block2 := mockStorageBlock(t, bucket, "user-1", 20, 30)
+
+	require.NoError(t, s.StartAsync(ctx))
+	require.NoError(t, s.AwaitRunning(ctx))
+
+	blocks, err := s.GetBlocks("user-1", 0, 30)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(blocks))
+	assert.Equal(t, block2.ULID, blocks[0].ULID)
+	assert.Equal(t, block1.ULID, blocks[1].ULID)
+
+	require.NoError(t, bucket.Delete(ctx, "user-1"))
+
+	// Trigger a periodic sync
+	require.NoError(t, s.scan(ctx))
+
+	blocks, err = s.GetBlocks("user-1", 0, 30)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(blocks))
+}
+
+func TestBlocksScanner_PeriodicScanFindsUserWhichWasPreviouslyDeleted(t *testing.T) {
+	ctx := context.Background()
+	s, bucket, _, _, cleanup := prepareBlocksScanner(t, prepareBlocksScannerConfig())
+	defer cleanup()
+
+	block1 := mockStorageBlock(t, bucket, "user-1", 10, 20)
+	block2 := mockStorageBlock(t, bucket, "user-1", 20, 30)
+
+	require.NoError(t, s.StartAsync(ctx))
+	require.NoError(t, s.AwaitRunning(ctx))
+
+	blocks, err := s.GetBlocks("user-1", 0, 40)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(blocks))
+	assert.Equal(t, block2.ULID, blocks[0].ULID)
+	assert.Equal(t, block1.ULID, blocks[1].ULID)
+
+	require.NoError(t, bucket.Delete(ctx, "user-1"))
+
+	// Trigger a periodic sync
+	require.NoError(t, s.scan(ctx))
+
+	blocks, err = s.GetBlocks("user-1", 0, 40)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(blocks))
+
+	block3 := mockStorageBlock(t, bucket, "user-1", 30, 40)
+
+	// Trigger a periodic sync
+	require.NoError(t, s.scan(ctx))
+
+	blocks, err = s.GetBlocks("user-1", 0, 40)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(blocks))
+	assert.Equal(t, block3.ULID, blocks[0].ULID)
+}
+
+func TestBlocksScanner_GetBlocks(t *testing.T) {
+	ctx := context.Background()
+	s, bucket, _, _, cleanup := prepareBlocksScanner(t, prepareBlocksScannerConfig())
+	defer cleanup()
+
+	block1 := mockStorageBlock(t, bucket, "user-1", 10, 15)
+	block2 := mockStorageBlock(t, bucket, "user-1", 12, 20)
+	block3 := mockStorageBlock(t, bucket, "user-1", 20, 30)
+	block4 := mockStorageBlock(t, bucket, "user-1", 30, 40)
+
+	require.NoError(t, s.StartAsync(ctx))
+	require.NoError(t, s.AwaitRunning(ctx))
+
+	tests := map[string]struct {
+		minT     int64
+		maxT     int64
+		expected []tsdb.BlockMeta
+	}{
+		"no matching block because the range is too low": {
+			minT: 0,
+			maxT: 5,
+		},
+		"no matching block because the range is too high": {
+			minT: 50,
+			maxT: 60,
+		},
+		"matching all blocks": {
+			minT:     0,
+			maxT:     60,
+			expected: []tsdb.BlockMeta{block4, block3, block2, block1},
+		},
+		"query range starting at a block maxT": {
+			minT:     block3.MaxTime,
+			maxT:     60,
+			expected: []tsdb.BlockMeta{block4},
+		},
+		"query range ending at a block minT": {
+			minT:     block3.MinTime,
+			maxT:     block4.MinTime,
+			expected: []tsdb.BlockMeta{block4, block3},
+		},
+		"query range within a single block": {
+			minT:     block3.MinTime + 2,
+			maxT:     block3.MaxTime - 2,
+			expected: []tsdb.BlockMeta{block3},
+		},
+		"query range within multiple blocks": {
+			minT:     13,
+			maxT:     16,
+			expected: []tsdb.BlockMeta{block2, block1},
+		},
+		"query range matching exactly a single block": {
+			minT:     block3.MinTime,
+			maxT:     block3.MaxTime - 1,
+			expected: []tsdb.BlockMeta{block3},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actual, err := s.GetBlocks("user-1", testData.minT, testData.maxT)
+			require.NoError(t, err)
+			require.Equal(t, len(testData.expected), len(actual))
+
+			for i, expectedBlock := range testData.expected {
+				assert.Equal(t, expectedBlock.ULID, actual[i].ULID)
+			}
+		})
+	}
+}
+
+func prepareBlocksScanner(t *testing.T, cfg BlocksScannerConfig) (*BlocksScanner, objstore.Bucket, string, *prometheus.Registry, func()) {
+	cacheDir, err := ioutil.TempDir(os.TempDir(), "blocks-scanner-test-cache")
+	require.NoError(t, err)
+
+	storageDir, err := ioutil.TempDir(os.TempDir(), "blocks-scanner-test-storage")
+	require.NoError(t, err)
+
+	bucket, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
+	require.NoError(t, err)
+
+	reg := prometheus.NewPedanticRegistry()
+	cfg.CacheDir = cacheDir
+	s := NewBlocksScanner(cfg, bucket, log.NewNopLogger(), reg)
+
+	cleanup := func() {
+		s.StopAsync()
+		s.AwaitTerminated(context.Background()) //nolint: errcheck
+		require.NoError(t, os.RemoveAll(cacheDir))
+		require.NoError(t, os.RemoveAll(storageDir))
+	}
+
+	return s, bucket, storageDir, reg, cleanup
+}
+
+func prepareBlocksScannerConfig() BlocksScannerConfig {
+	return BlocksScannerConfig{
+		ScanInterval:             time.Minute,
+		TenantsConcurrency:       10,
+		MetasConcurrency:         10,
+		ConsistencyDelay:         0,
+		IgnoreDeletionMarksDelay: 0,
+	}
+}
+
+func mockStorageBlock(t *testing.T, bucket objstore.Bucket, userID string, minT, maxT int64) tsdb.BlockMeta {
+	// Generate a block ID whose timestamp matches the maxT (for simplicity we assume it
+	// has been compacted and shipped in zero time, even if not realistic).
+	id := ulid.MustNew(uint64(maxT), rand.Reader)
+
+	meta := tsdb.BlockMeta{
+		Version: 1,
+		ULID:    id,
+		MinTime: minT,
+		MaxTime: maxT,
+		Compaction: tsdb.BlockMetaCompaction{
+			Level:   1,
+			Sources: []ulid.ULID{id},
+		},
+	}
+
+	metaContent, err := json.Marshal(meta)
+	if err != nil {
+		panic("failed to marshal mocked block meta")
+	}
+
+	metaContentReader := strings.NewReader(string(metaContent))
+	metaPath := fmt.Sprintf("%s/%s/meta.json", userID, id.String())
+	require.NoError(t, bucket.Upload(context.Background(), metaPath, metaContentReader))
+
+	return meta
+}


### PR DESCRIPTION
**What this PR does**:
According to the blocks sharding proposal, the querier needs to be able to scan the bucket to find blocks for a given user and time range. In this PR I'm introducing the `BlocksScanner` which periodically scans the bucket looking for new/deleted users/blocks and exposes a `GetBlocks()` function to find blocks.

Notes:
- I plan to work on the TODOs in `createMetaFetcher()` in a later stage
- The `BlocksScannerConfig` may be subject to change, based on the final design once we'll integrate the scanner

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
