### PR TITLE
Improve compactor blocks cleaner when running with a large number of tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * [ENHANCEMENT] Query-frontend / Querier / Ruler: added `-querier.max-query-lookback` to limit how long back data (series and metadata) can be queried. This setting can be overridden on a per-tenant basis and is enforced in the query-frontend, querier and ruler. #3452 #3458
 * [ENHANCEMENT] Querier: added `-querier.query-store-for-labels-enabled` to query store for series API. Only works with blocks storage engine. #3461
 * [ENHANCEMENT] Ingester: exposed `-blocks-storage.tsdb.wal-segment-size-bytes` config option to customise the TSDB WAL segment max size. #3476
+* [ENHANCEMENT] Compactor: concurrently run blocks cleaner for multiple tenants. Concurrency can be configured via `-compactor.cleanup-concurrency`. #3481
+* [ENHANCEMENT] Compactor: shuffle tenants before running compaction. #3481
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 * [ENHANCEMENT] Query-frontend / Querier / Ruler: added `-querier.max-query-lookback` to limit how long back data (series and metadata) can be queried. This setting can be overridden on a per-tenant basis and is enforced in the query-frontend, querier and ruler. #3452 #3458
 * [ENHANCEMENT] Querier: added `-querier.query-store-for-labels-enabled` to query store for series API. Only works with blocks storage engine. #3461
 * [ENHANCEMENT] Ingester: exposed `-blocks-storage.tsdb.wal-segment-size-bytes` config option to customise the TSDB WAL segment max size. #3476
-* [ENHANCEMENT] Compactor: concurrently run blocks cleaner for multiple tenants. Concurrency can be configured via `-compactor.cleanup-concurrency`. #3481
-* [ENHANCEMENT] Compactor: shuffle tenants before running compaction. #3481
+* [ENHANCEMENT] Compactor: concurrently run blocks cleaner for multiple tenants. Concurrency can be configured via `-compactor.cleanup-concurrency`. #3483
+* [ENHANCEMENT] Compactor: shuffle tenants before running compaction. #3483
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452

--- a/docs/blocks-storage/compactor.md
+++ b/docs/blocks-storage/compactor.md
@@ -114,6 +114,11 @@ compactor:
   # CLI flag: -compactor.compaction-concurrency
   [compaction_concurrency: <int> | default = 1]
 
+  # Max number of tenants for which blocks should be cleaned up concurrently
+  # (deletion of blocks previously marked for deletion).
+  # CLI flag: -compactor.cleanup-concurrency
+  [cleanup_concurrency: <int> | default = 20]
+
   # Time before a block marked for deletion is deleted from bucket. If not 0,
   # blocks will be marked for deletion and compactor component will delete
   # blocks marked for deletion from the bucket. If delete-delay is 0, blocks

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3865,6 +3865,11 @@ The `compactor_config` configures the compactor for the blocks storage.
 # CLI flag: -compactor.compaction-concurrency
 [compaction_concurrency: <int> | default = 1]
 
+# Max number of tenants for which blocks should be cleaned up concurrently
+# (deletion of blocks previously marked for deletion).
+# CLI flag: -compactor.cleanup-concurrency
+[cleanup_concurrency: <int> | default = 20]
+
 # Time before a block marked for deletion is deleted from bucket. If not 0,
 # blocks will be marked for deletion and compactor component will delete blocks
 # marked for deletion from the bucket. If delete-delay is 0, blocks will be

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -121,12 +121,8 @@ func (c *BlocksCleaner) cleanUsers(ctx context.Context) error {
 		return errors.Wrap(err, "failed to discover users from bucket")
 	}
 
