### PR TITLE
Improve DynamoDB BatchWrite error messages

### DIFF
--- a/pkg/chunk/aws/dynamodb_storage_client.go
+++ b/pkg/chunk/aws/dynamodb_storage_client.go
@@ -204,7 +204,7 @@ func (a dynamoDBStorageClient) BatchWrite(ctx context.Context, input chunk.Write
 				continue
 			} else if ok && awsErr.Code() == validationException {
 				// this write will never work, so the only option is to drop the offending items and continue.
-				level.Warn(util.Logger).Log("msg", "Data lost while flushing to Dynamo", "err", awsErr)
+				level.Warn(util.Logger).Log("msg", "Data lost while flushing to DynamoDB", "err", awsErr)
 				level.Debug(util.Logger).Log("msg", "Dropped request details", "requests", requests)
 				util.Event().Log("msg", "ValidationException", "requests", requests)
 				// recording the drop counter separately from recordDynamoError(), as the error code alone may not provide enough context
@@ -231,7 +231,7 @@ func (a dynamoDBStorageClient) BatchWrite(ctx context.Context, input chunk.Write
 	}
 
 	if valuesLeft := outstanding.Len() + unprocessed.Len(); valuesLeft > 0 {
-		return fmt.Errorf("failed to write chunk, %d values remaining: %s", valuesLeft, backoff.Err())
+		return fmt.Errorf("failed to write items to DynamoDB, %d values remaining: %s", valuesLeft, backoff.Err())
 	}
 	return backoff.Err()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
DynamoDB can be used for storing either or both chunks and indexes.

This change improves the error messages in `BatchWrite()` method by using
`items` instead of `chunk` and also adds `DynamoDB` to the error message.

The previous error message was misleading as a failed index write can produce
an error message about chunks:
```
caller=flush.go:199 org_id=fake msg="failed to flush user"
err="failed to write chunk, 1 values remaining: context deadline exceeded"
```

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
