### PR TITLE
Mixin: Fix querier metrics

### DIFF
--- a/production/dashboards/cortex-read.jsonnet
+++ b/production/dashboards/cortex-read.jsonnet
@@ -1,8 +1,8 @@
-local g = import "grafana.libsonnet";
-local db = import "bigtable.libsonnet";
+local db = import 'bigtable.libsonnet';
+local g = import 'grafana.libsonnet';
 
 g.dashboard(
-    title="Cortex - Read",
+    title='Cortex - Read',
     panelWidth=12
 )
 .addPanel(
@@ -15,20 +15,20 @@ g.dashboard(
         title='QPS',
         type='stack',
         targets=[{
-            query: 'sum(rate(cortex_request_duration_seconds_count{status_code=~"2.*", route="api_prom_api_v1"}[1m]))',
+            query: 'sum(rate(cortex_request_duration_seconds_count{status_code=~"2.*", route=~"api_prom_api_v1|prometheus_api_v1_.*"}[1m]))',
             legendFormat: '2xx',
         }, {
-            query: 'sum(rate(cortex_request_duration_seconds_count{status_code=~"4.*", route="api_prom_api_v1"}[1m]))',
+            query: 'sum(rate(cortex_request_duration_seconds_count{status_code=~"4.*", route=~"api_prom_api_v1|prometheus_api_v1_.*"}[1m]))',
             legendFormat: '4xx',
         }, {
-            query: 'sum(rate(cortex_request_duration_seconds_count{status_code=~"5.*", route="api_prom_api_v1"}[1m]))',
+            query: 'sum(rate(cortex_request_duration_seconds_count{status_code=~"5.*", route=~"api_prom_api_v1|prometheus_api_v1_.*"}[1m]))',
             legendFormat: '5xx',
         }],
     ) + {
         aliasColors: {
-            "2xx": "#7EB26D",
-            "4xx": "#F2C96D",
-            "5xx": "#BF1B00",
+            '2xx': '#7EB26D',
+            '4xx': '#F2C96D',
+            '5xx': '#BF1B00',
         },
     }
 )
@@ -36,13 +36,13 @@ g.dashboard(
     g.graphPanel(
         title='Latency',
         targets=[{
-            query: 'histogram_quantile(0.5, sum(rate(cortex_request_duration_seconds_bucket{route="api_prom_api_v1"}[1m])) by (le))',
+            query: 'histogram_quantile(0.5, sum(rate(cortex_request_duration_seconds_bucket{route=~"api_prom_api_v1|prometheus_api_v1_.*"}[1m])) by (le))',
             legendFormat: 'p50',
         }, {
-            query: 'histogram_quantile(0.95, sum(rate(cortex_request_duration_seconds_bucket{route="api_prom_api_v1"}[1m])) by (le))',
+            query: 'histogram_quantile(0.95, sum(rate(cortex_request_duration_seconds_bucket{route=~"api_prom_api_v1|prometheus_api_v1_.*"}[1m])) by (le))',
             legendFormat: 'p95',
         }, {
-            query: 'histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket{route="api_prom_api_v1"}[1m])) by (le))',
+            query: 'histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket{route=~"api_prom_api_v1|prometheus_api_v1_.*"}[1m])) by (le))',
             legendFormat: 'p99',
         }],
     )
@@ -65,8 +65,8 @@ g.dashboard(
         }],
     ) + {
         aliasColors: {
-            success: "#7EB26D",
-            failure: "#BF1B00",
+            success: '#7EB26D',
+            failure: '#BF1B00',
         },
     }
 )
@@ -100,8 +100,8 @@ g.dashboard(
         }],
     ) + {
         aliasColors: {
-            "2xx": "#7EB26D",
-            "5xx": "#BF1B00",
+            '2xx': '#7EB26D',
+            '5xx': '#BF1B00',
         },
     }
 )

--- a/production/dashboards/cortex-read.jsonnet
+++ b/production/dashboards/cortex-read.jsonnet
@@ -45,6 +45,7 @@ g.dashboard(
             query: 'histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket{route=~"api_prom_api_v1|prometheus_api_v1_.*"}[1m])) by (le))',
             legendFormat: 'p99',
         }],
+        yFormat='s',
     )
 )
 .addPanel(
@@ -61,7 +62,7 @@ g.dashboard(
             legendFormat: 'success',
         }, {
             query: 'sum(rate(cortex_request_duration_seconds_count{status_code!="success", route=~".*Query|.*LabelValues|.*MetricsForLabelMatchers"}[1m]))',
-            legendFormat: 'failuer',
+            legendFormat: 'failure',
         }],
     ) + {
         aliasColors: {
@@ -80,6 +81,7 @@ g.dashboard(
             query: 'histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket{route=~".*Query|.*LabelValues|.*MetricsForLabelMatchers"}[1m])) by (le, route))',
             legendFormat: 'p99 - {{route}}',
         }],
+        yFormat='s',
     )
 )
 .addPanel(
@@ -118,6 +120,7 @@ g.dashboard(
             query: 'histogram_quantile(0.99, sum(rate(cortex_cache_request_duration_seconds_bucket{method="memcache.fetch"}[1m])) by (le))',
             legendFormat: 'p99',
         }],
+        yFormat='s',
     )
 )
 .addPanel(
@@ -136,5 +139,6 @@ g.dashboard(
     g.graphPanel(
         title='Latency',
         targets=db.readLatencyTargets,
+        yFormat='s',
     ) + db.readLatencyMixin
 )


### PR DESCRIPTION
Querier routes labels are now prometheus_api_v1_query,
prometheus_api_v1_query_range, prometheus_api_v1_series,
prometheus_api_v1_metadata, prometheus_api_v1_label_name_values

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
