### PR TITLE
Finish span created in ingester query stream

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -692,6 +692,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 	}
 
 	log, ctx := spanlogger.New(stream.Context(), "QueryStream")
+	defer log.Finish()
 
 	from, through, matchers, err := client.FromQueryRequest(req)
 	if err != nil {

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -632,7 +632,8 @@ func createUserStats(db *userTSDB) *client.UserStatsResponse {
 
 // v2QueryStream streams metrics from a TSDB. This implements the client.IngesterServer interface
 func (i *Ingester) v2QueryStream(req *client.QueryRequest, stream client.Ingester_QueryStreamServer) error {
-	_, ctx := spanlogger.New(stream.Context(), "v2QueryStream")
+	log, ctx := spanlogger.New(stream.Context(), "v2QueryStream")
+	defer log.Finish()
 
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
@@ -715,6 +716,7 @@ func (i *Ingester) v2QueryStream(req *client.QueryRequest, stream client.Ingeste
 
 	i.metrics.queriedSeries.Observe(float64(numSeries))
 	i.metrics.queriedSamples.Observe(float64(numSamples))
+	level.Debug(log).Log("series", numSeries, "samples", numSamples)
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does**: This trivial PR finishes spans created by ingester, and logs number of series and samples returned by blocks ingester. It also logs number of returned time and chunk series in "Distributor.Query" and "QueryStream" spans.