### PR TITLE
Fix for #3111 Read form values and request body before sending request to RoundTripper 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [CHANGE] Renamed `-<prefix>.redis.enable-tls` CLI flag to `-<prefix>.redis.tls-enabled`, and its respective YAML config option from `enable_tls` to `tls_enabled`. #3298
 * [CHANGE] Increased default `-<prefix>.redis.timeout` from `100ms` to `500ms`. #3301
 * [CHANGE] `cortex_alertmanager_config_invalid` has been removed in favor of `cortex_alertmanager_config_last_reload_successful`. #3289
+* [CHANGE] Query POST requests: body size is read up to 10MiB. #3276
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-tenant` globally, or using per-tenant limit `max_queriers_per_tenant`), each tenants's requests will be handled by different set of queriers. #3113 #3257
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding ingesters on the read path. When ingesters shuffle-sharding is enabled and `-querier.shuffle-sharding-ingesters-lookback-period` is set, queriers will fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. #3252
 * [FEATURE] Query-frontend: added `compression` config to support results cache with compression. #3217
@@ -103,6 +104,7 @@
 * [BUGFIX] Fix common prefixes returned by List method of S3 client. #3358
 * [BUGFIX] Honor configured timeout in Azure and GCS object clients. #3285
 * [BUGFIX] Shuffle sharding: fixed max global series per user/metric limit when shuffle sharding and `-distributor.shard-by-all-labels=true` are both enabled in distributor. When using these global limits you should now set `-distributor.sharding-strategy` and `-distributor.zone-awareness-enabled` to ingesters too. #3369
+* [BUGFIX] Slow query logging: when using downstream server request parameters were not logged. #3276
 
 ## 1.4.0 / 2020-10-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 * [CHANGE] Renamed `-<prefix>.redis.enable-tls` CLI flag to `-<prefix>.redis.tls-enabled`, and its respective YAML config option from `enable_tls` to `tls_enabled`. #3298
 * [CHANGE] Increased default `-<prefix>.redis.timeout` from `100ms` to `500ms`. #3301
 * [CHANGE] `cortex_alertmanager_config_invalid` has been removed in favor of `cortex_alertmanager_config_last_reload_successful`. #3289
-* [CHANGE] Query POST requests: body size is read up to 10MiB. #3276
+* [CHANGE] Query-frontend: POST requests whose body size exceeds 10MiB will be rejected. The max body size can be customised via `-frontend.max-body-size`. #3276
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-tenant` globally, or using per-tenant limit `max_queriers_per_tenant`), each tenants's requests will be handled by different set of queriers. #3113 #3257
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding ingesters on the read path. When ingesters shuffle-sharding is enabled and `-querier.shuffle-sharding-ingesters-lookback-period` is set, queriers will fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. #3252
 * [FEATURE] Query-frontend: added `compression` config to support results cache with compression. #3217

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -769,6 +769,10 @@ The `query_frontend_config` configures the Cortex query-frontend.
 # CLI flag: -frontend.downstream-url
 [downstream_url: <string> | default = ""]
 
+# Max body size for downstream prometheus.
+# CLI flag: -frontend.downstream-max-body-size
+[downstream_max_body_size: <int> | default = 10485760]
+
 # Log queries that are slower than the specified duration. Set to 0 to disable.
 # Set to < 0 to enable on all queries.
 # CLI flag: -frontend.log-queries-longer-than

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -770,8 +770,8 @@ The `query_frontend_config` configures the Cortex query-frontend.
 [downstream_url: <string> | default = ""]
 
 # Max body size for downstream prometheus.
-# CLI flag: -frontend.downstream-max-body-size
-[downstream_max_body_size: <int> | default = 10485760]
+# CLI flag: -frontend.max-body-size
+[max_body_size: <int> | default = 10485760]
 
 # Log queries that are slower than the specified duration. Set to 0 to disable.
 # Set to < 0 to enable on all queries.

--- a/docs/configuration/prometheus-frontend.yml
+++ b/docs/configuration/prometheus-frontend.yml
@@ -56,5 +56,3 @@ frontend:
 
   # The Prometheus URL to which the query-frontend should connect to.
   downstream_url: http://prometheus.mydomain.com
