### PR TITLE
fix: register querier routes explicitly with handler for instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,6 @@
 * [ENHANCEMENT] Ruler: Include the tenant ID on the notifier logs. #3372
 * [ENHANCEMENT] Blocks storage Compactor: Added `-compactor.enabled-tenants` and `-compactor.disabled-tenants` to explicitly enable or disable compaction of specific tenants. #3385
 * [ENHANCEMENT] Blocks storage ingester: Creating checkpoint only once even when there are multiple Head compactions in a single `Compact()` call. #3373
-* [BUGFIX] Querier API: Fix issues #3432 where `cortex_querier_request_` metrics where truncated routes. #3436
 * [BUGFIX] Blocks storage ingester: Read repair memory-mapped chunks file which can end up being empty on abrupt shutdowns combined with faulty disks. #3373
 * [BUGFIX] Blocks storage ingester: Close TSDB resources on failed startup preventing ingester OOMing. #3373
 * [BUGFIX] No-longer-needed ingester operations for queries triggered by queriers and rulers are now canceled. #3178

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 * [ENHANCEMENT] Ruler: Include the tenant ID on the notifier logs. #3372
 * [ENHANCEMENT] Blocks storage Compactor: Added `-compactor.enabled-tenants` and `-compactor.disabled-tenants` to explicitly enable or disable compaction of specific tenants. #3385
 * [ENHANCEMENT] Blocks storage ingester: Creating checkpoint only once even when there are multiple Head compactions in a single `Compact()` call. #3373
+* [BUGFIX] Querier API: Fix issues #3432 where `cortex_querier_request_` metrics where truncated routes. #3436
 * [BUGFIX] Blocks storage ingester: Read repair memory-mapped chunks file which can end up being empty on abrupt shutdowns combined with faulty disks. #3373
 * [BUGFIX] Blocks storage ingester: Close TSDB resources on failed startup preventing ingester OOMing. #3373
 * [BUGFIX] No-longer-needed ingester operations for queries triggered by queriers and rulers are now canceled. #3178

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -8,11 +8,14 @@ import (
 	"regexp"
 	"sync"
 
+	"github.com/cortexproject/cortex/pkg/chunk/purger"
+	"github.com/cortexproject/cortex/pkg/distributor"
+	"github.com/cortexproject/cortex/pkg/querier"
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/gorilla/mux"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -24,12 +27,6 @@ import (
 	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/middleware"
-	"gopkg.in/yaml.v2"
-
-	"github.com/cortexproject/cortex/pkg/chunk/purger"
-	"github.com/cortexproject/cortex/pkg/distributor"
-	"github.com/cortexproject/cortex/pkg/querier"
-	"github.com/cortexproject/cortex/pkg/util"
 )
 
 const (
@@ -229,13 +226,13 @@ func NewQuerierHandler(
 	// https://github.com/prometheus/prometheus/pull/7125/files
 	router.Path(cfg.LegacyHTTPPrefix + "/api/v1/metadata").Handler(querier.MetadataHandler(distributor))
 	router.Path(cfg.LegacyHTTPPrefix + "/api/v1/read").Handler(querier.RemoteReadHandler(queryable))
-	router.Path(cfg.PrometheusHTTPPrefix + "/api/v1/read").Methods("POST").Handler(legacyPromRouter)
-	router.Path(cfg.PrometheusHTTPPrefix+"/api/v1/query").Methods("GET", "POST").Handler(legacyPromRouter)
-	router.Path(cfg.PrometheusHTTPPrefix+"/api/v1/query_range").Methods("GET", "POST").Handler(legacyPromRouter)
-	router.Path(cfg.PrometheusHTTPPrefix+"/api/v1/labels").Methods("GET", "POST").Handler(legacyPromRouter)
-	router.Path(cfg.PrometheusHTTPPrefix + "/api/v1/label/{name}/values").Methods("GET").Handler(legacyPromRouter)
-	router.Path(cfg.PrometheusHTTPPrefix+"/api/v1/series").Methods("GET", "POST", "DELETE").Handler(legacyPromRouter)
-	router.Path(cfg.PrometheusHTTPPrefix + "/api/v1/metadata").Methods("GET").Handler(legacyPromRouter)
+	router.Path(cfg.LegacyHTTPPrefix + "/api/v1/read").Methods("POST").Handler(legacyPromRouter)
+	router.Path(cfg.LegacyHTTPPrefix+"/api/v1/query").Methods("GET", "POST").Handler(legacyPromRouter)
+	router.Path(cfg.LegacyHTTPPrefix+"/api/v1/query_range").Methods("GET", "POST").Handler(legacyPromRouter)
+	router.Path(cfg.LegacyHTTPPrefix+"/api/v1/labels").Methods("GET", "POST").Handler(legacyPromRouter)
+	router.Path(cfg.LegacyHTTPPrefix + "/api/v1/label/{name}/values").Methods("GET").Handler(legacyPromRouter)
+	router.Path(cfg.LegacyHTTPPrefix+"/api/v1/series").Methods("GET", "POST", "DELETE").Handler(legacyPromRouter)
+	router.Path(cfg.LegacyHTTPPrefix + "/api/v1/metadata").Methods("GET").Handler(legacyPromRouter)
 
 	// Add a middleware to extract the trace context and add a header.
 	return nethttp.MiddlewareFunc(opentracing.GlobalTracer(), router.ServeHTTP, nethttp.OperationNameFunc(func(r *http.Request) string {

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -189,7 +189,7 @@ func NewQuerierHandler(
 		prometheus.GathererFunc(func() ([]*dto.MetricFamily, error) { return nil, nil }),
 	)
 
-	router := mux.NewRouter()
+	router := mux.NewRouter().PathPrefix(cfg.ServerPrefix)
 
 	// Use a separate metric for the querier in order to differentiate requests from the query-frontend when
 	// running Cortex as a single binary.

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -8,10 +8,6 @@ import (
 	"regexp"
 	"sync"
 
-	"github.com/cortexproject/cortex/pkg/chunk/purger"
-	"github.com/cortexproject/cortex/pkg/distributor"
-	"github.com/cortexproject/cortex/pkg/querier"
-	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/gorilla/mux"
@@ -28,6 +24,12 @@ import (
 	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/middleware"
+	"gopkg.in/yaml.v2"
+
+	"github.com/cortexproject/cortex/pkg/chunk/purger"
+	"github.com/cortexproject/cortex/pkg/distributor"
+	"github.com/cortexproject/cortex/pkg/querier"
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 const (


### PR DESCRIPTION
**What this PR does**:

- Registers the Querier internal routes explicitly to ensure the instrumentation utilizes the correct route names

**Which issue(s) this PR fixes**:
Fixes #3432 

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
