### PR TITLE
Basic functional options support to metrics assertion in integration tests

### DIFF
--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -5,8 +5,8 @@ package main
 import (
 	"context"
 	"testing"
-	"time"
 
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/integration/e2e"
@@ -80,7 +80,9 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	err = c.SetAlertmanagerConfig(context.Background(), cortexAlertmanagerUserConfigYaml, map[string]string{})
 	require.NoError(t, err)
 
-	require.NoError(t, am.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_alertmanager_config_invalid"}, e2e.WaitMissingMetrics))
+	require.NoError(t, am.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_alertmanager_config_invalid"},
+		e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "user", "user-1")),
+		e2e.WaitMissingMetrics))
 
 	cfg, err := c.GetAlertmanagerConfig(context.Background())
 	require.NoError(t, err)
@@ -96,7 +98,10 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	err = c.DeleteAlertmanagerConfig(context.Background())
 	require.NoError(t, err)
 
-	time.Sleep(2 * time.Second)
+	// The deleted config is applied asynchronously, so we should wait until the metric
+	// disappear for the specific user.
+	require.NoError(t, am.WaitMissingMetric("cortex_alertmanager_config_invalid", e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "user", "user-1"))))
 
 	cfg, err = c.GetAlertmanagerConfig(context.Background())
 	require.Error(t, err)

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -80,8 +80,7 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	err = c.SetAlertmanagerConfig(context.Background(), cortexAlertmanagerUserConfigYaml, map[string]string{})
 	require.NoError(t, err)
 
-	time.Sleep(2 * time.Second)
-	require.NoError(t, am.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_config_invalid"))
+	require.NoError(t, am.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_alertmanager_config_invalid"}, e2e.WaitMissingMetrics))
 
 	cfg, err := c.GetAlertmanagerConfig(context.Background())
 	require.NoError(t, err)

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -100,7 +100,7 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 
 	// The deleted config is applied asynchronously, so we should wait until the metric
 	// disappear for the specific user.
-	require.NoError(t, am.WaitMissingMetric("cortex_alertmanager_config_invalid", e2e.WithLabelMatchers(
+	require.NoError(t, am.WaitRemovedMetric("cortex_alertmanager_config_invalid", e2e.WithLabelMatchers(
 		labels.MustNewMatcher(labels.MatchEqual, "user", "user-1"))))
 
 	cfg, err = c.GetAlertmanagerConfig(context.Background())

--- a/integration/api_ruler_test.go
+++ b/integration/api_ruler_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -137,6 +138,9 @@ func TestRulerAPISingleBinary(t *testing.T) {
 	require.Equal(t, retrievedNamespace[0].Name, "rule")
 
 	// Check to make sure prometheus engine metrics are available for both engine types
-	require.NoError(t, cortex.WaitForMetricWithLabels(e2e.EqualsSingle(0), "prometheus_engine_queries", map[string]string{"engine": "querier"}))
-	require.NoError(t, cortex.WaitForMetricWithLabels(e2e.EqualsSingle(0), "prometheus_engine_queries", map[string]string{"engine": "ruler"}))
+	require.NoError(t, cortex.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"prometheus_engine_queries"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "engine", "querier"))))
+
+	require.NoError(t, cortex.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"prometheus_engine_queries"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "engine", "ruler"))))
 }

--- a/integration/e2e/composite_service.go
+++ b/integration/e2e/composite_service.go
@@ -39,13 +39,17 @@ func (s *CompositeHTTPService) Instances() []*HTTPService {
 // WaitSumMetrics waits for at least one instance of each given metric names to be present and their sums, returning true
 // when passed to given isExpected(...).
 func (s *CompositeHTTPService) WaitSumMetrics(isExpected func(sums ...float64) bool, metricNames ...string) error {
+	return s.WaitSumMetricsWithOptions(isExpected, metricNames)
+}
+
+func (s *CompositeHTTPService) WaitSumMetricsWithOptions(isExpected func(sums ...float64) bool, metricNames []string, opts ...MetricsOption) error {
 	var (
 		sums []float64
 		err  error
 	)
 
 	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
-		sums, err = s.SumMetrics(metricNames)
+		sums, err = s.SumMetrics(metricNames, opts...)
 		if err != nil {
 			return err
 		}
@@ -58,25 +62,6 @@ func (s *CompositeHTTPService) WaitSumMetrics(isExpected func(sums ...float64) b
 	}
 
 	return fmt.Errorf("unable to find metrics %s with expected values. Last values: %v", metricNames, sums)
-}
-
-func (s *CompositeHTTPService) WaitSumMetricWithLabels(isExpected func(sums float64) bool, metricName string, expectedLabels map[string]string) error {
-	lastSum := 0.0
-
-	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
-		lastSum, err := s.SumMetricWithLabels(metricName, expectedLabels)
-		if err != nil {
-			return err
-		}
-
-		if isExpected(lastSum) {
-			return nil
-		}
-
-		s.retryBackoff.Wait()
-	}
-
-	return fmt.Errorf("unable to find metric %s with labels %v with expected value. Last value: %v", metricName, expectedLabels, lastSum)
 }
 
 // SumMetrics returns the sum of the values of each given metric names.
