### PR TITLE
handling of empty directories in filesystem object client

### DIFF
--- a/pkg/chunk/local/fs_object_client.go
+++ b/pkg/chunk/local/fs_object_client.go
@@ -139,7 +139,7 @@ func (f *FSObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stora
 }
 
 func (f *FSObjectClient) DeleteObject(ctx context.Context, objectKey string) error {
-	// inspired from copied from https://github.com/thanos-io/thanos/blob/55cb8ca38b3539381dc6a781e637df15c694e50a/pkg/objstore/filesystem/filesystem.go#L195
+	// inspired from https://github.com/thanos-io/thanos/blob/55cb8ca38b3539381dc6a781e637df15c694e50a/pkg/objstore/filesystem/filesystem.go#L195
 	file := filepath.Join(f.cfg.Directory, objectKey)
 
 	for file != f.cfg.Directory {

--- a/pkg/chunk/local/fs_object_client.go
+++ b/pkg/chunk/local/fs_object_client.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/go-kit/kit/log/level"
@@ -143,7 +142,7 @@ func (f *FSObjectClient) DeleteObject(ctx context.Context, objectKey string) err
 	file := filepath.Join(f.cfg.Directory, objectKey)
 
 	for file != f.cfg.Directory {
-		if err := os.RemoveAll(file); err != nil {
+		if err := os.Remove(file); err != nil {
 			return err
 		}
 
@@ -186,13 +185,4 @@ func isDirEmpty(name string) (ok bool, err error) {
 		return true, nil
 	}
 	return false, err
-}
-
-func isNotEmptyErr(err error) bool {
-	pathErr, ok := err.(*os.PathError)
-	if ok && pathErr.Err == syscall.ENOTEMPTY {
-		return true
-	}
-
-	return false
 }

--- a/pkg/chunk/local/fs_object_client.go
+++ b/pkg/chunk/local/fs_object_client.go
@@ -157,11 +157,11 @@ func (f *FSObjectClient) DeleteObject(ctx context.Context, objectKey string) err
 	}
 
 	err = os.Remove(parentDir)
-	if err != nil && isNotEmptyErr(err) {
-		return nil
+	if err != nil && !isNotEmptyErr(err) {
+		return err
 	}
 
-	return err
+	return nil
 }
 
 // DeleteChunksBefore implements BucketClient

--- a/pkg/chunk/local/fs_object_client_test.go
+++ b/pkg/chunk/local/fs_object_client_test.go
@@ -137,7 +137,6 @@ func TestFSObjectClient_DeleteObject(t *testing.T) {
 
 	foldersWithFiles := make(map[string][]string)
 	foldersWithFiles["folder1/"] = []string{"file1", "file2"}
-	foldersWithFiles["folder2/"] = []string{"file3", "file4", "file5"}
 
 	for folder, files := range foldersWithFiles {
 		for _, filename := range files {
@@ -163,6 +162,15 @@ func TestFSObjectClient_DeleteObject(t *testing.T) {
 	require.NoError(t, bucketClient.DeleteObject(context.Background(), "folder1/file2"))
 	_, err = os.Stat(filepath.Join(fsObjectsDir, "folder1"))
 	require.True(t, os.IsNotExist(err))
+
+	_, err = os.Stat(fsObjectsDir)
+	require.NoError(t, err)
+
+	// let us see ensure folder2 is still there will all the files:
+	/*files, commonPrefixes, err := bucketClient.List(context.Background(), "folder2/")
+	require.NoError(t, err)
+	require.Len(t, commonPrefixes, 0)
+	require.Len(t, files, len(foldersWithFiles["folder2/"]))*/
 }
 
 func TestIsNotEmptyErr(t *testing.T) {

--- a/pkg/chunk/local/fs_object_client_test.go
+++ b/pkg/chunk/local/fs_object_client_test.go
@@ -180,4 +180,9 @@ func TestIsNotEmptyErr(t *testing.T) {
 	err = os.Remove(outerDir)
 	require.Error(t, err)
 	require.True(t, isNotEmptyErr(err))
+
+	// try removing a non-existent directory and see if it does not throw syscall.ENOTEMPTY error
+	err = os.Remove(filepath.Join(outerDir, "non-existent"))
+	require.Error(t, err)
+	require.False(t, isNotEmptyErr(err))
 }

--- a/pkg/chunk/local/fs_object_client_test.go
+++ b/pkg/chunk/local/fs_object_client_test.go
@@ -172,25 +172,3 @@ func TestFSObjectClient_DeleteObject(t *testing.T) {
 	require.Len(t, commonPrefixes, 0)
 	require.Len(t, files, len(foldersWithFiles["folder2/"]))*/
 }
-
-func TestIsNotEmptyErr(t *testing.T) {
-	outerDir, err := ioutil.TempDir(os.TempDir(), "empty-dir-err-check")
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, os.RemoveAll(outerDir))
-	}()
-
-	// create a directory inside the outer dir
-	require.NoError(t, os.Mkdir(filepath.Join(outerDir, "nested"), 0700))
-
-	// try removing the outer directory and see if it throws syscall.ENOTEMPTY error
-	err = os.Remove(outerDir)
-	require.Error(t, err)
-	require.True(t, isNotEmptyErr(err))
-
-	// try removing a non-existent directory and see if it does not throw syscall.ENOTEMPTY error
-	err = os.Remove(filepath.Join(outerDir, "non-existent"))
-	require.Error(t, err)
-	require.False(t, isNotEmptyErr(err))
-}

--- a/pkg/chunk/local/fs_object_client_test.go
+++ b/pkg/chunk/local/fs_object_client_test.go
@@ -164,3 +164,20 @@ func TestFSObjectClient_DeleteObject(t *testing.T) {
 	_, err = os.Stat(filepath.Join(fsObjectsDir, "folder1"))
 	require.True(t, os.IsNotExist(err))
 }
+
+func TestIsNotEmptyErr(t *testing.T) {
+	outerDir, err := ioutil.TempDir(os.TempDir(), "empty-dir-err-check")
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, os.RemoveAll(outerDir))
+	}()
+
+	// create a directory inside the outer dir
+	require.NoError(t, os.Mkdir(filepath.Join(outerDir, "nested"), 0700))
+
+	// try removing the outer directory and see if it throws syscall.ENOTEMPTY error
+	err = os.Remove(outerDir)
+	require.Error(t, err)
+	require.True(t, isNotEmptyErr(err))
+}

--- a/pkg/chunk/local/fs_object_client_test.go
+++ b/pkg/chunk/local/fs_object_client_test.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/chunk/util"
 )
 
 func TestFSObjectClient_DeleteChunksBefore(t *testing.T) {
@@ -82,6 +85,9 @@ func TestFSObjectClient_List(t *testing.T) {
 		}
 	}
 
+	// create an empty directory which should get excluded from the list
+	require.NoError(t, util.EnsureDirectory(filepath.Join(fsObjectsDir, "empty-folder")))
+
 	files := []string{"outer-file1", "outer-file2"}
 
 	for _, fl := range files {
@@ -114,4 +120,47 @@ func TestFSObjectClient_List(t *testing.T) {
 
 		require.Len(t, commonPrefixes, 0)
 	}
+}
+
+func TestFSObjectClient_DeleteObject(t *testing.T) {
+	fsObjectsDir, err := ioutil.TempDir(os.TempDir(), "fs-delete-object")
+	require.NoError(t, err)
+
+	bucketClient, err := NewFSObjectClient(FSConfig{
+		Directory: fsObjectsDir,
+	})
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, os.RemoveAll(fsObjectsDir))
+	}()
+
+	foldersWithFiles := make(map[string][]string)
+	foldersWithFiles["folder1/"] = []string{"file1", "file2"}
+	foldersWithFiles["folder2/"] = []string{"file3", "file4", "file5"}
+
+	for folder, files := range foldersWithFiles {
+		for _, filename := range files {
+			err := bucketClient.PutObject(context.Background(), folder+filename, bytes.NewReader([]byte(filename)))
+			require.NoError(t, err)
+		}
+	}
+
+	// let us check if we have right folders created
+	_, commonPrefixes, err := bucketClient.List(context.Background(), "")
+	require.NoError(t, err)
+	require.Len(t, commonPrefixes, len(foldersWithFiles))
+
+	// let us delete file1 from folder1 and check that file1 is gone but folder1 with file2 is still there
+	require.NoError(t, bucketClient.DeleteObject(context.Background(), "folder1/file1"))
+	_, err = os.Stat(filepath.Join(fsObjectsDir, "folder1/file1"))
+	require.True(t, os.IsNotExist(err))
+
+	_, err = os.Stat(filepath.Join(fsObjectsDir, "folder1/file2"))
+	require.NoError(t, err)
+
+	// let us delete second file as well and check that folder1 also got removed
+	require.NoError(t, bucketClient.DeleteObject(context.Background(), "folder1/file2"))
+	_, err = os.Stat(filepath.Join(fsObjectsDir, "folder1"))
+	require.True(t, os.IsNotExist(err))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
When using`filesystem` as ObjectClient we will not remove the directory as well when it is the last object that is being deleted.
This PR also excludes empty directories from the listing with `List` calls.
Both these changes make `filesystem` as ObjectClient consistent with hosted object stores like S3, GCS and Azure.

Changes inspired from filesystem as object store in Thanos.

**Checklist**
- [x] Tests updated
