### PR TITLE
Expose WAL segment size setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * [ENHANCEMENT] Query-Frontend / Query-Scheduler: New component called "Query-Scheduler" has been introduced. Query-Scheduler is simply a queue of requests, moved outside of Query-Frontend. This allows Query-Frontend to be scaled separately from number of queues. To make Query-Frontend and Querier use Query-Scheduler, they need to be started with `-frontend.scheduler-address` and `-querier.scheduler-address` options respectively. #3374
 * [ENHANCEMENT] Query-frontend / Querier / Ruler: added `-querier.max-query-lookback` to limit how long back data (series and metadata) can be queried. This setting can be overridden on a per-tenant basis and is enforced in the query-frontend, querier and ruler. #3452 #3458
 * [ENHANCEMENT] Querier: added `-querier.query-store-for-labels-enabled` to query store for series API. Only works with blocks storage engine. #3461
-* [ENHANCEMENT] Ingester: exposed `-blocks-storage.tsdb.wal-segment-size` config option to customise the TSDB WAL segment max size. #3476
+* [ENHANCEMENT] Ingester: exposed `-blocks-storage.tsdb.wal-segment-size-bytes` config option to customise the TSDB WAL segment max size. #3476
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [ENHANCEMENT] Query-Frontend / Query-Scheduler: New component called "Query-Scheduler" has been introduced. Query-Scheduler is simply a queue of requests, moved outside of Query-Frontend. This allows Query-Frontend to be scaled separately from number of queues. To make Query-Frontend and Querier use Query-Scheduler, they need to be started with `-frontend.scheduler-address` and `-querier.scheduler-address` options respectively. #3374
 * [ENHANCEMENT] Query-frontend / Querier / Ruler: added `-querier.max-query-lookback` to limit how long back data (series and metadata) can be queried. This setting can be overridden on a per-tenant basis and is enforced in the query-frontend, querier and ruler. #3452 #3458
 * [ENHANCEMENT] Querier: added `-querier.query-store-for-labels-enabled` to query store for series API. Only works with blocks storage engine. #3461
+* [ENHANCEMENT] Ingester: exposed `-blocks-storage.tsdb.wal-segment-size` config option to customise the TSDB WAL segment max size. #3476
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -634,7 +634,7 @@ blocks_storage:
     [wal_compression_enabled: <boolean> | default = false]
 
     # TSDB WAL segments files max size (bytes).
-    # CLI flag: -blocks-storage.tsdb.wal-segment-size
+    # CLI flag: -blocks-storage.tsdb.wal-segment-size-bytes
     [wal_segment_size_bytes: <int> | default = 134217728]
 
     # True to flush blocks to storage on shutdown. If false, incomplete blocks

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -633,6 +633,10 @@ blocks_storage:
     # CLI flag: -blocks-storage.tsdb.wal-compression-enabled
     [wal_compression_enabled: <boolean> | default = false]
 
+    # TSDB WAL segments files max size (bytes).
+    # CLI flag: -blocks-storage.tsdb.wal-segment-size
+    [wal_segment_size_bytes: <int> | default = 134217728]
+
     # True to flush blocks to storage on shutdown. If false, incomplete blocks
     # will be reused after restart.
     # CLI flag: -blocks-storage.tsdb.flush-blocks-on-shutdown

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -683,6 +683,10 @@ blocks_storage:
     # CLI flag: -blocks-storage.tsdb.wal-compression-enabled
     [wal_compression_enabled: <boolean> | default = false]
 
+    # TSDB WAL segments files max size (bytes).
+    # CLI flag: -blocks-storage.tsdb.wal-segment-size
+    [wal_segment_size_bytes: <int> | default = 134217728]
+
     # True to flush blocks to storage on shutdown. If false, incomplete blocks
     # will be reused after restart.
     # CLI flag: -blocks-storage.tsdb.flush-blocks-on-shutdown

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -684,7 +684,7 @@ blocks_storage:
     [wal_compression_enabled: <boolean> | default = false]
 
     # TSDB WAL segments files max size (bytes).
-    # CLI flag: -blocks-storage.tsdb.wal-segment-size
+    # CLI flag: -blocks-storage.tsdb.wal-segment-size-bytes
     [wal_segment_size_bytes: <int> | default = 134217728]
 
     # True to flush blocks to storage on shutdown. If false, incomplete blocks

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3809,6 +3809,10 @@ tsdb:
   # CLI flag: -blocks-storage.tsdb.wal-compression-enabled
   [wal_compression_enabled: <boolean> | default = false]
 
+  # TSDB WAL segments files max size (bytes).
+  # CLI flag: -blocks-storage.tsdb.wal-segment-size
+  [wal_segment_size_bytes: <int> | default = 134217728]
+
   # True to flush blocks to storage on shutdown. If false, incomplete blocks
   # will be reused after restart.
   # CLI flag: -blocks-storage.tsdb.flush-blocks-on-shutdown

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3810,7 +3810,7 @@ tsdb:
   [wal_compression_enabled: <boolean> | default = false]
 
   # TSDB WAL segments files max size (bytes).
