### PR TITLE
Return 502 if the alertmanager is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Return 502 if the Alertmanager of a particular tenant is not available. #3456
 * [ENHANCEMENT] Blocks storage ingester: exported more TSDB-related metrics. #3412
   - `cortex_ingester_tsdb_wal_corruptions_total`
   - `cortex_ingester_tsdb_head_truncations_failed_total`

--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -86,6 +86,7 @@ ruler:
 
 alertmanager:
   enable_api: true
+  external_url: http://alertmanager:8010/alertmanager
   storage:
     type: s3
     s3:

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - "14268"
 
   # Scrape the metrics also with the Grafana agent (useful to test metadata ingestion
-  # until metadata remote write is not supported by Prometheus).
+  # until metadata remote write is  supported by Prometheus).
   grafana-agent:
     image: grafana/agent:v0.2.0
     command: ["-config.file=/etc/agent-config/grafana-agent.yaml", "-prometheus.wal-directory=/tmp"]

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - "14268"
 
   # Scrape the metrics also with the Grafana agent (useful to test metadata ingestion
-  # until metadata remote write is  supported by Prometheus).
+  # until metadata remote write is supported by Prometheus).
   grafana-agent:
     image: grafana/agent:v0.2.0
     command: ["-config.file=/etc/agent-config/grafana-agent.yaml", "-prometheus.wal-directory=/tmp"]

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -76,7 +76,7 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 
 	_, err = c.GetAlertmanagerConfig(context.Background())
 	require.Error(t, err)
-	require.EqualError(t, err, e2ecortex.ErrNotFound.Error())
+	require.EqualError(t, err, "getting config failed with status 502 and error the Alertmanager is not configured\n")
 
 	err = c.SetAlertmanagerConfig(context.Background(), cortexAlertmanagerUserConfigYaml, map[string]string{})
 	require.NoError(t, err)
@@ -119,5 +119,5 @@ func TestAlertmanagerStoreAPI(t *testing.T) {
 	cfg, err = c.GetAlertmanagerConfig(context.Background())
 	require.Error(t, err)
 	require.Nil(t, cfg)
-	require.EqualError(t, err, "not found")
+	require.EqualError(t, err, "getting config failed with status 502 and error the Alertmanager is not configured\n")
 }

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -477,7 +477,7 @@ func (am *MultitenantAlertmanager) ServeHTTP(w http.ResponseWriter, req *http.Re
 	if ok {
 		if !userAM.IsActive() {
 			level.Debug(am.logger).Log("msg", "the Alertmanager is not active", "user", userID)
-			http.Error(w, "the Alertmanager is not configured", http.StatusNotFound)
+			http.Error(w, "the Alertmanager is not configured", http.StatusBadGateway)
 			return
 		}
 
@@ -498,7 +498,7 @@ func (am *MultitenantAlertmanager) ServeHTTP(w http.ResponseWriter, req *http.Re
 	}
 
 	level.Debug(am.logger).Log("msg", "the Alertmanager has no configuration and no fallback specified", "user", userID)
-	http.Error(w, "the Alertmanager is not configured", http.StatusNotFound)
+	http.Error(w, "the Alertmanager is not configured", http.StatusBadGateway)
 }
 
 func (am *MultitenantAlertmanager) alertmanagerFromFallbackConfig(userID string) (*Alertmanager, error) {


### PR DESCRIPTION
Often, we find it confusing that in the unlikely event of:

a) creating a configuration b) then deleting it

or

a) no fallback config b) making a request to the alertmanager

Our users (and ruler) receive a 404. This is generally, acceptable as the system might not want to reveal that a configuration for a particular user exists. However, we deliberately within Cortex do not make any assumptions wrt authentication/authorization.

I feel like we need to be more indicative and let clients know what exactly is  is happening. There are many status codes that could potentially fit the bill so any suggestions are welcome.

According to [HTTP standard](https://tools.ietf.org/html/rfc7231#section-6.5.8) 502 represents:

    The 502 (Bad Gateway) status code indicates that the server, while
    acting as a gateway or proxy, received an invalid response from an
    inbound server it accessed while attempting to fulfill the request.

Given this is not cacheable by default and represents a state within the server (a user could create a config to restore the service), it seems to be like appropriate.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
