### PR TITLE
test exporter changes for testing delete series

### DIFF
--- a/cmd/test-exporter/main.go
+++ b/cmd/test-exporter/main.go
@@ -58,6 +58,7 @@ func main() {
 	if runnerConfig.EnableDeleteSeriesTest {
 		runnerConfig.DeleteSeriesTestConfig.ExtraSelectors = runnerConfig.ExtraSelectors
 		runnerConfig.DeleteSeriesTestConfig.PrometheusAddr = runnerConfig.PrometheusAddr
+		runnerConfig.DeleteSeriesTestConfig.UserID = runnerConfig.UserID
 		runner.Add(correctness.NewDeleteSeriesTest("delete_series", func(t time.Time) float64 {
 			return t.Sub(unixStart).Seconds()
 		}, runnerConfig.DeleteSeriesTestConfig, runnerConfig.CommonTestConfig))

--- a/cmd/test-exporter/main.go
+++ b/cmd/test-exporter/main.go
@@ -46,14 +46,22 @@ func main() {
 
 	runner.Add(correctness.NewSimpleTestCase("now_seconds", func(t time.Time) float64 {
 		return t.Sub(unixStart).Seconds()
-	}))
+	}, runnerConfig.CommonTestConfig))
 
 	runner.Add(correctness.NewSimpleTestCase("sine_wave", func(t time.Time) float64 {
 		// With a 15-second scrape interval this gives a ten-minute period
-		period := float64(40 * runnerConfig.ScrapeInterval.Nanoseconds())
+		period := float64(40 * runnerConfig.CommonTestConfig.ScrapeInterval.Nanoseconds())
 		radians := float64(t.UnixNano()) / period * 2 * math.Pi
 		return math.Sin(radians)
-	}))
+	}, runnerConfig.CommonTestConfig))
+
+	if runnerConfig.EnableDeleteSeriesTest {
+		runnerConfig.DeleteSeriesTestConfig.ExtraSelectors = runnerConfig.ExtraSelectors
+		runnerConfig.DeleteSeriesTestConfig.PrometheusAddr = runnerConfig.PrometheusAddr
+		runner.Add(correctness.NewDeleteSeriesTest("delete_series", func(t time.Time) float64 {
+			return t.Sub(unixStart).Seconds()
+		}, runnerConfig.DeleteSeriesTestConfig, runnerConfig.CommonTestConfig))
+	}
 
 	prometheus.MustRegister(runner)
 	err = server.Run()

--- a/pkg/testexporter/correctness/case.go
+++ b/pkg/testexporter/correctness/case.go
@@ -9,12 +9,15 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-// Case is a metric that can query itself.
+// Case is a metric that can be used for exporting a metric and querying it for tests.
 type Case interface {
 	prometheus.Collector
 
 	Name() string
 	Query(ctx context.Context, client v1.API, selectors string, start time.Time, duration time.Duration) ([]model.SamplePair, error)
 	ExpectedValueAt(time.Time) float64
-	Quantized(time.Duration) time.Duration
+
+	MinQueryTime() time.Time
+	Test(ctx context.Context, client v1.API, selectors string, start time.Time, duration time.Duration) (bool, error)
+	Stop()
 }

--- a/pkg/testexporter/correctness/delete_series.go
+++ b/pkg/testexporter/correctness/delete_series.go
@@ -173,10 +173,15 @@ func (d *DeleteSeriesTest) Test(ctx context.Context, client v1.API, selectors st
 		passed := verifySamples(spanlogger.FromContext(ctx), d, pairs[verifyPairsFrom:verifyPairsTo], nonDeletedInterval.end.Sub(nonDeletedInterval.start), d.commonTestConfig)
 		if !passed {
 			verifyingPairs := pairs[verifyPairsFrom:verifyPairsTo]
-			level.Error(log).Log("msg", "failed to verify samples batch", "query start", start.Unix(), "query duration", duration,
-				"batch length", len(verifyingPairs),
-				"batch duration", nonDeletedInterval.end.Sub(nonDeletedInterval.start), "batch-start", verifyingPairs[0].Timestamp.Unix(),
-				"batch-end", verifyingPairs[len(verifyingPairs)-1].Timestamp.Unix())
+			if len(verifyingPairs) == 0 {
+				level.Error(log).Log("msg", fmt.Sprintf("expected samples from %d to %d but got 0 samples", nonDeletedInterval.start.Unix(),
+					nonDeletedInterval.end.Unix()), "query start", start.Unix(), "query duration", duration)
+			} else {
+				level.Error(log).Log("msg", "failed to verify samples batch", "query start", start.Unix(), "query duration", duration,
+					"batch length", len(verifyingPairs),
+					"batch duration", nonDeletedInterval.end.Sub(nonDeletedInterval.start), "batch-start", verifyingPairs[0].Timestamp.Unix(),
+					"batch-end", verifyingPairs[len(verifyingPairs)-1].Timestamp.Unix())
+			}
 			return false, nil
 		}
 

--- a/pkg/testexporter/correctness/delete_series.go
+++ b/pkg/testexporter/correctness/delete_series.go
@@ -170,7 +170,7 @@ func (d *DeleteSeriesTest) Test(ctx context.Context, client v1.API, selectors st
 			}
 		}
 
