### PR TITLE
Add memcached server address to Set() error

### DIFF
--- a/pkg/chunk/cache/memcached_client.go
+++ b/pkg/chunk/cache/memcached_client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/thanos-io/thanos/pkg/discovery/dns"
@@ -126,6 +127,22 @@ func NewMemcachedClient(cfg MemcachedClientConfig, name string, r prometheus.Reg
 func (c *memcachedClient) Stop() {
 	close(c.quit)
 	c.wait.Wait()
+}
+
+func (c *memcachedClient) Set(item *memcache.Item) error {
+	err := c.Client.Set(item)
+	if err == nil {
+		return nil
+	}
+
+	// Inject the server address in order to have more information about which memcached
+	// backend server failed. This is a best effort.
+	addr, addrErr := c.serverList.PickServer(item.Key)
+	if addrErr != nil {
+		return err
+	}
+
+	return errors.Wrapf(err, "server=%s", addr)
 }
 
 func (c *memcachedClient) updateLoop(updateInterval time.Duration) {


### PR DESCRIPTION
**What this PR does**:
Today we've experienced this error in prod:
` msg="failed to put to memcached" name=store.index-cache-read. err="memcache: unexpected response line from \"set\": \"SERVER_ERROR Out of memory during read\\r\\n\"`

And I've got an hard time figuring out which memcached server was returning the error. In this PR I propose to inject the server address to the `Set()` error.

Note: the same thing is difficult to do with the `GetMulti()` because we may potentially touch many (sometimes all) memcached server during a multi get request.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
