### PR TITLE
Make Flusher mode to work with blocks-engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [ENHANCEMENT] Experimental Alertmanager: Alertmanager configuration persisted to object storage using an experimental API that accepts and returns YAML-based Alertmanager configuration. #2768
 * [ENHANCEMENT] Ruler: `-ruler.alertmanager-url` now supports multiple URLs. Each URL is treated as a separate Alertmanager group. Support for multiple Alertmanagers in a group can be achieved by using DNS service discovery. #2851
 * [ENHANCEMENT] Experimental TSDB: Cortex Flusher now works with blocks engine. Flusher needs to be provided with blocks-engine configuration, existing Flusher flags are not used (they are only relevant for chunks engine). Note that flush errors are only reported via log. #2877
+* [ENHANCEMENT] Flusher: Added `-flusher.exit-after-flush` option (defaults to true) to control whether Cortex should stop completely after Flusher has finished its work. #2877
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * [ENHANCEMENT] Add metric `cortex_ruler_config_update_failures_total` to Ruler to track failures of loading rules files. #2857
 * [ENHANCEMENT] Experimental Alertmanager: Alertmanager configuration persisted to object storage using an experimental API that accepts and returns YAML-based Alertmanager configuration. #2768
 * [ENHANCEMENT] Ruler: `-ruler.alertmanager-url` now supports multiple URLs. Each URL is treated as a separate Alertmanager group. Support for multiple Alertmanagers in a group can be achieved by using DNS service discovery. #2851
+* [ENHANCEMENT] Experimental TSDB: Cortex Flusher now works with blocks engine. Flusher needs to be provided with blocks-engine configuration, existing Flusher flags are not used (they are only relevant for chunks engine). Note that flush errors are only reported via log. #2877
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2132,15 +2132,16 @@ grpc_store:
 The `flusher_config` configures the WAL flusher target, used to manually run one-time flushes when scaling down ingesters.
 
 ```yaml
-# Directory to read WAL from. (Chunks-only)
+# Directory to read WAL from (chunks storage engine only).
 # CLI flag: -flusher.wal-dir
 [wal_dir: <string> | default = "wal"]
 
-# Number of concurrent goroutines flushing to storage. (Chunks-only)
+# Number of concurrent goroutines flushing to storage (chunks storage engine
+# only).
 # CLI flag: -flusher.concurrent-flushes
 [concurrent_flushes: <int> | default = 50]
 
-# Timeout for individual flush operations. (Chunks-only)
+# Timeout for individual flush operations (chunks storage engine only).
 # CLI flag: -flusher.flush-op-timeout
 [flush_op_timeout: <duration> | default = 2m]
 ```

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2132,15 +2132,15 @@ grpc_store:
 The `flusher_config` configures the WAL flusher target, used to manually run one-time flushes when scaling down ingesters.
 
 ```yaml
-# Directory to read WAL from.
+# Directory to read WAL from. (Chunks-only)
 # CLI flag: -flusher.wal-dir
 [wal_dir: <string> | default = "wal"]
 
-# Number of concurrent goroutines flushing to dynamodb.
+# Number of concurrent goroutines flushing to storage. (Chunks-only)
 # CLI flag: -flusher.concurrent-flushes
 [concurrent_flushes: <int> | default = 50]
 
-# Timeout for individual flush operations.
+# Timeout for individual flush operations. (Chunks-only)
 # CLI flag: -flusher.flush-op-timeout
 [flush_op_timeout: <duration> | default = 2m]
 ```

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2144,6 +2144,11 @@ The `flusher_config` configures the WAL flusher target, used to manually run one
 # Timeout for individual flush operations (chunks storage engine only).
 # CLI flag: -flusher.flush-op-timeout
 [flush_op_timeout: <duration> | default = 2m]
+
+# Stop Cortex after flush has finished. If false, Cortex process will keep
+# running, doing nothing.
+# CLI flag: -flusher.exit-after-flush
+[exit_after_flush: <boolean> | default = true]
 ```
 
 ### `chunk_store_config`

--- a/pkg/flusher/flusher.go
+++ b/pkg/flusher/flusher.go
@@ -19,6 +19,7 @@ type Config struct {
 	WALDir            string        `yaml:"wal_dir"`
 	ConcurrentFlushes int           `yaml:"concurrent_flushes"`
 	FlushOpTimeout    time.Duration `yaml:"flush_op_timeout"`
+	ExitAfterFlush    bool          `yaml:"exit_after_flush"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -26,6 +27,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.WALDir, "flusher.wal-dir", "wal", "Directory to read WAL from (chunks storage engine only).")
 	f.IntVar(&cfg.ConcurrentFlushes, "flusher.concurrent-flushes", 50, "Number of concurrent goroutines flushing to storage (chunks storage engine only).")
 	f.DurationVar(&cfg.FlushOpTimeout, "flusher.flush-op-timeout", 2*time.Minute, "Timeout for individual flush operations (chunks storage engine only).")
