### PR TITLE
Added -querier.max-query-lookback and fixed -querier.max-query-into-future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Querier: deprecated `-store.max-look-back-period`. You should use `-querier.max-query-lookback` instead. #3451
 * [ENHANCEMENT] Blocks storage ingester: exported more TSDB-related metrics. #3412
   - `cortex_ingester_tsdb_wal_corruptions_total`
   - `cortex_ingester_tsdb_head_truncations_failed_total`
@@ -10,8 +11,10 @@
 * [ENHANCEMENT] Enforced keepalive on all gRPC clients used for inter-service communication. #3431
 * [ENHANCEMENT] Added `cortex_alertmanager_config_hash` metric to expose hash of Alertmanager Config loaded per user. #3388
 * [ENHANCEMENT] Query-Frontend / Query-Scheduler: New component called "Query-Scheduler" has been introduced. Query-Scheduler is simply a queue of requests, moved outside of Query-Frontend. This allows Query-Frontend to be scaled separately from number of queues. To make Query-Frontend and Querier use Query-Scheduler, they need to be started with `-frontend.scheduler-address` and `-querier.scheduler-address` options respectively. #3374
+* [ENHANCEMENT] Querier: added `-querier.max-query-lookback` to limit how long back data (series and metadata) can be queried. This setting can be overridden on a per-tenant basis. #3451
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
+* [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3451
 
 ## 1.5.0 in progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [CHANGE] Querier: deprecated `-store.max-look-back-period`. You should use `-querier.max-query-lookback` instead. #3451
+* [CHANGE] Querier: deprecated `-store.max-look-back-period`. You should use `-querier.max-query-lookback` instead. #3452
 * [ENHANCEMENT] Blocks storage ingester: exported more TSDB-related metrics. #3412
   - `cortex_ingester_tsdb_wal_corruptions_total`
   - `cortex_ingester_tsdb_head_truncations_failed_total`
@@ -11,10 +11,10 @@
 * [ENHANCEMENT] Enforced keepalive on all gRPC clients used for inter-service communication. #3431
 * [ENHANCEMENT] Added `cortex_alertmanager_config_hash` metric to expose hash of Alertmanager Config loaded per user. #3388
 * [ENHANCEMENT] Query-Frontend / Query-Scheduler: New component called "Query-Scheduler" has been introduced. Query-Scheduler is simply a queue of requests, moved outside of Query-Frontend. This allows Query-Frontend to be scaled separately from number of queues. To make Query-Frontend and Querier use Query-Scheduler, they need to be started with `-frontend.scheduler-address` and `-querier.scheduler-address` options respectively. #3374
-* [ENHANCEMENT] Querier: added `-querier.max-query-lookback` to limit how long back data (series and metadata) can be queried. This setting can be overridden on a per-tenant basis. #3451
+* [ENHANCEMENT] Querier: added `-querier.max-query-lookback` to limit how long back data (series and metadata) can be queried. This setting can be overridden on a per-tenant basis. #3452
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
-* [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3451
+* [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452
 
 ## 1.5.0 in progress
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3052,7 +3052,7 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 [max_chunks_per_query: <int> | default = 2000000]
 
 # Limit how long back data (series and metadata) can be queried, up until
-# <lookback> time ago. 0 to disable.
+# <lookback> duration ago. 0 to disable.
 # CLI flag: -querier.max-query-lookback
 [max_query_lookback: <duration> | default = 0s]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2530,7 +2530,8 @@ write_dedupe_cache_config:
 # CLI flag: -store.cache-lookups-older-than
 [cache_lookups_older_than: <duration> | default = 0s]
 
-# Limit how long back data can be queried
+# Deprecated: use -querier.max-query-lookback instead. Limit how long back data
+# can be queried. This setting applies to chunks storage only.
 # CLI flag: -store.max-look-back-period
 [max_look_back_period: <duration> | default = 0s]
 ```
@@ -3049,6 +3050,11 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # and store-gateway. 0 to disable.
 # CLI flag: -store.query-chunk-limit
 [max_chunks_per_query: <int> | default = 2000000]
+
+# Limit how long back data (series and metadata) can be queried, up until
+# <lookback> time ago. 0 to disable.
+# CLI flag: -querier.max-query-lookback
+[max_query_lookback: <duration> | default = 0s]
 
 # Limit the query time range (end - start time). This limit is enforced in the
 # query-frontend (on the received query), in the querier (on the query possibly

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -74,7 +74,7 @@ func (cfg *StoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.WriteDedupeCacheConfig.RegisterFlagsWithPrefix("store.index-cache-write.", "Cache config for index entry writing. ", f)
 
 	f.Var(&cfg.CacheLookupsOlderThan, "store.cache-lookups-older-than", "Cache index entries older than this period. 0 to disable.")
-	f.Var(&cfg.MaxLookBackPeriod, "store.max-look-back-period", "Limit how long back data can be queried")
+	f.Var(&cfg.MaxLookBackPeriod, "store.max-look-back-period", "Deprecated: use -querier.max-query-lookback instead. Limit how long back data can be queried. This setting applies to chunks storage only.") // To be removed in Cortex 1.8.
 }
 
 // Validate validates the store config.

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,6 +19,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/extract"
+	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
@@ -78,7 +80,12 @@ func (cfg *StoreConfig) RegisterFlags(f *flag.FlagSet) {
 }
 
 // Validate validates the store config.
-func (cfg *StoreConfig) Validate() error {
+func (cfg *StoreConfig) Validate(logger log.Logger) error {
+	if cfg.MaxLookBackPeriod > 0 {
+		flagext.DeprecatedFlagsUsed.Inc()
+		level.Warn(logger).Log("msg", "running with DEPRECATED flag -store.max-look-back-period, use -querier.max-query-lookback instead.")
+	}
+
 	if err := cfg.ChunkCacheConfig.Validate(); err != nil {
 		return err
 	}

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -175,7 +175,7 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.Storage.Validate(); err != nil {
 		return errors.Wrap(err, "invalid storage config")
 	}
-	if err := c.ChunkStore.Validate(); err != nil {
+	if err := c.ChunkStore.Validate(log); err != nil {
 		return errors.Wrap(err, "invalid chunk store config")
 	}
 	if err := c.Ruler.Validate(c.LimitsConfig); err != nil {

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -338,11 +338,13 @@ func (m *mockDistributor) QueryStream(ctx context.Context, from, to model.Time, 
 	args := m.Called(ctx, from, to, matchers)
 	return args.Get(0).(*client.QueryStreamResponse), args.Error(1)
 }
-func (m *mockDistributor) LabelValuesForLabelName(context.Context, model.Time, model.Time, model.LabelName) ([]string, error) {
-	return nil, nil
+func (m *mockDistributor) LabelValuesForLabelName(ctx context.Context, from, to model.Time, lbl model.LabelName) ([]string, error) {
+	args := m.Called(ctx, from, to, lbl)
+	return args.Get(0).([]string), args.Error(1)
 }
-func (m *mockDistributor) LabelNames(context.Context, model.Time, model.Time) ([]string, error) {
-	return nil, nil
+func (m *mockDistributor) LabelNames(ctx context.Context, from, to model.Time) ([]string, error) {
+	args := m.Called(ctx, from, to)
+	return args.Get(0).([]string), args.Error(1)
 }
 func (m *mockDistributor) MetricsForLabelMatchers(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) ([]metric.Metric, error) {
 	args := m.Called(ctx, from, to, matchers)

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -71,6 +71,7 @@ type Config struct {
 var (
 	errBadLookbackConfigs                             = errors.New("bad settings, query_store_after >= query_ingesters_within which can result in queries not being sent")
 	errShuffleShardingLookbackLessThanQueryStoreAfter = errors.New("the shuffle-sharding lookback period should be greater or equal than the configured 'query store after'")
+	errEmptyTimeRange                                 = errors.New("empty time range")
 )
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -204,18 +205,20 @@ func NewQueryable(distributor QueryableWithFilter, stores []QueryableWithFilter,
 	return storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 		now := time.Now()
 
-		if cfg.MaxQueryIntoFuture > 0 {
-			maxQueryTime := util.TimeToMillis(now.Add(cfg.MaxQueryIntoFuture))
+		userID, err := user.ExtractOrgID(ctx)
+		if err != nil {
+			return nil, err
+		}
 
-			if mint > maxQueryTime {
-				return storage.NoopQuerier(), nil
-			}
-			if maxt > maxQueryTime {
-				maxt = maxQueryTime
-			}
+		mint, maxt, err = validateQueryTimeRange(ctx, userID, mint, maxt, limits, cfg.MaxQueryIntoFuture)
+		if err == errEmptyTimeRange {
+			return storage.NoopQuerier(), nil
+		} else if err != nil {
+			return nil, err
 		}
 
 		q := querier{
+			cfg:              cfg,
 			ctx:              ctx,
 			mint:             mint,
 			maxt:             maxt,
@@ -253,6 +256,8 @@ func NewQueryable(distributor QueryableWithFilter, stores []QueryableWithFilter,
 }
 
 type querier struct {
+	cfg Config
+
 	// used for labels and metadata queries
 	metadataQuerier storage.Querier
 
@@ -284,6 +289,8 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 	// Also, in the recent versions of Prometheus, we pass in the hint but with Func set to "series".
 	// See: https://github.com/prometheus/prometheus/pull/8050
 	if sp == nil || sp.Func == "series" {
+		// In this case, the query time range has already been validated when the querier has been
+		// created.
 		return q.metadataQuerier.Select(true, sp, matchers...)
 	}
 
@@ -292,13 +299,30 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 		return storage.ErrSeriesSet(err)
 	}
 
-	// Validate query time range.
-	startTime := model.Time(sp.Start)
-	endTime := model.Time(sp.End)
+	// Validate query time range. Even if the time range has already been validated when we created
+	// the querier, we need to check it again here because the time range specified in hints may be
+	// different.
+	startMs, endMs, err := validateQueryTimeRange(ctx, userID, sp.Start, sp.End, q.limits, q.cfg.MaxQueryIntoFuture)
+	if err == errEmptyTimeRange {
+		return storage.NoopSeriesSet()
+	} else if err != nil {
+		return storage.ErrSeriesSet(err)
+	}
+
+	// The time range may have been manipulated during the validation,
+	// so we make sure changes are reflected back to hints.
+	sp.Start = startMs
+	sp.End = endMs
+
+	startTime := model.Time(startMs)
+	endTime := model.Time(endMs)
+
+	// Validate query time range. This validation should be done only for instant / range queries and
+	// NOT for metadata queries (series, labels) because the query-frontend doesn't support splitting
+	// of such queries.
 	if maxQueryLength := q.limits.MaxQueryLength(userID); maxQueryLength > 0 && endTime.Sub(startTime) > maxQueryLength {
 		limitErr := validation.LimitError(fmt.Sprintf(validation.ErrQueryTooLong, endTime.Sub(startTime), maxQueryLength))
 		return storage.ErrSeriesSet(limitErr)
-
 	}
 
 	tombstones, err := q.tombstonesLoader.GetPendingTombstonesForInterval(userID, startTime, endTime)
@@ -474,4 +498,42 @@ func UseBeforeTimestampQueryable(queryable storage.Queryable, ts time.Time) Quer
 		Queryable: queryable,
 		ts:        t,
 	}
+}
+
+func validateQueryTimeRange(ctx context.Context, userID string, startMs, endMs int64, limits *validation.Overrides, maxQueryIntoFuture time.Duration) (int64, int64, error) {
+	now := model.Now()
+	startTime := model.Time(startMs)
+	endTime := model.Time(endMs)
+
+	// Clamp time range based on max query into future.
+	if maxQueryIntoFuture > 0 && endTime.After(now.Add(maxQueryIntoFuture)) {
+		origEndTime := endTime
+		endTime = now.Add(maxQueryIntoFuture)
+
+		// Make sure to log it in traces to ease debugging.
+		level.Debug(spanlogger.FromContext(ctx)).Log(
+			"msg", "the start time of the query has been manipulated because of the 'max query into future' setting",
+			"original", origEndTime, "updated", endTime)
+
+		if endTime.Before(startTime) {
+			return 0, 0, errEmptyTimeRange
+		}
+	}
+
+	// Clamp the time range based on the max query lookback.
+	if maxQueryLookback := limits.MaxQueryLookback(userID); maxQueryLookback > 0 && startTime.Before(now.Add(-maxQueryLookback)) {
+		origStartTime := startTime
+		startTime = now.Add(-maxQueryLookback)
+
+		// Make sure to log it in traces to ease debugging.
+		level.Debug(spanlogger.FromContext(ctx)).Log(
+			"msg", "the start time of the query has been manipulated because of the 'max query lookback' setting",
+			"original", origStartTime, "updated", startTime)
+
+		if endTime.Before(startTime) {
+			return 0, 0, errEmptyTimeRange
+		}
+	}
+
+	return int64(startTime), int64(endTime), nil
 }

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -477,7 +477,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 	const (
 		engineLookbackDelta = 5 * time.Minute
-		month               = 30 * 24 * time.Hour
+		thirtyDays          = 30 * 24 * time.Hour
 	)
 
 	now := time.Now()
@@ -494,7 +494,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 		expectedMetadataEndTime   time.Time
 	}{
 		"should not manipulate time range for a query on short time range and rate time window close to the limit": {
-			maxQueryLookback:          month,
+			maxQueryLookback:          thirtyDays,
 			query:                     "rate(foo[29d])",
 			queryStartTime:            now.Add(-time.Hour),
 			queryEndTime:              now,
@@ -504,40 +504,40 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 			expectedMetadataEndTime:   now,
 		},
 		"should not manipulate a query on large time range close to the limit and short rate time window": {
-			maxQueryLookback:          month,
+			maxQueryLookback:          thirtyDays,
 			query:                     "rate(foo[1m])",
-			queryStartTime:            now.Add(-month).Add(time.Hour),
+			queryStartTime:            now.Add(-thirtyDays).Add(time.Hour),
 			queryEndTime:              now,
-			expectedQueryStartTime:    now.Add(-month).Add(time.Hour).Add(-time.Minute),
+			expectedQueryStartTime:    now.Add(-thirtyDays).Add(time.Hour).Add(-time.Minute),
 			expectedQueryEndTime:      now,
-			expectedMetadataStartTime: now.Add(-month).Add(time.Hour),
+			expectedMetadataStartTime: now.Add(-thirtyDays).Add(time.Hour),
 			expectedMetadataEndTime:   now,
 		},
 		"should manipulate a query on short time range and rate time window over the limit": {
-			maxQueryLookback:          month,
+			maxQueryLookback:          thirtyDays,
 			query:                     "rate(foo[31d])",
 			queryStartTime:            now.Add(-time.Hour),
 			queryEndTime:              now,
-			expectedQueryStartTime:    now.Add(-month),
+			expectedQueryStartTime:    now.Add(-thirtyDays),
 			expectedQueryEndTime:      now,
 			expectedMetadataStartTime: now.Add(-time.Hour),
 			expectedMetadataEndTime:   now,
 		},
 		"should manipulate a query on large time range over the limit and short rate time window": {
-			maxQueryLookback:          month,
+			maxQueryLookback:          thirtyDays,
 			query:                     "rate(foo[1m])",
-			queryStartTime:            now.Add(-month).Add(-100 * time.Hour),
+			queryStartTime:            now.Add(-thirtyDays).Add(-100 * time.Hour),
 			queryEndTime:              now,
-			expectedQueryStartTime:    now.Add(-month),
+			expectedQueryStartTime:    now.Add(-thirtyDays),
 			expectedQueryEndTime:      now,
-			expectedMetadataStartTime: now.Add(-month),
+			expectedMetadataStartTime: now.Add(-thirtyDays),
 			expectedMetadataEndTime:   now,
 		},
 		"should skip executing a query outside the allowed time range": {
-			maxQueryLookback: month,
+			maxQueryLookback: thirtyDays,
 			query:            "rate(foo[1m])",
-			queryStartTime:   now.Add(-month).Add(-100 * time.Hour),
-			queryEndTime:     now.Add(-month).Add(-90 * time.Hour),
+			queryStartTime:   now.Add(-thirtyDays).Add(-100 * time.Hour),
+			queryEndTime:     now.Add(-thirtyDays).Add(-90 * time.Hour),
 			expectedSkipped:  true,
 		},
 	}

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -736,17 +736,6 @@ func testQuery(t testing.TB, queryable storage.Queryable, end model.Time, q quer
 	return r
 }
 
-type errChunkStore struct {
-}
-
-func (m *errChunkStore) Get(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]chunk.Chunk, error) {
-	return nil, errDistributorError
-}
-
-func (m *errChunkStore) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
-	return storage.NoopQuerier(), errDistributorError
-}
-
 type errDistributor struct{}
 
 var errDistributorError = fmt.Errorf("errDistributorError")

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -305,61 +305,53 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 	}
 }
 
-func TestNoFutureQueries(t *testing.T) {
-	testCases := []struct {
-		name               string
-		mint, maxt         time.Time
-		hitStores          bool
+func TestQuerier_ValidateQueryTimeRange_MaxQueryIntoFuture(t *testing.T) {
+	const engineLookbackDelta = 5 * time.Minute
+
+	now := time.Now()
+
+	tests := map[string]struct {
 		maxQueryIntoFuture time.Duration
+		queryStartTime     time.Time
+		queryEndTime       time.Time
+		expectedSkipped    bool
+		expectedStartTime  time.Time
+		expectedEndTime    time.Time
 	}{
-		{
-			name:               "hit-test1",
-			mint:               time.Now().Add(-5 * time.Hour),
-			maxt:               time.Now().Add(1 * time.Hour),
-			hitStores:          true,
+		"should manipulate query if end time is after the limit": {
 			maxQueryIntoFuture: 10 * time.Minute,
+			queryStartTime:     now.Add(-5 * time.Hour),
+			queryEndTime:       now.Add(1 * time.Hour),
+			expectedStartTime:  now.Add(-5 * time.Hour).Add(-engineLookbackDelta),
+			expectedEndTime:    now.Add(10 * time.Minute),
 		},
-		{
-			name:               "hit-test2",
-			mint:               time.Now().Add(-5 * time.Hour),
-			maxt:               time.Now().Add(-59 * time.Minute),
-			hitStores:          true,
-			maxQueryIntoFuture: 10 * time.Minute,
-		},
-		{ // Skipping stores is disabled.
-			name:               "max-query-into-future-disabled",
-			mint:               time.Now().Add(500 * time.Hour),
-			maxt:               time.Now().Add(5000 * time.Hour),
-			hitStores:          true,
+		"should not manipulate query if end time is far in the future but limit is disabled": {
 			maxQueryIntoFuture: 0,
+			queryStartTime:     now.Add(-5 * time.Hour),
+			queryEndTime:       now.Add(100 * time.Hour),
+			expectedStartTime:  now.Add(-5 * time.Hour).Add(-engineLookbackDelta),
+			expectedEndTime:    now.Add(100 * time.Hour),
 		},
-		{ // Still hit because of staleness.
-			name:               "hit-test3",
-			mint:               time.Now().Add(12 * time.Minute),
-			maxt:               time.Now().Add(60 * time.Minute),
-			hitStores:          true,
+		"should not manipulate query if end time is in the future but below the limit": {
 			maxQueryIntoFuture: 10 * time.Minute,
+			queryStartTime:     now.Add(-100 * time.Minute),
+			queryEndTime:       now.Add(5 * time.Minute),
+			expectedStartTime:  now.Add(-100 * time.Minute).Add(-engineLookbackDelta),
+			expectedEndTime:    now.Add(5 * time.Minute),
 		},
-		{
-			name:               "dont-hit-test1",
-			mint:               time.Now().Add(100 * time.Minute),
-			maxt:               time.Now().Add(5 * time.Hour),
-			hitStores:          false,
+		"should skip executing a query outside the allowed time range": {
 			maxQueryIntoFuture: 10 * time.Minute,
-		},
-		{
-			name:               "dont-hit-test2",
-			mint:               time.Now().Add(16 * time.Minute),
-			maxt:               time.Now().Add(60 * time.Minute),
-			hitStores:          false,
-			maxQueryIntoFuture: 10 * time.Minute,
+			queryStartTime:     now.Add(50 * time.Minute),
+			queryEndTime:       now.Add(60 * time.Minute),
+			expectedSkipped:    true,
 		},
 	}
 
 	engine := promql.NewEngine(promql.EngineOpts{
-		Logger:     util.Logger,
-		MaxSamples: 1e6,
-		Timeout:    1 * time.Minute,
+		Logger:        util.Logger,
+		MaxSamples:    1e6,
+		Timeout:       1 * time.Minute,
+		LookbackDelta: engineLookbackDelta,
 	})
 
 	cfg := Config{}
@@ -367,37 +359,46 @@ func TestNoFutureQueries(t *testing.T) {
 
 	for _, ingesterStreaming := range []bool{true, false} {
 		cfg.IngesterStreaming = ingesterStreaming
-		for _, c := range testCases {
+		for name, c := range tests {
 			cfg.MaxQueryIntoFuture = c.maxQueryIntoFuture
-			t.Run(fmt.Sprintf("IngesterStreaming=%t,test=%s", cfg.IngesterStreaming, c.name), func(t *testing.T) {
-				chunkStore := &errChunkStore{}
-				distributor := &errDistributor{}
+			t.Run(fmt.Sprintf("%s (ingester streaming enabled = %t)", name, cfg.IngesterStreaming), func(t *testing.T) {
+				// We don't need to query any data for this test, so an empty store is fine.
+				chunkStore := &emptyChunkStore{}
+				distributor := &mockDistributor{}
+				distributor.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Matrix{}, nil)
+				distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&client.QueryStreamResponse{}, nil)
 
 				overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
 				require.NoError(t, err)
 
-				queryable, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(chunkStore)}, purger.NewTombstonesLoader(nil, nil), nil)
-				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
+				queryables := []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}
+				queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+				query, err := engine.NewRangeQuery(queryable, "dummy", c.queryStartTime, c.queryEndTime, time.Minute)
 				require.NoError(t, err)
 
 				ctx := user.InjectOrgID(context.Background(), "0")
 				r := query.Exec(ctx)
-				_, err = r.Matrix()
+				require.Nil(t, r.Err)
 
-				if c.hitStores {
-					// If the ingester was hit, the distributor always returns errDistributorError.
-					require.Error(t, err)
-					require.Equal(t, errDistributorError.Error(), err.Error())
+				_, err = r.Matrix()
+				require.Nil(t, err)
+
+				if !c.expectedSkipped {
+					// Assert on the time range of the actual executed query (5s delta).
+					delta := float64(5000)
+					require.Len(t, distributor.Calls, 1)
+					assert.InDelta(t, util.TimeToMillis(c.expectedStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
+					assert.InDelta(t, util.TimeToMillis(c.expectedEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
 				} else {
-					// If the ingester was hit, there would have been an error from errDistributor.
-					require.NoError(t, err)
+					// Ensure no query has been executed executed (because skipped).
+					assert.Len(t, distributor.Calls, 0)
 				}
 			})
 		}
 	}
 }
 
-func TestQuerier_ValidateQueryTimeRange(t *testing.T) {
+func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 	const maxQueryLength = 30 * 24 * time.Hour
 
 	tests := map[string]struct {
@@ -470,6 +471,214 @@ func TestQuerier_ValidateQueryTimeRange(t *testing.T) {
 				assert.Nil(t, r.Err)
 			}
 		})
+	}
+}
+
+func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
+	const (
+		engineLookbackDelta = 5 * time.Minute
+		month               = 30 * 24 * time.Hour
+	)
+
+	now := time.Now()
+
+	tests := map[string]struct {
+		maxQueryLookback          time.Duration
+		query                     string
+		queryStartTime            time.Time
+		queryEndTime              time.Time
+		expectedSkipped           bool
+		expectedQueryStartTime    time.Time
+		expectedQueryEndTime      time.Time
+		expectedMetadataStartTime time.Time
+		expectedMetadataEndTime   time.Time
+	}{
+		"should not manipulate time range for a query on short time range and rate time window close to the limit": {
+			maxQueryLookback:          month,
+			query:                     "rate(foo[29d])",
+			queryStartTime:            now.Add(-time.Hour),
+			queryEndTime:              now,
+			expectedQueryStartTime:    now.Add(-time.Hour).Add(-29 * 24 * time.Hour),
+			expectedQueryEndTime:      now,
+			expectedMetadataStartTime: now.Add(-time.Hour),
+			expectedMetadataEndTime:   now,
+		},
+		"should not manipulate a query on large time range close to the limit and short rate time window": {
+			maxQueryLookback:          month,
+			query:                     "rate(foo[1m])",
+			queryStartTime:            now.Add(-month).Add(time.Hour),
+			queryEndTime:              now,
+			expectedQueryStartTime:    now.Add(-month).Add(time.Hour).Add(-time.Minute),
+			expectedQueryEndTime:      now,
+			expectedMetadataStartTime: now.Add(-month).Add(time.Hour),
+			expectedMetadataEndTime:   now,
+		},
+		"should manipulate a query on short time range and rate time window over the limit": {
+			maxQueryLookback:          month,
+			query:                     "rate(foo[31d])",
+			queryStartTime:            now.Add(-time.Hour),
+			queryEndTime:              now,
+			expectedQueryStartTime:    now.Add(-month),
+			expectedQueryEndTime:      now,
+			expectedMetadataStartTime: now.Add(-time.Hour),
+			expectedMetadataEndTime:   now,
+		},
+		"should manipulate a query on large time range over the limit and short rate time window": {
+			maxQueryLookback:          month,
+			query:                     "rate(foo[1m])",
+			queryStartTime:            now.Add(-month).Add(-100 * time.Hour),
+			queryEndTime:              now,
+			expectedQueryStartTime:    now.Add(-month),
+			expectedQueryEndTime:      now,
+			expectedMetadataStartTime: now.Add(-month),
+			expectedMetadataEndTime:   now,
+		},
+		"should skip executing a query outside the allowed time range": {
+			maxQueryLookback: month,
+			query:            "rate(foo[1m])",
+			queryStartTime:   now.Add(-month).Add(-100 * time.Hour),
+			queryEndTime:     now.Add(-month).Add(-90 * time.Hour),
+			expectedSkipped:  true,
+		},
+	}
+
+	// Create the PromQL engine to execute the queries.
+	engine := promql.NewEngine(promql.EngineOpts{
+		Logger:             util.Logger,
+		ActiveQueryTracker: nil,
+		MaxSamples:         1e6,
+		LookbackDelta:      engineLookbackDelta,
+		Timeout:            1 * time.Minute,
+	})
+
+	for _, ingesterStreaming := range []bool{true, false} {
+		for testName, testData := range tests {
+			t.Run(testName, func(t *testing.T) {
+				ctx := user.InjectOrgID(context.Background(), "test")
+
+				var cfg Config
+				flagext.DefaultValues(&cfg)
+				cfg.IngesterStreaming = ingesterStreaming
+
+				limits := defaultLimitsConfig()
+				limits.MaxQueryLookback = testData.maxQueryLookback
+				overrides, err := validation.NewOverrides(limits, nil)
+				require.NoError(t, err)
+
+				// We don't need to query any data for this test, so an empty store is fine.
+				chunkStore := &emptyChunkStore{}
+				queryables := []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}
+
+				t.Run("query range", func(t *testing.T) {
+					distributor := &mockDistributor{}
+					distributor.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Matrix{}, nil)
+					distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&client.QueryStreamResponse{}, nil)
+
+					queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+					require.NoError(t, err)
+
+					query, err := engine.NewRangeQuery(queryable, testData.query, testData.queryStartTime, testData.queryEndTime, time.Minute)
+					require.NoError(t, err)
+
+					r := query.Exec(ctx)
+					require.Nil(t, r.Err)
+
+					_, err = r.Matrix()
+					require.Nil(t, r.Err)
+
+					if !testData.expectedSkipped {
+						// Assert on the time range of the actual executed query (5s delta).
+						delta := float64(5000)
+						require.Len(t, distributor.Calls, 1)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedQueryStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedQueryEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
+					} else {
+						// Ensure no query has been executed executed (because skipped).
+						assert.Len(t, distributor.Calls, 0)
+					}
+				})
+
+				t.Run("series", func(t *testing.T) {
+					distributor := &mockDistributor{}
+					distributor.On("MetricsForLabelMatchers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]metric.Metric{}, nil)
+
+					queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+					q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
+					require.NoError(t, err)
+
+					hints := &storage.SelectHints{
+						Start: util.TimeToMillis(testData.queryStartTime),
+						End:   util.TimeToMillis(testData.queryEndTime),
+						Func:  "series",
+					}
+					matcher := labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "test")
+
+					set := q.Select(false, hints, matcher)
+					require.False(t, set.Next()) // Expected to be empty.
+					require.NoError(t, set.Err())
+
+					if !testData.expectedSkipped {
+						// Assert on the time range of the actual executed query (5s delta).
+						delta := float64(5000)
+						require.Len(t, distributor.Calls, 1)
+						assert.Equal(t, "MetricsForLabelMatchers", distributor.Calls[0].Method)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
+					} else {
+						// Ensure no query has been executed executed (because skipped).
+						assert.Len(t, distributor.Calls, 0)
+					}
+				})
+
+				t.Run("label names", func(t *testing.T) {
+					distributor := &mockDistributor{}
+					distributor.On("LabelNames", mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
+
+					queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+					q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
+					require.NoError(t, err)
+
+					_, _, err = q.LabelNames()
+					require.NoError(t, err)
+
+					if !testData.expectedSkipped {
+						// Assert on the time range of the actual executed query (5s delta).
+						delta := float64(5000)
+						require.Len(t, distributor.Calls, 1)
+						assert.Equal(t, "LabelNames", distributor.Calls[0].Method)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
+					} else {
+						// Ensure no query has been executed executed (because skipped).
+						assert.Len(t, distributor.Calls, 0)
+					}
+				})
+
+				t.Run("label values", func(t *testing.T) {
+					distributor := &mockDistributor{}
+					distributor.On("LabelValuesForLabelName", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
+
+					queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+					q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
+					require.NoError(t, err)
+
+					_, _, err = q.LabelValues(labels.MetricName)
+					require.NoError(t, err)
+
+					if !testData.expectedSkipped {
+						// Assert on the time range of the actual executed query (5s delta).
+						delta := float64(5000)
+						require.Len(t, distributor.Calls, 1)
+						assert.Equal(t, "LabelValuesForLabelName", distributor.Calls[0].Method)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
+					} else {
+						// Ensure no query has been executed executed (because skipped).
+						assert.Len(t, distributor.Calls, 0)
+					}
+				})
+			})
+		}
 	}
 }
 

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -584,7 +584,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 					require.Nil(t, r.Err)
 
 					_, err = r.Matrix()
-					require.Nil(t, r.Err)
+					require.Nil(t, err)
 
 					if !testData.expectedSkipped {
 						// Assert on the time range of the actual executed query (5s delta).

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -32,7 +32,7 @@ func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, 
 }
 
 // FromContext returns a span logger using the current parent span.
-// If there is no parent span, the Spanlogger will only log to stdout.
+// If there is no parent span, the Spanlogger will only log to global logger.
 func FromContext(ctx context.Context) *SpanLogger {
 	sp := opentracing.SpanFromContext(ctx)
 	if sp == nil {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -67,6 +67,7 @@ type Limits struct {
 
 	// Querier enforced limits.
 	MaxChunksPerQuery    int           `yaml:"max_chunks_per_query"`
+	MaxQueryLookback     time.Duration `yaml:"max_query_lookback"`
 	MaxQueryLength       time.Duration `yaml:"max_query_length"`
 	MaxQueryParallelism  int           `yaml:"max_query_parallelism"`
 	CardinalityLimit     int           `yaml:"cardinality_limit"`
@@ -122,6 +123,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.IntVar(&l.MaxChunksPerQuery, "store.query-chunk-limit", 2e6, "Maximum number of chunks that can be fetched in a single query. This limit is enforced when fetching chunks from the long-term storage. When running the Cortex chunks storage, this limit is enforced in the querier, while when running the Cortex blocks storage this limit is both enforced in the querier and store-gateway. 0 to disable.")
 	f.DurationVar(&l.MaxQueryLength, "store.max-query-length", 0, "Limit the query time range (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query possibly split by the query-frontend) and in the chunks storage. 0 to disable.")
+	f.DurationVar(&l.MaxQueryLookback, "querier.max-query-lookback", 0, "Limit how long back data (series and metadata) can be queried, up until <lookback> time ago. 0 to disable.")
 	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of queries will be scheduled in parallel by the frontend.")
 	f.IntVar(&l.CardinalityLimit, "store.cardinality-limit", 1e5, "Cardinality limit for index queries. This limit is ignored when running the Cortex blocks storage. 0 to disable.")
 	f.DurationVar(&l.MaxCacheFreshness, "frontend.max-cache-freshness", 1*time.Minute, "Most recent allowed cacheable result per-tenant, to prevent caching very recent results that might still be in flux.")
@@ -306,6 +308,11 @@ func (o *Overrides) MaxGlobalSeriesPerMetric(userID string) int {
 // MaxChunksPerQuery returns the maximum number of chunks allowed per query.
 func (o *Overrides) MaxChunksPerQuery(userID string) int {
 	return o.getOverridesForUser(userID).MaxChunksPerQuery
+}
+
+// MaxQueryLookback returns the max lookback period of queries.
+func (o *Overrides) MaxQueryLookback(userID string) time.Duration {
+	return o.getOverridesForUser(userID).MaxQueryLookback
 }
 
 // MaxQueryLength returns the limit of the length (in time) of a query.

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -123,7 +123,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.IntVar(&l.MaxChunksPerQuery, "store.query-chunk-limit", 2e6, "Maximum number of chunks that can be fetched in a single query. This limit is enforced when fetching chunks from the long-term storage. When running the Cortex chunks storage, this limit is enforced in the querier, while when running the Cortex blocks storage this limit is both enforced in the querier and store-gateway. 0 to disable.")
 	f.DurationVar(&l.MaxQueryLength, "store.max-query-length", 0, "Limit the query time range (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query possibly split by the query-frontend) and in the chunks storage. 0 to disable.")
-	f.DurationVar(&l.MaxQueryLookback, "querier.max-query-lookback", 0, "Limit how long back data (series and metadata) can be queried, up until <lookback> time ago. 0 to disable.")
+	f.DurationVar(&l.MaxQueryLookback, "querier.max-query-lookback", 0, "Limit how long back data (series and metadata) can be queried, up until <lookback> duration ago. 0 to disable.")
 	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of queries will be scheduled in parallel by the frontend.")
 	f.IntVar(&l.CardinalityLimit, "store.cardinality-limit", 1e5, "Cardinality limit for index queries. This limit is ignored when running the Cortex blocks storage. 0 to disable.")
 	f.DurationVar(&l.MaxCacheFreshness, "frontend.max-cache-freshness", 1*time.Minute, "Most recent allowed cacheable result per-tenant, to prevent caching very recent results that might still be in flux.")


### PR DESCRIPTION
**What this PR does**:
Currently, the only option to limit the time range of queries is `-store.max-look-back-period`, but it suffers the following issues:

1. Applies to chunks storage only
2. Applies to instance/range queries only (not a strict requirement today, but we'll soon work on querying series/labels from storage in the blocks storage)
3. Can't be overridden on a per-tenant basis

In this PR I'm adding `-querier.max-query-lookback` which is expected is superseed `-store.max-look-back-period` solving the issues above. While working on tests, I've also noticed that `-querier.max-query-into-future` is currently broken (doesn't really enforce it), so I've fixed it in this PR.

Out of the scope of this PR:
- Enforcing the limit in the query-frontend too (will be done in a separate PR)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
