### PR TITLE
Fix TestShuffleShardWithCaching

### DIFF
--- a/pkg/ring/kv/consul/client.go
+++ b/pkg/ring/kv/consul/client.go
@@ -41,9 +41,6 @@ type Config struct {
 	ConsistentReads   bool          `yaml:"consistent_reads"`
 	WatchKeyRateLimit float64       `yaml:"watch_rate_limit"` // Zero disables rate limit
 	WatchKeyBurstSize int           `yaml:"watch_burst_size"` // Burst when doing rate-limit, defaults to 1
-
-	// How many times to retry CAS operation. Exposed for tests with many clients using inmemory KV.
-	CASRetries int `yaml:"-"`
 }
 
 type kv interface {
@@ -122,13 +119,8 @@ func (c *Client) CAS(ctx context.Context, key string, f func(in interface{}) (ou
 func (c *Client) cas(ctx context.Context, key string, f func(in interface{}) (out interface{}, retry bool, err error)) error {
 	var (
 		index   = uint64(0)
-		retries = c.cfg.CASRetries
-	)
-
-	if retries == 0 {
 		retries = 10
-	}
-
+	)
 	for i := 0; i < retries; i++ {
 		options := &consul.QueryOptions{
 			AllowStale:        !c.cfg.ConsistentReads,

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -798,7 +798,7 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 // This test checks if shuffle-sharded ring can be reused, and whether it receives
 // updates from "main" ring.
 func TestShuffleShardWithCaching(t *testing.T) {
-	inmem := consul.NewInMemoryClientWithConfig(GetCodec(), consul.Config{CASRetries: 50})
+	inmem := consul.NewInMemoryClient(GetCodec())
 
 	cfg := Config{
 		KVStore:              kv.Config{Mock: inmem},
@@ -814,8 +814,8 @@ func TestShuffleShardWithCaching(t *testing.T) {
 		_ = services.StartAndAwaitRunning(context.Background(), ring)
 	})
 
-	// We will stop one third of ingesters later, to see that subring is recomputed.
-	const numLifecyclers = 9
+	// We will stop <number of zones> ingesters later, to see that subring is recomputed.
+	const numLifecyclers = 6
 	const zones = 3
 
 	lcs := []*Lifecycler(nil)
@@ -876,15 +876,14 @@ func TestShuffleShardWithCaching(t *testing.T) {
 	})
 
 	// Change of ingesters -> new subring needed.
-	newSubring := ring.ShuffleShard("user", 3)
+	newSubring := ring.ShuffleShard("user", zones)
 	require.False(t, subring == newSubring)
-	require.Equal(t, 3, subring.IngesterCount())
+	require.Equal(t, zones, subring.IngesterCount())
 
 	// Change of shard size -> new subring needed.
 	subring = newSubring
-	newSubring = ring.ShuffleShard("user", 4)
+	newSubring = ring.ShuffleShard("user", 1)
 	require.False(t, subring == newSubring)
-	// Why 6? We have 3 zones each with 2 ingesters. Zone-aware shuffle-shard gives all zones the same number of
-	// ingesters, so 6 ingesters in total.
-	require.Equal(t, 6, newSubring.IngesterCount())
+	// Zone-aware shuffle-shard gives all zones the same number of ingesters (at least one).
+	require.Equal(t, zones, newSubring.IngesterCount())
 }

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -798,7 +798,7 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 // This test checks if shuffle-sharded ring can be reused, and whether it receives
 // updates from "main" ring.
 func TestShuffleShardWithCaching(t *testing.T) {
-	inmem := consul.NewInMemoryClient(GetCodec())
+	inmem := consul.NewInMemoryClientWithConfig(GetCodec(), consul.Config{CASRetries: 50})
 
 	cfg := Config{
 		KVStore:              kv.Config{Mock: inmem},


### PR DESCRIPTION
**What this PR does**: This PR modifies flaky `TestShuffleShardWithCaching` test to use fewer lifecyclers to avoid CAS operation failures. That should make test more stable.

**Which issue(s) this PR fixes**:
Fixes #3241 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
