### PR TITLE
ObjectClient List refactoring

### DIFF
--- a/integration/s3_storage_client_test.go
+++ b/integration/s3_storage_client_test.go
@@ -67,7 +67,7 @@ func TestS3Client(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := s3.NewS3ObjectClient(tt.cfg, "/")
+			client, err := s3.NewS3ObjectClient(tt.cfg)
 
 			require.NoError(t, err)
 

--- a/pkg/alertmanager/alerts/objectclient/store.go
+++ b/pkg/alertmanager/alerts/objectclient/store.go
@@ -33,7 +33,7 @@ func NewAlertStore(client chunk.ObjectClient) *AlertStore {
 
 // ListAlertConfigs returns all of the active alert configs in this store
 func (a *AlertStore) ListAlertConfigs(ctx context.Context) (map[string]alerts.AlertConfigDesc, error) {
-	objs, _, err := a.client.List(ctx, alertPrefix)
+	objs, _, err := a.client.List(ctx, alertPrefix, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/alertmanager/storage.go
+++ b/pkg/alertmanager/storage.go
@@ -55,9 +55,9 @@ func NewAlertStore(cfg AlertStoreConfig) (AlertStore, error) {
 	case "local":
 		return local.NewStore(cfg.Local)
 	case "gcs":
-		return newObjAlertStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCS, ""))
+		return newObjAlertStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCS))
 	case "s3":
-		return newObjAlertStore(aws.NewS3ObjectClient(cfg.S3, ""))
+		return newObjAlertStore(aws.NewS3ObjectClient(cfg.S3))
 	default:
 		return nil, fmt.Errorf("unrecognized alertmanager storage backend %v, choose one of: azure, configdb, gcs, local, s3", cfg.Type)
 	}

--- a/pkg/chunk/aws/fixtures.go
+++ b/pkg/chunk/aws/fixtures.go
@@ -44,10 +44,7 @@ var Fixtures = []testutils.Fixture{
 				schemaCfg:               schemaConfig,
 				metrics:                 newMetrics(nil),
 			}
