### PR TITLE
Reuse components slice when parsing chunk time range value.

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -254,7 +254,7 @@ func (c *baseStore) LabelValuesForMetricName(ctx context.Context, userID string,
 
 	var result UniqueStrings
 	for _, entry := range entries {
-		_, labelValue, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
+		_, labelValue, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
 		if err != nil {
 			return nil, err
 		}
@@ -559,7 +559,7 @@ func (c *baseStore) parseIndexEntries(_ context.Context, entries []IndexEntry, m
 
 	result := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		chunkKey, labelValue, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
+		chunkKey, labelValue, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/chunk/schema_test.go
+++ b/pkg/chunk/schema_test.go
@@ -151,7 +151,7 @@ const (
 
 // parseRangeValueType returns the type of rangeValue
 func parseRangeValueType(rangeValue []byte) (int, error) {
-	components := decodeRangeKey(rangeValue)
+	components := decodeRangeKey(rangeValue, make([][]byte, 0, 5))
 	switch {
 	case len(components) < 3:
 		return 0, fmt.Errorf("invalid range value: %x", rangeValue)
@@ -340,7 +340,7 @@ func TestSchemaRangeKey(t *testing.T) {
 					_, err := parseMetricNameRangeValue(entry.RangeValue, entry.Value)
 					require.NoError(t, err)
 				case ChunkTimeRangeValue:
-					_, _, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
+					_, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
 					require.NoError(t, err)
 				case SeriesRangeValue:
 					_, err := parseSeriesRangeValue(entry.RangeValue, entry.Value)

--- a/pkg/chunk/schema_util_test.go
+++ b/pkg/chunk/schema_util_test.go
@@ -93,7 +93,7 @@ func TestParseChunkTimeRangeValue(t *testing.T) {
 		{[]byte("a1b2c3d4\x00Y29kZQ\x002:1484661279394:1484664879394\x004\x00"),
 			"code", "2:1484661279394:1484664879394"},
 	} {
-		chunkID, labelValue, _, err := parseChunkTimeRangeValue(c.encoded, nil)
+		chunkID, labelValue, err := parseChunkTimeRangeValue(c.encoded, nil)
 		require.NoError(t, err)
 		assert.Equal(t, model.LabelValue(c.value), labelValue)
 		assert.Equal(t, c.chunkID, chunkID)


### PR DESCRIPTION
This uses a buffer pool for when we parse the chunk time range value.

```
❯ benchcmp before.txt after.txt
benchmark                                      old ns/op     new ns/op     delta
BenchmarkParseIndexEntries500-16               265343        232446        -12.40%
BenchmarkParseIndexEntries2500-16              1393835       1232639       -11.56%
BenchmarkParseIndexEntries10000-16             5741372       5032199       -12.35%
BenchmarkParseIndexEntries50000-16             30158888      27272835      -9.57%
BenchmarkParseIndexEntriesRegexSet500-16       79101         50394         -36.29%
BenchmarkParseIndexEntriesRegexSet2500-16      386920        246015        -36.42%
BenchmarkParseIndexEntriesRegexSet10000-16     1570068       957154        -39.04%
BenchmarkParseIndexEntriesRegexSet50000-16     7445006       4757111       -36.10%

benchmark                                      old allocs     new allocs     delta
BenchmarkParseIndexEntries500-16               1504           1004           -33.24%
BenchmarkParseIndexEntries2500-16              7504           5004           -33.32%
BenchmarkParseIndexEntries10000-16             30006          20005          -33.33%
BenchmarkParseIndexEntries50000-16             150008         100007         -33.33%
BenchmarkParseIndexEntriesRegexSet500-16       1522           1022           -32.85%
BenchmarkParseIndexEntriesRegexSet2500-16      7522           5022           -33.24%
BenchmarkParseIndexEntriesRegexSet10000-16     30022          20022          -33.31%
BenchmarkParseIndexEntriesRegexSet50000-16     150022         100022         -33.33%

benchmark                                      old bytes     new bytes     delta
BenchmarkParseIndexEntries500-16               96397         32365         -66.43%
BenchmarkParseIndexEntries2500-16              482307        162164        -66.38%
BenchmarkParseIndexEntries10000-16             1928766       648454        -66.38%
BenchmarkParseIndexEntries50000-16             9608702       3207322       -66.62%
BenchmarkParseIndexEntriesRegexSet500-16       88665         24689         -72.15%
BenchmarkParseIndexEntriesRegexSet2500-16      441471        121573        -72.46%
BenchmarkParseIndexEntriesRegexSet10000-16     1764370       484644        -72.53%
BenchmarkParseIndexEntriesRegexSet50000-16     8803429       2404042       -72.69%
```

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

