### PR TITLE
do not invalidate chunks cache when series are deleted

### DIFF
--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -142,7 +142,6 @@ func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConf
 
 	// lets wrap all caches with CacheGenMiddleware to facilitate cache invalidation using cache generation numbers
 	indexReadCache = cache.NewCacheGenNumMiddleware(indexReadCache)
-	chunksCache = cache.NewCacheGenNumMiddleware(chunksCache)
 	writeDedupeCache = cache.NewCacheGenNumMiddleware(writeDedupeCache)
 
 	err = schemaCfg.Load()

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -140,7 +140,9 @@ func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConf
 	chunksCache = cache.StopOnce(chunksCache)
 	writeDedupeCache = cache.StopOnce(writeDedupeCache)
 
-	// lets wrap all caches with CacheGenMiddleware to facilitate cache invalidation using cache generation numbers
+	// Lets wrap all caches except chunksCache with CacheGenMiddleware to facilitate cache invalidation using cache generation numbers.
+	// chunksCache is not wrapped because chunks content can't be anyways modified without changing its ID so there is no use of
+	// invalidating chunks cache. Also chunks can be fetched only by their ID found in index and we are anyways removing the index and invalidating index cache here.
 	indexReadCache = cache.NewCacheGenNumMiddleware(indexReadCache)
 	writeDedupeCache = cache.NewCacheGenNumMiddleware(writeDedupeCache)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
PR #2279 introduced invalidation of cache when the series deletion is requested. It invalidates results cache when delete request is received and all store caches(chunks, index and write-dedupe) when delete request is processed. It seems we need not invalidate chunks cache since we refer chunks by their ID and changing the content of the chunk requires changing its ID as well.

Also, a chunk is accessible only if it has an index entry for it which also means even though deleted chunks stay in cache until they are evicted, there should not be any harm since its index is already deleted and we would avoid clearing the whole cache containing non-deleted chunks as well.

Thanks to Bryan for pointing this out [here](https://github.com/cortexproject/cortex/pull/2279#issuecomment-636485265).