### PR TITLE
Improve the error message in readiness check when unhealthy ingesters are in the ring.

### DIFF
--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -228,7 +228,7 @@ func (i *Lifecycler) CheckReady(ctx context.Context) error {
 
 	if err := ringDesc.Ready(time.Now(), i.cfg.RingConfig.HeartbeatTimeout); err != nil {
 		level.Warn(util.Logger).Log("msg", "found an existing instance(s) with a problem in the ring, "+
-			"this instance cannot complete joining and become ready until this problem is resolved. "+
+			"this instance cannot become ready until this problem is resolved. "+
 			"The /ring http endpoint on the distributor (or single binary) provides visibility into the ring.",
 			"ring", i.RingName, "err", err)
 		return err


### PR DESCRIPTION

Signed-off-by: Edward Welch <edward.welch@grafana.com>


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
