### PR TITLE
Do not wait for the slowest response in the query-tee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,9 @@
 * [ENHANCEMENT] Experimental TSDB: added the flag `-experimental.tsdb.wal-compression-enabled` to allow to enable TSDB WAL compression. #2585
 * [ENHANCEMENT] Experimental TSDB: Querier and store-gateway components can now use so-called "caching bucket", which can currently cache fetched chunks into shared memcached server. #2572
 * [ENHANCEMENT] Ruler: Automatically remove unhealthy rulers from the ring. #2587
-* [ENHANCEMENT] `query-tee` supports `/metadata`, `/alerts`, and `/rules` #2600
+* [ENHANCEMENT] Query-tee: added support to `/metadata`, `/alerts`, and `/rules` endpoints #2600
+* [ENHANCEMENT] Query-tee: added support to query results comparison between two different backends. The comparison is disabled by default and can be enabled via `-proxy.compare-responses=true`. #2611
+* [ENHANCEMENT] Query-tee: improved the query-tee to not wait all backend responses before sending back the response to the client. The query-tee now sends back to the client first successful response, while honoring the `-backend.preferred` option.
 * [ENHANCEMENT] Thanos and Prometheus upgraded. #2604 #2634 #2686
   * TSDB now supports isolation of append and queries.
   * TSDB now holds less WAL files after Head Truncation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 * [ENHANCEMENT] Ruler: Automatically remove unhealthy rulers from the ring. #2587
 * [ENHANCEMENT] Query-tee: added support to `/metadata`, `/alerts`, and `/rules` endpoints #2600
 * [ENHANCEMENT] Query-tee: added support to query results comparison between two different backends. The comparison is disabled by default and can be enabled via `-proxy.compare-responses=true`. #2611
-* [ENHANCEMENT] Query-tee: improved the query-tee to not wait all backend responses before sending back the response to the client. The query-tee now sends back to the client first successful response, while honoring the `-backend.preferred` option.
+* [ENHANCEMENT] Query-tee: improved the query-tee to not wait all backend responses before sending back the response to the client. The query-tee now sends back to the client first successful response, while honoring the `-backend.preferred` option. #2702
 * [ENHANCEMENT] Thanos and Prometheus upgraded. #2604 #2634 #2686
   * TSDB now supports isolation of append and queries.
   * TSDB now holds less WAL files after Head Truncation.

--- a/docs/operations/query-tee.md
+++ b/docs/operations/query-tee.md
@@ -66,6 +66,16 @@ When a preferred backend **is not set**, `query-tee` sends back to the client:
 
 _Note: from the `query-tee` perspective, a backend request is considered successful even if the status code is 4xx because it generally means the error is due to an invalid request and not to a backend issue._
 
+### Backend results comparison
+
+`query-tee` allows to optionally enable the query results comparison between two backends. The results comparison can be enabled via the CLI flag `-proxy.compare-responses=true` and requires exactly two configured backends with a preferred one.
+
+When the comparison is enabled, the `query-tee` compares the response received from the two configured backends and logs a message for each query whose results don't match, as well as keeps track of the number of successful and failed comparison through the metric `cortex_querytee_responses_compared_total`.
+
+### Slow backends
+
+`query-tee` sends back to the client the first viable response as soon as available, without waiting to receive a response from all backends.
+
 ### Exported metrics
 
 `query-tee` exposes the following Prometheus metrics on the port configured via the CLI flag `-server.metrics-port`:
@@ -76,4 +86,8 @@ _Note: from the `query-tee` perspective, a backend request is considered success
 cortex_querytee_request_duration_seconds_bucket{backend="<hostname>",method="<method>",route="<route>",status_code="<status>",le="<bucket>"}
 cortex_querytee_request_duration_seconds_sum{backend="<hostname>",method="<method>",route="<route>",status_code="<status>"}
 cortex_querytee_request_duration_seconds_count{backend="<hostname>",method="<method>",route="<route>",status_code="<status>"}
