### PR TITLE
Support other TLS modes than mutual auth in Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [CHANGE] Ingester: don't update internal "last updated" timestamp of TSDB if tenant only sends invalid samples. This affects how "idle" time is computed. #3727
+* [CHANGE] Require explicit flag `-<prefix>.tls-enabled` to enable TLS in GRPC clients. Previously it was enough to specify a TLS flag to enable TLS validation. #3156
 * [FEATURE] Adds support to S3 server side encryption using KMS. Deprecated `-<prefix>.s3.sse-encryption`, you should use the following CLI flags that have been added. #3651
   - `-<prefix>.s3.sse.type`
   - `-<prefix>.s3.sse.kms-key-id`
@@ -13,6 +14,7 @@
   * Prevent compaction loop in TSDB on data gap.
 * [ENHANCEMENT] Return server side performance metrics for query-frontend (using Server-timing header). #3685
 * [ENHANCEMENT] Runtime Config: Add a `mode` query parameter for the runtime config endpoint. `/runtime_config?mode=diff` now shows the YAML runtime configuration with all values that differ from the defaults. #3700
+* [ENHANCEMENT] Add flag `-<prefix>.tls-server-name` to require a specific server name instead of the hostname on the certificate. #3156
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 
 ## 1.7.0 in progress

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -168,6 +168,10 @@ querier:
   [store_gateway_addresses: <string> | default = ""]
 
   store_gateway_client:
+    # Enable TLS for gRPC client connecting to store-gateway.
+    # CLI flag: -querier.store-gateway-client.tls-enabled
+    [tls_enabled: <boolean> | default = false]
+
     # Path to the client certificate file, which will be used for authenticating
     # with the server. Also requires the key path to be configured.
     # CLI flag: -querier.store-gateway-client.tls-cert-path
@@ -182,6 +186,10 @@ querier:
     # If not set, the host's root CA certificates are used.
     # CLI flag: -querier.store-gateway-client.tls-ca-path
     [tls_ca_path: <string> | default = ""]
+
+    # Override the expected name on the server certificate.
+    # CLI flag: -querier.store-gateway-client.tls-server-name
+    [tls_server_name: <string> | default = ""]
 
     # Skip validating server certificate.
     # CLI flag: -querier.store-gateway-client.tls-insecure-skip-verify

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3114,17 +3114,24 @@ The `etcd_config` configures the etcd client. The supported CLI flags `<prefix>`
 # CLI flag: -<prefix>.etcd.tls-enabled
 [tls_enabled: <boolean> | default = false]
 
-# The TLS certificate file path.
+# Path to the client certificate file, which will be used for authenticating
+# with the server. Also requires the key path to be configured.
 # CLI flag: -<prefix>.etcd.tls-cert-path
 [tls_cert_path: <string> | default = ""]
 
-# The TLS private key file path.
+# Path to the key file for the client certificate. Also requires the client
+# certificate to be configured.
 # CLI flag: -<prefix>.etcd.tls-key-path
 [tls_key_path: <string> | default = ""]
 
-# The trusted CA file path.
+# Path to the CA certificates file to validate server certificate against. If
+# not set, the host's root CA certificates are used.
 # CLI flag: -<prefix>.etcd.tls-ca-path
 [tls_ca_path: <string> | default = ""]
+
+# Override the expected name on the server certificate.
+# CLI flag: -<prefix>.etcd.tls-server-name
+[tls_server_name: <string> | default = ""]
 
 # Skip validating server certificate.
 # CLI flag: -<prefix>.etcd.tls-insecure-skip-verify

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -220,7 +220,8 @@ query_scheduler:
       [max_retries: <int> | default = 10]
 
     # Enable TLS in the GRPC client. This flag needs to be enabled when any
-    # other TLS flag is set.
+    # other TLS flag is set. If set to false, insecure connection to gRPC server
+    # will be used.
     # CLI flag: -query-scheduler.grpc-client-config.tls-enabled
     [tls_enabled: <boolean> | default = false]
 
@@ -958,7 +959,8 @@ grpc_client_config:
     [max_retries: <int> | default = 10]
 
   # Enable TLS in the GRPC client. This flag needs to be enabled when any other
-  # TLS flag is set.
+  # TLS flag is set. If set to false, insecure connection to gRPC server will be
+  # used.
   # CLI flag: -frontend.grpc-client-config.tls-enabled
   [tls_enabled: <boolean> | default = false]
 
@@ -1127,7 +1129,8 @@ ruler_client:
     [max_retries: <int> | default = 10]
 
   # Enable TLS in the GRPC client. This flag needs to be enabled when any other
-  # TLS flag is set.
+  # TLS flag is set. If set to false, insecure connection to gRPC server will be
+  # used.
   # CLI flag: -ruler.client.tls-enabled
   [tls_enabled: <boolean> | default = false]
 
@@ -2395,7 +2398,8 @@ bigtable:
       [max_retries: <int> | default = 10]
 
     # Enable TLS in the GRPC client. This flag needs to be enabled when any
-    # other TLS flag is set.
+    # other TLS flag is set. If set to false, insecure connection to gRPC server
+    # will be used.
     # CLI flag: -bigtable.tls-enabled
     [tls_enabled: <boolean> | default = true]
 
@@ -2943,7 +2947,8 @@ grpc_client_config:
     [max_retries: <int> | default = 10]
 
   # Enable TLS in the GRPC client. This flag needs to be enabled when any other
-  # TLS flag is set.
+  # TLS flag is set. If set to false, insecure connection to gRPC server will be
+  # used.
   # CLI flag: -ingester.client.tls-enabled
   [tls_enabled: <boolean> | default = false]
 
@@ -3049,7 +3054,8 @@ grpc_client_config:
     [max_retries: <int> | default = 10]
 
   # Enable TLS in the GRPC client. This flag needs to be enabled when any other
-  # TLS flag is set.
+  # TLS flag is set. If set to false, insecure connection to gRPC server will be
+  # used.
   # CLI flag: -querier.frontend-client.tls-enabled
   [tls_enabled: <boolean> | default = false]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -219,6 +219,11 @@ query_scheduler:
       # CLI flag: -query-scheduler.grpc-client-config.backoff-retries
       [max_retries: <int> | default = 10]
 
+    # Enable TLS in the GRPC client. This flag needs to be enabled when any
+    # other TLS flag is set.
+    # CLI flag: -query-scheduler.grpc-client-config.tls-enabled
+    [tls_enabled: <boolean> | default = false]
+
     # Path to the client certificate file, which will be used for authenticating
     # with the server. Also requires the key path to be configured.
     # CLI flag: -query-scheduler.grpc-client-config.tls-cert-path
@@ -233,6 +238,10 @@ query_scheduler:
     # If not set, the host's root CA certificates are used.
     # CLI flag: -query-scheduler.grpc-client-config.tls-ca-path
     [tls_ca_path: <string> | default = ""]
+
+    # Override the expected name on the server certificate.
+    # CLI flag: -query-scheduler.grpc-client-config.tls-server-name
+    [tls_server_name: <string> | default = ""]
 
     # Skip validating server certificate.
     # CLI flag: -query-scheduler.grpc-client-config.tls-insecure-skip-verify
@@ -826,6 +835,10 @@ The `querier_config` configures the Cortex querier.
 [store_gateway_addresses: <string> | default = ""]
 
 store_gateway_client:
+  # Enable TLS for gRPC client connecting to store-gateway.
+  # CLI flag: -querier.store-gateway-client.tls-enabled
+  [tls_enabled: <boolean> | default = false]
+
   # Path to the client certificate file, which will be used for authenticating
   # with the server. Also requires the key path to be configured.
   # CLI flag: -querier.store-gateway-client.tls-cert-path
@@ -840,6 +853,10 @@ store_gateway_client:
   # not set, the host's root CA certificates are used.
   # CLI flag: -querier.store-gateway-client.tls-ca-path
   [tls_ca_path: <string> | default = ""]
+
+  # Override the expected name on the server certificate.
+  # CLI flag: -querier.store-gateway-client.tls-server-name
+  [tls_server_name: <string> | default = ""]
 
   # Skip validating server certificate.
   # CLI flag: -querier.store-gateway-client.tls-insecure-skip-verify
