### PR TITLE
Enforced -querier.max-query-lookback in the query-frontend for range queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [ENHANCEMENT] Enforced keepalive on all gRPC clients used for inter-service communication. #3431
 * [ENHANCEMENT] Added `cortex_alertmanager_config_hash` metric to expose hash of Alertmanager Config loaded per user. #3388
 * [ENHANCEMENT] Query-Frontend / Query-Scheduler: New component called "Query-Scheduler" has been introduced. Query-Scheduler is simply a queue of requests, moved outside of Query-Frontend. This allows Query-Frontend to be scaled separately from number of queues. To make Query-Frontend and Querier use Query-Scheduler, they need to be started with `-frontend.scheduler-address` and `-querier.scheduler-address` options respectively. #3374
-* [ENHANCEMENT] Querier: added `-querier.max-query-lookback` to limit how long back data (series and metadata) can be queried. This setting can be overridden on a per-tenant basis. #3452
+* [ENHANCEMENT] Query-frontend / Querier / Ruler: added `-querier.max-query-lookback` to limit how long back data (series and metadata) can be queried. This setting can be overridden on a per-tenant basis and is enforced in the query-frontend, querier and ruler. #3452 #3458
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -414,7 +414,7 @@ blocks_storage:
         [max_get_multi_concurrency: <int> | default = 100]
 
         # The maximum number of keys a single underlying get operation should
-        # run. If more keys are specified, internally keys are splitted into
+        # run. If more keys are specified, internally keys are split into
         # multiple batches and fetched concurrently, honoring the max
         # concurrency. If set to 0, the max batch size is unlimited.
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size
@@ -465,7 +465,7 @@ blocks_storage:
         [max_get_multi_concurrency: <int> | default = 100]
 
         # The maximum number of keys a single underlying get operation should
-        # run. If more keys are specified, internally keys are splitted into
+        # run. If more keys are specified, internally keys are split into
         # multiple batches and fetched concurrently, honoring the max
         # concurrency. If set to 0, the max batch size is unlimited.
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size
@@ -531,7 +531,7 @@ blocks_storage:
         [max_get_multi_concurrency: <int> | default = 100]
 
         # The maximum number of keys a single underlying get operation should
-        # run. If more keys are specified, internally keys are splitted into
+        # run. If more keys are specified, internally keys are split into
         # multiple batches and fetched concurrently, honoring the max
         # concurrency. If set to 0, the max batch size is unlimited.
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -469,7 +469,7 @@ blocks_storage:
         [max_get_multi_concurrency: <int> | default = 100]
 
         # The maximum number of keys a single underlying get operation should
-        # run. If more keys are specified, internally keys are splitted into
+        # run. If more keys are specified, internally keys are split into
         # multiple batches and fetched concurrently, honoring the max
         # concurrency. If set to 0, the max batch size is unlimited.
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size
@@ -520,7 +520,7 @@ blocks_storage:
         [max_get_multi_concurrency: <int> | default = 100]
 
         # The maximum number of keys a single underlying get operation should
-        # run. If more keys are specified, internally keys are splitted into
+        # run. If more keys are specified, internally keys are split into
         # multiple batches and fetched concurrently, honoring the max
         # concurrency. If set to 0, the max batch size is unlimited.
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size
@@ -586,7 +586,7 @@ blocks_storage:
         [max_get_multi_concurrency: <int> | default = 100]
 
         # The maximum number of keys a single underlying get operation should
-        # run. If more keys are specified, internally keys are splitted into
+        # run. If more keys are specified, internally keys are split into
         # multiple batches and fetched concurrently, honoring the max
         # concurrency. If set to 0, the max batch size is unlimited.
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3065,8 +3065,7 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -store.max-query-length
 [max_query_length: <duration> | default = 0s]
 
-# Maximum number of splitted queries will be scheduled in parallel by the
-# frontend.
+# Maximum number of split queries will be scheduled in parallel by the frontend.
 # CLI flag: -querier.max-query-parallelism
 [max_query_parallelism: <int> | default = 14]
 
@@ -3596,7 +3595,7 @@ bucket_store:
       [max_get_multi_concurrency: <int> | default = 100]
 
       # The maximum number of keys a single underlying get operation should run.
-      # If more keys are specified, internally keys are splitted into multiple
+      # If more keys are specified, internally keys are split into multiple
       # batches and fetched concurrently, honoring the max concurrency. If set
       # to 0, the max batch size is unlimited.
       # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size
@@ -3647,7 +3646,7 @@ bucket_store:
       [max_get_multi_concurrency: <int> | default = 100]
 
       # The maximum number of keys a single underlying get operation should run.
-      # If more keys are specified, internally keys are splitted into multiple
+      # If more keys are specified, internally keys are split into multiple
       # batches and fetched concurrently, honoring the max concurrency. If set
       # to 0, the max batch size is unlimited.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size
