### PR TITLE
Index page should only show links that are valid for running Cortex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [BUGFIX] Ingester: If push request contained both valid and invalid samples, valid samples were ingested but not stored to WAL of the chunks storage. This has been fixed. #3067
 * [BUGFIX] Ruler: Config API would return both the `record` and `alert` in `YAML` response keys even when one of them must be empty. #3120
 * [BUGFIX] Index page now uses configured HTTP path prefix when creating links. #3126
+* [BUGFIX] Index page no longer shows links that are not valid for running Cortex instance. #3133
 
 ## 1.3.0 / 2020-08-21
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -66,6 +66,7 @@ type API struct {
 	server         *server.Server
 	logger         log.Logger
 	sourceIPs      *middleware.SourceIPExtractor
+	indexPage      *IndexPageContent
 }
 
 func New(cfg Config, serverCfg server.Config, s *server.Server, logger log.Logger) (*API, error) {
@@ -88,6 +89,7 @@ func New(cfg Config, serverCfg server.Config, s *server.Server, logger log.Logge
 		server:         s,
 		logger:         logger,
 		sourceIPs:      sourceIPs,
+		indexPage:      newIndexPageContent(),
 	}
 
 	// If no authentication middleware is present in the config, use the default authentication middleware.
@@ -143,6 +145,7 @@ func fakeRemoteAddr(handler http.Handler) http.Handler {
 // RegisterAlertmanager registers endpoints associated with the alertmanager. It will only
 // serve endpoints using the legacy http-prefix if it is not run as a single binary.
 func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, target, apiEnabled bool) {
+	a.indexPage.AddLink(SectionAdminEndpoints, "/multitenant_alertmanager/status", "Alertmanager Status")
 	// Ensure this route is registered before the prefixed AM route
 	a.RegisterRoute("/multitenant_alertmanager/status", am.GetStatusHandler(), false)
 
@@ -167,13 +170,19 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, tar
 
 // RegisterAPI registers the standard endpoints associated with a running Cortex.
 func (a *API) RegisterAPI(httpPathPrefix string, cfg interface{}) {
+	a.indexPage.AddLink(SectionAdminEndpoints, "/config", "Current Config")
+
 	a.RegisterRoute("/config", configHandler(cfg), false)
-	a.RegisterRoute("/", indexHandler(httpPathPrefix), false)
+	a.RegisterRoute("/", indexHandler(httpPathPrefix, a.indexPage), false)
 }
 
 // RegisterDistributor registers the endpoints associated with the distributor.
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config) {
 	a.RegisterRoute("/api/v1/push", push.Handler(pushConfig, a.sourceIPs, d.Push), true)
+
+	a.indexPage.AddLink(SectionAdminEndpoints, "/distributor/all_user_stats", "Usage Statistics")
+	a.indexPage.AddLink(SectionAdminEndpoints, "/distributor/ha_tracker", "HA Tracking Status")
+
 	a.RegisterRoute("/distributor/all_user_stats", http.HandlerFunc(d.AllUserStatsHandler), false)
 	a.RegisterRoute("/distributor/ha_tracker", d.HATracker, false)
 
@@ -187,6 +196,8 @@ func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distrib
 func (a *API) RegisterIngester(i *ingester.Ingester, pushConfig distributor.Config) {
 	client.RegisterIngesterServer(a.server.GRPC, i)
 
+	a.indexPage.AddLink(SectionDangerous, "/ingester/flush", "Trigger a Flush of data from Ingester to storage")
+	a.indexPage.AddLink(SectionDangerous, "/ingester/shutdown", "Trigger Ingester Shutdown (Dangerous)")
 	a.RegisterRoute("/ingester/flush", http.HandlerFunc(i.FlushHandler), false)
 	a.RegisterRoute("/ingester/shutdown", http.HandlerFunc(i.ShutdownHandler), false)
 	a.RegisterRoute("/ingester/push", push.Handler(pushConfig, a.sourceIPs, i.Push), true) // For testing and debugging.
@@ -216,6 +227,7 @@ func (a *API) RegisterPurger(store *purger.DeleteStore, deleteRequestCancelPerio
 // RegisterRuler registers routes associated with the Ruler service. If the
 // API is not enabled only the ring route is registered.
 func (a *API) RegisterRuler(r *ruler.Ruler, apiEnabled bool) {
+	a.indexPage.AddLink(SectionAdminEndpoints, "/ruler/ring", "Ruler Ring Status")
 	a.RegisterRoute("/ruler/ring", r, false)
 
 	// Legacy Ring Route
@@ -252,6 +264,7 @@ func (a *API) RegisterRuler(r *ruler.Ruler, apiEnabled bool) {
 
 // RegisterRing registers the ring UI page associated with the distributor for writes.
 func (a *API) RegisterRing(r *ring.Ring) {
+	a.indexPage.AddLink(SectionAdminEndpoints, "/ingester/ring", "Ingester Ring Status")
 	a.RegisterRoute("/ingester/ring", r, false)
 
 	// Legacy Route
@@ -262,11 +275,13 @@ func (a *API) RegisterRing(r *ring.Ring) {
 func (a *API) RegisterStoreGateway(s *storegateway.StoreGateway) {
 	storegatewaypb.RegisterStoreGatewayServer(a.server.GRPC, s)
 
+	a.indexPage.AddLink(SectionAdminEndpoints, "/store-gateway/ring", "Store Gateway Ring (experimental blocks storage)")
 	a.RegisterRoute("/store-gateway/ring", http.HandlerFunc(s.RingHandler), false)
 }
 
 // RegisterCompactor registers the ring UI page associated with the compactor.
 func (a *API) RegisterCompactor(c *compactor.Compactor) {
+	a.indexPage.AddLink(SectionAdminEndpoints, "/compactor/ring", "Compactor Ring Status (experimental blocks storage)")
 	a.RegisterRoute("/compactor/ring", http.HandlerFunc(c.RingHandler), false)
 }
 
@@ -406,5 +421,6 @@ func (a *API) RegisterQueryFrontend(f *frontend.Frontend) {
 // TODO: Refactor this code to be accomplished using the services.ServiceManager
 // or a future module manager #2291
 func (a *API) RegisterServiceMapHandler(handler http.Handler) {
+	a.indexPage.AddLink(SectionAdminEndpoints, "/services", "Service Status")
 	a.RegisterRoute("/services", handler, false)
 }

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 	"net/http"
 	"path"
+	"sync"
 
 	"github.com/go-kit/kit/log/level"
 	"gopkg.in/yaml.v2"
@@ -11,8 +12,52 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 )
 
-// TODO: Update this content to be a template that is dynamic based on how Cortex is run.
-var indexPageContent = template.Must(template.New("main").Parse(`
+const (
+	SectionAdminEndpoints = "Admin Endpoints:"
+	SectionDangerous      = "Dangerous:"
+)
+
+func newIndexPageContent() *IndexPageContent {
+	return &IndexPageContent{
+		content: map[string]map[string]string{},
+	}
+}
+
+// IndexPageContent is a map of sections to path -> description.
+type IndexPageContent struct {
+	mu      sync.Mutex
+	content map[string]map[string]string
+}
+
+func (pc *IndexPageContent) AddLink(section, path, description string) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	sectionMap := pc.content[section]
+	if sectionMap == nil {
+		sectionMap = make(map[string]string)
+		pc.content[section] = sectionMap
+	}
+
+	sectionMap[path] = description
+}
+
+func (pc *IndexPageContent) GetContent() map[string]map[string]string {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	result := map[string]map[string]string{}
+	for k, v := range pc.content {
+		sm := map[string]string{}
+		for smK, smV := range v {
+			sm[smK] = smV
+		}
+		result[k] = sm
+	}
+	return result
+}
+
+var indexPageTemplate = ` 
 <!DOCTYPE html>
 <html>
 	<head>
@@ -21,38 +66,28 @@ var indexPageContent = template.Must(template.New("main").Parse(`
 	</head>
 	<body>
 		<h1>Cortex</h1>
-		<p>Admin Endpoints:</p>
+		{{ range $s, $links := . }}
+		<p>{{ $s }}</p>
 		<ul>
-			<li><a href="{{ .AddPathPrefix "/config" }}">Current Config</a></li>
-			<li><a href="{{ .AddPathPrefix "/distributor/all_user_stats" }}">Usage Statistics</a></li>
-			<li><a href="{{ .AddPathPrefix "/distributor/ha_tracker" }}">HA Tracking Status</a></li>
-			<li><a href="{{ .AddPathPrefix "/multitenant_alertmanager/status" }}">Alertmanager Status</a></li>
-			<li><a href="{{ .AddPathPrefix "/ingester/ring" }}">Ingester Ring Status</a></li>
-			<li><a href="{{ .AddPathPrefix "/ruler/ring" }}">Ruler Ring Status</a></li>
-			<li><a href="{{ .AddPathPrefix "/services" }}">Service Status</a></li>
-			<li><a href="{{ .AddPathPrefix "/compactor/ring" }}">Compactor Ring Status (experimental blocks storage)</a></li>
-			<li><a href="{{ .AddPathPrefix "/store-gateway/ring" }}">Store Gateway Ring (experimental blocks storage)</a></li>
+			{{ range $path, $desc := $links }}
+				<li><a href="{{ AddPathPrefix $path }}">{{ $desc }}</a></li>
+			{{ end }}
 		</ul>
-
-		<p>Dangerous:</p>
-		<ul>
-			<li><a href="{{ .AddPathPrefix "/ingester/flush" }}">Trigger a Flush</a></li>
-			<li><a href="{{ .AddPathPrefix "/ingester/shutdown" }}">Trigger Ingester Shutdown</a></li>
-		</ul>
+		{{ end }}
 	</body>
-</html>`))
+</html>`
 
-type indexPageInput struct {
-	pathPrefix string
-}
+func indexHandler(httpPathPrefix string, content *IndexPageContent) http.HandlerFunc {
+	templ := template.New("main")
+	templ.Funcs(map[string]interface{}{
+		"AddPathPrefix": func(link string) string {
+			return path.Join(httpPathPrefix, link)
+		},
+	})
+	template.Must(templ.Parse(indexPageTemplate))
 
-func (i indexPageInput) AddPathPrefix(p string) string {
-	return path.Join(i.pathPrefix, p)
-}
-
-func indexHandler(httpPathPrefix string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		err := indexPageContent.Execute(w, indexPageInput{pathPrefix: httpPathPrefix})
+		err := templ.Execute(w, content.GetContent())
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestIndexHandlerPrefix(t *testing.T) {
+	c := newIndexPageContent()
+	c.AddLink(SectionAdminEndpoints, "/ingester/ring", "Ingester Ring")
+
 	for _, tc := range []struct {
 		prefix    string
 		toBeFound string
@@ -18,7 +21,7 @@ func TestIndexHandlerPrefix(t *testing.T) {
 		// All the extra slashed are cleaned up in the result.
 		{prefix: "///test///", toBeFound: "<a href=\"/test/ingester/ring\">"},
 	} {
-		h := indexHandler(tc.prefix)
+		h := indexHandler(tc.prefix, c)
 
 		req := httptest.NewRequest("GET", "/", nil)
 		resp := httptest.NewRecorder()
@@ -28,4 +31,25 @@ func TestIndexHandlerPrefix(t *testing.T) {
 		require.Equal(t, 200, resp.Code)
 		require.True(t, strings.Contains(resp.Body.String(), tc.toBeFound))
 	}
+}
+
+func TestIndexPageContent(t *testing.T) {
+	c := newIndexPageContent()
+	c.AddLink(SectionAdminEndpoints, "/ingester/ring", "Ingester Ring")
+	c.AddLink(SectionAdminEndpoints, "/store-gateway/ring", "Store Gateway Ring")
+	c.AddLink(SectionDangerous, "/shutdown", "Shutdown")
+
+	h := indexHandler("", c)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	resp := httptest.NewRecorder()
+
+	h.ServeHTTP(resp, req)
+
+	require.Equal(t, 200, resp.Code)
+	require.True(t, strings.Contains(resp.Body.String(), SectionAdminEndpoints))
+	require.True(t, strings.Contains(resp.Body.String(), SectionDangerous))
+	require.True(t, strings.Contains(resp.Body.String(), "Store Gateway Ring"))
+	require.True(t, strings.Contains(resp.Body.String(), "/shutdown"))
+	require.False(t, strings.Contains(resp.Body.String(), "/compactor/ring"))
 }


### PR DESCRIPTION
**What this PR does**: This PR makes index page dynamic. Cortex will now only show links that are valid for running instance.

**Which issue(s) this PR fixes**:
Fixes #3128

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
