### PR TITLE
Re-use buffers when serialising chunks.

### DIFF
--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -386,7 +386,7 @@ func (w *walWrapper) deleteCheckpoints(maxIndex int) (err error) {
 // checkpointSeries write the chunks of the series to the checkpoint.
 func (w *walWrapper) checkpointSeries(cp *wal.WAL, userID string, fp model.Fingerprint, series *memorySeries, wireChunks []client.Chunk) ([]client.Chunk, error) {
 	var err error
-	wireChunks, err = toWireChunks(series.chunkDescs, wireChunks[:0])
+	wireChunks, err = toWireChunks(series.chunkDescs, wireChunks)
 	if err != nil {
 		return wireChunks, err
 	}


### PR DESCRIPTION
Improves performance of ingester handover and WAL checkpoint by
reducing garbage.

Triggered by this memory allocation profile, taken mid-transfer:
```
  Total:      3.81GB     4.07GB (flat, cum) 20.56%
    349            .          .           } 
    350            .          .            
    351            .          .           // The passed wireChunks slice is for re-use. 
    352            .          .           func toWireChunks(descs []*desc, wireChunks []client.Chunk) ([]client.Chunk, error) { 
    353            .          .           	if cap(wireChunks) < len(descs) { 
    354         30MB       30MB           		wireChunks = make([]client.Chunk, 0, len(descs)) 
    355            .          .           	} 
    356            .          .           	wireChunks = wireChunks[:0] 
    357            .          .           	for _, d := range descs { 
    358            .          .           		wireChunk := client.Chunk{ 
    359            .          .           			StartTimestampMs: int64(d.FirstTime), 
    360            .          .           			EndTimestampMs:   int64(d.LastTime), 
    361            .          .           			Encoding:         int32(d.C.Encoding()), 
    362            .          .           		} 
    363            .          .            
    364       3.78GB     3.98GB           		buf := bytes.NewBuffer(make([]byte, 0, d.C.Size())) 
    365            .       64MB           		if err := d.C.Marshal(buf); err != nil { 
    366            .          .           			return nil, err 
    367            .          .           		} 
```

It looks like `QueryStream()` could also reuse its memory, but I didn't look too far into that.

**Checklist**
- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated 
