### PR TITLE
change: increase default cassandra RF to 3 and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Increase the default Cassandra client replication factor to 3. #3007
 * [CHANGE] Experimental blocks storage: removed the support to transfer blocks between ingesters on shutdown. When running the Cortex blocks storage, ingesters are expected to run with a persistent disk. The following metrics have been removed: #2996
   * `cortex_ingester_sent_files`
   * `cortex_ingester_received_files`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1861,7 +1861,7 @@ cassandra:
 
   # Replication factor to use in Cassandra.
   # CLI flag: -cassandra.replication-factor
-  [replication_factor: <int> | default = 1]
+  [replication_factor: <int> | default = 3]
 
   # Instruct the cassandra driver to not attempt to get host info from the
   # system.peers table.

--- a/integration/chunks_delete_series_test.go
+++ b/integration/chunks_delete_series_test.go
@@ -44,10 +44,11 @@ func TestDeleteSeriesAllIndexBackends(t *testing.T) {
 	}
 
 	flags := mergeFlags(ChunksStorageFlags, map[string]string{
-		"-cassandra.addresses": cassandra.NetworkHTTPEndpoint(),
-		"-cassandra.keyspace":  "tests", // keyspace gets created on startup if it does not exist
-		"-purger.enable":       "true",
-		"-deletes.store":       "bigtable",
+		"-cassandra.addresses":          cassandra.NetworkHTTPEndpoint(),
+		"-cassandra.keyspace":           "tests", // keyspace gets created on startup if it does not exist
+		"-cassandra.replication-factor": "1",
+		"-purger.enable":                "true",
+		"-deletes.store":                "bigtable",
 	})
 
 	// bigtable client needs to set an environment variable when connecting to an emulator.

--- a/integration/chunks_storage_backends_test.go
+++ b/integration/chunks_storage_backends_test.go
@@ -61,8 +61,9 @@ func TestChunksStorageAllIndexBackends(t *testing.T) {
 	}
 
 	storageFlags := mergeFlags(ChunksStorageFlags, map[string]string{
-		"-cassandra.addresses": cassandra.NetworkHTTPEndpoint(),
-		"-cassandra.keyspace":  "tests", // keyspace gets created on startup if it does not exist
+		"-cassandra.addresses":          cassandra.NetworkHTTPEndpoint(),
+		"-cassandra.keyspace":           "tests", // keyspace gets created on startup if it does not exist
+		"-cassandra.replication-factor": "1",
 	})
 
 	// bigtable client needs to set an environment variable when connecting to an emulator

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -57,7 +57,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.Port, "cassandra.port", 9042, "Port that Cassandra is running on")
 	f.StringVar(&cfg.Keyspace, "cassandra.keyspace", "", "Keyspace to use in Cassandra.")
 	f.StringVar(&cfg.Consistency, "cassandra.consistency", "QUORUM", "Consistency level for Cassandra.")
-	f.IntVar(&cfg.ReplicationFactor, "cassandra.replication-factor", 1, "Replication factor to use in Cassandra.")
+	f.IntVar(&cfg.ReplicationFactor, "cassandra.replication-factor", 3, "Replication factor to use in Cassandra.")
 	f.BoolVar(&cfg.DisableInitialHostLookup, "cassandra.disable-initial-host-lookup", false, "Instruct the cassandra driver to not attempt to get host info from the system.peers table.")
 	f.BoolVar(&cfg.SSL, "cassandra.ssl", false, "Use SSL when connecting to cassandra instances.")
 	f.BoolVar(&cfg.HostVerification, "cassandra.host-verification", true, "Require SSL certificate validation.")


### PR DESCRIPTION
**What this PR does**:

- Increase the default Cassandra replication factor to 3

**Which issue(s) this PR fixes**:
Fixes #2993 

**Checklist**
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
