### PR TITLE
Give ingester some timestamp tolerance

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -568,6 +568,10 @@ lifecycler:
   # CLI flag: -ingester.availability-zone
   [availability_zone: <string> | default = ""]
 
+# quantize ingested timestamps to within this tolerance
+# CLI flag: -ingester.timestamp-tolerance
+[timestampTolerance: <int> | default = 0]
+
 # Number of times to try and transfer chunks before falling back to flushing.
 # Negative value or zero disables hand-over. This feature is supported only by
 # the chunks storage.

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -75,7 +75,7 @@ func (s *memorySeries) add(v model.SamplePair, timestampTolerance int) error {
 			fmt.Errorf("sample timestamp out of order; last timestamp: %v, incoming timestamp: %v", s.lastTime, v.Timestamp))
 	}
 	// If gap since last scrape is very close to an exact number of seconds, tighten it up
-	if s.lastTime != 0 {
+	if s.lastTime != 0 && timestampTolerance != 0 {
 		gap := v.Timestamp - s.lastTime
 		seconds := ((gap + 500) / 1000)
 		diff := int(gap - seconds*1000)

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -983,7 +983,7 @@ func processWALSamples(userStates *userStates, stateCache map[string]*userState,
 			// There can be many out of order samples because of checkpoint and WAL overlap.
 			// Checking this beforehand avoids the allocation of lots of error messages.
 			if sp.Timestamp.After(series.lastTime) {
-				if err := series.add(sp); err != nil {
+				if err := series.add(sp, 0); err != nil {
 					errChan <- err
 					return
 				}


### PR DESCRIPTION
Inspired by https://github.com/prometheus/prometheus/pull/7976

If timestamps sent by remote-write clients are slightly off an exact period of seconds, quantize them to be exact.  This saves memory and storage space.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
