### PR TITLE
Support custom log.Logger instances in spanlogger

### DIFF
--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -12,17 +12,30 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 )
 
+type loggerCtxMarker struct{}
+
+var (
+	loggerCtxKey = &loggerCtxMarker{}
+)
+
 // SpanLogger unifies tracing and logging, to reduce repetition.
 type SpanLogger struct {
 	log.Logger
 	opentracing.Span
 }
 
-// New makes a new SpanLogger.
+// New makes a new SpanLogger, where logs will be sent to the global logger.
 func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, context.Context) {
+	return NewWithLogger(ctx, util.Logger, method, kvps...)
+}
+
+// NewWithLogger makes a new SpanLogger with a custom log.Logger to send logs
+// to. The provided context will have the logger attached to it and can be
+// retrieved with FromContext or FromContextWithFallback.
+func NewWithLogger(ctx context.Context, l log.Logger, method string, kvps ...interface{}) (*SpanLogger, context.Context) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, method)
 	logger := &SpanLogger{
-		Logger: log.With(util.WithContext(ctx, util.Logger), "method", method),
+		Logger: log.With(util.WithContext(ctx, l), "method", method),
 		Span:   span,
 	}
 	if len(kvps) > 0 {
@@ -31,18 +44,29 @@ func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, 
 	return logger, ctx
 }
 
-// FromContext returns a span logger using the current parent span.
-// If there is no parent span, the Spanlogger will only log to global logger.
+// FromContext returns a span logger using the current parent span. If there
+// is no parent span, the SpanLogger will only log to the logger
+// in the context. If the context doesn't have a logger, the global logger
+// is used.
 func FromContext(ctx context.Context) *SpanLogger {
+	return FromContextWithFallback(ctx, util.Logger)
+}
+
+// FromContextWithContext returns a span logger using the current parent span.
+// IF there is no parent span, the SpanLogger will only log to the logger
+// within the context. If the context doesn't have a logger, the fallback
+// logger is used.
+func FromContextWithFallback(ctx context.Context, fallback log.Logger) *SpanLogger {
+	logger, ok := ctx.Value(loggerCtxKey).(log.Logger)
+	if !ok {
+		logger = fallback
+	}
 	sp := opentracing.SpanFromContext(ctx)
 	if sp == nil {
-		return &SpanLogger{
-			Logger: util.WithContext(ctx, util.Logger),
-			Span:   defaultNoopSpan,
-		}
+		sp = defaultNoopSpan
 	}
 	return &SpanLogger{
-		Logger: util.WithContext(ctx, util.Logger),
+		Logger: util.WithContext(ctx, logger),
 		Span:   sp,
 	}
 }

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -52,7 +52,7 @@ func FromContext(ctx context.Context) *SpanLogger {
 	return FromContextWithFallback(ctx, util.Logger)
 }
 
-// FromContextWithContext returns a span logger using the current parent span.
+// FromContextWithFallback returns a span logger using the current parent span.
 // IF there is no parent span, the SpanLogger will only log to the logger
 // within the context. If the context doesn't have a logger, the fallback
 // logger is used.

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -41,6 +41,8 @@ func NewWithLogger(ctx context.Context, l log.Logger, method string, kvps ...int
 	if len(kvps) > 0 {
 		level.Debug(logger).Log(kvps...)
 	}
+
+	ctx = context.WithValue(ctx, loggerCtxKey, l)
 	return logger, ctx
 }
 

--- a/pkg/util/spanlogger/spanlogger_test.go
+++ b/pkg/util/spanlogger/spanlogger_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -18,4 +19,33 @@ func TestSpanLogger_Log(t *testing.T) {
 	_ = noSpan.Log("foo")
 	require.Error(t, noSpan.Error(errors.New("err")))
 	require.NoError(t, noSpan.Error(nil))
+}
+
+func TestSpanLogger_CustomLogger(t *testing.T) {
+	var logged [][]interface{}
+	var logger funcLogger = func(keyvals ...interface{}) error {
+		logged = append(logged, keyvals)
+		return nil
+	}
+	span, ctx := NewWithLogger(context.Background(), logger, "test")
+	span.Log("msg", "original spanlogger")
+
+	span = FromContextWithFallback(ctx, log.NewNopLogger())
+	span.Log("msg", "restored spanlogger")
+
+	span = FromContextWithFallback(context.Background(), logger)
+	span.Log("msg", "fallback spanlogger")
+
+	expect := [][]interface{}{
+		{"method", "test", "msg", "original spanlogger"},
+		{"msg", "restored spanlogger"},
+		{"msg", "fallback spanlogger"},
+	}
+	require.Equal(t, expect, logged)
+}
+
+type funcLogger func(keyvals ...interface{}) error
+
+func (f funcLogger) Log(keyvals ...interface{}) error {
+	return f(keyvals...)
 }

--- a/pkg/util/spanlogger/spanlogger_test.go
+++ b/pkg/util/spanlogger/spanlogger_test.go
@@ -28,13 +28,13 @@ func TestSpanLogger_CustomLogger(t *testing.T) {
 		return nil
 	}
 	span, ctx := NewWithLogger(context.Background(), logger, "test")
-	span.Log("msg", "original spanlogger")
+	_ = span.Log("msg", "original spanlogger")
 
 	span = FromContextWithFallback(ctx, log.NewNopLogger())
-	span.Log("msg", "restored spanlogger")
+	_ = span.Log("msg", "restored spanlogger")
 
 	span = FromContextWithFallback(context.Background(), logger)
-	span.Log("msg", "fallback spanlogger")
+	_ = span.Log("msg", "fallback spanlogger")
 
 	expect := [][]interface{}{
 		{"method", "test", "msg", "original spanlogger"},


### PR DESCRIPTION
This PR adds functionality to the `spanlogger` package to support passing in custom log.Logger instances. This will be useful for me within [grafana/agent](https://github.com/grafana/agent) where loggers with different labels are passed around to various components. 

Signed-off-by: Robert Fratto <robertfratto@gmail.com>