### PR TITLE
Expose the config hash as a metric.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - `cortex_ingester_tsdb_head_truncations_failed_total`
   - `cortex_ingester_tsdb_head_truncations_total`
   - `cortex_ingester_tsdb_head_gc_duration_seconds`
+* [ENHANCEMENT] Added `cortex_alertmanager_config_hash` metric to expose hash of Alertmanager Config loaded per user. #3388
 
 ## 1.5.0 in progress
 

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -32,6 +32,7 @@ func TestAlertmanager(t *testing.T) {
 	)
 	require.NoError(t, s.StartAndWaitReady(alertmanager))
 	require.NoError(t, alertmanager.WaitSumMetrics(e2e.Equals(1), "cortex_alertmanager_config_last_reload_successful"))
+	require.NoError(t, alertmanager.WaitSumMetrics(e2e.Greater(0), "cortex_alertmanager_config_hash"))
 
 	c, err := e2ecortex.NewClient("", "", alertmanager.HTTPEndpoint(), "", "user-1")
 	require.NoError(t, err)

--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -45,6 +45,9 @@ type alertmanagerMetrics struct {
 	silencesQueryDuration           *prometheus.Desc
 	silences                        *prometheus.Desc
 	silencesPropagatedMessagesTotal *prometheus.Desc
+
+	// The alertmanager config hash.
+	configHashValue *prometheus.Desc
 }
 
 func newAlertmanagerMetrics() *alertmanagerMetrics {
@@ -135,6 +138,10 @@ func newAlertmanagerMetrics() *alertmanagerMetrics {
 			"cortex_alertmanager_silences",
 			"How many silences by state.",
 			[]string{"user", "state"}, nil),
+		configHashValue: prometheus.NewDesc(
+			"cortex_alertmanager_config_hash",
+			"Hash of the currently loaded alertmanager configuration.",
+			[]string{"user"}, nil),
 	}
 }
 
@@ -178,6 +185,7 @@ func (m *alertmanagerMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.silencesQueryDuration
 	out <- m.silences
 	out <- m.silencesPropagatedMessagesTotal
+	out <- m.configHashValue
 }
 
 func (m *alertmanagerMetrics) Collect(out chan<- prometheus.Metric) {
@@ -207,4 +215,6 @@ func (m *alertmanagerMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfHistograms(out, m.silencesQueryDuration, "alertmanager_silences_query_duration_seconds")
 	data.SendSumOfCounters(out, m.silencesPropagatedMessagesTotal, "alertmanager_silences_gossip_messages_propagated_total")
 	data.SendSumOfGaugesPerUserWithLabels(out, m.silences, "alertmanager_silences", "state")
+
+	data.SendMaxOfGaugesPerUser(out, m.configHashValue, "alertmanager_config_hash")
 }

--- a/pkg/alertmanager/alertmanager_metrics_test.go
+++ b/pkg/alertmanager/alertmanager_metrics_test.go
@@ -51,6 +51,11 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		cortex_alertmanager_alerts_received_total{user="user1"} 10
 		cortex_alertmanager_alerts_received_total{user="user2"} 100
 		cortex_alertmanager_alerts_received_total{user="user3"} 1000
+		# HELP cortex_alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+		# TYPE cortex_alertmanager_config_hash gauge
+		cortex_alertmanager_config_hash{user="user1"} 0
+		cortex_alertmanager_config_hash{user="user2"} 0
+		cortex_alertmanager_config_hash{user="user3"} 0
 		# HELP cortex_alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
 		# TYPE cortex_alertmanager_nflog_gc_duration_seconds summary
 		cortex_alertmanager_nflog_gc_duration_seconds_sum 111

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -228,6 +228,13 @@ func (d MetricFamiliesPerUser) SendMaxOfGauges(out chan<- prometheus.Metric, des
 	out <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, result)
 }
 
+func (d MetricFamiliesPerUser) SendMaxOfGaugesPerUser(out chan<- prometheus.Metric, desc *prometheus.Desc, gauge string) {
+	for user, userMetrics := range d {
+		result := userMetrics.MaxGauges(gauge)
+		out <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, result, user)
+	}
+}
+
 func (d MetricFamiliesPerUser) SendSumOfSummaries(out chan<- prometheus.Metric, desc *prometheus.Desc, summaryName string) {
 	summaryData := SummaryData{}
 	for _, userMetrics := range d {


### PR DESCRIPTION
If there is a config drift, then we won't dedupe metrics. This can be
used to monitor things. See: https://github.com/prometheus/alertmanager/issues/596

This is set by the config coordinator upstream which we dont use, hence
we're setting it manually.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
