### PR TITLE
Increase integration tests timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,8 +161,8 @@ jobs:
           export CORTEX_IMAGE="${CORTEX_IMAGE_PREFIX}cortex:${CIRCLE_TAG:-$(./tools/image-tag)}"
           export CORTEX_CHECKOUT_DIR="/home/circleci/.go_workspace/src/github.com/cortexproject/cortex"
           echo "Running integration tests with image: $CORTEX_IMAGE"
-          go test -tags=requires_docker -timeout 1200s -v -count=1 ./integration/...
-        no_output_timeout: 20m
+          go test -tags=requires_docker -timeout 1800s -v -count=1 ./integration/...
+        no_output_timeout: 30m
 
   build:
     <<: *defaults

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -20,34 +20,13 @@ var (
 	// If you change the image tag, remember to update it in the preloading done
 	// by CircleCI too (see .circleci/config.yml).
 	previousVersionImages = map[string]func(map[string]string) map[string]string{
-		// 0.6.0 used 204 status code for querier and ingester
-		// distributor didn't have /ready page, and we used check on the /ring page instead
-		"quay.io/cortexproject/cortex:v0.6.0": preCortex10Flags,
-
-		// 0.7.0 used 204 status code for all components
-		"quay.io/cortexproject/cortex:v0.7.0": preCortex10Flags,
-
 		"quay.io/cortexproject/cortex:v1.0.0": preCortex14Flags,
 		"quay.io/cortexproject/cortex:v1.1.0": preCortex14Flags,
 		"quay.io/cortexproject/cortex:v1.2.0": preCortex14Flags,
 		"quay.io/cortexproject/cortex:v1.3.0": preCortex14Flags,
-
 		"quay.io/cortexproject/cortex:v1.4.0": nil,
 	}
 )
-
-func preCortex10Flags(flags map[string]string) map[string]string {
-	return e2e.MergeFlagsWithoutRemovingEmpty(flags, map[string]string{
-		"-schema-config-file":                             "",
-		"-config-yaml":                                    flags["-schema-config-file"],
-		"-table-manager.poll-interval":                    "",
-		"-dynamodb.poll-interval":                         flags["-table-manager.poll-interval"],
-		"-store-gateway.sharding-enabled":                 "",
-		"-store-gateway.sharding-ring.store":              "",
-		"-store-gateway.sharding-ring.consul.hostname":    "",
-		"-store-gateway.sharding-ring.replication-factor": "",
-	})
-}
 
 func preCortex14Flags(flags map[string]string) map[string]string {
 	return e2e.MergeFlagsWithoutRemovingEmpty(flags, map[string]string{


### PR DESCRIPTION
**What this PR does**:
The more integration tests we add, the longer they take and we're now seeing CI hitting the 20m timeout when running integration tests. In this PR:
- Increased timeout from 20m to 30m
- Removed backward compatibility tests for Cortex versions < 1.0

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
