### PR TITLE
Don't write empty values to the index.

### DIFF
--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -36,6 +36,7 @@ const (
 var (
 	// ErrNotSupported when a schema doesn't support that particular lookup.
 	ErrNotSupported = errors.New("not supported")
+	empty           = []byte("-")
 )
 
 type hasChunksForIntervalFunc func(userID, seriesID string, from, through model.Time) (bool, error)
@@ -677,6 +678,7 @@ func (v9Entries) GetLabelWriteEntries(bucket Bucket, metricName string, labels l
 			TableName:  bucket.tableName,
 			HashValue:  bucket.hashKey + ":" + metricName,
 			RangeValue: encodeRangeKey(seriesRangeKeyV1, seriesID, nil, nil),
+			Value:      empty,
 		},
 	}
 
@@ -780,6 +782,7 @@ func (s v10Entries) GetLabelWriteEntries(bucket Bucket, metricName string, label
 			TableName:  bucket.tableName,
 			HashValue:  fmt.Sprintf("%02d:%s:%s", shard, bucket.hashKey, metricName),
 			RangeValue: encodeRangeKey(seriesRangeKeyV1, seriesID, nil, nil),
+			Value:      empty,
 		},
 	}
 
@@ -811,6 +814,7 @@ func (v10Entries) GetChunkWriteEntries(bucket Bucket, metricName string, labels 
 			TableName:  bucket.tableName,
 			HashValue:  bucket.hashKey + ":" + string(seriesID),
 			RangeValue: encodeRangeKey(chunkTimeRangeKeyV3, encodedThroughBytes, nil, []byte(chunkID)),
+			Value:      empty,
 		},
 	}
 
@@ -923,6 +927,7 @@ func (s v11Entries) GetLabelWriteEntries(bucket Bucket, metricName string, label
 			TableName:  bucket.tableName,
 			HashValue:  fmt.Sprintf("%02d:%s:%s", shard, bucket.hashKey, metricName),
 			RangeValue: encodeRangeKey(seriesRangeKeyV1, seriesID, nil, nil),
+			Value:      empty,
 		},
 		// Entry for seriesID -> label names
 		{


### PR DESCRIPTION
This causes tombstones to be written to Cassandra, which causes excessive heap usage.:

Signed-off-by: Tom Wilkie <tom@grafana.com>

**What this PR does**:

We write empty values (just using the row and column value) for metric name and series rows.
These empty value cause tombstones to be written to Cortex (https://thelastpickle.com/blog/2018/07/05/undetectable-tombstones-in-apache-cassandra.html).  Tombstones make Cassandra slow(er).

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
