### PR TITLE
Index page should honor configured HTTP path prefix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [BUGFIX] Fixes `flag needs an argument: -config.expand-env` error. #3087
 * [BUGFIX] An index optimisation actually slows things down when using caching. Moved it to the right location. #2973
 * [BUGFIX] Ingester: If push request contained both valid and invalid samples, valid samples were ingested but not stored to WAL of the chunks storage. This has been fixed. #3067
+* [BUGFIX] Index page now uses configured HTTP path prefix when creating links. #3126
 
 ## 1.3.0 / 2020-08-21
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -166,9 +166,9 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, tar
 }
 
 // RegisterAPI registers the standard endpoints associated with a running Cortex.
-func (a *API) RegisterAPI(cfg interface{}) {
+func (a *API) RegisterAPI(httpPathPrefix string, cfg interface{}) {
 	a.RegisterRoute("/config", configHandler(cfg), false)
-	a.RegisterRoute("/", http.HandlerFunc(indexHandler), false)
+	a.RegisterRoute("/", indexHandler(httpPathPrefix), false)
 }
 
 // RegisterDistributor registers the endpoints associated with the distributor.

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -23,21 +23,21 @@ var indexPageContent = template.Must(template.New("main").Parse(`
 		<h1>Cortex</h1>
 		<p>Admin Endpoints:</p>
 		<ul>
-			<li><a href="{{ .JoinPath "/config" }}">Current Config</a></li>
-			<li><a href="{{ .JoinPath "/distributor/all_user_stats" }}">Usage Statistics</a></li>
-			<li><a href="{{ .JoinPath "/distributor/ha_tracker" }}">HA Tracking Status</a></li>
-			<li><a href="{{ .JoinPath "/multitenant_alertmanager/status" }}">Alertmanager Status</a></li>
-			<li><a href="{{ .JoinPath "/ingester/ring" }}">Ingester Ring Status</a></li>
-			<li><a href="{{ .JoinPath "/ruler/ring" }}">Ruler Ring Status</a></li>
-			<li><a href="{{ .JoinPath "/services" }}">Service Status</a></li>
-			<li><a href="{{ .JoinPath "/compactor/ring" }}">Compactor Ring Status (experimental blocks storage)</a></li>
-			<li><a href="{{ .JoinPath "/store-gateway/ring" }}">Store Gateway Ring (experimental blocks storage)</a></li>
+			<li><a href="{{ .AddPathPrefix "/config" }}">Current Config</a></li>
+			<li><a href="{{ .AddPathPrefix "/distributor/all_user_stats" }}">Usage Statistics</a></li>
+			<li><a href="{{ .AddPathPrefix "/distributor/ha_tracker" }}">HA Tracking Status</a></li>
+			<li><a href="{{ .AddPathPrefix "/multitenant_alertmanager/status" }}">Alertmanager Status</a></li>
+			<li><a href="{{ .AddPathPrefix "/ingester/ring" }}">Ingester Ring Status</a></li>
+			<li><a href="{{ .AddPathPrefix "/ruler/ring" }}">Ruler Ring Status</a></li>
+			<li><a href="{{ .AddPathPrefix "/services" }}">Service Status</a></li>
+			<li><a href="{{ .AddPathPrefix "/compactor/ring" }}">Compactor Ring Status (experimental blocks storage)</a></li>
+			<li><a href="{{ .AddPathPrefix "/store-gateway/ring" }}">Store Gateway Ring (experimental blocks storage)</a></li>
 		</ul>
 
 		<p>Dangerous:</p>
 		<ul>
-			<li><a href="{{ .JoinPath "/ingester/flush" }}">Trigger a Flush</a></li>
-			<li><a href="{{ .JoinPath "/ingester/shutdown" }}">Trigger Ingester Shutdown</a></li>
+			<li><a href="{{ .AddPathPrefix "/ingester/flush" }}">Trigger a Flush</a></li>
+			<li><a href="{{ .AddPathPrefix "/ingester/shutdown" }}">Trigger Ingester Shutdown</a></li>
 		</ul>
 	</body>
 </html>`))
@@ -46,7 +46,7 @@ type indexPageInput struct {
 	pathPrefix string
 }
 
-func (i indexPageInput) JoinPath(p string) string {
+func (i indexPageInput) AddPathPrefix(p string) string {
 	return path.Join(i.pathPrefix, p)
 }
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"html/template"
 	"net/http"
+	"path"
 
 	"github.com/go-kit/kit/log/level"
 	"gopkg.in/yaml.v2"
@@ -10,7 +12,7 @@ import (
 )
 
 // TODO: Update this content to be a template that is dynamic based on how Cortex is run.
-const indexPageContent = `
+var indexPageContent = template.Must(template.New("main").Parse(`
 <!DOCTYPE html>
 <html>
 	<head>
@@ -21,29 +23,39 @@ const indexPageContent = `
 		<h1>Cortex</h1>
 		<p>Admin Endpoints:</p>
 		<ul>
-			<li><a href="/config">Current Config</a></li>
-			<li><a href="/distributor/all_user_stats">Usage Statistics</a></li>
-			<li><a href="/distributor/ha_tracker">HA Tracking Status</a></li>
-			<li><a href="/multitenant_alertmanager/status">Alertmanager Status</a></li>
-			<li><a href="/ingester/ring">Ingester Ring Status</a></li>
-			<li><a href="/ruler/ring">Ruler Ring Status</a></li>
-			<li><a href="/services">Service Status</a></li>
-			<li><a href="/compactor/ring">Compactor Ring Status (experimental blocks storage)</a></li
-			<li><a href="/store-gateway/ring">Store Gateway Ring (experimental blocks storage)</a></li>
+			<li><a href="{{ .Join "/config" }}">Current Config</a></li>
+			<li><a href="{{ .Join "/distributor/all_user_stats" }}">Usage Statistics</a></li>
+			<li><a href="{{ .Join "/distributor/ha_tracker" }}">HA Tracking Status</a></li>
+			<li><a href="{{ .Join "/multitenant_alertmanager/status" }}">Alertmanager Status</a></li>
+			<li><a href="{{ .Join "/ingester/ring" }}">Ingester Ring Status</a></li>
+			<li><a href="{{ .Join "/ruler/ring" }}">Ruler Ring Status</a></li>
+			<li><a href="{{ .Join "/services" }}">Service Status</a></li>
+			<li><a href="{{ .Join "/compactor/ring" }}">Compactor Ring Status (experimental blocks storage)</a></li>
+			<li><a href="{{ .Join "/store-gateway/ring" }}">Store Gateway Ring (experimental blocks storage)</a></li>
 		</ul>
 
 		<p>Dangerous:</p>
 		<ul>
-			<li><a href="/ingester/flush">Trigger a Flush</a></li>
-			<li><a href="/ingester/shutdown">Trigger Ingester Shutdown</a></li>
+			<li><a href="{{ .Join "/ingester/flush" }}">Trigger a Flush</a></li>
+			<li><a href="{{ .Join "/ingester/shutdown" }}">Trigger Ingester Shutdown</a></li>
 		</ul>
 	</body>
-</html>`
+</html>`))
 
-func indexHandler(w http.ResponseWriter, _ *http.Request) {
-	if _, err := w.Write([]byte(indexPageContent)); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+type templateInp struct {
+	Prefix string
+}
+
+func (i templateInp) Join(p string) string {
+	return path.Join(i.Prefix, p)
+}
+
+func indexHandler(httpPathPrefix string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := indexPageContent.Execute(w, templateInp{Prefix: httpPathPrefix})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 	}
 }
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -23,36 +23,36 @@ var indexPageContent = template.Must(template.New("main").Parse(`
 		<h1>Cortex</h1>
 		<p>Admin Endpoints:</p>
 		<ul>
-			<li><a href="{{ .Join "/config" }}">Current Config</a></li>
-			<li><a href="{{ .Join "/distributor/all_user_stats" }}">Usage Statistics</a></li>
-			<li><a href="{{ .Join "/distributor/ha_tracker" }}">HA Tracking Status</a></li>
-			<li><a href="{{ .Join "/multitenant_alertmanager/status" }}">Alertmanager Status</a></li>
-			<li><a href="{{ .Join "/ingester/ring" }}">Ingester Ring Status</a></li>
-			<li><a href="{{ .Join "/ruler/ring" }}">Ruler Ring Status</a></li>
-			<li><a href="{{ .Join "/services" }}">Service Status</a></li>
-			<li><a href="{{ .Join "/compactor/ring" }}">Compactor Ring Status (experimental blocks storage)</a></li>
-			<li><a href="{{ .Join "/store-gateway/ring" }}">Store Gateway Ring (experimental blocks storage)</a></li>
+			<li><a href="{{ .JoinPath "/config" }}">Current Config</a></li>
+			<li><a href="{{ .JoinPath "/distributor/all_user_stats" }}">Usage Statistics</a></li>
+			<li><a href="{{ .JoinPath "/distributor/ha_tracker" }}">HA Tracking Status</a></li>
+			<li><a href="{{ .JoinPath "/multitenant_alertmanager/status" }}">Alertmanager Status</a></li>
+			<li><a href="{{ .JoinPath "/ingester/ring" }}">Ingester Ring Status</a></li>
+			<li><a href="{{ .JoinPath "/ruler/ring" }}">Ruler Ring Status</a></li>
+			<li><a href="{{ .JoinPath "/services" }}">Service Status</a></li>
+			<li><a href="{{ .JoinPath "/compactor/ring" }}">Compactor Ring Status (experimental blocks storage)</a></li>
+			<li><a href="{{ .JoinPath "/store-gateway/ring" }}">Store Gateway Ring (experimental blocks storage)</a></li>
 		</ul>
 
 		<p>Dangerous:</p>
 		<ul>
-			<li><a href="{{ .Join "/ingester/flush" }}">Trigger a Flush</a></li>
-			<li><a href="{{ .Join "/ingester/shutdown" }}">Trigger Ingester Shutdown</a></li>
+			<li><a href="{{ .JoinPath "/ingester/flush" }}">Trigger a Flush</a></li>
+			<li><a href="{{ .JoinPath "/ingester/shutdown" }}">Trigger Ingester Shutdown</a></li>
 		</ul>
 	</body>
 </html>`))
 
-type templateInp struct {
-	Prefix string
+type indexPageInput struct {
+	pathPrefix string
 }
 
-func (i templateInp) Join(p string) string {
-	return path.Join(i.Prefix, p)
+func (i indexPageInput) JoinPath(p string) string {
+	return path.Join(i.pathPrefix, p)
 }
 
 func indexHandler(httpPathPrefix string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		err := indexPageContent.Execute(w, templateInp{Prefix: httpPathPrefix})
+		err := indexPageContent.Execute(w, indexPageInput{pathPrefix: httpPathPrefix})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -15,9 +15,9 @@ func TestIndexHandlerPrefix(t *testing.T) {
 	}{
 		{prefix: "", toBeFound: "<a href=\"/ingester/ring\">"},
 		{prefix: "/test", toBeFound: "<a href=\"/test/ingester/ring\">"},
+		// All the extra slashed are cleaned up in the result.
 		{prefix: "///test///", toBeFound: "<a href=\"/test/ingester/ring\">"},
 	} {
-		// All the extra slashed are cleaned up in the result.
 		h := indexHandler(tc.prefix)
 
 		req := httptest.NewRequest("GET", "/", nil)

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexHandlerPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		prefix    string
+		toBeFound string
+	}{
+		{prefix: "", toBeFound: "<a href=\"/ingester/ring\">"},
+		{prefix: "/test", toBeFound: "<a href=\"/test/ingester/ring\">"},
+		{prefix: "///test///", toBeFound: "<a href=\"/test/ingester/ring\">"},
+	} {
+		// All the extra slashed are cleaned up in the result.
+		h := indexHandler(tc.prefix)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		resp := httptest.NewRecorder()
+
+		h.ServeHTTP(resp, req)
+
+		require.Equal(t, 200, resp.Code)
+		require.True(t, strings.Contains(resp.Body.String(), tc.toBeFound))
+	}
+}

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -80,7 +80,7 @@ func (t *Cortex) initAPI() (services.Service, error) {
 
 	t.API = a
 
-	t.API.RegisterAPI(t.Cfg)
+	t.API.RegisterAPI(t.Cfg.Server.PathPrefix, t.Cfg)
 
 	return nil, nil
 }


### PR DESCRIPTION
**What this PR does**: This PR fixes index page, and adds configured HTTP path prefix to all internal links it renders.

**Which issue(s) this PR fixes**:
Fixes #3118.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