-		passed := verifySamples(ctx, d, pairs[verifyPairsFrom:verifyPairsTo], nonDeletedInterval.end.Sub(nonDeletedInterval.start), d.commonTestConfig)
+		passed := verifySamples(spanlogger.FromContext(ctx), d, pairs[verifyPairsFrom:verifyPairsTo], nonDeletedInterval.end.Sub(nonDeletedInterval.start), d.commonTestConfig)
 		if !passed {
 			verifyingPairs := pairs[verifyPairsFrom:verifyPairsTo]
 			level.Error(log).Log("msg", "failed to verify samples batch", "query start", start.Unix(), "query duration", duration,

--- a/pkg/testexporter/correctness/delete_series.go
+++ b/pkg/testexporter/correctness/delete_series.go
@@ -1,0 +1,256 @@
+package correctness
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log/level"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
+)
+
+const deleteRequestPath = "/api/v1/admin/tsdb/delete_series"
+
+var (
+	deleteRequestCreationAttemptsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "delete_requests_creation_attempts_total",
+		Help:      "Total number of delete requests creation attempts with status",
+	}, []string{"status"})
+)
+
+type DeleteSeriesTestConfig struct {
+	deleteRequestCreationInterval time.Duration
+	deleteDataForRange            time.Duration
+	timeQueryStart                TimeValue
+	durationQuerySince            time.Duration
+
+	PrometheusAddr string
+	ExtraSelectors string
+}
+
+func (cfg *DeleteSeriesTestConfig) RegisterFlags(f *flag.FlagSet) {
+	f.DurationVar(&cfg.deleteRequestCreationInterval, "delete-request-creation-interval", 5*time.Minute, "The interval at which delete request should be sent.")
+	f.DurationVar(&cfg.deleteDataForRange, "delete-data-for-range", 2*time.Minute, "Time range for which data is deleted.")
+
+	// By default, we only query for values from when this process started
+	cfg.timeQueryStart = NewTimeValue(time.Now())
+	f.Var(&cfg.timeQueryStart, "delete-series-test.test-query-start", "Minimum start date for queries")
+	f.DurationVar(&cfg.durationQuerySince, "delete-series-test.test-query-since", 0, "Duration in the past to test.  Overrides -test-query-start")
+}
+
+// DeleteSeriesTest would keep deleting data for configured duration at configured interval.
+// Test method would check whether we are getting expected data by eliminating deleted samples while non deleted ones stays untouched.
+// For simplification it would not test samples from the start time of last sent delete request and just treat it as passed.
+type DeleteSeriesTest struct {
+	Case
+	cfg                            DeleteSeriesTestConfig
+	commonTestConfig               CommonTestConfig
+	lastDeleteRequestInterval      interval
+	lastDeleteRequestIntervalMutex sync.RWMutex
+	quit                           chan struct{}
+	wg                             sync.WaitGroup
+}
+
+func NewDeleteSeriesTest(name string, f func(time.Time) float64, cfg DeleteSeriesTestConfig, commonTestConfig CommonTestConfig) Case {
+	commonTestConfig.timeQueryStart = cfg.timeQueryStart
+	commonTestConfig.durationQuerySince = cfg.durationQuerySince
+	test := DeleteSeriesTest{
+		Case:             NewSimpleTestCase(name, f, commonTestConfig),
+		cfg:              cfg,
+		commonTestConfig: commonTestConfig,
+		quit:             make(chan struct{}),
+	}
+
+	test.wg.Add(1)
+	go test.sendDeleteRequestLoop()
+	return &test
+}
+
+func (d *DeleteSeriesTest) Stop() {
+	close(d.quit)
+	d.wg.Wait()
+}
+
+func (d *DeleteSeriesTest) sendDeleteRequestLoop() {
+	// send a delete request as soon as we start to avoid missing creation of delete request across restarts.
+	err := d.sendDeleteRequest()
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "error sending delete request", "error", err)
+	}
+
+	t := time.NewTicker(d.cfg.deleteRequestCreationInterval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			err := d.sendDeleteRequest()
+			if err != nil {
+				level.Error(util.Logger).Log("msg", "error sending delete request", "error", err)
+			}
+		case <-d.quit:
+			return
+		}
+	}
+}
+
+func (d *DeleteSeriesTest) Test(ctx context.Context, client v1.API, selectors string, start time.Time, duration time.Duration) (bool, error) {
+	log := spanlogger.FromContext(ctx)
+	queryInterval := interval{start: start.Add(-duration), end: start}
+
+	d.lastDeleteRequestIntervalMutex.RLock()
+	defer d.lastDeleteRequestIntervalMutex.RUnlock()
+
+	// we do not want to query data after the start time of last delete request sent to simplify things.
+	lastDeleteRequestInterval := d.lastDeleteRequestInterval
+	if !queryInterval.end.Before(lastDeleteRequestInterval.start) {
+		level.Info(log).Log("msg", fmt.Sprintf("skipping test for %d to %d requesting samples after last sent delete request's start time %d",
+			start.Add(-duration).Unix(), start.Unix(), lastDeleteRequestInterval.end.Unix()))
+		return true, nil
+	}
+
+	pairs, err := d.Query(ctx, client, selectors, start, duration)
+	if err != nil {
+		level.Error(log).Log("err", err)
+		return false, err
+	}
+
+	nonDeletedIntervals := d.getNonDeletedIntervals(queryInterval)
+	if len(nonDeletedIntervals) == 0 {
+		// we are querying data covered completed by deleted interval so there should not be any sample pairs returned by the query.
+		if len(pairs) != 0 {
+			return false, errors.New("samples should be 0")
+		}
+		return true, nil
+	}
+
+	verifyPairsFrom, verifyPairsTo := 0, 0
+	for _, nonDeletedInterval := range nonDeletedIntervals {
+		for ; verifyPairsTo < len(pairs); verifyPairsTo++ {
+			pair := pairs[verifyPairsTo]
+			if pair.Timestamp.Time().Before(nonDeletedInterval.start) {
+				return false, fmt.Errorf("unexpected sample at timestamp %d", pair.Timestamp.Unix())
+			} else if pair.Timestamp.Time().After(nonDeletedInterval.end) {
+				break
+			}
+		}
+
+		passed := verifySamples(ctx, d, pairs[verifyPairsFrom:verifyPairsTo], nonDeletedInterval.end.Sub(nonDeletedInterval.start), d.commonTestConfig)
+		if !passed {
+			level.Error(log).Log("msg", "failed to verify samples batch", "query start", start.Unix(), "query duration", duration,
+				"batch duration", nonDeletedInterval.end.Sub(nonDeletedInterval.start), "batch", pairs[verifyPairsFrom:verifyPairsTo])
+			return false, nil
+		}
+
+		verifyPairsFrom = verifyPairsTo
+	}
+
+	return true, nil
+}
+
+func (d *DeleteSeriesTest) sendDeleteRequest() (err error) {
+	// data is deleted by slicing the time by deleteRequestCreationInterval from 0 time i.e beginning of epoch
+	// and doing deletion for last deleteDataForRange duration at the end of that slice.
+	endTime := time.Now().Truncate(d.cfg.deleteRequestCreationInterval)
+	startTime := endTime.Add(-d.cfg.deleteDataForRange)
+	metricName := prometheus.BuildFQName(namespace, subsystem, d.Name())
+	selectors := fmt.Sprintf("%s{%s}", metricName, d.cfg.ExtraSelectors)
+
+	defer func() {
+		status := success
+		if err != nil {
+			status = fail
+		}
+		deleteRequestCreationAttemptsTotal.WithLabelValues(status).Inc()
+	}()
+
+	baseURL, err := url.Parse(d.cfg.PrometheusAddr)
+	if err != nil {
+		return
+	}
+
+	baseURL.Path = path.Join(baseURL.Path, deleteRequestPath)
+
+	query := baseURL.Query()
+	query.Add("match[]", selectors)
+	query.Add("start", fmt.Sprint(startTime.Unix()))
+	query.Add("end", fmt.Sprint(endTime.Unix()))
+	baseURL.RawQuery = query.Encode()
+
+	level.Error(util.Logger).Log("msg", "sending delete request", "selector", selectors, "starttime", startTime, "endtime", endTime)
+	resp, err := http.Post(baseURL.String(), "text/plain", nil)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+
+	d.lastDeleteRequestIntervalMutex.Lock()
+	defer d.lastDeleteRequestIntervalMutex.Unlock()
+
+	d.lastDeleteRequestInterval = interval{startTime, endTime}
+
+	return
+}
+
+func (d *DeleteSeriesTest) getNonDeletedIntervals(queryInterval interval) []interval {
+	intervalToProcess := queryInterval
+	var nonDeletedIntervals []interval
+
+	// build first deleted interval
+	deletedIntervalEnd := queryInterval.start.Truncate(d.cfg.deleteRequestCreationInterval)
+	deletedIntervalStart := deletedIntervalEnd.Add(-d.cfg.deleteDataForRange)
+
+	// first deleted interval could be out of range so try next intervals to find first relevant interval.
+	for !deletedIntervalStart.After(intervalToProcess.start) {
+		deletedIntervalStart = deletedIntervalStart.Add(d.cfg.deleteRequestCreationInterval)
+		if deletedIntervalEnd.Add(1).After(intervalToProcess.start) {
+			intervalToProcess.start = deletedIntervalEnd.Add(1)
+		}
+		deletedIntervalEnd = deletedIntervalEnd.Add(d.cfg.deleteRequestCreationInterval)
+	}
+
+	// keep building non-deleted intervals with each being from intervalToProcess.start to min(deletedIntervalStart.Start-1, intervalToProcess.end)
+	for !deletedIntervalStart.After(queryInterval.end) {
+		nonDeletedInterval := interval{intervalToProcess.start, deletedIntervalStart.Add(-1)}
+		if nonDeletedInterval.end.After(intervalToProcess.end) {
+			nonDeletedInterval.end = intervalToProcess.end
+		}
+		nonDeletedIntervals = append(nonDeletedIntervals, nonDeletedInterval)
+		intervalToProcess.start = deletedIntervalEnd.Add(1)
+
+		// build next deleted interval
+		deletedIntervalStart = deletedIntervalStart.Add(d.cfg.deleteRequestCreationInterval)
+		deletedIntervalEnd = deletedIntervalEnd.Add(d.cfg.deleteRequestCreationInterval)
+	}
+
+	// see if we have some interval left in intervalToProcess, add it if so.
+	if intervalToProcess.start.Before(intervalToProcess.end) {
+		nonDeletedIntervals = append(nonDeletedIntervals, intervalToProcess)
+	}
+
+	return nonDeletedIntervals
+}
+
+func (d *DeleteSeriesTest) MinQueryTime() time.Time {
+	return calculateMinQueryTime(d.cfg.durationQuerySince, d.cfg.timeQueryStart)
+}
+
+type interval struct {
+	start, end time.Time
+}

