### PR TITLE
Dont rely on hashes for collecting chunks together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [ENHANCEMENT] Ingester: added new metric `cortex_ingester_active_series` to track active series more accurately. Also added options to control whether active series tracking is enabled (`-ingester.active-series-enabled`, defaults to false), and how often this metric is updated (`-ingester.active-series-update-period`) and max idle time for series to be considered inactive (`-ingester.active-series-idle-timeout`). #3153
 * [BUGFIX] Ruler: directories in the configured `rules-path` will be removed on startup and shutdown in order to ensure they don't persist between runs. #3195
+* [BUGFIX] Handle hash-collisions in the query path. #3192
 
 ## 1.4.0-rc.0 in progress
 

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -178,7 +178,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 
 		// Parse any chunk series
 		for _, series := range response.Chunkseries {
-			key := LabelsToKeyString(client.FromLabelAdaptersToLabels(series.Labels))
+			key := client.LabelsToKeyString(client.FromLabelAdaptersToLabels(series.Labels))
 			existing := hashToChunkseries[key]
 			existing.Labels = series.Labels
 			existing.Chunks = append(existing.Chunks, series.Chunks...)
@@ -187,7 +187,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 
 		// Parse any time series
 		for _, series := range response.Timeseries {
-			key := LabelsToKeyString(client.FromLabelAdaptersToLabels(series.Labels))
+			key := client.LabelsToKeyString(client.FromLabelAdaptersToLabels(series.Labels))
 			existing := hashToTimeSeries[key]
 			existing.Labels = series.Labels
 			if existing.Samples == nil {
@@ -251,11 +251,4 @@ func sameSamples(a, b []ingester_client.Sample) bool {
 		}
 	}
 	return true
-}
-
-// LabelsToKeyString is used to form a string to be used as
-// the hashKey. Don't print, use l.String() for printing.
-func LabelsToKeyString(l labels.Labels) string {
-	b := make([]byte, 0, 1024)
-	return string(l.Bytes(b))
 }

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -170,32 +170,32 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 		return nil, err
 	}
 
-	hashToChunkseries := map[model.Fingerprint]ingester_client.TimeSeriesChunk{}
-	hashToTimeSeries := map[model.Fingerprint]ingester_client.TimeSeries{}
+	hashToChunkseries := map[string]ingester_client.TimeSeriesChunk{}
+	hashToTimeSeries := map[string]ingester_client.TimeSeries{}
 
 	for _, result := range results {
 		response := result.(*ingester_client.QueryStreamResponse)
 
 		// Parse any chunk series
 		for _, series := range response.Chunkseries {
-			hash := client.FastFingerprint(series.Labels)
-			existing := hashToChunkseries[hash]
+			key := LabelsToKeyString(client.FromLabelAdaptersToLabels(series.Labels))
+			existing := hashToChunkseries[key]
 			existing.Labels = series.Labels
 			existing.Chunks = append(existing.Chunks, series.Chunks...)
-			hashToChunkseries[hash] = existing
+			hashToChunkseries[key] = existing
 		}
 
 		// Parse any time series
 		for _, series := range response.Timeseries {
-			hash := client.FastFingerprint(series.Labels)
-			existing := hashToTimeSeries[hash]
+			key := LabelsToKeyString(client.FromLabelAdaptersToLabels(series.Labels))
+			existing := hashToTimeSeries[key]
 			existing.Labels = series.Labels
 			if existing.Samples == nil {
 				existing.Samples = series.Samples
 			} else {
 				existing.Samples = mergeSamples(existing.Samples, series.Samples)
 			}
-			hashToTimeSeries[hash] = existing
+			hashToTimeSeries[key] = existing
 		}
 	}
 
@@ -251,4 +251,11 @@ func sameSamples(a, b []ingester_client.Sample) bool {
 		}
 	}
 	return true
+}
+
+// LabelsToKeyString is used to form a string to be used as
+// the hashKey. Don't print, use l.String() for printing.
+func LabelsToKeyString(l labels.Labels) string {
+	b := make([]byte, 0, 1024)
+	return string(l.Bytes(b))
 }

--- a/pkg/distributor/query_test.go
+++ b/pkg/distributor/query_test.go
@@ -1,10 +1,8 @@
 package distributor
 
 import (
-	"strconv"
 	"testing"
 
-	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/require"
 
 	ingester_client "github.com/cortexproject/cortex/pkg/ingester/client"
@@ -107,51 +105,4 @@ func TestMergeSamplesIntoFirstNilB(t *testing.T) {
 	b := mergeSamples(a, nil)
 
 	require.Equal(t, b, a)
-}
-
-func BenchmarkSeriesMap(b *testing.B) {
-	benchmarkSeriesMap(100000, b)
-}
-
-func benchmarkSeriesMap(numSeries int, b *testing.B) {
-	series := makeSeries(numSeries)
-	sm := map[string]int{}
-
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for i, s := range series {
-			sm[LabelsToKeyString(s)] = i
-		}
-
-		for _, s := range series {
-			_, ok := sm[LabelsToKeyString(s)]
-			if !ok {
-				b.Fatal("element missing")
-			}
-		}
-
-		if len(sm) != numSeries {
-			b.Fatal("the number of series expected:", numSeries, "got:", len(sm))
-		}
-	}
-}
-
-func makeSeries(n int) []labels.Labels {
-	series := make([]labels.Labels, 0, n)
-	for i := 0; i < n; i++ {
-		series = append(series, labels.FromMap(map[string]string{
-			"label0": "value0",
-			"label1": "value1",
-			"label2": "value2",
-			"label3": "value3",
-			"label4": "value4",
-			"label5": "value5",
-			"label6": "value6",
-			"label7": "value7",
-			"label8": "value8",
-			"label9": strconv.Itoa(i),
-		}))
-	}
-
-	return series
 }

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -328,6 +328,16 @@ func Fingerprint(labels labels.Labels) model.Fingerprint {
 	return model.Fingerprint(sum)
 }
 
