### PR TITLE
Querier Metrics Fix

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -305,6 +305,12 @@ func (a *API) RegisterQuerier(queryable storage.Queryable, engine *promql.Engine
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/series", legacyPromHandler, true, "GET", "POST", "DELETE")
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/metadata", legacyPromHandler, true, "GET")
 
+	// if we have externally registered routes then we need to return the server handler
+	//  so that we continue to use all standard middleware
+	if registerRoutesExternally {
+		return a.server.HTTPServer.Handler
+	}
+
 	return router
 }
 


### PR DESCRIPTION
**What this PR does**:
Returns the weaveworks/common server instead of the router.  This restores the usage of weaveworks standard middleware/instrumentation in the querier.

**Which issue(s) this PR fixes**:
Fixes #2507 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
