### PR TITLE
Added auto-forget to store-gateway ring instances

### DIFF
--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -82,6 +82,8 @@ store_gateway:
   sharding_enabled: true
   sharding_ring:
     replication_factor: 1
+    heartbeat_period:   5s
+    heartbeat_timeout:  15s
     kvstore:
       store: consul
       consul:

--- a/pkg/ring/basic_lifecycler_delegates.go
+++ b/pkg/ring/basic_lifecycler_delegates.go
@@ -138,7 +138,7 @@ func (d *AutoForgetDelegate) OnRingInstanceHeartbeat(lifecycler *BasicLifecycler
 		lastHeartbeat := time.Unix(instance.GetTimestamp(), 0)
 
 		if time.Since(lastHeartbeat) > d.forgetPeriod {
-			level.Warn(d.logger).Log("msg", "auto-forgetting instance from the ring because unhealthy since a long time", "instance", id, "last_heartbeat", lastHeartbeat.String(), "forget_period", d.forgetPeriod)
+			level.Warn(d.logger).Log("msg", "auto-forgetting instance from the ring because it is unhealthy for a long time", "instance", id, "last_heartbeat", lastHeartbeat.String(), "forget_period", d.forgetPeriod)
 			ringDesc.RemoveIngester(id)
 		}
 	}

--- a/pkg/ring/basic_lifecycler_delegates.go
+++ b/pkg/ring/basic_lifecycler_delegates.go
@@ -36,6 +36,10 @@ func (d *LeaveOnStoppingDelegate) OnRingInstanceStopping(lifecycler *BasicLifecy
 	d.next.OnRingInstanceStopping(lifecycler)
 }
 
