### PR TITLE
Add topology aware read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master / unreleased
 
 * [CHANGE] Querier: deprecated `-store.max-look-back-period`. You should use `-querier.max-query-lookback` instead. #3452
-* [FEATURE] Add support for zone aware reads. #3414
+* [ENHANCEMENT] Added zone-awareness support on queries. When zone-awareness is enabled, queries will still succeed if all ingesters in a single zone will fail. #3414
 * [ENHANCEMENT] Blocks storage ingester: exported more TSDB-related metrics. #3412
   - `cortex_ingester_tsdb_wal_corruptions_total`
   - `cortex_ingester_tsdb_head_truncations_failed_total`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [CHANGE] Querier: deprecated `-store.max-look-back-period`. You should use `-querier.max-query-lookback` instead. #3452
+* [FEATURE] Add support for zone aware reads. #3414
 * [ENHANCEMENT] Blocks storage ingester: exported more TSDB-related metrics. #3412
   - `cortex_ingester_tsdb_wal_corruptions_total`
   - `cortex_ingester_tsdb_head_truncations_failed_total`

--- a/docs/guides/zone-replication.md
+++ b/docs/guides/zone-replication.md
@@ -11,6 +11,8 @@ It is completely possible that all the replicas for the given data are held with
 
 For this reason, Cortex optionally supports zone-aware replication. When zone-aware replication is **enabled**, replicas for the given data are guaranteed to span across different availability zones. This requires Cortex cluster to run at least in a number of zones equal to the configured replication factor.
 
