### PR TITLE
Ensure queries return correctly during rolling upgrades of stateful cluster with RF 3 and only 3 nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ This is the first major release of Cortex. We made a lot of **breaking changes**
 * [BUGFIX] Fixed etcd client keepalive settings. #2278
 * [BUGFIX] Register the metrics of the WAL. #2295
 * [BUXFIX] Experimental TSDB: fixed error handling when ingesting out of bound samples. #2342
+* [BUGFIX] Fix gaps when querying ingesters with replication factor = 3 and 2 ingesters in the cluster. #2503
 
 ### Known issues
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -434,7 +434,7 @@ func TestDistributor_PushQuery(t *testing.T) {
 
 				// When we have less ingesters than replication factor, any failed ingester
 				// will cause a failure.
-				if shardByAllLabels && numIngesters < 3 && happyIngesters < 2 {
+				if numIngesters < 3 && happyIngesters < 2 {
 					testcases = append(testcases, testcase{
 						name:             fmt.Sprintf("ExpectFail(shardByAllLabels=%v,numIngester=%d,happyIngester=%d)", shardByAllLabels, numIngesters, happyIngesters),
 						numIngesters:     numIngesters,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -407,7 +407,7 @@ func TestDistributor_PushQuery(t *testing.T) {
 	// Run every test in both sharding modes.
 	for _, shardByAllLabels := range []bool{true, false} {
 
-		// Test with between 3 and 10 ingesters.
+		// Test with between 2 and 10 ingesters.
 		for numIngesters := 2; numIngesters < 10; numIngesters++ {
 
 			// Test with between 0 and numIngesters "happy" ingesters.

--- a/pkg/ring/kv/consul/client_test.go
+++ b/pkg/ring/kv/consul/client_test.go
@@ -21,7 +21,7 @@ func writeValuesToKV(client *Client, key string, start, end int, sleep time.Dura
 		defer close(ch)
 		for i := start; i <= end; i++ {
 			level.Debug(util.Logger).Log("ts", time.Now(), "msg", "writing value", "val", i)
-			_, _ = client.Put(&consul.KVPair{Key: key, Value: []byte(fmt.Sprintf("%d", i))}, nil)
+			_, _ = client.kv.Put(&consul.KVPair{Key: key, Value: []byte(fmt.Sprintf("%d", i))}, nil)
 			time.Sleep(sleep)
 		}
 	}()
@@ -92,7 +92,7 @@ func TestReset(t *testing.T) {
 		defer close(ch)
 		for i := 0; i <= max; i++ {
 			level.Debug(util.Logger).Log("ts", time.Now(), "msg", "writing value", "val", i)
-			_, _ = c.Put(&consul.KVPair{Key: key, Value: []byte(fmt.Sprintf("%d", i))}, nil)
+			_, _ = c.kv.Put(&consul.KVPair{Key: key, Value: []byte(fmt.Sprintf("%d", i))}, nil)
 			if i == 1 {
 				c.kv.(*mockKV).ResetIndex()
 			}
@@ -142,11 +142,11 @@ func TestWatchKeyWithNoStartValue(t *testing.T) {
 
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		_, err := c.Put(&consul.KVPair{Key: key, Value: []byte("start")}, nil)
+		_, err := c.kv.Put(&consul.KVPair{Key: key, Value: []byte("start")}, nil)
 		require.NoError(t, err)
 
 		time.Sleep(100 * time.Millisecond)
-		_, err = c.Put(&consul.KVPair{Key: key, Value: []byte("end")}, nil)
+		_, err = c.kv.Put(&consul.KVPair{Key: key, Value: []byte("end")}, nil)
 		require.NoError(t, err)
 	}()
 

--- a/pkg/ring/replication_strategy.go
+++ b/pkg/ring/replication_strategy.go
@@ -34,7 +34,6 @@ func (s *DefaultReplicationStrategy) Filter(ingesters []IngesterDesc, op Operati
 	}
 
 	minSuccess := (replicationFactor / 2) + 1
-	maxFailure := replicationFactor - minSuccess
 
 	// Skip those that have not heartbeated in a while. NB these are still
 	// included in the calculation of minSuccess, so if too many failed ingesters
@@ -44,19 +43,18 @@ func (s *DefaultReplicationStrategy) Filter(ingesters []IngesterDesc, op Operati
 			i++
 		} else {
 			ingesters = append(ingesters[:i], ingesters[i+1:]...)
-			maxFailure--
 		}
 	}
 
 	// This is just a shortcut - if there are not minSuccess available ingesters,
 	// after filtering out dead ones, don't even bother trying.
-	if maxFailure < 0 || len(ingesters) < minSuccess {
+	if len(ingesters) < minSuccess {
 		err := fmt.Errorf("at least %d live replicas required, could only find %d",
 			minSuccess, len(ingesters))
 		return nil, 0, err
 	}
 
-	return ingesters, maxFailure, nil
+	return ingesters, len(ingesters) - minSuccess, nil
 }
 
 func (s *DefaultReplicationStrategy) ShouldExtendReplicaSet(ingester IngesterDesc, op Operation) bool {

--- a/pkg/ring/replication_strategy_test.go
+++ b/pkg/ring/replication_strategy_test.go
@@ -28,6 +28,13 @@ func TestRingReplicationStrategy(t *testing.T) {
 			ExpectedError: "at least 1 live replicas required, could only find 0",
 		},
 
+		// Ensure it works for RF=3 and 2 ingesters.
+		{
+			RF:                 3,
+			LiveIngesters:      2,
+			ExpectedMaxFailure: 0,
+		},
+
 		// Ensure it works for the default production config.
 		{
 			RF:                 3,

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -262,7 +262,8 @@ func (r *Ring) GetAll() (ReplicationSet, error) {
 	if numRequired < r.cfg.ReplicationFactor {
 		numRequired = r.cfg.ReplicationFactor
 	}
-	numRequired -= r.cfg.ReplicationFactor / 2
+	maxUnavailable := r.cfg.ReplicationFactor / 2
+	numRequired -= maxUnavailable
 
 	ingesters := make([]IngesterDesc, 0, len(r.ringDesc.Ingesters))
 	for _, ingester := range r.ringDesc.Ingesters {

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -256,24 +256,28 @@ func (r *Ring) GetAll() (ReplicationSet, error) {
 		return ReplicationSet{}, ErrEmptyRing
 	}
 
-	ingesters := make([]IngesterDesc, 0, len(r.ringDesc.Ingesters))
-	maxErrors := r.cfg.ReplicationFactor / 2
+	// Calculate the number of required ingesters;
+	// ensure we always require at least RF-1 when RF=3.
+	numRequired := len(r.ringDesc.Ingesters)
+	if numRequired < r.cfg.ReplicationFactor {
+		numRequired = r.cfg.ReplicationFactor
+	}
+	numRequired -= r.cfg.ReplicationFactor / 2
 
+	ingesters := make([]IngesterDesc, 0, len(r.ringDesc.Ingesters))
 	for _, ingester := range r.ringDesc.Ingesters {
-		if !r.IsHealthy(&ingester, Read) {
-			maxErrors--
-			continue
+		if r.IsHealthy(&ingester, Read) {
+			ingesters = append(ingesters, ingester)
 		}
-		ingesters = append(ingesters, ingester)
 	}
 
-	if maxErrors < 0 {
+	if len(ingesters) < numRequired {
 		return ReplicationSet{}, fmt.Errorf("too many failed ingesters")
 	}
 
 	return ReplicationSet{
 		Ingesters: ingesters,
-		MaxErrors: maxErrors,
+		MaxErrors: len(ingesters) - numRequired,
 	}, nil
 }
 

--- a/pkg/util/test/poll.go
+++ b/pkg/util/test/poll.go
@@ -17,7 +17,7 @@ func Poll(t *testing.T, d time.Duration, want interface{}, have func() interface
 		if reflect.DeepEqual(want, have()) {
 			return
 		}
-		time.Sleep(d / 10)
+		time.Sleep(d / 100)
 	}
 	h := have()
 	if !reflect.DeepEqual(want, h) {


### PR DESCRIPTION
Signed-off-by: Tom Wilkie <tom@grafana.com>

**What this PR does**:

- Use a real ring with mock KV when testing distributor.  This is to tease out errors in the replication logic.
- Extend the distributor tests to cover the case of RF=3 with 2 ingesters.
- Fix ring.GetAll to correctly calculate maxErrors when RF=3 and 2 ingesters.

**Which issue(s) this PR fixes**:
Fixes #2504

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
