### PR TITLE
Expose BucketStoreMetrics for store-gateway too

### DIFF
--- a/pkg/querier/block_store.go
+++ b/pkg/querier/block_store.go
@@ -36,7 +36,7 @@ type UserStore struct {
 	cfg                tsdb.Config
 	bucket             objstore.Bucket
 	logLevel           logging.Level
-	bucketStoreMetrics *tsdbBucketStoreMetrics
+	bucketStoreMetrics *BucketStoreMetrics
 	metaFetcherMetrics *metaFetcherMetrics
 	indexCacheMetrics  prometheus.Collector
 
@@ -61,7 +61,7 @@ func NewUserStore(cfg tsdb.Config, bucketClient objstore.Bucket, logLevel loggin
 		bucket:             bucketClient,
 		stores:             map[string]*store.BucketStore{},
 		logLevel:           logLevel,
-		bucketStoreMetrics: newTSDBBucketStoreMetrics(),
+		bucketStoreMetrics: NewBucketStoreMetrics(),
 		metaFetcherMetrics: newMetaFetcherMetrics(),
 		indexCacheMetrics:  tsdb.MustNewIndexCacheMetrics(cfg.BucketStore.IndexCache.Backend, indexCacheRegistry),
 		syncTimes: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
@@ -305,7 +305,7 @@ func (u *UserStore) getOrCreateStore(userID string) (*store.BucketStore, error) 
 
 	u.stores[userID] = bs
 	u.metaFetcherMetrics.addUserRegistry(userID, fetcherReg)
-	u.bucketStoreMetrics.addUserRegistry(userID, bucketStoreReg)
+	u.bucketStoreMetrics.AddUserRegistry(userID, bucketStoreReg)
 
 	return bs, nil
 }

--- a/pkg/querier/block_store_metrics.go
+++ b/pkg/querier/block_store_metrics.go
@@ -8,9 +8,9 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 )
 
-// This struct aggregates metrics exported by Thanos Bucket Store
+// BucketStoreMetrics aggregates metrics exported by Thanos Bucket Store
 // and re-exports those aggregates as Cortex metrics.
