### PR TITLE
Add store-gateway support to querier

### DIFF
--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -28,7 +28,13 @@ ingester:
           host: consul:8500
       replication_factor: 1
 
+querier:
+  # Used when the blocks sharding is disabled.
+  store_gateway_addresses: store-gateway-1:9008,store-gateway-2:9009
+
 tsdb:
+  store_gateway_enabled: true
+
   dir: /tmp/cortex-tsdb-ingester
   ship_interval: 1m
   block_ranges_period: [ 2h ]
@@ -67,6 +73,15 @@ compactor:
   consistency_delay:   1m
   sharding_enabled:    true
   sharding_ring:
+    kvstore:
+      store: consul
+      consul:
+        host: consul:8500
+
+store_gateway:
+  sharding_enabled: true
+  sharding_ring:
+    replication_factor: 1
     kvstore:
       store: consul
       consul:

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -92,7 +92,7 @@ services:
     volumes:
       - ./config:/cortex/config
 
-  store-gateway:
+  store-gateway-1:
     build:
       context:    .
       dockerfile: dev.dockerfile
@@ -103,6 +103,20 @@ services:
       - minio
     ports:
       - 8008:8008
+    volumes:
+      - ./config:/cortex/config
+
+  store-gateway-2:
+    build:
+      context:    .
+      dockerfile: dev.dockerfile
+    image: cortex
+    command: ["sh", "-c", "sleep 3 && exec ./cortex -config.file=./config/cortex.yaml -target=store-gateway -server.http-listen-port=8009 -server.grpc-listen-port=9009"]
+    depends_on:
+      - consul
+      - minio
+    ports:
+      - 8009:8009
     volumes:
       - ./config:/cortex/config
 

