### PR TITLE
feat: separate ruler into ruler and rulerAPI components

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -232,42 +232,42 @@ func (a *API) RegisterPurger(store *purger.DeleteStore, deleteRequestCancelPerio
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/admin/tsdb/cancel_delete_request", http.HandlerFunc(deleteRequestHandler.CancelDeleteRequestHandler), true, "PUT", "POST")
 }
 
-// RegisterRuler registers routes associated with the Ruler service. If the
-// API is not enabled only the ring route is registered.
-func (a *API) RegisterRuler(r *ruler.Ruler, apiEnabled bool) {
+// RegisterRuler registers routes associated with the Ruler service.
+func (a *API) RegisterRuler(r *ruler.Ruler) {
 	a.indexPage.AddLink(SectionAdminEndpoints, "/ruler/ring", "Ruler Ring Status")
 	a.RegisterRoute("/ruler/ring", r, false, "GET", "POST")
 
 	// Legacy Ring Route
 	a.RegisterRoute("/ruler_ring", r, false, "GET", "POST")
 
-	if apiEnabled {
-		// Prometheus Rule API Routes
-		a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/rules", http.HandlerFunc(r.PrometheusRules), true, "GET")
-		a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/alerts", http.HandlerFunc(r.PrometheusAlerts), true, "GET")
+	ruler.RegisterRulerServer(a.server.GRPC, r)
+}
 
-		ruler.RegisterRulerServer(a.server.GRPC, r)
+// RegisterRulerAPI registers routes associated with the Ruler API
+func (a *API) RegisterRulerAPI(r *ruler.API) {
+	// Prometheus Rule API Routes
+	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/rules", http.HandlerFunc(r.PrometheusRules), true, "GET")
+	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/alerts", http.HandlerFunc(r.PrometheusAlerts), true, "GET")
 
-		// Ruler API Routes
-		a.RegisterRoute("/api/v1/rules", http.HandlerFunc(r.ListRules), true, "GET")
-		a.RegisterRoute("/api/v1/rules/{namespace}", http.HandlerFunc(r.ListRules), true, "GET")
-		a.RegisterRoute("/api/v1/rules/{namespace}/{groupName}", http.HandlerFunc(r.GetRuleGroup), true, "GET")
-		a.RegisterRoute("/api/v1/rules/{namespace}", http.HandlerFunc(r.CreateRuleGroup), true, "POST")
-		a.RegisterRoute("/api/v1/rules/{namespace}/{groupName}", http.HandlerFunc(r.DeleteRuleGroup), true, "DELETE")
-		a.RegisterRoute("/api/v1/rules/{namespace}", http.HandlerFunc(r.DeleteNamespace), true, "DELETE")
+	// Ruler API Routes
+	a.RegisterRoute("/api/v1/rules", http.HandlerFunc(r.ListRules), true, "GET")
+	a.RegisterRoute("/api/v1/rules/{namespace}", http.HandlerFunc(r.ListRules), true, "GET")
+	a.RegisterRoute("/api/v1/rules/{namespace}/{groupName}", http.HandlerFunc(r.GetRuleGroup), true, "GET")
+	a.RegisterRoute("/api/v1/rules/{namespace}", http.HandlerFunc(r.CreateRuleGroup), true, "POST")
+	a.RegisterRoute("/api/v1/rules/{namespace}/{groupName}", http.HandlerFunc(r.DeleteRuleGroup), true, "DELETE")
+	a.RegisterRoute("/api/v1/rules/{namespace}", http.HandlerFunc(r.DeleteNamespace), true, "DELETE")
 
-		// Legacy Prometheus Rule API Routes
-		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/rules", http.HandlerFunc(r.PrometheusRules), true, "GET")
-		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/alerts", http.HandlerFunc(r.PrometheusAlerts), true, "GET")
+	// Legacy Prometheus Rule API Routes
+	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/rules", http.HandlerFunc(r.PrometheusRules), true, "GET")
+	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/alerts", http.HandlerFunc(r.PrometheusAlerts), true, "GET")
 
-		// Legacy Ruler API Routes
-		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules", http.HandlerFunc(r.ListRules), true, "GET")
-		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}", http.HandlerFunc(r.ListRules), true, "GET")
-		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}/{groupName}", http.HandlerFunc(r.GetRuleGroup), true, "GET")
-		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}", http.HandlerFunc(r.CreateRuleGroup), true, "POST")
-		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}/{groupName}", http.HandlerFunc(r.DeleteRuleGroup), true, "DELETE")
-		a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}", http.HandlerFunc(r.DeleteNamespace), true, "DELETE")
-	}
+	// Legacy Ruler API Routes
+	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules", http.HandlerFunc(r.ListRules), true, "GET")
+	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}", http.HandlerFunc(r.ListRules), true, "GET")
+	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}/{groupName}", http.HandlerFunc(r.GetRuleGroup), true, "GET")
+	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}", http.HandlerFunc(r.CreateRuleGroup), true, "POST")
+	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}/{groupName}", http.HandlerFunc(r.DeleteRuleGroup), true, "DELETE")
+	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/rules/{namespace}", http.HandlerFunc(r.DeleteNamespace), true, "DELETE")
 }
 
 // RegisterRing registers the ring UI page associated with the distributor for writes.

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -547,8 +547,13 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 		return
 	}
 
