### PR TITLE
BugFix: 1.0 Ingesters having availability zone value erased by pre-1.0 ingesters during rolling upgrade.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400
 * [BUGFIX] Cassandra Storage: Fix endpoint TLS host verification. #2109
 * [BUGFIX] Experimental TSDB: fixed response status code from `422` to `500` when an error occurs while iterating chunks with the experimental blocks storage. #2402
+* [BUGFIX] Ring: Fixed a situation where upgrading from pre-1.0 cortex with a rolling strategy caused new 1.0 ingesters to lose their zone value in the ring until manually forced to re-register. #2404
 
 ## 1.0.0 / 2020-04-02
 

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -667,6 +667,7 @@ func (i *Lifecycler) updateConsul(ctx context.Context) error {
 			ingesterDesc.Timestamp = time.Now().Unix()
 			ingesterDesc.State = i.GetState()
 			ingesterDesc.Addr = i.Addr
+			ingesterDesc.Zone = i.Zone
 			ringDesc.Ingesters[i.ID] = ingesterDesc
 		}
 

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -162,10 +162,6 @@ func NewLifecycler(cfg LifecyclerConfig, flushTransferer FlushTransferer, ringNa
 		util.WarnExperimentalUse("Zone aware replication")
 	}
 
-	if zone == "" {
-		zone = cfg.ID
-	}
-
 	// We do allow a nil FlushTransferer, but to keep the ring logic easier we assume
 	// it's always set, so we use a noop FlushTransferer
 	if flushTransferer == nil {


### PR DESCRIPTION

**What this PR does**: Corrects a bug reported by @pracucci when upgrading ingesters from pre-1.0, which causes the new ingesters to have their availability zone string overwritten by a blank value. This PR addresses the issue by having the ingesters update the ring data with their zone on every heartbeat, similar to what they do with address information.

**Which issue(s) this PR fixes**:
Fixes #2401 

**Checklist**
- [ x ] Tests updated
- [ X ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
