### PR TITLE
Fixed incorrect query results introduced in #2604

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1051,6 +1051,7 @@ Further, if you're using the configs service, we've upgraded the migration libra
 * [BUGFIX] Experimental TSDB: Fixed ingesters consistency during hand-over when using experimental TSDB blocks storage. #1854 #1818
 * [BUGFIX] Experimental TSDB: Fixed metrics when using experimental TSDB blocks storage. #1981 #1982 #1990 #1983
 * [BUGFIX] Experimental memberlist: Use the advertised address when sending packets to other peers of the Gossip memberlist. #1857
+* [BUGFIX] Experimental TSDB: Fixed incorrect query results introduced in #2604 caused by a buffer incorrectly reused while iterating samples. 
 
 ### Upgrading PostgreSQL (if you're using configs service)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1051,7 +1051,7 @@ Further, if you're using the configs service, we've upgraded the migration libra
 * [BUGFIX] Experimental TSDB: Fixed ingesters consistency during hand-over when using experimental TSDB blocks storage. #1854 #1818
 * [BUGFIX] Experimental TSDB: Fixed metrics when using experimental TSDB blocks storage. #1981 #1982 #1990 #1983
 * [BUGFIX] Experimental memberlist: Use the advertised address when sending packets to other peers of the Gossip memberlist. #1857
-* [BUGFIX] Experimental TSDB: Fixed incorrect query results introduced in #2604 caused by a buffer incorrectly reused while iterating samples. 
+* [BUGFIX] Experimental TSDB: Fixed incorrect query results introduced in #2604 caused by a buffer incorrectly reused while iterating samples. #2697
 
 ### Upgrading PostgreSQL (if you're using configs service)
 

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/prometheus/client_golang v1.6.1-0.20200604110148-03575cad4e55
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.10.0
-	github.com/prometheus/prometheus v1.8.2-0.20200604055556-c729df3d0fdf
+	github.com/prometheus/prometheus v1.8.2-0.20200609052543-1627d234da06
 	github.com/rafaeljusto/redigomock v0.0.0-20190202135759-257e089e14a1
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 	github.com/spf13/afero v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -961,8 +961,8 @@ github.com/prometheus/prometheus v0.0.0-20190818123050-43acd0e2e93f/go.mod h1:rM
 github.com/prometheus/prometheus v1.8.2-0.20200107122003-4708915ac6ef/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v1.8.2-0.20200213233353-b90be6f32a33/go.mod h1:fkIPPkuZnkXyopYHmXPxf9rgiPkVgZCN8w9o8+UgBlY=
 github.com/prometheus/prometheus v1.8.2-0.20200601152113-3268eac2ddda/go.mod h1:QKHYbx8sTY1fj75M+lL+LhzDSFM00+dOBlFn5wBi+14=
