### PR TITLE
Split listing and loading rule groups in rules.RuleStore interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * [ENHANCEMENT] Experimental Ruler API: Fetch rule groups from object storage in parallel. #3218
 * [ENHANCEMENT] Chunks GCS object storage client uses the `fields` selector to limit the payload size when listing objects in the bucket. #3218
 * [ENHANCEMENT] Added shuffle sharding support to ruler. Added new metric `cortex_ruler_sync_rules_total`. #3235
+* [ENHANCEMENT] Ruler: only load rules that belong to the ruler. Useful when using sharding. #3269
 * [BUGFIX] No-longer-needed ingester operations for queries triggered by queriers and rulers are now canceled. #3178
 * [BUGFIX] Ruler: directories in the configured `rules-path` will be removed on startup and shutdown in order to ensure they don't persist between runs. #3195
 * [BUGFIX] Handle hash-collisions in the query path. #3192

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 * [ENHANCEMENT] Experimental Ruler API: Fetch rule groups from object storage in parallel. #3218
 * [ENHANCEMENT] Chunks GCS object storage client uses the `fields` selector to limit the payload size when listing objects in the bucket. #3218
 * [ENHANCEMENT] Added shuffle sharding support to ruler. Added new metric `cortex_ruler_sync_rules_total`. #3235
-* [ENHANCEMENT] Ruler: only load rules that belong to the ruler. Useful when using sharding. #3269
+* [ENHANCEMENT] Ruler: only load rules that belong to the ruler. Improves rules synching performances when ruler sharding is enabled. #3269
 * [BUGFIX] No-longer-needed ingester operations for queries triggered by queriers and rulers are now canceled. #3178
 * [BUGFIX] Ruler: directories in the configured `rules-path` will be removed on startup and shutdown in order to ensure they don't persist between runs. #3195
 * [BUGFIX] Handle hash-collisions in the query path. #3192

--- a/integration/chunks_storage_backends_test.go
+++ b/integration/chunks_storage_backends_test.go
@@ -263,6 +263,7 @@ func TestSwiftRuleStorage(t *testing.T) {
 	rls, err := store.ListAllRuleGroups(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(rls[userID]))
+	require.NoError(t, store.LoadRuleGroups(ctx, rls))
 
 	userRules := rls[userID]
 	sort.Slice(userRules, func(i, j int) bool { return userRules[i].Name < userRules[j].Name })
@@ -277,6 +278,7 @@ func TestSwiftRuleStorage(t *testing.T) {
 	rls, err = store.ListAllRuleGroups(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rls[userID]))
+	require.NoError(t, store.LoadRuleGroups(ctx, rls))
 	require.Equal(t, r2, rls[userID][0])
 }
 

--- a/integration/chunks_storage_backends_test.go
+++ b/integration/chunks_storage_backends_test.go
@@ -260,7 +260,7 @@ func TestSwiftRuleStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get rules back.
-	rls, err := store.LoadAllRuleGroups(ctx)
+	rls, err := store.ListAllRuleGroups(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(rls[userID]))
 
@@ -274,7 +274,7 @@ func TestSwiftRuleStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	//Verify we only have the second rule group
-	rls, err = store.LoadAllRuleGroups(ctx)
+	rls, err = store.ListAllRuleGroups(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rls[userID]))
 	require.Equal(t, r2, rls[userID][0])

