### PR TITLE
Export distributor method to get ingester replication set

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -639,7 +639,7 @@ func (d *Distributor) ForReplicationSet(ctx context.Context, replicationSet ring
 
 // LabelValuesForLabelName returns all of the label values that are associated with a given label name.
 func (d *Distributor) LabelValuesForLabelName(ctx context.Context, labelName model.LabelName) ([]string, error) {
-	replicationSet, err := d.getIngestersForMetadata(ctx)
+	replicationSet, err := d.GetIngestersForMetadata(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -670,7 +670,7 @@ func (d *Distributor) LabelValuesForLabelName(ctx context.Context, labelName mod
 
 // LabelNames returns all of the label names.
 func (d *Distributor) LabelNames(ctx context.Context) ([]string, error) {
-	replicationSet, err := d.getIngestersForMetadata(ctx)
+	replicationSet, err := d.GetIngestersForMetadata(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -703,7 +703,7 @@ func (d *Distributor) LabelNames(ctx context.Context) ([]string, error) {
 
 // MetricsForLabelMatchers gets the metrics that match said matchers
 func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]metric.Metric, error) {
-	replicationSet, err := d.getIngestersForMetadata(ctx)
+	replicationSet, err := d.GetIngestersForMetadata(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -739,7 +739,7 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 
 // MetricsMetadata returns all metric metadata of a user.
 func (d *Distributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetadata, error) {
-	replicationSet, err := d.getIngestersForMetadata(ctx)
+	replicationSet, err := d.GetIngestersForMetadata(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -779,7 +779,7 @@ func (d *Distributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetad
 
 // UserStats returns statistics about the current user.
 func (d *Distributor) UserStats(ctx context.Context) (*UserStats, error) {
-	replicationSet, err := d.getIngestersForMetadata(ctx)
+	replicationSet, err := d.GetIngestersForMetadata(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -28,7 +28,7 @@ func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers .
 			return err
 		}
 
-		replicationSet, err := d.getIngestersForQuery(ctx, matchers...)
+		replicationSet, err := d.GetIngestersForQuery(ctx, matchers...)
 		if err != nil {
 			return err
 		}
@@ -55,7 +55,7 @@ func (d *Distributor) QueryStream(ctx context.Context, from, to model.Time, matc
 			return err
 		}
 
-		replicationSet, err := d.getIngestersForQuery(ctx, matchers...)
+		replicationSet, err := d.GetIngestersForQuery(ctx, matchers...)
 		if err != nil {
 			return err
 		}
@@ -73,9 +73,9 @@ func (d *Distributor) QueryStream(ctx context.Context, from, to model.Time, matc
 	return result, err
 }
 
-// getIngestersForQuery returns a replication set including all ingesters that should be queried
+// GetIngestersForQuery returns a replication set including all ingesters that should be queried
 // to fetch series matching input label matchers.
-func (d *Distributor) getIngestersForQuery(ctx context.Context, matchers ...*labels.Matcher) (ring.ReplicationSet, error) {
+func (d *Distributor) GetIngestersForQuery(ctx context.Context, matchers ...*labels.Matcher) (ring.ReplicationSet, error) {
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return ring.ReplicationSet{}, err

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -104,9 +104,9 @@ func (d *Distributor) getIngestersForQuery(ctx context.Context, matchers ...*lab
 	return d.ingestersRing.GetAll(ring.Read)
 }
 
-// getIngestersForMetadata returns a replication set including all ingesters that should be queried
+// GetIngestersForMetadata returns a replication set including all ingesters that should be queried
 // to fetch metadata (eg. label names/values or series).
-func (d *Distributor) getIngestersForMetadata(ctx context.Context) (ring.ReplicationSet, error) {
+func (d *Distributor) GetIngestersForMetadata(ctx context.Context) (ring.ReplicationSet, error) {
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return ring.ReplicationSet{}, err


### PR DESCRIPTION
I'd like to query all Ingesters of a replication set for some data, to do this I can use the distributor method `ForReplicationSet()`. But to obtain the replication set which I need to query I'd need to be able to call the distributor method `getIngestersForMetadata()`, which is currently not exported. Would it be fine for you to export that method, or is there a better way for me to obtain the replication set that I need to query?