### PR TITLE
Split ReadRing.GetAll() into two functions

### DIFF
--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -704,7 +704,7 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 	for _, c := range compactors {
 		cortex_testutil.Poll(t, 10*time.Second, len(compactors), func() interface{} {
 			// it is safe to access c.ring here, since we know that all compactors are Running now
-			rs, err := c.ring.GetAll(ring.Compactor)
+			rs, err := c.ring.GetAllHealthy(ring.Compactor)
 			if err != nil {
 				return 0
 			}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -835,7 +835,7 @@ func (d *Distributor) AllUserStats(ctx context.Context) ([]UserIDStats, error) {
 	req := &client.UserStatsRequest{}
 	ctx = user.InjectOrgID(ctx, "1") // fake: ingester insists on having an org ID
 	// Not using d.ForReplicationSet(), so we can fail after first error.
-	replicationSet, err := d.ingestersRing.GetAll(ring.Read)
+	replicationSet, err := d.ingestersRing.GetAllHealthy(ring.Read)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -88,7 +88,7 @@ func (d *Distributor) GetIngestersForQuery(ctx context.Context, matchers ...*lab
 		lookbackPeriod := d.cfg.ShuffleShardingLookbackPeriod
 
 		if shardSize > 0 && lookbackPeriod > 0 {
-			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now()).GetAll(ring.Read)
+			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now()).GetAllFor(ring.Read)
 		}
 	}
 
@@ -101,7 +101,7 @@ func (d *Distributor) GetIngestersForQuery(ctx context.Context, matchers ...*lab
 		}
 	}
 
-	return d.ingestersRing.GetAll(ring.Read)
+	return d.ingestersRing.GetAllFor(ring.Read)
 }
 
 // GetIngestersForMetadata returns a replication set including all ingesters that should be queried
@@ -119,11 +119,11 @@ func (d *Distributor) GetIngestersForMetadata(ctx context.Context) (ring.Replica
 		lookbackPeriod := d.cfg.ShuffleShardingLookbackPeriod
 
 		if shardSize > 0 && lookbackPeriod > 0 {
-			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now()).GetAll(ring.Read)
+			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now()).GetAllFor(ring.Read)
 		}
 	}
 
-	return d.ingestersRing.GetAll(ring.Read)
+	return d.ingestersRing.GetAllFor(ring.Read)
 }
 
 // queryIngesters queries the ingesters via the older, sample-based API.

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -88,7 +88,7 @@ func (d *Distributor) GetIngestersForQuery(ctx context.Context, matchers ...*lab
 		lookbackPeriod := d.cfg.ShuffleShardingLookbackPeriod
 
 		if shardSize > 0 && lookbackPeriod > 0 {
-			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now()).GetAllFor(ring.Read)
+			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now()).GetReplicationSetForOperation(ring.Read)
 		}
 	}
 
@@ -101,7 +101,7 @@ func (d *Distributor) GetIngestersForQuery(ctx context.Context, matchers ...*lab
 		}
 	}
 
-	return d.ingestersRing.GetAllFor(ring.Read)
+	return d.ingestersRing.GetReplicationSetForOperation(ring.Read)
 }
 
 // GetIngestersForMetadata returns a replication set including all ingesters that should be queried
@@ -119,11 +119,11 @@ func (d *Distributor) GetIngestersForMetadata(ctx context.Context) (ring.Replica
 		lookbackPeriod := d.cfg.ShuffleShardingLookbackPeriod
 
 		if shardSize > 0 && lookbackPeriod > 0 {
-			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now()).GetAllFor(ring.Read)
+			return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now()).GetReplicationSetForOperation(ring.Read)
 		}
 	}
 
-	return d.ingestersRing.GetAllFor(ring.Read)
+	return d.ingestersRing.GetReplicationSetForOperation(ring.Read)
 }
 
 // queryIngesters queries the ingesters via the older, sample-based API.

--- a/pkg/querier/blocks_store_replicated_set_test.go
+++ b/pkg/querier/blocks_store_replicated_set_test.go
@@ -342,7 +342,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 
 			// Wait until the ring client has initialised the state.
 			test.Poll(t, time.Second, true, func() interface{} {
-				all, err := r.GetAll(ring.Read)
+				all, err := r.GetAllHealthy(ring.Read)
 				return err == nil && len(all.Ingesters) > 0
 			})
 

