### PR TITLE
Expose dynamodb backoff config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [CHANGE] Experimental Delete Series: `/api/v1/admin/tsdb/delete_series` and `/api/v1/admin/tsdb/cancel_delete_request` purger APIs to return status code `204` instead of `200` for success. #2946
 * [ENHANCEMENT] Add support for azure storage in China, German and US Government environments. #2988
 * [ENHANCEMENT] Query-tee: added a small tolerance to floating point sample values comparison. #2994
+* [ENHANCMENT] Expose `storage.aws.dynamodb.backoff_config` configuration file field. #3026
 * [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
 
 ## 1.3.0 in progress

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1667,6 +1667,19 @@ aws:
     # CLI flag: -dynamodb.chunk.get-max-parallelism
     [chunk_get_max_parallelism: <int> | default = 32]
 
+    backoff_config:
+      # Minimum backoff time
+      # CLI flag: -dynamodb.min-backoff
+      [min_period: <duration> | default = 100ms]
+
+      # Maximum backoff time
+      # CLI flag: -dynamodb.max-backoff
+      [max_period: <duration> | default = 50s]
+
+      # Maximum number of times to retry an operation
+      # CLI flag: -dynamodb.max-retries
+      [max_retries: <int> | default = 20]
+
   # S3 endpoint URL with escaped Key and Secret encoded. If only region is
   # specified as a host, proper endpoint will be deduced. Use
   # inmemory:///<bucket-name> to use a mock in-memory implementation.

--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -48,7 +48,7 @@ func NewDynamoDBTableClient(cfg DynamoDBConfig, reg prometheus.Registerer) (chun
 
 	callManager := callManager{
 		limiter:       rate.NewLimiter(rate.Limit(cfg.APILimit), 1),
-		backoffConfig: cfg.backoffConfig,
+		backoffConfig: cfg.BackoffConfig,
 	}
 
 	var autoscale autoscale

--- a/pkg/chunk/aws/fixtures.go
+++ b/pkg/chunk/aws/fixtures.go
@@ -76,7 +76,7 @@ func dynamoDBFixture(provisionedErr, gangsize, maxParallelism int) testutils.Fix
 				cfg: DynamoDBConfig{
 					ChunkGangSize:          gangsize,
 					ChunkGetMaxParallelism: maxParallelism,
-					backoffConfig: util.BackoffConfig{
+					BackoffConfig: util.BackoffConfig{
 						MinBackoff: 1 * time.Millisecond,
 						MaxBackoff: 5 * time.Millisecond,
 						MaxRetries: 20,


### PR DESCRIPTION
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

**What this PR does**:
Exposes the `storage.aws.dynamodb.backoff_config` configuration file so that administrators may configure the DynamoDB backoff without the need for flags.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
