### PR TITLE
Improve logging in the chunk store.

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -411,10 +411,7 @@ func (c *store) getMetricNameChunks(ctx context.Context, userID string, from, th
 
 func (c *store) lookupChunksByMetricName(ctx context.Context, userID string, from, through model.Time, matchers []*labels.Matcher, metricName string) ([]Chunk, error) {
 	log, ctx := spanlogger.New(ctx, "ChunkStore.lookupChunksByMetricName")
-	defer func() {
-
-		log.Finish()
-	}()
+	defer log.Finish()
 
 	// Just get chunks for metric if there are no matchers
 	if len(matchers) == 0 {


### PR DESCRIPTION
This prints statistics and stringify matchers only once.
I realized we are pretty verbose and it doesn't actually add value to logs one stats by one, at the same it's also the hot path and this can consume CPU(around 10% while looking at queriers in Loki).

I've added a benchmark, I'm planning to use this one more in the future to improve index querying memory allocations..

bench diff:

```
benchmark                     old ns/op     new ns/op     delta
Benchmark_GetRefsChunk-16     461135        423417        -8.18%

benchmark                     old allocs     new allocs     delta
Benchmark_GetRefsChunk-16     1723           1539           -10.68%

benchmark                     old bytes     new bytes     delta
Benchmark_GetRefsChunk-16     104342        95305         -8.66%
```

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>