### PR TITLE
Enforce HTTP method required by most API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@
 * [CHANGE] Dropped "blank Alertmanager configuration; using fallback" message from Info to Debug level. #3205
 * [CHANGE] Zone-awareness replication for time-series now should be explicitly enabled in the distributor via the `-distributor.zone-awareness-enabled` CLI flag (or its respective YAML config option). Before, zone-aware replication was implicitly enabled if a zone was set on ingesters. #3200
 * [CHANGE] Removed the deprecated CLI flag `-config-yaml`. You should use `-schema-config-file` instead. #3225
+* [CHANGE] Enforced the HTTP method required by some API endpoints which did (incorrectly) allow any method before that. #3228
+  - `GET /`
+  - `GET /config`
+  - `GET /debug/fgprof`
+  - `GET /distributor/all_user_stats`
+  - `GET /distributor/ha_tracker`
+  - `GET /all_user_stats`
+  - `GET /ha-tracker`
+  - `GET /api/v1/user_stats`
+  - `GET /api/v1/chunks`
+  - `GET <legacy-http-prefix>/user_stats`
+  - `GET <legacy-http-prefix>/chunks`
+  - `GET /services`
+  - `GET|POST /ingester/ring`
+  - `GET|POST /ring`
+  - `GET|POST /store-gateway/ring`
+  - `GET|POST /compactor/ring`
 * [FEATURE] Added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-user` globally, or using per-user limit `max_queriers_per_user`), each user's requests will be handled by different set of queriers. #3113
 * [ENHANCEMENT] Added `cortex_query_frontend_connected_clients` metric to show the number of workers currently connected to the frontend. #3207
 * [ENHANCEMENT] Shuffle sharding: improved shuffle sharding in the write path. Shuffle sharding now should be explicitly enabled via `-distributor.sharding-strategy` CLI flag (or its respective YAML config option) and guarantees stability, consistency, shuffling and balanced zone-awareness properties. #3090

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,21 @@
   - `GET <legacy-http-prefix>/user_stats`
   - `GET <legacy-http-prefix>/chunks`
   - `GET /services`
+  - `GET /multitenant_alertmanager/status`
+  - `GET /status` (alertmanager microservice)
   - `GET|POST /ingester/ring`
   - `GET|POST /ring`
   - `GET|POST /store-gateway/ring`
   - `GET|POST /compactor/ring`
+  - `GET|POST /ingester/flush`
+  - `GET|POST /ingester/shutdown`
+  - `GET|POST /ingester/push`
+  - `GET|POST /flush`
+  - `GET|POST /shutdown`
+  - `GET|POST /ruler/ring`
+  - `POST /api/v1/push`
+  - `POST <legacy-http-prefix>/push`
+  - `POST /push`
 * [FEATURE] Added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-user` globally, or using per-user limit `max_queriers_per_user`), each user's requests will be handled by different set of queriers. #3113
 * [ENHANCEMENT] Added `cortex_query_frontend_connected_clients` metric to show the number of workers currently connected to the frontend. #3207
 * [ENHANCEMENT] Shuffle sharding: improved shuffle sharding in the write path. Shuffle sharding now should be explicitly enabled via `-distributor.sharding-strategy` CLI flag (or its respective YAML config option) and guarantees stability, consistency, shuffling and balanced zone-awareness properties. #3090

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,13 @@
   - `GET|POST /compactor/ring`
   - `GET|POST /ingester/flush`
   - `GET|POST /ingester/shutdown`
-  - `GET|POST /ingester/push`
   - `GET|POST /flush`
   - `GET|POST /shutdown`
   - `GET|POST /ruler/ring`
   - `POST /api/v1/push`
   - `POST <legacy-http-prefix>/push`
   - `POST /push`
