### PR TITLE
return directories in respose from List calls to object stores

### DIFF
--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -168,9 +168,10 @@ func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object
 	})
 }
 
-// List only objects from the store non-recursively
-func (a *S3ObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, error) {
+// List objects and common-prefixes i.e synthetic directories from the store non-recursively
+func (a *S3ObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []string, error) {
 	var storageObjects []chunk.StorageObject
+	var commonPrefixes []string
 
 	for i := range a.bucketNames {
 		err := instrument.CollectedRequest(ctx, "S3.List", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
@@ -193,6 +194,10 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stora
 					})
 				}
 
+				for _, commonPrefix := range output.CommonPrefixes {
+					commonPrefixes = append(commonPrefixes, commonPrefix.String())
+				}
+
 				if !*output.IsTruncated {
 					// No more results to fetch
 					break
@@ -205,9 +210,9 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stora
 		})
 
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return storageObjects, nil
+	return storageObjects, commonPrefixes, nil
 }

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -169,9 +169,9 @@ func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object
 }
 
 // List objects and common-prefixes i.e synthetic directories from the store non-recursively
-func (a *S3ObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []string, error) {
+func (a *S3ObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	var storageObjects []chunk.StorageObject
-	var commonPrefixes []string
+	var commonPrefixes []chunk.StorageCommonPrefix
 
 	for i := range a.bucketNames {
 		err := instrument.CollectedRequest(ctx, "S3.List", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
@@ -195,7 +195,7 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stora
 				}
 
 				for _, commonPrefix := range output.CommonPrefixes {
-					commonPrefixes = append(commonPrefixes, commonPrefix.String())
+					commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(commonPrefix.String()))
 				}
 
 				if !*output.IsTruncated {

--- a/pkg/chunk/azure/blob_storage_client.go
+++ b/pkg/chunk/azure/blob_storage_client.go
@@ -168,9 +168,9 @@ func (b *BlobStorage) newPipeline() (pipeline.Pipeline, error) {
 }
 
 // List objects and common-prefixes i.e synthetic directories from the store non-recursively
-func (b *BlobStorage) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []string, error) {
+func (b *BlobStorage) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	var storageObjects []chunk.StorageObject
-	var commonPrefixes []string
+	var commonPrefixes []chunk.StorageCommonPrefix
 
 	for marker := (azblob.Marker{}); marker.NotDone(); {
 		if ctx.Err() != nil {
@@ -194,7 +194,7 @@ func (b *BlobStorage) List(ctx context.Context, prefix string) ([]chunk.StorageO
 
 		// Process the BlobPrefixes so called commonPrefixes or synthetic directories in the listed synthetic directory
 		for _, blobPrefix := range listBlob.Segment.BlobPrefixes {
-			commonPrefixes = append(commonPrefixes, blobPrefix.Name)
+			commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(blobPrefix.Name))
 		}
 	}
 

--- a/pkg/chunk/azure/blob_storage_client.go
+++ b/pkg/chunk/azure/blob_storage_client.go
@@ -167,18 +167,19 @@ func (b *BlobStorage) newPipeline() (pipeline.Pipeline, error) {
 	}), nil
 }
 
-// List only objects from the store non-recursively
-func (b *BlobStorage) List(ctx context.Context, prefix string) ([]chunk.StorageObject, error) {
+// List objects and common-prefixes i.e synthetic directories from the store non-recursively
+func (b *BlobStorage) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []string, error) {
 	var storageObjects []chunk.StorageObject
+	var commonPrefixes []string
 
 	for marker := (azblob.Marker{}); marker.NotDone(); {
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		}
 
 		listBlob, err := b.containerURL.ListBlobsHierarchySegment(ctx, marker, b.delimiter, azblob.ListBlobsSegmentOptions{Prefix: prefix})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		marker = listBlob.NextMarker
@@ -190,9 +191,14 @@ func (b *BlobStorage) List(ctx context.Context, prefix string) ([]chunk.StorageO
 				ModifiedAt: blobInfo.Properties.LastModified,
 			})
 		}
+
+		// Process the BlobPrefixes so called commonPrefixes or synthetic directories in the listed synthetic directory
+		for _, blobPrefix := range listBlob.Segment.BlobPrefixes {
+			commonPrefixes = append(commonPrefixes, blobPrefix.Name)
+		}
 	}
 
