### PR TITLE
Improve time-series distribution with user_subring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * [BUGFIX] Experimental Delete Series: Fixed a data race in Purger. #2817
 * [BUGFIX] KV: Fixed a bug that triggered a panic due to metrics being registered with the same name but different labels when using a `multi` configured KV client. #2837
 * [BUGFIX] Query-frontend: Fix passing HTTP `Host` header if `-frontend.downstream-url` is configured. #2880
+* [BUGFIX] Ingester: Improve time-series distribution when `-experimental.distributor.user-subring-size` is enabled. #2757
 
 ## 1.2.0 / 2020-07-01
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -512,7 +512,7 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 
 	// Obtain a subring if required
 	if size := d.limits.SubringSize(userID); size > 0 {
-		h := client.HashAdd32(client.HashNew32(), userID)
+		h := client.HashAdd32a(client.HashNew32a(), userID)
 		subRing, err = d.ingestersRing.Subring(h, size)
 		if err != nil {
 			return nil, httpgrpc.Errorf(http.StatusInternalServerError, "unable to create subring: %v", err)

--- a/pkg/ingester/client/fnv.go
+++ b/pkg/ingester/client/fnv.go
@@ -75,3 +75,25 @@ func HashAddByte32(h uint32, b byte) uint32 {
 	h ^= uint32(b)
 	return h
 }
+
+// HashNew32a initializies a new fnv32a hash value.
+func HashNew32a() uint32 {
+	return offset32
+}
+
+// HashAdd32a adds a string to a fnv32a hash value, returning the updated hash.
+// Note this is the same algorithm as Go stdlib `sum32.Write()`
+func HashAdd32a(h uint32, s string) uint32 {
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= prime32
+	}
+	return h
+}
+
+// HashAddByte32a adds a byte to a fnv32a hash value, returning the updated hash.
+func HashAddByte32a(h uint32, b byte) uint32 {
+	h ^= uint32(b)
+	h *= prime32
+	return h
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- At the moment the hash function FNV-1 which is used for computing the ingester subring doesn't provide enough avalanche effect. The result of this is that, if similar user names are used in Cortex, they'll end up being assigned to a very few ingesters.
- The hash function FNV-1a has better avalanche characteristics than FNV-1. This PR changes subring hash to FNV-1a.

**Which issue(s) this PR fixes**:
Fixes #2757

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
