### PR TITLE
query-scheduler: forward error directly to frontend

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -165,6 +165,8 @@ query_scheduler:
   # CLI flag: -query-scheduler.max-outstanding-requests-per-tenant
   [max_outstanding_requests_per_tenant: <int> | default = 100]
 
+  # This configures the gRPC client used to report errors back to the
+  # query-frontend.
   grpc_client_config:
     # gRPC client max receive message size (bytes).
     # CLI flag: -query-scheduler.grpc-client-config.grpc-max-recv-msg-size

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -164,6 +164,69 @@ query_scheduler:
   # 429.
   # CLI flag: -query-scheduler.max-outstanding-requests-per-tenant
   [max_outstanding_requests_per_tenant: <int> | default = 100]
+
+  grpc_client_config:
+    # gRPC client max receive message size (bytes).
+    # CLI flag: -query-scheduler.grpc-client-config.grpc-max-recv-msg-size
+    [max_recv_msg_size: <int> | default = 104857600]
+
+    # gRPC client max send message size (bytes).
+    # CLI flag: -query-scheduler.grpc-client-config.grpc-max-send-msg-size
+    [max_send_msg_size: <int> | default = 16777216]
+
+    # Deprecated: Use gzip compression when sending messages.  If true,
+    # overrides grpc-compression flag.
+    # CLI flag: -query-scheduler.grpc-client-config.grpc-use-gzip-compression
+    [use_gzip_compression: <boolean> | default = false]
+
+    # Use compression when sending messages. Supported values are: 'gzip',
+    # 'snappy' and '' (disable compression)
+    # CLI flag: -query-scheduler.grpc-client-config.grpc-compression
+    [grpc_compression: <string> | default = ""]
+
+    # Rate limit for gRPC client; 0 means disabled.
+    # CLI flag: -query-scheduler.grpc-client-config.grpc-client-rate-limit
+    [rate_limit: <float> | default = 0]
+
+    # Rate limit burst for gRPC client.
+    # CLI flag: -query-scheduler.grpc-client-config.grpc-client-rate-limit-burst
+    [rate_limit_burst: <int> | default = 0]
+
+    # Enable backoff and retry when we hit ratelimits.
+    # CLI flag: -query-scheduler.grpc-client-config.backoff-on-ratelimits
+    [backoff_on_ratelimits: <boolean> | default = false]
+
+    backoff_config:
+      # Minimum delay when backing off.
+      # CLI flag: -query-scheduler.grpc-client-config.backoff-min-period
+      [min_period: <duration> | default = 100ms]
+
+      # Maximum delay when backing off.
+      # CLI flag: -query-scheduler.grpc-client-config.backoff-max-period
+      [max_period: <duration> | default = 10s]
+
+      # Number of times to backoff and retry before failing.
+      # CLI flag: -query-scheduler.grpc-client-config.backoff-retries
+      [max_retries: <int> | default = 10]
+
+    # Path to the client certificate file, which will be used for authenticating
+    # with the server. Also requires the key path to be configured.
+    # CLI flag: -query-scheduler.grpc-client-config.tls-cert-path
+    [tls_cert_path: <string> | default = ""]
+
+    # Path to the key file for the client certificate. Also requires the client
+    # certificate to be configured.
+    # CLI flag: -query-scheduler.grpc-client-config.tls-key-path
+    [tls_key_path: <string> | default = ""]
+
+    # Path to the CA certificates file to validate server certificate against.
+    # If not set, the host's root CA certificates are used.
+    # CLI flag: -query-scheduler.grpc-client-config.tls-ca-path
+    [tls_ca_path: <string> | default = ""]
+
+    # Skip validating server certificate.
+    # CLI flag: -query-scheduler.grpc-client-config.tls-insecure-skip-verify
+    [tls_insecure_skip_verify: <boolean> | default = false]
 ```
 
 ### `server_config`

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -20,7 +20,7 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
-	querier_frontend "github.com/cortexproject/cortex/pkg/querier/frontend2"
+	"github.com/cortexproject/cortex/pkg/frontend/v2/frontendv2pb"
 	"github.com/cortexproject/cortex/pkg/scheduler/schedulerpb"
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 	"github.com/cortexproject/cortex/pkg/util/grpcutil"
@@ -407,10 +407,10 @@ func (s *Scheduler) forwardErrorToFrontend(ctx context.Context, req *schedulerRe
 		_ = conn.Close()
 	}()
 
-	client := querier_frontend.NewFrontendForQuerierClient(conn)
+	client := frontendv2pb.NewFrontendForQuerierClient(conn)
 
 	userCtx := user.InjectOrgID(ctx, req.userID)
-	_, err = client.QueryResult(userCtx, &querier_frontend.QueryResultRequest{
+	_, err = client.QueryResult(userCtx, &frontendv2pb.QueryResultRequest{
 		QueryID: req.queryID,
 		HttpResponse: &httpgrpc.HTTPResponse{
 			Code: http.StatusInternalServerError,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -381,7 +381,10 @@ func (s *Scheduler) forwardRequestToQuerier(querier schedulerpb.SchedulerForQuer
 	case err := <-errCh:
 		// Is there was an error handling this request due to network IO,
 		// then error out this upstream request _and_ stream.
-		s.forwardErrorToFrontend(req.ctx, req, err)
+
+		if err != nil {
+			s.forwardErrorToFrontend(req.ctx, req, err)
+		}
 		return err
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -4,18 +4,25 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"net/http"
 	"sync"
 	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	otgrpc "github.com/opentracing-contrib/go-grpc"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/middleware"
+	"github.com/weaveworks/common/user"
 	"go.uber.org/atomic"
+	"google.golang.org/grpc"
 
+	"github.com/cortexproject/cortex/pkg/querier/frontend2"
 	"github.com/cortexproject/cortex/pkg/scheduler/schedulerpb"
+	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 	"github.com/cortexproject/cortex/pkg/util/grpcutil"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
@@ -29,6 +36,7 @@ var (
 type Scheduler struct {
 	services.Service
 
+	cfg Config
 	log log.Logger
 
 	limits Limits
@@ -66,15 +74,21 @@ type connectedFrontend struct {
 
 type Config struct {
 	MaxOutstandingPerTenant int `yaml:"max_outstanding_requests_per_tenant"`
+
+	// Used to report errors back to frontend, if needed.
+	GRPCClientConfig grpcclient.ConfigWithTLS `yaml:"grpc_client_config"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxOutstandingPerTenant, "query-scheduler.max-outstanding-requests-per-tenant", 100, "Maximum number of outstanding requests per tenant per query-scheduler. In-flight requests above this limit will fail with HTTP response status code 429.")
+
+	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("query-scheduler.grpc-client-config", f)
 }
 
 // NewScheduler creates a new Scheduler.
 func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer prometheus.Registerer) (*Scheduler, error) {
 	s := &Scheduler{
+		cfg:    cfg,
 		log:    log,
 		limits: limits,
 
@@ -367,8 +381,45 @@ func (s *Scheduler) forwardRequestToQuerier(querier schedulerpb.SchedulerForQuer
 	case err := <-errCh:
 		// Is there was an error handling this request due to network IO,
 		// then error out this upstream request _and_ stream.
-		// TODO: if err is not nil, scheduler should notify frontend using the frontend address.
+		s.forwardErrorToFrontend(req.ctx, req, err)
 		return err
+	}
+}
+
+func (s *Scheduler) forwardErrorToFrontend(ctx context.Context, req *schedulerRequest, requestErr error) {
+	opts, err := s.cfg.GRPCClientConfig.DialOption([]grpc.UnaryClientInterceptor{
+		otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()),
+		middleware.ClientUserHeaderInterceptor},
+		nil)
+	if err != nil {
+		level.Warn(s.log).Log("msg", "failed to create gRPC connection to frontend to report error", "frontend", req.frontendAddress, "err", err, "requestErr", requestKey{})
+		return
+	}
+
+	conn, err := grpc.DialContext(ctx, req.frontendAddress, opts...)
+	if err != nil {
+		level.Warn(s.log).Log("msg", "failed to create gRPC connection to frontend to report error", "frontend", req.frontendAddress, "err", err, "requestErr", requestKey{})
+		return
+	}
+
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	client := frontend2.NewFrontendForQuerierClient(conn)
+
+	userCtx := user.InjectOrgID(ctx, req.userID)
+	_, err = client.QueryResult(userCtx, &frontend2.QueryResultRequest{
+		QueryID: req.queryID,
+		HttpResponse: &httpgrpc.HTTPResponse{
+			Code: http.StatusInternalServerError,
+			Body: []byte(requestErr.Error()),
+		},
+	})
+
+	if err != nil {
+		level.Warn(s.log).Log("msg", "failed to forward error to frontend", "frontend", req.frontendAddress, "err", err, "requestErr", requestErr)
+		return
 	}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -75,13 +75,11 @@ type connectedFrontend struct {
 type Config struct {
 	MaxOutstandingPerTenant int `yaml:"max_outstanding_requests_per_tenant"`
 
-	// Used to report errors back to frontend, if needed.
-	GRPCClientConfig grpcclient.ConfigWithTLS `yaml:"grpc_client_config"`
+	GRPCClientConfig grpcclient.ConfigWithTLS `yaml:"grpc_client_config" doc:"description=This configures the gRPC client used to report errors back to the query-frontend."`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxOutstandingPerTenant, "query-scheduler.max-outstanding-requests-per-tenant", 100, "Maximum number of outstanding requests per tenant per query-scheduler. In-flight requests above this limit will fail with HTTP response status code 429.")
-
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("query-scheduler.grpc-client-config", f)
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -20,7 +20,7 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
-	"github.com/cortexproject/cortex/pkg/querier/frontend2"
+	querier_frontend "github.com/cortexproject/cortex/pkg/querier/frontend2"
 	"github.com/cortexproject/cortex/pkg/scheduler/schedulerpb"
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 	"github.com/cortexproject/cortex/pkg/util/grpcutil"
@@ -395,13 +395,13 @@ func (s *Scheduler) forwardErrorToFrontend(ctx context.Context, req *schedulerRe
 		middleware.ClientUserHeaderInterceptor},
 		nil)
 	if err != nil {
-		level.Warn(s.log).Log("msg", "failed to create gRPC connection to frontend to report error", "frontend", req.frontendAddress, "err", err, "requestErr", requestKey{})
+		level.Warn(s.log).Log("msg", "failed to create gRPC options for the connection to frontend to report error", "frontend", req.frontendAddress, "err", err, "requestErr", requestErr)
 		return
 	}
 
 	conn, err := grpc.DialContext(ctx, req.frontendAddress, opts...)
 	if err != nil {
-		level.Warn(s.log).Log("msg", "failed to create gRPC connection to frontend to report error", "frontend", req.frontendAddress, "err", err, "requestErr", requestKey{})
+		level.Warn(s.log).Log("msg", "failed to create gRPC connection to frontend to report error", "frontend", req.frontendAddress, "err", err, "requestErr", requestErr)
 		return
 	}
 
@@ -409,10 +409,10 @@ func (s *Scheduler) forwardErrorToFrontend(ctx context.Context, req *schedulerRe
 		_ = conn.Close()
 	}()
 
-	client := frontend2.NewFrontendForQuerierClient(conn)
+	client := querier_frontend.NewFrontendForQuerierClient(conn)
 
 	userCtx := user.InjectOrgID(ctx, req.userID)
-	_, err = client.QueryResult(userCtx, &frontend2.QueryResultRequest{
+	_, err = client.QueryResult(userCtx, &querier_frontend.QueryResultRequest{
 		QueryID: req.queryID,
 		HttpResponse: &httpgrpc.HTTPResponse{
 			Code: http.StatusInternalServerError,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"google.golang.org/grpc"
 
-	"github.com/cortexproject/cortex/pkg/querier/frontend2"
+	"github.com/cortexproject/cortex/pkg/frontend/v2/frontendv2pb"
 	"github.com/cortexproject/cortex/pkg/scheduler/schedulerpb"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	chunk "github.com/cortexproject/cortex/pkg/util/grpcutil"
@@ -352,7 +352,7 @@ func TestSchedulerForwardsErrorToFrontend(t *testing.T) {
 	// Setup frontend grpc server
 	{
 		frontendGrpcServer := grpc.NewServer()
-		frontend2.RegisterFrontendForQuerierServer(frontendGrpcServer, fm)
+		frontendv2pb.RegisterFrontendForQuerierServer(frontendGrpcServer, fm)
 
 		l, err := net.Listen("tcp", "")
 		require.NoError(t, err)
@@ -469,12 +469,12 @@ type frontendMock struct {
 	resp map[uint64]*httpgrpc.HTTPResponse
 }
 
-func (f *frontendMock) QueryResult(_ context.Context, request *frontend2.QueryResultRequest) (*frontend2.QueryResultResponse, error) {
+func (f *frontendMock) QueryResult(_ context.Context, request *frontendv2pb.QueryResultRequest) (*frontendv2pb.QueryResultResponse, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	f.resp[request.QueryID] = request.HttpResponse
-	return &frontend2.QueryResultResponse{}, nil
+	return &frontendv2pb.QueryResultResponse{}, nil
 }
 
 func (f *frontendMock) getRequest(queryID uint64) *httpgrpc.HTTPResponse {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,7 +17,9 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"google.golang.org/grpc"
 
+	"github.com/cortexproject/cortex/pkg/querier/frontend2"
 	"github.com/cortexproject/cortex/pkg/scheduler/schedulerpb"
+	"github.com/cortexproject/cortex/pkg/util/flagext"
 	chunk "github.com/cortexproject/cortex/pkg/util/grpcutil"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/test"
@@ -24,7 +28,11 @@ import (
 const testMaxOutstandingPerTenant = 5
 
 func setupScheduler(t *testing.T) (*Scheduler, schedulerpb.SchedulerForFrontendClient, schedulerpb.SchedulerForQuerierClient) {
-	s, err := NewScheduler(Config{MaxOutstandingPerTenant: testMaxOutstandingPerTenant}, &limits{queriers: 2}, log.NewNopLogger(), nil)
+	cfg := Config{}
+	flagext.DefaultValues(&cfg)
+	cfg.MaxOutstandingPerTenant = testMaxOutstandingPerTenant
+
+	s, err := NewScheduler(cfg, &limits{queriers: 2}, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 
 	server := grpc.NewServer()
@@ -335,6 +343,66 @@ func TestSchedulerMaxOutstandingRequests(t *testing.T) {
 	require.True(t, msg.Status == schedulerpb.TOO_MANY_REQUESTS_PER_TENANT)
 }
 
+func TestSchedulerForwardsErrorToFrontend(t *testing.T) {
+	_, frontendClient, querierClient := setupScheduler(t)
+
+	fm := &frontendMock{resp: map[uint64]*httpgrpc.HTTPResponse{}}
+	frontendAddress := ""
+
+	// Setup frontend grpc server
+	{
+		frontendGrpcServer := grpc.NewServer()
+		frontend2.RegisterFrontendForQuerierServer(frontendGrpcServer, fm)
+
+		l, err := net.Listen("tcp", "")
+		require.NoError(t, err)
+
+		frontendAddress = l.Addr().String()
+
+		go func() {
+			_ = frontendGrpcServer.Serve(l)
+		}()
+
+		t.Cleanup(func() {
+			_ = l.Close()
+		})
+	}
+
+	// After preparations, start frontend and querier.
+	frontendLoop := initFrontendLoop(t, frontendClient, frontendAddress)
+	frontendToScheduler(t, frontendLoop, &schedulerpb.FrontendToScheduler{
+		Type:        schedulerpb.ENQUEUE,
+		QueryID:     100,
+		UserID:      "test",
+		HttpRequest: &httpgrpc.HTTPRequest{Method: "GET", Url: "/hello"},
+	})
+
+	// Scheduler now has 1 query. We now connect querier, fetch the request, and then close the connection.
+	// This will make scheduler to report error back to frontend.
+
+	querierLoop, err := querierClient.QuerierLoop(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, querierLoop.Send(&schedulerpb.QuerierToScheduler{QuerierID: "querier-1"}))
+
+	// Dequeue first query.
+	_, err = querierLoop.Recv()
+	require.NoError(t, err)
+
+	// Querier now disconnects, without sending empty message back.
+	require.NoError(t, querierLoop.CloseSend())
+
+	// Verify that frontend was notified about request.
+	test.Poll(t, 2*time.Second, true, func() interface{} {
+		resp := fm.getRequest(100)
+		if resp == nil {
+			return false
+		}
+
+		require.Equal(t, int32(http.StatusInternalServerError), resp.Code)
+		return true
+	})
+}
+
 func initFrontendLoop(t *testing.T, client schedulerpb.SchedulerForFrontendClient, frontendAddr string) schedulerpb.SchedulerForFrontend_FrontendLoopClient {
 	loop, err := client.FrontendLoop(context.Background())
 	require.NoError(t, err)
@@ -394,4 +462,24 @@ type limits struct {
 
 func (l limits) MaxQueriersPerUser(_ string) int {
 	return l.queriers
+}
+
+type frontendMock struct {
+	mu   sync.Mutex
+	resp map[uint64]*httpgrpc.HTTPResponse
+}
+
+func (f *frontendMock) QueryResult(_ context.Context, request *frontend2.QueryResultRequest) (*frontend2.QueryResultResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.resp[request.QueryID] = request.HttpResponse
+	return &frontend2.QueryResultResponse{}, nil
+}
+
+func (f *frontendMock) getRequest(queryID uint64) *httpgrpc.HTTPResponse {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.resp[queryID]
 }


### PR DESCRIPTION
If query-frontend fails to send request to querier, or querier disconnects before sending response, scheduler now forwards error directly to frontend.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
