### PR TITLE
allow registering routes with multiple http methods with query tee

### DIFF
--- a/cmd/query-tee/main.go
+++ b/cmd/query-tee/main.go
@@ -59,13 +59,13 @@ func main() {
 func cortexReadRoutes() []querytee.Route {
 	samplesComparator := querytee.NewSamplesComparator()
 	return []querytee.Route{
-		{Path: "/api/v1/query", RouteName: "api_v1_query", Methods: "GET", ResponseComparator: samplesComparator},
-		{Path: "/api/v1/query_range", RouteName: "api_v1_query_range", Methods: "GET", ResponseComparator: samplesComparator},
-		{Path: "/api/v1/labels", RouteName: "api_v1_labels", Methods: "GET", ResponseComparator: nil},
-		{Path: "/api/v1/label/{name}/values", RouteName: "api_v1_label_name_values", Methods: "GET", ResponseComparator: nil},
-		{Path: "/api/v1/series", RouteName: "api_v1_series", Methods: "GET", ResponseComparator: nil},
-		{Path: "/api/v1/metadata", RouteName: "api_v1_metadata", Methods: "GET", ResponseComparator: nil},
-		{Path: "/api/v1/rules", RouteName: "api_v1_rules", Methods: "GET", ResponseComparator: nil},
-		{Path: "/api/v1/alerts", RouteName: "api_v1_alerts", Methods: "GET", ResponseComparator: nil},
+		{Path: "/api/v1/query", RouteName: "api_v1_query", Methods: []string{"GET"}, ResponseComparator: samplesComparator},
+		{Path: "/api/v1/query_range", RouteName: "api_v1_query_range", Methods: []string{"GET"}, ResponseComparator: samplesComparator},
+		{Path: "/api/v1/labels", RouteName: "api_v1_labels", Methods: []string{"GET"}, ResponseComparator: nil},
+		{Path: "/api/v1/label/{name}/values", RouteName: "api_v1_label_name_values", Methods: []string{"GET"}, ResponseComparator: nil},
+		{Path: "/api/v1/series", RouteName: "api_v1_series", Methods: []string{"GET"}, ResponseComparator: nil},
+		{Path: "/api/v1/metadata", RouteName: "api_v1_metadata", Methods: []string{"GET"}, ResponseComparator: nil},
+		{Path: "/api/v1/rules", RouteName: "api_v1_rules", Methods: []string{"GET"}, ResponseComparator: nil},
+		{Path: "/api/v1/alerts", RouteName: "api_v1_alerts", Methods: []string{"GET"}, ResponseComparator: nil},
 	}
 }

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -42,7 +42,7 @@ func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
 type Route struct {
 	Path               string
 	RouteName          string
-	Methods            string
+	Methods            []string
 	ResponseComparator ResponsesComparator
 }
 
@@ -139,7 +139,7 @@ func (p *Proxy) Start() error {
 		if p.cfg.CompareResponses {
 			comparator = route.ResponseComparator
 		}
-		router.Path(route.Path).Methods(route.Methods).Handler(NewProxyEndpoint(p.backends, route.RouteName, p.metrics, p.logger, comparator))
+		router.Path(route.Path).Methods(route.Methods...).Handler(NewProxyEndpoint(p.backends, route.RouteName, p.metrics, p.logger, comparator))
 	}
 
 	p.srvListener = listener

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var testRoutes = []Route{
-	{Path: "/api/v1/query", RouteName: "api_v1_query", Methods: "GET", ResponseComparator: nil},
+	{Path: "/api/v1/query", RouteName: "api_v1_query", Methods: []string{"GET"}, ResponseComparator: nil},
 }
 
 func Test_NewProxy(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Currently, query tee supports only 1 method type per route. This PR adds support for multiple method types per route.
