### PR TITLE
Make it possible to extend Makefile with custom settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ blocksconvert
 cortex
 query-tee
 test-exporter
+
+# This is custom Makefile modification, if it exists.
+Makefile.local

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Local settings (optional). See Makefile.local.example for an example.
+# WARNING: do not commit to a repository!
+-include Makefile.local
+
 .PHONY: all test clean images protos exes dist doc clean-doc check-doc
 .DEFAULT_GOAL := all
 

--- a/Makefile.local.example
+++ b/Makefile.local.example
@@ -1,0 +1,10 @@
+# Example of extending Makefile with Makefile.local.
+
+BUILD_IMAGE ?= quay.io/cortexproject/build-image
+IMAGE_PREFIX ?= custom-prefix/
+
+blocksconvert-push: cmd/blocksconvert/.uptodate
+	docker push $(IMAGE_PREFIX)blocksconvert:$(IMAGE_TAG)
+
+cortex-push: cmd/cortex/.uptodate
+	docker push $(IMAGE_PREFIX)cortex:$(IMAGE_TAG)


### PR DESCRIPTION
**What this PR does**: This PR modifies `Makefile` to include `Makefile.local` if it exists, so that it is possible to extend it with custom settings and rules without committing those in shared repository. Example `Makefile.local.example` is included for inspiration.

If `Makefile.local` is missing, nothing changes.