### PR TITLE
Agnostic Ruler

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -457,7 +457,14 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 	t.Cfg.Ruler.Ring.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	queryable, engine := querier.New(t.Cfg.Querier, t.Distributor, t.StoreQueryables, t.TombstonesLoader, prometheus.DefaultRegisterer)
 
-	t.Ruler, err = ruler.NewRuler(t.Cfg.Ruler, engine, queryable, t.Distributor, prometheus.DefaultRegisterer, util.Logger)
+	t.Ruler, err = ruler.NewRuler(
+		t.Cfg.Ruler,
+		ruler.PromDelayedQueryFunc(engine, queryable),
+		ruler.DefaultAppendableHistoryFunc(t.Distributor, queryable),
+		prometheus.DefaultRegisterer,
+		nil,
+		util.Logger,
+	)
 	if err != nil {
 		return
 	}

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -2,28 +2,44 @@ package ruler
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/cortexproject/cortex/pkg/ruler/rules"
 )
+
+// AppendableHistoryFunc allows creation of an Appendable and AlertHistory to be joined. The default implementation
+// does not take advantage of this option.
+type AppendableHistoryFunc = func(userID string, opts *rules.ManagerOptions) (rules.Appendable, rules.TenantAlertHistory)
+
+// This is the default implementation which returns an unlinked Appendable/AlertHistory.
+func DefaultAppendableHistoryFunc(p Pusher, q storage.Queryable) AppendableHistoryFunc {
+	return func(userID string, opts *rules.ManagerOptions) (rules.Appendable, rules.TenantAlertHistory) {
+		return &appender{
+			pusher: p,
+			userID: userID,
+		}, rules.NewMetricsHistory(q, opts)
+	}
+}
 
 // Pusher is an ingester server that accepts pushes.
 type Pusher interface {
 	Push(context.Context, *client.WriteRequest) (*client.WriteResponse, error)
 }
+
 type appender struct {
 	pusher  Pusher
 	labels  []labels.Labels
 	samples []client.Sample
 	userID  string
 }
