### PR TITLE
Enable WAL checkpoint by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   * `cortex_querier_bucket_store_blocks_meta_sync_duration_seconds` > `cortex_querier_blocks_meta_sync_duration_seconds`
   * `cortex_querier_bucket_store_blocks_meta_sync_consistency_delay_seconds` > `cortex_querier_blocks_meta_sync_consistency_delay_seconds`
 * [CHANGE] Experimental TSDB: Modified default values for `compactor.deletion-delay` option from 48h to 12h and `-experimental.tsdb.bucket-store.ignore-deletion-marks-delay` from 24h to 6h. #2414
+* [CHANGE] Experimental WAL: Default value of `-ingester.checkpoint-enabled` changed to `true`. #2416
 * [FEATURE] Ruler: The `-ruler.evaluation-delay` flag was added to allow users to configure a default evaluation delay for all rules in cortex. The default value is 0 which is the current behavior. #2423
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
 * [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383 

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -343,9 +343,6 @@ It also talks to a KVStore and has it's own copies of the same flags used by the
 
    Setting this to `true` enables writing to WAL during ingestion.
 
-- `-ingester.checkpoint-enabled`
-   Set this to `true` to enable checkpointing of in-memory chunks to disk. This is optional which helps in speeding up the replay process.
-
 - `-ingester.checkpoint-duration` 
    This is the interval at which checkpoints should be created.
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -390,9 +390,11 @@ walconfig:
   # CLI flag: -ingester.wal-enabled
   [wal_enabled: <boolean> | default = false]
 
-  # Enable checkpointing of in-memory chunks.
+  # Enable checkpointing of in-memory chunks. It should always be true when
+  # using normally. Set it to false iff you are doing some small tests as there
+  # is no mechanism to delete the old WAL yet if checkpoint is disabled.
   # CLI flag: -ingester.checkpoint-enabled
-  [checkpoint_enabled: <boolean> | default = false]
+  [checkpoint_enabled: <boolean> | default = true]
 
   # Recover data from existing WAL irrespective of WAL enabled/disabled.
   # CLI flag: -ingester.recover-from-wal

--- a/docs/production/ingesters-with-wal.md
+++ b/docs/production/ingesters-with-wal.md
@@ -16,9 +16,8 @@ _The WAL is currently considered experimental._
 1. Since ingesters need to have the same persistent volume across restarts/rollout, all the ingesters should be run on [statefulset](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) with fixed volumes.
 
 2. Following flags needs to be set
-    * `--ingester.wal-dir` to the directory where the WAL data should be stores and/or recovered from. Note that this should be on the mounted volume.
     * `--ingester.wal-enabled` to `true` which enables writing to WAL during ingestion.
-    * `--ingester.checkpoint-enabled` to `true` to enable checkpointing of in-memory chunks to disk. This is optional which helps in speeding up the replay process.
+    * `--ingester.wal-dir` to the directory where the WAL data should be stores and/or recovered from. Note that this should be on the mounted volume.
     * `--ingester.checkpoint-duration` to the interval at which checkpoints should be created. Default is `30m`, and depending on the number of series, it can be brought down to `15m` if there are less series per ingester (say 1M).
     * `--ingester.recover-from-wal` to `true` to recover data from an existing WAL. The data is recovered even if WAL is disabled and this is set to `true`. The WAL dir needs to be set for this.
         * If you are going to enable WAL, it is advisable to always set this to `true`.

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -42,7 +42,7 @@ func (cfg *WALConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.Dir, "ingester.wal-dir", "wal", "Directory to store the WAL and/or recover from WAL.")
 	f.BoolVar(&cfg.Recover, "ingester.recover-from-wal", false, "Recover data from existing WAL irrespective of WAL enabled/disabled.")
 	f.BoolVar(&cfg.WALEnabled, "ingester.wal-enabled", false, "Enable writing of ingested data into WAL.")
-	f.BoolVar(&cfg.CheckpointEnabled, "ingester.checkpoint-enabled", false, "Enable checkpointing of in-memory chunks.")
+	f.BoolVar(&cfg.CheckpointEnabled, "ingester.checkpoint-enabled", true, "Enable checkpointing of in-memory chunks. It should always be true when using normally. Set it to false iff you are doing some small tests as there is no mechanism to delete the old WAL yet if checkpoint is disabled.")
 	f.DurationVar(&cfg.CheckpointDuration, "ingester.checkpoint-duration", 30*time.Minute, "Interval at which checkpoints should be created.")
 }
 


### PR DESCRIPTION
There is no mechanism to delete the old WAL yet if checkpoint is disabled. It should be clearly stated for `-ingester.checkpoint-enabled` so that it is not set to `false` for production or extended dev usage.