### PR TITLE
Fix querier HTTP middlewares

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -210,7 +210,7 @@ func (t *Cortex) initQuerier(cfg *Config) (serv services.Service, err error) {
 
 	// Query frontend worker will only be started after all its dependencies are started, not here.
 	// Worker may also be nil, if not configured, which is OK.
-	worker, err := frontend.NewWorker(cfg.Worker, httpgrpc_server.NewServer(handler), util.Logger)
+	worker, err := frontend.NewWorker(cfg.Worker, httpgrpc_server.NewServer(t.server.HTTPMiddleware.Wrap(handler)), util.Logger)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
**What this PR does**:
After #2437, the querier no longer passes requests from the worker to the weaveworks/common server. This means none of the instrumentation/logging middleware is used on the request.

This PR tries to fix it (I manually tested it both running Cortex both in microservices and single-binary mode). It's a **draft PR** because it needs:
1. Weaveworks common change https://github.com/weaveworks/common/pull/189 to be approved and merged, and `vendor/` updated
2. Integration tests to be updated

/cc @joe-elliott 

**Which issue(s) this PR fixes**:
Fixes #2507

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
