### PR TITLE
Add EverQuote to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -5,6 +5,7 @@ This is the list of organisations that are using Cortex in **production environm
 * [Aspen Mesh](https://aspenmesh.io/)
 * [DigitalOcean](https://www.digitalocean.com/)
 * [Electronic Arts](https://www.ea.com/)
+* [EverQuote](https://everquote.com/)
 * [GoJek](https://www.gojek.io/)
 * [GrafanaLabs](https://grafana.com/)
 * [MayaData](https://mayadata.io/)


### PR DESCRIPTION
**What this PR does**:

Add EverQuote, Inc. to Adopters.md.  

We have been running Cortex in Production (self-hosted) for several months now.  Previously we used Cortex (hosted by Grafana Cloud) for several months as part of the POC.
