### PR TITLE
Remove dummy credentials from AWS config

### DIFF
--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -137,7 +137,6 @@ func buildS3Config(cfg S3Config) (*aws.Config, []string, error) {
 	} else {
 		s3Config = &aws.Config{}
 		s3Config = s3Config.WithRegion("dummy")
-		s3Config = s3Config.WithCredentials(credentials.AnonymousCredentials)
 	}
 
 	s3Config = s3Config.WithMaxRetries(0)                          // We do our own retries, so we can monitor them


### PR DESCRIPTION
**What this PR does**:

the current dummy credentials deny using EKS IAM service accounts, removing this line fallback to the AWS SDK default which is the following:

* Environment Variables
* Shared Credentials file
* Shared Configuration file (if SharedConfig is enabled)
* EC2 Instance Metadata (credentials only)

reference: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#NewSession

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
