### PR TITLE
Fixed chunk data corruption when querying back series using the blocks storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [ENHANCEMENT] Experimental TSDB: Added `cortex_querier_blocks_meta_synced`, which reflects current state of synced blocks over all tenants. #2392
 * [ENHANCEMENT] Added `cortex_distributor_latest_seen_sample_timestamp_seconds` metric to see how far behind Prometheus servers are in sending data. #2371
 * [ENHANCEMENT] FIFO cache to support eviction based on memory usage. The `-<prefix>.fifocache.size` CLI flag has been renamed to `-<prefix>.fifocache.max-size-items` as well as its YAML config option `size` renamed to `max_size_items`. Added `-<prefix>.fifocache.max-size-bytes` CLI flag and YAML config option `max_size_bytes` to specify memory limit of the cache. #2319
+* [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage.
 
 ## 1.0.0 / 2020-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * [ENHANCEMENT] Experimental TSDB: Added `cortex_querier_blocks_meta_synced`, which reflects current state of synced blocks over all tenants. #2392
 * [ENHANCEMENT] Added `cortex_distributor_latest_seen_sample_timestamp_seconds` metric to see how far behind Prometheus servers are in sending data. #2371
 * [ENHANCEMENT] FIFO cache to support eviction based on memory usage. The `-<prefix>.fifocache.size` CLI flag has been renamed to `-<prefix>.fifocache.max-size-items` as well as its YAML config option `size` renamed to `max_size_items`. Added `-<prefix>.fifocache.max-size-bytes` CLI flag and YAML config option `max_size_bytes` to specify memory limit of the cache. #2319
-* [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage.
+* [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400
 
 ## 1.0.0 / 2020-04-02
 


### PR DESCRIPTION
**What this PR does**:
In the PR #2324 I've introduced a severe issue affecting the blocks storage which cause corrupted chunk data when querying back series using the blocks storage. In this PR I'm picking the safest approach and copying the entire Series response.

The reason why I've not done any optimisation to reduce memory allocations is:
1. It's not worse than the state before PR #2324
2. The `store-gateway` (which we expect to merge in the next few weeks) will remove `bucketStoreSeriesServer` at all

**Which issue(s) this PR fixes**:
Fixes #2396

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
