### PR TITLE
Close TSDB and delete local data when TSDB is idle for a long time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [ENHANCEMENT] Blocks storage: enabled caching of `meta.json` attributes, configurable via `-blocks-storage.bucket-store.metadata-cache.metafile-attributes-ttl`. #3528
 * [ENHANCEMENT] Compactor: added a config validation check to fail fast if the compactor has been configured invalid block range periods (each period is expected to be a multiple of the previous one). #3534
 * [ENHANCEMENT] Blocks storage: concurrently fetch deletion marks from object storage. #3538
+* [ENHANCEMENT] Blocks storage ingester: ingester can now close idle TSDB and delete local data. #3491
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -653,6 +653,15 @@ blocks_storage:
     # CLI flag: -blocks-storage.tsdb.flush-blocks-on-shutdown
     [flush_blocks_on_shutdown: <boolean> | default = false]
 
+    # If TSDB has not received any data for this duration, and all blocks from
+    # TSDB have been shipped, TSDB is closed and deleted from local disk. If set
+    # to positive value, this value should be equal or higher than
+    # -querier.query-ingesters-within flag to make sure that TSDB is not closed
+    # prematurely, which could cause partial query results. 0 or negative value
+    # disables closing of idle TSDB.
+    # CLI flag: -blocks-storage.tsdb.close-idle-tsdb-timeout
+    [close_idle_tsdb_timeout: <duration> | default = 0s]
+
     # limit the number of concurrently opening TSDB's on startup
     # CLI flag: -blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup
     [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -703,6 +703,15 @@ blocks_storage:
     # CLI flag: -blocks-storage.tsdb.flush-blocks-on-shutdown
     [flush_blocks_on_shutdown: <boolean> | default = false]
 
+    # If TSDB has not received any data for this duration, and all blocks from
+    # TSDB have been shipped, TSDB is closed and deleted from local disk. If set
+    # to positive value, this value should be equal or higher than
+    # -querier.query-ingesters-within flag to make sure that TSDB is not closed
+    # prematurely, which could cause partial query results. 0 or negative value
+    # disables closing of idle TSDB.
+    # CLI flag: -blocks-storage.tsdb.close-idle-tsdb-timeout
+    [close_idle_tsdb_timeout: <duration> | default = 0s]
+
     # limit the number of concurrently opening TSDB's on startup
     # CLI flag: -blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup
     [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3855,6 +3855,15 @@ tsdb:
   # CLI flag: -blocks-storage.tsdb.flush-blocks-on-shutdown
   [flush_blocks_on_shutdown: <boolean> | default = false]
 
+  # If TSDB has not received any data for this duration, and all blocks from
+  # TSDB have been shipped, TSDB is closed and deleted from local disk. If set
+  # to positive value, this value should be equal or higher than
+  # -querier.query-ingesters-within flag to make sure that TSDB is not closed
+  # prematurely, which could cause partial query results. 0 or negative value
+  # disables closing of idle TSDB.
+  # CLI flag: -blocks-storage.tsdb.close-idle-tsdb-timeout
+  [close_idle_tsdb_timeout: <duration> | default = 0s]
+
   # limit the number of concurrently opening TSDB's on startup
   # CLI flag: -blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup
   [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -60,3 +60,4 @@ Currently experimental features are:
 - Blocks storage: lazy mmap of block indexes in the store-gateway (`-blocks-storage.bucket-store.index-header-lazy-loading-enabled`)
 - Ingester: do not unregister from ring on shutdown (`-ingester.unregister-on-shutdown=false`)
 - Distributor: do not extend writes on unhealthy ingesters (`-distributor.extend-writes=false`)
+- Ingester: close idle TSDB and remove them from local disk (`-blocks-storage.tsdb.close-idle-tsdb-timeout`)

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -311,10 +311,7 @@ type TSDBState struct {
 	appenderAddDuration    prometheus.Histogram
 	appenderCommitDuration prometheus.Histogram
 	refCachePurgeDuration  prometheus.Histogram
-
-	// Idle TSDB metrics.
-	idleTsdbChecks      prometheus.Counter
-	idleTsdbCheckResult *prometheus.CounterVec
+	idleTsdbCheckResult    *prometheus.CounterVec
 }
 
 func newTSDBState(bucketClient objstore.Bucket, registerer prometheus.Registerer) TSDBState {
@@ -370,10 +367,6 @@ func newTSDBState(bucketClient objstore.Bucket, registerer prometheus.Registerer
 			Buckets: prometheus.DefBuckets,
 		}),
 
-		idleTsdbChecks: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_ingester_idle_tsdb_checks_total",
-			Help: "The total number of checks for idle TSDB.",
-		}),
 		idleTsdbCheckResult: idleTsdbCheckResult,
 	}
 }