+	f.BoolVar(&cfg.ExitAfterFlush, "flusher.exit-after-flush", true, "Stop Cortex after flush has finished. If false, Cortex process will keep running, doing nothing.")
 }
 
 // Flusher is designed to be used as a job to flush the data from the WAL on disk.
@@ -87,5 +89,11 @@ func (f *Flusher) running(ctx context.Context) error {
 	if err := services.StopAndAwaitTerminated(ctx, ing); err != nil {
 		return errors.Wrap(err, "stop and await terminated ingester")
 	}
-	return util.ErrStopProcess
+
+	if f.cfg.ExitAfterFlush {
+		return util.ErrStopProcess
+	}
+
+	// Return normally -- this keep Cortex running.
+	return nil
 }

--- a/pkg/flusher/flusher.go
+++ b/pkg/flusher/flusher.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cortexproject/cortex/pkg/ingester"
-	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
@@ -24,18 +23,18 @@ type Config struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.WALDir, "flusher.wal-dir", "wal", "Directory to read WAL from.")
-	f.IntVar(&cfg.ConcurrentFlushes, "flusher.concurrent-flushes", 50, "Number of concurrent goroutines flushing to dynamodb.")
-	f.DurationVar(&cfg.FlushOpTimeout, "flusher.flush-op-timeout", 2*time.Minute, "Timeout for individual flush operations.")
+	f.StringVar(&cfg.WALDir, "flusher.wal-dir", "wal", "Directory to read WAL from. (Chunks-only)")
+	f.IntVar(&cfg.ConcurrentFlushes, "flusher.concurrent-flushes", 50, "Number of concurrent goroutines flushing to storage. (Chunks-only)")
+	f.DurationVar(&cfg.FlushOpTimeout, "flusher.flush-op-timeout", 2*time.Minute, "Timeout for individual flush operations. (Chunks-only)")
 }
 
-// Flusher is designed to be used as a job to flush the chunks from the WAL on disk.
+// Flusher is designed to be used as a job to flush the data from the WAL on disk.
+// Flusher works with both chunks-based and blocks-based ingesters.
 type Flusher struct {
 	services.Service
 
 	cfg            Config
 	ingesterConfig ingester.Config
-	clientConfig   client.Config
 	chunkStore     ingester.ChunkStore
 	registerer     prometheus.Registerer
 }
