### PR TITLE
provisioning of table for delete requests using table manager

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1849,7 +1849,7 @@ delete_store:
   # CLI flag: -deletes.requests-table-name
   [requests_table_name: <string> | default = "delete_requests"]
 
-  provisionconfig:
+  table_provisioning:
     # Enables on demand throughput provisioning for the storage provider (if
     # supported). Applies only to tables which are not autoscaled. Supported by
     # DynamoDB

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1138,14 +1138,6 @@ The `table_manager_config` configures the Cortex table-manager.
 [creation_grace_period: <duration> | default = 10m]
 
 index_tables_provisioning:
-  # Number of last inactive tables to enable write autoscale.
-  # CLI flag: -table-manager.index-table.inactive-write-throughput.scale-last-n
-  [inactive_write_scale_lastn: <int> | default = 4]
-
-  # Number of last inactive tables to enable read autoscale.
-  # CLI flag: -table-manager.index-table.inactive-read-throughput.scale-last-n
-  [inactive_read_scale_lastn: <int> | default = 4]
-
   # Enables on demand throughput provisioning for the storage provider (if
   # supported). Applies only to tables which are not autoscaled. Supported by
   # DynamoDB
@@ -1290,15 +1282,15 @@ index_tables_provisioning:
     # CLI flag: -table-manager.index-table.inactive-read-throughput.scale.target-value
     [target: <float> | default = 80]
 
-chunk_tables_provisioning:
   # Number of last inactive tables to enable write autoscale.
-  # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale-last-n
+  # CLI flag: -table-manager.index-table.inactive-write-throughput.scale-last-n
   [inactive_write_scale_lastn: <int> | default = 4]
 
   # Number of last inactive tables to enable read autoscale.
-  # CLI flag: -table-manager.chunk-table.inactive-read-throughput.scale-last-n
+  # CLI flag: -table-manager.index-table.inactive-read-throughput.scale-last-n
   [inactive_read_scale_lastn: <int> | default = 4]
 
+chunk_tables_provisioning:
   # Enables on demand throughput provisioning for the storage provider (if
   # supported). Applies only to tables which are not autoscaled. Supported by
   # DynamoDB
@@ -1442,6 +1434,14 @@ chunk_tables_provisioning:
     # DynamoDB target ratio of consumed capacity to provisioned capacity.
     # CLI flag: -table-manager.chunk-table.inactive-read-throughput.scale.target-value
     [target: <float> | default = 80]
