### PR TITLE
Transition Ruler to Thanos ObjStore Client

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -741,78 +741,61 @@ storage:
   # The CLI flags prefix for this block config is: ruler
   [configdb: <configstore_config>]
 
-  azure:
-    # Name of the blob container used to store chunks. Defaults to `cortex`.
-    # This container must be created before running cortex.
-    # CLI flag: -ruler.storage.azure.container-name
-    [container_name: <string> | default = "cortex"]
+  s3:
+    # S3 endpoint without schema
+    # CLI flag: -ruler.storage.s3.endpoint
+    [endpoint: <string> | default = ""]
 
-    # The Microsoft Azure account name to be used
+    # S3 bucket name
+    # CLI flag: -ruler.storage.s3.bucket-name
+    [bucket_name: <string> | default = ""]
+
+    # S3 secret access key
+    # CLI flag: -ruler.storage.s3.secret-access-key
+    [secret_access_key: <string> | default = ""]
+
+    # S3 access key ID
+    # CLI flag: -ruler.storage.s3.access-key-id
+    [access_key_id: <string> | default = ""]
+
+    # If enabled, use http:// for the S3 endpoint instead of https://. This
+    # could be useful in local dev/test environments while using an
+    # S3-compatible backend storage, like Minio.
+    # CLI flag: -ruler.storage.s3.insecure
+    [insecure: <boolean> | default = false]
+
+  gcs:
+    # GCS bucket name
+    # CLI flag: -ruler.storage.gcs.bucket-name
+    [bucket_name: <string> | default = ""]
+
+    # JSON representing either a Google Developers Console
+    # client_credentials.json file or a Google Developers service account key
+    # file. If empty, fallback to Google default logic.
+    # CLI flag: -ruler.storage.gcs.service-account
+    [service_account: <string> | default = ""]
+
+  azure:
+    # Azure storage account name
     # CLI flag: -ruler.storage.azure.account-name
     [account_name: <string> | default = ""]
 
-    # The Microsoft Azure account key to use.
+    # Azure storage account key
     # CLI flag: -ruler.storage.azure.account-key
     [account_key: <string> | default = ""]
 
-    # Preallocated buffer size for downloads (default is 512KB)
-    # CLI flag: -ruler.storage.azure.download-buffer-size
-    [download_buffer_size: <int> | default = 512000]
+    # Azure storage container name
+    # CLI flag: -ruler.storage.azure.container-name
+    [container_name: <string> | default = ""]
 
-    # Preallocated buffer size for up;oads (default is 256KB)
-    # CLI flag: -ruler.storage.azure.upload-buffer-size
-    [upload_buffer_size: <int> | default = 256000]
+    # Azure storage endpoint suffix without schema. The account name will be
+    # prefixed to this value to create the FQDN
+    # CLI flag: -ruler.storage.azure.endpoint-suffix
+    [endpoint_suffix: <string> | default = ""]
 
-    # Number of buffers used to used to upload a chunk. (defaults to 1)
-    # CLI flag: -ruler.storage.azure.download-buffer-count
-    [upload_buffer_count: <int> | default = 1]
-
-    # Timeout for requests made against azure blob storage. Defaults to 30
-    # seconds.
-    # CLI flag: -ruler.storage.azure.request-timeout
-    [request_timeout: <duration> | default = 30s]
-
-    # Number of retries for a request which times out.
+    # Number of retries for recoverable errors
     # CLI flag: -ruler.storage.azure.max-retries
