### PR TITLE
Don't return raw buffer from util.ParseProtoReader()

### DIFF
--- a/pkg/ingester/client/client_test.go
+++ b/pkg/ingester/client/client_test.go
@@ -39,9 +39,9 @@ func TestMarshall(t *testing.T) {
 			plentySize   = 1024 * 1024
 		)
 		req := WriteRequest{}
-		_, err := util.ParseProtoReader(context.Background(), recorder.Body, recorder.Body.Len(), tooSmallSize, &req, util.RawSnappy)
+		err := util.ParseProtoReader(context.Background(), recorder.Body, recorder.Body.Len(), tooSmallSize, &req, util.RawSnappy)
 		require.Error(t, err)
-		_, err = util.ParseProtoReader(context.Background(), recorder.Body, recorder.Body.Len(), plentySize, &req, util.RawSnappy)
+		err = util.ParseProtoReader(context.Background(), recorder.Body, recorder.Body.Len(), plentySize, &req, util.RawSnappy)
 		require.NoError(t, err)
 		require.Equal(t, numSeries, len(req.Timeseries))
 	}

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -21,7 +21,7 @@ func RemoteReadHandler(q storage.Queryable) http.Handler {
 		ctx := r.Context()
 		var req client.ReadRequest
 		logger := util.WithContext(r.Context(), util.Logger)
-		if _, err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRemoteReadQuerySize, &req, compressionType); err != nil {
+		if err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRemoteReadQuerySize, &req, compressionType); err != nil {
 			level.Error(logger).Log("err", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -73,7 +73,7 @@ func CompressionTypeFor(version string) CompressionType {
 }
 
 // ParseProtoReader parses a compressed proto from an io.Reader.
-func ParseProtoReader(ctx context.Context, reader io.Reader, expectedSize, maxSize int, req proto.Message, compression CompressionType) ([]byte, error) {
+func ParseProtoReader(ctx context.Context, reader io.Reader, expectedSize, maxSize int, req proto.Message, compression CompressionType) error {
 	var body []byte
 	var err error
 	sp := opentracing.SpanFromContext(ctx)
@@ -83,7 +83,7 @@ func ParseProtoReader(ctx context.Context, reader io.Reader, expectedSize, maxSi
 	var buf bytes.Buffer
 	if expectedSize > 0 {
 		if expectedSize > maxSize {
-			return nil, fmt.Errorf("message expected size larger than max (%d vs %d)", expectedSize, maxSize)
+			return fmt.Errorf("message expected size larger than max (%d vs %d)", expectedSize, maxSize)
 		}
 		buf.Grow(expectedSize + bytes.MinRead) // extra space guarantees no reallocation
 	}
@@ -108,10 +108,10 @@ func ParseProtoReader(ctx context.Context, reader io.Reader, expectedSize, maxSi
 		}
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if len(body) > maxSize {
-		return nil, fmt.Errorf("received message larger than max (%d vs %d)", len(body), maxSize)
+		return fmt.Errorf("received message larger than max (%d vs %d)", len(body), maxSize)
 	}
 
 	if sp != nil {
@@ -128,10 +128,10 @@ func ParseProtoReader(ctx context.Context, reader io.Reader, expectedSize, maxSi
 		err = proto.NewBuffer(body).Unmarshal(req)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return body, nil
+	return nil
 }
 
 // SerializeProtoResponse serializes a protobuf response into an HTTP response.

--- a/pkg/util/push/push.go
+++ b/pkg/util/push/push.go
@@ -27,7 +27,7 @@ func Handler(cfg distributor.Config, sourceIPs *middleware.SourceIPExtractor, pu
 		}
 		compressionType := util.CompressionTypeFor(r.Header.Get("X-Prometheus-Remote-Write-Version"))
 		var req client.PreallocWriteRequest
-		_, err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), cfg.MaxRecvMsgSize, &req, compressionType)
+		err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), cfg.MaxRecvMsgSize, &req, compressionType)
 		if err != nil {
 			level.Error(logger).Log("err", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
It's never used.  Noted in #3188

**Checklist**
- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated
