### PR TITLE
fix calling of stop method on series store

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -132,7 +132,7 @@ func newStore(cfg StoreConfig, schema StoreSchema, index IndexClient, chunks Cli
 }
 
 // Stop any background goroutines (ie in the cache.)
-func (c *store) Stop() {
+func (c *baseStore) Stop() {
 	c.storage.Stop()
 	c.Fetcher.Stop()
 	c.index.Stop()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
The code was recently refactored to include a type called `baseStore` which was having common functionalities of `seriesStore` and `store`. `seriesStore` was embedding `store` which was also changed to now embed `baseStore` instead. Now the problem is `baseStore` did not have a `Stop` method while `store` type has so the stop method on `seriesStore` was being called on some other embedded type. 
This code fixes the issue by defining `Stop` method on `baseStore` instead of `store` type which should be useful for both `store` and `seriesStore` type since both of them embed `baseStore`.

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
