### PR TITLE
Fixed max global series per user/metric limit when shuffle sharding is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 * [BUGFIX] Fix common prefixes returned by List method of S3 client. #3358
 * [BUGFIX] Honor configured timeout in Azure and GCS object clients. #3285
 * [BUGFIX] Shuffle sharding: fixed max global series per user/metric limit when shuffle sharding is enabled in distributor. When using these global limits you should now set `-distributor.sharding-strategy` to ingesters too. #3369
+* [BUGFIX] Shuffle sharding: fixed max global series per user/metric limit when shuffle sharding and `-distributor.shard-by-all-labels=true` are both enabled in distributor. When using these global limits you should now set `-distributor.sharding-strategy` to ingesters too. #3369
 
 ## 1.4.0 / 2020-10-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 * [BUGFIX] Blocks storage: Avoid deletion of blocks in the ingester which are not shipped to the storage yet. #3346
 * [BUGFIX] Fix common prefixes returned by List method of S3 client. #3358
 * [BUGFIX] Honor configured timeout in Azure and GCS object clients. #3285
+* [BUGFIX] Shuffle sharding: fixed max global series per user/metric limit when shuffle sharding is enabled in distributor. When using these global limits you should now set `-distributor.sharding-strategy` to ingesters too. #3369
 
 ## 1.4.0 / 2020-10-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,8 +101,7 @@
 * [BUGFIX] Blocks storage: Avoid deletion of blocks in the ingester which are not shipped to the storage yet. #3346
 * [BUGFIX] Fix common prefixes returned by List method of S3 client. #3358
 * [BUGFIX] Honor configured timeout in Azure and GCS object clients. #3285
-* [BUGFIX] Shuffle sharding: fixed max global series per user/metric limit when shuffle sharding is enabled in distributor. When using these global limits you should now set `-distributor.sharding-strategy` to ingesters too. #3369
-* [BUGFIX] Shuffle sharding: fixed max global series per user/metric limit when shuffle sharding and `-distributor.shard-by-all-labels=true` are both enabled in distributor. When using these global limits you should now set `-distributor.sharding-strategy` to ingesters too. #3369
+* [BUGFIX] Shuffle sharding: fixed max global series per user/metric limit when shuffle sharding and `-distributor.shard-by-all-labels=true` are both enabled in distributor. When using these global limits you should now set `-distributor.sharding-strategy` and `-distributor.zone-awareness-enabled` to ingesters too. #3369
 
 ## 1.4.0 / 2020-10-02
 

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -489,7 +489,7 @@ Valid per-tenant limits are (with their corresponding flags for default values):
 
    Like `max_series_per_user` and `max_series_per_metric`, but the limit is enforced across the cluster. Each ingester is configured with a local limit based on the replication factor, the `-distributor.shard-by-all-labels` setting and the current number of healthy ingesters, and is kept updated whenever the number of ingesters change.
 
-   Requires `-distributor.replication-factor`, `-distributor.shard-by-all-labels` and `-distributor.sharding-strategy` set for the ingesters too.
+   Requires `-distributor.replication-factor`, `-distributor.shard-by-all-labels`, `-distributor.sharding-strategy` and `-distributor.zone-awareness-enabled` set for the ingesters too.
 
 - `max_series_per_query` / `-ingester.max-series-per-query`
 - `max_samples_per_query` / `-ingester.max-samples-per-query`
@@ -506,7 +506,7 @@ Valid per-tenant limits are (with their corresponding flags for default values):
 
    Like `max_metadata_per_user` and `max_metadata_per_metric`, but the limit is enforced across the cluster. Each ingester is configured with a local limit based on the replication factor, the `-distributor.shard-by-all-labels` setting and the current number of healthy ingesters, and is kept updated whenever the number of ingesters change.
 
-   Requires `-distributor.replication-factor`, `-distributor.shard-by-all-labels` and `-distributor.sharding-strategy` set for the ingesters too.
+   Requires `-distributor.replication-factor`, `-distributor.shard-by-all-labels`, `-distributor.sharding-strategy` and `-distributor.zone-awareness-enabled` set for the ingesters too.
 
 ## Storage
 

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -489,12 +489,24 @@ Valid per-tenant limits are (with their corresponding flags for default values):
 
    Like `max_series_per_user` and `max_series_per_metric`, but the limit is enforced across the cluster. Each ingester is configured with a local limit based on the replication factor, the `-distributor.shard-by-all-labels` setting and the current number of healthy ingesters, and is kept updated whenever the number of ingesters change.
 
-   Requires `-distributor.replication-factor` and `-distributor.shard-by-all-labels` set for the ingesters too.
+   Requires `-distributor.replication-factor`, `-distributor.shard-by-all-labels` and `-distributor.sharding-strategy` set for the ingesters too.
 
 - `max_series_per_query` / `-ingester.max-series-per-query`
 - `max_samples_per_query` / `-ingester.max-samples-per-query`
 
   Limits on the number of timeseries and samples returns by a single ingester during a query.
+
+- `max_metadata_per_user` / `-ingester.max-metadata-per-user`
+- `max_metadata_per_metric` / `-ingester.max-metadata-per-metric`
+
+  Enforced by the ingesters; limits the number of active metadata a user (or a given metric) can have.  When running with `-distributor.shard-by-all-labels=false` (the default), this limit will enforce the maximum number of metadata a metric can have 'globally', as all metadata for a single metric will be sent to the same replication set of ingesters.  This is not the case when running with `-distributor.shard-by-all-labels=true`, so the actual limit will be N/RF times higher, where N is number of ingester replicas and RF is configured replication factor.
+
+- `max_global_metadata_per_user` / `-ingester.max-global-metadata-per-user`
+- `max_global_metadata_per_metric` / `-ingester.max-global-metadata-per-metric`
+
+   Like `max_metadata_per_user` and `max_metadata_per_metric`, but the limit is enforced across the cluster. Each ingester is configured with a local limit based on the replication factor, the `-distributor.shard-by-all-labels` setting and the current number of healthy ingesters, and is kept updated whenever the number of ingesters change.
+
+   Requires `-distributor.replication-factor`, `-distributor.shard-by-all-labels` and `-distributor.sharding-strategy` set for the ingesters too.
 
 ## Storage
 

