### PR TITLE
Expose number of entries in refcache as a metric.

### DIFF
--- a/pkg/storage/tsdb/ref_cache_test.go
+++ b/pkg/storage/tsdb/ref_cache_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRefCache_GetAndSetReferences(t *testing.T) {
@@ -82,7 +83,13 @@ func TestRefCache_Purge(t *testing.T) {
 			c.SetRef(now.Add(time.Duration(-i)*time.Second), series[i], uint64(i))
 		}
 
-		c.Purge(now.Add(time.Duration(-ttl) * time.Second))
+		entries := c.Purge(now.Add(time.Duration(-ttl) * time.Second))
+		expEntries := ttl + 1
+		if expEntries > len(series) {
+			expEntries = len(series)
+		}
+
+		require.Equal(t, entries, expEntries)
 
 		// Check retained and purged entries
 		for i := 0; i <= ttl && i < len(series); i++ {


### PR DESCRIPTION
**What this PR does**: Blocks-ingester uses RefCache to remember "ref" for each pushed series. RefCache is purged periodically (every 5 minutes, hardcoded), and removes series that were not used in last 10 minutes (hardcoded too). This means that number entries in the refcache roughly corresponds to active series for a user.

This PR exposes number of entries in refcache as a per-user metric.


**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
