### PR TITLE
Per tenant ruler rule group limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-tenant` globally, or using per-tenant limit `max_queriers_per_tenant`), each tenants's requests will be handled by different set of queriers. #3113 #3257
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding ingesters on the read path. When ingesters shuffle-sharding is enabled and `-querier.shuffle-sharding-ingesters-lookback-period` is set, queriers will fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. #3252
 * [FEATURE] Query-frontend: added `compression` config to support results cache with compression. #3217
-* [ENHANCEMENT] Ruler: Introduces two new limits `-ruler.max-rules-per-rule-group` and `-ruler.max-rule-groups-per-tenant` to control the number of rules per rule group and the total number of rule groups for a given user. #3366
+* [ENHANCEMENT] Ruler: Introduces two new limits `-ruler.max-rules-per-rule-group` and `-ruler.max-rule-groups-per-tenant` to control the number of rules per rule group and the total number of rule groups for a given user. They are disabled by default. #3366
 * [ENHANCEMENT] Allow to specify multiple comma-separated Cortex services to `-target` CLI option (or its respective YAML config option). For example, `-target=all,compactor` can be used to start Cortex single-binary with compactor as well. #3275
 * [ENHANCEMENT] Expose additional HTTP configs for the S3 backend client. New flag are listed below: #3244
   - `-blocks-storage.s3.http.idle-conn-timeout`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-tenant` globally, or using per-tenant limit `max_queriers_per_tenant`), each tenants's requests will be handled by different set of queriers. #3113 #3257
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding ingesters on the read path. When ingesters shuffle-sharding is enabled and `-querier.shuffle-sharding-ingesters-lookback-period` is set, queriers will fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. #3252
 * [FEATURE] Query-frontend: added `compression` config to support results cache with compression. #3217
