### PR TITLE
Remove upload grace period

### DIFF
--- a/development/tsdb-blocks-storage-s3-single-binary/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3-single-binary/config/cortex.yaml
@@ -37,6 +37,10 @@ store_gateway:
       consul:
         host: consul:8500
 
+querier:
+  blocks_consistency_check:
+    enabled: true
+
 tsdb:
   dir: /data/cortex-tsdb-ingester
   ship_interval: 1m

--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -32,6 +32,9 @@ querier:
   # Used when the blocks sharding is disabled.
   store_gateway_addresses: store-gateway-1:9008,store-gateway-2:9009
 
+  blocks_consistency_check:
+    enabled: true
+
 tsdb:
   store_gateway_enabled: true
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -672,11 +672,6 @@ blocks_consistency_check:
   # blocks have been queried.
   # CLI flag: -experimental.querier.blocks-consistency-check.enabled
   [enabled: <boolean> | default = false]
-
-  # The grace period allowed before a new block is included in the consistency
-  # check.
-  # CLI flag: -experimental.querier.blocks-consistency-check.upload-grace-period
-  [upload_grace_period: <duration> | default = 1h]
 ```
 
 ### `query_frontend_config`

--- a/pkg/querier/block_meta.go
+++ b/pkg/querier/block_meta.go
@@ -1,0 +1,26 @@
+package querier
+
+import (
+	"time"
+
+	"github.com/oklog/ulid"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+)
+
+// BlockMeta is a struct extending the Thanos block metadata and adding
+// Cortex-specific data too.
+type BlockMeta struct {
+	metadata.Meta
+
+	// UploadedAt is the timestamp when the block has been completed to be uploaded
+	// to the storage.
+	UploadedAt time.Time
+}
+
+func getULIDsFromBlockMetas(metas []*BlockMeta) []ulid.ULID {
+	ids := make([]ulid.ULID, len(metas))
+	for i, m := range metas {
+		ids[i] = m.ULID
+	}
+	return ids
+}

--- a/pkg/querier/blocks_consistency_checker.go
+++ b/pkg/querier/blocks_consistency_checker.go
@@ -77,7 +77,7 @@ func (c *BlocksConsistencyChecker) Check(expectedBlocks []*BlockMeta, knownDelet
 			deletionTime := time.Unix(mark.DeletionTime, 0)
 
 			if c.deletionGracePeriod > 0 && time.Since(deletionTime) > c.deletionGracePeriod {
-				level.Debug(c.logger).Log("msg", "block skipped from consistency check because marked for deletion", "block", meta.ULID.String(), "deletionTime", deletionTime.String())
+				level.Debug(c.logger).Log("msg", "block skipped from consistency check because it is marked for deletion", "block", meta.ULID.String(), "deletionTime", deletionTime.String())
 				continue
 			}
 		}

--- a/pkg/querier/blocks_consistency_checker.go
+++ b/pkg/querier/blocks_consistency_checker.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -15,15 +17,17 @@ import (
 type BlocksConsistencyChecker struct {
 	uploadGracePeriod   time.Duration
 	deletionGracePeriod time.Duration
+	logger              log.Logger
 
 	checksTotal  prometheus.Counter
 	checksFailed prometheus.Counter
 }
 
-func NewBlocksConsistencyChecker(uploadGracePeriod, deletionGracePeriod time.Duration, reg prometheus.Registerer) *BlocksConsistencyChecker {
+func NewBlocksConsistencyChecker(uploadGracePeriod, deletionGracePeriod time.Duration, logger log.Logger, reg prometheus.Registerer) *BlocksConsistencyChecker {
 	return &BlocksConsistencyChecker{
 		uploadGracePeriod:   uploadGracePeriod,
 		deletionGracePeriod: deletionGracePeriod,
+		logger:              logger,
 		checksTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_querier_blocks_consistency_checks_total",
 			Help: "Total number of consistency checks run on queried blocks.",
@@ -35,7 +39,7 @@ func NewBlocksConsistencyChecker(uploadGracePeriod, deletionGracePeriod time.Dur
 	}
 }
 
-func (c *BlocksConsistencyChecker) Check(expectedBlocks []ulid.ULID, knownDeletionMarks map[ulid.ULID]*metadata.DeletionMark, queriedBlocks map[string][]hintspb.Block) error {
+func (c *BlocksConsistencyChecker) Check(expectedBlocks []*BlockMeta, knownDeletionMarks map[ulid.ULID]*metadata.DeletionMark, queriedBlocks map[string][]hintspb.Block) error {
 	c.checksTotal.Inc()
 
 	// Reverse the map of queried blocks, so that we can easily look for missing ones
@@ -52,7 +56,7 @@ func (c *BlocksConsistencyChecker) Check(expectedBlocks []ulid.ULID, knownDeleti
 	missingBlocks := map[string][]string{}
 	var missingBlockIDs []string
 
-	for _, blockID := range expectedBlocks {
+	for _, meta := range expectedBlocks {
 		// Some recently uploaded blocks, already discovered by the querier, may not have been discovered
 		// and loaded by the store-gateway yet. In order to avoid false positives, we grant some time
 		// to the store-gateway to discover them. It's safe to exclude recently uploaded blocks because:
@@ -60,7 +64,8 @@ func (c *BlocksConsistencyChecker) Check(expectedBlocks []ulid.ULID, knownDeleti
 		//   on the configured retention period).
 		// - Blocks uploaded by compactor: the source blocks are marked for deletion but will continue to be
 		//   queried by store-gateways for a while (depends on the configured deletion marks delay).
-		if ulid.Now()-blockID.Time() < uint64(c.uploadGracePeriod.Milliseconds()) {
+		if c.uploadGracePeriod > 0 && time.Since(meta.UploadedAt) < c.uploadGracePeriod {
+			level.Debug(c.logger).Log("msg", "block skipped from consistency check because recently uploaded", "block", meta.ULID.String(), "uploadedAt", meta.UploadedAt.String())
 			continue
 		}
 
@@ -68,13 +73,16 @@ func (c *BlocksConsistencyChecker) Check(expectedBlocks []ulid.ULID, knownDeleti
 		// on blocks that can't be queried because they were offloaded. For this reason, we don't run the consistency check on any block
 		// which has been marked for deletion more then "grace period" time ago. Basically, the grace period is the time
 		// we still expect a block marked for deletion to be still queried.
-		if mark := knownDeletionMarks[blockID]; mark != nil {
-			if time.Since(time.Unix(mark.DeletionTime, 0)) > c.deletionGracePeriod {
+		if mark := knownDeletionMarks[meta.ULID]; mark != nil {
+			deletionTime := time.Unix(mark.DeletionTime, 0)
+
+			if c.deletionGracePeriod > 0 && time.Since(deletionTime) > c.deletionGracePeriod {
+				level.Debug(c.logger).Log("msg", "block skipped from consistency check because marked for deletion", "block", meta.ULID.String(), "deletionTime", deletionTime.String())
 				continue
 			}
 		}
 
-		id := blockID.String()
+		id := meta.ULID.String()
 		if gatewayAddrs, ok := actualBlocks[id]; !ok {
 			missingBlocks[id] = gatewayAddrs
 			missingBlockIDs = append(missingBlockIDs, id)

--- a/pkg/querier/blocks_consistency_checker.go
+++ b/pkg/querier/blocks_consistency_checker.go
@@ -65,7 +65,7 @@ func (c *BlocksConsistencyChecker) Check(expectedBlocks []*BlockMeta, knownDelet
 		// - Blocks uploaded by compactor: the source blocks are marked for deletion but will continue to be
 		//   queried by store-gateways for a while (depends on the configured deletion marks delay).
 		if c.uploadGracePeriod > 0 && time.Since(meta.UploadedAt) < c.uploadGracePeriod {
-			level.Debug(c.logger).Log("msg", "block skipped from consistency check because recently uploaded", "block", meta.ULID.String(), "uploadedAt", meta.UploadedAt.String())
+			level.Debug(c.logger).Log("msg", "block skipped from consistency check because it was uploaded recently", "block", meta.ULID.String(), "uploadedAt", meta.UploadedAt.String())
 			continue
 		}
 

--- a/pkg/querier/blocks_scanner_test.go
+++ b/pkg/querier/blocks_scanner_test.go
@@ -44,12 +44,15 @@ func TestBlocksScanner_InitialScan(t *testing.T) {
 	require.Equal(t, 2, len(blocks))
 	assert.Equal(t, user1Block2.ULID, blocks[0].ULID)
 	assert.Equal(t, user1Block1.ULID, blocks[1].ULID)
+	assert.WithinDuration(t, time.Now(), blocks[0].UploadedAt, 5*time.Second)
+	assert.WithinDuration(t, time.Now(), blocks[1].UploadedAt, 5*time.Second)
 	assert.Empty(t, deletionMarks)
 
 	blocks, deletionMarks, err = s.GetBlocks("user-2", 0, 30)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(blocks))
 	assert.Equal(t, user2Block1.ULID, blocks[0].ULID)
+	assert.WithinDuration(t, time.Now(), blocks[0].UploadedAt, 5*time.Second)
 	assert.Equal(t, map[ulid.ULID]*metadata.DeletionMark{
 		user2Block1.ULID: &user2Mark1,
 	}, deletionMarks)
@@ -154,6 +157,8 @@ func TestBlocksScanner_PeriodicScanFindsNewUser(t *testing.T) {
 	require.Equal(t, 2, len(blocks))
 	assert.Equal(t, block2.ULID, blocks[0].ULID)
 	assert.Equal(t, block1.ULID, blocks[1].ULID)
+	assert.WithinDuration(t, time.Now(), blocks[0].UploadedAt, 5*time.Second)
+	assert.WithinDuration(t, time.Now(), blocks[1].UploadedAt, 5*time.Second)
 	assert.Equal(t, map[ulid.ULID]*metadata.DeletionMark{
 		block2.ULID: &mark2,
 	}, deletionMarks)
@@ -172,6 +177,7 @@ func TestBlocksScanner_PeriodicScanFindsNewBlock(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(blocks))
 	assert.Equal(t, block1.ULID, blocks[0].ULID)
+	assert.WithinDuration(t, time.Now(), blocks[0].UploadedAt, 5*time.Second)
 	assert.Empty(t, deletionMarks)
 
 	block2 := mockStorageBlock(t, bucket, "user-1", 20, 30)
@@ -184,6 +190,8 @@ func TestBlocksScanner_PeriodicScanFindsNewBlock(t *testing.T) {
 	require.Equal(t, 2, len(blocks))
 	assert.Equal(t, block2.ULID, blocks[0].ULID)
 	assert.Equal(t, block1.ULID, blocks[1].ULID)
+	assert.WithinDuration(t, time.Now(), blocks[0].UploadedAt, 5*time.Second)
+	assert.WithinDuration(t, time.Now(), blocks[1].UploadedAt, 5*time.Second)
 	assert.Empty(t, deletionMarks)
 }
 

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -52,7 +52,7 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		finderResult   []*metadata.Meta
+		finderResult   []*BlockMeta
 		finderErr      error
 		storeSetResult []BlocksStoreClient
 		storeSetErr    error
@@ -68,17 +68,17 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 			expectedErr: "unable to find blocks",
 		},
 		"error while getting clients to query the store-gateway": {
-			finderResult: []*metadata.Meta{
-				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
-				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			finderResult: []*BlockMeta{
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
 			storeSetErr: errors.New("no client found"),
 			expectedErr: "no client found",
 		},
 		"a single store-gateway instance holds the required blocks (single returned series)": {
-			finderResult: []*metadata.Meta{
-				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
-				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			finderResult: []*BlockMeta{
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
 			storeSetResult: []BlocksStoreClient{
 				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
@@ -98,9 +98,9 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 			},
 		},
 		"a single store-gateway instance holds the required blocks (multiple returned series)": {
-			finderResult: []*metadata.Meta{
-				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
-				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			finderResult: []*BlockMeta{
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
 			storeSetResult: []BlocksStoreClient{
 				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
@@ -126,9 +126,9 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 			},
 		},
 		"multiple store-gateway instances holds the required blocks without overlapping blocks (single returned series)": {
-			finderResult: []*metadata.Meta{
-				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
-				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			finderResult: []*BlockMeta{
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
 			storeSetResult: []BlocksStoreClient{
 				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
@@ -151,9 +151,9 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 			},
 		},
 		"multiple store-gateway instances holds the required blocks with overlapping blocks (single returned series)": {
-			finderResult: []*metadata.Meta{
-				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
-				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			finderResult: []*BlockMeta{
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
 			storeSetResult: []BlocksStoreClient{
 				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
@@ -177,9 +177,9 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 			},
 		},
 		"multiple store-gateway instances holds the required blocks with overlapping blocks (multiple returned series)": {
-			finderResult: []*metadata.Meta{
-				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
-				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			finderResult: []*BlockMeta{
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
 			storeSetResult: []BlocksStoreClient{
 				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
@@ -215,9 +215,9 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 			},
 		},
 		"a single store-gateway instance has some missing blocks (consistency check failed)": {
-			finderResult: []*metadata.Meta{
-				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
-				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
+			finderResult: []*BlockMeta{
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
 			storeSetResult: []BlocksStoreClient{
 				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
@@ -229,10 +229,10 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 			expectedErr: fmt.Sprintf("consistency check failed because some blocks were not queried: %s", block2.String()),
 		},
 		"multiple store-gateway instances have some missing blocks (consistency check failed)": {
-			finderResult: []*metadata.Meta{
-				{BlockMeta: tsdb.BlockMeta{ULID: block1}},
-				{BlockMeta: tsdb.BlockMeta{ULID: block2}},
-				{BlockMeta: tsdb.BlockMeta{ULID: block3}},
+			finderResult: []*BlockMeta{
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block3}}},
 			},
 			storeSetResult: []BlocksStoreClient{
 				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
@@ -267,7 +267,7 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 				userID:      "user-1",
 				finder:      finder,
 				stores:      stores,
-				consistency: NewBlocksConsistencyChecker(0, 0, nil),
+				consistency: NewBlocksConsistencyChecker(0, 0, log.NewNopLogger(), nil),
 				logger:      log.NewNopLogger(),
 			}
 
@@ -327,11 +327,11 @@ func (m *blocksStoreSetMock) GetClientsFor(_ []ulid.ULID) ([]BlocksStoreClient, 
 type blocksFinderMock struct {
 	services.Service
 
-	mockedResult []*metadata.Meta
+	mockedResult []*BlockMeta
 	mockedErr    error
 }
 
-func (m *blocksFinderMock) GetBlocks(userID string, minT, maxT int64) ([]*metadata.Meta, map[ulid.ULID]*metadata.DeletionMark, error) {
+func (m *blocksFinderMock) GetBlocks(userID string, minT, maxT int64) ([]*BlockMeta, map[ulid.ULID]*metadata.DeletionMark, error) {
 	return m.mockedResult, nil, m.mockedErr
 }
 


### PR DESCRIPTION
**What this PR does**:
In the PR #2593 I've introduced a basic version of the consistency check for the read path, introducing the "upload grace period" based on the "block creation time" instead of the "block upload completed time" because we didn't have a way to know when a block was shipped to the storage.

In this PR I'm fixing it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
