### PR TITLE
Clarified supported S3 endpoints for the blocks storage

### DIFF
--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -483,8 +483,8 @@ tsdb:
 
   s3:
     # The S3 bucket endpoint. It could be an AWS S3 endpoint listed at
-    # https://docs.aws.amazon.com/general/latest/gr/s3.html or the hostname and
-    # port of an S3-compatible service in the hostname:port format.
+    # https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an
+    # S3-compatible service in hostname:port format.
     # CLI flag: -experimental.tsdb.s3.endpoint
     [endpoint: <string> | default = ""]
 

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -482,7 +482,9 @@ tsdb:
   [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
 
   s3:
-    # S3 endpoint without schema
+    # The S3 bucket endpoint. It could be an AWS S3 endpoint listed at
+    # https://docs.aws.amazon.com/general/latest/gr/s3.html or the hostname and
+    # port of an S3-compatible service in the hostname:port format.
     # CLI flag: -experimental.tsdb.s3.endpoint
     [endpoint: <string> | default = ""]
 

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -509,7 +509,9 @@ tsdb:
   [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
 
   s3:
-    # S3 endpoint without schema
+    # The S3 bucket endpoint. It could be an AWS S3 endpoint listed at
+    # https://docs.aws.amazon.com/general/latest/gr/s3.html or the hostname and
+    # port of an S3-compatible service in the hostname:port format.
     # CLI flag: -experimental.tsdb.s3.endpoint
     [endpoint: <string> | default = ""]
 

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -510,8 +510,8 @@ tsdb:
 
   s3:
     # The S3 bucket endpoint. It could be an AWS S3 endpoint listed at
-    # https://docs.aws.amazon.com/general/latest/gr/s3.html or the hostname and
-    # port of an S3-compatible service in the hostname:port format.
+    # https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an
+    # S3-compatible service in hostname:port format.
     # CLI flag: -experimental.tsdb.s3.endpoint
     [endpoint: <string> | default = ""]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3245,8 +3245,8 @@ bucket_store:
 
 s3:
   # The S3 bucket endpoint. It could be an AWS S3 endpoint listed at
-  # https://docs.aws.amazon.com/general/latest/gr/s3.html or the hostname and
-  # port of an S3-compatible service in the hostname:port format.
+  # https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an
+  # S3-compatible service in hostname:port format.
   # CLI flag: -experimental.tsdb.s3.endpoint
   [endpoint: <string> | default = ""]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3244,7 +3244,9 @@ bucket_store:
 [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
 
 s3:
-  # S3 endpoint without schema
+  # The S3 bucket endpoint. It could be an AWS S3 endpoint listed at
+  # https://docs.aws.amazon.com/general/latest/gr/s3.html or the hostname and
+  # port of an S3-compatible service in the hostname:port format.
   # CLI flag: -experimental.tsdb.s3.endpoint
   [endpoint: <string> | default = ""]
 

--- a/pkg/storage/backend/s3/config.go
+++ b/pkg/storage/backend/s3/config.go
@@ -25,6 +25,6 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.AccessKeyID, prefix+"s3.access-key-id", "", "S3 access key ID")
 	f.Var(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "S3 secret access key")
 	f.StringVar(&cfg.BucketName, prefix+"s3.bucket-name", "", "S3 bucket name")
-	f.StringVar(&cfg.Endpoint, prefix+"s3.endpoint", "", "S3 endpoint without schema")
+	f.StringVar(&cfg.Endpoint, prefix+"s3.endpoint", "", "The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the hostname and port of an S3-compatible service in the hostname:port format.")
 	f.BoolVar(&cfg.Insecure, prefix+"s3.insecure", false, "If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.")
 }

--- a/pkg/storage/backend/s3/config.go
+++ b/pkg/storage/backend/s3/config.go
@@ -25,6 +25,6 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.AccessKeyID, prefix+"s3.access-key-id", "", "S3 access key ID")
 	f.Var(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "S3 secret access key")
 	f.StringVar(&cfg.BucketName, prefix+"s3.bucket-name", "", "S3 bucket name")
-	f.StringVar(&cfg.Endpoint, prefix+"s3.endpoint", "", "The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the hostname and port of an S3-compatible service in the hostname:port format.")
+	f.StringVar(&cfg.Endpoint, prefix+"s3.endpoint", "", "The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.")
 	f.BoolVar(&cfg.Insecure, prefix+"s3.insecure", false, "If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.")
 }


### PR DESCRIPTION
**What this PR does**:
In this PR I'm clarifying the supported S3 endpoint for the blocks storage.

**Which issue(s) this PR fixes**:
Fixes #2885

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
