### PR TITLE
Update prometheus-frontend.md

### DIFF
--- a/docs/configuration/prometheus-frontend.md
+++ b/docs/configuration/prometheus-frontend.md
@@ -62,4 +62,5 @@ query_range:
 frontend:
   log_queries_longer_than: 1s
   compress_responses: true
+  downstream_url: prometheus.mydomain.com
 ```

--- a/docs/configuration/prometheus-frontend.md
+++ b/docs/configuration/prometheus-frontend.md
@@ -62,5 +62,7 @@ query_range:
 frontend:
   log_queries_longer_than: 1s
   compress_responses: true
-  downstream_url: prometheus.mydomain.com
+
+  # The Prometheus URL to which the query-frontend should connect to.
+  downstream_url: http://prometheus.mydomain.com
 ```

--- a/docs/configuration/prometheus-frontend.yml
+++ b/docs/configuration/prometheus-frontend.yml
@@ -54,3 +54,6 @@ query_range:
 frontend:
   log_queries_longer_than: 1s
   compress_responses: true
+
+  # The Prometheus URL to which the query-frontend should connect to.
+  downstream_url: http://prometheus.mydomain.com


### PR DESCRIPTION
I think if you are running the Cortex query frontend alone you basically always want to / need to configure the downstream_url.
Therefore it should be part of the default config for this usecase.

