### PR TITLE
Refetch series for missing blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,10 @@
   - `cortex_purger_oldest_pending_delete_request_age_seconds`: Age of oldest pending delete request in seconds.
   - `cortex_purger_pending_delete_requests_count`: Count of requests which are in process or are ready to be processed.
 * [ENHANCEMENT] Experimental TSDB: Improved compactor to hard-delete also partial blocks with an deletion mark (even if the deletion mark threshold has not been reached). #2751
-* [ENHANCEMENT] Experimental TSDB: Introduced a consistency check done by the querier to ensure all expected blocks have been queried via the store-gateway. If a block is missing on a store-gateway, the querier retries fetching series from missing blocks up to 3 times. If the consistency check fails once all retries have been exhausted, the query execution fails. #2593 #2630 #2695
+* [ENHANCEMENT] Experimental TSDB: Introduced a consistency check done by the querier to ensure all expected blocks have been queried via the store-gateway. If a block is missing on a store-gateway, the querier retries fetching series from missing blocks up to 3 times. If the consistency check fails once all retries have been exhausted, the query execution fails. The following metrics have been added: #2593 #2630 #2689 #2695
+  * `cortex_querier_blocks_consistency_checks_total`
+  * `cortex_querier_blocks_consistency_checks_failed_total`
+  * `cortex_querier_storegateway_refetches_per_query`
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400
@@ -171,7 +174,8 @@ Please make sure to review renamed metrics, and update your dashboards and alert
 * [FEATURE] Experimental: Added support for `/api/v1/metadata` Prometheus-based endpoint. #2549
 * [FEATURE] Add ability to limit concurrent queries to Cassandra with `-cassandra.query-concurrency` flag. #2562
 * [FEATURE] Add `-cassandra.table-options` flag to customize table options of Cassandra when creating the index or chunk table. #2575
-* [FEATURE] Experimental TSDB: Introduced store-gateway service used by the experimental blocks storage to load and query blocks. The store-gateway optionally supports blocks sharding and replication via a dedicated hash ring, configurable via `-experimental.store-gateway.sharding-enabled` and `-experimental.store-gateway.sharding-ring.*` flags. #2433 #2458 #2469 #2523
+* [FEATURE] Experimental TSDB: Introduced store-gateway service used by the experimental blocks storage to load and query blocks. The store-gateway optionally supports blocks sharding and replication via a dedicated hash ring, configurable via `-experimental.store-gateway.sharding-enabled` and `-experimental.store-gateway.sharding-ring.*` flags. The following metrics have been added: #2433 #2458 #2469 #2523
+  * `cortex_querier_storegateway_instances_hit_per_query`
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
 * [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383
 * [ENHANCEMENT] Experimental TSDB: Added `cortex_querier_blocks_meta_synced`, which reflects current state of synced blocks over all tenants. #2392

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@
   - `cortex_purger_oldest_pending_delete_request_age_seconds`: Age of oldest pending delete request in seconds.
   - `cortex_purger_pending_delete_requests_count`: Count of requests which are in process or are ready to be processed.
 * [ENHANCEMENT] Experimental TSDB: Improved compactor to hard-delete also partial blocks with an deletion mark (even if the deletion mark threshold has not been reached). #2751
+* [ENHANCEMENT] Experimental TSDB: Introduced a consistency check done by the querier to ensure all expected blocks have been queried via the store-gateway. If a block is missing on a store-gateway, the querier retries fetching series from missing blocks up to 3 times. If the consistency check fails once all retries have been exhausted, the query execution fails. #2593 #2630 #2695
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400
@@ -170,6 +171,7 @@ Please make sure to review renamed metrics, and update your dashboards and alert
 * [FEATURE] Experimental: Added support for `/api/v1/metadata` Prometheus-based endpoint. #2549
 * [FEATURE] Add ability to limit concurrent queries to Cassandra with `-cassandra.query-concurrency` flag. #2562
 * [FEATURE] Add `-cassandra.table-options` flag to customize table options of Cassandra when creating the index or chunk table. #2575
+* [FEATURE] Experimental TSDB: Introduced store-gateway service used by the experimental blocks storage to load and query blocks. The store-gateway optionally supports blocks sharding and replication via a dedicated hash ring, configurable via `-experimental.store-gateway.sharding-enabled` and `-experimental.store-gateway.sharding-ring.*` flags. #2433 #2458 #2469 #2523
 * [ENHANCEMENT] Experimental TSDB: sample ingestion errors are now reported via existing `cortex_discarded_samples_total` metric. #2370
 * [ENHANCEMENT] Failures on samples at distributors and ingesters return the first validation error as opposed to the last. #2383
 * [ENHANCEMENT] Experimental TSDB: Added `cortex_querier_blocks_meta_synced`, which reflects current state of synced blocks over all tenants. #2392
@@ -195,6 +197,7 @@ Please make sure to review renamed metrics, and update your dashboards and alert
 * [ENHANCEMENT] WAL: the experimental tag has been removed on the WAL in ingesters. #2560
 * [ENHANCEMENT] Use newer AWS API for paginated queries - removes 'Deprecated' message from logfiles. #2452
 * [ENHANCEMENT] Experimental memberlist: Add retry with backoff on memberlist join other members. #2705
+* [ENHANCEMENT] Experimental TSDB: when the store-gateway sharding is enabled, unhealthy store-gateway instances are automatically removed from the ring after 10 consecutive `-experimental.store-gateway.sharding-ring.heartbeat-timeout` periods. #2526
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. Fixes #2411. #2372
 * [BUGFIX] Experimental TSDB: Fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/development/tsdb-blocks-storage-s3-single-binary/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3-single-binary/config/cortex.yaml
@@ -37,10 +37,6 @@ store_gateway:
       consul:
         host: consul:8500
 
-querier:
-  blocks_consistency_check:
-    enabled: true
-
 tsdb:
   dir: /data/cortex-tsdb-ingester
   ship_interval: 1m

--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -32,9 +32,6 @@ querier:
   # Used when the blocks sharding is disabled.
   store_gateway_addresses: store-gateway-1:9008,store-gateway-2:9009
 
-  blocks_consistency_check:
-    enabled: true
-
 tsdb:
   store_gateway_enabled: true
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -667,14 +667,6 @@ store_gateway_client:
   # TLS CA path for the client
   # CLI flag: -experimental.querier.store-gateway-client.tls-ca-path
   [tls_ca_path: <string> | default = ""]
-
-# Configures the consistency check done by the querier on queried blocks when
-# running the experimental blocks storage.
-blocks_consistency_check:
-  # Whether the querier should run a consistency check to ensure all expected
-  # blocks have been queried.
-  # CLI flag: -experimental.querier.blocks-consistency-check.enabled
-  [enabled: <boolean> | default = false]
 ```
 
 ### `query_frontend_config`

--- a/pkg/querier/blocks_store_balanced_set.go
+++ b/pkg/querier/blocks_store_balanced_set.go
@@ -76,7 +76,7 @@ func (s *blocksStoreBalancedSet) GetClientsFor(blockIDs []ulid.ULID, exclude map
 		// Pick the first non excluded store-gateway instance.
 		addr := getFirstNonExcludedAddr(addresses, exclude[blockID])
 		if addr == "" {
-			return nil, fmt.Errorf("no store-gateway instance left after checking exclude list for block %s", blockID.String())
+			return nil, fmt.Errorf("no store-gateway instance left after filtering out excluded instances for block %s", blockID.String())
 		}
 
 		c, err := s.clientsPool.GetClientFor(addr)

--- a/pkg/querier/blocks_store_balanced_set_test.go
+++ b/pkg/querier/blocks_store_balanced_set_test.go
@@ -2,10 +2,12 @@ package querier
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/go-kit/kit/log"
+	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -18,6 +20,7 @@ import (
 func TestBlocksStoreBalancedSet_GetClientsFor(t *testing.T) {
 	const numGets = 1000
 	serviceAddrs := []string{"127.0.0.1", "127.0.0.2"}
+	block1 := ulid.MustNew(1, nil)
 
 	ctx := context.Background()
 	reg := prometheus.NewPedanticRegistry()
@@ -30,7 +33,7 @@ func TestBlocksStoreBalancedSet_GetClientsFor(t *testing.T) {
 	clientsCount := map[string]int{}
 
 	for i := 0; i < numGets; i++ {
-		clients, err := s.GetClientsFor(nil)
+		clients, err := s.GetClientsFor([]ulid.ULID{block1}, map[ulid.ULID][]string{})
 		require.NoError(t, err)
 		require.Len(t, clients, 1)
 
@@ -64,4 +67,84 @@ func TestBlocksStoreBalancedSet_GetClientsFor(t *testing.T) {
 		# TYPE cortex_storegateway_clients gauge
 		cortex_storegateway_clients{client="querier"} 2
 	`)))
