### PR TITLE
Set a content type for the remote_read response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * [BUGFIX] KV: Fixed a bug that triggered a panic due to metrics being registered with the same name but different labels when using a `multi` configured KV client. #2837
 * [BUGFIX] Query-frontend: Fix passing HTTP `Host` header if `-frontend.downstream-url` is configured. #2880
 * [BUGFIX] Ingester: Improve time-series distribution when `-experimental.distributor.user-subring-size` is enabled. #2887
+* [BUGFIX] Set content type to `x-protobuf` for remote_read responses. #2915
 
 ## 1.2.0 / 2020-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@
 * [BUGFIX] KV: Fixed a bug that triggered a panic due to metrics being registered with the same name but different labels when using a `multi` configured KV client. #2837
 * [BUGFIX] Query-frontend: Fix passing HTTP `Host` header if `-frontend.downstream-url` is configured. #2880
 * [BUGFIX] Ingester: Improve time-series distribution when `-experimental.distributor.user-subring-size` is enabled. #2887
-* [BUGFIX] Set content type to `x-protobuf` for remote_read responses. #2915
+* [BUGFIX] Set content type to `application/x-protobuf` for remote_read responses. #2915
 
 ## 1.2.0 / 2020-07-01
 

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -67,7 +67,7 @@ func RemoteReadHandler(q storage.Queryable) http.Handler {
 			http.Error(w, lastErr.Error(), http.StatusBadRequest)
 			return
 		}
-
+		w.Header().Add("Content-Type", "application/x-protobuf")
 		if err := util.SerializeProtoResponse(w, &resp, compressionType); err != nil {
 			level.Error(logger).Log("msg", "error sending remote read response", "err", err)
 		}

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -53,6 +53,7 @@ func TestRemoteReadHandler(t *testing.T) {
 	handler.ServeHTTP(recorder, request)
 
 	require.Equal(t, 200, recorder.Result().StatusCode)
+	require.Equal(t, []string([]string{"application/x-protobuf"}), recorder.Result().Header["Content-Type"])
 	responseBody, err := ioutil.ReadAll(recorder.Result().Body)
 	require.NoError(t, err)
 	responseBody, err = snappy.Decode(nil, responseBody)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Some applications calling remote_read need to know what type of response to expect.
They may need to discriminate between x-protobuf and x-streamed-protobuf.

**Which issue(s) this PR fixes**:

No open issues for it.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