-	return storageObjects, nil
+	return storageObjects, commonPrefixes, nil
 }
 
 func (b *BlobStorage) DeleteObject(ctx context.Context, chunkID string) error {

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -107,14 +107,15 @@ func (s *GCSObjectClient) PutObject(ctx context.Context, objectKey string, objec
 	return nil
 }
 
-// List only objects from the store non-recursively
-func (s *GCSObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, error) {
+// List objects and common-prefixes i.e synthetic directories from the store non-recursively
+func (s *GCSObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []string, error) {
 	var storageObjects []chunk.StorageObject
+	var commonPrefixes []string
 
 	iter := s.bucket.Objects(ctx, &storage.Query{Prefix: prefix, Delimiter: s.delimiter})
 	for {
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		}
 
 		attr, err := iter.Next()
@@ -122,12 +123,12 @@ func (s *GCSObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stor
 			if err == iterator.Done {
 				break
 			}
-			return nil, err
+			return nil, nil, err
 		}
 
 		// When doing query with Delimiter, Prefix is the only field set for entries which represent synthetic "directory entries".
-		// We do not want to consider those entries since we are doing only non-recursive listing of objects for now.
 		if attr.Name == "" {
+			commonPrefixes = append(commonPrefixes, attr.Prefix)
 			continue
 		}
 
@@ -137,7 +138,7 @@ func (s *GCSObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stor
 		})
 	}
 
-	return storageObjects, nil
+	return storageObjects, commonPrefixes, nil
 }
 
 // DeleteObject deletes the specified object key from the configured GCS bucket. If the

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -108,9 +108,9 @@ func (s *GCSObjectClient) PutObject(ctx context.Context, objectKey string, objec
 }
 
 // List objects and common-prefixes i.e synthetic directories from the store non-recursively
