### PR TITLE
pkg/ringkv/etcd: supply WithKeysOnly option in List operation

### DIFF
--- a/pkg/ring/kv/etcd/etcd.go
+++ b/pkg/ring/kv/etcd/etcd.go
@@ -214,7 +214,7 @@ outer:
 
 // List implements kv.Client.
 func (c *Client) List(ctx context.Context, prefix string) ([]string, error) {
-	resp, err := c.cli.Get(ctx, prefix, clientv3.WithPrefix())
+	resp, err := c.cli.Get(ctx, prefix, clientv3.WithPrefix(), clientv3.WithKeysOnly())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does**:
This commit adds the WithKeysOnly OpOption to the List function as we only care about the keys in
the operation.