### PR TITLE
Remove global metrics registry and global logger in cache package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [CHANGE] Experimental TSDB: compact head when opening TSDB. This should only affect ingester startup after it was unable to compact head in previous run. #2870
 * [CHANGE] Metric `cortex_overrides_last_reload_successful` has been renamed to `cortex_runtime_config_last_reload_successful`. #2874
 * [CHANGE] HipChat support has been removed from the alertmanager (because removed from the Prometheus upstream too). #2902
+* [CHANGE] Add constant label `name` to metric `cortex_cache_request_duration_seconds`. #2903
 * [FEATURE] Introduced `ruler.for-outage-tolerance`, Max time to tolerate outage for restoring "for" state of alert. #2783
 * [FEATURE] Introduced `ruler.for-grace-period`, Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. #2783
 * [FEATURE] Introduced `ruler.resend-delay`, Minimum amount of time to wait before resending an alert to Alertmanager. #2783

--- a/integration/chunks_storage_backends_test.go
+++ b/integration/chunks_storage_backends_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/assert"
@@ -184,7 +185,7 @@ func TestSwiftChunkStorage(t *testing.T) {
 	limits, err := validation.NewOverrides(defaults, nil)
 	require.NoError(t, err)
 
-	store, err := storage.NewStore(cfg, storeConfig, schemaConfig, limits, nil, nil)
+	store, err := storage.NewStore(cfg, storeConfig, schemaConfig, limits, nil, nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	defer store.Stop()

--- a/pkg/chunk/cache/background.go
+++ b/pkg/chunk/cache/background.go
@@ -47,17 +47,19 @@ func NewBackground(name string, cfg BackgroundConfig, cache Cache, reg prometheu
 		quit:     make(chan struct{}),
 		bgWrites: make(chan backgroundWrite, cfg.WriteBackBuffer),
 		name:     name,
-		droppedWriteBack: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "cortex",
-			Name:      "cache_dropped_background_writes_total",
-			Help:      "Total count of dropped write backs to cache.",
-		}, []string{"name"}).WithLabelValues(name),
+		droppedWriteBack: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "cortex",
+			Name:        "cache_dropped_background_writes_total",
+			Help:        "Total count of dropped write backs to cache.",
+			ConstLabels: prometheus.Labels{"name": name},
+		}),
 
-		queueLength: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: "cortex",
-			Name:      "cache_background_queue_length",
-			Help:      "Length of the cache background write queue.",
-		}, []string{"name"}).WithLabelValues(name),
+		queueLength: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace:   "cortex",
+			Name:        "cache_background_queue_length",
+			Help:        "Length of the cache background write queue.",
+			ConstLabels: prometheus.Labels{"name": name},
+		}),
 	}
 
 	c.wg.Add(cfg.WriteBackGoroutines)

--- a/pkg/chunk/cache/background.go
+++ b/pkg/chunk/cache/background.go
@@ -11,19 +11,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var (
-	droppedWriteBack = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "cortex",
-		Name:      "cache_dropped_background_writes_total",
-		Help:      "Total count of dropped write backs to cache.",
-	}, []string{"name"})
-	queueLength = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "cortex",
-		Name:      "cache_background_queue_length",
-		Help:      "Length of the cache background write queue.",
-	}, []string{"name"})
-)
-
 // BackgroundConfig is config for a Background Cache.
 type BackgroundConfig struct {
 	WriteBackGoroutines int `yaml:"writeback_goroutines"`
@@ -54,14 +41,23 @@ type backgroundWrite struct {
 }
 
 // NewBackground returns a new Cache that does stores on background goroutines.
-func NewBackground(name string, cfg BackgroundConfig, cache Cache) Cache {
+func NewBackground(name string, cfg BackgroundConfig, cache Cache, reg prometheus.Registerer) Cache {
 	c := &backgroundCache{
-		Cache:            cache,
-		quit:             make(chan struct{}),
-		bgWrites:         make(chan backgroundWrite, cfg.WriteBackBuffer),
-		name:             name,
-		droppedWriteBack: droppedWriteBack.WithLabelValues(name),
-		queueLength:      queueLength.WithLabelValues(name),
+		Cache:    cache,
+		quit:     make(chan struct{}),
+		bgWrites: make(chan backgroundWrite, cfg.WriteBackBuffer),
+		name:     name,
+		droppedWriteBack: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "cortex",
+			Name:      "cache_dropped_background_writes_total",
+			Help:      "Total count of dropped write backs to cache.",
+		}, []string{"name"}).WithLabelValues(name),
+
+		queueLength: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "cortex",
+			Name:      "cache_background_queue_length",
+			Help:      "Length of the cache background write queue.",
+		}, []string{"name"}).WithLabelValues(name),
 	}
 
 	c.wg.Add(cfg.WriteBackGoroutines)

--- a/pkg/chunk/cache/background_test.go
+++ b/pkg/chunk/cache/background_test.go
@@ -3,8 +3,6 @@ package cache_test
 import (
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 )
 
@@ -12,7 +10,7 @@ func TestBackground(t *testing.T) {
 	c := cache.NewBackground("mock", cache.BackgroundConfig{
 		WriteBackGoroutines: 1,
 		WriteBackBuffer:     100,
-	}, cache.NewMockCache(), prometheus.NewRegistry())
+	}, cache.NewMockCache(), nil)
 
 	keys, chunks := fillCache(t, c)
 	cache.Flush(c)

--- a/pkg/chunk/cache/background_test.go
+++ b/pkg/chunk/cache/background_test.go
@@ -3,6 +3,8 @@ package cache_test
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 )
 
@@ -10,7 +12,7 @@ func TestBackground(t *testing.T) {
 	c := cache.NewBackground("mock", cache.BackgroundConfig{
 		WriteBackGoroutines: 1,
 		WriteBackBuffer:     100,
-	}, cache.NewMockCache())
+	}, cache.NewMockCache(), prometheus.NewRegistry())
 
 	keys, chunks := fillCache(t, c)
 	cache.Flush(c)

