### PR TITLE
Support multiple Alertmanagers explicitly in the Ruler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [ENHANCEMENT] Prometheus upgraded. #2798 #2849
   * Optimized labels regex matchers for patterns containing literals (eg. `foo.*`, `.*foo`, `.*foo.*`)
 * [ENHANCEMENT] Experimental Alertmanager: Alertmanager configuration persisted to object storage using an experimental API that accepts and returns YAML-based Alertmanager configuration. #2768
+* [ENHANCEMENT] Ruler: `-ruler.alertmanager-url` now supports multiple URLs. Each URL is treated as a separate Alertmanager group. Support for multiple Alertmanagers in a group can be achieved by using DNS service discovery. #2851
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1000,19 +1000,22 @@ storage:
 # CLI flag: -ruler.rule-path
 [rule_path: <string> | default = "/rules"]
 
-# URL of the Alertmanager to send notifications to.
+# URL(s) of the Alertmanager(s) to send notifications to. Each Alertmanager URL
+# is treated as a separate group in the configuration. Multiple Alertmanagers in
+# HA per group can be supported by using DNS resolution via
+# -ruler.alertmanager-discovery.
 # CLI flag: -ruler.alertmanager-url
-[alertmanager_url: <url> | default = ]
+[alertmanager_url: <list of string> | default = ]
 
-# Use DNS SRV records to discover alertmanager hosts.
+# Use DNS SRV records to discover Alertmanager hosts.
 # CLI flag: -ruler.alertmanager-discovery
 [enable_alertmanager_discovery: <boolean> | default = false]
 
-# How long to wait between refreshing alertmanager hosts.
+# How long to wait between refreshing DNS resolutions of Alertmanager hosts.
 # CLI flag: -ruler.alertmanager-refresh-interval
 [alertmanager_refresh_interval: <duration> | default = 1m]
 
-# If enabled requests to alertmanager will utilize the V2 API.
+# If enabled requests to Alertmanager will utilize the V2 API.
 # CLI flag: -ruler.alertmanager-use-v2
 [enable_alertmanager_v2: <boolean> | default = false]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1000,10 +1000,10 @@ storage:
 # CLI flag: -ruler.rule-path
 [rule_path: <string> | default = "/rules"]
 
-# URL(s) of the Alertmanager(s) to send notifications to. Each Alertmanager URL
-# is treated as a separate group in the configuration. Multiple Alertmanagers in
-# HA per group can be supported by using DNS resolution via
-# -ruler.alertmanager-discovery.
+# Comma-separated list of URL(s) of the Alertmanager(s) to send notifications
+# to. Each Alertmanager URL is treated as a separate group in the configuration.
+# Multiple Alertmanagers in HA per group can be supported by using DNS
+# resolution via -ruler.alertmanager-discovery.
 # CLI flag: -ruler.alertmanager-url
 [alertmanager_url: <list of string> | default = ]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1000,7 +1000,7 @@ storage:
 # CLI flag: -ruler.rule-path
 [rule_path: <string> | default = "/rules"]
 
-# Comma-separated list of URL(s) of the Alertmanager(s) to send notifications
+# Space-separated list of URL(s) of the Alertmanager(s) to send notifications
 # to. Each Alertmanager URL is treated as a separate group in the configuration.
 # Multiple Alertmanagers in HA per group can be supported by using DNS
 # resolution via -ruler.alertmanager-discovery.

