### PR TITLE
add GetHeaders to the Response interface

### DIFF
--- a/pkg/querier/queryrange/query_range.go
+++ b/pkg/querier/queryrange/query_range.go
@@ -87,6 +87,8 @@ type Request interface {
 // Response represents a query range response.
 type Response interface {
 	proto.Message
+	// GetHeaders returns the HTTP headers in the response.
+	GetHeaders() []*PrometheusResponseHeader
 }
 
 type prometheusCodec struct{}

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -255,14 +255,12 @@ func (s resultsCache) shouldCacheResponse(ctx context.Context, r Response) bool 
 }
 
 func getHeaderValuesWithName(r Response, headerName string) (headerValues []string) {
-	if promResp, ok := r.(*PrometheusResponse); ok {
-		for _, hv := range promResp.Headers {
-			if hv.GetName() != headerName {
-				continue
-			}
-
-			headerValues = append(headerValues, hv.GetValues()...)
+	for _, hv := range r.GetHeaders() {
+		if hv.GetName() != headerName {
+			continue
 		}
+
+		headerValues = append(headerValues, hv.GetValues()...)
 	}
 
 	return


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This pr extends the query frontend `Response` interface with a new method.

```go
GetHeaders() []*PrometheusResponseHeader
```

This is useful when I need to extend the results cache to other types of responses. Like `Series` and `Labels`. I still want to check the response HTTP headers but the casting is not necessary.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
