### PR TITLE
Avoid sharding sub-aggregations in `querier.parallelise-shardable-queries`

### DIFF
--- a/pkg/querier/astmapper/parallel.go
+++ b/pkg/querier/astmapper/parallel.go
@@ -43,7 +43,7 @@ func CanParallelize(node promql.Node) bool {
 	case *promql.AggregateExpr:
 		_, ok := summableAggregates[n.Op]
 		if !ok {
-			return ok
+			return false
 		}
 
 		// Ensure there are no nested aggregations

--- a/pkg/querier/astmapper/parallel_test.go
+++ b/pkg/querier/astmapper/parallel_test.go
@@ -106,6 +106,16 @@ func TestCanParallel_String(t *testing.T) {
 			)`,
 			false,
 		},
+		{
+			`sum(
+				count(
+					count(
+						foo{bar="baz"}
+					)  by (a,b)
+				)  by (instance)
+			)`,
+			false,
+		},
 	}
 
 	for i, c := range testExpr {


### PR DESCRIPTION

## What
This PR fixes and issue where the groupings of sub-aggregations can cause query correctness issues. This only occurs  within a sharded sum aggregation (via the `querier.parallelise-shardable-queries` flag). This is because aggregations expose the `by (<labels...>)` syntax. Since the sharding optimizations [alter](https://github.com/cortexproject/cortex/blob/master/pkg/querier/astmapper/shard_summer.go#L123-L171) `sum` groupings,  we must be careful not to shard in such a way that will cause non-associative series merging due to `by` groupings. For an example, please see these [two new test cases](https://github.com/cortexproject/cortex/compare/master...owen-d:sharding-subaggregations?expand=1#diff-bef1fd1e4cc0b9ab1f9c4f205d7f2ca3R242-R281) which illustrate this.

## Further work
There may be further optimizations that can be applied ([example](https://github.com/cortexproject/cortex/compare/master...owen-d:sharding-subaggregations?expand=1#diff-bef1fd1e4cc0b9ab1f9c4f205d7f2ca3R282-R311)), but this PR addresses the current faulty behavior by avoiding trying to shard sum queries which wrap other aggregations.

**Checklist**
- [x] Tests updated