-    [max_retries: <int> | default = 5]
-
-    # Minimum time to wait before retrying a request.
-    # CLI flag: -ruler.storage.azure.min-retry-delay
-    [min_retry_delay: <duration> | default = 10ms]
-
-    # Maximum time to wait before retrying a request.
-    # CLI flag: -ruler.storage.azure.max-retry-delay
-    [max_retry_delay: <duration> | default = 500ms]
-
-  gcs:
-    # Name of GCS bucket to put chunks in.
-    # CLI flag: -ruler.storage.gcs.bucketname
-    [bucket_name: <string> | default = ""]
-
-    # The size of the buffer that GCS client for each PUT request. 0 to disable
-    # buffering.
-    # CLI flag: -ruler.storage.gcs.chunk-buffer-size
-    [chunk_buffer_size: <int> | default = 0]
-
-    # The duration after which the requests to GCS should be timed out.
-    # CLI flag: -ruler.storage.gcs.request-timeout
-    [request_timeout: <duration> | default = 0s]
-
-  s3:
-    # S3 endpoint URL with escaped Key and Secret encoded. If only region is
-    # specified as a host, proper endpoint will be deduced. Use
-    # inmemory:///<bucket-name> to use a mock in-memory implementation.
-    # CLI flag: -ruler.storage.s3.url
-    [s3: <url> | default = ]
-
-    # Comma separated list of bucket names to evenly distribute chunks over.
-    # Overrides any buckets specified in s3.url flag
-    # CLI flag: -ruler.storage.s3.buckets
-    [bucketnames: <string> | default = ""]
-
-    # Set this to `true` to force the request to use path-style addressing.
-    # CLI flag: -ruler.storage.s3.force-path-style
-    [s3forcepathstyle: <boolean> | default = false]
+    [max_retries: <int> | default = 20]
 
 # file path to store temporary rule files for the prometheus rule managers
 # CLI flag: -ruler.rule-path

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -159,7 +159,7 @@ func NewRuler(cfg Config, engine *promql.Engine, queryable promStorage.Queryable
 		return nil, err
 	}
 
-	ruleStore, err := NewRuleStorage(cfg.StoreConfig)
+	ruleStore, err := NewRuleStorage(cfg.StoreConfig, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ruler/storage.go
+++ b/pkg/ruler/storage.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/ruler/rules"
 	"github.com/cortexproject/cortex/pkg/ruler/rules/objectclient"
 	"github.com/cortexproject/cortex/pkg/storage/backend/azure"
-	"github.com/cortexproject/cortex/pkg/storage/backend/filesystem"
 	"github.com/cortexproject/cortex/pkg/storage/backend/gcs"
 	"github.com/cortexproject/cortex/pkg/storage/backend/s3"
 )
@@ -23,10 +22,9 @@ type RuleStoreConfig struct {
 	ConfigDB client.Config `yaml:"configdb"`
 
 	// Object Storage Configs
-	S3         s3.Config         `yaml:"s3"`
-	GCS        gcs.Config        `yaml:"gcs"`
-	Azure      azure.Config      `yaml:"azure"`
-	Filesystem filesystem.Config `yaml:"filesystem"`
+	S3    s3.Config    `yaml:"s3"`
+	GCS   gcs.Config   `yaml:"gcs"`
+	Azure azure.Config `yaml:"azure"`
 
 	mock rules.RuleStore `yaml:"-"`
 }
@@ -61,8 +59,6 @@ func NewRuleStorage(cfg RuleStoreConfig, logger log.Logger) (rules.RuleStore, er
 		return newObjRuleStore(gcs.NewBucketClient(context.Background(), cfg.GCS, "cortex-ruler", logger))
 	case "s3":
 		return newObjRuleStore(s3.NewBucketClient(cfg.S3, "cortex-ruler", logger))
-	case "filesystem":
-		return newObjRuleStore(filesystem.NewBucketClient(cfg.Filesystem))
 	default:
 		return nil, fmt.Errorf("Unrecognized rule storage mode %v, choose one of: configdb, gcs", cfg.Type)
 	}

--- a/pkg/ruler/storage.go
+++ b/pkg/ruler/storage.go
@@ -5,13 +5,16 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/cortexproject/cortex/pkg/chunk"
-	"github.com/cortexproject/cortex/pkg/chunk/aws"
-	"github.com/cortexproject/cortex/pkg/chunk/azure"
-	"github.com/cortexproject/cortex/pkg/chunk/gcp"
+	"github.com/go-kit/kit/log"
+	"github.com/thanos-io/thanos/pkg/objstore"
+
 	"github.com/cortexproject/cortex/pkg/configs/client"
 	"github.com/cortexproject/cortex/pkg/ruler/rules"
 	"github.com/cortexproject/cortex/pkg/ruler/rules/objectclient"
