### PR TITLE
add . to chunk cache name for clearer instrumentation

### DIFF
--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -128,7 +128,7 @@ func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConf
 	}
 
 	chunkCacheCfg := storeCfg.ChunkCacheConfig
-	chunkCacheCfg.Prefix = "chunks"
+	chunkCacheCfg.Prefix = "chunks."
 	chunksCache, err := cache.New(chunkCacheCfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does**:

Renames the label used for chunk cache metrics to be prefixed with `chunks.` instead of chunks.

**Which issue(s) this PR fixes**:

Currently the chunks cache name label is inconsistent with the reset of the metrics. It is currently formatted as `chunksmemcached.`. The rest of the labels have a dot separation between the cache name and cache type.

<img width="1680" alt="Screen Shot 2020-06-10 at 1 54 01 PM" src="https://user-images.githubusercontent.com/6921077/84301476-da1fa980-ab21-11ea-8a31-24eca9e337b9.png">


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
