### PR TITLE
Fix remote read route registration

### DIFF
--- a/integration/querier_remote_read_test.go
+++ b/integration/querier_remote_read_test.go
@@ -1,0 +1,124 @@
+// +build requires_docker
+
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/integration/e2e"
+	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
+	"github.com/cortexproject/cortex/integration/e2ecortex"
+)
+
+func TestQuerierRemoteRead(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
+	flags := mergeFlags(ChunksStorageFlags, map[string]string{})
+
+	// Start dependencies.
+	dynamo := e2edb.NewDynamoDB()
+
+	consul := e2edb.NewConsul()
+	require.NoError(t, s.StartAndWaitReady(consul, dynamo))
+
+	tableManager := e2ecortex.NewTableManager("table-manager", ChunksStorageFlags, "")
+	require.NoError(t, s.StartAndWaitReady(tableManager))
+
+	// Wait until the first table-manager sync has completed, so that we're
+	// sure the tables have been created.
+	require.NoError(t, tableManager.WaitSumMetrics(e2e.Greater(0), "cortex_table_manager_sync_success_timestamp_seconds"))
+
+	// Start Cortex components for the write path.
+	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
+	ingester := e2ecortex.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, "")
+	require.NoError(t, s.StartAndWaitReady(distributor, ingester))
+
+	// Wait until the distributor has updated the ring.
+	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+
+	// Push a series for each user to Cortex.
+	now := time.Now()
+
+	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", "user-1")
+	require.NoError(t, err)
+
+	series, expectedVectors := generateSeries("series_1", now)
+	res, err := c.Push(series)
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+
+	querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(), ChunksStorageFlags, "")
+	require.NoError(t, s.StartAndWaitReady(querier))
+
+	// Wait until the querier has updated the ring.
+	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+
+	matcher, err := labels.NewMatcher(labels.MatchEqual, "__name__", "series_1")
+	require.NoError(t, err)
+
+	startMs := now.Add(-1*time.Minute).Unix() * 1000
+	endMs := now.Add(time.Minute).Unix() * 1000
+
+	q, err := remote.ToQuery(startMs, endMs, []*labels.Matcher{matcher}, &storage.SelectParams{
+		Step:  1,
+		Start: startMs,
+		End:   endMs,
+	})
+	require.NoError(t, err)
+
+	req := &prompb.ReadRequest{
+		Queries:               []*prompb.Query{q},
+		AcceptedResponseTypes: []prompb.ReadRequest_ResponseType{prompb.ReadRequest_STREAMED_XOR_CHUNKS},
+	}
+
+	data, err := proto.Marshal(req)
+	require.NoError(t, err)
+	compressed := snappy.Encode(nil, data)
+
+	httpReq, err := http.NewRequest("POST", "http://"+querier.HTTPEndpoint()+"/prometheus/api/v1/read", bytes.NewReader(compressed))
+	require.NoError(t, err)
+	httpReq.Header.Set("X-Scope-OrgID", "user-1")
+	httpReq.Header.Add("Content-Encoding", "snappy")
+	httpReq.Header.Add("Accept-Encoding", "snappy")
+	httpReq.Header.Set("Content-Type", "application/x-protobuf")
+	httpReq.Header.Set("User-Agent", "Prometheus/1.8.2")
+	httpReq.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
+
+	httpResp, err := http.DefaultClient.Do(httpReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, httpResp.StatusCode)
+
+	compressed, err = ioutil.ReadAll(httpResp.Body)
+	require.NoError(t, err)
+
+	uncompressed, err := snappy.Decode(nil, compressed)
+	require.NoError(t, err)
+
+	var resp prompb.ReadResponse
+	err = proto.Unmarshal(uncompressed, &resp)
+	require.NoError(t, err)
+
+	// Validate the returned remote read data matches what was written
+	require.Len(t, resp.Results, 1)
+	require.Len(t, resp.Results[0].Timeseries, 1)
+	require.Len(t, resp.Results[0].Timeseries[0].Labels, 1)
+	require.Equal(t, "series_1", resp.Results[0].Timeseries[0].Labels[0].GetValue())
+	require.Len(t, resp.Results[0].Timeseries[0].Samples, 1)
+	require.Equal(t, int64(expectedVectors[0].Timestamp), resp.Results[0].Timeseries[0].Samples[0].Timestamp)
+	require.Equal(t, float64(expectedVectors[0].Value), resp.Results[0].Timeseries[0].Samples[0].Value)
+}

--- a/integration/querier_remote_read_test.go
+++ b/integration/querier_remote_read_test.go
@@ -74,7 +74,7 @@ func TestQuerierRemoteRead(t *testing.T) {
 	startMs := now.Add(-1*time.Minute).Unix() * 1000
 	endMs := now.Add(time.Minute).Unix() * 1000
 
-	q, err := remote.ToQuery(startMs, endMs, []*labels.Matcher{matcher}, &storage.SelectParams{
+	q, err := remote.ToQuery(startMs, endMs, []*labels.Matcher{matcher}, &storage.SelectHints{
 		Step:  1,
 		Start: startMs,
 		End:   endMs,

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -291,7 +291,7 @@ func (a *API) RegisterQuerier(queryable storage.Queryable, engine *promql.Engine
 	cacheGenHeaderMiddleware := getHTTPCacheGenNumberHeaderSetterMiddleware(tombstonesLoader)
 	promHandler := fakeRemoteAddr(cacheGenHeaderMiddleware.Wrap(promRouter))
 
-	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/read", querier.RemoteReadHandler(queryable), true, "GET")
+	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/read", querier.RemoteReadHandler(queryable), true, "POST")
 	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/query", promHandler, true, "GET", "POST")
 	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/query_range", promHandler, true, "GET", "POST")
 	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/labels", promHandler, true, "GET", "POST")
@@ -338,7 +338,7 @@ func (a *API) RegisterQueryFrontend(f *frontend.Frontend) {
 	// Previously the frontend handled all calls to the provided prefix. Instead explicit
 	// routing is used since it will be required to enable the frontend to be run as part
 	// of a single binary in the future.
-	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/read", f.Handler(), true, "GET")
+	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/read", f.Handler(), true, "POST")
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/query", f.Handler(), true, "GET", "POST")
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/query_range", f.Handler(), true, "GET", "POST")
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/labels", f.Handler(), true, "GET", "POST")
@@ -347,7 +347,7 @@ func (a *API) RegisterQueryFrontend(f *frontend.Frontend) {
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/metadata", f.Handler(), true, "GET")
 
 	// Register Legacy Routers
-	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/read", f.Handler(), true, "GET")
+	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/read", f.Handler(), true, "POST")
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/query", f.Handler(), true, "GET", "POST")
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/query_range", f.Handler(), true, "GET", "POST")
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/labels", f.Handler(), true, "GET", "POST")

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -305,7 +305,7 @@ func (a *API) RegisterQuerier(queryable storage.Queryable, engine *promql.Engine
 	api.Register(legacyPromRouter)
 	legacyPromHandler := fakeRemoteAddr(cacheGenHeaderMiddleware.Wrap(legacyPromRouter))
 
-	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/read", querier.RemoteReadHandler(queryable), true, "GET")
+	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/read", querier.RemoteReadHandler(queryable), true, "POST")
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/query", legacyPromHandler, true, "GET", "POST")
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/query_range", legacyPromHandler, true, "GET", "POST")
 	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/labels", legacyPromHandler, true, "GET", "POST")


### PR DESCRIPTION
**What this PR does**:

- Ensure the `POST` method is set for the`/read` route registration to match the endpoint in Prometheus. 

**Which issue(s) this PR fixes**:
Fixes #2619

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated