### PR TITLE
Metrics for enqueue/flush reason, and dequeue/flush outcome.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * `cortex_bucket_stores_gate_queries_in_flight`
   * `cortex_bucket_stores_gate_duration_seconds`
 * [CHANGE] Metric `cortex_ingester_flush_reasons` has been renamed to `cortex_ingester_flushed_series_total`, and is now incremented during flush, not when series is enqueued for flushing. #2802, #2818
-* [CHANGE] Added `cortex_ingester_enqueued_series_total` with `reason` label and `cortex_ingester_dequeued_series_total` with `outcome` label (superset of reason). #2818
+* [CHANGE] Added `cortex_ingester_enqueued_series_total` with `reason` label (works the same as `cortex_ingester_flush_reasons` did before) and `cortex_ingester_dequeued_series_total` with `outcome` label (superset of reason). #2818
 * [CHANGE] Experimental Delete Series: Metric `cortex_purger_oldest_pending_delete_request_age_seconds` would track age of delete requests since they are over their cancellation period instead of their creation time. #2806
 * [CHANGE] Experimental TSDB: the store-gateway service is required in a Cortex cluster running with the experimental blocks storage. Removed the `-experimental.tsdb.store-gateway-enabled` CLI flag and `store_gateway_enabled` YAML config option. The store-gateway is now always enabled when the storage engine is `tsdb`. #2822
 * [CHANGE] Ingester: Chunks flushed via /flush stay in memory until retention period is reached. This affects `cortex_ingester_memory_chunks` metric. #2778

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   * `cortex_bucket_stores_gate_queries_concurrent_max`
   * `cortex_bucket_stores_gate_queries_in_flight`
   * `cortex_bucket_stores_gate_duration_seconds`
-* [CHANGE] Metric `cortex_ingester_flush_reasons` has been replaced with `cortex_ingester_flushing_enqueued_series_total` with `reason` label (works the same as `cortex_ingester_flush_reasons` did before) and `cortex_ingester_flushing_dequeued_series_total` with `outcome` label (superset of reason). #2802, #2818
+* [CHANGE] Metric `cortex_ingester_flush_reasons` has been renamed to `cortex_ingester_flushing_enqueued_series_total`, and new metric `cortex_ingester_flushing_dequeued_series_total` with `outcome` label (superset of reason) has been added. #2802, #2818
 * [CHANGE] Experimental Delete Series: Metric `cortex_purger_oldest_pending_delete_request_age_seconds` would track age of delete requests since they are over their cancellation period instead of their creation time. #2806
 * [CHANGE] Experimental TSDB: the store-gateway service is required in a Cortex cluster running with the experimental blocks storage. Removed the `-experimental.tsdb.store-gateway-enabled` CLI flag and `store_gateway_enabled` YAML config option. The store-gateway is now always enabled when the storage engine is `tsdb`. #2822
 * [CHANGE] Ingester: Chunks flushed via /flush stay in memory until retention period is reached. This affects `cortex_ingester_memory_chunks` metric. #2778

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
   * `cortex_bucket_stores_gate_queries_concurrent_max`
   * `cortex_bucket_stores_gate_queries_in_flight`
   * `cortex_bucket_stores_gate_duration_seconds`
-* [CHANGE] Metric `cortex_ingester_flush_reasons` has been renamed to `cortex_ingester_flushed_series_total`, and is now incremented during flush, not when series is enqueued for flushing. #2802, #2818
-* [CHANGE] Added `cortex_ingester_flushing_enqueued_series_total` with `reason` label (works the same as `cortex_ingester_flush_reasons` did before) and `cortex_ingester_flushing_dequeued_series_total` with `outcome` label (superset of reason). #2818
+* [CHANGE] Metric `cortex_ingester_flush_reasons` has been replaced with `cortex_ingester_flushing_enqueued_series_total` with `reason` label (works the same as `cortex_ingester_flush_reasons` did before) and `cortex_ingester_flushing_dequeued_series_total` with `outcome` label (superset of reason). #2802, #2818
 * [CHANGE] Experimental Delete Series: Metric `cortex_purger_oldest_pending_delete_request_age_seconds` would track age of delete requests since they are over their cancellation period instead of their creation time. #2806
 * [CHANGE] Experimental TSDB: the store-gateway service is required in a Cortex cluster running with the experimental blocks storage. Removed the `-experimental.tsdb.store-gateway-enabled` CLI flag and `store_gateway_enabled` YAML config option. The store-gateway is now always enabled when the storage engine is `tsdb`. #2822
 * [CHANGE] Ingester: Chunks flushed via /flush stay in memory until retention period is reached. This affects `cortex_ingester_memory_chunks` metric. #2778

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * `cortex_bucket_stores_gate_queries_in_flight`
   * `cortex_bucket_stores_gate_duration_seconds`
 * [CHANGE] Metric `cortex_ingester_flush_reasons` has been renamed to `cortex_ingester_flushed_series_total`, and is now incremented during flush, not when series is enqueued for flushing. #2802, #2818
