### PR TITLE
Fix List in mock consul

### DIFF
--- a/integration/kv_test.go
+++ b/integration/kv_test.go
@@ -54,12 +54,19 @@ func TestKV_List_Delete(t *testing.T) {
 	}, stringCodec{})
 	require.NoError(t, err)
 
+	mockKv, err := kv.NewClient(kv.Config{
+		Store:  "inmemory",
+		Prefix: "keys/",
+	}, stringCodec{})
+	require.NoError(t, err)
+
 	kvs := []struct {
 		name string
 		kv   kv.Client
 	}{
 		{"etcd", etcdKv},
 		{"consul", consulKv},
+		{"inmemory", mockKv},
 	}
 
 	for _, kv := range kvs {

--- a/integration/kv_test.go
+++ b/integration/kv_test.go
@@ -54,19 +54,12 @@ func TestKV_List_Delete(t *testing.T) {
 	}, stringCodec{})
 	require.NoError(t, err)
 
-	mockKv, err := kv.NewClient(kv.Config{
-		Store:  "inmemory",
-		Prefix: "keys/",
-	}, stringCodec{})
-	require.NoError(t, err)
-
 	kvs := []struct {
 		name string
 		kv   kv.Client
 	}{
 		{"etcd", etcdKv},
 		{"consul", consulKv},
-		{"inmemory", mockKv},
 	}
 
 	for _, kv := range kvs {

--- a/pkg/ring/kv/consul/mock.go
+++ b/pkg/ring/kv/consul/mock.go
@@ -164,17 +164,19 @@ func (m *mockKV) List(prefix string, q *consul.QueryOptions) (consul.KVPairs, *c
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	deadline := time.Now().Add(mockedMaxWaitTime(q.WaitTime))
-	if ctxDeadline, ok := q.Context().Deadline(); ok && ctxDeadline.Before(deadline) {
-		// respect deadline from context, if set.
-		deadline = ctxDeadline
-	}
+	if q.WaitTime > 0 {
+		deadline := time.Now().Add(mockedMaxWaitTime(q.WaitTime))
+		if ctxDeadline, ok := q.Context().Deadline(); ok && ctxDeadline.Before(deadline) {
+			// respect deadline from context, if set.
+			deadline = ctxDeadline
+		}
 
-	for q.WaitIndex >= m.current && time.Now().Before(deadline) {
-		m.cond.Wait()
-	}
-	if time.Now().After(deadline) {
-		return nil, &consul.QueryMeta{LastIndex: q.WaitIndex}, nil
+		for q.WaitIndex >= m.current && time.Now().Before(deadline) {
+			m.cond.Wait()
+		}
+		if time.Now().After(deadline) {
+			return nil, &consul.QueryMeta{LastIndex: q.WaitIndex}, nil
+		}
 	}
 
 	result := consul.KVPairs{}


### PR DESCRIPTION
Using List on the inmemory KV store always silently failed because the Consul WaitTime is always zero, which the mock implementation treated as already past the deadline.

Signed-off-by: Robert Fratto <robert.fratto@grafana.com>

/cc @pstibrany 