### PR TITLE
Track metric with the last successful blocks sync, scan and compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@
 * [ENHANCEMENT] Experimental TSDB: added the following metrics to the ingester: #2580
   * `cortex_ingester_tsdb_appender_add_duration_seconds`
   * `cortex_ingester_tsdb_appender_commit_duration_seconds`
-* [ENHANCEMENT] Experimental TSDB: added metrics useful to alert on critical conditions of the blocks storage:
+* [ENHANCEMENT] Experimental TSDB: added metrics useful to alert on critical conditions of the blocks storage: #2573
   * `cortex_compactor_last_successful_run_time`
   * `cortex_querier_blocks_last_successful_sync_time` (when store-gateway is disabled)
   * `cortex_querier_blocks_last_successful_scan_time` (when store-gateway is enabled)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,10 +60,10 @@
   * `cortex_ingester_tsdb_appender_add_duration_seconds`
   * `cortex_ingester_tsdb_appender_commit_duration_seconds`
 * [ENHANCEMENT] Experimental TSDB: added metrics useful to alert on critical conditions of the blocks storage: #2573
-  * `cortex_compactor_last_successful_run_time`
-  * `cortex_querier_blocks_last_successful_sync_time` (when store-gateway is disabled)
-  * `cortex_querier_blocks_last_successful_scan_time` (when store-gateway is enabled)
-  * `cortex_storegateway_blocks_last_successful_sync_time`
+  * `cortex_compactor_last_successful_run_timestamp_seconds`
+  * `cortex_querier_blocks_last_successful_sync_timestamp_seconds` (when store-gateway is disabled)
+  * `cortex_querier_blocks_last_successful_scan_timestamp_seconds` (when store-gateway is enabled)
+  * `cortex_storegateway_blocks_last_successful_sync_timestamp_seconds`
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@
 * [ENHANCEMENT] Experimental TSDB: added the following metrics to the ingester: #2580
   * `cortex_ingester_tsdb_appender_add_duration_seconds`
   * `cortex_ingester_tsdb_appender_commit_duration_seconds`
+* [ENHANCEMENT] Experimental TSDB: added metrics useful to alert on critical conditions of the blocks storage:
+  * `cortex_compactor_last_successful_run_time`
+  * `cortex_querier_blocks_last_successful_sync_time` (when store-gateway is disabled)
+  * `cortex_querier_blocks_last_successful_scan_time` (when store-gateway is enabled)
+  * `cortex_storegateway_blocks_last_successful_sync_time`
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -157,7 +157,7 @@ func newCompactor(
 			Help: "Total number of compaction runs failed.",
 		}),
 		compactionRunsLastSuccess: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
-			Name: "cortex_compactor_last_successful_run_time",
+			Name: "cortex_compactor_last_successful_run_timestamp_seconds",
 			Help: "Unix timestamp of the last successful compaction run.",
 		}),
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -158,7 +158,7 @@ func newCompactor(
 		}),
 		compactionRunsLastSuccess: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_compactor_last_successful_run_time",
-			Help: "The time of the last successful compaction run.",
+			Help: "Unix timestamp of the last successful compaction run.",
 		}),
 
 		blocksCleaned: promauto.With(registerer).NewCounter(prometheus.CounterOpts{

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -97,9 +97,10 @@ type Compactor struct {
 	subservicesWatcher *services.FailureWatcher
 
 	// Metrics.
-	compactionRunsStarted   prometheus.Counter
-	compactionRunsCompleted prometheus.Counter
-	compactionRunsFailed    prometheus.Counter
+	compactionRunsStarted     prometheus.Counter
+	compactionRunsCompleted   prometheus.Counter
+	compactionRunsFailed      prometheus.Counter
+	compactionRunsLastSuccess prometheus.Gauge
 
 	blocksCleaned           prometheus.Counter
 	blockCleanupFailures    prometheus.Counter
@@ -154,6 +155,10 @@ func newCompactor(
 		compactionRunsFailed: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_compactor_runs_failed_total",
 			Help: "Total number of compaction runs failed.",
+		}),
+		compactionRunsLastSuccess: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_compactor_last_successful_run_time",
+			Help: "The time of the last successful compaction run.",
 		}),
 
 		blocksCleaned: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
