### PR TITLE
Fix memory leak caused by object pool and zero copy

### DIFF
--- a/pkg/ingester/client/timeseries.go
+++ b/pkg/ingester/client/timeseries.go
@@ -276,6 +276,10 @@ func ReuseSlice(ts []PreallocTimeseries) {
 
 // ReuseTimeseries puts the timeseries back into a sync.Pool for reuse.
 func ReuseTimeseries(ts *TimeSeries) {
+	for i := 0; i < len(ts.Labels); i++ {
+		ts.Labels[i].Name = ""
+		ts.Labels[i].Value = ""
+	}
 	ts.Labels = ts.Labels[:0]
 	ts.Samples = ts.Samples[:0]
 	timeSeriesPool.Put(ts)

--- a/pkg/ingester/client/timeseries.go
+++ b/pkg/ingester/client/timeseries.go
@@ -276,6 +276,7 @@ func ReuseSlice(ts []PreallocTimeseries) {
 
 // ReuseTimeseries puts the timeseries back into a sync.Pool for reuse.
 func ReuseTimeseries(ts *TimeSeries) {
+	// Name and Value may point into a large gRPC buffer, so clear the reference to allow GC
 	for i := 0; i < len(ts.Labels); i++ {
 		ts.Labels[i].Name = ""
 		ts.Labels[i].Value = ""


### PR DESCRIPTION
**What this PR does**:
The purpose of this PR is to fix the memory leak of Cortex Ingester. After this PR is merged, it is expected to reduce the runtime memory of Ingester by at least 30%.

**Which issue(s) this PR fixes**:
Fixes #2665 

Although the PR code looks very simple, the principle inside is more complicated. I try to make it as easy to understand as possible. If there are errors in some parts, please correct me.
When troubleshooting the memory problem of Ingester, I simplified Ingester.Push to make it do almost nothing. Like below：
```
// Push implements client.IngesterServer
func (i *Ingester) Push(ctx context.Context, req *client.WriteRequest) (*client.WriteResponse, error) {
    defer client.ReuseSlice(req.Timeseries)
    return &client.WriteResponse{}, nil
}
```
After the above modifications, Ingester still takes up very high memory (60G+), until OOM, I think it must be a problem with `client.ReuseSlice`.

However, when I commented out the reuse of TimeSeries, the problem was solved, Ingester only took up 700M memory, and it was very stable, like the following:
```
func ReuseTimeseries(ts *TimeSeries) {
	// ts.Labels = ts.Labels[:0]
	// ts.Samples = ts.Samples[:0]
	// timeSeriesPool.Put(ts)
}
```

By looking closely at the code, I found the source of the problem. First, in `ReuseTimeseries`，
```
ts.Labels = ts.Labels[:0]
ts.Samples = ts.Samples[:0]
```
It does not release the real underlying array. We know that slice’s real structure is as follows：
```
type sliceHeader struct {
    Length        int
    Capacity      int
    ZerothElement *byte
}
```
The above operation will only change the Length in sliceHeader to 0, the underlying array still cannot be released. Secondly, you can see in the deserialization of Label:
https://github.com/cortexproject/cortex/blob/8fe97dcc707a3e774229d9fd3b20425214e0ac9b/pkg/ingester/client/timeseries.go#L205
https://github.com/cortexproject/cortex/blob/8fe97dcc707a3e774229d9fd3b20425214e0ac9b/pkg/ingester/client/timeseries.go#L232-L234
In the deserialization, the zero-copy is used. `Label.Name` and `Label.Value` refer to the original []byte, which will cause the original request body to not be released.

This may have some abstractions, I can cite such an example：

The A request body has a total of 1M []byte (I call it `RawSliceA`). After Unmarshal, `timeSeriesA0` contains 10 Labels. Due to the use of zero copy, these 10 Labels actually refer to `RawSliceA`.
After the A request is processed, `timeSeriesA0` is put into `timeSeriesPool`, and the reference to `RawSliceA` is still not canceled at this time。
The B request body has a total of 500KB []byte. After Unmarshal, `timeSeriesB0` contains 3 Labels. In Unmarshal, it takes and reuses `timeSeriesA0` from `timeSeriesPool`. At this time, `RawSliceA` was released?
No, `RawSliceA` may not be released until the B request processing is completed, and even to the next request.
The whole process is like this：
![image](https://user-images.githubusercontent.com/29772821/86578244-15d95200-bfae-11ea-8704-366930cdb20d.png)

This example is a bit similar to：https://github.com/golang/go/issues/23199

For the problems mentioned above, I have the following thoughts:
1. I think there is no problem using zero copy like `yoloString`, because most of the bytes of `RawSlice` are describing Labels, which is cost-effective.
2. I think it is no problem to use memory pool for `timeSeries`, it can reuse `Labels` and `Samples` Slice.
3. Even though the GC will periodically clean up the Pool, a large number of consecutive requests will still cause a lot of memory to be wasted.
4. Before putting `timeSeries` into `timeSeriesPool`, must clear the `Name` and `Value` of `timeSeries.Labels` to dereference `RawSlice`.

After testing, this modification can greatly reduce the runtime memory of Ingester without introducing new problems.

**before**:
![image](https://user-images.githubusercontent.com/29772821/86579422-e3305900-bfaf-11ea-92b9-5f9cf3efeac3.png)

**after**:
![image](https://user-images.githubusercontent.com/29772821/86580020-b6307600-bfb0-11ea-83df-9543a37849cf.png)
(The illustration above was made after commenting out Push's real logic)