@@ -99,20 +84,4 @@ func (s *CompositeHTTPService) SumMetrics(metricNames []string, opts ...MetricsO
 	}
 
 	return sums, nil
-}
-
-// SumMetricWithLabels returns the sum of the values of metric with matching labels across all services.
-func (s *CompositeHTTPService) SumMetricWithLabels(metricName string, expectedLabels map[string]string) (float64, error) {
-	sum := 0.0
-
-	for _, service := range s.services {
-		s, err := service.SumMetricWithLabels(metricName, expectedLabels)
-		if err != nil {
-			return 0, err
-		}
-
-		sum += s
-	}
-
-	return sum, nil
 }

--- a/integration/e2e/composite_service.go
+++ b/integration/e2e/composite_service.go
@@ -45,7 +45,7 @@ func (s *CompositeHTTPService) WaitSumMetrics(isExpected func(sums ...float64) b
 	)
 
 	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
-		sums, err = s.SumMetrics(metricNames...)
+		sums, err = s.SumMetrics(metricNames)
 		if err != nil {
 			return err
 		}
@@ -80,11 +80,11 @@ func (s *CompositeHTTPService) WaitSumMetricWithLabels(isExpected func(sums floa
 }
 
 // SumMetrics returns the sum of the values of each given metric names.
-func (s *CompositeHTTPService) SumMetrics(metricNames ...string) ([]float64, error) {
+func (s *CompositeHTTPService) SumMetrics(metricNames []string, opts ...MetricsOption) ([]float64, error) {
 	sums := make([]float64, len(metricNames))
 
 	for _, service := range s.services {
-		partials, err := service.SumMetrics(metricNames...)
+		partials, err := service.SumMetrics(metricNames, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/integration/e2e/metrics.go
+++ b/integration/e2e/metrics.go
@@ -6,7 +6,7 @@ import (
 	io_prometheus_client "github.com/prometheus/client_model/go"
 )
 
-func getValue(m *io_prometheus_client.Metric) float64 {
+func getMetricValue(m *io_prometheus_client.Metric) float64 {
 	if m.GetGauge() != nil {
 		return m.GetGauge().GetValue()
 	} else if m.GetCounter() != nil {
@@ -20,10 +20,28 @@ func getValue(m *io_prometheus_client.Metric) float64 {
 	}
 }
 
-func sumValues(family *io_prometheus_client.MetricFamily) float64 {
-	sum := 0.0
+func getMetricCount(m *io_prometheus_client.Metric) float64 {
+	if m.GetHistogram() != nil {
+		return float64(m.GetHistogram().GetSampleCount())
+	} else if m.GetSummary() != nil {
+		return float64(m.GetSummary().GetSampleCount())
+	} else {
+		return 0
+	}
+}
+
+func getValues(family *io_prometheus_client.MetricFamily, get GetMetricValueFunc) []float64 {
+	values := make([]float64, 0, len(family.Metric))
 	for _, m := range family.Metric {
-		sum += getValue(m)
+		values = append(values, get(m))
+	}
+	return values
+}
+
+func sumValues(values []float64) float64 {
+	sum := 0.0
+	for _, v := range values {
+		sum += v
 	}
 	return sum
 }

--- a/integration/e2e/metrics_options.go
+++ b/integration/e2e/metrics_options.go
@@ -7,7 +7,8 @@ import (
 
 var (
 	DefaultMetricsOptions = MetricsOptions{
-		GetValue: getMetricValue,
+		GetValue:           getMetricValue,
+		WaitMissingMetrics: false,
 	}
 )
 
@@ -19,8 +20,9 @@ type MetricsOption func(*MetricsOptions)
 
 // MetricsOptions is the structure holding all options.
 type MetricsOptions struct {
-	GetValue      GetMetricValueFunc
-	LabelMatchers []*labels.Matcher
+	GetValue           GetMetricValueFunc
+	LabelMatchers      []*labels.Matcher
+	WaitMissingMetrics bool
 }
 
 // WithMetricCount is an option to get the histogram/summary count as metric value.
@@ -33,6 +35,12 @@ func WithLabelMatchers(matchers ...*labels.Matcher) MetricsOption {
 	return func(opts *MetricsOptions) {
 		opts.LabelMatchers = matchers
 	}
+}
+
+// WithWaitMissingMetrics is an option to wait whenever an expected metric is missing. If this
+// option is not enabled, will return error on missing metrics.
+func WaitMissingMetrics(opts *MetricsOptions) {
+	opts.WaitMissingMetrics = true
 }
 
 func buildMetricsOptions(opts []MetricsOption) MetricsOptions {

--- a/integration/e2e/metrics_options.go
+++ b/integration/e2e/metrics_options.go
@@ -1,6 +1,9 @@
 package e2e
 
-import io_prometheus_client "github.com/prometheus/client_model/go"
+import (
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/prometheus/prometheus/pkg/labels"
+)
 
 var (
 	DefaultMetricsOptions = MetricsOptions{
@@ -16,12 +19,20 @@ type MetricsOption func(*MetricsOptions)
 
 // MetricsOptions is the structure holding all options.
 type MetricsOptions struct {
-	GetValue GetMetricValueFunc
+	GetValue      GetMetricValueFunc
+	LabelMatchers []*labels.Matcher
 }
 
 // WithMetricCount is an option to get the histogram/summary count as metric value.
 func WithMetricCount(opts *MetricsOptions) {
 	opts.GetValue = getMetricCount
+}
+
+// WithLabelMatchers is an option to filter only matching series.
+func WithLabelMatchers(matchers ...*labels.Matcher) MetricsOption {
+	return func(opts *MetricsOptions) {
+		opts.LabelMatchers = matchers
+	}
 }
 
 func buildMetricsOptions(opts []MetricsOption) MetricsOptions {

--- a/integration/e2e/metrics_options.go
+++ b/integration/e2e/metrics_options.go
@@ -1,0 +1,33 @@
+package e2e
+
+import io_prometheus_client "github.com/prometheus/client_model/go"
+
+var (
+	DefaultMetricsOptions = MetricsOptions{
+		GetValue: getMetricValue,
+	}
+)
+
+// GetMetricValueFunc defined the signature of a function used to get the metric value.
+type GetMetricValueFunc func(m *io_prometheus_client.Metric) float64
+
+// MetricsOption defined the signature of a function used to manipulate options.
+type MetricsOption func(*MetricsOptions)
+
+// MetricsOptions is the structure holding all options.
+type MetricsOptions struct {
+	GetValue GetMetricValueFunc
+}
+
+// WithMetricCount is an option to get the histogram/summary count as metric value.
+func WithMetricCount(opts *MetricsOptions) {
+	opts.GetValue = getMetricCount
+}
+
+func buildMetricsOptions(opts []MetricsOption) MetricsOptions {
+	result := DefaultMetricsOptions
+	for _, opt := range opts {
+		opt(&result)
+	}
+	return result
+}

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -588,7 +588,8 @@ func (s *HTTPService) SumMetrics(metricNames []string, opts ...MetricsOption) ([
 	return sums, nil
 }
 
-func (s *HTTPService) WaitMissingMetric(metricName string, opts ...MetricsOption) error {
+// WaitRemovedMetric waits until a metric disappear from the list of metrics exported by the service.
+func (s *HTTPService) WaitRemovedMetric(metricName string, opts ...MetricsOption) error {
 	options := buildMetricsOptions(opts)
 
 	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {

--- a/integration/getting_started_with_gossiped_ring_test.go
+++ b/integration/getting_started_with_gossiped_ring_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -52,8 +53,13 @@ func TestGettingStartedWithGossipedRing(t *testing.T) {
 	require.NoError(t, cortex2.WaitSumMetrics(e2e.Equals(2*512), "cortex_ring_tokens_total"))
 
 	// We need two "ring members" visible from both Cortex instances
-	require.NoError(t, cortex1.WaitForMetricWithLabels(e2e.EqualsSingle(2), "cortex_ring_members", map[string]string{"name": "ingester", "state": "ACTIVE"}))
-	require.NoError(t, cortex2.WaitForMetricWithLabels(e2e.EqualsSingle(2), "cortex_ring_members", map[string]string{"name": "ingester", "state": "ACTIVE"}))
+	require.NoError(t, cortex1.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	require.NoError(t, cortex2.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	c1, err := e2ecortex.NewClient(cortex1.HTTPEndpoint(), cortex1.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)

--- a/integration/ingester_hand_over_test.go
+++ b/integration/ingester_hand_over_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -88,17 +89,30 @@ func runIngesterHandOverTest(t *testing.T, flags map[string]string, setup func(t
 
 	// Wait a bit to make sure that querier is caught up. Otherwise, we may be querying for data,
 	// while querier still knows about old ingester only.
-	require.NoError(t, querier.WaitForMetricWithLabels(e2e.EqualsSingle(1), "cortex_ring_members", map[string]string{"name": "ingester", "state": "ACTIVE"}))
-	require.NoError(t, querier.WaitForMetricWithLabels(e2e.EqualsSingle(1), "cortex_ring_members", map[string]string{"name": "ingester", "state": "PENDING"}))
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "PENDING"))))
 
 	// Stop ingester-1. This function will return once the ingester-1 is successfully
 	// stopped, which means the transfer to ingester-2 is completed.
 	require.NoError(t, s.Stop(ingester1))
 
 	// Make sure querier now sees only new ingester. We check that by verifying that there is only one ACTIVE, but no PENDING or JOINING ingester.
-	require.NoError(t, querier.WaitForMetricWithLabels(e2e.EqualsSingle(1), "cortex_ring_members", map[string]string{"name": "ingester", "state": "ACTIVE"}))
-	require.NoError(t, querier.WaitForMetricWithLabels(e2e.EqualsSingle(0), "cortex_ring_members", map[string]string{"name": "ingester", "state": "JOINING"}))
-	require.NoError(t, querier.WaitForMetricWithLabels(e2e.EqualsSingle(0), "cortex_ring_members", map[string]string{"name": "ingester", "state": "PENDING"}))
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "JOINING"))))
+
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "PENDING"))))
 
 	// Query the series again.
 	result, err = c.Query("series_1", now)

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -338,7 +339,8 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 			require.NoError(t, cluster.WaitSumMetrics(e2e.Equals(float64(2*cluster.NumInstances())), "cortex_ingester_memory_series_removed_total"))
 
 			// Wait until the querier has discovered the uploaded blocks (discovered both by the querier and store-gateway).
-			require.NoError(t, cluster.WaitSumMetricWithLabels(e2e.EqualsSingle(float64(2*cluster.NumInstances()*2)), "cortex_blocks_meta_synced", map[string]string{"component": "querier"}))
+			require.NoError(t, cluster.WaitSumMetricsWithOptions(e2e.Equals(float64(2*cluster.NumInstances()*2)), []string{"cortex_blocks_meta_synced"}, e2e.WithLabelMatchers(
+				labels.MustNewMatcher(labels.MatchEqual, "component", "querier"))))
 
 			// Wait until the store-gateway has synched the new uploaded blocks.
 			const shippedBlocks = 2

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -203,6 +203,11 @@ func runQueryFrontendTest(t *testing.T, testMissingMetricName bool, setup queryF
 	}
 	require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(numUsers*numQueriesPerUser+extra), "cortex_query_frontend_queries_total"))
 
+	// The number of received request is greater then the query requests because include
+	// requests to /metrics and /ready.
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Greater(numUsers*numQueriesPerUser), []string{"cortex_request_duration_seconds"}, e2e.WithMetricCount))
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Greater(numUsers*numQueriesPerUser), []string{"cortex_request_duration_seconds"}, e2e.WithMetricCount))
+
 	// Ensure no service-specific metrics prefix is used by the wrong service.
 	assertServiceMetricsPrefixes(t, Distributor, distributor)
 	assertServiceMetricsPrefixes(t, Ingester, ingester)


### PR DESCRIPTION
**What this PR does**:
In #2515 (by Joe) I wanted to assert on `cortex_request_duration_seconds` in the integration tests, but I wasn't able because unable to assert on a histogram's count value.

In this PR I'm doing **baby steps** do add functional options support to metrics assection in integration tests. Could be improved in many ways (and I will do in subsequent PRs if this one is approved), but in this PR I would prefer to keep the change set as smallest as possible to validate the basic design.

/cc @bwplotka 

**Which issue(s) this PR fixes**:
Fixes #2975.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
