### PR TITLE
AM Metric: Add tenant label to valid/invalid configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Add `user` label to the metric `cortex_alertmanager_configs` exposed by Alertmanager. #2960
 * [CHANGE] Experimental Delete Series: Change target flag for purger from `data-purger` to `purger`. #2777
 * [CHANGE] Experimental TSDB: The max concurrent queries against the long-term storage, configured via `-experimental.tsdb.bucket-store.max-concurrent`, is now a limit shared across all tenants and not a per-tenant limit anymore. The default value has changed from `20` to `100` and the following new metrics have been added: #2797
   * `cortex_bucket_stores_gate_queries_concurrent_max`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [CHANGE] Replace the metric `cortex_alertmanager_configs` with `cortex_alertmanager_invalid_config` exposed by Alertmanager. #2960
+* [CHANGE] Replace the metric `cortex_alertmanager_configs` with `cortex_alertmanager_config_invalid` exposed by Alertmanager. #2960
 * [CHANGE] Experimental Delete Series: Change target flag for purger from `data-purger` to `purger`. #2777
 * [CHANGE] Experimental TSDB: The max concurrent queries against the long-term storage, configured via `-experimental.tsdb.bucket-store.max-concurrent`, is now a limit shared across all tenants and not a per-tenant limit anymore. The default value has changed from `20` to `100` and the following new metrics have been added: #2797
   * `cortex_bucket_stores_gate_queries_concurrent_max`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [CHANGE] Add `user` label to the metric `cortex_alertmanager_configs` exposed by Alertmanager. #2960
+* [CHANGE] Replace the metric `cortex_alertmanager_configs` with `cortex_alertmanager_invalid_config` exposed by Alertmanager. #2960
 * [CHANGE] Experimental Delete Series: Change target flag for purger from `data-purger` to `purger`. #2777
 * [CHANGE] Experimental TSDB: The max concurrent queries against the long-term storage, configured via `-experimental.tsdb.bucket-store.max-concurrent`, is now a limit shared across all tenants and not a per-tenant limit anymore. The default value has changed from `20` to `100` and the following new metrics have been added: #2797
   * `cortex_bucket_stores_gate_queries_concurrent_max`

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -30,7 +30,7 @@ func TestAlertmanager(t *testing.T) {
 		"",
 	)
 	require.NoError(t, s.StartAndWaitReady(alertmanager))
