### PR TITLE
Cleanup and fix golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,9 @@ output:
 linters:
   enable:
     - goimports
+    - golint
+    - gofmt
+    - misspell
 
 linters-settings:
   errcheck:
@@ -12,3 +15,11 @@ linters-settings:
     exclude: ./.errcheck-exclude
   goimports:
     local-prefixes: "github.com/cortexproject/cortex"
+
+run:
+  timeout: 5m
+
+  # List of build tags, all linters use it.
+  build-tags:
+    - netgo
+    - requires_docker

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,9 @@ protos: $(PROTO_GOS)
 
 lint:
 	misspell -error docs
-	golangci-lint run --build-tags netgo,require_docker --timeout=5m --enable golint --enable misspell --enable gofmt
+
+	# Configured via .golangci.yml.
+	golangci-lint run
 
 	# Ensure no blacklisted package is imported.
 	faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert" ./pkg/... ./cmd/... ./tools/... ./integration/...

--- a/integration/api_ruler_test.go
+++ b/integration/api_ruler_test.go
@@ -39,7 +39,7 @@ func TestRulerAPI(t *testing.T) {
 		Name:     "test_encoded_+\"+group_name?",
 		Interval: 100,
 		Rules: []rulefmt.Rule{
-			rulefmt.Rule{
+			{
 				Record: "test_rule",
 				Expr:   "up",
 			},

--- a/integration/asserts.go
+++ b/integration/asserts.go
@@ -28,14 +28,14 @@ const (
 var (
 	// Service-specific metrics prefixes which shouldn't be used by any other service.
 	serviceMetricsPrefixes = map[ServiceType][]string{
-		Distributor:   []string{},
-		Ingester:      []string{"!cortex_ingester_client", "cortex_ingester"}, // The metrics prefix cortex_ingester_client may be used by other components so we ignore it.
-		Querier:       []string{},
-		QueryFrontend: []string{"cortex_frontend", "cortex_query_frontend"},
-		TableManager:  []string{},
-		AlertManager:  []string{"cortex_alertmanager"},
-		Ruler:         []string{},
-		StoreGateway:  []string{"!cortex_storegateway_client", "cortex_storegateway"}, // The metrics prefix cortex_storegateway_client may be used by other components so we ignore it.
+		Distributor:   {},
+		Ingester:      {"!cortex_ingester_client", "cortex_ingester"}, // The metrics prefix cortex_ingester_client may be used by other components so we ignore it.
+		Querier:       {},
+		QueryFrontend: {"cortex_frontend", "cortex_query_frontend"},
+		TableManager:  {},
+		AlertManager:  {"cortex_alertmanager"},
+		Ruler:         {},
+		StoreGateway:  {"!cortex_storegateway_client", "cortex_storegateway"}, // The metrics prefix cortex_storegateway_client may be used by other components so we ignore it.
 	}
 
 	// Blacklisted metrics prefixes across any Cortex service.

--- a/integration/kv_test.go
+++ b/integration/kv_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cortexproject/cortex/integration/e2e"
 	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
 	"github.com/cortexproject/cortex/pkg/ring/kv"
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	"github.com/cortexproject/cortex/pkg/ring/kv/etcd"
-	"github.com/stretchr/testify/require"
 )
 
 func TestKV_List_Delete(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
While reviewing the `golangci-lint` config I've realized two things fixed in this PR:
1. It's configured via a mix of CLI flags and config file (moved everything to config file)
2. The `require_docker` build tags is wrong: should be `requires_docker`

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
