### PR TITLE
Fix a bug about failure to add metrics of multi KV store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [CHANGE] Experimental TSDB: the store-gateway service is required in a Cortex cluster running with the experimental blocks storage. Removed the `-experimental.tsdb.store-gateway-enabled` CLI flag and `store_gateway_enabled` YAML config option. The store-gateway is now always enabled when the storage engine is `tsdb`. #2822
 * [CHANGE] Ingester: Chunks flushed via /flush stay in memory until retention period is reached. This affects `cortex_ingester_memory_chunks` metric. #2778
 * [CHANGE] Querier: the error message returned when the query time range exceeds `-store.max-query-length` has changed from `invalid query, length > limit (X > Y)` to `the query time range exceeds the limit (query length: X, limit: Y)`. #2826
+* [CHANGE] KV: The `role` label which was a label of `multi` KV store client only has been added to metrics of every KV store client. If KV store client is not `multi`, then the value of `role` label is `primary`. #2837
 * [FEATURE] Introduced `ruler.for-outage-tolerance`, Max time to tolerate outage for restoring "for" state of alert. #2783
 * [FEATURE] Introduced `ruler.for-grace-period`, Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. #2783
 * [FEATURE] Introduced `ruler.resend-delay`, Minimum amount of time to wait before resending an alert to Alertmanager. #2783
@@ -47,7 +48,7 @@
 * [BUGFIX] Ingester: Flushing chunks via `/flush` endpoint could previously lead to panic, if chunks were already flushed before and then removed from memory during the flush caused by `/flush` handler. Immediate flush now doesn't cause chunks to be flushed again. Samples received during flush triggered via `/flush` handler are no longer discarded. #2778
 * [BUGFIX] Prometheus upgraded. #2849
   * Fixed unknown symbol error during head compaction
-* [BUGFIX] Fixed a bug about failure to add metrics of multi KV store. #2837
+* [BUGFIX] KV: Fixed a bug that triggered a panic due to metrics being registered with the same name but different labels when using a `multi` configured KV client. #2837
 
 ## 1.2.0 / 2020-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [BUGFIX] Ingester: Flushing chunks via `/flush` endpoint could previously lead to panic, if chunks were already flushed before and then removed from memory during the flush caused by `/flush` handler. Immediate flush now doesn't cause chunks to be flushed again. Samples received during flush triggered via `/flush` handler are no longer discarded. #2778
 * [BUGFIX] Prometheus upgraded. #2849
   * Fixed unknown symbol error during head compaction
+* [BUGFIX] Fixed a bug about failure to add metrics of multi KV store. #2837
 
 ## 1.2.0 / 2020-07-01
 

