### PR TITLE
Fix logger context when creating a spanLogger from context.

### DIFF
--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -37,12 +37,12 @@ func FromContext(ctx context.Context) *SpanLogger {
 	sp := opentracing.SpanFromContext(ctx)
 	if sp == nil {
 		return &SpanLogger{
-			Logger: util.Logger,
+			Logger: log.With(util.WithContext(ctx, util.Logger),
 			Span:   defaultNoopSpan,
 		}
 	}
 	return &SpanLogger{
-		Logger: util.Logger,
+		Logger: log.With(util.WithContext(ctx, util.Logger),
 		Span:   sp,
 	}
 }

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -37,12 +37,12 @@ func FromContext(ctx context.Context) *SpanLogger {
 	sp := opentracing.SpanFromContext(ctx)
 	if sp == nil {
 		return &SpanLogger{
-			Logger: log.With(util.WithContext(ctx, util.Logger),
+			Logger: util.WithContext(ctx, util.Logger),
 			Span:   defaultNoopSpan,
 		}
 	}
 	return &SpanLogger{
-		Logger: log.With(util.WithContext(ctx, util.Logger),
+		Logger: util.WithContext(ctx, util.Logger),
 		Span:   sp,
 	}
 }


### PR DESCRIPTION
I made this function a while ago to avoid creating a span but still keep logging to a span.

However I just realized this won't log the org id nor the trace id as the original SpanLogger.New


Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>