### PR TITLE
QueryFrontend sets incorrect status code on HTTP timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [BUGFIX] Ring: Fixed a situation where upgrading from pre-1.0 cortex with a rolling strategy caused new 1.0 ingesters to lose their zone value in the ring until manually forced to re-register. #2404
 * [BUGFIX] Distributor: `/all_user_stats` now show API and Rule Ingest Rate correctly. #2457
 * [BUGFIX] Fixed `version`, `revision` and `branch` labels exported by the `cortex_build_info` metric. #2468
+* [BUGFIX] QueryFrontend: fixed a situation where HTTP error is ignored and an incorrect status code is set. #2483
 
 ## 1.0.0 / 2020-04-02
 

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -171,16 +171,16 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err = io.Copy(w, resp.Body); err != nil {
-		server.WriteError(w, err)
-		return
-	}
-
 	hs := w.Header()
 	for h, vs := range resp.Header {
 		hs[h] = vs
 	}
 	w.WriteHeader(resp.StatusCode)
+
+	if _, err = io.Copy(w, resp.Body); err != nil {
+		server.WriteError(w, err)
+		return
+	}
 }
 
 func writeError(w http.ResponseWriter, err error) {

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -171,12 +171,16 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if _, err = io.Copy(w, resp.Body); err != nil {
+		server.WriteError(w, err)
+		return
+	}
+
 	hs := w.Header()
 	for h, vs := range resp.Header {
 		hs[h] = vs
 	}
 	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
 }
 
 func writeError(w http.ResponseWriter, err error) {


### PR DESCRIPTION
Signed-off-by: Dmitry Shmulevich <dmitry.shmulevich@sysdig.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
It fixes bug where query frontend ignores an error in HTTP handler and reports incorrect status code

**Which issue(s) this PR fixes**:
Fixes #2482

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
