### PR TITLE
Allow custom replication strategy in the Ring

### DIFF
--- a/pkg/ring/replication_strategy.go
+++ b/pkg/ring/replication_strategy.go
@@ -2,22 +2,37 @@ package ring
 
 import (
 	"fmt"
+	"time"
 )
 
-// replicationStrategy decides, given the set of ingesters eligible for a key,
+type ReplicationStrategy interface {
+	// Filter out unhealthy instances and checks if there're enough instances
+	// for an operation to succeed. Returns an error if there are not enough
+	// instances.
+	Filter(instances []IngesterDesc, op Operation, replicationFactor int, heartbeatTimeout time.Duration) (healthy []IngesterDesc, maxFailures int, err error)
+
+	// ShouldExtendReplicaSet returns true if given an instance that's going to be
+	// added to the replica set, the replica set size should be extended by 1
+	// more instance for the given operation.
+	ShouldExtendReplicaSet(instance IngesterDesc, op Operation) bool
+}
+
+type DefaultReplicationStrategy struct{}
+
+// Filter decides, given the set of ingesters eligible for a key,
 // which ingesters you will try and write to and how many failures you will
 // tolerate.
 // - Filters out dead ingesters so the one doesn't even try to write to them.
 // - Checks there is enough ingesters for an operation to succeed.
 // The ingesters argument may be overwritten.
-func (r *Ring) replicationStrategy(ingesters []IngesterDesc, op Operation) ([]IngesterDesc, int, error) {
+func (s *DefaultReplicationStrategy) Filter(ingesters []IngesterDesc, op Operation, replicationFactor int, heartbeatTimeout time.Duration) ([]IngesterDesc, int, error) {
 	// We need a response from a quorum of ingesters, which is n/2 + 1.  In the
 	// case of a node joining/leaving, the actual replica set might be bigger
 	// than the replication factor, so use the bigger or the two.
-	replicationFactor := r.cfg.ReplicationFactor
 	if len(ingesters) > replicationFactor {
 		replicationFactor = len(ingesters)
 	}
+
 	minSuccess := (replicationFactor / 2) + 1
 	maxFailure := replicationFactor - minSuccess
 
@@ -25,7 +40,7 @@ func (r *Ring) replicationStrategy(ingesters []IngesterDesc, op Operation) ([]In
 	// included in the calculation of minSuccess, so if too many failed ingesters
 	// will cause the whole write to fail.
 	for i := 0; i < len(ingesters); {
-		if r.IsHealthy(&ingesters[i], op) {
+		if ingesters[i].IsHealthy(op, heartbeatTimeout) {
 			i++
 		} else {
 			ingesters = append(ingesters[:i], ingesters[i+1:]...)
@@ -42,6 +57,22 @@ func (r *Ring) replicationStrategy(ingesters []IngesterDesc, op Operation) ([]In
 	}
 
 	return ingesters, maxFailure, nil
+}
+
+func (s *DefaultReplicationStrategy) ShouldExtendReplicaSet(ingester IngesterDesc, op Operation) bool {
+	// We do not want to Write to Ingesters that are not ACTIVE, but we do want
+	// to write the extra replica somewhere.  So we increase the size of the set
+	// of replicas for the key. This means we have to also increase the
+	// size of the replica set for read, but we can read from Leaving ingesters,
+	// so don't skip it in this case.
+	// NB dead ingester will be filtered later by DefaultReplicationStrategy.Filter().
+	if op == Write && ingester.State != ACTIVE {
+		return true
+	} else if op == Read && (ingester.State != ACTIVE && ingester.State != LEAVING) {
+		return true
+	}
+
+	return false
 }
 
 // IsHealthy checks whether an ingester appears to be alive and heartbeating

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -46,6 +46,7 @@ func benchmarkBatch(b *testing.B, numIngester, numKeys int) {
 		name:     "ingester",
 		cfg:      cfg,
 		ringDesc: desc,
+		strategy: &DefaultReplicationStrategy{},
 	}
 
 	ctx := context.Background()
@@ -87,6 +88,7 @@ func TestDoBatchZeroIngesters(t *testing.T) {
 		name:     "ingester",
 		cfg:      Config{},
 		ringDesc: desc,
+		strategy: &DefaultReplicationStrategy{},
 	}
 	require.Error(t, DoBatch(ctx, &r, keys, callback, cleanup))
 }
@@ -143,6 +145,7 @@ func TestSubring(t *testing.T) {
 		},
 		ringDesc:   r,
 		ringTokens: r.getTokens(),
+		strategy:   &DefaultReplicationStrategy{},
 	}
 
 	// Subring of 0 invalid
@@ -197,6 +200,7 @@ func TestStableSubring(t *testing.T) {
 		},
 		ringDesc:   r,
 		ringTokens: r.getTokens(),
+		strategy:   &DefaultReplicationStrategy{},
 	}
 
 	// Generate the same subring multiple times
@@ -256,6 +260,7 @@ func TestZoneAwareIngesterAssignmentSucccess(t *testing.T) {
 		},
 		ringDesc:   r,
 		ringTokens: r.getTokens(),
+		strategy:   &DefaultReplicationStrategy{},
 	}
 	// use the GenerateTokens to get an array of random uint32 values
 	testValues := make([]uint32, testCount)
@@ -320,6 +325,7 @@ func TestZoneAwareIngesterAssignmentFailure(t *testing.T) {
 		},
 		ringDesc:   r,
 		ringTokens: r.getTokens(),
+		strategy:   &DefaultReplicationStrategy{},
 	}
 	// use the GenerateTokens to get an array of random uint32 values
 	testValues := make([]uint32, testCount)


### PR DESCRIPTION
**What this PR does**:
The upcoming `store-gateway` will need a replication strategy different than the ingesters one. In this PR I've refactored the ring, extracting the replication strategy into an interface which can be plugged via `ring.NewWithStoreClientAndStrategy()` (this function is still unused, but will be used in a subsequent PR).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
