### PR TITLE
Optimised /api/v1/series for blocks storage

### DIFF
--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -674,7 +674,7 @@ func (i *Ingester) v2MetricsForLabelMatchers(ctx context.Context, req *client.Me
 			return nil, ctx.Err()
 		}
 
-		seriesSet := q.Select(false, nil, matchers...)
+		seriesSet := q.Select(true, nil, matchers...)
 		sets = append(sets, seriesSet)
 	}
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -665,11 +665,8 @@ func (i *Ingester) v2MetricsForLabelMatchers(ctx context.Context, req *client.Me
 	}
 	defer q.Close()
 
-	// Run a query for each matchers set and collect all the results
-	added := map[string]struct{}{}
-	result := &client.MetricsForLabelMatchersResponse{
-		Metric: make([]*client.Metric, 0),
-	}
+	// Run a query for each matchers set and collect all the results.
+	var sets []storage.SeriesSet
 
 	for _, matchers := range matchersSet {
 		// Interrupt if the context has been canceled.
@@ -678,37 +675,24 @@ func (i *Ingester) v2MetricsForLabelMatchers(ctx context.Context, req *client.Me
 		}
 
 		seriesSet := q.Select(false, nil, matchers...)
-		if seriesSet.Err() != nil {
-			return nil, seriesSet.Err()
+		sets = append(sets, seriesSet)
+	}
+
+	// Generate the response merging all series sets.
+	result := &client.MetricsForLabelMatchersResponse{
+		Metric: make([]*client.Metric, 0),
+	}
+
+	mergedSet := storage.NewMergeSeriesSet(sets, storage.ChainedSeriesMerge)
+	for mergedSet.Next() {
+		// Interrupt if the context has been canceled.
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
 		}
 
-		for seriesSet.Next() {
-			// Interrupt if the context has been canceled.
-			if ctx.Err() != nil {
-				return nil, ctx.Err()
-			}
-
-			// Given the same series can be matched by multiple matchers and we want to
-			// return the unique set of matching series, we do check if the series has
-			// already been added to the result
-			ls := seriesSet.At().Labels()
-			key := ls.String()
-			if _, ok := added[key]; ok {
-				continue
-			}
-
-			result.Metric = append(result.Metric, &client.Metric{
-				Labels: client.FromLabelsToLabelAdapters(ls),
-			})
-
-			added[key] = struct{}{}
-		}
-
-		// In case of any error while iterating the series, we break
-		// the execution and return it
-		if err := seriesSet.Err(); err != nil {
-			return nil, err
-		}
+		result.Metric = append(result.Metric, &client.Metric{
+			Labels: client.FromLabelsToLabelAdapters(mergedSet.At().Labels()),
+		})
 	}
 
 	return result, nil

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -1042,31 +1042,86 @@ func Test_Ingester_v2MetricsForLabelMatchers(t *testing.T) {
 	}
 }
 
