### PR TITLE
Fixes the Alertmanager panicking when no external URL is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@
 * [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
 * [BUGFIX] Querier: query /series from ingesters regardless the `-querier.query-ingesters-within` setting. #3035
 * [BUGFIX] Experimental blocks storage: Ingester is less likely to hit gRPC message size limit when streaming data to queriers. #3015
-* [BUGFIX] Fixes the Alertmanager panicking when no `alertmanager.web.external-url` is provided. #3017
 * [BUGFIX] Fix configuration for TLS server validation, TLS skip verify was hardcoded to true for all TLS configurations and prevented validation of server certificates. #3030
+* [BUGFIX] Fixes the Alertmanager panicking when no `-alertmanager.web.external-url` is provided. #3017
 
 ## 1.3.0 in progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
 * [BUGFIX] Querier: query /series from ingesters regardless the `-querier.query-ingesters-within` setting. #3035
 * [BUGFIX] Experimental blocks storage: Ingester is less likely to hit gRPC message size limit when streaming data to queriers. #3015
+* [BUGFIX] Fixes the Alertmanager panicking when no `alertmanager.web.external-url` is provided. #3017
 * [BUGFIX] Fix configuration for TLS server validation, TLS skip verify was hardcoded to true for all TLS configurations and prevented validation of server certificates. #3030
 
 ## 1.3.0 in progress

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -106,5 +106,5 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	cfg, err = c.GetAlertmanagerConfig(context.Background())
 	require.Error(t, err)
 	require.Nil(t, cfg)
-	require.EqualError(t, err, e2ecortex.ErrNotFound.Error())
+	require.EqualError(t, err, "getting config failed with status 406 and error Alertmanager is not active, revise its configuration\n")
 }

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -106,5 +106,5 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	cfg, err = c.GetAlertmanagerConfig(context.Background())
 	require.Error(t, err)
 	require.Nil(t, cfg)
