### PR TITLE
Handle cache-control headers also during a partial cache hit.

### DIFF
--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -170,24 +170,17 @@ func (s resultsCache) Do(ctx context.Context, r Request) (Response, error) {
 // shouldCacheResponse says whether the response should be cached or not.
 func (s resultsCache) shouldCacheResponse(r Response) bool {
 	if promResp, ok := r.(*PrometheusResponse); ok {
-		shouldCache := true
-	outer:
 		for _, hv := range promResp.Headers {
-			if hv == nil {
+			if hv.GetName() != cachecontrolHeader {
 				continue
 			}
-			if hv.Name != cachecontrolHeader {
-				continue
-			}
-			for _, v := range hv.Values {
+			for _, v := range hv.GetValues() {
 				if v == noCacheValue {
-					shouldCache = false
 					level.Debug(s.logger).Log("msg", fmt.Sprintf("%s header in response is equal to %s, not caching the response", cachecontrolHeader, noCacheValue))
-					break outer
+					return false
 				}
 			}
 		}
-		return shouldCache
 	}
 	return true
 }

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
 
@@ -96,6 +97,7 @@ func mkExtent(start, end int64) Extent {
 }
 
 func TestShouldCache(t *testing.T) {
+	c := &resultsCache{logger: util.Logger}
 	for i, tc := range []struct {
 		input    Response
 		expected bool
@@ -139,7 +141,7 @@ func TestShouldCache(t *testing.T) {
 	} {
 		{
 			t.Run(strconv.Itoa(i), func(t *testing.T) {
-				ret := shouldCacheResponse(tc.input)
+				ret := c.shouldCacheResponse(tc.input)
 				require.Equal(t, tc.expected, ret)
 			})
 		}

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -138,6 +138,23 @@ func TestShouldCache(t *testing.T) {
 			}),
 			expected: false,
 		},
+		// some broken responses
+		{
+			input:    Response(&PrometheusResponse{}),
+			expected: true,
+		},
+		{
+			input: Response(&PrometheusResponse{
+				Headers: []*PrometheusResponseHeader{nil},
+			}),
+			expected: true,
+		},
+		{
+			input: Response(&PrometheusResponse{
+				Headers: []*PrometheusResponseHeader{{Name: cachecontrolHeader}},
+			}),
+			expected: true,
+		},
 	} {
 		{
 			t.Run(strconv.Itoa(i), func(t *testing.T) {


### PR DESCRIPTION
I was reading this code and realize that #1974 missed a place where we also query downstream for partial result in case of partial cache hit.

I've chatted about this with on Thanos dev and suggested to send a fix for them.

/cc @GiedriusS 

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
