### PR TITLE
Rename ingester.SeriesLimiter to ingester.Limiter

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -102,7 +102,7 @@ type Ingester struct {
 	chunkStore         ChunkStore
 	lifecycler         *ring.Lifecycler
 	limits             *validation.Overrides
-	limiter            *SeriesLimiter
+	limiter            *Limiter
 	subservicesWatcher *services.FailureWatcher
 
 	userStatesMtx sync.RWMutex // protects userStates and stopped
@@ -175,7 +175,7 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 	if err != nil {
 		return nil, err
 	}
-	i.limiter = NewSeriesLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor, cfg.ShardByAllLabels)
+	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor, cfg.ShardByAllLabels)
 	i.subservicesWatcher = services.NewFailureWatcher()
 	i.subservicesWatcher.WatchService(i.lifecycler)
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -137,7 +137,7 @@ func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides,
 	i.subservicesWatcher.WatchService(i.lifecycler)
 
 	// Init the limter and instantiate the user states which depend on it
-	i.limiter = NewSeriesLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor, cfg.ShardByAllLabels)
+	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor, cfg.ShardByAllLabels)
 	i.userStates = newUserStates(i.limiter, cfg, i.metrics)
 
 	i.Service = services.NewBasicService(i.startingV2, i.updateLoop, i.stoppingV2)

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -94,7 +94,7 @@ func TestSeriesLimit_maxSeriesPerMetric(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewSeriesLimiter(limits, ring, testData.ringReplicationFactor, testData.shardByAllLabels)
+			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, testData.shardByAllLabels)
 			actual := limiter.maxSeriesPerMetric("test")
 
 			assert.Equal(t, testData.expected, actual)
@@ -184,7 +184,7 @@ func TestSeriesLimit_maxSeriesPerUser(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewSeriesLimiter(limits, ring, testData.ringReplicationFactor, testData.shardByAllLabels)
+			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, testData.shardByAllLabels)
 			actual := limiter.maxSeriesPerUser("test")
 
 			assert.Equal(t, testData.expected, actual)
@@ -192,7 +192,7 @@ func TestSeriesLimit_maxSeriesPerUser(t *testing.T) {
 	}
 }
 
-func TestSeriesLimiter_AssertMaxSeriesPerMetric(t *testing.T) {
+func TestLimiter_AssertMaxSeriesPerMetric(t *testing.T) {
 	tests := map[string]struct {
 		maxLocalSeriesPerMetric  int
 		maxGlobalSeriesPerMetric int
@@ -246,7 +246,7 @@ func TestSeriesLimiter_AssertMaxSeriesPerMetric(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewSeriesLimiter(limits, ring, testData.ringReplicationFactor, testData.shardByAllLabels)
+			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, testData.shardByAllLabels)
 			actual := limiter.AssertMaxSeriesPerMetric("test", testData.series)
 
 			assert.Equal(t, testData.expected, actual)
@@ -254,7 +254,7 @@ func TestSeriesLimiter_AssertMaxSeriesPerMetric(t *testing.T) {
 	}
 }
 
-func TestSeriesLimiter_AssertMaxSeriesPerUser(t *testing.T) {
+func TestLimiter_AssertMaxSeriesPerUser(t *testing.T) {
 	tests := map[string]struct {
 		maxLocalSeriesPerUser  int
 		maxGlobalSeriesPerUser int
@@ -308,7 +308,7 @@ func TestSeriesLimiter_AssertMaxSeriesPerUser(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewSeriesLimiter(limits, ring, testData.ringReplicationFactor, testData.shardByAllLabels)
+			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, testData.shardByAllLabels)
 			actual := limiter.AssertMaxSeriesPerUser("test", testData.series)
 
 			assert.Equal(t, testData.expected, actual)
@@ -316,7 +316,7 @@ func TestSeriesLimiter_AssertMaxSeriesPerUser(t *testing.T) {
 	}
 }
 
-func TestSeriesLimiter_minNonZero(t *testing.T) {
+func TestLimiter_minNonZero(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
@@ -355,7 +355,7 @@ func TestSeriesLimiter_minNonZero(t *testing.T) {
 		testData := testData
 
 		t.Run(testName, func(t *testing.T) {
-			limiter := NewSeriesLimiter(nil, nil, 0, false)
+			limiter := NewLimiter(nil, nil, 0, false)
 			assert.Equal(t, testData.expected, limiter.minNonZero(testData.first, testData.second))
 		})
 	}

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -26,13 +26,13 @@ import (
 // each one containing all the in-memory series for a given user.
 type userStates struct {
 	states  sync.Map
-	limiter *SeriesLimiter
+	limiter *Limiter
 	cfg     Config
 	metrics *ingesterMetrics
 }
 
 type userState struct {
-	limiter             *SeriesLimiter
+	limiter             *Limiter
 	userID              string
 	fpLocker            *fingerprintLocker
 	fpToSeries          *seriesMap
@@ -63,7 +63,7 @@ type metricCounterShard struct {
 	m   map[string]int
 }
 
-func newUserStates(limiter *SeriesLimiter, cfg Config, metrics *ingesterMetrics) *userStates {
+func newUserStates(limiter *Limiter, cfg Config, metrics *ingesterMetrics) *userStates {
 	return &userStates{
 		limiter: limiter,
 		cfg:     cfg,


### PR DESCRIPTION
Hello everyone 👋,

As part of #2459, I plan to introduce ingester limits for Metadata. Instead of creating a new struct with similar attributes for limiting metadata, I thought about just changing the name of the current one to re-use it. Thus, this PR renames `SeriesLimiter` to `Limiter`.

How do maintainers feel about this?

The filename is already accurate, I see no tests that might need updating, and I don't think this is something we should add to the changelog but feel free to let me know if otherwise. I'll be happy to amend.

Signed-off-by: gotjosh <josue@grafana.com>


