### PR TITLE
Add more tracing spans to read path

### DIFF
--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
 	"github.com/cortexproject/cortex/pkg/querier/series"
 	"github.com/cortexproject/cortex/pkg/util/chunkcompat"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
 // Distributor is the read interface to the distributor, made an interface here
@@ -52,10 +53,13 @@ type distributorQuerier struct {
 // Select implements storage.Querier interface.
 // The bool passed is ignored because the series is always sorted.
 func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	log, ctx := spanlogger.New(q.ctx, "distributorQuerier.Select")
+	defer log.Span.Finish()
+
 	// Kludge: Prometheus passes nil SelectParams if it is doing a 'series' operation,
 	// which needs only metadata.
 	if sp == nil {
-		ms, err := q.distributor.MetricsForLabelMatchers(q.ctx, model.Time(q.mint), model.Time(q.maxt), matchers...)
+		ms, err := q.distributor.MetricsForLabelMatchers(ctx, model.Time(q.mint), model.Time(q.maxt), matchers...)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -68,7 +72,7 @@ func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 		return q.streamingSelect(*sp, matchers)
 	}
 
-	matrix, err := q.distributor.Query(q.ctx, model.Time(mint), model.Time(maxt), matchers...)
+	matrix, err := q.distributor.Query(ctx, model.Time(mint), model.Time(maxt), matchers...)
 	if err != nil {
 		return nil, nil, promql.ErrStorage{Err: err}
 	}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -245,6 +245,7 @@ type querier struct {
 func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
 	log, ctx := spanlogger.New(q.ctx, "querier.Select")
 	defer log.Span.Finish()
+	level.Debug(log).Log("start", sp.Start, "end", sp.End, "step", sp.Step)
 
 	// Kludge: Prometheus passes nil SelectHints if it is doing a 'series' operation,
 	// which needs only metadata. Here we expect that metadataQuerier querier will handle that.

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -245,7 +245,10 @@ type querier struct {
 func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
 	log, ctx := spanlogger.New(q.ctx, "querier.Select")
 	defer log.Span.Finish()
-	level.Debug(log).Log("start", sp.Start, "end", sp.End, "step", sp.Step)
+
+	if sp != nil {
+		level.Debug(log).Log("start", sp.Start, "end", sp.End, "step", sp.Step)
+	}
 
 	// Kludge: Prometheus passes nil SelectHints if it is doing a 'series' operation,
 	// which needs only metadata. Here we expect that metadataQuerier querier will handle that.

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -247,7 +247,7 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 	defer log.Span.Finish()
 
 	if sp != nil {
-		level.Debug(log).Log("start", sp.Start, "end", sp.End, "step", sp.Step)
+		level.Debug(log).Log("start", util.TimeFromMillis(sp.Start).UTC().String(), "end", util.TimeFromMillis(sp.End).UTC().String(), "step", sp.Step)
 	}
 
 	// Kludge: Prometheus passes nil SelectHints if it is doing a 'series' operation,

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/querier/series"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/cortexproject/cortex/pkg/util/tls"
 )
 
@@ -242,6 +243,9 @@ type querier struct {
 // Select implements storage.Querier interface.
 // The bool passed is ignored because the series is always sorted.
 func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {
+	log, ctx := spanlogger.New(q.ctx, "querier.Select")
+	defer log.Span.Finish()
+
 	// Kludge: Prometheus passes nil SelectHints if it is doing a 'series' operation,
 	// which needs only metadata. Here we expect that metadataQuerier querier will handle that.
 	// In Cortex it is not feasible to query entire history (with no mint/maxt), so we only ask ingesters and skip
@@ -250,7 +254,7 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 		return q.metadataQuerier.Select(true, nil, matchers...)
 	}
 
-	userID, err := user.ExtractOrgID(q.ctx)
+	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, nil, promql.ErrStorage{Err: err}
 	}
@@ -293,8 +297,8 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 			return nil, nil, err
 		case set := <-sets:
 			result = append(result, set)
-		case <-q.ctx.Done():
-			return nil, nil, q.ctx.Err()
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
 		}
 	}
 


### PR DESCRIPTION
**What this PR does**:
Add a couple of more tracing spans to better understand where the time is being spent while executing a query.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
