### PR TITLE
Querier workers refactor, step 1

### DIFF
--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -32,13 +32,13 @@ import (
 	"github.com/cortexproject/cortex/pkg/configs/db"
 	"github.com/cortexproject/cortex/pkg/distributor"
 	"github.com/cortexproject/cortex/pkg/flusher"
-	frontend "github.com/cortexproject/cortex/pkg/frontend"
+	"github.com/cortexproject/cortex/pkg/frontend"
 	frontendv1 "github.com/cortexproject/cortex/pkg/frontend/v1"
 	"github.com/cortexproject/cortex/pkg/ingester"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/querier"
-	querier_frontend "github.com/cortexproject/cortex/pkg/querier/frontend"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+	querier_worker "github.com/cortexproject/cortex/pkg/querier/worker"
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/ring/kv/memberlist"
 	"github.com/cortexproject/cortex/pkg/ruler"
@@ -80,27 +80,27 @@ type Config struct {
 	PrintConfig bool                   `yaml:"-"`
 	HTTPPrefix  string                 `yaml:"http_prefix"`
 
-	API            api.Config                            `yaml:"api"`
-	Server         server.Config                         `yaml:"server"`
-	Distributor    distributor.Config                    `yaml:"distributor"`
-	Querier        querier.Config                        `yaml:"querier"`
-	IngesterClient client.Config                         `yaml:"ingester_client"`
-	Ingester       ingester.Config                       `yaml:"ingester"`
-	Flusher        flusher.Config                        `yaml:"flusher"`
-	Storage        storage.Config                        `yaml:"storage"`
-	ChunkStore     chunk.StoreConfig                     `yaml:"chunk_store"`
-	Schema         chunk.SchemaConfig                    `yaml:"schema" doc:"hidden"` // Doc generation tool doesn't support it because part of the SchemaConfig doesn't support CLI flags (needs manual documentation)
-	LimitsConfig   validation.Limits                     `yaml:"limits"`
-	Prealloc       client.PreallocConfig                 `yaml:"prealloc" doc:"hidden"`
-	Worker         querier_frontend.CombinedWorkerConfig `yaml:"frontend_worker"`
-	Frontend       frontend.CombinedFrontendConfig       `yaml:"frontend"`
-	QueryRange     queryrange.Config                     `yaml:"query_range"`
-	TableManager   chunk.TableManagerConfig              `yaml:"table_manager"`
-	Encoding       encoding.Config                       `yaml:"-"` // No yaml for this, it only works with flags.
-	BlocksStorage  tsdb.BlocksStorageConfig              `yaml:"blocks_storage"`
-	Compactor      compactor.Config                      `yaml:"compactor"`
-	StoreGateway   storegateway.Config                   `yaml:"store_gateway"`
-	PurgerConfig   purger.Config                         `yaml:"purger"`
+	API            api.Config                          `yaml:"api"`
+	Server         server.Config                       `yaml:"server"`
+	Distributor    distributor.Config                  `yaml:"distributor"`
+	Querier        querier.Config                      `yaml:"querier"`
+	IngesterClient client.Config                       `yaml:"ingester_client"`
+	Ingester       ingester.Config                     `yaml:"ingester"`
+	Flusher        flusher.Config                      `yaml:"flusher"`
+	Storage        storage.Config                      `yaml:"storage"`
+	ChunkStore     chunk.StoreConfig                   `yaml:"chunk_store"`
+	Schema         chunk.SchemaConfig                  `yaml:"schema" doc:"hidden"` // Doc generation tool doesn't support it because part of the SchemaConfig doesn't support CLI flags (needs manual documentation)
+	LimitsConfig   validation.Limits                   `yaml:"limits"`
+	Prealloc       client.PreallocConfig               `yaml:"prealloc" doc:"hidden"`
+	Worker         querier_worker.CombinedWorkerConfig `yaml:"frontend_worker"`
+	Frontend       frontend.CombinedFrontendConfig     `yaml:"frontend"`
+	QueryRange     queryrange.Config                   `yaml:"query_range"`
+	TableManager   chunk.TableManagerConfig            `yaml:"table_manager"`
+	Encoding       encoding.Config                     `yaml:"-"` // No yaml for this, it only works with flags.
+	BlocksStorage  tsdb.BlocksStorageConfig            `yaml:"blocks_storage"`
+	Compactor      compactor.Config                    `yaml:"compactor"`
+	StoreGateway   storegateway.Config                 `yaml:"store_gateway"`
+	PurgerConfig   purger.Config                       `yaml:"purger"`
 
 	Ruler          ruler.Config                               `yaml:"ruler"`
 	Configs        configs.Config                             `yaml:"configs"`

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -28,8 +28,8 @@ import (
 	"github.com/cortexproject/cortex/pkg/frontend/transport"
 	"github.com/cortexproject/cortex/pkg/ingester"
 	"github.com/cortexproject/cortex/pkg/querier"
-	querier_frontend "github.com/cortexproject/cortex/pkg/querier/frontend"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+	querier_worker "github.com/cortexproject/cortex/pkg/querier/worker"
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/ring/kv/codec"
 	"github.com/cortexproject/cortex/pkg/ring/kv/memberlist"
@@ -298,7 +298,7 @@ func (t *Cortex) initQuerier() (serv services.Service, err error) {
 	}
 
 	// If neither frontend address or scheduler address is configured, no worker will be created.
-	return querier_frontend.InitQuerierWorker(t.Cfg.Worker, t.Cfg.Querier, internalQuerierRouter, util.Logger)
+	return querier_worker.InitQuerierWorker(t.Cfg.Worker, t.Cfg.Querier, internalQuerierRouter, util.Logger)
 }
 
 func (t *Cortex) initStoreQueryables() (services.Service, error) {

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/frontend/transport"
 	"github.com/cortexproject/cortex/pkg/frontend/v1/frontendv1pb"
 	"github.com/cortexproject/cortex/pkg/querier"
-	"github.com/cortexproject/cortex/pkg/querier/worker"
+	querier_worker "github.com/cortexproject/cortex/pkg/querier/worker"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
@@ -234,7 +234,7 @@ func testFrontend(t *testing.T, config CombinedFrontendConfig, handler http.Hand
 	}
 
 	var (
-		workerConfig  worker.WorkerConfig
+		workerConfig  querier_worker.WorkerConfig
 		querierConfig querier.Config
 	)
 	flagext.DefaultValues(&workerConfig)
@@ -282,14 +282,14 @@ func testFrontend(t *testing.T, config CombinedFrontendConfig, handler http.Hand
 	go httpServer.Serve(httpListen) //nolint:errcheck
 	go grpcServer.Serve(grpcListen) //nolint:errcheck
 
-	var wrkr services.Service
-	wrkr, err = worker.NewWorker(workerConfig, querierConfig, httpgrpc_server.NewServer(handler), logger)
+	var worker services.Service
+	worker, err = querier_worker.NewWorker(workerConfig, querierConfig, httpgrpc_server.NewServer(handler), logger)
 	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), wrkr))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), worker))
 
 	test(httpListen.Addr().String())
 
