### PR TITLE
export distributor properties to make ingester extendable

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -152,7 +152,7 @@ type Config struct {
 	// Distributors ring
 	DistributorRing RingConfig `yaml:"ring"`
 
-	// for testing
+	// for testing and for extending the ingester by adding calls to the client
 	IngesterClientFactory ring_client.PoolFactory `yaml:"-"`
 
 	// when true the distributor does not validate the label name, Cortex doesn't directly use
@@ -782,7 +782,7 @@ func (d *Distributor) AllUserStats(ctx context.Context) ([]UserIDStats, error) {
 
 	req := &client.UserStatsRequest{}
 	ctx = user.InjectOrgID(ctx, "1") // fake: ingester insists on having an org ID
-	// Not using d.forAllIngesters(), so we can fail after first error.
+	// Not using d.ForAllIngesters(), so we can fail after first error.
 	replicationSet, err := d.ingestersRing.GetAll(ring.Read)
 	if err != nil {
 		return nil, err

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -153,7 +153,7 @@ type Config struct {
 	DistributorRing RingConfig `yaml:"ring"`
 
 	// for testing
-	ingesterClientFactory ring_client.PoolFactory `yaml:"-"`
+	IngesterClientFactory ring_client.PoolFactory `yaml:"-"`
 
 	// when true the distributor does not validate the label name, Cortex doesn't directly use
 	// this (and should never use it) but this feature is used by other projects built on top of it
@@ -179,8 +179,8 @@ func (cfg *Config) Validate() error {
 
 // New constructs a new Distributor
 func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Overrides, ingestersRing ring.ReadRing, canJoinDistributorsRing bool, reg prometheus.Registerer) (*Distributor, error) {
-	if cfg.ingesterClientFactory == nil {
-		cfg.ingesterClientFactory = func(addr string) (ring_client.PoolClient, error) {
+	if cfg.IngesterClientFactory == nil {
+		cfg.IngesterClientFactory = func(addr string) (ring_client.PoolClient, error) {
 			return ingester_client.MakeIngesterClient(addr, clientConfig)
 		}
 	}
@@ -220,7 +220,7 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 	d := &Distributor{
 		cfg:                  cfg,
 		ingestersRing:        ingestersRing,
-		ingesterPool:         NewPool(cfg.PoolConfig, ingestersRing, cfg.ingesterClientFactory, util.Logger),
+		ingesterPool:         NewPool(cfg.PoolConfig, ingestersRing, cfg.IngesterClientFactory, util.Logger),
 		distributorsRing:     distributorsRing,
 		limits:               limits,
 		ingestionRateLimiter: limiter.NewRateLimiter(ingestionRateStrategy, 10*time.Second),
@@ -603,8 +603,8 @@ func (d *Distributor) send(ctx context.Context, ingester ring.IngesterDesc, time
 	return err
 }
 
-// forAllIngesters runs f, in parallel, for all ingesters
-func (d *Distributor) forAllIngesters(ctx context.Context, reallyAll bool, f func(client.IngesterClient) (interface{}, error)) ([]interface{}, error) {
+// ForAllIngesters runs f, in parallel, for all ingesters
+func (d *Distributor) ForAllIngesters(ctx context.Context, reallyAll bool, f func(client.IngesterClient) (interface{}, error)) ([]interface{}, error) {
 	replicationSet, err := d.ingestersRing.GetAll(ring.Read)
 	if err != nil {
 		return nil, err
@@ -628,7 +628,7 @@ func (d *Distributor) LabelValuesForLabelName(ctx context.Context, labelName mod
 	req := &client.LabelValuesRequest{
 		LabelName: string(labelName),
 	}
-	resps, err := d.forAllIngesters(ctx, false, func(client client.IngesterClient) (interface{}, error) {
+	resps, err := d.ForAllIngesters(ctx, false, func(client client.IngesterClient) (interface{}, error) {
 		return client.LabelValues(ctx, req)
 	})
 	if err != nil {
@@ -652,7 +652,7 @@ func (d *Distributor) LabelValuesForLabelName(ctx context.Context, labelName mod
 // LabelNames returns all of the label names.
 func (d *Distributor) LabelNames(ctx context.Context) ([]string, error) {
 	req := &client.LabelNamesRequest{}
-	resps, err := d.forAllIngesters(ctx, false, func(client client.IngesterClient) (interface{}, error) {
+	resps, err := d.ForAllIngesters(ctx, false, func(client client.IngesterClient) (interface{}, error) {
 		return client.LabelNames(ctx, req)
 	})
 	if err != nil {
@@ -684,7 +684,7 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 		return nil, err
 	}
 
-	resps, err := d.forAllIngesters(ctx, false, func(client client.IngesterClient) (interface{}, error) {
+	resps, err := d.ForAllIngesters(ctx, false, func(client client.IngesterClient) (interface{}, error) {
 		return client.MetricsForLabelMatchers(ctx, req)
 	})
 	if err != nil {
@@ -712,7 +712,7 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 func (d *Distributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetadata, error) {
 	req := &ingester_client.MetricsMetadataRequest{}
 	// TODO(gotjosh): We only need to look in all the ingesters if shardByAllLabels is enabled.
-	resps, err := d.forAllIngesters(ctx, false, func(client client.IngesterClient) (interface{}, error) {
+	resps, err := d.ForAllIngesters(ctx, false, func(client client.IngesterClient) (interface{}, error) {
 		return client.MetricsMetadata(ctx, req)
 	})
 	if err != nil {
@@ -746,7 +746,7 @@ func (d *Distributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetad
 // UserStats returns statistics about the current user.
 func (d *Distributor) UserStats(ctx context.Context) (*UserStats, error) {
 	req := &client.UserStatsRequest{}
-	resps, err := d.forAllIngesters(ctx, true, func(client client.IngesterClient) (interface{}, error) {
+	resps, err := d.ForAllIngesters(ctx, true, func(client client.IngesterClient) (interface{}, error) {
 		return client.UserStats(ctx, req)
 	})
 	if err != nil {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -953,7 +953,7 @@ func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, *rin
 		var clientConfig client.Config
 		flagext.DefaultValues(&distributorCfg, &clientConfig)
 
-		distributorCfg.ingesterClientFactory = factory
+		distributorCfg.IngesterClientFactory = factory
 		distributorCfg.ShardByAllLabels = cfg.shardByAllLabels
 		distributorCfg.ExtraQueryDelay = 50 * time.Millisecond
 		distributorCfg.DistributorRing.HeartbeatPeriod = 100 * time.Millisecond


### PR DESCRIPTION
I would like to add an additional GRPC call to the Ingester service, to query that additional call it would be nice if I could re-use the existing Ingester querying code in the Distributor. To make that possible the following two properties would need to be exported:

`Distributor.forAllIngesters()` 
By exporting this method I'll be able to query all Ingesters by calling `distributor.ForAllIngesters()` with a custom function which type-casts the Ingester client to one that supports my additional call, like this:
```
responses, err := dist.ForAllIngesters(ctx, true, func(client ingesterClient.IngesterClient) (interface{}, error) {
    extendedClient := client.(extendedIngester.ExtendedIngesterClient)
    resp, err := extendedClient.MyCustomCall(ctx, req)
    if err != nil {
        return nil, err
    }
    return resp, nil
})
```

`Config.ingesterClientFactory`
To make the Distributor instantiate clients of my extended type I'll also need to set the client factory in the Distributor config, like this:

```
distributorCfg.IngesterClientFactory = func(addr string) (ring_client.PoolClient, error) {
		return extendedIngester.MakeClient(addr, IngesterClient)
	}
```

What do you think about doing it this way?