### PR TITLE
Refcache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [ENHANCEMENT] Experimental TSDB: Use shared cache for metadata. This is especially useful when running multiple querier and store-gateway components to reduce number of object store API calls. #2626
 * [ENHANCEMENT] Upgrade Thanos to [f7802edbf830](https://github.com/thanos-io/thanos/commit/f7802edbf830) and Prometheus to [f4dd45609a05](https://github.com/prometheus/prometheus/commit/f4dd45609a05) which is after v2.18.1. #2634
   * TSDB now does memory-mapping of Head chunks and reduces memory usage.
+* [ENHANCEMENT] Experimental TSDB: small performance improvement in concurrent usage of RefCache, used during samples ingestion. #2651
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/pkg/storage/tsdb/ref_cache.go
+++ b/pkg/storage/tsdb/ref_cache.go
@@ -125,11 +125,13 @@ func (s *refCacheStripe) purge(keepUntil time.Time) {
 	s.refsMu.Lock()
 	defer s.refsMu.Unlock()
 
+	keepUntilNanos := keepUntil.UnixNano()
+
 	for fp, entries := range s.refs {
 		// Since we do expect very few fingerprint collisions, we
 		// have an optimized implementation for the common case.
 		if len(entries) == 1 {
-			if entries[0].touchedAt < keepUntil.UnixNano() {
+			if entries[0].touchedAt < keepUntilNanos {
 				delete(s.refs, fp)
 			}
 
@@ -139,7 +141,7 @@ func (s *refCacheStripe) purge(keepUntil time.Time) {
 		// We have more entries, which means there's a collision,
 		// so we have to iterate over the entries.
 		for i := 0; i < len(entries); {
-			if entries[i].touchedAt < keepUntil.UnixNano() {
+			if entries[i].touchedAt < keepUntilNanos {
 				entries = append(entries[:i], entries[i+1:]...)
 			} else {
 				i++

--- a/pkg/storage/tsdb/ref_cache.go
+++ b/pkg/storage/tsdb/ref_cache.go
@@ -17,7 +17,7 @@ const (
 	// the scrape interval of a series is greater than this TTL.
 	DefaultRefCacheTTL = 10 * time.Minute
 
-	numRefCacheStripes = 128
+	numRefCacheStripes = 512
 )
 
 // RefCache is a single-tenant cache mapping a labels set with the reference
@@ -48,7 +48,7 @@ func NewRefCache() *RefCache {
 	c := &RefCache{}
 
 	// Stripes are pre-allocated so that we only read on them and no lock is required.
-	for i := uint8(0); i < numRefCacheStripes; i++ {
+	for i := 0; i < numRefCacheStripes; i++ {
 		c.stripes[i] = &refCacheStripe{
 			refs: map[model.Fingerprint][]*refCacheEntry{},
 		}
@@ -77,7 +77,7 @@ func (c *RefCache) SetRef(now time.Time, series labels.Labels, ref uint64) {
 // Purge removes expired entries from the cache. This function should be called
 // periodically to avoid memory leaks.
 func (c *RefCache) Purge(keepUntil time.Time) {
-	for s := uint8(0); s < numRefCacheStripes; s++ {
+	for s := 0; s < numRefCacheStripes; s++ {
 		c.stripes[s].purge(keepUntil)
 	}
 }

--- a/pkg/storage/tsdb/ref_cache_test.go
+++ b/pkg/storage/tsdb/ref_cache_test.go
@@ -2,6 +2,7 @@ package tsdb
 
 import (
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -93,6 +94,61 @@ func TestRefCache_Purge(t *testing.T) {
 			assert.Equal(t, false, ok)
 		}
 	}
+}
+
+var series1M = prepareSeries(1e6)
+
+func BenchmarkRefCacheConcurrency_1m_50(b *testing.B) {
+	benchmarkRefCacheConcurrency(b, series1M, 50)
+}
+
+func BenchmarkRefCacheConcurrency_1m_250(b *testing.B) {
+	benchmarkRefCacheConcurrency(b, series1M, 100)
+}
+
+func BenchmarkRefCacheConcurrency_1m_1000(b *testing.B) {
+	benchmarkRefCacheConcurrency(b, series1M, 500)
+}
+
+func prepareSeries(numSeries int) []labels.Labels {
+	series := make([]labels.Labels, numSeries)
+
+	for s := 0; s < numSeries; s++ {
+		series[s] = labels.Labels{
+			{Name: "a", Value: strconv.Itoa(s)},
+		}
+	}
+
+	return series
+}
+
+func benchmarkRefCacheConcurrency(b *testing.B, series []labels.Labels, goroutines int) {
+	c := NewRefCache()
+
+	fn := func(wg *sync.WaitGroup, step int) {
+		defer wg.Done()
+
+		for i := 0; i < b.N; i++ {
+			now := time.Now()
+
+			for s := 0; s < len(series); s += step {
+				_, ok := c.Ref(now, series[s])
+				if !ok {
+					c.SetRef(now, series[s], uint64(s))
+				}
+			}
+		}
+	}
+
+	wg := &sync.WaitGroup{}
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go fn(wg, 1+(i%10))
+	}
+
+	b.ResetTimer()
+	wg.Wait()
 }
 
 func BenchmarkRefCache_SetRef(b *testing.B) {


### PR DESCRIPTION
**What this PR does**: this PR does some changes to `RefCache` to improve its throughput in new `RefCacheConcurrency` benchmark. Unfortunately it also makes individual `Ref` and `SetRef` calls slower. Sending for discussion, not necessarily merging.

```
name                           old time/op  new time/op  delta
RefCacheConcurrency_1m_50-4     1.29s ± 4%   1.10s ± 5%  -14.84%  (p=0.000 n=9+10)
RefCacheConcurrency_1m_250-4    2.35s ± 3%   1.85s ± 6%  -21.46%  (p=0.000 n=10+10)
RefCacheConcurrency_1m_1000-4   10.6s ± 2%    7.8s ± 3%  -27.00%  (p=0.000 n=10+10)
RefCache_SetRef-4               414µs ± 2%   651µs ± 2%  +57.43%  (p=0.000 n=10+10)
RefCache_Ref-4                  815µs ± 2%   894µs ± 3%   +9.69%  (p=0.000 n=10+10)
RefCache_purge-4                102ms ± 2%    54ms ± 2%  -47.13%  (p=0.000 n=10+10)
```