### PR TITLE
disabling of chunks write dedupe

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -63,7 +63,9 @@ type StoreConfig struct {
 	// is set, use different caches for ingesters and queriers.
 	chunkCacheStubs bool // don't write the full chunk to cache, just a stub entry
 
-	DisableChunksDedupe bool
+	// When DisableChunksDeduplication is true, cache would not be checked for whether chunk is already written.
+	// It would still write the chunk back to cache for reads.
+	DisableChunksDeduplication bool `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -62,6 +62,8 @@ type StoreConfig struct {
 	// ingester chunk write deduplication. But for the queriers we need the full value. So when this option
 	// is set, use different caches for ingesters and queriers.
 	chunkCacheStubs bool // don't write the full chunk to cache, just a stub entry
+
+	DisableChunksDedupe bool
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -414,9 +414,7 @@ func (c *seriesStore) Put(ctx context.Context, chunks []Chunk) error {
 // PutOne implements ChunkStore
 func (c *seriesStore) PutOne(ctx context.Context, from, through model.Time, chunk Chunk) error {
 	log, ctx := spanlogger.New(ctx, "SeriesStore.PutOne")
-	// When DisableChunksDedupe is true we do not want to dedupe the chunk but
-	// we still want to write the chunk back to cache down below for reads.
-	if !c.cfg.DisableChunksDedupe {
+	if !c.cfg.DisableChunksDeduplication {
 		// If this chunk is in cache it must already be in the database so we don't need to write it again
 		found, _, _ := c.cache.Fetch(ctx, []string{chunk.ExternalKey()})
 		if len(found) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This is actually useful for boltdb shipper feature in Loki where we want to disable chunks write dedupe. The option to disable chunks write dedupe is not user exposed and defaults to false so there must be no visible change for Cortex users.
