### PR TITLE
fix race in processing of headers in sharded queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
 * [BUGFIX] Ingester: increment series per metric when recovering from WAL or transfer. #2674
 * [BUGFIX] Fixed `wrong number of arguments for 'mget' command` Redis error when a query has no chunks to lookup from storage. #2700
 * [BUGFIX] Ingester: Automatically remove old tmp checkpoints, fixing a potential disk space leak after an ingester crashes.
+* [BUGFIX] Fix race in processing of headers in sharded queries. #2762
 
 ## 1.1.0 / 2020-05-21
 

--- a/pkg/querier/queryrange/queryable.go
+++ b/pkg/querier/queryrange/queryable.go
@@ -95,8 +95,8 @@ func (q *ShardedQuerier) handleEmbeddedQuery(encoded string) storage.SeriesSet {
 				errCh <- err
 				return
 			}
-			samplesCh <- streams
 			q.setResponseHeaders(resp.(*PrometheusResponse).Headers)
+			samplesCh <- streams
 		}(query)
 	}
 

--- a/pkg/querier/queryrange/queryable.go
+++ b/pkg/querier/queryrange/queryable.go
@@ -30,8 +30,11 @@ func (q *ShardedQueryable) Querier(ctx context.Context, mint, maxt int64) (stora
 	return q.sharededQuerier, nil
 }
 
-func (q *ShardedQueryable) getResponseHeaders() map[string][]string {
-	return q.sharededQuerier.ResponseHeaders
+func (q *ShardedQueryable) getResponseHeaders() []*PrometheusResponseHeader {
+	q.sharededQuerier.ResponseHeadersMtx.Lock()
+	defer q.sharededQuerier.ResponseHeadersMtx.Unlock()
+
+	return headersMapToPrometheusResponseHeaders(q.sharededQuerier.ResponseHeaders)
 }
 
 // ShardedQuerier is a an implementor of the Querier interface.
@@ -140,4 +143,12 @@ func (q *ShardedQuerier) LabelNames() ([]string, storage.Warnings, error) {
 // Close releases the resources of the Querier.
 func (q *ShardedQuerier) Close() error {
 	return nil
+}
+
+func headersMapToPrometheusResponseHeaders(headersMap map[string][]string) (prs []*PrometheusResponseHeader) {
+	for h, v := range headersMap {
+		prs = append(prs, &PrometheusResponseHeader{Name: h, Values: v})
+	}
+
+	return
 }

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -236,7 +236,7 @@ func (qs *queryShard) Do(ctx context.Context, r Request) (Response, error) {
 			ResultType: string(res.Value.Type()),
 			Result:     extracted,
 		},
-		Headers: headersMapToPrometheusResponseHeaders(shardedQueryable.getResponseHeaders()),
+		Headers: shardedQueryable.getResponseHeaders(),
 	}, nil
 }
 
@@ -321,12 +321,4 @@ func partitionRequest(r Request, t time.Time) (before Request, after Request) {
 	}
 
 	return r.WithStartEnd(r.GetStart(), boundary), r.WithStartEnd(boundary, r.GetEnd())
-}
-
-func headersMapToPrometheusResponseHeaders(headersMap map[string][]string) (prs []*PrometheusResponseHeader) {
-	for h, v := range headersMap {
-		prs = append(prs, &PrometheusResponseHeader{Name: h, Values: v})
-	}
-
-	return
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
We saw query frontend panicking with `fatal error: concurrent map iteration and map write` [here](https://github.com/cortexproject/cortex/blob/a92b613bc6a3ad8ce1080ae96b403fb2eb955968/pkg/querier/queryrange/querysharding.go#L327). It is possibly due to a race with finishing all the querying and processing of headers while the response headers from sharded queries are still not merged [here](https://github.com/cortexproject/cortex/blob/master/pkg/querier/queryrange/queryable.go#L99)

This PR takes care of that issue. 

Fixes: #2763 