### PR TITLE
Micro fixes to CHANGELOG and API doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## master / unreleased
 
-* [CHANGE] Cassandra backend support is now GA (stable).
-* [CHANGE] Blocks storage is now GA (stable). The `-experimental` prefix has been removed from all CLI flags related to the blocks storage (no YAML config changes).
+* [CHANGE] Cassandra backend support is now GA (stable). #3180
+* [CHANGE] Blocks storage is now GA (stable). The `-experimental` prefix has been removed from all CLI flags related to the blocks storage (no YAML config changes). #3180
   - `-experimental.blocks-storage.*` flags renamed to `-blocks-storage.*`
   - `-experimental.store-gateway.*` flags renamed to `-store-gateway.*`
   - `-experimental.querier.store-gateway-client.*` flags renamed to `-querier.store-gateway-client.*`

--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -555,6 +555,10 @@ DELETE <legacy-http-prefix>/rules/{namespace}/{groupName}
 
 Deletes a rule group by namespace and group name. This endpoints returns `202` on success.
 
+_This experimental endpoint is disabled by default and can be enabled via the `-experimental.ruler.enable-api` CLI flag (or its respective YAML config option)._
+
+_Requires [authentication](#authentication)._
+
 ### Delete namespace
 
 ```

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -338,8 +338,8 @@ func (c *Client) DeleteRuleGroup(namespace string, groupName string) error {
 	return nil
 }
 
-// DeleteNamespace deletes all the rule groups (and the namespace itself).
-func (c *Client) DeleteNamespace(namespace string) error {
+// DeleteRuleNamespace deletes all the rule groups (and the namespace itself).
+func (c *Client) DeleteRuleNamespace(namespace string) error {
 	// Create HTTP request
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s/api/prom/rules/%s", c.rulerAddress, url.PathEscape(namespace)), nil)
 	if err != nil {

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -77,7 +77,7 @@ func TestRulerAPI(t *testing.T) {
 
 	// Delete the set rule groups
 	require.NoError(t, c.DeleteRuleGroup(namespaceOne, ruleGroup.Name))
-	require.NoError(t, c.DeleteNamespace(namespaceTwo))
+	require.NoError(t, c.DeleteRuleNamespace(namespaceTwo))
 
 	// Wait until the users manager has been terminated
 	require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(0), "cortex_ruler_managers_total"))


### PR DESCRIPTION
**What this PR does**:
A couple of micro fixes to doc:
1. CHANGELOG entries for #3180 was missing the PR number
2. PR #3120 removed a couple of info from "Delete rule group" API doc

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
