### PR TITLE
Use valid grpc header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 * [BUGFIX] Experimental Alertmanager API: Do not allow empty Alertmanager configurations or bad template filenames to be submitted through the configuration API. #3185
 * [BUGFIX] Reduce failures to update heartbeat when using Consul. #3259
 * [BUGFIX] When using ruler sharding, moving all user rule groups from ruler to a different one and then back could end up with some user groups not being evaluated at all. #3235
+* [BUGFIX] Use a valid grpc header when logging IP addresses. #3307
 
 ## 1.4.0 / 2020-10-02
 

--- a/pkg/util/extract_forwarded.go
+++ b/pkg/util/extract_forwarded.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ipAddressesKey is key for the GRPC metadata where the IP addresses are stored
-const ipAddressesKey = "github.com/cortexproject/cortex/util/extract_forwarded/x-forwarded-for"
+const ipAddressesKey = "x-forwarded-for-bin"
 
 // GetSourceIPsFromOutgoingCtx extracts the source field from the GRPC context
 func GetSourceIPsFromOutgoingCtx(ctx context.Context) string {

--- a/pkg/util/extract_forwarded.go
+++ b/pkg/util/extract_forwarded.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ipAddressesKey is key for the GRPC metadata where the IP addresses are stored
-const ipAddressesKey = "x-forwarded-for-bin"
+const ipAddressesKey = "extract-forwarded-x-forwarded-for"
 
 // GetSourceIPsFromOutgoingCtx extracts the source field from the GRPC context
 func GetSourceIPsFromOutgoingCtx(ctx context.Context) string {


### PR DESCRIPTION
Signed-off-by: Michel Hollands <michel.hollands@grafana.com>

**What this PR does**:
Fix the incorrect grpc header used for IP logging. As per https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests the header cannot contain slashes.

Tested by running the steps in #3286 (without HAproxy even).

**Which issue(s) this PR fixes**:
Fixes #3286

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
