### PR TITLE
fix timeout handling in GetObject for azure and gcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@
 * [BUGFIX] Ingester: fail to start an ingester running the blocks storage, if unable to load any existing TSDB at startup. #3354
 * [BUGFIX] Blocks storage: Avoid deletion of blocks in the ingester which are not shipped to the storage yet. #3346
 * [BUGFIX] Fix common prefixes returned by List method of S3 client. #3358
-* [BUGFIX] fix timeout handling in `GetObject` method of azure and gcs object clients. #3285
+* [BUGFIX] Honor configured timeout in Azure and GCS object clients. #3285
 
 ## 1.4.0 / 2020-10-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 * [BUGFIX] Ingester: fail to start an ingester running the blocks storage, if unable to load any existing TSDB at startup. #3354
 * [BUGFIX] Blocks storage: Avoid deletion of blocks in the ingester which are not shipped to the storage yet. #3346
 * [BUGFIX] Fix common prefixes returned by List method of S3 client. #3358
+* [BUGFIX] fix timeout handling in `GetObject` method of azure and gcs object clients. #3285
 
 ## 1.4.0 / 2020-10-02
 

--- a/pkg/alertmanager/alerts/objectclient/store.go
+++ b/pkg/alertmanager/alerts/objectclient/store.go
@@ -60,7 +60,7 @@ func (a *AlertStore) getAlertConfig(ctx context.Context, key string) (alerts.Ale
 		return alerts.AlertConfigDesc{}, err
 	}
 
-	defer runutil.CloseWithLogOnErr(util.Logger, readCloser, "close object reader")
+	defer runutil.CloseWithLogOnErr(util.Logger, readCloser, "close alert config reader")
 
 	buf, err := ioutil.ReadAll(readCloser)
 	if err != nil {

--- a/pkg/alertmanager/alerts/objectclient/store.go
+++ b/pkg/alertmanager/alerts/objectclient/store.go
@@ -6,8 +6,11 @@ import (
 	"io/ioutil"
 	"path"
 
+	"github.com/thanos-io/thanos/pkg/runutil"
+
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
 	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 // Object Alert Storage Schema
@@ -52,12 +55,14 @@ func (a *AlertStore) ListAlertConfigs(ctx context.Context) (map[string]alerts.Al
 }
 
 func (a *AlertStore) getAlertConfig(ctx context.Context, key string) (alerts.AlertConfigDesc, error) {
-	reader, err := a.client.GetObject(ctx, key)
+	readCloser, err := a.client.GetObject(ctx, key)
 	if err != nil {
 		return alerts.AlertConfigDesc{}, err
 	}
 
-	buf, err := ioutil.ReadAll(reader)
+	defer runutil.CloseWithLogOnErr(util.Logger, readCloser, "close object reader")
+
+	buf, err := ioutil.ReadAll(readCloser)
 	if err != nil {
 		return alerts.AlertConfigDesc{}, err
 	}

--- a/pkg/chunk/azure/blob_storage_client.go
+++ b/pkg/chunk/azure/blob_storage_client.go
@@ -111,10 +111,7 @@ func (b *BlobStorage) Stop() {}
 
 func (b *BlobStorage) GetObject(ctx context.Context, objectKey string) (io.ReadCloser, error) {
 	if b.cfg.RequestTimeout > 0 {
-		// The context will be cancelled with the timeout or when the parent context is cancelled, whichever occurs first.
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, b.cfg.RequestTimeout)
-		defer cancel()
+		ctx, _ = context.WithTimeout(ctx, b.cfg.RequestTimeout)
 	}
 
 	blockBlobURL, err := b.getBlobURL(objectKey)

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/api/iterator"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
+	"github.com/cortexproject/cortex/pkg/chunk/util"
 )
 
 type GCSObjectClient struct {
@@ -67,10 +68,26 @@ func (s *GCSObjectClient) Stop() {
 // GetObject returns a reader for the specified object key from the configured GCS bucket. If the
 // key does not exist a generic chunk.ErrStorageObjectNotFound error is returned.
 func (s *GCSObjectClient) GetObject(ctx context.Context, objectKey string) (io.ReadCloser, error) {
+	var cancel context.CancelFunc
 	if s.cfg.RequestTimeout > 0 {
-		ctx, _ = context.WithTimeout(ctx, s.cfg.RequestTimeout)
+		ctx, cancel = context.WithTimeout(ctx, s.cfg.RequestTimeout)
 	}
 
+	rc, err := s.getObject(ctx, objectKey)
+	if cancel != nil {
+		if err != nil {
+			// cancel the context if there is an error.
+			cancel()
+			return nil, err
+		}
+		// else return a wrapped ReadCloser which cancels the context while closing the reader.
+		rc = util.NewReadCloserWithContextCancelFunc(rc, cancel)
+	}
+
+	return rc, nil
+}
+
+func (s *GCSObjectClient) getObject(ctx context.Context, objectKey string) (rc io.ReadCloser, err error) {
 	reader, err := s.bucket.Object(objectKey).NewReader(ctx)
 
 	if err != nil {

--- a/pkg/chunk/gcp/gcs_object_client.go
+++ b/pkg/chunk/gcp/gcs_object_client.go
@@ -68,10 +68,7 @@ func (s *GCSObjectClient) Stop() {
 // key does not exist a generic chunk.ErrStorageObjectNotFound error is returned.
 func (s *GCSObjectClient) GetObject(ctx context.Context, objectKey string) (io.ReadCloser, error) {
 	if s.cfg.RequestTimeout > 0 {
-		// The context will be cancelled with the timeout or when the parent context is cancelled, whichever occurs first.
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, s.cfg.RequestTimeout)
-		defer cancel()
+		ctx, _ = context.WithTimeout(ctx, s.cfg.RequestTimeout)
 	}
 
 	reader, err := s.bucket.Object(objectKey).NewReader(ctx)

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -61,6 +61,7 @@ type ReadBatchIterator interface {
 // ObjectClient is used to store arbitrary data in Object Store (S3/GCS/Azure/...)
 type ObjectClient interface {
 	PutObject(ctx context.Context, objectKey string, object io.ReadSeeker) error
+	// NOTE: The consumer of GetObject should always call the Close method when it is done reading which otherwise could cause a resource leak.
 	GetObject(ctx context.Context, objectKey string) (io.ReadCloser, error)
 
 	// List objects with given prefix.

--- a/pkg/chunk/util/util.go
+++ b/pkg/chunk/util/util.go
@@ -129,7 +129,7 @@ func EnsureDirectory(dir string) error {
 }
 
 // ReadCloserWithContextCancelFunc helps with cancelling the context when closing a ReadCloser.
-// Note: The consumer of ReadCloserWithContextCancelFunc should always call the Close method when it is done reading which otherwise could cause a resource leak.
+// NOTE: The consumer of ReadCloserWithContextCancelFunc should always call the Close method when it is done reading which otherwise could cause a resource leak.
 type ReadCloserWithContextCancelFunc struct {
 	io.ReadCloser
 	cancel context.CancelFunc

--- a/pkg/chunk/util/util.go
+++ b/pkg/chunk/util/util.go
@@ -129,6 +129,7 @@ func EnsureDirectory(dir string) error {
 }
 
 // ReadCloserWithContextCancelFunc helps with cancelling the context when closing a ReadCloser.
+// Note: The consumer of ReadCloserWithContextCancelFunc should always call the Close method when it is done reading which otherwise could cause a resource leak.
 type ReadCloserWithContextCancelFunc struct {
 	io.ReadCloser
 	cancel context.CancelFunc


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
When a timeout is configured for gcs and azure object clients the `GetObject` function(which returns a reader) cancels the context in defer which means we return a reader with a cancelled context. This is causing the download operation to fail.

I think it was a mistake done by me when I refactored the code to split `GetChunk` method to have a `GetObject` method in object store clients which otherwise was downloading the chunks within the functions and not returning an object reader.

I have changed the code to not cancel the context and just set the timeout in context.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
