### PR TITLE
Simpler instrumentation for non-batched memcached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * `cortex_ingester_sent_bytes_total`
 * [CHANGE] Experimental blocks storage: the `operation` label value `getrange` has changed into `get_range` for the metrics `thanos_store_bucket_cache_operation_requests_total` and `thanos_store_bucket_cache_operation_hits_total`. #3000
 * [CHANGE] Experimental Delete Series: `/api/v1/admin/tsdb/delete_series` and `/api/v1/admin/tsdb/cancel_delete_request` purger APIs to return status code `204` instead of `200` for success. #2946
+* [CHANGE] Histogram `cortex_memcache_request_duration_seconds` `method` label value changes from `Memcached.Get` to `Memcached.GetBatched` for batched lookups, and is not reported for non-batched lookups (label value `Memcached.GetMulti` remains, and had exactly the same value as `Get` in nonbatched lookups).  The same change applies to tracing spans. #3046
 * [ENHANCEMENT] Add support for azure storage in China, German and US Government environments. #2988
 * [ENHANCEMENT] Query-tee: added a small tolerance to floating point sample values comparison. #2994
 * [ENHANCEMENT] Query-tee: add support for doing a passthrough of requests to preferred backend for unregistered routes #3018

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -132,12 +132,11 @@ func memcacheStatusCode(err error) string {
 
 // Fetch gets keys from the cache. The keys that are found must be in the order of the keys requested.
 func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missed []string) {
-	_ = instr.CollectedRequest(ctx, "Memcache.Get", c.requestDuration, memcacheStatusCode, func(ctx context.Context) error {
-		if c.cfg.BatchSize == 0 {
-			found, bufs, missed = c.fetch(ctx, keys)
-			return nil
-		}
-
+	if c.cfg.BatchSize == 0 {
+		found, bufs, missed = c.fetch(ctx, keys)
+		return
+	}
+	_ = instr.CollectedRequest(ctx, "Memcache.GetBatched", c.requestDuration, memcacheStatusCode, func(ctx context.Context) error {
 		found, bufs, missed = c.fetchKeysBatched(ctx, keys)
 		return nil
 	})


### PR DESCRIPTION
Previously it would record a `Memcached.Get` operation with a nested `Memcached.GetMulti`; since they are in one-to-one correspondance this is pointless.

Skip the outer data collection for the non-batched case, and rename the batched one to `Memcached.GetBatched` which is more descriptive.

These names are used for metric labels and for tracing span names.

**Checklist**
- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated
