### PR TITLE
Allow users to configure the number of TCP connections per host for Cassandra.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
   * TSDB now does memory-mapping of Head chunks and reduces memory usage.
 * [ENHANCEMENT] Experimental TSDB: when `-querier.query-store-after` is configured and running the experimental blocks storage, the time range of the query sent to the store is now manipulated to ensure the query end time is not more recent than 'now - query-store-after'. #2642
 * [ENHANCEMENT] Experimental TSDB: small performance improvement in concurrent usage of RefCache, used during samples ingestion. #2651
+* [ENHANCEMENT] Add `-cassandra.num-connections` to allow increasing the number of TCP connections to each Cassandra server. #2666
+* [ENHANCEMENT] Use separate Cassandra clients and connections for reads and writes. #2666
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1726,6 +1726,10 @@ cassandra:
   # CLI flag: -cassandra.query-concurrency
   [query_concurrency: <int> | default = 0]
 
+  # Number of TCP connections per host.
+  # CLI flag: -cassandra.num-connections
+  [num_connections: <int> | default = 2]
+
 boltdb:
   # Location of BoltDB index files.
   # CLI flag: -boltdb.dir

--- a/pkg/chunk/cassandra/fixtures.go
+++ b/pkg/chunk/cassandra/fixtures.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/testutils"
+	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
 
 // GOCQL doesn't provide nice mocks, so we use a real Cassandra instance.
@@ -40,12 +41,12 @@ func Fixtures() ([]testutils.Fixture, error) {
 		return nil, nil
 	}
 
-	cfg := Config{
-		Addresses:         addresses,
-		Keyspace:          "test",
-		Consistency:       "QUORUM",
-		ReplicationFactor: 1,
-	}
+	var cfg Config
+	flagext.DefaultValues(&cfg)
+	cfg.Addresses = addresses
+	cfg.Keyspace = "test"
+	cfg.Consistency = "QUORUM"
+	cfg.ReplicationFactor = 1
 
 	// Get a SchemaConfig with the defaults.
 	schemaConfig := testutils.DefaultSchemaConfig("cassandra")

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -42,6 +42,7 @@ type Config struct {
 	MaxBackoff               time.Duration       `yaml:"retry_max_backoff"`
 	MinBackoff               time.Duration       `yaml:"retry_min_backoff"`
 	QueryConcurrency         int                 `yaml:"query_concurrency"`
+	NumConnections           int                 `yaml:"num_connections"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -66,6 +67,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.MinBackoff, "cassandra.retry-min-backoff", 100*time.Millisecond, "Minimum time to wait before retrying a failed request. (Default = 100ms)")
 	f.DurationVar(&cfg.MaxBackoff, "cassandra.retry-max-backoff", 10*time.Second, "Maximum time to wait before retrying a failed request. (Default = 10s)")
 	f.IntVar(&cfg.QueryConcurrency, "cassandra.query-concurrency", 0, "Limit number of concurrent queries to Cassandra. (Default is 0: no limit)")
+	f.IntVar(&cfg.NumConnections, "cassandra.num-connections", 2, "Number of TCP connections per host.")
 }
 
 func (cfg *Config) Validate() error {
@@ -92,6 +94,7 @@ func (cfg *Config) session() (*gocql.Session, error) {
 	cluster.QueryObserver = observer{}
 	cluster.Timeout = cfg.Timeout
 	cluster.ConnectTimeout = cfg.ConnectTimeout
+	cluster.NumConns = cfg.NumConnections
 	if cfg.Retries > 0 {
 		cluster.RetryPolicy = &gocql.ExponentialBackoffRetryPolicy{
 			NumRetries: cfg.Retries,


### PR DESCRIPTION
Allow users to configure the number of TCP connections per host for Cassandra

This should increase the number of streams (concurrent Cassandra requests) available on the client side, and reduce the chance of getting "gocql: no hosts in pool" errors under load.

Also, use separate clients for reads and writes, to stop the two interferring. 