### PR TITLE
Run integration tests with Go 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,8 @@ jobs:
         name: Upgrade golang
         command: |
           cd /tmp && \
-          wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && \
-          tar -zxvf go1.13.3.linux-amd64.tar.gz && \
+          wget https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz && \
+          tar -zxvf go1.14.4.linux-amd64.tar.gz && \
           sudo rm -fr /usr/local/go && \
           sudo mv /tmp/go /usr/local/go && \
           cd -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@
   * `cortex_querier_blocks_consistency_checks_total`
   * `cortex_querier_blocks_consistency_checks_failed_total`
   * `cortex_querier_storegateway_refetches_per_query`
+* [ENHANCEMENT] Cortex is now built with Go 1.14. #2480 #2753
 * [BUGFIX] Ruler: Ensure temporary rule files with special characters are properly mapped and cleaned up. #2506
 * [BUGFIX] Fixes #2411, Ensure requests are properly routed to the prometheus api embedded in the query if `-server.path-prefix` is set. #2372
 * [BUGFIX] Experimental TSDB: fixed chunk data corruption when querying back series using the experimental blocks storage. #2400


### PR DESCRIPTION
**What this PR does**:
This PR fixes the Go version used to run integration tests in CI.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