+// LabelsToKeyString is used to form a string to be used as
+// the hashKey. Don't print, use l.String() for printing.
+func LabelsToKeyString(l labels.Labels) string {
+	// We are allocating 1024, even though most series are less than 600b long.
+	// But this is not an issue as this function is being inlined when called in a loop
+	// and buffer allocated is a static buffer and not a dynamic buffer on the heap.
+	b := make([]byte, 0, 1024)
+	return string(l.Bytes(b))
+}
+
 // MarshalJSON implements json.Marshaler.
 func (s Sample) MarshalJSON() ([]byte, error) {
 	t, err := json.Marshal(model.Time(s.TimestampMs))

--- a/pkg/querier/chunk_store_queryable.go
+++ b/pkg/querier/chunk_store_queryable.go
@@ -10,7 +10,7 @@ import (
 	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
-	"github.com/cortexproject/cortex/pkg/distributor"
+	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/querier/chunkstore"
 	seriesset "github.com/cortexproject/cortex/pkg/querier/series"
 )
@@ -55,7 +55,7 @@ func (q *chunkStoreQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...
 func partitionChunks(chunks []chunk.Chunk, mint, maxt int64, iteratorFunc chunkIteratorFunc) storage.SeriesSet {
 	chunksBySeries := map[string][]chunk.Chunk{}
 	for _, c := range chunks {
-		key := distributor.LabelsToKeyString(c.Metric)
+		key := client.LabelsToKeyString(c.Metric)
 		chunksBySeries[key] = append(chunksBySeries[key], c)
 	}
 

--- a/pkg/querier/chunk_store_queryable.go
+++ b/pkg/querier/chunk_store_queryable.go
@@ -10,7 +10,7 @@ import (
 	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
-	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/cortexproject/cortex/pkg/distributor"
 	"github.com/cortexproject/cortex/pkg/querier/chunkstore"
 	seriesset "github.com/cortexproject/cortex/pkg/querier/series"
 )
@@ -53,10 +53,10 @@ func (q *chunkStoreQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...
 
 // Series in the returned set are sorted alphabetically by labels.
 func partitionChunks(chunks []chunk.Chunk, mint, maxt int64, iteratorFunc chunkIteratorFunc) storage.SeriesSet {
-	chunksBySeries := map[model.Fingerprint][]chunk.Chunk{}
+	chunksBySeries := map[string][]chunk.Chunk{}
 	for _, c := range chunks {
-		fp := client.Fingerprint(c.Metric)
-		chunksBySeries[fp] = append(chunksBySeries[fp], c)
+		key := distributor.LabelsToKeyString(c.Metric)
+		chunksBySeries[key] = append(chunksBySeries[key], c)
 	}
 
 	series := make([]storage.Series, 0, len(chunksBySeries))


### PR DESCRIPTION
This fixes #717

We hit issue in production when our customer issued a query that issued
a simple query that touched 20K series, many of which had hash
collisions on `client.FastFingerprint`. This made our querier code
merge multiple series together which caused counters to go up
and down and caused rate() to return weird artifacts.

It is quite tricky to debug and I now have a test up which proves that
we will suffer if we don't handle collisions explicitly. After looking
at several solutions for fixing that, I've finally settled on something
super simple, just use a string as the map key.

Here is a benchmark where I insert and lookup 100K series:

```
goos: linux
goarch: amd64
pkg: github.com/cortexproject/cortex/pkg/distributor
BenchmarkSeriesMap-8         842          91633894 ns/op
PASS
ok      github.com/cortexproject/cortex/pkg/distributor 86.307s
```

Now I could have just used labels.String(), but the performance there is
quite bad:

```
goos: linux
goarch: amd64
pkg: github.com/cortexproject/cortex/pkg/distributor
BenchmarkSeriesMap-8         195         373104859 ns/op
PASS
ok      github.com/cortexproject/cortex/pkg/distributor 110.456s
```

Compare this to using client.Fingerprint for the hashing:
```
goos: linux
goarch: amd64
pkg: github.com/cortexproject/cortex/pkg/distributor
BenchmarkSeriesMap-8        1273          54778130 ns/op
```
This means that we've gotten 70% in this section, but as explained below
this is very small when compared to the overall query.

----------------

Now the reason I've stuck to the simplified case is because it takes
<100ms for doing this over 100K series, and in most cases the network
time to load all the chunks and iterate through them is several orders
of magnitude higher.

And tbh, I've looked at manually handling collsions, and we need to do
labels.Equal(l1, l2) to see if the series we're looking is the actual
series in the map or a collision, and the perf there actually worse.

I'm open to ideas here. Also note that the values of each map are
different, and any complex solution would require interface{} which is
arguably worse. sha256 has been tried and is worse in comparision.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #717

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
