### PR TITLE
Ensures promql's default evaluation interval is set for the query frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 * [BUGFIX] Fixed collection of tracing spans from Thanos components used internally. #2584
 * [BUGFIX] Experimental TSDB: fixed memory leak in ingesters. #2586
 * [BUGFIX] Ingester: Fix an ingester starting up in the JOINING state and staying there forever. #2565
+* [BUGFIX] QueryFrontend: fixed a panic (`integer divide by zero`) in the query-frontend. The query-frontend now requires the `-querier.default-evaluation-interval` config to be set to the same value of the querier. #2603
 
 ## 1.0.1 / 2020-04-23
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -308,6 +308,11 @@ func (t *Cortex) initQueryFrontend() (serv services.Service, err error) {
 		return
 	}
 
+	// Ensure the default evaluation interval is set (promql uses a package-scoped mutable variable).
+	// This is important when `querier.parallelise-shardable-queries` is enabled because the frontend
+	// aggregates the sharded queries.
+	promql.SetDefaultEvaluationInterval(t.Cfg.Querier.DefaultEvaluationInterval)
+
 	tripperware, cache, err := queryrange.NewTripperware(
 		t.Cfg.QueryRange,
 		util.Logger,


### PR DESCRIPTION
Ensure the default evaluation interval is set (promql uses a package-scoped mutable variable). This is important when `querier.parallelise-shardable-queries` is enabled because the frontend aggregates the sharded queries.

Closes https://github.com/cortexproject/cortex/issues/2603