-	return concurrency.ForeachUser(ctx, users, c.cfg.CleanupConcurrency, func(userID string) error {
-		if cleanErr := c.cleanUser(ctx, userID); cleanErr != nil {
-			return errors.Wrapf(cleanErr, "failed to delete user blocks (user: %s)", userID)
-		}
-
-		return nil
+	return concurrency.ForEachUser(ctx, users, c.cfg.CleanupConcurrency, func(ctx context.Context, userID string) error {
+		return errors.Wrapf(c.cleanUser(ctx, userID), "failed to delete user blocks (user: %s)", userID)
 	})
 }
 

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/compact"
@@ -19,6 +18,7 @@ import (
 
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/concurrency"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -27,6 +27,7 @@ type BlocksCleanerConfig struct {
 	MetaSyncConcurrency int
 	DeletionDelay       time.Duration
 	CleanupInterval     time.Duration
+	CleanupConcurrency  int
 }
 
 type BlocksCleaner struct {
@@ -120,20 +121,13 @@ func (c *BlocksCleaner) cleanUsers(ctx context.Context) error {
 		return errors.Wrap(err, "failed to discover users from bucket")
 	}
 
-	errs := tsdb_errors.NewMulti()
-	for _, userID := range users {
-		// Ensure the context has not been canceled (ie. shutdown has been triggered).
-		if ctx.Err() != nil {
-			return ctx.Err()
+	return concurrency.ForeachUser(ctx, users, c.cfg.CleanupConcurrency, func(userID string) error {
+		if cleanErr := c.cleanUser(ctx, userID); cleanErr != nil {
+			return errors.Wrapf(cleanErr, "failed to delete user blocks (user: %s)", userID)
 		}
 
-		if err = c.cleanUser(ctx, userID); err != nil {
-			errs.Add(errors.Wrapf(err, "failed to delete user blocks (user: %s)", userID))
-			continue
-		}
-	}
-
-	return errs.Err()
+		return nil
+	})
 }
 
 func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string) error {

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring"
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/concurrency"
 	"github.com/cortexproject/cortex/pkg/util/extract"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
@@ -1339,11 +1340,11 @@ func (i *Ingester) shipBlocks(ctx context.Context) {
 
 	// Number of concurrent workers is limited in order to avoid to concurrently sync a lot
 	// of tenants in a large cluster.
-	i.runConcurrentUserWorkers(ctx, i.cfg.BlocksStorageConfig.TSDB.ShipConcurrency, func(userID string) {
+	_ = concurrency.ForeachUser(ctx, i.getTSDBUsers(), i.cfg.BlocksStorageConfig.TSDB.ShipConcurrency, func(userID string) error {
 		// Get the user's DB. If the user doesn't exist, we skip it.
 		userDB := i.getTSDB(userID)
 		if userDB == nil || userDB.shipper == nil {
-			return
+			return nil
 		}
 
 		// Run the shipper's Sync() to upload unshipped blocks.
@@ -1352,6 +1353,8 @@ func (i *Ingester) shipBlocks(ctx context.Context) {
 		} else {
 			level.Debug(util.Logger).Log("msg", "shipper successfully synchronized TSDB blocks with storage", "user", userID, "uploaded", uploaded)
 		}
+
+		return nil
 	})
 }
 
@@ -1391,16 +1394,16 @@ func (i *Ingester) compactBlocks(ctx context.Context, force bool) {
 		}
 	}
 
-	i.runConcurrentUserWorkers(ctx, i.cfg.BlocksStorageConfig.TSDB.HeadCompactionConcurrency, func(userID string) {
+	_ = concurrency.ForeachUser(ctx, i.getTSDBUsers(), i.cfg.BlocksStorageConfig.TSDB.HeadCompactionConcurrency, func(userID string) error {
 		userDB := i.getTSDB(userID)
 		if userDB == nil {
-			return
+			return nil
 		}
 
 		// Don't do anything, if there is nothing to compact.
 		h := userDB.Head()
 		if h.NumSeries() == 0 {
-			return
+			return nil
 		}
 
 		var err error
@@ -1429,39 +1432,9 @@ func (i *Ingester) compactBlocks(ctx context.Context, force bool) {
 		} else {
 			level.Debug(util.Logger).Log("msg", "TSDB blocks compaction completed successfully", "user", userID, "compactReason", reason)
 		}
+
+		return nil
 	})
-}
-
-func (i *Ingester) runConcurrentUserWorkers(ctx context.Context, concurrency int, userFunc func(userID string)) {
-	wg := sync.WaitGroup{}
-	ch := make(chan string)
-
-	for ix := 0; ix < concurrency; ix++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			for userID := range ch {
-				userFunc(userID)
-			}
-		}()
-	}
-
-sendLoop:
-	for _, userID := range i.getTSDBUsers() {
-		select {
-		case ch <- userID:
-			// ok
-		case <-ctx.Done():
-			// don't start new tasks.
-			break sendLoop
-		}
-	}
-
-	close(ch)
-
-	// wait for ongoing workers to finish.
-	wg.Wait()
 }
 
 // This method will flush all data. It is called as part of Lifecycler's shutdown (if flush on shutdown is configured), or from the flusher.

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1340,7 +1340,7 @@ func (i *Ingester) shipBlocks(ctx context.Context) {
 
 	// Number of concurrent workers is limited in order to avoid to concurrently sync a lot
 	// of tenants in a large cluster.
-	_ = concurrency.ForeachUser(ctx, i.getTSDBUsers(), i.cfg.BlocksStorageConfig.TSDB.ShipConcurrency, func(userID string) error {
+	_ = concurrency.ForEachUser(ctx, i.getTSDBUsers(), i.cfg.BlocksStorageConfig.TSDB.ShipConcurrency, func(ctx context.Context, userID string) error {
 		// Get the user's DB. If the user doesn't exist, we skip it.
 		userDB := i.getTSDB(userID)
 		if userDB == nil || userDB.shipper == nil {
@@ -1394,7 +1394,7 @@ func (i *Ingester) compactBlocks(ctx context.Context, force bool) {
 		}
 	}
 
-	_ = concurrency.ForeachUser(ctx, i.getTSDBUsers(), i.cfg.BlocksStorageConfig.TSDB.HeadCompactionConcurrency, func(userID string) error {
+	_ = concurrency.ForEachUser(ctx, i.getTSDBUsers(), i.cfg.BlocksStorageConfig.TSDB.HeadCompactionConcurrency, func(ctx context.Context, userID string) error {
 		userDB := i.getTSDB(userID)
 		if userDB == nil {
 			return nil

--- a/pkg/util/concurrency/buffer.go
+++ b/pkg/util/concurrency/buffer.go
@@ -1,0 +1,25 @@
+package concurrency
+
+import (
+	"bytes"
+	"sync"
+)
+
+type SyncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (sb *SyncBuffer) Write(p []byte) (n int, err error) {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+
+	return sb.buf.Write(p)
+}
+
+func (sb *SyncBuffer) String() string {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+
+	return sb.buf.String()
+}

--- a/pkg/util/concurrency/runner.go
+++ b/pkg/util/concurrency/runner.go
@@ -7,10 +7,10 @@ import (
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 )
 
-// ForeachUser runs the provided userFunc for each userIDs up to concurrency concurrent workers.
+// ForEachUser runs the provided userFunc for each userIDs up to concurrency concurrent workers.
 // In case userFunc returns error, it will continue to process remaining users but returns an
 // error with all errors userFunc has returned.
-func ForeachUser(ctx context.Context, userIDs []string, concurrency int, userFunc func(userID string) error) error {
+func ForEachUser(ctx context.Context, userIDs []string, concurrency int, userFunc func(ctx context.Context, userID string) error) error {
 	wg := sync.WaitGroup{}
 	ch := make(chan string)
 
@@ -29,7 +29,7 @@ func ForeachUser(ctx context.Context, userIDs []string, concurrency int, userFun
 					break
 				}
 
-				if err := userFunc(userID); err != nil {
+				if err := userFunc(ctx, userID); err != nil {
 					errsMx.Lock()
 					errs.Add(err)
 					errsMx.Unlock()

--- a/pkg/util/concurrency/runner.go
+++ b/pkg/util/concurrency/runner.go
@@ -1,0 +1,64 @@
+package concurrency
+
+import (
+	"context"
+	"sync"
+
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+)
+
+// ForeachUser runs the provided userFunc for each userIDs up to concurrency concurrent workers.
+// In case userFunc returns error, it will continue to process remaining users but returns an
+// error with all errors userFunc has returned.
+func ForeachUser(ctx context.Context, userIDs []string, concurrency int, userFunc func(userID string) error) error {
+	wg := sync.WaitGroup{}
+	ch := make(chan string)
+
+	// Keep track of all errors occurred.
+	errs := tsdb_errors.NewMulti()
+	errsMx := sync.Mutex{}
+
+	for ix := 0; ix < concurrency; ix++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for userID := range ch {
+				// Ensure the context has not been canceled (ie. shutdown has been triggered).
+				if ctx.Err() != nil {
+					break
+				}
+
+				if err := userFunc(userID); err != nil {
+					errsMx.Lock()
+					errs.Add(err)
+					errsMx.Unlock()
+				}
+			}
+		}()
+	}
+
+sendLoop:
+	for _, userID := range userIDs {
+		select {
+		case ch <- userID:
+			// ok
+		case <-ctx.Done():
+			// don't start new tasks.
+			break sendLoop
+		}
+	}
+
+	close(ch)
+
+	// wait for ongoing workers to finish.
+	wg.Wait()
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	errsMx.Lock()
+	defer errsMx.Unlock()
+	return errs.Err()
+}


### PR DESCRIPTION
**What this PR does**:
I'm testing the compactor in a cluster with a large number of tenants (6K) and I've found out the blocks cleaner doesn't scale. The problem is that cleaning 1 tenant at a time is too slow, so I'm proposing to add concurrency to it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
