### PR TITLE
Remove additional step, the issue is closed?

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,10 +72,6 @@ jobs:
     - run:
         name: Lint
         command: make BUILD_IN_CONTAINER=false lint
-    # fails to run everything first time - see https://github.com/golangci/golangci-lint/issues/866
-    - run:
-        name: Lint again
-        command: make BUILD_IN_CONTAINER=false lint
     - run:
         name: Check vendor directory is consistent.
         command: make BUILD_IN_CONTAINER=false mod-check


### PR DESCRIPTION
Was going through the circle config and realised that we're running lint because of an issue that has since been closed. 