--- a/docs/operations/blocks-storage.md
+++ b/docs/operations/blocks-storage.md
@@ -109,6 +109,7 @@ The general [configuration documentation](../configuration/_index.md) also appli
 
 - [`storage_config`](#storage-config)
 - [`tsdb_config`](#tsdb-config)
+- [`store_gateway_config`](#store-gateway-config)
 - [`compactor_config`](#compactor-config)
 
 ### `storage_config`
@@ -286,6 +287,11 @@ tsdb:
   # CLI flag: -experimental.tsdb.stripe-size
   [stripe_size: <int> | default = 16384]
 
+  # True if the Cortex cluster is running the store-gateway service and the
+  # querier should query the bucket store via the store-gateway.
+  # CLI flag: -experimental.tsdb.store-gateway-enabled
+  [store_gateway_enabled: <boolean> | default = false]
+
   # limit the number of concurrently opening TSDB's on startup
   # CLI flag: -experimental.tsdb.max-tsdb-opening-concurrency-on-startup
   [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
@@ -351,6 +357,74 @@ tsdb:
     # CLI flag: -experimental.tsdb.filesystem.dir
     [dir: <string> | default = ""]
 ```
+
+### `store_gateway_config`
+
+The `store_gateway_config` configures the store-gateway service used by the experimental blocks storage.
+
+```yaml
+store_gateway:
+  # Shard blocks across multiple store gateway instances.
+  # CLI flag: -experimental.store-gateway.sharding-enabled
+  [sharding_enabled: <boolean> | default = false]
+
+  sharding_ring:
+    kvstore:
+      # Backend storage to use for the ring. Supported values are: consul, etcd,
+      # inmemory, multi, memberlist (experimental).
+      # CLI flag: -experimental.store-gateway.sharding-ring.store
+      [store: <string> | default = "consul"]
+
+      # The prefix for the keys in the store. Should end with a /.
+      # CLI flag: -experimental.store-gateway.sharding-ring.prefix
+      [prefix: <string> | default = "collectors/"]
+
+      # The consul_config configures the consul client.
+      # The CLI flags prefix for this block config is:
+      # experimental.store-gateway.sharding-ring
+      [consul: <consul_config>]
+
+      # The etcd_config configures the etcd client.
+      # The CLI flags prefix for this block config is:
+      # experimental.store-gateway.sharding-ring
+      [etcd: <etcd_config>]
+
+      multi:
+        # Primary backend storage used by multi-client.
+        # CLI flag: -experimental.store-gateway.sharding-ring.multi.primary
+        [primary: <string> | default = ""]
+
+        # Secondary backend storage used by multi-client.
+        # CLI flag: -experimental.store-gateway.sharding-ring.multi.secondary
+        [secondary: <string> | default = ""]
+
+        # Mirror writes to secondary store.
+        # CLI flag: -experimental.store-gateway.sharding-ring.multi.mirror-enabled
+        [mirror_enabled: <boolean> | default = false]
+
+        # Timeout for storing value to secondary store.
+        # CLI flag: -experimental.store-gateway.sharding-ring.multi.mirror-timeout
+        [mirror_timeout: <duration> | default = 2s]
+
+    # Period at which to heartbeat to the ring.
+    # CLI flag: -experimental.store-gateway.sharding-ring.heartbeat-period
+    [heartbeat_period: <duration> | default = 15s]
+
+    # The heartbeat timeout after which store gateways are considered unhealthy
+    # within the ring.
+    # CLI flag: -experimental.store-gateway.sharding-ring.heartbeat-timeout
+    [heartbeat_timeout: <duration> | default = 1m]
+
+    # The replication factor to use when sharding blocks.
+    # CLI flag: -experimental.store-gateway.replication-factor
+    [replication_factor: <int> | default = 3]
+
+    # File path where tokens are stored. If empty, tokens are not stored at
+    # shutdown and restored at startup.
+    # CLI flag: -experimental.store-gateway.tokens-file-path
+    [tokens_file_path: <string> | default = ""]
+```
+
 ### `compactor_config`
 
 The `compactor_config` configures the compactor for the experimental blocks storage.

--- a/docs/operations/blocks-storage.template
+++ b/docs/operations/blocks-storage.template
@@ -109,6 +109,7 @@ The general [configuration documentation](../configuration/_index.md) also appli
 
 - [`storage_config`](#storage-config)
 - [`tsdb_config`](#tsdb-config)
+- [`store_gateway_config`](#store-gateway-config)
 - [`compactor_config`](#compactor-config)
 
 ### `storage_config`
@@ -123,6 +124,9 @@ storage:
 ```
 
 {{ .TSDBConfigBlock }}
+
+{{ .StoreGatewayConfigBlock }}
+
 {{ .CompactorConfigBlock }}
 
 ## Known issues

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	go.etcd.io/etcd v0.0.0-20190709142735-eb7dd97135a5
 	go.uber.org/atomic v1.5.0
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/api v0.14.0
 	google.golang.org/grpc v1.25.1

--- a/integration/api_config_test.go
+++ b/integration/api_config_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,11 +22,8 @@ func TestConfigAPIEndpoint(t *testing.T) {
 
 	// Start Cortex in single binary mode, reading the config from file.
 	require.NoError(t, copyFileToSharedDir(s, "docs/configuration/single-process-config.yaml", cortexConfigFile))
-	flags := map[string]string{
-		"-config.file": filepath.Join(e2e.ContainerSharedDir, cortexConfigFile),
-	}
 
-	cortex1 := e2ecortex.NewSingleBinary("cortex-1", flags, "", 9009, 9095)
+	cortex1 := e2ecortex.NewSingleBinaryWithConfigFile("cortex-1", cortexConfigFile, nil, "", 9009, 9095)
 	require.NoError(t, s.StartAndWaitReady(cortex1))
 
 	// Get config from /config API endpoint.
@@ -42,6 +38,6 @@ func TestConfigAPIEndpoint(t *testing.T) {
 	// Start again Cortex in single binary with the exported config
 	// and ensure it starts (pass the readiness probe).
 	require.NoError(t, writeFileToSharedDir(s, cortexConfigFile, body))
-	cortex2 := e2ecortex.NewSingleBinary("cortex-2", flags, "", 9009, 9095)
+	cortex2 := e2ecortex.NewSingleBinaryWithConfigFile("cortex-2", cortexConfigFile, nil, "", 9009, 9095)
 	require.NoError(t, s.StartAndWaitReady(cortex2))
 }

--- a/integration/asserts.go
+++ b/integration/asserts.go
@@ -22,6 +22,7 @@ const (
 	TableManager
 	AlertManager
 	Ruler
+	StoreGateway
 )
 
 var (
@@ -34,11 +35,13 @@ var (
 		TableManager:  []string{},
 		AlertManager:  []string{"cortex_alertmanager"},
 		Ruler:         []string{},
+		StoreGateway:  []string{"!cortex_storegateway_client", "cortex_storegateway"}, // The metrics prefix cortex_storegateway_client may be used by other components so we ignore it.
 	}
 
 	// Blacklisted metrics prefixes across any Cortex service.
 	blacklistedMetricsPrefixes = []string{
 		"cortex_alert_manager", // It should be "cortex_alertmanager"
+		"cortex_store_gateway", // It should be "cortex_storegateway"
 	}
 )
 

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -55,11 +55,16 @@ func runBackwardCompatibilityTestWithChunksStorage(t *testing.T, previousImage s
 	consul := e2edb.NewConsul()
 	require.NoError(t, s.StartAndWaitReady(dynamo, consul))
 
-	flagsForOldImage := mergeFlags(ChunksStorageFlags, map[string]string{
-		"-schema-config-file":          "",
-		"-config-yaml":                 ChunksStorageFlags["-schema-config-file"],
-		"-table-manager.poll-interval": "",
-		"-dynamodb.poll-interval":      ChunksStorageFlags["-table-manager.poll-interval"],
+	// Keep empty values because they will be used to remove default flags.
+	flagsForOldImage := e2e.MergeFlagsWithoutRemovingEmpty(ChunksStorageFlags, map[string]string{
+		"-schema-config-file":                                       "",
+		"-config-yaml":                                              ChunksStorageFlags["-schema-config-file"],
+		"-table-manager.poll-interval":                              "",
+		"-dynamodb.poll-interval":                                   ChunksStorageFlags["-table-manager.poll-interval"],
+		"-experimental.store-gateway.sharding-enabled":              "",
+		"-experimental.store-gateway.sharding-ring.store":           "",
+		"-experimental.store-gateway.sharding-ring.consul.hostname": "",
+		"-experimental.store-gateway.replication-factor":            "",
 	})
 
 	require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
@@ -123,12 +128,17 @@ func runNewDistributorsCanPushToOldIngestersWithReplication(t *testing.T, previo
 	consul := e2edb.NewConsul()
 	require.NoError(t, s.StartAndWaitReady(dynamo, consul))
 
-	flagsForOldImage := mergeFlags(ChunksStorageFlags, map[string]string{
-		"-schema-config-file":             "",
-		"-config-yaml":                    ChunksStorageFlags["-schema-config-file"],
-		"-table-manager.poll-interval":    "",
-		"-dynamodb.poll-interval":         ChunksStorageFlags["-table-manager.poll-interval"],
-		"-distributor.replication-factor": "3",
+	// Keep empty values because they will be used to remove default flags.
+	flagsForOldImage := e2e.MergeFlagsWithoutRemovingEmpty(ChunksStorageFlags, map[string]string{
+		"-schema-config-file":                                       "",
+		"-config-yaml":                                              ChunksStorageFlags["-schema-config-file"],
+		"-table-manager.poll-interval":                              "",
+		"-dynamodb.poll-interval":                                   ChunksStorageFlags["-table-manager.poll-interval"],
+		"-distributor.replication-factor":                           "3",
+		"-experimental.store-gateway.sharding-enabled":              "",
+		"-experimental.store-gateway.sharding-ring.store":           "",
+		"-experimental.store-gateway.sharding-ring.consul.hostname": "",
+		"-experimental.store-gateway.replication-factor":            "",
 	})
 
 	flagsForNewImage := mergeFlags(ChunksStorageFlags, map[string]string{

--- a/integration/e2e/composite_service.go
+++ b/integration/e2e/composite_service.go
@@ -1,0 +1,83 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+// CompositeHTTPService abstract an higher-level service composed, under the hood,
+// by 2+ HTTPService.
+type CompositeHTTPService struct {
+	services []*HTTPService
+
+	// Generic retry backoff.
+	retryBackoff *util.Backoff
+}
+
+func NewCompositeHTTPService(services ...*HTTPService) *CompositeHTTPService {
+	return &CompositeHTTPService{
+		services: services,
+		retryBackoff: util.NewBackoff(context.Background(), util.BackoffConfig{
+			MinBackoff: 300 * time.Millisecond,
+			MaxBackoff: 600 * time.Millisecond,
+			MaxRetries: 50, // Sometimes the CI is slow ¯\_(ツ)_/¯
+		}),
+	}
+}
+
+func (s *CompositeHTTPService) NumInstances() int {
+	return len(s.services)
+}
+
+func (s *CompositeHTTPService) Instances() []*HTTPService {
+	return s.services
+}
+
+// WaitSumMetrics waits for at least one instance of each given metric names to be present and their sums, returning true
+// when passed to given isExpected(...).
+func (s *CompositeHTTPService) WaitSumMetrics(isExpected func(sums ...float64) bool, metricNames ...string) error {
+	var (
+		sums []float64
+		err  error
+	)
+
+	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
+		sums, err = s.SumMetrics(metricNames...)
+		if err != nil {
+			return err
+		}
+
+		if isExpected(sums...) {
+			return nil
+		}
+
+		s.retryBackoff.Wait()
+	}
+
+	return fmt.Errorf("unable to find metrics %s with expected values. Last values: %v", metricNames, sums)
+}
+
+// SumMetrics returns the sum of the values of each given metric names.
+func (s *CompositeHTTPService) SumMetrics(metricNames ...string) ([]float64, error) {
+	sums := make([]float64, len(metricNames))
+
+	for _, service := range s.services {
+		partials, err := service.SumMetrics(metricNames...)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(partials) != len(sums) {
+			return nil, fmt.Errorf("unexpected mismatching sum metrics results (got %d, expected %d)", len(partials), len(sums))
+		}
+
+		for i := 0; i < len(sums); i++ {
+			sums[i] += partials[i]
+		}
+	}
+
+	return sums, nil
+}

--- a/integration/e2e/metrics.go
+++ b/integration/e2e/metrics.go
@@ -1,0 +1,95 @@
+package e2e
+
+import (
+	"math"
+
+	io_prometheus_client "github.com/prometheus/client_model/go"
+)
+
+func getValue(m *io_prometheus_client.Metric) float64 {
+	if m.GetGauge() != nil {
+		return m.GetGauge().GetValue()
+	} else if m.GetCounter() != nil {
+		return m.GetCounter().GetValue()
+	} else if m.GetHistogram() != nil {
+		return m.GetHistogram().GetSampleSum()
+	} else if m.GetSummary() != nil {
+		return m.GetSummary().GetSampleSum()
+	} else {
+		return 0
+	}
+}
+
+func sumValues(family *io_prometheus_client.MetricFamily) float64 {
+	sum := 0.0
+	for _, m := range family.Metric {
+		sum += getValue(m)
+	}
+	return sum
+}
+
+func EqualsSingle(expected float64) func(float64) bool {
+	return func(v float64) bool {
+		return v == expected || (math.IsNaN(v) && math.IsNaN(expected))
+	}
+}
+
+// Equals is an isExpected function for WaitSumMetrics that returns true if given single sum is equals to given value.
+func Equals(value float64) func(sums ...float64) bool {
+	return func(sums ...float64) bool {
+		if len(sums) != 1 {
+			panic("equals: expected one value")
+		}
+		return sums[0] == value || math.IsNaN(sums[0]) && math.IsNaN(value)
+	}
+}
+
+// Greater is an isExpected function for WaitSumMetrics that returns true if given single sum is greater than given value.
+func Greater(value float64) func(sums ...float64) bool {
+	return func(sums ...float64) bool {
+		if len(sums) != 1 {
+			panic("greater: expected one value")
+		}
+		return sums[0] > value
+	}
+}
+
+// Less is an isExpected function for WaitSumMetrics that returns true if given single sum is less than given value.
+func Less(value float64) func(sums ...float64) bool {
+	return func(sums ...float64) bool {
+		if len(sums) != 1 {
+			panic("less: expected one value")
+		}
+		return sums[0] < value
+	}
+}
+
+// EqualsAmongTwo is an isExpected function for WaitSumMetrics that returns true if first sum is equal to the second.
+// NOTE: Be careful on scrapes in between of process that changes two metrics. Those are
+// usually not atomic.
+func EqualsAmongTwo(sums ...float64) bool {
+	if len(sums) != 2 {
+		panic("equalsAmongTwo: expected two values")
+	}
+	return sums[0] == sums[1]
+}
+
+// GreaterAmongTwo is an isExpected function for WaitSumMetrics that returns true if first sum is greater than second.
+// NOTE: Be careful on scrapes in between of process that changes two metrics. Those are
+// usually not atomic.
+func GreaterAmongTwo(sums ...float64) bool {
+	if len(sums) != 2 {
+		panic("greaterAmongTwo: expected two values")
+	}
+	return sums[0] > sums[1]
+}
+
+// LessAmongTwo is an isExpected function for WaitSumMetrics that returns true if first sum is smaller than second.
+// NOTE: Be careful on scrapes in between of process that changes two metrics. Those are
+// usually not atomic.
+func LessAmongTwo(sums ...float64) bool {
+	if len(sums) != 2 {
+		panic("lessAmongTwo: expected two values")
+	}
+	return sums[0] < sums[1]
+}

--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -22,17 +22,23 @@ func EmptyFlags() map[string]string {
 }
 
 func MergeFlags(inputs ...map[string]string) map[string]string {
+	output := MergeFlagsWithoutRemovingEmpty(inputs...)
+
+	for k, v := range output {
+		if v == "" {
+			delete(output, k)
+		}
+	}
+
+	return output
+}
+
+func MergeFlagsWithoutRemovingEmpty(inputs ...map[string]string) map[string]string {
 	output := map[string]string{}
 
 	for _, input := range inputs {
 		for name, value := range input {
 			output[name] = value
-		}
-	}
-
-	for k, v := range output {
-		if v == "" {
-			delete(output, k)
 		}
 	}
 

--- a/integration/e2ecortex/service.go
+++ b/integration/e2ecortex/service.go
@@ -19,7 +19,7 @@ func NewCortexService(
 	otherPorts ...int,
 ) *CortexService {
 	return &CortexService{
-		HTTPService: e2e.NewHTTPService(name, image, command, readiness, httpPort, otherPorts...),
+		HTTPService: e2e.NewHTTPService(name, image, command, readiness, httpPort, append(otherPorts, grpcPort)...),
 		grpcPort:    grpcPort,
 	}
 }
@@ -30,4 +30,21 @@ func (s *CortexService) GRPCEndpoint() string {
 
 func (s *CortexService) NetworkGRPCEndpoint() string {
 	return s.NetworkEndpoint(s.grpcPort)
+}
+
+// CompositeCortexService abstract an higher-level service composed, under the hood,
+// by 2+ CortexService.
+type CompositeCortexService struct {
+	*e2e.CompositeHTTPService
+}
+
+func NewCompositeCortexService(services ...*CortexService) *CompositeCortexService {
+	var httpServices []*e2e.HTTPService
+	for _, s := range services {
+		httpServices = append(httpServices, s.HTTPService)
+	}
+
+	return &CompositeCortexService{
+		CompositeHTTPService: e2e.NewCompositeHTTPService(httpServices...),
+	}
 }

--- a/integration/getting_started_single_process_config_test.go
+++ b/integration/getting_started_single_process_config_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -23,15 +22,10 @@ func TestGettingStartedSingleProcessConfigWithChunksStorage(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	// Start Cortex components.
+	// Start Cortex in single binary mode, reading the config from file.
 	require.NoError(t, copyFileToSharedDir(s, "docs/configuration/single-process-config.yaml", cortexConfigFile))
 
-	// Start Cortex in single binary mode, reading the config from file.
-	flags := map[string]string{
-		"-config.file": filepath.Join(e2e.ContainerSharedDir, cortexConfigFile),
-	}
-
-	cortex := e2ecortex.NewSingleBinary("cortex-1", flags, "", 9009, 9095)
+	cortex := e2ecortex.NewSingleBinaryWithConfigFile("cortex-1", cortexConfigFile, nil, "", 9009, 9095)
 	require.NoError(t, s.StartAndWaitReady(cortex))
 
 	c, err := e2ecortex.NewClient(cortex.HTTPEndpoint(), cortex.HTTPEndpoint(), "", "", "user-1")
@@ -75,7 +69,6 @@ func TestGettingStartedSingleProcessConfigWithBlocksStorage(t *testing.T) {
 	// Start Cortex in single binary mode, reading the config from file and overwriting
 	// the backend config to make it work with Minio.
 	flags := map[string]string{
-		"-config.file":                            filepath.Join(e2e.ContainerSharedDir, cortexConfigFile),
 		"-experimental.tsdb.s3.access-key-id":     e2edb.MinioAccessKey,
 		"-experimental.tsdb.s3.secret-access-key": e2edb.MinioSecretKey,
 		"-experimental.tsdb.s3.bucket-name":       bucketName,
@@ -83,7 +76,7 @@ func TestGettingStartedSingleProcessConfigWithBlocksStorage(t *testing.T) {
 		"-experimental.tsdb.s3.insecure":          "true",
 	}
 
-	cortex := e2ecortex.NewSingleBinary("cortex-1", flags, "", 9009, 9095)
+	cortex := e2ecortex.NewSingleBinaryWithConfigFile("cortex-1", cortexConfigFile, flags, "", 9009, 9095)
 	require.NoError(t, s.StartAndWaitReady(cortex))
 
 	c, err := e2ecortex.NewClient(cortex.HTTPEndpoint(), cortex.HTTPEndpoint(), "", "", "user-1")

--- a/integration/getting_started_with_gossiped_ring_test.go
+++ b/integration/getting_started_with_gossiped_ring_test.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -32,13 +31,11 @@ func TestGettingStartedWithGossipedRing(t *testing.T) {
 	}
 
 	// This cortex will fail to join the cluster configured in yaml file. That's fine.
-	cortex1 := e2ecortex.NewSingleBinary("cortex-1", e2e.MergeFlags(flags, map[string]string{
-		"-config.file":              filepath.Join(e2e.ContainerSharedDir, "config1.yaml"),
+	cortex1 := e2ecortex.NewSingleBinaryWithConfigFile("cortex-1", "config1.yaml", e2e.MergeFlags(flags, map[string]string{
 		"-ingester.lifecycler.addr": networkName + "-cortex-1", // Ingester's hostname in docker setup
 	}), "", 9109, 9195)
 
-	cortex2 := e2ecortex.NewSingleBinary("cortex-2", e2e.MergeFlags(flags, map[string]string{
-		"-config.file":              filepath.Join(e2e.ContainerSharedDir, "config2.yaml"),
+	cortex2 := e2ecortex.NewSingleBinaryWithConfigFile("cortex-2", "config2.yaml", e2e.MergeFlags(flags, map[string]string{
 		"-ingester.lifecycler.addr": networkName + "-cortex-2", // Ingester's hostname in docker setup
 		"-memberlist.join":          networkName + "-cortex-1:7946",
 	}), "", 9209, 9295)

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -59,8 +59,6 @@ func TestSingleBinaryWithMemberlist(t *testing.T) {
 
 func newSingleBinary(name string, join string) *e2ecortex.CortexService {
 	flags := map[string]string{
-		"-target":                        "all", // single-binary mode
-		"-log.level":                     "warn",
 		"-ingester.final-sleep":          "0s",
 		"-ingester.join-after":           "0s", // join quickly
 		"-ingester.min-ready-duration":   "0s",
@@ -81,7 +79,6 @@ func newSingleBinary(name string, join string) *e2ecortex.CortexService {
 		name,
 		mergeFlags(ChunksStorageFlags, flags),
 		"",
-		80,
 		8000,
 	)
 

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -20,7 +22,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 )
 
-func TestQuerierWithBlocksStorage(t *testing.T) {
+func TestQuerierWithBlocksStorageWithoutStoreGateway(t *testing.T) {
 	tests := map[string]struct {
 		flags map[string]string
 	}{
@@ -55,6 +57,7 @@ func TestQuerierWithBlocksStorage(t *testing.T) {
 			// Configure the blocks storage to frequently compact TSDB head
 			// and ship blocks to the storage.
 			flags := mergeFlags(testCfg.flags, map[string]string{
+				"-experimental.tsdb.store-gateway-enabled":      "false",
 				"-experimental.tsdb.block-ranges-period":        blockRangePeriod.String(),
 				"-experimental.tsdb.ship-interval":              "1s",
 				"-experimental.tsdb.bucket-store.sync-interval": "1s",
@@ -174,6 +177,381 @@ func TestQuerierWithBlocksStorage(t *testing.T) {
 			assertServiceMetricsPrefixes(t, Distributor, distributor)
 			assertServiceMetricsPrefixes(t, Ingester, ingester)
 			assertServiceMetricsPrefixes(t, Querier, querier)
+		})
+	}
+}
+
+func TestQuerierWithBlocksStorageAndStoreGatewayRunningInMicroservicesMode(t *testing.T) {
+	tests := map[string]struct {
+		blocksShardingEnabled    bool
+		ingesterStreamingEnabled bool
+		indexCacheBackend        string
+	}{
+		"blocks sharding enabled, ingester gRPC streaming disabled, inmemory index cache": {
+			blocksShardingEnabled:    true,
+			ingesterStreamingEnabled: false,
+			indexCacheBackend:        tsdb.IndexCacheBackendInMemory,
+		},
+		"blocks sharding enabled, ingester gRPC streaming enabled, inmemory index cache": {
+			blocksShardingEnabled:    true,
+			ingesterStreamingEnabled: true,
+			indexCacheBackend:        tsdb.IndexCacheBackendInMemory,
+		},
+		"blocks sharding disabled, ingester gRPC streaming disabled, memcached index cache": {
+			blocksShardingEnabled:    false,
+			ingesterStreamingEnabled: false,
+			// Memcached index cache is required to avoid flaky tests when the blocks sharding is disabled
+			// because two different requests may hit two different store-gateways, so if the cache is not
+			// shared there's no guarantee we'll have a cache hit.
+			indexCacheBackend: tsdb.IndexCacheBackendMemcached,
+		},
+		"blocks sharding enabled, ingester gRPC streaming enabled, memcached index cache": {
+			blocksShardingEnabled:    true,
+			ingesterStreamingEnabled: true,
+			indexCacheBackend:        tsdb.IndexCacheBackendMemcached,
+		},
+	}
+
+	for testName, testCfg := range tests {
+		t.Run(testName, func(t *testing.T) {
+			const blockRangePeriod = 5 * time.Second
+
+			s, err := e2e.NewScenario(networkName)
+			require.NoError(t, err)
+			defer s.Close()
+
+			// Configure the blocks storage to frequently compact TSDB head
+			// and ship blocks to the storage.
+			flags := mergeFlags(BlocksStorageFlags, map[string]string{
+				"-experimental.tsdb.store-gateway-enabled":            "true",
+				"-experimental.tsdb.block-ranges-period":              blockRangePeriod.String(),
+				"-experimental.tsdb.ship-interval":                    "1s",
+				"-experimental.tsdb.bucket-store.sync-interval":       "1s",
+				"-experimental.tsdb.retention-period":                 ((blockRangePeriod * 2) - 1).String(),
+				"-experimental.tsdb.bucket-store.index-cache.backend": testCfg.indexCacheBackend,
+				"-experimental.store-gateway.sharding-enabled":        strconv.FormatBool(testCfg.blocksShardingEnabled),
+				"-querier.ingester-streaming":                         strconv.FormatBool(testCfg.ingesterStreamingEnabled),
+			})
+
+			// Start dependencies.
+			consul := e2edb.NewConsul()
+			minio := e2edb.NewMinio(9000, flags["-experimental.tsdb.s3.bucket-name"])
+			memcached := e2ecache.NewMemcached()
+			require.NoError(t, s.StartAndWaitReady(consul, minio, memcached))
+
+			// Add the memcached address to the flags.
+			flags["-experimental.tsdb.bucket-store.index-cache.memcached.addresses"] = "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort)
+
+			// Start Cortex components.
+			distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
+			ingester := e2ecortex.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, "")
+			storeGateway1 := e2ecortex.NewStoreGateway("store-gateway-1", consul.NetworkHTTPEndpoint(), flags, "")
+			storeGateway2 := e2ecortex.NewStoreGateway("store-gateway-2", consul.NetworkHTTPEndpoint(), flags, "")
+			storeGateways := e2ecortex.NewCompositeCortexService(storeGateway1, storeGateway2)
+			require.NoError(t, s.StartAndWaitReady(distributor, ingester, storeGateway1, storeGateway2))
+
+			// Start the querier with configuring store-gateway addresses if sharding is disabled.
+			if !testCfg.blocksShardingEnabled {
+				flags = mergeFlags(flags, map[string]string{
+					"-experimental.querier.store-gateway-addresses": strings.Join([]string{storeGateway1.NetworkGRPCEndpoint(), storeGateway2.NetworkGRPCEndpoint()}, ","),
+				})
+			}
+			querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, "")
+			require.NoError(t, s.StartAndWaitReady(querier))
+
+			// Wait until both the distributor and querier have updated the ring. The querier will also watch
+			// the store-gateway ring if blocks sharding is enabled.
+			require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+			if testCfg.blocksShardingEnabled {
+				require.NoError(t, querier.WaitSumMetrics(e2e.Equals(float64(512+(512*storeGateways.NumInstances()))), "cortex_ring_tokens_total"))
+			} else {
+				require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+			}
+
+			c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", "user-1")
+			require.NoError(t, err)
+
+			// Push some series to Cortex.
+			series1Timestamp := time.Now()
+			series2Timestamp := series1Timestamp.Add(blockRangePeriod * 2)
+			series1, expectedVector1 := generateSeries("series_1", series1Timestamp)
+			series2, expectedVector2 := generateSeries("series_2", series2Timestamp)
+
+			res, err := c.Push(series1)
+			require.NoError(t, err)
+			require.Equal(t, 200, res.StatusCode)
+
+			res, err = c.Push(series2)
+			require.NoError(t, err)
+			require.Equal(t, 200, res.StatusCode)
+
+			// Wait until the TSDB head is compacted and shipped to the storage.
+			// The shipped block contains the 1st series, while the 2ns series in in the head.
+			require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(1), "cortex_ingester_shipper_uploads_total"))
+			require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(1), "cortex_ingester_memory_series"))
+			require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(2), "cortex_ingester_memory_series_created_total"))
+			require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(1), "cortex_ingester_memory_series_removed_total"))
+
+			// Push another series to further compact another block and delete the first block
+			// due to expired retention.
+			series3Timestamp := series2Timestamp.Add(blockRangePeriod * 2)
+			series3, expectedVector3 := generateSeries("series_3", series3Timestamp)
+
+			res, err = c.Push(series3)
+			require.NoError(t, err)
+			require.Equal(t, 200, res.StatusCode)
+
+			require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(2), "cortex_ingester_shipper_uploads_total"))
+			require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(1), "cortex_ingester_memory_series"))
+			require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(3), "cortex_ingester_memory_series_created_total"))
+			require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(2), "cortex_ingester_memory_series_removed_total"))
+
+			// Wait until the querier has discovered the uploaded blocks.
+			require.NoError(t, querier.WaitSumMetrics(e2e.Equals(2), "cortex_querier_blocks_meta_synced"))
+
+			// Wait until the store-gateway has synched the new uploaded blocks. When sharding is enabled
+			// we don't known which store-gateway instance will synch the blocks, so we need to wait on
+			// metrics extracted from all instances.
+			if testCfg.blocksShardingEnabled {
+				require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(2), "cortex_storegateway_bucket_store_blocks_loaded"))
+			} else {
+				require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(float64(2*storeGateways.NumInstances())), "cortex_storegateway_bucket_store_blocks_loaded"))
+			}
+
+			// Query back the series (1 only in the storage, 1 only in the ingesters, 1 on both).
+			result, err := c.Query("series_1", series1Timestamp)
+			require.NoError(t, err)
+			require.Equal(t, model.ValVector, result.Type())
+			assert.Equal(t, expectedVector1, result.(model.Vector))
+
+			result, err = c.Query("series_2", series2Timestamp)
+			require.NoError(t, err)
+			require.Equal(t, model.ValVector, result.Type())
+			assert.Equal(t, expectedVector2, result.(model.Vector))
+
+			result, err = c.Query("series_3", series3Timestamp)
+			require.NoError(t, err)
+			require.Equal(t, model.ValVector, result.Type())
+			assert.Equal(t, expectedVector3, result.(model.Vector))
+
+			// Check the in-memory index cache metrics (in the store-gateway).
+			require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(7), "cortex_storegateway_blocks_index_cache_requests_total"))
+			require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(0), "cortex_storegateway_blocks_index_cache_hits_total")) // no cache hit cause the cache was empty
+
+			if testCfg.indexCacheBackend == tsdb.IndexCacheBackendInMemory {
+				require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(2*2), "cortex_storegateway_blocks_index_cache_items"))             // 2 series both for postings and series cache
+				require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(2*2), "cortex_storegateway_blocks_index_cache_items_added_total")) // 2 series both for postings and series cache
+			} else if testCfg.indexCacheBackend == tsdb.IndexCacheBackendMemcached {
+				require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(11), "cortex_storegateway_blocks_index_cache_memcached_operations_total")) // 7 gets + 4 sets
+			}
+
+			// Query back again the 1st series from storage. This time it should use the index cache.
+			result, err = c.Query("series_1", series1Timestamp)
+			require.NoError(t, err)
+			require.Equal(t, model.ValVector, result.Type())
+			assert.Equal(t, expectedVector1, result.(model.Vector))
+
+			require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(7+2), "cortex_storegateway_blocks_index_cache_requests_total"))
+			require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(2), "cortex_storegateway_blocks_index_cache_hits_total")) // this time has used the index cache
+
+			if testCfg.indexCacheBackend == tsdb.IndexCacheBackendInMemory {
+				require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(2*2), "cortex_storegateway_blocks_index_cache_items"))             // as before
+				require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(2*2), "cortex_storegateway_blocks_index_cache_items_added_total")) // as before
+			} else if testCfg.indexCacheBackend == tsdb.IndexCacheBackendMemcached {
+				require.NoError(t, storeGateways.WaitSumMetrics(e2e.Equals(11+2), "cortex_storegateway_blocks_index_cache_memcached_operations_total")) // as before + 2 gets
+			}
+
+			// Ensure no service-specific metrics prefix is used by the wrong service.
+			assertServiceMetricsPrefixes(t, Distributor, distributor)
+			assertServiceMetricsPrefixes(t, Ingester, ingester)
+			assertServiceMetricsPrefixes(t, Querier, querier)
+			assertServiceMetricsPrefixes(t, StoreGateway, storeGateway1)
+			assertServiceMetricsPrefixes(t, StoreGateway, storeGateway2)
+		})
+	}
+}
+
+func TestQuerierWithBlocksStorageAndStoreGatewayRunningInSingleBinaryMode(t *testing.T) {
+	tests := map[string]struct {
+		blocksShardingEnabled    bool
+		ingesterStreamingEnabled bool
+		indexCacheBackend        string
+	}{
+		"blocks sharding enabled, ingester gRPC streaming disabled, inmemory index cache": {
+			blocksShardingEnabled:    true,
+			ingesterStreamingEnabled: false,
+			indexCacheBackend:        tsdb.IndexCacheBackendInMemory,
+		},
+		"blocks sharding enabled, ingester gRPC streaming enabled, inmemory index cache": {
+			blocksShardingEnabled:    true,
+			ingesterStreamingEnabled: true,
+			indexCacheBackend:        tsdb.IndexCacheBackendInMemory,
+		},
+		"blocks sharding disabled, ingester gRPC streaming disabled, memcached index cache": {
+			blocksShardingEnabled:    false,
+			ingesterStreamingEnabled: false,
+			// Memcached index cache is required to avoid flaky tests when the blocks sharding is disabled
+			// because two different requests may hit two different store-gateways, so if the cache is not
+			// shared there's no guarantee we'll have a cache hit.
+			indexCacheBackend: tsdb.IndexCacheBackendMemcached,
+		},
+		"blocks sharding enabled, ingester gRPC streaming enabled, memcached index cache": {
+			blocksShardingEnabled:    true,
+			ingesterStreamingEnabled: true,
+			indexCacheBackend:        tsdb.IndexCacheBackendMemcached,
+		},
+	}
+
+	for testName, testCfg := range tests {
+		t.Run(testName, func(t *testing.T) {
+			const blockRangePeriod = 5 * time.Second
+
+			s, err := e2e.NewScenario(networkName)
+			require.NoError(t, err)
+			defer s.Close()
+
+			// Start dependencies.
+			consul := e2edb.NewConsul()
+			minio := e2edb.NewMinio(9000, bucketName)
+			memcached := e2ecache.NewMemcached()
+			require.NoError(t, s.StartAndWaitReady(consul, minio, memcached))
+
+			// Setting the replication factor equal to the number of Cortex replicas
+			// make sure each replica creates the same blocks, so the total number of
+			// blocks is stable and easy to assert on.
+			const seriesReplicationFactor = 2
+
+			// Configure the blocks storage to frequently compact TSDB head
+			// and ship blocks to the storage.
+			flags := mergeFlags(BlocksStorageFlags, map[string]string{
+				"-experimental.tsdb.store-gateway-enabled":                        "true",
+				"-experimental.tsdb.block-ranges-period":                          blockRangePeriod.String(),
+				"-experimental.tsdb.ship-interval":                                "1s",
+				"-experimental.tsdb.bucket-store.sync-interval":                   "1s",
+				"-experimental.tsdb.retention-period":                             ((blockRangePeriod * 2) - 1).String(),
+				"-experimental.tsdb.bucket-store.index-cache.backend":             testCfg.indexCacheBackend,
+				"-experimental.tsdb.bucket-store.index-cache.memcached.addresses": "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
+				"-querier.ingester-streaming":                                     strconv.FormatBool(testCfg.ingesterStreamingEnabled),
+				// Ingester.
+				"-ring.store":      "consul",
+				"-consul.hostname": consul.NetworkHTTPEndpoint(),
+				// Distributor.
+				"-distributor.replication-factor": strconv.FormatInt(seriesReplicationFactor, 10),
+				// Store-gateway.
+				"-experimental.store-gateway.sharding-enabled":              strconv.FormatBool(testCfg.blocksShardingEnabled),
+				"-experimental.store-gateway.sharding-ring.store":           "consul",
+				"-experimental.store-gateway.sharding-ring.consul.hostname": consul.NetworkHTTPEndpoint(),
+				"-experimental.store-gateway.replication-factor":            "1",
+			})
+
+			// Start Cortex replicas.
+			cortex1 := e2ecortex.NewSingleBinary("cortex-1", flags, "")
+			cortex2 := e2ecortex.NewSingleBinary("cortex-2", flags, "")
+			cluster := e2ecortex.NewCompositeCortexService(cortex1, cortex2)
+			require.NoError(t, s.StartAndWaitReady(cortex1, cortex2))
+
+			// Wait until Cortex replicas have updated the ring state.
+			for _, replica := range cluster.Instances() {
+				numTokensPerInstance := 512 // Ingesters ring.
+				if testCfg.blocksShardingEnabled {
+					numTokensPerInstance += 512 * 2 // Store-gateway ring (read both by the querier and store-gateway).
+				}
+
+				require.NoError(t, replica.WaitSumMetrics(e2e.Equals(float64(numTokensPerInstance*cluster.NumInstances())), "cortex_ring_tokens_total"))
+			}
+
+			c, err := e2ecortex.NewClient(cortex1.HTTPEndpoint(), cortex2.HTTPEndpoint(), "", "", "user-1")
+			require.NoError(t, err)
+
+			// Push some series to Cortex.
+			series1Timestamp := time.Now()
+			series2Timestamp := series1Timestamp.Add(blockRangePeriod * 2)
+			series1, expectedVector1 := generateSeries("series_1", series1Timestamp)
+			series2, expectedVector2 := generateSeries("series_2", series2Timestamp)
+
+			res, err := c.Push(series1)
+			require.NoError(t, err)
+			require.Equal(t, 200, res.StatusCode)
+
+			res, err = c.Push(series2)
+			require.NoError(t, err)
+			require.Equal(t, 200, res.StatusCode)
+
+			// Wait until the TSDB head is compacted and shipped to the storage.
+			// The shipped block contains the 1st series, while the 2ns series in in the head.
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(1*cluster.NumInstances())), "cortex_ingester_shipper_uploads_total"))
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(1*cluster.NumInstances())), "cortex_ingester_memory_series"))
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(2*cluster.NumInstances())), "cortex_ingester_memory_series_created_total"))
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(1*cluster.NumInstances())), "cortex_ingester_memory_series_removed_total"))
+
+			// Push another series to further compact another block and delete the first block
+			// due to expired retention.
+			series3Timestamp := series2Timestamp.Add(blockRangePeriod * 2)
+			series3, expectedVector3 := generateSeries("series_3", series3Timestamp)
+
+			res, err = c.Push(series3)
+			require.NoError(t, err)
+			require.Equal(t, 200, res.StatusCode)
+
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(2*cluster.NumInstances())), "cortex_ingester_shipper_uploads_total"))
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(1*cluster.NumInstances())), "cortex_ingester_memory_series"))
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(3*cluster.NumInstances())), "cortex_ingester_memory_series_created_total"))
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(2*cluster.NumInstances())), "cortex_ingester_memory_series_removed_total"))
+
+			// Wait until the querier has discovered the uploaded blocks (discovered both by the querier and store-gateway).
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(2*cluster.NumInstances()*2)), "cortex_querier_blocks_meta_synced"))
+
+			// Wait until the store-gateway has synched the new uploaded blocks.
+			const shippedBlocks = 2
+
+			if testCfg.blocksShardingEnabled {
+				require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(shippedBlocks*seriesReplicationFactor)), "cortex_storegateway_bucket_store_blocks_loaded"))
+			} else {
+				require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(shippedBlocks*seriesReplicationFactor*cluster.NumInstances())), "cortex_storegateway_bucket_store_blocks_loaded"))
+			}
+
+			// Query back the series (1 only in the storage, 1 only in the ingesters, 1 on both).
+			result, err := c.Query("series_1", series1Timestamp)
+			require.NoError(t, err)
+			require.Equal(t, model.ValVector, result.Type())
+			assert.Equal(t, expectedVector1, result.(model.Vector))
+
+			result, err = c.Query("series_2", series2Timestamp)
+			require.NoError(t, err)
+			require.Equal(t, model.ValVector, result.Type())
+			assert.Equal(t, expectedVector2, result.(model.Vector))
+
+			result, err = c.Query("series_3", series3Timestamp)
+			require.NoError(t, err)
+			require.Equal(t, model.ValVector, result.Type())
+			assert.Equal(t, expectedVector3, result.(model.Vector))
+
+			// Check the in-memory index cache metrics (in the store-gateway).
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(7*seriesReplicationFactor)), "cortex_storegateway_blocks_index_cache_requests_total"))
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(0), "cortex_storegateway_blocks_index_cache_hits_total")) // no cache hit cause the cache was empty
+
+			if testCfg.indexCacheBackend == tsdb.IndexCacheBackendInMemory {
+				require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(2*2*seriesReplicationFactor)), "cortex_storegateway_blocks_index_cache_items"))             // 2 series both for postings and series cache
+				require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(2*2*seriesReplicationFactor)), "cortex_storegateway_blocks_index_cache_items_added_total")) // 2 series both for postings and series cache
+			} else if testCfg.indexCacheBackend == tsdb.IndexCacheBackendMemcached {
+				require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(11*seriesReplicationFactor)), "cortex_storegateway_blocks_index_cache_memcached_operations_total")) // 7 gets + 4 sets
+			}
+
+			// Query back again the 1st series from storage. This time it should use the index cache.
+			result, err = c.Query("series_1", series1Timestamp)
+			require.NoError(t, err)
+			require.Equal(t, model.ValVector, result.Type())
+			assert.Equal(t, expectedVector1, result.(model.Vector))
+
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64((7+2)*seriesReplicationFactor)), "cortex_storegateway_blocks_index_cache_requests_total"))
+			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(2*seriesReplicationFactor)), "cortex_storegateway_blocks_index_cache_hits_total")) // this time has used the index cache
+
+			if testCfg.indexCacheBackend == tsdb.IndexCacheBackendInMemory {
+				require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(2*2*seriesReplicationFactor)), "cortex_storegateway_blocks_index_cache_items"))             // as before
+				require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(2*2*seriesReplicationFactor)), "cortex_storegateway_blocks_index_cache_items_added_total")) // as before
+			} else if testCfg.indexCacheBackend == tsdb.IndexCacheBackendMemcached {
+				require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64((11+2)*seriesReplicationFactor)), "cortex_storegateway_blocks_index_cache_memcached_operations_total")) // as before + 2 gets
+			}
 		})
 	}
 }

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -92,7 +92,7 @@ type Config struct {
 	Encoding         encoding.Config          `yaml:"-"` // No yaml for this, it only works with flags.
 	TSDB             tsdb.Config              `yaml:"tsdb"`
 	Compactor        compactor.Config         `yaml:"compactor"`
-	StoreGateway     storegateway.Config      `yaml:"store_gateway" doc:"hidden"` // this component is not yet finished.
+	StoreGateway     storegateway.Config      `yaml:"store_gateway"`
 	DataPurgerConfig purger.Config            `yaml:"purger"`
 
 	Ruler         ruler.Config                               `yaml:"ruler"`

--- a/pkg/querier/blocks_store_balanced_set.go
+++ b/pkg/querier/blocks_store_balanced_set.go
@@ -1,0 +1,71 @@
+package querier
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/discovery/dns"
+	"github.com/thanos-io/thanos/pkg/extprom"
+
+	"github.com/cortexproject/cortex/pkg/ring/client"
+	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+// BlocksStoreSet implementation used when the blocks are not sharded in the store-gateway
+// and so requests are balanced across the set of store-gateway instances.
+type blocksStoreBalancedSet struct {
+	services.Service
+
+	serviceAddresses []string
+	clientsPool      *client.Pool
+	dnsProvider      *dns.Provider
+}
+
+func newBlocksStoreBalancedSet(serviceAddresses []string, logger log.Logger, reg prometheus.Registerer) *blocksStoreBalancedSet {
+	const dnsResolveInterval = 10 * time.Second
+
+	dnsProviderReg := extprom.WrapRegistererWithPrefix("cortex_storegateway_client_", reg)
+
+	s := &blocksStoreBalancedSet{
+		serviceAddresses: serviceAddresses,
+		dnsProvider:      dns.NewProvider(logger, dnsProviderReg, dns.GolangResolverType),
+		clientsPool:      newStoreGatewayClientPool(nil, logger, reg),
+	}
+
+	s.Service = services.NewTimerService(dnsResolveInterval, s.starting, s.resolve, nil)
+	return s
+}
+
+func (s *blocksStoreBalancedSet) starting(ctx context.Context) error {
+	// Initial DNS resolution.
+	return s.resolve(ctx)
+}
+
+func (s *blocksStoreBalancedSet) resolve(ctx context.Context) error {
+	s.dnsProvider.Resolve(ctx, s.serviceAddresses)
+	return nil
+}
+
+func (s *blocksStoreBalancedSet) GetClientsFor(_ []*metadata.Meta) ([]storegatewaypb.StoreGatewayClient, error) {
+	addresses := s.dnsProvider.Addresses()
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("no address resolved for the store-gateway service addresses %s", strings.Join(s.serviceAddresses, ","))
+	}
+
+	// Pick a random address and return its client from the pool.
+	addr := addresses[rand.Intn(len(addresses))]
+	c, err := s.clientsPool.GetClientFor(addr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get store-gateway client for %s", addr)
+	}
+
+	return []storegatewaypb.StoreGatewayClient{c.(storegatewaypb.StoreGatewayClient)}, nil
+}

