### PR TITLE
add registerwithprefix function for thanos objstore configs

### DIFF
--- a/pkg/storage/backend/azure/config.go
+++ b/pkg/storage/backend/azure/config.go
@@ -17,9 +17,14 @@ type Config struct {
 
 // RegisterFlags registers the flags for TSDB Azure storage
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.StorageAccountName, "experimental.tsdb.azure.account-name", "", "Azure storage account name")
-	f.Var(&cfg.StorageAccountKey, "experimental.tsdb.azure.account-key", "Azure storage account key")
-	f.StringVar(&cfg.ContainerName, "experimental.tsdb.azure.container-name", "", "Azure storage container name")
-	f.StringVar(&cfg.Endpoint, "experimental.tsdb.azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN")
-	f.IntVar(&cfg.MaxRetries, "experimental.tsdb.azure.max-retries", 20, "Number of retries for recoverable errors")
+	cfg.RegisterFlagsWithPrefix("experimental.tsdb.", f)
+}
+
+// RegisterFlagsWithPrefix registers the flags for TSDB Azure storage
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.StorageAccountName, prefix+"azure.account-name", "", "Azure storage account name")
+	f.Var(&cfg.StorageAccountKey, prefix+"azure.account-key", "Azure storage account key")
+	f.StringVar(&cfg.ContainerName, prefix+"azure.container-name", "", "Azure storage container name")
+	f.StringVar(&cfg.Endpoint, prefix+"azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN")
+	f.IntVar(&cfg.MaxRetries, prefix+"azure.max-retries", 20, "Number of retries for recoverable errors")
 }

--- a/pkg/storage/backend/filesystem/config.go
+++ b/pkg/storage/backend/filesystem/config.go
@@ -9,5 +9,10 @@ type Config struct {
 
 // RegisterFlags registers the flags for TSDB filesystem storage
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.Directory, "experimental.tsdb.filesystem.dir", "", "Local filesystem storage directory.")
+	cfg.RegisterFlagsWithPrefix("experimental.tsdb.", f)
+}
+
+// RegisterFlagsWithPrefix registers the flags for TSDB filesystem storage with the provided prefix
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.Directory, prefix+"filesystem.dir", "", "Local filesystem storage directory.")
 }

--- a/pkg/storage/backend/gcs/config.go
+++ b/pkg/storage/backend/gcs/config.go
@@ -14,6 +14,11 @@ type Config struct {
 
 // RegisterFlags registers the flags for TSDB GCS storage
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.BucketName, "experimental.tsdb.gcs.bucket-name", "", "GCS bucket name")
-	f.Var(&cfg.ServiceAccount, "experimental.tsdb.gcs.service-account", "JSON representing either a Google Developers Console client_credentials.json file or a Google Developers service account key file. If empty, fallback to Google default logic.")
+	cfg.RegisterFlagsWithPrefix("experimental.tsdb.", f)
+}
+
+// RegisterFlagsWithPrefix registers the flags for TSDB GCS storage with the provided prefix
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.BucketName, prefix+"gcs.bucket-name", "", "GCS bucket name")
+	f.Var(&cfg.ServiceAccount, prefix+"gcs.service-account", "JSON representing either a Google Developers Console client_credentials.json file or a Google Developers service account key file. If empty, fallback to Google default logic.")
 }

--- a/pkg/storage/backend/s3/config.go
+++ b/pkg/storage/backend/s3/config.go
@@ -15,11 +15,16 @@ type Config struct {
 	Insecure        bool           `yaml:"insecure"`
 }
 
-// RegisterFlags registers the flags for TSDB s3 storage
+// RegisterFlags registers the flags for TSDB s3 storage with the provided prefix
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.AccessKeyID, "experimental.tsdb.s3.access-key-id", "", "S3 access key ID")
-	f.Var(&cfg.SecretAccessKey, "experimental.tsdb.s3.secret-access-key", "S3 secret access key")
-	f.StringVar(&cfg.BucketName, "experimental.tsdb.s3.bucket-name", "", "S3 bucket name")
-	f.StringVar(&cfg.Endpoint, "experimental.tsdb.s3.endpoint", "", "S3 endpoint without schema")
-	f.BoolVar(&cfg.Insecure, "experimental.tsdb.s3.insecure", false, "If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.")
+	cfg.RegisterFlagsWithPrefix("experimental.tsdb.", f)
+}
+
+// RegisterFlagsWithPrefix registers the flags for TSDB s3 storage with the provided prefix
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.AccessKeyID, prefix+"s3.access-key-id", "", "S3 access key ID")
+	f.Var(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "S3 secret access key")
+	f.StringVar(&cfg.BucketName, prefix+"s3.bucket-name", "", "S3 bucket name")
+	f.StringVar(&cfg.Endpoint, prefix+"s3.endpoint", "", "S3 endpoint without schema")
+	f.BoolVar(&cfg.Insecure, prefix+"s3.insecure", false, "If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.")
 }


### PR DESCRIPTION
**What this PR does**:

This PR updates all of the config structs in the `pkg/storage/backend/*` packages to have a `RegisterFlagsWithPrefix` function. This is needed to make it easier to reuse the Thanos objstore client across our stack. Will help remove some code from #2489 


**Which issue(s) this PR fixes**:
Related #2262 
