### PR TITLE
Add Redis cache options used by Redigo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 * [ENHANCEMENT] Add de-duplicated chunks counter `cortex_chunk_store_deduped_chunks_total` which counts every chunk not sent to the store because it was already sent by another replica. #2485
 * [ENHANCEMENT] query-frontend now also logs the POST data of long queries. #2481
 * [ENHANCEMENT] Experimental WAL: Ingester WAL records now have type header and the custom WAL records have been replaced by Prometheus TSDB's WAL records. Old records will not be supported from 1.3 onwards. Note: once this is deployed, you cannot downgrade without data loss. #2436
-* [ENHANCEMENT] Redis Cache: Added `idle_timeout`, `wait` and `max_conn_lifetime` options to redis cache configuration. 
+* [ENHANCEMENT] Redis Cache: Added `idle_timeout`, `wait` and `max_conn_lifetime` options to redis cache configuration. #2550 
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [ENHANCEMENT] Add de-duplicated chunks counter `cortex_chunk_store_deduped_chunks_total` which counts every chunk not sent to the store because it was already sent by another replica. #2485
 * [ENHANCEMENT] query-frontend now also logs the POST data of long queries. #2481
 * [ENHANCEMENT] Experimental WAL: Ingester WAL records now have type header and the custom WAL records have been replaced by Prometheus TSDB's WAL records. Old records will not be supported from 1.3 onwards. Note: once this is deployed, you cannot downgrade without data loss. #2436
+* [ENHANCEMENT] Redis Cache: Added `idle_timeout`, `wait` and `max_conn_lifetime` options to redis cache configuration. 
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 * [ENHANCEMENT] Add de-duplicated chunks counter `cortex_chunk_store_deduped_chunks_total` which counts every chunk not sent to the store because it was already sent by another replica. #2485
 * [ENHANCEMENT] query-frontend now also logs the POST data of long queries. #2481
 * [ENHANCEMENT] Experimental WAL: Ingester WAL records now have type header and the custom WAL records have been replaced by Prometheus TSDB's WAL records. Old records will not be supported from 1.3 onwards. Note: once this is deployed, you cannot downgrade without data loss. #2436
-* [ENHANCEMENT] Redis Cache: Added `idle_timeout`, `wait` and `max_conn_lifetime` options to redis cache configuration. #2550
+* [ENHANCEMENT] Redis Cache: Added `idle_timeout`, `wait_on_pool_exhaustion` and `max_conn_lifetime` options to redis cache configuration. #2550
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 * [ENHANCEMENT] Add de-duplicated chunks counter `cortex_chunk_store_deduped_chunks_total` which counts every chunk not sent to the store because it was already sent by another replica. #2485
 * [ENHANCEMENT] query-frontend now also logs the POST data of long queries. #2481
 * [ENHANCEMENT] Experimental WAL: Ingester WAL records now have type header and the custom WAL records have been replaced by Prometheus TSDB's WAL records. Old records will not be supported from 1.3 onwards. Note: once this is deployed, you cannot downgrade without data loss. #2436
-* [ENHANCEMENT] Redis Cache: Added `idle_timeout`, `wait` and `max_conn_lifetime` options to redis cache configuration. #2550 
+* [ENHANCEMENT] Redis Cache: Added `idle_timeout`, `wait` and `max_conn_lifetime` options to redis cache configuration. #2550
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2329,6 +2329,23 @@ The `redis_config` configures the Redis backend cache. The supported CLI flags `
 # Enables connecting to redis with TLS.
 # CLI flag: -<prefix>.redis.enable-tls
 [enable_tls: <boolean> | default = false]
+
+# Close connections after remaining idle for this duration. 
+# If the value is zero, then idle connections are not closed.
+# CLI flag: -<prefix>.redis.idle-timeout
+[idle_timeout: <duration> | default = 0s]
+
+# Enables waiting if there are no idle connections.
+# If the value is false and the pool is at the max_active_conns limit,
+# the pool will return a connection with ErrPoolExhausted error
+# and not wait for idle connections. 
+# CLI flag: -<prefix>.redis.wait
+[wait: <boolean> | default = false]
+
+# Close connections older than this duration. 
+# If the value is zero, then the pool does not close connections based on age.
+# CLI flag: -<prefix>.redis.max-conn-lifetime
+[max_conn_lifetime: <duration> | default = 0s]
 ```
 
 ### `memcached_config`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2330,20 +2330,19 @@ The `redis_config` configures the Redis backend cache. The supported CLI flags `
 # CLI flag: -<prefix>.redis.enable-tls
 [enable_tls: <boolean> | default = false]
 
-# Close connections after remaining idle for this duration. 
-# If the value is zero, then idle connections are not closed.
+# Close connections after remaining idle for this duration. If the value is
+# zero, then idle connections are not closed.
 # CLI flag: -<prefix>.redis.idle-timeout
 [idle_timeout: <duration> | default = 0s]
 
