### PR TITLE
Add TODOs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![GoDoc](https://godoc.org/github.com/cortexproject/cortex?status.svg)](https://godoc.org/github.com/cortexproject/cortex)
 <a href="https://goreportcard.com/report/github.com/cortexproject/cortex"><img src="https://goreportcard.com/badge/github.com/cortexproject/cortex" alt="Go Report Card" /></a>
 <a href="https://cloud-native.slack.com/messages/cortex/"><img src="https://img.shields.io/badge/join%20slack-%23cortex-brightgreen.svg" alt="Slack" /></a>
+[![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/cortexproject/cortex)](https://www.tickgit.com/browse?repo=github.com/cortexproject/cortex)
 
 # Cortex: horizontally scalable, highly available, multi-tenant, long term storage for Prometheus.
 


### PR DESCRIPTION
Closes #2529:

> Hi there! I wanted to propose adding the following badge to the README to indicate how many 
> TODO comments are in this codebase:
> 
> [![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/cortexproject/cortex)](https://www.tickgit.com/browse?repo=github.com/cortexproject/cortex)
> 
> The badge links to tickgit.com which is a free service that indexes and displays TODO comments in public github repos. It can help surface latent work and be a way for contributors to find areas of code to improve, that might not be otherwise documented.
> 
> Thanks for considering, feel free to close this issue if it's not appropriate or you prefer not to!
> 
> (full disclosure, I am the creator/maintainer of tickgit)

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #2529

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
