### PR TITLE
Support querying multiple stores by Querier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@
   * `cortex_querier_blocks_consistency_checks_failed_total`
   * `cortex_querier_storegateway_refetches_per_query`
 * [ENHANCEMENT] Cortex is now built with Go 1.14. #2480 #2753
+* [ENHANCEMENT] Querier can now optionally query secondary store. This is specified by using `-querier.second-store-engine` option, with values `chunks` or `tsdb`. Standard configuration options for this store are used. Additionally, this querying can be configured to happen only for queries that need data older than `-querier.use-second-store-before-time`. #2747
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@
   * `cortex_querier_blocks_consistency_checks_failed_total`
   * `cortex_querier_storegateway_refetches_per_query`
 * [ENHANCEMENT] Cortex is now built with Go 1.14. #2480 #2753
-* [ENHANCEMENT] Querier can now optionally query secondary store. This is specified by using `-querier.second-store-engine` option, with values `chunks` or `tsdb`. Standard configuration options for this store are used. Additionally, this querying can be configured to happen only for queries that need data older than `-querier.use-second-store-before-time`. #2747
+* [ENHANCEMENT] Experimental: Querier can now optionally query secondary store. This is specified by using `-querier.second-store-engine` option, with values `chunks` or `tsdb`. Standard configuration options for this store are used. Additionally, this querying can be configured to happen only for queries that need data older than `-querier.use-second-store-before-time`. Default value of zero will always query secondary store. #2747
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -667,6 +667,17 @@ store_gateway_client:
   # TLS CA path for the client
   # CLI flag: -experimental.querier.store-gateway-client.tls-ca-path
   [tls_ca_path: <string> | default = ""]
+
+# Second store engine to use for querying. Empty = disabled.
+# CLI flag: -querier.second-store-engine
+[second_store_engine: <string> | default = ""]
+
+# If specified, second store is only used for queries before this timestamp. 0
+# to disable. Available formats: 2006-01-02 (midnight, local timezone),
+# 2006-01-02T15:04 (local timezone), 2006-01-02T15:04:05Z07:00 (UTC or specified
+# timezone)
+# CLI flag: -querier.use-second-store-before-time
+[use_second_store_before_time: <time> | default = 0]
 ```
 
 ### `query_frontend_config`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -22,7 +22,7 @@ To specify which configuration file to load, pass the `-config.file` flag at the
 * `<string>`: a regular string
 * `<url>`: an URL
 * `<prefix>`: a CLI flag prefix based on the context (look at the parent configuration block to see which CLI flags prefix should be used)
-* `<time>`: a timestamp, with available formats: `2006-01-20` (midnight, local timezone), `2006-01-20T15:04` (local timezone), `2006-01-20T15:04:05Z` (UTC) or `2006-01-20T15:04:05+07:00` (explicit timezone)
+* `<time>`: a timestamp, with available formats: `2006-01-20` (midnight, local timezone), `2006-01-20T15:04` (local timezone), and RFC 3339 formats: `2006-01-20T15:04:05Z` (UTC) or `2006-01-20T15:04:05+07:00` (explicit timezone)
 
 ### Use environment variables in the configuration
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -22,6 +22,7 @@ To specify which configuration file to load, pass the `-config.file` flag at the
 * `<string>`: a regular string
 * `<url>`: an URL
 * `<prefix>`: a CLI flag prefix based on the context (look at the parent configuration block to see which CLI flags prefix should be used)
+* `<time>`: a timestamp, with available formats: `2006-01-20` (midnight, local timezone), `2006-01-20T15:04` (local timezone), `2006-01-20T15:04:05Z` (UTC) or `2006-01-20T15:04:05+07:00` (explicit timezone)
 
 ### Use environment variables in the configuration
 
@@ -672,10 +673,8 @@ store_gateway_client:
 # CLI flag: -querier.second-store-engine
 [second_store_engine: <string> | default = ""]
 
-# If specified, second store is only used for queries before this timestamp. 0
-# to disable. Available formats: 2006-01-02 (midnight, local timezone),
-# 2006-01-02T15:04 (local timezone), 2006-01-02T15:04:05Z07:00 (UTC or specified
-# timezone)
+# If specified, second store is only used for queries before this timestamp.
+# Default value 0 means secondary store is always queried.
 # CLI flag: -querier.use-second-store-before-time
 [use_second_store_before_time: <time> | default = 0]
 ```

