### PR TITLE
Fixed TestKV_List_Delete flakyness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
         command: |
           docker pull minio/minio:RELEASE.2019-12-30T05-45-39Z
           docker pull amazon/dynamodb-local:1.11.477
-          docker pull consul:0.9
+          docker pull consul:1.8.4
           docker pull gcr.io/etcd-development/etcd:v3.4.7
           docker pull quay.io/cortexproject/cortex:v0.6.0
           docker pull quay.io/cortexproject/cortex:v0.7.0

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           docker pull minio/minio:RELEASE.2019-12-30T05-45-39Z
           docker pull amazon/dynamodb-local:1.11.477
-          docker pull consul:0.9
+          docker pull consul:1.8.4
           docker pull gcr.io/etcd-development/etcd:v3.4.7
           docker pull quay.io/cortexproject/cortex:v1.0.0
           docker pull quay.io/cortexproject/cortex:v1.1.0

--- a/integration/e2e/db/db.go
+++ b/integration/e2e/db/db.go
@@ -42,7 +42,7 @@ func NewConsul() *e2e.HTTPService {
 		images.Consul,
 		// Run consul in "dev" mode so that the initial leader election is immediate
 		e2e.NewCommand("agent", "-server", "-client=0.0.0.0", "-dev", "-log-level=err"),
-		nil,
+		e2e.NewTCPReadinessProbe(8500),
 		8500,
 	)
 }
@@ -51,9 +51,10 @@ func NewETCD() *e2e.HTTPService {
 	return e2e.NewHTTPService(
 		"etcd",
 		images.ETCD,
-		e2e.NewCommand("/usr/local/bin/etcd", "--listen-client-urls=http://0.0.0.0:2379", "--advertise-client-urls=http://0.0.0.0:2379", "--log-level=error"),
-		nil,
+		e2e.NewCommand("/usr/local/bin/etcd", "--listen-client-urls=http://0.0.0.0:2379", "--advertise-client-urls=http://0.0.0.0:2379", "--listen-metrics-urls=http://0.0.0.0:9000", "--log-level=error"),
+		e2e.NewHTTPReadinessProbe(9000, "/health", 200, 204),
 		2379,
+		9000, // Metrics
 	)
 }
 

--- a/integration/e2e/db/db.go
+++ b/integration/e2e/db/db.go
@@ -42,7 +42,7 @@ func NewConsul() *e2e.HTTPService {
 		images.Consul,
 		// Run consul in "dev" mode so that the initial leader election is immediate
 		e2e.NewCommand("agent", "-server", "-client=0.0.0.0", "-dev", "-log-level=err"),
-		e2e.NewTCPReadinessProbe(8500),
+		e2e.NewHTTPReadinessProbe(8500, "/v1/operator/autopilot/health", 200, 200, `"Healthy": true`),
 		8500,
 	)
 }

--- a/integration/e2e/images/images.go
+++ b/integration/e2e/images/images.go
@@ -1,14 +1,14 @@
 package images
 
 // If you change the image tag, remember to update it in the preloading done
-// by CircleCI too (see .circleci/config.yml).
+// by CircleCI (see .circleci/config.yml) and GitHub actions (see .github/workflows/*).
 
 // These are variables so that they can be modified.
 
 var (
 	Memcached        = "memcached:1.6.1"
 	Minio            = "minio/minio:RELEASE.2019-12-30T05-45-39Z"
-	Consul           = "consul:0.9"
+	Consul           = "consul:1.8.4"
 	ETCD             = "gcr.io/etcd-development/etcd:v3.4.7"
 	DynamoDB         = "amazon/dynamodb-local:1.11.477"
 	BigtableEmulator = "shopify/bigtable-emulator:0.1.0"


### PR DESCRIPTION
**What this PR does**:
I've noticed the integration test `` is flaky ([see here](https://github.com/cortexproject/cortex/runs/1293159338)) and my suspect is that we may start testing against etcd/consul after the container is running but before the service is actually ready.

In this PR I've:
- Added readiness probes for consul and etcd
- Took the opportunity to upgrade consul used in integration tests (was very old)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