+
+# HELP cortex_querytee_responses_compared_total Total number of responses compared per route name by result
+# TYPE cortex_querytee_responses_compared_total counter
+cortex_querytee_responses_compared_total{route="<route>",result="<success|fail>"}
 ```

--- a/docs/operations/query-tee.md
+++ b/docs/operations/query-tee.md
@@ -87,7 +87,11 @@ cortex_querytee_request_duration_seconds_bucket{backend="<hostname>",method="<me
 cortex_querytee_request_duration_seconds_sum{backend="<hostname>",method="<method>",route="<route>",status_code="<status>"}
 cortex_querytee_request_duration_seconds_count{backend="<hostname>",method="<method>",route="<route>",status_code="<status>"}
 
-# HELP cortex_querytee_responses_compared_total Total number of responses compared per route name by result
+# HELP cortex_querytee_responses_total Total number of responses sent back to the client by the selected backend.
+# TYPE cortex_querytee_responses_total counter
+cortex_querytee_responses_total{backend="<hostname>",method="<method>",route="<route>"}
+
+# HELP cortex_querytee_responses_compared_total Total number of responses compared per route name by result.
 # TYPE cortex_querytee_responses_compared_total counter
 cortex_querytee_responses_compared_total{route="<route>",result="<success|fail>"}
 ```

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -34,7 +34,7 @@ type ProxyConfig struct {
 func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.ServerServicePort, "server.service-port", 80, "The port where the query-tee service listens to.")
 	f.StringVar(&cfg.BackendEndpoints, "backend.endpoints", "", "Comma separated list of backend endpoints to query.")
-	f.StringVar(&cfg.PreferredBackend, "backend.preferred", "", "The hostname of the preferred backend when selecting the response to send back to the client.")
+	f.StringVar(&cfg.PreferredBackend, "backend.preferred", "", "The hostname of the preferred backend when selecting the response to send back to the client. If no preferred backend is configured then the query-tee will send back to the client the first successful response received without waiting for other backends.")
 	f.DurationVar(&cfg.BackendReadTimeout, "backend.read-timeout", 90*time.Second, "The timeout when reading the response from a backend.")
 	f.BoolVar(&cfg.CompareResponses, "proxy.compare-responses", false, "Compare responses between preferred and secondary endpoints for supported routes.")
 }
@@ -63,7 +63,7 @@ type Proxy struct {
 
 func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer prometheus.Registerer) (*Proxy, error) {
 	if cfg.CompareResponses && cfg.PreferredBackend == "" {
-		return nil, fmt.Errorf("when enabling comparion of results -backend.preferred flag must be set to hostname of preferred backend")
+		return nil, fmt.Errorf("when enabling comparison of results -backend.preferred flag must be set to hostname of preferred backend")
 	}
 
 	p := &Proxy{
@@ -134,8 +134,8 @@ func (p *Proxy) Start() error {
 	}))
 
 	// register routes
