### PR TITLE
Metadata caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
   * `cortex_compactor_block_cleanup_completed_total`
   * `cortex_compactor_block_cleanup_failed_total`
   * `cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds`
+* [ENHANCEMENT] Experimental TSDB: Use shared cache for metadata. This is especially useful when running multiple querier and store-gateway components to reduce number of object store API calls. #2626
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2807,7 +2807,7 @@ bucket_store:
     # CLI flag: -experimental.tsdb.bucket-store.chunks-cache.max-get-range-requests
     [max_get_range_requests: <int> | default = 3]
 
-    # TTL for caching object size for chunks.
+    # TTL for caching object attributes for chunks.
     # CLI flag: -experimental.tsdb.bucket-store.chunks-cache.attributes-ttl
     [attributes_ttl: <duration> | default = 24h]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2815,6 +2815,82 @@ bucket_store:
     # CLI flag: -experimental.tsdb.bucket-store.chunks-cache.subrange-ttl
     [subrange_ttl: <duration> | default = 24h]
 
+  metadata_cache:
+    cachebackend:
+      # Backend for metadata cache, if not empty. Supported values: memcached.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.backend
+      [backend: <string> | default = ""]
+
+      memcached:
+        # Comma separated list of memcached addresses. Supported prefixes are:
+        # dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV
+        # query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup
+        # made after that).
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.addresses
+        [addresses: <string> | default = ""]
+
+        # The socket read/write timeout.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.timeout
+        [timeout: <duration> | default = 100ms]
+
+        # The maximum number of idle connections that will be maintained per
+        # address.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-idle-connections
+        [max_idle_connections: <int> | default = 16]
+
+        # The maximum number of concurrent asynchronous operations can occur.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-concurrency
+        [max_async_concurrency: <int> | default = 50]
+
+        # The maximum number of enqueued asynchronous operations allowed.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-buffer-size
+        [max_async_buffer_size: <int> | default = 10000]
+
+        # The maximum number of concurrent connections running get operations.
+        # If set to 0, concurrency is unlimited.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-concurrency
+        [max_get_multi_concurrency: <int> | default = 100]
+
+        # The maximum number of keys a single underlying get operation should
+        # run. If more keys are specified, internally keys are splitted into
+        # multiple batches and fetched concurrently, honoring the max
+        # concurrency. If set to 0, the max batch size is unlimited.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-batch-size
+        [max_get_multi_batch_size: <int> | default = 0]
+
+        # The maximum size of an item stored in memcached. Bigger items are not
+        # stored. If set to 0, no maximum size is enforced.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-item-size
+        [max_item_size: <int> | default = 1048576]
+
+    # How long to cache list of tenants in the bucket.
+    # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.tenants-list-ttl
+    [tenantslistttl: <duration> | default = 15m]
+
+    # How long to cache list of blocks for each tenant.
+    # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.tenant-blocks-list-ttl
+    [tenantblockslistttl: <duration> | default = 15m]
+
+    # How long to cache list of chunks for a block.
+    # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.chunks-list-ttl
+    [chunkslistttl: <duration> | default = 24h]
+
+    # How long to cache information that block metafile exists.
+    # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-exists-ttl
+    [metafileexiststtl: <duration> | default = 2h]
+
+    # How long to cache information that block metafile doesn't exist.
+    # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-doesnt-exist-ttl
+    [metafiledoesntexistttl: <duration> | default = 15m]
+
+    # How long to cache content of the metafile.
+    # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-content-ttl
+    [metafilecontentttl: <duration> | default = 24h]
+
+    # Maximum size of metafile content to cache.
+    # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-max-size
+    [metafilemaxsize: <int> | default = 1048576]
+
   # Duration after which the blocks marked for deletion will be filtered out
   # while fetching blocks. The idea of ignore-deletion-marks-delay is to ignore
   # blocks that are marked for deletion with some delay. This ensures store can

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2808,8 +2808,8 @@ bucket_store:
     [max_get_range_requests: <int> | default = 3]
 
     # TTL for caching object size for chunks.
-    # CLI flag: -experimental.tsdb.bucket-store.chunks-cache.object-size-ttl
-    [object_size_ttl: <duration> | default = 24h]
+    # CLI flag: -experimental.tsdb.bucket-store.chunks-cache.attributes-ttl
+    [attributes_ttl: <duration> | default = 24h]
 
     # TTL for caching individual chunks subranges.
     # CLI flag: -experimental.tsdb.bucket-store.chunks-cache.subrange-ttl
@@ -2886,9 +2886,9 @@ bucket_store:
     # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-content-ttl
     [metafile_content_ttl: <duration> | default = 24h]
 
-    # Maximum size of metafile content to cache.
-    # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-max-size
-    [metafile_max_size: <int> | default = 1048576]
+    # Maximum size of metafile content to cache in bytes.
+    # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-max-size-bytes
+    [metafile_max_size_bytes: <int> | default = 1048576]
 
   # Duration after which the blocks marked for deletion will be filtered out
   # while fetching blocks. The idea of ignore-deletion-marks-delay is to ignore

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2816,80 +2816,79 @@ bucket_store:
     [subrange_ttl: <duration> | default = 24h]
 
   metadata_cache:
-    cachebackend:
-      # Backend for metadata cache, if not empty. Supported values: memcached.
-      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.backend
-      [backend: <string> | default = ""]
+    # Backend for metadata cache, if not empty. Supported values: memcached.
+    # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.backend
+    [backend: <string> | default = ""]
 
-      memcached:
-        # Comma separated list of memcached addresses. Supported prefixes are:
-        # dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV
-        # query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup
-        # made after that).
-        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.addresses
-        [addresses: <string> | default = ""]
+    memcached:
+      # Comma separated list of memcached addresses. Supported prefixes are:
+      # dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query,
+      # dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup made after
+      # that).
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.addresses
+      [addresses: <string> | default = ""]
 
-        # The socket read/write timeout.
-        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.timeout
-        [timeout: <duration> | default = 100ms]
+      # The socket read/write timeout.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.timeout
+      [timeout: <duration> | default = 100ms]
 
-        # The maximum number of idle connections that will be maintained per
-        # address.
-        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-idle-connections
-        [max_idle_connections: <int> | default = 16]
+      # The maximum number of idle connections that will be maintained per
+      # address.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-idle-connections
+      [max_idle_connections: <int> | default = 16]
 
-        # The maximum number of concurrent asynchronous operations can occur.
-        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-concurrency
-        [max_async_concurrency: <int> | default = 50]
+      # The maximum number of concurrent asynchronous operations can occur.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-concurrency
+      [max_async_concurrency: <int> | default = 50]
 
-        # The maximum number of enqueued asynchronous operations allowed.
-        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-buffer-size
-        [max_async_buffer_size: <int> | default = 10000]
+      # The maximum number of enqueued asynchronous operations allowed.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-buffer-size
+      [max_async_buffer_size: <int> | default = 10000]
 
-        # The maximum number of concurrent connections running get operations.
-        # If set to 0, concurrency is unlimited.
-        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-concurrency
-        [max_get_multi_concurrency: <int> | default = 100]
+      # The maximum number of concurrent connections running get operations. If
+      # set to 0, concurrency is unlimited.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-concurrency
+      [max_get_multi_concurrency: <int> | default = 100]
 
-        # The maximum number of keys a single underlying get operation should
-        # run. If more keys are specified, internally keys are splitted into
-        # multiple batches and fetched concurrently, honoring the max
-        # concurrency. If set to 0, the max batch size is unlimited.
-        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-batch-size
-        [max_get_multi_batch_size: <int> | default = 0]
+      # The maximum number of keys a single underlying get operation should run.
+      # If more keys are specified, internally keys are splitted into multiple
+      # batches and fetched concurrently, honoring the max concurrency. If set
+      # to 0, the max batch size is unlimited.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-batch-size
+      [max_get_multi_batch_size: <int> | default = 0]
 
-        # The maximum size of an item stored in memcached. Bigger items are not
-        # stored. If set to 0, no maximum size is enforced.
-        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-item-size
-        [max_item_size: <int> | default = 1048576]
+      # The maximum size of an item stored in memcached. Bigger items are not
+      # stored. If set to 0, no maximum size is enforced.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-item-size
+      [max_item_size: <int> | default = 1048576]
 
     # How long to cache list of tenants in the bucket.
     # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.tenants-list-ttl
