### PR TITLE
Allow the Ruler to delete a whole namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 * [ENHANCEMENT] Memcached dial() calls now have an optional circuit-breaker to avoid hammering a broken cache #3051
 * [ENHANCEMENT] Add TLS support to etcd client. #3102
 * [ENHANCEMENT] When a tenant accesses the Alertmanager UI or its API, if we have valid `-alertmanager.configs.fallback` we'll use that to start the manager and avoid failing the request. #3073
-* [ENHANCEMENT] Add `DELETE api/v1/rules/{namespace}` to the Ruler. It allows all the rule groups of a namespace to be deleted. #XXXX
+* [ENHANCEMENT] Add `DELETE api/v1/rules/{namespace}` to the Ruler. It allows all the rule groups of a namespace to be deleted. #3120
 * [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
 * [BUGFIX] Querier: Merge results from chunks and blocks ingesters when using streaming of results. #3013
 * [BUGFIX] Querier: query /series from ingesters regardless the `-querier.query-ingesters-within` setting. #3035
@@ -43,6 +43,7 @@
 * [BUGFIX] Fixes `flag needs an argument: -config.expand-env` error. #3087
 * [BUGFIX] An index optimisation actually slows things down when using caching. Moved it to the right location. #2973
 * [BUGFIX] Ingester: If push request contained both valid and invalid samples, valid samples were ingested but not stored to WAL of the chunks storage. This has been fixed. #3067
+* [BUGFIX] Ruler: Config API would return both the `record` and `alert` in `YAML` response keys even when one of them must be empty. #3120
 
 ## 1.3.0 / 2020-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [ENHANCEMENT] Memcached dial() calls now have an optional circuit-breaker to avoid hammering a broken cache #3051
 * [ENHANCEMENT] Add TLS support to etcd client. #3102
 * [ENHANCEMENT] When a tenant accesses the Alertmanager UI or its API, if we have valid `-alertmanager.configs.fallback` we'll use that to start the manager and avoid failing the request. #3073
+* [ENHANCEMENT] Add `DELETE api/v1/rules/{namespace}` to the Ruler. It allows all the rule groups of a namespace to be deleted. #XXXX
 * [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
 * [BUGFIX] Querier: Merge results from chunks and blocks ingesters when using streaming of results. #3013
 * [BUGFIX] Querier: query /series from ingesters regardless the `-querier.query-ingesters-within` setting. #3035

--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -45,6 +45,7 @@ For the sake of clarity, in this document we have grouped API endpoints by servi
 | [Get rule group](#get-rule-group) | Ruler | `GET /api/v1/rules/{namespace}/{groupName}` |
 | [Set rule group](#set-rule-group) | Ruler | `POST /api/v1/rules/{namespace}` |
 | [Delete rule group](#delete-rule-group) | Ruler | `DELETE /api/v1/rules/{namespace}/{groupName}` |
+| [Delete namespace](#delete-namespace) | Ruler | `DELETE /api/v1/rules/{namespace}` |
 | [Alertmanager status](#alertmanager-status) | Alertmanager | `GET /multitenant_alertmanager/status` |
 | [Alertmanager UI](#alertmanager-ui) | Alertmanager | `GET /<alertmanager-http-prefix>` |
 | [Get Alertmanager configuration](#get-alertmanager-configuration) | Alertmanager | `GET /api/v1/alerts` |
@@ -553,6 +554,17 @@ DELETE <legacy-http-prefix>/rules/{namespace}/{groupName}
 ```
 
 Deletes a rule group by namespace and group name. This endpoints returns `202` on success.
+
+### Delete namespace
+
+```
+DELETE /api/v1/rules/{namespace}
+
+# Legacy
+DELETE <legacy-http-prefix>/rules/{namespace}
+```
+
+Deletes all the rule groups in a namespace (including the namespace itself). This endpoint returns `202` on success.
 
 _This experimental endpoint is disabled by default and can be enabled via the `-experimental.ruler.enable-api` CLI flag (or its respective YAML config option)._
 

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -331,7 +331,7 @@ func (c *Client) DeleteNamespace(namespace string) error {
 	defer cancel()
 
 	// Execute HTTP request
-	_, err := c.httpClient.Do(req.WithContext(ctx))
+	_, err = c.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -317,6 +317,7 @@ func (c *Client) DeleteRuleGroup(namespace string, groupName string) error {
 	return nil
 }
 
+// DeleteNamespace deletes all the rule groups (and the namespace itself).
 func (c *Client) DeleteNamespace(namespace string) error {
 	// Create HTTP request
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s/api/prom/rules/%s", c.rulerAddress, url.PathEscape(namespace)), nil)
@@ -324,19 +325,17 @@ func (c *Client) DeleteNamespace(namespace string) error {
 		return err
 	}
 
-	req.Header.Set("Content-Type", "application/yaml")
 	req.Header.Set("X-Scope-OrgID", c.orgID)
 
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
 	// Execute HTTP request
-	res, err := c.httpClient.Do(req.WithContext(ctx))
+	_, err := c.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}
 
-	defer res.Body.Close()
 	return nil
 }
 

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -317,6 +317,29 @@ func (c *Client) DeleteRuleGroup(namespace string, groupName string) error {
 	return nil
 }
 
+func (c *Client) DeleteNamespace(namespace string) error {
+	// Create HTTP request
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s/api/prom/rules/%s", c.rulerAddress, url.PathEscape(namespace)), nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/yaml")
+	req.Header.Set("X-Scope-OrgID", c.orgID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	// Execute HTTP request
+	res, err := c.httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+	return nil
+}
+
 // userConfig is used to communicate a users alertmanager configs
 type userConfig struct {
 	TemplateFiles      map[string]string `yaml:"template_files"`

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -77,7 +77,7 @@ func TestRulerAPI(t *testing.T) {
 
 	// Delete the set rule groups
 	require.NoError(t, c.DeleteRuleGroup(namespaceOne, ruleGroup.Name))
-	require.NoError(t, c.DeleteRuleGroup(namespaceTwo, ruleGroup.Name))
+	require.NoError(t, c.DeleteNamespace(namespaceTwo))
 
 	// Wait until the users manager has been terminated
 	require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(0), "cortex_ruler_managers_total"))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -234,6 +234,7 @@ func (a *API) RegisterRuler(r *ruler.Ruler, apiEnabled bool) {
 		a.RegisterRoute("/api/v1/rules/{namespace}/{groupName}", http.HandlerFunc(r.GetRuleGroup), true, "GET")
 		a.RegisterRoute("/api/v1/rules/{namespace}", http.HandlerFunc(r.CreateRuleGroup), true, "POST")
 		a.RegisterRoute("/api/v1/rules/{namespace}/{groupName}", http.HandlerFunc(r.DeleteRuleGroup), true, "DELETE")
+		a.RegisterRoute("/api/v1/rules/{namespace}", http.HandlerFunc(r.DeleteNamespace), true, "DELETE")
 
 		// Legacy Prometheus Rule API Routes
 		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/rules", http.HandlerFunc(r.PrometheusRules), true, "GET")
@@ -245,10 +246,11 @@ func (a *API) RegisterRuler(r *ruler.Ruler, apiEnabled bool) {
 		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}/{groupName}", http.HandlerFunc(r.GetRuleGroup), true, "GET")
 		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}", http.HandlerFunc(r.CreateRuleGroup), true, "POST")
 		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}/{groupName}", http.HandlerFunc(r.DeleteRuleGroup), true, "DELETE")
+		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}", http.HandlerFunc(r.DeleteNamespace), true, "DELETE")
 	}
 }
 
-// // RegisterRing registers the ring UI page associated with the distributor for writes.
+// RegisterRing registers the ring UI page associated with the distributor for writes.
 func (a *API) RegisterRing(r *ring.Ring) {
 	a.RegisterRoute("/ingester/ring", r, false)
 

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -463,6 +463,28 @@ func (r *Ruler) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 	respondAccepted(w, logger)
 }
 
+func (r *Ruler) DeleteNamespace(w http.ResponseWriter, req *http.Request) {
+	logger := util.WithContext(req.Context(), util.Logger)
+
+	userID, namespace, _, err := parseRequest(req, true, false)
+	if err != nil {
+		respondError(logger, w, err.Error())
+		return
+	}
+
+	err = r.store.DeleteNamespace(req.Context(), userID, namespace)
+	if err != nil {
+		if err == rules.ErrGroupNamespaceNotFound {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		respondError(logger, w, err.Error())
+		return
+	}
+
+	respondAccepted(w, logger)
+}
+
 func (r *Ruler) DeleteRuleGroup(w http.ResponseWriter, req *http.Request) {
 	logger := util.WithContext(req.Context(), util.Logger)
 

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -231,6 +231,14 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusAccepted, w.Code)
 	require.Equal(t, "{\"status\":\"success\",\"data\":null,\"errorType\":\"\",\"error\":\"\"}", w.Body.String())
+
+	// On Partial failures
+	req = requestFor(t, http.MethodDelete, "https://localhost:8080/api/v1/rules/namespace2", nil, "user1")
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Equal(t, "{\"status\":\"error\",\"data\":null,\"errorType\":\"server_error\",\"error\":\"unable to delete rg\"}", w.Body.String())
 }
 
 func requestFor(t *testing.T, method string, url string, body io.Reader, userID string) *http.Request {

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -170,8 +170,7 @@ func TestRuler_Create(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	rules := `
-name: test
+	rules := `name: test
 interval: 15s
 rules:
 - record: up_rule
@@ -202,6 +201,7 @@ rules:
 
 	router.ServeHTTP(w, req)
 	require.Equal(t, 200, w.Code)
+	require.Equal(t, "name: test\ninterval: 15s\nrules:\n    - record: up_rule\n      expr: up{}\n    - alert: up_alert\n      expr: sum(up{}) > 1\n      for: 30s\n      labels:\n        test: test\n      annotations:\n        test: test\n", w.Body.String())
 }
 
 func TestRuler_DeleteNamespace(t *testing.T) {
@@ -217,13 +217,12 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 	router.Path("/api/v1/rules/{namespace}/{groupName}").Methods(http.MethodGet).HandlerFunc(r.GetRuleGroup)
 
 	// Verify namespace1 rules are there.
-
 	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/v1/rules/namespace1/group1", nil, "user1")
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "name: group1\ninterval: 1m\nrules:\n    - record: UP_RULE\n      alert: \"\"\n      expr: up\n    - record: \"\"\n      alert: UP_ALERT\n      expr: up < 1\n", w.Body.String())
+	require.Equal(t, "name: group1\ninterval: 1m\nrules:\n    - record: UP_RULE\n      expr: up\n    - alert: UP_ALERT\n      expr: up < 1\n", w.Body.String())
 
 	// Delete namespace1
 	req = requestFor(t, http.MethodDelete, "https://localhost:8080/api/v1/rules/namespace1", nil, "user1")

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -3,6 +3,7 @@ package ruler
 import (
 	"context"
 	"encoding/json"
+	io "io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -25,8 +26,7 @@ func TestRuler_rules(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	req := httptest.NewRequest("GET", "https://localhost:8080/api/prom/api/v1/rules", nil)
-	req.Header.Add(user.OrgIDHeaderName, "user1")
+	req := requestFor(t, "GET", "https://localhost:8080/api/prom/api/v1/rules", nil, "user1")
 	w := httptest.NewRecorder()
 	r.PrometheusRules(w, req)
 
@@ -81,8 +81,7 @@ func TestRuler_rules_special_characters(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	req := httptest.NewRequest("GET", "https://localhost:8080/api/prom/api/v1/rules", nil)
-	req.Header.Add(user.OrgIDHeaderName, "user1")
+	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/prom/api/v1/rules", nil, "user1")
 	w := httptest.NewRecorder()
 	r.PrometheusRules(w, req)
 
@@ -137,8 +136,7 @@ func TestRuler_alerts(t *testing.T) {
 	defer rcleanup()
 	defer r.StopAsync()
 
-	req := httptest.NewRequest("GET", "https://localhost:8080/api/prom/api/v1/alerts", nil)
-	req.Header.Add(user.OrgIDHeaderName, "user1")
+	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/prom/api/v1/alerts", nil, "user1")
 	w := httptest.NewRecorder()
 	r.PrometheusAlerts(w, req)
 
@@ -192,20 +190,56 @@ rules:
 	router.Path("/api/v1/rules/{namespace}/{groupName}").Methods("GET").HandlerFunc(r.GetRuleGroup)
 
 	// POST
-	req := httptest.NewRequest("POST", "https://localhost:8080/api/v1/rules/namespace", strings.NewReader(rules))
-	req.Header.Add(user.OrgIDHeaderName, "user1")
-	ctx := user.InjectOrgID(req.Context(), "user1")
+	req := requestFor(t, http.MethodPost, "https://localhost:8080/api/v1/rules/namespace", strings.NewReader(rules), "user1")
 	w := httptest.NewRecorder()
 
-	router.ServeHTTP(w, req.WithContext(ctx))
+	router.ServeHTTP(w, req)
 	require.Equal(t, 202, w.Code)
 
 	// GET
-	req = httptest.NewRequest("GET", "https://localhost:8080/api/v1/rules/namespace/test", nil)
-	req.Header.Add(user.OrgIDHeaderName, "user1")
-	ctx = user.InjectOrgID(req.Context(), "user1")
+	req = requestFor(t, http.MethodGet, "https://localhost:8080/api/v1/rules/namespace/test", nil, "user1")
 	w = httptest.NewRecorder()
 
-	router.ServeHTTP(w, req.WithContext(ctx))
+	router.ServeHTTP(w, req)
 	require.Equal(t, 200, w.Code)
+}
+
+func TestRuler_DeleteNamespace(t *testing.T) {
+	cfg, cleanup := defaultRulerConfig(newMockRuleStore(mockRulesNamespaces))
+	defer cleanup()
+
+	r, rcleanup := newTestRuler(t, cfg)
+	defer rcleanup()
+	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
+
+	router := mux.NewRouter()
+	router.Path("/api/v1/rules/{namespace}").Methods(http.MethodDelete).HandlerFunc(r.DeleteNamespace)
+	router.Path("/api/v1/rules/{namespace}/{groupName}").Methods(http.MethodGet).HandlerFunc(r.GetRuleGroup)
+
+	// Verify namespace1 rules are there.
+
+	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/v1/rules/namespace1/group1", nil, "user1")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "name: group1\ninterval: 1m\nrules:\n    - record: UP_RULE\n      alert: \"\"\n      expr: up\n    - record: \"\"\n      alert: UP_ALERT\n      expr: up < 1\n", w.Body.String())
+
+	// Delete namespace1
+	req = requestFor(t, http.MethodDelete, "https://localhost:8080/api/v1/rules/namespace1", nil, "user1")
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code)
+	require.Equal(t, "{\"status\":\"success\",\"data\":null,\"errorType\":\"\",\"error\":\"\"}", w.Body.String())
+}
+
+func requestFor(t *testing.T, method string, url string, body io.Reader, userID string) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(method, url, body)
+	req.Header.Add(user.OrgIDHeaderName, userID)
+	ctx := user.InjectOrgID(req.Context(), userID)
+
+	return req.WithContext(ctx)
 }

--- a/pkg/ruler/rules/compat.go
+++ b/pkg/ruler/rules/compat.go
@@ -48,19 +48,24 @@ func FromProto(rg *RuleGroupDesc) rulefmt.RuleGroup {
 	}
 
 	for i, rl := range rg.GetRules() {
-		recordNode := yaml.Node{}
-		recordNode.SetString(rl.GetRecord())
-		alertNode := yaml.Node{}
-		alertNode.SetString(rl.GetAlert())
 		exprNode := yaml.Node{}
 		exprNode.SetString(rl.GetExpr())
+
 		newRule := rulefmt.RuleNode{
-			Record:      recordNode,
-			Alert:       alertNode,
 			Expr:        exprNode,
 			Labels:      client.FromLabelAdaptersToLabels(rl.Labels).Map(),
 			Annotations: client.FromLabelAdaptersToLabels(rl.Annotations).Map(),
 			For:         model.Duration(rl.GetFor()),
+		}
+
+		if rl.GetRecord() != "" {
+			recordNode := yaml.Node{}
+			recordNode.SetString(rl.GetRecord())
+			newRule.Record = recordNode
+		} else {
+			alertNode := yaml.Node{}
+			alertNode.SetString(rl.GetAlert())
+			newRule.Alert = alertNode
 		}
 
 		formattedRuleGroup.Rules[i] = newRule

--- a/pkg/ruler/rules/local/local.go
+++ b/pkg/ruler/rules/local/local.go
@@ -87,6 +87,11 @@ func (l *Client) DeleteRuleGroup(ctx context.Context, userID, namespace string, 
 	return errors.New("DeleteRuleGroup unsupported in rule local store")
 }
 
+// DeleteNamespace implements RulerStore
+func (l *Client) DeleteNamespace(ctx context.Context, userID, namespace string) error {
+	return errors.New("DeleteNamespace unsupported in rule local store")
+}
+
 func (l *Client) listAllRulesGroupsForUser(ctx context.Context, userID string) (rules.RuleGroupList, error) {
 	var allLists rules.RuleGroupList
 

--- a/pkg/ruler/rules/objectclient/rule_store.go
+++ b/pkg/ruler/rules/objectclient/rule_store.go
@@ -160,7 +160,6 @@ func (o *RuleStore) DeleteNamespace(ctx context.Context, userID, namespace strin
 		return rules.ErrGroupNamespaceNotFound
 	}
 
-	//TODO: Probably collect individual errors and aggregate them into a single one?
 	for _, obj := range ruleGroupObjects {
 		level.Debug(util.Logger).Log("msg", "deleting rule group", "namespace", namespace, "key", obj.Key)
 		err = o.client.DeleteObject(ctx, obj.Key)

--- a/pkg/ruler/rules/objectclient/rule_store.go
+++ b/pkg/ruler/rules/objectclient/rule_store.go
@@ -165,6 +165,7 @@ func (o *RuleStore) DeleteNamespace(ctx context.Context, userID, namespace strin
 		err = o.client.DeleteObject(ctx, obj.Key)
 		if err != nil {
 			level.Error(util.Logger).Log("msg", "unable to delete rule group from namespace", "err", err, "namespace", namespace, "key", obj.Key)
+			return err
 		}
 	}
 

--- a/pkg/ruler/rules/objectclient/rule_store.go
+++ b/pkg/ruler/rules/objectclient/rule_store.go
@@ -176,11 +176,18 @@ func generateRuleObjectKey(id, namespace, name string) string {
 	if id == "" {
 		return rulePrefix
 	}
+
 	prefix := rulePrefix + id + "/"
 	if namespace == "" {
 		return prefix
 	}
-	return prefix + base64.URLEncoding.EncodeToString([]byte(namespace)) + "/" + base64.URLEncoding.EncodeToString([]byte(name))
+
+	ns := base64.URLEncoding.EncodeToString([]byte(namespace)) + "/"
+	if name == "" {
+		return prefix + ns
+	}
+
+	return prefix + ns + base64.URLEncoding.EncodeToString([]byte(name))
 }
 
 func decomposeRuleObjectKey(handle string) string {

--- a/pkg/ruler/rules/store.go
+++ b/pkg/ruler/rules/store.go
@@ -26,6 +26,7 @@ type RuleStore interface {
 	GetRuleGroup(ctx context.Context, userID, namespace, group string) (*RuleGroupDesc, error)
 	SetRuleGroup(ctx context.Context, userID, namespace string, group *RuleGroupDesc) error
 	DeleteRuleGroup(ctx context.Context, userID, namespace string, group string) error
+	DeleteNamespace(ctx context.Context, userID, namespace string) error
 }
 
 // RuleGroupList contains a set of rule groups
@@ -127,5 +128,10 @@ func (c *ConfigRuleStore) SetRuleGroup(ctx context.Context, userID, namespace st
 
 // DeleteRuleGroup is not implemented
 func (c *ConfigRuleStore) DeleteRuleGroup(ctx context.Context, userID, namespace string, group string) error {
+	return errors.New("not implemented by the config service rule store")
+}
+
+// DeleteNamespace is not implemented
+func (c *ConfigRuleStore) DeleteNamespace(ctx context.Context, userID, namespace string) error {
 	return errors.New("not implemented by the config service rule store")
 }

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -121,10 +121,7 @@ func (m *mockRuleStore) ListAllRuleGroups(ctx context.Context) (map[string]rules
 	copy := make(map[string]rules.RuleGroupList)
 	for k, v := range m.rules {
 		rgl := make(rules.RuleGroupList, 0, len(v))
-		for _, rgc := range v {
-			rgl = append(rgl, rgc)
-		}
-
+		rgl = append(rgl, v...)
 		copy[k] = rgl
 	}
 

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -120,7 +120,12 @@ func (m *mockRuleStore) ListAllRuleGroups(ctx context.Context) (map[string]rules
 
 	copy := make(map[string]rules.RuleGroupList)
 	for k, v := range m.rules {
-		copy[k] = v
+		rgl := make(rules.RuleGroupList, 0, len(v))
+		for _, rgc := range v {
+			rgl = append(rgl, rgc)
+		}
+
+		copy[k] = rgl
 	}
 
 	return copy, nil

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -14,8 +14,44 @@ type mockRuleStore struct {
 }
 
 var (
-	interval, _ = time.ParseDuration("1m")
-	mockRules   = map[string]rules.RuleGroupList{
+	interval, _         = time.ParseDuration("1m")
+	mockRulesNamespaces = map[string]rules.RuleGroupList{
+		"user1": {
+			&rules.RuleGroupDesc{
+				Name:      "group1",
+				Namespace: "namespace1",
+				User:      "user1",
+				Rules: []*rules.RuleDesc{
+					{
+						Record: "UP_RULE",
+						Expr:   "up",
+					},
+					{
+						Alert: "UP_ALERT",
+						Expr:  "up < 1",
+					},
+				},
+				Interval: interval,
+			},
+			&rules.RuleGroupDesc{
+				Name:      "group2",
+				Namespace: "namespace1",
+				User:      "user1",
+				Rules: []*rules.RuleDesc{
+					{
+						Record: "UP2_RULE",
+						Expr:   "up",
+					},
+					{
+						Alert: "UP2_ALERT",
+						Expr:  "up < 1",
+					},
+				},
+				Interval: interval,
+			},
+		},
+	}
+	mockRules = map[string]rules.RuleGroupList{
 		"user1": {
 			&rules.RuleGroupDesc{
 				Name:      "group1",
@@ -183,6 +219,29 @@ func (m *mockRuleStore) DeleteRuleGroup(ctx context.Context, userID string, name
 		if rg.Namespace == namespace && rg.Name == group {
 			m.rules[userID] = append(userRules[:i], userRules[:i+1]...)
 			return nil
+		}
+	}
+
+	return nil
+}
+
+func (m *mockRuleStore) DeleteNamespace(ctx context.Context, userID, namespace string) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	userRules, exists := m.rules[userID]
+	if !exists {
+		userRules = rules.RuleGroupList{}
+		m.rules[userID] = userRules
+	}
+
+	if namespace == "" {
+		return rules.ErrGroupNamespaceNotFound
+	}
+
+	for i, rg := range userRules {
+		if rg.Namespace == namespace {
+			m.rules[userID] = append(userRules[:i], userRules[i+1:]...)
 		}
 	}
 

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -2,6 +2,7 @@ package ruler
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -34,8 +35,8 @@ var (
 				Interval: interval,
 			},
 			&rules.RuleGroupDesc{
-				Name:      "group2",
-				Namespace: "namespace1",
+				Name:      "fail",
+				Namespace: "namespace2",
 				User:      "user1",
 				Rules: []*rules.RuleDesc{
 					{
@@ -243,6 +244,12 @@ func (m *mockRuleStore) DeleteNamespace(ctx context.Context, userID, namespace s
 
 	for i, rg := range userRules {
 		if rg.Namespace == namespace {
+
+			// Only here to assert on partial failures.
+			if rg.Name == "fail" {
+				return fmt.Errorf("unable to delete rg")
+			}
+
 			m.rules[userID] = append(userRules[:i], userRules[i+1:]...)
 		}
 	}


### PR DESCRIPTION
**What this PR does**:

Allow the Ruler API to delete a whole namespace. There's also a small bugfix that fixes responses in the ruler API.


Needs:

- [x] Integration test

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