-* [CHANGE] Added `cortex_ingester_enqueued_series_total` with `reason` label (works the same as `cortex_ingester_flush_reasons` did before) and `cortex_ingester_dequeued_series_total` with `outcome` label (superset of reason). #2818
+* [CHANGE] Added `cortex_ingester_flushing_enqueued_series_total` with `reason` label (works the same as `cortex_ingester_flush_reasons` did before) and `cortex_ingester_flushing_dequeued_series_total` with `outcome` label (superset of reason). #2818
 * [CHANGE] Experimental Delete Series: Metric `cortex_purger_oldest_pending_delete_request_age_seconds` would track age of delete requests since they are over their cancellation period instead of their creation time. #2806
 * [CHANGE] Experimental TSDB: the store-gateway service is required in a Cortex cluster running with the experimental blocks storage. Removed the `-experimental.tsdb.store-gateway-enabled` CLI flag and `store_gateway_enabled` YAML config option. The store-gateway is now always enabled when the storage engine is `tsdb`. #2822
 * [CHANGE] Ingester: Chunks flushed via /flush stay in memory until retention period is reached. This affects `cortex_ingester_memory_chunks` metric. #2778

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   * `cortex_bucket_stores_gate_queries_concurrent_max`
   * `cortex_bucket_stores_gate_queries_in_flight`
   * `cortex_bucket_stores_gate_duration_seconds`
-* [CHANGE] Metric `cortex_ingester_flush_reasons` has been renamed to `cortex_ingester_series_flushed_total`, and is now incremented during flush, not when series is enqueued for flushing. #2802
+* [CHANGE] Metric `cortex_ingester_flush_reasons` has been renamed to `cortex_ingester_flushed_series_total`, and is now incremented during flush, not when series is enqueued for flushing. #2802
+* [CHANGE] Added `cortex_ingester_enqueued_series_total` with `reason` label and `cortex_ingester_dequeued_series_total` with `outcome` label (superset of reason).
 * [CHANGE] Experimental Delete Series: Metric `cortex_purger_oldest_pending_delete_request_age_seconds` would track age of delete requests since they are over their cancellation period instead of their creation time. #2806
 * [CHANGE] Experimental TSDB: the store-gateway service is required in a Cortex cluster running with the experimental blocks storage. Removed the `-experimental.tsdb.store-gateway-enabled` CLI flag and `store_gateway_enabled` YAML config option. The store-gateway is now always enabled when the storage engine is `tsdb`. #2822
 * [CHANGE] Ingester: Chunks flushed via /flush stay in memory until retention period is reached. This affects `cortex_ingester_memory_chunks` metric. #2778

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
   * `cortex_bucket_stores_gate_queries_concurrent_max`
   * `cortex_bucket_stores_gate_queries_in_flight`
   * `cortex_bucket_stores_gate_duration_seconds`
-* [CHANGE] Metric `cortex_ingester_flush_reasons` has been renamed to `cortex_ingester_flushed_series_total`, and is now incremented during flush, not when series is enqueued for flushing. #2802
-* [CHANGE] Added `cortex_ingester_enqueued_series_total` with `reason` label and `cortex_ingester_dequeued_series_total` with `outcome` label (superset of reason).
+* [CHANGE] Metric `cortex_ingester_flush_reasons` has been renamed to `cortex_ingester_flushed_series_total`, and is now incremented during flush, not when series is enqueued for flushing. #2802, #2818
+* [CHANGE] Added `cortex_ingester_enqueued_series_total` with `reason` label and `cortex_ingester_dequeued_series_total` with `outcome` label (superset of reason). #2818
 * [CHANGE] Experimental Delete Series: Metric `cortex_purger_oldest_pending_delete_request_age_seconds` would track age of delete requests since they are over their cancellation period instead of their creation time. #2806
 * [CHANGE] Experimental TSDB: the store-gateway service is required in a Cortex cluster running with the experimental blocks storage. Removed the `-experimental.tsdb.store-gateway-enabled` CLI flag and `store_gateway_enabled` YAML config option. The store-gateway is now always enabled when the storage engine is `tsdb`. #2822
 * [CHANGE] Ingester: Chunks flushed via /flush stay in memory until retention period is reached. This affects `cortex_ingester_memory_chunks` metric. #2778

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -322,8 +322,6 @@ func (i *Ingester) flushUserSeries(flushQueueIndex int, userID string, fp model.
 		return noChunks, nil
 	}
 
