### PR TITLE
Add more documentation on AM templates

### DIFF
--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -639,6 +639,8 @@ alertmanager_config: |
   global:
     smtp_smarthost: 'localhost:25'
     smtp_from: 'youraddress@example.org'
+  templates:
+    - 'default_template'
   route:
     receiver: example-email
   receivers:
@@ -764,7 +766,16 @@ The following schema is used both when retrieving the current configs from the A
 - **`config.rules_files`**<br />
   The contents of a rules file should be as described [here](http://prometheus.io/docs/prometheus/latest/configuration/recording_rules/), encoded as a single string to fit within the overall JSON payload.
 - **`config.template_files`**<br />
-  The contents of a template file should be as described [here](https://prometheus.io/docs/alerting/notification_examples/#defining-reusable-templates), encoded as a single string to fit within the overall JSON payload.
+  The contents of a template file should be as described [here](https://prometheus.io/docs/alerting/notification_examples/#defining-reusable-templates), encoded as a single string to fit within the overall JSON payload. These entries should match the `templates` entries in `alertmanager_config`. Example:
+  ```yaml
+  template_files:
+    myorg.tmpl: |
+      {{ define "__alertmanager" }}AlertManager{{ end }}
+      {{ define "__alertmanagerURL" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver | urlquery }}{{ end }}
+  alertmanager_config: |
+    templates:
+      - 'myorg.tmpl'
+  ```
 
 ### Get rule files
 


### PR DESCRIPTION
Signed-off-by: Stan Kwong <stanley.kwong@robinhood.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds more documentation on how to import template files into your Alertmanager configuration.

**Which issue(s) this PR fixes**:
Fixes https://github.com/cortexproject/cortex/issues/3194

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [documentation changes don't seem to fix into any of these?] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