--- a/pkg/chunk/cache/cache_test.go
+++ b/pkg/chunk/cache/cache_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/require"
@@ -158,7 +160,8 @@ func testCache(t *testing.T, cache cache.Cache) {
 
 func TestMemcache(t *testing.T) {
 	t.Run("Unbatched", func(t *testing.T) {
-		cache := cache.NewMemcached(cache.MemcachedConfig{}, newMockMemcache(), "test")
+		cache := cache.NewMemcached(cache.MemcachedConfig{}, newMockMemcache(),
+			"test", prometheus.NewRegistry(), log.NewNopLogger())
 		testCache(t, cache)
 	})
 
@@ -166,17 +169,18 @@ func TestMemcache(t *testing.T) {
 		cache := cache.NewMemcached(cache.MemcachedConfig{
 			BatchSize:   10,
 			Parallelism: 3,
-		}, newMockMemcache(), "test")
+		}, newMockMemcache(), "test", prometheus.NewRegistry(), log.NewNopLogger())
 		testCache(t, cache)
 	})
 }
 
 func TestFifoCache(t *testing.T) {
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 1e3, Validity: 1 * time.Hour})
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 1e3, Validity: 1 * time.Hour},
+		prometheus.NewRegistry(), log.NewNopLogger())
 	testCache(t, cache)
 }
 
 func TestSnappyCache(t *testing.T) {
-	cache := cache.NewSnappy(cache.NewMockCache())
+	cache := cache.NewSnappy(cache.NewMockCache(), log.NewNopLogger())
 	testCache(t, cache)
 }

--- a/pkg/chunk/cache/cache_test.go
+++ b/pkg/chunk/cache/cache_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/require"
@@ -161,7 +160,7 @@ func testCache(t *testing.T, cache cache.Cache) {
 func TestMemcache(t *testing.T) {
 	t.Run("Unbatched", func(t *testing.T) {
 		cache := cache.NewMemcached(cache.MemcachedConfig{}, newMockMemcache(),
-			"test", prometheus.NewRegistry(), log.NewNopLogger())
+			"test", nil, log.NewNopLogger())
 		testCache(t, cache)
 	})
 
@@ -169,14 +168,14 @@ func TestMemcache(t *testing.T) {
 		cache := cache.NewMemcached(cache.MemcachedConfig{
 			BatchSize:   10,
 			Parallelism: 3,
-		}, newMockMemcache(), "test", prometheus.NewRegistry(), log.NewNopLogger())
+		}, newMockMemcache(), "test", nil, log.NewNopLogger())
 		testCache(t, cache)
 	})
 }
 
 func TestFifoCache(t *testing.T) {
 	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 1e3, Validity: 1 * time.Hour},
-		prometheus.NewRegistry(), log.NewNopLogger())
+		nil, log.NewNopLogger())
 	testCache(t, cache)
 }
 

--- a/pkg/chunk/cache/fifo_cache.go
+++ b/pkg/chunk/cache/fifo_cache.go
@@ -114,62 +114,69 @@ func NewFifoCache(name string, cfg FifoCacheConfig, reg prometheus.Registerer, l
 		entries:      make(map[string]*list.Element),
 		lru:          list.New(),
 
-		// TODO(bwplotka): There might be simple cache.Cache wrapper for those.
-		entriesAdded: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "querier",
-			Subsystem: "cache",
-			Name:      "added_total",
-			Help:      "The total number of Put calls on the cache",
-		}, []string{"cache"}).WithLabelValues(name),
+		entriesAdded: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "querier",
+			Subsystem:   "cache",
+			Name:        "added_total",
+			Help:        "The total number of Put calls on the cache",
+			ConstLabels: prometheus.Labels{"cache": name},
+		}),
 
-		entriesAddedNew: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "querier",
-			Subsystem: "cache",
-			Name:      "added_new_total",
-			Help:      "The total number of new entries added to the cache",
-		}, []string{"cache"}).WithLabelValues(name),
+		entriesAddedNew: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "querier",
+			Subsystem:   "cache",
+			Name:        "added_new_total",
+			Help:        "The total number of new entries added to the cache",
+			ConstLabels: prometheus.Labels{"cache": name},
+		}),
 
-		entriesEvicted: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "querier",
-			Subsystem: "cache",
-			Name:      "evicted_total",
-			Help:      "The total number of evicted entries",
-		}, []string{"cache"}).WithLabelValues(name),
+		entriesEvicted: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "querier",
+			Subsystem:   "cache",
+			Name:        "evicted_total",
+			Help:        "The total number of evicted entries",
+			ConstLabels: prometheus.Labels{"cache": name},
+		}),
 
-		entriesCurrent: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: "querier",
-			Subsystem: "cache",
-			Name:      "entries",
-			Help:      "The total number of entries",
-		}, []string{"cache"}).WithLabelValues(name),
+		entriesCurrent: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace:   "querier",
+			Subsystem:   "cache",
+			Name:        "entries",
+			Help:        "The total number of entries",
+			ConstLabels: prometheus.Labels{"cache": name},
+		}),
 
-		totalGets: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "querier",
-			Subsystem: "cache",
-			Name:      "gets_total",
-			Help:      "The total number of Get calls",
-		}, []string{"cache"}).WithLabelValues(name),
+		totalGets: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "querier",
+			Subsystem:   "cache",
+			Name:        "gets_total",
+			Help:        "The total number of Get calls",
+			ConstLabels: prometheus.Labels{"cache": name},
+		}),
 
-		totalMisses: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "querier",
-			Subsystem: "cache",
-			Name:      "misses_total",
-			Help:      "The total number of Get calls that had no valid entry",
-		}, []string{"cache"}).WithLabelValues(name),
+		totalMisses: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "querier",
+			Subsystem:   "cache",
+			Name:        "misses_total",
+			Help:        "The total number of Get calls that had no valid entry",
+			ConstLabels: prometheus.Labels{"cache": name},
+		}),
 
-		staleGets: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "querier",
-			Subsystem: "cache",
-			Name:      "stale_gets_total",
-			Help:      "The total number of Get calls that had an entry which expired",
-		}, []string{"cache"}).WithLabelValues(name),
+		staleGets: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace:   "querier",
+			Subsystem:   "cache",
+			Name:        "stale_gets_total",
+			Help:        "The total number of Get calls that had an entry which expired",
+			ConstLabels: prometheus.Labels{"cache": name},
+		}),
 