--- a/pkg/testexporter/correctness/runner.go
+++ b/pkg/testexporter/correctness/runner.go
@@ -45,7 +45,7 @@ type RunnerConfig struct {
 	testQueryMinSize       time.Duration
 	testQueryMaxSize       time.Duration
 	PrometheusAddr         string
-	userID                 string
+	UserID                 string
 	ExtraSelectors         string
 	EnableDeleteSeriesTest bool
 	CommonTestConfig       CommonTestConfig
@@ -59,7 +59,7 @@ func (cfg *RunnerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.testQueryMaxSize, "test-query-max-size", 60*time.Minute, "The max query size to Prometheus.")
 
 	f.StringVar(&cfg.PrometheusAddr, "prometheus-address", "", "Address of Prometheus instance to query.")
-	f.StringVar(&cfg.userID, "user-id", "", "UserID to send to Cortex.")
+	f.StringVar(&cfg.UserID, "user-id", "", "UserID to send to Cortex.")
 
 	f.StringVar(&cfg.ExtraSelectors, "extra-selectors", "", "Extra selectors to be included in queries, eg to identify different instances of this job.")
 	f.BoolVar(&cfg.EnableDeleteSeriesTest, "enable-delete-series-test", false, "Enable tests for checking deletion of series.")
@@ -83,10 +83,10 @@ func NewRunner(cfg RunnerConfig) (*Runner, error) {
 	apiCfg := api.Config{
 		Address: cfg.PrometheusAddr,
 	}
-	if cfg.userID != "" {
+	if cfg.UserID != "" {
 		apiCfg.RoundTripper = &nethttp.Transport{
 			RoundTripper: promhttp.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				_ = user.InjectOrgIDIntoHTTPRequest(user.InjectOrgID(context.Background(), cfg.userID), req)
+				_ = user.InjectOrgIDIntoHTTPRequest(user.InjectOrgID(context.Background(), cfg.UserID), req)
 				return api.DefaultRoundTripper.RoundTrip(req)
 			}),
 		}

--- a/pkg/testexporter/correctness/runner.go
+++ b/pkg/testexporter/correctness/runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"math"
 	"math/rand"
 	"net/http"
 	"sync"
@@ -13,12 +12,11 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	opentracing "github.com/opentracing/opentracing-go"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/prometheus/common/model"
 	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
@@ -30,50 +28,28 @@ const (
 )
 
 var (
-	testcaseResult = prometheus.NewCounterVec(
+	testcaseResult = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: subsystem,
 			Name:      "test_case_result_total",
-			Help:      "Number of test cases that succeed / fail.",
+			Help:      "Number of test cases by test name, that succeed / fail.",
 		},
-		[]string{"result"},
+		[]string{"name", "result"},
 	)
-	sampleResult = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      "sample_result_total",
-			Help:      "Number of samples that succeed / fail.",
-		},
-		[]string{"result"},
-	)
-	prometheusRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Subsystem: subsystem,
-		Name:      "prometheus_request_duration_seconds",
-		Help:      "Time spent doing Prometheus requests.",
-		Buckets:   prometheus.DefBuckets,
-	}, []string{"operation", "status_code"})
+	startTime = time.Now()
 )
