### PR TITLE
Decoupled blocks deletion from compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
 * [ENHANCEMENT] Thanos and Prometheus upgraded to [806479182a6b](https://github.com/thanos-io/thanos/commit/806479182a6b) and [cd73b3d33e06](https://github.com/prometheus/prometheus/commit/cd73b3d33e06) respectively. #2604
   * TSDB now supports isolation of append and queries.
   * TSDB now holds less WAL files after Head Truncation.
+* [ENHANCEMENT] Experimental TSDB: decoupled blocks deletion from blocks compaction in the compactor, so that blocks deletion is not blocked by a busy compactor. The following metrics have been added:
+  * `cortex_compactor_block_cleanup_started_total`
+  * `cortex_compactor_block_cleanup_completed_total`
+  * `cortex_compactor_block_cleanup_failed_total`
+  * `cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds`
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 * [ENHANCEMENT] Thanos and Prometheus upgraded to [806479182a6b](https://github.com/thanos-io/thanos/commit/806479182a6b) and [cd73b3d33e06](https://github.com/prometheus/prometheus/commit/cd73b3d33e06) respectively. #2604
   * TSDB now supports isolation of append and queries.
   * TSDB now holds less WAL files after Head Truncation.
-* [ENHANCEMENT] Experimental TSDB: decoupled blocks deletion from blocks compaction in the compactor, so that blocks deletion is not blocked by a busy compactor. The following metrics have been added:
+* [ENHANCEMENT] Experimental TSDB: decoupled blocks deletion from blocks compaction in the compactor, so that blocks deletion is not blocked by a busy compactor. The following metrics have been added: #2623
   * `cortex_compactor_block_cleanup_started_total`
   * `cortex_compactor_block_cleanup_completed_total`
   * `cortex_compactor_block_cleanup_failed_total`

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -1,0 +1,178 @@
+package compactor
+
+import (
+	"context"
+	"path"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/compact"
+	"github.com/thanos-io/thanos/pkg/objstore"
+
+	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+type BlocksCleanerConfig struct {
+	DataDir             string
+	MetaSyncConcurrency int
+	DeletionDelay       time.Duration
+	CleanupInterval     time.Duration
+}
+
+type BlocksCleaner struct {
+	services.Service
+
+	cfg          BlocksCleanerConfig
+	logger       log.Logger
+	bucketClient objstore.Bucket
+	usersScanner *UsersScanner
+
+	// Metrics.
+	runsStarted        prometheus.Counter
+	runsCompleted      prometheus.Counter
+	runsFailed         prometheus.Counter
+	runsLastSuccess    prometheus.Gauge
+	blocksCleanedTotal prometheus.Counter
+	blocksFailedTotal  prometheus.Counter
+}
+
+func NewBlocksCleaner(cfg BlocksCleanerConfig, bucketClient objstore.Bucket, usersScanner *UsersScanner, logger log.Logger, reg prometheus.Registerer) *BlocksCleaner {
+	c := &BlocksCleaner{
+		cfg:          cfg,
+		bucketClient: bucketClient,
+		usersScanner: usersScanner,
+		logger:       log.With(logger, "component", "cleaner"),
+		runsStarted: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_compactor_block_cleanup_started_total",
+			Help: "Total number of blocks cleanup runs started.",
+		}),
+		runsCompleted: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_compactor_block_cleanup_completed_total",
+			Help: "Total number of blocks cleanup runs successfully completed.",
+		}),
+		runsFailed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_compactor_block_cleanup_failed_total",
+			Help: "Total number of blocks cleanup runs failed.",
+		}),
+		runsLastSuccess: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds",
+			Help: "Unix timestamp of the last successful blocks cleanup run.",
+		}),
+		blocksCleanedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_compactor_blocks_cleaned_total",
+			Help: "Total number of blocks deleted.",
+		}),
+		blocksFailedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_compactor_block_cleanup_failures_total",
+			Help: "Total number of blocks failed to be deleted.",
+		}),
+	}
+
+	c.Service = services.NewTimerService(cfg.CleanupInterval, c.starting, c.ticker, nil)
+
+	return c
+}
+
+func (c *BlocksCleaner) starting(ctx context.Context) error {
+	// Run a cleanup so that any other service depending on this service
+	// is guaranteed to start once the initial cleanup has been done.
+	c.runCleanup(ctx)
+
+	return nil
+}
+
+func (c *BlocksCleaner) ticker(ctx context.Context) error {
+	c.runCleanup(ctx)
+
+	return nil
+}
+
+func (c *BlocksCleaner) runCleanup(ctx context.Context) {
+	level.Info(c.logger).Log("msg", "started hard deletion of blocks marked for deletion")
+	c.runsStarted.Inc()
+
+	if err := c.cleanUsers(ctx); err == nil {
+		level.Info(c.logger).Log("msg", "successfully completed hard deletion of blocks marked for deletion")
+		c.runsCompleted.Inc()
+		c.runsLastSuccess.SetToCurrentTime()
+	} else if errors.Is(err, context.Canceled) {
+		level.Info(c.logger).Log("msg", "canceled hard deletion of blocks marked for deletion", "err", err)
+		return
+	} else {
+		level.Error(c.logger).Log("msg", "failed to hard delete blocks marked for deletion", "err", err.Error())
+		c.runsFailed.Inc()
+	}
+}
+
+func (c *BlocksCleaner) cleanUsers(ctx context.Context) error {
+	users, err := c.usersScanner.ScanUsers(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to discover users from bucket")
+	}
+
+	errs := tsdb_errors.MultiError{}
+	for _, userID := range users {
+		// Ensure the context has not been canceled (ie. shutdown has been triggered).
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if err = c.cleanUser(ctx, userID); err != nil {
+			errs.Add(errors.Wrapf(err, "failed to delete user blocks (user: %s)", userID))
+			continue
+		}
+	}
+
+	return errs.Err()
+}
+
+func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string) error {
+	userLogger := util.WithUserID(userID, c.logger)
+	userBucket := cortex_tsdb.NewUserBucketClient(userID, c.bucketClient)
+
+	ignoreDeletionMarkFilter := block.NewIgnoreDeletionMarkFilter(userLogger, userBucket, c.cfg.DeletionDelay)
+
+	fetcher, err := block.NewMetaFetcher(
+		userLogger,
+		c.cfg.MetaSyncConcurrency,
+		userBucket,
+		// The fetcher stores cached metas in the "meta-syncer/" sub directory,
+		// but we prefix it in order to guarantee no clashing with the compactor.
+		path.Join(c.cfg.DataDir, "blocks-cleaner-meta-"+userID),
+		// No metrics.
+		nil,
+		[]block.MetadataFilter{ignoreDeletionMarkFilter},
+		nil,
+	)
+	if err != nil {
+		return errors.Wrap(err, "error creating metadata fetcher")
+	}
+
+	// Runs a bucket scan to get a fresh list of all blocks and populate
+	// the list of deleted blocks in filter.
+	if _, _, err = fetcher.Fetch(ctx); err != nil {
+		return errors.Wrap(err, "error fetching metadata")
+	}
+
+	cleaner := compact.NewBlocksCleaner(
+		userLogger,
+		userBucket,
+		ignoreDeletionMarkFilter,
+		c.cfg.DeletionDelay,
+		c.blocksCleanedTotal,
+		c.blocksFailedTotal)
+
+	if err := cleaner.DeleteMarkedBlocks(ctx); err != nil {
+		return errors.Wrap(err, "error cleaning blocks")
+	}
+
+	return nil
+}

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -1,0 +1,80 @@
+package compactor
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+
+	"github.com/cortexproject/cortex/pkg/storage/backend/filesystem"
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+func TestBlocksCleaner(t *testing.T) {
+	// Create a temporary directory for local storage.
+	storageDir, err := ioutil.TempDir(os.TempDir(), "storage")
+	require.NoError(t, err)
+	defer os.RemoveAll(storageDir) //nolint:errcheck
+
+	// Create a temporary directory for cleaner.
+	dataDir, err := ioutil.TempDir(os.TempDir(), "data")
+	require.NoError(t, err)
+	defer os.RemoveAll(dataDir) //nolint:errcheck
+
+	// Create blocks.
+	now := time.Now()
+	deletionDelay := 12 * time.Hour
+	block1 := createTSDBBlock(t, filepath.Join(storageDir, "user-1"), 10, 20, nil)
+	block2 := createTSDBBlock(t, filepath.Join(storageDir, "user-1"), 20, 30, nil)
+	block3 := createTSDBBlock(t, filepath.Join(storageDir, "user-1"), 30, 40, nil)
+	createDeletionMark(t, filepath.Join(storageDir, "user-1"), block2, now.Add(-deletionDelay).Add(time.Hour))  // Hasn't reached the deletion threshold yet.
+	createDeletionMark(t, filepath.Join(storageDir, "user-1"), block3, now.Add(-deletionDelay).Add(-time.Hour)) // Reached the deletion threshold.
+
+	// Create a bucket client on the local storage.
+	bucketClient, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
+	require.NoError(t, err)
+
+	cfg := BlocksCleanerConfig{
+		DataDir:             dataDir,
+		MetaSyncConcurrency: 10,
+		DeletionDelay:       deletionDelay,
+		CleanupInterval:     time.Minute,
+	}
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	scanner := NewUsersScanner(bucketClient, func(_ string) (bool, error) { return true, nil }, logger)
+
+	cleaner := NewBlocksCleaner(cfg, bucketClient, scanner, logger, nil)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, cleaner))
+	defer services.StopAndAwaitTerminated(ctx, cleaner) //nolint:errcheck
+
+	// Check the storage to ensure only the block which has reached the deletion threshold
+	// has been effectively deleted.
+	exists, err := bucketClient.Exists(ctx, path.Join("user-1", block1.String(), metadata.MetaFilename))
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = bucketClient.Exists(ctx, path.Join("user-1", block2.String(), metadata.MetaFilename))
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = bucketClient.Exists(ctx, path.Join("user-1", block3.String(), metadata.MetaFilename))
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsStarted))
+	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsCompleted))
+	assert.Equal(t, float64(0), testutil.ToFloat64(cleaner.runsFailed))
+	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.blocksCleanedTotal))
+	assert.Equal(t, float64(0), testutil.ToFloat64(cleaner.blocksFailedTotal))
+}

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -240,6 +240,7 @@ func (c *Compactor) starting(ctx context.Context) error {
 
 	// Ensure an initial cleanup occurred before starting the compactor.
 	if err := services.StartAndAwaitRunning(ctx, c.blocksCleaner); err != nil {
+		c.ringSubservices.StopAsync()
 		return errors.Wrap(err, "failed to start the blocks cleaner")
 	}
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -81,10 +81,18 @@ type Compactor struct {
 	compactorCfg Config
 	storageCfg   cortex_tsdb.Config
 	logger       log.Logger
+	parentLogger log.Logger
+	registerer   prometheus.Registerer
 
 	// function that creates bucket client and TSDB compactor using the context.
 	// Useful for injecting mock objects from tests.
 	createBucketClientAndTsdbCompactor func(ctx context.Context) (objstore.Bucket, tsdb.Compactor, error)
+
+	// Users scanner, used to discover users from the bucket.
+	usersScanner *UsersScanner
+
+	// Blocks cleaner is responsible to hard delete blocks marked for deletion.
+	blocksCleaner *BlocksCleaner
 
 	// Underlying compactor used to compact TSDB blocks.
 	tsdbCompactor tsdb.Compactor
@@ -93,22 +101,17 @@ type Compactor struct {
 	bucketClient objstore.Bucket
 
 	// Ring used for sharding compactions.
-	ringLifecycler *ring.Lifecycler
-	ring           *ring.Ring
-
-	// Subservices manager (ring, lifecycler)
-	subservices        *services.Manager
-	subservicesWatcher *services.FailureWatcher
+	ringLifecycler         *ring.Lifecycler
+	ring                   *ring.Ring
+	ringSubservices        *services.Manager
+	ringSubservicesWatcher *services.FailureWatcher
 
 	// Metrics.
 	compactionRunsStarted     prometheus.Counter
 	compactionRunsCompleted   prometheus.Counter
 	compactionRunsFailed      prometheus.Counter
 	compactionRunsLastSuccess prometheus.Gauge
-
-	blocksCleaned           prometheus.Counter
-	blockCleanupFailures    prometheus.Counter
-	blocksMarkedForDeletion prometheus.Counter
+	blocksMarkedForDeletion   prometheus.Counter
 
 	// TSDB syncer metrics
 	syncerMetrics *syncerMetrics
@@ -144,7 +147,9 @@ func newCompactor(
 	c := &Compactor{
 		compactorCfg:                       compactorCfg,
 		storageCfg:                         storageCfg,
-		logger:                             logger,
+		parentLogger:                       logger,
+		logger:                             log.With(logger, "component", "compactor"),
+		registerer:                         registerer,
 		syncerMetrics:                      newSyncerMetrics(registerer),
 		createBucketClientAndTsdbCompactor: createBucketClientAndTsdbCompactor,
 
@@ -164,15 +169,6 @@ func newCompactor(
 			Name: "cortex_compactor_last_successful_run_timestamp_seconds",
 			Help: "Unix timestamp of the last successful compaction run.",
 		}),
-
-		blocksCleaned: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_compactor_blocks_cleaned_total",
-			Help: "Total number of blocks deleted in compactor.",
-		}),
-		blockCleanupFailures: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_compactor_block_cleanup_failures_total",
-			Help: "Failures encountered while deleting blocks in compactor.",
-		}),
 		blocksMarkedForDeletion: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_compactor_blocks_marked_for_deletion_total",
 			Help: "Total number of blocks marked for deletion in compactor.",