-		memoryBytes: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: "querier",
-			Subsystem: "cache",
-			Name:      "memory_bytes",
-			Help:      "The current cache size in bytes",
-		}, []string{"cache"}).WithLabelValues(name),
+		memoryBytes: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace:   "querier",
+			Subsystem:   "cache",
+			Name:        "memory_bytes",
+			Help:        "The current cache size in bytes",
+			ConstLabels: prometheus.Labels{"cache": name},
+		}),
 	}
 }
 

--- a/pkg/chunk/cache/fifo_cache_test.go
+++ b/pkg/chunk/cache/fifo_cache_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,7 +39,7 @@ func TestFifoCacheEviction(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c := NewFifoCache(test.name, test.cfg)
+		c := NewFifoCache(test.name, test.cfg, prometheus.NewRegistry(), log.NewNopLogger())
 		ctx := context.Background()
 
 		// Check put / get works
@@ -185,7 +187,7 @@ func TestFifoCacheExpiry(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c := NewFifoCache(test.name, test.cfg)
+		c := NewFifoCache(test.name, test.cfg, prometheus.NewRegistry(), log.NewNopLogger())
 		ctx := context.Background()
 
 		c.Store(ctx,

--- a/pkg/chunk/cache/fifo_cache_test.go
+++ b/pkg/chunk/cache/fifo_cache_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,7 +38,7 @@ func TestFifoCacheEviction(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c := NewFifoCache(test.name, test.cfg, prometheus.NewRegistry(), log.NewNopLogger())
+		c := NewFifoCache(test.name, test.cfg, nil, log.NewNopLogger())
 		ctx := context.Background()
 
 		// Check put / get works
@@ -187,7 +186,7 @@ func TestFifoCacheExpiry(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c := NewFifoCache(test.name, test.cfg, prometheus.NewRegistry(), log.NewNopLogger())
+		c := NewFifoCache(test.name, test.cfg, nil, log.NewNopLogger())
 		ctx := context.Background()
 
 		c.Store(ctx,

--- a/pkg/chunk/cache/instrumented.go
+++ b/pkg/chunk/cache/instrumented.go
@@ -6,31 +6,13 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	instr "github.com/weaveworks/common/instrument"
 )
 
-var (
-	requestDuration = instr.NewHistogramCollector(prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "cortex",
-		Name:      "cache_request_duration_seconds",
-		Help:      "Total time spent in seconds doing cache requests.",
-		// Cache requests are very quick: smallest bucket is 16us, biggest is 1s.
-		Buckets: prometheus.ExponentialBuckets(0.000016, 4, 8),
-	}, []string{"method", "status_code"}))
-
-	fetchedKeys = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "cortex",
-		Name:      "cache_fetched_keys",
-		Help:      "Total count of keys requested from cache.",
-	}, []string{"name"})
-
-	hits = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "cortex",
-		Name:      "cache_hits",
-		Help:      "Total count of keys found in cache.",
-	}, []string{"name"})
-
-	valueSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+// Instrument returns an instrumented cache.
+func Instrument(name string, cache Cache, reg prometheus.Registerer) Cache {
+	valueSize := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "cortex",
 		Name:      "cache_value_size_bytes",
 		Help:      "Size of values in the cache.",
@@ -39,23 +21,33 @@ var (
 		// 1024 * 4^(7-1) = 4MB
 		Buckets: prometheus.ExponentialBuckets(1024, 4, 7),
 	}, []string{"name", "method"})
-)
 
-func init() {
-	requestDuration.Register()
-	prometheus.MustRegister(fetchedKeys)
-	prometheus.MustRegister(hits)
-	prometheus.MustRegister(valueSize)
-}
+	requestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "cortex",
+		Name:      "cache_request_duration_seconds",
+		Help:      "Total time spent in seconds doing cache requests.",
+		// Cache requests are very quick: smallest bucket is 16us, biggest is 1s.
+		Buckets: prometheus.ExponentialBuckets(0.000016, 4, 8),
+	}, []string{"method", "status_code"})
 
-// Instrument returns an instrumented cache.
-func Instrument(name string, cache Cache) Cache {
 	return &instrumentedCache{
 		name:  name,
 		Cache: cache,
 
-		fetchedKeys:      fetchedKeys.WithLabelValues(name),
-		hits:             hits.WithLabelValues(name),
+		requestDuration: instr.NewHistogramCollector(requestDuration),
+
+		fetchedKeys: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "cortex",
+			Name:      "cache_fetched_keys",
+			Help:      "Total count of keys requested from cache.",
+		}, []string{"name"}).WithLabelValues(name),
+
+		hits: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "cortex",
+			Name:      "cache_hits",
+			Help:      "Total count of keys found in cache.",
+		}, []string{"name"}).WithLabelValues(name),
+
 		storedValueSize:  valueSize.WithLabelValues(name, "store"),
 		fetchedValueSize: valueSize.WithLabelValues(name, "fetch"),
 	}
