### PR TITLE
Start an Alertmanager when it is requested if we have a fallback config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@
 * [ENHANCEMENT] Add "integration" as a label for `cortex_alertmanager_notifications_total` and `cortex_alertmanager_notifications_failed_total` metrics. #3056
 * [ENHANCEMENT] Add `cortex_ruler_config_last_reload_successful` and `cortex_ruler_config_last_reload_successful_seconds` to check status of users rule manager. #3056
 * [ENHANCEMENT] Memcached dial() calls now have an optional circuit-breaker to avoid hammering a broken cache #3051
+<<<<<<< HEAD
 * [ENHANCEMENT] Add TLS support to etcd client. #3102
+=======
+* [ENHANCEMENT] When a tenant accesses the Alertmanager UI or its API, if we have valid `-alertmanager.configs.fallback` we'll use that to start the manager and avoid failing the request. #XXXX
+>>>>>>> baf7a0e40... Start an Alertmanager when the first request is received
 * [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
 * [BUGFIX] Querier: Merge results from chunks and blocks ingesters when using streaming of results. #3013
 * [BUGFIX] Querier: query /series from ingesters regardless the `-querier.query-ingesters-within` setting. #3035

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,8 @@
 * [ENHANCEMENT] Add "integration" as a label for `cortex_alertmanager_notifications_total` and `cortex_alertmanager_notifications_failed_total` metrics. #3056
 * [ENHANCEMENT] Add `cortex_ruler_config_last_reload_successful` and `cortex_ruler_config_last_reload_successful_seconds` to check status of users rule manager. #3056
 * [ENHANCEMENT] Memcached dial() calls now have an optional circuit-breaker to avoid hammering a broken cache #3051
-<<<<<<< HEAD
 * [ENHANCEMENT] Add TLS support to etcd client. #3102
-=======
-* [ENHANCEMENT] When a tenant accesses the Alertmanager UI or its API, if we have valid `-alertmanager.configs.fallback` we'll use that to start the manager and avoid failing the request. #XXXX
->>>>>>> baf7a0e40... Start an Alertmanager when the first request is received
+* [ENHANCEMENT] When a tenant accesses the Alertmanager UI or its API, if we have valid `-alertmanager.configs.fallback` we'll use that to start the manager and avoid failing the request. #3073
 * [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
 * [BUGFIX] Querier: Merge results from chunks and blocks ingesters when using streaming of results. #3013
 * [BUGFIX] Querier: query /series from ingesters regardless the `-querier.query-ingesters-within` setting. #3035

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -489,8 +489,7 @@ func (am *MultitenantAlertmanager) ServeHTTP(w http.ResponseWriter, req *http.Re
 
 func (am *MultitenantAlertmanager) alertmanagerFromFallbackConfig(userID string) (*Alertmanager, error) {
 	// Upload an empty config so that the Alertmanager is no de-activated in the next poll
-	cfg := &UserConfig{AlertmanagerConfig: ""}
-	cfgDesc := alerts.ToProto(cfg.AlertmanagerConfig, cfg.TemplateFiles, userID)
+	cfgDesc := alerts.ToProto("", nil, userID)
 	err := am.store.SetAlertConfig(context.Background(), cfgDesc)
 	if err != nil {
 		return nil, err

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -270,11 +270,10 @@ receivers:
 `
 
 	// Create the Multitenant Alertmanager.
-	reg := prometheus.NewPedanticRegistry()
 	am := createMultitenantAlertmanager(&MultitenantAlertmanagerConfig{
 		ExternalURL: externalURL,
 		DataDir:     tempDir,
-	}, nil, nil, mockStore, log.NewNopLogger(), reg)
+	}, nil, nil, mockStore, log.NewNopLogger(), nil)
 	am.fallbackConfig = fallbackCfg
 
 	// Request when no user configuration is present.

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
@@ -48,7 +49,8 @@ func (m *mockAlertStore) GetAlertConfig(ctx context.Context, user string) (alert
 }
 
 func (m *mockAlertStore) SetAlertConfig(ctx context.Context, cfg alerts.AlertConfigDesc) error {
-	return fmt.Errorf("not implemented")
+	m.configs[cfg.User] = cfg
+	return nil
 }
 
 func (m *mockAlertStore) DeleteAlertConfig(ctx context.Context, user string) error {
@@ -239,5 +241,71 @@ func TestAlertmanager_ServeHTTP(t *testing.T) {
 
 	resp = w.Result()
 	body, _ = ioutil.ReadAll(resp.Body)
+	require.Equal(t, "the Alertmanager is not configured\n", string(body))
+}
+
+func TestAlertmanager_ServeHTTPWithFallbackConfig(t *testing.T) {
+	mockStore := &mockAlertStore{
+		configs: map[string]alerts.AlertConfigDesc{},
+	}
+
+	externalURL := flagext.URLValue{}
+	err := externalURL.Set("http://localhost:8080/alertmanager")
+	require.NoError(t, err)
+
+	tempDir, err := ioutil.TempDir(os.TempDir(), "alertmanager")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	fallbackCfg := `
+global:
+  smtp_smarthost: 'localhost:25'
+  smtp_from: 'youraddress@example.org'
+route:
+  receiver: example-email
+receivers:
+  - name: example-email
+    email_configs:
+    - to: 'youraddress@example.org'
+`
+
+	// Create the Multitenant Alertmanager.
+	reg := prometheus.NewPedanticRegistry()
+	am := createMultitenantAlertmanager(&MultitenantAlertmanagerConfig{
+		ExternalURL: externalURL,
+		DataDir:     tempDir,
+	}, nil, nil, mockStore, log.NewNopLogger(), reg)
+	am.fallbackConfig = fallbackCfg
+
+	// Request when no user configuration is present.
+	req := httptest.NewRequest("GET", externalURL.String()+"/api/v1/status", nil)
+	req.Header.Add(user.OrgIDHeaderName, "user1")
+	w := httptest.NewRecorder()
+
+	am.ServeHTTP(w, req)
+
+	resp := w.Result()
+
+	// It succeeds and the Alertmanager is started
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, am.alertmanagers, 1)
+	require.True(t, am.alertmanagers["user1"].IsActive())
+
+	// Even after a poll it does not pause your Alertmanager
+	err = am.updateConfigs()
+	require.NoError(t, err)
+
+	require.True(t, am.alertmanagers["user1"].IsActive())
+	require.Len(t, am.alertmanagers, 1)
+
+	// Pause the alertmanager
+	am.alertmanagers["user1"].Pause()
+
+	// Request when user configuration is paused.
+	w = httptest.NewRecorder()
+	am.ServeHTTP(w, req)
+
+	resp = w.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
 	require.Equal(t, "the Alertmanager is not configured\n", string(body))
 }


### PR DESCRIPTION
Opening this in the form a proposal to see what others think cc: @pracucci @gouthamve @bboreham 

Currently, fallback configurations work in the form of:

- Poll for all config in the object storage
- If the user has an empty config file and we have a fallback config, then use the fallback to start a new Alertmanager

With this PR, we start the am and upload an empty config if the alert manager path is hit (either by accessing the UI or receiving an alert). There are some downsides with this approach:

- If the user uploads a config and accesses the UI before we poll its config will be overwritten (although a check can be added as part of this process?)
- there's no way to know when an Alertmanager has gone "stale" and remove it from memory (although this might not be a concern of cortex?)

Clearly, there's thing missing but I just want to gauge opinions before I invest more effort into this.