### PR TITLE
Undo a spurious change in push handler

### DIFF
--- a/pkg/util/push/push.go
+++ b/pkg/util/push/push.go
@@ -17,15 +17,13 @@ func Handler(cfg distributor.Config, push func(context.Context, *client.WriteReq
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		compressionType := util.CompressionTypeFor(r.Header.Get("X-Prometheus-Remote-Write-Version"))
 		var req client.PreallocWriteRequest
+		req.Source = client.API
 		_, err := util.ParseProtoReader(r.Context(), r.Body, int(r.ContentLength), cfg.MaxRecvMsgSize, &req, compressionType)
 		logger := util.WithContext(r.Context(), util.Logger)
 		if err != nil {
 			level.Error(logger).Log("err", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
-		}
-		if req.Source == 0 {
-			req.Source = client.API
 		}
 
 		if _, err := push(r.Context(), &req.WriteRequest); err != nil {


### PR DESCRIPTION
The meaning of the code before #2457 is that we initialise to `API` but allow the unmarshal code to override.

Tests were added in #2457 to confirm this works as expected.
