### PR TITLE
Create index table from local table client for boltdb 

### DIFF
--- a/pkg/chunk/local/boltdb_table_client.go
+++ b/pkg/chunk/local/boltdb_table_client.go
@@ -36,7 +36,12 @@ func (c *TableClient) ListTables(ctx context.Context) ([]string, error) {
 }
 
 func (c *TableClient) CreateTable(ctx context.Context, desc chunk.TableDesc) error {
-	return nil
+	file, err := os.OpenFile(filepath.Join(c.directory, desc.Name), os.O_CREATE|os.O_RDONLY, 0666)
+	if err != nil {
+		return err
+	}
+
+	return file.Close()
 }
 
 func (c *TableClient) DeleteTable(ctx context.Context, name string) error {

--- a/pkg/chunk/local/fixtures.go
+++ b/pkg/chunk/local/fixtures.go
@@ -59,6 +59,10 @@ func (f *fixture) Clients() (
 				Prefix: "chunks",
 				Period: 10 * time.Minute,
 			},
+			IndexTables: chunk.PeriodicTableConfig{
+				Prefix: "index",
+				Period: 10 * time.Minute,
+			},
 		}},
 	}
 


### PR DESCRIPTION
**What this PR does**:
When using boltdb for index, calling create and update table doesn't have any action and this makes logs too much verbose.
Reference: https://github.com/grafana/loki/issues/1786

**Checklist**
- [x] Tests updated
