### PR TITLE
Refactored TSDB opening concurrency at startup

### DIFF
--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1109,9 +1109,7 @@ func (i *Ingester) openExistingTSDB(ctx context.Context) error {
 			defer wg.Done()
 
 			for userID := range queue {
-				defer func(ts time.Time) {
-					i.TSDBState.walReplayTime.Observe(time.Since(ts).Seconds())
-				}(time.Now())
+				startTime := time.Now()
 
 				db, err := i.createTSDB(userID)
 				if err != nil {
@@ -1128,6 +1126,8 @@ func (i *Ingester) openExistingTSDB(ctx context.Context) error {
 				i.TSDBState.dbs[userID] = db
 				i.userStatesMtx.Unlock()
 				i.metrics.memUsers.Inc()
+
+				i.TSDBState.walReplayTime.Observe(time.Since(startTime).Seconds())
 			}
 		}()
 	}

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1097,17 +1097,12 @@ func (i *Ingester) openExistingTSDB(ctx context.Context) error {
 	level.Info(util.Logger).Log("msg", "opening existing TSDBs")
 
 	queue := make(chan string)
-	group, groupCtx := errgroup.WithContext(context.Background())
+	group, groupCtx := errgroup.WithContext(ctx)
 
 	// Create a pool of workers which will open existing TSDBs.
 	for n := 0; n < i.cfg.BlocksStorageConfig.TSDB.MaxTSDBOpeningConcurrencyOnStartup; n++ {
 		group.Go(func() error {
 			for userID := range queue {
-				// Interrupt in case a failure occurred in another goroutine.
-				if groupCtx.Err() != nil {
-					return nil
-				}
-
 				startTime := time.Now()
 
 				db, err := i.createTSDB(userID)

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -55,6 +55,7 @@ var (
 
 	errUnsupportedStorageBackend    = errors.New("unsupported TSDB storage backend")
 	errInvalidShipConcurrency       = errors.New("invalid TSDB ship concurrency")
+	errInvalidOpeningConcurrency    = errors.New("invalid TSDB opening concurrency")
 	errInvalidCompactionInterval    = errors.New("invalid TSDB compaction interval")
 	errInvalidCompactionConcurrency = errors.New("invalid TSDB compaction concurrency")
 	errInvalidStripeSize            = errors.New("invalid TSDB stripe size")
@@ -207,6 +208,10 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 func (cfg *TSDBConfig) Validate() error {
 	if cfg.ShipInterval > 0 && cfg.ShipConcurrency <= 0 {
 		return errInvalidShipConcurrency
+	}
+
+	if cfg.MaxTSDBOpeningConcurrencyOnStartup <= 0 {
+		return errInvalidOpeningConcurrency
 	}
 
 	if cfg.HeadCompactionInterval <= 0 || cfg.HeadCompactionInterval > 5*time.Minute {


### PR DESCRIPTION
**What this PR does**:
This is an internal refactoring with no user impact. In the PR #3354 I received the feedback:

> feel like error-handling code could be clearer by using errgroup. Also splitting the concerns would help -- one goroutine doing the scan, other N goroutines doing opening. Now both are mixed.

In this PR I'm addressing this feedback splitting the logic between the "scan" and the "opening".

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