@@ -940,6 +957,11 @@ grpc_client_config:
     # CLI flag: -frontend.grpc-client-config.backoff-retries
     [max_retries: <int> | default = 10]
 
+  # Enable TLS in the GRPC client. This flag needs to be enabled when any other
+  # TLS flag is set.
+  # CLI flag: -frontend.grpc-client-config.tls-enabled
+  [tls_enabled: <boolean> | default = false]
+
   # Path to the client certificate file, which will be used for authenticating
   # with the server. Also requires the key path to be configured.
   # CLI flag: -frontend.grpc-client-config.tls-cert-path
@@ -954,6 +976,10 @@ grpc_client_config:
   # not set, the host's root CA certificates are used.
   # CLI flag: -frontend.grpc-client-config.tls-ca-path
   [tls_ca_path: <string> | default = ""]
+
+  # Override the expected name on the server certificate.
+  # CLI flag: -frontend.grpc-client-config.tls-server-name
+  [tls_server_name: <string> | default = ""]
 
   # Skip validating server certificate.
   # CLI flag: -frontend.grpc-client-config.tls-insecure-skip-verify
@@ -1100,6 +1126,11 @@ ruler_client:
     # CLI flag: -ruler.client.backoff-retries
     [max_retries: <int> | default = 10]
 
+  # Enable TLS in the GRPC client. This flag needs to be enabled when any other
+  # TLS flag is set.
+  # CLI flag: -ruler.client.tls-enabled
+  [tls_enabled: <boolean> | default = false]
+
   # Path to the client certificate file, which will be used for authenticating
   # with the server. Also requires the key path to be configured.
   # CLI flag: -ruler.client.tls-cert-path
@@ -1114,6 +1145,10 @@ ruler_client:
   # not set, the host's root CA certificates are used.
   # CLI flag: -ruler.client.tls-ca-path
   [tls_ca_path: <string> | default = ""]
+
+  # Override the expected name on the server certificate.
+  # CLI flag: -ruler.client.tls-server-name
+  [tls_server_name: <string> | default = ""]
 
   # Skip validating server certificate.
   # CLI flag: -ruler.client.tls-insecure-skip-verify
@@ -2359,6 +2394,34 @@ bigtable:
       # CLI flag: -bigtable.backoff-retries
       [max_retries: <int> | default = 10]
 
+    # Enable TLS in the GRPC client. This flag needs to be enabled when any
+    # other TLS flag is set.
+    # CLI flag: -bigtable.tls-enabled
+    [tls_enabled: <boolean> | default = true]
+
+    # Path to the client certificate file, which will be used for authenticating
+    # with the server. Also requires the key path to be configured.
+    # CLI flag: -bigtable.tls-cert-path
+    [tls_cert_path: <string> | default = ""]
+
+    # Path to the key file for the client certificate. Also requires the client
+    # certificate to be configured.
+    # CLI flag: -bigtable.tls-key-path
+    [tls_key_path: <string> | default = ""]
+
+    # Path to the CA certificates file to validate server certificate against.
+    # If not set, the host's root CA certificates are used.
+    # CLI flag: -bigtable.tls-ca-path
+    [tls_ca_path: <string> | default = ""]
+
+    # Override the expected name on the server certificate.
+    # CLI flag: -bigtable.tls-server-name
+    [tls_server_name: <string> | default = ""]
+
+    # Skip validating server certificate.
+    # CLI flag: -bigtable.tls-insecure-skip-verify
+    [tls_insecure_skip_verify: <boolean> | default = false]
+
   # If enabled, once a tables info is fetched, it is cached.
   # CLI flag: -bigtable.table-cache.enabled
   [table_cache_enabled: <boolean> | default = true]
@@ -2879,6 +2942,11 @@ grpc_client_config:
     # CLI flag: -ingester.client.backoff-retries
     [max_retries: <int> | default = 10]
 
+  # Enable TLS in the GRPC client. This flag needs to be enabled when any other
+  # TLS flag is set.
+  # CLI flag: -ingester.client.tls-enabled
+  [tls_enabled: <boolean> | default = false]
+
   # Path to the client certificate file, which will be used for authenticating
   # with the server. Also requires the key path to be configured.
   # CLI flag: -ingester.client.tls-cert-path
@@ -2893,6 +2961,10 @@ grpc_client_config:
   # not set, the host's root CA certificates are used.
   # CLI flag: -ingester.client.tls-ca-path
   [tls_ca_path: <string> | default = ""]
+
+  # Override the expected name on the server certificate.
+  # CLI flag: -ingester.client.tls-server-name
+  [tls_server_name: <string> | default = ""]
 
   # Skip validating server certificate.
   # CLI flag: -ingester.client.tls-insecure-skip-verify
@@ -2976,6 +3048,11 @@ grpc_client_config:
     # CLI flag: -querier.frontend-client.backoff-retries
     [max_retries: <int> | default = 10]
 
+  # Enable TLS in the GRPC client. This flag needs to be enabled when any other
+  # TLS flag is set.
+  # CLI flag: -querier.frontend-client.tls-enabled
+  [tls_enabled: <boolean> | default = false]
+
   # Path to the client certificate file, which will be used for authenticating
   # with the server. Also requires the key path to be configured.
   # CLI flag: -querier.frontend-client.tls-cert-path
@@ -2990,6 +3067,10 @@ grpc_client_config:
   # not set, the host's root CA certificates are used.
   # CLI flag: -querier.frontend-client.tls-ca-path
   [tls_ca_path: <string> | default = ""]
+
+  # Override the expected name on the server certificate.
+  # CLI flag: -querier.frontend-client.tls-server-name
+  [tls_server_name: <string> | default = ""]
 
   # Skip validating server certificate.
   # CLI flag: -querier.frontend-client.tls-insecure-skip-verify
@@ -3658,6 +3739,10 @@ The `configstore_config` configures the config database storing rules and alerts
 # not set, the host's root CA certificates are used.
 # CLI flag: -<prefix>.configs.tls-ca-path
 [tls_ca_path: <string> | default = ""]
+
+# Override the expected name on the server certificate.
+# CLI flag: -<prefix>.configs.tls-server-name
+[tls_server_name: <string> | default = ""]
 
 # Skip validating server certificate.
 # CLI flag: -<prefix>.configs.tls-insecure-skip-verify