+func (d *LeaveOnStoppingDelegate) OnRingInstanceHeartbeat(lifecycler *BasicLifecycler, ringDesc *Desc, instanceDesc *IngesterDesc) {
+	d.next.OnRingInstanceHeartbeat(lifecycler, ringDesc, instanceDesc)
+}
+
 type TokensPersistencyDelegate struct {
 	next       BasicLifecyclerDelegate
 	logger     log.Logger
@@ -95,4 +99,49 @@ func (d *TokensPersistencyDelegate) OnRingInstanceTokens(lifecycler *BasicLifecy
 
 func (d *TokensPersistencyDelegate) OnRingInstanceStopping(lifecycler *BasicLifecycler) {
 	d.next.OnRingInstanceStopping(lifecycler)
+}
+
+func (d *TokensPersistencyDelegate) OnRingInstanceHeartbeat(lifecycler *BasicLifecycler, ringDesc *Desc, instanceDesc *IngesterDesc) {
+	d.next.OnRingInstanceHeartbeat(lifecycler, ringDesc, instanceDesc)
+}
+
+// AutoForgetDelegate automatically remove an instance from the ring if the last
+// heartbeat is older than a configured period.
+type AutoForgetDelegate struct {
+	next         BasicLifecyclerDelegate
+	logger       log.Logger
+	forgetPeriod time.Duration
+}
+
+func NewAutoForgetDelegate(forgetPeriod time.Duration, next BasicLifecyclerDelegate, logger log.Logger) *AutoForgetDelegate {
+	return &AutoForgetDelegate{
+		next:         next,
+		logger:       logger,
+		forgetPeriod: forgetPeriod,
+	}
+}
+
+func (d *AutoForgetDelegate) OnRingInstanceRegister(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens) {
+	return d.next.OnRingInstanceRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
+}
+
+func (d *AutoForgetDelegate) OnRingInstanceTokens(lifecycler *BasicLifecycler, tokens Tokens) {
+	d.next.OnRingInstanceTokens(lifecycler, tokens)
+}
+
+func (d *AutoForgetDelegate) OnRingInstanceStopping(lifecycler *BasicLifecycler) {
+	d.next.OnRingInstanceStopping(lifecycler)
+}
+
+func (d *AutoForgetDelegate) OnRingInstanceHeartbeat(lifecycler *BasicLifecycler, ringDesc *Desc, instanceDesc *IngesterDesc) {
+	for id, instance := range ringDesc.Ingesters {
+		lastHeartbeat := time.Unix(instance.GetTimestamp(), 0)
+
+		if time.Since(lastHeartbeat) > d.forgetPeriod {
+			level.Warn(d.logger).Log("msg", "auto-forgetting instance from the ring because unhealthy since a long time", "instance", id, "last_heartbeat", lastHeartbeat.String(), "forget_period", d.forgetPeriod)
+			ringDesc.RemoveIngester(id)
+		}
+	}
+
+	d.next.OnRingInstanceHeartbeat(lifecycler, ringDesc, instanceDesc)
 }

--- a/pkg/ring/basic_lifecycler_delegates_test.go
+++ b/pkg/ring/basic_lifecycler_delegates_test.go
@@ -5,12 +5,15 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/util/services"
+	"github.com/cortexproject/cortex/pkg/util/test"
 )
 
 func TestLeaveOnStoppingDelegate(t *testing.T) {
@@ -214,4 +217,78 @@ func TestDelegatesChain(t *testing.T) {
 	actualTokens, err := LoadTokensFromFile(tokensFile.Name())
 	require.NoError(t, err)
 	assert.Equal(t, Tokens{1, 2, 3, 4, 5}, actualTokens)
+}
+
+func TestAutoForgetDelegate(t *testing.T) {
+	const forgetPeriod = time.Minute
+
+	tests := map[string]struct {
+		setup             func(ringDesc *Desc)
+		expectedInstances []string
+	}{
+		"no unhealthy instance in the ring": {
+			setup: func(ringDesc *Desc) {
+				ringDesc.AddIngester("instance-1", "1.1.1.1", "", nil, ACTIVE)
+			},
+			expectedInstances: []string{testInstanceID, "instance-1"},
+		},
+		"unhealthy instance in the ring that has NOTreached the forget period yet": {
+			setup: func(ringDesc *Desc) {
+				i := ringDesc.AddIngester("instance-1", "1.1.1.1", "", nil, ACTIVE)
+				i.Timestamp = time.Now().Add(-forgetPeriod).Add(5 * time.Second).Unix()
+				ringDesc.Ingesters["instance-1"] = i
+			},
+			expectedInstances: []string{testInstanceID, "instance-1"},
+		},
+		"unhealthy instance in the ring that has reached the forget period": {
+			setup: func(ringDesc *Desc) {
+				i := ringDesc.AddIngester("instance-1", "1.1.1.1", "", nil, ACTIVE)
+				i.Timestamp = time.Now().Add(-forgetPeriod).Add(-5 * time.Second).Unix()
+				ringDesc.Ingesters["instance-1"] = i
+			},
+			expectedInstances: []string{testInstanceID},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ctx := context.Background()
+			cfg := prepareBasicLifecyclerConfig()
+			cfg.HeartbeatPeriod = 100 * time.Millisecond
+
+			testDelegate := &mockDelegate{}
+
+			autoForgetDelegate := NewAutoForgetDelegate(forgetPeriod, testDelegate, log.NewNopLogger())
+			lifecycler, store, err := prepareBasicLifecyclerWithDelegate(cfg, autoForgetDelegate)
+			require.NoError(t, err)
+
+			// Setup the initial state of the ring.
+			require.NoError(t, store.CAS(ctx, testRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+				ringDesc := NewDesc()
+				testData.setup(ringDesc)
+				return ringDesc, true, nil
+			}))
+
+			// Start the lifecycler.
+			require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+			defer services.StopAndAwaitTerminated(ctx, lifecycler) //nolint:errcheck
+
+			// Wait until an heartbeat has been sent.
+			test.Poll(t, time.Second, true, func() interface{} {
+				return testutil.ToFloat64(lifecycler.metrics.heartbeats) > 0
+			})
+
+			// Read back the ring status from the store.
+			v, err := store.Get(ctx, testRingKey)
+			require.NoError(t, err)
+			require.NotNil(t, v)
+
+			var actualInstances []string
+			for id, _ := range GetOrCreateRingDesc(v).GetIngesters() {
+				actualInstances = append(actualInstances, id)
+			}
+
+			assert.ElementsMatch(t, testData.expectedInstances, actualInstances)
+		})
+	}
 }