+}
+
+func TestBlocksStoreBalancedSet_GetClientsFor_Blacklist(t *testing.T) {
+	block1 := ulid.MustNew(1, nil)
+	block2 := ulid.MustNew(2, nil)
+
+	tests := map[string]struct {
+		serviceAddrs    []string
+		queryBlocks     []ulid.ULID
+		blacklist       map[ulid.ULID][]string
+		expectedClients map[string][]ulid.ULID
+		expectedErr     error
+	}{
+		"no blacklist": {
+			serviceAddrs: []string{"127.0.0.1"},
+			queryBlocks:  []ulid.ULID{block1, block2},
+			expectedClients: map[string][]ulid.ULID{
+				"127.0.0.1": {block1, block2},
+			},
+		},
+		"single instance available and blacklisted for a non-queried block": {
+			serviceAddrs: []string{"127.0.0.1"},
+			queryBlocks:  []ulid.ULID{block1},
+			blacklist: map[ulid.ULID][]string{
+				block2: {"127.0.0.1"},
+			},
+			expectedClients: map[string][]ulid.ULID{
+				"127.0.0.1": {block1},
+			},
+		},
+		"single instance available and blacklisted for the queried block": {
+			serviceAddrs: []string{"127.0.0.1"},
+			queryBlocks:  []ulid.ULID{block1},
+			blacklist: map[ulid.ULID][]string{
+				block1: {"127.0.0.1"},
+			},
+			expectedErr: fmt.Errorf("no store-gateway instance left after checking blacklist for block %s", block1.String()),
+		},
+		"multiple instances available and one is blacklisted for the queried blocks": {
+			serviceAddrs: []string{"127.0.0.1", "127.0.0.2"},
+			queryBlocks:  []ulid.ULID{block1, block2},
+			blacklist: map[ulid.ULID][]string{
+				block1: {"127.0.0.1"},
+				block2: {"127.0.0.2"},
+			},
+			expectedClients: map[string][]ulid.ULID{
+				"127.0.0.1": {block2},
+				"127.0.0.2": {block1},
+			},
+		},
+		"multiple instances available and all are blacklisted for the queried block": {
+			serviceAddrs: []string{"127.0.0.1", "127.0.0.2"},
+			queryBlocks:  []ulid.ULID{block1, block2},
+			blacklist: map[ulid.ULID][]string{
+				block1: {"127.0.0.1", "127.0.0.2"},
+			},
+			expectedErr: fmt.Errorf("no store-gateway instance left after checking blacklist for block %s", block1.String()),
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			s := newBlocksStoreBalancedSet(testData.serviceAddrs, tls.ClientConfig{}, log.NewNopLogger(), nil)
+			require.NoError(t, services.StartAndAwaitRunning(ctx, s))
+			defer services.StopAndAwaitTerminated(ctx, s) //nolint:errcheck
+
+			clients, err := s.GetClientsFor(testData.queryBlocks, testData.blacklist)
+			assert.Equal(t, testData.expectedErr, err)
+
+			if testData.expectedErr == nil {
+				assert.Equal(t, testData.expectedClients, getStoreGatewayClientAddrs(clients))
+			}
+		})
+	}
+
 }

--- a/pkg/querier/blocks_store_balanced_set_test.go
+++ b/pkg/querier/blocks_store_balanced_set_test.go
@@ -103,7 +103,7 @@ func TestBlocksStoreBalancedSet_GetClientsFor_Exclude(t *testing.T) {
 			exclude: map[ulid.ULID][]string{
 				block1: {"127.0.0.1"},
 			},
-			expectedErr: fmt.Errorf("no store-gateway instance left after checking exclude list for block %s", block1.String()),
+			expectedErr: fmt.Errorf("no store-gateway instance left after filtering out excluded instances for block %s", block1.String()),
 		},
 		"multiple instances available and one is excluded for the queried blocks": {
 			serviceAddrs: []string{"127.0.0.1", "127.0.0.2"},
@@ -123,7 +123,7 @@ func TestBlocksStoreBalancedSet_GetClientsFor_Exclude(t *testing.T) {
 			exclude: map[ulid.ULID][]string{
 				block1: {"127.0.0.1", "127.0.0.2"},
 			},
-			expectedErr: fmt.Errorf("no store-gateway instance left after checking exclude list for block %s", block1.String()),
+			expectedErr: fmt.Errorf("no store-gateway instance left after filtering out excluded instances for block %s", block1.String()),
 		},
 	}
 

--- a/pkg/querier/blocks_store_balanced_set_test.go
+++ b/pkg/querier/blocks_store_balanced_set_test.go
@@ -103,7 +103,7 @@ func TestBlocksStoreBalancedSet_GetClientsFor_Exclude(t *testing.T) {
 			exclude: map[ulid.ULID][]string{
 				block1: {"127.0.0.1"},
 			},
-			expectedErr: fmt.Errorf("no store-gateway instance left after checking exclude for block %s", block1.String()),
+			expectedErr: fmt.Errorf("no store-gateway instance left after checking exclude list for block %s", block1.String()),
 		},
 		"multiple instances available and one is excluded for the queried blocks": {
 			serviceAddrs: []string{"127.0.0.1", "127.0.0.2"},
@@ -123,7 +123,7 @@ func TestBlocksStoreBalancedSet_GetClientsFor_Exclude(t *testing.T) {
 			exclude: map[ulid.ULID][]string{
 				block1: {"127.0.0.1", "127.0.0.2"},
 			},
-			expectedErr: fmt.Errorf("no store-gateway instance left after checking exclude for block %s", block1.String()),
+			expectedErr: fmt.Errorf("no store-gateway instance left after checking exclude list for block %s", block1.String()),
 		},
 	}
 

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -95,7 +95,7 @@ func newBlocksStoreQueryableMetrics(reg prometheus.Registerer) *blocksStoreQuery
 			Namespace: "cortex",
 			Name:      "querier_storegateway_refetches_per_query",
 			Help:      "Number of re-fetches attempted while querying store-gateway instances due to missing blocks.",
