### PR TITLE
Add traceID if possible when using context logger.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   * `cortex_querier_bucket_store_blocks_meta_sync_consistency_delay_seconds` > `cortex_querier_blocks_meta_sync_consistency_delay_seconds`
 * [CHANGE] Experimental TSDB: Modified default values for `compactor.deletion-delay` option from 48h to 12h and `-experimental.tsdb.bucket-store.ignore-deletion-marks-delay` from 24h to 6h. #2414
 * [CHANGE] Experimental WAL: Default value of `-ingester.checkpoint-enabled` changed to `true`. #2416
+* [CHANGE] `trace_id` field in log files has been renamed to `traceID`. #2518
 * [FEATURE] Ruler: The `-ruler.evaluation-delay` flag was added to allow users to configure a default evaluation delay for all rules in cortex. The default value is 0 which is the current behavior. #2423
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
 * [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -103,10 +103,12 @@ func WithContext(ctx context.Context, l log.Logger) log.Logger {
 	// Weaveworks uses "orgs" and "orgID" to represent Cortex users,
 	// even though the code-base generally uses `userID` to refer to the same thing.
 	userID, err := user.ExtractOrgID(ctx)
-	if err != nil {
+	if err != nil && err != user.ErrNoOrgID {
 		return l
 	}
-	l = WithUserID(userID, l)
+	if err == nil {
+		l = WithUserID(userID, l)
+	}
 
 	traceID, ok := middleware.ExtractTraceID(ctx)
 	if !ok {
@@ -127,7 +129,7 @@ func WithUserID(userID string, l log.Logger) log.Logger {
 // its details.
 func WithTraceID(traceID string, l log.Logger) log.Logger {
 	// See note in WithContext.
-	return log.With(l, "trace_id", traceID)
+	return log.With(l, "traceID", traceID)
 }
 
 // CheckFatal prints an error and exits with error code 1 if err is non-nil

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -103,9 +103,6 @@ func WithContext(ctx context.Context, l log.Logger) log.Logger {
 	// Weaveworks uses "orgs" and "orgID" to represent Cortex users,
 	// even though the code-base generally uses `userID` to refer to the same thing.
 	userID, err := user.ExtractOrgID(ctx)
-	if err != nil && err != user.ErrNoOrgID {
-		return l
-	}
 	if err == nil {
 		l = WithUserID(userID, l)
 	}


### PR DESCRIPTION
This change the behaviour of the context logger, there is situation where we don't have an org_id and we would still want to log with the spanID.

I'm also renaming `span_id` to `spanID` because we have inconsistency  with weaveworks server which uses `spanID`. Wasn't sure if this would be welcomed change in weaveworks but I'm can send the PR there.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
