### PR TITLE
Experimental Alertmanager API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [ENHANCEMENT] Memberlist members can join cluster via SRV records. #2788
 * [ENHANCEMENT] Prometheus upgraded. #2798 #2849
   * Optimized labels regex matchers for patterns containing literals (eg. `foo.*`, `.*foo`, `.*foo.*`)
+* [ENHANCEMENT] Experimental Alertmanager: Alertmanager configuration persisted to object storage using an experimental API that accepts and returns YAML-based Alertmanager configuration. #XXXX
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,13 +37,9 @@
 * [ENHANCEMENT] Experimental TSDB: Added support to enforce max query time range length via `-store.max-query-length`. #2826
 * [ENHANCEMENT] Ingester: Added new metric `cortex_ingester_flush_series_in_progress` that reports number of ongoing flush-series operations. Useful when calling `/flush` handler: if `cortex_ingester_flush_queue_length + cortex_ingester_flush_series_in_progress` is 0, all flushes are finished. #2778
 * [ENHANCEMENT] Memberlist members can join cluster via SRV records. #2788
-<<<<<<< HEAD
 * [ENHANCEMENT] Prometheus upgraded. #2798 #2849
   * Optimized labels regex matchers for patterns containing literals (eg. `foo.*`, `.*foo`, `.*foo.*`)
-* [ENHANCEMENT] Experimental Alertmanager: Alertmanager configuration persisted to object storage using an experimental API that accepts and returns YAML-based Alertmanager configuration. #XXXX
-=======
 * [ENHANCEMENT] Experimental Alertmanager: Alertmanager configuration persisted to object storage using an experimental API that accepts and returns YAML-based Alertmanager configuration. #2768
->>>>>>> Update changelog with PR number
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,13 @@
 * [ENHANCEMENT] Experimental TSDB: Added support to enforce max query time range length via `-store.max-query-length`. #2826
 * [ENHANCEMENT] Ingester: Added new metric `cortex_ingester_flush_series_in_progress` that reports number of ongoing flush-series operations. Useful when calling `/flush` handler: if `cortex_ingester_flush_queue_length + cortex_ingester_flush_series_in_progress` is 0, all flushes are finished. #2778
 * [ENHANCEMENT] Memberlist members can join cluster via SRV records. #2788
+<<<<<<< HEAD
 * [ENHANCEMENT] Prometheus upgraded. #2798 #2849
   * Optimized labels regex matchers for patterns containing literals (eg. `foo.*`, `.*foo`, `.*foo.*`)
 * [ENHANCEMENT] Experimental Alertmanager: Alertmanager configuration persisted to object storage using an experimental API that accepts and returns YAML-based Alertmanager configuration. #XXXX
+=======
+* [ENHANCEMENT] Experimental Alertmanager: Alertmanager configuration persisted to object storage using an experimental API that accepts and returns YAML-based Alertmanager configuration. #2768
+>>>>>>> Update changelog with PR number
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762

--- a/development/tsdb-blocks-storage-s3/.data-minio/.gitignore
+++ b/development/tsdb-blocks-storage-s3/.data-minio/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+!cortex-tsdb
+!cortex-alertmanager

--- a/development/tsdb-blocks-storage-s3/.data-minio/.gitignore
+++ b/development/tsdb-blocks-storage-s3/.data-minio/.gitignore
@@ -1,3 +1,2 @@
 *
-!cortex-tsdb
 !.gitignore

--- a/development/tsdb-blocks-storage-s3/.data-minio/cortex-alertmanager/.gitignore
+++ b/development/tsdb-blocks-storage-s3/.data-minio/cortex-alertmanager/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -72,6 +72,15 @@ ruler:
     configdb:
       configs_api_url: http://configstore:80/
 
+alertmanager:
+  enable_api: true
+  storage:
+    type: s3
+    s3:
+      bucketnames: cortex-alertmanager
+      s3forcepathstyle: true
+      s3: http://cortex:supersecret@minio.:9000
+
 storage:
   engine: tsdb
 

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -240,3 +240,18 @@ services:
       - 18007:18007
     volumes:
       - ./config:/cortex/config
+
+  alertmanager:
+    build:
+      context:    .
+      dockerfile: dev.dockerfile
+    image: cortex
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18008 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=alertmanager -server.http-listen-port=8008 -server.grpc-listen-port=9008"]
+    depends_on:
+      - consul
+      - minio
+    ports:
+      - 8008:8008
+      - 18008:18008
+    volumes:
+      - ./config:/cortex/config

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -246,12 +246,12 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: cortex
-    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18008 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=alertmanager -server.http-listen-port=8008 -server.grpc-listen-port=9008"]
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18010 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=alertmanager -server.http-listen-port=8010 -server.grpc-listen-port=9010"]
     depends_on:
       - consul
       - minio
     ports:
-      - 8008:8008
-      - 18008:18008
+      - 8010:8010
+      - 18010:18010
     volumes:
       - ./config:/cortex/config

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -243,6 +243,57 @@ DELETE /api/v1/rules/{namespace}/{group_name}
 
 **Body**: None
 
+## Alertmanager
+
+### Experimental API
+
+Simiarly to the Cortex Ruler, the Cortex Alertmanager supports operations using a configured object storage client as a backend for the storage and management of user's Alertmanager configuration. These API endpoints are opt-in and must be enabled via the `experimental.alertmanger.enable-api` config flag.
+
+### Get Alertmanager configuration
+
+```
+GET /api/v1/alerts
+```
+
+##### Success Response
+
+**Code**: `200 OK`
+
+**Data**:
+```yaml
+TBD
+```
+
+### Set Alertmanager configuration
+
+```
+POST /api/v1/alerts
+```
+
+##### Success Response
+
+**Code**: `201 CREATED`
+
+**Data**:
+```yaml
+TBD
+```
+
+### Delete Alertmanager configuration
+
+```
+DELETE /api/v1/alerts
+```
+
+##### Success Response
+
+**Code**: `200 OK`
+
+**Data**:
+```yaml
+TBD
+```
+
 ## Configs API
 
 The configs service provides an API-driven multi-tenant approach to handling various configuration files for prometheus. The service hosts an API where users can read and write Prometheus rule files, Alertmanager configuration files, and Alertmanager templates to a database.

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -247,7 +247,7 @@ DELETE /api/v1/rules/{namespace}/{group_name}
 
 ### Experimental API
 
-Simiarly to the Cortex Ruler, the Cortex Alertmanager supports operations using a configured object storage client as a backend for the storage and management of user's Alertmanager configuration. These API endpoints are opt-in and must be enabled via the `experimental.alertmanger.enable-api` config flag.
+Similarly to the Cortex Ruler, the Cortex Alertmanager supports operations using a configured object storage client as a backend for the storage and management of user's Alertmanager configuration. These API endpoints are opt-in and must be enabled via the `experimental.alertmanger.enable-api` CLI flag.
 
 ### Get Alertmanager configuration
 
@@ -259,11 +259,6 @@ GET /api/v1/alerts
 
 **Code**: `200 OK`
 
-**Data**:
-```yaml
-TBD
-```
-
 ### Set Alertmanager configuration
 
 ```
@@ -274,11 +269,6 @@ POST /api/v1/alerts
 
 **Code**: `201 CREATED`
 
-**Data**:
-```yaml
-TBD
-```
-
 ### Delete Alertmanager configuration
 
 ```
@@ -288,11 +278,6 @@ DELETE /api/v1/alerts
 ##### Success Response
 
 **Code**: `200 OK`
-
-**Data**:
-```yaml
-TBD
-```
 
 ## Configs API
 

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -259,6 +259,8 @@ GET /api/v1/alerts
 
 **Code**: `200 OK`
 
+**Body**: None
+
 ### Set Alertmanager configuration
 
 ```
@@ -269,6 +271,16 @@ POST /api/v1/alerts
 
 **Code**: `201 CREATED`
 
+**Body**:
+
+```yaml
+template_files:
+  default_template: |
+    {{ define "__alertmanager" }}AlertManager{{ end }}
+    {{ define "__alertmanagerURL" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver | urlquery }}{{ end }}
+alertmanager_config: "global: \n  smtp_smarthost: 'localhost:25' \n  smtp_from: 'youraddress@example.org' \nroute: \n  receiver: example-email \nreceivers: \n  - name: example-email \n    email_configs: \n    - to: 'youraddress@example.org' \n"
+```
+
 ### Delete Alertmanager configuration
 
 ```
@@ -278,6 +290,9 @@ DELETE /api/v1/alerts
 ##### Success Response
 
 **Code**: `200 OK`
+
+**Body**: None
+
 
 ## Configs API
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1116,7 +1116,7 @@ The `alertmanager_config` configures the Cortex alertmanager.
 
 storage:
   # Type of backend to use to store alertmanager configs. Supported values are:
