### PR TITLE
Expose blocks_meta_synced metric.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * `cortex_querier_bucket_store_blocks_meta_sync_consistency_delay_seconds` > `cortex_querier_blocks_meta_sync_consistency_delay_seconds`
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
 * [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383 
+* [CHANGE] Added `cortex_querier_blocks_meta_synced`, which reflects current state of synced blocks over all tenants. #2392
 
 ## 1.0.0 / 2020-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   * `cortex_querier_bucket_store_blocks_meta_sync_consistency_delay_seconds` > `cortex_querier_blocks_meta_sync_consistency_delay_seconds`
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
 * [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383 
-* [CHANGE] Added `cortex_querier_blocks_meta_synced`, which reflects current state of synced blocks over all tenants. #2392
+* [ENHANCEMENT] Experimental TSDB: Added `cortex_querier_blocks_meta_synced`, which reflects current state of synced blocks over all tenants. #2392
 
 ## 1.0.0 / 2020-04-02
 

--- a/pkg/querier/blocks_meta_fetcher_metrics.go
+++ b/pkg/querier/blocks_meta_fetcher_metrics.go
@@ -20,9 +20,9 @@ type metaFetcherMetrics struct {
 	syncFailures         *prometheus.Desc
 	syncDuration         *prometheus.Desc
 	syncConsistencyDelay *prometheus.Desc
+	synced               *prometheus.Desc
 
 	// Ignored:
-	// blocks_meta_synced
 	// blocks_meta_modified
 }
 
@@ -46,6 +46,10 @@ func newMetaFetcherMetrics() *metaFetcherMetrics {
 			"cortex_querier_blocks_meta_sync_consistency_delay_seconds",
 			"Configured consistency delay in seconds.",
 			nil, nil),
+		synced: prometheus.NewDesc(
+			"cortex_querier_blocks_meta_synced",
+			"Reflects current state of synced blocks (over all tenants).",
+			[]string{"state"}, nil),
 	}
 }
 
@@ -73,6 +77,7 @@ func (m *metaFetcherMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.syncFailures
 	out <- m.syncDuration
 	out <- m.syncConsistencyDelay
+	out <- m.synced
 }
 
 func (m *metaFetcherMetrics) Collect(out chan<- prometheus.Metric) {
@@ -82,4 +87,5 @@ func (m *metaFetcherMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCounters(out, m.syncFailures, "blocks_meta_sync_failures_total")
 	data.SendSumOfHistograms(out, m.syncDuration, "blocks_meta_sync_duration_seconds")
 	data.SendMaxOfGauges(out, m.syncConsistencyDelay, "consistency_delay_seconds")
+	data.SendSumOfGaugesWithLabels(out, m.synced, "blocks_meta_synced", "state")
 }


### PR DESCRIPTION
**What this PR does**: this PR exposes `blocks_meta_synced` metric from Thanos meta fetcher component as `cortex_querier_blocks_meta_synced`.  In Cortex, this metric reflects current state of synced blocks over all tenants.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
