### PR TITLE
check response comparison flag in query tee to compare responses

### DIFF
--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -134,8 +134,8 @@ func (p *Proxy) Start() error {
 	}))
 
 	// register routes
+	var comparator ResponsesComparator
 	for _, route := range p.routes {
-		var comparator ResponsesComparator
 		if p.cfg.CompareResponses {
 			comparator = route.ResponseComparator
 		}

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -135,7 +135,11 @@ func (p *Proxy) Start() error {
 
 	// register routes
 	for _, route := range p.routes {
-		router.Path(route.Path).Methods(route.Methods).Handler(NewProxyEndpoint(p.backends, route.RouteName, p.metrics, p.logger, route.ResponseComparator))
+		var comparator ResponsesComparator
+		if p.cfg.CompareResponses {
+			comparator = route.ResponseComparator
+		}
+		router.Path(route.Path).Methods(route.Methods).Handler(NewProxyEndpoint(p.backends, route.RouteName, p.metrics, p.logger, comparator))
 	}
 
 	p.srvListener = listener

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -108,7 +108,8 @@ func (p *ProxyEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			result := resultSuccess
 			err := p.compareResponses(expectedResponse, actualResponse)
 			if err != nil {
-				level.Error(util.Logger).Log("msg", "response comparison failed", "route-name", p.routeName, "err", err)
+				level.Error(util.Logger).Log("msg", "response comparison failed", "route-name", p.routeName,
+					"query", r.URL.RawQuery, "err", err)
 				result = resultFailed
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
`query-tee` was not checking `proxy.compare-responses` and doing the comparison of responses always. This PR fixes that behaviours. It also adds the `RawQuery` in logs when comparison fails.
