### PR TITLE
Sync rules on read path to avoid mismatch

### DIFF
--- a/pkg/ruler/rules/store.go
+++ b/pkg/ruler/rules/store.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"context"
 	"errors"
+	time "time"
 
 	"github.com/prometheus/prometheus/pkg/rulefmt"
 
@@ -29,6 +30,10 @@ type RuleStore interface {
 	// LoadRuleGroupsForUserAndNamespace returns all the active rule groups for a user from given namespace.
 	// If namespace is empty, groups from all namespaces are returned.
 	LoadRuleGroupsForUserAndNamespace(ctx context.Context, userID string, namespace string) (RuleGroupList, error)
+
+	// LoadRuleGroupsIfUpdatedAfter returns all the active rule groups for a user.
+	LoadRuleGroupsIfUpdatedAfter(ctx context.Context, userID string, ts time.Time) (RuleGroupList, error)
+
 	GetRuleGroup(ctx context.Context, userID, namespace, group string) (*RuleGroupDesc, error)
 	SetRuleGroup(ctx context.Context, userID, namespace string, group *RuleGroupDesc) error
 	DeleteRuleGroup(ctx context.Context, userID, namespace string, group string) error
@@ -144,6 +149,13 @@ func (c *ConfigRuleStore) LoadRuleGroupsForUserAndNamespace(ctx context.Context,
 	}
 
 	return list, nil
+}
+
+// LoadRuleGroupsIfUpdatedAfter is not implemented.
+// The reason we dont return an error is because this function is called in the
+// read path and we should make this a nop instead of error.
+func (c *ConfigRuleStore) LoadRuleGroupsIfUpdatedAfter(ctx context.Context, userID string, ts time.Time) (RuleGroupList, error) {
+	return nil, nil
 }
 
 // GetRuleGroup is not implemented

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -166,6 +166,10 @@ func (m *mockRuleStore) LoadRuleGroupsForUserAndNamespace(ctx context.Context, u
 	return namespaceRules, nil
 }
 
+func (m *mockRuleStore) LoadRuleGroupsIfUpdatedAfter(ctx context.Context, userID string, ts time.Time) (rules.RuleGroupList, error) {
+	return m.LoadRuleGroupsForUserAndNamespace(ctx, userID, "")
+}
+
 func (m *mockRuleStore) GetRuleGroup(ctx context.Context, userID string, namespace string, group string) (*rules.RuleGroupDesc, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()


### PR DESCRIPTION
Currently our config update API just writes to Object store. We
periodically sync the data from Object store to in-memory, and the
in-memory state is returned in prometheus-rules API call. This means
after a user updates the config, he won't see it reflect in the UI
for minutes.

This PR will store the last updated timestamp and will sync to disk any
rules that have been updated since. This means we'll be emitting a LIST
call per ruler everytime the user calls the prometheus rules endpoint
but it should be rare enough that this shouldn't materially matter.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests added
- [ ] Documentation added
- [x] Make sure it works with config service
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`