### PR TITLE
Added default template funcs to templates validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [BUGFIX] Ingester: If push request contained both valid and invalid samples, valid samples were ingested but not stored to WAL of the chunks storage. This has been fixed. #3067
 * [BUGFIX] Ruler: Config API would return both the `record` and `alert` in `YAML` response keys even when one of them must be empty. #3120
 * [BUGFIX] Index page now uses configured HTTP path prefix when creating links. #3126
+* [BUGFIX] Configs: prevent validation of templates to fail when using template functions. #3157
 
 ## 1.3.0 / 2020-08-21
 

--- a/pkg/configs/api/api.go
+++ b/pkg/configs/api/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/gorilla/mux"
 	amconfig "github.com/prometheus/alertmanager/config"
+	amtemplate "github.com/prometheus/alertmanager/template"
 	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/configs/db"
@@ -247,7 +248,7 @@ func validateRulesFiles(c userconfig.Config) error {
 
 func validateTemplateFiles(c userconfig.Config) error {
 	for fn, content := range c.TemplateFiles {
-		if _, err := template.New(fn).Parse(content); err != nil {
+		if _, err := template.New(fn).Funcs(template.FuncMap(amtemplate.DefaultFuncs)).Parse(content); err != nil {
 			return err
 		}
 	}

--- a/pkg/configs/api/api_test.go
+++ b/pkg/configs/api/api_test.go
@@ -374,3 +374,25 @@ func TestParseConfigFormat(t *testing.T) {
 		})
 	}
 }
+
+func Test_SetConfig_ValidateTemplateFiles(t *testing.T) {
+	cfg := userconfig.Config{
+		TemplateFiles: map[string]string{
+			"mytemplate.tmpl": `
+				{{ define "mytemplate" }}
+				ToUpper{{ .Value | toUpper }}
+				ToLower{{ .Value | toLower }}
+				Title{{ .Value | title }}
+				Join{{ .Values | join " " }}
+				Match{{ .Value | match "fir" }}
+				SafeHTML{{ .Value | safeHtml }}
+				ReReplaceAll{{ .Value | reReplaceAll "-" "_" }}
+				StringSlice{{ .Value | stringSlice }}
+				{{ end }}
+			`,
+		},
+	}
+
+	err := validateTemplateFiles(cfg)
+	assert.Equal(t, nil, err)
+}


### PR DESCRIPTION
Signed-off-by: Roger Steneteg <rsteneteg@ea.com>

**What this PR does**:
The Configs API was missing the default funcs when validating templates, this lead to Configs returning an error when trying to set templates using any of those default funcs

**Which issue(s) this PR fixes**:
Fixes #2490

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