-github.com/prometheus/prometheus v1.8.2-0.20200604055556-c729df3d0fdf h1:hcXPopjouAsoBFXgbze9CxpkiCerwJtsPovjP77FWiE=
-github.com/prometheus/prometheus v1.8.2-0.20200604055556-c729df3d0fdf/go.mod h1:CwaXafRa0mm72de2GQWtfQxjGytbSKIGivWxQvjpRZs=
+github.com/prometheus/prometheus v1.8.2-0.20200609052543-1627d234da06 h1:VeGF2wHPK5Y2zvj+lqvizJtfRsEkC22YT5mT8Wl1vbk=
+github.com/prometheus/prometheus v1.8.2-0.20200609052543-1627d234da06/go.mod h1:CwaXafRa0mm72de2GQWtfQxjGytbSKIGivWxQvjpRZs=
 github.com/rafaeljusto/redigomock v0.0.0-20190202135759-257e089e14a1 h1:+kGqA4dNN5hn7WwvKdzHl0rdN5AEkbNZd0VjRltAiZg=
 github.com/rafaeljusto/redigomock v0.0.0-20190202135759-257e089e14a1/go.mod h1:JaY6n2sDr+z2WTsXkOmNRUfDy6FN0L6Nk7x06ndm4tY=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -226,7 +226,7 @@ func createAggrChunkWithSineSamples(minTime, maxTime time.Time, step time.Durati
 	stepMillis := step.Milliseconds()
 
 	for t := minT; t < maxT; t += stepMillis {
-		samples = append(samples, promql.Point{t, math.Sin(float64(t))})
+		samples = append(samples, promql.Point{T: t, V: math.Sin(float64(t))})
 	}
 
 	return createAggrChunk(minT, maxT, samples...)

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -2,12 +2,14 @@ package querier
 
 import (
 	"math"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/assert"
@@ -119,7 +121,7 @@ func TestBlockQuerierSeriesSet(t *testing.T) {
 			{
 				Labels: mkLabels("__name__", "first", "a", "a"),
 				Chunks: []storepb.AggrChunk{
-					createChunkWithSineSamples(now, now.Add(100*time.Second), 3*time.Millisecond), // ceil(100 / 0.003) samples (= 33334)
+					createAggrChunkWithSineSamples(now, now.Add(100*time.Second), 3*time.Millisecond), // ceil(100 / 0.003) samples (= 33334)
 				},
 			},
 
@@ -127,7 +129,7 @@ func TestBlockQuerierSeriesSet(t *testing.T) {
 			{
 				Labels: mkLabels("__name__", "first", "a", "a"),
 				Chunks: []storepb.AggrChunk{
-					createChunkWithSineSamples(now.Add(100*time.Second), now.Add(200*time.Second), 3*time.Millisecond), // ceil(100 / 0.003) samples more, 66668 in total
+					createAggrChunkWithSineSamples(now.Add(100*time.Second), now.Add(200*time.Second), 3*time.Millisecond), // ceil(100 / 0.003) samples more, 66668 in total
 				},
 			},
 
@@ -136,9 +138,9 @@ func TestBlockQuerierSeriesSet(t *testing.T) {
 				Labels: mkLabels("__name__", "second"),
 				Chunks: []storepb.AggrChunk{
 					// unordered chunks
-					createChunkWithSineSamples(now.Add(400*time.Second), now.Add(600*time.Second), 5*time.Millisecond), // 200 / 0.005 (= 40000 samples, = 120000 in total)
-					createChunkWithSineSamples(now.Add(200*time.Second), now.Add(400*time.Second), 5*time.Millisecond), // 200 / 0.005 (= 40000 samples)
-					createChunkWithSineSamples(now, now.Add(200*time.Second), 5*time.Millisecond),                      // 200 / 0.005 (= 40000 samples)
+					createAggrChunkWithSineSamples(now.Add(400*time.Second), now.Add(600*time.Second), 5*time.Millisecond), // 200 / 0.005 (= 40000 samples, = 120000 in total)
+					createAggrChunkWithSineSamples(now.Add(200*time.Second), now.Add(400*time.Second), 5*time.Millisecond), // 200 / 0.005 (= 40000 samples)
+					createAggrChunkWithSineSamples(now, now.Add(200*time.Second), 5*time.Millisecond),                      // 200 / 0.005 (= 40000 samples)
 				},
 			},
 
@@ -146,14 +148,14 @@ func TestBlockQuerierSeriesSet(t *testing.T) {
 			{
 				Labels: mkLabels("__name__", "overlapping"),
 				Chunks: []storepb.AggrChunk{
-					createChunkWithSineSamples(now, now.Add(10*time.Second), 5*time.Millisecond), // 10 / 0.005 = 2000 samples
+					createAggrChunkWithSineSamples(now, now.Add(10*time.Second), 5*time.Millisecond), // 10 / 0.005 = 2000 samples
 				},
 			},
 			{
 				Labels: mkLabels("__name__", "overlapping"),
 				Chunks: []storepb.AggrChunk{
 					// 10 / 0.005 = 2000 samples, but first 1000 are overlapping with previous series, so this chunk only contributes 1000
-					createChunkWithSineSamples(now.Add(5*time.Second), now.Add(15*time.Second), 5*time.Millisecond),
+					createAggrChunkWithSineSamples(now.Add(5*time.Second), now.Add(15*time.Second), 5*time.Millisecond),
 				},
 			},
 
@@ -162,21 +164,21 @@ func TestBlockQuerierSeriesSet(t *testing.T) {
 				Labels: mkLabels("__name__", "overlapping2"),
 				Chunks: []storepb.AggrChunk{
 					// entire range overlaps with the next chunk, so this chunks contributes 0 samples (it will be sorted as second)
-					createChunkWithSineSamples(now.Add(3*time.Second), now.Add(7*time.Second), 5*time.Millisecond),
+					createAggrChunkWithSineSamples(now.Add(3*time.Second), now.Add(7*time.Second), 5*time.Millisecond),
 				},
 			},
 			{
 				Labels: mkLabels("__name__", "overlapping2"),
 				Chunks: []storepb.AggrChunk{
 					// this chunk has completely overlaps previous chunk. Since its minTime is lower, it will be sorted as first.
-					createChunkWithSineSamples(now, now.Add(10*time.Second), 5*time.Millisecond), // 10 / 0.005 = 2000 samples
+					createAggrChunkWithSineSamples(now, now.Add(10*time.Second), 5*time.Millisecond), // 10 / 0.005 = 2000 samples
 				},
 			},
 			{
 				Labels: mkLabels("__name__", "overlapping2"),
 				Chunks: []storepb.AggrChunk{
 					// no samples
-					createChunkWithSineSamples(now, now, 5*time.Millisecond),
+					createAggrChunkWithSineSamples(now, now, 5*time.Millisecond),
 				},
 			},
 
@@ -184,7 +186,7 @@ func TestBlockQuerierSeriesSet(t *testing.T) {
 				Labels: mkLabels("__name__", "overlapping2"),
 				Chunks: []storepb.AggrChunk{
 					// 2000 samples more (10 / 0.005)
-					createChunkWithSineSamples(now.Add(20*time.Second), now.Add(30*time.Second), 5*time.Millisecond),
+					createAggrChunkWithSineSamples(now.Add(20*time.Second), now.Add(30*time.Second), 5*time.Millisecond),
 				},
 			},
 		},
@@ -216,24 +218,43 @@ func verifyNextSeries(t *testing.T, ss storage.SeriesSet, labels labels.Labels, 
 	require.Equal(t, samples, count)
 }
 
-func createChunkWithSineSamples(minTime, maxTime time.Time, step time.Duration) storepb.AggrChunk {
-	chunk := chunkenc.NewXORChunk()
-	appender, err := chunk.Appender()
-	if err != nil {
-		panic(err)
-	}
+func createAggrChunkWithSineSamples(minTime, maxTime time.Time, step time.Duration) storepb.AggrChunk {
+	var samples []promql.Point
 
 	minT := minTime.Unix() * 1000
 	maxT := maxTime.Unix() * 1000
 	stepMillis := step.Milliseconds()
 
 	for t := minT; t < maxT; t += stepMillis {
-		appender.Append(t, math.Sin(float64(t)))
+		samples = append(samples, promql.Point{t, math.Sin(float64(t))})
+	}
+
+	return createAggrChunk(minT, maxT, samples...)
+}
+
+func createAggrChunkWithSamples(samples ...promql.Point) storepb.AggrChunk {
+	return createAggrChunk(samples[0].T, samples[len(samples)-1].T, samples...)
+}
+
+func createAggrChunk(minTime, maxTime int64, samples ...promql.Point) storepb.AggrChunk {
+	// Ensure samples are sorted by timestamp.
+	sort.Slice(samples, func(i, j int) bool {
+		return samples[i].T < samples[j].T
+	})
+
+	chunk := chunkenc.NewXORChunk()
+	appender, err := chunk.Appender()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, s := range samples {
+		appender.Append(s.T, s.V)
 	}
 
 	return storepb.AggrChunk{
-		MinTime: minT,
-		MaxTime: maxT,
+		MinTime: minTime,
+		MaxTime: maxTime,
 		Raw: &storepb.Chunk{
 			Type: storepb.Chunk_XOR,
 			Data: chunk.Bytes(),
@@ -268,7 +289,7 @@ func Benchmark_newBlockQuerierSeries(b *testing.B) {
 		"label_9", "value_9")
 
 	chunks := []storepb.AggrChunk{
-		createChunkWithSineSamples(time.Now(), time.Now().Add(-time.Hour), time.Minute),
+		createAggrChunkWithSineSamples(time.Now(), time.Now().Add(-time.Hour), time.Minute),
 	}
 
 	b.ResetTimer()
@@ -292,7 +313,7 @@ func Benchmark_blockQuerierSeriesSet_iteration(b *testing.B) {
 
 		// Create chunks with 1 sample per second.
 		for minT := int64(0); minT < numChunksPerSeries*numSamplesPerChunk; minT += numSamplesPerChunk {
-			chunks = append(chunks, createChunkWithSineSamples(util.TimeFromMillis(minT), util.TimeFromMillis(minT+numSamplesPerChunk), time.Millisecond))
+			chunks = append(chunks, createAggrChunkWithSineSamples(util.TimeFromMillis(minT), util.TimeFromMillis(minT+numSamplesPerChunk), time.Millisecond))
 		}
 
 		series = append(series, &storepb.Series{

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -22,6 +23,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/store/hintspb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
+	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc"
 
 	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
@@ -393,6 +395,126 @@ func TestBlocksStoreQuerier_SelectSortedShouldHonorQueryStoreAfter(t *testing.T)
 			}
 		})
 	}
+}
+
+func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
+	block1 := ulid.MustNew(1, nil)
+	block2 := ulid.MustNew(2, nil)
+	series1 := []storepb.Label{{Name: "__name__", Value: "metric_1"}}
+	series2 := []storepb.Label{{Name: "__name__", Value: "metric_2"}}
+
+	series1Samples := []promql.Point{
+		{T: 1589759955000, V: 1},
+		{T: 1589759970000, V: 1},
+		{T: 1589759985000, V: 1},
+		{T: 1589760000000, V: 1},
+		{T: 1589760015000, V: 1},
+		{T: 1589760030000, V: 1},
+	}
+
+	series2Samples := []promql.Point{
+		{T: 1589759955000, V: 2},
+		{T: 1589759970000, V: 2},
+		{T: 1589759985000, V: 2},
+		{T: 1589760000000, V: 2},
+		{T: 1589760015000, V: 2},
+		{T: 1589760030000, V: 2},
+	}
+
+	// Mock the finder to simulate we need to query two blocks.
+	finder := &blocksFinderMock{
+		Service: services.NewIdleService(nil, nil),
+	}
+	finder.On("GetBlocks", "user-1", mock.Anything, mock.Anything).Return([]*BlockMeta{
+		{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block1}}},
+		{Meta: metadata.Meta{BlockMeta: tsdb.BlockMeta{ULID: block2}}},
+	}, map[ulid.ULID]*metadata.DeletionMark(nil), error(nil))
+
+	// Mock the store to simulate each block is queried from a different store-gateway.
+	gateway1 := &storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedResponses: []*storepb.SeriesResponse{
+		{
+			Result: &storepb.SeriesResponse_Series{
+				Series: &storepb.Series{
+					Labels: series1,
+					Chunks: []storepb.AggrChunk{
+						createAggrChunkWithSamples(series1Samples[:3]...),
+					},
+				},
+			},
+		}, {
+			Result: &storepb.SeriesResponse_Series{
+				Series: &storepb.Series{
+					Labels: series2,
+					Chunks: []storepb.AggrChunk{
+						createAggrChunkWithSamples(series2Samples[:3]...),
+					},
+				},
+			},
+		},
+		mockHintsResponse(block1),
+	}}
+
+	gateway2 := &storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedResponses: []*storepb.SeriesResponse{
+		{
+			Result: &storepb.SeriesResponse_Series{
+				Series: &storepb.Series{
+					Labels: series1,
+					Chunks: []storepb.AggrChunk{
+						createAggrChunkWithSamples(series1Samples[3:]...),
+					},
+				},
+			},
+		}, {
+			Result: &storepb.SeriesResponse_Series{
+				Series: &storepb.Series{
+					Labels: series2,
+					Chunks: []storepb.AggrChunk{
+						createAggrChunkWithSamples(series2Samples[3:]...),
+					},
+				},
+			},
+		},
+		mockHintsResponse(block2),
+	}}
+
+	stores := &blocksStoreSetMock{
+		Service: services.NewIdleService(nil, nil),
+		mockedResult: map[BlocksStoreClient][]ulid.ULID{
+			gateway1: {block1},
+			gateway2: {block2},
+		},
+	}
+
+	// Instance the querier that will be executed to run the query.
+	logger := log.NewNopLogger()
+	queryable, err := NewBlocksStoreQueryable(stores, finder, NewBlocksConsistencyChecker(0, 0, logger, nil), 0, logger, nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), queryable))
+	defer services.StopAndAwaitTerminated(context.Background(), queryable) // nolint:errcheck
+
+	engine := promql.NewEngine(promql.EngineOpts{
+		Logger:     logger,
+		Timeout:    10 * time.Second,
+		MaxSamples: 1e6,
+	})
+
+	// Run a query.
+	q, err := engine.NewRangeQuery(queryable, `{__name__=~"metric.*"}`, time.Unix(1589759955, 0), time.Unix(1589760030, 0), 15*time.Second)
+	require.NoError(t, err)
+
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	res := q.Exec(ctx)
+	require.NoError(t, err)
+	require.NoError(t, res.Err)
+
+	matrix, err := res.Matrix()
+	require.NoError(t, err)
+	require.Len(t, matrix, 2)
+
+	assert.Equal(t, storepb.LabelsToPromLabels(series1), matrix[0].Metric)
+	assert.Equal(t, storepb.LabelsToPromLabels(series2), matrix[1].Metric)
+	assert.Equal(t, series1Samples, matrix[0].Points)
+	assert.Equal(t, series2Samples, matrix[1].Points)
 }
 
 type blocksStoreSetMock struct {

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -460,7 +460,7 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 				Series: &storepb.Series{
 					Labels: series1,
 					Chunks: []storepb.AggrChunk{
-						createAggrChunkWithSamples(series1Samples[3:]...),
+						createAggrChunkWithSamples(series1Samples[3:]...), // Second half.
 					},
 				},
 			},

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -437,7 +437,7 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 				Series: &storepb.Series{
 					Labels: series1,
 					Chunks: []storepb.AggrChunk{
-						createAggrChunkWithSamples(series1Samples[:3]...),
+						createAggrChunkWithSamples(series1Samples[:3]...), // First half.
 					},
 				},
 			},

