### PR TITLE
Use Ticker for WAL series spreading

### DIFF
--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -333,6 +333,8 @@ func (w *walWrapper) performCheckpoint(immediate bool) (err error) {
 	}
 	records := [][]byte{}
 	totalSize := 0
+	ticker := time.NewTicker(perSeriesDuration)
+	defer ticker.Stop()
 	for userID, state := range us {
 		for pair := range state.fpToSeries.iter() {
 			state.fpLocker.Lock(pair.fp)
@@ -358,7 +360,7 @@ func (w *walWrapper) performCheckpoint(immediate bool) (err error) {
 
 			if !immediate {
 				select {
-				case <-time.After(perSeriesDuration):
+				case <-ticker.C:
 				case <-w.quit: // When we're trying to shutdown, finish the checkpoint as fast as possible.
 				}
 			}


### PR DESCRIPTION
Right now series are spread out across the WAL checkpoint duration using
a time.After() call, however that does not account for the amount of
time it may take to checkpoint the series in question. I am consistently
seeing a checkpoint take longer than the goal, and this will help
account for that difference.

**Checklist**
- [N/A] Tests updated
- [N/A] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
  * Is this needed? Possibly ENHANCEMENT but I don't know if it needs mentioning. WDYT?
