### PR TITLE
Lower default blocks listing and meta.json not exist TTL to 5m

### DIFF
--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -395,7 +395,7 @@ blocks_storage:
 
       # How long to cache list of blocks for each tenant.
       # CLI flag: -experimental.blocks-storage.bucket-store.metadata-cache.tenant-blocks-list-ttl
-      [tenant_blocks_list_ttl: <duration> | default = 15m]
+      [tenant_blocks_list_ttl: <duration> | default = 5m]
 
       # How long to cache list of chunks for a block.
       # CLI flag: -experimental.blocks-storage.bucket-store.metadata-cache.chunks-list-ttl
@@ -407,7 +407,7 @@ blocks_storage:
 
       # How long to cache information that block metafile doesn't exist.
       # CLI flag: -experimental.blocks-storage.bucket-store.metadata-cache.metafile-doesnt-exist-ttl
-      [metafile_doesnt_exist_ttl: <duration> | default = 15m]
+      [metafile_doesnt_exist_ttl: <duration> | default = 5m]
 
       # How long to cache content of the metafile.
       # CLI flag: -experimental.blocks-storage.bucket-store.metadata-cache.metafile-content-ttl

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -422,7 +422,7 @@ blocks_storage:
 
       # How long to cache list of blocks for each tenant.
       # CLI flag: -experimental.blocks-storage.bucket-store.metadata-cache.tenant-blocks-list-ttl
-      [tenant_blocks_list_ttl: <duration> | default = 15m]
+      [tenant_blocks_list_ttl: <duration> | default = 5m]
 
       # How long to cache list of chunks for a block.
       # CLI flag: -experimental.blocks-storage.bucket-store.metadata-cache.chunks-list-ttl
@@ -434,7 +434,7 @@ blocks_storage:
 
       # How long to cache information that block metafile doesn't exist.
       # CLI flag: -experimental.blocks-storage.bucket-store.metadata-cache.metafile-doesnt-exist-ttl
-      [metafile_doesnt_exist_ttl: <duration> | default = 15m]
+      [metafile_doesnt_exist_ttl: <duration> | default = 5m]
 
       # How long to cache content of the metafile.
       # CLI flag: -experimental.blocks-storage.bucket-store.metadata-cache.metafile-content-ttl

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3195,7 +3195,7 @@ bucket_store:
 
     # How long to cache list of blocks for each tenant.
     # CLI flag: -experimental.blocks-storage.bucket-store.metadata-cache.tenant-blocks-list-ttl
-    [tenant_blocks_list_ttl: <duration> | default = 15m]
+    [tenant_blocks_list_ttl: <duration> | default = 5m]
 
     # How long to cache list of chunks for a block.
     # CLI flag: -experimental.blocks-storage.bucket-store.metadata-cache.chunks-list-ttl
@@ -3207,7 +3207,7 @@ bucket_store:
 
     # How long to cache information that block metafile doesn't exist.
     # CLI flag: -experimental.blocks-storage.bucket-store.metadata-cache.metafile-doesnt-exist-ttl
-    [metafile_doesnt_exist_ttl: <duration> | default = 15m]
+    [metafile_doesnt_exist_ttl: <duration> | default = 5m]
 
     # How long to cache content of the metafile.
     # CLI flag: -experimental.blocks-storage.bucket-store.metadata-cache.metafile-content-ttl

--- a/pkg/storage/tsdb/caching_bucket.go
+++ b/pkg/storage/tsdb/caching_bucket.go
@@ -84,10 +84,10 @@ func (cfg *MetadataCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix 
 	cfg.Memcached.RegisterFlagsWithPrefix(f, prefix+"memcached.")
 
 	f.DurationVar(&cfg.TenantsListTTL, prefix+"tenants-list-ttl", 15*time.Minute, "How long to cache list of tenants in the bucket.")
-	f.DurationVar(&cfg.TenantBlocksListTTL, prefix+"tenant-blocks-list-ttl", 15*time.Minute, "How long to cache list of blocks for each tenant.")
+	f.DurationVar(&cfg.TenantBlocksListTTL, prefix+"tenant-blocks-list-ttl", 5*time.Minute, "How long to cache list of blocks for each tenant.")
 	f.DurationVar(&cfg.ChunksListTTL, prefix+"chunks-list-ttl", 24*time.Hour, "How long to cache list of chunks for a block.")
 	f.DurationVar(&cfg.MetafileExistsTTL, prefix+"metafile-exists-ttl", 2*time.Hour, "How long to cache information that block metafile exists.")
-	f.DurationVar(&cfg.MetafileDoesntExistTTL, prefix+"metafile-doesnt-exist-ttl", 15*time.Minute, "How long to cache information that block metafile doesn't exist.")
+	f.DurationVar(&cfg.MetafileDoesntExistTTL, prefix+"metafile-doesnt-exist-ttl", 5*time.Minute, "How long to cache information that block metafile doesn't exist.")
 	f.DurationVar(&cfg.MetafileContentTTL, prefix+"metafile-content-ttl", 24*time.Hour, "How long to cache content of the metafile.")
 	f.IntVar(&cfg.MetafileMaxSize, prefix+"metafile-max-size-bytes", 1*1024*1024, "Maximum size of metafile content to cache in bytes.")
 }


### PR DESCRIPTION
**What this PR does**:
The default `-experimental.blocks-storage.bucket-store.sync-interval` value is `5m` so, every 5 minutes, queriers and store-gateway re-iterate the bucket looking for new blocks. However, 2 out 3 times it will be useless because of the caching TTL, which defaults to 15m.

In this PR I propose to lower the default blocks listing and `meta.json` doesn't exist caching to 5m, to match the bucket sync interval.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
