### PR TITLE
Generate sha256 for .rpm and .deb packages too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,10 +239,10 @@ dist dist/cortex-linux-amd64 dist/cortex-darwin-amd64 dist/query-tee-linux-amd64
 	GOOS="darwin" GOARCH="amd64" CGO_ENABLED=0 go build $(GO_FLAGS) -o ./dist/cortex-darwin-amd64  ./cmd/cortex
 	GOOS="linux"  GOARCH="amd64" CGO_ENABLED=0 go build $(GO_FLAGS) -o ./dist/query-tee-linux-amd64   ./cmd/query-tee
 	GOOS="darwin" GOARCH="amd64" CGO_ENABLED=0 go build $(GO_FLAGS) -o ./dist/query-tee-darwin-amd64  ./cmd/query-tee
-	shasum -a 256 ./dist/cortex-darwin-amd64 | cut -d ' ' -f 1 > ./dist/cortex-darwin-amd64-sha-256
-	shasum -a 256 ./dist/cortex-linux-amd64  | cut -d ' ' -f 1 > ./dist/cortex-linux-amd64-sha-256
-	shasum -a 256 ./dist/query-tee-darwin-amd64 | cut -d ' ' -f 1 > ./dist/query-tee-darwin-amd64-sha-256
-	shasum -a 256 ./dist/query-tee-linux-amd64  | cut -d ' ' -f 1 > ./dist/query-tee-linux-amd64-sha-256
+	sha256sum ./dist/cortex-darwin-amd64 | cut -d ' ' -f 1 > ./dist/cortex-darwin-amd64-sha-256
+	sha256sum ./dist/cortex-linux-amd64  | cut -d ' ' -f 1 > ./dist/cortex-linux-amd64-sha-256
+	sha256sum ./dist/query-tee-darwin-amd64 | cut -d ' ' -f 1 > ./dist/query-tee-darwin-amd64-sha-256
+	sha256sum ./dist/query-tee-linux-amd64  | cut -d ' ' -f 1 > ./dist/query-tee-linux-amd64-sha-256
 
 # Generate packages for a Cortex release.
 FPM_OPTS := fpm -s dir -v $(VERSION) -n cortex -f \
@@ -277,6 +277,7 @@ dist/%.deb: dist/cortex-linux-amd64 $(wildcard packaging/deb/**)
 		--package $@ $(FPM_ARGS) \
 		packaging/deb/default/cortex=/etc/default/cortex \
 		packaging/deb/systemd/cortex.service=/etc/systemd/system/cortex.service
+	sha256sum ./dist/cortex-$(VERSION).deb | cut -d ' ' -f 1 > ./dist/cortex-$(VERSION).deb-sha-256
 
 dist/%.rpm: dist/cortex-linux-amd64 $(wildcard packaging/rpm/**)
 	$(FPM_OPTS) -t rpm  \
@@ -285,6 +286,7 @@ dist/%.rpm: dist/cortex-linux-amd64 $(wildcard packaging/rpm/**)
 		--package $@ $(FPM_ARGS) \
 		packaging/rpm/sysconfig/cortex=/etc/sysconfig/cortex \
 		packaging/rpm/systemd/cortex.service=/etc/systemd/system/cortex.service
+	sha256sum ./dist/cortex-$(VERSION).rpm | cut -d ' ' -f 1 > ./dist/cortex-$(VERSION).rpm-sha-256
 endif
 
 .PHONY: test-packages


### PR DESCRIPTION
**What this PR does**:
Originated from a need during the `1.3.0-rc.0` release, in this PR I'm adding the sha256 hash generation for .rpm and .deb packages too. I've switched to `sha256sum` which works on Linux and can be installed on OSX via `brew install coreutils`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