+	"github.com/cortexproject/cortex/pkg/storage/backend/azure"
+	"github.com/cortexproject/cortex/pkg/storage/backend/filesystem"
+	"github.com/cortexproject/cortex/pkg/storage/backend/gcs"
+	"github.com/cortexproject/cortex/pkg/storage/backend/s3"
 )
 
 // RuleStoreConfig conigures a rule store
@@ -20,9 +23,10 @@ type RuleStoreConfig struct {
 	ConfigDB client.Config `yaml:"configdb"`
 
 	// Object Storage Configs
-	Azure azure.BlobStorageConfig `yaml:"azure"`
-	GCS   gcp.GCSConfig           `yaml:"gcs"`
-	S3    aws.S3Config            `yaml:"s3"`
+	S3         s3.Config         `yaml:"s3"`
+	GCS        gcs.Config        `yaml:"gcs"`
+	Azure      azure.Config      `yaml:"azure"`
+	Filesystem filesystem.Config `yaml:"filesystem"`
 
 	mock rules.RuleStore `yaml:"-"`
 }
@@ -37,7 +41,7 @@ func (cfg *RuleStoreConfig) RegisterFlags(f *flag.FlagSet) {
 }
 
 // NewRuleStorage returns a new rule storage backend poller and store
-func NewRuleStorage(cfg RuleStoreConfig) (rules.RuleStore, error) {
+func NewRuleStorage(cfg RuleStoreConfig, logger log.Logger) (rules.RuleStore, error) {
 	if cfg.mock != nil {
 		return cfg.mock, nil
 	}
@@ -52,17 +56,19 @@ func NewRuleStorage(cfg RuleStoreConfig) (rules.RuleStore, error) {
 
 		return rules.NewConfigRuleStore(c), nil
 	case "azure":
-		return newObjRuleStore(azure.NewBlobStorage(&cfg.Azure, ""))
+		return newObjRuleStore(azure.NewBucketClient(cfg.Azure, "cortex-ruler", logger))
 	case "gcs":
-		return newObjRuleStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCS, ""))
+		return newObjRuleStore(gcs.NewBucketClient(context.Background(), cfg.GCS, "cortex-ruler", logger))
 	case "s3":
-		return newObjRuleStore(aws.NewS3ObjectClient(cfg.S3, ""))
+		return newObjRuleStore(s3.NewBucketClient(cfg.S3, "cortex-ruler", logger))
+	case "filesystem":
+		return newObjRuleStore(filesystem.NewBucketClient(cfg.Filesystem))
 	default:
 		return nil, fmt.Errorf("Unrecognized rule storage mode %v, choose one of: configdb, gcs", cfg.Type)
 	}
 }
 
-func newObjRuleStore(client chunk.ObjectClient, err error) (rules.RuleStore, error) {
+func newObjRuleStore(client objstore.Bucket, err error) (rules.RuleStore, error) {
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/backend/azure/config.go
+++ b/pkg/storage/backend/azure/config.go
@@ -15,11 +15,16 @@ type Config struct {
 	MaxRetries         int            `yaml:"max_retries"`
 }
 
-// RegisterFlags registers the flags for TSDB Azure storage
+// RegisterFlags registers the flags for TSDB Azure storage with the TSDB prefix
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.StorageAccountName, "experimental.tsdb.azure.account-name", "", "Azure storage account name")
-	f.Var(&cfg.StorageAccountKey, "experimental.tsdb.azure.account-key", "Azure storage account key")
-	f.StringVar(&cfg.ContainerName, "experimental.tsdb.azure.container-name", "", "Azure storage container name")
-	f.StringVar(&cfg.Endpoint, "experimental.tsdb.azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN")
-	f.IntVar(&cfg.MaxRetries, "experimental.tsdb.azure.max-retries", 20, "Number of retries for recoverable errors")
+	cfg.RegisterFlagsWithPrefix("experimental.tsdb.", f)
+}
+
+// RegisterFlags registers the flags for Azure storage with the specified prefix
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.StorageAccountName, prefix+"azure.account-name", "", "Azure storage account name")
+	f.Var(&cfg.StorageAccountKey, prefix+"azure.account-key", "Azure storage account key")
+	f.StringVar(&cfg.ContainerName, prefix+"azure.container-name", "", "Azure storage container name")
+	f.StringVar(&cfg.Endpoint, prefix+"azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN")
+	f.IntVar(&cfg.MaxRetries, prefix+"azure.max-retries", 20, "Number of retries for recoverable errors")
 }