--- a/docs/configuration/config-file-reference.template
+++ b/docs/configuration/config-file-reference.template
@@ -22,6 +22,7 @@ To specify which configuration file to load, pass the `-config.file` flag at the
 * `<string>`: a regular string
 * `<url>`: an URL
 * `<prefix>`: a CLI flag prefix based on the context (look at the parent configuration block to see which CLI flags prefix should be used)
+* `<time>`: a timestamp, with available formats: `2006-01-20` (midnight, local timezone), `2006-01-20T15:04` (local timezone), `2006-01-20T15:04:05Z` (UTC) or `2006-01-20T15:04:05+07:00` (explicit timezone)
 
 ### Use environment variables in the configuration
 

--- a/docs/configuration/config-file-reference.template
+++ b/docs/configuration/config-file-reference.template
@@ -22,7 +22,7 @@ To specify which configuration file to load, pass the `-config.file` flag at the
 * `<string>`: a regular string
 * `<url>`: an URL
 * `<prefix>`: a CLI flag prefix based on the context (look at the parent configuration block to see which CLI flags prefix should be used)
-* `<time>`: a timestamp, with available formats: `2006-01-20` (midnight, local timezone), `2006-01-20T15:04` (local timezone), `2006-01-20T15:04:05Z` (UTC) or `2006-01-20T15:04:05+07:00` (explicit timezone)
+* `<time>`: a timestamp, with available formats: `2006-01-20` (midnight, local timezone), `2006-01-20T15:04` (local timezone), and RFC 3339 formats: `2006-01-20T15:04:05Z` (UTC) or `2006-01-20T15:04:05+07:00` (explicit timezone)
 
 ### Use environment variables in the configuration
 

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -45,3 +45,4 @@ Currently experimental features are:
 - In-memory (FIFO) and Redis cache.
 - Openstack Swift storage.
 - gRPC Store.
+- Querier support for querying chunks and blocks store at the same time.

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -500,6 +500,9 @@ func (c *baseStore) lookupIdsByMetricNameMatcher(ctx context.Context, from, thro
 	return ids, nil
 }
 