-			Buckets:   []float64{0, 1, 2, 3},
+			Buckets:   []float64{0, 1, 2},
 		}),
 	}
 }

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -411,7 +411,7 @@ func (q *blocksStoreQuerier) selectSorted(sp *storage.SelectHints, matchers ...*
 
 	// We've not been able to query all expected blocks after all retries.
 	err = fmt.Errorf("consistency check failed because some blocks were not queried: %s", strings.Join(convertULIDsToString(remainingBlocks), " "))
-	level.Warn(util.WithContext(q.ctx, q.logger)).Log("msg", "failed consistency check", "err", err)
+	level.Warn(util.WithContext(spanCtx, q.logger)).Log("msg", "failed consistency check", "err", err)
 
 	return nil, nil, err
 }

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -367,6 +367,7 @@ func (q *blocksStoreQuerier) selectSorted(sp *storage.SelectHints, matchers ...*
 			// If it's a retry and we get an error, it means there are no more store-gateways left
 			// from which running another attempt, so we're just stopping retrying.
 			if attempt > 1 {
+				level.Warn(spanLog).Log("msg", "unable to get store-gateway clients while retrying to fetch missing blocks", "err", err)
 				break
 			}
 

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -2,7 +2,7 @@ package querier
 
 import (
 	"context"
-	"flag"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -38,6 +38,13 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
+const (
+	// The maximum number of times we retry fetching missing blocks from different
+	// store-gateways. If no more store-gateways are left (ie. due to lower replication
+	// factor) than we'll end the retries earlier.
+	maxFetchSeriesTries = 3
+)
+
 var (
 	errNoStoreGatewayAddress = errors.New("no store-gateway address configured")
 )
@@ -48,7 +55,7 @@ type BlocksStoreSet interface {
 
 	// GetClientsFor returns the store gateway clients that should be used to
 	// query the set of blocks in input.
-	GetClientsFor(blockIDs []ulid.ULID) (map[BlocksStoreClient][]ulid.ULID, error)
+	GetClientsFor(blockIDs []ulid.ULID, blacklist map[ulid.ULID][]string) (map[BlocksStoreClient][]ulid.ULID, error)
 }
 
 // BlocksFinder is the interface used to find blocks for a given user and time range.
@@ -70,12 +77,26 @@ type BlocksStoreClient interface {
 	RemoteAddress() string
 }
 
-type BlocksConsistencyCheckConfig struct {
-	Enabled bool `yaml:"enabled"`
+type blocksStoreQueryableMetrics struct {
+	storesHit prometheus.Histogram
+	refetches prometheus.Histogram
 }
 
-func (cfg *BlocksConsistencyCheckConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.BoolVar(&cfg.Enabled, prefix+".enabled", false, "Whether the querier should run a consistency check to ensure all expected blocks have been queried.")
+func newBlocksStoreQueryableMetrics(reg prometheus.Registerer) *blocksStoreQueryableMetrics {
+	return &blocksStoreQueryableMetrics{
+		storesHit: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Namespace: "cortex",
+			Name:      "querier_storegateway_instances_hit_per_query",
+			Help:      "Number of store-gateway instances hit for a single query.",
+			Buckets:   []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		}),
+		refetches: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Namespace: "cortex",
+			Name:      "querier_storegateway_refetches_per_query",
+			Help:      "Number of re-fetches attempted while querying store-gateway instances due to missing blocks.",
+			Buckets:   []float64{0, 1, 2, 3},
+		}),
+	}
 }
 
 // BlocksStoreQueryable is a queryable which queries blocks storage via
@@ -88,13 +109,11 @@ type BlocksStoreQueryable struct {
 	consistency     *BlocksConsistencyChecker
 	logger          log.Logger
 	queryStoreAfter time.Duration
+	metrics         *blocksStoreQueryableMetrics
 
 	// Subservices manager.
 	subservices        *services.Manager
 	subservicesWatcher *services.FailureWatcher
-
-	// Metrics.
-	storesHit prometheus.Histogram
 }
 
 func NewBlocksStoreQueryable(stores BlocksStoreSet, finder BlocksFinder, consistency *BlocksConsistencyChecker, queryStoreAfter time.Duration, logger log.Logger, reg prometheus.Registerer) (*BlocksStoreQueryable, error) {
@@ -113,12 +132,7 @@ func NewBlocksStoreQueryable(stores BlocksStoreSet, finder BlocksFinder, consist
 		logger:             logger,
 		subservices:        manager,
 		subservicesWatcher: services.NewFailureWatcher(),
-		storesHit: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Namespace: "cortex",
-			Name:      "querier_storegateway_instances_hit_per_query",
-			Help:      "Number of store-gateway instances hit for a single query.",
-			Buckets:   []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		}),
+		metrics:            newBlocksStoreQueryableMetrics(reg),
 	}
 
 	q.Service = services.NewBasicService(q.starting, q.running, q.stopping)
@@ -182,20 +196,17 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 		stores = newBlocksStoreBalancedSet(querierCfg.GetStoreGatewayAddresses(), querierCfg.StoreGatewayClient, logger, reg)
 	}
 
-	var consistency *BlocksConsistencyChecker
-	if querierCfg.BlocksConsistencyCheck.Enabled {
-		consistency = NewBlocksConsistencyChecker(
-			// Exclude blocks which have been recently uploaded, in order to give enough time to store-gateways
-			// to discover and load them (3 times the sync interval).
-			storageCfg.BucketStore.ConsistencyDelay+(3*storageCfg.BucketStore.SyncInterval),
-			// To avoid any false positive in the consistency check, we do exclude blocks which have been
-			// recently marked for deletion, until the "ignore delay / 2". This means the consistency checker
-			// exclude such blocks about 50% of the time before querier and store-gateway stops querying them.
-			storageCfg.BucketStore.IgnoreDeletionMarksDelay/2,
-			logger,
-			reg,
-		)
-	}
+	consistency := NewBlocksConsistencyChecker(
+		// Exclude blocks which have been recently uploaded, in order to give enough time to store-gateways
+		// to discover and load them (3 times the sync interval).
+		storageCfg.BucketStore.ConsistencyDelay+(3*storageCfg.BucketStore.SyncInterval),
+		// To avoid any false positive in the consistency check, we do exclude blocks which have been
+		// recently marked for deletion, until the "ignore delay / 2". This means the consistency checker
+		// exclude such blocks about 50% of the time before querier and store-gateway stops querying them.
+		storageCfg.BucketStore.IgnoreDeletionMarksDelay/2,
+		logger,
+		reg,
+	)
 
 	return NewBlocksStoreQueryable(stores, scanner, consistency, querierCfg.QueryStoreAfter, logger, reg)
 }
