### PR TITLE
chore: ensure internalQuerier utilizes identical authMiddleware to API

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
 	prom_storage "github.com/prometheus/prometheus/storage"
-	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager"
@@ -295,7 +294,7 @@ func (t *Cortex) initQuerier() (serv services.Service, err error) {
 		// If queries are processed using the external HTTP Server, we need wrap the internal querier with
 		// HTTP router with middleware to parse the tenant ID from the HTTP header and inject it into the
 		// request context.
-		internalQuerierRouter = middleware.AuthenticateUser.Wrap(internalQuerierRouter)
+		internalQuerierRouter = t.API.AuthMiddleware.Wrap(internalQuerierRouter)
 	}
 
 	// If neither frontend address or scheduler address is configured, no worker will be created.


### PR DESCRIPTION
**What this PR does**:

This PR ensures the authentication middleware used by the internalQuerier is the same that is used by the API struct. I was worried this might be causing an issue with queries for single binary users with `no org id` errors, however, I manually verified it is not. Currently, this isn't causing an issue because the query-frontend will create the `x-scope-orgid` header with `fake` as a value so the `AuthenticateUser` middleware is valid. However, this will ensure any changes made to the auth middleware used by the API in the future will also be added to this internalHandler..