### PR TITLE
Fixed basic lifecycler instance registration when only the address differs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@
 * [BUGFIX] Query-frontend: Fix passing HTTP `Host` header if `-frontend.downstream-url` is configured. #2880
 * [BUGFIX] Ingester: Improve time-series distribution when `-experimental.distributor.user-subring-size` is enabled. #2887
 * [BUGFIX] Set content type to `application/x-protobuf` for remote_read responses. #2915
-* [BUGFIX] Fixed ruler and store-gateway instance registration in the ring (when sharding is enabled) when an instance replaces a previously registered instance which has been abruptly terminated and the only difference between the two instances is the address. #2954
+* [BUGFIX] Fixed ruler and store-gateway instance registration in the ring (when sharding is enabled) when a new instance replaces abruptly terminated one, and the only difference between the two instances is the address. #2954
 
 ## 1.2.0 / 2020-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 * [BUGFIX] Query-frontend: Fix passing HTTP `Host` header if `-frontend.downstream-url` is configured. #2880
 * [BUGFIX] Ingester: Improve time-series distribution when `-experimental.distributor.user-subring-size` is enabled. #2887
 * [BUGFIX] Set content type to `application/x-protobuf` for remote_read responses. #2915
+* [BUGFIX] Fixed ruler and store-gateway instance registration in the ring (when sharding is enabled) when an instance replaces a previously registered instance which has been abruptly terminated and the only difference between the two instances is the address. #2954
 
 ## 1.2.0 / 2020-07-01
 

--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -253,13 +253,11 @@ func (l *BasicLifecycler) registerInstance(ctx context.Context) error {
 			return ringDesc, true, nil
 		}
 
-		if instanceDesc.State != state || !tokens.Equals(instanceDesc.Tokens) {
-			instanceDesc = ringDesc.AddIngester(l.cfg.ID, l.cfg.Addr, l.cfg.Zone, tokens, state)
-			return ringDesc, true, nil
-		}
-
-		// We haven't modified the ring, so don't try to store it.
-		return nil, true, nil
+		// Always overwrite the instance in the ring (even if already exists) because some properties
+		// may have changed (stated, tokens, zone, address) and even if they didn't the heartbeat at
+		// least did.
+		instanceDesc = ringDesc.AddIngester(l.cfg.ID, l.cfg.Addr, l.cfg.Zone, tokens, state)
+		return ringDesc, true, nil
 	})
 
 	if err != nil {

--- a/pkg/ring/basic_lifecycler_test.go
+++ b/pkg/ring/basic_lifecycler_test.go
@@ -43,7 +43,7 @@ func TestBasicLifecycler_RegisterOnStart(t *testing.T) {
 			registerState:  ACTIVE,
 			registerTokens: Tokens{1, 2, 3, 4, 5},
 		},
-		"initial ring contains the same instance with a different address and tokens": {
+		"initial ring contains the same instance with different state, tokens and address (new one is 127.0.0.1)": {
 			initialInstanceID: testInstanceID,
 			initialInstanceDesc: &IngesterDesc{
 				Addr:   "1.1.1.1",
@@ -51,6 +51,16 @@ func TestBasicLifecycler_RegisterOnStart(t *testing.T) {
 				Tokens: Tokens{6, 7, 8, 9, 10},
 			},
 			registerState:  JOINING,
+			registerTokens: Tokens{1, 2, 3, 4, 5},
+		},
+		"initial ring contains the same instance with different address (new one is 127.0.0.1)": {
+			initialInstanceID: testInstanceID,
+			initialInstanceDesc: &IngesterDesc{
+				Addr:   "1.1.1.1",
+				State:  ACTIVE,
+				Tokens: Tokens{1, 2, 3, 4, 5},
+			},
+			registerState:  ACTIVE,
 			registerTokens: Tokens{1, 2, 3, 4, 5},
 		},
 	}


### PR DESCRIPTION
**What this PR does**:
I think I've tried to be too smart in the `BasicLifecycler` instance registration to avoid CAS operation when not required. Before this PR, if an instance already exists in the ring, it's not updated at registration phase if only the address differs. This PR fixes it.

**Which issue(s) this PR fixes**:
I'm not 💯  sure, but could fix #2950.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
