### PR TITLE
include Cortex version in cortex_build_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [BUGFIX] Experimental TSDB: fixed response status code from `422` to `500` when an error occurs while iterating chunks with the experimental blocks storage. #2402
 * [BUGFIX] Ring: Fixed a situation where upgrading from pre-1.0 cortex with a rolling strategy caused new 1.0 ingesters to lose their zone value in the ring until manually forced to re-register. #2404
 * [BUGFIX] Distributor: `/all_user_stats` now show API and Rule Ingest Rate correctly. #2457
+* [BUGFIX] Fixed `version`, `revision` and `branch` labels exported by the `cortex_build_info` metric. #2468
 
 ## 1.0.0 / 2020-04-02
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 .PHONY: all test clean images protos exes dist
 .DEFAULT_GOAL := all
 
+# Version number
+VERSION=$(shell cat "./VERSION" 2> /dev/null)
+
 # Boiler plate for building Docker containers.
 # All this must go at top of file I'm afraid.
 IMAGE_PREFIX ?= quay.io/cortexproject/
 # Use CIRCLE_TAG if present for releases.
 IMAGE_TAG ?= $(if $(CIRCLE_TAG),$(CIRCLE_TAG),$(shell ./tools/image-tag))
-GIT_REVISION := $(shell git rev-parse HEAD)
+GIT_REVISION := $(shell git rev-parse --short HEAD)
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 UPTODATE := .uptodate
 
 # Support gsed on OSX (installed via brew), falling back to sed. On Linux
@@ -82,7 +86,7 @@ RM := --rm
 # as it currently disallows TTY devices. This value needs to be overridden
 # in any custom cloudbuild.yaml files
 TTY := --tty
-GO_FLAGS := -ldflags "-extldflags \"-static\" -s -w" -tags netgo
+GO_FLAGS := -ldflags "-X main.Branch=$(GIT_BRANCH) -X main.Revision=$(GIT_REVISION) -X main.Version=$(VERSION) -extldflags \"-static\" -s -w" -tags netgo
 
 ifeq ($(BUILD_IN_CONTAINER),true)
 

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -22,7 +22,17 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
 
+// Version is set via build flag -ldflags -X main.Version
+var (
+	Version  string
+	Branch   string
+	Revision string
+)
+
 func init() {
+	version.Version = Version
+	version.Branch = Branch
+	version.Revision = Revision
 	prometheus.MustRegister(version.NewCollector("cortex"))
 }
 


### PR DESCRIPTION
**What this PR does**: Adds the version,branch,revision to the build args, so that `cortex_build_info` correctly populates the version number.

Fixes #1709 

`cortex_build_info{branch="build-info-version",goversion="go1.13.3",revision="ca93c1b87",version="1.0.0"} 1`

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
