### PR TITLE
Document Query Results Cache options in caching.md

### DIFF
--- a/docs/production/caching.md
+++ b/docs/production/caching.md
@@ -163,7 +163,8 @@ These query results can potentially be very large, and as such the maximum value
 The cache is populated when there is a cache miss.
 Items stay in the cache indefinitely.
 
-The query results cache should be configured on the **query-frontend** using flags with `-frontend.memcached` prefix. You need to also set `-querier.cache-results=true` and `-querier.split-queries-by-interval=24h` (24h is a good starting point).
+The query results cache should be configured on the **query-frontend** using flags with `-frontend.memcached` (or for example -frontend.redis) prefix.
+You need to also set `-querier.cache-results=true` and `-querier.split-queries-by-interval=24h` (24h is a good starting point).
 
 
 ### Index Write Cache

--- a/docs/production/caching.md
+++ b/docs/production/caching.md
@@ -163,7 +163,8 @@ These query results can potentially be very large, and as such the maximum value
 The cache is populated when there is a cache miss.
 Items stay in the cache indefinitely.
 
-The query results cache should be configured on the **query-frontend** using flags with `-frontend.cache` prefix.
+The query results cache should be configured on the **query-frontend** using flags with `-frontend.memcached` prefix. You need to also set `-querier.cache-results=true` and `-querier.split-queries-by-interval=24h` (24h is a good starting point).
+
 
 ### Index Write Cache
 

--- a/docs/production/caching.md
+++ b/docs/production/caching.md
@@ -163,8 +163,13 @@ These query results can potentially be very large, and as such the maximum value
 The cache is populated when there is a cache miss.
 Items stay in the cache indefinitely.
 
-The query results cache should be configured on the **query-frontend** using flags with `-frontend.memcached` (or for example `-frontend.redis`) prefix.
-You need to also set `-querier.cache-results=true` and `-querier.split-queries-by-interval=24h` (24h is a good starting point).
+The query results cache should be configured on the **query-frontend** using flags with `-frontend` prefix:
+
+- `-frontend.memcached.*` flags to use Memcached backend
+- `-frontend.redis.*` flags to use Redis backend
+- `-frontend.fifocache.*` and `-frontend.cache.enable-fifocache` flags to use the per-process in-memory cache (not shared across multiple query-frontend instances)
+
+Please keep in mind to also enable `-querier.cache-results=true` and configure `-querier.split-queries-by-interval=24h` (`24h` is a good starting point).
 
 
 ### Index Write Cache

--- a/docs/production/caching.md
+++ b/docs/production/caching.md
@@ -163,7 +163,7 @@ These query results can potentially be very large, and as such the maximum value
 The cache is populated when there is a cache miss.
 Items stay in the cache indefinitely.
 
-The query results cache should be configured on the **query-frontend** using flags with `-frontend.memcached` (or for example -frontend.redis) prefix.
+The query results cache should be configured on the **query-frontend** using flags with `-frontend.memcached` (or for example `-frontend.redis`) prefix.
 You need to also set `-querier.cache-results=true` and `-querier.split-queries-by-interval=24h` (24h is a good starting point).
 
 


### PR DESCRIPTION
The documentation for the Query Results Cache was a bit outdated as it was pointing to an incorrect -frontend.cache prefix. I was unable to get the caching work without additional help. This change contains all the info to get the query result cache working.

Signed-off-by: Juho Makinen <juho.makinen@gmail.com>
