### PR TITLE
Unexperimentalize memberlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
   * `cortex_<service>_blocks_last_successful_sync_timestamp_seconds` => `cortex_bucket_stores_blocks_last_successful_sync_timestamp_seconds{component="<service>"}`
 * [CHANGE] Available command-line flags are printed to stdout, and only when requested via `-help`. Using invalid flag no longer causes printing of all available flags. #2691
 * [CHANGE] Experimental Memberlist ring: randomize gossip node names to avoid conflicts when running multiple clients on the same host, or reusing host names (eg. pods in statefulset). Node name randomization can be disabled by using `-memberlist.randomize-node-name=false`. #2715
+* [CHANGE] Memberlist KV client is no longer considered experimental.
 * [FEATURE] TLS config options added for GRPC clients in Querier (Query-frontend client & Ingester client), Ruler, Store Gateway, as well as HTTP client in Config store client. #2502
 * [FEATURE] The flag `-frontend.max-cache-freshness` is now supported within the limits overrides, to specify per-tenant max cache freshness values. The corresponding YAML config parameter has been changed from `results_cache.max_freshness` to `limits_config.max_cache_freshness`. The legacy YAML config parameter (`results_cache.max_freshness`) will continue to be supported till Cortex release `v1.4.0`. #2609
 * [FEATURE] Experimental gRPC Store: Added support to 3rd parties index and chunk stores using gRPC client/server plugin mechanism. #2220

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
   * `cortex_<service>_blocks_last_successful_sync_timestamp_seconds` => `cortex_bucket_stores_blocks_last_successful_sync_timestamp_seconds{component="<service>"}`
 * [CHANGE] Available command-line flags are printed to stdout, and only when requested via `-help`. Using invalid flag no longer causes printing of all available flags. #2691
 * [CHANGE] Experimental Memberlist ring: randomize gossip node names to avoid conflicts when running multiple clients on the same host, or reusing host names (eg. pods in statefulset). Node name randomization can be disabled by using `-memberlist.randomize-node-name=false`. #2715
-* [CHANGE] Memberlist KV client is no longer considered experimental.
+* [CHANGE] Memberlist KV client is no longer considered experimental. #2725
 * [FEATURE] TLS config options added for GRPC clients in Querier (Query-frontend client & Ingester client), Ruler, Store Gateway, as well as HTTP client in Config store client. #2502
 * [FEATURE] The flag `-frontend.max-cache-freshness` is now supported within the limits overrides, to specify per-tenant max cache freshness values. The corresponding YAML config parameter has been changed from `results_cache.max_freshness` to `limits_config.max_cache_freshness`. The legacy YAML config parameter (`results_cache.max_freshness`) will continue to be supported till Cortex release `v1.4.0`. #2609
 * [FEATURE] Experimental gRPC Store: Added support to 3rd parties index and chunk stores using gRPC client/server plugin mechanism. #2220

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -182,18 +182,24 @@ prefix these flags with `distributor.ha-tracker.`
 - `etcd.max-retries`
    The maximum number of retries to do for failed ops.
 
-#### memberlist (EXPERIMENTAL)
+#### memberlist
 
-Flags for configuring KV store based on memberlist library. This feature is experimental, please don't use it yet.
+Flags for configuring KV store based on memberlist library.
 
 - `memberlist.nodename`
    Name of the node in memberlist cluster. Defaults to hostname.
+- `memberlist.randomize-node-name`
+   This flag adds extra random suffix to the node name used by memberlist. Defaults to true. Using random suffix helps to prevent issues when running multiple memberlist nodes on the same machine, or when node names are reused (eg. in stateful sets).
 - `memberlist.retransmit-factor`
    Multiplication factor used when sending out messages (factor * log(N+1)). If not set, default value is used.
 - `memberlist.join`
    Other cluster members to join. Can be specified multiple times.
+- `memberlist.min-join-backoff`, `memberlist.max-join-backoff`, `memberlist.max-join-retries`
+   These flags control backoff settings when joining the cluster.
 - `memberlist.abort-if-join-fails`
    If this node fails to join memberlist cluster, abort.
+- `memberlist.rejoin-interval`
+   How often to try to rejoin the memberlist cluster. Defaults to 0, no rejoining. Occasional rejoin may be useful in some configurations, and is otherwise harmless.
 - `memberlist.left-ingesters-timeout`
    How long to keep LEFT ingesters in the ring. Note: this is only used for gossiping, LEFT ingesters are otherwise invisible.
 - `memberlist.leave-timeout`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2303,8 +2303,7 @@ The `memberlist_config` configures the Gossip memberlist.
 # CLI flag: -memberlist.dead-node-reclaim-time
 [dead_node_reclaim_time: <duration> | default = 0s]
 
-# Other cluster members to join. Can be specified multiple times. Memberlist
-# store is EXPERIMENTAL.
+# Other cluster members to join. Can be specified multiple times.
 # CLI flag: -memberlist.join
 [join_members: <list of string> | default = ]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -322,7 +322,7 @@ ha_tracker:
 
   kvstore:
     # Backend storage to use for the ring. Supported values are: consul, etcd,
-    # inmemory, multi, memberlist (experimental).
+    # inmemory, memberlist, multi.
     # CLI flag: -distributor.ha-tracker.store
     [store: <string> | default = "consul"]
 