--- a/pkg/ring/kv/client.go
+++ b/pkg/ring/kv/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	"github.com/cortexproject/cortex/pkg/ring/kv/etcd"
 	"github.com/cortexproject/cortex/pkg/ring/kv/memberlist"
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 const (
@@ -211,7 +211,7 @@ func buildMultiClient(cfg StoreConfig, codec codec.Codec, reg prometheus.Registe
 
 // The mockClient does not anything.
 // This is used for testing only.
-type mockClient struct {}
+type mockClient struct{}
 
 func buildMockClient() (Client, error) {
 	level.Warn(util.Logger).Log("msg", "created mockClient for testing only")

--- a/pkg/ring/kv/client.go
+++ b/pkg/ring/kv/client.go
@@ -6,14 +6,12 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cortexproject/cortex/pkg/ring/kv/codec"
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	"github.com/cortexproject/cortex/pkg/ring/kv/etcd"
 	"github.com/cortexproject/cortex/pkg/ring/kv/memberlist"
-	"github.com/cortexproject/cortex/pkg/util"
 )
 
 const (
@@ -207,35 +205,4 @@ func buildMultiClient(cfg StoreConfig, codec codec.Codec, reg prometheus.Registe
 	}
 
 	return NewMultiClient(cfg.Multi, clients), nil
-}
-
-// The mockClient does not anything.
-// This is used for testing only.
-type mockClient struct{}
-
-func buildMockClient() (Client, error) {
-	level.Warn(util.Logger).Log("msg", "created mockClient for testing only")
-	return mockClient{}, nil
-}
-
-func (m mockClient) List(ctx context.Context, prefix string) ([]string, error) {
-	return []string{}, nil
-}
-
-func (m mockClient) Get(ctx context.Context, key string) (interface{}, error) {
-	return "", nil
-}
-
-func (m mockClient) Delete(ctx context.Context, key string) error {
-	return nil
-}
-
-func (m mockClient) CAS(ctx context.Context, key string, f func(in interface{}) (out interface{}, retry bool, err error)) error {
-	return nil
-}
-
-func (m mockClient) WatchKey(ctx context.Context, key string, f func(interface{}) bool) {
-}
-
-func (m mockClient) WatchPrefix(ctx context.Context, prefix string, f func(string, interface{}) bool) {
 }

--- a/pkg/ring/kv/client.go
+++ b/pkg/ring/kv/client.go
@@ -154,7 +154,7 @@ func createClient(backend string, prefix string, cfg StoreConfig, codec codec.Co
 	case "multi":
 		client, err = buildMultiClient(cfg, codec, reg)
 
-	// this case is for testing. The mock KV client does not anything internally.
+	// This case is for testing. The mock KV client does not do anything internally.
 	case "mock":
 		client, err = buildMockClient()
 

--- a/pkg/ring/kv/client.go
+++ b/pkg/ring/kv/client.go
@@ -151,8 +151,10 @@ func createClient(backend string, prefix string, cfg StoreConfig, codec codec.Co
 		client = PrefixClient(client, prefix)
 	}
 
-	// If no Registerer is provided return the raw client
-	if reg == nil {
+	// If no Registerer is provided or backend is "multi", return the raw client.
+	// The multi KV store does not have to register metrics.
+	// Because metrics are registered when creating primary and secondary KV stores.
+	if reg == nil || backend == "multi" {
 		return client, nil
 	}
 

--- a/pkg/ring/kv/client_test.go
+++ b/pkg/ring/kv/client_test.go
@@ -94,6 +94,7 @@ func Test_createClient_multiBackend_mustContainRoleAndTypeLabels(t *testing.T) {
 	require.Equal(t, "primary", actual["multi"])
 	require.Equal(t, "primary", actual["inmemory"])
 	require.Equal(t, "secondary", actual["mock"])
+
 }
 
 func typeToRoleMap(t *testing.T, reg prometheus.Gatherer) map[string]string {

--- a/pkg/ring/kv/client_test.go
+++ b/pkg/ring/kv/client_test.go
@@ -49,7 +49,7 @@ func Test_createClient_multi(t *testing.T) {
 		},
 	}
 	require.NotPanics(t, func() {
-		_, err := createClient("multi", "/collector", cfg, codec.NewProtoCodec("test", nil), prometheus.DefaultRegisterer)
+		_, err := createClient("multi", "/collector", cfg, codec.NewProtoCodec("test", nil), prometheus.NewRegistry())
 		require.NoError(t, err)
 	})
 }

--- a/pkg/ring/kv/client_test.go
+++ b/pkg/ring/kv/client_test.go
@@ -3,8 +3,13 @@ package kv
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	"github.com/cortexproject/cortex/pkg/ring/kv/codec"
+	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
+	"github.com/cortexproject/cortex/pkg/ring/kv/etcd"
 )
 
 func TestParseConfig(t *testing.T) {
@@ -28,4 +33,23 @@ multi:
 	require.Equal(t, "consul:8500", cfg.Consul.Host)
 	require.Equal(t, "consul", cfg.Multi.Primary)
 	require.Equal(t, "etcd", cfg.Multi.Secondary)
+}
+
+func Test_createClient_multi(t *testing.T) {
+	cfg := StoreConfig{
+		Consul: consul.Config{
+			Host: "consul.test",
+		},
+		Etcd: etcd.Config{
+			Endpoints: []string{"etcd.test"},
+		},
+		Multi: MultiConfig{
+			Primary:   "consul",
+			Secondary: "etcd",
+		},
+	}
+	require.NotPanics(t, func() {
+		_, err := createClient("multi", "/collector", cfg, codec.NewProtoCodec("test", nil), prometheus.DefaultRegisterer)
+		require.NoError(t, err)
+	})
 }

--- a/pkg/ring/kv/client_test.go
+++ b/pkg/ring/kv/client_test.go
@@ -1,14 +1,16 @@
 package kv
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
 	"github.com/cortexproject/cortex/pkg/ring/kv/codec"
-	"github.com/cortexproject/cortex/pkg/ring/kv/memberlist"
 )
 
 func TestParseConfig(t *testing.T) {
@@ -34,22 +36,113 @@ multi:
 	require.Equal(t, "etcd", cfg.Multi.Secondary)
 }
 
-func Test_createClient_multi(t *testing.T) {
-	testCodec := codec.NewProtoCodec("test", nil)
-	cfg := StoreConfig{
-		Multi: MultiConfig{
-			Primary:   "inmemory",
-			Secondary: "memberlist",
-		},
-		MemberlistKV: func() (*memberlist.KV, error) {
-			cfg := memberlist.KVConfig{
-				Codecs: []codec.Codec{testCodec},
-			}
-			return memberlist.NewKV(cfg), nil
-		},
-	}
+func Test_createClient_multiBackend_withSingleRing(t *testing.T) {
+	storeCfg, testCodec := newConfigsForTest()
 	require.NotPanics(t, func() {
-		_, err := createClient("multi", "/collector", cfg, testCodec, prometheus.NewRegistry())
+		_, err := createClient("multi", "/collector", storeCfg, testCodec, Primary, prometheus.NewRegistry())
 		require.NoError(t, err)
 	})
+}
+
+func Test_createClient_multiBackend_withMultiRing(t *testing.T) {
+	storeCfg1, testCodec := newConfigsForTest()
+	storeCfg2 := StoreConfig{}
+	reg := prometheus.NewRegistry()
+
+	require.NotPanics(t, func() {
+		_, err := createClient("multi", "/test", storeCfg1, testCodec, Primary, reg)
+		require.NoError(t, err)
+	}, "First client for KV store must not panic")
+	require.NotPanics(t, func() {
+		_, err := createClient("mock", "/test", storeCfg2, testCodec, Primary, reg)
+		require.NoError(t, err)
+	}, "Second client for KV store must not panic")
+}
+
+func Test_createClient_singleBackend_mustContainRoleAndTypeLabels(t *testing.T) {
+	storeCfg, testCodec := newConfigsForTest()
+	reg := prometheus.NewRegistry()
+	client, err := createClient("mock", "/test1", storeCfg, testCodec, Primary, reg)
+	require.NoError(t, err)
+	require.NoError(t, client.CAS(context.Background(), "/test", func(_ interface{}) (out interface{}, retry bool, err error) {
+		out = &mockMessage{id: "inCAS"}
+		retry = false
+		return
+	}))
+
+	actual := typeToRoleMap(t, reg)
+	require.Len(t, actual, 1)
+	require.Equal(t, "primary", actual["mock"])
+}
+
+func Test_createClient_multiBackend_mustContainRoleAndTypeLabels(t *testing.T) {
+	storeCfg, testCodec := newConfigsForTest()
+	storeCfg.Multi.MirrorEnabled = true
+	storeCfg.Multi.MirrorTimeout = 10 * time.Second
+	reg := prometheus.NewRegistry()
+	client, err := createClient("multi", "/test1", storeCfg, testCodec, Primary, reg)
+	require.NoError(t, err)
+	require.NoError(t, client.CAS(context.Background(), "/test", func(_ interface{}) (out interface{}, retry bool, err error) {
+		out = &mockMessage{id: "inCAS"}
+		retry = false
+		return
+	}))
+
+	actual := typeToRoleMap(t, reg)
+	// expected multi-primary, inmemory-primary and mock-secondary
+	require.Len(t, actual, 3)
+	require.Equal(t, "primary", actual["multi"])
+	require.Equal(t, "primary", actual["inmemory"])
+	require.Equal(t, "secondary", actual["mock"])
+}
+
+func typeToRoleMap(t *testing.T, reg prometheus.Gatherer) map[string]string {
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	result := map[string]string{}
+	for _, mf := range mfs {
+		for _, m := range mf.GetMetric() {
+			backendType := ""
+			role := ""
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "role" {
+					role = l.GetValue()
+				} else if l.GetName() == "type" {
+					backendType = l.GetValue()
+				}
+			}
+			require.NotEmpty(t, backendType)
+			require.NotEmpty(t, role)
+			result[backendType] = role
+		}
+	}
+	return result
+}
+func newConfigsForTest() (cfg StoreConfig, c codec.Codec) {
+	cfg = StoreConfig{
+		Multi: MultiConfig{
+			Primary:   "inmemory",
+			Secondary: "mock",
+		},
+	}
+	c = codec.NewProtoCodec("test", func() proto.Message {
+		return &mockMessage{id: "inCodec"}
+	})
+	return
+}
+
+type mockMessage struct {
+	id string
+}
+
+func (m *mockMessage) Reset() {
+	panic("do not use")
+}
+
+func (m *mockMessage) String() string {
+	panic("do not use")
+}
+
+func (m *mockMessage) ProtoMessage() {
+	panic("do not use")
 }

--- a/pkg/ring/kv/metrics.go
+++ b/pkg/ring/kv/metrics.go
@@ -31,6 +31,12 @@ func errorCode(err error) string {
 	return "500"
 }
 
+const (
+	MetricNamespace = "cortex"
+	MetricName = "kv_request_duration_seconds"
+	MetricHelp = "Time spent on kv store requests."
+)
+
 type metrics struct {
 	c               Client
 	requestDuration *instrument.HistogramCollector
@@ -41,9 +47,9 @@ func newMetricsClient(backend string, c Client, reg prometheus.Registerer) Clien
 		c: c,
 		requestDuration: instrument.NewHistogramCollector(
 			promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: "cortex",
-				Name:      "kv_request_duration_seconds",
-				Help:      "Time spent on kv store requests.",
+				Namespace: MetricNamespace,
+				Name:      MetricName,
+				Help:      MetricHelp,
 				Buckets:   prometheus.DefBuckets,
 				ConstLabels: prometheus.Labels{
 					"type": backend,

--- a/pkg/ring/kv/metrics.go
+++ b/pkg/ring/kv/metrics.go
@@ -33,8 +33,8 @@ func errorCode(err error) string {
 
 const (
 	MetricNamespace = "cortex"
-	MetricName = "kv_request_duration_seconds"
-	MetricHelp = "Time spent on kv store requests."
+	MetricName      = "kv_request_duration_seconds"
+	MetricHelp      = "Time spent on kv store requests."
 )
 
 type metrics struct {

--- a/pkg/ring/kv/metrics.go
+++ b/pkg/ring/kv/metrics.go
@@ -31,12 +31,6 @@ func errorCode(err error) string {
 	return "500"
 }
 
-const (
-	MetricNamespace = "cortex"
-	MetricName      = "kv_request_duration_seconds"
-	MetricHelp      = "Time spent on kv store requests."
-)
-
 type metrics struct {
 	c               Client
 	requestDuration *instrument.HistogramCollector
@@ -47,9 +41,9 @@ func newMetricsClient(backend string, c Client, reg prometheus.Registerer) Clien
 		c: c,
 		requestDuration: instrument.NewHistogramCollector(
 			promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: MetricNamespace,
-				Name:      MetricName,
-				Help:      MetricHelp,
+				Namespace: "cortex",
+				Name:      "kv_request_duration_seconds",
+				Help:      "Time spent on kv store requests.",
 				Buckets:   prometheus.DefBuckets,
 				ConstLabels: prometheus.Labels{
 					"type": backend,

--- a/pkg/ring/kv/mock.go
+++ b/pkg/ring/kv/mock.go
@@ -1,0 +1,40 @@
+package kv
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/log/level"
+
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+// The mockClient does not anything.
+// This is used for testing only.
+type mockClient struct{}
+
+func buildMockClient() (Client, error) {
+	level.Warn(util.Logger).Log("msg", "created mockClient for testing only")
+	return mockClient{}, nil
+}
+
+func (m mockClient) List(ctx context.Context, prefix string) ([]string, error) {
+	return []string{}, nil
+}
+
+func (m mockClient) Get(ctx context.Context, key string) (interface{}, error) {
+	return "", nil
+}
+
+func (m mockClient) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (m mockClient) CAS(ctx context.Context, key string, f func(in interface{}) (out interface{}, retry bool, err error)) error {
+	return nil
+}
+
+func (m mockClient) WatchKey(ctx context.Context, key string, f func(interface{}) bool) {
+}
+
+func (m mockClient) WatchPrefix(ctx context.Context, prefix string, f func(string, interface{}) bool) {
+}


### PR DESCRIPTION
Signed-off-by: Kyeongwon Seo <ruddnjs1230@gmail.com>

**What this PR does**:
This PR fixes a bug about failure to add metrics of multi KV store.
The multi KV store does not have to register metrics.
Because the metrics are registered when creating primary and secondary KV stores.

**Which issue(s) this PR fixes**:
Fixes #2807

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