-	// Expose HTTP endpoints.
-	t.API.RegisterRuler(t.Ruler, t.Cfg.Ruler.EnableAPI)
+	// Expose HTTP/GRPC endpoints for the Ruler service
+	t.API.RegisterRuler(t.Ruler)
+
+	// If the API is enabled, register the Ruler API
+	if t.Cfg.Ruler.EnableAPI {
+		t.API.RegisterRulerAPI(ruler.NewAPI(t.Ruler, t.RulerStorage))
+	}
 
 	return t.Ruler, nil
 }

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -389,7 +389,7 @@ func (a *API) ListRules(w http.ResponseWriter, req *http.Request) {
 	}
 
 	level.Debug(logger).Log("msg", "retrieving rule groups with namespace", "userID", userID, "namespace", namespace)
-	rgs, err := r.store.ListRuleGroupsForUserAndNamespace(req.Context(), userID, namespace)
+	rgs, err := a.store.ListRuleGroupsForUserAndNamespace(req.Context(), userID, namespace)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -118,7 +118,21 @@ func respondError(logger log.Logger, w http.ResponseWriter, msg string) {
 	}
 }
 
-func (r *Ruler) PrometheusRules(w http.ResponseWriter, req *http.Request) {
+// API is used to handle HTTP requests for the ruler service
+type API struct {
+	ruler *Ruler
+	store rules.RuleStore
+}
+
+// NewAPI returns a new API struct with the provided ruler and rule store
+func NewAPI(r *Ruler, s rules.RuleStore) *API {
+	return &API{
+		ruler: r,
+		store: s,
+	}
+}
+
+func (a *API) PrometheusRules(w http.ResponseWriter, req *http.Request) {
 	logger := util.WithContext(req.Context(), util.Logger)
 	userID, ctx, err := user.ExtractOrgIDFromHTTPRequest(req)
 	if err != nil || userID == "" {
@@ -128,7 +142,7 @@ func (r *Ruler) PrometheusRules(w http.ResponseWriter, req *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	rgs, err := r.GetRules(ctx)
+	rgs, err := a.ruler.GetRules(ctx)
 
 	if err != nil {
 		respondError(logger, w, err.Error())
@@ -210,7 +224,7 @@ func (r *Ruler) PrometheusRules(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (r *Ruler) PrometheusAlerts(w http.ResponseWriter, req *http.Request) {
+func (a *API) PrometheusAlerts(w http.ResponseWriter, req *http.Request) {
 	logger := util.WithContext(req.Context(), util.Logger)
 	userID, ctx, err := user.ExtractOrgIDFromHTTPRequest(req)
 	if err != nil || userID == "" {
@@ -220,7 +234,7 @@ func (r *Ruler) PrometheusAlerts(w http.ResponseWriter, req *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	rgs, err := r.GetRules(ctx)
+	rgs, err := a.ruler.GetRules(ctx)
 
 	if err != nil {
 		respondError(logger, w, err.Error())
@@ -365,7 +379,7 @@ func parseRequest(req *http.Request, requireNamespace, requireGroup bool) (strin
 	return userID, namespace, group, nil
 }
 
-func (r *Ruler) ListRules(w http.ResponseWriter, req *http.Request) {
+func (a *API) ListRules(w http.ResponseWriter, req *http.Request) {
 	logger := util.WithContext(req.Context(), util.Logger)
 
 	userID, namespace, _, err := parseRequest(req, false, false)
@@ -387,7 +401,7 @@ func (r *Ruler) ListRules(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err = r.store.LoadRuleGroups(req.Context(), map[string]rules.RuleGroupList{userID: rgs})
+	err = a.store.LoadRuleGroups(req.Context(), map[string]rules.RuleGroupList{userID: rgs})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -399,7 +413,7 @@ func (r *Ruler) ListRules(w http.ResponseWriter, req *http.Request) {
 	marshalAndSend(formatted, w, logger)
 }
 
-func (r *Ruler) GetRuleGroup(w http.ResponseWriter, req *http.Request) {
+func (a *API) GetRuleGroup(w http.ResponseWriter, req *http.Request) {
 	logger := util.WithContext(req.Context(), util.Logger)
 	userID, namespace, groupName, err := parseRequest(req, true, true)
 	if err != nil {
@@ -407,7 +421,7 @@ func (r *Ruler) GetRuleGroup(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	rg, err := r.store.GetRuleGroup(req.Context(), userID, namespace, groupName)
+	rg, err := a.store.GetRuleGroup(req.Context(), userID, namespace, groupName)
 	if err != nil {
 		if err == store.ErrGroupNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -421,7 +435,7 @@ func (r *Ruler) GetRuleGroup(w http.ResponseWriter, req *http.Request) {
 	marshalAndSend(formatted, w, logger)
 }
 
-func (r *Ruler) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
+func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 	logger := util.WithContext(req.Context(), util.Logger)
 	userID, namespace, _, err := parseRequest(req, true, false)
 	if err != nil {
@@ -446,7 +460,7 @@ func (r *Ruler) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	errs := r.manager.ValidateRuleGroup(rg)
+	errs := a.ruler.manager.ValidateRuleGroup(rg)
 	if len(errs) > 0 {
 		e := []string{}
 		for _, err := range errs {
@@ -461,7 +475,7 @@ func (r *Ruler) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 	rgProto := store.ToProto(userID, namespace, rg)
 
 	level.Debug(logger).Log("msg", "attempting to store rulegroup", "userID", userID, "group", rgProto.String())
-	err = r.store.SetRuleGroup(req.Context(), userID, namespace, rgProto)
+	err = a.store.SetRuleGroup(req.Context(), userID, namespace, rgProto)
 	if err != nil {
 		level.Error(logger).Log("msg", "unable to store rule group", "err", err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -471,7 +485,7 @@ func (r *Ruler) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 	respondAccepted(w, logger)
 }
 
-func (r *Ruler) DeleteNamespace(w http.ResponseWriter, req *http.Request) {
+func (a *API) DeleteNamespace(w http.ResponseWriter, req *http.Request) {
 	logger := util.WithContext(req.Context(), util.Logger)
 
 	userID, namespace, _, err := parseRequest(req, true, false)
@@ -480,7 +494,7 @@ func (r *Ruler) DeleteNamespace(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err = r.store.DeleteNamespace(req.Context(), userID, namespace)
+	err = a.store.DeleteNamespace(req.Context(), userID, namespace)
 	if err != nil {
 		if err == rules.ErrGroupNamespaceNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -493,7 +507,7 @@ func (r *Ruler) DeleteNamespace(w http.ResponseWriter, req *http.Request) {
 	respondAccepted(w, logger)
 }
 
-func (r *Ruler) DeleteRuleGroup(w http.ResponseWriter, req *http.Request) {
+func (a *API) DeleteRuleGroup(w http.ResponseWriter, req *http.Request) {
 	logger := util.WithContext(req.Context(), util.Logger)
 
 	userID, namespace, groupName, err := parseRequest(req, true, true)
@@ -502,7 +516,7 @@ func (r *Ruler) DeleteRuleGroup(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err = r.store.DeleteRuleGroup(req.Context(), userID, namespace, groupName)
+	err = a.store.DeleteRuleGroup(req.Context(), userID, namespace, groupName)
 	if err != nil {
 		if err == rules.ErrGroupNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -27,10 +27,7 @@ func TestRuler_rules(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	a := API{
-		ruler: r,
-		store: r.store,
-	}
+	a := NewAPI(r, r.store)
 
 	req := requestFor(t, "GET", "https://localhost:8080/api/prom/api/v1/rules", nil, "user1")
 	w := httptest.NewRecorder()

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -27,9 +27,14 @@ func TestRuler_rules(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
+	a := API{
+		ruler: r,
+		store: r.store,
+	}
+
 	req := requestFor(t, "GET", "https://localhost:8080/api/prom/api/v1/rules", nil, "user1")
 	w := httptest.NewRecorder()
-	r.PrometheusRules(w, req)
+	a.PrometheusRules(w, req)
 
 	resp := w.Result()
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -82,9 +87,14 @@ func TestRuler_rules_special_characters(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
+	a := API{
+		ruler: r,
+		store: r.store,
+	}
+
 	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/prom/api/v1/rules", nil, "user1")
 	w := httptest.NewRecorder()
-	r.PrometheusRules(w, req)
+	a.PrometheusRules(w, req)
 
 	resp := w.Result()
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -137,9 +147,14 @@ func TestRuler_alerts(t *testing.T) {
 	defer rcleanup()
 	defer r.StopAsync()
 
+	a := API{
+		ruler: r,
+		store: r.store,
+	}
+
 	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/prom/api/v1/alerts", nil, "user1")
 	w := httptest.NewRecorder()
-	r.PrometheusAlerts(w, req)
+	a.PrometheusAlerts(w, req)
 
 	resp := w.Result()
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -170,6 +185,11 @@ func TestRuler_Create(t *testing.T) {
 	r, rcleanup := newTestRuler(t, cfg)
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
+
+	a := API{
+		ruler: r,
+		store: r.store,
+	}
 
 	tc := []struct {
 		name   string
@@ -228,8 +248,8 @@ rules:
 	for _, tt := range tc {
 		t.Run(tt.name, func(t *testing.T) {
 			router := mux.NewRouter()
-			router.Path("/api/v1/rules/{namespace}").Methods("POST").HandlerFunc(r.CreateRuleGroup)
-			router.Path("/api/v1/rules/{namespace}/{groupName}").Methods("GET").HandlerFunc(r.GetRuleGroup)
+			router.Path("/api/v1/rules/{namespace}").Methods("POST").HandlerFunc(a.CreateRuleGroup)
+			router.Path("/api/v1/rules/{namespace}/{groupName}").Methods("GET").HandlerFunc(a.GetRuleGroup)
 			// POST
 			req := requestFor(t, http.MethodPost, "https://localhost:8080/api/v1/rules/namespace", strings.NewReader(tt.input), "user1")
 			w := httptest.NewRecorder()
@@ -260,9 +280,14 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
+	a := API{
+		ruler: r,
+		store: r.store,
+	}
+
 	router := mux.NewRouter()
-	router.Path("/api/v1/rules/{namespace}").Methods(http.MethodDelete).HandlerFunc(r.DeleteNamespace)
-	router.Path("/api/v1/rules/{namespace}/{groupName}").Methods(http.MethodGet).HandlerFunc(r.GetRuleGroup)
+	router.Path("/api/v1/rules/{namespace}").Methods(http.MethodDelete).HandlerFunc(a.DeleteNamespace)
+	router.Path("/api/v1/rules/{namespace}/{groupName}").Methods(http.MethodGet).HandlerFunc(a.GetRuleGroup)
 
 	// Verify namespace1 rules are there.
 	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/v1/rules/namespace1/group1", nil, "user1")

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -84,10 +84,7 @@ func TestRuler_rules_special_characters(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	a := API{
-		ruler: r,
-		store: r.store,
-	}
+	a := NewAPI(r, r.store)
 
 	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/prom/api/v1/rules", nil, "user1")
 	w := httptest.NewRecorder()
@@ -144,10 +141,7 @@ func TestRuler_alerts(t *testing.T) {
 	defer rcleanup()
 	defer r.StopAsync()
 
-	a := API{
-		ruler: r,
-		store: r.store,
-	}
+	a := NewAPI(r, r.store)
 
 	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/prom/api/v1/alerts", nil, "user1")
 	w := httptest.NewRecorder()
@@ -183,10 +177,7 @@ func TestRuler_Create(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	a := API{
-		ruler: r,
-		store: r.store,
-	}
+	a := NewAPI(r, r.store)
 
 	tc := []struct {
 		name   string
@@ -277,10 +268,7 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	a := API{
-		ruler: r,
-		store: r.store,
-	}
+	a := NewAPI(r, r.store)
 
 	router := mux.NewRouter()
 	router.Path("/api/v1/rules/{namespace}").Methods(http.MethodDelete).HandlerFunc(a.DeleteNamespace)


### PR DESCRIPTION
**What this PR does**:

This PR decouples the ruler and rule store API into separate components and allow for their configuration and usage to be decoupled. In a later PR if the ruler is fully decoupled from the API, it will be possible to run the rules API as a standalone service which will make it easier to deal with the challenges of using an eventually consistent object storage backend.

**Checklist**
- [x] Tests updated
