### PR TITLE
support for cancellation of delete requests

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -180,8 +180,8 @@ func (a *API) RegisterIngester(i *ingester.Ingester, pushConfig distributor.Conf
 // RegisterPurger registers the endpoints associated with the Purger/DeleteStore. They do not exactly
 // match the Prometheus API but mirror it closely enough to justify their routing under the Prometheus
 // component/
-func (a *API) RegisterPurger(store *purger.DeleteStore, dataPurger *purger.DataPurger) {
-	deleteRequestHandler := purger.NewDeleteRequestHandler(store, dataPurger, prometheus.DefaultRegisterer)
+func (a *API) RegisterPurger(store *purger.DeleteStore) {
+	deleteRequestHandler := purger.NewDeleteRequestHandler(store, prometheus.DefaultRegisterer)
 
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/admin/tsdb/delete_series", http.HandlerFunc(deleteRequestHandler.AddDeleteRequestHandler), true, "PUT", "POST")
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/admin/tsdb/delete_series", http.HandlerFunc(deleteRequestHandler.GetAllDeleteRequestsHandler), true, "GET")

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -177,18 +177,20 @@ func (a *API) RegisterIngester(i *ingester.Ingester, pushConfig distributor.Conf
 	a.RegisterRoute("/push", push.Handler(pushConfig, i.Push), true) // For testing and debugging.
 }
 
-// RegisterPurger registers the endpoints associated with the Purger/DeleteStore. They do not exacty
+// RegisterPurger registers the endpoints associated with the Purger/DeleteStore. They do not exactly
 // match the Prometheus API but mirror it closely enough to justify their routing under the Prometheus
 // component/
-func (a *API) RegisterPurger(store *purger.DeleteStore) {
-	deleteRequestHandler := purger.NewDeleteRequestHandler(store, prometheus.DefaultRegisterer)
+func (a *API) RegisterPurger(store *purger.DeleteStore, dataPurger *purger.DataPurger) {
+	deleteRequestHandler := purger.NewDeleteRequestHandler(store, dataPurger, prometheus.DefaultRegisterer)
 
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/admin/tsdb/delete_series", http.HandlerFunc(deleteRequestHandler.AddDeleteRequestHandler), true, "PUT", "POST")
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/admin/tsdb/delete_series", http.HandlerFunc(deleteRequestHandler.GetAllDeleteRequestsHandler), true, "GET")
+	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/admin/tsdb/cancel_delete_request", http.HandlerFunc(deleteRequestHandler.CancelDeleteRequestHandler), true, "PUT", "POST")
 
 	// Legacy Routes
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/admin/tsdb/delete_series", http.HandlerFunc(deleteRequestHandler.AddDeleteRequestHandler), true, "PUT", "POST")
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/admin/tsdb/delete_series", http.HandlerFunc(deleteRequestHandler.GetAllDeleteRequestsHandler), true, "GET")
+	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/admin/tsdb/cancel_delete_request", http.HandlerFunc(deleteRequestHandler.CancelDeleteRequestHandler), true, "PUT", "POST")
 }
 
 // RegisterRuler registers routes associated with the Ruler service. If the

--- a/pkg/chunk/purger/delete_requests_store.go
+++ b/pkg/chunk/purger/delete_requests_store.go
@@ -293,6 +293,25 @@ func (ds *DeleteStore) queryCacheGenerationNumber(ctx context.Context, userID st
 	return genNumber, nil
 }
 
+// RemoveDeleteRequest removes a delete request and increments cache gen number
+func (ds *DeleteStore) RemoveDeleteRequest(ctx context.Context, userID, requestID string, createdAt, startTime, endTime model.Time) error {
+	userIDAndRequestID := fmt.Sprintf("%s:%s", userID, requestID)
+
+	writeBatch := ds.indexClient.NewWriteBatch()
+	writeBatch.Delete(ds.cfg.RequestsTableName, string(deleteRequestID), []byte(userIDAndRequestID))
+
+	// Add another entry with additional details like creation time, time range of delete request and selectors in value
+	rangeValue := fmt.Sprintf("%x:%x:%x", int64(createdAt), int64(startTime), int64(endTime))
+	writeBatch.Delete(ds.cfg.RequestsTableName, fmt.Sprintf("%s:%s", deleteRequestDetails, userIDAndRequestID),
+		[]byte(rangeValue))
+
+	// we need to invalidate results cache since removal of delete request would cause query results to change
+	writeBatch.Add(ds.cfg.RequestsTableName, fmt.Sprintf("%s:%s:%s", cacheGenNum, userID, CacheKindResults),
+		nil, []byte(strconv.FormatInt(time.Now().Unix(), 10)))
+
+	return ds.indexClient.BatchWrite(ctx, writeBatch)
+}
+
 func parseDeleteRequestTimestamps(rangeValue []byte, deleteRequest DeleteRequest) (DeleteRequest, error) {
 	hexParts := strings.Split(string(rangeValue), ":")
 	if len(hexParts) != 3 {

--- a/pkg/chunk/purger/purger.go
+++ b/pkg/chunk/purger/purger.go
@@ -24,7 +24,10 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
-const millisecondPerDay = int64(24 * time.Hour / time.Millisecond)
+const (
+	millisecondPerDay                 = int64(24 * time.Hour / time.Millisecond)
+	deleteRequestCancellationDeadline = 24 * time.Hour
+)
 
 type purgerMetrics struct {
 	deleteRequestsProcessedTotal      *prometheus.CounterVec
@@ -97,10 +100,6 @@ type DataPurger struct {
 	// and break the purge plan for other requests
 	inProcessRequestIDs    map[string]string
 	inProcessRequestIDsMtx sync.RWMutex
-	// used mostly for avoiding a race between cancellation of delete request and picking up delete requests for processing
-	// this is based on assumption that only one instance of purger should be running and delete request handler runs with purger.
-	// current design of DataPurger does require it to be running as single instance.
-	loadNewRequestsMtx sync.Mutex
 
 	pendingPlansCount    map[string]int // per request pending plan count
 	pendingPlansCountMtx sync.Mutex
@@ -333,16 +332,14 @@ func (dp *DataPurger) loadInprocessDeleteRequests() error {
 // pullDeleteRequestsToPlanDeletes pulls delete requests which do not have their delete plans built yet and sends them for building delete plans
 // after pulling delete requests for building plans, it updates its status to StatusBuildingPlan status to avoid picking this up again next time
 func (dp *DataPurger) pullDeleteRequestsToPlanDeletes() error {
-	dp.loadNewRequestsMtx.Lock()
-	defer dp.loadNewRequestsMtx.Unlock()
-
 	deleteRequests, err := dp.deleteStore.GetDeleteRequestsByStatus(context.Background(), StatusReceived)
 	if err != nil {
 		return err
 	}
 
 	for _, deleteRequest := range deleteRequests {
-		if deleteRequest.CreatedAt.Add(24 * time.Hour).After(model.Now()) {
+		// adding an extra minute here to avoid a race between cancellation of request and picking of the request for processing
+		if deleteRequest.CreatedAt.Add(deleteRequestCancellationDeadline).Add(time.Hour).After(model.Now()) {
 			continue
 		}
 

--- a/pkg/chunk/purger/purger.go
+++ b/pkg/chunk/purger/purger.go
@@ -339,7 +339,7 @@ func (dp *DataPurger) pullDeleteRequestsToPlanDeletes() error {
 
 	for _, deleteRequest := range deleteRequests {
 		// adding an extra minute here to avoid a race between cancellation of request and picking of the request for processing
-		if deleteRequest.CreatedAt.Add(deleteRequestCancellationDeadline).Add(time.Hour).After(model.Now()) {
+		if deleteRequest.CreatedAt.Add(deleteRequestCancellationDeadline).Add(time.Minute).After(model.Now()) {
 			continue
 		}
 

--- a/pkg/chunk/purger/request_handler.go
+++ b/pkg/chunk/purger/request_handler.go
@@ -171,5 +171,8 @@ func (dm *DeleteRequestHandler) CancelDeleteRequestHandler(w http.ResponseWriter
 	if err := dm.deleteStore.RemoveDeleteRequest(ctx, userID, requestID, deleteRequest.CreatedAt, deleteRequest.StartTime, deleteRequest.EndTime); err != nil {
 		level.Error(util.Logger).Log("msg", "error cancelling the delete request", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
+
+	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -509,7 +509,7 @@ func (t *Cortex) initDataPurger(cfg *Config) (services.Service, error) {
 		return nil, err
 	}
 
-	t.api.RegisterPurger(t.deletesStore, t.dataPurger)
+	t.api.RegisterPurger(t.deletesStore)
 
 	return t.dataPurger, nil
 }

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -509,7 +509,7 @@ func (t *Cortex) initDataPurger(cfg *Config) (services.Service, error) {
 		return nil, err
 	}
 
-	t.api.RegisterPurger(t.deletesStore)
+	t.api.RegisterPurger(t.deletesStore, t.dataPurger)
 
 	return t.dataPurger, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds support for cancellation of delete requests. Delete requests can be cancelled only when they are in `RECEIVED` status i.e it is not picked up for processing.

**NOTE**: To avoid a race between cancellation of delete requests and `DataPurger` picking up the delete request, I have added a Mutex. This is based on the assumption that `DataPurger` would always run as a single instance and it is always going to be the case since it kind of works as an orchestrator to manage delete requests. We will be scaling deletes in future by scaling workers(running as a service) not `DataPurger` service.
Alternative:
Currently, delete requests are processed only after they have aged for 24 hours. It is a hardcoded value and we are going to make it configurable just for running integration tests. Another option that we have is to allow delete requests to be cancelled only until they have aged for 24 hours and processing of delete requests to be deferred until they have aged for minimum 24 hours + 5 or so minutes. I have not considered that option because it would cause a problem in the implementation of integration tests.

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
