### PR TITLE
Blocks compactionLoop: Respect context cancellation faster.

### DIFF
--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1195,7 +1195,7 @@ func (i *Ingester) compactionLoop(ctx context.Context) error {
 	ticker := time.NewTicker(i.cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval)
 	defer ticker.Stop()
 
-	for {
+	for ctx.Err() == nil {
 		select {
 		case <-ticker.C:
 			i.compactBlocks(ctx, false)
@@ -1213,6 +1213,7 @@ func (i *Ingester) compactionLoop(ctx context.Context) error {
 			return nil
 		}
 	}
+	return nil
 }
 
 // Compacts all compactable blocks. Force flag will force compaction even if head is not compactable yet.


### PR DESCRIPTION
**What this PR does**: [compactionLoop](https://github.com/cortexproject/cortex/blob/e26519995ae889d0f7a187a1e74dde99571fa39d/pkg/ingester/ingester_v2.go#L1194) method in blocks-ingester can ignore finished context if compaction takes too long. On next iteration, if multiple `select` cases are active (eg. both cancellation and ticker), Go runtime will [randomly](https://golang.org/ref/spec#Select_statements) select one. If it selects the ticker again, another compaction will run and block the shutdown.

This PR modifies the compaction loop to stop faster if context is cancelled.
