### PR TITLE
Ruler Object Storage Base64 Encoding

### DIFF
--- a/pkg/ruler/rules/objectclient/rule_store.go
+++ b/pkg/ruler/rules/objectclient/rule_store.go
@@ -3,6 +3,7 @@ package objectclient
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"io/ioutil"
 	strings "strings"
 
@@ -16,8 +17,12 @@ import (
 
 // Object Rule Storage Schema
 // =======================
-// Object Name: "rules/<user_id>/<namespace>/<group_name>"
+// Object Name: "rules/<user_id>/<base64 URL Encoded: namespace>/<base64 URL Encoded: group_name>"
 // Storage Format: Encoded RuleGroupDesc
+//
+// Prometheus Rule Groups can include a large number of characters that are not valid object names
+// in common object storage systems. A URL Base64 encoding allows for generic consistent naming
+// across all backends
 
 const (
 	rulePrefix = "rules/"
@@ -152,7 +157,7 @@ func generateRuleObjectKey(id, namespace, name string) string {
 	if namespace == "" {
 		return prefix
 	}
-	return prefix + namespace + "/" + name
+	return prefix + base64.URLEncoding.EncodeToString([]byte(namespace)) + "/" + base64.URLEncoding.EncodeToString([]byte(name))
 }
 
 func decomposeRuleObjectKey(handle string) string {


### PR DESCRIPTION
**What this PR does**:

This PR incorporates a small aspect of the #2543 that ensures rule group names and namespaces are base64 encoded when incorporated into the object key and written to disk. This fixes an issue where illegal characters such as `/` can be set in a rule group that affects the proper operation of the system. This can be seen by running the current integration test present in this PR against a current version of Cortex.

Base64 Encoding was chosen since it is a universally accepted format and fulfills all the naming requirements of common object storage backends:
- https://cloud.google.com/storage/docs/naming-objects
- https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html


*Note: This is a breaking change for anyone with the `-experimental.ruler.enable-api` enabled and object storage configured. I am working on a small migration tool w/ docs for anyone in this predicament.

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
