### PR TITLE
Add tenant resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ lint:
 	GOFLAGS="-tags=requires_docker" faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
 		golang.org/x/net/context=context,\
 		sync/atomic=go.uber.org/atomic,\
-		github.com/weaveworks/common/user.{ExtractOrgID}=github.com/cortexproject/cortex/pkg/tenant.{UserID,TenantID},\
+		github.com/weaveworks/common/user.{ExtractOrgID}=github.com/cortexproject/cortex/pkg/tenant.{TenantID},\
 		github.com/weaveworks/common/user.{ExtractOrgIDFromHTTPRequest}=github.com/cortexproject/cortex/pkg/tenant.{ExtractTenantIDFromHTTPRequest}" ./pkg/... ./cmd/... ./tools/... ./integration/...
 
 	# Ensure clean pkg structure.

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,9 @@ lint:
 	# Ensure no blacklisted package is imported.
 	GOFLAGS="-tags=requires_docker" faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
 		golang.org/x/net/context=context,\
-		sync/atomic=go.uber.org/atomic" ./pkg/... ./cmd/... ./tools/... ./integration/...
+		sync/atomic=go.uber.org/atomic,\
+		github.com/weaveworks/common/user.{ExtractOrgID}=github.com/cortexproject/cortex/pkg/tenant.DefaultResolver.{UserID,TenantID},\
+		github.com/weaveworks/common/user.{ExtractOrgIDFromHTTPRequest}=github.com/cortexproject/cortex/pkg/tenant.{ExtractTenantIDFromHTTPRequest}" ./pkg/... ./cmd/... ./tools/... ./integration/...
 
 	# Ensure clean pkg structure.
 	faillint -paths "\

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ lint:
 	GOFLAGS="-tags=requires_docker" faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
 		golang.org/x/net/context=context,\
 		sync/atomic=go.uber.org/atomic,\
