### PR TITLE
Add a `user` label to the query_frontend_queue_length metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [CHANGE] Metric `cortex_overrides_last_reload_successful` has been renamed to `cortex_runtime_config_last_reload_successful`. #2874
 * [CHANGE] HipChat support has been removed from the alertmanager (because removed from the Prometheus upstream too). #2902
 * [CHANGE] Add constant label `name` to metric `cortex_cache_request_duration_seconds`. #2903
+* [CHANGE] Add `user` label to metric `cortex_query_frontend_queue_length`. #2939
 * [FEATURE] Introduced `ruler.for-outage-tolerance`, Max time to tolerate outage for restoring "for" state of alert. #2783
 * [FEATURE] Introduced `ruler.for-grace-period`, Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. #2783
 * [FEATURE] Introduced `ruler.resend-delay`, Minimum amount of time to wait before resending an alert to Alertmanager. #2783

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -363,7 +363,7 @@ func (f *Frontend) queueRequest(ctx context.Context, req *request) error {
 
 	select {
 	case queue <- req:
-		f.queueLength.WithLabelValues(userID).Add(1)
+		f.queueLength.WithLabelValues(userID).Inc()
 		f.cond.Broadcast()
 		return nil
 	default:
@@ -416,7 +416,7 @@ FindQueue:
 			f.cond.Broadcast()
 
 			f.queueDuration.Observe(time.Since(request.enqueueTime).Seconds())
-			f.queueLength.Add(-1)
+			f.queueLength.WithLabelValues(userID).Dec()
 			request.queueSpan.Finish()
 
 			// Ensure the request has not already expired.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

To better track issues around queries being queued or backed up in the query frontend this PR adds a `user` label to the `cortex_query_frontend_queue_length` gauge.  This can be helpful in understanding if queues backing up are systemic or limited to a single user, as well as understanding if a particular user is regularly backing up a queue.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

Signed-off-by: Edward Welch <edward.welch@grafana.com>

