### PR TITLE
track oldest delete request age since their cancellation period is over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * `cortex_bucket_stores_gate_queries_in_flight`
   * `cortex_bucket_stores_gate_duration_seconds`
 * [CHANGE] Metric `cortex_ingester_flush_reasons` has been renamed to `cortex_ingester_series_flushed_total`, and is now incremented during flush, not when series is enqueued for flushing. #2802
-* [CHANGE] Experimental Delete Series: Metric `purger_pending_delete_requests_count` would track age of delete requests since they are over their cancellation period instead of their creation time. #2806
+* [CHANGE] Experimental Delete Series: Metric `cortex_purger_oldest_pending_delete_request_age_seconds` would track age of delete requests since they are over their cancellation period instead of their creation time. #2806
 * [FEATURE] Introduced `ruler.for-outage-tolerance`, Max time to tolerate outage for restoring "for" state of alert. #2783
 * [FEATURE] Introduced `ruler.for-grace-period`, Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. #2783
 * [FEATURE] Introduced `ruler.resend-delay`, Minimum amount of time to wait before resending an alert to Alertmanager. #2783

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * `cortex_bucket_stores_gate_queries_in_flight`
   * `cortex_bucket_stores_gate_duration_seconds`
 * [CHANGE] Metric `cortex_ingester_flush_reasons` has been renamed to `cortex_ingester_series_flushed_total`, and is now incremented during flush, not when series is enqueued for flushing. #2802
+* [CHANGE] Experimental Delete Series: Metric `purger_pending_delete_requests_count` would track age of delete requests since they are over their cancellation period instead of their creation time. #2806
 * [FEATURE] Introduced `ruler.for-outage-tolerance`, Max time to tolerate outage for restoring "for" state of alert. #2783
 * [FEATURE] Introduced `ruler.for-grace-period`, Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. #2783
 * [FEATURE] Introduced `ruler.resend-delay`, Minimum amount of time to wait before resending an alert to Alertmanager. #2783

--- a/pkg/chunk/purger/purger.go
+++ b/pkg/chunk/purger/purger.go
@@ -248,6 +248,10 @@ func (p *Purger) workerJobCleanup(job workerJob) {
 			default:
 				// already sent
 			}
+		} else if len(p.usersWithPendingRequests) == 0 {
+			// there are no pending requests from any of the users, set the oldest pending request and number of pending requests to 0
+			p.metrics.oldestPendingDeleteRequestAgeSeconds.Set(0)
+			p.metrics.pendingDeleteRequestsCount.Set(0)
 		}
 	} else {
 		p.pendingPlansCountMtx.Unlock()

--- a/pkg/chunk/purger/purger.go
+++ b/pkg/chunk/purger/purger.go
@@ -71,7 +71,7 @@ func newPurgerMetrics(r prometheus.Registerer) *purgerMetrics {
 	m.pendingDeleteRequestsCount = promauto.With(r).NewGauge(prometheus.GaugeOpts{
 		Namespace: "cortex",
 		Name:      "purger_pending_delete_requests_count",
-		Help:      "Count of requests which are in process or are ready to be processed",
+		Help:      "Count of delete requests which are over their cancellation period and have not finished processing yet",
 	})
 
 	return &m

--- a/pkg/chunk/purger/purger_test.go
+++ b/pkg/chunk/purger/purger_test.go
@@ -429,9 +429,6 @@ func TestPurger_Metrics(t *testing.T) {
 		return testutil.ToFloat64(purger.metrics.deleteRequestsProcessedTotal)
 	})
 
-	// load new delete requests for processing which should update the metrics
-	require.NoError(t, purger.pullDeleteRequestsToPlanDeletes())
-
 	// there must be 0 pending delete requests so the age for oldest pending must be 0
 	require.InDelta(t, float64(0), testutil.ToFloat64(purger.metrics.oldestPendingDeleteRequestAgeSeconds), 1)
 	require.Equal(t, float64(0), testutil.ToFloat64(purger.metrics.pendingDeleteRequestsCount))

--- a/pkg/chunk/purger/purger_test.go
+++ b/pkg/chunk/purger/purger_test.go
@@ -410,8 +410,8 @@ func TestPurger_Metrics(t *testing.T) {
 	// load new delete requests for processing
 	require.NoError(t, purger.pullDeleteRequestsToPlanDeletes())
 
-	// there must be 2 pending delete requests, oldest being 3 days old
-	require.InDelta(t, float64(3*86400), testutil.ToFloat64(purger.metrics.oldestPendingDeleteRequestAgeSeconds), 1)
+	// there must be 2 pending delete requests, oldest being 2 days old since its cancellation time is over
+	require.InDelta(t, float64(2*86400), testutil.ToFloat64(purger.metrics.oldestPendingDeleteRequestAgeSeconds), 1)
 	require.Equal(t, float64(2), testutil.ToFloat64(purger.metrics.pendingDeleteRequestsCount))
 
 	// start loop to process requests

--- a/pkg/testexporter/correctness/runner_test.go
+++ b/pkg/testexporter/correctness/runner_test.go
@@ -27,7 +27,6 @@ func TestMinQueryTime(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		//require.Equal(t, tt.expected, tc.MinQueryTime())
-		assert.WithinDuration(t, tt.expected, calculateMinQueryTime(tt.durationQuerySince, tt.timeQueryStart), 5*time.Millisecond)
+		assert.WithinDuration(t, tt.expected, calculateMinQueryTime(tt.durationQuerySince, tt.timeQueryStart), 50*time.Millisecond)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Changes the tracking of the age of delete requests from "since creation time" to "since they are over their cancellation period".
This would help with defining alerts and SLO/SLAs since the cancellation period is configurable now.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
