### PR TITLE
make fs object client windows compatible and add a method to get pathseparator from object clients

### DIFF
--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -325,3 +325,7 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stora
 
 	return storageObjects, commonPrefixes, nil
 }
+
+func (a *S3ObjectClient) PathSeparator() string {
+	return a.delimiter
+}

--- a/pkg/chunk/azure/blob_storage_client.go
+++ b/pkg/chunk/azure/blob_storage_client.go
@@ -210,3 +210,7 @@ func (b *BlobStorage) DeleteObject(ctx context.Context, blobID string) error {
 	_, err = blockBlobURL.Delete(ctx, azblob.DeleteSnapshotsOptionInclude, azblob.BlobAccessConditions{})
 	return err
 }
+
+func (b *BlobStorage) PathSeparator() string {
+	return b.delimiter
+}

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -155,3 +155,7 @@ func (s *GCSObjectClient) DeleteObject(ctx context.Context, objectKey string) er
 
 	return nil
 }
+
+func (s *GCSObjectClient) PathSeparator() string {
+	return s.delimiter
+}

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -390,6 +390,10 @@ func (m *MockStorage) List(ctx context.Context, prefix string) ([]StorageObject,
 	return storageObjects, []StorageCommonPrefix{}, nil
 }
 
+func (m *MockStorage) PathSeparator() string {
+	return DirDelim
+}
+
 type mockWriteBatch struct {
 	inserts []struct {
 		tableName, hashValue string

--- a/pkg/chunk/local/fs_object_client.go
+++ b/pkg/chunk/local/fs_object_client.go
@@ -34,7 +34,8 @@ func (cfg *FSConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 
 // FSObjectClient holds config for filesystem as object store
 type FSObjectClient struct {
-	cfg FSConfig
+	cfg           FSConfig
+	pathSeparator string
 }
 
 // NewFSObjectClient makes a chunk.Client which stores chunks as files in the local filesystem.
@@ -48,7 +49,8 @@ func NewFSObjectClient(cfg FSConfig) (*FSObjectClient, error) {
 	}
 
 	return &FSObjectClient{
-		cfg: cfg,
+		cfg:           cfg,
+		pathSeparator: string(os.PathSeparator),
 	}, nil
 }
 
@@ -124,7 +126,7 @@ func (f *FSObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stora
 
 			// add the directory only if it is not empty
 			if !empty {
-				commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(nameWithPrefix+chunk.DirDelim))
+				commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(nameWithPrefix+f.pathSeparator))
 			}
 			continue
 		}
@@ -171,6 +173,10 @@ func (f *FSObjectClient) DeleteChunksBefore(ctx context.Context, ts time.Time) e
 		}
 		return nil
 	})
+}
+
+func (f *FSObjectClient) PathSeparator() string {
+	return f.pathSeparator
 }
 
 // copied from https://github.com/thanos-io/thanos/blob/55cb8ca38b3539381dc6a781e637df15c694e50a/pkg/objstore/filesystem/filesystem.go#L181

--- a/pkg/chunk/openstack/swift_object_client.go
+++ b/pkg/chunk/openstack/swift_object_client.go
@@ -176,3 +176,7 @@ func (s *SwiftObjectClient) DeleteObject(ctx context.Context, objectKey string) 
 	}
 	return err
 }
+
+func (s *SwiftObjectClient) PathSeparator() string {
+	return string(s.delimiter)
+}

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -67,6 +67,7 @@ type ObjectClient interface {
 	GetObject(ctx context.Context, objectKey string) (io.ReadCloser, error)
 	List(ctx context.Context, prefix string) ([]StorageObject, []StorageCommonPrefix, error)
 	DeleteObject(ctx context.Context, objectKey string) error
+	PathSeparator() string
 	Stop()
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Makes filesystem object client windows compatible by not using a hardcoded separator.
It also adds a method to `ObjectClient` to get what separator is being used by underlying storage.

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
