### PR TITLE
Fix memory leak in blocks storage ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 * [BUGFIX] QueryFrontend: fixed a situation where span context missed when downstream_url is used. #2539
 * [BUGFIX] Querier: Fixed a situation where querier would crash because of an unresponsive frontend instance. #2569
 * [BUGFIX] Fixed collection of tracing spans from Thanos components used internally. #2584
+* [BUGFIX] Experimental TSDB: fixed memory leak in ingesters. #2586
 
 ## 1.0.1 / 2020-04-23
 

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -229,15 +229,19 @@ func FromLabelAdaptersToLabels(ls []LabelAdapter) labels.Labels {
 // get in input labels whose data structure is reused.
 func FromLabelAdaptersToLabelsWithCopy(input []LabelAdapter) labels.Labels {
 	result := make(labels.Labels, len(input))
-
 	for i, l := range input {
 		result[i] = labels.Label{
-			Name:  l.Name,
-			Value: l.Value,
+			Name:  copyString(l.Name),
+			Value: copyString(l.Value),
 		}
 	}
-
 	return result
+}
+
+func copyString(in string) string {
+	out := make([]byte, len(in))
+	copy(out, in)
+	return string(out)
 }
 
 // FromLabelsToLabelAdapters casts labels.Labels to []LabelAdapter.


### PR DESCRIPTION
**What this PR does**:
In a production cluster running the blocks storage we've seen a large portion of the inuse heap retaining memory allocate by `grpc.recvMsg()`. This is caused by the fact that `FromLabelAdaptersToLabelsWithCopy()` doesn't do a deep copy but reuse input strings (which are read-only slice pointers).

In this PR we're fixing it doing a deep copy.

**Credits: the root cause has been spotted and fixed by @pstibrany**. I've just done double checks and opening the PR for it.

Given the same exact test scenario, this is the `recvMsg()` allocations **before the fix**:
![Screen Shot 2020-05-12 at 17 29 12](https://user-images.githubusercontent.com/1701904/81715152-28d11980-9478-11ea-99ea-38af226dad2a.png)

And this is **after the fix**:
![Screen Shot 2020-05-12 at 17 24 46](https://user-images.githubusercontent.com/1701904/81715166-2ec6fa80-9478-11ea-87c1-b807e045f21f.png)



**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