-  # CLI flag: -blocks-storage.tsdb.wal-segment-size
+  # CLI flag: -blocks-storage.tsdb.wal-segment-size-bytes
   [wal_segment_size_bytes: <int> | default = 134217728]
 
   # True to flush blocks to storage on shutdown. If false, incomplete blocks

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1100,6 +1100,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 		NoLockfile:              true,
 		StripeSize:              i.cfg.BlocksStorageConfig.TSDB.StripeSize,
 		WALCompression:          i.cfg.BlocksStorageConfig.TSDB.WALCompressionEnabled,
+		WALSegmentSize:          i.cfg.BlocksStorageConfig.TSDB.WALSegmentSizeBytes,
 		SeriesLifecycleCallback: userDB,
 		BlocksToDelete:          userDB.blocksToDelete,
 	})

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -204,7 +204,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.HeadCompactionIdleTimeout, "blocks-storage.tsdb.head-compaction-idle-timeout", 1*time.Hour, "If TSDB head is idle for this duration, it is compacted. 0 means disabled.")
 	f.IntVar(&cfg.StripeSize, "blocks-storage.tsdb.stripe-size", 16384, "The number of shards of series to use in TSDB (must be a power of 2). Reducing this will decrease memory footprint, but can negatively impact performance.")
 	f.BoolVar(&cfg.WALCompressionEnabled, "blocks-storage.tsdb.wal-compression-enabled", false, "True to enable TSDB WAL compression.")
-	f.IntVar(&cfg.WALSegmentSizeBytes, "blocks-storage.tsdb.wal-segment-size", wal.DefaultSegmentSize, "TSDB WAL segments files max size (bytes).")
+	f.IntVar(&cfg.WALSegmentSizeBytes, "blocks-storage.tsdb.wal-segment-size-bytes", wal.DefaultSegmentSize, "TSDB WAL segments files max size (bytes).")
 	f.BoolVar(&cfg.FlushBlocksOnShutdown, "blocks-storage.tsdb.flush-blocks-on-shutdown", false, "True to flush blocks to storage on shutdown. If false, incomplete blocks will be reused after restart.")
 }
 

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alecthomas/units"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/tsdb/wal"
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/store"
 
@@ -58,6 +59,7 @@ var (
 	errInvalidOpeningConcurrency    = errors.New("invalid TSDB opening concurrency")
 	errInvalidCompactionInterval    = errors.New("invalid TSDB compaction interval")
 	errInvalidCompactionConcurrency = errors.New("invalid TSDB compaction concurrency")
+	errInvalidWALSegmentSizeBytes   = errors.New("invalid TSDB WAL segment size bytes")
 	errInvalidStripeSize            = errors.New("invalid TSDB stripe size")
 	errEmptyBlockranges             = errors.New("empty block ranges for TSDB")
 )
@@ -174,6 +176,7 @@ type TSDBConfig struct {
 	HeadCompactionIdleTimeout time.Duration `yaml:"head_compaction_idle_timeout"`
 	StripeSize                int           `yaml:"stripe_size"`
 	WALCompressionEnabled     bool          `yaml:"wal_compression_enabled"`
+	WALSegmentSizeBytes       int           `yaml:"wal_segment_size_bytes"`
 	FlushBlocksOnShutdown     bool          `yaml:"flush_blocks_on_shutdown"`
 
 	// MaxTSDBOpeningConcurrencyOnStartup limits the number of concurrently opening TSDB's during startup.
@@ -201,6 +204,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.HeadCompactionIdleTimeout, "blocks-storage.tsdb.head-compaction-idle-timeout", 1*time.Hour, "If TSDB head is idle for this duration, it is compacted. 0 means disabled.")
 	f.IntVar(&cfg.StripeSize, "blocks-storage.tsdb.stripe-size", 16384, "The number of shards of series to use in TSDB (must be a power of 2). Reducing this will decrease memory footprint, but can negatively impact performance.")
 	f.BoolVar(&cfg.WALCompressionEnabled, "blocks-storage.tsdb.wal-compression-enabled", false, "True to enable TSDB WAL compression.")
+	f.IntVar(&cfg.WALSegmentSizeBytes, "blocks-storage.tsdb.wal-segment-size", wal.DefaultSegmentSize, "TSDB WAL segments files max size (bytes).")
 	f.BoolVar(&cfg.FlushBlocksOnShutdown, "blocks-storage.tsdb.flush-blocks-on-shutdown", false, "True to flush blocks to storage on shutdown. If false, incomplete blocks will be reused after restart.")
 }
 
@@ -228,6 +232,10 @@ func (cfg *TSDBConfig) Validate() error {
 
 	if len(cfg.BlockRanges) == 0 {
 		return errEmptyBlockranges
+	}
+
+	if cfg.WALSegmentSizeBytes <= 0 {
+		return errInvalidWALSegmentSizeBytes
 	}
 
 	return nil

--- a/pkg/storage/tsdb/config_test.go
+++ b/pkg/storage/tsdb/config_test.go
@@ -108,6 +108,12 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			expectedErr: errEmptyBlockranges,
 		},
+		"should fail on invalid TSDB WAL segment size": {
+			setup: func(cfg *BlocksStorageConfig) {
+				cfg.TSDB.WALSegmentSizeBytes = 0
+			},
+			expectedErr: errInvalidWALSegmentSizeBytes,
+		},
 	}
 
 	for testName, testData := range tests {


### PR DESCRIPTION
**What this PR does**:
There are some use cases (eg. Cortex clusters with very small tenants) where reducing the WAL segment size may reduce the disk requirements. In this PR I'm proposing to allow to customise it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
