### PR TITLE
Fixed query start/end timestamp rounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
 
 ## 1.3.0 in progress
 

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -112,9 +112,19 @@ func (c *Client) Push(timeseries []prompb.TimeSeries) (*http.Response, error) {
 	return res, nil
 }
 
-// Query runs a query
+// Query runs an instant query.
 func (c *Client) Query(query string, ts time.Time) (model.Value, error) {
 	value, _, err := c.querierClient.Query(context.Background(), query, ts)
+	return value, err
+}
+
+// Query runs a query range.
+func (c *Client) QueryRange(query string, start, end time.Time, step time.Duration) (model.Value, error) {
+	value, _, err := c.querierClient.QueryRange(context.Background(), query, promv1.Range{
+		Start: start,
+		End:   end,
+		Step:  step,
+	})
 	return value, err
 }
 

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -196,7 +196,7 @@ func runQueryFrontendTest(t *testing.T, testMissingMetricName bool, setup queryF
 			require.Len(t, matrix, 1)
 			require.Len(t, matrix[0].Values, 3)
 			assert.Equal(t, model.Time(1595846748806), matrix[0].Values[0].Timestamp)
-			assert.Equal(t, model.Time(1595846750806), matrix[2].Values[0].Timestamp)
+			assert.Equal(t, model.Time(1595846750806), matrix[0].Values[2].Timestamp)
 		}
 
 		for q := 0; q < numQueriesPerUser; q++ {

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -175,12 +175,28 @@ func runQueryFrontendTest(t *testing.T, testMissingMetricName bool, setup queryF
 		c, err := e2ecortex.NewClient("", queryFrontend.HTTPEndpoint(), "", "", fmt.Sprintf("user-%d", userID))
 		require.NoError(t, err)
 
-		// No need to repeat this test for each user.
+		// No need to repeat the test on missing metric name for each user.
 		if userID == 0 && testMissingMetricName {
 			res, body, err := c.QueryRaw("{instance=~\"hello.*\"}")
 			require.NoError(t, err)
 			require.Equal(t, 422, res.StatusCode)
 			require.Contains(t, string(body), "query must contain metric name")
+		}
+
+		// No need to repeat the test on start/end time rounding for each user.
+		if userID == 0 {
+			start := time.Unix(1595846748, 806*1e6)
+			end := time.Unix(1595846750, 806*1e6)
+
+			result, err := c.QueryRange("time()", start, end, time.Second)
+			require.NoError(t, err)
+			require.Equal(t, model.ValMatrix, result.Type())
+
+			matrix := result.(model.Matrix)
+			require.Len(t, matrix, 1)
+			require.Len(t, matrix[0].Values, 3)
+			assert.Equal(t, model.Time(1595846748806), matrix[0].Values[0].Timestamp)
+			assert.Equal(t, model.Time(1595846750806), matrix[2].Values[0].Timestamp)
 		}
 
 		for q := 0; q < numQueriesPerUser; q++ {
@@ -197,9 +213,9 @@ func runQueryFrontendTest(t *testing.T, testMissingMetricName bool, setup queryF
 
 	wg.Wait()
 
-	extra := float64(0)
+	extra := float64(1)
 	if testMissingMetricName {
-		extra = 1
+		extra += 1
 	}
 	require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(numUsers*numQueriesPerUser+extra), "cortex_query_frontend_queries_total"))
 

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -215,7 +215,7 @@ func runQueryFrontendTest(t *testing.T, testMissingMetricName bool, setup queryF
 
 	extra := float64(1)
 	if testMissingMetricName {
-		extra += 1
+		extra++
 	}
 	require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(numUsers*numQueriesPerUser+extra), "cortex_query_frontend_queries_total"))
 

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -27,6 +27,7 @@ func TimeFromMillis(ms int64) time.Time {
 func ParseTime(s string) (int64, error) {
 	if t, err := strconv.ParseFloat(s, 64); err == nil {
 		s, ns := math.Modf(t)
+		ns = math.Round(ns*1000) / 1000
 		tm := time.Unix(int64(s), int64(ns*float64(time.Second)))
 		return TimeToMillis(tm), nil
 	}

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -38,3 +38,52 @@ func TestDurationWithJitter(t *testing.T) {
 func TestDurationWithJitter_ZeroInputDuration(t *testing.T) {
 	assert.Equal(t, time.Duration(0), DurationWithJitter(time.Duration(0), 0.5))
 }
+
+func TestParseTime(t *testing.T) {
+	ts, err := time.Parse(time.RFC3339Nano, "2015-06-03T13:21:58.555Z")
+	require.NoError(t, err)
+
+	var tests = []struct {
+		input  string
+		fail   bool
+		result time.Time
+	}{
+		{
+			input: "",
+			fail:  true,
+		}, {
+			input: "abc",
+			fail:  true,
+		}, {
+			input: "30s",
+			fail:  true,
+		}, {
+			input:  "123",
+			result: time.Unix(123, 0),
+		}, {
+			input:  "123.123",
+			result: time.Unix(123, 123000000),
+		}, {
+			input:  "2015-06-03T13:21:58.555Z",
+			result: ts,
+		}, {
+			input:  "2015-06-03T14:21:58.555+01:00",
+			result: ts,
+		}, {
+			// Test float rounding.
+			input:  "1543578564.705",
+			result: time.Unix(1543578564, 705*1e6),
+		},
+	}
+
+	for _, test := range tests {
+		ts, err := ParseTime(test.input)
+		if test.fail {
+			require.Error(t, err)
+			continue
+		}
+
+		require.NoError(t, err)
+		assert.Equal(t, TimeToMillis(test.result), ts)
+	}
+}

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -40,9 +40,6 @@ func TestDurationWithJitter_ZeroInputDuration(t *testing.T) {
 }
 
 func TestParseTime(t *testing.T) {
-	ts, err := time.Parse(time.RFC3339Nano, "2015-06-03T13:21:58.555Z")
-	require.NoError(t, err)
-
 	var tests = []struct {
 		input  string
 		fail   bool
@@ -65,10 +62,14 @@ func TestParseTime(t *testing.T) {
 			result: time.Unix(123, 123000000),
 		}, {
 			input:  "2015-06-03T13:21:58.555Z",
-			result: ts,
+			result: time.Unix(1433337718, 555*time.Millisecond.Nanoseconds()),
 		}, {
 			input:  "2015-06-03T14:21:58.555+01:00",
-			result: ts,
+			result: time.Unix(1433337718, 555*time.Millisecond.Nanoseconds()),
+		}, {
+			// Test nanosecond rounding.
+			input:  "2015-06-03T13:21:58.56789Z",
+			result: time.Unix(1433337718, 567*1e6),
 		}, {
 			// Test float rounding.
 			input:  "1543578564.705",


### PR DESCRIPTION
**What this PR does**:
The good @juliusv reported we're not rounding query start/end timestamps like Prometheus. This PR fixes it, specifically introduces the change done in Prometheus almost 3y ago https://github.com/prometheus/prometheus/pull/4941.

**Which issue(s) this PR fixes**:
Fixes #2932

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
