### PR TITLE
Fixed ring topology change detection in store-gateway

### DIFF
--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -591,7 +591,7 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 	for _, c := range compactors {
 		cortex_testutil.Poll(t, 10*time.Second, len(compactors), func() interface{} {
 			// it is safe to access c.ring here, since we know that all compactors are Running now
-			rs, err := c.ring.GetAll()
+			rs, err := c.ring.GetAll(ring.Read)
 			if err != nil {
 				return 0
 			}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -599,7 +599,7 @@ func (d *Distributor) send(ctx context.Context, ingester ring.IngesterDesc, time
 
 // forAllIngesters runs f, in parallel, for all ingesters
 func (d *Distributor) forAllIngesters(ctx context.Context, reallyAll bool, f func(client.IngesterClient) (interface{}, error)) ([]interface{}, error) {
-	replicationSet, err := d.ingestersRing.GetAll()
+	replicationSet, err := d.ingestersRing.GetAll(ring.Read)
 	if err != nil {
 		return nil, err
 	}
@@ -778,7 +778,7 @@ func (d *Distributor) AllUserStats(ctx context.Context) ([]UserIDStats, error) {
 	req := &client.UserStatsRequest{}
 	ctx = user.InjectOrgID(ctx, "1") // fake: ingester insists on having an org ID
 	// Not using d.forAllIngesters(), so we can fail after first error.
-	replicationSet, err := d.ingestersRing.GetAll()
+	replicationSet, err := d.ingestersRing.GetAll(ring.Read)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -71,7 +71,7 @@ func (d *Distributor) queryPrep(ctx context.Context, from, to model.Time, matche
 	if !d.cfg.ShardByAllLabels && ok && metricNameMatcher.Type == labels.MatchEqual {
 		replicationSet, err = d.ingestersRing.Get(shardByMetricName(userID, metricNameMatcher.Value), ring.Read, nil)
 	} else {
-		replicationSet, err = d.ingestersRing.GetAll()
+		replicationSet, err = d.ingestersRing.GetAll(ring.Read)
 	}
 	return replicationSet, req, err
 }

--- a/pkg/querier/blocks_store_replicated_set_test.go
+++ b/pkg/querier/blocks_store_replicated_set_test.go
@@ -182,7 +182,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 
 			// Wait until the ring client has initialised the state.
 			test.Poll(t, time.Second, true, func() interface{} {
-				all, err := r.GetAll()
+				all, err := r.GetAll(ring.Read)
 				return err == nil && len(all.Ingesters) > 0
 			})
 

--- a/pkg/ring/client/ring_service_discovery.go
+++ b/pkg/ring/client/ring_service_discovery.go
@@ -6,7 +6,7 @@ import (
 
 func NewRingServiceDiscovery(r ring.ReadRing) PoolServiceDiscovery {
 	return func() ([]string, error) {
-		replicationSet, err := r.GetAll()
+		replicationSet, err := r.GetAll(ring.Read)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ring/client/ring_service_discovery_test.go
+++ b/pkg/ring/client/ring_service_discovery_test.go
@@ -58,6 +58,6 @@ type mockReadRing struct {
 	mockedErr            error
 }
 
-func (m *mockReadRing) GetAll() (ring.ReplicationSet, error) {
+func (m *mockReadRing) GetAll(_ ring.Operation) (ring.ReplicationSet, error) {
 	return m.mockedReplicationSet, m.mockedErr
 }

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -18,6 +18,13 @@ func (ts ByToken) Len() int           { return len(ts) }
 func (ts ByToken) Swap(i, j int)      { ts[i], ts[j] = ts[j], ts[i] }
 func (ts ByToken) Less(i, j int) bool { return ts[i].Token < ts[j].Token }
 
+// ByAddr is a sortable list of IngesterDesc.
+type ByAddr []IngesterDesc
+
+func (ts ByAddr) Len() int           { return len(ts) }
+func (ts ByAddr) Swap(i, j int)      { ts[i], ts[j] = ts[j], ts[i] }
+func (ts ByAddr) Less(i, j int) bool { return ts[i].Addr < ts[j].Addr }
+
 // ProtoDescFactory makes new Descs
 func ProtoDescFactory() proto.Message {
 	return NewDesc()
@@ -403,23 +410,6 @@ func (d *Desc) getTokens() []TokenDesc {
 
 	sort.Sort(ByToken(tokens))
 	return tokens
-}
-
-// TokenDescs holds a sorted list of TokenDesc.
-type TokenDescs []TokenDesc
-
-func (t TokenDescs) Equals(other TokenDescs) bool {
-	if len(t) != len(other) {
-		return false
-	}
-
-	for i := 0; i < len(t); i++ {
-		if (t[i].Token != other[i].Token) || (t[i].Ingester != other[i].Ingester) || (t[i].Zone != other[i].Zone) {
-			return false
-		}
-	}
-
-	return true
 }
 
 func GetOrCreateRingDesc(d interface{}) *Desc {

--- a/pkg/ring/model_test.go
+++ b/pkg/ring/model_test.go
@@ -1,7 +1,6 @@
 package ring
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -185,79 +184,5 @@ func TestDesc_Ready(t *testing.T) {
 
 	if err := r.Ready(now, 10*time.Second); err != nil {
 		t.Fatal("expected ready, got", err)
-	}
-}
-
-func TestTokenDescs_Equals(t *testing.T) {
-	tests := []struct {
-		first    TokenDescs
-		second   TokenDescs
-		expected bool
-	}{
-		{
-			first:    nil,
-			second:   nil,
-			expected: true,
-		}, {
-			first:    TokenDescs{},
-			second:   TokenDescs{},
-			expected: true,
-		}, {
-			first: TokenDescs{
-				{Token: 1, Ingester: "1", Zone: "1"},
-			},
-			second:   nil,
-			expected: false,
-		}, {
-			first: TokenDescs{
-				{Token: 1, Ingester: "1", Zone: "1"},
-				{Token: 2, Ingester: "2", Zone: "2"},
-			},
-			second: TokenDescs{
-				{Token: 1, Ingester: "1", Zone: "1"},
-				{Token: 2, Ingester: "2", Zone: "2"},
-			},
-			expected: true,
-		}, {
-			first: TokenDescs{
-				{Token: 1, Ingester: "1", Zone: "1"},
-				{Token: 2, Ingester: "2", Zone: "2"},
-			},
-			second: TokenDescs{
-				{Token: 1, Ingester: "1", Zone: "1"},
-			},
-			expected: false,
-		}, {
-			first: TokenDescs{
-				{Token: 1, Ingester: "1", Zone: "1"},
-			},
-			second: TokenDescs{
-				{Token: 1, Ingester: "1", Zone: "different"},
-			},
-			expected: false,
-		}, {
-			first: TokenDescs{
-				{Token: 1, Ingester: "1", Zone: "1"},
-			},
-			second: TokenDescs{
-				{Token: 1, Ingester: "different", Zone: "1"},
-			},
-			expected: false,
-		}, {
-			first: TokenDescs{
-				{Token: 1, Ingester: "1", Zone: "1"},
-			},
-			second: TokenDescs{
-				{Token: 0, Ingester: "1", Zone: "1"},
-			},
-			expected: false,
-		},
-	}
-
-	for testID, testData := range tests {
-		t.Run(fmt.Sprintf("Test %d", testID), func(t *testing.T) {
-			assert.Equal(t, testData.expected, testData.first.Equals(testData.second))
-			assert.Equal(t, testData.expected, testData.second.Equals(testData.first))
-		})
 	}
 }

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -9,13 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	"github.com/cortexproject/cortex/pkg/util/services"
-	"github.com/cortexproject/cortex/pkg/util/test"
 )
 
 const (
@@ -344,135 +340,4 @@ func TestZoneAwareIngesterAssignmentFailure(t *testing.T) {
 		t.Fail()
 	}
 
-}
-
-func TestRing_GetAllTokens_ForStoreGatewayOperations(t *testing.T) {
-	tests := map[string]struct {
-		instances     map[string]IngesterDesc
-		syncExpected  TokenDescs
-		queryExpected TokenDescs
-	}{
-		"a single instance in JOINING state": {
-			instances: map[string]IngesterDesc{
-				"instance-1": {
-					Timestamp: time.Now().Unix(),
-					State:     JOINING,
-					Tokens:    []uint32{1, 6},
-				},
-			},
-			syncExpected: TokenDescs{
-				{Token: 1, Ingester: "instance-1"},
-				{Token: 6, Ingester: "instance-1"},
-			},
-			queryExpected: TokenDescs{},
-		},
-		"multiple instances in JOINING state": {
-			instances: map[string]IngesterDesc{
-				"instance-1": {
-					Timestamp: time.Now().Unix(),
-					State:     JOINING,
-					Tokens:    []uint32{1, 6},
-				},
-				"instance-2": {
-					Timestamp: time.Now().Unix(),
-					State:     JOINING,
-					Tokens:    []uint32{3, 8},
-				},
-			},
-			syncExpected: TokenDescs{
-				{Token: 1, Ingester: "instance-1"},
-				{Token: 3, Ingester: "instance-2"},
-				{Token: 6, Ingester: "instance-1"},
-				{Token: 8, Ingester: "instance-2"},
-			},
-			queryExpected: TokenDescs{},
-		},
-		"multiple instances in JOINING and ACTIVE state": {
-			instances: map[string]IngesterDesc{
-				"instance-1": {
-					Timestamp: time.Now().Unix(),
-					State:     JOINING,
-					Tokens:    []uint32{1, 6},
-				},
-				"instance-2": {
-					Timestamp: time.Now().Unix(),
-					State:     ACTIVE,
-					Tokens:    []uint32{3, 8},
-				},
-			},
-			syncExpected: TokenDescs{
-				{Token: 1, Ingester: "instance-1"},
-				{Token: 3, Ingester: "instance-2"},
-				{Token: 6, Ingester: "instance-1"},
-				{Token: 8, Ingester: "instance-2"},
-			},
-			queryExpected: TokenDescs{
-				{Token: 3, Ingester: "instance-2"},
-				{Token: 8, Ingester: "instance-2"},
-			},
-		},
-		"multiple instances in ACTIVE and LEAVING state": {
-			instances: map[string]IngesterDesc{
-				"instance-1": {
-					Timestamp: time.Now().Unix(),
-					State:     LEAVING,
-					Tokens:    []uint32{1, 6},
-				},
-				"instance-2": {
-					Timestamp: time.Now().Unix(),
-					State:     ACTIVE,
-					Tokens:    []uint32{3, 8},
-				},
-			},
-			syncExpected: TokenDescs{
-				{Token: 1, Ingester: "instance-1"},
-				{Token: 3, Ingester: "instance-2"},
-				{Token: 6, Ingester: "instance-1"},
-				{Token: 8, Ingester: "instance-2"},
-			},
-			queryExpected: TokenDescs{
-				{Token: 3, Ingester: "instance-2"},
-				{Token: 8, Ingester: "instance-2"},
-			},
-		},
-	}
-
-	for testName, testData := range tests {
-		testData := testData
-
-		t.Run(testName, func(t *testing.T) {
-			t.Parallel()
-
-			cfg := Config{
-				HeartbeatTimeout:  time.Minute,
-				ReplicationFactor: 3,
-			}
-
-			ctx := context.Background()
-			store := consul.NewInMemoryClient(GetCodec())
-			r, err := NewWithStoreClientAndStrategy(cfg, "test", "test", store, &DefaultReplicationStrategy{})
-			require.NoError(t, err)
-
-			// Initialize the store.
-			require.NoError(t, store.CAS(ctx, "test", func(in interface{}) (interface{}, bool, error) {
-				d := NewDesc()
-				d.Ingesters = testData.instances
-				return d, true, nil
-			}))
-
-			require.NoError(t, services.StartAndAwaitRunning(ctx, r))
-			defer services.StopAndAwaitTerminated(ctx, r) //nolint:errcheck
-
-			// Wait until the initial sync succeeded.
-			test.Poll(t, time.Second, true, func() interface{} {
-				return r.IngesterCount() > 0
-			})
-
-			tokens := r.GetAllTokens(BlocksSync)
-			assert.Equal(t, testData.syncExpected, tokens)
-
-			tokens = r.GetAllTokens(BlocksRead)
-			assert.Equal(t, testData.queryExpected, tokens)
-		})
-	}
 }

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -594,7 +594,7 @@ func (r *Ruler) getLocalRules(userID string) ([]*GroupStateDesc, error) {
 }
 
 func (r *Ruler) getShardedRules(ctx context.Context) ([]*GroupStateDesc, error) {
-	rulers, err := r.ring.GetAll()
+	rulers, err := r.ring.GetAll(ring.Read)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -200,6 +200,15 @@ func (g *StoreGateway) starting(ctx context.Context) (err error) {
 		if err = g.ringLifecycler.ChangeState(ctx, ring.ACTIVE); err != nil {
 			return errors.Wrapf(err, "switch instance to %s in the ring", ring.ACTIVE)
 		}
+
+		// Wait until the ring client detected this instance in the ACTIVE state to
+		// make sure that when we'll run the loop it won't be detected as a ring
+		// topology change.
+		level.Info(g.logger).Log("msg", "waiting until store-gateway is ACTIVE in the ring")
+		if err := ring.WaitInstanceState(ctx, g.ring, g.ringLifecycler.GetInstanceID(), ring.ACTIVE); err != nil {
+			return err
+		}
+		level.Info(g.logger).Log("msg", "store-gateway is ACTIVE in the ring")
 	}
 
 	return nil
@@ -207,13 +216,13 @@ func (g *StoreGateway) starting(ctx context.Context) (err error) {
 
 func (g *StoreGateway) running(ctx context.Context) error {
 	var ringTickerChan <-chan time.Time
-	var ringLastTokens ring.TokenDescs
+	var ringLastState ring.ReplicationSet
 
 	syncTicker := time.NewTicker(g.storageCfg.BucketStore.SyncInterval)
 	defer syncTicker.Stop()
 
 	if g.gatewayCfg.ShardingEnabled {
-		ringLastTokens = g.ring.GetAllTokens(ring.BlocksSync)
+		ringLastState, _ = g.ring.GetAll(ring.BlocksSync) // nolint:errcheck
 		ringTicker := time.NewTicker(g.gatewayCfg.ShardingRing.RingCheckPeriod)
 		defer ringTicker.Stop()
 		ringTickerChan = ringTicker.C
@@ -224,9 +233,12 @@ func (g *StoreGateway) running(ctx context.Context) error {
 		case <-syncTicker.C:
 			g.syncStores(ctx, syncReasonPeriodic)
 		case <-ringTickerChan:
-			currTokens := g.ring.GetAllTokens(ring.BlocksSync)
-			if !currTokens.Equals(ringLastTokens) {
-				ringLastTokens = currTokens
+			// We ignore the error because in case of error it will return an empty
+			// replication set which we use to compare with the previous state.
+			currRingState, _ := g.ring.GetAll(ring.BlocksSync) // nolint:errcheck
+
+			if hasRingTopologyChanged(ringLastState, currRingState) {
+				ringLastState = currRingState
 				g.syncStores(ctx, syncReasonRingChange)
 			}
 		case <-ctx.Done():

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -353,6 +353,18 @@ func TestStoreGateway_SyncOnRingTopologyChanged(t *testing.T) {
 			},
 			expectedSync: true,
 		},
+		"should sync when an instance changes state": {
+			setupRing: func(desc *ring.Desc) {
+				desc.AddIngester("instance-1", "127.0.0.1", "", ring.Tokens{1, 2, 3}, ring.ACTIVE)
+				desc.AddIngester("instance-2", "127.0.0.2", "", ring.Tokens{4, 5, 6}, ring.JOINING)
+			},
+			updateRing: func(desc *ring.Desc) {
+				instance := desc.Ingesters["instance-2"]
+				instance.State = ring.ACTIVE
+				desc.Ingesters["instance-2"] = instance
+			},
+			expectedSync: true,
+		},
 		"should sync when an healthy instance becomes unhealthy": {
 			setupRing: func(desc *ring.Desc) {
 				desc.AddIngester("instance-1", "127.0.0.1", "", ring.Tokens{1, 2, 3}, ring.ACTIVE)


### PR DESCRIPTION
**What this PR does**:
When I've implemented the blocks sharding and replication in the store-gateway I was aware of an issue with the "ring topology change detection": the resync wasn't guaranteed to trigger when an instance change state (ie. JOINING -> ACTIVE).

In this PR I've fixed it following a different approach. I use `ring.GetAll()` to get a snapshot of the ring for a given operation (now configurable) and then I compare it with the last known snapshot.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
