### PR TITLE
Dashboard s3.jsonnet

### DIFF
--- a/production/dashboards/cortex-read.jsonnet
+++ b/production/dashboards/cortex-read.jsonnet
@@ -92,10 +92,10 @@ g.dashboard(
         title='QPS',
         type='stack',
         targets=[{
-            query: 'sum(rate(cortex_cache_request_duration_seconds_count{method="memcache.fetch", status_code=~"2.*"}[1m]))',
+            query: 'sum(rate(cortex_cache_request_duration_seconds_count{method="Memcache.Get", status_code=~"2.*"}[1m]))',
             legendFormat: '2xx',
         }, {
-            query: 'sum(rate(cortex_cache_request_duration_seconds_count{method="memcache.fetch", status_code=~"5.*"}[1m]))',
+            query: 'sum(rate(cortex_cache_request_duration_seconds_count{method="Memcache.Get", status_code=~"5.*"}[1m]))',
             legendFormat: '5xx',
         }],
     ) + {
@@ -109,13 +109,13 @@ g.dashboard(
     g.graphPanel(
         title='Latency',
         targets=[{
-            query: 'histogram_quantile(0.5, sum(rate(cortex_cache_request_duration_seconds_bucket{method="memcache.fetch"}[1m])) by (le))',
+            query: 'histogram_quantile(0.5, sum(rate(cortex_cache_request_duration_seconds_bucket{method="Memcache.Get"}[1m])) by (le))',
             legendFormat: 'p50',
         }, {
-            query: 'histogram_quantile(0.95, sum(rate(cortex_cache_request_duration_seconds_bucket{method="memcache.fetch"}[1m])) by (le))',
+            query: 'histogram_quantile(0.95, sum(rate(cortex_cache_request_duration_seconds_bucket{method="Memcache.Get"}[1m])) by (le))',
             legendFormat: 'p95',
         }, {
-            query: 'histogram_quantile(0.99, sum(rate(cortex_cache_request_duration_seconds_bucket{method="memcache.fetch"}[1m])) by (le))',
+            query: 'histogram_quantile(0.99, sum(rate(cortex_cache_request_duration_seconds_bucket{method="Memcache.Get"}[1m])) by (le))',
             legendFormat: 'p99',
         }],
     )

--- a/production/dashboards/cortex-write.jsonnet
+++ b/production/dashboards/cortex-write.jsonnet
@@ -124,10 +124,10 @@ g.dashboard(
         title='WPS',
         type='stack',
         targets=[{
-            query: 'sum(rate(cortex_cache_request_duration_seconds_count{method="memcache.store", status_code=~"2.*"}[1m]))',
+            query: 'sum(rate(cortex_cache_request_duration_seconds_count{method="Memcache.Put", status_code=~"2.*"}[1m]))',
             legendFormat: '2xx',
         }, {
-            query: 'sum(rate(cortex_cache_request_duration_seconds_count{method="memcache.store", status_code=~"5.*"}[1m]))',
+            query: 'sum(rate(cortex_cache_request_duration_seconds_count{method="Memcache.Put", status_code=~"5.*"}[1m]))',
             legendFormat: '5xx',
         }],
     ) + {
@@ -141,13 +141,13 @@ g.dashboard(
     g.graphPanel(
         title='Latency',
         targets=[{
-            query: 'histogram_quantile(0.5, sum(rate(cortex_cache_request_duration_seconds_bucket{method="memcache.store"}[1m])) by (le))',
+            query: 'histogram_quantile(0.5, sum(rate(cortex_cache_request_duration_seconds_bucket{method="Memcache.Put"}[1m])) by (le))',
             legendFormat: 'p50',
         }, {
-            query: 'histogram_quantile(0.95, sum(rate(cortex_cache_request_duration_seconds_bucket{method="memcache.store"}[1m])) by (le))',
+            query: 'histogram_quantile(0.95, sum(rate(cortex_cache_request_duration_seconds_bucket{method="Memcache.Put"}[1m])) by (le))',
             legendFormat: 'p95',
         }, {
-            query: 'histogram_quantile(0.99, sum(rate(cortex_cache_request_duration_seconds_bucket{method="memcache.store"}[1m])) by (le))',
+            query: 'histogram_quantile(0.99, sum(rate(cortex_cache_request_duration_seconds_bucket{method="Memcache.Put"}[1m])) by (le))',
             legendFormat: 'p99',
         }],
     )

--- a/production/dashboards/s3.libsonnet
+++ b/production/dashboards/s3.libsonnet
@@ -1,0 +1,50 @@
+{
+    name: 's3',
+
+    readRateTargets: [{
+        query: 'sum(rate(cortex_s3_request_duration_seconds_count{operation=~"S3.GetObject"}[1m])) by (status_code)',
+        legendFormat: '{{status_code}}',
+    }],
+    readRateMixin: {
+        aliasColors: {
+            "200": "#7EB26D",
+            "500": "#BF1B00",
+        },
+    },
+
+    readLatencyTargets: [{
+        query: 'histogram_quantile(0.5, sum(rate(cortex_s3_request_duration_seconds_bucket[1m])) by (le))',
+        legendFormat: 'p50',
+    }, {
+        query: 'histogram_quantile(0.95, sum(rate(cortex_s3_request_duration_seconds_bucket[1m])) by (le))',
+        legendFormat: 'p95',
+    }, {
+        query: 'histogram_quantile(0.99, sum(rate(cortex_s3_request_duration_seconds_bucket[1m])) by (le))',
+        legendFormat: 'p99',
+    }],
+    readLatencyMixin: {},
+
+    writeRateTargets: [{
+        query: 'sum(rate(cortex_s3_request_duration_seconds_count{operation="S3.PutObject"}[1m])) by (status_code)',
+        legendFormat: '{{status_code}}',
+    }],
+    writeRateMixin: {
+        aliasColors: {
+            "200": "#7EB26D",
+            "500": "#BF1B00",
+        },
+    },
+
+    writeLatencyTargets: [{
+        query: 'histogram_quantile(0.5, sum(rate(cortex_s3_request_duration_seconds_bucket{operation="S3.PutObject"}[1m])) by (le))',
+        legendFormat: 'p50',
+    }, {
+        query: 'histogram_quantile(0.95, sum(rate(cortex_s3_request_duration_seconds_bucket{operation="S3.PutObject"}[1m])) by (le))',
+        legendFormat: 'p95',
+    }, {
+        query: 'histogram_quantile(0.99, sum(rate(cortex_s3_request_duration_seconds_bucket{operation="S3.PutObject"}[1m])) by (le))',
+        legendFormat: 'p99',
+    }],
+    writeLatencyMixin: {},
+
+}


### PR DESCRIPTION
Pushing this mostly to see if this is interesting for someone else.

**What this PR does**:

 1. Adds an `s3.libsonnet` file as currently only bigtable is offered.
 2. Fixes (a bug?) in the dashboard files, memcache methods must have been renamed.

**Checklist**
- [x] ~~Tests updated~~
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
