### PR TITLE
feat: simplify query related modules

### DIFF
--- a/integration/getting_started_single_process_config_test.go
+++ b/integration/getting_started_single_process_config_test.go
@@ -52,6 +52,10 @@ func TestGettingStartedSingleProcessConfigWithChunksStorage(t *testing.T) {
 	labelNames, err := c.LabelNames()
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
+
+	// Check that a range query does not return an error to sanity check the queryrange tripperware.
+	_, err = c.QueryRange("series_1", now.Add(-15*time.Minute), now, 15*time.Second)
+	require.NoError(t, err)
 }
 
 func TestGettingStartedSingleProcessConfigWithBlocksStorage(t *testing.T) {
@@ -103,4 +107,8 @@ func TestGettingStartedSingleProcessConfigWithBlocksStorage(t *testing.T) {
 	labelNames, err := c.LabelNames()
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
+
+	// Check that a range query does not return an error to sanity check the queryrange tripperware.
+	_, err = c.QueryRange("series_1", now.Add(-15*time.Minute), now, 15*time.Second)
+	require.NoError(t, err)
 }

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -259,6 +259,7 @@ func runQueryFrontendTest(t *testing.T, testMissingMetricName bool, setup queryF
 	// requests to /metrics and /ready.
 	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Greater(numUsers*numQueriesPerUser), []string{"cortex_request_duration_seconds"}, e2e.WithMetricCount))
 	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Greater(numUsers*numQueriesPerUser), []string{"cortex_request_duration_seconds"}, e2e.WithMetricCount))
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Greater(numUsers*numQueriesPerUser), []string{"cortex_querier_request_duration_seconds"}, e2e.WithMetricCount))
 
 	// Ensure no service-specific metrics prefix is used by the wrong service.
 	assertServiceMetricsPrefixes(t, Distributor, distributor)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -6,11 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/felixge/fgprof"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,28 +1,17 @@
 package api
 
 import (
-	"context"
-	"errors"
 	"flag"
 	"net/http"
-	"regexp"
 	"strings"
 	"time"
 
-	"github.com/opentracing-contrib/go-stdlib/nethttp"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 
 	"github.com/felixge/fgprof"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/gorilla/mux"
-	"github.com/prometheus/common/route"
-	"github.com/prometheus/prometheus/config"
-	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
-	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
 
@@ -104,12 +93,6 @@ func New(cfg Config, serverCfg server.Config, s *server.Server, logger log.Logge
 // RegisterRoute registers a single route enforcing HTTP methods. A single
 // route is expected to be specific about which HTTP methods are supported.
 func (a *API) RegisterRoute(path string, handler http.Handler, auth bool, method string, methods ...string) {
-	a.registerRouteWithRouter(a.server.HTTP, path, handler, auth, method, methods...)
-}
-
-// RegisterRoute registers a single route to a router, enforcing HTTP methods. A single
-// route is expected to be specific about which HTTP methods are supported.
-func (a *API) registerRouteWithRouter(router *mux.Router, path string, handler http.Handler, auth bool, method string, methods ...string) {
 	methods = append([]string{method}, methods...)
 
 	level.Debug(a.logger).Log("msg", "api: registering route", "methods", strings.Join(methods, ","), "path", path, "auth", auth)
@@ -117,10 +100,10 @@ func (a *API) registerRouteWithRouter(router *mux.Router, path string, handler h
 		handler = a.authMiddleware.Wrap(handler)
 	}
 	if len(methods) == 0 {
-		router.Path(path).Handler(handler)
+		a.server.HTTP.Path(path).Handler(handler)
 		return
 	}
-	router.Path(path).Methods(methods...).Handler(handler)
+	a.server.HTTP.Path(path).Methods(methods...).Handler(handler)
 }
 
 func (a *API) RegisterRoutesWithPrefix(prefix string, handler http.Handler, auth bool, methods ...string) {
@@ -133,20 +116,6 @@ func (a *API) RegisterRoutesWithPrefix(prefix string, handler http.Handler, auth
 		return
 	}
 	a.server.HTTP.PathPrefix(prefix).Methods(methods...).Handler(handler)
-}
-
-// Latest Prometheus requires r.RemoteAddr to be set to addr:port, otherwise it reject the request.
-// Requests to Querier sometimes doesn't have that (if they are fetched from Query-Frontend).
-// Prometheus uses this when logging queries to QueryLogger, but Cortex doesn't call engine.SetQueryLogger to set one.
-//
-// Can be removed when (if) https://github.com/prometheus/prometheus/pull/6840 is merged.
-func fakeRemoteAddr(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RemoteAddr == "" {
-			r.RemoteAddr = "127.0.0.1:8888"
-		}
-		handler.ServeHTTP(w, r)
-	})
 }
 
 // RegisterAlertmanager registers endpoints associated with the alertmanager. It will only