+func Test_Ingester_v2MetricsForLabelMatchers_Deduplication(t *testing.T) {
+	const (
+		userID    = "test"
+		numSeries = 100000
+	)
+
+	now := util.TimeToMillis(time.Now())
+	i := createIngesterWithSeries(t, userID, numSeries, now)
+	ctx := user.InjectOrgID(context.Background(), "test")
+
+	req := &client.MetricsForLabelMatchersRequest{
+		StartTimestampMs: now,
+		EndTimestampMs:   now,
+		// Overlapping matchers to make sure series are correctly deduplicated.
+		MatchersSet: []*client.LabelMatchers{
+			{Matchers: []*client.LabelMatcher{
+				{Type: client.REGEX_MATCH, Name: model.MetricNameLabel, Value: "test.*"},
+			}},
+			{Matchers: []*client.LabelMatcher{
+				{Type: client.REGEX_MATCH, Name: model.MetricNameLabel, Value: "test.*0"},
+			}},
+		},
+	}
+
+	res, err := i.v2MetricsForLabelMatchers(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, res.GetMetric(), numSeries)
+}
+
 func Benchmark_Ingester_v2MetricsForLabelMatchers(b *testing.B) {
 	const (
-		numSeries    = 100000
-		maxBatchSize = 1000
+		userID    = "test"
+		numSeries = 100000
 	)
+
+	now := util.TimeToMillis(time.Now())
+	i := createIngesterWithSeries(b, userID, numSeries, now)
+	ctx := user.InjectOrgID(context.Background(), "test")
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		req := &client.MetricsForLabelMatchersRequest{
+			StartTimestampMs: now,
+			EndTimestampMs:   now,
+			MatchersSet: []*client.LabelMatchers{{Matchers: []*client.LabelMatcher{
+				{Type: client.REGEX_MATCH, Name: model.MetricNameLabel, Value: "test.*"},
+			}}},
+		}
+
+		res, err := i.v2MetricsForLabelMatchers(ctx, req)
+		require.NoError(b, err)
+		require.Len(b, res.GetMetric(), numSeries)
+	}
+}
+
+// createIngesterWithSeries creates an ingester and push numSeries with 1 sample
+// per series.
+func createIngesterWithSeries(t testing.TB, userID string, numSeries int, timestamp int64) *Ingester {
+	const maxBatchSize = 1000
 
 	// Create ingester.
 	i, cleanup, err := newIngesterMockWithTSDBStorage(defaultIngesterTestConfig(), nil)
-	require.NoError(b, err)
-	require.NoError(b, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
-	defer cleanup()
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), i))
+		cleanup()
+	})
 
 	// Wait until it's ACTIVE.
-	test.Poll(b, 1*time.Second, ring.ACTIVE, func() interface{} {
+	test.Poll(t, 1*time.Second, ring.ACTIVE, func() interface{} {
 		return i.lifecycler.GetState()
 	})
 
 	// Push fixtures.
-	ctx := user.InjectOrgID(context.Background(), "test")
-	now := util.TimeToMillis(time.Now())
+	ctx := user.InjectOrgID(context.Background(), userID)
 
 	for o := 0; o < numSeries; o += maxBatchSize {
 		batchSize := util.Min(maxBatchSize, numSeries-o)
-		timestamp := now + int64(o/maxBatchSize)
 
 		// Generate metrics and samples (1 for each series).
 		metrics := make([]labels.Labels, 0, batchSize)
@@ -1086,24 +1141,10 @@ func Benchmark_Ingester_v2MetricsForLabelMatchers(b *testing.B) {
 		// Send metrics to the ingester.
 		req := client.ToWriteRequest(metrics, samples, nil, client.API)
 		_, err := i.v2Push(ctx, req)
-		require.NoError(b, err)
+		require.NoError(t, err)
 	}
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
-		req := &client.MetricsForLabelMatchersRequest{
-			StartTimestampMs: now,
-			EndTimestampMs:   now,
-			MatchersSet: []*client.LabelMatchers{{Matchers: []*client.LabelMatcher{
-				{Type: client.REGEX_MATCH, Name: model.MetricNameLabel, Value: "test.*"},
-			}}},
-		}
-
-		res, err := i.v2MetricsForLabelMatchers(ctx, req)
-		require.NoError(b, err)
-		require.Len(b, res.GetMetric(), numSeries)
-	}
+	return i
 }
 
 func TestIngester_v2QueryStream(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
While working on #2794, I've compared our implementation to fetch series with Prometheus one and I've noticed Prometheus is easier. I've done the refactoring and written and benchmark and turned out it performs better too.

```
benchmark                                           old ns/op     new ns/op     delta
Benchmark_Ingester_v2MetricsForLabelMatchers-12     250057594     226011946     -9.62%

benchmark                                           old allocs     new allocs     delta
Benchmark_Ingester_v2MetricsForLabelMatchers-12     1104071        800196         -27.52%

benchmark                                           old bytes     new bytes     delta
Benchmark_Ingester_v2MetricsForLabelMatchers-12     62724828      51382654      -18.08%
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