+Reads from a zone-aware replication enabled Cortex Cluster can withstand zone failures as long as there are more than replication factor / 2 zones available without any failing instances. 
+
 The Cortex services supporting **zone-aware replication** are:
 
 - **[Distributors and Ingesters](#distributors-and-ingesters-time-series-replication)**

--- a/docs/guides/zone-replication.md
+++ b/docs/guides/zone-replication.md
@@ -11,7 +11,7 @@ It is completely possible that all the replicas for the given data are held with
 
 For this reason, Cortex optionally supports zone-aware replication. When zone-aware replication is **enabled**, replicas for the given data are guaranteed to span across different availability zones. This requires Cortex cluster to run at least in a number of zones equal to the configured replication factor.
 
-Reads from a zone-aware replication enabled Cortex Cluster can withstand zone failures as long as there are more than replication factor / 2 zones available without any failing instances. 
+Reads from a zone-aware replication enabled Cortex Cluster can withstand zone failures as long as there are more than replication factor / 2 zones available without any failing instances.
 
 The Cortex services supporting **zone-aware replication** are:
 

--- a/docs/guides/zone-replication.md
+++ b/docs/guides/zone-replication.md
@@ -26,6 +26,8 @@ The Cortex time-series replication is used to hold multiple (typically 3) replic
 2. Rollout ingesters to apply the configured zone
 3. Enable time-series zone-aware replication via the `-distributor.zone-awareness-enabled` CLI flag (or its respective YAML config option). Please be aware this configuration option should be set to distributors, queriers and rulers.
 
+The `-distributor.shard-by-all-labels` setting has an impact on zone replication. When set to `true` there will be more series stored that will be spread out over more instances. When an instance goes down fewer series will be impacted.
+
 ## Store-gateways: blocks replication
 
 The Cortex [store-gateway](../blocks-storage/store-gateway.md) (used only when Cortex is running with the [blocks storage](../blocks-storage/_index.md)) supports blocks sharding, used to horizontally scale blocks in a large cluster without hitting any vertical scalability limit.

--- a/docs/guides/zone-replication.md
+++ b/docs/guides/zone-replication.md
@@ -11,7 +11,7 @@ It is completely possible that all the replicas for the given data are held with
 
 For this reason, Cortex optionally supports zone-aware replication. When zone-aware replication is **enabled**, replicas for the given data are guaranteed to span across different availability zones. This requires Cortex cluster to run at least in a number of zones equal to the configured replication factor.
 
-Reads from a zone-aware replication enabled Cortex Cluster can withstand zone failures as long as there are more than replication factor / 2 zones available without any failing instances.
+Reads from a zone-aware replication enabled Cortex Cluster can withstand zone failures as long as there are no more than `floor(replication factor / 2)` zones with failing instances.
 
 The Cortex services supporting **zone-aware replication** are:
 
@@ -28,7 +28,9 @@ The Cortex time-series replication is used to hold multiple (typically 3) replic
 2. Rollout ingesters to apply the configured zone
 3. Enable time-series zone-aware replication via the `-distributor.zone-awareness-enabled` CLI flag (or its respective YAML config option). Please be aware this configuration option should be set to distributors, queriers and rulers.
 
-The `-distributor.shard-by-all-labels` setting has an impact on zone replication. When set to `true` there will be more series stored that will be spread out over more instances. When an instance goes down fewer series will be impacted.
+The `-distributor.shard-by-all-labels` setting has an impact on read availability. When enabled, a metric is sharded across all ingesters and querier needs to fetch series from all ingesters while, when disabled, a metric is sharded only across `<replication factor>` ingesters.
+
+In the event of a large outage impacting ingesters in more than 1 zone, when `-distributor.shard-by-all-labels=true` all queries will fail, while when disabled some queries may still succeed if the ingesters holding the required metric are not impacted by the outage.
 
 ## Store-gateways: blocks replication
 

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -172,6 +172,11 @@ func (s *ConcreteService) Kill() error {
 		logger.Log(string(out))
 		return err
 	}
+
+	// Wait until the container actually stopped. However, this could fail if
+	// the container already exited, so we just ignore the error.
+	_, _ = RunCommandAndGetOutput("docker", "wait", s.containerName())
+
 	s.usedNetworkName = ""
 
 	return nil

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -168,7 +168,7 @@ func (s *ConcreteService) Kill() error {
 
 	logger.Log("Killing", s.name)
 
-	if out, err := RunCommandAndGetOutput("docker", "stop", "--time=0", s.containerName()); err != nil {
+	if out, err := RunCommandAndGetOutput("docker", "kill", s.containerName()); err != nil {
 		logger.Log(string(out))
 		return err
 	}

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -153,7 +153,6 @@ func (c *Client) QueryRaw(query string) (*http.Response, []byte, error) {
 }
 
 func (c *Client) query(addr string) (*http.Response, []byte, error) {
-
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 

--- a/integration/zone_aware_test.go
+++ b/integration/zone_aware_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/integration/e2e"
-	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
-	"github.com/cortexproject/cortex/integration/e2ecortex"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/integration/e2e"
+	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
+	"github.com/cortexproject/cortex/integration/e2ecortex"
 )
 
 func TestZoneAwareReadPath(t *testing.T) {

--- a/integration/zone_aware_test.go
+++ b/integration/zone_aware_test.go
@@ -1,0 +1,124 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cortexproject/cortex/integration/e2e"
+	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
+	"github.com/cortexproject/cortex/integration/e2ecortex"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZoneAwareReadPath(t *testing.T) {
+	const numSeriesToPush = 100
+
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	flags := BlocksStorageFlags()
+
+	// Start dependencies.
+	consul := e2edb.NewConsul()
+	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+	require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+	// Start Cortex components.
+	zoneFlags := func(zone string) map[string]string {
+		zoneflags := mergeFlags(flags, map[string]string{
+			"-ingester.availability-zone":         zone,
+			"-distributor.replication-factor":     "3",
+			"-distributor.zone-awareness-enabled": "true",
+		})
+		return zoneflags
+	}
+
+	zoneAwarenessEnabledFlags := mergeFlags(flags, map[string]string{
+		"-distributor.zone-awareness-enabled": "true",
+		"-distributor.replication-factor":     "3",
+	})
+
+	ingester1 := e2ecortex.NewIngesterWithConfigFile("ingester-1", consul.NetworkHTTPEndpoint(), "", zoneFlags("zone-a"), "")
+	ingester2 := e2ecortex.NewIngesterWithConfigFile("ingester-2", consul.NetworkHTTPEndpoint(), "", zoneFlags("zone-a"), "")
+	ingester3 := e2ecortex.NewIngesterWithConfigFile("ingester-3", consul.NetworkHTTPEndpoint(), "", zoneFlags("zone-b"), "")
+	ingester4 := e2ecortex.NewIngesterWithConfigFile("ingester-4", consul.NetworkHTTPEndpoint(), "", zoneFlags("zone-b"), "")
+	ingester5 := e2ecortex.NewIngesterWithConfigFile("ingester-5", consul.NetworkHTTPEndpoint(), "", zoneFlags("zone-c"), "")
+	ingester6 := e2ecortex.NewIngesterWithConfigFile("ingester-6", consul.NetworkHTTPEndpoint(), "", zoneFlags("zone-c"), "")
+	require.NoError(t, s.StartAndWaitReady(ingester1, ingester2, ingester3, ingester4, ingester5, ingester6))
+
+	distributor := e2ecortex.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), zoneAwarenessEnabledFlags, "")
+	querier := e2ecortex.NewQuerier("querier", consul.NetworkHTTPEndpoint(), zoneAwarenessEnabledFlags, "")
+	require.NoError(t, s.StartAndWaitReady(distributor, querier))
+
+	// Wait until distributor and queriers have updated the ring.
+	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(6), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(6), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	client, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
+	require.NoError(t, err)
+
+	// Push 100 series
+	now := time.Now()
+	expectedVectors := map[string]model.Vector{}
+
+	for i := 1; i <= numSeriesToPush; i++ {
+		metricName := fmt.Sprintf("series_%d", i)
+		series, expectedVector := generateSeries(metricName, now)
+		res, err := client.Push(series)
+		require.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+
+		expectedVectors[metricName] = expectedVector
+	}
+
+	// Query back 100 series => all good
+	for metricName, expectedVector := range expectedVectors {
+		result, err := client.Query(metricName, now)
+		require.NoError(t, err)
+		require.Equal(t, model.ValVector, result.Type())
+		assert.Equal(t, expectedVector, result.(model.Vector))
+	}
+
+	// SIGKILL 1 ingester in 1 zone
+	require.NoError(t, ingester5.Kill())
+
+	// Query back 100 series => all good
+	for metricName, expectedVector := range expectedVectors {
+		result, err := client.Query(metricName, now)
+		require.NoError(t, err)
+		require.Equal(t, model.ValVector, result.Type())
+		assert.Equal(t, expectedVector, result.(model.Vector))
+	}
+
+	// SIGKILL 1 more ingester in the same zone
+	require.NoError(t, ingester6.Kill())
+
+	// Query back 100 series => all good
+	for metricName, expectedVector := range expectedVectors {
+		result, err := client.Query(metricName, now)
+		require.NoError(t, err)
+		require.Equal(t, model.ValVector, result.Type())
+		assert.Equal(t, expectedVector, result.(model.Vector))
+	}
+
+	// SIGKILL 1 more ingester in a different zone
+	require.NoError(t, ingester1.Kill())
+
+	// Query back 100 series => fail
+	for i := 1; i <= numSeriesToPush; i++ {
+		metricName := fmt.Sprintf("series_%d", i)
+		result, _, err := client.QueryRaw(metricName)
+		require.NoError(t, err)
+		require.Equal(t, 500, result.StatusCode)
+	}
+}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1487,6 +1487,9 @@ func (i *mockIngester) MetricsMetadata(ctx context.Context, req *client.MetricsM
 }
 
 func (i *mockIngester) trackCall(name string) {
+	i.Lock()
+	defer i.Unlock()
+
 	if i.calls == nil {
 		i.calls = map[string]int{}
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1283,6 +1283,9 @@ func (i *mockIngester) series() map[uint32]*client.PreallocTimeseries {
 }
 
 func (i *mockIngester) Check(ctx context.Context, in *grpc_health_v1.HealthCheckRequest, opts ...grpc.CallOption) (*grpc_health_v1.HealthCheckResponse, error) {
+	i.Lock()
+	defer i.Unlock()
+
 	i.trackCall("Check")
 
 	return &grpc_health_v1.HealthCheckResponse{}, nil
@@ -1487,9 +1490,6 @@ func (i *mockIngester) MetricsMetadata(ctx context.Context, req *client.MetricsM
 }
 
 func (i *mockIngester) trackCall(name string) {
-	i.Lock()
-	defer i.Unlock()
-
 	if i.calls == nil {
 		i.calls = map[string]int{}
 	}

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-var errorTooManyZoneFailures = errors.New("Too many zones failed")
+var errorTooManyZoneFailures = errors.New("too many zones failed")
 
 // ReplicationSet describes the ingesters to talk to for a given key, and how
 // many errors to tolerate.

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -63,13 +63,13 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 		numErrs          int
 		numSuccess       int
 		results          = make([]interface{}, 0, len(r.Ingesters))
-		zoneFailureCount = make(map[string]int)
+		zoneFailureCount = make(map[string]struct{})
 	)
 	for numSuccess < minSuccess {
 		select {
 		case err := <-errs:
 			if r.MaxUnavailableZones > 0 {
-				zoneFailureCount[err.instance.Zone]++
+				zoneFailureCount[err.instance.Zone] = struct{}{}
 
 				if len(zoneFailureCount) > r.MaxUnavailableZones {
 					return nil, errorTooManyZoneFailures

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -2,22 +2,32 @@ package ring
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sort"
 	"time"
 )
 
+var errorTooManyZoneFailures = errors.New("Too many zones failed")
+
 // ReplicationSet describes the ingesters to talk to for a given key, and how
 // many errors to tolerate.
 type ReplicationSet struct {
-	Ingesters []IngesterDesc
-	MaxErrors int
+	Ingesters           []IngesterDesc
+	MaxErrors           int
+	MaxUnavailableZones int
+}
+
+type ingesterError struct {
+	err error
+	ing *IngesterDesc
 }
 
 // Do function f in parallel for all replicas in the set, erroring is we exceed
 // MaxErrors and returning early otherwise.
 func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(context.Context, *IngesterDesc) (interface{}, error)) ([]interface{}, error) {
 	var (
-		errs        = make(chan error, len(r.Ingesters))
+		errs        = make(chan ingesterError, len(r.Ingesters))
 		resultsChan = make(chan interface{}, len(r.Ingesters))
 		minSuccess  = len(r.Ingesters) - r.MaxErrors
 		forceStart  = make(chan struct{}, r.MaxErrors)
@@ -38,9 +48,14 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 				case <-after.C:
 				}
 			}
+			fmt.Printf("About to run for addr %v and zone %v\n", ing.Addr, ing.Zone)
 			result, err := f(ctx, ing)
+			fmt.Printf("Addr %v and zone %v result %v\n", ing.Addr, ing.Zone, err)
 			if err != nil {
-				errs <- err
+				errs <- ingesterError{
+					err: err,
+					ing: ing,
+				}
 			} else {
 				resultsChan <- result
 			}
@@ -48,17 +63,37 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 	}
 
 	var (
-		numErrs    int
-		numSuccess int
-		results    = make([]interface{}, 0, len(r.Ingesters))
+		numErrs          int
+		numSuccess       int
+		results          = make([]interface{}, 0, len(r.Ingesters))
+		zoneFailureCount = make(map[string]int)
 	)
+	fmt.Printf("minSuccess %v\n", minSuccess)
 	for numSuccess < minSuccess {
+		fmt.Printf("numSuccess %v\n", numSuccess)
 		select {
 		case err := <-errs:
 			numErrs++
-			if numErrs > r.MaxErrors {
-				return nil, err
+
+			if r.MaxUnavailableZones > 0 {
+				// Non zone aware path
+				fmt.Printf("Incrementing count for Zone %v\n", err.ing.Zone)
+				zoneFailureCount[err.ing.Zone]++
+				fmt.Printf("Count map %v\n", zoneFailureCount)
+
+				if len(zoneFailureCount) > r.MaxUnavailableZones {
+					return nil, errorTooManyZoneFailures
+				}
+			} else {
+				// Non zone aware path
+				// Errors per zone : only RF-1 zone can be failing
+				// if failingZones > r.MaxUnavailableZones
+
+				if numErrs > r.MaxErrors {
+					return nil, err.err
+				}
 			}
+
 			// force one of the delayed requests to start
 			forceStart <- struct{}{}
 

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -71,7 +71,7 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 			numErrs++
 
 			if r.MaxUnavailableZones > 0 {
-				// Non zone aware path
+				// Zone aware path
 				zoneFailureCount[err.ing.Zone]++
 
 				if len(zoneFailureCount) > r.MaxUnavailableZones {

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -9,8 +9,14 @@ import (
 // ReplicationSet describes the ingesters to talk to for a given key, and how
 // many errors to tolerate.
 type ReplicationSet struct {
-	Ingesters           []IngesterDesc
-	MaxErrors           int
+	Ingesters []IngesterDesc
+
+	// Maximum number of tolerated failing instances. Max errors and max unavailable zones are
+	// mutually exclusive.
+	MaxErrors int
+
+	// Maximum number of different zones in which instances can fail. Max unavailable zones and
+	// max errors are mutually exclusive.
 	MaxUnavailableZones int
 }
 

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -3,7 +3,6 @@ package ring
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 	"time"
 )
@@ -48,9 +47,7 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 				case <-after.C:
 				}
 			}
-			fmt.Printf("About to run for addr %v and zone %v\n", ing.Addr, ing.Zone)
 			result, err := f(ctx, ing)
-			fmt.Printf("Addr %v and zone %v result %v\n", ing.Addr, ing.Zone, err)
 			if err != nil {
 				errs <- ingesterError{
 					err: err,
@@ -68,18 +65,14 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 		results          = make([]interface{}, 0, len(r.Ingesters))
 		zoneFailureCount = make(map[string]int)
 	)
-	fmt.Printf("minSuccess %v\n", minSuccess)
 	for numSuccess < minSuccess {
-		fmt.Printf("numSuccess %v\n", numSuccess)
 		select {
 		case err := <-errs:
 			numErrs++
 
 			if r.MaxUnavailableZones > 0 {
 				// Non zone aware path
-				fmt.Printf("Incrementing count for Zone %v\n", err.ing.Zone)
 				zoneFailureCount[err.ing.Zone]++
-				fmt.Printf("Count map %v\n", zoneFailureCount)
 
 				if len(zoneFailureCount) > r.MaxUnavailableZones {
 					return nil, errorTooManyZoneFailures

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -127,104 +127,44 @@ func TestReplicationSet_Do(t *testing.T) {
 			expectedError:      context.Canceled,
 		},
 		{
-			name: "max errors = 0, should succeed on all successful instances",
-			instances: []IngesterDesc{{
-				Zone: "zone1",
-			}, {
-				Zone: "zone2",
-			}, {
-				Zone: "zone3",
-			}},
+			name:      "max errors = 0, should succeed on all successful instances",
+			instances: []IngesterDesc{{Zone: "zone1"}, {Zone: "zone2"}, {Zone: "zone3"}},
 			f: func(c context.Context, id *IngesterDesc) (interface{}, error) {
 				return 1, nil
 			},
 			want: []interface{}{1, 1, 1},
 		},
 		{
-			name: "max unavailable zones = 1, should succeed on instances failing in 1 out of 3 zones (3 instances)",
-			instances: []IngesterDesc{{
-				Zone: "zone1",
-			}, {
-				Zone: "zone2",
-			}, {
-				Zone: "zone3",
-			}},
+			name:                "max unavailable zones = 1, should succeed on instances failing in 1 out of 3 zones (3 instances)",
+			instances:           []IngesterDesc{{Zone: "zone1"}, {Zone: "zone2"}, {Zone: "zone3"}},
 			f:                   failingFunctionOnZones("zone1"),
 			maxUnavailableZones: 1,
 			want:                []interface{}{1, 1},
 		},
 		{
-			name: "max unavailable zones = 1, should fail on instances failing in 2 out of 3 zones (3 instances)",
-			instances: []IngesterDesc{{
-				Zone: "zone1",
-			}, {
-				Zone: "zone2",
-			}, {
-				Zone: "zone3",
-			}},
+			name:                "max unavailable zones = 1, should fail on instances failing in 2 out of 3 zones (3 instances)",
+			instances:           []IngesterDesc{{Zone: "zone1"}, {Zone: "zone2"}, {Zone: "zone3"}},
 			f:                   failingFunctionOnZones("zone1", "zone2"),
 			maxUnavailableZones: 1,
 			expectedError:       errZoneFailure,
 		},
 		{
-			name: "max unavailable zones = 1, should succeed on instances failing in 1 out of 3 zones (6 instances)",
-			instances: []IngesterDesc{{
-				Zone: "zone1",
-			}, {
-				Zone: "zone1",
-			}, {
-				Zone: "zone2",
-			}, {
-				Zone: "zone2",
-			}, {
-				Zone: "zone3",
-			}, {
-				Zone: "zone3",
-			}},
+			name:                "max unavailable zones = 1, should succeed on instances failing in 1 out of 3 zones (6 instances)",
+			instances:           []IngesterDesc{{Zone: "zone1"}, {Zone: "zone1"}, {Zone: "zone2"}, {Zone: "zone2"}, {Zone: "zone3"}, {Zone: "zone3"}},
 			f:                   failingFunctionOnZones("zone1"),
 			maxUnavailableZones: 1,
 			want:                []interface{}{1, 1, 1, 1},
 		},
 		{
-			name: "max unavailable zones = 2, should fail on instances failing in 3 out of 5 zones (5 instances)",
-			instances: []IngesterDesc{{
-				Zone: "zone1",
-			}, {
-				Zone: "zone2",
-			}, {
-				Zone: "zone3",
-			}, {
-				Zone: "zone4",
-			}, {
-				Zone: "zone5",
-			}},
+			name:                "max unavailable zones = 2, should fail on instances failing in 3 out of 5 zones (5 instances)",
+			instances:           []IngesterDesc{{Zone: "zone1"}, {Zone: "zone2"}, {Zone: "zone3"}, {Zone: "zone4"}, {Zone: "zone5"}},
 			f:                   failingFunctionOnZones("zone1", "zone2", "zone3"),
 			maxUnavailableZones: 2,
 			expectedError:       errZoneFailure,
 		},
 		{
-			name: "max unavailable zones = 2, should succeed on instances failing in 2 out of 5 zones (10 instances)",
-			instances: []IngesterDesc{{
-				Zone: "zone1",
-			}, {
-				Zone: "zone1",
-			}, {
-				Zone: "zone2",
-			}, {
-				Zone: "zone2",
-			}, {
-				Zone: "zone3",
-			}, {
-				Zone: "zone3",
-			}, {
-				Zone: "zone4",
-			}, {
-				Zone: "zone4",
-			}, {
-				Zone: "zone5",
-			}, {
-				Zone: "zone5",
-			}},
+			name:                "max unavailable zones = 2, should succeed on instances failing in 2 out of 5 zones (10 instances)",
+			instances:           []IngesterDesc{{Zone: "zone1"}, {Zone: "zone1"}, {Zone: "zone2"}, {Zone: "zone2"}, {Zone: "zone3"}, {Zone: "zone3"}, {Zone: "zone4"}, {Zone: "zone4"}, {Zone: "zone5"}, {Zone: "zone5"}},
 			f:                   failingFunctionOnZones("zone1", "zone5"),
 			maxUnavailableZones: 2,
 			want:                []interface{}{1, 1, 1, 1, 1, 1},
@@ -245,11 +185,9 @@ func TestReplicationSet_Do(t *testing.T) {
 			if tt.cancelContextDelay > 0 {
 				var cancel context.CancelFunc
 				ctx, cancel = context.WithCancel(ctx)
-				go func() {
-					time.AfterFunc(tt.cancelContextDelay, func() {
-						cancel()
-					})
-				}()
+				time.AfterFunc(tt.cancelContextDelay, func() {
+					cancel()
+				})
 			}
 			got, err := r.Do(ctx, tt.delay, tt.f)
 			if tt.expectedError != nil {

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -3,11 +3,11 @@ package ring
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
 )
 
 func TestReplicationSet_GetAddresses(t *testing.T) {
@@ -44,26 +44,11 @@ var (
 )
 
 // Return a function that fails starting from failAfter times
-func failingFunctionAfter(failAfter int, delay time.Duration) func(context.Context, *IngesterDesc) (interface{}, error) {
-	var mutex = &sync.RWMutex{}
 func failingFunctionAfter(failAfter int32, delay time.Duration) func(context.Context, *IngesterDesc) (interface{}, error) {
 	count := atomic.NewInt32(0)
 	return func(context.Context, *IngesterDesc) (interface{}, error) {
 		time.Sleep(delay)
 		if count.Inc() > failAfter {
-			return nil, errFailure
-		}
-		return 1, nil
-	}
-}
-	return func(context.Context, *IngesterDesc) (interface{}, error) {
-		mutex.Lock()
-		count++
-		mutex.Unlock()
-		time.Sleep(delay)
-		mutex.RLock()
-		defer mutex.RUnlock()
-		if count > failAfter {
 			return nil, errFailure
 		}
 		return 1, nil

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -203,7 +203,7 @@ func TestReplicationSet_Do(t *testing.T) {
 			expectedError:       errZoneFailure,
 		},
 		{
-			name: "max unavailable zones = 2, should succeed on instances failing in 1 out of 5 zones (10 instances)",
+			name: "max unavailable zones = 2, should succeed on instances failing in 2 out of 5 zones (10 instances)",
 			instances: []IngesterDesc{{
 				Zone: "zone1",
 			}, {
@@ -225,7 +225,7 @@ func TestReplicationSet_Do(t *testing.T) {
 			}, {
 				Zone: "zone5",
 			}},
-			f:                   failingFunctionOnZones("zone1"),
+			f:                   failingFunctionOnZones("zone1", "zone5"),
 			maxUnavailableZones: 2,
 			want:                []interface{}{1, 1, 1, 1, 1, 1},
 		},

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -1,7 +1,10 @@
 package ring
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -30,6 +33,106 @@ func TestReplicationSet_GetAddresses(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			assert.ElementsMatch(t, testData.expected, testData.rs.GetAddresses())
+		})
+	}
+}
+
+// Return a function that fails starting from failAfter times
+func failingFunctionAfter(failAfter int, delay time.Duration) func(context.Context, *IngesterDesc) (interface{}, error) {
+	count := 0
+	return func(context.Context, *IngesterDesc) (interface{}, error) {
+		count++
+		time.Sleep(delay)
+		if count > failAfter {
+			return nil, errors.New("Dummy error")
+		}
+		return 1, nil
+	}
+}
+
+func TestReplicationSet_Do(t *testing.T) {
+	tests := []struct {
+		name              string
+		ingesters         []IngesterDesc
+		maxErrors         int
+		f                 func(context.Context, *IngesterDesc) (interface{}, error)
+		delay             time.Duration
+		closeContextDelay time.Duration
+		want              []interface{}
+		wantErr           bool
+		expectedError     error
+	}{
+		{
+			name: "no errors no delay",
+			ingesters: []IngesterDesc{
+				{},
+			},
+			f: func(c context.Context, id *IngesterDesc) (interface{}, error) {
+				return 1, nil
+			},
+			want: []interface{}{1},
+		},
+		{
+			name:      "1 error, no errors expected",
+			ingesters: []IngesterDesc{{}},
+			f: func(c context.Context, id *IngesterDesc) (interface{}, error) {
+				return nil, errors.New("Dummy error")
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:      "3 ingesters, last call fails",
+			ingesters: []IngesterDesc{{}, {}, {}},
+			f:         failingFunctionAfter(2, 10*time.Millisecond),
+			want:      nil,
+			wantErr:   true,
+		},
+		{
+			name:      "5 ingesters, with delay, last 3 calls fail",
+			ingesters: []IngesterDesc{{}, {}, {}, {}, {}},
+			maxErrors: 1,
+			f:         failingFunctionAfter(2, 10*time.Millisecond),
+			delay:     100 * time.Millisecond,
+			want:      nil,
+			wantErr:   true,
+		},
+		{
+			name:              "3 ingesters, context fails",
+			ingesters:         []IngesterDesc{{}, {}, {}},
+			maxErrors:         1,
+			f:                 failingFunctionAfter(0, 200*time.Millisecond),
+			closeContextDelay: 100 * time.Millisecond,
+			want:              nil,
+			wantErr:           true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := ReplicationSet{
+				Ingesters: tt.ingesters,
+				MaxErrors: tt.maxErrors,
+			}
+			ctx := context.Background()
+			if tt.closeContextDelay > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				go func() {
+					time.AfterFunc(tt.closeContextDelay, func() {
+						cancel()
+					})
+				}()
+			}
+			got, err := r.Do(ctx, tt.delay, tt.f)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedError != nil {
+					assert.Equal(t, tt.expectedError, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -46,7 +46,16 @@ var (
 // Return a function that fails starting from failAfter times
 func failingFunctionAfter(failAfter int, delay time.Duration) func(context.Context, *IngesterDesc) (interface{}, error) {
 	var mutex = &sync.RWMutex{}
-	count := 0
+func failingFunctionAfter(failAfter int32, delay time.Duration) func(context.Context, *IngesterDesc) (interface{}, error) {
+	count := atomic.NewInt32(0)
+	return func(context.Context, *IngesterDesc) (interface{}, error) {
+		time.Sleep(delay)
+		if count.Inc() > failAfter {
+			return nil, errFailure
+		}
+		return 1, nil
+	}
+}
 	return func(context.Context, *IngesterDesc) (interface{}, error) {
 		mutex.Lock()
 		count++

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -165,7 +165,7 @@ func TestReplicationSet_Do(t *testing.T) {
 			f:                   failingFunctionForZones("zone1", "zone2"),
 			maxUnavailableZones: 1,
 			maxErrors:           1,
-			expectedError:       errorTooManyZoneFailures,
+			expectedError:       errZoneFailure,
 		},
 		{
 			name: "6 instances, 3 zones, 1 zone fails",
@@ -203,7 +203,7 @@ func TestReplicationSet_Do(t *testing.T) {
 			f:                   failingFunctionForZones("zone1", "zone2", "zone3"),
 			maxUnavailableZones: 2,
 			maxErrors:           2,
-			expectedError:       errorTooManyZoneFailures,
+			expectedError:       errZoneFailure,
 		},
 		{
 			name: "10 instances, 5 zones, 2 failures in zone 1",

--- a/pkg/ring/replication_set_tracker.go
+++ b/pkg/ring/replication_set_tracker.go
@@ -1,0 +1,104 @@
+package ring
+
+import "github.com/cortexproject/cortex/pkg/util"
+
+type replicationSetResultTracker interface {
+	// TODO doc
+	done(instance *IngesterDesc, err error)
+
+	// TODO doc
+	succeeded() bool
+
+	// TODO doc
+	failed() bool
+}
+
+type defaultResultTracker struct {
+	minSucceeded int
+	numSucceeded int
+	numErrors    int
+	maxErrors    int
+}
+
+func newDefaultResultTracker(instances []IngesterDesc, maxErrors int) *defaultResultTracker {
+	return &defaultResultTracker{
+		minSucceeded: len(instances) - maxErrors,
+		numSucceeded: 0,
+		numErrors:    0,
+		maxErrors:    maxErrors,
+	}
+}
+
+func (t *defaultResultTracker) done(instance *IngesterDesc, err error) {
+	if err == nil {
+		t.numSucceeded++
+	} else {
+		t.numErrors++
+	}
+}
+
+func (t *defaultResultTracker) succeeded() bool {
+	return t.numSucceeded >= t.minSucceeded
+}
+
+func (t *defaultResultTracker) failed() bool {
+	return t.numErrors > t.maxErrors
+}
+
+type zoneAwareResultTracker struct {
+	waitingByZone       map[string]int
+	failuresByZone      map[string]int
+	maxUnavailableZones int
+}
+
+func newZoneAwareResultTracker(instances []IngesterDesc, maxUnavailableZones int) *zoneAwareResultTracker {
+	t := &zoneAwareResultTracker{
+		waitingByZone:       make(map[string]int),
+		failuresByZone:      make(map[string]int),
+		maxUnavailableZones: maxUnavailableZones,
+	}
+
+	for _, instance := range instances {
+		t.waitingByZone[instance.Zone]++
+		t.failuresByZone[instance.Zone] = 0
+	}
+
+	return t
+}
+
+func (t *zoneAwareResultTracker) done(instance *IngesterDesc, err error) {
+	t.waitingByZone[instance.Zone]--
+
+	if err != nil {
+		t.failuresByZone[instance.Zone]++
+	}
+}
+
+func (t *zoneAwareResultTracker) succeeded() bool {
+	minSucceededZones := util.Max(0, len(t.waitingByZone)-t.maxUnavailableZones)
+	actualSucceededZones := 0
+
+	// The execution succeeded once we successfully received a successful result
+	// from "all zones - max unavailable zones".
+	for zone, numWaiting := range t.waitingByZone {
+		if numWaiting == 0 && t.failuresByZone[zone] == 0 {
+			actualSucceededZones++
+		}
+	}
+
+	return actualSucceededZones >= minSucceededZones
+}
+
+func (t *zoneAwareResultTracker) failed() bool {
+	failedZones := 0
+
+	// The execution failed if the number of zones, for which we have tracker at least 1
+	// failure, exceeds the max unavailable zones.
+	for _, numFailures := range t.failuresByZone {
+		if numFailures > 0 {
+			failedZones++
+		}
+	}
+
+	return failedZones > t.maxUnavailableZones
+}

--- a/pkg/ring/replication_set_tracker_test.go
+++ b/pkg/ring/replication_set_tracker_test.go
@@ -1,0 +1,266 @@
+package ring
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultResultTracker(t *testing.T) {
+	instance1 := IngesterDesc{Addr: "127.0.0.1"}
+	instance2 := IngesterDesc{Addr: "127.0.0.2"}
+	instance3 := IngesterDesc{Addr: "127.0.0.3"}
+	instance4 := IngesterDesc{Addr: "127.0.0.4"}
+
+	tests := map[string]struct {
+		instances []IngesterDesc
+		maxErrors int
+		run       func(t *testing.T, tracker *defaultResultTracker)
+	}{
+		"should succeed on no instances to track": {
+			instances: nil,
+			maxErrors: 0,
+			run: func(t *testing.T, tracker *defaultResultTracker) {
+				assert.True(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+			},
+		},
+		"should succeed once all instances succeed on max errors = 0": {
+			instances: []IngesterDesc{instance1, instance2, instance3, instance4},
+			maxErrors: 0,
+			run: func(t *testing.T, tracker *defaultResultTracker) {
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance1, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance2, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance3, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance4, nil)
+				assert.True(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+			},
+		},
+		"should fail on 1st failing instance on max errors = 0": {
+			instances: []IngesterDesc{instance1, instance2, instance3, instance4},
+			maxErrors: 0,
+			run: func(t *testing.T, tracker *defaultResultTracker) {
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance1, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance2, errors.New("test"))
+				assert.False(t, tracker.succeeded())
+				assert.True(t, tracker.failed())
+			},
+		},
+		"should fail on 2nd failing instance on max errors = 1": {
+			instances: []IngesterDesc{instance1, instance2, instance3, instance4},
+			maxErrors: 1,
+			run: func(t *testing.T, tracker *defaultResultTracker) {
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance1, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance2, errors.New("test"))
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance3, errors.New("test"))
+				assert.False(t, tracker.succeeded())
+				assert.True(t, tracker.failed())
+			},
+		},
+		"should fail on 3rd failing instance on max errors = 2": {
+			instances: []IngesterDesc{instance1, instance2, instance3, instance4},
+			maxErrors: 2,
+			run: func(t *testing.T, tracker *defaultResultTracker) {
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance1, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance2, errors.New("test"))
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance3, errors.New("test"))
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance4, errors.New("test"))
+				assert.False(t, tracker.succeeded())
+				assert.True(t, tracker.failed())
+			},
+		},
+	}
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			testCase.run(t, newDefaultResultTracker(testCase.instances, testCase.maxErrors))
+		})
+	}
+}
+
+func TestZoneAwareResultTracker(t *testing.T) {
+	instance1 := IngesterDesc{Addr: "127.0.0.1", Zone: "zone-a"}
+	instance2 := IngesterDesc{Addr: "127.0.0.2", Zone: "zone-a"}
+	instance3 := IngesterDesc{Addr: "127.0.0.3", Zone: "zone-b"}
+	instance4 := IngesterDesc{Addr: "127.0.0.4", Zone: "zone-b"}
+	instance5 := IngesterDesc{Addr: "127.0.0.5", Zone: "zone-c"}
+	instance6 := IngesterDesc{Addr: "127.0.0.6", Zone: "zone-c"}
+
+	tests := map[string]struct {
+		instances           []IngesterDesc
+		maxUnavailableZones int
+		run                 func(t *testing.T, tracker *zoneAwareResultTracker)
+	}{
+		"should succeed on no instances to track": {
+			instances:           nil,
+			maxUnavailableZones: 0,
+			run: func(t *testing.T, tracker *zoneAwareResultTracker) {
+				assert.True(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+			},
+		},
+		"should succeed once all instances succeed on max unavailable zones = 0": {
+			instances:           []IngesterDesc{instance1, instance2, instance3},
+			maxUnavailableZones: 0,
+			run: func(t *testing.T, tracker *zoneAwareResultTracker) {
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance1, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance2, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance3, nil)
+				assert.True(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+			},
+		},
+		"should fail on 1st failing instance on max unavailable zones = 0": {
+			instances:           []IngesterDesc{instance1, instance2, instance3, instance4, instance5, instance6},
+			maxUnavailableZones: 0,
+			run: func(t *testing.T, tracker *zoneAwareResultTracker) {
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance1, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance2, errors.New("test"))
+				assert.False(t, tracker.succeeded())
+				assert.True(t, tracker.failed())
+			},
+		},
+		"should succeed on 2 failing instances within the same zone on max unavailable zones = 1": {
+			instances:           []IngesterDesc{instance1, instance2, instance3, instance4, instance5, instance6},
+			maxUnavailableZones: 1,
+			run: func(t *testing.T, tracker *zoneAwareResultTracker) {
+				// Track failing instances.
+				for _, instance := range []IngesterDesc{instance1, instance2} {
+					tracker.done(&instance, errors.New("test"))
+					assert.False(t, tracker.succeeded())
+					assert.False(t, tracker.failed())
+				}
+
+				// Track successful instances.
+				for _, instance := range []IngesterDesc{instance3, instance4, instance5} {
+					tracker.done(&instance, nil)
+					assert.False(t, tracker.succeeded())
+					assert.False(t, tracker.failed())
+				}
+
+				tracker.done(&instance6, nil)
+				assert.True(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+			},
+		},
+		"should succeed as soon as the response has been successfully received from 'all zones - 1' on max unavailable zones = 1": {
+			instances:           []IngesterDesc{instance1, instance2, instance3, instance4, instance5, instance6},
+			maxUnavailableZones: 1,
+			run: func(t *testing.T, tracker *zoneAwareResultTracker) {
+				// Track successful instances.
+				for _, instance := range []IngesterDesc{instance1, instance2, instance3} {
+					tracker.done(&instance, nil)
+					assert.False(t, tracker.succeeded())
+					assert.False(t, tracker.failed())
+				}
+
+				tracker.done(&instance4, nil)
+				assert.True(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+			},
+		},
+		"should succeed on failing instances within 2 zones on max unavailable zones = 2": {
+			instances:           []IngesterDesc{instance1, instance2, instance3, instance4, instance5, instance6},
+			maxUnavailableZones: 2,
+			run: func(t *testing.T, tracker *zoneAwareResultTracker) {
+				// Track failing instances.
+				for _, instance := range []IngesterDesc{instance1, instance2, instance3, instance4} {
+					tracker.done(&instance, errors.New("test"))
+					assert.False(t, tracker.succeeded())
+					assert.False(t, tracker.failed())
+				}
+
+				// Track successful instances.
+				tracker.done(&instance5, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				tracker.done(&instance6, nil)
+				assert.True(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+			},
+		},
+		"should succeed as soon as the response has been successfully received from 'all zones - 2' on max unavailable zones = 2": {
+			instances:           []IngesterDesc{instance1, instance2, instance3, instance4, instance5, instance6},
+			maxUnavailableZones: 2,
+			run: func(t *testing.T, tracker *zoneAwareResultTracker) {
+				// Zone-a
+				tracker.done(&instance1, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				// Zone-b
+				tracker.done(&instance3, nil)
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+
+				// Zone-a
+				tracker.done(&instance1, nil)
+				assert.True(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+			},
+		},
+	}
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			testCase.run(t, newZoneAwareResultTracker(testCase.instances, testCase.maxUnavailableZones))
+		})
+	}
+}

--- a/pkg/ring/replication_set_tracker_test.go
+++ b/pkg/ring/replication_set_tracker_test.go
@@ -251,7 +251,7 @@ func TestZoneAwareResultTracker(t *testing.T) {
 				assert.False(t, tracker.failed())
 
 				// Zone-a
-				tracker.done(&instance1, nil)
+				tracker.done(&instance2, nil)
 				assert.True(t, tracker.succeeded())
 				assert.False(t, tracker.failed())
 			},

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -371,7 +371,11 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 	}
 	maxUnavailable := r.cfg.ReplicationFactor / 2
 	numRequired -= maxUnavailable
-	maxUnavailableZones := maxUnavailable
+	numRequiredZones := len(r.ringZones)
+	if len(r.ringZones) > r.cfg.ReplicationFactor {
+		numRequiredZones = r.cfg.ReplicationFactor
+	}
+	maxUnavailableZones := util.Max(0, numRequiredZones-maxUnavailable-1)
 
 	instances := make([]IngesterDesc, 0, len(r.ringDesc.Ingesters))
 	zoneFailures := make(map[string]int)

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -398,6 +398,7 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 			}
 		}
 
+		// TODO when this logic is triggered, we must guarantee that maxErrors is 0
 		instances = filteredInstances
 		maxUnavailableZones = 0
 		numRequired = len(instances)

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -395,7 +395,8 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 			// We remove all instances (even healthy ones) from zones with at least
 			// 1 failing ingester. Due to how replication works when zone-awareness is
 			// enabled (data is replicated to RF different zones), there's no benefit in
-			// querying healthy instances from "failing zones".
+			// querying healthy instances from "failing zones". A zone is considered
+			// failed if there is single error.
 			filteredInstances := make([]IngesterDesc, 0, len(r.ringDesc.Ingesters))
 			for _, ingester := range healthyInstances {
 				if _, ok := zoneFailures[ingester.Zone]; !ok {

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -375,12 +375,12 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 	maxUnavailableZones := util.Max(0, numRequiredZones-maxUnavailable-1)
 
 	instances := make([]IngesterDesc, 0, len(r.ringDesc.Ingesters))
-	zoneFailures := make(map[string]int)
+	zoneFailures := make(map[string]struct{})
 	for _, ingester := range r.ringDesc.Ingesters {
 		if r.IsHealthy(&ingester, op) {
 			instances = append(instances, ingester)
 		} else {
-			zoneFailures[ingester.Zone]++
+			zoneFailures[ingester.Zone] = struct{}{}
 		}
 	}
 

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -385,9 +385,6 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 		// contains instances in a number of zones < RF.
 		numReplicatedZones := util.Min(len(r.ringZones), r.cfg.ReplicationFactor)
 		minSuccessZones := (numReplicatedZones / 2) + 1
-		if r.cfg.ReplicationFactor == 2 && len(r.ringZones) == 2 {
-			minSuccessZones = 1
-		}
 		maxUnavailableZones = numReplicatedZones - minSuccessZones
 
 		if len(zoneFailures) > maxUnavailableZones {

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -385,6 +385,9 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 		// contains instances in a number of zones < RF.
 		numReplicatedZones := util.Min(len(r.ringZones), r.cfg.ReplicationFactor)
 		minSuccessZones := (numReplicatedZones / 2) + 1
+		if r.cfg.ReplicationFactor == 2 && len(r.ringZones) == 2 {
+			minSuccessZones = 1
+		}
 		maxUnavailableZones = numReplicatedZones - minSuccessZones
 
 		if len(zoneFailures) > maxUnavailableZones {

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -371,10 +371,7 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 	}
 	maxUnavailable := r.cfg.ReplicationFactor / 2
 	numRequired -= maxUnavailable
-	numRequiredZones := len(r.ringZones)
-	if len(r.ringZones) > r.cfg.ReplicationFactor {
-		numRequiredZones = r.cfg.ReplicationFactor
-	}
+	numRequiredZones := util.Min(len(r.ringZones), r.cfg.ReplicationFactor)
 	maxUnavailableZones := util.Max(0, numRequiredZones-maxUnavailable-1)
 
 	instances := make([]IngesterDesc, 0, len(r.ringDesc.Ingesters))

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -101,12 +101,8 @@ var (
 	// not registered within the ring.
 	ErrInstanceNotFound = errors.New("instance not found in the ring")
 
-<<<<<<< HEAD
 	// ErrTooManyFailedIngesters is the error returned when there are too many failed ingesters for a
 	// specific operation.
-=======
-	// ErrTooManyFailedIngesters is the error returned when not enough ingesters are available
->>>>>>> Do not return early and add more test cases
 	ErrTooManyFailedIngesters = errors.New("too many failed ingesters")
 )
 
@@ -334,16 +330,6 @@ func (r *Ring) Get(key uint32, op Operation, buf []IngesterDesc) (ReplicationSet
 		Ingesters: liveIngesters,
 		MaxErrors: maxFailure,
 	}, nil
-}
-
-func calculateRequiredInstances(nrInstances, replicationFactor int) int {
-	numRequired := nrInstances
-	if numRequired < replicationFactor {
-		numRequired = replicationFactor
-	}
-	maxUnavailable := replicationFactor / 2
-	numRequired -= maxUnavailable
-	return numRequired
 }
 
 // GetAllHealthy implements ReadRing.

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -383,22 +383,22 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 	// ensure we always require at least RF-1 when RF=3.
 	numRequired := calculateRequiredInstances(len(r.ringDesc.Ingesters), r.cfg.ReplicationFactor)
 
-	ingesters := make([]IngesterDesc, 0, len(r.ringDesc.Ingesters))
+	instances := make([]IngesterDesc, 0, len(r.ringDesc.Ingesters))
 	zoneFailures := make(map[string]int)
 	for _, ingester := range r.ringDesc.Ingesters {
 		if r.IsHealthy(&ingester, op) {
-			ingesters = append(ingesters, ingester)
+			instances = append(instances, ingester)
 
 		} else {
 			zoneFailures[ingester.Zone]++
 		}
 	}
-	maxErrors := len(ingesters) - numRequired
+	maxErrors := len(instances) - numRequired
 
 	if r.cfg.ZoneAwarenessEnabled {
 		filteredInstances := make([]IngesterDesc, 0, len(r.ringDesc.Ingesters))
 		if len(zoneFailures) > 0 {
-			for _, ingester := range ingesters {
+			for _, ingester := range instances {
 				_, present := zoneFailures[ingester.Zone]
 				if !present {
 					filteredInstances = append(filteredInstances, ingester)
@@ -407,19 +407,19 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 		}
 
 		if len(filteredInstances) != 0 {
-			ingesters = filteredInstances
+			instances = filteredInstances
 			maxUnavailableZones = 0
-			numRequired = calculateRequiredInstances(len(ingesters), r.cfg.ReplicationFactor)
+			numRequired = calculateRequiredInstances(len(instances), r.cfg.ReplicationFactor)
 			maxErrors = 0
 		}
 	}
 
-	if len(ingesters) < numRequired {
+	if len(instances) < numRequired {
 		return ReplicationSet{}, ErrTooManyFailedIngesters
 	}
 
 	return ReplicationSet{
-		Ingesters:           ingesters,
+		Ingesters:           instances,
 		MaxErrors:           maxErrors,
 		MaxUnavailableZones: maxUnavailableZones,
 	}, nil

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -385,7 +385,7 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 		// contains instances in a number of zones < RF.
 		numReplicatedZones := util.Min(len(r.ringZones), r.cfg.ReplicationFactor)
 		minSuccessZones := (numReplicatedZones / 2) + 1
-		maxUnavailableZones = numReplicatedZones - minSuccessZones
+		maxUnavailableZones = minSuccessZones - 1
 
 		if len(zoneFailures) > maxUnavailableZones {
 			return ReplicationSet{}, ErrTooManyFailedIngesters

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -442,6 +442,26 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 0,
 		},
+		"single zone, one unhealthy instance": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+			},
+			unhealthyInstances: []string{"instance-2"},
+			replicationFactor:  1,
+			expectedError:      ErrTooManyFailedIngesters,
+		},
+		"three zones, replication factor one, one unhealthy instance": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+			},
+			unhealthyInstances: []string{"instance-3"},
+			replicationFactor:  1,
+			expectedError:      ErrTooManyFailedIngesters,
+		},
 		"three zones, one instance per zone": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -1503,6 +1503,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 					cfg: Config{
 						HeartbeatTimeout:     time.Hour,
 						ZoneAwarenessEnabled: true,
+						ReplicationFactor:    3,
 					},
 					ringDesc:         ringDesc,
 					ringTokens:       ringDesc.getTokens(),

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -572,6 +572,18 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 0,
 		},
+		"five zones, one instances per zone, three unhealthy instances": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+			},
+			unhealthyInstances: []string{"instance-2", "instance-4", "instance-5"},
+			replicationFactor:  5,
+			expectedError:      ErrTooManyFailedIngesters,
+		},
 	}
 
 	for testName, testData := range tests {

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -462,6 +462,25 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 			replicationFactor:  1,
 			expectedError:      ErrTooManyFailedIngesters,
 		},
+		"RF=2, 2 zones": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2"},
+			replicationFactor:           2,
+			expectedMaxUnavailableZones: 1,
+		},
+		"RF=2, 2 zones, one unhealthy instance": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedAddresses:           []string{"127.0.0.1"},
+			unhealthyInstances:          []string{"instance-2"},
+			replicationFactor:           2,
+			expectedMaxUnavailableZones: 0,
+		},
 		"RF=3, 3 zones, one instance per zone": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -418,7 +418,7 @@ func TestRing_GetReplicationSetForOperation(t *testing.T) {
 	}
 }
 
-func TestRing_GetAll_ZoneAware(t *testing.T) {
+func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.T) {
 	tests := map[string]struct {
 		ringInstances               map[string]IngesterDesc
 		unhealthyInstances          []string
@@ -432,7 +432,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			ringInstances: nil,
 			expectedError: ErrEmptyRing,
 		},
-		"single zone": {
+		"RF=1, 1 zone": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
@@ -442,7 +442,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 0,
 		},
-		"single zone, one unhealthy instance": {
+		"RF=1, 1 zone, one unhealthy instance": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
@@ -452,7 +452,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			replicationFactor:  1,
 			expectedError:      ErrTooManyFailedIngesters,
 		},
-		"three zones, replication factor one, one unhealthy instance": {
+		"RF=1, 3 zones, one unhealthy instance": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
@@ -462,7 +462,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			replicationFactor:  1,
 			expectedError:      ErrTooManyFailedIngesters,
 		},
-		"three zones, one instance per zone": {
+		"RF=3, 3 zones, one instance per zone": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
@@ -470,10 +470,10 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"},
 			replicationFactor:           3,
-			expectedMaxErrors:           1,
+			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 1,
 		},
-		"three zones, one instance per zone, one instance unhealthy": {
+		"RF=3, 3 zones, one instance per zone, one instance unhealthy": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
@@ -485,7 +485,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 0,
 		},
-		"three zones, one instance per zone, two instances unhealthy in separate zones": {
+		"RF=3, 3 zones, one instance per zone, two instances unhealthy in separate zones": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
@@ -495,7 +495,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			replicationFactor:  3,
 			expectedError:      ErrTooManyFailedIngesters,
 		},
-		"three zones, one instance per zone, all instances unhealthy": {
+		"RF=3, 3 zones, one instance per zone, all instances unhealthy": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
@@ -505,7 +505,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			replicationFactor:  3,
 			expectedError:      ErrTooManyFailedIngesters,
 		},
-		"three zones, two instances per zone": {
+		"RF=3, 3 zones, two instances per zone": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
@@ -516,10 +516,10 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.5", "127.0.0.6"},
 			replicationFactor:           3,
-			expectedMaxErrors:           1,
+			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 1,
 		},
-		"three zones, two instances per zone, two instances unhealthy in same zone": {
+		"RF=3, 3 zones, two instances per zone, two instances unhealthy in same zone": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
@@ -534,7 +534,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 0,
 		},
-		"three zones, three instances per zone, two instances unhealthy in same zone": {
+		"RF=3, 3 zones, three instances per zone, two instances unhealthy in same zone": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
@@ -552,7 +552,53 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 0,
 		},
-		"five zones, two instances per zone except for one zone which has three": {
+		"RF=3, only 2 zones, two instances per zone": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"},
+			unhealthyInstances:          []string{},
+			replicationFactor:           3,
+			expectedMaxErrors:           0,
+			expectedMaxUnavailableZones: 0,
+		},
+		"RF=3, only 2 zones, two instances per zone, one instance unhealthy": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedAddresses:  []string{},
+			unhealthyInstances: []string{"instance-4"},
+			replicationFactor:  3,
+			expectedError:      ErrTooManyFailedIngesters,
+		},
+		"RF=3, only 1 zone, two instances per zone": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2"},
+			unhealthyInstances:          []string{},
+			replicationFactor:           3,
+			expectedMaxErrors:           0,
+			expectedMaxUnavailableZones: 0,
+		},
+		"RF=3, only 1 zone, two instances per zone, one instance unhealthy": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedAddresses:  []string{},
+			unhealthyInstances: []string{"instance-2"},
+			replicationFactor:  3,
+			expectedError:      ErrTooManyFailedIngesters,
+		},
+		"RF=5, 5 zones, two instances per zone except for one zone which has three": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1":  {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2":  {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
@@ -569,10 +615,30 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			expectedAddresses: []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.5",
 				"127.0.0.6", "127.0.0.7", "127.0.0.8", "127.0.0.9", "127.0.0.10", "127.0.0.11"},
 			replicationFactor:           5,
-			expectedMaxErrors:           2,
+			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 2,
 		},
-		"five zones, two instances per zone except for one zone which has three, 2 unhealthy nodes in separate zones": {
+		"RF=5, 5 zones, two instances per zone except for one zone which has three, 2 unhealthy nodes in same zones": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1":  {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2":  {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3":  {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4":  {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5":  {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6":  {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-7":  {Addr: "127.0.0.7", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-8":  {Addr: "127.0.0.8", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-9":  {Addr: "127.0.0.9", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+				"instance-10": {Addr: "127.0.0.10", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+				"instance-11": {Addr: "127.0.0.11", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.5", "127.0.0.6", "127.0.0.7", "127.0.0.8", "127.0.0.9", "127.0.0.10", "127.0.0.11"},
+			unhealthyInstances:          []string{"instance-3", "instance-4"},
+			replicationFactor:           5,
+			expectedMaxErrors:           0,
+			expectedMaxUnavailableZones: 1,
+		},
+		"RF=5, 5 zones, two instances per zone except for one zone which has three, 2 unhealthy nodes in separate zones": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1":  {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2":  {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
@@ -592,7 +658,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 0,
 		},
-		"five zones, one instances per zone, three unhealthy instances": {
+		"RF=5, 5 zones, one instances per zone, three unhealthy instances": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
@@ -608,6 +674,10 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
+			// Ensure the test case has been correctly setup (max errors and max unavailable zones are
+			// mutually exclusive).
+			require.False(t, testData.expectedMaxErrors > 0 && testData.expectedMaxUnavailableZones > 0)
+
 			// Init the ring.
 			ringDesc := &Desc{Ingesters: testData.ringInstances}
 			for id, instance := range ringDesc.Ingesters {
@@ -615,7 +685,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 				instance.State = ACTIVE
 				for _, instanceName := range testData.unhealthyInstances {
 					if instanceName == id {
-						instance.State = JOINING
+						instance.Timestamp = time.Now().Add(-time.Hour).Unix()
 					}
 				}
 				ringDesc.Ingesters[id] = instance
@@ -623,7 +693,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 
 			ring := Ring{
 				cfg: Config{
-					HeartbeatTimeout:     time.Hour,
+					HeartbeatTimeout:     time.Minute,
 					ZoneAwarenessEnabled: true,
 					ReplicationFactor:    testData.replicationFactor,
 				},

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -635,7 +635,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			}
 
 			// Check the replication set has the correct settings
-			replicationSet, err := ring.GetAll(Read)
+			replicationSet, err := ring.GetReplicationSetForOperation(Read)
 			if testData.expectedError == nil {
 				require.NoError(t, err)
 			} else {

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -465,6 +465,26 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 0,
 		},
+		"three zones, one instance per zone, two instances unhealthy in separate zones": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+			},
+			unhealthyInstances: []string{"instance-1", "instance-2"},
+			replicationFactor:  3,
+			expectedError:      ErrTooManyFailedIngesters,
+		},
+		"three zones, one instance per zone, all instances unhealthy": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+			},
+			unhealthyInstances: []string{"instance-1", "instance-2", "instance-3"},
+			replicationFactor:  3,
+			expectedError:      ErrTooManyFailedIngesters,
+		},
 		"three zones, two instances per zone": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
@@ -490,6 +510,24 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.5", "127.0.0.6"},
 			unhealthyInstances:          []string{"instance-3", "instance-4"},
+			replicationFactor:           3,
+			expectedMaxErrors:           0,
+			expectedMaxUnavailableZones: 0,
+		},
+		"three zones, three instances per zone, two instances unhealthy in same zone": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-7": {Addr: "127.0.0.7", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-8": {Addr: "127.0.0.8", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-9": {Addr: "127.0.0.9", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.7", "127.0.0.8", "127.0.0.9"},
+			unhealthyInstances:          []string{"instance-4", "instance-6"},
 			replicationFactor:           3,
 			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 0,
@@ -569,7 +607,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			if testData.expectedError == nil {
 				require.NoError(t, err)
 			} else {
-				require.EqualError(t, err, ErrEmptyRing.Error())
+				require.Equal(t, testData.expectedError, err)
 			}
 
 			assert.Equal(t, testData.expectedMaxErrors, replicationSet.MaxErrors)

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -469,16 +469,16 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2"},
 			replicationFactor:           2,
-			expectedMaxUnavailableZones: 0,
+			expectedMaxUnavailableZones: 1,
 		},
 		"RF=2, 2 zones, one unhealthy instance": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
 			},
+			expectedAddresses:  []string{"127.0.0.1"},
 			unhealthyInstances: []string{"instance-2"},
 			replicationFactor:  2,
-			expectedError:      ErrTooManyFailedIngesters,
 		},
 		"RF=3, 3 zones, one instance per zone": {
 			ringInstances: map[string]IngesterDesc{
@@ -578,10 +578,9 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"},
-			unhealthyInstances:          []string{},
 			replicationFactor:           3,
 			expectedMaxErrors:           0,
-			expectedMaxUnavailableZones: 0,
+			expectedMaxUnavailableZones: 1,
 		},
 		"RF=3, only 2 zones, two instances per zone, one instance unhealthy": {
 			ringInstances: map[string]IngesterDesc{
@@ -590,10 +589,11 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
 				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
 			},
-			expectedAddresses:  []string{},
-			unhealthyInstances: []string{"instance-4"},
-			replicationFactor:  3,
-			expectedError:      ErrTooManyFailedIngesters,
+			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2"},
+			unhealthyInstances:          []string{"instance-4"},
+			replicationFactor:           3,
+			expectedMaxErrors:           0,
+			expectedMaxUnavailableZones: 0,
 		},
 		"RF=3, only 1 zone, two instances per zone": {
 			ringInstances: map[string]IngesterDesc{
@@ -601,7 +601,6 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2"},
-			unhealthyInstances:          []string{},
 			replicationFactor:           3,
 			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 0,
@@ -611,7 +610,6 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 			},
-			expectedAddresses:  []string{},
 			unhealthyInstances: []string{"instance-2"},
 			replicationFactor:  3,
 			expectedError:      ErrTooManyFailedIngesters,

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -469,17 +469,16 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 			},
 			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2"},
 			replicationFactor:           2,
-			expectedMaxUnavailableZones: 1,
+			expectedMaxUnavailableZones: 0,
 		},
 		"RF=2, 2 zones, one unhealthy instance": {
 			ringInstances: map[string]IngesterDesc{
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
 			},
-			expectedAddresses:           []string{"127.0.0.1"},
-			unhealthyInstances:          []string{"instance-2"},
-			replicationFactor:           2,
-			expectedMaxUnavailableZones: 0,
+			unhealthyInstances: []string{"instance-2"},
+			replicationFactor:  2,
+			expectedError:      ErrTooManyFailedIngesters,
 		},
 		"RF=3, 3 zones, one instance per zone": {
 			ringInstances: map[string]IngesterDesc{

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -418,6 +418,110 @@ func TestRing_GetReplicationSetForOperation(t *testing.T) {
 	}
 }
 
+func TestRing_GetAll_ZoneAware(t *testing.T) {
+	tests := map[string]struct {
+		ringInstances               map[string]IngesterDesc
+		expectedError               error
+		expectedMaxErrors           int
+		expectedMaxUnavailableZones int
+	}{
+		"empty ring": {
+			ringInstances: nil,
+			expectedError: ErrEmptyRing,
+		},
+		"single zone": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedMaxErrors:           0,
+			expectedMaxUnavailableZones: 0,
+		},
+		"single zone, shard size < num instances": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedMaxErrors:           0,
+			expectedMaxUnavailableZones: 0,
+		},
+		"three zones, one instance per zone": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedMaxErrors:           1,
+			expectedMaxUnavailableZones: 1,
+		},
+		"three zones, two instances per zone": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedMaxErrors:           2,
+			expectedMaxUnavailableZones: 1,
+		},
+		"five zones, two instances per zone except for one zone which has three": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1":  {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2":  {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3":  {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4":  {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5":  {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6":  {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-7":  {Addr: "127.0.0.7", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-8":  {Addr: "127.0.0.6", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-9":  {Addr: "127.0.0.9", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+				"instance-10": {Addr: "127.0.0.10", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+				"instance-11": {Addr: "127.0.0.11", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedMaxErrors:           4,
+			expectedMaxUnavailableZones: 2,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			// Init the ring.
+			ringDesc := &Desc{Ingesters: testData.ringInstances}
+			for id, instance := range ringDesc.Ingesters {
+				instance.Timestamp = time.Now().Unix()
+				instance.State = ACTIVE
+				ringDesc.Ingesters[id] = instance
+			}
+
+			ring := Ring{
+				cfg: Config{
+					HeartbeatTimeout:     time.Hour,
+					ZoneAwarenessEnabled: true,
+				},
+				ringDesc:         ringDesc,
+				ringTokens:       ringDesc.getTokens(),
+				ringTokensByZone: ringDesc.getTokensByZone(),
+				ringZones:        getZones(ringDesc.getTokensByZone()),
+				strategy:         &DefaultReplicationStrategy{},
+			}
+
+			// Check the replication set has the correct settings
+			replicationSet, err := ring.GetAll(Read)
+			if testData.expectedError == nil {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, ErrEmptyRing.Error())
+			}
+
+			assert.Equal(t, testData.expectedMaxErrors, replicationSet.MaxErrors)
+			assert.Equal(t, testData.expectedMaxUnavailableZones, replicationSet.MaxUnavailableZones)
+		})
+	}
+}
+
 func TestRing_ShuffleShard(t *testing.T) {
 	tests := map[string]struct {
 		ringInstances        map[string]IngesterDesc

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -421,6 +421,9 @@ func TestRing_GetReplicationSetForOperation(t *testing.T) {
 func TestRing_GetAll_ZoneAware(t *testing.T) {
 	tests := map[string]struct {
 		ringInstances               map[string]IngesterDesc
+		unhealthyInstances          []string
+		expectedAddresses           []string
+		replicationFactor           int
 		expectedError               error
 		expectedMaxErrors           int
 		expectedMaxUnavailableZones int
@@ -434,15 +437,8 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
 			},
-			expectedMaxErrors:           0,
-			expectedMaxUnavailableZones: 0,
-		},
-		"single zone, shard size < num instances": {
-			ringInstances: map[string]IngesterDesc{
-				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
-				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
-				"instance-3": {Addr: "127.0.0.3", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
-			},
+			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2"},
+			replicationFactor:           1,
 			expectedMaxErrors:           0,
 			expectedMaxUnavailableZones: 0,
 		},
@@ -452,8 +448,22 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
 				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
+			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"},
+			replicationFactor:           3,
 			expectedMaxErrors:           1,
 			expectedMaxUnavailableZones: 1,
+		},
+		"three zones, one instance per zone, one instance unhealthy": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedAddresses:           []string{"127.0.0.2", "127.0.0.3"},
+			unhealthyInstances:          []string{"instance-1"},
+			replicationFactor:           3,
+			expectedMaxErrors:           0,
+			expectedMaxUnavailableZones: 0,
 		},
 		"three zones, two instances per zone": {
 			ringInstances: map[string]IngesterDesc{
@@ -464,8 +474,25 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 			},
-			expectedMaxErrors:           2,
+			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.5", "127.0.0.6"},
+			replicationFactor:           3,
+			expectedMaxErrors:           1,
 			expectedMaxUnavailableZones: 1,
+		},
+		"three zones, two instances per zone, two instances unhealthy in same zone": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2": {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3": {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4": {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5": {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6": {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.5", "127.0.0.6"},
+			unhealthyInstances:          []string{"instance-3", "instance-4"},
+			replicationFactor:           3,
+			expectedMaxErrors:           0,
+			expectedMaxUnavailableZones: 0,
 		},
 		"five zones, two instances per zone except for one zone which has three": {
 			ringInstances: map[string]IngesterDesc{
@@ -476,13 +503,36 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 				"instance-5":  {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 				"instance-6":  {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
 				"instance-7":  {Addr: "127.0.0.7", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
-				"instance-8":  {Addr: "127.0.0.6", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-8":  {Addr: "127.0.0.8", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
 				"instance-9":  {Addr: "127.0.0.9", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
 				"instance-10": {Addr: "127.0.0.10", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
 				"instance-11": {Addr: "127.0.0.11", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
 			},
-			expectedMaxErrors:           4,
+			expectedAddresses: []string{"127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.5",
+				"127.0.0.6", "127.0.0.7", "127.0.0.8", "127.0.0.9", "127.0.0.10", "127.0.0.11"},
+			replicationFactor:           5,
+			expectedMaxErrors:           2,
 			expectedMaxUnavailableZones: 2,
+		},
+		"five zones, two instances per zone except for one zone which has three, 2 unhealthy nodes in separate zones": {
+			ringInstances: map[string]IngesterDesc{
+				"instance-1":  {Addr: "127.0.0.1", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-2":  {Addr: "127.0.0.2", Zone: "zone-a", Tokens: GenerateTokens(128, nil)},
+				"instance-3":  {Addr: "127.0.0.3", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-4":  {Addr: "127.0.0.4", Zone: "zone-b", Tokens: GenerateTokens(128, nil)},
+				"instance-5":  {Addr: "127.0.0.5", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-6":  {Addr: "127.0.0.6", Zone: "zone-c", Tokens: GenerateTokens(128, nil)},
+				"instance-7":  {Addr: "127.0.0.7", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-8":  {Addr: "127.0.0.8", Zone: "zone-d", Tokens: GenerateTokens(128, nil)},
+				"instance-9":  {Addr: "127.0.0.9", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+				"instance-10": {Addr: "127.0.0.10", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+				"instance-11": {Addr: "127.0.0.11", Zone: "zone-e", Tokens: GenerateTokens(128, nil)},
+			},
+			expectedAddresses:           []string{"127.0.0.1", "127.0.0.2", "127.0.0.7", "127.0.0.8", "127.0.0.9", "127.0.0.10", "127.0.0.11"},
+			unhealthyInstances:          []string{"instance-3", "instance-5"},
+			replicationFactor:           5,
+			expectedMaxErrors:           0,
+			expectedMaxUnavailableZones: 0,
 		},
 	}
 
@@ -493,6 +543,11 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 			for id, instance := range ringDesc.Ingesters {
 				instance.Timestamp = time.Now().Unix()
 				instance.State = ACTIVE
+				for _, instanceName := range testData.unhealthyInstances {
+					if instanceName == id {
+						instance.State = JOINING
+					}
+				}
 				ringDesc.Ingesters[id] = instance
 			}
 
@@ -500,6 +555,7 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 				cfg: Config{
 					HeartbeatTimeout:     time.Hour,
 					ZoneAwarenessEnabled: true,
+					ReplicationFactor:    testData.replicationFactor,
 				},
 				ringDesc:         ringDesc,
 				ringTokens:       ringDesc.getTokens(),
@@ -518,6 +574,15 @@ func TestRing_GetAll_ZoneAware(t *testing.T) {
 
 			assert.Equal(t, testData.expectedMaxErrors, replicationSet.MaxErrors)
 			assert.Equal(t, testData.expectedMaxUnavailableZones, replicationSet.MaxUnavailableZones)
+
+			returnAddresses := []string{}
+			for _, instance := range replicationSet.Ingesters {
+				returnAddresses = append(returnAddresses, instance.Addr)
+			}
+			for _, addr := range testData.expectedAddresses {
+				assert.Contains(t, returnAddresses, addr)
+			}
+			assert.Equal(t, len(testData.expectedAddresses), len(replicationSet.Ingesters))
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Add zone awareness to the read path. A `MaxUnavailableZones` field is added to the `ReplicationSet` struct. The value of that field is derived from the number of zones.

In `ReplicationSet.Do()` the zones of the of the failing requests is taken into account for zone aware requests. If too many zones have failures then the request fails.

Unit tests for the non-zone aware invocations of `ReplicationSet.Do()` are added as well.
 
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
