### PR TITLE
Replace SegmentRange with upstream wal.Segments

### DIFF
--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1005,7 +1004,7 @@ func newWalReader(name string, startSegment int) (*wal.Reader, io.Closer, error)
 			return nil, nil, err
 		}
 	} else {
-		first, last, err := SegmentRange(name)
+		first, last, err := wal.Segments(name)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1025,33 +1024,6 @@ func newWalReader(name string, startSegment int) (*wal.Reader, io.Closer, error)
 		}
 	}
 	return wal.NewReader(segmentReader), segmentReader, nil
-}
-
-// SegmentRange returns the first and last segment index of the WAL in the dir.
-// If https://github.com/prometheus/prometheus/pull/6477 is merged, get rid of this
-// method and use from Prometheus directly.
-func SegmentRange(dir string) (int, int, error) {
-	files, err := ioutil.ReadDir(dir)
-	if err != nil {
-		return 0, 0, err
-	}
-	first, last := math.MaxInt32, math.MinInt32
-	for _, f := range files {
-		k, err := strconv.Atoi(f.Name())
-		if err != nil {
-			continue
-		}
-		if k < first {
-			first = k
-		}
-		if k > last {
-			last = k
-		}
-	}
-	if first == math.MaxInt32 || last == math.MinInt32 {
-		return -1, -1, nil
-	}
-	return first, last, nil
 }
 
 func decodeCheckpointRecord(rec []byte, m proto.Message) (_ proto.Message, err error) {


### PR DESCRIPTION
Signed-off-by: Brett Snyder <bsnyder@digitalocean.com>

**What this PR does**:
Replaces SegmentRange with upstream TSDB wal.Segments

**Which issue(s) this PR fixes**:
Fixes #3114

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