+
+func (a *appender) Appender(_ rules.Rule) (storage.Appender, error) { return a, nil }
 
 func (a *appender) Add(l labels.Labels, t int64, v float64) (uint64, error) {
 	a.labels = append(a.labels, l)
@@ -53,47 +69,16 @@ func (a *appender) Rollback() error {
 	return nil
 }
 
-// TSDB fulfills the storage.Storage interface for prometheus manager
-// it allows for alerts to be restored by the manager
-type tsdb struct {
-	pusher    Pusher
-	userID    string
-	queryable storage.Queryable
-}
-
-// Appender returns a storage.Appender
-func (t *tsdb) Appender() storage.Appender {
-	return &appender{
-		pusher: t.pusher,
-		userID: t.userID,
+// PromDelayedQueryFunc returns a DelayedQueryFunc bound to a promql engine.
+func PromDelayedQueryFunc(engine *promql.Engine, q storage.Queryable) DelayedQueryFunc {
+	return func(delay time.Duration) rules.QueryFunc {
+		orig := rules.EngineQueryFunc(engine, q)
+		return func(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
+			return orig(ctx, qs, t.Add(-delay))
+		}
 	}
 }
 
-// Querier returns a new Querier on the storage.
-func (t *tsdb) Querier(ctx context.Context, mint int64, maxt int64) (storage.Querier, error) {
-	return t.queryable.Querier(ctx, mint, maxt)
-}
-
-// ChunkQuerier returns an error as it is not implemented.
-func (t *tsdb) ChunkQuerier(ctx context.Context, mint int64, maxt int64) (storage.ChunkQuerier, error) {
-	return nil, errors.New("ChunkQuerier not implemented")
-}
-
-// StartTime returns the oldest timestamp stored in the storage.
-func (t *tsdb) StartTime() (int64, error) {
-	return 0, nil
-}
-
-// Close closes the storage and all its underlying resources.
-func (t *tsdb) Close() error {
-	return nil
-}
-
-// engineQueryFunc returns a new query function using the rules.EngineQueryFunc function
-// and passing an altered timestamp.
-func engineQueryFunc(engine *promql.Engine, q storage.Queryable, delay time.Duration) rules.QueryFunc {
-	orig := rules.EngineQueryFunc(engine, q)
-	return func(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
-		return orig(ctx, qs, t.Add(-delay))
-	}
-}
+// DelayedQueryFunc consumes a queryable and a delay, returning a Queryfunc which
+// takes this delay into account when executing against the queryable.
+type DelayedQueryFunc = func(time.Duration) rules.QueryFunc

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -20,9 +20,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/notifier"
-	"github.com/prometheus/prometheus/promql"
-	promRules "github.com/prometheus/prometheus/rules"
-	promStorage "github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/strutil"
 	"github.com/weaveworks/common/user"
 	"golang.org/x/net/context/ctxhttp"
@@ -148,12 +145,12 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 type Ruler struct {
 	services.Service
 
-	cfg         Config
-	engine      *promql.Engine
-	queryable   promStorage.Queryable
-	pusher      Pusher
-	alertURL    *url.URL
-	notifierCfg *config.Config
+	cfg               Config
+	appendableHistory AppendableHistoryFunc
+	alertURL          *url.URL
+	notifierCfg       *config.Config
+	queryFunc         DelayedQueryFunc
+	parseExpr         func(string) (fmt.Stringer, error)
 
 	lifecycler  *ring.BasicLifecycler
 	ring        *ring.Ring
@@ -162,7 +159,7 @@ type Ruler struct {
 	store          rules.RuleStore
 	mapper         *mapper
 	userManagerMtx sync.Mutex
-	userManagers   map[string]*promRules.Manager
+	userManagers   map[string]*rules.Manager
 
 	// Per-user notifiers with separate queues.
 	notifiersMtx sync.Mutex
@@ -173,7 +170,7 @@ type Ruler struct {
 }
 
 // NewRuler creates a new ruler from a distributor and chunk store.
-func NewRuler(cfg Config, engine *promql.Engine, queryable promStorage.Queryable, pusher Pusher, reg prometheus.Registerer, logger log.Logger) (*Ruler, error) {
+func NewRuler(cfg Config, queryFunc DelayedQueryFunc, appendableHist AppendableHistoryFunc, reg prometheus.Registerer, parseExpr func(string) (fmt.Stringer, error), logger log.Logger) (*Ruler, error) {
 	ncfg, err := buildNotifierConfig(&cfg)
 	if err != nil {
 		return nil, err
@@ -185,18 +182,18 @@ func NewRuler(cfg Config, engine *promql.Engine, queryable promStorage.Queryable
 	}
 
 	ruler := &Ruler{
-		cfg:          cfg,
-		engine:       engine,
-		queryable:    queryable,
-		alertURL:     cfg.ExternalURL.URL,
-		notifierCfg:  ncfg,
-		notifiers:    map[string]*rulerNotifier{},
-		store:        ruleStore,
-		pusher:       pusher,
-		mapper:       newMapper(cfg.RulePath, logger),
-		userManagers: map[string]*promRules.Manager{},
-		registry:     reg,
-		logger:       logger,
+		cfg:               cfg,
+		queryFunc:         queryFunc,
+		parseExpr:         parseExpr,
+		alertURL:          cfg.ExternalURL.URL,
+		notifierCfg:       ncfg,
+		notifiers:         map[string]*rulerNotifier{},
+		store:             ruleStore,
+		appendableHistory: appendableHist,
+		mapper:            newMapper(cfg.RulePath, logger),
+		userManagers:      map[string]*rules.Manager{},
+		registry:          reg,
+		logger:            logger,
 	}
 
 	if cfg.EnableSharding {
@@ -278,7 +275,7 @@ func (r *Ruler) stopping(_ error) error {
 	for user, manager := range r.userManagers {
 		level.Debug(r.logger).Log("msg", "shutting down user  manager", "user", user)
 		wg.Add(1)
-		go func(manager *promRules.Manager, user string) {
+		go func(manager *rules.Manager, user string) {
 			manager.Stop()
 			wg.Done()
 			level.Debug(r.logger).Log("msg", "user manager shut down", "user", user)
@@ -294,13 +291,13 @@ func (r *Ruler) stopping(_ error) error {
 // It filters any non-firing alerts from the input.
 //
 // Copied from Prometheus's main.go.
-func sendAlerts(n *notifier.Manager, externalURL string) promRules.NotifyFunc {
-	return func(ctx context.Context, expr string, alerts ...*promRules.Alert) {
+func sendAlerts(n *notifier.Manager, externalURL string) rules.NotifyFunc {
+	return func(ctx context.Context, expr string, alerts ...*rules.Alert) {
 		var res []*notifier.Alert
 
 		for _, alert := range alerts {
 			// Only send actually firing alerts.
-			if alert.State == promRules.StatePending {
+			if alert.State == rules.StatePending {
 				continue
 			}
 			a := &notifier.Alert{
@@ -519,12 +516,7 @@ func (r *Ruler) syncManager(ctx context.Context, user string, groups store.RuleG
 
 // newManager creates a prometheus rule manager wrapped with a user id
 // configured storage, appendable, notifier, and instrumentation
-func (r *Ruler) newManager(ctx context.Context, userID string) (*promRules.Manager, error) {
-	tsdb := &tsdb{
-		pusher:    r.pusher,
-		userID:    userID,
-		queryable: r.queryable,
-	}
+func (r *Ruler) newManager(ctx context.Context, userID string) (*rules.Manager, error) {
 
 	notifier, err := r.getOrCreateNotifier(userID)
 	if err != nil {
@@ -535,10 +527,9 @@ func (r *Ruler) newManager(ctx context.Context, userID string) (*promRules.Manag
 	reg := prometheus.WrapRegistererWith(prometheus.Labels{"user": userID}, r.registry)
 	reg = prometheus.WrapRegistererWithPrefix("cortex_", reg)
 	logger := log.With(r.logger, "user", userID)
-	opts := &promRules.ManagerOptions{
-		Appendable:      tsdb,
-		TSDB:            tsdb,
-		QueryFunc:       engineQueryFunc(r.engine, r.queryable, r.cfg.EvaluationDelay),
+	opts := &rules.ManagerOptions{
+		QueryFunc:       r.queryFunc(r.cfg.EvaluationDelay),
+		ParseExpr:       r.parseExpr,
 		Context:         user.InjectOrgID(ctx, userID),
 		ExternalURL:     r.alertURL,
 		NotifyFunc:      sendAlerts(notifier, r.alertURL.String()),
@@ -548,7 +539,10 @@ func (r *Ruler) newManager(ctx context.Context, userID string) (*promRules.Manag
 		ForGracePeriod:  r.cfg.ForGracePeriod,
 		ResendDelay:     r.cfg.ResendDelay,
 	}
-	return promRules.NewManager(opts), nil
+	app, hist := r.appendableHistory(userID, opts)
+	opts.Appendable = app
+	opts.AlertHistory = hist
+	return rules.NewManager(opts), nil
 }
 
 // GetRules retrieves the running rules from this ruler and all running rulers in the ring if
@@ -567,7 +561,7 @@ func (r *Ruler) GetRules(ctx context.Context) ([]*GroupStateDesc, error) {
 }
 
 func (r *Ruler) getLocalRules(userID string) ([]*GroupStateDesc, error) {
-	var groups []*promRules.Group
+	var groups []*rules.Group
 	r.userManagerMtx.Lock()
 	if mngr, exists := r.userManagers[userID]; exists {
 		groups = mngr.RuleGroups()
@@ -604,7 +598,7 @@ func (r *Ruler) getLocalRules(userID string) ([]*GroupStateDesc, error) {
 
 			var ruleDesc *RuleStateDesc
 			switch rule := r.(type) {
-			case *promRules.AlertingRule:
+			case *rules.AlertingRule:
 				rule.ActiveAlerts()
 				alerts := []*AlertStateDesc{}
 				for _, a := range rule.ActiveAlerts() {
@@ -635,7 +629,7 @@ func (r *Ruler) getLocalRules(userID string) ([]*GroupStateDesc, error) {
 					EvaluationTimestamp: rule.GetEvaluationTimestamp(),
 					EvaluationDuration:  rule.GetEvaluationDuration(),
 				}
-			case *promRules.RecordingRule:
+			case *rules.RecordingRule:
 				ruleDesc = &RuleStateDesc{
 					Rule: &rules.RuleDesc{
 						Record: rule.Name(),

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -82,7 +82,7 @@ func newRuler(t *testing.T, cfg Config) (*Ruler, func()) {
 
 	l := log.NewLogfmtLogger(os.Stdout)
 	l = level.NewFilter(l, level.AllowInfo())
-	ruler, err := NewRuler(cfg, engine, noopQueryable, pusher, prometheus.NewRegistry(), l)
+	ruler, err := NewRuler(cfg, PromDelayedQueryFunc(engine, noopQueryable), DefaultAppendableHistoryFunc(pusher, noopQueryable), prometheus.NewRegistry(), nil, l)
 	require.NoError(t, err)
 
 	return ruler, cleanup

--- a/pkg/ruler/rules/alerting.go
+++ b/pkg/ruler/rules/alerting.go
@@ -1,0 +1,555 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	html_template "html/template"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/template"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+const (
+	// AlertMetricName is the metric name for synthetic alert timeseries.
+	alertMetricName = "ALERTS"
+	// AlertForStateMetricName is the metric name for 'for' state of alert.
+	AlertForStateMetricName = "ALERTS_FOR_STATE"
+
+	// AlertNameLabel is the label name indicating the name of an alert.
+	alertNameLabel = "alertname"
+	// AlertStateLabel is the label name indicating the state of an alert.
+	alertStateLabel = "alertstate"
+)
+
+// AlertState denotes the state of an active alert.
+type AlertState int
+
+const (
+	// StateInactive is the state of an alert that is neither firing nor pending.
+	StateInactive AlertState = iota
+	// StatePending is the state of an alert that has been active for less than
+	// the configured threshold duration.
+	StatePending
+	// StateFiring is the state of an alert that has been active for longer than
+	// the configured threshold duration.
+	StateFiring
+)
+
+func (s AlertState) String() string {
+	switch s {
+	case StateInactive:
+		return "inactive"
+	case StatePending:
+		return "pending"
+	case StateFiring:
+		return "firing"
+	}
+	panic(errors.Errorf("unknown alert state: %s", s.String()))
+}
+
+// Alert is the user-level representation of a single instance of an alerting rule.
+type Alert struct {
+	State AlertState
+
+	Labels      labels.Labels
+	Annotations labels.Labels
+
+	// The value at the last evaluation of the alerting expression.
+	Value float64
+	// The interval during which the condition of this alert held true.
+	// ResolvedAt will be 0 to indicate a still active alert.
+	ActiveAt   time.Time
+	FiredAt    time.Time
+	ResolvedAt time.Time
+	LastSentAt time.Time
+	ValidUntil time.Time
+}
+
+func (a *Alert) needsSending(ts time.Time, resendDelay time.Duration) bool {
+	if a.State == StatePending {
+		return false
+	}
+
+	// if an alert has been resolved since the last send, resend it
+	if a.ResolvedAt.After(a.LastSentAt) {
+		return true
+	}
+
+	return a.LastSentAt.Add(resendDelay).Before(ts)
+}
+
+// An AlertingRule generates alerts from its vector expression.
+type AlertingRule struct {
+	// The name of the alert.
+	name string
+	// The vector expression from which to generate alerts.
+	// Cortex-Note: this is changed to fmt.Stringer instead of a parser.Expr in order to facilitate arbitrary expressions.
+	vector fmt.Stringer
+	// The duration for which a labelset needs to persist in the expression
+	// output vector before an alert transitions from Pending to Firing state.
+	holdDuration time.Duration
+	// Extra labels to attach to the resulting alert sample vectors.
+	labels labels.Labels
+	// Non-identifying key/value pairs.
+	annotations labels.Labels
+	// External labels from the global config.
+	externalLabels map[string]string
+	// true if old state has been restored. We start persisting samples for ALERT_FOR_STATE
+	// only after the restoration.
+	restored bool
+	// Protects the below.
+	mtx sync.Mutex
+	// Time in seconds taken to evaluate rule.
+	evaluationDuration time.Duration
+	// Timestamp of last evaluation of rule.
+	evaluationTimestamp time.Time
+	// The health of the alerting rule.
+	health RuleHealth
+	// The last error seen by the alerting rule.
+	lastError error
+	// A map of alerts which are currently active (Pending or Firing), keyed by
+	// the fingerprint of the labelset they correspond to.
+	active map[uint64]*Alert
+
+	logger log.Logger
+}
+
+// NewAlertingRule constructs a new AlertingRule.
+func NewAlertingRule(
+	name string, vec fmt.Stringer, hold time.Duration,
+	labels, annotations, externalLabels labels.Labels,
+	restored bool, logger log.Logger,
+) *AlertingRule {
+	el := make(map[string]string, len(externalLabels))
+	for _, lbl := range externalLabels {
+		el[lbl.Name] = lbl.Value
+	}
+
+	return &AlertingRule{
+		name:           name,
+		vector:         vec,
+		holdDuration:   hold,
+		labels:         labels,
+		annotations:    annotations,
+		externalLabels: el,
+		health:         HealthUnknown,
+		active:         map[uint64]*Alert{},
+		logger:         logger,
+		restored:       restored,
+	}
+}
+
+// Name returns the name of the alerting rule.
+func (r *AlertingRule) Name() string {
+	return r.name
+}
+
+// SetLastError sets the current error seen by the alerting rule.
+func (r *AlertingRule) SetLastError(err error) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	r.lastError = err
+}
+
+// LastError returns the last error seen by the alerting rule.
+func (r *AlertingRule) LastError() error {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return r.lastError
+}
+
+// SetHealth sets the current health of the alerting rule.
+func (r *AlertingRule) SetHealth(health RuleHealth) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	r.health = health
+}
+
+// Health returns the current health of the alerting rule.
+func (r *AlertingRule) Health() RuleHealth {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return r.health
+}
+
+// Query returns the query expression of the alerting rule.
+func (r *AlertingRule) Query() fmt.Stringer {
+	return r.vector
+}
+
+// Duration returns the hold duration of the alerting rule.
+func (r *AlertingRule) Duration() time.Duration {
+	return r.holdDuration
+}
+
+// Labels returns the labels of the alerting rule.
+func (r *AlertingRule) Labels() labels.Labels {
+	return r.labels
+}
+
+// Annotations returns the annotations of the alerting rule.
+func (r *AlertingRule) Annotations() labels.Labels {
+	return r.annotations
+}
+
+func (r *AlertingRule) sample(alert *Alert, ts time.Time) promql.Sample {
+	lb := labels.NewBuilder(r.labels)
+
+	for _, l := range alert.Labels {
+		lb.Set(l.Name, l.Value)
+	}
+
+	lb.Set(labels.MetricName, alertMetricName)
+	lb.Set(labels.AlertName, r.name)
+	lb.Set(alertStateLabel, alert.State.String())
+
+	s := promql.Sample{
+		Metric: lb.Labels(),
+		Point:  promql.Point{T: timestamp.FromTime(ts), V: 1},
+	}
+	return s
+}
+
+// ForStateSample returns the sample for ALERTS_FOR_STATE.
+func (r *AlertingRule) ForStateSample(alert *Alert, ts time.Time, v float64) promql.Sample {
+	lb := labels.NewBuilder(r.labels)
+
+	for _, l := range alert.Labels {
+		lb.Set(l.Name, l.Value)
+	}
+
+	lb.Set(labels.MetricName, AlertForStateMetricName)
+	lb.Set(labels.AlertName, r.name)
+
+	s := promql.Sample{
+		Metric: lb.Labels(),
+		Point:  promql.Point{T: timestamp.FromTime(ts), V: v},
+	}
+	return s
+}
+
+// SetEvaluationDuration updates evaluationDuration to the duration it took to evaluate the rule on its last evaluation.
+func (r *AlertingRule) SetEvaluationDuration(dur time.Duration) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	r.evaluationDuration = dur
+}
+
+// GetEvaluationDuration returns the time in seconds it took to evaluate the alerting rule.
+func (r *AlertingRule) GetEvaluationDuration() time.Duration {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return r.evaluationDuration
+}
+
+// SetEvaluationTimestamp updates evaluationTimestamp to the timestamp of when the rule was last evaluated.
+func (r *AlertingRule) SetEvaluationTimestamp(ts time.Time) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	r.evaluationTimestamp = ts
+}
+
+// GetEvaluationTimestamp returns the time the evaluation took place.
+func (r *AlertingRule) GetEvaluationTimestamp() time.Time {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return r.evaluationTimestamp
+}
+
+// SetRestored updates the restoration state of the alerting rule.
+func (r *AlertingRule) SetRestored(restored bool) {
+	r.restored = restored
+}
+
+// resolvedRetention is the duration for which a resolved alert instance
+// is kept in memory state and consequently repeatedly sent to the AlertManager.
+const resolvedRetention = 15 * time.Minute
+
+// Eval evaluates the rule expression and then creates pending alerts and fires
+// or removes previously pending alerts accordingly.
+func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, externalURL *url.URL) (promql.Vector, error) {
+	res, err := query(ctx, r.vector.String(), ts)
+	if err != nil {
+		r.SetHealth(HealthBad)
+		r.SetLastError(err)
+		return nil, err
+	}
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	// Create pending alerts for any new vector elements in the alert expression
+	// or update the expression value for existing elements.
+	resultFPs := map[uint64]struct{}{}
+
+	var vec promql.Vector
+	var alerts = make(map[uint64]*Alert, len(res))
+	for _, smpl := range res {
+		// Provide the alert information to the template.
+		l := make(map[string]string, len(smpl.Metric))
+		for _, lbl := range smpl.Metric {
+			l[lbl.Name] = lbl.Value
+		}
+
+		tmplData := template.AlertTemplateData(l, r.externalLabels, smpl.V)
+		// Inject some convenience variables that are easier to remember for users
+		// who are not used to Go's templating system.
+		defs := []string{
+			"{{$labels := .Labels}}",
+			"{{$externalLabels := .ExternalLabels}}",
+			"{{$value := .Value}}",
+		}
+
+		expand := func(text string) string {
+			tmpl := template.NewTemplateExpander(
+				ctx,
+				strings.Join(append(defs, text), ""),
+				"__alert_"+r.Name(),
+				tmplData,
+				model.Time(timestamp.FromTime(ts)),
+				template.QueryFunc(query),
+				externalURL,
+			)
+			result, err := tmpl.Expand()
+			if err != nil {
+				result = fmt.Sprintf("<error expanding template: %s>", err)
+				level.Warn(r.logger).Log("msg", "Expanding alert template failed", "err", err, "data", tmplData)
+			}
+			return result
+		}
+
+		lb := labels.NewBuilder(smpl.Metric).Del(labels.MetricName)
+
+		for _, l := range r.labels {
+			lb.Set(l.Name, expand(l.Value))
+		}
+		lb.Set(labels.AlertName, r.Name())
+
+		annotations := make(labels.Labels, 0, len(r.annotations))
+		for _, a := range r.annotations {
+			annotations = append(annotations, labels.Label{Name: a.Name, Value: expand(a.Value)})
+		}
+
+		lbs := lb.Labels()
+		h := lbs.Hash()
+		resultFPs[h] = struct{}{}
+
+		if _, ok := alerts[h]; ok {
+			err = fmt.Errorf("vector contains metrics with the same labelset after applying alert labels")
+			// We have already acquired the lock above hence using SetHealth and
+			// SetLastError will deadlock.
+			r.health = HealthBad
+			r.lastError = err
+			return nil, err
+		}
+
+		alerts[h] = &Alert{
+			Labels:      lbs,
+			Annotations: annotations,
+			ActiveAt:    ts,
+			State:       StatePending,
+			Value:       smpl.V,
+		}
+	}
+
+	for h, a := range alerts {
+		// Check whether we already have alerting state for the identifying label set.
+		// Update the last value and annotations if so, create a new alert entry otherwise.
+		if alert, ok := r.active[h]; ok && alert.State != StateInactive {
+			alert.Value = a.Value
+			alert.Annotations = a.Annotations
+			continue
+		}
+
+		r.active[h] = a
+	}
+
+	// Check if any pending alerts should be removed or fire now. Write out alert timeseries.
+	for fp, a := range r.active {
+		if _, ok := resultFPs[fp]; !ok {
+			// If the alert was previously firing, keep it around for a given
+			// retention time so it is reported as resolved to the AlertManager.
+			if a.State == StatePending || (!a.ResolvedAt.IsZero() && ts.Sub(a.ResolvedAt) > resolvedRetention) {
+				delete(r.active, fp)
+			}
+			if a.State != StateInactive {
+				a.State = StateInactive
+				a.ResolvedAt = ts
+			}
+			continue
+		}
+
+		if a.State == StatePending && ts.Sub(a.ActiveAt) >= r.holdDuration {
+			a.State = StateFiring
+			a.FiredAt = ts
+		}
+
+		if r.restored {
+			vec = append(vec, r.sample(a, ts))
+			vec = append(vec, r.ForStateSample(a, ts, float64(a.ActiveAt.Unix())))
+		}
+	}
+
+	// We have already acquired the lock above hence using SetHealth and
+	// SetLastError will deadlock.
+	r.health = HealthGood
+	r.lastError = err
+	return vec, nil
+}
+
+// State returns the maximum state of alert instances for this rule.
+// StateFiring > StatePending > StateInactive
+func (r *AlertingRule) State() AlertState {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	maxState := StateInactive
+	for _, a := range r.active {
+		if a.State > maxState {
+			maxState = a.State
+		}
+	}
+	return maxState
+}
+
+// ActiveAlerts returns a slice of active alerts.
+func (r *AlertingRule) ActiveAlerts() []*Alert {
+	var res []*Alert
+	for _, a := range r.currentAlerts() {
+		if a.ResolvedAt.IsZero() {
+			res = append(res, a)
+		}
+	}
+	return res
+}
+
+// currentAlerts returns all instances of alerts for this rule. This may include
+// inactive alerts that were previously firing.
+func (r *AlertingRule) currentAlerts() []*Alert {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	alerts := make([]*Alert, 0, len(r.active))
+
+	for _, a := range r.active {
+		anew := *a
+		alerts = append(alerts, &anew)
+	}
+	return alerts
+}
+
+// ForEachActiveAlert runs the given function on each alert.
+// This should be used when you want to use the actual alerts from the AlertingRule
+// and not on its copy.
+// If you want to run on a copy of alerts then don't use this, get the alerts from 'ActiveAlerts()'.
+func (r *AlertingRule) ForEachActiveAlert(f func(*Alert)) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	for _, a := range r.active {
+		f(a)
+	}
+}
+
+func (r *AlertingRule) sendAlerts(ctx context.Context, ts time.Time, resendDelay time.Duration, interval time.Duration, notifyFunc NotifyFunc) {
+	alerts := []*Alert{}
+	r.ForEachActiveAlert(func(alert *Alert) {
+		if alert.needsSending(ts, resendDelay) {
+			alert.LastSentAt = ts
+			// Allow for a couple Eval or Alertmanager send failures
+			delta := resendDelay
+			if interval > resendDelay {
+				delta = interval
+			}
+			alert.ValidUntil = ts.Add(3 * delta)
+			anew := *alert
+			alerts = append(alerts, &anew)
+		}
+	})
+	notifyFunc(ctx, r.vector.String(), alerts...)
+}
+
+func (r *AlertingRule) String() string {
+	ar := rulefmt.Rule{
+		Alert:       r.name,
+		Expr:        r.vector.String(),
+		For:         model.Duration(r.holdDuration),
+		Labels:      r.labels.Map(),
+		Annotations: r.annotations.Map(),
+	}
+
+	byt, err := yaml.Marshal(ar)
+	if err != nil {
+		return fmt.Sprintf("error marshaling alerting rule: %s", err.Error())
+	}
+
+	return string(byt)
+}
+
+// HTMLSnippet returns an HTML snippet representing this alerting rule. The
+// resulting snippet is expected to be presented in a <pre> element, so that
+// line breaks and other returned whitespace is respected.
+func (r *AlertingRule) HTMLSnippet(pathPrefix string) html_template.HTML {
+	alertMetric := model.Metric{
+		model.MetricNameLabel: alertMetricName,
+		alertNameLabel:        model.LabelValue(r.name),
+	}
+
+	labelsMap := make(map[string]string, len(r.labels))
+	for _, l := range r.labels {
+		labelsMap[l.Name] = html_template.HTMLEscapeString(l.Value)
+	}
+
+	annotationsMap := make(map[string]string, len(r.annotations))
+	for _, l := range r.annotations {
+		annotationsMap[l.Name] = html_template.HTMLEscapeString(l.Value)
+	}
+
+	ar := rulefmt.Rule{
+		Alert:       fmt.Sprintf("<a href=%q>%s</a>", pathPrefix+strutil.TableLinkForExpression(alertMetric.String()), r.name),
+		Expr:        fmt.Sprintf("<a href=%q>%s</a>", pathPrefix+strutil.TableLinkForExpression(r.vector.String()), html_template.HTMLEscapeString(r.vector.String())),
+		For:         model.Duration(r.holdDuration),
+		Labels:      labelsMap,
+		Annotations: annotationsMap,
+	}
+
+	byt, err := yaml.Marshal(ar)
+	if err != nil {
+		return html_template.HTML(fmt.Sprintf("error marshaling alerting rule: %q", html_template.HTMLEscapeString(err.Error())))
+	}
+	return html_template.HTML(byt)
+}
+
+// HoldDuration returns the holdDuration of the alerting rule.
+func (r *AlertingRule) HoldDuration() time.Duration {
+	return r.holdDuration
+}

--- a/pkg/ruler/rules/alerting_test.go
+++ b/pkg/ruler/rules/alerting_test.go
@@ -1,0 +1,328 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/teststorage"
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestAlertingRuleHTMLSnippet(t *testing.T) {
+	expr, err := parser.ParseExpr(`foo{html="<b>BOLD<b>"}`)
+	testutil.Ok(t, err)
+	rule := NewAlertingRule("testrule", expr, 0, labels.FromStrings("html", "<b>BOLD</b>"), labels.FromStrings("html", "<b>BOLD</b>"), nil, false, nil)
+
+	const want = `alert: <a href="/test/prefix/graph?g0.expr=ALERTS%7Balertname%3D%22testrule%22%7D&g0.tab=1">testrule</a>
+expr: <a href="/test/prefix/graph?g0.expr=foo%7Bhtml%3D%22%3Cb%3EBOLD%3Cb%3E%22%7D&g0.tab=1">foo{html=&#34;&lt;b&gt;BOLD&lt;b&gt;&#34;}</a>
+labels:
+  html: '&lt;b&gt;BOLD&lt;/b&gt;'
+annotations:
+  html: '&lt;b&gt;BOLD&lt;/b&gt;'
+`
+
+	got := rule.HTMLSnippet("/test/prefix")
+	testutil.Assert(t, want == got, "incorrect HTML snippet; want:\n\n|%v|\n\ngot:\n\n|%v|", want, got)
+}
+
+func TestAlertingRuleLabelsUpdate(t *testing.T) {
+	suite, err := promql.NewTest(t, `
+		load 1m
+			http_requests{job="app-server", instance="0"}	75 85 70 70
+	`)
+	testutil.Ok(t, err)
+	defer suite.Close()
+
+	testutil.Ok(t, suite.Run())
+
+	expr, err := parser.ParseExpr(`http_requests < 100`)
+	testutil.Ok(t, err)
+
+	rule := NewAlertingRule(
+		"HTTPRequestRateLow",
+		expr,
+		time.Minute,
+		// Basing alerting rule labels off of a value that can change is a very bad idea.
+		// If an alert is going back and forth between two label values it will never fire.
+		// Instead, you should write two alerts with constant labels.
+		labels.FromStrings("severity", "{{ if lt $value 80.0 }}critical{{ else }}warning{{ end }}"),
+		nil, nil, true, nil,
+	)
+
+	results := []promql.Vector{
+		{
+			{
+				Metric: labels.FromStrings(
+					"__name__", "ALERTS",
+					"alertname", "HTTPRequestRateLow",
+					"alertstate", "pending",
+					"instance", "0",
+					"job", "app-server",
+					"severity", "critical",
+				),
+				Point: promql.Point{V: 1},
+			},
+		},
+		{
+			{
+				Metric: labels.FromStrings(
+					"__name__", "ALERTS",
+					"alertname", "HTTPRequestRateLow",
+					"alertstate", "pending",
+					"instance", "0",
+					"job", "app-server",
+					"severity", "warning",
+				),
+				Point: promql.Point{V: 1},
+			},
+		},
+		{
+			{
+				Metric: labels.FromStrings(
+					"__name__", "ALERTS",
+					"alertname", "HTTPRequestRateLow",
+					"alertstate", "pending",
+					"instance", "0",
+					"job", "app-server",
+					"severity", "critical",
+				),
+				Point: promql.Point{V: 1},
+			},
+		},
+		{
+			{
+				Metric: labels.FromStrings(
+					"__name__", "ALERTS",
+					"alertname", "HTTPRequestRateLow",
+					"alertstate", "firing",
+					"instance", "0",
+					"job", "app-server",
+					"severity", "critical",
+				),
+				Point: promql.Point{V: 1},
+			},
+		},
+	}
+
+	baseTime := time.Unix(0, 0)
+	for i, result := range results {
+		t.Logf("case %d", i)
+		evalTime := baseTime.Add(time.Duration(i) * time.Minute)
+		result[0].Point.T = timestamp.FromTime(evalTime)
+		res, err := rule.Eval(suite.Context(), evalTime, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil)
+		testutil.Ok(t, err)
+
+		var filteredRes promql.Vector // After removing 'ALERTS_FOR_STATE' samples.
+		for _, smpl := range res {
+			smplName := smpl.Metric.Get("__name__")
+			if smplName == "ALERTS" {
+				filteredRes = append(filteredRes, smpl)
+			} else {
+				// If not 'ALERTS', it has to be 'ALERTS_FOR_STATE'.
+				testutil.Equals(t, "ALERTS_FOR_STATE", smplName)
+			}
+		}
+
+		testutil.Equals(t, result, filteredRes)
+	}
+}
+
+func TestAlertingRuleExternalLabelsInTemplate(t *testing.T) {
+	suite, err := promql.NewTest(t, `
+		load 1m
+			http_requests{job="app-server", instance="0"}	75 85 70 70
+	`)
+	testutil.Ok(t, err)
+	defer suite.Close()
+
+	testutil.Ok(t, suite.Run())
+
+	expr, err := parser.ParseExpr(`http_requests < 100`)
+	testutil.Ok(t, err)
+
+	ruleWithoutExternalLabels := NewAlertingRule(
+		"ExternalLabelDoesNotExist",
+		expr,
+		time.Minute,
+		labels.FromStrings("templated_label", "There are {{ len $externalLabels }} external Labels, of which foo is {{ $externalLabels.foo }}."),
+		nil,
+		nil,
+		true, log.NewNopLogger(),
+	)
+	ruleWithExternalLabels := NewAlertingRule(
+		"ExternalLabelExists",
+		expr,
+		time.Minute,
+		labels.FromStrings("templated_label", "There are {{ len $externalLabels }} external Labels, of which foo is {{ $externalLabels.foo }}."),
+		nil,
+		labels.FromStrings("foo", "bar", "dings", "bums"),
+		true, log.NewNopLogger(),
+	)
+	result := promql.Vector{
+		{
+			Metric: labels.FromStrings(
+				"__name__", "ALERTS",
+				"alertname", "ExternalLabelDoesNotExist",
+				"alertstate", "pending",
+				"instance", "0",
+				"job", "app-server",
+				"templated_label", "There are 0 external Labels, of which foo is .",
+			),
+			Point: promql.Point{V: 1},
+		},
+		{
+			Metric: labels.FromStrings(
+				"__name__", "ALERTS",
+				"alertname", "ExternalLabelExists",
+				"alertstate", "pending",
+				"instance", "0",
+				"job", "app-server",
+				"templated_label", "There are 2 external Labels, of which foo is bar.",
+			),
+			Point: promql.Point{V: 1},
+		},
+	}
+
+	evalTime := time.Unix(0, 0)
+	result[0].Point.T = timestamp.FromTime(evalTime)
+	result[1].Point.T = timestamp.FromTime(evalTime)
+
+	var filteredRes promql.Vector // After removing 'ALERTS_FOR_STATE' samples.
+	res, err := ruleWithoutExternalLabels.Eval(
+		suite.Context(), evalTime, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil,
+	)
+	testutil.Ok(t, err)
+	for _, smpl := range res {
+		smplName := smpl.Metric.Get("__name__")
+		if smplName == "ALERTS" {
+			filteredRes = append(filteredRes, smpl)
+		} else {
+			// If not 'ALERTS', it has to be 'ALERTS_FOR_STATE'.
+			testutil.Equals(t, "ALERTS_FOR_STATE", smplName)
+		}
+	}
+
+	res, err = ruleWithExternalLabels.Eval(
+		suite.Context(), evalTime, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil,
+	)
+	testutil.Ok(t, err)
+	for _, smpl := range res {
+		smplName := smpl.Metric.Get("__name__")
+		if smplName == "ALERTS" {
+			filteredRes = append(filteredRes, smpl)
+		} else {
+			// If not 'ALERTS', it has to be 'ALERTS_FOR_STATE'.
+			testutil.Equals(t, "ALERTS_FOR_STATE", smplName)
+		}
+	}
+
+	testutil.Equals(t, result, filteredRes)
+}
+
+func TestAlertingRuleEmptyLabelFromTemplate(t *testing.T) {
+	suite, err := promql.NewTest(t, `
+		load 1m
+			http_requests{job="app-server", instance="0"}	75 85 70 70
+	`)
+	testutil.Ok(t, err)
+	defer suite.Close()
+
+	testutil.Ok(t, suite.Run())
+
+	expr, err := parser.ParseExpr(`http_requests < 100`)
+	testutil.Ok(t, err)
+
+	rule := NewAlertingRule(
+		"EmptyLabel",
+		expr,
+		time.Minute,
+		labels.FromStrings("empty_label", ""),
+		nil,
+		nil,
+		true, log.NewNopLogger(),
+	)
+	result := promql.Vector{
+		{
+			Metric: labels.FromStrings(
+				"__name__", "ALERTS",
+				"alertname", "EmptyLabel",
+				"alertstate", "pending",
+				"instance", "0",
+				"job", "app-server",
+			),
+			Point: promql.Point{V: 1},
+		},
+	}
+
+	evalTime := time.Unix(0, 0)
+	result[0].Point.T = timestamp.FromTime(evalTime)
+
+	var filteredRes promql.Vector // After removing 'ALERTS_FOR_STATE' samples.
+	res, err := rule.Eval(
+		suite.Context(), evalTime, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil,
+	)
+	testutil.Ok(t, err)
+	for _, smpl := range res {
+		smplName := smpl.Metric.Get("__name__")
+		if smplName == "ALERTS" {
+			filteredRes = append(filteredRes, smpl)
+		} else {
+			// If not 'ALERTS', it has to be 'ALERTS_FOR_STATE'.
+			testutil.Equals(t, "ALERTS_FOR_STATE", smplName)
+		}
+	}
+	testutil.Equals(t, result, filteredRes)
+}
+
+func TestAlertingRuleDuplicate(t *testing.T) {
+	storage := teststorage.New(t)
+	defer storage.Close()
+
+	opts := promql.EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+
+	engine := promql.NewEngine(opts)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	now := time.Now()
+
+	expr, _ := parser.ParseExpr(`vector(0) or label_replace(vector(0),"test","x","","")`)
+	rule := NewAlertingRule(
+		"foo",
+		expr,
+		time.Minute,
+		labels.FromStrings("test", "test"),
+		nil,
+		nil,
+		true, log.NewNopLogger(),
+	)
+	_, err := rule.Eval(ctx, now, EngineQueryFunc(engine, storage), nil)
+	testutil.NotOk(t, err)
+	e := fmt.Errorf("vector contains metrics with the same labelset after applying alert labels")
+	testutil.ErrorEqual(t, e, err)
+}

--- a/pkg/ruler/rules/fixtures/rules.yaml
+++ b/pkg/ruler/rules/fixtures/rules.yaml
@@ -1,0 +1,5 @@
+groups:
+  - name: test
+    rules:
+    - record: job:http_requests:rate5m
+      expr: sum by (job)(rate(http_requests_total[5m]))

--- a/pkg/ruler/rules/fixtures/rules2.yaml
+++ b/pkg/ruler/rules/fixtures/rules2.yaml
@@ -1,0 +1,5 @@
+groups:
+  - name: test_2
+    rules:
+    - record: test_2
+      expr: vector(2)

--- a/pkg/ruler/rules/history.go
+++ b/pkg/ruler/rules/history.go
@@ -1,0 +1,140 @@
+package rules
+
+import (
+	"time"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/value"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// Cortex-Note: this entire file is the interface and default implementation
+// of what was previously defined in prometheus as (*Group).RestoreForState.
+
+// TenantAlertHistory is a tenant specific interface for restoring the for state of an alert after restarts/etc.
+type TenantAlertHistory interface {
+	RestoreForState(ts time.Time, alertRule *AlertingRule)
+	Stop()
+}
+
+// QuerierHistory embeds a Querier and determines last active at via the traditional Prometheus metric `ALERTS_FOR_STATE`
+type MetricsHistory struct {
+	q    storage.Queryable
+	opts *ManagerOptions
+}
+
+func NewMetricsHistory(q storage.Queryable, opts *ManagerOptions) *MetricsHistory {
+	return &MetricsHistory{
+		q:    q,
+		opts: opts,
+	}
+}
+
+func (m *MetricsHistory) Stop() {}
+
+func (m *MetricsHistory) RestoreForState(ts time.Time, alertRule *AlertingRule) {
+	maxtMS := int64(model.TimeFromUnixNano(ts.UnixNano()))
+	// We allow restoration only if alerts were active before after certain time.
+	mint := ts.Add(-m.opts.OutageTolerance)
+	mintMS := int64(model.TimeFromUnixNano(mint.UnixNano()))
+	q, err := m.q.Querier(m.opts.Context, mintMS, maxtMS)
+	if err != nil {
+		level.Error(m.opts.Logger).Log("msg", "Failed to get Querier", "err", err)
+		return
+	}
+	defer func() {
+		if err := q.Close(); err != nil {
+			level.Error(m.opts.Logger).Log("msg", "Failed to close Querier", "err", err)
+		}
+	}()
+
+	alertRule.ForEachActiveAlert(func(a *Alert) {
+		smpl := alertRule.ForStateSample(a, time.Now(), 0)
+		var matchers []*labels.Matcher
+		for _, l := range smpl.Metric {
+			mt, err := labels.NewMatcher(labels.MatchEqual, l.Name, l.Value)
+			if err != nil {
+				panic(err)
+			}
+			matchers = append(matchers, mt)
+		}
+
+		sset := q.Select(false, nil, matchers...)
+
+		seriesFound := false
+		var s storage.Series
+		for sset.Next() {
+			// Query assures that smpl.Metric is included in sset.At().Labels(),
+			// hence just checking the length would act like equality.
+			// (This is faster than calling labels.Compare again as we already have some info).
+			if len(sset.At().Labels()) == len(smpl.Metric) {
+				s = sset.At()
+				seriesFound = true
+				break
+			}
+		}
+
+		if !seriesFound {
+			return
+		}
+
+		// Series found for the 'for' state.
+		var t int64
+		var v float64
+		it := s.Iterator()
+		for it.Next() {
+			t, v = it.At()
+		}
+		if it.Err() != nil {
+			level.Error(m.opts.Logger).Log("msg", "Failed to restore 'for' state",
+				labels.AlertName, alertRule.Name(), "stage", "Iterator", "err", it.Err())
+			return
+		}
+		if value.IsStaleNaN(v) { // Alert was not active.
+			return
+		}
+
+		alertHoldDuration := alertRule.HoldDuration()
+		downAt := time.Unix(t/1000, 0)
+		restoredActiveAt := time.Unix(int64(v), 0)
+		timeSpentPending := downAt.Sub(restoredActiveAt)
+		timeRemainingPending := alertHoldDuration - timeSpentPending
+
+		if timeRemainingPending <= 0 {
+			// It means that alert was firing when prometheus went down.
+			// In the next Eval, the state of this alert will be set back to
+			// firing again if it's still firing in that Eval.
+			// Nothing to be done in this case.
+		} else if timeRemainingPending < m.opts.ForGracePeriod {
+			// (new) restoredActiveAt = (ts + m.opts.ForGracePeriod) - alertHoldDuration
+			//                            /* new firing time */      /* moving back by hold duration */
+			//
+			// Proof of correctness:
+			// firingTime = restoredActiveAt.Add(alertHoldDuration)
+			//            = ts + m.opts.ForGracePeriod - alertHoldDuration + alertHoldDuration
+			//            = ts + m.opts.ForGracePeriod
+			//
+			// Time remaining to fire = firingTime.Sub(ts)
+			//                        = (ts + m.opts.ForGracePeriod) - ts
+			//                        = m.opts.ForGracePeriod
+			restoredActiveAt = ts.Add(m.opts.ForGracePeriod).Add(-alertHoldDuration)
+		} else {
+			// By shifting ActiveAt to the future (ActiveAt + some_duration),
+			// the total pending time from the original ActiveAt
+			// would be `alertHoldDuration + some_duration`.
+			// Here, some_duration = downDuration.
+			downDuration := ts.Sub(downAt)
+			restoredActiveAt = restoredActiveAt.Add(downDuration)
+		}
+
+		a.ActiveAt = restoredActiveAt
+		level.Debug(m.opts.Logger).Log("msg", "'for' state restored",
+			labels.AlertName, alertRule.Name(), "restored_time", a.ActiveAt.Format(time.RFC850),
+			"labels", a.Labels.String())
+
+	})
+
+	alertRule.SetRestored(true)
+}

--- a/pkg/ruler/rules/manager.go
+++ b/pkg/ruler/rules/manager.go
@@ -1,0 +1,953 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"context"
+	"fmt"
+	html_template "html/template"
+	"math"
+	"net/url"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/prometheus/prometheus/pkg/value"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// RuleHealth describes the health state of a rule.
+type RuleHealth string
+
+// The possible health states of a rule based on the last execution.
+const (
+	HealthUnknown RuleHealth = "unknown"
+	HealthGood    RuleHealth = "ok"
+	HealthBad     RuleHealth = "err"
+)
+
+// Constants for instrumentation.
+const namespace = "prometheus"
+
+// Metrics for rule evaluation.
+type Metrics struct {
+	evalDuration        prometheus.Summary
+	evalFailures        prometheus.Counter
+	evalTotal           prometheus.Counter
+	iterationDuration   prometheus.Summary
+	iterationsMissed    prometheus.Counter
+	iterationsScheduled prometheus.Counter
+	groupInterval       *prometheus.GaugeVec
+	groupLastEvalTime   *prometheus.GaugeVec
+	groupLastDuration   *prometheus.GaugeVec
+	groupRules          *prometheus.GaugeVec
+}
+
+// Cortex-Note: New method to expose underlying metric
+func (m *Metrics) EvalDuration(d time.Duration) {
+	m.evalDuration.Observe(d.Seconds())
+}
+
+// Cortex-Note: New method to expose underlying metric
+func (m *Metrics) FailedEvaluate() {
+	m.evalFailures.Inc()
+}
+
+// Cortex-Note: New method to expose underlying metric
+func (m *Metrics) IncrementEvaluations() {
+	m.evalTotal.Inc()
+}
+
+// NewGroupMetrics makes a new Metrics and registers them with the provided registerer,
+// if not nil.
+func NewGroupMetrics(reg prometheus.Registerer) *Metrics {
+	m := &Metrics{
+		evalDuration: prometheus.NewSummary(
+			prometheus.SummaryOpts{
+				Namespace:  namespace,
+				Name:       "rule_evaluation_duration_seconds",
+				Help:       "The duration for a rule to execute.",
+				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+			}),
+		evalFailures: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "rule_evaluation_failures_total",
+				Help:      "The total number of rule evaluation failures.",
+			}),
+		evalTotal: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "rule_evaluations_total",
+				Help:      "The total number of rule evaluations.",
+			}),
+		iterationDuration: prometheus.NewSummary(prometheus.SummaryOpts{
+			Namespace:  namespace,
+			Name:       "rule_group_duration_seconds",
+			Help:       "The duration of rule group evaluations.",
+			Objectives: map[float64]float64{0.01: 0.001, 0.05: 0.005, 0.5: 0.05, 0.90: 0.01, 0.99: 0.001},
+		}),
+		iterationsMissed: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "rule_group_iterations_missed_total",
+			Help:      "The total number of rule group evaluations missed due to slow rule group evaluation.",
+		}),
+		iterationsScheduled: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "rule_group_iterations_total",
+			Help:      "The total number of scheduled rule group evaluations, whether executed or missed.",
+		}),
+		groupInterval: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "rule_group_interval_seconds",
+				Help:      "The interval of a rule group.",
+			},
+			[]string{"rule_group"},
+		),
+		groupLastEvalTime: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "rule_group_last_evaluation_timestamp_seconds",
+				Help:      "The timestamp of the last rule group evaluation in seconds.",
+			},
+			[]string{"rule_group"},
+		),
+		groupLastDuration: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "rule_group_last_duration_seconds",
+				Help:      "The duration of the last rule group evaluation.",
+			},
+			[]string{"rule_group"},
+		),
+		groupRules: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "rule_group_rules",
+				Help:      "The number of rules.",
+			},
+			[]string{"rule_group"},
+		),
+	}
+
+	if reg != nil {
+		reg.MustRegister(
+			m.evalDuration,
+			m.evalFailures,
+			m.evalTotal,
+			m.iterationDuration,
+			m.iterationsMissed,
+			m.iterationsScheduled,
+			m.groupInterval,
+			m.groupLastEvalTime,
+			m.groupLastDuration,
+			m.groupRules,
+		)
+	}
+
+	return m
+}
+
+// QueryFunc processes PromQL queries.
+type QueryFunc func(ctx context.Context, q string, t time.Time) (promql.Vector, error)
+
+// EngineQueryFunc returns a new query function that executes instant queries against
+// the given engine.
+// It converts scalar into vector results.
+func EngineQueryFunc(engine *promql.Engine, q storage.Queryable) QueryFunc {
+	return func(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
+		q, err := engine.NewInstantQuery(q, qs, t)
+		if err != nil {
+			return nil, err
+		}
+		res := q.Exec(ctx)
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		switch v := res.Value.(type) {
+		case promql.Vector:
+			return v, nil
+		case promql.Scalar:
+			return promql.Vector{promql.Sample{
+				Point:  promql.Point(v),
+				Metric: labels.Labels{},
+			}}, nil
+		default:
+			return nil, errors.New("rule result is not a vector or scalar")
+		}
+	}
+}
+
+// A Rule encapsulates a vector expression which is evaluated at a specified
+// interval and acted upon (currently either recorded or used for alerting).
+type Rule interface {
+	Name() string
+	// Labels of the rule.
+	Labels() labels.Labels
+	// eval evaluates the rule, including any associated recording or alerting actions.
+	Eval(context.Context, time.Time, QueryFunc, *url.URL) (promql.Vector, error)
+	// String returns a human-readable string representation of the rule.
+	String() string
+	// SetLastErr sets the current error experienced by the rule.
+	SetLastError(error)
+	// LastErr returns the last error experienced by the rule.
+	LastError() error
+	// SetHealth sets the current health of the rule.
+	SetHealth(RuleHealth)
+	// Health returns the current health of the rule.
+	Health() RuleHealth
+	SetEvaluationDuration(time.Duration)
+	// GetEvaluationDuration returns last evaluation duration.
+	// NOTE: Used dynamically by rules.html template.
+	GetEvaluationDuration() time.Duration
+	SetEvaluationTimestamp(time.Time)
+	// GetEvaluationTimestamp returns last evaluation timestamp.
+	// NOTE: Used dynamically by rules.html template.
+	GetEvaluationTimestamp() time.Time
+	// HTMLSnippet returns a human-readable string representation of the rule,
+	// decorated with HTML elements for use the web frontend.
+	HTMLSnippet(pathPrefix string) html_template.HTML
+}
+
+// Group is a set of rules that have a logical relation.
+type Group struct {
+	name                 string
+	file                 string
+	interval             time.Duration
+	rules                []Rule
+	seriesInPreviousEval []map[string]labels.Labels // One per Rule.
+	staleSeries          []labels.Labels
+	opts                 *ManagerOptions
+	mtx                  sync.Mutex
+	evaluationDuration   time.Duration
+	evaluationTimestamp  time.Time
+
+	shouldRestore bool
+
+	done       chan struct{}
+	terminated chan struct{}
+
+	logger log.Logger
+
+	metrics *Metrics
+}
+
+// NewGroup makes a new Group with the given name, options, and rules.
+func NewGroup(name, file string, interval time.Duration, rules []Rule, shouldRestore bool, opts *ManagerOptions) *Group {
+	metrics := opts.Metrics
+	if metrics == nil {
+		metrics = NewGroupMetrics(opts.Registerer)
+	}
+
+	metrics.groupLastEvalTime.WithLabelValues(groupKey(file, name))
+	metrics.groupLastDuration.WithLabelValues(groupKey(file, name))
+	metrics.groupRules.WithLabelValues(groupKey(file, name)).Set(float64(len(rules)))
+	metrics.groupInterval.WithLabelValues(groupKey(file, name)).Set(interval.Seconds())
+
+	return &Group{
+		name:                 name,
+		file:                 file,
+		interval:             interval,
+		rules:                rules,
+		shouldRestore:        shouldRestore,
+		opts:                 opts,
+		seriesInPreviousEval: make([]map[string]labels.Labels, len(rules)),
+		done:                 make(chan struct{}),
+		terminated:           make(chan struct{}),
+		logger:               log.With(opts.Logger, "group", name),
+		metrics:              metrics,
+	}
+}
+
+// Name returns the group name.
+func (g *Group) Name() string { return g.name }
+
+// File returns the group's file.
+func (g *Group) File() string { return g.file }
+
+// Rules returns the group's rules.
+func (g *Group) Rules() []Rule { return g.rules }
+
+// Interval returns the group's interval.
+func (g *Group) Interval() time.Duration { return g.interval }
+
+func (g *Group) run(ctx context.Context) {
+	defer close(g.terminated)
+
+	// Wait an initial amount to have consistently slotted intervals.
+	evalTimestamp := g.evalTimestamp().Add(g.interval)
+	select {
+	case <-time.After(time.Until(evalTimestamp)):
+	case <-g.done:
+		return
+	}
+
+	ctx = promql.NewOriginContext(ctx, map[string]interface{}{
+		"ruleGroup": map[string]string{
+			"file": g.File(),
+			"name": g.Name(),
+		},
+	})
+
+	iter := func() {
+		g.metrics.iterationsScheduled.Inc()
+
+		start := time.Now()
+		g.Eval(ctx, evalTimestamp)
+		timeSinceStart := time.Since(start)
+
+		g.metrics.iterationDuration.Observe(timeSinceStart.Seconds())
+		g.setEvaluationDuration(timeSinceStart)
+		g.setEvaluationTimestamp(start)
+	}
+
+	// The assumption here is that since the ticker was started after having
+	// waited for `evalTimestamp` to pass, the ticks will trigger soon
+	// after each `evalTimestamp + N * g.interval` occurrence.
+	tick := time.NewTicker(g.interval)
+	defer tick.Stop()
+
+	iter()
+	if g.shouldRestore {
+		// If we have to restore, we wait for another Eval to finish.
+		// The reason behind this is, during first eval (or before it)
+		// we might not have enough data scraped, and recording rules would not
+		// have updated the latest values, on which some alerts might depend.
+		select {
+		case <-g.done:
+			return
+		case <-tick.C:
+			missed := (time.Since(evalTimestamp) / g.interval) - 1
+			if missed > 0 {
+				g.metrics.iterationsMissed.Add(float64(missed))
+				g.metrics.iterationsScheduled.Add(float64(missed))
+			}
+			evalTimestamp = evalTimestamp.Add((missed + 1) * g.interval)
+			iter()
+		}
+
+		g.RestoreForState(time.Now())
+		g.shouldRestore = false
+	}
+
+	for {
+		select {
+		case <-g.done:
+			return
+		default:
+			select {
+			case <-g.done:
+				return
+			case <-tick.C:
+				missed := (time.Since(evalTimestamp) / g.interval) - 1
+				if missed > 0 {
+					g.metrics.iterationsMissed.Add(float64(missed))
+					g.metrics.iterationsScheduled.Add(float64(missed))
+				}
+				evalTimestamp = evalTimestamp.Add((missed + 1) * g.interval)
+				iter()
+			}
+		}
+	}
+}
+
+func (g *Group) stop() {
+	close(g.done)
+	<-g.terminated
+}
+
+func (g *Group) hash() uint64 {
+	l := labels.New(
+		labels.Label{Name: "name", Value: g.name},
+		labels.Label{Name: "file", Value: g.file},
+	)
+	return l.Hash()
+}
+
+// AlertingRules returns the list of the group's alerting rules.
+func (g *Group) AlertingRules() []*AlertingRule {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+
+	var alerts []*AlertingRule
+	for _, rule := range g.rules {
+		if alertingRule, ok := rule.(*AlertingRule); ok {
+			alerts = append(alerts, alertingRule)
+		}
+	}
+	sort.Slice(alerts, func(i, j int) bool {
+		return alerts[i].State() > alerts[j].State() ||
+			(alerts[i].State() == alerts[j].State() &&
+				alerts[i].Name() < alerts[j].Name())
+	})
+	return alerts
+}
+
+// HasAlertingRules returns true if the group contains at least one AlertingRule.
+func (g *Group) HasAlertingRules() bool {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+
+	for _, rule := range g.rules {
+		if _, ok := rule.(*AlertingRule); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// GetEvaluationDuration returns the time in seconds it took to evaluate the rule group.
+func (g *Group) GetEvaluationDuration() time.Duration {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+	return g.evaluationDuration
+}
+
+// setEvaluationDuration sets the time in seconds the last evaluation took.
+func (g *Group) setEvaluationDuration(dur time.Duration) {
+	g.metrics.groupLastDuration.WithLabelValues(groupKey(g.file, g.name)).Set(dur.Seconds())
+
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+	g.evaluationDuration = dur
+}
+
+// GetEvaluationTimestamp returns the time the last evaluation of the rule group took place.
+func (g *Group) GetEvaluationTimestamp() time.Time {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+	return g.evaluationTimestamp
+}
+
+// setEvaluationTimestamp updates evaluationTimestamp to the timestamp of when the rule group was last evaluated.
+func (g *Group) setEvaluationTimestamp(ts time.Time) {
+	g.metrics.groupLastEvalTime.WithLabelValues(groupKey(g.file, g.name)).Set(float64(ts.UnixNano()) / 1e9)
+
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+	g.evaluationTimestamp = ts
+}
+
+// evalTimestamp returns the immediately preceding consistently slotted evaluation time.
+func (g *Group) evalTimestamp() time.Time {
+	var (
+		offset = int64(g.hash() % uint64(g.interval))
+		now    = time.Now().UnixNano()
+		adjNow = now - offset
+		base   = adjNow - (adjNow % int64(g.interval))
+	)
+
+	return time.Unix(0, base+offset)
+}
+
+func nameAndLabels(rule Rule) string {
+	return rule.Name() + rule.Labels().String()
+}
+
+// CopyState copies the alerting rule and staleness related state from the given group.
+//
+// Rules are matched based on their name and labels. If there are duplicates, the
+// first is matched with the first, second with the second etc.
+func (g *Group) CopyState(from *Group) {
+	g.evaluationDuration = from.evaluationDuration
+
+	ruleMap := make(map[string][]int, len(from.rules))
+
+	for fi, fromRule := range from.rules {
+		nameAndLabels := nameAndLabels(fromRule)
+		l := ruleMap[nameAndLabels]
+		ruleMap[nameAndLabels] = append(l, fi)
+	}
+
+	for i, rule := range g.rules {
+		nameAndLabels := nameAndLabels(rule)
+		indexes := ruleMap[nameAndLabels]
+		if len(indexes) == 0 {
+			continue
+		}
+		fi := indexes[0]
+		g.seriesInPreviousEval[i] = from.seriesInPreviousEval[fi]
+		ruleMap[nameAndLabels] = indexes[1:]
+
+		ar, ok := rule.(*AlertingRule)
+		if !ok {
+			continue
+		}
+		far, ok := from.rules[fi].(*AlertingRule)
+		if !ok {
+			continue
+		}
+
+		for fp, a := range far.active {
+			ar.active[fp] = a
+		}
+	}
+
+	// Handle deleted and unmatched duplicate rules.
+	g.staleSeries = from.staleSeries
+	for fi, fromRule := range from.rules {
+		nameAndLabels := nameAndLabels(fromRule)
+		l := ruleMap[nameAndLabels]
+		if len(l) != 0 {
+			for _, series := range from.seriesInPreviousEval[fi] {
+				g.staleSeries = append(g.staleSeries, series)
+			}
+		}
+	}
+}
+
+// Eval runs a single evaluation cycle in which all rules are evaluated sequentially.
+func (g *Group) Eval(ctx context.Context, ts time.Time) {
+	for i, rule := range g.rules {
+		select {
+		case <-g.done:
+			return
+		default:
+		}
+
+		func(i int, rule Rule) {
+			sp, ctx := opentracing.StartSpanFromContext(ctx, "rule")
+			sp.SetTag("name", rule.Name())
+			defer func(t time.Time) {
+				sp.Finish()
+
+				since := time.Since(t)
+				g.metrics.EvalDuration(since)
+				rule.SetEvaluationDuration(since)
+				rule.SetEvaluationTimestamp(t)
+			}(time.Now())
+
+			g.metrics.IncrementEvaluations()
+
+			vector, err := rule.Eval(ctx, ts, g.opts.QueryFunc, g.opts.ExternalURL)
+			if err != nil {
+				// Canceled queries are intentional termination of queries. This normally
+				// happens on shutdown and thus we skip logging of any errors here.
+				if _, ok := err.(promql.ErrQueryCanceled); !ok {
+					level.Warn(g.logger).Log("msg", "Evaluating rule failed", "rule", rule, "err", err)
+				}
+				g.metrics.FailedEvaluate()
+				return
+			}
+
+			if ar, ok := rule.(*AlertingRule); ok {
+				ar.sendAlerts(ctx, ts, g.opts.ResendDelay, g.interval, g.opts.NotifyFunc)
+			}
+			var (
+				numOutOfOrder = 0
+				numDuplicates = 0
+			)
+
+			app, err := g.opts.Appendable.Appender(rule)
+			if err != nil {
+				level.Warn(g.logger).Log("msg", "creating appender failed", "err", err)
+				return
+			}
+
+			seriesReturned := make(map[string]labels.Labels, len(g.seriesInPreviousEval[i]))
+			for _, s := range vector {
+				if _, err := app.Add(s.Metric, s.T, s.V); err != nil {
+					switch err {
+					case storage.ErrOutOfOrderSample:
+						numOutOfOrder++
+						level.Debug(g.logger).Log("msg", "Rule evaluation result discarded", "err", err, "sample", s)
+					case storage.ErrDuplicateSampleForTimestamp:
+						numDuplicates++
+						level.Debug(g.logger).Log("msg", "Rule evaluation result discarded", "err", err, "sample", s)
+					default:
+						level.Warn(g.logger).Log("msg", "Rule evaluation result discarded", "err", err, "sample", s)
+					}
+				} else {
+					seriesReturned[s.Metric.String()] = s.Metric
+				}
+			}
+			if numOutOfOrder > 0 {
+				level.Warn(g.logger).Log("msg", "Error on ingesting out-of-order result from rule evaluation", "numDropped", numOutOfOrder)
+			}
+			if numDuplicates > 0 {
+				level.Warn(g.logger).Log("msg", "Error on ingesting results from rule evaluation with different value but same timestamp", "numDropped", numDuplicates)
+			}
+
+			for metric, lset := range g.seriesInPreviousEval[i] {
+				if _, ok := seriesReturned[metric]; !ok {
+					// Series no longer exposed, mark it stale.
+					_, err = app.Add(lset, timestamp.FromTime(ts), math.Float64frombits(value.StaleNaN))
+					switch err {
+					case nil:
+					case storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp:
+						// Do not count these in logging, as this is expected if series
+						// is exposed from a different rule.
+					default:
+						level.Warn(g.logger).Log("msg", "adding stale sample failed", "sample", metric, "err", err)
+					}
+				}
+			}
+			if err := app.Commit(); err != nil {
+				level.Warn(g.logger).Log("msg", "rule sample appending failed", "err", err)
+			} else {
+				g.seriesInPreviousEval[i] = seriesReturned
+			}
+		}(i, rule)
+	}
+
+	if len(g.staleSeries) != 0 {
+		app, err := g.opts.Appendable.Appender(nil)
+		if err != nil {
+			level.Warn(g.logger).Log("msg", "creating appender failed", "err", err)
+			return
+		}
+		for _, s := range g.staleSeries {
+			// Rule that produced series no longer configured, mark it stale.
+			_, err = app.Add(s, timestamp.FromTime(ts), math.Float64frombits(value.StaleNaN))
+			switch err {
+			case nil:
+			case storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp:
+				// Do not count these in logging, as this is expected if series
+				// is exposed from a different rule.
+			default:
+				level.Warn(g.logger).Log("msg", "adding stale sample for previous configuration failed", "sample", s, "err", err)
+			}
+		}
+		if err := app.Commit(); err != nil {
+			level.Warn(g.logger).Log("msg", "stale sample appending for previous configuration failed", "err", err)
+		} else {
+			g.staleSeries = nil
+		}
+	}
+}
+
+// RestoreForState restores the 'for' state of the alerts
+// by looking up last ActiveAt from storage.
+func (g *Group) RestoreForState(ts time.Time) {
+	for _, rule := range g.Rules() {
+		alertRule, ok := rule.(*AlertingRule)
+		if !ok {
+			continue
+		}
+
+		alertHoldDuration := alertRule.HoldDuration()
+		if alertHoldDuration < g.opts.ForGracePeriod {
+			// If alertHoldDuration is already less than grace period, we would not
+			// like to make it wait for `g.opts.ForGracePeriod` time before firing.
+			// Hence we skip restoration, which will make it wait for alertHoldDuration.
+			alertRule.SetRestored(true)
+			continue
+		}
+
+		// Cortex-Note: The implementation in Prometheus is now passed via an interface. The default variant
+		// is identical to the Prometheus implementation and is defined in history.go.
+		g.opts.AlertHistory.RestoreForState(ts, alertRule)
+
+	}
+
+}
+
+// Equals return if two groups are the same.
+func (g *Group) Equals(ng *Group) bool {
+	if g.name != ng.name {
+		return false
+	}
+
+	if g.file != ng.file {
+		return false
+	}
+
+	if g.interval != ng.interval {
+		return false
+	}
+
+	if len(g.rules) != len(ng.rules) {
+		return false
+	}
+
+	for i, gr := range g.rules {
+		if gr.String() != ng.rules[i].String() {
+			return false
+		}
+	}
+
+	return true
+}
+
+// The Manager manages recording and alerting rules.
+type Manager struct {
+	opts     *ManagerOptions
+	groups   map[string]*Group
+	mtx      sync.RWMutex
+	block    chan struct{}
+	restored bool
+
+	logger log.Logger
+}
+
+// Appendable returns an Appender.
+// Cortex-Note: This Appendable interface differs from the prometheus storage.Appendable interface by accepting
+// a rule argument. The default implementation does ignores this argument as the metric store isn't related to the rule.
+type Appendable interface {
+	// Appender accepts a rule and returns an appender. The rule may be nil but may be used
+	// for upkeep/context in certain implementations.
+	Appender(rule Rule) (storage.Appender, error)
+}
+
+// NotifyFunc sends notifications about a set of alerts generated by the given expression.
+type NotifyFunc func(ctx context.Context, expr string, alerts ...*Alert)
+
+// ManagerOptions bundles options for the Manager.
+type ManagerOptions struct {
+	ExternalURL *url.URL
+	QueryFunc   QueryFunc
+	// Cortex-Note: Validation function introduced, defaults to the previously hardcoded parser.ParseExpr.
+	ParseExpr  func(string) (fmt.Stringer, error)
+	NotifyFunc NotifyFunc
+	Context    context.Context
+	// Cortex-Note: uses new Appendable interface instead of prometheus storage.Appendable.
+	Appendable Appendable
+	// Cortex-Note: TenantAlertHistory replaces the old prometheus storage.Queryable.
+	AlertHistory    TenantAlertHistory
+	Logger          log.Logger
+	Registerer      prometheus.Registerer
+	OutageTolerance time.Duration
+	ForGracePeriod  time.Duration
+	ResendDelay     time.Duration
+
+	Metrics *Metrics
+}
+
+// NewManager returns an implementation of Manager, ready to be started
+// by calling the Run method.
+func NewManager(o *ManagerOptions) *Manager {
+	if o.Metrics == nil {
+		o.Metrics = NewGroupMetrics(o.Registerer)
+	}
+
+	// Cortex-Note: defaults validation function to previously hardcoded implementation.
+	if o.ParseExpr == nil {
+		o.ParseExpr = func(s string) (fmt.Stringer, error) { return parser.ParseExpr(s) }
+	}
+
+	m := &Manager{
+		groups: map[string]*Group{},
+		opts:   o,
+		block:  make(chan struct{}),
+		logger: o.Logger,
+	}
+
+	o.Metrics.iterationsMissed.Inc()
+	return m
+}
+
+// Run starts processing of the rule manager.
+func (m *Manager) Run() {
+	close(m.block)
+}
+
+// Stop the rule manager's rule evaluation cycles.
+func (m *Manager) Stop() {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	level.Info(m.logger).Log("msg", "Stopping rule manager...")
+
+	for _, eg := range m.groups {
+		eg.stop()
+	}
+
+	m.opts.AlertHistory.Stop()
+
+	level.Info(m.logger).Log("msg", "Rule manager stopped")
+}
+
+// Update the rule manager's state as the config requires. If
+// loading the new rules failed the old rule set is restored.
+func (m *Manager) Update(interval time.Duration, files []string, externalLabels labels.Labels) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	groups, errs := m.LoadGroups(interval, externalLabels, files...)
+	if errs != nil {
+		for _, e := range errs {
+			level.Error(m.logger).Log("msg", "loading groups failed", "err", e)
+		}
+		return errors.New("error loading rules, previous rule set restored")
+	}
+	m.restored = true
+
+	var wg sync.WaitGroup
+	for _, newg := range groups {
+		// If there is an old group with the same identifier,
+		// check if new group equals with the old group, if yes then skip it.
+		// If not equals, stop it and wait for it to finish the current iteration.
+		// Then copy it into the new group.
+		gn := groupKey(newg.file, newg.name)
+		oldg, ok := m.groups[gn]
+		delete(m.groups, gn)
+
+		if ok && oldg.Equals(newg) {
+			groups[gn] = oldg
+			continue
+		}
+
+		wg.Add(1)
+		go func(newg *Group) {
+			if ok {
+				oldg.stop()
+				newg.CopyState(oldg)
+			}
+			go func() {
+				// Wait with starting evaluation until the rule manager
+				// is told to run. This is necessary to avoid running
+				// queries against a bootstrapping storage.
+				<-m.block
+				newg.run(m.opts.Context)
+			}()
+			wg.Done()
+		}(newg)
+	}
+
+	// Stop remaining old groups.
+	for n, oldg := range m.groups {
+		oldg.stop()
+		if m := oldg.metrics; m != nil {
+			m.groupInterval.DeleteLabelValues(n)
+			m.groupLastEvalTime.DeleteLabelValues(n)
+			m.groupLastDuration.DeleteLabelValues(n)
+			m.groupRules.DeleteLabelValues(n)
+		}
+	}
+
+	wg.Wait()
+	m.groups = groups
+
+	return nil
+}
+
+// LoadGroups reads groups from a list of files.
+func (m *Manager) LoadGroups(
+	interval time.Duration, externalLabels labels.Labels, filenames ...string,
+) (map[string]*Group, []error) {
+	groups := make(map[string]*Group)
+
+	shouldRestore := !m.restored
+
+	for _, fn := range filenames {
+		rgs, errs := rulefmt.ParseFile(fn)
+		if errs != nil {
+			return nil, errs
+		}
+
+		for _, rg := range rgs.Groups {
+			itv := interval
+			if rg.Interval != 0 {
+				itv = time.Duration(rg.Interval)
+			}
+
+			rules := make([]Rule, 0, len(rg.Rules))
+			for _, r := range rg.Rules {
+				// Cortex-Note: uses ParseExpr field in options instead of hardcoded parser.ParseExpr
+				expr, err := m.opts.ParseExpr(r.Expr.Value)
+				if err != nil {
+					return nil, []error{errors.Wrap(err, fn)}
+				}
+
+				if r.Alert.Value != "" {
+					rules = append(rules, NewAlertingRule(
+						r.Alert.Value,
+						expr,
+						time.Duration(r.For),
+						labels.FromMap(r.Labels),
+						labels.FromMap(r.Annotations),
+						externalLabels,
+						m.restored,
+						log.With(m.logger, "alert", r.Alert),
+					))
+					continue
+				}
+				rules = append(rules, NewRecordingRule(
+					r.Record.Value,
+					expr,
+					labels.FromMap(r.Labels),
+				))
+			}
+
+			groups[groupKey(fn, rg.Name)] = NewGroup(rg.Name, fn, itv, rules, shouldRestore, m.opts)
+		}
+	}
+
+	return groups, nil
+}
+
+// Group names need not be unique across filenames.
+func groupKey(file, name string) string {
+	return file + ";" + name
+}
+
+// RuleGroups returns the list of manager's rule groups.
+func (m *Manager) RuleGroups() []*Group {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	rgs := make([]*Group, 0, len(m.groups))
+	for _, g := range m.groups {
+		rgs = append(rgs, g)
+	}
+
+	sort.Slice(rgs, func(i, j int) bool {
+		if rgs[i].file != rgs[j].file {
+			return rgs[i].file < rgs[j].file
+		}
+		return rgs[i].name < rgs[j].name
+	})
+
+	return rgs
+}
+
+// Rules returns the list of the manager's rules.
+func (m *Manager) Rules() []Rule {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	var rules []Rule
+	for _, g := range m.groups {
+		rules = append(rules, g.rules...)
+	}
+
+	return rules
+}
+
+// AlertingRules returns the list of the manager's alerting rules.
+func (m *Manager) AlertingRules() []*AlertingRule {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	alerts := []*AlertingRule{}
+	for _, rule := range m.Rules() {
+		if alertingRule, ok := rule.(*AlertingRule); ok {
+			alerts = append(alerts, alertingRule)
+		}
+	}
+
+	return alerts
+}

--- a/pkg/ruler/rules/manager_test.go
+++ b/pkg/ruler/rules/manager_test.go
@@ -531,9 +531,12 @@ func TestStaleness(t *testing.T) {
 
 	// A time series that has two samples and then goes stale.
 	app := storage.Appender()
-	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 0, 1)
-	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 1000, 2)
-	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 2000, math.Float64frombits(value.StaleNaN))
+	_, err = app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 0, 1)
+	testutil.Ok(t, err)
+	_, err = app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 1000, 2)
+	testutil.Ok(t, err)
+	_, err = app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 2000, math.Float64frombits(value.StaleNaN))
+	testutil.Ok(t, err)
 
 	err = app.Commit()
 	testutil.Ok(t, err)
@@ -642,7 +645,7 @@ func TestCopyState(t *testing.T) {
 	testutil.Equals(t, want, newGroup.seriesInPreviousEval)
 	testutil.Equals(t, oldGroup.rules[0], newGroup.rules[3])
 	testutil.Equals(t, oldGroup.evaluationDuration, newGroup.evaluationDuration)
-	testutil.Equals(t, []labels.Labels{labels.Labels{{Name: "l1", Value: "v3"}}}, newGroup.staleSeries)
+	testutil.Equals(t, []labels.Labels{{{Name: "l1", Value: "v3"}}}, newGroup.staleSeries)
 }
 
 func TestDeletedRuleMarkedStale(t *testing.T) {
@@ -810,7 +813,8 @@ func formatRules(r *rulefmt.RuleGroups) ruleGroupsTest {
 func reloadAndValidate(rgs *rulefmt.RuleGroups, t *testing.T, tmpFile *os.File, ruleManager *Manager, expected map[string]labels.Labels, ogs map[string]*Group) {
 	bs, err := yaml.Marshal(formatRules(rgs))
 	testutil.Ok(t, err)
-	tmpFile.Seek(0, 0)
+	_, err = tmpFile.Seek(0, 0)
+	testutil.Ok(t, err)
 	_, err = tmpFile.Write(bs)
 	testutil.Ok(t, err)
 	err = ruleManager.Update(10*time.Second, []string{tmpFile.Name()}, nil)
@@ -853,10 +857,14 @@ func TestNotify(t *testing.T) {
 	group := NewGroup("alert", "", time.Second, []Rule{rule}, true, opts)
 
 	app := storage.Appender()
-	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 1000, 2)
-	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 2000, 3)
-	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 5000, 3)
-	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 6000, 0)
+	_, err = app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 1000, 2)
+	testutil.Ok(t, err)
+	_, err = app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 2000, 3)
+	testutil.Ok(t, err)
+	_, err = app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 5000, 3)
+	testutil.Ok(t, err)
+	_, err = app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 6000, 0)
+	testutil.Ok(t, err)
 
 	err = app.Commit()
 	testutil.Ok(t, err)

--- a/pkg/ruler/rules/manager_test.go
+++ b/pkg/ruler/rules/manager_test.go
@@ -1,0 +1,959 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/prometheus/prometheus/pkg/value"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/teststorage"
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+// Cortex-Note: test adapter which disregards rule
+type AppendableAdapter struct{ storage.Storage }
+
+func (a AppendableAdapter) Appender(_ Rule) (storage.Appender, error) {
+	return a.Storage.Appender(), nil
+}
+
+func TestAlertingRule(t *testing.T) {
+	suite, err := promql.NewTest(t, `
+		load 5m
+			http_requests{job="app-server", instance="0", group="canary", severity="overwrite-me"}	75 85  95 105 105  95  85
+			http_requests{job="app-server", instance="1", group="canary", severity="overwrite-me"}	80 90 100 110 120 130 140
+	`)
+	testutil.Ok(t, err)
+	defer suite.Close()
+
+	err = suite.Run()
+	testutil.Ok(t, err)
+
+	expr, err := parser.ParseExpr(`http_requests{group="canary", job="app-server"} < 100`)
+	testutil.Ok(t, err)
+
+	rule := NewAlertingRule(
+		"HTTPRequestRateLow",
+		expr,
+		time.Minute,
+		labels.FromStrings("severity", "{{\"c\"}}ritical"),
+		nil, nil, true, nil,
+	)
+	result := promql.Vector{
+		{
+			Metric: labels.FromStrings(
+				"__name__", "ALERTS",
+				"alertname", "HTTPRequestRateLow",
+				"alertstate", "pending",
+				"group", "canary",
+				"instance", "0",
+				"job", "app-server",
+				"severity", "critical",
+			),
+			Point: promql.Point{V: 1},
+		},
+		{
+			Metric: labels.FromStrings(
+				"__name__", "ALERTS",
+				"alertname", "HTTPRequestRateLow",
+				"alertstate", "pending",
+				"group", "canary",
+				"instance", "1",
+				"job", "app-server",
+				"severity", "critical",
+			),
+			Point: promql.Point{V: 1},
+		},
+		{
+			Metric: labels.FromStrings(
+				"__name__", "ALERTS",
+				"alertname", "HTTPRequestRateLow",
+				"alertstate", "firing",
+				"group", "canary",
+				"instance", "0",
+				"job", "app-server",
+				"severity", "critical",
+			),
+			Point: promql.Point{V: 1},
+		},
+		{
+			Metric: labels.FromStrings(
+				"__name__", "ALERTS",
+				"alertname", "HTTPRequestRateLow",
+				"alertstate", "firing",
+				"group", "canary",
+				"instance", "1",
+				"job", "app-server",
+				"severity", "critical",
+			),
+			Point: promql.Point{V: 1},
+		},
+	}
+
+	baseTime := time.Unix(0, 0)
+
+	var tests = []struct {
+		time   time.Duration
+		result promql.Vector
+	}{
+		{
+			time:   0,
+			result: result[:2],
+		}, {
+			time:   5 * time.Minute,
+			result: result[2:],
+		}, {
+			time:   10 * time.Minute,
+			result: result[2:3],
+		},
+		{
+			time:   15 * time.Minute,
+			result: nil,
+		},
+		{
+			time:   20 * time.Minute,
+			result: nil,
+		},
+		{
+			time:   25 * time.Minute,
+			result: result[:1],
+		},
+		{
+			time:   30 * time.Minute,
+			result: result[2:3],
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("case %d", i)
+
+		evalTime := baseTime.Add(test.time)
+
+		res, err := rule.Eval(suite.Context(), evalTime, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil)
+		testutil.Ok(t, err)
+
+		var filteredRes promql.Vector // After removing 'ALERTS_FOR_STATE' samples.
+		for _, smpl := range res {
+			smplName := smpl.Metric.Get("__name__")
+			if smplName == "ALERTS" {
+				filteredRes = append(filteredRes, smpl)
+			} else {
+				// If not 'ALERTS', it has to be 'ALERTS_FOR_STATE'.
+				testutil.Equals(t, smplName, "ALERTS_FOR_STATE")
+			}
+		}
+		for i := range test.result {
+			test.result[i].T = timestamp.FromTime(evalTime)
+		}
+		testutil.Assert(t, len(test.result) == len(filteredRes), "%d. Number of samples in expected and actual output don't match (%d vs. %d)", i, len(test.result), len(res))
+
+		sort.Slice(filteredRes, func(i, j int) bool {
+			return labels.Compare(filteredRes[i].Metric, filteredRes[j].Metric) < 0
+		})
+		testutil.Equals(t, test.result, filteredRes)
+
+		for _, aa := range rule.ActiveAlerts() {
+			testutil.Assert(t, aa.Labels.Get(model.MetricNameLabel) == "", "%s label set on active alert: %s", model.MetricNameLabel, aa.Labels)
+		}
+	}
+}
+
+func TestForStateAddSamples(t *testing.T) {
+	suite, err := promql.NewTest(t, `
+		load 5m
+			http_requests{job="app-server", instance="0", group="canary", severity="overwrite-me"}	75 85  95 105 105  95  85
+			http_requests{job="app-server", instance="1", group="canary", severity="overwrite-me"}	80 90 100 110 120 130 140
+	`)
+	testutil.Ok(t, err)
+	defer suite.Close()
+
+	err = suite.Run()
+	testutil.Ok(t, err)
+
+	expr, err := parser.ParseExpr(`http_requests{group="canary", job="app-server"} < 100`)
+	testutil.Ok(t, err)
+
+	rule := NewAlertingRule(
+		"HTTPRequestRateLow",
+		expr,
+		time.Minute,
+		labels.FromStrings("severity", "{{\"c\"}}ritical"),
+		nil, nil, true, nil,
+	)
+	result := promql.Vector{
+		{
+			Metric: labels.FromStrings(
+				"__name__", "ALERTS_FOR_STATE",
+				"alertname", "HTTPRequestRateLow",
+				"group", "canary",
+				"instance", "0",
+				"job", "app-server",
+				"severity", "critical",
+			),
+			Point: promql.Point{V: 1},
+		},
+		{
+			Metric: labels.FromStrings(
+				"__name__", "ALERTS_FOR_STATE",
+				"alertname", "HTTPRequestRateLow",
+				"group", "canary",
+				"instance", "1",
+				"job", "app-server",
+				"severity", "critical",
+			),
+			Point: promql.Point{V: 1},
+		},
+		{
+			Metric: labels.FromStrings(
+				"__name__", "ALERTS_FOR_STATE",
+				"alertname", "HTTPRequestRateLow",
+				"group", "canary",
+				"instance", "0",
+				"job", "app-server",
+				"severity", "critical",
+			),
+			Point: promql.Point{V: 1},
+		},
+		{
+			Metric: labels.FromStrings(
+				"__name__", "ALERTS_FOR_STATE",
+				"alertname", "HTTPRequestRateLow",
+				"group", "canary",
+				"instance", "1",
+				"job", "app-server",
+				"severity", "critical",
+			),
+			Point: promql.Point{V: 1},
+		},
+	}
+
+	baseTime := time.Unix(0, 0)
+
+	var tests = []struct {
+		time            time.Duration
+		result          promql.Vector
+		persistThisTime bool // If true, it means this 'time' is persisted for 'for'.
+	}{
+		{
+			time:            0,
+			result:          append(promql.Vector{}, result[:2]...),
+			persistThisTime: true,
+		},
+		{
+			time:   5 * time.Minute,
+			result: append(promql.Vector{}, result[2:]...),
+		},
+		{
+			time:   10 * time.Minute,
+			result: append(promql.Vector{}, result[2:3]...),
+		},
+		{
+			time:   15 * time.Minute,
+			result: nil,
+		},
+		{
+			time:   20 * time.Minute,
+			result: nil,
+		},
+		{
+			time:            25 * time.Minute,
+			result:          append(promql.Vector{}, result[:1]...),
+			persistThisTime: true,
+		},
+		{
+			time:   30 * time.Minute,
+			result: append(promql.Vector{}, result[2:3]...),
+		},
+	}
+
+	var forState float64
+	for i, test := range tests {
+		t.Logf("case %d", i)
+		evalTime := baseTime.Add(test.time)
+
+		if test.persistThisTime {
+			forState = float64(evalTime.Unix())
+		}
+		if test.result == nil {
+			forState = float64(value.StaleNaN)
+		}
+
+		res, err := rule.Eval(suite.Context(), evalTime, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil)
+		testutil.Ok(t, err)
+
+		var filteredRes promql.Vector // After removing 'ALERTS' samples.
+		for _, smpl := range res {
+			smplName := smpl.Metric.Get("__name__")
+			if smplName == "ALERTS_FOR_STATE" {
+				filteredRes = append(filteredRes, smpl)
+			} else {
+				// If not 'ALERTS_FOR_STATE', it has to be 'ALERTS'.
+				testutil.Equals(t, smplName, "ALERTS")
+			}
+		}
+		for i := range test.result {
+			test.result[i].T = timestamp.FromTime(evalTime)
+			// Updating the expected 'for' state.
+			if test.result[i].V >= 0 {
+				test.result[i].V = forState
+			}
+		}
+		testutil.Assert(t, len(test.result) == len(filteredRes), "%d. Number of samples in expected and actual output don't match (%d vs. %d)", i, len(test.result), len(res))
+
+		sort.Slice(filteredRes, func(i, j int) bool {
+			return labels.Compare(filteredRes[i].Metric, filteredRes[j].Metric) < 0
+		})
+		testutil.Equals(t, test.result, filteredRes)
+
+		for _, aa := range rule.ActiveAlerts() {
+			testutil.Assert(t, aa.Labels.Get(model.MetricNameLabel) == "", "%s label set on active alert: %s", model.MetricNameLabel, aa.Labels)
+		}
+
+	}
+}
+
+// sortAlerts sorts `[]*Alert` w.r.t. the Labels.
+func sortAlerts(items []*Alert) {
+	sort.Slice(items, func(i, j int) bool {
+		return labels.Compare(items[i].Labels, items[j].Labels) <= 0
+	})
+}
+
+func TestForStateRestore(t *testing.T) {
+	suite, err := promql.NewTest(t, `
+		load 5m
+		http_requests{job="app-server", instance="0", group="canary", severity="overwrite-me"}	75  85 50 0 0 25 0 0 40 0 120
+		http_requests{job="app-server", instance="1", group="canary", severity="overwrite-me"}	125 90 60 0 0 25 0 0 40 0 130
+	`)
+	testutil.Ok(t, err)
+	defer suite.Close()
+
+	err = suite.Run()
+	testutil.Ok(t, err)
+
+	expr, err := parser.ParseExpr(`http_requests{group="canary", job="app-server"} < 100`)
+	testutil.Ok(t, err)
+
+	opts := &ManagerOptions{
+		QueryFunc:       EngineQueryFunc(suite.QueryEngine(), suite.Storage()),
+		Appendable:      AppendableAdapter{suite.Storage()},
+		Context:         context.Background(),
+		Logger:          log.NewNopLogger(),
+		NotifyFunc:      func(ctx context.Context, expr string, alerts ...*Alert) {},
+		OutageTolerance: 30 * time.Minute,
+		ForGracePeriod:  10 * time.Minute,
+	}
+	opts.AlertHistory = NewMetricsHistory(suite.Storage(), opts)
+
+	alertForDuration := 25 * time.Minute
+	// Initial run before prometheus goes down.
+	rule := NewAlertingRule(
+		"HTTPRequestRateLow",
+		expr,
+		alertForDuration,
+		labels.FromStrings("severity", "critical"),
+		nil, nil, true, nil,
+	)
+
+	group := NewGroup("default", "", time.Second, []Rule{rule}, true, opts)
+	groups := make(map[string]*Group)
+	groups["default;"] = group
+
+	initialRuns := []time.Duration{0, 5 * time.Minute}
+
+	baseTime := time.Unix(0, 0)
+	for _, duration := range initialRuns {
+		evalTime := baseTime.Add(duration)
+		group.Eval(suite.Context(), evalTime)
+	}
+
+	exp := rule.ActiveAlerts()
+	for _, aa := range exp {
+		testutil.Assert(t, aa.Labels.Get(model.MetricNameLabel) == "", "%s label set on active alert: %s", model.MetricNameLabel, aa.Labels)
+	}
+	sort.Slice(exp, func(i, j int) bool {
+		return labels.Compare(exp[i].Labels, exp[j].Labels) < 0
+	})
+
+	// Prometheus goes down here. We create new rules and groups.
+	type testInput struct {
+		restoreDuration time.Duration
+		alerts          []*Alert
+
+		num          int
+		noRestore    bool
+		gracePeriod  bool
+		downDuration time.Duration
+	}
+
+	tests := []testInput{
+		{
+			// Normal restore (alerts were not firing).
+			restoreDuration: 15 * time.Minute,
+			alerts:          rule.ActiveAlerts(),
+			downDuration:    10 * time.Minute,
+		},
+		{
+			// Testing Outage Tolerance.
+			restoreDuration: 40 * time.Minute,
+			noRestore:       true,
+			num:             2,
+		},
+		{
+			// No active alerts.
+			restoreDuration: 50 * time.Minute,
+			alerts:          []*Alert{},
+		},
+	}
+
+	testFunc := func(tst testInput) {
+		newRule := NewAlertingRule(
+			"HTTPRequestRateLow",
+			expr,
+			alertForDuration,
+			labels.FromStrings("severity", "critical"),
+			nil, nil, false, nil,
+		)
+		newGroup := NewGroup("default", "", time.Second, []Rule{newRule}, true, opts)
+
+		newGroups := make(map[string]*Group)
+		newGroups["default;"] = newGroup
+
+		restoreTime := baseTime.Add(tst.restoreDuration)
+		// First eval before restoration.
+		newGroup.Eval(suite.Context(), restoreTime)
+		// Restore happens here.
+		newGroup.RestoreForState(restoreTime)
+
+		got := newRule.ActiveAlerts()
+		for _, aa := range got {
+			testutil.Assert(t, aa.Labels.Get(model.MetricNameLabel) == "", "%s label set on active alert: %s", model.MetricNameLabel, aa.Labels)
+		}
+		sort.Slice(got, func(i, j int) bool {
+			return labels.Compare(got[i].Labels, got[j].Labels) < 0
+		})
+
+		// Checking if we have restored it correctly.
+		if tst.noRestore {
+			testutil.Equals(t, tst.num, len(got))
+			for _, e := range got {
+				testutil.Equals(t, e.ActiveAt, restoreTime)
+			}
+		} else if tst.gracePeriod {
+			testutil.Equals(t, tst.num, len(got))
+			for _, e := range got {
+				testutil.Equals(t, opts.ForGracePeriod, e.ActiveAt.Add(alertForDuration).Sub(restoreTime))
+			}
+		} else {
+			exp := tst.alerts
+			testutil.Equals(t, len(exp), len(got))
+			sortAlerts(exp)
+			sortAlerts(got)
+			for i, e := range exp {
+				testutil.Equals(t, e.Labels, got[i].Labels)
+
+				// Difference in time should be within 1e6 ns, i.e. 1ms
+				// (due to conversion between ns & ms, float64 & int64).
+				activeAtDiff := float64(e.ActiveAt.Unix() + int64(tst.downDuration/time.Second) - got[i].ActiveAt.Unix())
+				testutil.Assert(t, math.Abs(activeAtDiff) == 0, "'for' state restored time is wrong")
+			}
+		}
+	}
+
+	for _, tst := range tests {
+		testFunc(tst)
+	}
+
+	// Testing the grace period.
+	for _, duration := range []time.Duration{10 * time.Minute, 15 * time.Minute, 20 * time.Minute} {
+		evalTime := baseTime.Add(duration)
+		group.Eval(suite.Context(), evalTime)
+	}
+	testFunc(testInput{
+		restoreDuration: 25 * time.Minute,
+		alerts:          []*Alert{},
+		gracePeriod:     true,
+		num:             2,
+	})
+}
+
+func TestStaleness(t *testing.T) {
+	storage := teststorage.New(t)
+	defer storage.Close()
+	engineOpts := promql.EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := promql.NewEngine(engineOpts)
+	opts := &ManagerOptions{
+		QueryFunc:  EngineQueryFunc(engine, storage),
+		Appendable: AppendableAdapter{storage},
+		Context:    context.Background(),
+		Logger:     log.NewNopLogger(),
+	}
+	opts.AlertHistory = NewMetricsHistory(storage, opts)
+
+	expr, err := parser.ParseExpr("a + 1")
+	testutil.Ok(t, err)
+	rule := NewRecordingRule("a_plus_one", expr, labels.Labels{})
+	group := NewGroup("default", "", time.Second, []Rule{rule}, true, opts)
+
+	// A time series that has two samples and then goes stale.
+	app := storage.Appender()
+	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 0, 1)
+	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 1000, 2)
+	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 2000, math.Float64frombits(value.StaleNaN))
+
+	err = app.Commit()
+	testutil.Ok(t, err)
+
+	ctx := context.Background()
+
+	// Execute 3 times, 1 second apart.
+	group.Eval(ctx, time.Unix(0, 0))
+	group.Eval(ctx, time.Unix(1, 0))
+	group.Eval(ctx, time.Unix(2, 0))
+
+	querier, err := storage.Querier(context.Background(), 0, 2000)
+	testutil.Ok(t, err)
+	defer querier.Close()
+
+	matcher, err := labels.NewMatcher(labels.MatchEqual, model.MetricNameLabel, "a_plus_one")
+	testutil.Ok(t, err)
+
+	set := querier.Select(false, nil, matcher)
+
+	samples, err := readSeriesSet(set)
+	testutil.Ok(t, err)
+
+	metric := labels.FromStrings(model.MetricNameLabel, "a_plus_one").String()
+	metricSample, ok := samples[metric]
+
+	testutil.Assert(t, ok, "Series %s not returned.", metric)
+	testutil.Assert(t, value.IsStaleNaN(metricSample[2].V), "Appended second sample not as expected. Wanted: stale NaN Got: %x", math.Float64bits(metricSample[2].V))
+	metricSample[2].V = 42 // reflect.DeepEqual cannot handle NaN.
+
+	want := map[string][]promql.Point{
+		metric: {{T: 0, V: 2}, {T: 1000, V: 3}, {T: 2000, V: 42}},
+	}
+
+	testutil.Equals(t, want, samples)
+}
+
+// Convert a SeriesSet into a form usable with reflect.DeepEqual.
+func readSeriesSet(ss storage.SeriesSet) (map[string][]promql.Point, error) {
+	result := map[string][]promql.Point{}
+
+	for ss.Next() {
+		series := ss.At()
+
+		points := []promql.Point{}
+		it := series.Iterator()
+		for it.Next() {
+			t, v := it.At()
+			points = append(points, promql.Point{T: t, V: v})
+		}
+
+		name := series.Labels().String()
+		result[name] = points
+	}
+	return result, ss.Err()
+}
+
+func TestCopyState(t *testing.T) {
+	oldGroup := &Group{
+		rules: []Rule{
+			NewAlertingRule("alert", nil, 0, nil, nil, nil, true, nil),
+			NewRecordingRule("rule1", nil, nil),
+			NewRecordingRule("rule2", nil, nil),
+			NewRecordingRule("rule3", nil, labels.Labels{{Name: "l1", Value: "v1"}}),
+			NewRecordingRule("rule3", nil, labels.Labels{{Name: "l1", Value: "v2"}}),
+			NewRecordingRule("rule3", nil, labels.Labels{{Name: "l1", Value: "v3"}}),
+			NewAlertingRule("alert2", nil, 0, labels.Labels{{Name: "l2", Value: "v1"}}, nil, nil, true, nil),
+		},
+		seriesInPreviousEval: []map[string]labels.Labels{
+			{},
+			{},
+			{},
+			{"r3a": labels.Labels{{Name: "l1", Value: "v1"}}},
+			{"r3b": labels.Labels{{Name: "l1", Value: "v2"}}},
+			{"r3c": labels.Labels{{Name: "l1", Value: "v3"}}},
+			{"a2": labels.Labels{{Name: "l2", Value: "v1"}}},
+		},
+		evaluationDuration: time.Second,
+	}
+	oldGroup.rules[0].(*AlertingRule).active[42] = nil
+	newGroup := &Group{
+		rules: []Rule{
+			NewRecordingRule("rule3", nil, labels.Labels{{Name: "l1", Value: "v0"}}),
+			NewRecordingRule("rule3", nil, labels.Labels{{Name: "l1", Value: "v1"}}),
+			NewRecordingRule("rule3", nil, labels.Labels{{Name: "l1", Value: "v2"}}),
+			NewAlertingRule("alert", nil, 0, nil, nil, nil, true, nil),
+			NewRecordingRule("rule1", nil, nil),
+			NewAlertingRule("alert2", nil, 0, labels.Labels{{Name: "l2", Value: "v0"}}, nil, nil, true, nil),
+			NewAlertingRule("alert2", nil, 0, labels.Labels{{Name: "l2", Value: "v1"}}, nil, nil, true, nil),
+			NewRecordingRule("rule4", nil, nil),
+		},
+		seriesInPreviousEval: make([]map[string]labels.Labels, 8),
+	}
+	newGroup.CopyState(oldGroup)
+
+	want := []map[string]labels.Labels{
+		nil,
+		{"r3a": labels.Labels{{Name: "l1", Value: "v1"}}},
+		{"r3b": labels.Labels{{Name: "l1", Value: "v2"}}},
+		{},
+		{},
+		nil,
+		{"a2": labels.Labels{{Name: "l2", Value: "v1"}}},
+		nil,
+	}
+	testutil.Equals(t, want, newGroup.seriesInPreviousEval)
+	testutil.Equals(t, oldGroup.rules[0], newGroup.rules[3])
+	testutil.Equals(t, oldGroup.evaluationDuration, newGroup.evaluationDuration)
+	testutil.Equals(t, []labels.Labels{labels.Labels{{Name: "l1", Value: "v3"}}}, newGroup.staleSeries)
+}
+
+func TestDeletedRuleMarkedStale(t *testing.T) {
+	storage := teststorage.New(t)
+	defer storage.Close()
+	oldGroup := &Group{
+		rules: []Rule{
+			NewRecordingRule("rule1", nil, labels.Labels{{Name: "l1", Value: "v1"}}),
+		},
+		seriesInPreviousEval: []map[string]labels.Labels{
+			{"r1": labels.Labels{{Name: "l1", Value: "v1"}}},
+		},
+	}
+	newGroup := &Group{
+		rules:                []Rule{},
+		seriesInPreviousEval: []map[string]labels.Labels{},
+		opts: &ManagerOptions{
+			Appendable: AppendableAdapter{storage},
+		},
+	}
+	newGroup.CopyState(oldGroup)
+
+	newGroup.Eval(context.Background(), time.Unix(0, 0))
+
+	querier, err := storage.Querier(context.Background(), 0, 2000)
+	testutil.Ok(t, err)
+	defer querier.Close()
+
+	matcher, err := labels.NewMatcher(labels.MatchEqual, "l1", "v1")
+	testutil.Ok(t, err)
+
+	set := querier.Select(false, nil, matcher)
+
+	samples, err := readSeriesSet(set)
+	testutil.Ok(t, err)
+
+	metric := labels.FromStrings("l1", "v1").String()
+	metricSample, ok := samples[metric]
+
+	testutil.Assert(t, ok, "Series %s not returned.", metric)
+	testutil.Assert(t, value.IsStaleNaN(metricSample[0].V), "Appended sample not as expected. Wanted: stale NaN Got: %x", math.Float64bits(metricSample[0].V))
+}
+
+func TestUpdate(t *testing.T) {
+	files := []string{"fixtures/rules.yaml"}
+	expected := map[string]labels.Labels{
+		"test": labels.FromStrings("name", "value"),
+	}
+	storage := teststorage.New(t)
+	defer storage.Close()
+	opts := promql.EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := promql.NewEngine(opts)
+	mo := &ManagerOptions{
+		Appendable: AppendableAdapter{storage},
+		QueryFunc:  EngineQueryFunc(engine, storage),
+		Context:    context.Background(),
+		Logger:     log.NewNopLogger(),
+	}
+	mo.AlertHistory = NewMetricsHistory(storage, mo)
+	ruleManager := NewManager(mo)
+
+	ruleManager.Run()
+	defer ruleManager.Stop()
+
+	err := ruleManager.Update(10*time.Second, files, nil)
+	testutil.Ok(t, err)
+	testutil.Assert(t, len(ruleManager.groups) > 0, "expected non-empty rule groups")
+	ogs := map[string]*Group{}
+	for h, g := range ruleManager.groups {
+		g.seriesInPreviousEval = []map[string]labels.Labels{
+			expected,
+		}
+		ogs[h] = g
+	}
+
+	err = ruleManager.Update(10*time.Second, files, nil)
+	testutil.Ok(t, err)
+	for h, g := range ruleManager.groups {
+		for _, actual := range g.seriesInPreviousEval {
+			testutil.Equals(t, expected, actual)
+		}
+		// Groups are the same because of no updates.
+		testutil.Equals(t, ogs[h], g)
+	}
+
+	// Groups will be recreated if updated.
+	rgs, errs := rulefmt.ParseFile("fixtures/rules.yaml")
+	testutil.Assert(t, len(errs) == 0, "file parsing failures")
+
+	tmpFile, err := ioutil.TempFile("", "rules.test.*.yaml")
+	testutil.Ok(t, err)
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	err = ruleManager.Update(10*time.Second, []string{tmpFile.Name()}, nil)
+	testutil.Ok(t, err)
+
+	for h, g := range ruleManager.groups {
+		ogs[h] = g
+	}
+
+	// Update interval and reload.
+	for i, g := range rgs.Groups {
+		if g.Interval != 0 {
+			rgs.Groups[i].Interval = g.Interval * 2
+		} else {
+			rgs.Groups[i].Interval = model.Duration(10)
+		}
+
+	}
+	reloadAndValidate(rgs, t, tmpFile, ruleManager, expected, ogs)
+
+	// Change group rules and reload.
+	for i, g := range rgs.Groups {
+		for j, r := range g.Rules {
+			rgs.Groups[i].Rules[j].Expr.SetString(fmt.Sprintf("%s * 0", r.Expr.Value))
+		}
+	}
+	reloadAndValidate(rgs, t, tmpFile, ruleManager, expected, ogs)
+}
+
+// ruleGroupsTest for running tests over rules.
+type ruleGroupsTest struct {
+	Groups []ruleGroupTest `yaml:"groups"`
+}
+
+// ruleGroupTest forms a testing struct for running tests over rules.
+type ruleGroupTest struct {
+	Name     string         `yaml:"name"`
+	Interval model.Duration `yaml:"interval,omitempty"`
+	Rules    []rulefmt.Rule `yaml:"rules"`
+}
+
+func formatRules(r *rulefmt.RuleGroups) ruleGroupsTest {
+	grps := r.Groups
+	tmp := []ruleGroupTest{}
+	for _, g := range grps {
+		rtmp := []rulefmt.Rule{}
+		for _, r := range g.Rules {
+			rtmp = append(rtmp, rulefmt.Rule{
+				Record:      r.Record.Value,
+				Alert:       r.Alert.Value,
+				Expr:        r.Expr.Value,
+				For:         r.For,
+				Labels:      r.Labels,
+				Annotations: r.Annotations,
+			})
+		}
+		tmp = append(tmp, ruleGroupTest{
+			Name:     g.Name,
+			Interval: g.Interval,
+			Rules:    rtmp,
+		})
+	}
+	return ruleGroupsTest{
+		Groups: tmp,
+	}
+}
+
+func reloadAndValidate(rgs *rulefmt.RuleGroups, t *testing.T, tmpFile *os.File, ruleManager *Manager, expected map[string]labels.Labels, ogs map[string]*Group) {
+	bs, err := yaml.Marshal(formatRules(rgs))
+	testutil.Ok(t, err)
+	tmpFile.Seek(0, 0)
+	_, err = tmpFile.Write(bs)
+	testutil.Ok(t, err)
+	err = ruleManager.Update(10*time.Second, []string{tmpFile.Name()}, nil)
+	testutil.Ok(t, err)
+	for h, g := range ruleManager.groups {
+		if ogs[h] == g {
+			t.Fail()
+		}
+		ogs[h] = g
+	}
+}
+
+func TestNotify(t *testing.T) {
+	storage := teststorage.New(t)
+	defer storage.Close()
+	engineOpts := promql.EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := promql.NewEngine(engineOpts)
+	var lastNotified []*Alert
+	notifyFunc := func(ctx context.Context, expr string, alerts ...*Alert) {
+		lastNotified = alerts
+	}
+	opts := &ManagerOptions{
+		QueryFunc:   EngineQueryFunc(engine, storage),
+		Appendable:  AppendableAdapter{storage},
+		Context:     context.Background(),
+		Logger:      log.NewNopLogger(),
+		NotifyFunc:  notifyFunc,
+		ResendDelay: 2 * time.Second,
+	}
+	opts.AlertHistory = NewMetricsHistory(storage, opts)
+
+	expr, err := parser.ParseExpr("a > 1")
+	testutil.Ok(t, err)
+	rule := NewAlertingRule("aTooHigh", expr, 0, labels.Labels{}, labels.Labels{}, nil, true, log.NewNopLogger())
+	group := NewGroup("alert", "", time.Second, []Rule{rule}, true, opts)
+
+	app := storage.Appender()
+	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 1000, 2)
+	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 2000, 3)
+	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 5000, 3)
+	app.Add(labels.FromStrings(model.MetricNameLabel, "a"), 6000, 0)
+
+	err = app.Commit()
+	testutil.Ok(t, err)
+
+	ctx := context.Background()
+
+	// Alert sent right away
+	group.Eval(ctx, time.Unix(1, 0))
+	testutil.Equals(t, 1, len(lastNotified))
+	testutil.Assert(t, !lastNotified[0].ValidUntil.IsZero(), "ValidUntil should not be zero")
+
+	// Alert is not sent 1s later
+	group.Eval(ctx, time.Unix(2, 0))
+	testutil.Equals(t, 0, len(lastNotified))
+
+	// Alert is resent at t=5s
+	group.Eval(ctx, time.Unix(5, 0))
+	testutil.Equals(t, 1, len(lastNotified))
+
+	// Resolution alert sent right away
+	group.Eval(ctx, time.Unix(6, 0))
+	testutil.Equals(t, 1, len(lastNotified))
+}
+
+func TestMetricsUpdate(t *testing.T) {
+	files := []string{"fixtures/rules.yaml", "fixtures/rules2.yaml"}
+	metricNames := []string{
+		"prometheus_rule_group_interval_seconds",
+		"prometheus_rule_group_last_duration_seconds",
+		"prometheus_rule_group_last_evaluation_timestamp_seconds",
+		"prometheus_rule_group_rules",
+	}
+
+	storage := teststorage.New(t)
+	registry := prometheus.NewRegistry()
+	defer storage.Close()
+	opts := promql.EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := promql.NewEngine(opts)
+	mo := &ManagerOptions{
+		Appendable: AppendableAdapter{storage},
+		QueryFunc:  EngineQueryFunc(engine, storage),
+		Context:    context.Background(),
+		Logger:     log.NewNopLogger(),
+		Registerer: registry,
+	}
+	mo.AlertHistory = NewMetricsHistory(storage, mo)
+	ruleManager := NewManager(mo)
+	ruleManager.Run()
+	defer ruleManager.Stop()
+
+	countMetrics := func() int {
+		ms, err := registry.Gather()
+		testutil.Ok(t, err)
+		var metrics int
+		for _, m := range ms {
+			s := m.GetName()
+			for _, n := range metricNames {
+				if s == n {
+					metrics += len(m.Metric)
+					break
+				}
+			}
+		}
+		return metrics
+	}
+
+	cases := []struct {
+		files   []string
+		metrics int
+	}{
+		{
+			files:   files,
+			metrics: 8,
+		},
+		{
+			files:   files[:1],
+			metrics: 4,
+		},
+		{
+			files:   files[:0],
+			metrics: 0,
+		},
+		{
+			files:   files[1:],
+			metrics: 4,
+		},
+	}
+
+	for i, c := range cases {
+		err := ruleManager.Update(time.Second, c.files, nil)
+		testutil.Ok(t, err)
+		time.Sleep(2 * time.Second)
+		testutil.Equals(t, c.metrics, countMetrics(), "test %d: invalid count of metrics", i)
+	}
+}

