### PR TITLE
Changes in docker-compose (multiservices) setup

### DIFF
--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -53,6 +53,16 @@ tsdb:
       memcached:
         addresses: dns+memcached:11211
 
+    chunks_cache:
+      backend: memcached
+      memcached:
+        addresses: dns+memcached:11211
+
+    metadata_cache:
+      backend: memcached
+      memcached:
+        addresses: dns+memcached:11211
+
   s3:
     endpoint:          minio:9000
     bucket_name:       cortex-tsdb

--- a/development/tsdb-blocks-storage-s3/config/grafana-agent.yaml
+++ b/development/tsdb-blocks-storage-s3/config/grafana-agent.yaml
@@ -11,51 +11,48 @@ prometheus:
     - name: local
       host_filter: false
       scrape_configs:
-        - job_name: cortex-distributor
+        - job_name: tsdb-blocks-storage-s3/distributor
           static_configs:
             - targets: ['distributor:8001']
               labels:
-                container: 'distributor'
-        - job_name: cortex-ingester-1
+                cluster: 'docker-compose'
+                namespace: 'tsdb-blocks-storage-s3'
+        - job_name: tsdb-blocks-storage-s3/ingester
           static_configs:
-            - targets: ['ingester-1:8002']
+            - targets: ['ingester-1:8002', 'ingester-2:8003']
               labels:
-                container: 'ingester-1'
-        - job_name: cortex-ingester-2
-          static_configs:
-            - targets: ['ingester-2:8003']
-              labels:
-                container: 'ingester-2'
-        - job_name: cortex-querier
+                cluster: 'docker-compose'
+                namespace: 'tsdb-blocks-storage-s3'
+        - job_name: tsdb-blocks-storage-s3/querier
           static_configs:
             - targets: ['querier:8004']
               labels:
-                container: 'querier'
-        - job_name: cortex-ruler
+                cluster: 'docker-compose'
+                namespace: 'tsdb-blocks-storage-s3'
+        - job_name: tsdb-blocks-storage-s3/ruler
           static_configs:
             - targets: ['ruler:8005']
               labels:
-                container: 'ruler'
-        - job_name: cortex-compactor
+                cluster: 'docker-compose'
+                namespace: 'tsdb-blocks-storage-s3'
+        - job_name: tsdb-blocks-storage-s3/compactor
           static_configs:
             - targets: ['compactor:8006']
               labels:
-                container: 'compactor'
-        - job_name: cortex-query-frontend
+                cluster: 'docker-compose'
+                namespace: 'tsdb-blocks-storage-s3'
+        - job_name: tsdb-blocks-storage-s3/query-frontend
           static_configs:
             - targets: ['query-frontend:8007']
               labels:
-                container: 'query-frontend'
-        - job_name: cortex-store-gateway-1
+                cluster: 'docker-compose'
+                namespace: 'tsdb-blocks-storage-s3'
+        - job_name: tsdb-blocks-storage-s3/store-gateway
           static_configs:
-            - targets: ['store-gateway-1:8008']
+            - targets: ['store-gateway-1:8008', 'store-gateway-2:8009']
               labels:
-                container: 'store-gateway-1'
-        - job_name: cortex-store-gateway-2
-          static_configs:
-            - targets: ['store-gateway-2:8009']
-              labels:
-                container: 'store-gateway-2'
+                cluster: 'docker-compose'
+                namespace: 'tsdb-blocks-storage-s3'
 
       remote_write:
         - url: http://distributor:8001/api/prom/push

--- a/development/tsdb-blocks-storage-s3/config/prometheus.yaml
+++ b/development/tsdb-blocks-storage-s3/config/prometheus.yaml
@@ -4,51 +4,48 @@ global:
     origin: prometheus
 
 scrape_configs:
-  - job_name: cortex-distributor
+  - job_name: tsdb-blocks-storage-s3/distributor
     static_configs:
       - targets: ['distributor:8001']
         labels:
-          container: 'distributor'
-  - job_name: cortex-ingester-1
+          cluster: 'docker-compose'
+          namespace: 'tsdb-blocks-storage-s3'
+  - job_name: tsdb-blocks-storage-s3/ingester
     static_configs:
-      - targets: ['ingester-1:8002']
+      - targets: ['ingester-1:8002', 'ingester-2:8003']
         labels:
-          container: 'ingester-1'
-  - job_name: cortex-ingester-2
-    static_configs:
-      - targets: ['ingester-2:8003']
-        labels:
-          container: 'ingester-2'
-  - job_name: cortex-querier
+          cluster: 'docker-compose'
+          namespace: 'tsdb-blocks-storage-s3'
+  - job_name: tsdb-blocks-storage-s3/querier
     static_configs:
       - targets: ['querier:8004']
         labels:
-          container: 'querier'
-  - job_name: cortex-ruler
+          cluster: 'docker-compose'
+          namespace: 'tsdb-blocks-storage-s3'
+  - job_name: tsdb-blocks-storage-s3/ruler
     static_configs:
       - targets: ['ruler:8005']
         labels:
-          container: 'ruler'
-  - job_name: cortex-compactor
+          cluster: 'docker-compose'
+          namespace: 'tsdb-blocks-storage-s3'
+  - job_name: tsdb-blocks-storage-s3/compactor
     static_configs:
       - targets: ['compactor:8006']
         labels:
-          container: 'compactor'
-  - job_name: cortex-query-frontend
+          cluster: 'docker-compose'
+          namespace: 'tsdb-blocks-storage-s3'
+  - job_name: tsdb-blocks-storage-s3/query-frontend
     static_configs:
       - targets: ['query-frontend:8007']
         labels:
-          container: 'query-frontend'
-  - job_name: cortex-store-gateway-1
+          cluster: 'docker-compose'
+          namespace: 'tsdb-blocks-storage-s3'
+  - job_name: tsdb-blocks-storage-s3/store-gateway
     static_configs:
-      - targets: ['store-gateway-1:8008']
+      - targets: ['store-gateway-1:8008', 'store-gateway-2:8009']
         labels:
-          container: 'store-gateway-1'
-  - job_name: cortex-store-gateway-2
-    static_configs:
-      - targets: ['store-gateway-2:8009']
-        labels:
-          container: 'store-gateway-2'
+          cluster: 'docker-compose'
+          namespace: 'tsdb-blocks-storage-s3'
 
 remote_write:
   - url: http://distributor:8001/api/prom/push


### PR DESCRIPTION
This PR modifies docker-compose setup:
- It enables chunks and metadata caching (using same memcached)
- It modifies Prometheus and Grafana Agent config to add `cluster` and `namespace` labels, and to include namespace in the `job` label. This matches deployment in Kubernetes, and makes it easier to test dashboards from https://github.com/grafana/cortex-jsonnet/ repository.

