### PR TITLE
Fixed double tracing spans

### DIFF
--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -10,9 +10,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
-	"github.com/thanos-io/thanos/pkg/tracing"
 	"github.com/weaveworks/common/server"
 	"github.com/weaveworks/common/signals"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -272,13 +270,8 @@ func New(cfg Config) (*Cortex, error) {
 // setupThanosTracing appends a gRPC middleware used to inject our tracer into the custom
 // context used by Thanos, in order to get Thanos spans correctly attached to our traces.
 func (t *Cortex) setupThanosTracing() {
-	t.Cfg.Server.GRPCMiddleware = append(t.Cfg.Server.GRPCMiddleware,
-		tracing.UnaryServerInterceptor(opentracing.GlobalTracer()),
-	)
-
-	t.Cfg.Server.GRPCStreamMiddleware = append(t.Cfg.Server.GRPCStreamMiddleware,
-		tracing.StreamServerInterceptor(opentracing.GlobalTracer()),
-	)
+	t.Cfg.Server.GRPCMiddleware = append(t.Cfg.Server.GRPCMiddleware, ThanosTracerUnaryInterceptor)
+	t.Cfg.Server.GRPCStreamMiddleware = append(t.Cfg.Server.GRPCStreamMiddleware, ThanosTracerStreamInterceptor)
 }
 
 // Run starts Cortex running, and blocks until a Cortex stops.

--- a/pkg/cortex/tracing.go
+++ b/pkg/cortex/tracing.go
@@ -1,0 +1,33 @@
+package cortex
+
+import (
+	"context"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/thanos-io/thanos/pkg/tracing"
+	"google.golang.org/grpc"
+)
+
+// ThanosTracerUnaryInterceptor injects the opentracing global tracer into the context
+// in order to get it picked up by Thanos components.
+func ThanosTracerUnaryInterceptor(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return handler(tracing.ContextWithTracer(ctx, opentracing.GlobalTracer()), req)
+}
+
+// ThanosTracerStreamInterceptor injects the opentracing global tracer into the context
+// in order to get it picked up by Thanos components.
+func ThanosTracerStreamInterceptor(srv interface{}, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return handler(srv, wrappedServerStream{
+		ctx:          tracing.ContextWithTracer(ss.Context(), opentracing.GlobalTracer()),
+		ServerStream: ss,
+	})
+}
+
+type wrappedServerStream struct {
+	ctx context.Context
+	grpc.ServerStream
+}
+
+func (ss wrappedServerStream) Context() context.Context {
+	return ss.ctx
+}


### PR DESCRIPTION
**What this PR does**:
@bboreham reported in #3168 that we have some double tracing spans, due to how we inject the tracer for Thanos. According to my investigation, the issue is caused by the usage of `grpc_tracing.UnaryServerInterceptor()` and `grpc_tracing.StreamServerInterceptor()` (respectively called by Thanos `UnaryServerInterceptor()` and `StreamServerInterceptor()`) which create a new span.

This PR should fix it. I've manually tested it (both for unary and stream interceptors) and looks fixing the issue.

**Which issue(s) this PR fixes**:
Fixes #3168

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
