### PR TITLE
add store method for getting fetcher for a chunk

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -715,6 +715,6 @@ func (c *store) DeleteSeriesIDs(ctx context.Context, from, through model.Time, u
 	return nil
 }
 
-func (c *baseStore) GetChunkFetcher(chunk Chunk) *Fetcher {
+func (c *baseStore) GetChunkFetcher(_ model.Time) *Fetcher {
 	return c.fetcher
 }

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -714,3 +714,7 @@ func (c *store) DeleteSeriesIDs(ctx context.Context, from, through model.Time, u
 	// SeriesID is something which is only used in SeriesStore so we need not do anything here
 	return nil
 }
+
+func (c *baseStore) GetChunkFetcher(chunk Chunk) *Fetcher {
+	return c.fetcher
+}

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -176,7 +176,7 @@ func (c compositeStore) GetChunkRefs(ctx context.Context, userID string, from, t
 }
 
 func (c compositeStore) GetChunkFetcher(tm model.Time) *Fetcher {
-	// next, find the schema with the lowest start _after_ tm
+	// find the schema with the lowest start _after_ tm
 	j := sort.Search(len(c.stores), func(j int) bool {
 		return c.stores[j].start > tm
 	})

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -184,7 +184,7 @@ func (c compositeStore) GetChunkFetcher(tm model.Time) *Fetcher {
 	// reduce it by 1 because we want a schema with start <= tm
 	j--
 
-	if j >= 0 && len(c.stores) > j {
+	if 0 <= j && j < len(c.stores) {
 		return c.stores[j].GetChunkFetcher(tm)
 	}
 

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -32,7 +32,7 @@ type Store interface {
 	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([][]Chunk, []*Fetcher, error)
 	LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string) ([]string, error)
 	LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string) ([]string, error)
-	GetChunkFetcher(chunk Chunk) *Fetcher
+	GetChunkFetcher(tm model.Time) *Fetcher
 
 	// DeleteChunk deletes a chunks index entry and then deletes the actual chunk from chunk storage.
 	// It takes care of chunks which are deleting partially by creating and inserting a new chunk first and then deleting the original chunk
@@ -175,17 +175,17 @@ func (c compositeStore) GetChunkRefs(ctx context.Context, userID string, from, t
 	return chunkIDs, fetchers, err
 }
 
-func (c compositeStore) GetChunkFetcher(chunk Chunk) *Fetcher {
-	// next, find the schema with the lowest start _after_ through
+func (c compositeStore) GetChunkFetcher(tm model.Time) *Fetcher {
+	// next, find the schema with the lowest start _after_ tm
 	j := sort.Search(len(c.stores), func(j int) bool {
-		return c.stores[j].start > chunk.Through
+		return c.stores[j].start > tm
 	})
 
-	// reduce it by 1 because we want a schema with start <= through
+	// reduce it by 1 because we want a schema with start <= tm
 	j--
 
 	if j >= 0 && len(c.stores) > j {
-		return c.stores[j].GetChunkFetcher(chunk)
+		return c.stores[j].GetChunkFetcher(tm)
 	}
 
 	return nil
@@ -248,12 +248,6 @@ func (c compositeStore) forStores(ctx context.Context, userID string, from, thro
 		nextSchemaStarts := model.Latest
 		if i+1 < len(c.stores) {
 			nextSchemaStarts = c.stores[i+1].start
-		}
-
-		// If the next schema starts at the same time as this one,
-		// skip this one.
-		if nextSchemaStarts == c.stores[i].start {
-			continue
 		}
 
 		end := min(through, nextSchemaStarts-1)

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -25,10 +25,11 @@ const (
 )
 
 var (
-	errInvalidSchemaVersion    = errors.New("invalid schema version")
-	errInvalidTablePeriod      = errors.New("the table period must be a multiple of 24h (1h for schema v1)")
-	errConfigFileNotSet        = errors.New("schema config file needs to be set")
-	errConfigChunkPrefixNotSet = errors.New("schema config for chunks is missing the 'prefix' setting")
+	errInvalidSchemaVersion     = errors.New("invalid schema version")
+	errInvalidTablePeriod       = errors.New("the table period must be a multiple of 24h (1h for schema v1)")
+	errConfigFileNotSet         = errors.New("schema config file needs to be set")
+	errConfigChunkPrefixNotSet  = errors.New("schema config for chunks is missing the 'prefix' setting")
+	errSchemaIncreasingFromTime = errors.New("from time in schemas must be distinct and in increasing order")
 )
 
 // PeriodConfig defines the schema and tables to use for a period of time
@@ -119,6 +120,12 @@ func (cfg *SchemaConfig) Validate() error {
 		periodCfg.applyDefaults()
 		if err := periodCfg.validate(); err != nil {
 			return err
+		}
+
+		if i+1 < len(cfg.Configs) {
+			if cfg.Configs[i].From.Time.Unix() >= cfg.Configs[i+1].From.Time.Unix() {
+				return errSchemaIncreasingFromTime
+			}
 		}
 	}
 	return nil

--- a/pkg/chunk/schema_config_test.go
+++ b/pkg/chunk/schema_config_test.go
@@ -553,6 +553,50 @@ func TestSchemaConfig_Validate(t *testing.T) {
 			},
 			err: errConfigChunkPrefixNotSet,
 		},
+		"invalid schema with same from time configs": {
+			config: &SchemaConfig{
+				Configs: []PeriodConfig{
+					{
+						From:   MustParseDayTime("1970-01-01"),
+						Schema: "v9",
+					},
+					{
+						From:   MustParseDayTime("1970-01-01"),
+						Schema: "v10",
+					},
+				},
+			},
+			err: errSchemaIncreasingFromTime,
+		},
+		"invalid schema with from time not in increasing order": {
+			config: &SchemaConfig{
+				Configs: []PeriodConfig{
+					{
+						From:   MustParseDayTime("1970-01-02"),
+						Schema: "v9",
+					},
+					{
+						From:   MustParseDayTime("1970-01-01"),
+						Schema: "v10",
+					},
+				},
+			},
+			err: errSchemaIncreasingFromTime,
+		},
+		"valid schema with different from time configs": {
+			config: &SchemaConfig{
+				Configs: []PeriodConfig{
+					{
+						From:   MustParseDayTime("1970-01-01"),
+						Schema: "v9",
+					},
+					{
+						From:   MustParseDayTime("1970-01-02"),
+						Schema: "v10",
+					},
+				},
+			},
+		},
 	}
 
 	for testName, testData := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds a new store method called `GetChunkFetcher` which helps to get a chunk fetcher for a chunk.
I have used end time of the chunk to find the store for it.

This helps with a use-case where Loki has a bunch of chunk ids which would be converted to chunkref using `ParseExternalKey` and passed to this method to get a fetcher for it.

**Checklist**
- [x] Tests updated