@@ -3712,7 +3711,7 @@ bucket_store:
       [max_get_multi_concurrency: <int> | default = 100]
 
       # The maximum number of keys a single underlying get operation should run.
-      # If more keys are specified, internally keys are splitted into multiple
+      # If more keys are specified, internally keys are split into multiple
       # batches and fetched concurrently, honoring the max concurrency. If set
       # to 0, the max batch size is unlimited.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3052,7 +3052,10 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 [max_chunks_per_query: <int> | default = 2000000]
 
 # Limit how long back data (series and metadata) can be queried, up until
-# <lookback> duration ago. 0 to disable.
+# <lookback> duration ago. This limit is enforced in the query-frontend, querier
+# and ruler. If the requested time range is outside the allowed range, the
+# request will not fail but will be manipulated to only query data within the
+# allowed time range. 0 to disable.
 # CLI flag: -querier.max-query-lookback
 [max_query_lookback: <duration> | default = 0s]
 
@@ -3062,7 +3065,8 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -store.max-query-length
 [max_query_length: <duration> | default = 0s]
 
-# Maximum number of queries will be scheduled in parallel by the frontend.
+# Maximum number of splitted queries will be scheduled in parallel by the
+# frontend.
 # CLI flag: -querier.max-query-parallelism
 [max_query_parallelism: <int> | default = 14]
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -512,7 +512,8 @@ func validateQueryTimeRange(ctx context.Context, userID string, startMs, endMs i
 		// Make sure to log it in traces to ease debugging.
 		level.Debug(spanlogger.FromContext(ctx)).Log(
 			"msg", "the end time of the query has been manipulated because of the 'max query into future' setting",
-			"original", origEndTime, "updated", endTime)
+			"original", origEndTime.String(),
+			"updated", endTime.String())
 
 		if endTime.Before(startTime) {
 			return 0, 0, errEmptyTimeRange
@@ -527,7 +528,8 @@ func validateQueryTimeRange(ctx context.Context, userID string, startMs, endMs i
 		// Make sure to log it in traces to ease debugging.
 		level.Debug(spanlogger.FromContext(ctx)).Log(
 			"msg", "the start time of the query has been manipulated because of the 'max query lookback' setting",
-			"original", origStartTime, "updated", startTime)
+			"original", origStartTime.String(),
+			"updated", startTime.String())
 
 		if endTime.Before(startTime) {
 			return 0, 0, errEmptyTimeRange

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -512,8 +512,8 @@ func validateQueryTimeRange(ctx context.Context, userID string, startMs, endMs i
 		// Make sure to log it in traces to ease debugging.
 		level.Debug(spanlogger.FromContext(ctx)).Log(
 			"msg", "the end time of the query has been manipulated because of the 'max query into future' setting",
-			"original", origEndTime.String(),
-			"updated", endTime.String())
+			"original", util.FormatTimeModel(origEndTime),
+			"updated", util.FormatTimeModel(endTime))
 
 		if endTime.Before(startTime) {
 			return 0, 0, errEmptyTimeRange
@@ -528,8 +528,8 @@ func validateQueryTimeRange(ctx context.Context, userID string, startMs, endMs i
 		// Make sure to log it in traces to ease debugging.
 		level.Debug(spanlogger.FromContext(ctx)).Log(
 			"msg", "the start time of the query has been manipulated because of the 'max query lookback' setting",
-			"original", origStartTime.String(),
-			"updated", startTime.String())
+			"original", util.FormatTimeModel(origStartTime),
+			"updated", util.FormatTimeModel(startTime))
 
 		if endTime.Before(startTime) {
 			return 0, 0, errEmptyTimeRange

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -5,107 +5,92 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 // Limits allows us to specify per-tenant runtime limits on the behavior of
 // the query handling code.
 type Limits interface {
+	// MaxQueryLookback returns the max lookback period of queries.
+	MaxQueryLookback(userID string) time.Duration
+
+	// MaxQueryLength returns the limit of the length (in time) of a query.
 	MaxQueryLength(string) time.Duration
+
+	// MaxQueryParallelism returns the limit to the number of splitted queries the
+	// frontend will process in parallel.
 	MaxQueryParallelism(string) int
+
+	// MaxCacheFreshness returns the period after which results are cacheable,
+	// to prevent caching of very recent results.
 	MaxCacheFreshness(string) time.Duration
 }
 
-type limits struct {
+type limitsMiddleware struct {
 	Limits
 	next Handler
 }
 
-// LimitsMiddleware creates a new Middleware that invalidates large queries based on Limits interface.
-func LimitsMiddleware(l Limits) Middleware {
+// NewLimitsMiddleware creates a new Middleware that enforces query limits.
+func NewLimitsMiddleware(l Limits) Middleware {
 	return MiddlewareFunc(func(next Handler) Handler {
-		return limits{
+		return limitsMiddleware{
 			next:   next,
 			Limits: l,
 		}
 	})
 }
 
-func (l limits) Do(ctx context.Context, r Request) (Response, error) {
-	userid, err := user.ExtractOrgID(ctx)
+func (l limitsMiddleware) Do(ctx context.Context, r Request) (Response, error) {
+	log, ctx := spanlogger.New(ctx, "limits")
+	defer log.Finish()
+
+	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 
-	maxQueryLen := l.MaxQueryLength(userid)
-	queryLen := timestamp.Time(r.GetEnd()).Sub(timestamp.Time(r.GetStart()))
-	if maxQueryLen > 0 && queryLen > maxQueryLen {
-		return nil, httpgrpc.Errorf(http.StatusBadRequest, validation.ErrQueryTooLong, queryLen, maxQueryLen)
+	// Clamp the time range based on the max query lookback.
+	if maxQueryLookback := l.MaxQueryLookback(userID); maxQueryLookback > 0 {
+		minStartTime := util.TimeToMillis(time.Now().Add(-maxQueryLookback))
+
+		if r.GetEnd() < minStartTime {
+			// The request is fully outside the allowed range, so we can return an
+			// empty response.
+			level.Debug(log).Log(
+				"msg", "skipping the execution of the query because its time range is before the 'max query lookback' setting",
+				"reqStart", util.FormatTimeMillis(r.GetStart()),
+				"redEnd", util.FormatTimeMillis(r.GetEnd()),
+				"maxQueryLookback", maxQueryLookback)
+
+			return NewEmptyPrometheusResponse(), nil
+		}
+
+		if r.GetStart() < minStartTime {
+			// Replace the start time in the request.
+			level.Debug(log).Log(
+				"msg", "the start time of the query has been manipulated because of the 'max query lookback' setting",
+				"original", util.FormatTimeMillis(r.GetStart()),
+				"updated", util.FormatTimeMillis(minStartTime))
+
+			r = r.WithStartEnd(minStartTime, r.GetEnd())
+		}
 	}
+
+	// Enforce the max query length.
+	if maxQueryLength := l.MaxQueryLength(userID); maxQueryLength > 0 {
+		queryLen := timestamp.Time(r.GetEnd()).Sub(timestamp.Time(r.GetStart()))
+		if queryLen > maxQueryLength {
+			return nil, httpgrpc.Errorf(http.StatusBadRequest, validation.ErrQueryTooLong, queryLen, maxQueryLength)
+		}
+	}
+
 	return l.next.Do(ctx, r)
-}
-
-// RequestResponse contains a request response and the respective request that was used.
-type RequestResponse struct {
-	Request  Request
-	Response Response
-}
-
-// DoRequests executes a list of requests in parallel. The limits parameters is used to limit parallelism per single request.
-func DoRequests(ctx context.Context, downstream Handler, reqs []Request, limits Limits) ([]RequestResponse, error) {
-	userid, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
-	}
-
-	// If one of the requests fail, we want to be able to cancel the rest of them.
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// Feed all requests to a bounded intermediate channel to limit parallelism.
-	intermediate := make(chan Request)
-	go func() {
-		for _, req := range reqs {
-			intermediate <- req
-		}
-		close(intermediate)
-	}()
-
-	respChan, errChan := make(chan RequestResponse), make(chan error)
-	parallelism := limits.MaxQueryParallelism(userid)
-	if parallelism > len(reqs) {
-		parallelism = len(reqs)
-	}
-	for i := 0; i < parallelism; i++ {
-		go func() {
-			for req := range intermediate {
-				resp, err := downstream.Do(ctx, req)
-				if err != nil {
-					errChan <- err
-				} else {
-					respChan <- RequestResponse{req, resp}
-				}
-			}
-		}()
-	}
-
-	resps := make([]RequestResponse, 0, len(reqs))
-	var firstErr error
-	for range reqs {
-		select {
-		case resp := <-respChan:
-			resps = append(resps, resp)
-		case err := <-errChan:
-			if firstErr == nil {
-				cancel()
-				firstErr = err
-			}
-		}
-	}
-
-	return resps, firstErr
 }

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -24,7 +24,7 @@ type Limits interface {
 	// MaxQueryLength returns the limit of the length (in time) of a query.
 	MaxQueryLength(string) time.Duration
 
-	// MaxQueryParallelism returns the limit to the number of splitted queries the
+	// MaxQueryParallelism returns the limit to the number of split queries the
 	// frontend will process in parallel.
 	MaxQueryParallelism(string) int
 

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -28,7 +28,7 @@ func TestLimitsMiddleware_MaxQueryLookback(t *testing.T) {
 		expectedStartTime time.Time
 		expectedEndTime   time.Time
 	}{
-		"should not manipulate time range it max lookback is disabled": {
+		"should not manipulate time range if max lookback is disabled": {
 			maxQueryLookback:  0,
 			reqStartTime:      time.Unix(0, 0),
 			reqEndTime:        now,
@@ -143,7 +143,7 @@ func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
 		},
 		"should fail on a query on large time range over the limit, ending in the past": {
 			maxQueryLength: thirtyDays,
-			reqStartTime:   now.Add(-2 * thirtyDays).Add(-thirtyDays).Add(-100 * time.Hour),
+			reqStartTime:   now.Add(-4 * thirtyDays),
 			reqEndTime:     now.Add(-2 * thirtyDays),
 			expectedErr:    "the query time range exceeds the limit",
 		},

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -1,0 +1,218 @@
+package queryrange
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+func TestLimitsMiddleware_MaxQueryLookback(t *testing.T) {
+	const (
+		thirtyDays = 30 * 24 * time.Hour
+	)
+
+	now := time.Now()
+
+	tests := map[string]struct {
+		maxQueryLookback  time.Duration
+		reqStartTime      time.Time
+		reqEndTime        time.Time
+		expectedSkipped   bool
+		expectedStartTime time.Time
+		expectedEndTime   time.Time
+	}{
+		"should not manipulate time range it max lookback is disabled": {
+			maxQueryLookback:  0,
+			reqStartTime:      time.Unix(0, 0),
+			reqEndTime:        now,
+			expectedStartTime: time.Unix(0, 0),
+			expectedEndTime:   now,
+		},
+		"should not manipulate time range for a query on short time range": {
+			maxQueryLookback:  thirtyDays,
+			reqStartTime:      now.Add(-time.Hour),
+			reqEndTime:        now,
+			expectedStartTime: now.Add(-time.Hour),
+			expectedEndTime:   now,
+		},
+		"should not manipulate a query on large time range close to the limit": {
+			maxQueryLookback:  thirtyDays,
+			reqStartTime:      now.Add(-thirtyDays).Add(time.Hour),
+			reqEndTime:        now,
+			expectedStartTime: now.Add(-thirtyDays).Add(time.Hour),
+			expectedEndTime:   now,
+		},
+		"should manipulate a query on large time range over the limit": {
+			maxQueryLookback:  thirtyDays,
+			reqStartTime:      now.Add(-thirtyDays).Add(-100 * time.Hour),
+			reqEndTime:        now,
+			expectedStartTime: now.Add(-thirtyDays),
+			expectedEndTime:   now,
+		},
+		"should skip executing a query outside the allowed time range": {
+			maxQueryLookback: thirtyDays,
+			reqStartTime:     now.Add(-thirtyDays).Add(-100 * time.Hour),
+			reqEndTime:       now.Add(-thirtyDays).Add(-90 * time.Hour),
+			expectedSkipped:  true,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			req := &PrometheusRequest{
+				Start: util.TimeToMillis(testData.reqStartTime),
+				End:   util.TimeToMillis(testData.reqEndTime),
+			}
+
+			limits := mockLimits{maxQueryLookback: testData.maxQueryLookback}
+			middleware := NewLimitsMiddleware(limits)
+
+			innerRes := NewEmptyPrometheusResponse()
+			inner := &mockHandler{}
+			inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
+
+			ctx := user.InjectOrgID(context.Background(), "test")
+			outer := middleware.Wrap(inner)
+			res, err := outer.Do(ctx, req)
+			require.NoError(t, err)
+
+			if testData.expectedSkipped {
+				// We expect an empty response, but not the one returned by the inner handler
+				// which we expect has been skipped.
+				assert.NotSame(t, innerRes, res)
+				assert.Len(t, inner.Calls, 0)
+			} else {
+				// We expect the response returned by the inner handler.
+				assert.Same(t, innerRes, res)
+
+				// Assert on the time range of the request passed to the inner handler (5s delta).
+				delta := float64(5000)
+				require.Len(t, inner.Calls, 1)
+				assert.InDelta(t, util.TimeToMillis(testData.expectedStartTime), inner.Calls[0].Arguments.Get(1).(Request).GetStart(), delta)
+				assert.InDelta(t, util.TimeToMillis(testData.expectedEndTime), inner.Calls[0].Arguments.Get(1).(Request).GetEnd(), delta)
+			}
+		})
+	}
+}
+
+func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
+	const (
+		thirtyDays = 30 * 24 * time.Hour
+	)
+
+	now := time.Now()
+
+	tests := map[string]struct {
+		maxQueryLength time.Duration
+		reqStartTime   time.Time
+		reqEndTime     time.Time
+		expectedErr    string
+	}{
+		"should skip validation if max length is disabled": {
+			maxQueryLength: 0,
+			reqStartTime:   time.Unix(0, 0),
+			reqEndTime:     now,
+		},
+		"should succeed on a query on short time range, ending now": {
+			maxQueryLength: thirtyDays,
+			reqStartTime:   now.Add(-time.Hour),
+			reqEndTime:     now,
+		},
+		"should succeed on a query on short time range, ending in the past": {
+			maxQueryLength: thirtyDays,
+			reqStartTime:   now.Add(-2 * thirtyDays).Add(-time.Hour),
+			reqEndTime:     now.Add(-2 * thirtyDays),
+		},
+		"should succeed on a query on large time range close to the limit, ending now": {
+			maxQueryLength: thirtyDays,
+			reqStartTime:   now.Add(-thirtyDays).Add(time.Hour),
+			reqEndTime:     now,
+		},
+		"should fail on a query on large time range over the limit, ending now": {
+			maxQueryLength: thirtyDays,
+			reqStartTime:   now.Add(-thirtyDays).Add(-100 * time.Hour),
+			reqEndTime:     now,
+			expectedErr:    "the query time range exceeds the limit",
+		},
+		"should fail on a query on large time range over the limit, ending in the past": {
+			maxQueryLength: thirtyDays,
+			reqStartTime:   now.Add(-2 * thirtyDays).Add(-thirtyDays).Add(-100 * time.Hour),
+			reqEndTime:     now.Add(-2 * thirtyDays),
+			expectedErr:    "the query time range exceeds the limit",
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			req := &PrometheusRequest{
+				Start: util.TimeToMillis(testData.reqStartTime),
+				End:   util.TimeToMillis(testData.reqEndTime),
+			}
+
+			limits := mockLimits{maxQueryLength: testData.maxQueryLength}
+			middleware := NewLimitsMiddleware(limits)
+
+			innerRes := NewEmptyPrometheusResponse()
+			inner := &mockHandler{}
+			inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
+
+			ctx := user.InjectOrgID(context.Background(), "test")
+			outer := middleware.Wrap(inner)
+			res, err := outer.Do(ctx, req)
+
+			if testData.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), testData.expectedErr)
+				assert.Nil(t, res)
+				assert.Len(t, inner.Calls, 0)
+			} else {
+				// We expect the response returned by the inner handler.
+				require.NoError(t, err)
+				assert.Same(t, innerRes, res)
+
+				// The time range of the request passed to the inner handler should have not been manipulated.
+				require.Len(t, inner.Calls, 1)
+				assert.Equal(t, util.TimeToMillis(testData.reqStartTime), inner.Calls[0].Arguments.Get(1).(Request).GetStart())
+				assert.Equal(t, util.TimeToMillis(testData.reqEndTime), inner.Calls[0].Arguments.Get(1).(Request).GetEnd())
+			}
+		})
+	}
+}
+
+type mockLimits struct {
+	maxQueryLookback  time.Duration
+	maxQueryLength    time.Duration
+	maxCacheFreshness time.Duration
+}
+
+func (m mockLimits) MaxQueryLookback(string) time.Duration {
+	return m.maxQueryLookback
+}
+
+func (m mockLimits) MaxQueryLength(string) time.Duration {
+	return m.maxQueryLength
+}
+
+func (mockLimits) MaxQueryParallelism(string) int {
+	return 14 // Flag default.
+}
+
+func (m mockLimits) MaxCacheFreshness(string) time.Duration {
+	return m.maxCacheFreshness
+}
+
+type mockHandler struct {
+	mock.Mock
+}
+
+func (m *mockHandler) Do(ctx context.Context, req Request) (Response, error) {
+	args := m.Called(ctx, req)
+	return args.Get(0).(Response), args.Error(1)
+}

--- a/pkg/querier/queryrange/query_range.go
+++ b/pkg/querier/queryrange/query_range.go
@@ -76,7 +76,7 @@ type Request interface {
 	// GetCachingOptions returns the caching options.
 	GetCachingOptions() CachingOptions
 	// WithStartEnd clone the current request with different start and end timestamp.
-	WithStartEnd(int64, int64) Request
+	WithStartEnd(startTime int64, endTime int64) Request
 	// WithQuery clone the current request with a different query.
 	WithQuery(string) Request
 	proto.Message
@@ -135,15 +135,20 @@ func (resp *PrometheusResponse) minTime() int64 {
 	return result[0].Samples[0].TimestampMs
 }
 
+// NewEmptyPrometheusResponse returns an empty successful Prometheus query range response.
+func NewEmptyPrometheusResponse() *PrometheusResponse {
+	return &PrometheusResponse{
+		Status: StatusSuccess,
+		Data: PrometheusData{
+			ResultType: model.ValMatrix.String(),
+			Result:     []SampleStream{},
+		},
+	}
+}
+
 func (prometheusCodec) MergeResponse(responses ...Response) (Response, error) {
 	if len(responses) == 0 {
-		return &PrometheusResponse{
-			Status: StatusSuccess,
-			Data: PrometheusData{
-				ResultType: model.ValMatrix.String(),
-				Result:     []SampleStream{},
-			},
-		}, nil
+		return NewEmptyPrometheusResponse(), nil
 	}
 
 	promResponses := make([]*PrometheusResponse, 0, len(responses))

--- a/pkg/querier/queryrange/queryable_test.go
+++ b/pkg/querier/queryrange/queryable_test.go
@@ -31,7 +31,7 @@ func TestSelect(t *testing.T) {
 		},
 		{
 			name: "replaces query",
-			querier: mkQuerier(mockHandler(
+			querier: mkQuerier(mockHandlerWith(
 				&PrometheusResponse{},
 				nil,
 			)),
@@ -65,7 +65,7 @@ func TestSelect(t *testing.T) {
 		},
 		{
 			name: "propagates response error",
-			querier: mkQuerier(mockHandler(
+			querier: mkQuerier(mockHandlerWith(
 				&PrometheusResponse{
 					Error: "SomeErr",
 				},
@@ -85,7 +85,7 @@ func TestSelect(t *testing.T) {
 		},
 		{
 			name: "returns SeriesSet",
-			querier: mkQuerier(mockHandler(
+			querier: mkQuerier(mockHandlerWith(
 				&PrometheusResponse{
 					Data: PrometheusData{
 						ResultType: string(parser.ValueTypeVector),
@@ -214,7 +214,7 @@ func TestSelectConcurrent(t *testing.T) {
 
 		t.Run(c.name, func(t *testing.T) {
 			// each request will return a single samplestream
-			querier := mkQuerier(mockHandler(&PrometheusResponse{
+			querier := mkQuerier(mockHandlerWith(&PrometheusResponse{
 				Data: PrometheusData{
 					ResultType: string(parser.ValueTypeVector),
 					Result: []SampleStream{

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -34,7 +34,7 @@ func TestQueryshardingMiddleware(t *testing.T) {
 		{
 			name: "invalid query error",
 			// if the query parses correctly force it to succeed
-			next: mockHandler(&PrometheusResponse{
+			next: mockHandlerWith(&PrometheusResponse{
 				Status: "",
 				Data: PrometheusData{
 					ResultType: string(parser.ValueTypeVector),
@@ -50,7 +50,7 @@ func TestQueryshardingMiddleware(t *testing.T) {
 		},
 		{
 			name:     "downstream err",
-			next:     mockHandler(nil, errors.Errorf("some err")),
+			next:     mockHandlerWith(nil, errors.Errorf("some err")),
 			input:    defaultReq(),
 			ctx:      context.Background(),
 			expected: nil,
@@ -58,7 +58,7 @@ func TestQueryshardingMiddleware(t *testing.T) {
 		},
 		{
 			name: "successful trip",
-			next: mockHandler(sampleMatrixResponse(), nil),
+			next: mockHandlerWith(sampleMatrixResponse(), nil),
 			override: func(t *testing.T, handler Handler) {
 
 				// pre-encode the query so it doesn't try to re-split. We're just testing if it passes through correctly
@@ -158,7 +158,7 @@ func sampleMatrixResponse() *PrometheusResponse {
 	}
 }
 
-func mockHandler(resp *PrometheusResponse, err error) Handler {
+func mockHandlerWith(resp *PrometheusResponse, err error) Handler {
 	return HandlerFunc(func(ctx context.Context, req Request) (Response, error) {
 		if expired := ctx.Err(); expired != nil {
 			return nil, expired

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -159,7 +159,7 @@ func NewTripperware(
 	// Metric used to keep track of each middleware execution duration.
 	metrics := NewInstrumentMiddlewareMetrics(registerer)
 
-	queryRangeMiddleware := []Middleware{LimitsMiddleware(limits)}
+	queryRangeMiddleware := []Middleware{NewLimitsMiddleware(limits)}
 	if cfg.AlignQueriesWithStep {
 		queryRangeMiddleware = append(queryRangeMiddleware, InstrumentMiddleware("step_align", metrics), StepAlignMiddleware)
 	}

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -48,7 +48,7 @@ func TestRoundTrip(t *testing.T) {
 
 	tw, _, err := NewTripperware(Config{},
 		util.Logger,
-		fakeLimits{},
+		mockLimits{},
 		PrometheusCodec,
 		nil,
 		chunk.SchemaConfig{},

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -279,7 +279,7 @@ func TestSplitByDay(t *testing.T) {
 			roundtripper := NewRoundTripper(singleHostRoundTripper{
 				host: u.Host,
 				next: http.DefaultTransport,
-			}, PrometheusCodec, LimitsMiddleware(fakeLimits{}), SplitByIntervalMiddleware(interval, fakeLimits{}, PrometheusCodec, nil))
+			}, PrometheusCodec, NewLimitsMiddleware(mockLimits{}), SplitByIntervalMiddleware(interval, mockLimits{}, PrometheusCodec, nil))
 
 			req, err := http.NewRequest("GET", tc.path, http.NoBody)
 			require.NoError(t, err)

--- a/pkg/querier/queryrange/util.go
+++ b/pkg/querier/queryrange/util.go
@@ -1,0 +1,70 @@
+package queryrange
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/user"
+)
+
+// RequestResponse contains a request response and the respective request that was used.
+type RequestResponse struct {
+	Request  Request
+	Response Response
+}
+
+// DoRequests executes a list of requests in parallel. The limits parameters is used to limit parallelism per single request.
+func DoRequests(ctx context.Context, downstream Handler, reqs []Request, limits Limits) ([]RequestResponse, error) {
+	userid, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
+	}
+
+	// If one of the requests fail, we want to be able to cancel the rest of them.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Feed all requests to a bounded intermediate channel to limit parallelism.
+	intermediate := make(chan Request)
+	go func() {
+		for _, req := range reqs {
+			intermediate <- req
+		}
+		close(intermediate)
+	}()
+
+	respChan, errChan := make(chan RequestResponse), make(chan error)
+	parallelism := limits.MaxQueryParallelism(userid)
+	if parallelism > len(reqs) {
+		parallelism = len(reqs)
+	}
+	for i := 0; i < parallelism; i++ {
+		go func() {
+			for req := range intermediate {
+				resp, err := downstream.Do(ctx, req)
+				if err != nil {
+					errChan <- err
+				} else {
+					respChan <- RequestResponse{req, resp}
+				}
+			}
+		}()
+	}
+
+	resps := make([]RequestResponse, 0, len(reqs))
+	var firstErr error
+	for range reqs {
+		select {
+		case resp := <-respChan:
+			resps = append(resps, resp)
+		case err := <-errChan:
+			if firstErr == nil {
+				cancel()
+				firstErr = err
+			}
+		}
+	}
+
+	return resps, firstErr
+}

--- a/pkg/storage/tsdb/memcache_client_config.go
+++ b/pkg/storage/tsdb/memcache_client_config.go
@@ -27,7 +27,7 @@ func (cfg *MemcachedClientConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefi
 	f.IntVar(&cfg.MaxAsyncConcurrency, prefix+"max-async-concurrency", 50, "The maximum number of concurrent asynchronous operations can occur.")
 	f.IntVar(&cfg.MaxAsyncBufferSize, prefix+"max-async-buffer-size", 10000, "The maximum number of enqueued asynchronous operations allowed.")
 	f.IntVar(&cfg.MaxGetMultiConcurrency, prefix+"max-get-multi-concurrency", 100, "The maximum number of concurrent connections running get operations. If set to 0, concurrency is unlimited.")
-	f.IntVar(&cfg.MaxGetMultiBatchSize, prefix+"max-get-multi-batch-size", 0, "The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are splitted into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.")
+	f.IntVar(&cfg.MaxGetMultiBatchSize, prefix+"max-get-multi-batch-size", 0, "The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.")
 	f.IntVar(&cfg.MaxItemSize, prefix+"max-item-size", 1024*1024, "The maximum size of an item stored in memcached. Bigger items are not stored. If set to 0, no maximum size is enforced.")
 }
 

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/prometheus/common/model"
 	"github.com/weaveworks/common/httpgrpc"
 )
 
@@ -26,6 +27,11 @@ func TimeFromMillis(ms int64) time.Time {
 // FormatTimeMillis returns a human readable version of the input time (in milliseconds).
 func FormatTimeMillis(ms int64) string {
 	return TimeFromMillis(ms).String()
+}
+
+// FormatTimeModel returns a human readable version of the input time.
+func FormatTimeModel(t model.Time) string {
+	return TimeFromMillis(int64(t)).String()
 }
 
 // ParseTime parses the string into an int64, milliseconds since epoch.

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -23,6 +23,11 @@ func TimeFromMillis(ms int64) time.Time {
 	return time.Unix(0, ms*nanosecondsInMillisecond)
 }
 
+// FormatTimeMillis returns a human readable version of the input time (in milliseconds).
+func FormatTimeMillis(ms int64) string {
+	return TimeFromMillis(ms).String()
+}
+
 // ParseTime parses the string into an int64, milliseconds since epoch.
 func ParseTime(s string) (int64, error) {
 	if t, err := strconv.ParseFloat(s, 64); err == nil {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -124,7 +124,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxChunksPerQuery, "store.query-chunk-limit", 2e6, "Maximum number of chunks that can be fetched in a single query. This limit is enforced when fetching chunks from the long-term storage. When running the Cortex chunks storage, this limit is enforced in the querier, while when running the Cortex blocks storage this limit is both enforced in the querier and store-gateway. 0 to disable.")
 	f.DurationVar(&l.MaxQueryLength, "store.max-query-length", 0, "Limit the query time range (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query possibly split by the query-frontend) and in the chunks storage. 0 to disable.")
 	f.DurationVar(&l.MaxQueryLookback, "querier.max-query-lookback", 0, "Limit how long back data (series and metadata) can be queried, up until <lookback> duration ago. This limit is enforced in the query-frontend, querier and ruler. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.")
-	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of splitted queries will be scheduled in parallel by the frontend.")
+	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of split queries will be scheduled in parallel by the frontend.")
 	f.IntVar(&l.CardinalityLimit, "store.cardinality-limit", 1e5, "Cardinality limit for index queries. This limit is ignored when running the Cortex blocks storage. 0 to disable.")
 	f.DurationVar(&l.MaxCacheFreshness, "frontend.max-cache-freshness", 1*time.Minute, "Most recent allowed cacheable result per-tenant, to prevent caching very recent results that might still be in flux.")
 	f.IntVar(&l.MaxQueriersPerTenant, "frontend.max-queriers-per-tenant", 0, "Maximum number of queriers that can handle requests for a single tenant. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the tenant. Each frontend (or query-scheduler, if used) will select the same set of queriers for the same tenant (given that all queriers are connected to all frontends / query-schedulers). This option only works with queriers connecting to the query-frontend / query-scheduler, not when using downstream URL.")
@@ -331,7 +331,7 @@ func (o *Overrides) MaxQueriersPerUser(userID string) int {
 	return o.getOverridesForUser(userID).MaxQueriersPerTenant
 }
 
-// MaxQueryParallelism returns the limit to the number of splitted queries the
+// MaxQueryParallelism returns the limit to the number of split queries the
 // frontend will process in parallel.
 func (o *Overrides) MaxQueryParallelism(userID string) int {
 	return o.getOverridesForUser(userID).MaxQueryParallelism

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -123,8 +123,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.IntVar(&l.MaxChunksPerQuery, "store.query-chunk-limit", 2e6, "Maximum number of chunks that can be fetched in a single query. This limit is enforced when fetching chunks from the long-term storage. When running the Cortex chunks storage, this limit is enforced in the querier, while when running the Cortex blocks storage this limit is both enforced in the querier and store-gateway. 0 to disable.")
 	f.DurationVar(&l.MaxQueryLength, "store.max-query-length", 0, "Limit the query time range (end - start time). This limit is enforced in the query-frontend (on the received query), in the querier (on the query possibly split by the query-frontend) and in the chunks storage. 0 to disable.")
-	f.DurationVar(&l.MaxQueryLookback, "querier.max-query-lookback", 0, "Limit how long back data (series and metadata) can be queried, up until <lookback> duration ago. 0 to disable.")
-	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of queries will be scheduled in parallel by the frontend.")
+	f.DurationVar(&l.MaxQueryLookback, "querier.max-query-lookback", 0, "Limit how long back data (series and metadata) can be queried, up until <lookback> duration ago. This limit is enforced in the query-frontend, querier and ruler. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.")
+	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of splitted queries will be scheduled in parallel by the frontend.")
 	f.IntVar(&l.CardinalityLimit, "store.cardinality-limit", 1e5, "Cardinality limit for index queries. This limit is ignored when running the Cortex blocks storage. 0 to disable.")
 	f.DurationVar(&l.MaxCacheFreshness, "frontend.max-cache-freshness", 1*time.Minute, "Most recent allowed cacheable result per-tenant, to prevent caching very recent results that might still be in flux.")
 	f.IntVar(&l.MaxQueriersPerTenant, "frontend.max-queriers-per-tenant", 0, "Maximum number of queriers that can handle requests for a single tenant. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the tenant. Each frontend (or query-scheduler, if used) will select the same set of queriers for the same tenant (given that all queriers are connected to all frontends / query-schedulers). This option only works with queriers connecting to the query-frontend / query-scheduler, not when using downstream URL.")
@@ -320,7 +320,8 @@ func (o *Overrides) MaxQueryLength(userID string) time.Duration {
 	return o.getOverridesForUser(userID).MaxQueryLength
 }
 
-// MaxCacheFreshness returns the limit of the length (in time) of a query.
+// MaxCacheFreshness returns the period after which results are cacheable,
+// to prevent caching of very recent results.
 func (o *Overrides) MaxCacheFreshness(userID string) time.Duration {
 	return o.getOverridesForUser(userID).MaxCacheFreshness
 }
@@ -330,7 +331,7 @@ func (o *Overrides) MaxQueriersPerUser(userID string) int {
 	return o.getOverridesForUser(userID).MaxQueriersPerTenant
 }
 
-// MaxQueryParallelism returns the limit to the number of sub-queries the
+// MaxQueryParallelism returns the limit to the number of splitted queries the
 // frontend will process in parallel.
 func (o *Overrides) MaxQueryParallelism(userID string) int {
 	return o.getOverridesForUser(userID).MaxQueryParallelism


### PR DESCRIPTION
**What this PR does**:
In the PR #3452 I've introduced `-querier.max-query-lookback` but I've intentionally skipped enforcing the limit in the query-frontend, in order to keep the change  set smaller. In this PR I'm enforcing it in the query-frontend too, for range queries.

The main benefit of enforcing it in the query-frontend too is to reduce the number of query range requests enqueued for a tenant, if such queries cover a range outside the max lookback. Without this PR, the limit would be enforced anyway in the querier, but we may end up with a large number of splitted queries in the query-frontend/query-scheduler queue which would be noop once executed in the querier.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