@@ -243,7 +254,7 @@ func (q *BlocksStoreQueryable) Querier(ctx context.Context, mint, maxt int64) (s
 		userID:          userID,
 		finder:          q.finder,
 		stores:          q.stores,
-		storesHit:       q.storesHit,
+		metrics:         q.metrics,
 		consistency:     q.consistency,
 		logger:          q.logger,
 		queryStoreAfter: q.queryStoreAfter,
@@ -256,7 +267,7 @@ type blocksStoreQuerier struct {
 	userID      string
 	finder      BlocksFinder
 	stores      BlocksStoreSet
-	storesHit   prometheus.Histogram
+	metrics     *blocksStoreQueryableMetrics
 	consistency *BlocksConsistencyChecker
 	logger      log.Logger
 
@@ -315,51 +326,94 @@ func (q *blocksStoreQuerier) selectSorted(sp *storage.SelectHints, matchers ...*
 		}
 
 		if maxT < minT {
-			q.storesHit.Observe(0)
+			q.metrics.storesHit.Observe(0)
 			level.Debug(spanLog).Log("msg", "empty query time range after max time manipulation")
 			return series.NewEmptySeriesSet(), nil, nil
 		}
 	}
 
 	// Find the list of blocks we need to query given the time range.
-	metas, deletionMarks, err := q.finder.GetBlocks(q.userID, minT, maxT)
+	knownMetas, knownDeletionMarks, err := q.finder.GetBlocks(q.userID, minT, maxT)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if len(metas) == 0 {
-		q.storesHit.Observe(0)
+	if len(knownMetas) == 0 {
+		q.metrics.storesHit.Observe(0)
 		level.Debug(spanLog).Log("msg", "no blocks found")
 		return series.NewEmptySeriesSet(), nil, nil
 	}
 
-	level.Debug(spanLog).Log("msg", "found blocks to query", "expected", BlockMetas(metas).String())
+	level.Debug(spanLog).Log("msg", "found blocks to query", "expected", BlockMetas(knownMetas).String())
 
-	// Convert matchers.
-	convertedMatchers := convertMatchersToLabelMatcher(matchers)
+	var (
+		// At the beginning the list of blocks to query are all known blocks.
+		remainingBlocks = getULIDsFromBlockMetas(knownMetas)
+		attemptedBlocks = map[ulid.ULID][]string{}
+		touchedStores   = map[string]struct{}{}
 
-	// Find the set of store-gateway instances having the blocks.
-	blockIDs := getULIDsFromBlockMetas(metas)
-	clients, err := q.stores.GetClientsFor(blockIDs)
-	if err != nil {
-		return nil, nil, err
-	}
-	level.Debug(spanLog).Log("msg", "found store-gateway instances to query", "num instances", len(clients))
+		convertedMatchers = convertMatchersToLabelMatcher(matchers)
+		resSeriesSets     = []storage.SeriesSet(nil)
+		resWarnings       = storage.Warnings(nil)
+		resQueriedBlocks  = []ulid.ULID(nil)
+	)
 
-	seriesSets, queriedBlocks, warnings, err := q.fetchSeriesFromStores(spanCtx, clients, minT, maxT, convertedMatchers)
+	for retry := 0; retry < maxFetchSeriesTries; retry++ {
+		// Find the set of store-gateway instances having the blocks. The blacklist passed is the
+		// map of blocks queried so far, with the list of store-gateway addresses for each block.
+		clients, err := q.stores.GetClientsFor(remainingBlocks, attemptedBlocks)
+		if err != nil {
+			// If it's a retry and we get an error, it means there are no more store-gateways left
+			// from which running another attempt, so we're just stopping retrying.
+			if retry > 0 {
+				break
+			}
 
-	level.Debug(spanLog).Log("msg", "received series from all store-gateways", "queried blocks", queriedBlocks)
-	q.storesHit.Observe(float64(len(clients)))
-
-	// Ensure all expected blocks have been queried.
-	if q.consistency != nil {
-		if err := q.consistency.Check(metas, deletionMarks, queriedBlocks); err != nil {
-			level.Warn(util.WithContext(q.ctx, q.logger)).Log("msg", "failed consistency check", "err", err)
 			return nil, nil, err
 		}
+		level.Debug(spanLog).Log("msg", "found store-gateway instances to query", "num instances", len(clients), "retry", retry)
+
+		// Fetch series from stores. If an error occur we do not retry because retries
+		// are only meant to cover missing blocks.
+		seriesSets, queriedBlocks, warnings, err := q.fetchSeriesFromStores(spanCtx, clients, minT, maxT, convertedMatchers)
+		if err != nil {
+			return nil, nil, err
+		}
+		level.Debug(spanLog).Log("msg", "received series from all store-gateways", "queried blocks", strings.Join(convertULIDsToString(queriedBlocks), " "))
+
+		resSeriesSets = append(resSeriesSets, seriesSets...)
+		resWarnings = append(resWarnings, warnings...)
+		resQueriedBlocks = append(resQueriedBlocks, queriedBlocks...)
+
+		// Update the map of blocks we attempted to query.
+		for client, blockIDs := range clients {
+			touchedStores[client.RemoteAddress()] = struct{}{}
+
+			for _, blockID := range blockIDs {
+				attemptedBlocks[blockID] = append(attemptedBlocks[blockID], client.RemoteAddress())
+			}
+		}
+
+		// Ensure all expected blocks have been queried (during all tries done so far).
+		missingBlocks := q.consistency.Check(knownMetas, knownDeletionMarks, resQueriedBlocks)
+		if len(missingBlocks) == 0 {
+			q.metrics.storesHit.Observe(float64(len(touchedStores)))
+			q.metrics.refetches.Observe(float64(retry))
+
+			return storage.NewMergeSeriesSet(resSeriesSets, storage.ChainedSeriesMerge), resWarnings, nil
+		}
+
+		level.Debug(spanLog).Log("msg", "consistency check failed", "missing blocks", strings.Join(convertULIDsToString(missingBlocks), " "))
+
+		// The next retry should just query the missing blocks.
+		remainingBlocks = missingBlocks
 	}
 
-	return storage.NewMergeSeriesSet(seriesSets, storage.ChainedSeriesMerge), warnings, nil
+	// We've not been able to query all expected blocks after all retries.
+	err = fmt.Errorf("consistency check failed because some blocks were not queried: %s", strings.Join(convertULIDsToString(remainingBlocks), " "))
+	level.Warn(util.WithContext(q.ctx, q.logger)).Log("msg", "failed consistency check", "err", err)
+
+	return nil, nil, err
 }
 
 func (q *blocksStoreQuerier) fetchSeriesFromStores(
@@ -368,14 +422,14 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 	minT int64,
 	maxT int64,
 	matchers []storepb.LabelMatcher,
-) ([]storage.SeriesSet, map[string][]hintspb.Block, storage.Warnings, error) {
+) ([]storage.SeriesSet, []ulid.ULID, storage.Warnings, error) {
 	var (
 		reqCtx        = grpc_metadata.AppendToOutgoingContext(ctx, cortex_tsdb.TenantIDExternalLabel, q.userID)
 		g, gCtx       = errgroup.WithContext(reqCtx)
 		mtx           = sync.Mutex{}
 		seriesSets    = []storage.SeriesSet(nil)
 		warnings      = storage.Warnings(nil)
-		queriedBlocks = map[string][]hintspb.Block{}
+		queriedBlocks = []ulid.ULID(nil)
 		spanLog       = spanlogger.FromContext(ctx)
 	)
 
@@ -398,7 +452,7 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 
 			mySeries := []*storepb.Series(nil)
 			myWarnings := storage.Warnings(nil)
-			myQueriedBlocks := []hintspb.Block(nil)
+			myQueriedBlocks := []ulid.ULID(nil)
 
 			for {
 				resp, err := stream.Recv()
@@ -423,7 +477,13 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 					if err := types.UnmarshalAny(h, &hints); err != nil {
 						return errors.Wrapf(err, "failed to unmarshal hints from %s", c)
 					}
-					myQueriedBlocks = append(myQueriedBlocks, hints.QueriedBlocks...)
+
+					ids, err := convertBlockHintsToULIDs(hints.QueriedBlocks)
+					if err != nil {
+						return errors.Wrapf(err, "failed to parse queried block IDs from received hints")
+					}
+
+					myQueriedBlocks = append(myQueriedBlocks, ids...)
 				}
 			}
 
@@ -431,14 +491,14 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 				"instance", c,
 				"num series", len(mySeries),
 				"bytes series", countSeriesBytes(mySeries),
-				"requested blocks", strings.Join(convertULIDsToString(blockIDs), ","),
-				"queried blocks", strings.Join(convertBlockHintsToString(myQueriedBlocks), ","))
+				"requested blocks", strings.Join(convertULIDsToString(blockIDs), " "),
+				"queried blocks", strings.Join(convertULIDsToString(myQueriedBlocks), " "))
 
 			// Store the result.
 			mtx.Lock()
 			seriesSets = append(seriesSets, &blockQuerierSeriesSet{series: mySeries})
 			warnings = append(warnings, myWarnings...)
-			queriedBlocks[c.RemoteAddress()] = myQueriedBlocks
+			queriedBlocks = append(queriedBlocks, myQueriedBlocks...)
 			mtx.Unlock()
 
 			return nil
@@ -487,12 +547,19 @@ func convertULIDsToString(ids []ulid.ULID) []string {
 	return res
 }
 
-func convertBlockHintsToString(hints []hintspb.Block) []string {
-	res := make([]string, len(hints))
+func convertBlockHintsToULIDs(hints []hintspb.Block) ([]ulid.ULID, error) {
+	res := make([]ulid.ULID, len(hints))
+
 	for idx, hint := range hints {
-		res[idx] = hint.Id
+		blockID, err := ulid.Parse(hint.Id)
+		if err != nil {
+			return nil, err
+		}
+
+		res[idx] = blockID
 	}
-	return res
+
+	return res, nil
 }
 
 func countSeriesBytes(series []*storepb.Series) (count uint64) {

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -55,7 +55,7 @@ type BlocksStoreSet interface {
 
 	// GetClientsFor returns the store gateway clients that should be used to
 	// query the set of blocks in input.
-	GetClientsFor(blockIDs []ulid.ULID, blacklist map[ulid.ULID][]string) (map[BlocksStoreClient][]ulid.ULID, error)
+	GetClientsFor(blockIDs []ulid.ULID, exclude map[ulid.ULID][]string) (map[BlocksStoreClient][]ulid.ULID, error)
 }
 
 // BlocksFinder is the interface used to find blocks for a given user and time range.
@@ -359,7 +359,7 @@ func (q *blocksStoreQuerier) selectSorted(sp *storage.SelectHints, matchers ...*
 	)
 
 	for retry := 0; retry < maxFetchSeriesTries; retry++ {
-		// Find the set of store-gateway instances having the blocks. The blacklist passed is the
+		// Find the set of store-gateway instances having the blocks. The exclude list passed is the
 		// map of blocks queried so far, with the list of store-gateway addresses for each block.
 		clients, err := q.stores.GetClientsFor(remainingBlocks, attemptedBlocks)
 		if err != nil {

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
@@ -59,12 +61,12 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		finderResult   []*BlockMeta
-		finderErr      error
-		storeSetResult map[BlocksStoreClient][]ulid.ULID
-		storeSetErr    error
-		expectedSeries []seriesResult
-		expectedErr    string
+		finderResult      []*BlockMeta
+		finderErr         error
+		storeSetResponses []interface{}
+		expectedSeries    []seriesResult
+		expectedErr       string
+		expectedMetrics   string
 	}{
 		"no block in the storage matching the query time range": {
 			finderResult: nil,
@@ -79,7 +81,9 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
-			storeSetErr: errors.New("no client found"),
+			storeSetResponses: []interface{}{
+				errors.New("no client found"),
+			},
 			expectedErr: "no client found",
 		},
 		"a single store-gateway instance holds the required blocks (single returned series)": {
@@ -87,12 +91,14 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
-			storeSetResult: map[BlocksStoreClient][]ulid.ULID{
-				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
-					mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
-					mockHintsResponse(block1, block2),
-				}}: {block1, block2},
+			storeSetResponses: []interface{}{
+				map[BlocksStoreClient][]ulid.ULID{
+					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
+						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockHintsResponse(block1, block2),
+					}}: {block1, block2},
+				},
 			},
 			expectedSeries: []seriesResult{
 				{
@@ -109,13 +115,15 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
-			storeSetResult: map[BlocksStoreClient][]ulid.ULID{
-				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
-					mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
-					mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 3),
-					mockHintsResponse(block1, block2),
-				}}: {block1, block2},
+			storeSetResponses: []interface{}{
+				map[BlocksStoreClient][]ulid.ULID{
+					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
+						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 3),
+						mockHintsResponse(block1, block2),
+					}}: {block1, block2},
+				},
 			},
 			expectedSeries: []seriesResult{
 				{
@@ -137,15 +145,17 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
-			storeSetResult: map[BlocksStoreClient][]ulid.ULID{
-				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
-					mockHintsResponse(block1),
-				}}: {block1},
-				&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
-					mockHintsResponse(block2),
-				}}: {block2},
+			storeSetResponses: []interface{}{
+				map[BlocksStoreClient][]ulid.ULID{
+					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
+						mockHintsResponse(block1),
+					}}: {block1},
+					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockHintsResponse(block2),
+					}}: {block2},
+				},
 			},
 			expectedSeries: []seriesResult{
 				{
@@ -162,16 +172,18 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
-			storeSetResult: map[BlocksStoreClient][]ulid.ULID{
-				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
-					mockHintsResponse(block1),
-				}}: {block1},
-				&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
-					mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
-					mockHintsResponse(block2),
-				}}: {block2},
+			storeSetResponses: []interface{}{
+				map[BlocksStoreClient][]ulid.ULID{
+					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockHintsResponse(block1),
+					}}: {block1},
+					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel}, minT, 1),
+						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockHintsResponse(block2),
+					}}: {block2},
+				},
 			},
 			expectedSeries: []seriesResult{
 				{
@@ -188,22 +200,24 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
-			storeSetResult: map[BlocksStoreClient][]ulid.ULID{
-				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
-					mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 1),
-					mockHintsResponse(block1),
-				}}: {block1},
-				&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
-					mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
-					mockHintsResponse(block2),
-				}}: {block2},
-				&storeGatewayClientMock{remoteAddr: "3.3.3.3", mockedResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 1),
-					mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT+1, 3),
-					mockHintsResponse(block3),
-				}}: {block3},
+			storeSetResponses: []interface{}{
+				map[BlocksStoreClient][]ulid.ULID{
+					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 1),
+						mockHintsResponse(block1),
+					}}: {block1},
+					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
+						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockHintsResponse(block2),
+					}}: {block2},
+					&storeGatewayClientMock{remoteAddr: "3.3.3.3", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 1),
+						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT+1, 3),
+						mockHintsResponse(block3),
+					}}: {block3},
+				},
 			},
 			expectedSeries: []seriesResult{
 				{
@@ -220,18 +234,51 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 					},
 				},
 			},
