### PR TITLE
feat: add separate consistency configuration cassandra table ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 * [CHANGE] Increased default `-<prefix>.redis.timeout` from `100ms` to `500ms`. #3301
 * [CHANGE] `cortex_alertmanager_config_invalid` has been removed in favor of `cortex_alertmanager_config_last_reload_successful`. #3289
 * [CHANGE] Query-frontend: POST requests whose body size exceeds 10MiB will be rejected. The max body size can be customised via `-frontend.max-body-size`. #3276
-* [FEATURE] Cassandra: Add `-cassandra.table-operations-consistency` flag that allows a separate consistency level to be set for keyspace/table operations to Cassandra. #xxxx
+* [FEATURE] Cassandra: Add `-cassandra.table-operations-consistency` flag that allows a separate consistency level to be set for keyspace/table operations to Cassandra. #3402
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-tenant` globally, or using per-tenant limit `max_queriers_per_tenant`), each tenants's requests will be handled by different set of queriers. #3113 #3257
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding ingesters on the read path. When ingesters shuffle-sharding is enabled and `-querier.shuffle-sharding-ingesters-lookback-period` is set, queriers will fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. #3252
 * [FEATURE] Query-frontend: added `compression` config to support results cache with compression. #3217

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [CHANGE] Increased default `-<prefix>.redis.timeout` from `100ms` to `500ms`. #3301
 * [CHANGE] `cortex_alertmanager_config_invalid` has been removed in favor of `cortex_alertmanager_config_last_reload_successful`. #3289
 * [CHANGE] Query-frontend: POST requests whose body size exceeds 10MiB will be rejected. The max body size can be customised via `-frontend.max-body-size`. #3276
+* [FEATURE] Cassandra: Add `-cassandra.table-operations-consistency` flag that allows a separate consistency level to be set for keyspace/table operations to Cassandra. #xxxx
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding queriers in the query-frontend. When configured (`-frontend.max-queriers-per-tenant` globally, or using per-tenant limit `max_queriers_per_tenant`), each tenants's requests will be handled by different set of queriers. #3113 #3257
 * [FEATURE] Shuffle sharding: added support for shuffle-sharding ingesters on the read path. When ingesters shuffle-sharding is enabled and `-querier.shuffle-sharding-ingesters-lookback-period` is set, queriers will fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since 'now - lookback period'. #3252
 * [FEATURE] Query-frontend: added `compression` config to support results cache with compression. #3217

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2050,6 +2050,10 @@ cassandra:
   # CLI flag: -cassandra.table-options
   [table_options: <string> | default = ""]
 
+  # Consistency level for Cassandra table and keyspace operations.
+  # CLI flag: -cassandra.table-operations-consistency
+  [table_operations_consistency: <string> | default = "ALL"]
+
 boltdb:
   # Location of BoltDB index files.
   # CLI flag: -boltdb.dir

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2052,7 +2052,7 @@ cassandra:
 
   # Consistency level for Cassandra table and keyspace operations.
   # CLI flag: -cassandra.table-operations-consistency
-  [table_operations_consistency: <string> | default = "ALL"]
+  [table_operations_consistency: <string> | default = "QUORUM"]
 
 boltdb:
   # Location of BoltDB index files.

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -78,7 +78,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.NumConnections, "cassandra.num-connections", 2, "Number of TCP connections per host.")
 	f.BoolVar(&cfg.ConvictHosts, "cassandra.convict-hosts-on-failure", true, "Convict hosts of being down on failure.")
 	f.StringVar(&cfg.TableOptions, "cassandra.table-options", "", "Table options used to create index or chunk tables. This value is used as plain text in the table `WITH` like this, \"CREATE TABLE <generated_by_cortex> (...) WITH <cassandra.table-options>\". For details, see https://cortexmetrics.io/docs/production/cassandra. By default it will use the default table options of your Cassandra cluster.")
-	f.StringVar(&cfg.TableOperationsConsistency, "cassandra.table-operations-consistency", "ALL", "Consistency level for Cassandra table and keyspace operations.")
+	f.StringVar(&cfg.TableOperationsConsistency, "cassandra.table-operations-consistency", "QUORUM", "Consistency level for Cassandra table and keyspace operations.")
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/chunk/cassandra/storage_client_test.go
+++ b/pkg/chunk/cassandra/storage_client_test.go
@@ -16,7 +16,7 @@ func TestConfig_setClusterConfig_noAuth(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 
 	cqlCfg := gocql.NewCluster()
-	err := cfg.setClusterConfig(cqlCfg)
+	err := cfg.setClusterConfig(cqlCfg, false)
 	require.NoError(t, err)
 	assert.Nil(t, cqlCfg.Authenticator)
 }
@@ -29,7 +29,7 @@ func TestConfig_setClusterConfig_authWithPassword(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 
 	cqlCfg := gocql.NewCluster()
-	err := cfg.setClusterConfig(cqlCfg)
+	err := cfg.setClusterConfig(cqlCfg, false)
 	require.NoError(t, err)
 	assert.NotNil(t, cqlCfg.Authenticator)
 	assert.Equal(t, "user", cqlCfg.Authenticator.(gocql.PasswordAuthenticator).Username)
@@ -44,7 +44,7 @@ func TestConfig_setClusterConfig_authWithPasswordFile_withoutTrailingNewline(t *
 	require.NoError(t, cfg.Validate())
 
 	cqlCfg := gocql.NewCluster()
-	err := cfg.setClusterConfig(cqlCfg)
+	err := cfg.setClusterConfig(cqlCfg, false)
 	require.NoError(t, err)
 	assert.NotNil(t, cqlCfg.Authenticator)
 	assert.Equal(t, "user", cqlCfg.Authenticator.(gocql.PasswordAuthenticator).Username)
@@ -59,7 +59,7 @@ func TestConfig_setClusterConfig_authWithPasswordFile_withTrailingNewline(t *tes
 	require.NoError(t, cfg.Validate())
 
 	cqlCfg := gocql.NewCluster()
-	err := cfg.setClusterConfig(cqlCfg)
+	err := cfg.setClusterConfig(cqlCfg, false)
 	require.NoError(t, err)
 	assert.NotNil(t, cqlCfg.Authenticator)
 	assert.Equal(t, "user", cqlCfg.Authenticator.(gocql.PasswordAuthenticator).Username)
@@ -99,7 +99,7 @@ func TestConfig_setClusterConfig_consistency(t *testing.T) {
 			require.NoError(t, testData.cfg.Validate())
 
 			cqlCfg := gocql.NewCluster()
-			err := testData.cfg.setClusterConfig(cqlCfg)
+			err := testData.cfg.setClusterConfig(cqlCfg, false)
 			require.NoError(t, err)
 			assert.Equal(t, testData.expectedConsistency, cqlCfg.Consistency.String())
 		})

--- a/pkg/chunk/cassandra/table_client.go
+++ b/pkg/chunk/cassandra/table_client.go
@@ -18,7 +18,7 @@ type tableClient struct {
 
 // NewTableClient returns a new TableClient.
 func NewTableClient(ctx context.Context, cfg Config, registerer prometheus.Registerer) (chunk.TableClient, error) {
-	session, err := cfg.session("table-manager", registerer)
+	session, err := cfg.session("table-manager", registerer, true)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
**What this PR does**:

Add a `-cassandra.table-operations-consistency` flag that allows a separate consistency level to be set for operations that affect tables and keyspaces. This is meant to allow a stricter level of consistency when interacting with tables/keyspaces to avoid schema conflicts/

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
