### PR TITLE
Ruler TenantManager interface

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -493,7 +493,7 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 			t.Cfg.Ruler,
 			t.Distributor,
 			queryable,
-			ruler.PromDelayedQueryFunc(engine, queryable),
+			engine,
 		),
 		prometheus.DefaultRegisterer,
 		util.Logger,

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -487,7 +487,7 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 	rulerRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "ruler"}, prometheus.DefaultRegisterer)
 	queryable, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, t.TombstonesLoader, rulerRegisterer)
 
-	t.Ruler, err = ruler.NewRuler(t.Cfg.Ruler, engine, queryable, t.Distributor, prometheus.DefaultRegisterer, util.Logger, t.RulerStorage)
+	t.Ruler, err = ruler.NewRuler(t.Cfg.Ruler, ruler.PromDelayedQueryFunc(engine, queryable), ruler.PushLoader(t.Distributor, queryable), prometheus.DefaultRegisterer, util.Logger, t.RulerStorage)
 	if err != nil {
 		return
 	}

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -487,7 +487,18 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 	rulerRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "ruler"}, prometheus.DefaultRegisterer)
 	queryable, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, t.TombstonesLoader, rulerRegisterer)
 
-	t.Ruler, err = ruler.NewRuler(t.Cfg.Ruler, ruler.PromDelayedQueryFunc(engine, queryable), ruler.PushLoader(t.Distributor, queryable), prometheus.DefaultRegisterer, util.Logger, t.RulerStorage)
+	t.Ruler, err = ruler.NewRuler(
+		t.Cfg.Ruler,
+		ruler.DefaultTenantOptions(
+			t.Cfg.Ruler,
+			t.Distributor,
+			queryable,
+			ruler.PromDelayedQueryFunc(engine, queryable),
+		),
+		prometheus.DefaultRegisterer,
+		util.Logger,
+		t.RulerStorage,
+	)
 	if err != nil {
 		return
 	}

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -489,7 +489,7 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 
 	t.Ruler, err = ruler.NewRuler(
 		t.Cfg.Ruler,
-		ruler.DefaultTenantOptions(
+		ruler.DefaultTenantManager(
 			t.Cfg.Ruler,
 			t.Distributor,
 			queryable,

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -489,7 +489,7 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 
 	t.Ruler, err = ruler.NewRuler(
 		t.Cfg.Ruler,
-		ruler.DefaultTenantManager(
+		ruler.DefaultTenantManagerFactory(
 			t.Cfg.Ruler,
 			t.Distributor,
 			queryable,

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -79,8 +79,7 @@ func engineQueryFunc(engine *promql.Engine, q storage.Queryable, delay time.Dura
 	}
 }
 
-// TenantManagerFunc is a function adapter for the TenantManager interface
-type TenantManagerFunc func(
+type ManagerFactory = func(
 	ctx context.Context,
 	userID string,
 	notifier *notifier.Manager,
@@ -88,23 +87,13 @@ type TenantManagerFunc func(
 	reg prometheus.Registerer,
 ) *rules.Manager
 
-func (fn TenantManagerFunc) NewManager(
-	ctx context.Context,
-	userID string,
-	notifier *notifier.Manager,
-	logger log.Logger,
-	reg prometheus.Registerer,
-) *rules.Manager {
-	return fn(ctx, userID, notifier, logger, reg)
-}
-
-func DefaultTenantManager(
+func DefaultTenantManagerFactory(
 	cfg Config,
 	p Pusher,
 	q storage.Queryable,
 	engine *promql.Engine,
-) TenantManagerFunc {
-	return TenantManagerFunc(func(
+) ManagerFactory {
+	return func(
 		ctx context.Context,
 		userID string,
 		notifier *notifier.Manager,
@@ -124,5 +113,5 @@ func DefaultTenantManager(
 			ForGracePeriod:  cfg.ForGracePeriod,
 			ResendDelay:     cfg.ResendDelay,
 		})
-	})
+	}
 }

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -122,7 +122,7 @@ func DefaultTenantManager(
 			QueryFunc:       queryFunc(cfg.EvaluationDelay),
 			Context:         user.InjectOrgID(ctx, userID),
 			ExternalURL:     cfg.ExternalURL.URL,
-			NotifyFunc:      sendAlerts(notifier, cfg.ExternalURL.URL.String()),
+			NotifyFunc:      SendAlerts(notifier, cfg.ExternalURL.URL.String()),
 			Logger:          log.With(logger, "user", userID),
 			Registerer:      reg,
 			OutageTolerance: cfg.OutageTolerance,

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -88,6 +88,7 @@ func (fn StorageLoaderFunc) Load(userID string) (promStorage.Appendable, promSto
 	return fn(userID)
 }
 
+// PushLoader creates a StorageLoader from a Pusher and Queryable
 func PushLoader(p Pusher, q promStorage.Queryable) StorageLoaderFunc {
 	return StorageLoaderFunc(func(userID string) (promStorage.Appendable, promStorage.Queryable) {
 		return &appender{pusher: p, userID: userID}, q

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/notifier"
 	promRules "github.com/prometheus/prometheus/rules"
-	promStorage "github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/strutil"
 	"github.com/weaveworks/common/user"
 	"golang.org/x/net/context/ctxhttp"
@@ -148,11 +147,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.OutageTolerance, "ruler.for-outage-tolerance", time.Hour, `Max time to tolerate outage for restoring "for" state of alert.`)
 	f.DurationVar(&cfg.ForGracePeriod, "ruler.for-grace-period", 10*time.Minute, `Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period.`)
 	f.DurationVar(&cfg.ResendDelay, "ruler.resend-delay", time.Minute, `Minimum amount of time to wait before resending an alert to Alertmanager.`)
-}
-
-// StorageLoader is an interface for loading custom promStorage implementations.
-type StorageLoader interface {
-	Load(userID string) (promStorage.Appendable, promStorage.Queryable)
 }
 
 // Ruler evaluates rules.

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -290,11 +290,11 @@ func (r *Ruler) stopping(_ error) error {
 	return nil
 }
 
-// sendAlerts implements a rules.NotifyFunc for a Notifier.
+// SendAlerts implements a rules.NotifyFunc for a Notifier.
 // It filters any non-firing alerts from the input.
 //
 // Copied from Prometheus's main.go.
-func sendAlerts(n *notifier.Manager, externalURL string) promRules.NotifyFunc {
+func SendAlerts(n *notifier.Manager, externalURL string) promRules.NotifyFunc {
 	return func(ctx context.Context, expr string, alerts ...*promRules.Alert) {
 		var res []*notifier.Alert
 

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -84,7 +84,7 @@ func newRuler(t *testing.T, cfg Config) (*Ruler, func()) {
 	l = level.NewFilter(l, level.AllowInfo())
 	storage, err := NewRuleStorage(cfg.StoreConfig)
 	require.NoError(t, err)
-	ruler, err := NewRuler(cfg, PromDelayedQueryFunc(engine, noopQueryable), noopQueryable, pusher, prometheus.NewRegistry(), l, storage)
+	ruler, err := NewRuler(cfg, PromDelayedQueryFunc(engine, noopQueryable), PushLoader(pusher, noopQueryable), prometheus.NewRegistry(), l, storage)
 	require.NoError(t, err)
 
 	return ruler, cleanup

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -86,7 +86,7 @@ func newRuler(t *testing.T, cfg Config) (*Ruler, func()) {
 	require.NoError(t, err)
 	ruler, err := NewRuler(
 		cfg,
-		DefaultTenantOptions(cfg, pusher, noopQueryable, PromDelayedQueryFunc(engine, noopQueryable)),
+		DefaultTenantManager(cfg, pusher, noopQueryable, PromDelayedQueryFunc(engine, noopQueryable)),
 		prometheus.NewRegistry(),
 		l,
 		storage,

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -86,7 +86,7 @@ func newRuler(t *testing.T, cfg Config) (*Ruler, func()) {
 	require.NoError(t, err)
 	ruler, err := NewRuler(
 		cfg,
-		DefaultTenantManager(cfg, pusher, noopQueryable, PromDelayedQueryFunc(engine, noopQueryable)),
+		DefaultTenantManager(cfg, pusher, noopQueryable, engine),
 		prometheus.NewRegistry(),
 		l,
 		storage,

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -84,7 +84,7 @@ func newRuler(t *testing.T, cfg Config) (*Ruler, func()) {
 	l = level.NewFilter(l, level.AllowInfo())
 	storage, err := NewRuleStorage(cfg.StoreConfig)
 	require.NoError(t, err)
-	ruler, err := NewRuler(cfg, engine, noopQueryable, pusher, prometheus.NewRegistry(), l, storage)
+	ruler, err := NewRuler(cfg, PromDelayedQueryFunc(engine, noopQueryable), noopQueryable, pusher, prometheus.NewRegistry(), l, storage)
 	require.NoError(t, err)
 
 	return ruler, cleanup

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -84,7 +84,13 @@ func newRuler(t *testing.T, cfg Config) (*Ruler, func()) {
 	l = level.NewFilter(l, level.AllowInfo())
 	storage, err := NewRuleStorage(cfg.StoreConfig)
 	require.NoError(t, err)
-	ruler, err := NewRuler(cfg, PromDelayedQueryFunc(engine, noopQueryable), PushLoader(pusher, noopQueryable), prometheus.NewRegistry(), l, storage)
+	ruler, err := NewRuler(
+		cfg,
+		DefaultTenantOptions(cfg, pusher, noopQueryable, PromDelayedQueryFunc(engine, noopQueryable)),
+		prometheus.NewRegistry(),
+		l,
+		storage,
+	)
 	require.NoError(t, err)
 
 	return ruler, cleanup

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -86,7 +86,7 @@ func newRuler(t *testing.T, cfg Config) (*Ruler, func()) {
 	require.NoError(t, err)
 	ruler, err := NewRuler(
 		cfg,
-		DefaultTenantManager(cfg, pusher, noopQueryable, engine),
+		DefaultTenantManagerFactory(cfg, pusher, noopQueryable, engine),
 		prometheus.NewRegistry(),
 		l,
 		storage,


### PR DESCRIPTION
This PR creates a `TenantManager` interface and a default implementation (functionally equivalent to before) which allows different managers to be substituted (i.e. for Loki's ruler).

It also exposes the `SendAlerts` function for reuse in Loki and fixes some confusing naming issues with structs like `appender` which actually implemented `Appendable` and vice versa.

This also enables removing a few fields from the Ruler struct.