### PR TITLE
Small logic simplification on the query-frontend

### DIFF
--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"path"
@@ -359,13 +358,7 @@ FindQueue:
 		return nil, err
 	}
 
-	i, n := 0, rand.Intn(len(f.queues))
 	for userID, queue := range f.queues {
-		if i < n {
-			i++
-			continue
-		}
-
 		/*
 		  We want to dequeue the next unexpired request from the chosen tenant queue.
 		  The chance of choosing a particular tenant for dequeueing is (1/active_tenants).

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"path"
@@ -358,7 +359,17 @@ FindQueue:
 		return nil, err
 	}
 
-	for userID, queue := range f.queues {
+	keys := make([]string, 0, len(f.queues))
+	for k := range f.queues {
+		keys = append(keys, k)
+	}
+	rand.Shuffle(len(keys), func(i, j int) { keys[i], keys[j] = keys[j], keys[i] })
+
+	for _, userID := range keys {
+		queue, ok := f.queues[userID]
+		if !ok {
+			continue
+		}
 		/*
 		  We want to dequeue the next unexpired request from the chosen tenant queue.
 		  The chance of choosing a particular tenant for dequeueing is (1/active_tenants).

--- a/pkg/querier/frontend/queue_test.go
+++ b/pkg/querier/frontend/queue_test.go
@@ -100,14 +100,20 @@ func BenchmarkGetNextRequest(b *testing.B) {
 	frontends := make([]*Frontend, 0, b.N)
 
 	for n := 0; n < b.N; n++ {
-		f, _ := setupFrontend(config)
+		f, err := setupFrontend(config)
+		if err != nil {
+			b.Fatal(err)
+		}
 
 		for i := 0; i < config.MaxOutstandingPerTenant; i++ {
 			for j := 0; j < numTenants; j++ {
 				userID := strconv.Itoa(j)
 				ctx := user.InjectOrgID(context.Background(), userID)
 
-				_ = f.queueRequest(ctx, testReq(ctx))
+				err = f.queueRequest(ctx, testReq(ctx))
+				if err != nil {
+					b.Fatal(err)
+				}
 			}
 		}
 
@@ -118,7 +124,10 @@ func BenchmarkGetNextRequest(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < config.MaxOutstandingPerTenant*numTenants; j++ {
-			_, _ = frontends[i].getNextRequest(ctx)
+			_, err := frontends[i].getNextRequest(ctx)
+			if err != nil {
+				b.Fatal(err)
+			}
 		}
 	}
 }

--- a/pkg/querier/frontend/queue_test.go
+++ b/pkg/querier/frontend/queue_test.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/go-kit/kit/log"
@@ -11,13 +12,16 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
 
-func setupFrontend(t *testing.T, config Config) *Frontend {
+func setupFrontend(config Config) (*Frontend, error) {
 	logger := log.NewNopLogger()
 
 	frontend, err := New(config, logger, nil)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
+
 	defer frontend.Close()
-	return frontend
+	return frontend, nil
 }
 
 func testReq(ctx context.Context) *request {
@@ -35,7 +39,8 @@ func TestDequeuesExpiredRequests(t *testing.T) {
 	userID := "1"
 	userID2 := "2"
 
-	f := setupFrontend(t, config)
+	f, err := setupFrontend(config)
+	require.NoError(t, err)
 
 	ctx := user.InjectOrgID(context.Background(), userID)
 	expired, cancel := context.WithCancel(ctx)
@@ -83,4 +88,32 @@ func TestDequeuesExpiredRequests(t *testing.T) {
 	}
 	_, ok = f.queues[userID2]
 	require.Equal(t, false, ok)
+}
+
+func BenchmarkGetNextRequest(b *testing.B) {
+	var config Config
+	flagext.DefaultValues(&config)
+	config.MaxOutstandingPerTenant = 1
+
+	const numTenants = 2
+
+	f, _ := setupFrontend(config)
+
+	for i := 0; i < config.MaxOutstandingPerTenant; i++ {
+		for j := 0; j < numTenants; j++ {
+			userID := strconv.Itoa(j)
+			ctx := user.InjectOrgID(context.Background(), userID)
+
+			_ = f.queueRequest(ctx, testReq(ctx))
+		}
+	}
+
+	ctx := context.Background()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < config.MaxOutstandingPerTenant*numTenants-1; j++ {
+			_, _ = f.getNextRequest(ctx)
+		}
+	}
 }


### PR DESCRIPTION
**What this PR does**:
Small simplification to the logic in `getNextRequest` on the query frontend.  Maps are already returned in a random order when ranged over.  Removed code that attempted to pick a random spot in the map of queues to reduce code complexity.

It should be noted that the current code already relies upon the map range behavior in go.  Otherwise the first queue in the map would be underserviced.