### PR TITLE
Fixed faillint for ./integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ lint:
 	golangci-lint run
 
 	# Ensure no blacklisted package is imported.
-	faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
+	GOFLAGS="-tags=requires_docker" faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
 		golang.org/x/net/context=context,\
 		github.com/prometheus/prometheus/tsdb/errors=util,\
 		sync/atomic=go.uber.org/atomic" ./pkg/... ./cmd/... ./tools/... ./integration/...


### PR DESCRIPTION
**What this PR does**:
Faillint didn't run on integration tests. Was a known issue, but didin't know how to fix. The good @fatih showed me the solution https://github.com/fatih/faillint/issues/20 and in this PR I'm fixing it. I've tried to manually introduce a failure in `./integration` and `faillint` correctly fails.

**Which issue(s) this PR fixes**:
Fixes #3024

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
