### PR TITLE
Add debugger to Docker compose

### DIFF
--- a/development/tsdb-blocks-storage-s3/compose-up.sh
+++ b/development/tsdb-blocks-storage-s3/compose-up.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+set -e
+
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex && \
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build distributor && \
+# -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -gcflags "all=-N -l" -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex
+docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build distributor
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@

--- a/development/tsdb-blocks-storage-s3/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3/dev.dockerfile
@@ -1,5 +1,9 @@
+FROM golang:1.14
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+RUN go get github.com/go-delve/delve/cmd/dlv
 FROM alpine:3.10
 
 RUN     mkdir /cortex
 WORKDIR /cortex
 ADD     ./cortex ./
+COPY --from=0 /go/bin/dlv ./

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: cortex
-    command: ["sh", "-c", "sleep 3 && exec ./cortex -config.file=./config/cortex.yaml -target=distributor -server.http-listen-port=8001 -server.grpc-listen-port=9001"]
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18001 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=distributor -server.http-listen-port=8001 -server.grpc-listen-port=9001"]
     depends_on:
       - consul
       - minio
@@ -67,6 +67,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8001:8001
+      - 18001:18001
     volumes:
       - ./config:/cortex/config
 
@@ -75,7 +76,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: cortex
-    command: ["sh", "-c", "sleep 3 && exec ./cortex -config.file=./config/cortex.yaml -target=ingester -server.http-listen-port=8002 -server.grpc-listen-port=9002"]
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18002 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=ingester -server.http-listen-port=8002 -server.grpc-listen-port=9002"]
     depends_on:
       - consul
       - minio
@@ -87,6 +88,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8002:8002
+      - 18002:18002
     volumes:
       - ./config:/cortex/config
       - .data-ingester-1:/tmp/cortex-tsdb-ingester:delegated
@@ -96,7 +98,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: cortex
-    command: ["sh", "-c", "sleep 3 && exec ./cortex -config.file=./config/cortex.yaml -target=ingester -server.http-listen-port=8003 -server.grpc-listen-port=9003"]
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18003 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=ingester -server.http-listen-port=8003 -server.grpc-listen-port=9003"]
     depends_on:
       - consul
       - minio
@@ -108,6 +110,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8003:8003
+      - 18003:18003
     volumes:
       - ./config:/cortex/config
       - .data-ingester-2:/tmp/cortex-tsdb-ingester:delegated
@@ -117,7 +120,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: cortex
-    command: ["sh", "-c", "sleep 3 && exec ./cortex -config.file=./config/cortex.yaml -target=querier -server.http-listen-port=8004 -server.grpc-listen-port=9004"]
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18004 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=querier -server.http-listen-port=8004 -server.grpc-listen-port=9004"]
     depends_on:
       - consul
       - minio
@@ -129,6 +132,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8004:8004
+      - 18004:18004
     volumes:
       - ./config:/cortex/config
 
@@ -137,7 +141,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: cortex
-    command: ["sh", "-c", "sleep 3 && exec ./cortex -config.file=./config/cortex.yaml -target=store-gateway -server.http-listen-port=8008 -server.grpc-listen-port=9008"]
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18008 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=store-gateway -server.http-listen-port=8008 -server.grpc-listen-port=9008"]
     depends_on:
       - consul
       - minio
@@ -149,6 +153,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8008:8008
+      - 18008:18008
     volumes:
       - ./config:/cortex/config
 
@@ -157,7 +162,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: cortex
-    command: ["sh", "-c", "sleep 3 && exec ./cortex -config.file=./config/cortex.yaml -target=store-gateway -server.http-listen-port=8009 -server.grpc-listen-port=9009"]
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18009 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=store-gateway -server.http-listen-port=8009 -server.grpc-listen-port=9009"]
     depends_on:
       - consul
       - minio
@@ -169,6 +174,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8009:8009
+      - 18009:18009
     volumes:
       - ./config:/cortex/config
 