@@ -264,6 +269,7 @@ func (c *Compactor) compactUsersWithRetries(ctx context.Context) {
 	for retries.Ongoing() {
 		if success := c.compactUsers(ctx); success {
 			c.compactionRunsCompleted.Inc()
+			c.compactionRunsLastSuccess.SetToCurrentTime()
 			return
 		}
 

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -178,7 +178,27 @@ func TestCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 		# HELP cortex_compactor_blocks_marked_for_deletion_total Total number of blocks marked for deletion in compactor.
 		# TYPE cortex_compactor_blocks_marked_for_deletion_total counter
 		cortex_compactor_blocks_marked_for_deletion_total 0
-	`)))
+	`),
+		"cortex_compactor_runs_started_total",
+		"cortex_compactor_runs_completed_total",
+		"cortex_compactor_runs_failed_total",
+		"cortex_compactor_garbage_collected_blocks_total",
+		"cortex_compactor_garbage_collection_duration_seconds",
+		"cortex_compactor_garbage_collection_failures_total",
+		"cortex_compactor_garbage_collection_total",
+		"cortex_compactor_meta_sync_consistency_delay_seconds",
+		"cortex_compactor_meta_sync_duration_seconds",
+		"cortex_compactor_meta_sync_failures_total",
+		"cortex_compactor_meta_syncs_total",
+		"cortex_compactor_group_compaction_runs_completed_total",
+		"cortex_compactor_group_compaction_runs_started_total",
+		"cortex_compactor_group_compactions_failures_total",
+		"cortex_compactor_group_compactions_total",
+		"cortex_compactor_group_vertical_compactions_total",
+		"cortex_compactor_block_cleanup_failures_total",
+		"cortex_compactor_blocks_cleaned_total",
+		"cortex_compactor_blocks_marked_for_deletion_total",
+	))
 }
 
 func TestCompactor_ShouldRetryOnFailureWhileDiscoveringUsersFromBucket(t *testing.T) {
@@ -291,7 +311,27 @@ func TestCompactor_ShouldRetryOnFailureWhileDiscoveringUsersFromBucket(t *testin
 		# HELP cortex_compactor_blocks_marked_for_deletion_total Total number of blocks marked for deletion in compactor.
 		# TYPE cortex_compactor_blocks_marked_for_deletion_total counter
 		cortex_compactor_blocks_marked_for_deletion_total 0
-	`)))
+	`),
+		"cortex_compactor_runs_started_total",
+		"cortex_compactor_runs_completed_total",
+		"cortex_compactor_runs_failed_total",
+		"cortex_compactor_garbage_collected_blocks_total",
+		"cortex_compactor_garbage_collection_duration_seconds",
+		"cortex_compactor_garbage_collection_failures_total",
+		"cortex_compactor_garbage_collection_total",
+		"cortex_compactor_meta_sync_consistency_delay_seconds",
+		"cortex_compactor_meta_sync_duration_seconds",
+		"cortex_compactor_meta_sync_failures_total",
+		"cortex_compactor_meta_syncs_total",
+		"cortex_compactor_group_compaction_runs_completed_total",
+		"cortex_compactor_group_compaction_runs_started_total",
+		"cortex_compactor_group_compactions_failures_total",
+		"cortex_compactor_group_compactions_total",
+		"cortex_compactor_group_vertical_compactions_total",
+		"cortex_compactor_block_cleanup_failures_total",
+		"cortex_compactor_blocks_cleaned_total",
+		"cortex_compactor_blocks_marked_for_deletion_total",
+	))
 }
 
 func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {

--- a/pkg/querier/blocks_bucket_stores_service.go
+++ b/pkg/querier/blocks_bucket_stores_service.go
@@ -2,7 +2,6 @@ package querier
 
 import (
 	"context"
-	"io"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -85,7 +84,7 @@ func (s *BucketStoresService) syncStoresLoop(ctx context.Context) error {
 
 	err := runutil.Repeat(syncInterval, ctx.Done(), func() error {
 		level.Info(s.logger).Log("msg", "synchronizing TSDB blocks for all users")
-		if err := s.stores.SyncBlocks(ctx); err != nil && err != io.EOF {
+		if err := s.stores.SyncBlocks(ctx); err != nil {
 			level.Warn(s.logger).Log("msg", "failed to synchronize TSDB blocks", "err", err)
 		} else {
 			level.Info(s.logger).Log("msg", "successfully synchronized TSDB blocks for all users")

--- a/pkg/querier/blocks_bucket_stores_service_test.go
+++ b/pkg/querier/blocks_bucket_stores_service_test.go
@@ -70,7 +70,12 @@ func TestBucketStoresService_InitialSync(t *testing.T) {
 				defer services.StopAndAwaitTerminated(context.Background(), us) //nolint:errcheck
 			}
 
-			require.Equal(t, testData.expectedErr, err)
+			if testData.expectedErr != nil && err != nil {
+				require.Equal(t, testData.expectedErr.Error(), err.Error())
+			} else {
+				require.Equal(t, testData.expectedErr, err)
+			}
+
 			bucketClient.AssertNumberOfCalls(t, "Iter", testData.expectedIter)
 		})
 	}

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -74,7 +74,7 @@ func NewBlocksScanner(cfg BlocksScannerConfig, bucketClient objstore.Bucket, log
 			Buckets: []float64{1, 10, 20, 30, 60, 120, 180, 240, 300, 600},
 		}),
 		scanLastSuccess: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Name: "cortex_querier_blocks_last_successful_scan_time",
+			Name: "cortex_querier_blocks_last_successful_scan_timestamp_seconds",
 			Help: "Unix timestamp of the last successful blocks scan.",
 		}),
 	}

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -75,7 +75,7 @@ func NewBlocksScanner(cfg BlocksScannerConfig, bucketClient objstore.Bucket, log
 		}),
 		scanLastSuccess: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_querier_blocks_last_successful_scan_time",