@@ -302,114 +271,22 @@ func (a *API) RegisterCompactor(c *compactor.Compactor) {
 	a.RegisterRoute("/compactor/ring", http.HandlerFunc(c.RingHandler), false, "GET", "POST")
 }
 
-// RegisterQuerier registers the Prometheus routes supported by the
-// Cortex querier service. Currently this can not be registered simultaneously
-// with the QueryFrontend.
-func (a *API) RegisterQuerier(
+// RegisterQueryable registers the the default routes associated with the querier
+// module.
+func (a *API) RegisterQueryable(
 	queryable storage.SampleAndChunkQueryable,
-	engine *promql.Engine,
 	distributor *distributor.Distributor,
-	registerRoutesExternally bool,
-	tombstonesLoader *purger.TombstonesLoader,
-	querierRequestDuration *prometheus.HistogramVec,
-	receivedMessageSize *prometheus.HistogramVec,
-	sentMessageSize *prometheus.HistogramVec,
-	inflightRequests *prometheus.GaugeVec,
-) http.Handler {
-	api := v1.NewAPI(
-		engine,
-		errorTranslateQueryable{queryable}, // Translate errors to errors expected by API.
-		func(context.Context) v1.TargetRetriever { return &querier.DummyTargetRetriever{} },
-		func(context.Context) v1.AlertmanagerRetriever { return &querier.DummyAlertmanagerRetriever{} },
-		func() config.Config { return config.Config{} },
-		map[string]string{}, // TODO: include configuration flags
-		v1.GlobalURLOptions{},
-		func(f http.HandlerFunc) http.HandlerFunc { return f },
-		nil,   // Only needed for admin APIs.
-		"",    // This is for snapshots, which is disabled when admin APIs are disabled. Hence empty.
-		false, // Disable admin APIs.
-		a.logger,
-		func(context.Context) v1.RulesRetriever { return &querier.DummyRulesRetriever{} },
-		0, 0, 0, // Remote read samples and concurrency limit.
-		regexp.MustCompile(".*"),
-		func() (v1.RuntimeInfo, error) { return v1.RuntimeInfo{}, errors.New("not implemented") },
-		&v1.PrometheusVersion{},
-		// This is used for the stats API which we should not support. Or find other ways to.
-		prometheus.GathererFunc(func() ([]*dto.MetricFamily, error) { return nil, nil }),
-	)
-
+) {
 	// these routes are always registered to the default server
 	a.RegisterRoute("/api/v1/user_stats", http.HandlerFunc(distributor.UserStatsHandler), true, "GET")
 	a.RegisterRoute("/api/v1/chunks", querier.ChunksHandler(queryable), true, "GET")
 
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/user_stats", http.HandlerFunc(distributor.UserStatsHandler), true, "GET")
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/chunks", querier.ChunksHandler(queryable), true, "GET")
-
-	// these routes are either registered the default server OR to an internal mux.  The internal mux is
-	// for use in a single binary mode when both the query frontend and the querier would attempt to claim these routes
-	// TODO:  Add support to expose querier paths with a configurable prefix in single binary mode.
-	router := mux.NewRouter()
-	if registerRoutesExternally {
-		router = a.server.HTTP
-	}
-
-	// Use a separate metric for the querier in order to differentiate requests from the query-frontend when
-	// running Cortex as a single binary.
-	inst := middleware.Instrument{
-		RouteMatcher:     router,
-		Duration:         querierRequestDuration,
-		RequestBodySize:  receivedMessageSize,
-		ResponseBodySize: sentMessageSize,
-		InflightRequests: inflightRequests,
-	}
-
-	promRouter := route.New().WithPrefix(a.cfg.ServerPrefix + a.cfg.PrometheusHTTPPrefix + "/api/v1")
-	api.Register(promRouter)
-	cacheGenHeaderMiddleware := getHTTPCacheGenNumberHeaderSetterMiddleware(tombstonesLoader)
-	promHandler := fakeRemoteAddr(inst.Wrap(cacheGenHeaderMiddleware.Wrap(promRouter)))
-
-	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/read", querier.RemoteReadHandler(queryable), true, "POST")
-	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/query", promHandler, true, "GET", "POST")
-	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/query_range", promHandler, true, "GET", "POST")
-	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/labels", promHandler, true, "GET", "POST")
-	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/label/{name}/values", promHandler, true, "GET")
-	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/series", promHandler, true, "GET", "POST", "DELETE")
-	//TODO(gotjosh): This custom handler is temporary until we're able to vendor the changes in:
-	// https://github.com/prometheus/prometheus/pull/7125/files
-	a.registerRouteWithRouter(router, a.cfg.PrometheusHTTPPrefix+"/api/v1/metadata", querier.MetadataHandler(distributor), true, "GET")
-
-	legacyPromRouter := route.New().WithPrefix(a.cfg.ServerPrefix + a.cfg.LegacyHTTPPrefix + "/api/v1")
-	api.Register(legacyPromRouter)
-	legacyPromHandler := fakeRemoteAddr(inst.Wrap(cacheGenHeaderMiddleware.Wrap(legacyPromRouter)))
-
-	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/read", querier.RemoteReadHandler(queryable), true, "POST")
-	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/query", legacyPromHandler, true, "GET", "POST")
-	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/query_range", legacyPromHandler, true, "GET", "POST")
-	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/labels", legacyPromHandler, true, "GET", "POST")
-	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/label/{name}/values", legacyPromHandler, true, "GET")
-	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/series", legacyPromHandler, true, "GET", "POST", "DELETE")
-	//TODO(gotjosh): This custom handler is temporary until we're able to vendor the changes in:
-	// https://github.com/prometheus/prometheus/pull/7125/files
-	a.registerRouteWithRouter(router, a.cfg.LegacyHTTPPrefix+"/api/v1/metadata", querier.MetadataHandler(distributor), true, "GET")
-
-	// if we have externally registered routes then we need to return the server handler
-	// so that we continue to use all standard middleware
-	if registerRoutesExternally {
-		return a.server.HTTPServer.Handler
-	}
-
-	// Since we have a new router and the request will not go trough the default server
-	// HTTP middleware stack, we need to add a middleware to extract the trace context
-	// from the HTTP headers and inject it into the Go context.
-	return nethttp.MiddlewareFunc(opentracing.GlobalTracer(), router.ServeHTTP, nethttp.OperationNameFunc(func(r *http.Request) string {
-		return "internalQuerier"
-	}))
 }
 
-// registerQueryAPI registers the Prometheus routes supported by the
-// Cortex querier service. Currently this can not be registered simultaneously
-// with the Querier.
-func (a *API) registerQueryAPI(handler http.Handler) {
+// RegisterQueryAPI registers the Prometheus API routes with the provided handler.
+func (a *API) RegisterQueryAPI(handler http.Handler) {
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/read", handler, true, "POST")
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/query", handler, true, "GET", "POST")
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/query_range", handler, true, "GET", "POST")
@@ -433,7 +310,7 @@ func (a *API) registerQueryAPI(handler http.Handler) {
 // with the Querier.
 func (a *API) RegisterQueryFrontend(f *frontend.Frontend) {
 	frontend.RegisterFrontendServer(a.server.GRPC, f)
-	a.registerQueryAPI(f.Handler())
+	a.RegisterQueryAPI(f.Handler())
 }
 
 // RegisterServiceMapHandler registers the Cortex structs service handler

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"flag"
 	"net/http"
 	"strings"

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -1,14 +1,33 @@
 package api
 
 import (
+	"context"
 	"html/template"
 	"net/http"
 	"path"
+	"regexp"
 	"sync"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/gorilla/mux"
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/common/route"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
+	"github.com/weaveworks/common/instrument"
+	"github.com/weaveworks/common/middleware"
 	"gopkg.in/yaml.v2"
 
+	"github.com/cortexproject/cortex/pkg/chunk/purger"
+	"github.com/cortexproject/cortex/pkg/distributor"
+	"github.com/cortexproject/cortex/pkg/querier"
 	"github.com/cortexproject/cortex/pkg/util"
 )
 
@@ -108,4 +127,109 @@ func configHandler(cfg interface{}) http.HandlerFunc {
 			level.Error(util.Logger).Log("msg", "error writing response", "err", err)
 		}
 	}
+}
+
+// NewQuerierHandler returns a HTTP handler that can be used by the querier service to
+// either register with the frontend worker query processor or with the external HTTP
+// server to fulfill the Prometheus query API.
+func NewQuerierHandler(
+	cfg Config,
+	queryable storage.SampleAndChunkQueryable,
+	engine *promql.Engine,
+	distributor *distributor.Distributor,
+	tombstonesLoader *purger.TombstonesLoader,
+	reg prometheus.Registerer,
+	logger log.Logger,
+) http.Handler {
+	// Prometheus histograms for requests to the querier.
+	querierRequestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "cortex",
+		Name:      "querier_request_duration_seconds",
+		Help:      "Time (in seconds) spent serving HTTP requests to the querier.",
+		Buckets:   instrument.DefBuckets,
+	}, []string{"method", "route", "status_code", "ws"})
+
+	receivedMessageSize := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "cortex",
+		Name:      "querier_request_message_bytes",
+		Help:      "Size (in bytes) of messages received in the request to the querier.",
+		Buckets:   middleware.BodySizeBuckets,
+	}, []string{"method", "route"})
+
+	sentMessageSize := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "cortex",
+		Name:      "querier_response_message_bytes",
+		Help:      "Size (in bytes) of messages sent in response by the querier.",
+		Buckets:   middleware.BodySizeBuckets,
+	}, []string{"method", "route"})
+
+	inflightRequests := promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "cortex",
+		Name:      "querier_inflight_requests",
+		Help:      "Current number of inflight requests to the querier.",
+	}, []string{"method", "route"})
+
+	api := v1.NewAPI(
+		engine,
+		errorTranslateQueryable{queryable}, // Translate errors to errors expected by API.
+		func(context.Context) v1.TargetRetriever { return &querier.DummyTargetRetriever{} },
+		func(context.Context) v1.AlertmanagerRetriever { return &querier.DummyAlertmanagerRetriever{} },
+		func() config.Config { return config.Config{} },
+		map[string]string{}, // TODO: include configuration flags
+		v1.GlobalURLOptions{},
+		func(f http.HandlerFunc) http.HandlerFunc { return f },
+		nil,   // Only needed for admin APIs.
+		"",    // This is for snapshots, which is disabled when admin APIs are disabled. Hence empty.
+		false, // Disable admin APIs.
+		logger,
+		func(context.Context) v1.RulesRetriever { return &querier.DummyRulesRetriever{} },
+		0, 0, 0, // Remote read samples and concurrency limit.
+		regexp.MustCompile(".*"),
+		func() (v1.RuntimeInfo, error) { return v1.RuntimeInfo{}, errors.New("not implemented") },
+		&v1.PrometheusVersion{},
+		// This is used for the stats API which we should not support. Or find other ways to.
+		prometheus.GathererFunc(func() ([]*dto.MetricFamily, error) { return nil, nil }),
+	)
+
+	router := mux.NewRouter()
+
+	// Use a separate metric for the querier in order to differentiate requests from the query-frontend when
+	// running Cortex as a single binary.
+	inst := middleware.Instrument{
+		RouteMatcher:     router,
+		Duration:         querierRequestDuration,
+		RequestBodySize:  receivedMessageSize,
+		ResponseBodySize: sentMessageSize,
+		InflightRequests: inflightRequests,
+	}
+	cacheGenHeaderMiddleware := getHTTPCacheGenNumberHeaderSetterMiddleware(tombstonesLoader)
+	middlewares := middleware.Merge(fakeRemoteAddr(), inst, cacheGenHeaderMiddleware)
+	router.Use(middlewares.Wrap)
+
+	promRouter := route.New().WithPrefix(cfg.ServerPrefix + cfg.PrometheusHTTPPrefix + "/api/v1")
+	api.Register(promRouter)
+
+	legacyPromRouter := route.New().WithPrefix(cfg.ServerPrefix + cfg.LegacyHTTPPrefix + "/api/v1")
+	api.Register(legacyPromRouter)
+
+	//TODO(gotjosh): This custom handler is temporary until we're able to vendor the changes in:
+	// https://github.com/prometheus/prometheus/pull/7125/files
+	router.Path(cfg.PrometheusHTTPPrefix + "/api/v1/metadata").Handler(querier.MetadataHandler(distributor))
+	router.Path(cfg.PrometheusHTTPPrefix + "/api/v1/read").Handler(querier.RemoteReadHandler(queryable))
+	// A prefix is fine because external routes will be registered explicitly
+	router.PathPrefix(cfg.PrometheusHTTPPrefix + "/api/v1/").Handler(promRouter)
+
+	//TODO(gotjosh): This custom handler is temporary until we're able to vendor the changes in:
+	// https://github.com/prometheus/prometheus/pull/7125/files
+	router.Path(cfg.LegacyHTTPPrefix + "/api/v1/metadata").Handler(querier.MetadataHandler(distributor))
+	router.Path(cfg.LegacyHTTPPrefix + "/api/v1/read").Handler(querier.RemoteReadHandler(queryable))
+	// A prefix is fine because external routes will be registered explicitly
+	router.PathPrefix(cfg.LegacyHTTPPrefix + "/api/v1/").Handler(legacyPromRouter)
+
+	// Since we have a new router and the request will not go trough the default server
+	// HTTP middleware stack, we need to add a middleware to extract the trace context
+	// from the HTTP headers and inject it into the Go context.
+	return nethttp.MiddlewareFunc(opentracing.GlobalTracer(), router.ServeHTTP, nethttp.OperationNameFunc(func(r *http.Request) string {
+		return "internalQuerier"
+	}))
 }

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/promql"