-	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), wrkr))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), worker))
 }
 
 func defaultFrontendConfig() CombinedFrontendConfig {

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/frontend/transport"
 	"github.com/cortexproject/cortex/pkg/frontend/v1/frontendv1pb"
 	"github.com/cortexproject/cortex/pkg/querier"
-	"github.com/cortexproject/cortex/pkg/querier/frontend"
+	"github.com/cortexproject/cortex/pkg/querier/worker"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
@@ -234,7 +234,7 @@ func testFrontend(t *testing.T, config CombinedFrontendConfig, handler http.Hand
 	}
 
 	var (
-		workerConfig  frontend.WorkerConfig
+		workerConfig  worker.WorkerConfig
 		querierConfig querier.Config
 	)
 	flagext.DefaultValues(&workerConfig)
@@ -282,14 +282,14 @@ func testFrontend(t *testing.T, config CombinedFrontendConfig, handler http.Hand
 	go httpServer.Serve(httpListen) //nolint:errcheck
 	go grpcServer.Serve(grpcListen) //nolint:errcheck
 
-	var worker services.Service
-	worker, err = frontend.NewWorker(workerConfig, querierConfig, httpgrpc_server.NewServer(handler), logger)
+	var wrkr services.Service
+	wrkr, err = worker.NewWorker(workerConfig, querierConfig, httpgrpc_server.NewServer(handler), logger)
 	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), worker))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), wrkr))
 
 	test(httpListen.Addr().String())
 