-type tsdbBucketStoreMetrics struct {
+type BucketStoreMetrics struct {
 	// Maps userID -> registry
 	regsMu sync.Mutex
 	regs   map[string]*prometheus.Registry
@@ -38,66 +38,66 @@ type tsdbBucketStoreMetrics struct {
 	cachedPostingsCompressedSizeBytes    *prometheus.Desc
 }
 
-func newTSDBBucketStoreMetrics() *tsdbBucketStoreMetrics {
-	return &tsdbBucketStoreMetrics{
+func NewBucketStoreMetrics() *BucketStoreMetrics {
+	return &BucketStoreMetrics{
 		regs: map[string]*prometheus.Registry{},
 
 		blockLoads: prometheus.NewDesc(
 			"cortex_querier_bucket_store_block_loads_total",
-			"TSDB: Total number of remote block loading attempts.",
+			"Total number of remote block loading attempts.",
 			nil, nil),
 		blockLoadFailures: prometheus.NewDesc(
 			"cortex_querier_bucket_store_block_load_failures_total",
-			"TSDB: Total number of failed remote block loading attempts.",
+			"Total number of failed remote block loading attempts.",
 			nil, nil),
 		blockDrops: prometheus.NewDesc(
 			"cortex_querier_bucket_store_block_drops_total",
-			"TSDB: Total number of local blocks that were dropped.",
+			"Total number of local blocks that were dropped.",
 			nil, nil),
 		blockDropFailures: prometheus.NewDesc(
 			"cortex_querier_bucket_store_block_drop_failures_total",
-			"TSDB: Total number of local blocks that failed to be dropped.",
+			"Total number of local blocks that failed to be dropped.",
 			nil, nil),
 		blocksLoaded: prometheus.NewDesc(
 			"cortex_querier_bucket_store_blocks_loaded",
-			"TSDB: Number of currently loaded blocks.",
+			"Number of currently loaded blocks.",
 			nil, nil),
 		seriesDataTouched: prometheus.NewDesc(
 			"cortex_querier_bucket_store_series_data_touched",
-			"TSDB: How many items of a data type in a block were touched for a single series request.",
+			"How many items of a data type in a block were touched for a single series request.",
 			[]string{"data_type"}, nil),
 		seriesDataFetched: prometheus.NewDesc(
 			"cortex_querier_bucket_store_series_data_fetched",
-			"TSDB: How many items of a data type in a block were fetched for a single series request.",
+			"How many items of a data type in a block were fetched for a single series request.",
 			[]string{"data_type"}, nil),
 		seriesDataSizeTouched: prometheus.NewDesc(
 			"cortex_querier_bucket_store_series_data_size_touched_bytes",
-			"TSDB: Size of all items of a data type in a block were touched for a single series request.",
+			"Size of all items of a data type in a block were touched for a single series request.",
 			[]string{"data_type"}, nil),
 		seriesDataSizeFetched: prometheus.NewDesc(
 			"cortex_querier_bucket_store_series_data_size_fetched_bytes",
-			"TSDB: Size of all items of a data type in a block were fetched for a single series request.",
+			"Size of all items of a data type in a block were fetched for a single series request.",
 			[]string{"data_type"}, nil),
 		seriesBlocksQueried: prometheus.NewDesc(
 			"cortex_querier_bucket_store_series_blocks_queried",
-			"TSDB: Number of blocks in a bucket store that were touched to satisfy a query.",
+			"Number of blocks in a bucket store that were touched to satisfy a query.",
 			nil, nil),
 
 		seriesGetAllDuration: prometheus.NewDesc(
 			"cortex_querier_bucket_store_series_get_all_duration_seconds",
-			"TSDB: Time it takes until all per-block prepares and preloads for a query are finished.",
+			"Time it takes until all per-block prepares and preloads for a query are finished.",
 			nil, nil),
 		seriesMergeDuration: prometheus.NewDesc(
 			"cortex_querier_bucket_store_series_merge_duration_seconds",
-			"TSDB: Time it takes to merge sub-results from all queried blocks into a single result.",
+			"Time it takes to merge sub-results from all queried blocks into a single result.",
 			nil, nil),
 		seriesRefetches: prometheus.NewDesc(
 			"cortex_querier_bucket_store_series_refetches_total",
-			"TSDB: Total number of cases where the built-in max series size was not enough to fetch series from index, resulting in refetch.",
+			"Total number of cases where the built-in max series size was not enough to fetch series from index, resulting in refetch.",
 			nil, nil),
 		resultSeriesCount: prometheus.NewDesc(
 			"cortex_querier_bucket_store_series_result_series",
-			"TSDB: Number of series observed in the final result of a query.",
+			"Number of series observed in the final result of a query.",
 			nil, nil),
 
 		cachedPostingsCompressions: prometheus.NewDesc(
@@ -123,13 +123,13 @@ func newTSDBBucketStoreMetrics() *tsdbBucketStoreMetrics {
 	}
 }
 
-func (m *tsdbBucketStoreMetrics) addUserRegistry(user string, reg *prometheus.Registry) {
+func (m *BucketStoreMetrics) AddUserRegistry(user string, reg *prometheus.Registry) {
 	m.regsMu.Lock()
 	m.regs[user] = reg
 	m.regsMu.Unlock()
 }
 
-func (m *tsdbBucketStoreMetrics) registries() map[string]*prometheus.Registry {
+func (m *BucketStoreMetrics) registries() map[string]*prometheus.Registry {
 	regs := map[string]*prometheus.Registry{}
 
 	m.regsMu.Lock()
@@ -141,7 +141,7 @@ func (m *tsdbBucketStoreMetrics) registries() map[string]*prometheus.Registry {
 	return regs
 }
 
-func (m *tsdbBucketStoreMetrics) Describe(out chan<- *prometheus.Desc) {
+func (m *BucketStoreMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.blockLoads
 	out <- m.blockLoadFailures
 	out <- m.blockDrops
@@ -164,7 +164,7 @@ func (m *tsdbBucketStoreMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.cachedPostingsCompressedSizeBytes
 }
 
-func (m *tsdbBucketStoreMetrics) Collect(out chan<- prometheus.Metric) {
+func (m *BucketStoreMetrics) Collect(out chan<- prometheus.Metric) {
 	data := util.BuildMetricFamiliesPerUserFromUserRegistries(m.registries())
 
 	data.SendSumOfCounters(out, m.blockLoads, "thanos_bucket_store_block_loads_total")

--- a/pkg/querier/bucket_store_metrics_test.go
+++ b/pkg/querier/bucket_store_metrics_test.go
@@ -11,44 +11,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTSDBBucketStoreMetrics(t *testing.T) {
+func TestBucketStoreMetrics(t *testing.T) {
 	mainReg := prometheus.NewPedanticRegistry()
 
-	tsdbMetrics := newTSDBBucketStoreMetrics()
+	tsdbMetrics := NewBucketStoreMetrics()
 	mainReg.MustRegister(tsdbMetrics)
 
-	tsdbMetrics.addUserRegistry("user1", populateTSDBBucketStoreMetrics(5328))
-	tsdbMetrics.addUserRegistry("user2", populateTSDBBucketStoreMetrics(6908))
-	tsdbMetrics.addUserRegistry("user3", populateTSDBBucketStoreMetrics(10283))
+	tsdbMetrics.AddUserRegistry("user1", populateMockedBucketStoreMetrics(5328))
+	tsdbMetrics.AddUserRegistry("user2", populateMockedBucketStoreMetrics(6908))
+	tsdbMetrics.AddUserRegistry("user3", populateMockedBucketStoreMetrics(10283))
 
 	//noinspection ALL
 	err := testutil.GatherAndCompare(mainReg, bytes.NewBufferString(`
-			# HELP cortex_querier_bucket_store_blocks_loaded TSDB: Number of currently loaded blocks.
+			# HELP cortex_querier_bucket_store_blocks_loaded Number of currently loaded blocks.
 			# TYPE cortex_querier_bucket_store_blocks_loaded gauge
 			cortex_querier_bucket_store_blocks_loaded 22519
 
-			# HELP cortex_querier_bucket_store_block_loads_total TSDB: Total number of remote block loading attempts.
+			# HELP cortex_querier_bucket_store_block_loads_total Total number of remote block loading attempts.
 			# TYPE cortex_querier_bucket_store_block_loads_total counter
 			cortex_querier_bucket_store_block_loads_total 45038
 
-			# HELP cortex_querier_bucket_store_block_load_failures_total TSDB: Total number of failed remote block loading attempts.
+			# HELP cortex_querier_bucket_store_block_load_failures_total Total number of failed remote block loading attempts.
 			# TYPE cortex_querier_bucket_store_block_load_failures_total counter
 			cortex_querier_bucket_store_block_load_failures_total 67557
 
-			# HELP cortex_querier_bucket_store_block_drops_total TSDB: Total number of local blocks that were dropped.
+			# HELP cortex_querier_bucket_store_block_drops_total Total number of local blocks that were dropped.
 			# TYPE cortex_querier_bucket_store_block_drops_total counter
 			cortex_querier_bucket_store_block_drops_total 90076
 
-			# HELP cortex_querier_bucket_store_block_drop_failures_total TSDB: Total number of local blocks that failed to be dropped.
+			# HELP cortex_querier_bucket_store_block_drop_failures_total Total number of local blocks that failed to be dropped.
 			# TYPE cortex_querier_bucket_store_block_drop_failures_total counter
 			cortex_querier_bucket_store_block_drop_failures_total 112595
 
-			# HELP cortex_querier_bucket_store_series_blocks_queried TSDB: Number of blocks in a bucket store that were touched to satisfy a query.
+			# HELP cortex_querier_bucket_store_series_blocks_queried Number of blocks in a bucket store that were touched to satisfy a query.
 			# TYPE cortex_querier_bucket_store_series_blocks_queried summary
 			cortex_querier_bucket_store_series_blocks_queried_sum 1.283583e+06
 			cortex_querier_bucket_store_series_blocks_queried_count 9
 
-			# HELP cortex_querier_bucket_store_series_data_fetched TSDB: How many items of a data type in a block were fetched for a single series request.
+			# HELP cortex_querier_bucket_store_series_data_fetched How many items of a data type in a block were fetched for a single series request.
 			# TYPE cortex_querier_bucket_store_series_data_fetched summary
 			cortex_querier_bucket_store_series_data_fetched_sum{data_type="fetched-a"} 202671
 			cortex_querier_bucket_store_series_data_fetched_count{data_type="fetched-a"} 3
@@ -57,7 +57,7 @@ func TestTSDBBucketStoreMetrics(t *testing.T) {
 			cortex_querier_bucket_store_series_data_fetched_sum{data_type="fetched-c"} 247709
 			cortex_querier_bucket_store_series_data_fetched_count{data_type="fetched-c"} 3
 
-			# HELP cortex_querier_bucket_store_series_data_size_fetched_bytes TSDB: Size of all items of a data type in a block were fetched for a single series request.
+			# HELP cortex_querier_bucket_store_series_data_size_fetched_bytes Size of all items of a data type in a block were fetched for a single series request.
 			# TYPE cortex_querier_bucket_store_series_data_size_fetched_bytes summary
 			cortex_querier_bucket_store_series_data_size_fetched_bytes_sum{data_type="size-fetched-a"} 337785
 			cortex_querier_bucket_store_series_data_size_fetched_bytes_count{data_type="size-fetched-a"} 3
@@ -66,7 +66,7 @@ func TestTSDBBucketStoreMetrics(t *testing.T) {
 			cortex_querier_bucket_store_series_data_size_fetched_bytes_sum{data_type="size-fetched-c"} 382823
 			cortex_querier_bucket_store_series_data_size_fetched_bytes_count{data_type="size-fetched-c"} 3
 
-			# HELP cortex_querier_bucket_store_series_data_size_touched_bytes TSDB: Size of all items of a data type in a block were touched for a single series request.
+			# HELP cortex_querier_bucket_store_series_data_size_touched_bytes Size of all items of a data type in a block were touched for a single series request.
 			# TYPE cortex_querier_bucket_store_series_data_size_touched_bytes summary
 			cortex_querier_bucket_store_series_data_size_touched_bytes_sum{data_type="size-touched-a"} 270228
 			cortex_querier_bucket_store_series_data_size_touched_bytes_count{data_type="size-touched-a"} 3
@@ -75,7 +75,7 @@ func TestTSDBBucketStoreMetrics(t *testing.T) {
 			cortex_querier_bucket_store_series_data_size_touched_bytes_sum{data_type="size-touched-c"} 315266
 			cortex_querier_bucket_store_series_data_size_touched_bytes_count{data_type="size-touched-c"} 3
 
-			# HELP cortex_querier_bucket_store_series_data_touched TSDB: How many items of a data type in a block were touched for a single series request.
+			# HELP cortex_querier_bucket_store_series_data_touched How many items of a data type in a block were touched for a single series request.
 			# TYPE cortex_querier_bucket_store_series_data_touched summary
 			cortex_querier_bucket_store_series_data_touched_sum{data_type="touched-a"} 135114
 			cortex_querier_bucket_store_series_data_touched_count{data_type="touched-a"} 3
@@ -84,7 +84,7 @@ func TestTSDBBucketStoreMetrics(t *testing.T) {
 			cortex_querier_bucket_store_series_data_touched_sum{data_type="touched-c"} 180152
 			cortex_querier_bucket_store_series_data_touched_count{data_type="touched-c"} 3
 
-			# HELP cortex_querier_bucket_store_series_get_all_duration_seconds TSDB: Time it takes until all per-block prepares and preloads for a query are finished.
+			# HELP cortex_querier_bucket_store_series_get_all_duration_seconds Time it takes until all per-block prepares and preloads for a query are finished.
 			# TYPE cortex_querier_bucket_store_series_get_all_duration_seconds histogram
 			cortex_querier_bucket_store_series_get_all_duration_seconds_bucket{le="0.001"} 0
 			cortex_querier_bucket_store_series_get_all_duration_seconds_bucket{le="0.01"} 0
@@ -104,7 +104,7 @@ func TestTSDBBucketStoreMetrics(t *testing.T) {
 			cortex_querier_bucket_store_series_get_all_duration_seconds_sum 1.486254e+06
 			cortex_querier_bucket_store_series_get_all_duration_seconds_count 9
 
-			# HELP cortex_querier_bucket_store_series_merge_duration_seconds TSDB: Time it takes to merge sub-results from all queried blocks into a single result.
+			# HELP cortex_querier_bucket_store_series_merge_duration_seconds Time it takes to merge sub-results from all queried blocks into a single result.
 			# TYPE cortex_querier_bucket_store_series_merge_duration_seconds histogram
 			cortex_querier_bucket_store_series_merge_duration_seconds_bucket{le="0.001"} 0
 			cortex_querier_bucket_store_series_merge_duration_seconds_bucket{le="0.01"} 0
@@ -124,11 +124,11 @@ func TestTSDBBucketStoreMetrics(t *testing.T) {
 			cortex_querier_bucket_store_series_merge_duration_seconds_sum 1.688925e+06
 			cortex_querier_bucket_store_series_merge_duration_seconds_count 9
 
-			# HELP cortex_querier_bucket_store_series_refetches_total TSDB: Total number of cases where the built-in max series size was not enough to fetch series from index, resulting in refetch.
+			# HELP cortex_querier_bucket_store_series_refetches_total Total number of cases where the built-in max series size was not enough to fetch series from index, resulting in refetch.
 			# TYPE cortex_querier_bucket_store_series_refetches_total counter
 			cortex_querier_bucket_store_series_refetches_total 743127
 
-			# HELP cortex_querier_bucket_store_series_result_series TSDB: Number of series observed in the final result of a query.
+			# HELP cortex_querier_bucket_store_series_result_series Number of series observed in the final result of a query.
 			# TYPE cortex_querier_bucket_store_series_result_series summary
 			cortex_querier_bucket_store_series_result_series_sum 1.238545e+06
 			cortex_querier_bucket_store_series_result_series_count 6
@@ -178,12 +178,12 @@ func BenchmarkMetricsCollections10000(b *testing.B) {
 func benchmarkMetricsCollection(b *testing.B, users int) {
 	mainReg := prometheus.NewRegistry()
 
-	tsdbMetrics := newTSDBBucketStoreMetrics()
+	tsdbMetrics := NewBucketStoreMetrics()
 	mainReg.MustRegister(tsdbMetrics)
 
 	base := 123456.0
 	for i := 0; i < users; i++ {
-		tsdbMetrics.addUserRegistry(fmt.Sprintf("user-%d", i), populateTSDBBucketStoreMetrics(base*float64(i)))
+		tsdbMetrics.AddUserRegistry(fmt.Sprintf("user-%d", i), populateMockedBucketStoreMetrics(base*float64(i)))
 	}
 
 	b.ResetTimer()
@@ -192,9 +192,9 @@ func benchmarkMetricsCollection(b *testing.B, users int) {
 	}
 }
 
-func populateTSDBBucketStoreMetrics(base float64) *prometheus.Registry {
+func populateMockedBucketStoreMetrics(base float64) *prometheus.Registry {
 	reg := prometheus.NewRegistry()
-	m := newBucketStoreMetrics(reg)
+	m := newMockedBucketStoreMetrics(reg)
 
 	m.blocksLoaded.Add(1 * base)
 	m.blockLoads.Add(2 * base)
@@ -256,7 +256,7 @@ func populateTSDBBucketStoreMetrics(base float64) *prometheus.Registry {
 }
 
 // copied from Thanos, pkg/store/bucket.go
-type bucketStoreMetrics struct {
+type mockedBucketStoreMetrics struct {
 	blocksLoaded          prometheus.Gauge
 	blockLoads            prometheus.Counter
 	blockLoadFailures     prometheus.Counter
@@ -282,8 +282,8 @@ type bucketStoreMetrics struct {
 	cachedPostingsCompressedSizeBytes    prometheus.Counter
 }
 
-func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
-	var m bucketStoreMetrics
+func newMockedBucketStoreMetrics(reg prometheus.Registerer) *mockedBucketStoreMetrics {
+	var m mockedBucketStoreMetrics
 
 	m.blockLoads = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "thanos_bucket_store_block_loads_total",


### PR DESCRIPTION
**What this PR does**:
The upcoming `store-gateway` will internally run the `BucketStore` and, at some point, the querier will not run the `BucketStore` anymore (in favour of the `store-gateway`). While developing the `store-gateway`, `BucketStore` will co-exist both in the querier and store-gateway. Because of this, I would like to expose the `BucketStoreMetrics` from the querier so that the store-gateway can use them instead of duplicating code (the `BucketStoreMetrics` will be moved to the `storegateway` pkg once the querier will not run the `BucketStore` anymore).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
