### PR TITLE
Fixes `-config.expand-env` requires argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [BUGFIX] Fix configuration for TLS server validation, TLS skip verify was hardcoded to true for all TLS configurations and prevented validation of server certificates. #3030
 * [BUGFIX] Fixes the Alertmanager panicking when no `-alertmanager.web.external-url` is provided. #3017
 * [BUGFIX] Fixes the registration of the Alertmanager API metrics `cortex_alertmanager_alerts_received_total` and `cortex_alertmanager_alerts_invalid_total`. #3065
+* [BUGFIX] Fixes `-config.expand-env` requires argument.
 
 ## 1.3.0 / 2020-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 * [BUGFIX] Fix configuration for TLS server validation, TLS skip verify was hardcoded to true for all TLS configurations and prevented validation of server certificates. #3030
 * [BUGFIX] Fixes the Alertmanager panicking when no `-alertmanager.web.external-url` is provided. #3017
 * [BUGFIX] Fixes the registration of the Alertmanager API metrics `cortex_alertmanager_alerts_received_total` and `cortex_alertmanager_alerts_invalid_total`. #3065
-* [BUGFIX] Fixes `-config.expand-env` requires argument.
+* [BUGFIX] Fixes `-config.expand-env` requires argument. #3083
 
 ## 1.3.0 / 2020-08-21
 

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -80,7 +80,7 @@ func main() {
 
 	// Ignore -config.file and -config.expand-env here, since it was already parsed, but it's still present on command line.
 	flagext.IgnoredFlag(flag.CommandLine, configFileOption, "Configuration file to load.")
-	flagext.IgnoredFlag(flag.CommandLine, configExpandENV, "Expands ${var} or $var in config according to the values of the environment variables.")
+	_ = flag.CommandLine.Bool(configExpandENV, false, "Expands ${var} or $var in config according to the values of the environment variables.")
 
 	flag.IntVar(&eventSampleRate, "event.sample-rate", 0, "How often to sample observability events (0 = never).")
 	flag.IntVar(&ballastBytes, "mem-ballast-size-bytes", 0, "Size of memory ballast to allocate.")


### PR DESCRIPTION
Signed-off-by: Wing924 <weihe924stephen@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

old:
```
% docker run --rm  quay.io/cortexproject/cortex:v1.3.0 -config.expand-env
flag needs an argument: -config.expand-env
Run with -help to get list of available parameters
```

new:
```
-> % docker run --rm quay.io/cortexproject/cortex -config.expand-env
level=info ts=2020-08-25T08:41:46.0276577Z caller=main.go:162 msg="Starting Cortex" version="(version=1.3.0, branch=master, revision=2cbf61af6)"
level=info ts=2020-08-25T08:41:46.0283108Z caller=server.go:223 http=[::]:80 grpc=[::]:9095 msg="server listening on addresses"
level=info ts=2020-08-25T08:41:46.0287076Z caller=modules.go:488 msg="RulerStorage is not configured in single binary mode and will not be started."
level=error ts=2020-08-25T08:41:46.0300884Z caller=log.go:143 msg="error running cortex" err="schema config file needs to be set\nerror initialising module: table-manager\ngithub.com/cortexproject/cortex/pkg/util/modules.(*Manager).InitModuleServices\n\t/go/src/github.com/cortexproject/cortex/pkg/util/modules/modules.go:89\ngithub.com/cortexproject/cortex/pkg/cortex.(*Cortex).Run\n\t/go/src/github.com/cortexproject/cortex/pkg/cortex/cortex.go:282\nmain.main\n\t/go/src/github.com/cortexproject/cortex/cmd/cortex/main.go:164\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373"
```

**Which issue(s) this PR fixes**:
Fixes #3082

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
