### PR TITLE
Fix flaky test.

### DIFF
--- a/pkg/ring/kv/consul/client.go
+++ b/pkg/ring/kv/consul/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"time"
 
@@ -41,6 +42,10 @@ type Config struct {
 	ConsistentReads   bool          `yaml:"consistent_reads"`
 	WatchKeyRateLimit float64       `yaml:"watch_rate_limit"` // Zero disables rate limit
 	WatchKeyBurstSize int           `yaml:"watch_burst_size"` // Burst when doing rate-limit, defaults to 1
+
+	// Used in tests only.
+	MaxCasRetries int           `yaml:"-"`
+	CasRetryDelay time.Duration `yaml:"-"`
 }
 
 type kv interface {
@@ -117,11 +122,22 @@ func (c *Client) CAS(ctx context.Context, key string, f func(in interface{}) (ou
 }
 
 func (c *Client) cas(ctx context.Context, key string, f func(in interface{}) (out interface{}, retry bool, err error)) error {
-	var (
-		index   = uint64(0)
+	retries := c.cfg.MaxCasRetries
+	if retries == 0 {
 		retries = 10
-	)
+	}
+
+	sleepBeforeRetry := time.Duration(0)
+	if c.cfg.CasRetryDelay > 0 {
+		sleepBeforeRetry = time.Duration(rand.Int63n(c.cfg.CasRetryDelay.Nanoseconds()))
+	}
+
+	index := uint64(0)
 	for i := 0; i < retries; i++ {
+		if i > 0 && sleepBeforeRetry > 0 {
+			time.Sleep(sleepBeforeRetry)
+		}
+
 		// Get with default options - don't want stale data to compare with
 		options := &consul.QueryOptions{}
 		kvp, _, err := c.kv.Get(key, options.WithContext(ctx))

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -1,7 +1,6 @@
 package ring
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -10,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -796,7 +794,7 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), lc))
 
 	t.Cleanup(func() {
-		_ = services.StartAndAwaitRunning(context.Background(), lc)
+		_ = services.StopAndAwaitTerminated(context.Background(), lc)
 	})
 
 	return lc
@@ -805,15 +803,6 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 // This test checks if shuffle-sharded ring can be reused, and whether it receives
 // updates from "main" ring.
 func TestShuffleShardWithCaching(t *testing.T) {
-	buf := bytes.Buffer{}
-	util.Logger = log.NewSyncLogger(log.NewLogfmtLogger(&buf))
-
-	defer func() {
-		if t.Failed() {
-			fmt.Println(buf.String())
-		}
-	}()
-
 	inmem := consul.NewInMemoryClientWithConfig(GetCodec(), consul.Config{
 		MaxCasRetries: 20,
 		CasRetryDelay: 500 * time.Millisecond,

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -1,6 +1,7 @@
 package ring
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -803,6 +805,15 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 // This test checks if shuffle-sharded ring can be reused, and whether it receives
 // updates from "main" ring.
 func TestShuffleShardWithCaching(t *testing.T) {
+	buf := bytes.Buffer{}
+	util.Logger = log.NewLogfmtLogger(&buf)
+
+	defer func() {
+		if t.Failed() {
+			fmt.Println(buf.String())
+		}
+	}()
+
 	inmem := consul.NewInMemoryClient(GetCodec())
 
 	cfg := Config{

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -1,6 +1,7 @@
 package ring
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -803,6 +805,15 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 // This test checks if shuffle-sharded ring can be reused, and whether it receives
 // updates from "main" ring.
 func TestShuffleShardWithCaching(t *testing.T) {
+	buf := bytes.Buffer{}
+	util.Logger = log.NewSyncLogger(log.NewLogfmtLogger(&buf))
+
+	defer func() {
+		if t.Failed() {
+			fmt.Println(buf.String())
+		}
+	}()
+
 	inmem := consul.NewInMemoryClientWithConfig(GetCodec(), consul.Config{
 		MaxCasRetries: 20,
 		CasRetryDelay: 500 * time.Millisecond,

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -806,7 +806,7 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 // updates from "main" ring.
 func TestShuffleShardWithCaching(t *testing.T) {
 	buf := bytes.Buffer{}
-	util.Logger = log.NewLogfmtLogger(&buf)
+	util.Logger = log.NewSyncLogger(log.NewLogfmtLogger(&buf))
 
 	defer func() {
 		if t.Failed() {
@@ -814,7 +814,10 @@ func TestShuffleShardWithCaching(t *testing.T) {
 		}
 	}()
 
-	inmem := consul.NewInMemoryClient(GetCodec())
+	inmem := consul.NewInMemoryClientWithConfig(GetCodec(), consul.Config{
+		MaxCasRetries: 20,
+		CasRetryDelay: 500 * time.Millisecond,
+	})
 
 	cfg := Config{
 		KVStore:              kv.Config{Mock: inmem},

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -1,7 +1,6 @@
 package ring
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -10,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -805,15 +803,6 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 // This test checks if shuffle-sharded ring can be reused, and whether it receives
 // updates from "main" ring.
 func TestShuffleShardWithCaching(t *testing.T) {
-	buf := bytes.Buffer{}
-	util.Logger = log.NewSyncLogger(log.NewLogfmtLogger(&buf))
-
-	defer func() {
-		if t.Failed() {
-			fmt.Println(buf.String())
-		}
-	}()
-
 	inmem := consul.NewInMemoryClientWithConfig(GetCodec(), consul.Config{
 		MaxCasRetries: 20,
 		CasRetryDelay: 500 * time.Millisecond,

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -725,7 +725,7 @@ func TestRingUpdates(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ring))
 	t.Cleanup(func() {
-		_ = services.StartAndAwaitRunning(context.Background(), ring)
+		_ = services.StopAndAwaitTerminated(context.Background(), ring)
 	})
 
 	require.Equal(t, 0, ring.IngesterCount())


### PR DESCRIPTION
**What this PR does**: This PR attempts to fix flaky test in `ring_test.go` by adding more CAS retries and using randomized delay between CAS retries.

~This PR will fix flaky test in ring_test.go. For now it just captures and logs output when test fails to get full understanding on what's going on.~ (I couldn't reproduce failure on CI machine)

