### PR TITLE
Configurable delay on rule evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * `cortex_querier_bucket_store_blocks_meta_sync_duration_seconds` > `cortex_querier_blocks_meta_sync_duration_seconds`
   * `cortex_querier_bucket_store_blocks_meta_sync_consistency_delay_seconds` > `cortex_querier_blocks_meta_sync_consistency_delay_seconds`
 * [CHANGE] Experimental TSDB: Modified default values for `compactor.deletion-delay` option from 48h to 12h and `-experimental.tsdb.bucket-store.ignore-deletion-marks-delay` from 24h to 6h. #2414
+* [FEATURE] Ruler: The `-ruler.evaluation-delay` flag was added to allow users to configure a default evaluation delay for all rules in cortex. The default value is 0 which is the current behavior. #2423
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
 * [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383 
 * [ENHANCEMENT] Experimental TSDB: Added `cortex_querier_blocks_meta_synced`, which reflects current state of synced blocks over all tenants. #2392

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -700,10 +700,10 @@ The `ruler_config` configures the Cortex ruler.
 # CLI flag: -ruler.evaluation-interval
 [evaluation_interval: <duration> | default = 1m0s]
 
-# Set interval to delay the evaluation of rules to ensure they underlying
-# metrics have been pushed to cortex. Default
-# CLI flag: -ruler.evaluation-delay
-[evaluation_delay: <duration> | default = 0s]
+# Duration to delay the evaluation of rules to ensure they underlying metrics
+# have been pushed to cortex.
+# CLI flag: -ruler.evaluation-delay-duration
+[evaluation_delay_duration: <duration> | default = 0s]
 
 # How frequently to poll for rule changes
 # CLI flag: -ruler.poll-interval

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -700,6 +700,11 @@ The `ruler_config` configures the Cortex ruler.
 # CLI flag: -ruler.evaluation-interval
 [evaluation_interval: <duration> | default = 1m0s]
 
+# Set interval to delay the evaluation of rules to ensure they underlying
+# metrics have been pushed to cortex. Default
+# CLI flag: -ruler.evaluation-delay
+[evaluation_delay: <duration> | default = 0s]
+
 # How frequently to poll for rule changes
 # CLI flag: -ruler.poll-interval
 [poll_interval: <duration> | default = 1m0s]

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -61,6 +61,9 @@ type Config struct {
 	ExternalURL flagext.URLValue `yaml:"external_url"`
 	// How frequently to evaluate rules by default.
 	EvaluationInterval time.Duration `yaml:"evaluation_interval"`
+	// Delay the evaluation of all rules by a set interval to give a buffer
+	// to metric that haven't been forwarded to cortex yet.
+	EvaluationDelay time.Duration `yaml:"evaluation_delay"`
 	// How frequently to poll for updated rules.
 	PollInterval time.Duration `yaml:"poll_interval"`
 	// Rule Storage and Polling configuration.
@@ -103,6 +106,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.ExternalURL.URL, _ = url.Parse("") // Must be non-nil
 	f.Var(&cfg.ExternalURL, "ruler.external.url", "URL of alerts return path.")
 	f.DurationVar(&cfg.EvaluationInterval, "ruler.evaluation-interval", 1*time.Minute, "How frequently to evaluate rules")
+	f.DurationVar(&cfg.EvaluationDelay, "ruler.evaluation-delay", 0, "Set interval to delay the evaluation of rules to ensure they underlying metrics have been pushed to cortex. Default ")
 	f.DurationVar(&cfg.PollInterval, "ruler.poll-interval", 1*time.Minute, "How frequently to poll for rule changes")
 	f.Var(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "URL of the Alertmanager to send notifications to.")
 	f.BoolVar(&cfg.AlertmanagerDiscovery, "ruler.alertmanager-discovery", false, "Use DNS SRV records to discover alertmanager hosts.")
@@ -480,7 +484,7 @@ func (r *Ruler) newManager(ctx context.Context, userID string) (*promRules.Manag
 	opts := &promRules.ManagerOptions{
 		Appendable:  tsdb,
 		TSDB:        tsdb,
-		QueryFunc:   promRules.EngineQueryFunc(r.engine, r.queryable),
+		QueryFunc:   engineQueryFunc(r.engine, r.queryable, r.cfg.EvaluationDelay),
 		Context:     user.InjectOrgID(ctx, userID),
 		ExternalURL: r.alertURL,
 		NotifyFunc:  sendAlerts(notifier, r.alertURL.String()),

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -63,7 +63,7 @@ type Config struct {
 	EvaluationInterval time.Duration `yaml:"evaluation_interval"`
 	// Delay the evaluation of all rules by a set interval to give a buffer
 	// to metric that haven't been forwarded to cortex yet.
-	EvaluationDelay time.Duration `yaml:"evaluation_delay"`
+	EvaluationDelay time.Duration `yaml:"evaluation_delay_duration"`
 	// How frequently to poll for updated rules.
 	PollInterval time.Duration `yaml:"poll_interval"`
 	// Rule Storage and Polling configuration.
@@ -106,7 +106,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.ExternalURL.URL, _ = url.Parse("") // Must be non-nil
 	f.Var(&cfg.ExternalURL, "ruler.external.url", "URL of alerts return path.")
 	f.DurationVar(&cfg.EvaluationInterval, "ruler.evaluation-interval", 1*time.Minute, "How frequently to evaluate rules")
-	f.DurationVar(&cfg.EvaluationDelay, "ruler.evaluation-delay", 0, "Set interval to delay the evaluation of rules to ensure they underlying metrics have been pushed to cortex. Default ")
+	f.DurationVar(&cfg.EvaluationDelay, "ruler.evaluation-delay-duration", 0, "Duration to delay the evaluation of rules to ensure they underlying metrics have been pushed to cortex.")
 	f.DurationVar(&cfg.PollInterval, "ruler.poll-interval", 1*time.Minute, "How frequently to poll for rule changes")
 	f.Var(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "URL of the Alertmanager to send notifications to.")
 	f.BoolVar(&cfg.AlertmanagerDiscovery, "ruler.alertmanager-discovery", false, "Use DNS SRV records to discover alertmanager hosts.")


### PR DESCRIPTION
**What this PR does**:

This PR gives the operator the option to add an evaluation delay interval to the Ruler. This can be configured to ensure the ruler does not evaluate rules before the data required for the evaluation of those rules is written to Cortex.

**Which issue(s) this PR fixes**:
Fixes #1723

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
