### PR TITLE
Fix alertmanager metrics Describe() ordering

### DIFF
--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -169,6 +169,7 @@ func (m *alertmanagerMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.numNotifications
 	out <- m.numFailedNotifications
 	out <- m.notificationLatencySeconds
+	out <- m.markerAlerts
 	out <- m.nflogGCDuration
 	out <- m.nflogSnapshotDuration
 	out <- m.nflogSnapshotSize
@@ -176,15 +177,14 @@ func (m *alertmanagerMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.nflogQueryErrorsTotal
 	out <- m.nflogQueryDuration
 	out <- m.nflogPropagatedMessagesTotal
-	out <- m.markerAlerts
 	out <- m.silencesGCDuration
 	out <- m.silencesSnapshotDuration
 	out <- m.silencesSnapshotSize
 	out <- m.silencesQueriesTotal
 	out <- m.silencesQueryErrorsTotal
 	out <- m.silencesQueryDuration
-	out <- m.silences
 	out <- m.silencesPropagatedMessagesTotal
+	out <- m.silences
 	out <- m.configHashValue
 }
 


### PR DESCRIPTION
**What this PR does**:
Some time ago I encountered a weird bug causing not all metrics to be exposed because the order of metrics in `Collect()` and `Describe()` was not the same. Starting that time, I've always made sure they're sorted the same way, but while reviewing the PR #3388 I've noticed the alertmanager metrics are not sorted correctly, so I'm fixing it in this PR.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
