### PR TITLE
query-frontend: fix trace propagation when downstream_url is specifie…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [BUGFIX] Distributor: `/all_user_stats` now show API and Rule Ingest Rate correctly. #2457
 * [BUGFIX] Fixed `version`, `revision` and `branch` labels exported by the `cortex_build_info` metric. #2468
 * [BUGFIX] QueryFrontend: fixed a situation where HTTP error is ignored and an incorrect status code is set. #2483
+* [BUGFIX] QueryFrontend: fixed a situation where span context missed when downstream_url is used. #2538
 
 ## 1.0.0 / 2020-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 * [BUGFIX] Distributor: `/all_user_stats` now show API and Rule Ingest Rate correctly. #2457
 * [BUGFIX] Fixed `version`, `revision` and `branch` labels exported by the `cortex_build_info` metric. #2468
 * [BUGFIX] QueryFrontend: fixed a situation where HTTP error is ignored and an incorrect status code is set. #2483
-* [BUGFIX] QueryFrontend: fixed a situation where span context missed when downstream_url is used. #2538
+* [BUGFIX] QueryFrontend: fixed a situation where span context missed when downstream_url is used. #2539
 
 ## 1.0.0 / 2020-04-02
 

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -111,6 +111,11 @@ func New(cfg Config, log log.Logger, registerer prometheus.Registerer) (*Fronten
 		}
 
 		f.roundTripper = RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			tracer, span := opentracing.GlobalTracer(), opentracing.SpanFromContext(r.Context())
+			if tracer != nil && span != nil {
+				carrier := opentracing.HTTPHeadersCarrier(r.Header)
+				tracer.Inject(span.Context(), opentracing.HTTPHeaders, carrier)
+			}
 			r.URL.Scheme = u.Scheme
 			r.URL.Host = u.Host
 			r.URL.Path = path.Join(u.Path, r.URL.Path)


### PR DESCRIPTION
Fixes #2538