@@ -67,6 +59,7 @@ type instrumentedCache struct {
 
 	fetchedKeys, hits                 prometheus.Counter
 	storedValueSize, fetchedValueSize prometheus.Observer
+	requestDuration                   *instr.HistogramCollector
 }
 
 func (i *instrumentedCache) Store(ctx context.Context, keys []string, bufs [][]byte) {
@@ -75,7 +68,7 @@ func (i *instrumentedCache) Store(ctx context.Context, keys []string, bufs [][]b
 	}
 
 	method := i.name + ".store"
-	_ = instr.CollectedRequest(ctx, method, requestDuration, instr.ErrorCode, func(ctx context.Context) error {
+	_ = instr.CollectedRequest(ctx, method, i.requestDuration, instr.ErrorCode, func(ctx context.Context) error {
 		sp := ot.SpanFromContext(ctx)
 		sp.LogFields(otlog.Int("keys", len(keys)))
 		i.Cache.Store(ctx, keys, bufs)
@@ -91,7 +84,7 @@ func (i *instrumentedCache) Fetch(ctx context.Context, keys []string) ([]string,
 		method  = i.name + ".fetch"
 	)
 
-	_ = instr.CollectedRequest(ctx, method, requestDuration, instr.ErrorCode, func(ctx context.Context) error {
+	_ = instr.CollectedRequest(ctx, method, i.requestDuration, instr.ErrorCode, func(ctx context.Context) error {
 		sp := ot.SpanFromContext(ctx)
 		sp.LogFields(otlog.Int("keys requested", len(keys)))
 

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -61,22 +61,20 @@ type Memcached struct {
 
 // NewMemcached makes a new Memcache.
 func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string, reg prometheus.Registerer, logger log.Logger) *Memcached {
-	memcacheRequestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "cortex",
-		Name:      "memcache_request_duration_seconds",
-		Help:      "Total time spent in seconds doing memcache requests.",
-		// Memecache requests are very quick: smallest bucket is 16us, biggest is 1s
-		Buckets:     prometheus.ExponentialBuckets(0.000016, 4, 8),
-		ConstLabels: prometheus.Labels{"name": name},
-	}, []string{"method", "status_code"})
-
 	c := &Memcached{
 		cfg:      cfg,
 		memcache: client,
 		name:     name,
 		logger:   logger,
 		requestDuration: observableVecCollector{
-			v: memcacheRequestDuration,
+			v: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+				Namespace: "cortex",
+				Name:      "memcache_request_duration_seconds",
+				Help:      "Total time spent in seconds doing memcache requests.",
+				// Memecache requests are very quick: smallest bucket is 16us, biggest is 1s
+				Buckets:     prometheus.ExponentialBuckets(0.000016, 4, 8),
+				ConstLabels: prometheus.Labels{"name": name},
+			}, []string{"method", "status_code"}),
 		},
 	}
 

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	opentracing "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -17,16 +18,6 @@ import (
 	instr "github.com/weaveworks/common/instrument"
 
 	"github.com/cortexproject/cortex/pkg/util"
-)
-
-var (
-	memcacheRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "cortex",
-		Name:      "memcache_request_duration_seconds",
-		Help:      "Total time spent in seconds doing memcache requests.",
-		// Memecache requests are very quick: smallest bucket is 16us, biggest is 1s
-		Buckets: prometheus.ExponentialBuckets(0.000016, 4, 8),
-	}, []string{"method", "status_code", "name"})
 )
 
 type observableVecCollector struct {
@@ -64,16 +55,25 @@ type Memcached struct {
 
 	wg      sync.WaitGroup
 	inputCh chan *work
+
+	logger log.Logger
 }
 
 // NewMemcached makes a new Memcache.
-// TODO(bwplotka): Fix metrics, get them out of globals, separate or allow prefixing.
-// TODO(bwplotka): Remove globals & util packages from cache package entirely (e.g util.Logger).
-func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string) *Memcached {
+func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string, reg prometheus.Registerer, logger log.Logger) *Memcached {
+	memcacheRequestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "cortex",
+		Name:      "memcache_request_duration_seconds",
+		Help:      "Total time spent in seconds doing memcache requests.",
+		// Memecache requests are very quick: smallest bucket is 16us, biggest is 1s
+		Buckets: prometheus.ExponentialBuckets(0.000016, 4, 8),
+	}, []string{"method", "status_code", "name"})
+
 	c := &Memcached{
 		cfg:      cfg,
 		memcache: client,
 		name:     name,
+		logger:   logger,
 		requestDuration: observableVecCollector{
 			v: memcacheRequestDuration.MustCurryWith(prometheus.Labels{
 				"name": name,
@@ -161,7 +161,7 @@ func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, b
 		// Memcached returns partial results even on error.
 		if err != nil {
 			sp.LogFields(otlog.Error(err))
-			level.Error(util.Logger).Log("msg", "Failed to get keys from memcached", "err", err)
+			level.Error(c.logger).Log("msg", "Failed to get keys from memcached", "err", err)
 		}
 		return err
 	})
@@ -234,7 +234,7 @@ func (c *Memcached) Store(ctx context.Context, keys []string, bufs [][]byte) {
 			return c.memcache.Set(&item)
 		})
 		if err != nil {
-			level.Error(util.Logger).Log("msg", "failed to put to memcached", "name", c.name, "err", err)
+			level.Error(c.logger).Log("msg", "failed to put to memcached", "name", c.name, "err", err)
 		}
 	}
 }

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -66,8 +66,9 @@ func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string, reg 
 		Name:      "memcache_request_duration_seconds",
 		Help:      "Total time spent in seconds doing memcache requests.",
 		// Memecache requests are very quick: smallest bucket is 16us, biggest is 1s
-		Buckets: prometheus.ExponentialBuckets(0.000016, 4, 8),
-	}, []string{"method", "status_code", "name"})
+		Buckets:     prometheus.ExponentialBuckets(0.000016, 4, 8),
+		ConstLabels: prometheus.Labels{"name": name},
+	}, []string{"method", "status_code"})
 
 	c := &Memcached{
 		cfg:      cfg,
@@ -75,9 +76,7 @@ func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string, reg 
 		name:     name,
 		logger:   logger,
 		requestDuration: observableVecCollector{
-			v: memcacheRequestDuration.MustCurryWith(prometheus.Labels{
-				"name": name,
-			}),
+			v: memcacheRequestDuration,
 		},
 	}
 

--- a/pkg/chunk/cache/memcached_client.go
+++ b/pkg/chunk/cache/memcached_client.go
@@ -101,11 +101,12 @@ func NewMemcachedClient(cfg MemcachedClientConfig, name string, r prometheus.Reg
 		provider:   dns.NewProvider(logger, dnsProviderRegisterer, dns.GolangResolverType),
 		quit:       make(chan struct{}),
 
-		numServers: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: "cortex",
-			Name:      "memcache_client_servers",
-			Help:      "The number of memcache servers discovered.",
-		}, []string{"name"}).WithLabelValues(name),
+		numServers: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace:   "cortex",
+			Name:        "memcache_client_servers",
+			Help:        "The number of memcache servers discovered.",
+			ConstLabels: prometheus.Labels{"name": name},
+		}),
 	}
 
 	if len(cfg.Addresses) > 0 {

--- a/pkg/chunk/cache/memcached_client.go
+++ b/pkg/chunk/cache/memcached_client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,14 +19,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/discovery/dns"
 
 	"github.com/cortexproject/cortex/pkg/util"
-)
-
-var (
-	memcacheServersDiscovered = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "cortex",
-		Name:      "memcache_client_servers",
-		Help:      "The number of memcache servers discovered.",
-	}, []string{"name"})
 )
 
 // MemcachedClient interface exists for mocking memcacheClient.