+  - `POST /ingester/push`
 * [FEATURE] Added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-user` globally, or using per-user limit `max_queriers_per_user`), each user's requests will be handled by different set of queriers. #3113
 * [ENHANCEMENT] Added `cortex_query_frontend_connected_clients` metric to show the number of workers currently connected to the frontend. #3207
 * [ENHANCEMENT] Shuffle sharding: improved shuffle sharding in the write path. Shuffle sharding now should be explicitly enabled via `-distributor.sharding-strategy` CLI flag (or its respective YAML config option) and guarantees stability, consistency, shuffling and balanced zone-awareness properties. #3090

--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -67,6 +68,13 @@ func GetRequest(url string) (*http.Response, error) {
 
 	client := &http.Client{Timeout: timeout}
 	return client.Get(url)
+}
+
+func PostRequest(url string) (*http.Response, error) {
+	const timeout = 1 * time.Second
+
+	client := &http.Client{Timeout: timeout}
+	return client.Post(url, "", strings.NewReader(""))
 }
 
 // timeToMilliseconds returns the input time as milliseconds, using the same

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -173,9 +173,9 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, tar
 func (a *API) RegisterAPI(httpPathPrefix string, cfg interface{}) {
 	a.indexPage.AddLink(SectionAdminEndpoints, "/config", "Current Config")
 
-	a.RegisterRoute("/config", configHandler(cfg), false)
-	a.RegisterRoute("/", indexHandler(httpPathPrefix, a.indexPage), false)
-	a.RegisterRoute("/debug/fgprof", fgprof.Handler(), false)
+	a.RegisterRoute("/config", configHandler(cfg), false, "GET")
+	a.RegisterRoute("/", indexHandler(httpPathPrefix, a.indexPage), false, "GET")
+	a.RegisterRoute("/debug/fgprof", fgprof.Handler(), false, "GET")
 }
 
 // RegisterDistributor registers the endpoints associated with the distributor.
@@ -185,13 +185,13 @@ func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distrib
 	a.indexPage.AddLink(SectionAdminEndpoints, "/distributor/all_user_stats", "Usage Statistics")
 	a.indexPage.AddLink(SectionAdminEndpoints, "/distributor/ha_tracker", "HA Tracking Status")
 
-	a.RegisterRoute("/distributor/all_user_stats", http.HandlerFunc(d.AllUserStatsHandler), false)
-	a.RegisterRoute("/distributor/ha_tracker", d.HATracker, false)
+	a.RegisterRoute("/distributor/all_user_stats", http.HandlerFunc(d.AllUserStatsHandler), false, "GET")
+	a.RegisterRoute("/distributor/ha_tracker", d.HATracker, false, "GET")
 
 	// Legacy Routes
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/push", push.Handler(pushConfig, a.sourceIPs, d.Push), true)
-	a.RegisterRoute("/all_user_stats", http.HandlerFunc(d.AllUserStatsHandler), false)
-	a.RegisterRoute("/ha-tracker", d.HATracker, false)
+	a.RegisterRoute("/all_user_stats", http.HandlerFunc(d.AllUserStatsHandler), false, "GET")
+	a.RegisterRoute("/ha-tracker", d.HATracker, false, "GET")
 }
 
 // RegisterIngester registers the ingesters HTTP and GRPC service
@@ -267,10 +267,10 @@ func (a *API) RegisterRuler(r *ruler.Ruler, apiEnabled bool) {
 // RegisterRing registers the ring UI page associated with the distributor for writes.
 func (a *API) RegisterRing(r *ring.Ring) {
 	a.indexPage.AddLink(SectionAdminEndpoints, "/ingester/ring", "Ingester Ring Status")
-	a.RegisterRoute("/ingester/ring", r, false)
+	a.RegisterRoute("/ingester/ring", r, false, "GET", "POST")
 
 	// Legacy Route
-	a.RegisterRoute("/ring", r, false)
+	a.RegisterRoute("/ring", r, false, "GET", "POST")
 }
 
 // RegisterStoreGateway registers the ring UI page associated with the store-gateway.
@@ -278,13 +278,13 @@ func (a *API) RegisterStoreGateway(s *storegateway.StoreGateway) {
 	storegatewaypb.RegisterStoreGatewayServer(a.server.GRPC, s)
 
 	a.indexPage.AddLink(SectionAdminEndpoints, "/store-gateway/ring", "Store Gateway Ring")
-	a.RegisterRoute("/store-gateway/ring", http.HandlerFunc(s.RingHandler), false)
+	a.RegisterRoute("/store-gateway/ring", http.HandlerFunc(s.RingHandler), false, "GET", "POST")
 }
 
 // RegisterCompactor registers the ring UI page associated with the compactor.
 func (a *API) RegisterCompactor(c *compactor.Compactor) {
 	a.indexPage.AddLink(SectionAdminEndpoints, "/compactor/ring", "Compactor Ring Status")
-	a.RegisterRoute("/compactor/ring", http.HandlerFunc(c.RingHandler), false)
+	a.RegisterRoute("/compactor/ring", http.HandlerFunc(c.RingHandler), false, "GET", "POST")
 }
 
 // RegisterQuerier registers the Prometheus routes supported by the
@@ -322,11 +322,11 @@ func (a *API) RegisterQuerier(
 	)
 
 	// these routes are always registered to the default server
-	a.RegisterRoute("/api/v1/user_stats", http.HandlerFunc(distributor.UserStatsHandler), true)
-	a.RegisterRoute("/api/v1/chunks", querier.ChunksHandler(queryable), true)
+	a.RegisterRoute("/api/v1/user_stats", http.HandlerFunc(distributor.UserStatsHandler), true, "GET")
+	a.RegisterRoute("/api/v1/chunks", querier.ChunksHandler(queryable), true, "GET")
 
-	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/user_stats", http.HandlerFunc(distributor.UserStatsHandler), true)
-	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/chunks", querier.ChunksHandler(queryable), true)
+	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/user_stats", http.HandlerFunc(distributor.UserStatsHandler), true, "GET")
+	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/chunks", querier.ChunksHandler(queryable), true, "GET")
 
 	// these routes are either registered the default server OR to an internal mux.  The internal mux is
 	// for use in a single binary mode when both the query frontend and the querier would attempt to claim these routes
@@ -424,5 +424,5 @@ func (a *API) RegisterQueryFrontend(f *frontend.Frontend) {
 // or a future module manager #2291
 func (a *API) RegisterServiceMapHandler(handler http.Handler) {
 	a.indexPage.AddLink(SectionAdminEndpoints, "/services", "Service Status")
-	a.RegisterRoute("/services", handler, false)
+	a.RegisterRoute("/services", handler, false, "GET")
 }

--- a/pkg/cortex/index.go
+++ b/pkg/cortex/index.go
@@ -1,1 +1,0 @@
-package cortex


### PR DESCRIPTION
**What this PR does**:
We had some API endpoints which allowed any HTTP method, while they were clearly only `GET` and/or `POST`. This is particularly insidious if someone misconfigure Prometheus and remote writes to `/` because that POST requests will succeed while they shouldn't.

In this PR I'm fixing it.

**Which issue(s) this PR fixes**:
Fixes #3227

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