@@ -1556,8 +1549,6 @@ func (i *Ingester) closeAndDeleteIdleUserTSDBs(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return nil
 		}
-
-		i.TSDBState.idleTsdbChecks.Inc()
 
 		result := i.closeAndDeleteUserTSDBIfIdle(userID)
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -48,6 +48,31 @@ type Shipper interface {
 	Sync(ctx context.Context) (uploaded int, err error)
 }
 
+type tsdbState int
+
+const (
+	active          tsdbState = iota // Pushes are allowed only in this state.
+	forceCompacting                  // TSDB is being force-compacted.
+	closing                          // Used while closing idle TSDB.
+	closed                           // Used to avoid setting closing back to active in closeAndDeleteIdleUsers method.
+)
+
+// Describes result of TSDB idle check (for closing). String is used as metric label.
+type tsdbIdleCheckResult string
+
+const (
+	tsdbIdle              tsdbIdleCheckResult = "idle" // Not reported via metrics. Metrics use tsdbIdleClosed on success.
+	tsdbShippingDisabled  tsdbIdleCheckResult = "shipping_disabled"
+	tsdbNotIdle           tsdbIdleCheckResult = "not_idle"
+	tsdbNotCompacted      tsdbIdleCheckResult = "not_compacted"
+	tsdbNotShipped        tsdbIdleCheckResult = "not_shipped"
+	tsdbCheckFailed       tsdbIdleCheckResult = "check_failed"
+	tsdbCloseFailed       tsdbIdleCheckResult = "close_failed"
+	tsdbNotActive         tsdbIdleCheckResult = "not_active"
+	tsdbDataRemovalFailed tsdbIdleCheckResult = "data_removal_failed"
+	tsdbIdleClosed        tsdbIdleCheckResult = "idle_closed" // Success.
+)
+
 type userTSDB struct {
 	db             *tsdb.DB
 	userID         string
@@ -56,13 +81,12 @@ type userTSDB struct {
 	seriesInMetric *metricCounter
 	limiter        *Limiter
 
-	forcedCompactionInProgressMtx sync.RWMutex
-	forcedCompactionInProgress    bool
-
-	pushesInFlight sync.WaitGroup
+	stateMtx       sync.RWMutex
+	state          tsdbState
+	pushesInFlight sync.WaitGroup // Increased with Read lock held, only if state == active.
 
 	// Used to detect idle TSDBs.
-	lastUpdate *atomic.Int64
+	lastUpdate atomic.Int64
 
 	// Thanos shipper used to ship blocks to the storage.
 	shipper Shipper
@@ -102,16 +126,25 @@ func (u *userTSDB) StartTime() (int64, error) {
 	return u.db.StartTime()
 }
 
+func (u *userTSDB) casState(from, to tsdbState) bool {
+	u.stateMtx.Lock()
+	defer u.stateMtx.Unlock()
+
+	if u.state != from {
+		return false
+	}
+	u.state = to
+	return true
+}
+
 // compactHead compacts the Head block at specified block durations avoiding a single huge block.
 func (u *userTSDB) compactHead(blockDuration int64) error {
-	u.forcedCompactionInProgressMtx.Lock()
-	u.forcedCompactionInProgress = true
-	u.forcedCompactionInProgressMtx.Unlock()
-	defer func() {
-		u.forcedCompactionInProgressMtx.Lock()
-		u.forcedCompactionInProgress = false
-		u.forcedCompactionInProgressMtx.Unlock()
-	}()
+	if !u.casState(active, forceCompacting) {
+		return errors.New("TSDB head cannot be compacted because it is not in active state (possibly being closed)")
+	}
+
+	defer u.casState(forceCompacting, active)
+
 	// Ingestion of samples in parallel with forced compaction can lead to overlapping blocks.
 	// So we wait for existing in-flight requests to finish. Future push requests would fail until compaction is over.
 	u.pushesInFlight.Wait()
@@ -190,7 +223,7 @@ func (u *userTSDB) blocksToDelete(blocks []*tsdb.Block) map[ulid.ULID]struct{} {
 		return deletable
 	}
 
-	shipperMeta, err := shipper.ReadMetaFile(u.db.Dir())
+	shippedBlocks, err := u.getShippedBlocks()
 	if err != nil {
 		// If there is any issue with the shipper, we should be conservative and not delete anything.
 		level.Error(util.Logger).Log("msg", "failed to read shipper meta during deletion of blocks", "user", u.userID, "err", err)
@@ -198,12 +231,21 @@ func (u *userTSDB) blocksToDelete(blocks []*tsdb.Block) map[ulid.ULID]struct{} {
 	}
 
 	result := map[ulid.ULID]struct{}{}
-	for _, shippedID := range shipperMeta.Uploaded {
+	for _, shippedID := range shippedBlocks {
 		if _, ok := deletable[shippedID]; ok {
 			result[shippedID] = struct{}{}
 		}
 	}
 	return result
+}
+
+func (u *userTSDB) getShippedBlocks() ([]ulid.ULID, error) {
+	shipperMeta, err := shipper.ReadMetaFile(u.db.Dir())
+	if err != nil {
+		return nil, err
+	}
+
+	return shipperMeta.Uploaded, nil
 }
 
 func (u *userTSDB) isIdle(now time.Time, idle time.Duration) bool {
@@ -214,6 +256,37 @@ func (u *userTSDB) isIdle(now time.Time, idle time.Duration) bool {
 
 func (u *userTSDB) setLastUpdate(t time.Time) {
 	u.lastUpdate.Store(t.Unix())
+}
+
+// Reports tsdbIdle if TSDB can be closed, or some other tsdbIdleCheckResult.
+func (u *userTSDB) canIdleClose(idleTimeout time.Duration) (tsdbIdleCheckResult, error) {
+	if !u.isIdle(time.Now(), idleTimeout) {
+		return tsdbNotIdle, nil
+	}
+
+	// If head is not compacted, we cannot close this yet.
+	if u.Head().NumSeries() > 0 {
+		return tsdbNotCompacted, nil
+	}
+
+	// Verify that all blocks have been shipped.
+	shipped, err := u.getShippedBlocks()
+	if err != nil {
+		return tsdbCheckFailed, errors.Wrapf(err, "failed to read shipper meta")
+	}
+
+	shippedMap := make(map[ulid.ULID]bool, len(shipped))
+	for _, b := range shipped {
+		shippedMap[b] = true
+	}
+
+	for _, b := range u.Blocks() {
+		if !shippedMap[b.Meta().ULID] {
+			return tsdbNotShipped, nil
+		}
+	}
+
+	return tsdbIdle, nil
 }
 
 // TSDBState holds data structures used by the TSDB storage engine
@@ -238,9 +311,28 @@ type TSDBState struct {
 	appenderAddDuration    prometheus.Histogram
 	appenderCommitDuration prometheus.Histogram
 	refCachePurgeDuration  prometheus.Histogram
+
+	// Idle TSDB metrics.
+	idleTsdbChecks      prometheus.Counter
+	idleTsdbCheckResult *prometheus.CounterVec
 }
 
 func newTSDBState(bucketClient objstore.Bucket, registerer prometheus.Registerer) TSDBState {
+	idleTsdbCheckResult := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_ingester_idle_tsdb_check_results_total",
+		Help: "The total number of various results for idle TSDB checks.",
+	}, []string{"result"})
+
+	idleTsdbCheckResult.WithLabelValues(string(tsdbShippingDisabled))
+	idleTsdbCheckResult.WithLabelValues(string(tsdbNotIdle))
+	idleTsdbCheckResult.WithLabelValues(string(tsdbNotCompacted))
+	idleTsdbCheckResult.WithLabelValues(string(tsdbNotShipped))
+	idleTsdbCheckResult.WithLabelValues(string(tsdbCheckFailed))
+	idleTsdbCheckResult.WithLabelValues(string(tsdbCloseFailed))
+	idleTsdbCheckResult.WithLabelValues(string(tsdbNotActive))
+	idleTsdbCheckResult.WithLabelValues(string(tsdbDataRemovalFailed))
+	idleTsdbCheckResult.WithLabelValues(string(tsdbIdleClosed))
+
 	return TSDBState{
 		dbs:                 make(map[string]*userTSDB),
 		bucket:              bucketClient,
@@ -277,6 +369,12 @@ func newTSDBState(bucketClient objstore.Bucket, registerer prometheus.Registerer
 			Help:    "The total time it takes to purge the TSDB series reference cache for a single tenant.",
 			Buckets: prometheus.DefBuckets,
 		}),
+
+		idleTsdbChecks: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingester_idle_tsdb_checks_total",
+			Help: "The total number of checks for idle TSDB.",
+		}),
+		idleTsdbCheckResult: idleTsdbCheckResult,
 	}
 }
 
@@ -392,6 +490,15 @@ func (i *Ingester) startingV2(ctx context.Context) error {
 	if i.cfg.BlocksStorageConfig.TSDB.ShipInterval > 0 {
 		shippingService := services.NewBasicService(nil, i.shipBlocksLoop, nil)
 		servs = append(servs, shippingService)
+	}
+
+	if i.cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBTimeout > 0 {
+		interval := i.cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBInterval
+		if interval == 0 {
+			interval = cortex_tsdb.DefaultCloseIdleTSDBInterval
+		}
+		closeIdleService := services.NewTimerService(interval, nil, i.closeAndDeleteIdleUserTSDBs, nil)
+		servs = append(servs, closeIdleService)
 	}
 
 	var err error
@@ -680,11 +787,18 @@ func (i *Ingester) v2Push(ctx context.Context, req *client.WriteRequest) (*clien
 }
 
 func (u *userTSDB) acquireAppendLock() error {
-	u.forcedCompactionInProgressMtx.RLock()
-	defer u.forcedCompactionInProgressMtx.RUnlock()
+	u.stateMtx.RLock()
+	defer u.stateMtx.RUnlock()
 
-	if u.forcedCompactionInProgress {
-		return errors.New("forced compaction in progress")
+	if u.state != active {
+		switch u.state {
+		case forceCompacting:
+			return errors.New("forced compaction in progress")
+		case closing:
+			return errors.New("TSDB is closing")
+		default:
+			return errors.New("TSDB is not active")
+		}
 	}
 
 	u.pushesInFlight.Add(1)
@@ -1090,7 +1204,6 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 		seriesInMetric:      newMetricCounter(i.limiter),
 		ingestedAPISamples:  newEWMARate(0.2, i.cfg.RateUpdatePeriod),
 		ingestedRuleSamples: newEWMARate(0.2, i.cfg.RateUpdatePeriod),
-		lastUpdate:          atomic.NewInt64(0),
 	}
 
 	// Create a new user database
@@ -1436,6 +1549,83 @@ func (i *Ingester) compactBlocks(ctx context.Context, force bool) {
 
 		return nil
 	})
+}
+
+func (i *Ingester) closeAndDeleteIdleUserTSDBs(ctx context.Context) error {
+	for _, userID := range i.getTSDBUsers() {
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		i.TSDBState.idleTsdbChecks.Inc()
+
+		result := i.closeAndDeleteUserTSDBIfIdle(userID)
+
+		i.TSDBState.idleTsdbCheckResult.WithLabelValues(string(result)).Inc()
+	}
+
+	return nil
+}
+
+func (i *Ingester) closeAndDeleteUserTSDBIfIdle(userID string) tsdbIdleCheckResult {
+	userDB := i.getTSDB(userID)
+	if userDB == nil || userDB.shipper == nil {
+		// We will not delete local data when not using shipping to storage.
+		return tsdbShippingDisabled
+	}
+
+	if result, err := userDB.canIdleClose(i.cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBTimeout); result != tsdbIdle {
+		if err != nil {
+			level.Error(util.Logger).Log("msg", "cannot close idle TSDB", "user", userID, "err", err)
+		}
+		return result
+	}
+
+	// This disables pushes and force-compactions.
+	if !userDB.casState(active, closing) {
+		return tsdbNotActive
+	}
+
+	// If TSDB is fully closed, we will set state to 'closed', which will prevent this defered closing -> active transition.
+	defer userDB.casState(closing, active)
+
+	// Make sure we don't ignore any possible inflight pushes.
+	userDB.pushesInFlight.Wait()
+
+	// Verify again, things may have changed during the checks and pushes.
+	if result, err := userDB.canIdleClose(i.cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBTimeout); result != tsdbIdle {
+		if err != nil {
+			level.Error(util.Logger).Log("msg", "cannot close idle TSDB", "user", userID, "err", err)
+		}
+		return result
+	}
+
+	dir := userDB.db.Dir()
+
+	if err := userDB.Close(); err != nil {
+		level.Error(util.Logger).Log("msg", "failed to close idle TSDB", "user", userID, "err", err)
+		return tsdbCloseFailed
+	}
+
+	level.Info(util.Logger).Log("msg", "closed idle TSDB", "user", userID)
+
+	// This will prevent going back to "active" state in deferred statement.
+	userDB.casState(closing, closed)
+
+	i.userStatesMtx.Lock()
+	delete(i.TSDBState.dbs, userID)
+	i.userStatesMtx.Unlock()
+
+	i.TSDBState.tsdbMetrics.removeRegistryForUser(userID)
+
+	// And delete local data.
+	if err := os.RemoveAll(dir); err != nil {
+		level.Error(util.Logger).Log("msg", "failed to delete idle TSDB", "user", userID, "err", err)
+		return tsdbDataRemovalFailed
+	}
+
+	level.Info(util.Logger).Log("msg", "deleted data for idle TSDB", "user", userID, "dir", dir)
+	return tsdbIdleClosed
 }
 
 // This method will flush all data. It is called as part of Lifecycler's shutdown (if flush on shutdown is configured), or from the flusher.

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -311,24 +311,24 @@ type TSDBState struct {
 	appenderAddDuration    prometheus.Histogram
 	appenderCommitDuration prometheus.Histogram
 	refCachePurgeDuration  prometheus.Histogram
-	idleTsdbCheckResult    *prometheus.CounterVec
+	idleTsdbChecks         *prometheus.CounterVec
 }
 
 func newTSDBState(bucketClient objstore.Bucket, registerer prometheus.Registerer) TSDBState {
-	idleTsdbCheckResult := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-		Name: "cortex_ingester_idle_tsdb_check_results_total",
+	idleTsdbChecks := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_ingester_idle_tsdb_checks_total",
 		Help: "The total number of various results for idle TSDB checks.",
 	}, []string{"result"})
 