+
+  # Number of last inactive tables to enable write autoscale.
+  # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale-last-n
+  [inactive_write_scale_lastn: <int> | default = 4]
+
+  # Number of last inactive tables to enable read autoscale.
+  # CLI flag: -table-manager.chunk-table.inactive-read-throughput.scale-last-n
+  [inactive_read_scale_lastn: <int> | default = 4]
 ```
 
 ### `storage_config`
@@ -1853,78 +1853,78 @@ delete_store:
     # Enables on demand throughput provisioning for the storage provider (if
     # supported). Applies only to tables which are not autoscaled. Supported by
     # DynamoDB
-    # CLI flag: -deletes.tables.enable-ondemand-throughput-mode
+    # CLI flag: -deletes.table.enable-ondemand-throughput-mode
     [enable_ondemand_throughput_mode: <boolean> | default = false]
 
     # Table default write throughput. Supported by DynamoDB
-    # CLI flag: -deletes.tables.write-throughput
+    # CLI flag: -deletes.table.write-throughput
     [provisioned_write_throughput: <int> | default = 1]
 
     # Table default read throughput. Supported by DynamoDB
-    # CLI flag: -deletes.tables.read-throughput
+    # CLI flag: -deletes.table.read-throughput
     [provisioned_read_throughput: <int> | default = 300]
 
     write_scale:
       # Should we enable autoscale for the table.
-      # CLI flag: -deletes.tables.write-throughput.scale.enabled
+      # CLI flag: -deletes.table.write-throughput.scale.enabled
       [enabled: <boolean> | default = false]
 
       # AWS AutoScaling role ARN
-      # CLI flag: -deletes.tables.write-throughput.scale.role-arn
+      # CLI flag: -deletes.table.write-throughput.scale.role-arn
       [role_arn: <string> | default = ""]
 
       # DynamoDB minimum provision capacity.
-      # CLI flag: -deletes.tables.write-throughput.scale.min-capacity
+      # CLI flag: -deletes.table.write-throughput.scale.min-capacity
       [min_capacity: <int> | default = 3000]
 
       # DynamoDB maximum provision capacity.
-      # CLI flag: -deletes.tables.write-throughput.scale.max-capacity
+      # CLI flag: -deletes.table.write-throughput.scale.max-capacity
       [max_capacity: <int> | default = 6000]
 
       # DynamoDB minimum seconds between each autoscale up.
-      # CLI flag: -deletes.tables.write-throughput.scale.out-cooldown
+      # CLI flag: -deletes.table.write-throughput.scale.out-cooldown
       [out_cooldown: <int> | default = 1800]
 
       # DynamoDB minimum seconds between each autoscale down.
-      # CLI flag: -deletes.tables.write-throughput.scale.in-cooldown
+      # CLI flag: -deletes.table.write-throughput.scale.in-cooldown
       [in_cooldown: <int> | default = 1800]
 
       # DynamoDB target ratio of consumed capacity to provisioned capacity.
-      # CLI flag: -deletes.tables.write-throughput.scale.target-value
+      # CLI flag: -deletes.table.write-throughput.scale.target-value
       [target: <float> | default = 80]
 
     read_scale:
       # Should we enable autoscale for the table.
-      # CLI flag: -deletes.tables.read-throughput.scale.enabled
+      # CLI flag: -deletes.table.read-throughput.scale.enabled
       [enabled: <boolean> | default = false]
 
       # AWS AutoScaling role ARN
-      # CLI flag: -deletes.tables.read-throughput.scale.role-arn
+      # CLI flag: -deletes.table.read-throughput.scale.role-arn
       [role_arn: <string> | default = ""]
 
       # DynamoDB minimum provision capacity.
-      # CLI flag: -deletes.tables.read-throughput.scale.min-capacity
+      # CLI flag: -deletes.table.read-throughput.scale.min-capacity
       [min_capacity: <int> | default = 3000]
 
       # DynamoDB maximum provision capacity.
-      # CLI flag: -deletes.tables.read-throughput.scale.max-capacity
+      # CLI flag: -deletes.table.read-throughput.scale.max-capacity
       [max_capacity: <int> | default = 6000]
 
       # DynamoDB minimum seconds between each autoscale up.
-      # CLI flag: -deletes.tables.read-throughput.scale.out-cooldown
+      # CLI flag: -deletes.table.read-throughput.scale.out-cooldown
       [out_cooldown: <int> | default = 1800]
 
       # DynamoDB minimum seconds between each autoscale down.
-      # CLI flag: -deletes.tables.read-throughput.scale.in-cooldown
+      # CLI flag: -deletes.table.read-throughput.scale.in-cooldown
       [in_cooldown: <int> | default = 1800]
 
       # DynamoDB target ratio of consumed capacity to provisioned capacity.
-      # CLI flag: -deletes.tables.read-throughput.scale.target-value
+      # CLI flag: -deletes.table.read-throughput.scale.target-value
       [target: <float> | default = 80]
 
     # Tag (of the form key=value) to be added to the tables. Supported by
     # DynamoDB
-    # CLI flag: -deletes.tables.tags
+    # CLI flag: -deletes.table.tags
     [tags: <map of string to string> | default = ]
 
 grpc_store:

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1138,6 +1138,14 @@ The `table_manager_config` configures the Cortex table-manager.
 [creation_grace_period: <duration> | default = 10m]
 
 index_tables_provisioning:
+  # Number of last inactive tables to enable write autoscale.
+  # CLI flag: -table-manager.index-table.inactive-write-throughput.scale-last-n
+  [inactive_write_scale_lastn: <int> | default = 4]
+
+  # Number of last inactive tables to enable read autoscale.
+  # CLI flag: -table-manager.index-table.inactive-read-throughput.scale-last-n
+  [inactive_read_scale_lastn: <int> | default = 4]
+
   # Enables on demand throughput provisioning for the storage provider (if
   # supported). Applies only to tables which are not autoscaled. Supported by
   # DynamoDB
@@ -1151,20 +1159,6 @@ index_tables_provisioning:
   # Table default read throughput. Supported by DynamoDB
   # CLI flag: -table-manager.index-table.read-throughput
   [provisioned_read_throughput: <int> | default = 300]
-
-  # Enables on demand throughput provisioning for the storage provider (if
-  # supported). Applies only to tables which are not autoscaled. Supported by
-  # DynamoDB
-  # CLI flag: -table-manager.index-table.inactive-enable-ondemand-throughput-mode
-  [enable_inactive_throughput_on_demand_mode: <boolean> | default = false]
-
-  # Table write throughput for inactive tables. Supported by DynamoDB
-  # CLI flag: -table-manager.index-table.inactive-write-throughput
-  [inactive_write_throughput: <int> | default = 1]
-
-  # Table read throughput for inactive tables. Supported by DynamoDB
-  # CLI flag: -table-manager.index-table.inactive-read-throughput
-  [inactive_read_throughput: <int> | default = 300]
 
   write_scale:
     # Should we enable autoscale for the table.
@@ -1195,39 +1189,6 @@ index_tables_provisioning:
     # CLI flag: -table-manager.index-table.write-throughput.scale.target-value
     [target: <float> | default = 80]
 
-  inactive_write_scale:
-    # Should we enable autoscale for the table.
-    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.enabled
-    [enabled: <boolean> | default = false]
-
-    # AWS AutoScaling role ARN
-    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.role-arn
-    [role_arn: <string> | default = ""]
-
-    # DynamoDB minimum provision capacity.
-    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.min-capacity
-    [min_capacity: <int> | default = 3000]
-
-    # DynamoDB maximum provision capacity.
-    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.max-capacity
-    [max_capacity: <int> | default = 6000]
-
-    # DynamoDB minimum seconds between each autoscale up.
-    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.out-cooldown
-    [out_cooldown: <int> | default = 1800]
-
-    # DynamoDB minimum seconds between each autoscale down.
-    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.in-cooldown
-    [in_cooldown: <int> | default = 1800]
-
-    # DynamoDB target ratio of consumed capacity to provisioned capacity.
-    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.target-value
-    [target: <float> | default = 80]
-
-  # Number of last inactive tables to enable write autoscale.
-  # CLI flag: -table-manager.index-table.inactive-write-throughput.scale-last-n
-  [inactive_write_scale_lastn: <int> | default = 4]
-
   read_scale:
     # Should we enable autoscale for the table.
     # CLI flag: -table-manager.index-table.read-throughput.scale.enabled
@@ -1255,6 +1216,49 @@ index_tables_provisioning:
 
     # DynamoDB target ratio of consumed capacity to provisioned capacity.
     # CLI flag: -table-manager.index-table.read-throughput.scale.target-value
+    [target: <float> | default = 80]
+
+  # Enables on demand throughput provisioning for the storage provider (if
+  # supported). Applies only to tables which are not autoscaled. Supported by
+  # DynamoDB
+  # CLI flag: -table-manager.index-table.inactive-enable-ondemand-throughput-mode
+  [enable_inactive_throughput_on_demand_mode: <boolean> | default = false]
+
+  # Table write throughput for inactive tables. Supported by DynamoDB
+  # CLI flag: -table-manager.index-table.inactive-write-throughput
+  [inactive_write_throughput: <int> | default = 1]
+
+  # Table read throughput for inactive tables. Supported by DynamoDB
+  # CLI flag: -table-manager.index-table.inactive-read-throughput
+  [inactive_read_throughput: <int> | default = 300]
+
+  inactive_write_scale:
+    # Should we enable autoscale for the table.
+    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.enabled
+    [enabled: <boolean> | default = false]
+
+    # AWS AutoScaling role ARN
+    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.role-arn
+    [role_arn: <string> | default = ""]
+
+    # DynamoDB minimum provision capacity.
+    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.min-capacity
+    [min_capacity: <int> | default = 3000]
+
+    # DynamoDB maximum provision capacity.
+    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.max-capacity
+    [max_capacity: <int> | default = 6000]
+
+    # DynamoDB minimum seconds between each autoscale up.
+    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.out-cooldown
+    [out_cooldown: <int> | default = 1800]
+
+    # DynamoDB minimum seconds between each autoscale down.
+    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.in-cooldown
+    [in_cooldown: <int> | default = 1800]
+
+    # DynamoDB target ratio of consumed capacity to provisioned capacity.
+    # CLI flag: -table-manager.index-table.inactive-write-throughput.scale.target-value
     [target: <float> | default = 80]
 
   inactive_read_scale:
@@ -1286,11 +1290,15 @@ index_tables_provisioning:
     # CLI flag: -table-manager.index-table.inactive-read-throughput.scale.target-value
     [target: <float> | default = 80]
 
+chunk_tables_provisioning:
+  # Number of last inactive tables to enable write autoscale.
+  # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale-last-n
+  [inactive_write_scale_lastn: <int> | default = 4]
+
   # Number of last inactive tables to enable read autoscale.
-  # CLI flag: -table-manager.index-table.inactive-read-throughput.scale-last-n
+  # CLI flag: -table-manager.chunk-table.inactive-read-throughput.scale-last-n
   [inactive_read_scale_lastn: <int> | default = 4]
 
-chunk_tables_provisioning:
   # Enables on demand throughput provisioning for the storage provider (if
   # supported). Applies only to tables which are not autoscaled. Supported by
   # DynamoDB
@@ -1304,20 +1312,6 @@ chunk_tables_provisioning:
   # Table default read throughput. Supported by DynamoDB
   # CLI flag: -table-manager.chunk-table.read-throughput
   [provisioned_read_throughput: <int> | default = 300]
-
-  # Enables on demand throughput provisioning for the storage provider (if
-  # supported). Applies only to tables which are not autoscaled. Supported by
-  # DynamoDB
-  # CLI flag: -table-manager.chunk-table.inactive-enable-ondemand-throughput-mode
-  [enable_inactive_throughput_on_demand_mode: <boolean> | default = false]
-
-  # Table write throughput for inactive tables. Supported by DynamoDB
-  # CLI flag: -table-manager.chunk-table.inactive-write-throughput
-  [inactive_write_throughput: <int> | default = 1]
-
-  # Table read throughput for inactive tables. Supported by DynamoDB
-  # CLI flag: -table-manager.chunk-table.inactive-read-throughput
-  [inactive_read_throughput: <int> | default = 300]
 
   write_scale:
     # Should we enable autoscale for the table.
@@ -1348,39 +1342,6 @@ chunk_tables_provisioning:
     # CLI flag: -table-manager.chunk-table.write-throughput.scale.target-value
     [target: <float> | default = 80]
 
-  inactive_write_scale:
-    # Should we enable autoscale for the table.
-    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.enabled
-    [enabled: <boolean> | default = false]
-
-    # AWS AutoScaling role ARN
-    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.role-arn
-    [role_arn: <string> | default = ""]
-
-    # DynamoDB minimum provision capacity.
-    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.min-capacity
-    [min_capacity: <int> | default = 3000]
-
-    # DynamoDB maximum provision capacity.
-    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.max-capacity
-    [max_capacity: <int> | default = 6000]
-
-    # DynamoDB minimum seconds between each autoscale up.
-    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.out-cooldown
-    [out_cooldown: <int> | default = 1800]
-
-    # DynamoDB minimum seconds between each autoscale down.
-    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.in-cooldown
-    [in_cooldown: <int> | default = 1800]
-
-    # DynamoDB target ratio of consumed capacity to provisioned capacity.
-    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.target-value
-    [target: <float> | default = 80]
-
-  # Number of last inactive tables to enable write autoscale.
-  # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale-last-n
-  [inactive_write_scale_lastn: <int> | default = 4]
-
   read_scale:
     # Should we enable autoscale for the table.
     # CLI flag: -table-manager.chunk-table.read-throughput.scale.enabled
@@ -1408,6 +1369,49 @@ chunk_tables_provisioning:
 
     # DynamoDB target ratio of consumed capacity to provisioned capacity.
     # CLI flag: -table-manager.chunk-table.read-throughput.scale.target-value
+    [target: <float> | default = 80]
+
+  # Enables on demand throughput provisioning for the storage provider (if
+  # supported). Applies only to tables which are not autoscaled. Supported by
+  # DynamoDB
+  # CLI flag: -table-manager.chunk-table.inactive-enable-ondemand-throughput-mode
+  [enable_inactive_throughput_on_demand_mode: <boolean> | default = false]
+
+  # Table write throughput for inactive tables. Supported by DynamoDB
+  # CLI flag: -table-manager.chunk-table.inactive-write-throughput
+  [inactive_write_throughput: <int> | default = 1]
+
+  # Table read throughput for inactive tables. Supported by DynamoDB
+  # CLI flag: -table-manager.chunk-table.inactive-read-throughput
+  [inactive_read_throughput: <int> | default = 300]
+
+  inactive_write_scale:
+    # Should we enable autoscale for the table.
+    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.enabled
+    [enabled: <boolean> | default = false]
+
+    # AWS AutoScaling role ARN
+    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.role-arn
+    [role_arn: <string> | default = ""]
+
+    # DynamoDB minimum provision capacity.
+    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.min-capacity
+    [min_capacity: <int> | default = 3000]
+
+    # DynamoDB maximum provision capacity.
+    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.max-capacity
+    [max_capacity: <int> | default = 6000]
+
+    # DynamoDB minimum seconds between each autoscale up.
+    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.out-cooldown
+    [out_cooldown: <int> | default = 1800]
+
+    # DynamoDB minimum seconds between each autoscale down.
+    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.in-cooldown
+    [in_cooldown: <int> | default = 1800]
+
+    # DynamoDB target ratio of consumed capacity to provisioned capacity.
+    # CLI flag: -table-manager.chunk-table.inactive-write-throughput.scale.target-value
     [target: <float> | default = 80]
 
   inactive_read_scale:
@@ -1438,10 +1442,6 @@ chunk_tables_provisioning:
     # DynamoDB target ratio of consumed capacity to provisioned capacity.
     # CLI flag: -table-manager.chunk-table.inactive-read-throughput.scale.target-value
     [target: <float> | default = 80]
-
-  # Number of last inactive tables to enable read autoscale.
-  # CLI flag: -table-manager.chunk-table.inactive-read-throughput.scale-last-n
-  [inactive_read_scale_lastn: <int> | default = 4]
 ```
 
 ### `storage_config`
