### PR TITLE
Move validation code into schema creation

### DIFF
--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -60,9 +60,12 @@ func NewCompositeStore() CompositeStore {
 
 // AddPeriod adds the configuration for a period of time to the CompositeStore
 func (c *CompositeStore) AddPeriod(storeCfg StoreConfig, cfg PeriodConfig, index IndexClient, chunks Client, limits StoreLimits, chunksCache, writeDedupeCache cache.Cache) error {
-	schema := cfg.CreateSchema()
+	schema, err := cfg.CreateSchema()
+	if err != nil {
+		return err
+	}
+
 	var store Store
-	var err error
 	switch s := schema.(type) {
 	case SeriesStoreSchema:
 		store, err = newSeriesStore(storeCfg, s, index, chunks, limits, chunksCache, writeDedupeCache)

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -145,34 +145,46 @@ func (cfg *SchemaConfig) ForEachAfter(t model.Time, f func(config *PeriodConfig)
 }
 
 // CreateSchema returns the schema defined by the PeriodConfig
-func (cfg PeriodConfig) CreateSchema() BaseSchema {
-	buckets, _ := cfg.createBucketsFunc()
+func (cfg PeriodConfig) CreateSchema() (BaseSchema, error) {
+	buckets, bucketsPeriod := cfg.createBucketsFunc()
+
+	// Ensure the tables period is a multiple of the bucket period
+	if cfg.IndexTables.Period > 0 && cfg.IndexTables.Period%bucketsPeriod != 0 {
+		return nil, errInvalidTablePeriod
+	}
+
+	if cfg.ChunkTables.Period > 0 && cfg.ChunkTables.Period%bucketsPeriod != 0 {
+		return nil, errInvalidTablePeriod
+	}
 
 	switch cfg.Schema {
 	case "v1":
-		return newStoreSchema(buckets, originalEntries{})
+		return newStoreSchema(buckets, originalEntries{}), nil
 	case "v2":
-		return newStoreSchema(buckets, originalEntries{})
+		return newStoreSchema(buckets, originalEntries{}), nil
 	case "v3":
-		return newStoreSchema(buckets, base64Entries{originalEntries{}})
+		return newStoreSchema(buckets, base64Entries{originalEntries{}}), nil
 	case "v4":
-		return newStoreSchema(buckets, labelNameInHashKeyEntries{})
+		return newStoreSchema(buckets, labelNameInHashKeyEntries{}), nil
 	case "v5":
-		return newStoreSchema(buckets, v5Entries{})
+		return newStoreSchema(buckets, v5Entries{}), nil
 	case "v6":
-		return newStoreSchema(buckets, v6Entries{})
+		return newStoreSchema(buckets, v6Entries{}), nil
 	case "v9":
-		return newSeriesStoreSchema(buckets, v9Entries{})
-	case "v10":
-		return newSeriesStoreSchema(buckets, v10Entries{rowShards: cfg.RowShards})
-	case "v11":
-		return newSeriesStoreSchema(buckets, v11Entries{
-			v10Entries: v10Entries{
-				rowShards: cfg.RowShards,
-			},
-		})
+		return newSeriesStoreSchema(buckets, v9Entries{}), nil
+	case "v10", "v11":
+		if cfg.RowShards == 0 {
+			return nil, fmt.Errorf("Must have row_shards > 0 (current: %d) for schema (%s)", cfg.RowShards, cfg.Schema)
+		}
+
+		v10 := v10Entries{rowShards: cfg.RowShards}
+		if cfg.Schema == "v10" {
+			return newSeriesStoreSchema(buckets, v10), nil
+		}
+
+		return newSeriesStoreSchema(buckets, v11Entries{v10}), nil
 	default:
-		return nil
+		return nil, errInvalidSchemaVersion
 	}
 }
 
@@ -193,35 +205,8 @@ func (cfg *PeriodConfig) applyDefaults() {
 
 // Validate the period config.
 func (cfg PeriodConfig) validate() error {
-	// Ensure the schema version exists
-	schema := cfg.CreateSchema()
-	if schema == nil {
-		return errInvalidSchemaVersion
-	}
-
-	// Ensure the tables period is a multiple of the bucket period
-	_, bucketsPeriod := cfg.createBucketsFunc()
-
-	if cfg.IndexTables.Period > 0 && cfg.IndexTables.Period%bucketsPeriod != 0 {
-		return errInvalidTablePeriod
-	}
-
-	if cfg.ChunkTables.Period > 0 && cfg.ChunkTables.Period%bucketsPeriod != 0 {
-		return errInvalidTablePeriod
-	}
-
-	switch cfg.Schema {
-	case "v1", "v2", "v3", "v4", "v5", "v6", "v9":
-	case "v10", "v11":
-		if cfg.RowShards == 0 {
-			return fmt.Errorf("Must have row_shards > 0 (current: %d) for schema (%s)", cfg.RowShards, cfg.Schema)
-		}
-	default:
-		// This generally unreachable path protects us from adding schemas and not handling them in this function.
-		return fmt.Errorf("unexpected schema (%s)", cfg.Schema)
-	}
-
-	return nil
+	_, err := cfg.CreateSchema()
+	return err
 }
 
 // Load the yaml file, or build the config from legacy command-line flags

--- a/pkg/chunk/schema_test.go
+++ b/pkg/chunk/schema_test.go
@@ -39,18 +39,23 @@ func mergeResults(rss ...[]IndexEntry) []IndexEntry {
 
 const table = "table"
 
-func makeSeriesStoreSchema(schemaName string) SeriesStoreSchema {
-	return PeriodConfig{
+func mustMakeSchema(schemaName string) BaseSchema {
+	s, err := PeriodConfig{
 		Schema:      schemaName,
 		IndexTables: PeriodicTableConfig{Prefix: table},
-	}.CreateSchema().(SeriesStoreSchema)
+	}.CreateSchema()
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func makeSeriesStoreSchema(schemaName string) SeriesStoreSchema {
+	return mustMakeSchema(schemaName).(SeriesStoreSchema)
 }
 
 func makeStoreSchema(schemaName string) StoreSchema {
-	return PeriodConfig{
-		Schema:      schemaName,
-		IndexTables: PeriodicTableConfig{Prefix: table},
-	}.CreateSchema().(StoreSchema)
+	return mustMakeSchema(schemaName).(StoreSchema)
 }
 
 func TestSchemaHashKeys(t *testing.T) {


### PR DESCRIPTION
**What this PR does**: This simple refactoring PR moves schema validation code into `CreateSchema`, to keep schema-specific logic at one place only.

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
