### PR TITLE
Expose all TSDB metrics in the ingester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master / unreleased
 
+* [ENHANCEMENT] Blocks storage ingester: exported more TSDB-related metrics. #3412
+  - `cortex_ingester_tsdb_wal_corruptions_total`
+  - `cortex_ingester_tsdb_head_truncations_failed_total`
+  - `cortex_ingester_tsdb_head_truncations_total`
+  - `cortex_ingester_tsdb_head_gc_duration_seconds`
+
 ## 1.5.0 in progress
 
 * [CHANGE] Blocks storage: update the default HTTP configuration values for the S3 client to the upstream Thanos default values. #3244

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -1860,12 +1860,12 @@ func TestIngester_flushing(t *testing.T) {
 				i.FlushHandler(httptest.NewRecorder(), httptest.NewRequest("POST", "/flush", nil))
 
 				// Flush handler only triggers compactions, but doesn't wait for them to finish. Let's wait for a moment, and then verify.
-				test.Poll(t, 1*time.Second, true, func() interface{} {
+				test.Poll(t, 5*time.Second, uint64(0), func() interface{} {
 					db := i.getTSDB(userID)
 					if db == nil {
 						return false
 					}
-					return db.Head().NumSeries() == 0
+					return db.Head().NumSeries()
 				})
 
 				// The above waiting only ensures compaction, waiting another second to register the Sync call.
@@ -1900,12 +1900,12 @@ func TestIngester_flushing(t *testing.T) {
 				i.FlushHandler(httptest.NewRecorder(), httptest.NewRequest("POST", "/flush", nil))
 
 				// Flush handler only triggers compactions, but doesn't wait for them to finish. Let's wait for a moment, and then verify.
-				test.Poll(t, 1*time.Second, true, func() interface{} {
+				test.Poll(t, 5*time.Second, uint64(0), func() interface{} {
 					db := i.getTSDB(userID)
 					if db == nil {
 						return false
 					}
-					return db.Head().NumSeries() == 0
+					return db.Head().NumSeries()
 				})
 
 				// The above waiting only ensures compaction, waiting another second to register the Sync call.

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -84,9 +84,26 @@ func TestTSDBMetrics(t *testing.T) {
 			# TYPE cortex_ingester_tsdb_wal_truncations_total counter
 			cortex_ingester_tsdb_wal_truncations_total 1387834
 
+			# HELP cortex_ingester_tsdb_wal_corruptions_total Total number of TSDB WAL corruptions.
+			# TYPE cortex_ingester_tsdb_wal_corruptions_total counter
+			cortex_ingester_tsdb_wal_corruptions_total 2.676537e+06
+
 			# HELP cortex_ingester_tsdb_wal_writes_failed_total Total number of TSDB WAL writes that failed.
 			# TYPE cortex_ingester_tsdb_wal_writes_failed_total counter
 			cortex_ingester_tsdb_wal_writes_failed_total 1486965
+
+			# HELP cortex_ingester_tsdb_head_truncations_failed_total Total number of TSDB head truncations that failed.
+			# TYPE cortex_ingester_tsdb_head_truncations_failed_total counter
+			cortex_ingester_tsdb_head_truncations_failed_total 2.775668e+06
+
+			# HELP cortex_ingester_tsdb_head_truncations_total Total number of TSDB head truncations attempted.
+			# TYPE cortex_ingester_tsdb_head_truncations_total counter
+			cortex_ingester_tsdb_head_truncations_total 2.874799e+06
+
+			# HELP cortex_ingester_tsdb_head_gc_duration_seconds Runtime of garbage collection in the TSDB head.
+			# TYPE cortex_ingester_tsdb_head_gc_duration_seconds summary
+			cortex_ingester_tsdb_head_gc_duration_seconds_sum 9
+			cortex_ingester_tsdb_head_gc_duration_seconds_count 3
 
 			# HELP cortex_ingester_tsdb_checkpoint_deletions_failed_total Total number of TSDB checkpoint deletions that failed.
 			# TYPE cortex_ingester_tsdb_checkpoint_deletions_failed_total counter
@@ -308,6 +325,30 @@ func populateTSDBMetrics(base float64) *prometheus.Registry {
 		Help: "Total number of memory-mapped chunk corruptions.",
 	})
 	mmapChunkCorruptionTotal.Add(26 * base)
+
+	walCorruptionsTotal := promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_wal_corruptions_total",
+		Help: "Total number of WAL corruptions.",
+	})
+	walCorruptionsTotal.Add(27 * base)
+
+	headTruncateFail := promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_head_truncations_failed_total",
+		Help: "Total number of head truncations that failed.",
+	})
+	headTruncateFail.Add(28 * base)
+
+	headTruncateTotal := promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_head_truncations_total",
+		Help: "Total number of head truncations attempted.",
+	})
+	headTruncateTotal.Add(29 * base)
+
+	gcDuration := promauto.With(r).NewSummary(prometheus.SummaryOpts{
+		Name: "prometheus_tsdb_head_gc_duration_seconds",
+		Help: "Runtime of garbage collection in the head block.",
+	})
+	gcDuration.Observe(3)
 
 	return r
 }


### PR DESCRIPTION
**What this PR does**:
In past few days we experienced TSDB WAL corruption twice. Given the root cause investigation (and possible fix) is a separate issue, I've also realised we're not mapping all TSDB metrics so in this PR I'm fixing this gap.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
