### PR TITLE
Clarified actual limits in the series limit error

### DIFF
--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	errMaxSeriesPerMetricLimitExceeded   = "per-metric series limit (local: %d global: %d actual local: %d) exceeded"
-	errMaxSeriesPerUserLimitExceeded     = "per-user series limit (local: %d global: %d actual local: %d) exceeded"
-	errMaxMetadataPerMetricLimitExceeded = "per-metric metadata limit (local: %d global: %d actual local: %d) exceeded"
-	errMaxMetadataPerUserLimitExceeded   = "per-user metric metadata limit (local: %d global %d actual local: %d) exceeded"
+	errMaxSeriesPerMetricLimitExceeded   = "per-metric series limit (local limit: %d global limit: %d actual local limit: %d) exceeded"
+	errMaxSeriesPerUserLimitExceeded     = "per-user series limit (local limit: %d global limit: %d actual local limit: %d) exceeded"
+	errMaxMetadataPerMetricLimitExceeded = "per-metric metadata limit (local limit: %d global limit: %d actual local limit: %d) exceeded"
+	errMaxMetadataPerUserLimitExceeded   = "per-user metric metadata limit (local limit: %d global limit: %d actual local limit: %d) exceeded"
 )
 
 // RingCount is the interface exposed by a ring implementation which allows


### PR DESCRIPTION
**What this PR does**:
Today an SRE in our company got confused by the series limit error and thought that "actual local" was the "actual number of series" and not the limit. Now, when the limit is reached they're the same thing but I'm proposing to clarify it anyway.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