@@ -186,56 +182,47 @@ func newCompactor(
 
 // Start the compactor.
 func (c *Compactor) starting(ctx context.Context) error {
+	var err error
+
+	// Create bucket client and compactor.
+	c.bucketClient, c.tsdbCompactor, err = c.createBucketClientAndTsdbCompactor(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize compactor objects")
+	}
+
+	// Create the users scanner.
+	c.usersScanner = NewUsersScanner(c.bucketClient, c.ownUser, c.parentLogger)
+
 	// Initialize the compactors ring if sharding is enabled.
 	if c.compactorCfg.ShardingEnabled {
 		lifecyclerCfg := c.compactorCfg.ShardingRing.ToLifecyclerConfig()
-		lifecycler, err := ring.NewLifecycler(lifecyclerCfg, ring.NewNoopFlushTransferer(), "compactor", ring.CompactorRingKey, false)
+		c.ringLifecycler, err = ring.NewLifecycler(lifecyclerCfg, ring.NewNoopFlushTransferer(), "compactor", ring.CompactorRingKey, false)
 		if err != nil {
 			return errors.Wrap(err, "unable to initialize compactor ring lifecycler")
 		}
 
-		c.ringLifecycler = lifecycler
-
-		ring, err := ring.New(lifecyclerCfg.RingConfig, "compactor", ring.CompactorRingKey)
+		c.ring, err = ring.New(lifecyclerCfg.RingConfig, "compactor", ring.CompactorRingKey)
 		if err != nil {
 			return errors.Wrap(err, "unable to initialize compactor ring")
 		}
 
-		c.ring = ring
-
-		c.subservices, err = services.NewManager(c.ringLifecycler, c.ring)
+		c.ringSubservices, err = services.NewManager(c.ringLifecycler, c.ring)
 		if err == nil {
-			c.subservicesWatcher = services.NewFailureWatcher()
-			c.subservicesWatcher.WatchManager(c.subservices)
+			c.ringSubservicesWatcher = services.NewFailureWatcher()
+			c.ringSubservicesWatcher.WatchManager(c.ringSubservices)
 
-			err = services.StartManagerAndAwaitHealthy(ctx, c.subservices)
+			err = services.StartManagerAndAwaitHealthy(ctx, c.ringSubservices)
 		}
 
 		if err != nil {
-			return errors.Wrap(err, "unable to start compactor dependencies")
+			return errors.Wrap(err, "unable to start compactor ring dependencies")
 		}
-	}
 
-	var err error
-	c.bucketClient, c.tsdbCompactor, err = c.createBucketClientAndTsdbCompactor(ctx)
-	if err != nil && c.subservices != nil {
-		c.subservices.StopAsync()
-	}
-
-	return errors.Wrap(err, "failed to initialize compactor objects")
-}
-
-func (c *Compactor) stopping(_ error) error {
-	if c.subservices != nil {
-		return services.StopManagerAndAwaitStopped(context.Background(), c.subservices)
-	}
-	return nil
-}
-
-func (c *Compactor) running(ctx context.Context) error {
-	// If sharding is enabled we should wait until this instance is
-	// ACTIVE within the ring.
-	if c.compactorCfg.ShardingEnabled {
+		// If sharding is enabled we should wait until this instance is
+		// ACTIVE within the ring. This MUST be done before starting the
+		// any other component depending on the users scanner, because the
+		// users scanner depends on the ring (to check whether an user belongs
+		// to this shard or not).
 		level.Info(c.logger).Log("msg", "waiting until compactor is ACTIVE in the ring")
 		if err := ring.WaitInstanceState(ctx, c.ring, c.ringLifecycler.ID, ring.ACTIVE); err != nil {
 			return err
@@ -243,6 +230,33 @@ func (c *Compactor) running(ctx context.Context) error {
 		level.Info(c.logger).Log("msg", "compactor is ACTIVE in the ring")
 	}
 
+	// Create the blocks cleaner (service).
+	c.blocksCleaner = NewBlocksCleaner(BlocksCleanerConfig{
+		DataDir:             c.compactorCfg.DataDir,
+		MetaSyncConcurrency: c.compactorCfg.MetaSyncConcurrency,
+		DeletionDelay:       c.compactorCfg.DeletionDelay,
+		CleanupInterval:     c.compactorCfg.CompactionInterval,
+	}, c.bucketClient, c.usersScanner, c.parentLogger, c.registerer)
+
+	// Ensure an initial cleanup occurred before starting the compactor.
+	if err := services.StartAndAwaitRunning(ctx, c.blocksCleaner); err != nil {
+		return errors.Wrap(err, "failed to start the blocks cleaner")
+	}
+
+	return nil
+}
+
+func (c *Compactor) stopping(_ error) error {
+	ctx := context.Background()
+
+	services.StopAndAwaitTerminated(ctx, c.blocksCleaner) //nolint:errcheck
+	if c.ringSubservices != nil {
+		return services.StopManagerAndAwaitStopped(ctx, c.ringSubservices)
+	}
+	return nil
+}
+
+func (c *Compactor) running(ctx context.Context) error {
 	// Run an initial compaction before starting the interval.
 	c.compactUsersWithRetries(ctx)
 
@@ -255,7 +269,7 @@ func (c *Compactor) running(ctx context.Context) error {
 			c.compactUsersWithRetries(ctx)
 		case <-ctx.Done():
 			return nil
-		case err := <-c.subservicesWatcher.Chan():
+		case err := <-c.ringSubservicesWatcher.Chan():
 			return errors.Wrap(err, "compactor subservice failed")
 		}
 	}
@@ -344,9 +358,9 @@ func (c *Compactor) compactUser(ctx context.Context, userID string) error {
 		c.compactorCfg.MetaSyncConcurrency,
 		bucket,
 		// The fetcher stores cached metas in the "meta-syncer/" sub directory,
-		// but we prefix it with "meta-" in order to guarantee no clashing with
+		// but we prefix it with "compactor-meta-" in order to guarantee no clashing with
 		// the directory used by the Thanos Syncer, whatever is the user ID.
-		path.Join(c.compactorCfg.DataDir, "meta-"+userID),
+		path.Join(c.compactorCfg.DataDir, "compactor-meta-"+userID),
 		reg,
 		[]block.MetadataFilter{
 			// List of filters to apply (order matters).
@@ -393,12 +407,6 @@ func (c *Compactor) compactUser(ctx context.Context, userID string) error {
 		return errors.Wrap(err, "compaction")
 	}
 
-	blocksCleaner := compact.NewBlocksCleaner(ulogger, bucket, ignoreDeletionMarkFilter, c.compactorCfg.DeletionDelay, c.blocksCleaned, c.blockCleanupFailures)
-
-	if err := blocksCleaner.DeleteMarkedBlocks(ctx); err != nil {
-		return errors.Wrap(err, "error cleaning blocks")
-	}
-
 	return nil
 }
 
@@ -414,6 +422,11 @@ func (c *Compactor) discoverUsers(ctx context.Context) ([]string, error) {
 }
 
 func (c *Compactor) ownUser(userID string) (bool, error) {
+	// Always owned if sharding is disabled.
+	if !c.compactorCfg.ShardingEnabled {
+		return true, nil
+	}
+
 	// Hash the user ID.
 	hasher := fnv.New32a()
 	_, _ = hasher.Write([]byte(userID))

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -748,8 +748,9 @@ func createTSDBBlock(t *testing.T, dir string, minT, maxT int64, externalLabels 
 
 	// Create a new TSDB.
 	db, err := tsdb.Open(tempDir, nil, nil, &tsdb.Options{
-		BlockRanges:       []int64{int64(2 * 60 * 60 * 1000)}, // 2h period
-		RetentionDuration: uint64(15 * 86400 * 1000),          // 15 days
+		MinBlockDuration:  int64(2 * 60 * 60 * 1000), // 2h period
+		MaxBlockDuration:  int64(2 * 60 * 60 * 1000), // 2h period
+		RetentionDuration: int64(15 * 86400 * 1000),  // 15 days
 	})
 	require.NoError(t, err)
 

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -9,6 +9,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +20,7 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -94,8 +98,10 @@ func TestCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
 
 	assert.Equal(t, []string{
-		`level=info msg="discovering users from bucket"`,
-		`level=info msg="discovered users from bucket" users=0`,
+		`level=info component=cleaner msg="started hard deletion of blocks marked for deletion"`,
+		`level=info component=cleaner msg="successfully completed hard deletion of blocks marked for deletion"`,
+		`level=info component=compactor msg="discovering users from bucket"`,
+		`level=info component=compactor msg="discovered users from bucket" users=0`,
 	}, strings.Split(strings.TrimSpace(logs.String()), "\n"))
 
 	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
@@ -167,17 +173,29 @@ func TestCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 		# TYPE cortex_compactor_group_vertical_compactions_total counter
 		cortex_compactor_group_vertical_compactions_total 0
 
-		# HELP cortex_compactor_block_cleanup_failures_total Failures encountered while deleting blocks in compactor.
 		# TYPE cortex_compactor_block_cleanup_failures_total counter
+		# HELP cortex_compactor_block_cleanup_failures_total Total number of blocks failed to be deleted.
 		cortex_compactor_block_cleanup_failures_total 0
 
-		# HELP cortex_compactor_blocks_cleaned_total Total number of blocks deleted in compactor.
+		# HELP cortex_compactor_blocks_cleaned_total Total number of blocks deleted.
 		# TYPE cortex_compactor_blocks_cleaned_total counter
 		cortex_compactor_blocks_cleaned_total 0
 
 		# HELP cortex_compactor_blocks_marked_for_deletion_total Total number of blocks marked for deletion in compactor.
 		# TYPE cortex_compactor_blocks_marked_for_deletion_total counter
 		cortex_compactor_blocks_marked_for_deletion_total 0
+
+		# TYPE cortex_compactor_block_cleanup_started_total counter
+		# HELP cortex_compactor_block_cleanup_started_total Total number of blocks cleanup runs started.
+		cortex_compactor_block_cleanup_started_total 1
+
+		# TYPE cortex_compactor_block_cleanup_completed_total counter
+		# HELP cortex_compactor_block_cleanup_completed_total Total number of blocks cleanup runs successfully completed.
+		cortex_compactor_block_cleanup_completed_total 1
+
+		# TYPE cortex_compactor_block_cleanup_failed_total counter
+		# HELP cortex_compactor_block_cleanup_failed_total Total number of blocks cleanup runs failed.
+		cortex_compactor_block_cleanup_failed_total 0
 	`),
 		"cortex_compactor_runs_started_total",
 		"cortex_compactor_runs_completed_total",
@@ -198,10 +216,13 @@ func TestCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 		"cortex_compactor_block_cleanup_failures_total",
 		"cortex_compactor_blocks_cleaned_total",
 		"cortex_compactor_blocks_marked_for_deletion_total",
+		"cortex_compactor_block_cleanup_started_total",
+		"cortex_compactor_block_cleanup_completed_total",
+		"cortex_compactor_block_cleanup_failed_total",
 	))
 }
 
-func TestCompactor_ShouldRetryOnFailureWhileDiscoveringUsersFromBucket(t *testing.T) {
+func TestCompactor_ShouldRetryCompactionOnFailureWhileDiscoveringUsersFromBucket(t *testing.T) {
 	t.Parallel()
 
 	// Fail to iterate over the bucket while discovering users.
@@ -220,15 +241,17 @@ func TestCompactor_ShouldRetryOnFailureWhileDiscoveringUsersFromBucket(t *testin
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
 
 	// Ensure the bucket iteration has been retried the configured number of times.
-	bucketClient.AssertNumberOfCalls(t, "Iter", 3)
+	bucketClient.AssertNumberOfCalls(t, "Iter", 1+3)
 
 	assert.Equal(t, []string{
-		`level=info msg="discovering users from bucket"`,
-		`level=error msg="failed to discover users from bucket" err="failed to iterate the bucket"`,
-		`level=info msg="discovering users from bucket"`,
-		`level=error msg="failed to discover users from bucket" err="failed to iterate the bucket"`,
-		`level=info msg="discovering users from bucket"`,
-		`level=error msg="failed to discover users from bucket" err="failed to iterate the bucket"`,
+		`level=info component=cleaner msg="started hard deletion of blocks marked for deletion"`,
+		`level=error component=cleaner msg="failed to hard delete blocks marked for deletion" err="failed to discover users from bucket: failed to iterate the bucket"`,
+		`level=info component=compactor msg="discovering users from bucket"`,
+		`level=error component=compactor msg="failed to discover users from bucket" err="failed to iterate the bucket"`,
+		`level=info component=compactor msg="discovering users from bucket"`,
+		`level=error component=compactor msg="failed to discover users from bucket" err="failed to iterate the bucket"`,
+		`level=info component=compactor msg="discovering users from bucket"`,
+		`level=error component=compactor msg="failed to discover users from bucket" err="failed to iterate the bucket"`,
 	}, strings.Split(strings.TrimSpace(logs.String()), "\n"))
 
 	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
@@ -300,17 +323,29 @@ func TestCompactor_ShouldRetryOnFailureWhileDiscoveringUsersFromBucket(t *testin
 		# TYPE cortex_compactor_group_vertical_compactions_total counter
 		cortex_compactor_group_vertical_compactions_total 0
 
-		# HELP cortex_compactor_block_cleanup_failures_total Failures encountered while deleting blocks in compactor.
 		# TYPE cortex_compactor_block_cleanup_failures_total counter
+		# HELP cortex_compactor_block_cleanup_failures_total Total number of blocks failed to be deleted.
 		cortex_compactor_block_cleanup_failures_total 0
 
-		# HELP cortex_compactor_blocks_cleaned_total Total number of blocks deleted in compactor.
+		# HELP cortex_compactor_blocks_cleaned_total Total number of blocks deleted.
 		# TYPE cortex_compactor_blocks_cleaned_total counter
 		cortex_compactor_blocks_cleaned_total 0
 
 		# HELP cortex_compactor_blocks_marked_for_deletion_total Total number of blocks marked for deletion in compactor.
 		# TYPE cortex_compactor_blocks_marked_for_deletion_total counter
 		cortex_compactor_blocks_marked_for_deletion_total 0
+
+		# TYPE cortex_compactor_block_cleanup_started_total counter
+		# HELP cortex_compactor_block_cleanup_started_total Total number of blocks cleanup runs started.
+		cortex_compactor_block_cleanup_started_total 1
+
+		# TYPE cortex_compactor_block_cleanup_completed_total counter
+		# HELP cortex_compactor_block_cleanup_completed_total Total number of blocks cleanup runs successfully completed.
+		cortex_compactor_block_cleanup_completed_total 0
+
+		# TYPE cortex_compactor_block_cleanup_failed_total counter
+		# HELP cortex_compactor_block_cleanup_failed_total Total number of blocks cleanup runs failed.
+		cortex_compactor_block_cleanup_failed_total 1
 	`),
 		"cortex_compactor_runs_started_total",
 		"cortex_compactor_runs_completed_total",
@@ -331,6 +366,9 @@ func TestCompactor_ShouldRetryOnFailureWhileDiscoveringUsersFromBucket(t *testin
 		"cortex_compactor_block_cleanup_failures_total",
 		"cortex_compactor_blocks_cleaned_total",
 		"cortex_compactor_blocks_marked_for_deletion_total",
+		"cortex_compactor_block_cleanup_started_total",
+		"cortex_compactor_block_cleanup_completed_total",
+		"cortex_compactor_block_cleanup_failed_total",
 	))
 }
 
@@ -349,13 +387,14 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 
 	c, tsdbCompactor, logs, registry, cleanup := prepare(t, prepareConfig(), bucketClient)
 	defer cleanup()
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Mock the compactor as if there's no compaction to do,
 	// in order to simplify tests (all in all, we just want to
 	// test our logic and not TSDB compactor which we expect to
 	// be already tested).
 	tsdbCompactor.On("Plan", mock.Anything).Return([]string{}, nil)
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
 	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
@@ -368,24 +407,26 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 	tsdbCompactor.AssertNumberOfCalls(t, "Plan", 2)
 
 	assert.Equal(t, []string{
-		`level=info msg="discovering users from bucket"`,
-		`level=info msg="discovered users from bucket" users=2`,
-		`level=info msg="starting compaction of user blocks" user=user-1`,
-		`level=info org_id=user-1 msg="start sync of metas"`,
-		`level=info org_id=user-1 msg="start of GC"`,
-		`level=info org_id=user-1 msg="start of compactions"`,
-		`level=info org_id=user-1 msg="compaction iterations done"`,
-		`level=info org_id=user-1 msg="started cleaning of blocks marked for deletion"`,
-		`level=info org_id=user-1 msg="cleaning of blocks marked for deletion done"`,
-		`level=info msg="successfully compacted user blocks" user=user-1`,
-		`level=info msg="starting compaction of user blocks" user=user-2`,
-		`level=info org_id=user-2 msg="start sync of metas"`,
-		`level=info org_id=user-2 msg="start of GC"`,
-		`level=info org_id=user-2 msg="start of compactions"`,
-		`level=info org_id=user-2 msg="compaction iterations done"`,
-		`level=info org_id=user-2 msg="started cleaning of blocks marked for deletion"`,
-		`level=info org_id=user-2 msg="cleaning of blocks marked for deletion done"`,
-		`level=info msg="successfully compacted user blocks" user=user-2`,
+		`level=info component=cleaner msg="started hard deletion of blocks marked for deletion"`,
+		`level=info component=cleaner org_id=user-1 msg="started cleaning of blocks marked for deletion"`,
+		`level=info component=cleaner org_id=user-1 msg="cleaning of blocks marked for deletion done"`,
+		`level=info component=cleaner org_id=user-2 msg="started cleaning of blocks marked for deletion"`,
+		`level=info component=cleaner org_id=user-2 msg="cleaning of blocks marked for deletion done"`,
+		`level=info component=cleaner msg="successfully completed hard deletion of blocks marked for deletion"`,
+		`level=info component=compactor msg="discovering users from bucket"`,
+		`level=info component=compactor msg="discovered users from bucket" users=2`,
+		`level=info component=compactor msg="starting compaction of user blocks" user=user-1`,
+		`level=info component=compactor org_id=user-1 msg="start sync of metas"`,
+		`level=info component=compactor org_id=user-1 msg="start of GC"`,
+		`level=info component=compactor org_id=user-1 msg="start of compactions"`,
+		`level=info component=compactor org_id=user-1 msg="compaction iterations done"`,
+		`level=info component=compactor msg="successfully compacted user blocks" user=user-1`,
+		`level=info component=compactor msg="starting compaction of user blocks" user=user-2`,
+		`level=info component=compactor org_id=user-2 msg="start sync of metas"`,
+		`level=info component=compactor org_id=user-2 msg="start of GC"`,
+		`level=info component=compactor org_id=user-2 msg="start of compactions"`,
+		`level=info component=compactor org_id=user-2 msg="compaction iterations done"`,
+		`level=info component=compactor msg="successfully compacted user blocks" user=user-2`,
 	}, removeMetaFetcherLogs(strings.Split(strings.TrimSpace(logs.String()), "\n")))
 
 	// Instead of testing for shipper metrics, we only check our metrics here.
@@ -393,6 +434,7 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 	testedMetrics := []string{
 		"cortex_compactor_runs_started_total", "cortex_compactor_runs_completed_total", "cortex_compactor_runs_failed_total",
 		"cortex_compactor_blocks_cleaned_total", "cortex_compactor_block_cleanup_failures_total", "cortex_compactor_blocks_marked_for_deletion_total",
+		"cortex_compactor_block_cleanup_started_total", "cortex_compactor_block_cleanup_completed_total", "cortex_compactor_block_cleanup_failed_total",
 	}
 	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
 		# TYPE cortex_compactor_runs_started_total counter
@@ -407,17 +449,29 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 		# HELP cortex_compactor_runs_failed_total Total number of compaction runs failed.
 		cortex_compactor_runs_failed_total 0
 
-		# HELP cortex_compactor_block_cleanup_failures_total Failures encountered while deleting blocks in compactor.
 		# TYPE cortex_compactor_block_cleanup_failures_total counter
+		# HELP cortex_compactor_block_cleanup_failures_total Total number of blocks failed to be deleted.
 		cortex_compactor_block_cleanup_failures_total 0
 
-		# HELP cortex_compactor_blocks_cleaned_total Total number of blocks deleted in compactor.
+		# HELP cortex_compactor_blocks_cleaned_total Total number of blocks deleted.
 		# TYPE cortex_compactor_blocks_cleaned_total counter
 		cortex_compactor_blocks_cleaned_total 0
-	
+
 		# HELP cortex_compactor_blocks_marked_for_deletion_total Total number of blocks marked for deletion in compactor.
 		# TYPE cortex_compactor_blocks_marked_for_deletion_total counter
 		cortex_compactor_blocks_marked_for_deletion_total 0
+
+		# TYPE cortex_compactor_block_cleanup_started_total counter
+		# HELP cortex_compactor_block_cleanup_started_total Total number of blocks cleanup runs started.
+		cortex_compactor_block_cleanup_started_total 1
+
+		# TYPE cortex_compactor_block_cleanup_completed_total counter
+		# HELP cortex_compactor_block_cleanup_completed_total Total number of blocks cleanup runs successfully completed.
+		cortex_compactor_block_cleanup_completed_total 1
+
+		# TYPE cortex_compactor_block_cleanup_failed_total counter
+		# HELP cortex_compactor_block_cleanup_failed_total Total number of blocks cleanup runs failed.
+		cortex_compactor_block_cleanup_failed_total 0
 	`), testedMetrics...))
 }
 
@@ -444,13 +498,14 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForDeletion(t *testing.T) {
 
 	c, tsdbCompactor, logs, registry, cleanup := prepare(t, cfg, bucketClient)
 	defer cleanup()
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Mock the compactor as if there's no compaction to do,
 	// in order to simplify tests (all in all, we just want to
 	// test our logic and not TSDB compactor which we expect to
 	// be already tested).
 	tsdbCompactor.On("Plan", mock.Anything).Return([]string{}, nil)
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
 	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
@@ -463,19 +518,21 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForDeletion(t *testing.T) {
 	tsdbCompactor.AssertNumberOfCalls(t, "Plan", 1)
 
 	assert.Equal(t, []string{
-		`level=info msg="discovering users from bucket"`,
-		`level=info msg="discovered users from bucket" users=1`,
-		`level=info msg="starting compaction of user blocks" user=user-1`,
-		`level=info org_id=user-1 msg="start sync of metas"`,
-		`level=info org_id=user-1 msg="start of GC"`,
-		`level=info org_id=user-1 msg="start of compactions"`,
-		`level=info org_id=user-1 msg="compaction iterations done"`,
-		`level=info org_id=user-1 msg="started cleaning of blocks marked for deletion"`,
-		`level=debug org_id=user-1 msg="deleted file" file=01DTW0ZCPDDNV4BV83Q2SV4QAZ/meta.json bucket=mock`,
-		`level=debug org_id=user-1 msg="deleted file" file=01DTW0ZCPDDNV4BV83Q2SV4QAZ/deletion-mark.json bucket=mock`,
-		`level=info org_id=user-1 msg="deleted block marked for deletion" block=01DTW0ZCPDDNV4BV83Q2SV4QAZ`,
-		`level=info org_id=user-1 msg="cleaning of blocks marked for deletion done"`,
-		`level=info msg="successfully compacted user blocks" user=user-1`,
+		`level=info component=cleaner msg="started hard deletion of blocks marked for deletion"`,
+		`level=info component=cleaner org_id=user-1 msg="started cleaning of blocks marked for deletion"`,
+		`level=debug component=cleaner org_id=user-1 msg="deleted file" file=01DTW0ZCPDDNV4BV83Q2SV4QAZ/meta.json bucket=mock`,
+		`level=debug component=cleaner org_id=user-1 msg="deleted file" file=01DTW0ZCPDDNV4BV83Q2SV4QAZ/deletion-mark.json bucket=mock`,
+		`level=info component=cleaner org_id=user-1 msg="deleted block marked for deletion" block=01DTW0ZCPDDNV4BV83Q2SV4QAZ`,
+		`level=info component=cleaner org_id=user-1 msg="cleaning of blocks marked for deletion done"`,
+		`level=info component=cleaner msg="successfully completed hard deletion of blocks marked for deletion"`,
+		`level=info component=compactor msg="discovering users from bucket"`,
+		`level=info component=compactor msg="discovered users from bucket" users=1`,
+		`level=info component=compactor msg="starting compaction of user blocks" user=user-1`,
+		`level=info component=compactor org_id=user-1 msg="start sync of metas"`,
+		`level=info component=compactor org_id=user-1 msg="start of GC"`,
+		`level=info component=compactor org_id=user-1 msg="start of compactions"`,
+		`level=info component=compactor org_id=user-1 msg="compaction iterations done"`,
+		`level=info component=compactor msg="successfully compacted user blocks" user=user-1`,
 	}, removeMetaFetcherLogs(strings.Split(strings.TrimSpace(logs.String()), "\n")))
 
 	// Instead of testing for shipper metrics, we only check our metrics here.
@@ -483,6 +540,7 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForDeletion(t *testing.T) {
 	testedMetrics := []string{
 		"cortex_compactor_runs_started_total", "cortex_compactor_runs_completed_total", "cortex_compactor_runs_failed_total",
 		"cortex_compactor_blocks_cleaned_total", "cortex_compactor_block_cleanup_failures_total", "cortex_compactor_blocks_marked_for_deletion_total",
+		"cortex_compactor_block_cleanup_started_total", "cortex_compactor_block_cleanup_completed_total", "cortex_compactor_block_cleanup_failed_total",
 	}
 	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
 		# TYPE cortex_compactor_runs_started_total counter
@@ -497,17 +555,29 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForDeletion(t *testing.T) {
 		# HELP cortex_compactor_runs_failed_total Total number of compaction runs failed.
 		cortex_compactor_runs_failed_total 0
 
-		# HELP cortex_compactor_block_cleanup_failures_total Failures encountered while deleting blocks in compactor.
 		# TYPE cortex_compactor_block_cleanup_failures_total counter
+		# HELP cortex_compactor_block_cleanup_failures_total Total number of blocks failed to be deleted.
 		cortex_compactor_block_cleanup_failures_total 0
 
-		# HELP cortex_compactor_blocks_cleaned_total Total number of blocks deleted in compactor.
+		# HELP cortex_compactor_blocks_cleaned_total Total number of blocks deleted.
 		# TYPE cortex_compactor_blocks_cleaned_total counter
 		cortex_compactor_blocks_cleaned_total 1
 
 		# HELP cortex_compactor_blocks_marked_for_deletion_total Total number of blocks marked for deletion in compactor.
 		# TYPE cortex_compactor_blocks_marked_for_deletion_total counter
 		cortex_compactor_blocks_marked_for_deletion_total 0
+
+		# TYPE cortex_compactor_block_cleanup_started_total counter
+		# HELP cortex_compactor_block_cleanup_started_total Total number of blocks cleanup runs started.
+		cortex_compactor_block_cleanup_started_total 1
+
+		# TYPE cortex_compactor_block_cleanup_completed_total counter
+		# HELP cortex_compactor_block_cleanup_completed_total Total number of blocks cleanup runs successfully completed.
+		cortex_compactor_block_cleanup_completed_total 1
+
+		# TYPE cortex_compactor_block_cleanup_failed_total counter
+		# HELP cortex_compactor_block_cleanup_failed_total Total number of blocks cleanup runs failed.
+		cortex_compactor_block_cleanup_failed_total 0
 	`), testedMetrics...))
 }
 
