### PR TITLE
Decouple gRPC health check service from ingesters

### DIFF
--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"os"
 
+	"google.golang.org/grpc/health/grpc_health_v1"
+
 	"github.com/cortexproject/cortex/pkg/configs"
 	"github.com/cortexproject/cortex/pkg/storegateway"
 
@@ -316,8 +318,10 @@ func (t *Cortex) Run() error {
 		return err
 	}
 
-	// before starting servers, register /ready handler. It should reflect entire Cortex.
+	// before starting servers, register /ready handler and gRPC health check service.
+	// It should reflect entire Cortex.
 	t.server.HTTP.Path("/ready").Handler(t.readyHandler(sm))
+	grpc_health_v1.RegisterHealthServer(t.server.GRPC, newHealthCheck(sm))
 
 	// Let's listen for events from this manager, and log them.
 	healthy := func() { level.Info(util.Logger).Log("msg", "Cortex started") }

--- a/pkg/cortex/health_check.go
+++ b/pkg/cortex/health_check.go
@@ -1,0 +1,35 @@
+package cortex
+
+import (
+	"context"
+
+	"github.com/gogo/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+type healthCheck struct {
+	sm *services.Manager
+}
+
+func newHealthCheck(sm *services.Manager) *healthCheck {
+	return &healthCheck{
+		sm: sm,
+	}
+}
+
+// Check implements the grpc healthcheck.
+func (h *healthCheck) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	if !h.sm.IsHealthy() {
+		return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+	}
+
+	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}
+
+// Watch implements the grpc healthcheck.
+func (h *healthCheck) Watch(_ *grpc_health_v1.HealthCheckRequest, _ grpc_health_v1.Health_WatchServer) error {
+	return status.Error(codes.Unimplemented, "Watching is not supported")
+}