--- a/integration/ingester_limits_test.go
+++ b/integration/ingester_limits_test.go
@@ -1,0 +1,135 @@
+// +build requires_docker
+
+package integration
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/integration/e2e"
+	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
+	"github.com/cortexproject/cortex/integration/e2ecortex"
+)
+
+func TestIngesterGlobalLimits(t *testing.T) {
+	tests := map[string]struct {
+		shardingStrategy         string
+		tenantShardSize          int
+		maxGlobalSeriesPerTenant int
+		maxGlobalSeriesPerMetric int
+	}{
+		"default sharding strategy": {
+			shardingStrategy:         "default",
+			tenantShardSize:          1, // Ignored by default strategy.
+			maxGlobalSeriesPerTenant: 1000,
+			maxGlobalSeriesPerMetric: 300,
+		},
+		"shuffle sharding strategy": {
+			shardingStrategy:         "shuffle-sharding",
+			tenantShardSize:          1,
+			maxGlobalSeriesPerTenant: 1000,
+			maxGlobalSeriesPerMetric: 300,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			s, err := e2e.NewScenario(networkName)
+			require.NoError(t, err)
+			defer s.Close()
+
+			flags := BlocksStorageFlags
+			flags["-distributor.replication-factor"] = "1"
+			flags["-distributor.shard-by-all-labels"] = "true"
+			flags["-distributor.sharding-strategy"] = testData.shardingStrategy
+			flags["-distributor.ingestion-tenant-shard-size"] = strconv.Itoa(testData.tenantShardSize)
+			flags["-ingester.max-series-per-user"] = "0"
+			flags["-ingester.max-series-per-metric"] = "0"
+			flags["-ingester.max-global-series-per-user"] = strconv.Itoa(testData.maxGlobalSeriesPerTenant)
+			flags["-ingester.max-global-series-per-metric"] = strconv.Itoa(testData.maxGlobalSeriesPerMetric)
+			flags["-ingester.heartbeat-period"] = "1s"
+
+			// Start dependencies.
+			consul := e2edb.NewConsul()
+			minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+			require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+			// Start Cortex components.
+			distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, "")
+			ingester1 := e2ecortex.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), flags, "")
+			ingester2 := e2ecortex.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), flags, "")
+			ingester3 := e2ecortex.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), flags, "")
+			require.NoError(t, s.StartAndWaitReady(distributor, ingester1, ingester2, ingester3))
+
+			// Wait until distributor has updated the ring.
+			require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(3), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+				labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+			// Wait until ingesters have heartbeated the ring after all ingesters were active,
+			// in order to update the number of instances. Since we have no metric, we have to
+			// rely on a ugly sleep.
+			time.Sleep(2 * time.Second)
+
+			now := time.Now()
+			client, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", userID)
+			require.NoError(t, err)
+
+			numSeriesWithSameMetricName := 0
+			numSeriesTotal := 0
+
+			// Try to push as many series with the same metric name as we can.
+			for i := 1; i <= 10000; i++ {
+				series, _ := generateSeries("test_limit_per_metric", now, prompb.Label{
+					Name:  "cardinality",
+					Value: strconv.Itoa(rand.Int()),
+				})
+
+				res, err := client.Push(series)
+				require.NoError(t, err)
+
+				if res.StatusCode != 200 {
+					break
+				}
+
+				numSeriesTotal++
+				numSeriesWithSameMetricName++
+			}
+
+			// Try to push as many series with the different metric name as we can.
+			for i := 1; i <= 10000; i++ {
+				series, _ := generateSeries(fmt.Sprintf("test_limit_per_tenant_%d", rand.Int()), now)
+				res, err := client.Push(series)
+				require.NoError(t, err)
+
+				if res.StatusCode != 200 {
+					break
+				}
+
+				numSeriesTotal++
+			}
+
+			// We expect the number of series we've been successfully pushed to be around
+			// the limit. Due to how the global limit implementation works (lack of centralised
+			// coordination) the actual number of written series could be slightly different
+			// than the global limit, so we allow a 10% difference.
+			delta := 0.1
+			assert.InDelta(t, testData.maxGlobalSeriesPerMetric, numSeriesWithSameMetricName, float64(testData.maxGlobalSeriesPerMetric)*delta)
+			assert.InDelta(t, testData.maxGlobalSeriesPerTenant, numSeriesTotal, float64(testData.maxGlobalSeriesPerTenant)*delta)
+
+			// Ensure no service-specific metrics prefix is used by the wrong service.
+			assertServiceMetricsPrefixes(t, Distributor, distributor)
+			assertServiceMetricsPrefixes(t, Ingester, ingester1)
+			assertServiceMetricsPrefixes(t, Ingester, ingester2)
+			assertServiceMetricsPrefixes(t, Ingester, ingester3)
+		})
+	}
+}

