### PR TITLE
Remove blocksconvert binary from the tree.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 cmd/test-exporter/test-exporter
 cmd/cortex/cortex
 cmd/query-tee/query-tee
+cmd/blocksconvert/blocksconvert
 .uptodate
 .pkg
 .cache


### PR DESCRIPTION
**What this PR does**: This PR removes `blocksconvert` binary from the tree, and adds it to `.gitignore`.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
