### PR TITLE
Added PromQL evaluation on top of returned metrics.

### DIFF
--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -21,7 +21,7 @@ func TestAlertmanager(t *testing.T) {
 
 	alertmanager := e2ecortex.NewAlertmanager("alertmanager", AlertmanagerFlags, "")
 	require.NoError(t, s.StartAndWaitReady(alertmanager))
-	require.NoError(t, alertmanager.WaitSumMetrics(e2e.Equals(1), "cortex_alertmanager_configs"))
+	require.NoError(t, alertmanager.WaitForPromQL("cortex_alertmanager_configs{status='valid'} > 0"))
 
 	c, err := e2ecortex.NewClient("", "", alertmanager.HTTPEndpoint(), "", "user-1")
 	require.NoError(t, err)

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -21,7 +21,7 @@ func TestAlertmanager(t *testing.T) {
 
 	alertmanager := e2ecortex.NewAlertmanager("alertmanager", AlertmanagerFlags, "")
 	require.NoError(t, s.StartAndWaitReady(alertmanager))
-	require.NoError(t, alertmanager.WaitForPromQL("cortex_alertmanager_configs{status='valid'} == 1"))
+	require.NoError(t, alertmanager.WaitForPromQL(e2e.Equals(1), "cortex_alertmanager_configs{status='valid'}"))
 
 	c, err := e2ecortex.NewClient("", "", alertmanager.HTTPEndpoint(), "", "user-1")
 	require.NoError(t, err)

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -21,7 +21,7 @@ func TestAlertmanager(t *testing.T) {
 
 	alertmanager := e2ecortex.NewAlertmanager("alertmanager", AlertmanagerFlags, "")
 	require.NoError(t, s.StartAndWaitReady(alertmanager))
-	require.NoError(t, alertmanager.WaitForPromQL("cortex_alertmanager_configs{status='valid'} > 0"))
+	require.NoError(t, alertmanager.WaitForPromQL("cortex_alertmanager_configs{status='valid'} == 1"))
 
 	c, err := e2ecortex.NewClient("", "", alertmanager.HTTPEndpoint(), "", "user-1")
 	require.NoError(t, err)

--- a/integration/e2e/metrics_promql.go
+++ b/integration/e2e/metrics_promql.go
@@ -258,10 +258,9 @@ func newSampleIterator(ts int64, val float64) storage.SeriesIterator {
 
 // Seek implements storage.SeriesIterator.
 func (c *singleSampleIterator) Seek(t int64) bool {
-	if t <= c.ts {
-		return true
-	}
-	return false
+	// If requested timestamp is before what we have, we can "advance".
+	// If it is past it, we cannot.
+	return t <= c.ts
 }
 
 // At implements storage.SeriesIterator.

--- a/integration/e2e/metrics_promql.go
+++ b/integration/e2e/metrics_promql.go
@@ -1,0 +1,284 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+)
+
+var (
+	errTooManyVectorElements = "query returned vector with %d values"
+	errNotScalarOrVector     = errors.New("not a scalar or vector with single value")
+)
+
+func evaluatePromQLWithTextMetrics(expr string, metrics string) (float64, error) {
+	var tp expfmt.TextParser
+	families, err := tp.TextToMetricFamilies(strings.NewReader(metrics))
+	if err != nil {
+		return 0, err
+	}
+
+	now := time.Now()
+
+	samples := convertMetricFamiliesToSamples(int64(model.TimeFromUnixNano(now.UnixNano())), families)
+
+	eng := promql.NewEngine(promql.EngineOpts{
+		Logger:             nil,
+		Reg:                nil,
+		MaxSamples:         1e6,
+		Timeout:            time.Hour, // time.Second,
+		ActiveQueryTracker: nil,
+	})
+
+	queryable := samplesQueryable(samples)
+	q, err := eng.NewInstantQuery(&queryable, expr, now)
+	if err != nil {
+		return 0, err
+	}
+
+	r := q.Exec(context.Background())
+	if r.Err != nil {
+		return 0, r.Err
+	}
+
+	switch s := r.Value.(type) {
+	case promql.Scalar:
+		return s.V, nil
+
+	case promql.Vector:
+		if len(s) == 0 {
+			return 0, nil
+		}
+
+		if len(s) == 1 {
+			return s[0].V, nil
+		}
+
+		return 0, fmt.Errorf(errTooManyVectorElements, len(s))
+	}
+
+	return 0, errNotScalarOrVector
+}
+
+type sample struct {
+	labels map[string]string
+	ts     int64
+	val    float64
+}
+
+func convertMetricFamiliesToSamples(ts int64, mfs map[string]*dto.MetricFamily) []sample {
+	result := []sample{}
+
+	for _, mf := range mfs {
+		switch mf.GetType() {
+		case dto.MetricType_COUNTER:
+			for _, m := range mf.GetMetric() {
+				result = append(result, sample{
+					labels: getLabels(mf.GetName(), m.GetLabel()),
+					ts:     getTimestamp(ts, m.GetTimestampMs()),
+					val:    m.GetCounter().GetValue(),
+				})
+			}
+
+		case dto.MetricType_GAUGE:
+			for _, m := range mf.GetMetric() {
+				result = append(result, sample{
+					labels: getLabels(mf.GetName(), m.GetLabel()),
+					ts:     getTimestamp(ts, m.GetTimestampMs()),
+					val:    m.GetGauge().GetValue(),
+				})
+			}
+
+		case dto.MetricType_SUMMARY:
+			for _, m := range mf.GetMetric() {
+				result = append(result, sample{
+					labels: getLabels(mf.GetName()+"_count", m.GetLabel()),
+					ts:     getTimestamp(ts, m.GetTimestampMs()),
+					val:    float64(m.GetSummary().GetSampleCount()),
+				})
+
+				result = append(result, sample{
+					labels: getLabels(mf.GetName()+"_sum", m.GetLabel()),
+					ts:     getTimestamp(ts, m.GetTimestampMs()),
+					val:    m.GetSummary().GetSampleSum(),
+				})
+			}
+
+		case dto.MetricType_HISTOGRAM:
+			for _, m := range mf.GetMetric() {
+				for _, b := range m.GetHistogram().GetBucket() {
+					result = append(result, sample{
+						labels: getLabelsExt(mf.GetName()+"_bucket", m.GetLabel(), true, b.GetUpperBound()),
+						ts:     getTimestamp(ts, m.GetTimestampMs()),
+						val:    float64(b.GetCumulativeCount()),
+					})
+				}
+
+				result = append(result, sample{
+					labels: getLabels(mf.GetName()+"_count", m.GetLabel()),
+					ts:     getTimestamp(ts, m.GetTimestampMs()),
+					val:    float64(m.GetHistogram().GetSampleCount()),
+				})
+
+				result = append(result, sample{
+					labels: getLabels(mf.GetName()+"_sum", m.GetLabel()),
+					ts:     getTimestamp(ts, m.GetTimestampMs()),
+					val:    m.GetHistogram().GetSampleSum(),
+				})
+			}
+		}
+	}
+
+	return result
+}
+
+func getTimestamp(ts int64, mts int64) int64 {
+	if mts != 0 {
+		return mts
+	}
+	return ts
+}
+
+func getLabels(name string, pairs []*dto.LabelPair) map[string]string {
+	return getLabelsExt(name, pairs, false, 0)
+}
+
+func getLabelsExt(name string, pairs []*dto.LabelPair, bucket bool, upperBound float64) map[string]string {
+	result := map[string]string{}
+	result[labels.MetricName] = name
+	if bucket {
+		result[labels.BucketLabel] = fmt.Sprintf("%g", upperBound)
+	}
+
+	for _, p := range pairs {
+		result[p.GetName()] = p.GetValue()
+	}
+	return result
+}
+
+// implements Queryable and Querier
+type samplesQueryable []sample
+
+func (sq *samplesQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+	return sq, nil
+}
+
+func (sq samplesQueryable) SelectSorted(params *storage.SelectParams, matcher ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	var series []storage.Series
+
+	for _, s := range sq {
+		if s.matches(matcher...) {
+			series = append(series, s)
+		}
+	}
+
+	return &seriesSet{series: series}, nil, nil
+}
+
+func (sq samplesQueryable) Select(params *storage.SelectParams, matcher ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	return sq.SelectSorted(params, matcher...)
+}
+
+func (sq *samplesQueryable) LabelValues(name string) ([]string, storage.Warnings, error) {
+	panic("implement me")
+}
+
+func (sq *samplesQueryable) LabelNames() ([]string, storage.Warnings, error) {
+	panic("implement me")
+}
+
+func (sq *samplesQueryable) Close() error {
+	return nil
+}
+
+// seriesSet implements storage.SeriesSet.
+type seriesSet struct {
+	cur    int
+	series []storage.Series
+}
+
+func (c *seriesSet) Next() bool {
+	c.cur++
+	return c.cur-1 < len(c.series)
+}
+
+func (c *seriesSet) At() storage.Series {
+	return c.series[c.cur-1]
+}
+
+func (c *seriesSet) Err() error {
+	return nil
+}
+
+// sample implements storage.Series
+func (c sample) Labels() labels.Labels {
+	b := labels.NewBuilder(nil)
+	for k, v := range c.labels {
+		b.Set(k, v)
+	}
+	return b.Labels()
+}
+
+func (c sample) Iterator() storage.SeriesIterator {
+	return newSampleIterator(c.ts, c.val)
+}
+
+func (c sample) matches(matcher ...*labels.Matcher) bool {
+	for _, m := range matcher {
+		if !m.Matches(c.labels[m.Name]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// concreteSeriesIterator implements storage.SeriesIterator.
+type singleSampleIterator struct {
+	nextCalled bool
+	ts         int64
+	val        float64
+}
+
+func newSampleIterator(ts int64, val float64) storage.SeriesIterator {
+	return &singleSampleIterator{
+		ts:  ts,
+		val: val,
+	}
+}
+
+// Seek implements storage.SeriesIterator.
+func (c *singleSampleIterator) Seek(t int64) bool {
+	if t <= c.ts {
+		return true
+	}
+	return false
+}
+
+// At implements storage.SeriesIterator.
+func (c *singleSampleIterator) At() (t int64, v float64) {
+	return c.ts, c.val
+}
+
+// Next implements storage.SeriesIterator.
+func (c *singleSampleIterator) Next() bool {
+	if c.nextCalled {
+		return false
+	}
+	c.nextCalled = true
+	return true
+}
+
+// Err implements storage.SeriesIterator.
+func (c *singleSampleIterator) Err() error {
+	return nil
+}

--- a/integration/e2e/metrics_promql_test.go
+++ b/integration/e2e/metrics_promql_test.go
@@ -92,6 +92,10 @@ func TestEvaluatePromQLWithTextMetrics(t *testing.T) {
 			expr: "blocks_index_cache_items[1m]",
 			err:  errNotScalarOrVector,
 		},
+		{
+			expr: "unknown_metric",
+			val:  0,
+		},
 	} {
 		t.Run(tc.expr, func(t *testing.T) {
 			val, err := evaluatePromQLWithTextMetrics(tc.expr, metrics)

--- a/integration/e2e/metrics_promql_test.go
+++ b/integration/e2e/metrics_promql_test.go
@@ -74,7 +74,7 @@ func TestEvaluatePromQLWithTextMetrics(t *testing.T) {
 		},
 		{
 			expr: "blocks_index_cache_items > 50000",
-			val:  53280, // returns blocks_index_cache_items{item_type="Series"} 53280
+			val:  53280, // Returns blocks_index_cache_items{item_type="Series"} 53280.
 		},
 		{
 			expr: "blocks_index_cache_items{item_type='Series'} >bool 50000",
@@ -94,6 +94,14 @@ func TestEvaluatePromQLWithTextMetrics(t *testing.T) {
 		},
 		{
 			expr: "unknown_metric",
+			val:  0,
+		},
+		{
+			expr: "increase(blocks_index_cache_items[1m])",
+			val:  0,
+		},
+		{
+			expr: "rate(blocks_index_cache_items[1h])",
 			val:  0,
 		},
 	} {

--- a/integration/e2e/metrics_promql_test.go
+++ b/integration/e2e/metrics_promql_test.go
@@ -1,0 +1,102 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluatePromQLWithTextMetrics(t *testing.T) {
+	metrics := `
+			# HELP blocks_index_cache_items_evicted_total Total number of items that were evicted from the index cache.
+			# TYPE blocks_index_cache_items_evicted_total counter
+			blocks_index_cache_items_evicted_total{item_type="Postings"} 5328
+			blocks_index_cache_items_evicted_total{item_type="Series"} 10656
+
+			# HELP blocks_index_cache_requests_total Total number of requests to the cache.
+			# TYPE blocks_index_cache_requests_total counter
+			blocks_index_cache_requests_total{item_type="Postings"} 15984
+			blocks_index_cache_requests_total{item_type="Series"} 21312
+
+			# HELP blocks_index_cache_hits_total Total number of requests to the cache that were a hit.
+			# TYPE blocks_index_cache_hits_total counter
+			blocks_index_cache_hits_total{item_type="Postings"} 26640
+			blocks_index_cache_hits_total{item_type="Series"} 31968
+
+			# HELP blocks_index_cache_items_added_total Total number of items that were added to the index cache.
+			# TYPE blocks_index_cache_items_added_total counter
+			blocks_index_cache_items_added_total{item_type="Postings"} 37296
+			blocks_index_cache_items_added_total{item_type="Series"} 42624
+
+			# HELP blocks_index_cache_items Current number of items in the index cache.
+			# TYPE blocks_index_cache_items gauge
+			blocks_index_cache_items{item_type="Postings"} 47952
+			blocks_index_cache_items{item_type="Series"} 53280
+
+			# HELP bucket_store_series_get_all_duration_seconds Time it takes until all per-block prepares and preloads for a query are finished.
+			# TYPE bucket_store_series_get_all_duration_seconds histogram
+			bucket_store_series_get_all_duration_seconds_bucket{le="0.001"} 0
+			bucket_store_series_get_all_duration_seconds_bucket{le="0.01"} 0
+			bucket_store_series_get_all_duration_seconds_bucket{le="0.1"} 0
+			bucket_store_series_get_all_duration_seconds_bucket{le="0.3"} 0
+			bucket_store_series_get_all_duration_seconds_bucket{le="0.6"} 0
+			bucket_store_series_get_all_duration_seconds_bucket{le="1"} 0
+			bucket_store_series_get_all_duration_seconds_bucket{le="+Inf"} 9
+			bucket_store_series_get_all_duration_seconds_sum 1.486254e+06
+			bucket_store_series_get_all_duration_seconds_count 9
+`
+
+	for _, tc := range []struct {
+		expr string
+		val  float64
+		err  error
+	}{
+		{
+			expr: "sum(blocks_index_cache_items_evicted_total)",
+			val:  15984,
+		},
+		{
+			expr: "sum({__name__=~'blocks_index_cache_items_evicted_.*'})",
+			val:  15984,
+		},
+		{
+			expr: "blocks_index_cache_requests_total{item_type='Series'}",
+			val:  21312,
+		},
+		{
+			expr: "blocks_index_cache_requests_total{item_type!='Series'}",
+			val:  15984,
+		},
+		{
+			expr: "count(blocks_index_cache_hits_total)",
+			val:  2,
+		},
+		{
+			expr: "blocks_index_cache_items > 50000",
+			val:  53280, // returns blocks_index_cache_items{item_type="Series"} 53280
+		},
+		{
+			expr: "blocks_index_cache_items{item_type='Series'} >bool 50000",
+			val:  1,
+		},
+		{
+			expr: "bucket_store_series_get_all_duration_seconds_bucket > 0",
+			val:  9,
+		},
+		{
+			expr: "bucket_store_series_get_all_duration_seconds_bucket",
+			err:  fmt.Errorf(errTooManyVectorElements, 7),
+		},
+		{
+			expr: "blocks_index_cache_items[1m]",
+			err:  errNotScalarOrVector,
+		},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			val, err := evaluatePromQLWithTextMetrics(tc.expr, metrics)
+			assert.Equal(t, tc.err, err)
+			assert.Equal(t, tc.val, val)
+		})
+	}
+}

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -587,8 +587,6 @@ func (s *HTTPService) WaitForPromQL(expr string) error {
 			return err
 		}
 
-		fmt.Println(expr, "returned", val)
-
 		if val > 0 {
 			return nil
 		}

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -202,6 +202,9 @@ func runQueryFrontendTest(t *testing.T, testMissingMetricName bool, setup queryF
 	}
 	require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(numUsers*numQueriesPerUser+extra), "cortex_query_frontend_queries_total"))
 
+	require.NoError(t, queryFrontend.WaitForPromQL(fmt.Sprintf("sum(cortex_request_duration_seconds_count) > %d", numUsers*numQueriesPerUser)))
+	require.NoError(t, querier.WaitForPromQL(fmt.Sprintf("sum(cortex_request_duration_seconds_count) > %d", numUsers*numQueriesPerUser)))
+
 	// Ensure no service-specific metrics prefix is used by the wrong service.
 	assertServiceMetricsPrefixes(t, Distributor, distributor)
 	assertServiceMetricsPrefixes(t, Ingester, ingester)

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -202,8 +202,8 @@ func runQueryFrontendTest(t *testing.T, testMissingMetricName bool, setup queryF
 	}
 	require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(numUsers*numQueriesPerUser+extra), "cortex_query_frontend_queries_total"))
 
-	require.NoError(t, queryFrontend.WaitForPromQL(fmt.Sprintf("sum(cortex_request_duration_seconds_count) > %d", numUsers*numQueriesPerUser)))
-	require.NoError(t, querier.WaitForPromQL(fmt.Sprintf("sum(cortex_request_duration_seconds_count) > %d", numUsers*numQueriesPerUser)))
+	require.NoError(t, queryFrontend.WaitForPromQL(e2e.Greater(numUsers*numQueriesPerUser), "sum(cortex_request_duration_seconds_count)"))
+	require.NoError(t, querier.WaitForPromQL(e2e.Greater(numUsers*numQueriesPerUser), "sum(cortex_request_duration_seconds_count)"))
 
 	// Ensure no service-specific metrics prefix is used by the wrong service.
 	assertServiceMetricsPrefixes(t, Distributor, distributor)


### PR DESCRIPTION
This can simplify testing for metrics as shown by alertmanager and query frontend test.

This is an alternative to proposal in #2522. 

/cc @bwplotka 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
