### PR TITLE
Implement /api/v1/metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [FEATURE] Ruler: The `-ruler.evaluation-delay` flag was added to allow users to configure a default evaluation delay for all rules in cortex. The default value is 0 which is the current behavior. #2423
 * [FEATURE] Experimental: Added a new object storage client for OpenStack Swift. #2440
 * [FEATURE] Update in dependency `weaveworks/common`. TLS config options added to the Server. #2535
+* [FEATURE] Experimental: Added support for `/api/v1/metadata` Prometheus-based endpoint. #XXXX
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
 * [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383
 * [ENHANCEMENT] Experimental TSDB: Added `cortex_querier_blocks_meta_synced`, which reflects current state of synced blocks over all tenants. #2392

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * [FEATURE] Ruler: The `-ruler.evaluation-delay` flag was added to allow users to configure a default evaluation delay for all rules in cortex. The default value is 0 which is the current behavior. #2423
 * [FEATURE] Experimental: Added a new object storage client for OpenStack Swift. #2440
 * [FEATURE] Update in dependency `weaveworks/common`. TLS config options added to the Server. #2535
-* [FEATURE] Experimental: Added support for `/api/v1/metadata` Prometheus-based endpoint. #XXXX
+* [FEATURE] Experimental: Added support for `/api/v1/metadata` Prometheus-based endpoint. #2549
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
 * [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383
 * [ENHANCEMENT] Experimental TSDB: Added `cortex_querier_blocks_meta_synced`, which reflects current state of synced blocks over all tenants. #2392

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -294,7 +294,7 @@ func (a *API) RegisterQuerier(queryable storage.Queryable, engine *promql.Engine
 	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/labels", promHandler, true, "GET", "POST")
 	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/label/{name}/values", promHandler, true, "GET")
 	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/series", promHandler, true, "GET", "POST", "DELETE")
-	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/metadata", promHandler, true, "GET")
+	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/metadata", querier.MetadataHandler(distributor), true, "GET")
 
 	legacyPromRouter := route.New().WithPrefix(a.cfg.ServerPrefix + a.cfg.LegacyHTTPPrefix + "/api/v1")
 	api.Register(legacyPromRouter)
@@ -306,7 +306,7 @@ func (a *API) RegisterQuerier(queryable storage.Queryable, engine *promql.Engine
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/labels", legacyPromHandler, true, "GET", "POST")
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/label/{name}/values", legacyPromHandler, true, "GET")
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/series", legacyPromHandler, true, "GET", "POST", "DELETE")
-	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/metadata", legacyPromHandler, true, "GET")
+	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/metadata", querier.MetadataHandler(distributor), true, "GET")
 
 	// if we have externally registered routes then we need to return the server handler
 	// so that we continue to use all standard middleware

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -294,6 +294,8 @@ func (a *API) RegisterQuerier(queryable storage.Queryable, engine *promql.Engine
 	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/labels", promHandler, true, "GET", "POST")
 	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/label/{name}/values", promHandler, true, "GET")
 	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/series", promHandler, true, "GET", "POST", "DELETE")
+	//TODO(gotjosh): This custom handler is temporary until we're able to vendor the changes in:
+	// https://github.com/prometheus/prometheus/pull/7125/files
 	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/metadata", querier.MetadataHandler(distributor), true, "GET")
 
 	legacyPromRouter := route.New().WithPrefix(a.cfg.ServerPrefix + a.cfg.LegacyHTTPPrefix + "/api/v1")
@@ -306,6 +308,8 @@ func (a *API) RegisterQuerier(queryable storage.Queryable, engine *promql.Engine
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/labels", legacyPromHandler, true, "GET", "POST")
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/label/{name}/values", legacyPromHandler, true, "GET")
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/series", legacyPromHandler, true, "GET", "POST", "DELETE")
+	//TODO(gotjosh): This custom handler is temporary until we're able to vendor the changes in:
+	// https://github.com/prometheus/prometheus/pull/7125/files
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/metadata", querier.MetadataHandler(distributor), true, "GET")
 
 	// if we have externally registered routes then we need to return the server handler

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -702,11 +702,10 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 	return result, nil
 }
 
-// MetricMetadata returns all metric metadata of a user.
+// MetricsMetadata returns all metric metadata of a user.
 func (d *Distributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetadata, error) {
 	req := &ingester_client.MetricsMetadataRequest{}
-	// TODO: We only need to look in all the ingesters if we're shardByAllLabels is enabled.
-	// Look into distributor/query.go
+	// TODO(gotjosh): We only need to look in all the ingesters if shardByAllLabels is enabled.
 	resps, err := d.forAllIngesters(ctx, false, func(client client.IngesterClient) (interface{}, error) {
 		return client.MetricsMetadata(ctx, req)
 	})

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -107,8 +107,10 @@ func TestIngesterStreaming(t *testing.T) {
 }
 
 type mockDistributor struct {
-	m model.Matrix
-	r *client.QueryStreamResponse
+	metadata      []scrape.MetricMetadata
+	metadataError error
+	m             model.Matrix
+	r             *client.QueryStreamResponse
 }
 
 func (m *mockDistributor) Query(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error) {
@@ -128,5 +130,9 @@ func (m *mockDistributor) MetricsForLabelMatchers(ctx context.Context, from, thr
 }
 
 func (m *mockDistributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetadata, error) {
-	return nil, nil
+	if m.metadataError != nil {
+		return nil, m.metadataError
+	}
+
+	return m.metadata, nil
 }

--- a/pkg/querier/metadata_handler.go
+++ b/pkg/querier/metadata_handler.go
@@ -1,0 +1,50 @@
+package querier
+
+import (
+	"net/http"
+
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+type metricMetadata struct {
+	Type string `json:"type"`
+	Help string `json:"help"`
+	Unit string `json:"unit"`
+}
+
+const (
+	statusSuccess = "success"
+	statusError   = "error"
+)
+
+type metadataResult struct {
+	Status string                      `json:"status"`
+	Data   map[string][]metricMetadata `json:"data,omitempty"`
+	Error  string                      `json:"error,omitempty"`
+}
+
+// MetadataHandler allows you to fetch metric metadata held by cortex for a given tenant.
+func MetadataHandler(d Distributor) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp, err := d.MetricsMetadata(r.Context())
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			util.WriteJSONResponse(w, metadataResult{Status: statusError, Error: err.Error()})
+			return
+		}
+
+		// Put all the elements of the pseudo-set into a map of slices for marshalling.
+		metrics := map[string][]metricMetadata{}
+		for _, m := range resp {
+			ms, ok := metrics[m.Metric]
+			if !ok {
+				// Most metrics will only hold 1 copy of the same metadata.
+				ms = make([]metricMetadata, 0, 1)
+				metrics[m.Metric] = ms
+			}
+			metrics[m.Metric] = append(ms, metricMetadata{Type: string(m.Type), Help: m.Help, Unit: m.Unit})
+		}
+
+		util.WriteJSONResponse(w, metadataResult{Status: statusSuccess, Data: metrics})
+	})
+}

--- a/pkg/querier/metadata_handler.go
+++ b/pkg/querier/metadata_handler.go
@@ -23,7 +23,8 @@ type metadataResult struct {
 	Error  string                      `json:"error,omitempty"`
 }
 
-// MetadataHandler allows you to fetch metric metadata held by cortex for a given tenant.
+// MetadataHandler returns metric metadata held by Cortex for a given tenant.
+// It is kept and returned as a set.
 func MetadataHandler(d Distributor) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp, err := d.MetricsMetadata(r.Context())

--- a/pkg/querier/metadata_handler_test.go
+++ b/pkg/querier/metadata_handler_test.go
@@ -1,0 +1,76 @@
+package querier
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/prometheus/scrape"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataHandler_Success(t *testing.T) {
+	d := &mockDistributor{
+		metadata: []scrape.MetricMetadata{
+			{Metric: "alertmanager_dispatcher_aggregation_groups", Help: "Number of active aggregation groups", Type: "gauge", Unit: ""},
+		},
+	}
+
+	handler := MetadataHandler(d)
+
+	request, err := http.NewRequest("GET", "/metadata", nil)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Result().StatusCode)
+	responseBody, err := ioutil.ReadAll(recorder.Result().Body)
+	require.NoError(t, err)
+
+	expectedJSON := `
+	{
+		"status": "success",
+		"data": {
+			"alertmanager_dispatcher_aggregation_groups": [
+				{
+					"help": "Number of active aggregation groups",
+					"type": "gauge",
+					"unit": ""
+				}
+			]
+		}
+	}
+	`
+
+	require.JSONEq(t, expectedJSON, string(responseBody))
+}
+
+func TestMetadataHandler_Error(t *testing.T) {
+	d := &mockDistributor{
+		metadataError: fmt.Errorf("no user id"),
+	}
+
+	handler := MetadataHandler(d)
+
+	request, err := http.NewRequest("GET", "/metadata", nil)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusBadRequest, recorder.Result().StatusCode)
+	responseBody, err := ioutil.ReadAll(recorder.Result().Body)
+	require.NoError(t, err)
+
+	expectedJSON := `
+	{
+		"status": "error",
+		"error": "no user id"
+	}
+	`
+
+	require.JSONEq(t, expectedJSON, string(responseBody))
+}


### PR DESCRIPTION
**What this PR does**:

Properly Implements the `/api/v1/metadata` endpoint. Up until now, we were using the default behaviour introduced by the Prometheus API in:

https://github.com/cortexproject/cortex/blob/d94cdce0aa46b69fff7cb40d1ad57e77b11b4ab0/pkg/api/api.go#L253-L268

To fetch this information the dummy struct `dummy. DummyTargetRetriever` was used which meant no records where ever returned. 

The reason for this implementation is two-fold:

- Given an implemented `dummy. DummyTargetRetriever`  does not support `context` passing, we're not able to extract the tenant ID. This was fixed in upstream Prometheus by https://github.com/prometheus/prometheus/pull/7125
- We vendor Prometheus through Thanos. By the looks of it is going to take a while before we upgrade based on https://github.com/thanos-io/thanos/pull/2535

Once Prometheus is upgraded, this can be removed in favour of the implementation of `dummy. DummyTargetRetriever`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [] Documentation added (N/A)
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
