### PR TITLE
Return first validation error on sample ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@
 * [ENHANCEMENT] Output all config fields to /config API, including those with empty value. #2209
 * [ENHANCEMENT] Add "missing_metric_name" and "metric_name_invalid" reasons to cortex_discarded_samples_total metric. #2346
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
-* [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #XXXX 
+* [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383 
 * [BUGFIX] Ensure user state metrics are updated if a transfer fails. #2338
 * [BUGFIX] Fixed etcd client keepalive settings. #2278
 * [BUGFIX] Fixed bug in updating last element of FIFO cache. #2270

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 * [ENHANCEMENT] Output all config fields to /config API, including those with empty value. #2209
 * [ENHANCEMENT] Add "missing_metric_name" and "metric_name_invalid" reasons to cortex_discarded_samples_total metric. #2346
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
+* [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #XXXX 
 * [BUGFIX] Ensure user state metrics are updated if a transfer fails. #2338
 * [BUGFIX] Fixed etcd client keepalive settings. #2278
 * [BUGFIX] Fixed bug in updating last element of FIFO cache. #2270

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1139,6 +1139,18 @@ func TestDistributorValidation(t *testing.T) {
 			}},
 			err: httpgrpc.Errorf(http.StatusBadRequest, `sample for 'testmetric{foo2="bar2", foo="bar"}' has 3 label names; limit 2`),
 		},
+		// Test multiple validation fails return the first one.
+		{
+			labels: []labels.Labels{
+				{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}, {Name: "foo2", Value: "bar2"}},
+				{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}},
+			},
+			samples: []client.Sample{
+				{TimestampMs: int64(now), Value: 2},
+				{TimestampMs: int64(past), Value: 2},
+			},
+			err: httpgrpc.Errorf(http.StatusBadRequest, `sample for 'testmetric{foo2="bar2", foo="bar"}' has 3 label names; limit 2`),
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var limits validation.Limits

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -476,6 +476,42 @@ func TestIngesterMetricSeriesLimitExceeded(t *testing.T) {
 	assert.Equal(t, expected, res)
 }
 
+func TestIngesterValidation(t *testing.T) {
+	_, ing := newDefaultTestStore(t)
+	defer services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
+	userID := "1"
+	ctx := user.InjectOrgID(context.Background(), userID)
+	m := labelPairs{{Name: labels.MetricName, Value: "testmetric"}}
+
+	// As a setup, let's append samples.
+	ing.append(context.Background(), userID, m, 1, 0, client.API, nil)
+
+	for _, tc := range []struct {
+		desc    string
+		lbls    []labels.Labels
+		samples []client.Sample
+		err     error
+	}{
+		{
+			desc: "With multiple append failures, only return the first error.",
+			lbls: []labels.Labels{
+				{{Name: labels.MetricName, Value: "testmetric"}},
+				{{Name: labels.MetricName, Value: "testmetric"}},
+			},
+			samples: []client.Sample{
+				{TimestampMs: 0, Value: 0}, // earlier timestamp, out of order.
+				{TimestampMs: 1, Value: 2}, // same timestamp different value.
+			},
+			err: httpgrpc.Errorf(http.StatusBadRequest, `user=1: sample timestamp out of order; last timestamp: 0.001, incoming timestamp: 0 for series {__name__="testmetric"}`),
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := ing.Push(ctx, client.ToWriteRequest(tc.lbls, tc.samples, client.API))
+			require.Equal(t, tc.err, err)
+		})
+	}
+}
+
 func BenchmarkIngesterSeriesCreationLocking(b *testing.B) {
 	for i := 1; i <= 32; i++ {
 		b.Run(strconv.Itoa(i), func(b *testing.B) {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -484,7 +484,8 @@ func TestIngesterValidation(t *testing.T) {
 	m := labelPairs{{Name: labels.MetricName, Value: "testmetric"}}
 
 	// As a setup, let's append samples.
-	ing.append(context.Background(), userID, m, 1, 0, client.API, nil)
+	err := ing.append(context.Background(), userID, m, 1, 0, client.API, nil)
+	require.NoError(t, err)
 
 	for _, tc := range []struct {
 		desc    string


### PR DESCRIPTION
**What this PR does**:

This commit changes which error we return on validation back to the
clients (Prometheus or Distributors).

The samples that do not pass validation at distributors and/or ingesters
now return the first validation error as opposed to the last.


**Which issue(s) this PR fixes**:
Abstract from a conversation in #2336 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