-	idleTsdbCheckResult.WithLabelValues(string(tsdbShippingDisabled))
-	idleTsdbCheckResult.WithLabelValues(string(tsdbNotIdle))
-	idleTsdbCheckResult.WithLabelValues(string(tsdbNotCompacted))
-	idleTsdbCheckResult.WithLabelValues(string(tsdbNotShipped))
-	idleTsdbCheckResult.WithLabelValues(string(tsdbCheckFailed))
-	idleTsdbCheckResult.WithLabelValues(string(tsdbCloseFailed))
-	idleTsdbCheckResult.WithLabelValues(string(tsdbNotActive))
-	idleTsdbCheckResult.WithLabelValues(string(tsdbDataRemovalFailed))
-	idleTsdbCheckResult.WithLabelValues(string(tsdbIdleClosed))
+	idleTsdbChecks.WithLabelValues(string(tsdbShippingDisabled))
+	idleTsdbChecks.WithLabelValues(string(tsdbNotIdle))
+	idleTsdbChecks.WithLabelValues(string(tsdbNotCompacted))
+	idleTsdbChecks.WithLabelValues(string(tsdbNotShipped))
+	idleTsdbChecks.WithLabelValues(string(tsdbCheckFailed))
+	idleTsdbChecks.WithLabelValues(string(tsdbCloseFailed))
+	idleTsdbChecks.WithLabelValues(string(tsdbNotActive))
+	idleTsdbChecks.WithLabelValues(string(tsdbDataRemovalFailed))
+	idleTsdbChecks.WithLabelValues(string(tsdbIdleClosed))
 
 	return TSDBState{
 		dbs:                 make(map[string]*userTSDB),
@@ -367,7 +367,7 @@ func newTSDBState(bucketClient objstore.Bucket, registerer prometheus.Registerer
 			Buckets: prometheus.DefBuckets,
 		}),
 
