### PR TITLE
Fixed gRPC connections leaking in rulers when rulers sharding is enabled and APIs called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,8 @@
 * [BUGFIX] Reduce failures to update heartbeat when using Consul. #3259
 * [BUGFIX] When using ruler sharding, moving all user rule groups from ruler to a different one and then back could end up with some user groups not being evaluated at all. #3235
 * [BUGFIX] Use a valid grpc header when logging IP addresses. #3307
-* [BUGFIX] Fixes the metric `cortex_prometheus_rule_group_duration_seconds` in the Ruler, it wouldn't report any values. #3310
+* [BUGFIX] Fixed the metric `cortex_prometheus_rule_group_duration_seconds` in the Ruler, it wouldn't report any values. #3310
+* [BUGFIX] Fixed gRPC connections leaking in rulers when rulers sharding is enabled and APIs called. #3314
 
 ## 1.4.0 / 2020-10-02
 

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -707,6 +707,12 @@ func (r *Ruler) getShardedRules(ctx context.Context) ([]*GroupStateDesc, error) 
 		}
 		cc := NewRulerClient(conn)
 		newGrps, err := cc.Rules(ctx, nil)
+
+		// Close the gRPC connection regardless the RPC was successful or not.
+		if closeErr := conn.Close(); closeErr != nil {
+			level.Warn(r.logger).Log("msg", "failed to close gRPC connection to ruler", "remote", rlr.Addr, "err", closeErr)
+		}
+
 		if err != nil {
 			return nil, fmt.Errorf("unable to retrieve rules from other rulers, %v", err)
 		}


### PR DESCRIPTION
**What this PR does**:
We just found out that the ruler is leaking gRPC connections when rulers sharding is enabled and APIs called. This is an hot fix. The proper fix (that will be done later) is to use the gRPC clients pool like we do in any other place.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
