### PR TITLE
Add -store.max-query-length support to blocks storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * [CHANGE] Metric `cortex_ingester_flush_reasons` has been renamed to `cortex_ingester_series_flushed_total`, and is now incremented during flush, not when series is enqueued for flushing. #2802
 * [CHANGE] Experimental Delete Series: Metric `cortex_purger_oldest_pending_delete_request_age_seconds` would track age of delete requests since they are over their cancellation period instead of their creation time. #2806
 * [CHANGE] Ingester: Chunks flushed via /flush stay in memory until retention period is reached. This affects `cortex_ingester_memory_chunks` metric. #2778
-* [CHANGE] Querier: the error message returned when the query time range exceeds `-store.max-query-length` has changed from `invalid query, length > limit (X > Y)` to `the query time range exceeds the limit (query length: X, limit: Y)`.
+* [CHANGE] Querier: the error message returned when the query time range exceeds `-store.max-query-length` has changed from `invalid query, length > limit (X > Y)` to `the query time range exceeds the limit (query length: X, limit: Y)`. #2826
 * [FEATURE] Introduced `ruler.for-outage-tolerance`, Max time to tolerate outage for restoring "for" state of alert. #2783
 * [FEATURE] Introduced `ruler.for-grace-period`, Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. #2783
 * [FEATURE] Introduced `ruler.resend-delay`, Minimum amount of time to wait before resending an alert to Alertmanager. #2783
@@ -33,7 +33,7 @@
 * [ENHANCEMENT] Query-tee: Forward `X-Scope-OrgId` header to backend, if present in the request. #2815
 * [ENHANCEMENT] Experimental TSDB: Added `-experimental.tsdb.head-compaction-idle-timeout` option to force compaction of data in memory into a block. #2803
 * [ENHANCEMENT] Experimental TSDB: Added support for flushing blocks via `/flush`, `/shutdown` (previously these only worked for chunks storage) and by using `-experimental.tsdb.flush-blocks-on-shutdown` option. #2794
-* [ENHANCEMENT] Experimental TSDB: Added support to enforce max query time range length via `-store.max-query-length`.
+* [ENHANCEMENT] Experimental TSDB: Added support to enforce max query time range length via `-store.max-query-length`. #2826
 * [ENHANCEMENT] Ingester: Added new metric `cortex_ingester_flush_series_in_progress` that reports number of ongoing flush-series operations. Useful when calling `/flush` handler: if `cortex_ingester_flush_queue_length + cortex_ingester_flush_series_in_progress` is 0, all flushes are finished. #2778
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [CHANGE] Metric `cortex_ingester_flush_reasons` has been renamed to `cortex_ingester_series_flushed_total`, and is now incremented during flush, not when series is enqueued for flushing. #2802
 * [CHANGE] Experimental Delete Series: Metric `cortex_purger_oldest_pending_delete_request_age_seconds` would track age of delete requests since they are over their cancellation period instead of their creation time. #2806
 * [CHANGE] Ingester: Chunks flushed via /flush stay in memory until retention period is reached. This affects `cortex_ingester_memory_chunks` metric. #2778
+* [CHANGE] Querier: the error message returned when the query time range exceeds `-store.max-query-length` has changed from `invalid query, length > limit (X > Y)` to `the query time range exceeds the limit (query length: X, limit: Y)`.
 * [FEATURE] Introduced `ruler.for-outage-tolerance`, Max time to tolerate outage for restoring "for" state of alert. #2783
 * [FEATURE] Introduced `ruler.for-grace-period`, Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. #2783
 * [FEATURE] Introduced `ruler.resend-delay`, Minimum amount of time to wait before resending an alert to Alertmanager. #2783
@@ -32,6 +33,7 @@
 * [ENHANCEMENT] Query-tee: Forward `X-Scope-OrgId` header to backend, if present in the request. #2815
 * [ENHANCEMENT] Experimental TSDB: Added `-experimental.tsdb.head-compaction-idle-timeout` option to force compaction of data in memory into a block. #2803
 * [ENHANCEMENT] Experimental TSDB: Added support for flushing blocks via `/flush`, `/shutdown` (previously these only worked for chunks storage) and by using `-experimental.tsdb.flush-blocks-on-shutdown` option. #2794