@@ -55,6 +48,8 @@ type memcachedClient struct {
 	wait sync.WaitGroup
 
 	numServers prometheus.Gauge
+
+	logger log.Logger
 }
 
 // MemcachedClientConfig defines how a MemcachedClient should be constructed.
@@ -81,7 +76,7 @@ func (cfg *MemcachedClientConfig) RegisterFlagsWithPrefix(prefix, description st
 
 // NewMemcachedClient creates a new MemcacheClient that gets its server list
 // from SRV and updates the server list on a regular basis.
-func NewMemcachedClient(cfg MemcachedClientConfig, name string, r prometheus.Registerer) MemcachedClient {
+func NewMemcachedClient(cfg MemcachedClientConfig, name string, r prometheus.Registerer, logger log.Logger) MemcachedClient {
 	var selector serverSelector
 	if cfg.ConsistentHash {
 		selector = &MemcachedJumpHashSelector{}
@@ -102,10 +97,15 @@ func NewMemcachedClient(cfg MemcachedClientConfig, name string, r prometheus.Reg
 		serverList: selector,
 		hostname:   cfg.Host,
 		service:    cfg.Service,
-		provider:   dns.NewProvider(util.Logger, dnsProviderRegisterer, dns.GolangResolverType),
+		logger:     logger,
+		provider:   dns.NewProvider(logger, dnsProviderRegisterer, dns.GolangResolverType),
 		quit:       make(chan struct{}),
 
-		numServers: memcacheServersDiscovered.WithLabelValues(name),
+		numServers: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "cortex",
+			Name:      "memcache_client_servers",
+			Help:      "The number of memcache servers discovered.",
+		}, []string{"name"}).WithLabelValues(name),
 	}
 
 	if len(cfg.Addresses) > 0 {
@@ -115,7 +115,7 @@ func NewMemcachedClient(cfg MemcachedClientConfig, name string, r prometheus.Reg
 
 	err := newClient.updateMemcacheServers()
 	if err != nil {
-		level.Error(util.Logger).Log("msg", "error setting memcache servers to host", "host", cfg.Host, "err", err)
+		level.Error(logger).Log("msg", "error setting memcache servers to host", "host", cfg.Host, "err", err)
 	}
 
 	newClient.wait.Add(1)
@@ -153,7 +153,7 @@ func (c *memcachedClient) updateLoop(updateInterval time.Duration) {
 		case <-ticker.C:
 			err := c.updateMemcacheServers()
 			if err != nil {
-				level.Warn(util.Logger).Log("msg", "error updating memcache servers", "err", err)
+				level.Warn(c.logger).Log("msg", "error updating memcache servers", "err", err)
 			}
 		case <-c.quit:
 			ticker.Stop()

--- a/pkg/chunk/cache/memcached_test.go
+++ b/pkg/chunk/cache/memcached_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/go-kit/kit/log"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
@@ -18,7 +17,7 @@ func TestMemcached(t *testing.T) {
 	t.Run("unbatched", func(t *testing.T) {
 		client := newMockMemcache()
 		memcache := cache.NewMemcached(cache.MemcachedConfig{}, client,
-			"test", prometheus.NewRegistry(), log.NewNopLogger())
+			"test", nil, log.NewNopLogger())
 
 		testMemcache(t, memcache)
 	})
@@ -28,7 +27,7 @@ func TestMemcached(t *testing.T) {
 		memcache := cache.NewMemcached(cache.MemcachedConfig{
 			BatchSize:   10,
 			Parallelism: 5,
-		}, client, "test", prometheus.NewRegistry(), log.NewNopLogger())
+		}, client, "test", nil, log.NewNopLogger())
 
 		testMemcache(t, memcache)
 	})
@@ -94,7 +93,7 @@ func TestMemcacheFailure(t *testing.T) {
 	t.Run("unbatched", func(t *testing.T) {
 		client := newMockMemcacheFailing()
 		memcache := cache.NewMemcached(cache.MemcachedConfig{}, client,
-			"test", prometheus.NewRegistry(), log.NewNopLogger())
+			"test", nil, log.NewNopLogger())
 
 		testMemcacheFailing(t, memcache)
 	})
@@ -104,7 +103,7 @@ func TestMemcacheFailure(t *testing.T) {
 		memcache := cache.NewMemcached(cache.MemcachedConfig{
 			BatchSize:   10,
 			Parallelism: 5,
-		}, client, "test", prometheus.NewRegistry(), log.NewNopLogger())
+		}, client, "test", nil, log.NewNopLogger())
 
 		testMemcacheFailing(t, memcache)
 	})

--- a/pkg/chunk/cache/memcached_test.go
+++ b/pkg/chunk/cache/memcached_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
@@ -15,7 +17,8 @@ import (
 func TestMemcached(t *testing.T) {
 	t.Run("unbatched", func(t *testing.T) {
 		client := newMockMemcache()
-		memcache := cache.NewMemcached(cache.MemcachedConfig{}, client, "test")
+		memcache := cache.NewMemcached(cache.MemcachedConfig{}, client,
+			"test", prometheus.NewRegistry(), log.NewNopLogger())
 
 		testMemcache(t, memcache)
 	})
@@ -25,7 +28,7 @@ func TestMemcached(t *testing.T) {
 		memcache := cache.NewMemcached(cache.MemcachedConfig{
 			BatchSize:   10,
 			Parallelism: 5,
-		}, client, "test")
+		}, client, "test", prometheus.NewRegistry(), log.NewNopLogger())
 
 		testMemcache(t, memcache)
 	})
