### PR TITLE
Add warning that schema configuration is not used in blocks storage mode

### DIFF
--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -190,6 +190,11 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.TableManager.Validate(); err != nil {
 		return errors.Wrap(err, "invalid table_manager config")
 	}
+
+	if c.Storage.Engine == storage.StorageEngineBlocks && len(c.Schema.Configs) > 0 {
+		level.Warn(log).Log("schema configuration is not used in blocks storage mode, and will have no effect")
+	}
+
 	return nil
 }
 

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -191,8 +191,8 @@ func (c *Config) Validate(log log.Logger) error {
 		return errors.Wrap(err, "invalid table_manager config")
 	}
 
-	if c.Storage.Engine == storage.StorageEngineBlocks && len(c.Schema.Configs) > 0 {
-		level.Warn(log).Log("schema configuration is not used in blocks storage mode, and will have no effect")
+	if c.Storage.Engine == storage.StorageEngineBlocks && c.Querier.SecondStoreEngine != storage.StorageEngineChunks && len(c.Schema.Configs) > 0 {
+		level.Warn(log).Log("schema configuration is not used by the blocks storage engine, and will have no effect")
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does**:
When using block storage, schema-related configuration is not used. This PR adds a warning if schema has been configured anyway.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
