### PR TITLE
improve query speed when does not enable caching

### DIFF
--- a/pkg/chunk/cache/tiered.go
+++ b/pkg/chunk/cache/tiered.go
@@ -15,10 +15,8 @@ func NewTiered(caches []Cache) Cache {
 
 // IsEmptyTieredCache is used to determine whether the current Cache is implemented by an empty tiered.
 func IsEmptyTieredCache(cache Cache) bool {
-	if c, ok := cache.(tiered); ok && len(c) == 0 {
-		return true
-	}
-	return false
+	c, ok := cache.(tiered)
+	return ok && len(c) == 0
 }
 
 func (t tiered) Store(ctx context.Context, keys []string, bufs [][]byte) {

--- a/pkg/chunk/cache/tiered.go
+++ b/pkg/chunk/cache/tiered.go
@@ -13,6 +13,14 @@ func NewTiered(caches []Cache) Cache {
 	return tiered(caches)
 }
 
+// IsEmptyTieredCache is used to determine whether the current Cache is implemented by an empty tiered.
+func IsEmptyTieredCache(cache Cache) bool {
+	if c, ok := cache.(tiered); ok && len(c) == 0 {
+		return true
+	}
+	return false
+}
+
 func (t tiered) Store(ctx context.Context, keys []string, bufs [][]byte) {
 	for _, c := range []Cache(t) {
 		c.Store(ctx, keys, bufs)

--- a/pkg/chunk/storage/caching_index_client.go
+++ b/pkg/chunk/storage/caching_index_client.go
@@ -115,10 +115,18 @@ func (s *cachingIndexClient) QueryPages(ctx context.Context, queries []chunk.Ind
 	for _, key := range misses {
 		// Only need to consider one of the queries as they have the same table & hash.
 		queries := queriesByKey[key]
-		cacheableMissed = append(cacheableMissed, chunk.IndexQuery{
+		query := chunk.IndexQuery{
 			TableName: queries[0].TableName,
 			HashValue: queries[0].HashValue,
-		})
+		}
+
+		if cache.IsEmptyTieredCache(s.cache) {
+			query.RangeValueStart = queries[0].RangeValueStart
+			query.RangeValuePrefix = queries[0].RangeValuePrefix
+			query.ValueEqual = queries[0].ValueEqual
+		}
+
+		cacheableMissed = append(cacheableMissed, query)
 
 		rb := ReadBatch{
 			Key:    key,


### PR DESCRIPTION
Signed-off-by: storyicon <storyicon@foxmail.com>

**What this PR does**:
When the cache is not enabled, more query conditions are used to reduce query costs and increase query speed

**Which issue(s) this PR fixes**:
Fixes #2644

