### PR TITLE
more metrics in purger for monitoring delete requests processing progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,10 @@
 * [ENHANCEMENT] Experimental TSDB: Applied a jitter to the period bucket scans in order to better distribute bucket operations over the time and increase the probability of hitting the shared cache (if configured). #2693
 * [ENHANCEMENT] Experimental TSDB: Series limit per user and per metric now work in TSDB blocks. #2676
 * [ENHANCEMENT] Experimental Memberlist: Added ability to periodically rejoin the memberlist cluster. #2724
+* [ENHANCEMENT] Experimental Delete Series: Added the following metrics for monitoring processing of delete requests: #2445
+  - `cortex_purger_load_pending_requests_attempts_total`: Number of attempts that were made to load pending requests with status.
+  - `cortex_purger_oldest_pending_delete_request_age_seconds`: Age of oldest pending delete request in seconds.
+  - `cortex_purger_pending_delete_requests_count`: Count of requests which are in process or are ready to be processed.
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/pkg/chunk/purger/purger.go
+++ b/pkg/chunk/purger/purger.go
@@ -28,12 +28,17 @@ import (
 const (
 	millisecondPerDay                 = int64(24 * time.Hour / time.Millisecond)
 	deleteRequestCancellationDeadline = 24 * time.Hour
+	statusSuccess                     = "success"
+	statusFail                        = "fail"
 )
 
 type purgerMetrics struct {
-	deleteRequestsProcessedTotal      *prometheus.CounterVec
-	deleteRequestsChunksSelectedTotal *prometheus.CounterVec
-	deleteRequestsProcessingFailures  *prometheus.CounterVec
+	deleteRequestsProcessedTotal         *prometheus.CounterVec
+	deleteRequestsChunksSelectedTotal    *prometheus.CounterVec
+	deleteRequestsProcessingFailures     *prometheus.CounterVec
+	loadPendingRequestsAttempsTotal      *prometheus.CounterVec
+	oldestPendingDeleteRequestAgeSeconds prometheus.Gauge
+	pendingDeleteRequestsCount           prometheus.Gauge
 }
 
 func newPurgerMetrics(r prometheus.Registerer) *purgerMetrics {
@@ -54,6 +59,21 @@ func newPurgerMetrics(r prometheus.Registerer) *purgerMetrics {
 		Name:      "purger_delete_requests_processing_failures_total",
 		Help:      "Number of delete requests processing failures per user",
 	}, []string{"user"})
+	m.loadPendingRequestsAttempsTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Namespace: "cortex",
+		Name:      "purger_load_pending_requests_attempts_total",
+		Help:      "Number of attempts that were made to load pending requests with status",
+	}, []string{"status"})
+	m.oldestPendingDeleteRequestAgeSeconds = promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		Namespace: "cortex",
+		Name:      "purger_oldest_pending_delete_request_age_seconds",
+		Help:      "Age of oldest pending delete request in seconds",
+	})
+	m.pendingDeleteRequestsCount = promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		Namespace: "cortex",
+		Name:      "purger_pending_delete_requests_count",
+		Help:      "Count of requests which are in process or are ready to be processed",
+	})
 
 	return &m
 }
