### PR TITLE
Do not return error from Ring.Subring()

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -513,10 +513,7 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 	// Obtain a subring if required
 	if size := d.limits.SubringSize(userID); size > 0 {
 		h := client.HashAdd32a(client.HashNew32a(), userID)
-		subRing, err = d.ingestersRing.Subring(h, size)
-		if err != nil {
-			return nil, httpgrpc.Errorf(http.StatusInternalServerError, "unable to create subring: %v", err)
-		}
+		subRing = d.ingestersRing.Subring(h, size)
 	}
 
 	keys := append(seriesKeys, metadataKeys...)

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -145,14 +145,9 @@ func TestSubring(t *testing.T) {
 		strategy:   &DefaultReplicationStrategy{},
 	}
 
-	// Subring of 0 invalid
-	_, err := ring.Subring(0, 0)
-	require.Error(t, err)
-
 	// Generate a sub ring for all possible valid ranges
 	for i := 1; i < n+2; i++ {
-		subr, err := ring.Subring(rand.Uint32(), i)
-		require.NoError(t, err)
+		subr := ring.Subring(rand.Uint32(), i)
 		subringSize := i
 		if i > n {
 			subringSize = n
@@ -204,8 +199,7 @@ func TestStableSubring(t *testing.T) {
 	key := rand.Uint32()
 	subringsize := 4
 	for i := 1; i < 4; i++ {
-		subr, err := ring.Subring(key, subringsize)
-		require.NoError(t, err)
+		subr := ring.Subring(key, subringsize)
 		require.Equal(t, subringsize, len(subr.(*Ring).ringDesc.Ingesters))
 		require.Equal(t, subringsize*128, len(subr.(*Ring).ringTokens))
 		require.True(t, sort.SliceIsSorted(subr.(*Ring).ringTokens, func(i, j int) bool {


### PR DESCRIPTION
**What this PR does**:
While working on the shuffle sharding in the store-gateway, I've realised it's quite annoying that the `Ring.Subring()` can return an error. My take is that if the subring can't be constructed (for any reason) we shouldn't fail, but we should fallback to the full ring. In this PR I'm proposing it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