--- a/pkg/ruler/rules/recording.go
+++ b/pkg/ruler/rules/recording.go
@@ -1,0 +1,203 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"net/url"
+	"sync"
+	"time"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+// A RecordingRule records its vector expression into new timeseries.
+type RecordingRule struct {
+	name string
+	// Cortex-Note: this is changed to fmt.Stringer instead of a parser.Expr in order to facilitate arbitrary expressions.
+	vector fmt.Stringer
+	labels labels.Labels
+	// Protects the below.
+	mtx sync.Mutex
+	// The health of the recording rule.
+	health RuleHealth
+	// Timestamp of last evaluation of the recording rule.
+	evaluationTimestamp time.Time
+	// The last error seen by the recording rule.
+	lastError error
+	// Duration of how long it took to evaluate the recording rule.
+	evaluationDuration time.Duration
+}
+
+// NewRecordingRule returns a new recording rule.
+func NewRecordingRule(name string, vector fmt.Stringer, lset labels.Labels) *RecordingRule {
+	return &RecordingRule{
+		name:   name,
+		vector: vector,
+		health: HealthUnknown,
+		labels: lset,
+	}
+}
+
+// Name returns the rule name.
+func (rule *RecordingRule) Name() string {
+	return rule.name
+}
+
+// Query returns the rule query expression.
+func (rule *RecordingRule) Query() fmt.Stringer {
+	return rule.vector
+}
+
+// Labels returns the rule labels.
+func (rule *RecordingRule) Labels() labels.Labels {
+	return rule.labels
+}
+
+// Eval evaluates the rule and then overrides the metric names and labels accordingly.
+func (rule *RecordingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, _ *url.URL) (promql.Vector, error) {
+	vector, err := query(ctx, rule.vector.String(), ts)
+	if err != nil {
+		rule.SetHealth(HealthBad)
+		rule.SetLastError(err)
+		return nil, err
+	}
+	// Override the metric name and labels.
+	for i := range vector {
+		sample := &vector[i]
+
+		lb := labels.NewBuilder(sample.Metric)
+
+		lb.Set(labels.MetricName, rule.name)
+
+		for _, l := range rule.labels {
+			lb.Set(l.Name, l.Value)
+		}
+
+		sample.Metric = lb.Labels()
+	}
+
+	// Check that the rule does not produce identical metrics after applying
+	// labels.
+	if vector.ContainsSameLabelset() {
+		err = fmt.Errorf("vector contains metrics with the same labelset after applying rule labels")
+		rule.SetHealth(HealthBad)
+		rule.SetLastError(err)
+		return nil, err
+	}
+
+	rule.SetHealth(HealthGood)
+	rule.SetLastError(err)
+	return vector, nil
+}
+
+func (rule *RecordingRule) String() string {
+	r := rulefmt.Rule{
+		Record: rule.name,
+		Expr:   rule.vector.String(),
+		Labels: rule.labels.Map(),
+	}
+
+	byt, err := yaml.Marshal(r)
+	if err != nil {
+		return fmt.Sprintf("error marshaling recording rule: %q", err.Error())
+	}
+
+	return string(byt)
+}
+
+// SetEvaluationDuration updates evaluationDuration to the time in seconds it took to evaluate the rule on its last evaluation.
+func (rule *RecordingRule) SetEvaluationDuration(dur time.Duration) {
+	rule.mtx.Lock()
+	defer rule.mtx.Unlock()
+	rule.evaluationDuration = dur
+}
+
+// SetLastError sets the current error seen by the recording rule.
+func (rule *RecordingRule) SetLastError(err error) {
+	rule.mtx.Lock()
+	defer rule.mtx.Unlock()
+	rule.lastError = err
+}
+
+// LastError returns the last error seen by the recording rule.
+func (rule *RecordingRule) LastError() error {
+	rule.mtx.Lock()
+	defer rule.mtx.Unlock()
+	return rule.lastError
+}
+
+// SetHealth sets the current health of the recording rule.
+func (rule *RecordingRule) SetHealth(health RuleHealth) {
+	rule.mtx.Lock()
+	defer rule.mtx.Unlock()
+	rule.health = health
+}
+
+// Health returns the current health of the recording rule.
+func (rule *RecordingRule) Health() RuleHealth {
+	rule.mtx.Lock()
+	defer rule.mtx.Unlock()
+	return rule.health
+}
+
+// GetEvaluationDuration returns the time in seconds it took to evaluate the recording rule.
+func (rule *RecordingRule) GetEvaluationDuration() time.Duration {
+	rule.mtx.Lock()
+	defer rule.mtx.Unlock()
+	return rule.evaluationDuration
+}
+
+// SetEvaluationTimestamp updates evaluationTimestamp to the timestamp of when the rule was last evaluated.
+func (rule *RecordingRule) SetEvaluationTimestamp(ts time.Time) {
+	rule.mtx.Lock()
+	defer rule.mtx.Unlock()
+	rule.evaluationTimestamp = ts
+}
+
+// GetEvaluationTimestamp returns the time the evaluation took place.
+func (rule *RecordingRule) GetEvaluationTimestamp() time.Time {
+	rule.mtx.Lock()
+	defer rule.mtx.Unlock()
+	return rule.evaluationTimestamp
+}
+
+// HTMLSnippet returns an HTML snippet representing this rule.
+func (rule *RecordingRule) HTMLSnippet(pathPrefix string) template.HTML {
+	ruleExpr := rule.vector.String()
+	labels := make(map[string]string, len(rule.labels))
+	for _, l := range rule.labels {
+		labels[l.Name] = template.HTMLEscapeString(l.Value)
+	}
+
+	r := rulefmt.Rule{
+		Record: fmt.Sprintf(`<a href="%s">%s</a>`, pathPrefix+strutil.TableLinkForExpression(rule.name), rule.name),
+		Expr:   fmt.Sprintf(`<a href="%s">%s</a>`, pathPrefix+strutil.TableLinkForExpression(ruleExpr), template.HTMLEscapeString(ruleExpr)),
+		Labels: labels,
+	}
+
+	byt, err := yaml.Marshal(r)
+	if err != nil {
+		return template.HTML(fmt.Sprintf("error marshaling recording rule: %q", template.HTMLEscapeString(err.Error())))
+	}
+
+	return template.HTML(byt)
+}