-	require.NoError(t, alertmanager.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_invalid_config"))
+	require.NoError(t, alertmanager.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_config_invalid"))
 
 	c, err := e2ecortex.NewClient("", "", alertmanager.HTTPEndpoint(), "", "user-1")
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)
-	require.NoError(t, am.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_invalid_config"))
+	require.NoError(t, am.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_config_invalid"))
 
 	cfg, err := c.GetAlertmanagerConfig(context.Background())
 	require.NoError(t, err)

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -29,7 +30,7 @@ func TestAlertmanager(t *testing.T) {
 		"",
 	)
 	require.NoError(t, s.StartAndWaitReady(alertmanager))
-	require.NoError(t, alertmanager.WaitSumMetrics(e2e.Equals(1), "cortex_alertmanager_configs"))
+	require.NoError(t, alertmanager.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_invalid_config"))
 
 	c, err := e2ecortex.NewClient("", "", alertmanager.HTTPEndpoint(), "", "user-1")
 	require.NoError(t, err)
@@ -67,6 +68,7 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	)
 
 	require.NoError(t, s.StartAndWaitReady(am))
+	require.NoError(t, am.WaitSumMetrics(e2e.Equals(1), "alertmanager_cluster_members"))
 
 	c, err := e2ecortex.NewClient("", "", am.HTTPEndpoint(), "", "user-1")
 	require.NoError(t, err)
@@ -78,7 +80,8 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	err = c.SetAlertmanagerConfig(context.Background(), cortexAlertmanagerUserConfigYaml, map[string]string{})
 	require.NoError(t, err)
 
-	require.NoError(t, am.WaitSumMetrics(e2e.Equals(1), "cortex_alertmanager_configs"))
+	time.Sleep(2 * time.Second)
+	require.NoError(t, am.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_invalid_config"))
 
 	cfg, err := c.GetAlertmanagerConfig(context.Background())
 	require.NoError(t, err)
@@ -93,6 +96,8 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 
 	err = c.DeleteAlertmanagerConfig(context.Background())
 	require.NoError(t, err)
+
+	time.Sleep(2 * time.Second)
 
 	cfg, err = c.GetAlertmanagerConfig(context.Background())
 	require.Error(t, err)

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -67,7 +67,6 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	)
 
 	require.NoError(t, s.StartAndWaitReady(am))
-	require.NoError(t, am.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_configs"))
 
 	c, err := e2ecortex.NewClient("", "", am.HTTPEndpoint(), "", "user-1")
 	require.NoError(t, err)
@@ -95,7 +94,6 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	err = c.DeleteAlertmanagerConfig(context.Background())
 	require.NoError(t, err)
 
-	require.NoError(t, am.WaitSumMetrics(e2e.Equals(0), "cortex_alertmanager_configs"))
 	cfg, err = c.GetAlertmanagerConfig(context.Background())
 	require.Error(t, err)
 	require.Nil(t, cfg)

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -134,7 +134,7 @@ func newMultitenantAlertmanagerMetrics(reg prometheus.Registerer) *multitenantAl
 
 	m.invalidConfig = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "cortex",
-		Name:      "alertmanager_invalid_config",
+		Name:      "alertmanager_config_invalid",
 		Help:      "Whenever the Alertmanager config is invalid for a user.",
 	}, []string{"user"})
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -333,6 +333,8 @@ func (am *MultitenantAlertmanager) syncConfigs(cfgs map[string]alerts.AlertConfi
 			level.Info(am.logger).Log("msg", "deactivating per-tenant alertmanager", "user", user)
 			userAM.Pause()
 			delete(am.cfgs, user)
+			am.multitenantMetrics.totalConfigs.DeleteLabelValues(configStatusInvalid, user)
+			am.multitenantMetrics.totalConfigs.DeleteLabelValues(configStatusValid, user)
 			level.Info(am.logger).Log("msg", "deactivated per-tenant alertmanager", "user", user)
 		}
 	}

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -96,10 +96,12 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.Equal(t, simpleConfigOne, currentConfig.RawConfig)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_alertmanager_configs How many configs the multitenant alertmanager knows about.
+		# HELP cortex_alertmanager_configs State of configs the multitenant alertmanager knows about a particular user.
 		# TYPE cortex_alertmanager_configs gauge
-		cortex_alertmanager_configs{status="valid"} 2
-		cortex_alertmanager_configs{status="invalid"} 0
+		cortex_alertmanager_configs{status="valid",user="user1"} 1
+		cortex_alertmanager_configs{status="valid",user="user2"} 1
+		cortex_alertmanager_configs{status="invalid",user="user1" } 0
+		cortex_alertmanager_configs{status="invalid",user="user2" } 0
 	`), "cortex_alertmanager_configs"))
 
 	// Ensure when a 3rd config is added, it is synced correctly
@@ -113,10 +115,14 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.Len(t, am.alertmanagers, 3)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_alertmanager_configs How many configs the multitenant alertmanager knows about.
+		# HELP cortex_alertmanager_configs State of configs the multitenant alertmanager knows about a particular user.
 		# TYPE cortex_alertmanager_configs gauge
-		cortex_alertmanager_configs{status="valid"} 3
-		cortex_alertmanager_configs{status="invalid"} 0
+		cortex_alertmanager_configs{status="valid",user="user1"} 1
+		cortex_alertmanager_configs{status="valid",user="user2"} 1
+		cortex_alertmanager_configs{status="valid",user="user3"} 1
+		cortex_alertmanager_configs{status="invalid",user="user1" } 0
+		cortex_alertmanager_configs{status="invalid",user="user2" } 0
+		cortex_alertmanager_configs{status="invalid",user="user3" } 0
 	`), "cortex_alertmanager_configs"))
 
 	// Ensure the config is updated
