### PR TITLE
Remove -store.fullsize-chunks option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [CHANGE] Experimental Memberlist ring: randomize gossip node names to avoid conflicts when running multiple clients on the same host, or reusing host names (eg. pods in statefulset). Node name randomization can be disabled by using `-memberlist.randomize-node-name=false`. #2715
 * [CHANGE] Memberlist KV client is no longer considered experimental. #2725
 * [CHANGE] Change target flag for purger from `data-purger` to `purger` and make delete request cancellation duration configurable. #2760
+* [CHANGE] Removed `-store.fullsize-chunks` option which was undocumented and unused (it broke ingester hand-overs). #2656
 * [FEATURE] TLS config options added for GRPC clients in Querier (Query-frontend client & Ingester client), Ruler, Store Gateway, as well as HTTP client in Config store client. #2502
 * [FEATURE] The flag `-frontend.max-cache-freshness` is now supported within the limits overrides, to specify per-tenant max cache freshness values. The corresponding YAML config parameter has been changed from `results_cache.max_freshness` to `limits_config.max_cache_freshness`. The legacy YAML config parameter (`results_cache.max_freshness`) will continue to be supported till Cortex release `v1.4.0`. #2609
 * [FEATURE] Experimental gRPC Store: Added support to 3rd parties index and chunk stores using gRPC client/server plugin mechanism. #2220

--- a/pkg/chunk/encoding/chunk_test.go
+++ b/pkg/chunk/encoding/chunk_test.go
@@ -56,7 +56,6 @@ func TestLen(t *testing.T) {
 var step = int(15 * time.Second / time.Millisecond)
 
 func TestChunk(t *testing.T) {
-	alwaysMarshalFullsizeChunks = false
 	for _, tc := range []struct {
 		encoding   Encoding
 		maxSamples int

--- a/pkg/chunk/encoding/factory.go
+++ b/pkg/chunk/encoding/factory.go
@@ -15,15 +15,13 @@ type Config struct{}
 
 var (
 	// DefaultEncoding exported for use in unit tests elsewhere
-	DefaultEncoding             = Bigchunk
-	alwaysMarshalFullsizeChunks = true
-	bigchunkSizeCapBytes        = 0
+	DefaultEncoding      = Bigchunk
+	bigchunkSizeCapBytes = 0
 )
 
 // RegisterFlags registers configuration settings.
 func (Config) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&DefaultEncoding, "ingester.chunk-encoding", "Encoding version to use for chunks.")
-	flag.BoolVar(&alwaysMarshalFullsizeChunks, "store.fullsize-chunks", alwaysMarshalFullsizeChunks, "When saving varbit chunks, pad to 1024 bytes")
 	flag.IntVar(&bigchunkSizeCapBytes, "store.bigchunk-size-cap-bytes", bigchunkSizeCapBytes, "When using bigchunk encoding, start a new bigchunk if over this size (0 = unlimited)")
 }
 

--- a/pkg/chunk/encoding/varbit.go
+++ b/pkg/chunk/encoding/varbit.go
@@ -318,6 +318,7 @@ func (c varbitChunk) Utilization() float64 {
 }
 
 // marshalLen returns the number of bytes that should be marshalled for this chunk
+// (if someone has used a version of this code that doesn't just send 1024 every time)
 func (c varbitChunk) marshalLen() int {
 	bits := c.nextSampleOffset()
 	if bits < varbitThirdSampleBitOffset {
@@ -340,10 +341,7 @@ func (c varbitChunk) Len() int {
 }
 
 func (c varbitChunk) Size() int {
-	if alwaysMarshalFullsizeChunks {
-		return cap(c)
-	}
-	return c.marshalLen()
+	return cap(c)
 }
 
 func (c varbitChunk) firstTime() model.Time {


### PR DESCRIPTION
It broke ingester hand-overs, and is not needed now we use BigChunk.

Fixes #1163

**Checklist**
- [x] Tests updated
- [x] Documentation added N/A
- [x] `CHANGELOG.md` updated 