### PR TITLE
Querier: Unset Host Header if DownstreamUrl is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
   * Fixed unknown symbol error during head compaction
 * [BUGFIX] Experimental Delete Series: Fixed a data race in Purger. #2817
 * [BUGFIX] KV: Fixed a bug that triggered a panic due to metrics being registered with the same name but different labels when using a `multi` configured KV client. #2837
-* [BUGFIX] Querier: Fix passing Host header if DownstreamUrl is configured. #2880
+* [BUGFIX] Query-frontend: Fix passing HTTP `Host` header if `-frontend.downstream-url` is configured. #2880
 
 ## 1.2.0 / 2020-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
   * Fixed unknown symbol error during head compaction
 * [BUGFIX] Experimental Delete Series: Fixed a data race in Purger. #2817
 * [BUGFIX] KV: Fixed a bug that triggered a panic due to metrics being registered with the same name but different labels when using a `multi` configured KV client. #2837
+* [BUGFIX] Querier: Fix passing Host header if DownstreamUrl is configured. #2880
 
 ## 1.2.0 / 2020-07-01
 

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -123,6 +123,7 @@ func New(cfg Config, log log.Logger, registerer prometheus.Registerer) (*Fronten
 			r.URL.Scheme = u.Scheme
 			r.URL.Host = u.Host
 			r.URL.Path = path.Join(u.Path, r.URL.Path)
+			r.Host = ""
 			return http.DefaultTransport.RoundTrip(r)
 		})
 	}


### PR DESCRIPTION
**What this PR does**:

This change is necessary to correctly pass the Host Header to backend
service. The Host Header will be set by stdlib, so flushing them should
do the trick.

**Which issue(s) this PR fixes**:
Fixes #2875

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
