### PR TITLE
add support for creating more ObjectClient types and flush file immediately for filesystem type

### DIFF
--- a/pkg/chunk/local/fs_object_client.go
+++ b/pkg/chunk/local/fs_object_client.go
@@ -76,8 +76,11 @@ func (f *FSObjectClient) PutObject(ctx context.Context, objectKey string, object
 
 	defer fl.Close()
 
-	_, err = io.Copy(fl, object)
-	return err
+	if _, err := io.Copy(fl, object); err != nil {
+		return err
+	}
+
+	return fl.Sync()
 }
 
 // List only objects from the store non-recursively

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -265,11 +265,17 @@ func NewBucketClient(storageConfig Config) (chunk.BucketClient, error) {
 // NewObjectClient makes a new StorageClient of the desired types.
 func NewObjectClient(name string, cfg Config) (chunk.ObjectClient, error) {
 	switch name {
+	case "aws", "s3":
+		return aws.NewS3ObjectClient(cfg.AWSStorageConfig.S3Config, chunk.DirDelim)
+	case "gcs":
+		return gcp.NewGCSObjectClient(context.Background(), cfg.GCSConfig, chunk.DirDelim)
+	case "azure":
+		return azure.NewBlobStorage(&cfg.AzureStorageConfig, chunk.DirDelim)
 	case "inmemory":
 		return chunk.NewMockStorage(), nil
 	case "filesystem":
 		return local.NewFSObjectClient(cfg.FSConfig)
 	default:
-		return nil, fmt.Errorf("Unrecognized storage client %v, choose one of: filesystem", name)
+		return nil, fmt.Errorf("Unrecognized storage client %v, choose one of: aws, s3, gcs, azure, filesystem", name)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
We already implement `ObjectClient` for various storages but `NewObjectClient` was allowing them all. This PR adds support for them.
It also adds a call to `File.Flush` method in `PutObject` method of filesystem type to make it flush the file to disk immediately.
