### PR TITLE
Change -frontend.max-queriers-per-user to -frontend.max-queriers-per-tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
   - `POST <legacy-http-prefix>/push`
   - `POST /push`
   - `POST /ingester/push`
-* [FEATURE] Added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-user` globally, or using per-user limit `max_queriers_per_user`), each user's requests will be handled by different set of queriers. #3113
+* [FEATURE] Added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-tenant` globally, or using per-tenant limit `max_queriers_per_tenant`), each tenants's requests will be handled by different set of queriers. #3113
 * [FEATURE] Query-frontend: added `compression` config to support results cache with compression. #3217
 * [ENHANCEMENT] Added `cortex_query_frontend_connected_clients` metric to show the number of workers currently connected to the frontend. #3207
 * [ENHANCEMENT] Shuffle sharding: improved shuffle sharding in the write path. Shuffle sharding now should be explicitly enabled via `-distributor.sharding-strategy` CLI flag (or its respective YAML config option) and guarantees stability, consistency, shuffling and balanced zone-awareness properties. #3090 #3214

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
   - `POST <legacy-http-prefix>/push`
   - `POST /push`
   - `POST /ingester/push`
-* [FEATURE] Added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-tenant` globally, or using per-tenant limit `max_queriers_per_tenant`), each tenants's requests will be handled by different set of queriers. #3113
+* [FEATURE] Added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-tenant` globally, or using per-tenant limit `max_queriers_per_tenant`), each tenants's requests will be handled by different set of queriers. #3113 #3257
 * [FEATURE] Query-frontend: added `compression` config to support results cache with compression. #3217
 * [ENHANCEMENT] Added `cortex_query_frontend_connected_clients` metric to show the number of workers currently connected to the frontend. #3207
 * [ENHANCEMENT] Shuffle sharding: improved shuffle sharding in the write path. Shuffle sharding now should be explicitly enabled via `-distributor.sharding-strategy` CLI flag (or its respective YAML config option) and guarantees stability, consistency, shuffling and balanced zone-awareness properties. #3090 #3214

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2852,14 +2852,14 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -frontend.max-cache-freshness
 [max_cache_freshness: <duration> | default = 1m]
 
-# Maximum number of queriers that can handle requests for a single user. If set
-# to 0 or value higher than number of available queriers, *all* queriers will
-# handle requests for the user. Each frontend will select the same set of
-# queriers for the same user (given that all queriers are connected to all
+# Maximum number of queriers that can handle requests for a single tenant. If
+# set to 0 or value higher than number of available queriers, *all* queriers
+# will handle requests for the tenant. Each frontend will select the same set of
+# queriers for the same tenant (given that all queriers are connected to all
 # frontends). This option only works with queriers connecting to the
 # query-frontend, not when using downstream URL.
-# CLI flag: -frontend.max-queriers-per-user
-[max_queriers_per_user: <int> | default = 0]
+# CLI flag: -frontend.max-queriers-per-tenant
+[max_queriers_per_tenant: <int> | default = 0]
 
 # Duration to delay the evaluation of rules to ensure the underlying metrics
 # have been pushed to Cortex.

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -47,7 +47,7 @@ Currently experimental features are:
 - gRPC Store.
 - Querier support for querying chunks and blocks store at the same time.
 - Tracking of active series and exporting them as metrics (`-ingester.active-series-metrics-enabled` and related flags)
-- Shuffle-sharding of queriers in the query-frontend (i.e. use of `-frontend.max-queriers-per-user` flag with non-zero value).
+- Shuffle-sharding of queriers in the query-frontend (i.e. use of `-frontend.max-queriers-per-tenant` flag with non-zero value).
 - TLS configuration in gRPC and HTTP clients.
 - TLS configuration in Etcd client.
 - Blocksconvert tools

--- a/docs/guides/shuffle-sharding.md
+++ b/docs/guides/shuffle-sharding.md
@@ -79,7 +79,7 @@ _The shard size can be overridden on a per-tenant basis in the limits overrides 
 
 By default all Cortex queriers can execute received queries for given tenant.
 
