### PR TITLE
add ingester interface

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -200,6 +200,8 @@ func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distrib
 	a.RegisterRoute("/ha-tracker", d.HATracker, false, "GET")
 }
 
+// ingester is defined as an interface to allow for alternative implementations
+// of ingesters to be passed into the API.RegisterIngester() method.
 type ingester interface {
 	client.IngesterServer
 	FlushHandler(http.ResponseWriter, *http.Request)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/purger"
 	"github.com/cortexproject/cortex/pkg/compactor"
 	"github.com/cortexproject/cortex/pkg/distributor"
-	"github.com/cortexproject/cortex/pkg/ingester"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/querier"
 	"github.com/cortexproject/cortex/pkg/querier/frontend"
@@ -201,8 +200,15 @@ func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distrib
 	a.RegisterRoute("/ha-tracker", d.HATracker, false, "GET")
 }
 
+type ingester interface {
+	client.IngesterServer
+	FlushHandler(http.ResponseWriter, *http.Request)
+	ShutdownHandler(http.ResponseWriter, *http.Request)
+	Push(context.Context, *client.WriteRequest) (*client.WriteResponse, error)
+}
+
 // RegisterIngester registers the ingesters HTTP and GRPC service
-func (a *API) RegisterIngester(i *ingester.Ingester, pushConfig distributor.Config) {
+func (a *API) RegisterIngester(i ingester, pushConfig distributor.Config) {
 	client.RegisterIngesterServer(a.server.GRPC, i)
 
 	a.indexPage.AddLink(SectionDangerous, "/ingester/flush", "Trigger a Flush of data from Ingester to storage")


### PR DESCRIPTION
I would like to extend the Ingester by wrapping it in another struct, which overrides some methods and does additional work before calling the original Ingester methods.

Currently the API method `.RegisterIngester()` expects the concrete type `*ingester.Ingester`, so I can't pass it the extended ingester type. Outside the `api` package I also can't easily re-implement the `.RegisterIngester()` method, because it uses an unexported property of the API (`sourceIPs`). 
By changing the API method `RegisterIngester()` to expect an interface I'll be able to pass it the extended Ingester type and register its methods on the HTTP and the GRPC server.

What do you think about this approach?
An alternative to creating an Ingester interface would be to export that unexported property `.sourceIPs` which is used by `API.RegisterIngester()`, that way I could basically just re-implement what this method is doing outside the package, but that seems less elegant and might be more error-prone because if `RegisterIngester()` changes in the future I'll have to ensure that my copy stays up2date.