### PR TITLE
Pool hash to reduce allocations on Push.

### DIFF
--- a/pkg/ingester/active_series.go
+++ b/pkg/ingester/active_series.go
@@ -1,6 +1,7 @@
 package ingester
 
 import (
+	"hash"
 	"math"
 	"sync"
 	"time"
@@ -60,8 +61,13 @@ func (c *ActiveSeries) UpdateSeries(series labels.Labels, now time.Time, labelsC
 
 var sep = []byte{model.SeparatorByte}
 
+var hashPool = sync.Pool{New: func() interface{} { return xxhash.New() }}
+
 func fingerprint(series labels.Labels) uint64 {
-	sum := xxhash.New()
+	sum := hashPool.Get().(hash.Hash64)
+	defer hashPool.Put(sum)
+
+	sum.Reset()
 	for _, label := range series {
 		_, _ = sum.Write(yoloBuf(label.Name))
 		_, _ = sum.Write(sep)

--- a/pkg/ingester/active_series.go
+++ b/pkg/ingester/active_series.go
@@ -115,11 +115,8 @@ func (s *activeSeriesStripe) updateSeriesTimestamp(now time.Time, series labels.
 	}
 
 	if !entryTimeSet {
-		for prev := e.Load(); nowNanos > prev; {
-			if e.CAS(prev, nowNanos) {
-				entryTimeSet = true
-				break
-			}
+		if prev := e.Load(); nowNanos > prev {
+			entryTimeSet = e.CAS(prev, nowNanos)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does**: This PR adds pooling to `xxhash.New()`, which helps to reduce allocations on `Push`-path in ingester.

```
name                                  old time/op    new time/op    delta
ActiveSeriesTest_single_series/50-4     86.2ns ± 2%    78.1ns ± 1%    -9.41%  (p=0.000 n=10+8)
ActiveSeriesTest_single_series/100-4    86.5ns ± 1%    80.0ns ±10%    -7.42%  (p=0.002 n=9+10)
ActiveSeriesTest_single_series/500-4    87.3ns ± 6%    90.1ns ±33%      ~     (p=0.393 n=10+10)
ActiveSeries_UpdateSeries-4              736ns ±19%     718ns ±12%      ~     (p=0.953 n=9+10)

name                                  old alloc/op   new alloc/op   delta
ActiveSeriesTest_single_series/50-4      80.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
ActiveSeriesTest_single_series/100-4     80.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
ActiveSeriesTest_single_series/500-4     80.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
ActiveSeries_UpdateSeries-4               241B ±17%      164B ±12%   -31.85%  (p=0.000 n=10+8)

name                                  old allocs/op  new allocs/op  delta
ActiveSeriesTest_single_series/50-4       1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
ActiveSeriesTest_single_series/100-4      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
ActiveSeriesTest_single_series/500-4      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
ActiveSeries_UpdateSeries-4               3.00 ± 0%      2.00 ± 0%   -33.33%  (p=0.000 n=10+10)
```

This PR also removes for-loop when updating series timestamp. If there are multiple goroutines trying to update timestamp at the same time, they most likely will be very close to each other... there is no need for super-precision. (And makes benchmarks with many goroutines runnable again)