--- a/pkg/ring/basic_lifecycler_delegates_test.go
+++ b/pkg/ring/basic_lifecycler_delegates_test.go
@@ -198,6 +198,7 @@ func TestDelegatesChain(t *testing.T) {
 
 	chain = NewTokensPersistencyDelegate(tokensFile.Name(), ACTIVE, chain, log.NewNopLogger())
 	chain = NewLeaveOnStoppingDelegate(chain, log.NewNopLogger())
+	chain = NewAutoForgetDelegate(time.Minute, chain, log.NewNopLogger())
 
 	ctx := context.Background()
 	cfg := prepareBasicLifecyclerConfig()
@@ -284,7 +285,7 @@ func TestAutoForgetDelegate(t *testing.T) {
 			require.NotNil(t, v)
 
 			var actualInstances []string
-			for id, _ := range GetOrCreateRingDesc(v).GetIngesters() {
+			for id := range GetOrCreateRingDesc(v).GetIngesters() {
 				actualInstances = append(actualInstances, id)
 			}
 

--- a/pkg/ring/basic_lifecycler_test.go
+++ b/pkg/ring/basic_lifecycler_test.go
@@ -325,7 +325,7 @@ func TestBasicLifecycler_updateInstance_ShouldAddInstanceToTheRingIfDoesNotExist
 
 	// Run a noop update instance, but since the instance is not in the ring we do expect
 	// it will added back anyway.
-	require.NoError(t, lifecycler.updateInstance(ctx, func(_ Desc, desc *IngesterDesc) bool {
+	require.NoError(t, lifecycler.updateInstance(ctx, func(_ *Desc, desc *IngesterDesc) bool {
 		return false
 	}))
 
@@ -363,6 +363,7 @@ type mockDelegate struct {
 	onRegister      func(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens)
 	onTokensChanged func(lifecycler *BasicLifecycler, tokens Tokens)
 	onStopping      func(lifecycler *BasicLifecycler)
+	onHeartbeat     func(lifecycler *BasicLifecycler, ringDesc *Desc, instanceDesc *IngesterDesc)
 }
 
 func (m *mockDelegate) OnRingInstanceRegister(lifecycler *BasicLifecycler, ringDesc Desc, instanceExists bool, instanceID string, instanceDesc IngesterDesc) (IngesterState, Tokens) {
@@ -382,6 +383,12 @@ func (m *mockDelegate) OnRingInstanceTokens(lifecycler *BasicLifecycler, tokens 
 func (m *mockDelegate) OnRingInstanceStopping(lifecycler *BasicLifecycler) {
 	if m.onStopping != nil {
 		m.onStopping(lifecycler)
+	}
+}
+
+func (m *mockDelegate) OnRingInstanceHeartbeat(lifecycler *BasicLifecycler, ringDesc *Desc, instanceDesc *IngesterDesc) {
+	if m.onHeartbeat != nil {
+		m.onHeartbeat(lifecycler, ringDesc, instanceDesc)
 	}
 }
 

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -31,6 +31,10 @@ const (
 	// sharedOptionWithQuerier is a message appended to all config options that should be also
 	// set on the querier in order to work correct.
 	sharedOptionWithQuerier = " This option needs be set both on the store-gateway and querier when running in microservices mode."
+
+	// ringAutoForgetUnhealthyPeriods is how many consecutive timeout periods an unhealthy instance
+	// in the ring will be automatically removed.
+	ringAutoForgetUnhealthyPeriods = 10
 )
 
 // Config holds the store gateway config.
@@ -116,7 +120,7 @@ func newStoreGateway(gatewayCfg Config, storageCfg cortex_tsdb.Config, bucketCli
 		delegate := ring.BasicLifecyclerDelegate(g)
 		delegate = ring.NewLeaveOnStoppingDelegate(delegate, logger)
 		delegate = ring.NewTokensPersistencyDelegate(gatewayCfg.ShardingRing.TokensFilePath, ring.JOINING, delegate, logger)
-		delegate = ring.NewAutoForgetDelegate(10*gatewayCfg.ShardingRing.HeartbeatTimeout, delegate, logger)
+		delegate = ring.NewAutoForgetDelegate(ringAutoForgetUnhealthyPeriods*gatewayCfg.ShardingRing.HeartbeatTimeout, delegate, logger)
 
 		g.ringLifecycler, err = ring.NewBasicLifecycler(lifecyclerCfg, RingNameForServer, RingKey, ringStore, delegate, logger, reg)
 		if err != nil {


### PR DESCRIPTION
**What this PR does**:
In this PR I've introduced the support to auto-forget a store-gateway instance in the ring, 10x after the heartbeat timeout period is expired.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
