### PR TITLE
Add metric to monitor cert expiry time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
   * `cortex_storegateway_blocks_last_successful_sync_timestamp_seconds`
 * [ENHANCEMENT] Experimental TSDB: added the flag `-experimental.tsdb.wal-compression-enabled` to allow to enable TSDB WAL compression. #2585
 * [ENHANCEMENT] Experimental TSDB: Querier and store-gateway components can now use so-called "caching bucket", which can currently cache fetched chunks into shared memcached server. #2572
+* [ENHANCEMENT] Added new metric to monitor TLS client cert expiry time. #2592
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/pkg/util/tls/tls.go
+++ b/pkg/util/tls/tls.go
@@ -7,8 +7,17 @@ import (
 	"io/ioutil"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+)
+
+var (
+	tlsCertNotAfterTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "cortex",
+		Name:      "tls_cert_not_after_timestamp",
+		Help:      "Timestamp of expiry for the TLS certificate",
+	}, []string{"filename"})
 )
 
 // ClientConfig is the config for client TLS.
@@ -41,6 +50,13 @@ func (cfg *ClientConfig) GetTLSConfig() (*tls.Config, error) {
 		caCertPool = x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 		if len(clientCert.Certificate) > 0 && caCertPool != nil {
+			prometheus.MustRegister(tlsCertNotAfterTimestamp)
+			var x509Cert *x509.Certificate
+			var err error
+			if x509Cert, err = x509.ParseCertificate(clientCert.Certificate[0]); err != nil {
+				return nil, errors.Wrap(err, "error parsing TLS certificate")
+			}
+			tlsCertNotAfterTimestamp.WithLabelValues(cfg.CertPath).Set(float64(x509Cert.NotAfter.Unix()))
 			return &tls.Config{
 				InsecureSkipVerify: true,
 				Certificates:       []tls.Certificate{clientCert},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds metric to monitor TLS client cert expiry time.

**Which issue(s) this PR fixes**:
Follow up from #2502 

**Checklist**
- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

Signed-off-by: Annanay <annanayagarwal@gmail.com>
