### PR TITLE
Cutting CHANGELOG before next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+## 1.4.0-rc.0 in progress
+
 * [CHANGE] Cassandra backend support is now GA (stable). #3180
 * [CHANGE] Blocks storage is now GA (stable). The `-experimental` prefix has been removed from all CLI flags related to the blocks storage (no YAML config changes). #3180
   - `-experimental.blocks-storage.*` flags renamed to `-blocks-storage.*`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,7 @@ Our goal is to provide a new minor release every 6 weeks. This is a new process 
 | v1.1.0         | 2020-05-11                                 | Peter Štibraný (@pstibrany)                 |
 | v1.2.0         | 2020-06-24                                 | Bryan Boreham                               |
 | v1.3.0         | 2020-08-03                                 | Marco Pracucci (@pracucci)                  |
-| v1.4.0         | 2020-09-14                                 |                                             |
+| v1.4.0         | 2020-09-14                                 | Marco Pracucci (@pracucci)                  |
 | v1.5.0         | 2020-10-26                                 |                                             |
 
 ## Release shepherd responsibilities


### PR DESCRIPTION
**What this PR does**:
I'm about to cut `1.4.0-rc.0`. As a preliminary step, I'm cutting the CHANGELOG to simplify conflicts management.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
