### PR TITLE
Be consistent with span logging, set error=true and use otlog.Error

### DIFF
--- a/.errcheck-exclude
+++ b/.errcheck-exclude
@@ -3,3 +3,4 @@ io/ioutil.ReadFile
 (github.com/go-kit/kit/log.Logger).Log
 io.Copy
 (github.com/opentracing/opentracing-go.Tracer).Inject
+(*github.com/cortexproject/cortex/pkg/util/spanlogger.SpanLogger).Error

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -11,13 +11,13 @@ import (
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	opentracing "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	instr "github.com/weaveworks/common/instrument"
 
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
 type observableVecCollector struct {
@@ -146,19 +146,20 @@ func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, b
 
 func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missed []string) {
 	var items map[string]*memcache.Item
-	err := instr.CollectedRequest(ctx, "Memcache.GetMulti", c.requestDuration, memcacheStatusCode, func(innerCtx context.Context) error {
-		sp := opentracing.SpanFromContext(innerCtx)
-		sp.LogFields(otlog.Int("keys requested", len(keys)))
+	method := "Memcache.GetMulti"
+	err := instr.CollectedRequest(ctx, method, c.requestDuration, memcacheStatusCode, func(innerCtx context.Context) error {
+		log, _ := spanlogger.New(innerCtx, method)
+		log.LogFields(otlog.Int("keys requested", len(keys)))
 
 		var err error
 		items, err = c.memcache.GetMulti(keys)
 
-		sp.LogFields(otlog.Int("keys found", len(items)))
+		log.LogFields(otlog.Int("keys found", len(items)))
 
 		// Memcached returns partial results even on error.
 		if err != nil {
-			sp.LogFields(otlog.Error(err))
-			level.Error(c.logger).Log("msg", "Failed to get keys from memcached", "err", err)
+			log.Error(err)
+			level.Error(log).Log("msg", "Failed to get keys from memcached", "err", err)
 		}
 		return err
 	})

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -158,7 +158,7 @@ func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, b
 
 		// Memcached returns partial results even on error.
 		if err != nil {
-			log.Error(err)
+			log.Error(err) //nolint:errcheck
 			level.Error(log).Log("msg", "Failed to get keys from memcached", "err", err)
 		}
 		return err

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -146,7 +146,7 @@ func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, b
 
 func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missed []string) {
 	var items map[string]*memcache.Item
-	method := "Memcache.GetMulti"
+	const method = "Memcache.GetMulti"
 	err := instr.CollectedRequest(ctx, method, c.requestDuration, memcacheStatusCode, func(innerCtx context.Context) error {
 		log, _ := spanlogger.New(innerCtx, method)
 		log.LogFields(otlog.Int("keys requested", len(keys)))

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -158,7 +158,7 @@ func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, b
 
 		// Memcached returns partial results even on error.
 		if err != nil {
-			log.Error(err) //nolint:errcheck
+			log.Error(err)
 			level.Error(log).Log("msg", "Failed to get keys from memcached", "err", err)
 		}
 		return err

--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -358,7 +358,7 @@ func (s *storageClientV1) query(ctx context.Context, query chunk.IndexQuery, cal
 		return true
 	})
 	if err != nil {
-		log.Error(err)
+		log.Error(err) //nolint:errcheck
 		return errors.WithStack(err)
 	}
 	return nil

--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -324,7 +324,7 @@ func (s *storageClientV1) QueryPages(ctx context.Context, queries []chunk.IndexQ
 func (s *storageClientV1) query(ctx context.Context, query chunk.IndexQuery, callback chunk_util.Callback) error {
 	const null = string('\xff')
 
-	log, _ := spanlogger.New(ctx, "QueryPages", ot.Tag{Key: "tableName", Value: query.TableName}, ot.Tag{Key: "hashValue", Value: query.HashValue})
+	log, ctx := spanlogger.New(ctx, "QueryPages", ot.Tag{Key: "tableName", Value: query.TableName}, ot.Tag{Key: "hashValue", Value: query.HashValue})
 	defer log.Finish()
 
 	table := s.client.Open(query.TableName)

--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -13,13 +13,13 @@ import (
 	"cloud.google.com/go/bigtable"
 	"github.com/go-kit/kit/log"
 	ot "github.com/opentracing/opentracing-go"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
 const (
@@ -324,8 +324,8 @@ func (s *storageClientV1) QueryPages(ctx context.Context, queries []chunk.IndexQ
 func (s *storageClientV1) query(ctx context.Context, query chunk.IndexQuery, callback chunk_util.Callback) error {
 	const null = string('\xff')
 
-	sp, ctx := ot.StartSpanFromContext(ctx, "QueryPages", ot.Tag{Key: "tableName", Value: query.TableName}, ot.Tag{Key: "hashValue", Value: query.HashValue})
-	defer sp.Finish()
+	log, _ := spanlogger.New(ctx, "QueryPages", ot.Tag{Key: "tableName", Value: query.TableName}, ot.Tag{Key: "hashValue", Value: query.HashValue})
+	defer log.Finish()
 
 	table := s.client.Open(query.TableName)
 
@@ -358,7 +358,7 @@ func (s *storageClientV1) query(ctx context.Context, query chunk.IndexQuery, cal
 		return true
 	})
 	if err != nil {
-		sp.LogFields(otlog.String("error", err.Error()))
+		log.Error(err)
 		return errors.WithStack(err)
 	}
 	return nil

--- a/pkg/chunk/gcp/bigtable_index_client.go
+++ b/pkg/chunk/gcp/bigtable_index_client.go
@@ -358,7 +358,7 @@ func (s *storageClientV1) query(ctx context.Context, query chunk.IndexQuery, cal
 		return true
 	})
 	if err != nil {
-		log.Error(err) //nolint:errcheck
+		log.Error(err)
 		return errors.WithStack(err)
 	}
 	return nil

--- a/pkg/chunk/util/parallel_chunk_fetch.go
+++ b/pkg/chunk/util/parallel_chunk_fetch.go
@@ -64,7 +64,7 @@ func GetParallelChunks(ctx context.Context, chunks []chunk.Chunk, f func(context
 
 	log.LogFields(otlog.Int("chunks fetched", len(result)))
 	if lastErr != nil {
-		log.Error(lastErr) //nolint:errcheck
+		log.Error(lastErr)
 	}
 
 	// Return any chunks we did receive: a partial result may be useful

--- a/pkg/chunk/util/parallel_chunk_fetch.go
+++ b/pkg/chunk/util/parallel_chunk_fetch.go
@@ -64,7 +64,7 @@ func GetParallelChunks(ctx context.Context, chunks []chunk.Chunk, f func(context
 
 	log.LogFields(otlog.Int("chunks fetched", len(result)))
 	if lastErr != nil {
-		log.Error(lastErr)
+		log.Error(lastErr) //nolint:errcheck
 	}
 
 	// Return any chunks we did receive: a partial result may be useful

--- a/pkg/querier/queryrange/query_range.go
+++ b/pkg/querier/queryrange/query_range.go
@@ -244,7 +244,7 @@ func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ R
 
 	buf, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		log.Error(err) //nolint:errcheck
+		log.Error(err)
 		return nil, httpgrpc.Errorf(http.StatusInternalServerError, "error decoding response: %v", err)
 	}
 

--- a/pkg/querier/queryrange/query_range.go
+++ b/pkg/querier/queryrange/query_range.go
@@ -244,7 +244,7 @@ func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ R
 
 	buf, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		log.Error(err)
+		log.Error(err) //nolint:errcheck
 		return nil, httpgrpc.Errorf(http.StatusInternalServerError, "error decoding response: %v", err)
 	}
 

--- a/pkg/querier/queryrange/query_range.go
+++ b/pkg/querier/queryrange/query_range.go
@@ -239,7 +239,7 @@ func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ R
 		body, _ := ioutil.ReadAll(r.Body)
 		return nil, httpgrpc.Errorf(r.StatusCode, string(body))
 	}
-	log, _ := spanlogger.New(ctx, "ParseQueryRangeResponse")
+	log, ctx := spanlogger.New(ctx, "ParseQueryRangeResponse")
 	defer log.Finish()
 
 	buf, err := ioutil.ReadAll(r.Body)

--- a/pkg/querier/queryrange/query_range.go
+++ b/pkg/querier/queryrange/query_range.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
 // StatusSuccess Prometheus success result.
@@ -238,17 +239,16 @@ func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ R
 		body, _ := ioutil.ReadAll(r.Body)
 		return nil, httpgrpc.Errorf(r.StatusCode, string(body))
 	}
-
-	sp, _ := opentracing.StartSpanFromContext(ctx, "ParseQueryRangeResponse")
-	defer sp.Finish()
+	log, _ := spanlogger.New(ctx, "ParseQueryRangeResponse")
+	defer log.Finish()
 
 	buf, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		sp.LogFields(otlog.Error(err))
+		log.Error(err)
 		return nil, httpgrpc.Errorf(http.StatusInternalServerError, "error decoding response: %v", err)
 	}
 
-	sp.LogFields(otlog.Int("bytes", len(buf)))
+	log.LogFields(otlog.Int("bytes", len(buf)))
 
 	var resp PrometheusResponse
 	if err := json.Unmarshal(buf, &resp); err != nil {

--- a/pkg/querier/queryrange/query_range.go
+++ b/pkg/querier/queryrange/query_range.go
@@ -239,7 +239,7 @@ func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ R
 		body, _ := ioutil.ReadAll(r.Body)
 		return nil, httpgrpc.Errorf(r.StatusCode, string(body))
 	}
-	log, ctx := spanlogger.New(ctx, "ParseQueryRangeResponse")
+	log, ctx := spanlogger.New(ctx, "ParseQueryRangeResponse") //nolint:ineffassign,staticcheck
 	defer log.Finish()
 
 	buf, err := ioutil.ReadAll(r.Body)

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -457,7 +457,7 @@ func (s resultsCache) get(ctx context.Context, key string) ([]Extent, bool) {
 
 	if err := proto.Unmarshal(bufs[0], &resp); err != nil {
 		level.Error(log).Log("msg", "error unmarshalling cached value", "err", err)
-		log.Error(err) //nolint:errcheck
+		log.Error(err)
 		return nil, false
 	}
 

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -450,14 +450,14 @@ func (s resultsCache) get(ctx context.Context, key string) ([]Extent, bool) {
 	}
 
 	var resp CachedResponse
-	sp, _ := opentracing.StartSpanFromContext(ctx, "unmarshal-extent")
-	defer sp.Finish()
+	log, ctx := spanlogger.New(ctx, "unmarshal-extent")
+	defer log.Finish()
 
-	sp.LogFields(otlog.Int("bytes", len(bufs[0])))
+	log.LogFields(otlog.Int("bytes", len(bufs[0])))
 
 	if err := proto.Unmarshal(bufs[0], &resp); err != nil {
-		level.Error(s.logger).Log("msg", "error unmarshalling cached value", "err", err)
-		sp.LogFields(otlog.Error(err))
+		level.Error(log).Log("msg", "error unmarshalling cached value", "err", err)
+		log.Error(err)
 		return nil, false
 	}
 

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -457,7 +457,7 @@ func (s resultsCache) get(ctx context.Context, key string) ([]Extent, bool) {
 
 	if err := proto.Unmarshal(bufs[0], &resp); err != nil {
 		level.Error(log).Log("msg", "error unmarshalling cached value", "err", err)
-		log.Error(err)
+		log.Error(err) //nolint:errcheck
 		return nil, false
 	}
 

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -450,7 +450,7 @@ func (s resultsCache) get(ctx context.Context, key string) ([]Extent, bool) {
 	}
 
 	var resp CachedResponse
-	log, ctx := spanlogger.New(ctx, "unmarshal-extent")
+	log, _ := spanlogger.New(ctx, "unmarshal-extent")
 	defer log.Finish()
 
 	log.LogFields(otlog.Int("bytes", len(bufs[0])))

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -450,7 +450,7 @@ func (s resultsCache) get(ctx context.Context, key string) ([]Extent, bool) {
 	}
 
 	var resp CachedResponse
-	log, _ := spanlogger.New(ctx, "unmarshal-extent")
+	log, ctx := spanlogger.New(ctx, "unmarshal-extent")
 	defer log.Finish()
 
 	log.LogFields(otlog.Int("bytes", len(bufs[0])))

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -450,7 +450,7 @@ func (s resultsCache) get(ctx context.Context, key string) ([]Extent, bool) {
 	}
 
 	var resp CachedResponse
-	log, ctx := spanlogger.New(ctx, "unmarshal-extent")
+	log, ctx := spanlogger.New(ctx, "unmarshal-extent") //nolint:ineffassign,staticcheck
 	defer log.Finish()
 
 	log.LogFields(otlog.Int("bytes", len(bufs[0])))

--- a/pkg/testexporter/correctness/simple.go
+++ b/pkg/testexporter/correctness/simple.go
@@ -170,14 +170,14 @@ func verifySamples(log *spanlogger.SpanLogger, tc Case, pairs []model.SamplePair
 		expectedNumSamples := int(duration / cfg.ScrapeInterval)
 		if !epsilonCorrect(float64(len(pairs)), float64(expectedNumSamples), cfg.samplesEpsilon) {
 			level.Error(log).Log("msg", "wrong number of samples", "expected", expectedNumSamples, "actual", len(pairs))
-			log.Error(fmt.Errorf("wrong value")) //nolint:errcheck
+			log.Error(fmt.Errorf("wrong number of samples")) //nolint:errcheck
 			return false
 		}
 	} else {
 		expectedNumSamples := int(duration / cfg.ScrapeInterval)
 		if math.Abs(float64(expectedNumSamples-len(pairs))) > 2 {
 			level.Error(log).Log("msg", "wrong number of samples", "expected", expectedNumSamples, "actual", len(pairs))
-			log.Error(fmt.Errorf("wrong value")) //nolint:errcheck
+			log.Error(fmt.Errorf("wrong number of samples")) //nolint:errcheck
 			return false
 		}
 	}

--- a/pkg/testexporter/correctness/simple.go
+++ b/pkg/testexporter/correctness/simple.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log/level"
-	otlog "github.com/opentracing/opentracing-go/log"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -161,7 +160,7 @@ func verifySamples(log *spanlogger.SpanLogger, tc Case, pairs []model.SamplePair
 		} else {
 			sampleResult.WithLabelValues(tc.Name(), fail).Inc()
 			level.Error(log).Log("msg", "wrong value", "at", pair.Timestamp, "expected", tc.ExpectedValueAt(pair.Timestamp.Time()), "actual", pair.Value)
-			log.LogFields(otlog.Error(fmt.Errorf("wrong value")))
+			log.Error(fmt.Errorf("wrong value"))
 			return false
 		}
 	}
@@ -171,14 +170,14 @@ func verifySamples(log *spanlogger.SpanLogger, tc Case, pairs []model.SamplePair
 		expectedNumSamples := int(duration / cfg.ScrapeInterval)
 		if !epsilonCorrect(float64(len(pairs)), float64(expectedNumSamples), cfg.samplesEpsilon) {
 			level.Error(log).Log("msg", "wrong number of samples", "expected", expectedNumSamples, "actual", len(pairs))
-			log.LogFields(otlog.Error(fmt.Errorf("wrong number of samples")))
+			log.Error(fmt.Errorf("wrong value"))
 			return false
 		}
 	} else {
 		expectedNumSamples := int(duration / cfg.ScrapeInterval)
 		if math.Abs(float64(expectedNumSamples-len(pairs))) > 2 {
 			level.Error(log).Log("msg", "wrong number of samples", "expected", expectedNumSamples, "actual", len(pairs))
-			log.LogFields(otlog.Error(fmt.Errorf("wrong number of samples")))
+			log.Error(fmt.Errorf("wrong value"))
 			return false
 		}
 	}

--- a/pkg/testexporter/correctness/simple.go
+++ b/pkg/testexporter/correctness/simple.go
@@ -160,7 +160,7 @@ func verifySamples(log *spanlogger.SpanLogger, tc Case, pairs []model.SamplePair
 		} else {
 			sampleResult.WithLabelValues(tc.Name(), fail).Inc()
 			level.Error(log).Log("msg", "wrong value", "at", pair.Timestamp, "expected", tc.ExpectedValueAt(pair.Timestamp.Time()), "actual", pair.Value)
-			log.Error(fmt.Errorf("wrong value"))
+			log.Error(fmt.Errorf("wrong value")) //nolint:errcheck
 			return false
 		}
 	}
@@ -170,14 +170,14 @@ func verifySamples(log *spanlogger.SpanLogger, tc Case, pairs []model.SamplePair
 		expectedNumSamples := int(duration / cfg.ScrapeInterval)
 		if !epsilonCorrect(float64(len(pairs)), float64(expectedNumSamples), cfg.samplesEpsilon) {
 			level.Error(log).Log("msg", "wrong number of samples", "expected", expectedNumSamples, "actual", len(pairs))
-			log.Error(fmt.Errorf("wrong value"))
+			log.Error(fmt.Errorf("wrong value")) //nolint:errcheck
 			return false
 		}
 	} else {
 		expectedNumSamples := int(duration / cfg.ScrapeInterval)
 		if math.Abs(float64(expectedNumSamples-len(pairs))) > 2 {
 			level.Error(log).Log("msg", "wrong number of samples", "expected", expectedNumSamples, "actual", len(pairs))
-			log.Error(fmt.Errorf("wrong value"))
+			log.Error(fmt.Errorf("wrong value")) //nolint:errcheck
 			return false
 		}
 	}

--- a/pkg/testexporter/correctness/simple.go
+++ b/pkg/testexporter/correctness/simple.go
@@ -160,7 +160,7 @@ func verifySamples(log *spanlogger.SpanLogger, tc Case, pairs []model.SamplePair
 		} else {
 			sampleResult.WithLabelValues(tc.Name(), fail).Inc()
 			level.Error(log).Log("msg", "wrong value", "at", pair.Timestamp, "expected", tc.ExpectedValueAt(pair.Timestamp.Time()), "actual", pair.Value)
-			log.Error(fmt.Errorf("wrong value")) //nolint:errcheck
+			log.Error(fmt.Errorf("wrong value"))
 			return false
 		}
 	}
@@ -170,14 +170,14 @@ func verifySamples(log *spanlogger.SpanLogger, tc Case, pairs []model.SamplePair
 		expectedNumSamples := int(duration / cfg.ScrapeInterval)
 		if !epsilonCorrect(float64(len(pairs)), float64(expectedNumSamples), cfg.samplesEpsilon) {
 			level.Error(log).Log("msg", "wrong number of samples", "expected", expectedNumSamples, "actual", len(pairs))
-			log.Error(fmt.Errorf("wrong number of samples")) //nolint:errcheck
+			log.Error(fmt.Errorf("wrong number of samples"))
 			return false
 		}
 	} else {
 		expectedNumSamples := int(duration / cfg.ScrapeInterval)
 		if math.Abs(float64(expectedNumSamples-len(pairs))) > 2 {
 			level.Error(log).Log("msg", "wrong number of samples", "expected", expectedNumSamples, "actual", len(pairs))
-			log.Error(fmt.Errorf("wrong number of samples")) //nolint:errcheck
+			log.Error(fmt.Errorf("wrong number of samples"))
 			return false
 		}
 	}

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -59,7 +59,7 @@ func (s *SpanLogger) Log(kvps ...interface{}) error {
 	return nil
 }
 
-// Error sets error flag and logs the error, if non-nil.  Returns the err passed in.
+// Error sets error flag and logs the error on the span, if non-nil.  Returns the err passed in.
 func (s *SpanLogger) Error(err error) error {
 	if err == nil {
 		return nil


### PR DESCRIPTION
It's very confusing to look at a trace UI for two traces that seemed to have failed for the same reason, yet one has error ! icons and the other doesn't. This seems to be a side effect of not setting `error=true` on all error cases, and one case where we had `error="a string"`.

There's also a change required in upstream weaveworks/common to add another `error=true`

Signed-off-by: Callum Styan <callumstyan@gmail.com>

cc @gouthamve @gotjosh @joe-elliott 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
