### PR TITLE
Cherry picked PR 3198

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 1.4.0-rc.0 / 2020-09-15
 
+* [CHANGE] TLS configuration for gRPC, HTTP and etcd clients is now marked as experimental. These features are not yet fully baked, and we expect possible small breaking changes in Cortex 1.5. #3198
 * [CHANGE] Cassandra backend support is now GA (stable). #3180
 * [CHANGE] Blocks storage is now GA (stable). The `-experimental` prefix has been removed from all CLI flags related to the blocks storage (no YAML config changes). #3180 #3201
   - `-experimental.blocks-storage.*` flags renamed to `-blocks-storage.*`

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -46,3 +46,5 @@ Currently experimental features are:
 - Openstack Swift storage.
 - gRPC Store.
 - Querier support for querying chunks and blocks store at the same time.
+- TLS configuration in gRPC and HTTP clients.
+- TLS configuration in Etcd client.


### PR DESCRIPTION
**What this PR does**:
As agreed on CNCF Slack, I'm cherry picking PR #3198 to explicitly mark TLS support experimental in 1.4.0.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