-  # Max body size for downstream prometheus
-  downstream_max_body_size: 10485760

--- a/docs/configuration/prometheus-frontend.yml
+++ b/docs/configuration/prometheus-frontend.yml
@@ -56,3 +56,5 @@ frontend:
 
   # The Prometheus URL to which the query-frontend should connect to.
   downstream_url: http://prometheus.mydomain.com
+  # Max body size for downstream prometheus
+  downstream_max_body_size: 10485760

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -179,8 +179,6 @@ func (f *Frontend) Handler() http.Handler {
 }
 
 func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
-	startTime := time.Now()
-
 	// to parse form we need to be sure
 	// that roundtriper request gets not read reader
 	var buf bytes.Buffer
@@ -192,6 +190,7 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 	}
 	r.Body = ioutil.NopCloser(&buf)
 
+	startTime := time.Now()
 	resp, err := f.roundTripper.RoundTrip(r)
 	queryResponseTime := time.Since(startTime)
 

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -182,7 +182,7 @@ func (f *Frontend) Handler() http.Handler {
 func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
-	// buffer the body for later use in case of slow query
+	// Buffer the body for later use to track slow queries.
 	var buf bytes.Buffer
 	r.Body = http.MaxBytesReader(w, r.Body, int64(maxBodySize))
 	r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &buf))

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -47,7 +47,7 @@ type Config struct {
 	MaxOutstandingPerTenant int           `yaml:"max_outstanding_per_tenant"`
 	CompressResponses       bool          `yaml:"compress_responses"`
 	DownstreamURL           string        `yaml:"downstream_url"`
-	DownstreamMaxBodySize   int64         `yaml:"downstream_max_body_size"`
+	MaxBodySize             int64         `yaml:"max_body_size"`
 	LogQueriesLongerThan    time.Duration `yaml:"log_queries_longer_than"`
 }
 
@@ -56,7 +56,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxOutstandingPerTenant, "querier.max-outstanding-requests-per-tenant", 100, "Maximum number of outstanding requests per tenant per frontend; requests beyond this error with HTTP 429.")
 	f.BoolVar(&cfg.CompressResponses, "querier.compress-http-responses", false, "Compress HTTP responses.")
 	f.StringVar(&cfg.DownstreamURL, "frontend.downstream-url", "", "URL of downstream Prometheus.")
-	f.Int64Var(&cfg.DownstreamMaxBodySize, "frontend.downstream-max-body-size", defaultMaxBodySize, "Max body size for downstream prometheus.")
+	f.Int64Var(&cfg.MaxBodySize, "frontend.max-body-size", defaultMaxBodySize, "Max body size for downstream prometheus.")
 	f.DurationVar(&cfg.LogQueriesLongerThan, "frontend.log-queries-longer-than", 0, "Log queries that are slower than the specified duration. Set to 0 to disable. Set to < 0 to enable on all queries.")
 }
 
@@ -187,7 +187,7 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 
 	// Buffer the body for later use to track slow queries.
 	var buf bytes.Buffer
-	r.Body = http.MaxBytesReader(w, r.Body, f.cfg.DownstreamMaxBodySize)
+	r.Body = http.MaxBytesReader(w, r.Body, f.cfg.MaxBodySize)
 	r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &buf))
 
 	startTime := time.Now()

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -32,13 +32,13 @@ import (
 const (
 	// StatusClientClosedRequest is the status code for when a client request cancellation of an http request
 	StatusClientClosedRequest = 499
+	maxBodySize               = 10 * 1024 * 1024 // 10 MiB
 )
 
 var (
 	errTooManyRequest   = httpgrpc.Errorf(http.StatusTooManyRequests, "too many outstanding requests")
 	errCanceled         = httpgrpc.Errorf(StatusClientClosedRequest, context.Canceled.Error())
 	errDeadlineExceeded = httpgrpc.Errorf(http.StatusGatewayTimeout, context.DeadlineExceeded.Error())
-	maxBodySize         = 10 * 1024 * 1024 // 10 MiB
 )
 
 // Config for a Frontend.
@@ -202,11 +202,8 @@ func (f *Frontend) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(resp.StatusCode)
-	_, err = io.Copy(w, resp.Body)
-	if err != nil {
-		writeError(w, err)
-		return
-	}
+	// we don't check for copy error as there is no much we can do at this point
+	io.Copy(w, resp.Body)
 
 	f.reportSlowQuery(queryResponseTime, r, buf)
 }

