### PR TITLE
Disable CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,26 +13,25 @@ filters: &filters
     tags:
       only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
 
-workflows:
-  version: 2
-  test-build-deploy:
+# workflows:
+#   version: 2
+#   test-build-deploy:
     # You must specify a tag filter for each job that deploy depends on.
-    jobs:
-    - lint:
-        <<: *filters
-    - test:
-        <<: *filters
-    - integration:
-        requires:
-        - build
-        <<: *filters
-    - integration-configs-db:
-        requires:
-        - build
-        <<: *filters
-    - build:
-        <<: *filters
-    # Disabling deploy jobs to prevent deploying twice while Github Actions Workflows are Running
+    # jobs:
+    # - lint:
+    #     <<: *filters
+    # - test:
+    #     <<: *filters
+    # - integration:
+    #     requires:
+    #     - build
+    #     <<: *filters
+    # - integration-configs-db:
+    #     requires:
+    #     - build
+    #     <<: *filters
+    # - build:
+    #     <<: *filters
     # - deploy_website:
     #     requires:
     #     - test


### PR DESCRIPTION
**What this PR does**:
We're currently running the CI both in GitHub actions and CircleCI. The GitHub actions workflow looks to be stable and @csmarchbanks fixed the last few things came up during the `1.5.0-rc.0` release process.

What's the sentiment about disabling CircleCI workflow as next step, before completely tearing it down?

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
