### PR TITLE
Add a metric to track ruler update failures (errors in loading rules files).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
   * `s3.http.insecure-skip-verify`
 * [ENHANCEMENT] Prometheus upgraded. #2798 #2849
   * Optimized labels regex matchers for patterns containing literals (eg. `foo.*`, `.*foo`, `.*foo.*`)
+* [ENHANCEMENT] Add metric `ruler_config_update_failures_total` to Ruler to track failures of loading rules files. #2857
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
   * `s3.http.insecure-skip-verify`
 * [ENHANCEMENT] Prometheus upgraded. #2798 #2849
   * Optimized labels regex matchers for patterns containing literals (eg. `foo.*`, `.*foo`, `.*foo.*`)
-* [ENHANCEMENT] Add metric `ruler_config_update_failures_total` to Ruler to track failures of loading rules files. #2857
+* [ENHANCEMENT] Add metric `cortex_ruler_config_update_failures_total` to Ruler to track failures of loading rules files. #2857
 * [ENHANCEMENT] Experimental Alertmanager: Alertmanager configuration persisted to object storage using an experimental API that accepts and returns YAML-based Alertmanager configuration. #2768
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -50,6 +50,11 @@ var (
 		Name:      "ruler_config_updates_total",
 		Help:      "Total number of config updates triggered by a user",
 	}, []string{"user"})
+	configUpdateFailuresTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "cortex",
+		Name:      "ruler_config_update_failures_total",
+		Help:      "Total number of config update failures triggered by a user",
+	}, []string{"user"})
 	managersTotal = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "cortex",
 		Name:      "ruler_managers_total",
@@ -511,6 +516,7 @@ func (r *Ruler) syncManager(ctx context.Context, user string, groups store.RuleG
 		}
 		err = manager.Update(r.cfg.EvaluationInterval, files, nil)
 		if err != nil {
+			configUpdateFailuresTotal.WithLabelValues(user).Inc()
 			level.Error(r.logger).Log("msg", "unable to update rule manager", "user", user, "err", err)
 			return
 		}


### PR DESCRIPTION
**What this PR does**:
Adds a metric to track ruler update failures per user.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

cc @gotjosh @jtlisi 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
