### PR TITLE
Micro optimization in newBlockQuerierSeries()

### DIFF
--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -204,12 +204,7 @@ func newBlockQuerierSeries(lbls []storepb.Label, chunks []storepb.AggrChunk) *bl
 		return chunks[i].MinTime < chunks[j].MinTime
 	})
 
-	b := labels.NewBuilder(nil)
-	for _, l := range lbls {
-		b.Set(l.Name, l.Value)
-	}
-
-	return &blockQuerierSeries{labels: b.Labels(), chunks: chunks}
+	return &blockQuerierSeries{labels: storepb.LabelsToPromLabelsUnsafe(lbls), chunks: chunks}
 }
 
 type blockQuerierSeries struct {

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -199,6 +199,7 @@ func (bqss *blockQuerierSeriesSet) Err() error {
 	return nil
 }
 
+// newBlockQuerierSeries makes a new blockQuerierSeries. Input labels must be already sorted by name.
 func newBlockQuerierSeries(lbls []storepb.Label, chunks []storepb.AggrChunk) *blockQuerierSeries {
 	sort.Slice(chunks, func(i, j int) bool {
 		return chunks[i].MinTime < chunks[j].MinTime

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -250,3 +250,26 @@ func mkLabels(s ...string) []storepb.Label {
 
 	return result
 }
+
+func Benchmark_newBlockQuerierSeries(b *testing.B) {
+	lbls := mkLabels(
+		"__name__", "test",
+		"label_1", "value_1",
+		"label_2", "value_2",
+		"label_3", "value_3",
+		"label_4", "value_4",
+		"label_5", "value_5",
+		"label_6", "value_6",
+		"label_7", "value_7",
+		"label_8", "value_8",
+		"label_9", "value_9")
+
+	chunks := []storepb.AggrChunk{
+		createChunkWithSineSamples(time.Now(), time.Now().Add(-time.Hour), time.Minute),
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		newBlockQuerierSeries(lbls, chunks)
+	}
+}

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -112,9 +112,9 @@ func TestBlockQuerierSeriesSet(t *testing.T) {
 
 	bss := &blockQuerierSeriesSet{
 		series: []*storepb.Series{
-			// labels here are not sorted, but blockQuerierSeriesSet will sort it.
+			// first, with one chunk.
 			{
-				Labels: mkLabels("a", "a", "__name__", "first"),
+				Labels: mkLabels("__name__", "first", "a", "a"),
 				Chunks: []storepb.AggrChunk{
 					createChunkWithSineSamples(now, now.Add(100*time.Second), 3*time.Millisecond), // ceil(100 / 0.003) samples (= 33334)
 				},
@@ -122,7 +122,7 @@ func TestBlockQuerierSeriesSet(t *testing.T) {
 
 			// continuation of previous series. Must have exact same labels.
 			{
-				Labels: mkLabels("a", "a", "__name__", "first"),
+				Labels: mkLabels("__name__", "first", "a", "a"),
 				Chunks: []storepb.AggrChunk{
 					createChunkWithSineSamples(now.Add(100*time.Second), now.Add(200*time.Second), 3*time.Millisecond), // ceil(100 / 0.003) samples more, 66668 in total
 				},


### PR DESCRIPTION
**What this PR does**:
Since #2599 we don't need to use labels builder anymore. An unsafe conversion should just be fine.

```
BEFORE: Benchmark_newBlockQuerierSeries-4   	  921447	      1135 ns/op
AFTER:  Benchmark_newBlockQuerierSeries-4   	 9260770	       108 ns/op
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
