### PR TITLE
Install gsutil in the default Cortex image

### DIFF
--- a/cmd/cortex/Dockerfile
+++ b/cmd/cortex/Dockerfile
@@ -5,6 +5,18 @@ COPY       cortex /bin/cortex
 EXPOSE     80
 ENTRYPOINT [ "/bin/cortex" ]
 
+# Install the CLI tool "gsutil" in order to help cluster operators to run manual operations
+# when running the Cortex blocks storage with GCS.
+# IMPORTANT: if you change python version, remember to also change the plugin path at /etc/boto.cfg.
+RUN apk add --no-cache python3~=3.8 py3-pip && \
+    pip install google-compute-engine && \
+    wget https://storage.googleapis.com/pub/gsutil.tar.gz && \
+    tar -zxf gsutil.tar.gz -C /usr/local/bin && \
+    rm -f gsutil.tar.gz && \
+    mv /usr/local/bin/gsutil /usr/local/bin/gsutil-sources && \
+    ln -s /usr/local/bin/gsutil-sources/gsutil /usr/local/bin/gsutil && \
+    ln -s /usr/bin/python3 /usr/bin/python
+
 ARG revision
 LABEL org.opencontainers.image.title="cortex" \
       org.opencontainers.image.source="https://github.com/cortexproject/cortex/tree/master/cmd/cortex" \

--- a/cmd/cortex/etc/boto.cfg
+++ b/cmd/cortex/etc/boto.cfg
@@ -1,0 +1,5 @@
+[GoogleCompute]
+service_account = default
+
+[Plugin]
+plugin_directory = /usr/lib/python3.8/site-packages/google_compute_engine/boto


### PR DESCRIPTION
**What this PR does**:
What's the sentiment to install the `gsutil` CLI in the default Cortex image, to provide cluster operators a ready to use CLI tool to manually upload local data to a GCS bucket? This could be useful while dealing with an outage.

The image size increases from 98MB to 179MB (because of Python).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
