### PR TITLE
Alertmanager Config API: Do not allow empty configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 * [BUGFIX] Configs: prevent validation of templates to fail when using template functions. #3157
 * [BUGFIX] Configuring the S3 URL with an `@` but without username and password doesn't enable the AWS static credentials anymore. #3170
 * [BUGFIX] Limit errors on ranged queries (`api/v1/query_range`) no longer return a status code `500` but `422` instead. #3167
+* [BUGFIX] Experimental Alertmanager: Do not allow empty Alertmanager configurations to be submitted through the configuration API. #XXXX
 
 ## 1.3.0 / 2020-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * [BUGFIX] No-longer-needed ingester operations for queries triggered by queriers and rulers are now canceled. #3178
 * [BUGFIX] Ruler: directories in the configured `rules-path` will be removed on startup and shutdown in order to ensure they don't persist between runs. #3195
 * [BUGFIX] Handle hash-collisions in the query path. #3192
-* [BUGFIX] Check for postgres rows errors. #3197
+* [BUGFIX] Experimental Alertmanager: Do not allow empty Alertmanager configurations or bad template filenames to be submitted through the configuration API. #3185
 
 ## 1.4.0-rc.0 in progress
 
@@ -94,7 +94,6 @@
 * [BUGFIX] Configs: prevent validation of templates to fail when using template functions. #3157
 * [BUGFIX] Configuring the S3 URL with an `@` but without username and password doesn't enable the AWS static credentials anymore. #3170
 * [BUGFIX] Limit errors on ranged queries (`api/v1/query_range`) no longer return a status code `500` but `422` instead. #3167
-* [BUGFIX] Experimental Alertmanager: Do not allow empty Alertmanager configurations to be submitted through the configuration API. #XXXX
 
 ## 1.3.0 / 2020-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 * [BUGFIX] No-longer-needed ingester operations for queries triggered by queriers and rulers are now canceled. #3178
 * [BUGFIX] Ruler: directories in the configured `rules-path` will be removed on startup and shutdown in order to ensure they don't persist between runs. #3195
 * [BUGFIX] Handle hash-collisions in the query path. #3192
