### PR TITLE
Don't checkpoint when shutting down

### DIFF
--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -172,10 +172,6 @@ func (w *walWrapper) run() {
 			level.Info(util.Logger).Log("msg", "checkpoint done", "time", elapsed.String())
 			w.checkpointDuration.Observe(elapsed.Seconds())
 		case <-w.quit:
-			level.Info(util.Logger).Log("msg", "creating checkpoint before shutdown")
-			if err := w.performCheckpoint(true); err != nil {
-				level.Error(util.Logger).Log("msg", "error checkpointing series during shutdown", "err", err)
-			}
 			return
 		}
 	}


### PR DESCRIPTION
As checkpointing is spread over the checkpoint duration, we don't need to start another checkpointing at the end as one checkpoint would be just over.

Opened as draft as I have to see if the additional replay time that it incurs is less than checkpointing itself (if not, checkpointing at the end is better).