### PR TITLE
Added lint check to disallow golang.org/x/net/context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ lint:
 	golangci-lint run
 
 	# Ensure no blacklisted package is imported.
-	faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert" ./pkg/... ./cmd/... ./tools/... ./integration/...
+	faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,golang.org/x/net/context=context" ./pkg/... ./cmd/... ./tools/... ./integration/...
 
 	# Validate Kubernetes spec files. Requires:
 	# https://kubeval.instrumenta.dev


### PR DESCRIPTION
**What this PR does**:
While reviewing the PR #2220 I've seen that in a while was used `golang.org/x/net/context` instead of `context`. For recent versions of Go, `golang.org/x/net/context` is just a wrapper over `context` and I think we should check it with the linter.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
