### PR TITLE
fix cache generation keys prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762
 * [BUGFIX] Query Frontend: Do not re-split sharded requests around ingester boundaries. #2766
+* [BUGFIX] Experimental Delete Series: Fixed a problem with cache generation numbers prefixed to cache keys. #2800
 
 ## 1.2.0 / 2020-06-xx
 (in progress of release: current release candidate is https://github.com/cortexproject/cortex/releases/tag/v1.2.0-rc.0)

--- a/pkg/chunk/cache/cache_gen.go
+++ b/pkg/chunk/cache/cache_gen.go
@@ -58,32 +58,35 @@ func ExtractCacheGenNumber(ctx context.Context) string {
 	return cacheGenNumber
 }
 
-// addCacheGenNumToCacheKeys adds gen number to keys as suffix.
+// addCacheGenNumToCacheKeys adds gen number to keys as prefix.
 func addCacheGenNumToCacheKeys(ctx context.Context, keys []string) []string {
 	cacheGen := ExtractCacheGenNumber(ctx)
 	if cacheGen == "" {
 		return keys
 	}
 
+	prefixedKeys := make([]string, len(keys))
+
 	for i := range keys {
-		keys[i] = cacheGen + keys[i]
+		prefixedKeys[i] = cacheGen + keys[i]
 	}
 
-	return keys
+	return prefixedKeys
 }
 
-// removeCacheGenNumFromKeys removes suffixed gen number from keys.
+// removeCacheGenNumFromKeys removes prefixed gen number from keys.
 func removeCacheGenNumFromKeys(ctx context.Context, keys []string) []string {
 	cacheGen := ExtractCacheGenNumber(ctx)
 	if cacheGen == "" {
 		return keys
 	}
 
-	cacheGenSuffixLen := len(cacheGen) - 1
+	unprefixedKeys := make([]string, len(keys))
+	cacheGenPrefixLen := len(cacheGen)
 
 	for i := range keys {
-		keys[i] = keys[i][cacheGenSuffixLen:]
+		unprefixedKeys[i] = keys[i][cacheGenPrefixLen:]
 	}
 
-	return keys
+	return unprefixedKeys
 }

--- a/pkg/chunk/cache/cache_gen_test.go
+++ b/pkg/chunk/cache/cache_gen_test.go
@@ -1,0 +1,39 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheGenNumCacheKeysPrefix(t *testing.T) {
+	keys := []string{"foo", "bar", "baz"}
+
+	for _, tc := range []struct {
+		name   string
+		prefix string
+	}{
+		{
+			name: "empty-prefix",
+		},
+		{
+			name:   "with-prefix",
+			prefix: "prefix",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := InjectCacheGenNumber(context.Background(), tc.prefix)
+
+			prefixedKeys := addCacheGenNumToCacheKeys(ctx, keys)
+			for i, key := range prefixedKeys {
+				require.Equal(t, tc.prefix+keys[i], key)
+			}
+
+			unprefixedKeys := removeCacheGenNumFromKeys(ctx, prefixedKeys)
+			for i, key := range unprefixedKeys {
+				require.Equal(t, keys[i], key)
+			}
+		})
+	}
+}

--- a/pkg/chunk/cache/cache_gen_test.go
+++ b/pkg/chunk/cache/cache_gen_test.go
@@ -29,11 +29,13 @@ func TestCacheGenNumCacheKeysPrefix(t *testing.T) {
 			for i, key := range prefixedKeys {
 				require.Equal(t, tc.prefix+keys[i], key)
 			}
+			require.Len(t, prefixedKeys, len(keys))
 
 			unprefixedKeys := removeCacheGenNumFromKeys(ctx, prefixedKeys)
 			for i, key := range unprefixedKeys {
 				require.Equal(t, keys[i], key)
 			}
+			require.Len(t, unprefixedKeys, len(keys))
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Fixes a problem with removing cache generation number from keys prefixed with it.
Also adds required tests.

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
