### PR TITLE
Check for postgres rows errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [BUGFIX] No-longer-needed ingester operations for queries triggered by queriers and rulers are now canceled. #3178
 * [BUGFIX] Ruler: directories in the configured `rules-path` will be removed on startup and shutdown in order to ensure they don't persist between runs. #3195
 * [BUGFIX] Handle hash-collisions in the query path. #3192
+* [BUGFIX] Check for postgres rows errors. #3197
 
 ## 1.4.0-rc.0 in progress
 

--- a/pkg/configs/db/postgres/postgres.go
+++ b/pkg/configs/db/postgres/postgres.go
@@ -134,6 +134,13 @@ func (d DB) findConfigs(filter squirrel.Sqlizer) (map[string]userconfig.View, er
 		cfg.DeletedAt = deletedAt.Time
 		cfgs[userID] = cfg
 	}
+
+	// Check for any errors encountered.
+	err = rows.Err()
+	if err != nil {
+		return nil, err
+	}
+
 	return cfgs, nil
 }
 
@@ -272,6 +279,13 @@ func (d DB) findRulesConfigs(filter squirrel.Sqlizer) (map[string]userconfig.Ver
 		cfg.DeletedAt = deletedAt.Time
 		cfgs[userID] = cfg
 	}
+
+	// Check for any errors encountered.
+	err = rows.Err()
+	if err != nil {
+		return nil, err
+	}
+
 	return cfgs, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Ben Wells <b.v.wells@gmail.com>

**What this PR does**:

This PR checks for errors when reading postgress rows. The rows.Next() method may encounter an error when reading the next row. In this case a false value is returned and it is important to call rows.Err() to see whether an error was encountered.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