+			expectedMetrics: `
+				# HELP cortex_querier_storegateway_instances_hit_per_query Number of store-gateway instances hit for a single query.
+				# TYPE cortex_querier_storegateway_instances_hit_per_query histogram
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="0"} 0
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="1"} 0
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="2"} 0
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="3"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="4"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="5"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="6"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="7"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="8"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="9"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="10"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="+Inf"} 1
+				cortex_querier_storegateway_instances_hit_per_query_sum 3
+				cortex_querier_storegateway_instances_hit_per_query_count 1
+
+				# HELP cortex_querier_storegateway_refetches_per_query Number of re-fetches attempted while querying store-gateway instances due to missing blocks.
+				# TYPE cortex_querier_storegateway_refetches_per_query histogram
+				cortex_querier_storegateway_refetches_per_query_bucket{le="0"} 1
+				cortex_querier_storegateway_refetches_per_query_bucket{le="1"} 1
+				cortex_querier_storegateway_refetches_per_query_bucket{le="2"} 1
+				cortex_querier_storegateway_refetches_per_query_bucket{le="3"} 1
+				cortex_querier_storegateway_refetches_per_query_bucket{le="+Inf"} 1
+				cortex_querier_storegateway_refetches_per_query_sum 0
+				cortex_querier_storegateway_refetches_per_query_count 1
+			`,
 		},
 		"a single store-gateway instance has some missing blocks (consistency check failed)": {
 			finderResult: []*BlockMeta{
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
 			},
-			storeSetResult: map[BlocksStoreClient][]ulid.ULID{
-				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
-					mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
-					mockHintsResponse(block1),
-				}}: {block1},
+			storeSetResponses: []interface{}{
+				// First attempt returns a client whose response does not include all expected blocks.
+				map[BlocksStoreClient][]ulid.ULID{
+					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
+						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockHintsResponse(block1),
+					}}: {block1},
+				},
+				// Second attempt returns an error because there are no other store-gateways left.
+				errors.New("no store-gateway remaining after blacklist"),
 			},
 			expectedErr: fmt.Sprintf("consistency check failed because some blocks were not queried: %s", block2.String()),
 		},
