### PR TITLE
frontend: also log the POST data of long queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [ENHANCEMENT] Added per tenant metrics for queries and chunks and bytes read from chunk store: #2463
   * `cortex_chunk_store_fetched_chunks_total` and `cortex_chunk_store_fetched_chunk_bytes_total`
   * `cortex_query_frontend_queries_total` (per tenant queries counted by the frontend)
+* [ENHANCEMENT] query-frontend now also logs the POST data of long queries
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400
 * [BUGFIX] Cassandra Storage: Fix endpoint TLS host verification. #2109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 * [ENHANCEMENT] Added per tenant metrics for queries and chunks and bytes read from chunk store: #2463
   * `cortex_chunk_store_fetched_chunks_total` and `cortex_chunk_store_fetched_chunk_bytes_total`
   * `cortex_query_frontend_queries_total` (per tenant queries counted by the frontend)
-* [ENHANCEMENT] query-frontend now also logs the POST data of long queries
+* [ENHANCEMENT] query-frontend now also logs the POST data of long queries. #2481
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400
 * [BUGFIX] Cassandra Storage: Fix endpoint TLS host verification. #2109

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -163,7 +163,16 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 	queryResponseTime := time.Since(startTime)
 
 	if f.cfg.LogQueriesLongerThan > 0 && queryResponseTime > f.cfg.LogQueriesLongerThan {
-		level.Info(f.log).Log("msg", "slow query", "org_id", userID, "url", fmt.Sprintf("http://%s", r.Host+r.RequestURI), "time_taken", queryResponseTime.String())
+		logMessage := []interface{}{"msg", "slow query",
+			"org_id", userID,
+			"url", fmt.Sprintf("http://%s", r.Host+r.RequestURI),
+			"time_taken", queryResponseTime.String(),
+		}
+		pf := r.PostForm.Encode()
+		if pf != "" {
+			logMessage = append(logMessage, "body", pf)
+		}
+		level.Info(f.log).Log(logMessage...)
 	}
 
 	if err != nil {


### PR DESCRIPTION
The feature of query-frontend to log slower queries is already amazing
but we can make it even better by logging the POST body as well. It is
not uncommon nowadays to use POST with the Prometheus API. All of the
data that is passed via POST is not visible via the URL. Thus, let's
also print the POST data if it is available.

Small testing shows that the message now looks like the following:

```
level=info ts=2020-04-17T16:34:51.200200445Z caller=frontend.go:174 msg="slow query" org_id=fake url=http://localhost:9009/api/prom/api/v1/query_range time_taken=1.638201ms body="end=1587141285&query=prometheus_http_requests_total&start=1587140385&step=15"
```

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>
