### PR TITLE
Arbitrary group loading in local rules backend

### DIFF
--- a/integration/chunks_storage_backends_test.go
+++ b/integration/chunks_storage_backends_test.go
@@ -246,7 +246,7 @@ func TestSwiftRuleStorage(t *testing.T) {
 	store, err := ruler.NewRuleStorage(ruler.RuleStoreConfig{
 		Type:  "swift",
 		Swift: swiftConfig(swift),
-	})
+	}, nil)
 	require.NoError(t, err)
 	ctx := context.Background()
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/rules"
 	prom_storage "github.com/prometheus/prometheus/storage"
 	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
 	"github.com/weaveworks/common/instrument"
@@ -514,7 +515,7 @@ func (t *Cortex) initRulerStorage() (serv services.Service, err error) {
 		return
 	}
 
-	t.RulerStorage, err = ruler.NewRuleStorage(t.Cfg.Ruler.StoreConfig)
+	t.RulerStorage, err = ruler.NewRuleStorage(t.Cfg.Ruler.StoreConfig, rules.FileLoader{})
 
 	return
 }

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
+	promRules "github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/testutil"
 	"github.com/stretchr/testify/assert"
@@ -102,7 +103,7 @@ func newManager(t *testing.T, cfg Config) (*DefaultMultiTenantManager, func()) {
 
 func newRuler(t *testing.T, cfg Config) (*Ruler, func()) {
 	engine, noopQueryable, pusher, logger, overrides, cleanup := testSetup(t, cfg)
-	storage, err := NewRuleStorage(cfg.StoreConfig)
+	storage, err := NewRuleStorage(cfg.StoreConfig, promRules.FileLoader{})
 	require.NoError(t, err)
 
 	reg := prometheus.NewRegistry()

--- a/pkg/ruler/rules/local/local_test.go
+++ b/pkg/ruler/rules/local/local_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
+	promRules "github.com/prometheus/prometheus/rules"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -68,7 +69,7 @@ func TestClient_ListAllRuleGroups(t *testing.T) {
 
 	client, err := NewLocalRulesClient(Config{
 		Directory: dir,
-	})
+	}, promRules.FileLoader{})
 	require.NoError(t, err)
 
 	ctx := context.Background()


### PR DESCRIPTION
**Allow arbitrary group loading from local rule storage**:

This PR passes the upstream [GroupLoader](https://github.com/prometheus/prometheus/blob/master/rules/manager.go#L992-L996) interface to the local rules storage backend. This interface is already used in the Ruler API via the Prometheus rules manager to validate rules. This PR aims for parity with that and avoids hardcoding the implementation which allows downstream projects (Loki) to use the local backend store.