-    [tenantslistttl: <duration> | default = 15m]
+    [tenants_list_ttl: <duration> | default = 15m]
 
     # How long to cache list of blocks for each tenant.
     # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.tenant-blocks-list-ttl
-    [tenantblockslistttl: <duration> | default = 15m]
+    [tenant_blocks_list_ttl: <duration> | default = 15m]
 
     # How long to cache list of chunks for a block.
     # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.chunks-list-ttl
-    [chunkslistttl: <duration> | default = 24h]
+    [chunks_list_ttl: <duration> | default = 24h]
 
     # How long to cache information that block metafile exists.
     # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-exists-ttl
-    [metafileexiststtl: <duration> | default = 2h]
+    [metafile_exists_ttl: <duration> | default = 2h]
 
     # How long to cache information that block metafile doesn't exist.
     # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-doesnt-exist-ttl
-    [metafiledoesntexistttl: <duration> | default = 15m]
+    [metafile_doesnt_exist_ttl: <duration> | default = 15m]
 
     # How long to cache content of the metafile.
     # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-content-ttl
-    [metafilecontentttl: <duration> | default = 24h]
+    [metafile_content_ttl: <duration> | default = 24h]
 
     # Maximum size of metafile content to cache.
     # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-max-size
-    [metafilemaxsize: <int> | default = 1048576]
+    [metafile_max_size: <int> | default = 1048576]
 
   # Duration after which the blocks marked for deletion will be filtered out
   # while fetching blocks. The idea of ignore-deletion-marks-delay is to ignore

--- a/docs/operations/blocks-storage.md
+++ b/docs/operations/blocks-storage.md
@@ -111,6 +111,14 @@ To enable chunks cache, please set `-experimental.tsdb.bucket-store.chunks-cache
 
 There are additional low-level options for configuring chunks cache. Please refer to other flags with `experimental.tsdb.bucket-store.chunks-cache` prefix.
 
+## Metadata cache
+
+Store-gateway and querier can use memcached for storing metadata: list of users, list of blocks per user, meta.json files and deletion mark files. Using the cache can reduce number of API calls to object storage significantly.
+
+To enable metadata cache, please set `-experimental.tsdb.bucket-store.metadata-cache.backend`. Only `memcached` backend is supported currently. Memcached client has additional configuration available via flags with `-experimental.tsdb.bucket-store.metadata-cache.memcached` prefix.
+
+Additional options for configuring metadata cache have `-experimental.tsdb.bucket-store.metadata-cache.` prefix. By configuring TTL to zero or negative value, caching of given item type is disabled.
+
 ## Configuration
 
 The general [configuration documentation](../configuration/_index.md) also applied to a Cortex cluster running the blocks storage, with few differences:

--- a/docs/operations/blocks-storage.md
+++ b/docs/operations/blocks-storage.md
@@ -337,8 +337,8 @@ tsdb:
       [max_get_range_requests: <int> | default = 3]
 
       # TTL for caching object size for chunks.
-      # CLI flag: -experimental.tsdb.bucket-store.chunks-cache.object-size-ttl
-      [object_size_ttl: <duration> | default = 24h]
+      # CLI flag: -experimental.tsdb.bucket-store.chunks-cache.attributes-ttl
+      [attributes_ttl: <duration> | default = 24h]
 
       # TTL for caching individual chunks subranges.
       # CLI flag: -experimental.tsdb.bucket-store.chunks-cache.subrange-ttl
@@ -415,9 +415,9 @@ tsdb:
       # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-content-ttl
       [metafile_content_ttl: <duration> | default = 24h]
 
-      # Maximum size of metafile content to cache.
-      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-max-size
-      [metafile_max_size: <int> | default = 1048576]
+      # Maximum size of metafile content to cache in bytes.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-max-size-bytes
+      [metafile_max_size_bytes: <int> | default = 1048576]
 
     # Duration after which the blocks marked for deletion will be filtered out
     # while fetching blocks. The idea of ignore-deletion-marks-delay is to

--- a/docs/operations/blocks-storage.md
+++ b/docs/operations/blocks-storage.md
@@ -336,7 +336,7 @@ tsdb:
       # CLI flag: -experimental.tsdb.bucket-store.chunks-cache.max-get-range-requests
       [max_get_range_requests: <int> | default = 3]
 
-      # TTL for caching object size for chunks.
+      # TTL for caching object attributes for chunks.
       # CLI flag: -experimental.tsdb.bucket-store.chunks-cache.attributes-ttl
       [attributes_ttl: <duration> | default = 24h]
 

--- a/docs/operations/blocks-storage.md
+++ b/docs/operations/blocks-storage.md
@@ -336,6 +336,82 @@ tsdb:
       # CLI flag: -experimental.tsdb.bucket-store.chunks-cache.subrange-ttl
       [subrange_ttl: <duration> | default = 24h]
 
+    metadata_cache:
+      cachebackend:
+        # Backend for metadata cache, if not empty. Supported values: memcached.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.backend
+        [backend: <string> | default = ""]
+
+        memcached:
+          # Comma separated list of memcached addresses. Supported prefixes are:
+          # dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV
+          # query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup
+          # made after that).
+          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.addresses
+          [addresses: <string> | default = ""]
+
+          # The socket read/write timeout.
+          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.timeout
+          [timeout: <duration> | default = 100ms]
+
+          # The maximum number of idle connections that will be maintained per
+          # address.
+          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-idle-connections
+          [max_idle_connections: <int> | default = 16]
+
+          # The maximum number of concurrent asynchronous operations can occur.
+          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-concurrency
+          [max_async_concurrency: <int> | default = 50]
+
+          # The maximum number of enqueued asynchronous operations allowed.
+          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-buffer-size
+          [max_async_buffer_size: <int> | default = 10000]
+
+          # The maximum number of concurrent connections running get operations.
+          # If set to 0, concurrency is unlimited.
+          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-concurrency
+          [max_get_multi_concurrency: <int> | default = 100]
+
+          # The maximum number of keys a single underlying get operation should
+          # run. If more keys are specified, internally keys are splitted into
+          # multiple batches and fetched concurrently, honoring the max
+          # concurrency. If set to 0, the max batch size is unlimited.
+          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-batch-size
+          [max_get_multi_batch_size: <int> | default = 0]
+
+          # The maximum size of an item stored in memcached. Bigger items are
+          # not stored. If set to 0, no maximum size is enforced.
+          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-item-size
+          [max_item_size: <int> | default = 1048576]
+
+      # How long to cache list of tenants in the bucket.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.tenants-list-ttl
+      [tenantslistttl: <duration> | default = 15m]
+
+      # How long to cache list of blocks for each tenant.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.tenant-blocks-list-ttl
+      [tenantblockslistttl: <duration> | default = 15m]
+
+      # How long to cache list of chunks for a block.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.chunks-list-ttl
+      [chunkslistttl: <duration> | default = 24h]
+
+      # How long to cache information that block metafile exists.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-exists-ttl
+      [metafileexiststtl: <duration> | default = 2h]
+
+      # How long to cache information that block metafile doesn't exist.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-doesnt-exist-ttl
+      [metafiledoesntexistttl: <duration> | default = 15m]
+
+      # How long to cache content of the metafile.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-content-ttl
+      [metafilecontentttl: <duration> | default = 24h]
+
+      # Maximum size of metafile content to cache.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-max-size
+      [metafilemaxsize: <int> | default = 1048576]
+
     # Duration after which the blocks marked for deletion will be filtered out
     # while fetching blocks. The idea of ignore-deletion-marks-delay is to
     # ignore blocks that are marked for deletion with some delay. This ensures

--- a/docs/operations/blocks-storage.md
+++ b/docs/operations/blocks-storage.md
@@ -345,80 +345,79 @@ tsdb:
       [subrange_ttl: <duration> | default = 24h]
 
     metadata_cache:
-      cachebackend:
-        # Backend for metadata cache, if not empty. Supported values: memcached.
-        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.backend
-        [backend: <string> | default = ""]
+      # Backend for metadata cache, if not empty. Supported values: memcached.
+      # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.backend
+      [backend: <string> | default = ""]
 
-        memcached:
-          # Comma separated list of memcached addresses. Supported prefixes are:
-          # dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV
-          # query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup
-          # made after that).
-          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.addresses
-          [addresses: <string> | default = ""]
+      memcached:
+        # Comma separated list of memcached addresses. Supported prefixes are:
+        # dns+ (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV
+        # query, dnssrvnoa+ (looked up as a SRV query, with no A/AAAA lookup
+        # made after that).
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.addresses
+        [addresses: <string> | default = ""]
 
-          # The socket read/write timeout.
-          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.timeout
-          [timeout: <duration> | default = 100ms]
+        # The socket read/write timeout.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.timeout
+        [timeout: <duration> | default = 100ms]
 
-          # The maximum number of idle connections that will be maintained per
-          # address.
-          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-idle-connections
-          [max_idle_connections: <int> | default = 16]
+        # The maximum number of idle connections that will be maintained per
+        # address.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-idle-connections
+        [max_idle_connections: <int> | default = 16]
 
-          # The maximum number of concurrent asynchronous operations can occur.
-          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-concurrency
-          [max_async_concurrency: <int> | default = 50]
+        # The maximum number of concurrent asynchronous operations can occur.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-concurrency
+        [max_async_concurrency: <int> | default = 50]
 
-          # The maximum number of enqueued asynchronous operations allowed.
-          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-buffer-size
-          [max_async_buffer_size: <int> | default = 10000]
+        # The maximum number of enqueued asynchronous operations allowed.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-buffer-size
+        [max_async_buffer_size: <int> | default = 10000]
 
-          # The maximum number of concurrent connections running get operations.
-          # If set to 0, concurrency is unlimited.
-          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-concurrency
-          [max_get_multi_concurrency: <int> | default = 100]
+        # The maximum number of concurrent connections running get operations.
+        # If set to 0, concurrency is unlimited.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-concurrency
+        [max_get_multi_concurrency: <int> | default = 100]
 
-          # The maximum number of keys a single underlying get operation should
-          # run. If more keys are specified, internally keys are splitted into
-          # multiple batches and fetched concurrently, honoring the max
-          # concurrency. If set to 0, the max batch size is unlimited.
-          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-batch-size
-          [max_get_multi_batch_size: <int> | default = 0]
+        # The maximum number of keys a single underlying get operation should
+        # run. If more keys are specified, internally keys are splitted into
+        # multiple batches and fetched concurrently, honoring the max
+        # concurrency. If set to 0, the max batch size is unlimited.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-batch-size
+        [max_get_multi_batch_size: <int> | default = 0]
 
-          # The maximum size of an item stored in memcached. Bigger items are
-          # not stored. If set to 0, no maximum size is enforced.
-          # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-item-size
-          [max_item_size: <int> | default = 1048576]
+        # The maximum size of an item stored in memcached. Bigger items are not
+        # stored. If set to 0, no maximum size is enforced.
+        # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.memcached.max-item-size
+        [max_item_size: <int> | default = 1048576]
 
       # How long to cache list of tenants in the bucket.
       # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.tenants-list-ttl
-      [tenantslistttl: <duration> | default = 15m]
+      [tenants_list_ttl: <duration> | default = 15m]
 
       # How long to cache list of blocks for each tenant.
       # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.tenant-blocks-list-ttl
-      [tenantblockslistttl: <duration> | default = 15m]
+      [tenant_blocks_list_ttl: <duration> | default = 15m]
 
       # How long to cache list of chunks for a block.
       # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.chunks-list-ttl
-      [chunkslistttl: <duration> | default = 24h]
+      [chunks_list_ttl: <duration> | default = 24h]
 
       # How long to cache information that block metafile exists.
       # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-exists-ttl
-      [metafileexiststtl: <duration> | default = 2h]
+      [metafile_exists_ttl: <duration> | default = 2h]
 
       # How long to cache information that block metafile doesn't exist.
       # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-doesnt-exist-ttl
-      [metafiledoesntexistttl: <duration> | default = 15m]
+      [metafile_doesnt_exist_ttl: <duration> | default = 15m]
 
       # How long to cache content of the metafile.
       # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-content-ttl
-      [metafilecontentttl: <duration> | default = 24h]
+      [metafile_content_ttl: <duration> | default = 24h]
 
       # Maximum size of metafile content to cache.
       # CLI flag: -experimental.tsdb.bucket-store.metadata-cache.metafile-max-size
-      [metafilemaxsize: <int> | default = 1048576]
+      [metafile_max_size: <int> | default = 1048576]
 
     # Duration after which the blocks marked for deletion will be filtered out
     # while fetching blocks. The idea of ignore-deletion-marks-delay is to

--- a/docs/operations/blocks-storage.template
+++ b/docs/operations/blocks-storage.template
@@ -111,6 +111,14 @@ To enable chunks cache, please set `-experimental.tsdb.bucket-store.chunks-cache
 
 There are additional low-level options for configuring chunks cache. Please refer to other flags with `experimental.tsdb.bucket-store.chunks-cache` prefix.
 
