### PR TITLE
Replace usage of sync/atomic with uber-go/atomic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,9 @@ lint:
 	golangci-lint run
 
 	# Ensure no blacklisted package is imported.
-	faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,golang.org/x/net/context=context" ./pkg/... ./cmd/... ./tools/... ./integration/...
+	faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
+		golang.org/x/net/context=context,\
+		sync/atomic=go.uber.org/atomic" ./pkg/... ./cmd/... ./tools/... ./integration/...
 
 	# Validate Kubernetes spec files. Requires:
 	# https://kubeval.instrumenta.dev

--- a/pkg/chunk/cache/memcached_test.go
+++ b/pkg/chunk/cache/memcached_test.go
@@ -3,12 +3,12 @@ package cache_test
 import (
 	"context"
 	"errors"
-	"sync/atomic"
 	"testing"
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 )
@@ -71,7 +71,7 @@ func testMemcache(t *testing.T, memcache *cache.Memcached) {
 // mockMemcache whose calls fail 1/3rd of the time.
 type mockMemcacheFailing struct {
 	*mockMemcache
-	calls uint64
+	calls atomic.Uint64
 }
 
 func newMockMemcacheFailing() *mockMemcacheFailing {
@@ -81,7 +81,7 @@ func newMockMemcacheFailing() *mockMemcacheFailing {
 }
 
 func (c *mockMemcacheFailing) GetMulti(keys []string) (map[string]*memcache.Item, error) {
-	calls := atomic.AddUint64(&c.calls, 1)
+	calls := c.calls.Inc()
 	if calls%3 == 0 {
 		return nil, errors.New("fail")
 	}

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -7,13 +7,13 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/user"
+	"go.uber.org/atomic"
 )
 
 const seconds = 1e3 // 1e3 milliseconds per second.
@@ -261,11 +261,11 @@ func TestSplitByDay(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 
-			actualCount := int32(0)
+			var actualCount atomic.Int32
 			s := httptest.NewServer(
 				middleware.AuthenticateUser.Wrap(
 					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-						atomic.AddInt32(&actualCount, 1)
+						actualCount.Inc()
 						_, _ = w.Write([]byte(responseBody))
 					}),
 				),
@@ -293,7 +293,7 @@ func TestSplitByDay(t *testing.T) {
 			bs, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedBody, string(bs))
-			require.Equal(t, tc.expectedQueryCount, actualCount)
+			require.Equal(t, tc.expectedQueryCount, actualCount.Load())
 		})
 	}
 }

--- a/pkg/util/events.go
+++ b/pkg/util/events.go
@@ -2,9 +2,9 @@ package util
 
 import (
 	"os"
-	"sync/atomic"
 
 	"github.com/go-kit/kit/log"
+	"go.uber.org/atomic"
 )
 
 // Provide an "event" interface for observability
@@ -43,11 +43,11 @@ func newEventLogger(freq int) log.Logger {
 type samplingFilter struct {
 	next  log.Logger
 	freq  int
-	count int64
+	count atomic.Int64
 }
 
 func (e *samplingFilter) Log(keyvals ...interface{}) error {
-	count := atomic.AddInt64(&e.count, 1)
+	count := e.count.Inc()
 	if count%int64(e.freq) == 0 {
 		return e.next.Log(keyvals...)
 	}

--- a/pkg/util/services/services_test.go
+++ b/pkg/util/services/services_test.go
@@ -3,11 +3,11 @@ package services
 import (
 	"context"
 	"errors"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 func TestIdleService(t *testing.T) {
@@ -41,10 +41,10 @@ func TestIdleService(t *testing.T) {
 func TestTimerService(t *testing.T) {
 	t.Parallel()
 
-	iterations := int64(0)
+	var iterations atomic.Uint64
 
 	s := NewTimerService(100*time.Millisecond, nil, func(ctx context.Context) error {
-		atomic.AddInt64(&iterations, 1)
+		iterations.Inc()
 		return nil
 	}, nil)
 	defer s.StopAsync()
@@ -57,7 +57,7 @@ func TestTimerService(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	val := atomic.LoadInt64(&iterations)
+	val := iterations.Load()
 	require.NotZero(t, val) // we should observe some iterations now
 
 	s.StopAsync()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**: Replaces all direct usages of `sync/atomic` with `go.uber.org/atomic`. That way we ensure that all access to variables that have atomic access is in fact always atomic.

**Which issue(s) this PR fixes**:
Fixes https://github.com/cortexproject/cortex/issues/2923

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
