### PR TITLE
Fix flaky test in issue 2825

### DIFF
--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -37,8 +37,8 @@ func TestSweepImmediateDropsSamples(t *testing.T) {
 	notify := make(chan struct{})
 	ing.preFlushChunks = func() {
 		if ing.State() == services.Running {
-			notify <- struct{}{}
 			pushSample(t, ing, <-samples)
+			notify <- struct{}{}
 		}
 	}
 


### PR DESCRIPTION
To trigger the original bug, we need to push sample during sweep-flush (achieved by doing push from preFlushChunks).

Shutdown is used to trigger another sweep-flush, and not critical part of the test. Imporant part is that second flush doesn't ignore just-pushed sample (buggy version dropped it completely).

Flakiness was introduced by shutting down ingester too early (possibly before new sample was pushed). Now we wait with shutdown.

**Which issue(s) this PR fixes**:
Fixes https://github.com/cortexproject/cortex/issues/2825

**Checklist**
- [x] Tests updated