-			Help: "The time of the last successful blocks scan.",
+			Help: "Unix timestamp of the last successful blocks scan.",
 		}),
 	}
 

--- a/pkg/querier/blocks_scanner_test.go
+++ b/pkg/querier/blocks_scanner_test.go
@@ -112,7 +112,7 @@ func TestBlocksScanner_InitialScanFailure(t *testing.T) {
 		# TYPE cortex_querier_blocks_meta_sync_consistency_delay_seconds gauge
 		cortex_querier_blocks_meta_sync_consistency_delay_seconds 0
 
-		# HELP cortex_querier_blocks_last_successful_scan_time The time of the last successful blocks scan.
+		# HELP cortex_querier_blocks_last_successful_scan_time Unix timestamp of the last successful blocks scan.
 		# TYPE cortex_querier_blocks_last_successful_scan_time gauge
 		cortex_querier_blocks_last_successful_scan_time 0
 	`),

--- a/pkg/querier/blocks_scanner_test.go
+++ b/pkg/querier/blocks_scanner_test.go
@@ -65,6 +65,8 @@ func TestBlocksScanner_InitialScan(t *testing.T) {
 		"cortex_querier_blocks_meta_sync_failures_total",
 		"cortex_querier_blocks_meta_sync_consistency_delay_seconds",
 	))
+
+	assert.Greater(t, testutil.ToFloat64(s.scanLastSuccess), float64(0))
 }
 
 func TestBlocksScanner_InitialScanFailure(t *testing.T) {
@@ -109,10 +111,15 @@ func TestBlocksScanner_InitialScanFailure(t *testing.T) {
 		# HELP cortex_querier_blocks_meta_sync_consistency_delay_seconds Configured consistency delay in seconds.
 		# TYPE cortex_querier_blocks_meta_sync_consistency_delay_seconds gauge
 		cortex_querier_blocks_meta_sync_consistency_delay_seconds 0
+
+		# HELP cortex_querier_blocks_last_successful_scan_time The time of the last successful blocks scan.
+		# TYPE cortex_querier_blocks_last_successful_scan_time gauge
+		cortex_querier_blocks_last_successful_scan_time 0
 	`),
 		"cortex_querier_blocks_meta_syncs_total",
 		"cortex_querier_blocks_meta_sync_failures_total",
 		"cortex_querier_blocks_meta_sync_consistency_delay_seconds",
+		"cortex_querier_blocks_last_successful_scan_time",
 	))
 }
 