-# Enables waiting if there are no idle connections.
-# If the value is false and the pool is at the max_active_conns limit,
-# the pool will return a connection with ErrPoolExhausted error
-# and not wait for idle connections. 
+# Enables waiting if there are no idle connections. If the value is false and
+# the pool is at the max_active_conns limit, the pool will return a connection
+# with ErrPoolExhausted error and not wait for idle connections.
 # CLI flag: -<prefix>.redis.wait
 [wait: <boolean> | default = false]
 
-# Close connections older than this duration. 
-# If the value is zero, then the pool does not close connections based on age.
+# Close connections older than this duration. If the value is zero, then the
+# pool does not close connections based on age.
 # CLI flag: -<prefix>.redis.max-conn-lifetime
 [max_conn_lifetime: <duration> | default = 0s]
 ```

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2338,8 +2338,8 @@ The `redis_config` configures the Redis backend cache. The supported CLI flags `
 # Enables waiting if there are no idle connections. If the value is false and
 # the pool is at the max_active_conns limit, the pool will return a connection
 # with ErrPoolExhausted error and not wait for idle connections.
-# CLI flag: -<prefix>.redis.wait
-[wait: <boolean> | default = false]
+# CLI flag: -<prefix>.redis.wait-on-pool-exhaustion
+[wait_on_pool_exhaustion: <boolean> | default = false]
 
 # Close connections older than this duration. If the value is zero, then the
 # pool does not close connections based on age.