+* [ENHANCEMENT] Experimental TSDB: Added support to enforce max query time range length via `-store.max-query-length`.
 * [ENHANCEMENT] Ingester: Added new metric `cortex_ingester_flush_series_in_progress` that reports number of ongoing flush-series operations. Useful when calling `/flush` handler: if `cortex_ingester_flush_queue_length + cortex_ingester_flush_series_in_progress` is 0, all flushes are finished. #2778
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764

--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -101,3 +101,10 @@ store_gateway:
 
 frontend_worker:
   frontend_address: "query-frontend:9007"
+
+query_range:
+  split_queries_by_interval: 24h
+
+limits:
+  # Limit max query time range to 31d
+  max_query_length: 744h

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -225,7 +225,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: cortex
-    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18007 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=query-frontend -server.http-listen-port=8007 -server.grpc-listen-port=9007"]
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18007 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=query-frontend -server.http-listen-port=8007 -server.grpc-listen-port=9007 -store.max-query-length=8760h"]
     depends_on:
       - consul
       - minio

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -112,9 +112,9 @@ api:
 # The query_frontend_config configures the Cortex query-frontend.
 [frontend: <query_frontend_config>]
 
-# The queryrange_config configures the query splitting and caching in the Cortex
-# query-frontend.
-[query_range: <queryrange_config>]
+# The query_range_config configures the query splitting and caching in the
+# Cortex query-frontend.
+[query_range: <query_range_config>]
 
 # The table_manager_config configures the Cortex table-manager.
 [table_manager: <table_manager_config>]
@@ -708,9 +708,9 @@ The `query_frontend_config` configures the Cortex query-frontend.
 [log_queries_longer_than: <duration> | default = 0s]
 ```
 
-### `queryrange_config`
+### `query_range_config`
 
-The `queryrange_config` configures the query splitting and caching in the Cortex query-frontend.
+The `query_range_config` configures the query splitting and caching in the Cortex query-frontend.
 
 ```yaml
 # Split queries by an interval and execute in parallel, 0 disables it. You
@@ -2514,7 +2514,10 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -store.query-chunk-limit
 [max_chunks_per_query: <int> | default = 2000000]
 
-# Limit to length of chunk store queries, 0 to disable.
+# Limit the query time range length (end - start time). This limit is enforced
+# in the query-frontend (on the received query), in the querier (on the query
+# eventually splitted by the query-frontend) and in the chunks storage. 0 to
+# disable.
 # CLI flag: -store.max-query-length
 [max_query_length: <duration> | default = 0s]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2514,10 +2514,9 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -store.query-chunk-limit
 [max_chunks_per_query: <int> | default = 2000000]
 