-		github.com/weaveworks/common/user.{ExtractOrgID}=github.com/cortexproject/cortex/pkg/tenant.DefaultResolver.{UserID,TenantID},\
+		github.com/weaveworks/common/user.{ExtractOrgID}=github.com/cortexproject/cortex/pkg/tenant.{UserID,TenantID},\
 		github.com/weaveworks/common/user.{ExtractOrgIDFromHTTPRequest}=github.com/cortexproject/cortex/pkg/tenant.{ExtractTenantIDFromHTTPRequest}" ./pkg/... ./cmd/... ./tools/... ./integration/...
 
 	# Ensure clean pkg structure.

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -36,7 +36,7 @@ type UserConfig struct {
 func (am *MultitenantAlertmanager) GetUserConfig(w http.ResponseWriter, r *http.Request) {
 	logger := util.WithContext(r.Context(), am.logger)
 
-	userID, err := tenant.DefaultResolver().TenantID(r.Context())
+	userID, err := tenant.TenantID(r.Context())
 	if err != nil {
 		level.Error(logger).Log("msg", errNoOrgID, "err", err.Error())
 		http.Error(w, fmt.Sprintf("%s: %s", errNoOrgID, err.Error()), http.StatusUnauthorized)
@@ -73,7 +73,7 @@ func (am *MultitenantAlertmanager) GetUserConfig(w http.ResponseWriter, r *http.
 
 func (am *MultitenantAlertmanager) SetUserConfig(w http.ResponseWriter, r *http.Request) {
 	logger := util.WithContext(r.Context(), am.logger)
-	userID, err := tenant.DefaultResolver().TenantID(r.Context())
+	userID, err := tenant.TenantID(r.Context())
 	if err != nil {
 		level.Error(logger).Log("msg", errNoOrgID, "err", err.Error())
 		http.Error(w, fmt.Sprintf("%s: %s", errNoOrgID, err.Error()), http.StatusUnauthorized)
@@ -114,7 +114,7 @@ func (am *MultitenantAlertmanager) SetUserConfig(w http.ResponseWriter, r *http.
 
 func (am *MultitenantAlertmanager) DeleteUserConfig(w http.ResponseWriter, r *http.Request) {
 	logger := util.WithContext(r.Context(), am.logger)
-	userID, err := tenant.DefaultResolver().TenantID(r.Context())
+	userID, err := tenant.TenantID(r.Context())
 	if err != nil {
 		level.Error(logger).Log("msg", errNoOrgID, "err", err.Error())
 		http.Error(w, fmt.Sprintf("%s: %s", errNoOrgID, err.Error()), http.StatusUnauthorized)

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -8,13 +8,13 @@ import (
 	"path/filepath"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/template"
-	"github.com/weaveworks/common/user"
 	"gopkg.in/yaml.v2"
 )
 
@@ -36,7 +36,7 @@ type UserConfig struct {
 func (am *MultitenantAlertmanager) GetUserConfig(w http.ResponseWriter, r *http.Request) {
 	logger := util.WithContext(r.Context(), am.logger)
 
-	userID, err := user.ExtractOrgID(r.Context())
+	userID, err := tenant.DefaultResolver().TenantID(r.Context())
 	if err != nil {
 		level.Error(logger).Log("msg", errNoOrgID, "err", err.Error())
 		http.Error(w, fmt.Sprintf("%s: %s", errNoOrgID, err.Error()), http.StatusUnauthorized)
@@ -73,7 +73,7 @@ func (am *MultitenantAlertmanager) GetUserConfig(w http.ResponseWriter, r *http.
 
 func (am *MultitenantAlertmanager) SetUserConfig(w http.ResponseWriter, r *http.Request) {
 	logger := util.WithContext(r.Context(), am.logger)
-	userID, err := user.ExtractOrgID(r.Context())
+	userID, err := tenant.DefaultResolver().TenantID(r.Context())
 	if err != nil {
 		level.Error(logger).Log("msg", errNoOrgID, "err", err.Error())
 		http.Error(w, fmt.Sprintf("%s: %s", errNoOrgID, err.Error()), http.StatusUnauthorized)
@@ -114,7 +114,7 @@ func (am *MultitenantAlertmanager) SetUserConfig(w http.ResponseWriter, r *http.
 
 func (am *MultitenantAlertmanager) DeleteUserConfig(w http.ResponseWriter, r *http.Request) {
 	logger := util.WithContext(r.Context(), am.logger)
-	userID, err := user.ExtractOrgID(r.Context())
+	userID, err := tenant.DefaultResolver().TenantID(r.Context())
 	if err != nil {
 		level.Error(logger).Log("msg", errNoOrgID, "err", err.Error())
 		http.Error(w, fmt.Sprintf("%s: %s", errNoOrgID, err.Error()), http.StatusUnauthorized)

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -20,9 +20,9 @@ import (
 	amconfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
@@ -462,7 +462,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *amco
 
 // ServeHTTP serves the Alertmanager's web UI and API.
 func (am *MultitenantAlertmanager) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	userID, err := user.ExtractOrgID(req.Context())
+	userID, err := tenant.DefaultResolver().TenantID(req.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -462,7 +462,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *amco
 
 // ServeHTTP serves the Alertmanager's web UI and API.
 func (am *MultitenantAlertmanager) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	userID, err := tenant.DefaultResolver().TenantID(req.Context())
+	userID, err := tenant.TenantID(req.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return

--- a/pkg/api/middlewares.go
+++ b/pkg/api/middlewares.go
@@ -14,7 +14,7 @@ import (
 func getHTTPCacheGenNumberHeaderSetterMiddleware(cacheGenNumbersLoader *purger.TombstonesLoader) middleware.Interface {
 	return middleware.Func(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			userID, err := tenant.UserID(r.Context())
+			userID, err := tenant.TenantID(r.Context())
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 				return

--- a/pkg/api/middlewares.go
+++ b/pkg/api/middlewares.go
@@ -14,7 +14,7 @@ import (
 func getHTTPCacheGenNumberHeaderSetterMiddleware(cacheGenNumbersLoader *purger.TombstonesLoader) middleware.Interface {
 	return middleware.Func(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			userID, err := tenant.DefaultResolver().UserID(r.Context())
+			userID, err := tenant.UserID(r.Context())
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 				return

--- a/pkg/api/middlewares.go
+++ b/pkg/api/middlewares.go
@@ -4,17 +4,17 @@ import (
 	"net/http"
 
 	"github.com/weaveworks/common/middleware"
-	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/chunk/purger"
 	"github.com/cortexproject/cortex/pkg/querier/queryrange"
+	"github.com/cortexproject/cortex/pkg/tenant"
 )
 
 // middleware for setting cache gen header to let consumer of response know all previous responses could be invalid due to delete operation
 func getHTTPCacheGenNumberHeaderSetterMiddleware(cacheGenNumbersLoader *purger.TombstonesLoader) middleware.Interface {
 	return middleware.Func(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			userID, err := user.ExtractOrgID(r.Context())
+			userID, err := tenant.DefaultResolver().UserID(r.Context())
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 				return

--- a/pkg/chunk/purger/request_handler.go
+++ b/pkg/chunk/purger/request_handler.go
@@ -54,7 +54,7 @@ func NewDeleteRequestHandler(deleteStore *DeleteStore, deleteRequestCancelPeriod
 // AddDeleteRequestHandler handles addition of new delete request
 func (dm *DeleteRequestHandler) AddDeleteRequestHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -119,7 +119,7 @@ func (dm *DeleteRequestHandler) AddDeleteRequestHandler(w http.ResponseWriter, r
 // GetAllDeleteRequestsHandler handles get all delete requests
 func (dm *DeleteRequestHandler) GetAllDeleteRequestsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -141,7 +141,7 @@ func (dm *DeleteRequestHandler) GetAllDeleteRequestsHandler(w http.ResponseWrite
 // CancelDeleteRequestHandler handles delete request cancellation
 func (dm *DeleteRequestHandler) CancelDeleteRequestHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/chunk/purger/request_handler.go
+++ b/pkg/chunk/purger/request_handler.go
@@ -12,8 +12,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql/parser"
-	"github.com/weaveworks/common/user"
 
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 )
 
@@ -54,7 +54,7 @@ func NewDeleteRequestHandler(deleteStore *DeleteStore, deleteRequestCancelPeriod
 // AddDeleteRequestHandler handles addition of new delete request
 func (dm *DeleteRequestHandler) AddDeleteRequestHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -119,7 +119,7 @@ func (dm *DeleteRequestHandler) AddDeleteRequestHandler(w http.ResponseWriter, r
 // GetAllDeleteRequestsHandler handles get all delete requests
 func (dm *DeleteRequestHandler) GetAllDeleteRequestsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -141,7 +141,7 @@ func (dm *DeleteRequestHandler) GetAllDeleteRequestsHandler(w http.ResponseWrite
 // CancelDeleteRequestHandler handles delete request cancellation
 func (dm *DeleteRequestHandler) CancelDeleteRequestHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/chunk/storage/caching_index_client.go
+++ b/pkg/chunk/storage/caching_index_client.go
@@ -72,7 +72,7 @@ func (s *cachingIndexClient) QueryPages(ctx context.Context, queries []chunk.Ind
 	// We cache the entire row, so filter client side.
 	callback = chunk_util.QueryFilter(callback)
 
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/chunk/storage/caching_index_client.go
+++ b/pkg/chunk/storage/caching_index_client.go
@@ -10,11 +10,11 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	chunk_util "github.com/cortexproject/cortex/pkg/chunk/util"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
@@ -72,7 +72,7 @@ func (s *cachingIndexClient) QueryPages(ctx context.Context, queries []chunk.Ind
 	// We cache the entire row, so filter client side.
 	callback = chunk_util.QueryFilter(callback)
 
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/configs/api/api.go
+++ b/pkg/configs/api/api.go
@@ -19,10 +19,10 @@ import (
 	"github.com/gorilla/mux"
 	amconfig "github.com/prometheus/alertmanager/config"
 	amtemplate "github.com/prometheus/alertmanager/template"
-	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/configs/db"
 	"github.com/cortexproject/cortex/pkg/configs/userconfig"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 )
 
@@ -108,7 +108,7 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 
 // getConfig returns the request configuration.
 func (a *API) getConfig(w http.ResponseWriter, r *http.Request) {
-	userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
+	userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(tenant.DefaultResolver(), r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
@@ -146,7 +146,7 @@ func (a *API) getConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) setConfig(w http.ResponseWriter, r *http.Request) {
-	userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
+	userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(tenant.DefaultResolver(), r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
@@ -296,7 +296,7 @@ func (a *API) getConfigs(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) deactivateConfig(w http.ResponseWriter, r *http.Request) {
-	userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
+	userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(tenant.DefaultResolver(), r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
@@ -318,7 +318,7 @@ func (a *API) deactivateConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) restoreConfig(w http.ResponseWriter, r *http.Request) {
-	userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
+	userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(tenant.DefaultResolver(), r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return

--- a/pkg/configs/api/api.go
+++ b/pkg/configs/api/api.go
@@ -108,7 +108,7 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 
 // getConfig returns the request configuration.
 func (a *API) getConfig(w http.ResponseWriter, r *http.Request) {
-	userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(tenant.DefaultResolver(), r)
+	userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
@@ -146,7 +146,7 @@ func (a *API) getConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) setConfig(w http.ResponseWriter, r *http.Request) {
-	userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(tenant.DefaultResolver(), r)
+	userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
@@ -296,7 +296,7 @@ func (a *API) getConfigs(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) deactivateConfig(w http.ResponseWriter, r *http.Request) {
-	userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(tenant.DefaultResolver(), r)
+	userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
@@ -318,7 +318,7 @@ func (a *API) deactivateConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) restoreConfig(w http.ResponseWriter, r *http.Request) {
-	userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(tenant.DefaultResolver(), r)
+	userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
 	"github.com/cortexproject/cortex/pkg/ring"
 	ring_client "github.com/cortexproject/cortex/pkg/ring/client"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/extract"
 	"github.com/cortexproject/cortex/pkg/util/limiter"
@@ -384,7 +385,7 @@ func (d *Distributor) validateSeries(ts ingester_client.PreallocTimeseries, user
 
 // Push implements client.IngesterServer
 func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*client.WriteResponse, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -385,7 +385,7 @@ func (d *Distributor) validateSeries(ts ingester_client.PreallocTimeseries, user
 
 // Push implements client.IngesterServer
 func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*client.WriteResponse, error) {
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -428,7 +428,7 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 					d.HATracker = r
 				}
 
-				userID, err := tenant.DefaultResolver().TenantID(ctx)
+				userID, err := tenant.TenantID(ctx)
 				assert.NoError(t, err)
 				err = d.HATracker.checkReplica(ctx, userID, tc.cluster, tc.acceptedReplica)
 				assert.NoError(t, err)
@@ -1315,7 +1315,7 @@ func (i *mockIngester) Push(ctx context.Context, req *client.WriteRequest, opts 
 		i.metadata = map[uint32]map[client.MetricMetadata]struct{}{}
 	}
 
-	orgid, err := tenant.DefaultResolver().TenantID(ctx)
+	orgid, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -33,6 +33,7 @@ import (
 	ring_client "github.com/cortexproject/cortex/pkg/ring/client"
 	"github.com/cortexproject/cortex/pkg/ring/kv"
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/chunkcompat"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
@@ -427,7 +428,7 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 					d.HATracker = r
 				}
 
-				userID, err := user.ExtractOrgID(ctx)
+				userID, err := tenant.DefaultResolver().TenantID(ctx)
 				assert.NoError(t, err)
 				err = d.HATracker.checkReplica(ctx, userID, tc.cluster, tc.acceptedReplica)
 				assert.NoError(t, err)
@@ -1314,7 +1315,7 @@ func (i *mockIngester) Push(ctx context.Context, req *client.WriteRequest, opts 
 		i.metadata = map[uint32]map[client.MetricMetadata]struct{}{}
 	}
 
-	orgid, err := user.ExtractOrgID(ctx)
+	orgid, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -76,7 +76,7 @@ func (d *Distributor) QueryStream(ctx context.Context, from, to model.Time, matc
 // GetIngestersForQuery returns a replication set including all ingesters that should be queried
 // to fetch series matching input label matchers.
 func (d *Distributor) GetIngestersForQuery(ctx context.Context, matchers ...*labels.Matcher) (ring.ReplicationSet, error) {
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return ring.ReplicationSet{}, err
 	}
@@ -107,7 +107,7 @@ func (d *Distributor) GetIngestersForQuery(ctx context.Context, matchers ...*lab
 // GetIngestersForMetadata returns a replication set including all ingesters that should be queried
 // to fetch metadata (eg. label names/values or series).
 func (d *Distributor) GetIngestersForMetadata(ctx context.Context) (ring.ReplicationSet, error) {
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return ring.ReplicationSet{}, err
 	}

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -9,11 +9,11 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/weaveworks/common/instrument"
-	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	ingester_client "github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ring"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/extract"
 	grpc_util "github.com/cortexproject/cortex/pkg/util/grpc"
@@ -76,7 +76,7 @@ func (d *Distributor) QueryStream(ctx context.Context, from, to model.Time, matc
 // GetIngestersForQuery returns a replication set including all ingesters that should be queried
 // to fetch series matching input label matchers.
 func (d *Distributor) GetIngestersForQuery(ctx context.Context, matchers ...*labels.Matcher) (ring.ReplicationSet, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return ring.ReplicationSet{}, err
 	}
@@ -107,7 +107,7 @@ func (d *Distributor) GetIngestersForQuery(ctx context.Context, matchers ...*lab
 // GetIngestersForMetadata returns a replication set including all ingesters that should be queried
 // to fetch metadata (eg. label names/values or series).
 func (d *Distributor) GetIngestersForMetadata(ctx context.Context) (ring.ReplicationSet, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return ring.ReplicationSet{}, err
 	}

--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -250,7 +250,7 @@ func getQuerierID(server frontendv1pb.Frontend_ProcessServer) (string, error) {
 }
 
 func (f *Frontend) queueRequest(ctx context.Context, req *request) error {
-	userID, err := tenant.UserID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -14,10 +14,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/httpgrpc"
-	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/frontend/v1/frontendv1pb"
 	"github.com/cortexproject/cortex/pkg/scheduler/queue"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util/grpcutil"
 )
 
@@ -250,7 +250,7 @@ func getQuerierID(server frontendv1pb.Frontend_ProcessServer) (string, error) {
 }
 
 func (f *Frontend) queueRequest(ctx context.Context, req *request) error {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().UserID(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -250,7 +250,7 @@ func getQuerierID(server frontendv1pb.Frontend_ProcessServer) (string, error) {
 }
 
 func (f *Frontend) queueRequest(ctx context.Context, req *request) error {
-	userID, err := tenant.DefaultResolver().UserID(ctx)
+	userID, err := tenant.UserID(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -151,7 +151,7 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, req *httpgrpc.HTTPRequest)
 		return nil, fmt.Errorf("frontend not running: %v", s)
 	}
 
-	userID, err := tenant.DefaultResolver().UserID(ctx)
+	userID, err := tenant.UserID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ enqueueAgain:
 }
 
 func (f *Frontend) QueryResult(ctx context.Context, qrReq *frontendv2pb.QueryResultRequest) (*frontendv2pb.QueryResultResponse, error) {
-	userID, err := tenant.DefaultResolver().UserID(ctx)
+	userID, err := tenant.UserID(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -151,7 +151,7 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, req *httpgrpc.HTTPRequest)
 		return nil, fmt.Errorf("frontend not running: %v", s)
 	}
 
-	userID, err := tenant.UserID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ enqueueAgain:
 }
 
 func (f *Frontend) QueryResult(ctx context.Context, qrReq *frontendv2pb.QueryResultRequest) (*frontendv2pb.QueryResultResponse, error) {
-	userID, err := tenant.UserID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -16,10 +16,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/httpgrpc"
-	"github.com/weaveworks/common/user"
 	"go.uber.org/atomic"
 
 	"github.com/cortexproject/cortex/pkg/frontend/v2/frontendv2pb"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 	"github.com/cortexproject/cortex/pkg/util/grpcutil"
@@ -151,7 +151,7 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, req *httpgrpc.HTTPRequest)
 		return nil, fmt.Errorf("frontend not running: %v", s)
 	}
 
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().UserID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ enqueueAgain:
 }
 
 func (f *Frontend) QueryResult(ctx context.Context, qrReq *frontendv2pb.QueryResultRequest) (*frontendv2pb.QueryResultResponse, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().UserID(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -440,7 +440,7 @@ func (i *Ingester) Push(ctx context.Context, req *client.WriteRequest) (*client.
 	// retain anything from `req` past the call to ReuseSlice
 	defer client.ReuseSlice(req.Timeseries)
 
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id")
 	}
@@ -683,7 +683,7 @@ func (i *Ingester) Query(ctx context.Context, req *client.QueryRequest) (*client
 		return i.v2Query(ctx, req)
 	}
 
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -930,7 +930,7 @@ func (i *Ingester) MetricsMetadata(ctx context.Context, req *client.MetricsMetad
 	}
 	i.userStatesMtx.RUnlock()
 
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id")
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	tsdb_record "github.com/prometheus/prometheus/tsdb/record"
 	"github.com/weaveworks/common/httpgrpc"
-	"github.com/weaveworks/common/user"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc/codes"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
@@ -440,7 +440,7 @@ func (i *Ingester) Push(ctx context.Context, req *client.WriteRequest) (*client.
 	// retain anything from `req` past the call to ReuseSlice
 	defer client.ReuseSlice(req.Timeseries)
 
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id")
 	}
@@ -683,7 +683,7 @@ func (i *Ingester) Query(ctx context.Context, req *client.QueryRequest) (*client
 		return i.v2Query(ctx, req)
 	}
 
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -930,7 +930,7 @@ func (i *Ingester) MetricsMetadata(ctx context.Context, req *client.MetricsMetad
 	}
 	i.userStatesMtx.RUnlock()
 
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id")
 	}

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -24,13 +24,13 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore"
 	"github.com/thanos-io/thanos/pkg/shipper"
 	"github.com/weaveworks/common/httpgrpc"
-	"github.com/weaveworks/common/user"
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ring"
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/concurrency"
 	"github.com/cortexproject/cortex/pkg/util/extract"
@@ -606,7 +606,7 @@ func (i *Ingester) v2Push(ctx context.Context, req *client.WriteRequest) (*clien
 	// retain anything from `req` past the call to ReuseSlice
 	defer client.ReuseSlice(req.Timeseries)
 
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id")
 	}
@@ -803,7 +803,7 @@ func (u *userTSDB) releaseAppendLock() {
 }
 
 func (i *Ingester) v2Query(ctx context.Context, req *client.QueryRequest) (*client.QueryResponse, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -859,7 +859,7 @@ func (i *Ingester) v2Query(ctx context.Context, req *client.QueryRequest) (*clie
 }
 
 func (i *Ingester) v2LabelValues(ctx context.Context, req *client.LabelValuesRequest) (*client.LabelValuesResponse, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -891,7 +891,7 @@ func (i *Ingester) v2LabelValues(ctx context.Context, req *client.LabelValuesReq
 }
 
 func (i *Ingester) v2LabelNames(ctx context.Context, req *client.LabelNamesRequest) (*client.LabelNamesResponse, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -923,7 +923,7 @@ func (i *Ingester) v2LabelNames(ctx context.Context, req *client.LabelNamesReque
 }
 
 func (i *Ingester) v2MetricsForLabelMatchers(ctx context.Context, req *client.MetricsForLabelMatchersRequest) (*client.MetricsForLabelMatchersResponse, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -984,7 +984,7 @@ func (i *Ingester) v2MetricsForLabelMatchers(ctx context.Context, req *client.Me
 }
 
 func (i *Ingester) v2UserStats(ctx context.Context, req *client.UserStatsRequest) (*client.UserStatsResponse, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1033,7 +1033,7 @@ func (i *Ingester) v2QueryStream(req *client.QueryRequest, stream client.Ingeste
 	log, ctx := spanlogger.New(stream.Context(), "v2QueryStream")
 	defer log.Finish()
 
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -606,7 +606,7 @@ func (i *Ingester) v2Push(ctx context.Context, req *client.WriteRequest) (*clien
 	// retain anything from `req` past the call to ReuseSlice
 	defer client.ReuseSlice(req.Timeseries)
 
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id")
 	}
@@ -803,7 +803,7 @@ func (u *userTSDB) releaseAppendLock() {
 }
 
 func (i *Ingester) v2Query(ctx context.Context, req *client.QueryRequest) (*client.QueryResponse, error) {
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -859,7 +859,7 @@ func (i *Ingester) v2Query(ctx context.Context, req *client.QueryRequest) (*clie
 }
 
 func (i *Ingester) v2LabelValues(ctx context.Context, req *client.LabelValuesRequest) (*client.LabelValuesResponse, error) {
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -891,7 +891,7 @@ func (i *Ingester) v2LabelValues(ctx context.Context, req *client.LabelValuesReq
 }
 
 func (i *Ingester) v2LabelNames(ctx context.Context, req *client.LabelNamesRequest) (*client.LabelNamesResponse, error) {
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -923,7 +923,7 @@ func (i *Ingester) v2LabelNames(ctx context.Context, req *client.LabelNamesReque
 }
 
 func (i *Ingester) v2MetricsForLabelMatchers(ctx context.Context, req *client.MetricsForLabelMatchersRequest) (*client.MetricsForLabelMatchersResponse, error) {
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -984,7 +984,7 @@ func (i *Ingester) v2MetricsForLabelMatchers(ctx context.Context, req *client.Me
 }
 
 func (i *Ingester) v2UserStats(ctx context.Context, req *client.UserStatsRequest) (*client.UserStatsResponse, error) {
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1033,7 +1033,7 @@ func (i *Ingester) v2QueryStream(req *client.QueryRequest, stream client.Ingeste
 	log, ctx := spanlogger.New(stream.Context(), "v2QueryStream")
 	defer log.Finish()
 
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -172,7 +172,7 @@ func (us *userStates) teardown() {
 }
 
 func (us *userStates) getViaContext(ctx context.Context) (*userState, bool, error) {
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, false, fmt.Errorf("no user id")
 	}

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -14,10 +14,10 @@ import (
 	tsdb_record "github.com/prometheus/prometheus/tsdb/record"
 	"github.com/segmentio/fasthash/fnv1a"
 	"github.com/weaveworks/common/httpgrpc"
-	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ingester/index"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/extract"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
@@ -172,7 +172,7 @@ func (us *userStates) teardown() {
 }
 
 func (us *userStates) getViaContext(ctx context.Context) (*userState, bool, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, false, fmt.Errorf("no user id")
 	}

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -24,7 +24,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/store/hintspb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/strutil"
-	"github.com/weaveworks/common/user"
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 	grpc_metadata "google.golang.org/grpc/metadata"
@@ -35,6 +34,7 @@ import (
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/storegateway"
 	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
@@ -252,7 +252,7 @@ func (q *BlocksStoreQueryable) Querier(ctx context.Context, mint, maxt int64) (s
 		return nil, errors.Errorf("BlocksStoreQueryable is not running: %v", s)
 	}
 
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -252,7 +252,7 @@ func (q *BlocksStoreQueryable) Querier(ctx context.Context, mint, maxt int64) (s
 		return nil, errors.Errorf("BlocksStoreQueryable is not running: %v", s)
 	}
 
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/querier/chunk_store_queryable.go
+++ b/pkg/querier/chunk_store_queryable.go
@@ -7,12 +7,12 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/querier/chunkstore"
 	seriesset "github.com/cortexproject/cortex/pkg/querier/series"
+	"github.com/cortexproject/cortex/pkg/tenant"
 )
 
 type chunkIteratorFunc func(chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterator
@@ -39,7 +39,7 @@ type chunkStoreQuerier struct {
 // Select implements storage.Querier interface.
 // The bool passed is ignored because the series is always sorted.
 func (q *chunkStoreQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	userID, err := user.ExtractOrgID(q.ctx)
+	userID, err := tenant.DefaultResolver().TenantID(q.ctx)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}

--- a/pkg/querier/chunk_store_queryable.go
+++ b/pkg/querier/chunk_store_queryable.go
@@ -39,7 +39,7 @@ type chunkStoreQuerier struct {
 // Select implements storage.Querier interface.
 // The bool passed is ignored because the series is always sorted.
 func (q *chunkStoreQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	userID, err := tenant.DefaultResolver().TenantID(q.ctx)
+	userID, err := tenant.TenantID(q.ctx)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}

--- a/pkg/querier/chunks_handler.go
+++ b/pkg/querier/chunks_handler.go
@@ -8,9 +8,9 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
-	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/querier/chunkstore"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 )
 
@@ -20,7 +20,7 @@ import (
 // on ingester chunk query streaming.
 func ChunksHandler(queryable storage.Queryable) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID, err := user.ExtractOrgID(r.Context())
+		userID, err := tenant.DefaultResolver().TenantID(r.Context())
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/querier/chunks_handler.go
+++ b/pkg/querier/chunks_handler.go
@@ -20,7 +20,7 @@ import (
 // on ingester chunk query streaming.
 func ChunksHandler(queryable storage.Queryable) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID, err := tenant.DefaultResolver().TenantID(r.Context())
+		userID, err := tenant.TenantID(r.Context())
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -129,7 +129,7 @@ func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 }
 
 func (q *distributorQuerier) streamingSelect(minT, maxT int64, matchers []*labels.Matcher) storage.SeriesSet {
-	userID, err := tenant.DefaultResolver().TenantID(q.ctx)
+	userID, err := tenant.TenantID(q.ctx)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -10,11 +10,11 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
-	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/prom1/storage/metric"
 	"github.com/cortexproject/cortex/pkg/querier/series"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/chunkcompat"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
@@ -129,7 +129,7 @@ func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 }
 
 func (q *distributorQuerier) streamingSelect(minT, maxT int64, matchers []*labels.Matcher) storage.SeriesSet {
-	userID, err := user.ExtractOrgID(q.ctx)
+	userID, err := tenant.DefaultResolver().TenantID(q.ctx)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -210,7 +210,7 @@ func NewQueryable(distributor QueryableWithFilter, stores []QueryableWithFilter,
 	return storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 		now := time.Now()
 
-		userID, err := tenant.DefaultResolver().TenantID(ctx)
+		userID, err := tenant.TenantID(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -300,7 +300,7 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 		return q.metadataQuerier.Select(true, sp, matchers...)
 	}
 
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/thanos-io/thanos/pkg/strutil"
-	"github.com/weaveworks/common/user"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
@@ -26,6 +25,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/querier/iterators"
 	"github.com/cortexproject/cortex/pkg/querier/lazyquery"
 	"github.com/cortexproject/cortex/pkg/querier/series"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
@@ -210,7 +210,7 @@ func NewQueryable(distributor QueryableWithFilter, stores []QueryableWithFilter,
 	return storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 		now := time.Now()
 
-		userID, err := user.ExtractOrgID(ctx)
+		userID, err := tenant.DefaultResolver().TenantID(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -300,7 +300,7 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 		return q.metadataQuerier.Select(true, sp, matchers...)
 	}
 
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -8,8 +8,8 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/weaveworks/common/httpgrpc"
-	"github.com/weaveworks/common/user"
 
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/cortexproject/cortex/pkg/util/validation"
@@ -52,7 +52,7 @@ func (l limitsMiddleware) Do(ctx context.Context, r Request) (Response, error) {
 	log, ctx := spanlogger.New(ctx, "limits")
 	defer log.Finish()
 
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().UserID(ctx)
 	if err != nil {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -52,7 +52,7 @@ func (l limitsMiddleware) Do(ctx context.Context, r Request) (Response, error) {
 	log, ctx := spanlogger.New(ctx, "limits")
 	defer log.Finish()
 
-	userID, err := tenant.UserID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}

--- a/pkg/querier/queryrange/limits.go
+++ b/pkg/querier/queryrange/limits.go
@@ -52,7 +52,7 @@ func (l limitsMiddleware) Do(ctx context.Context, r Request) (Response, error) {
 	log, ctx := spanlogger.New(ctx, "limits")
 	defer log.Finish()
 
-	userID, err := tenant.DefaultResolver().UserID(ctx)
+	userID, err := tenant.UserID(ctx)
 	if err != nil {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -179,7 +179,7 @@ func NewResultsCacheMiddleware(
 }
 
 func (s resultsCache) Do(ctx context.Context, r Request) (Response, error) {
-	userID, err := tenant.UserID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -179,7 +179,7 @@ func NewResultsCacheMiddleware(
 }
 
 func (s resultsCache) Do(ctx context.Context, r Request) (Response, error) {
-	userID, err := tenant.DefaultResolver().UserID(ctx)
+	userID, err := tenant.UserID(ctx)
 	if err != nil {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -19,10 +19,10 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/uber/jaeger-client-go"
 	"github.com/weaveworks/common/httpgrpc"
-	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
@@ -179,7 +179,7 @@ func NewResultsCacheMiddleware(
 }
 
 func (s resultsCache) Do(ctx context.Context, r Request) (Response, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().UserID(ctx)
 	if err != nil {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -218,7 +218,7 @@ func NewTripperware(
 					op = "query_range"
 				}
 
-				user, err := tenant.DefaultResolver().UserID(r.Context())
+				user, err := tenant.UserID(r.Context())
 				// This should never happen anyways because we have auth middleware before this.
 				if err != nil {
 					return nil, err

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -218,7 +218,7 @@ func NewTripperware(
 					op = "query_range"
 				}
 
-				user, err := tenant.UserID(r.Context())
+				user, err := tenant.TenantID(r.Context())
 				// This should never happen anyways because we have auth middleware before this.
 				if err != nil {
 					return nil, err

--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
+	"github.com/cortexproject/cortex/pkg/tenant"
 )
 
 const day = 24 * time.Hour
@@ -217,7 +218,7 @@ func NewTripperware(
 					op = "query_range"
 				}
 
-				user, err := user.ExtractOrgID(r.Context())
+				user, err := tenant.DefaultResolver().UserID(r.Context())
 				// This should never happen anyways because we have auth middleware before this.
 				if err != nil {
 					return nil, err

--- a/pkg/querier/queryrange/util.go
+++ b/pkg/querier/queryrange/util.go
@@ -5,7 +5,8 @@ import (
 	"net/http"
 
 	"github.com/weaveworks/common/httpgrpc"
-	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/tenant"
 )
 
 // RequestResponse contains a request response and the respective request that was used.
@@ -16,7 +17,7 @@ type RequestResponse struct {
 
 // DoRequests executes a list of requests in parallel. The limits parameters is used to limit parallelism per single request.
 func DoRequests(ctx context.Context, downstream Handler, reqs []Request, limits Limits) ([]RequestResponse, error) {
-	userid, err := user.ExtractOrgID(ctx)
+	userid, err := tenant.DefaultResolver().UserID(ctx)
 	if err != nil {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}

--- a/pkg/querier/queryrange/util.go
+++ b/pkg/querier/queryrange/util.go
@@ -17,7 +17,7 @@ type RequestResponse struct {
 
 // DoRequests executes a list of requests in parallel. The limits parameters is used to limit parallelism per single request.
 func DoRequests(ctx context.Context, downstream Handler, reqs []Request, limits Limits) ([]RequestResponse, error) {
-	userid, err := tenant.UserID(ctx)
+	userid, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}

--- a/pkg/querier/queryrange/util.go
+++ b/pkg/querier/queryrange/util.go
@@ -17,7 +17,7 @@ type RequestResponse struct {
 
 // DoRequests executes a list of requests in parallel. The limits parameters is used to limit parallelism per single request.
 func DoRequests(ctx context.Context, downstream Handler, reqs []Request, limits Limits) ([]RequestResponse, error) {
-	userid, err := tenant.DefaultResolver().UserID(ctx)
+	userid, err := tenant.UserID(ctx)
 	if err != nil {
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -135,7 +135,7 @@ func NewAPI(r *Ruler, s rules.RuleStore) *API {
 
 func (a *API) PrometheusRules(w http.ResponseWriter, req *http.Request) {
 	logger := util.WithContext(req.Context(), util.Logger)
-	userID, err := tenant.DefaultResolver().TenantID(req.Context())
+	userID, err := tenant.TenantID(req.Context())
 	if err != nil || userID == "" {
 		level.Error(logger).Log("msg", "error extracting org id from context", "err", err)
 		respondError(logger, w, "no valid org id found")
@@ -227,7 +227,7 @@ func (a *API) PrometheusRules(w http.ResponseWriter, req *http.Request) {
 
 func (a *API) PrometheusAlerts(w http.ResponseWriter, req *http.Request) {
 	logger := util.WithContext(req.Context(), util.Logger)
-	userID, err := tenant.DefaultResolver().TenantID(req.Context())
+	userID, err := tenant.TenantID(req.Context())
 	if err != nil || userID == "" {
 		level.Error(logger).Log("msg", "error extracting org id from context", "err", err)
 		respondError(logger, w, "no valid org id found")
@@ -356,7 +356,7 @@ func parseGroupName(params map[string]string) (string, error) {
 // and returns them in that order. It also allows users to require a namespace or group name and return
 // an error if it they can not be parsed.
 func parseRequest(req *http.Request, requireNamespace, requireGroup bool) (string, string, string, error) {
-	userID, err := tenant.DefaultResolver().TenantID(req.Context())
+	userID, err := tenant.TenantID(req.Context())
 	if err != nil {
 		return "", "", "", user.ErrNoOrgID
 	}

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/ruler/rules"
 	store "github.com/cortexproject/cortex/pkg/ruler/rules"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 )
 
@@ -134,7 +135,7 @@ func NewAPI(r *Ruler, s rules.RuleStore) *API {
 
 func (a *API) PrometheusRules(w http.ResponseWriter, req *http.Request) {
 	logger := util.WithContext(req.Context(), util.Logger)
-	userID, err := user.ExtractOrgID(req.Context())
+	userID, err := tenant.DefaultResolver().TenantID(req.Context())
 	if err != nil || userID == "" {
 		level.Error(logger).Log("msg", "error extracting org id from context", "err", err)
 		respondError(logger, w, "no valid org id found")
@@ -226,7 +227,7 @@ func (a *API) PrometheusRules(w http.ResponseWriter, req *http.Request) {
 
 func (a *API) PrometheusAlerts(w http.ResponseWriter, req *http.Request) {
 	logger := util.WithContext(req.Context(), util.Logger)
-	userID, err := user.ExtractOrgID(req.Context())
+	userID, err := tenant.DefaultResolver().TenantID(req.Context())
 	if err != nil || userID == "" {
 		level.Error(logger).Log("msg", "error extracting org id from context", "err", err)
 		respondError(logger, w, "no valid org id found")
@@ -355,7 +356,7 @@ func parseGroupName(params map[string]string) (string, error) {
 // and returns them in that order. It also allows users to require a namespace or group name and return
 // an error if it they can not be parsed.
 func parseRequest(req *http.Request, requireNamespace, requireGroup bool) (string, string, string, error) {
-	userID, err := user.ExtractOrgID(req.Context())
+	userID, err := tenant.DefaultResolver().TenantID(req.Context())
 	if err != nil {
 		return "", "", "", user.ErrNoOrgID
 	}

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring/kv"
 	"github.com/cortexproject/cortex/pkg/ruler/rules"
 	store "github.com/cortexproject/cortex/pkg/ruler/rules"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
@@ -584,7 +585,7 @@ func filterRuleGroups(userID string, ruleGroups []*store.RuleGroupDesc, ring rin
 // GetRules retrieves the running rules from this ruler and all running rulers in the ring if
 // sharding is enabled
 func (r *Ruler) GetRules(ctx context.Context) ([]*GroupStateDesc, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id found in context")
 	}
@@ -724,7 +725,7 @@ func (r *Ruler) getShardedRules(ctx context.Context) ([]*GroupStateDesc, error) 
 
 // Rules implements the rules service
 func (r *Ruler) Rules(ctx context.Context, in *RulesRequest) (*RulesResponse, error) {
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().TenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id found in context")
 	}

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -585,7 +585,7 @@ func filterRuleGroups(userID string, ruleGroups []*store.RuleGroupDesc, ring rin
 // GetRules retrieves the running rules from this ruler and all running rulers in the ring if
 // sharding is enabled
 func (r *Ruler) GetRules(ctx context.Context) ([]*GroupStateDesc, error) {
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id found in context")
 	}
@@ -725,7 +725,7 @@ func (r *Ruler) getShardedRules(ctx context.Context) ([]*GroupStateDesc, error) 
 
 // Rules implements the rules service
 func (r *Ruler) Rules(ctx context.Context, in *RulesRequest) (*RulesResponse, error) {
-	userID, err := tenant.DefaultResolver().TenantID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id found in context")
 	}

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring/kv"
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	"github.com/cortexproject/cortex/pkg/ruler/rules"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
@@ -162,7 +163,7 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 	// We do expect 1 API call for the user create with the getOrCreateNotifier()
 	wg.Add(1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID, _, err := user.ExtractOrgIDFromHTTPRequest(r)
+		userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(tenant.DefaultResolver(), r)
 		assert.NoError(t, err)
 		assert.Equal(t, userID, "1")
 		wg.Done()

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -163,7 +163,7 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 	// We do expect 1 API call for the user create with the getOrCreateNotifier()
 	wg.Add(1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(tenant.DefaultResolver(), r)
+		userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(r)
 		assert.NoError(t, err)
 		assert.Equal(t, userID, "1")
 		wg.Done()

--- a/pkg/tenant/resolver.go
+++ b/pkg/tenant/resolver.go
@@ -1,0 +1,121 @@
+package tenant
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/weaveworks/common/user"
+)
+
+type Resolver interface {
+	// UserID extracts the user identifier from the context. This should be
+	// used to identify a user in log messages, metrics, fairness behaviour and
+	// for config overrides.
+	UserID(context.Context) (string, error)
+
+	// TenantID returns exactly a single tenant ID from the context. It should
+	// be used when a certain endpoint should only support exactly a single
+	// tenant ID. It fails when there is no tenant ID supplied.
+	TenantID(context.Context) (string, error)
+
+	// TenantIDs returns potentially multiple tenant IDs from the context. It
+	// should be used if a supply of multiple tenant IDs is expected.
+	TenantIDs(context.Context) ([]string, error)
+}
+
+// NewSingleResolver creates a tenant resolver, which restricts all requests to
+// be using a single tenant only. This allows a wider set of characters to be
+// used within the tenant ID and should not impose a breaking change.
+func NewSingleResolver() *SingleResolver {
+	return &SingleResolver{}
+}
+
+type SingleResolver struct {
+}
+
+func (t *SingleResolver) UserID(ctx context.Context) (string, error) {
+	//lint:ignore faillint wrapper around upstream method
+	return user.ExtractOrgID(ctx)
+}
+
+func (t *SingleResolver) TenantID(ctx context.Context) (string, error) {
+	//lint:ignore faillint wrapper around upstream method
+	return user.ExtractOrgID(ctx)
+}
+
+func (t *SingleResolver) TenantIDs(ctx context.Context) ([]string, error) {
+	//lint:ignore faillint wrapper around upstream method
+	orgID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return []string{orgID}, err
+}
+
+type MultiResolver struct {
+}
+
+// NewMultiResolver creates a tenant resolver, which allows request to have
+// multiple tenant ids submitted sepearted by a '|' character. This enforces
+// further limits on the character set allowed within tenants as detailed here:
+// https://cortexmetrics.io/docs/guides/limitations/#tenant-id-naming)
+func NewMultiResolver() *MultiResolver {
+	return &MultiResolver{}
+}
+
+func (t *MultiResolver) UserID(ctx context.Context) (string, error) {
+	orgIDs, err := t.TenantIDs(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.Join(orgIDs, tenantIDsLabelSeparator), nil
+}
+
+func (t *MultiResolver) TenantID(ctx context.Context) (string, error) {
+	orgIDs, err := t.TenantIDs(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if len(orgIDs) > 1 {
+		return "", user.ErrTooManyOrgIDs
+	}
+
+	return orgIDs[0], nil
+}
+
+func (t *MultiResolver) TenantIDs(ctx context.Context) ([]string, error) {
+	//lint:ignore faillint wrapper around upstream method
+	orgID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	orgIDs := strings.Split(orgID, tenantIDsLabelSeparator)
+	for _, orgID := range orgIDs {
+		if err := ValidTenantID(orgID); err != nil {
+			return nil, err
+		}
+	}
+
+	return NormalizeTenantIDs(orgIDs), nil
+}
+
+// ExtractTenantIDFromHTTPRequest extracts a single TenantID through a given
+// resolver directly from a HTTP request.
+func ExtractTenantIDFromHTTPRequest(resolver Resolver, req *http.Request) (string, context.Context, error) {
+	//lint:ignore faillint wrapper around upstream method
+	_, ctx, err := user.ExtractOrgIDFromHTTPRequest(req)
+	if err != nil {
+		return "", nil, err
+	}
+
+	tenantID, err := resolver.TenantID(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return tenantID, ctx, nil
+}

--- a/pkg/tenant/resolver.go
+++ b/pkg/tenant/resolver.go
@@ -8,6 +8,16 @@ import (
 	"github.com/weaveworks/common/user"
 )
 
+var defaultResolver Resolver = NewSingleResolver()
+
+func DefaultResolver() Resolver {
+	return defaultResolver
+}
+
+func WithDefaultResolver(r Resolver) {
+	defaultResolver = r
+}
+
 type Resolver interface {
 	// UserID extracts the user identifier from the context. This should be
 	// used to identify a user in log messages, metrics, fairness behaviour and

--- a/pkg/tenant/resolver.go
+++ b/pkg/tenant/resolver.go
@@ -15,13 +15,6 @@ func WithDefaultResolver(r Resolver) {
 	defaultResolver = r
 }
 
-// UserID extracts the user identifier from the context. This should be
-// used to identify a user in log messages, metrics, fairness behaviour and
-// for config overrides.
-func UserID(ctx context.Context) (string, error) {
-	return defaultResolver.UserID(ctx)
-}
-
 // TenantID returns exactly a single tenant ID from the context. It should
 // be used when a certain endpoint should only support exactly a single
 // tenant ID. It fails when there is no tenant ID supplied.
@@ -42,11 +35,6 @@ func TenantIDs(ctx context.Context) ([]string, error) {
 }
 
 type Resolver interface {
-	// UserID extracts the user identifier from the context. This should be
-	// used to identify a user in log messages, metrics, fairness behaviour and
-	// for config overrides.
-	UserID(context.Context) (string, error)
-
 	// TenantID returns exactly a single tenant ID from the context. It should
 	// be used when a certain endpoint should only support exactly a single
 	// tenant ID. It fails when there is no tenant ID supplied.
@@ -65,11 +53,6 @@ func NewSingleResolver() *SingleResolver {
 }
 
 type SingleResolver struct {
-}
-
-func (t *SingleResolver) UserID(ctx context.Context) (string, error) {
-	//lint:ignore faillint wrapper around upstream method
-	return user.ExtractOrgID(ctx)
 }
 
 func (t *SingleResolver) TenantID(ctx context.Context) (string, error) {
@@ -95,15 +78,6 @@ type MultiResolver struct {
 // https://cortexmetrics.io/docs/guides/limitations/#tenant-id-naming)
 func NewMultiResolver() *MultiResolver {
 	return &MultiResolver{}
-}
-
-func (t *MultiResolver) UserID(ctx context.Context) (string, error) {
-	orgIDs, err := t.TenantIDs(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	return strings.Join(orgIDs, tenantIDsLabelSeparator), nil
 }
 
 func (t *MultiResolver) TenantID(ctx context.Context) (string, error) {

--- a/pkg/tenant/resolver.go
+++ b/pkg/tenant/resolver.go
@@ -15,9 +15,10 @@ func WithDefaultResolver(r Resolver) {
 	defaultResolver = r
 }
 
-// TenantID returns exactly a single tenant ID from the context. It should
-// be used when a certain endpoint should only support exactly a single
-// tenant ID. It fails when there is no tenant ID supplied.
+// TenantID returns exactly a single tenant ID from the context. It should be
+// used when a certain endpoint should only support exactly a single
+// tenant ID. It returns an error user.ErrNoOrgID if there is no tenant ID
+// supplied or user.ErrTooManyOrgIDs if there are multiple tenant IDs present.
 //
 // ignore stutter warning
 //nolint:golint
@@ -25,8 +26,9 @@ func TenantID(ctx context.Context) (string, error) {
 	return defaultResolver.TenantID(ctx)
 }
 
-// TenantIDs returns potentially multiple tenant IDs from the context. It
-// should be used if a supply of multiple tenant IDs is expected.
+// TenantIDs returns all tenant IDs from the context. It should return
+// normalized list of ordered and distinct tenant IDs (as produced by
+// NormalizeTenantIDs).
 //
 // ignore stutter warning
 //nolint:golint
@@ -35,13 +37,15 @@ func TenantIDs(ctx context.Context) ([]string, error) {
 }
 
 type Resolver interface {
-	// TenantID returns exactly a single tenant ID from the context. It should
-	// be used when a certain endpoint should only support exactly a single
-	// tenant ID. It fails when there is no tenant ID supplied.
+	// TenantID returns exactly a single tenant ID from the context. It should be
+	// used when a certain endpoint should only support exactly a single
+	// tenant ID. It returns an error user.ErrNoOrgID if there is no tenant ID
+	// supplied or user.ErrTooManyOrgIDs if there are multiple tenant IDs present.
 	TenantID(context.Context) (string, error)
 
-	// TenantIDs returns potentially multiple tenant IDs from the context. It
-	// should be used if a supply of multiple tenant IDs is expected.
+	// TenantIDs returns all tenant IDs from the context. It should return
+	// normalized list of ordered and distinct tenant IDs (as produced by
+	// NormalizeTenantIDs).
 	TenantIDs(context.Context) ([]string, error)
 }
 

--- a/pkg/tenant/resolver_test.go
+++ b/pkg/tenant/resolver_test.go
@@ -1,0 +1,123 @@
+package tenant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/common/user"
+)
+
+func strptr(s string) *string {
+	return &s
+}
+
+type resolverTestCase struct {
+	name         string
+	headerValue  *string
+	errUserID    error
+	errTenantID  error
+	errTenantIDs error
+	userID       string
+	tenantID     string
+	tenantIDs    []string
+}
+
+func (tc *resolverTestCase) test(r Resolver) func(t *testing.T) {
+	return func(t *testing.T) {
+
+		ctx := context.Background()
+		if tc.headerValue != nil {
+			ctx = user.InjectOrgID(ctx, *tc.headerValue)
+		}
+
+		userID, err := r.UserID(ctx)
+		if tc.errUserID != nil {
+			assert.Equal(t, tc.errUserID, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, tc.userID, userID)
+		}
+
+		tenantID, err := r.TenantID(ctx)
+		if tc.errTenantID != nil {
+			assert.Equal(t, tc.errTenantID, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, tc.tenantID, tenantID)
+		}
+
+		tenantIDs, err := r.TenantIDs(ctx)
+		if tc.errTenantIDs != nil {
+			assert.Equal(t, tc.errTenantIDs, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, tc.tenantIDs, tenantIDs)
+		}
+	}
+}
+
+var commonResolverTestCases = []resolverTestCase{
+	{
+		name:         "no-header",
+		errUserID:    user.ErrNoOrgID,
+		errTenantID:  user.ErrNoOrgID,
+		errTenantIDs: user.ErrNoOrgID,
+	},
+	{
+		name:        "empty",
+		headerValue: strptr(""),
+		tenantIDs:   []string{""},
+	},
+	{
+		name:        "single-tenant",
+		headerValue: strptr("tenant-a"),
+		userID:      "tenant-a",
+		tenantID:    "tenant-a",
+		tenantIDs:   []string{"tenant-a"},
+	},
+}
+
+func TestSingleResolver(t *testing.T) {
+	r := NewSingleResolver()
+	for _, tc := range append(commonResolverTestCases, []resolverTestCase{
+		{
+			name:        "multi-tenant",
+			headerValue: strptr("tenant-a|tenant-b"),
+			userID:      "tenant-a|tenant-b",
+			tenantID:    "tenant-a|tenant-b",
+			tenantIDs:   []string{"tenant-a|tenant-b"},
+		},
+	}...) {
+		t.Run(tc.name, tc.test(r))
+	}
+}
+
+func TestMultiResolver(t *testing.T) {
+	r := NewMultiResolver()
+	for _, tc := range append(commonResolverTestCases, []resolverTestCase{
+		{
+			name:        "multi-tenant",
+			headerValue: strptr("tenant-a|tenant-b"),
+			userID:      "tenant-a|tenant-b",
+			errTenantID: user.ErrTooManyOrgIDs,
+			tenantIDs:   []string{"tenant-a", "tenant-b"},
+		},
+		{
+			name:        "multi-tenant-wrong-order",
+			headerValue: strptr("tenant-b|tenant-a"),
+			userID:      "tenant-a|tenant-b",
+			errTenantID: user.ErrTooManyOrgIDs,
+			tenantIDs:   []string{"tenant-a", "tenant-b"},
+		},
+		{
+			name:        "multi-tenant-duplicate-order",
+			headerValue: strptr("tenant-b|tenant-b|tenant-a"),
+			userID:      "tenant-a|tenant-b",
+			errTenantID: user.ErrTooManyOrgIDs,
+			tenantIDs:   []string{"tenant-a", "tenant-b"},
+		},
+	}...) {
+		t.Run(tc.name, tc.test(r))
+	}
+}

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -1,0 +1,86 @@
+package tenant
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+var (
+	errTenantIDTooLong = errors.New("tenant ID is too long: max 150 characters")
+)
+
+type errTenantIDUnsupportedCharacter struct {
+	pos      int
+	tenantID string
+}
+
+func (e *errTenantIDUnsupportedCharacter) Error() string {
+	return fmt.Sprintf(
+		"tenant ID '%s' contains unsupported character '%c'",
+		e.tenantID,
+		e.tenantID[e.pos],
+	)
+}
+
+const tenantIDsLabelSeparator = "|"
+
+// NormalizeTenantIDs is putting the IDs in a normalized form, which is sorts and de-duplicate them
+func NormalizeTenantIDs(ids []string) []string {
+	sort.Strings(ids)
+
+	// de-duplicate orgIDs
+	var result []string
+	for pos := range ids {
+		// skip if we are matching the entry before us
+		if pos > 0 && ids[pos] == ids[pos-1] {
+			continue
+		}
+
+		result = append(result, ids[pos])
+	}
+	return result
+}
+
+// ValidTenantID
+func ValidTenantID(s string) error {
+	// check if it contains invalid runes
+	for pos, r := range s {
+		if !isSupported(r) {
+			return &errTenantIDUnsupportedCharacter{
+				tenantID: s,
+				pos:      pos,
+			}
+		}
+	}
+
+	if len(s) > 150 {
+		return errTenantIDTooLong
+	}
+
+	return nil
+}
+
+// this checks if a rune is supported in tenant IDs (according to
+// https://cortexmetrics.io/docs/guides/limitations/#tenant-id-naming)
+func isSupported(c rune) bool {
+	// characters
+	if ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') {
+		return true
+	}
+
+	// digits
+	if '0' <= c && c <= '9' {
+		return true
+	}
+
+	// special
+	return c == '!' ||
+		c == '-' ||
+		c == '_' ||
+		c == '.' ||
+		c == '*' ||
+		c == '\'' ||
+		c == '(' ||
+		c == ')'
+}

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -25,21 +25,24 @@ func (e *errTenantIDUnsupportedCharacter) Error() string {
 
 const tenantIDsLabelSeparator = "|"
 
-// NormalizeTenantIDs is putting the IDs in a normalized form, which is sorts and de-duplicate them
-func NormalizeTenantIDs(ids []string) []string {
-	sort.Strings(ids)
+// NormalizeTenantIDs is creating a normalized form by sortiing and de-duplicating the list of tenantIDs
+func NormalizeTenantIDs(tenantIDs []string) []string {
+	sort.Strings(tenantIDs)
 
-	// de-duplicate orgIDs
-	var result []string
-	for pos := range ids {
-		// skip if we are matching the entry before us
-		if pos > 0 && ids[pos] == ids[pos-1] {
-			continue
-		}
-
-		result = append(result, ids[pos])
+	count := len(tenantIDs)
+	if count <= 1 {
+		return tenantIDs
 	}
-	return result
+
+	posOut := 1
+	for posIn := 1; posIn < count; posIn++ {
+		if tenantIDs[posIn] != tenantIDs[posIn-1] {
+			tenantIDs[posOut] = tenantIDs[posIn]
+			posOut++
+		}
+	}
+
+	return tenantIDs[0:posOut]
 }
 
 // ValidTenantID

--- a/pkg/tenant/tenant_test.go
+++ b/pkg/tenant/tenant_test.go
@@ -1,0 +1,42 @@
+package tenant
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidTenantIDs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  *string
+	}{
+		{
+			name: "tenant-a",
+		},
+		{
+			name: "ABCDEFGHIJKLMNOPQRSTUVWXYZ-abcdefghijklmnopqrstuvwxyz_0987654321!.*'()",
+		},
+		{
+			name: "invalid|",
+			err:  strptr("tenant ID 'invalid|' contains unsupported character '|'"),
+		},
+		{
+			name: strings.Repeat("a", 150),
+		},
+		{
+			name: strings.Repeat("a", 151),
+			err:  strptr("tenant ID is too long: max 150 characters"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidTenantID(tc.name)
+			if tc.err == nil {
+				assert.Nil(t, err)
+			} else {
+				assert.EqualError(t, err, *tc.err)
+			}
+		})
+	}
+}

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -106,7 +106,7 @@ func (pl *PrometheusLogger) Log(kv ...interface{}) error {
 func WithContext(ctx context.Context, l log.Logger) log.Logger {
 	// Weaveworks uses "orgs" and "orgID" to represent Cortex users,
 	// even though the code-base generally uses `userID` to refer to the same thing.
-	userID, err := tenant.DefaultResolver().UserID(ctx)
+	userID, err := tenant.UserID(ctx)
 	if err == nil {
 		l = WithUserID(userID, l)
 	}

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -106,7 +106,7 @@ func (pl *PrometheusLogger) Log(kv ...interface{}) error {
 func WithContext(ctx context.Context, l log.Logger) log.Logger {
 	// Weaveworks uses "orgs" and "orgID" to represent Cortex users,
 	// even though the code-base generally uses `userID` to refer to the same thing.
-	userID, err := tenant.UserID(ctx)
+	userID, err := tenant.TenantID(ctx)
 	if err == nil {
 		l = WithUserID(userID, l)
 	}

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -11,7 +11,8 @@ import (
 	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
-	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/tenant"
 )
 
 var (
@@ -105,7 +106,7 @@ func (pl *PrometheusLogger) Log(kv ...interface{}) error {
 func WithContext(ctx context.Context, l log.Logger) log.Logger {
 	// Weaveworks uses "orgs" and "orgID" to represent Cortex users,
 	// even though the code-base generally uses `userID` to refer to the same thing.
-	userID, err := user.ExtractOrgID(ctx)
+	userID, err := tenant.DefaultResolver().UserID(ctx)
 	if err == nil {
 		l = WithUserID(userID, l)
 	}


### PR DESCRIPTION
**What this PR does**:

**Which issue(s) this PR fixes**:

This implements the multi tenant resolver as described by the [proposal] for multi tenant query-federation.

By default it behaves like before, but it's implementation can be swapped out.

This replaces:
 * `user.ExtractOrgID` by either `TenantID` or `UserID` depending on if in this context a multi tenant usage should be allowed
*  `user.ExtractOrgIDFromHTTPRequest` with `ExtractTenantIDFromHTTPRequest` to gather exactly one tenant id.

I have also added lint test to check for usage of the upstream methods directly

[proposal]: #3364

**Checklist**
- [x] Tests updated
- [not necessary] Documentation added
- [not necessary]  `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