+* [ENHANCEMENT] Ruler: Introduces two new limits `-ruler.max-rules-per-rule-group` and `-ruler.max-rule-groups` to control the number of rules per rule group and the total number of rule groups for a given user. #3366
 * [ENHANCEMENT] Allow to specify multiple comma-separated Cortex services to `-target` CLI option (or its respective YAML config option). For example, `-target=all,compactor` can be used to start Cortex single-binary with compactor as well. #3275
 * [ENHANCEMENT] Expose additional HTTP configs for the S3 backend client. New flag are listed below: #3244
   - `-blocks-storage.s3.http.idle-conn-timeout`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-tenant` globally, or using per-tenant limit `max_queriers_per_tenant`), each tenants's requests will be handled by different set of queriers. #3113 #3257
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding ingesters on the read path. When ingesters shuffle-sharding is enabled and `-querier.shuffle-sharding-ingesters-lookback-period` is set, queriers will fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. #3252
 * [FEATURE] Query-frontend: added `compression` config to support results cache with compression. #3217
-* [ENHANCEMENT] Ruler: Introduces two new limits `-ruler.max-rules-per-rule-group` and `-ruler.max-rule-groups` to control the number of rules per rule group and the total number of rule groups for a given user. #3366
+* [ENHANCEMENT] Ruler: Introduces two new limits `-ruler.max-rules-per-rule-group` and `-ruler.max-rule-groups-per-tenant` to control the number of rules per rule group and the total number of rule groups for a given user. #3366
 * [ENHANCEMENT] Allow to specify multiple comma-separated Cortex services to `-target` CLI option (or its respective YAML config option). For example, `-target=all,compactor` can be used to start Cortex single-binary with compactor as well. #3275
 * [ENHANCEMENT] Expose additional HTTP configs for the S3 backend client. New flag are listed below: #3244
   - `-blocks-storage.s3.http.idle-conn-timeout`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2905,11 +2905,11 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 
 # Maximum number of rules per rule group per-tenant. 0 to disable.
 # CLI flag: -ruler.max-rules-per-rule-group
-[ruler_max_rules_per_rule_group: <int> | default = 15]
+[ruler_max_rules_per_rule_group: <int> | default = 0]
 
 # Maximum number of rule groups per-tenant. 0 to disable.
 # CLI flag: -ruler.max-rule-groups-per-tenant
-[ruler_max_rule_groups_per_tenant: <int> | default = 20]
+[ruler_max_rule_groups_per_tenant: <int> | default = 0]
 
 # The default tenant's shard size when the shuffle-sharding strategy is used.
 # Must be set when the store-gateway sharding is enabled with the

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2909,7 +2909,7 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 
 # Maximum number of rule groups per-tenant. 0 to disable.
 # CLI flag: -ruler.max-rule-groups-per-tenant
-[ruler_max_rule_groups: <int> | default = 20]
+[ruler_max_rule_groups_per_tenant: <int> | default = 20]
 
 # The default tenant's shard size when the shuffle-sharding strategy is used.
 # Must be set when the store-gateway sharding is enabled with the

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2908,7 +2908,7 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 [ruler_max_rules_per_rule_group: <int> | default = 15]
 
 # Maximum number of rule groups per-tenant. 0 to disable.
-# CLI flag: -ruler.max-rule-groups
+# CLI flag: -ruler.max-rule-groups-per-tenant
 [ruler_max_rule_groups: <int> | default = 20]
 
 # The default tenant's shard size when the shuffle-sharding strategy is used.

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2903,11 +2903,11 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -ruler.tenant-shard-size
 [ruler_tenant_shard_size: <int> | default = 0]
 
-# Maximum number of rules per rule group per-tenant.
+# Maximum number of rules per rule group per-tenant. 0 to disable.
 # CLI flag: -ruler.max-rules-per-rule-group
-[ruler_max_rules_per_rule_group_per_user: <int> | default = 15]
+[ruler_max_rules_per_rule_group: <int> | default = 15]
 
-# Maximum number of rule groups per-tenant.
+# Maximum number of rule groups per-tenant. 0 to disable.
 # CLI flag: -ruler.max-rule-groups
 [ruler_max_rule_groups: <int> | default = 20]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2903,6 +2903,14 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -ruler.tenant-shard-size
 [ruler_tenant_shard_size: <int> | default = 0]
 
+# Maximum number of rules per rule group per-tenant.
+# CLI flag: -ruler.max-rules-per-rule-group
+[ruler_max_rules_per_rule_group_per_user: <int> | default = 15]
+
+# Maximum number of rule groups per-tenant.
+# CLI flag: -ruler.max-rule-groups
+[ruler_max_rule_groups: <int> | default = 20]
+
 # The default tenant's shard size when the shuffle-sharding strategy is used.
 # Must be set when the store-gateway sharding is enabled with the
 # shuffle-sharding strategy. When this setting is specified in the per-tenant

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -472,7 +472,7 @@ func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if err := a.ruler.AssertMaxRulesPerRuleGroupPerUser(userID, len(rg.Rules)); err != nil {
+	if err := a.ruler.AssertMaxRulesPerRuleGroup(userID, len(rg.Rules)); err != nil {
 		level.Error(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -485,7 +485,7 @@ func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if err := a.ruler.AssertMaxRuleGroupsPerUser(userID, len(rgs)); err != nil {
+	if err := a.ruler.AssertMaxRuleGroups(userID, len(rgs)); err != nil {
 		level.Error(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -480,7 +480,7 @@ func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 
 	rgs, err := a.store.ListRuleGroupsForUserAndNamespace(req.Context(), userID, "")
 	if err != nil {
-		level.Error(logger).Log("msg", "unable to fetch current rule groups for validation", "err", err.Error())
+		level.Error(logger).Log("msg", "unable to fetch current rule groups for validation", "err", err.Error(), "user", userID)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -472,6 +472,25 @@ func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	if err := a.ruler.AssertMaxRulesPerRuleGroupPerUser(userID, len(rg.Rules)); err != nil {
+		level.Error(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	rgl, err := a.store.ListRuleGroupsForUserAndNamespace(req.Context(), userID, "")
+	if err != nil {
+		level.Error(logger).Log("msg", "unable to fetch current rule groups for validation", "err", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := a.ruler.AssertMaxRuleGroupsPerUser(userID, len(rgl)); err != nil {
+		level.Error(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	rgProto := store.ToProto(userID, namespace, rg)
 
 	level.Debug(logger).Log("msg", "attempting to store rulegroup", "userID", userID, "group", rgProto.String())

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -478,14 +478,14 @@ func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	rgl, err := a.store.ListRuleGroupsForUserAndNamespace(req.Context(), userID, "")
+	rgs, err := a.store.ListRuleGroupsForUserAndNamespace(req.Context(), userID, "")
 	if err != nil {
 		level.Error(logger).Log("msg", "unable to fetch current rule groups for validation", "err", err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	if err := a.ruler.AssertMaxRuleGroupsPerUser(userID, len(rgl)); err != nil {
+	if err := a.ruler.AssertMaxRuleGroupsPerUser(userID, len(rgs)); err != nil {
 		level.Error(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -76,6 +76,8 @@ func (t *PusherAppendable) Appender(ctx context.Context) storage.Appender {
 type RulesLimits interface {
 	EvaluationDelay(userID string) time.Duration
 	RulerTenantShardSize(userID string) int
+	RulerMaxRuleGroupsPerUser(userID string) int
+	RulerMaxRulesPerRuleGroupPerUser(userID string) int
 }
 
 // engineQueryFunc returns a new query function using the rules.EngineQueryFunc function

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -76,8 +76,8 @@ func (t *PusherAppendable) Appender(ctx context.Context) storage.Appender {
 type RulesLimits interface {
 	EvaluationDelay(userID string) time.Duration
 	RulerTenantShardSize(userID string) int
-	RulerMaxRuleGroupsPerUser(userID string) int
-	RulerMaxRulesPerRuleGroupPerUser(userID string) int
+	RulerMaxRuleGroups(userID string) int
+	RulerMaxRulesPerRuleGroup(userID string) int
 }
 
 // engineQueryFunc returns a new query function using the rules.EngineQueryFunc function

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -76,7 +76,7 @@ func (t *PusherAppendable) Appender(ctx context.Context) storage.Appender {
 type RulesLimits interface {
 	EvaluationDelay(userID string) time.Duration
 	RulerTenantShardSize(userID string) int
-	RulerMaxRuleGroups(userID string) int
+	RulerMaxRuleGroupsPerTenant(userID string) int
 	RulerMaxRulesPerRuleGroup(userID string) int
 }
 

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -58,7 +58,7 @@ const (
 	rulerSyncReasonRingChange = "ring-change"
 
 	// Limit errors
-	errMaxRuleGroupsPerUserLimitExceeded        = "per-user rule groups limit (limit %d actual: %d) exceeded"
+	errMaxRuleGroupsPerUserLimitExceeded        = "per-user rule groups limit (limit: %d actual: %d) exceeded"
 	errMaxRulesPerRuleGroupPerUserLimitExceeded = "per-user rules per rule group limit (limit: %d actual: %d) exceeded"
 )
 

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -741,6 +741,8 @@ func (r *Ruler) Rules(ctx context.Context, in *RulesRequest) (*RulesResponse, er
 	return &RulesResponse{Groups: groupDescs}, nil
 }
 
+// AssertMaxRuleGroupsPerUser limit has not been reached compared to the current
+// number of total rule groups in input and returns an error if so.
 func (r *Ruler) AssertMaxRuleGroupsPerUser(userID string, rg int) error {
 	limit := r.limits.RulerMaxRuleGroupsPerUser(userID)
 
@@ -751,6 +753,8 @@ func (r *Ruler) AssertMaxRuleGroupsPerUser(userID string, rg int) error {
 	return fmt.Errorf(errMaxRuleGroupsPerUserLimitExceeded, limit, rg)
 }
 
+// AssertMaxRulesPerRuleGroupPerUser limit has not been reached compared to the current
+// number of rules in a rule group in input and returns an error if so.
 func (r *Ruler) AssertMaxRulesPerRuleGroupPerUser(userID string, rules int) error {
 	limit := r.limits.RulerMaxRulesPerRuleGroupPerUser(userID)
 

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -56,6 +56,10 @@ const (
 	rulerSyncReasonInitial    = "initial"
 	rulerSyncReasonPeriodic   = "periodic"
 	rulerSyncReasonRingChange = "ring-change"
+
+	// Limit errors
+	errMaxRuleGroupsPerUserLimitExceeded        = "per-user rule groups limit (limit %d actual: %d) exceeded"
+	errMaxRulesPerRuleGroupPerUserLimitExceeded = "per-user rules per rule group limit (limit: %d actual: %d) exceeded"
 )
 
 // Config is the configuration for the recording rules server.
@@ -735,4 +739,23 @@ func (r *Ruler) Rules(ctx context.Context, in *RulesRequest) (*RulesResponse, er
 	}
 
 	return &RulesResponse{Groups: groupDescs}, nil
+}
+
+func (r *Ruler) AssertMaxRuleGroupsPerUser(userID string, rg int) error {
+	limit := r.limits.RulerMaxRuleGroupsPerUser(userID)
+
+	if rg < limit {
+		return nil
+	}
+
+	return fmt.Errorf(errMaxRuleGroupsPerUserLimitExceeded, limit, rg)
+}
+
+func (r *Ruler) AssertMaxRulesPerRuleGroupPerUser(userID string, rules int) error {
+	limit := r.limits.RulerMaxRulesPerRuleGroupPerUser(userID)
+
+	if rules < limit {
+		return nil
+	}
+	return fmt.Errorf(errMaxRulesPerRuleGroupPerUserLimitExceeded, limit, rules)
 }

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -744,7 +744,7 @@ func (r *Ruler) Rules(ctx context.Context, in *RulesRequest) (*RulesResponse, er
 // AssertMaxRuleGroups limit has not been reached compared to the current
 // number of total rule groups in input and returns an error if so.
 func (r *Ruler) AssertMaxRuleGroups(userID string, rg int) error {
-	limit := r.limits.RulerMaxRuleGroups(userID)
+	limit := r.limits.RulerMaxRuleGroupsPerTenant(userID)
 
 	if limit <= 0 {
 		return nil

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -741,10 +741,14 @@ func (r *Ruler) Rules(ctx context.Context, in *RulesRequest) (*RulesResponse, er
 	return &RulesResponse{Groups: groupDescs}, nil
 }
 
-// AssertMaxRuleGroupsPerUser limit has not been reached compared to the current
+// AssertMaxRuleGroups limit has not been reached compared to the current
 // number of total rule groups in input and returns an error if so.
-func (r *Ruler) AssertMaxRuleGroupsPerUser(userID string, rg int) error {
-	limit := r.limits.RulerMaxRuleGroupsPerUser(userID)
+func (r *Ruler) AssertMaxRuleGroups(userID string, rg int) error {
+	limit := r.limits.RulerMaxRuleGroups(userID)
+
+	if limit <= 0 {
+		return nil
+	}
 
 	if rg < limit {
 		return nil
@@ -753,10 +757,14 @@ func (r *Ruler) AssertMaxRuleGroupsPerUser(userID string, rg int) error {
 	return fmt.Errorf(errMaxRuleGroupsPerUserLimitExceeded, limit, rg)
 }
 
-// AssertMaxRulesPerRuleGroupPerUser limit has not been reached compared to the current
+// AssertMaxRulesPerRuleGroup limit has not been reached compared to the current
 // number of rules in a rule group in input and returns an error if so.
-func (r *Ruler) AssertMaxRulesPerRuleGroupPerUser(userID string, rules int) error {
-	limit := r.limits.RulerMaxRulesPerRuleGroupPerUser(userID)
+func (r *Ruler) AssertMaxRulesPerRuleGroup(userID string, rules int) error {
+	limit := r.limits.RulerMaxRulesPerRuleGroup(userID)
+
+	if limit <= 0 {
+		return nil
+	}
 
 	if rules < limit {
 		return nil

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -111,7 +111,7 @@ func testSetup(t *testing.T, cfg Config) (*promql.Engine, storage.QueryableFunc,
 	l := log.NewLogfmtLogger(os.Stdout)
 	l = level.NewFilter(l, level.AllowInfo())
 
-	return engine, noopQueryable, pusher, l, ruleLimits{evalDelay: 0}, cleanup
+	return engine, noopQueryable, pusher, l, ruleLimits{evalDelay: 0, maxRuleGroups: 20, maxRulesPerRuleGroup: 15}, cleanup
 }
 
 func newManager(t *testing.T, cfg Config) (*DefaultMultiTenantManager, func()) {

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -77,7 +77,7 @@ func (r ruleLimits) RulerTenantShardSize(_ string) int {
 	return r.tenantShard
 }
 
-func (r ruleLimits) RulerMaxRuleGroups(_ string) int {
+func (r ruleLimits) RulerMaxRuleGroupsPerTenant(_ string) int {
 	return r.maxRuleGroups
 }
 

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -77,11 +77,11 @@ func (r ruleLimits) RulerTenantShardSize(_ string) int {
 	return r.tenantShard
 }
 
-func (r ruleLimits) RulerMaxRuleGroupsPerUser(_ string) int {
+func (r ruleLimits) RulerMaxRuleGroups(_ string) int {
 	return r.maxRuleGroups
 }
 
-func (r ruleLimits) RulerMaxRulesPerRuleGroupPerUser(_ string) int {
+func (r ruleLimits) RulerMaxRulesPerRuleGroup(_ string) int {
 	return r.maxRulesPerRuleGroup
 }
 

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -63,8 +63,10 @@ func defaultRulerConfig(store rules.RuleStore) (Config, func()) {
 }
 
 type ruleLimits struct {
-	evalDelay   time.Duration
-	tenantShard int
+	evalDelay            time.Duration
+	tenantShard          int
+	maxRulesPerRuleGroup int
+	maxRuleGroups        int
 }
 
 func (r ruleLimits) EvaluationDelay(_ string) time.Duration {
@@ -73,6 +75,14 @@ func (r ruleLimits) EvaluationDelay(_ string) time.Duration {
 
 func (r ruleLimits) RulerTenantShardSize(_ string) int {
 	return r.tenantShard
+}
+
+func (r ruleLimits) RulerMaxRuleGroupsPerUser(_ string) int {
+	return r.maxRuleGroups
+}
+
+func (r ruleLimits) RulerMaxRulesPerRuleGroupPerUser(_ string) int {
+	return r.maxRulesPerRuleGroup
 }
 
 func testSetup(t *testing.T, cfg Config) (*promql.Engine, storage.QueryableFunc, Pusher, log.Logger, RulesLimits, func()) {

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -144,7 +144,7 @@ func (m *mockRuleStore) ListRuleGroupsForUserAndNamespace(_ context.Context, use
 
 	userRules, exists := m.rules[userID]
 	if !exists {
-		return nil, rules.ErrUserNotFound
+		return rules.RuleGroupList{}, nil
 	}
 
 	if namespace == "" {
@@ -160,7 +160,7 @@ func (m *mockRuleStore) ListRuleGroupsForUserAndNamespace(_ context.Context, use
 	}
 
 	if len(namespaceRules) == 0 {
-		return nil, rules.ErrGroupNamespaceNotFound
+		return rules.RuleGroupList{}, nil
 	}
 
 	return namespaceRules, nil

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -71,10 +71,10 @@ type Limits struct {
 	MaxQueriersPerTenant int           `yaml:"max_queriers_per_tenant"`
 
 	// Ruler defaults and limits.
-	RulerEvaluationDelay             time.Duration `yaml:"ruler_evaluation_delay_duration"`
-	RulerTenantShardSize             int           `yaml:"ruler_tenant_shard_size"`
-	RulerMaxRulesPerRuleGroupPerUser int           `yaml:"ruler_max_rules_per_rule_group_per_user"`
-	RulerMaxRuleGroupsPerUser        int           `yaml:"ruler_max_rule_groups_per_user"`
+	RulerEvaluationDelay      time.Duration `yaml:"ruler_evaluation_delay_duration"`
+	RulerTenantShardSize      int           `yaml:"ruler_tenant_shard_size"`
+	RulerMaxRulesPerRuleGroup int           `yaml:"ruler_max_rules_per_rule_group"`
+	RulerMaxRuleGroups        int           `yaml:"ruler_max_rule_groups"`
 
 	// Store-gateway.
 	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size"`
