### PR TITLE
Initialize RuntimeConfig module only if config is specified

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -122,6 +122,10 @@ func (t *Cortex) initRing() (serv services.Service, err error) {
 
 func (t *Cortex) initRuntimeConfig() (services.Service, error) {
 	if t.Cfg.RuntimeConfig.LoadPath == "" {
+		if t.Cfg.LimitsConfig.PerTenantOverrideConfig == "" {
+			// no need to initialize module if load path is empty
+			return nil, nil
+		}
 		t.Cfg.RuntimeConfig.LoadPath = t.Cfg.LimitsConfig.PerTenantOverrideConfig
 		t.Cfg.RuntimeConfig.ReloadPeriod = t.Cfg.LimitsConfig.PerTenantOverridePeriod
 	}

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -122,12 +122,13 @@ func (t *Cortex) initRing() (serv services.Service, err error) {
 
 func (t *Cortex) initRuntimeConfig() (services.Service, error) {
 	if t.Cfg.RuntimeConfig.LoadPath == "" {
-		if t.Cfg.LimitsConfig.PerTenantOverrideConfig == "" {
-			// no need to initialize module if load path is empty
-			return nil, nil
-		}
 		t.Cfg.RuntimeConfig.LoadPath = t.Cfg.LimitsConfig.PerTenantOverrideConfig
 		t.Cfg.RuntimeConfig.ReloadPeriod = t.Cfg.LimitsConfig.PerTenantOverridePeriod
+	}
+
+	if t.Cfg.RuntimeConfig.LoadPath == "" {
+		// no need to initialize module if load path is empty
+		return nil, nil
 	}
 	t.Cfg.RuntimeConfig.Loader = loadRuntimeConfig
 

--- a/pkg/cortex/runtime_config.go
+++ b/pkg/cortex/runtime_config.go
@@ -37,6 +37,9 @@ func loadRuntimeConfig(filename string) (interface{}, error) {
 }
 
 func tenantLimitsFromRuntimeConfig(c *runtimeconfig.Manager) validation.TenantLimits {
+	if c == nil {
+		return nil
+	}
 	return func(userID string) *validation.Limits {
 		cfg, ok := c.GetConfig().(*runtimeConfigValues)
 		if !ok || cfg == nil {
@@ -48,6 +51,9 @@ func tenantLimitsFromRuntimeConfig(c *runtimeconfig.Manager) validation.TenantLi
 }
 
 func multiClientRuntimeConfigChannel(manager *runtimeconfig.Manager) func() <-chan kv.MultiRuntimeConfig {
+	if manager == nil {
+		return nil
+	}
 	// returns function that can be used in MultiConfig.ConfigProvider
 	return func() <-chan kv.MultiRuntimeConfig {
 		outCh := make(chan kv.MultiRuntimeConfig, 1)

--- a/pkg/util/runtimeconfig/manager.go
+++ b/pkg/util/runtimeconfig/manager.go
@@ -56,7 +56,7 @@ func NewRuntimeConfigManager(cfg ManagerConfig, registerer prometheus.Registerer
 		}),
 	}
 
-	if registerer != nil && len(cfg.LoadPath) > 0 {
+	if registerer != nil {
 		registerer.MustRegister(mgr.configLoadSuccess)
 	}
 

--- a/pkg/util/runtimeconfig/manager.go
+++ b/pkg/util/runtimeconfig/manager.go
@@ -56,7 +56,7 @@ func NewRuntimeConfigManager(cfg ManagerConfig, registerer prometheus.Registerer
 		}),
 	}
 
-	if registerer != nil {
+	if registerer != nil && len(cfg.LoadPath) > 0 {
 		registerer.MustRegister(mgr.configLoadSuccess)
 	}
 


### PR DESCRIPTION
Signed-off-by: Annanay <annanayagarwal@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR is a follow up from #2092. Updated so that the `RuntimeConfig` module no longer initializes if the config path is empty.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
