### PR TITLE
Documented how to mirror traffic with Envoy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
   docker:
     # IMPORTANT: whenever you change the build-image version tag, remember to replace it
     #            across the entire file (there are multiple references).
-    - image: quay.io/cortexproject/build-image:introduce-faillint-to-ci-ca69fd09b-WIP
+    - image: quay.io/cortexproject/build-image:share-traffic-mirroring-with-envoy-2af1da4d8-WIP
   working_directory: /go/src/github.com/cortexproject/cortex
 
 filters: &filters
@@ -91,7 +91,7 @@ jobs:
 
   test:
     docker:
-      - image: quay.io/cortexproject/build-image:introduce-faillint-to-ci-ca69fd09b-WIP
+      - image: quay.io/cortexproject/build-image:share-traffic-mirroring-with-envoy-2af1da4d8-WIP
       - image: cassandra:3.11
         environment:
           JVM_OPTS: "-Xms1024M -Xmx1024M"
@@ -115,7 +115,7 @@ jobs:
         name: Integration Test
         command: |
           touch build-image/.uptodate
-          MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations make BUILD_IMAGE=quay.io/cortexproject/build-image:introduce-faillint-to-ci-ca69fd09b-WIP configs-integration-test
+          MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations make BUILD_IMAGE=quay.io/cortexproject/build-image:share-traffic-mirroring-with-envoy-2af1da4d8-WIP configs-integration-test
 
   integration:
     machine:

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ load-images:
 doc: clean-doc
 	go run ./tools/doc-generator ./docs/configuration/config-file-reference.template >> ./docs/configuration/config-file-reference.md
 	go run ./tools/doc-generator ./docs/operations/blocks-storage.template           >> ./docs/operations/blocks-storage.md
+	embedmd -w docs/operations/requests-mirroring-to-secondary-cluster.md
 
 clean-doc:
 	rm -f ./docs/configuration/config-file-reference.md ./docs/operations/blocks-storage.md

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -36,6 +36,11 @@ ENV FAILLINT_VERSION=1.2.0
 RUN GO111MODULE=on go get github.com/fatih/faillint@v${FAILLINT_VERSION} && \
     rm -rf /go/pkg /go/src
 
+# Install embedmd used to embed content into markdown files.
+ENV EMBEDMD_VERSION=1.0.0
+RUN GO111MODULE=on go get github.com/campoy/embedmd@v${EMBEDMD_VERSION} && \
+    rm -rf /go/pkg /go/src
+
 ARG revision
 LABEL org.opencontainers.image.title="build-image" \
       org.opencontainers.image.source="https://github.com/cortexproject/cortex/tree/master/build-image" \

--- a/docs/operations/requests-mirroring-envoy.yaml
+++ b/docs/operations/requests-mirroring-envoy.yaml
@@ -1,0 +1,49 @@
+admin:
+  # No access logs.
+  access_log_path: /dev/null
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+    - name: cortex_listener
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 9900 }
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                stat_prefix: cortex_ingress
+                route_config:
+                  name: all_routes
+                  virtual_hosts:
+                    - name: all_hosts
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: cortex_primary
+
+                            # Specifies the upstream timeout. This spans between the point at which the entire downstream
+                            # request has been processed and when the upstream response has been completely processed.
+                            timeout: 15s
+
+                            # Specifies the cluster that requests will be mirrored to. The performances and availability of
+                            # the secondary cluster have no impact on the requests to the primary one. The response to the
+                            # client will always be the one from the primary one. The requests from Envoy to the secondary
+                            # cluster are "fire and forget".
+                            request_mirror_policies:
+                              - cluster: cortex_secondary
+                http_filters:
+                  - name: envoy.router
+  clusters:
+    - name: cortex_primary
+      type: STRICT_DNS
+      connect_timeout: 1s
+      hosts: [{ socket_address: { address: cortex-primary, port_value: 80 }}]
+      dns_refresh_rate: 5s
+    - name: cortex_secondary
+      type: STRICT_DNS
+      connect_timeout: 1s
+      hosts: [{ socket_address: { address: cortex-secondary, port_value: 80 }}]
+      dns_refresh_rate: 5s

--- a/docs/operations/requests-mirroring-to-secondary-cluster.md
+++ b/docs/operations/requests-mirroring-to-secondary-cluster.md
@@ -1,0 +1,71 @@
+---
+title: "Requests mirroring to secondary cluster"
+linkTitle: "Requests mirroring to secondary cluster"
+weight: 4
+slug: requests-mirroring-to-secondary-cluster
+---
+
+Requests mirroring (or shadowing) is a technique you can use to mirror requests from a primary Cortex cluster to a secondary one.
+
+For example, requests mirroring can be used when you need to setup a testing Cortex cluster receiving the same series ingested by a primary one without having control over Prometheus remote write config (if you do, then configuring two remote write entries in Prometheus would be the preferred option).
+
+## Mirroring with Envoy proxy
+
+[Envoy proxy](https://www.envoyproxy.io/) can be used to mirror HTTP requests to a secondary upstream cluster. From a network path perspective, you should run Envoy in front of both clusters distributors, letting Envoy to proxy requests to the primary Cortex cluster and mirror them to a secondary cluster in background. The performances and availability of the secondary cluster have no impact on the requests to the primary one. The response to the client will always be the one from the primary one. In this sense, the requests from Envoy to the secondary cluster are "fire and forget".
+
+### Example Envoy config
+
+The following Envoy configuration shows an example with two Cortex clusters. Envoy will listen on port `9900` and will proxies all requests to `cortex-primary:80`, mirroring it to `cortex-secondary:80` too.
+
+[embedmd]:# (./requests-mirroring-envoy.yaml)
+```yaml
+admin:
+  # No access logs.
+  access_log_path: /dev/null
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+    - name: cortex_listener
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 9900 }
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                stat_prefix: cortex_ingress
+                route_config:
+                  name: all_routes
+                  virtual_hosts:
+                    - name: all_hosts
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: cortex_primary
+
+                            # Specifies the upstream timeout. This spans between the point at which the entire downstream
+                            # request has been processed and when the upstream response has been completely processed.
+                            timeout: 15s
+
+                            # Specifies the cluster that requests will be mirrored to. The performances and availability of
+                            # the secondary cluster have no impact on the requests to the primary one. The response to the
+                            # client will always be the one from the primary one. The requests from Envoy to the secondary
+                            # cluster are "fire and forget".
+                            request_mirror_policies:
+                              - cluster: cortex_secondary
+                http_filters:
+                  - name: envoy.router
+  clusters:
+    - name: cortex_primary
+      type: STRICT_DNS
+      connect_timeout: 1s
+      hosts: [{ socket_address: { address: cortex-primary, port_value: 80 }}]
+      dns_refresh_rate: 5s
+    - name: cortex_secondary
+      type: STRICT_DNS
+      connect_timeout: 1s
+      hosts: [{ socket_address: { address: cortex-secondary, port_value: 80 }}]
+      dns_refresh_rate: 5s
+```


### PR DESCRIPTION
**What this PR does**:
We've successfully setup write-path traffic mirroring with Envoy and I would like to share an example config in our documentation.

I've introduced `embedmd` to have an easy way to embed a file (or a subset of it) inside our markdown, while keeping it synched. CI will ensure doc is synced (via `make check-doc`) and contributors can run `make doc` to compile the doc.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
