### PR TITLE
Added support for flushing blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [ENHANCEMENT] Query-tee: Support for custom API prefix by using `-server.path-prefix` option. #2814
 * [ENHANCEMENT] Query-tee: Forward `X-Scope-OrgId` header to backend, if present in the request. #2815
 * [ENHANCEMENT] Experimental TSDB: Added `-experimental.tsdb.head-compaction-idle-timeout` option to force compaction of data in memory into a block. #2803
+* [ENHANCEMENT] Experimental TSDB: Added support for flushing blocks via `/flush`, `/shutdown` (previously these only worked for chunks storage) and by using `-experimental.tsdb.flush-blocks-on-shutdown` option. #2794
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3067,6 +3067,12 @@ bucket_store:
 # CLI flag: -experimental.tsdb.store-gateway-enabled
 [store_gateway_enabled: <boolean> | default = false]
 
+# If true, and transfer of blocks on shutdown fails or is disabled, incomplete
+# blocks are flushed to storage instead. If false, incomplete blocks will be
+# reused after restart, and uploaded when finished.
+# CLI flag: -experimental.tsdb.flush-blocks-on-shutdown
+[flush_blocks_on_shutdown: <boolean> | default = false]
+
 # limit the number of concurrently opening TSDB's on startup
 # CLI flag: -experimental.tsdb.max-tsdb-opening-concurrency-on-startup
 [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]

--- a/docs/operations/blocks-storage.md
+++ b/docs/operations/blocks-storage.md
@@ -452,6 +452,12 @@ tsdb:
   # CLI flag: -experimental.tsdb.store-gateway-enabled
   [store_gateway_enabled: <boolean> | default = false]
 