--- a/integration/util.go
+++ b/integration/util.go
@@ -63,12 +63,10 @@ func getServerTLSFlags() map[string]string {
 
 func getClientTLSFlagsWithPrefix(prefix string) map[string]string {
 	return map[string]string{
-		"-" + prefix + ".tls-cert-path": filepath.Join(e2e.ContainerSharedDir, clientCertFile),
-		"-" + prefix + ".tls-key-path":  filepath.Join(e2e.ContainerSharedDir, clientKeyFile),
-		"-" + prefix + ".tls-ca-path":   filepath.Join(e2e.ContainerSharedDir, caCertFile),
-
-		// TODO: Remove this in the future to test if TLS verification works,
-		// this requires a TLSServerName flags to be specified
-		"-" + prefix + ".tls-insecure-skip-verify": "true",
+		"-" + prefix + ".tls-cert-path":   filepath.Join(e2e.ContainerSharedDir, clientCertFile),
+		"-" + prefix + ".tls-key-path":    filepath.Join(e2e.ContainerSharedDir, clientKeyFile),
+		"-" + prefix + ".tls-ca-path":     filepath.Join(e2e.ContainerSharedDir, caCertFile),
+		"-" + prefix + ".tls-server-name": "ingester.client",
+		"-" + prefix + ".tls-enabled":     "true",
 	}
 }

--- a/pkg/chunk/gcp/bigtable_object_client.go
+++ b/pkg/chunk/gcp/bigtable_object_client.go
@@ -22,8 +22,11 @@ type bigtableObjectClient struct {
 // NewBigtableObjectClient makes a new chunk.Client that stores chunks in
 // Bigtable.
 func NewBigtableObjectClient(ctx context.Context, cfg Config, schemaCfg chunk.SchemaConfig) (chunk.Client, error) {
-	opts := toOptions(cfg.GRPCClientConfig.DialOption(bigtableInstrumentation()))
-	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, opts...)
+	dialOpts, err := cfg.GRPCClientConfig.DialOption(bigtableInstrumentation())
+	if err != nil {
+		return nil, err
+	}
+	client, err := bigtable.NewClient(ctx, cfg.Project, cfg.Instance, toOptions(dialOpts)...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chunk/gcp/table_client.go
+++ b/pkg/chunk/gcp/table_client.go
@@ -24,8 +24,11 @@ type tableClient struct {
 
 // NewTableClient returns a new TableClient.
 func NewTableClient(ctx context.Context, cfg Config) (chunk.TableClient, error) {
-	opts := toOptions(cfg.GRPCClientConfig.DialOption(bigtableInstrumentation()))
-	client, err := bigtable.NewAdminClient(ctx, cfg.Project, cfg.Instance, opts...)
+	dialOpts, err := cfg.GRPCClientConfig.DialOption(bigtableInstrumentation())
+	if err != nil {
+		return nil, err
+	}
+	client, err := bigtable.NewAdminClient(ctx, cfg.Project, cfg.Instance, toOptions(dialOpts)...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -29,10 +29,10 @@ import (
 
 // Config for a Frontend.
 type Config struct {
-	SchedulerAddress  string                   `yaml:"scheduler_address"`
-	DNSLookupPeriod   time.Duration            `yaml:"scheduler_dns_lookup_period"`
-	WorkerConcurrency int                      `yaml:"scheduler_worker_concurrency"`
-	GRPCClientConfig  grpcclient.ConfigWithTLS `yaml:"grpc_client_config"`
+	SchedulerAddress  string            `yaml:"scheduler_address"`
+	DNSLookupPeriod   time.Duration     `yaml:"scheduler_dns_lookup_period"`
+	WorkerConcurrency int               `yaml:"scheduler_worker_concurrency"`
+	GRPCClientConfig  grpcclient.Config `yaml:"grpc_client_config"`
 
 	// Used to find local IP address, that is sent to scheduler and querier-worker.
 	InfNames []string `yaml:"instance_interface_names"`

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -55,7 +55,7 @@ func (c *closableHealthAndIngesterClient) Close() error {
 
 // Config is the configuration struct for the ingester client
 type Config struct {
-	GRPCClientConfig grpcclient.ConfigWithTLS `yaml:"grpc_client_config"`
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config"`
 }
 
 // RegisterFlags registers configuration settings used by the ingester client config.

--- a/pkg/querier/blocks_store_balanced_set.go
+++ b/pkg/querier/blocks_store_balanced_set.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring/client"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/services"
-	"github.com/cortexproject/cortex/pkg/util/tls"
 )
 
 // BlocksStoreSet implementation used when the blocks are not sharded in the store-gateway
@@ -31,7 +30,7 @@ type blocksStoreBalancedSet struct {
 	dnsProvider      *dns.Provider
 }
 
-func newBlocksStoreBalancedSet(serviceAddresses []string, tlsCfg tls.ClientConfig, logger log.Logger, reg prometheus.Registerer) *blocksStoreBalancedSet {
+func newBlocksStoreBalancedSet(serviceAddresses []string, clientConfig ClientConfig, logger log.Logger, reg prometheus.Registerer) *blocksStoreBalancedSet {
 	const dnsResolveInterval = 10 * time.Second
 
 	dnsProviderReg := extprom.WrapRegistererWithPrefix("cortex_storegateway_client_", reg)
@@ -39,7 +38,7 @@ func newBlocksStoreBalancedSet(serviceAddresses []string, tlsCfg tls.ClientConfi
 	s := &blocksStoreBalancedSet{
 		serviceAddresses: serviceAddresses,
 		dnsProvider:      dns.NewProvider(logger, dnsProviderReg, dns.GolangResolverType),
-		clientsPool:      newStoreGatewayClientPool(nil, tlsCfg, logger, reg),
+		clientsPool:      newStoreGatewayClientPool(nil, clientConfig, logger, reg),
 	}
 
 	s.Service = services.NewTimerService(dnsResolveInterval, s.starting, s.resolve, nil)

--- a/pkg/querier/blocks_store_balanced_set_test.go
+++ b/pkg/querier/blocks_store_balanced_set_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/util/services"
-	"github.com/cortexproject/cortex/pkg/util/tls"
 )
 
 func TestBlocksStoreBalancedSet_GetClientsFor(t *testing.T) {
@@ -24,7 +23,7 @@ func TestBlocksStoreBalancedSet_GetClientsFor(t *testing.T) {
 
 	ctx := context.Background()
 	reg := prometheus.NewPedanticRegistry()
-	s := newBlocksStoreBalancedSet(serviceAddrs, tls.ClientConfig{}, log.NewNopLogger(), reg)
+	s := newBlocksStoreBalancedSet(serviceAddrs, ClientConfig{}, log.NewNopLogger(), reg)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 	defer services.StopAndAwaitTerminated(ctx, s) //nolint:errcheck
 
@@ -134,7 +133,7 @@ func TestBlocksStoreBalancedSet_GetClientsFor_Exclude(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			s := newBlocksStoreBalancedSet(testData.serviceAddrs, tls.ClientConfig{}, log.NewNopLogger(), nil)
+			s := newBlocksStoreBalancedSet(testData.serviceAddrs, ClientConfig{}, log.NewNopLogger(), nil)
 			require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 			defer services.StopAndAwaitTerminated(ctx, s) //nolint:errcheck
 

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/storegateway"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/services"
-	"github.com/cortexproject/cortex/pkg/util/tls"
 )
 
 // BlocksStoreSet implementation used when the blocks are sharded and replicated across
@@ -37,7 +36,7 @@ func newBlocksStoreReplicationSet(
 	storesRing *ring.Ring,
 	shardingStrategy string,
 	limits BlocksStoreLimits,
-	tlsCfg tls.ClientConfig,
+	tlsCfg ClientConfig,
 	logger log.Logger,
 	reg prometheus.Registerer,
 ) (*blocksStoreReplicationSet, error) {

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -36,13 +36,13 @@ func newBlocksStoreReplicationSet(
 	storesRing *ring.Ring,
 	shardingStrategy string,
 	limits BlocksStoreLimits,
-	tlsCfg ClientConfig,
+	clientConfig ClientConfig,
 	logger log.Logger,
 	reg prometheus.Registerer,
 ) (*blocksStoreReplicationSet, error) {
 	s := &blocksStoreReplicationSet{
 		storesRing:       storesRing,
-		clientsPool:      newStoreGatewayClientPool(client.NewRingServiceDiscovery(storesRing), tlsCfg, logger, reg),
+		clientsPool:      newStoreGatewayClientPool(client.NewRingServiceDiscovery(storesRing), clientConfig, logger, reg),
 		shardingStrategy: shardingStrategy,
 		limits:           limits,
 	}

--- a/pkg/querier/blocks_store_replicated_set_test.go
+++ b/pkg/querier/blocks_store_replicated_set_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/test"
-	"github.com/cortexproject/cortex/pkg/util/tls"
 )
 
 func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
@@ -334,7 +333,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			}
 
 			reg := prometheus.NewPedanticRegistry()
-			s, err := newBlocksStoreReplicationSet(r, testData.shardingStrategy, limits, tls.ClientConfig{}, log.NewNopLogger(), reg)
+			s, err := newBlocksStoreReplicationSet(r, testData.shardingStrategy, limits, ClientConfig{}, log.NewNopLogger(), reg)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 			defer services.StopAndAwaitTerminated(ctx, s) //nolint:errcheck

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
-	"github.com/cortexproject/cortex/pkg/util/tls"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
@@ -63,8 +62,8 @@ type Config struct {
 	LookbackDelta time.Duration `yaml:"lookback_delta"`
 
 	// Blocks storage only.
-	StoreGatewayAddresses string           `yaml:"store_gateway_addresses"`
-	StoreGatewayClient    tls.ClientConfig `yaml:"store_gateway_client"`
+	StoreGatewayAddresses string       `yaml:"store_gateway_addresses"`
+	StoreGatewayClient    ClientConfig `yaml:"store_gateway_client"`
 
 	SecondStoreEngine        string       `yaml:"second_store_engine"`
 	UseSecondStoreBeforeTime flagext.Time `yaml:"use_second_store_before_time"`

--- a/pkg/querier/store_gateway_client.go
+++ b/pkg/querier/store_gateway_client.go
@@ -1,6 +1,7 @@
 package querier
 
 import (
+	"flag"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -16,7 +17,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/tls"
 )
 
-func newStoreGatewayClientFactory(clientCfg grpcclient.Config, tlsCfg tls.ClientConfig, reg prometheus.Registerer) client.PoolFactory {
+func newStoreGatewayClientFactory(clientCfg grpcclient.Config, reg prometheus.Registerer) client.PoolFactory {
 	requestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   "cortex",
 		Name:        "storegateway_client_request_duration_seconds",
@@ -26,16 +27,16 @@ func newStoreGatewayClientFactory(clientCfg grpcclient.Config, tlsCfg tls.Client
 	}, []string{"operation", "status_code"})
 
 	return func(addr string) (client.PoolClient, error) {
-		return dialStoreGatewayClient(clientCfg, tlsCfg, addr, requestDuration)
+		return dialStoreGatewayClient(clientCfg, addr, requestDuration)
 	}
 }
 
-func dialStoreGatewayClient(clientCfg grpcclient.Config, tlsCfg tls.ClientConfig, addr string, requestDuration *prometheus.HistogramVec) (*storeGatewayClient, error) {
-	opts, err := tlsCfg.GetGRPCDialOptions()
+func dialStoreGatewayClient(clientCfg grpcclient.Config, addr string, requestDuration *prometheus.HistogramVec) (*storeGatewayClient, error) {
+	opts, err := clientCfg.DialOption(grpcclient.Instrument(requestDuration))
 	if err != nil {
 		return nil, err
 	}
-	opts = append(opts, clientCfg.DialOption(grpcclient.Instrument(requestDuration))...)
+
 	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to dial store-gateway %s", addr)
@@ -66,7 +67,7 @@ func (c *storeGatewayClient) RemoteAddress() string {
 	return c.conn.Target()
 }
 
-func newStoreGatewayClientPool(discovery client.PoolServiceDiscovery, tlsCfg tls.ClientConfig, logger log.Logger, reg prometheus.Registerer) *client.Pool {
+func newStoreGatewayClientPool(discovery client.PoolServiceDiscovery, tlsCfg ClientConfig, logger log.Logger, reg prometheus.Registerer) *client.Pool {
 	// We prefer sane defaults instead of exposing further config options.
 	clientCfg := grpcclient.Config{
 		MaxRecvMsgSize:      100 << 20,
@@ -75,6 +76,8 @@ func newStoreGatewayClientPool(discovery client.PoolServiceDiscovery, tlsCfg tls
 		RateLimit:           0,
 		RateLimitBurst:      0,
 		BackoffOnRatelimits: false,
+		TLSEnabled:          tlsCfg.TLSEnabled,
+		TLS:                 tlsCfg.TLS,
 	}
 	poolCfg := client.PoolConfig{
 		CheckInterval:      time.Minute,
@@ -89,5 +92,15 @@ func newStoreGatewayClientPool(discovery client.PoolServiceDiscovery, tlsCfg tls
 		ConstLabels: map[string]string{"client": "querier"},
 	})
 
-	return client.NewPool("store-gateway", poolCfg, discovery, newStoreGatewayClientFactory(clientCfg, tlsCfg, reg), clientsCount, logger)
+	return client.NewPool("store-gateway", poolCfg, discovery, newStoreGatewayClientFactory(clientCfg, reg), clientsCount, logger)
+}
+
+type ClientConfig struct {
+	TLSEnabled bool             `yaml:"tls_enabled"`
+	TLS        tls.ClientConfig `yaml:",inline"`
+}
+
+func (cfg *ClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", cfg.TLSEnabled, "Enable TLS for gRPC client connecting to store-gateway.")
+	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
 }

--- a/pkg/querier/store_gateway_client.go
+++ b/pkg/querier/store_gateway_client.go
@@ -67,7 +67,7 @@ func (c *storeGatewayClient) RemoteAddress() string {
 	return c.conn.Target()
 }
 
-func newStoreGatewayClientPool(discovery client.PoolServiceDiscovery, tlsCfg ClientConfig, logger log.Logger, reg prometheus.Registerer) *client.Pool {
+func newStoreGatewayClientPool(discovery client.PoolServiceDiscovery, clientConfig ClientConfig, logger log.Logger, reg prometheus.Registerer) *client.Pool {
 	// We prefer sane defaults instead of exposing further config options.
 	clientCfg := grpcclient.Config{
 		MaxRecvMsgSize:      100 << 20,
@@ -76,8 +76,8 @@ func newStoreGatewayClientPool(discovery client.PoolServiceDiscovery, tlsCfg Cli
 		RateLimit:           0,
 		RateLimitBurst:      0,
 		BackoffOnRatelimits: false,
-		TLSEnabled:          tlsCfg.TLSEnabled,
-		TLS:                 tlsCfg.TLS,
+		TLSEnabled:          clientConfig.TLSEnabled,
+		TLS:                 clientConfig.TLS,
 	}
 	poolCfg := client.PoolConfig{
 		CheckInterval:      time.Minute,

--- a/pkg/querier/store_gateway_client_test.go
+++ b/pkg/querier/store_gateway_client_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
-	"github.com/cortexproject/cortex/pkg/util/tls"
 )
 
 func Test_newStoreGatewayClientFactory(t *testing.T) {
@@ -37,11 +36,10 @@ func Test_newStoreGatewayClientFactory(t *testing.T) {
 	// Create a client factory and query back the mocked service
 	// with different clients.
 	cfg := grpcclient.Config{}
-	tlsCfg := tls.ClientConfig{}
 	flagext.DefaultValues(&cfg)
 
 	reg := prometheus.NewPedanticRegistry()
-	factory := newStoreGatewayClientFactory(cfg, tlsCfg, reg)
+	factory := newStoreGatewayClientFactory(cfg, reg)
 
 	for i := 0; i < 2; i++ {
 		client, err := factory(listener.Addr().String())

--- a/pkg/querier/worker/frontend_processor.go
+++ b/pkg/querier/worker/frontend_processor.go
@@ -28,7 +28,7 @@ func newFrontendProcessor(cfg Config, handler RequestHandler, log log.Logger) pr
 	return &frontendProcessor{
 		log:            log,
 		handler:        handler,
-		maxMessageSize: cfg.GRPCClientConfig.GRPC.MaxSendMsgSize,
+		maxMessageSize: cfg.GRPCClientConfig.MaxSendMsgSize,
 		querierID:      cfg.QuerierID,
 	}
 }

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -35,7 +35,7 @@ func newSchedulerProcessor(cfg Config, handler RequestHandler, log log.Logger, r
 	p := &schedulerProcessor{
 		log:            log,
 		handler:        handler,
-		maxMessageSize: cfg.GRPCClientConfig.GRPC.MaxSendMsgSize,
+		maxMessageSize: cfg.GRPCClientConfig.MaxSendMsgSize,
 		querierID:      cfg.QuerierID,
 		grpcConfig:     cfg.GRPCClientConfig,
 
@@ -65,7 +65,7 @@ func newSchedulerProcessor(cfg Config, handler RequestHandler, log log.Logger, r
 type schedulerProcessor struct {
 	log            log.Logger
 	handler        RequestHandler
-	grpcConfig     grpcclient.ConfigWithTLS
+	grpcConfig     grpcclient.Config
 	maxMessageSize int
 	querierID      string
 

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -30,7 +30,7 @@ type Config struct {
 
 	QuerierID string `yaml:"id"`
 
-	GRPCClientConfig grpcclient.ConfigWithTLS `yaml:"grpc_client_config"`
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/ring/kv/etcd/etcd.go
+++ b/pkg/ring/kv/etcd/etcd.go
@@ -15,18 +15,16 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring/kv/codec"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	tls2 "github.com/cortexproject/cortex/pkg/util/tls"
 )
 
 // Config for a new etcd.Client.
 type Config struct {
-	Endpoints          []string      `yaml:"endpoints"`
-	DialTimeout        time.Duration `yaml:"dial_timeout"`
-	MaxRetries         int           `yaml:"max_retries"`
-	EnableTLS          bool          `yaml:"tls_enabled"`
-	CertFile           string        `yaml:"tls_cert_path"`
-	KeyFile            string        `yaml:"tls_key_path"`
-	TrustedCAFile      string        `yaml:"tls_ca_path"`
-	InsecureSkipVerify bool          `yaml:"tls_insecure_skip_verify"`
+	Endpoints   []string          `yaml:"endpoints"`
+	DialTimeout time.Duration     `yaml:"dial_timeout"`
+	MaxRetries  int               `yaml:"max_retries"`
+	EnableTLS   bool              `yaml:"tls_enabled"`
+	TLS         tls2.ClientConfig `yaml:",inline"`
 }
 
 // Client implements ring.KVClient for etcd.
@@ -43,10 +41,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.DurationVar(&cfg.DialTimeout, prefix+"etcd.dial-timeout", 10*time.Second, "The dial timeout for the etcd connection.")
 	f.IntVar(&cfg.MaxRetries, prefix+"etcd.max-retries", 10, "The maximum number of retries to do for failed ops.")
 	f.BoolVar(&cfg.EnableTLS, prefix+"etcd.tls-enabled", false, "Enable TLS.")
-	f.StringVar(&cfg.CertFile, prefix+"etcd.tls-cert-path", "", "The TLS certificate file path.")
-	f.StringVar(&cfg.KeyFile, prefix+"etcd.tls-key-path", "", "The TLS private key file path.")
-	f.StringVar(&cfg.TrustedCAFile, prefix+"etcd.tls-ca-path", "", "The trusted CA file path.")
-	f.BoolVar(&cfg.InsecureSkipVerify, prefix+"etcd.tls-insecure-skip-verify", false, "Skip validating server certificate.")
+	cfg.TLS.RegisterFlagsWithPrefix(prefix+"etcd", f)
 }
 
 // GetTLS sets the TLS config field with certs
@@ -55,10 +50,11 @@ func (cfg *Config) GetTLS() (*tls.Config, error) {
 		return nil, nil
 	}
 	tlsInfo := &transport.TLSInfo{
-		CertFile:           cfg.CertFile,
-		KeyFile:            cfg.KeyFile,
-		TrustedCAFile:      cfg.TrustedCAFile,
-		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		CertFile:           cfg.TLS.CertPath,
+		KeyFile:            cfg.TLS.KeyPath,
+		TrustedCAFile:      cfg.TLS.CAPath,
+		ServerName:         cfg.TLS.ServerName,
+		InsecureSkipVerify: cfg.TLS.InsecureSkipVerify,
 	}
 	return tlsInfo.ClientConfig()
 }

--- a/pkg/ring/kv/etcd/etcd.go
+++ b/pkg/ring/kv/etcd/etcd.go
@@ -15,16 +15,16 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring/kv/codec"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	tls2 "github.com/cortexproject/cortex/pkg/util/tls"
+	cortex_tls "github.com/cortexproject/cortex/pkg/util/tls"
 )
 
 // Config for a new etcd.Client.
 type Config struct {
-	Endpoints   []string          `yaml:"endpoints"`
-	DialTimeout time.Duration     `yaml:"dial_timeout"`
-	MaxRetries  int               `yaml:"max_retries"`
-	EnableTLS   bool              `yaml:"tls_enabled"`
-	TLS         tls2.ClientConfig `yaml:",inline"`
+	Endpoints   []string                `yaml:"endpoints"`
+	DialTimeout time.Duration           `yaml:"dial_timeout"`
+	MaxRetries  int                     `yaml:"max_retries"`
+	EnableTLS   bool                    `yaml:"tls_enabled"`
+	TLS         cortex_tls.ClientConfig `yaml:",inline"`
 }
 
 // Client implements ring.KVClient for etcd.

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -64,7 +64,7 @@ type Config struct {
 	// This is used for template expansion in alerts; must be a valid URL.
 	ExternalURL flagext.URLValue `yaml:"external_url"`
 	// GRPC Client configuration.
-	ClientTLSConfig grpcclient.ConfigWithTLS `yaml:"ruler_client"`
+	ClientTLSConfig grpcclient.Config `yaml:"ruler_client"`
 	// How frequently to evaluate rules by default.
 	EvaluationInterval time.Duration `yaml:"evaluation_interval"`
 	// How frequently to poll for updated rules.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -74,7 +74,7 @@ type connectedFrontend struct {
 type Config struct {
 	MaxOutstandingPerTenant int `yaml:"max_outstanding_requests_per_tenant"`
 
-	GRPCClientConfig grpcclient.ConfigWithTLS `yaml:"grpc_client_config" doc:"description=This configures the gRPC client used to report errors back to the query-frontend."`
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=This configures the gRPC client used to report errors back to the query-frontend."`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/util/grpcclient/grpcclient.go
+++ b/pkg/util/grpcclient/grpcclient.go
@@ -26,6 +26,9 @@ type Config struct {
 
 	BackoffOnRatelimits bool               `yaml:"backoff_on_ratelimits"`
 	BackoffConfig       util.BackoffConfig `yaml:"backoff_config"`
+
+	TLSEnabled bool             `yaml:"tls_enabled"`
+	TLS        tls.ClientConfig `yaml:",inline"`
 }
 
 // RegisterFlags registers flags.
@@ -41,8 +44,11 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Float64Var(&cfg.RateLimit, prefix+".grpc-client-rate-limit", 0., "Rate limit for gRPC client; 0 means disabled.")
 	f.IntVar(&cfg.RateLimitBurst, prefix+".grpc-client-rate-limit-burst", 0, "Rate limit burst for gRPC client.")
 	f.BoolVar(&cfg.BackoffOnRatelimits, prefix+".backoff-on-ratelimits", false, "Enable backoff and retry when we hit ratelimits.")
+	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", cfg.TLSEnabled, "Enable TLS in the GRPC client. This flag needs to be enabled when any other TLS flag is set.")
 
 	cfg.BackoffConfig.RegisterFlags(prefix, f)
+
+	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
 }
 
 func (cfg *Config) Validate(log log.Logger) error {
@@ -67,7 +73,14 @@ func (cfg *Config) CallOptions() []grpc.CallOption {
 }
 
 // DialOption returns the config as a grpc.DialOptions.
-func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientInterceptor, streamClientInterceptors []grpc.StreamClientInterceptor) []grpc.DialOption {
+func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientInterceptor, streamClientInterceptors []grpc.StreamClientInterceptor) ([]grpc.DialOption, error) {
+	var opts []grpc.DialOption
+	tlsOpts, err := cfg.TLS.GetGRPCDialOptions(cfg.TLSEnabled)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, tlsOpts...)
+
 	if cfg.BackoffOnRatelimits {
 		unaryClientInterceptors = append([]grpc.UnaryClientInterceptor{NewBackoffRetry(cfg.BackoffConfig)}, unaryClientInterceptors...)
 	}
@@ -76,7 +89,8 @@ func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientIntercep
 		unaryClientInterceptors = append([]grpc.UnaryClientInterceptor{NewRateLimiter(cfg)}, unaryClientInterceptors...)
 	}
 
-	return []grpc.DialOption{
+	return append(
+		opts,
 		grpc.WithDefaultCallOptions(cfg.CallOptions()...),
 		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(unaryClientInterceptors...)),
 		grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(streamClientInterceptors...)),
@@ -85,31 +99,5 @@ func (cfg *Config) DialOption(unaryClientInterceptors []grpc.UnaryClientIntercep
 			Timeout:             time.Second * 10,
 			PermitWithoutStream: true,
 		}),
-	}
-}
-
-// ConfigWithTLS is the config for a grpc client with tls
-type ConfigWithTLS struct {
-	GRPC Config           `yaml:",inline"`
-	TLS  tls.ClientConfig `yaml:",inline"`
-}
-
-// RegisterFlagsWithPrefix registers flags with prefix.
-func (cfg *ConfigWithTLS) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	cfg.GRPC.RegisterFlagsWithPrefix(prefix, f)
-	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
-}
-
-func (cfg *ConfigWithTLS) Validate(log log.Logger) error {
-	return cfg.GRPC.Validate(log)
-}
-
-// DialOption returns the config as a grpc.DialOptions
-func (cfg *ConfigWithTLS) DialOption(unaryClientInterceptors []grpc.UnaryClientInterceptor, streamClientInterceptors []grpc.StreamClientInterceptor) ([]grpc.DialOption, error) {
-	opts, err := cfg.TLS.GetGRPCDialOptions()
-	if err != nil {
-		return nil, err
-	}
-
-	return append(opts, cfg.GRPC.DialOption(unaryClientInterceptors, streamClientInterceptors)...), nil
+	), nil
 }

--- a/pkg/util/grpcclient/grpcclient.go
+++ b/pkg/util/grpcclient/grpcclient.go
@@ -44,7 +44,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Float64Var(&cfg.RateLimit, prefix+".grpc-client-rate-limit", 0., "Rate limit for gRPC client; 0 means disabled.")
 	f.IntVar(&cfg.RateLimitBurst, prefix+".grpc-client-rate-limit-burst", 0, "Rate limit burst for gRPC client.")
 	f.BoolVar(&cfg.BackoffOnRatelimits, prefix+".backoff-on-ratelimits", false, "Enable backoff and retry when we hit ratelimits.")
-	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", cfg.TLSEnabled, "Enable TLS in the GRPC client. This flag needs to be enabled when any other TLS flag is set.")
+	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", cfg.TLSEnabled, "Enable TLS in the GRPC client. This flag needs to be enabled when any other TLS flag is set. If set to false, insecure connection to gRPC server will be used.")
 
 	cfg.BackoffConfig.RegisterFlags(prefix, f)
 

--- a/pkg/util/tls/test/tls_integration_test.go
+++ b/pkg/util/tls/test/tls_integration_test.go
@@ -1,0 +1,567 @@
+package test
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gogo/status"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/server"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/cortexproject/cortex/integration/ca"
+	"github.com/cortexproject/cortex/pkg/util/grpcclient"
+	"github.com/cortexproject/cortex/pkg/util/tls"
+)
+
+type tcIntegrationClientServer struct {
+	name            string
+	tlsGrpcEnabled  bool
+	tlsConfig       tls.ClientConfig
+	httpExpectError func(*testing.T, error)
+	grpcExpectError func(*testing.T, error)
+}
+
+type grpcHealthCheck struct {
+	healthy bool
+}
+
+func (h *grpcHealthCheck) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	if !h.healthy {
+		return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+	}
+
+	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}
+
+func (h *grpcHealthCheck) Watch(_ *grpc_health_v1.HealthCheckRequest, _ grpc_health_v1.Health_WatchServer) error {
+	return status.Error(codes.Unimplemented, "Watching is not supported")
+}
+
+func getLocalHostPort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := l.Close(); err != nil {
+		return 0, err
+	}
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+func newIntegrationClientServer(
+	t *testing.T,
+	cfg server.Config,
+	tcs []tcIntegrationClientServer,
+) {
+	// server registers some metrics to default registry
+	savedRegistry := prometheus.DefaultRegisterer
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	defer func() {
+		prometheus.DefaultRegisterer = savedRegistry
+	}()
+
+	grpcPort, err := getLocalHostPort()
+	require.NoError(t, err)
+	httpPort, err := getLocalHostPort()
+	require.NoError(t, err)
+
+	cfg.HTTPListenPort = httpPort
+	cfg.GRPCListenPort = grpcPort
+
+	serv, err := server.New(cfg)
+	require.NoError(t, err)
+
+	serv.HTTP.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "OK")
+	})
+
+	grpc_health_v1.RegisterHealthServer(serv.GRPC, &grpcHealthCheck{true})
+
+	go func() {
+		err := serv.Run()
+		require.NoError(t, err)
+	}()
+
+	httpURL := fmt.Sprintf("https://localhost:%d/hello", httpPort)
+	grpcHost := fmt.Sprintf("localhost:%d", grpcPort)
+
+	for _, tc := range tcs {
+		tlsClientConfig, err := tc.tlsConfig.GetTLSConfig()
+		require.NoError(t, err)
+
+		// HTTP
+		t.Run("HTTP/"+tc.name, func(t *testing.T) {
+			transport := &http.Transport{TLSClientConfig: tlsClientConfig}
+			client := &http.Client{Transport: transport}
+
+			resp, err := client.Get(httpURL)
+			if err == nil {
+				defer resp.Body.Close()
+			}
+			if tc.httpExpectError != nil {
+				tc.httpExpectError(t, err)
+				return
+			}
+			if err != nil {
+				assert.NoError(t, err, tc.name)
+				return
+			}
+			body, err := ioutil.ReadAll(resp.Body)
+			assert.NoError(t, err, tc.name)
+
+			assert.Equal(t, []byte("OK"), body, tc.name)
+
+		})
+
+		// GRPC
+		t.Run("GRPC/"+tc.name, func(t *testing.T) {
+			clientConfig := grpcclient.Config{}
+			clientConfig.RegisterFlags(flag.NewFlagSet("fake", flag.ContinueOnError))
+
+			clientConfig.TLSEnabled = tc.tlsGrpcEnabled
+			clientConfig.TLS = tc.tlsConfig
+
+			dialOptions, err := clientConfig.DialOption(nil, nil)
+			assert.NoError(t, err, tc.name)
+			dialOptions = append([]grpc.DialOption{grpc.WithDefaultCallOptions(clientConfig.CallOptions()...)}, dialOptions...)
+
+			conn, err := grpc.Dial(grpcHost, dialOptions...)
+			assert.NoError(t, err, tc.name)
+			require.NoError(t, err, tc.name)
+			require.NoError(t, err, tc.name)
+
+			client := grpc_health_v1.NewHealthClient(conn)
+
+			// TODO: Investigate why the client doesn't really receive the
+			// error about the bad certificate from the server side and just
+			// see connection closed instead
+			resp, err := client.Check(context.TODO(), &grpc_health_v1.HealthCheckRequest{})
+			if tc.grpcExpectError != nil {
+				tc.grpcExpectError(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			if err == nil {
+				assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+			}
+		})
+
+	}
+
+	serv.Shutdown()
+}
+
+func TestServerWithoutTlsEnabled(t *testing.T) {
+	cfg := server.Config{}
+	(&cfg).RegisterFlags(flag.NewFlagSet("fake", flag.ContinueOnError))
+
+	newIntegrationClientServer(
+		t,
+		cfg,
+		[]tcIntegrationClientServer{
+			{
+				name:            "no-config",
+				tlsConfig:       tls.ClientConfig{},
+				httpExpectError: errorContainsString("http: server gave HTTP response to HTTPS client"),
+				grpcExpectError: nil,
+			},
+			{
+				name:            "tls-enable",
+				tlsGrpcEnabled:  true,
+				tlsConfig:       tls.ClientConfig{},
+				httpExpectError: errorContainsString("http: server gave HTTP response to HTTPS client"),
+				grpcExpectError: errorContainsString("transport: authentication handshake failed: tls: first record does not look like a TLS handshake"),
+			},
+		},
+	)
+}
+
+func TestServerWithLocalhostCertNoClientCertAuth(t *testing.T) {
+	certs := setupCertificates(t)
+
+	cfg := server.Config{}
+	(&cfg).RegisterFlags(flag.NewFlagSet("fake", flag.ContinueOnError))
+
+	unavailableDescErr := errorContainsString("rpc error: code = Unavailable desc =")
+
+	cfg.HTTPTLSConfig.TLSCertPath = certs.serverCertFile
+	cfg.HTTPTLSConfig.TLSKeyPath = certs.serverKeyFile
+	cfg.GRPCTLSConfig.TLSCertPath = certs.serverCertFile
+	cfg.GRPCTLSConfig.TLSKeyPath = certs.serverKeyFile
+
+	// Test a TLS server with localhost cert without any client certificate enforcement
+	newIntegrationClientServer(
+		t,
+		cfg,
+		[]tcIntegrationClientServer{
+			{
+				name:            "no-config",
+				tlsConfig:       tls.ClientConfig{},
+				httpExpectError: errorContainsString("x509: certificate signed by unknown authority"),
+				// For GRPC we expect this error as we try to connect without TLS to a TLS enabled server
+				grpcExpectError: unavailableDescErr,
+			},
+			{
+				name:            "grpc-tls-enabled",
+				tlsGrpcEnabled:  true,
+				tlsConfig:       tls.ClientConfig{},
+				httpExpectError: errorContainsString("x509: certificate signed by unknown authority"),
+				grpcExpectError: errorContainsString("x509: certificate signed by unknown authority"),
+			},
+			{
+				name:           "tls-skip-verify",
+				tlsGrpcEnabled: true,
+				tlsConfig: tls.ClientConfig{
+					InsecureSkipVerify: true,
+				},
+			},
+			{
+				name:           "tls-skip-verify-no-grpc-tls-enabled",
+				tlsGrpcEnabled: false,
+				tlsConfig: tls.ClientConfig{
+					InsecureSkipVerify: true,
+				},
+				grpcExpectError: unavailableDescErr,
+			},
+			{
+				name:           "ca-path-set",
+				tlsGrpcEnabled: true,
+				tlsConfig: tls.ClientConfig{
+					CAPath: certs.caCertFile,
+				},
+			},
+			{
+				name:           "ca-path-no-grpc-tls-enabled",
+				tlsGrpcEnabled: false,
+				tlsConfig: tls.ClientConfig{
+					CAPath: certs.caCertFile,
+				},
+				grpcExpectError: unavailableDescErr,
+			},
+		},
+	)
+}
+
+func TestServerWithoutLocalhostCertNoClientCertAuth(t *testing.T) {
+	certs := setupCertificates(t)
+
+	cfg := server.Config{}
+	(&cfg).RegisterFlags(flag.NewFlagSet("fake", flag.ContinueOnError))
+
+	unavailableDescErr := errorContainsString("rpc error: code = Unavailable desc =")
+
+	// Test a TLS server without localhost cert without any client certificate enforcement
+	cfg.HTTPTLSConfig.TLSCertPath = certs.serverNoLocalhostCertFile
+	cfg.HTTPTLSConfig.TLSKeyPath = certs.serverNoLocalhostKeyFile
+	cfg.GRPCTLSConfig.TLSCertPath = certs.serverNoLocalhostCertFile
+	cfg.GRPCTLSConfig.TLSKeyPath = certs.serverNoLocalhostKeyFile
+	newIntegrationClientServer(
+		t,
+		cfg,
+		[]tcIntegrationClientServer{
+			{
+				name:            "no-config",
+				tlsConfig:       tls.ClientConfig{},
+				httpExpectError: errorContainsString("x509: certificate is valid for my-other-name, not localhost"),
+				// For GRPC we expect this error as we try to connect without TLS to a TLS enabled server
+				grpcExpectError: unavailableDescErr,
+			},
+			{
+				name:            "grpc-tls-enabled",
+				tlsGrpcEnabled:  true,
+				tlsConfig:       tls.ClientConfig{},
+				httpExpectError: errorContainsString("x509: certificate is valid for my-other-name, not localhost"),
+				grpcExpectError: errorContainsString("x509: certificate is valid for my-other-name, not localhost"),
+			},
+			{
+				name:           "ca-path",
+				tlsGrpcEnabled: true,
+				tlsConfig: tls.ClientConfig{
+					CAPath: certs.caCertFile,
+				},
+				httpExpectError: errorContainsString("x509: certificate is valid for my-other-name, not localhost"),
+				grpcExpectError: errorContainsString("x509: certificate is valid for my-other-name, not localhost"),
+			},
+			{
+				name:           "server-name",
+				tlsGrpcEnabled: true,
+				tlsConfig: tls.ClientConfig{
+					CAPath:     certs.caCertFile,
+					ServerName: "my-other-name",
+				},
+			},
+			{
+				name:           "tls-skip-verify",
+				tlsGrpcEnabled: true,
+				tlsConfig: tls.ClientConfig{
+					InsecureSkipVerify: true,
+				},
+			},
+		},
+	)
+}
+
+func TestTLSServerWithLocalhostCertWithClientCertificateEnforcementUsingClientCA1(t *testing.T) {
+	certs := setupCertificates(t)
+
+	cfg := server.Config{}
+	(&cfg).RegisterFlags(flag.NewFlagSet("fake", flag.ContinueOnError))
+
+	unavailableDescErr := errorContainsString("rpc error: code = Unavailable desc =")
+
+	// Test a TLS server with localhost cert with client certificate enforcement through client CA 1
+	cfg.HTTPTLSConfig.TLSCertPath = certs.serverCertFile
+	cfg.HTTPTLSConfig.TLSKeyPath = certs.serverKeyFile
+	cfg.HTTPTLSConfig.ClientCAs = certs.clientCA1CertFile
+	cfg.HTTPTLSConfig.ClientAuth = "RequireAndVerifyClientCert"
+	cfg.GRPCTLSConfig.TLSCertPath = certs.serverCertFile
+	cfg.GRPCTLSConfig.TLSKeyPath = certs.serverKeyFile
+	cfg.GRPCTLSConfig.ClientCAs = certs.clientCA1CertFile
+	cfg.GRPCTLSConfig.ClientAuth = "RequireAndVerifyClientCert"
+
+	// TODO: Investigate why we don't really receive the error about the
+	// bad certificate from the server side and just see connection
+	// closed/reset instead
+	badCertErr := errorContainsString("remote error: tls: bad certificate")
+	newIntegrationClientServer(
+		t,
+		cfg,
+		[]tcIntegrationClientServer{
+			{
+				name:           "tls-skip-verify",
+				tlsGrpcEnabled: true,
+				tlsConfig: tls.ClientConfig{
+					InsecureSkipVerify: true,
+				},
+				httpExpectError: badCertErr,
+				grpcExpectError: unavailableDescErr,
+			},
+			{
+				name:           "ca-path",
+				tlsGrpcEnabled: true,
+				tlsConfig: tls.ClientConfig{
+					CAPath: certs.caCertFile,
+				},
+				httpExpectError: badCertErr,
+				grpcExpectError: unavailableDescErr,
+			},
+			{
+				name:           "ca-path-and-client-cert-ca1",
+				tlsGrpcEnabled: true,
+				tlsConfig: tls.ClientConfig{
+					CAPath:   certs.caCertFile,
+					CertPath: certs.client1CertFile,
+					KeyPath:  certs.client1KeyFile,
+				},
+			},
+			{
+				name:           "tls-skip-verify-and-client-cert-ca1",
+				tlsGrpcEnabled: true,
+				tlsConfig: tls.ClientConfig{
+					InsecureSkipVerify: true,
+					CertPath:           certs.client1CertFile,
+					KeyPath:            certs.client1KeyFile,
+				},
+			},
+			{
+				name:           "ca-cert-and-client-cert-ca2",
+				tlsGrpcEnabled: true,
+				tlsConfig: tls.ClientConfig{
+					CAPath:   certs.caCertFile,
+					CertPath: certs.client2CertFile,
+					KeyPath:  certs.client2KeyFile,
+				},
+				httpExpectError: badCertErr,
+				grpcExpectError: unavailableDescErr,
+			},
+		},
+	)
+}
+
+func TestTLSServerWithLocalhostCertWithClientCertificateEnforcementUsingClientCA2(t *testing.T) {
+	certs := setupCertificates(t)
+
+	cfg := server.Config{}
+	(&cfg).RegisterFlags(flag.NewFlagSet("fake", flag.ContinueOnError))
+
+	// Test a TLS server with localhost cert with client certificate enforcement through client CA 1
+	cfg.HTTPTLSConfig.TLSCertPath = certs.serverCertFile
+	cfg.HTTPTLSConfig.TLSKeyPath = certs.serverKeyFile
+	cfg.HTTPTLSConfig.ClientCAs = certs.clientCABothCertFile
+	cfg.HTTPTLSConfig.ClientAuth = "RequireAndVerifyClientCert"
+	cfg.GRPCTLSConfig.TLSCertPath = certs.serverCertFile
+	cfg.GRPCTLSConfig.TLSKeyPath = certs.serverKeyFile
+	cfg.GRPCTLSConfig.ClientCAs = certs.clientCABothCertFile
+	cfg.GRPCTLSConfig.ClientAuth = "RequireAndVerifyClientCert"
+
+	newIntegrationClientServer(
+		t,
+		cfg,
+		[]tcIntegrationClientServer{
+			{
+				name:           "ca-cert-and-client-cert-ca1",
+				tlsGrpcEnabled: true,
+				tlsConfig: tls.ClientConfig{
+					CAPath:   certs.caCertFile,
+					CertPath: certs.client1CertFile,
+					KeyPath:  certs.client1KeyFile,
+				},
+			},
+			{
+				name:           "ca-cert-and-client-cert-ca2",
+				tlsGrpcEnabled: true,
+				tlsConfig: tls.ClientConfig{
+					CAPath:   certs.caCertFile,
+					CertPath: certs.client2CertFile,
+					KeyPath:  certs.client2KeyFile,
+				},
+			},
+		},
+	)
+}
+
+func setupCertificates(t *testing.T) keyMaterial {
+	testCADir, err := ioutil.TempDir("", "cortex-ca")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(testCADir))
+	})
+
+	// create server side CA
+
+	testCA := ca.New("Cortex Test")
+	caCertFile := filepath.Join(testCADir, "ca.crt")
+	require.NoError(t, testCA.WriteCACertificate(caCertFile))
+
+	serverCertFile := filepath.Join(testCADir, "server.crt")
+	serverKeyFile := filepath.Join(testCADir, "server.key")
+	require.NoError(t, testCA.WriteCertificate(
+		&x509.Certificate{
+			Subject:     pkix.Name{CommonName: "server"},
+			DNSNames:    []string{"localhost", "my-other-name"},
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		},
+		serverCertFile,
+		serverKeyFile,
+	))
+
+	serverNoLocalhostCertFile := filepath.Join(testCADir, "server-no-localhost.crt")
+	serverNoLocalhostKeyFile := filepath.Join(testCADir, "server-no-localhost.key")
+	require.NoError(t, testCA.WriteCertificate(
+		&x509.Certificate{
+			Subject:     pkix.Name{CommonName: "server-no-localhost"},
+			DNSNames:    []string{"my-other-name"},
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		},
+		serverNoLocalhostCertFile,
+		serverNoLocalhostKeyFile,
+	))
+
+	// create client CAs
+	testClientCA1 := ca.New("Cortex Test Client CA 1")
+	testClientCA2 := ca.New("Cortex Test Client CA 2")
+
+	clientCA1CertFile := filepath.Join(testCADir, "ca-client-1.crt")
+	require.NoError(t, testClientCA1.WriteCACertificate(clientCA1CertFile))
+	clientCA2CertFile := filepath.Join(testCADir, "ca-client-2.crt")
+	require.NoError(t, testClientCA2.WriteCACertificate(clientCA2CertFile))
+
+	// create a ca file with both certs
+	clientCABothCertFile := filepath.Join(testCADir, "ca-client-both.crt")
+	func() {
+		src1, err := os.Open(clientCA1CertFile)
+		require.NoError(t, err)
+		defer src1.Close()
+		src2, err := os.Open(clientCA2CertFile)
+		require.NoError(t, err)
+		defer src2.Close()
+
+		dst, err := os.Create(clientCABothCertFile)
+		require.NoError(t, err)
+		defer dst.Close()
+
+		_, err = io.Copy(dst, src1)
+		require.NoError(t, err)
+		_, err = io.Copy(dst, src2)
+		require.NoError(t, err)
+
+	}()
+
+	client1CertFile := filepath.Join(testCADir, "client-1.crt")
+	client1KeyFile := filepath.Join(testCADir, "client-1.key")
+	require.NoError(t, testClientCA1.WriteCertificate(
+		&x509.Certificate{
+			Subject:     pkix.Name{CommonName: "client-1"},
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		},
+		client1CertFile,
+		client1KeyFile,
+	))
+
+	client2CertFile := filepath.Join(testCADir, "client-2.crt")
+	client2KeyFile := filepath.Join(testCADir, "client-2.key")
+	require.NoError(t, testClientCA2.WriteCertificate(
+		&x509.Certificate{
+			Subject:     pkix.Name{CommonName: "client-2"},
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		},
+		client2CertFile,
+		client2KeyFile,
+	))
+
+	return keyMaterial{
+		caCertFile:                caCertFile,
+		serverCertFile:            serverCertFile,
+		serverKeyFile:             serverKeyFile,
+		serverNoLocalhostCertFile: serverNoLocalhostCertFile,
+		serverNoLocalhostKeyFile:  serverNoLocalhostKeyFile,
+		clientCA1CertFile:         clientCA1CertFile,
+		clientCABothCertFile:      clientCABothCertFile,
+		client1CertFile:           client1CertFile,
+		client1KeyFile:            client1KeyFile,
+		client2CertFile:           client2CertFile,
+		client2KeyFile:            client2KeyFile,
+	}
+}
+
+type keyMaterial struct {
+	caCertFile                string
+	serverCertFile            string
+	serverKeyFile             string
+	serverNoLocalhostCertFile string
+	serverNoLocalhostKeyFile  string
+	clientCA1CertFile         string
+	clientCABothCertFile      string
+	client1CertFile           string
+	client1KeyFile            string
+	client2CertFile           string
+	client2KeyFile            string
+}
+
+func errorContainsString(str string) func(*testing.T, error) {
+	return func(t *testing.T, err error) {
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), str)
+	}
+}

--- a/pkg/util/tls/tls_test.go
+++ b/pkg/util/tls/tls_test.go
@@ -171,9 +171,20 @@ func TestGetTLSConfig_CA(t *testing.T) {
 	assert.Contains(t, err.Error(), "error loading ca cert")
 }
 
-func TestGetTLSConfig_NoConfig(t *testing.T) {
-	c := &ClientConfig{}
+func TestGetTLSConfig_InsecureSkipVerify(t *testing.T) {
+	c := &ClientConfig{
+		InsecureSkipVerify: true,
+	}
 	tlsConfig, err := c.GetTLSConfig()
 	assert.NoError(t, err)
-	assert.Nil(t, tlsConfig)
+	assert.True(t, tlsConfig.InsecureSkipVerify)
+}
+
+func TestGetTLSConfig_ServerName(t *testing.T) {
+	c := &ClientConfig{
+		ServerName: "myserver.com",
+	}
+	tlsConfig, err := c.GetTLSConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, "myserver.com", tlsConfig.ServerName)
 }

--- a/tools/blocksconvert/planprocessor/service.go
+++ b/tools/blocksconvert/planprocessor/service.go
@@ -37,7 +37,7 @@ type Config struct {
 	HeartbeatPeriod   time.Duration
 	SchedulerEndpoint string
 	NextPlanInterval  time.Duration
-	GrpcConfig        grpcclient.ConfigWithTLS
+	GrpcConfig        grpcclient.Config
 }
 
 func (cfg *Config) RegisterFlags(prefix string, f *flag.FlagSet) {


### PR DESCRIPTION
**What this PR does**:

Increase TLS test coverage and support other TLS modes than mutual auth in Client by implementing explicit TLS enable flag.

This also adds a `tls-server-name` flag to require a specific server name instead of the hostname on the certificate.

**Which issue(s) this PR fixes**:

Fixes #3062 #3063 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
