### PR TITLE
test: provide unique network name for docker tests

### DIFF
--- a/integration/configs.go
+++ b/integration/configs.go
@@ -5,8 +5,10 @@ package integration
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/cortexproject/cortex/integration/e2e"
 	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
@@ -16,8 +18,17 @@ type storeConfig struct {
 	From, IndexStore string
 }
 
+// Docker networks must be uniquely named. In order to run parallel integration
+// tests on the same docker host, a network name is generated using the current
+// timestamp in milliseconds.
+var networkName string
+
+func init() {
+	nowMillis := int(time.Now().UnixNano() / 1000)
+	networkName = "e2e-cortex-test-" + strconv.Itoa(nowMillis)
+}
+
 const (
-	networkName            = "e2e-cortex-test"
 	bucketName             = "cortex"
 	cortexConfigFile       = "config.yaml"
 	cortexSchemaConfigFile = "schema.yaml"


### PR DESCRIPTION
**What this PR does**:

Appends a randomly generated test ID string at launch of the integration tests to the network name used by each scenario. On linux, Docker bridge networks are implemented using IP tables and there should not be any issues with additional networks being created. The will only persist after tests that fail to shut down correctly.

**Which issue(s) this PR fixes**:
Fixes #3146 

**Checklist**
- [x] Tests updated