--- a/pkg/chunk/cache/redis_cache.go
+++ b/pkg/chunk/cache/redis_cache.go
@@ -22,13 +22,16 @@ type RedisCache struct {
 
 // RedisConfig defines how a RedisCache should be constructed.
 type RedisConfig struct {
-	Endpoint       string         `yaml:"endpoint"`
-	Timeout        time.Duration  `yaml:"timeout"`
-	Expiration     time.Duration  `yaml:"expiration"`
-	MaxIdleConns   int            `yaml:"max_idle_conns"`
-	MaxActiveConns int            `yaml:"max_active_conns"`
-	Password       flagext.Secret `yaml:"password"`
-	EnableTLS      bool           `yaml:"enable_tls"`
+	Endpoint        string         `yaml:"endpoint"`
+	Timeout         time.Duration  `yaml:"timeout"`
+	Expiration      time.Duration  `yaml:"expiration"`
+	MaxIdleConns    int            `yaml:"max_idle_conns"`
+	MaxActiveConns  int            `yaml:"max_active_conns"`
+	Password        flagext.Secret `yaml:"password"`
+	EnableTLS       bool           `yaml:"enable_tls"`
+	IdleTimeout     time.Duration  `yaml:"idle_timeout"`
+	Wait            bool           `yaml:"wait"`
+	MaxConnLifetime time.Duration  `yaml:"max_conn_lifetime"`
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
@@ -40,6 +43,9 @@ func (cfg *RedisConfig) RegisterFlagsWithPrefix(prefix, description string, f *f
 	f.IntVar(&cfg.MaxActiveConns, prefix+"redis.max-active-conns", 0, description+"Maximum number of active connections in pool.")
 	f.Var(&cfg.Password, prefix+"redis.password", description+"Password to use when connecting to redis.")
 	f.BoolVar(&cfg.EnableTLS, prefix+"redis.enable-tls", false, description+"Enables connecting to redis with TLS.")
+	f.DurationVar(&cfg.IdleTimeout, prefix+"redis.idle-timeout", 0, description+"Close connections after remaining idle for this duration. If the value is zero, then idle connections are not closed.")
+	f.BoolVar(&cfg.Wait, prefix+"redis.wait", false, description+"Enables waiting if there are no idle connections.")
+	f.DurationVar(&cfg.MaxConnLifetime, prefix+"redis.max-conn-lifetime", 0, description+"Close connections older than this duration. If the value is zero, then the pool does not close connections based on age.")
 }
 
 // NewRedisCache creates a new RedisCache
@@ -48,8 +54,6 @@ func NewRedisCache(cfg RedisConfig, name string, pool *redis.Pool) *RedisCache {
 	// pool != nil only in unit tests
 	if pool == nil {
 		pool = &redis.Pool{
-			MaxIdle:   cfg.MaxIdleConns,
-			MaxActive: cfg.MaxActiveConns,
 			Dial: func() (redis.Conn, error) {
 				options := make([]redis.DialOption, 0, 2)
 				if cfg.EnableTLS {
@@ -65,6 +69,11 @@ func NewRedisCache(cfg RedisConfig, name string, pool *redis.Pool) *RedisCache {
 				}
 				return c, err
 			},
+			MaxIdle:         cfg.MaxIdleConns,
+			MaxActive:       cfg.MaxActiveConns,
+			IdleTimeout:     cfg.IdleTimeout,
+			Wait:            cfg.Wait,
+			MaxConnLifetime: cfg.MaxConnLifetime,
 		}
 	}
 

--- a/pkg/chunk/cache/redis_cache.go
+++ b/pkg/chunk/cache/redis_cache.go
@@ -22,16 +22,16 @@ type RedisCache struct {
 
 // RedisConfig defines how a RedisCache should be constructed.
 type RedisConfig struct {
-	Endpoint        string         `yaml:"endpoint"`
-	Timeout         time.Duration  `yaml:"timeout"`
-	Expiration      time.Duration  `yaml:"expiration"`
-	MaxIdleConns    int            `yaml:"max_idle_conns"`
-	MaxActiveConns  int            `yaml:"max_active_conns"`
-	Password        flagext.Secret `yaml:"password"`
-	EnableTLS       bool           `yaml:"enable_tls"`
-	IdleTimeout     time.Duration  `yaml:"idle_timeout"`
-	Wait            bool           `yaml:"wait"`
-	MaxConnLifetime time.Duration  `yaml:"max_conn_lifetime"`
+	Endpoint             string         `yaml:"endpoint"`
+	Timeout              time.Duration  `yaml:"timeout"`
+	Expiration           time.Duration  `yaml:"expiration"`
+	MaxIdleConns         int            `yaml:"max_idle_conns"`
+	MaxActiveConns       int            `yaml:"max_active_conns"`
+	Password             flagext.Secret `yaml:"password"`
+	EnableTLS            bool           `yaml:"enable_tls"`
+	IdleTimeout          time.Duration  `yaml:"idle_timeout"`
+	WaitOnPoolExhaustion bool           `yaml:"wait_on_pool_exhaustion"`
+	MaxConnLifetime      time.Duration  `yaml:"max_conn_lifetime"`
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
@@ -44,7 +44,7 @@ func (cfg *RedisConfig) RegisterFlagsWithPrefix(prefix, description string, f *f
 	f.Var(&cfg.Password, prefix+"redis.password", description+"Password to use when connecting to redis.")
 	f.BoolVar(&cfg.EnableTLS, prefix+"redis.enable-tls", false, description+"Enables connecting to redis with TLS.")
 	f.DurationVar(&cfg.IdleTimeout, prefix+"redis.idle-timeout", 0, description+"Close connections after remaining idle for this duration. If the value is zero, then idle connections are not closed.")
-	f.BoolVar(&cfg.Wait, prefix+"redis.wait", false, description+"Enables waiting if there are no idle connections. If the value is false and the pool is at the max_active_conns limit, the pool will return a connection with ErrPoolExhausted error and not wait for idle connections.")
+	f.BoolVar(&cfg.WaitOnPoolExhaustion, prefix+"redis.wait-on-pool-exhaustion", false, description+"Enables waiting if there are no idle connections. If the value is false and the pool is at the max_active_conns limit, the pool will return a connection with ErrPoolExhausted error and not wait for idle connections.")
 	f.DurationVar(&cfg.MaxConnLifetime, prefix+"redis.max-conn-lifetime", 0, description+"Close connections older than this duration. If the value is zero, then the pool does not close connections based on age.")
 }
 
@@ -72,7 +72,7 @@ func NewRedisCache(cfg RedisConfig, name string, pool *redis.Pool) *RedisCache {
 			MaxIdle:         cfg.MaxIdleConns,
 			MaxActive:       cfg.MaxActiveConns,
 			IdleTimeout:     cfg.IdleTimeout,
-			Wait:            cfg.Wait,
+			Wait:            cfg.WaitOnPoolExhaustion,
 			MaxConnLifetime: cfg.MaxConnLifetime,
 		}
 	}

--- a/pkg/chunk/cache/redis_cache.go
+++ b/pkg/chunk/cache/redis_cache.go
@@ -44,7 +44,7 @@ func (cfg *RedisConfig) RegisterFlagsWithPrefix(prefix, description string, f *f
 	f.Var(&cfg.Password, prefix+"redis.password", description+"Password to use when connecting to redis.")
 	f.BoolVar(&cfg.EnableTLS, prefix+"redis.enable-tls", false, description+"Enables connecting to redis with TLS.")
 	f.DurationVar(&cfg.IdleTimeout, prefix+"redis.idle-timeout", 0, description+"Close connections after remaining idle for this duration. If the value is zero, then idle connections are not closed.")
-	f.BoolVar(&cfg.Wait, prefix+"redis.wait", false, description+"Enables waiting if there are no idle connections.")
+	f.BoolVar(&cfg.Wait, prefix+"redis.wait", false, description+"Enables waiting if there are no idle connections. If the value is false and the pool is at the max_active_conns limit, the pool will return a connection with ErrPoolExhausted error and not wait for idle connections.")
 	f.DurationVar(&cfg.MaxConnLifetime, prefix+"redis.max-conn-lifetime", 0, description+"Close connections older than this duration. If the value is zero, then the pool does not close connections based on age.")
 }
 


### PR DESCRIPTION
**What this PR does**:

I think Redis cache configuration need some more options.
I added the configuration options used by Redigo.
(reference: https://godoc.org/github.com/gomodule/redigo/redis)

- `idle_timeout`
- `wait`
- `max_conn_lifetime`

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