@@ -532,13 +602,14 @@ func TestCompactor_ShouldCompactAllUsersOnShardingEnabledButOnlyOneInstanceRunni
 
 	c, tsdbCompactor, logs, _, cleanup := prepare(t, cfg, bucketClient)
 	defer cleanup()
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Mock the compactor as if there's no compaction to do,
 	// in order to simplify tests (all in all, we just want to
 	// test our logic and not TSDB compactor which we expect to
 	// be already tested).
 	tsdbCompactor.On("Plan", mock.Anything).Return([]string{}, nil)
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
 	cortex_testutil.Poll(t, 5*time.Second, 1.0, func() interface{} {
@@ -551,26 +622,28 @@ func TestCompactor_ShouldCompactAllUsersOnShardingEnabledButOnlyOneInstanceRunni
 	tsdbCompactor.AssertNumberOfCalls(t, "Plan", 2)
 
 	assert.Equal(t, []string{
-		`level=info msg="waiting until compactor is ACTIVE in the ring"`,
-		`level=info msg="compactor is ACTIVE in the ring"`,
-		`level=info msg="discovering users from bucket"`,
-		`level=info msg="discovered users from bucket" users=2`,
-		`level=info msg="starting compaction of user blocks" user=user-1`,
-		`level=info org_id=user-1 msg="start sync of metas"`,
-		`level=info org_id=user-1 msg="start of GC"`,
-		`level=info org_id=user-1 msg="start of compactions"`,
-		`level=info org_id=user-1 msg="compaction iterations done"`,
-		`level=info org_id=user-1 msg="started cleaning of blocks marked for deletion"`,
-		`level=info org_id=user-1 msg="cleaning of blocks marked for deletion done"`,
-		`level=info msg="successfully compacted user blocks" user=user-1`,
-		`level=info msg="starting compaction of user blocks" user=user-2`,
-		`level=info org_id=user-2 msg="start sync of metas"`,
-		`level=info org_id=user-2 msg="start of GC"`,
-		`level=info org_id=user-2 msg="start of compactions"`,
-		`level=info org_id=user-2 msg="compaction iterations done"`,
-		`level=info org_id=user-2 msg="started cleaning of blocks marked for deletion"`,
-		`level=info org_id=user-2 msg="cleaning of blocks marked for deletion done"`,
-		`level=info msg="successfully compacted user blocks" user=user-2`,
+		`level=info component=compactor msg="waiting until compactor is ACTIVE in the ring"`,
+		`level=info component=compactor msg="compactor is ACTIVE in the ring"`,
+		`level=info component=cleaner msg="started hard deletion of blocks marked for deletion"`,
+		`level=info component=cleaner org_id=user-1 msg="started cleaning of blocks marked for deletion"`,
+		`level=info component=cleaner org_id=user-1 msg="cleaning of blocks marked for deletion done"`,
+		`level=info component=cleaner org_id=user-2 msg="started cleaning of blocks marked for deletion"`,
+		`level=info component=cleaner org_id=user-2 msg="cleaning of blocks marked for deletion done"`,
+		`level=info component=cleaner msg="successfully completed hard deletion of blocks marked for deletion"`,
+		`level=info component=compactor msg="discovering users from bucket"`,
+		`level=info component=compactor msg="discovered users from bucket" users=2`,
+		`level=info component=compactor msg="starting compaction of user blocks" user=user-1`,
+		`level=info component=compactor org_id=user-1 msg="start sync of metas"`,
+		`level=info component=compactor org_id=user-1 msg="start of GC"`,
+		`level=info component=compactor org_id=user-1 msg="start of compactions"`,
+		`level=info component=compactor org_id=user-1 msg="compaction iterations done"`,
+		`level=info component=compactor msg="successfully compacted user blocks" user=user-1`,
+		`level=info component=compactor msg="starting compaction of user blocks" user=user-2`,
+		`level=info component=compactor org_id=user-2 msg="start sync of metas"`,
+		`level=info component=compactor org_id=user-2 msg="start of GC"`,
+		`level=info component=compactor org_id=user-2 msg="start of compactions"`,
+		`level=info component=compactor org_id=user-2 msg="compaction iterations done"`,
+		`level=info component=compactor msg="successfully compacted user blocks" user=user-2`,
 	}, removeMetaFetcherLogs(strings.Split(strings.TrimSpace(logs.String()), "\n")))
 }
 
@@ -658,8 +731,76 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 	for _, userID := range userIDs {
 		_, l, err := findCompactorByUserID(compactors, logs, userID)
 		require.NoError(t, err)
-		assert.Contains(t, l.String(), fmt.Sprintf(`level=info msg="successfully compacted user blocks" user=%s`, userID))
+		assert.Contains(t, l.String(), fmt.Sprintf(`level=info component=compactor msg="successfully compacted user blocks" user=%s`, userID))
 	}
+}
+
+func createTSDBBlock(t *testing.T, dir string, minT, maxT int64, externalLabels map[string]string) ulid.ULID {
+	// Create a temporary dir for TSDB.
+	tempDir, err := ioutil.TempDir(os.TempDir(), "tsdb")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir) //nolint:errcheck
+
+	// Create a temporary dir for the snapshot.
+	snapshotDir, err := ioutil.TempDir(os.TempDir(), "snapshot")
+	require.NoError(t, err)
+	defer os.RemoveAll(snapshotDir) //nolint:errcheck
+
+	// Create a new TSDB.
+	db, err := tsdb.Open(tempDir, nil, nil, &tsdb.Options{
+		BlockRanges:       []int64{int64(2 * 60 * 60 * 1000)}, // 2h period
+		RetentionDuration: uint64(15 * 86400 * 1000),          // 15 days
+	})
+	require.NoError(t, err)
+
+	db.DisableCompactions()
+
+	// Append a sample at the beginning and one at the end of the time range.
+	for i, ts := range []int64{minT, maxT - 1} {
+		lbls := labels.Labels{labels.Label{Name: "series_id", Value: strconv.Itoa(i)}}
+
+		app := db.Appender()
+		_, err := app.Add(lbls, ts, float64(i))
+		require.NoError(t, err)
+
+		err = app.Commit()
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, db.Compact())
+	require.NoError(t, db.Snapshot(snapshotDir, true))
+
+	// Look for the created block (we expect one).
+	entries, err := ioutil.ReadDir(snapshotDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.True(t, entries[0].IsDir())
+
+	blockID, err := ulid.Parse(entries[0].Name())
+	require.NoError(t, err)
+
+	// Inject Thanos external labels to the block.
+	meta := metadata.Thanos{
+		Labels: externalLabels,
+		Source: "test",
+	}
+	_, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(snapshotDir, blockID.String()), meta, nil)
+	require.NoError(t, err)
+
+	// Ensure the output directory exists.
+	require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+
+	// Copy the block files to the storage dir.
+	require.NoError(t, exec.Command("cp", "-r", filepath.Join(snapshotDir, blockID.String()), dir).Run())
+
+	return blockID
+}
+
+func createDeletionMark(t *testing.T, dir string, blockID ulid.ULID, deletionTime time.Time) {
+	content := mockDeletionMarkJSON(blockID.String(), deletionTime)
+	path := filepath.Join(dir, blockID.String(), metadata.DeletionMarkFilename)
+
+	require.NoError(t, ioutil.WriteFile(path, []byte(content), os.ModePerm))
 }
 
 func findCompactorByUserID(compactors []*Compactor, logs []*bytes.Buffer, userID string) (*Compactor, *bytes.Buffer, error) {

--- a/pkg/compactor/users_scanner.go
+++ b/pkg/compactor/users_scanner.go
@@ -1,0 +1,47 @@
+package compactor
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+type UsersScanner struct {
+	bucketClient objstore.Bucket
+	logger       log.Logger
+	isOwned      func(userID string) (bool, error)
+}
+
+func NewUsersScanner(bucketClient objstore.Bucket, isOwned func(userID string) (bool, error), logger log.Logger) *UsersScanner {
+	return &UsersScanner{
+		bucketClient: bucketClient,
+		logger:       logger,
+		isOwned:      isOwned,
+	}
+}
+
+// ScanUsers returns a fresh list of users found in the storage. If sharding is enabled,
+// the returned list contains only the users owned by this instance.
+func (s *UsersScanner) ScanUsers(ctx context.Context) ([]string, error) {
+	var users []string
+
+	err := s.bucketClient.Iter(ctx, "", func(entry string) error {
+		userID := strings.TrimSuffix(entry, "/")
+
+		// Check if it's owned by this instance.
+		owned, err := s.isOwned(userID)
+		if err != nil {
+			level.Warn(s.logger).Log("msg", "unable to check if user is owned by this shard", "user", userID, "err", err)
+		} else if !owned {
+			return nil
+		}
+
+		users = append(users, userID)
+		return nil
+	})
+
+	return users, err
+}

--- a/pkg/compactor/users_scanner_test.go
+++ b/pkg/compactor/users_scanner_test.go
@@ -1,0 +1,44 @@
+package compactor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+)
+
+func TestUsersScanner_ScanUsers_ShouldReturnedOwnedUsersOnly(t *testing.T) {
+	bucketClient := &cortex_tsdb.BucketClientMock{}
+	bucketClient.MockIter("", []string{"user-1", "user-2", "user-3"}, nil)
+
+	isOwned := func(userID string) (bool, error) {
+		return userID == "user-1" || userID == "user-3", nil
+	}
+
+	s := NewUsersScanner(bucketClient, isOwned, log.NewNopLogger())
+	actual, err := s.ScanUsers(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"user-1", "user-3"}, actual)
+
+}
+
+func TestUsersScanner_ScanUsers_ShouldReturnUsersForWhichOwnerCheckFailed(t *testing.T) {
+	expected := []string{"user-1", "user-2"}
+
+	bucketClient := &cortex_tsdb.BucketClientMock{}
+	bucketClient.MockIter("", expected, nil)
+
+	isOwned := func(userID string) (bool, error) {
+		return false, errors.New("failed to check if user is owned")
+	}
+
+	s := NewUsersScanner(bucketClient, isOwned, log.NewNopLogger())
+	actual, err := s.ScanUsers(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/util/services/manager.go
+++ b/pkg/util/services/manager.go
@@ -86,6 +86,10 @@ func (m *Manager) StartAsync(ctx context.Context) error {
 
 // Initiates service shutdown if necessary on all the services being managed.
 func (m *Manager) StopAsync() {
+	if m == nil {
+		return
+	}
+
 	for _, s := range m.services {
 		s.StopAsync()
 	}


### PR DESCRIPTION
**What this PR does**:
While running the blocks compactor at scale, we reliased that blocks marked for deletion could be potentially never deleted if the compactor is busy all the time compacting blocks.

In this PR I've decoupled blocks deletion from compaction, so that blocks deletion is not blocked by a busy compactor.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