@@ -242,27 +289,108 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block3}}},
 				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block4}}},
 			},
-			storeSetResult: map[BlocksStoreClient][]ulid.ULID{
-				&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
-					mockHintsResponse(block1),
-				}}: {block1},
-				&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
-					mockHintsResponse(block2),
-				}}: {block2},
+			storeSetResponses: []interface{}{
+				// First attempt returns a client whose response does not include all expected blocks.
+				map[BlocksStoreClient][]ulid.ULID{
+					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockHintsResponse(block1),
+					}}: {block1},
+					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel}, minT+1, 2),
+						mockHintsResponse(block2),
+					}}: {block2},
+				},
+				// Second attempt returns an error because there are no other store-gateways left.
+				errors.New("no store-gateway remaining after blacklist"),
 			},
 			expectedErr: fmt.Sprintf("consistency check failed because some blocks were not queried: %s %s", block3.String(), block4.String()),
+		},
+		"multiple store-gateway instances have some missing blocks but queried from a replica during subsequent attempts": {
+			finderResult: []*BlockMeta{
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block3}}},
+				{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block4}}},
+			},
+			storeSetResponses: []interface{}{
+				// First attempt returns a client whose response does not include all expected blocks.
+				map[BlocksStoreClient][]ulid.ULID{
+					&storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 1),
+						mockHintsResponse(block1),
+					}}: {block1, block3},
+					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT, 2),
+						mockHintsResponse(block2),
+					}}: {block2, block4},
+				},
+				// Second attempt returns 1 missing block.
+				map[BlocksStoreClient][]ulid.ULID{
+					&storeGatewayClientMock{remoteAddr: "3.3.3.3", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT+1, 2),
+						mockHintsResponse(block3),
+					}}: {block3, block4},
+				},
+				// Third attempt returns the last missing block.
+				map[BlocksStoreClient][]ulid.ULID{
+					&storeGatewayClientMock{remoteAddr: "4.4.4.4", mockedResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{metricNameLabel, series2Label}, minT+1, 3),
+						mockHintsResponse(block4),
+					}}: {block4},
+				},
+			},
+			expectedSeries: []seriesResult{
+				{
+					lbls: labels.New(metricNameLabel, series1Label),
+					values: []valueResult{
+						{t: minT, v: 1},
+						{t: minT + 1, v: 2},
+					},
+				}, {
+					lbls: labels.New(metricNameLabel, series2Label),
+					values: []valueResult{
+						{t: minT, v: 2},
+						{t: minT + 1, v: 3},
+					},
+				},
+			},
+			expectedMetrics: `
+				# HELP cortex_querier_storegateway_instances_hit_per_query Number of store-gateway instances hit for a single query.
+				# TYPE cortex_querier_storegateway_instances_hit_per_query histogram
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="0"} 0
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="1"} 0
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="2"} 0
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="3"} 0
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="4"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="5"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="6"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="7"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="8"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="9"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="10"} 1
+				cortex_querier_storegateway_instances_hit_per_query_bucket{le="+Inf"} 1
+				cortex_querier_storegateway_instances_hit_per_query_sum 4
+				cortex_querier_storegateway_instances_hit_per_query_count 1
+
+				# HELP cortex_querier_storegateway_refetches_per_query Number of re-fetches attempted while querying store-gateway instances due to missing blocks.
+				# TYPE cortex_querier_storegateway_refetches_per_query histogram
+				cortex_querier_storegateway_refetches_per_query_bucket{le="0"} 0
+				cortex_querier_storegateway_refetches_per_query_bucket{le="1"} 0
+				cortex_querier_storegateway_refetches_per_query_bucket{le="2"} 1
+				cortex_querier_storegateway_refetches_per_query_bucket{le="3"} 1
+				cortex_querier_storegateway_refetches_per_query_bucket{le="+Inf"} 1
+				cortex_querier_storegateway_refetches_per_query_sum 2
+				cortex_querier_storegateway_refetches_per_query_count 1
+			`,
 		},
 	}
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			ctx := context.Background()
-			stores := &blocksStoreSetMock{
-				mockedResult: testData.storeSetResult,
-				mockedErr:    testData.storeSetErr,
-			}
+			reg := prometheus.NewPedanticRegistry()
+			stores := &blocksStoreSetMock{mockedResponses: testData.storeSetResponses}
 			finder := &blocksFinderMock{}
 			finder.On("GetBlocks", "user-1", minT, maxT).Return(testData.finderResult, map[ulid.ULID]*metadata.DeletionMark(nil), testData.finderErr)
 