-	i.metrics.flushedSeries.WithLabelValues(reason.String()).Inc()
-
 	// flush the chunks without locking the series, as we don't want to hold the series lock for the duration of the dynamo/s3 rpcs.
 	ctx, cancel := context.WithTimeout(context.Background(), i.cfg.FlushOpTimeout)
 	defer cancel() // releases resources if slowOperation completes before timeout elapses

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -169,3 +169,9 @@ func newSampleGenerator(t *testing.T, initTime time.Time, step time.Duration) <-
 
 	return ts
 }
+
+func TestFlushReasonString(t *testing.T) {
+	for fr := flushReason(0); fr < maxFlushReason; fr++ {
+		require.True(t, len(fr.String()) > 0)
+	}
+}

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -55,7 +55,6 @@ type ingesterMetrics struct {
 	memoryChunks                  prometheus.Gauge
 	seriesEnqueuedForFlush        *prometheus.CounterVec
 	seriesDequeuedOutcome         *prometheus.CounterVec
-	flushedSeries                 *prometheus.CounterVec
 	droppedChunks                 prometheus.Counter
 	oldestUnflushedChunkTimestamp prometheus.Gauge
 }
@@ -202,10 +201,6 @@ func newIngesterMetrics(r prometheus.Registerer, createMetricsConflictingWithTSD
 			Name: "cortex_ingester_flushing_dequeued_series_total",
 			Help: "Total number of series dequeued for flushing, with outcome (superset of enqueue reasons)",
 		}, []string{"outcome"}),
-		flushedSeries: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ingester_flushed_series_total",
-			Help: "Total number of flushed series, with reasons.",
-		}, []string{"reason"}),
 		droppedChunks: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_ingester_dropped_chunks_total",
 			Help: "Total number of chunks dropped from flushing because they have too few samples.",

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -53,6 +53,8 @@ type ingesterMetrics struct {
 	chunkSize                     prometheus.Histogram
 	chunkAge                      prometheus.Histogram
 	memoryChunks                  prometheus.Gauge
+	seriesEnqueuedForFlush        *prometheus.CounterVec
+	seriesDequeuedOutcome         *prometheus.CounterVec
 	flushedSeries                 *prometheus.CounterVec
 	droppedChunks                 prometheus.Counter
 	oldestUnflushedChunkTimestamp prometheus.Gauge
@@ -192,8 +194,16 @@ func newIngesterMetrics(r prometheus.Registerer, createMetricsConflictingWithTSD
 			Name: "cortex_ingester_memory_chunks",
 			Help: "The total number of chunks in memory.",
 		}),
+		seriesEnqueuedForFlush: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_ingester_enqueued_series_total",
+			Help: "Total number of series enqueued for flushing, with reasons.",
+		}, []string{"reason"}),
+		seriesDequeuedOutcome: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_ingester_dequeued_series_total",
+			Help: "Total number of series dequeued for flushing, with outcome (superset of enqueue reasons)",
+		}, []string{"outcome"}),
 		flushedSeries: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ingester_series_flushed_total",
+			Name: "cortex_ingester_flushed_series_total",
 			Help: "Total number of flushed series, with reasons.",
 		}, []string{"reason"}),
 		droppedChunks: promauto.With(r).NewCounter(prometheus.CounterOpts{

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -195,11 +195,11 @@ func newIngesterMetrics(r prometheus.Registerer, createMetricsConflictingWithTSD
 			Help: "The total number of chunks in memory.",
 		}),
 		seriesEnqueuedForFlush: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ingester_enqueued_series_total",
+			Name: "cortex_ingester_flushing_enqueued_series_total",
 			Help: "Total number of series enqueued for flushing, with reasons.",
 		}, []string{"reason"}),
 		seriesDequeuedOutcome: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ingester_dequeued_series_total",
+			Name: "cortex_ingester_flushing_dequeued_series_total",
 			Help: "Total number of series dequeued for flushing, with outcome (superset of enqueue reasons)",
 		}, []string{"outcome"}),
 		flushedSeries: promauto.With(r).NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
**What this PR does**: Re-added `cortex_ingester_flush_reasons` under the name `cortex_ingester_enqueued_series_total`.
Added `cortex_ingester_dequeued_series_total`, with outcome label. Outcome is a super set of flush reason.

Follow-up to #2802 and #2811.

**Which issue(s) this PR fixes**:
Fixes #2287

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