--- a/integration/ingester_limits_test.go
+++ b/integration/ingester_limits_test.go
@@ -46,7 +46,7 @@ func TestIngesterGlobalLimits(t *testing.T) {
 			require.NoError(t, err)
 			defer s.Close()
 
-			flags := BlocksStorageFlags
+			flags := BlocksStorageFlags()
 			flags["-distributor.replication-factor"] = "1"
 			flags["-distributor.shard-by-all-labels"] = "true"
 			flags["-distributor.sharding-strategy"] = testData.shardingStrategy

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -318,7 +318,8 @@ func (t *Cortex) tsdbIngesterConfig() {
 func (t *Cortex) initIngesterService() (serv services.Service, err error) {
 	t.Cfg.Ingester.LifecyclerConfig.RingConfig.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
 	t.Cfg.Ingester.LifecyclerConfig.ListenPort = t.Cfg.Server.GRPCListenPort
-	t.Cfg.Ingester.ShardByAllLabels = t.Cfg.Distributor.ShardByAllLabels
+	t.Cfg.Ingester.DistributorShardingStrategy = t.Cfg.Distributor.ShardingStrategy
+	t.Cfg.Ingester.DistributorShardByAllLabels = t.Cfg.Distributor.ShardByAllLabels
 	t.tsdbIngesterConfig()
 
 	t.Ingester, err = ingester.New(t.Cfg.Ingester, t.Cfg.IngesterClient, t.Overrides, t.Store, prometheus.DefaultRegisterer)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -106,7 +106,7 @@ var (
 	}, []string{"user"})
 	emptyPreallocSeries = ingester_client.PreallocTimeseries{}
 
-	supportedShardingStrategies = []string{ShardingStrategyDefault, ShardingStrategyShuffle}
+	supportedShardingStrategies = []string{util.ShardingStrategyDefault, util.ShardingStrategyShuffle}
 
 	// Validation errors.
 	errInvalidShardingStrategy = errors.New("invalid sharding strategy")
@@ -118,8 +118,7 @@ const (
 	typeMetadata = "metadata"
 
 	// Supported sharding strategies.
-	ShardingStrategyDefault = "default"
-	ShardingStrategyShuffle = "shuffle-sharding"
+
 )
 
 // Distributor is a storage.SampleAppender and a client.Querier which
@@ -185,7 +184,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")
 	f.DurationVar(&cfg.ExtraQueryDelay, "distributor.extra-query-delay", 0, "Time to wait before sending more than the minimum successful query requests.")
 	f.BoolVar(&cfg.ShardByAllLabels, "distributor.shard-by-all-labels", false, "Distribute samples based on all labels, as opposed to solely by user and metric name.")
-	f.StringVar(&cfg.ShardingStrategy, "distributor.sharding-strategy", ShardingStrategyDefault, fmt.Sprintf("The sharding strategy to use. Supported values are: %s.", strings.Join(supportedShardingStrategies, ", ")))
+	f.StringVar(&cfg.ShardingStrategy, "distributor.sharding-strategy", util.ShardingStrategyDefault, fmt.Sprintf("The sharding strategy to use. Supported values are: %s.", strings.Join(supportedShardingStrategies, ", ")))
 }
 
 // Validate config and returns error on failure
@@ -194,7 +193,7 @@ func (cfg *Config) Validate(limits validation.Limits) error {
 		return errInvalidShardingStrategy
 	}
 
-	if cfg.ShardingStrategy == ShardingStrategyShuffle && limits.IngestionTenantShardSize <= 0 {
+	if cfg.ShardingStrategy == util.ShardingStrategyShuffle && limits.IngestionTenantShardSize <= 0 {
 		return errInvalidTenantShardSize
 	}
 
@@ -535,7 +534,7 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 	subRing := d.ingestersRing.(ring.ReadRing)
 
 	// Obtain a subring if required.
-	if d.cfg.ShardingStrategy == ShardingStrategyShuffle {
+	if d.cfg.ShardingStrategy == util.ShardingStrategyShuffle {
 		subRing = d.ingestersRing.ShuffleShard(userID, d.limits.IngestionTenantShardSize(userID))
 	}
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1136,7 +1136,7 @@ func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, *rin
 		distributorCfg.DistributorRing.InstanceAddr = "127.0.0.1"
 
 		if cfg.shuffleShardEnabled {
-			distributorCfg.ShardingStrategy = ShardingStrategyShuffle
+			distributorCfg.ShardingStrategy = util.ShardingStrategyShuffle
 			distributorCfg.ShuffleShardingLookbackPeriod = time.Hour
 
 			cfg.limits.IngestionTenantShardSize = cfg.shuffleShardSize

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -83,7 +83,7 @@ func (d *Distributor) GetIngestersForQuery(ctx context.Context, matchers ...*lab
 
 	// If shuffle sharding is enabled we should only query ingesters which are
 	// part of the tenant's subring.
-	if d.cfg.ShardingStrategy == ShardingStrategyShuffle {
+	if d.cfg.ShardingStrategy == util.ShardingStrategyShuffle {
 		shardSize := d.limits.IngestionTenantShardSize(userID)
 		lookbackPeriod := d.cfg.ShuffleShardingLookbackPeriod
 
@@ -114,7 +114,7 @@ func (d *Distributor) GetIngestersForMetadata(ctx context.Context) (ring.Replica
 
 	// If shuffle sharding is enabled we should only query ingesters which are
 	// part of the tenant's subring.
-	if d.cfg.ShardingStrategy == ShardingStrategyShuffle {
+	if d.cfg.ShardingStrategy == util.ShardingStrategyShuffle {
 		shardSize := d.limits.IngestionTenantShardSize(userID)
 		lookbackPeriod := d.cfg.ShuffleShardingLookbackPeriod
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -217,7 +217,15 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 	if err != nil {
 		return nil, err
 	}
-	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor, cfg.DistributorShardingStrategy, cfg.DistributorShardByAllLabels)
+
+	i.limiter = NewLimiter(
+		limits,
+		i.lifecycler,
+		cfg.DistributorShardingStrategy,
+		cfg.DistributorShardByAllLabels,
+		cfg.LifecyclerConfig.RingConfig.ReplicationFactor,
+		cfg.LifecyclerConfig.RingConfig.ZoneAwarenessEnabled)
+
 	i.subservicesWatcher = services.NewFailureWatcher()
 	i.subservicesWatcher.WatchService(i.lifecycler)
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -82,7 +82,8 @@ type Config struct {
 
 	// Injected at runtime and read from the distributor config, required
 	// to accurately apply global limits.
-	ShardByAllLabels bool `yaml:"-"`
+	DistributorShardingStrategy string `yaml:"-"`
+	DistributorShardByAllLabels bool   `yaml:"-"`
 
 	// For testing, you can override the address and ID of this ingester.
 	ingesterClientFactory func(addr string, cfg client.Config) (client.HealthAndIngesterClient, error)
@@ -216,7 +217,7 @@ func New(cfg Config, clientConfig client.Config, limits *validation.Overrides, c
 	if err != nil {
 		return nil, err
 	}
-	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor, cfg.ShardByAllLabels)
+	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor, cfg.DistributorShardingStrategy, cfg.DistributorShardByAllLabels)
 	i.subservicesWatcher = services.NewFailureWatcher()
 	i.subservicesWatcher.WatchService(i.lifecycler)
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -247,7 +247,7 @@ func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides,
 	i.subservicesWatcher.WatchService(i.lifecycler)
 
 	// Init the limter and instantiate the user states which depend on it
-	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor, cfg.ShardByAllLabels)
+	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor, cfg.DistributorShardingStrategy, cfg.DistributorShardByAllLabels)
 	i.userStates = newUserStates(i.limiter, cfg, i.metrics)
 
 	i.TSDBState.shipperIngesterID = i.lifecycler.ID

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -247,7 +247,14 @@ func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides,
 	i.subservicesWatcher.WatchService(i.lifecycler)
 
 	// Init the limter and instantiate the user states which depend on it
-	i.limiter = NewLimiter(limits, i.lifecycler, cfg.LifecyclerConfig.RingConfig.ReplicationFactor, cfg.DistributorShardingStrategy, cfg.DistributorShardByAllLabels)
+	i.limiter = NewLimiter(
+		limits,
+		i.lifecycler,
+		cfg.DistributorShardingStrategy,
+		cfg.DistributorShardByAllLabels,
+		cfg.LifecyclerConfig.RingConfig.ReplicationFactor,
+		cfg.LifecyclerConfig.RingConfig.ZoneAwarenessEnabled)
+
 	i.userStates = newUserStates(i.limiter, cfg, i.metrics)
 
 	i.TSDBState.shipperIngesterID = i.lifecycler.ID

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -19,6 +19,7 @@ const (
 // to count members
 type RingCount interface {
 	HealthyInstancesCount() int
+	ZonesCount() int
 }
 
 // Limiter implements primitives to get the maximum number of series
@@ -29,16 +30,25 @@ type Limiter struct {
 	replicationFactor      int
 	shuffleShardingEnabled bool
 	shardByAllLabels       bool
+	zoneAwarenessEnabled   bool
 }
 
 // NewLimiter makes a new in-memory series limiter
-func NewLimiter(limits *validation.Overrides, ring RingCount, replicationFactor int, shardingStrategy string, shardByAllLabels bool) *Limiter {
+func NewLimiter(
+	limits *validation.Overrides,
+	ring RingCount,
+	shardingStrategy string,
+	shardByAllLabels bool,
+	replicationFactor int,
+	zoneAwarenessEnabled bool,
+) *Limiter {
 	return &Limiter{
 		limits:                 limits,
 		ring:                   ring,
 		replicationFactor:      replicationFactor,
 		shuffleShardingEnabled: shardingStrategy == util.ShardingStrategyShuffle,
 		shardByAllLabels:       shardByAllLabels,
+		zoneAwarenessEnabled:   zoneAwarenessEnabled,
 	}
 }
 
@@ -113,7 +123,7 @@ func (l *Limiter) maxSeriesPerMetric(userID string) int {
 		if l.shardByAllLabels {
 			// We can assume that series are evenly distributed across ingesters
 			// so we do convert the global limit into a local limit
-			localLimit = minNonZero(localLimit, l.convertGlobalToLocalLimit(globalLimit, l.getShardSize(userID)))
+			localLimit = minNonZero(localLimit, l.convertGlobalToLocalLimit(userID, globalLimit))
 		} else {
 			// Given a metric is always pushed to the same set of ingesters (based on
 			// the replication factor), we can configure the per-ingester local limit
@@ -137,7 +147,7 @@ func (l *Limiter) maxMetadataPerMetric(userID string) int {
 
 	if globalLimit > 0 {
 		if l.shardByAllLabels {
-			localLimit = minNonZero(localLimit, l.convertGlobalToLocalLimit(globalLimit, l.getShardSize(userID)))
+			localLimit = minNonZero(localLimit, l.convertGlobalToLocalLimit(userID, globalLimit))
 		} else {
 			localLimit = minNonZero(localLimit, globalLimit)
 		}
@@ -176,7 +186,7 @@ func (l *Limiter) maxByLocalAndGlobal(userID string, localLimitFn, globalLimitFn
 		// We can assume that series/metadata are evenly distributed across ingesters
 		// so we do convert the global limit into a local limit
 		globalLimit := globalLimitFn(userID)
-		localLimit = minNonZero(localLimit, l.convertGlobalToLocalLimit(globalLimit, l.getShardSize(userID)))
+		localLimit = minNonZero(localLimit, l.convertGlobalToLocalLimit(userID, globalLimit))
 	}
 
 	// If both the local and global limits are disabled, we just
@@ -188,7 +198,7 @@ func (l *Limiter) maxByLocalAndGlobal(userID string, localLimitFn, globalLimitFn
 	return localLimit
 }
 
-func (l *Limiter) convertGlobalToLocalLimit(globalLimit, shardSize int) int {
+func (l *Limiter) convertGlobalToLocalLimit(userID string, globalLimit int) int {
 	if globalLimit == 0 {
 		return 0
 	}
@@ -208,8 +218,9 @@ func (l *Limiter) convertGlobalToLocalLimit(globalLimit, shardSize int) int {
 	// If the number of available ingesters is greater than the tenant's shard
 	// size, then we should honor the shard size because series/metadata won't
 	// be written to more ingesters than it.
-	if shardSize > 0 && shardSize < numIngesters {
-		numIngesters = shardSize
+	if shardSize := l.getShardSize(userID); shardSize > 0 {
+		// We use Min() to protect from the case the expected shard size is > available ingesters.
+		numIngesters = util.Min(numIngesters, util.ShuffleShardExpectedInstances(shardSize, l.getNumZones()))
 	}
 
 	return int((float64(globalLimit) / float64(numIngesters)) * float64(l.replicationFactor))
@@ -221,6 +232,13 @@ func (l *Limiter) getShardSize(userID string) int {
 	}
 
 	return l.limits.IngestionTenantShardSize(userID)
+}
+
+func (l *Limiter) getNumZones() int {
+	if l.zoneAwarenessEnabled {
+		return util.Max(l.ring.ZonesCount(), 1)
+	}
+	return 1
 }
 
 func minNonZero(first, second int) int {

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -90,7 +90,7 @@ func (s *blocksStoreReplicationSet) GetClientsFor(userID string, blockIDs []ulid
 	// If shuffle sharding is enabled, we should build a subring for the user,
 	// otherwise we just use the full ring.
 	var userRing ring.ReadRing
-	if s.shardingStrategy == storegateway.ShardingStrategyShuffle {
+	if s.shardingStrategy == util.ShardingStrategyShuffle {
 		userRing = storegateway.GetShuffleShardingSubring(s.storesRing, userID, s.limits)
 	} else {
 		userRing = s.storesRing

--- a/pkg/querier/blocks_store_replicated_set_test.go
+++ b/pkg/querier/blocks_store_replicated_set_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/storegateway"
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/test"
@@ -54,7 +55,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 		// Sharding strategy: default
 		//
 		"default sharding, single instance in the ring with RF = 1": {
-			shardingStrategy:  storegateway.ShardingStrategyDefault,
+			shardingStrategy:  util.ShardingStrategyDefault,
 			replicationFactor: 1,
 			setup: func(d *ring.Desc) {
 				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE, registeredAt)
@@ -65,7 +66,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			},
 		},
 		"default sharding, single instance in the ring with RF = 1 but excluded": {
-			shardingStrategy:  storegateway.ShardingStrategyDefault,
+			shardingStrategy:  util.ShardingStrategyDefault,
 			replicationFactor: 1,
 			setup: func(d *ring.Desc) {
 				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE, registeredAt)
@@ -77,7 +78,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			expectedErr: fmt.Errorf("no store-gateway instance left after checking exclude for block %s", block1.String()),
 		},
 		"default sharding, single instance in the ring with RF = 1 but excluded for non queried block": {
-			shardingStrategy:  storegateway.ShardingStrategyDefault,
+			shardingStrategy:  util.ShardingStrategyDefault,
 			replicationFactor: 1,
 			setup: func(d *ring.Desc) {
 				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE, registeredAt)
@@ -91,7 +92,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			},
 		},
 		"default sharding, single instance in the ring with RF = 2": {
-			shardingStrategy:  storegateway.ShardingStrategyDefault,
+			shardingStrategy:  util.ShardingStrategyDefault,
 			replicationFactor: 2,
 			setup: func(d *ring.Desc) {
 				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE, registeredAt)
@@ -102,7 +103,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			},
 		},
 		"default sharding, multiple instances in the ring with each requested block belonging to a different store-gateway and RF = 1": {
-			shardingStrategy:  storegateway.ShardingStrategyDefault,
+			shardingStrategy:  util.ShardingStrategyDefault,
 			replicationFactor: 1,
 			setup: func(d *ring.Desc) {
 				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE, registeredAt)
@@ -118,7 +119,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			},
 		},
 		"default sharding, multiple instances in the ring with each requested block belonging to a different store-gateway and RF = 1 but excluded": {
-			shardingStrategy:  storegateway.ShardingStrategyDefault,
+			shardingStrategy:  util.ShardingStrategyDefault,
 			replicationFactor: 1,
 			setup: func(d *ring.Desc) {
 				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE, registeredAt)
@@ -133,7 +134,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			expectedErr: fmt.Errorf("no store-gateway instance left after checking exclude for block %s", block3.String()),
 		},
 		"default sharding, multiple instances in the ring with each requested block belonging to a different store-gateway and RF = 2": {
-			shardingStrategy:  storegateway.ShardingStrategyDefault,
+			shardingStrategy:  util.ShardingStrategyDefault,
 			replicationFactor: 2,
 			setup: func(d *ring.Desc) {
 				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE, registeredAt)
@@ -149,7 +150,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			},
 		},
 		"default sharding, multiple instances in the ring with multiple requested blocks belonging to the same store-gateway and RF = 2": {
-			shardingStrategy:  storegateway.ShardingStrategyDefault,
+			shardingStrategy:  util.ShardingStrategyDefault,
 			replicationFactor: 2,
 			setup: func(d *ring.Desc) {
 				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE, registeredAt)
@@ -162,7 +163,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			},
 		},
 		"default sharding, multiple instances in the ring with each requested block belonging to a different store-gateway and RF = 2 and some blocks excluded but with replacement available": {
-			shardingStrategy:  storegateway.ShardingStrategyDefault,
+			shardingStrategy:  util.ShardingStrategyDefault,
 			replicationFactor: 2,
 			setup: func(d *ring.Desc) {
 				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.ACTIVE, registeredAt)
@@ -184,7 +185,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 		// Sharding strategy: shuffle sharding
 		//
 		"shuffle sharding, single instance in the ring with RF = 1, SS = 1": {
-			shardingStrategy:  storegateway.ShardingStrategyShuffle,
+			shardingStrategy:  util.ShardingStrategyShuffle,
 			tenantShardSize:   1,
 			replicationFactor: 1,
 			setup: func(d *ring.Desc) {
@@ -196,7 +197,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			},
 		},
 		"shuffle sharding, single instance in the ring with RF = 1, SS = 1 but excluded": {
-			shardingStrategy:  storegateway.ShardingStrategyShuffle,
+			shardingStrategy:  util.ShardingStrategyShuffle,
 			tenantShardSize:   1,
 			replicationFactor: 1,
 			setup: func(d *ring.Desc) {
@@ -209,7 +210,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			expectedErr: fmt.Errorf("no store-gateway instance left after checking exclude for block %s", block1.String()),
 		},
 		"shuffle sharding, single instance in the ring with RF = 2, SS = 2": {
-			shardingStrategy:  storegateway.ShardingStrategyShuffle,
+			shardingStrategy:  util.ShardingStrategyShuffle,
 			tenantShardSize:   2,
 			replicationFactor: 2,
 			setup: func(d *ring.Desc) {
@@ -221,7 +222,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			},
 		},
 		"shuffle sharding, multiple instances in the ring with RF = 1, SS = 1": {
-			shardingStrategy:  storegateway.ShardingStrategyShuffle,
+			shardingStrategy:  util.ShardingStrategyShuffle,
 			tenantShardSize:   1,
 			replicationFactor: 1,
 			setup: func(d *ring.Desc) {
@@ -236,7 +237,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			},
 		},
 		"shuffle sharding, multiple instances in the ring with RF = 1, SS = 2": {
-			shardingStrategy:  storegateway.ShardingStrategyShuffle,
+			shardingStrategy:  util.ShardingStrategyShuffle,
 			tenantShardSize:   2,
 			replicationFactor: 1,
 			setup: func(d *ring.Desc) {
@@ -252,7 +253,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			},
 		},
 		"shuffle sharding, multiple instances in the ring with RF = 1, SS = 4": {
-			shardingStrategy:  storegateway.ShardingStrategyShuffle,
+			shardingStrategy:  util.ShardingStrategyShuffle,
 			tenantShardSize:   4,
 			replicationFactor: 1,
 			setup: func(d *ring.Desc) {
@@ -269,7 +270,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			},
 		},
 		"shuffle sharding, multiple instances in the ring with RF = 2, SS = 2 with excluded blocks but some replacement available": {
-			shardingStrategy:  storegateway.ShardingStrategyShuffle,
+			shardingStrategy:  util.ShardingStrategyShuffle,
 			tenantShardSize:   2,
 			replicationFactor: 2,
 			setup: func(d *ring.Desc) {
@@ -288,7 +289,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			},
 		},
 		"shuffle sharding, multiple instances in the ring with RF = 2, SS = 2 with excluded blocks and no replacement available": {
-			shardingStrategy:  storegateway.ShardingStrategyShuffle,
+			shardingStrategy:  util.ShardingStrategyShuffle,
 			tenantShardSize:   2,
 			replicationFactor: 2,
 			setup: func(d *ring.Desc) {

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -139,6 +139,7 @@ type Lifecycler struct {
 	// Keeps stats updated at every heartbeat period
 	countersLock          sync.RWMutex
 	healthyInstancesCount int
+	zonesCount            int
 }
 
 // NewLifecycler creates new Lifecycler. It must be started via StartAsync.
@@ -351,13 +352,22 @@ func (i *Lifecycler) ClaimTokensFor(ctx context.Context, ingesterID string) erro
 	return <-errCh
 }
 
-// HealthyInstancesCount returns the number of healthy instances in the ring, updated
-// during the last heartbeat period
+// HealthyInstancesCount returns the number of healthy instances for the Write operation
+// in the ring, updated during the last heartbeat period.
 func (i *Lifecycler) HealthyInstancesCount() int {
 	i.countersLock.RLock()
 	defer i.countersLock.RUnlock()
 
 	return i.healthyInstancesCount
+}
+
+// ZonesCount returns the number of zones for which there's at least 1 instance registered
+// in the ring.
+func (i *Lifecycler) ZonesCount() int {
+	i.countersLock.RLock()
+	defer i.countersLock.RUnlock()
+
+	return i.zonesCount
 }
 
 func (i *Lifecycler) loop(ctx context.Context) error {
@@ -736,11 +746,14 @@ func (i *Lifecycler) changeState(ctx context.Context, state IngesterState) error
 }
 
 func (i *Lifecycler) updateCounters(ringDesc *Desc) {
-	// Count the number of healthy instances for Write operation
 	healthyInstancesCount := 0
+	zones := map[string]struct{}{}
 
 	if ringDesc != nil {
 		for _, ingester := range ringDesc.Ingesters {
+			zones[ingester.Zone] = struct{}{}
+
+			// Count the number of healthy instances for Write operation.
 			if ingester.IsHealthy(Write, i.cfg.RingConfig.HeartbeatTimeout) {
 				healthyInstancesCount++
 			}
@@ -750,6 +763,7 @@ func (i *Lifecycler) updateCounters(ringDesc *Desc) {
 	// Update counters
 	i.countersLock.Lock()
 	i.healthyInstancesCount = healthyInstancesCount
+	i.zonesCount = len(zones)
 	i.countersLock.Unlock()
 }
 

--- a/pkg/ring/lifecycler_test.go
+++ b/pkg/ring/lifecycler_test.go
@@ -18,18 +18,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/test"
 )
 
-type flushTransferer struct {
-	lifecycler *Lifecycler
-}
-
-func (f *flushTransferer) Flush() {}
-func (f *flushTransferer) TransferOut(ctx context.Context) error {
-	if err := f.lifecycler.ClaimTokensFor(ctx, "ing1"); err != nil {
-		return err
-	}
-	return f.lifecycler.ChangeState(ctx, ACTIVE)
-}
-
 func testLifecyclerConfig(ringConfig Config, id string) LifecyclerConfig {
 	var lifecyclerConfig LifecyclerConfig
 	flagext.DefaultValues(&lifecyclerConfig)

--- a/pkg/ring/lifecycler_test.go
+++ b/pkg/ring/lifecycler_test.go
@@ -2,6 +2,7 @@ package ring
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"sort"
@@ -58,21 +59,19 @@ func TestLifecycler_HealthyInstancesCount(t *testing.T) {
 	flagext.DefaultValues(&ringConfig)
 	ringConfig.KVStore.Mock = consul.NewInMemoryClient(GetCodec())
 
-	r, err := New(ringConfig, "ingester", IngesterRingKey, nil)
-	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
-	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
+	ctx := context.Background()
 
 	// Add the first ingester to the ring
 	lifecyclerConfig1 := testLifecyclerConfig(ringConfig, "ing1")
 	lifecyclerConfig1.HeartbeatPeriod = 100 * time.Millisecond
 	lifecyclerConfig1.JoinAfter = 100 * time.Millisecond
 
-	lifecycler1, err := NewLifecycler(lifecyclerConfig1, &flushTransferer{}, "ingester", IngesterRingKey, true, nil)
+	lifecycler1, err := NewLifecycler(lifecyclerConfig1, &nopFlushTransferer{}, "ingester", IngesterRingKey, true, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, lifecycler1.HealthyInstancesCount())
 
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), lifecycler1))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler1))
+	defer services.StopAndAwaitTerminated(ctx, lifecycler1) // nolint:errcheck
 
 	// Assert the first ingester joined the ring
 	test.Poll(t, 1000*time.Millisecond, true, func() interface{} {
@@ -84,11 +83,12 @@ func TestLifecycler_HealthyInstancesCount(t *testing.T) {
 	lifecyclerConfig2.HeartbeatPeriod = 100 * time.Millisecond
 	lifecyclerConfig2.JoinAfter = 100 * time.Millisecond
 
-	lifecycler2, err := NewLifecycler(lifecyclerConfig2, &flushTransferer{}, "ingester", IngesterRingKey, true, nil)
+	lifecycler2, err := NewLifecycler(lifecyclerConfig2, &nopFlushTransferer{}, "ingester", IngesterRingKey, true, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, lifecycler2.HealthyInstancesCount())
 
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), lifecycler2))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler2))
+	defer services.StopAndAwaitTerminated(ctx, lifecycler2) // nolint:errcheck
 
 	// Assert the second ingester joined the ring
 	test.Poll(t, 1000*time.Millisecond, true, func() interface{} {
@@ -99,6 +99,46 @@ func TestLifecycler_HealthyInstancesCount(t *testing.T) {
 	test.Poll(t, 1000*time.Millisecond, true, func() interface{} {
 		return lifecycler1.HealthyInstancesCount() == 2
 	})
+}
+
+func TestLifecycler_ZonesCount(t *testing.T) {
+	var ringConfig Config
+	flagext.DefaultValues(&ringConfig)
+	ringConfig.KVStore.Mock = consul.NewInMemoryClient(GetCodec())
+
+	events := []struct {
+		zone          string
+		expectedZones int
+	}{
+		{"zone-a", 1},
+		{"zone-b", 2},
+		{"zone-a", 2},
+		{"zone-c", 3},
+	}
+
+	for idx, event := range events {
+		ctx := context.Background()
+
+		// Register an ingester to the ring.
+		cfg := testLifecyclerConfig(ringConfig, fmt.Sprintf("instance-%d", idx))
+		cfg.HeartbeatPeriod = 100 * time.Millisecond
+		cfg.JoinAfter = 100 * time.Millisecond
+		cfg.Zone = event.zone
+
+		lifecycler, err := NewLifecycler(cfg, &nopFlushTransferer{}, "ingester", IngesterRingKey, true, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 0, lifecycler.ZonesCount())
+
+		require.NoError(t, services.StartAndAwaitRunning(ctx, lifecycler))
+		defer services.StopAndAwaitTerminated(ctx, lifecycler) // nolint:errcheck
+
+		// Wait until joined.
+		test.Poll(t, time.Second, idx+1, func() interface{} {
+			return lifecycler.HealthyInstancesCount()
+		})
+
+		assert.Equal(t, event.expectedZones, lifecycler.ZonesCount())
+	}
 }
 
 func TestLifecycler_NilFlushTransferer(t *testing.T) {
@@ -156,8 +196,8 @@ func TestLifecycler_TwoRingsWithDifferentKeysOnTheSameKVStore(t *testing.T) {
 type nopFlushTransferer struct{}
 
 func (f *nopFlushTransferer) Flush() {}
-func (f *nopFlushTransferer) TransferOut(ctx context.Context) error {
-	panic("should not be called")
+func (f *nopFlushTransferer) TransferOut(_ context.Context) error {
+	return nil
 }
 
 func TestLifecycler_ShouldHandleInstanceAbruptlyRestarted(t *testing.T) {

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -507,10 +507,7 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 	var actualZones []string
 
 	if r.cfg.ZoneAwarenessEnabled {
-		// When zone-awareness is enabled, we expect the shard size to be divisible
-		// by the number of zones, in order to have nodes balanced across zones.
-		// If it's not, we do round up.
-		numInstancesPerZone = int(math.Ceil(float64(size) / float64(len(r.ringZones))))
+		numInstancesPerZone = util.ShuffleShardExpectedInstancesPerZone(size, len(r.ringZones))
 		actualZones = r.ringZones
 	} else {
 		numInstancesPerZone = size

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	supportedShardingStrategies = []string{ShardingStrategyDefault, ShardingStrategyShuffle}
+	supportedShardingStrategies = []string{util.ShardingStrategyDefault, util.ShardingStrategyShuffle}
 
 	// Validation errors.
 	errInvalidShardingStrategy = errors.New("invalid sharding strategy")
@@ -46,10 +46,6 @@ var (
 )
 
 const (
-	// Supported sharding strategies.
-	ShardingStrategyDefault = "default"
-	ShardingStrategyShuffle = "shuffle-sharding"
-
 	// Number of concurrent group list and group loads operations.
 	loadRulesConcurrency = 10
 
@@ -114,7 +110,7 @@ func (cfg *Config) Validate(limits validation.Limits) error {
 		return errInvalidShardingStrategy
 	}
 
-	if cfg.ShardingStrategy == ShardingStrategyShuffle && limits.RulerTenantShardSize <= 0 {
+	if cfg.ShardingStrategy == util.ShardingStrategyShuffle && limits.RulerTenantShardSize <= 0 {
 		return errInvalidTenantShardSize
 	}
 
@@ -150,7 +146,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	f.DurationVar(&cfg.SearchPendingFor, "ruler.search-pending-for", 5*time.Minute, "Time to spend searching for a pending ruler when shutting down.")
 	f.BoolVar(&cfg.EnableSharding, "ruler.enable-sharding", false, "Distribute rule evaluation using ring backend")
-	f.StringVar(&cfg.ShardingStrategy, "ruler.sharding-strategy", ShardingStrategyDefault, fmt.Sprintf("The sharding strategy to use. Supported values are: %s.", strings.Join(supportedShardingStrategies, ", ")))
+	f.StringVar(&cfg.ShardingStrategy, "ruler.sharding-strategy", util.ShardingStrategyDefault, fmt.Sprintf("The sharding strategy to use. Supported values are: %s.", strings.Join(supportedShardingStrategies, ", ")))
 	f.DurationVar(&cfg.FlushCheckPeriod, "ruler.flush-period", 1*time.Minute, "Period with which to attempt to flush rule groups.")
 	f.StringVar(&cfg.RulePath, "ruler.rule-path", "/rules", "file path to store temporary rule files for the prometheus rule managers")
 	f.BoolVar(&cfg.EnableAPI, "experimental.ruler.enable-api", false, "Enable the ruler api")
@@ -456,10 +452,10 @@ func (r *Ruler) listRules(ctx context.Context) (map[string]rules.RuleGroupList, 
 	case !r.cfg.EnableSharding:
 		return r.listRulesNoSharding(ctx)
 
-	case r.cfg.ShardingStrategy == ShardingStrategyDefault:
+	case r.cfg.ShardingStrategy == util.ShardingStrategyDefault:
 		return r.listRulesShardingDefault(ctx)
 
-	case r.cfg.ShardingStrategy == ShardingStrategyShuffle:
+	case r.cfg.ShardingStrategy == util.ShardingStrategyShuffle:
 		return r.listRulesShuffleSharding(ctx)
 
 	default:

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -291,7 +291,7 @@ func TestSharding(t *testing.T) {
 
 		"default sharding, single ruler": {
 			sharding:         true,
-			shardingStrategy: ShardingStrategyDefault,
+			shardingStrategy: util.ShardingStrategyDefault,
 			setupRing: func(desc *ring.Desc) {
 				desc.AddIngester(ruler1, ruler1Addr, "", []uint32{0}, ring.ACTIVE, time.Now())
 			},
@@ -300,7 +300,7 @@ func TestSharding(t *testing.T) {
 
 		"default sharding, multiple ACTIVE rulers": {
 			sharding:         true,
-			shardingStrategy: ShardingStrategyDefault,
+			shardingStrategy: util.ShardingStrategyDefault,
 			setupRing: func(desc *ring.Desc) {
 				desc.AddIngester(ruler1, ruler1Addr, "", sortTokens([]uint32{user1Group1Token + 1, user2Group1Token + 1}), ring.ACTIVE, time.Now())
 				desc.AddIngester(ruler2, ruler2Addr, "", sortTokens([]uint32{user1Group2Token + 1, user3Group1Token + 1}), ring.ACTIVE, time.Now())
@@ -321,7 +321,7 @@ func TestSharding(t *testing.T) {
 
 		"default sharding, unhealthy ACTIVE ruler": {
 			sharding:         true,
-			shardingStrategy: ShardingStrategyDefault,
+			shardingStrategy: util.ShardingStrategyDefault,
 
 			setupRing: func(desc *ring.Desc) {
 				desc.AddIngester(ruler1, ruler1Addr, "", sortTokens([]uint32{user1Group1Token + 1, user2Group1Token + 1}), ring.ACTIVE, time.Now())
@@ -345,7 +345,7 @@ func TestSharding(t *testing.T) {
 
 		"default sharding, LEAVING ruler": {
 			sharding:         true,
-			shardingStrategy: ShardingStrategyDefault,
+			shardingStrategy: util.ShardingStrategyDefault,
 
 			setupRing: func(desc *ring.Desc) {
 				desc.AddIngester(ruler1, ruler1Addr, "", sortTokens([]uint32{user1Group1Token + 1, user2Group1Token + 1}), ring.LEAVING, time.Now())
@@ -361,7 +361,7 @@ func TestSharding(t *testing.T) {
 
 		"default sharding, JOINING ruler": {
 			sharding:         true,
-			shardingStrategy: ShardingStrategyDefault,
+			shardingStrategy: util.ShardingStrategyDefault,
 
 			setupRing: func(desc *ring.Desc) {
 				desc.AddIngester(ruler1, ruler1Addr, "", sortTokens([]uint32{user1Group1Token + 1, user2Group1Token + 1}), ring.JOINING, time.Now())
@@ -377,7 +377,7 @@ func TestSharding(t *testing.T) {
 
 		"shuffle sharding, single ruler": {
 			sharding:         true,
-			shardingStrategy: ShardingStrategyShuffle,
+			shardingStrategy: util.ShardingStrategyShuffle,
 
 			setupRing: func(desc *ring.Desc) {
 				desc.AddIngester(ruler1, ruler1Addr, "", sortTokens([]uint32{0}), ring.ACTIVE, time.Now())
@@ -390,7 +390,7 @@ func TestSharding(t *testing.T) {
 
 		"shuffle sharding, multiple rulers, shard size 1": {
 			sharding:         true,
-			shardingStrategy: ShardingStrategyShuffle,
+			shardingStrategy: util.ShardingStrategyShuffle,
 			shuffleShardSize: 1,
 
 			setupRing: func(desc *ring.Desc) {
@@ -407,7 +407,7 @@ func TestSharding(t *testing.T) {
 		// Same test as previous one, but with shard size=2. Second ruler gets all the rules.
 		"shuffle sharding, two rulers, shard size 2": {
 			sharding:         true,
-			shardingStrategy: ShardingStrategyShuffle,
+			shardingStrategy: util.ShardingStrategyShuffle,
 			shuffleShardSize: 2,
 
 			setupRing: func(desc *ring.Desc) {
@@ -424,7 +424,7 @@ func TestSharding(t *testing.T) {
 
 		"shuffle sharding, two rulers, shard size 1, distributed users": {
 			sharding:         true,
-			shardingStrategy: ShardingStrategyShuffle,
+			shardingStrategy: util.ShardingStrategyShuffle,
 			shuffleShardSize: 1,
 
 			setupRing: func(desc *ring.Desc) {
@@ -444,7 +444,7 @@ func TestSharding(t *testing.T) {
 		},
 		"shuffle sharding, three rulers, shard size 2": {
 			sharding:         true,
-			shardingStrategy: ShardingStrategyShuffle,
+			shardingStrategy: util.ShardingStrategyShuffle,
 			shuffleShardSize: 2,
 
 			setupRing: func(desc *ring.Desc) {
@@ -468,7 +468,7 @@ func TestSharding(t *testing.T) {
 		},
 		"shuffle sharding, three rulers, shard size 2, ruler2 has no users": {
 			sharding:         true,
-			shardingStrategy: ShardingStrategyShuffle,
+			shardingStrategy: util.ShardingStrategyShuffle,
 			shuffleShardSize: 2,
 
 			setupRing: func(desc *ring.Desc) {

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -38,14 +38,10 @@ const (
 	// ringAutoForgetUnhealthyPeriods is how many consecutive timeout periods an unhealthy instance
 	// in the ring will be automatically removed.
 	ringAutoForgetUnhealthyPeriods = 10
-
-	// Supported sharding strategies.
-	ShardingStrategyDefault = "default"
-	ShardingStrategyShuffle = "shuffle-sharding"
 )
 
 var (
-	supportedShardingStrategies = []string{ShardingStrategyDefault, ShardingStrategyShuffle}
+	supportedShardingStrategies = []string{util.ShardingStrategyDefault, util.ShardingStrategyShuffle}
 
 	// Validation errors.
 	errInvalidShardingStrategy = errors.New("invalid sharding strategy")
@@ -64,7 +60,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.ShardingRing.RegisterFlags(f)
 
 	f.BoolVar(&cfg.ShardingEnabled, "store-gateway.sharding-enabled", false, "Shard blocks across multiple store gateway instances."+sharedOptionWithQuerier)
-	f.StringVar(&cfg.ShardingStrategy, "store-gateway.sharding-strategy", ShardingStrategyDefault, fmt.Sprintf("The sharding strategy to use. Supported values are: %s.", strings.Join(supportedShardingStrategies, ", ")))
+	f.StringVar(&cfg.ShardingStrategy, "store-gateway.sharding-strategy", util.ShardingStrategyDefault, fmt.Sprintf("The sharding strategy to use. Supported values are: %s.", strings.Join(supportedShardingStrategies, ", ")))
 }
 
 // Validate the Config.
@@ -74,7 +70,7 @@ func (cfg *Config) Validate(limits validation.Limits) error {
 			return errInvalidShardingStrategy
 		}
 
-		if cfg.ShardingStrategy == ShardingStrategyShuffle && limits.StoreGatewayTenantShardSize <= 0 {
+		if cfg.ShardingStrategy == util.ShardingStrategyShuffle && limits.StoreGatewayTenantShardSize <= 0 {
 			return errInvalidTenantShardSize
 		}
 	}
@@ -177,9 +173,9 @@ func newStoreGateway(gatewayCfg Config, storageCfg cortex_tsdb.BlocksStorageConf
 
 		// Instance the right strategy.
 		switch gatewayCfg.ShardingStrategy {
-		case ShardingStrategyDefault:
+		case util.ShardingStrategyDefault:
 			shardingStrategy = NewDefaultShardingStrategy(g.ring, lifecyclerCfg.Addr, logger)
-		case ShardingStrategyShuffle:
+		case util.ShardingStrategyShuffle:
 			shardingStrategy = NewShuffleShardingStrategy(g.ring, lifecyclerCfg.ID, lifecyclerCfg.Addr, limits, logger)
 		default:
 			return nil, errInvalidShardingStrategy

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -58,14 +58,14 @@ func TestConfig_Validate(t *testing.T) {
 		"should fail if the sharding strategy is shuffle-sharding and shard size has not been set": {
 			setup: func(cfg *Config, limits *validation.Limits) {
 				cfg.ShardingEnabled = true
-				cfg.ShardingStrategy = ShardingStrategyShuffle
+				cfg.ShardingStrategy = util.ShardingStrategyShuffle
 			},
 			expected: errInvalidTenantShardSize,
 		},
 		"should pass if the sharding strategy is shuffle-sharding and shard size has been set": {
 			setup: func(cfg *Config, limits *validation.Limits) {
 				cfg.ShardingEnabled = true
-				cfg.ShardingStrategy = ShardingStrategyShuffle
+				cfg.ShardingStrategy = util.ShardingStrategyShuffle
 				limits.StoreGatewayTenantShardSize = 3
 			},
 			expected: nil,
@@ -244,45 +244,45 @@ func TestStoreGateway_BlocksSharding(t *testing.T) {
 			expectedBlocksLoaded: 2 * numBlocks, // each gateway loads all the blocks
 		},
 		"default sharding strategy, 1 gateway, RF = 1": {
-			shardingStrategy:     ShardingStrategyDefault,
+			shardingStrategy:     util.ShardingStrategyDefault,
 			replicationFactor:    1,
 			numGateways:          1,
 			expectedBlocksLoaded: numBlocks,
 		},
 		"default sharding strategy, 2 gateways, RF = 1": {
-			shardingStrategy:     ShardingStrategyDefault,
+			shardingStrategy:     util.ShardingStrategyDefault,
 			replicationFactor:    1,
 			numGateways:          2,
 			expectedBlocksLoaded: numBlocks, // blocks are sharded across gateways
 		},
 		"default sharding strategy, 3 gateways, RF = 2": {
-			shardingStrategy:     ShardingStrategyDefault,
+			shardingStrategy:     util.ShardingStrategyDefault,
 			replicationFactor:    2,
 			numGateways:          3,
 			expectedBlocksLoaded: 2 * numBlocks, // blocks are replicated 2 times
 		},
 		"default sharding strategy, 5 gateways, RF = 3": {
-			shardingStrategy:     ShardingStrategyDefault,
+			shardingStrategy:     util.ShardingStrategyDefault,
 			replicationFactor:    3,
 			numGateways:          5,
 			expectedBlocksLoaded: 3 * numBlocks, // blocks are replicated 3 times
 		},
 		"shuffle sharding strategy, 1 gateway, RF = 1, SS = 1": {
-			shardingStrategy:     ShardingStrategyShuffle,
+			shardingStrategy:     util.ShardingStrategyShuffle,
 			tenantShardSize:      1,
 			replicationFactor:    1,
 			numGateways:          1,
 			expectedBlocksLoaded: numBlocks,
 		},
 		"shuffle sharding strategy, 5 gateways, RF = 2, SS = 3": {
-			shardingStrategy:     ShardingStrategyShuffle,
+			shardingStrategy:     util.ShardingStrategyShuffle,
 			tenantShardSize:      3,
 			replicationFactor:    2,
 			numGateways:          5,
 			expectedBlocksLoaded: 2 * numBlocks, // blocks are replicated 2 times
 		},
 		"shuffle sharding strategy, 20 gateways, RF = 3, SS = 3": {
-			shardingStrategy:     ShardingStrategyShuffle,
+			shardingStrategy:     util.ShardingStrategyShuffle,
 			tenantShardSize:      3,
 			replicationFactor:    3,
 			numGateways:          20,
@@ -360,7 +360,7 @@ func TestStoreGateway_BlocksSharding(t *testing.T) {
 			assert.Equal(t, float64(testData.expectedBlocksLoaded), metrics.GetSumOfGauges("cortex_bucket_store_blocks_loaded"))
 			assert.Equal(t, float64(2*testData.numGateways), metrics.GetSumOfGauges("cortex_bucket_stores_tenants_discovered"))
 
-			if testData.shardingStrategy == ShardingStrategyShuffle {
+			if testData.shardingStrategy == util.ShardingStrategyShuffle {
 				assert.Equal(t, float64(testData.tenantShardSize*numBlocks), metrics.GetSumOfGauges("cortex_blocks_meta_synced"))
 				assert.Equal(t, float64(testData.tenantShardSize*numUsers), metrics.GetSumOfGauges("cortex_bucket_stores_tenants_synced"))
 			} else {

--- a/pkg/util/math.go
+++ b/pkg/util/math.go
@@ -1,5 +1,13 @@
 package util
 
+// Max returns the maximum of two ints
+func Max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 // Min returns the minimum of two ints
 func Min(a, b int) int {
 	if a < b {

--- a/pkg/util/shard.go
+++ b/pkg/util/shard.go
@@ -3,6 +3,7 @@ package util
 import (
 	"crypto/md5"
 	"encoding/binary"
+	"math"
 )
 
 const (
@@ -28,4 +29,17 @@ func ShuffleShardSeed(identifier, zone string) int64 {
 
 	// Generate the seed based on the first 64 bits of the checksum.
 	return int64(binary.BigEndian.Uint64(checksum))
+}
+
+// ShuffleShardExpectedInstancesPerZone returns the number of instances that should be selected for each
+// zone when zone-aware replication is enabled. The algorithm expects the shard size to be divisible
+// by the number of zones, in order to have nodes balanced across zones. If it's not, we do round up.
+func ShuffleShardExpectedInstancesPerZone(shardSize, numZones int) int {
+	return int(math.Ceil(float64(shardSize) / float64(numZones)))
+}
+
+// ShuffleShardExpectedInstances returns the total number of instances that should be selected for a given
+// tenant. If zone-aware replication is disabled, the input numZones should be 1.
+func ShuffleShardExpectedInstances(shardSize, numZones int) int {
+	return ShuffleShardExpectedInstancesPerZone(shardSize, numZones) * numZones
 }

--- a/pkg/util/shard.go
+++ b/pkg/util/shard.go
@@ -5,6 +5,12 @@ import (
 	"encoding/binary"
 )
 
+const (
+	// Sharding strategies.
+	ShardingStrategyDefault = "default"
+	ShardingStrategyShuffle = "shuffle-sharding"
+)
+
 var (
 	seedSeparator = []byte{0}
 )

--- a/pkg/util/shard_test.go
+++ b/pkg/util/shard_test.go
@@ -1,0 +1,83 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShuffleShardExpectedInstancesPerZone(t *testing.T) {
+	tests := []struct {
+		shardSize int
+		numZones  int
+		expected  int
+	}{
+		{
+			shardSize: 1,
+			numZones:  1,
+			expected:  1,
+		},
+		{
+			shardSize: 1,
+			numZones:  3,
+			expected:  1,
+		},
+		{
+			shardSize: 3,
+			numZones:  3,
+			expected:  1,
+		},
+		{
+			shardSize: 4,
+			numZones:  3,
+			expected:  2,
+		},
+		{
+			shardSize: 6,
+			numZones:  3,
+			expected:  2,
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expected, ShuffleShardExpectedInstancesPerZone(test.shardSize, test.numZones))
+	}
+}
+
+func TestShuffleShardExpectedInstances(t *testing.T) {
+	tests := []struct {
+		shardSize int
+		numZones  int
+		expected  int
+	}{
+		{
+			shardSize: 1,
+			numZones:  1,
+			expected:  1,
+		},
+		{
+			shardSize: 1,
+			numZones:  3,
+			expected:  3,
+		},
+		{
+			shardSize: 3,
+			numZones:  3,
+			expected:  3,
+		},
+		{
+			shardSize: 4,
+			numZones:  3,
+			expected:  6,
+		},
+		{
+			shardSize: 6,
+			numZones:  3,
+			expected:  6,
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expected, ShuffleShardExpectedInstances(test.shardSize, test.numZones))
+	}
+}


### PR DESCRIPTION
**What this PR does**:
The max global series per user/metric limit doesn't work correctly when shuffle sharding and shard-by-all-labels are both enabled because it considers series to be distributed across all ingesters, while actually series are only distributed across a subset of ingesters (the shard size).

**Which issue(s) this PR fixes**:
Fixes #3367

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
