### PR TITLE
Make it possible for user to discover which modules are included in "All" target.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 * [ENHANCEMENT] When a tenant accesses the Alertmanager UI or its API, if we have valid `-alertmanager.configs.fallback` we'll use that to start the manager and avoid failing the request. #3073
 * [ENHANCEMENT] Add `DELETE api/v1/rules/{namespace}` to the Ruler. It allows all the rule groups of a namespace to be deleted. #3120
 * [ENHANCEMENT] Experimental Delete Series: Retry processing of Delete requests during failures. #2926
-* [ENHANCEMENT] Modules included in "All" target are now visible in output of `-modules` CLI flag.
+* [ENHANCEMENT] Modules included in "All" target are now visible in output of `-modules` CLI flag. #3155
 * [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
 * [BUGFIX] Querier: Merge results from chunks and blocks ingesters when using streaming of results. #3013
 * [BUGFIX] Querier: query /series from ingesters regardless the `-querier.query-ingesters-within` setting. #3035

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [ENHANCEMENT] When a tenant accesses the Alertmanager UI or its API, if we have valid `-alertmanager.configs.fallback` we'll use that to start the manager and avoid failing the request. #3073
 * [ENHANCEMENT] Add `DELETE api/v1/rules/{namespace}` to the Ruler. It allows all the rule groups of a namespace to be deleted. #3120
 * [ENHANCEMENT] Experimental Delete Series: Retry processing of Delete requests during failures. #2926
+* [ENHANCEMENT] Modules included in "All" target are now visible in output of `-modules` CLI flag.
 * [BUGFIX] Query-frontend: Fixed rounding for incoming query timestamps, to be 100% Prometheus compatible. #2990
 * [BUGFIX] Querier: Merge results from chunks and blocks ingesters when using streaming of results. #3013
 * [BUGFIX] Querier: query /series from ingesters regardless the `-querier.query-ingesters-within` setting. #3035

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -148,9 +149,21 @@ func main() {
 	util.CheckFatal("initializing cortex", err)
 
 	if t.Cfg.ListModules {
+		allDeps := t.ModuleManager.DependenciesForModule(cortex.All)
+
 		for _, m := range t.ModuleManager.UserVisibleModuleNames() {
-			fmt.Fprintln(os.Stdout, m)
+			ix := sort.SearchStrings(allDeps, m)
+			included := ix < len(allDeps) && allDeps[ix] == m
+
+			if included {
+				fmt.Fprintln(os.Stdout, m, "*")
+			} else {
+				fmt.Fprintln(os.Stdout, m)
+			}
 		}
+
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprintln(os.Stdout, "Modules marked with * are included in target All.")
 
 		// in test mode we cannot call os.Exit, it will stop to whole test process.
 		if testMode {

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -65,13 +65,13 @@ func TestFlagParsing(t *testing.T) {
 
 		"user visible module listing": {
 			arguments:      []string{"-modules"},
-			stdoutMessage:  "ingester\n",
+			stdoutMessage:  "ingester *\n",
 			stderrExcluded: "ingester\n",
 		},
 
 		"user visible module listing flag take precedence over target flag": {
 			arguments:      []string{"-modules", "-target=blah"},
-			stdoutMessage:  "ingester\n",
+			stdoutMessage:  "ingester *\n",
 			stderrExcluded: "ingester\n",
 		},
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -52,8 +52,8 @@ Where default_value is the value to use if the environment variable is undefined
 ### Supported contents and default values of the config file
 
 ```yaml
-# The Cortex service to run. Use "-modules" command line flag to get a list of
-# available options.
+# The Cortex module to run. Use "-modules" command line flag to get a list of
+# available modules, and to see which modules are included in "All".
 # CLI flag: -target
 [target: <string> | default = "all"]
 

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -110,7 +110,7 @@ type Config struct {
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Server.MetricsNamespace = "cortex"
 	c.Server.ExcludeRequestInLog = true
-	f.StringVar(&c.Target, "target", All, "The Cortex service to run. Use \"-modules\" command line flag to get a list of available options.")
+	f.StringVar(&c.Target, "target", All, "The Cortex service to run. Use \"-modules\" command line flag to get a list of available services, and to see which services are included in \"All\".")
 	f.BoolVar(&c.ListModules, "modules", false, "List available values to be use as target. Cannot be used in YAML config.")
 	f.BoolVar(&c.AuthEnabled, "auth.enabled", true, "Set to false to disable auth.")
 	f.BoolVar(&c.PrintConfig, "print.config", false, "Print the config and exit.")

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -110,7 +110,7 @@ type Config struct {
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Server.MetricsNamespace = "cortex"
 	c.Server.ExcludeRequestInLog = true
-	f.StringVar(&c.Target, "target", All, "The Cortex service to run. Use \"-modules\" command line flag to get a list of available services, and to see which services are included in \"All\".")
+	f.StringVar(&c.Target, "target", All, "The Cortex module to run. Use \"-modules\" command line flag to get a list of available modules, and to see which modules are included in \"All\".")
 	f.BoolVar(&c.ListModules, "modules", false, "List available values to be use as target. Cannot be used in YAML config.")
 	f.BoolVar(&c.AuthEnabled, "auth.enabled", true, "Set to false to disable auth.")
 	f.BoolVar(&c.PrintConfig, "print.config", false, "Print the config and exit.")

--- a/pkg/util/modules/modules.go
+++ b/pkg/util/modules/modules.go
@@ -192,3 +192,18 @@ func (m *Manager) findInverseDependencies(mod string, mods []string) []string {
 
 	return result
 }
+
+// DependenciesForModule returns transitive dependencies for given module, sorted by name.
+func (m *Manager) DependenciesForModule(module string) []string {
+	dedup := map[string]bool{}
+	for _, d := range m.listDeps(module) {
+		dedup[d] = true
+	}
+
+	result := make([]string, 0, len(dedup))
+	for d := range dedup {
+		result = append(result, d)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/pkg/util/modules/modules_test.go
+++ b/pkg/util/modules/modules_test.go
@@ -126,3 +126,18 @@ func TestIsUserVisibleModule(t *testing.T) {
 	result = sut.IsUserVisibleModule("ghost")
 	assert.False(t, result, "expects result be false when module does not exist")
 }
+
+func TestDependenciesForModule(t *testing.T) {
+	m := NewManager()
+	m.RegisterModule("test", nil)
+	m.RegisterModule("dep1", nil)
+	m.RegisterModule("dep2", nil)
+	m.RegisterModule("dep3", nil)
+
+	require.NoError(t, m.AddDependency("test", "dep2", "dep1"))
+	require.NoError(t, m.AddDependency("dep1", "dep2"))
+	require.NoError(t, m.AddDependency("dep2", "dep3"))
+
+	deps := m.DependenciesForModule("test")
+	assert.Equal(t, []string{"dep1", "dep2", "dep3"}, deps)
+}


### PR DESCRIPTION
**What this PR does**: This PR enhances output of `-modules` option to mark which modules are part of "All":
```
$ ./cmd/cortex/cortex -modules
alertmanager
all
compactor
configs
distributor *
flusher
ingester *
purger *
querier *
query-frontend *
ruler *
store-gateway *
table-manager *

Modules marked with * are included in target All.
```

Inspired by https://github.com/cortexproject/cortex/issues/3041#issuecomment-689886482.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
