### PR TITLE
Make label name character set validation optional

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -154,6 +154,9 @@ type Config struct {
 
 	// for testing
 	ingesterClientFactory ring_client.PoolFactory `yaml:"-"`
+
+	// when true the distributor does not validate the label name
+	SkipLabelNameValidation bool `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -332,7 +335,7 @@ func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica 
 // Returns the validated series with it's labels/samples, and any error.
 func (d *Distributor) validateSeries(ts ingester_client.PreallocTimeseries, userID string) (client.PreallocTimeseries, error) {
 	labelsHistogram.Observe(float64(len(ts.Labels)))
-	if err := validation.ValidateLabels(d.limits, userID, ts.Labels); err != nil {
+	if err := validation.ValidateLabels(d.limits, userID, ts.Labels, d.cfg.SkipLabelNameValidation); err != nil {
 		return emptyPreallocSeries, err
 	}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -154,10 +154,6 @@ type Config struct {
 
 	// for testing
 	ingesterClientFactory ring_client.PoolFactory `yaml:"-"`
-
-	// when true the distributor does not validate labels at ingest time, Cortex doesn't directly use
-	// this (and should never use it) but this feature is used by other projects built on top of it
-	SkipLabelValidation bool `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -336,10 +332,8 @@ func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica 
 // Returns the validated series with it's labels/samples, and any error.
 func (d *Distributor) validateSeries(ts ingester_client.PreallocTimeseries, userID string) (client.PreallocTimeseries, error) {
 	labelsHistogram.Observe(float64(len(ts.Labels)))
-	if !d.cfg.SkipLabelValidation {
-		if err := validation.ValidateLabels(d.limits, userID, ts.Labels); err != nil {
-			return emptyPreallocSeries, err
-		}
+	if err := validation.ValidateLabels(d.limits, userID, ts.Labels); err != nil {
+		return emptyPreallocSeries, err
 	}
 
 	metricName, _ := extract.MetricNameFromLabelAdapters(ts.Labels)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -155,7 +155,8 @@ type Config struct {
 	// for testing
 	ingesterClientFactory ring_client.PoolFactory `yaml:"-"`
 
-	// when true the distributor does not validate the label name
+	// when true the distributor does not validate the label name, Cortex doesn't directly use
+	// this (and should never use it) but this feature is used by other projects built on top of it
 	SkipLabelNameValidation bool `yaml:"-"`
 }
 

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -112,9 +112,9 @@ type LabelValidationConfig interface {
 }
 
 // ValidateLabels returns an err if the labels are invalid.
-func ValidateLabels(cfg LabelValidationConfig, userID string, ls []client.LabelAdapter) error {
-	metricName, err := extract.MetricNameFromLabelAdapters(ls)
+func ValidateLabels(cfg LabelValidationConfig, userID string, ls []client.LabelAdapter, skipLabelNameValidation bool) error {
 	if cfg.EnforceMetricName(userID) {
+		metricName, err := extract.MetricNameFromLabelAdapters(ls)
 		if err != nil {
 			DiscardedSamples.WithLabelValues(missingMetricName, userID).Inc()
 			return httpgrpc.Errorf(http.StatusBadRequest, errMissingMetricName)
@@ -139,7 +139,7 @@ func ValidateLabels(cfg LabelValidationConfig, userID string, ls []client.LabelA
 		var errTemplate string
 		var reason string
 		var cause interface{}
-		if !model.LabelName(l.Name).IsValid() {
+		if !skipLabelNameValidation && !model.LabelName(l.Name).IsValid() {
 			reason = invalidLabel
 			errTemplate = errInvalidLabel
 			cause = l.Name


### PR DESCRIPTION
This removes the `SkipLabelValidation` distributor config property again and introduces a new flag called `-validation.enforce-label-name-charset`. That config flag can be used to disable the enforcement of the prometheus character set restrictions when validating label names, to allow for a wider set of characters in label names. \
The advantage of doing it this way is that the enforcement of the label name charset can be disabled specifically, while all the other label limits (`-validation.max-length-label-name`, `-validation.max-length-label-value`, etc) remain in place.