### PR TITLE
Mark TLS Configuration in gRPC, HTTP and etcd clients as experimental.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ## 1.4.0-rc.0 in progress
 
+* [CHANGE] TLS configuration for gRPC and HTTP clients and etcd clients is now marked as experimental. These features are not yet fully baked, and we expect possible small breaking changes in Cortex 1.5. #3198
 * [CHANGE] Cassandra backend support is now GA (stable). #3180
 * [CHANGE] Blocks storage is now GA (stable). The `-experimental` prefix has been removed from all CLI flags related to the blocks storage (no YAML config changes). #3180
   - `-experimental.blocks-storage.*` flags renamed to `-blocks-storage.*`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ## 1.4.0-rc.0 in progress
 
-* [CHANGE] TLS configuration for gRPC and HTTP clients and etcd clients is now marked as experimental. These features are not yet fully baked, and we expect possible small breaking changes in Cortex 1.5. #3198
+* [CHANGE] TLS configuration for gRPC, HTTP and etcd clients is now marked as experimental. These features are not yet fully baked, and we expect possible small breaking changes in Cortex 1.5. #3198
 * [CHANGE] Cassandra backend support is now GA (stable). #3180
 * [CHANGE] Blocks storage is now GA (stable). The `-experimental` prefix has been removed from all CLI flags related to the blocks storage (no YAML config changes). #3180
   - `-experimental.blocks-storage.*` flags renamed to `-blocks-storage.*`

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -48,3 +48,5 @@ Currently experimental features are:
 - Querier support for querying chunks and blocks store at the same time.
 - Tracking of active series and exporting them as metrics (`-ingester.active-series-metrics-enabled` and related flags)
 - Shuffle-sharding of queriers in the query-frontend (i.e. use of `-frontend.max-queriers-per-user` flag with non-zero value).
+- TLS configuration in gRPC and HTTP clients.
+- TLS configuration in Etcd client.


### PR DESCRIPTION
**What this PR does**: This PR marks TLS configuration for gRPC, HTTP and etcd clients as experimental. This feature was introduced without experimental flag, and while it works, there are some edge cases that will require introduction of breaking changes. (see https://github.com/cortexproject/cortex/pull/3156 for discussion).
