### PR TITLE
change: separate distributor into api and service module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Distributor API endpoints are no longer served unless target is set to `distributor` or `all`. #3112
 * [CHANGE] Increase the default Cassandra client replication factor to 3. #3007
 * [CHANGE] Experimental blocks storage: removed the support to transfer blocks between ingesters on shutdown. When running the Cortex blocks storage, ingesters are expected to run with a persistent disk. The following metrics have been removed: #2996
   * `cortex_ingester_sent_files`

--- a/pkg/cortex/cortex_test.go
+++ b/pkg/cortex/cortex_test.go
@@ -87,5 +87,5 @@ func TestCortex(t *testing.T) {
 	require.NotNil(t, serviceMap[Server])
 	require.NotNil(t, serviceMap[Ingester])
 	require.NotNil(t, serviceMap[Ring])
-	require.NotNil(t, serviceMap[Distributor])
+	require.NotNil(t, serviceMap[DistributorService])
 }

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -50,7 +50,6 @@ const (
 	Server              string = "server"
 	Distributor         string = "distributor"
 	DistributorService  string = "distributor-service"
-	DistributorAPI      string = "distributor-api"
 	Ingester            string = "ingester"
 	Flusher             string = "flusher"
 	Querier             string = "querier"
@@ -168,7 +167,7 @@ func (t *Cortex) initDistributorService() (serv services.Service, err error) {
 	return t.Distributor, nil
 }
 
-func (t *Cortex) initDistributorAPI() (serv services.Service, err error) {
+func (t *Cortex) initDistributor() (serv services.Service, err error) {
 	t.API.RegisterDistributor(t.Distributor, t.Cfg.Distributor)
 
 	return nil, nil
@@ -637,8 +636,7 @@ func (t *Cortex) setupModuleManager() error {
 	mm.RegisterModule(Ring, t.initRing, modules.UserInvisibleModule)
 	mm.RegisterModule(Overrides, t.initOverrides, modules.UserInvisibleModule)
 	mm.RegisterModule(Distributor, nil)
-	mm.RegisterModule(DistributorAPI, t.initDistributorAPI)
-	mm.RegisterModule(DistributorService, t.initDistributorService)
+	mm.RegisterModule(DistributorService, t.initDistributorService, modules.UserInvisibleModule)
 	mm.RegisterModule(Store, t.initChunkStore, modules.UserInvisibleModule)
 	mm.RegisterModule(DeleteRequestsStore, t.initDeleteRequestsStore, modules.UserInvisibleModule)
 	mm.RegisterModule(Ingester, t.initIngester)
@@ -661,8 +659,7 @@ func (t *Cortex) setupModuleManager() error {
 		API:                {Server},
 		Ring:               {API, RuntimeConfig, MemberlistKV},
 		Overrides:          {RuntimeConfig},
-		Distributor:        {DistributorService, DistributorAPI},
-		DistributorAPI:     {DistributorService, API},
+		Distributor:        {DistributorService, API},
 		DistributorService: {Ring, Overrides},
 		Store:              {Overrides, DeleteRequestsStore},
 		Ingester:           {Overrides, Store, API, RuntimeConfig, MemberlistKV},

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -635,7 +635,7 @@ func (t *Cortex) setupModuleManager() error {
 	mm.RegisterModule(MemberlistKV, t.initMemberlistKV, modules.UserInvisibleModule)
 	mm.RegisterModule(Ring, t.initRing, modules.UserInvisibleModule)
 	mm.RegisterModule(Overrides, t.initOverrides, modules.UserInvisibleModule)
-	mm.RegisterModule(Distributor, nil)
+	mm.RegisterModule(Distributor, t.initDistributor)
 	mm.RegisterModule(DistributorService, t.initDistributorService, modules.UserInvisibleModule)
 	mm.RegisterModule(Store, t.initChunkStore, modules.UserInvisibleModule)
 	mm.RegisterModule(DeleteRequestsStore, t.initDeleteRequestsStore, modules.UserInvisibleModule)


### PR DESCRIPTION
**What this PR does**:

- Decouples the distributor service from the API

**Which issue(s) this PR fixes**:

Fixes #3109 

TLDR: Querier will no longer host distributor endpoints

**Checklist**

- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
