### PR TITLE
Upgraded Docker base images to alpine:3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [FEATURE] Introduced `ruler.for-outage-tolerance`, Max time to tolerate outage for restoring "for" state of alert. #2783
 * [FEATURE] Introduced `ruler.for-grace-period`, Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. #2783
 * [FEATURE] Introduced `ruler.resend-delay`, Minimum amount of time to wait before resending an alert to Alertmanager. #2783
+* [ENHANCEMENT] Upgraded Docker base images to `alpine:3.12`. #2862
 * [ENHANCEMENT] Experimental: Querier can now optionally query secondary store. This is specified by using `-querier.second-store-engine` option, with values `chunks` or `tsdb`. Standard configuration options for this store are used. Additionally, this querying can be configured to happen only for queries that need data older than `-querier.use-second-store-before-time`. Default value of zero will always query secondary store. #2747
 * [ENHANCEMENT] Query-tee: increased the `cortex_querytee_request_duration_seconds` metric buckets granularity. #2799
 * [ENHANCEMENT] Query-tee: fail to start if the configured `-backend.preferred` is unknown. #2799

--- a/cmd/cortex/Dockerfile
+++ b/cmd/cortex/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine:3.8
+FROM       alpine:3.12
 RUN        apk add --no-cache ca-certificates
 COPY       migrations /migrations/
 COPY       cortex /bin/cortex

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine:3.11
+FROM       alpine:3.12
 RUN        apk add --no-cache ca-certificates
 COPY       query-tee /
 ENTRYPOINT ["/query-tee"]

--- a/cmd/test-exporter/Dockerfile
+++ b/cmd/test-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine:3.8
+FROM       alpine:3.12
 RUN        apk add --no-cache ca-certificates
 COPY       test-exporter /
 ENTRYPOINT ["/test-exporter"]

--- a/development/tsdb-blocks-storage-s3-single-binary/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3-single-binary/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.12
 
 RUN     mkdir /cortex
 WORKDIR /cortex

--- a/development/tsdb-blocks-storage-s3/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3/dev.dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.14
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 RUN go get github.com/go-delve/delve/cmd/dlv
-FROM alpine:3.10
+
+FROM alpine:3.12
 
 RUN     mkdir /cortex
 WORKDIR /cortex


### PR DESCRIPTION
**What this PR does**:
@codesome noticed we are building some of our Docker images based on old version of Alpine, so I took the opportunity to upgrade them. I've run few smoke tests and it looks good.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
