### PR TITLE
Removed querier dependency from storegateway pkg

### DIFF
--- a/pkg/querier/blocks_bucket_stores_service.go
+++ b/pkg/querier/blocks_bucket_stores_service.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/storegateway"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -27,11 +28,11 @@ type BucketStoresService struct {
 
 	cfg    tsdb.Config
 	logger log.Logger
-	stores *BucketStores
+	stores *storegateway.BucketStores
 }
 
 func NewBucketStoresService(cfg tsdb.Config, bucketClient objstore.Bucket, logLevel logging.Level, logger log.Logger, registerer prometheus.Registerer) (*BucketStoresService, error) {
-	stores, err := NewBucketStores(cfg, nil, bucketClient, logLevel, logger, registerer)
+	stores, err := storegateway.NewBucketStores(cfg, nil, bucketClient, logLevel, logger, registerer)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +100,7 @@ func (s *BucketStoresService) Series(ctx context.Context, userID string, req *st
 	// Inject the user ID into the context metadata, as expected by BucketStores.
 	ctx = setUserIDToGRPCContext(ctx, userID)
 
-	srv := newBucketStoreSeriesServer(ctx)
+	srv := storegateway.NewBucketStoreSeriesServer(ctx)
 	err := s.stores.Series(req, srv)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/querier/blocks_bucket_stores_service_test.go
+++ b/pkg/querier/blocks_bucket_stores_service_test.go
@@ -3,16 +3,18 @@ package querier
 import (
 	"context"
 	"errors"
-	"sync/atomic"
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/thanos-io/thanos/pkg/store"
+	"github.com/weaveworks/common/logging"
 
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
+	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -74,30 +76,27 @@ func TestBucketStoresService_InitialSync(t *testing.T) {
 	}
 }
 
-func TestBucketStoresService_syncUsersBlocks(t *testing.T) {
-	cfg, cleanup := prepareStorageConfig(t)
-	cfg.BucketStore.TenantSyncConcurrency = 2
-	defer cleanup()
-
-	// Disable the sync interval so that there will be no initial sync.
-	cfg.BucketStore.SyncInterval = 0
-
-	bucketClient := &tsdb.BucketClientMock{}
-	bucketClient.MockIter("", []string{"user-1", "user-2", "user-3"}, nil)
-
-	us, err := NewBucketStoresService(cfg, bucketClient, mockLoggingLevel(), log.NewNopLogger(), nil)
+func prepareStorageConfig(t *testing.T) (cortex_tsdb.Config, func()) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "blocks-sync-*")
 	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), us))
-	defer services.StopAndAwaitTerminated(context.Background(), us) //nolint:errcheck
 
-	// Sync user stores and count the number of times the callback is called.
-	storesCount := int32(0)
-	err = us.stores.syncUsersBlocks(context.Background(), func(ctx context.Context, bs *store.BucketStore) error {
-		atomic.AddInt32(&storesCount, 1)
-		return nil
-	})
+	cfg := cortex_tsdb.Config{}
+	flagext.DefaultValues(&cfg)
+	cfg.BucketStore.SyncDir = tmpDir
 
