### PR TITLE
AwaitHealthy now returns more descriptive error message

### DIFF
--- a/pkg/util/services/manager_test.go
+++ b/pkg/util/services/manager_test.go
@@ -177,7 +177,9 @@ func TestManagerThatFailsToStart(t *testing.T) {
 	require.Equal(t, states, map[State][]Service{New: {s1, s2, s3}})
 
 	require.NoError(t, m.StartAsync(context.Background()))
-	require.Error(t, m.AwaitHealthy(context.Background())) // will never get healthy, since one service fails to start
+	err = m.AwaitHealthy(context.Background())
+	require.Error(t, err) // will never get healthy, since one service fails to start
+	require.EqualError(t, err, "not healthy, 0 terminated, 1 failed: [failed to start]")
 
 	states = m.ServicesByState()
 	// check that failed state contains s3.


### PR DESCRIPTION
**What this PR does**: This PR modifies `(*services.Manager).AwaitHealthy` method to return more descriptive error message, including the failure cases of failed services.

**Which issue(s) this PR fixes**:
Fixes #3124 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
