### PR TITLE
Use correct version of yaml

### DIFF
--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -19,7 +19,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
 	"github.com/prometheus/prometheus/prompb"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 var (

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -17,7 +17,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
 	"github.com/weaveworks/common/user"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ruler/rules"

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -6,8 +6,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 
@@ -159,4 +161,50 @@ func TestRuler_alerts(t *testing.T) {
 	})
 
 	require.Equal(t, string(expectedResponse), string(body))
+}
+
+func TestRuler_Create(t *testing.T) {
+	cfg, cleanup := defaultRulerConfig(newMockRuleStore(mockRules))
+	defer cleanup()
+
+	r, rcleanup := newTestRuler(t, cfg)
+	defer rcleanup()
+	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
+
+	rules := `
+name: test
+interval: 15s
+rules:
+- record: up_rule
+  expr: up{}
+- alert: up_alert
+  expr: sum(up{}) > 1
+  for: 30s
+  annotations:
+    test: test
+  labels:
+    test: test
+`
+
+	router := mux.NewRouter()
+	router.Path("/api/v1/rules/{namespace}").Methods("POST").HandlerFunc(r.CreateRuleGroup)
+	router.Path("/api/v1/rules/{namespace}/{groupName}").Methods("GET").HandlerFunc(r.GetRuleGroup)
+
+	// POST
+	req := httptest.NewRequest("POST", "https://localhost:8080/api/v1/rules/namespace", strings.NewReader(rules))
+	req.Header.Add(user.OrgIDHeaderName, "user1")
+	ctx := user.InjectOrgID(req.Context(), "user1")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req.WithContext(ctx))
+	require.Equal(t, 202, w.Code)
+
+	// GET
+	req = httptest.NewRequest("GET", "https://localhost:8080/api/v1/rules/namespace/test", nil)
+	req.Header.Add(user.OrgIDHeaderName, "user1")
+	ctx = user.InjectOrgID(req.Context(), "user1")
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req.WithContext(ctx))
+	require.Equal(t, 200, w.Code)
 }

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
 
+	"github.com/cortexproject/cortex/pkg/ruler/rules"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -164,7 +165,7 @@ func TestRuler_alerts(t *testing.T) {
 }
 
 func TestRuler_Create(t *testing.T) {
-	cfg, cleanup := defaultRulerConfig(newMockRuleStore(mockRules))
+	cfg, cleanup := defaultRulerConfig(newMockRuleStore(make(map[string]rules.RuleGroupList)))
 	defer cleanup()
 
 	r, rcleanup := newTestRuler(t, cfg)


### PR DESCRIPTION
**What this PR does**:
Fixes an issue where recent changes prevented rules from being parsed properly.  This PR: https://github.com/cortexproject/cortex/pull/2878/files changed the way rules were being parsed which broke the ruler api.

POSTS with both cortextool and manually via curl resulted in:
```
cortex-1_1       | level=error ts=2020-07-21T16:32:43.8053596Z caller=api.go:462 org_id=fake traceID=58bf3378ad39cc93 msg="unable to unmarshal rule group payload" err="yaml: unmarshal errors:\n  line 4: cannot unmarshal !!str `test` into yaml.Node\n  line 5: cannot unmarshal !!str `` into yaml.Node\n  line 6: cannot unmarshal !!str `sum by(...` into yaml.Node"
```

This PR fixes the issue by using the correct yaml version in the ruler api.