### PR TITLE
Inject Cortex tracer to Thanos gRPC context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 * [BUGFIX] QueryFrontend: fixed a situation where HTTP error is ignored and an incorrect status code is set. #2483
 * [BUGFIX] QueryFrontend: fixed a situation where span context missed when downstream_url is used. #2539
 * [BUGFIX] Querier: Fixed a situation where querier would crash because of an unresponsive frontend instance. #2569
+* [BUGFIX] Fixed collection of tracing spans from Thanos components used internally. #2584
 
 ## 1.0.1 / 2020-04-23
 


### PR DESCRIPTION
**What this PR does**:
Nowadays we're using Thanos for several things (ie. blocks storage, DNS service discovery, ...) but Thanos traces are not correctly collected because Thanos requires a custom key to be set on the gRPC context. I've added a middleware to inject it for any request.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
