### PR TITLE
Fixed doc about Gossip/memberlist support no more experimental

### DIFF
--- a/docs/getting-started/getting-started-with-gossip-ring.md
+++ b/docs/getting-started/getting-started-with-gossip-ring.md
@@ -1,6 +1,6 @@
 ---
-title: "Getting Started with Gossiped Ring (experimental)"
-linkTitle: "Gossip Ring (experimental)"
+title: "Getting Started with Gossiped Ring"
+linkTitle: "Gossip Ring"
 weight: 2
 slug: getting-started-with-gossiped-ring
 ---

--- a/pkg/ring/kv/memberlist/memberlist_client.go
+++ b/pkg/ring/kv/memberlist/memberlist_client.go
@@ -359,8 +359,6 @@ func (m *KV) buildMemberlistConfig() (*memberlist.Config, error) {
 }
 
 func (m *KV) starting(_ context.Context) error {
-	util.WarnExperimentalUse("Gossip memberlist ring")
-
 	mlCfg, err := m.buildMemberlistConfig()
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does**:
We marked gossip/memberlist support as stable in 1.2.0 but we forgot to update all the doc and remove the experimental warning from logs. This PR fixes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