-
-func init() {
-	prometheus.MustRegister(testcaseResult)
-	prometheus.MustRegister(sampleResult)
-	prometheus.MustRegister(prometheusRequestDuration)
-}
 
 // RunnerConfig is config, for the runner.
 type RunnerConfig struct {
-	testRate           float64
-	testQueryMinSize   time.Duration
-	testQueryMaxSize   time.Duration
-	testTimeEpsilon    time.Duration
-	testEpsilon        float64
-	prometheusAddr     string
-	userID             string
-	timeQueryStart     TimeValue
-	durationQuerySince time.Duration
-	extraSelectors     string
-	ScrapeInterval     time.Duration
-	samplesEpsilon     float64
+	testRate               float64
+	testQueryMinSize       time.Duration
+	testQueryMaxSize       time.Duration
+	PrometheusAddr         string
+	userID                 string
+	ExtraSelectors         string
+	EnableDeleteSeriesTest bool
+	CommonTestConfig       CommonTestConfig
+	DeleteSeriesTestConfig DeleteSeriesTestConfig
 }
 
 // RegisterFlags does what it says.
@@ -81,31 +57,15 @@ func (cfg *RunnerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&cfg.testRate, "test-rate", 1, "Query QPS")
 	f.DurationVar(&cfg.testQueryMinSize, "test-query-min-size", 5*time.Minute, "The min query size to Prometheus.")
 	f.DurationVar(&cfg.testQueryMaxSize, "test-query-max-size", 60*time.Minute, "The max query size to Prometheus.")