--- a/pkg/api/middlewares.go
+++ b/pkg/api/middlewares.go
@@ -10,6 +10,22 @@ import (
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 )
 
+// Latest Prometheus requires r.RemoteAddr to be set to addr:port, otherwise it reject the request.
+// Requests to Querier sometimes doesn't have that (if they are fetched from Query-Frontend).
+// Prometheus uses this when logging queries to QueryLogger, but Cortex doesn't call engine.SetQueryLogger to set one.
+//
+// Can be removed when (if) https://github.com/prometheus/prometheus/pull/6840 is merged.
+func fakeRemoteAddr() middleware.Interface {
+	return middleware.Func(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.RemoteAddr == "" {
+				r.RemoteAddr = "127.0.0.1:8888"
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
+}
+
 // middleware for setting cache gen header to let consumer of response know all previous responses could be invalid due to delete operation
 func getHTTPCacheGenNumberHeaderSetterMiddleware(cacheGenNumbersLoader *purger.TombstonesLoader) middleware.Interface {
 	return middleware.Func(func(next http.Handler) http.Handler {

--- a/pkg/api/middlewares.go
+++ b/pkg/api/middlewares.go
@@ -10,22 +10,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
 )
 
-// Latest Prometheus requires r.RemoteAddr to be set to addr:port, otherwise it reject the request.
-// Requests to Querier sometimes doesn't have that (if they are fetched from Query-Frontend).
-// Prometheus uses this when logging queries to QueryLogger, but Cortex doesn't call engine.SetQueryLogger to set one.
-//
-// Can be removed when (if) https://github.com/prometheus/prometheus/pull/6840 is merged.
-func fakeRemoteAddr() middleware.Interface {
-	return middleware.Func(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.RemoteAddr == "" {
-				r.RemoteAddr = "127.0.0.1:8888"
-			}
-			next.ServeHTTP(w, r)
-		})
-	})
-}
-
 // middleware for setting cache gen header to let consumer of response know all previous responses could be invalid due to delete operation
 func getHTTPCacheGenNumberHeaderSetterMiddleware(cacheGenNumbersLoader *purger.TombstonesLoader) middleware.Interface {
 	return middleware.Func(func(next http.Handler) http.Handler {

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -250,23 +250,23 @@ type Cortex struct {
 	ServiceMap    map[string]services.Service
 	ModuleManager *modules.Manager
 
-	API              *api.API
-	Server           *server.Server
-	Ring             *ring.Ring
-	Overrides        *validation.Overrides
-	Distributor      *distributor.Distributor
-	Ingester         *ingester.Ingester
-	Flusher          *flusher.Flusher
-	Store            chunk.Store
-	DeletesStore     *purger.DeleteStore
-	Frontend         *frontend.Frontend
-	TableManager     *chunk.TableManager
-	RuntimeConfig    *runtimeconfig.Manager
-	Purger           *purger.Purger
-	TombstonesLoader *purger.TombstonesLoader
-	QuerierQueryable prom_storage.SampleAndChunkQueryable
-	QuerierEngine    *promql.Engine
-	Tripperware      frontend.Tripperware
+	API                      *api.API
+	Server                   *server.Server
+	Ring                     *ring.Ring
+	Overrides                *validation.Overrides
+	Distributor              *distributor.Distributor
+	Ingester                 *ingester.Ingester
+	Flusher                  *flusher.Flusher
+	Store                    chunk.Store
+	DeletesStore             *purger.DeleteStore
+	Frontend                 *frontend.Frontend
+	TableManager             *chunk.TableManager
+	RuntimeConfig            *runtimeconfig.Manager
+	Purger                   *purger.Purger
+	TombstonesLoader         *purger.TombstonesLoader
+	QuerierQueryable         prom_storage.SampleAndChunkQueryable
+	QuerierEngine            *promql.Engine
+	QueryFrontendTripperware frontend.Tripperware
 
 	Ruler        *ruler.Ruler
 	RulerStorage rules.RuleStore

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -12,6 +12,8 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/promql"
+	prom_storage "github.com/prometheus/prometheus/storage"
 	"github.com/weaveworks/common/server"
 	"github.com/weaveworks/common/signals"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -20,7 +22,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/alertmanager"
 	"github.com/cortexproject/cortex/pkg/api"
 	"github.com/cortexproject/cortex/pkg/chunk"
-	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/chunk/encoding"
 	"github.com/cortexproject/cortex/pkg/chunk/purger"
 	"github.com/cortexproject/cortex/pkg/chunk/storage"
@@ -260,10 +261,12 @@ type Cortex struct {
 	DeletesStore     *purger.DeleteStore
 	Frontend         *frontend.Frontend
 	TableManager     *chunk.TableManager
-	Cache            cache.Cache
 	RuntimeConfig    *runtimeconfig.Manager
 	Purger           *purger.Purger
 	TombstonesLoader *purger.TombstonesLoader
+	QuerierQueryable prom_storage.SampleAndChunkQueryable
+	QuerierEngine    *promql.Engine
+	Tripperware      frontend.Tripperware
 
 	Ruler        *ruler.Ruler
 	RulerStorage rules.RuleStore

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -206,13 +206,17 @@ func (t *Cortex) initQueryable() (serv services.Service, err error) {
 
 // initQuerier registers an internal HTTP router with a Prometheus API backed by the
 // Cortex Queryable. Then it does one of the following:
+//
 // 1. Query-Frontend Enabled: If Cortex has an All or QueryFrontend target, the internal
 //    HTTP router is wrapped with Tenant ID parsing middleware and passed to the frontend
 //    worker.
+//
 // 2. Querier Standalone: The querier will register the internal HTTP router with the external
 //    HTTP router for the Prometheus API routes. Then the external HTTP server will be passed
 //    as a http.Handler to the frontend worker.
+//
 // Route Diagram:
+//
 //                        │  query
 //                        │ request
 //                        │
@@ -249,6 +253,7 @@ func (t *Cortex) initQueryable() (serv services.Service, err error) {
 //                     └──────────────────────│  Prometheus API  │
 //                                            │                  │
 //                                            └──────────────────┘
+//
 func (t *Cortex) initQuerier() (serv services.Service, err error) {
 	// Create a internal HTTP handler that is configured with the Prometheus API routes and points
 	// to a Prometheus API struct instantiated with the Cortex Queryable.

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -7,12 +7,10 @@ import (
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
 	prom_storage "github.com/prometheus/prometheus/storage"
 	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
-	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
 
@@ -56,8 +54,10 @@ const (
 	IngesterService     string = "ingester-service"
 	Flusher             string = "flusher"
 	Querier             string = "querier"
+	Queryable           string = "queryable"
 	StoreQueryable      string = "store-queryable"
 	QueryFrontend       string = "query-frontend"
+	QueryTripperware    string = "query-tripperware"
 	Store               string = "store"
 	DeleteRequestsStore string = "delete-requests-store"
 	TableManager        string = "table-manager"
@@ -190,55 +190,71 @@ func (t *Cortex) initDistributor() (serv services.Service, err error) {
 	return nil, nil
 }
 
-func (t *Cortex) initQuerier() (serv services.Service, err error) {
+// initQueryable instantiates the queryable and promQL engine used to service queries to
+// Cortex. It also registers the API endpoints associated with those two services.
+func (t *Cortex) initQueryable() (serv services.Service, err error) {
 	querierRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "querier"}, prometheus.DefaultRegisterer)
-	queryable, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, t.TombstonesLoader, querierRegisterer)
 
-	// Prometheus histograms for requests to the querier.
-	querierRequestDuration := promauto.With(prometheus.DefaultRegisterer).NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "cortex",
-		Name:      "querier_request_duration_seconds",
-		Help:      "Time (in seconds) spent serving HTTP requests to the querier.",
-		Buckets:   instrument.DefBuckets,
-	}, []string{"method", "route", "status_code", "ws"})
+	// Create a querier queryable and PromQL engine
+	t.QuerierQueryable, t.QuerierEngine = querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, t.TombstonesLoader, querierRegisterer)
 
-	receivedMessageSize := promauto.With(prometheus.DefaultRegisterer).NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "cortex",
-		Name:      "querier_request_message_bytes",
-		Help:      "Size (in bytes) of messages received in the request to the querier.",
-		Buckets:   middleware.BodySizeBuckets,
-	}, []string{"method", "route"})
+	// Register the default endpoints that are always enabled for the querier module
+	t.API.RegisterQueryable(t.QuerierQueryable, t.Distributor)
 
-	sentMessageSize := promauto.With(prometheus.DefaultRegisterer).NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "cortex",
-		Name:      "querier_response_message_bytes",
-		Help:      "Size (in bytes) of messages sent in response by the querier.",
-		Buckets:   middleware.BodySizeBuckets,
-	}, []string{"method", "route"})
+	return nil, nil
+}
 
-	inflightRequests := promauto.With(prometheus.DefaultRegisterer).NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "cortex",
-		Name:      "querier_inflight_requests",
-		Help:      "Current number of inflight requests to the querier.",
-	}, []string{"method", "route"})
+// initQuerier registers an internal HTTP router with a Prometheus API backed by the
+// Cortex Queryable. Then it does one of the following:
+// 1. Query-Frontend Enabled: If Cortex has an All or QueryFrontend target, they internal
+//    HTTP router is wrapped with Tenant ID parsing middleware and passed to the frontend
+//    worker.
+// 2. Querier Standalone: The querier will register the internal HTTP router with the external
+//    HTTP router for the Prometheus API routes. Then the external HTTP server will be passed
+//    as a http.Handler to the frontend worker.
+func (t *Cortex) initQuerier() (serv services.Service, err error) {
+	// Create a internal HTTP handler that is configured with the Prometheus API routes and points
+	// to a Prometheus API struct instantiated with the Cortex Queryable.
+	queryHandler := api.NewQuerierHandler(
+		t.Cfg.API,
+		t.QuerierQueryable,
+		t.QuerierEngine,
+		t.Distributor,
+		t.TombstonesLoader,
+		prometheus.DefaultRegisterer,
+		util.Logger,
+	)
 
-	// if we are not configured for single binary mode then the querier needs to register its paths externally
-	registerExternally := !t.Cfg.isModuleEnabled(All)
-	handler := t.API.RegisterQuerier(queryable, engine, t.Distributor, registerExternally, t.TombstonesLoader, querierRequestDuration, receivedMessageSize, sentMessageSize, inflightRequests)
+	// If the querier is running standalone without the query-frontend, we must register it's internal
+	// HTTP handler externally and provide the external Cortex Server HTTP handler to the frontend worker
+	// to ensure requests it processes use the default middleware instrumentation.
+	if !t.Cfg.isModuleEnabled(QueryFrontend) && !t.Cfg.isModuleEnabled(All) {
+		// First, register the internal querier handler with the external HTTP server
+		t.API.RegisterQueryAPI(queryHandler)
 
-	// single binary mode requires a properly configured worker.  if the operator did not attempt to configure the
-	//  worker we will attempt an automatic configuration here
-	if t.Cfg.Worker.Address == "" && t.Cfg.isModuleEnabled(All) {
-		address := fmt.Sprintf("127.0.0.1:%d", t.Cfg.Server.GRPCListenPort)
-		level.Warn(util.Logger).Log("msg", "Worker address is empty in single binary mode.  Attempting automatic worker configuration.  If queries are unresponsive consider configuring the worker explicitly.", "address", address)
-		t.Cfg.Worker.Address = address
+		// Second, set the http.Handler that the frontend worker will use to process requests to point to
+		// the external HTTP server. This will allow the querier to consolidate query metrics both external
+		// and internal using the default instrumentation when running as a standalone service.
+		queryHandler = t.Server.HTTPServer.Handler
+	} else {
+		// Single binary mode requires a query frontend endpoint for the worker. If no frontend endpoint
+		// is configured, Cortex will default to using localhost on it's own GRPC listening port.
+		if t.Cfg.Worker.Address == "" {
+			address := fmt.Sprintf("127.0.0.1:%d", t.Cfg.Server.GRPCListenPort)
+			level.Warn(util.Logger).Log("msg", "Worker address is empty in single binary mode.  Attempting automatic worker configuration.  If queries are unresponsive consider configuring the worker explicitly.", "address", address)
+			t.Cfg.Worker.Address = address
+		}
+
+		// If queries processed using the external HTTP Server, we need wrap the internalHandler with
+		// middleware to parse the tenant ID from the HTTP header and inject it into the request context
+		queryHandler = middleware.AuthenticateUser.Wrap(queryHandler)
 	}
 
 	// Query frontend worker will only be started after all its dependencies are started, not here.
 	// Worker may also be nil, if not configured, which is OK.
-	worker, err := frontend.NewWorker(t.Cfg.Worker, t.Cfg.Querier, httpgrpc_server.NewServer(handler), util.Logger)
+	worker, err := frontend.NewWorker(t.Cfg.Worker, t.Cfg.Querier, httpgrpc_server.NewServer(queryHandler), util.Logger)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	return worker, nil
@@ -399,18 +415,15 @@ func (t *Cortex) initDeleteRequestsStore() (serv services.Service, err error) {
 	return
 }
 
-func (t *Cortex) initQueryFrontend() (serv services.Service, err error) {
+// initTripperware instantiates the tripperware used by the query frontend
+// to optimize Prometheus query requests.
+func (t *Cortex) initTripperware() (serv services.Service, err error) {
 	// Load the schema only if sharded queries is set.
 	if t.Cfg.QueryRange.ShardedQueries {
 		err = t.Cfg.Schema.Load()
 		if err != nil {
 			return
 		}
-	}
-
-	t.Frontend, err = frontend.New(t.Cfg.Frontend, t.Overrides, util.Logger, prometheus.DefaultRegisterer)
-	if err != nil {
-		return
 	}
 
 	tripperware, cache, err := queryrange.NewTripperware(
@@ -437,17 +450,29 @@ func (t *Cortex) initQueryFrontend() (serv services.Service, err error) {
 	if err != nil {
 		return nil, err
 	}
-	t.Cache = cache
-	t.Frontend.Wrap(tripperware)
 
+	t.Tripperware = tripperware
+
+	return services.NewIdleService(nil, func(_ error) error {
+		if cache != nil {
+			cache.Stop()
+			cache = nil
+		}
+		return nil
+	}), nil
+}
+
+func (t *Cortex) initQueryFrontend() (serv services.Service, err error) {
+	t.Frontend, err = frontend.New(t.Cfg.Frontend, t.Overrides, util.Logger, prometheus.DefaultRegisterer)
+	if err != nil {
+		return
+	}
+
+	t.Frontend.Wrap(t.Tripperware)
 	t.API.RegisterQueryFrontend(t.Frontend)
 
 	return services.NewIdleService(nil, func(_ error) error {
 		t.Frontend.Close()
-		if t.Cache != nil {
-			t.Cache.Stop()
-			t.Cache = nil
-		}
 		return nil
 	}), nil
 }
@@ -673,8 +698,10 @@ func (t *Cortex) setupModuleManager() error {
 	mm.RegisterModule(Ingester, t.initIngester)
 	mm.RegisterModule(IngesterService, t.initIngesterService, modules.UserInvisibleModule)
 	mm.RegisterModule(Flusher, t.initFlusher)
+	mm.RegisterModule(Queryable, t.initQueryable, modules.UserInvisibleModule)
 	mm.RegisterModule(Querier, t.initQuerier)
 	mm.RegisterModule(StoreQueryable, t.initStoreQueryables, modules.UserInvisibleModule)
+	mm.RegisterModule(QueryTripperware, t.initTripperware, modules.UserInvisibleModule)
 	mm.RegisterModule(QueryFrontend, t.initQueryFrontend)
 	mm.RegisterModule(TableManager, t.initTableManager)
 	mm.RegisterModule(RulerStorage, t.initRulerStorage, modules.UserInvisibleModule)
@@ -697,9 +724,11 @@ func (t *Cortex) setupModuleManager() error {
 		Ingester:           {IngesterService, API},
 		IngesterService:    {Overrides, Store, RuntimeConfig, MemberlistKV},
 		Flusher:            {Store, API},
-		Querier:            {Overrides, DistributorService, Store, Ring, API, StoreQueryable, MemberlistKV},
+		Queryable:          {Overrides, DistributorService, Store, Ring, API, StoreQueryable, MemberlistKV},
+		Querier:            {Queryable},
 		StoreQueryable:     {Overrides, Store, MemberlistKV},
-		QueryFrontend:      {API, Overrides, DeleteRequestsStore},
+		QueryFrontend:      {QueryTripperware},
+		QueryTripperware:   {API, Overrides, DeleteRequestsStore},
 		TableManager:       {API},
 		Ruler:              {Overrides, DistributorService, Store, StoreQueryable, RulerStorage},
 		Configs:            {API},


### PR DESCRIPTION
**What this PR does**:

- Simplify the querier handler code by consolidating the querier specific latency metrics and the custom handler for the internal querier into a single function.
- Separates the `querier` module into two modules: `querier` and `queryable`.
- Decouples the instantiation of the `queryrange` tripperware from the `query-frontend`

The goal of this PR is to simplify the setup of the querier and make it clearer how requests are routed to the querier when running with or without the query-frontend enabled simultaneously and to decouple the initialization of the default queryable and the initialization of the request processing/handling code.

I did my best in this PR to comment/clarify how the routing for the querier is instantiated when running standalone or as a part of single-binary.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