--- a/pkg/querier/duplicates_test.go
+++ b/pkg/querier/duplicates_test.go
@@ -109,7 +109,7 @@ func runPromQLAndGetJSONResult(t *testing.T, query string, ts client.TimeSeries,
 }
 
 type testQueryable struct {
-	ts *timeSeriesSeriesSet
+	ts storage.SeriesSet
 }
 
 func (t *testQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
@@ -117,7 +117,7 @@ func (t *testQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.
 }
 
 type testQuerier struct {
-	ts *timeSeriesSeriesSet
+	ts storage.SeriesSet
 }
 
 func (m testQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) (storage.SeriesSet, storage.Warnings, error) {

--- a/vendor/github.com/prometheus/prometheus/storage/generic.go
+++ b/vendor/github.com/prometheus/prometheus/storage/generic.go
@@ -108,26 +108,24 @@ func (q *chunkQuerierAdapter) Select(sortSeries bool, hints *SelectHints, matche
 
 type seriesMergerAdapter struct {
 	VerticalSeriesMergeFunc
-	buf []Series
 }
 
 func (a *seriesMergerAdapter) Merge(s ...Labels) Labels {
-	a.buf = a.buf[:0]
+	buf := make([]Series, 0, len(s))
 	for _, ser := range s {
-		a.buf = append(a.buf, ser.(Series))
+		buf = append(buf, ser.(Series))
 	}
-	return a.VerticalSeriesMergeFunc(a.buf...)
+	return a.VerticalSeriesMergeFunc(buf...)
 }
 
 type chunkSeriesMergerAdapter struct {
 	VerticalChunkSeriesMergerFunc
-	buf []ChunkSeries
 }
 
 func (a *chunkSeriesMergerAdapter) Merge(s ...Labels) Labels {
-	a.buf = a.buf[:0]
+	buf := make([]ChunkSeries, 0, len(s))
 	for _, ser := range s {
-		a.buf = append(a.buf, ser.(ChunkSeries))
+		buf = append(buf, ser.(ChunkSeries))
 	}
-	return a.VerticalChunkSeriesMergerFunc(a.buf...)
+	return a.VerticalChunkSeriesMergerFunc(buf...)
 }

--- a/vendor/github.com/prometheus/prometheus/tsdb/chunks/head_chunks.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/chunks/head_chunks.go
@@ -78,13 +78,16 @@ func (e *CorruptionErr) Error() string {
 // ChunkDiskMapper is for writing the Head block chunks to the disk
 // and access chunks via mmapped file.
 type ChunkDiskMapper struct {
+	// Keep all 64bit atomically accessed variables at the top of this struct.
+	// See https://golang.org/pkg/sync/atomic/#pkg-note-BUG for more info.
+	curFileNumBytes int64 // Bytes written in current open file.
+
 	/// Writer.
 	dir *os.File
 
 	curFile         *os.File // File being written to.
 	curFileSequence int      // Index of current open file being appended to.
 	curFileMaxt     int64    // Used for the size retention.
-	curFileNumBytes int64    // Bytes written in current open file.
 
 	byteBuf      [MaxHeadChunkMetaSize]byte // Buffer used to write the header of the chunk.
 	chkWriter    *bufio.Writer              // Writer for the current open file.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -445,7 +445,7 @@ github.com/prometheus/node_exporter/https
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20200604055556-c729df3d0fdf
+# github.com/prometheus/prometheus v1.8.2-0.20200609052543-1627d234da06
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
 github.com/prometheus/prometheus/discovery/azure


### PR DESCRIPTION
**What this PR does**:
Fixed incorrect query results introduced in #2604 caused by a buffer incorrectly reused while iterating samples.

Draft PR until Prometheus upstream fix https://github.com/prometheus/prometheus/pull/7361 won't be merged.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