-func (s *GCSObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []string, error) {
+func (s *GCSObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	var storageObjects []chunk.StorageObject
-	var commonPrefixes []string
+	var commonPrefixes []chunk.StorageCommonPrefix
 
 	iter := s.bucket.Objects(ctx, &storage.Query{Prefix: prefix, Delimiter: s.delimiter})
 	for {
@@ -128,7 +128,7 @@ func (s *GCSObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stor
 
 		// When doing query with Delimiter, Prefix is the only field set for entries which represent synthetic "directory entries".
 		if attr.Name == "" {
-			commonPrefixes = append(commonPrefixes, attr.Prefix)
+			commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(attr.Prefix))
 			continue
 		}
 

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -374,7 +374,7 @@ func (m *MockStorage) DeleteObject(ctx context.Context, objectKey string) error 
 	return nil
 }
 
-func (m *MockStorage) List(ctx context.Context, prefix string) ([]StorageObject, error) {
+func (m *MockStorage) List(ctx context.Context, prefix string) ([]StorageObject, []string, error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -384,7 +384,7 @@ func (m *MockStorage) List(ctx context.Context, prefix string) ([]StorageObject,
 		storageObjects = append(storageObjects, StorageObject{Key: key})
 	}
 
-	return storageObjects, nil
+	return storageObjects, []string{}, nil
 }
 
 type mockWriteBatch struct {

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -374,7 +374,7 @@ func (m *MockStorage) DeleteObject(ctx context.Context, objectKey string) error 
 	return nil
 }
 
-func (m *MockStorage) List(ctx context.Context, prefix string) ([]StorageObject, []string, error) {
+func (m *MockStorage) List(ctx context.Context, prefix string) ([]StorageObject, []StorageCommonPrefix, error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -384,7 +384,7 @@ func (m *MockStorage) List(ctx context.Context, prefix string) ([]StorageObject,
 		storageObjects = append(storageObjects, StorageObject{Key: key})
 	}
 
-	return storageObjects, []string{}, nil
+	return storageObjects, []StorageCommonPrefix{}, nil
 }
 
 type mockWriteBatch struct {

--- a/pkg/chunk/local/fs_object_client.go
+++ b/pkg/chunk/local/fs_object_client.go
@@ -91,9 +91,9 @@ func (f *FSObjectClient) PutObject(ctx context.Context, objectKey string, object
 }
 
 // List objects and common-prefixes i.e directories from the store non-recursively
-func (f *FSObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []string, error) {
+func (f *FSObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	var storageObjects []chunk.StorageObject
-	var commonPrefixes []string
+	var commonPrefixes []chunk.StorageCommonPrefix
 
 	folderPath := filepath.Join(f.cfg.Directory, prefix)
 
@@ -114,7 +114,7 @@ func (f *FSObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stora
 		nameWithPrefix := filepath.Join(prefix, fileInfo.Name())
 
 		if fileInfo.IsDir() {
-			commonPrefixes = append(commonPrefixes, nameWithPrefix)
+			commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(nameWithPrefix+chunk.DirDelim))
 			continue
 		}
 		storageObjects = append(storageObjects, chunk.StorageObject{

--- a/pkg/chunk/local/fs_object_client.go
+++ b/pkg/chunk/local/fs_object_client.go
@@ -90,35 +90,40 @@ func (f *FSObjectClient) PutObject(ctx context.Context, objectKey string, object
 	return fl.Close()
 }
 
-// List only objects from the store non-recursively
-func (f *FSObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, error) {
+// List objects and common-prefixes i.e directories from the store non-recursively
+func (f *FSObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []string, error) {
 	var storageObjects []chunk.StorageObject
+	var commonPrefixes []string
+
 	folderPath := filepath.Join(f.cfg.Directory, prefix)
 
 	_, err := os.Stat(folderPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return storageObjects, nil
+			return storageObjects, commonPrefixes, nil
 		}
-		return nil, err
+		return nil, nil, err
 	}
 
 	filesInfo, err := ioutil.ReadDir(folderPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, fileInfo := range filesInfo {
+		nameWithPrefix := filepath.Join(prefix, fileInfo.Name())
+
 		if fileInfo.IsDir() {
+			commonPrefixes = append(commonPrefixes, nameWithPrefix)
 			continue
 		}
 		storageObjects = append(storageObjects, chunk.StorageObject{
-			Key:        filepath.Join(prefix, fileInfo.Name()),
+			Key:        nameWithPrefix,
 			ModifiedAt: fileInfo.ModTime(),
 		})
 	}
 
-	return storageObjects, nil
+	return storageObjects, commonPrefixes, nil
 }
 
 func (f *FSObjectClient) DeleteObject(ctx context.Context, objectKey string) error {

--- a/pkg/chunk/purger/purger_test.go
+++ b/pkg/chunk/purger/purger_test.go
@@ -189,7 +189,7 @@ func TestDataPurger_BuildPlan(t *testing.T) {
 				require.NoError(t, err)
 				planPath := fmt.Sprintf("%s:%s/", userID, deleteRequest.RequestID)
 
-				plans, err := storageClient.List(context.Background(), planPath)
+				plans, _, err := storageClient.List(context.Background(), planPath)
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedNumberOfPlans, len(plans))
 

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -65,7 +65,7 @@ type ReadBatchIterator interface {
 type ObjectClient interface {
 	PutObject(ctx context.Context, objectKey string, object io.ReadSeeker) error
 	GetObject(ctx context.Context, objectKey string) (io.ReadCloser, error)
-	List(ctx context.Context, prefix string) ([]StorageObject, error)
+	List(ctx context.Context, prefix string) ([]StorageObject, []string, error)
 	DeleteObject(ctx context.Context, objectKey string) error
 	Stop()
 }

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -65,7 +65,7 @@ type ReadBatchIterator interface {
 type ObjectClient interface {
 	PutObject(ctx context.Context, objectKey string, object io.ReadSeeker) error
 	GetObject(ctx context.Context, objectKey string) (io.ReadCloser, error)
-	List(ctx context.Context, prefix string) ([]StorageObject, []string, error)
+	List(ctx context.Context, prefix string) ([]StorageObject, []StorageCommonPrefix, error)
 	DeleteObject(ctx context.Context, objectKey string) error
 	Stop()
 }
@@ -75,3 +75,7 @@ type StorageObject struct {
 	Key        string
 	ModifiedAt time.Time
 }
+
+// StorageCommonPrefix represents a common prefix aka a synthetic directory in Object Store.
+// It is guaranteed to always end with DirDelim
+type StorageCommonPrefix string

--- a/pkg/ruler/rules/objectclient/rule_store.go
+++ b/pkg/ruler/rules/objectclient/rule_store.go
@@ -64,7 +64,7 @@ func (o *RuleStore) getRuleGroup(ctx context.Context, objectKey string) (*rules.
 
 // ListAllRuleGroups returns all the active rule groups
 func (o *RuleStore) ListAllRuleGroups(ctx context.Context) (map[string]rules.RuleGroupList, error) {
-	ruleGroupObjects, err := o.client.List(ctx, generateRuleObjectKey("", "", ""))
+	ruleGroupObjects, _, err := o.client.List(ctx, generateRuleObjectKey("", "", ""))
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (o *RuleStore) ListAllRuleGroups(ctx context.Context) (map[string]rules.Rul
 
 // ListRuleGroups returns all the active rule groups for a user
 func (o *RuleStore) ListRuleGroups(ctx context.Context, userID, namespace string) (rules.RuleGroupList, error) {
-	ruleGroupObjects, err := o.client.List(ctx, generateRuleObjectKey(userID, namespace, ""))
+	ruleGroupObjects, _, err := o.client.List(ctx, generateRuleObjectKey(userID, namespace, ""))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds list of directories(synthetic directories in object stores like S3, GCS and Azure) in the response from List calls to `chunk.ObjectStore`.
This would be helpful in custom `TableClient` that I need to implement in Loki for BoltDB Shipper.
It would be used in `TableClient.ListTables` call for listing all the directories that are there in the store.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