@@ -126,8 +126,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.DurationVar(&l.RulerEvaluationDelay, "ruler.evaluation-delay-duration", 0, "Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed to Cortex.")
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The default tenant's shard size when the shuffle-sharding strategy is used by ruler. When this setting is specified in the per-tenant overrides, a value of 0 disables shuffle sharding for the tenant.")
-	f.IntVar(&l.RulerMaxRulesPerRuleGroupPerUser, "ruler.max-rules-per-rule-group", 15, "Maximum number of rules per rule group per-tenant.")
-	f.IntVar(&l.RulerMaxRuleGroupsPerUser, "ruler.max-rule-groups-per-user", 20, "Maximum number of rule groups per-tenant.")
+	f.IntVar(&l.RulerMaxRulesPerRuleGroup, "ruler.max-rules-per-rule-group", 15, "Maximum number of rules per rule group per-tenant. 0 to disable.")
+	f.IntVar(&l.RulerMaxRuleGroups, "ruler.max-rule-groups", 20, "Maximum number of rule groups per-tenant. 0 to disable.")
 
 	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "File name of per-user overrides. [deprecated, use -runtime-config.file instead]")
 	f.DurationVar(&l.PerTenantOverridePeriod, "limits.per-user-override-period", 10*time.Second, "Period with which to reload the overrides. [deprecated, use -runtime-config.reload-period instead]")
