### PR TITLE
Small optimization for FromLabelAdaptersToLabelsWithCopy

### DIFF
--- a/pkg/ingester/client/compat_test.go
+++ b/pkg/ingester/client/compat_test.go
@@ -145,7 +145,17 @@ func TestQueryResponse(t *testing.T) {
 	if !reflect.DeepEqual(have, want) {
 		t.Fatalf("Bad FromQueryResponse(ToQueryResponse) round trip")
 	}
+}
 
+func BenchmarkFromLabelAdaptersToLabelsWithCopy(b *testing.B) {
+	input := []LabelAdapter{
+		{Name: "hello", Value: "world"},
+		{Name: "some label", Value: "and its value"},
+		{Name: "long long long long long label name", Value: "perhaps even longer label value, but who's counting anyway?"}}
+
+	for i := 0; i < b.N; i++ {
+		FromLabelAdaptersToLabelsWithCopy(input)
+	}
 }
 
 // This test shows label sets with same fingerprints, and also shows how to easily create new collisions


### PR DESCRIPTION
This PR makes a small optimization in `FromLabelAdaptersToLabelsWithCopy` method: instead of making a copy of each string individually, all strings are copied to the single buffer. This reduces number of allocations, and makes `FromLabelAdaptersToLabelsWithCopy` faster.

Furthermore, number of allocations is now constant.

Master:

```
BenchmarkFromLabelAdaptersToLabelsWithCopy
BenchmarkFromLabelAdaptersToLabelsWithCopy-4   	 3148969	       391 ns/op	     400 B/op	      13 allocs/op
BenchmarkFromLabelAdaptersToLabelsWithCopy-4   	 3164420	       394 ns/op	     400 B/op	      13 allocs/op
BenchmarkFromLabelAdaptersToLabelsWithCopy-4   	 3195446	       385 ns/op	     400 B/op	      13 allocs/op
BenchmarkFromLabelAdaptersToLabelsWithCopy-4   	 3314721	       370 ns/op	     400 B/op	      13 allocs/op
BenchmarkFromLabelAdaptersToLabelsWithCopy-4   	 3152192	       362 ns/op	     400 B/op	      13 allocs/op
```

With PR:

```
BenchmarkFromLabelAdaptersToLabelsWithCopy
BenchmarkFromLabelAdaptersToLabelsWithCopy-4   	 7418990	       174 ns/op	     224 B/op	       2 allocs/op
BenchmarkFromLabelAdaptersToLabelsWithCopy-4   	 7012654	       168 ns/op	     224 B/op	       2 allocs/op
BenchmarkFromLabelAdaptersToLabelsWithCopy-4   	 7199830	       171 ns/op	     224 B/op	       2 allocs/op
BenchmarkFromLabelAdaptersToLabelsWithCopy-4   	 7079529	       161 ns/op	     224 B/op	       2 allocs/op
BenchmarkFromLabelAdaptersToLabelsWithCopy-4   	 7821024	       152 ns/op	     224 B/op	       2 allocs/op
```

Benchstat:

```
name                                 old time/op    new time/op    delta
FromLabelAdaptersToLabelsWithCopy-4     380ns ± 5%     165ns ± 8%  -56.57%  (p=0.008 n=5+5)

name                                 old alloc/op   new alloc/op   delta
FromLabelAdaptersToLabelsWithCopy-4      400B ± 0%      224B ± 0%  -44.00%  (p=0.008 n=5+5)

name                                 old allocs/op  new allocs/op  delta
FromLabelAdaptersToLabelsWithCopy-4      13.0 ± 0%       2.0 ± 0%  -84.62%  (p=0.008 n=5+5)
```