@@ -275,7 +403,7 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 				stores:      stores,
 				consistency: NewBlocksConsistencyChecker(0, 0, log.NewNopLogger(), nil),
 				logger:      log.NewNopLogger(),
-				storesHit:   prometheus.NewHistogram(prometheus.HistogramOpts{}),
+				metrics:     newBlocksStoreQueryableMetrics(reg),
 			}
 
 			matchers := []*labels.Matcher{
@@ -316,6 +444,11 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 			}
 			require.NoError(t, set.Err())
 			assert.Equal(t, testData.expectedSeries, actualSeries)
+
+			// Assert on metrics (optional, only for test cases defining it).
+			if testData.expectedMetrics != "" {
+				assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(testData.expectedMetrics)))
+			}
 		})
 	}
 }
@@ -374,7 +507,7 @@ func TestBlocksStoreQuerier_SelectSortedShouldHonorQueryStoreAfter(t *testing.T)
 				stores:          &blocksStoreSetMock{},
 				consistency:     NewBlocksConsistencyChecker(0, 0, log.NewNopLogger(), nil),
 				logger:          log.NewNopLogger(),
-				storesHit:       prometheus.NewHistogram(prometheus.HistogramOpts{}),
+				metrics:         newBlocksStoreQueryableMetrics(nil),
 				queryStoreAfter: testData.queryStoreAfter,
 			}
 
@@ -520,12 +653,26 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 type blocksStoreSetMock struct {
 	services.Service
 
-	mockedResult map[BlocksStoreClient][]ulid.ULID
-	mockedErr    error
+	mockedResponses []interface{}
+	nextResult      int
 }
 
-func (m *blocksStoreSetMock) GetClientsFor(_ []ulid.ULID) (map[BlocksStoreClient][]ulid.ULID, error) {
-	return m.mockedResult, m.mockedErr
+func (m *blocksStoreSetMock) GetClientsFor(_ []ulid.ULID, _ map[ulid.ULID][]string) (map[BlocksStoreClient][]ulid.ULID, error) {
+	if m.nextResult >= len(m.mockedResponses) {
+		panic("not enough mocked results")
+	}
+
+	res := m.mockedResponses[m.nextResult]
+	m.nextResult++
+
+	if err, ok := res.(error); ok {
+		return nil, err
+	}
+	if clients, ok := res.(map[BlocksStoreClient][]ulid.ULID); ok {
+		return clients, nil
+	}
+
+	return nil, errors.New("unknown data type in the mocked result")
 }
 
 type blocksFinderMock struct {

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -257,7 +257,6 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 				cortex_querier_storegateway_refetches_per_query_bucket{le="0"} 1
 				cortex_querier_storegateway_refetches_per_query_bucket{le="1"} 1
 				cortex_querier_storegateway_refetches_per_query_bucket{le="2"} 1
-				cortex_querier_storegateway_refetches_per_query_bucket{le="3"} 1
 				cortex_querier_storegateway_refetches_per_query_bucket{le="+Inf"} 1
 				cortex_querier_storegateway_refetches_per_query_sum 0
 				cortex_querier_storegateway_refetches_per_query_count 1
@@ -378,7 +377,6 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 				cortex_querier_storegateway_refetches_per_query_bucket{le="0"} 0
 				cortex_querier_storegateway_refetches_per_query_bucket{le="1"} 0
 				cortex_querier_storegateway_refetches_per_query_bucket{le="2"} 1
-				cortex_querier_storegateway_refetches_per_query_bucket{le="3"} 1
 				cortex_querier_storegateway_refetches_per_query_bucket{le="+Inf"} 1
 				cortex_querier_storegateway_refetches_per_query_sum 2
 				cortex_querier_storegateway_refetches_per_query_count 1

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -278,7 +278,7 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 					}}: {block1},
 				},
 				// Second attempt returns an error because there are no other store-gateways left.
-				errors.New("no store-gateway remaining after blacklist"),
+				errors.New("no store-gateway remaining after exclude"),
 			},
 			expectedErr: fmt.Sprintf("consistency check failed because some blocks were not queried: %s", block2.String()),
 		},
@@ -302,7 +302,7 @@ func TestBlocksStoreQuerier_SelectSorted(t *testing.T) {
 					}}: {block2},
 				},
 				// Second attempt returns an error because there are no other store-gateways left.
-				errors.New("no store-gateway remaining after blacklist"),
+				errors.New("no store-gateway remaining after exclude"),
 			},
 			expectedErr: fmt.Sprintf("consistency check failed because some blocks were not queried: %s %s", block3.String(), block4.String()),
 		},
@@ -612,9 +612,11 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 
 	stores := &blocksStoreSetMock{
 		Service: services.NewIdleService(nil, nil),
-		mockedResult: map[BlocksStoreClient][]ulid.ULID{
-			gateway1: {block1},
-			gateway2: {block2},
+		mockedResponses: []interface{}{
+			map[BlocksStoreClient][]ulid.ULID{
+				gateway1: {block1},
+				gateway2: {block2},
+			},
 		},
 	}
 

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -75,11 +75,6 @@ func (s *blocksStoreReplicationSet) stopping(_ error) error {
 func (s *blocksStoreReplicationSet) GetClientsFor(blockIDs []ulid.ULID, exclude map[ulid.ULID][]string) (map[BlocksStoreClient][]ulid.ULID, error) {
 	shards := map[string][]ulid.ULID{}
 
-	// Easy way to handle the case of a missing exclude list.
-	if exclude == nil {
-		exclude = map[ulid.ULID][]string{}
-	}
-
 	// Find the replication set of each block we need to query.
 	for _, blockID := range blockIDs {
 		// Buffer internally used by the ring (give extra room for a JOINING + LEAVING instance).

--- a/pkg/querier/blocks_store_replicated_set_test.go
+++ b/pkg/querier/blocks_store_replicated_set_test.go
@@ -41,7 +41,9 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 		replicationFactor int
 		setup             func(*ring.Desc)
 		queryBlocks       []ulid.ULID
+		blacklist         map[ulid.ULID][]string
 		expectedClients   map[string][]ulid.ULID
+		expectedErr       error
 	}{
 		"single instance in the ring with replication factor = 1": {
 			replicationFactor: 1,
@@ -49,6 +51,30 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE)
 			},
 			queryBlocks: []ulid.ULID{block1, block2},
+			expectedClients: map[string][]ulid.ULID{
+				"127.0.0.1": {block1, block2},
+			},
+		},
+		"single instance in the ring with replication factor = 1 but blacklisted": {
+			replicationFactor: 1,
+			setup: func(d *ring.Desc) {
+				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE)
+			},
+			queryBlocks: []ulid.ULID{block1, block2},
+			blacklist: map[ulid.ULID][]string{
+				block1: {"127.0.0.1"},
+			},
+			expectedErr: fmt.Errorf("no store-gateway instance left after checking blacklist for block %s", block1.String()),
+		},
+		"single instance in the ring with replication factor = 1 but blacklisted for non queried block": {
+			replicationFactor: 1,
+			setup: func(d *ring.Desc) {
+				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE)
+			},
+			queryBlocks: []ulid.ULID{block1, block2},
+			blacklist: map[ulid.ULID][]string{
+				block3: {"127.0.0.1"},
+			},
 			expectedClients: map[string][]ulid.ULID{
 				"127.0.0.1": {block1, block2},
 			},
@@ -78,6 +104,20 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 				"127.0.0.4": {block4},
 			},
 		},
