### PR TITLE
Disable DNS resolution for testing.

### DIFF
--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -68,7 +68,7 @@ func TestResetConcurrency(t *testing.T) {
 				MaxConcurrentRequests: tt.maxConcurrent,
 			}
 
-			w, err := newQuerierWorkerWithProcessor(cfg, util.Logger, &mockProcessor{}, "localhost", nil)
+			w, err := newQuerierWorkerWithProcessor(cfg, util.Logger, &mockProcessor{}, "", nil)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), w))
 

--- a/pkg/util/test/poll.go
+++ b/pkg/util/test/poll.go
@@ -21,6 +21,6 @@ func Poll(t testing.TB, d time.Duration, want interface{}, have func() interface
 	}
 	h := have()
 	if !reflect.DeepEqual(want, h) {
-		t.Fatalf("%v != %v", want, h)
+		t.Fatalf("expected %v, got %v", want, h)
 	}
 }


### PR DESCRIPTION
**What this PR does**: This PR fixes flaky `TestResetConcurrency` test ([failure](https://github.com/cortexproject/cortex/pull/3405/checks?check_run_id=1357010241)). It has used "localhost" as address to resolve, which could add additional unexpected targets to the worker.