-# Limit the query time range length (end - start time). This limit is enforced
-# in the query-frontend (on the received query), in the querier (on the query
-# eventually splitted by the query-frontend) and in the chunks storage. 0 to
-# disable.
+# Limit the query time range (end - start time). This limit is enforced in the
+# query-frontend (on the received query), in the querier (on the query possibly
+# split by the query-frontend) and in the chunks storage. 0 to disable.
 # CLI flag: -store.max-query-length
 [max_query_length: <duration> | default = 0s]
 

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -918,7 +918,7 @@ func TestChunkStoreError(t *testing.T) {
 			query:   "foo",
 			from:    model.Time(0),
 			through: model.Time(0).Add(31 * 24 * time.Hour),
-			err:     "invalid query, length > limit (744h0m0s > 720h0m0s)",
+			err:     "the query time range exceeds the limit (query length: 744h0m0s, limit: 720h0m0s)",
 		},
 		{
 			query:   "{foo=\"bar\"}",

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -169,7 +169,7 @@ func (t *Cortex) initDistributor() (serv services.Service, err error) {
 }
 
 func (t *Cortex) initQuerier() (serv services.Service, err error) {
-	queryable, engine := querier.New(t.Cfg.Querier, t.Distributor, t.StoreQueryables, t.TombstonesLoader, prometheus.DefaultRegisterer)
+	queryable, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, t.TombstonesLoader, prometheus.DefaultRegisterer)
 
 	// Prometheus histograms for requests to the querier.
 	querierRequestDuration := promauto.With(prometheus.DefaultRegisterer).NewHistogramVec(prometheus.HistogramOpts{
@@ -455,7 +455,7 @@ func (t *Cortex) initTableManager() (services.Service, error) {
 func (t *Cortex) initRuler() (serv services.Service, err error) {
 	t.Cfg.Ruler.Ring.ListenPort = t.Cfg.Server.GRPCListenPort
 	t.Cfg.Ruler.Ring.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
-	queryable, engine := querier.New(t.Cfg.Querier, t.Distributor, t.StoreQueryables, t.TombstonesLoader, prometheus.DefaultRegisterer)
+	queryable, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, t.TombstonesLoader, prometheus.DefaultRegisterer)
 
 	t.Ruler, err = ruler.NewRuler(t.Cfg.Ruler, engine, queryable, t.Distributor, prometheus.DefaultRegisterer, util.Logger)
 	if err != nil {
@@ -590,11 +590,11 @@ func (t *Cortex) setupModuleManager() error {
 		Store:          {Overrides, DeleteRequestsStore},
 		Ingester:       {Overrides, Store, API, RuntimeConfig, MemberlistKV},
 		Flusher:        {Store, API},
-		Querier:        {Distributor, Store, Ring, API, StoreQueryable},
+		Querier:        {Overrides, Distributor, Store, Ring, API, StoreQueryable},
 		StoreQueryable: {Store},
 		QueryFrontend:  {API, Overrides, DeleteRequestsStore},
 		TableManager:   {API},
-		Ruler:          {Distributor, Store, StoreQueryable},
+		Ruler:          {Overrides, Distributor, Store, StoreQueryable},
 		Configs:        {API},
 		AlertManager:   {API},
 		Compactor:      {API},

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 
 	"github.com/cortexproject/cortex/pkg/chunk/purger"
+	"github.com/cortexproject/cortex/pkg/util/validation"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -22,6 +23,7 @@ import (
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 
@@ -153,8 +155,11 @@ func TestQuerier(t *testing.T) {
 						chunkStore, through := makeMockChunkStore(t, chunks, encoding.e)
 						distributor := mockDistibutorFor(t, chunkStore, through)
 
+						overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
+						require.NoError(t, err)
+
 						queryables := []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore)), UseAlwaysQueryable(db)}
-						queryable, _ := New(cfg, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+						queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
 						testQuery(t, queryable, through, query)
 					})
 				}
@@ -275,7 +280,10 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 				chunkStore, _ := makeMockChunkStore(t, 24, encodings[0].e)
 				distributor := &errDistributor{}
 
-				queryable, _ := New(cfg, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}, purger.NewTombstonesLoader(nil, nil), nil)
+				overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
+				require.NoError(t, err)
+
+				queryable, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}, purger.NewTombstonesLoader(nil, nil), nil)
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 
@@ -295,7 +303,6 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 			})
 		}
 	}