+## Metadata cache
+
+Store-gateway and querier can use memcached for storing metadata: list of users, list of blocks per user, meta.json files and deletion mark files. Using the cache can reduce number of API calls to object storage significantly.
+
+To enable metadata cache, please set `-experimental.tsdb.bucket-store.metadata-cache.backend`. Only `memcached` backend is supported currently. Memcached client has additional configuration available via flags with `-experimental.tsdb.bucket-store.metadata-cache.memcached` prefix.
+
+Additional options for configuring metadata cache have `-experimental.tsdb.bucket-store.metadata-cache.` prefix. By configuring TTL to zero or negative value, caching of given item type is disabled.
+
 ## Configuration
 
 The general [configuration documentation](../configuration/_index.md) also applied to a Cortex cluster running the blocks storage, with few differences:

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.4.0
-	github.com/thanos-io/thanos v0.12.3-0.20200520075802-806479182a6b
+	github.com/thanos-io/thanos v0.12.3-0.20200524133339-079ad4274d5b
 	github.com/uber/jaeger-client-go v2.20.1+incompatible
 	github.com/weaveworks/common v0.0.0-20200512154658-384f10054ec5
 	go.etcd.io/bbolt v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -919,8 +919,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/thanos-io/thanos v0.8.1-0.20200109203923-552ffa4c1a0d/go.mod h1:usT/TxtJQ7DzinTt+G9kinDQmRS5sxwu0unVKZ9vdcw=
-github.com/thanos-io/thanos v0.12.3-0.20200520075802-806479182a6b h1:BQPyohMtq8uV+6eoVywL+3DW14454uWZzBtY0aMpNqw=
-github.com/thanos-io/thanos v0.12.3-0.20200520075802-806479182a6b/go.mod h1:I/DAcQA84wLoyYvz5g/jpStEf/dm6nF0KXlDHvv7xQ8=
+github.com/thanos-io/thanos v0.12.3-0.20200524133339-079ad4274d5b h1:ne+i2dLDoxsnKauoX2itJSod4julDLwXhykaXDn/BTE=
+github.com/thanos-io/thanos v0.12.3-0.20200524133339-079ad4274d5b/go.mod h1:I/DAcQA84wLoyYvz5g/jpStEf/dm6nF0KXlDHvv7xQ8=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/storage/tsdb/bucket_client_mock.go
+++ b/pkg/storage/tsdb/bucket_client_mock.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/thanos-io/thanos/pkg/objstore"
 )
 
 var errObjectDoesNotExist = errors.New("object does not exist")
@@ -112,10 +113,10 @@ func (m *BucketClientMock) IsObjNotFoundErr(err error) bool {
 	return err == errObjectDoesNotExist
 }
 
-// ObjectSize mocks objstore.Bucket.ObjectSize()
-func (m *BucketClientMock) ObjectSize(ctx context.Context, name string) (uint64, error) {
+// ObjectSize mocks objstore.Bucket.Attributes()
+func (m *BucketClientMock) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
 	args := m.Called(ctx, name)
-	return args.Get(0).(uint64), args.Error(1)
+	return args.Get(0).(objstore.ObjectAttributes), args.Error(1)
 }
 
 // Close mocks objstore.Bucket.Close()

