### PR TITLE
Remove old temporary checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 * [BUGFIX] Cassandra: fixed an edge case leading to an invalid CQL query when querying the index on a Cassandra store. #2639
 * [BUGFIX] Ingester: increment series per metric when recovering from WAL or transfer. #2674
 * [BUGFIX] Fixed `wrong number of arguments for 'mget' command` Redis error when a query has no chunks to lookup from storage. #2700
+* [BUGFIX] Ingester: Automatically remove old tmp checkpoints, fixing a potential disk space leak after an ingester crashes.
 
 ## 1.1.0 / 2020-05-21
 

--- a/pkg/ingester/wal_test.go
+++ b/pkg/ingester/wal_test.go
@@ -285,6 +285,66 @@ func TestMigrationToTypedRecord(t *testing.T) {
 	require.Equal(t, checkpointRecord, newCheckpointRecordDecoded)
 }
 
+func TestCheckpointIndex(t *testing.T) {
+	tcs := []struct {
+		filename    string
+		includeTmp  bool
+		index       int
+		shouldError bool
+	}{
+		{
+			filename:    "checkpoint.123456",
+			includeTmp:  false,
+			index:       123456,
+			shouldError: false,
+		},
+		{
+			filename:    "checkpoint.123456",
+			includeTmp:  true,
+			index:       123456,
+			shouldError: false,
+		},
+		{
+			filename:    "checkpoint.123456.tmp",
+			includeTmp:  true,
+			index:       123456,
+			shouldError: false,
+		},
+		{
+			filename:    "checkpoint.123456.tmp",
+			includeTmp:  false,
+			shouldError: true,
+		},
+		{
+			filename:    "not-checkpoint.123456.tmp",
+			includeTmp:  true,
+			shouldError: true,
+		},
+		{
+			filename:    "checkpoint.123456.tmp2",
+			shouldError: true,
+		},
+		{
+			filename:    "checkpoints123456",
+			shouldError: true,
+		},
+		{
+			filename:    "012345",
+			shouldError: true,
+		},
+	}
+	for _, tc := range tcs {
+		index, err := checkpointIndex(tc.filename, tc.includeTmp)
+		if tc.shouldError {
+			require.Error(t, err, "filename: %s, includeTmp: %t", tc.filename, tc.includeTmp)
+			continue
+		}
+
+		require.NoError(t, err, "filename: %s, includeTmp: %t", tc.filename, tc.includeTmp)
+		require.Equal(t, tc.index, index)
+	}
+}
+
 func BenchmarkWALReplay(b *testing.B) {
 	dirname, err := ioutil.TempDir("", "cortex-wal")
 	require.NoError(b, err)


### PR DESCRIPTION
If an ingester crashes while doing a checkpoint, which is likely as
checkpoints are almost always happening, then a checkpoint like
checkpoint.123456.tmp will be left on disk. When the next checkpoint
succeeds, the old .tmp checkpoints are not deleted even though it will
never be used. After enough crashes it is possible to fill the entire
disk with .tmp checkpoints, bringing down an ingester.

**Checklist**
- [x] Tests updated
- [x] Documentation added (Not needed)
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
