### PR TITLE
Set JoinAfter to 0 if WAL is enabled

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -147,6 +147,9 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 		// or the data has to be flushed during scaledown.
 		cfg.MaxTransferRetries = 0
 
+		// Transfers are disabled with WAL, hence no need to wait for transfers.
+		cfg.LifecyclerConfig.JoinAfter = 0
+
 		recordPool = sync.Pool{
 			New: func() interface{} {
 				return &Record{}


### PR DESCRIPTION
Transfers are disabled with WAL, hence no need to wait for transfers. Makes restarts faster.