### PR TITLE
Deploy when running github action on a tag

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -173,7 +173,7 @@ jobs:
 
   deploy_website:
     needs: [build, test]
-    if: github.ref == 'refs/heads/master' && github.repository == 'cortexproject/cortex'
+    if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-latest
     container:
       image: quay.io/cortexproject/build-image:upgrade-build-image-debian-491e60715-WIP
@@ -210,7 +210,7 @@ jobs:
 
   deploy:
     needs: [build, test, lint, integration, integration-configs-db]
-    if: github.ref == 'refs/heads/master' && github.repository == 'cortexproject/cortex'
+    if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-latest
     container:
       image: quay.io/cortexproject/build-image:upgrade-build-image-debian-491e60715-WIP


### PR DESCRIPTION
When releasing 1.5.0-rc.0 the docker image is not being created, nor is the website updated. It appears that github actions is skipping the deploy job for tags, this tries to fix that.

I have no idea what I am doing with github actions, so please tell me if this is totally off base.