### PR TITLE
Doc fixes related to block storage

### DIFF
--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -44,7 +44,7 @@ The store-gateway supports two sharding strategies:
 
 The **`default`** sharding strategy spreads the blocks of each tenant across all store-gateway instances. It's the easiest form of sharding supported, but doesn't provide any workload isolation between different tenants.
 
-The **`shuffle-sharding`** strategy spreads the blocks of a tenant across a subset of store-gateway instances. This way, the number of store-gateway instances loading blocks of a single tenant is limited and the blast radius of any issue that could be introduced by the ternant's workload is limited to its shard instances.
+The **`shuffle-sharding`** strategy spreads the blocks of a tenant across a subset of store-gateway instances. This way, the number of store-gateway instances loading blocks of a single tenant is limited and the blast radius of any issue that could be introduced by the tenant's workload is limited to its shard instances.
 
 The shuffle sharding strategy can be enabled via `-experimental.store-gateway.sharding-strategy=shuffle-sharding` and requires the `-experimental.store-gateway.tenant-shard-size` flag (or their respective YAML config options) to be set to the default shard size, which is the default number of store-gateway instances each tenant should be sharded to. The shard size can then be overridden on a per-tenant basis setting the `store_gateway_tenant_shard_size` in the limits overrides.
 

--- a/docs/blocks-storage/store-gateway.template
+++ b/docs/blocks-storage/store-gateway.template
@@ -44,7 +44,7 @@ The store-gateway supports two sharding strategies:
 
 The **`default`** sharding strategy spreads the blocks of each tenant across all store-gateway instances. It's the easiest form of sharding supported, but doesn't provide any workload isolation between different tenants.
 
-The **`shuffle-sharding`** strategy spreads the blocks of a tenant across a subset of store-gateway instances. This way, the number of store-gateway instances loading blocks of a single tenant is limited and the blast radius of any issue that could be introduced by the ternant's workload is limited to its shard instances.
+The **`shuffle-sharding`** strategy spreads the blocks of a tenant across a subset of store-gateway instances. This way, the number of store-gateway instances loading blocks of a single tenant is limited and the blast radius of any issue that could be introduced by the tenant's workload is limited to its shard instances.
 
 The shuffle sharding strategy can be enabled via `-experimental.store-gateway.sharding-strategy=shuffle-sharding` and requires the `-experimental.store-gateway.tenant-shard-size` flag (or their respective YAML config options) to be set to the default shard size, which is the default number of store-gateway instances each tenant should be sharded to. The shard size can then be overridden on a per-tenant basis setting the `store_gateway_tenant_shard_size` in the limits overrides.
 

--- a/docs/production/running.md
+++ b/docs/production/running.md
@@ -25,7 +25,7 @@ Commercial cloud options are DynamoDB/S3 and Bigtable/GCS: the advantage is you 
 Alternatively you can choose Apache Cassandra, which you will have to install and manage.
 Cassandra support can also be used with commecial Cassandra-compatible services such as Azure Cosmos DB.
 
-Cortex has an alternative to chunk storage: [block storage](../blocks-storage/).  Block storage is not ready for production usage at this time.
+Cortex has an alternative to chunk storage: [block storage](../blocks-storage/_index.md).  Block storage is not ready for production usage at this time.
 
 ## 2. Deploy Query Frontend
 

--- a/k8s/query-frontend-svc.yaml
+++ b/k8s/query-frontend-svc.yaml
@@ -8,7 +8,7 @@ spec:
   clusterIP: None
   ports:
     - port: 9095
-      name: grcp
+      name: grpc
     - port: 80
       name: http
   selector:


### PR DESCRIPTION
Fix a link to `block storage` on:
https://cortexmetrics.io/docs/production/running-in-production/

Also fix a spelling error in store-gateway docs, and a port name in
`query-frontend-svc.yaml`.

Signed-off-by: Andrew Seigner <andrew@sig.gy>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