+// Using this function avoids logging of nil matcher, which works, but indirectly via panic and recover.
+// That confuses attached debugger, which wants to breakpoint on each panic.
+// Using simple check is also faster.
 func formatMatcher(matcher *labels.Matcher) string {
 	if matcher == nil {
 		return "nil"

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -446,7 +446,7 @@ func (c *store) lookupChunksByMetricName(ctx context.Context, userID string, fro
 }
 
 func (c *baseStore) lookupIdsByMetricNameMatcher(ctx context.Context, from, through model.Time, userID, metricName string, matcher *labels.Matcher, filter func([]IndexQuery) []IndexQuery) ([]string, error) {
-	log, ctx := spanlogger.New(ctx, "Store.lookupIdsByMetricNameMatcher", "metricName", metricName, "matcher", matcher)
+	log, ctx := spanlogger.New(ctx, "Store.lookupIdsByMetricNameMatcher", "metricName", metricName, "matcher", formatMatcher(matcher))
 	defer log.Span.Finish()
 
 	var err error
@@ -474,11 +474,11 @@ func (c *baseStore) lookupIdsByMetricNameMatcher(ctx context.Context, from, thro
 	if err != nil {
 		return nil, err
 	}
-	level.Debug(log).Log("matcher", matcher, "queries", len(queries))
+	level.Debug(log).Log("matcher", formatMatcher(matcher), "queries", len(queries))
 
 	if filter != nil {
 		queries = filter(queries)
-		level.Debug(log).Log("matcher", matcher, "filteredQueries", len(queries))
+		level.Debug(log).Log("matcher", formatMatcher(matcher), "filteredQueries", len(queries))
 	}
 
 	entries, err := c.lookupEntriesByQueries(ctx, queries)
@@ -489,15 +489,22 @@ func (c *baseStore) lookupIdsByMetricNameMatcher(ctx context.Context, from, thro
 	} else if err != nil {
 		return nil, err
 	}
-	level.Debug(log).Log("matcher", matcher, "entries", len(entries))
+	level.Debug(log).Log("matcher", formatMatcher(matcher), "entries", len(entries))
 
 	ids, err := c.parseIndexEntries(ctx, entries, matcher)
 	if err != nil {
 		return nil, err
 	}
-	level.Debug(log).Log("matcher", matcher, "ids", len(ids))
+	level.Debug(log).Log("matcher", formatMatcher(matcher), "ids", len(ids))
 
 	return ids, nil
+}
+
+func formatMatcher(matcher *labels.Matcher) string {
+	if matcher == nil {
+		return "nil"
+	}
+	return matcher.String()
 }
 
 func (c *baseStore) lookupEntriesByQueries(ctx context.Context, queries []IndexQuery) ([]IndexEntry, error) {

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/go-kit/kit/log/level"

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -2,7 +2,6 @@ package chunk
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/go-kit/kit/log/level"

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
-	prom_storage "github.com/prometheus/prometheus/storage"
 	"github.com/thanos-io/thanos/pkg/tracing"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
@@ -218,9 +217,9 @@ type Cortex struct {
 	StoreGateway *storegateway.StoreGateway
 	MemberlistKV *memberlist.KVInitService
 
-	// Queryable that the querier should use to query the long
+	// Queryables that the querier should use to query the long
 	// term storage. It depends on the storage engine used.
-	StoreQueryable prom_storage.Queryable
+	StoreQueryables []querier.QueryableWithFilter
 }
 
 // New makes a new Cortex.

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -210,6 +210,10 @@ func (t *Cortex) initStoreQueryable() (services.Service, error) {
 	}
 
 	if t.Cfg.Querier.SecondStoreEngine != "" {
+		if t.Cfg.Querier.SecondStoreEngine == t.Cfg.Storage.Engine {
+			return nil, fmt.Errorf("second store engine used by querier '%s' must be different than primary engine '%s'", t.Cfg.Querier.SecondStoreEngine, t.Cfg.Storage.Engine)
+		}
+
 		sq, err := initQueryableForEngine(t.Cfg.Querier.SecondStoreEngine, t.Cfg, t.Store, prometheus.DefaultRegisterer)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize querier for engine '%s': %v", t.Cfg.Querier.SecondStoreEngine, err)

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -199,6 +199,7 @@ func (t *Cortex) initQuerier() (serv services.Service, err error) {
 func (t *Cortex) initStoreQueryable() (services.Service, error) {
 	var servs []services.Service
 
+	//nolint:golint // I prefer this form over removing 'else', because it allows q to have smaller scope.
 	if q, err := initQueryableForEngine(t.Cfg.Storage.Engine, t.Cfg, t.Store, prometheus.DefaultRegisterer); err != nil {
 		return nil, fmt.Errorf("failed to initialize querier for engine '%s': %v", t.Cfg.Storage.Engine, err)
 	} else {

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -38,7 +38,7 @@ func TestDistributorQuerier(t *testing.T) {
 			},
 		},
 	}
-	queryable := newDistributorQueryable(d, false, nil)
+	queryable := newDistributorQueryable(d, false, nil, 0)
 	querier, err := queryable.Querier(context.Background(), mint, maxt)
 	require.NoError(t, err)
 
@@ -87,7 +87,7 @@ func TestIngesterStreaming(t *testing.T) {
 		},
 	}
 	ctx := user.InjectOrgID(context.Background(), "0")
-	queryable := newDistributorQueryable(d, true, mergeChunks)
+	queryable := newDistributorQueryable(d, true, mergeChunks, 0)
 	querier, err := queryable.Querier(ctx, mint, maxt)
 	require.NoError(t, err)
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -93,7 +93,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	// TODO: Remove this flag in v1.4.0.
 	f.DurationVar(&cfg.legacyLookbackDelta, "promql.lookback-delta", defaultLookbackDelta, "[DEPRECATED] Time since the last sample after which a time series is considered stale and ignored by expression evaluations. Please use -querier.lookback-delta instead.")
 	f.StringVar(&cfg.SecondStoreEngine, "querier.second-store-engine", "", "Second store engine to use for querying. Empty = disabled.")
-	f.Var(&cfg.UseSecondStoreBeforeTime, "querier.use-second-store-before-time", "If specified, second store is only used for queries before this timestamp. 0 to disable. Available formats: 2006-01-02 (midnight, local timezone), 2006-01-02T15:04 (local timezone), 2006-01-02T15:04:05Z07:00 (UTC or specified timezone)")
+	f.Var(&cfg.UseSecondStoreBeforeTime, "querier.use-second-store-before-time", "If specified, second store is only used for queries before this timestamp. Default value 0 means secondary store is always queried.")
 }
 
 // Validate the config

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -93,7 +93,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	// TODO: Remove this flag in v1.4.0.
 	f.DurationVar(&cfg.legacyLookbackDelta, "promql.lookback-delta", defaultLookbackDelta, "[DEPRECATED] Time since the last sample after which a time series is considered stale and ignored by expression evaluations. Please use -querier.lookback-delta instead.")
 	f.StringVar(&cfg.SecondStoreEngine, "querier.second-store-engine", "", "Second store engine to use for querying. Empty = disabled.")
-	f.Var(&cfg.UseSecondStoreBeforeTime, "querier.use-second-store-before-time", "If specified, second store is only used for queries before this timestamp.")
+	f.Var(&cfg.UseSecondStoreBeforeTime, "querier.use-second-store-before-time", "If specified, second store is only used for queries before this timestamp. 0 to disable. Available formats: 2006-01-02, 2006-01-02T15:04, 2006-01-02T15:04:05Z07:00")
 }
 
 // Validate the config

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -93,7 +93,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	// TODO: Remove this flag in v1.4.0.
 	f.DurationVar(&cfg.legacyLookbackDelta, "promql.lookback-delta", defaultLookbackDelta, "[DEPRECATED] Time since the last sample after which a time series is considered stale and ignored by expression evaluations. Please use -querier.lookback-delta instead.")
 	f.StringVar(&cfg.SecondStoreEngine, "querier.second-store-engine", "", "Second store engine to use for querying. Empty = disabled.")
-	f.Var(&cfg.UseSecondStoreBeforeTime, "querier.use-second-store-before-time", "If specified, second store is only used for queries before this timestamp. 0 to disable. Available formats: 2006-01-02, 2006-01-02T15:04, 2006-01-02T15:04:05Z07:00")
+	f.Var(&cfg.UseSecondStoreBeforeTime, "querier.use-second-store-before-time", "If specified, second store is only used for queries before this timestamp. 0 to disable. Available formats: 2006-01-02 (midnight, local timezone), 2006-01-02T15:04 (local timezone), 2006-01-02T15:04:05Z07:00 (UTC or specified timezone)")
 }
 
 // Validate the config

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -146,7 +146,7 @@ func TestQuerier(t *testing.T) {
 						chunkStore, through := makeMockChunkStore(t, 24, encoding.e)
 						distributor := mockDistibutorFor(t, chunkStore, through)
 
-						queryable, _ := New(cfg, distributor, []QueryableWithFilter{alwaysTrueFilterQueryable{NewChunkStoreQueryable(cfg, chunkStore)}}, purger.NewTombstonesLoader(nil, nil), nil)
+						queryable, _ := New(cfg, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}, purger.NewTombstonesLoader(nil, nil), nil)
 						testQuery(t, queryable, through, query)
 					})
 				}
@@ -219,7 +219,7 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 				chunkStore, _ := makeMockChunkStore(t, 24, encodings[0].e)
 				distributor := &errDistributor{}
 
-				queryable, _ := New(cfg, distributor, []QueryableWithFilter{alwaysTrueFilterQueryable{NewChunkStoreQueryable(cfg, chunkStore)}}, purger.NewTombstonesLoader(nil, nil), nil)
+				queryable, _ := New(cfg, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}, purger.NewTombstonesLoader(nil, nil), nil)
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 
@@ -310,7 +310,7 @@ func TestNoFutureQueries(t *testing.T) {
 				chunkStore := &errChunkStore{}
 				distributor := &errDistributor{}
 
-				queryable, _ := New(cfg, distributor, []QueryableWithFilter{alwaysTrueFilterQueryable{chunkStore}}, purger.NewTombstonesLoader(nil, nil), nil)
+				queryable, _ := New(cfg, distributor, []QueryableWithFilter{UseAlwaysQueryable(chunkStore)}, purger.NewTombstonesLoader(nil, nil), nil)
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 
@@ -501,7 +501,7 @@ func TestShortTermQueryToLTS(t *testing.T) {
 				chunkStore := &emptyChunkStore{}
 				distributor := &errDistributor{}
 
-				queryable, _ := New(cfg, distributor, []QueryableWithFilter{alwaysTrueFilterQueryable{NewChunkStoreQueryable(cfg, chunkStore)}}, purger.NewTombstonesLoader(nil, nil), nil)
+				queryable, _ := New(cfg, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}, purger.NewTombstonesLoader(nil, nil), nil)
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 
@@ -526,12 +526,4 @@ func TestShortTermQueryToLTS(t *testing.T) {
 		}
 	}
 
-}
-
-type alwaysTrueFilterQueryable struct {
-	storage.Queryable
-}
-
-func (alwaysTrueFilterQueryable) UseQueryable(_ time.Time, _, _ int64) bool {
-	return true
 }

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -146,7 +146,7 @@ func TestQuerier(t *testing.T) {
 						chunkStore, through := makeMockChunkStore(t, 24, encoding.e)
 						distributor := mockDistibutorFor(t, chunkStore, through)
 
-						queryable, _ := New(cfg, distributor, NewChunkStoreQueryable(cfg, chunkStore), purger.NewTombstonesLoader(nil, nil), nil)
+						queryable, _ := New(cfg, distributor, []QueryableWithFilter{alwaysTrueFilterQueryable{NewChunkStoreQueryable(cfg, chunkStore)}}, purger.NewTombstonesLoader(nil, nil), nil)
 						testQuery(t, queryable, through, query)
 					})
 				}
@@ -219,7 +219,7 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 				chunkStore, _ := makeMockChunkStore(t, 24, encodings[0].e)
 				distributor := &errDistributor{}
 
-				queryable, _ := New(cfg, distributor, NewChunkStoreQueryable(cfg, chunkStore), purger.NewTombstonesLoader(nil, nil), nil)
+				queryable, _ := New(cfg, distributor, []QueryableWithFilter{alwaysTrueFilterQueryable{NewChunkStoreQueryable(cfg, chunkStore)}}, purger.NewTombstonesLoader(nil, nil), nil)
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 
@@ -310,7 +310,7 @@ func TestNoFutureQueries(t *testing.T) {
 				chunkStore := &errChunkStore{}
 				distributor := &errDistributor{}
 
-				queryable, _ := New(cfg, distributor, chunkStore, purger.NewTombstonesLoader(nil, nil), nil)
+				queryable, _ := New(cfg, distributor, []QueryableWithFilter{alwaysTrueFilterQueryable{chunkStore}}, purger.NewTombstonesLoader(nil, nil), nil)
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 
@@ -501,7 +501,7 @@ func TestShortTermQueryToLTS(t *testing.T) {
 				chunkStore := &emptyChunkStore{}
 				distributor := &errDistributor{}
 
-				queryable, _ := New(cfg, distributor, NewChunkStoreQueryable(cfg, chunkStore), purger.NewTombstonesLoader(nil, nil), nil)
+				queryable, _ := New(cfg, distributor, []QueryableWithFilter{alwaysTrueFilterQueryable{NewChunkStoreQueryable(cfg, chunkStore)}}, purger.NewTombstonesLoader(nil, nil), nil)
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 
@@ -526,4 +526,12 @@ func TestShortTermQueryToLTS(t *testing.T) {
 		}
 	}
 
+}
+
+type alwaysTrueFilterQueryable struct {
+	storage.Queryable
+}
+
+func (alwaysTrueFilterQueryable) UseQueryable(_ time.Time, _, _ int64) bool {
+	return true
 }

