### PR TITLE
Safely check pointer in aws client before using them.

### DIFF
--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -317,11 +317,14 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix, delimiter string) ([]
 					commonPrefixes = append(commonPrefixes, chunk.StorageCommonPrefix(aws.StringValue(commonPrefix.Prefix)))
 				}
 
-				if !*output.IsTruncated {
+				if output.IsTruncated == nil || !*output.IsTruncated {
 					// No more results to fetch
 					break
 				}
-
+				if output.NextContinuationToken == nil {
+					// No way to continue
+					break
+				}
 				input.SetContinuationToken(*output.NextContinuationToken)
 			}
 


### PR DESCRIPTION
It seems that some client might not returns those properties.

see  https://github.com/grafana/loki/issues/2912

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
