### PR TITLE
change flag DisableChunksDeduplication to DisableIndexDeduplication for disabling just index deduplication

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -576,8 +576,8 @@ func processChunkResponse(response *dynamodb.BatchGetItemOutput, chunksByKey map
 
 // PutChunkAndIndex implements chunk.ObjectAndIndexClient
 // Combine both sets of writes before sending to DynamoDB, for performance
-func (a dynamoDBStorageClient) PutChunkAndIndex(ctx context.Context, c chunk.Chunk, index chunk.WriteBatch) error {
-	dynamoDBWrites, err := a.writesForChunks([]chunk.Chunk{c})
+func (a dynamoDBStorageClient) PutChunksAndIndex(ctx context.Context, chunks []chunk.Chunk, index chunk.WriteBatch) error {
+	dynamoDBWrites, err := a.writesForChunks(chunks)
 	if err != nil {
 		return err
 	}

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -63,9 +63,8 @@ type StoreConfig struct {
 	// is set, use different caches for ingesters and queriers.
 	chunkCacheStubs bool // don't write the full chunk to cache, just a stub entry
 
-	// When DisableChunksDeduplication is true, cache would not be checked for whether chunk is already written.
-	// It would still write the chunk back to cache for reads.
-	DisableChunksDeduplication bool `yaml:"-"`
+	// When DisableIndexDeduplication is true and chunk is already there in cache, only index would be written to the store and not chunk.
+	DisableIndexDeduplication bool `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -20,7 +20,8 @@ type MockStorage struct {
 	tables  map[string]*mockTable
 	objects map[string][]byte
 
-	numWrites int
+	numIndexWrites int
+	numChunkWrites int
 }
 
 type mockTable struct {
@@ -137,7 +138,7 @@ func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
 	mockBatch := *batch.(*mockWriteBatch)
 	seenWrites := map[string]bool{}
 
-	m.numWrites += len(mockBatch.inserts)
+	m.numIndexWrites += len(mockBatch.inserts)
 
 	for _, req := range mockBatch.inserts {
 		table, ok := m.tables[req.tableName]
@@ -300,6 +301,8 @@ func (m *MockStorage) query(ctx context.Context, query IndexQuery, callback func
 func (m *MockStorage) PutChunks(_ context.Context, chunks []Chunk) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
+
+	m.numChunkWrites += len(chunks)
 
 	for i := range chunks {
 		buf, err := chunks[i].Encoded()

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -40,7 +40,7 @@ type Client interface {
 
 // ObjectAndIndexClient allows optimisations where the same client handles both
 type ObjectAndIndexClient interface {
-	PutChunkAndIndex(ctx context.Context, c Chunk, index WriteBatch) error
+	PutChunksAndIndex(ctx context.Context, chunks []Chunk, index WriteBatch) error
 }
 
 // WriteBatch represents a batch of writes.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
`DisableChunksDeduplication` was added for disabling chunks deduplication for boltdb shipper in Loki but the problem is it still makes us write an already written chunk again to the storage while the requirement is to not dedupe just the index.
This PR changes flag `DisableChunksDeduplication` to `DisableIndexDeduplication` to disable deduping of just the index and not both chunk+index. It also still writes the chunk to cache for write performance.