@@ -90,7 +93,8 @@ func (c *mockMemcacheFailing) GetMulti(keys []string) (map[string]*memcache.Item
 func TestMemcacheFailure(t *testing.T) {
 	t.Run("unbatched", func(t *testing.T) {
 		client := newMockMemcacheFailing()
-		memcache := cache.NewMemcached(cache.MemcachedConfig{}, client, "test")
+		memcache := cache.NewMemcached(cache.MemcachedConfig{}, client,
+			"test", prometheus.NewRegistry(), log.NewNopLogger())
 
 		testMemcacheFailing(t, memcache)
 	})
@@ -100,7 +104,7 @@ func TestMemcacheFailure(t *testing.T) {
 		memcache := cache.NewMemcached(cache.MemcachedConfig{
 			BatchSize:   10,
 			Parallelism: 5,
-		}, client, "test")
+		}, client, "test", prometheus.NewRegistry(), log.NewNopLogger())
 
 		testMemcacheFailing(t, memcache)
 	})

--- a/pkg/chunk/cache/redis_cache_test.go
+++ b/pkg/chunk/cache/redis_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/gomodule/redigo/redis"
 	"github.com/rafaeljusto/redigomock"
 	"github.com/stretchr/testify/require"
@@ -53,7 +54,7 @@ func TestRedisCache(t *testing.T) {
 	conn.Command("MGET", missIntf...).ExpectError(nil)
 
 	// mock the cache
-	c := cache.NewRedisCache(cfg, "mock", pool)
+	c := cache.NewRedisCache(cfg, "mock", pool, log.NewNopLogger())
 	ctx := context.Background()
 
 	c.Store(ctx, keys, bufs)

--- a/pkg/chunk/cache/snappy.go
+++ b/pkg/chunk/cache/snappy.go
@@ -3,20 +3,21 @@ package cache
 import (
 	"context"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/golang/snappy"
-
-	"github.com/cortexproject/cortex/pkg/util"
 )
 
 type snappyCache struct {
-	next Cache
+	next   Cache
+	logger log.Logger
 }
 
 // NewSnappy makes a new snappy encoding cache wrapper.
-func NewSnappy(next Cache) Cache {
+func NewSnappy(next Cache, logger log.Logger) Cache {
 	return &snappyCache{
-		next: next,
+		next:   next,
+		logger: logger,
 	}
 }
 
@@ -35,7 +36,7 @@ func (s *snappyCache) Fetch(ctx context.Context, keys []string) ([]string, [][]b
 	for _, buf := range bufs {
 		d, err := snappy.Decode(nil, buf)
 		if err != nil {
-			level.Error(util.Logger).Log("msg", "failed to decode cache entry", "err", err)
+			level.Error(s.logger).Log("msg", "failed to decode cache entry", "err", err)
 			return nil, nil, keys
 		}
 		ds = append(ds, d)

--- a/pkg/chunk/storage/caching_fixtures.go
+++ b/pkg/chunk/storage/caching_fixtures.go
@@ -1,8 +1,11 @@
 package storage
 
 import (
-	io "io"
+	"io"
 	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/validation"
@@ -25,10 +28,12 @@ func (f fixture) Clients() (chunk.IndexClient, chunk.Client, chunk.TableClient, 
 		return nil, nil, nil, chunk.SchemaConfig{}, nil, err
 	}
 	indexClient, chunkClient, tableClient, schemaConfig, closer, err := f.fixture.Clients()
+	reg := prometheus.NewRegistry()
+	logger := log.NewNopLogger()
 	indexClient = newCachingIndexClient(indexClient, cache.NewFifoCache("index-fifo", cache.FifoCacheConfig{
 		MaxSizeItems: 500,
 		Validity:     5 * time.Minute,
-	}), 5*time.Minute, limits)
+	}, reg, logger), 5*time.Minute, limits, logger)
 	return indexClient, chunkClient, tableClient, schemaConfig, closer, err
 }
 

--- a/pkg/chunk/storage/caching_index_client_test.go
+++ b/pkg/chunk/storage/caching_index_client_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
@@ -42,9 +41,8 @@ func TestCachingStorageClientBasic(t *testing.T) {
 	}
 	limits, err := defaultLimits()
 	require.NoError(t, err)
-	reg := prometheus.NewRegistry()
 	logger := log.NewNopLogger()
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, reg, logger)
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
 	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger)
 	queries := []chunk.IndexQuery{{
 		TableName: "table",
@@ -75,9 +73,8 @@ func TestTempCachingStorageClient(t *testing.T) {
 	}
 	limits, err := defaultLimits()
 	require.NoError(t, err)
-	reg := prometheus.NewRegistry()
 	logger := log.NewNopLogger()
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, reg, logger)
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
 	client := newCachingIndexClient(store, cache, 100*time.Millisecond, limits, logger)
 	queries := []chunk.IndexQuery{
 		{TableName: "table", HashValue: "foo"},
@@ -135,9 +132,8 @@ func TestPermCachingStorageClient(t *testing.T) {
 	}
 	limits, err := defaultLimits()
 	require.NoError(t, err)
-	reg := prometheus.NewRegistry()
 	logger := log.NewNopLogger()
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, reg, logger)
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
 	client := newCachingIndexClient(store, cache, 100*time.Millisecond, limits, logger)
 	queries := []chunk.IndexQuery{
 		{TableName: "table", HashValue: "foo", Immutable: true},
@@ -188,9 +184,8 @@ func TestCachingStorageClientEmptyResponse(t *testing.T) {
 	store := &mockStore{}
 	limits, err := defaultLimits()
 	require.NoError(t, err)
-	reg := prometheus.NewRegistry()
 	logger := log.NewNopLogger()
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, reg, logger)
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
 	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger)
 	queries := []chunk.IndexQuery{{TableName: "table", HashValue: "foo"}}
 	err = client.QueryPages(ctx, queries, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
@@ -228,9 +223,8 @@ func TestCachingStorageClientCollision(t *testing.T) {
 	}
 	limits, err := defaultLimits()
 	require.NoError(t, err)
-	reg := prometheus.NewRegistry()
 	logger := log.NewNopLogger()
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, reg, logger)
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
 	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger)
 	queries := []chunk.IndexQuery{
 		{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},

--- a/pkg/chunk/storage/caching_index_client_test.go
+++ b/pkg/chunk/storage/caching_index_client_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
@@ -40,8 +42,10 @@ func TestCachingStorageClientBasic(t *testing.T) {
 	}
 	limits, err := defaultLimits()
 	require.NoError(t, err)
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second})
-	client := newCachingIndexClient(store, cache, 1*time.Second, limits)
+	reg := prometheus.NewRegistry()
+	logger := log.NewNopLogger()
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, reg, logger)
+	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger)
 	queries := []chunk.IndexQuery{{
 		TableName: "table",
 		HashValue: "baz",
@@ -71,8 +75,10 @@ func TestTempCachingStorageClient(t *testing.T) {
 	}
 	limits, err := defaultLimits()
 	require.NoError(t, err)
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second})
-	client := newCachingIndexClient(store, cache, 100*time.Millisecond, limits)
+	reg := prometheus.NewRegistry()
+	logger := log.NewNopLogger()
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, reg, logger)
+	client := newCachingIndexClient(store, cache, 100*time.Millisecond, limits, logger)
 	queries := []chunk.IndexQuery{
 		{TableName: "table", HashValue: "foo"},
 		{TableName: "table", HashValue: "bar"},
@@ -129,8 +135,10 @@ func TestPermCachingStorageClient(t *testing.T) {
 	}
 	limits, err := defaultLimits()
 	require.NoError(t, err)
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second})
-	client := newCachingIndexClient(store, cache, 100*time.Millisecond, limits)
+	reg := prometheus.NewRegistry()
+	logger := log.NewNopLogger()
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, reg, logger)
+	client := newCachingIndexClient(store, cache, 100*time.Millisecond, limits, logger)
 	queries := []chunk.IndexQuery{
 		{TableName: "table", HashValue: "foo", Immutable: true},
 		{TableName: "table", HashValue: "bar", Immutable: true},
@@ -180,8 +188,10 @@ func TestCachingStorageClientEmptyResponse(t *testing.T) {
 	store := &mockStore{}
 	limits, err := defaultLimits()
 	require.NoError(t, err)
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second})
-	client := newCachingIndexClient(store, cache, 1*time.Second, limits)
+	reg := prometheus.NewRegistry()
+	logger := log.NewNopLogger()
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, reg, logger)
+	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger)
 	queries := []chunk.IndexQuery{{TableName: "table", HashValue: "foo"}}
 	err = client.QueryPages(ctx, queries, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
 		assert.False(t, batch.Iterator().Next())
@@ -218,8 +228,10 @@ func TestCachingStorageClientCollision(t *testing.T) {
 	}
 	limits, err := defaultLimits()
 	require.NoError(t, err)
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second})
-	client := newCachingIndexClient(store, cache, 1*time.Second, limits)
+	reg := prometheus.NewRegistry()
+	logger := log.NewNopLogger()
+	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, reg, logger)
+	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger)
 	queries := []chunk.IndexQuery{
 		{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},
 		{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("baz")},

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -115,10 +115,17 @@ func (cfg *Config) Validate() error {
 }
 
 // NewStore makes the storage clients based on the configuration.
-func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConfig, limits StoreLimits, reg prometheus.Registerer, cacheGenNumLoader chunk.CacheGenNumLoader) (chunk.Store, error) {
+func NewStore(
+	cfg Config,
+	storeCfg chunk.StoreConfig,
+	schemaCfg chunk.SchemaConfig,
+	limits StoreLimits,
+	reg prometheus.Registerer,
+	cacheGenNumLoader chunk.CacheGenNumLoader,
+	logger log.Logger,
+) (chunk.Store, error) {
 	chunkMetrics := newChunkClientMetrics(reg)
 
-	logger := log.NewNopLogger()
 	indexReadCache, err := cache.New(cfg.IndexQueriesCacheConfig, reg, logger)
 	if err != nil {
 		return nil, err

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -117,19 +118,20 @@ func (cfg *Config) Validate() error {
 func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConfig, limits StoreLimits, reg prometheus.Registerer, cacheGenNumLoader chunk.CacheGenNumLoader) (chunk.Store, error) {
 	chunkMetrics := newChunkClientMetrics(reg)
 
-	indexReadCache, err := cache.New(cfg.IndexQueriesCacheConfig)
+	logger := log.NewNopLogger()
+	indexReadCache, err := cache.New(cfg.IndexQueriesCacheConfig, reg, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	writeDedupeCache, err := cache.New(storeCfg.WriteDedupeCacheConfig)
+	writeDedupeCache, err := cache.New(storeCfg.WriteDedupeCacheConfig, reg, logger)
 	if err != nil {
 		return nil, err
 	}
 
 	chunkCacheCfg := storeCfg.ChunkCacheConfig
 	chunkCacheCfg.Prefix = "chunks"
-	chunksCache, err := cache.New(chunkCacheCfg)
+	chunksCache, err := cache.New(chunkCacheCfg, reg, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +162,7 @@ func NewStore(cfg Config, storeCfg chunk.StoreConfig, schemaCfg chunk.SchemaConf
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating index client")
 		}
-		index = newCachingIndexClient(index, indexReadCache, cfg.IndexCacheValidity, limits)
+		index = newCachingIndexClient(index, indexReadCache, cfg.IndexCacheValidity, limits, logger)
 
 		objectStoreType := s.ObjectType
 		if objectStoreType == "" {

--- a/pkg/chunk/storage/factory_test.go
+++ b/pkg/chunk/storage/factory_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func TestFactoryStop(t *testing.T) {
 	limits, err := validation.NewOverrides(defaults, nil)
 	require.NoError(t, err)
 
-	store, err := NewStore(cfg, storeConfig, schemaConfig, limits, nil, nil)
+	store, err := NewStore(cfg, storeConfig, schemaConfig, limits, nil, nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	store.Stop()
@@ -190,7 +191,7 @@ func TestCassandraInMultipleSchemas(t *testing.T) {
 	limits, err := validation.NewOverrides(defaults, nil)
 	require.NoError(t, err)
 
-	store, err := NewStore(cfg, storeConfig, schemaCfg, limits, prometheus.NewRegistry(), nil)
+	store, err := NewStore(cfg, storeConfig, schemaCfg, limits, prometheus.NewRegistry(), nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	store.Stop()

--- a/pkg/chunk/storage/factory_test.go
+++ b/pkg/chunk/storage/factory_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
@@ -191,7 +190,7 @@ func TestCassandraInMultipleSchemas(t *testing.T) {
 	limits, err := validation.NewOverrides(defaults, nil)
 	require.NoError(t, err)
 
-	store, err := NewStore(cfg, storeConfig, schemaCfg, limits, prometheus.NewRegistry(), nil, log.NewNopLogger())
+	store, err := NewStore(cfg, storeConfig, schemaCfg, limits, nil, nil, log.NewNopLogger())
 	require.NoError(t, err)
 
 	store.Stop()

--- a/pkg/chunk/storage/index_client_test.go
+++ b/pkg/chunk/storage/index_client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
@@ -204,7 +205,7 @@ func TestCardinalityLimit(t *testing.T) {
 		limits, err := defaultLimits()
 		require.NoError(t, err)
 
-		client = newCachingIndexClient(client, cache.NewMockCache(), time.Minute, limits)
+		client = newCachingIndexClient(client, cache.NewMockCache(), time.Minute, limits, log.NewNopLogger())
 		batch := client.NewWriteBatch()
 		for i := 0; i < 10; i++ {
 			batch.Add(tableName, "bar", []byte(strconv.Itoa(i)), []byte(strconv.Itoa(i)))

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -316,7 +316,7 @@ func (t *Cortex) initChunkStore() (serv services.Service, err error) {
 		return
 	}
 
-	t.Store, err = storage.NewStore(t.Cfg.Storage, t.Cfg.ChunkStore, t.Cfg.Schema, t.Overrides, prometheus.DefaultRegisterer, t.TombstonesLoader)
+	t.Store, err = storage.NewStore(t.Cfg.Storage, t.Cfg.ChunkStore, t.Cfg.Schema, t.Overrides, prometheus.DefaultRegisterer, t.TombstonesLoader, util.Logger)
 	if err != nil {
 		return
 	}

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/uber/jaeger-client-go"
 	"github.com/weaveworks/common/httpgrpc"
@@ -128,8 +129,9 @@ func NewResultsCacheMiddleware(
 	merger Merger,
 	extractor Extractor,
 	cacheGenNumberLoader CacheGenNumberLoader,
+	reg prometheus.Registerer,
 ) (Middleware, cache.Cache, error) {
-	c, err := cache.New(cfg.CacheConfig)
+	c, err := cache.New(cfg.CacheConfig, reg, logger)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/gogo/protobuf/types"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -380,7 +379,7 @@ func TestResultsCache(t *testing.T) {
 		PrometheusCodec,
 		PrometheusResponseExtractor{},
 		nil,
-		prometheus.NewRegistry(),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -419,7 +418,7 @@ func TestResultsCacheRecent(t *testing.T) {
 		PrometheusCodec,
 		PrometheusResponseExtractor{},
 		nil,
-		prometheus.NewRegistry(),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -487,7 +486,7 @@ func TestResultsCacheMaxFreshness(t *testing.T) {
 				PrometheusCodec,
 				PrometheusResponseExtractor{},
 				nil,
-				prometheus.NewRegistry(),
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -523,7 +522,7 @@ func Test_resultsCache_MissingData(t *testing.T) {
 		PrometheusCodec,
 		PrometheusResponseExtractor{},
 		nil,
-		prometheus.NewRegistry(),
+		nil,
 	)
 	require.NoError(t, err)
 	rc := rm.Wrap(nil).(*resultsCache)

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/gogo/protobuf/types"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -379,6 +380,7 @@ func TestResultsCache(t *testing.T) {
 		PrometheusCodec,
 		PrometheusResponseExtractor{},
 		nil,
+		prometheus.NewRegistry(),
 	)
 	require.NoError(t, err)
 
@@ -409,7 +411,16 @@ func TestResultsCacheRecent(t *testing.T) {
 	var cfg ResultsCacheConfig
 	flagext.DefaultValues(&cfg)
 	cfg.CacheConfig.Cache = cache.NewMockCache()
-	rcm, _, err := NewResultsCacheMiddleware(log.NewNopLogger(), cfg, constSplitter(day), fakeLimitsHighMaxCacheFreshness{}, PrometheusCodec, PrometheusResponseExtractor{}, nil)
+	rcm, _, err := NewResultsCacheMiddleware(
+		log.NewNopLogger(),
+		cfg,
+		constSplitter(day),
+		fakeLimitsHighMaxCacheFreshness{},
+		PrometheusCodec,
+		PrometheusResponseExtractor{},
+		nil,
+		prometheus.NewRegistry(),
+	)
 	require.NoError(t, err)
 
 	req := parsedRequest.WithStartEnd(int64(model.Now())-(60*1e3), int64(model.Now()))
@@ -476,6 +487,7 @@ func TestResultsCacheMaxFreshness(t *testing.T) {
 				PrometheusCodec,
 				PrometheusResponseExtractor{},
 				nil,
+				prometheus.NewRegistry(),
 			)
 			require.NoError(t, err)
 
@@ -511,6 +523,7 @@ func Test_resultsCache_MissingData(t *testing.T) {
 		PrometheusCodec,
 		PrometheusResponseExtractor{},
 		nil,
+		prometheus.NewRegistry(),
 	)
 	require.NoError(t, err)
 	rc := rm.Wrap(nil).(*resultsCache)

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -159,7 +159,7 @@ func NewTripperware(
 
 	var c cache.Cache
 	if cfg.CacheResults {
-		queryCacheMiddleware, cache, err := NewResultsCacheMiddleware(log, cfg.ResultsCacheConfig, constSplitter(cfg.SplitQueriesByInterval), limits, codec, cacheExtractor, cacheGenNumberLoader)
+		queryCacheMiddleware, cache, err := NewResultsCacheMiddleware(log, cfg.ResultsCacheConfig, constSplitter(cfg.SplitQueriesByInterval), limits, codec, cacheExtractor, cacheGenNumberLoader, registerer)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This pr removes global prometheus registries and util.logger in the `cache` package. This is good for reusing this package in other project like Thanos.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
