### PR TITLE
Fixed deploy via GitHub actions

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -238,14 +238,14 @@ jobs:
           if [ -n "$DOCKER_REGISTRY_PASSWORD" ]; then
             docker login -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD"
           fi
-          if [ -n "$QUAY_PASSWORD" ]; then
+          if [ -n "$QUAY_REGISTRY_PASSWORD" ]; then
             docker login -u "$QUAY_REGISTRY_USER" -p "$QUAY_REGISTRY_PASSWORD" quay.io;
           fi
           IMAGE_TAG=$GIT_TAG ./push-images $NOQUAY
         env:
           DOCKER_REGISTRY_USER: ${{secrets.DOCKER_REGISTRY_USER}}
           DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
-          QUAY_REGISTRY_USER: ${{secrets.QUAY_USER}}
-          QUAY_REGISTRY_PASSWORD: ${{secrets.QUAY_PASSWORD}}
+          QUAY_REGISTRY_USER: ${{secrets.QUAY_REGISTRY_USER}}
+          QUAY_REGISTRY_PASSWORD: ${{secrets.$QUAY_REGISTRY_PASSWORD}}
           GIT_TAG: ${{github.event.release.tag_name}}
           NOQUAY: ${{secrets.NOQUAY}}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -246,6 +246,6 @@ jobs:
           DOCKER_REGISTRY_USER: ${{secrets.DOCKER_REGISTRY_USER}}
           DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           QUAY_REGISTRY_USER: ${{secrets.QUAY_REGISTRY_USER}}
-          QUAY_REGISTRY_PASSWORD: ${{secrets.$QUAY_REGISTRY_PASSWORD}}
+          QUAY_REGISTRY_PASSWORD: ${{secrets.QUAY_REGISTRY_PASSWORD}}
           GIT_TAG: ${{github.event.release.tag_name}}
           NOQUAY: ${{secrets.NOQUAY}}


### PR DESCRIPTION
**What this PR does**:
The new GitHub actions workflow "deploy" job (see #3368) is broken because of an issue with secrets/env variables name. In this PR I'm fixing it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