@@ -49,11 +48,11 @@ const (
 func New(
 	cfg Config,
 	ingesterConfig ingester.Config,
-	clientConfig client.Config,
 	chunkStore ingester.ChunkStore,
 	registerer prometheus.Registerer,
 ) (*Flusher, error) {
 
+	// These are ignored by blocks-ingester, but that's fine.
 	ingesterConfig.WALConfig.Dir = cfg.WALDir
 	ingesterConfig.ConcurrentFlushes = cfg.ConcurrentFlushes
 	ingesterConfig.FlushOpTimeout = cfg.FlushOpTimeout
@@ -61,7 +60,6 @@ func New(
 	f := &Flusher{
 		cfg:            cfg,
 		ingesterConfig: ingesterConfig,
-		clientConfig:   clientConfig,
 		chunkStore:     chunkStore,
 		registerer:     registerer,
 	}
@@ -70,7 +68,7 @@ func New(
 }
 
 func (f *Flusher) running(ctx context.Context) error {
-	ing, err := ingester.NewForFlusher(f.ingesterConfig, f.clientConfig, f.chunkStore, f.registerer)
+	ing, err := ingester.NewForFlusher(f.ingesterConfig, f.chunkStore, f.registerer)
 	if err != nil {
 		return errors.Wrap(err, "create ingester")
 	}

--- a/pkg/flusher/flusher.go
+++ b/pkg/flusher/flusher.go
@@ -23,9 +23,9 @@ type Config struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.WALDir, "flusher.wal-dir", "wal", "Directory to read WAL from. (Chunks-only)")
-	f.IntVar(&cfg.ConcurrentFlushes, "flusher.concurrent-flushes", 50, "Number of concurrent goroutines flushing to storage. (Chunks-only)")
-	f.DurationVar(&cfg.FlushOpTimeout, "flusher.flush-op-timeout", 2*time.Minute, "Timeout for individual flush operations. (Chunks-only)")
+	f.StringVar(&cfg.WALDir, "flusher.wal-dir", "wal", "Directory to read WAL from (chunks storage engine only).")
+	f.IntVar(&cfg.ConcurrentFlushes, "flusher.concurrent-flushes", 50, "Number of concurrent goroutines flushing to storage (chunks storage engine only).")
+	f.DurationVar(&cfg.FlushOpTimeout, "flusher.flush-op-timeout", 2*time.Minute, "Timeout for individual flush operations (chunks storage engine only).")
 }
 
 // Flusher is designed to be used as a job to flush the data from the WAL on disk.

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -302,7 +302,9 @@ func (i *Ingester) startingV2(ctx context.Context) error {
 }
 
 func (i *Ingester) stoppingV2ForFlusher(_ error) error {
-	i.closeAllTSDB()
+	if !i.cfg.TSDBConfig.KeepUserTSDBOpenOnShutdown {
+		i.closeAllTSDB()
+	}
 	return nil
 }
 
@@ -321,7 +323,9 @@ func (i *Ingester) stoppingV2(_ error) error {
 		level.Warn(util.Logger).Log("msg", "stopping ingester lifecycler", "err", err)
 	}
 
-	i.closeAllTSDB()
+	if !i.cfg.TSDBConfig.KeepUserTSDBOpenOnShutdown {
+		i.closeAllTSDB()
+	}
 	return nil
 }
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -124,6 +124,9 @@ type TSDBState struct {
 	dbs    map[string]*userTSDB // tsdb sharded by userID
 	bucket objstore.Bucket
 
+	// Value used by shipper as external label.
+	shipperIngesterID string
+
 	// Keeps count of in-flight requests
 	inflightWriteReqs sync.WaitGroup
 
@@ -147,6 +150,46 @@ type TSDBState struct {
 	refCachePurgeDuration  prometheus.Histogram
 }
 
+func newTSDBState(bucketClient objstore.Bucket, registerer prometheus.Registerer) TSDBState {
+	return TSDBState{
+		dbs:                 make(map[string]*userTSDB),
+		bucket:              bucketClient,
+		tsdbMetrics:         newTSDBMetrics(registerer),
+		forceCompactTrigger: make(chan chan<- struct{}),
+		shipTrigger:         make(chan chan<- struct{}),
+
+		compactionsTriggered: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_tsdb_compactions_triggered_total",
+			Help: "Total number of triggered compactions.",
+		}),
+
+		compactionsFailed: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_tsdb_compactions_failed_total",
+			Help: "Total number of compactions that failed.",
+		}),
+		walReplayTime: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_tsdb_wal_replay_duration_seconds",
+			Help:    "The total time it takes to open and replay a TSDB WAL.",
+			Buckets: prometheus.DefBuckets,
+		}),
+		appenderAddDuration: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_tsdb_appender_add_duration_seconds",
+			Help:    "The total time it takes for a push request to add samples to the TSDB appender.",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		}),
+		appenderCommitDuration: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_tsdb_appender_commit_duration_seconds",
+			Help:    "The total time it takes for a push request to commit samples appended to TSDB.",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		}),
+		refCachePurgeDuration: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_tsdb_refcache_purge_duration_seconds",
+			Help:    "The total time it takes to purge the TSDB series reference cache for a single tenant.",
+			Buckets: prometheus.DefBuckets,
+		}),
+	}
+}
+
 // NewV2 returns a new Ingester that uses prometheus block storage instead of chunk storage
 func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides, registerer prometheus.Registerer) (*Ingester, error) {
 	util.WarnExperimentalUse("Blocks storage engine")
@@ -163,43 +206,7 @@ func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides,
 		chunkStore:    nil,
 		usersMetadata: map[string]*userMetricsMetadata{},
 		wal:           &noopWAL{},
-		TSDBState: TSDBState{
-			dbs:                 make(map[string]*userTSDB),
-			bucket:              bucketClient,
-			tsdbMetrics:         newTSDBMetrics(registerer),
-			forceCompactTrigger: make(chan chan<- struct{}),
-			shipTrigger:         make(chan chan<- struct{}),
-
-			compactionsTriggered: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
-				Name: "cortex_ingester_tsdb_compactions_triggered_total",
-				Help: "Total number of triggered compactions.",
-			}),
-
-			compactionsFailed: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
-				Name: "cortex_ingester_tsdb_compactions_failed_total",
-				Help: "Total number of compactions that failed.",
-			}),
-			walReplayTime: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
-				Name:    "cortex_ingester_tsdb_wal_replay_duration_seconds",
-				Help:    "The total time it takes to open and replay a TSDB WAL.",
-				Buckets: prometheus.DefBuckets,
-			}),
-			appenderAddDuration: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
-				Name:    "cortex_ingester_tsdb_appender_add_duration_seconds",
-				Help:    "The total time it takes for a push request to add samples to the TSDB appender.",
-				Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
-			}),
-			appenderCommitDuration: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
-				Name:    "cortex_ingester_tsdb_appender_commit_duration_seconds",
-				Help:    "The total time it takes for a push request to commit samples appended to TSDB.",
-				Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
-			}),
-			refCachePurgeDuration: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
-				Name:    "cortex_ingester_tsdb_refcache_purge_duration_seconds",
-				Help:    "The total time it takes to purge the TSDB series reference cache for a single tenant.",
-				Buckets: prometheus.DefBuckets,
-			}),
-		},
+		TSDBState:     newTSDBState(bucketClient, registerer),
 	}
 
 	// Replace specific metrics which we can't directly track but we need to read
