### PR TITLE
Clarify that schema config is used only by the chunks storage

### DIFF
--- a/docs/blocks-storage/_index.md
+++ b/docs/blocks-storage/_index.md
@@ -14,7 +14,7 @@ The supported backends for the blocks storage are:
 * [Microsoft Azure Storage](https://azure.microsoft.com/en-us/services/storage/)
 * [Local Filesystem](https://thanos.io/storage.md/#filesystem) (single node only)
 
-_Internally, this storage engine is based on [Thanos](https://thanos.io), but no Thanos knowledge is required in order to run it._
+_Internally, some components are based on [Thanos](https://thanos.io), but no Thanos knowledge is required in order to run it._
 
 ## Architecture
 
@@ -30,7 +30,7 @@ The **[store-gateway](./store-gateway.md)** is responsible to query blocks and i
 
 The **[compactor](./compactor.md)** is responsible to merge and deduplicate smaller blocks into larger ones, in order to reduce the number of blocks stored in the long-term storage for a given tenant and query them more efficiently. The compactor is optional but highly recommended.
 
-Finally, the **table-manager** is not used by the blocks storage.
+Finally, the **table-manager** and the [**schema**](../configuration/schema-config-reference.md) configuration are **not used** by the blocks storage.
 
 ### The write path
 

--- a/docs/configuration/schema-config-reference.md
+++ b/docs/configuration/schema-config-reference.md
@@ -5,9 +5,15 @@ weight: 4
 slug: schema-configuration
 ---
 
-Cortex uses a NoSQL Store to store its index and optionally an Object store to store its chunks. Cortex has overtime evolved its schema to be more optimal and better fit the use cases and query patterns that arose.
+Cortex chunks storage uses a NoSQL Store to store its index and optionally an Object store to store its chunks. Cortex has overtime evolved its schema to be more optimal and better fit the use cases and query patterns that arose.
+
+The schema configuration is used only by the chunks storage, while it's not used by the [blocks storage](../blocks-storage/_index.md) engine.
+
+## Schema versions
 
 Currently there are 11 schemas that are used in production but we recommend running with the **v9 schema** for most use cases and **v10 schema** if you expect to have very high cardinality metrics. You can move from one schema to another if a new schema fits your purpose better, but you still need to configure Cortex to make sure it can read the old data in the old schemas.
+
+## Configuration
 
 You can configure the schemas using a YAML config file, that you can point to using the `-schema-config-file` flag. It has the following YAML spec:
 

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -82,7 +82,7 @@ type SchemaConfig struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *SchemaConfig) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.fileName, "schema-config-file", "", "The path to the schema config file.")
+	f.StringVar(&cfg.fileName, "schema-config-file", "", "The path to the schema config file. The schema config is used only when running Cortex with the chunks storage.")
 	// TODO(gouthamve): Add a metric for this.
 	f.StringVar(&cfg.legacyFileName, "config-yaml", "", "DEPRECATED(use -schema-config-file) The path to the schema config file.")
 }


### PR DESCRIPTION
**What this PR does**:
We recently received a question on CNCF Slack asking if the schema config was used by the blocks storage too. It not, but the doc is not much clear about it, so in this PR I'm improving the doc.

**Which issue(s) this PR fixes**:
Fixes #3006

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
