### PR TITLE
Uniform error field name in logs

### DIFF
--- a/pkg/configs/db/postgres/postgres.go
+++ b/pkg/configs/db/postgres/postgres.go
@@ -60,7 +60,7 @@ func dbWait(db *sql.DB) error {
 		if err == nil {
 			return nil
 		}
-		level.Warn(util.Logger).Log("msg", "db connection not established, retrying...", "error", err)
+		level.Warn(util.Logger).Log("msg", "db connection not established, retrying...", "err", err)
 		time.Sleep(time.Second << uint(tries))
 	}
 	return errors.Wrapf(err, "db connection not established after %s", dbTimeout)
@@ -94,7 +94,7 @@ func New(uri, migrationsDir string) (DB, error) {
 			if err != migrate.ErrNoChange {
 				return DB{}, errors.Wrap(err, "database migrations failed")
 			}
-			level.Debug(util.Logger).Log("msg", "no change in schema, error (ignored)", "error", err)
+			level.Debug(util.Logger).Log("msg", "no change in schema, error (ignored)", "err", err)
 		}
 	}
 
@@ -340,7 +340,7 @@ func (d DB) Transaction(f func(DB) error) error {
 	if err != nil {
 		// Rollback error is ignored as we already have one in progress
 		if err2 := tx.Rollback(); err2 != nil {
-			level.Warn(util.Logger).Log("msg", "transaction rollback error (ignored)", "error", err2)
+			level.Warn(util.Logger).Log("msg", "transaction rollback error (ignored)", "err", err2)
 		}
 		return err
 	}

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -326,15 +326,15 @@ func (t *Cortex) Run() error {
 		for m, s := range t.ServiceMap {
 			if s == service {
 				if service.FailureCase() == util.ErrStopProcess {
-					level.Info(util.Logger).Log("msg", "received stop signal via return error", "module", m, "error", service.FailureCase())
+					level.Info(util.Logger).Log("msg", "received stop signal via return error", "module", m, "err", service.FailureCase())
 				} else {
-					level.Error(util.Logger).Log("msg", "module failed", "module", m, "error", service.FailureCase())
+					level.Error(util.Logger).Log("msg", "module failed", "module", m, "err", service.FailureCase())
 				}
 				return
 			}
 		}
 
-		level.Error(util.Logger).Log("msg", "module failed", "module", "unknown", "error", service.FailureCase())
+		level.Error(util.Logger).Log("msg", "module failed", "module", "unknown", "err", service.FailureCase())
 	}
 
 	sm.AddListener(services.NewManagerListener(healthy, stopped, serviceFailed))

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -236,7 +236,7 @@ func (c *haTracker) checkReplica(ctx context.Context, userID, cluster, replica s
 		// The callback within checkKVStore will return a 202 if the sample is being deduped,
 		// otherwise there may have been an actual error CAS'ing that we should log.
 		if resp, ok := httpgrpc.HTTPResponseFromError(err); ok && resp.GetCode() != 202 {
-			level.Error(util.Logger).Log("msg", "rejecting sample", "error", err)
+			level.Error(util.Logger).Log("msg", "rejecting sample", "err", err)
 		}
 	}
 	return err

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -189,7 +189,7 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 		// Ensure the form has been parsed so all the parameters are present
 		err = r.ParseForm()
 		if err != nil {
-			level.Warn(util.WithContext(r.Context(), f.log)).Log("msg", "unable to parse form for request", "error", err)
+			level.Warn(util.WithContext(r.Context(), f.log)).Log("msg", "unable to parse form for request", "err", err)
 		}
 
 		// Attempt to iterate through the Form to log any filled in values


### PR DESCRIPTION
**What this PR does**:
Yesterday I left a feedback to @jtlisi in https://github.com/cortexproject/cortex/pull/2722 to use "error" as log field name for consistency. I was wrong. There are more occurences of "err" then "error" in logs.

In this PR I'm uniforming it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