@@ -223,13 +230,47 @@ func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides,
 	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor, cfg.ShardByAllLabels)
 	i.userStates = newUserStates(i.limiter, cfg, i.metrics)
 
+	i.TSDBState.shipperIngesterID = i.lifecycler.ID
+
 	i.BasicService = services.NewBasicService(i.startingV2, i.updateLoop, i.stoppingV2)
 	return i, nil
 }
 
+// Special version of ingester used by Flusher. This ingester is not ingesting anything, its only purpose is to react
+// on Flush method and flush all openened TSDBs when called.
+func NewV2ForFlusher(cfg Config, registerer prometheus.Registerer) (*Ingester, error) {
+	util.WarnExperimentalUse("Blocks storage engine")
+	bucketClient, err := cortex_tsdb.NewBucketClient(context.Background(), cfg.TSDBConfig, "ingester", util.Logger, registerer)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create the bucket client")
+	}
+
+	i := &Ingester{
+		cfg:       cfg,
+		metrics:   newIngesterMetrics(registerer, false),
+		wal:       &noopWAL{},
+		TSDBState: newTSDBState(bucketClient, registerer),
+	}
+
+	i.TSDBState.shipperIngesterID = "flusher"
+
+	// This ingester will not start any subservices (lifecycler, compaction, shipping),
+	// and will only open TSDBs, wait for Flush to be called, and then close TSDBs again.
+	i.BasicService = services.NewIdleService(i.startingV2ForFlusher, i.stoppingV2ForFlusher)
+	return i, nil
+}
+
+func (i *Ingester) startingV2ForFlusher(ctx context.Context) error {
+	if err := i.openExistingTSDB(ctx); err != nil {
+		return errors.Wrap(err, "opening existing TSDBs")
+	}
+
+	// Don't start any sub-services (lifecycler, compaction, shipper) at all.
+	return nil
+}
+
 func (i *Ingester) startingV2(ctx context.Context) error {
-	// Scan and open TSDB's that already exist on disk
-	if err := i.openExistingTSDB(context.Background()); err != nil {
+	if err := i.openExistingTSDB(ctx); err != nil {
 		return errors.Wrap(err, "opening existing TSDBs")
 	}
 
@@ -260,6 +301,11 @@ func (i *Ingester) startingV2(ctx context.Context) error {
 	return errors.Wrap(err, "failed to start ingester components")
 }
 
+func (i *Ingester) stoppingV2ForFlusher(_ error) error {
+	i.closeAllTSDB()
+	return nil
+}
+
 // runs when V2 ingester is stopping
 func (i *Ingester) stoppingV2(_ error) error {
 	// It's important to wait until shipper is finished,
@@ -271,7 +317,12 @@ func (i *Ingester) stoppingV2(_ error) error {
 	}
 
 	// Next initiate our graceful exit from the ring.
-	return services.StopAndAwaitTerminated(context.Background(), i.lifecycler)
+	if err := services.StopAndAwaitTerminated(context.Background(), i.lifecycler); err != nil {
+		level.Warn(util.Logger).Log("msg", "stopping ingester lifecycler", "err", err)
+	}
+
+	i.closeAllTSDB()
+	return nil
 }
 
 func (i *Ingester) updateLoop(ctx context.Context) error {
@@ -898,6 +949,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 	// Run compaction before using this TSDB. If there is data in head that needs to be put into blocks,
 	// this will actually create the blocks. If there is no data (empty TSDB), this is a no-op, although
 	// local blocks compaction may still take place if configured.
+	level.Info(userLogger).Log("msg", "Running compaction after WAL replay")
 	err = db.Compact()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to compact TSDB: %s", udir)
@@ -918,7 +970,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 			Value: userID,
 		}, {
 			Name:  cortex_tsdb.IngesterIDExternalLabel,
-			Value: i.lifecycler.ID,
+			Value: i.TSDBState.shipperIngesterID,
 		},
 	}
 
@@ -1088,9 +1140,11 @@ func (i *Ingester) shipBlocks(ctx context.Context) {
 	// particularly important for the JOINING state because there could
 	// be a blocks transfer in progress (from another ingester) and if we
 	// run the shipper in such state we could end up with race conditions.
-	if ingesterState := i.lifecycler.GetState(); ingesterState == ring.PENDING || ingesterState == ring.JOINING {
-		level.Info(util.Logger).Log("msg", "TSDB blocks shipping has been skipped because of the current ingester state", "state", ingesterState)
-		return
+	if i.lifecycler != nil {
+		if ingesterState := i.lifecycler.GetState(); ingesterState == ring.PENDING || ingesterState == ring.JOINING {
+			level.Info(util.Logger).Log("msg", "TSDB blocks shipping has been skipped because of the current ingester state", "state", ingesterState)
+			return
+		}
 	}
 
 	// Number of concurrent workers is limited in order to avoid to concurrently sync a lot
@@ -1139,9 +1193,11 @@ func (i *Ingester) compactionLoop(ctx context.Context) error {
 func (i *Ingester) compactBlocks(ctx context.Context, force bool) {
 	// Don't compact TSDB blocks while JOINING as there may be ongoing blocks transfers.
 	// Compaction loop is not running in LEAVING state, so if we get here in LEAVING state, we're flushing blocks.
-	if ingesterState := i.lifecycler.GetState(); ingesterState == ring.JOINING {
-		level.Info(util.Logger).Log("msg", "TSDB blocks compaction has been skipped because of the current ingester state", "state", ingesterState)
-		return
+	if i.lifecycler != nil {
+		if ingesterState := i.lifecycler.GetState(); ingesterState == ring.JOINING {
+			level.Info(util.Logger).Log("msg", "TSDB blocks compaction has been skipped because of the current ingester state", "state", ingesterState)
+			return
+		}
 	}
 
 	i.runConcurrentUserWorkers(ctx, i.cfg.TSDBConfig.HeadCompactionConcurrency, func(userID string) {
@@ -1217,9 +1273,12 @@ sendLoop:
 	wg.Wait()
 }
 
-// This method is called as part of Lifecycler's shutdown, to flush all data.
-// Lifecycler shutdown happens as part of Ingester shutdown (see stoppingV2 method).
+// This method will flush all data. It is called as part of Lifecycler's shutdown (if flush on shutdown is configured), or from the flusher.
+//
+// When called as during Lifecycler shutdown, this happens as part of normal Ingester shutdown (see stoppingV2 method).
 // Samples are not received at this stage. Compaction and Shipping loops have already been stopped as well.
+//
+// When used from flusher, ingester is constructed in a way that compaction, shipping and receiving of samples is never started.
 func (i *Ingester) v2LifecyclerFlush() {
 	level.Info(util.Logger).Log("msg", "starting to flush and ship TSDB blocks")
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -190,7 +190,7 @@ func newTSDBState(bucketClient objstore.Bucket, registerer prometheus.Registerer
 	}
 }
 
-// NewV2 returns a new Ingester that uses prometheus block storage instead of chunk storage
+// NewV2 returns a new Ingester that uses Cortex block storage instead of chunks storage.
 func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides, registerer prometheus.Registerer) (*Ingester, error) {
 	util.WarnExperimentalUse("Blocks storage engine")
 	bucketClient, err := cortex_tsdb.NewBucketClient(context.Background(), cfg.TSDBConfig, "ingester", util.Logger, registerer)
@@ -315,12 +315,12 @@ func (i *Ingester) stoppingV2(_ error) error {
 	// there's no shipping on-going.
 
 	if err := services.StopManagerAndAwaitStopped(context.Background(), i.TSDBState.subservices); err != nil {
-		level.Warn(util.Logger).Log("msg", "stopping ingester subservices", "err", err)
+		level.Warn(util.Logger).Log("msg", "failed to stop ingester subservices", "err", err)
 	}
 
 	// Next initiate our graceful exit from the ring.
 	if err := services.StopAndAwaitTerminated(context.Background(), i.lifecycler); err != nil {
-		level.Warn(util.Logger).Log("msg", "stopping ingester lifecycler", "err", err)
+		level.Warn(util.Logger).Log("msg", "failed to stop ingester lifecycler", "err", err)
 	}
 
 	if !i.cfg.TSDBConfig.KeepUserTSDBOpenOnShutdown {

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -1310,6 +1310,7 @@ func TestIngester_flushing(t *testing.T) {
 		"ingesterShutdown": {
 			setupIngester: func(cfg *Config) {
 				cfg.TSDBConfig.FlushBlocksOnShutdown = true
+				cfg.TSDBConfig.KeepUserTSDBOpenOnShutdown = true
 			},
 			action: func(t *testing.T, i *Ingester, m *shipperMock) {
 				pushSingleSample(t, i)
@@ -1330,6 +1331,7 @@ func TestIngester_flushing(t *testing.T) {
 		"shutdownHandler": {
 			setupIngester: func(cfg *Config) {
 				cfg.TSDBConfig.FlushBlocksOnShutdown = false
+				cfg.TSDBConfig.KeepUserTSDBOpenOnShutdown = true
 			},
 
 			action: func(t *testing.T, i *Ingester, m *shipperMock) {
@@ -1730,4 +1732,37 @@ func TestHeadCompactionOnStartup(t *testing.T) {
 	dur := time.Duration(h.MaxTime()-h.MinTime()) * time.Millisecond
 	require.True(t, dur <= 2*time.Hour)
 	require.Equal(t, 11, len(db.Blocks()))
+}
+
+func TestIngester_CloseTSDBsOnShutdown(t *testing.T) {
+	cfg := defaultIngesterTestConfig()
+	cfg.LifecyclerConfig.JoinAfter = 0
+
+	// Create ingester
+	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	t.Cleanup(func() {
+		_ = services.StopAndAwaitTerminated(context.Background(), i)
+	})
+
+	// Wait until it's ACTIVE
+	test.Poll(t, 10*time.Millisecond, ring.ACTIVE, func() interface{} {
+		return i.lifecycler.GetState()
+	})
+
+	// Push some data.
+	pushSingleSample(t, i)
+
+	db := i.getTSDB(userID)
+	require.NotNil(t, db)
+
+	// Stop ingester.
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), i))
+
+	// Verify that DB is no longer in memory, but was closed
+	db = i.getTSDB(userID)
+	require.Nil(t, db)
 }

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -1438,6 +1438,7 @@ func TestIngester_ForFlush(t *testing.T) {
 
 	// Restart ingester in "For Flusher" mode. We reuse the same config (esp. same dir)
 	i, err = NewV2ForFlusher(i.cfg, nil)
+	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 
 	m = mockUserShipper(t, i)

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -80,6 +80,10 @@ type Config struct {
 	GCS        gcs.Config        `yaml:"gcs"`
 	Azure      azure.Config      `yaml:"azure"`
 	Filesystem filesystem.Config `yaml:"filesystem"`
+
+	// If true, user TSDBs are not closed on shutdown. Only for testing.
+	// If false (default), user TSDBs are closed to make sure all resources are released and closed properly.
+	KeepUserTSDBOpenOnShutdown bool `yaml:"-"`
 }
 
 // DurationList is the block ranges for a tsdb

--- a/pkg/util/services/services.go
+++ b/pkg/util/services/services.go
@@ -7,7 +7,7 @@ import (
 
 // Initializes basic service as an "idle" service -- it doesn't do anything in its Running state,
 // but still supports all state transitions.
-func NewIdleService(up StartingFn, down StoppingFn) Service {
+func NewIdleService(up StartingFn, down StoppingFn) *BasicService {
 	run := func(ctx context.Context) error {
 		<-ctx.Done()
 		return nil


### PR DESCRIPTION
**What this PR does**: This PR makes Flusher mode to work with blocks: by starting Cortex with `flusher` target, it will open all existing local TSDBs, flush data to blocks, upload these blocks to the storage and then exit. Note that currently the only error reporting is via logs -- Cortex exits gracefully even if flushing fails.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