-	assert.NoError(t, err)
-	bucketClient.AssertNumberOfCalls(t, "Iter", 1)
-	assert.Equal(t, storesCount, int32(3))
+	cleanup := func() {
+		require.NoError(t, os.RemoveAll(tmpDir))
+	}
+
+	return cfg, cleanup
+}
+
+func mockLoggingLevel() logging.Level {
+	level := logging.Level{}
+	err := level.Set("info")
+	if err != nil {
+		panic(err)
+	}
+
+	return level
 }

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -20,6 +20,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore"
 
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/storegateway"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
@@ -44,7 +45,7 @@ type BlocksScanner struct {
 	cfg             BlocksScannerConfig
 	logger          log.Logger
 	bucketClient    objstore.Bucket
-	fetchersMetrics *metaFetcherMetrics
+	fetchersMetrics *storegateway.MetadataFetcherMetrics
 
 	// We reuse the metadata fetcher instance for a given tenant both because of performance
 	// reasons (the fetcher keeps a in-memory cache) and being able to collect and group metrics.
@@ -65,7 +66,7 @@ func NewBlocksScanner(cfg BlocksScannerConfig, bucketClient objstore.Bucket, log
 		bucketClient:    bucketClient,
 		fetchers:        make(map[string]block.MetadataFetcher),
 		metas:           make(map[string][]*metadata.Meta),
-		fetchersMetrics: newMetaFetcherMetrics(),
+		fetchersMetrics: storegateway.NewMetadataFetcherMetrics(),
 		scanDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_querier_blocks_scan_duration_seconds",
 			Help:    "The total time it takes to run a full blocks scan across the storage.",
@@ -289,7 +290,7 @@ func (d *BlocksScanner) createMetaFetcher(userID string) (block.MetadataFetcher,
 		return nil, err
 	}
 
-	d.fetchersMetrics.addUserRegistry(userID, userReg)
+	d.fetchersMetrics.AddUserRegistry(userID, userReg)
 	return f, nil
 }
 

--- a/pkg/storegateway/bucket_store_inmemory_server.go
+++ b/pkg/storegateway/bucket_store_inmemory_server.go
@@ -1,4 +1,4 @@
-package querier
+package storegateway
 
 import (
 	"context"
@@ -8,10 +8,10 @@ import (
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
-// bucketStoreSeriesServer is an fake in-memory gRPC server used to
+// BucketStoreSeriesServer is an fake in-memory gRPC server used to
 // call Thanos BucketStore.Series() without having to go through the
 // gRPC networking stack.
-type bucketStoreSeriesServer struct {
+type BucketStoreSeriesServer struct {
 	// This field just exist to pseudo-implement the unused methods of the interface.
 	storepb.Store_SeriesServer
 
@@ -21,11 +21,11 @@ type bucketStoreSeriesServer struct {
 	Warnings  storage.Warnings
 }
 
-func newBucketStoreSeriesServer(ctx context.Context) *bucketStoreSeriesServer {
-	return &bucketStoreSeriesServer{ctx: ctx}
+func NewBucketStoreSeriesServer(ctx context.Context) *BucketStoreSeriesServer {
+	return &BucketStoreSeriesServer{ctx: ctx}
 }
 
-func (s *bucketStoreSeriesServer) Send(r *storepb.SeriesResponse) error {
+func (s *BucketStoreSeriesServer) Send(r *storepb.SeriesResponse) error {
 	if r.GetWarning() != "" {
 		s.Warnings = append(s.Warnings, errors.New(r.GetWarning()))
 	}
@@ -51,6 +51,6 @@ func (s *bucketStoreSeriesServer) Send(r *storepb.SeriesResponse) error {
 	return nil
 }
 
-func (s *bucketStoreSeriesServer) Context() context.Context {
+func (s *BucketStoreSeriesServer) Context() context.Context {
 	return s.ctx
 }

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -1,4 +1,4 @@
-package querier
+package storegateway
 
 import (
 	"sync"

--- a/pkg/storegateway/bucket_store_metrics_test.go
+++ b/pkg/storegateway/bucket_store_metrics_test.go
@@ -1,4 +1,4 @@
-package querier
+package storegateway
 
 import (
 	"bytes"

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -1,4 +1,4 @@
-package querier
+package storegateway
 
 import (
 	"context"
@@ -33,7 +33,7 @@ type BucketStores struct {
 	bucket             objstore.Bucket
 	logLevel           logging.Level
 	bucketStoreMetrics *BucketStoreMetrics
-	metaFetcherMetrics *metaFetcherMetrics
+	metaFetcherMetrics *MetadataFetcherMetrics
 	indexCacheMetrics  prometheus.Collector
 	filters            []block.MetadataFilter
 
@@ -60,7 +60,7 @@ func NewBucketStores(cfg tsdb.Config, filters []block.MetadataFilter, bucketClie
 		stores:             map[string]*store.BucketStore{},
 		logLevel:           logLevel,
 		bucketStoreMetrics: NewBucketStoreMetrics(),
-		metaFetcherMetrics: newMetaFetcherMetrics(),
+		metaFetcherMetrics: NewMetadataFetcherMetrics(),
 		indexCacheMetrics:  tsdb.MustNewIndexCacheMetrics(cfg.BucketStore.IndexCache.Backend, indexCacheRegistry),
 		syncTimes: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_querier_blocks_sync_seconds",
@@ -254,7 +254,7 @@ func (u *BucketStores) getOrCreateStore(userID string) (*store.BucketStore, erro
 	}
 
 	u.stores[userID] = bs
-	u.metaFetcherMetrics.addUserRegistry(userID, fetcherReg)
+	u.metaFetcherMetrics.AddUserRegistry(userID, fetcherReg)
 	u.bucketStoreMetrics.AddUserRegistry(userID, bucketStoreReg)
 
 	return bs, nil

--- a/pkg/storegateway/metadata_fetcher_metrics.go
+++ b/pkg/storegateway/metadata_fetcher_metrics.go
@@ -1,4 +1,4 @@
-package querier
+package storegateway
 
 import (
 	"sync"
@@ -10,7 +10,7 @@ import (
 
 // This struct aggregates metrics exported by Thanos MetaFetcher
 // and re-exports those aggregates as Cortex metrics.
-type metaFetcherMetrics struct {
+type MetadataFetcherMetrics struct {
 	// Maps userID -> registry
 	regsMu sync.Mutex
 	regs   map[string]*prometheus.Registry
@@ -26,8 +26,8 @@ type metaFetcherMetrics struct {
 	// blocks_meta_modified
 }
 
-func newMetaFetcherMetrics() *metaFetcherMetrics {
-	return &metaFetcherMetrics{
+func NewMetadataFetcherMetrics() *MetadataFetcherMetrics {
+	return &MetadataFetcherMetrics{
 		regs: map[string]*prometheus.Registry{},
 
 		syncs: prometheus.NewDesc(
@@ -53,13 +53,13 @@ func newMetaFetcherMetrics() *metaFetcherMetrics {
 	}
 }
 
-func (m *metaFetcherMetrics) addUserRegistry(user string, reg *prometheus.Registry) {
+func (m *MetadataFetcherMetrics) AddUserRegistry(user string, reg *prometheus.Registry) {
 	m.regsMu.Lock()
 	m.regs[user] = reg
 	m.regsMu.Unlock()
 }
 
-func (m *metaFetcherMetrics) registries() map[string]*prometheus.Registry {
+func (m *MetadataFetcherMetrics) registries() map[string]*prometheus.Registry {
 	regs := map[string]*prometheus.Registry{}
 
 	m.regsMu.Lock()
@@ -71,7 +71,7 @@ func (m *metaFetcherMetrics) registries() map[string]*prometheus.Registry {
 	return regs
 }
 
-func (m *metaFetcherMetrics) Describe(out chan<- *prometheus.Desc) {
+func (m *MetadataFetcherMetrics) Describe(out chan<- *prometheus.Desc) {
 
 	out <- m.syncs
 	out <- m.syncFailures
@@ -80,7 +80,7 @@ func (m *metaFetcherMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.synced
 }
 
-func (m *metaFetcherMetrics) Collect(out chan<- prometheus.Metric) {
+func (m *MetadataFetcherMetrics) Collect(out chan<- prometheus.Metric) {
 	data := util.BuildMetricFamiliesPerUserFromUserRegistries(m.registries())
 
 	data.SendSumOfCounters(out, m.syncs, "blocks_meta_syncs_total")

--- a/pkg/storegateway/metadata_fetcher_metrics_test.go
+++ b/pkg/storegateway/metadata_fetcher_metrics_test.go
@@ -1,4 +1,4 @@
-package querier
+package storegateway
 
 import (
 	"bytes"
@@ -10,15 +10,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMetaFetcherMetrics(t *testing.T) {
+func TestMetadataFetcherMetrics(t *testing.T) {
 	mainReg := prometheus.NewPedanticRegistry()
 
-	metrics := newMetaFetcherMetrics()
+	metrics := NewMetadataFetcherMetrics()
 	mainReg.MustRegister(metrics)
 
-	metrics.addUserRegistry("user1", populateMetaFetcherMetrics(3))
-	metrics.addUserRegistry("user2", populateMetaFetcherMetrics(5))
-	metrics.addUserRegistry("user3", populateMetaFetcherMetrics(7))
+	metrics.AddUserRegistry("user1", populateMetadataFetcherMetrics(3))
+	metrics.AddUserRegistry("user2", populateMetadataFetcherMetrics(5))
+	metrics.AddUserRegistry("user3", populateMetadataFetcherMetrics(7))
 
 	//noinspection ALL
 	err := testutil.GatherAndCompare(mainReg, bytes.NewBufferString(`
@@ -54,9 +54,9 @@ func TestMetaFetcherMetrics(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func populateMetaFetcherMetrics(base float64) *prometheus.Registry {
+func populateMetadataFetcherMetrics(base float64) *prometheus.Registry {
 	reg := prometheus.NewRegistry()
-	m := newMetaFetcherMetricsMock(reg)
+	m := newMetadataFetcherMetricsMock(reg)
 
 	m.syncs.Add(base * 1)
 	m.syncFailures.Add(base * 2)
@@ -70,7 +70,7 @@ func populateMetaFetcherMetrics(base float64) *prometheus.Registry {
 	return reg
 }
 
-type metaFetcherMetricsMock struct {
+type metadataFetcherMetricsMock struct {
 	syncs                prometheus.Counter
 	syncFailures         prometheus.Counter
 	syncDuration         prometheus.Histogram
@@ -78,8 +78,8 @@ type metaFetcherMetricsMock struct {
 	synced               *prometheus.GaugeVec
 }
 
-func newMetaFetcherMetricsMock(reg prometheus.Registerer) *metaFetcherMetricsMock {
-	var m metaFetcherMetricsMock
+func newMetadataFetcherMetricsMock(reg prometheus.Registerer) *metadataFetcherMetricsMock {
+	var m metadataFetcherMetricsMock
 
 	m.syncs = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Subsystem: "blocks_meta",


### PR DESCRIPTION
**What this PR does**:
As part of the work I'm doing on the `store-gateway`, for a while we'll have both the querier and `store-gateway` synching blocks (at the end, only the `store-gateway` will do). Currently the shared bucket store logic is in `pkg/querier` while we should transition to move all such logic to `pkg/storegateway`.

Conceptually (and also practically to avoid circular dependencies) the querier depends on the store-gateway but not viceversa, so in this PR I'm removing any `pkg/querier` dependency from `pkg/storegateway` moving the shared logic from the querier to the store-gateway (which is where it should live anyway once the querier will not sync blocks anymore).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
