### PR TITLE
Disallow stale reads for Consul CAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * [BUGFIX] Check for postgres rows errors. #3197
 * [BUGFIX] Ruler Experimental API: Don't allow rule groups without names or empty rule groups. #3210
 * [BUGFIX] Experimental Alertmanager API: Do not allow empty Alertmanager configurations or bad template filenames to be submitted through the configuration API. #3185
+* [BUGFIX] Reduce failures to update heartbeat when using Consul. #3259
 
 ## 1.4.0-rc.0 in progress
 

--- a/pkg/ring/kv/consul/client.go
+++ b/pkg/ring/kv/consul/client.go
@@ -122,10 +122,8 @@ func (c *Client) cas(ctx context.Context, key string, f func(in interface{}) (ou
 		retries = 10
 	)
 	for i := 0; i < retries; i++ {
-		options := &consul.QueryOptions{
-			AllowStale:        !c.cfg.ConsistentReads,
-			RequireConsistent: c.cfg.ConsistentReads,
-		}
+		// Get with default options - don't want stale data to compare with
+		options := &consul.QueryOptions{}
 		kvp, _, err := c.kv.Get(key, options.WithContext(ctx))
 		if err != nil {
 			level.Error(util.Logger).Log("msg", "error getting key", "key", key, "err", err)


### PR DESCRIPTION
In order for the CAS to succeed, we need to have up-to-date data to compare against, so it doesn't make sense to allow stale reads.

More info: https://www.consul.io/api-docs/features/consistency

**Checklist**
- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated
