### PR TITLE
Cleanup partial blocks with deletion mark expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
   - `cortex_purger_load_pending_requests_attempts_total`: Number of attempts that were made to load pending requests with status.
   - `cortex_purger_oldest_pending_delete_request_age_seconds`: Age of oldest pending delete request in seconds.
   - `cortex_purger_pending_delete_requests_count`: Count of requests which are in process or are ready to be processed.
+* [ENHANCEMENT] Experimental TSDB: Improved compactor to hard-delete also partial blocks with an deletion mark (even if the deletion mark threshold has not been reached). #2751
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400

--- a/development/tsdb-blocks-storage-s3-single-binary/config/grafana-agent.yaml
+++ b/development/tsdb-blocks-storage-s3-single-binary/config/grafana-agent.yaml
@@ -6,7 +6,7 @@ prometheus:
   global:
     scrape_interval: 5s
     external_labels:
-      origin: grafana-agent
+      scraped_by: grafana-agent
   configs:
     - name: local
       host_filter: false

--- a/development/tsdb-blocks-storage-s3-single-binary/config/prometheus.yaml
+++ b/development/tsdb-blocks-storage-s3-single-binary/config/prometheus.yaml
@@ -1,7 +1,7 @@
 global:
   scrape_interval: 5s
   external_labels:
-    origin: prometheus
+    scraped_by: prometheus
 
 scrape_configs:
   - job_name: cortex-1

--- a/development/tsdb-blocks-storage-s3/config/grafana-agent.yaml
+++ b/development/tsdb-blocks-storage-s3/config/grafana-agent.yaml
@@ -6,7 +6,7 @@ prometheus:
   global:
     scrape_interval: 5s
     external_labels:
-      origin: grafana-agent
+      scraped_by: grafana-agent
   configs:
     - name: local
       host_filter: false

--- a/development/tsdb-blocks-storage-s3/config/prometheus.yaml
+++ b/development/tsdb-blocks-storage-s3/config/prometheus.yaml
@@ -1,7 +1,7 @@
 global:
   scrape_interval: 5s
   external_labels:
-    origin: prometheus
+    scraped_by: prometheus
 
 scrape_configs:
   - job_name: tsdb-blocks-storage-s3/distributor

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -180,7 +180,9 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string) error {
 	// Partial blocks with a deletion mark can be cleaned up. This is a best effort, so we don't return
 	// error if the cleanup of partial blocks fail.
 	if len(partials) > 0 {
+		level.Info(userLogger).Log("msg", "started cleaning of partial blocks marked for deletion")
 		c.cleanUserPartialBlocks(ctx, partials, userBucket, userLogger)
+		level.Info(userLogger).Log("msg", "cleaning of partial blocks marked for deletion done")
 	}
 
 	return nil
@@ -199,7 +201,7 @@ func (c *BlocksCleaner) cleanUserPartialBlocks(ctx context.Context, partials map
 			continue
 		}
 		if err != nil {
-			level.Warn(userLogger).Log("msg", "error reading partial block deletion mark", "err", err)
+			level.Warn(userLogger).Log("msg", "error reading partial block deletion mark", "block", blockID, "err", err)
 			continue
 		}
 

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -80,10 +80,10 @@ func TestBlocksCleaner(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, exists)
 
-	// Should not delete a partial block with deletion mark who hasn't reached the deletion threshold yet.
+	// Should delete a partial block with deletion mark who hasn't reached the deletion threshold yet.
 	exists, err = bucketClient.Exists(ctx, path.Join("user-1", block4.String(), metadata.DeletionMarkFilename))
 	require.NoError(t, err)
-	assert.True(t, exists)
+	assert.False(t, exists)
 
 	// Should delete a partial block with deletion mark who has reached the deletion threshold.
 	exists, err = bucketClient.Exists(ctx, path.Join("user-1", block5.String(), metadata.DeletionMarkFilename))
@@ -98,6 +98,6 @@ func TestBlocksCleaner(t *testing.T) {
 	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsStarted))
 	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsCompleted))
 	assert.Equal(t, float64(0), testutil.ToFloat64(cleaner.runsFailed))
-	assert.Equal(t, float64(2), testutil.ToFloat64(cleaner.blocksCleanedTotal))
+	assert.Equal(t, float64(3), testutil.ToFloat64(cleaner.blocksCleanedTotal))
 	assert.Equal(t, float64(0), testutil.ToFloat64(cleaner.blocksFailedTotal))
 }

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -2,6 +2,7 @@ package compactor
 
 import (
 	"context"
+	"crypto/rand"
 	"io/ioutil"
 	"os"
 	"path"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,18 +32,25 @@ func TestBlocksCleaner(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dataDir) //nolint:errcheck
 
+	// Create a bucket client on the local storage.
+	bucketClient, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
+	require.NoError(t, err)
+
 	// Create blocks.
+	ctx := context.Background()
 	now := time.Now()
 	deletionDelay := 12 * time.Hour
 	block1 := createTSDBBlock(t, filepath.Join(storageDir, "user-1"), 10, 20, nil)
 	block2 := createTSDBBlock(t, filepath.Join(storageDir, "user-1"), 20, 30, nil)
 	block3 := createTSDBBlock(t, filepath.Join(storageDir, "user-1"), 30, 40, nil)
-	createDeletionMark(t, filepath.Join(storageDir, "user-1"), block2, now.Add(-deletionDelay).Add(time.Hour))  // Hasn't reached the deletion threshold yet.
-	createDeletionMark(t, filepath.Join(storageDir, "user-1"), block3, now.Add(-deletionDelay).Add(-time.Hour)) // Reached the deletion threshold.
-
-	// Create a bucket client on the local storage.
-	bucketClient, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
-	require.NoError(t, err)
+	block4 := ulid.MustNew(4, rand.Reader)
+	block5 := ulid.MustNew(5, rand.Reader)
+	block6 := createTSDBBlock(t, filepath.Join(storageDir, "user-1"), 40, 50, nil)
+	createDeletionMark(t, filepath.Join(storageDir, "user-1"), block2, now.Add(-deletionDelay).Add(time.Hour))  // Block hasn't reached the deletion threshold yet.
+	createDeletionMark(t, filepath.Join(storageDir, "user-1"), block3, now.Add(-deletionDelay).Add(-time.Hour)) // Block reached the deletion threshold.
+	createDeletionMark(t, filepath.Join(storageDir, "user-1"), block4, now.Add(-deletionDelay).Add(time.Hour))  // Partial block hasn't reached the deletion threshold yet.
+	createDeletionMark(t, filepath.Join(storageDir, "user-1"), block5, now.Add(-deletionDelay).Add(-time.Hour)) // Partial block reached the deletion threshold.
+	require.NoError(t, bucketClient.Delete(ctx, path.Join("user-1", block6.String(), metadata.MetaFilename)))   // Partial block without deletion mark.
 
 	cfg := BlocksCleanerConfig{
 		DataDir:             dataDir,
@@ -50,7 +59,6 @@ func TestBlocksCleaner(t *testing.T) {
 		CleanupInterval:     time.Minute,
 	}
 
-	ctx := context.Background()
 	logger := log.NewNopLogger()
 	scanner := NewUsersScanner(bucketClient, func(_ string) (bool, error) { return true, nil }, logger)
 
@@ -72,9 +80,24 @@ func TestBlocksCleaner(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, exists)
 
+	// Should not delete a partial block with deletion mark who hasn't reached the deletion threshold yet.
+	exists, err = bucketClient.Exists(ctx, path.Join("user-1", block4.String(), metadata.DeletionMarkFilename))
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// Should delete a partial block with deletion mark who has reached the deletion threshold.
+	exists, err = bucketClient.Exists(ctx, path.Join("user-1", block5.String(), metadata.DeletionMarkFilename))
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// Should not delete a partial block without deletion mark.
+	exists, err = bucketClient.Exists(ctx, path.Join("user-1", block6.String(), "index"))
+	require.NoError(t, err)
+	assert.True(t, exists)
+
 	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsStarted))
 	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsCompleted))
 	assert.Equal(t, float64(0), testutil.ToFloat64(cleaner.runsFailed))
-	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.blocksCleanedTotal))
+	assert.Equal(t, float64(2), testutil.ToFloat64(cleaner.blocksCleanedTotal))
 	assert.Equal(t, float64(0), testutil.ToFloat64(cleaner.blocksFailedTotal))
 }

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -239,7 +239,7 @@ func (c *Compactor) starting(ctx context.Context) error {
 		DataDir:             c.compactorCfg.DataDir,
 		MetaSyncConcurrency: c.compactorCfg.MetaSyncConcurrency,
 		DeletionDelay:       c.compactorCfg.DeletionDelay,
-		CleanupInterval:     c.compactorCfg.CompactionInterval,
+		CleanupInterval:     util.DurationWithJitter(c.compactorCfg.CompactionInterval, 0.05),
 	}, c.bucketClient, c.usersScanner, c.parentLogger, c.registerer)
 
 	// Ensure an initial cleanup occurred before starting the compactor.
@@ -265,7 +265,7 @@ func (c *Compactor) running(ctx context.Context) error {
 	// Run an initial compaction before starting the interval.
 	c.compactUsersWithRetries(ctx)
 
-	ticker := time.NewTicker(c.compactorCfg.CompactionInterval)
+	ticker := time.NewTicker(util.DurationWithJitter(c.compactorCfg.CompactionInterval, 0.05))
 	defer ticker.Stop()
 
 	for {

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -799,9 +799,13 @@ func createTSDBBlock(t *testing.T, dir string, minT, maxT int64, externalLabels 
 
 func createDeletionMark(t *testing.T, dir string, blockID ulid.ULID, deletionTime time.Time) {
 	content := mockDeletionMarkJSON(blockID.String(), deletionTime)
-	path := filepath.Join(dir, blockID.String(), metadata.DeletionMarkFilename)
+	blockPath := filepath.Join(dir, blockID.String())
+	markPath := filepath.Join(blockPath, metadata.DeletionMarkFilename)
 
-	require.NoError(t, ioutil.WriteFile(path, []byte(content), os.ModePerm))
+	// Ensure the block directory exists.
+	os.MkdirAll(blockPath, os.ModePerm)
+
+	require.NoError(t, ioutil.WriteFile(markPath, []byte(content), os.ModePerm))
 }
 
 func findCompactorByUserID(compactors []*Compactor, logs []*bytes.Buffer, userID string) (*Compactor, *bytes.Buffer, error) {

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -803,7 +803,7 @@ func createDeletionMark(t *testing.T, dir string, blockID ulid.ULID, deletionTim
 	markPath := filepath.Join(blockPath, metadata.DeletionMarkFilename)
 
 	// Ensure the block directory exists.
-	os.MkdirAll(blockPath, os.ModePerm)
+	require.NoError(t, os.MkdirAll(blockPath, os.ModePerm))
 
 	require.NoError(t, ioutil.WriteFile(markPath, []byte(content), os.ModePerm))
 }


### PR DESCRIPTION
**What this PR does**:
I've investigated #2748 and fixing it may be non trivial without a coordination between compactor and blocks cleaner. Another option to fix it would be disabling the compactor garbage collection at all, but would require a discussion in Thanos first and deeply understand the impact of it.

Since Thanos and the Cortex blocks storage can deal with partial blocks (it's an expected state because a block is partial also each time it's upload is in progress from the ingester) I propose to keep it simple and just add a cleanup of partial blocks marked for deletion in the blocks cleaner.

**Which issue(s) this PR fixes**:
Fixes #2748

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