--- a/integration/chunks_storage_backends_test.go
+++ b/integration/chunks_storage_backends_test.go
@@ -250,12 +250,12 @@ func TestSwiftRuleStorage(t *testing.T) {
 	require.NoError(t, err)
 	ctx := context.Background()
 
-	// Add 2 rule group.
-	r1 := newRule(userID, "1")
+	// Add 2 rule groups.
+	r1 := newRuleGroup(userID, "foo", "1")
 	err = store.SetRuleGroup(ctx, userID, "foo", r1)
 	require.NoError(t, err)
 
-	r2 := newRule(userID, "2")
+	r2 := newRuleGroup(userID, "bar", "2")
 	err = store.SetRuleGroup(ctx, userID, "bar", r2)
 	require.NoError(t, err)
 
@@ -282,11 +282,11 @@ func TestSwiftRuleStorage(t *testing.T) {
 	require.Equal(t, r2, rls[userID][0])
 }
 
-func newRule(userID, name string) *rules.RuleGroupDesc {
+func newRuleGroup(userID, namespace, group string) *rules.RuleGroupDesc {
 	return &rules.RuleGroupDesc{
-		Name:      name + "rule",
+		Name:      group,
 		Interval:  time.Minute,
-		Namespace: name + "namespace",
+		Namespace: namespace,
 		Rules: []*rules.RuleDesc{
 			{
 				Expr:   fmt.Sprintf(`{%s="bar"}`, name),

--- a/integration/chunks_storage_backends_test.go
+++ b/integration/chunks_storage_backends_test.go
@@ -289,8 +289,8 @@ func newRuleGroup(userID, namespace, group string) *rules.RuleGroupDesc {
 		Namespace: namespace,
 		Rules: []*rules.RuleDesc{
 			{
-				Expr:   fmt.Sprintf(`{%s="bar"}`, name),
-				Record: name + ":bar",
+				Expr:   fmt.Sprintf(`{%s="bar"}`, group),
+				Record: group + ":bar",
 			},
 		},
 		User: userID,

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -377,19 +377,25 @@ func (r *Ruler) ListRules(w http.ResponseWriter, req *http.Request) {
 	}
 
 	level.Debug(logger).Log("msg", "retrieving rule groups with namespace", "userID", userID, "namespace", namespace)
-	rgs, err := r.store.LoadRuleGroupsForUserAndNamespace(req.Context(), userID, namespace)
+	rgs, err := r.store.ListRuleGroupsForUserAndNamespace(req.Context(), userID, namespace)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	level.Debug(logger).Log("msg", "retrieved rule groups from rule store", "userID", userID, "num_namespaces", len(rgs))
 
 	if len(rgs) == 0 {
 		level.Info(logger).Log("msg", "no rule groups found", "userID", userID)
 		http.Error(w, ErrNoRuleGroups.Error(), http.StatusNotFound)
 		return
 	}
+
+	err = r.store.LoadRuleGroups(req.Context(), map[string]rules.RuleGroupList{userID: rgs})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	level.Debug(logger).Log("msg", "retrieved rule groups from rule store", "userID", userID, "num_namespaces", len(rgs))
 
 	formatted := rgs.Formatted()
 	marshalAndSend(formatted, w, logger)

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -555,7 +555,7 @@ func TestSharding(t *testing.T) {
 			}
 
 			// Always add ruler1 to expected rulers, even if there is no ring (no sharding).
-			loadedRules1, err := r1.loadRules(context.Background())
+			loadedRules1, err := r1.listRules(context.Background())
 			require.NoError(t, err)
 
 			expected := expectedRulesMap{
@@ -565,7 +565,7 @@ func TestSharding(t *testing.T) {
 			addToExpected := func(id string, r *Ruler) {
 				// Only expect rules from other rulers when using ring, and they are present in the ring.
 				if r != nil && rulerRing != nil && rulerRing.HasInstance(id) {
-					loaded, err := r.loadRules(context.Background())
+					loaded, err := r.listRules(context.Background())
 					require.NoError(t, err)
 					// Normalize nil map to empty one.
 					if loaded == nil {

--- a/pkg/ruler/rules/local/local_test.go
+++ b/pkg/ruler/rules/local/local_test.go
@@ -73,7 +73,7 @@ func TestClient_LoadAllRuleGroups(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	userMap, err := client.LoadAllRuleGroups(ctx)
+	userMap, err := client.ListAllRuleGroups(ctx) // Client loads rules in its List method.
 	require.NoError(t, err)
 
 	for _, u := range []string{user1, user2} {

--- a/pkg/ruler/rules/objectclient/rule_store.go
+++ b/pkg/ruler/rules/objectclient/rule_store.go
@@ -45,6 +45,7 @@ func NewRuleStore(client chunk.ObjectClient, loadConcurrency int) *RuleStore {
 	}
 }
 
+// If existing rule group is supplied, it is Reset and reused. If nil, new RuleGroupDesc is allocated.
 func (o *RuleStore) getRuleGroup(ctx context.Context, objectKey string, rg *rules.RuleGroupDesc) (*rules.RuleGroupDesc, error) {
 	reader, err := o.client.GetObject(ctx, objectKey)
 	if err == chunk.ErrStorageObjectNotFound {
@@ -139,7 +140,7 @@ func (o *RuleStore) LoadRuleGroups(ctx context.Context, groupsToLoad map[string]
 				key := generateRuleObjectKey(user, namespace, group)
 
 				level.Debug(util.Logger).Log("msg", "loading rule group", "key", key, "user", user)
-				gr, err := o.getRuleGroup(gCtx, key, gr)
+				gr, err := o.getRuleGroup(gCtx, key, gr) // reuse group pointer from the map.
 				if err != nil {
 					level.Error(util.Logger).Log("msg", "failed to get rule group", "key", key, "user", user)
 					return err

--- a/pkg/ruler/rules/objectclient/rule_store.go
+++ b/pkg/ruler/rules/objectclient/rule_store.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"strings"
-	"sync"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/gogo/protobuf/proto"
@@ -27,24 +27,25 @@ import (
 // across all backends
 
 const (
-	delim                     = "/"
-	rulePrefix                = "rules" + delim
-	loadRuleGroupsConcurrency = 4
+	delim      = "/"
+	rulePrefix = "rules" + delim
 )
 
 // RuleStore allows cortex rules to be stored using an object store backend.
 type RuleStore struct {
-	client chunk.ObjectClient
+	client          chunk.ObjectClient
+	loadConcurrency int
 }
 
 // NewRuleStore returns a new RuleStore
-func NewRuleStore(client chunk.ObjectClient) *RuleStore {
+func NewRuleStore(client chunk.ObjectClient, loadConcurrency int) *RuleStore {
 	return &RuleStore{
-		client: client,
+		client:          client,
+		loadConcurrency: loadConcurrency,
 	}
 }
 
-func (o *RuleStore) getRuleGroup(ctx context.Context, objectKey string) (*rules.RuleGroupDesc, error) {
+func (o *RuleStore) getRuleGroup(ctx context.Context, objectKey string, rg *rules.RuleGroupDesc) (*rules.RuleGroupDesc, error) {
 	reader, err := o.client.GetObject(ctx, objectKey)
 	if err == chunk.ErrStorageObjectNotFound {
 		level.Debug(util.Logger).Log("msg", "rule group does not exist", "name", objectKey)
@@ -61,7 +62,11 @@ func (o *RuleStore) getRuleGroup(ctx context.Context, objectKey string) (*rules.
 		return nil, err
 	}
 
-	rg := &rules.RuleGroupDesc{}
+	if rg == nil {
+		rg = &rules.RuleGroupDesc{}
+	} else {
+		rg.Reset()
+	}
 
 	err = proto.Unmarshal(buf, rg)
 	if err != nil {
@@ -92,44 +97,100 @@ func (o *RuleStore) ListAllUsers(ctx context.Context) ([]string, error) {
 	return result, nil
 }
 
-// LoadAllRuleGroups implements rules.RuleStore.
-func (o *RuleStore) LoadAllRuleGroups(ctx context.Context) (map[string]rules.RuleGroupList, error) {
+// ListAllRuleGroups implements rules.RuleStore.
+func (o *RuleStore) ListAllRuleGroups(ctx context.Context) (map[string]rules.RuleGroupList, error) {
 	// No delimiter to get *all* rule groups for all users and namespaces.
-	ruleGroupObjects, _, err := o.client.List(ctx, generateRuleObjectKey("", "", ""), "")
+	ruleGroupObjects, _, err := o.client.List(ctx, rulePrefix, "")
 	if err != nil {
 		return nil, err
 	}
 
-	if len(ruleGroupObjects) == 0 {
-		return map[string]rules.RuleGroupList{}, nil
-	}
-
-	return o.loadRuleGroupsConcurrently(ctx, ruleGroupObjects)
+	return convertRuleGroupObjectsToMap(ruleGroupObjects), nil
 }
 
-func (o *RuleStore) LoadRuleGroupsForUserAndNamespace(ctx context.Context, userID, namespace string) (rules.RuleGroupList, error) {
+func (o *RuleStore) ListRuleGroupsForUserAndNamespace(ctx context.Context, userID, namespace string) (rules.RuleGroupList, error) {
 	ruleGroupObjects, _, err := o.client.List(ctx, generateRuleObjectKey(userID, namespace, ""), "")
 	if err != nil {
 		return nil, err
 	}
 
-	if len(ruleGroupObjects) == 0 {
-		return rules.RuleGroupList{}, nil
+	return convertRuleGroupObjectsToMap(ruleGroupObjects)[userID], nil
+}
+
+func (o *RuleStore) LoadRuleGroups(ctx context.Context, groupsToLoad map[string]rules.RuleGroupList) error {
+	ch := make(chan *rules.RuleGroupDesc)
+
+	// Given we store one file per rule group. With this, we create a pool of workers that will
+	// download all rule groups in parallel. We limit the number of workers to avoid a
+	// particular user having too many rule groups rate limiting us with the object storage.
+	g, gCtx := errgroup.WithContext(ctx)
+	for i := 0; i < o.loadConcurrency; i++ {
+		g.Go(func() error {
+			for gr := range ch {
+				if gr == nil {
+					continue
+				}
+
+				user, namespace, group := gr.GetUser(), gr.GetNamespace(), gr.GetName()
+				if user == "" || namespace == "" || group == "" {
+					return fmt.Errorf("invalid rule group: user=%q, namespace=%q, group=%q", user, namespace, group)
+				}
+
+				key := generateRuleObjectKey(user, namespace, group)
+
+				level.Debug(util.Logger).Log("msg", "loading rule group", "key", key, "user", user)
+				gr, err := o.getRuleGroup(gCtx, key, gr)
+				if err != nil {
+					level.Error(util.Logger).Log("msg", "failed to get rule group", "key", key, "user", user)
+					return err
+				}
+
+				if user != gr.User || namespace != gr.Namespace || group != gr.Name {
+					return fmt.Errorf("mismatch between requested rule group and loaded rule group, requested: user=%q, namespace=%q, group=%q, loaded: user=%q, namespace=%q, group=%q", user, namespace, group, gr.User, gr.Namespace, gr.Name)
+				}
+			}
+
+			return nil
+		})
 	}
 
-	groups, err := o.loadRuleGroupsConcurrently(ctx, ruleGroupObjects)
-	return groups[userID], err
+outer:
+	for _, gs := range groupsToLoad {
+		for _, g := range gs {
+			select {
+			case <-gCtx.Done():
+				break outer
+			case ch <- g:
+				// ok
+			}
+		}
+	}
+	close(ch)
+
+	return g.Wait()
+}
+
+func convertRuleGroupObjectsToMap(ruleGroupObjects []chunk.StorageObject) map[string]rules.RuleGroupList {
+	result := map[string]rules.RuleGroupList{}
+	for _, rg := range ruleGroupObjects {
+		user, namespace, group := decomposeRuleObjectKey(rg.Key)
+		if user == "" || namespace == "" || group == "" {
+			continue
+		}
+
+		result[user] = append(result[user], &rules.RuleGroupDesc{
+			User:      user,
+			Namespace: namespace,
+			Name:      group,
+		})
+	}
+	return result
 }
 
 // GetRuleGroup returns the requested rule group
 func (o *RuleStore) GetRuleGroup(ctx context.Context, userID string, namespace string, grp string) (*rules.RuleGroupDesc, error) {
 	handle := generateRuleObjectKey(userID, namespace, grp)
-	rg, err := o.getRuleGroup(ctx, handle)
-	if err != nil {
-		return nil, err
-	}
-
-	return rg, nil
+	return o.getRuleGroup(ctx, handle, nil)
 }
 
 // SetRuleGroup sets provided rule group
@@ -176,54 +237,6 @@ func (o *RuleStore) DeleteNamespace(ctx context.Context, userID, namespace strin
 	return nil
 }
 
-func (o *RuleStore) loadRuleGroupsConcurrently(ctx context.Context, rgObjects []chunk.StorageObject) (map[string]rules.RuleGroupList, error) {
-	ch := make(chan string, len(rgObjects))
-
-	for _, obj := range rgObjects {
-		ch <- obj.Key
-	}
-	close(ch)
-
-	mtx := sync.Mutex{}
-	result := map[string]rules.RuleGroupList{}
-
-	concurrency := loadRuleGroupsConcurrency
-	if loadRuleGroupsConcurrency < len(rgObjects) {
-		concurrency = len(rgObjects)
-	}
-
-	// Given we store one file per rule group. With this, we create a pool of workers that will
-	// download all rule groups in parallel. We limit the number of workers to avoid a
-	// particular user having too many rule groups rate limiting us with the object storage.
-	g, gCtx := errgroup.WithContext(ctx)
-	for i := 0; i < concurrency; i++ {
-		g.Go(func() error {
-			for key := range ch {
-				user := decomposeRuleObjectKey(key)
-				if user == "" {
-					continue
-				}
-
-				level.Debug(util.Logger).Log("msg", "listing rule group", "key", key, "user", user)
-				rg, err := o.getRuleGroup(gCtx, key)
-				if err != nil {
-					level.Error(util.Logger).Log("msg", "failed to get rule group", "key", key, "user", user)
-					return err
-				}
-
-				mtx.Lock()
-				result[user] = append(result[user], rg)
-				mtx.Unlock()
-			}
-
-			return nil
-		})
-	}
-
-	err := g.Wait()
-	return result, err
-}
-
 func generateRuleObjectKey(userID, namespace, groupName string) string {
 	if userID == "" {
 		return rulePrefix
@@ -242,10 +255,15 @@ func generateRuleObjectKey(userID, namespace, groupName string) string {
 	return prefix + ns + base64.URLEncoding.EncodeToString([]byte(groupName))
 }
 
-func decomposeRuleObjectKey(handle string) string {
-	components := strings.Split(handle, "/")
-	if len(components) != 4 {
-		return ""
+func decomposeRuleObjectKey(objectKey string) (userID, namespace, groupName string) {
+	if !strings.HasPrefix(objectKey, rulePrefix) {
+		return
 	}
-	return components[1]
+
+	components := strings.Split(objectKey, delim)
+	if len(components) != 4 {
+		return
+	}
+
+	return components[1], components[2], components[3]
 }

--- a/pkg/ruler/rules/objectclient/rule_store.go
+++ b/pkg/ruler/rules/objectclient/rule_store.go
@@ -265,5 +265,15 @@ func decomposeRuleObjectKey(objectKey string) (userID, namespace, groupName stri
 		return
 	}
 
-	return components[1], components[2], components[3]
+	ns, err := base64.URLEncoding.DecodeString(components[2])
+	if err != nil {
+		return
+	}
+
+	gr, err := base64.URLEncoding.DecodeString(components[3])
+	if err != nil {
+		return
+	}
+
+	return components[1], string(ns), string(gr)
 }

--- a/pkg/ruler/rules/objectclient/rule_store_test.go
+++ b/pkg/ruler/rules/objectclient/rule_store_test.go
@@ -1,0 +1,158 @@
+package objectclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/chunk"
+	github_com_cortexproject_cortex_pkg_ingester_client "github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/cortexproject/cortex/pkg/ruler/rules"
+)
+
+type testGroup struct {
+	user, namespace string
+	ruleGroup       rulefmt.RuleGroup
+}
+
+func TestListRules(t *testing.T) {
+	obj := chunk.NewMockStorage()
+	rs := NewRuleStore(obj, 5)
+
+	groups := []testGroup{
+		{user: "user1", namespace: "hello", ruleGroup: rulefmt.RuleGroup{Name: "first testGroup"}},
+		{user: "user1", namespace: "hello", ruleGroup: rulefmt.RuleGroup{Name: "second testGroup"}},
+		{user: "user1", namespace: "world", ruleGroup: rulefmt.RuleGroup{Name: "another namespace testGroup"}},
+		{user: "user2", namespace: "+-!@#$%. ", ruleGroup: rulefmt.RuleGroup{Name: "different user"}},
+	}
+
+	for _, g := range groups {
+		desc := rules.ToProto(g.user, g.namespace, g.ruleGroup)
+		require.NoError(t, rs.SetRuleGroup(context.Background(), g.user, g.namespace, desc))
+	}
+
+	{
+		users, err := rs.ListAllUsers(context.Background())
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"user1", "user2"}, users)
+	}
+
+	{
+		allGroupsMap, err := rs.ListAllRuleGroups(context.Background())
+		require.NoError(t, err)
+		require.Len(t, allGroupsMap, 2)
+		require.ElementsMatch(t, []*rules.RuleGroupDesc{
+			{User: "user1", Namespace: "hello", Name: "first testGroup"},
+			{User: "user1", Namespace: "hello", Name: "second testGroup"},
+			{User: "user1", Namespace: "world", Name: "another namespace testGroup"},
+		}, allGroupsMap["user1"])
+		require.ElementsMatch(t, []*rules.RuleGroupDesc{
+			{User: "user2", Namespace: "+-!@#$%. ", Name: "different user"},
+		}, allGroupsMap["user2"])
+	}
+
+	{
+		user1Groups, err := rs.ListRuleGroupsForUserAndNamespace(context.Background(), "user1", "")
+		require.NoError(t, err)
+		require.ElementsMatch(t, []*rules.RuleGroupDesc{
+			{User: "user1", Namespace: "hello", Name: "first testGroup"},
+			{User: "user1", Namespace: "hello", Name: "second testGroup"},
+			{User: "user1", Namespace: "world", Name: "another namespace testGroup"},
+		}, user1Groups)
+	}
+
+	{
+		helloGroups, err := rs.ListRuleGroupsForUserAndNamespace(context.Background(), "user1", "hello")
+		require.NoError(t, err)
+		require.ElementsMatch(t, []*rules.RuleGroupDesc{
+			{User: "user1", Namespace: "hello", Name: "first testGroup"},
+			{User: "user1", Namespace: "hello", Name: "second testGroup"},
+		}, helloGroups)
+	}
+
+	{
+		invalidUserGroups, err := rs.ListRuleGroupsForUserAndNamespace(context.Background(), "invalid", "")
+		require.NoError(t, err)
+		require.Empty(t, invalidUserGroups)
+	}
+
+	{
+		user2Groups, err := rs.ListRuleGroupsForUserAndNamespace(context.Background(), "user2", "")
+		require.NoError(t, err)
+		require.ElementsMatch(t, []*rules.RuleGroupDesc{
+			{User: "user2", Namespace: "+-!@#$%. ", Name: "different user"},
+		}, user2Groups)
+	}
+}
+
+func TestLoadRules(t *testing.T) {
+	obj := chunk.NewMockStorage()
+	rs := NewRuleStore(obj, 5)
+
+	groups := []testGroup{
+		{user: "user1", namespace: "hello", ruleGroup: rulefmt.RuleGroup{Name: "first testGroup", Interval: model.Duration(time.Minute), Rules: []rulefmt.RuleNode{{
+			For:    model.Duration(5 * time.Minute),
+			Labels: map[string]string{"label1": "value1"},
+		}}}},
+		{user: "user1", namespace: "hello", ruleGroup: rulefmt.RuleGroup{Name: "second testGroup", Interval: model.Duration(2 * time.Minute)}},
+		{user: "user1", namespace: "world", ruleGroup: rulefmt.RuleGroup{Name: "another namespace testGroup", Interval: model.Duration(1 * time.Hour)}},
+		{user: "user2", namespace: "+-!@#$%. ", ruleGroup: rulefmt.RuleGroup{Name: "different user", Interval: model.Duration(5 * time.Minute)}},
+	}
+
+	for _, g := range groups {
+		desc := rules.ToProto(g.user, g.namespace, g.ruleGroup)
+		require.NoError(t, rs.SetRuleGroup(context.Background(), g.user, g.namespace, desc))
+	}
+
+	allGroupsMap, err := rs.ListAllRuleGroups(context.Background())
+
+	// Before load, rules are not loaded
+	{
+		require.NoError(t, err)
+		require.Len(t, allGroupsMap, 2)
+		require.ElementsMatch(t, []*rules.RuleGroupDesc{
+			{User: "user1", Namespace: "hello", Name: "first testGroup"},
+			{User: "user1", Namespace: "hello", Name: "second testGroup"},
+			{User: "user1", Namespace: "world", Name: "another namespace testGroup"},
+		}, allGroupsMap["user1"])
+		require.ElementsMatch(t, []*rules.RuleGroupDesc{
+			{User: "user2", Namespace: "+-!@#$%. ", Name: "different user"},
+		}, allGroupsMap["user2"])
+	}
+
+	err = rs.LoadRuleGroups(context.Background(), allGroupsMap)
+	require.NoError(t, err)
+
+	// After load, rules are loaded.
+	{
+		require.NoError(t, err)
+		require.Len(t, allGroupsMap, 2)
+
+		require.ElementsMatch(t, []*rules.RuleGroupDesc{
+			{User: "user1", Namespace: "hello", Name: "first testGroup", Interval: time.Minute, Rules: []*rules.RuleDesc{
+				{
+					For:    5 * time.Minute,
+					Labels: []github_com_cortexproject_cortex_pkg_ingester_client.LabelAdapter{{Name: "label1", Value: "value1"}},
+				},
+			}},
+			{User: "user1", Namespace: "hello", Name: "second testGroup", Interval: 2 * time.Minute},
+			{User: "user1", Namespace: "world", Name: "another namespace testGroup", Interval: 1 * time.Hour},
+		}, allGroupsMap["user1"])
+
+		require.ElementsMatch(t, []*rules.RuleGroupDesc{
+			{User: "user2", Namespace: "+-!@#$%. ", Name: "different user", Interval: 5 * time.Minute},
+		}, allGroupsMap["user2"])
+	}
+
+	// Loading group with mismatched info fails.
+	require.NoError(t, rs.SetRuleGroup(context.Background(), "user1", "hello", &rules.RuleGroupDesc{User: "user2", Namespace: "world", Name: "first testGroup"}))
+	require.EqualError(t, rs.LoadRuleGroups(context.Background(), allGroupsMap), "mismatch between requested rule group and loaded rule group, requested: user=\"user1\", namespace=\"hello\", group=\"first testGroup\", loaded: user=\"user2\", namespace=\"world\", group=\"first testGroup\"")
+
+	// Load with missing rule groups fails.
+	require.NoError(t, rs.DeleteRuleGroup(context.Background(), "user1", "hello", "first testGroup"))
+	require.EqualError(t, rs.LoadRuleGroups(context.Background(), allGroupsMap), "group does not exist")
+}

--- a/pkg/ruler/rules/store.go
+++ b/pkg/ruler/rules/store.go
@@ -19,16 +19,19 @@ var (
 	ErrUserNotFound = errors.New("no rule groups found for user")
 )
 
-// RuleStore is used to store and retrieve rules
+// RuleStore is used to store and retrieve rules.
+// Methods starting with "List" prefix may return partially loaded groups: with only group Name, Namespace and User fields set.
+// To make sure that rules within each group are loaded, client must use LoadRuleGroups method.
 type RuleStore interface {
 	ListAllUsers(ctx context.Context) ([]string, error)
-
-	// Returns all rule groups, and loads rules for each group.
-	LoadAllRuleGroups(ctx context.Context) (map[string]RuleGroupList, error)
-
-	// LoadRuleGroupsForUserAndNamespace returns all the active rule groups for a user from given namespace.
+	ListAllRuleGroups(ctx context.Context) (map[string]RuleGroupList, error)
+	// ListRuleGroupsForUserAndNamespace returns all the active rule groups for a user from given namespace.
 	// If namespace is empty, groups from all namespaces are returned.
-	LoadRuleGroupsForUserAndNamespace(ctx context.Context, userID string, namespace string) (RuleGroupList, error)
+	ListRuleGroupsForUserAndNamespace(ctx context.Context, userID string, namespace string) (RuleGroupList, error)
+
+	// LoadRuleGroups loads rules for each rule group in the map.
+	LoadRuleGroups(ctx context.Context, groupsToLoad map[string]RuleGroupList) error
+
 	GetRuleGroup(ctx context.Context, userID, namespace, group string) (*RuleGroupDesc, error)
 	SetRuleGroup(ctx context.Context, userID, namespace string, group *RuleGroupDesc) error
 	DeleteRuleGroup(ctx context.Context, userID, namespace string, group string) error
@@ -70,7 +73,7 @@ func NewConfigRuleStore(c client.Client) *ConfigRuleStore {
 }
 
 func (c *ConfigRuleStore) ListAllUsers(ctx context.Context) ([]string, error) {
-	m, err := c.LoadAllRuleGroups(ctx)
+	m, err := c.ListAllRuleGroups(ctx)
 
 	// TODO: this should be optimized, if possible.
 	result := []string(nil)
@@ -81,8 +84,8 @@ func (c *ConfigRuleStore) ListAllUsers(ctx context.Context) ([]string, error) {
 	return result, err
 }
 
-// LoadAllRuleGroups implements RuleStore
-func (c *ConfigRuleStore) LoadAllRuleGroups(ctx context.Context) (map[string]RuleGroupList, error) {
+// ListAllRuleGroups implements RuleStore
+func (c *ConfigRuleStore) ListAllRuleGroups(ctx context.Context) (map[string]RuleGroupList, error) {
 	configs, err := c.configClient.GetRules(ctx, c.since)
 
 	if err != nil {
@@ -124,8 +127,8 @@ func getLatestConfigID(cfgs map[string]userconfig.VersionedRulesConfig, latest u
 	return ret
 }
 
-func (c *ConfigRuleStore) LoadRuleGroupsForUserAndNamespace(ctx context.Context, userID string, namespace string) (RuleGroupList, error) {
-	r, err := c.LoadAllRuleGroups(ctx)
+func (c *ConfigRuleStore) ListRuleGroupsForUserAndNamespace(ctx context.Context, userID string, namespace string) (RuleGroupList, error) {
+	r, err := c.ListAllRuleGroups(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -144,6 +147,11 @@ func (c *ConfigRuleStore) LoadRuleGroupsForUserAndNamespace(ctx context.Context,
 	}
 
 	return list, nil
+}
+
+func (c *ConfigRuleStore) LoadRuleGroups(ctx context.Context, groupsToLoad map[string]RuleGroupList) error {
+	// Since ConfigRuleStore already Loads the rules in the List methods, there is nothing left to do here.
+	return nil
 }
 
 // GetRuleGroup is not implemented

--- a/pkg/ruler/rules/store.go
+++ b/pkg/ruler/rules/store.go
@@ -30,6 +30,8 @@ type RuleStore interface {
 	ListRuleGroupsForUserAndNamespace(ctx context.Context, userID string, namespace string) (RuleGroupList, error)
 
 	// LoadRuleGroups loads rules for each rule group in the map.
+	// Parameter with groups to load *MUST* be coming from one of the List methods.
+	// Reason is that some implementations don't do anything, since their List method already loads the rules.
 	LoadRuleGroups(ctx context.Context, groupsToLoad map[string]RuleGroupList) error
 
 	GetRuleGroup(ctx context.Context, userID, namespace, group string) (*RuleGroupDesc, error)

--- a/pkg/ruler/rules/store_test.go
+++ b/pkg/ruler/rules/store_test.go
@@ -35,7 +35,7 @@ func Test_ConfigRuleStoreError(t *testing.T) {
 	}
 
 	store := NewConfigRuleStore(mock)
-	_, err := store.LoadAllRuleGroups(context.Background())
+	_, err := store.ListAllRuleGroups(context.Background())
 
 	assert.Equal(t, mock.err, err, "Unexpected error returned")
 }
@@ -54,7 +54,7 @@ func Test_ConfigRuleStoreReturn(t *testing.T) {
 	}
 
 	store := NewConfigRuleStore(mock)
-	rules, _ := store.LoadAllRuleGroups(context.Background())
+	rules, _ := store.ListAllRuleGroups(context.Background())
 
 	assert.Equal(t, 1, len(rules["user"]))
 	assert.Equal(t, id, store.since)
@@ -73,7 +73,7 @@ func Test_ConfigRuleStoreDelete(t *testing.T) {
 	}
 
 	store := NewConfigRuleStore(mock)
-	_, _ = store.LoadAllRuleGroups(context.Background())
+	_, _ = store.ListAllRuleGroups(context.Background())
 
 	mock.cfgs["user"] = userconfig.VersionedRulesConfig{
 		ID:        1,
@@ -81,7 +81,7 @@ func Test_ConfigRuleStoreDelete(t *testing.T) {
 		DeletedAt: time.Unix(0, 1),
 	}
 
-	rules, _ := store.LoadAllRuleGroups(context.Background())
+	rules, _ := store.ListAllRuleGroups(context.Background())
 
 	assert.Equal(t, 0, len(rules["user"]))
 }
@@ -99,7 +99,7 @@ func Test_ConfigRuleStoreAppend(t *testing.T) {
 	}
 
 	store := NewConfigRuleStore(mock)
-	_, _ = store.LoadAllRuleGroups(context.Background())
+	_, _ = store.ListAllRuleGroups(context.Background())
 
 	delete(mock.cfgs, "user")
 	mock.cfgs["user2"] = userconfig.VersionedRulesConfig{
@@ -108,7 +108,7 @@ func Test_ConfigRuleStoreAppend(t *testing.T) {
 		DeletedAt: zeroTime,
 	}
 
-	rules, _ := store.LoadAllRuleGroups(context.Background())
+	rules, _ := store.ListAllRuleGroups(context.Background())
 
 	assert.Equal(t, 2, len(rules))
 }
@@ -136,7 +136,7 @@ func Test_ConfigRuleStoreSinceSet(t *testing.T) {
 	}
 
 	store := NewConfigRuleStore(mock)
-	_, _ = store.LoadAllRuleGroups(context.Background())
+	_, _ = store.ListAllRuleGroups(context.Background())
 	assert.Equal(t, userconfig.ID(100), store.since)
 
 	delete(mock.cfgs, "user")
@@ -147,7 +147,7 @@ func Test_ConfigRuleStoreSinceSet(t *testing.T) {
 		DeletedAt: zeroTime,
 	}
 
-	_, _ = store.LoadAllRuleGroups(context.Background())
+	_, _ = store.ListAllRuleGroups(context.Background())
 	assert.Equal(t, userconfig.ID(100), store.since)
 
 	mock.cfgs["user2"] = userconfig.VersionedRulesConfig{
@@ -156,7 +156,7 @@ func Test_ConfigRuleStoreSinceSet(t *testing.T) {
 		DeletedAt: zeroTime,
 	}
 
-	_, _ = store.LoadAllRuleGroups(context.Background())
+	_, _ = store.ListAllRuleGroups(context.Background())
 	assert.Equal(t, userconfig.ID(101), store.since)
 }
 

--- a/pkg/ruler/storage.go
+++ b/pkg/ruler/storage.go
@@ -100,5 +100,5 @@ func newObjRuleStore(client chunk.ObjectClient, err error) (rules.RuleStore, err
 	if err != nil {
 		return nil, err
 	}
-	return objectclient.NewRuleStore(client), nil
+	return objectclient.NewRuleStore(client, loadRulesConcurrency), nil
 }

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -126,7 +126,7 @@ func (m *mockRuleStore) ListAllUsers(_ context.Context) ([]string, error) {
 	return result, nil
 }
 
-func (m *mockRuleStore) LoadAllRuleGroups(_ context.Context) (map[string]rules.RuleGroupList, error) {
+func (m *mockRuleStore) ListAllRuleGroups(_ context.Context) (map[string]rules.RuleGroupList, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -138,7 +138,7 @@ func (m *mockRuleStore) LoadAllRuleGroups(_ context.Context) (map[string]rules.R
 	return result, nil
 }
 
-func (m *mockRuleStore) LoadRuleGroupsForUserAndNamespace(ctx context.Context, userID, namespace string) (rules.RuleGroupList, error) {
+func (m *mockRuleStore) ListRuleGroupsForUserAndNamespace(_ context.Context, userID, namespace string) (rules.RuleGroupList, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -166,7 +166,12 @@ func (m *mockRuleStore) LoadRuleGroupsForUserAndNamespace(ctx context.Context, u
 	return namespaceRules, nil
 }
 
-func (m *mockRuleStore) GetRuleGroup(ctx context.Context, userID string, namespace string, group string) (*rules.RuleGroupDesc, error) {
+func (m *mockRuleStore) LoadRuleGroups(ctx context.Context, groupsToLoad map[string]rules.RuleGroupList) error {
+	// Nothing to do, as mockRuleStore already returns groups with loaded rules.
+	return nil
+}
+
+func (m *mockRuleStore) GetRuleGroup(_ context.Context, userID string, namespace string, group string) (*rules.RuleGroupDesc, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 


### PR DESCRIPTION
**What this PR does**: This PR splits listing and loading rules in `rules.RuleStore` interface and most importantly `objectclient.RuleStore` implementation. This makes it more efficient, since we don't need to load rules that ruler doesn't own. Other implementations (local, configdb) still combine listing and loading.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