-			object := objectclient.NewClient(&S3ObjectClient{
-				S3:        newMockS3(),
-				delimiter: chunk.DirDelim,
-			}, nil)
+			object := objectclient.NewClient(&S3ObjectClient{S3: newMockS3()}, nil)
 			return index, object, table, schemaConfig, testutils.CloserFunc(func() error {
 				table.Stop()
 				index.Stop()

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -94,12 +94,11 @@ func (cfg *S3Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 type S3ObjectClient struct {
 	bucketNames   []string
 	S3            s3iface.S3API
-	delimiter     string
 	sseEncryption *string
 }
 
 // NewS3ObjectClient makes a new S3-backed ObjectClient.
-func NewS3ObjectClient(cfg S3Config, delimiter string) (*S3ObjectClient, error) {
+func NewS3ObjectClient(cfg S3Config) (*S3ObjectClient, error) {
 	s3Config, bucketNames, err := buildS3Config(cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build s3 config")
@@ -120,7 +119,6 @@ func NewS3ObjectClient(cfg S3Config, delimiter string) (*S3ObjectClient, error) 
 	client := S3ObjectClient{
 		S3:            s3Client,
 		bucketNames:   bucketNames,
-		delimiter:     delimiter,
 		sseEncryption: sseEncryption,
 	}
 	return &client, nil
@@ -289,8 +287,7 @@ func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object
 	})
 }
 
-// List objects and common-prefixes i.e synthetic directories from the store non-recursively
-func (a *S3ObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
+func (a *S3ObjectClient) List(ctx context.Context, prefix, delimiter string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	var storageObjects []chunk.StorageObject
 	var commonPrefixes []chunk.StorageCommonPrefix
 
@@ -299,7 +296,7 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stora
 			input := s3.ListObjectsV2Input{
 				Bucket:    aws.String(a.bucketNames[i]),
 				Prefix:    aws.String(prefix),
-				Delimiter: aws.String(a.delimiter),
+				Delimiter: aws.String(delimiter),
 			}
 
 			for {
@@ -336,8 +333,4 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix string) ([]chunk.Stora
 	}
 
 	return storageObjects, commonPrefixes, nil
-}
-
-func (a *S3ObjectClient) PathSeparator() string {
-	return a.delimiter
 }

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -287,6 +287,7 @@ func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object
 	})
 }
 
+// List implements chunk.ObjectClient.
 func (a *S3ObjectClient) List(ctx context.Context, prefix, delimiter string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	var storageObjects []chunk.StorageObject
 	var commonPrefixes []chunk.StorageCommonPrefix

--- a/pkg/chunk/aws/s3_storage_client_test.go
+++ b/pkg/chunk/aws/s3_storage_client_test.go
@@ -59,7 +59,7 @@ func TestRequestMiddleware(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg.Inject = tt.fn
-			client, err := NewS3ObjectClient(cfg, "/")
+			client, err := NewS3ObjectClient(cfg)
 			require.NoError(t, err)
 
 			readCloser, err := client.GetObject(context.Background(), "key")

--- a/pkg/chunk/azure/blob_storage_client.go
+++ b/pkg/chunk/azure/blob_storage_client.go
@@ -88,15 +88,13 @@ type BlobStorage struct {
 	//blobService storage.Serv
 	cfg          *BlobStorageConfig
 	containerURL azblob.ContainerURL
-	delimiter    string
 }
 
 // NewBlobStorage creates a new instance of the BlobStorage struct.
-func NewBlobStorage(cfg *BlobStorageConfig, delimiter string) (*BlobStorage, error) {
+func NewBlobStorage(cfg *BlobStorageConfig) (*BlobStorage, error) {
 	util.WarnExperimentalUse("Azure Blob Storage")
 	blobStorage := &BlobStorage{
-		cfg:       cfg,
-		delimiter: delimiter,
+		cfg: cfg,
 	}
 
 	var err error
@@ -196,8 +194,7 @@ func (b *BlobStorage) newPipeline() (pipeline.Pipeline, error) {
 	}), nil
 }
 
-// List objects and common-prefixes i.e synthetic directories from the store non-recursively
-func (b *BlobStorage) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
+func (b *BlobStorage) List(ctx context.Context, prefix, delimiter string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	var storageObjects []chunk.StorageObject
 	var commonPrefixes []chunk.StorageCommonPrefix
 
@@ -206,7 +203,7 @@ func (b *BlobStorage) List(ctx context.Context, prefix string) ([]chunk.StorageO
 			return nil, nil, ctx.Err()
 		}
 
-		listBlob, err := b.containerURL.ListBlobsHierarchySegment(ctx, marker, b.delimiter, azblob.ListBlobsSegmentOptions{Prefix: prefix})
+		listBlob, err := b.containerURL.ListBlobsHierarchySegment(ctx, marker, delimiter, azblob.ListBlobsSegmentOptions{Prefix: prefix})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -238,10 +235,6 @@ func (b *BlobStorage) DeleteObject(ctx context.Context, blobID string) error {
 
 	_, err = blockBlobURL.Delete(ctx, azblob.DeleteSnapshotsOptionInclude, azblob.BlobAccessConditions{})
 	return err
-}
-
-func (b *BlobStorage) PathSeparator() string {
-	return b.delimiter
 }
 
 // Validate the config.

--- a/pkg/chunk/azure/blob_storage_client.go
+++ b/pkg/chunk/azure/blob_storage_client.go
@@ -194,6 +194,7 @@ func (b *BlobStorage) newPipeline() (pipeline.Pipeline, error) {
 	}), nil
 }
 
+// List implements chunk.ObjectClient.
 func (b *BlobStorage) List(ctx context.Context, prefix, delimiter string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	var storageObjects []chunk.StorageObject
 	var commonPrefixes []chunk.StorageCommonPrefix

--- a/pkg/chunk/gcp/fixtures.go
+++ b/pkg/chunk/gcp/fixtures.go
@@ -78,9 +78,7 @@ func (f *fixture) Clients() (
 	}
 
 	if f.gcsObjectClient {
-		cClient = objectclient.NewClient(newGCSObjectClient(GCSConfig{
-			BucketName: "chunks",
-		}, f.gcssrv.Client(), chunk.DirDelim), nil)
+		cClient = objectclient.NewClient(newGCSObjectClient(GCSConfig{BucketName: "chunks"}, f.gcssrv.Client()), nil)
 	} else {
 		cClient = newBigtableObjectClient(Config{}, schemaConfig, client)
 	}

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -13,10 +13,9 @@ import (
 )
 
 type GCSObjectClient struct {
-	cfg       GCSConfig
-	client    *storage.Client
-	bucket    *storage.BucketHandle
-	delimiter string
+	cfg    GCSConfig
+	client *storage.Client
+	bucket *storage.BucketHandle
 }
 
 // GCSConfig is config for the GCS Chunk Client.
@@ -39,7 +38,7 @@ func (cfg *GCSConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 }
 
 // NewGCSObjectClient makes a new chunk.Client that writes chunks to GCS.
-func NewGCSObjectClient(ctx context.Context, cfg GCSConfig, delimiter string) (*GCSObjectClient, error) {
+func NewGCSObjectClient(ctx context.Context, cfg GCSConfig) (*GCSObjectClient, error) {
 	option, err := gcsInstrumentation(ctx, storage.ScopeReadWrite)
 	if err != nil {
 		return nil, err
@@ -49,16 +48,15 @@ func NewGCSObjectClient(ctx context.Context, cfg GCSConfig, delimiter string) (*
 	if err != nil {
 		return nil, err
 	}
-	return newGCSObjectClient(cfg, client, delimiter), nil
+	return newGCSObjectClient(cfg, client), nil
 }
 
-func newGCSObjectClient(cfg GCSConfig, client *storage.Client, delimiter string) *GCSObjectClient {
+func newGCSObjectClient(cfg GCSConfig, client *storage.Client) *GCSObjectClient {
 	bucket := client.Bucket(cfg.BucketName)
 	return &GCSObjectClient{
-		cfg:       cfg,
-		client:    client,
-		bucket:    bucket,
-		delimiter: delimiter,
+		cfg:    cfg,
+		client: client,
+		bucket: bucket,
 	}
 }
 
@@ -108,11 +106,11 @@ func (s *GCSObjectClient) PutObject(ctx context.Context, objectKey string, objec
 }
 
 // List objects and common-prefixes i.e synthetic directories from the store non-recursively
-func (s *GCSObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
+func (s *GCSObjectClient) List(ctx context.Context, prefix, delimiter string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	var storageObjects []chunk.StorageObject
 	var commonPrefixes []chunk.StorageCommonPrefix
 
-	iter := s.bucket.Objects(ctx, &storage.Query{Prefix: prefix, Delimiter: s.delimiter})
+	iter := s.bucket.Objects(ctx, &storage.Query{Prefix: prefix, Delimiter: delimiter})
 	for {
 		if ctx.Err() != nil {
 			return nil, nil, ctx.Err()
@@ -154,8 +152,4 @@ func (s *GCSObjectClient) DeleteObject(ctx context.Context, objectKey string) er
 	}
 
 	return nil
-}
-
-func (s *GCSObjectClient) PathSeparator() string {
-	return s.delimiter
 }

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -105,7 +105,6 @@ func (s *GCSObjectClient) PutObject(ctx context.Context, objectKey string, objec
 	return nil
 }
 
-// List objects and common-prefixes i.e synthetic directories from the store non-recursively
 func (s *GCSObjectClient) List(ctx context.Context, prefix, delimiter string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	var storageObjects []chunk.StorageObject
 	var commonPrefixes []chunk.StorageCommonPrefix

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -105,6 +105,7 @@ func (s *GCSObjectClient) PutObject(ctx context.Context, objectKey string, objec
 	return nil
 }
 
+// List implements chunk.ObjectClient.
 func (s *GCSObjectClient) List(ctx context.Context, prefix, delimiter string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	var storageObjects []chunk.StorageObject
 	var commonPrefixes []chunk.StorageCommonPrefix

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -442,10 +442,6 @@ func (m *MockStorage) List(ctx context.Context, prefix, delimiter string) ([]Sto
 	return storageObjects, []StorageCommonPrefix{}, nil
 }
 
-func (m *MockStorage) PathSeparator() string {
-	return DirDelim
-}
-
 type mockWriteBatch struct {
 	inserts []struct {
 		tableName, hashValue string

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -425,7 +425,7 @@ func (m *MockStorage) DeleteObject(ctx context.Context, objectKey string) error 
 	return nil
 }
 
-func (m *MockStorage) List(ctx context.Context, prefix string) ([]StorageObject, []StorageCommonPrefix, error) {
+func (m *MockStorage) List(ctx context.Context, prefix, delimiter string) ([]StorageObject, []StorageCommonPrefix, error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -425,6 +425,7 @@ func (m *MockStorage) DeleteObject(ctx context.Context, objectKey string) error 
 	return nil
 }
 
+// List implements chunk.ObjectClient.
 func (m *MockStorage) List(ctx context.Context, prefix, delimiter string) ([]StorageObject, []StorageCommonPrefix, error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()

--- a/pkg/chunk/local/fixtures.go
+++ b/pkg/chunk/local/fixtures.go
@@ -38,9 +38,7 @@ func (f *fixture) Clients() (
 		return
 	}
 
-	oClient, err := NewFSObjectClient(FSConfig{
-		Directory: f.dirname,
-	})
+	oClient, err := NewFSObjectClient(FSConfig{Directory: f.dirname})
 	if err != nil {
 		return
 	}

--- a/pkg/chunk/local/fs_object_client.go
+++ b/pkg/chunk/local/fs_object_client.go
@@ -95,8 +95,8 @@ func (f *FSObjectClient) PutObject(ctx context.Context, objectKey string, object
 	return fl.Close()
 }
 
-// List objects and common-prefixes i.e directories from the store non-recursively
-func (f *FSObjectClient) List(ctx context.Context, prefix string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
+// TODO: support for delimiter.
+func (f *FSObjectClient) List(ctx context.Context, prefix, _ string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	var storageObjects []chunk.StorageObject
 	var commonPrefixes []chunk.StorageCommonPrefix
 

--- a/pkg/chunk/local/fs_object_client.go
+++ b/pkg/chunk/local/fs_object_client.go
@@ -126,17 +126,17 @@ func (f *FSObjectClient) List(ctx context.Context, prefix, delimiter string) ([]
 			if delimiter == "" {
 				// Go into directory
 				return nil
-			} else {
-				empty, err := isDirEmpty(path)
-				if err != nil {
-					return err
-				}
-
-				if !empty {
-					commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(relPath+delimiter))
-				}
-				return filepath.SkipDir
 			}
+
+			empty, err := isDirEmpty(path)
+			if err != nil {
+				return err
+			}
+
+			if !empty {
+				commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(relPath+delimiter))
+			}
+			return filepath.SkipDir
 		}
 
 		storageObjects = append(storageObjects, chunk.StorageObject{Key: relPath, ModifiedAt: info.ModTime()})

--- a/pkg/chunk/local/fs_object_client.go
+++ b/pkg/chunk/local/fs_object_client.go
@@ -95,6 +95,7 @@ func (f *FSObjectClient) PutObject(_ context.Context, objectKey string, object i
 	return fl.Close()
 }
 
+// List implements chunk.ObjectClient.
 // FSObjectClient assumes that prefix is a directory, and only supports "" and "/" delimiters.
 func (f *FSObjectClient) List(ctx context.Context, prefix, delimiter string) ([]chunk.StorageObject, []chunk.StorageCommonPrefix, error) {
 	if delimiter != "" && delimiter != "/" {

--- a/pkg/chunk/local/fs_object_client_test.go
+++ b/pkg/chunk/local/fs_object_client_test.go
@@ -152,6 +152,17 @@ func TestFSObjectClient_List(t *testing.T) {
 		storageObjectPaths = append(storageObjectPaths, so.Key)
 	}
 	require.ElementsMatch(t, allFiles, storageObjectPaths)
+
+	storageObjects, commonPrefixes, err = bucketClient.List(context.Background(), "doesnt_exist", "")
+	require.NoError(t, err)
+	require.Empty(t, storageObjects)
+	require.Empty(t, commonPrefixes)
+
+	storageObjects, commonPrefixes, err = bucketClient.List(context.Background(), "outer-file1", "")
+	require.NoError(t, err)
+	require.Len(t, storageObjects, 1)
+	require.Equal(t, "outer-file1", storageObjects[0].Key)
+	require.Empty(t, commonPrefixes)
 }
 
 func TestFSObjectClient_DeleteObject(t *testing.T) {

--- a/pkg/chunk/local/fs_object_client_test.go
+++ b/pkg/chunk/local/fs_object_client_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -74,52 +76,81 @@ func TestFSObjectClient_List(t *testing.T) {
 		require.NoError(t, os.RemoveAll(fsObjectsDir))
 	}()
 
-	foldersWithFiles := make(map[string][]string)
-	foldersWithFiles["folder1"] = []string{"file1", "file2"}
-	foldersWithFiles["folder2"] = []string{"file3", "file4", "file5"}
+	allFiles := []string{
+		"outer-file1",
+		"outer-file2",
+		"folder1/file1",
+		"folder1/file2",
+		"folder2/file3",
+		"folder2/file4",
+		"folder2/file5",
+		"deeply/nested/folder/a",
+		"deeply/nested/folder/b",
+		"deeply/nested/folder/c",
+	}
 
-	for folder, files := range foldersWithFiles {
-		for _, filename := range files {
-			err := bucketClient.PutObject(context.Background(), filepath.Join(folder, filename), bytes.NewReader([]byte(filename)))
-			require.NoError(t, err)
+	topLevelFolders := map[string]bool{}
+	topLevelFiles := map[string]bool{}
+	filesInTopLevelFolders := map[string]map[string]bool{}
+
+	for _, f := range allFiles {
+		require.NoError(t, bucketClient.PutObject(context.Background(), f, bytes.NewReader([]byte(f))))
+
+		s := strings.Split(f, "/")
+		if len(s) > 1 {
+			topLevelFolders[s[0]] = true
+		} else {
+			topLevelFiles[s[0]] = true
+		}
+
+		if len(s) == 2 {
+			if filesInTopLevelFolders[s[0]] == nil {
+				filesInTopLevelFolders[s[0]] = map[string]bool{}
+			}
+			filesInTopLevelFolders[s[0]][s[1]] = true
 		}
 	}
 
 	// create an empty directory which should get excluded from the list
 	require.NoError(t, util.EnsureDirectory(filepath.Join(fsObjectsDir, "empty-folder")))
 
-	files := []string{"outer-file1", "outer-file2"}
-
-	for _, fl := range files {
-		err := bucketClient.PutObject(context.Background(), fl, bytes.NewReader([]byte(fl)))
-		require.NoError(t, err)
-	}
-
 	storageObjects, commonPrefixes, err := bucketClient.List(context.Background(), "", "/")
 	require.NoError(t, err)
 
-	require.Len(t, storageObjects, len(files))
-	for i := range storageObjects {
-		require.Equal(t, storageObjects[i].Key, files[i])
+	require.Len(t, storageObjects, len(topLevelFiles))
+	for _, so := range storageObjects {
+		require.True(t, topLevelFiles[so.Key])
 	}
 
-	require.Len(t, commonPrefixes, len(foldersWithFiles))
+	require.Len(t, commonPrefixes, len(topLevelFolders))
 	for _, commonPrefix := range commonPrefixes {
-		_, ok := foldersWithFiles[string(commonPrefix)[:len(commonPrefix)-len(bucketClient.PathSeparator())]]
-		require.True(t, ok)
+		require.True(t, topLevelFolders[string(commonPrefix)[:len(commonPrefix)-1]]) // 1 to remove "/" separator.
 	}
 
-	for folder, files := range foldersWithFiles {
+	for folder, files := range filesInTopLevelFolders {
 		storageObjects, commonPrefixes, err := bucketClient.List(context.Background(), folder, "/")
 		require.NoError(t, err)
 
 		require.Len(t, storageObjects, len(files))
-		for i := range storageObjects {
-			require.Equal(t, storageObjects[i].Key, filepath.Join(folder, files[i]))
+		for _, so := range storageObjects {
+			require.True(t, strings.HasPrefix(so.Key, folder+"/"))
+			require.True(t, files[path.Base(so.Key)])
 		}
 
 		require.Len(t, commonPrefixes, 0)
 	}
+
+	// List everything from the top, recursively.
+	storageObjects, commonPrefixes, err = bucketClient.List(context.Background(), "", "")
+
+	// Since delimiter is empty, there are no commonPrefixes.
+	require.Empty(t, commonPrefixes)
+
+	var storageObjectPaths []string
+	for _, so := range storageObjects {
+		storageObjectPaths = append(storageObjectPaths, so.Key)
+	}
+	require.ElementsMatch(t, allFiles, storageObjectPaths)
 }
 
 func TestFSObjectClient_DeleteObject(t *testing.T) {
@@ -140,7 +171,7 @@ func TestFSObjectClient_DeleteObject(t *testing.T) {
 
 	for folder, files := range foldersWithFiles {
 		for _, filename := range files {
-			err := bucketClient.PutObject(context.Background(), filepath.Join(folder, filename), bytes.NewReader([]byte(filename)))
+			err := bucketClient.PutObject(context.Background(), path.Join(folder, filename), bytes.NewReader([]byte(filename)))
 			require.NoError(t, err)
 		}
 	}
@@ -151,7 +182,7 @@ func TestFSObjectClient_DeleteObject(t *testing.T) {
 	require.Len(t, commonPrefixes, len(foldersWithFiles))
 
 	// let us delete file1 from folder1 and check that file1 is gone but folder1 with file2 is still there
-	require.NoError(t, bucketClient.DeleteObject(context.Background(), filepath.Join("folder1", "file1")))
+	require.NoError(t, bucketClient.DeleteObject(context.Background(), path.Join("folder1", "file1")))
 	_, err = os.Stat(filepath.Join(fsObjectsDir, filepath.Join("folder1", "file1")))
 	require.True(t, os.IsNotExist(err))
 
@@ -159,7 +190,7 @@ func TestFSObjectClient_DeleteObject(t *testing.T) {
 	require.NoError(t, err)
 
 	// let us delete second file as well and check that folder1 also got removed
-	require.NoError(t, bucketClient.DeleteObject(context.Background(), filepath.Join("folder1", "file2")))
+	require.NoError(t, bucketClient.DeleteObject(context.Background(), path.Join("folder1", "file2")))
 	_, err = os.Stat(filepath.Join(fsObjectsDir, "folder1"))
 	require.True(t, os.IsNotExist(err))
 

--- a/pkg/chunk/local/fs_object_client_test.go
+++ b/pkg/chunk/local/fs_object_client_test.go
@@ -142,6 +142,7 @@ func TestFSObjectClient_List(t *testing.T) {
 
 	// List everything from the top, recursively.
 	storageObjects, commonPrefixes, err = bucketClient.List(context.Background(), "", "")
+	require.NoError(t, err)
 
 	// Since delimiter is empty, there are no commonPrefixes.
 	require.Empty(t, commonPrefixes)

--- a/pkg/chunk/local/fs_object_client_test.go
+++ b/pkg/chunk/local/fs_object_client_test.go
@@ -95,7 +95,7 @@ func TestFSObjectClient_List(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	storageObjects, commonPrefixes, err := bucketClient.List(context.Background(), "")
+	storageObjects, commonPrefixes, err := bucketClient.List(context.Background(), "", "/")
 	require.NoError(t, err)
 
 	require.Len(t, storageObjects, len(files))
@@ -110,7 +110,7 @@ func TestFSObjectClient_List(t *testing.T) {
 	}
 
 	for folder, files := range foldersWithFiles {
-		storageObjects, commonPrefixes, err := bucketClient.List(context.Background(), folder)
+		storageObjects, commonPrefixes, err := bucketClient.List(context.Background(), folder, "/")
 		require.NoError(t, err)
 
 		require.Len(t, storageObjects, len(files))
@@ -146,7 +146,7 @@ func TestFSObjectClient_DeleteObject(t *testing.T) {
 	}
 
 	// let us check if we have right folders created
-	_, commonPrefixes, err := bucketClient.List(context.Background(), "")
+	_, commonPrefixes, err := bucketClient.List(context.Background(), "", "/")
 	require.NoError(t, err)
 	require.Len(t, commonPrefixes, len(foldersWithFiles))
 

--- a/pkg/chunk/purger/purger_test.go
+++ b/pkg/chunk/purger/purger_test.go
@@ -208,7 +208,7 @@ func TestPurger_BuildPlan(t *testing.T) {
 				require.NoError(t, err)
 				planPath := fmt.Sprintf("%s:%s/", userID, deleteRequest.RequestID)
 
-				plans, _, err := storageClient.List(context.Background(), planPath)
+				plans, _, err := storageClient.List(context.Background(), planPath, "/")
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedNumberOfPlans, len(plans))
 

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -246,7 +246,7 @@ func NewChunkClient(name string, cfg Config, schemaCfg chunk.SchemaConfig, regis
 	case "inmemory":
 		return chunk.NewMockStorage(), nil
 	case "aws", "s3":
-		return newChunkClientFromStore(aws.NewS3ObjectClient(cfg.AWSStorageConfig.S3Config, chunk.DirDelim))
+		return newChunkClientFromStore(aws.NewS3ObjectClient(cfg.AWSStorageConfig.S3Config))
 	case "aws-dynamo":
 		if cfg.AWSStorageConfig.DynamoDB.URL == nil {
 			return nil, fmt.Errorf("Must set -dynamodb.url in aws mode")
@@ -257,15 +257,15 @@ func NewChunkClient(name string, cfg Config, schemaCfg chunk.SchemaConfig, regis
 		}
 		return aws.NewDynamoDBChunkClient(cfg.AWSStorageConfig.DynamoDBConfig, schemaCfg, registerer)
 	case "azure":
-		return newChunkClientFromStore(azure.NewBlobStorage(&cfg.AzureStorageConfig, chunk.DirDelim))
+		return newChunkClientFromStore(azure.NewBlobStorage(&cfg.AzureStorageConfig))
 	case "gcp":
 		return gcp.NewBigtableObjectClient(context.Background(), cfg.GCPStorageConfig, schemaCfg)
 	case "gcp-columnkey", "bigtable", "bigtable-hashed":
 		return gcp.NewBigtableObjectClient(context.Background(), cfg.GCPStorageConfig, schemaCfg)
 	case "gcs":
-		return newChunkClientFromStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCSConfig, chunk.DirDelim))
+		return newChunkClientFromStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCSConfig))
 	case "swift":
-		return newChunkClientFromStore(openstack.NewSwiftObjectClient(cfg.Swift, chunk.DirDelim))
+		return newChunkClientFromStore(openstack.NewSwiftObjectClient(cfg.Swift))
 	case "cassandra":
 		return cassandra.NewObjectClient(cfg.CassandraStorageConfig, schemaCfg, registerer)
 	case "filesystem":
@@ -334,13 +334,13 @@ func NewBucketClient(storageConfig Config) (chunk.BucketClient, error) {
 func NewObjectClient(name string, cfg Config) (chunk.ObjectClient, error) {
 	switch name {
 	case "aws", "s3":
-		return aws.NewS3ObjectClient(cfg.AWSStorageConfig.S3Config, chunk.DirDelim)
+		return aws.NewS3ObjectClient(cfg.AWSStorageConfig.S3Config)
 	case "gcs":
-		return gcp.NewGCSObjectClient(context.Background(), cfg.GCSConfig, chunk.DirDelim)
+		return gcp.NewGCSObjectClient(context.Background(), cfg.GCSConfig)
 	case "azure":
-		return azure.NewBlobStorage(&cfg.AzureStorageConfig, chunk.DirDelim)
+		return azure.NewBlobStorage(&cfg.AzureStorageConfig)
 	case "swift":
-		return openstack.NewSwiftObjectClient(cfg.Swift, chunk.DirDelim)
+		return openstack.NewSwiftObjectClient(cfg.Swift)
 	case "inmemory":
 		return chunk.NewMockStorage(), nil
 	case "filesystem":

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -72,7 +72,8 @@ type ObjectClient interface {
 	// For example, if the prefix is "notes/" and the delimiter is a slash (/) as in "notes/summer/july", the common prefix is "notes/summer/".
 	// Common prefixes will always end with passed delimiter.
 	//
-	// Keys of returned storage objects have given prefix.	List(ctx context.Context, prefix string, delimiter string) ([]StorageObject, []StorageCommonPrefix, error)
+	// Keys of returned storage objects have given prefix.
+	List(ctx context.Context, prefix string, delimiter string) ([]StorageObject, []StorageCommonPrefix, error)
 	DeleteObject(ctx context.Context, objectKey string) error
 	Stop()
 }

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -7,9 +7,6 @@ import (
 	"time"
 )
 
-// DirDelim is the delimiter used to model a directory structure in an object store.
-const DirDelim = "/"
-
 var (
 	// ErrStorageObjectNotFound when object storage does not have requested object
 	ErrStorageObjectNotFound = errors.New("object not found in storage")
@@ -67,10 +64,15 @@ type ObjectClient interface {
 	GetObject(ctx context.Context, objectKey string) (io.ReadCloser, error)
 
 	// List objects with given prefix.
-	// If delimiter is empty, all objects are returned, even if they are in "subdirectories".
+	//
+	// If delimiter is empty, all objects are returned, even if they are in nested in "subdirectories".
 	// If delimiter is not empty, it is used to compute common prefixes ("subdirectories"),
 	// and objects containing delimiter in the name will not be returned in the result.
-	List(ctx context.Context, prefix string, delimiter string) ([]StorageObject, []StorageCommonPrefix, error)
+	//
+	// For example, if the prefix is "notes/" and the delimiter is a slash (/) as in "notes/summer/july", the common prefix is "notes/summer/".
+	// Common prefixes will always end with passed delimiter.
+	//
+	// Keys of returned storage objects have given prefix.	List(ctx context.Context, prefix string, delimiter string) ([]StorageObject, []StorageCommonPrefix, error)
 	DeleteObject(ctx context.Context, objectKey string) error
 	Stop()
 }
@@ -82,5 +84,4 @@ type StorageObject struct {
 }
 
 // StorageCommonPrefix represents a common prefix aka a synthetic directory in Object Store.
-// It is guaranteed to always end with DirDelim
 type StorageCommonPrefix string

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -65,9 +65,13 @@ type ReadBatchIterator interface {
 type ObjectClient interface {
 	PutObject(ctx context.Context, objectKey string, object io.ReadSeeker) error
 	GetObject(ctx context.Context, objectKey string) (io.ReadCloser, error)
-	List(ctx context.Context, prefix string) ([]StorageObject, []StorageCommonPrefix, error)
+
+	// List objects with given prefix.
+	// If delimiter is empty, all objects are returned, even if they are in "subdirectories".
+	// If delimiter is not empty, it is used to compute common prefixes ("subdirectories"),
+	// and objects containing delimiter in the name will not be returned in the result.
+	List(ctx context.Context, prefix string, delimiter string) ([]StorageObject, []StorageCommonPrefix, error)
 	DeleteObject(ctx context.Context, objectKey string) error
-	PathSeparator() string
 	Stop()
 }
 

--- a/pkg/ruler/rules/objectclient/rule_store.go
+++ b/pkg/ruler/rules/objectclient/rule_store.go
@@ -69,7 +69,7 @@ func (o *RuleStore) getRuleGroup(ctx context.Context, objectKey string) (*rules.
 
 // ListAllRuleGroups returns all the active rule groups
 func (o *RuleStore) ListAllRuleGroups(ctx context.Context) (map[string]rules.RuleGroupList, error) {
-	ruleGroupObjects, _, err := o.client.List(ctx, generateRuleObjectKey("", "", ""))
+	ruleGroupObjects, _, err := o.client.List(ctx, generateRuleObjectKey("", "", ""), "")
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (o *RuleStore) ListAllRuleGroups(ctx context.Context) (map[string]rules.Rul
 
 // ListRuleGroups returns all the active rule groups for a user
 func (o *RuleStore) ListRuleGroups(ctx context.Context, userID, namespace string) (rules.RuleGroupList, error) {
-	ruleGroupObjects, _, err := o.client.List(ctx, generateRuleObjectKey(userID, namespace, ""))
+	ruleGroupObjects, _, err := o.client.List(ctx, generateRuleObjectKey(userID, namespace, ""), "")
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (o *RuleStore) DeleteRuleGroup(ctx context.Context, userID string, namespac
 
 // DeleteNamespace deletes all the rule groups in the specified namespace
 func (o *RuleStore) DeleteNamespace(ctx context.Context, userID, namespace string) error {
-	ruleGroupObjects, _, err := o.client.List(ctx, generateRuleObjectKey(userID, namespace, ""))
+	ruleGroupObjects, _, err := o.client.List(ctx, generateRuleObjectKey(userID, namespace, ""), "")
 	if err != nil {
 		return err
 	}

--- a/pkg/ruler/storage.go
+++ b/pkg/ruler/storage.go
@@ -82,13 +82,13 @@ func NewRuleStorage(cfg RuleStoreConfig, loader promRules.GroupLoader) (rules.Ru
 
 		return rules.NewConfigRuleStore(c), nil
 	case "azure":
-		return newObjRuleStore(azure.NewBlobStorage(&cfg.Azure, ""))
+		return newObjRuleStore(azure.NewBlobStorage(&cfg.Azure))
 	case "gcs":
-		return newObjRuleStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCS, ""))
+		return newObjRuleStore(gcp.NewGCSObjectClient(context.Background(), cfg.GCS))
 	case "s3":
-		return newObjRuleStore(aws.NewS3ObjectClient(cfg.S3, ""))
+		return newObjRuleStore(aws.NewS3ObjectClient(cfg.S3))
 	case "swift":
-		return newObjRuleStore(openstack.NewSwiftObjectClient(cfg.Swift, ""))
+		return newObjRuleStore(openstack.NewSwiftObjectClient(cfg.Swift))
 	case "local":
 		return local.NewLocalRulesClient(cfg.Local, loader)
 	default:


### PR DESCRIPTION
**What this PR does**: This PR refactors `ObjectClient` interface to explicitly pass `delimiter` to `List` method. Previously delimiter was property of `ObjectClient` passed to it when created, but that doesn't work if code using `ObjectClient` wants to do both recursive and non-recursive calls.

This PR also changes `FSObjectClient` such that it always expects paths using `/` separator, but maps it to `\` on Windows internally. Code using `FSObjectClient` will only see `/` returned.

This is a pre-requisite for PR #3235.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