@@ -145,10 +151,14 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.False(t, userAM.IsActive())
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_alertmanager_configs How many configs the multitenant alertmanager knows about.
+		# HELP cortex_alertmanager_configs State of configs the multitenant alertmanager knows about a particular user.
 		# TYPE cortex_alertmanager_configs gauge
-		cortex_alertmanager_configs{status="valid"} 2
-		cortex_alertmanager_configs{status="invalid"} 0
+		cortex_alertmanager_configs{status="valid",user="user1"} 1
+		cortex_alertmanager_configs{status="valid",user="user2"} 1
+		cortex_alertmanager_configs{status="valid",user="user3"} 1
+		cortex_alertmanager_configs{status="invalid",user="user1" } 0
+		cortex_alertmanager_configs{status="invalid",user="user2" } 0
+		cortex_alertmanager_configs{status="invalid",user="user3" } 0
 	`), "cortex_alertmanager_configs"))
 
 	// Ensure when a 3rd config is re-added, it is synced correctly
@@ -169,9 +179,13 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.True(t, userAM.IsActive())
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_alertmanager_configs How many configs the multitenant alertmanager knows about.
+		# HELP cortex_alertmanager_configs State of configs the multitenant alertmanager knows about a particular user.
 		# TYPE cortex_alertmanager_configs gauge
-		cortex_alertmanager_configs{status="valid"} 3
-		cortex_alertmanager_configs{status="invalid"} 0
+		cortex_alertmanager_configs{status="valid",user="user1"} 1
+		cortex_alertmanager_configs{status="valid",user="user2"} 1
+		cortex_alertmanager_configs{status="valid",user="user3"} 1
+		cortex_alertmanager_configs{status="invalid",user="user1" } 0
+		cortex_alertmanager_configs{status="invalid",user="user2" } 0
+		cortex_alertmanager_configs{status="invalid",user="user3" } 0
 	`), "cortex_alertmanager_configs"))
 }

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -96,13 +96,11 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.Equal(t, simpleConfigOne, currentConfig.RawConfig)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_alertmanager_configs State of configs the multitenant alertmanager knows about a particular user.
-		# TYPE cortex_alertmanager_configs gauge
-		cortex_alertmanager_configs{status="valid",user="user1"} 1
-		cortex_alertmanager_configs{status="valid",user="user2"} 1
-		cortex_alertmanager_configs{status="invalid",user="user1" } 0
-		cortex_alertmanager_configs{status="invalid",user="user2" } 0
-	`), "cortex_alertmanager_configs"))
+		# HELP cortex_alertmanager_invalid_config Whenever the Alertmanager config is invalid for a user.
+		# TYPE cortex_alertmanager_invalid_config gauge
+		cortex_alertmanager_invalid_config{user="user1"} 0
+		cortex_alertmanager_invalid_config{user="user2"} 0
+	`), "cortex_alertmanager_invalid_config"))
 
 	// Ensure when a 3rd config is added, it is synced correctly
 	mockStore.configs["user3"] = alerts.AlertConfigDesc{
@@ -115,15 +113,12 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.Len(t, am.alertmanagers, 3)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_alertmanager_configs State of configs the multitenant alertmanager knows about a particular user.
-		# TYPE cortex_alertmanager_configs gauge
-		cortex_alertmanager_configs{status="valid",user="user1"} 1
-		cortex_alertmanager_configs{status="valid",user="user2"} 1
-		cortex_alertmanager_configs{status="valid",user="user3"} 1
-		cortex_alertmanager_configs{status="invalid",user="user1" } 0
-		cortex_alertmanager_configs{status="invalid",user="user2" } 0
-		cortex_alertmanager_configs{status="invalid",user="user3" } 0
-	`), "cortex_alertmanager_configs"))
+		# HELP cortex_alertmanager_invalid_config Whenever the Alertmanager config is invalid for a user.
+		# TYPE cortex_alertmanager_invalid_config gauge
+		cortex_alertmanager_invalid_config{user="user1"} 0
+		cortex_alertmanager_invalid_config{user="user2"} 0
+		cortex_alertmanager_invalid_config{user="user3"} 0
+	`), "cortex_alertmanager_invalid_config"))
 
 	// Ensure the config is updated
 	mockStore.configs["user1"] = alerts.AlertConfigDesc{
@@ -151,13 +146,11 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.False(t, userAM.IsActive())
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_alertmanager_configs State of configs the multitenant alertmanager knows about a particular user.
-		# TYPE cortex_alertmanager_configs gauge
-		cortex_alertmanager_configs{status="valid",user="user1"} 1
-		cortex_alertmanager_configs{status="valid",user="user2"} 1
-		cortex_alertmanager_configs{status="invalid",user="user1" } 0
-		cortex_alertmanager_configs{status="invalid",user="user2" } 0
-	`), "cortex_alertmanager_configs"))
+		# HELP cortex_alertmanager_invalid_config Whenever the Alertmanager config is invalid for a user.
+		# TYPE cortex_alertmanager_invalid_config gauge
+		cortex_alertmanager_invalid_config{user="user1"} 0
+		cortex_alertmanager_invalid_config{user="user2"} 0
+	`), "cortex_alertmanager_invalid_config"))
 
 	// Ensure when a 3rd config is re-added, it is synced correctly
 	mockStore.configs["user3"] = alerts.AlertConfigDesc{
@@ -177,13 +170,10 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.True(t, userAM.IsActive())
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_alertmanager_configs State of configs the multitenant alertmanager knows about a particular user.
-		# TYPE cortex_alertmanager_configs gauge
-		cortex_alertmanager_configs{status="valid",user="user1"} 1
-		cortex_alertmanager_configs{status="valid",user="user2"} 1
-		cortex_alertmanager_configs{status="valid",user="user3"} 1
-		cortex_alertmanager_configs{status="invalid",user="user1" } 0
-		cortex_alertmanager_configs{status="invalid",user="user2" } 0
-		cortex_alertmanager_configs{status="invalid",user="user3" } 0
-	`), "cortex_alertmanager_configs"))
+		# HELP cortex_alertmanager_invalid_config Whenever the Alertmanager config is invalid for a user.
+		# TYPE cortex_alertmanager_invalid_config gauge
+		cortex_alertmanager_invalid_config{user="user1"} 0
+		cortex_alertmanager_invalid_config{user="user2"} 0
+		cortex_alertmanager_invalid_config{user="user3"} 0
+	`), "cortex_alertmanager_invalid_config"))
 }

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -155,10 +155,8 @@ func TestLoadAllConfigs(t *testing.T) {
 		# TYPE cortex_alertmanager_configs gauge
 		cortex_alertmanager_configs{status="valid",user="user1"} 1
 		cortex_alertmanager_configs{status="valid",user="user2"} 1
-		cortex_alertmanager_configs{status="valid",user="user3"} 1
 		cortex_alertmanager_configs{status="invalid",user="user1" } 0
 		cortex_alertmanager_configs{status="invalid",user="user2" } 0
-		cortex_alertmanager_configs{status="invalid",user="user3" } 0
 	`), "cortex_alertmanager_configs"))
 
 	// Ensure when a 3rd config is re-added, it is synced correctly

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -96,11 +96,11 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.Equal(t, simpleConfigOne, currentConfig.RawConfig)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_alertmanager_invalid_config Whenever the Alertmanager config is invalid for a user.
-		# TYPE cortex_alertmanager_invalid_config gauge
-		cortex_alertmanager_invalid_config{user="user1"} 0
-		cortex_alertmanager_invalid_config{user="user2"} 0
-	`), "cortex_alertmanager_invalid_config"))
+		# HELP cortex_alertmanager_config_invalid Whenever the Alertmanager config is invalid for a user.
+		# TYPE cortex_alertmanager_config_invalid gauge
+		cortex_alertmanager_config_invalid{user="user1"} 0
+		cortex_alertmanager_config_invalid{user="user2"} 0
+	`), "cortex_alertmanager_config_invalid"))
 
 	// Ensure when a 3rd config is added, it is synced correctly
 	mockStore.configs["user3"] = alerts.AlertConfigDesc{
@@ -113,12 +113,12 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.Len(t, am.alertmanagers, 3)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_alertmanager_invalid_config Whenever the Alertmanager config is invalid for a user.
-		# TYPE cortex_alertmanager_invalid_config gauge
-		cortex_alertmanager_invalid_config{user="user1"} 0
-		cortex_alertmanager_invalid_config{user="user2"} 0
-		cortex_alertmanager_invalid_config{user="user3"} 0
-	`), "cortex_alertmanager_invalid_config"))
+		# HELP cortex_alertmanager_config_invalid Whenever the Alertmanager config is invalid for a user.
+		# TYPE cortex_alertmanager_config_invalid gauge
+		cortex_alertmanager_config_invalid{user="user1"} 0
+		cortex_alertmanager_config_invalid{user="user2"} 0
+		cortex_alertmanager_config_invalid{user="user3"} 0
+	`), "cortex_alertmanager_config_invalid"))
 
 	// Ensure the config is updated
 	mockStore.configs["user1"] = alerts.AlertConfigDesc{
@@ -146,11 +146,11 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.False(t, userAM.IsActive())
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_alertmanager_invalid_config Whenever the Alertmanager config is invalid for a user.
-		# TYPE cortex_alertmanager_invalid_config gauge
-		cortex_alertmanager_invalid_config{user="user1"} 0
-		cortex_alertmanager_invalid_config{user="user2"} 0
-	`), "cortex_alertmanager_invalid_config"))
+		# HELP cortex_alertmanager_config_invalid Whenever the Alertmanager config is invalid for a user.
+		# TYPE cortex_alertmanager_config_invalid gauge
+		cortex_alertmanager_config_invalid{user="user1"} 0
+		cortex_alertmanager_config_invalid{user="user2"} 0
+	`), "cortex_alertmanager_config_invalid"))
 
 	// Ensure when a 3rd config is re-added, it is synced correctly
 	mockStore.configs["user3"] = alerts.AlertConfigDesc{
@@ -170,10 +170,10 @@ func TestLoadAllConfigs(t *testing.T) {
 	require.True(t, userAM.IsActive())
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-		# HELP cortex_alertmanager_invalid_config Whenever the Alertmanager config is invalid for a user.
-		# TYPE cortex_alertmanager_invalid_config gauge
-		cortex_alertmanager_invalid_config{user="user1"} 0
-		cortex_alertmanager_invalid_config{user="user2"} 0
-		cortex_alertmanager_invalid_config{user="user3"} 0
-	`), "cortex_alertmanager_invalid_config"))
+		# HELP cortex_alertmanager_config_invalid Whenever the Alertmanager config is invalid for a user.
+		# TYPE cortex_alertmanager_config_invalid gauge
+		cortex_alertmanager_config_invalid{user="user1"} 0
+		cortex_alertmanager_config_invalid{user="user2"} 0
+		cortex_alertmanager_config_invalid{user="user3"} 0
+	`), "cortex_alertmanager_config_invalid"))
 }


### PR DESCRIPTION
Gives us a way to know whenever a tenant has an invalid configuration in
place.

Signed-off-by: gotjosh <josue@grafana.com>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
