### PR TITLE
Added support for path prefix to query-tee.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   * `cortex_prometheus_notifications_queue_capacity`
   * `cortex_prometheus_notifications_alertmanagers_discovered`
 * [ENHANCEMENT] Added `-ingester.flush-on-shutdown-with-wal-enabled` option to enable chunks flushing even when WAL is enabled. #2780
+* [ENHANCEMENT] Query-tee: Support for custom API prefix. #2814
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   * `cortex_prometheus_notifications_queue_capacity`
   * `cortex_prometheus_notifications_alertmanagers_discovered`
 * [ENHANCEMENT] Added `-ingester.flush-on-shutdown-with-wal-enabled` option to enable chunks flushing even when WAL is enabled. #2780
-* [ENHANCEMENT] Query-tee: Support for custom API prefix. #2814
+* [ENHANCEMENT] Query-tee: Support for custom API prefix by using `-server.path-prefix` option. #2814
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762

--- a/cmd/query-tee/main_test.go
+++ b/cmd/query-tee/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCortexReadRoutes(t *testing.T) {
+	routes := cortexReadRoutes("")
+	for _, r := range routes {
+		assert.True(t, strings.HasPrefix(r.Path, "/api/v1/"))
+	}
+
+	routes = cortexReadRoutes("/some/random/prefix///")
+	for _, r := range routes {
+		assert.True(t, strings.HasPrefix(r.Path, "/some/random/prefix/api/v1/"))
+	}
+}


### PR DESCRIPTION
**What this PR does**: This PR adds support for custom prefix for API calls supported by query-tee.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