--- a/pkg/querier/blocks_store_balanced_set_test.go
+++ b/pkg/querier/blocks_store_balanced_set_test.go
@@ -1,0 +1,63 @@
+package querier
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+func TestBlocksStoreBalancedSet_GetClientsFor(t *testing.T) {
+	const numGets = 1000
+	serviceAddrs := []string{"127.0.0.1", "127.0.0.2"}
+
+	ctx := context.Background()
+	reg := prometheus.NewPedanticRegistry()
+	s := newBlocksStoreBalancedSet(serviceAddrs, log.NewNopLogger(), reg)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
+	defer services.StopAndAwaitTerminated(ctx, s) //nolint:errcheck
+
+	// Call the GetClientsFor() many times to measure the distribution
+	// of returned clients (we expect an even distribution).
+	clientsCount := map[string]int{}
+
+	for i := 0; i < numGets; i++ {
+		clients, err := s.GetClientsFor(nil)
+		require.NoError(t, err)
+
+		addrs := getStoreClientClientAddrs(clients)
+		require.Len(t, addrs, 1)
+
+		clientsCount[addrs[0]] = clientsCount[addrs[0]] + 1
+	}
+
+	assert.Len(t, clientsCount, len(serviceAddrs))
+	for addr, count := range clientsCount {
+		// Ensure that the number of times each client is returned is above
+		// the 80% of the perfect even distribution.
+		assert.Greaterf(t, count, int((float64(numGets)/float64(len(serviceAddrs)))*0.8), "service address: %s", addr)
+	}
+
+	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_storegateway_client_dns_failures_total The number of DNS lookup failures
+		# TYPE cortex_storegateway_client_dns_failures_total counter
+		cortex_storegateway_client_dns_failures_total 0
+		# HELP cortex_storegateway_client_dns_lookups_total The number of DNS lookups resolutions attempts
+		# TYPE cortex_storegateway_client_dns_lookups_total counter
+		cortex_storegateway_client_dns_lookups_total 0
+		# HELP cortex_storegateway_client_dns_provider_results The number of resolved endpoints for each configured address
+		# TYPE cortex_storegateway_client_dns_provider_results gauge
+		cortex_storegateway_client_dns_provider_results{addr="127.0.0.1"} 1
+		cortex_storegateway_client_dns_provider_results{addr="127.0.0.2"} 1
+		# HELP cortex_storegateway_clients The current number of store-gateway clients in the pool.
+		# TYPE cortex_storegateway_clients gauge
+		cortex_storegateway_clients{client="querier"} 2
+	`)))
+}

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -196,10 +196,8 @@ func (q *blocksStoreQuerier) SelectSorted(sp *storage.SelectParams, matchers ...
 	set, warnings, err := q.selectSorted(sp, matchers...)
 
 	// We need to wrap the error in order to have Prometheus returning a 5xx error.
-	if err != nil {
-		if unwrappedErr := errors.Unwrap(err); unwrappedErr != context.Canceled && unwrappedErr != context.DeadlineExceeded {
-			err = promql.ErrStorage{Err: err}
-		}
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		err = promql.ErrStorage{Err: err}
 	}
 
 	return set, warnings, err

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -1,0 +1,312 @@
+package querier
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"github.com/weaveworks/common/user"
+	"golang.org/x/sync/errgroup"
+	grpc_metadata "google.golang.org/grpc/metadata"
+
+	"github.com/cortexproject/cortex/pkg/querier/series"
+	"github.com/cortexproject/cortex/pkg/ring"
+	"github.com/cortexproject/cortex/pkg/ring/kv"
+	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/storegateway"
+	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
+)
+
+var (
+	errNoStoreGatewayAddress = errors.New("no store-gateway address configured")
+)
+
+// BlocksStoreSet is the interface used to get the clients to query series on a set of blocks.
+type BlocksStoreSet interface {
+	services.Service
+
+	// GetClientsFor returns the store gateway clients that should be used to
+	// query the set of blocks in input.
+	GetClientsFor(metas []*metadata.Meta) ([]storegatewaypb.StoreGatewayClient, error)
+}
+
+// BlocksStoreQueryable is a queryable which queries blocks storage via
+// the store-gateway.
+type BlocksStoreQueryable struct {
+	services.Service
+
+	stores  BlocksStoreSet
+	scanner *BlocksScanner
+
+	// Subservices manager.
+	subservices        *services.Manager
+	subservicesWatcher *services.FailureWatcher
+
+	// Metrics.
+	storesHit prometheus.Histogram
+}
+
+func NewBlocksStoreQueryable(stores BlocksStoreSet, scanner *BlocksScanner, reg prometheus.Registerer) (*BlocksStoreQueryable, error) {
+	util.WarnExperimentalUse("Blocks storage engine")
+
+	manager, err := services.NewManager(stores, scanner)
+	if err != nil {
+		return nil, errors.Wrap(err, "register blocks storage queryable subservices")
+	}
+
+	q := &BlocksStoreQueryable{
+		stores:             stores,
+		scanner:            scanner,
+		subservices:        manager,
+		subservicesWatcher: services.NewFailureWatcher(),
+		storesHit: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Namespace: "cortex",
+			Name:      "querier_storegateway_instances_hit_per_query",
+			Help:      "Number of store-gateway instances hit for a single query.",
+			Buckets:   []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		}),
+	}
+
+	q.Service = services.NewBasicService(q.starting, q.running, q.stopping)
+
+	return q, nil
+}
+
+func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegateway.Config, storageCfg cortex_tsdb.Config, logger log.Logger, reg prometheus.Registerer) (*BlocksStoreQueryable, error) {
+	var stores BlocksStoreSet
+
+	bucketClient, err := cortex_tsdb.NewBucketClient(context.Background(), storageCfg, "querier", logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create bucket client")
+	}
+
+	scanner := NewBlocksScanner(BlocksScannerConfig{
+		ScanInterval:             storageCfg.BucketStore.SyncInterval,
+		TenantsConcurrency:       storageCfg.BucketStore.TenantSyncConcurrency,
+		MetasConcurrency:         storageCfg.BucketStore.BlockSyncConcurrency,
+		CacheDir:                 storageCfg.BucketStore.SyncDir,
+		ConsistencyDelay:         storageCfg.BucketStore.ConsistencyDelay,
+		IgnoreDeletionMarksDelay: storageCfg.BucketStore.IgnoreDeletionMarksDelay,
+	}, bucketClient, logger, reg)
+
+	if gatewayCfg.ShardingEnabled {
+		storesRingCfg := gatewayCfg.ShardingRing.ToRingConfig()
+		storesRingBackend, err := kv.NewClient(storesRingCfg.KVStore, ring.GetCodec())
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create store-gateway ring backend")
+		}
+
+		storesRing, err := ring.NewWithStoreClientAndStrategy(storesRingCfg, storegateway.RingNameForClient, storegateway.RingKey, storesRingBackend, &storegateway.BlocksReplicationStrategy{})
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create store-gateway ring client")
+		}
+
+		if reg != nil {
+			reg.MustRegister(storesRing)
+		}
+
+		stores, err = newBlocksStoreReplicationSet(storesRing, logger, reg)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create store set")
+		}
+	} else {
+		if len(querierCfg.GetStoreGatewayAddresses()) == 0 {
+			return nil, errNoStoreGatewayAddress
+		}
+
+		stores = newBlocksStoreBalancedSet(querierCfg.GetStoreGatewayAddresses(), logger, reg)
+	}
+
+	return NewBlocksStoreQueryable(stores, scanner, reg)
+}
+
+func (q *BlocksStoreQueryable) starting(ctx context.Context) error {
+	q.subservicesWatcher.WatchManager(q.subservices)
+
+	if err := services.StartManagerAndAwaitHealthy(ctx, q.subservices); err != nil {
+		return errors.Wrap(err, "unable to start blocks storage queryable subservices")
+	}
+
+	return nil
+}
+
+func (q *BlocksStoreQueryable) running(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-q.subservicesWatcher.Chan():
+			return errors.Wrap(err, "block storage queryable subservice failed")
+		}
+	}
+}
+
+func (q *BlocksStoreQueryable) stopping(_ error) error {
+	return services.StopManagerAndAwaitStopped(context.Background(), q.subservices)
+}
+
+// Querier returns a new Querier on the storage.
+func (q *BlocksStoreQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+	if s := q.State(); s != services.Running {
+		return nil, promql.ErrStorage{Err: errors.Errorf("BlocksStoreQueryable is not running: %v", s)}
+	}
+
+	userID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, promql.ErrStorage{Err: err}
+	}
+
+	return &blocksStoreQuerier{
+		ctx:       ctx,
+		minT:      mint,
+		maxT:      maxt,
+		userID:    userID,
+		scanner:   q.scanner,
+		stores:    q.stores,
+		storesHit: q.storesHit,
+	}, nil
+}
+
+type blocksStoreQuerier struct {
+	ctx        context.Context
+	minT, maxT int64
+	userID     string
+	scanner    *BlocksScanner
+	stores     BlocksStoreSet
+	storesHit  prometheus.Histogram
+}
+
+func (q *blocksStoreQuerier) Select(sp *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	return q.SelectSorted(sp, matchers...)
+}
+
+func (q *blocksStoreQuerier) SelectSorted(sp *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	set, warnings, err := q.selectSorted(sp, matchers...)
+
+	// We need to wrap the error in order to have Prometheus returning a 5xx error.
+	if err != nil && err != context.Canceled && err != context.DeadlineExceeded {
+		err = promql.ErrStorage{Err: err}
+	}
+
+	return set, warnings, err
+}
+
+func (q *blocksStoreQuerier) LabelValues(name string) ([]string, storage.Warnings, error) {
+	// Cortex doesn't use this. It will ask ingesters for metadata.
+	return nil, nil, errors.New("not implemented")
+}
+
+func (q *blocksStoreQuerier) LabelNames() ([]string, storage.Warnings, error) {
+	// Cortex doesn't use this. It will ask ingesters for metadata.
+	return nil, nil, errors.New("not implemented")
+}
+
+func (q *blocksStoreQuerier) Close() error {
+	return nil
+}
+
+func (q *blocksStoreQuerier) selectSorted(sp *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	log, _ := spanlogger.New(q.ctx, "blocksStoreQuerier.selectSorted")
+	defer log.Span.Finish()
+
+	minT, maxT := q.minT, q.maxT
+	if sp != nil {
+		minT, maxT = sp.Start, sp.End
+	}
+
+	// Find the list of blocks we need to query given the time range.
+	metas, err := q.scanner.GetBlocks(q.userID, minT, maxT)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(metas) == 0 {
+		q.storesHit.Observe(0)
+		return series.NewEmptySeriesSet(), nil, nil
+	}
+
+	// Find the set of store-gateway instances having the blocks.
+	clients, err := q.stores.GetClientsFor(metas)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req := &storepb.SeriesRequest{
+		MinTime:                 minT,
+		MaxTime:                 maxT,
+		Matchers:                convertMatchersToLabelMatcher(matchers),
+		PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
+	}
+
+	var (
+		reqCtx     = grpc_metadata.AppendToOutgoingContext(q.ctx, cortex_tsdb.TenantIDExternalLabel, q.userID)
+		g, gCtx    = errgroup.WithContext(reqCtx)
+		mtx        = sync.Mutex{}
+		seriesSets = []storage.SeriesSet(nil)
+		warnings   = storage.Warnings(nil)
+	)
+
+	// Concurrently fetch series from all clients.
+	for _, c := range clients {
+		// Change variable scope since it will be used in a goroutine.
+		c := c
+
+		g.Go(func() error {
+			stream, err := c.Series(gCtx, req)
+			if err != nil {
+				return errors.Wrapf(err, "failed to fetch series from %s", c)
+			}
+
+			mySeries := []*storepb.Series(nil)
+			myWarnings := storage.Warnings(nil)
+
+			for {
+				resp, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return err
+				}
+
+				// Response may either contain series or warning. If it's warning, we get nil here.
+				if s := resp.GetSeries(); s != nil {
+					mySeries = append(mySeries, s)
+				}
+
+				// Collect and return warnings too.
+				if w := resp.GetWarning(); w != "" {
+					myWarnings = append(myWarnings, errors.New(w))
+				}
+			}
+
+			// Store the result.
+			mtx.Lock()
+			seriesSets = append(seriesSets, &blockQuerierSeriesSet{series: mySeries})
+			warnings = append(warnings, myWarnings...)
+			mtx.Unlock()
+
+			return nil
+		})
+	}
+
+	// Wait until all client requests complete.
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
+	}
+
+	q.storesHit.Observe(float64(len(clients)))
+	return storage.NewMergeSeriesSet(seriesSets, nil), warnings, nil
+}

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -1,0 +1,341 @@
+package querier
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"google.golang.org/grpc"
+
+	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
+	const (
+		metricName = "test_metric"
+		minT       = 10
+		maxT       = 20
+	)
+
+	var (
+		block1          = ulid.MustNew(1, nil)
+		block2          = ulid.MustNew(2, nil)
+		metricNameLabel = labels.Label{Name: labels.MetricName, Value: metricName}
+		series1Label    = labels.Label{Name: "series", Value: "1"}
+		series2Label    = labels.Label{Name: "series", Value: "2"}
+	)
+
+	type valueResult struct {
+		t int64
+		v float64
+	}
+
+	type seriesResult struct {
+		lbls   labels.Labels
+		values []valueResult
+	}
+
+	tests := map[string]struct {
+		finderResult   []*metadata.Meta
+		finderErr      error
+		storeSetResult []storegatewaypb.StoreGatewayClient
+		storeSetErr    error
+		expectedSeries []seriesResult
+		expectedErr    string
+	}{
+		"no block in the storage matching the query time range": {
+			finderResult: nil,
+			expectedErr:  "",
+		},
+		"error while finding blocks matching the query time range": {
+			finderErr:   errors.New("unable to find blocks"),
+			expectedErr: "unable to find blocks",
+		},
+		"error while getting clients to query the store-gateway": {
+			finderResult: []*metadata.Meta{
+				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
+				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			},
+			storeSetErr: errors.New("no client found"),
+			expectedErr: "no client found",
+		},
+		"a single store-gateway instance holds the required blocks (single returned series)": {
+			finderResult: []*metadata.Meta{
+				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
+				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			},
+			storeSetResult: []storegatewaypb.StoreGatewayClient{
+				&storeGatewayClientMock{mockedResponses: []*storepb.SeriesResponse{
+					mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
+					mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+				}},
+			},
+			expectedSeries: []seriesResult{
+				{
+					lbls: labels.New(metricNameLabel),
+					values: []valueResult{
+						{t: minT, v: 1},
+						{t: minT + 1, v: 2},
+					},
+				},
+			},
+		},
+		"a single store-gateway instance holds the required blocks (multiple returned series)": {
+			finderResult: []*metadata.Meta{
+				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
+				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			},
+			storeSetResult: []storegatewaypb.StoreGatewayClient{
+				&storeGatewayClientMock{mockedResponses: []*storepb.SeriesResponse{
+					mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
+					mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+					mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 3),
+				}},
+			},
+			expectedSeries: []seriesResult{
+				{
+					lbls: labels.New(metricNameLabel, series1Label),
+					values: []valueResult{
+						{t: minT, v: 1},
+						{t: minT + 1, v: 2},
+					},
+				}, {
+					lbls: labels.New(metricNameLabel, series2Label),
+					values: []valueResult{
+						{t: minT, v: 3},
+					},
+				},
+			},
+		},
+		"multiple store-gateway instances holds the required blocks without overlapping blocks (single returned series)": {
+			finderResult: []*metadata.Meta{
+				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
+				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			},
+			storeSetResult: []storegatewaypb.StoreGatewayClient{
+				&storeGatewayClientMock{mockedResponses: []*storepb.SeriesResponse{
+					mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
+				}},
+				&storeGatewayClientMock{mockedResponses: []*storepb.SeriesResponse{
+					mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+				}},
+			},
+			expectedSeries: []seriesResult{
+				{
+					lbls: labels.New(metricNameLabel),
+					values: []valueResult{
+						{t: minT, v: 1},
+						{t: minT + 1, v: 2},
+					},
+				},
+			},
+		},
+		"multiple store-gateway instances holds the required blocks with overlapping blocks (single returned series)": {
+			finderResult: []*metadata.Meta{
+				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
+				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			},
+			storeSetResult: []storegatewaypb.StoreGatewayClient{
+				&storeGatewayClientMock{mockedResponses: []*storepb.SeriesResponse{
+					mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+				}},
+				&storeGatewayClientMock{mockedResponses: []*storepb.SeriesResponse{
+					mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
+					mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+				}},
+			},
+			expectedSeries: []seriesResult{
+				{
+					lbls: labels.New(metricNameLabel),
+					values: []valueResult{
+						{t: minT, v: 1},
+						{t: minT + 1, v: 2},
+					},
+				},
+			},
+		},
+		"multiple store-gateway instances holds the required blocks with overlapping blocks (multiple returned series)": {
+			finderResult: []*metadata.Meta{
+				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
+				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			},
+			storeSetResult: []storegatewaypb.StoreGatewayClient{
+				&storeGatewayClientMock{mockedResponses: []*storepb.SeriesResponse{
+					mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+					mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 1),
+				}},
+				&storeGatewayClientMock{mockedResponses: []*storepb.SeriesResponse{
+					mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
+					mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+				}},
+				&storeGatewayClientMock{mockedResponses: []*storepb.SeriesResponse{
+					mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 1),
+					mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT+1, 3),
+				}},
+			},
+			expectedSeries: []seriesResult{
+				{
+					lbls: labels.New(metricNameLabel, series1Label),
+					values: []valueResult{
+						{t: minT, v: 1},
+						{t: minT + 1, v: 2},
+					},
+				}, {
+					lbls: labels.New(metricNameLabel, series2Label),
+					values: []valueResult{
+						{t: minT, v: 1},
+						{t: minT + 1, v: 3},
+					},
+				},
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ctx := context.Background()
+			stores := &blocksStoreSetMock{
+				mockedResult: testData.storeSetResult,
+				mockedErr:    testData.storeSetErr,
+			}
+			finder := &blocksFinderMock{
+				mockedResult: testData.finderResult,
+				mockedErr:    testData.finderErr,
+			}
+
+			q := &blocksStoreQuerier{
+				ctx:    ctx,
+				minT:   minT,
+				maxT:   maxT,
+				userID: "user-1",
+				finder: finder,
+				stores: stores,
+			}
+
+			matchers := []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, metricName),
+			}
+
+			set, warnings, err := q.SelectSorted(nil, matchers...)
+			if testData.expectedErr != "" {
+				assert.EqualError(t, err, testData.expectedErr)
+				assert.Nil(t, set)
+				assert.Nil(t, warnings)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, warnings, 0)
+
+			// Read all returned series and their values.
+			var actualSeries []seriesResult
+			for set.Next() {
+				var actualValues []valueResult
+
+				it := set.At().Iterator()
+				for it.Next() {
+					t, v := it.At()
+					actualValues = append(actualValues, valueResult{
+						t: t,
+						v: v,
+					})
+				}
+
+				require.NoError(t, it.Err())
+
+				actualSeries = append(actualSeries, seriesResult{
+					lbls:   set.At().Labels(),
+					values: actualValues,
+				})
+			}
+			require.NoError(t, set.Err())
+			assert.Equal(t, testData.expectedSeries, actualSeries)
+		})
+	}
+}
+
+type blocksStoreSetMock struct {
+	services.Service
+
+	mockedResult []storegatewaypb.StoreGatewayClient
+	mockedErr    error
+}
+
+func (m *blocksStoreSetMock) GetClientsFor(metas []*metadata.Meta) ([]storegatewaypb.StoreGatewayClient, error) {
+	return m.mockedResult, m.mockedErr
+}
+
+type blocksFinderMock struct {
+	services.Service
+
+	mockedResult []*metadata.Meta
+	mockedErr    error
+}
+
+func (m *blocksFinderMock) GetBlocks(userID string, minT, maxT int64) ([]*metadata.Meta, error) {
+	return m.mockedResult, m.mockedErr
+}
+
+type storeGatewayClientMock struct {
+	mockedResponses []*storepb.SeriesResponse
+}
+
+func (m *storeGatewayClientMock) Series(ctx context.Context, in *storepb.SeriesRequest, opts ...grpc.CallOption) (storegatewaypb.StoreGateway_SeriesClient, error) {
+	seriesClient := &storeGatewaySeriesClientMock{
+		mockedResponses: m.mockedResponses,
+	}
+
+	return seriesClient, nil
+}
+
+type storeGatewaySeriesClientMock struct {
+	grpc.ClientStream
+
+	mockedResponses []*storepb.SeriesResponse
+}
+
+func (m *storeGatewaySeriesClientMock) Recv() (*storepb.SeriesResponse, error) {
+	// Ensure some concurrency occurs.
+	time.Sleep(10 * time.Millisecond)
+
+	if len(m.mockedResponses) == 0 {
+		return nil, io.EOF
+	}
+
+	res := m.mockedResponses[0]
+	m.mockedResponses = m.mockedResponses[1:]
+	return res, nil
+}
+
+func mockSeriesResponse(lbls labels.Labels, timeMillis int64, value float64) *storepb.SeriesResponse {
+	// Generate a chunk containing a single value (for simplicity).
+	chunk := chunkenc.NewXORChunk()
+	appender, err := chunk.Appender()
+	if err != nil {
+		panic(err)
+	}
+	appender.Append(timeMillis, value)
+	chunkData := chunk.Bytes()
+
+	return &storepb.SeriesResponse{
+		Result: &storepb.SeriesResponse_Series{
+			Series: &storepb.Series{
+				Labels: storepb.PromLabelsToLabels(lbls),
+				Chunks: []storepb.AggrChunk{
+					{MinTime: timeMillis, MaxTime: timeMillis, Raw: &storepb.Chunk{Type: storepb.Chunk_XOR, Data: chunkData}},
+				},
+			},
+		},
+	}
+}

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -1,0 +1,150 @@
+package querier
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+
+	"github.com/cortexproject/cortex/pkg/ring"
+	"github.com/cortexproject/cortex/pkg/ring/client"
+	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+// BlocksStoreSet implementation used when the blocks are sharded and replicated across
+// a set of store-gateway instances.
+type blocksStoreReplicationSet struct {
+	services.Service
+
+	storesRing  *ring.Ring
+	clientsPool *client.Pool
+
+	// Subservices manager.
+	subservices        *services.Manager
+	subservicesWatcher *services.FailureWatcher
+}
+
+func newBlocksStoreReplicationSet(storesRing *ring.Ring, logger log.Logger, reg prometheus.Registerer) (*blocksStoreReplicationSet, error) {
+	s := &blocksStoreReplicationSet{
+		storesRing:  storesRing,
+		clientsPool: newStoreGatewayClientPool(storesRing, logger, reg),
+	}
+
+	var err error
+	s.subservices, err = services.NewManager(s.storesRing, s.clientsPool)
+	if err != nil {
+		return nil, err
+	}
+
+	s.Service = services.NewBasicService(s.starting, s.running, s.stopping)
+
+	return s, nil
+}
+
+func (s *blocksStoreReplicationSet) starting(ctx context.Context) error {
+	s.subservicesWatcher.WatchManager(s.subservices)
+
+	if err := services.StartManagerAndAwaitHealthy(ctx, s.subservices); err != nil {
+		return errors.Wrap(err, "unable to start blocks store set subservices")
+	}
+
+	return nil
+}
+
+func (s *blocksStoreReplicationSet) running(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-s.subservicesWatcher.Chan():
+			return errors.Wrap(err, "blocks store set subservice failed")
+		}
+	}
+}
+
+func (s *blocksStoreReplicationSet) stopping(_ error) error {
+	return services.StopManagerAndAwaitStopped(context.Background(), s.subservices)
+}
+
+func (s *blocksStoreReplicationSet) GetClientsFor(metas []*metadata.Meta) ([]storegatewaypb.StoreGatewayClient, error) {
+	var sets []ring.ReplicationSet
+
+	// Find the replication set of each block we need to query.
+	for _, m := range metas {
+		// Buffer internally used by the ring (give extra room for a JOINING + LEAVING instance).
+		// Do not reuse the same buffer across multiple Get() calls because we do retain the
+		// returned replication set.
+		buf := make([]ring.IngesterDesc, 0, s.storesRing.ReplicationFactor()+2)
+
+		set, err := s.storesRing.Get(cortex_tsdb.HashBlockID(m.ULID), ring.BlocksRead, buf)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get store-gateway replication set owning the block %s", m.ULID.String())
+		}
+
+		sets = append(sets, set)
+	}
+
+	var clients []storegatewaypb.StoreGatewayClient
+
+	// Get the client for each store-gateway.
+	for _, addr := range findSmallestInstanceSet(sets) {
+		c, err := s.clientsPool.GetClientFor(addr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get store-gateway client for %s", addr)
+		}
+
+		clients = append(clients, c.(storegatewaypb.StoreGatewayClient))
+	}
+
+	return clients, nil
+}
+
+// findSmallestInstanceSet returns the minimal set of store-gateway instances including all required blocks.
+// Blocks may be replicated across store-gateway instances, but we want to query the lowest number of instances
+// possible, so this function tries to find the smallest set of store-gateway instances containing all blocks
+// we need to query.
+func findSmallestInstanceSet(sets []ring.ReplicationSet) []string {
+	addr := findHighestInstanceOccurrences(sets)
+	if addr == "" {
+		return nil
+	}
+
+	// Remove any replication set containing the selected instance address.
+	for i := 0; i < len(sets); {
+		if sets[i].Includes(addr) {
+			sets = append(sets[:i], sets[i+1:]...)
+		} else {
+			i++
+		}
+	}
+
+	return append([]string{addr}, findSmallestInstanceSet(sets)...)
+}
+
+func findHighestInstanceOccurrences(sets []ring.ReplicationSet) string {
+	var highestAddr string
+	var highestCount int
+
+	occurrences := map[string]int{}
+
+	for _, set := range sets {
+		for _, i := range set.Ingesters {
+			if v, ok := occurrences[i.Addr]; ok {
+				occurrences[i.Addr] = v + 1
+			} else {
+				occurrences[i.Addr] = 1
+			}
+
+			if occurrences[i.Addr] > highestCount {
+				highestAddr = i.Addr
+				highestCount = occurrences[i.Addr]
+			}
+		}
+	}
+
+	return highestAddr
+}

--- a/pkg/querier/blocks_store_replicated_set_test.go
+++ b/pkg/querier/blocks_store_replicated_set_test.go
@@ -1,0 +1,213 @@
+package querier
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+
+	"github.com/cortexproject/cortex/pkg/ring"
+	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
+	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/storegateway"
+	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
+	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/services"
+	"github.com/cortexproject/cortex/pkg/util/test"
+)
+
+func Test_findSmallestInstanceSet(t *testing.T) {
+	tests := map[string]struct {
+		input    []ring.ReplicationSet
+		expected []string
+	}{
+		"empty replication set": {
+			input:    nil,
+			expected: nil,
+		},
+		"single replication set": {
+			input: []ring.ReplicationSet{
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-1"}, {Addr: "instance-2"}}},
+			},
+			expected: []string{"instance-1"},
+		},
+		"no replication": {
+			input: []ring.ReplicationSet{
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-1"}}},
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-3"}}},
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-1"}}},
+			},
+			expected: []string{"instance-1", "instance-3"},
+		},
+		"all replication sets share the same instance": {
+			input: []ring.ReplicationSet{
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-1"}, {Addr: "instance-2"}}},
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-3"}, {Addr: "instance-2"}}},
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-4"}, {Addr: "instance-2"}}},
+			},
+			expected: []string{"instance-2"},
+		},
+		"all replication sets share the same instance except one": {
+			input: []ring.ReplicationSet{
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-1"}, {Addr: "instance-2"}}},
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-3"}, {Addr: "instance-2"}}},
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-4"}, {Addr: "instance-2"}}},
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-5"}, {Addr: "instance-1"}}},
+			},
+			expected: []string{"instance-2", "instance-5"},
+		},
+		"few replication sets share the same instance": {
+			input: []ring.ReplicationSet{
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-1"}, {Addr: "instance-2"}}},
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-3"}, {Addr: "instance-4"}}},
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-1"}, {Addr: "instance-5"}}},
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-4"}, {Addr: "instance-6"}}},
+			},
+			expected: []string{"instance-1", "instance-4"},
+		},
+		"no replication set share the same instance": {
+			input: []ring.ReplicationSet{
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-1"}, {Addr: "instance-2"}}},
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-3"}, {Addr: "instance-4"}}},
+				{Ingesters: []ring.IngesterDesc{{Addr: "instance-5"}, {Addr: "instance-6"}}},
+			},
+			expected: []string{"instance-1", "instance-3", "instance-5"},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, testData.expected, findSmallestInstanceSet(testData.input))
+		})
+	}
+}
+
+func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
+	// The following block IDs have been picked to have increasing hash values
+	// in order to simplify the tests.
+	block1 := ulid.MustNew(1, nil) // hash: 283204220
+	block2 := ulid.MustNew(2, nil) // hash: 444110359
+	block3 := ulid.MustNew(5, nil) // hash: 2931974232
+	block4 := ulid.MustNew(6, nil) // hash: 3092880371
+
+	block1Hash := cortex_tsdb.HashBlockID(block1)
+	block2Hash := cortex_tsdb.HashBlockID(block2)
+	block3Hash := cortex_tsdb.HashBlockID(block3)
+	block4Hash := cortex_tsdb.HashBlockID(block4)
+
+	tests := map[string]struct {
+		replicationFactor int
+		setup             func(*ring.Desc)
+		queryBlocks       []ulid.ULID
+		expectedClients   []string
+	}{
+		"single instance in the ring with replication factor = 1": {
+			replicationFactor: 1,
+			setup: func(d *ring.Desc) {
+				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE)
+			},
+			queryBlocks:     []ulid.ULID{block1, block2},
+			expectedClients: []string{"127.0.0.1"},
+		},
+		"single instance in the ring with replication factor = 2": {
+			replicationFactor: 2,
+			setup: func(d *ring.Desc) {
+				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE)
+			},
+			queryBlocks:     []ulid.ULID{block1, block2},
+			expectedClients: []string{"127.0.0.1"},
+		},
+		"multiple instances in the ring with replication factor = 1": {
+			replicationFactor: 1,
+			setup: func(d *ring.Desc) {
+				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE)
+				d.AddIngester("instance-2", "127.0.0.2", "", []uint32{block2Hash + 1}, ring.ACTIVE)
+				d.AddIngester("instance-3", "127.0.0.3", "", []uint32{block3Hash + 1}, ring.ACTIVE)
+				d.AddIngester("instance-4", "127.0.0.4", "", []uint32{block4Hash + 1}, ring.ACTIVE)
+			},
+			queryBlocks:     []ulid.ULID{block1, block3, block4},
+			expectedClients: []string{"127.0.0.1", "127.0.0.3", "127.0.0.4"},
+		},
+		"multiple instances in the ring with replication factor = 2": {
+			replicationFactor: 2,
+			setup: func(d *ring.Desc) {
+				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE)
+				d.AddIngester("instance-2", "127.0.0.2", "", []uint32{block2Hash + 1}, ring.ACTIVE)
+				d.AddIngester("instance-3", "127.0.0.3", "", []uint32{block3Hash + 1}, ring.ACTIVE)
+				d.AddIngester("instance-4", "127.0.0.4", "", []uint32{block4Hash + 1}, ring.ACTIVE)
+			},
+			queryBlocks:     []ulid.ULID{block1, block3, block4},
+			expectedClients: []string{"127.0.0.1", "127.0.0.4" /* block4 is also replicated by instance-4 */},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			// Setup the ring state.
+			ringStore := consul.NewInMemoryClient(ring.GetCodec())
+			require.NoError(t, ringStore.CAS(ctx, "test", func(in interface{}) (interface{}, bool, error) {
+				d := ring.NewDesc()
+				testData.setup(d)
+				return d, true, nil
+			}))
+
+			ringCfg := ring.Config{}
+			flagext.DefaultValues(&ringCfg)
+			ringCfg.ReplicationFactor = testData.replicationFactor
+
+			r, err := ring.NewWithStoreClientAndStrategy(ringCfg, "test", "test", ringStore, &storegateway.BlocksReplicationStrategy{})
+			require.NoError(t, err)
+
+			reg := prometheus.NewPedanticRegistry()
+			s, err := newBlocksStoreReplicationSet(r, log.NewNopLogger(), reg)
+			require.NoError(t, err)
+			require.NoError(t, services.StartAndAwaitRunning(ctx, s))
+			defer services.StopAndAwaitTerminated(ctx, s) //nolint:errcheck
+
+			// Wait until the ring client has initialised the state.
+			test.Poll(t, time.Second, true, func() interface{} {
+				all, err := r.GetAll()
+				return err == nil && len(all.Ingesters) > 0
+			})
+
+			var metas []*metadata.Meta
+			for _, id := range testData.queryBlocks {
+				metas = append(metas, &metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: id}})
+			}
+
+			clients, err := s.GetClientsFor(metas)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, testData.expectedClients, getStoreClientClientAddrs(clients))
+
+			assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+				# HELP cortex_storegateway_clients The current number of store-gateway clients in the pool.
+				# TYPE cortex_storegateway_clients gauge
+				cortex_storegateway_clients{client="querier"} %d
+			`, len(testData.expectedClients))), "cortex_storegateway_clients"))
+		})
+	}
+}
+
+func getStoreClientClientAddrs(clients []storegatewaypb.StoreGatewayClient) []string {
+	var addrs []string
+	for _, c := range clients {
+		addrs = append(addrs, c.(*storeGatewayClient).conn.Target())
+	}
+	return addrs
+}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"strings"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/chunk/purger"
@@ -48,6 +49,9 @@ type Config struct {
 	// However, we need to use active query tracker, otherwise we cannot limit Max Concurrent queries in the PromQL
 	// engine.
 	ActiveQueryTrackerDir string `yaml:"active_query_tracker_dir"`
+
+	// Blocks storage only.
+	StoreGatewayAddresses string `yaml:"store_gateway_addresses"`
 }
 
 var (
@@ -70,6 +74,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.DefaultEvaluationInterval, "querier.default-evaluation-interval", time.Minute, "The default evaluation interval or step size for subqueries.")
 	f.DurationVar(&cfg.QueryStoreAfter, "querier.query-store-after", 0, "The time after which a metric should only be queried from storage and not just ingesters. 0 means all queries are sent to store.")
 	f.StringVar(&cfg.ActiveQueryTrackerDir, "querier.active-query-tracker-dir", "./active-query-tracker", "Active query tracker monitors active queries, and writes them to the file in given directory. If Cortex discovers any queries in this log during startup, it will log them to the log file. Setting to empty value disables active query tracker, which also disables -querier.max-concurrent option.")
