### PR TITLE
Wait until container is actually running, not just created.

### DIFF
--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"io/ioutil"
 	"math"
 	"math/rand"
@@ -18,6 +19,14 @@ import (
 
 func RunCommandAndGetOutput(name string, args ...string) ([]byte, error) {
 	cmd := exec.Command(name, args...)
+	return cmd.CombinedOutput()
+}
+
+func RunCommandWithTimeoutAndGetOutput(timeout time.Duration, name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, name, args...)
 	return cmd.CombinedOutput()
 }
 


### PR DESCRIPTION
**What this PR does**: this PR modifies integration tests to wait for container to be in Running state, and not just created. I've observed up to 30 seconds between container was created and actually running. Problem is that when integration tests try to get ports for container, and it's only in Created state, getting ports fails. In Running state, it succeeds.