### PR TITLE
query-tee: Support metadata, rules and alerts routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 * [FEATURE] Experimental: Added support for `/api/v1/metadata` Prometheus-based endpoint. #2549
 * [FEATURE] Add ability to limit concurrent queries to Cassandra with `-cassandra.query-concurrency` flag. #2562
 * [FEATURE] TLS config options added for GRPC clients in Querier (Query-frontend client & Ingester client), Ruler, Store Gateway, as well as HTTP client in Config store client. #2502
-* [ENHANCEMENT] `query-tee` supports `/metadata`, `/alerts`, and `/rules` #XXXX
+* [ENHANCEMENT] `query-tee` supports `/metadata`, `/alerts`, and `/rules` #2600
 * [ENHANCEMENT] Ruler: Automatically remove unhealthy rulers from the ring. #2587
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
 * [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [FEATURE] Experimental: Added support for `/api/v1/metadata` Prometheus-based endpoint. #2549
 * [FEATURE] Add ability to limit concurrent queries to Cassandra with `-cassandra.query-concurrency` flag. #2562
 * [FEATURE] TLS config options added for GRPC clients in Querier (Query-frontend client & Ingester client), Ruler, Store Gateway, as well as HTTP client in Config store client. #2502
+* [ENHANCEMENT] `query-tee` supports `/metadata`, `/alerts`, and `/rules` #XXXX
 * [ENHANCEMENT] Ruler: Automatically remove unhealthy rulers from the ring. #2587
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
 * [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383

--- a/cmd/query-tee/proxy.go
+++ b/cmd/query-tee/proxy.go
@@ -99,12 +99,25 @@ func (p *Proxy) Start() error {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	// Read endpoints.
-	router.Path("/api/v1/query").Methods("GET").Handler(NewProxyEndpoint(p.backends, "api_v1_query", p.metrics, p.logger))
-	router.Path("/api/v1/query_range").Methods("GET").Handler(NewProxyEndpoint(p.backends, "api_v1_query_range", p.metrics, p.logger))
-	router.Path("/api/v1/labels").Methods("GET").Handler(NewProxyEndpoint(p.backends, "api_v1_labels", p.metrics, p.logger))
-	router.Path("/api/v1/label/{name}/values").Methods("GET").Handler(NewProxyEndpoint(p.backends, "api_v1_label_name_values", p.metrics, p.logger))
-	router.Path("/api/v1/series").Methods("GET").Handler(NewProxyEndpoint(p.backends, "api_v1_series", p.metrics, p.logger))
+	endpoints := []struct {
+		endpoint  string
+		methods   string
+		routeName string
+	}{
+		{"/api/v1/query", "GET", "api_v1_query"},
+		{"/api/v1/query_range", "GET", "api_v1_query_range"},
+		{"/api/v1/labels", "GET", "api_v1_labels"},
+		{"/api/v1/label/{name}/values", "GET", "api_v1_label_name_values"},
+		{"/api/v1/series", "GET", "api_v1_series"},
+		{"/api/v1/metadata", "GET", "api_v1_metadata"},
+		{"/api/v1/rules", "GET", "api_v1_rules"},
+		{"/api/v1/alerts", "GET", "api_v1_alerts"},
+	}
+
+	// Read endpoints
+	for _, e := range endpoints {
+		router.Path(e.endpoint).Methods(e.methods).Handler(NewProxyEndpoint(p.backends, e.routeName, p.metrics, p.logger))
+	}
 
 	p.srvListener = listener
 	p.srv = &http.Server{

--- a/docs/operations/query-tee.md
+++ b/docs/operations/query-tee.md
@@ -35,6 +35,9 @@ The following Prometheus API endpoints are supported by `query-tee`:
 - `/api/v1/labels` (GET)
 - `/api/v1/label/{name}/values` (GET)
 - `/api/v1/series` (GET)
+- `/api/v1/metadata` (GET)
+- `/api/v1/alerts` (GET)
+- `/api/v1/rules` (GET)
 
 ### Authentication
 

--- a/pkg/ruler/storage.go
+++ b/pkg/ruler/storage.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ruler/rules/objectclient"
 )
 
-// RuleStoreConfig conigures a rule store
+// RuleStoreConfig configures a rule store.
 type RuleStoreConfig struct {
 	Type     string        `yaml:"type"`
 	ConfigDB client.Config `yaml:"configdb"`
@@ -73,7 +73,7 @@ func NewRuleStorage(cfg RuleStoreConfig) (rules.RuleStore, error) {
 	case "swift":
 		return newObjRuleStore(openstack.NewSwiftObjectClient(cfg.Swift, ""))
 	default:
-		return nil, fmt.Errorf("Unrecognized rule storage mode %v, choose one of: configdb, gcs", cfg.Type)
+		return nil, fmt.Errorf("Unrecognized rule storage mode %v, choose one of: configdb, gcs, s3, swift, azure", cfg.Type)
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:

Allows `query-tee` to support `/metadata`, `/alerts`, and `/rules` endpoints.

# The problem

Instead of opening an issue, I decided to just go ahead and establish the discussion on this PR. This is a bit tricky given the `/metadata` and `/rules` endpoints don't really query Prometheus but instead are served from memory or a file, no "queries" are involved. Which makes this semantically incorrect.

However, `query-tee` is typically deployed as a shim - which means that if you're using something like Grafana, the endpoint of your data source will be the `query-tee` URL. Grafana will fail to access these endpoints given `query-tee` only proxies certain routes. 

An alternative to this might be to allow `query-tee` to operate in a whitelist or blacklist mode where URLs not supported can either be blocked or forwarded. Happy to take it in whichever direction maintainers decide. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
