### PR TITLE
Query /series from ingesters regardless the -querier.query-ingesters-within setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [ENHANCEMENT] Add support for azure storage in China, German and US Government environments. #2988
 * [ENHANCEMENT] Query-tee: added a small tolerance to floating point sample values comparison. #2994
 * [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
+* [BUGFIX] Querier: query /series from ingesters regardless the `-querier.query-ingesters-within` setting. #3035
 
 ## 1.3.0 in progress
 

--- a/development/tsdb-blocks-storage-s3-single-binary/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3-single-binary/config/cortex.yaml
@@ -26,6 +26,9 @@ ingester:
           host: consul:8500
       replication_factor: 1
 
+querier:
+  query_ingesters_within: 3h
+
 store_gateway:
   sharding_enabled: true
   sharding_ring:

--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -27,6 +27,8 @@ ingester:
       replication_factor: 1
 
 querier:
+  query_ingesters_within: 3h
+
   # Used when the blocks sharding is disabled.
   store_gateway_addresses: store-gateway-1:9008,store-gateway-2:9009
 

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -155,18 +155,24 @@ func (c *Client) QueryRaw(query string) (*http.Response, []byte, error) {
 	return res, body, nil
 }
 
+// Series finds series by label matchers.
+func (c *Client) Series(matches []string, start, end time.Time) ([]model.LabelSet, error) {
+	result, _, err := c.querierClient.Series(context.Background(), matches, start, end)
+	return result, err
+}
+
 // LabelValues gets label values
 func (c *Client) LabelValues(label string) (model.LabelValues, error) {
 	// Cortex currently doesn't support start/end time.
-	value, _, err := c.querierClient.LabelValues(context.Background(), label, time.Time{}, time.Time{})
-	return value, err
+	result, _, err := c.querierClient.LabelValues(context.Background(), label, time.Time{}, time.Time{})
+	return result, err
 }
 
 // LabelNames gets label names
 func (c *Client) LabelNames() ([]string, error) {
 	// Cortex currently doesn't support start/end time.
-	value, _, err := c.querierClient.LabelNames(context.Background(), time.Time{}, time.Time{})
-	return value, err
+	result, _, err := c.querierClient.LabelNames(context.Background(), time.Time{}, time.Time{})
+	return result, err
 }
 
 type addOrgIDRoundTripper struct {

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,6 +125,7 @@ func runQueryFrontendTest(t *testing.T, testMissingMetricName bool, setup queryF
 	flags = mergeFlags(flags, map[string]string{
 		"-querier.cache-results":             "true",
 		"-querier.split-queries-by-interval": "24h",
+		"-querier.query-ingesters-within":    "12h", // Required by the test on query /series out of ingesters time range
 		"-frontend.memcached.addresses":      "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
 	})
 
@@ -199,6 +201,18 @@ func runQueryFrontendTest(t *testing.T, testMissingMetricName bool, setup queryF
 			assert.Equal(t, model.Time(1595846750806), matrix[0].Values[2].Timestamp)
 		}
 
+		// In this test we do ensure that the /series start/end time is ignored and Cortex
+		// always returns series in ingesters memory. No need to repeat it for each user.
+		if userID == 0 {
+			start := now.Add(-1000 * time.Hour)
+			end := now.Add(-999 * time.Hour)
+
+			result, err := c.Series([]string{"series_1"}, start, end)
+			require.NoError(t, err)
+			require.Len(t, result, 1)
+			assert.Equal(t, model.LabelSet{labels.MetricName: "series_1"}, result[0])
+		}
+
 		for q := 0; q < numQueriesPerUser; q++ {
 			go func() {
 				defer wg.Done()
@@ -213,7 +227,7 @@ func runQueryFrontendTest(t *testing.T, testMissingMetricName bool, setup queryF
 
 	wg.Wait()
 
-	extra := float64(1)
+	extra := float64(2)
 	if testMissingMetricName {
 		extra++
 	}

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -79,10 +79,20 @@ func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 	log, ctx := spanlogger.New(q.ctx, "distributorQuerier.Select")
 	defer log.Span.Finish()
 
-	minT, maxT := q.mint, q.maxt
-	if sp != nil {
-		minT, maxT = sp.Start, sp.End
+	// Kludge: Prometheus passes nil SelectParams if it is doing a 'series' operation,
+	// which needs only metadata. For this specific case we shouldn't apply the queryIngestersWithin
+	// time range manipulation, otherwise we'll end up returning no series at all for
+	// older time ranges (while in Cortex we do ignore the start/end and always return
+	// series in ingesters).
+	if sp == nil {
+		ms, err := q.distributor.MetricsForLabelMatchers(ctx, model.Time(q.mint), model.Time(q.maxt), matchers...)
+		if err != nil {
+			return storage.ErrSeriesSet(err)
+		}
+		return series.MetricsToSeriesSet(ms)
 	}
+
+	minT, maxT := sp.Start, sp.End
 
 	// If queryIngestersWithin is enabled, we do manipulate the query mint to query samples up until
 	// now - queryIngestersWithin, because older time ranges are covered by the storage. This
@@ -101,16 +111,6 @@ func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 			level.Debug(log).Log("msg", "empty query time range after min time manipulation")
 			return storage.EmptySeriesSet()
 		}
-	}
-
-	// Kludge: Prometheus passes nil SelectParams if it is doing a 'series' operation,
-	// which needs only metadata.
-	if sp == nil {
-		ms, err := q.distributor.MetricsForLabelMatchers(ctx, model.Time(minT), model.Time(maxT), matchers...)
-		if err != nil {
-			return storage.ErrSeriesSet(err)
-		}
-		return series.MetricsToSeriesSet(ms)
 	}
 
 	if q.streaming {


### PR DESCRIPTION
**What this PR does**:
In https://github.com/cortexproject/cortex/pull/2904 I've introduced a bug which prevents `/series` requests to be sent to ingesters if the request time range is older then `-querier.query-ingesters-within`. This is an unintended regression which this PR should fix.

I've run both new unit test and integration test with `master`, and they both break (both for chunks and blocks storage).

**Which issue(s) this PR fixes**:
Fixes #3032

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
