### PR TITLE
Fix @ in the S3 URL without username and password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [BUGFIX] Index page now uses configured HTTP path prefix when creating links. #3126
 * [BUGFIX] Index page no longer shows links that are not valid for running Cortex instance. #3133
 * [BUGFIX] Configs: prevent validation of templates to fail when using template functions. #3157
+* [BUGFIX] Configuring the S3 URL with an `@` but without username and password doesn't enable the AWS static credentials anymore. #3170
 
 ## 1.3.0 / 2020-08-21
 

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/thanos-io/thanos v0.13.1-0.20200807203500-9b578afb4763
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
-	github.com/weaveworks/common v0.0.0-20200820123129-280614068c5e
+	github.com/weaveworks/common v0.0.0-20200914083218-61ffdd448099
 	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da // indirect
 	go.etcd.io/bbolt v1.3.5-0.20200615073812-232d8fc87f50
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200520232829-54ba9589114f

--- a/go.sum
+++ b/go.sum
@@ -1100,8 +1100,8 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/weaveworks/common v0.0.0-20200206153930-760e36ae819a/go.mod h1:6enWAqfQBFrE8X/XdJwZr8IKgh1chStuFR0mjU/UOUw=
 github.com/weaveworks/common v0.0.0-20200625145055-4b1847531bc9/go.mod h1:c98fKi5B9u8OsKGiWHLRKus6ToQ1Tubeow44ECO1uxY=
-github.com/weaveworks/common v0.0.0-20200820123129-280614068c5e h1:t/as1iFw9iI6s0q9ESR2tTn2qGhI42LjBkPuQLuLzM8=
-github.com/weaveworks/common v0.0.0-20200820123129-280614068c5e/go.mod h1:hz10LOsAdzC3K/iXaKoFxOKTDRgxJl+BTGX1GY+TzO4=
+github.com/weaveworks/common v0.0.0-20200914083218-61ffdd448099 h1:MS5M2antM8wzMUqVxIfAi+yb6yjXvDINRFvLnmNXeIw=
+github.com/weaveworks/common v0.0.0-20200914083218-61ffdd448099/go.mod h1:hz10LOsAdzC3K/iXaKoFxOKTDRgxJl+BTGX1GY+TzO4=
 github.com/weaveworks/promrus v1.2.0 h1:jOLf6pe6/vss4qGHjXmGz4oDJQA+AOCqEL3FvvZGz7M=
 github.com/weaveworks/promrus v1.2.0/go.mod h1:SaE82+OJ91yqjrE1rsvBWVzNZKcHYFtMUyS1+Ogs/KA=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=

--- a/vendor/github.com/weaveworks/common/aws/config.go
+++ b/vendor/github.com/weaveworks/common/aws/config.go
@@ -40,9 +40,13 @@ func ConfigFromURL(awsURL *url.URL) (*aws.Config, error) {
 		})
 
 	if awsURL.User != nil {
+		username := awsURL.User.Username()
 		password, _ := awsURL.User.Password()
-		creds := credentials.NewStaticCredentials(awsURL.User.Username(), password, "")
-		config = config.WithCredentials(creds)
+
+		// We request at least the username or password being set to enable the static credentials.
+		if username != "" || password != "" {
+			config = config.WithCredentials(credentials.NewStaticCredentials(username, password, ""))
+		}
 	}
 
 	if strings.Contains(awsURL.Host, ".") {

--- a/vendor/github.com/weaveworks/common/httpgrpc/README.md
+++ b/vendor/github.com/weaveworks/common/httpgrpc/README.md
@@ -1,6 +1,6 @@
 **What?** Embedding HTTP requests and responses into a gRPC service; a service and client to translate back and forth between the two, so you can use them with your faviourite mux.
 
-**Why?** Get all the goodness of protobuf encoding, HTTP/2, snappy, load balancing, persistent connection and native Kuberneretes load balancing with ~none of the effort.
+**Why?** Get all the goodness of protobuf encoding, HTTP/2, snappy, load balancing, persistent connection and native Kubernetes load balancing with ~none of the effort.
 
 To rebuild generated protobuf code, run:
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -718,7 +718,7 @@ github.com/uber/jaeger-client-go/utils
 # github.com/uber/jaeger-lib v2.2.0+incompatible
 github.com/uber/jaeger-lib/metrics
 github.com/uber/jaeger-lib/metrics/prometheus
-# github.com/weaveworks/common v0.0.0-20200820123129-280614068c5e
+# github.com/weaveworks/common v0.0.0-20200914083218-61ffdd448099
 ## explicit
 github.com/weaveworks/common/aws
 github.com/weaveworks/common/errors


### PR DESCRIPTION
**What this PR does**:
In this PR I'm upgrading `weaveworks/common` to bring in https://github.com/weaveworks/common/pull/198, which fixes an issue with the S3 URL contains `@` but no username and password.

**Which issue(s) this PR fixes**:
Fixes #3034

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
