### PR TITLE
Move cover to build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
   docker:
     # IMPORTANT: whenever you change the build-image version tag, remember to replace it
     #            across the entire file (there are multiple references).
-    - image: quay.io/cortexproject/build-image:update-build-image-ce3bc5f86
+    - image: quay.io/cortexproject/build-image:with-cover-32d2cb52b
   working_directory: /go/src/github.com/cortexproject/cortex
 
 filters: &filters
@@ -87,7 +87,7 @@ jobs:
 
   test:
     docker:
-      - image: quay.io/cortexproject/build-image:update-build-image-ce3bc5f86
+      - image: quay.io/cortexproject/build-image:with-cover-32d2cb52b
       - image: cassandra:3.11
         environment:
           JVM_OPTS: "-Xms1024M -Xmx1024M"
@@ -111,7 +111,7 @@ jobs:
         name: Integration Test
         command: |
           touch build-image/.uptodate
-          MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations make BUILD_IMAGE=quay.io/cortexproject/build-image:update-build-image-ce3bc5f86 configs-integration-test
+          MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations make BUILD_IMAGE=quay.io/cortexproject/build-image:with-cover-32d2cb52b configs-integration-test
 
   integration:
     machine:

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -20,7 +20,8 @@ RUN GO111MODULE=on go get -tags netgo \
 		github.com/client9/misspell/cmd/misspell@v0.3.4 \
 		github.com/golang/protobuf/protoc-gen-go@v1.3.1 \
 		github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 \
-		github.com/gogo/protobuf/gogoproto@v1.3.0 && \
+		github.com/gogo/protobuf/gogoproto@v1.3.0 \
+		github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 && \
 	rm -rf /go/pkg /go/src
 
 ENV KUBEVAL_VERSION=0.15.0

--- a/tools/test
+++ b/tools/test
@@ -134,9 +134,6 @@ if [ -n "$PARALLEL" ]; then
 fi
 
 if [ -n "$SLOW" ] && [ -z "$COVERDIR" ]; then
-    go get github.com/weaveworks/tools/cover
-    go mod vendor # re-vendor everything
-
     cover "$coverdir"/* >profile.cov
     rm -rf "$coverdir"
     go tool cover -html=profile.cov -o=coverage.html


### PR DESCRIPTION
**What this PR does**: This PR updates is a follow-up for https://github.com/cortexproject/cortex/pull/2749#discussion_r443675025. It updates build-image to include [cover](github.com/weaveworks/tools/cover) tool, to avoid having to run go get and go mod vendor in the test script.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