--- a/pkg/querier/blocks_scanner_test.go
+++ b/pkg/querier/blocks_scanner_test.go
@@ -112,14 +112,14 @@ func TestBlocksScanner_InitialScanFailure(t *testing.T) {
 		# TYPE cortex_querier_blocks_meta_sync_consistency_delay_seconds gauge
 		cortex_querier_blocks_meta_sync_consistency_delay_seconds 0
 
-		# HELP cortex_querier_blocks_last_successful_scan_time Unix timestamp of the last successful blocks scan.
-		# TYPE cortex_querier_blocks_last_successful_scan_time gauge
-		cortex_querier_blocks_last_successful_scan_time 0
+		# HELP cortex_querier_blocks_last_successful_scan_timestamp_seconds Unix timestamp of the last successful blocks scan.
+		# TYPE cortex_querier_blocks_last_successful_scan_timestamp_seconds gauge
+		cortex_querier_blocks_last_successful_scan_timestamp_seconds 0
 	`),
 		"cortex_querier_blocks_meta_syncs_total",
 		"cortex_querier_blocks_meta_sync_failures_total",
 		"cortex_querier_blocks_meta_sync_consistency_delay_seconds",
-		"cortex_querier_blocks_last_successful_scan_time",
+		"cortex_querier_blocks_last_successful_scan_timestamp_seconds",
 	))
 }
 

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -70,7 +70,7 @@ func NewBucketStores(cfg tsdb.Config, filters []block.MetadataFilter, bucketClie
 			Buckets: []float64{0.1, 1, 10, 30, 60, 120, 300, 600, 900},
 		}),
 		syncLastSuccess: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Name: "blocks_last_successful_sync_time",
+			Name: "blocks_last_successful_sync_timestamp_seconds",
 			Help: "Unix timestamp of the last successful blocks sync.",
 		}),
 	}

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -71,7 +71,7 @@ func NewBucketStores(cfg tsdb.Config, filters []block.MetadataFilter, bucketClie
 		}),
 		syncLastSuccess: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "blocks_last_successful_sync_time",
-			Help: "The time of the last successful blocks sync.",
+			Help: "Unix timestamp of the last successful blocks sync.",
 		}),
 	}
 
@@ -139,7 +139,7 @@ func (u *BucketStores) syncUsersBlocks(ctx context.Context, f func(context.Conte
 			for job := range jobs {
 				if jobErr := f(ctx, job.store); jobErr != nil {
 					errsMx.Lock()
-					errs.Add(errors.Wrap(jobErr, fmt.Sprintf("failed to synchronize TSDB blocks for user %s", job.userID)))
+					errs.Add(errors.Wrapf(jobErr, "failed to synchronize TSDB blocks for user %s", job.userID))
 					errsMx.Unlock()
 				}
 			}

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -89,6 +89,8 @@ func TestBucketStores_InitialSync(t *testing.T) {
 			# TYPE bucket_store_block_load_failures_total counter
 			bucket_store_block_load_failures_total 0
 	`), "bucket_store_blocks_loaded", "bucket_store_block_loads_total", "bucket_store_block_load_failures_total"))
+
+	assert.Greater(t, testutil.ToFloat64(stores.syncLastSuccess), float64(0))
 }
 
 func TestBucketStores_SyncBlocks(t *testing.T) {
@@ -144,6 +146,8 @@ func TestBucketStores_SyncBlocks(t *testing.T) {
 			# TYPE bucket_store_block_load_failures_total counter
 			bucket_store_block_load_failures_total 0
 	`), "bucket_store_blocks_loaded", "bucket_store_block_loads_total", "bucket_store_block_load_failures_total"))
+
+	assert.Greater(t, testutil.ToFloat64(stores.syncLastSuccess), float64(0))
 }
 
 func TestBucketStores_syncUsersBlocks(t *testing.T) {

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -3,7 +3,6 @@ package storegateway
 import (
 	"context"
 	"flag"
-	"io"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -269,7 +268,7 @@ func (g *StoreGateway) syncStores(ctx context.Context, reason string) {
 	level.Info(g.logger).Log("msg", "synchronizing TSDB blocks for all users", "reason", reason)
 	g.bucketSync.WithLabelValues(reason).Inc()
 
-	if err := g.stores.SyncBlocks(ctx); err != nil && err != io.EOF {
+	if err := g.stores.SyncBlocks(ctx); err != nil {
 		level.Warn(g.logger).Log("msg", "failed to synchronize TSDB blocks", "reason", reason, "err", err)
 	} else {
 		level.Info(g.logger).Log("msg", "successfully synchronized TSDB blocks for all users", "reason", reason)


### PR DESCRIPTION
**What this PR does**:
While working on critical Cortex alerts for the blocks storage I've realised there's no reliable way to alert on few critical conditions: blocks are not successfully scanned, synched and compacted.

In this PR I propose the following metrics which allows to alert if a successful scan/sync/compact hasn't occurred in the last X time:
  * `cortex_compactor_last_successful_run_time`
  * `cortex_querier_blocks_last_successful_sync_time` (when store-gateway is disabled)
  * `cortex_querier_blocks_last_successful_scan_time` (when store-gateway is enabled)
  * `cortex_storegateway_blocks_last_successful_sync_time`

I've also removed the check on `io.EOF` because I can't see a good reason of having it. We can add it anytime if we figure out there's a good reason of having it, but right now I'm wondering if it's a just misprint from the past.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
