### PR TITLE
Fixes the registration of the Alertmanager alert receiving API metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [BUGFIX] Experimental blocks storage: Ingester is less likely to hit gRPC message size limit when streaming data to queriers. #3015
 * [BUGFIX] Fix configuration for TLS server validation, TLS skip verify was hardcoded to true for all TLS configurations and prevented validation of server certificates. #3030
 * [BUGFIX] Fixes the Alertmanager panicking when no `-alertmanager.web.external-url` is provided. #3017
+* [BUGFIX] Fixes the registration of the Alertmanager API metrics `cortex_alertmanager_alerts_received_total` and `cortex_alertmanager_alerts_invalid_total`. #3065
 
 ## 1.3.0 / 2020-08-21
 

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -73,14 +73,6 @@ type Alertmanager struct {
 
 var (
 	webReload = make(chan chan error)
-
-	// In order to workaround a bug in the alertmanager, which doesn't register the
-	// metrics in the input registry but to the global default one, we do define a
-	// singleton dispatcher metrics instance that is going to be shared across all
-	// tenants alertmanagers.
-	// TODO change this once the vendored alertmanager will have this PR merged into:
-	//      https://github.com/prometheus/alertmanager/pull/2200
-	dispatcherMetrics = dispatch.NewDispatcherMetrics(prometheus.NewRegistry())
 )
 
 func init() {
@@ -240,7 +232,7 @@ func (am *Alertmanager) ApplyConfig(userID string, conf *config.Config) error {
 		am.marker,
 		timeoutFunc,
 		log.With(am.logger, "component", "dispatcher"),
-		dispatcherMetrics,
+		dispatch.NewDispatcherMetrics(am.registry),
 	)
 
 	go am.dispatcher.Run()

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -150,6 +150,7 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 		Silences:   am.silences,
 		StatusFunc: am.marker.Status,
 		Peer:       cfg.Peer,
+		Registry:   am.registry,
 		Logger:     log.With(am.logger, "component", "api"),
 		GroupFunc: func(f1 func(*dispatch.Route) bool, f2 func(*types.Alert, time.Time) bool) (dispatch.AlertGroups, map[model.Fingerprint][]string) {
 			return am.dispatcher.Groups(f1, f2)

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -1,5 +1,3 @@
-// +build !race
-
 package alertmanager
 
 import (
@@ -57,8 +55,6 @@ func (m *mockAlertStore) DeleteAlertConfig(ctx context.Context, user string) err
 	return fmt.Errorf("not implemented")
 }
 
-// TestLoadAllConfigs ensures the multitenant alertmanager can properly load configs from a local backend store.
-// It is excluded from the race detector due to a vendored race issue https://github.com/prometheus/alertmanager/issues/2182
 func TestLoadAllConfigs(t *testing.T) {
 	mockStore := &mockAlertStore{
 		configs: map[string]alerts.AlertConfigDesc{


### PR DESCRIPTION
**What this PR does**:

Fixes the registration of the Alertmanager API metrics for receiving alerts. Additionally, it removes a couple of TODOs I noticed along the way - they should be a no-op.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
