### PR TITLE
Reduces allocations in `GetParallelChunks`.

### DIFF
--- a/pkg/chunk/util/parallel_chunk_fetch_test.go
+++ b/pkg/chunk/util/parallel_chunk_fetch_test.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+)
+
+func BenchmarkGetParallelChunks(b *testing.B) {
+	ctx := context.Background()
+	in := make([]chunk.Chunk, 1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := GetParallelChunks(ctx, in,
+			func(_ context.Context, d *chunk.DecodeContext, c chunk.Chunk) (chunk.Chunk, error) {
+				return c, nil
+			})
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(res) != len(in) {
+			b.Fatal("unexpected number of chunk returned")
+		}
+	}
+}


### PR DESCRIPTION
I was seeing a lot of allocation in this code path and it turns out snappy reader is expensive to create.

This uses a pool in GetParallelChunks that way snappy reader are re-used.

benchmp:

```
❯ benchcmp before.txt after.txt
benchmark                         old ns/op     new ns/op     delta
BenchmarkGetParallelChunks-16     18147888      1483198       -91.83%

benchmark                         old allocs     new allocs     delta
BenchmarkGetParallelChunks-16     4214           9              -99.79%

benchmark                         old bytes     new bytes     delta
BenchmarkGetParallelChunks-16     146576089     127882        -99.91%
```
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>