--- a/pkg/ruler/rules/recording_test.go
+++ b/pkg/ruler/rules/recording_test.go
@@ -1,0 +1,120 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/teststorage"
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestRuleEval(t *testing.T) {
+	storage := teststorage.New(t)
+	defer storage.Close()
+
+	opts := promql.EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+
+	engine := promql.NewEngine(opts)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	now := time.Now()
+
+	suite := []struct {
+		name   string
+		expr   parser.Expr
+		labels labels.Labels
+		result promql.Vector
+	}{
+		{
+			name:   "nolabels",
+			expr:   &parser.NumberLiteral{Val: 1},
+			labels: labels.Labels{},
+			result: promql.Vector{promql.Sample{
+				Metric: labels.FromStrings("__name__", "nolabels"),
+				Point:  promql.Point{V: 1, T: timestamp.FromTime(now)},
+			}},
+		},
+		{
+			name:   "labels",
+			expr:   &parser.NumberLiteral{Val: 1},
+			labels: labels.FromStrings("foo", "bar"),
+			result: promql.Vector{promql.Sample{
+				Metric: labels.FromStrings("__name__", "labels", "foo", "bar"),
+				Point:  promql.Point{V: 1, T: timestamp.FromTime(now)},
+			}},
+		},
+	}
+
+	for _, test := range suite {
+		rule := NewRecordingRule(test.name, test.expr, test.labels)
+		result, err := rule.Eval(ctx, now, EngineQueryFunc(engine, storage), nil)
+		testutil.Ok(t, err)
+		testutil.Equals(t, test.result, result)
+	}
+}
+
+func TestRecordingRuleHTMLSnippet(t *testing.T) {
+	expr, err := parser.ParseExpr(`foo{html="<b>BOLD<b>"}`)
+	testutil.Ok(t, err)
+	rule := NewRecordingRule("testrule", expr, labels.FromStrings("html", "<b>BOLD</b>"))
+
+	const want = `record: <a href="/test/prefix/graph?g0.expr=testrule&g0.tab=1">testrule</a>
+expr: <a href="/test/prefix/graph?g0.expr=foo%7Bhtml%3D%22%3Cb%3EBOLD%3Cb%3E%22%7D&g0.tab=1">foo{html=&#34;&lt;b&gt;BOLD&lt;b&gt;&#34;}</a>
+labels:
+  html: '&lt;b&gt;BOLD&lt;/b&gt;'
+`
+
+	got := rule.HTMLSnippet("/test/prefix")
+	testutil.Assert(t, want == got, "incorrect HTML snippet; want:\n\n%s\n\ngot:\n\n%s", want, got)
+}
+
+// TestRuleEvalDuplicate tests for duplicate labels in recorded metrics, see #5529.
+func TestRuleEvalDuplicate(t *testing.T) {
+	storage := teststorage.New(t)
+	defer storage.Close()
+
+	opts := promql.EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+
+	engine := promql.NewEngine(opts)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	now := time.Now()
+
+	expr, _ := parser.ParseExpr(`vector(0) or label_replace(vector(0),"test","x","","")`)
+	rule := NewRecordingRule("foo", expr, labels.FromStrings("test", "test"))
+	_, err := rule.Eval(ctx, now, EngineQueryFunc(engine, storage), nil)
+	testutil.NotOk(t, err)
+	e := fmt.Errorf("vector contains metrics with the same labelset after applying rule labels")
+	testutil.ErrorEqual(t, e, err)
+}