+		"multiple instances in the ring with each requested block belonging to a different store-gateway and replication factor = 1 but blacklisted": {
+			replicationFactor: 1,
+			setup: func(d *ring.Desc) {
+				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE)
+				d.AddIngester("instance-2", "127.0.0.2", "", []uint32{block2Hash + 1}, ring.ACTIVE)
+				d.AddIngester("instance-3", "127.0.0.3", "", []uint32{block3Hash + 1}, ring.ACTIVE)
+				d.AddIngester("instance-4", "127.0.0.4", "", []uint32{block4Hash + 1}, ring.ACTIVE)
+			},
+			queryBlocks: []ulid.ULID{block1, block3, block4},
+			blacklist: map[ulid.ULID][]string{
+				block3: {"127.0.0.3"},
+			},
+			expectedErr: fmt.Errorf("no store-gateway instance left after checking blacklist for block %s", block3.String()),
+		},
 		"multiple instances in the ring with each requested block belonging to a different store-gateway and replication factor = 2": {
 			replicationFactor: 2,
 			setup: func(d *ring.Desc) {
@@ -103,6 +143,24 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			expectedClients: map[string][]ulid.ULID{
 				"127.0.0.1": {block1, block4},
 				"127.0.0.2": {block2, block3},
+			},
+		},
+		"multiple instances in the ring with each requested block belonging to a different store-gateway and replication factor = 2 and some blocks blacklisted but with replacement available": {
+			replicationFactor: 2,
+			setup: func(d *ring.Desc) {
+				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE)
+				d.AddIngester("instance-2", "127.0.0.2", "", []uint32{block2Hash + 1}, ring.ACTIVE)
+				d.AddIngester("instance-3", "127.0.0.3", "", []uint32{block3Hash + 1}, ring.ACTIVE)
+				d.AddIngester("instance-4", "127.0.0.4", "", []uint32{block4Hash + 1}, ring.ACTIVE)
+			},
+			queryBlocks: []ulid.ULID{block1, block3, block4},
+			blacklist: map[ulid.ULID][]string{
+				block3: {"127.0.0.3"},
+				block1: {"127.0.0.1"},
+			},
+			expectedClients: map[string][]ulid.ULID{
+				"127.0.0.2": {block1},
+				"127.0.0.4": {block3, block4},
 			},
 		},
 	}
@@ -142,15 +200,18 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 				return err == nil && len(all.Ingesters) > 0
 			})
 
-			clients, err := s.GetClientsFor(testData.queryBlocks)
-			require.NoError(t, err)
-			assert.Equal(t, testData.expectedClients, getStoreGatewayClientAddrs(clients))
+			clients, err := s.GetClientsFor(testData.queryBlocks, testData.blacklist)
+			assert.Equal(t, testData.expectedErr, err)
 
-			assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-				# HELP cortex_storegateway_clients The current number of store-gateway clients in the pool.
-				# TYPE cortex_storegateway_clients gauge
-				cortex_storegateway_clients{client="querier"} %d
-			`, len(testData.expectedClients))), "cortex_storegateway_clients"))
+			if testData.expectedErr == nil {
+				assert.Equal(t, testData.expectedClients, getStoreGatewayClientAddrs(clients))
+
+				assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					# HELP cortex_storegateway_clients The current number of store-gateway clients in the pool.
+					# TYPE cortex_storegateway_clients gauge
+					cortex_storegateway_clients{client="querier"} %d
+				`, len(testData.expectedClients))), "cortex_storegateway_clients"))
+			}
 		})
 	}
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -59,9 +59,8 @@ type Config struct {
 	legacyLookbackDelta time.Duration
 
 	// Blocks storage only.
-	StoreGatewayAddresses  string                       `yaml:"store_gateway_addresses"`
-	StoreGatewayClient     tls.ClientConfig             `yaml:"store_gateway_client"`
-	BlocksConsistencyCheck BlocksConsistencyCheckConfig `yaml:"blocks_consistency_check" doc:"description=Configures the consistency check done by the querier on queried blocks when running the experimental blocks storage."`
+	StoreGatewayAddresses string           `yaml:"store_gateway_addresses"`
+	StoreGatewayClient    tls.ClientConfig `yaml:"store_gateway_client"`
 }
 
 var (
@@ -75,7 +74,6 @@ const (
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.StoreGatewayClient.RegisterFlagsWithPrefix("experimental.querier.store-gateway-client", f)
-	cfg.BlocksConsistencyCheck.RegisterFlagsWithPrefix("experimental.querier.blocks-consistency-check", f)
 	f.IntVar(&cfg.MaxConcurrent, "querier.max-concurrent", 20, "The maximum number of concurrent queries.")
 	f.DurationVar(&cfg.Timeout, "querier.timeout", 2*time.Minute, "The timeout for a query.")
 	f.BoolVar(&cfg.Iterators, "querier.iterators", false, "Use iterators to execute query, as opposed to fully materialising the series in memory.")


### PR DESCRIPTION
**What this PR does**:
_Take a deep breath..._

This should be the last missing piece in my original design when I've started working on introducing the store-gateway (doc excluded, will be done in a separate PR).

Due to the consistency check, a query may fail because some expected blocks are missing from the specific selected store-gateway. This is not a edge condition and could actually occur relatively frequently due to the resharding (ie. during a rolling update or scale up/down).

In this PR I'm introducing the ability to refetch series for missing blocks from different store-gateway replicas which are supposed to have these blocks. I've done some manual local tests and looks working as expected; further tests will be done on staging next Monday.

Draft until:
- Further tests are done in our staging environment

Notes to reviewers:
- The [first commit](https://github.com/cortexproject/cortex/commit/d14667d2fbd2c5eb673f2f4650a6aa5d297a892a) I've pushed contains a simple refactoring without any logic change. This commit has been pushed separately to help review the next commit, which is where the changes occurred.
- Tests changes could be easier to review enabling "hide whitespace changes"
- The consistency check is now always enabled

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
