### PR TITLE
Don't report io.EOF as error from FrontendLoop.

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -156,6 +157,10 @@ func (s *Scheduler) FrontendLoop(frontend schedulerpb.SchedulerForFrontend_Front
 	for s.State() == services.Running {
 		msg, err := frontend.Recv()
 		if err != nil {
+			// No need to report this as error, it is expected when query-frontend performs SendClose() (as frontendSchedulerWorker does).
+			if err == io.EOF {
+				return nil
+			}
 			return err
 		}
 


### PR DESCRIPTION
**What this PR does**: This PR ignores `io.EOF` in FrontendLoop of query-scheduler. This is expected behaviour when query-frontend closes connection due to restart.

We see `grpc_logging.go` logging EOF error unnecessarily. When trying to add unit test for this,  instantiating `GRPCServerLog` and correct logging setup in the unit test was too much for this trivial change, so I haven't included it in the PR. It seemed that test complexity outweighed the benefit.

**Checklist**
- [no] Tests updated 
- [no] Documentation added
- [no] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