@@ -177,7 +183,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: cortex
-    command: ["sh", "-c", "sleep 3 && exec ./cortex -config.file=./config/cortex.yaml -target=ruler -server.http-listen-port=8005 -server.grpc-listen-port=9005"]
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18005 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=ruler -server.http-listen-port=8005 -server.grpc-listen-port=9005"]
     depends_on:
       - consul
       - minio
@@ -189,6 +195,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8005:8005
+      - 18005:18005
     volumes:
       - ./config:/cortex/config
 
@@ -197,7 +204,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: cortex
-    command: ["sh", "-c", "sleep 3 && exec ./cortex -config.file=./config/cortex.yaml -target=compactor -server.http-listen-port=8006 -server.grpc-listen-port=9006"]
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18006 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=compactor -server.http-listen-port=8006 -server.grpc-listen-port=9006"]
     depends_on:
       - consul
       - minio
@@ -209,6 +216,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8006:8006
+      - 18006:18006
     volumes:
       - ./config:/cortex/config
 
@@ -217,7 +225,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: cortex
-    command: ["sh", "-c", "sleep 3 && exec ./cortex -config.file=./config/cortex.yaml -target=query-frontend -server.http-listen-port=8007 -server.grpc-listen-port=9007"]
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18007 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=query-frontend -server.http-listen-port=8007 -server.grpc-listen-port=9007"]
     depends_on:
       - consul
       - minio
@@ -229,5 +237,6 @@ services:
       - JAEGER_SAMPLER_PARAM=1
     ports:
       - 8007:8007
+      - 18007:18007
     volumes:
       - ./config:/cortex/config

--- a/development/tsdb-blocks-storage-s3/goland/compactor.run.xml
+++ b/development/tsdb-blocks-storage-s3/goland/compactor.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Compactor" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18006">
+    <method v="2" />
+  </configuration>
+</component>

--- a/development/tsdb-blocks-storage-s3/goland/distributor.run.xml
+++ b/development/tsdb-blocks-storage-s3/goland/distributor.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Distributor" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18001">
+    <method v="2" />
+  </configuration>
+</component>

--- a/development/tsdb-blocks-storage-s3/goland/ingester-1.run.xml
+++ b/development/tsdb-blocks-storage-s3/goland/ingester-1.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Ingester-1" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18002">
+    <method v="2" />
+  </configuration>
+</component>

--- a/development/tsdb-blocks-storage-s3/goland/ingester-2.run.xml
+++ b/development/tsdb-blocks-storage-s3/goland/ingester-2.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Ingester-2" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18003">
+    <method v="2" />
+  </configuration>
+</component>

--- a/development/tsdb-blocks-storage-s3/goland/querier.run.xml
+++ b/development/tsdb-blocks-storage-s3/goland/querier.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Querier" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18004">
+    <method v="2" />
+  </configuration>
+</component>

--- a/development/tsdb-blocks-storage-s3/goland/query-frontend.run.xml
+++ b/development/tsdb-blocks-storage-s3/goland/query-frontend.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Query-frontend" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18007">
+    <method v="2" />
+  </configuration>
+</component>

--- a/development/tsdb-blocks-storage-s3/goland/store-gateway-1.run.xml
+++ b/development/tsdb-blocks-storage-s3/goland/store-gateway-1.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Store-gateway-1" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18008">
+    <method v="2" />
+  </configuration>
+</component>

--- a/development/tsdb-blocks-storage-s3/goland/store-gateway-2.run.xml
+++ b/development/tsdb-blocks-storage-s3/goland/store-gateway-2.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Store-gateway-2" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18009">
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
**What this PR does**: This PR modifies docker-compose for TSDB blocks in following ways:
- it modifies compilation of Cortex used by docker-compose to disable optimizations (for better debuggability) and inlining
- it adds Delve debugger to the image
- Cortex now runs under Delve debugger with remote debugging enabled
- Adds Goland configurations for connecting to individual components

