### PR TITLE
Refactored gRPC clients pool to not depend on ReadRing

### DIFF
--- a/pkg/distributor/ingester_client_pool.go
+++ b/pkg/distributor/ingester_client_pool.go
@@ -38,5 +38,5 @@ func NewPool(cfg PoolConfig, ring ring.ReadRing, factory ring_client.PoolFactory
 		HealthCheckTimeout: cfg.RemoteTimeout,
 	}
 
-	return ring_client.NewPool("ingester", poolCfg, ring, factory, clients, logger)
+	return ring_client.NewPool("ingester", poolCfg, ring_client.NewRingServiceDiscovery(ring), factory, clients, logger)
 }

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -31,7 +31,7 @@ type blocksStoreReplicationSet struct {
 func newBlocksStoreReplicationSet(storesRing *ring.Ring, logger log.Logger, reg prometheus.Registerer) (*blocksStoreReplicationSet, error) {
 	s := &blocksStoreReplicationSet{
 		storesRing:  storesRing,
-		clientsPool: newStoreGatewayClientPool(storesRing, logger, reg),
+		clientsPool: newStoreGatewayClientPool(client.NewRingServiceDiscovery(storesRing), logger, reg),
 	}
 
 	var err error

--- a/pkg/querier/store_gateway_client.go
+++ b/pkg/querier/store_gateway_client.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/ring/client"
 	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
@@ -59,7 +58,7 @@ func (c *storeGatewayClient) String() string {
 	return c.conn.Target()
 }
 
-func newStoreGatewayClientPool(r ring.ReadRing, logger log.Logger, reg prometheus.Registerer) *client.Pool {
+func newStoreGatewayClientPool(discovery client.PoolServiceDiscovery, logger log.Logger, reg prometheus.Registerer) *client.Pool {
 	// We prefer sane defaults instead of exposing further config options.
 	clientCfg := grpcclient.Config{
 		MaxRecvMsgSize:      100 << 20,
@@ -83,5 +82,5 @@ func newStoreGatewayClientPool(r ring.ReadRing, logger log.Logger, reg prometheu
 		ConstLabels: map[string]string{"client": "querier"},
 	})
 
-	return client.NewPool("store-gateway", poolCfg, r, newStoreGatewayClientFactory(clientCfg, reg), clientsCount, logger)
+	return client.NewPool("store-gateway", poolCfg, discovery, newStoreGatewayClientFactory(clientCfg, reg), clientsCount, logger)
 }

--- a/pkg/ring/client/pool.go
+++ b/pkg/ring/client/pool.go
@@ -13,7 +13,6 @@ import (
 	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
@@ -28,6 +27,12 @@ type PoolClient interface {
 // PoolFactory defines the signature for a client factory.
 type PoolFactory func(addr string) (PoolClient, error)
 
+// PoolServiceDiscovery defines the signature of a function returning the list
+// of known service endpoints. This function is used to remove stale clients from
+// the pool (a stale client is a client connected to a service endpoint no more
+// active).
+type PoolServiceDiscovery func() ([]string, error)
+
 // PoolConfig is config for creating a Pool.
 type PoolConfig struct {
 	CheckInterval      time.Duration
@@ -40,7 +45,7 @@ type Pool struct {
 	services.Service
 
 	cfg        PoolConfig
-	ring       ring.ReadRing
+	discovery  PoolServiceDiscovery
 	factory    PoolFactory
 	logger     log.Logger
 	clientName string
@@ -52,10 +57,10 @@ type Pool struct {
 }
 
 // NewPool creates a new Pool.
-func NewPool(clientName string, cfg PoolConfig, ring ring.ReadRing, factory PoolFactory, clientsMetric prometheus.Gauge, logger log.Logger) *Pool {
+func NewPool(clientName string, cfg PoolConfig, discovery PoolServiceDiscovery, factory PoolFactory, clientsMetric prometheus.Gauge, logger log.Logger) *Pool {
 	p := &Pool{
 		cfg:           cfg,
-		ring:          ring,
+		discovery:     discovery,
 		factory:       factory,
 		logger:        logger,
 		clientName:    clientName,
@@ -127,7 +132,7 @@ func (p *Pool) RemoveClientFor(addr string) {
 	}
 }
 
-// RegisteredAddresses returns all the addresses that a client is cached for
+// RegisteredAddresses returns all the service addresses for which there's an active client.
 func (p *Pool) RegisteredAddresses() []string {
 	result := []string{}
 	p.RLock()
@@ -146,24 +151,19 @@ func (p *Pool) Count() int {
 }
 
 func (p *Pool) removeStaleClients() {
-	// Only if this pool is based on the ring.
-	if p.ring == nil {
+	// Only if service discovery has been configured.
+	if p.discovery == nil {
 		return
 	}
 
-	clients := map[string]struct{}{}
-	replicationSet, err := p.ring.GetAll()
+	serviceAddrs, err := p.discovery()
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error removing stale clients", "err", err)
 		return
 	}
 
-	for _, ing := range replicationSet.Ingesters {
-		clients[ing.Addr] = struct{}{}
-	}
-
 	for _, addr := range p.RegisteredAddresses() {
-		if _, ok := clients[addr]; ok {
+		if util.StringsContain(serviceAddrs, addr) {
 			continue
 		}
 		level.Info(util.Logger).Log("msg", "removing stale client", "addr", addr)

--- a/pkg/ring/client/pool_test.go
+++ b/pkg/ring/client/pool_test.go
@@ -13,7 +13,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -35,14 +34,6 @@ func (i mockClient) Close() error {
 
 func (i mockClient) Watch(ctx context.Context, in *grpc_health_v1.HealthCheckRequest, opts ...grpc.CallOption) (grpc_health_v1.Health_WatchClient, error) {
 	return nil, status.Error(codes.Unimplemented, "Watching is not supported")
-}
-
-type mockReadRing struct {
-	ring.ReadRing
-}
-
-func (mockReadRing) GetAll() (ring.ReplicationSet, error) {
-	return ring.ReplicationSet{}, nil
 }
 
 func TestHealthCheck(t *testing.T) {
@@ -81,7 +72,7 @@ func TestPoolCache(t *testing.T) {
 		CheckInterval:      10 * time.Second,
 	}
 
-	pool := NewPool("test", cfg, mockReadRing{}, factory, nil, log.NewNopLogger())
+	pool := NewPool("test", cfg, nil, factory, nil, log.NewNopLogger())
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), pool))
 	defer services.StopAndAwaitTerminated(context.Background(), pool) //nolint:errcheck
 

--- a/pkg/ring/client/ring_service_discovery.go
+++ b/pkg/ring/client/ring_service_discovery.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"github.com/cortexproject/cortex/pkg/ring"
+)
+
+func NewRingServiceDiscovery(r ring.ReadRing) PoolServiceDiscovery {
+	return func() ([]string, error) {
+		replicationSet, err := r.GetAll()
+		if err != nil {
+			return nil, err
+		}
+
+		var addrs []string
+		for _, instance := range replicationSet.Ingesters {
+			addrs = append(addrs, instance.Addr)
+		}
+		return addrs, nil
+	}
+}

--- a/pkg/ring/client/ring_service_discovery_test.go
+++ b/pkg/ring/client/ring_service_discovery_test.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cortexproject/cortex/pkg/ring"
+)
+
+func TestNewRingServiceDiscovery(t *testing.T) {
+	tests := map[string]struct {
+		ringReplicationSet ring.ReplicationSet
+		ringErr            error
+		expectedAddrs      []string
+		expectedErr        error
+	}{
+		"discovery failure": {
+			ringErr:     errors.New("mocked error"),
+			expectedErr: errors.New("mocked error"),
+		},
+		"empty replication set": {
+			ringReplicationSet: ring.ReplicationSet{
+				Ingesters: []ring.IngesterDesc{},
+			},
+			expectedAddrs: nil,
+		},
+		"replication containing some endpoints": {
+			ringReplicationSet: ring.ReplicationSet{
+				Ingesters: []ring.IngesterDesc{
+					{Addr: "1.1.1.1"},
+					{Addr: "2.2.2.2"},
+				},
+			},
+			expectedAddrs: []string{"1.1.1.1", "2.2.2.2"},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			r := &mockReadRing{}
+			r.mockedReplicationSet = testData.ringReplicationSet
+			r.mockedErr = testData.ringErr
+
+			d := NewRingServiceDiscovery(r)
+			addrs, err := d()
+			assert.Equal(t, testData.expectedErr, err)
+			assert.Equal(t, testData.expectedAddrs, addrs)
+		})
+	}
+}
+
+type mockReadRing struct {
+	ring.ReadRing
+
+	mockedReplicationSet ring.ReplicationSet
+	mockedErr            error
+}
+
+func (m *mockReadRing) GetAll() (ring.ReplicationSet, error) {
+	return m.mockedReplicationSet, m.mockedErr
+}


### PR DESCRIPTION
**What this PR does**:
While working on #2469, I received [this feedback](https://github.com/cortexproject/cortex/pull/2469#discussion_r410044504) from @pstibrany:
> I think we missed an opportunity here... client.Pool should not depend on ring. It only needs a function to get a list of all clients. (New PR)

In this PR I'm proposing a refactoring to decouple the client `Pool` from the `ReadRing`, just taking in input a function to run the service discovery.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
