### PR TITLE
feat(e2e): set network name in e2e tests using env variable

### DIFF
--- a/docs/contributing/how-integration-tests-work.md
+++ b/docs/contributing/how-integration-tests-work.md
@@ -37,6 +37,8 @@ go test -v -tags=requires_docker ./integration -run "^TestChunksStorageAllIndexB
   The absolute path of the Cortex repository local checkout (defaults to `$GOPATH/src/github.com/cortexproject/cortex`)
 -- **`E2E_TEMP_DIR`**<br />
   The absolute path to a directory where the integration test will create an additional temporary directory to store files generated during the test.
+-- **`E2E_NETWORK_NAME`**<br />
+  Name of the docker network to create and use for integration tests. If no variable is set, defaults to `e2e-cortex-test`.
 
 ### The `requires_docker` tag
 

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -4,11 +4,10 @@ package integration
 
 import (
 	"fmt"
-	"math/rand"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
-	"time"
 
 	"github.com/cortexproject/cortex/integration/e2e"
 	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
@@ -19,7 +18,7 @@ type storeConfig struct {
 }
 
 const (
-	networkNamePrefix      = "e2e-cortex-test-"
+	defaultNetworkName     = "e2e-cortex-test"
 	bucketName             = "cortex"
 	cortexConfigFile       = "config.yaml"
 	cortexSchemaConfigFile = "schema.yaml"
@@ -31,21 +30,19 @@ const (
 	serverKeyFile          = "certs/server.key"
 )
 
-// Generate a 6 character (a-z,0-9) id for the test being run.
-// This ID is used to generate a network name for the test
-func genUniqueTestID() string {
-	rand.Seed(time.Now().UnixNano())
-	chars := []rune("abcdefghijklmnopqrstuvwxyz" + "0123456789")
-	length := 6
-	var b strings.Builder
-	for i := 0; i < length; i++ {
-		b.WriteRune(chars[rand.Intn(len(chars))])
+// GetNetworkName returns the docker network name to run tests within.
+func GetNetworkName() string {
+	// If the E2E_NETWORK_NAME is set, use that for the network name.
+	// Otherwise, return the default network name.
+	if os.Getenv("E2E_NETWORK_NAME") != "" {
+		return os.Getenv("E2E_NETWORK_NAME")
 	}
-	return b.String() // E.g. "ExcbsVQs"
+
+	return defaultNetworkName
 }
 
 var (
-	networkName         = networkNamePrefix + genUniqueTestID()
+	networkName         = GetNetworkName()
 	storeConfigTemplate = `
 - from: {{.From}}
   store: {{.IndexStore}}


### PR DESCRIPTION
**What this PR does**:

- Reverts the network name used by default in integration tests to be static
- Allow for users to override the network name using the `E2E_NETWORK_NAME` env variable

**Which issue(s) this PR fixes**:
Related Comment: https://github.com/cortexproject/cortex/pull/3147#issuecomment-692158510

**Checklist**
- [x] Tests updated
- [x] Documentation added