-  # "configdb", "local".
+  # "configdb", "gcs", "s3", "local".
   # CLI flag: -alertmanager.storage.type
   [type: <string> | default = "configdb"]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1129,6 +1129,40 @@ storage:
     # Path at which alertmanager configurations are stored.
     # CLI flag: -alertmanager.storage.local.path
     [path: <string> | default = ""]
+
+  gcs:
+    # Name of GCS bucket to put chunks in.
+    # CLI flag: -alertmanager.storage.gcs.bucketname
+    [bucket_name: <string> | default = ""]
+
+    # The size of the buffer that GCS client for each PUT request. 0 to disable
+    # buffering.
+    # CLI flag: -alertmanager.storage.gcs.chunk-buffer-size
+    [chunk_buffer_size: <int> | default = 0]
+
+    # The duration after which the requests to GCS should be timed out.
+    # CLI flag: -alertmanager.storage.gcs.request-timeout
+    [request_timeout: <duration> | default = 0s]
+
+  s3:
+    # S3 endpoint URL with escaped Key and Secret encoded. If only region is
+    # specified as a host, proper endpoint will be deduced. Use
+    # inmemory:///<bucket-name> to use a mock in-memory implementation.
+    # CLI flag: -alertmanager.storage.s3.url
+    [s3: <url> | default = ]
+
+    # Comma separated list of bucket names to evenly distribute chunks over.
+    # Overrides any buckets specified in s3.url flag
+    # CLI flag: -alertmanager.storage.s3.buckets
+    [bucketnames: <string> | default = ""]
+
+    # Set this to `true` to force the request to use path-style addressing.
+    # CLI flag: -alertmanager.storage.s3.force-path-style
+    [s3forcepathstyle: <boolean> | default = false]
+
+# Enable the experimental alertmanager config api.
+# CLI flag: -experimental.alertmanager.enable-api
+[enable_api: <boolean> | default = false]
 ```
 
 ### `table_manager_config`

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -40,6 +40,7 @@ Currently experimental features are:
 - Zone awareness based replication.
 - User subrings.
 - Ruler API (to PUT rules).
+- Alertmanager API
 - Memcached client DNS-based service discovery.
 - Delete series APIs.
 - In-memory (FIFO) and Redis cache.

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,7 @@ github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD
 github.com/armon/go-metrics v0.3.3 h1:a9F4rlj7EWWrbj7BYw8J8+x+ZZkJeqzNyRk8hdPF+ro=
 github.com/armon/go-metrics v0.3.3/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
@@ -285,6 +286,7 @@ github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elastic/go-sysinfo v1.0.1/go.mod h1:O/D5m1VpYLwGjCYzEt63g3Z1uO3jXfwyzzjiW90t8cY=
+github.com/elastic/go-sysinfo v1.1.1 h1:ZVlaLDyhVkDfjwPGU55CQRCRolNpc7P0BbyhhQZQmMI=
 github.com/elastic/go-sysinfo v1.1.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=

--- a/go.sum
+++ b/go.sum
@@ -144,7 +144,6 @@ github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD
 github.com/armon/go-metrics v0.3.3 h1:a9F4rlj7EWWrbj7BYw8J8+x+ZZkJeqzNyRk8hdPF+ro=
 github.com/armon/go-metrics v0.3.3/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
@@ -286,7 +285,6 @@ github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elastic/go-sysinfo v1.0.1/go.mod h1:O/D5m1VpYLwGjCYzEt63g3Z1uO3jXfwyzzjiW90t8cY=
-github.com/elastic/go-sysinfo v1.1.1 h1:ZVlaLDyhVkDfjwPGU55CQRCRolNpc7P0BbyhhQZQmMI=
 github.com/elastic/go-sysinfo v1.1.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
@@ -307,7 +305,6 @@ github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:bH6Xx7IW
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/fatih/structtag v1.1.0 h1:6j4mUV/ES2duvnAzKMFkN6/A5mCaNYPD3xfbAkLLOF8=
 github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
@@ -319,7 +316,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsouza/fake-gcs-server v1.7.0 h1:Un0BXUXrRWYSmYyC1Rqm2e2WJfTPyDy/HGMz31emTi8=
 github.com/fsouza/fake-gcs-server v1.7.0/go.mod h1:5XIRs4YvwNbNoz+1JF8j6KLAyDh7RHGAyAK3EP2EsNk=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -329,12 +325,10 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
-github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0 h1:dXFJfIHVvUcpSgDOV+Ne6t7jXri8Tfv2uOLHUZ2XNuo=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
-github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
@@ -345,7 +339,6 @@ github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpR
 github.com/go-openapi/analysis v0.17.2/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.19.2/go.mod h1:3P1osvZa9jKjb8ed2TPng3f0i/UY9snX6gxi44djMjk=
-github.com/go-openapi/analysis v0.19.4 h1:1TjOzrWkj+9BrjnM1yPAICbaoC0FyfD49oVkTBrSSa0=
 github.com/go-openapi/analysis v0.19.4/go.mod h1:3P1osvZa9jKjb8ed2TPng3f0i/UY9snX6gxi44djMjk=
 github.com/go-openapi/analysis v0.19.5/go.mod h1:hkEAkxagaIvIP7VTn8ygJNkd4kAYON2rCu0v0ObL0AU=
 github.com/go-openapi/analysis v0.19.10 h1:5BHISBAXOc/aJK25irLZnx2D3s6WyYaY9D4gmuz9fdE=
@@ -353,7 +346,6 @@ github.com/go-openapi/analysis v0.19.10/go.mod h1:qmhS3VNFxBlquFJ0RGoDtylO9y4pgT
 github.com/go-openapi/errors v0.17.0/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQHVjmcZxhka0=
 github.com/go-openapi/errors v0.17.2/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQHVjmcZxhka0=
 github.com/go-openapi/errors v0.18.0/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQHVjmcZxhka0=
-github.com/go-openapi/errors v0.19.2 h1:a2kIyV3w+OS3S97zxUndRVD46+FhGOUBDFY7nmu4CsY=
 github.com/go-openapi/errors v0.19.2/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=
 github.com/go-openapi/errors v0.19.3/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=
 github.com/go-openapi/errors v0.19.4 h1:fSGwO1tSYHFu70NKaWJt5Qh0qoBRtCm/mXS1yhf+0W0=
@@ -362,7 +354,6 @@ github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.17.2/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
-github.com/go-openapi/jsonpointer v0.19.2 h1:A9+F4Dc/MCNB5jibxf6rRvOvR/iFgQdyNx9eIhnGqq0=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -370,7 +361,6 @@ github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.17.2/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
-github.com/go-openapi/jsonreference v0.19.2 h1:o20suLFB4Ri0tuzpWtyHlh7E7HnkqTNLq6aR6WVNS1w=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
 github.com/go-openapi/jsonreference v0.19.3 h1:5cxNfTy0UVC3X8JL5ymxzyoUZmo8iZb+jeTWn7tUa8o=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
@@ -378,7 +368,6 @@ github.com/go-openapi/loads v0.17.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf
 github.com/go-openapi/loads v0.17.2/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.18.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.19.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
-github.com/go-openapi/loads v0.19.2 h1:rf5ArTHmIJxyV5Oiks+Su0mUens1+AjpkPoWr5xFRcI=
 github.com/go-openapi/loads v0.19.2/go.mod h1:QAskZPMX5V0C2gvfkGZzJlINuP7Hx/4+ix5jWFxsNPs=
 github.com/go-openapi/loads v0.19.3/go.mod h1:YVfqhUCdahYwR3f3iiwQLhicVRvLlU/WO5WPaZvcvSI=
 github.com/go-openapi/loads v0.19.4/go.mod h1:zZVHonKd8DXyxyw4yfnVjPzBjIQcLt0CCsn0N0ZrQsk=
@@ -388,7 +377,6 @@ github.com/go-openapi/runtime v0.0.0-20180920151709-4f900dc2ade9/go.mod h1:6v9a6
 github.com/go-openapi/runtime v0.18.0/go.mod h1:uI6pHuxWYTy94zZxgcwJkUWa9wbIlhteGfloI10GD4U=
 github.com/go-openapi/runtime v0.19.0/go.mod h1:OwNfisksmmaZse4+gpV3Ne9AyMOlP1lt4sK4FXt0O64=
 github.com/go-openapi/runtime v0.19.3/go.mod h1:X277bwSUBxVlCYR3r7xgZZGKVvBd/29gLDlFGtJ8NL4=
-github.com/go-openapi/runtime v0.19.4 h1:csnOgcgAiuGoM/Po7PEpKDoNulCcF3FGbSnbHfxgjMI=
 github.com/go-openapi/runtime v0.19.4/go.mod h1:X277bwSUBxVlCYR3r7xgZZGKVvBd/29gLDlFGtJ8NL4=
 github.com/go-openapi/runtime v0.19.15 h1:2GIefxs9Rx1vCDNghRtypRq+ig8KSLrjHbAYI/gCLCM=
 github.com/go-openapi/runtime v0.19.15/go.mod h1:dhGWCTKRXlAfGnQG0ONViOZpjfg0m2gUt9nTQPQZuoo=
@@ -396,7 +384,6 @@ github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nA
 github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.17.2/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
-github.com/go-openapi/spec v0.19.2 h1:SStNd1jRcYtfKCN7R0laGNs80WYYvn5CbBjM2sOmCrE=
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/spec v0.19.6/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
@@ -406,10 +393,8 @@ github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pL
 github.com/go-openapi/strfmt v0.17.2/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.19.0/go.mod h1:+uW+93UVvGGq2qGaZxdDeJqSAqBqBdl+ZPMF/cC8nDY=
-github.com/go-openapi/strfmt v0.19.2 h1:clPGfBnJohokno0e+d7hs6Yocrzjlgz6EsQSDncCRnE=
 github.com/go-openapi/strfmt v0.19.2/go.mod h1:0yX7dbo8mKIvc3XSKp7MNfxw4JytCfCD6+bY1AVL9LU=
 github.com/go-openapi/strfmt v0.19.3/go.mod h1:0yX7dbo8mKIvc3XSKp7MNfxw4JytCfCD6+bY1AVL9LU=
-github.com/go-openapi/strfmt v0.19.4 h1:eRvaqAhpL0IL6Trh5fDsGnGhiXndzHFuA05w6sXH6/g=
 github.com/go-openapi/strfmt v0.19.4/go.mod h1:eftuHTlB/dI8Uq8JJOyRlieZf+WkkxUuk0dgdHXr2Qk=
 github.com/go-openapi/strfmt v0.19.5 h1:0utjKrw+BAh8s57XE9Xz8DUBsVvPmRUB6styvl9wWIM=
 github.com/go-openapi/strfmt v0.19.5/go.mod h1:eftuHTlB/dI8Uq8JJOyRlieZf+WkkxUuk0dgdHXr2Qk=
@@ -419,14 +404,12 @@ github.com/go-openapi/swag v0.17.2/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/
 github.com/go-openapi/swag v0.18.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.4/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
-github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.7/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfTe5McPyhY=
 github.com/go-openapi/swag v0.19.9 h1:1IxuqvBUU3S2Bi4YC7tlP9SJF1gVpCvqN0T2Qof4azE=
 github.com/go-openapi/swag v0.19.9/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfTe5McPyhY=
 github.com/go-openapi/validate v0.17.2/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
-github.com/go-openapi/validate v0.19.2 h1:ky5l57HjyVRrsJfd2+Ro5Z9PjGuKbsmftwyMtk8H7js=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.3/go.mod h1:90Vh6jjkTn+OT1Eefm0ZixWNFjhtOH7vS9k0lo6zwJo=
 github.com/go-openapi/validate v0.19.8 h1:YFzsdWIDfVuLvIOF+ZmKjVg1MbPJ1QgY9PihMwei1ys=
@@ -504,9 +487,7 @@ github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
-github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
-github.com/golang/protobuf v1.4.1 h1:ZFgWrT+bLgsYPirOnRfKLYJLvssAegOj/hgyMFdJZe0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
@@ -529,7 +510,6 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
-github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -564,7 +544,6 @@ github.com/gophercloud/gophercloud v0.3.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbGkcYwAR7EZK2WMqM=
 github.com/gophercloud/gophercloud v0.11.0 h1:pYMP9UZBdQa3lsfIZ1tZor4EbtxiuB6BHhocenkiH/E=
 github.com/gophercloud/gophercloud v0.11.0/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
-github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de h1:F7WD09S8QB4LrkEpka0dFPLSotH11HRpCsLIbIcJ7sU=
 github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -863,7 +842,6 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.10.3 h1:OoxbjfXVZyod1fmWYhI7SEyaD8B00ynP3T+D5GiyHOY=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -934,7 +912,6 @@ github.com/prometheus/client_golang v1.2.1/go.mod h1:XMU6Z2MjaRKVu/dC1qupJI9SiNk
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.4.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
-github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
 github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
 github.com/prometheus/client_golang v1.6.1-0.20200604110148-03575cad4e55 h1:ADHic9K/n5JQDFx/OAQbxkwR+uPJ9oYmN0taBMyYrBo=
 github.com/prometheus/client_golang v1.6.1-0.20200604110148-03575cad4e55/go.mod h1:25h+Uz1WvXDBZYwqGX8PAb71RBkcjxEVV/R5wGnsq4I=
@@ -1096,7 +1073,6 @@ github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHM
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
-github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6 h1:YdYsPAZ2pC6Tow/nPZOPQ96O3hm/ToAkGsPLzedXERk=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -1324,9 +1300,7 @@ golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 h1:OjiUf46hAmXblsZdnoSXsEUSKU8r1UEzcL5RVZ4gO9Y=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1487,10 +1461,8 @@ google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLY
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
-google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zimw=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEGA=
@@ -1527,11 +1499,9 @@ gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2 h1:XZx7nhd5GMaZpmDaEHFVafUZC7ya0fuo7cSJ3UCKYmM=
 gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200603094226-e3079894b1e8 h1:jL/vaozO53FMfZLySWM+4nulF3gQEC6q5jH90LPomDo=
 gopkg.in/yaml.v3 v3.0.0-20200603094226-e3079894b1e8/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -1571,7 +1541,6 @@ k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKf
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 h1:Oh3Mzx5pJ+yIumsAD0MOECPVeXsVot0UkiaCGVyfGQY=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/utils v0.0.0-20190809000727-6c36bc71fc4a/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6 h1:p0Ai3qVtkbCG/Af26dBmU0E1W58NID3hSSh7cMyylpM=
 k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200414100711-2df71ebbae66 h1:Ly1Oxdu5p5ZFmiVT71LFgeZETvMfZ1iBIGeOenT2JeM=
@@ -1586,7 +1555,6 @@ sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:w
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0 h1:dOmIZBMfhcHS09XZkMyUgkq5trg3/jRyJYFZUiaOp8E=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
-sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/go.sum
+++ b/go.sum
@@ -1096,6 +1096,7 @@ github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHM
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6 h1:YdYsPAZ2pC6Tow/nPZOPQ96O3hm/ToAkGsPLzedXERk=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -5,10 +5,12 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/integration/e2e"
+	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
 	"github.com/cortexproject/cortex/integration/e2ecortex"
 )
 
@@ -19,7 +21,14 @@ func TestAlertmanager(t *testing.T) {
 
 	require.NoError(t, writeFileToSharedDir(s, "alertmanager_configs/user-1.yaml", []byte(cortexAlertmanagerUserConfigYaml)))
 
-	alertmanager := e2ecortex.NewAlertmanager("alertmanager", AlertmanagerFlags, "")
+	alertmanager := e2ecortex.NewAlertmanager(
+		"alertmanager",
+		mergeFlags(
+			AlertmanagerFlags,
+			AlertmanagerLocalFlags,
+		),
+		"",
+	)
 	require.NoError(t, s.StartAndWaitReady(alertmanager))
 	require.NoError(t, alertmanager.WaitSumMetrics(e2e.Equals(1), "cortex_alertmanager_configs"))
 
@@ -39,4 +48,56 @@ func TestAlertmanager(t *testing.T) {
 
 	// Ensure no service-specific metrics prefix is used by the wrong service.
 	assertServiceMetricsPrefixes(t, AlertManager, alertmanager)
+}
+
+func TestAlertmanagerStoreAPI(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	minio := e2edb.NewMinio(9000, AlertmanagerS3Flags["-alertmanager.storage.s3.buckets"])
+	require.NoError(t, s.StartAndWaitReady(minio))
+
+	am := e2ecortex.NewAlertmanager(
+		"alertmanager",
+		mergeFlags(
+			AlertmanagerFlags,
+			AlertmanagerS3Flags,
+		),
+		"",
+	)
+
+	require.NoError(t, s.StartAndWaitReady(am))
+	require.NoError(t, am.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_configs"))
+
+	c, err := e2ecortex.NewClient("", "", am.HTTPEndpoint(), "user-1")
+	require.NoError(t, err)
+
+	_, err = c.GetAlertmanagerConfig(context.Background())
+	require.Error(t, err)
+	require.EqualError(t, err, e2ecortex.ErrNotFound.Error())
+
+	err = c.SetAlertmanagerConfig(context.Background(), cortexAlertmanagerUserConfigYaml, map[string]string{})
+	require.NoError(t, err)
+
+	time.Sleep(time.Second * 2)
+
+	cfg, err := c.GetAlertmanagerConfig(context.Background())
+	require.NoError(t, err)
+
+	// Ensure the returned status config matches the loaded config
+	require.NotNil(t, cfg)
+	require.Equal(t, "example_receiver", cfg.Route.Receiver)
+	require.Len(t, cfg.Route.GroupByStr, 1)
+	require.Equal(t, "example_groupby", cfg.Route.GroupByStr[0])
+	require.Len(t, cfg.Receivers, 1)
+	require.Equal(t, "example_receiver", cfg.Receivers[0].Name)
+
+	err = c.DeleteAlertmanagerConfig(context.Background())
+	require.NoError(t, err)
+
+	require.NoError(t, am.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_configs"))
+	cfg, err = c.GetAlertmanagerConfig(context.Background())
+	require.Error(t, err)
+	require.EqualError(t, err, e2ecortex.ErrNotFound.Error())
 }

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -70,7 +70,7 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	require.NoError(t, s.StartAndWaitReady(am))
 	require.NoError(t, am.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_configs"))
 
-	c, err := e2ecortex.NewClient("", "", am.HTTPEndpoint(), "user-1")
+	c, err := e2ecortex.NewClient("", "", am.HTTPEndpoint(), "", "user-1")
 	require.NoError(t, err)
 
 	_, err = c.GetAlertmanagerConfig(context.Background())

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -99,5 +99,6 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	require.NoError(t, am.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_configs"))
 	cfg, err = c.GetAlertmanagerConfig(context.Background())
 	require.Error(t, err)
+	require.Nil(t, cfg)
 	require.EqualError(t, err, e2ecortex.ErrNotFound.Error())
 }

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -5,7 +5,6 @@ package main
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -80,7 +79,7 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	err = c.SetAlertmanagerConfig(context.Background(), cortexAlertmanagerUserConfigYaml, map[string]string{})
 	require.NoError(t, err)
 
-	time.Sleep(time.Second * 2)
+	require.NoError(t, am.WaitSumMetrics(e2e.Equals(1), "cortex_alertmanager_configs"))
 
 	cfg, err := c.GetAlertmanagerConfig(context.Background())
 	require.NoError(t, err)

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -51,9 +51,20 @@ var (
 	cortexSchemaConfigYaml = buildSchemaConfigWith([]storeConfig{{From: "2019-03-20", IndexStore: "aws-dynamo"}})
 
 	AlertmanagerFlags = map[string]string{
-		"-alertmanager.storage.local.path": filepath.Join(e2e.ContainerSharedDir, "alertmanager_configs"),
+		"-alertmanager.configs.poll-interval": "1s",
+		"-alertmanager.web.external-url":      "http://localhost/api/prom",
+	}
+
+	AlertmanagerLocalFlags = map[string]string{
 		"-alertmanager.storage.type":       "local",
-		"-alertmanager.web.external-url":   "http://localhost/api/prom",
+		"-alertmanager.storage.local.path": filepath.Join(e2e.ContainerSharedDir, "alertmanager_configs"),
+	}
+
+	AlertmanagerS3Flags = map[string]string{
+		"-alertmanager.storage.type":                "s3",
+		"-alertmanager.storage.s3.buckets":          "cortex-alerts",
+		"-alertmanager.storage.s3.force-path-style": "true",
+		"-alertmanager.storage.s3.url":              fmt.Sprintf("s3://%s:%s@%s-minio-9000.:9000", e2edb.MinioAccessKey, e2edb.MinioSecretKey, networkName),
 	}
 
 	RulerConfigs = map[string]string{

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -52,7 +52,7 @@ var (
 
 	AlertmanagerFlags = map[string]string{
 		"-alertmanager.configs.poll-interval": "1s",
-		"-alertmanager.web.external-url":      "http://localhost/api/prom",
+		"-alertmanager.web.external-url":      "http://localhost/alertmanager",
 	}
 
 	AlertmanagerLocalFlags = map[string]string{

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -52,7 +52,7 @@ var (
 
 	AlertmanagerFlags = map[string]string{
 		"-alertmanager.configs.poll-interval": "1s",
-		"-alertmanager.web.external-url":      "http://localhost/alertmanager",
+		"-alertmanager.web.external-url":      "http://localhost/api/prom",
 	}
 
 	AlertmanagerLocalFlags = map[string]string{

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -329,7 +329,7 @@ func (c *Client) SetAlertmanagerConfig(ctx context.Context, amConfig string, tem
 		return ErrNotFound
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("setting config failed with status %d and error %v", resp.StatusCode, string(body))
 	}
 

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -68,7 +68,7 @@ func NewClient(
 
 	if alertmanagerAddress != "" {
 		alertmanagerAPIClient, err := promapi.NewClient(promapi.Config{
-			Address:      "http://" + alertmanagerAddress + "/api/prom",
+			Address:      "http://" + alertmanagerAddress,
 			RoundTripper: &addOrgIDRoundTripper{orgID: orgID, next: http.DefaultTransport},
 		})
 		if err != nil {
@@ -180,7 +180,7 @@ type ServerStatus struct {
 
 // GetAlertmanagerConfig gets the status of an alertmanager instance
 func (c *Client) GetAlertmanagerConfig(ctx context.Context) (*alertConfig.Config, error) {
-	u := c.alertmanagerClient.URL("/api/v1/status", nil)
+	u := c.alertmanagerClient.URL("api/prom/api/v1/status", nil)
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
@@ -304,7 +304,7 @@ type userConfig struct {
 
 // SetAlertmanagerConfig gets the status of an alertmanager instance
 func (c *Client) SetAlertmanagerConfig(ctx context.Context, amConfig string, templates map[string]string) error {
-	u := c.alertmanagerClient.URL("/alerts", nil)
+	u := c.alertmanagerClient.URL("/api/v1/alerts", nil)
 
 	data, err := yaml.Marshal(&userConfig{
 		AlertmanagerConfig: amConfig,
@@ -338,7 +338,7 @@ func (c *Client) SetAlertmanagerConfig(ctx context.Context, amConfig string, tem
 
 // DeleteAlertmanagerConfig gets the status of an alertmanager instance
 func (c *Client) DeleteAlertmanagerConfig(ctx context.Context) error {
-	u := c.alertmanagerClient.URL("/alerts", nil)
+	u := c.alertmanagerClient.URL("/api/v1/alerts", nil)
 	req, err := http.NewRequest(http.MethodDelete, u.String(), nil)
 	if err != nil {
 		return fmt.Errorf("error creating request: %v", err)

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -330,7 +330,7 @@ func (c *Client) SetAlertmanagerConfig(ctx context.Context, amConfig string, tem
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("setting config failed, %v", string(body))
+		return fmt.Errorf("setting config failed with status %d and error %v", resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -354,7 +354,7 @@ func (c *Client) DeleteAlertmanagerConfig(ctx context.Context) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("deleting config failed, %v", string(body))
+		return fmt.Errorf("deleting config failed with status %d and error %v", resp.StatusCode, string(body))
 	}
 
 	return nil

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -20,6 +21,10 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	rulefmt "github.com/cortexproject/cortex/pkg/ruler/legacy_rulefmt"
+)
+
+var (
+	ErrNotFound = errors.New("not found")
 )
 
 // Client is a client used to interact with Cortex in integration tests
@@ -182,9 +187,13 @@ func (c *Client) GetAlertmanagerConfig(ctx context.Context) (*alertConfig.Config
 		return nil, fmt.Errorf("error creating request: %v", err)
 	}
 
-	_, body, err := c.alertmanagerClient.Do(ctx, req)
+	resp, body, err := c.alertmanagerClient.Do(ctx, req)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("not found")
 	}
 
 	var ss *ServerStatus
@@ -284,5 +293,69 @@ func (c *Client) DeleteRuleGroup(namespace string, groupName string) error {
 	}
 
 	defer res.Body.Close()
+	return nil
+}
+
+// userConfig is used to communicate a users alertmanager configs
+type userConfig struct {
+	TemplateFiles      map[string]string `yaml:"template_files"`
+	AlertmanagerConfig string            `yaml:"alertmanager_config"`
+}
+
+// SetAlertmanagerConfig gets the status of an alertmanager instance
+func (c *Client) SetAlertmanagerConfig(ctx context.Context, amConfig string, templates map[string]string) error {
+	u := c.alertmanagerClient.URL("/alerts", nil)
+
+	data, err := yaml.Marshal(&userConfig{
+		AlertmanagerConfig: amConfig,
+		TemplateFiles:      templates,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("error creating request: %v", err)
+	}
+
+	resp, body, err := c.alertmanagerClient.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("not found")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("setting config failed, %v", string(body))
+	}
+
+	return nil
+}
+
+// DeleteAlertmanagerConfig gets the status of an alertmanager instance
+func (c *Client) DeleteAlertmanagerConfig(ctx context.Context) error {
+	u := c.alertmanagerClient.URL("/alerts", nil)
+	req, err := http.NewRequest(http.MethodDelete, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("error creating request: %v", err)
+	}
+
+	resp, body, err := c.alertmanagerClient.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("not found")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("deleting config failed, %v", string(body))
+	}
+
 	return nil
 }

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -180,7 +180,7 @@ type ServerStatus struct {
 
 // GetAlertmanagerConfig gets the status of an alertmanager instance
 func (c *Client) GetAlertmanagerConfig(ctx context.Context) (*alertConfig.Config, error) {
-	u := c.alertmanagerClient.URL("api/prom/api/v1/status", nil)
+	u := c.alertmanagerClient.URL("/api/prom/api/v1/status", nil)
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -193,7 +193,7 @@ func (c *Client) GetAlertmanagerConfig(ctx context.Context) (*alertConfig.Config
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("not found")
+		return nil, ErrNotFound
 	}
 
 	var ss *ServerStatus
@@ -326,7 +326,7 @@ func (c *Client) SetAlertmanagerConfig(ctx context.Context, amConfig string, tem
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("not found")
+		return ErrNotFound
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -350,7 +350,7 @@ func (c *Client) DeleteAlertmanagerConfig(ctx context.Context) error {
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("not found")
+		return ErrNotFound
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -275,8 +275,9 @@ func NewAlertmanager(name string, flags map[string]string, image string) *Cortex
 		name,
 		image,
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
-			"-target":    "alertmanager",
-			"-log.level": "warn",
+			"-target":                               "alertmanager",
+			"-log.level":                            "warn",
+			"-experimental.alertmanager.enable-api": "true",
 		}, flags))...),
 		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
 		httpPort,

--- a/pkg/alertmanager/alerts/compat.go
+++ b/pkg/alertmanager/alerts/compat.go
@@ -1,0 +1,26 @@
+package alerts
+
+// ToProto transforms a yaml Alertmanager config and map of template files to an AlertConficDesc
+func ToProto(cfg string, templates map[string]string, user string) (AlertConfigDesc, error) {
+	tmpls := []*TemplateDesc{}
+	for fn, body := range templates {
+		tmpls = append(tmpls, &TemplateDesc{
+			Body:     body,
+			Filename: fn,
+		})
+	}
+	return AlertConfigDesc{
+		User:      user,
+		RawConfig: cfg,
+		Templates: tmpls,
+	}, nil
+}
+
+// ParseTemplates returns a alertmanager config object
+func ParseTemplates(cfg AlertConfigDesc) map[string]string {
+	templates := map[string]string{}
+	for _, t := range cfg.Templates {
+		templates[t.Filename] = t.Body
+	}
+	return templates
+}

--- a/pkg/alertmanager/alerts/compat.go
+++ b/pkg/alertmanager/alerts/compat.go
@@ -1,5 +1,11 @@
 package alerts
 
+import "errors"
+
+var (
+	ErrNotFound = errors.New("alertmanager config not found")
+)
+
 // ToProto transforms a yaml Alertmanager config and map of template files to an AlertConficDesc
 func ToProto(cfg string, templates map[string]string, user string) (AlertConfigDesc, error) {
 	tmpls := []*TemplateDesc{}

--- a/pkg/alertmanager/alerts/compat.go
+++ b/pkg/alertmanager/alerts/compat.go
@@ -6,7 +6,7 @@ var (
 	ErrNotFound = errors.New("alertmanager config not found")
 )
 
-// ToProto transforms a yaml Alertmanager config and map of template files to an AlertConficDesc
+// ToProto transforms a yaml Alertmanager config and map of template files to an AlertConfigDesc
 func ToProto(cfg string, templates map[string]string, user string) (AlertConfigDesc, error) {
 	tmpls := []*TemplateDesc{}
 	for fn, body := range templates {

--- a/pkg/alertmanager/alerts/configdb/store.go
+++ b/pkg/alertmanager/alerts/configdb/store.go
@@ -65,12 +65,7 @@ func (c *Store) ListAlertConfigs(ctx context.Context) (map[string]alerts.AlertCo
 }
 
 func (c *Store) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
-	cfgs, err := c.ListAlertConfigs(ctx)
-	if err != nil {
-		return alerts.AlertConfigDesc{}, err
-	}
-
-	cfg, exists := cfgs[user]
+	cfg, exists := c.alertConfigs[user]
 
 	if !exists {
 		return alerts.AlertConfigDesc{}, alerts.ErrNotFound

--- a/pkg/alertmanager/alerts/configdb/store.go
+++ b/pkg/alertmanager/alerts/configdb/store.go
@@ -59,3 +59,15 @@ func (c *Store) ListAlertConfigs(ctx context.Context) (map[string]alerts.AlertCo
 
 	return c.alertConfigs, nil
 }
+
+func (c *Store) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (c *Store) SetAlertConfig(ctx context.Context, cfg alerts.AlertConfigDesc) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (c *Store) DeleteAlertConfig(ctx context.Context, user string) error {
+	panic("not implemented") // TODO: Implement
+}

--- a/pkg/alertmanager/alerts/configdb/store.go
+++ b/pkg/alertmanager/alerts/configdb/store.go
@@ -2,11 +2,15 @@ package configdb
 
 import (
 	"context"
-
-	"github.com/cortexproject/cortex/pkg/configs/userconfig"
+	"errors"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
 	"github.com/cortexproject/cortex/pkg/configs/client"
+	"github.com/cortexproject/cortex/pkg/configs/userconfig"
+)
+
+var (
+	errReadOnly = errors.New("local alertmanager config storage is read-only")
 )
 
 // Store is a concrete implementation of RuleStore that sources rules from the config service
@@ -61,13 +65,24 @@ func (c *Store) ListAlertConfigs(ctx context.Context) (map[string]alerts.AlertCo
 }
 
 func (c *Store) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
-	panic("not implemented") // TODO: Implement
+	cfgs, err := c.ListAlertConfigs(ctx)
+	if err != nil {
+		return alerts.AlertConfigDesc{}, err
+	}
+
+	cfg, exists := cfgs[user]
+
+	if !exists {
+		return alerts.AlertConfigDesc{}, alerts.ErrNotFound
+	}
+
+	return cfg, nil
 }
 
 func (c *Store) SetAlertConfig(ctx context.Context, cfg alerts.AlertConfigDesc) error {
-	panic("not implemented") // TODO: Implement
+	return errReadOnly
 }
 
 func (c *Store) DeleteAlertConfig(ctx context.Context, user string) error {
-	panic("not implemented") // TODO: Implement
+	return errReadOnly
 }

--- a/pkg/alertmanager/alerts/configdb/store.go
+++ b/pkg/alertmanager/alerts/configdb/store.go
@@ -64,6 +64,7 @@ func (c *Store) ListAlertConfigs(ctx context.Context) (map[string]alerts.AlertCo
 	return c.alertConfigs, nil
 }
 
+// GetAlertConfig finds and returns the AlertManager configuration of an user.
 func (c *Store) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
 	cfg, exists := c.alertConfigs[user]
 

--- a/pkg/alertmanager/alerts/configdb/store.go
+++ b/pkg/alertmanager/alerts/configdb/store.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	errReadOnly = errors.New("local alertmanager config storage is read-only")
+	errReadOnly = errors.New("configdb alertmanager config storage is read-only")
 )
 
 // Store is a concrete implementation of RuleStore that sources rules from the config service
@@ -66,6 +66,13 @@ func (c *Store) ListAlertConfigs(ctx context.Context) (map[string]alerts.AlertCo
 
 // GetAlertConfig finds and returns the AlertManager configuration of an user.
 func (c *Store) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
+
+	// Refresh the local state before fetching an specific one.
+	_, err := c.ListAlertConfigs(ctx)
+	if err != nil {
+		return alerts.AlertConfigDesc{}, err
+	}
+
 	cfg, exists := c.alertConfigs[user]
 
 	if !exists {

--- a/pkg/alertmanager/alerts/local/store.go
+++ b/pkg/alertmanager/alerts/local/store.go
@@ -14,6 +14,10 @@ import (
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
 )
 
+var (
+	errReadOnly = errors.New("local alertmanager config storage is read-only")
+)
+
 // StoreConfig configures a static file alertmanager store
 type StoreConfig struct {
 	Path string `yaml:"path"`
@@ -77,14 +81,25 @@ func (f *Store) ListAlertConfigs(ctx context.Context) (map[string]alerts.AlertCo
 	return configs, nil
 }
 
-func (c *Store) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
-	panic("not implemented") // TODO: Implement
+func (f *Store) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
+	cfgs, err := f.ListAlertConfigs(ctx)
+	if err != nil {
+		return alerts.AlertConfigDesc{}, err
+	}
+
+	cfg, exists := cfgs[user]
+
+	if !exists {
+		return alerts.AlertConfigDesc{}, alerts.ErrNotFound
+	}
+
+	return cfg, nil
 }
 
-func (c *Store) SetAlertConfig(ctx context.Context, cfg alerts.AlertConfigDesc) error {
-	panic("not implemented") // TODO: Implement
+func (f *Store) SetAlertConfig(ctx context.Context, cfg alerts.AlertConfigDesc) error {
+	return errReadOnly
 }
 
-func (c *Store) DeleteAlertConfig(ctx context.Context, user string) error {
-	panic("not implemented") // TODO: Implement
+func (f *Store) DeleteAlertConfig(ctx context.Context, user string) error {
+	return errReadOnly
 }

--- a/pkg/alertmanager/alerts/local/store.go
+++ b/pkg/alertmanager/alerts/local/store.go
@@ -76,3 +76,15 @@ func (f *Store) ListAlertConfigs(ctx context.Context) (map[string]alerts.AlertCo
 
 	return configs, nil
 }
+
+func (c *Store) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (c *Store) SetAlertConfig(ctx context.Context, cfg alerts.AlertConfigDesc) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (c *Store) DeleteAlertConfig(ctx context.Context, user string) error {
+	panic("not implemented") // TODO: Implement
+}

--- a/pkg/alertmanager/alerts/objectclient/store.go
+++ b/pkg/alertmanager/alerts/objectclient/store.go
@@ -1,0 +1,91 @@
+package objectclient
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+
+	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
+	"github.com/cortexproject/cortex/pkg/chunk"
+)
+
+// Object Alert Storage Schema
+// =======================
+// Object Name: "alerts/<user_id>"
+// Storage Format: Encoded AlertConfigDesc
+
+const (
+	alertPrefix = "alerts/"
+)
+
+// AlertStore allows cortex alertmanager configs to be stored using an object store backend.
+type AlertStore struct {
+	client chunk.ObjectClient
+}
+
+// NewAlertStore returns a new AlertStore
+func NewAlertStore(client chunk.ObjectClient) *AlertStore {
+	return &AlertStore{
+		client: client,
+	}
+}
+
+// ListAlertConfigs returns all of the active alert configs in this store
+func (a *AlertStore) ListAlertConfigs(ctx context.Context) (map[string]alerts.AlertConfigDesc, error) {
+	objs, err := a.client.List(ctx, alertPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	cfgs := map[string]alerts.AlertConfigDesc{}
+
+	for _, obj := range objs {
+		cfg, err := a.getAlertConfig(ctx, obj.Key)
+		if err != nil {
+			return nil, err
+		}
+		cfgs[cfg.User] = cfg
+	}
+
+	return cfgs, nil
+}
+
+func (a *AlertStore) getAlertConfig(ctx context.Context, key string) (alerts.AlertConfigDesc, error) {
+	reader, err := a.client.GetObject(ctx, key)
+	if err != nil {
+		return alerts.AlertConfigDesc{}, err
+	}
+
+	buf, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return alerts.AlertConfigDesc{}, err
+	}
+
+	config := alerts.AlertConfigDesc{}
+	err = config.Unmarshal(buf)
+	if err != nil {
+		return alerts.AlertConfigDesc{}, err
+	}
+
+	return config, nil
+}
+
+// GetAlertConfig returns a specified users alertmanager configuration
+func (a *AlertStore) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
+	return a.getAlertConfig(ctx, alertPrefix+user)
+}
+
+// SetAlertConfig sets a specified users alertmanager configuration
+func (a *AlertStore) SetAlertConfig(ctx context.Context, cfg alerts.AlertConfigDesc) error {
+	cfgBytes, err := cfg.Marshal()
+	if err != nil {
+		return err
+	}
+
+	return a.client.PutObject(ctx, alertPrefix+cfg.User, bytes.NewReader(cfgBytes))
+}
+
+// DeleteAlertConfig deletes a specified users alertmanager configuration
+func (a *AlertStore) DeleteAlertConfig(ctx context.Context, user string) error {
+	return a.client.DeleteObject(ctx, alertPrefix+user)
+}

--- a/pkg/alertmanager/alerts/objectclient/store.go
+++ b/pkg/alertmanager/alerts/objectclient/store.go
@@ -32,7 +32,7 @@ func NewAlertStore(client chunk.ObjectClient) *AlertStore {
 
 // ListAlertConfigs returns all of the active alert configs in this store
 func (a *AlertStore) ListAlertConfigs(ctx context.Context) (map[string]alerts.AlertConfigDesc, error) {
-	objs, err := a.client.List(ctx, alertPrefix)
+	objs, _, err := a.client.List(ctx, alertPrefix)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/alertmanager/alerts/objectclient/store.go
+++ b/pkg/alertmanager/alerts/objectclient/store.go
@@ -72,7 +72,12 @@ func (a *AlertStore) getAlertConfig(ctx context.Context, key string) (alerts.Ale
 
 // GetAlertConfig returns a specified users alertmanager configuration
 func (a *AlertStore) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
-	return a.getAlertConfig(ctx, alertPrefix+user)
+	cfg, err := a.getAlertConfig(ctx, alertPrefix+user)
+	if err == chunk.ErrStorageObjectNotFound {
+		return cfg, alerts.ErrNotFound
+	}
+
+	return cfg, err
 }
 
 // SetAlertConfig sets a specified users alertmanager configuration

--- a/pkg/alertmanager/alerts/objectclient/store.go
+++ b/pkg/alertmanager/alerts/objectclient/store.go
@@ -70,7 +70,7 @@ func (a *AlertStore) getAlertConfig(ctx context.Context, key string) (alerts.Ale
 	return config, nil
 }
 
-// GetAlertConfig returns a specified users alertmanager configuration
+// GetAlertConfig returns a specified user's alertmanager configuration
 func (a *AlertStore) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
 	cfg, err := a.getAlertConfig(ctx, alertPrefix+user)
 	if err == chunk.ErrStorageObjectNotFound {
@@ -80,7 +80,7 @@ func (a *AlertStore) GetAlertConfig(ctx context.Context, user string) (alerts.Al
 	return cfg, err
 }
 
-// SetAlertConfig sets a specified users alertmanager configuration
+// SetAlertConfig sets a specified user's alertmanager configuration
 func (a *AlertStore) SetAlertConfig(ctx context.Context, cfg alerts.AlertConfigDesc) error {
 	cfgBytes, err := cfg.Marshal()
 	if err != nil {
@@ -90,7 +90,7 @@ func (a *AlertStore) SetAlertConfig(ctx context.Context, cfg alerts.AlertConfigD
 	return a.client.PutObject(ctx, alertPrefix+cfg.User, bytes.NewReader(cfgBytes))
 }
 
-// DeleteAlertConfig deletes a specified users alertmanager configuration
+// DeleteAlertConfig deletes a specified user's alertmanager configuration
 func (a *AlertStore) DeleteAlertConfig(ctx context.Context, user string) error {
 	return a.client.DeleteObject(ctx, alertPrefix+user)
 }

--- a/pkg/alertmanager/alerts/objectclient/store.go
+++ b/pkg/alertmanager/alerts/objectclient/store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io/ioutil"
+	"path"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
 	"github.com/cortexproject/cortex/pkg/chunk"
@@ -72,7 +73,7 @@ func (a *AlertStore) getAlertConfig(ctx context.Context, key string) (alerts.Ale
 
 // GetAlertConfig returns a specified user's alertmanager configuration
 func (a *AlertStore) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
-	cfg, err := a.getAlertConfig(ctx, alertPrefix+user)
+	cfg, err := a.getAlertConfig(ctx, path.Join(alertPrefix, user))
 	if err == chunk.ErrStorageObjectNotFound {
 		return cfg, alerts.ErrNotFound
 	}
@@ -87,10 +88,10 @@ func (a *AlertStore) SetAlertConfig(ctx context.Context, cfg alerts.AlertConfigD
 		return err
 	}
 
-	return a.client.PutObject(ctx, alertPrefix+cfg.User, bytes.NewReader(cfgBytes))
+	return a.client.PutObject(ctx, path.Join(alertPrefix, cfg.User), bytes.NewReader(cfgBytes))
 }
 
 // DeleteAlertConfig deletes a specified user's alertmanager configuration
 func (a *AlertStore) DeleteAlertConfig(ctx context.Context, user string) error {
-	return a.client.DeleteObject(ctx, alertPrefix+user)
+	return a.client.DeleteObject(ctx, path.Join(alertPrefix, user))
 }

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -54,7 +54,11 @@ func (am *MultitenantAlertmanager) getUserConfig(w http.ResponseWriter, r *http.
 
 	cfg, err := am.store.GetAlertConfig(r.Context(), userID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		if err == alerts.ErrNotFound {
+			http.Error(w, err.Error(), http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
 		return
 	}
 

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log/level"
-	"github.com/gorilla/mux"
 	"github.com/weaveworks/common/user"
 	"gopkg.in/yaml.v2"
 )
@@ -18,21 +17,7 @@ type UserConfig struct {
 	AlertmanagerConfig string            `yaml:"alertmanager_config"`
 }
 
-// RegisterRoutes registers the configs API HTTP routes with the provided Router.
-func (am *MultitenantAlertmanager) RegisterRoutes(r *mux.Router) {
-	for _, route := range []struct {
-		name, method, path string
-		handler            http.HandlerFunc
-	}{
-		{"get_config", "GET", "/alerts", am.getUserConfig},
-		{"set_config", "POST", "/alerts", am.setUserConfig},
-		{"delete_config", "DELETE", "/alerts", am.deleteUserConfig},
-	} {
-		r.Handle(route.path, route.handler).Methods(route.method).Name(route.name)
-	}
-}
-
-func (am *MultitenantAlertmanager) getUserConfig(w http.ResponseWriter, r *http.Request) {
+func (am *MultitenantAlertmanager) GetUserConfig(w http.ResponseWriter, r *http.Request) {
 	userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
@@ -80,7 +65,7 @@ func (am *MultitenantAlertmanager) getUserConfig(w http.ResponseWriter, r *http.
 	}
 }
 
-func (am *MultitenantAlertmanager) setUserConfig(w http.ResponseWriter, r *http.Request) {
+func (am *MultitenantAlertmanager) SetUserConfig(w http.ResponseWriter, r *http.Request) {
 	userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
@@ -127,7 +112,7 @@ func (am *MultitenantAlertmanager) setUserConfig(w http.ResponseWriter, r *http.
 	w.WriteHeader(http.StatusOK)
 }
 
-func (am *MultitenantAlertmanager) deleteUserConfig(w http.ResponseWriter, r *http.Request) {
+func (am *MultitenantAlertmanager) DeleteUserConfig(w http.ResponseWriter, r *http.Request) {
 	userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -1,0 +1,149 @@
+package alertmanager
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/go-kit/kit/log/level"
+	"github.com/gorilla/mux"
+	"github.com/weaveworks/common/user"
+	"gopkg.in/yaml.v2"
+)
+
+// UserConfig is used to communicate a users alertmanager configs
+type UserConfig struct {
+	TemplateFiles      map[string]string `yaml:"template_files"`
+	AlertmanagerConfig string            `yaml:"alertmanager_config"`
+}
+
+// RegisterRoutes registers the configs API HTTP routes with the provided Router.
+func (am *MultitenantAlertmanager) RegisterRoutes(r *mux.Router) {
+	for _, route := range []struct {
+		name, method, path string
+		handler            http.HandlerFunc
+	}{
+		{"get_config", "GET", "/alerts", am.getUserConfig},
+		{"set_config", "POST", "/alerts", am.setUserConfig},
+		{"delete_config", "DELETE", "/alerts", am.deleteUserConfig},
+	} {
+		r.Handle(route.path, route.handler).Methods(route.method).Name(route.name)
+	}
+}
+
+func (am *MultitenantAlertmanager) getUserConfig(w http.ResponseWriter, r *http.Request) {
+	userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	logger := util.WithContext(r.Context(), util.Logger)
+	if err != nil {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if userID == "" {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	cfg, err := am.store.GetAlertConfig(r.Context(), userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	d, err := yaml.Marshal(&UserConfig{
+		TemplateFiles:      alerts.ParseTemplates(cfg),
+		AlertmanagerConfig: cfg.RawConfig,
+	})
+
+	if err != nil {
+		level.Error(logger).Log("msg", "error marshalling yaml alertmanager config", "err", err, "user", userID)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/yaml")
+	if _, err := w.Write(d); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (am *MultitenantAlertmanager) setUserConfig(w http.ResponseWriter, r *http.Request) {
+	userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	logger := util.WithContext(r.Context(), util.Logger)
+
+	if userID == "" {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	payload, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	cfg := &UserConfig{}
+	err = yaml.Unmarshal(payload, cfg)
+	if err != nil {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	cfgDesc, err := alerts.ToProto(cfg.AlertmanagerConfig, cfg.TemplateFiles, userID)
+	if err != nil {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	err = am.store.SetAlertConfig(r.Context(), cfgDesc)
+	if err != nil {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (am *MultitenantAlertmanager) deleteUserConfig(w http.ResponseWriter, r *http.Request) {
+	userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	logger := util.WithContext(r.Context(), util.Logger)
+
+	if userID == "" {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	am.store.DeleteAlertConfig(r.Context(), userID)
+	if err != nil {
+		level.Error(logger).Log("err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
 	"github.com/cortexproject/cortex/pkg/util"
+
 	"github.com/go-kit/kit/log/level"
 	"github.com/weaveworks/common/user"
 	"gopkg.in/yaml.v2"
@@ -127,7 +128,7 @@ func (am *MultitenantAlertmanager) DeleteUserConfig(w http.ResponseWriter, r *ht
 		return
 	}
 
-	am.store.DeleteAlertConfig(r.Context(), userID)
+	err = am.store.DeleteAlertConfig(r.Context(), userID)
 	if err != nil {
 		level.Error(logger).Log("err", err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -101,6 +101,8 @@ type MultitenantAlertmanagerConfig struct {
 	AutoWebhookRoot    string `yaml:"auto_webhook_root"`
 
 	Store AlertStoreConfig `yaml:"storage"`
+
+	EnableAPI bool `yaml:"enable_api"`
 }
 
 const defaultClusterAddr = "0.0.0.0:9094"
@@ -120,6 +122,8 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.ClusterAdvertiseAddr, "cluster.advertise-address", "", "Explicit address to advertise in cluster.")
 	f.Var(&cfg.Peers, "cluster.peer", "Initial peers (may be repeated).")
 	f.DurationVar(&cfg.PeerTimeout, "cluster.peer-timeout", time.Second*15, "Time to wait between peers to send notifications.")
+
+	f.BoolVar(&cfg.EnableAPI, "experimental.alertmanager.enable-api", false, "Enable the experimental alertmanager config api.")
 
 	cfg.Store.RegisterFlags(f)
 }

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -313,8 +313,11 @@ func (am *MultitenantAlertmanager) syncConfigs(cfgs map[string]alerts.AlertConfi
 	for _, cfg := range cfgs {
 		err := am.setConfig(cfg)
 		if err != nil {
+			userInvalidConfig.WithLabelValues(cfg.User).Set(1)
 			invalid++
 			level.Warn(am.logger).Log("msg", "error applying config", "err", err)
+		} else {
+			userInvalidConfig.WithLabelValues(cfg.User).Set(0)
 		}
 	}
 
@@ -328,6 +331,7 @@ func (am *MultitenantAlertmanager) syncConfigs(cfgs map[string]alerts.AlertConfi
 			level.Info(am.logger).Log("msg", "deactivating per-tenant alertmanager", "user", user)
 			userAM.Pause()
 			delete(am.cfgs, user)
+			userInvalidConfig.WithLabelValues(user).Set(0)
 			level.Info(am.logger).Log("msg", "deactivated per-tenant alertmanager", "user", user)
 		}
 	}

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -313,11 +313,8 @@ func (am *MultitenantAlertmanager) syncConfigs(cfgs map[string]alerts.AlertConfi
 	for _, cfg := range cfgs {
 		err := am.setConfig(cfg)
 		if err != nil {
-			userInvalidConfig.WithLabelValues(cfg.User).Set(1)
 			invalid++
 			level.Warn(am.logger).Log("msg", "error applying config", "err", err)
-		} else {
-			userInvalidConfig.WithLabelValues(cfg.User).Set(0)
 		}
 	}
 
@@ -331,7 +328,6 @@ func (am *MultitenantAlertmanager) syncConfigs(cfgs map[string]alerts.AlertConfi
 			level.Info(am.logger).Log("msg", "deactivating per-tenant alertmanager", "user", user)
 			userAM.Pause()
 			delete(am.cfgs, user)
-			userInvalidConfig.WithLabelValues(user).Set(0)
 			level.Info(am.logger).Log("msg", "deactivated per-tenant alertmanager", "user", user)
 		}
 	}

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -5,6 +5,7 @@ package alertmanager
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -40,6 +41,18 @@ type mockAlertStore struct {
 
 func (m *mockAlertStore) ListAlertConfigs(ctx context.Context) (map[string]alerts.AlertConfigDesc, error) {
 	return m.configs, nil
+}
+
+func (m *mockAlertStore) GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error) {
+	return alerts.AlertConfigDesc{}, fmt.Errorf("not implemented")
+}
+
+func (m *mockAlertStore) SetAlertConfig(ctx context.Context, cfg alerts.AlertConfigDesc) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockAlertStore) DeleteAlertConfig(ctx context.Context, user string) error {
+	return fmt.Errorf("not implemented")
 }
 
 // TestLoadAllConfigs ensures the multitenant alertmanager can properly load configs from a local backend store.

--- a/pkg/alertmanager/storage.go
+++ b/pkg/alertmanager/storage.go
@@ -8,12 +8,19 @@ import (
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts/configdb"
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts/local"
+	"github.com/cortexproject/cortex/pkg/alertmanager/alerts/objectclient"
+	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/chunk/aws"
+	"github.com/cortexproject/cortex/pkg/chunk/gcp"
 	"github.com/cortexproject/cortex/pkg/configs/client"
 )
 
 // AlertStore stores and configures users rule configs
 type AlertStore interface {
 	ListAlertConfigs(ctx context.Context) (map[string]alerts.AlertConfigDesc, error)
+	GetAlertConfig(ctx context.Context, user string) (alerts.AlertConfigDesc, error)
+	SetAlertConfig(ctx context.Context, cfg alerts.AlertConfigDesc) error
+	DeleteAlertConfig(ctx context.Context, user string) error
 }
 
 // AlertStoreConfig configures the alertmanager backend
@@ -21,6 +28,9 @@ type AlertStoreConfig struct {
 	Type     string            `yaml:"type"`
 	ConfigDB client.Config     `yaml:"configdb"`
 	Local    local.StoreConfig `yaml:"local"`
+
+	GCS gcp.GCSConfig `yaml:"gcs,omitempty"`
+	S3  aws.S3Config  `yaml:"s3,omitempty"`
 }
 
 // RegisterFlags registers flags.
@@ -28,6 +38,9 @@ func (cfg *AlertStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.Local.RegisterFlags(f)
 	cfg.ConfigDB.RegisterFlagsWithPrefix("alertmanager.", f)
 	f.StringVar(&cfg.Type, "alertmanager.storage.type", "configdb", "Type of backend to use to store alertmanager configs. Supported values are: \"configdb\", \"local\".")
+
+	cfg.GCS.RegisterFlagsWithPrefix("alertmanager.storage.", f)
+	cfg.S3.RegisterFlagsWithPrefix("alertmanager.storage.", f)
 }
 
 // NewAlertStore returns a new rule storage backend poller and store
@@ -41,7 +54,18 @@ func NewAlertStore(cfg AlertStoreConfig) (AlertStore, error) {
 		return configdb.NewStore(c), nil
 	case "local":
 		return local.NewStore(cfg.Local)
+	case "gcs":
+		return newObjAlertStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCS))
+	case "s3":
+		return newObjAlertStore(aws.NewS3ObjectClient(cfg.S3))
 	default:
-		return nil, fmt.Errorf("unrecognized alertmanager storage backend %v, choose one of:  \"configdb\", \"local\"", cfg.Type)
+		return nil, fmt.Errorf("unrecognized alertmanager storage backend %v, choose one of: azure, configdb, gcs, local, s3", cfg.Type)
 	}
+}
+
+func newObjAlertStore(client chunk.ObjectClient, err error) (AlertStore, error) {
+	if err != nil {
+		return nil, err
+	}
+	return objectclient.NewAlertStore(client), nil
 }

--- a/pkg/alertmanager/storage.go
+++ b/pkg/alertmanager/storage.go
@@ -55,9 +55,9 @@ func NewAlertStore(cfg AlertStoreConfig) (AlertStore, error) {
 	case "local":
 		return local.NewStore(cfg.Local)
 	case "gcs":
-		return newObjAlertStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCS))
+		return newObjAlertStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCS, ""))
 	case "s3":
-		return newObjAlertStore(aws.NewS3ObjectClient(cfg.S3))
+		return newObjAlertStore(aws.NewS3ObjectClient(cfg.S3, ""))
 	default:
 		return nil, fmt.Errorf("unrecognized alertmanager storage backend %v, choose one of: azure, configdb, gcs, local, s3", cfg.Type)
 	}

--- a/pkg/alertmanager/storage.go
+++ b/pkg/alertmanager/storage.go
@@ -29,7 +29,7 @@ type AlertStoreConfig struct {
 	ConfigDB client.Config     `yaml:"configdb"`
 	Local    local.StoreConfig `yaml:"local"`
 
-	GCS gcp.GCSConfig `yaml:"gcs,omitempty"`
+	GCS gcp.GCSConfig `yaml:"gcs"`
 	S3  aws.S3Config  `yaml:"s3,omitempty"`
 }
 
@@ -37,7 +37,7 @@ type AlertStoreConfig struct {
 func (cfg *AlertStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.Local.RegisterFlags(f)
 	cfg.ConfigDB.RegisterFlagsWithPrefix("alertmanager.", f)
-	f.StringVar(&cfg.Type, "alertmanager.storage.type", "configdb", "Type of backend to use to store alertmanager configs. Supported values are: \"configdb\", \"local\".")
+	f.StringVar(&cfg.Type, "alertmanager.storage.type", "configdb", "Type of backend to use to store alertmanager configs. Supported values are: \"configdb\", \"gcs\", \"s3\", \"local\".")
 
 	cfg.GCS.RegisterFlagsWithPrefix("alertmanager.storage.", f)
 	cfg.S3.RegisterFlagsWithPrefix("alertmanager.storage.", f)

--- a/pkg/alertmanager/storage.go
+++ b/pkg/alertmanager/storage.go
@@ -30,7 +30,7 @@ type AlertStoreConfig struct {
 	Local    local.StoreConfig `yaml:"local"`
 
 	GCS gcp.GCSConfig `yaml:"gcs"`
-	S3  aws.S3Config  `yaml:"s3,omitempty"`
+	S3  aws.S3Config  `yaml:"s3"`
 }
 
 // RegisterFlags registers flags.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -130,7 +130,7 @@ func fakeRemoteAddr(handler http.Handler) http.Handler {
 
 // RegisterAlertmanager registers endpoints associated with the alertmanager. It will only
 // serve endpoints using the legacy http-prefix if it is not run as a single binary.
-func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, target bool) {
+func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, target, apiEnabled bool) {
 	// Ensure this route is registered before the prefixed AM route
 	a.RegisterRoute("/multitenant_alertmanager/status", am.GetStatusHandler(), false)
 
@@ -143,6 +143,13 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, tar
 	if target {
 		a.RegisterRoute("/status", am.GetStatusHandler(), false)
 		a.RegisterRoutesWithPrefix(a.cfg.LegacyHTTPPrefix, am, true)
+	}
+
+	// MultiTenant Alertmanager Experimental API routes
+	if apiEnabled {
+		a.registerRoute("/api/v1/alerts", http.HandlerFunc(am.GetUserConfig), true, "GET")
+		a.registerRoute("/api/v1/alerts", http.HandlerFunc(am.SetUserConfig), true, "POST")
+		a.registerRoute("/api/v1/alerts", http.HandlerFunc(am.DeleteUserConfig), true, "DELETE")
 	}
 }
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -147,9 +147,9 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, tar
 
 	// MultiTenant Alertmanager Experimental API routes
 	if apiEnabled {
-		a.registerRoute("/api/v1/alerts", http.HandlerFunc(am.GetUserConfig), true, "GET")
-		a.registerRoute("/api/v1/alerts", http.HandlerFunc(am.SetUserConfig), true, "POST")
-		a.registerRoute("/api/v1/alerts", http.HandlerFunc(am.DeleteUserConfig), true, "DELETE")
+		a.RegisterRoute("/api/v1/alerts", http.HandlerFunc(am.GetUserConfig), true, "GET")
+		a.RegisterRoute("/api/v1/alerts", http.HandlerFunc(am.SetUserConfig), true, "POST")
+		a.RegisterRoute("/api/v1/alerts", http.HandlerFunc(am.DeleteUserConfig), true, "DELETE")
 	}
 }
 

--- a/pkg/configs/client/client.go
+++ b/pkg/configs/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -19,6 +20,10 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	tls_cfg "github.com/cortexproject/cortex/pkg/util/tls"
+)
+
+var (
+	errBadURL = errors.New("configs_api_url is not set or valid")
 )
 
 // Config says where we can find the ruler userconfig.
@@ -54,6 +59,11 @@ type Client interface {
 
 // New creates a new ConfigClient.
 func New(cfg Config) (*ConfigDBClient, error) {
+
+	if cfg.ConfigsAPIURL.URL == nil {
+		return nil, errBadURL
+	}
+
 	client := &ConfigDBClient{
 		URL:     cfg.ConfigsAPIURL.URL,
 		Timeout: cfg.ClientTimeout,

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -483,7 +483,8 @@ func (t *Cortex) initAlertManager() (serv services.Service, err error) {
 	if err != nil {
 		return
 	}
-	t.API.RegisterAlertmanager(t.Alertmanager, t.Cfg.Target == AlertManager)
+
+	t.API.RegisterAlertmanager(t.Alertmanager, t.Cfg.Target == AlertManager, t.Cfg.Alertmanager.EnableAPI)
 	return t.Alertmanager, nil
 }
 


### PR DESCRIPTION
**What this PR does**:

Similarly to the ruler, this PR introduces a "configuration" API for the Alertmanager. It is per tenant, accepts/takes YAML and is backed up by object storage.

While I cannot take credit for this PR (as it was done by @jtlisi), I'm happy to follow up on reviews to see if I can get this merged.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