### PR DESCRIPTION
**What this PR does**:
Refactors & inhouses the prometheus `rules` package in order to allow it to evaluate arbitrary expressions and defer both pushing series & querying series to implementers. This primarily aids Loki which uses these interfaces to evaluate it's own alerts & maintain a synthetic series store in memory.

For instance, there is now a new interface responsible for restoring the `ALERTS_FOR_STATE` after i.e. restarts or ring re-sharding in cortex. The default implementation is still the same (pulled from prometheus via the `rules` pkg), but it also allows Loki to take advantage of the ruler as well.

```
// TenantAlertHistory is a tenant specific interface for restoring the for state of an alert after restarts/etc.
type TenantAlertHistory interface {
	RestoreForState(ts time.Time, alertRule *AlertingRule)
	Stop()
}
```

**Changes**:
- extends `ConcreteSeries` to support new manipulations & bound growth.
- pulls in prometheus rules pkg
- refactors said rules pkg via a few interfaces in order to support evaluating arbitrary rules

**Checklist**
- [x] Tests updated

**Disclaimer**:
This has been bundled into two commits. The first is responsible for bringing the prometheus rules package into cortex. All changes therein are denoted via `Cortex-Note` comments. I chose to subsume the entire rules package after first struggling with many unexported pieces of the package when trying to do it piecemeal. By including the entire package, it also allows us to easily refactor this again in the future should this be upstreamed in Prometheus.

The following commit shows the changes to the ruler to fulfill the required interfaces/etc.
