### PR TITLE
[WIP] Chnage the cache interface so that the cache client can be reused in Thanos

### DIFF
--- a/pkg/chunk/cache/cache.go
+++ b/pkg/chunk/cache/cache.go
@@ -18,8 +18,8 @@ import (
 // Whatsmore, we found partially successful Fetchs were often treated as failed
 // when they returned an error.
 type Cache interface {
-	Store(ctx context.Context, key []string, buf [][]byte)
-	Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string)
+	Store(ctx context.Context, data map[string][]byte)
+	Fetch(ctx context.Context, keys []string) (results map[string][]byte, missing []string)
 	Stop()
 }
 

--- a/pkg/chunk/cache/fifo_cache.go
+++ b/pkg/chunk/cache/fifo_cache.go
@@ -181,8 +181,8 @@ func NewFifoCache(name string, cfg FifoCacheConfig, reg prometheus.Registerer, l
 }
 
 // Fetch implements Cache.
-func (c *FifoCache) Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string) {
-	found, missing, bufs = make([]string, 0, len(keys)), make([]string, 0, len(keys)), make([][]byte, 0, len(keys))
+func (c *FifoCache) Fetch(ctx context.Context, keys []string) (found map[string][]byte, missing []string) {
+	found, missing = make(map[string][]byte, len(keys)), make([]string, 0, len(keys))
 	for _, key := range keys {
 		val, ok := c.Get(ctx, key)
 		if !ok {
@@ -190,21 +190,20 @@ func (c *FifoCache) Fetch(ctx context.Context, keys []string) (found []string, b
 			continue
 		}
 
-		found = append(found, key)
-		bufs = append(bufs, val)
+		found[key] = val
 	}
 	return
 }
 
 // Store implements Cache.
-func (c *FifoCache) Store(ctx context.Context, keys []string, values [][]byte) {
+func (c *FifoCache) Store(ctx context.Context, data map[string][]byte) {
 	c.entriesAdded.Inc()
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	for i := range keys {
-		c.put(keys[i], values[i])
+	for k, v := range data {
+		c.put(k, v)
 	}
 }
 

--- a/pkg/chunk/cache/mock.go
+++ b/pkg/chunk/cache/mock.go
@@ -10,22 +10,21 @@ type mockCache struct {
 	cache map[string][]byte
 }
 
-func (m *mockCache) Store(_ context.Context, keys []string, bufs [][]byte) {
+func (m *mockCache) Store(_ context.Context, data map[string][]byte) {
 	m.Lock()
 	defer m.Unlock()
-	for i := range keys {
-		m.cache[keys[i]] = bufs[i]
+	for k, v := range data {
+		m.cache[k] = v
 	}
 }
 
-func (m *mockCache) Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string) {
+func (m *mockCache) Fetch(ctx context.Context, keys []string) (found map[string][]byte, missing []string) {
 	m.Lock()
 	defer m.Unlock()
 	for _, key := range keys {
 		buf, ok := m.cache[key]
 		if ok {
-			found = append(found, key)
-			bufs = append(bufs, buf)
+			found[key] = buf
 		} else {
 			missing = append(missing, key)
 		}

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -33,8 +33,8 @@ type IndexClient interface {
 type Client interface {
 	Stop()
 
-	PutChunks(ctx context.Context, chunks []Chunk) error
-	GetChunks(ctx context.Context, chunks []Chunk) ([]Chunk, error)
+	PutChunks(ctx context.Context, chunks map[string]Chunk) error
+	GetChunks(ctx context.Context, chunks map[string]Chunk) (map[string]Chunk, error)
 	DeleteChunk(ctx context.Context, userID, chunkID string) error
 }
 


### PR DESCRIPTION
```
// Thanos
type Cache interface {
	Store(ctx context.Context, data map[string][]byte, ttl
time.Duration)
	Fetch(ctx context.Context, keys []string) map[string][]byte
}

// Cortex
type Cache interface {
	Store(ctx context.Context, key []string, buf [][]byte)
	Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missing []string)
	Stop()
}

// Will work towards this nice middle ground:

type Cache interface {
	Store(ctx context.Context, data map[string][]byte)
	Fetch(ctx context.Context, keys []string) (results map[string][]byte, missing []string)
	Stop()
}

```

related to : https://github.com/thanos-io/thanos/pull/3032

Please let me know if think there could be some issues with this change 

Stil WIP as I want to test how well will this work on the Thanos side.

Signed-off-by: Krasi Georgiev <8903888+krasi-georgiev@users.noreply.github.com>

