### PR TITLE
Use vendor deps when building.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ RM := --rm
 # as it currently disallows TTY devices. This value needs to be overridden
 # in any custom cloudbuild.yaml files
 TTY := --tty
-GO_FLAGS := -ldflags "-X main.Branch=$(GIT_BRANCH) -X main.Revision=$(GIT_REVISION) -X main.Version=$(VERSION) -extldflags \"-static\" -s -w" -tags netgo
+GO_FLAGS := -ldflags "-X main.Branch=$(GIT_BRANCH) -X main.Revision=$(GIT_REVISION) -X main.Version=$(VERSION) -extldflags \"-static\" -s -w" -tags netgo -mod vendor
 
 ifeq ($(BUILD_IN_CONTAINER),true)
 


### PR DESCRIPTION
Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>

**What this PR does**:

Use `-mod=vendor` when building, to prevent us downloading all the modules and make sure we build with the vendored files.

**Which issue(s) this PR fixes**:
Fixes #1710