### PR TITLE
Selectively query blocks from each store-gateway

### DIFF
--- a/pkg/querier/blocks_consistency_checker.go
+++ b/pkg/querier/blocks_consistency_checker.go
@@ -63,7 +63,7 @@ func (c *BlocksConsistencyChecker) Check(expectedBlocks []*BlockMeta, knownDelet
 		// - Blocks uploaded by ingesters: we will continue querying them from ingesters for a while (depends
 		//   on the configured retention period).
 		// - Blocks uploaded by compactor: the source blocks are marked for deletion but will continue to be
-		//   queried by store-gateways for a while (depends on the configured deletion marks delay).
+		//   queried by queriers for a while (depends on the configured deletion marks delay).
 		if c.uploadGracePeriod > 0 && time.Since(meta.UploadedAt) < c.uploadGracePeriod {
 			level.Debug(c.logger).Log("msg", "block skipped from consistency check because it was uploaded recently", "block", meta.ULID.String(), "uploadedAt", meta.UploadedAt.String())
 			continue

--- a/pkg/querier/blocks_store_balanced_set.go
+++ b/pkg/querier/blocks_store_balanced_set.go
@@ -58,7 +58,7 @@ func (s *blocksStoreBalancedSet) resolve(ctx context.Context) error {
 	return nil
 }
 
-func (s *blocksStoreBalancedSet) GetClientsFor(_ []ulid.ULID) ([]BlocksStoreClient, error) {
+func (s *blocksStoreBalancedSet) GetClientsFor(blockIDs []ulid.ULID) (map[BlocksStoreClient][]ulid.ULID, error) {
 	addresses := s.dnsProvider.Addresses()
 	if len(addresses) == 0 {
 		return nil, fmt.Errorf("no address resolved for the store-gateway service addresses %s", strings.Join(s.serviceAddresses, ","))
@@ -71,5 +71,8 @@ func (s *blocksStoreBalancedSet) GetClientsFor(_ []ulid.ULID) ([]BlocksStoreClie
 		return nil, errors.Wrapf(err, "failed to get store-gateway client for %s", addr)
 	}
 
-	return []BlocksStoreClient{c.(BlocksStoreClient)}, nil
+	clients := map[BlocksStoreClient][]ulid.ULID{}
+	clients[c.(BlocksStoreClient)] = blockIDs
+
+	return clients, nil
 }

--- a/pkg/querier/blocks_store_balanced_set_test.go
+++ b/pkg/querier/blocks_store_balanced_set_test.go
@@ -32,11 +32,14 @@ func TestBlocksStoreBalancedSet_GetClientsFor(t *testing.T) {
 	for i := 0; i < numGets; i++ {
 		clients, err := s.GetClientsFor(nil)
 		require.NoError(t, err)
+		require.Len(t, clients, 1)
 
-		addrs := getStoreGatewayClientAddrs(clients)
-		require.Len(t, addrs, 1)
+		var clientAddr string
+		for c := range clients {
+			clientAddr = c.RemoteAddress()
+		}
 
-		clientsCount[addrs[0]] = clientsCount[addrs[0]] + 1
+		clientsCount[clientAddr] = clientsCount[clientAddr] + 1
 	}
 
 	assert.Len(t, clientsCount, len(serviceAddrs))

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	"github.com/thanos-io/thanos/pkg/store/hintspb"
@@ -46,7 +48,7 @@ type BlocksStoreSet interface {
 
 	// GetClientsFor returns the store gateway clients that should be used to
 	// query the set of blocks in input.
-	GetClientsFor(blockIDs []ulid.ULID) ([]BlocksStoreClient, error)
+	GetClientsFor(blockIDs []ulid.ULID) (map[BlocksStoreClient][]ulid.ULID, error)
 }
 
 // BlocksFinder is the interface used to find blocks for a given user and time range.
@@ -341,28 +343,28 @@ func (q *blocksStoreQuerier) selectSorted(sp *storage.SelectHints, matchers ...*
 	}
 	level.Debug(spanLog).Log("msg", "found store-gateway instances to query", "num instances", len(clients))
 
-	req := &storepb.SeriesRequest{
-		MinTime:                 minT,
-		MaxTime:                 maxT,
-		Matchers:                convertMatchersToLabelMatcher(matchers),
-		PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
-	}
-
 	var (
-		reqCtx        = grpc_metadata.AppendToOutgoingContext(spanCtx, cortex_tsdb.TenantIDExternalLabel, q.userID)
-		g, gCtx       = errgroup.WithContext(reqCtx)
-		mtx           = sync.Mutex{}
-		seriesSets    = []storage.SeriesSet(nil)
-		warnings      = storage.Warnings(nil)
-		queriedBlocks = map[string][]hintspb.Block{}
+		reqCtx            = grpc_metadata.AppendToOutgoingContext(spanCtx, cortex_tsdb.TenantIDExternalLabel, q.userID)
+		g, gCtx           = errgroup.WithContext(reqCtx)
+		mtx               = sync.Mutex{}
+		seriesSets        = []storage.SeriesSet(nil)
+		warnings          = storage.Warnings(nil)
+		queriedBlocks     = map[string][]hintspb.Block{}
+		convertedMatchers = convertMatchersToLabelMatcher(matchers)
 	)
 
 	// Concurrently fetch series from all clients.
-	for _, c := range clients {
-		// Change variable scope since it will be used in a goroutine.
+	for c, blockIDs := range clients {
+		// Change variables scope since it will be used in a goroutine.
 		c := c
+		blockIDs := blockIDs
 
 		g.Go(func() error {
+			req, err := createSeriesRequest(minT, maxT, convertedMatchers, blockIDs)
+			if err != nil {
+				return errors.Wrapf(err, "failed to create series request")
+			}
+
 			stream, err := c.Series(gCtx, req)
 			if err != nil {
 				return errors.Wrapf(err, "failed to fetch series from %s", c)
@@ -399,7 +401,12 @@ func (q *blocksStoreQuerier) selectSorted(sp *storage.SelectHints, matchers ...*
 				}
 			}
 
-			level.Debug(spanLog).Log("msg", "received series from store-gateway", "instance", c, "num series", len(mySeries), "bytes series", countSeriesBytes(mySeries))
+			level.Debug(spanLog).Log("msg", "received series from store-gateway",
+				"instance", c,
+				"num series", len(mySeries),
+				"bytes series", countSeriesBytes(mySeries),
+				"requested blocks", convertULIDsToString(blockIDs),
+				"queried blocks", convertBlockHintsToString(myQueriedBlocks))
 
 			// Store the result.
 			mtx.Lock()
@@ -429,6 +436,48 @@ func (q *blocksStoreQuerier) selectSorted(sp *storage.SelectHints, matchers ...*
 	}
 
 	return storage.NewMergeSeriesSet(seriesSets, storage.ChainedSeriesMerge), warnings, nil
+}
+
+func createSeriesRequest(minT, maxT int64, matchers []storepb.LabelMatcher, blockIDs []ulid.ULID) (*storepb.SeriesRequest, error) {
+	// Selectively query only specific blocks.
+	hints := &hintspb.SeriesRequestHints{
+		BlockMatchers: []storepb.LabelMatcher{
+			{
+				Type:  storepb.LabelMatcher_RE,
+				Name:  block.BlockIDLabel,
+				Value: strings.Join(convertULIDsToString(blockIDs), "|"),
+			},
+		},
+	}
+
+	anyHints, err := types.MarshalAny(hints)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to marshal request hints")
+	}
+
+	return &storepb.SeriesRequest{
+		MinTime:                 minT,
+		MaxTime:                 maxT,
+		Matchers:                matchers,
+		PartialResponseStrategy: storepb.PartialResponseStrategy_ABORT,
+		Hints:                   anyHints,
+	}, nil
+}
+
+func convertULIDsToString(ids []ulid.ULID) []string {
+	res := make([]string, len(ids))
+	for idx, id := range ids {
+		res[idx] = id.String()
+	}
+	return res
+}
+
+func convertBlockHintsToString(hints []hintspb.Block) []string {
+	res := make([]string, len(hints))
+	for idx, hint := range hints {
+		res[idx] = hint.Id
+	}
+	return res
 }
 
 func countSeriesBytes(series []*storepb.Series) (count uint64) {

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -405,8 +405,8 @@ func (q *blocksStoreQuerier) selectSorted(sp *storage.SelectHints, matchers ...*
 				"instance", c,
 				"num series", len(mySeries),
 				"bytes series", countSeriesBytes(mySeries),
-				"requested blocks", convertULIDsToString(blockIDs),
-				"queried blocks", convertBlockHintsToString(myQueriedBlocks))
+				"requested blocks", strings.Join(convertULIDsToString(blockIDs), ","),
+				"queried blocks", strings.Join(convertBlockHintsToString(myQueriedBlocks), ","))
 
 			// Store the result.
 			mtx.Lock()

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -70,8 +70,8 @@ func (s *blocksStoreReplicationSet) stopping(_ error) error {
 	return services.StopManagerAndAwaitStopped(context.Background(), s.subservices)
 }
 
-func (s *blocksStoreReplicationSet) GetClientsFor(blockIDs []ulid.ULID) ([]BlocksStoreClient, error) {
-	var sets []ring.ReplicationSet
+func (s *blocksStoreReplicationSet) GetClientsFor(blockIDs []ulid.ULID) (map[BlocksStoreClient][]ulid.ULID, error) {
+	shards := map[string][]ulid.ULID{}
 
 	// Find the replication set of each block we need to query.
 	for _, blockID := range blockIDs {
@@ -85,66 +85,27 @@ func (s *blocksStoreReplicationSet) GetClientsFor(blockIDs []ulid.ULID) ([]Block
 			return nil, errors.Wrapf(err, "failed to get store-gateway replication set owning the block %s", blockID.String())
 		}
 
-		sets = append(sets, set)
+		// Pick the first store-gateway instance.
+		addr := set.Ingesters[0].Addr
+
+		if _, ok := shards[addr]; ok {
+			shards[addr] = append(shards[addr], blockID)
+		} else {
+			shards[addr] = []ulid.ULID{blockID}
+		}
 	}
 
-	var clients []BlocksStoreClient
+	clients := map[BlocksStoreClient][]ulid.ULID{}
 
 	// Get the client for each store-gateway.
-	for _, addr := range findSmallestInstanceSet(sets) {
+	for addr, blockIDs := range shards {
 		c, err := s.clientsPool.GetClientFor(addr)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get store-gateway client for %s", addr)
 		}
 
-		clients = append(clients, c.(BlocksStoreClient))
+		clients[c.(BlocksStoreClient)] = blockIDs
 	}
 
 	return clients, nil
-}
-
-// findSmallestInstanceSet returns the minimal set of store-gateway instances including all required blocks.
-// Blocks may be replicated across store-gateway instances, but we want to query the lowest number of instances
-// possible, so this function tries to find the smallest set of store-gateway instances containing all blocks
-// we need to query.
-func findSmallestInstanceSet(sets []ring.ReplicationSet) []string {
-	addr := findHighestInstanceOccurrences(sets)
-	if addr == "" {
-		return nil
-	}
-
-	// Remove any replication set containing the selected instance address.
-	for i := 0; i < len(sets); {
-		if sets[i].Includes(addr) {
-			sets = append(sets[:i], sets[i+1:]...)
-		} else {
-			i++
-		}
-	}
-
-	return append([]string{addr}, findSmallestInstanceSet(sets)...)
-}
-
-func findHighestInstanceOccurrences(sets []ring.ReplicationSet) string {
-	var highestAddr string
-	var highestCount int
-
-	occurrences := map[string]int{}
-
-	for _, set := range sets {
-		for _, i := range set.Ingesters {
-			if v, ok := occurrences[i.Addr]; ok {
-				occurrences[i.Addr] = v + 1
-			} else {
-				occurrences[i.Addr] = 1
-			}
-
-			if occurrences[i.Addr] > highestCount {
-				highestAddr = i.Addr
-				highestCount = occurrences[i.Addr]
-			}
-		}
-	}
-
-	return highestAddr
 }

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -88,11 +88,7 @@ func (s *blocksStoreReplicationSet) GetClientsFor(blockIDs []ulid.ULID) (map[Blo
 		// Pick the first store-gateway instance.
 		addr := set.Ingesters[0].Addr
 
-		if _, ok := shards[addr]; ok {
-			shards[addr] = append(shards[addr], blockID)
-		} else {
-			shards[addr] = []ulid.ULID{blockID}
-		}
+		shards[addr] = append(shards[addr], blockID)
 	}
 
 	clients := map[BlocksStoreClient][]ulid.ULID{}


### PR DESCRIPTION
**What this PR does**:
What we learned running Cortex blocks storage at a medium scale is that store-gateway blocks sharding may lead to some inefficiencies at query time, having the same block unintentionally queried from multiple store-gateway (replicas) at the same time.

To improve this, we introduced in Thanos the ability to selectively pick which blocks should be queried (via block matchers) and in this PR I'm leveraging on this to selectively query blocks from each store-gateway instance.

~~Draft PR until~~:
- ~~https://github.com/cortexproject/cortex/pull/2688 gets merged and rebased here~~
- ~~Tests are done in our dev clusters~~

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