-	require.EqualError(t, err, "getting config failed with status 406 and error Alertmanager is not active, revise its configuration\n")
+	require.EqualError(t, err, "not found")
 }

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -212,6 +212,10 @@ func (c *Client) GetAlertmanagerConfig(ctx context.Context) (*alertConfig.Config
 		return nil, ErrNotFound
 	}
 
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("getting config failed with status %d and error %v", resp.StatusCode, string(body))
+	}
+
 	var ss *ServerStatus
 	err = json.Unmarshal(body, &ss)
 	if err != nil {

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -484,7 +484,7 @@ func (am *MultitenantAlertmanager) ServeHTTP(w http.ResponseWriter, req *http.Re
 	am.alertmanagersMtx.Unlock()
 
 	if !ok {
-		http.Error(w, "no Alertmanager for this user ID, Alertmanager not configured", http.StatusNotFound)
+		http.Error(w, "the Alertmanager has not been configured", http.StatusNotFound)
 		return
 	}
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -175,6 +175,10 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig, logger log.L
 		return nil, fmt.Errorf("unable to create Alertmanager data directory %q: %s", cfg.DataDir, err)
 	}
 
+	if cfg.ExternalURL.URL == nil {
+		return nil, fmt.Errorf("unable to create Alertmanager, no 'web.external-url' configured")
+	}
+
 	var fallbackConfig []byte
 	if cfg.FallbackConfigFile != "" {
 		fallbackConfig, err = ioutil.ReadFile(cfg.FallbackConfigFile)

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -483,13 +483,8 @@ func (am *MultitenantAlertmanager) ServeHTTP(w http.ResponseWriter, req *http.Re
 	userAM, ok := am.alertmanagers[userID]
 	am.alertmanagersMtx.Unlock()
 
-	if !ok {
-		http.Error(w, "the Alertmanager has not been configured", http.StatusNotFound)
-		return
-	}
-
-	if !userAM.IsActive() {
-		http.Error(w, "Alertmanager is not active, revise its configuration", http.StatusNotAcceptable)
+	if !ok || !userAM.IsActive() {
+		http.Error(w, "the Alertmanager is not configured", http.StatusNotFound)
 		return
 	}
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -483,10 +483,16 @@ func (am *MultitenantAlertmanager) ServeHTTP(w http.ResponseWriter, req *http.Re
 	userAM, ok := am.alertmanagers[userID]
 	am.alertmanagersMtx.Unlock()
 
-	if !ok || !userAM.IsActive() {
-		http.Error(w, "no Alertmanager for this user ID", http.StatusNotFound)
+	if !ok {
+		http.Error(w, "no Alertmanager for this user ID, Alertmanager not configured", http.StatusNotFound)
 		return
 	}
+
+	if !userAM.IsActive() {
+		http.Error(w, "Alertmanager is not active, revise its configuration", http.StatusNotAcceptable)
+		return
+	}
+
 	userAM.mux.ServeHTTP(w, req)
 }
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -176,7 +176,7 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig, logger log.L
 	}
 
 	if cfg.ExternalURL.URL == nil {
-		return nil, fmt.Errorf("unable to create Alertmanager, no 'web.external-url' configured")
+		return nil, fmt.Errorf("unable to create Alertmanager because the external URL has not been configured")
 	}
 
 	var fallbackConfig []byte

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -191,7 +191,7 @@ func TestAlertmanager_NoExternalURL(t *testing.T) {
 		DataDir: tempDir,
 	}, log.NewNopLogger(), reg)
 
-	require.EqualError(t, err, "unable to create Alertmanager, no 'web.external-url' configured")
+	require.EqualError(t, err, "unable to create Alertmanager because the external URL has not been configured")
 }
 
 func TestAlertmanager_ServeHTTP(t *testing.T) {
@@ -223,7 +223,7 @@ func TestAlertmanager_ServeHTTP(t *testing.T) {
 
 	resp := w.Result()
 	body, _ := ioutil.ReadAll(resp.Body)
-	require.Equal(t, "no Alertmanager for this user ID, Alertmanager not configured\n", string(body))
+	require.Equal(t, "the Alertmanager is not configured\n", string(body))
 
 	// Create a configuration for the user in storage.
 	mockStore.configs["user1"] = alerts.AlertConfigDesc{
@@ -243,5 +243,5 @@ func TestAlertmanager_ServeHTTP(t *testing.T) {
 
 	resp = w.Result()
 	body, _ = ioutil.ReadAll(resp.Body)
-	require.Equal(t, "Alertmanager is not active, revise its configuration\n", string(body))
+	require.Equal(t, "the Alertmanager is not configured\n", string(body))
 }

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
@@ -190,4 +192,56 @@ func TestAlertmanager_NoExternalURL(t *testing.T) {
 	}, log.NewNopLogger(), reg)
 
 	require.EqualError(t, err, "unable to create Alertmanager, no 'web.external-url' configured")
+}
+
+func TestAlertmanager_ServeHTTP(t *testing.T) {
+	mockStore := &mockAlertStore{
+		configs: map[string]alerts.AlertConfigDesc{},
+	}
+
+	externalURL := flagext.URLValue{}
+	err := externalURL.Set("http://localhost:8080/alertmanager")
+	require.NoError(t, err)
+
+	tempDir, err := ioutil.TempDir(os.TempDir(), "alertmanager")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create the Multitenant Alertmanager.
+	reg := prometheus.NewPedanticRegistry()
+	am := createMultitenantAlertmanager(&MultitenantAlertmanagerConfig{
+		ExternalURL: externalURL,
+		DataDir:     tempDir,
+	}, nil, nil, mockStore, log.NewNopLogger(), reg)
+
+	// Request when no user configuration is present.
+	req := httptest.NewRequest("GET", externalURL.String(), nil)
+	req.Header.Add(user.OrgIDHeaderName, "user1")
+	w := httptest.NewRecorder()
+
+	am.ServeHTTP(w, req)
+
+	resp := w.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+	require.Equal(t, "no Alertmanager for this user ID, Alertmanager not configured\n", string(body))
+
+	// Create a configuration for the user in storage.
+	mockStore.configs["user1"] = alerts.AlertConfigDesc{
+		User:      "user1",
+		RawConfig: simpleConfigTwo,
+		Templates: []*alerts.TemplateDesc{},
+	}
+
+	// Make the alertmanager pick it up, then pause it.
+	err = am.updateConfigs()
+	require.NoError(t, err)
+	am.alertmanagers["user1"].Pause()
+
+	// Request when user configuration is paused.
+	w = httptest.NewRecorder()
+	am.ServeHTTP(w, req)
+
+	resp = w.Result()
+	body, _ = ioutil.ReadAll(resp.Body)
+	require.Equal(t, "Alertmanager is not active, revise its configuration\n", string(body))
 }

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -177,3 +177,17 @@ func TestLoadAllConfigs(t *testing.T) {
 		cortex_alertmanager_config_invalid{user="user3"} 0
 	`), "cortex_alertmanager_config_invalid"))
 }
+
+func TestAlertmanager_NoExternalURL(t *testing.T) {
+	tempDir, err := ioutil.TempDir(os.TempDir(), "alertmanager")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create the Multitenant Alertmanager.
+	reg := prometheus.NewPedanticRegistry()
+	_, err = NewMultitenantAlertmanager(&MultitenantAlertmanagerConfig{
+		DataDir: tempDir,
+	}, log.NewNopLogger(), reg)
+
+	require.EqualError(t, err, "unable to create Alertmanager, no 'web.external-url' configured")
+}


### PR DESCRIPTION
**What this PR does**:

Two really small improvements, and a precedent to start the discussion around automatic fallback configuration.

**Which issue(s) this PR fixes**:
Fixes #2704 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
