### PR TITLE
Always return a result and result type in QueryRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 * [ENHANCEMENT] Added metrics `cortex_config_hash` and `cortex_runtime_config_hash` to expose hash of the currently active config file. #2874
 * [ENHANCEMENT] Logger: added JSON logging support, configured via the `-log.format=json` CLI flag or its respective YAML config option. #2386
 * [ENHANCEMENT] Clarify limitations of the `/api/v1/series`, `/api/v1/labels` and `/api/v1/label/{name}/values` endpoints. #2953
+* [BUGFIX] Fixed a bug with `api/v1/query_range` where no responses would return null values for `result` and empty values for `resultType`. #2962
 * [BUGFIX] Fixed a bug in the index intersect code causing storage to return more chunks/series than required. #2796
 * [BUGFIX] Fixed the number of reported keys in the background cache queue. #2764
 * [BUGFIX] Fix race in processing of headers in sharded queries. #2762

--- a/pkg/querier/queryrange/query_range.go
+++ b/pkg/querier/queryrange/query_range.go
@@ -133,6 +133,10 @@ func (prometheusCodec) MergeResponse(responses ...Response) (Response, error) {
 	if len(responses) == 0 {
 		return &PrometheusResponse{
 			Status: StatusSuccess,
+			Data: PrometheusData{
+				ResultType: model.ValMatrix.String(),
+				Result:     []SampleStream{},
+			},
 		}, nil
 	}
 

--- a/pkg/querier/queryrange/query_range_test.go
+++ b/pkg/querier/queryrange/query_range_test.go
@@ -113,11 +113,15 @@ func TestMergeAPIResponses(t *testing.T) {
 		input    []Response
 		expected Response
 	}{
-		// No responses shouldn't panic.
+		// No responses shouldn't panic and return a non-empty result and result type.
 		{
 			input: []Response{},
 			expected: &PrometheusResponse{
 				Status: StatusSuccess,
+				Data: PrometheusData{
+					ResultType: matrix,
+					Result:     []SampleStream{},
+				},
 			},
 		},
 

--- a/pkg/querier/queryrange/query_range_test.go
+++ b/pkg/querier/queryrange/query_range_test.go
@@ -113,7 +113,7 @@ func TestMergeAPIResponses(t *testing.T) {
 		input    []Response
 		expected Response
 	}{
-		// No responses shouldn't panic and return a non-empty result and result type.
+		// No responses shouldn't panic and return a non-null result and result type.
 		{
 			input: []Response{},
 			expected: &PrometheusResponse{


### PR DESCRIPTION
**What this PR does**:

Prometheus always returns a result and result type when executing ranged
queries. This was inconsistent in Cortex where no responses would return
`null` for these two values.

https://github.com/prometheus/prometheus/blob/f482c7bdd734ba012f6cedd68ddc24b1416efb35/web/api/v1/api.go#L461-L465

Signed-off-by: gotjosh <josue@grafana.com>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
