### PR TITLE
Fail fast an ingester if unable to load existing TSDBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 * [BUGFIX] Fixed the metric `cortex_prometheus_rule_group_duration_seconds` in the Ruler, it wouldn't report any values. #3310
 * [BUGFIX] Fixed gRPC connections leaking in rulers when rulers sharding is enabled and APIs called. #3314
 * [BUGFIX] Fixed shuffle sharding consistency when zone-awareness is enabled and the shard size is increased or instances in a new zone are added. #3299
+* [BUGFIX] Ingester: fail to start an ingester running the blocks storage, if unable to load any existing TSDB at startup. #3354
 
 ## 1.4.0 / 2020-10-02
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/shipper"
@@ -253,6 +254,9 @@ func NewV2ForFlusher(cfg Config, registerer prometheus.Registerer) (*Ingester, e
 
 func (i *Ingester) startingV2ForFlusher(ctx context.Context) error {
 	if err := i.openExistingTSDB(ctx); err != nil {
+		// Try to rollback and close opened TSDBs before halting the ingester.
+		i.closeAllTSDB()
+
 		return errors.Wrap(err, "opening existing TSDBs")
 	}
 
@@ -262,6 +266,9 @@ func (i *Ingester) startingV2ForFlusher(ctx context.Context) error {
 
 func (i *Ingester) startingV2(ctx context.Context) error {
 	if err := i.openExistingTSDB(ctx); err != nil {
+		// Try to rollback and close opened TSDBs before halting the ingester.
+		i.closeAllTSDB()
+
 		return errors.Wrap(err, "opening existing TSDBs")
 	}
 
@@ -1057,8 +1064,13 @@ func (i *Ingester) openExistingTSDB(ctx context.Context) error {
 	wg := &sync.WaitGroup{}
 	openGate := gate.New(i.cfg.BlocksStorageConfig.TSDB.MaxTSDBOpeningConcurrencyOnStartup)
 
-	err := filepath.Walk(i.cfg.BlocksStorageConfig.TSDB.Dir, func(path string, info os.FileInfo, err error) error {
+	// Keep track of all errors that could occur.
+	errs := tsdb_errors.MultiError{}
+	errsMx := sync.Mutex{}
+
+	walkErr := filepath.Walk(i.cfg.BlocksStorageConfig.TSDB.Dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			level.Warn(util.Logger).Log("msg", "skipped filesystem entry when looking for existing TSDB to open", "path", path, "err", err)
 			return filepath.SkipDir
 		}
 
@@ -1071,18 +1083,19 @@ func (i *Ingester) openExistingTSDB(ctx context.Context) error {
 		userID := info.Name()
 		f, err := os.Open(path)
 		if err != nil {
-			level.Error(util.Logger).Log("msg", "unable to open user TSDB dir", "err", err, "user", userID, "path", path)
-			return filepath.SkipDir
+			level.Error(util.Logger).Log("msg", "unable to open TSDB dir", "err", err, "user", userID, "path", path)
+			return errors.Wrapf(err, "unable to open TSDB dir %s for user %s", path, userID)
 		}
 		defer f.Close()
 
 		// If the dir is empty skip it
 		if _, err := f.Readdirnames(1); err != nil {
-			if err != io.EOF {
-				level.Error(util.Logger).Log("msg", "unable to read TSDB dir", "err", err, "user", userID, "path", path)
+			if err == io.EOF {
+				return filepath.SkipDir
 			}
 
-			return filepath.SkipDir
+			level.Error(util.Logger).Log("msg", "unable to read TSDB dir", "err", err, "user", userID, "path", path)
+			return errors.Wrapf(err, "unable to read TSDB dir %s for user %s", path, userID)
 		}
 
 		// Limit the number of TSDB's opening concurrently. Start blocks until there's a free spot available or the context is cancelled.
@@ -1100,7 +1113,11 @@ func (i *Ingester) openExistingTSDB(ctx context.Context) error {
 
 			db, err := i.createTSDB(userID)
 			if err != nil {
-				level.Error(util.Logger).Log("msg", "unable to open user TSDB", "err", err, "user", userID)
+				errsMx.Lock()
+				errs.Add(errors.Wrapf(err, "unable to open TSDB for user %s", userID))
+				errsMx.Unlock()
+
+				level.Error(util.Logger).Log("msg", "unable to open TSDB", "err", err, "user", userID)
 				return
 			}
 
@@ -1114,14 +1131,23 @@ func (i *Ingester) openExistingTSDB(ctx context.Context) error {
 		return filepath.SkipDir // Don't descend into directories
 	})
 
+	if walkErr != nil {
+		errsMx.Lock()
+		errs.Add(errors.Wrapf(walkErr, "unable to walk directory %s containing existing TSDBs", i.cfg.BlocksStorageConfig.TSDB.Dir))
+		errsMx.Unlock()
+	}
+
 	// Wait for all opening routines to finish
 	wg.Wait()
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error while opening existing TSDBs")
-	} else {
+
+	// Ensure no error occurred.
+	if errs.Err() == nil {
 		level.Info(util.Logger).Log("msg", "successfully opened existing TSDBs")
+		return nil
 	}
-	return err
+
+	level.Error(util.Logger).Log("msg", "error while opening existing TSDBs", "err", errs.Error())
+	return errs.Err()
 }
 
 // numSeriesInTSDB returns the total number of in-memory series across all open TSDBs.

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1070,6 +1070,11 @@ func (i *Ingester) openExistingTSDB(ctx context.Context) error {
 
 	walkErr := filepath.Walk(i.cfg.BlocksStorageConfig.TSDB.Dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			// If the root directory doesn't exist, we're OK (not needed to be created upfront).
+			if os.IsNotExist(err) && path == i.cfg.BlocksStorageConfig.TSDB.Dir {
+				return filepath.SkipDir
+			}
+
 			level.Error(util.Logger).Log("msg", "an error occurred while iterating the filesystem storing TSDBs", "path", path, "err", err)
 			return errors.Wrapf(err, "an error occurred while iterating the filesystem storing TSDBs at %s", path)
 		}

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1070,8 +1070,8 @@ func (i *Ingester) openExistingTSDB(ctx context.Context) error {
 
 	walkErr := filepath.Walk(i.cfg.BlocksStorageConfig.TSDB.Dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			level.Warn(util.Logger).Log("msg", "skipped filesystem entry when looking for existing TSDB to open", "path", path, "err", err)
-			return filepath.SkipDir
+			level.Error(util.Logger).Log("msg", "an error occurred while iterating the filesystem storing TSDBs", "path", path, "err", err)
+			return errors.Wrapf(err, "an error occurred while iterating the filesystem storing TSDBs at %s", path)
 		}
 
 		// Skip root dir and all other files


### PR DESCRIPTION
**What this PR does**:
Tonight we had an issue in one ingester which had TSDB head chunks corrupted (root cause will be discussed separately). When a similar issue happen, the ingester skips the corrupted TSDB at startup, it joins the ring with `ACTIVE` state and, as soon as receive any write request from the tenant with the corrupted TSDB it will try to reopen the TSDB for *every single write request*. This leads to an undesirable situation, which will soon get the ingester to get killed (due to OOM).

In this PR I'm proposing to fail fast the ingester if unable to load an existing TSDB. It's a loud and clear signal to the Cortex cluster operator and, in my opinion, it's better to fail fast an ingester before it start receiving write requests instead of having it failing few minutes after running.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
