### PR TITLE
Move GRPC health check to separate package

### DIFF
--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/storegateway"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/grpc/healthcheck"
 	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/validation"
@@ -322,7 +323,7 @@ func (t *Cortex) Run() error {
 	// before starting servers, register /ready handler and gRPC health check service.
 	// It should reflect entire Cortex.
 	t.server.HTTP.Path("/ready").Handler(t.readyHandler(sm))
-	grpc_health_v1.RegisterHealthServer(t.server.GRPC, newHealthCheck(sm))
+	grpc_health_v1.RegisterHealthServer(t.server.GRPC, healthcheck.New(sm))
 
 	// Let's listen for events from this manager, and log them.
 	healthy := func() { level.Info(util.Logger).Log("msg", "Cortex started") }

--- a/pkg/util/grpc/healthcheck/health_check.go
+++ b/pkg/util/grpc/healthcheck/health_check.go
@@ -1,4 +1,4 @@
-package cortex
+package healthcheck
 
 import (
 	"context"
@@ -10,18 +10,21 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
-type healthCheck struct {
+// HealthCheck fulfills the grpc_health_v1.HealthServer interface by ensuring
+// the services being managed by the provided service manager are healthy.
+type HealthCheck struct {
 	sm *services.Manager
 }
 
-func newHealthCheck(sm *services.Manager) *healthCheck {
-	return &healthCheck{
+// New returns a new HealthCheck for the provided service manager.
+func New(sm *services.Manager) *HealthCheck {
+	return &HealthCheck{
 		sm: sm,
 	}
 }
 
 // Check implements the grpc healthcheck.
-func (h *healthCheck) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+func (h *HealthCheck) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
 	if !h.isHealthy() {
 		return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
 	}
@@ -30,12 +33,12 @@ func (h *healthCheck) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequ
 }
 
 // Watch implements the grpc healthcheck.
-func (h *healthCheck) Watch(_ *grpc_health_v1.HealthCheckRequest, _ grpc_health_v1.Health_WatchServer) error {
+func (h *HealthCheck) Watch(_ *grpc_health_v1.HealthCheckRequest, _ grpc_health_v1.Health_WatchServer) error {
 	return status.Error(codes.Unimplemented, "Watching is not supported")
 }
 
 // isHealthy returns whether the Cortex instance should be considered healthy.
-func (h *healthCheck) isHealthy() bool {
+func (h *HealthCheck) isHealthy() bool {
 	states := h.sm.ServicesByState()
 
 	// Given this is an health check endpoint for the whole instance, we should consider

--- a/pkg/util/grpc/healthcheck/health_check_test.go
+++ b/pkg/util/grpc/healthcheck/health_check_test.go
@@ -1,4 +1,4 @@
-package cortex
+package healthcheck
 
 import (
 	"context"
@@ -73,7 +73,7 @@ func TestHealthCheck_isHealthy(t *testing.T) {
 				s.(*mockService).switchState(testData.states[i])
 			}
 
-			h := newHealthCheck(sm)
+			h := New(sm)
 			assert.Equal(t, testData.expected, h.isHealthy())
 		})
 	}


### PR DESCRIPTION
**What this PR does**:

In order to reduce the amount of code in `pkg/cortex` I moved the healthCheck grpc handler into a separate package located at `pkg/utils/grpc/healthcheck`. I think this makes sense since it has not dependencies on anything else in the `pkg/cortex` package and could be useful for anyone trying to utilize the `pkg/utils/services package`.
