### PR TITLE
Add ingesters shuffle sharding support on the read path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@
 * [CHANGE] Renamed `-<prefix>.redis.enable-tls` CLI flag to `-<prefix>.redis.tls-enabled`, and its respective YAML config option from `enable_tls` to `tls_enabled`. #3298
 * [CHANGE] Increased default `-<prefix>.redis.timeout` from `100ms` to `500ms`. #3301
 * [CHANGE] `cortex_alertmanager_config_invalid` has been removed in favor of `cortex_alertmanager_config_last_reload_successful`. #3289
-* [FEATURE] Added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-tenant` globally, or using per-tenant limit `max_queriers_per_tenant`), each tenants's requests will be handled by different set of queriers. #3113 #3257
+* [FEATURE] Shuffle sharding: added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-tenant` globally, or using per-tenant limit `max_queriers_per_tenant`), each tenants's requests will be handled by different set of queriers. #3113 #3257
+* [FEATURE] Shuffle sharding: added support for shuffle-sharding ingesters on the read path. When ingesters shuffle-sharding is enabled and `-querier.shuffle-sharding-ingesters-lookback-period` is set, queriers will fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. #3252
 * [FEATURE] Query-frontend: added `compression` config to support results cache with compression. #3217
 * [ENHANCEMENT] Allow to specify multiple comma-separated Cortex services to `-target` CLI option (or its respective YAML config option). For example, `-target=all,compactor` can be used to start Cortex single-binary with compactor as well. #3275
 * [ENHANCEMENT] Expose additional HTTP configs for the S3 backend client. New flag are listed below: #3244

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 * [BUGFIX] Use a valid grpc header when logging IP addresses. #3307
 * [BUGFIX] Fixed the metric `cortex_prometheus_rule_group_duration_seconds` in the Ruler, it wouldn't report any values. #3310
 * [BUGFIX] Fixed gRPC connections leaking in rulers when rulers sharding is enabled and APIs called. #3314
+* [BUGFIX] Fixed shuffle sharding consistency when zone-awareness is enabled and the shard size is increased or instances in a new zone are added. #3299
 
 ## 1.4.0 / 2020-10-02
 

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -178,7 +178,7 @@ querier:
   # > 0, queriers fetch in-memory series from the minimum set of required
   # ingesters, selecting only ingesters which may have received series since
   # 'now - lookback period'. If this setting is 0, queriers always query all
-  # ingesters.
+  # ingesters (ingesters shuffle sharding on read path is disabled).
   # CLI flag: -querier.shuffle-sharding-ingesters-lookback-period
   [shuffle_sharding_ingesters_lookback_period: <duration> | default = 0s]
 ```

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -173,6 +173,14 @@ querier:
   # Default value 0 means secondary store is always queried.
   # CLI flag: -querier.use-second-store-before-time
   [use_second_store_before_time: <time> | default = 0]
+
+  # When distributor's sharding strategy is shuffle-sharding and this setting is
+  # > 0, queriers fetch in-memory series from the minimum set of required
+  # ingesters, selecting only ingesters which may have received series since
+  # 'now - lookback period'. If this setting is 0, queriers always query all
+  # ingesters.
+  # CLI flag: -querier.shuffle-sharding-ingesters-lookback-period
+  [shuffle_sharding_ingesters_lookback_period: <duration> | default = 0s]
 ```
 
 ### `blocks_storage_config`

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -177,8 +177,9 @@ querier:
   # When distributor's sharding strategy is shuffle-sharding and this setting is
   # > 0, queriers fetch in-memory series from the minimum set of required
   # ingesters, selecting only ingesters which may have received series since
-  # 'now - lookback period'. If this setting is 0, queriers always query all
-  # ingesters (ingesters shuffle sharding on read path is disabled).
+  # 'now - lookback period'. The lookback period should be greater or equal than
+  # the configured 'query store after'. If this setting is 0, queriers always
+  # query all ingesters (ingesters shuffle sharding on read path is disabled).
   # CLI flag: -querier.shuffle-sharding-ingesters-lookback-period
   [shuffle_sharding_ingesters_lookback_period: <duration> | default = 0s]
 ```

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -744,8 +744,9 @@ store_gateway_client:
 # When distributor's sharding strategy is shuffle-sharding and this setting is >
 # 0, queriers fetch in-memory series from the minimum set of required ingesters,
 # selecting only ingesters which may have received series since 'now - lookback
-# period'. If this setting is 0, queriers always query all ingesters (ingesters
-# shuffle sharding on read path is disabled).
+# period'. The lookback period should be greater or equal than the configured
+# 'query store after'. If this setting is 0, queriers always query all ingesters
+# (ingesters shuffle sharding on read path is disabled).
 # CLI flag: -querier.shuffle-sharding-ingesters-lookback-period
 [shuffle_sharding_ingesters_lookback_period: <duration> | default = 0s]
 ```

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -740,6 +740,13 @@ store_gateway_client:
 # Default value 0 means secondary store is always queried.
 # CLI flag: -querier.use-second-store-before-time
 [use_second_store_before_time: <time> | default = 0]
+
+# When distributor's sharding strategy is shuffle-sharding and this setting is >
+# 0, queriers fetch in-memory series from the minimum set of required ingesters,
+# selecting only ingesters which may have received series since 'now - lookback
+# period'. If this setting is 0, queriers always query all ingesters.
+# CLI flag: -querier.shuffle-sharding-ingesters-lookback-period
+[shuffle_sharding_ingesters_lookback_period: <duration> | default = 0s]
 ```
 
 ### `query_frontend_config`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -744,7 +744,8 @@ store_gateway_client:
 # When distributor's sharding strategy is shuffle-sharding and this setting is >
 # 0, queriers fetch in-memory series from the minimum set of required ingesters,
 # selecting only ingesters which may have received series since 'now - lookback
-# period'. If this setting is 0, queriers always query all ingesters.
+# period'. If this setting is 0, queriers always query all ingesters (ingesters
+# shuffle sharding on read path is disabled).
 # CLI flag: -querier.shuffle-sharding-ingesters-lookback-period
 [shuffle_sharding_ingesters_lookback_period: <duration> | default = 0s]
 ```

--- a/integration/e2e/metrics_options.go
+++ b/integration/e2e/metrics_options.go
@@ -23,6 +23,7 @@ type MetricsOptions struct {
 	GetValue           GetMetricValueFunc
 	LabelMatchers      []*labels.Matcher
 	WaitMissingMetrics bool
+	SkipMissingMetrics bool
 }
 
 // WithMetricCount is an option to get the histogram/summary count as metric value.