-
 }
 
 func TestNoFutureQueries(t *testing.T) {
@@ -366,7 +373,10 @@ func TestNoFutureQueries(t *testing.T) {
 				chunkStore := &errChunkStore{}
 				distributor := &errDistributor{}
 
-				queryable, _ := New(cfg, distributor, []QueryableWithFilter{UseAlwaysQueryable(chunkStore)}, purger.NewTombstonesLoader(nil, nil), nil)
+				overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
+				require.NoError(t, err)
+
+				queryable, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(chunkStore)}, purger.NewTombstonesLoader(nil, nil), nil)
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 
@@ -384,6 +394,82 @@ func TestNoFutureQueries(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestQuerier_ValidateQueryTimeRange(t *testing.T) {
+	const maxQueryLength = 30 * 24 * time.Hour
+
+	tests := map[string]struct {
+		query          string
+		queryStartTime time.Time
+		queryEndTime   time.Time
+		expected       error
+	}{
+		"should allow query on short time range and rate time window close to the limit": {
+			query:          "rate(foo[29d])",
+			queryStartTime: time.Now().Add(-time.Hour),
+			queryEndTime:   time.Now(),
+			expected:       nil,
+		},
+		"should allow query on large time range close to the limit and short rate time window": {
+			query:          "rate(foo[1m])",
+			queryStartTime: time.Now().Add(-maxQueryLength).Add(time.Hour),
+			queryEndTime:   time.Now(),
+			expected:       nil,
+		},
+		"should forbid query on short time range and rate time window over the limit": {
+			query:          "rate(foo[31d])",
+			queryStartTime: time.Now().Add(-time.Hour),
+			queryEndTime:   time.Now(),
+			expected:       errors.New("expanding series: the query time range exceeds the limit (query length: 745h0m0s, limit: 720h0m0s)"),
+		},
+		"should forbid query on large time range over the limit and short rate time window": {
+			query:          "rate(foo[1m])",
+			queryStartTime: time.Now().Add(-maxQueryLength).Add(-time.Hour),
+			queryEndTime:   time.Now(),
+			expected:       errors.New("expanding series: the query time range exceeds the limit (query length: 721h1m0s, limit: 720h0m0s)"),
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			var cfg Config
+			flagext.DefaultValues(&cfg)
+
+			limits := defaultLimitsConfig()
+			limits.MaxQueryLength = maxQueryLength
+			overrides, err := validation.NewOverrides(limits, nil)
+			require.NoError(t, err)
+
+			// We don't need to query any data for this test, so an empty store is fine.
+			chunkStore := &emptyChunkStore{}
+			distributor := &emptyDistributor{}
+
+			queryables := []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}
+			queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+
+			// Create the PromQL engine to execute the query.
+			engine := promql.NewEngine(promql.EngineOpts{
+				Logger:             util.Logger,
+				ActiveQueryTracker: nil,
+				MaxSamples:         1e6,
+				Timeout:            1 * time.Minute,
+			})
+
+			query, err := engine.NewRangeQuery(queryable, testData.query, testData.queryStartTime, testData.queryEndTime, time.Minute)
+			require.NoError(t, err)
+
+			ctx := user.InjectOrgID(context.Background(), "test")
+			r := query.Exec(ctx)
+
+			if testData.expected != nil {
+				require.NotNil(t, r.Err)
+				assert.Equal(t, testData.expected.Error(), r.Err.Error())
+			} else {
+				assert.Nil(t, r.Err)
+			}
+		})
 	}
 }
 
@@ -495,6 +581,32 @@ func (c *emptyChunkStore) IsCalled() bool {
 	return c.called
 }
 
