### PR TITLE
use pointer receiver on lazySeriesSet methods

### DIFF
--- a/pkg/querier/lazyquery/lazyquery.go
+++ b/pkg/querier/lazyquery/lazyquery.go
@@ -96,7 +96,7 @@ func (s *lazySeriesSet) Next() bool {
 }
 
 // At implements storage.SeriesSet.
-func (s lazySeriesSet) At() storage.Series {
+func (s *lazySeriesSet) At() storage.Series {
 	if s.next == nil {
 		s.next = <-s.future
 	}
@@ -104,7 +104,7 @@ func (s lazySeriesSet) At() storage.Series {
 }
 
 // Err implements storage.SeriesSet.
-func (s lazySeriesSet) Err() error {
+func (s *lazySeriesSet) Err() error {
 	if s.next == nil {
 		s.next = <-s.future
 	}
@@ -112,6 +112,6 @@ func (s lazySeriesSet) Err() error {
 }
 
 // Warnings implements storage.SeriesSet.
-func (s lazySeriesSet) Warnings() storage.Warnings {
+func (s *lazySeriesSet) Warnings() storage.Warnings {
 	return nil
 }


### PR DESCRIPTION
This fixes a bug in the `lazySeriesSet` iterator.

The typical user of an iterator would first check whether an error has occurred via `.Err()`, if not they'd check if there's an object to consume via `.Next()`, if there is they'll obtain the object via `.At()`. If `.Err()` isn't using a pointer receiver for `s` then it consumes an object from the `s.future` chan and saves it in `s.next`, but because `s` is not a pointer that property doesn't persist until the following call to `.Next()`. The following `.Next()` will then try to consume another object from `s.future`, which is going to block. 