### PR TITLE
Introduced BasicLifecycler

### DIFF
--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -1,0 +1,474 @@
+package ring
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/cortexproject/cortex/pkg/ring/kv"
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+type BasicLifecyclerDelegate interface {
+	// OnRingInstanceRegister is called while the lifecycler is registering the
+	// instance within the ring and should return the state and set of tokens to
+	// use for the instance itself.
+	OnRingInstanceRegister(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens)
+
+	// OnRingInstanceTokens is called once the instance tokens are set and are
+	// stable within the ring (honoring the observe period, if set).
+	OnRingInstanceTokens(lifecycler *BasicLifecycler, tokens Tokens)
+
+	// OnRingInstanceStopping is called while the lifecycler is stopping. The lifecycler
+	// will continue to hearbeat the ring the this function is executing and will proceed
+	// to unregister the instance from the ring only after this function has returned.
+	OnRingInstanceStopping(lifecycler *BasicLifecycler)
+}
+
+type OnRingInstanceRegister func(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens)
+type OnRingInstanceTokensChanged func(lifecycler *BasicLifecycler, tokens Tokens)
+type OnRingInstanceStopping func(lifecycler *BasicLifecycler)
+
+type BasicLifecyclerConfig struct {
+	InstanceID          string
+	InstanceAddr        string
+	InstancePort        int
+	InstanceZone        string
+	KVStore             kv.Config
+	HeartbeatPeriod     time.Duration
+	TokensObservePeriod time.Duration
+	NumTokens           int
+}
+
+// BasicLifecycler is a basic ring lifecycler which allows to hook custom
+// logic at different stages of the lifecycle. This lifecycler should be
+// used to build higher level lifecyclers.
+//
+// Contract:
+// 1. This lifecycler never change the instance state. It's the delegate
+//    responsibility to ChangeState().
+type BasicLifecycler struct {
+	*services.BasicService
+
+	cfg      BasicLifecyclerConfig
+	logger   log.Logger
+	store    kv.Client
+	delegate BasicLifecyclerDelegate
+	metrics  *BasicLifecyclerMetrics
+
+	// Channel used to execute logic within the lifecycler loop.
+	actorChan chan func()
+
+	// These values are initialised at startup, and never change
+	instanceID   string
+	instanceAddr string
+	instanceZone string
+	ringName     string
+	ringKey      string
+
+	// The current instance state.
+	currState        sync.RWMutex
+	currInstanceDesc *IngesterDesc
+}
+
+// NewBasicLifecycler makes a new BasicLifecycler.
+func NewBasicLifecycler(cfg BasicLifecyclerConfig, ringName, ringKey string, delegate BasicLifecyclerDelegate, logger log.Logger, reg prometheus.Registerer) (*BasicLifecycler, error) {
+	store, err := kv.NewClient(cfg.KVStore, GetCodec())
+	if err != nil {
+		return nil, errors.Wrap(err, "create KV store client")
+	}
+
+	return NewBasicLifecyclerWithStoreClient(cfg, ringName, ringKey, store, delegate, logger, reg)
+}
+
+// NewBasicLifecycler makes a new BasicLifecycler.
+func NewBasicLifecyclerWithStoreClient(cfg BasicLifecyclerConfig, ringName, ringKey string, store kv.Client, delegate BasicLifecyclerDelegate, logger log.Logger, reg prometheus.Registerer) (*BasicLifecycler, error) {
+	instanceAddr := fmt.Sprintf("%s:%d", cfg.InstanceAddr, cfg.InstancePort)
+
+	l := &BasicLifecycler{
+		cfg:          cfg,
+		instanceID:   cfg.InstanceID,
+		instanceAddr: instanceAddr,
+		instanceZone: cfg.InstanceZone,
+		ringName:     ringName,
+		ringKey:      ringKey,
+		logger:       logger,
+		store:        store,
+		delegate:     delegate,
+		metrics:      NewBasicLifecyclerMetrics(ringName, reg),
+		actorChan:    make(chan func()),
+	}
+
+	l.metrics.tokensToOwn.Set(float64(cfg.NumTokens))
+	l.BasicService = services.NewBasicService(l.starting, l.running, l.stopping)
+
+	return l, nil
+}
+
+func (l *BasicLifecycler) GetInstanceID() string {
+	return l.instanceID
+}
+
+func (l *BasicLifecycler) GetInstanceAddr() string {
+	return l.instanceAddr
+}
+
+func (l *BasicLifecycler) GetInstanceZone() string {
+	return l.instanceZone
+}
+
+func (l *BasicLifecycler) GetState() IngesterState {
+	l.currState.RLock()
+	defer l.currState.RUnlock()
+
+	if l.currInstanceDesc == nil {
+		return PENDING
+	}
+
+	return l.currInstanceDesc.GetState()
+}
+
+func (l *BasicLifecycler) GetTokens() Tokens {
+	l.currState.RLock()
+	defer l.currState.RUnlock()
+
+	if l.currInstanceDesc == nil {
+		return Tokens{}
+	}
+
+	return l.currInstanceDesc.GetTokens()
+}
+
+// IsRegistered returns whether the instance is currently registered within the ring.
+func (l *BasicLifecycler) IsRegistered() bool {
+	l.currState.RLock()
+	defer l.currState.RUnlock()
+
+	return l.currInstanceDesc != nil
+}
+
+func (l *BasicLifecycler) ChangeState(ctx context.Context, state IngesterState) error {
+	return l.run(func() error {
+		return l.changeState(ctx, state)
+	})
+}
+
+func (l *BasicLifecycler) starting(ctx context.Context) error {
+	if err := l.registerInstance(ctx); err != nil {
+		return errors.Wrap(err, "register instance in the ring")
+	}
+
+	// If we have registered an instance with some tokens and
+	// an observe period has been configured, we should now wait
+	// until tokens are "stable" within the ring.
+	if len(l.GetTokens()) > 0 && l.cfg.TokensObservePeriod > 0 {
+		if err := l.waitStableTokens(ctx, l.cfg.TokensObservePeriod); err != nil {
+			return errors.Wrap(err, "wait stable tokens in the ring")
+		}
+	}
+
+	// At this point, if some tokens have been set they're stable and we
+	// can notify the delegate.
+	if tokens := l.GetTokens(); len(tokens) > 0 {
+		l.metrics.tokensOwned.Set(float64(len(tokens)))
+		l.delegate.OnRingInstanceTokens(l, tokens)
+	}
+
+	return nil
+}
+
+func (l *BasicLifecycler) running(ctx context.Context) error {
+	heartbeatTicker := time.NewTicker(l.cfg.HeartbeatPeriod)
+	defer heartbeatTicker.Stop()
+
+	for {
+		select {
+		case <-heartbeatTicker.C:
+			l.heartbeat(ctx)
+
+		case f := <-l.actorChan:
+			f()
+
+		case <-ctx.Done():
+			level.Info(util.Logger).Log("msg", "ring lifecycler is shutting down", "ring", l.ringName)
+			return nil
+		}
+	}
+}
+
+func (l *BasicLifecycler) stopping(runningError error) error {
+	if runningError != nil {
+		return nil
+	}
+
+	// Let the delegate change the instance state (ie. to LEAVING) and handling any
+	// state transferring / flushing while we continue to heartbeat.
+	done := make(chan struct{})
+	go func() {
+		l.delegate.OnRingInstanceStopping(l)
+		close(done)
+	}()
+
+	// Heartbeat while the stopping delegate function is running.
+	heartbeatTicker := time.NewTicker(l.cfg.HeartbeatPeriod)
+	defer heartbeatTicker.Stop()
+
+heartbeatLoop:
+	for {
+		select {
+		case <-heartbeatTicker.C:
+			l.heartbeat(context.Background())
+		case <-done:
+			break heartbeatLoop
+		}
+	}
+
+	// Remove the instance from the ring.
+	if err := l.unregisterInstance(context.Background()); err != nil {
+		return errors.Wrapf(err, "failed to unregister instance from the ring (ring: %s)", l.ringName)
+	}
+	level.Info(l.logger).Log("msg", "instance removed from the ring", "ring", l.ringName)
+
+	return nil
+}
+
+// registerInstance registers the instance in the ring. The initial state and set of tokens
+// depends on the OnRingInstanceRegister() delegate function.
+func (l *BasicLifecycler) registerInstance(ctx context.Context) error {
+	var instanceDesc IngesterDesc
+
+	err := l.store.CAS(ctx, l.ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		ringDesc := getOrCreateRingDesc(in)
+
+		var exists bool
+		instanceDesc, exists = ringDesc.Ingesters[l.instanceID]
+		if exists {
+			level.Info(l.logger).Log("msg", "instance found in the ring", "instance", l.instanceID, "ring", l.ringName, "state", instanceDesc.GetState(), "tokens", len(instanceDesc.GetTokens()))
+		} else {
+			level.Info(l.logger).Log("msg", "instance not found in the ring", "instance", l.instanceID, "ring", l.ringName)
+		}
+
+		// We call the delegate to get the desired state right after the initialization.
+		state, tokens := l.delegate.OnRingInstanceRegister(l, *ringDesc, exists, l.instanceID, instanceDesc)
+
+		// Ensure tokens are sorted.
+		sort.Sort(tokens)
+
+		if !exists {
+			instanceDesc = ringDesc.AddIngester(l.instanceID, l.instanceAddr, l.instanceZone, tokens, state)
+			return ringDesc, true, nil
+		}
+
+		if instanceDesc.State != state || !tokens.Equals(instanceDesc.Tokens) {
+			instanceDesc = ringDesc.AddIngester(l.instanceID, l.instanceAddr, l.instanceZone, tokens, state)
+			return ringDesc, true, nil
+		}
+
+		// We haven't modified the ring, so don't try to store it.
+		return nil, true, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	l.currState.Lock()
+	l.currInstanceDesc = &instanceDesc
+	l.currState.Unlock()
+
+	return nil
+}
+
+func (l *BasicLifecycler) waitStableTokens(ctx context.Context, period time.Duration) error {
+	heartbeatTicker := time.NewTicker(l.cfg.HeartbeatPeriod)
+	defer heartbeatTicker.Stop()
+
+	// The first observation will occur after the specified period.
+	level.Info(l.logger).Log("msg", "waiting stable tokens", "ring", l.ringName)
+	observeChan := time.After(period)
+
+	for {
+		select {
+		case <-observeChan:
+			if !l.verifyTokens(ctx) {
+				// The verification has failed
+				level.Info(l.logger).Log("msg", "tokens verification failed, keep observing", "ring", l.ringName)
+				observeChan = time.After(period)
+				break
+			}
+
+			level.Info(l.logger).Log("msg", "tokens verification succeeded", "ring", l.ringName)
+			return nil
+
+		case <-heartbeatTicker.C:
+			l.heartbeat(ctx)
+
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// Verifies that tokens that this instance has registered to the ring still belong to it.
+// Gossiping ring may change the ownership of tokens in case of conflicts.
+// If instance doesn't own its tokens anymore, this method generates new tokens and stores them to the ring.
+func (l *BasicLifecycler) verifyTokens(ctx context.Context) bool {
+	result := false
+
+	err := l.updateInstance(ctx, func(r Desc, i *IngesterDesc) bool {
+		// At this point, we should have the same tokens as we have registered before.
+		actualTokens, takenTokens := r.TokensFor(l.instanceID)
+
+		if actualTokens.Equals(l.GetTokens()) {
+			// Tokens have been verified. No need to change them.
+			result = true
+			return false
+		}
+
+		// uh, oh... our tokens are not our anymore. Let's try new ones.
+		needTokens := l.cfg.NumTokens - len(actualTokens)
+
+		level.Info(l.logger).Log("msg", "generating new tokens", "count", needTokens, "ring", l.ringName)
+		newTokens := GenerateTokens(needTokens, takenTokens)
+
+		actualTokens = append(actualTokens, newTokens...)
+		sort.Sort(actualTokens)
+
+		i.Tokens = actualTokens
+		return true
+	})
+
+	if err != nil {
+		level.Error(l.logger).Log("msg", "failed to verify tokens", "ring", l.ringName, "err", err)
+		return false
+	}
+
+	return result
+}
+
+// unregister removes our entry from the store.
+func (l *BasicLifecycler) unregisterInstance(ctx context.Context) error {
+	level.Info(l.logger).Log("msg", "unregistering instance from ring", "ring", l.ringName)
+
+	err := l.store.CAS(ctx, l.ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		if in == nil {
+			return nil, false, fmt.Errorf("found empty ring when trying to unregister")
+		}
+
+		ringDesc := in.(*Desc)
+		ringDesc.RemoveIngester(l.instanceID)
+		return ringDesc, true, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	l.currState.Lock()
+	l.currInstanceDesc = nil
+	l.currState.Unlock()
+
+	l.metrics.tokensToOwn.Set(0)
+	l.metrics.tokensOwned.Set(0)
+	return nil
+}
+
+func (l *BasicLifecycler) updateInstance(ctx context.Context, update func(Desc, *IngesterDesc) bool) error {
+	var instanceDesc IngesterDesc
+
+	err := l.store.CAS(ctx, l.ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		ringDesc := getOrCreateRingDesc(in)
+
+		var ok bool
+		instanceDesc, ok = ringDesc.Ingesters[l.instanceID]
+
+		// This could happen if the backend store restarted (and content deleted)
+		// or the instance has been forgotten. In this case, we do re-insert it.
+		if !ok {
+			level.Warn(l.logger).Log("msg", "instance missing in the ring, adding it back", "ring", l.ringName)
+			instanceDesc = ringDesc.AddIngester(l.instanceID, l.instanceAddr, l.instanceZone, l.GetTokens(), l.GetState())
+		}
+
+		changed := update(*ringDesc, &instanceDesc)
+		if !changed {
+			return nil, false, nil
+		}
+
+		ringDesc.Ingesters[l.instanceID] = instanceDesc
+		return ringDesc, true, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	l.currState.Lock()
+	l.currInstanceDesc = &instanceDesc
+	l.currState.Unlock()
+
+	return nil
+}
+
+// heartbeat updates the instance timestamp within the ring. This function is guaranteed
+// to be called within the lifecycler main goroutine.
+func (l *BasicLifecycler) heartbeat(ctx context.Context) {
+	err := l.updateInstance(ctx, func(_ Desc, i *IngesterDesc) bool {
+		i.Timestamp = time.Now().Unix()
+		return true
+	})
+
+	if err != nil {
+		level.Warn(l.logger).Log("msg", "failed to heartbeat instance in the ring", "ring", l.ringName, "err", err)
+		return
+	}
+
+	l.metrics.heartbeats.Inc()
+}
+
+// changeState of the instance within the ring. This function is guaranteed
+// to be called within the lifecycler main goroutine.
+func (l *BasicLifecycler) changeState(ctx context.Context, state IngesterState) error {
+	err := l.updateInstance(ctx, func(_ Desc, i *IngesterDesc) bool {
+		// No-op if the state hasn't changed.
+		if i.State == state {
+			return false
+		}
+
+		i.State = state
+		return true
+	})
+
+	if err != nil {
+		level.Warn(l.logger).Log("msg", "failed to change instance state in the ring", "from", l.GetState(), "to", state, "err", err)
+	}
+
+	return err
+}
+
+// run a function within the lifecycler service goroutine.
+func (l *BasicLifecycler) run(fn func() error) error {
+	sc := l.ServiceContext()
+	if sc == nil {
+		return errors.New("lifecycler not running")
+	}
+
+	errCh := make(chan error)
+	wrappedFn := func() {
+		errCh <- fn()
+	}
+
+	select {
+	case <-sc.Done():
+		return errors.New("lifecycler not running")
+	case l.actorChan <- wrappedFn:
+		return <-errCh
+	}
+}

--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -44,7 +44,6 @@ type BasicLifecyclerConfig struct {
 	// if zone awareness is unused.
 	Zone string
 
-	KVStore             kv.Config
 	HeartbeatPeriod     time.Duration
 	TokensObservePeriod time.Duration
 	NumTokens           int
@@ -78,17 +77,7 @@ type BasicLifecycler struct {
 }
 
 // NewBasicLifecycler makes a new BasicLifecycler.
-func NewBasicLifecycler(cfg BasicLifecyclerConfig, ringName, ringKey string, delegate BasicLifecyclerDelegate, logger log.Logger, reg prometheus.Registerer) (*BasicLifecycler, error) {
-	store, err := kv.NewClient(cfg.KVStore, GetCodec())
-	if err != nil {
-		return nil, errors.Wrap(err, "create KV store client")
-	}
-
-	return NewBasicLifecyclerWithStoreClient(cfg, ringName, ringKey, store, delegate, logger, reg)
-}
-
-// NewBasicLifecycler makes a new BasicLifecycler.
-func NewBasicLifecyclerWithStoreClient(cfg BasicLifecyclerConfig, ringName, ringKey string, store kv.Client, delegate BasicLifecyclerDelegate, logger log.Logger, reg prometheus.Registerer) (*BasicLifecycler, error) {
+func NewBasicLifecycler(cfg BasicLifecyclerConfig, ringName, ringKey string, store kv.Client, delegate BasicLifecyclerDelegate, logger log.Logger, reg prometheus.Registerer) (*BasicLifecycler, error) {
 	l := &BasicLifecycler{
 		cfg:       cfg,
 		ringName:  ringName,

--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -34,10 +34,16 @@ type BasicLifecyclerDelegate interface {
 }
 
 type BasicLifecyclerConfig struct {
-	InstanceID          string
-	InstanceAddr        string
-	InstancePort        int
-	InstanceZone        string
+	// ID is the instance unique ID.
+	ID string
+
+	// Addr is the instance address, in the form "address:port".
+	Addr string
+
+	// Zone is the instance availability zone. Can be an empty string
+	// if zone awareness is unused.
+	Zone string
+
 	KVStore             kv.Config
 	HeartbeatPeriod     time.Duration
 	TokensObservePeriod time.Duration
@@ -87,13 +93,11 @@ func NewBasicLifecycler(cfg BasicLifecyclerConfig, ringName, ringKey string, del
 
 // NewBasicLifecycler makes a new BasicLifecycler.
 func NewBasicLifecyclerWithStoreClient(cfg BasicLifecyclerConfig, ringName, ringKey string, store kv.Client, delegate BasicLifecyclerDelegate, logger log.Logger, reg prometheus.Registerer) (*BasicLifecycler, error) {
-	instanceAddr := fmt.Sprintf("%s:%d", cfg.InstanceAddr, cfg.InstancePort)
-
 	l := &BasicLifecycler{
 		cfg:          cfg,
-		instanceID:   cfg.InstanceID,
-		instanceAddr: instanceAddr,
-		instanceZone: cfg.InstanceZone,
+		instanceID:   cfg.ID,
+		instanceAddr: cfg.Addr,
+		instanceZone: cfg.Zone,
 		ringName:     ringName,
 		ringKey:      ringKey,
 		logger:       logger,

--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -380,7 +380,7 @@ func (l *BasicLifecycler) updateInstance(ctx context.Context, update func(Desc, 
 		}
 
 		changed := update(*ringDesc, &instanceDesc)
-		if !changed {
+		if ok && !changed {
 			return nil, false, nil
 		}
 

--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -33,10 +33,6 @@ type BasicLifecyclerDelegate interface {
 	OnRingInstanceStopping(lifecycler *BasicLifecycler)
 }
 
-type OnRingInstanceRegister func(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens)
-type OnRingInstanceTokensChanged func(lifecycler *BasicLifecycler, tokens Tokens)
-type OnRingInstanceStopping func(lifecycler *BasicLifecycler)
-
 type BasicLifecyclerConfig struct {
 	InstanceID          string
 	InstanceAddr        string

--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -54,9 +54,8 @@ type BasicLifecyclerConfig struct {
 // logic at different stages of the lifecycle. This lifecycler should be
 // used to build higher level lifecyclers.
 //
-// Contract:
-// 1. This lifecycler never change the instance state. It's the delegate
-//    responsibility to ChangeState().
+// This lifecycler never change the instance state. It's the delegate
+// responsibility to ChangeState().
 type BasicLifecycler struct {
 	*services.BasicService
 

--- a/pkg/ring/basic_lifecycler_delegates.go
+++ b/pkg/ring/basic_lifecycler_delegates.go
@@ -1,0 +1,98 @@
+package ring
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+type LeaveOnStoppingDelegate struct {
+	next   BasicLifecyclerDelegate
+	logger log.Logger
+}
+
+func NewLeaveOnStoppingDelegate(next BasicLifecyclerDelegate, logger log.Logger) *LeaveOnStoppingDelegate {
+	return &LeaveOnStoppingDelegate{
+		next:   next,
+		logger: logger,
+	}
+}
+
+func (d *LeaveOnStoppingDelegate) OnRingInstanceRegister(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens) {
+	return d.next.OnRingInstanceRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
+}
+
+func (d *LeaveOnStoppingDelegate) OnRingInstanceTokens(lifecycler *BasicLifecycler, tokens Tokens) {
+	d.next.OnRingInstanceTokens(lifecycler, tokens)
+}
+
+func (d *LeaveOnStoppingDelegate) OnRingInstanceStopping(lifecycler *BasicLifecycler) {
+	if err := lifecycler.changeState(context.Background(), LEAVING); err != nil {
+		level.Error(d.logger).Log("msg", "failed to change instance state to LEAVING in the ring", "err", err)
+	}
+
+	d.next.OnRingInstanceStopping(lifecycler)
+}
+
+type TokensPersistencyDelegate struct {
+	next       BasicLifecyclerDelegate
+	logger     log.Logger
+	tokensPath string
+	loadState  IngesterState
+}
+
+func NewTokensPersistencyDelegate(path string, state IngesterState, next BasicLifecyclerDelegate, logger log.Logger) *TokensPersistencyDelegate {
+	return &TokensPersistencyDelegate{
+		next:       next,
+		logger:     logger,
+		tokensPath: path,
+		loadState:  state,
+	}
+}
+
+func (d *TokensPersistencyDelegate) OnRingInstanceRegister(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens) {
+	// Skip if no path has been configured.
+	if d.tokensPath == "" {
+		level.Info(d.logger).Log("msg", "not loading tokens from file, tokens file path is empty")
+		return d.next.OnRingInstanceRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
+	}
+
+	// Do not load tokens from disk if the instance is already in the ring.
+	if instanceExists {
+		level.Info(d.logger).Log("msg", "not loading tokens from file, instance already in the ring")
+		return d.next.OnRingInstanceRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
+	}
+
+	tokensFromFile, err := LoadTokensFromFile(d.tokensPath)
+	if err != nil {
+		level.Error(d.logger).Log("msg", "error in getting tokens from file", "err", err)
+		return d.next.OnRingInstanceRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
+	}
+
+	// Signal the next delegate that the tokens have been loaded, miming the
+	// case the instance exist in the ring (which is OK because the lifecycler
+	// will correctly reconcile this case too).
+	return d.next.OnRingInstanceRegister(lifecycler, ringDesc, true, lifecycler.GetInstanceID(), IngesterDesc{
+		Addr:      lifecycler.GetInstanceAddr(),
+		Timestamp: time.Now().Unix(),
+		State:     d.loadState,
+		Tokens:    tokensFromFile,
+		Zone:      lifecycler.GetInstanceZone(),
+	})
+}
+
+func (d *TokensPersistencyDelegate) OnRingInstanceTokens(lifecycler *BasicLifecycler, tokens Tokens) {
+	if d.tokensPath != "" {
+		if err := tokens.StoreToFile(d.tokensPath); err != nil {
+			level.Error(d.logger).Log("msg", "error storing tokens to disk", "path", d.tokensPath, "err", err)
+		}
+	}
+
+	d.next.OnRingInstanceTokens(lifecycler, tokens)
+}
+
+func (d *TokensPersistencyDelegate) OnRingInstanceStopping(lifecycler *BasicLifecycler) {
+	d.next.OnRingInstanceStopping(lifecycler)
+}

--- a/pkg/ring/basic_lifecycler_delegates.go
+++ b/pkg/ring/basic_lifecycler_delegates.go
@@ -59,8 +59,8 @@ func (d *TokensPersistencyDelegate) OnRingInstanceRegister(lifecycler *BasicLife
 		return d.next.OnRingInstanceRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
 	}
 
-	// Do not load tokens from disk if the instance is already in the ring.
-	if instanceExists {
+	// Do not load tokens from disk if the instance is already in the ring and has some tokens.
+	if instanceExists && len(instanceDesc.GetTokens()) > 0 {
 		level.Info(d.logger).Log("msg", "not loading tokens from file, instance already in the ring")
 		return d.next.OnRingInstanceRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
 	}

--- a/pkg/ring/basic_lifecycler_delegates_test.go
+++ b/pkg/ring/basic_lifecycler_delegates_test.go
@@ -1,0 +1,154 @@
+package ring
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+func TestLeaveOnStoppingDelegate(t *testing.T) {
+	onStoppingCalled := false
+
+	ctx := context.Background()
+	cfg := prepareBasicLifecyclerConfig()
+
+	testDelegate := &mockDelegate{
+		onStopping: func(l *BasicLifecycler) {
+			assert.Equal(t, LEAVING, l.GetState())
+			onStoppingCalled = true
+		},
+	}
+
+	leaveDelegate := NewLeaveOnStoppingDelegate(testDelegate, log.NewNopLogger())
+	lifecycler, _, err := prepareBasicLifecyclerWithDelegate(cfg, leaveDelegate)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+
+	assert.NoError(t, services.StopAndAwaitTerminated(ctx, lifecycler))
+	assert.True(t, onStoppingCalled)
+}
+
+func TestTokensPersistencyDelegate_ShouldSkipTokensLoadingIfFileDoesNotExist(t *testing.T) {
+	// Create a temporary file and immediately delete it.
+	tokensFile, err := ioutil.TempFile(os.TempDir(), "tokens-*")
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(tokensFile.Name()))
+
+	testDelegate := &mockDelegate{
+		onRegister: func(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens) {
+			assert.False(t, instanceExists)
+			return JOINING, Tokens{1, 2, 3, 4, 5}
+		},
+	}
+
+	leaveDelegate := NewTokensPersistencyDelegate(tokensFile.Name(), ACTIVE, testDelegate, log.NewNopLogger())
+
+	ctx := context.Background()
+	cfg := prepareBasicLifecyclerConfig()
+	lifecycler, _, err := prepareBasicLifecyclerWithDelegate(cfg, leaveDelegate)
+	require.NoError(t, err)
+	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+	assert.Equal(t, JOINING, lifecycler.GetState())
+	assert.Equal(t, Tokens{1, 2, 3, 4, 5}, lifecycler.GetTokens())
+	assert.True(t, lifecycler.IsRegistered())
+
+	require.NoError(t, services.StopAndAwaitTerminated(ctx, lifecycler))
+
+	// Ensure tokens have been stored.
+	actualTokens, err := LoadTokensFromFile(tokensFile.Name())
+	require.NoError(t, err)
+	assert.Equal(t, Tokens{1, 2, 3, 4, 5}, actualTokens)
+}
+
+func TestTokensPersistencyDelegate_ShouldLoadTokensFromFileIfFileExist(t *testing.T) {
+	tokensFile, err := ioutil.TempFile(os.TempDir(), "tokens-*")
+	require.NoError(t, err)
+	defer os.Remove(tokensFile.Name()) //nolint:errcheck
+
+	// Store some tokens to the file.
+	storedTokens := Tokens{6, 7, 8, 9, 10}
+	require.NoError(t, storedTokens.StoreToFile(tokensFile.Name()))
+
+	testDelegate := &mockDelegate{
+		onRegister: func(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens) {
+			assert.True(t, instanceExists)
+			assert.Equal(t, ACTIVE, instanceDesc.GetState())
+			assert.Equal(t, storedTokens, Tokens(instanceDesc.GetTokens()))
+
+			return instanceDesc.GetState(), instanceDesc.GetTokens()
+		},
+	}
+
+	leaveDelegate := NewTokensPersistencyDelegate(tokensFile.Name(), ACTIVE, testDelegate, log.NewNopLogger())
+
+	ctx := context.Background()
+	cfg := prepareBasicLifecyclerConfig()
+	lifecycler, _, err := prepareBasicLifecyclerWithDelegate(cfg, leaveDelegate)
+	require.NoError(t, err)
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+	assert.Equal(t, ACTIVE, lifecycler.GetState())
+	assert.Equal(t, storedTokens, lifecycler.GetTokens())
+	assert.True(t, lifecycler.IsRegistered())
+
+	require.NoError(t, services.StopAndAwaitTerminated(ctx, lifecycler))
+
+	// Ensure we can still read back the tokens file.
+	actualTokens, err := LoadTokensFromFile(tokensFile.Name())
+	require.NoError(t, err)
+	assert.Equal(t, storedTokens, actualTokens)
+}
+
+// TestDelegatesChain tests chaining all provided delegates together.
+func TestDelegatesChain(t *testing.T) {
+	onStoppingCalled := false
+
+	// Create a temporary file and immediately delete it.
+	tokensFile, err := ioutil.TempFile(os.TempDir(), "tokens-*")
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(tokensFile.Name()))
+
+	// Chain delegates together.
+	var chain BasicLifecyclerDelegate
+	chain = &mockDelegate{
+		onRegister: func(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens) {
+			assert.False(t, instanceExists)
+			return JOINING, Tokens{1, 2, 3, 4, 5}
+		},
+		onStopping: func(l *BasicLifecycler) {
+			assert.Equal(t, LEAVING, l.GetState())
+			onStoppingCalled = true
+		},
+	}
+
+	chain = NewTokensPersistencyDelegate(tokensFile.Name(), ACTIVE, chain, log.NewNopLogger())
+	chain = NewLeaveOnStoppingDelegate(chain, log.NewNopLogger())
+
+	ctx := context.Background()
+	cfg := prepareBasicLifecyclerConfig()
+	lifecycler, _, err := prepareBasicLifecyclerWithDelegate(cfg, chain)
+	require.NoError(t, err)
+	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+	assert.Equal(t, JOINING, lifecycler.GetState())
+	assert.Equal(t, Tokens{1, 2, 3, 4, 5}, lifecycler.GetTokens())
+	assert.True(t, lifecycler.IsRegistered())
+
+	require.NoError(t, services.StopAndAwaitTerminated(ctx, lifecycler))
+	assert.True(t, onStoppingCalled)
+
+	// Ensure tokens have been stored.
+	actualTokens, err := LoadTokensFromFile(tokensFile.Name())
+	require.NoError(t, err)
+	assert.Equal(t, Tokens{1, 2, 3, 4, 5}, actualTokens)
+}

--- a/pkg/ring/basic_lifecycler_delegates_test.go
+++ b/pkg/ring/basic_lifecycler_delegates_test.go
@@ -109,16 +109,11 @@ func TestTokensPersistencyDelegate_ShouldLoadTokensFromFileIfFileExist(t *testin
 }
 
 func TestTokensPersistencyDelegate_ShouldHandleTheCaseTheInstanceIsAlreadyInTheRing(t *testing.T) {
-	tokensFile, err := ioutil.TempFile(os.TempDir(), "tokens-*")
-	require.NoError(t, err)
-	defer os.Remove(tokensFile.Name()) //nolint:errcheck
-
-	// Store some tokens to the file.
 	storedTokens := Tokens{6, 7, 8, 9, 10}
 	differentTokens := Tokens{1, 2, 3, 4, 5}
-	require.NoError(t, storedTokens.StoreToFile(tokensFile.Name()))
 
 	tests := map[string]struct {
+		storedTokens   Tokens
 		initialState   IngesterState
 		initialTokens  Tokens
 		expectedState  IngesterState
@@ -140,6 +135,13 @@ func TestTokensPersistencyDelegate_ShouldHandleTheCaseTheInstanceIsAlreadyInTheR
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
+			tokensFile, err := ioutil.TempFile(os.TempDir(), "tokens-*")
+			require.NoError(t, err)
+			defer os.Remove(tokensFile.Name()) //nolint:errcheck
+
+			// Store some tokens to the file.
+			require.NoError(t, storedTokens.StoreToFile(tokensFile.Name()))
+
 			testDelegate := &mockDelegate{
 				onRegister: func(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens) {
 					return instanceDesc.GetState(), instanceDesc.GetTokens()

--- a/pkg/ring/basic_lifecycler_metrics.go
+++ b/pkg/ring/basic_lifecycler_metrics.go
@@ -1,0 +1,32 @@
+package ring
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type BasicLifecyclerMetrics struct {
+	heartbeats  prometheus.Counter
+	tokensOwned prometheus.Gauge
+	tokensToOwn prometheus.Gauge
+}
+
+func NewBasicLifecyclerMetrics(ringName string, reg prometheus.Registerer) *BasicLifecyclerMetrics {
+	return &BasicLifecyclerMetrics{
+		heartbeats: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name:        "cortex_ring_member_heartbeats_total",
+			Help:        "The total number of heartbeats sent.",
+			ConstLabels: prometheus.Labels{"name": ringName},
+		}),
+		tokensOwned: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name:        "cortex_ring_member_tokens_owned",
+			Help:        "The number of tokens owned in the ring.",
+			ConstLabels: prometheus.Labels{"name": ringName},
+		}),
+		tokensToOwn: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name:        "cortex_ring_member_tokens_to_own",
+			Help:        "The number of tokens to own in the ring.",
+			ConstLabels: prometheus.Labels{"name": ringName},
+		}),
+	}
+}

--- a/pkg/ring/basic_lifecycler_test.go
+++ b/pkg/ring/basic_lifecycler_test.go
@@ -1,0 +1,338 @@
+package ring
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/ring/kv"
+	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
+	"github.com/cortexproject/cortex/pkg/util/services"
+	"github.com/cortexproject/cortex/pkg/util/test"
+)
+
+const (
+	testRingKey    = "test"
+	testRingName   = "test"
+	testInstanceID = "test-id"
+)
+
+func TestBasicLifecycler_RegisterOnStart(t *testing.T) {
+	tests := map[string]struct {
+		initialInstanceID   string
+		initialInstanceDesc *IngesterDesc
+		registerState       IngesterState
+		registerTokens      Tokens
+	}{
+		"initial ring is empty": {
+			registerState:  ACTIVE,
+			registerTokens: Tokens{1, 2, 3, 4, 5},
+		},
+		"initial ring non empty (containing another instance)": {
+			initialInstanceID: "instance-1",
+			initialInstanceDesc: &IngesterDesc{
+				Addr:   "1.1.1.1",
+				State:  ACTIVE,
+				Tokens: Tokens{6, 7, 8, 9, 10},
+			},
+			registerState:  ACTIVE,
+			registerTokens: Tokens{1, 2, 3, 4, 5},
+		},
+		"initial ring contains the same instance with a different address and tokens": {
+			initialInstanceID: testInstanceID,
+			initialInstanceDesc: &IngesterDesc{
+				Addr:   "1.1.1.1",
+				State:  ACTIVE,
+				Tokens: Tokens{6, 7, 8, 9, 10},
+			},
+			registerState:  JOINING,
+			registerTokens: Tokens{1, 2, 3, 4, 5},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ctx := context.Background()
+			cfg := prepareBasicLifecyclerConfig()
+			lifecycler, delegate, store, err := prepareBasicLifecycler(cfg)
+			require.NoError(t, err)
+			defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
+
+			// Add an initial instance to the ring.
+			if testData.initialInstanceDesc != nil {
+				require.NoError(t, store.CAS(ctx, testRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+					desc := testData.initialInstanceDesc
+
+					ringDesc := getOrCreateRingDesc(in)
+					ringDesc.AddIngester(testData.initialInstanceID, desc.Addr, desc.Zone, desc.Tokens, desc.State)
+					return ringDesc, true, nil
+				}))
+			}
+
+			// Assert on the lifecycler state once the instance register delegate function will be called.
+			delegate.onRegister = func(_ *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens) {
+				assert.Equal(t, services.Starting, lifecycler.State())
+				assert.False(t, lifecycler.IsRegistered())
+				assert.Equal(t, testInstanceID, instanceID)
+				assert.NotNil(t, ringDesc)
+
+				if testData.initialInstanceID == instanceID {
+					assert.True(t, instanceExists)
+					assert.Equal(t, testData.initialInstanceDesc.Addr, instanceDesc.Addr)
+					assert.Equal(t, testData.initialInstanceDesc.Zone, instanceDesc.Zone)
+					assert.Equal(t, testData.initialInstanceDesc.State, instanceDesc.State)
+					assert.Equal(t, testData.initialInstanceDesc.Tokens, instanceDesc.Tokens)
+				} else {
+					assert.False(t, instanceExists)
+				}
+
+				return testData.registerState, testData.registerTokens
+			}
+
+			assert.Equal(t, testInstanceID, lifecycler.GetInstanceID())
+			assert.Equal(t, services.New, lifecycler.State())
+			assert.Equal(t, PENDING, lifecycler.GetState())
+			assert.Empty(t, lifecycler.GetTokens())
+			assert.False(t, lifecycler.IsRegistered())
+			assert.Equal(t, float64(0), testutil.ToFloat64(lifecycler.metrics.tokensOwned))
+			assert.Equal(t, float64(cfg.NumTokens), testutil.ToFloat64(lifecycler.metrics.tokensToOwn))
+
+			require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+
+			assert.Equal(t, services.Running, lifecycler.State())
+			assert.Equal(t, testData.registerState, lifecycler.GetState())
+			assert.Equal(t, testData.registerTokens, lifecycler.GetTokens())
+			assert.True(t, lifecycler.IsRegistered())
+			assert.Equal(t, float64(cfg.NumTokens), testutil.ToFloat64(lifecycler.metrics.tokensOwned))
+			assert.Equal(t, float64(cfg.NumTokens), testutil.ToFloat64(lifecycler.metrics.tokensToOwn))
+
+			// Assert on the instance registered within the ring.
+			instanceDesc, ok := getInstanceFromStore(t, store, testInstanceID)
+			assert.True(t, ok)
+			assert.Equal(t, fmt.Sprintf("%s:%d", cfg.InstanceAddr, cfg.InstancePort), instanceDesc.GetAddr())
+			assert.Equal(t, testData.registerState, instanceDesc.GetState())
+			assert.Equal(t, testData.registerTokens, Tokens(instanceDesc.GetTokens()))
+			assert.Equal(t, cfg.InstanceZone, instanceDesc.GetZone())
+		})
+	}
+}
+
+func TestBasicLifecycler_UnregisterOnStop(t *testing.T) {
+	ctx := context.Background()
+	cfg := prepareBasicLifecyclerConfig()
+	lifecycler, delegate, store, err := prepareBasicLifecycler(cfg)
+	require.NoError(t, err)
+
+	delegate.onRegister = func(_ *BasicLifecycler, _ Desc, _ bool, _ string, _ IngesterDesc) (IngesterState, Tokens) {
+		return ACTIVE, Tokens{1, 2, 3, 4, 5}
+	}
+	delegate.onStopping = func(_ *BasicLifecycler) {
+		assert.Equal(t, services.Stopping, lifecycler.State())
+	}
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+	assert.Equal(t, ACTIVE, lifecycler.GetState())
+	assert.Equal(t, Tokens{1, 2, 3, 4, 5}, lifecycler.GetTokens())
+	assert.True(t, lifecycler.IsRegistered())
+	assert.Equal(t, float64(cfg.NumTokens), testutil.ToFloat64(lifecycler.metrics.tokensOwned))
+	assert.Equal(t, float64(cfg.NumTokens), testutil.ToFloat64(lifecycler.metrics.tokensToOwn))
+
+	require.NoError(t, services.StopAndAwaitTerminated(ctx, lifecycler))
+	assert.Equal(t, PENDING, lifecycler.GetState())
+	assert.Equal(t, Tokens{}, lifecycler.GetTokens())
+	assert.False(t, lifecycler.IsRegistered())
+	assert.Equal(t, float64(0), testutil.ToFloat64(lifecycler.metrics.tokensOwned))
+	assert.Equal(t, float64(0), testutil.ToFloat64(lifecycler.metrics.tokensToOwn))
+
+	// Assert on the instance removed from the ring.
+	_, ok := getInstanceFromStore(t, store, testInstanceID)
+	assert.False(t, ok)
+}
+
+func TestBasicLifecycler_HeartbeatWhileRunning(t *testing.T) {
+	ctx := context.Background()
+	cfg := prepareBasicLifecyclerConfig()
+	cfg.HeartbeatPeriod = 10 * time.Millisecond
+
+	lifecycler, _, store, err := prepareBasicLifecycler(cfg)
+	require.NoError(t, err)
+	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+
+	// Get the initial timestamp so that we can then assert on the timestamp updated.
+	desc, _ := getInstanceFromStore(t, store, testInstanceID)
+	initialTimestamp := desc.GetTimestamp()
+
+	test.Poll(t, time.Second, true, func() interface{} {
+		desc, _ := getInstanceFromStore(t, store, testInstanceID)
+		currTimestamp := desc.GetTimestamp()
+
+		return currTimestamp > initialTimestamp
+	})
+
+	assert.Greater(t, testutil.ToFloat64(lifecycler.metrics.heartbeats), float64(0))
+}
+
+func TestBasicLifecycler_HeartbeatWhileStopping(t *testing.T) {
+	ctx := context.Background()
+	cfg := prepareBasicLifecyclerConfig()
+	cfg.HeartbeatPeriod = 10 * time.Millisecond
+
+	lifecycler, delegate, store, err := prepareBasicLifecycler(cfg)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+
+	// Get the initial timestamp so that we can then assert on the timestamp updated.
+	desc, _ := getInstanceFromStore(t, store, testInstanceID)
+	initialTimestamp := desc.GetTimestamp()
+	onStoppingCalled := false
+
+	delegate.onStopping = func(_ *BasicLifecycler) {
+		test.Poll(t, time.Second, true, func() interface{} {
+			desc, _ := getInstanceFromStore(t, store, testInstanceID)
+			currTimestamp := desc.GetTimestamp()
+
+			return currTimestamp > initialTimestamp
+		})
+
+		onStoppingCalled = true
+	}
+
+	assert.NoError(t, services.StopAndAwaitTerminated(ctx, lifecycler))
+	assert.True(t, onStoppingCalled)
+}
+
+func TestBasicLifecycler_ChangeState(t *testing.T) {
+	ctx := context.Background()
+	cfg := prepareBasicLifecyclerConfig()
+	lifecycler, delegate, store, err := prepareBasicLifecycler(cfg)
+	require.NoError(t, err)
+	defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
+
+	delegate.onRegister = func(_ *BasicLifecycler, _ Desc, _ bool, _ string, _ IngesterDesc) (IngesterState, Tokens) {
+		return JOINING, Tokens{1, 2, 3, 4, 5}
+	}
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+	assert.Equal(t, JOINING, lifecycler.GetState())
+
+	for _, state := range []IngesterState{ACTIVE, LEAVING} {
+		assert.NoError(t, lifecycler.ChangeState(ctx, state))
+		assert.Equal(t, state, lifecycler.GetState())
+
+		// Assert on the instance state read from the ring.
+		desc, ok := getInstanceFromStore(t, store, testInstanceID)
+		assert.True(t, ok)
+		assert.Equal(t, state, desc.GetState())
+	}
+}
+
+func TestBasicLifecycler_TokensObservePeriod(t *testing.T) {
+	ctx := context.Background()
+	cfg := prepareBasicLifecyclerConfig()
+	cfg.NumTokens = 5
+	cfg.TokensObservePeriod = time.Second
+
+	lifecycler, delegate, store, err := prepareBasicLifecycler(cfg)
+	require.NoError(t, err)
+
+	delegate.onRegister = func(_ *BasicLifecycler, _ Desc, _ bool, _ string, _ IngesterDesc) (IngesterState, Tokens) {
+		return ACTIVE, Tokens{1, 2, 3, 4, 5}
+	}
+
+	require.NoError(t, lifecycler.StartAsync(ctx))
+
+	// While the lifecycler is starting we poll the ring. As soon as the instance
+	// is registered, we remove some tokens to simulate how gossip memberlist
+	// reconciliation works in case of clashing tokens.
+	test.Poll(t, time.Second, true, func() interface{} {
+		// Ensure the instance has been registered in the ring.
+		desc, ok := getInstanceFromStore(t, store, testInstanceID)
+		if !ok {
+			return false
+		}
+
+		// Remove some tokens.
+		return store.CAS(ctx, testRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+			ringDesc := getOrCreateRingDesc(in)
+			ringDesc.AddIngester(testInstanceID, desc.Addr, desc.Zone, Tokens{4, 5}, desc.State)
+			return ringDesc, true, nil
+		}) == nil
+	})
+
+	require.NoError(t, lifecycler.AwaitRunning(ctx))
+	assert.Subset(t, lifecycler.GetTokens(), Tokens{4, 5})
+	assert.NotContains(t, lifecycler.GetTokens(), uint32(1))
+	assert.NotContains(t, lifecycler.GetTokens(), uint32(2))
+	assert.NotContains(t, lifecycler.GetTokens(), uint32(3))
+}
+
+func prepareBasicLifecyclerConfig() BasicLifecyclerConfig {
+	return BasicLifecyclerConfig{
+		InstanceID:          testInstanceID,
+		InstanceAddr:        "127.0.0.1",
+		InstancePort:        12345,
+		InstanceZone:        "test-zone",
+		HeartbeatPeriod:     time.Minute,
+		TokensObservePeriod: 0,
+		NumTokens:           5,
+	}
+}
+
+func prepareBasicLifecycler(cfg BasicLifecyclerConfig) (*BasicLifecycler, *mockDelegate, kv.Client, error) {
+	delegate := &mockDelegate{}
+	lifecycler, store, err := prepareBasicLifecyclerWithDelegate(cfg, delegate)
+	return lifecycler, delegate, store, err
+}
+
+func prepareBasicLifecyclerWithDelegate(cfg BasicLifecyclerConfig, delegate BasicLifecyclerDelegate) (*BasicLifecycler, kv.Client, error) {
+	store := consul.NewInMemoryClient(GetCodec())
+	lifecycler, err := NewBasicLifecyclerWithStoreClient(cfg, testRingName, testRingKey, store, delegate, log.NewNopLogger(), nil)
+	return lifecycler, store, err
+}
+
+type mockDelegate struct {
+	onRegister      OnRingInstanceRegister
+	onTokensChanged OnRingInstanceTokensChanged
+	onStopping      OnRingInstanceStopping
+}
+
+func (m *mockDelegate) OnRingInstanceRegister(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens) {
+	if m.onRegister == nil {
+		return PENDING, Tokens{}
+	}
+
+	return m.onRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
+}
+
+func (m *mockDelegate) OnRingInstanceTokens(lifecycler *BasicLifecycler, tokens Tokens) {
+	if m.onTokensChanged != nil {
+		m.onTokensChanged(lifecycler, tokens)
+	}
+}
+
+func (m *mockDelegate) OnRingInstanceStopping(lifecycler *BasicLifecycler) {
+	if m.onStopping != nil {
+		m.onStopping(lifecycler)
+	}
+}
+
+func getInstanceFromStore(t *testing.T, store kv.Client, instanceID string) (IngesterDesc, bool) {
+	out, err := store.Get(context.Background(), testRingKey)
+	require.NoError(t, err)
+
+	if out == nil {
+		return IngesterDesc{}, false
+	}
+
+	ringDesc := out.(*Desc)
+	instanceDesc, ok := ringDesc.GetIngesters()[instanceID]
+
+	return instanceDesc, ok
+}

--- a/pkg/ring/basic_lifecycler_test.go
+++ b/pkg/ring/basic_lifecycler_test.go
@@ -2,7 +2,6 @@ package ring
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -115,10 +114,10 @@ func TestBasicLifecycler_RegisterOnStart(t *testing.T) {
 			// Assert on the instance registered within the ring.
 			instanceDesc, ok := getInstanceFromStore(t, store, testInstanceID)
 			assert.True(t, ok)
-			assert.Equal(t, fmt.Sprintf("%s:%d", cfg.InstanceAddr, cfg.InstancePort), instanceDesc.GetAddr())
+			assert.Equal(t, cfg.Addr, instanceDesc.GetAddr())
 			assert.Equal(t, testData.registerState, instanceDesc.GetState())
 			assert.Equal(t, testData.registerTokens, Tokens(instanceDesc.GetTokens()))
-			assert.Equal(t, cfg.InstanceZone, instanceDesc.GetZone())
+			assert.Equal(t, cfg.Zone, instanceDesc.GetZone())
 		})
 	}
 }
@@ -275,10 +274,9 @@ func TestBasicLifecycler_TokensObservePeriod(t *testing.T) {
 
 func prepareBasicLifecyclerConfig() BasicLifecyclerConfig {
 	return BasicLifecyclerConfig{
-		InstanceID:          testInstanceID,
-		InstanceAddr:        "127.0.0.1",
-		InstancePort:        12345,
-		InstanceZone:        "test-zone",
+		ID:                  testInstanceID,
+		Addr:                "127.0.0.1:12345",
+		Zone:                "test-zone",
 		HeartbeatPeriod:     time.Minute,
 		TokensObservePeriod: 0,
 		NumTokens:           5,

--- a/pkg/ring/basic_lifecycler_test.go
+++ b/pkg/ring/basic_lifecycler_test.go
@@ -291,7 +291,7 @@ func prepareBasicLifecycler(cfg BasicLifecyclerConfig) (*BasicLifecycler, *mockD
 
 func prepareBasicLifecyclerWithDelegate(cfg BasicLifecyclerConfig, delegate BasicLifecyclerDelegate) (*BasicLifecycler, kv.Client, error) {
 	store := consul.NewInMemoryClient(GetCodec())
-	lifecycler, err := NewBasicLifecyclerWithStoreClient(cfg, testRingName, testRingKey, store, delegate, log.NewNopLogger(), nil)
+	lifecycler, err := NewBasicLifecycler(cfg, testRingName, testRingKey, store, delegate, log.NewNopLogger(), nil)
 	return lifecycler, store, err
 }
 

--- a/pkg/ring/basic_lifecycler_test.go
+++ b/pkg/ring/basic_lifecycler_test.go
@@ -298,9 +298,9 @@ func prepareBasicLifecyclerWithDelegate(cfg BasicLifecyclerConfig, delegate Basi
 }
 
 type mockDelegate struct {
-	onRegister      OnRingInstanceRegister
-	onTokensChanged OnRingInstanceTokensChanged
-	onStopping      OnRingInstanceStopping
+	onRegister      func(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens)
+	onTokensChanged func(lifecycler *BasicLifecycler, tokens Tokens)
+	onStopping      func(lifecycler *BasicLifecycler)
 }
 
 func (m *mockDelegate) OnRingInstanceRegister(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens) {

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -37,7 +37,7 @@ func NewDesc() *Desc {
 
 // AddIngester adds the given ingester to the ring. Ingester will only use supplied tokens,
 // any other tokens are removed.
-func (d *Desc) AddIngester(id, addr, zone string, tokens []uint32, state IngesterState) {
+func (d *Desc) AddIngester(id, addr, zone string, tokens []uint32, state IngesterState) IngesterDesc {
 	if d.Ingesters == nil {
 		d.Ingesters = map[string]IngesterDesc{}
 	}
@@ -51,6 +51,7 @@ func (d *Desc) AddIngester(id, addr, zone string, tokens []uint32, state Ingeste
 	}
 
 	d.Ingesters[id] = ingester
+	return ingester
 }
 
 // RemoveIngester removes the given ingester and all its tokens.
@@ -396,4 +397,11 @@ func (d *Desc) getTokens() []TokenDesc {
 
 	sort.Sort(ByToken(tokens))
 	return tokens
+}
+
+func getOrCreateRingDesc(d interface{}) *Desc {
+	if d == nil {
+		return NewDesc()
+	}
+	return d.(*Desc)
 }

--- a/pkg/ring/tokens.go
+++ b/pkg/ring/tokens.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"sort"
 )
 
 // Tokens is a simple list of tokens.
@@ -13,6 +14,25 @@ type Tokens []uint32
 func (t Tokens) Len() int           { return len(t) }
 func (t Tokens) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 func (t Tokens) Less(i, j int) bool { return t[i] < t[j] }
+
+// Equals returns whether the tokens are equal to the input ones.
+func (t Tokens) Equals(other Tokens) bool {
+	if len(t) != len(other) {
+		return false
+	}
+
+	mine := t
+	sort.Sort(mine)
+	sort.Sort(other)
+
+	for i := 0; i < len(mine); i++ {
+		if mine[i] != other[i] {
+			return false
+		}
+	}
+
+	return true
+}
 
 // StoreToFile stores the tokens in the given directory.
 func (t Tokens) StoreToFile(tokenFilePath string) error {

--- a/pkg/ring/tokens_test.go
+++ b/pkg/ring/tokens_test.go
@@ -4,10 +4,11 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestTokenSerialization(t *testing.T) {
+func TestTokens_Serialization(t *testing.T) {
 	tokens := make(Tokens, 512)
 	for i := 0; i < 512; i++ {
 		tokens = append(tokens, uint32(rand.Int31()))
@@ -19,4 +20,38 @@ func TestTokenSerialization(t *testing.T) {
 	var unmarshaledTokens Tokens
 	require.NoError(t, unmarshaledTokens.Unmarshal(b))
 	require.Equal(t, tokens, unmarshaledTokens)
+}
+
+func TestTokens_Equals(t *testing.T) {
+	tests := []struct {
+		first    Tokens
+		second   Tokens
+		expected bool
+	}{
+		{
+			first:    Tokens{},
+			second:   Tokens{},
+			expected: true,
+		},
+		{
+			first:    Tokens{1, 2, 3},
+			second:   Tokens{1, 2, 3},
+			expected: true,
+		},
+		{
+			first:    Tokens{1, 2, 3},
+			second:   Tokens{3, 2, 1},
+			expected: true,
+		},
+		{
+			first:    Tokens{1, 2},
+			second:   Tokens{1, 2, 3},
+			expected: false,
+		},
+	}
+
+	for _, c := range tests {
+		assert.Equal(t, c.expected, c.first.Equals(c.second))
+		assert.Equal(t, c.expected, c.second.Equals(c.first))
+	}
 }


### PR DESCRIPTION
**What this PR does**:
The upcoming `store-gateway` ([proposal](https://cortexmetrics.io/docs/proposals/blocks-storage-sharding/)) will use the ring as the foundation for the sharding.

However, the `store-gateway` ring lifecycle will be different than the ingesters one and unfortunately the current `ring.Lifecycler` logic doesn't fit (ie. we need to inject `store-gateway` custom logic between `JOINING` and `ACTIVE` state while continuing doing heatbeats, or we need a new `store-gateway` instance to always reset its state to `JOINING` even if already present within the ring).

I initially tried to change `ring.Lifecycler` to also add `store-gateway` use cases but I ended up with many hacks I wasn't comfortable with. This lead me to approach a different solution: build a ring lifecycler foundation (`BasicLifecycler`) which we can use to build higher level lifecyclers.

Currently, this change doesn't touch the existing `ring.Lifecycler` at all and `BasicLifecycler` is not a drop-in replacement for it, but `BasicLifecycler` is a first step in this direction. On the other side, `BasicLifecycler` allows to easily build a custom lifecycler for the `store-gateway` (few lines of code) and may be used to build other ring lifecyclers too (ie. compactor).

The `BasicLifecycler` contract is simple:
- Delegate any decision to a set of delegated functions (provided in input)
- Never automatically change the instance state (it's the delegate responsability deciding when the state should change or which tokens should be used to join the ring)

I've also provided a couple of built-in delegates which can be chained together:
- Load/store tokens to disk
- Switch state to `LEAVING` on lifecycler stop

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
