### PR TITLE
blocksconvert: Set compaction sources correctly

### DIFF
--- a/tools/blocksconvert/builder/tsdb.go
+++ b/tools/blocksconvert/builder/tsdb.go
@@ -191,6 +191,10 @@ func (d *tsdbBuilder) finishBlock(source string, labels map[string]string) (ulid
 			Version: 1,
 			MinTime: math.MaxInt64,
 			MaxTime: math.MinInt64,
+			Compaction: tsdb.BlockMetaCompaction{
+				Level:   1,
+				Sources: []ulid.ULID{d.ulid},
+			},
 		},
 
 		Thanos: metadata.Thanos{

--- a/tools/blocksconvert/builder/tsdb_test.go
+++ b/tools/blocksconvert/builder/tsdb_test.go
@@ -117,18 +117,18 @@ func TestTsdbBuilder(t *testing.T) {
 	m, err := metadata.Read(filepath.Join(dir, id.String()))
 	require.NoError(t, err)
 
-	otherId := ulid.MustNew(ulid.Now(), nil)
+	otherID := ulid.MustNew(ulid.Now(), nil)
 
 	// Make sure that deduplicate filter doesn't remove this block (thanks to correct sources).
 	df := block.NewDeduplicateFilter()
 	inp := map[ulid.ULID]*metadata.Meta{
-		otherId: {
+		otherID: {
 			BlockMeta: tsdb.BlockMeta{
-				ULID:    otherId,
+				ULID:    otherID,
 				MinTime: 0,
 				MaxTime: 0,
 				Compaction: tsdb.BlockMetaCompaction{
-					Sources: []ulid.ULID{otherId},
+					Sources: []ulid.ULID{otherID},
 				},
 				Version: 0,
 			},

--- a/tools/blocksconvert/builder/tsdb_test.go
+++ b/tools/blocksconvert/builder/tsdb_test.go
@@ -78,6 +78,7 @@ func TestTsdbBuilder(t *testing.T) {
 	blocks := db.Blocks()
 	require.Equal(t, 1, len(blocks))
 	require.Equal(t, id, blocks[0].Meta().ULID)
+	require.Equal(t, id, blocks[0].Meta().Compaction.Sources[0])
 	require.Equal(t, uint64(seriesCount), blocks[0].Meta().Stats.NumSeries)
 	require.Equal(t, uint64(totalSamples.Load()), blocks[0].Meta().Stats.NumSamples)
 


### PR DESCRIPTION
**What this PR does**: This PR fixes meta.json file of converted blocks.

Without correct `sources` in `meta.json`, compactor will treat blocks as subsumed by any other block that exists, and delete it eventually.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
