### PR TITLE
split ingester module into ingester and ingesterService

### DIFF
--- a/pkg/cortex/cortex_test.go
+++ b/pkg/cortex/cortex_test.go
@@ -85,7 +85,7 @@ func TestCortex(t *testing.T) {
 
 	// check random modules that we expect to be configured when using Target=All
 	require.NotNil(t, serviceMap[Server])
-	require.NotNil(t, serviceMap[Ingester])
+	require.NotNil(t, serviceMap[IngesterService])
 	require.NotNil(t, serviceMap[Ring])
 	require.NotNil(t, serviceMap[DistributorService])
 }

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -316,7 +316,7 @@ func (t *Cortex) initIngesterService() (serv services.Service, err error) {
 func (t *Cortex) initIngester() (serv services.Service, err error) {
 	t.API.RegisterIngester(t.Ingester, t.Cfg.Distributor)
 
-	return t.Ingester, nil
+	return nil, nil
 }
 
 func (t *Cortex) initFlusher() (serv services.Service, err error) {

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -51,6 +51,7 @@ const (
 	Distributor         string = "distributor"
 	DistributorService  string = "distributor-service"
 	Ingester            string = "ingester"
+	IngesterService     string = "ingester-service"
 	Flusher             string = "flusher"
 	Querier             string = "querier"
 	StoreQueryable      string = "store-queryable"
@@ -298,7 +299,7 @@ func (t *Cortex) tsdbIngesterConfig() {
 	t.Cfg.Ingester.BlocksStorageConfig = t.Cfg.BlocksStorage
 }
 
-func (t *Cortex) initIngester() (serv services.Service, err error) {
+func (t *Cortex) initIngesterService() (serv services.Service, err error) {
 	t.Cfg.Ingester.LifecyclerConfig.RingConfig.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
 	t.Cfg.Ingester.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
 	t.Cfg.Ingester.ShardByAllLabels = t.Cfg.Distributor.ShardByAllLabels
@@ -309,6 +310,10 @@ func (t *Cortex) initIngester() (serv services.Service, err error) {
 		return
 	}
 
+	return t.Ingester, nil
+}
+
+func (t *Cortex) initIngester() (serv services.Service, err error) {
 	t.API.RegisterIngester(t.Ingester, t.Cfg.Distributor)
 
 	return t.Ingester, nil
@@ -640,6 +645,7 @@ func (t *Cortex) setupModuleManager() error {
 	mm.RegisterModule(Store, t.initChunkStore, modules.UserInvisibleModule)
 	mm.RegisterModule(DeleteRequestsStore, t.initDeleteRequestsStore, modules.UserInvisibleModule)
 	mm.RegisterModule(Ingester, t.initIngester)
+	mm.RegisterModule(IngesterService, t.initIngesterService, modules.UserInvisibleModule)
 	mm.RegisterModule(Flusher, t.initFlusher)
 	mm.RegisterModule(Querier, t.initQuerier)
 	mm.RegisterModule(StoreQueryable, t.initStoreQueryables, modules.UserInvisibleModule)
@@ -662,7 +668,8 @@ func (t *Cortex) setupModuleManager() error {
 		Distributor:        {DistributorService, API},
 		DistributorService: {Ring, Overrides},
 		Store:              {Overrides, DeleteRequestsStore},
-		Ingester:           {Overrides, Store, API, RuntimeConfig, MemberlistKV},
+		Ingester:           {IngesterService, API},
+		IngesterService:    {Overrides, Store, RuntimeConfig, MemberlistKV},
 		Flusher:            {Store, API},
 		Querier:            {Overrides, DistributorService, Store, Ring, API, StoreQueryable, MemberlistKV},
 		StoreQueryable:     {Overrides, Store},


### PR DESCRIPTION
I'm in a situation where i would like to be able to instantiate an Ingester without registering its API endpoints and without registering the GRPC service, because I want to embed it in a struct to override some of its methods and then register that outer struct as the GRPC service. 

Currently `Cortex.initIngester()` contains quite a lot of logic which is private to the package (in `multiClientRuntimeConfigChannel()`) and the same method also registers the API endpoints and the GRPC service. So if I want to init the Ingester in the same way as `initIngester()` does it, then I have to re-implement (copy-paste) the logic in `multiClientRuntimeConfigChannel()`, which is not very nice.

I saw how the Distributor got split into two modules `DistributorService` and `Distributor`, I think if we'd do the same thing with the Ingester then this would enable me to do what I need to do because I could simply initialize the `IngesterService` module and then embed the initialized Ingester from `Cortex.Ingester` in my struct with the method-overrides.

What do you think about that?