### PR TITLE
BugFix: setting -race and code coverage flags for GitHub Actions workflow

### DIFF
--- a/tools/test
+++ b/tools/test
@@ -53,7 +53,7 @@ done
 
 GO_TEST_ARGS=(-tags "${TAGS[@]}" -cpu 4 -timeout $TIMEOUT $VERBOSE)
 
-if [ -n "$SLOW" ] || [ -n "$CIRCLECI" ]; then
+if [ -n "$SLOW" ] || [ -n "$CIRCLECI" ] || [ -n "$CI" ]; then
     SLOW=true
 fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR adds a condition in `tools/test.sh` to add `-race` and code coverage flags when running tests in GitHub Actions. This is accomplished by checking the existence of `$CI` which is a [default env variable](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables) in GitHub Actions and is always set to `true`

**Which issue(s) this PR fixes**:
Fixes https://github.com/cortexproject/cortex/issues/3337

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

cc: @alolita