### PR TITLE
Add a log if the initial blocks scan fail in the querier

### DIFF
--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -146,7 +146,12 @@ func (d *BlocksScanner) GetBlocks(userID string, minT, maxT int64) ([]*BlockMeta
 func (d *BlocksScanner) starting(ctx context.Context) error {
 	// Before the service is in the running state it must have successfully
 	// complete the initial scan.
-	return d.scanBucket(ctx)
+	if err := d.scanBucket(ctx); err != nil {
+		level.Error(d.logger).Log("msg", "unable to run the initial blocks scan", "err", err)
+		return err
+	}
+
+	return nil
 }
 
 func (d *BlocksScanner) scan(ctx context.Context) error {


### PR DESCRIPTION
**What this PR does**:
If the initial blocks scan fail, no specific log is logged, while the operator gets a very generic log message:
```
level=error ts=2020-08-06T20:23:30.893013454Z caller=cortex.go:319 msg="module failed" module=querier err="failed to start querier, because it depends on module store-queryable, which has failed: invalid service state: Failed, expected: Running, failure: invalid service state: Failed, expected: Running, failure: unable to start blocks storage queryable subservices: not healthy"
```

In this PR I log the error that could occur while starting the `BlocksScanner`.

**Which issue(s) this PR fixes**:
Fixes #2991

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
