### PR TITLE
Upgrade Prometheus and Thanos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - `cortex_ingester_tsdb_head_gc_duration_seconds`
 * [ENHANCEMENT] Added `cortex_alertmanager_config_hash` metric to expose hash of Alertmanager Config loaded per user. #3388
 * [ENHANCEMENT] Query-Frontend / Query-Scheduler: New component called "Query-Scheduler" has been introduced. Query-Scheduler is simply a queue of requests, moved outside of Query-Frontend. This allows Query-Frontend to be scaled separately from number of queues. To make Query-Frontend and Querier use Query-Scheduler, they need to be started with `-frontend.scheduler-address` and `-querier.scheduler-address` options respectively. #3374
+* [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 
 ## 1.5.0 in progress
 

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,6 @@ lint:
 	# Ensure no blacklisted package is imported.
 	faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
 		golang.org/x/net/context=context,\
-		github.com/prometheus/prometheus/tsdb/errors=util,\
 		sync/atomic=go.uber.org/atomic" ./pkg/... ./cmd/... ./tools/... ./integration/...
 
 	# Validate Kubernetes spec files. Requires:

--- a/go.mod
+++ b/go.mod
@@ -47,12 +47,12 @@ require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.14.0
-	github.com/prometheus/prometheus v1.8.2-0.20201028100903-3245b3267b24
+	github.com/prometheus/prometheus v1.8.2-0.20201029103703-63be30dceed9
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e
 	github.com/sony/gobreaker v0.4.1
 	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.6.1
-	github.com/thanos-io/thanos v0.13.1-0.20201019130456-f41940581d9a
+	github.com/thanos-io/thanos v0.13.1-0.20201030101306-47f9a225cc52
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
 	github.com/weaveworks/common v0.0.0-20200914083218-61ffdd448099
 	go.etcd.io/bbolt v1.3.5-0.20200615073812-232d8fc87f50

--- a/go.sum
+++ b/go.sum
@@ -253,6 +253,7 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cortexproject/cortex v0.6.1-0.20200228110116-92ab6cbe0995/go.mod h1:3Xa3DjJxtpXqxcMGdk850lcIRb81M0fyY1MQ6udY134=
 github.com/cortexproject/cortex v1.2.1-0.20200805064754-d8edc95e2c91/go.mod h1:PVPxNLrxKH+yc8asaJOxuz7TiRmMizFfnSMOnRzM6oM=
 github.com/cortexproject/cortex v1.3.1-0.20200923145333-8587ea61fe17/go.mod h1:dJ9gpW7dzQ7z09cKtNN9PfebumgyO4dtNdFQ6eQEed0=
+github.com/cortexproject/cortex v1.4.1-0.20201030080541-83ad6df2abea/go.mod h1:kXo5F3jlF7Ky3+I31jt/bXTzOlQjl2X/vGDpy0RY1gU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cznic/b v0.0.0-20180115125044-35e9bbe41f07/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
@@ -1081,8 +1082,9 @@ github.com/prometheus/prometheus v1.8.2-0.20200805082714-e0cf219f0de2/go.mod h1:
 github.com/prometheus/prometheus v1.8.2-0.20200819132913-cb830b0a9c78 h1:tHIAD+hgCIb86T0/Du7vGyfHa6J1+XsImQoY8Ete+c8=
 github.com/prometheus/prometheus v1.8.2-0.20200819132913-cb830b0a9c78/go.mod h1:zfAqy/MwhMFajB9E2n12/9gG2fvofIE9uKDtlZCDxqs=
 github.com/prometheus/prometheus v1.8.2-0.20200923143134-7e2db3d092f3/go.mod h1:9VNWoDFHOMovlubld5uKKxfCDcPBj2GMOCjcUFXkYaM=
-github.com/prometheus/prometheus v1.8.2-0.20201028100903-3245b3267b24 h1:V/4Cj2GytqdqK7OMEz6c4LNjey3SNyfw3pg5jPKtJvQ=
 github.com/prometheus/prometheus v1.8.2-0.20201028100903-3245b3267b24/go.mod h1:MDRkz271loM/PrYN+wUNEaTMDGSP760MQzB0yEjdgSQ=
+github.com/prometheus/prometheus v1.8.2-0.20201029103703-63be30dceed9 h1:T6pkPNGKXv21lLfgD/mnIABj9aOhmz8HphDmKllfKWs=
+github.com/prometheus/prometheus v1.8.2-0.20201029103703-63be30dceed9/go.mod h1:MDRkz271loM/PrYN+wUNEaTMDGSP760MQzB0yEjdgSQ=
 github.com/rafaeljusto/redigomock v0.0.0-20190202135759-257e089e14a1 h1:+kGqA4dNN5hn7WwvKdzHl0rdN5AEkbNZd0VjRltAiZg=
 github.com/rafaeljusto/redigomock v0.0.0-20190202135759-257e089e14a1/go.mod h1:JaY6n2sDr+z2WTsXkOmNRUfDy6FN0L6Nk7x06ndm4tY=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -1180,6 +1182,8 @@ github.com/thanos-io/thanos v0.13.1-0.20200807203500-9b578afb4763 h1:c84P3YUu8bx
 github.com/thanos-io/thanos v0.13.1-0.20200807203500-9b578afb4763/go.mod h1:KyW0a93tsh7v4hXAwo2CVAIRYuZT1Kkf4e04gisQjAg=
 github.com/thanos-io/thanos v0.13.1-0.20201019130456-f41940581d9a h1:4rNkFHeY+EIR7UdiYn5fZE7Q35Y3Dmae8q1Qbb90tcY=
 github.com/thanos-io/thanos v0.13.1-0.20201019130456-f41940581d9a/go.mod h1:A3qUEEbsVkplJnxyDLwuIuvTDaJPByTH+hMdTl9ujAA=
+github.com/thanos-io/thanos v0.13.1-0.20201030101306-47f9a225cc52 h1:z3hglXVwJ4HgU0OoDS+8+MvEipv/U83IQ+fMsDr00YQ=
+github.com/thanos-io/thanos v0.13.1-0.20201030101306-47f9a225cc52/go.mod h1:OqqX4x21cg5N5MMHd/yGQAc/V3wg8a7Do4Jk8HfaFZQ=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab h1:7ZR3hmisBWw77ZpO1/o86g+JV3VKlk3d48jopJxzTjU=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab/go.mod h1:eheTFp954zcWZXCU8d0AT76ftsQOTo4DTqkN/h3k1MY=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
+	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/mtime"
 
@@ -469,7 +470,7 @@ func (m *TableManager) partitionTables(ctx context.Context, descriptions []Table
 
 func (m *TableManager) createTables(ctx context.Context, descriptions []TableDesc) error {
 	numFailures := 0
-	merr := util.NewMultiError()
+	merr := tsdberrors.NewMulti()
 
 	for _, desc := range descriptions {
 		level.Info(util.Logger).Log("msg", "creating table", "table", desc.Name)
@@ -486,7 +487,7 @@ func (m *TableManager) createTables(ctx context.Context, descriptions []TableDes
 
 func (m *TableManager) deleteTables(ctx context.Context, descriptions []TableDesc) error {
 	numFailures := 0
-	merr := util.NewMultiError()
+	merr := tsdberrors.NewMulti()
 
 	for _, desc := range descriptions {
 		level.Info(util.Logger).Log("msg", "table has exceeded the retention period", "table", desc.Name)

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
-	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/mtime"
 
@@ -470,7 +470,7 @@ func (m *TableManager) partitionTables(ctx context.Context, descriptions []Table
 
 func (m *TableManager) createTables(ctx context.Context, descriptions []TableDesc) error {
 	numFailures := 0
-	merr := tsdberrors.NewMulti()
+	merr := tsdb_errors.NewMulti()
 
 	for _, desc := range descriptions {
 		level.Info(util.Logger).Log("msg", "creating table", "table", desc.Name)
@@ -487,7 +487,7 @@ func (m *TableManager) createTables(ctx context.Context, descriptions []TableDes
 
 func (m *TableManager) deleteTables(ctx context.Context, descriptions []TableDesc) error {
 	numFailures := 0
-	merr := tsdberrors.NewMulti()
+	merr := tsdb_errors.NewMulti()
 
 	for _, desc := range descriptions {
 		level.Info(util.Logger).Log("msg", "table has exceeded the retention period", "table", desc.Name)

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/compact"
@@ -119,7 +120,7 @@ func (c *BlocksCleaner) cleanUsers(ctx context.Context) error {
 		return errors.Wrap(err, "failed to discover users from bucket")
 	}
 
-	errs := util.NewMultiError()
+	errs := tsdb_errors.NewMulti()
 	for _, userID := range users {
 		// Ensure the context has not been canceled (ie. shutdown has been triggered).
 		if ctx.Err() != nil {

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/tsdb"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/compact"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
@@ -343,7 +344,7 @@ func (c *Compactor) compactUsers(ctx context.Context) error {
 	}
 	level.Info(c.logger).Log("msg", "discovered users from bucket", "users", len(users))
 
-	errs := util.NewMultiError()
+	errs := tsdb_errors.NewMulti()
 
 	for _, userID := range users {
 		// Ensure the context has not been canceled (ie. compactor shutdown has been triggered).

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -795,11 +795,8 @@ func processWALWithRepair(startSegment int, userStates *userStates, params walRe
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error in repairing WAL", "err", err)
 	}
-	multiErr := tsdb_errors.NewMulti()
-	multiErr.Add(err)
-	multiErr.Add(w.Close())
 
-	return multiErr.Err()
+	return tsdb_errors.NewMulti(err, w.Close()).Err()
 }
 
 // processWAL processes the records in the WAL concurrently.

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/tsdb/encoding"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	tsdb_record "github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/wal"
@@ -444,7 +445,7 @@ func (w *walWrapper) deleteCheckpoints(maxIndex int) (err error) {
 		}
 	}()
 
-	errs := util.NewMultiError()
+	errs := tsdb_errors.NewMulti()
 
 	files, err := ioutil.ReadDir(w.wal.Dir())
 	if err != nil {
@@ -794,7 +795,8 @@ func processWALWithRepair(startSegment int, userStates *userStates, params walRe
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error in repairing WAL", "err", err)
 	}
-	multiErr := util.NewMultiError(err)
+	multiErr := tsdb_errors.NewMulti()
+	multiErr.Add(err)
 	multiErr.Add(w.Close())
 
 	return multiErr.Err()

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/objstore"
@@ -175,7 +176,7 @@ func (d *BlocksScanner) scanBucket(ctx context.Context) (returnErr error) {
 	resMetas := map[string][]*BlockMeta{}
 	resMetasLookup := map[string]map[ulid.ULID]*BlockMeta{}
 	resDeletionMarks := map[string]map[ulid.ULID]*metadata.DeletionMark{}
-	resErrs := util.NewMultiError()
+	resErrs := tsdb_errors.NewMulti()
 
 	// Create a pool of workers which will synchronize metas. The pool size
 	// is limited in order to avoid to concurrently sync a lot of tenants in

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/thanos-io/thanos/pkg/block"
 	thanos_metadata "github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/extprom"
@@ -153,7 +154,7 @@ func (u *BucketStores) syncUsersBlocks(ctx context.Context, f func(context.Conte
 
 	wg := &sync.WaitGroup{}
 	jobs := make(chan job)
-	errs := util.NewMultiError()
+	errs := tsdb_errors.NewMulti()
 	errsMx := sync.Mutex{}
 
 	// Scan users in the bucket. In case of error, it may return a subset of users. If we sync a subset of users

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -1,69 +1,8 @@
 package util
 
 import (
-	"bytes"
 	"errors"
-	"fmt"
 )
 
 // ErrStopProcess is the error returned by a service as a hint to stop the server entirely.
 var ErrStopProcess = errors.New("stop process")
-
-// MultiError type allows combining multiple errors into one.
-type MultiError []error
-
-// NewMultiError returns MultiError with provided errors added if not nil.
-func NewMultiError(errs ...error) MultiError { // nolint:golint
-	m := MultiError{}
-	m.Add(errs...)
-	return m
-}
-
-// Add adds single or many errors to the error list. Each error is added only if not nil.
-// If the error is a nonNilMultiError type, the errors inside nonNilMultiError are added to the main MultiError.
-func (es *MultiError) Add(errs ...error) {
-	for _, err := range errs {
-		if err == nil {
-			continue
-		}
-		if merr, ok := err.(nonNilMultiError); ok {
-			*es = append(*es, merr.errs...)
-			continue
-		}
-		*es = append(*es, err)
-	}
-}
-
-// Err returns the error list as an error or nil if it is empty.
-func (es MultiError) Err() error {
-	if len(es) == 0 {
-		return nil
-	}
-	return nonNilMultiError{errs: es}
-}
-
-// nonNilMultiError implements the error interface, and it represents
-// MultiError with at least one error inside it.
-// This type is needed to make sure that nil is returned when no error is combined in MultiError for err != nil
-// check to work.
-type nonNilMultiError struct {
-	errs MultiError
-}
-
-// Error returns a concatenated string of the contained errors.
-func (es nonNilMultiError) Error() string {
-	var buf bytes.Buffer
-
-	if len(es.errs) > 1 {
-		fmt.Fprintf(&buf, "%d errors: ", len(es.errs))
-	}
-
-	for i, err := range es.errs {
-		if i != 0 {
-			buf.WriteString("; ")
-		}
-		buf.WriteString(err.Error())
-	}
-
-	return buf.String()
-}

--- a/tools/blocksconvert/builder/series.go
+++ b/tools/blocksconvert/builder/series.go
@@ -11,8 +11,7 @@ import (
 	"github.com/golang/snappy"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
-
-	"github.com/cortexproject/cortex/pkg/util"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 )
 
 type series struct {
@@ -119,7 +118,7 @@ func writeSymbols(filename string, symbols []string) error {
 	sn := snappy.NewBufferedWriter(f)
 	enc := gob.NewEncoder(sn)
 
-	errs := util.NewMultiError()
+	errs := tsdb_errors.NewMulti()
 
 	for _, s := range symbols {
 		err := enc.Encode(s)
@@ -142,7 +141,7 @@ func writeSeries(filename string, sers []series) (map[string]struct{}, error) {
 
 	symbols := map[string]struct{}{}
 
-	errs := util.NewMultiError()
+	errs := tsdb_errors.NewMulti()
 
 	sn := snappy.NewBufferedWriter(f)
 	enc := gob.NewEncoder(sn)

--- a/tools/blocksconvert/scanner/files.go
+++ b/tools/blocksconvert/scanner/files.go
@@ -9,8 +9,7 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/cortexproject/cortex/pkg/util"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 )
 
 type file struct {
@@ -94,7 +93,7 @@ func (of *openFiles) closeAllFiles(footerFn func() interface{}) error {
 	of.mu.Lock()
 	defer of.mu.Unlock()
 
-	errs := util.NewMultiError()
+	errs := tsdb_errors.NewMulti()
 
 	for fn, f := range of.files {
 		delete(of.files, fn)

--- a/vendor/github.com/prometheus/prometheus/storage/fanout.go
+++ b/vendor/github.com/prometheus/prometheus/storage/fanout.go
@@ -80,8 +80,7 @@ func (f *fanout) Querier(ctx context.Context, mint, maxt int64) (Querier, error)
 		querier, err := storage.Querier(ctx, mint, maxt)
 		if err != nil {
 			// Close already open Queriers, append potential errors to returned error.
-			errs := tsdb_errors.MultiError{err}
-			errs.Add(primary.Close())
+			errs := tsdb_errors.NewMulti(err, primary.Close())
 			for _, q := range secondaries {
 				errs.Add(q.Close())
 			}
@@ -103,8 +102,7 @@ func (f *fanout) ChunkQuerier(ctx context.Context, mint, maxt int64) (ChunkQueri
 		querier, err := storage.ChunkQuerier(ctx, mint, maxt)
 		if err != nil {
 			// Close already open Queriers, append potential errors to returned error.
-			errs := tsdb_errors.MultiError{err}
-			errs.Add(primary.Close())
+			errs := tsdb_errors.NewMulti(err, primary.Close())
 			for _, q := range secondaries {
 				errs.Add(q.Close())
 			}
@@ -130,8 +128,7 @@ func (f *fanout) Appender(ctx context.Context) Appender {
 
 // Close closes the storage and all its underlying resources.
 func (f *fanout) Close() error {
-	errs := tsdb_errors.MultiError{}
-	errs.Add(f.primary.Close())
+	errs := tsdb_errors.NewMulti(f.primary.Close())
 	for _, s := range f.secondaries {
 		errs.Add(s.Close())
 	}

--- a/vendor/github.com/prometheus/prometheus/storage/merge.go
+++ b/vendor/github.com/prometheus/prometheus/storage/merge.go
@@ -248,7 +248,7 @@ func (q *mergeGenericQuerier) LabelNames() ([]string, Warnings, error) {
 
 // Close releases the resources of the generic querier.
 func (q *mergeGenericQuerier) Close() error {
-	errs := tsdb_errors.MultiError{}
+	errs := tsdb_errors.NewMulti()
 	for _, querier := range q.queriers {
 		if err := querier.Close(); err != nil {
 			errs.Add(err)
@@ -534,11 +534,9 @@ func (c *chainSampleIterator) Next() bool {
 }
 
 func (c *chainSampleIterator) Err() error {
-	var errs tsdb_errors.MultiError
+	errs := tsdb_errors.NewMulti()
 	for _, iter := range c.iterators {
-		if err := iter.Err(); err != nil {
-			errs.Add(err)
-		}
+		errs.Add(iter.Err())
 	}
 	return errs.Err()
 }
@@ -681,11 +679,9 @@ func (c *compactChunkIterator) Next() bool {
 }
 
 func (c *compactChunkIterator) Err() error {
-	var errs tsdb_errors.MultiError
+	errs := tsdb_errors.NewMulti()
 	for _, iter := range c.iterators {
-		if err := iter.Err(); err != nil {
-			errs.Add(err)
-		}
+		errs.Add(iter.Err())
 	}
 	errs.Add(c.err)
 	return errs.Err()

--- a/vendor/github.com/prometheus/prometheus/storage/remote/queue_manager.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/queue_manager.go
@@ -64,6 +64,7 @@ type queueManagerMetrics struct {
 	minNumShards          prometheus.Gauge
 	desiredNumShards      prometheus.Gauge
 	bytesSent             prometheus.Counter
+	maxSamplesPerSend     prometheus.Gauge
 }
 
 func newQueueManagerMetrics(r prometheus.Registerer, rn, e string) *queueManagerMetrics {
@@ -176,6 +177,13 @@ func newQueueManagerMetrics(r prometheus.Registerer, rn, e string) *queueManager
 		Help:        "The total number of bytes sent by the queue.",
 		ConstLabels: constLabels,
 	})
+	m.maxSamplesPerSend = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   namespace,
+		Subsystem:   subsystem,
+		Name:        "max_samples_per_send",
+		Help:        "The maximum number of samples to be sent, in a single request, to the remote storage.",
+		ConstLabels: constLabels,
+	})
 
 	return m
 }
@@ -197,6 +205,7 @@ func (m *queueManagerMetrics) register() {
 			m.minNumShards,
 			m.desiredNumShards,
 			m.bytesSent,
+			m.maxSamplesPerSend,
 		)
 	}
 }
@@ -217,6 +226,7 @@ func (m *queueManagerMetrics) unregister() {
 		m.reg.Unregister(m.minNumShards)
 		m.reg.Unregister(m.desiredNumShards)
 		m.reg.Unregister(m.bytesSent)
+		m.reg.Unregister(m.maxSamplesPerSend)
 	}
 }
 
@@ -372,6 +382,7 @@ func (t *QueueManager) Start() {
 	t.metrics.maxNumShards.Set(float64(t.cfg.MaxShards))
 	t.metrics.minNumShards.Set(float64(t.cfg.MinShards))
 	t.metrics.desiredNumShards.Set(float64(t.cfg.MinShards))
+	t.metrics.maxSamplesPerSend.Set(float64(t.cfg.MaxSamplesPerSend))
 
 	t.shards.start(t.numShards)
 	t.watcher.Start()

--- a/vendor/github.com/prometheus/prometheus/tsdb/CHANGELOG.md
+++ b/vendor/github.com/prometheus/prometheus/tsdb/CHANGELOG.md
@@ -33,7 +33,7 @@
  - [BUGFIX] Don't panic and recover nicely when running out of disk space.
  - [BUGFIX] Correctly handle empty labels.
  - [BUGFIX] Don't crash on an unknown tombstone ref.
- - [ENHANCEMENT] Re-add FromData function to create a chunk from bytes. It is used by Cortex and Thanos.
+ - [ENHANCEMENT] Re-add `FromData` function to create a chunk from bytes. It is used by Cortex and Thanos.
  - [ENHANCEMENT] Simplify mergedPostings.Seek.
  - [FEATURE]  Added `currentSegment` metric for the current WAL segment it is being written to.
 

--- a/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/chunk.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/chunk.go
@@ -14,7 +14,6 @@
 package chunkenc
 
 import (
-	"fmt"
 	"math"
 	"sync"
 
@@ -132,7 +131,7 @@ func (p *pool) Get(e Encoding, b []byte) (Chunk, error) {
 		c.b.count = 0
 		return c, nil
 	}
-	return nil, errors.Errorf("invalid encoding %q", e)
+	return nil, errors.Errorf("invalid chunk encoding %q", e)
 }
 
 func (p *pool) Put(c Chunk) error {
@@ -149,7 +148,7 @@ func (p *pool) Put(c Chunk) error {
 		xc.b.count = 0
 		p.xor.Put(c)
 	default:
-		return errors.Errorf("invalid encoding %q", c.Encoding())
+		return errors.Errorf("invalid chunk encoding %q", c.Encoding())
 	}
 	return nil
 }
@@ -162,5 +161,5 @@ func FromData(e Encoding, d []byte) (Chunk, error) {
 	case EncXOR:
 		return &XORChunk{b: bstream{count: 0, stream: d}}, nil
 	}
-	return nil, fmt.Errorf("unknown chunk encoding: %d", e)
+	return nil, errors.Errorf("invalid chunk encoding %q", e)
 }

--- a/vendor/github.com/prometheus/prometheus/tsdb/chunks/chunks.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/chunks/chunks.go
@@ -230,14 +230,13 @@ func cutSegmentFile(dirFile *os.File, magicNumber uint32, chunksFormat byte, all
 	}
 	defer func() {
 		if returnErr != nil {
-			var merr tsdb_errors.MultiError
-			merr.Add(returnErr)
+			errs := tsdb_errors.NewMulti(returnErr)
 			if f != nil {
-				merr.Add(f.Close())
+				errs.Add(f.Close())
 			}
 			// Calling RemoveAll on a non-existent file does not return error.
-			merr.Add(os.RemoveAll(ptmp))
-			returnErr = merr.Err()
+			errs.Add(os.RemoveAll(ptmp))
+			returnErr = errs.Err()
 		}
 	}()
 	if allocSize > 0 {
@@ -463,16 +462,16 @@ func NewDirReader(dir string, pool chunkenc.Pool) (*Reader, error) {
 	}
 
 	var (
-		bs   []ByteSlice
-		cs   []io.Closer
-		merr tsdb_errors.MultiError
+		bs []ByteSlice
+		cs []io.Closer
 	)
 	for _, fn := range files {
 		f, err := fileutil.OpenMmapFile(fn)
 		if err != nil {
-			merr.Add(errors.Wrap(err, "mmap files"))
-			merr.Add(closeAll(cs))
-			return nil, merr
+			return nil, tsdb_errors.NewMulti(
+				errors.Wrap(err, "mmap files"),
+				tsdb_errors.CloseAll(cs),
+			).Err()
 		}
 		cs = append(cs, f)
 		bs = append(bs, realByteSlice(f.Bytes()))
@@ -480,15 +479,16 @@ func NewDirReader(dir string, pool chunkenc.Pool) (*Reader, error) {
 
 	reader, err := newReader(bs, cs, pool)
 	if err != nil {
-		merr.Add(err)
-		merr.Add(closeAll(cs))
-		return nil, merr
+		return nil, tsdb_errors.NewMulti(
+			err,
+			tsdb_errors.CloseAll(cs),
+		).Err()
 	}
 	return reader, nil
 }
 
 func (s *Reader) Close() error {
-	return closeAll(s.cs)
+	return tsdb_errors.CloseAll(s.cs)
 }
 
 // Size returns the size of the chunks.
@@ -587,13 +587,4 @@ func sequenceFiles(dir string) ([]string, error) {
 		res = append(res, filepath.Join(dir, fi.Name()))
 	}
 	return res, nil
-}
-
-func closeAll(cs []io.Closer) error {
-	var merr tsdb_errors.MultiError
-
-	for _, c := range cs {
-		merr.Add(c.Close())
-	}
-	return merr.Err()
 }

--- a/vendor/github.com/prometheus/prometheus/tsdb/chunks/head_chunks.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/chunks/head_chunks.go
@@ -153,10 +153,7 @@ func (cdm *ChunkDiskMapper) openMMapFiles() (returnErr error) {
 	cdm.closers = map[int]io.Closer{}
 	defer func() {
 		if returnErr != nil {
-			var merr tsdb_errors.MultiError
-			merr.Add(returnErr)
-			merr.Add(closeAllFromMap(cdm.closers))
-			returnErr = merr.Err()
+			returnErr = tsdb_errors.NewMulti(returnErr, closeAllFromMap(cdm.closers)).Err()
 
 			cdm.mmappedChunkFiles = nil
 			cdm.closers = nil
@@ -370,10 +367,7 @@ func (cdm *ChunkDiskMapper) cut() (returnErr error) {
 		// The file should not be closed if there is no error,
 		// its kept open in the ChunkDiskMapper.
 		if returnErr != nil {
-			var merr tsdb_errors.MultiError
-			merr.Add(returnErr)
-			merr.Add(newFile.Close())
-			returnErr = merr.Err()
+			returnErr = tsdb_errors.NewMulti(returnErr, newFile.Close()).Err()
 		}
 	}()
 
@@ -717,13 +711,13 @@ func (cdm *ChunkDiskMapper) Truncate(mint int64) error {
 	}
 	cdm.readPathMtx.RUnlock()
 
-	var merr tsdb_errors.MultiError
+	errs := tsdb_errors.NewMulti()
 	// Cut a new file only if the current file has some chunks.
 	if cdm.curFileSize() > HeadChunkFileHeaderSize {
-		merr.Add(cdm.CutNewFile())
+		errs.Add(cdm.CutNewFile())
 	}
-	merr.Add(cdm.deleteFiles(removedFiles))
-	return merr.Err()
+	errs.Add(cdm.deleteFiles(removedFiles))
+	return errs.Err()
 }
 
 func (cdm *ChunkDiskMapper) deleteFiles(removedFiles []int) error {
@@ -795,23 +789,23 @@ func (cdm *ChunkDiskMapper) Close() error {
 	}
 	cdm.closed = true
 
-	var merr tsdb_errors.MultiError
-	merr.Add(closeAllFromMap(cdm.closers))
-	merr.Add(cdm.finalizeCurFile())
-	merr.Add(cdm.dir.Close())
-
+	errs := tsdb_errors.NewMulti(
+		closeAllFromMap(cdm.closers),
+		cdm.finalizeCurFile(),
+		cdm.dir.Close(),
+	)
 	cdm.mmappedChunkFiles = map[int]*mmappedChunkFile{}
 	cdm.closers = map[int]io.Closer{}
 
-	return merr.Err()
+	return errs.Err()
 }
 
 func closeAllFromMap(cs map[int]io.Closer) error {
-	var merr tsdb_errors.MultiError
+	errs := tsdb_errors.NewMulti()
 	for _, c := range cs {
-		merr.Add(c.Close())
+		errs.Add(c.Close())
 	}
-	return merr.Err()
+	return errs.Err()
 }
 
 const inBufferShards = 128 // 128 is a randomly chosen number.

--- a/vendor/github.com/prometheus/prometheus/tsdb/errors/errors.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/errors/errors.go
@@ -17,21 +17,59 @@ package errors
 import (
 	"bytes"
 	"fmt"
+	"io"
 )
 
-// The MultiError type implements the error interface, and contains the
-// Errors used to construct it.
-type MultiError []error
+// multiError type allows combining multiple errors into one.
+type multiError []error
 
-// Returns a concatenated string of the contained errors
-func (es MultiError) Error() string {
+// NewMulti returns multiError with provided errors added if not nil.
+func NewMulti(errs ...error) multiError { // nolint:golint
+	m := multiError{}
+	m.Add(errs...)
+	return m
+}
+
+// Add adds single or many errors to the error list. Each error is added only if not nil.
+// If the error is a nonNilMultiError type, the errors inside nonNilMultiError are added to the main multiError.
+func (es *multiError) Add(errs ...error) {
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		if merr, ok := err.(nonNilMultiError); ok {
+			*es = append(*es, merr.errs...)
+			continue
+		}
+		*es = append(*es, err)
+	}
+}
+
+// Err returns the error list as an error or nil if it is empty.
+func (es multiError) Err() error {
+	if len(es) == 0 {
+		return nil
+	}
+	return nonNilMultiError{errs: es}
+}
+
+// nonNilMultiError implements the error interface, and it represents
+// multiError with at least one error inside it.
+// This type is needed to make sure that nil is returned when no error is combined in multiError for err != nil
+// check to work.
+type nonNilMultiError struct {
+	errs multiError
+}
+
+// Error returns a concatenated string of the contained errors.
+func (es nonNilMultiError) Error() string {
 	var buf bytes.Buffer
 
-	if len(es) > 1 {
-		fmt.Fprintf(&buf, "%d errors: ", len(es))
+	if len(es.errs) > 1 {
+		fmt.Fprintf(&buf, "%d errors: ", len(es.errs))
 	}
 
-	for i, err := range es {
+	for i, err := range es.errs {
 		if i != 0 {
 			buf.WriteString("; ")
 		}
@@ -41,22 +79,11 @@ func (es MultiError) Error() string {
 	return buf.String()
 }
 
-// Add adds the error to the error list if it is not nil.
-func (es *MultiError) Add(err error) {
-	if err == nil {
-		return
+// CloseAll closes all given closers while recording error in MultiError.
+func CloseAll(cs []io.Closer) error {
+	errs := NewMulti()
+	for _, c := range cs {
+		errs.Add(c.Close())
 	}
-	if merr, ok := err.(MultiError); ok {
-		*es = append(*es, merr...)
-	} else {
-		*es = append(*es, err)
-	}
-}
-
-// Err returns the error list as an error or nil if it is empty.
-func (es MultiError) Err() error {
-	if len(es) == 0 {
-		return nil
-	}
-	return es
+	return errs.Err()
 }

--- a/vendor/github.com/prometheus/prometheus/tsdb/head.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head.go
@@ -1465,12 +1465,11 @@ func (h *Head) Close() error {
 	h.closedMtx.Lock()
 	defer h.closedMtx.Unlock()
 	h.closed = true
-	var merr tsdb_errors.MultiError
-	merr.Add(h.chunkDiskMapper.Close())
+	errs := tsdb_errors.NewMulti(h.chunkDiskMapper.Close())
 	if h.wal != nil {
-		merr.Add(h.wal.Close())
+		errs.Add(h.wal.Close())
 	}
-	return merr.Err()
+	return errs.Err()
 }
 
 type headChunkReader struct {

--- a/vendor/github.com/prometheus/prometheus/tsdb/index/index.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/index/index.go
@@ -1075,10 +1075,10 @@ func NewFileReader(path string) (*Reader, error) {
 	}
 	r, err := newReader(realByteSlice(f.Bytes()), f)
 	if err != nil {
-		var merr tsdb_errors.MultiError
-		merr.Add(err)
-		merr.Add(f.Close())
-		return nil, merr
+		return nil, tsdb_errors.NewMulti(
+			err,
+			f.Close(),
+		).Err()
 	}
 
 	return r, nil

--- a/vendor/github.com/prometheus/prometheus/tsdb/querier.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/querier.go
@@ -97,12 +97,14 @@ func (q *blockBaseQuerier) Close() error {
 	if q.closed {
 		return errors.New("block querier already closed")
 	}
-	var merr tsdb_errors.MultiError
-	merr.Add(q.index.Close())
-	merr.Add(q.chunks.Close())
-	merr.Add(q.tombstones.Close())
+
+	errs := tsdb_errors.NewMulti(
+		q.index.Close(),
+		q.chunks.Close(),
+		q.tombstones.Close(),
+	)
 	q.closed = true
-	return merr.Err()
+	return errs.Err()
 }
 
 type blockQuerier struct {

--- a/vendor/github.com/prometheus/prometheus/tsdb/repair.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/repair.go
@@ -83,18 +83,18 @@ func repairBadIndexVersion(logger log.Logger, dir string) error {
 			return errors.Wrapf(err, "copy content of index to index.repaired for block dir: %v", d)
 		}
 
-		var merr tsdb_errors.MultiError
-
 		// Set the 5th byte to 2 to indicate the correct file format version.
 		if _, err := repl.WriteAt([]byte{2}, 4); err != nil {
-			merr.Add(errors.Wrap(err, "rewrite of index.repaired"))
-			merr.Add(errors.Wrap(repl.Close(), "close"))
-			return errors.Wrapf(merr.Err(), "block dir: %v", d)
+			return tsdb_errors.NewMulti(
+				errors.Wrapf(err, "rewrite of index.repaired for block dir: %v", d),
+				errors.Wrap(repl.Close(), "close"),
+			).Err()
 		}
 		if err := repl.Sync(); err != nil {
-			merr.Add(errors.Wrap(err, "sync of index.repaired"))
-			merr.Add(errors.Wrap(repl.Close(), "close"))
-			return errors.Wrapf(merr.Err(), "block dir: %v", d)
+			return tsdb_errors.NewMulti(
+				errors.Wrapf(err, "sync of index.repaired for block dir: %v", d),
+				errors.Wrap(repl.Close(), "close"),
+			).Err()
 		}
 		if err := repl.Close(); err != nil {
 			return errors.Wrapf(repl.Close(), "close repaired index for block dir: %v", d)

--- a/vendor/github.com/prometheus/prometheus/tsdb/tombstones/tombstones.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/tombstones/tombstones.go
@@ -126,10 +126,8 @@ func WriteFile(logger log.Logger, dir string, tr Reader) (int64, error) {
 	}
 	size += n
 
-	var merr tsdb_errors.MultiError
-	if merr.Add(f.Sync()); merr.Err() != nil {
-		merr.Add(f.Close())
-		return 0, merr.Err()
+	if err := f.Sync(); err != nil {
+		return 0, tsdb_errors.NewMulti(err, f.Close()).Err()
 	}
 
 	if err = f.Close(); err != nil {

--- a/vendor/github.com/prometheus/prometheus/tsdb/wal/checkpoint.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/wal/checkpoint.go
@@ -68,14 +68,12 @@ func DeleteCheckpoints(dir string, maxIndex int) error {
 		return err
 	}
 
-	var errs tsdb_errors.MultiError
+	errs := tsdb_errors.NewMulti()
 	for _, checkpoint := range checkpoints {
 		if checkpoint.index >= maxIndex {
 			break
 		}
-		if err := os.RemoveAll(filepath.Join(dir, checkpoint.name)); err != nil {
-			errs.Add(err)
-		}
+		errs.Add(os.RemoveAll(filepath.Join(dir, checkpoint.name)))
 	}
 	return errs.Err()
 }

--- a/vendor/github.com/prometheus/prometheus/tsdb/wal/wal.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/wal/wal.go
@@ -74,9 +74,18 @@ func (p *page) reset() {
 	p.flushed = 0
 }
 
+// SegmentFile represents the underlying file used to store a segment.
+type SegmentFile interface {
+	Stat() (os.FileInfo, error)
+	Sync() error
+	io.Writer
+	io.Reader
+	io.Closer
+}
+
 // Segment represents a segment file.
 type Segment struct {
-	*os.File
+	SegmentFile
 	dir string
 	i   int
 }
@@ -130,7 +139,7 @@ func OpenWriteSegment(logger log.Logger, dir string, k int) (*Segment, error) {
 			return nil, errors.Wrap(err, "zero-pad torn page")
 		}
 	}
-	return &Segment{File: f, i: k, dir: dir}, nil
+	return &Segment{SegmentFile: f, i: k, dir: dir}, nil
 }
 
 // CreateSegment creates a new segment k in dir.
@@ -139,7 +148,7 @@ func CreateSegment(dir string, k int) (*Segment, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Segment{File: f, i: k, dir: dir}, nil
+	return &Segment{SegmentFile: f, i: k, dir: dir}, nil
 }
 
 // OpenReadSegment opens the segment with the given filename.
@@ -152,7 +161,7 @@ func OpenReadSegment(fn string) (*Segment, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Segment{File: f, i: k, dir: filepath.Dir(fn)}, nil
+	return &Segment{SegmentFile: f, i: k, dir: filepath.Dir(fn)}, nil
 }
 
 // WAL is a write ahead log that stores records in segment files.
@@ -517,8 +526,10 @@ func (w *WAL) flushPage(clear bool) error {
 	if clear {
 		p.alloc = pageSize // Write till end of page.
 	}
+
 	n, err := w.segment.Write(p.buf[p.flushed:p.alloc])
 	if err != nil {
+		p.flushed += n
 		return err
 	}
 	p.flushed += n
@@ -664,6 +675,9 @@ func (w *WAL) log(rec []byte, final bool) error {
 
 		if w.page.full() {
 			if err := w.flushPage(true); err != nil {
+				// TODO When the flushing fails at this point and the record has not been
+				// fully written to the buffer, we end up with a corrupted WAL because some part of the
+				// record have been written to the buffer, while the rest of the record will be discarded.
 				return err
 			}
 		}
@@ -705,7 +719,7 @@ func (w *WAL) Truncate(i int) (err error) {
 
 func (w *WAL) fsync(f *Segment) error {
 	start := time.Now()
-	err := f.File.Sync()
+	err := f.Sync()
 	w.metrics.fsyncDuration.Observe(time.Since(start).Seconds())
 	return err
 }

--- a/vendor/github.com/prometheus/prometheus/util/testutil/directory.go
+++ b/vendor/github.com/prometheus/prometheus/util/testutil/directory.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -139,32 +139,32 @@ func NewTemporaryDirectory(name string, t T) (handler TemporaryDirectory) {
 func DirHash(t *testing.T, path string) []byte {
 	hash := sha256.New()
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		if info.IsDir() {
 			return nil
 		}
 		f, err := os.Open(path)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer f.Close()
 
 		_, err = io.Copy(hash, f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		_, err = io.WriteString(hash, strconv.Itoa(int(info.Size())))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		_, err = io.WriteString(hash, info.Name())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		modTime, err := info.ModTime().GobEncode()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		_, err = io.WriteString(hash, string(modTime))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return hash.Sum(nil)
 }

--- a/vendor/github.com/thanos-io/thanos/pkg/block/fetcher.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/block/fetcher.go
@@ -24,14 +24,15 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/tsdb"
-	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
+	"golang.org/x/sync/errgroup"
+	"gopkg.in/yaml.v2"
+
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/errutil"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	"github.com/thanos-io/thanos/pkg/model"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/runutil"
-	"golang.org/x/sync/errgroup"
-	"gopkg.in/yaml.v2"
 )
 
 type fetcherMetrics struct {
@@ -278,7 +279,7 @@ type response struct {
 	metas   map[ulid.ULID]*metadata.Meta
 	partial map[ulid.ULID]error
 	// If metaErr > 0 it means incomplete view, so some metas, failed to be loaded.
-	metaErrs tsdberrors.MultiError
+	metaErrs errutil.MultiError
 
 	noMetas        float64
 	corruptedMetas float64

--- a/vendor/github.com/thanos-io/thanos/pkg/compact/downsample/downsample.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/compact/downsample/downsample.go
@@ -18,9 +18,9 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
-	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/errutil"
 	"github.com/thanos-io/thanos/pkg/runutil"
 )
 
@@ -73,7 +73,7 @@ func Downsample(
 	// Remove blockDir in case of errors.
 	defer func() {
 		if err != nil {
-			var merr tsdberrors.MultiError
+			var merr errutil.MultiError
 			merr.Add(err)
 			merr.Add(os.RemoveAll(blockDir))
 			err = merr.Err()

--- a/vendor/github.com/thanos-io/thanos/pkg/compact/downsample/streamed_block_writer.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/compact/downsample/streamed_block_writer.go
@@ -15,11 +15,11 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunks"
-	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/errutil"
 	"github.com/thanos-io/thanos/pkg/runutil"
 )
 
@@ -61,7 +61,7 @@ func NewStreamedBlockWriter(
 	// We should close any opened Closer up to an error.
 	defer func() {
 		if err != nil {
-			var merr tsdberrors.MultiError
+			var merr errutil.MultiError
 			merr.Add(err)
 			for _, cl := range closers {
 				merr.Add(cl.Close())
@@ -143,7 +143,7 @@ func (w *streamedBlockWriter) Close() error {
 	}
 	w.finalized = true
 
-	merr := tsdberrors.MultiError{}
+	merr := errutil.MultiError{}
 
 	if w.ignoreFinalize {
 		// Close open file descriptors anyway.

--- a/vendor/github.com/thanos-io/thanos/pkg/discovery/dns/provider.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/discovery/dns/provider.go
@@ -13,9 +13,9 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
 
 	"github.com/thanos-io/thanos/pkg/discovery/dns/miekgdns"
+	"github.com/thanos-io/thanos/pkg/errutil"
 	"github.com/thanos-io/thanos/pkg/extprom"
 )
 
@@ -111,7 +111,7 @@ func GetQTypeName(addr string) (qtype string, name string) {
 // defaultPort is used for non-SRV records when a port is not supplied.
 func (p *Provider) Resolve(ctx context.Context, addrs []string) error {
 	resolvedAddrs := map[string][]string{}
-	errs := tsdberrors.MultiError{}
+	errs := errutil.MultiError{}
 
 	for _, addr := range addrs {
 		var resolved []string

--- a/vendor/github.com/thanos-io/thanos/pkg/errutil/multierror.go.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/errutil/multierror.go.go
@@ -1,0 +1,51 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package errutil
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// The MultiError type implements the error interface, and contains the
+// Errors used to construct it.
+type MultiError []error
+
+// Returns a concatenated string of the contained errors.
+func (es MultiError) Error() string {
+	var buf bytes.Buffer
+
+	if len(es) > 1 {
+		fmt.Fprintf(&buf, "%d errors: ", len(es))
+	}
+
+	for i, err := range es {
+		if i != 0 {
+			buf.WriteString("; ")
+		}
+		buf.WriteString(err.Error())
+	}
+
+	return buf.String()
+}
+
+// Add adds the error to the error list if it is not nil.
+func (es *MultiError) Add(err error) {
+	if err == nil {
+		return
+	}
+	if merr, ok := err.(MultiError); ok {
+		*es = append(*es, merr...)
+	} else {
+		*es = append(*es, err)
+	}
+}
+
+// Err returns the error list as an error or nil if it is empty.
+func (es MultiError) Err() error {
+	if len(es) == 0 {
+		return nil
+	}
+	return es
+}

--- a/vendor/github.com/thanos-io/thanos/pkg/objstore/azure/helpers.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/objstore/azure/helpers.go
@@ -19,6 +19,17 @@ const DirDelim = "/"
 
 var errorCodeRegex = regexp.MustCompile(`X-Ms-Error-Code:\D*\[(\w+)\]`)
 
+func init() {
+	// Disable `ForceLog` in Azure storage module
+	// As the time of this patch, the logging function in the storage module isn't correctly
+	// detecting expected REST errors like 404 and so outputs them to syslog along with a stacktrace.
+	// https://github.com/Azure/azure-storage-blob-go/issues/214
+	//
+	// This needs to be done at startup because the underlying variable is not thread safe.
+	// https://github.com/Azure/azure-pipeline-go/blob/dc95902f1d32034f8f743ccc6c3f2eb36b84da27/pipeline/core.go#L276-L283
+	pipeline.SetForceLogEnabled(false)
+}
+
 func getContainerURL(ctx context.Context, conf Config) (blob.ContainerURL, error) {
 	c, err := blob.NewSharedKeyCredential(conf.StorageAccountName, conf.StorageAccountKey)
 	if err != nil {

--- a/vendor/github.com/thanos-io/thanos/pkg/objstore/s3/s3.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/objstore/s3/s3.go
@@ -59,16 +59,17 @@ var DefaultConfig = Config{
 
 // Config stores the configuration for s3 bucket.
 type Config struct {
-	Bucket          string            `yaml:"bucket"`
-	Endpoint        string            `yaml:"endpoint"`
-	Region          string            `yaml:"region"`
-	AccessKey       string            `yaml:"access_key"`
-	Insecure        bool              `yaml:"insecure"`
-	SignatureV2     bool              `yaml:"signature_version2"`
-	SecretKey       string            `yaml:"secret_key"`
-	PutUserMetadata map[string]string `yaml:"put_user_metadata"`
-	HTTPConfig      HTTPConfig        `yaml:"http_config"`
-	TraceConfig     TraceConfig       `yaml:"trace"`
+	Bucket             string            `yaml:"bucket"`
+	Endpoint           string            `yaml:"endpoint"`
+	Region             string            `yaml:"region"`
+	AccessKey          string            `yaml:"access_key"`
+	Insecure           bool              `yaml:"insecure"`
+	SignatureV2        bool              `yaml:"signature_version2"`
+	SecretKey          string            `yaml:"secret_key"`
+	PutUserMetadata    map[string]string `yaml:"put_user_metadata"`
+	HTTPConfig         HTTPConfig        `yaml:"http_config"`
+	TraceConfig        TraceConfig       `yaml:"trace"`
+	ListObjectsVersion string            `yaml:"list_objects_version"`
 	// PartSize used for multipart upload. Only used if uploaded object size is known and larger than configured PartSize.
 	PartSize  uint64    `yaml:"part_size"`
 	SSEConfig SSEConfig `yaml:"sse_config"`
@@ -137,6 +138,7 @@ type Bucket struct {
 	sse             encrypt.ServerSide
 	putUserMetadata map[string]string
 	partSize        uint64
+	listObjectsV1   bool
 }
 
 // parseConfig unmarshals a buffer into a Config with default HTTPConfig values.
@@ -246,6 +248,10 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 		client.TraceOn(logWriter)
 	}
 
+	if config.ListObjectsVersion != "" && config.ListObjectsVersion != "v1" && config.ListObjectsVersion != "v2" {
+		return nil, errors.Errorf("Initialize s3 client list objects version: Unsupported version %q was provided. Supported values are v1, v2", config.ListObjectsVersion)
+	}
+
 	bkt := &Bucket{
 		logger:          logger,
 		name:            config.Bucket,
@@ -253,6 +259,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 		sse:             sse,
 		putUserMetadata: config.PutUserMetadata,
 		partSize:        config.PartSize,
+		listObjectsV1:   config.ListObjectsVersion == "v1",
 	}
 	return bkt, nil
 }
@@ -309,6 +316,7 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error) err
 	opts := minio.ListObjectsOptions{
 		Prefix:    dir,
 		Recursive: false,
+		UseV1:     b.listObjectsV1,
 	}
 
 	for object := range b.client.ListObjects(ctx, b.name, opts) {

--- a/vendor/github.com/thanos-io/thanos/pkg/runutil/runutil.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/runutil/runutil.go
@@ -59,7 +59,8 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
-	tsdberrors "github.com/prometheus/prometheus/tsdb/errors"
+
+	"github.com/thanos-io/thanos/pkg/errutil"
 )
 
 // Repeat executes f every interval seconds until stopc is closed or f returns an error.
@@ -136,7 +137,7 @@ func ExhaustCloseWithLogOnErr(logger log.Logger, r io.ReadCloser, format string,
 // CloseWithErrCapture runs function and on error return error by argument including the given error (usually
 // from caller function).
 func CloseWithErrCapture(err *error, closer io.Closer, format string, a ...interface{}) {
-	merr := tsdberrors.MultiError{}
+	merr := errutil.MultiError{}
 
 	merr.Add(*err)
 	merr.Add(errors.Wrapf(closer.Close(), format, a...))
@@ -151,7 +152,7 @@ func ExhaustCloseWithErrCapture(err *error, r io.ReadCloser, format string, a ..
 	CloseWithErrCapture(err, r, format, a...)
 
 	// Prepend the io.Copy error.
-	merr := tsdberrors.MultiError{}
+	merr := errutil.MultiError{}
 	merr.Add(copyErr)
 	merr.Add(*err)
 

--- a/vendor/github.com/thanos-io/thanos/pkg/store/multitsdb.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/store/multitsdb.go
@@ -15,14 +15,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
-	"github.com/thanos-io/thanos/pkg/runutil"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/thanos-io/thanos/pkg/component"
+	"github.com/thanos-io/thanos/pkg/errutil"
+	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/tracing"
@@ -168,7 +168,7 @@ func (s *tenantSeriesSetServer) Delegate(closer io.Closer) {
 }
 
 func (s *tenantSeriesSetServer) Close() error {
-	var merr tsdb_errors.MultiError
+	var merr errutil.MultiError
 	for _, c := range s.closers {
 		merr.Add(c.Close())
 	}

--- a/vendor/github.com/thanos-io/thanos/pkg/store/storepb/testutil/series.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/store/storepb/testutil/series.go
@@ -235,10 +235,14 @@ func TestServerSeries(t testutil.TB, store storepb.StoreServer, cases ...*Series
 					if len(c.ExpectedSeries) > 4 {
 						for j := range c.ExpectedSeries {
 							testutil.Equals(t, c.ExpectedSeries[j].Labels, srv.SeriesSet[j].Labels, "%v series chunks mismatch", j)
-							if len(c.ExpectedSeries[j].Chunks) > 20 {
-								testutil.Equals(t, len(c.ExpectedSeries[j].Chunks), len(srv.SeriesSet[j].Chunks), "%v series chunks number mismatch", j)
+
+							// Check chunks when it is not a skip chunk query
+							if !c.Req.SkipChunks {
+								if len(c.ExpectedSeries[j].Chunks) > 20 {
+									testutil.Equals(t, len(c.ExpectedSeries[j].Chunks), len(srv.SeriesSet[j].Chunks), "%v series chunks number mismatch", j)
+								}
+								testutil.Equals(t, c.ExpectedSeries[j].Chunks, srv.SeriesSet[j].Chunks, "%v series chunks mismatch", j)
 							}
-							testutil.Equals(t, c.ExpectedSeries[j].Chunks, srv.SeriesSet[j].Chunks, "%v series chunks mismatch", j)
 						}
 					} else {
 						testutil.Equals(t, c.ExpectedSeries, srv.SeriesSet)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -483,7 +483,7 @@ github.com/prometheus/node_exporter/https
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20201028100903-3245b3267b24
+# github.com/prometheus/prometheus v1.8.2-0.20201029103703-63be30dceed9
 ## explicit
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -565,7 +565,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thanos-io/thanos v0.13.1-0.20201019130456-f41940581d9a
+# github.com/thanos-io/thanos v0.13.1-0.20201030101306-47f9a225cc52
 ## explicit
 github.com/thanos-io/thanos/pkg/block
 github.com/thanos-io/thanos/pkg/block/indexheader
@@ -578,6 +578,7 @@ github.com/thanos-io/thanos/pkg/component
 github.com/thanos-io/thanos/pkg/discovery/cache
 github.com/thanos-io/thanos/pkg/discovery/dns
 github.com/thanos-io/thanos/pkg/discovery/dns/miekgdns
+github.com/thanos-io/thanos/pkg/errutil
 github.com/thanos-io/thanos/pkg/extprom
 github.com/thanos-io/thanos/pkg/gate
 github.com/thanos-io/thanos/pkg/http


### PR DESCRIPTION
**What this PR does**:
In this PR I'm upgrading Prometheus and Thanos, in order to backport the TSDB WAL corruption (partial) fix done in https://github.com/prometheus/prometheus/pull/8125.

In this PR I'm also removing the temporarily interned `MultiError` (https://github.com/cortexproject/cortex/pull/3425) which was done as a trick to avoid a circular breaking change between Cortex and Thanos, blocking both projects from upgrading Prometheus.

I've checked Thanos changes and there's nothing that we should change on our side (eg. no new metrics to map).

/cc @codesome 

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
