### PR TITLE
Upgrade grpc to v1.30.0

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2321,9 +2321,9 @@ The `frontend_worker_config` configures the worker - running within the Cortex q
 # CLI flag: -querier.worker-match-max-concurrent
 [match_max_concurrent: <boolean> | default = false]
 
-# How often to query DNS.
+# [DEPRECATED] How often to query DNS. This flag is ignored.
 # CLI flag: -querier.dns-lookup-period
-[dns_lookup_duration: <duration> | default = 10s]
+[dns_lookup_duration: <duration> | default = 0s]
 
 grpc_client_config:
   # gRPC client max receive message size (bytes).

--- a/pkg/querier/frontend/worker.go
+++ b/pkg/querier/frontend/worker.go
@@ -3,19 +3,19 @@ package frontend
 import (
 	"context"
 	"flag"
-	"fmt"
 	"math/rand"
 	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/weaveworks/common/httpgrpc/server"
 	"github.com/weaveworks/common/middleware"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/naming"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
 
 	"github.com/cortexproject/cortex/pkg/querier"
+	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
@@ -35,9 +35,10 @@ func (cfg *WorkerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.Address, "querier.frontend-address", "", "Address of query frontend service, in host:port format.")
 	f.IntVar(&cfg.Parallelism, "querier.worker-parallelism", 10, "Number of simultaneous queries to process per query frontend.")
 	f.BoolVar(&cfg.MatchMaxConcurrency, "querier.worker-match-max-concurrent", false, "Force worker concurrency to match the -querier.max-concurrent option.  Overrides querier.worker-parallelism.")
-	f.DurationVar(&cfg.DNSLookupDuration, "querier.dns-lookup-period", 10*time.Second, "How often to query DNS.")
-
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("querier.frontend-client", f)
+
+	// TODO: Remove this flag in v1.6.0.
+	f.DurationVar(&cfg.DNSLookupDuration, "querier.dns-lookup-period", 0, "[DEPRECATED] How often to query DNS. This flag is ignored.")
 }
 
 // Worker is the counter-part to the frontend, actually processing requests.
@@ -46,8 +47,8 @@ type worker struct {
 	querierCfg querier.Config
 	log        log.Logger
 	server     *server.Server
+	service    *services.BasicService
 
-	watcher  naming.Watcher //nolint:staticcheck //Skipping for now. If you still see this more than likely issue https://github.com/cortexproject/cortex/issues/2015 has not yet been addressed.
 	managers map[string]*frontendManager
 }
 
@@ -59,14 +60,9 @@ func NewWorker(cfg WorkerConfig, querierCfg querier.Config, server *server.Serve
 		return nil, nil
 	}
 