--- a/pkg/ruler/notifier.go
+++ b/pkg/ruler/notifier.go
@@ -92,7 +92,7 @@ func buildNotifierConfig(rulerConfig *Config) (*config.Config, error) {
 		// hosts provided follow this specification: _service._proto.name
 		// e.g. _http._tcp.alertmanager.com
 		if rulerConfig.AlertmanagerDiscovery && !srvDNSregexp.MatchString(url.Host) {
-			return nil, fmt.Errorf("When alertmanager-discovery is on, host name must be of the form _portname._tcp.service.fqdn (is %q)", url.Host)
+			return nil, fmt.Errorf("when alertmanager-discovery is on, host name must be of the form _portname._tcp.service.fqdn (is %q)", url.Host)
 		}
 
 		validURLs = append(validURLs, url)

--- a/pkg/ruler/notifier_test.go
+++ b/pkg/ruler/notifier_test.go
@@ -1,0 +1,176 @@
+package ruler
+
+import (
+	"testing"
+	"time"
+
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	sd_config "github.com/prometheus/prometheus/discovery/config"
+	"github.com/prometheus/prometheus/discovery/dns"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildNotifierConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		ncfg *config.Config
+	}{
+		{
+			name: "with no valid hosts, returns an empty config",
+			cfg:  &Config{},
+			ncfg: &config.Config{},
+		},
+		{
+			name: "with a single URL and no service discovery",
+			cfg: &Config{
+				AlertmanagerURL: []string{"http://alertmanager.default.svc.cluster.local/alertmanager"},
+			},
+			ncfg: &config.Config{
+				AlertingConfig: config.AlertingConfig{
+					AlertmanagerConfigs: []*config.AlertmanagerConfig{
+						{
+							APIVersion: "v1",
+							Scheme:     "http",
+							PathPrefix: "/alertmanager",
+							ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{StaticConfigs: []*targetgroup.Group{{
+								Targets: []model.LabelSet{{"__address__": "alertmanager.default.svc.cluster.local"}},
+							}}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with a single URL and service discovery",
+			cfg: &Config{
+				AlertmanagerURL:             []string{"http://alertmanager.default.svc.cluster.local/alertmanager"},
+				AlertmanagerDiscovery:       true,
+				AlertmanagerRefreshInterval: time.Duration(60),
+			},
+			ncfg: &config.Config{
+				AlertingConfig: config.AlertingConfig{
+					AlertmanagerConfigs: []*config.AlertmanagerConfig{
+						{
+							APIVersion: "v1",
+							Scheme:     "http",
+							PathPrefix: "/alertmanager",
+							ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{DNSSDConfigs: []*dns.SDConfig{{
+								Names:           []string{"alertmanager.default.svc.cluster.local"},
+								RefreshInterval: 60,
+								Type:            "SRV",
+								Port:            0,
+							}}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with multiple URLs and no service discovery",
+			cfg: &Config{
+				AlertmanagerURL: []string{
+					"http://alertmanager-0.default.svc.cluster.local/alertmanager",
+					"http://alertmanager-1.default.svc.cluster.local/alertmanager",
+				},
+			},
+			ncfg: &config.Config{
+				AlertingConfig: config.AlertingConfig{
+					AlertmanagerConfigs: []*config.AlertmanagerConfig{
+						{
+							APIVersion: "v1",
+							Scheme:     "http",
+							PathPrefix: "/alertmanager",
+							ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{StaticConfigs: []*targetgroup.Group{{
+								Targets: []model.LabelSet{{"__address__": "alertmanager-0.default.svc.cluster.local"}},
+							}}},
+						},
+						{
+							APIVersion: "v1",
+							Scheme:     "http",
+							PathPrefix: "/alertmanager",
+							ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{StaticConfigs: []*targetgroup.Group{{
+								Targets: []model.LabelSet{{"__address__": "alertmanager-1.default.svc.cluster.local"}},
+							}}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with multiple URLs and service discovery",
+			cfg: &Config{
+				AlertmanagerURL: []string{
+					"http://alertmanager-0.default.svc.cluster.local/alertmanager",
+					"http://alertmanager-1.default.svc.cluster.local/alertmanager",
+				},
+				AlertmanagerDiscovery:       true,
+				AlertmanagerRefreshInterval: time.Duration(60),
+			},
+			ncfg: &config.Config{
+				AlertingConfig: config.AlertingConfig{
+					AlertmanagerConfigs: []*config.AlertmanagerConfig{
+						{
+							APIVersion: "v1",
+							Scheme:     "http",
+							PathPrefix: "/alertmanager",
+							ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{DNSSDConfigs: []*dns.SDConfig{{
+								Names:           []string{"alertmanager-0.default.svc.cluster.local"},
+								RefreshInterval: 60,
+								Type:            "SRV",
+								Port:            0,
+							}}},
+						},
+						{
+							APIVersion: "v1",
+							Scheme:     "http",
+							PathPrefix: "/alertmanager",
+							ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{DNSSDConfigs: []*dns.SDConfig{{
+								Names:           []string{"alertmanager-1.default.svc.cluster.local"},
+								RefreshInterval: 60,
+								Type:            "SRV",
+								Port:            0,
+							}}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with Basic Authentication",
+			cfg: &Config{
+				AlertmanagerURL: []string{
+					"http://marco:hunter2@alertmanager-0.default.svc.cluster.local/alertmanager",
+				},
+			},
+			ncfg: &config.Config{
+				AlertingConfig: config.AlertingConfig{
+					AlertmanagerConfigs: []*config.AlertmanagerConfig{
+						{
+							HTTPClientConfig: config_util.HTTPClientConfig{
+								BasicAuth: &config_util.BasicAuth{Username: "marco", Password: "hunter2"},
+							},
+							APIVersion: "v1",
+							Scheme:     "http",
+							PathPrefix: "/alertmanager",
+							ServiceDiscoveryConfig: sd_config.ServiceDiscoveryConfig{StaticConfigs: []*targetgroup.Group{{
+								Targets: []model.LabelSet{{"__address__": "alertmanager-0.default.svc.cluster.local"}},
+							}}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ncfg, err := buildNotifierConfig(tt.cfg)
+			require.NoError(t, err)
+			require.Equal(t, tt.ncfg, ncfg)
+		})
+	}
+}

--- a/pkg/ruler/notifier_test.go
+++ b/pkg/ruler/notifier_test.go
@@ -77,7 +77,7 @@ func TestBuildNotifierConfig(t *testing.T) {
 				AlertmanagerURL:       []string{"http://_http.default.svc.cluster.local/alertmanager"},
 				AlertmanagerDiscovery: true,
 			},
-			err: fmt.Errorf("When alertmanager-discovery is on, host name must be of the form _portname._tcp.service.fqdn (is \"alertmanager.default.svc.cluster.local\")"),
+			err: fmt.Errorf("when alertmanager-discovery is on, host name must be of the form _portname._tcp.service.fqdn (is \"alertmanager.default.svc.cluster.local\")"),
 		},
 		{
 			name: "with multiple URLs and no service discovery",

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -76,12 +76,12 @@ type Config struct {
 	RulePath string `yaml:"rule_path"`
 
 	// URL of the Alertmanager to send notifications to.
-	AlertmanagerURL flagext.URLValue `yaml:"alertmanager_url"`
-	// Whether to use DNS SRV records to discover alertmanagers.
+	AlertmanagerURL flagext.StringSlice `yaml:"alertmanager_url"`
+	// Whether to use DNS SRV records to discover Alertmanager.
 	AlertmanagerDiscovery bool `yaml:"enable_alertmanager_discovery"`
-	// How long to wait between refreshing the list of alertmanagers based on DNS service discovery.
+	// How long to wait between refreshing the list of Alertmanager based on DNS service discovery.
 	AlertmanagerRefreshInterval time.Duration `yaml:"alertmanager_refresh_interval"`
-	// Enables the ruler notifier to use the alertmananger V2 API.
+	// Enables the ruler notifier to use the Alertmananger V2 API.
 	AlertmanangerEnableV2API bool `yaml:"enable_alertmanager_v2"`
 	// Capacity of the queue for notifications to be sent to the Alertmanager.
 	NotificationQueueCapacity int `yaml:"notification_queue_capacity"`
@@ -128,12 +128,14 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.EvaluationInterval, "ruler.evaluation-interval", 1*time.Minute, "How frequently to evaluate rules")
 	f.DurationVar(&cfg.EvaluationDelay, "ruler.evaluation-delay-duration", 0, "Duration to delay the evaluation of rules to ensure they underlying metrics have been pushed to cortex.")
 	f.DurationVar(&cfg.PollInterval, "ruler.poll-interval", 1*time.Minute, "How frequently to poll for rule changes")
-	f.Var(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "URL of the Alertmanager to send notifications to.")
-	f.BoolVar(&cfg.AlertmanagerDiscovery, "ruler.alertmanager-discovery", false, "Use DNS SRV records to discover alertmanager hosts.")
-	f.DurationVar(&cfg.AlertmanagerRefreshInterval, "ruler.alertmanager-refresh-interval", 1*time.Minute, "How long to wait between refreshing alertmanager hosts.")
-	f.BoolVar(&cfg.AlertmanangerEnableV2API, "ruler.alertmanager-use-v2", false, "If enabled requests to alertmanager will utilize the V2 API.")
+
+	f.Var(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "URL(s) of the Alertmanager(s) to send notifications to. Each Alertmanager URL is treated as a separate group in the configuration. Multiple Alertmanagers in HA per group can be supported by using DNS resolution via -ruler.alertmanager-discovery.")
+	f.BoolVar(&cfg.AlertmanagerDiscovery, "ruler.alertmanager-discovery", false, "Use DNS SRV records to discover Alertmanager hosts.")
+	f.DurationVar(&cfg.AlertmanagerRefreshInterval, "ruler.alertmanager-refresh-interval", 1*time.Minute, "How long to wait between refreshing DNS resolutions of Alertmanager hosts.")
+	f.BoolVar(&cfg.AlertmanangerEnableV2API, "ruler.alertmanager-use-v2", false, "If enabled requests to Alertmanager will utilize the V2 API.")
 	f.IntVar(&cfg.NotificationQueueCapacity, "ruler.notification-queue-capacity", 10000, "Capacity of the queue for notifications to be sent to the Alertmanager.")
 	f.DurationVar(&cfg.NotificationTimeout, "ruler.notification-timeout", 10*time.Second, "HTTP timeout duration when sending notifications to the Alertmanager.")
+
 	f.DurationVar(&cfg.SearchPendingFor, "ruler.search-pending-for", 5*time.Minute, "Time to spend searching for a pending ruler when shutting down.")
 	f.BoolVar(&cfg.EnableSharding, "ruler.enable-sharding", false, "Distribute rule evaluation using ring backend")
 	f.DurationVar(&cfg.FlushCheckPeriod, "ruler.flush-period", 1*time.Minute, "Period with which to attempt to flush rule groups.")

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -129,7 +129,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.EvaluationDelay, "ruler.evaluation-delay-duration", 0, "Duration to delay the evaluation of rules to ensure they underlying metrics have been pushed to cortex.")
 	f.DurationVar(&cfg.PollInterval, "ruler.poll-interval", 1*time.Minute, "How frequently to poll for rule changes")
 
-	f.Var(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "Comma-separated list of URL(s) of the Alertmanager(s) to send notifications to. Each Alertmanager URL is treated as a separate group in the configuration. Multiple Alertmanagers in HA per group can be supported by using DNS resolution via -ruler.alertmanager-discovery.")
+	f.Var(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "Space-separated list of URL(s) of the Alertmanager(s) to send notifications to. Each Alertmanager URL is treated as a separate group in the configuration. Multiple Alertmanagers in HA per group can be supported by using DNS resolution via -ruler.alertmanager-discovery.")
 	f.BoolVar(&cfg.AlertmanagerDiscovery, "ruler.alertmanager-discovery", false, "Use DNS SRV records to discover Alertmanager hosts.")
 	f.DurationVar(&cfg.AlertmanagerRefreshInterval, "ruler.alertmanager-refresh-interval", 1*time.Minute, "How long to wait between refreshing DNS resolutions of Alertmanager hosts.")
 	f.BoolVar(&cfg.AlertmanangerEnableV2API, "ruler.alertmanager-use-v2", false, "If enabled requests to Alertmanager will utilize the V2 API.")

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -129,7 +129,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.EvaluationDelay, "ruler.evaluation-delay-duration", 0, "Duration to delay the evaluation of rules to ensure they underlying metrics have been pushed to cortex.")
 	f.DurationVar(&cfg.PollInterval, "ruler.poll-interval", 1*time.Minute, "How frequently to poll for rule changes")
 
-	f.Var(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "URL(s) of the Alertmanager(s) to send notifications to. Each Alertmanager URL is treated as a separate group in the configuration. Multiple Alertmanagers in HA per group can be supported by using DNS resolution via -ruler.alertmanager-discovery.")
+	f.Var(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "Comma-separated list of URL(s) of the Alertmanager(s) to send notifications to. Each Alertmanager URL is treated as a separate group in the configuration. Multiple Alertmanagers in HA per group can be supported by using DNS resolution via -ruler.alertmanager-discovery.")
 	f.BoolVar(&cfg.AlertmanagerDiscovery, "ruler.alertmanager-discovery", false, "Use DNS SRV records to discover Alertmanager hosts.")
 	f.DurationVar(&cfg.AlertmanagerRefreshInterval, "ruler.alertmanager-refresh-interval", 1*time.Minute, "How long to wait between refreshing DNS resolutions of Alertmanager hosts.")
 	f.BoolVar(&cfg.AlertmanangerEnableV2API, "ruler.alertmanager-use-v2", false, "If enabled requests to Alertmanager will utilize the V2 API.")


### PR DESCRIPTION
**What this PR does**:

At the moment, the Ruler only support sending alerts to multiple
Alertmanagers via DNS based service discovery. However, sending to
multiple Alertmanager groups is something that Prometheus allows.

I believe the Ruler should support this too and this commit introduces
that.

To keep backward compatibility we're reusing the same flag but allowing
a list of 1+. With this, we can treat each URL as an Alertmanager group
where multiple Alertmanagers per group is only supported if DNS service
discovery is enabled.

~~*Please note that this would be effectively a breaking change on the ruler flags. In the docs, the ruler API is currently listed as experimental but not the ruler itself. I assume meant we would still need to support the flag for at least 2 more versions should we want to do what's on this PR*~~

Signed-off-by: gotjosh <josue@grafana.com>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
