### PR TITLE
Exclude packaging images from CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 
 # We don't want find to scan inside a bunch of directories, to accelerate the
 # 'make: Entering directory '/go/src/github.com/cortexproject/cortex' phase.
-DONT_FIND := -name tools -prune -o -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune -o
+DONT_FIND := -name tools -prune -o -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune -o -name packaging -prune -o
 
 # Get a list of directories containing Dockerfiles
 DOCKERFILES := $(shell find . $(DONT_FIND) -type f -name 'Dockerfile' -print)


### PR DESCRIPTION
**What this PR does**:
This morning I've merged https://github.com/cortexproject/cortex/pull/2838 which breaks the CI when running in master because it also tries to publish the Docker images used to test the rpm/deb packaging. In this PR I'm excluding them.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