+	f.StringVar(&cfg.StoreGatewayAddresses, "experimental.querier.store-gateway-addresses", "", "Comma separated list of store-gateway addresses in DNS Service Discovery format. This option should be set when using the experimental blocks storage and the store-gateway sharding is disabled (when enabled, the store-gateway instances form a ring and addresses are picked from the ring).")
 }
 
 // Validate the config
@@ -83,6 +88,14 @@ func (cfg *Config) Validate() error {
 	}
 
 	return nil
+}
+
+func (cfg *Config) GetStoreGatewayAddresses() []string {
+	if cfg.StoreGatewayAddresses == "" {
+		return nil
+	}
+
+	return strings.Split(cfg.StoreGatewayAddresses, ",")
 }
 
 func getChunksIteratorFunction(cfg Config) chunkIteratorFunc {

--- a/pkg/querier/series/series_set.go
+++ b/pkg/querier/series/series_set.go
@@ -346,3 +346,14 @@ func (emptySeriesIterator) Next() bool {
 func (emptySeriesIterator) Err() error {
 	return nil
 }
+
+type emptySeriesSet struct{}
+
+func (emptySeriesSet) Next() bool         { return false }
+func (emptySeriesSet) At() storage.Series { return nil }
+func (emptySeriesSet) Err() error         { return nil }
+
+// NewEmptySeriesSet returns a new series set that contains no series.
+func NewEmptySeriesSet() storage.SeriesSet {
+	return emptySeriesSet{}
+}

--- a/pkg/querier/store_gateway_client.go
+++ b/pkg/querier/store_gateway_client.go
@@ -1,22 +1,26 @@
 package querier
 
 import (
+	"time"
+
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/ring/client"
 	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 )
 
-func NewStoreGatewayClientFactory(cfg grpcclient.Config, reg prometheus.Registerer) client.PoolFactory {
+func newStoreGatewayClientFactory(cfg grpcclient.Config, reg prometheus.Registerer) client.PoolFactory {
 	requestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   "cortex",
 		Name:        "storegateway_client_request_duration_seconds",
-		Help:        "Time spent executing requests on store-gateway.",
+		Help:        "Time spent executing requests to the store-gateway.",
 		Buckets:     prometheus.ExponentialBuckets(0.008, 4, 7),
 		ConstLabels: prometheus.Labels{"client": "querier"},
 	}, []string{"operation", "status_code"})
@@ -49,4 +53,35 @@ type storeGatewayClient struct {
 
 func (c *storeGatewayClient) Close() error {
 	return c.conn.Close()
+}
+
+func (c *storeGatewayClient) String() string {
+	return c.conn.Target()
+}
+
+func newStoreGatewayClientPool(r ring.ReadRing, logger log.Logger, reg prometheus.Registerer) *client.Pool {
+	// We prefer sane defaults instead of exposing further config options.
+	clientCfg := grpcclient.Config{
+		MaxRecvMsgSize:      100 << 20,
+		MaxSendMsgSize:      16 << 20,
+		UseGzipCompression:  false,
+		RateLimit:           0,
+		RateLimitBurst:      0,
+		BackoffOnRatelimits: false,
+	}
+
+	poolCfg := client.PoolConfig{
+		CheckInterval:      time.Minute,
+		HealthCheckEnabled: true,
+		HealthCheckTimeout: 10 * time.Second,
+	}
+
+	clientsCount := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		Namespace:   "cortex",
+		Name:        "storegateway_clients",
+		Help:        "The current number of store-gateway clients in the pool.",
+		ConstLabels: map[string]string{"client": "querier"},
+	})
+
+	return client.NewPool("store-gateway", poolCfg, r, newStoreGatewayClientFactory(clientCfg, reg), clientsCount, logger)
 }

--- a/pkg/querier/store_gateway_client_test.go
+++ b/pkg/querier/store_gateway_client_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 )
 