@@ -375,7 +375,7 @@ ha_tracker:
 ring:
   kvstore:
     # Backend storage to use for the ring. Supported values are: consul, etcd,
-    # inmemory, multi, memberlist (experimental).
+    # inmemory, memberlist, multi.
     # CLI flag: -distributor.ring.store
     [store: <string> | default = "consul"]
 
@@ -450,7 +450,7 @@ lifecycler:
   ring:
     kvstore:
       # Backend storage to use for the ring. Supported values are: consul, etcd,
-      # inmemory, multi, memberlist (experimental).
+      # inmemory, memberlist, multi.
       # CLI flag: -ring.store
       [store: <string> | default = "consul"]
 
@@ -990,7 +990,7 @@ storage:
 ring:
   kvstore:
     # Backend storage to use for the ring. Supported values are: consul, etcd,
-    # inmemory, multi, memberlist (experimental).
+    # inmemory, memberlist, multi.
     # CLI flag: -ruler.ring.store
     [store: <string> | default = "consul"]
 
@@ -3170,7 +3170,7 @@ The `compactor_config` configures the compactor for the experimental blocks stor
 sharding_ring:
   kvstore:
     # Backend storage to use for the ring. Supported values are: consul, etcd,
-    # inmemory, multi, memberlist (experimental).
+    # inmemory, memberlist, multi.
     # CLI flag: -compactor.ring.store
     [store: <string> | default = "consul"]
 
@@ -3231,7 +3231,7 @@ sharding_ring:
   # in microservices mode.
   kvstore:
     # Backend storage to use for the ring. Supported values are: consul, etcd,
-    # inmemory, multi, memberlist (experimental).
+    # inmemory, memberlist, multi.
     # CLI flag: -experimental.store-gateway.sharding-ring.store
     [store: <string> | default = "consul"]
 

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -38,7 +38,6 @@ Currently experimental features are:
 - Cassandra storage engine.
 - Azure blob storage.
 - Zone awareness based replication.
-- Gossip based ring.
 - User subrings.
 - Ruler API (to PUT rules).
 - Memcached client DNS-based service discovery.

--- a/docs/operations/blocks-storage.md
+++ b/docs/operations/blocks-storage.md
@@ -534,7 +534,7 @@ store_gateway:
     # running in microservices mode.
     kvstore:
       # Backend storage to use for the ring. Supported values are: consul, etcd,
-      # inmemory, multi, memberlist (experimental).
+      # inmemory, memberlist, multi.
       # CLI flag: -experimental.store-gateway.sharding-ring.store
       [store: <string> | default = "consul"]
 
@@ -654,7 +654,7 @@ compactor:
   sharding_ring:
     kvstore:
       # Backend storage to use for the ring. Supported values are: consul, etcd,
-      # inmemory, multi, memberlist (experimental).
+      # inmemory, memberlist, multi.
       # CLI flag: -compactor.ring.store
       [store: <string> | default = "consul"]
 

--- a/pkg/ring/kv/client.go
+++ b/pkg/ring/kv/client.go
@@ -61,7 +61,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(flagsPrefix, defaultPrefix string, f 
 		flagsPrefix = "ring."
 	}
 	f.StringVar(&cfg.Prefix, flagsPrefix+"prefix", defaultPrefix, "The prefix for the keys in the store. Should end with a /.")
-	f.StringVar(&cfg.Store, flagsPrefix+"store", "consul", "Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, multi, memberlist (experimental).")
+	f.StringVar(&cfg.Store, flagsPrefix+"store", "consul", "Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi.")
 }
 
 // Client is a high-level client for key-value stores (such as Etcd and

--- a/pkg/ring/kv/memberlist/memberlist_client.go
+++ b/pkg/ring/kv/memberlist/memberlist_client.go
@@ -164,7 +164,7 @@ func (cfg *KVConfig) RegisterFlags(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.RandomizeNodeName, prefix+"memberlist.randomize-node-name", true, "Add random suffix to the node name.")
 	f.DurationVar(&cfg.StreamTimeout, prefix+"memberlist.stream-timeout", 0, "The timeout for establishing a connection with a remote node, and for read/write operations. Uses memberlist LAN defaults if 0.")
 	f.IntVar(&cfg.RetransmitMult, prefix+"memberlist.retransmit-factor", 0, "Multiplication factor used when sending out messages (factor * log(N+1)).")
-	f.Var(&cfg.JoinMembers, prefix+"memberlist.join", "Other cluster members to join. Can be specified multiple times. Memberlist store is EXPERIMENTAL.")
+	f.Var(&cfg.JoinMembers, prefix+"memberlist.join", "Other cluster members to join. Can be specified multiple times.")
 	f.DurationVar(&cfg.MinJoinBackoff, prefix+"memberlist.min-join-backoff", 1*time.Second, "Min backoff duration to join other cluster members.")
 	f.DurationVar(&cfg.MaxJoinBackoff, prefix+"memberlist.max-join-backoff", 1*time.Minute, "Max backoff duration to join other cluster members.")
 	f.IntVar(&cfg.MaxJoinRetries, prefix+"memberlist.max-join-retries", 10, "Max number of retries to join other cluster members.")


### PR DESCRIPTION
**What this PR does**: This PR adds missing flags from documentation, and marks Memberlist as no longer experimental. Note that this PR assumes #2713 and #2724 to be merged first.

**Which issue(s) this PR fixes**:
Fixes #2638

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