-	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), worker))
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), wrkr))
 }
 
 func defaultFrontendConfig() CombinedFrontendConfig {

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/frontend/transport"
 	"github.com/cortexproject/cortex/pkg/frontend/v1/frontendv1pb"
 	"github.com/cortexproject/cortex/pkg/querier"
-	querier_frontend "github.com/cortexproject/cortex/pkg/querier/frontend"
+	querier_worker "github.com/cortexproject/cortex/pkg/querier/worker"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
@@ -179,7 +179,7 @@ func testFrontend(t *testing.T, config Config, handler http.Handler, test func(a
 	}
 
 	var (
-		workerConfig  querier_frontend.WorkerConfig
+		workerConfig  querier_worker.WorkerConfig
 		querierConfig querier.Config
 	)
 	flagext.DefaultValues(&workerConfig)
@@ -227,7 +227,7 @@ func testFrontend(t *testing.T, config Config, handler http.Handler, test func(a
 	go grpcServer.Serve(grpcListen) //nolint:errcheck
 
 	var worker services.Service
-	worker, err = querier_frontend.NewWorker(workerConfig, querierConfig, httpgrpc_server.NewServer(handler), logger)
+	worker, err = querier_worker.NewWorker(workerConfig, querierConfig, httpgrpc_server.NewServer(handler), logger)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), worker))
 

--- a/pkg/querier/worker/config.go
+++ b/pkg/querier/worker/config.go
@@ -1,4 +1,4 @@
-package frontend
+package worker
 
 import (
 	"flag"
@@ -10,15 +10,14 @@ import (
 	"github.com/weaveworks/common/httpgrpc/server"
 
 	"github.com/cortexproject/cortex/pkg/querier"
-	"github.com/cortexproject/cortex/pkg/querier/frontend2"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 // Configuration for both querier workers, V1 (using frontend) and V2 (using scheduler). Since many flags are reused
 // between the two, they are exposed to YAML/CLI in V1 version (WorkerConfig), and copied to V2 in the init method.
 type CombinedWorkerConfig struct {
-	WorkerV1 WorkerConfig                   `yaml:",inline"`
-	WorkerV2 frontend2.QuerierWorkersConfig `yaml:",inline"`
+	WorkerV1 WorkerConfig         `yaml:",inline"`
+	WorkerV2 QuerierWorkersConfig `yaml:",inline"`
 }
 
 func (cfg *CombinedWorkerConfig) RegisterFlags(f *flag.FlagSet) {
@@ -44,7 +43,7 @@ func InitQuerierWorker(cfg CombinedWorkerConfig, querierCfg querier.Config, hand
 		cfg.WorkerV2.QuerierID = cfg.WorkerV1.QuerierID
 
 		level.Info(log).Log("msg", "Starting querier worker connected to query-scheduler", "scheduler", cfg.WorkerV2.SchedulerAddress)
-		return frontend2.NewQuerierSchedulerWorkers(cfg.WorkerV2, server.NewServer(handler), prometheus.DefaultRegisterer, log)
+		return NewQuerierSchedulerWorkers(cfg.WorkerV2, server.NewServer(handler), prometheus.DefaultRegisterer, log)
 
 	case cfg.WorkerV1.FrontendAddress != "":
 		level.Info(log).Log("msg", "Starting querier worker connected to query-frontend", "frontend", cfg.WorkerV1.FrontendAddress)

--- a/pkg/querier/worker/querier_scheduler_worker.go
+++ b/pkg/querier/worker/querier_scheduler_worker.go
@@ -1,4 +1,4 @@
-package frontend2
+package worker
 
 import (
 	"context"

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -1,4 +1,4 @@
-package frontend
+package worker
 
 import (
 	"context"

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -23,6 +23,7 @@ import (
 )
 
 // WorkerConfig is config for a worker.
+// nolint:golint
 type WorkerConfig struct {
 	FrontendAddress     string        `yaml:"frontend_address"`
 	Parallelism         int           `yaml:"parallelism"`

--- a/pkg/querier/worker/worker_frontend_manager.go
+++ b/pkg/querier/worker/worker_frontend_manager.go
@@ -1,4 +1,4 @@
-package frontend
+package worker
 
 import (
 	"context"

--- a/pkg/querier/worker/worker_frontend_manager_test.go
+++ b/pkg/querier/worker/worker_frontend_manager_test.go
@@ -1,4 +1,4 @@
-package frontend
+package worker
 
 import (
 	"context"

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -1,4 +1,4 @@
-package frontend
+package worker
 
 import (
 	"context"

--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -26,8 +26,8 @@ import (
 	"github.com/cortexproject/cortex/pkg/ingester"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/querier"
-	querier_frontend "github.com/cortexproject/cortex/pkg/querier/frontend"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+	querier_worker "github.com/cortexproject/cortex/pkg/querier/worker"
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	"github.com/cortexproject/cortex/pkg/ring/kv/etcd"
 	"github.com/cortexproject/cortex/pkg/ring/kv/memberlist"
@@ -113,7 +113,7 @@ var (
 		},
 		{
 			name:       "frontend_worker_config",
-			structType: reflect.TypeOf(querier_frontend.CombinedWorkerConfig{}),
+			structType: reflect.TypeOf(querier_worker.CombinedWorkerConfig{}),
 			desc:       "The frontend_worker_config configures the worker - running within the Cortex querier - picking up and executing queries enqueued by the query-frontend.",
 		},
 		{


### PR DESCRIPTION
This is first step in querier workers refactor. There are two workers (one using frontend, one using scheduler) with lot of copied code. End-goal is to refactor common parts.

First step is only moving `querier_scheduler_worker.go` to `pkg/querier/frontend` package, and then renaming `pkg/querier/frontend` to `pkg/querier/worker`, all done via Goland refactoring. No change in logic was done.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
