### PR TITLE
Cleanup white noise in Markdown files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,9 @@ jobs:
     - run:
         name: Check generated documentation is consistent.
         command: make BUILD_IN_CONTAINER=false check-doc
+    - run:
+        name: Check white noise.
+        command: make BUILD_IN_CONTAINER=false check-white-noise
 
   test:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,7 @@ This is the first major release of Cortex. We made a lot of **breaking changes**
 
 ### Known issues
 
-- This experimental blocks storage in Cortex `1.0.0` has a bug which may lead to the error `cannot iterate chunk for series` when running queries. This bug has been fixed in #2400. If you're running the experimental blocks storage, please build Cortex from `master`. 
+- This experimental blocks storage in Cortex `1.0.0` has a bug which may lead to the error `cannot iterate chunk for series` when running queries. This bug has been fixed in #2400. If you're running the experimental blocks storage, please build Cortex from `master`.
 
 ### Config file breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [CHANGE] Experimental WAL: Default value of `-ingester.checkpoint-enabled` changed to `true`. #2416
 * [FEATURE] Ruler: The `-ruler.evaluation-delay` flag was added to allow users to configure a default evaluation delay for all rules in cortex. The default value is 0 which is the current behavior. #2423
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
-* [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383 
+* [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383
 * [ENHANCEMENT] Experimental TSDB: Added `cortex_querier_blocks_meta_synced`, which reflects current state of synced blocks over all tenants. #2392
 * [ENHANCEMENT] Added `cortex_distributor_latest_seen_sample_timestamp_seconds` metric to see how far behind Prometheus servers are in sending data. #2371
 * [ENHANCEMENT] FIFO cache to support eviction based on memory usage. The `-<prefix>.fifocache.size` CLI flag has been renamed to `-<prefix>.fifocache.max-size-items` as well as its YAML config option `size` renamed to `max_size_items`. Added `-<prefix>.fifocache.max-size-bytes` CLI flag and YAML config option `max_size_bytes` to specify memory limit of the cache. #2319
@@ -87,7 +87,7 @@ This is the first major release of Cortex. We made a lot of **breaking changes**
 * [CHANGE] Frontend worker in querier now starts after all Querier module dependencies are started. This fixes issue where frontend worker started to send queries to querier before it was ready to serve them (mostly visible when using experimental blocks storage). #2246
 * [CHANGE] Lifecycler component now enters Failed state on errors, and doesn't exit the process. (Important if you're vendoring Cortex and use Lifecycler) #2251
 * [CHANGE] `/ready` handler now returns 200 instead of 204. #2330
-* [CHANGE] Better defaults for the following options: #2344 
+* [CHANGE] Better defaults for the following options: #2344
   - `-<prefix>.consul.consistent-reads`: Old default: `true`, new default: `false`. This reduces the load on Consul.
   - `-<prefix>.consul.watch-rate-limit`: Old default: 0, new default: 1. This rate limits the reads to 1 per second. Which is good enough for ring watches.
   - `-distributor.health-check-ingesters`: Old default: `false`, new default: `true`.
@@ -180,19 +180,19 @@ In this section you can find a config file diff showing the breaking changes int
  # CLI flag: -ingester.concurrent-flushes
 -[concurrentflushes: <int> | default = 50]
 +[concurrent_flushes: <int> | default = 50]
- 
+
 -# If true, spread series flushes across the whole period of MaxChunkAge
 +# If true, spread series flushes across the whole period of
 +# -ingester.max-chunk-age.
  # CLI flag: -ingester.spread-flushes
 -[spreadflushes: <boolean> | default = false]
 +[spread_flushes: <boolean> | default = true]
- 
+
  # Period with which to update the per-user ingestion rates.
  # CLI flag: -ingester.rate-update-period
 -[rateupdateperiod: <duration> | default = 15s]
 +[rate_update_period: <duration> | default = 15s]
- 
+
 
 ### querier_config
 
@@ -200,35 +200,35 @@ In this section you can find a config file diff showing the breaking changes int
  # CLI flag: -querier.max-concurrent
 -[maxconcurrent: <int> | default = 20]
 +[max_concurrent: <int> | default = 20]
- 
+
  # Use batch iterators to execute query, as opposed to fully materialising the
  # series in memory.  Takes precedent over the -querier.iterators flag.
  # CLI flag: -querier.batch-iterators
 -[batchiterators: <boolean> | default = false]
 +[batch_iterators: <boolean> | default = true]
- 
+
  # Use streaming RPCs to query ingester.
  # CLI flag: -querier.ingester-streaming
 -[ingesterstreaming: <boolean> | default = false]
 +[ingester_streaming: <boolean> | default = true]
- 
+
  # Maximum number of samples a single query can load into memory.
  # CLI flag: -querier.max-samples
 -[maxsamples: <int> | default = 50000000]
 +[max_samples: <int> | default = 50000000]
- 
+
  # The default evaluation interval or step size for subqueries.
  # CLI flag: -querier.default-evaluation-interval
 -[defaultevaluationinterval: <duration> | default = 1m0s]
 +[default_evaluation_interval: <duration> | default = 1m0s]
- 
+
 ### query_frontend_config
 
  # URL of downstream Prometheus.
  # CLI flag: -frontend.downstream-url
 -[downstream: <string> | default = ""]
 +[downstream_url: <string> | default = ""]
- 
+
 
 ### ruler_config
 
@@ -236,125 +236,125 @@ In this section you can find a config file diff showing the breaking changes int
  # CLI flag: -ruler.external.url
 -[externalurl: <url> | default = ]
 +[external_url: <url> | default = ]
- 
+
  # How frequently to evaluate rules
  # CLI flag: -ruler.evaluation-interval
 -[evaluationinterval: <duration> | default = 1m0s]
 +[evaluation_interval: <duration> | default = 1m0s]
- 
+
  # How frequently to poll for rule changes
  # CLI flag: -ruler.poll-interval
 -[pollinterval: <duration> | default = 1m0s]
 +[poll_interval: <duration> | default = 1m0s]
- 
+
 -storeconfig:
 +storage:
- 
+
  # file path to store temporary rule files for the prometheus rule managers
  # CLI flag: -ruler.rule-path
 -[rulepath: <string> | default = "/rules"]
 +[rule_path: <string> | default = "/rules"]
- 
+
  # URL of the Alertmanager to send notifications to.
  # CLI flag: -ruler.alertmanager-url
 -[alertmanagerurl: <url> | default = ]
 +[alertmanager_url: <url> | default = ]
- 
+
  # Use DNS SRV records to discover alertmanager hosts.
  # CLI flag: -ruler.alertmanager-discovery
 -[alertmanagerdiscovery: <boolean> | default = false]
 +[enable_alertmanager_discovery: <boolean> | default = false]
- 
+
  # How long to wait between refreshing alertmanager hosts.
  # CLI flag: -ruler.alertmanager-refresh-interval
 -[alertmanagerrefreshinterval: <duration> | default = 1m0s]
 +[alertmanager_refresh_interval: <duration> | default = 1m0s]
- 
+
  # If enabled requests to alertmanager will utilize the V2 API.
  # CLI flag: -ruler.alertmanager-use-v2
 -[alertmanangerenablev2api: <boolean> | default = false]
 +[enable_alertmanager_v2: <boolean> | default = false]
- 
+
  # Capacity of the queue for notifications to be sent to the Alertmanager.
  # CLI flag: -ruler.notification-queue-capacity
 -[notificationqueuecapacity: <int> | default = 10000]
 +[notification_queue_capacity: <int> | default = 10000]
- 
+
  # HTTP timeout duration when sending notifications to the Alertmanager.
  # CLI flag: -ruler.notification-timeout
 -[notificationtimeout: <duration> | default = 10s]
 +[notification_timeout: <duration> | default = 10s]
- 
+
  # Distribute rule evaluation using ring backend
  # CLI flag: -ruler.enable-sharding
 -[enablesharding: <boolean> | default = false]
 +[enable_sharding: <boolean> | default = false]
- 
+
  # Time to spend searching for a pending ruler when shutting down.
  # CLI flag: -ruler.search-pending-for
 -[searchpendingfor: <duration> | default = 5m0s]
 +[search_pending_for: <duration> | default = 5m0s]
- 
+
  # Period with which to attempt to flush rule groups.
  # CLI flag: -ruler.flush-period
 -[flushcheckperiod: <duration> | default = 1m0s]
 +[flush_period: <duration> | default = 1m0s]
- 
+
 ### alertmanager_config
 
  # Base path for data storage.
  # CLI flag: -alertmanager.storage.path
 -[datadir: <string> | default = "data/"]
 +[data_dir: <string> | default = "data/"]
- 
+
  # will be used to prefix all HTTP endpoints served by Alertmanager. If omitted,
  # relevant URL components will be derived automatically.
  # CLI flag: -alertmanager.web.external-url
 -[externalurl: <url> | default = ]
 +[external_url: <url> | default = ]
- 
+
  # How frequently to poll Cortex configs
  # CLI flag: -alertmanager.configs.poll-interval
 -[pollinterval: <duration> | default = 15s]
 +[poll_interval: <duration> | default = 15s]
- 
+
  # Listen address for cluster.
  # CLI flag: -cluster.listen-address
 -[clusterbindaddr: <string> | default = "0.0.0.0:9094"]
 +[cluster_bind_address: <string> | default = "0.0.0.0:9094"]
- 
+
  # Explicit address to advertise in cluster.
  # CLI flag: -cluster.advertise-address
 -[clusteradvertiseaddr: <string> | default = ""]
 +[cluster_advertise_address: <string> | default = ""]
- 
+
  # Time to wait between peers to send notifications.
  # CLI flag: -cluster.peer-timeout
 -[peertimeout: <duration> | default = 15s]
 +[peer_timeout: <duration> | default = 15s]
- 
+
  # Filename of fallback config to use if none specified for instance.
  # CLI flag: -alertmanager.configs.fallback
 -[fallbackconfigfile: <string> | default = ""]
 +[fallback_config_file: <string> | default = ""]
- 
+
  # Root of URL to generate if config is http://internal.monitor
  # CLI flag: -alertmanager.configs.auto-webhook-root
 -[autowebhookroot: <string> | default = ""]
 +[auto_webhook_root: <string> | default = ""]
- 
+
 ### table_manager_config
 
 -store:
 +storage:
- 
+
 -# How frequently to poll DynamoDB to learn our capacity.
 -# CLI flag: -dynamodb.poll-interval
 -[dynamodb_poll_interval: <duration> | default = 2m0s]
 +# How frequently to poll backend to learn our capacity.
 +# CLI flag: -table-manager.poll-interval
 +[poll_interval: <duration> | default = 2m0s]
- 
+
 -# DynamoDB periodic tables grace period (duration which table will be
 -# created/deleted before/after it's needed).
 -# CLI flag: -dynamodb.periodic-table.grace-period
@@ -362,7 +362,7 @@ In this section you can find a config file diff showing the breaking changes int
 +# before/after it's needed).
 +# CLI flag: -table-manager.periodic-table.grace-period
  [creation_grace_period: <duration> | default = 10m0s]
- 
+
  index_tables_provisioning:
    # Enables on demand throughput provisioning for the storage provider (if
 -  # supported). Applies only to tables which are not autoscaled
@@ -372,8 +372,8 @@ In this section you can find a config file diff showing the breaking changes int
 +  # DynamoDB
 +  # CLI flag: -table-manager.index-table.enable-ondemand-throughput-mode
 +  [enable_ondemand_throughput_mode: <boolean> | default = false]
- 
- 
+
+
    # Enables on demand throughput provisioning for the storage provider (if
 -  # supported). Applies only to tables which are not autoscaled
 -  # CLI flag: -dynamodb.periodic-table.inactive-enable-ondemand-throughput-mode
@@ -382,8 +382,8 @@ In this section you can find a config file diff showing the breaking changes int
 +  # DynamoDB
 +  # CLI flag: -table-manager.index-table.inactive-enable-ondemand-throughput-mode
 +  [enable_inactive_throughput_on_demand_mode: <boolean> | default = false]
- 
- 
+
+
  chunk_tables_provisioning:
    # Enables on demand throughput provisioning for the storage provider (if
 -  # supported). Applies only to tables which are not autoscaled
@@ -393,7 +393,7 @@ In this section you can find a config file diff showing the breaking changes int
 +  # DynamoDB
 +  # CLI flag: -table-manager.chunk-table.enable-ondemand-throughput-mode
 +  [enable_ondemand_throughput_mode: <boolean> | default = false]
- 
+
 ### storage_config
 
  aws:
@@ -405,12 +405,12 @@ In this section you can find a config file diff showing the breaking changes int
      # CLI flag: -dynamodb.url
 -    [dynamodb: <url> | default = ]
 +    [dynamodb_url: <url> | default = ]
- 
+
      # DynamoDB table management requests per second limit.
      # CLI flag: -dynamodb.api-limit
 -    [apilimit: <float> | default = 2]
 +    [api_limit: <float> | default = 2]
- 
+
      # DynamoDB rate cap to back off when throttled.
      # CLI flag: -dynamodb.throttle-limit
 -    [throttlelimit: <float> | default = 10]
@@ -419,93 +419,93 @@ In this section you can find a config file diff showing the breaking changes int
 -    # ApplicationAutoscaling endpoint URL with escaped Key and Secret encoded.
 -    # CLI flag: -applicationautoscaling.url
 -    [applicationautoscaling: <url> | default = ]
- 
- 
+
+
        # Queue length above which we will scale up capacity
        # CLI flag: -metrics.target-queue-length
 -      [targetqueuelen: <int> | default = 100000]
 +      [target_queue_length: <int> | default = 100000]
- 
+
        # Scale up capacity by this multiple
        # CLI flag: -metrics.scale-up-factor
 -      [scaleupfactor: <float> | default = 1.3]
 +      [scale_up_factor: <float> | default = 1.3]
- 
+
        # Ignore throttling below this level (rate per second)
        # CLI flag: -metrics.ignore-throttle-below
 -      [minthrottling: <float> | default = 1]
 +      [ignore_throttle_below: <float> | default = 1]
- 
+
        # query to fetch ingester queue length
        # CLI flag: -metrics.queue-length-query
 -      [queuelengthquery: <string> | default = "sum(avg_over_time(cortex_ingester_flush_queue_length{job=\"cortex/ingester\"}[2m]))"]
 +      [queue_length_query: <string> | default = "sum(avg_over_time(cortex_ingester_flush_queue_length{job=\"cortex/ingester\"}[2m]))"]
- 
+
        # query to fetch throttle rates per table
        # CLI flag: -metrics.write-throttle-query
 -      [throttlequery: <string> | default = "sum(rate(cortex_dynamo_throttled_total{operation=\"DynamoDB.BatchWriteItem\"}[1m])) by (table) > 0"]
 +      [write_throttle_query: <string> | default = "sum(rate(cortex_dynamo_throttled_total{operation=\"DynamoDB.BatchWriteItem\"}[1m])) by (table) > 0"]
- 
+
        # query to fetch write capacity usage per table
        # CLI flag: -metrics.usage-query
 -      [usagequery: <string> | default = "sum(rate(cortex_dynamo_consumed_capacity_total{operation=\"DynamoDB.BatchWriteItem\"}[15m])) by (table) > 0"]
 +      [write_usage_query: <string> | default = "sum(rate(cortex_dynamo_consumed_capacity_total{operation=\"DynamoDB.BatchWriteItem\"}[15m])) by (table) > 0"]
- 
+
        # query to fetch read capacity usage per table
        # CLI flag: -metrics.read-usage-query
 -      [readusagequery: <string> | default = "sum(rate(cortex_dynamo_consumed_capacity_total{operation=\"DynamoDB.QueryPages\"}[1h])) by (table) > 0"]
 +      [read_usage_query: <string> | default = "sum(rate(cortex_dynamo_consumed_capacity_total{operation=\"DynamoDB.QueryPages\"}[1h])) by (table) > 0"]
- 
+
        # query to fetch read errors per table
        # CLI flag: -metrics.read-error-query
 -      [readerrorquery: <string> | default = "sum(increase(cortex_dynamo_failures_total{operation=\"DynamoDB.QueryPages\",error=\"ProvisionedThroughputExceededException\"}[1m])) by (table) > 0"]
 +      [read_error_query: <string> | default = "sum(increase(cortex_dynamo_failures_total{operation=\"DynamoDB.QueryPages\",error=\"ProvisionedThroughputExceededException\"}[1m])) by (table) > 0"]
- 
+
      # Number of chunks to group together to parallelise fetches (zero to
      # disable)
 -    # CLI flag: -dynamodb.chunk.gang.size
 -    [chunkgangsize: <int> | default = 10]
 +    # CLI flag: -dynamodb.chunk-gang-size
 +    [chunk_gang_size: <int> | default = 10]
- 
+
      # Max number of chunk-get operations to start in parallel
 -    # CLI flag: -dynamodb.chunk.get.max.parallelism
 -    [chunkgetmaxparallelism: <int> | default = 32]
 +    # CLI flag: -dynamodb.chunk.get-max-parallelism
 +    [chunk_get_max_parallelism: <int> | default = 32]
- 
+
      backoff_config:
        # Minimum delay when backing off.
        # CLI flag: -bigtable.backoff-min-period
 -      [minbackoff: <duration> | default = 100ms]
 +      [min_period: <duration> | default = 100ms]
- 
+
        # Maximum delay when backing off.
        # CLI flag: -bigtable.backoff-max-period
 -      [maxbackoff: <duration> | default = 10s]
 +      [max_period: <duration> | default = 10s]
- 
+
        # Number of times to backoff and retry before failing.
        # CLI flag: -bigtable.backoff-retries
 -      [maxretries: <int> | default = 10]
 +      [max_retries: <int> | default = 10]
- 
+
    # If enabled, once a tables info is fetched, it is cached.
    # CLI flag: -bigtable.table-cache.enabled
 -  [tablecacheenabled: <boolean> | default = true]
 +  [table_cache_enabled: <boolean> | default = true]
- 
+
    # Duration to cache tables before checking again.
    # CLI flag: -bigtable.table-cache.expiration
 -  [tablecacheexpiration: <duration> | default = 30m0s]
 +  [table_cache_expiration: <duration> | default = 30m0s]
- 
+
  # Cache validity for active index entries. Should be no higher than
  # -ingester.max-chunk-idle.
  # CLI flag: -store.index-cache-validity
 -[indexcachevalidity: <duration> | default = 5m0s]
 +[index_cache_validity: <duration> | default = 5m0s]
- 
+
 ### ingester_client_config
 
  grpc_client_config:
@@ -514,17 +514,17 @@ In this section you can find a config file diff showing the breaking changes int
      # CLI flag: -ingester.client.backoff-min-period
 -    [minbackoff: <duration> | default = 100ms]
 +    [min_period: <duration> | default = 100ms]
- 
+
      # Maximum delay when backing off.
      # CLI flag: -ingester.client.backoff-max-period
 -    [maxbackoff: <duration> | default = 10s]
 +    [max_period: <duration> | default = 10s]
- 
+
      # Number of times to backoff and retry before failing.
      # CLI flag: -ingester.client.backoff-retries
 -    [maxretries: <int> | default = 10]
 +    [max_retries: <int> | default = 10]
- 
+
 ### frontend_worker_config
 
 -# Address of query frontend service.
@@ -532,19 +532,19 @@ In this section you can find a config file diff showing the breaking changes int
  # CLI flag: -querier.frontend-address
 -[address: <string> | default = ""]
 +[frontend_address: <string> | default = ""]
- 
+
  # How often to query DNS.
  # CLI flag: -querier.dns-lookup-period
 -[dnslookupduration: <duration> | default = 10s]
 +[dns_lookup_duration: <duration> | default = 10s]
- 
+
  grpc_client_config:
    backoff_config:
      # Minimum delay when backing off.
      # CLI flag: -querier.frontend-client.backoff-min-period
 -    [minbackoff: <duration> | default = 100ms]
 +    [min_period: <duration> | default = 100ms]
- 
+
      # Maximum delay when backing off.
      # CLI flag: -querier.frontend-client.backoff-max-period
 -    [maxbackoff: <duration> | default = 10s]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,7 +23,7 @@ The release shepherd is responsible for the entire release series of a minor rel
 * We aim to keep the master branch in a working state at all times. In principle, it should be possible to cut a release from master at any time. In practice, things might not work out as nicely. A few days before the pre-release is scheduled, the shepherd should check the state of master. Following their best judgement, the shepherd should try to expedite bug fixes that are still in progress but should make it into the release. On the other hand, the shepherd may hold back merging last-minute invasive and risky changes that are better suited for the next minor release.
 * On the date listed in the table above, the release shepherd cuts the first pre-release (using the suffix `-rc.0`) and creates a new branch called  `release-<major>.<minor>` starting at the commit tagged for the pre-release. In general, a pre-release is considered a release candidate (that's what `rc` stands for) and should therefore not contain any known bugs that are planned to be fixed in the final release.
 * With the pre-release, the release shepherd is responsible for coordinating or running the release candidate in Grafana or WeaveWorks production for 3 days.
-* If regressions or critical bugs are detected, they need to get fixed before cutting a new pre-release (called `-rc.1`, `-rc.2`, etc.). 
+* If regressions or critical bugs are detected, they need to get fixed before cutting a new pre-release (called `-rc.1`, `-rc.2`, etc.).
 
 See the next section for details on cutting an individual release.
 

--- a/VENDORED_CODE.md
+++ b/VENDORED_CODE.md
@@ -7,11 +7,11 @@ entire license text they are under.
 The following bits of vendored code are under the MPL-2.0 and can be found
 in the ./vendor/ directory:
 
-- https://github.com/hashicorp/go-cleanhttp and  
+- https://github.com/hashicorp/go-cleanhttp and
   https://github.com/hashicorp/consul
-- Pulled in by dependencies are  
-  https://github.com/hashicorp/golang-lru  
-  https://github.com/hashicorp/serf  
+- Pulled in by dependencies are
+  https://github.com/hashicorp/golang-lru
+  https://github.com/hashicorp/serf
   https://github.com/hashicorp/go-rootcerts
 
 [One file used in tests](COPYING.LGPL-3) is under LGPL-3, that's why we ship

--- a/docs/case-studies/gojek.md
+++ b/docs/case-studies/gojek.md
@@ -2,12 +2,12 @@
 title: "How Gojek Is Leveraging Cortex to Keep Up with Its Ever-Growing Scale"
 linkTitle: "Gojek"
 weight: 1
-slug: gojek 
+slug: gojek
 ---
 
 [Gojek](https://www.gojek.com/) launched in 2010 as a call center for booking motorcycle taxi rides in Indonesia. Today, the startup is a decacorn serving  millions of users across Southeast Asia with its mobile wallet, GoPay, and 20+ products on its super app. Want to order dinner? Book a massage? Buy movie tickets? You can do all of that with the Gojek app.
 
-The company’s mission is to solve everyday challenges with technology innovation. To achieve that across multiple markets the systems team at Gojek focused on building an infrastructure for speed, reliability, and scale. By 2019, the team realized it needed a new monitoring system that could keep up with Gojek’s ever-growing technology organization, which led them to [Cortex](https://github.com/cortexproject/cortex), the horizontally scalable [Prometheus](https://prometheus.io/) implementation. 
+The company’s mission is to solve everyday challenges with technology innovation. To achieve that across multiple markets the systems team at Gojek focused on building an infrastructure for speed, reliability, and scale. By 2019, the team realized it needed a new monitoring system that could keep up with Gojek’s ever-growing technology organization, which led them to [Cortex](https://github.com/cortexproject/cortex), the horizontally scalable [Prometheus](https://prometheus.io/) implementation.
 
 “We were using InfluxDB for metrics storage. Developers configured alerts by committing kapacitor scripts in git repos. To achieve high availability, we had a relay setup with two InfluxDBs. Since we could not horizontally scale Influx unless we paid for an enterprise license, we ended up having many InfluxDB clusters with relay setup,” says Product Engineer Ankit Goel.
 
@@ -29,7 +29,7 @@ Cortex met all of these requirements, and also had the following features that t
 
 Because it supports remote_write, Cortex enabled one of Gojek’s key needs: the ability to offer monitoring as a service. “With Thanos, we would have had to deploy a Thanos sidecar on every Prometheus that would have been deployed,” says Goel. “So essentially, there would be a substantial part of infrastructure on the client side that we would need to manage. We preferred Cortex because people could simply push their metrics to us, and we would have all the metrics in a single place.”
 
-The implementation started in January 2019. The team developed a few tools: a simple service for token-based authentication, and another for storing team information, such as notification channels and PagerDuty policies. Once all this was done, they leveraged [InfluxData Telegraf’s remote_write plugin](https://github.com/achilles42/telegraf/tree/prometheus-remote-write) to write to Cortex. This allowed them to have all the metrics being sent to InfluxDB to be sent to Cortex as well. “So moving from InfluxDB to tenants would not be that complicated. Because Cortex was multi-tenant, we could directly map each of our InfluxDB servers to our tenants,” says Goel. They’ve developed an internal helm chart to deploy and manage Cortex. After the customizations were completed in about two months, “we had our setup up and running, and we onboarded one team on Cortex,” he says. 
+The implementation started in January 2019. The team developed a few tools: a simple service for token-based authentication, and another for storing team information, such as notification channels and PagerDuty policies. Once all this was done, they leveraged [InfluxData Telegraf’s remote_write plugin](https://github.com/achilles42/telegraf/tree/prometheus-remote-write) to write to Cortex. This allowed them to have all the metrics being sent to InfluxDB to be sent to Cortex as well. “So moving from InfluxDB to tenants would not be that complicated. Because Cortex was multi-tenant, we could directly map each of our InfluxDB servers to our tenants,” says Goel. They’ve developed an internal helm chart to deploy and manage Cortex. After the customizations were completed in about two months, “we had our setup up and running, and we onboarded one team on Cortex,” he says.
 
 In the initial version, GitOps was the only interface for developers to apply alerts and create dashboards. The team built tools like [grafonnet-playground](https://github.com/lahsivjar/grafonnet-playground) to make it easy for developers to create dashboards. Developers are also allowed to create dashboards using the UI, since Grafana maintains version history for dashboards.
 

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -303,7 +303,7 @@ It also talks to a KVStore and has it's own copies of the same flags used by the
    Deprecated. New ingesters always write "normalised" tokens to the ring. Normalised tokens consume less memory to encode and decode; as the ring is unmarshalled regularly, this significantly reduces memory usage of anything that watches the ring.
 
    Cortex 0.4.0 is the last version that can *write* denormalised tokens. Cortex 0.5.0 and above always write normalised tokens.
-   
+
    Cortex 0.6.0 is the last version that can *read* denormalised tokens. Starting with Cortex 0.7.0 only normalised tokens are supported, and ingesters writing denormalised tokens to the ring (running Cortex 0.4.0 or earlier with `-ingester.normalise-tokens=false`) are ignored by distributors. Such ingesters should either switch to using normalised tokens, or be upgraded to Cortex 0.5.0 or later.
 
 - `-ingester.chunk-encoding`
@@ -343,7 +343,7 @@ It also talks to a KVStore and has it's own copies of the same flags used by the
 
    Setting this to `true` enables writing to WAL during ingestion.
 
-- `-ingester.checkpoint-duration` 
+- `-ingester.checkpoint-duration`
    This is the interval at which checkpoints should be created.
 
 - `-ingester.recover-from-wal`

--- a/docs/configuration/schema-config-reference.md
+++ b/docs/configuration/schema-config-reference.md
@@ -5,7 +5,7 @@ weight: 4
 slug: schema-configuration
 ---
 
-Cortex uses a NoSQL Store to store its index and optionally an Object store to store its chunks. Cortex has overtime evolved its schema to be more optimal and better fit the use cases and query patterns that arose. 
+Cortex uses a NoSQL Store to store its index and optionally an Object store to store its chunks. Cortex has overtime evolved its schema to be more optimal and better fit the use cases and query patterns that arose.
 
 Currently there are 9 schemas that are used in production but we recommend running with `v9` schema when possible. You can move from one schema to another if a new schema fits your purpose better, but you still need to configure Cortex to make sure it can read the old data in the old schemas.
 
@@ -45,12 +45,12 @@ configs:
   - from: "2020-03-01" # Or typically a week before the Cortex cluster was created.
     schema: v9
     index:
-      period: 1w 
+      period: 1w
       prefix: cortex_index_
     # Chunks section is optional and required only if you're not using a
     # separate object store.
     chunks:
-      period: 1w 
+      period: 1w
       prefix: cortex_chunks
     store: aws-dynamo/bigtable-hashed/cassandra/boltdb
     object_store: <above options>/s3/gcs/azure/filesystem
@@ -66,10 +66,10 @@ configs:
   - from: "2018-08-23"
     schema: v9
     chunks:
-        period: 1w 
+        period: 1w
         prefix: dev_chunks_
     index:
-        period: 1w 
+        period: 1w
         prefix: dev_index_
     store: gcp-columnkey
 
@@ -77,10 +77,10 @@ configs:
   - from: "2019-02-13"
     schema: v9
     chunks:
-        period: 1w 
+        period: 1w
         prefix: dev_chunks_
     index:
-        period: 1w 
+        period: 1w
         prefix: dev_index_
     object_store: gcs
     store: gcp-columnkey
@@ -90,22 +90,22 @@ configs:
   - from: "2019-02-24"
     schema: v9
     chunks:
-        period: 1w 
+        period: 1w
         prefix: dev_chunks_
     index:
-        period: 1w 
+        period: 1w
         prefix: dev_index_
     object_store: gcs
     store: bigtable-hashed
 
-  # Starting 2019-03-05 we moved from v9 schema to v10 schema. 
+  # Starting 2019-03-05 we moved from v9 schema to v10 schema.
   - from: "2019-03-05"
     schema: v10
     chunks:
-        period: 1w 
+        period: 1w
         prefix: dev_chunks_
     index:
-        period: 1w 
+        period: 1w
         prefix: dev_index_
     object_store: gcs
     store: bigtable-hashed

--- a/docs/configuration/single-process-config.md
+++ b/docs/configuration/single-process-config.md
@@ -63,7 +63,7 @@ schema:
     schema: v10
     index:
       prefix: index_
-      period: 1w 
+      period: 1w
 
 storage:
   boltdb:

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -1,7 +1,7 @@
 ---
 title: "v1.x Guarantees"
 linkTitle: "v1.x Guarantees"
-weight: 6 
+weight: 6
 slug: v1guarantees
 ---
 

--- a/docs/contributing/how-to-upgrade-golang-version.md
+++ b/docs/contributing/how-to-upgrade-golang-version.md
@@ -13,8 +13,8 @@ To upgrade the Golang version:
    - Publish the new image to `quay.io` (requires a maintainer)
    - Update the Docker image tag in `.circleci/config.yml`
 2. Upgrade integration tests version
-   - Update the Golang version installed in the `integration` job in `.circleci/config.yml` 
+   - Update the Golang version installed in the `integration` job in `.circleci/config.yml`
 
 If the minimum support Golang version should be upgraded as well:
 
-1. Upgrade `go` version in `go.mod` 
+1. Upgrade `go` version in `go.mod`

--- a/docs/getting-started/getting-started-with-gossip-ring.md
+++ b/docs/getting-started/getting-started-with-gossip-ring.md
@@ -106,7 +106,7 @@ is annotated diff:
 
     # bind_port needs to be unique
 -   bind_port: 7946
-+   bind_port: 7948 
++   bind_port: 7948
 
 ...
 

--- a/docs/guides/sharded_ruler.md
+++ b/docs/guides/sharded_ruler.md
@@ -7,7 +7,7 @@ slug: ruler-sharding
 
 ## Context
 
-One option to scale the ruler is by scaling it horizontally. However, with multiple ruler instances running they will need to coordinate to determine which instance will evaluate which rule. Similar to the ingesters, the rulers establish a hash ring to divide up the responsibilities of evaluating rules. 
+One option to scale the ruler is by scaling it horizontally. However, with multiple ruler instances running they will need to coordinate to determine which instance will evaluate which rule. Similar to the ingesters, the rulers establish a hash ring to divide up the responsibilities of evaluating rules.
 
 ## Config
 

--- a/docs/operations/query-tee.md
+++ b/docs/operations/query-tee.md
@@ -5,7 +5,7 @@ weight: 3
 slug: query-tee
 ---
 
-The `query-tee` is a standalone service which can be used for testing purposes to compare the query performances of 2+ backend systems (ie. Cortex clusters) ingesting the same exact series. 
+The `query-tee` is a standalone service which can be used for testing purposes to compare the query performances of 2+ backend systems (ie. Cortex clusters) ingesting the same exact series.
 
 This service exposes Prometheus-compatible read API endpoints and, for each received request, performs the request against all backends tracking the response time of each backend and then sends back to the client one of the received responses.
 

--- a/docs/proposals/api_design.md
+++ b/docs/proposals/api_design.md
@@ -16,7 +16,7 @@ The purpose of this design document is to propose a set of standards that should
 
 ## Current Design
 
-As things currently stand, the majority of HTTP API calls exist under the `/api/prom` path prefix. This prefix is configurable. However, since this prefix is shared between all the modules which leads to conflicts if the Alertmanager is attempted to be run as as part of the single binary (#1722). 
+As things currently stand, the majority of HTTP API calls exist under the `/api/prom` path prefix. This prefix is configurable. However, since this prefix is shared between all the modules which leads to conflicts if the Alertmanager is attempted to be run as as part of the single binary (#1722).
 
 ## Proposed Design
 
@@ -35,7 +35,7 @@ Under this path prefix, Cortex will act as a Alertmanager web server. In this ca
 #### `/api/v1/*` -- The cortex API will exist under this path prefix.
 
 - `/push`
-- `/chunks` 
+- `/chunks`
 - `/rules/*`
 
 | Current             | Proposed          |
@@ -65,7 +65,7 @@ A number of endpoints currently exist that are not under the `/api/prom` prefix 
 
 ### Path Versioning
 
-Cortex will utilize path based versioning similar to both Prometheus and Alertmanager. This will allow future versions of the API to be released with changes over time. 
+Cortex will utilize path based versioning similar to both Prometheus and Alertmanager. This will allow future versions of the API to be released with changes over time.
 
 ### Backwards-Compatibility
 

--- a/docs/proposals/receiving_metadata.md
+++ b/docs/proposals/receiving_metadata.md
@@ -11,7 +11,7 @@ slug: support-metadata-api
 - Status: Accepted
 
 ## Problem Statement
-Prometheus holds metric metadata alongside the contents of a scrape. This metadata (`HELP`, `TYPE`, `UNIT` and `METRIC_NAME`) enables [some Prometheus API](https://github.com/prometheus/prometheus/issues/6395) endpoints to output the metadata for integrations (e.g. [Grafana](https://github.com/grafana/grafana/pull/21124)) to consume it. 
+Prometheus holds metric metadata alongside the contents of a scrape. This metadata (`HELP`, `TYPE`, `UNIT` and `METRIC_NAME`) enables [some Prometheus API](https://github.com/prometheus/prometheus/issues/6395) endpoints to output the metadata for integrations (e.g. [Grafana](https://github.com/grafana/grafana/pull/21124)) to consume it.
 
 At the moment of writing, Cortex does not support the `api/v1/metadata` endpoint that Prometheus implements as metadata was never propagated via remote write. Recent [work is done in Prometheus](https://github.com/prometheus/prometheus/pull/6815/files) enables the propagation of metadata.
 
@@ -22,7 +22,7 @@ Before we delve into the solutions, let's set a baseline about how the data is r
 
 Metadata from Prometheus is sent in the same [`WriteRequest` proto message](https://github.com/prometheus/prometheus/blob/master/prompb/remote.proto) that the samples use. It is part of a different field (#3 given #2 is already [used interally](https://github.com/cortexproject/cortex/blob/master/pkg/ingester/client/cortex.proto#L36)), the data is a set identified by the metric name - that means it is aggregated across targets, and is sent all at once. Implying, Cortex will receive a single `WriteRequest` containing a set of the metadata for that instance at an specified interval.
 
-. It is also important to note that this current process is an intermediary step. Eventually, metadata in a request will be sent alongside samples and only for those included. The solutions proposed, take this nuance into account to avoid coupling between the current and future state of Prometheus, and hopefully do something now that also works for the future. 
+. It is also important to note that this current process is an intermediary step. Eventually, metadata in a request will be sent alongside samples and only for those included. The solutions proposed, take this nuance into account to avoid coupling between the current and future state of Prometheus, and hopefully do something now that also works for the future.
 
 As a reference, these are some key numbers regarding the size (and send timings) of the data at hand from our clusters at Grafana Labs:
 

--- a/pkg/util/services/README.md
+++ b/pkg/util/services/README.md
@@ -2,13 +2,13 @@
 
 This is a Go implementation of [services model](https://github.com/google/guava/wiki/ServiceExplained) from [Google Guava](https://github.com/google/guava) library.
 
-It provides `Service` interface (with implementation in `BasicService` type) and `Manager` for managing group of services at once. 
+It provides `Service` interface (with implementation in `BasicService` type) and `Manager` for managing group of services at once.
 
 Main benefits of this model are:
 
 - Services have well-defined explicit states. Services are not supposed to start any work until they are started, and they are supposed to enter Running state only if they have successfully done all initialization in Starting state.
 - States are observable by clients. Client can not only see the state, but also wait for Running or Terminated state.
-- If more observability is needed, clients can register state listeners. 
+- If more observability is needed, clients can register state listeners.
 - Service startup and shutdown is done asynchronously. This allows for nice parallelization of startup or shutdown of multiple services.
 - Services that depend on each other can simply wait for other service to be in correct state before using it.
 
@@ -31,17 +31,17 @@ Once service is in `Terminated` or `Failed` state, it cannot be restarted, these
 Full state diagram:
 
 ```text
-   ┌────────────────────────────────────────────────────────────────────┐      
-   │                                                                    │      
-   │                                                                    ▼      
+   ┌────────────────────────────────────────────────────────────────────┐
+   │                                                                    │
+   │                                                                    ▼
 ┌─────┐      ┌──────────┐      ┌─────────┐     ┌──────────┐      ┌────────────┐
 │ New │─────▶│ Starting │─────▶│ Running │────▶│ Stopping │───┬─▶│ Terminated │
 └─────┘      └──────────┘      └─────────┘     └──────────┘   │  └────────────┘
-                   │                                          │                
-                   │                                          │                
-                   │                                          │   ┌────────┐   
-                   └──────────────────────────────────────────┴──▶│ Failed │   
-                                                                  └────────┘   
+                   │                                          │
+                   │                                          │
+                   │                                          │   ┌────────┐
+                   └──────────────────────────────────────────┴──▶│ Failed │
+                                                                  └────────┘
 ```
 
 API and states and semantics are implemented to correspond to [Service class](https://guava.dev/releases/snapshot/api/docs/com/google/common/util/concurrent/Service.html) in Guava library.

--- a/tools/cleanup-white-noise.sh
+++ b/tools/cleanup-white-noise.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+SED_BIN=${SED_BIN:-sed}
+
+${SED_BIN} -i 's/[ \t]*$//' "$@"


### PR DESCRIPTION
**What this PR does**:
Sometimes we do receive PRs from people which (correctly) configure automatic trailing whitespaces removal in the IDE/text editor (ie. CHANGELOG edits in #2440).

I would suggest to solve this problem once and for all, forcing any PR to have no trailing whitespaces in markdown. In this PR I've added a linter check and a quick way to fix it (`make clean-white-noise`). I inherited the script from our Thanos friends ❤️ .

/cc @cyriltovena 

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