-	var comparator ResponsesComparator
 	for _, route := range p.routes {
+		var comparator ResponsesComparator
 		if p.cfg.CompareResponses {
 			comparator = route.ResponseComparator
 		}

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/util"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 type ResponsesComparator interface {
@@ -23,17 +23,29 @@ type ProxyEndpoint struct {
 	logger     log.Logger
 	comparator ResponsesComparator
 
+	// Whether for this endpoint there's a preferred backend configured.
+	hasPreferredBackend bool
+
 	// The route name used to track metrics.
 	routeName string
 }
 
 func NewProxyEndpoint(backends []*ProxyBackend, routeName string, metrics *ProxyMetrics, logger log.Logger, comparator ResponsesComparator) *ProxyEndpoint {
+	hasPreferredBackend := false
+	for _, backend := range backends {
+		if backend.preferred {
+			hasPreferredBackend = true
+			break
+		}
+	}
+
 	return &ProxyEndpoint{
-		backends:   backends,
-		routeName:  routeName,
-		metrics:    metrics,
-		logger:     logger,
-		comparator: comparator,
+		backends:            backends,
+		routeName:           routeName,
+		metrics:             metrics,
+		logger:              logger,
+		comparator:          comparator,
+		hasPreferredBackend: hasPreferredBackend,
 	}
 }
 
@@ -41,9 +53,27 @@ func (p *ProxyEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	level.Debug(p.logger).Log("msg", "Received request", "path", r.URL.Path, "query", r.URL.RawQuery)
 
 	// Send the same request to all backends.
+	resCh := make(chan *backendResponse, len(p.backends))
+	go p.executeBackendRequests(r, resCh)
+
+	// Wait for the first response that's feasible to be sent back to the client.
+	downstreamRes := p.waitBackendResponseForDownstream(resCh)
+
+	if downstreamRes.err != nil {
+		http.Error(w, downstreamRes.err.Error(), http.StatusInternalServerError)
+	} else {
+		w.WriteHeader(downstreamRes.status)
+		if _, err := w.Write(downstreamRes.body); err != nil {
+			level.Warn(p.logger).Log("msg", "Unable to write response", "err", err)
+		}
+	}
+}
+
+func (p *ProxyEndpoint) executeBackendRequests(r *http.Request, resCh chan *backendResponse) {
+	responses := make([]*backendResponse, 0, len(p.backends))
+
 	wg := sync.WaitGroup{}
 	wg.Add(len(p.backends))
-	resCh := make(chan *backendResponse, len(p.backends))
 
 	for _, b := range p.backends {
 		b := b
@@ -60,9 +90,7 @@ func (p *ProxyEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				status:  status,
 				body:    body,
 				err:     err,
-				elapsed: elapsed,
 			}
-			resCh <- res
 
 			// Log with a level based on the backend response.
 			lvl := level.Debug
@@ -71,6 +99,14 @@ func (p *ProxyEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 
 			lvl(p.logger).Log("msg", "Backend response", "path", r.URL.Path, "query", r.URL.RawQuery, "backend", b.name, "status", status, "elapsed", elapsed)
+			p.metrics.durationMetric.WithLabelValues(res.backend.name, r.Method, p.routeName, strconv.Itoa(res.statusCode())).Observe(elapsed.Seconds())
+
+			// Keep track of the response if required.
+			if p.comparator != nil {
+				responses = append(responses, res)
+			}
+
+			resCh <- res
 		}()
 	}
 
@@ -78,59 +114,55 @@ func (p *ProxyEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	wg.Wait()
 	close(resCh)
 
-	// Collect all responses and track metrics for each of them.
-	responses := make([]*backendResponse, 0, len(p.backends))
-	for res := range resCh {
-		responses = append(responses, res)
-
-		p.metrics.durationMetric.WithLabelValues(res.backend.name, r.Method, p.routeName, strconv.Itoa(res.statusCode())).Observe(res.elapsed.Seconds())
-	}
-
-	// Select the response to send back to the client.
-	downstreamRes := p.pickResponseForDownstream(responses)
-	if downstreamRes.err != nil {
-		http.Error(w, downstreamRes.err.Error(), http.StatusInternalServerError)
-	} else {
-		w.WriteHeader(downstreamRes.status)
-		if _, err := w.Write(downstreamRes.body); err != nil {
-			level.Warn(p.logger).Log("msg", "Unable to write response", "err", err)
-		}
-	}
-
+	// Compare responses.
 	if p.comparator != nil {
-		go func() {
-			expectedResponse := responses[0]
-			actualResponse := responses[1]
-			if responses[1].backend.preferred {
-				expectedResponse, actualResponse = actualResponse, expectedResponse
-			}
+		expectedResponse := responses[0]
+		actualResponse := responses[1]
+		if responses[1].backend.preferred {
+			expectedResponse, actualResponse = actualResponse, expectedResponse
+		}
 
-			result := resultSuccess
-			err := p.compareResponses(expectedResponse, actualResponse)
-			if err != nil {
-				level.Error(util.Logger).Log("msg", "response comparison failed", "route-name", p.routeName,
-					"query", r.URL.RawQuery, "err", err)
-				result = resultFailed
-			}
+		result := comparisonSuccess
+		err := p.compareResponses(expectedResponse, actualResponse)
+		if err != nil {
+			level.Error(util.Logger).Log("msg", "response comparison failed", "route-name", p.routeName,
+				"query", r.URL.RawQuery, "err", err)
+			result = comparisonFailed
+		}
 
-			p.metrics.responsesComparedTotal.WithLabelValues(p.routeName, result).Inc()
-		}()
+		p.metrics.responsesComparedTotal.WithLabelValues(p.routeName, result).Inc()
 	}
 }
 
-func (p *ProxyEndpoint) pickResponseForDownstream(responses []*backendResponse) *backendResponse {
-	// Look for a successful response from the preferred backend.
-	for _, res := range responses {
-		if res.backend.preferred && res.succeeded() {
-			return res
-		}
-	}
+func (p *ProxyEndpoint) waitBackendResponseForDownstream(resCh chan *backendResponse) *backendResponse {
+	var (
+		responses                 = make([]*backendResponse, 0, len(p.backends))
+		preferredResponseReceived = false
+	)
 
-	// Look for any other successful response.
-	for _, res := range responses {
-		if res.succeeded() {
+	for res := range resCh {
+		// If the response is successful we can immediately return it if:
+		// - There's no preferred backend configured
+		// - Or this response is from the preferred backend
+		// - Or the preferred backend response has already been received and wasn't successful
+		if res.succeeded() && (!p.hasPreferredBackend || res.backend.preferred || preferredResponseReceived) {
 			return res
 		}
+
+		// If we received a non successful response from the preferred backend, then we can
+		// return the first successful response received so far (if any).
+		if res.backend.preferred && !res.succeeded() {
+			preferredResponseReceived = true
+
+			for _, prevRes := range responses {
+				if prevRes.succeeded() {
+					return prevRes
+				}
+			}
+		}
+
+		// Otherwise we keep track of it for later.
+		responses = append(responses, res)
 	}
 
 	// No successful response, so let's pick the first one.
@@ -159,7 +191,6 @@ type backendResponse struct {
 	status  int
 	body    []byte
 	err     error
-	elapsed time.Duration
 }
 
 func (r *backendResponse) succeeded() bool {

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -12,16 +12,16 @@ import (
 )
 
 func Test_ProxyEndpoint_waitBackendResponseForDownstream(t *testing.T) {
-	backendUrl1, err := url.Parse("http://backend-1/")
+	backendURL1, err := url.Parse("http://backend-1/")
 	require.NoError(t, err)
-	backendUrl2, err := url.Parse("http://backend-2/")
+	backendURL2, err := url.Parse("http://backend-2/")
 	require.NoError(t, err)
-	backendUrl3, err := url.Parse("http://backend-3/")
+	backendURL3, err := url.Parse("http://backend-3/")
 	require.NoError(t, err)
 
-	backendPref := NewProxyBackend("backend-1", backendUrl1, time.Second, true)
-	backendOther1 := NewProxyBackend("backend-2", backendUrl2, time.Second, false)
-	backendOther2 := NewProxyBackend("backend-3", backendUrl3, time.Second, false)
+	backendPref := NewProxyBackend("backend-1", backendURL1, time.Second, true)
+	backendOther1 := NewProxyBackend("backend-2", backendURL2, time.Second, false)
+	backendOther2 := NewProxyBackend("backend-3", backendURL3, time.Second, false)
 
 	tests := map[string]struct {
 		backends  []*ProxyBackend

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -1,11 +1,111 @@
 package querytee
 
 import (
+	"net/url"
 	"testing"
+	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func Test_ProxyEndpoint_waitBackendResponseForDownstream(t *testing.T) {
+	backendUrl1, err := url.Parse("http://backend-1/")
+	require.NoError(t, err)
+	backendUrl2, err := url.Parse("http://backend-2/")
+	require.NoError(t, err)
+	backendUrl3, err := url.Parse("http://backend-3/")
+	require.NoError(t, err)
+
+	backendPref := NewProxyBackend("backend-1", backendUrl1, time.Second, true)
+	backendOther1 := NewProxyBackend("backend-2", backendUrl2, time.Second, false)
+	backendOther2 := NewProxyBackend("backend-3", backendUrl3, time.Second, false)
+
+	tests := map[string]struct {
+		backends  []*ProxyBackend
+		responses []*backendResponse
+		expected  *ProxyBackend
+	}{
+		"the preferred backend is the 1st response received": {
+			backends: []*ProxyBackend{backendPref, backendOther1},
+			responses: []*backendResponse{
+				{backend: backendPref, status: 200},
+			},
+			expected: backendPref,
+		},
+		"the preferred backend is the last response received": {
+			backends: []*ProxyBackend{backendPref, backendOther1},
+			responses: []*backendResponse{
+				{backend: backendOther1, status: 200},
+				{backend: backendPref, status: 200},
+			},
+			expected: backendPref,
+		},
+		"the preferred backend is the last response received but it's not successful": {
+			backends: []*ProxyBackend{backendPref, backendOther1},
+			responses: []*backendResponse{
+				{backend: backendOther1, status: 200},
+				{backend: backendPref, status: 500},
+			},
+			expected: backendOther1,
+		},
+		"the preferred backend is the 2nd response received but only the last one is successful": {
+			backends: []*ProxyBackend{backendPref, backendOther1, backendOther2},
+			responses: []*backendResponse{
+				{backend: backendOther1, status: 500},
+				{backend: backendPref, status: 500},
+				{backend: backendOther2, status: 200},
+			},
+			expected: backendOther2,
+		},
+		"there's no preferred backend configured and the 1st response is successful": {
+			backends: []*ProxyBackend{backendOther1, backendOther2},
+			responses: []*backendResponse{
+				{backend: backendOther1, status: 200},
+			},
+			expected: backendOther1,
+		},
+		"there's no preferred backend configured and the last response is successful": {
+			backends: []*ProxyBackend{backendOther1, backendOther2},
+			responses: []*backendResponse{
+				{backend: backendOther1, status: 500},
+				{backend: backendOther2, status: 200},
+			},
+			expected: backendOther2,
+		},
+		"no received response is successful": {
+			backends: []*ProxyBackend{backendPref, backendOther1},
+			responses: []*backendResponse{
+				{backend: backendOther1, status: 500},
+				{backend: backendPref, status: 500},
+			},
+			expected: backendOther1,
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			endpoint := NewProxyEndpoint(testData.backends, "test", NewProxyMetrics(nil), log.NewNopLogger(), nil)
+
+			// Send the responses from a dedicated goroutine.
+			resCh := make(chan *backendResponse)
+			go func() {
+				for _, res := range testData.responses {
+					resCh <- res
+				}
+				close(resCh)
+			}()
+
+			// Wait for the selected backend response.
+			actual := endpoint.waitBackendResponseForDownstream(resCh)
+			assert.Equal(t, testData.expected, actual.backend)
+		})
+	}
+}
 
 func Test_backendResponse_succeeded(t *testing.T) {
 	tests := map[string]struct {

--- a/tools/querytee/proxy_metrics.go
+++ b/tools/querytee/proxy_metrics.go
@@ -12,22 +12,28 @@ const (
 )
 
 type ProxyMetrics struct {
-	durationMetric         *prometheus.HistogramVec
+	requestDuration        *prometheus.HistogramVec
+	responsesTotal         *prometheus.CounterVec
 	responsesComparedTotal *prometheus.CounterVec
 }
 
 func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 	m := &ProxyMetrics{
-		durationMetric: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
+		requestDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "cortex_querytee",
 			Name:      "request_duration_seconds",
 			Help:      "Time (in seconds) spent serving HTTP requests.",
 			Buckets:   instrument.DefBuckets,
 		}, []string{"backend", "method", "route", "status_code"}),
+		responsesTotal: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "cortex_querytee",
+			Name:      "responses_total",
+			Help:      "Total number of responses sent back to the client by the selected backend.",
+		}, []string{"backend", "method", "route"}),
 		responsesComparedTotal: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "cortex_querytee",
 			Name:      "responses_compared_total",
-			Help:      "Total number of responses compared per route name by result",
+			Help:      "Total number of responses compared per route name by result.",
 		}, []string{"route", "result"}),
 	}
 

--- a/tools/querytee/proxy_metrics.go
+++ b/tools/querytee/proxy_metrics.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	resultSuccess = "success"
-	resultFailed  = "fail"
+	comparisonSuccess = "success"
+	comparisonFailed  = "fail"
 )
 
 type ProxyMetrics struct {
@@ -28,7 +28,7 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 			Namespace: "cortex_querytee",
 			Name:      "responses_compared_total",
 			Help:      "Total number of responses compared per route name by result",
-		}, []string{"route_name", "result"}),
+		}, []string{"route", "result"}),
 	}
 
 	return m

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -31,7 +31,6 @@ func Test_Proxy_RequestsForwarding(t *testing.T) {
 	const (
 		querySingleMetric1 = `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"cortex_build_info"},"value":[1583320883,"1"]}]}}`
 		querySingleMetric2 = `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"cortex_build_info"},"value":[1583320883,"2"]}]}}`
-		queryEmpty         = `{"status":"success","data":{"resultType":"vector","result":[]}}`
 	)
 
 	type mockedBackend struct {


### PR DESCRIPTION
**What this PR does**:
Currently, the `query-tee` waits all backend responses before sending back the response to the client. This means that the query performances, as perceived by the client, are always influenced by the slowest backend.

In this PR I'm fixing this. The `query-tee` now sends back to the client the first viable response received, where "viable" depends on whether the preferred backend is configured. If the preferred backend is configured we need to honor it, so we have to wait for the preferred backend response before sending back the response to the client, while if it's not configured then the first successful response will be picked.

/cc @sandeepsukhani 

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
