### PR TITLE
bugfix(ruler): fix crashing when manager registers duplicate metrics

### DIFF
--- a/pkg/ruler/manager_metrics.go
+++ b/pkg/ruler/manager_metrics.go
@@ -1,0 +1,149 @@
+package ruler
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+// ManagerMetrics aggregates metrics exported by the Prometheus
+// rules package and returns them as Cortex metrics
+type ManagerMetrics struct {
+	// Maps userID -> registry
+	regsMu sync.Mutex
+	regs   map[string]*prometheus.Registry
+
+	EvalDuration        *prometheus.Desc
+	IterationDuration   *prometheus.Desc
+	IterationsMissed    *prometheus.Desc
+	IterationsScheduled *prometheus.Desc
+	EvalTotal           *prometheus.Desc
+	EvalFailures        *prometheus.Desc
+	GroupInterval       *prometheus.Desc
+	GroupLastEvalTime   *prometheus.Desc
+	GroupLastDuration   *prometheus.Desc
+	GroupRules          *prometheus.Desc
+}
+
+// NewManagerMetrics returns a ManagerMetrics struct
+func NewManagerMetrics() *ManagerMetrics {
+	return &ManagerMetrics{
+		regs:   map[string]*prometheus.Registry{},
+		regsMu: sync.Mutex{},
+
+		EvalDuration: prometheus.NewDesc(
+			"cortex_prometheus_rule_evaluation_duration_seconds",
+			"The duration for a rule to execute.",
+			[]string{"user"},
+			nil,
+		),
+		IterationDuration: prometheus.NewDesc(
+			"cortex_prometheus_rule_group_duration_seconds",
+			"The duration of rule group evaluations.",
+			[]string{"user"},
+			nil,
+		),
+		IterationsMissed: prometheus.NewDesc(
+			"cortex_prometheus_rule_group_iterations_missed_total",
+			"The total number of rule group evaluations missed due to slow rule group evaluation.",
+			[]string{"user"},
+			nil,
+		),
+		IterationsScheduled: prometheus.NewDesc(
+			"cortex_prometheus_rule_group_iterations_total",
+			"The total number of scheduled rule group evaluations, whether executed or missed.",
+			[]string{"user"},
+			nil,
+		),
+		EvalTotal: prometheus.NewDesc(
+			"cortex_prometheus_rule_evaluations_total",
+			"The total number of rule evaluations.",
+			[]string{"user", "rule_group"},
+			nil,
+		),
+		EvalFailures: prometheus.NewDesc(
+			"cortex_prometheus_rule_evaluation_failures_total",
+			"The total number of rule evaluation failures.",
+			[]string{"user", "rule_group"},
+			nil,
+		),
+		GroupInterval: prometheus.NewDesc(
+			"cortex_prometheus_rule_group_interval_seconds",
+			"The interval of a rule group.",
+			[]string{"user", "rule_group"},
+			nil,
+		),
+		GroupLastEvalTime: prometheus.NewDesc(
+			"cortex_prometheus_rule_group_last_evaluation_timestamp_seconds",
+			"The timestamp of the last rule group evaluation in seconds.",
+			[]string{"user", "rule_group"},
+			nil,
+		),
+		GroupLastDuration: prometheus.NewDesc(
+			"cortex_prometheus_rule_group_last_duration_seconds",
+			"The duration of the last rule group evaluation.",
+			[]string{"user", "rule_group"},
+			nil,
+		),
+		GroupRules: prometheus.NewDesc(
+			"cortex_prometheus_rule_group_rules",
+			"The number of rules.",
+			[]string{"user", "rule_group"},
+			nil,
+		),
+	}
+}
+
+// AddUserRegistry adds a Prometheus registry to the struct
+func (m *ManagerMetrics) AddUserRegistry(user string, reg *prometheus.Registry) {
+	m.regsMu.Lock()
+	m.regs[user] = reg
+	m.regsMu.Unlock()
+}
+
+// Registries returns a map of prometheus registries managed by the struct
+func (m *ManagerMetrics) Registries() map[string]*prometheus.Registry {
+	regs := map[string]*prometheus.Registry{}
+
+	m.regsMu.Lock()
+	defer m.regsMu.Unlock()
+	for uid, r := range m.regs {
+		regs[uid] = r
+	}
+
+	return regs
+}
+
+// Describe implements the Collector interface
+func (m *ManagerMetrics) Describe(out chan<- *prometheus.Desc) {
+	out <- m.EvalDuration
+	out <- m.IterationDuration
+	out <- m.IterationsMissed
+	out <- m.IterationsScheduled
+	out <- m.EvalTotal
+	out <- m.EvalFailures
+	out <- m.GroupInterval
+	out <- m.GroupLastEvalTime
+	out <- m.GroupLastDuration
+	out <- m.GroupRules
+}
+
+// Collect implements the Collector interface
+func (m *ManagerMetrics) Collect(out chan<- prometheus.Metric) {
+	data := util.BuildMetricFamiliesPerUserFromUserRegistries(m.Registries())
+
+	data.SendSumOfSummariesPerUser(out, m.EvalDuration, "prometheus_rule_evaluation_duration_seconds")
+	data.SendSumOfSummariesPerUser(out, m.IterationDuration, "cortex_prometheus_rule_group_duration_seconds")
+
+	data.SendSumOfCountersPerUser(out, m.IterationsMissed, "prometheus_rule_group_iterations_missed_total")
+	data.SendSumOfCountersPerUser(out, m.IterationsScheduled, "prometheus_rule_group_iterations_total")
+
+	data.SendSumOfCountersPerUserWithLabels(out, m.EvalTotal, "prometheus_rule_evaluations_total", "rule_group")
+	data.SendSumOfCountersPerUserWithLabels(out, m.EvalFailures, "prometheus_rule_evaluation_failures_total", "rule_group")
+	data.SendSumOfGaugesPerUserWithLabels(out, m.GroupInterval, "prometheus_rule_group_interval_seconds", "rule_group")
+	data.SendSumOfGaugesPerUserWithLabels(out, m.GroupLastEvalTime, "prometheus_rule_group_last_evaluation_timestamp_seconds", "rule_group")
+	data.SendSumOfGaugesPerUserWithLabels(out, m.GroupLastDuration, "prometheus_rule_group_last_duration_seconds", "rule_group")
+	data.SendSumOfGaugesPerUserWithLabels(out, m.GroupRules, "prometheus_rule_group_rules", "rule_group")
+}

