### PR TITLE
Give example of default label keys for HA pair

### DIFF
--- a/docs/production/ha-pair-handling.md
+++ b/docs/production/ha-pair-handling.md
@@ -21,18 +21,18 @@ Now we do the same leader election process T2.
 
 ### Client Side
 
-So for Cortex to achieve this, we need 2 identifiers for each process, one identifier for the cluster (T1 or T2, etc) and one identifier to identify the replica in the cluster (a or b). The easiest way to do with is by setting external labels, ideally `cluster` and `replica` (note the default is `__replica__`). For example:
+So for Cortex to achieve this, we need 2 identifiers for each process, one identifier for the cluster (T1 or T2, etc) and one identifier to identify the replica in the cluster (a or b). The easiest way to do with is by setting external labels, the default labels are `cluster` and `__replica__`. For example:
 
 ```
 cluster: prom-team1
-replica: replica1 (or pod-name)
+__replica__: replica1 (or pod-name)
 ```
 
 and
 
 ```
 cluster: prom-team1
-replica: replica2
+__replica__: replica2
 ```
 
 Note: These are external labels and have nothing to do with remote_write config.


### PR DESCRIPTION
**What this PR does**:

I found it confusing that the example doesn't use the default label names, and says the non-default (replica vs __replica__) is ideal. Made the documentation less confusing by giving example of the sensible default.

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