+  # If true, and transfer of blocks on shutdown fails or is disabled, incomplete
+  # blocks are flushed to storage instead. If false, incomplete blocks will be
+  # reused after restart, and uploaded when finished.
+  # CLI flag: -experimental.tsdb.flush-blocks-on-shutdown
+  [flush_blocks_on_shutdown: <boolean> | default = false]
+
   # limit the number of concurrently opening TSDB's on startup
   # CLI flag: -experimental.tsdb.max-tsdb-opening-concurrency-on-startup
   [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -24,6 +24,11 @@ const (
 // Flush triggers a flush of all the chunks and closes the flush queues.
 // Called from the Lifecycler as part of the ingester shutdown.
 func (i *Ingester) Flush() {
+	if i.cfg.TSDBEnabled {
+		i.v2LifecyclerFlush()
+		return
+	}
+
 	level.Info(util.Logger).Log("msg", "starting to flush all the chunks")
 	i.sweepUsers(true)
 	level.Info(util.Logger).Log("msg", "flushing of chunks complete")
@@ -39,6 +44,11 @@ func (i *Ingester) Flush() {
 // FlushHandler triggers a flush of all in memory chunks.  Mainly used for
 // local testing.
 func (i *Ingester) FlushHandler(w http.ResponseWriter, r *http.Request) {
+	if i.cfg.TSDBEnabled {
+		i.v2FlushHandler(w, r)
+		return
+	}
+
 	level.Info(util.Logger).Log("msg", "starting to flush all the chunks")
 	i.sweepUsers(true)
 	level.Info(util.Logger).Log("msg", "flushing of chunks complete")

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -108,7 +108,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 // Ingester deals with "in flight" chunks.  Based on Prometheus 1.x
 // MemorySeriesStorage.
 type Ingester struct {
-	services.Service
+	*services.BasicService
 
 	cfg          Config
 	clientConfig client.Config
@@ -207,7 +207,7 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 	i.subservicesWatcher = services.NewFailureWatcher()
 	i.subservicesWatcher.WatchService(i.lifecycler)
 
-	i.Service = services.NewBasicService(i.starting, i.loop, i.stopping)
+	i.BasicService = services.NewBasicService(i.starting, i.loop, i.stopping)
 	return i, nil
 }
 
@@ -276,7 +276,7 @@ func NewForFlusher(cfg Config, clientConfig client.Config, chunkStore ChunkStore
 		wal:          &noopWAL{},
 	}
 
-	i.Service = services.NewBasicService(i.startingForFlusher, i.loop, i.stopping)
+	i.BasicService = services.NewBasicService(i.startingForFlusher, i.loop, i.stopping)
 	return i, nil
 }
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1059,6 +1059,12 @@ func (i *Ingester) shipBlocksLoop(ctx context.Context) error {
 
 		case <-i.TSDBState.shipTrigger:
 			i.shipBlocks(ctx)
+			// This complements log message from v2FlushHandler.
+			if e := ctx.Err(); e == nil {
+				level.Info(util.Logger).Log("msg", "finished shipping of TSDB blocks")
+			} else {
+				level.Info(util.Logger).Log("msg", "shipping of TSDB blocks finished prematurely", "err", e)
+			}
 
 		case <-ctx.Done():
 			return nil

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1211,7 +1211,7 @@ sendLoop:
 
 // This method is called as part of Lifecycler's shutdown, to flush all data.
 // Lifecycler shutdown happens as part of Ingester shutdown (see stoppingV2 method).
-// Samples are not received at this stage. Shipping service has already been stopped as well.
+// Samples are not received at this stage. Compaction and Shipping loops have already been stopped as well.
 func (i *Ingester) v2LifecyclerFlush() {
 	level.Info(util.Logger).Log("msg", "starting to flush and ship TSDB blocks")
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1160,7 +1160,7 @@ func (i *Ingester) compactBlocks(ctx context.Context, force bool) {
 
 		case i.cfg.TSDBConfig.HeadCompactionIdleTimeout > 0 && userDB.isIdle(time.Now(), i.cfg.TSDBConfig.HeadCompactionIdleTimeout):
 			reason = "idle"
-			level.Debug(util.Logger).Log("msg", "TSDB is idle, forcing compaction", "user", userID)
+			level.Info(util.Logger).Log("msg", "TSDB is idle, forcing compaction", "user", userID)
 			err = userDB.CompactHead(tsdb.NewRangeHead(h, h.MinTime(), h.MaxTime()))
 
 		default:

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1160,7 +1160,7 @@ func (i *Ingester) compactBlocks(ctx context.Context, force bool) {
 
 		case i.cfg.TSDBConfig.HeadCompactionIdleTimeout > 0 && userDB.isIdle(time.Now(), i.cfg.TSDBConfig.HeadCompactionIdleTimeout):
 			reason = "idle"
-			level.Debug(util.Logger).Log("msg", "TSDB is idle, forcing compaction")
+			level.Debug(util.Logger).Log("msg", "TSDB is idle, forcing compaction", "user", userID)
 			err = userDB.CompactHead(tsdb.NewRangeHead(h, h.MinTime(), h.MaxTime()))
 
 		default:

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1230,7 +1230,7 @@ func (i *Ingester) v2FlushHandler(w http.ResponseWriter, _ *http.Request) {
 	go func() {
 		ingCtx := i.BasicService.ServiceContext()
 		if ingCtx == nil || ingCtx.Err() != nil {
-			// Not started or already finished.
+			level.Info(util.Logger).Log("msg", "flushing TSDB blocks: ingester not running, ignoring flush request")
 			return
 		}
 
@@ -1241,7 +1241,7 @@ func (i *Ingester) v2FlushHandler(w http.ResponseWriter, _ *http.Request) {
 		case i.TSDBState.forceCompactTrigger <- ch:
 			// Compacting now.
 		case <-ingCtx.Done():
-			level.Info(util.Logger).Log("msg", "failed to compact TSDB blocks, ingester not running anymore")
+			level.Warn(util.Logger).Log("msg", "failed to compact TSDB blocks, ingester not running anymore")
 			return
 		}
 
@@ -1250,7 +1250,7 @@ func (i *Ingester) v2FlushHandler(w http.ResponseWriter, _ *http.Request) {
 		case <-ch:
 			level.Info(util.Logger).Log("msg", "finished compacting TSDB blocks")
 		case <-ingCtx.Done():
-			level.Info(util.Logger).Log("msg", "failed to compact TSDB blocks, ingester not running anymore")
+			level.Warn(util.Logger).Log("msg", "failed to compact TSDB blocks, ingester not running anymore")
 			return
 		}
 
@@ -1261,7 +1261,7 @@ func (i *Ingester) v2FlushHandler(w http.ResponseWriter, _ *http.Request) {
 			case i.TSDBState.shipTrigger <- ch:
 				// shipping now
 			case <-ingCtx.Done():
-				level.Info(util.Logger).Log("msg", "failed to ship TSDB blocks, ingester not running anymore")
+				level.Warn(util.Logger).Log("msg", "failed to ship TSDB blocks, ingester not running anymore")
 				return
 			}
 
@@ -1270,7 +1270,7 @@ func (i *Ingester) v2FlushHandler(w http.ResponseWriter, _ *http.Request) {
 			case <-ch:
 				level.Info(util.Logger).Log("msg", "shipping of TSDB blocks finished")
 			case <-ingCtx.Done():
-				level.Info(util.Logger).Log("msg", "failed to ship TSDB blocks, ingester not running anymore")
+				level.Warn(util.Logger).Log("msg", "failed to ship TSDB blocks, ingester not running anymore")
 				return
 			}
 		}

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1163,15 +1163,12 @@ func (i *Ingester) forceCompactBlocks(ctx context.Context) {
 		}
 
 		h := userDB.Head()
-		min := h.MinTime()
-		max := h.MaxTime()
-
-		if min == max {
+		if h.NumSeries() == 0 {
 			// No samples in the HEAD, no need to compact.
 			return
 		}
 
-		err := userDB.CompactHead(tsdb.NewRangeHead(h, min, max))
+		err := userDB.CompactHead(tsdb.NewRangeHead(h, h.MinTime(), h.MaxTime()))
 		if err != nil {
 			level.Warn(util.Logger).Log("msg", "TSDB blocks force-compaction for user has failed", "user", userID, "err", err)
 		} else {

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -1407,7 +1407,7 @@ func verifyCompactedHead(t *testing.T, i *Ingester) {
 	require.NotNil(t, db)
 
 	h := db.Head()
-	require.Equal(t, h.MinTime(), h.MaxTime())
+	require.Zero(t, h.NumSeries())
 }
 
 func pushSingleSample(t *testing.T, i *Ingester) {

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -1303,8 +1302,6 @@ func (m *shipperMock) Sync(ctx context.Context) (uploaded int, err error) {
 }
 
 func TestIngester_flushing(t *testing.T) {
-	util.Logger = log.NewLogfmtLogger(os.Stdout)
-
 	for name, tc := range map[string]struct {
 		setupIngester func(cfg *Config)
 		action        func(t *testing.T, i *Ingester, m *shipperMock)

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -145,7 +145,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.StripeSize, "experimental.tsdb.stripe-size", 16384, "The number of shards of series to use in TSDB (must be a power of 2). Reducing this will decrease memory footprint, but can negatively impact performance.")
 	f.BoolVar(&cfg.WALCompressionEnabled, "experimental.tsdb.wal-compression-enabled", false, "True to enable TSDB WAL compression.")
 	f.BoolVar(&cfg.StoreGatewayEnabled, "experimental.tsdb.store-gateway-enabled", false, "True if the Cortex cluster is running the store-gateway service and the querier should query the bucket store via the store-gateway.")
-	f.BoolVar(&cfg.FlushBlocksOnShutdown, "experimental.tsdb.flush-blocks-on-shutdown", false, "If true, and transfer of blocks on shutdown fails or is disabled, incomplete blocks are flushed to storage instead.")
+	f.BoolVar(&cfg.FlushBlocksOnShutdown, "experimental.tsdb.flush-blocks-on-shutdown", false, "If true, and transfer of blocks on shutdown fails or is disabled, incomplete blocks are flushed to storage instead. If false, incomplete blocks will be reused after restart, and uploaded when finished.")
 }
 
 // Validate the config.

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	StripeSize                int               `yaml:"stripe_size"`
 	WALCompressionEnabled     bool              `yaml:"wal_compression_enabled"`
 	StoreGatewayEnabled       bool              `yaml:"store_gateway_enabled"`
+	FlushBlocksOnShutdown     bool              `yaml:"flush_blocks_on_shutdown"`
 
 	// MaxTSDBOpeningConcurrencyOnStartup limits the number of concurrently opening TSDB's during startup
 	MaxTSDBOpeningConcurrencyOnStartup int `yaml:"max_tsdb_opening_concurrency_on_startup"`
@@ -144,6 +145,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.StripeSize, "experimental.tsdb.stripe-size", 16384, "The number of shards of series to use in TSDB (must be a power of 2). Reducing this will decrease memory footprint, but can negatively impact performance.")
 	f.BoolVar(&cfg.WALCompressionEnabled, "experimental.tsdb.wal-compression-enabled", false, "True to enable TSDB WAL compression.")
 	f.BoolVar(&cfg.StoreGatewayEnabled, "experimental.tsdb.store-gateway-enabled", false, "True if the Cortex cluster is running the store-gateway service and the querier should query the bucket store via the store-gateway.")
+	f.BoolVar(&cfg.FlushBlocksOnShutdown, "experimental.tsdb.flush-blocks-on-shutdown", false, "If true, and transfer of blocks on shutdown fails or is disabled, incomplete blocks are flushed to storage instead.")
 }
 
 // Validate the config.


### PR DESCRIPTION
**What this PR does**: This PR adds support for flushing blocks.

Flushing can be triggered by:
- using `-experimental.tsdb.flush-blocks-on-shutdown` option, honored when ingester shuts down
- using `/flush` endpoint (works for chunks too) -- this triggers flush and shipping (if enabled), but endpoint returns immediately. There are log messages written after flushing and shipping (if enabled) has finished
- using `/shutdown` endpoint (works for chunks too) -- this shuts down ingester with flush flag enabled. Endpoint waits until flushing and shipping has finished.

This follows the proposal from PR #2717.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
