### PR TITLE
Separate HTTP Instrumentation for Querier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [FEATURE] TLS config options added for GRPC clients in Querier (Query-frontend client & Ingester client), Ruler, Store Gateway, as well as HTTP client in Config store client. #2502
 * [FEATURE] The flag `-frontend.max-cache-freshness` is now supported within the limits overrides, to specify per-tenant max cache freshness values. The corresponding YAML config parameter has been changed from `results_cache.max_freshness` to `limits_config.max_cache_freshness`. The legacy YAML config parameter (`results_cache.max_freshness`) will continue to be supported till Cortex release `v1.4.0`. #2609
 * [FEATURE] Experimental gRPC Store: Added support to 3rd parties index and chunk stores using gRPC client/server plugin mechanism. #2220
+* [ENHANCEMENT] Querier: Added metric `cortex_querier_request_duration_seconds` for all requests to the querier. #2708
 * [ENHANCEMENT] Experimental TSDB: added the following metrics to the ingester: #2580 #2583 #2589 #2654
   * `cortex_ingester_tsdb_appender_add_duration_seconds`
   * `cortex_ingester_tsdb_appender_commit_duration_seconds`

--- a/integration/asserts.go
+++ b/integration/asserts.go
@@ -30,7 +30,7 @@ var (
 	serviceMetricsPrefixes = map[ServiceType][]string{
 		Distributor:   {},
 		Ingester:      {"!cortex_ingester_client", "cortex_ingester"}, // The metrics prefix cortex_ingester_client may be used by other components so we ignore it.
-		Querier:       {},
+		Querier:       {"cortex_querier"},
 		QueryFrontend: {"cortex_frontend", "cortex_query_frontend"},
 		TableManager:  {},
 		AlertManager:  {"cortex_alertmanager"},

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -71,10 +71,10 @@ func New(cfg Config, s *server.Server, logger log.Logger) (*API, error) {
 	s.HTTP.UseEncodedPath()
 
 	api := &API{
-		cfg:                    cfg,
-		authMiddleware:         cfg.HTTPAuthMiddleware,
-		server:                 s,
-		logger:                 logger,
+		cfg:            cfg,
+		authMiddleware: cfg.HTTPAuthMiddleware,
+		server:         s,
+		logger:         logger,
 	}
 
 	// If no authentication middleware is present in the config, use the default authentication middleware.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -73,14 +73,14 @@ func New(cfg Config, s *server.Server, logger log.Logger, reg prometheus.Registe
 	// Ensure the encoded path is used. Required for the rules API
 	s.HTTP.UseEncodedPath()
 
-		// Prometheus histograms for requests.
-		querierRequestDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: "cortex",
-			Name:      "querier_request_duration_seconds",
-			Help:      "Time (in seconds) spent serving HTTP requests to the querier.",
-			Buckets:   instrument.DefBuckets,
-		}, []string{"method", "route", "status_code", "ws"})
-		reg.MustRegister(querierRequestDuration)
+	// Prometheus histograms for requests.
+	querierRequestDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "cortex",
+		Name:      "querier_request_duration_seconds",
+		Help:      "Time (in seconds) spent serving HTTP requests to the querier.",
+		Buckets:   instrument.DefBuckets,
+	}, []string{"method", "route", "status_code", "ws"})
+	reg.MustRegister(querierRequestDuration)
 
 	api := &API{
 		cfg:            cfg,

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -83,10 +83,10 @@ func New(cfg Config, s *server.Server, logger log.Logger, reg prometheus.Registe
 	reg.MustRegister(querierRequestDuration)
 
 	api := &API{
-		cfg:            cfg,
-		authMiddleware: cfg.HTTPAuthMiddleware,
-		server:         s,
-		logger:         logger,
+		cfg:                    cfg,
+		authMiddleware:         cfg.HTTPAuthMiddleware,
+		server:                 s,
+		logger:                 logger,
 		querierRequestDuration: querierRequestDuration,
 	}
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -344,10 +344,10 @@ func (a *API) RegisterQuerier(
 	}))
 }
 
-// RegisterQueryAPI registers the Prometheus routes supported by the
+// registerQueryAPI registers the Prometheus routes supported by the
 // Cortex querier service. Currently this can not be registered simultaneously
 // with the Querier.
-func (a *API) RegisterQueryAPI(handler http.Handler) {
+func (a *API) registerQueryAPI(handler http.Handler) {
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/read", handler, true, "POST")
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/query", handler, true, "GET", "POST")
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/query_range", handler, true, "GET", "POST")
@@ -371,7 +371,7 @@ func (a *API) RegisterQueryAPI(handler http.Handler) {
 // with the Querier.
 func (a *API) RegisterQueryFrontend(f *frontend.Frontend) {
 	frontend.RegisterFrontendServer(a.server.GRPC, f)
-	a.RegisterQueryAPI(f.Handler())
+	a.registerQueryAPI(f.Handler())
 }
 
 // RegisterServiceMapHandler registers the Cortex structs service handler

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/promql"
 	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
+	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/server"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager"
@@ -66,7 +68,7 @@ func (t *Cortex) initAPI() (services.Service, error) {
 	t.Cfg.API.ServerPrefix = t.Cfg.Server.PathPrefix
 	t.Cfg.API.LegacyHTTPPrefix = t.Cfg.HTTPPrefix
 
-	a, err := api.New(t.Cfg.API, t.Server, util.Logger, prometheus.DefaultRegisterer)
+	a, err := api.New(t.Cfg.API, t.Server, util.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -162,9 +164,17 @@ func (t *Cortex) initDistributor() (serv services.Service, err error) {
 func (t *Cortex) initQuerier() (serv services.Service, err error) {
 	queryable, engine := querier.New(t.Cfg.Querier, t.Distributor, t.StoreQueryable, t.TombstonesLoader, prometheus.DefaultRegisterer)
 
+	// Prometheus histograms for requests to the querier.
+	querierRequestDuration := promauto.With(prometheus.DefaultRegisterer).NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "cortex",
+		Name:      "querier_request_duration_seconds",
+		Help:      "Time (in seconds) spent serving HTTP requests to the querier.",
+		Buckets:   instrument.DefBuckets,
+	}, []string{"method", "route", "status_code", "ws"})
+
 	// if we are not configured for single binary mode then the querier needs to register its paths externally
 	registerExternally := t.Cfg.Target != All
-	handler := t.API.RegisterQuerier(queryable, engine, t.Distributor, registerExternally, t.TombstonesLoader)
+	handler := t.API.RegisterQuerier(queryable, engine, t.Distributor, registerExternally, t.TombstonesLoader, querierRequestDuration)
 
 	// single binary mode requires a properly configured worker.  if the operator did not attempt to configure the
 	//  worker we will attempt an automatic configuration here

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -66,7 +66,7 @@ func (t *Cortex) initAPI() (services.Service, error) {
 	t.Cfg.API.ServerPrefix = t.Cfg.Server.PathPrefix
 	t.Cfg.API.LegacyHTTPPrefix = t.Cfg.HTTPPrefix
 
-	a, err := api.New(t.Cfg.API, t.Server, util.Logger)
+	a, err := api.New(t.Cfg.API, t.Server, util.Logger, prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does**:

When running cortex as a single binary the requests processed by the querier are not instrumented. This PR adds a separate histogram metric `cortex_querier_request_duration_seconds` that allows the operator to make this distinction.

The metric is registered in both single binary and microservice mode. This will allow the new metric to be used for dashboards/panels in both modes. 

**Which issue(s) this PR fixes**:
Fixes #2707 

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
