### PR TITLE
Refactor querier batch iterator to make it general purpose

### DIFF
--- a/pkg/querier/batch/batch_test.go
+++ b/pkg/querier/batch/batch_test.go
@@ -1,0 +1,67 @@
+package batch
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+	promchunk "github.com/cortexproject/cortex/pkg/chunk/encoding"
+)
+
+func BenchmarkNewChunkMergeIterator_CreateAndIterate(b *testing.B) {
+	scenarios := []struct {
+		numChunks          int
+		numSamplesPerChunk int
+		duplicationFactor  int
+		enc                promchunk.Encoding
+	}{
+		{numChunks: 1000, numSamplesPerChunk: 100, duplicationFactor: 1, enc: promchunk.Bigchunk},
+		{numChunks: 1000, numSamplesPerChunk: 100, duplicationFactor: 3, enc: promchunk.Bigchunk},
+		{numChunks: 1000, numSamplesPerChunk: 100, duplicationFactor: 1, enc: promchunk.Varbit},
+		{numChunks: 1000, numSamplesPerChunk: 100, duplicationFactor: 3, enc: promchunk.Varbit},
+		{numChunks: 1000, numSamplesPerChunk: 100, duplicationFactor: 1, enc: promchunk.DoubleDelta},
+		{numChunks: 1000, numSamplesPerChunk: 100, duplicationFactor: 3, enc: promchunk.DoubleDelta},
+	}
+
+	for _, scenario := range scenarios {
+		name := fmt.Sprintf("chunks: %d samples per chunk: %d duplication factor: %d encoding: %s",
+			scenario.numChunks,
+			scenario.numSamplesPerChunk,
+			scenario.duplicationFactor,
+			scenario.enc.String())
+
+		chunks := createChunks(b, scenario.numChunks, scenario.numSamplesPerChunk, scenario.duplicationFactor, scenario.enc)
+
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			for n := 0; n < b.N; n++ {
+				it := NewChunkMergeIterator(chunks, 0, 0)
+				for it.Next() {
+					it.At()
+				}
+
+				// Ensure no error occurred.
+				if it.Err() != nil {
+					b.Fatal(it.Err().Error())
+				}
+			}
+		})
+	}
+}
+
+func createChunks(b *testing.B, numChunks, numSamplesPerChunk, duplicationFactor int, enc promchunk.Encoding) []chunk.Chunk {
+	result := make([]chunk.Chunk, 0, numChunks)
+
+	for d := 0; d < duplicationFactor; d++ {
+		for c := 0; c < numChunks; c++ {
+			minTime := step * time.Duration(c*numSamplesPerChunk)
+			result = append(result, mkChunk(b, model.Time(minTime.Milliseconds()), numSamplesPerChunk, enc))
+		}
+	}
+
+	return result
+}

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -22,7 +22,7 @@ const (
 
 func TestChunkIter(t *testing.T) {
 	forEncodings(t, func(t *testing.T, enc promchunk.Encoding) {
-		chunk := mkChunk(t, 0, 100, enc)
+		chunk := mkGenericChunk(t, 0, 100, enc)
 		iter := &chunkIterator{}
 		iter.reset(chunk)
 		testIter(t, 100, newIteratorAdapter(iter))
@@ -57,6 +57,11 @@ func mkChunk(t require.TestingT, from model.Time, points int, enc promchunk.Enco
 		ts = ts.Add(step)
 	}
 	return chunk.NewChunk(userID, fp, metric, pc, model.Time(0), ts)
+}
+
+func mkGenericChunk(t require.TestingT, from model.Time, points int, enc promchunk.Encoding) GenericChunk {
+	ck := mkChunk(t, from, points, enc)
+	return NewGenericChunk(int64(ck.From), int64(ck.Through), ck.Data.NewIterator)
 }
 
 func testIter(t require.TestingT, points int, iter chunkenc.Iterator) {
@@ -95,8 +100,8 @@ func testSeek(t require.TestingT, points int, iter chunkenc.Iterator) {
 func TestSeek(t *testing.T) {
 	var it mockIterator
 	c := chunkIterator{
-		chunk: chunk.Chunk{
-			Through: promchunk.BatchSize,
+		chunk: GenericChunk{
+			MaxTime: promchunk.BatchSize,
 		},
 		it: &it,
 	}

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -6,18 +6,17 @@ import (
 
 	"github.com/prometheus/common/model"
 
-	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/encoding"
 )
 
 func TestMergeIter(t *testing.T) {
 	forEncodings(t, func(t *testing.T, enc encoding.Encoding) {
-		chunk1 := mkChunk(t, 0, 100, enc)
-		chunk2 := mkChunk(t, model.TimeFromUnix(25), 100, enc)
-		chunk3 := mkChunk(t, model.TimeFromUnix(50), 100, enc)
-		chunk4 := mkChunk(t, model.TimeFromUnix(75), 100, enc)
-		chunk5 := mkChunk(t, model.TimeFromUnix(100), 100, enc)
-		iter := newMergeIterator([]chunk.Chunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+		chunk1 := mkGenericChunk(t, 0, 100, enc)
+		chunk2 := mkGenericChunk(t, model.TimeFromUnix(25), 100, enc)
+		chunk3 := mkGenericChunk(t, model.TimeFromUnix(50), 100, enc)
+		chunk4 := mkGenericChunk(t, model.TimeFromUnix(75), 100, enc)
+		chunk5 := mkGenericChunk(t, model.TimeFromUnix(100), 100, enc)
+		iter := newMergeIterator([]GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
 		testIter(t, 200, newIteratorAdapter(iter))
 		testSeek(t, 200, newIteratorAdapter(iter))
 	})
@@ -27,13 +26,13 @@ func TestMergeHarder(t *testing.T) {
 	forEncodings(t, func(t *testing.T, enc encoding.Encoding) {
 		var (
 			numChunks = 24 * 15
-			chunks    = make([]chunk.Chunk, 0)
+			chunks    = make([]GenericChunk, 0, numChunks)
 			from      = model.Time(0)
 			offset    = 30
 			samples   = 100
 		)
 		for i := 0; i < numChunks; i++ {
-			chunks = append(chunks, mkChunk(t, from, samples, enc))
+			chunks = append(chunks, mkGenericChunk(t, from, samples, enc))
 			from = from.Add(time.Duration(offset) * time.Second)
 		}
 		iter := newMergeIterator(chunks)

--- a/pkg/querier/batch/non_overlapping.go
+++ b/pkg/querier/batch/non_overlapping.go
@@ -1,19 +1,18 @@
 package batch
 
 import (
-	"github.com/cortexproject/cortex/pkg/chunk"
 	promchunk "github.com/cortexproject/cortex/pkg/chunk/encoding"
 )
 
 type nonOverlappingIterator struct {
 	curr   int
-	chunks []chunk.Chunk
+	chunks []GenericChunk
 	iter   chunkIterator
 }
 
 // newNonOverlappingIterator returns a single iterator over an slice of sorted,
 // non-overlapping iterators.
-func newNonOverlappingIterator(chunks []chunk.Chunk) *nonOverlappingIterator {
+func newNonOverlappingIterator(chunks []GenericChunk) *nonOverlappingIterator {
 	it := &nonOverlappingIterator{
 		chunks: chunks,
 	}

--- a/pkg/querier/batch/non_overlapping_test.go
+++ b/pkg/querier/batch/non_overlapping_test.go
@@ -5,15 +5,14 @@ import (
 
 	"github.com/prometheus/common/model"
 
-	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/encoding"
 )
 
 func TestNonOverlappingIter(t *testing.T) {
 	forEncodings(t, func(t *testing.T, enc encoding.Encoding) {
-		cs := []chunk.Chunk{}
+		cs := []GenericChunk(nil)
 		for i := int64(0); i < 100; i++ {
-			cs = append(cs, mkChunk(t, model.TimeFromUnix(i*10), 10, enc))
+			cs = append(cs, mkGenericChunk(t, model.TimeFromUnix(i*10), 10, enc))
 		}
 		testIter(t, 10*100, newIteratorAdapter(newNonOverlappingIterator(cs)))
 		testSeek(t, 10*100, newIteratorAdapter(newNonOverlappingIterator(cs)))
@@ -22,13 +21,13 @@ func TestNonOverlappingIter(t *testing.T) {
 
 func TestNonOverlappingIterSparse(t *testing.T) {
 	forEncodings(t, func(t *testing.T, enc encoding.Encoding) {
-		cs := []chunk.Chunk{
-			mkChunk(t, model.TimeFromUnix(0), 1, enc),
-			mkChunk(t, model.TimeFromUnix(1), 3, enc),
-			mkChunk(t, model.TimeFromUnix(4), 1, enc),
-			mkChunk(t, model.TimeFromUnix(5), 90, enc),
-			mkChunk(t, model.TimeFromUnix(95), 1, enc),
-			mkChunk(t, model.TimeFromUnix(96), 4, enc),
+		cs := []GenericChunk{
+			mkGenericChunk(t, model.TimeFromUnix(0), 1, enc),
+			mkGenericChunk(t, model.TimeFromUnix(1), 3, enc),
+			mkGenericChunk(t, model.TimeFromUnix(4), 1, enc),
+			mkGenericChunk(t, model.TimeFromUnix(5), 90, enc),
+			mkGenericChunk(t, model.TimeFromUnix(95), 1, enc),
+			mkGenericChunk(t, model.TimeFromUnix(96), 4, enc),
 		}
 		testIter(t, 100, newIteratorAdapter(newNonOverlappingIterator(cs)))
 		testSeek(t, 100, newIteratorAdapter(newNonOverlappingIterator(cs)))


### PR DESCRIPTION
**What this PR does**:
We would like to reuse the querier batch iterator in the blocks storage too because preminary tests showed to bring a significant speed up in the query execution (we're currently using the TSDB series merger and iterator, which is optimised for low memory consumption but is significantly slower).

In order to use it, we would need to make the batch iterator general purpose. I tried two approaches:
1. Define an interface for the Chunk used by the batch iterator
2. Define a minimal structure for the Chunk used by the batch iterator

It turned out that the penalty introduced by the interface is too high (see below), while using a minimal structure we make it even faster at the cost of having more allocation OPs (1 per chunk).

What's the general feeling about this change?

### Benchmark comparing master vs this PR

```
benchmark                                                                                                                             old ns/op     new ns/op     delta
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Bigchunk-4        10020268      8404163       -16.13%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Bigchunk-4        31939048      28450913      -10.92%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Varbit-4          6465872       5651066       -12.60%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Varbit-4          24011040      21032546      -12.40%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_DoubleDelta-4     6143207       5614876       -8.60%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_DoubleDelta-4     24046341      20173709      -16.10%

benchmark                                                                                                                             old allocs     new allocs     delta
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Bigchunk-4        4018           5019           +24.91%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Bigchunk-4        12022          15023          +24.96%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Varbit-4          3018           4019           +33.17%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Varbit-4          9022           12023          +33.26%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_DoubleDelta-4     4018           5019           +24.91%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_DoubleDelta-4     12022          15023          +24.96%

benchmark                                                                                                                             old bytes     new bytes     delta
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Bigchunk-4        11475107      10720404      -6.58%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Bigchunk-4        34903491      32340176      -7.34%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Varbit-4          11475088      10720403      -6.58%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Varbit-4          34903488      32340183      -7.34%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_DoubleDelta-4     11475091      10720400      -6.58%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_DoubleDelta-4     34903488      32340176      -7.34%
```

### Benchmark comparing master vs the attempt to use an interface

```
benchmark                                                                                                                             old ns/op     new ns/op     delta
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Bigchunk-4        10020268      11645325      +16.22%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Bigchunk-4        31939048      52028295      +62.90%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Varbit-4          6465872       8863111       +37.08%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Varbit-4          24011040      44406526      +84.94%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_DoubleDelta-4     6143207       8930470       +45.37%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_DoubleDelta-4     24046341      44445349      +84.83%

benchmark                                                                                                                             old allocs     new allocs     delta
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Bigchunk-4        4018           4020           +0.05%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Bigchunk-4        12022          12024          +0.02%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Varbit-4          3018           3020           +0.07%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Varbit-4          9022           9024           +0.02%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_DoubleDelta-4     4018           4020           +0.05%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_DoubleDelta-4     12022          12024          +0.02%

benchmark                                                                                                                             old bytes     new bytes     delta
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Bigchunk-4        11475107      10616435      -7.48%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Bigchunk-4        34903491      31993296      -8.34%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Varbit-4          11475088      10616402      -7.48%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Varbit-4          34903488      31993296      -8.34%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_DoubleDelta-4     11475091      10616402      -7.48%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_DoubleDelta-4     34903488      31993299      -8.34%
```



**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
