### PR TITLE
Improve throughput through sharding fingerprints

### DIFF
--- a/pkg/ingester/index/index.go
+++ b/pkg/ingester/index/index.go
@@ -93,10 +93,9 @@ type indexEntry struct {
 }
 
 type indexValueEntry struct {
-	value string
+	value  string
 	shards [][]model.Fingerprint
 }
-
 
 const indexValueShards = 200
 
@@ -116,7 +115,7 @@ func (c *indexValueEntry) fps() []model.Fingerprint {
 	return fps
 }
 
-func (c *indexValueEntry) delete(fp model.Fingerprint){
+func (c *indexValueEntry) delete(fp model.Fingerprint) {
 	num := c.shard(fp)
 	fps := c.shards[num]
 	j := sort.Search(len(fps), func(i int) bool {
@@ -140,7 +139,7 @@ func (c *indexValueEntry) shard(fp model.Fingerprint) int {
 	return int(math.Floor(float64(len(c.shards)) * float64(fp) / math.MaxUint64))
 }
 
-func (c *indexValueEntry) add(fp model.Fingerprint){
+func (c *indexValueEntry) add(fp model.Fingerprint) {
 	num := c.shard(fp)
 	fps := c.shards[num]
 	// Insert into the right position to keep fingerprints sorted


### PR DESCRIPTION
**What this PR does**:
This PR is expected to increase the throughput of ingester(chunk storage) by 10-100 times.

**Which issue(s) this PR fixes**:
Fixes #3093

According to the issue description, `Lock` and `Append` take up 95% of the entire `Push` request time.
The time consumption of the `Lock` is affected by the amount of concurrency, but in essence it is affected by the time consumption of the code area it protects.
So the key is to solve the problem that `Copy` takes too long. In fact, this is a truth that any data structure beginner understands: the cost of random insertion into the array is expensive because it requires moving a large number of elements.
To be honest, I first thought of skiplist, because the scene here is very similar to redis's sorted set. After some comparative tests, the random insertion speed of skiplist is indeed much better than that of array. But when it was actually integrated into cortex and used in my environment, it took up too much memory. So I finally went back to the array.
What I consider is to divide a big ordered slice into multiple ordered slices to reduce the cost of `Copy`. It sounds a bit simple, but is really effective and suitable

Its general idea is as follows:
It divides `math.MaxUint64` (this is the value range of fingerprint) into `N` shards:
```
shards[0]: [0, math.MaxUint64 * 1/N)
shards[1]: [math.MaxUint64 * 1/N, math.MaxUint64 * 2/N)
...
shards[n]: [math.MaxUint64 * (N-1)/N, math.MaxUint64]
```
(the actual shard is not as accurate as the above).

`Fingerprints` in each shard are kept in order. In this way, we can deal with it as we did with a large array of fingerprints. It brings a small cost (shard), but greatly improves the throughput, and it even helps to reduce memory consumption to some extent (large arrays take up more memory when growing).

**Comparison**:
![image](https://user-images.githubusercontent.com/29772821/91332138-4abf9380-e7fe-11ea-90f8-c1759528368b.png)

In my test, each consumer can only consume up to  `25000 series/s` before the modification, and it can consume up to `1400000 series/s` after the modification. You may have doubts about the data, I will provide the testing process below.