### PR TITLE
make label name validation optional

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -154,6 +154,9 @@ type Config struct {
 
 	// for testing
 	ingesterClientFactory ring_client.PoolFactory `yaml:"-"`
+
+	// when true the distributor does not validate labels at ingest time
+	SkipLabelValidation bool
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -332,8 +335,10 @@ func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica 
 // Returns the validated series with it's labels/samples, and any error.
 func (d *Distributor) validateSeries(ts ingester_client.PreallocTimeseries, userID string) (client.PreallocTimeseries, error) {
 	labelsHistogram.Observe(float64(len(ts.Labels)))
-	if err := validation.ValidateLabels(d.limits, userID, ts.Labels); err != nil {
-		return emptyPreallocSeries, err
+	if !d.cfg.SkipLabelValidation {
+		if err := validation.ValidateLabels(d.limits, userID, ts.Labels); err != nil {
+			return emptyPreallocSeries, err
+		}
 	}
 
 	metricName, _ := extract.MetricNameFromLabelAdapters(ts.Labels)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -156,7 +156,7 @@ type Config struct {
 	ingesterClientFactory ring_client.PoolFactory `yaml:"-"`
 
 	// when true the distributor does not validate labels at ingest time
-	SkipLabelValidation bool
+	SkipLabelValidation bool `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -155,7 +155,8 @@ type Config struct {
 	// for testing
 	ingesterClientFactory ring_client.PoolFactory `yaml:"-"`
 
-	// when true the distributor does not validate labels at ingest time
+	// when true the distributor does not validate labels at ingest time, Cortex doesn't directly use
+	// this (and should never use it) but this feature is used by other projects built on top of it
 	SkipLabelValidation bool `yaml:"-"`
 }
 


### PR DESCRIPTION
introduces a new configuration parameter to allow the user to disable label name validation in the distributor.
the option to disable label name validation is useful for users who want to store non-prometheus data in cortex.

Fixes https://github.com/cortexproject/cortex/issues/2770

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