--- a/pkg/ruler/manager_metrics_test.go
+++ b/pkg/ruler/manager_metrics_test.go
@@ -1,0 +1,209 @@
+package ruler
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerMetrics(t *testing.T) {
+	mainReg := prometheus.NewPedanticRegistry()
+
+	managerMetrics := NewManagerMetrics()
+	mainReg.MustRegister(managerMetrics)
+	managerMetrics.AddUserRegistry("user1", populateManager(1))
+	managerMetrics.AddUserRegistry("user2", populateManager(10))
+	managerMetrics.AddUserRegistry("user3", populateManager(100))
+
+	//noinspection ALL
+	err := testutil.GatherAndCompare(mainReg, bytes.NewBufferString(`
+# HELP cortex_prometheus_rule_evaluation_duration_seconds The duration for a rule to execute.
+# TYPE cortex_prometheus_rule_evaluation_duration_seconds summary
+cortex_prometheus_rule_evaluation_duration_seconds{user="user1",quantile="0.5"} 1
+cortex_prometheus_rule_evaluation_duration_seconds{user="user1",quantile="0.9"} 1
+cortex_prometheus_rule_evaluation_duration_seconds{user="user1",quantile="0.99"} 1
+cortex_prometheus_rule_evaluation_duration_seconds_sum{user="user1"} 1
+cortex_prometheus_rule_evaluation_duration_seconds_count{user="user1"} 1
+cortex_prometheus_rule_evaluation_duration_seconds{user="user2",quantile="0.5"} 10
+cortex_prometheus_rule_evaluation_duration_seconds{user="user2",quantile="0.9"} 10
+cortex_prometheus_rule_evaluation_duration_seconds{user="user2",quantile="0.99"} 10
+cortex_prometheus_rule_evaluation_duration_seconds_sum{user="user2"} 10
+cortex_prometheus_rule_evaluation_duration_seconds_count{user="user2"} 1
+cortex_prometheus_rule_evaluation_duration_seconds{user="user3",quantile="0.5"} 100
+cortex_prometheus_rule_evaluation_duration_seconds{user="user3",quantile="0.9"} 100
+cortex_prometheus_rule_evaluation_duration_seconds{user="user3",quantile="0.99"} 100
+cortex_prometheus_rule_evaluation_duration_seconds_sum{user="user3"} 100
+cortex_prometheus_rule_evaluation_duration_seconds_count{user="user3"} 1
+# HELP cortex_prometheus_rule_evaluation_failures_total The total number of rule evaluation failures.
+# TYPE cortex_prometheus_rule_evaluation_failures_total counter
+cortex_prometheus_rule_evaluation_failures_total{rule_group="group_one",user="user1"} 1
+cortex_prometheus_rule_evaluation_failures_total{rule_group="group_one",user="user2"} 10
+cortex_prometheus_rule_evaluation_failures_total{rule_group="group_one",user="user3"} 100
+cortex_prometheus_rule_evaluation_failures_total{rule_group="group_two",user="user1"} 1
+cortex_prometheus_rule_evaluation_failures_total{rule_group="group_two",user="user2"} 10
+cortex_prometheus_rule_evaluation_failures_total{rule_group="group_two",user="user3"} 100
+# HELP cortex_prometheus_rule_evaluations_total The total number of rule evaluations.
+# TYPE cortex_prometheus_rule_evaluations_total counter
+cortex_prometheus_rule_evaluations_total{rule_group="group_one",user="user1"} 1
+cortex_prometheus_rule_evaluations_total{rule_group="group_one",user="user2"} 10
+cortex_prometheus_rule_evaluations_total{rule_group="group_one",user="user3"} 100
+cortex_prometheus_rule_evaluations_total{rule_group="group_two",user="user1"} 1
+cortex_prometheus_rule_evaluations_total{rule_group="group_two",user="user2"} 10
+cortex_prometheus_rule_evaluations_total{rule_group="group_two",user="user3"} 100
+# HELP cortex_prometheus_rule_group_duration_seconds The duration of rule group evaluations.
+# TYPE cortex_prometheus_rule_group_duration_seconds summary
+cortex_prometheus_rule_group_duration_seconds_sum{user="user1"} 0
+cortex_prometheus_rule_group_duration_seconds_count{user="user1"} 0
+cortex_prometheus_rule_group_duration_seconds_sum{user="user2"} 0
+cortex_prometheus_rule_group_duration_seconds_count{user="user2"} 0
+cortex_prometheus_rule_group_duration_seconds_sum{user="user3"} 0
+cortex_prometheus_rule_group_duration_seconds_count{user="user3"} 0
+# HELP cortex_prometheus_rule_group_iterations_missed_total The total number of rule group evaluations missed due to slow rule group evaluation.
+# TYPE cortex_prometheus_rule_group_iterations_missed_total counter
+cortex_prometheus_rule_group_iterations_missed_total{user="user1"} 1
+cortex_prometheus_rule_group_iterations_missed_total{user="user2"} 10
+cortex_prometheus_rule_group_iterations_missed_total{user="user3"} 100
+# HELP cortex_prometheus_rule_group_iterations_total The total number of scheduled rule group evaluations, whether executed or missed.
+# TYPE cortex_prometheus_rule_group_iterations_total counter
+cortex_prometheus_rule_group_iterations_total{user="user1"} 1
+cortex_prometheus_rule_group_iterations_total{user="user2"} 10
+cortex_prometheus_rule_group_iterations_total{user="user3"} 100
+# HELP cortex_prometheus_rule_group_last_duration_seconds The duration of the last rule group evaluation.
+# TYPE cortex_prometheus_rule_group_last_duration_seconds gauge
+cortex_prometheus_rule_group_last_duration_seconds{rule_group="group_one",user="user1"} 1000
+cortex_prometheus_rule_group_last_duration_seconds{rule_group="group_one",user="user2"} 10000
+cortex_prometheus_rule_group_last_duration_seconds{rule_group="group_one",user="user3"} 100000
+cortex_prometheus_rule_group_last_duration_seconds{rule_group="group_two",user="user1"} 1000
+cortex_prometheus_rule_group_last_duration_seconds{rule_group="group_two",user="user2"} 10000
+cortex_prometheus_rule_group_last_duration_seconds{rule_group="group_two",user="user3"} 100000
+# HELP cortex_prometheus_rule_group_last_evaluation_timestamp_seconds The timestamp of the last rule group evaluation in seconds.
+# TYPE cortex_prometheus_rule_group_last_evaluation_timestamp_seconds gauge
+cortex_prometheus_rule_group_last_evaluation_timestamp_seconds{rule_group="group_one",user="user1"} 1000
+cortex_prometheus_rule_group_last_evaluation_timestamp_seconds{rule_group="group_one",user="user2"} 10000
+cortex_prometheus_rule_group_last_evaluation_timestamp_seconds{rule_group="group_one",user="user3"} 100000
+cortex_prometheus_rule_group_last_evaluation_timestamp_seconds{rule_group="group_two",user="user1"} 1000
+cortex_prometheus_rule_group_last_evaluation_timestamp_seconds{rule_group="group_two",user="user2"} 10000
+cortex_prometheus_rule_group_last_evaluation_timestamp_seconds{rule_group="group_two",user="user3"} 100000
+# HELP cortex_prometheus_rule_group_rules The number of rules.
+# TYPE cortex_prometheus_rule_group_rules gauge
+cortex_prometheus_rule_group_rules{rule_group="group_one",user="user1"} 1000
+cortex_prometheus_rule_group_rules{rule_group="group_one",user="user2"} 10000
+cortex_prometheus_rule_group_rules{rule_group="group_one",user="user3"} 100000
+cortex_prometheus_rule_group_rules{rule_group="group_two",user="user1"} 1000
+cortex_prometheus_rule_group_rules{rule_group="group_two",user="user2"} 10000
+cortex_prometheus_rule_group_rules{rule_group="group_two",user="user3"} 100000
+`))
+	require.NoError(t, err)
+}
+
+func populateManager(base float64) *prometheus.Registry {
+	r := prometheus.NewRegistry()
+
+	metrics := newGroupMetrics(r)
+
+	metrics.evalDuration.Observe(base)
+	metrics.iterationDuration.Observe(base)
+	metrics.iterationsMissed.Add(base)
+	metrics.iterationsScheduled.Add(base)
+
+	metrics.evalTotal.WithLabelValues("group_one").Add(base)
+	metrics.evalTotal.WithLabelValues("group_two").Add(base)
+	metrics.evalFailures.WithLabelValues("group_one").Add(base)
+	metrics.evalFailures.WithLabelValues("group_two").Add(base)
+
+	metrics.groupLastEvalTime.WithLabelValues("group_one").Add(base * 1000)
+	metrics.groupLastEvalTime.WithLabelValues("group_two").Add(base * 1000)
+
+	metrics.groupLastDuration.WithLabelValues("group_one").Add(base * 1000)
+	metrics.groupLastDuration.WithLabelValues("group_two").Add(base * 1000)
+
+	metrics.groupRules.WithLabelValues("group_one").Add(base * 1000)
+	metrics.groupRules.WithLabelValues("group_two").Add(base * 1000)
+	return r
+}
+
+// Copied from github.com/prometheus/rules/manager.go
+type groupMetrics struct {
+	evalDuration        prometheus.Summary
+	iterationDuration   prometheus.Summary
+	iterationsMissed    prometheus.Counter
+	iterationsScheduled prometheus.Counter
+	evalTotal           *prometheus.CounterVec
+	evalFailures        *prometheus.CounterVec
+	groupInterval       *prometheus.GaugeVec
+	groupLastEvalTime   *prometheus.GaugeVec
+	groupLastDuration   *prometheus.GaugeVec
+	groupRules          *prometheus.GaugeVec
+}
+
+func newGroupMetrics(r prometheus.Registerer) *groupMetrics {
+	m := &groupMetrics{
+		evalDuration: promauto.With(r).NewSummary(
+			prometheus.SummaryOpts{
+				Name:       "prometheus_rule_evaluation_duration_seconds",
+				Help:       "The duration for a rule to execute.",
+				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+			}),
+		iterationDuration: promauto.With(r).NewSummary(prometheus.SummaryOpts{
+			Name:       "prometheus_rule_group_duration_seconds",
+			Help:       "The duration of rule group evaluations.",
+			Objectives: map[float64]float64{0.01: 0.001, 0.05: 0.005, 0.5: 0.05, 0.90: 0.01, 0.99: 0.001},
+		}),
+		iterationsMissed: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "prometheus_rule_group_iterations_missed_total",
+			Help: "The total number of rule group evaluations missed due to slow rule group evaluation.",
+		}),
+		iterationsScheduled: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "prometheus_rule_group_iterations_total",
+			Help: "The total number of scheduled rule group evaluations, whether executed or missed.",
+		}),
+		evalTotal: promauto.With(r).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "prometheus_rule_evaluations_total",
+				Help: "The total number of rule evaluations.",
+			},
+			[]string{"rule_group"},
+		),
+		evalFailures: promauto.With(r).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "prometheus_rule_evaluation_failures_total",
+				Help: "The total number of rule evaluation failures.",
+			},
+			[]string{"rule_group"},
+		),
+		groupInterval: promauto.With(r).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "prometheus_rule_group_interval_seconds",
+				Help: "The interval of a rule group.",
+			},
+			[]string{"rule_group"},
+		),
+		groupLastEvalTime: promauto.With(r).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "prometheus_rule_group_last_evaluation_timestamp_seconds",
+				Help: "The timestamp of the last rule group evaluation in seconds.",
+			},
+			[]string{"rule_group"},
+		),
+		groupLastDuration: promauto.With(r).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "prometheus_rule_group_last_duration_seconds",
+				Help: "The duration of the last rule group evaluation.",
+			},
+			[]string{"rule_group"},
+		),
+		groupRules: promauto.With(r).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "prometheus_rule_group_rules",
+				Help: "The number of rules.",
+			},
+			[]string{"rule_group"},
+		),
+	}
+
+	return m
+}

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -191,7 +191,10 @@ func NewRuler(cfg Config, engine *promql.Engine, queryable promStorage.Queryable
 	}
 
 	userManagerMetrics := NewManagerMetrics()
