### PR TITLE
Batch series in streaming ingester based on message sizes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [ENHANCMENT] Expose `storage.aws.dynamodb.backoff_config` configuration file field. #3026
 * [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
 * [BUGFIX] Querier: query /series from ingesters regardless the `-querier.query-ingesters-within` setting. #3035
-* [BUGFIX] Experimental blocks storage: Ingester is less likely to hit gRPC message size limit when streaming data to queriers. #3015 
+* [BUGFIX] Experimental blocks storage: Ingester is less likely to hit gRPC message size limit when streaming data to queriers. #3015
 
 ## 1.3.0 in progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [ENHANCMENT] Expose `storage.aws.dynamodb.backoff_config` configuration file field. #3026
 * [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
 * [BUGFIX] Querier: query /series from ingesters regardless the `-querier.query-ingesters-within` setting. #3035
+* [BUGFIX] Experimental blocks storage: Ingester is less likely to hit gRPC message size limit when streaming data to queriers. #3015 
 
 ## 1.3.0 in progress
 


### PR DESCRIPTION
**What this PR does**: This PR modifies batching in blocks-based ingester, when it is streaming results back. Instead of using only number of series for batching, it also considers how much data is buffered in memory, and flushes batch if it get too big. This is to prevent problems with too large gRPC messages. "Too big" is hardcoded to 1 MiB, to comfortably fit into grpc default, and also to avoid using too much memory.

Note that if *single* series returns too much data, it can still reach gRPC limit for sending messages. Solution to that would be splitting single timeseries into multiple messages, but querier doesn't support that at the moment.

**Which issue(s) this PR fixes**:
Fixes #2945 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
