### PR TITLE
Dedicated struct and methods for metric counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 * [BUGFIX] QueryFrontend: fixed a panic (`integer divide by zero`) in the query-frontend. The query-frontend now requires the `-querier.default-evaluation-interval` config to be set to the same value of the querier. #2603
 * [BUGFIX] Experimental TSDB: when the querier receives a `/series` request with a time range older than the data stored in the ingester, it now ignores the requested time range and returns known series anyway instead of returning an empty response. This aligns the behaviour with the chunks storage. #2617
 * [BUGFIX] Cassandra: fixed an edge case leading to an invalid CQL query when querying the index on a Cassandra store. #2639
+* [BUGFIX] Ingester: increment series per metric when recovering from WAL or transfer. #2674
 
 ## 1.1.0 / 2020-05-21
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -502,12 +503,23 @@ func TestIngesterAppendBlankLabel(t *testing.T) {
 }
 
 func TestIngesterUserLimitExceeded(t *testing.T) {
+	dirname, err := ioutil.TempDir("", "limits")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dirname))
+	}()
+
+	cfg := defaultIngesterTestConfig()
+	cfg.WALConfig.WALEnabled = true
+	cfg.WALConfig.Recover = true
+	cfg.WALConfig.Dir = dirname
+	cfg.WALConfig.CheckpointDuration = 100 * time.Minute
+
 	limits := defaultLimitsTestConfig()
 	limits.MaxLocalSeriesPerUser = 1
 	limits.MaxLocalMetricsWithMetadataPerUser = 1
 
-	_, ing := newTestStore(t, defaultIngesterTestConfig(), defaultClientTestConfig(), limits, nil)
-	defer services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
+	_, ing := newTestStore(t, cfg, defaultClientTestConfig(), limits, nil)
 
 	userID := "1"
 	// Series
@@ -531,54 +543,76 @@ func TestIngesterUserLimitExceeded(t *testing.T) {
 
 	// Append only one series and one metadata first, expect no error.
 	ctx := user.InjectOrgID(context.Background(), userID)
-	_, err := ing.Push(ctx, client.ToWriteRequest([]labels.Labels{labels1}, []client.Sample{sample1}, []*client.MetricMetadata{metadata1}, client.API))
+	_, err = ing.Push(ctx, client.ToWriteRequest([]labels.Labels{labels1}, []client.Sample{sample1}, []*client.MetricMetadata{metadata1}, client.API))
 	require.NoError(t, err)
 
-	// Append to two series, expect series-exceeded error.
-	_, err = ing.Push(ctx, client.ToWriteRequest([]labels.Labels{labels1, labels3}, []client.Sample{sample2, sample3}, nil, client.API))
-	if resp, ok := httpgrpc.HTTPResponseFromError(err); !ok || resp.Code != http.StatusTooManyRequests {
-		t.Fatalf("expected error about exceeding metrics per user, got %v", err)
-	}
-	// Append two metadata, expect no error since metadata is a best effort approach.
-	_, err = ing.Push(ctx, client.ToWriteRequest(nil, nil, []*client.MetricMetadata{metadata1, metadata2}, client.API))
-	require.NoError(t, err)
+	testLimits := func() {
+		// Append to two series, expect series-exceeded error.
+		_, err = ing.Push(ctx, client.ToWriteRequest([]labels.Labels{labels1, labels3}, []client.Sample{sample2, sample3}, nil, client.API))
+		if resp, ok := httpgrpc.HTTPResponseFromError(err); !ok || resp.Code != http.StatusTooManyRequests {
+			t.Fatalf("expected error about exceeding metrics per user, got %v", err)
+		}
+		// Append two metadata, expect no error since metadata is a best effort approach.
+		_, err = ing.Push(ctx, client.ToWriteRequest(nil, nil, []*client.MetricMetadata{metadata1, metadata2}, client.API))
+		require.NoError(t, err)
 
-	// Read samples back via ingester queries.
-	res, _, err := runTestQuery(ctx, t, ing, labels.MatchEqual, model.MetricNameLabel, "testmetric")
-	require.NoError(t, err)
+		// Read samples back via ingester queries.
+		res, _, err := runTestQuery(ctx, t, ing, labels.MatchEqual, model.MetricNameLabel, "testmetric")
+		require.NoError(t, err)
 
-	expected := model.Matrix{
-		{
-			Metric: client.FromLabelAdaptersToMetric(client.FromLabelsToLabelAdapters(labels1)),
-			Values: []model.SamplePair{
-				{
-					Timestamp: model.Time(sample1.TimestampMs),
-					Value:     model.SampleValue(sample1.Value),
-				},
-				{
-					Timestamp: model.Time(sample2.TimestampMs),
-					Value:     model.SampleValue(sample2.Value),
+		expected := model.Matrix{
+			{
+				Metric: client.FromLabelAdaptersToMetric(client.FromLabelsToLabelAdapters(labels1)),
+				Values: []model.SamplePair{
+					{
+						Timestamp: model.Time(sample1.TimestampMs),
+						Value:     model.SampleValue(sample1.Value),
+					},
+					{
+						Timestamp: model.Time(sample2.TimestampMs),
+						Value:     model.SampleValue(sample2.Value),
+					},
 				},
 			},
-		},
+		}
+
+		// Verify samples
+		require.Equal(t, expected, res)
+
+		// Verify metadata
+		m, err := ing.MetricsMetadata(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []*client.MetricMetadata{metadata1}, m.Metadata)
 	}
 
-	// Verify samples
-	require.Equal(t, expected, res)
+	testLimits()
 
-	// Verify metadata
-	m, err := ing.MetricsMetadata(ctx, nil)
-	require.NoError(t, err)
-	assert.Equal(t, []*client.MetricMetadata{metadata1}, m.Metadata)
+	// Limits should hold after restart.
+	services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
+	_, ing = newTestStore(t, cfg, defaultClientTestConfig(), limits, nil)
+	defer services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
+
+	testLimits()
 }
 
 func TestIngesterMetricLimitExceeded(t *testing.T) {
+	dirname, err := ioutil.TempDir("", "limits")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dirname))
+	}()
+
+	cfg := defaultIngesterTestConfig()
+	cfg.WALConfig.WALEnabled = true
+	cfg.WALConfig.Recover = true
+	cfg.WALConfig.Dir = dirname
+	cfg.WALConfig.CheckpointDuration = 100 * time.Minute
+
 	limits := defaultLimitsTestConfig()
 	limits.MaxLocalSeriesPerMetric = 1
 	limits.MaxLocalMetadataPerMetric = 1
 
-	_, ing := newTestStore(t, defaultIngesterTestConfig(), defaultClientTestConfig(), limits, nil)
-	defer services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
+	_, ing := newTestStore(t, cfg, defaultClientTestConfig(), limits, nil)
 
 	userID := "1"
 	labels1 := labels.Labels{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}}
