### PR TITLE
Add support for forwarding X-Scope-OrgId.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [ENHANCEMENT] Add `-modules` command line flag to list possible values for `-target`. Also, log warning if given target is internal component. #2752
 * [ENHANCEMENT] Added `-ingester.flush-on-shutdown-with-wal-enabled` option to enable chunks flushing even when WAL is enabled. #2780
 * [ENHANCEMENT] Query-tee: Support for custom API prefix by using `-server.path-prefix` option. #2814
+* [ENHANCEMENT] Query-tee: Forward `X-Scope-OrgId` header to backend, if present in the request. #2815
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762

--- a/tools/querytee/proxy_backend.go
+++ b/tools/querytee/proxy_backend.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const orgIdHeader = "X-Scope-OrgId"
+const orgIDHeader = "X-Scope-OrgId"
 
 // ProxyBackend holds the information of a single backend.
 type ProxyBackend struct {
@@ -90,8 +90,8 @@ func (b *ProxyBackend) createBackendRequest(orig *http.Request) (*http.Request, 
 	}
 
 	// If there is X-Scope-OrgId header in the request, forward it. This is done even if there was username/password.
-	if orgId := orig.Header.Get(orgIdHeader); orgId != "" {
-		req.Header.Set(orgIdHeader, orgId)
+	if orgID := orig.Header.Get(orgIDHeader); orgID != "" {
+		req.Header.Set(orgIDHeader, orgID)
 	}
 
 	return req, nil

--- a/tools/querytee/proxy_backend.go
+++ b/tools/querytee/proxy_backend.go
@@ -12,6 +12,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const orgIdHeader = "X-Scope-OrgId"
+
 // ProxyBackend holds the information of a single backend.
 type ProxyBackend struct {
 	name     string
@@ -85,6 +87,11 @@ func (b *ProxyBackend) createBackendRequest(orig *http.Request) (*http.Request, 
 		req.SetBasicAuth(endpointUser, clientPass)
 	} else if clientAuth {
 		req.SetBasicAuth(clientUser, clientPass)
+	}
+
+	// If there is X-Scope-OrgId header in the request, forward it. This is done even if there was username/password.
+	if orgId := orig.Header.Get(orgIdHeader); orgId != "" {
+		req.Header.Set(orgIdHeader, orgId)
 	}
 
 	return req, nil


### PR DESCRIPTION
**What this PR does**: This PR adds support for forwarding `X-Scope-OrgId` header into query-tee.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
