### PR TITLE
Fixed CLI flags for memcached circuit breaker

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2937,16 +2937,16 @@ The `memcached_client_config` configures the client used to connect to Memcached
 
 # Trip circuit-breaker after this number of consecutive dial failures (if zero
 # then circuit-breaker is disabled).
-# CLI flag: -<prefix>.memcached.cb.failures
+# CLI flag: -<prefix>.memcached.circuit-breaker-consecutive-failures
 [circuit_breaker_consecutive_failures: <int> | default = 0]
 
 # Duration circuit-breaker remains open after tripping (if zero then 60 seconds
 # is used).
-# CLI flag: -<prefix>.memcached.cb.timeout
+# CLI flag: -<prefix>.memcached.circuit-breaker-timeout
 [circuit_breaker_timeout: <duration> | default = 10s]
 
 # Reset circuit-breaker counts after this long (if zero then never reset).
-# CLI flag: -<prefix>.memcached.cb.interval
+# CLI flag: -<prefix>.memcached.circuit-breaker-interval
 [circuit_breaker_interval: <duration> | default = 10s]
 ```
 

--- a/pkg/chunk/cache/memcached_client.go
+++ b/pkg/chunk/cache/memcached_client.go
@@ -83,9 +83,9 @@ func (cfg *MemcachedClientConfig) RegisterFlagsWithPrefix(prefix, description st
 	f.DurationVar(&cfg.Timeout, prefix+"memcached.timeout", 100*time.Millisecond, description+"Maximum time to wait before giving up on memcached requests.")
 	f.DurationVar(&cfg.UpdateInterval, prefix+"memcached.update-interval", 1*time.Minute, description+"Period with which to poll DNS for memcache servers.")
 	f.BoolVar(&cfg.ConsistentHash, prefix+"memcached.consistent-hash", true, description+"Use consistent hashing to distribute to memcache servers.")
-	f.UintVar(&cfg.CBFailures, prefix+"memcached.cb.failures", 0, description+"Trip circuit-breaker after this number of consecutive dial failures (if zero then circuit-breaker is disabled).")
-	f.DurationVar(&cfg.CBTimeout, prefix+"memcached.cb.timeout", 10*time.Second, description+"Duration circuit-breaker remains open after tripping (if zero then 60 seconds is used).")
-	f.DurationVar(&cfg.CBInterval, prefix+"memcached.cb.interval", 10*time.Second, description+"Reset circuit-breaker counts after this long (if zero then never reset).")
+	f.UintVar(&cfg.CBFailures, prefix+"memcached.circuit-breaker-consecutive-failures", 0, description+"Trip circuit-breaker after this number of consecutive dial failures (if zero then circuit-breaker is disabled).")
+	f.DurationVar(&cfg.CBTimeout, prefix+"memcached.circuit-breaker-timeout", 10*time.Second, description+"Duration circuit-breaker remains open after tripping (if zero then 60 seconds is used).")
+	f.DurationVar(&cfg.CBInterval, prefix+"memcached.circuit-breaker-interval", 10*time.Second, description+"Reset circuit-breaker counts after this long (if zero then never reset).")
 }
 
 // NewMemcachedClient creates a new MemcacheClient that gets its server list


### PR DESCRIPTION
**What this PR does**:
In #3051 we introduced memcached circuit breaker. For new config options, we try to keep YAML and CLI flags naming specular, so in this PR I'm fixing the new CLI flags to match YAML (`-` in CLI are `_` in YAML).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