--- a/pkg/storage/backend/filesystem/config.go
+++ b/pkg/storage/backend/filesystem/config.go
@@ -9,5 +9,10 @@ type Config struct {
 
 // RegisterFlags registers the flags for TSDB filesystem storage
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.Directory, "experimental.tsdb.filesystem.dir", "", "Local filesystem storage directory.")
+	cfg.RegisterFlagsWithPrefix("experimental.tsdb.", f)
+}
+
+// RegisterFlags registers the flags for filesystem storage with the specified prefix
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.Directory, prefix+"filesystem.dir", "", "Local filesystem storage directory.")
 }

--- a/pkg/storage/backend/gcs/config.go
+++ b/pkg/storage/backend/gcs/config.go
@@ -12,8 +12,13 @@ type Config struct {
 	ServiceAccount flagext.Secret `yaml:"service_account"`
 }
 
-// RegisterFlags registers the flags for TSDB GCS storage
+// RegisterFlags registers the flags for TSDB GCS storage with the TSDB prefix
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.BucketName, "experimental.tsdb.gcs.bucket-name", "", "GCS bucket name")
-	f.Var(&cfg.ServiceAccount, "experimental.tsdb.gcs.service-account", "JSON representing either a Google Developers Console client_credentials.json file or a Google Developers service account key file. If empty, fallback to Google default logic.")
+	cfg.RegisterFlagsWithPrefix("experimental.tsdb.", f)
+}
+
+// RegisterFlags registers the flags for GCS storage with the specified prefix
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.BucketName, prefix+"gcs.bucket-name", "", "GCS bucket name")
+	f.Var(&cfg.ServiceAccount, prefix+"gcs.service-account", "JSON representing either a Google Developers Console client_credentials.json file or a Google Developers service account key file. If empty, fallback to Google default logic.")
 }

--- a/pkg/storage/backend/s3/config.go
+++ b/pkg/storage/backend/s3/config.go
@@ -17,9 +17,14 @@ type Config struct {
 
 // RegisterFlags registers the flags for TSDB s3 storage
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.AccessKeyID, "experimental.tsdb.s3.access-key-id", "", "S3 access key ID")
-	f.Var(&cfg.SecretAccessKey, "experimental.tsdb.s3.secret-access-key", "S3 secret access key")
-	f.StringVar(&cfg.BucketName, "experimental.tsdb.s3.bucket-name", "", "S3 bucket name")
-	f.StringVar(&cfg.Endpoint, "experimental.tsdb.s3.endpoint", "", "S3 endpoint without schema")
-	f.BoolVar(&cfg.Insecure, "experimental.tsdb.s3.insecure", false, "If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.")
+	cfg.RegisterFlagsWithPrefix("experimental.tsdb.", f)
+}
+
+// RegisterFlags registers the flags for s3 storage with the specified prefix
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.AccessKeyID, prefix+"s3.access-key-id", "", "S3 access key ID")
+	f.Var(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "S3 secret access key")
+	f.StringVar(&cfg.BucketName, prefix+"s3.bucket-name", "", "S3 bucket name")
+	f.StringVar(&cfg.Endpoint, prefix+"s3.endpoint", "", "S3 endpoint without schema")
+	f.BoolVar(&cfg.Insecure, prefix+"s3.insecure", false, "If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.")
 }


### PR DESCRIPTION
**What this PR does**:

As a next step for #2262 this PR transitions the ruler to using the Thanos bucket client instead of the chunk object client.

**Which issue(s) this PR fixes**:
Related: #2262 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
