### PR TITLE
Run Grafana Agent in the local dev env too

### DIFF
--- a/development/tsdb-blocks-storage-s3-single-binary/.dockerignore
+++ b/development/tsdb-blocks-storage-s3-single-binary/.dockerignore
@@ -1,3 +1,3 @@
-.data-ingester-1
-.data-ingester-2
+.data-cortex-1
+.data-cortex-2
 .data-minio

--- a/development/tsdb-blocks-storage-s3-single-binary/config/grafana-agent.yaml
+++ b/development/tsdb-blocks-storage-s3-single-binary/config/grafana-agent.yaml
@@ -1,0 +1,26 @@
+server:
+  log_level: debug
+  http_listen_port: 9091
+
+prometheus:
+  global:
+    scrape_interval: 5s
+    external_labels:
+      origin: grafana-agent
+  configs:
+    - name: local
+      host_filter: false
+      scrape_configs:
+        - job_name: cortex-1
+          static_configs:
+            - targets: ['cortex-1:8001']
+              labels:
+                container: 'cortex-1'
+        - job_name: cortex-2
+          static_configs:
+            - targets: ['cortex-2:8002']
+              labels:
+                container: 'cortex-2'
+
+      remote_write:
+        - url: http://cortex-1:8001/api/prom/push

--- a/development/tsdb-blocks-storage-s3-single-binary/config/prometheus.yaml
+++ b/development/tsdb-blocks-storage-s3-single-binary/config/prometheus.yaml
@@ -1,5 +1,7 @@
 global:
   scrape_interval: 5s
+  external_labels:
+    origin: prometheus
 
 scrape_configs:
   - job_name: cortex-1

--- a/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
@@ -26,6 +26,16 @@ services:
     ports:
       - 9090:9090
 
+  # Scrape the metrics also with the Grafana agent (useful to test metadata ingestion
+  # until metadata remote write is not supported by Prometheus).
+  grafana-agent:
+    image: grafana/agent:v0.2.0
+    command: ["-config.file=/etc/agent-config/grafana-agent.yaml", "-prometheus.wal-directory=/tmp"]
+    volumes:
+      - ./config:/etc/agent-config
+    ports:
+      - 9091:9091
+
   jaeger:
     image: jaegertracing/all-in-one
     ports:

--- a/development/tsdb-blocks-storage-s3/config/grafana-agent.yaml
+++ b/development/tsdb-blocks-storage-s3/config/grafana-agent.yaml
@@ -1,0 +1,51 @@
+server:
+  log_level: debug
+  http_listen_port: 9091
+
+prometheus:
+  global:
+    scrape_interval: 5s
+    external_labels:
+      origin: grafana-agent
+  configs:
+    - name: local
+      host_filter: false
+      scrape_configs:
+        - job_name: cortex-distributor
+          static_configs:
+            - targets: ['distributor:8001']
+              labels:
+                container: 'distributor'
+        - job_name: cortex-ingester-1
+          static_configs:
+            - targets: ['ingester-1:8002']
+              labels:
+                container: 'ingester-1'
+        - job_name: cortex-ingester-2
+          static_configs:
+            - targets: ['ingester-2:8003']
+              labels:
+                container: 'ingester-2'
+        - job_name: cortex-querier
+          static_configs:
+            - targets: ['querier:8004']
+              labels:
+                container: 'querier'
+        - job_name: cortex-ruler
+          static_configs:
+            - targets: ['ruler:8005']
+              labels:
+                container: 'ruler'
+        - job_name: cortex-compactor
+          static_configs:
+            - targets: ['compactor:8006']
+              labels:
+                container: 'compactor'
+        - job_name: cortex-query-frontend
+          static_configs:
+            - targets: ['query-frontend:8007']
+              labels:
+                container: 'query-frontend'
+
+      remote_write:
+        - url: http://distributor:8001/api/prom/push

--- a/development/tsdb-blocks-storage-s3/config/prometheus.yaml
+++ b/development/tsdb-blocks-storage-s3/config/prometheus.yaml
@@ -1,5 +1,7 @@
 global:
   scrape_interval: 5s
+  external_labels:
+    origin: prometheus
 
 scrape_configs:
   - job_name: cortex-distributor

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -40,6 +40,16 @@ services:
       - 16686:16686
       - "14268"
 
+  # Scrape the metrics also with the Grafana agent (useful to test metadata ingestion
+  # until metadata remote write is not supported by Prometheus).
+  grafana-agent:
+    image: grafana/agent:v0.2.0
+    command: ["-config.file=/etc/agent-config/grafana-agent.yaml", "-prometheus.wal-directory=/tmp"]
+    volumes:
+      - ./config:/etc/agent-config
+    ports:
+      - 9091:9091
+
   distributor:
     build:
       context:    .


### PR DESCRIPTION
**What this PR does**:
We've just merged #2549 from @gotjosh but I've realised there's no easy way to test metadata ingestion in the local dev env. In this PR I'm suggesting to run the Grafana Agent alongside Prometheus (series differentiated by the `origin` label) in order to have an easy way to also manually test metadata ingestion in the future.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