--- a/pkg/storage/tsdb/caching_bucket.go
+++ b/pkg/storage/tsdb/caching_bucket.go
@@ -67,15 +67,15 @@ func (cfg *ChunksCacheConfig) Validate() error {
 }
 
 type MetadataCacheConfig struct {
-	CacheBackend
+	CacheBackend `yaml:",inline"`
 
-	TenantsListTTL         time.Duration `json:"tenants_list_ttl"`
-	TenantBlocksListTTL    time.Duration `json:"tenant_blocks_list_ttl"`
-	ChunksListTTL          time.Duration `json:"chunks_list_ttl"`
-	MetafileExistsTTL      time.Duration `json:"metafile_exists_ttl"`
-	MetafileDoesntExistTTL time.Duration `json:"metafile_doesnt_exist_ttl"`
-	MetafileContentTTL     time.Duration `json:"metafile_content_ttl"`
-	MetafileMaxSize        int           `json:"metafile_max_size"`
+	TenantsListTTL         time.Duration `yaml:"tenants_list_ttl"`
+	TenantBlocksListTTL    time.Duration `yaml:"tenant_blocks_list_ttl"`
+	ChunksListTTL          time.Duration `yaml:"chunks_list_ttl"`
+	MetafileExistsTTL      time.Duration `yaml:"metafile_exists_ttl"`
+	MetafileDoesntExistTTL time.Duration `yaml:"metafile_doesnt_exist_ttl"`
+	MetafileContentTTL     time.Duration `yaml:"metafile_content_ttl"`
+	MetafileMaxSize        int           `yaml:"metafile_max_size"`
 }
 
 func (cfg *MetadataCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {

--- a/pkg/storage/tsdb/caching_bucket.go
+++ b/pkg/storage/tsdb/caching_bucket.go
@@ -47,7 +47,7 @@ type ChunksCacheConfig struct {
 
 	SubrangeSize        int64         `yaml:"subrange_size"`
 	MaxGetRangeRequests int           `yaml:"max_get_range_requests"`
-	ObjectSizeTTL       time.Duration `yaml:"object_size_ttl"`
+	AttributesTTL       time.Duration `yaml:"attributes_ttl"`
 	SubrangeTTL         time.Duration `yaml:"subrange_ttl"`
 }
 
@@ -58,7 +58,7 @@ func (cfg *ChunksCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix st
 
 	f.Int64Var(&cfg.SubrangeSize, prefix+"subrange-size", 16000, "Size of each subrange that bucket object is split into for better caching.")
 	f.IntVar(&cfg.MaxGetRangeRequests, prefix+"max-get-range-requests", 3, "Maximum number of sub-GetRange requests that a single GetRange request can be split into when fetching chunks. Zero or negative value = unlimited number of sub-requests.")
-	f.DurationVar(&cfg.ObjectSizeTTL, prefix+"object-size-ttl", 24*time.Hour, "TTL for caching object size for chunks.")
+	f.DurationVar(&cfg.AttributesTTL, prefix+"attributes-ttl", 24*time.Hour, "TTL for caching object size for chunks.")
 	f.DurationVar(&cfg.SubrangeTTL, prefix+"subrange-ttl", 24*time.Hour, "TTL for caching individual chunks subranges.")
 }
 
@@ -106,7 +106,7 @@ func CreateCachingBucket(chunksConfig ChunksCacheConfig, metadataConfig Metadata
 	}
 	if chunksCache != nil {
 		cachingConfigured = true
-		cfg.CacheGetRange("chunks", chunksCache, isTSDBChunkFile, chunksConfig.SubrangeSize, chunksConfig.ObjectSizeTTL, chunksConfig.SubrangeTTL, chunksConfig.MaxGetRangeRequests)
+		cfg.CacheGetRange("chunks", chunksCache, isTSDBChunkFile, chunksConfig.SubrangeSize, chunksConfig.AttributesTTL, chunksConfig.SubrangeTTL, chunksConfig.MaxGetRangeRequests)
 	}
 
 	metadataCache, err := createCache("metadata-cache", metadataConfig.Backend, metadataConfig.Memcached, logger, reg)

--- a/pkg/storage/tsdb/caching_bucket.go
+++ b/pkg/storage/tsdb/caching_bucket.go
@@ -58,7 +58,7 @@ func (cfg *ChunksCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix st
 
 	f.Int64Var(&cfg.SubrangeSize, prefix+"subrange-size", 16000, "Size of each subrange that bucket object is split into for better caching.")
 	f.IntVar(&cfg.MaxGetRangeRequests, prefix+"max-get-range-requests", 3, "Maximum number of sub-GetRange requests that a single GetRange request can be split into when fetching chunks. Zero or negative value = unlimited number of sub-requests.")
-	f.DurationVar(&cfg.AttributesTTL, prefix+"attributes-ttl", 24*time.Hour, "TTL for caching object size for chunks.")
+	f.DurationVar(&cfg.AttributesTTL, prefix+"attributes-ttl", 24*time.Hour, "TTL for caching object attributes for chunks.")
 	f.DurationVar(&cfg.SubrangeTTL, prefix+"subrange-ttl", 24*time.Hour, "TTL for caching individual chunks subranges.")
 }
 

--- a/pkg/storage/tsdb/caching_bucket.go
+++ b/pkg/storage/tsdb/caching_bucket.go
@@ -4,20 +4,42 @@ import (
 	"flag"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/golang/snappy"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/cache"
 	"github.com/thanos-io/thanos/pkg/cacheutil"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	storecache "github.com/thanos-io/thanos/pkg/store/cache"
 )
 
-type ChunksCacheConfig struct {
+type CacheBackend struct {
 	Backend   string                `yaml:"backend"`
 	Memcached MemcachedClientConfig `yaml:"memcached"`
+}
+
+// Validate the config.
+func (cfg *CacheBackend) Validate() error {
+	if cfg.Backend != "" && cfg.Backend != string(storecache.MemcachedBucketCacheProvider) {
+		return fmt.Errorf("unsupported cache backend: %s", cfg.Backend)
+	}
+
+	if cfg.Backend == string(storecache.MemcachedBucketCacheProvider) {
+		if err := cfg.Memcached.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type ChunksCacheConfig struct {
+	CacheBackend `yaml:",inline"`
 
 	SubrangeSize        int64         `yaml:"subrange_size"`
 	MaxGetRangeRequests int           `yaml:"max_get_range_requests"`
@@ -36,47 +58,134 @@ func (cfg *ChunksCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix st
 	f.DurationVar(&cfg.SubrangeTTL, prefix+"subrange-ttl", 24*time.Hour, "TTL for caching individual chunks subranges.")
 }
 
-// Validate the config.
 func (cfg *ChunksCacheConfig) Validate() error {
-	if cfg.Backend != "" && cfg.Backend != string(storecache.MemcachedBucketCacheProvider) {
-		return fmt.Errorf("unsupported cache backend: %s", cfg.Backend)
-	}
-
-	if cfg.Backend == string(storecache.MemcachedBucketCacheProvider) {
-		if err := cfg.Memcached.Validate(); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return cfg.CacheBackend.Validate()
 }
 
-func CreateCachingBucket(chunksConfig ChunksCacheConfig, bkt objstore.Bucket, logger log.Logger, reg prometheus.Registerer) (objstore.Bucket, error) {
-	var chunksCache cache.Cache
+type MetadataCacheConfig struct {
+	CacheBackend
 
-	switch chunksConfig.Backend {
-	case "":
-		// No caching.
-		return bkt, nil
+	TenantsListTTL         time.Duration `json:"tenants_list_ttl"`
+	TenantBlocksListTTL    time.Duration `json:"tenant_blocks_list_ttl"`
+	ChunksListTTL          time.Duration `json:"chunks_list_ttl"`
+	MetafileExistsTTL      time.Duration `json:"metafile_exists_ttl"`
+	MetafileDoesntExistTTL time.Duration `json:"metafile_doesnt_exist_ttl"`
+	MetafileContentTTL     time.Duration `json:"metafile_content_ttl"`
+	MetafileMaxSize        int           `json:"metafile_max_size"`
+}
 
-	case string(storecache.MemcachedBucketCacheProvider):
-		var memcached cacheutil.MemcachedClient
-		memcached, err := cacheutil.NewMemcachedClientWithConfig(logger, "chunks-cache", chunksConfig.Memcached.ToMemcachedClientConfig(), reg)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create memcached client for chunks-cache")
-		}
-		chunksCache = cache.NewMemcachedCache("chunks-cache", logger, memcached, reg)
+func (cfg *MetadataCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
+	f.StringVar(&cfg.Backend, prefix+"backend", "", fmt.Sprintf("Backend for metadata cache, if not empty. Supported values: %s.", storecache.MemcachedBucketCacheProvider))
 
-	default:
-		return nil, errors.Errorf("unsupported cache type: %s", chunksConfig.Backend)
+	cfg.Memcached.RegisterFlagsWithPrefix(f, prefix+"memcached.")
+
+	f.DurationVar(&cfg.TenantsListTTL, prefix+"tenants-list-ttl", 15*time.Minute, "How long to cache list of tenants in the bucket.")
+	f.DurationVar(&cfg.TenantBlocksListTTL, prefix+"tenant-blocks-list-ttl", 15*time.Minute, "How long to cache list of blocks for each tenant.")
+	f.DurationVar(&cfg.TenantBlocksListTTL, prefix+"chunks-list-ttl", 24*time.Hour, "How long to cache list of chunks for a block.")
+
+	f.DurationVar(&cfg.MetafileExistsTTL, prefix+"metafile-exists-ttl", 2*time.Hour, "How long to cache information that block metafile exists.")
+	f.DurationVar(&cfg.MetafileDoesntExistTTL, prefix+"metafile-doesnt-exist-ttl", 15*time.Minute, "How long to cache information that block metafile doesn't exist.")
+	f.DurationVar(&cfg.MetafileContentTTL, prefix+"metafile-content-ttl", 24*time.Hour, "How long to cache content of the metafile.")
+	f.IntVar(&cfg.MetafileMaxSize, prefix+"metafile-max-size", 1*1024*1024, "Maximum size of metafile content to cache.")
+}
+
+func (cfg *MetadataCacheConfig) Validate() error {
+	return cfg.CacheBackend.Validate()
+}
+
+func CreateCachingBucket(chunksConfig ChunksCacheConfig, metadataConfig MetadataCacheConfig, bkt objstore.Bucket, logger log.Logger, reg prometheus.Registerer) (objstore.Bucket, error) {
+	cfg := storecache.NewCachingBucketConfig()
+	cachingConfigured := false
+
+	chunksCache, err := createCache("chunks-cache", chunksConfig.Backend, chunksConfig.Memcached, logger, reg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "chunks-cache")
+	}
+	if chunksCache != nil {
+		cachingConfigured = true
+		cfg.CacheGetRange("chunks", chunksCache, isTSDBChunkFile, chunksConfig.SubrangeSize, chunksConfig.ObjectSizeTTL, chunksConfig.SubrangeTTL, chunksConfig.MaxGetRangeRequests)
 	}
 
-	cfg := storecache.NewCachingBucketConfig()
-	cfg.CacheGetRange("chunks", chunksCache, isTSDBChunkFile, chunksConfig.SubrangeSize, chunksConfig.ObjectSizeTTL, chunksConfig.SubrangeTTL, chunksConfig.MaxGetRangeRequests)
+	metadataCache, err := createCache("metadata-cache", metadataConfig.Backend, metadataConfig.Memcached, logger, reg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "metadata-cache")
+	}
+	if metadataCache != nil {
+		cachingConfigured = true
+
+		cfg.CacheExists("metafile", metadataCache, isMetaFile, metadataConfig.MetafileExistsTTL, metadataConfig.MetafileDoesntExistTTL)
+		cfg.CacheGet("metafile", metadataCache, isMetaFile, metadataConfig.MetafileMaxSize, metadataConfig.MetafileContentTTL, metadataConfig.MetafileExistsTTL, metadataConfig.MetafileDoesntExistTTL)
+
+		cfg.CacheIter("tenants-iter", metadataCache, isTenantsDir, metadataConfig.TenantsListTTL, storecache.JSONIterCodec{})
+		cfg.CacheIter("tenant-blocks-iter", metadataCache, isTenantBlocksDir, metadataConfig.TenantBlocksListTTL, snappyIterCodec{storecache.JSONIterCodec{}})
+		cfg.CacheIter("chunks-iter", metadataCache, isChunksDir, metadataConfig.ChunksListTTL, snappyIterCodec{storecache.JSONIterCodec{}})
+	}
+
+	if !cachingConfigured {
+		// No caching is configured.
+		return bkt, nil
+	}
 
 	return storecache.NewCachingBucket(bkt, cfg, logger, reg)
+}
+
+func createCache(cacheName string, backend string, memcached MemcachedClientConfig, logger log.Logger, reg prometheus.Registerer) (cache.Cache, error) {
+	switch backend {
+	case "":
+		// No caching.
+		return nil, nil
+
+	case string(storecache.MemcachedBucketCacheProvider):
+		var client cacheutil.MemcachedClient
+		client, err := cacheutil.NewMemcachedClientWithConfig(logger, cacheName, memcached.ToMemcachedClientConfig(), prometheus.WrapRegistererWith(prometheus.Labels{"cache": cacheName}, reg))
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create memcached client")
+		}
+		return cache.NewMemcachedCache(cacheName, logger, client, reg), nil
+
+	default:
+		return nil, errors.Errorf("unsupported cache type: %s", backend)
+	}
 }
 
 var chunksMatcher = regexp.MustCompile(`^.*/chunks/\d+$`)
 
 func isTSDBChunkFile(name string) bool { return chunksMatcher.MatchString(name) }
+
+func isMetaFile(name string) bool {
+	return strings.HasSuffix(name, "/"+metadata.MetaFilename) || strings.HasSuffix(name, "/"+metadata.DeletionMarkFilename)
+}
+
+func isTenantsDir(name string) bool {
+	return name == ""
+}
+
+var tenantDirMatcher = regexp.MustCompile("^[^/]+/?$")
+
+func isTenantBlocksDir(name string) bool {
+	return tenantDirMatcher.MatchString(name)
+}
+
+func isChunksDir(name string) bool {
+	return strings.HasSuffix(name, "/chunks")
+}
+
+type snappyIterCodec struct {
+	storecache.IterCodec
+}
+
+func (i snappyIterCodec) Encode(files []string) ([]byte, error) {
+	b, err := i.IterCodec.Encode(files)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
+}
+
+func (i snappyIterCodec) Decode(cachedData []byte) ([]string, error) {
+	b, err := snappy.Decode(nil, cachedData)
+	if err != nil {
+		return nil, errors.Wrap(err, "snappyIterCodec")
+	}
+	return i.IterCodec.Decode(b)
+}

--- a/pkg/storage/tsdb/caching_bucket_test.go
+++ b/pkg/storage/tsdb/caching_bucket_test.go
@@ -1,0 +1,15 @@
+package tsdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTenantDir(t *testing.T) {
+	assert.False(t, isTenantBlocksDir(""))
+	assert.True(t, isTenantBlocksDir("test"))
+	assert.True(t, isTenantBlocksDir("test/"))
+	assert.False(t, isTenantBlocksDir("test/block"))
+	assert.False(t, isTenantBlocksDir("test/block/chunks"))
+}

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -175,19 +175,20 @@ func (cfg *Config) Validate() error {
 
 // BucketStoreConfig holds the config information for Bucket Stores used by the querier
 type BucketStoreConfig struct {
-	SyncDir                  string            `yaml:"sync_dir"`
-	SyncInterval             time.Duration     `yaml:"sync_interval"`
-	MaxChunkPoolBytes        uint64            `yaml:"max_chunk_pool_bytes"`
-	MaxSampleCount           uint64            `yaml:"max_sample_count"`
-	MaxConcurrent            int               `yaml:"max_concurrent"`
-	TenantSyncConcurrency    int               `yaml:"tenant_sync_concurrency"`
-	BlockSyncConcurrency     int               `yaml:"block_sync_concurrency"`
-	MetaSyncConcurrency      int               `yaml:"meta_sync_concurrency"`
-	BinaryIndexHeader        bool              `yaml:"binary_index_header_enabled"`
-	ConsistencyDelay         time.Duration     `yaml:"consistency_delay"`
-	IndexCache               IndexCacheConfig  `yaml:"index_cache"`
-	ChunksCache              ChunksCacheConfig `yaml:"chunks_cache"`
-	IgnoreDeletionMarksDelay time.Duration     `yaml:"ignore_deletion_mark_delay"`
+	SyncDir                  string              `yaml:"sync_dir"`
+	SyncInterval             time.Duration       `yaml:"sync_interval"`
+	MaxChunkPoolBytes        uint64              `yaml:"max_chunk_pool_bytes"`
+	MaxSampleCount           uint64              `yaml:"max_sample_count"`
+	MaxConcurrent            int                 `yaml:"max_concurrent"`
+	TenantSyncConcurrency    int                 `yaml:"tenant_sync_concurrency"`
+	BlockSyncConcurrency     int                 `yaml:"block_sync_concurrency"`
+	MetaSyncConcurrency      int                 `yaml:"meta_sync_concurrency"`
+	BinaryIndexHeader        bool                `yaml:"binary_index_header_enabled"`
+	ConsistencyDelay         time.Duration       `yaml:"consistency_delay"`
+	IndexCache               IndexCacheConfig    `yaml:"index_cache"`
+	ChunksCache              ChunksCacheConfig   `yaml:"chunks_cache"`
+	MetadataCache            MetadataCacheConfig `yaml:"metadata_cache"`
+	IgnoreDeletionMarksDelay time.Duration       `yaml:"ignore_deletion_mark_delay"`
 
 	// Controls what is the ratio of postings offsets store will hold in memory.
 	// Larger value will keep less offsets, which will increase CPU cycles needed for query touching those postings.
@@ -201,6 +202,7 @@ type BucketStoreConfig struct {
 func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.IndexCache.RegisterFlagsWithPrefix(f, "experimental.tsdb.bucket-store.index-cache.")
 	cfg.ChunksCache.RegisterFlagsWithPrefix(f, "experimental.tsdb.bucket-store.chunks-cache.")
+	cfg.MetadataCache.RegisterFlagsWithPrefix(f, "experimental.tsdb.bucket-store.metadata-cache.")
 
 	f.StringVar(&cfg.SyncDir, "experimental.tsdb.bucket-store.sync-dir", "tsdb-sync", "Directory to store synchronized TSDB index headers.")
 	f.DurationVar(&cfg.SyncInterval, "experimental.tsdb.bucket-store.sync-interval", 5*time.Minute, "How frequently scan the bucket to look for changes (new blocks shipped by ingesters and blocks removed by retention or compaction). 0 disables it.")
@@ -227,6 +229,10 @@ func (cfg *BucketStoreConfig) Validate() error {
 	err = cfg.ChunksCache.Validate()
 	if err != nil {
 		return errors.Wrap(err, "chunks-cache configuration")
+	}
+	err = cfg.MetadataCache.Validate()
+	if err != nil {
+		return errors.Wrap(err, "metadata-cache configuration")
 	}
 	return nil
 }

--- a/pkg/storage/tsdb/user_bucket_client.go
+++ b/pkg/storage/tsdb/user_bucket_client.go
@@ -83,9 +83,9 @@ func (b *UserBucketReaderClient) IsObjNotFoundErr(err error) bool {
 	return b.bucket.IsObjNotFoundErr(err)
 }
 
-// ObjectSize returns the size of the specified object.
-func (b *UserBucketReaderClient) ObjectSize(ctx context.Context, name string) (uint64, error) {
-	return b.bucket.ObjectSize(ctx, b.fullName(name))
+// Attributes returns attributes of the specified object.
+func (b *UserBucketReaderClient) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
+	return b.bucket.Attributes(ctx, b.fullName(name))
 }
 
 // ReaderWithExpectedErrs allows to specify a filter that marks certain errors as expected, so it will not increment

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -55,7 +55,7 @@ type BucketStores struct {
 
 // NewBucketStores makes a new BucketStores.
 func NewBucketStores(cfg tsdb.Config, filters []block.MetadataFilter, bucketClient objstore.Bucket, logLevel logging.Level, logger log.Logger, reg prometheus.Registerer) (*BucketStores, error) {
-	cachingBucket, err := tsdb.CreateCachingBucket(cfg.BucketStore.ChunksCache, bucketClient, logger, reg)
+	cachingBucket, err := tsdb.CreateCachingBucket(cfg.BucketStore.ChunksCache, cfg.BucketStore.MetadataCache, bucketClient, logger, reg)
 	if err != nil {
 		return nil, errors.Wrapf(err, "create caching bucket")
 	}

--- a/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/binary_reader.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/block/indexheader/binary_reader.go
@@ -131,9 +131,9 @@ type chunkedIndexReader struct {
 
 func newChunkedIndexReader(ctx context.Context, bkt objstore.BucketReader, id ulid.ULID) (*chunkedIndexReader, int, error) {
 	indexFilepath := filepath.Join(id.String(), block.IndexFilename)
-	size, err := bkt.ObjectSize(ctx, indexFilepath)
+	attrs, err := bkt.Attributes(ctx, indexFilepath)
 	if err != nil {
-		return nil, 0, errors.Wrapf(err, "get object size of %s", indexFilepath)
+		return nil, 0, errors.Wrapf(err, "get object attributes of %s", indexFilepath)
 	}
 
 	rc, err := bkt.GetRange(ctx, indexFilepath, 0, index.HeaderLen)
@@ -164,7 +164,7 @@ func newChunkedIndexReader(ctx context.Context, bkt objstore.BucketReader, id ul
 	ir := &chunkedIndexReader{
 		ctx:  ctx,
 		path: indexFilepath,
-		size: size,
+		size: uint64(attrs.Size),
 		bkt:  bkt,
 	}
 

--- a/vendor/github.com/thanos-io/thanos/pkg/cacheutil/memcached_client.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/cacheutil/memcached_client.go
@@ -182,12 +182,14 @@ func NewMemcachedClientWithConfig(logger log.Logger, name string, config Memcach
 	client.Timeout = config.Timeout
 	client.MaxIdleConns = config.MaxIdleConnections
 
-	return newMemcachedClient(logger, name, client, selector, config, reg)
+	if reg != nil {
+		reg = prometheus.WrapRegistererWith(prometheus.Labels{"name": name}, reg)
+	}
+	return newMemcachedClient(logger, client, selector, config, reg)
 }
 
 func newMemcachedClient(
 	logger log.Logger,
-	name string,
 	client memcachedClientBackend,
 	selector *MemcachedJumpHashSelector,
 	config MemcachedClientConfig,
@@ -196,7 +198,7 @@ func newMemcachedClient(
 	dnsProvider := dns.NewProvider(
 		logger,
 		extprom.WrapRegistererWithPrefix("thanos_memcached_", reg),
-		dns.ResolverType(dns.GolangResolverType),
+		dns.GolangResolverType,
 	)
 
 	c := &memcachedClient{
@@ -214,34 +216,30 @@ func newMemcachedClient(
 	}
 
 	c.operations = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name:        "thanos_memcached_operations_total",
-		Help:        "Total number of operations against memcached.",
-		ConstLabels: prometheus.Labels{"name": name},
+		Name: "thanos_memcached_operations_total",
+		Help: "Total number of operations against memcached.",
 	}, []string{"operation"})
 	c.operations.WithLabelValues(opGetMulti)
 	c.operations.WithLabelValues(opSet)
 
 	c.failures = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name:        "thanos_memcached_operation_failures_total",
-		Help:        "Total number of operations against memcached that failed.",
-		ConstLabels: prometheus.Labels{"name": name},
+		Name: "thanos_memcached_operation_failures_total",
+		Help: "Total number of operations against memcached that failed.",
 	}, []string{"operation"})
 	c.failures.WithLabelValues(opGetMulti)
 	c.failures.WithLabelValues(opSet)
 
 	c.skipped = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name:        "thanos_memcached_operation_skipped_total",
-		Help:        "Total number of operations against memcached that have been skipped.",
-		ConstLabels: prometheus.Labels{"name": name},
+		Name: "thanos_memcached_operation_skipped_total",
+		Help: "Total number of operations against memcached that have been skipped.",
 	}, []string{"operation", "reason"})
 	c.skipped.WithLabelValues(opGetMulti, reasonMaxItemSize)
 	c.skipped.WithLabelValues(opSet, reasonMaxItemSize)
 
 	c.duration = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-		Name:        "thanos_memcached_operation_duration_seconds",
-		Help:        "Duration of operations against memcached.",
-		ConstLabels: prometheus.Labels{"name": name},
-		Buckets:     []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 3, 6, 10},
+		Name:    "thanos_memcached_operation_duration_seconds",
+		Help:    "Duration of operations against memcached.",
+		Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 3, 6, 10},
 	}, []string{"operation"})
 	c.duration.WithLabelValues(opGetMulti)
 	c.duration.WithLabelValues(opSet)
@@ -273,7 +271,7 @@ func (c *memcachedClient) Stop() {
 	c.workers.Wait()
 }
 
-func (c *memcachedClient) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) (err error) {
+func (c *memcachedClient) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error {
 	// Skip hitting memcached at all if the item is bigger than the max allowed size.
 	if c.config.MaxItemSize > 0 && uint64(len(value)) > uint64(c.config.MaxItemSize) {
 		c.skipped.WithLabelValues(opSet, reasonMaxItemSize).Inc()
@@ -284,6 +282,7 @@ func (c *memcachedClient) SetAsync(ctx context.Context, key string, value []byte
 		start := time.Now()
 		c.operations.WithLabelValues(opSet).Inc()
 
+		var err error
 		tracing.DoInSpan(ctx, "memcached_set", func(ctx context.Context) {
 			err = c.client.Set(&memcache.Item{
 				Key:        key,

--- a/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go
@@ -487,7 +487,7 @@ func (e RetryError) Error() string {
 // IsRetryError returns true if the base error is a RetryError.
 // If a multierror is passed, all errors must be retriable.
 func IsRetryError(err error) bool {
-	if multiErr, ok := err.(terrors.MultiError); ok {
+	if multiErr, ok := errors.Cause(err).(terrors.MultiError); ok {
 		for _, err := range multiErr {
 			if _, ok := errors.Cause(err).(RetryError); !ok {
 				return false

--- a/vendor/github.com/thanos-io/thanos/pkg/objstore/azure/azure.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/objstore/azure/azure.go
@@ -231,18 +231,23 @@ func (b *Bucket) GetRange(ctx context.Context, name string, off, length int64) (
 	return b.getBlobReader(ctx, name, off, length)
 }
 
-// ObjectSize returns the size of the specified object.
-func (b *Bucket) ObjectSize(ctx context.Context, name string) (uint64, error) {
+// Attributes returns information about the specified object.
+func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
 	blobURL, err := getBlobURL(ctx, *b.config, name)
 	if err != nil {
-		return 0, errors.Wrapf(err, "cannot get Azure blob URL, blob: %s", name)
+		return objstore.ObjectAttributes{}, errors.Wrapf(err, "cannot get Azure blob URL, blob: %s", name)
 	}
+
 	var props *blob.BlobGetPropertiesResponse
 	props, err = blobURL.GetProperties(ctx, blob.BlobAccessConditions{})
 	if err != nil {
-		return 0, err
+		return objstore.ObjectAttributes{}, err
 	}
-	return uint64(props.ContentLength()), nil
+
+	return objstore.ObjectAttributes{
+		Size:         props.ContentLength(),
+		LastModified: props.LastModified(),
+	}, nil
 }
 
 // Exists checks if the given object exists.

--- a/vendor/github.com/thanos-io/thanos/pkg/objstore/filesystem/filesystem.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/objstore/filesystem/filesystem.go
@@ -107,14 +107,18 @@ func (r *rangeReaderCloser) Close() error {
 	return r.f.Close()
 }
 
-// ObjectSize returns the size of the specified object.
-func (b *Bucket) ObjectSize(_ context.Context, name string) (uint64, error) {
+// Attributes returns information about the specified object.
+func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
 	file := filepath.Join(b.rootDir, name)
-	st, err := os.Stat(file)
+	stat, err := os.Stat(file)
 	if err != nil {
-		return 0, errors.Wrapf(err, "stat %s", file)
+		return objstore.ObjectAttributes{}, errors.Wrapf(err, "stat %s", file)
 	}
-	return uint64(st.Size()), nil
+
+	return objstore.ObjectAttributes{
+		Size:         stat.Size(),
+		LastModified: stat.ModTime(),
+	}, nil
 }
 
 // GetRange returns a new range reader for the given object name and range.

--- a/vendor/github.com/thanos-io/thanos/pkg/objstore/gcs/gcs.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/objstore/gcs/gcs.go
@@ -125,13 +125,17 @@ func (b *Bucket) GetRange(ctx context.Context, name string, off, length int64) (
 	return b.bkt.Object(name).NewRangeReader(ctx, off, length)
 }
 
-// ObjectSize returns the size of the specified object.
-func (b *Bucket) ObjectSize(ctx context.Context, name string) (uint64, error) {
-	obj, err := b.bkt.Object(name).Attrs(ctx)
+// Attributes returns information about the specified object.
+func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
+	attrs, err := b.bkt.Object(name).Attrs(ctx)
 	if err != nil {
-		return 0, err
+		return objstore.ObjectAttributes{}, err
 	}
-	return uint64(obj.Size), nil
+
+	return objstore.ObjectAttributes{
+		Size:         attrs.Size,
+		LastModified: attrs.Updated,
+	}, nil
 }
 
 // Handle returns the underlying GCS bucket handle.

--- a/vendor/github.com/thanos-io/thanos/pkg/objstore/inmem.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/objstore/inmem.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -22,12 +23,16 @@ var errNotFound = errors.New("inmem: object not found")
 type InMemBucket struct {
 	mtx     sync.RWMutex
 	objects map[string][]byte
+	attrs   map[string]ObjectAttributes
 }
 
 // NewInMemBucket returns a new in memory Bucket.
 // NOTE: Returned bucket is just a naive in memory bucket implementation. For test use cases only.
 func NewInMemBucket() *InMemBucket {
-	return &InMemBucket{objects: map[string][]byte{}}
+	return &InMemBucket{
+		objects: map[string][]byte{},
+		attrs:   map[string]ObjectAttributes{},
+	}
 }
 
 // Objects returns internally stored objects.
@@ -144,15 +149,15 @@ func (b *InMemBucket) Exists(_ context.Context, name string) (bool, error) {
 	return ok, nil
 }
 
-// ObjectSize returns the size of the specified object.
-func (b *InMemBucket) ObjectSize(_ context.Context, name string) (uint64, error) {
+// Attributes returns information about the specified object.
+func (b *InMemBucket) Attributes(_ context.Context, name string) (ObjectAttributes, error) {
 	b.mtx.RLock()
-	file, ok := b.objects[name]
+	attrs, ok := b.attrs[name]
 	b.mtx.RUnlock()
 	if !ok {
-		return 0, errNotFound
+		return ObjectAttributes{}, errNotFound
 	}
-	return uint64(len(file)), nil
+	return attrs, nil
 }
 
 // Upload writes the file specified in src to into the memory.
@@ -164,6 +169,10 @@ func (b *InMemBucket) Upload(_ context.Context, name string, r io.Reader) error 
 		return err
 	}
 	b.objects[name] = body
+	b.attrs[name] = ObjectAttributes{
+		Size:         int64(len(body)),
+		LastModified: time.Now(),
+	}
 	return nil
 }
 
@@ -175,6 +184,7 @@ func (b *InMemBucket) Delete(_ context.Context, name string) error {
 		return errNotFound
 	}
 	delete(b.objects, name)
+	delete(b.attrs, name)
 	return nil
 }
 

--- a/vendor/github.com/thanos-io/thanos/pkg/objstore/s3/s3.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/objstore/s3/s3.go
@@ -332,13 +332,17 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
 	return nil
 }
 
-// ObjectSize returns the size of the specified object.
-func (b *Bucket) ObjectSize(_ context.Context, name string) (uint64, error) {
+// Attributes returns information about the specified object.
+func (b *Bucket) Attributes(_ context.Context, name string) (objstore.ObjectAttributes, error) {
 	objInfo, err := b.client.StatObject(b.name, name, minio.StatObjectOptions{})
 	if err != nil {
-		return 0, err
+		return objstore.ObjectAttributes{}, err
 	}
-	return uint64(objInfo.Size), nil
+
+	return objstore.ObjectAttributes{
+		Size:         objInfo.Size,
+		LastModified: objInfo.LastModified,
+	}, nil
 }
 
 // Delete removes the object with the given name.

--- a/vendor/github.com/thanos-io/thanos/pkg/objstore/swift/swift.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/objstore/swift/swift.go
@@ -128,14 +128,18 @@ func (c *Container) GetRange(ctx context.Context, name string, off, length int64
 	return response.Body, response.Err
 }
 
-// ObjectSize returns the size of the specified object.
-func (c *Container) ObjectSize(ctx context.Context, name string) (uint64, error) {
+// Attributes returns information about the specified object.
+func (c *Container) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
 	response := objects.Get(c.client, c.name, name, nil)
 	headers, err := response.Extract()
 	if err != nil {
-		return 0, err
+		return objstore.ObjectAttributes{}, err
 	}
-	return uint64(headers.ContentLength), nil
+
+	return objstore.ObjectAttributes{
+		Size:         headers.ContentLength,
+		LastModified: headers.LastModified,
+	}, nil
 }
 
 // Exists checks if the given object exists.

--- a/vendor/github.com/thanos-io/thanos/pkg/objstore/testing.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/objstore/testing.go
@@ -94,7 +94,7 @@ func AcceptanceTest(t *testing.T, bkt Bucket) {
 	testutil.Ok(t, err)
 	testutil.Assert(t, !ok, "expected not exits")
 
-	_, err = bkt.ObjectSize(ctx, "id1/obj_1.some")
+	_, err = bkt.Attributes(ctx, "id1/obj_1.some")
 	testutil.NotOk(t, err)
 	testutil.Assert(t, bkt.IsObjNotFoundErr(err), "expected not found error but got %s", err)
 
@@ -110,9 +110,9 @@ func AcceptanceTest(t *testing.T, bkt Bucket) {
 	testutil.Equals(t, "@test-data@", string(content))
 
 	// Check if we can get the correct size.
-	sz, err := bkt.ObjectSize(ctx, "id1/obj_1.some")
+	attrs, err := bkt.Attributes(ctx, "id1/obj_1.some")
 	testutil.Ok(t, err)
-	testutil.Assert(t, sz == 11, "expected size to be equal to 11")
+	testutil.Assert(t, attrs.Size == 11, "expected size to be equal to 11")
 
 	rc2, err := bkt.GetRange(ctx, "id1/obj_1.some", 1, 3)
 	testutil.Ok(t, err)

--- a/vendor/github.com/thanos-io/thanos/pkg/store/cache/caching_bucket.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/store/cache/caching_bucket.go
@@ -6,7 +6,6 @@ package storecache
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -36,7 +35,7 @@ const (
 	opGetRange   = "getrange"
 	opIter       = "iter"
 	opExists     = "exists"
-	opObjectSize = "objectsize"
+	opAttributes = "attributes"
 )
 
 var errObjNotFound = errors.Errorf("object not found")
@@ -291,50 +290,58 @@ func (cb *CachingBucket) GetRange(ctx context.Context, name string, off, length 
 	return r, err
 }
 
-func (cb *CachingBucket) ObjectSize(ctx context.Context, name string) (uint64, error) {
-	cfgName, cfg := cb.cfg.findObjectSizeConfig(name)
+func (cb *CachingBucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
+	cfgName, cfg := cb.cfg.findAttributesConfig(name)
 	if cfg == nil {
-		return cb.Bucket.ObjectSize(ctx, name)
+		return cb.Bucket.Attributes(ctx, name)
 	}
 
-	return cb.cachedObjectSize(ctx, name, cfgName, cfg.cache, cfg.ttl)
+	return cb.cachedAttributes(ctx, name, cfgName, cfg.cache, cfg.ttl)
 }
 
-func (cb *CachingBucket) cachedObjectSize(ctx context.Context, name string, cfgName string, cache cache.Cache, ttl time.Duration) (uint64, error) {
-	key := cachingKeyObjectSize(name)
+func (cb *CachingBucket) cachedAttributes(ctx context.Context, name string, cfgName string, cache cache.Cache, ttl time.Duration) (objstore.ObjectAttributes, error) {
+	key := cachingKeyAttributes(name)
 
-	cb.operationRequests.WithLabelValues(opObjectSize, cfgName).Inc()
+	cb.operationRequests.WithLabelValues(opAttributes, cfgName).Inc()
 
 	hits := cache.Fetch(ctx, []string{key})
-	if s := hits[key]; len(s) == 8 {
-		cb.operationHits.WithLabelValues(opObjectSize, cfgName).Inc()
-		return binary.BigEndian.Uint64(s), nil
+	if raw, ok := hits[key]; ok {
+		var attrs objstore.ObjectAttributes
+		err := json.Unmarshal(raw, &attrs)
+		if err == nil {
+			cb.operationHits.WithLabelValues(opAttributes, cfgName).Inc()
+			return attrs, nil
+		}
+
+		level.Warn(cb.logger).Log("msg", "failed to decode cached Attributes result", "key", key, "err", err)
 	}
 
-	size, err := cb.Bucket.ObjectSize(ctx, name)
+	attrs, err := cb.Bucket.Attributes(ctx, name)
 	if err != nil {
-		return 0, err
+		return objstore.ObjectAttributes{}, err
 	}
 
-	var buf [8]byte
-	binary.BigEndian.PutUint64(buf[:], size)
-	cache.Store(ctx, map[string][]byte{key: buf[:]}, ttl)
+	if raw, err := json.Marshal(attrs); err == nil {
+		cache.Store(ctx, map[string][]byte{key: raw}, ttl)
+	} else {
+		level.Warn(cb.logger).Log("msg", "failed to encode cached Attributes result", "key", key, "err", err)
+	}
 
-	return size, nil
+	return attrs, nil
 }
 
 func (cb *CachingBucket) cachedGetRange(ctx context.Context, name string, offset, length int64, cfgName string, cfg *getRangeConfig) (io.ReadCloser, error) {
 	cb.operationRequests.WithLabelValues(opGetRange, cfgName).Inc()
 	cb.requestedGetRangeBytes.WithLabelValues(cfgName).Add(float64(length))
 
-	size, err := cb.cachedObjectSize(ctx, name, cfgName, cfg.cache, cfg.objectSizeTTL)
+	attrs, err := cb.cachedAttributes(ctx, name, cfgName, cfg.cache, cfg.attributesTTL)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get size of object: %s", name)
+		return nil, errors.Wrapf(err, "failed to get object attributes: %s", name)
 	}
 
 	// If length goes over object size, adjust length. We use it later to limit number of read bytes.
-	if uint64(offset+length) > size {
-		length = int64(size - uint64(offset))
+	if offset+length > attrs.Size {
+		length = attrs.Size - offset
 	}
 
 	// Start and end range are subrange-aligned offsets into object, that we're going to read.
@@ -347,9 +354,9 @@ func (cb *CachingBucket) cachedGetRange(ctx context.Context, name string, offset
 	// The very last subrange in the object may have length that is not divisible by subrange size.
 	lastSubrangeOffset := endRange - cfg.subrangeSize
 	lastSubrangeLength := int(cfg.subrangeSize)
-	if uint64(endRange) > size {
-		lastSubrangeOffset = (int64(size) / cfg.subrangeSize) * cfg.subrangeSize
-		lastSubrangeLength = int(int64(size) - lastSubrangeOffset)
+	if endRange > attrs.Size {
+		lastSubrangeOffset = (attrs.Size / cfg.subrangeSize) * cfg.subrangeSize
+		lastSubrangeLength = int(attrs.Size - lastSubrangeOffset)
 	}
 
 	numSubranges := (endRange - startRange) / cfg.subrangeSize
@@ -360,8 +367,8 @@ func (cb *CachingBucket) cachedGetRange(ctx context.Context, name string, offset
 	totalRequestedBytes := int64(0)
 	for off := startRange; off < endRange; off += cfg.subrangeSize {
 		end := off + cfg.subrangeSize
-		if end > int64(size) {
-			end = int64(size)
+		if end > attrs.Size {
+			end = attrs.Size
 		}
 		totalRequestedBytes += (end - off)
 
@@ -489,8 +496,8 @@ func mergeRanges(input []rng, limit int64) []rng {
 	return input[:last+1]
 }
 
-func cachingKeyObjectSize(name string) string {
-	return fmt.Sprintf("size:%s", name)
+func cachingKeyAttributes(name string) string {
+	return fmt.Sprintf("attrs:%s", name)
 }
 
 func cachingKeyObjectSubrange(name string, start int64, end int64) string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -534,7 +534,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thanos-io/thanos v0.12.3-0.20200520075802-806479182a6b
+# github.com/thanos-io/thanos v0.12.3-0.20200524133339-079ad4274d5b
 github.com/thanos-io/thanos/pkg/block
 github.com/thanos-io/thanos/pkg/block/indexheader
 github.com/thanos-io/thanos/pkg/block/metadata


### PR DESCRIPTION
**What this PR does**: This PR adds support for caching metadata (meta files, iteration results) to blocks storage, using caching bucket from Thanos. Caching bucket is configured with Cortex usage of blocks in mind (caching top level directory with users, list of blocks per user, content of meta.json and deletion mark files, list of chunks directory).

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