@@ -602,46 +636,57 @@ func TestIngesterMetricLimitExceeded(t *testing.T) {
 
 	// Append only one series and one metadata first, expect no error.
 	ctx := user.InjectOrgID(context.Background(), userID)
-	_, err := ing.Push(ctx, client.ToWriteRequest([]labels.Labels{labels1}, []client.Sample{sample1}, []*client.MetricMetadata{metadata1}, client.API))
+	_, err = ing.Push(ctx, client.ToWriteRequest([]labels.Labels{labels1}, []client.Sample{sample1}, []*client.MetricMetadata{metadata1}, client.API))
 	require.NoError(t, err)
 
-	// Append two series, expect series-exceeded error.
-	_, err = ing.Push(ctx, client.ToWriteRequest([]labels.Labels{labels1, labels3}, []client.Sample{sample2, sample3}, nil, client.API))
-	if resp, ok := httpgrpc.HTTPResponseFromError(err); !ok || resp.Code != http.StatusTooManyRequests {
-		t.Fatalf("expected error about exceeding series per metric, got %v", err)
-	}
+	testLimits := func() {
+		// Append two series, expect series-exceeded error.
+		_, err = ing.Push(ctx, client.ToWriteRequest([]labels.Labels{labels1, labels3}, []client.Sample{sample2, sample3}, nil, client.API))
+		if resp, ok := httpgrpc.HTTPResponseFromError(err); !ok || resp.Code != http.StatusTooManyRequests {
+			t.Fatalf("expected error about exceeding series per metric, got %v", err)
+		}
 
-	// Append two metadata for the same metric. Drop the second one, and expect no error since metadata is a best effort approach.
-	_, err = ing.Push(ctx, client.ToWriteRequest(nil, nil, []*client.MetricMetadata{metadata1, metadata2}, client.API))
-	require.NoError(t, err)
+		// Append two metadata for the same metric. Drop the second one, and expect no error since metadata is a best effort approach.
+		_, err = ing.Push(ctx, client.ToWriteRequest(nil, nil, []*client.MetricMetadata{metadata1, metadata2}, client.API))
+		require.NoError(t, err)
 
-	// Read samples back via ingester queries.
-	res, _, err := runTestQuery(ctx, t, ing, labels.MatchEqual, model.MetricNameLabel, "testmetric")
-	require.NoError(t, err)
+		// Read samples back via ingester queries.
+		res, _, err := runTestQuery(ctx, t, ing, labels.MatchEqual, model.MetricNameLabel, "testmetric")
+		require.NoError(t, err)
 
-	// Verify Series
-	expected := model.Matrix{
-		{
-			Metric: client.FromLabelAdaptersToMetric(client.FromLabelsToLabelAdapters(labels1)),
-			Values: []model.SamplePair{
-				{
-					Timestamp: model.Time(sample1.TimestampMs),
-					Value:     model.SampleValue(sample1.Value),
-				},
-				{
-					Timestamp: model.Time(sample2.TimestampMs),
-					Value:     model.SampleValue(sample2.Value),
+		// Verify Series
+		expected := model.Matrix{
+			{
+				Metric: client.FromLabelAdaptersToMetric(client.FromLabelsToLabelAdapters(labels1)),
+				Values: []model.SamplePair{
+					{
+						Timestamp: model.Time(sample1.TimestampMs),
+						Value:     model.SampleValue(sample1.Value),
+					},
+					{
+						Timestamp: model.Time(sample2.TimestampMs),
+						Value:     model.SampleValue(sample2.Value),
+					},
 				},
 			},
-		},
+		}
+
+		assert.Equal(t, expected, res)
+
+		// Verify metadata
+		m, err := ing.MetricsMetadata(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []*client.MetricMetadata{metadata1}, m.Metadata)
 	}
 
-	assert.Equal(t, expected, res)
+	testLimits()
 
-	// Verify metadata
-	m, err := ing.MetricsMetadata(ctx, nil)
-	require.NoError(t, err)
-	assert.Equal(t, []*client.MetricMetadata{metadata1}, m.Metadata)
+	// Limits should hold after restart.
+	services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
+	_, ing = newTestStore(t, cfg, defaultClientTestConfig(), limits, nil)
+	defer services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
+
+	testLimits()
 }
 
 func TestIngesterValidation(t *testing.T) {

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -42,7 +42,7 @@ type userState struct {
 	ingestedAPISamples  *ewmaRate
 	ingestedRuleSamples *ewmaRate
 
-	seriesInMetric []metricCounterShard
+	seriesInMetric *metricCounter
 
 	// Series metrics.
 	memSeries             prometheus.Gauge
@@ -52,18 +52,11 @@ type userState struct {
 	createdChunks         prometheus.Counter
 }
 
-const metricCounterShards = 128
-
 // DiscardedSamples metric labels
 const (
 	perUserSeriesLimit   = "per_user_series_limit"
 	perMetricSeriesLimit = "per_metric_series_limit"
 )
-
-type metricCounterShard struct {
-	mtx sync.Mutex
-	m   map[string]int
-}
 
 func newUserStates(limiter *Limiter, cfg Config, metrics *ingesterMetrics) *userStates {
 	return &userStates{
@@ -114,13 +107,6 @@ func (us *userStates) getOrCreate(userID string) *userState {
 	state, ok := us.get(userID)
 	if !ok {
 
-		seriesInMetric := make([]metricCounterShard, 0, metricCounterShards)
-		for i := 0; i < metricCounterShards; i++ {
-			seriesInMetric = append(seriesInMetric, metricCounterShard{
-				m: map[string]int{},
-			})
-		}
-
 		// Speculatively create a userState object and try to store it
 		// in the map.  Another goroutine may have got there before
 		// us, in which case this userState will be discarded
@@ -132,7 +118,7 @@ func (us *userStates) getOrCreate(userID string) *userState {
 			index:               index.New(),
 			ingestedAPISamples:  newEWMARate(0.2, us.cfg.RateUpdatePeriod),
 			ingestedRuleSamples: newEWMARate(0.2, us.cfg.RateUpdatePeriod),
-			seriesInMetric:      seriesInMetric,
+			seriesInMetric:      newMetricCounter(us.limiter),
 
 			memSeries:             us.metrics.memSeries,
 			memSeriesCreatedTotal: us.metrics.memSeriesCreatedTotal.WithLabelValues(userID),
@@ -224,7 +210,7 @@ func (u *userState) createSeriesWithFingerprint(fp model.Fingerprint, metric lab
 
 	if !recovery {
 		// Check if the per-metric limit has been exceeded
-		if err = u.canAddSeriesFor(string(metricName)); err != nil {
+		if err = u.seriesInMetric.canAddSeriesFor(u.userID, metricName); err != nil {
 			// WARNING: returns a reference to `metric`
 			return nil, makeMetricLimitError(perMetricSeriesLimit, client.FromLabelAdaptersToLabels(metric), err)
 		}
@@ -232,6 +218,7 @@ func (u *userState) createSeriesWithFingerprint(fp model.Fingerprint, metric lab
 
 	u.memSeriesCreatedTotal.Inc()
 	u.memSeries.Inc()
+	u.seriesInMetric.seriesAddedFor(metricName)
 
 	if record != nil {
 		lbls := make(labels.Labels, 0, len(metric))
@@ -251,23 +238,9 @@ func (u *userState) createSeriesWithFingerprint(fp model.Fingerprint, metric lab
 	return series, nil
 }
 
-func (u *userState) canAddSeriesFor(metric string) error {
-	shard := &u.seriesInMetric[util.HashFP(model.Fingerprint(fnv1a.HashString64(string(metric))))%metricCounterShards]
-	shard.mtx.Lock()
-	defer shard.mtx.Unlock()
-
-	err := u.limiter.AssertMaxSeriesPerMetric(u.userID, shard.m[metric])
-	if err != nil {
-		return err
-	}
-
-	shard.m[metric]++
-	return nil
-}
-
 func (u *userState) removeSeries(fp model.Fingerprint, metric labels.Labels) {
 	u.fpToSeries.del(fp)
-	u.index.Delete(labels.Labels(metric), fp)
+	u.index.Delete(metric, fp)
 
 	metricName := metric.Get(model.MetricNameLabel)
 	if metricName == "" {
@@ -276,14 +249,7 @@ func (u *userState) removeSeries(fp model.Fingerprint, metric labels.Labels) {
 		panic("No metric name label")
 	}
 
-	shard := &u.seriesInMetric[util.HashFP(model.Fingerprint(fnv1a.HashString64(string(metricName))))%metricCounterShards]
-	shard.mtx.Lock()
-	defer shard.mtx.Unlock()
-
-	shard.m[metricName]--
-	if shard.m[metricName] == 0 {
-		delete(shard.m, metricName)
-	}
+	u.seriesInMetric.removeMetricName(metricName)
 
 	u.memSeriesRemovedTotal.Inc()
 	u.memSeries.Dec()
@@ -352,4 +318,66 @@ outer:
 		return send(ctx)
 	}
 	return nil
+}
+
+const numMetricCounterShards = 128
+
+type metricCounterShard struct {
+	mtx sync.Mutex
+	m   map[string]int
+}
+
+type metricCounter struct {
+	limiter *Limiter
+	shards  []metricCounterShard
+}
+
+func newMetricCounter(limiter *Limiter) *metricCounter {
+	shards := make([]metricCounterShard, 0, numMetricCounterShards)
+	for i := 0; i < numMetricCounterShards; i++ {
+		shards = append(shards, metricCounterShard{
+			m: map[string]int{},
+		})
+	}
+	return &metricCounter{
+		limiter: limiter,
+		shards:  shards,
+	}
+}
+
+func (m *metricCounter) removeMetricName(metricName string) {
+	shard := m.getShard(metricName)
+	shard.mtx.Lock()
+	defer shard.mtx.Unlock()
+
+	shard.m[metricName]--
+	if shard.m[metricName] == 0 {
+		delete(shard.m, metricName)
+	}
+}
+
+func (m *metricCounter) getShard(metricName string) *metricCounterShard {
+	shard := &m.shards[util.HashFP(model.Fingerprint(fnv1a.HashString64(metricName)))%numMetricCounterShards]
+	return shard
+}
+
+func (m *metricCounter) canAddSeriesFor(userID, metric string) error {
+	shard := m.getShard(metric)
+	shard.mtx.Lock()
+	defer shard.mtx.Unlock()
+
+	err := m.limiter.AssertMaxSeriesPerMetric(userID, shard.m[metric])
+	if err != nil {
+		return err
+	}
+
+	shard.m[metric]++
+	return nil
+}
+
+func (m *metricCounter) seriesAddedFor(metric string) {
+	shard := m.getShard(metric)
+	shard.mtx.Lock()
+	shard.m[metric]++
+	shard.mtx.Unlock()
 }

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -366,13 +366,7 @@ func (m *metricCounter) canAddSeriesFor(userID, metric string) error {
 	shard.mtx.Lock()
 	defer shard.mtx.Unlock()
 
-	err := m.limiter.AssertMaxSeriesPerMetric(userID, shard.m[metric])
-	if err != nil {
-		return err
-	}
-
-	shard.m[metric]++
-	return nil
+	return m.limiter.AssertMaxSeriesPerMetric(userID, shard.m[metric])
 }
 
 func (m *metricCounter) seriesAddedFor(metric string) {


### PR DESCRIPTION

**What this PR does**:
This refactoring will help in adding series limits to block based ingester. It also fixes a bug where the [series per metric is not incremented when recovering from WAL](https://github.com/cortexproject/cortex/blob/85f93ff4abd7af81a5eeeae0e07379dd6ff2071d/pkg/ingester/user_state.go#L225-L231).

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