@@ -1848,6 +1848,84 @@ delete_store:
   # Name of the table which stores delete requests
   # CLI flag: -deletes.requests-table-name
   [requests_table_name: <string> | default = "delete_requests"]
+
+  provisionconfig:
+    # Enables on demand throughput provisioning for the storage provider (if
+    # supported). Applies only to tables which are not autoscaled. Supported by
+    # DynamoDB
+    # CLI flag: -deletes.tables.enable-ondemand-throughput-mode
+    [enable_ondemand_throughput_mode: <boolean> | default = false]
+
+    # Table default write throughput. Supported by DynamoDB
+    # CLI flag: -deletes.tables.write-throughput
+    [provisioned_write_throughput: <int> | default = 1]
+
+    # Table default read throughput. Supported by DynamoDB
+    # CLI flag: -deletes.tables.read-throughput
+    [provisioned_read_throughput: <int> | default = 300]
+
+    write_scale:
+      # Should we enable autoscale for the table.
+      # CLI flag: -deletes.tables.write-throughput.scale.enabled
+      [enabled: <boolean> | default = false]
+
+      # AWS AutoScaling role ARN
+      # CLI flag: -deletes.tables.write-throughput.scale.role-arn
+      [role_arn: <string> | default = ""]
+
+      # DynamoDB minimum provision capacity.
+      # CLI flag: -deletes.tables.write-throughput.scale.min-capacity
+      [min_capacity: <int> | default = 3000]
+
+      # DynamoDB maximum provision capacity.
+      # CLI flag: -deletes.tables.write-throughput.scale.max-capacity
+      [max_capacity: <int> | default = 6000]
+
+      # DynamoDB minimum seconds between each autoscale up.
+      # CLI flag: -deletes.tables.write-throughput.scale.out-cooldown
+      [out_cooldown: <int> | default = 1800]
+
+      # DynamoDB minimum seconds between each autoscale down.
+      # CLI flag: -deletes.tables.write-throughput.scale.in-cooldown
+      [in_cooldown: <int> | default = 1800]
+
+      # DynamoDB target ratio of consumed capacity to provisioned capacity.
+      # CLI flag: -deletes.tables.write-throughput.scale.target-value
+      [target: <float> | default = 80]
+
+    read_scale:
+      # Should we enable autoscale for the table.
+      # CLI flag: -deletes.tables.read-throughput.scale.enabled
+      [enabled: <boolean> | default = false]
+
+      # AWS AutoScaling role ARN
+      # CLI flag: -deletes.tables.read-throughput.scale.role-arn
+      [role_arn: <string> | default = ""]
+
+      # DynamoDB minimum provision capacity.
+      # CLI flag: -deletes.tables.read-throughput.scale.min-capacity
+      [min_capacity: <int> | default = 3000]
+
+      # DynamoDB maximum provision capacity.
+      # CLI flag: -deletes.tables.read-throughput.scale.max-capacity
+      [max_capacity: <int> | default = 6000]
+
+      # DynamoDB minimum seconds between each autoscale up.
+      # CLI flag: -deletes.tables.read-throughput.scale.out-cooldown
+      [out_cooldown: <int> | default = 1800]
+
+      # DynamoDB minimum seconds between each autoscale down.
+      # CLI flag: -deletes.tables.read-throughput.scale.in-cooldown
+      [in_cooldown: <int> | default = 1800]
+
+      # DynamoDB target ratio of consumed capacity to provisioned capacity.
+      # CLI flag: -deletes.tables.read-throughput.scale.target-value
+      [target: <float> | default = 80]
+
+    # Tag (of the form key=value) to be added to the tables. Supported by
+    # DynamoDB
+    # CLI flag: -deletes.tables.tags
+    [tags: <map of string to string> | default = ]
 
 grpc_store:
   # Hostname or IP of the gRPC store instance.

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -58,24 +58,32 @@ func fixturePeriodicTableConfig(prefix string) chunk.PeriodicTableConfig {
 
 func fixtureProvisionConfig(inactLastN int64, writeScale, inactWriteScale chunk.AutoScalingConfig) chunk.ProvisionConfig {
 	return chunk.ProvisionConfig{
-		ProvisionedWriteThroughput: write,
-		ProvisionedReadThroughput:  read,
-		InactiveWriteThroughput:    inactiveWrite,
-		InactiveReadThroughput:     inactiveRead,
-		WriteScale:                 writeScale,
-		InactiveWriteScale:         inactWriteScale,
-		InactiveWriteScaleLastN:    inactLastN,
+		ActiveTableProvisionConfig: chunk.ActiveTableProvisionConfig{
+			ProvisionedWriteThroughput: write,
+			ProvisionedReadThroughput:  read,
+			WriteScale:                 writeScale,
+		},
+		InactiveTableProvisionConfig: chunk.InactiveTableProvisionConfig{
+			InactiveWriteThroughput: inactiveWrite,
+			InactiveReadThroughput:  inactiveRead,
+			InactiveWriteScale:      inactWriteScale,
+		},
+		InactiveWriteScaleLastN: inactLastN,
 	}
 }
 
 func fixtureReadProvisionConfig(readScale, inactReadScale chunk.AutoScalingConfig) chunk.ProvisionConfig {
 	return chunk.ProvisionConfig{
-		ProvisionedWriteThroughput: write,
-		ProvisionedReadThroughput:  read,
-		InactiveWriteThroughput:    inactiveWrite,
-		InactiveReadThroughput:     inactiveRead,
-		ReadScale:                  readScale,
-		InactiveReadScale:          inactReadScale,
+		ActiveTableProvisionConfig: chunk.ActiveTableProvisionConfig{
+			ProvisionedWriteThroughput: write,
+			ProvisionedReadThroughput:  read,
+			ReadScale:                  readScale,
+		},
+		InactiveTableProvisionConfig: chunk.InactiveTableProvisionConfig{
+			InactiveWriteThroughput: inactiveWrite,
+			InactiveReadThroughput:  inactiveRead,
+			InactiveReadScale:       inactReadScale,
+		},
 	}
 }
 
@@ -162,7 +170,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 		ChunkTables:         fixtureProvisionConfig(2, chunkWriteScale, inactiveWriteScale),
 	}
 
-	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil)
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +328,7 @@ func TestTableManagerMetricsReadAutoScaling(t *testing.T) {
 		ChunkTables:         fixtureReadProvisionConfig(chunkReadScale, inactiveReadScale),
 	}
 
