### PR TITLE
Fix Redis cache error when a query has no chunks to lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
 * [BUGFIX] Experimental TSDB: when the querier receives a `/series` request with a time range older than the data stored in the ingester, it now ignores the requested time range and returns known series anyway instead of returning an empty response. This aligns the behaviour with the chunks storage. #2617
 * [BUGFIX] Cassandra: fixed an edge case leading to an invalid CQL query when querying the index on a Cassandra store. #2639
 * [BUGFIX] Ingester: increment series per metric when recovering from WAL or transfer. #2674
+* [BUGFIX] Fixed `wrong number of arguments for 'mget' command` Redis error when a query has no chunks to lookup from storage. #2700
 
 ## 1.1.0 / 2020-05-21
 

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -505,6 +505,11 @@ func (c *baseStore) lookupEntriesByQueries(ctx context.Context, queries []IndexQ
 	log, ctx := spanlogger.New(ctx, "store.lookupEntriesByQueries")
 	defer log.Span.Finish()
 
+	// Nothing to do if there are no queries.
+	if len(queries) == 0 {
+		return nil, nil
+	}
+
 	var lock sync.Mutex
 	var entries []IndexEntry
 	err := c.index.QueryPages(ctx, queries, func(query IndexQuery, resp ReadBatch) bool {
@@ -527,7 +532,12 @@ func (c *baseStore) lookupEntriesByQueries(ctx context.Context, queries []IndexQ
 	return entries, err
 }
 
-func (c *baseStore) parseIndexEntries(ctx context.Context, entries []IndexEntry, matcher *labels.Matcher) ([]string, error) {
+func (c *baseStore) parseIndexEntries(_ context.Context, entries []IndexEntry, matcher *labels.Matcher) ([]string, error) {
+	// Nothing to do if there are no entries.
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
 	result := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		chunkKey, labelValue, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -162,6 +162,11 @@ func (c compositeStore) GetChunkRefs(ctx context.Context, userID string, from, t
 			return err
 		}
 
+		// Skip it if there are no chunks.
+		if len(ids) == 0 {
+			return nil
+		}
+
 		chunkIDs = append(chunkIDs, ids...)
 		fetchers = append(fetchers, fetcher...)
 		return nil

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -182,6 +182,11 @@ func (c *seriesStore) GetChunkRefs(ctx context.Context, userID string, from, thr
 	level.Debug(log).Log("chunks-post-filtering", len(chunks))
 	chunksPerQuery.Observe(float64(len(chunks)))
 
+	// We should return an empty chunks slice if there are no chunks.
+	if len(chunks) == 0 {
+		return [][]Chunk{}, []*Fetcher{}, nil
+	}
+
 	return [][]Chunk{chunks}, []*Fetcher{c.baseStore.Fetcher}, nil
 }
 


### PR DESCRIPTION
**What this PR does**:
Redis chunks cache lookup can fail with the error `ERR wrong number of arguments for 'mget' command` if a query has no chunks to lookup from storage. This happens because we don't correctly handle the case `SeriesStore.GetChunkRefs()` returns no chunks.

**Which issue(s) this PR fixes**:
Fixes #2133

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
