### PR TITLE
feat: allow for temp dir to be specified using an env variable in E2E…

### DIFF
--- a/docs/contributing/how-integration-tests-work.md
+++ b/docs/contributing/how-integration-tests-work.md
@@ -35,6 +35,8 @@ go test -v -tags=requires_docker ./integration -run "^TestChunksStorageAllIndexB
   Docker image used to run Cortex in integration tests (defaults to `quay.io/cortexproject/cortex:latest`)
 - **`CORTEX_CHECKOUT_DIR`**<br />
   The absolute path of the Cortex repository local checkout (defaults to `$GOPATH/src/github.com/cortexproject/cortex`)
+-- **`E2E_TEMP_DIR`**<br />
+  The absolute path to a directory where the integration test will create an additional temporary directory to store files generated during the test.
 
 ### The `requires_docker` tag
 

--- a/integration/e2e/scenario.go
+++ b/integration/e2e/scenario.go
@@ -2,9 +2,7 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -34,17 +32,9 @@ type Scenario struct {
 func NewScenario(networkName string) (*Scenario, error) {
 	s := &Scenario{networkName: networkName}
 
-	dir, err := os.Getwd()
+	var err error
+	s.sharedDir, err = GetTempDirectory()
 	if err != nil {
-		return nil, err
-	}
-	tmpDir, err := ioutil.TempDir(dir, "e2e_integration_test")
-	if err != nil {
-		return nil, err
-	}
-	s.sharedDir, err = filepath.Abs(tmpDir)
-	if err != nil {
-		_ = os.RemoveAll(tmpDir)
 		return nil, err
 	}
 

--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -113,7 +113,7 @@ func GenerateSeries(name string, ts time.Time, additionalLabels ...prompb.Label)
 }
 
 // GetTempDirectory creates a temporary directory for shared integration
-// test files, either in the working directoy or a directory referenced by
+// test files, either in the working directory or a directory referenced by
 // the E2E_TEMP_DIR environment variable
 func GetTempDirectory() (string, error) {
 	var (

--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -1,10 +1,13 @@
 package e2e
 
 import (
+	"io/ioutil"
 	"math"
 	"math/rand"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -107,4 +110,35 @@ func GenerateSeries(name string, ts time.Time, additionalLabels ...prompb.Label)
 	})
 
 	return
+}
+
+// GetTempDirectory creates a temporary directory for shared integration
+// test files, either in the working directoy or a directory referenced by
+// the E2E_TEMP_DIR environment variable
+func GetTempDirectory() (string, error) {
+	var (
+		dir string
+		err error
+	)
+	// If a temp dir is referenced, return that
+	if os.Getenv("E2E_TEMP_DIR") != "" {
+		dir = os.Getenv("E2E_TEMP_DIR")
+	} else {
+		dir, err = os.Getwd()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	tmpDir, err := ioutil.TempDir(dir, "e2e_integration_test")
+	if err != nil {
+		return "", err
+	}
+	absDir, err := filepath.Abs(tmpDir)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return "", err
+	}
+
+	return absDir, nil
 }


### PR DESCRIPTION
**What this PR does**:

- Allows the location of the generated temporary directory in e2e tests to be specified using an env variable

**Which issue(s) this PR fixes**:

In Drone CI each step is run in a container and to utilize Docker the underlying hosts docker engine is utilized. However, the new containers are not able to mount the temporary directory of the docker container that created them.

**Checklist**
- [x] Tests updated
- [x] Documentation added
