### PR TITLE
add dist/ repo to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ website/resources
 website/content/en/docs
 e2e_integration_test*
 active-query-tracker
-
+dist/


### PR DESCRIPTION
**What this PR does**:

Adds `dist/` directory to the `.gitignore` file. This ensures users don't accidentally commit distribution binaries they build.

