### PR TITLE
Improved website section index

### DIFF
--- a/docs/case-studies/_index.md
+++ b/docs/case-studies/_index.md
@@ -2,6 +2,7 @@
 title: "Case Studies"
 linkTitle: "Case Studies"
 slug: case-studies
+no_section_index_title: true
 weight: 11
 menu:
 ---

--- a/docs/configuration/_index.md
+++ b/docs/configuration/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Configuration"
 linkTitle: "Configuration"
+no_section_index_title: true
 weight: 7
 menu:
 ---

--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Getting Started"
 linkTitle: "Getting Started"
+no_section_index_title: true
 weight: 1
 menu:
 ---

--- a/docs/guides/_index.md
+++ b/docs/guides/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Guides"
 linkTitle: "Guides"
+no_section_index_title: true
 weight: 6
 menu:
 ---

--- a/docs/operations/_index.md
+++ b/docs/operations/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Operating Cortex"
 linkTitle: "Operations"
+no_section_index_title: true
 weight: 7
 menu:
 ---

--- a/docs/production/_index.md
+++ b/docs/production/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Production"
 linkTitle: "Production"
+no_section_index_title: true
 weight: 3
 menu:
 ---

--- a/docs/proposals/_index.md
+++ b/docs/proposals/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Proposals"
 linkTitle: "Proposals"
+no_section_index_title: true
 weight: 12
 menu:
 ---

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,4 @@
- This is typically done in Grafana Labs or Weaveworks but we are looking for more volunteers!---
+---
 title: "Roadmap"
 linkTitle: "Roadmap"
 weight: 50

--- a/website/layouts/partials/section-index.html
+++ b/website/layouts/partials/section-index.html
@@ -1,0 +1,17 @@
+{{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
+{{ $parent := .Page }}
+
+{{ if $parent.Params.no_section_index }}
+    {{/* If no_section_index is true we don't show a list of subpages */}}
+{{ else }}
+    {{ if $parent.Params.no_section_index_title }}{{ else }}
+        <h2 id="more-in-this-section">More in this section</h2>
+    {{ end }}
+    <ul>
+        {{ range $pages }}
+            {{ if eq .Parent $parent }}
+                <li><a href="{{ .RelPermalink }}">{{- .Title -}}</a></li>
+            {{ end }}
+        {{ end }}
+    </ul>
+{{ end }}


### PR DESCRIPTION
**What this PR does**:
In this PR I'm proposing to change the way the section index is rendered, adding a title to it and using a normal list rendered with the default font size.

This PR also fixes the roadmap page.

**Before**:
![before](https://user-images.githubusercontent.com/1701904/87065320-2e957200-c211-11ea-8ae3-61ace8b9f98a.png)


**After**:
![after](https://user-images.githubusercontent.com/1701904/87065292-250c0a00-c211-11ea-9a46-157d905ae97f.png)


**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
