### PR TITLE
makes rule group validation an interface

### DIFF
--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -273,29 +273,6 @@ var (
 	ErrBadRuleGroup = errors.New("unable to decoded rule group")
 )
 
-// ValidateRuleGroup validates a rulegroup
-func ValidateRuleGroup(g rulefmt.RuleGroup) []error {
-	var errs []error
-	for i, r := range g.Rules {
-		for _, err := range r.Validate() {
-			var ruleName string
-			if r.Alert.Value != "" {
-				ruleName = r.Alert.Value
-			} else {
-				ruleName = r.Record.Value
-			}
-			errs = append(errs, &rulefmt.Error{
-				Group:    g.Name,
-				Rule:     i,
-				RuleName: ruleName,
-				Err:      err,
-			})
-		}
-	}
-
-	return errs
-}
-
 func marshalAndSend(output interface{}, w http.ResponseWriter, logger log.Logger) {
 	d, err := yaml.Marshal(&output)
 	if err != nil {
@@ -464,7 +441,7 @@ func (r *Ruler) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	errs := ValidateRuleGroup(rg)
+	errs := r.manager.ValidateRuleGroup(rg)
 	if len(errs) > 0 {
 		for _, err := range errs {
 			level.Error(logger).Log("msg", "unable to validate rule group payload", "err", err.Error())

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/notifier"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
 	promRules "github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/util/strutil"
 	"github.com/weaveworks/common/user"
@@ -137,6 +138,8 @@ type MultiTenantManager interface {
 	GetRules(userID string) []*promRules.Group
 	// Stop stops all Manager components.
 	Stop()
+	// ValidateRuleGroup validates a rulegroup
+	ValidateRuleGroup(rulefmt.RuleGroup) []error
 }
 
 // Ruler evaluates rules.


### PR DESCRIPTION
Prometheus was refactored to support [arbitrary rule loading](https://github.com/prometheus/prometheus/pull/7569), but we currently bind incoming rule groups to promql via the underlying `rulefmt` package implementation. This PR extracts said validation functionality into an interface method on the pre-existing `MultiTenantManager` interface which will allow plug-able implementations (attractive in my case for logql expressions in Loki).