### PR TITLE
Always query series and labels from TSDB head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 * [BUGFIX] Fixed ruler and store-gateway instance registration in the ring (when sharding is enabled) when a new instance replaces abruptly terminated one, and the only difference between the two instances is the address. #2954
 * [BUGFIX] Fixed `Missing chunks and index config causing silent failure` Absence of chunks and index from schema config is not validated. #2732
 * [BUGFIX] Fix panic caused by KVs from boltdb being used beyond their life. #2971
+* [BUGFIX] Experimental TSDB: `/api/v1/series`, `/api/v1/labels` and `/api/v1/label/{name}/values` only query the TSDB head regardless of the configured `-experimental.blocks-storage.tsdb.retention-period`. #2974
 
 ## 1.2.0 / 2020-07-01
 


### PR DESCRIPTION
**What this PR does**:
Yesterday we had an outage in our staging environment running the blocks storage, caused by all ingesters going OOM while concurrently running several heavy `/api/v1/series` queries.

The problem is that we run ingesters with a TSDB retention of 4 days and we ignore the query time range when handling "metadata" API requests (series and labels). In this PR I'm proposing to mitigate the issue forcing the time range to the TSDB head only, regardless of the TSDB retention (which could be several days). The new logic in this PR is conceptually similar to the Cortex chunks storage, where we do query only in-memory series.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
