### PR TITLE
Fixed ring metrics collection

### DIFF
--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -47,7 +47,6 @@ func benchmarkBatch(b *testing.B, numIngester, numKeys int) {
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)
 	r := Ring{
-		name:     "ingester",
 		cfg:      cfg,
 		ringDesc: desc,
 		strategy: &DefaultReplicationStrategy{},
@@ -89,7 +88,6 @@ func TestDoBatchZeroIngesters(t *testing.T) {
 	}
 	desc := NewDesc()
 	r := Ring{
-		name:     "ingester",
 		cfg:      Config{},
 		ringDesc: desc,
 		strategy: &DefaultReplicationStrategy{},
@@ -143,7 +141,6 @@ func TestSubring(t *testing.T) {
 
 	// Create a ring with the ingesters
 	ring := Ring{
-		name: "main ring",
 		cfg: Config{
 			HeartbeatTimeout: time.Hour,
 		},
@@ -198,7 +195,6 @@ func TestStableSubring(t *testing.T) {
 
 	// Create a ring with the ingesters
 	ring := Ring{
-		name: "main ring",
 		cfg: Config{
 			HeartbeatTimeout: time.Hour,
 		},
@@ -257,7 +253,6 @@ func TestZoneAwareIngesterAssignmentSucccess(t *testing.T) {
 
 	// Create a ring with the ingesters
 	ring := Ring{
-		name: "main ring",
 		cfg: Config{
 			HeartbeatTimeout:  time.Hour,
 			ReplicationFactor: 3,
@@ -322,7 +317,6 @@ func TestZoneAwareIngesterAssignmentFailure(t *testing.T) {
 
 	// Create a ring with the ingesters
 	ring := Ring{
-		name: "main ring",
 		cfg: Config{
 			HeartbeatTimeout:  time.Hour,
 			ReplicationFactor: 3,

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -15,11 +15,15 @@ import (
 )
 
 const (
-	// StoreGatewayRingKey is the key under which we store the store gateways ring in the KVStore.
+	// RingKey is the key under which we store the store gateways ring in the KVStore.
 	RingKey = "store-gateway"
 
-	// StoreGatewayRingName is the name of the ring used by the store gateways.
-	RingName = "store-gateway"
+	// RingNameForServer is the name of the ring used by the store gateway server.
+	RingNameForServer = "store-gateway"
+
+	// RingNameForClient is the name of the ring used by the store gateway client (we need
+	// a different name to avoid clashing Prometheus metrics when running in single-binary).
+	RingNameForClient = "store-gateway-client"
 
 	// We use a safe default instead of exposing to config option to the user
 	// in order to simplify the config.


### PR DESCRIPTION
**What this PR does**:
While working on the `store-gateway` I found two issues related to the ring metrics:

1. `oldestTimestampDesc` was not included in the `Describe()`: fixed
2. It's not possible to export metrics from two different ring client instances because of clashing metrics: fixed moving the `name` label as a constant label instead of a dynamic one (constant labels are taken in account when building the desc ID, so solving the issue)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