--- a/pkg/util/flagext/time.go
+++ b/pkg/util/flagext/time.go
@@ -1,0 +1,51 @@
+package flagext
+
+import (
+	"fmt"
+	"time"
+)
+
+// Time usable as flag or in YAML config.
+type Time time.Time
+
+// String implements flag.Value
+func (t Time) String() string {
+	return time.Time(t).Format(time.RFC3339)
+}
+
+// Set implements flag.Value
+func (t *Time) Set(s string) error {
+	p, err := time.Parse("2006-01-02", s)
+	if err == nil {
+		*t = Time(p)
+		return nil
+	}
+
+	p, err = time.Parse("2006-01-02T15:04", s)
+	if err == nil {
+		*t = Time(p)
+		return nil
+	}
+
+	p, err = time.Parse("2006-01-02T15:04:05Z07:00", s)
+	if err == nil {
+		*t = Time(p)
+		return nil
+	}
+
+	return fmt.Errorf("failed to parse time: %q", s)
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (t *Time) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	return t.Set(s)
+}
+
+// MarshalYAML implements yaml.Marshaler.
+func (t Time) MarshalYAML() (interface{}, error) {
+	return t.String(), nil
+}

--- a/pkg/util/flagext/time.go
+++ b/pkg/util/flagext/time.go
@@ -10,11 +10,20 @@ type Time time.Time
 
 // String implements flag.Value
 func (t Time) String() string {
+	if time.Time(t).IsZero() {
+		return "0"
+	}
+
 	return time.Time(t).Format(time.RFC3339)
 }
 
 // Set implements flag.Value
 func (t *Time) Set(s string) error {
+	if s == "0" {
+		*t = Time(time.Time{})
+		return nil
+	}
+
 	p, err := time.Parse("2006-01-02", s)
 	if err == nil {
 		*t = Time(p)

--- a/pkg/util/flagext/time_test.go
+++ b/pkg/util/flagext/time_test.go
@@ -1,0 +1,76 @@
+package flagext
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestTimeYAML(t *testing.T) {
+	{
+		type TestStruct struct {
+			T Time `yaml:"time"`
+		}
+
+		var testStruct TestStruct
+		require.NoError(t, testStruct.T.Set("2020-10-20"))
+
+		marshaled, err := yaml.Marshal(testStruct)
+		require.NoError(t, err)
+
+		expected := `time: "2020-10-20T00:00:00Z"` + "\n"
+		assert.Equal(t, expected, string(marshaled))
+
+		var actualStruct TestStruct
+		err = yaml.Unmarshal([]byte(expected), &actualStruct)
+		require.NoError(t, err)
+		assert.Equal(t, testStruct, actualStruct)
+	}
+
+	{
+		type TestStruct struct {
+			T *Time `yaml:"time"`
+		}
+
+		var testStruct TestStruct
+		testStruct.T = &Time{}
+		require.NoError(t, testStruct.T.Set("2020-10-20"))
+
+		marshaled, err := yaml.Marshal(testStruct)
+		require.NoError(t, err)
+
+		expected := `time: "2020-10-20T00:00:00Z"` + "\n"
+		assert.Equal(t, expected, string(marshaled))
+
+		var actualStruct TestStruct
+		err = yaml.Unmarshal([]byte(expected), &actualStruct)
+		require.NoError(t, err)
+		assert.Equal(t, testStruct, actualStruct)
+	}
+}
+
+func TestTimeFormats(t *testing.T) {
+	ts := &Time{}
+	require.NoError(t, ts.Set("2020-10-05"))
+	require.Equal(t, mustParseTime(t, "2006-01-02", "2020-10-05").Format(time.RFC3339), ts.String())
+
+	require.NoError(t, ts.Set("2020-10-05T13:27"))
+	require.Equal(t, mustParseTime(t, "2006-01-02T15:04", "2020-10-05T13:27").Format(time.RFC3339), ts.String())
+
+	require.NoError(t, ts.Set("2020-10-05T13:27:00Z"))
+	require.Equal(t, mustParseTime(t, "2006-01-02T15:04:05Z", "2020-10-05T13:27:00Z").Format(time.RFC3339), ts.String())
+
+	require.NoError(t, ts.Set("2020-10-05T13:27:00+02:00"))
+	require.Equal(t, mustParseTime(t, "2006-01-02T15:04:05Z07:00", "2020-10-05T13:27:00+02:00").Format(time.RFC3339), ts.String())
+}
+
+func mustParseTime(t *testing.T, f, s string) time.Time {
+	ts, err := time.Parse(f, s)
+	if err != nil {
+		t.Fatalf("failed to parse %q: %v", s, err)
+	}
+	return ts
+}

--- a/pkg/util/flagext/time_test.go
+++ b/pkg/util/flagext/time_test.go
@@ -54,6 +54,10 @@ func TestTimeYAML(t *testing.T) {
 
 func TestTimeFormats(t *testing.T) {
 	ts := &Time{}
+	require.NoError(t, ts.Set("0"))
+	require.True(t, time.Time(*ts).IsZero())
+	require.Equal(t, "0", ts.String())
+
 	require.NoError(t, ts.Set("2020-10-05"))
 	require.Equal(t, mustParseTime(t, "2006-01-02", "2020-10-05").Format(time.RFC3339), ts.String())
 

--- a/tools/doc-generator/parser.go
+++ b/tools/doc-generator/parser.go
@@ -369,6 +369,22 @@ func getCustomFieldEntry(field reflect.StructField, fieldValue reflect.Value, fl
 			fieldDefault: fieldFlag.DefValue,
 		}, nil
 	}
+	if field.Type == reflect.TypeOf(flagext.Time{}) {
+		fieldFlag, err := getFieldFlag(field, fieldValue, flags)
+		if err != nil {
+			return nil, err
+		}
+
+		return &configEntry{
+			kind:         "field",
+			name:         getFieldName(field),
+			required:     isFieldRequired(field),
+			fieldFlag:    fieldFlag.Name,
+			fieldDesc:    fieldFlag.Usage,
+			fieldType:    "time",
+			fieldDefault: fieldFlag.DefValue,
+		}, nil
+	}
 
 	return nil, nil
 }


### PR DESCRIPTION
**What this PR does**: This PR adds support to Querier component to query multiple stores. This implements idea from #2717  proposal, and allows querying both blocks and chunk store at the same time. Secondary store can be further queried only for queries older than some timestamp.

Querier-specific configuration for second store engine consists of only backend type (chunks/tsdb) and that timestamp. The rest of the configuration is reused from standard chunks-store/tsdb-engine flags.

~Draft for now, documentation and changelog entry is missing.~ Also not sure if we want to merge #2717  first or not.

I think we should mark this experimental until we test it in production. (Although I've tested it and it worked nicely)

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