-	reg.MustRegister(userManagerMetrics)
+
+	if reg != nil {
+		reg.MustRegister(userManagerMetrics)
+	}
 
 	ruler := &Ruler{
 		cfg:                cfg,

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -166,10 +166,14 @@ type Ruler struct {
 	ring        *ring.Ring
 	subservices *services.Manager
 
-	store          rules.RuleStore
-	mapper         *mapper
-	userManagerMtx sync.Mutex
-	userManagers   map[string]*promRules.Manager
+	store  rules.RuleStore
+	mapper *mapper
+
+	// Structs for holding per-user Prometheus rules Managers
+	// and a corresponding metrics struct
+	userManagerMtx     sync.Mutex
+	userManagers       map[string]*promRules.Manager
+	userManagerMetrics *ManagerMetrics
 
 	// Per-user notifiers with separate queues.
 	notifiersMtx sync.Mutex
@@ -186,19 +190,23 @@ func NewRuler(cfg Config, engine *promql.Engine, queryable promStorage.Queryable
 		return nil, err
 	}
 
+	userManagerMetrics := NewManagerMetrics()
+	reg.MustRegister(userManagerMetrics)
+
 	ruler := &Ruler{
-		cfg:          cfg,
-		engine:       engine,
-		queryable:    queryable,
-		alertURL:     cfg.ExternalURL.URL,
-		notifierCfg:  ncfg,
-		notifiers:    map[string]*rulerNotifier{},
-		store:        ruleStore,
-		pusher:       pusher,
-		mapper:       newMapper(cfg.RulePath, logger),
-		userManagers: map[string]*promRules.Manager{},
-		registry:     reg,
-		logger:       logger,
+		cfg:                cfg,
+		engine:             engine,
+		queryable:          queryable,
+		alertURL:           cfg.ExternalURL.URL,
+		notifierCfg:        ncfg,
+		notifiers:          map[string]*rulerNotifier{},
+		store:              ruleStore,
+		pusher:             pusher,
+		mapper:             newMapper(cfg.RulePath, logger),
+		userManagers:       map[string]*promRules.Manager{},
+		userManagerMetrics: userManagerMetrics,
+		registry:           reg,
+		logger:             logger,
 	}
 
 	if cfg.EnableSharding {
@@ -531,9 +539,11 @@ func (r *Ruler) newManager(ctx context.Context, userID string) (*promRules.Manag
 		return nil, err
 	}
 
-	// Wrap registerer with userID and cortex_ prefix
-	reg := prometheus.WrapRegistererWith(prometheus.Labels{"user": userID}, r.registry)
-	reg = prometheus.WrapRegistererWithPrefix("cortex_", reg)
+	// Create a new Prometheus registry and register it within
+	// our metrics struct for the provided user.
+	reg := prometheus.NewRegistry()
+	r.userManagerMetrics.AddUserRegistry(userID, reg)
+
 	logger := log.With(r.logger, "user", userID)
 	opts := &promRules.ManagerOptions{
 		Appendable:      &appender{pusher: r.pusher, userID: userID},

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -166,6 +166,17 @@ func (d MetricFamiliesPerUser) SendSumOfCountersPerUser(out chan<- prometheus.Me
 	}
 }
 
+// SendSumOfCountersPerUserWithLabels provides metrics with the provided label names on a per-user basis. This function assumes that `user` is the
+// first label on the provided metric Desc
+func (d MetricFamiliesPerUser) SendSumOfCountersPerUserWithLabels(out chan<- prometheus.Metric, desc *prometheus.Desc, metric string, labelNames ...string) {
+	for user, userMetrics := range d {
+		result := singleValueWithLabelsMap{}
+		userMetrics.sumOfSingleValuesWithLabels(metric, labelNames, counterValue, result.aggregateFn)
+		result.prependUserLabelValue(user)
+		result.WriteToMetricChannel(out, desc, prometheus.CounterValue)
+	}
+}
+
 func (d MetricFamiliesPerUser) GetSumOfGauges(gauge string) float64 {
 	result := float64(0)
 	for _, userMetrics := range d {
@@ -251,6 +262,17 @@ func (d MetricFamiliesPerUser) SendSumOfSummariesWithLabels(out chan<- prometheu
 
 	for _, sr := range result {
 		out <- sr.data.Metric(desc, sr.labelValues...)
+	}
+}
+
+func (d MetricFamiliesPerUser) SendSumOfSummariesPerUser(out chan<- prometheus.Metric, desc *prometheus.Desc, summaryName string) {
+	result := map[string]SummaryData{}
+	for user, userMetrics := range d {
+		result[user] = userMetrics.SumSummaries(summaryName)
+	}
+
+	for user, data := range result {
+		out <- data.Metric(desc, user)
 	}
 }
 

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -266,12 +266,8 @@ func (d MetricFamiliesPerUser) SendSumOfSummariesWithLabels(out chan<- prometheu
 }
 
 func (d MetricFamiliesPerUser) SendSumOfSummariesPerUser(out chan<- prometheus.Metric, desc *prometheus.Desc, summaryName string) {
-	result := map[string]SummaryData{}
 	for user, userMetrics := range d {
-		result[user] = userMetrics.SumSummaries(summaryName)
-	}
-
-	for user, data := range result {
+		data := userMetrics.SumSummaries(summaryName)
 		out <- data.Metric(desc, user)
 	}
 }


### PR DESCRIPTION
**What this PR does**:

- Add a metrics struct that wraps the metrics registries passed to the Prometheus `rules.Manager` and collects metrics. Identical to the `alertmanagerMetrics` struct used by our multi-tenant alertmanager.
- Adds `SendSumOfCountersPerUserWithLabels` and `SendSumOfSummariesPerUser` functions to the metrics-helper w/ tests

**note**: This PR does not alter the rules exported by the ruler. However, as discussed in #2907, it will enable future changes to remove summary metrics that are not worth exposing. See #2944 

**Which issue(s) this PR fixes**:
Fixes #2907

**Checklist**
- [x] Tests updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
