### PR TITLE
Log a warning when checking the ring and finding a problem 

### DIFF
--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -227,6 +227,9 @@ func (i *Lifecycler) CheckReady(ctx context.Context) error {
 	}
 
 	if err := ringDesc.Ready(time.Now(), i.cfg.RingConfig.HeartbeatTimeout); err != nil {
+		level.Warn(util.Logger).Log("msg", "found an existing ingester(s) with a problem in the ring, "+
+			"this ingester cannot complete joining and become ready until this problem is resolved. "+
+			"The /ring http endpoint on the distributor (or single binary) provides visibility into the ring.", "err", err)
 		return err
 	}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Currently an ingester will fail report a 200 on the /ready endpoint if there is a problem in the current state of the ring (stale entry or unhealthy entry), this is intentional, there are a few issues discussing this such as #1521. 

Leaving the debate of this behavior to another issue I think it would help if we logged a warning when this happens.  This still catches us by surprise sometimes when an ingester will not enter the ready state and there is nothing in the logs indicating an issue.

This PR will log a warning when the check of the current ring state fails, this will log over and over every time the /ready healthcheck is queried providing some slightly noisy but hopefully very obvious indication as to why the ingester will not provide a ready response to the /ready endpoint.


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`



Signed-off-by: Edward Welch <edward.welch@grafana.com>