-	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil)
+	tableManager, err := chunk.NewTableManager(tbm, cfg, maxChunkAge, client, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -67,8 +67,8 @@ func fixtureProvisionConfig(inactLastN int64, writeScale, inactWriteScale chunk.
 			InactiveWriteThroughput: inactiveWrite,
 			InactiveReadThroughput:  inactiveRead,
 			InactiveWriteScale:      inactWriteScale,
+			InactiveWriteScaleLastN: inactLastN,
 		},
-		InactiveWriteScaleLastN: inactLastN,
 	}
 }
 

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -79,7 +79,7 @@ func newTestChunkStoreConfigWithMockStorage(t require.TestingT, schemaCfg Schema
 	require.NoError(t, err)
 	flagext.DefaultValues(&tbmConfig)
 	storage := NewMockStorage()
-	tableManager, err := NewTableManager(tbmConfig, schemaCfg, maxChunkAge, storage, nil, nil)
+	tableManager, err := NewTableManager(tbmConfig, schemaCfg, maxChunkAge, storage, nil, nil, nil)
 	require.NoError(t, err)
 
 	err = tableManager.SyncTables(context.Background())

--- a/pkg/chunk/purger/delete_requests_store.go
+++ b/pkg/chunk/purger/delete_requests_store.go
@@ -73,12 +73,14 @@ type DeleteStore struct {
 
 // DeleteStoreConfig holds configuration for delete store.
 type DeleteStoreConfig struct {
-	Store             string `yaml:"store"`
-	RequestsTableName string `yaml:"requests_table_name"`
+	Store             string                  `yaml:"store"`
+	RequestsTableName string                  `yaml:"requests_table_name"`
+	ProvisionConfig   TableProvisioningConfig `json:"table_provisioning"`
 }
 
 // RegisterFlags adds the flags required to configure this flag set.
 func (cfg *DeleteStoreConfig) RegisterFlags(f *flag.FlagSet) {
+	cfg.ProvisionConfig.RegisterFlags("deletes.tables", f)
 	f.StringVar(&cfg.Store, "deletes.store", "", "Store for keeping delete request")
 	f.StringVar(&cfg.RequestsTableName, "deletes.requests-table-name", "delete_requests", "Name of the table which stores delete requests")
 }

--- a/pkg/chunk/purger/delete_requests_store.go
+++ b/pkg/chunk/purger/delete_requests_store.go
@@ -80,7 +80,7 @@ type DeleteStoreConfig struct {
 
 // RegisterFlags adds the flags required to configure this flag set.
 func (cfg *DeleteStoreConfig) RegisterFlags(f *flag.FlagSet) {
-	cfg.ProvisionConfig.RegisterFlags("deletes.tables", f)
+	cfg.ProvisionConfig.RegisterFlags("deletes.table", f)
 	f.StringVar(&cfg.Store, "deletes.store", "", "Store for keeping delete request")
 	f.StringVar(&cfg.RequestsTableName, "deletes.requests-table-name", "delete_requests", "Name of the table which stores delete requests")
 }

--- a/pkg/chunk/purger/delete_requests_store.go
+++ b/pkg/chunk/purger/delete_requests_store.go
@@ -75,7 +75,7 @@ type DeleteStore struct {
 type DeleteStoreConfig struct {
 	Store             string                  `yaml:"store"`
 	RequestsTableName string                  `yaml:"requests_table_name"`
-	ProvisionConfig   TableProvisioningConfig `json:"table_provisioning"`
+	ProvisionConfig   TableProvisioningConfig `yaml:"table_provisioning"`
 }
 
 // RegisterFlags adds the flags required to configure this flag set.

--- a/pkg/chunk/purger/purger_test.go
+++ b/pkg/chunk/purger/purger_test.go
@@ -36,11 +36,10 @@ func setupTestDeleteStore(t *testing.T) *DeleteStore {
 	mockStorage := chunk.NewMockStorage()
 
 	extraTables := []chunk.ExtraTables{{TableClient: mockStorage, Tables: deleteStoreConfig.GetTables()}}
-	tableManager, err := chunk.NewTableManager(tbmConfig, schemaCfg, 12*time.Hour, mockStorage, nil, nil, extraTables)
+	tableManager, err := chunk.NewTableManager(tbmConfig, schemaCfg, 12*time.Hour, mockStorage, nil, extraTables, nil)
 	require.NoError(t, err)
 
-	require.NoError(t, tableManager.StartAsync(context.Background()))
-	require.NoError(t, tableManager.AwaitRunning(context.Background()))
+	require.NoError(t, tableManager.SyncTables(context.Background()))
 
 	deleteStore, err := NewDeleteStore(deleteStoreConfig, mockStorage)
 	require.NoError(t, err)

--- a/pkg/chunk/purger/purger_test.go
+++ b/pkg/chunk/purger/purger_test.go
@@ -24,25 +24,32 @@ const (
 	modelTimeHour = model.Time(time.Hour / time.Millisecond)
 )
 
-func setupTestDeleteStore() (*DeleteStore, error) {
-	var deleteStoreConfig DeleteStoreConfig
+func setupTestDeleteStore(t *testing.T) *DeleteStore {
+	var (
+		deleteStoreConfig DeleteStoreConfig
+		tbmConfig         chunk.TableManagerConfig
+		schemaCfg         = chunk.DefaultSchemaConfig("", "v10", 0)
+	)
 	flagext.DefaultValues(&deleteStoreConfig)
+	flagext.DefaultValues(&tbmConfig)
 
 	mockStorage := chunk.NewMockStorage()
 
-	err := mockStorage.CreateTable(context.Background(), chunk.TableDesc{
-		Name: deleteStoreConfig.RequestsTableName,
-	})
-	if err != nil {
-		return nil, err
-	}
+	extraTables := []chunk.ExtraTables{{TableClient: mockStorage, Tables: deleteStoreConfig.GetTables()}}
+	tableManager, err := chunk.NewTableManager(tbmConfig, schemaCfg, 12*time.Hour, mockStorage, nil, nil, extraTables)
+	require.NoError(t, err)
 
-	return NewDeleteStore(deleteStoreConfig, mockStorage)
+	require.NoError(t, tableManager.StartAsync(context.Background()))
+	require.NoError(t, tableManager.AwaitRunning(context.Background()))
+
+	deleteStore, err := NewDeleteStore(deleteStoreConfig, mockStorage)
+	require.NoError(t, err)
+
+	return deleteStore
 }
 
 func setupStoresAndPurger(t *testing.T) (*DeleteStore, chunk.Store, chunk.ObjectClient, *DataPurger) {
-	deleteStore, err := setupTestDeleteStore()
-	require.NoError(t, err)
+	deleteStore := setupTestDeleteStore(t)
 
 	chunkStore, err := testutils.SetupTestChunkStore()
 	require.NoError(t, err)

--- a/pkg/chunk/purger/table_provisioning.go
+++ b/pkg/chunk/purger/table_provisioning.go
@@ -1,0 +1,30 @@
+package purger
+
+import (
+	"flag"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+)
+
+// TableProvisioningConfig holds config for table throuput and autoscaling. Currently only used by DynamoDB.
+type TableProvisioningConfig struct {
+	chunk.ActiveTableProvisionConfig `yaml:",inline"`
+	TableTags                        chunk.Tags `yaml:"tags"`
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet.
+// Adding a separate RegisterFlags here instead of using it from embedded chunk.ActiveTableProvisionConfig to be able to manage defaults separately.
+// Defaults for WriteScale and ReadScale are shared for now to avoid adding further complexity since autoscaling is disabled anyways by default.
+func (cfg *TableProvisioningConfig) RegisterFlags(argPrefix string, f *flag.FlagSet) {
+	f.Int64Var(&cfg.ProvisionedWriteThroughput, argPrefix+".write-throughput", 1, "Table default write throughput. Supported by DynamoDB")
+	f.Int64Var(&cfg.ProvisionedReadThroughput, argPrefix+".read-throughput", 300, "Table default read throughput. Supported by DynamoDB")
+	f.BoolVar(&cfg.ProvisionedThroughputOnDemandMode, argPrefix+".enable-ondemand-throughput-mode", false, "Enables on demand throughput provisioning for the storage provider (if supported). Applies only to tables which are not autoscaled. Supported by DynamoDB")
+	f.Var(&cfg.TableTags, argPrefix+".tags", "Tag (of the form key=value) to be added to the tables. Supported by DynamoDB")
+
+	cfg.WriteScale.RegisterFlags(argPrefix+".write-throughput.scale", f)
+	cfg.ReadScale.RegisterFlags(argPrefix+".read-throughput.scale", f)
+}
+
+func (cfg DeleteStoreConfig) GetTables() []chunk.TableDesc {
+	return []chunk.TableDesc{cfg.ProvisionConfig.BuildTableDesc(cfg.RequestsTableName, cfg.ProvisionConfig.TableTags)}
+}

--- a/pkg/chunk/purger/table_provisioning.go
+++ b/pkg/chunk/purger/table_provisioning.go
@@ -16,13 +16,13 @@ type TableProvisioningConfig struct {
 // Adding a separate RegisterFlags here instead of using it from embedded chunk.ActiveTableProvisionConfig to be able to manage defaults separately.
 // Defaults for WriteScale and ReadScale are shared for now to avoid adding further complexity since autoscaling is disabled anyways by default.
 func (cfg *TableProvisioningConfig) RegisterFlags(argPrefix string, f *flag.FlagSet) {
-	f.Int64Var(&cfg.ProvisionedWriteThroughput, argPrefix+".write-throughput", 1, "Table default write throughput. Supported by DynamoDB")
-	f.Int64Var(&cfg.ProvisionedReadThroughput, argPrefix+".read-throughput", 300, "Table default read throughput. Supported by DynamoDB")
-	f.BoolVar(&cfg.ProvisionedThroughputOnDemandMode, argPrefix+".enable-ondemand-throughput-mode", false, "Enables on demand throughput provisioning for the storage provider (if supported). Applies only to tables which are not autoscaled. Supported by DynamoDB")
-	f.Var(&cfg.TableTags, argPrefix+".tags", "Tag (of the form key=value) to be added to the tables. Supported by DynamoDB")
+	// default values ActiveTableProvisionConfig
+	cfg.ProvisionedWriteThroughput = 1
+	cfg.ProvisionedReadThroughput = 300
+	cfg.ProvisionedThroughputOnDemandMode = false
 
-	cfg.WriteScale.RegisterFlags(argPrefix+".write-throughput.scale", f)
-	cfg.ReadScale.RegisterFlags(argPrefix+".read-throughput.scale", f)
+	cfg.ActiveTableProvisionConfig.RegisterFlags(argPrefix, f)
+	f.Var(&cfg.TableTags, argPrefix+".tags", "Tag (of the form key=value) to be added to the tables. Supported by DynamoDB")
 }
 
 func (cfg DeleteStoreConfig) GetTables() []chunk.TableDesc {

--- a/pkg/chunk/purger/tombstones_test.go
+++ b/pkg/chunk/purger/tombstones_test.go
@@ -94,9 +94,7 @@ func TestTombstonesLoader(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			deleteStore, err := setupTestDeleteStore()
-			require.NoError(t, err)
-
+			deleteStore := setupTestDeleteStore(t)
 			tombstonesLoader := NewTombstonesLoader(deleteStore, nil)
 
 			// add delete requests

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -81,6 +81,13 @@ func newTableManagerMetrics(r prometheus.Registerer) *tableManagerMetrics {
 	return &m
 }
 
+// ExtraTables holds the list of tables that TableManager has to manage using a TableClient.
+// This is useful for managing tables other than Chunk and Index tables.
+type ExtraTables struct {
+	TableClient TableClient
+	Tables      []TableDesc
+}
+
 // TableManagerConfig holds config for a TableManager
 type TableManagerConfig struct {
 	// Master 'off-switch' for table capacity updates, e.g. when troubleshooting
@@ -139,23 +146,6 @@ func (cfg *TableManagerConfig) Validate() error {
 	return nil
 }
 
-// ProvisionConfig holds config for provisioning capacity (on DynamoDB for now)
-type ProvisionConfig struct {
-	ProvisionedThroughputOnDemandMode bool  `yaml:"enable_ondemand_throughput_mode"`
-	ProvisionedWriteThroughput        int64 `yaml:"provisioned_write_throughput"`
-	ProvisionedReadThroughput         int64 `yaml:"provisioned_read_throughput"`
-	InactiveThroughputOnDemandMode    bool  `yaml:"enable_inactive_throughput_on_demand_mode"`
-	InactiveWriteThroughput           int64 `yaml:"inactive_write_throughput"`
-	InactiveReadThroughput            int64 `yaml:"inactive_read_throughput"`
-
-	WriteScale              AutoScalingConfig `yaml:"write_scale"`
-	InactiveWriteScale      AutoScalingConfig `yaml:"inactive_write_scale"`
-	InactiveWriteScaleLastN int64             `yaml:"inactive_write_scale_lastn"`
-	ReadScale               AutoScalingConfig `yaml:"read_scale"`
-	InactiveReadScale       AutoScalingConfig `yaml:"inactive_read_scale"`
-	InactiveReadScaleLastN  int64             `yaml:"inactive_read_scale_lastn"`
-}
-
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *TableManagerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.ThroughputUpdatesDisabled, "table-manager.throughput-updates-disabled", false, "If true, disable all changes to DB capacity")
@@ -168,24 +158,6 @@ func (cfg *TableManagerConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.ChunkTables.RegisterFlags("table-manager.chunk-table", f)
 }
 
-// RegisterFlags adds the flags required to config this to the given FlagSet.
-func (cfg *ProvisionConfig) RegisterFlags(argPrefix string, f *flag.FlagSet) {
-	f.Int64Var(&cfg.ProvisionedWriteThroughput, argPrefix+".write-throughput", 1000, "Table default write throughput. Supported by DynamoDB")
-	f.Int64Var(&cfg.ProvisionedReadThroughput, argPrefix+".read-throughput", 300, "Table default read throughput. Supported by DynamoDB")
-	f.BoolVar(&cfg.ProvisionedThroughputOnDemandMode, argPrefix+".enable-ondemand-throughput-mode", false, "Enables on demand throughput provisioning for the storage provider (if supported). Applies only to tables which are not autoscaled. Supported by DynamoDB")
-	f.Int64Var(&cfg.InactiveWriteThroughput, argPrefix+".inactive-write-throughput", 1, "Table write throughput for inactive tables. Supported by DynamoDB")
-	f.Int64Var(&cfg.InactiveReadThroughput, argPrefix+".inactive-read-throughput", 300, "Table read throughput for inactive tables. Supported by DynamoDB")
-	f.BoolVar(&cfg.InactiveThroughputOnDemandMode, argPrefix+".inactive-enable-ondemand-throughput-mode", false, "Enables on demand throughput provisioning for the storage provider (if supported). Applies only to tables which are not autoscaled. Supported by DynamoDB")
-
-	cfg.WriteScale.RegisterFlags(argPrefix+".write-throughput.scale", f)
-	cfg.InactiveWriteScale.RegisterFlags(argPrefix+".inactive-write-throughput.scale", f)
-	f.Int64Var(&cfg.InactiveWriteScaleLastN, argPrefix+".inactive-write-throughput.scale-last-n", 4, "Number of last inactive tables to enable write autoscale.")
-
-	cfg.ReadScale.RegisterFlags(argPrefix+".read-throughput.scale", f)
-	cfg.InactiveReadScale.RegisterFlags(argPrefix+".inactive-read-throughput.scale", f)
-	f.Int64Var(&cfg.InactiveReadScaleLastN, argPrefix+".inactive-read-throughput.scale-last-n", 4, "Number of last inactive tables to enable read autoscale.")
-}
-
 // TableManager creates and manages the provisioned throughput on DynamoDB tables
 type TableManager struct {
 	services.Service
@@ -196,13 +168,14 @@ type TableManager struct {
 	maxChunkAge  time.Duration
 	bucketClient BucketClient
 	metrics      *tableManagerMetrics
+	extraTables  []ExtraTables
 
 	bucketRetentionLoop services.Service
 }
 
 // NewTableManager makes a new TableManager
 func NewTableManager(cfg TableManagerConfig, schemaCfg SchemaConfig, maxChunkAge time.Duration, tableClient TableClient,
-	objectClient BucketClient, registerer prometheus.Registerer) (*TableManager, error) {
+	objectClient BucketClient, registerer prometheus.Registerer, extraTables []ExtraTables) (*TableManager, error) {
 
 	if cfg.RetentionPeriod != 0 {
 		// Assume the newest config is the one to use for validation of retention
@@ -219,6 +192,7 @@ func NewTableManager(cfg TableManagerConfig, schemaCfg SchemaConfig, maxChunkAge
 		client:       tableClient,
 		bucketClient: objectClient,
 		metrics:      newTableManagerMetrics(registerer),
+		extraTables:  extraTables,
 	}
 
 	tm.Service = services.NewBasicService(tm.starting, tm.loop, tm.stopping)
@@ -227,6 +201,10 @@ func NewTableManager(cfg TableManagerConfig, schemaCfg SchemaConfig, maxChunkAge
 
 // Start the TableManager
 func (m *TableManager) starting(ctx context.Context) error {
+	err := m.checkAndCreateExtraTables()
+	if err != nil {
+		return err
+	}
 	if m.bucketClient != nil && m.cfg.RetentionPeriod != 0 && m.cfg.RetentionDeletesEnabled {
 		m.bucketRetentionLoop = services.NewTimerService(bucketRetentionEnforcementInterval, nil, m.bucketRetentionIteration, nil)
 		return services.StartAndAwaitRunning(ctx, m.bucketRetentionLoop)
@@ -271,6 +249,67 @@ func (m *TableManager) loop(ctx context.Context) error {
 			return nil
 		}
 	}
+}
+
+func (m *TableManager) checkAndCreateExtraTables() error {
+	for _, extraTables := range m.extraTables {
+		existingTablesList, err := extraTables.TableClient.ListTables(context.Background())
+		if err != nil {
+			return err
+		}
+
+		existingTablesMap := map[string]struct{}{}
+		for _, table := range existingTablesList {
+			existingTablesMap[table] = struct{}{}
+		}
+
+		for _, tableDesc := range extraTables.Tables {
+			if _, ok := existingTablesMap[tableDesc.Name]; !ok {
+				// creating table
+				level.Info(util.Logger).Log("msg", "creating extra table",
+					"tableName", tableDesc.Name,
+					"provisionedRead", tableDesc.ProvisionedRead,
+					"provisionedWrite", tableDesc.ProvisionedWrite,
+					"useOnDemandMode", tableDesc.UseOnDemandIOMode,
+					"useWriteAutoScale", tableDesc.WriteScale.Enabled,
+					"useReadAutoScale", tableDesc.ReadScale.Enabled,
+				)
+				err = extraTables.TableClient.CreateTable(context.Background(), tableDesc)
+				if err != nil {
+					return err
+				}
+				continue
+			} else if m.cfg.ThroughputUpdatesDisabled {
+				// table already exists, throughput updates are disabled so no need to check for difference in configured throuhput vs actual
+				continue
+			}
+
+			level.Info(util.Logger).Log("msg", "checking throughput of extra table", "table", tableDesc.Name)
+			// table already exists, lets check actual throughput for tables is same as what is in configurations, if not let us update it
+			current, _, err := extraTables.TableClient.DescribeTable(context.Background(), tableDesc.Name)
+			if err != nil {
+				return err
+			}
+
+			if !current.Equals(tableDesc) {
+				level.Info(util.Logger).Log("msg", "updating throughput of extra table",
+					"table", tableDesc.Name,
+					"tableName", tableDesc.Name,
+					"provisionedRead", tableDesc.ProvisionedRead,
+					"provisionedWrite", tableDesc.ProvisionedWrite,
+					"useOnDemandMode", tableDesc.UseOnDemandIOMode,
+					"useWriteAutoScale", tableDesc.WriteScale.Enabled,
+					"useReadAutoScale", tableDesc.ReadScale.Enabled,
+				)
+				err := extraTables.TableClient.UpdateTable(context.Background(), current, tableDesc)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 // single iteration of bucket retention loop

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -167,8 +167,8 @@ func TestTableManager(t *testing.T) {
 				InactiveWriteThroughput: inactiveWrite,
 				InactiveReadThroughput:  inactiveRead,
 				InactiveWriteScale:      inactiveScalingConfig,
+				InactiveWriteScaleLastN: autoScaleLastN,
 			},
-			InactiveWriteScaleLastN: autoScaleLastN,
 		},
 		ChunkTables: ProvisionConfig{
 			ActiveTableProvisionConfig: ActiveTableProvisionConfig{
@@ -360,8 +360,8 @@ func TestTableManagerAutoscaleInactiveOnly(t *testing.T) {
 				InactiveWriteThroughput: inactiveWrite,
 				InactiveReadThroughput:  inactiveRead,
 				InactiveWriteScale:      inactiveScalingConfig,
+				InactiveWriteScaleLastN: autoScaleLastN,
 			},
-			InactiveWriteScaleLastN: autoScaleLastN,
 		},
 		ChunkTables: ProvisionConfig{
 			ActiveTableProvisionConfig: ActiveTableProvisionConfig{
@@ -455,8 +455,8 @@ func TestTableManagerDynamicIOModeInactiveOnly(t *testing.T) {
 				InactiveReadThroughput:         inactiveRead,
 				InactiveWriteScale:             inactiveScalingConfig,
 				InactiveThroughputOnDemandMode: true,
+				InactiveWriteScaleLastN:        1,
 			},
-			InactiveWriteScaleLastN: 1,
 		},
 		ChunkTables: ProvisionConfig{
 			ActiveTableProvisionConfig: ActiveTableProvisionConfig{
@@ -625,8 +625,8 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 				InactiveWriteThroughput: inactiveWrite,
 				InactiveReadThroughput:  inactiveRead,
 				InactiveWriteScale:      inactiveScalingConfig,
+				InactiveWriteScaleLastN: autoScaleLastN,
 			},
-			InactiveWriteScaleLastN: autoScaleLastN,
 		},
 		ChunkTables: ProvisionConfig{
 			ActiveTableProvisionConfig: ActiveTableProvisionConfig{

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -158,22 +158,30 @@ func TestTableManager(t *testing.T) {
 	tbmConfig := TableManagerConfig{
 		CreationGracePeriod: gracePeriod,
 		IndexTables: ProvisionConfig{
-			ProvisionedWriteThroughput: write,
-			ProvisionedReadThroughput:  read,
-			InactiveWriteThroughput:    inactiveWrite,
-			InactiveReadThroughput:     inactiveRead,
-			WriteScale:                 activeScalingConfig,
-			InactiveWriteScale:         inactiveScalingConfig,
-			InactiveWriteScaleLastN:    autoScaleLastN,
+			ActiveTableProvisionConfig: ActiveTableProvisionConfig{
+				ProvisionedWriteThroughput: write,
+				ProvisionedReadThroughput:  read,
+				WriteScale:                 activeScalingConfig,
+			},
+			InactiveTableProvisionConfig: InactiveTableProvisionConfig{
+				InactiveWriteThroughput: inactiveWrite,
+				InactiveReadThroughput:  inactiveRead,
+				InactiveWriteScale:      inactiveScalingConfig,
+			},
+			InactiveWriteScaleLastN: autoScaleLastN,
 		},
 		ChunkTables: ProvisionConfig{
-			ProvisionedWriteThroughput: write,
-			ProvisionedReadThroughput:  read,
-			InactiveWriteThroughput:    inactiveWrite,
-			InactiveReadThroughput:     inactiveRead,
+			ActiveTableProvisionConfig: ActiveTableProvisionConfig{
+				ProvisionedWriteThroughput: write,
+				ProvisionedReadThroughput:  read,
+			},
+			InactiveTableProvisionConfig: InactiveTableProvisionConfig{
+				InactiveWriteThroughput: inactiveWrite,
+				InactiveReadThroughput:  inactiveRead,
+			},
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -344,21 +352,29 @@ func TestTableManagerAutoscaleInactiveOnly(t *testing.T) {
 	tbmConfig := TableManagerConfig{
 		CreationGracePeriod: gracePeriod,
 		IndexTables: ProvisionConfig{
-			ProvisionedWriteThroughput: write,
-			ProvisionedReadThroughput:  read,
-			InactiveWriteThroughput:    inactiveWrite,
-			InactiveReadThroughput:     inactiveRead,
-			InactiveWriteScale:         inactiveScalingConfig,
-			InactiveWriteScaleLastN:    autoScaleLastN,
+			ActiveTableProvisionConfig: ActiveTableProvisionConfig{
+				ProvisionedWriteThroughput: write,
+				ProvisionedReadThroughput:  read,
+			},
+			InactiveTableProvisionConfig: InactiveTableProvisionConfig{
+				InactiveWriteThroughput: inactiveWrite,
+				InactiveReadThroughput:  inactiveRead,
+				InactiveWriteScale:      inactiveScalingConfig,
+			},
+			InactiveWriteScaleLastN: autoScaleLastN,
 		},
 		ChunkTables: ProvisionConfig{
-			ProvisionedWriteThroughput: write,
-			ProvisionedReadThroughput:  read,
-			InactiveWriteThroughput:    inactiveWrite,
-			InactiveReadThroughput:     inactiveRead,
+			ActiveTableProvisionConfig: ActiveTableProvisionConfig{
+				ProvisionedWriteThroughput: write,
+				ProvisionedReadThroughput:  read,
+			},
+			InactiveTableProvisionConfig: InactiveTableProvisionConfig{
+				InactiveWriteThroughput: inactiveWrite,
+				InactiveReadThroughput:  inactiveRead,
+			},
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -430,23 +446,31 @@ func TestTableManagerDynamicIOModeInactiveOnly(t *testing.T) {
 	tbmConfig := TableManagerConfig{
 		CreationGracePeriod: gracePeriod,
 		IndexTables: ProvisionConfig{
-			ProvisionedWriteThroughput:     write,
-			ProvisionedReadThroughput:      read,
-			InactiveWriteThroughput:        inactiveWrite,
-			InactiveReadThroughput:         inactiveRead,
-			InactiveWriteScale:             inactiveScalingConfig,
-			InactiveWriteScaleLastN:        1,
-			InactiveThroughputOnDemandMode: true,
+			ActiveTableProvisionConfig: ActiveTableProvisionConfig{
+				ProvisionedWriteThroughput: write,
+				ProvisionedReadThroughput:  read,
+			},
+			InactiveTableProvisionConfig: InactiveTableProvisionConfig{
+				InactiveWriteThroughput:        inactiveWrite,
+				InactiveReadThroughput:         inactiveRead,
+				InactiveWriteScale:             inactiveScalingConfig,
+				InactiveThroughputOnDemandMode: true,
+			},
+			InactiveWriteScaleLastN: 1,
 		},
 		ChunkTables: ProvisionConfig{
-			ProvisionedWriteThroughput:     write,
-			ProvisionedReadThroughput:      read,
-			InactiveWriteThroughput:        inactiveWrite,
-			InactiveReadThroughput:         inactiveRead,
-			InactiveThroughputOnDemandMode: true,
+			ActiveTableProvisionConfig: ActiveTableProvisionConfig{
+				ProvisionedWriteThroughput: write,
+				ProvisionedReadThroughput:  read,
+			},
+			InactiveTableProvisionConfig: InactiveTableProvisionConfig{
+				InactiveWriteThroughput:        inactiveWrite,
+				InactiveReadThroughput:         inactiveRead,
+				InactiveThroughputOnDemandMode: true,
+			},
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -529,7 +553,7 @@ func TestTableManagerTags(t *testing.T) {
 				IndexTables: PeriodicTableConfig{},
 			}},
 		}
-		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, nil, nil)
+		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, nil, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -553,7 +577,7 @@ func TestTableManagerTags(t *testing.T) {
 				},
 			}},
 		}
-		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, nil, nil)
+		tableManager, err := NewTableManager(TableManagerConfig{}, cfg, maxChunkAge, client, nil, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -593,21 +617,29 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 		RetentionDeletesEnabled: true,
 		CreationGracePeriod:     gracePeriod,
 		IndexTables: ProvisionConfig{
-			ProvisionedWriteThroughput: write,
-			ProvisionedReadThroughput:  read,
-			InactiveWriteThroughput:    inactiveWrite,
-			InactiveReadThroughput:     inactiveRead,
-			InactiveWriteScale:         inactiveScalingConfig,
-			InactiveWriteScaleLastN:    autoScaleLastN,
+			ActiveTableProvisionConfig: ActiveTableProvisionConfig{
+				ProvisionedWriteThroughput: write,
+				ProvisionedReadThroughput:  read,
+			},
+			InactiveTableProvisionConfig: InactiveTableProvisionConfig{
+				InactiveWriteThroughput: inactiveWrite,
+				InactiveReadThroughput:  inactiveRead,
+				InactiveWriteScale:      inactiveScalingConfig,
+			},
+			InactiveWriteScaleLastN: autoScaleLastN,
 		},
 		ChunkTables: ProvisionConfig{
-			ProvisionedWriteThroughput: write,
-			ProvisionedReadThroughput:  read,
-			InactiveWriteThroughput:    inactiveWrite,
-			InactiveReadThroughput:     inactiveRead,
+			ActiveTableProvisionConfig: ActiveTableProvisionConfig{
+				ProvisionedWriteThroughput: write,
+				ProvisionedReadThroughput:  read,
+			},
+			InactiveTableProvisionConfig: InactiveTableProvisionConfig{
+				InactiveWriteThroughput: inactiveWrite,
+				InactiveReadThroughput:  inactiveRead,
+			},
 		},
 	}
-	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil)
+	tableManager, err := NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -730,6 +762,6 @@ func TestTableManagerRetentionOnly(t *testing.T) {
 
 	// Test table manager retention not multiple of periodic config
 	tbmConfig.RetentionPeriod++
-	_, err = NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil)
+	_, err = NewTableManager(tbmConfig, cfg, maxChunkAge, client, nil, nil, nil)
 	require.Error(t, err)
 }

--- a/pkg/chunk/table_provisioning.go
+++ b/pkg/chunk/table_provisioning.go
@@ -10,6 +10,11 @@ type ProvisionConfig struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *ProvisionConfig) RegisterFlags(argPrefix string, f *flag.FlagSet) {
+	// defaults for ActiveTableProvisionConfig
+	cfg.ProvisionedWriteThroughput = 1000
+	cfg.ProvisionedReadThroughput = 300
+	cfg.ProvisionedThroughputOnDemandMode = false
+
 	cfg.ActiveTableProvisionConfig.RegisterFlags(argPrefix, f)
 	cfg.InactiveTableProvisionConfig.RegisterFlags(argPrefix, f)
 }
@@ -24,10 +29,11 @@ type ActiveTableProvisionConfig struct {
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
+// Make sure defaults are set in the respective fields before calling RegisterFlags.
 func (cfg *ActiveTableProvisionConfig) RegisterFlags(argPrefix string, f *flag.FlagSet) {
-	f.Int64Var(&cfg.ProvisionedWriteThroughput, argPrefix+".write-throughput", 1000, "Table default write throughput. Supported by DynamoDB")
-	f.Int64Var(&cfg.ProvisionedReadThroughput, argPrefix+".read-throughput", 300, "Table default read throughput. Supported by DynamoDB")
-	f.BoolVar(&cfg.ProvisionedThroughputOnDemandMode, argPrefix+".enable-ondemand-throughput-mode", false, "Enables on demand throughput provisioning for the storage provider (if supported). Applies only to tables which are not autoscaled. Supported by DynamoDB")
+	f.Int64Var(&cfg.ProvisionedWriteThroughput, argPrefix+".write-throughput", cfg.ProvisionedWriteThroughput, "Table default write throughput. Supported by DynamoDB")
+	f.Int64Var(&cfg.ProvisionedReadThroughput, argPrefix+".read-throughput", cfg.ProvisionedReadThroughput, "Table default read throughput. Supported by DynamoDB")
+	f.BoolVar(&cfg.ProvisionedThroughputOnDemandMode, argPrefix+".enable-ondemand-throughput-mode", cfg.ProvisionedThroughputOnDemandMode, "Enables on demand throughput provisioning for the storage provider (if supported). Applies only to tables which are not autoscaled. Supported by DynamoDB")
 
 	cfg.WriteScale.RegisterFlags(argPrefix+".write-throughput.scale", f)
 	cfg.ReadScale.RegisterFlags(argPrefix+".read-throughput.scale", f)

--- a/pkg/chunk/table_provisioning.go
+++ b/pkg/chunk/table_provisioning.go
@@ -4,9 +4,6 @@ import "flag"
 
 // ProvisionConfig holds config for provisioning capacity for index and chunk tables (on DynamoDB for now)
 type ProvisionConfig struct {
-	InactiveWriteScaleLastN int64 `yaml:"inactive_write_scale_lastn"`
-	InactiveReadScaleLastN  int64 `yaml:"inactive_read_scale_lastn"`
-
 	ActiveTableProvisionConfig   `yaml:",inline"`
 	InactiveTableProvisionConfig `yaml:",inline"`
 }
@@ -15,9 +12,6 @@ type ProvisionConfig struct {
 func (cfg *ProvisionConfig) RegisterFlags(argPrefix string, f *flag.FlagSet) {
 	cfg.ActiveTableProvisionConfig.RegisterFlags(argPrefix, f)
 	cfg.InactiveTableProvisionConfig.RegisterFlags(argPrefix, f)
-
-	f.Int64Var(&cfg.InactiveWriteScaleLastN, argPrefix+".inactive-write-throughput.scale-last-n", 4, "Number of last inactive tables to enable write autoscale.")
-	f.Int64Var(&cfg.InactiveReadScaleLastN, argPrefix+".inactive-read-throughput.scale-last-n", 4, "Number of last inactive tables to enable read autoscale.")
 }
 
 type ActiveTableProvisionConfig struct {
@@ -46,6 +40,9 @@ type InactiveTableProvisionConfig struct {
 
 	InactiveWriteScale AutoScalingConfig `yaml:"inactive_write_scale"`
 	InactiveReadScale  AutoScalingConfig `yaml:"inactive_read_scale"`
+
+	InactiveWriteScaleLastN int64 `yaml:"inactive_write_scale_lastn"`
+	InactiveReadScaleLastN  int64 `yaml:"inactive_read_scale_lastn"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -56,6 +53,9 @@ func (cfg *InactiveTableProvisionConfig) RegisterFlags(argPrefix string, f *flag
 
 	cfg.InactiveWriteScale.RegisterFlags(argPrefix+".inactive-write-throughput.scale", f)
 	cfg.InactiveReadScale.RegisterFlags(argPrefix+".inactive-read-throughput.scale", f)
+
+	f.Int64Var(&cfg.InactiveWriteScaleLastN, argPrefix+".inactive-write-throughput.scale-last-n", 4, "Number of last inactive tables to enable write autoscale.")
+	f.Int64Var(&cfg.InactiveReadScaleLastN, argPrefix+".inactive-read-throughput.scale-last-n", 4, "Number of last inactive tables to enable read autoscale.")
 }
 
 func (cfg ActiveTableProvisionConfig) BuildTableDesc(tableName string, tags Tags) TableDesc {

--- a/pkg/chunk/table_provisioning.go
+++ b/pkg/chunk/table_provisioning.go
@@ -1,0 +1,105 @@
+package chunk
+
+import "flag"
+
+// ProvisionConfig holds config for provisioning capacity for index and chunk tables (on DynamoDB for now)
+type ProvisionConfig struct {
+	InactiveWriteScaleLastN int64 `yaml:"inactive_write_scale_lastn"`
+	InactiveReadScaleLastN  int64 `yaml:"inactive_read_scale_lastn"`
+
+	ActiveTableProvisionConfig   `yaml:",inline"`
+	InactiveTableProvisionConfig `yaml:",inline"`
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet.
+func (cfg *ProvisionConfig) RegisterFlags(argPrefix string, f *flag.FlagSet) {
+	cfg.ActiveTableProvisionConfig.RegisterFlags(argPrefix, f)
+	cfg.InactiveTableProvisionConfig.RegisterFlags(argPrefix, f)
+
+	f.Int64Var(&cfg.InactiveWriteScaleLastN, argPrefix+".inactive-write-throughput.scale-last-n", 4, "Number of last inactive tables to enable write autoscale.")
+	f.Int64Var(&cfg.InactiveReadScaleLastN, argPrefix+".inactive-read-throughput.scale-last-n", 4, "Number of last inactive tables to enable read autoscale.")
+}
+
+type ActiveTableProvisionConfig struct {
+	ProvisionedThroughputOnDemandMode bool  `yaml:"enable_ondemand_throughput_mode"`
+	ProvisionedWriteThroughput        int64 `yaml:"provisioned_write_throughput"`
+	ProvisionedReadThroughput         int64 `yaml:"provisioned_read_throughput"`
+
+	WriteScale AutoScalingConfig `yaml:"write_scale"`
+	ReadScale  AutoScalingConfig `yaml:"read_scale"`
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet.
+func (cfg *ActiveTableProvisionConfig) RegisterFlags(argPrefix string, f *flag.FlagSet) {
+	f.Int64Var(&cfg.ProvisionedWriteThroughput, argPrefix+".write-throughput", 1000, "Table default write throughput. Supported by DynamoDB")
+	f.Int64Var(&cfg.ProvisionedReadThroughput, argPrefix+".read-throughput", 300, "Table default read throughput. Supported by DynamoDB")
+	f.BoolVar(&cfg.ProvisionedThroughputOnDemandMode, argPrefix+".enable-ondemand-throughput-mode", false, "Enables on demand throughput provisioning for the storage provider (if supported). Applies only to tables which are not autoscaled. Supported by DynamoDB")
+
+	cfg.WriteScale.RegisterFlags(argPrefix+".write-throughput.scale", f)
+	cfg.ReadScale.RegisterFlags(argPrefix+".read-throughput.scale", f)
+}
+
+type InactiveTableProvisionConfig struct {
+	InactiveThroughputOnDemandMode bool  `yaml:"enable_inactive_throughput_on_demand_mode"`
+	InactiveWriteThroughput        int64 `yaml:"inactive_write_throughput"`
+	InactiveReadThroughput         int64 `yaml:"inactive_read_throughput"`
+
+	InactiveWriteScale AutoScalingConfig `yaml:"inactive_write_scale"`
+	InactiveReadScale  AutoScalingConfig `yaml:"inactive_read_scale"`
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet.
+func (cfg *InactiveTableProvisionConfig) RegisterFlags(argPrefix string, f *flag.FlagSet) {
+	f.Int64Var(&cfg.InactiveWriteThroughput, argPrefix+".inactive-write-throughput", 1, "Table write throughput for inactive tables. Supported by DynamoDB")
+	f.Int64Var(&cfg.InactiveReadThroughput, argPrefix+".inactive-read-throughput", 300, "Table read throughput for inactive tables. Supported by DynamoDB")
+	f.BoolVar(&cfg.InactiveThroughputOnDemandMode, argPrefix+".inactive-enable-ondemand-throughput-mode", false, "Enables on demand throughput provisioning for the storage provider (if supported). Applies only to tables which are not autoscaled. Supported by DynamoDB")
+
+	cfg.InactiveWriteScale.RegisterFlags(argPrefix+".inactive-write-throughput.scale", f)
+	cfg.InactiveReadScale.RegisterFlags(argPrefix+".inactive-read-throughput.scale", f)
+}
+
+func (cfg ActiveTableProvisionConfig) BuildTableDesc(tableName string, tags Tags) TableDesc {
+	table := TableDesc{
+		Name:              tableName,
+		ProvisionedRead:   cfg.ProvisionedReadThroughput,
+		ProvisionedWrite:  cfg.ProvisionedWriteThroughput,
+		UseOnDemandIOMode: cfg.ProvisionedThroughputOnDemandMode,
+		Tags:              tags,
+	}
+
+	if cfg.WriteScale.Enabled {
+		table.WriteScale = cfg.WriteScale
+		table.UseOnDemandIOMode = false
+	}
+
+	if cfg.ReadScale.Enabled {
+		table.ReadScale = cfg.ReadScale
+		table.UseOnDemandIOMode = false
+	}
+
+	return table
+}
+
+func (cfg InactiveTableProvisionConfig) BuildTableDesc(tableName string, tags Tags, disableAutoscale bool) TableDesc {
+	table := TableDesc{
+		Name:              tableName,
+		ProvisionedRead:   cfg.InactiveReadThroughput,
+		ProvisionedWrite:  cfg.InactiveWriteThroughput,
+		UseOnDemandIOMode: cfg.InactiveThroughputOnDemandMode,
+		Tags:              tags,
+	}
+
+	if !disableAutoscale {
+		if cfg.InactiveWriteScale.Enabled {
+			table.WriteScale = cfg.InactiveWriteScale
+			table.UseOnDemandIOMode = false
+		}
+
+		if cfg.InactiveReadScale.Enabled {
+			table.ReadScale = cfg.InactiveReadScale
+			table.UseOnDemandIOMode = false
+		}
+	}
+
+	return table
+}

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -45,7 +45,7 @@ func Setup(fixture Fixture, tableName string) (chunk.IndexClient, chunk.Client, 
 		return nil, nil, err
 	}
 
-	tableManager, err := chunk.NewTableManager(tbmConfig, schemaConfig, 12*time.Hour, tableClient, nil, nil)
+	tableManager, err := chunk.NewTableManager(tbmConfig, schemaConfig, 12*time.Hour, tableClient, nil, nil, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -114,7 +114,7 @@ func SetupTestChunkStore() (chunk.Store, error) {
 	)
 	flagext.DefaultValues(&tbmConfig)
 	storage := chunk.NewMockStorage()
-	tableManager, err := chunk.NewTableManager(tbmConfig, schemaCfg, 12*time.Hour, storage, nil, nil)
+	tableManager, err := chunk.NewTableManager(tbmConfig, schemaCfg, 12*time.Hour, storage, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -393,7 +393,8 @@ func (t *Cortex) initTableManager() (services.Service, error) {
 		extraTables = append(extraTables, chunk.ExtraTables{TableClient: deleteStoreTableClient, Tables: t.Cfg.Storage.DeleteStoreConfig.GetTables()})
 	}
 
-	t.TableManager, err = chunk.NewTableManager(t.Cfg.TableManager, t.Cfg.Schema, t.Cfg.Ingester.MaxChunkAge, tableClient, bucketClient, prometheus.DefaultRegisterer, extraTables)
+	t.TableManager, err = chunk.NewTableManager(t.Cfg.TableManager, t.Cfg.Schema, t.Cfg.Ingester.MaxChunkAge, tableClient,
+		bucketClient, extraTables, prometheus.DefaultRegisterer)
 	return t.TableManager, err
 }
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -383,7 +383,17 @@ func (t *Cortex) initTableManager() (services.Service, error) {
 	bucketClient, err := storage.NewBucketClient(t.Cfg.Storage)
 	util.CheckFatal("initializing bucket client", err)
 
-	t.TableManager, err = chunk.NewTableManager(t.Cfg.TableManager, t.Cfg.Schema, t.Cfg.Ingester.MaxChunkAge, tableClient, bucketClient, prometheus.DefaultRegisterer)
+	var extraTables []chunk.ExtraTables
+	if t.Cfg.DataPurgerConfig.Enable {
+		deleteStoreTableClient, err := storage.NewTableClient(t.Cfg.Storage.DeleteStoreConfig.Store, t.Cfg.Storage)
+		if err != nil {
+			return nil, err
+		}
+
+		extraTables = append(extraTables, chunk.ExtraTables{TableClient: deleteStoreTableClient, Tables: t.Cfg.Storage.DeleteStoreConfig.GetTables()})
+	}
+
+	t.TableManager, err = chunk.NewTableManager(t.Cfg.TableManager, t.Cfg.Schema, t.Cfg.Ingester.MaxChunkAge, tableClient, bucketClient, prometheus.DefaultRegisterer, extraTables)
 	return t.TableManager, err
 }
 

--- a/tools/doc-generator/parser.go
+++ b/tools/doc-generator/parser.go
@@ -286,6 +286,9 @@ func getFieldType(t reflect.Type) (string, error) {
 
 		return "list of " + elemType, nil
 
+	case reflect.Map:
+		return fmt.Sprintf("map of %s to %s", t.Key(), t.Elem().String()), nil
+
 	default:
 		return "", fmt.Errorf("unsupported data type %s", t.Kind())
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds support for provisioning tables for delete store using table manager.
Throughput settings for tables created for delete requests store are part of the store configuration itself.
I have refactored the code used for provisioning throughput for index and chunks tables in table manager to be able to reuse most of the code.
This also adds support for `map` type in doc generator.

**NOTE**: Since the refactoring of provisioning code in table manager changed the order of elements in configuration struct the order of the entries in configuration doc as well changed. There are no breaking changes in configuration.

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