-	resolver, err := naming.NewDNSResolverWithFreq(cfg.DNSLookupDuration)
-	if err != nil {
-		return nil, err
-	}
-
-	watcher, err := resolver.Resolve(cfg.Address)
-	if err != nil {
-		return nil, err
+	if cfg.DNSLookupDuration != 0 {
+		flagext.DeprecatedFlagsUsed.Inc()
+		level.Warn(log).Log("msg", "Using deprecated flag -querier.dns-lookup-period, this flag is ignored")
 	}
 
 	w := &worker{
@@ -74,10 +70,11 @@ func NewWorker(cfg WorkerConfig, querierCfg querier.Config, server *server.Serve
 		querierCfg: querierCfg,
 		log:        log,
 		server:     server,
-		watcher:    watcher,
 		managers:   map[string]*frontendManager{},
 	}
-	return services.NewBasicService(nil, w.watchDNSLoop, w.stopping), nil
+	w.service = services.NewBasicService(nil, w.running, w.stopping)
+
+	return w.service, nil
 }
 
 func (w *worker) stopping(_ error) error {
@@ -88,54 +85,79 @@ func (w *worker) stopping(_ error) error {
 	return nil
 }
 
-// watchDNSLoop watches for changes in DNS and starts or stops workers.
-func (w *worker) watchDNSLoop(servCtx context.Context) error {
-	go func() {
-		// Close the watcher, when this service is asked to stop.
-		// Closing the watcher makes watchDNSLoop exit, since it only iterates on watcher updates, and has no other
-		// way to stop. We cannot close the watcher in `stopping` method, because it is only called *after*
-		// watchDNSLoop exits.
-		<-servCtx.Done()
-		w.watcher.Close()
-	}()
+// UpdateState implements resolver.ClientConn interface.
+// It adds or removes workers based on updated DNS state.
+func (w *worker) UpdateState(state resolver.State) {
+	newManagers := make(map[string]*frontendManager, len(state.Addresses))
 
-	for {
-		updates, err := w.watcher.Next()
+	// Add new addresses.
+	for _, addr := range state.Addresses {
+		if m, ok := w.managers[addr.Addr]; ok {
+			newManagers[addr.Addr] = m
+			continue
+		}
+
+		level.Debug(w.log).Log("msg", "adding connection", "addr", addr.Addr)
+		client, err := w.connect(w.service.ServiceContext(), addr.Addr)
 		if err != nil {
-			// watcher.Next returns error when Close is called, but we call Close when our context is done.
-			// we don't want to report error in that case.
-			if servCtx.Err() != nil {
-				return nil
-			}
-			return errors.Wrapf(err, "error from DNS watcher")
+			level.Error(w.log).Log("msg", "error connecting", "addr", addr.Addr, "err", err)
+			continue
 		}
-
-		for _, update := range updates {
-			switch update.Op {
-			case naming.Add:
-				level.Debug(w.log).Log("msg", "adding connection", "addr", update.Addr)
-				client, err := w.connect(servCtx, update.Addr)
-				if err != nil {
-					level.Error(w.log).Log("msg", "error connecting", "addr", update.Addr, "err", err)
-					continue
-				}
-
-				w.managers[update.Addr] = newFrontendManager(servCtx, w.log, w.server, client, w.cfg.GRPCClientConfig)
-
-			case naming.Delete:
-				level.Debug(w.log).Log("msg", "removing connection", "addr", update.Addr)
-				if mgr, ok := w.managers[update.Addr]; ok {
-					mgr.stop()
-					delete(w.managers, update.Addr)
-				}
-
-			default:
-				return fmt.Errorf("unknown op: %v", update.Op)
-			}
-		}
-
-		w.resetConcurrency()
+		newManagers[addr.Addr] = newFrontendManager(w.service.ServiceContext(), w.log, w.server, client, w.cfg.GRPCClientConfig)
 	}
+
+	// Stop old addresses.
+	for addr, mngr := range w.managers {
+		if _, ok := newManagers[addr]; ok {
+			continue
+		}
+		level.Debug(w.log).Log("msg", "removing connection", "addr", addr)
+		mngr.stop()
+	}
+
+	// TODO: Check if UpdateState can be called concurrently.
+	w.managers = newManagers
+	w.resetConcurrency()
+}
+
+// ReportError implements resolver.ClientConn interface.
+func (w *worker) ReportError(err error) {
+	// TODO: How to exit on non-recoverable error. 'naming' package had it.
+	level.Error(w.log).Log("msg", "resolver error", "err", err)
+}
+
+// NewAddress implements resolver.ClientConn interface.
+// Deprecated in favour of UpdateState.
+func (w *worker) NewAddress([]resolver.Address) {}
+
+// NewServiceConfig implements resolver.ClientConn interface.
+// Deprecated in favour of UpdateState.
+func (w *worker) NewServiceConfig(string) {}
+
+// ParseServiceConfig implements resolver.ClientConn interface.
+func (w *worker) ParseServiceConfig(string) *serviceconfig.ParseResult {
+	return nil
+}
+
+// watchDNSLoop watches for changes in DNS and starts or stops workers.
+func (w *worker) running(servCtx context.Context) error {
+	builder := resolver.Get("dns")
+	r, err := builder.Build(
+		resolver.Target{
+			Scheme:    "dns",
+			Authority: "",
+			Endpoint:  w.cfg.Address,
+		},
+		w,
+		resolver.BuildOptions{},
+	)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	<-servCtx.Done()
+	return nil
 }
 
 func (w *worker) connect(ctx context.Context, address string) (FrontendClient, error) {


### PR DESCRIPTION
**What this PR does**:

I was attempting Prometheus upgrade, but grpc is also upgraded with that. grpc v1.30.0 removes the deprecated `google.golang.org/grpc/naming` package which is used by query-frontend. Hence on @pracucci's suggestion, I am attempting the grpc upgrade separately before Prometheus upgrade. 

**Which issue(s) this PR fixes**:
Fixes #2015

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