+type emptyDistributor struct{}
+
+func (d *emptyDistributor) Query(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error) {
+	return nil, nil
+}
+
+func (d *emptyDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
+	return &client.QueryStreamResponse{}, nil
+}
+
+func (d *emptyDistributor) LabelValuesForLabelName(context.Context, model.LabelName) ([]string, error) {
+	return nil, nil
+}
+
+func (d *emptyDistributor) LabelNames(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (d *emptyDistributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]metric.Metric, error) {
+	return nil, nil
+}
+
+func (d *emptyDistributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetadata, error) {
+	return nil, nil
+}
+
 func TestShortTermQueryToLTS(t *testing.T) {
 	testCases := []struct {
 		name                 string
@@ -557,7 +669,10 @@ func TestShortTermQueryToLTS(t *testing.T) {
 				chunkStore := &emptyChunkStore{}
 				distributor := &errDistributor{}
 
-				queryable, _ := New(cfg, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}, purger.NewTombstonesLoader(nil, nil), nil)
+				overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
+				require.NoError(t, err)
+
+				queryable, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}, purger.NewTombstonesLoader(nil, nil), nil)
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 
@@ -632,4 +747,10 @@ func (m *mockQueryableWithFilter) Querier(_ context.Context, _, _ int64) (storag
 func (m *mockQueryableWithFilter) UseQueryable(_ time.Time, _, _ int64) bool {
 	m.useQueryableCalled = true
 	return true
+}
+
+func defaultLimitsConfig() validation.Limits {
+	limits := validation.Limits{}
+	flagext.DefaultValues(&limits)
+	return limits
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -101,7 +101,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxGlobalMetadataPerMetric, "ingester.max-global-metadata-per-metric", 0, "The maximum number of metadata per metric, across the cluster. 0 to disable.")
 
 	f.IntVar(&l.MaxChunksPerQuery, "store.query-chunk-limit", 2e6, "Maximum number of chunks that can be fetched in a single query.")
-	f.DurationVar(&l.MaxQueryLength, "store.max-query-length", 0, "Limit the query time range length (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query eventually splitted by the query-frontend) and in the chunks storage. 0 to disable.")
+	f.DurationVar(&l.MaxQueryLength, "store.max-query-length", 0, "Limit the query time range (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query possibly split by the query-frontend) and in the chunks storage. 0 to disable.")
 	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of queries will be scheduled in parallel by the frontend.")
 	f.IntVar(&l.CardinalityLimit, "store.cardinality-limit", 1e5, "Cardinality limit for index queries.")
 	f.DurationVar(&l.MaxCacheFreshness, "frontend.max-cache-freshness", 1*time.Minute, "Most recent allowed cacheable result per-tenant, to prevent caching very recent results that might still be in flux.")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -101,7 +101,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxGlobalMetadataPerMetric, "ingester.max-global-metadata-per-metric", 0, "The maximum number of metadata per metric, across the cluster. 0 to disable.")
 
 	f.IntVar(&l.MaxChunksPerQuery, "store.query-chunk-limit", 2e6, "Maximum number of chunks that can be fetched in a single query.")
-	f.DurationVar(&l.MaxQueryLength, "store.max-query-length", 0, "Limit to length of chunk store queries, 0 to disable.")
+	f.DurationVar(&l.MaxQueryLength, "store.max-query-length", 0, "Limit the query time range length (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query eventually splitted by the query-frontend) and in the chunks storage. 0 to disable.")
 	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of queries will be scheduled in parallel by the frontend.")
 	f.IntVar(&l.CardinalityLimit, "store.cardinality-limit", 1e5, "Cardinality limit for index queries.")
 	f.DurationVar(&l.MaxCacheFreshness, "frontend.max-cache-freshness", 1*time.Minute, "Most recent allowed cacheable result per-tenant, to prevent caching very recent results that might still be in flux.")

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -39,8 +39,8 @@ const (
 	errDuplicateLabelName = "duplicate label name: %.200q metric %.200q"
 	errLabelsNotSorted    = "labels not sorted: %.200q metric %.200q"
 
-	// ErrQueryTooLong is used in chunk store and query frontend.
-	ErrQueryTooLong = "invalid query, length > limit (%s > %s)"
+	// ErrQueryTooLong is used in chunk store, querier and query frontend.
+	ErrQueryTooLong = "the query time range exceeds the limit (query length: %s, limit: %s)"
 
 	missingMetricName       = "missing_metric_name"
 	invalidMetricName       = "metric_name_invalid"

--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -71,9 +71,9 @@ var (
 			desc:       "The query_frontend_config configures the Cortex query-frontend.",
 		},
 		{
-			name:       "queryrange_config",
+			name:       "query_range_config",
 			structType: reflect.TypeOf(queryrange.Config{}),
-			desc:       "The queryrange_config configures the query splitting and caching in the Cortex query-frontend.",
+			desc:       "The query_range_config configures the query splitting and caching in the Cortex query-frontend.",
 		},
 		{
 			name:       "ruler_config",


### PR DESCRIPTION
**What this PR does**:
The `-store.max-query-length` is currently enforced in the query-frontend (before splitting) and in the chunks store. In this PR I propose to validate it in the querier so that it applies both to the chunks and blocks storage.

However, I've noticed the limit in the chunks store is also used by Loki, reason why I haven't removed it from there. /cc @cyriltovena 

WDYT?

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
