### PR TITLE
Update k8s manifests to use minio s3 backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## master / unreleased
-
+* [BUGFIX] Minio dependency in k8s manifests now configured correctly.
 * [CHANGE] Metric `cortex_kv_request_duration_seconds` now includes `name` label to denote which client is being used as well as the `backend` label to denote the KV backend implementation in use. #2648
 * [CHANGE] Experimental Ruler: Rule groups persisted to object storage using the experimental API have an updated object key encoding to better handle special characters. Rule groups previously-stored using object storage must be renamed to the new format. #2646
 * [CHANGE] Query Frontend now uses Round Robin to choose a tenant queue to service next. #2553

--- a/k8s/ingester-dep.yaml
+++ b/k8s/ingester-dep.yaml
@@ -43,7 +43,8 @@ spec:
         - -target=ingester
         - -ingester.join-after=30s
         - -consul.hostname=consul.default.svc.cluster.local:8500
-        - -s3.url=s3://abc:123@s3.default.svc.cluster.local:4569
+        - -s3.url=s3://abc:12345678@s3.default.svc.cluster.local:9000/cortex
+        - -s3.force-path-style=true
         - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
         - -schema-config-file=/etc/cortex/schema.yaml
         - -store.chunks-cache.memcached.hostname=memcached.default.svc.cluster.local

--- a/k8s/querier-dep.yaml
+++ b/k8s/querier-dep.yaml
@@ -21,7 +21,8 @@ spec:
         - -target=querier
         - -server.http-listen-port=80
         - -consul.hostname=consul.default.svc.cluster.local:8500
-        - -s3.url=s3://abc:123@s3.default.svc.cluster.local:4569
+        - -s3.url=s3://abc:12345678@s3.default.svc.cluster.local:9000/cortex
+        - -s3.force-path-style=true
         - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
         - -schema-config-file=/etc/cortex/schema.yaml
         - -querier.frontend-address=query-frontend.default.svc.cluster.local:9095

--- a/k8s/ruler-dep.yaml
+++ b/k8s/ruler-dep.yaml
@@ -24,7 +24,8 @@ spec:
         - -ruler.configs.url=http://configs.default.svc.cluster.local:80
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/api/prom/alertmanager/
         - -consul.hostname=consul.default.svc.cluster.local:8500
-        - -s3.url=s3://abc:123@default.svc.cluster.local:4569/s3
+        - -s3.url=s3://abc:12345678@s3.default.svc.cluster.local:9000/cortex
+        - -s3.force-path-style=true
         - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
         - -schema-config-file=/etc/cortex/schema.yaml
         - -store.chunks-cache.memcached.hostname=memcached.default.svc.cluster.local

--- a/k8s/s3-bucket-config.yaml
+++ b/k8s/s3-bucket-config.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: s3-bucket-config
+data:
+  initialize: |
+    #!/bin/sh
+    set -e ; # Have script exit in the event of a failed command.
+
+    MC="/usr/bin/mc"
+
+    # connectToMinio
+    # Use a check-sleep-check loop to wait for Minio service to be available
+    connectToMinio() {
+      SCHEME=$1
+      ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+      set -e ; # fail if we can't read the keys.
+      ACCESS="abc" ;
+      SECRET="12345678" ;
+      set +e ; # The connections to minio are allowed to fail.
+      echo "Connecting to Minio server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+      MC_COMMAND="${MC} config host add myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+      $MC_COMMAND ;
+      STATUS=$? ;
+      until [ $STATUS = 0 ]
+      do
+        ATTEMPTS=`expr $ATTEMPTS + 1` ;
+        echo \"Failed attempts: $ATTEMPTS\" ;
+        if [ $ATTEMPTS -gt $LIMIT ]; then
+          exit 1 ;
+        fi ;
+        sleep 2 ; # 1 second intervals between attempts
+        $MC_COMMAND ;
+        STATUS=$? ;
+      done ;
+      set -e ; # reset `e` as active
+      return 0
+    }
+
+    # checkBucketExists ($bucket)
+    # Check if the bucket exists, by using the exit code of `mc ls`
+    checkBucketExists() {
+      BUCKET=$1
+      CMD=$(${MC} ls myminio/$BUCKET > /dev/null 2>&1)
+      return $?
+    }
+
+    # createBucket ($bucket, $policy, $purge)
+    # Ensure bucket exists, purging if asked to
+    createBucket() {
+      BUCKET=$1
+      POLICY=$2
+      PURGE=$3
+
+      # Purge the bucket, if set & exists
+      # Since PURGE is user input, check explicitly for `true`
+      if [ $PURGE = true ]; then
+        if checkBucketExists $BUCKET ; then
+          echo "Purging bucket '$BUCKET'."
+          set +e ; # don't exit if this fails
+          ${MC} rm -r --force myminio/$BUCKET
+          set -e ; # reset `e` as active
+        else
+          echo "Bucket '$BUCKET' does not exist, skipping purge."
+        fi
+      fi
+
+      # Create the bucket if it does not exist
+      if ! checkBucketExists $BUCKET ; then
+        echo "Creating bucket '$BUCKET'"
+        ${MC} mb myminio/$BUCKET
+      else
+        echo "Bucket '$BUCKET' already exists."
+      fi
+
+      # At this point, the bucket should exist, skip checking for existence
+      # Set policy on the bucket
+      echo "Setting policy of bucket '$BUCKET' to '$POLICY'."
+      ${MC} policy set $POLICY myminio/$BUCKET
+    }
+
+    # Try connecting to Minio instance
+    connectToMinio "http"
+
+    # Create the bucket
+    createBucket "cortex" "public" "false"

--- a/k8s/s3-create-bucket-job.yaml
+++ b/k8s/s3-create-bucket-job.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: s3-create-bucket-job
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+        - name: minio-configuration
+          projected:
+            sources:
+            - configMap:
+                name: s3-bucket-config
+      containers:
+      - name: minio-mc
+        image: minio/mc:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "/config/initialize"]
+        env:
+          - name: MINIO_ENDPOINT
+            value: s3.default.svc.cluster.local
+          - name: MINIO_PORT
+            value: "9000"
+        volumeMounts:
+          - name: minio-configuration
+            mountPath: /config

--- a/k8s/s3-dep.yaml
+++ b/k8s/s3-dep.yaml
@@ -25,10 +25,10 @@ spec:
         - name: MINIO_ACCESS_KEY
           value: "abc"
         - name: MINIO_SECRET_KEY
-          value: "123"
+          value: "12345678"
         imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 4569
+        - containerPort: 9000
         volumeMounts:
         - name: storage
           mountPath: "/storage"

--- a/k8s/s3-svc.yaml
+++ b/k8s/s3-svc.yaml
@@ -5,6 +5,6 @@ metadata:
   name: s3
 spec:
   ports:
-    - port: 4569
+    - port: 9000
   selector:
     name: s3


### PR DESCRIPTION
Signed-off-by: Austin McKinley <austin.mckinley@robinhood.com>

**What this PR does**:
Minio is not a drop-in replacement for whatever these manifests were using before for s3. Update all the k8s manifests to use minio, and configure minio correctly, including creating the necessary buckets.

**Which issue(s) this PR fixes**:
Fixes #2727 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
