### PR TITLE
Blocksconvert: added support for specifying date range for tables scan

### DIFF
--- a/tools/blocksconvert/scanner/scanner.go
+++ b/tools/blocksconvert/scanner/scanner.go
@@ -150,7 +150,7 @@ func NewScanner(cfg Config, scfg blocksconvert.SharedConfig, l log.Logger, reg p
 		}),
 		currentTableScannedRanges: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_blocksconvert_scanner_bigtable_scanned_ranges_from_current_table",
-			Help: "Number of scanned ranges from current table. (Goes from 0 on each new table)",
+			Help: "Number of scanned ranges from current table. Resets to 0 every time a table is getting scanned or its scan has completed.",
 		}),
 
 		series: promauto.With(reg).NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
**What this PR does**: This PR adds support for specifying date-range when scanning for tables. It also adds metrics to scanner to better track its progress.

Tables ignored due to range are logged:
```
level=info ts=2020-09-23T06:17:18.034230103Z caller=scanner.go:264 msg="table starts after period-end, ignoring" table=index_2646 table_start="2020-09-17 00:00:00 +0000 UTC" table_end="2020-09-24 00:00:00 +0000 UTC" period_end=2020-09-17T00:00:00Z

level=info ts=2020-09-23T06:17:18.034241493Z caller=scanner.go:259 msg="table ends before period-start, ignoring" table=index_2613 table_start="2020-01-30 00:00:00 +0000 UTC" table_end="2020-02-06 00:00:00 +0000 UTC" period_start=2020-02-06T00:00:00Z
```
