### PR TITLE
Add injectable middlewares to bucket client

### DIFF
--- a/pkg/storage/tsdb/bucket_client.go
+++ b/pkg/storage/tsdb/bucket_client.go
@@ -32,6 +32,11 @@ func NewBucketClient(ctx context.Context, cfg BucketConfig, name string, logger 
 		return nil, err
 	}
 
+	// Wrap the client with any provided middleware
+	for _, wrap := range cfg.Middleware {
+		client = wrap(client)
+	}
+
 	return objstore.NewTracingBucket(bucketWithMetrics(client, name, reg)), nil
 }
 

--- a/pkg/storage/tsdb/bucket_client.go
+++ b/pkg/storage/tsdb/bucket_client.go
@@ -33,7 +33,7 @@ func NewBucketClient(ctx context.Context, cfg BucketConfig, name string, logger 
 	}
 
 	// Wrap the client with any provided middleware
-	for _, wrap := range cfg.Middleware {
+	for _, wrap := range cfg.Middlewares {
 		client = wrap(client)
 	}
 

--- a/pkg/storage/tsdb/bucket_client.go
+++ b/pkg/storage/tsdb/bucket_client.go
@@ -32,12 +32,17 @@ func NewBucketClient(ctx context.Context, cfg BucketConfig, name string, logger 
 		return nil, err
 	}
 
+	client = objstore.NewTracingBucket(bucketWithMetrics(client, name, reg))
+
 	// Wrap the client with any provided middleware
 	for _, wrap := range cfg.Middlewares {
-		client = wrap(client)
+		client, err = wrap(client)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return objstore.NewTracingBucket(bucketWithMetrics(client, name, reg)), nil
+	return client, nil
 }
 
 func bucketWithMetrics(bucketClient objstore.Bucket, name string, reg prometheus.Registerer) objstore.Bucket {

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alecthomas/units"
 	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/store"
 
 	"github.com/cortexproject/cortex/pkg/storage/backend/azure"
@@ -64,6 +65,10 @@ type BucketConfig struct {
 	GCS        gcs.Config        `yaml:"gcs"`
 	Azure      azure.Config      `yaml:"azure"`
 	Filesystem filesystem.Config `yaml:"filesystem"`
+
+	// Not used internally, meant to allow callers to wrap Buckets
+	// created using this config
+	Middleware []func(objstore.Bucket) objstore.Bucket `yaml:"-"`
 }
 
 // BlocksStorageConfig holds the config information for the blocks storage.

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -68,7 +68,7 @@ type BucketConfig struct {
 
 	// Not used internally, meant to allow callers to wrap Buckets
 	// created using this config
-	Middleware []func(objstore.Bucket) objstore.Bucket `yaml:"-"`
+	Middlewares []func(objstore.Bucket) objstore.Bucket `yaml:"-"`
 }
 
 // BlocksStorageConfig holds the config information for the blocks storage.

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -68,7 +68,7 @@ type BucketConfig struct {
 
 	// Not used internally, meant to allow callers to wrap Buckets
 	// created using this config
-	Middlewares []func(objstore.Bucket) objstore.Bucket `yaml:"-"`
+	Middlewares []func(objstore.Bucket) (objstore.Bucket, error) `yaml:"-"`
 }
 
 // BlocksStorageConfig holds the config information for the blocks storage.


### PR DESCRIPTION
**What this PR does**:

- This adds a config field for injecting middlewares when creating a bucket client to allow for the clients created within modules to be created with these middlewares.
- This approach is overtly simple and a factory approach similar to the Ruler may be preferable. 