### PR TITLE
Error if the store gateway is run on an invalid engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * [ENHANCEMENT] Experimental Ruler API: Fetch rule groups from object storage in parallel. #3218
 * [ENHANCEMENT] Chunks GCS object storage client uses the `fields` selector to limit the payload size when listing objects in the bucket. #3218
 * [ENHANCEMENT] Added shuffle sharding support to ruler. Added new metric `cortex_ruler_sync_rules_total`. #3235
+* [ENHANCEMENT] Return an explicit error when the store-gateway is explicitly requested without a blocks storage engine. #3287
 * [BUGFIX] No-longer-needed ingester operations for queries triggered by queriers and rulers are now canceled. #3178
 * [BUGFIX] Ruler: directories in the configured `rules-path` will be removed on startup and shutdown in order to ensure they don't persist between runs. #3195
 * [BUGFIX] Handle hash-collisions in the query path. #3192

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -593,6 +593,9 @@ func (t *Cortex) initCompactor() (serv services.Service, err error) {
 
 func (t *Cortex) initStoreGateway() (serv services.Service, err error) {
 	if t.Cfg.Storage.Engine != storage.StorageEngineBlocks {
+		if t.Cfg.Target != All {
+			return nil, fmt.Errorf("storage engine must be set to blocks to enable the store-gateway")
+		}
 		return nil, nil
 	}
 


### PR DESCRIPTION
This pull request returns an explicit error if the user asks to start
the store gateway but omits to set the storage type to `blocks`.

The previous behaviour was to silently ignore the -target=store-gateway
argument.

Note that this does not apply when target is `all`.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
