### PR TITLE
Improve the frontend slow query logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   * `cortex_querier_bucket_store_blocks_meta_sync_consistency_delay_seconds` > `cortex_querier_blocks_meta_sync_consistency_delay_seconds`
 * [CHANGE] Experimental TSDB: Modified default values for `compactor.deletion-delay` option from 48h to 12h and `-experimental.tsdb.bucket-store.ignore-deletion-marks-delay` from 24h to 6h. #2414
 * [CHANGE] Experimental WAL: Default value of `-ingester.checkpoint-enabled` changed to `true`. #2416
+* [CHANGE] Slow query log has a different output now. Previously used `url` field has been replaced with `host` and `path`, and query parameters are logged as individual log fields with `qs_` prefix. #2520
 * [FEATURE] Ruler: The `-ruler.evaluation-delay` flag was added to allow users to configure a default evaluation delay for all rules in cortex. The default value is 0 which is the current behavior. #2423
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
 * [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -23,6 +24,8 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/httpgrpc/server"
 	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 const (
@@ -152,27 +155,26 @@ func (f *Frontend) Handler() http.Handler {
 }
 
 func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
-	userID, err := user.ExtractOrgID(r.Context())
-	if err != nil {
-		server.WriteError(w, err)
-		return
-	}
 
 	startTime := time.Now()
 	resp, err := f.roundTripper.RoundTrip(r)
 	queryResponseTime := time.Since(startTime)
 
 	if f.cfg.LogQueriesLongerThan > 0 && queryResponseTime > f.cfg.LogQueriesLongerThan {
-		logMessage := []interface{}{"msg", "slow query",
-			"org_id", userID,
-			"url", fmt.Sprintf("http://%s", r.Host+r.RequestURI),
+		logMessage := []interface{}{
+			"msg", "slow query",
+			"host", r.Host,
+			"path", r.URL.Path,
 			"time_taken", queryResponseTime.String(),
+		}
+		for k, v := range r.URL.Query() {
+			append(logMessage, fmt.Sprintf("qs_%s", k), strings.Join(v, ","))
 		}
 		pf := r.PostForm.Encode()
 		if pf != "" {
 			logMessage = append(logMessage, "body", pf)
 		}
-		level.Info(f.log).Log(logMessage...)
+		level.Info(util.WithContext(r.Context(), util.Logger)).Log(logMessage...)
 	}
 
 	if err != nil {

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -168,7 +168,7 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 			"time_taken", queryResponseTime.String(),
 		}
 		for k, v := range r.URL.Query() {
-			append(logMessage, fmt.Sprintf("qs_%s", k), strings.Join(v, ","))
+			logMessage = append(logMessage, fmt.Sprintf("qs_%s", k), strings.Join(v, ","))
 		}
 		pf := r.PostForm.Encode()
 		if pf != "" {

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -174,7 +174,7 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 		if pf != "" {
 			logMessage = append(logMessage, "body", pf)
 		}
-		level.Info(util.WithContext(r.Context(), util.Logger)).Log(logMessage...)
+		level.Info(util.WithContext(r.Context(), f.log)).Log(logMessage...)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This will help for the log to be more readable, parsable. I've also added the traceID using the context logger.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