-		idleTsdbCheckResult: idleTsdbCheckResult,
+		idleTsdbChecks: idleTsdbChecks,
 	}
 }
 
@@ -1552,7 +1552,7 @@ func (i *Ingester) closeAndDeleteIdleUserTSDBs(ctx context.Context) error {
 
 		result := i.closeAndDeleteUserTSDBIfIdle(userID)
 
-		i.TSDBState.idleTsdbCheckResult.WithLabelValues(string(result)).Inc()
+		i.TSDBState.idleTsdbChecks.WithLabelValues(string(result)).Inc()
 	}
 
 	return nil

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -2210,6 +2210,92 @@ func TestIngesterCompactIdleBlock(t *testing.T) {
     `), memSeriesCreatedTotalName, memSeriesRemovedTotalName))
 }
 
+func TestIngesterCompactAndCloseIdleTSDB(t *testing.T) {
+	cfg := defaultIngesterTestConfig()
+	cfg.LifecyclerConfig.JoinAfter = 0
+	cfg.BlocksStorageConfig.TSDB.ShipInterval = 1 * time.Second // Required to enable shipping.
+	cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 1
+	cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval = 1 * time.Second
+	cfg.BlocksStorageConfig.TSDB.HeadCompactionIdleTimeout = 1 * time.Second
+	cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBTimeout = 1 * time.Second
+	cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBInterval = 1 * time.Second
+
+	r := prometheus.NewRegistry()
+
+	// Create ingester
+	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, r)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	t.Cleanup(func() {
+		_ = services.StopAndAwaitTerminated(context.Background(), i)
+	})
+
+	// Wait until it's ACTIVE
+	test.Poll(t, 1*time.Second, ring.ACTIVE, func() interface{} {
+		return i.lifecycler.GetState()
+	})
+
+	m := mockUserShipper(t, i)
+	m.On("Sync", mock.Anything).Return(0, nil)
+
+	pushSingleSample(t, i)
+
+	require.NoError(t, testutil.GatherAndCompare(r, strings.NewReader(`
+		# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
+		# TYPE cortex_ingester_memory_series_created_total counter
+		cortex_ingester_memory_series_created_total{user="1"} 1
+
+		# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
+		# TYPE cortex_ingester_memory_series_removed_total counter
+		cortex_ingester_memory_series_removed_total{user="1"} 0
+    `), memSeriesCreatedTotalName, memSeriesRemovedTotalName))
+
+	// Wait until idle TSDB is force-compacted, shipped, and eventually closed and removed.
+	test.Poll(t, 10*time.Second, 0, func() interface{} {
+		db := i.getTSDB(userID)
+		if db != nil {
+			// Simulate shipper updating metadata file.
+			meta := &shipper.Meta{Version: shipper.MetaVersion1}
+
+			blocks := db.Blocks()
+			for _, b := range blocks {
+				meta.Uploaded = append(meta.Uploaded, b.Meta().ULID)
+			}
+
+			require.NoError(t, shipper.WriteMetaFile(util.Logger, db.db.Dir(), meta))
+		}
+
+		i.userStatesMtx.Lock()
+		defer i.userStatesMtx.Unlock()
+		return len(i.TSDBState.dbs)
+	})
+
+	// Verify that user has disappeared from metrics.
+	require.NoError(t, testutil.GatherAndCompare(r, strings.NewReader(`
+		# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
+		# TYPE cortex_ingester_memory_series_created_total counter
+
+		# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
+		# TYPE cortex_ingester_memory_series_removed_total counter
+    `), memSeriesCreatedTotalName, memSeriesRemovedTotalName))
+
+	// Pushing another sample will recreate TSDB.
+	pushSingleSample(t, i)
+
+	// User is back.
+	require.NoError(t, testutil.GatherAndCompare(r, strings.NewReader(`
+		# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
+		# TYPE cortex_ingester_memory_series_created_total counter
+		cortex_ingester_memory_series_created_total{user="1"} 1
+
+		# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
+		# TYPE cortex_ingester_memory_series_removed_total counter
+		cortex_ingester_memory_series_removed_total{user="1"} 0
+    `), memSeriesCreatedTotalName, memSeriesRemovedTotalName))
+}
+
 func verifyCompactedHead(t *testing.T, i *Ingester, expected bool) {
 	db := i.getTSDB(userID)
 	require.NotNil(t, db)
@@ -2444,10 +2530,7 @@ func TestIngesterPushErrorDuringForcedCompaction(t *testing.T) {
 	// We mock a flushing by setting the boolean.
 	db := i.getTSDB(userID)
 	require.NotNil(t, db)
-	db.forcedCompactionInProgressMtx.Lock()
-	require.False(t, db.forcedCompactionInProgress)
-	db.forcedCompactionInProgress = true
-	db.forcedCompactionInProgressMtx.Unlock()
+	require.True(t, db.casState(active, forceCompacting))
 
 	// Ingestion should fail with a 503.
 	req, _, _ := mockWriteRequest(labels.Labels{{Name: labels.MetricName, Value: "test"}}, 0, util.TimeToMillis(time.Now()))
@@ -2456,10 +2539,7 @@ func TestIngesterPushErrorDuringForcedCompaction(t *testing.T) {
 	require.Equal(t, httpgrpc.Errorf(http.StatusServiceUnavailable, wrapWithUser(errors.New("forced compaction in progress"), userID).Error()), err)
 
 	// Ingestion is successful after a flush.
-	db.forcedCompactionInProgressMtx.Lock()
-	require.True(t, db.forcedCompactionInProgress)
-	db.forcedCompactionInProgress = false
-	db.forcedCompactionInProgressMtx.Unlock()
+	require.True(t, db.casState(forceCompacting, active))
 	pushSingleSample(t, i)
 }
 

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -2272,6 +2272,9 @@ func TestIngesterCompactAndCloseIdleTSDB(t *testing.T) {
 		return len(i.TSDBState.dbs)
 	})
 
+	require.Greater(t, testutil.ToFloat64(i.TSDBState.idleTsdbChecks), float64(0))
+	require.Greater(t, testutil.ToFloat64(i.TSDBState.idleTsdbCheckResult.WithLabelValues(string(tsdbIdleClosed))), float64(0))
+
 	// Verify that user has disappeared from metrics.
 	require.NoError(t, testutil.GatherAndCompare(r, strings.NewReader(`
 		# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -2272,7 +2272,6 @@ func TestIngesterCompactAndCloseIdleTSDB(t *testing.T) {
 		return len(i.TSDBState.dbs)
 	})
 