@@ -41,6 +42,11 @@ func WithLabelMatchers(matchers ...*labels.Matcher) MetricsOption {
 // option is not enabled, will return error on missing metrics.
 func WaitMissingMetrics(opts *MetricsOptions) {
 	opts.WaitMissingMetrics = true
+}
+
+// SkipWaitMissingMetrics is an option to skip/ignore whenever an expected metric is missing.
+func SkipMissingMetrics(opts *MetricsOptions) {
+	opts.SkipMissingMetrics = true
 }
 
 func buildMetricsOptions(opts []MetricsOption) MetricsOptions {

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -577,12 +577,20 @@ func (s *HTTPService) SumMetrics(metricNames []string, opts ...MetricsOption) ([
 		// Get the metric family.
 		mf, ok := families[m]
 		if !ok {
+			if options.SkipMissingMetrics {
+				continue
+			}
+
 			return nil, errors.Wrapf(errMissingMetric, "metric=%s service=%s", m, s.name)
 		}
 
 		// Filter metrics.
 		metrics := filterMetrics(mf.GetMetric(), options)
 		if len(metrics) == 0 {
+			if options.SkipMissingMetrics {
+				continue
+			}
+
 			return nil, errors.Wrapf(errMissingMetric, "metric=%s service=%s", m, s.name)
 		}
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -169,6 +169,7 @@ func (t *Cortex) initOverrides() (serv services.Service, err error) {
 
 func (t *Cortex) initDistributorService() (serv services.Service, err error) {
 	t.Cfg.Distributor.DistributorRing.ListenPort = t.Cfg.Server.GRPCListenPort
+	t.Cfg.Distributor.ShuffleShardingLookbackPeriod = t.Cfg.Querier.ShuffleShardingIngestersLookbackPeriod
 
 	// Check whether the distributor can join the distributors ring, which is
 	// whenever it's not running as an internal dependency (ie. querier or

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -170,6 +170,9 @@ type Config struct {
 	// when true the distributor does not validate the label name, Cortex doesn't directly use
 	// this (and should never use it) but this feature is used by other projects built on top of it
 	SkipLabelNameValidation bool `yaml:"-"`
+
+	// This config is dynamically injected because defined in the querier config.
+	ShuffleShardingLookbackPeriod time.Duration `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -622,16 +625,8 @@ func (d *Distributor) send(ctx context.Context, ingester ring.IngesterDesc, time
 	return err
 }
 
-// ForAllIngesters runs f, in parallel, for all ingesters
-func (d *Distributor) ForAllIngesters(ctx context.Context, reallyAll bool, f func(context.Context, client.IngesterClient) (interface{}, error)) ([]interface{}, error) {
-	replicationSet, err := d.ingestersRing.GetAll(ring.Read)
-	if err != nil {
-		return nil, err
-	}
-	if reallyAll {
-		replicationSet.MaxErrors = 0
-	}
-
+// ForReplicationSet runs f, in parallel, for all ingesters in the input replication set.
+func (d *Distributor) ForReplicationSet(ctx context.Context, replicationSet ring.ReplicationSet, f func(context.Context, client.IngesterClient) (interface{}, error)) ([]interface{}, error) {
 	return replicationSet.Do(ctx, d.cfg.ExtraQueryDelay, func(ctx context.Context, ing *ring.IngesterDesc) (interface{}, error) {
 		client, err := d.ingesterPool.GetClientFor(ing.Addr)
 		if err != nil {
@@ -644,10 +639,15 @@ func (d *Distributor) ForAllIngesters(ctx context.Context, reallyAll bool, f fun
 
 // LabelValuesForLabelName returns all of the label values that are associated with a given label name.
 func (d *Distributor) LabelValuesForLabelName(ctx context.Context, labelName model.LabelName) ([]string, error) {
+	replicationSet, err := d.getIngestersForMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	req := &client.LabelValuesRequest{
 		LabelName: string(labelName),
 	}
-	resps, err := d.ForAllIngesters(ctx, false, func(ctx context.Context, client client.IngesterClient) (interface{}, error) {
+	resps, err := d.ForReplicationSet(ctx, replicationSet, func(ctx context.Context, client client.IngesterClient) (interface{}, error) {
 		return client.LabelValues(ctx, req)
 	})
 	if err != nil {
@@ -670,8 +670,13 @@ func (d *Distributor) LabelValuesForLabelName(ctx context.Context, labelName mod
 
 // LabelNames returns all of the label names.
 func (d *Distributor) LabelNames(ctx context.Context) ([]string, error) {
+	replicationSet, err := d.getIngestersForMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	req := &client.LabelNamesRequest{}
-	resps, err := d.ForAllIngesters(ctx, false, func(ctx context.Context, client client.IngesterClient) (interface{}, error) {
+	resps, err := d.ForReplicationSet(ctx, replicationSet, func(ctx context.Context, client client.IngesterClient) (interface{}, error) {
 		return client.LabelNames(ctx, req)
 	})
 	if err != nil {
@@ -698,12 +703,17 @@ func (d *Distributor) LabelNames(ctx context.Context) ([]string, error) {
 
 // MetricsForLabelMatchers gets the metrics that match said matchers
 func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]metric.Metric, error) {
+	replicationSet, err := d.getIngestersForMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := ingester_client.ToMetricsForLabelMatchersRequest(from, through, matchers)
 	if err != nil {
 		return nil, err
 	}
 
-	resps, err := d.ForAllIngesters(ctx, false, func(ctx context.Context, client client.IngesterClient) (interface{}, error) {
+	resps, err := d.ForReplicationSet(ctx, replicationSet, func(ctx context.Context, client client.IngesterClient) (interface{}, error) {
 		return client.MetricsForLabelMatchers(ctx, req)
 	})
 	if err != nil {
@@ -729,9 +739,14 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 
 // MetricsMetadata returns all metric metadata of a user.
 func (d *Distributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetadata, error) {
+	replicationSet, err := d.getIngestersForMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	req := &ingester_client.MetricsMetadataRequest{}
 	// TODO(gotjosh): We only need to look in all the ingesters if shardByAllLabels is enabled.
-	resps, err := d.ForAllIngesters(ctx, false, func(ctx context.Context, client client.IngesterClient) (interface{}, error) {
+	resps, err := d.ForReplicationSet(ctx, replicationSet, func(ctx context.Context, client client.IngesterClient) (interface{}, error) {
 		return client.MetricsMetadata(ctx, req)
 	})
 	if err != nil {
@@ -764,8 +779,17 @@ func (d *Distributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetad
 
 // UserStats returns statistics about the current user.
 func (d *Distributor) UserStats(ctx context.Context) (*UserStats, error) {
+	// We always need to query all ingesters.
+	replicationSet, err := d.ingestersRing.GetAll(ring.Read)
+	if err != nil {
+		return nil, err
+	}
+
+	// Make sure we get a successful response from all of them.
+	replicationSet.MaxErrors = 0
+
 	req := &client.UserStatsRequest{}
-	resps, err := d.ForAllIngesters(ctx, true, func(ctx context.Context, client client.IngesterClient) (interface{}, error) {
+	resps, err := d.ForReplicationSet(ctx, replicationSet, func(ctx context.Context, client client.IngesterClient) (interface{}, error) {
 		return client.UserStats(ctx, req)
 	})
 	if err != nil {
@@ -801,7 +825,7 @@ func (d *Distributor) AllUserStats(ctx context.Context) ([]UserIDStats, error) {
 
 	req := &client.UserStatsRequest{}
 	ctx = user.InjectOrgID(ctx, "1") // fake: ingester insists on having an org ID
-	// Not using d.ForAllIngesters(), so we can fail after first error.
+	// Not using d.ForReplicationSet(), so we can fail after first error.
 	replicationSet, err := d.ingestersRing.GetAll(ring.Read)
 	if err != nil {
 		return nil, err

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -779,8 +779,7 @@ func (d *Distributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetad
 
 // UserStats returns statistics about the current user.
 func (d *Distributor) UserStats(ctx context.Context) (*UserStats, error) {
-	// We always need to query all ingesters.
-	replicationSet, err := d.ingestersRing.GetAll(ring.Read)
+	replicationSet, err := d.getIngestersForMetadata(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1722,8 +1722,8 @@ func TestSortLabels(t *testing.T) {
 
 func countMockIngestersCalls(ingesters []mockIngester, name string) int {
 	count := 0
-	for _, ing := range ingesters {
-		if ing.countCalls(name) > 0 {
+	for i := 0; i < len(ingesters); i++ {
+		if ingesters[i].countCalls(name) > 0 {
 			count++
 		}
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -445,22 +445,26 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 }
 
 func TestDistributor_PushQuery(t *testing.T) {
+	const shuffleShardSize = 5
+
 	nameMatcher := mustEqualMatcher(model.MetricNameLabel, "foo")
 	barMatcher := mustEqualMatcher("bar", "baz")
 
 	type testcase struct {
-		name             string
-		numIngesters     int
-		happyIngesters   int
-		samples          int
-		metadata         int
-		matchers         []*labels.Matcher
-		expectedResponse model.Matrix
-		expectedError    error
-		shardByAllLabels bool
+		name                string
+		numIngesters        int
+		happyIngesters      int
+		samples             int
+		metadata            int
+		matchers            []*labels.Matcher
+		expectedIngesters   int
+		expectedResponse    model.Matrix
+		expectedError       error
+		shardByAllLabels    bool
+		shuffleShardEnabled bool
 	}
 
-	// We'll programatically build the test cases now, as we want complete
+	// We'll programmatically build the test cases now, as we want complete
 	// coverage along quite a few different axis.
 	testcases := []testcase{}
 
@@ -473,74 +477,98 @@ func TestDistributor_PushQuery(t *testing.T) {
 			// Test with between 0 and numIngesters "happy" ingesters.
 			for happyIngesters := 0; happyIngesters <= numIngesters; happyIngesters++ {
 
-				// When we're not sharding by metric name, queriers with more than one
-				// failed ingester should fail.
-				if shardByAllLabels && numIngesters-happyIngesters > 1 {
+				// Test either with shuffle-sharding enabled or disabled.
+				for _, shuffleShardEnabled := range []bool{false, true} {
+					scenario := fmt.Sprintf("shardByAllLabels=%v, numIngester=%d, happyIngester=%d, shuffleSharding=%v)", shardByAllLabels, numIngesters, happyIngesters, shuffleShardEnabled)
+
+					// The number of ingesters we expect to query depends whether shuffle sharding and/or
+					// shard by all labels are enabled.
+					var expectedIngesters int
+					if shuffleShardEnabled {
+						expectedIngesters = util.Min(shuffleShardSize, numIngesters)
+					} else if shardByAllLabels {
+						expectedIngesters = numIngesters
+					} else {
+						expectedIngesters = 3 // Replication factor
+					}
+
+					// When we're not sharding by metric name, queriers with more than one
+					// failed ingester should fail.
+					if shardByAllLabels && numIngesters-happyIngesters > 1 {
+						testcases = append(testcases, testcase{
+							name:                fmt.Sprintf("ExpectFail(%s)", scenario),
+							numIngesters:        numIngesters,
+							happyIngesters:      happyIngesters,
+							matchers:            []*labels.Matcher{nameMatcher, barMatcher},
+							expectedError:       errFail,
+							shardByAllLabels:    shardByAllLabels,
+							shuffleShardEnabled: shuffleShardEnabled,
+						})
+						continue
+					}
+
+					// When we have less ingesters than replication factor, any failed ingester
+					// will cause a failure.
+					if numIngesters < 3 && happyIngesters < 2 {
+						testcases = append(testcases, testcase{
+							name:                fmt.Sprintf("ExpectFail(%s)", scenario),
+							numIngesters:        numIngesters,
+							happyIngesters:      happyIngesters,
+							matchers:            []*labels.Matcher{nameMatcher, barMatcher},
+							expectedError:       errFail,
+							shardByAllLabels:    shardByAllLabels,
+							shuffleShardEnabled: shuffleShardEnabled,
+						})
+						continue
+					}
+
+					// If we're sharding by metric name and we have failed ingesters, we can't
+					// tell ahead of time if the query will succeed, as we don't know which
+					// ingesters will hold the results for the query.
+					if !shardByAllLabels && numIngesters-happyIngesters > 1 {
+						continue
+					}
+
+					// Reading all the samples back should succeed.
 					testcases = append(testcases, testcase{
-						name:             fmt.Sprintf("ExpectFail(shardByAllLabels=%v,numIngester=%d,happyIngester=%d)", shardByAllLabels, numIngesters, happyIngesters),
-						numIngesters:     numIngesters,
-						happyIngesters:   happyIngesters,
-						matchers:         []*labels.Matcher{nameMatcher, barMatcher},
-						expectedError:    errFail,
-						shardByAllLabels: shardByAllLabels,
+						name:                fmt.Sprintf("ReadAll(%s)", scenario),
+						numIngesters:        numIngesters,
+						happyIngesters:      happyIngesters,
+						samples:             10,
+						matchers:            []*labels.Matcher{nameMatcher, barMatcher},
+						expectedResponse:    expectedResponse(0, 10),
+						expectedIngesters:   expectedIngesters,
+						shardByAllLabels:    shardByAllLabels,
+						shuffleShardEnabled: shuffleShardEnabled,
 					})
-					continue
-				}
 
-				// When we have less ingesters than replication factor, any failed ingester
-				// will cause a failure.
-				if numIngesters < 3 && happyIngesters < 2 {
+					// As should reading none of the samples back.
 					testcases = append(testcases, testcase{
-						name:             fmt.Sprintf("ExpectFail(shardByAllLabels=%v,numIngester=%d,happyIngester=%d)", shardByAllLabels, numIngesters, happyIngesters),
-						numIngesters:     numIngesters,
-						happyIngesters:   happyIngesters,
-						matchers:         []*labels.Matcher{nameMatcher, barMatcher},
-						expectedError:    errFail,
-						shardByAllLabels: shardByAllLabels,
+						name:                fmt.Sprintf("ReadNone(%s)", scenario),
+						numIngesters:        numIngesters,
+						happyIngesters:      happyIngesters,
+						samples:             10,
+						matchers:            []*labels.Matcher{nameMatcher, mustEqualMatcher("not", "found")},
+						expectedResponse:    expectedResponse(0, 0),
+						expectedIngesters:   expectedIngesters,
+						shardByAllLabels:    shardByAllLabels,
+						shuffleShardEnabled: shuffleShardEnabled,
 					})
-					continue
-				}
 
-				// If we're sharding by metric name and we have failed ingesters, we can't
-				// tell ahead of time if the query will succeed, as we don't know which
-				// ingesters will hold the results for the query.
-				if !shardByAllLabels && numIngesters-happyIngesters > 1 {
-					continue
-				}
-
-				// Reading all the samples back should succeed.
-				testcases = append(testcases, testcase{
-					name:             fmt.Sprintf("ReadAll(shardByAllLabels=%v,numIngester=%d,happyIngester=%d)", shardByAllLabels, numIngesters, happyIngesters),
-					numIngesters:     numIngesters,
-					happyIngesters:   happyIngesters,
-					samples:          10,
-					matchers:         []*labels.Matcher{nameMatcher, barMatcher},
-					expectedResponse: expectedResponse(0, 10),
-					shardByAllLabels: shardByAllLabels,
-				})
-
-				// As should reading none of the samples back.
-				testcases = append(testcases, testcase{
-					name:             fmt.Sprintf("ReadNone(shardByAllLabels=%v,numIngester=%d,happyIngester=%d)", shardByAllLabels, numIngesters, happyIngesters),
-					numIngesters:     numIngesters,
-					happyIngesters:   happyIngesters,
-					samples:          10,
-					matchers:         []*labels.Matcher{nameMatcher, mustEqualMatcher("not", "found")},
-					expectedResponse: expectedResponse(0, 0),
-					shardByAllLabels: shardByAllLabels,
-				})
-
-				// And reading each sample individually.
-				for i := 0; i < 10; i++ {
-					testcases = append(testcases, testcase{
-						name:             fmt.Sprintf("ReadOne(shardByAllLabels=%v, sample=%d,numIngester=%d,happyIngester=%d)", shardByAllLabels, i, numIngesters, happyIngesters),
-						numIngesters:     numIngesters,
-						happyIngesters:   happyIngesters,
-						samples:          10,
-						matchers:         []*labels.Matcher{nameMatcher, mustEqualMatcher("sample", strconv.Itoa(i))},
-						expectedResponse: expectedResponse(i, i+1),
-						shardByAllLabels: shardByAllLabels,
-					})
+					// And reading each sample individually.
+					for i := 0; i < 10; i++ {
+						testcases = append(testcases, testcase{
+							name:                fmt.Sprintf("ReadOne(%s, sample=%d)", scenario, i),
+							numIngesters:        numIngesters,
+							happyIngesters:      happyIngesters,
+							samples:             10,
+							matchers:            []*labels.Matcher{nameMatcher, mustEqualMatcher("sample", strconv.Itoa(i))},
+							expectedResponse:    expectedResponse(i, i+1),
+							expectedIngesters:   expectedIngesters,
+							shardByAllLabels:    shardByAllLabels,
+							shuffleShardEnabled: shuffleShardEnabled,
+						})
+					}
 				}
 			}
 		}
@@ -548,11 +576,13 @@ func TestDistributor_PushQuery(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ds, _, r := prepare(t, prepConfig{
-				numIngesters:     tc.numIngesters,
-				happyIngesters:   tc.happyIngesters,
-				numDistributors:  1,
-				shardByAllLabels: tc.shardByAllLabels,
+			ds, ingesters, r := prepare(t, prepConfig{
+				numIngesters:        tc.numIngesters,
+				happyIngesters:      tc.happyIngesters,
+				numDistributors:     1,
+				shardByAllLabels:    tc.shardByAllLabels,
+				shuffleShardEnabled: tc.shuffleShardEnabled,
+				shuffleShardSize:    shuffleShardSize,
 			})
 			defer stopAll(ds, r)
 
@@ -576,6 +606,15 @@ func TestDistributor_PushQuery(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedResponse.String(), response.String())
+
+			// Check how many ingesters have been queried.
+			// Due to the quorum the distributor could cancel the last request towards ingesters
+			// if all other ones are successful, so we're good either has been queried X or X-1
+			// ingesters.
+			if tc.expectedError == nil {
+				assert.Contains(t, []int{tc.expectedIngesters, tc.expectedIngesters - 1}, countMockIngestersCalls(ingesters, "Query"))
+				assert.Contains(t, []int{tc.expectedIngesters, tc.expectedIngesters - 1}, countMockIngestersCalls(ingesters, "QueryStream"))
+			}
 		})
 	}
 }
@@ -808,6 +847,8 @@ func TestSlowQueries(t *testing.T) {
 }
 
 func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
+	const numIngesters = 5
+
 	fixtures := []struct {
 		lbls      labels.Labels
 		value     float64
@@ -822,96 +863,169 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		matchers []*labels.Matcher
-		expected []metric.Metric
+		shuffleShardEnabled bool
+		shuffleShardSize    int
+		matchers            []*labels.Matcher
+		expectedResult      []metric.Metric
+		expectedIngesters   int
 	}{
 		"should return an empty response if no metric match": {
 			matchers: []*labels.Matcher{
 				mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "unknown"),
 			},
-			expected: []metric.Metric{},
+			expectedResult:    []metric.Metric{},
+			expectedIngesters: numIngesters,
 		},
 		"should filter metrics by single matcher": {
 			matchers: []*labels.Matcher{
 				mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test_1"),
 			},
-			expected: []metric.Metric{
+			expectedResult: []metric.Metric{
 				{Metric: util.LabelsToMetric(fixtures[0].lbls)},
 				{Metric: util.LabelsToMetric(fixtures[1].lbls)},
 			},
+			expectedIngesters: numIngesters,
 		},
 		"should filter metrics by multiple matchers": {
 			matchers: []*labels.Matcher{
 				mustNewMatcher(labels.MatchEqual, "status", "200"),
 				mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test_1"),
 			},
-			expected: []metric.Metric{
+			expectedResult: []metric.Metric{
 				{Metric: util.LabelsToMetric(fixtures[0].lbls)},
 			},
+			expectedIngesters: numIngesters,
 		},
 		"should return all matching metrics even if their FastFingerprint collide": {
 			matchers: []*labels.Matcher{
 				mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "fast_fingerprint_collision"),
 			},
-			expected: []metric.Metric{
+			expectedResult: []metric.Metric{
 				{Metric: util.LabelsToMetric(fixtures[3].lbls)},
 				{Metric: util.LabelsToMetric(fixtures[4].lbls)},
 			},
+			expectedIngesters: numIngesters,
+		},
+		"should query only ingesters belonging to tenant's subring if shuffle sharding is enabled": {
+			shuffleShardEnabled: true,
+			shuffleShardSize:    3,
+			matchers: []*labels.Matcher{
+				mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test_1"),
+			},
+			expectedResult: []metric.Metric{
+				{Metric: util.LabelsToMetric(fixtures[0].lbls)},
+				{Metric: util.LabelsToMetric(fixtures[1].lbls)},
+			},
+			expectedIngesters: 3,
+		},
+		"should query all ingesters if shuffle sharding is enabled but shard size is 0": {
+			shuffleShardEnabled: true,
+			shuffleShardSize:    0,
+			matchers: []*labels.Matcher{
+				mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test_1"),
+			},
+			expectedResult: []metric.Metric{
+				{Metric: util.LabelsToMetric(fixtures[0].lbls)},
+				{Metric: util.LabelsToMetric(fixtures[1].lbls)},
+			},
+			expectedIngesters: numIngesters,
 		},
 	}
 
-	// Create distributor
-	ds, _, r := prepare(t, prepConfig{
-		numIngesters:     3,
-		happyIngesters:   3,
-		numDistributors:  1,
-		shardByAllLabels: true,
-	})
-	defer stopAll(ds, r)
-
-	// Push fixtures
-	ctx := user.InjectOrgID(context.Background(), "test")
-
-	for _, series := range fixtures {
-		req := mockWriteRequest(series.lbls, series.value, series.timestamp)
-		_, err := ds[0].Push(ctx, req)
-		require.NoError(t, err)
-	}
-
-	// Run tests
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			now := model.Now()
 
+			// Create distributor
+			ds, ingesters, r := prepare(t, prepConfig{
+				numIngesters:        numIngesters,
+				happyIngesters:      numIngesters,
+				numDistributors:     1,
+				shardByAllLabels:    true,
+				shuffleShardEnabled: testData.shuffleShardEnabled,
+				shuffleShardSize:    testData.shuffleShardSize,
+			})
+			defer stopAll(ds, r)
+
+			// Push fixtures
+			ctx := user.InjectOrgID(context.Background(), "test")
+
+			for _, series := range fixtures {
+				req := mockWriteRequest(series.lbls, series.value, series.timestamp)
+				_, err := ds[0].Push(ctx, req)
+				require.NoError(t, err)
+			}
+
 			metrics, err := ds[0].MetricsForLabelMatchers(ctx, now, now, testData.matchers...)
 			require.NoError(t, err)
-			assert.ElementsMatch(t, testData.expected, metrics)
+			assert.ElementsMatch(t, testData.expectedResult, metrics)
+
+			// Check how many ingesters have been queried.
+			// Due to the quorum the distributor could cancel the last request towards ingesters
+			// if all other ones are successful, so we're good either has been queried X or X-1
+			// ingesters.
+			assert.Contains(t, []int{testData.expectedIngesters, testData.expectedIngesters - 1}, countMockIngestersCalls(ingesters, "MetricsForLabelMatchers"))
 		})
 	}
 }
 
 func TestDistributor_MetricsMetadata(t *testing.T) {
-	// Create distributor
-	ds, _, r := prepare(t, prepConfig{
-		numIngesters:     3,
-		happyIngesters:   3,
-		numDistributors:  1,
-		shardByAllLabels: true,
-		limits:           nil,
-	})
-	defer stopAll(ds, r)
+	const numIngesters = 5
 
-	// Push metadata
-	ctx := user.InjectOrgID(context.Background(), "test")
+	tests := map[string]struct {
+		shuffleShardEnabled bool
+		shuffleShardSize    int
+		expectedIngesters   int
+	}{
+		"should query all ingesters if shuffle sharding is disabled": {
+			shuffleShardEnabled: false,
+			expectedIngesters:   numIngesters,
+		},
+		"should query all ingesters if shuffle sharding is enabled but shard size is 0": {
+			shuffleShardEnabled: true,
+			shuffleShardSize:    0,
+			expectedIngesters:   numIngesters,
+		},
+		"should query only ingesters belonging to tenant's subring if shuffle sharding is enabled": {
+			shuffleShardEnabled: true,
+			shuffleShardSize:    3,
+			expectedIngesters:   3,
+		},
+	}
 
-	req := makeWriteRequest(0, 0, 10)
-	_, err := ds[0].Push(ctx, req)
-	require.NoError(t, err)
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			// Create distributor
+			ds, ingesters, r := prepare(t, prepConfig{
+				numIngesters:        numIngesters,
+				happyIngesters:      numIngesters,
+				numDistributors:     1,
+				shardByAllLabels:    true,
+				shuffleShardEnabled: testData.shuffleShardEnabled,
+				shuffleShardSize:    testData.shuffleShardSize,
+				limits:              nil,
+			})
+			defer stopAll(ds, r)
 
-	// Asert on metric metadata
-	metadata, err := ds[0].MetricsMetadata(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, 10, len(metadata))
+			// Push metadata
+			ctx := user.InjectOrgID(context.Background(), "test")
+
+			req := makeWriteRequest(0, 0, 10)
+			_, err := ds[0].Push(ctx, req)
+			require.NoError(t, err)
+
+			// Assert on metric metadata
+			metadata, err := ds[0].MetricsMetadata(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, 10, len(metadata))
+
+			// Check how many ingesters have been queried.
+			// Due to the quorum the distributor could cancel the last request towards ingesters
+			// if all other ones are successful, so we're good either has been queried X or X-1
+			// ingesters.
+			assert.Contains(t, []int{testData.expectedIngesters, testData.expectedIngesters - 1}, countMockIngestersCalls(ingesters, "MetricsMetadata"))
+		})
+	}
 }
 
 func mustNewMatcher(t labels.MatchType, n, v string) *labels.Matcher {
@@ -938,6 +1052,8 @@ type prepConfig struct {
 	numIngesters, happyIngesters int
 	queryDelay                   time.Duration
 	shardByAllLabels             bool
+	shuffleShardEnabled          bool
+	shuffleShardSize             int
 	limits                       *validation.Limits
 	numDistributors              int
 }
@@ -966,7 +1082,7 @@ func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, *rin
 			Zone:                "",
 			State:               ring.ACTIVE,
 			Timestamp:           time.Now().Unix(),
-			RegisteredTimestamp: time.Now().Unix(),
+			RegisteredTimestamp: time.Now().Add(-2 * time.Hour).Unix(),
 			Tokens:              []uint32{uint32((math.MaxUint32 / cfg.numIngesters) * i)},
 		}
 		ingestersByAddr[addr] = &ingesters[i]
@@ -1002,6 +1118,11 @@ func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, *rin
 
 	distributors := make([]*Distributor, 0, cfg.numDistributors)
 	for i := 0; i < cfg.numDistributors; i++ {
+		if cfg.limits == nil {
+			cfg.limits = &validation.Limits{}
+			flagext.DefaultValues(cfg.limits)
+		}
+
 		var distributorCfg Config
 		var clientConfig client.Config
 		flagext.DefaultValues(&distributorCfg, &clientConfig)
@@ -1014,10 +1135,13 @@ func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, *rin
 		distributorCfg.DistributorRing.KVStore.Mock = kvStore
 		distributorCfg.DistributorRing.InstanceAddr = "127.0.0.1"
 
-		if cfg.limits == nil {
-			cfg.limits = &validation.Limits{}
-			flagext.DefaultValues(cfg.limits)
+		if cfg.shuffleShardEnabled {
+			distributorCfg.ShardingStrategy = ShardingStrategyShuffle
+			distributorCfg.ShuffleShardingLookbackPeriod = time.Hour
+
+			cfg.limits.IngestionTenantShardSize = cfg.shuffleShardSize
 		}
+
 		overrides, err := validation.NewOverrides(*cfg.limits, nil)
 		require.NoError(t, err)
 
@@ -1143,6 +1267,7 @@ type mockIngester struct {
 	timeseries map[uint32]*client.PreallocTimeseries
 	metadata   map[uint32]map[client.MetricMetadata]struct{}
 	queryDelay time.Duration
+	calls      map[string]int
 }
 
 func (i *mockIngester) series() map[uint32]*client.PreallocTimeseries {
@@ -1157,6 +1282,8 @@ func (i *mockIngester) series() map[uint32]*client.PreallocTimeseries {
 }
 
 func (i *mockIngester) Check(ctx context.Context, in *grpc_health_v1.HealthCheckRequest, opts ...grpc.CallOption) (*grpc_health_v1.HealthCheckResponse, error) {
+	i.trackCall("Check")
+
 	return &grpc_health_v1.HealthCheckResponse{}, nil
 }
 
@@ -1167,6 +1294,8 @@ func (i *mockIngester) Close() error {
 func (i *mockIngester) Push(ctx context.Context, req *client.WriteRequest, opts ...grpc.CallOption) (*client.WriteResponse, error) {
 	i.Lock()
 	defer i.Unlock()
+
+	i.trackCall("Push")
 
 	if !i.happy {
 		return nil, errFail
@@ -1220,8 +1349,11 @@ func (i *mockIngester) Push(ctx context.Context, req *client.WriteRequest, opts 
 
 func (i *mockIngester) Query(ctx context.Context, req *client.QueryRequest, opts ...grpc.CallOption) (*client.QueryResponse, error) {
 	time.Sleep(i.queryDelay)
+
 	i.Lock()
 	defer i.Unlock()
+
+	i.trackCall("Query")
 
 	if !i.happy {
 		return nil, errFail
@@ -1243,8 +1375,11 @@ func (i *mockIngester) Query(ctx context.Context, req *client.QueryRequest, opts
 
 func (i *mockIngester) QueryStream(ctx context.Context, req *client.QueryRequest, opts ...grpc.CallOption) (client.Ingester_QueryStreamClient, error) {
 	time.Sleep(i.queryDelay)
+
 	i.Lock()
 	defer i.Unlock()
+
+	i.trackCall("QueryStream")
 
 	if !i.happy {
 		return nil, errFail
@@ -1308,6 +1443,8 @@ func (i *mockIngester) MetricsForLabelMatchers(ctx context.Context, req *client.
 	i.Lock()
 	defer i.Unlock()
 
+	i.trackCall("MetricsForLabelMatchers")
+
 	if !i.happy {
 		return nil, errFail
 	}
@@ -1332,6 +1469,8 @@ func (i *mockIngester) MetricsMetadata(ctx context.Context, req *client.MetricsM
 	i.Lock()
 	defer i.Unlock()
 
+	i.trackCall("MetricsMetadata")
+
 	if !i.happy {
 		return nil, errFail
 	}
@@ -1344,6 +1483,21 @@ func (i *mockIngester) MetricsMetadata(ctx context.Context, req *client.MetricsM
 	}
 
 	return resp, nil
+}
+
+func (i *mockIngester) trackCall(name string) {
+	if i.calls == nil {
+		i.calls = map[string]int{}
+	}
+
+	i.calls[name]++
+}
+
+func (i *mockIngester) countCalls(name string) int {
+	i.Lock()
+	defer i.Unlock()
+
+	return i.calls[name]
 }
 
 type stream struct {
@@ -1564,4 +1718,14 @@ func TestSortLabels(t *testing.T) {
 	sort.SliceIsSorted(unsorted, func(i, j int) bool {
 		return strings.Compare(unsorted[i].Name, unsorted[j].Name) < 0
 	})
+}
+
+func countMockIngestersCalls(ingesters []mockIngester, name string) int {
+	count := 0
+	for _, ing := range ingesters {
+		if ing.countCalls(name) > 0 {
+			count++
+		}
+	}
+	return count
 }

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -3,6 +3,7 @@ package distributor
 import (
 	"context"
 	"io"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
@@ -87,7 +88,7 @@ func (d *Distributor) getIngestersForQuery(ctx context.Context, matchers ...*lab
 		lookbackPeriod := d.cfg.ShuffleShardingLookbackPeriod
 
 		if shardSize > 0 && lookbackPeriod > 0 {
-			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod).GetAll(ring.Read)
+			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now()).GetAll(ring.Read)
 		}
 	}
 
@@ -115,7 +116,7 @@ func (d *Distributor) getIngestersForMetadata(ctx context.Context) (ring.Replica
 		lookbackPeriod := d.cfg.ShuffleShardingLookbackPeriod
 
 		if shardSize > 0 {
-			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod).GetAll(ring.Read)
+			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now()).GetAll(ring.Read)
 		}
 	}
 

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -115,7 +115,7 @@ func (d *Distributor) getIngestersForMetadata(ctx context.Context) (ring.Replica
 		shardSize := d.limits.IngestionTenantShardSize(userID)
 		lookbackPeriod := d.cfg.ShuffleShardingLookbackPeriod
 
-		if shardSize > 0 {
+		if shardSize > 0 && lookbackPeriod > 0 {
 			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now()).GetAll(ring.Read)
 		}
 	}

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -93,9 +93,12 @@ func (d *Distributor) getIngestersForQuery(ctx context.Context, matchers ...*lab
 	}
 
 	// If "shard by all labels" is disabled, we can get ingesters by metricName if exists.
-	metricNameMatcher, _, ok := extract.MetricNameMatcherFromMatchers(matchers)
-	if !d.cfg.ShardByAllLabels && ok && metricNameMatcher.Type == labels.MatchEqual {
-		return d.ingestersRing.Get(shardByMetricName(userID, metricNameMatcher.Value), ring.Read, nil)
+	if !d.cfg.ShardByAllLabels {
+		metricNameMatcher, _, ok := extract.MetricNameMatcherFromMatchers(matchers)
+
+		if ok && metricNameMatcher.Type == labels.MatchEqual {
+			return d.ingestersRing.Get(shardByMetricName(userID, metricNameMatcher.Value), ring.Read, nil)
+		}
 	}
 
 	return d.ingestersRing.GetAll(ring.Read)

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -91,7 +91,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.LookbackDelta, "querier.lookback-delta", 5*time.Minute, "Time since the last sample after which a time series is considered stale and ignored by expression evaluations.")
 	f.StringVar(&cfg.SecondStoreEngine, "querier.second-store-engine", "", "Second store engine to use for querying. Empty = disabled.")
 	f.Var(&cfg.UseSecondStoreBeforeTime, "querier.use-second-store-before-time", "If specified, second store is only used for queries before this timestamp. Default value 0 means secondary store is always queried.")
-	f.DurationVar(&cfg.ShuffleShardingIngestersLookbackPeriod, "querier.shuffle-sharding-ingesters-lookback-period", 0, "When distributor's sharding strategy is shuffle-sharding and this setting is > 0, queriers fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. If this setting is 0, queriers always query all ingesters (ingesters shuffle sharding on read path is disabled).")
+	f.DurationVar(&cfg.ShuffleShardingIngestersLookbackPeriod, "querier.shuffle-sharding-ingesters-lookback-period", 0, "When distributor's sharding strategy is shuffle-sharding and this setting is > 0, queriers fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. The lookback period should be greater or equal than the configured 'query store after'. If this setting is 0, queriers always query all ingesters (ingesters shuffle sharding on read path is disabled).")
 }
 
 // Validate the config

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -64,6 +64,8 @@ type Config struct {
 
 	SecondStoreEngine        string       `yaml:"second_store_engine"`
 	UseSecondStoreBeforeTime flagext.Time `yaml:"use_second_store_before_time"`
+
+	ShuffleShardingIngestersLookbackPeriod time.Duration `yaml:"shuffle_sharding_ingesters_lookback_period"`
 }
 
 var (
@@ -88,6 +90,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.LookbackDelta, "querier.lookback-delta", 5*time.Minute, "Time since the last sample after which a time series is considered stale and ignored by expression evaluations.")
 	f.StringVar(&cfg.SecondStoreEngine, "querier.second-store-engine", "", "Second store engine to use for querying. Empty = disabled.")
 	f.Var(&cfg.UseSecondStoreBeforeTime, "querier.use-second-store-before-time", "If specified, second store is only used for queries before this timestamp. Default value 0 means secondary store is always queried.")
+	f.DurationVar(&cfg.ShuffleShardingIngestersLookbackPeriod, "querier.shuffle-sharding-ingesters-lookback-period", 0, "When distributor's sharding strategy is shuffle-sharding and this setting is > 0, queriers fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. If this setting is 0, queriers always query all ingesters.")
 }
 
 // Validate the config

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -69,7 +69,8 @@ type Config struct {
 }
 
 var (
-	errBadLookbackConfigs = errors.New("bad settings, query_store_after >= query_ingesters_within which can result in queries not being sent")
+	errBadLookbackConfigs                             = errors.New("bad settings, query_store_after >= query_ingesters_within which can result in queries not being sent")
+	errShuffleShardingLookbackLessThanQueryStoreAfter = errors.New("the shuffle-sharding lookback period should be greater or equal than the configured 'query store after'")
 )
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -90,16 +91,21 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.LookbackDelta, "querier.lookback-delta", 5*time.Minute, "Time since the last sample after which a time series is considered stale and ignored by expression evaluations.")
 	f.StringVar(&cfg.SecondStoreEngine, "querier.second-store-engine", "", "Second store engine to use for querying. Empty = disabled.")
 	f.Var(&cfg.UseSecondStoreBeforeTime, "querier.use-second-store-before-time", "If specified, second store is only used for queries before this timestamp. Default value 0 means secondary store is always queried.")
-	f.DurationVar(&cfg.ShuffleShardingIngestersLookbackPeriod, "querier.shuffle-sharding-ingesters-lookback-period", 0, "When distributor's sharding strategy is shuffle-sharding and this setting is > 0, queriers fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. If this setting is 0, queriers always query all ingesters.")
+	f.DurationVar(&cfg.ShuffleShardingIngestersLookbackPeriod, "querier.shuffle-sharding-ingesters-lookback-period", 0, "When distributor's sharding strategy is shuffle-sharding and this setting is > 0, queriers fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. If this setting is 0, queriers always query all ingesters (ingesters shuffle sharding on read path is disabled).")
 }
 
 // Validate the config
 func (cfg *Config) Validate() error {
-
 	// Ensure the config wont create a situation where no queriers are returned.
 	if cfg.QueryIngestersWithin != 0 && cfg.QueryStoreAfter != 0 {
 		if cfg.QueryStoreAfter >= cfg.QueryIngestersWithin {
 			return errBadLookbackConfigs
+		}
+	}
+
+	if cfg.ShuffleShardingIngestersLookbackPeriod > 0 {
+		if cfg.ShuffleShardingIngestersLookbackPeriod < cfg.QueryStoreAfter {
+			return errShuffleShardingLookbackLessThanQueryStoreAfter
 		}
 	}
 

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -25,18 +25,6 @@ func (ts ByAddr) Len() int           { return len(ts) }
 func (ts ByAddr) Swap(i, j int)      { ts[i], ts[j] = ts[j], ts[i] }
 func (ts ByAddr) Less(i, j int) bool { return ts[i].Addr < ts[j].Addr }
 
-// ByZoneAndAddr is a sortable list of IngesterDesc.
-type ByZoneAddr []IngesterDesc
-
-func (ts ByZoneAddr) Len() int      { return len(ts) }
-func (ts ByZoneAddr) Swap(i, j int) { ts[i], ts[j] = ts[j], ts[i] }
-func (ts ByZoneAddr) Less(i, j int) bool {
-	if ts[i].Zone != ts[j].Zone {
-		return ts[i].Zone < ts[j].Zone
-	}
-	return ts[i].Addr < ts[j].Addr
-}
-
 // ProtoDescFactory makes new Descs
 func ProtoDescFactory() proto.Message {
 	return NewDesc()

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -25,6 +25,18 @@ func (ts ByAddr) Len() int           { return len(ts) }
 func (ts ByAddr) Swap(i, j int)      { ts[i], ts[j] = ts[j], ts[i] }
 func (ts ByAddr) Less(i, j int) bool { return ts[i].Addr < ts[j].Addr }
 
+// ByZoneAndAddr is a sortable list of IngesterDesc.
+type ByZoneAddr []IngesterDesc
+
+func (ts ByZoneAddr) Len() int      { return len(ts) }
+func (ts ByZoneAddr) Swap(i, j int) { ts[i], ts[j] = ts[j], ts[i] }
+func (ts ByZoneAddr) Less(i, j int) bool {
+	if ts[i].Zone != ts[j].Zone {
+		return ts[i].Zone < ts[j].Zone
+	}
+	return ts[i].Addr < ts[j].Addr
+}
+
 // ProtoDescFactory makes new Descs
 func ProtoDescFactory() proto.Message {
 	return NewDesc()

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -85,6 +85,15 @@ func (r ReplicationSet) Includes(addr string) bool {
 	return false
 }
 
+// GetAddresses returns the addresses of all instances within the replication set.
+func (r ReplicationSet) GetAddresses() []string {
+	addrs := make([]string, 0, len(r.Ingesters))
+	for _, desc := range r.Ingesters {
+		addrs = append(addrs, desc.Addr)
+	}
+	return addrs
+}
+
 // HasReplicationSetChanged returns true if two replications sets are the same (with possibly different timestamps),
 // false if they differ in any way (number of instances, instance states, tokens, zones, ...).
 func HasReplicationSetChanged(before, after ReplicationSet) bool {

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -85,7 +85,8 @@ func (r ReplicationSet) Includes(addr string) bool {
 	return false
 }
 
-// GetAddresses returns the addresses of all instances within the replication set.
+// GetAddresses returns the addresses of all instances within the replication set. Returned slice
+// order is not guaranteed.
 func (r ReplicationSet) GetAddresses() []string {
 	addrs := make([]string, 0, len(r.Ingesters))
 	for _, desc := range r.Ingesters {

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -1,0 +1,35 @@
+package ring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplicationSet_GetAddresses(t *testing.T) {
+	tests := map[string]struct {
+		rs       ReplicationSet
+		expected []string
+	}{
+		"should return an empty slice on empty replication set": {
+			rs:       ReplicationSet{},
+			expected: []string{},
+		},
+		"should return instances addresses (no order guaranteed)": {
+			rs: ReplicationSet{
+				Ingesters: []IngesterDesc{
+					{Addr: "127.0.0.1"},
+					{Addr: "127.0.0.2"},
+					{Addr: "127.0.0.3"},
+				},
+			},
+			expected: []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assert.ElementsMatch(t, testData.expected, testData.rs.GetAddresses())
+		})
+	}
+}

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -477,7 +477,7 @@ func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
 
 	result := r.shuffleShard(identifier, size, 0, time.Now())
 
-	r.setCachedShuffledSubring(identifier, size, result.(*Ring))
+	r.setCachedShuffledSubring(identifier, size, result)
 	return result
 }
 
@@ -497,10 +497,8 @@ func (r *Ring) ShuffleShardWithLookback(identifier string, size int, lookbackPer
 	return r.shuffleShard(identifier, size, lookbackPeriod, now)
 }
 
-func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Duration, now time.Time) ReadRing {
+func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Duration, now time.Time) *Ring {
 	lookbackUntil := now.Add(-lookbackPeriod).Unix()
-
-	var result *Ring
 
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
@@ -585,7 +583,7 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 	shardDesc := &Desc{Ingesters: shard}
 	shardTokensByZone := shardDesc.getTokensByZone()
 
-	result = &Ring{
+	return &Ring{
 		cfg:              r.cfg,
 		strategy:         r.strategy,
 		ringDesc:         shardDesc,
@@ -596,8 +594,6 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 		// For caching to work, remember these values.
 		lastTopologyChange: r.lastTopologyChange,
 	}
-
-	return result
 }
 
 // GetInstanceState returns the current state of an instance or an error if the

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -905,7 +905,9 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3"}},
 				// Scale up.
 				{what: add, instanceID: "instance-7", instanceDesc: generateRingInstanceWithInfo("instance-7", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now)},
+				{what: test, shardSize: 3, expected: []string{"instance-7", "instance-2", "instance-3" /* lookback: */, "instance-1"}},
 				{what: add, instanceID: "instance-8", instanceDesc: generateRingInstanceWithInfo("instance-8", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 1}, now)},
+				{what: test, shardSize: 3, expected: []string{"instance-7", "instance-8", "instance-3" /* lookback: */, "instance-1", "instance-2"}},
 				{what: add, instanceID: "instance-9", instanceDesc: generateRingInstanceWithInfo("instance-9", "zone-c", []uint32{userToken(userID, "zone-c", 2) + 1}, now)},
 				{what: test, shardSize: 3, expected: []string{"instance-7", "instance-8", "instance-9" /* lookback: */, "instance-1", "instance-2", "instance-3"}},
 			},
@@ -924,7 +926,9 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3"}},
 				// Scale down.
 				{what: remove, instanceID: "instance-1"},
+				{what: test, shardSize: 3, expected: []string{"instance-7", "instance-2", "instance-3"}},
 				{what: remove, instanceID: "instance-2"},
+				{what: test, shardSize: 3, expected: []string{"instance-7", "instance-8", "instance-3"}},
 				{what: remove, instanceID: "instance-3"},
 				{what: test, shardSize: 3, expected: []string{"instance-7", "instance-8", "instance-9"}},
 			},

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -790,29 +790,29 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 	}{
 		"single zone, shard size = 1, recently bootstrapped cluster": {
 			timeline: []event{
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-time.Minute))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now.Add(-time.Minute))},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, "zone-a", 2) + 1}, now.Add(-time.Minute))},
 				{what: test, shardSize: 1, expected: []string{"instance-1", "instance-2", "instance-3"}},
 			},
 		},
 		"single zone, shard size = 1, instances scale up": {
 			timeline: []event{
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 3}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, "zone-a", 2) + 1}, now.Add(-2*lookbackPeriod))},
 				{what: test, shardSize: 1, expected: []string{"instance-1"}},
-				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 0) + 2}, now.Add(-10*time.Minute))},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 2}, now.Add(-10*time.Minute))},
 				{what: test, shardSize: 1, expected: []string{"instance-4" /* lookback: */, "instance-1"}},
-				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-5*time.Minute))},
+				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-5*time.Minute))},
 				{what: test, shardSize: 1, expected: []string{"instance-5" /* lookback: */, "instance-4", "instance-1"}},
 			},
 		},
 		"single zone, shard size = 1, instances scale down": {
 			timeline: []event{
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, "zone-a", 2) + 1}, now.Add(-2*lookbackPeriod))},
 				{what: test, shardSize: 1, expected: []string{"instance-1"}},
 				{what: remove, instanceID: "instance-3"},
 				{what: test, shardSize: 1, expected: []string{"instance-1"}},
@@ -822,61 +822,61 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 		},
 		"single zone, shard size = 1, rollout with instances unregistered (removed and re-added one by one)": {
 			timeline: []event{
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, "zone-a", 2) + 1}, now.Add(-2*lookbackPeriod))},
 				{what: test, shardSize: 1, expected: []string{"instance-1"}},
 				// Rollout instance-3.
 				{what: remove, instanceID: "instance-3"},
 				{what: test, shardSize: 1, expected: []string{"instance-1"}},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now)},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, "zone-a", 2) + 1}, now)},
 				{what: test, shardSize: 1, expected: []string{"instance-1"}},
 				// Rollout instance-2.
 				{what: remove, instanceID: "instance-2"},
 				{what: test, shardSize: 1, expected: []string{"instance-1"}},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now)},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now)},
 				{what: test, shardSize: 1, expected: []string{"instance-1"}},
 				// Rollout instance-1.
 				{what: remove, instanceID: "instance-1"},
 				{what: test, shardSize: 1, expected: []string{"instance-2" /* side effect: */, "instance-3"}},
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now)},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now)},
 				{what: test, shardSize: 1, expected: []string{"instance-1" /* lookback: */, "instance-2" /* side effect: */, "instance-3"}},
 			},
 		},
 		"single zone, shard size = 2, rollout with instances unregistered (removed and re-added one by one)": {
 			timeline: []event{
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 3) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, "zone-a", 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, "zone-a", 3) + 1}, now.Add(-2*lookbackPeriod))},
 				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2"}},
 				// Rollout instance-4.
 				{what: remove, instanceID: "instance-4"},
 				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2"}},
-				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 3) + 1}, now)},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, "zone-a", 3) + 1}, now)},
 				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2"}},
 				// Rollout instance-3.
 				{what: remove, instanceID: "instance-3"},
 				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2"}},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now)},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, "zone-a", 2) + 1}, now)},
 				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2"}},
 				// Rollout instance-2.
 				{what: remove, instanceID: "instance-2"},
 				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-3" /* side effect:*/, "instance-4"}},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now)},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now)},
 				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2" /* lookback: */, "instance-3" /* side effect:*/, "instance-4"}},
 				// Rollout instance-1.
 				{what: remove, instanceID: "instance-1"},
 				{what: test, shardSize: 2, expected: []string{"instance-2" /* lookback: */, "instance-3" /* side effect:*/, "instance-4"}},
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now)},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now)},
 				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2" /* lookback: */, "instance-3" /* side effect:*/, "instance-4"}},
 			},
 		},
 		"single zone, increase shard size": {
 			timeline: []event{
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, "zone-a", 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, "zone-a", 2) + 1}, now.Add(-2*lookbackPeriod))},
 				{what: test, shardSize: 1, expected: []string{"instance-1"}},
 				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2"}},
 				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3"}},
@@ -885,42 +885,42 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 		},
 		"multi zone, shard size = 3, recently bootstrapped cluster": {
 			timeline: []event{
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-time.Minute))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, 1) + 1}, now.Add(-time.Minute))},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-c", []uint32{userToken(userID, 2) + 1}, now.Add(-time.Minute))},
-				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 3) + 1}, now.Add(-time.Minute))},
-				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-b", []uint32{userToken(userID, 4) + 1}, now.Add(-time.Minute))},
-				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, 5) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-c", []uint32{userToken(userID, "zone-c", 2) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, "zone-a", 3) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-b", []uint32{userToken(userID, "zone-b", 4) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, "zone-c", 5) + 1}, now.Add(-time.Minute))},
 				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3", "instance-4", "instance-5", "instance-6"}},
 			},
 		},
 		"multi zone, shard size = 3, instances scale up": {
 			timeline: []event{
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 2}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, 1) + 2}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-c", []uint32{userToken(userID, 2) + 2}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 0) + 3}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-b", []uint32{userToken(userID, 1) + 3}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, 2) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-c", []uint32{userToken(userID, "zone-c", 2) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, "zone-c", 2) + 3}, now.Add(-2*lookbackPeriod))},
 				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3"}},
 				// Scale up.
-				{what: add, instanceID: "instance-7", instanceDesc: generateRingInstanceWithInfo("instance-7", "zone-a", []uint32{userToken(userID, 0) + 1}, now)},
-				{what: add, instanceID: "instance-8", instanceDesc: generateRingInstanceWithInfo("instance-8", "zone-b", []uint32{userToken(userID, 1) + 1}, now)},
-				{what: add, instanceID: "instance-9", instanceDesc: generateRingInstanceWithInfo("instance-9", "zone-c", []uint32{userToken(userID, 2) + 1}, now)},
+				{what: add, instanceID: "instance-7", instanceDesc: generateRingInstanceWithInfo("instance-7", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now)},
+				{what: add, instanceID: "instance-8", instanceDesc: generateRingInstanceWithInfo("instance-8", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 1}, now)},
+				{what: add, instanceID: "instance-9", instanceDesc: generateRingInstanceWithInfo("instance-9", "zone-c", []uint32{userToken(userID, "zone-c", 2) + 1}, now)},
 				{what: test, shardSize: 3, expected: []string{"instance-7", "instance-8", "instance-9" /* lookback: */, "instance-1", "instance-2", "instance-3"}},
 			},
 		},
 		"multi zone, shard size = 3, instances scale down": {
 			timeline: []event{
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-c", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 0) + 3}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-b", []uint32{userToken(userID, 1) + 3}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, 2) + 3}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-7", instanceDesc: generateRingInstanceWithInfo("instance-7", "zone-a", []uint32{userToken(userID, 0) + 2}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-8", instanceDesc: generateRingInstanceWithInfo("instance-8", "zone-b", []uint32{userToken(userID, 1) + 2}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-9", instanceDesc: generateRingInstanceWithInfo("instance-9", "zone-c", []uint32{userToken(userID, 2) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-c", []uint32{userToken(userID, "zone-c", 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, "zone-c", 2) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-7", instanceDesc: generateRingInstanceWithInfo("instance-7", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-8", instanceDesc: generateRingInstanceWithInfo("instance-8", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-9", instanceDesc: generateRingInstanceWithInfo("instance-9", "zone-c", []uint32{userToken(userID, "zone-c", 2) + 2}, now.Add(-2*lookbackPeriod))},
 				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3"}},
 				// Scale down.
 				{what: remove, instanceID: "instance-1"},
@@ -931,15 +931,15 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 		},
 		"multi zone, increase shard size": {
 			timeline: []event{
-				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-c", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 0) + 3}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-b", []uint32{userToken(userID, 1) + 3}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, 2) + 3}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-7", instanceDesc: generateRingInstanceWithInfo("instance-7", "zone-a", []uint32{userToken(userID, 0) + 2}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-8", instanceDesc: generateRingInstanceWithInfo("instance-8", "zone-b", []uint32{userToken(userID, 1) + 2}, now.Add(-2*lookbackPeriod))},
-				{what: add, instanceID: "instance-9", instanceDesc: generateRingInstanceWithInfo("instance-9", "zone-c", []uint32{userToken(userID, 2) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-c", []uint32{userToken(userID, "zone-c", 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, "zone-c", 2) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-7", instanceDesc: generateRingInstanceWithInfo("instance-7", "zone-a", []uint32{userToken(userID, "zone-a", 0) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-8", instanceDesc: generateRingInstanceWithInfo("instance-8", "zone-b", []uint32{userToken(userID, "zone-b", 1) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-9", instanceDesc: generateRingInstanceWithInfo("instance-9", "zone-c", []uint32{userToken(userID, "zone-c", 2) + 2}, now.Add(-2*lookbackPeriod))},
 				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3"}},
 				{what: test, shardSize: 6, expected: []string{"instance-1", "instance-2", "instance-3", "instance-7", "instance-8", "instance-9"}},
 			},
@@ -1121,168 +1121,6 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 				}
 			})
 		}
-	}
-}
-
-func TestRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
-	// Create 30 instances in 3 zones.
-	ringInstances := map[string]IngesterDesc{}
-	for i := 0; i < 30; i++ {
-		name, desc := generateRingInstance(i, i%3)
-		ringInstances[name] = desc
-	}
-
-	// Init the ring description.
-	ringDesc := &Desc{Ingesters: ringInstances}
-	for id, instance := range ringDesc.Ingesters {
-		instance.Timestamp = time.Now().Unix()
-		instance.State = ACTIVE
-		ringDesc.Ingesters[id] = instance
-	}
-
-	ring := Ring{
-		cfg: Config{
-			HeartbeatTimeout:     time.Hour,
-			ZoneAwarenessEnabled: true,
-		},
-		ringDesc:         ringDesc,
-		ringTokens:       ringDesc.getTokens(),
-		ringTokensByZone: ringDesc.getTokensByZone(),
-		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         &DefaultReplicationStrategy{},
-	}
-
-	// Get the replication set with shard size = 3.
-	firstShard := ring.ShuffleShard("tenant-id", 3)
-	assert.Equal(t, 3, firstShard.IngesterCount())
-
-	firstSet, err := firstShard.GetAll(Read)
-	require.NoError(t, err)
-
-	// Increase shard size to 6.
-	secondShard := ring.ShuffleShard("tenant-id", 6)
-	assert.Equal(t, 6, secondShard.IngesterCount())
-
-	secondSet, err := secondShard.GetAll(Read)
-	require.NoError(t, err)
-
-	for _, firstInstance := range firstSet.Ingesters {
-		assert.True(t, secondSet.Includes(firstInstance.Addr), "new replication set is expected to include previous instance %s", firstInstance.Addr)
-	}
-
-	// Increase shard size to 9.
-	thirdShard := ring.ShuffleShard("tenant-id", 9)
-	assert.Equal(t, 9, thirdShard.IngesterCount())
-
-	thirdSet, err := thirdShard.GetAll(Read)
-	require.NoError(t, err)
-
-	for _, secondInstance := range secondSet.Ingesters {
-		assert.True(t, thirdSet.Includes(secondInstance.Addr), "new replication set is expected to include previous instance %s", secondInstance.Addr)
-	}
-
-	// Decrease shard size to 6.
-	fourthShard := ring.ShuffleShard("tenant-id", 6)
-	assert.Equal(t, 6, fourthShard.IngesterCount())
-
-	fourthSet, err := fourthShard.GetAll(Read)
-	require.NoError(t, err)
-
-	// We expect to have the same exact instances we had when the shard size was 6.
-	for _, secondInstance := range secondSet.Ingesters {
-		assert.True(t, fourthSet.Includes(secondInstance.Addr), "new replication set is expected to include previous instance %s", secondInstance.Addr)
-	}
-
-	// Decrease shard size to 3.
-	fifthShard := ring.ShuffleShard("tenant-id", 3)
-	assert.Equal(t, 3, fifthShard.IngesterCount())
-
-	fifthSet, err := fifthShard.GetAll(Read)
-	require.NoError(t, err)
-
-	// We expect to have the same exact instances we had when the shard size was 3.
-	for _, firstInstance := range firstSet.Ingesters {
-		assert.True(t, fifthSet.Includes(firstInstance.Addr), "new replication set is expected to include previous instance %s", firstInstance.Addr)
-	}
-}
-
-func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
-	// Create 20 instances in 2 zones.
-	ringInstances := map[string]IngesterDesc{}
-	for i := 0; i < 20; i++ {
-		name, desc := generateRingInstance(i, i%2)
-		ringInstances[name] = desc
-	}
-
-	// Init the ring description.
-	ringDesc := &Desc{Ingesters: ringInstances}
-	for id, instance := range ringDesc.Ingesters {
-		instance.Timestamp = time.Now().Unix()
-		instance.State = ACTIVE
-		ringDesc.Ingesters[id] = instance
-	}
-
-	ring := Ring{
-		cfg: Config{
-			HeartbeatTimeout:     time.Hour,
-			ZoneAwarenessEnabled: true,
-		},
-		ringDesc:         ringDesc,
-		ringTokens:       ringDesc.getTokens(),
-		ringTokensByZone: ringDesc.getTokensByZone(),
-		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         &DefaultReplicationStrategy{},
-	}
-
-	// Get the replication set with shard size = 2.
-	firstShard := ring.ShuffleShard("tenant-id", 2)
-	assert.Equal(t, 2, firstShard.IngesterCount())
-
-	firstSet, err := firstShard.GetAll(Read)
-	require.NoError(t, err)
-
-	// Increase shard size to 4.
-	secondShard := ring.ShuffleShard("tenant-id", 4)
-	assert.Equal(t, 4, secondShard.IngesterCount())
-
-	secondSet, err := secondShard.GetAll(Read)
-	require.NoError(t, err)
-
-	for _, firstInstance := range firstSet.Ingesters {
-		assert.True(t, secondSet.Includes(firstInstance.Addr), "new replication set is expected to include previous instance %s", firstInstance.Addr)
-	}
-
-	// Scale up cluster, adding 10 instances in 1 new zone.
-	for i := 20; i < 30; i++ {
-		name, desc := generateRingInstance(i, 2)
-		ringInstances[name] = desc
-	}
-
-	ring.ringDesc.Ingesters = ringInstances
-	ring.ringTokens = ringDesc.getTokens()
-	ring.ringTokensByZone = ringDesc.getTokensByZone()
-	ring.ringZones = getZones(ringDesc.getTokensByZone())
-
-	// Increase shard size to 6.
-	thirdShard := ring.ShuffleShard("tenant-id", 6)
-	assert.Equal(t, 6, thirdShard.IngesterCount())
-
-	thirdSet, err := thirdShard.GetAll(Read)
-	require.NoError(t, err)
-
-	for _, secondInstance := range secondSet.Ingesters {
-		assert.True(t, thirdSet.Includes(secondInstance.Addr), "new replication set is expected to include previous instance %s", secondInstance.Addr)
-	}
-
-	// Increase shard size to 9.
-	fourthShard := ring.ShuffleShard("tenant-id", 9)
-	assert.Equal(t, 9, fourthShard.IngesterCount())
-
-	fourthSet, err := fourthShard.GetAll(Read)
-	require.NoError(t, err)
-
-	for _, thirdInstance := range thirdSet.Ingesters {
-		assert.True(t, fourthSet.Includes(thirdInstance.Addr), "new replication set is expected to include previous instance %s", thirdInstance.Addr)
 	}
 }
 
@@ -1581,8 +1419,8 @@ func TestShuffleShardWithCaching(t *testing.T) {
 }
 
 // User shuffle shard token.
-func userToken(user string, skip int) uint32 {
-	r := rand.New(rand.NewSource(util.ShuffleShardSeed(user)))
+func userToken(user, zone string, skip int) uint32 {
+	r := rand.New(rand.NewSource(util.ShuffleShardSeed(user, zone)))
 
 	for ; skip > 0; skip-- {
 		_ = r.Uint32()

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"math/rand"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -759,6 +760,356 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 	}
 }
 
+func TestRing_ShuffleShardWithLookback(t *testing.T) {
+	type eventType int
+
+	const (
+		add eventType = iota
+		remove
+		test
+
+		lookbackPeriod = time.Hour
+		userID         = "user-1"
+	)
+
+	var (
+		now = time.Now()
+	)
+
+	type event struct {
+		what         eventType
+		instanceID   string
+		instanceDesc IngesterDesc
+		shardSize    int
+		expected     []string
+	}
+
+	tests := map[string]struct {
+		timeline []event
+	}{
+		"single zone, shard size = 1, recently bootstrapped cluster": {
+			timeline: []event{
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now.Add(-time.Minute))},
+				{what: test, shardSize: 1, expected: []string{"instance-1", "instance-2", "instance-3"}},
+			},
+		},
+		"single zone, shard size = 1, instances scale up": {
+			timeline: []event{
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: test, shardSize: 1, expected: []string{"instance-1"}},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 0) + 2}, now.Add(-10*time.Minute))},
+				{what: test, shardSize: 1, expected: []string{"instance-4" /* lookback: */, "instance-1"}},
+				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-5*time.Minute))},
+				{what: test, shardSize: 1, expected: []string{"instance-5" /* lookback: */, "instance-4", "instance-1"}},
+			},
+		},
+		"single zone, shard size = 1, instances scale down": {
+			timeline: []event{
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: test, shardSize: 1, expected: []string{"instance-1"}},
+				{what: remove, instanceID: "instance-3"},
+				{what: test, shardSize: 1, expected: []string{"instance-1"}},
+				{what: remove, instanceID: "instance-1"},
+				{what: test, shardSize: 1, expected: []string{"instance-2"}},
+			},
+		},
+		"single zone, shard size = 1, rollout with instances unregistered (removed and re-added one by one)": {
+			timeline: []event{
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: test, shardSize: 1, expected: []string{"instance-1"}},
+				// Rollout instance-3.
+				{what: remove, instanceID: "instance-3"},
+				{what: test, shardSize: 1, expected: []string{"instance-1"}},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now)},
+				{what: test, shardSize: 1, expected: []string{"instance-1"}},
+				// Rollout instance-2.
+				{what: remove, instanceID: "instance-2"},
+				{what: test, shardSize: 1, expected: []string{"instance-1"}},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now)},
+				{what: test, shardSize: 1, expected: []string{"instance-1"}},
+				// Rollout instance-1.
+				{what: remove, instanceID: "instance-1"},
+				{what: test, shardSize: 1, expected: []string{"instance-2", "instance-3"}}, // TODO instance-3 is a side effect (investigate better)
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now)},
+				{what: test, shardSize: 1, expected: []string{"instance-1" /* lookback: */, "instance-2", "instance-3"}},
+			},
+		},
+		"single zone, shard size = 2, rollout with instances unregistered (removed and re-added one by one)": {
+			timeline: []event{
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 3) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2"}},
+				// Rollout instance-4.
+				{what: remove, instanceID: "instance-4"},
+				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2"}},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 3) + 1}, now)},
+				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2"}},
+				// Rollout instance-3.
+				{what: remove, instanceID: "instance-3"},
+				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2"}},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now)},
+				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2"}},
+				// Rollout instance-2.
+				{what: remove, instanceID: "instance-2"},
+				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-3", "instance-4"}}, // TODO instance-4 is a side effect (investigate better)
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now)},
+				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2" /* lookback: */, "instance-3", "instance-4"}},
+				// Rollout instance-1.
+				{what: remove, instanceID: "instance-1"},
+				{what: test, shardSize: 2, expected: []string{"instance-2" /* lookback: */, "instance-3", "instance-4"}},
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now)},
+				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2" /* lookback: */, "instance-3", "instance-4"}},
+			},
+		},
+		"single zone, increase shard size": {
+			timeline: []event{
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-a", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-a", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: test, shardSize: 1, expected: []string{"instance-1"}},
+				{what: test, shardSize: 2, expected: []string{"instance-1", "instance-2"}},
+				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3"}},
+				{what: test, shardSize: 4, expected: []string{"instance-1", "instance-2", "instance-3"}},
+			},
+		},
+		"multi zone, shard size = 3, recently bootstrapped cluster": {
+			timeline: []event{
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, 1) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-c", []uint32{userToken(userID, 2) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 3) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-b", []uint32{userToken(userID, 4) + 1}, now.Add(-time.Minute))},
+				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, 5) + 1}, now.Add(-time.Minute))},
+				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3", "instance-4", "instance-5", "instance-6"}},
+			},
+		},
+		"multi zone, shard size = 3, instances scale up": {
+			timeline: []event{
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, 1) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-c", []uint32{userToken(userID, 2) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 0) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-b", []uint32{userToken(userID, 1) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, 2) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3"}},
+				// Scale up.
+				{what: add, instanceID: "instance-7", instanceDesc: generateRingInstanceWithInfo("instance-7", "zone-a", []uint32{userToken(userID, 0) + 1}, now)},
+				{what: add, instanceID: "instance-8", instanceDesc: generateRingInstanceWithInfo("instance-8", "zone-b", []uint32{userToken(userID, 1) + 1}, now)},
+				{what: add, instanceID: "instance-9", instanceDesc: generateRingInstanceWithInfo("instance-9", "zone-c", []uint32{userToken(userID, 2) + 1}, now)},
+				{what: test, shardSize: 3, expected: []string{"instance-7", "instance-8", "instance-9" /* lookback: */, "instance-1", "instance-2", "instance-3"}},
+			},
+		},
+		"multi zone, shard size = 3, instances scale down": {
+			timeline: []event{
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-c", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 0) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-b", []uint32{userToken(userID, 1) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, 2) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-7", instanceDesc: generateRingInstanceWithInfo("instance-7", "zone-a", []uint32{userToken(userID, 0) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-8", instanceDesc: generateRingInstanceWithInfo("instance-8", "zone-b", []uint32{userToken(userID, 1) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-9", instanceDesc: generateRingInstanceWithInfo("instance-9", "zone-c", []uint32{userToken(userID, 2) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3"}},
+				// Scale down.
+				{what: remove, instanceID: "instance-1"},
+				{what: remove, instanceID: "instance-2"},
+				{what: remove, instanceID: "instance-3"},
+				{what: test, shardSize: 3, expected: []string{"instance-7", "instance-8", "instance-9"}},
+			},
+		},
+		"multi zone, increase shard size": {
+			timeline: []event{
+				{what: add, instanceID: "instance-1", instanceDesc: generateRingInstanceWithInfo("instance-1", "zone-a", []uint32{userToken(userID, 0) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-2", instanceDesc: generateRingInstanceWithInfo("instance-2", "zone-b", []uint32{userToken(userID, 1) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-3", instanceDesc: generateRingInstanceWithInfo("instance-3", "zone-c", []uint32{userToken(userID, 2) + 1}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-4", instanceDesc: generateRingInstanceWithInfo("instance-4", "zone-a", []uint32{userToken(userID, 0) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-5", instanceDesc: generateRingInstanceWithInfo("instance-5", "zone-b", []uint32{userToken(userID, 1) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-6", instanceDesc: generateRingInstanceWithInfo("instance-6", "zone-c", []uint32{userToken(userID, 2) + 3}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-7", instanceDesc: generateRingInstanceWithInfo("instance-7", "zone-a", []uint32{userToken(userID, 0) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-8", instanceDesc: generateRingInstanceWithInfo("instance-8", "zone-b", []uint32{userToken(userID, 1) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: add, instanceID: "instance-9", instanceDesc: generateRingInstanceWithInfo("instance-9", "zone-c", []uint32{userToken(userID, 2) + 2}, now.Add(-2*lookbackPeriod))},
+				{what: test, shardSize: 3, expected: []string{"instance-1", "instance-2", "instance-3"}},
+				{what: test, shardSize: 6, expected: []string{"instance-1", "instance-2", "instance-3", "instance-7", "instance-8", "instance-9"}},
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			// Initialise the ring.
+			ringDesc := &Desc{Ingesters: map[string]IngesterDesc{}}
+			ring := Ring{
+				cfg: Config{
+					HeartbeatTimeout:     time.Hour,
+					ZoneAwarenessEnabled: true,
+				},
+				ringDesc:         ringDesc,
+				ringTokens:       ringDesc.getTokens(),
+				ringTokensByZone: ringDesc.getTokensByZone(),
+				ringZones:        getZones(ringDesc.getTokensByZone()),
+				strategy:         &DefaultReplicationStrategy{},
+			}
+
+			// Replay the events on the timeline.
+			for _, event := range testData.timeline {
+				switch event.what {
+				case add:
+					ringDesc.Ingesters[event.instanceID] = event.instanceDesc
+
+					ring.ringTokens = ringDesc.getTokens()
+					ring.ringTokensByZone = ringDesc.getTokensByZone()
+					ring.ringZones = getZones(ringDesc.getTokensByZone())
+				case remove:
+					delete(ringDesc.Ingesters, event.instanceID)
+
+					ring.ringTokens = ringDesc.getTokens()
+					ring.ringTokensByZone = ringDesc.getTokensByZone()
+					ring.ringZones = getZones(ringDesc.getTokensByZone())
+				case test:
+					rs, err := ring.ShuffleShardWithLookback(userID, event.shardSize, lookbackPeriod).GetAll(Read)
+					require.NoError(t, err)
+					assert.ElementsMatch(t, event.expected, rs.GetAddresses())
+				}
+			}
+		})
+	}
+}
+
+func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
+	// The goal of this test is NOT to ensure that the minimum required number of instances
+	// are returned at any given time, BUT at least all required instances are returned.
+	var (
+		numInitialInstances = []int{9, 30, 60, 90}
+		numInitialZones     = []int{1, 3}
+		numEvents           = 100
+		lookbackPeriod      = time.Hour
+		delayBetweenEvents  = 5 * time.Minute // 12 events / hour
+		userID              = "user-1"
+
+		// Make test execution reproducible.
+		entropy = rand.New(rand.NewSource(1))
+	)
+
+	for _, numInstances := range numInitialInstances {
+		for _, numZones := range numInitialZones {
+			testName := fmt.Sprintf("num instances = %d, num zones = %d", numInstances, numZones)
+
+			t.Run(testName, func(t *testing.T) {
+				// Initialise the ring.
+				ringDesc := &Desc{Ingesters: generateRingInstances(numInstances, numZones)}
+				ring := Ring{
+					cfg: Config{
+						HeartbeatTimeout:     time.Hour,
+						ZoneAwarenessEnabled: true,
+					},
+					ringDesc:         ringDesc,
+					ringTokens:       ringDesc.getTokens(),
+					ringTokensByZone: ringDesc.getTokensByZone(),
+					ringZones:        getZones(ringDesc.getTokensByZone()),
+					strategy:         &DefaultReplicationStrategy{},
+				}
+
+				// The simulation starts with the minimum shard size. Random events can later increase it.
+				shardSize := numZones
+
+				// The simulation assumes the initial ring contains instances registered
+				// since more than the lookback period.
+				currTime := time.Now().Add(lookbackPeriod).Add(time.Minute)
+
+				// Add the initial shard to the history.
+				rs, err := ring.ShuffleShard(userID, shardSize).GetAll(Read)
+				require.NoError(t, err)
+
+				history := map[time.Time]ReplicationSet{
+					currTime: rs,
+				}
+
+				// Simulate a progression of random events over the time and, at each iteration of the simuation,
+				// make sure the subring includes all non-removed instances picked from previous versions of the
+				// ring up until the lookback period.
+				for i := 1; i <= numEvents; i++ {
+					currTime = currTime.Add(delayBetweenEvents)
+
+					switch r := entropy.Intn(100); {
+					case r < 80:
+						// Scale up instances by 1.
+						id := len(ringDesc.Ingesters) + 1
+						instanceID := fmt.Sprintf("instance-%d", id)
+						zoneID := fmt.Sprintf("zone-%d", id%numZones)
+						ringDesc.Ingesters[instanceID] = generateRingInstanceWithInfo(instanceID, zoneID, GenerateTokens(128, nil), currTime)
+
+						ring.ringTokens = ringDesc.getTokens()
+						ring.ringTokensByZone = ringDesc.getTokensByZone()
+						ring.ringZones = getZones(ringDesc.getTokensByZone())
+					case r < 90:
+						// Scale down instances by 1.
+						idxToRemove := rand.Intn(len(ring.ringTokens))
+						idToRemove := ring.ringTokens[idxToRemove].Ingester
+						delete(ringDesc.Ingesters, idToRemove)
+
+						ring.ringTokens = ringDesc.getTokens()
+						ring.ringTokensByZone = ringDesc.getTokensByZone()
+						ring.ringZones = getZones(ringDesc.getTokensByZone())
+
+						// Remove the terminated instance from the history.
+						for ringTime, ringState := range history {
+							for idx, desc := range ringState.Ingesters {
+								// In this simulation instance ID == instance address.
+								if desc.Addr != idToRemove {
+									continue
+								}
+
+								ringState.Ingesters = append(ringState.Ingesters[:idx], ringState.Ingesters[idx+1:]...)
+								history[ringTime] = ringState
+								break
+							}
+						}
+					default:
+						// Scale up shard size (keeping the per-zone balance).
+						shardSize += numZones
+					}
+
+					// Add the current shard to the history.
+					rs, err = ring.ShuffleShard(userID, shardSize).GetAll(Read)
+					require.NoError(t, err)
+					history[currTime] = rs
+
+					// Ensure the shard with lookback includes all instances from previous states of the ring.
+					rsWithLookback, err := ring.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod).GetAll(Read)
+					require.NoError(t, err)
+
+					for ringTime, ringState := range history {
+						if ringTime.Before(currTime.Add(-lookbackPeriod)) {
+							// This entry from the history is obsolete, we can remove it.
+							delete(history, ringTime)
+							continue
+						}
+
+						for _, expectedAddr := range ringState.GetAddresses() {
+							if !rsWithLookback.Includes(expectedAddr) {
+								t.Fatalf(
+									"subring generated after event %d is expected to include instance %s but it's missing (actual instances are: %s)",
+									i, expectedAddr, strings.Join(rsWithLookback.GetAddresses(), ", "))
+							}
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
 func BenchmarkRing_ShuffleShard(b *testing.B) {
 	for _, numInstances := range []int{50, 100, 1000} {
 		for _, numZones := range []int{1, 3} {
@@ -832,13 +1183,20 @@ func generateRingInstances(numInstances, numZones int) map[string]IngesterDesc {
 }
 
 func generateRingInstance(id, zone int) (string, IngesterDesc) {
-	return fmt.Sprintf("instance-%d", id), IngesterDesc{
-		Addr:                fmt.Sprintf("127.0.0.%d", id),
+	instanceID := fmt.Sprintf("instance-%d", id)
+	zoneID := fmt.Sprintf("zone-%d", zone)
+
+	return instanceID, generateRingInstanceWithInfo(instanceID, zoneID, GenerateTokens(128, nil), time.Now())
+}
+
+func generateRingInstanceWithInfo(addr, zone string, tokens []uint32, registeredAt time.Time) IngesterDesc {
+	return IngesterDesc{
+		Addr:                addr,
 		Timestamp:           time.Now().Unix(),
-		RegisteredTimestamp: time.Now().Unix(),
+		RegisteredTimestamp: registeredAt.Unix(),
 		State:               ACTIVE,
-		Tokens:              GenerateTokens(128, nil),
-		Zone:                fmt.Sprintf("zone-%d", zone),
+		Tokens:              tokens,
+		Zone:                zone,
 	}
 }
 
@@ -1044,4 +1402,14 @@ func TestShuffleShardWithCaching(t *testing.T) {
 	require.False(t, subring == newSubring)
 	// Zone-aware shuffle-shard gives all zones the same number of ingesters (at least one).
 	require.Equal(t, zones, newSubring.IngesterCount())
+}
+
+// User shuffle shard token.
+func userToken(user string, skip int) uint32 {
+	r := rand.New(rand.NewSource(util.ShuffleShardSeed(user)))
+
+	for ; skip > 0; skip-- {
+		_ = r.Uint32()
+	}
+	return r.Uint32()
 }

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -1035,7 +1035,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 				currTime := time.Now().Add(lookbackPeriod).Add(time.Minute)
 
 				// Add the initial shard to the history.
-				rs, err := ring.ShuffleShard(userID, shardSize).GetAll(Read)
+				rs, err := ring.shuffleShard(userID, shardSize, 0, time.Now()).GetAll(Read)
 				require.NoError(t, err)
 
 				history := map[time.Time]ReplicationSet{
@@ -1099,7 +1099,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 					}
 
 					// Add the current shard to the history.
-					rs, err = ring.ShuffleShard(userID, shardSize).GetAll(Read)
+					rs, err = ring.shuffleShard(userID, shardSize, 0, time.Now()).GetAll(Read)
 					require.NoError(t, err)
 					history[currTime] = rs
 

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -996,23 +996,23 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 	// are returned at any given time, BUT at least all required instances are returned.
 	var (
 		numInitialInstances = []int{9, 30, 60, 90}
-		numInitialZones     = []int{3, 1, 3}
+		numInitialZones     = []int{1, 3}
 		numEvents           = 100
 		lookbackPeriod      = time.Hour
 		delayBetweenEvents  = 5 * time.Minute // 12 events / hour
 		userID              = "user-1"
 	)
 
-	// Randomise the seed but log it in case we need to reproduce the test on failure.
-	seed := time.Now().UnixNano()
-	rand.Seed(seed)
-	t.Log("random generator seed:", seed)
-
 	for _, numInstances := range numInitialInstances {
 		for _, numZones := range numInitialZones {
 			testName := fmt.Sprintf("num instances = %d, num zones = %d", numInstances, numZones)
 
 			t.Run(testName, func(t *testing.T) {
+				// Randomise the seed but log it in case we need to reproduce the test on failure.
+				seed := time.Now().UnixNano()
+				rand.Seed(seed)
+				t.Log("random generator seed:", seed)
+
 				// Initialise the ring.
 				ringDesc := &Desc{Ingesters: generateRingInstances(numInstances, numZones)}
 				ring := Ring{

--- a/tools/test
+++ b/tools/test
@@ -7,7 +7,7 @@ SLOW=
 TAGS=
 PARALLEL=
 RACE="-race -covermode=atomic"
-TIMEOUT=5m
+TIMEOUT=10m
 VERBOSE=
 
 usage() {


### PR DESCRIPTION
**What this PR does**:
This PR aims to implement the ingesters shuffle sharding on the read path, as described in [this design doc](https://cortexmetrics.io/docs/proposals/shuffle-sharding-on-the-read-path/#querier-ingesters-shuffle-sharding).

The idea is that, when distributors/ingesters shuffle sharding is enabled, we only query data from the subset of ingesters holding the data for a specific tenant.

This PR builds on top of #3299.

_Documentation has not been updated yet._

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