-* [BUGFIX] Experimental Alertmanager: Do not allow empty Alertmanager configurations or bad template filenames to be submitted through the configuration API. #3185
+* [BUGFIX] Check for postgres rows errors. #3197
+* [BUGFIX] Experimental Alertmanager API: Do not allow empty Alertmanager configurations or bad template filenames to be submitted through the configuration API. #3185
 
 ## 1.4.0-rc.0 in progress
 

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -154,10 +154,14 @@ func validateUserConfig(logger log.Logger, cfg alerts.AlertConfigDesc) error {
 	defer os.RemoveAll(tmpDir)
 
 	for _, tmpl := range cfg.Templates {
+		if tmpl.Filename != filepath.Base(tmpl.Filename) {
+			return fmt.Errorf("template file name '%s' is not not valid, consider using '%s'", tmpl.Filename, filepath.Base(tmpl.Filename))
+		}
+
 		_, err := createTemplateFile(tmpDir, cfg.User, tmpl.Filename, tmpl.Body)
 		if err != nil {
 			level.Error(logger).Log("msg", "unable to create template file", "err", err, "user", cfg.User)
-			return fmt.Errorf("unable to create template file %s", tmpl.Filename)
+			return fmt.Errorf("unable to create template file '%s'", tmpl.Filename)
 		}
 	}
 

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -154,10 +154,6 @@ func validateUserConfig(logger log.Logger, cfg alerts.AlertConfigDesc) error {
 	defer os.RemoveAll(tmpDir)
 
 	for _, tmpl := range cfg.Templates {
-		if tmpl.Filename != filepath.Base(tmpl.Filename) {
-			return fmt.Errorf("template file name '%s' is not not valid, consider using '%s'", tmpl.Filename, filepath.Base(tmpl.Filename))
-		}
-
 		_, err := createTemplateFile(tmpDir, cfg.User, tmpl.Filename, tmpl.Body)
 		if err != nil {
 			level.Error(logger).Log("msg", "unable to create template file", "err", err, "user", cfg.User)

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -133,6 +133,10 @@ func (am *MultitenantAlertmanager) DeleteUserConfig(w http.ResponseWriter, r *ht
 
 // Partially copied from: https://github.com/prometheus/alertmanager/blob/8e861c646bf67599a1704fc843c6a94d519ce312/cli/check_config.go#L65-L96
 func validateUserConfig(logger log.Logger, cfg alerts.AlertConfigDesc) error {
+	// We don't have a valid use case for empty configurations. If a tenant does not have a
+	// configuration set and issue a request to the Alertmanager, we'll a) upload an empty
+	// config and b) immediately start an Alertmanager instance for them if a fallback
+	// configuration is provisioned.
 	if cfg.RawConfig == "" {
 		return fmt.Errorf("configuration provided is empty, if you'd like to remove your configuration please use the delete configuration endpoint")
 	}

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
 	"github.com/cortexproject/cortex/pkg/util"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/template"
@@ -95,7 +96,7 @@ func (am *MultitenantAlertmanager) SetUserConfig(w http.ResponseWriter, r *http.
 	}
 
 	cfgDesc := alerts.ToProto(cfg.AlertmanagerConfig, cfg.TemplateFiles, userID)
-	if err := validateUserConfig(cfgDesc); err != nil {
+	if err := validateUserConfig(logger, cfgDesc); err != nil {
 		level.Warn(logger).Log("msg", errValidatingConfig, "err", err.Error())
 		http.Error(w, fmt.Sprintf("%s: %s", errValidatingConfig, err.Error()), http.StatusBadRequest)
 		return
@@ -130,8 +131,12 @@ func (am *MultitenantAlertmanager) DeleteUserConfig(w http.ResponseWriter, r *ht
 	w.WriteHeader(http.StatusOK)
 }
 
-func validateUserConfig(cfg alerts.AlertConfigDesc) error {
-	// Validation copied from: https://github.com/prometheus/alertmanager/blob/8e861c646bf67599a1704fc843c6a94d519ce312/cli/check_config.go#L65-L96
+// Partially copied from: https://github.com/prometheus/alertmanager/blob/8e861c646bf67599a1704fc843c6a94d519ce312/cli/check_config.go#L65-L96
+func validateUserConfig(logger log.Logger, cfg alerts.AlertConfigDesc) error {
+	if cfg.RawConfig == "" {
+		return fmt.Errorf("configuration provided is empty, if you'd like to remove your configuration please use the delete configuration endpoint")
+	}
+
 	amCfg, err := config.Load(cfg.RawConfig)
 	if err != nil {
 		return err
@@ -151,7 +156,8 @@ func validateUserConfig(cfg alerts.AlertConfigDesc) error {
 	for _, tmpl := range cfg.Templates {
 		_, err := createTemplateFile(tmpDir, cfg.User, tmpl.Filename, tmpl.Body)
 		if err != nil {
-			return err
+			level.Error(logger).Log("msg", "unable to create template file", "err", err, "user", cfg.User)
+			return fmt.Errorf("unable to create template file %s", tmpl.Filename)
 		}
 	}
 

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -66,7 +66,25 @@ template_files:
   "good.tpl": "good-templ"
   "not/very/good.tpl": "bad-template"
 `,
-			err: fmt.Errorf("error validating Alertmanager config: unable to create template file not/very/good.tpl"),
+			err: fmt.Errorf("error validating Alertmanager config: template file name 'not/very/good.tpl' is not not valid, consider using 'good.tpl'"),
+		},
+		{
+			name: "It is not valid with .",
+			cfg: `
+alertmanager_config: |
+  route:
+    receiver: 'default-receiver'
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    group_by: [cluster, alertname]
+  receivers:
+    - name: default-receiver
+template_files:
+  "good.tpl": "good-templ"
+  ".": "bad-template"
+`,
+			err: fmt.Errorf("error validating Alertmanager config: unable to create template file '.'"),
 		},
 		{
 			name: "It is not valid if the config is empty due to wrong indendatation",

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -66,7 +66,7 @@ template_files:
   "good.tpl": "good-templ"
   "not/very/good.tpl": "bad-template"
 `,
-			err: fmt.Errorf("error validating Alertmanager config: template file name 'not/very/good.tpl' is not not valid, consider using 'good.tpl'"),
+			err: fmt.Errorf("error validating Alertmanager config: unable to create template file 'not/very/good.tpl'"),
 		},
 		{
 			name: "It is not valid with .",

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -3,10 +3,10 @@ package alertmanager
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
@@ -14,30 +14,64 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
-	"gopkg.in/yaml.v2"
 )
 
 func TestAMConfigValidationAPI(t *testing.T) {
 	testCases := []struct {
-		cfg    UserConfig
-		hasErr bool
+		name     string
+		cfg      string
+		response string
+		err      error
 	}{
 		{
-			cfg: UserConfig{
-				AlertmanagerConfig: `
-route:
-  receiver: 'default-receiver'
-  group_wait: 30s
-  group_interval: 5m
-  repeat_interval: 4h
-  group_by: [cluster, alertname]
+			name: "It is not a valid payload without receivers",
+			cfg: `
+alertmanager_config: |
+  route:
+    receiver: 'default-receiver'
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    group_by: [cluster, alertname]
 `,
-			},
-			hasErr: true,
+			err: fmt.Errorf("error validating Alertmanager config: undefined receiver \"default-receiver\" used in route"),
 		},
 		{
-			cfg: UserConfig{
-				AlertmanagerConfig: `
+			name: "It is valid",
+			cfg: `
+alertmanager_config: |
+  route:
+    receiver: 'default-receiver'
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    group_by: [cluster, alertname]
+  receivers:
+    - name: default-receiver
+`,
+		},
+		{
+			name: "It is not valid with paths in the template",
+			cfg: `
+alertmanager_config: |
+  route:
+    receiver: 'default-receiver'
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    group_by: [cluster, alertname]
+  receivers:
+    - name: default-receiver
+template_files:
+  "good.tpl": "good-templ"
+  "not/very/good.tpl": "bad-template"
+`,
+			err: fmt.Errorf("error validating Alertmanager config: unable to create template file not/very/good.tpl"),
+		},
+		{
+			name: "It is not valid if the config is empty due to wrong indendatation",
+			cfg: `
+alertmanager_config: |
 route:
   receiver: 'default-receiver'
   group_wait: 30s
@@ -46,28 +80,29 @@ route:
   group_by: [cluster, alertname]
 receivers:
   - name: default-receiver
+template_files:
+  "good.tpl": "good-templ"
+  "not/very/good.tpl": "bad-template"
 `,
-			},
-			hasErr: false,
+			err: fmt.Errorf("error validating Alertmanager config: configuration provided is empty, if you'd like to remove your configuration please use the delete configuration endpoint"),
 		},
 		{
-			cfg: UserConfig{
-				AlertmanagerConfig: `
-route:
-  receiver: 'default-receiver'
-  group_wait: 30s
-  group_interval: 5m
-  repeat_interval: 4h
-  group_by: [cluster, alertname]
-receivers:
-  - name: default-receiver
+			name: "It is not valid if the config is empty due to wrong key",
+			cfg: `
+XWRONGalertmanager_config: |
+  route:
+    receiver: 'default-receiver'
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    group_by: [cluster, alertname]
+  receivers:
+    - name: default-receiver
+template_files:
+  "good.tpl": "good-templ"
+  "not/very/good.tpl": "bad-template"
 `,
-				TemplateFiles: map[string]string{
-					"good.tpl":          "good-template",
-					"not/very/good.tpl": "bad-template", // Paths are not allowed in templates.
-				},
-			},
-			hasErr: true,
+			err: fmt.Errorf("error validating Alertmanager config: configuration provided is empty, if you'd like to remove your configuration please use the delete configuration endpoint"),
 		},
 	}
 
@@ -76,27 +111,28 @@ receivers:
 		logger: util.Logger,
 	}
 	for _, tc := range testCases {
-		payload, err := yaml.Marshal(&tc.cfg)
-		require.NoError(t, err)
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://alertmanager/api/v1/alerts", bytes.NewReader([]byte(tc.cfg)))
+			ctx := context.Background()
+			ctx = user.InjectOrgID(ctx, "testing")
+			require.NoError(t, user.InjectOrgIDIntoHTTPRequest(ctx, req))
+			w := httptest.NewRecorder()
+			am.SetUserConfig(w, req)
+			resp := w.Result()
 
-		req := httptest.NewRequest(http.MethodPost, "http://alertmanager/api/v1/alerts", bytes.NewReader(payload))
-		ctx := context.Background()
-		ctx = user.InjectOrgID(ctx, "testing")
-		require.NoError(t, user.InjectOrgIDIntoHTTPRequest(ctx, req))
-		w := httptest.NewRecorder()
-		am.SetUserConfig(w, req)
-
-		resp := w.Result()
-		if tc.hasErr {
-			require.Equal(t, 400, resp.StatusCode)
-			respBody, err := ioutil.ReadAll(resp.Body)
+			body, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
-			require.True(t, strings.Contains(string(respBody), "error validating Alertmanager config"))
-		} else {
-			require.Equal(t, 201, resp.StatusCode)
-		}
-	}
 
+			if tc.err == nil {
+				require.Equal(t, http.StatusCreated, resp.StatusCode)
+				require.Equal(t, "", string(body))
+			} else {
+				require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+				require.Equal(t, tc.err.Error()+"\n", string(body))
+			}
+
+		})
+	}
 }
 
 type noopAlertStore struct{}

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -528,6 +528,10 @@ func (s StatusHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func createTemplateFile(dataDir, userID, fn, content string) (bool, error) {
+	if fn != filepath.Base(fn) {
+		return false, fmt.Errorf("template file name '%s' is not not valid", fn)
+	}
+
 	dir := filepath.Join(dataDir, "templates", userID, filepath.Dir(fn))
 	err := os.MkdirAll(dir, 0755)
 	if err != nil {


### PR DESCRIPTION
**What this PR does**:

Fixes #3142 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