@@ -99,7 +119,7 @@ type DataPurger struct {
 
 	// we would only allow processing of singe delete request at a time since delete requests touching same chunks could change the chunk IDs of partially deleted chunks
 	// and break the purge plan for other requests
-	inProcessRequestIDs    map[string]string
+	inProcessRequestIDs    map[string]DeleteRequest
 	inProcessRequestIDsMtx sync.RWMutex
 
 	// We do not want to limit pulling new delete requests to a fixed interval which otherwise would limit number of delete requests we process per user.
@@ -128,7 +148,7 @@ func NewDataPurger(cfg Config, deleteStore *DeleteStore, chunkStore chunk.Store,
 		pullNewRequestsChan:      make(chan struct{}, 1),
 		executePlansChan:         make(chan deleteRequestWithLogger, 50),
 		workerJobChan:            make(chan workerJob, 50),
-		inProcessRequestIDs:      map[string]string{},
+		inProcessRequestIDs:      map[string]DeleteRequest{},
 		usersWithPendingRequests: map[string]struct{}{},
 		pendingPlansCount:        map[string]int{},
 	}
@@ -151,15 +171,23 @@ func (dp *DataPurger) init(ctx context.Context) error {
 }
 
 func (dp *DataPurger) loop(ctx context.Context) error {
-	loadRequestsTicker := time.NewTicker(time.Hour)
-	defer loadRequestsTicker.Stop()
-
 	loadRequests := func() {
+		status := statusSuccess
+
 		err := dp.pullDeleteRequestsToPlanDeletes()
 		if err != nil {
+			status = statusFail
 			level.Error(util.Logger).Log("msg", "error pulling delete requests for building plans", "err", err)
 		}
+
+		dp.metrics.loadPendingRequestsAttempsTotal.WithLabelValues(status).Inc()
 	}
+
+	// load requests on startup instead of waiting for first ticker
+	loadRequests()
+
+	loadRequestsTicker := time.NewTicker(time.Hour)
+	defer loadRequestsTicker.Stop()
 
 	for {
 		select {
@@ -339,7 +367,7 @@ func (dp *DataPurger) loadInprocessDeleteRequests() error {
 
 		level.Info(req.logger).Log("msg", "loaded in process delete requests with status building plan")
 
-		dp.inProcessRequestIDs[deleteRequest.UserID] = deleteRequest.RequestID
+		dp.inProcessRequestIDs[deleteRequest.UserID] = deleteRequest
 		err := dp.buildDeletePlan(req)
 		if err != nil {
 			dp.metrics.deleteRequestsProcessingFailures.WithLabelValues(deleteRequest.UserID).Inc()
@@ -360,7 +388,7 @@ func (dp *DataPurger) loadInprocessDeleteRequests() error {
 		req := makeDeleteRequestWithLogger(deleteRequest, util.Logger)
 		level.Info(req.logger).Log("msg", "loaded in process delete requests with status deleting")
 
-		dp.inProcessRequestIDs[deleteRequest.UserID] = deleteRequest.RequestID
+		dp.inProcessRequestIDs[deleteRequest.UserID] = deleteRequest
 		dp.executePlansChan <- req
 	}
 
@@ -375,23 +403,43 @@ func (dp *DataPurger) pullDeleteRequestsToPlanDeletes() error {
 		return err
 	}
 
+	dp.inProcessRequestIDsMtx.RLock()
+	pendingDeleteRequestsCount := len(dp.inProcessRequestIDs)
+	dp.inProcessRequestIDsMtx.RUnlock()
+
+	now := model.Now()
+	oldestPendingRequestCreatedAt := now
+
+	// requests which are still being processed are also considered pending
+	if pendingDeleteRequestsCount != 0 {
+		oldestInProcessRequest := dp.getOldestInProcessRequest()
+		if oldestInProcessRequest != nil {
+			oldestPendingRequestCreatedAt = oldestInProcessRequest.CreatedAt
+		}
+	}
+
 	for _, deleteRequest := range deleteRequests {
 		// adding an extra minute here to avoid a race between cancellation of request and picking of the request for processing
 		if deleteRequest.CreatedAt.Add(deleteRequestCancellationDeadline).Add(time.Minute).After(model.Now()) {
 			continue
 		}
 
+		pendingDeleteRequestsCount++
+		if deleteRequest.CreatedAt.Before(oldestPendingRequestCreatedAt) {
+			oldestPendingRequestCreatedAt = deleteRequest.CreatedAt
+		}
+
 		dp.inProcessRequestIDsMtx.RLock()
-		inprocessDeleteRequestID := dp.inProcessRequestIDs[deleteRequest.UserID]
+		inprocessDeleteRequest, ok := dp.inProcessRequestIDs[deleteRequest.UserID]
 		dp.inProcessRequestIDsMtx.RUnlock()
 
-		if inprocessDeleteRequestID != "" {
+		if ok {
 			dp.usersWithPendingRequestsMtx.Lock()
 			dp.usersWithPendingRequests[deleteRequest.UserID] = struct{}{}
 			dp.usersWithPendingRequestsMtx.Unlock()
 
 			level.Debug(util.Logger).Log("msg", "skipping delete request processing for now since another request from same user is already in process",
-				"inprocess_request_id", inprocessDeleteRequestID,
+				"inprocess_request_id", inprocessDeleteRequest.RequestID,
 				"skipped_request_id", deleteRequest.RequestID, "user_id", deleteRequest.UserID)
 			continue
 		}
@@ -402,7 +450,7 @@ func (dp *DataPurger) pullDeleteRequestsToPlanDeletes() error {
 		}
 
 		dp.inProcessRequestIDsMtx.Lock()
-		dp.inProcessRequestIDs[deleteRequest.UserID] = deleteRequest.RequestID
+		dp.inProcessRequestIDs[deleteRequest.UserID] = deleteRequest
 		dp.inProcessRequestIDsMtx.Unlock()
 
 		req := makeDeleteRequestWithLogger(deleteRequest, util.Logger)
@@ -423,6 +471,9 @@ func (dp *DataPurger) pullDeleteRequestsToPlanDeletes() error {
 		level.Info(req.logger).Log("msg", "sending delete request for execution")
 		dp.executePlansChan <- req
 	}
+
+	dp.metrics.oldestPendingDeleteRequestAgeSeconds.Set(float64(now.Sub(oldestPendingRequestCreatedAt) / time.Second))
+	dp.metrics.pendingDeleteRequestsCount.Set(float64(pendingDeleteRequestsCount))
 
 	return nil
 }
@@ -536,6 +587,20 @@ func (dp *DataPurger) getDeletePlan(ctx context.Context, userID, requestID strin
 func (dp *DataPurger) removeDeletePlan(ctx context.Context, userID, requestID string, planNo int) error {
 	objectKey := buildObjectKeyForPlan(userID, requestID, planNo)
 	return dp.objectClient.DeleteObject(ctx, objectKey)
+}
+
+func (dp *DataPurger) getOldestInProcessRequest() *DeleteRequest {
+	dp.inProcessRequestIDsMtx.RLock()
+	defer dp.inProcessRequestIDsMtx.RUnlock()
+
+	var oldestRequest *DeleteRequest
+	for _, request := range dp.inProcessRequestIDs {
+		if oldestRequest == nil || request.CreatedAt.Before(oldestRequest.CreatedAt) {
+			oldestRequest = &request
+		}
+	}
+
+	return oldestRequest
 }
 
 // returns interval per plan

--- a/pkg/chunk/purger/purger_test.go
+++ b/pkg/chunk/purger/purger_test.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
@@ -47,7 +51,9 @@ func setupTestDeleteStore(t *testing.T) *DeleteStore {
 	return deleteStore
 }
 
-func setupStoresAndPurger(t *testing.T) (*DeleteStore, chunk.Store, chunk.ObjectClient, *DataPurger) {
+func setupStoresAndPurger(t *testing.T) (*DeleteStore, chunk.Store, chunk.ObjectClient, *DataPurger, *prometheus.Registry) {
+	registry := prometheus.NewRegistry()
+
 	deleteStore := setupTestDeleteStore(t)
 
 	chunkStore, err := testutils.SetupTestChunkStore()
@@ -59,10 +65,10 @@ func setupStoresAndPurger(t *testing.T) (*DeleteStore, chunk.Store, chunk.Object
 	var cfg Config
 	flagext.DefaultValues(&cfg)
 
-	dataPurger, err := NewDataPurger(cfg, deleteStore, chunkStore, storageClient, nil)
+	dataPurger, err := NewDataPurger(cfg, deleteStore, chunkStore, storageClient, registry)
 	require.NoError(t, err)
 
-	return deleteStore, chunkStore, storageClient, dataPurger
+	return deleteStore, chunkStore, storageClient, dataPurger, registry
 }
 
 func buildChunks(from, through model.Time, batchSize int) ([]chunk.Chunk, error) {
@@ -170,7 +176,7 @@ func TestDataPurger_BuildPlan(t *testing.T) {
 	for _, tc := range purgePlanTestCases {
 		for batchSize := 1; batchSize <= 5; batchSize++ {
 			t.Run(fmt.Sprintf("%s/batch-size=%d", tc.name, batchSize), func(t *testing.T) {
-				deleteStore, chunkStore, storageClient, dataPurger := setupStoresAndPurger(t)
+				deleteStore, chunkStore, storageClient, dataPurger, _ := setupStoresAndPurger(t)
 				defer func() {
 					dataPurger.StopAsync()
 					chunkStore.Stop()
@@ -237,6 +243,7 @@ func TestDataPurger_BuildPlan(t *testing.T) {
 				}
 
 				require.Equal(t, tc.numChunksToDelete*batchSize, len(chunkIDs))
+				require.Equal(t, float64(tc.numChunksToDelete*batchSize), testutil.ToFloat64(dataPurger.metrics.deleteRequestsChunksSelectedTotal))
 			})
 		}
 	}
@@ -251,7 +258,7 @@ func TestDataPurger_ExecutePlan(t *testing.T) {
 	for _, tc := range purgePlanTestCases {
 		for batchSize := 1; batchSize <= 5; batchSize++ {
 			t.Run(fmt.Sprintf("%s/batch-size=%d", tc.name, batchSize), func(t *testing.T) {
-				deleteStore, chunkStore, _, dataPurger := setupStoresAndPurger(t)
+				deleteStore, chunkStore, _, dataPurger, _ := setupStoresAndPurger(t)
 				defer func() {
 					dataPurger.StopAsync()
 					chunkStore.Stop()
@@ -312,7 +319,7 @@ func TestDataPurger_Restarts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deleteStore, chunkStore, storageClient, dataPurger := setupStoresAndPurger(t)
+	deleteStore, chunkStore, storageClient, dataPurger, _ := setupStoresAndPurger(t)
 	defer func() {
 		chunkStore.Stop()
 	}()
@@ -342,11 +349,14 @@ func TestDataPurger_Restarts(t *testing.T) {
 	// create a new purger to check whether it picks up in process delete requests
 	var cfg Config
 	flagext.DefaultValues(&cfg)
-	newPurger, err := NewDataPurger(cfg, deleteStore, chunkStore, storageClient, nil)
+	newPurger, err := NewDataPurger(cfg, deleteStore, chunkStore, storageClient, prometheus.NewPedanticRegistry())
 	require.NoError(t, err)
 
 	// load in process delete requests by calling Run
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), newPurger))
+
+	// there must be 1 pending delete request
+	require.Equal(t, float64(1), testutil.ToFloat64(newPurger.metrics.pendingDeleteRequestsCount))
 
 	defer newPurger.StopAsync()
 
@@ -377,6 +387,87 @@ func TestDataPurger_Restarts(t *testing.T) {
 	deleteRequests, err = deleteStore.GetAllDeleteRequestsForUser(context.Background(), userID)
 	require.NoError(t, err)
 	require.Equal(t, StatusProcessed, deleteRequests[0].Status)
+
+	require.Equal(t, float64(1), testutil.ToFloat64(newPurger.metrics.deleteRequestsProcessedTotal))
+	require.PanicsWithError(t, "collected 0 metrics instead of exactly 1", func() {
+		testutil.ToFloat64(newPurger.metrics.deleteRequestsProcessingFailures)
+	})
+}
+
+func TestPurger_Metrics(t *testing.T) {
+	deleteStore, chunkStore, _, purger, registry := setupStoresAndPurger(t)
+	defer func() {
+		purger.StopAsync()
+		chunkStore.Stop()
+	}()
+
+	// start loop to load requests
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), purger))
+
+	// no delete requests for processing so age and pending request is 0 while we have successfully attempted loading request once.
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(
+		`
+			# HELP cortex_purger_load_pending_requests_attempts_total Number of attempts that were made to load pending requests with status
+			# TYPE cortex_purger_load_pending_requests_attempts_total counter
+			cortex_purger_load_pending_requests_attempts_total{status="success"} 1
+			# HELP cortex_purger_oldest_pending_delete_request_age_seconds Age of oldest pending delete request in seconds
+			# TYPE cortex_purger_oldest_pending_delete_request_age_seconds gauge
+			cortex_purger_oldest_pending_delete_request_age_seconds 0
+			# HELP cortex_purger_pending_delete_requests_count Count of requests which are in process or are ready to be processed
+			# TYPE cortex_purger_pending_delete_requests_count gauge
+			cortex_purger_pending_delete_requests_count 0
+		`),
+		"cortex_purger_load_pending_requests_attempts_total",
+		"cortex_purger_oldest_pending_delete_request_age_seconds",
+		"cortex_purger_pending_delete_requests_count",
+	))
+
+	// add delete request whose createdAt is now
+	err := deleteStore.AddDeleteRequest(context.Background(), userID, model.Time(0).Add(24*time.Hour),
+		model.Time(0).Add(2*24*time.Hour), []string{"foo"})
+	require.NoError(t, err)
+
+	// add delete request whose createdAt is 2 days back
+	err = deleteStore.addDeleteRequest(context.Background(), userID, model.Now().Add(-2*24*time.Hour), model.Time(0).Add(24*time.Hour),
+		model.Time(0).Add(2*24*time.Hour), []string{"foo"})
+	require.NoError(t, err)
+
+	// add delete request whose createdAt is 3 days back
+	err = deleteStore.addDeleteRequest(context.Background(), userID, model.Now().Add(-3*24*time.Hour), model.Time(0).Add(24*time.Hour),
+		model.Time(0).Add(8*24*time.Hour), []string{"foo"})
+	require.NoError(t, err)
+
+	// load new delete requests for processing
+	require.NoError(t, purger.pullDeleteRequestsToPlanDeletes())
+
+	// there must be 2 pending delete requests, oldest being 3 days old
+	require.InDelta(t, float64(3*86400), testutil.ToFloat64(purger.metrics.oldestPendingDeleteRequestAgeSeconds), 1)
+	require.Equal(t, float64(2), testutil.ToFloat64(purger.metrics.pendingDeleteRequestsCount))
+
+	// wait until purger_delete_requests_processed_total starts to show up.
+	for {
+		count, err := testutil.GatherAndCount(registry, "cortex_purger_delete_requests_processed_total")
+		require.NoError(t, err)
+		if count != 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// wait until both the pending delete requests are processed.
+	for {
+		if testutil.ToFloat64(purger.metrics.deleteRequestsProcessedTotal) == 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// load new delete requests for processing which should update the metrics
+	require.NoError(t, purger.pullDeleteRequestsToPlanDeletes())
+
+	// there must be 0 pending delete requests so the age for oldest pending must be 0
+	require.InDelta(t, float64(0), testutil.ToFloat64(purger.metrics.oldestPendingDeleteRequestAgeSeconds), 1)
+	require.Equal(t, float64(0), testutil.ToFloat64(purger.metrics.pendingDeleteRequestsCount))
 }
 
 func getNonDeletedIntervals(originalInterval, deletedInterval model.Interval) []model.Interval {

--- a/pkg/chunk/purger/purger_test.go
+++ b/pkg/chunk/purger/purger_test.go
@@ -367,7 +367,7 @@ func TestDataPurger_Restarts(t *testing.T) {
 	for ctx.Err() == nil {
 		newPurger.inProcessRequestIDsMtx.RLock()
 
-		if len(newPurger.inProcessRequestIDs) == 0 {
+		if len(newPurger.inProcessRequests) == 0 {
 			newPurger.inProcessRequestIDsMtx.RUnlock()
 			break
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds the following 3 new metrics for monitoring the progress of the processing of delete request:
* `purger_load_pending_requests_attempts_total`: Number of attempts that were made to load pending requests with status.
* `purger_oldest_pending_delete_request_age_seconds`: Age of oldest pending delete request in seconds.
* `purger_pending_delete_requests_count`: Count of requests which are in process or are ready to be processed.

This PR also loads new delete requests for processing on startup instead of waiting for the first tick, which is an hour now.