--- a/pkg/cortex/health_check.go
+++ b/pkg/cortex/health_check.go
@@ -22,7 +22,7 @@ func newHealthCheck(sm *services.Manager) *healthCheck {
 
 // Check implements the grpc healthcheck.
 func (h *healthCheck) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
-	if !h.sm.IsHealthy() {
+	if !h.isHealthy() {
 		return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
 	}
 
@@ -32,4 +32,19 @@ func (h *healthCheck) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequ
 // Watch implements the grpc healthcheck.
 func (h *healthCheck) Watch(_ *grpc_health_v1.HealthCheckRequest, _ grpc_health_v1.Health_WatchServer) error {
 	return status.Error(codes.Unimplemented, "Watching is not supported")
+}
+
+// isHealthy returns whether the Cortex instance should be considered healthy.
+func (h *healthCheck) isHealthy() bool {
+	states := h.sm.ServicesByState()
+
+	// Given this is an health check endpoint for the whole instance, we should consider
+	// it healthy after all services have been started (running) and until there's
+	// still a service stopping (because some services, like ingesters, are still
+	// fully functioning while stopping).
+	if len(states[services.New]) > 0 || len(states[services.Starting]) > 0 || len(states[services.Failed]) > 0 {
+		return false
+	}
+
+	return len(states[services.Running]) > 0 || len(states[services.Stopping]) > 0
 }

--- a/pkg/cortex/health_check.go
+++ b/pkg/cortex/health_check.go
@@ -39,9 +39,9 @@ func (h *healthCheck) isHealthy() bool {
 	states := h.sm.ServicesByState()
 
 	// Given this is an health check endpoint for the whole instance, we should consider
-	// it healthy after all services have been started (running) and until there's
-	// still a service stopping (because some services, like ingesters, are still
-	// fully functioning while stopping).
+	// it healthy after all services have been started (running) and until all
+	// services are terminated. Some services, like ingesters, are still
+	// fully functioning while stopping.
 	if len(states[services.New]) > 0 || len(states[services.Starting]) > 0 || len(states[services.Failed]) > 0 {
 		return false
 	}

--- a/pkg/cortex/health_check_test.go
+++ b/pkg/cortex/health_check_test.go
@@ -1,0 +1,146 @@
+package cortex
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+func TestHealthCheck_isHealthy(t *testing.T) {
+	tests := map[string]struct {
+		states   []services.State
+		expected bool
+	}{
+		"all services are new": {
+			states:   []services.State{services.New, services.New},
+			expected: false,
+		},
+		"all services are starting": {
+			states:   []services.State{services.Starting, services.Starting},
+			expected: false,
+		},
+		"some services are starting and some running": {
+			states:   []services.State{services.Starting, services.Running},
+			expected: false,
+		},
+		"all services are running": {
+			states:   []services.State{services.Running, services.Running},
+			expected: true,
+		},
+		"some services are stopping": {
+			states:   []services.State{services.Running, services.Stopping},
+			expected: true,
+		},
+		"some services are terminated while others running": {
+			states:   []services.State{services.Running, services.Terminated},
+			expected: true,
+		},
+		"all services are stopping": {
+			states:   []services.State{services.Stopping, services.Stopping},
+			expected: true,
+		},
+		"some services are terminated while others stopping": {
+			states:   []services.State{services.Stopping, services.Terminated},
+			expected: true,
+		},
+		"a service has failed while others are running": {
+			states:   []services.State{services.Running, services.Failed},
+			expected: false,
+		},
+		"all services are terminated": {
+			states:   []services.State{services.Terminated, services.Terminated},
+			expected: false,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			var svcs []services.Service
+			for _ = range testData.states {
+				svcs = append(svcs, &mockService{})
+			}
+
+			sm, err := services.NewManager(svcs...)
+			require.NoError(t, err)
+
+			// Switch the state of each mocked services.
+			for i, s := range svcs {
+				s.(*mockService).switchState(testData.states[i])
+			}
+
+			h := newHealthCheck(sm)
+			assert.Equal(t, testData.expected, h.isHealthy())
+		})
+	}
+}
+
+type mockService struct {
+	services.Service
+	state     services.State
+	listeners []services.Listener
+}
+
+func (s *mockService) switchState(desiredState services.State) {
+	// Simulate all the states between the current state and the desired one.
+	orderedStates := []services.State{services.New, services.Starting, services.Running, services.Failed, services.Stopping, services.Terminated}
+	simulationStarted := false
+
+	for _, orderedState := range orderedStates {
+		// Skip until we reach the current state.
+		if !simulationStarted && orderedState != s.state {
+			continue
+		}
+
+		// Start the simulation once we reach the current state.
+		if orderedState == s.state {
+			simulationStarted = true
+			continue
+		}
+
+		// Skip the failed state, unless it's the desired one.
+		if orderedState == services.Failed && desiredState != services.Failed {
+			continue
+		}
+
+		s.state = orderedState
+
+		// Synchronously call listeners to avoid flaky tests.
+		for _, listener := range s.listeners {
+			switch orderedState {
+			case services.Starting:
+				listener.Starting()
+			case services.Running:
+				listener.Running()
+			case services.Stopping:
+				listener.Stopping(services.Running)
+			case services.Failed:
+				listener.Failed(services.Running, errors.New("mocked error"))
+			case services.Terminated:
+				listener.Terminated(services.Stopping)
+			}
+		}
+
+		if orderedState == desiredState {
+			break
+		}
+	}
+}
+
+func (s *mockService) State() services.State {
+	return s.state
+}
+
+func (s *mockService) AddListener(listener services.Listener) {
+	s.listeners = append(s.listeners, listener)
+}
+
+func (s *mockService) StartAsync(_ context.Context) error      { return nil }
+func (s *mockService) AwaitRunning(_ context.Context) error    { return nil }
+func (s *mockService) StopAsync()                              {}
+func (s *mockService) AwaitTerminated(_ context.Context) error { return nil }
+func (s *mockService) FailureCase() error                      { return nil }

--- a/pkg/cortex/health_check_test.go
+++ b/pkg/cortex/health_check_test.go
@@ -61,7 +61,7 @@ func TestHealthCheck_isHealthy(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			var svcs []services.Service
-			for _ = range testData.states {
+			for range testData.states {
 				svcs = append(svcs, &mockService{})
 			}
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -17,7 +17,6 @@ import (
 	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
-	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager"
 	"github.com/cortexproject/cortex/pkg/chunk"
@@ -270,7 +269,6 @@ func (t *Cortex) initIngester(cfg *Config) (serv services.Service, err error) {
 	}
 
 	client.RegisterIngesterServer(t.server.GRPC, t.ingester)
-	grpc_health_v1.RegisterHealthServer(t.server.GRPC, t.ingester)
 	t.server.HTTP.Path("/flush").Handler(http.HandlerFunc(t.ingester.FlushHandler))
 	t.server.HTTP.Path("/shutdown").Handler(http.HandlerFunc(t.ingester.ShutdownHandler))
 	t.server.HTTP.Handle("/push", t.httpAuthMiddleware.Wrap(push.Handler(cfg.Distributor, t.ingester.Push)))

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -17,7 +17,6 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/health/grpc_health_v1"
 
 	cortex_chunk "github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
@@ -792,20 +791,6 @@ func (i *Ingester) AllUserStats(ctx context.Context, req *client.UserStatsReques
 		})
 	}
 	return response, nil
-}
-
-// Check implements the grpc healthcheck
-func (i *Ingester) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
-	if err := i.checkRunningOrStopping(); err != nil {
-		return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
-	}
-
-	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
-}
-
-// Watch implements the grpc healthcheck.
-func (i *Ingester) Watch(in *grpc_health_v1.HealthCheckRequest, stream grpc_health_v1.Health_WatchServer) error {
-	return status.Error(codes.Unimplemented, "Watching is not supported")
 }
 
 // CheckReady is the readiness handler used to indicate to k8s when the ingesters


### PR DESCRIPTION
**What this PR does**:
In order to build the `store-gateway` service ([proposal](https://cortexmetrics.io/docs/proposals/blocks-storage-sharding/)), I would need to be able to do gRPC health checks against the `store-gateway` when running in microservices mode. However, the gRPC health check service is currently registered by the ingester so can't be also registered in other places (otherwise it clashes).

Given the `Ingester.Check()` implementation is not ingester-specific (it just checks if the ingester service is running/stopping), in this PR I'm proposing to generalise the gRPC health check service registration and mark the Cortex instance as healthy once all services are running, making it consistent with the `/ready` endpoint.

Notes:
- ~~`services.Manager.IsHealthy()` returns true after all services are running and until all of them are stopped (so stopping is considered as healthy, @pstibrany correct me if I'm wrong)~~
- Loki is not affected by this change

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
