### PR TITLE
Fix test timeout when test.Poll in TestBasicLifecycler_HeartbeatWhile…

### DIFF
--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -199,8 +199,8 @@ func (l *BasicLifecycler) stopping(runningError error) error {
 	// state transferring / flushing while we continue to heartbeat.
 	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		l.delegate.OnRingInstanceStopping(l)
-		close(done)
 	}()
 
 	// Heartbeat while the stopping delegate function is running.


### PR DESCRIPTION
This PR fixes test timeout observed at https://app.circleci.com/pipelines/github/cortexproject/cortex/6177/workflows/621b9e86-1e1e-410e-ba8a-bfd5b376fe74/jobs/31442/steps.

What happens is that `onStopping` delegate in `TestBasicLifecycler_HeartbeatWhileStopping` test fails (which is implemented as panic and recover), which then doesn't close `done` channel in basic lifecycler. Lifecycler then never leaves `stopping` function.

Fixed by defering closing of the channel.