--- a/pkg/ring/client/ring_service_discovery.go
+++ b/pkg/ring/client/ring_service_discovery.go
@@ -6,7 +6,7 @@ import (
 
 func NewRingServiceDiscovery(r ring.ReadRing) PoolServiceDiscovery {
 	return func() ([]string, error) {
-		replicationSet, err := r.GetAll(ring.Read)
+		replicationSet, err := r.GetAllHealthy(ring.HealthCheck)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ring/client/ring_service_discovery.go
+++ b/pkg/ring/client/ring_service_discovery.go
@@ -6,7 +6,7 @@ import (
 
 func NewRingServiceDiscovery(r ring.ReadRing) PoolServiceDiscovery {
 	return func() ([]string, error) {
-		replicationSet, err := r.GetAllHealthy(ring.HealthCheck)
+		replicationSet, err := r.GetAllHealthy(ring.Reporting)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ring/client/ring_service_discovery_test.go
+++ b/pkg/ring/client/ring_service_discovery_test.go
@@ -58,6 +58,6 @@ type mockReadRing struct {
 	mockedErr            error
 }
 
-func (m *mockReadRing) GetAll(_ ring.Operation) (ring.ReplicationSet, error) {
+func (m *mockReadRing) GetAllHealthy(_ ring.Operation) (ring.ReplicationSet, error) {
 	return m.mockedReplicationSet, m.mockedErr
 }

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -168,10 +168,6 @@ func (i *IngesterDesc) IsHealthy(op Operation, heartbeatTimeout time.Duration) b
 
 	case Compactor:
 		healthy = i.State == ACTIVE
-
-	case HealthCheck:
-		// No assertion on the instance state.
-		healthy = true
 	}
 
 	return healthy && time.Since(time.Unix(i.Timestamp, 0)) <= heartbeatTimeout

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -168,6 +168,10 @@ func (i *IngesterDesc) IsHealthy(op Operation, heartbeatTimeout time.Duration) b
 
 	case Compactor:
 		healthy = i.State == ACTIVE
+
+	case HealthCheck:
+		// No assertion on the instance state.
+		healthy = true
 	}
 
 	return healthy && time.Since(time.Unix(i.Timestamp, 0)) <= heartbeatTimeout

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -50,11 +50,11 @@ type ReadRing interface {
 	// of unhealthy ingesters is greater than the tolerated max unavailable.
 	GetAllHealthy(op Operation) (ReplicationSet, error)
 
-	// GetAllFor returns all instances where the input operation should be executed.
+	// GetReplicationSetForOperation returns all instances where the input operation should be executed.
 	// The resulting ReplicationSet doesn't necessarily contains all healthy instances
 	// in the ring, but could contain the minimum set of instances required to execute
 	// the input operation.
-	GetAllFor(op Operation) (ReplicationSet, error)
+	GetReplicationSetForOperation(op Operation) (ReplicationSet, error)
 
 	ReplicationFactor() int
 	IngesterCount() int
@@ -91,9 +91,6 @@ const (
 
 	// Compactor is the operation used for distributing tenants/blocks across compactors.
 	Compactor
-
-	// HealthCheck is a "virtual" operation just used for health checking.
-	HealthCheck
 )
 
 var (
@@ -354,9 +351,9 @@ func (r *Ring) GetAllHealthy(op Operation) (ReplicationSet, error) {
 	}, nil
 }
 
-// GetAllFor implements ReadRing.
+// GetReplicationSetForOperation implements ReadRing.
 // TODO test me
-func (r *Ring) GetAllFor(op Operation) (ReplicationSet, error) {
+func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, error) {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -1035,7 +1035,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 				currTime := time.Now().Add(lookbackPeriod).Add(time.Minute)
 
 				// Add the initial shard to the history.
-				rs, err := ring.shuffleShard(userID, shardSize, 0, time.Now()).GetAllFor(Read)
+				rs, err := ring.shuffleShard(userID, shardSize, 0, time.Now()).GetReplicationSetForOperation(Read)
 				require.NoError(t, err)
 
 				history := map[time.Time]ReplicationSet{
@@ -1099,12 +1099,12 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 					}
 
 					// Add the current shard to the history.
-					rs, err = ring.shuffleShard(userID, shardSize, 0, time.Now()).GetAllFor(Read)
+					rs, err = ring.shuffleShard(userID, shardSize, 0, time.Now()).GetReplicationSetForOperation(Read)
 					require.NoError(t, err)
 					history[currTime] = rs
 
 					// Ensure the shard with lookback includes all instances from previous states of the ring.
-					rsWithLookback, err := ring.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, currTime).GetAllFor(Read)
+					rsWithLookback, err := ring.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, currTime).GetReplicationSetForOperation(Read)
 					require.NoError(t, err)
 
 					for ringTime, ringState := range history {
@@ -1362,7 +1362,7 @@ func TestShuffleShardWithCaching(t *testing.T) {
 	// Wait until all instances in the ring are ACTIVE.
 	test.Poll(t, 5*time.Second, numLifecyclers, func() interface{} {
 		active := 0
-		rs, _ := ring.GetAllFor(Read)
+		rs, _ := ring.GetReplicationSetForOperation(Read)
 		for _, ing := range rs.Ingesters {
 			if ing.State == ACTIVE {
 				active++
@@ -1390,7 +1390,7 @@ func TestShuffleShardWithCaching(t *testing.T) {
 
 	// Make sure subring has up-to-date timestamps.
 	{
-		rs, err := subring.GetAllFor(Read)
+		rs, err := subring.GetReplicationSetForOperation(Read)
 		require.NoError(t, err)
 
 		now := time.Now()

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -684,7 +684,7 @@ func (r *Ruler) getLocalRules(userID string) ([]*GroupStateDesc, error) {
 }
 
 func (r *Ruler) getShardedRules(ctx context.Context) ([]*GroupStateDesc, error) {
-	rulers, err := r.ring.GetAllFor(ring.Ruler)
+	rulers, err := r.ring.GetReplicationSetForOperation(ring.Ruler)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -406,7 +406,7 @@ func (r *Ruler) run(ctx context.Context) error {
 	var ringLastState ring.ReplicationSet
 
 	if r.cfg.EnableSharding {
-		ringLastState, _ = r.ring.GetAll(ring.Ruler)
+		ringLastState, _ = r.ring.GetAllHealthy(ring.Ruler)
 		ringTicker := time.NewTicker(util.DurationWithJitter(r.cfg.RingCheckPeriod, 0.2))
 		defer ringTicker.Stop()
 		ringTickerChan = ringTicker.C
@@ -422,7 +422,7 @@ func (r *Ruler) run(ctx context.Context) error {
 		case <-ringTickerChan:
 			// We ignore the error because in case of error it will return an empty
 			// replication set which we use to compare with the previous state.
-			currRingState, _ := r.ring.GetAll(ring.Ruler)
+			currRingState, _ := r.ring.GetAllHealthy(ring.Ruler)
 
 			if ring.HasReplicationSetChanged(ringLastState, currRingState) {
 				ringLastState = currRingState
@@ -684,7 +684,7 @@ func (r *Ruler) getLocalRules(userID string) ([]*GroupStateDesc, error) {
 }
 
 func (r *Ruler) getShardedRules(ctx context.Context) ([]*GroupStateDesc, error) {
-	rulers, err := r.ring.GetAll(ring.Ruler)
+	rulers, err := r.ring.GetAllFor(ring.Ruler)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -270,7 +270,7 @@ func (g *StoreGateway) running(ctx context.Context) error {
 	defer syncTicker.Stop()
 
 	if g.gatewayCfg.ShardingEnabled {
-		ringLastState, _ = g.ring.GetAll(ring.BlocksSync) // nolint:errcheck
+		ringLastState, _ = g.ring.GetAllHealthy(ring.BlocksSync) // nolint:errcheck
 		ringTicker := time.NewTicker(util.DurationWithJitter(g.gatewayCfg.ShardingRing.RingCheckPeriod, 0.2))
 		defer ringTicker.Stop()
 		ringTickerChan = ringTicker.C
@@ -283,7 +283,7 @@ func (g *StoreGateway) running(ctx context.Context) error {
 		case <-ringTickerChan:
 			// We ignore the error because in case of error it will return an empty
 			// replication set which we use to compare with the previous state.
-			currRingState, _ := g.ring.GetAll(ring.BlocksSync) // nolint:errcheck
+			currRingState, _ := g.ring.GetAllHealthy(ring.BlocksSync) // nolint:errcheck
 
 			if ring.HasReplicationSetChanged(ringLastState, currRingState) {
 				ringLastState = currRingState


### PR DESCRIPTION
**What this PR does**:
In the PR #3414 we're working to add zone-awareness support to `Ring.GetAll()`. The new logic (which triggers when zone-awareness replication is enabled) is not safe to apply in all contexts where `GetAll()` is used.

The reason is that `GetAll()` is currently used for two very distinct purposes:
1. Get a view over the ring (all healthy instances)
2. Get the set of instances (ingesters) to query for a given operation

The zone-awareness logic should apply to (2) but not to (1).

In this PR, I'm proposing to split `GetAll()` into `GetAllHealthy()` (to cover case 1) and `GetReplicationSetForOperation()` (to cover case 2). The reason why I renamed `GetAll()` into `GetReplicationSetForOperation()` is so that we can signal downstream projects about this change and let them take an informed decision whether should be used one or the other one.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