-	f.DurationVar(&cfg.testTimeEpsilon, "test-time-epsilion", 1*time.Second, "Amount samples are allowed to be off by")
-	f.Float64Var(&cfg.testEpsilon, "test-epsilion", 0.01, "Amount samples are allowed to be off by this %%")
-	f.StringVar(&cfg.prometheusAddr, "prometheus-address", "", "Address of Prometheus instance to query.")
+
+	f.StringVar(&cfg.PrometheusAddr, "prometheus-address", "", "Address of Prometheus instance to query.")
 	f.StringVar(&cfg.userID, "user-id", "", "UserID to send to Cortex.")
 
-	// By default, we only query for values from when this process started
-	f.Var(&cfg.timeQueryStart, "test-query-start", "Minimum start date for queries")
-	f.DurationVar(&cfg.durationQuerySince, "test-query-since", 0, "Duration in the past to test.  Overrides -test-query-start")
+	f.StringVar(&cfg.ExtraSelectors, "extra-selectors", "", "Extra selectors to be included in queries, eg to identify different instances of this job.")
+	f.BoolVar(&cfg.EnableDeleteSeriesTest, "enable-delete-series-test", false, "Enable tests for checking deletion of series.")
 
-	f.StringVar(&cfg.extraSelectors, "extra-selectors", "", "Extra selectors to be included in queries, eg to identify different instances of this job.")
-	f.DurationVar(&cfg.ScrapeInterval, "scrape-interval", 15*time.Second, "Expected scrape interval.")
-	f.Float64Var(&cfg.samplesEpsilon, "test-samples-epsilon", 0.1, "Amount that the number of samples are allowed to be off by")
-}
-
-func (cfg *RunnerConfig) minQueryTime() time.Time {
-	start := time.Now()
-
-	if cfg.timeQueryStart.set {
-		start = cfg.timeQueryStart.Time
-	}
-	if cfg.durationQuerySince != 0 {
-		start = time.Now().Add(-cfg.durationQuerySince)
-	}
-
-	return start
+	cfg.CommonTestConfig.RegisterFlags(f)
+	cfg.DeleteSeriesTestConfig.RegisterFlags(f)
 }
 
 // Runner runs a bunch of test cases, periodically checking their value.
