### PR TITLE
Refactor Schema to make code more explicit about interface usage

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -81,7 +81,7 @@ type baseStore struct {
 	*Fetcher
 }
 
-func newReadStore(cfg StoreConfig, schema BaseSchema, index IndexClient, chunks Client, limits StoreLimits, chunksCache cache.Cache) (baseStore, error) {
+func newBaseStore(cfg StoreConfig, schema BaseSchema, index IndexClient, chunks Client, limits StoreLimits, chunksCache cache.Cache) (baseStore, error) {
 	fetcher, err := NewChunkFetcher(chunksCache, cfg.chunkCacheStubs, chunks)
 	if err != nil {
 		return baseStore{}, err
@@ -104,7 +104,7 @@ type store struct {
 }
 
 func newStore(cfg StoreConfig, schema StoreSchema, index IndexClient, chunks Client, limits StoreLimits, chunksCache cache.Cache) (Store, error) {
-	rs, err := newReadStore(cfg, schema, index, chunks, limits, chunksCache)
+	rs, err := newBaseStore(cfg, schema, index, chunks, limits, chunksCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -71,30 +71,47 @@ func (cfg *StoreConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.MaxLookBackPeriod, "store.max-look-back-period", 0, "Limit how long back data can be queried")
 }
 
-// store implements Store
-type store struct {
+type baseStore struct {
 	cfg StoreConfig
 
 	index  IndexClient
 	chunks Client
-	schema Schema
+	schema BaseSchema
 	limits StoreLimits
 	*Fetcher
 }
 
-func newStore(cfg StoreConfig, schema Schema, index IndexClient, chunks Client, limits StoreLimits, chunksCache cache.Cache) (Store, error) {
+func newReadStore(cfg StoreConfig, schema BaseSchema, index IndexClient, chunks Client, limits StoreLimits, chunksCache cache.Cache) (baseStore, error) {
 	fetcher, err := NewChunkFetcher(chunksCache, cfg.chunkCacheStubs, chunks)
 	if err != nil {
-		return nil, err
+		return baseStore{}, err
 	}
 
-	return &store{
+	return baseStore{
 		cfg:     cfg,
 		index:   index,
 		chunks:  chunks,
 		schema:  schema,
 		limits:  limits,
 		Fetcher: fetcher,
+	}, nil
+}
+
+// store implements Store
+type store struct {
+	baseStore
+	schema StoreSchema
+}
+
+func newStore(cfg StoreConfig, schema StoreSchema, index IndexClient, chunks Client, limits StoreLimits, chunksCache cache.Cache) (Store, error) {
+	rs, err := newReadStore(cfg, schema, index, chunks, limits, chunksCache)
+	if err != nil {
+		return nil, err
+	}
+
+	return &store{
+		baseStore: rs,
+		schema:    schema,
 	}, nil
 }
 
@@ -187,7 +204,7 @@ func (c *store) GetChunkRefs(ctx context.Context, userID string, from, through m
 }
 
 // LabelValuesForMetricName retrieves all label values for a single label name and metric name.
-func (c *store) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName, labelName string) ([]string, error) {
+func (c *baseStore) LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName, labelName string) ([]string, error) {
 	log, ctx := spanlogger.New(ctx, "ChunkStore.LabelValues")
 	defer log.Span.Finish()
 	level.Debug(log).Log("from", from, "through", through, "metricName", metricName, "labelName", labelName)
@@ -253,7 +270,7 @@ func (c *store) LabelNamesForMetricName(ctx context.Context, userID string, from
 	return labelNamesFromChunks(allChunks), nil
 }
 
-func (c *store) validateQueryTimeRange(ctx context.Context, userID string, from *model.Time, through *model.Time) (bool, error) {
+func (c *baseStore) validateQueryTimeRange(ctx context.Context, userID string, from *model.Time, through *model.Time) (bool, error) {
 	//nolint:ineffassign,staticcheck //Leaving ctx even though we don't currently use it, we want to make it available for when we might need it and hopefully will ensure us using the correct context at that time
 	log, ctx := spanlogger.New(ctx, "store.validateQueryTimeRange")
 	defer log.Span.Finish()
@@ -291,7 +308,7 @@ func (c *store) validateQueryTimeRange(ctx context.Context, userID string, from 
 	return false, nil
 }
 
-func (c *store) validateQuery(ctx context.Context, userID string, from *model.Time, through *model.Time, matchers []*labels.Matcher) (string, []*labels.Matcher, bool, error) {
+func (c *baseStore) validateQuery(ctx context.Context, userID string, from *model.Time, through *model.Time, matchers []*labels.Matcher) (string, []*labels.Matcher, bool, error) {
 	log, ctx := spanlogger.New(ctx, "store.validateQuery")
 	defer log.Span.Finish()
 
@@ -436,7 +453,7 @@ func (c *store) lookupChunksByMetricName(ctx context.Context, userID string, fro
 	return c.convertChunkIDsToChunks(ctx, userID, chunkIDs)
 }
 
-func (c *store) lookupEntriesByQueries(ctx context.Context, queries []IndexQuery) ([]IndexEntry, error) {
+func (c *baseStore) lookupEntriesByQueries(ctx context.Context, queries []IndexQuery) ([]IndexEntry, error) {
 	log, ctx := spanlogger.New(ctx, "store.lookupEntriesByQueries")
 	defer log.Span.Finish()
 
@@ -462,7 +479,7 @@ func (c *store) lookupEntriesByQueries(ctx context.Context, queries []IndexQuery
 	return entries, err
 }
 
-func (c *store) parseIndexEntries(ctx context.Context, entries []IndexEntry, matcher *labels.Matcher) ([]string, error) {
+func (c *baseStore) parseIndexEntries(ctx context.Context, entries []IndexEntry, matcher *labels.Matcher) ([]string, error) {
 	result := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		chunkKey, labelValue, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
@@ -481,7 +498,7 @@ func (c *store) parseIndexEntries(ctx context.Context, entries []IndexEntry, mat
 	return result, nil
 }
 
-func (c *store) convertChunkIDsToChunks(ctx context.Context, userID string, chunkIDs []string) ([]Chunk, error) {
+func (c *baseStore) convertChunkIDsToChunks(ctx context.Context, userID string, chunkIDs []string) ([]Chunk, error) {
 	chunkSet := make([]Chunk, 0, len(chunkIDs))
 	for _, chunkID := range chunkIDs {
 		chunk, err := ParseExternalKey(userID, chunkID)
@@ -510,7 +527,7 @@ func (c *store) DeleteChunk(ctx context.Context, from, through model.Time, userI
 	})
 }
 
-func (c *store) deleteChunk(ctx context.Context,
+func (c *baseStore) deleteChunk(ctx context.Context,
 	userID string,
 	chunkID string,
 	metric labels.Labels,
@@ -552,7 +569,7 @@ func (c *store) deleteChunk(ctx context.Context,
 	return nil
 }
 
-func (c *store) reboundChunk(ctx context.Context, userID, chunkID string, partiallyDeletedInterval model.Interval, putChunkFunc func(chunk Chunk) error) error {
+func (c *baseStore) reboundChunk(ctx context.Context, userID, chunkID string, partiallyDeletedInterval model.Interval, putChunkFunc func(chunk Chunk) error) error {
 	chunk, err := ParseExternalKey(userID, chunkID)
 	if err != nil {
 		return errors.Wrap(err, "when parsing external key")

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -40,7 +40,7 @@ func labelNamesFromChunks(chunks []Chunk) []string {
 	var result UniqueStrings
 	for _, c := range chunks {
 		for _, l := range c.Metric {
-			result.Add(string(l.Name))
+			result.Add(l.Name)
 		}
 	}
 	return result.Strings()

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -42,20 +42,29 @@ type hasChunksForIntervalFunc func(userID, seriesID string, from, through model.
 
 // Schema interface defines methods to calculate the hash and range keys needed
 // to write or read chunks from the external index.
-type Schema interface {
-	// When doing a write, use this method to return the list of entries you should write to.
-	GetWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
-
-	// Should only be used with the seriesStore. TODO: Make seriesStore implement a different interface altogether.
-	// returns cache key string and []IndexEntry per bucket, matched in order
-	GetCacheKeysAndLabelWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]string, [][]IndexEntry, error)
-	GetChunkWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
-
+type BaseSchema interface {
 	// When doing a read, use these methods to return the list of entries you should query
 	GetReadQueriesForMetric(from, through model.Time, userID string, metricName string) ([]IndexQuery, error)
 	GetReadQueriesForMetricLabel(from, through model.Time, userID string, metricName string, labelName string) ([]IndexQuery, error)
 	GetReadQueriesForMetricLabelValue(from, through model.Time, userID string, metricName string, labelName string, labelValue string) ([]IndexQuery, error)
 	FilterReadQueries(queries []IndexQuery, shard *astmapper.ShardAnnotation) []IndexQuery
+}
+
+// Schema used by store
+type StoreSchema interface {
+	BaseSchema
+
+	// When doing a write, use this method to return the list of entries you should write to.
+	GetWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
+}
+
+// Schema used by seriesStore
+type SeriesStoreSchema interface {
+	BaseSchema
+
+	// returns cache key string and []IndexEntry per bucket, matched in order
+	GetCacheKeysAndLabelWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]string, [][]IndexEntry, error)
+	GetChunkWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
 
 	// If the query resulted in series IDs, use this method to find chunks.
 	GetChunksForSeries(from, through model.Time, userID string, seriesID []byte) ([]IndexQuery, error)
@@ -102,13 +111,39 @@ type IndexEntry struct {
 
 type schemaBucketsFunc func(from, through model.Time, userID string) []Bucket
 
-// schema implements Schema given a bucketing function and and set of range key callbacks
-type schema struct {
+// baseSchema implements BaseSchema given a bucketing function and and set of range key callbacks
+type baseSchema struct {
 	buckets schemaBucketsFunc
-	entries entries
+	entries baseEntries
 }
 
-func (s schema) GetWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
+// storeSchema implements StoreSchema given a bucketing function and and set of range key callbacks
+type storeSchema struct {
+	baseSchema
+	entries storeEntries
+}
+
+// seriesStoreSchema implements SeriesStoreSchema given a bucketing function and and set of range key callbacks
+type seriesStoreSchema struct {
+	baseSchema
+	entries seriesStoreEntries
+}
+
+func newStoreSchema(buckets schemaBucketsFunc, entries storeEntries) storeSchema {
+	return storeSchema{
+		baseSchema: baseSchema{buckets: buckets, entries: entries},
+		entries:    entries,
+	}
+}
+
+func newSeriesStoreSchema(buckets schemaBucketsFunc, entries seriesStoreEntries) seriesStoreSchema {
+	return seriesStoreSchema{
+		baseSchema: baseSchema{buckets: buckets, entries: entries},
+		entries:    entries,
+	}
+}
+
+func (s storeSchema) GetWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	var result []IndexEntry
 
 	for _, bucket := range s.buckets(from, through, userID) {
@@ -122,7 +157,7 @@ func (s schema) GetWriteEntries(from, through model.Time, userID string, metricN
 }
 
 // returns cache key string and []IndexEntry per bucket, matched in order
-func (s schema) GetCacheKeysAndLabelWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]string, [][]IndexEntry, error) {
+func (s seriesStoreSchema) GetCacheKeysAndLabelWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]string, [][]IndexEntry, error) {
 	var keys []string
 	var indexEntries [][]IndexEntry
 
@@ -148,7 +183,7 @@ func (s schema) GetCacheKeysAndLabelWriteEntries(from, through model.Time, userI
 	return keys, indexEntries, nil
 }
 
-func (s schema) GetChunkWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
+func (s seriesStoreSchema) GetChunkWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	var result []IndexEntry
 
 	for _, bucket := range s.buckets(from, through, userID) {
@@ -162,7 +197,7 @@ func (s schema) GetChunkWriteEntries(from, through model.Time, userID string, me
 
 }
 
-func (s schema) GetReadQueriesForMetric(from, through model.Time, userID string, metricName string) ([]IndexQuery, error) {
+func (s baseSchema) GetReadQueriesForMetric(from, through model.Time, userID string, metricName string) ([]IndexQuery, error) {
 	var result []IndexQuery
 
 	buckets := s.buckets(from, through, userID)
@@ -176,7 +211,7 @@ func (s schema) GetReadQueriesForMetric(from, through model.Time, userID string,
 	return result, nil
 }
 
-func (s schema) GetReadQueriesForMetricLabel(from, through model.Time, userID string, metricName string, labelName string) ([]IndexQuery, error) {
+func (s baseSchema) GetReadQueriesForMetricLabel(from, through model.Time, userID string, metricName string, labelName string) ([]IndexQuery, error) {
 	var result []IndexQuery
 
 	buckets := s.buckets(from, through, userID)
@@ -190,7 +225,7 @@ func (s schema) GetReadQueriesForMetricLabel(from, through model.Time, userID st
 	return result, nil
 }
 
-func (s schema) GetReadQueriesForMetricLabelValue(from, through model.Time, userID string, metricName string, labelName string, labelValue string) ([]IndexQuery, error) {
+func (s baseSchema) GetReadQueriesForMetricLabelValue(from, through model.Time, userID string, metricName string, labelName string, labelValue string) ([]IndexQuery, error) {
 	var result []IndexQuery
 
 	buckets := s.buckets(from, through, userID)
@@ -204,7 +239,7 @@ func (s schema) GetReadQueriesForMetricLabelValue(from, through model.Time, user
 	return result, nil
 }
 
-func (s schema) GetChunksForSeries(from, through model.Time, userID string, seriesID []byte) ([]IndexQuery, error) {
+func (s seriesStoreSchema) GetChunksForSeries(from, through model.Time, userID string, seriesID []byte) ([]IndexQuery, error) {
 	var result []IndexQuery
 
 	buckets := s.buckets(from, through, userID)
@@ -222,7 +257,7 @@ func (s schema) GetChunksForSeries(from, through model.Time, userID string, seri
 // Since SeriesIDs are created per bucket, it makes sure that we don't include series entries which are in use by verifying using hasChunksForIntervalFunc i.e
 // It checks first and last buckets covered by the time interval to see if a SeriesID still has chunks in the store,
 // if yes then it doesn't include IndexEntry's for that bucket for deletion.
-func (s schema) GetSeriesDeleteEntries(from, through model.Time, userID string, metric labels.Labels, hasChunksForIntervalFunc hasChunksForIntervalFunc) ([]IndexEntry, error) {
+func (s seriesStoreSchema) GetSeriesDeleteEntries(from, through model.Time, userID string, metric labels.Labels, hasChunksForIntervalFunc hasChunksForIntervalFunc) ([]IndexEntry, error) {
 	metricName := metric.Get(model.MetricNameLabel)
 	if metricName == "" {
 		return nil, ErrMetricNameLabelMissing
@@ -290,7 +325,7 @@ func (s schema) GetSeriesDeleteEntries(from, through model.Time, userID string, 
 	return result, nil
 }
 
-func (s schema) GetLabelNamesForSeries(from, through model.Time, userID string, seriesID []byte) ([]IndexQuery, error) {
+func (s seriesStoreSchema) GetLabelNamesForSeries(from, through model.Time, userID string, seriesID []byte) ([]IndexQuery, error) {
 	var result []IndexQuery
 
 	buckets := s.buckets(from, through, userID)
@@ -304,21 +339,33 @@ func (s schema) GetLabelNamesForSeries(from, through model.Time, userID string, 
 	return result, nil
 }
 
-func (s schema) FilterReadQueries(queries []IndexQuery, shard *astmapper.ShardAnnotation) []IndexQuery {
+func (s baseSchema) FilterReadQueries(queries []IndexQuery, shard *astmapper.ShardAnnotation) []IndexQuery {
 	return s.entries.FilterReadQueries(queries, shard)
 }
 
-type entries interface {
-	GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
-	GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
-	GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
-
+type baseEntries interface {
 	GetReadMetricQueries(bucket Bucket, metricName string) ([]IndexQuery, error)
 	GetReadMetricLabelQueries(bucket Bucket, metricName string, labelName string) ([]IndexQuery, error)
 	GetReadMetricLabelValueQueries(bucket Bucket, metricName string, labelName string, labelValue string) ([]IndexQuery, error)
+	FilterReadQueries(queries []IndexQuery, shard *astmapper.ShardAnnotation) []IndexQuery
+}
+
+// used by storeSchema
+type storeEntries interface {
+	baseEntries
+
+	GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
+}
+
+// used by seriesStoreSchema
+type seriesStoreEntries interface {
+	baseEntries
+
+	GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
+	GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
+
 	GetChunksForSeries(bucket Bucket, seriesID []byte) ([]IndexQuery, error)
 	GetLabelNamesForSeries(bucket Bucket, seriesID []byte) ([]IndexQuery, error)
-	FilterReadQueries(queries []IndexQuery, shard *astmapper.ShardAnnotation) []IndexQuery
 }
 
 // original entries:
@@ -344,13 +391,6 @@ func (originalEntries) GetWriteEntries(bucket Bucket, metricName string, labels 
 		})
 	}
 	return result, nil
-}
-
-func (originalEntries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	return nil, ErrNotSupported
-}
-func (originalEntries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	return nil, ErrNotSupported
 }
 
 func (originalEntries) GetReadMetricQueries(bucket Bucket, metricName string) ([]IndexQuery, error) {
@@ -386,14 +426,6 @@ func (originalEntries) GetReadMetricLabelValueQueries(bucket Bucket, metricName 
 	}, nil
 }
 
-func (originalEntries) GetChunksForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
-	return nil, ErrNotSupported
-}
-
-func (originalEntries) GetLabelNamesForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
-	return nil, ErrNotSupported
-}
-
 func (originalEntries) FilterReadQueries(queries []IndexQuery, shard *astmapper.ShardAnnotation) []IndexQuery {
 	return queries
 }
@@ -421,13 +453,6 @@ func (base64Entries) GetWriteEntries(bucket Bucket, metricName string, labels la
 		})
 	}
 	return result, nil
-}
-
-func (base64Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	return nil, ErrNotSupported
-}
-func (base64Entries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	return nil, ErrNotSupported
 }
 
 func (base64Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string, labelName string, labelValue string) ([]IndexQuery, error) {
@@ -473,13 +498,6 @@ func (labelNameInHashKeyEntries) GetWriteEntries(bucket Bucket, metricName strin
 	return entries, nil
 }
 
-func (labelNameInHashKeyEntries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	return nil, ErrNotSupported
-}
-func (labelNameInHashKeyEntries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	return nil, ErrNotSupported
-}
-
 func (labelNameInHashKeyEntries) GetReadMetricQueries(bucket Bucket, metricName string) ([]IndexQuery, error) {
 	return []IndexQuery{
 		{
@@ -507,14 +525,6 @@ func (labelNameInHashKeyEntries) GetReadMetricLabelValueQueries(bucket Bucket, m
 			RangeValuePrefix: rangeValuePrefix(nil, encodedBytes),
 		},
 	}, nil
-}
-
-func (labelNameInHashKeyEntries) GetChunksForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
-	return nil, ErrNotSupported
-}
-
-func (labelNameInHashKeyEntries) GetLabelNamesForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
-	return nil, ErrNotSupported
 }
 
 func (labelNameInHashKeyEntries) FilterReadQueries(queries []IndexQuery, shard *astmapper.ShardAnnotation) []IndexQuery {
@@ -553,13 +563,6 @@ func (v5Entries) GetWriteEntries(bucket Bucket, metricName string, labels labels
 	return entries, nil
 }
 
-func (v5Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	return nil, ErrNotSupported
-}
-func (v5Entries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	return nil, ErrNotSupported
-}
-
 func (v5Entries) GetReadMetricQueries(bucket Bucket, metricName string) ([]IndexQuery, error) {
 	return []IndexQuery{
 		{
@@ -585,14 +588,6 @@ func (v5Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string
 			HashValue: fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
 		},
 	}, nil
-}
-
-func (v5Entries) GetChunksForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
-	return nil, ErrNotSupported
-}
-
-func (v5Entries) GetLabelNamesForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
-	return nil, ErrNotSupported
 }
 
 func (v5Entries) FilterReadQueries(queries []IndexQuery, shard *astmapper.ShardAnnotation) []IndexQuery {
@@ -630,13 +625,6 @@ func (v6Entries) GetWriteEntries(bucket Bucket, metricName string, labels labels
 	return entries, nil
 }
 
-func (v6Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	return nil, ErrNotSupported
-}
-func (v6Entries) GetChunkWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	return nil, ErrNotSupported
-}
-
 func (v6Entries) GetReadMetricQueries(bucket Bucket, metricName string) ([]IndexQuery, error) {
 	encodedFromBytes := encodeTime(bucket.from)
 	return []IndexQuery{
@@ -669,14 +657,6 @@ func (v6Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string
 			ValueEqual:      []byte(labelValue),
 		},
 	}, nil
-}
-
-func (v6Entries) GetChunksForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
-	return nil, ErrNotSupported
-}
-
-func (v6Entries) GetLabelNamesForSeries(_ Bucket, _ []byte) ([]IndexQuery, error) {
-	return nil, ErrNotSupported
 }
 
 func (v6Entries) FilterReadQueries(queries []IndexQuery, shard *astmapper.ShardAnnotation) []IndexQuery {

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -666,10 +666,6 @@ func (v6Entries) FilterReadQueries(queries []IndexQuery, shard *astmapper.ShardA
 // v9Entries adds a layer of indirection between labels -> series -> chunks.
 type v9Entries struct{}
 
-func (v9Entries) GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	return nil, ErrNotSupported
-}
-
 func (v9Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
 	seriesID := labelsSeriesID(labels)
 
@@ -768,10 +764,6 @@ func (v9Entries) FilterReadQueries(queries []IndexQuery, shard *astmapper.ShardA
 // v10Entries builds on v9 by sharding index rows to reduce their size.
 type v10Entries struct {
 	rowShards uint32
-}
-
-func (v10Entries) GetWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {
-	return nil, ErrNotSupported
 }
 
 func (s v10Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error) {

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -40,8 +40,10 @@ var (
 
 type hasChunksForIntervalFunc func(userID, seriesID string, from, through model.Time) (bool, error)
 
-// Schema interface defines methods to calculate the hash and range keys needed
+// Schema interfaces define methods to calculate the hash and range keys needed
 // to write or read chunks from the external index.
+
+// BasicSchema has operation shared between StoreSchema and SeriesStoreSchema
 type BaseSchema interface {
 	// When doing a read, use these methods to return the list of entries you should query
 	GetReadQueriesForMetric(from, through model.Time, userID string, metricName string) ([]IndexQuery, error)
@@ -50,7 +52,7 @@ type BaseSchema interface {
 	FilterReadQueries(queries []IndexQuery, shard *astmapper.ShardAnnotation) []IndexQuery
 }
 
-// Schema used by store
+// StoreSchema is a schema used by store
 type StoreSchema interface {
 	BaseSchema
 
@@ -58,7 +60,7 @@ type StoreSchema interface {
 	GetWriteEntries(from, through model.Time, userID string, metricName string, labels labels.Labels, chunkID string) ([]IndexEntry, error)
 }
 
-// Schema used by seriesStore
+// SeriesStoreSchema is a schema used by seriesStore
 type SeriesStoreSchema interface {
 	BaseSchema
 

--- a/pkg/chunk/schema_caching.go
+++ b/pkg/chunk/schema_caching.go
@@ -8,13 +8,13 @@ import (
 )
 
 type schemaCaching struct {
-	Schema
+	SeriesStoreSchema
 
 	cacheOlderThan time.Duration
 }
 
 func (s *schemaCaching) GetReadQueriesForMetric(from, through model.Time, userID string, metricName string) ([]IndexQuery, error) {
-	queries, err := s.Schema.GetReadQueriesForMetric(from, through, userID, metricName)
+	queries, err := s.SeriesStoreSchema.GetReadQueriesForMetric(from, through, userID, metricName)
 	if err != nil {
 		return nil, err
 	}
@@ -22,7 +22,7 @@ func (s *schemaCaching) GetReadQueriesForMetric(from, through model.Time, userID
 }
 
 func (s *schemaCaching) GetReadQueriesForMetricLabel(from, through model.Time, userID string, metricName string, labelName string) ([]IndexQuery, error) {
-	queries, err := s.Schema.GetReadQueriesForMetricLabel(from, through, userID, metricName, labelName)
+	queries, err := s.SeriesStoreSchema.GetReadQueriesForMetricLabel(from, through, userID, metricName, labelName)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (s *schemaCaching) GetReadQueriesForMetricLabel(from, through model.Time, u
 }
 
 func (s *schemaCaching) GetReadQueriesForMetricLabelValue(from, through model.Time, userID string, metricName string, labelName string, labelValue string) ([]IndexQuery, error) {
-	queries, err := s.Schema.GetReadQueriesForMetricLabelValue(from, through, userID, metricName, labelName, labelValue)
+	queries, err := s.SeriesStoreSchema.GetReadQueriesForMetricLabelValue(from, through, userID, metricName, labelName, labelValue)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (s *schemaCaching) GetReadQueriesForMetricLabelValue(from, through model.Ti
 
 // If the query resulted in series IDs, use this method to find chunks.
 func (s *schemaCaching) GetChunksForSeries(from, through model.Time, userID string, seriesID []byte) ([]IndexQuery, error) {
-	queries, err := s.Schema.GetChunksForSeries(from, through, userID, seriesID)
+	queries, err := s.SeriesStoreSchema.GetChunksForSeries(from, through, userID, seriesID)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (s *schemaCaching) GetChunksForSeries(from, through model.Time, userID stri
 }
 
 func (s *schemaCaching) GetLabelNamesForSeries(from, through model.Time, userID string, seriesID []byte) ([]IndexQuery, error) {
-	queries, err := s.Schema.GetLabelNamesForSeries(from, through, userID, seriesID)
+	queries, err := s.SeriesStoreSchema.GetLabelNamesForSeries(from, through, userID, seriesID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chunk/schema_caching_test.go
+++ b/pkg/chunk/schema_caching_test.go
@@ -12,15 +12,12 @@ import (
 )
 
 func TestCachingSchema(t *testing.T) {
-	const (
-		userID         = "userid"
-		periodicPrefix = "periodicPrefix"
-	)
+	const userID = "userid"
 
-	dailyBuckets := makeSchema("v3")
+	dailyBuckets := makeSeriesStoreSchema("v9")
 	schema := &schemaCaching{
-		Schema:         dailyBuckets,
-		cacheOlderThan: 24 * time.Hour,
+		SeriesStoreSchema: dailyBuckets,
+		cacheOlderThan:    24 * time.Hour,
 	}
 
 	baseTime := time.Unix(0, 0)

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -145,41 +145,35 @@ func (cfg *SchemaConfig) ForEachAfter(t model.Time, f func(config *PeriodConfig)
 }
 
 // CreateSchema returns the schema defined by the PeriodConfig
-func (cfg PeriodConfig) CreateSchema() Schema {
+func (cfg PeriodConfig) CreateSchema() BaseSchema {
+	buckets, _ := cfg.createBucketsFunc()
 
-	var e entries
 	switch cfg.Schema {
 	case "v1":
-		e = originalEntries{}
+		return newStoreSchema(buckets, originalEntries{})
 	case "v2":
-		e = originalEntries{}
+		return newStoreSchema(buckets, originalEntries{})
 	case "v3":
-		e = base64Entries{originalEntries{}}
+		return newStoreSchema(buckets, base64Entries{originalEntries{}})
 	case "v4":
-		e = labelNameInHashKeyEntries{}
+		return newStoreSchema(buckets, labelNameInHashKeyEntries{})
 	case "v5":
-		e = v5Entries{}
+		return newStoreSchema(buckets, v5Entries{})
 	case "v6":
-		e = v6Entries{}
+		return newStoreSchema(buckets, v6Entries{})
 	case "v9":
-		e = v9Entries{}
+		return newSeriesStoreSchema(buckets, v9Entries{})
 	case "v10":
-		e = v10Entries{
-			rowShards: cfg.RowShards,
-		}
+		return newSeriesStoreSchema(buckets, v10Entries{rowShards: cfg.RowShards})
 	case "v11":
-		e = v11Entries{
+		return newSeriesStoreSchema(buckets, v11Entries{
 			v10Entries: v10Entries{
 				rowShards: cfg.RowShards,
 			},
-		}
+		})
 	default:
 		return nil
 	}
-
-	buckets, _ := cfg.createBucketsFunc()
-
-	return schema{buckets, e}
 }
 
 func (cfg PeriodConfig) createBucketsFunc() (schemaBucketsFunc, time.Duration) {

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -64,32 +64,27 @@ var (
 
 // seriesStore implements Store
 type seriesStore struct {
-	store
+	baseStore
+	schema           SeriesStoreSchema
 	writeDedupeCache cache.Cache
 }
 
-func newSeriesStore(cfg StoreConfig, schema Schema, index IndexClient, chunks Client, limits StoreLimits, chunksCache, writeDedupeCache cache.Cache) (Store, error) {
-	fetcher, err := NewChunkFetcher(chunksCache, cfg.chunkCacheStubs, chunks)
+func newSeriesStore(cfg StoreConfig, schema SeriesStoreSchema, index IndexClient, chunks Client, limits StoreLimits, chunksCache, writeDedupeCache cache.Cache) (Store, error) {
+	rs, err := newReadStore(cfg, schema, index, chunks, limits, chunksCache)
 	if err != nil {
 		return nil, err
 	}
 
 	if cfg.CacheLookupsOlderThan != 0 {
 		schema = &schemaCaching{
-			Schema:         schema,
-			cacheOlderThan: cfg.CacheLookupsOlderThan,
+			SeriesStoreSchema: schema,
+			cacheOlderThan:    cfg.CacheLookupsOlderThan,
 		}
 	}
 
 	return &seriesStore{
-		store: store{
-			cfg:     cfg,
-			index:   index,
-			chunks:  chunks,
-			schema:  schema,
-			limits:  limits,
-			Fetcher: fetcher,
-		},
+		baseStore:        rs,
+		schema:           schema,
 		writeDedupeCache: writeDedupeCache,
 	}, nil
 }
@@ -183,7 +178,7 @@ func (c *seriesStore) GetChunkRefs(ctx context.Context, userID string, from, thr
 	level.Debug(log).Log("chunks-post-filtering", len(chunks))
 	chunksPerQuery.Observe(float64(len(chunks)))
 
-	return [][]Chunk{chunks}, []*Fetcher{c.store.Fetcher}, nil
+	return [][]Chunk{chunks}, []*Fetcher{c.baseStore.Fetcher}, nil
 }
 
 // LabelNamesForMetricName retrieves all label names for a metric name.

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -70,7 +70,7 @@ type seriesStore struct {
 }
 
 func newSeriesStore(cfg StoreConfig, schema SeriesStoreSchema, index IndexClient, chunks Client, limits StoreLimits, chunksCache, writeDedupeCache cache.Cache) (Store, error) {
-	rs, err := newReadStore(cfg, schema, index, chunks, limits, chunksCache)
+	rs, err := newBaseStore(cfg, schema, index, chunks, limits, chunksCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chunk/storage/factory_test.go
+++ b/pkg/chunk/storage/factory_test.go
@@ -27,10 +27,12 @@ func TestFactoryStop(t *testing.T) {
 		{
 			From:      chunk.DayTime{Time: model.Time(0)},
 			IndexType: "inmemory",
+			Schema:    "v3",
 		},
 		{
 			From:      chunk.DayTime{Time: model.Time(1)},
 			IndexType: "inmemory",
+			Schema:    "v9",
 		},
 	}
 


### PR DESCRIPTION
While studying how schemas work, I've found some oddities, that this PR tries to address.
- some entries implementations having many methods that only returned "not supported" errors
- `seriesStore` embedding `store` to reuse some of the methods
- `Schema` having methods for supporting different stores

This PR splits `Schema` interface (and then also `entries`) into `StoreSchema` and `SeriesStoreSchema` plus shared `BaseSchema` supertype.

Similarly, `baseStore` was extracted from `store`, and `seriesStore` now uses that, instead of store directly.

This makes code more explicit about what is used where, or why some methods are not implemented in various schema / entries versions.

(I haven't reordered methods for to keep `baseStore` and `store` methods together, as that would increase diff size. It would be nice thing to do at some point. Same for `baseSchema` vs `storeSchema` and `seriesStoreSchema`)

Signed-off-by: Peter Štibraný <peter.stibrany@grafana.com>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

/cc @owen-d @cyriltovena 