### PR TITLE
Intern Prometheus MultiError to solve blocking circular dependency between Cortex and Thanos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ lint:
 	# Ensure no blacklisted package is imported.
 	faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
 		golang.org/x/net/context=context,\
+		github.com/prometheus/prometheus/tsdb/errors=util,\
 		sync/atomic=go.uber.org/atomic" ./pkg/... ./cmd/... ./tools/... ./integration/...
 
 	# Validate Kubernetes spec files. Requires:

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
-	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/mtime"
 
@@ -470,7 +469,7 @@ func (m *TableManager) partitionTables(ctx context.Context, descriptions []Table
 
 func (m *TableManager) createTables(ctx context.Context, descriptions []TableDesc) error {
 	numFailures := 0
-	merr := tsdberrors.MultiError{}
+	merr := util.NewMultiError()
 
 	for _, desc := range descriptions {
 		level.Info(util.Logger).Log("msg", "creating table", "table", desc.Name)
@@ -487,7 +486,7 @@ func (m *TableManager) createTables(ctx context.Context, descriptions []TableDes
 
 func (m *TableManager) deleteTables(ctx context.Context, descriptions []TableDesc) error {
 	numFailures := 0
-	merr := tsdberrors.MultiError{}
+	merr := util.NewMultiError()
 
 	for _, desc := range descriptions {
 		level.Info(util.Logger).Log("msg", "table has exceeded the retention period", "table", desc.Name)

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/compact"
@@ -120,7 +119,7 @@ func (c *BlocksCleaner) cleanUsers(ctx context.Context) error {
 		return errors.Wrap(err, "failed to discover users from bucket")
 	}
 
-	errs := tsdb_errors.MultiError{}
+	errs := util.NewMultiError()
 	for _, userID := range users {
 		// Ensure the context has not been canceled (ie. shutdown has been triggered).
 		if ctx.Err() != nil {

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/tsdb"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/compact"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
@@ -344,7 +343,7 @@ func (c *Compactor) compactUsers(ctx context.Context) error {
 	}
 	level.Info(c.logger).Log("msg", "discovered users from bucket", "users", len(users))
 
-	errs := tsdb_errors.MultiError{}
+	errs := util.NewMultiError()
 
 	for _, userID := range users {
 		// Ensure the context has not been canceled (ie. compactor shutdown has been triggered).

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -20,7 +20,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/tsdb/encoding"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	tsdb_record "github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/wal"
@@ -445,7 +444,7 @@ func (w *walWrapper) deleteCheckpoints(maxIndex int) (err error) {
 		}
 	}()
 
-	var errs tsdb_errors.MultiError
+	errs := util.NewMultiError()
 
 	files, err := ioutil.ReadDir(w.wal.Dir())
 	if err != nil {
@@ -795,8 +794,7 @@ func processWALWithRepair(startSegment int, userStates *userStates, params walRe
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error in repairing WAL", "err", err)
 	}
-	var multiErr tsdb_errors.MultiError
-	multiErr.Add(err)
+	multiErr := util.NewMultiError(err)
 	multiErr.Add(w.Close())
 
 	return multiErr.Err()

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/objstore"
@@ -176,7 +175,7 @@ func (d *BlocksScanner) scanBucket(ctx context.Context) (returnErr error) {
 	resMetas := map[string][]*BlockMeta{}
 	resMetasLookup := map[string]map[ulid.ULID]*BlockMeta{}
 	resDeletionMarks := map[string]map[ulid.ULID]*metadata.DeletionMark{}
-	resErrs := tsdb_errors.MultiError{}
+	resErrs := util.NewMultiError()
 
 	// Create a pool of workers which will synchronize metas. The pool size
 	// is limited in order to avoid to concurrently sync a lot of tenants in

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/thanos-io/thanos/pkg/block"
 	thanos_metadata "github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/extprom"
@@ -154,7 +153,7 @@ func (u *BucketStores) syncUsersBlocks(ctx context.Context, f func(context.Conte
 
 	wg := &sync.WaitGroup{}
 	jobs := make(chan job)
-	errs := tsdb_errors.MultiError{}
+	errs := util.NewMultiError()
 	errsMx := sync.Mutex{}
 
 	// Scan users in the bucket. In case of error, it may return a subset of users. If we sync a subset of users

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -1,6 +1,69 @@
 package util
 
-import "errors"
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
 
 // ErrStopProcess is the error returned by a service as a hint to stop the server entirely.
 var ErrStopProcess = errors.New("stop process")
+
+// MultiError type allows combining multiple errors into one.
+type MultiError []error
+
+// NewMultiError returns MultiError with provided errors added if not nil.
+func NewMultiError(errs ...error) MultiError { // nolint:golint
+	m := MultiError{}
+	m.Add(errs...)
+	return m
+}
+
+// Add adds single or many errors to the error list. Each error is added only if not nil.
+// If the error is a nonNilMultiError type, the errors inside nonNilMultiError are added to the main MultiError.
+func (es *MultiError) Add(errs ...error) {
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		if merr, ok := err.(nonNilMultiError); ok {
+			*es = append(*es, merr.errs...)
+			continue
+		}
+		*es = append(*es, err)
+	}
+}
+
+// Err returns the error list as an error or nil if it is empty.
+func (es MultiError) Err() error {
+	if len(es) == 0 {
+		return nil
+	}
+	return nonNilMultiError{errs: es}
+}
+
+// nonNilMultiError implements the error interface, and it represents
+// MultiError with at least one error inside it.
+// This type is needed to make sure that nil is returned when no error is combined in MultiError for err != nil
+// check to work.
+type nonNilMultiError struct {
+	errs MultiError
+}
+
+// Error returns a concatenated string of the contained errors.
+func (es nonNilMultiError) Error() string {
+	var buf bytes.Buffer
+
+	if len(es.errs) > 1 {
+		fmt.Fprintf(&buf, "%d errors: ", len(es.errs))
+	}
+
+	for i, err := range es.errs {
+		if i != 0 {
+			buf.WriteString("; ")
+		}
+		buf.WriteString(err.Error())
+	}
+
+	return buf.String()
+}

--- a/tools/blocksconvert/builder/series.go
+++ b/tools/blocksconvert/builder/series.go
@@ -11,7 +11,8 @@ import (
 	"github.com/golang/snappy"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
-	"github.com/prometheus/prometheus/tsdb/errors"
+
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 type series struct {
@@ -118,7 +119,7 @@ func writeSymbols(filename string, symbols []string) error {
 	sn := snappy.NewBufferedWriter(f)
 	enc := gob.NewEncoder(sn)
 
-	errs := errors.MultiError{}
+	errs := util.NewMultiError()
 
 	for _, s := range symbols {
 		err := enc.Encode(s)
@@ -141,7 +142,7 @@ func writeSeries(filename string, sers []series) (map[string]struct{}, error) {
 
 	symbols := map[string]struct{}{}
 
-	errs := errors.MultiError{}
+	errs := util.NewMultiError()
 
 	sn := snappy.NewBufferedWriter(f)
 	enc := gob.NewEncoder(sn)

--- a/tools/blocksconvert/builder/series_iterator.go
+++ b/tools/blocksconvert/builder/series_iterator.go
@@ -7,17 +7,19 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/tsdb/errors"
+
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 type seriesIterator struct {
 	files []*seriesFile
-	errs  errors.MultiError
+	errs  util.MultiError
 }
 
 func newSeriesIterator(files []*seriesFile) *seriesIterator {
 	si := &seriesIterator{
 		files: files,
+		errs:  util.NewMultiError(),
 	}
 	si.buildHeap()
 	return si
@@ -83,7 +85,7 @@ func (sit *seriesIterator) Error() error {
 }
 
 func (sit *seriesIterator) Close() error {
-	var errs errors.MultiError
+	errs := util.NewMultiError()
 	for _, f := range sit.files {
 		errs.Add(f.close())
 	}

--- a/tools/blocksconvert/builder/symbols_iterator.go
+++ b/tools/blocksconvert/builder/symbols_iterator.go
@@ -6,12 +6,13 @@ import (
 	"os"
 
 	"github.com/golang/snappy"
-	"github.com/prometheus/prometheus/tsdb/errors"
+
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 type symbolsIterator struct {
 	files []*symbolsFile
-	errs  errors.MultiError
+	errs  util.MultiError
 
 	// To avoid returning duplicates, we remember last returned symbol.
 	lastReturned *string
@@ -20,6 +21,7 @@ type symbolsIterator struct {
 func newSymbolsIterator(files []*symbolsFile) *symbolsIterator {
 	si := &symbolsIterator{
 		files: files,
+		errs:  util.NewMultiError(),
 	}
 	si.buildHeap()
 	return si
@@ -92,7 +94,7 @@ func (sit *symbolsIterator) Error() error {
 }
 
 func (sit *symbolsIterator) Close() error {
-	var errs errors.MultiError
+	errs := util.NewMultiError()
 	for _, f := range sit.files {
 		errs.Add(f.close())
 	}

--- a/tools/blocksconvert/scanner/files.go
+++ b/tools/blocksconvert/scanner/files.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/tsdb/errors"
+
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 type file struct {
@@ -93,7 +94,7 @@ func (of *openFiles) closeAllFiles(footerFn func() interface{}) error {
 	of.mu.Lock()
 	defer of.mu.Unlock()
 
-	errs := errors.MultiError{}
+	errs := util.NewMultiError()
 
 	for fn, f := range of.files {
 		delete(of.files, fn)


### PR DESCRIPTION
**What this PR does**:
Cortex and Thanos vendoring are a circular dependency. Cortex depends on Thanos (for blocks storage) and Thanos depends on Cortex (for query-frontend). This is currently blocking Prometheus upgrade in both projects.

The reason is that Prometheus `MultiError` has been refactored. We can't upgrade Prometheus in Cortex because it breaks Thanos, but can't upgrade Prometheus in Thanos too because breaks Cortex. In this PR I'm interning the `MultiError` into Cortex to unblock this annoying situation and being able to upgrade Prometheus in Thanos first, and then upgrade Prometheus + Thanos in Cortex.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
