### PR TITLE
Bump test timeout

### DIFF
--- a/tools/test
+++ b/tools/test
@@ -8,7 +8,7 @@ NO_GO_GET=true
 TAGS=
 PARALLEL=
 RACE="-race -covermode=atomic"
-TIMEOUT=1m
+TIMEOUT=5m
 VERBOSE=
 
 usage() {


### PR DESCRIPTION
**What this PR does**: We're seeing test timeouts on CI in pkg/chunks package lately, bump test timeout to 5 minutes. (Running same test manually on circleCI machine takes about minute and passes)
