### PR TITLE
Share auth-injector tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ website/content/en/docs
 e2e_integration_test*
 active-query-tracker
 dist/
+
+# Binaries built from ./cmd
+blocksconvert
+cortex
+query-tee
+test-exporter

--- a/tools/auth-injector/main.go
+++ b/tools/auth-injector/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+)
+
+type Config struct {
+	LocalAddress string
+	RemoteURL    string
+	TenantID     string
+}
+
+func main() {
+	cfg := Config{}
+	flag.StringVar(&cfg.LocalAddress, "local-address", "", "Local address to listen to (eg. localhost:8080).")
+	flag.StringVar(&cfg.RemoteURL, "remote-address", "", "Remote address to proxy to (eg. http://domain.com:80).")
+	flag.StringVar(&cfg.TenantID, "tenant-id", "", "Tenant ID to inject to proxied requests.")
+	flag.Parse()
+
+	// Parse remote URL.
+	remoteURL, err := url.Parse(cfg.RemoteURL)
+	if err != nil {
+		log.Fatalf("Unable to parse remote address. Error: %s.", err.Error())
+	}
+
+	s := &http.Server{
+		Addr:           cfg.LocalAddress,
+		Handler:        injectAuthHeader(cfg.TenantID, httputil.NewSingleHostReverseProxy(remoteURL)),
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+
+	log.Fatal(s.ListenAndServe())
+}
+
+func injectAuthHeader(tenantID string, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Set("X-Scope-OrgID", tenantID)
+		h.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
**What this PR does**:
I had this simple tool in my local repository since a while and I thought to propose to upstream it. It's just an HTTP reverse proxy offering a quick way to inject `X-Scope-OrgID` header.

For example, the following command listens on `8081` and proxies all requests to `8080` injecting `X-Scope-OrgID: load-balancer-1`:
```
go run ./tools/auth-injector -local-address=localhost:8081 -remote-address=http://localhost:8080 -tenant-id=load-balancer-1
```

Do you think it make sense to upstream it?

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