--- a/pkg/querier/frontend/frontend.go
+++ b/pkg/querier/frontend/frontend.go
@@ -244,7 +244,6 @@ func writeError(w http.ResponseWriter, err error) {
 
 // RoundTrip implement http.Transport.
 func (f *Frontend) RoundTrip(r *http.Request) (*http.Response, error) {
-	defer r.Body.Close()
 	req, err := server.HTTPRequest(r)
 	if err != nil {
 		return nil, err

--- a/pkg/querier/frontend/frontend_test.go
+++ b/pkg/querier/frontend/frontend_test.go
@@ -255,7 +255,7 @@ func TestFrontendCheckReady(t *testing.T) {
 	}
 }
 
-func TestFrontend_LogsSlowQueriesFormValues_Issue3111(t *testing.T) {
+func TestFrontend_LogsSlowQueriesFormValues(t *testing.T) {
 	// Create an HTTP server listening locally. This server mocks the downstream
 	// Prometheus API-compatible server.
 	downstreamListen, err := net.Listen("tcp", "localhost:0")
@@ -284,7 +284,7 @@ func TestFrontend_LogsSlowQueriesFormValues_Issue3111(t *testing.T) {
 		data.Set("test", "form")
 		data.Set("issue", "3111")
 
-		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/", addr), strings.NewReader(data.Encode()))
+		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/?foo=bar", addr), strings.NewReader(data.Encode()))
 		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 		req.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
 
@@ -311,6 +311,7 @@ func TestFrontend_LogsSlowQueriesFormValues_Issue3111(t *testing.T) {
 		assert.Contains(t, logs, "msg=\"slow query detected\"")
 		assert.Contains(t, logs, "param_issue=3111")
 		assert.Contains(t, logs, "param_test=form")
+		assert.Contains(t, logs, "param_foo=bar")
 	}
 
 	testFrontend(t, config, nil, test, false, l)

--- a/pkg/querier/frontend/frontend_test.go
+++ b/pkg/querier/frontend/frontend_test.go
@@ -336,7 +336,7 @@ func TestFrontend_ReturnsRequestBodyTooLargeError(t *testing.T) {
 	// Configure the query-frontend with the mocked downstream server.
 	config := defaultFrontendConfig()
 	config.DownstreamURL = fmt.Sprintf("http://%s", downstreamListen.Addr())
-	config.DownstreamMaxBodySize = 1
+	config.MaxBodySize = 1
 
 	test := func(addr string) {
 		data := url.Values{}

--- a/pkg/querier/frontend/frontend_test.go
+++ b/pkg/querier/frontend/frontend_test.go
@@ -304,6 +304,7 @@ func TestFrontend_LogsSlowQueriesFormValues_Issue3111(t *testing.T) {
 		}
 
 		resp, err := client.Do(req)
+		assert.NoError(t, err)
 		b, err := ioutil.ReadAll(resp.Body)
 		defer resp.Body.Close()
 		assert.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Golang `http.RoundTripper` requires to close request body (https://golang.org/pkg/net/http/#RoundTripper), so accessing request body after running roundtrip can result in two scenarios:

a) silent - Body is NopReader and no form values is reported
b) warning - Body is ReadCloser and warning pops up about accessing closed body

This PR attempts to capture form values before running roundtrip which allows us to report form values and prevents us from breaking http (content length is X but body len is 0). 

**Which issue(s) this PR fixes**:
Fixes #3111

**Checklist**
- [x] Tests updated 
- [ ] ~Documentation added~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

PS. Let me know if I should put something in CHANGELOG regarding this. 