@@ -381,14 +381,14 @@ func (o *Overrides) RulerTenantShardSize(userID string) int {
 	return o.getOverridesForUser(userID).RulerTenantShardSize
 }
 
-// RulerMaxRulesPerRuleGroupPerUser returns the maximum number of rules per rule group for a given user.
-func (o *Overrides) RulerMaxRulesPerRuleGroupPerUser(userID string) int {
-	return o.getOverridesForUser(userID).RulerMaxRulesPerRuleGroupPerUser
+// RulerMaxRulesPerRuleGroup returns the maximum number of rules per rule group for a given user.
+func (o *Overrides) RulerMaxRulesPerRuleGroup(userID string) int {
+	return o.getOverridesForUser(userID).RulerMaxRulesPerRuleGroup
 }
 
-// RulerMaxRuleGroupsPerUser returns the maximum number of rule groups for a given user.
-func (o *Overrides) RulerMaxRuleGroupsPerUser(userID string) int {
-	return o.getOverridesForUser(userID).RulerMaxRuleGroupsPerUser
+// RulerMaxRuleGroups returns the maximum number of rule groups for a given user.
+func (o *Overrides) RulerMaxRuleGroups(userID string) int {
+	return o.getOverridesForUser(userID).RulerMaxRuleGroups
 }
 
 // StoreGatewayTenantShardSize returns the store-gateway shard size for a given user.

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -381,10 +381,12 @@ func (o *Overrides) RulerTenantShardSize(userID string) int {
 	return o.getOverridesForUser(userID).RulerTenantShardSize
 }
 
+// RulerMaxRulesPerRuleGroupPerUser returns the maximum number of rules per rule group for a given user.
 func (o *Overrides) RulerMaxRulesPerRuleGroupPerUser(userID string) int {
 	return o.getOverridesForUser(userID).RulerMaxRulesPerRuleGroupPerUser
 }
 
+// RulerMaxRuleGroupsPerUser returns the maximum number of rule groups for a given user.
 func (o *Overrides) RulerMaxRuleGroupsPerUser(userID string) int {
 	return o.getOverridesForUser(userID).RulerMaxRuleGroupsPerUser
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -127,7 +127,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&l.RulerEvaluationDelay, "ruler.evaluation-delay-duration", 0, "Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed to Cortex.")
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The default tenant's shard size when the shuffle-sharding strategy is used by ruler. When this setting is specified in the per-tenant overrides, a value of 0 disables shuffle sharding for the tenant.")
 	f.IntVar(&l.RulerMaxRulesPerRuleGroupPerUser, "ruler.max-rules-per-rule-group", 15, "Maximum number of rules per rule group per-tenant.")
-	f.IntVar(&l.RulerMaxRuleGroupsPerUser, "ruler.max-rule-groups", 20, "Maximum number of rule groups per-tenant.")
+	f.IntVar(&l.RulerMaxRuleGroupsPerUser, "ruler.max-rule-groups-per-user", 20, "Maximum number of rule groups per-tenant.")
 
 	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "File name of per-user overrides. [deprecated, use -runtime-config.file instead]")
 	f.DurationVar(&l.PerTenantOverridePeriod, "limits.per-user-override-period", 10*time.Second, "Period with which to reload the overrides. [deprecated, use -runtime-config.reload-period instead]")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -74,7 +74,7 @@ type Limits struct {
 	RulerEvaluationDelay        time.Duration `yaml:"ruler_evaluation_delay_duration"`
 	RulerTenantShardSize        int           `yaml:"ruler_tenant_shard_size"`
 	RulerMaxRulesPerRuleGroup   int           `yaml:"ruler_max_rules_per_rule_group"`
-	RulerMaxRuleGroupsPerTenant int           `yaml:"ruler_max_rule_groups"`
+	RulerMaxRuleGroupsPerTenant int           `yaml:"ruler_max_rule_groups_per_tenant"`
 
 	// Store-gateway.
 	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size"`

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -126,8 +126,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.DurationVar(&l.RulerEvaluationDelay, "ruler.evaluation-delay-duration", 0, "Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed to Cortex.")
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The default tenant's shard size when the shuffle-sharding strategy is used by ruler. When this setting is specified in the per-tenant overrides, a value of 0 disables shuffle sharding for the tenant.")
-	f.IntVar(&l.RulerMaxRulesPerRuleGroup, "ruler.max-rules-per-rule-group", 15, "Maximum number of rules per rule group per-tenant. 0 to disable.")
-	f.IntVar(&l.RulerMaxRuleGroupsPerTenant, "ruler.max-rule-groups-per-tenant", 20, "Maximum number of rule groups per-tenant. 0 to disable.")
+	f.IntVar(&l.RulerMaxRulesPerRuleGroup, "ruler.max-rules-per-rule-group", 0, "Maximum number of rules per rule group per-tenant. 0 to disable.")
+	f.IntVar(&l.RulerMaxRuleGroupsPerTenant, "ruler.max-rule-groups-per-tenant", 0, "Maximum number of rule groups per-tenant. 0 to disable.")
 
 	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "File name of per-user overrides. [deprecated, use -runtime-config.file instead]")
 	f.DurationVar(&l.PerTenantOverridePeriod, "limits.per-user-override-period", 10*time.Second, "Period with which to reload the overrides. [deprecated, use -runtime-config.reload-period instead]")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -74,7 +74,7 @@ type Limits struct {
 	RulerEvaluationDelay             time.Duration `yaml:"ruler_evaluation_delay_duration"`
 	RulerTenantShardSize             int           `yaml:"ruler_tenant_shard_size"`
 	RulerMaxRulesPerRuleGroupPerUser int           `yaml:"ruler_max_rules_per_rule_group_per_user"`
-	RulerMaxRuleGroupsPerUser        int           `yaml:"ruler_max_rule_groups"`
+	RulerMaxRuleGroupsPerUser        int           `yaml:"ruler_max_rule_groups_per_user"`
 
 	// Store-gateway.
 	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size"`

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -71,10 +71,10 @@ type Limits struct {
 	MaxQueriersPerTenant int           `yaml:"max_queriers_per_tenant"`
 
 	// Ruler defaults and limits.
-	RulerEvaluationDelay      time.Duration `yaml:"ruler_evaluation_delay_duration"`
-	RulerTenantShardSize      int           `yaml:"ruler_tenant_shard_size"`
-	RulerMaxRulesPerRuleGroup int           `yaml:"ruler_max_rules_per_rule_group"`
-	RulerMaxRuleGroups        int           `yaml:"ruler_max_rule_groups"`
+	RulerEvaluationDelay        time.Duration `yaml:"ruler_evaluation_delay_duration"`
+	RulerTenantShardSize        int           `yaml:"ruler_tenant_shard_size"`
+	RulerMaxRulesPerRuleGroup   int           `yaml:"ruler_max_rules_per_rule_group"`
+	RulerMaxRuleGroupsPerTenant int           `yaml:"ruler_max_rule_groups"`
 
 	// Store-gateway.
 	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size"`
@@ -127,7 +127,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&l.RulerEvaluationDelay, "ruler.evaluation-delay-duration", 0, "Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed to Cortex.")
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The default tenant's shard size when the shuffle-sharding strategy is used by ruler. When this setting is specified in the per-tenant overrides, a value of 0 disables shuffle sharding for the tenant.")
 	f.IntVar(&l.RulerMaxRulesPerRuleGroup, "ruler.max-rules-per-rule-group", 15, "Maximum number of rules per rule group per-tenant. 0 to disable.")
-	f.IntVar(&l.RulerMaxRuleGroups, "ruler.max-rule-groups", 20, "Maximum number of rule groups per-tenant. 0 to disable.")
+	f.IntVar(&l.RulerMaxRuleGroupsPerTenant, "ruler.max-rule-groups-per-tenant", 20, "Maximum number of rule groups per-tenant. 0 to disable.")
 
 	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "File name of per-user overrides. [deprecated, use -runtime-config.file instead]")
 	f.DurationVar(&l.PerTenantOverridePeriod, "limits.per-user-override-period", 10*time.Second, "Period with which to reload the overrides. [deprecated, use -runtime-config.reload-period instead]")
@@ -386,9 +386,9 @@ func (o *Overrides) RulerMaxRulesPerRuleGroup(userID string) int {
 	return o.getOverridesForUser(userID).RulerMaxRulesPerRuleGroup
 }
 
-// RulerMaxRuleGroups returns the maximum number of rule groups for a given user.
-func (o *Overrides) RulerMaxRuleGroups(userID string) int {
-	return o.getOverridesForUser(userID).RulerMaxRuleGroups
+// RulerMaxRuleGroupsPerTenant returns the maximum number of rule groups for a given user.
+func (o *Overrides) RulerMaxRuleGroupsPerTenant(userID string) int {
+	return o.getOverridesForUser(userID).RulerMaxRuleGroupsPerTenant
 }
 
 // StoreGatewayTenantShardSize returns the store-gateway shard size for a given user.

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -71,8 +71,10 @@ type Limits struct {
 	MaxQueriersPerTenant int           `yaml:"max_queriers_per_tenant"`
 
 	// Ruler defaults and limits.
-	RulerEvaluationDelay time.Duration `yaml:"ruler_evaluation_delay_duration"`
-	RulerTenantShardSize int           `yaml:"ruler_tenant_shard_size"`
+	RulerEvaluationDelay             time.Duration `yaml:"ruler_evaluation_delay_duration"`
+	RulerTenantShardSize             int           `yaml:"ruler_tenant_shard_size"`
+	RulerMaxRulesPerRuleGroupPerUser int           `yaml:"ruler_max_rules_per_rule_group_per_user"`
+	RulerMaxRuleGroupsPerUser        int           `yaml:"ruler_max_rule_groups"`
 
 	// Store-gateway.
 	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size"`
@@ -124,6 +126,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.DurationVar(&l.RulerEvaluationDelay, "ruler.evaluation-delay-duration", 0, "Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed to Cortex.")
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The default tenant's shard size when the shuffle-sharding strategy is used by ruler. When this setting is specified in the per-tenant overrides, a value of 0 disables shuffle sharding for the tenant.")
+	f.IntVar(&l.RulerMaxRulesPerRuleGroupPerUser, "ruler.max-rules-per-rule-group", 15, "Maximum number of rules per rule group per-tenant.")
+	f.IntVar(&l.RulerMaxRuleGroupsPerUser, "ruler.max-rule-groups", 20, "Maximum number of rule groups per-tenant.")
 
 	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "File name of per-user overrides. [deprecated, use -runtime-config.file instead]")
 	f.DurationVar(&l.PerTenantOverridePeriod, "limits.per-user-override-period", 10*time.Second, "Period with which to reload the overrides. [deprecated, use -runtime-config.reload-period instead]")
@@ -375,6 +379,14 @@ func (o *Overrides) EvaluationDelay(userID string) time.Duration {
 // RulerTenantShardSize returns shard size (number of rulers) used by this tenant when using shuffle-sharding strategy.
 func (o *Overrides) RulerTenantShardSize(userID string) int {
 	return o.getOverridesForUser(userID).RulerTenantShardSize
+}
+
+func (o *Overrides) RulerMaxRulesPerRuleGroupPerUser(userID string) int {
+	return o.getOverridesForUser(userID).RulerMaxRulesPerRuleGroupPerUser
+}
+
+func (o *Overrides) RulerMaxRuleGroupsPerUser(userID string) int {
+	return o.getOverridesForUser(userID).RulerMaxRuleGroupsPerUser
 }
 
 // StoreGatewayTenantShardSize returns the store-gateway shard size for a given user.


### PR DESCRIPTION
**What this PR does**:

Limits the number of rules per rule group, total rule groups and rules a particular tenant can create. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