-	require.Greater(t, testutil.ToFloat64(i.TSDBState.idleTsdbChecks), float64(0))
 	require.Greater(t, testutil.ToFloat64(i.TSDBState.idleTsdbCheckResult.WithLabelValues(string(tsdbIdleClosed))), float64(0))
 
 	// Verify that user has disappeared from metrics.

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -2272,7 +2272,7 @@ func TestIngesterCompactAndCloseIdleTSDB(t *testing.T) {
 		return len(i.TSDBState.dbs)
 	})
 
-	require.Greater(t, testutil.ToFloat64(i.TSDBState.idleTsdbCheckResult.WithLabelValues(string(tsdbIdleClosed))), float64(0))
+	require.Greater(t, testutil.ToFloat64(i.TSDBState.idleTsdbChecks.WithLabelValues(string(tsdbIdleClosed))), float64(0))
 
 	// Verify that user has disappeared from metrics.
 	require.NoError(t, testutil.GatherAndCompare(r, strings.NewReader(`

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -412,7 +412,6 @@ func (sm *tsdbMetrics) Describe(out chan<- *prometheus.Desc) {
 
 	out <- sm.memSeriesCreatedTotal
 	out <- sm.memSeriesRemovedTotal
-
 }
 
 func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
@@ -454,4 +453,8 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 
 func (sm *tsdbMetrics) setRegistryForUser(userID string, registry *prometheus.Registry) {
 	sm.regs.AddUserRegistry(userID, registry)
+}
+
+func (sm *tsdbMetrics) removeRegistryForUser(userID string) {
+	sm.regs.RemoveUserRegistry(userID, false)
 }


### PR DESCRIPTION
**What this PR does**: This PR adds ability for ingester to close idle TSDB and delete local data when TSDB is idle for a long time (no data is appended to it). Closing/deletion only happens if head is empty (possibly thanks to previous force-compaction due to being idle), and all blocks were shipped.

~This PR also takes care of hiding user metrics, while keeping the registry to avoid breaking the counters over all users.~ Support for metrics removal has been extracted to separate PR, https://github.com/cortexproject/cortex/pull/3511.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