-func TestNewStoreGatewayClientFactory(t *testing.T) {
+func Test_newStoreGatewayClientFactory(t *testing.T) {
 	// Create a GRPC server used to query the mocked service.
 	grpcServer := grpc.NewServer()
 	defer grpcServer.GracefulStop()
@@ -39,7 +39,7 @@ func TestNewStoreGatewayClientFactory(t *testing.T) {
 	flagext.DefaultValues(&cfg)
 
 	reg := prometheus.NewPedanticRegistry()
-	factory := NewStoreGatewayClientFactory(cfg, reg)
+	factory := newStoreGatewayClientFactory(cfg, reg)
 
 	for i := 0; i < 2; i++ {
 		client, err := factory(listener.Addr().String())

--- a/pkg/ring/client/pool.go
+++ b/pkg/ring/client/pool.go
@@ -146,6 +146,11 @@ func (p *Pool) Count() int {
 }
 
 func (p *Pool) removeStaleClients() {
+	// Only if this pool is based on the ring.
+	if p.ring == nil {
+		return
+	}
+
 	clients := map[string]struct{}{}
 	replicationSet, err := p.ring.GetAll()
 	if err != nil {

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	HeadCompactionInterval    time.Duration     `yaml:"head_compaction_interval"`
 	HeadCompactionConcurrency int               `yaml:"head_compaction_concurrency"`
 	StripeSize                int               `yaml:"stripe_size"`
+	StoreGatewayEnabled       bool              `yaml:"store_gateway_enabled"`
 
 	// MaxTSDBOpeningConcurrencyOnStartup limits the number of concurrently opening TSDB's during startup
 	MaxTSDBOpeningConcurrencyOnStartup int `yaml:"max_tsdb_opening_concurrency_on_startup"`
@@ -128,6 +129,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.HeadCompactionInterval, "experimental.tsdb.head-compaction-interval", 1*time.Minute, "How frequently does Cortex try to compact TSDB head. Block is only created if data covers smallest block range. Must be greater than 0 and max 5 minutes.")
 	f.IntVar(&cfg.HeadCompactionConcurrency, "experimental.tsdb.head-compaction-concurrency", 5, "Maximum number of tenants concurrently compacting TSDB head into a new block")
 	f.IntVar(&cfg.StripeSize, "experimental.tsdb.stripe-size", 16384, "The number of shards of series to use in TSDB (must be a power of 2). Reducing this will decrease memory footprint, but can negatively impact performance.")
+	f.BoolVar(&cfg.StoreGatewayEnabled, "experimental.tsdb.store-gateway-enabled", false, "True if the Cortex cluster is running the store-gateway service and the querier should query the bucket store via the store-gateway.")
 }
 
 // Validate the config.

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -61,18 +61,18 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	}
 
 	// Ring flags
-	cfg.KVStore.RegisterFlagsWithPrefix("experimental.store-gateway.ring.", "collectors/", f)
-	f.DurationVar(&cfg.HeartbeatPeriod, "experimental.store-gateway.ring.heartbeat-period", 15*time.Second, "Period at which to heartbeat to the ring.")
-	f.DurationVar(&cfg.HeartbeatTimeout, "experimental.store-gateway.ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which store gateways are considered unhealthy within the ring.")
+	cfg.KVStore.RegisterFlagsWithPrefix("experimental.store-gateway.sharding-ring.", "collectors/", f)
+	f.DurationVar(&cfg.HeartbeatPeriod, "experimental.store-gateway.sharding-ring.heartbeat-period", 15*time.Second, "Period at which to heartbeat to the ring.")
+	f.DurationVar(&cfg.HeartbeatTimeout, "experimental.store-gateway.sharding-ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which store gateways are considered unhealthy within the ring.")
 	f.IntVar(&cfg.ReplicationFactor, "experimental.store-gateway.replication-factor", 3, "The replication factor to use when sharding blocks.")
 	f.StringVar(&cfg.TokensFilePath, "experimental.store-gateway.tokens-file-path", "", "File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.")
 
 	// Instance flags
 	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}
-	f.Var((*flagext.Strings)(&cfg.InstanceInterfaceNames), "experimental.store-gateway.ring.instance-interface", "Name of network interface to read address from.")
-	f.StringVar(&cfg.InstanceAddr, "experimental.store-gateway.ring.instance-addr", "", "IP address to advertise in the ring.")
-	f.IntVar(&cfg.InstancePort, "experimental.store-gateway.ring.instance-port", 0, "Port to advertise in the ring (defaults to server.grpc-listen-port).")
-	f.StringVar(&cfg.InstanceID, "experimental.store-gateway.ring.instance-id", hostname, "Instance ID to register in the ring.")
+	f.Var((*flagext.Strings)(&cfg.InstanceInterfaceNames), "experimental.store-gateway.sharding-ring.instance-interface", "Name of network interface to read address from.")
+	f.StringVar(&cfg.InstanceAddr, "experimental.store-gateway.sharding-ring.instance-addr", "", "IP address to advertise in the ring.")
+	f.IntVar(&cfg.InstancePort, "experimental.store-gateway.sharding-ring.instance-port", 0, "Port to advertise in the ring (defaults to server.grpc-listen-port).")
+	f.StringVar(&cfg.InstanceID, "experimental.store-gateway.sharding-ring.instance-id", hostname, "Instance ID to register in the ring.")
 
 	// Defaults for internal settings.
 	cfg.RingCheckPeriod = 5 * time.Second

--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -323,13 +323,15 @@ func main() {
 
 	// Generate documentation markdown.
 	data := struct {
-		ConfigFile           string
-		TSDBConfigBlock      string
-		CompactorConfigBlock string
+		ConfigFile              string
+		TSDBConfigBlock         string
+		StoreGatewayConfigBlock string
+		CompactorConfigBlock    string
 	}{
-		ConfigFile:           generateBlocksMarkdown(blocks),
-		TSDBConfigBlock:      generateBlockMarkdown(blocks, "tsdb_config", "tsdb"),
-		CompactorConfigBlock: generateBlockMarkdown(blocks, "compactor_config", "compactor"),
+		ConfigFile:              generateBlocksMarkdown(blocks),
+		TSDBConfigBlock:         generateBlockMarkdown(blocks, "tsdb_config", "tsdb"),
+		StoreGatewayConfigBlock: generateBlockMarkdown(blocks, "store_gateway_config", "store_gateway"),
+		CompactorConfigBlock:    generateBlockMarkdown(blocks, "compactor_config", "compactor"),
 	}
 
 	// Load the template file.


### PR DESCRIPTION
**What this PR does**:
Following up #2458, in this PR I'm introducing the store-gateway support to queriers. Currently, store-gateways are opt-in so you can still use blocks synched/loaded in queriers (store-gateway will be made mandatory in a future PR, once we'll be confident enough with the store-gateway).

Out of the scope of this PR (to keep this PR "smaller"):
- Consistency check
- Cleanup the config to avoid having to pass store-gateway config to the querier
- Documentation / CHANGELOG entry

This PR is a draft because it's still lacking:
- Solve (1) TODO in the code
- Integration tests
- Cleanup the config (currently the querier requires the store-gateway config, which is a bad design)

I've opened the draft to start collecting some feedback.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
