### PR TITLE
Make tests build on go1.15

### DIFF
--- a/pkg/chunk/cache/memcached_test.go
+++ b/pkg/chunk/cache/memcached_test.go
@@ -3,6 +3,7 @@ package cache_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/bradfitz/gomemcache/memcache"
@@ -43,26 +44,26 @@ func testMemcache(t *testing.T, memcache *cache.Memcached) {
 
 	// Insert 1000 keys skipping all multiples of 5.
 	for i := 0; i < numKeys; i++ {
-		keysIncMissing = append(keysIncMissing, string(i))
+		keysIncMissing = append(keysIncMissing, fmt.Sprint(i))
 		if i%5 == 0 {
 			continue
 		}
 
-		keys = append(keys, string(i))
-		bufs = append(bufs, []byte(string(i)))
+		keys = append(keys, fmt.Sprint(i))
+		bufs = append(bufs, []byte(fmt.Sprint(i)))
 	}
 	memcache.Store(ctx, keys, bufs)
 
 	found, bufs, missing := memcache.Fetch(ctx, keysIncMissing)
 	for i := 0; i < numKeys; i++ {
 		if i%5 == 0 {
-			require.Equal(t, string(i), missing[0])
+			require.Equal(t, fmt.Sprint(i), missing[0])
 			missing = missing[1:]
 			continue
 		}
 
-		require.Equal(t, string(i), found[0])
-		require.Equal(t, string(i), string(bufs[0]))
+		require.Equal(t, fmt.Sprint(i), found[0])
+		require.Equal(t, fmt.Sprint(i), string(bufs[0]))
 		found = found[1:]
 		bufs = bufs[1:]
 	}
@@ -118,12 +119,12 @@ func testMemcacheFailing(t *testing.T, memcache *cache.Memcached) {
 	bufs := make([][]byte, 0, numKeys)
 	// Insert 1000 keys skipping all multiples of 5.
 	for i := 0; i < numKeys; i++ {
-		keysIncMissing = append(keysIncMissing, string(i))
+		keysIncMissing = append(keysIncMissing, fmt.Sprint(i))
 		if i%5 == 0 {
 			continue
 		}
-		keys = append(keys, string(i))
-		bufs = append(bufs, []byte(string(i)))
+		keys = append(keys, fmt.Sprint(i))
+		bufs = append(bufs, []byte(fmt.Sprint(i)))
 	}
 	memcache.Store(ctx, keys, bufs)
 

--- a/pkg/chunk/schema_test.go
+++ b/pkg/chunk/schema_test.go
@@ -409,8 +409,8 @@ func TestV10IndexQueries(t *testing.T) {
 			res = append(res, IndexQuery{
 				TableName:       "tbl",
 				HashValue:       fmt.Sprintf("%02d:%s:%s:%s", i, "hash", "metric", "label"),
-				RangeValueStart: []byte(string(i)),
-				ValueEqual:      []byte(string(i)),
+				RangeValueStart: []byte(fmt.Sprint(i)),
+				ValueEqual:      []byte(fmt.Sprint(i)),
 			})
 		}
 		return res

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -18,7 +19,7 @@ func TestTimeFromMillis(t *testing.T) {
 	}
 
 	for i, c := range testExpr {
-		t.Run(string(i), func(t *testing.T) {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			res := TimeFromMillis(c.input)
 			require.Equal(t, c.expected, res)
 		})


### PR DESCRIPTION
My machine was upgraded to go1.15 and tests were failing with
`conversion from int to string yields a string of one rune, not a string
of digits (did you mean fmt.Sprint(x)?)`

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>