### PR TITLE
fix common prefixes returned by List method of s3 client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@
 * [BUGFIX] Fixed Gossip memberlist members joining when addresses are configured using DNS-based service discovery. #3360
 * [BUGFIX] Ingester: fail to start an ingester running the blocks storage, if unable to load any existing TSDB at startup. #3354
 * [BUGFIX] Blocks storage: Avoid deletion of blocks in the ingester which are not shipped to the storage yet. #3346
-* [BUGFIX] Fix common prefixes returned by List method of s3 client. #3358
+* [BUGFIX] Fix common prefixes returned by List method of S3 client. #3358
 
 ## 1.4.0 / 2020-10-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 * [BUGFIX] Fixed Gossip memberlist members joining when addresses are configured using DNS-based service discovery. #3360
 * [BUGFIX] Ingester: fail to start an ingester running the blocks storage, if unable to load any existing TSDB at startup. #3354
 * [BUGFIX] Blocks storage: Avoid deletion of blocks in the ingester which are not shipped to the storage yet. #3346
+* [BUGFIX] Fix common prefixes returned by List method of s3 client. #3358
 
 ## 1.4.0 / 2020-10-02
 

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -314,7 +314,7 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix, delimiter string) ([]
 				}
 
 				for _, commonPrefix := range output.CommonPrefixes {
-					commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(*commonPrefix.Prefix))
+					commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(aws.StringValue(commonPrefix.Prefix)))
 				}
 
 				if !*output.IsTruncated {

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -314,7 +314,7 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix, delimiter string) ([]
 				}
 
 				for _, commonPrefix := range output.CommonPrefixes {
-					commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(commonPrefix.String()))
+					commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(*commonPrefix.Prefix))
 				}
 
 				if !*output.IsTruncated {


### PR DESCRIPTION
Signed-off-by: Sandeep Sukhani <sandeep.d.sukhani@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
AWS SDK returns a type called `CommonPrefix` which is a struct and inside it there is a Prefix field which holds the actual common prefix value. I was by mistake using `String` method on  `CommonPrefix` instead of accessing the `Prefix` field for building the response from `List` call.
This PR fixes the issue by returning the correct value instead of marshalled `CommonPrefix` type.

I have verified this fix with an s3 bucket, now it works fine as expected.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