-When shuffle sharding is **enabled** by setting `-frontend.max-queriers-per-user` (or its respective YAML config option) to a value higher than 0 and lower than the number of available queriers, only specified number of queriers will execute queries for single tenant. Note that this distribution happens in query-frontend. When not using query-frontend, this option is not available.
+When shuffle sharding is **enabled** by setting `-frontend.max-queriers-per-tenant` (or its respective YAML config option) to a value higher than 0 and lower than the number of available queriers, only specified number of queriers will execute queries for single tenant. Note that this distribution happens in query-frontend. When not using query-frontend, this option is not available.
 
 _The maximum number of queriers can be overridden on a per-tenant basis in the limits overrides configuration._
 

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -54,7 +54,7 @@ func runQuerierShardingTest(t *testing.T, sharding bool) {
 
 	if sharding {
 		// Use only single querier for each user.
-		flags["-frontend.max-queriers-per-user"] = "1"
+		flags["-frontend.max-queriers-per-tenant"] = "1"
 	}
 
 	// Start Cortex components.

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -63,12 +63,12 @@ type Limits struct {
 	MaxGlobalMetadataPerMetric          int `yaml:"max_global_metadata_per_metric"`
 
 	// Querier enforced limits.
-	MaxChunksPerQuery   int           `yaml:"max_chunks_per_query"`
-	MaxQueryLength      time.Duration `yaml:"max_query_length"`
-	MaxQueryParallelism int           `yaml:"max_query_parallelism"`
-	CardinalityLimit    int           `yaml:"cardinality_limit"`
-	MaxCacheFreshness   time.Duration `yaml:"max_cache_freshness"`
-	MaxQueriersPerUser  int           `yaml:"max_queriers_per_user"`
+	MaxChunksPerQuery    int           `yaml:"max_chunks_per_query"`
+	MaxQueryLength       time.Duration `yaml:"max_query_length"`
+	MaxQueryParallelism  int           `yaml:"max_query_parallelism"`
+	CardinalityLimit     int           `yaml:"cardinality_limit"`
+	MaxCacheFreshness    time.Duration `yaml:"max_cache_freshness"`
+	MaxQueriersPerTenant int           `yaml:"max_queriers_per_tenant"`
 
 	// Ruler defaults and limits.
 	RulerEvaluationDelay time.Duration `yaml:"ruler_evaluation_delay_duration"`
@@ -119,7 +119,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of queries will be scheduled in parallel by the frontend.")
 	f.IntVar(&l.CardinalityLimit, "store.cardinality-limit", 1e5, "Cardinality limit for index queries. This limit is ignored when running the Cortex blocks storage. 0 to disable.")
 	f.DurationVar(&l.MaxCacheFreshness, "frontend.max-cache-freshness", 1*time.Minute, "Most recent allowed cacheable result per-tenant, to prevent caching very recent results that might still be in flux.")
-	f.IntVar(&l.MaxQueriersPerUser, "frontend.max-queriers-per-user", 0, "Maximum number of queriers that can handle requests for a single user. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the user. Each frontend will select the same set of queriers for the same user (given that all queriers are connected to all frontends). This option only works with queriers connecting to the query-frontend, not when using downstream URL.")
+	f.IntVar(&l.MaxQueriersPerTenant, "frontend.max-queriers-per-tenant", 0, "Maximum number of queriers that can handle requests for a single tenant. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the tenant. Each frontend will select the same set of queriers for the same tenant (given that all queriers are connected to all frontends). This option only works with queriers connecting to the query-frontend, not when using downstream URL.")
 
 	f.DurationVar(&l.RulerEvaluationDelay, "ruler.evaluation-delay-duration", 0, "Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed to Cortex.")
 
@@ -311,7 +311,7 @@ func (o *Overrides) MaxCacheFreshness(userID string) time.Duration {
 
 // MaxQueriersPerUser returns the maximum number of queriers that can handle requests for this user.
 func (o *Overrides) MaxQueriersPerUser(userID string) int {
-	return o.getOverridesForUser(userID).MaxQueriersPerUser
+	return o.getOverridesForUser(userID).MaxQueriersPerTenant
 }
 
 // MaxQueryParallelism returns the limit to the number of sub-queries the


### PR DESCRIPTION
**What this PR does**: This PR renames ` -frontend.max-queriers-per-user` to `-frontend.max-queriers-per-tenant` to be consistent with other sharding flags. This isn't a breaking change, since this flag was not part of stable release yet, and the feature is marked as experimental.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
