### PR TITLE
Querier Metrics Fix

### DIFF
--- a/development/tsdb-blocks-storage-s3-single-binary/compose-up.sh
+++ b/development/tsdb-blocks-storage-s3-single-binary/compose-up.sh
@@ -2,6 +2,6 @@
 
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 
-GOOS=linux GOARCH=amd64 go build -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex && \
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex && \
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build cortex-1 && \
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@

--- a/development/tsdb-blocks-storage-s3-single-binary/compose-up.sh
+++ b/development/tsdb-blocks-storage-s3-single-binary/compose-up.sh
@@ -2,6 +2,6 @@
 
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex && \
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex && \
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build cortex-1 && \
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@

--- a/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     image: jaegertracing/all-in-one
     ports:
       - 16686:16686
+      - "14268"
 
   cortex-1:
     build:
@@ -41,8 +42,9 @@ services:
       - consul
       - minio
     environment:
-      - JAEGER_COLLECTOR_URL=http://jaeger:14268
-      - JAEGER_TAGS=cortex=1
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_TAGS=app=cortex-1
       - JAEGER_SAMPLER_TYPE=const
       - JAEGER_SAMPLER_PARAM=1
     ports:
@@ -61,8 +63,9 @@ services:
       - consul
       - minio
     environment:
-      - JAEGER_COLLECTOR_URL=http://jaeger:14268
-      - JAEGER_TAGS=cortex=1
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_TAGS=app=cortex-2
       - JAEGER_SAMPLER_TYPE=const
       - JAEGER_SAMPLER_PARAM=1
     ports:

--- a/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
@@ -26,6 +26,11 @@ services:
     ports:
       - 9090:9090
 
+  jaeger:
+    image: jaegertracing/all-in-one
+    ports:
+      - 16686:16686
+
   cortex-1:
     build:
       context:    .
@@ -35,6 +40,11 @@ services:
     depends_on:
       - consul
       - minio
+    environment:
+      - JAEGER_COLLECTOR_URL=http://jaeger:14268
+      - JAEGER_TAGS=cortex=1
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8001:8001
     volumes:
@@ -50,6 +60,11 @@ services:
     depends_on:
       - consul
       - minio
+    environment:
+      - JAEGER_COLLECTOR_URL=http://jaeger:14268
+      - JAEGER_TAGS=cortex=1
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8002:8002
     volumes:

--- a/development/tsdb-blocks-storage-s3/compose-up.sh
+++ b/development/tsdb-blocks-storage-s3/compose-up.sh
@@ -2,6 +2,6 @@
 
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 
-GOOS=linux GOARCH=amd64 go build -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex && \
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex && \
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build distributor && \
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -34,6 +34,12 @@ services:
     ports:
       - 9090:9090
 
+  jaeger:
+    image: jaegertracing/all-in-one
+    ports:
+      - 16686:16686
+      - "14268"
+
   distributor:
     build:
       context:    .
@@ -43,6 +49,12 @@ services:
     depends_on:
       - consul
       - minio
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_TAGS=app=distributor
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8001:8001
     volumes:
@@ -57,6 +69,12 @@ services:
     depends_on:
       - consul
       - minio
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_TAGS=app=ingester-1
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8002:8002
     volumes:
@@ -72,6 +90,12 @@ services:
     depends_on:
       - consul
       - minio
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_TAGS=app=ingester-2
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8003:8003
     volumes:
@@ -87,6 +111,12 @@ services:
     depends_on:
       - consul
       - minio
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_TAGS=app=querier
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8004:8004
     volumes:
@@ -101,6 +131,12 @@ services:
     depends_on:
       - consul
       - minio
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_TAGS=app=store-gateway-1
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8008:8008
     volumes:
@@ -115,6 +151,12 @@ services:
     depends_on:
       - consul
       - minio
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_TAGS=app=store-gateway-2
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8009:8009
     volumes:
@@ -129,6 +171,12 @@ services:
     depends_on:
       - consul
       - minio
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_TAGS=app=ruler
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8005:8005
     volumes:
@@ -143,6 +191,12 @@ services:
     depends_on:
       - consul
       - minio
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_TAGS=app=compactor
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8006:8006
     volumes:
@@ -157,6 +211,12 @@ services:
     depends_on:
       - consul
       - minio
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_TAGS=app=query-frontend
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8007:8007
     volumes:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -305,6 +305,12 @@ func (a *API) RegisterQuerier(queryable storage.Queryable, engine *promql.Engine
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/series", legacyPromHandler, true, "GET", "POST", "DELETE")
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/metadata", legacyPromHandler, true, "GET")
 
+	// if we have externally registered routes then we need to return the server handler
+	//  so that we continue to use all standard middleware
+	if registerRoutesExternally {
+		return a.server.HTTPServer.Handler
+	}
+
 	return router
 }
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/go-kit/kit/log"
@@ -311,7 +313,9 @@ func (a *API) RegisterQuerier(queryable storage.Queryable, engine *promql.Engine
 		return a.server.HTTPServer.Handler
 	}
 
-	return router
+	return nethttp.MiddlewareFunc(opentracing.GlobalTracer(), router.ServeHTTP, nethttp.OperationNameFunc(func(r *http.Request) string {
+		return "httpGRPCBridge"
+	}))
 }
 
 // RegisterQueryFrontend registers the Prometheus routes supported by the

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -314,7 +314,7 @@ func (a *API) RegisterQuerier(queryable storage.Queryable, engine *promql.Engine
 	}
 
 	return nethttp.MiddlewareFunc(opentracing.GlobalTracer(), router.ServeHTTP, nethttp.OperationNameFunc(func(r *http.Request) string {
-		return "httpGRPCBridge"
+		return "internalQuerier"
 	}))
 }
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -276,8 +276,8 @@ func (a *API) RegisterQuerier(queryable storage.Queryable, engine *promql.Engine
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/chunks", querier.ChunksHandler(queryable), true)
 
 	// these routes are either registered the default server OR to an internal mux.  The internal mux is
-	//  for use in a single binary mode when both the query frontend and the querier would attempt to claim these routes
-	//  TODO:  Add support to expose querier paths with a configurable prefix in single binary mode.
+	// for use in a single binary mode when both the query frontend and the querier would attempt to claim these routes
+	// TODO:  Add support to expose querier paths with a configurable prefix in single binary mode.
 	router := mux.NewRouter()
 	if registerRoutesExternally {
 		router = a.server.HTTP
@@ -308,11 +308,14 @@ func (a *API) RegisterQuerier(queryable storage.Queryable, engine *promql.Engine
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/metadata", legacyPromHandler, true, "GET")
 
 	// if we have externally registered routes then we need to return the server handler
-	//  so that we continue to use all standard middleware
+	// so that we continue to use all standard middleware
 	if registerRoutesExternally {
 		return a.server.HTTPServer.Handler
 	}
 
+	// Since we have a new router and the request will not go trough the default server
+	// HTTP middleware stack, we need to add a middleware to extract the trace context
+	// from the HTTP headers and inject it into the Go context.
 	return nethttp.MiddlewareFunc(opentracing.GlobalTracer(), router.ServeHTTP, nethttp.OperationNameFunc(func(r *http.Request) string {
 		return "internalQuerier"
 	}))


### PR DESCRIPTION
**What this PR does**:
Returns the weaveworks/common server instead of the router. This restores the usage of weaveworks standard middleware/instrumentation in the querier.

**Which issue(s) this PR fixes**:
Fixes #2507

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