@@ -121,7 +81,7 @@ type Runner struct {
 // NewRunner makes a new Runner.
 func NewRunner(cfg RunnerConfig) (*Runner, error) {
 	apiCfg := api.Config{
-		Address: cfg.prometheusAddr,
+		Address: cfg.PrometheusAddr,
 	}
 	if cfg.userID != "" {
 		apiCfg.RoundTripper = &nethttp.Transport{
@@ -130,6 +90,8 @@ func NewRunner(cfg RunnerConfig) (*Runner, error) {
 				return api.DefaultRoundTripper.RoundTrip(req)
 			}),
 		}
+	} else {
+		apiCfg.RoundTripper = &nethttp.Transport{}
 	}
 
 	client, err := api.NewClient(apiCfg)
@@ -164,6 +126,10 @@ func (t tracingClient) Do(ctx context.Context, req *http.Request) (*http.Respons
 func (r *Runner) Stop() {
 	close(r.quit)
 	r.wg.Wait()
+
+	for _, tc := range r.cases {
+		tc.Stop()
+	}
 }
 
 // Add a new TestCase.
@@ -219,7 +185,7 @@ func (r *Runner) runRandomTest() {
 		trace = fmt.Sprintf("%s", span.Context())
 	}
 
-	minQueryTime := r.cfg.minQueryTime()
+	minQueryTime := tc.MinQueryTime()
 	level.Info(log).Log("name", tc.Name(), "trace", trace, "minTime", minQueryTime)
 	defer log.Finish()
 
@@ -235,55 +201,19 @@ func (r *Runner) runRandomTest() {
 	if duration < r.cfg.testQueryMinSize {
 		return
 	}
+
+	// round off duration to minutes because we anyways have a window in minutes while doing queries.
+	duration = (duration / time.Minute) * time.Minute
 	level.Info(log).Log("start", start, "duration", duration)
 
-	pairs, err := tc.Query(ctx, r.client, r.cfg.extraSelectors, start, duration)
+	passed, err := tc.Test(ctx, r.client, r.cfg.ExtraSelectors, start, duration)
 	if err != nil {
-		level.Info(log).Log("err", err)
-		return
+		level.Error(log).Log("err", err)
 	}
 
-	failures := false
-	for _, pair := range pairs {
-		correct := r.timeEpsilonCorrect(tc.ExpectedValueAt, pair) || r.valueEpsilonCorrect(tc.ExpectedValueAt, pair)
-		if correct {
-			sampleResult.WithLabelValues(success).Inc()
-		} else {
-			failures = true
-			sampleResult.WithLabelValues(fail).Inc()
-			level.Error(log).Log("msg", "wrong value", "at", pair.Timestamp, "expected", tc.ExpectedValueAt(pair.Timestamp.Time()), "actual", pair.Value)
-			log.LogFields(otlog.Error(fmt.Errorf("wrong value")))
-		}
-	}
-
-	expectedNumSamples := int(tc.Quantized(duration) / r.cfg.ScrapeInterval)
-	if !epsilonCorrect(float64(len(pairs)), float64(expectedNumSamples), r.cfg.samplesEpsilon) {
-		level.Error(log).Log("msg", "wrong number of samples", "expected", expectedNumSamples, "actual", len(pairs))
-		log.LogFields(otlog.Error(fmt.Errorf("wrong number of samples")))
-		failures = true
-	}
-
-	if failures {
-		testcaseResult.WithLabelValues(fail).Inc()
+	if passed {
+		testcaseResult.WithLabelValues(tc.Name(), success).Inc()
 	} else {
-		testcaseResult.WithLabelValues(success).Inc()
+		testcaseResult.WithLabelValues(tc.Name(), fail).Inc()
 	}
-}
-
-func (r *Runner) timeEpsilonCorrect(f func(time.Time) float64, pair model.SamplePair) bool {
-	minExpected := f(pair.Timestamp.Time().Add(-r.cfg.testTimeEpsilon))
-	maxExpected := f(pair.Timestamp.Time().Add(r.cfg.testTimeEpsilon))
-	if minExpected > maxExpected {
-		minExpected, maxExpected = maxExpected, minExpected
-	}
-	return minExpected < float64(pair.Value) && float64(pair.Value) < maxExpected
-}
-
-func (r *Runner) valueEpsilonCorrect(f func(time.Time) float64, pair model.SamplePair) bool {
-	return epsilonCorrect(float64(pair.Value), f(pair.Timestamp.Time()), r.cfg.testEpsilon)
-}
-
-func epsilonCorrect(actual, expected, epsilon float64) bool {
-	delta := math.Abs((actual - expected) / expected)
-	return delta < epsilon
 }

--- a/pkg/testexporter/correctness/runner_test.go
+++ b/pkg/testexporter/correctness/runner_test.go
@@ -9,28 +9,25 @@ import (
 
 func TestMinQueryTime(t *testing.T) {
 	tests := []struct {
-		cfg      RunnerConfig
-		expected time.Time
+		durationQuerySince time.Duration
+		timeQueryStart     TimeValue
+		expected           time.Time
 	}{
 		{
-			cfg:      RunnerConfig{},
 			expected: time.Now(),
 		},
 		{
-			cfg: RunnerConfig{
-				timeQueryStart: NewTimeValue(time.Unix(1234567890, 0)),
-			},
-			expected: time.Unix(1234567890, 0),
+			timeQueryStart: NewTimeValue(time.Unix(1234567890, 0)),
+			expected:       time.Unix(1234567890, 0),
 		},
 		{
-			cfg: RunnerConfig{
-				durationQuerySince: 10 * time.Hour,
-			},
-			expected: time.Now().Add(-10 * time.Hour),
+			durationQuerySince: 10 * time.Hour,
+			expected:           time.Now().Add(-10 * time.Hour),
 		},
 	}
 
 	for _, tt := range tests {
-		assert.WithinDuration(t, tt.expected, tt.cfg.minQueryTime(), 5*time.Millisecond)
+		//require.Equal(t, tt.expected, tc.MinQueryTime())
+		assert.WithinDuration(t, tt.expected, calculateMinQueryTime(tt.durationQuerySince, tt.timeQueryStart), 5*time.Millisecond)
 	}
 }

--- a/pkg/testexporter/correctness/simple.go
+++ b/pkg/testexporter/correctness/simple.go
@@ -2,12 +2,16 @@ package correctness
 
 import (
 	"context"
+	"flag"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/go-kit/kit/log/level"
+	otlog "github.com/opentracing/opentracing-go/log"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
@@ -18,14 +22,45 @@ const (
 	subsystem = "test_exporter"
 )
 
+var sampleResult = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: subsystem,
+		Name:      "sample_result_total",
+		Help:      "Number of samples that succeed / fail.",
+	},
+	[]string{"result"},
+)
+
 type simpleTestCase struct {
 	prometheus.GaugeFunc
 	name            string
 	expectedValueAt func(time.Time) float64
+	cfg             CommonTestConfig
+}
+
+type CommonTestConfig struct {
+	testTimeEpsilon    time.Duration
+	testEpsilon        float64
+	ScrapeInterval     time.Duration
+	samplesEpsilon     float64
+	timeQueryStart     TimeValue
+	durationQuerySince time.Duration
+}
+
+func (cfg *CommonTestConfig) RegisterFlags(f *flag.FlagSet) {
+	f.DurationVar(&cfg.testTimeEpsilon, "test-time-epsilion", 1*time.Second, "Amount samples are allowed to be off by")
+	f.Float64Var(&cfg.testEpsilon, "test-epsilion", 0.01, "Amount samples are allowed to be off by this %%")
+	f.DurationVar(&cfg.ScrapeInterval, "scrape-interval", 15*time.Second, "Expected scrape interval.")
+	f.Float64Var(&cfg.samplesEpsilon, "test-samples-epsilon", 0.1, "Amount that the number of samples are allowed to be off by")
+
+	// By default, we only query for values from when this process started
+	cfg.timeQueryStart = NewTimeValue(time.Now())
+	f.Var(&cfg.timeQueryStart, "test-query-start", "Minimum start date for queries")
+	f.DurationVar(&cfg.durationQuerySince, "test-query-since", 0, "Duration in the past to test.  Overrides -test-query-start")
 }
 
 // NewSimpleTestCase makes a new simpleTestCase
-func NewSimpleTestCase(name string, f func(time.Time) float64) Case {
+func NewSimpleTestCase(name string, f func(time.Time) float64, cfg CommonTestConfig) Case {
 	return &simpleTestCase{
 		GaugeFunc: prometheus.NewGaugeFunc(
 			prometheus.GaugeOpts{
@@ -40,7 +75,11 @@ func NewSimpleTestCase(name string, f func(time.Time) float64) Case {
 		),
 		name:            name,
 		expectedValueAt: f,
+		cfg:             cfg,
 	}
+}
+
+func (tc *simpleTestCase) Stop() {
 }
 
 func (tc *simpleTestCase) Name() string {
@@ -86,6 +125,80 @@ func (tc *simpleTestCase) Query(ctx context.Context, client v1.API, selectors st
 	return result, nil
 }
 
-func (tc *simpleTestCase) Quantized(duration time.Duration) time.Duration {
-	return duration.Truncate(time.Minute)
+func (tc *simpleTestCase) Test(ctx context.Context, client v1.API, selectors string, start time.Time, duration time.Duration) (bool, error) {
+	log := spanlogger.FromContext(ctx)
+	pairs, err := tc.Query(ctx, client, selectors, start, duration)
+	if err != nil {
+		level.Info(log).Log("err", err)
+		return false, err
+	}
+
+	return verifySamples(ctx, tc, pairs, duration, tc.cfg), nil
+}
+
+func (tc *simpleTestCase) MinQueryTime() time.Time {
+	return calculateMinQueryTime(tc.cfg.durationQuerySince, tc.cfg.timeQueryStart)
+}
+
+func verifySamples(ctx context.Context, tc Case, pairs []model.SamplePair, duration time.Duration, cfg CommonTestConfig) bool {
+	log := spanlogger.FromContext(ctx)
+
+	for _, pair := range pairs {
+		correct := timeEpsilonCorrect(tc.ExpectedValueAt, pair, cfg.testTimeEpsilon) || valueEpsilonCorrect(tc.ExpectedValueAt, pair, cfg.testEpsilon)
+		if correct {
+			sampleResult.WithLabelValues(success).Inc()
+		} else {
+			sampleResult.WithLabelValues(fail).Inc()
+			level.Error(log).Log("msg", "wrong value", "at", pair.Timestamp, "expected", tc.ExpectedValueAt(pair.Timestamp.Time()), "actual", pair.Value)
+			log.LogFields(otlog.Error(fmt.Errorf("wrong value")))
+			return false
+		}
+	}
+
+	// when verifying a deleted series we get samples for very short interval. As small as 1 or 2 missing/extra samples can cause test to fail.
+	if duration > 5*time.Minute {
+		expectedNumSamples := int(duration / cfg.ScrapeInterval)
+		if !epsilonCorrect(float64(len(pairs)), float64(expectedNumSamples), cfg.samplesEpsilon) {
+			level.Error(log).Log("msg", "wrong number of samples", "expected", expectedNumSamples, "actual", len(pairs))
+			log.LogFields(otlog.Error(fmt.Errorf("wrong number of samples")))
+			return false
+		}
+	} else {
+		expectedNumSamples := int(duration / cfg.ScrapeInterval)
+		if math.Abs(float64(expectedNumSamples-len(pairs))) > 2 {
+			level.Error(log).Log("msg", "wrong number of samples", "expected", expectedNumSamples, "actual", len(pairs))
+			log.LogFields(otlog.Error(fmt.Errorf("wrong number of samples")))
+			return false
+		}
+	}
+
+	return true
+}
+
+func timeEpsilonCorrect(f func(time.Time) float64, pair model.SamplePair, testTimeEpsilon time.Duration) bool {
+	minExpected := f(pair.Timestamp.Time().Add(-testTimeEpsilon))
+	maxExpected := f(pair.Timestamp.Time().Add(testTimeEpsilon))
+	if minExpected > maxExpected {
+		minExpected, maxExpected = maxExpected, minExpected
+	}
+	return minExpected < float64(pair.Value) && float64(pair.Value) < maxExpected
+}
+
+func valueEpsilonCorrect(f func(time.Time) float64, pair model.SamplePair, testEpsilon float64) bool {
+	return epsilonCorrect(float64(pair.Value), f(pair.Timestamp.Time()), testEpsilon)
+}
+
+func epsilonCorrect(actual, expected, epsilon float64) bool {
+	delta := math.Abs((actual - expected) / expected)
+	return delta < epsilon
+}
+
+func calculateMinQueryTime(durationQuerySince time.Duration, timeQueryStart TimeValue) time.Time {
+	minQueryTime := startTime
+	if durationQuerySince != 0 {
+		minQueryTime = time.Now().Add(-durationQuerySince)
+	} else if timeQueryStart.set {
+		minQueryTime = timeQueryStart.Time
+	}
+	return minQueryTime
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Test Exporter to continuously test delete series. Here is how it would work:
1. A loop would keep sending delete request at a configured interval(default 5m) for the configured duration(default 2m). Deletion is done by slicing the time by the deletion interval from 0(i.e beginning of epoch) and then deleting data from last slice's end, for configured delete request duration. Following examples show for what interval data would be deleted based on when the deletion is happening(in UTC) with default config:
```
deletion happening at -> deletion interval
00:06:03              -> 00:03:00 to 00:05:00
12:24:30              -> 12:18:00 to 12:20:00
23:00:00              -> 22:58:00 to 23:00:00
```
2. When deleted series is being tested, we would calculate what all intervals would be deleted and verify the deleted data is gone and non-deleted data is left untouched.

Other supporting changes:
1. Rounded off query duration to be a multiple of a minute because we are anyways querying series with rounded off duration while tests were calculating the expected number of samples based on non-rounded duration.
2. Fixed `MinQueryTime` which was broken for default behaviour which was set to start of the process.
3. Added test name to `test_case_result_total` to be able to quickly find out which tests are failing the most.
4. Used `promauto` for registering the metrics.

**Note**: This PR depends on #2546 for provisioning of tables to store delete requests.

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
