### PR TITLE
Fixed false counters resets for aggregated metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452
+* [BUGFIX] Fixed float64 precision stability when aggregating metrics before exposing them. This could have lead to false counters resets when querying some metrics exposed by Cortex. #3506
 
 ## Blocksconvert
 

--- a/pkg/compactor/syncer_metrics.go
+++ b/pkg/compactor/syncer_metrics.go
@@ -99,7 +99,7 @@ func (m *syncerMetrics) gatherThanosSyncerMetrics(reg *prometheus.Registry) {
 		return
 	}
 
-	mfm, err := util.NewMetricFamilyMap(mf)
+	mfm, err := util.NewUserMetricFamilies("", mf)
 	if err != nil {
 		level.Warn(util.Logger).Log("msg", "failed to gather metrics from syncer registry after compaction", "err", err)
 		return

--- a/pkg/compactor/syncer_metrics.go
+++ b/pkg/compactor/syncer_metrics.go
@@ -99,7 +99,7 @@ func (m *syncerMetrics) gatherThanosSyncerMetrics(reg *prometheus.Registry) {
 		return
 	}
 
-	mfm, err := util.NewUserMetricFamilies("", mf)
+	mfm, err := util.NewUserMetricFamilies(mf)
 	if err != nil {
 		level.Warn(util.Logger).Log("msg", "failed to gather metrics from syncer registry after compaction", "err", err)
 		return

--- a/pkg/compactor/syncer_metrics.go
+++ b/pkg/compactor/syncer_metrics.go
@@ -99,7 +99,7 @@ func (m *syncerMetrics) gatherThanosSyncerMetrics(reg *prometheus.Registry) {
 		return
 	}
 
-	mfm, err := util.NewUserMetricFamilies(mf)
+	mfm, err := util.NewMetricFamilyMap(mf)
 	if err != nil {
 		level.Warn(util.Logger).Log("msg", "failed to gather metrics from syncer registry after compaction", "err", err)
 		return

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -1,8 +1,6 @@
 package ingester
 
 import (
-	"sync"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -256,13 +254,12 @@ type tsdbMetrics struct {
 	memSeriesCreatedTotal *prometheus.Desc
 	memSeriesRemovedTotal *prometheus.Desc
 
-	regsMu sync.RWMutex                    // custom mutex for shipper registry, to avoid blocking main user state mutex on collection
-	regs   map[string]*prometheus.Registry // One prometheus registry per tenant
+	regs *util.UserRegistries
 }
 
 func newTSDBMetrics(r prometheus.Registerer) *tsdbMetrics {
 	m := &tsdbMetrics{
-		regs: make(map[string]*prometheus.Registry),
+		regs: util.NewUserRegistries(),
 
 		dirSyncs: prometheus.NewDesc(
 			"cortex_ingester_shipper_dir_syncs_total",
@@ -419,7 +416,7 @@ func (sm *tsdbMetrics) Describe(out chan<- *prometheus.Desc) {
 }
 
 func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
-	data := util.BuildMetricFamiliesPerUserFromUserRegistries(sm.registries())
+	data := sm.regs.BuildMetricFamiliesPerUser()
 
 	// OK, we have it all. Let's build results.
 	data.SendSumOfCounters(out, sm.dirSyncs, "thanos_shipper_dir_syncs_total")
@@ -455,20 +452,6 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCountersPerUser(out, sm.memSeriesRemovedTotal, "prometheus_tsdb_head_series_removed_total")
 }
 
-// make a copy of the map, so that metrics can be gathered while the new registry is being added.
-func (sm *tsdbMetrics) registries() map[string]*prometheus.Registry {
-	sm.regsMu.RLock()
-	defer sm.regsMu.RUnlock()
-
-	regs := make(map[string]*prometheus.Registry, len(sm.regs))
-	for u, r := range sm.regs {
-		regs[u] = r
-	}
-	return regs
-}
-
 func (sm *tsdbMetrics) setRegistryForUser(userID string, registry *prometheus.Registry) {
-	sm.regsMu.Lock()
-	sm.regs[userID] = registry
-	sm.regsMu.Unlock()
+	sm.regs.AddUserRegistry(userID, registry)
 }

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -109,7 +109,7 @@ func (r *DefaultMultiTenantManager) SyncRuleGroups(ctx context.Context, ruleGrou
 			r.lastReloadSuccessful.DeleteLabelValues(userID)
 			r.lastReloadSuccessfulTimestamp.DeleteLabelValues(userID)
 			r.configUpdatesTotal.DeleteLabelValues(userID)
-			r.userManagerMetrics.DeleteUserRegistry(userID)
+			r.userManagerMetrics.RemoveUserRegistry(userID)
 			level.Info(r.logger).Log("msg", "deleting rule manager", "user", userID)
 		}
 	}

--- a/pkg/ruler/manager_metrics.go
+++ b/pkg/ruler/manager_metrics.go
@@ -1,8 +1,6 @@
 package ruler
 
 import (
-	"sync"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cortexproject/cortex/pkg/util"
@@ -11,9 +9,7 @@ import (
 // ManagerMetrics aggregates metrics exported by the Prometheus
 // rules package and returns them as Cortex metrics
 type ManagerMetrics struct {
-	// Maps userID -> registry
-	regsMu sync.Mutex
-	regs   map[string]*prometheus.Registry
+	regs *util.UserRegistries
 
 	EvalDuration        *prometheus.Desc
 	IterationDuration   *prometheus.Desc
@@ -30,8 +26,7 @@ type ManagerMetrics struct {
 // NewManagerMetrics returns a ManagerMetrics struct
 func NewManagerMetrics() *ManagerMetrics {
 	return &ManagerMetrics{
-		regs:   map[string]*prometheus.Registry{},
-		regsMu: sync.Mutex{},
+		regs: util.NewUserRegistries(),
 
 		EvalDuration: prometheus.NewDesc(
 			"cortex_prometheus_rule_evaluation_duration_seconds",
@@ -96,33 +91,14 @@ func NewManagerMetrics() *ManagerMetrics {
 	}
 }
 
-// AddUserRegistry adds a Prometheus registry to the struct
+// AddUserRegistry adds a user-specific Prometheus registry.
 func (m *ManagerMetrics) AddUserRegistry(user string, reg *prometheus.Registry) {
-	m.regsMu.Lock()
-	defer m.regsMu.Unlock()
-
-	m.regs[user] = reg
+	m.regs.AddUserRegistry(user, reg)
 }
 
-// DeleteUserRegistry removes user-specific Prometheus registry.
-func (m *ManagerMetrics) DeleteUserRegistry(user string) {
-	m.regsMu.Lock()
-	defer m.regsMu.Unlock()
-
-	delete(m.regs, user)
-}
-
-// Registries returns a map of prometheus registries managed by the struct
-func (m *ManagerMetrics) Registries() map[string]*prometheus.Registry {
-	regs := map[string]*prometheus.Registry{}
-
-	m.regsMu.Lock()
-	defer m.regsMu.Unlock()
-	for uid, r := range m.regs {
-		regs[uid] = r
-	}
-
-	return regs
+// RemoveUserRegistry removes user-specific Prometheus registry.
+func (m *ManagerMetrics) RemoveUserRegistry(user string) {
+	m.regs.RemoveUserRegistry(user)
 }
 
 // Describe implements the Collector interface
@@ -141,10 +117,10 @@ func (m *ManagerMetrics) Describe(out chan<- *prometheus.Desc) {
 
 // Collect implements the Collector interface
 func (m *ManagerMetrics) Collect(out chan<- prometheus.Metric) {
-	data := util.BuildMetricFamiliesPerUserFromUserRegistries(m.Registries())
+	data := m.regs.BuildMetricFamiliesPerUser()
 
 	// WARNING: It is important that all metrics generated in this method are "Per User".
-	// Thanks to that we can actually *remove* metrics for given user (see DeleteUserRegistry).
+	// Thanks to that we can actually *remove* metrics for given user (see RemoveUserRegistry).
 	// If same user is later re-added, all metrics will start from 0, which is fine.
 
 	data.SendSumOfSummariesPerUser(out, m.EvalDuration, "prometheus_rule_evaluation_duration_seconds")

--- a/pkg/ruler/manager_metrics_test.go
+++ b/pkg/ruler/manager_metrics_test.go
@@ -22,7 +22,7 @@ func TestManagerMetrics(t *testing.T) {
 	managerMetrics.AddUserRegistry("user3", populateManager(100))
 
 	managerMetrics.AddUserRegistry("user4", populateManager(1000))
-	managerMetrics.DeleteUserRegistry("user4")
+	managerMetrics.RemoveUserRegistry("user4")
 
 	//noinspection ALL
 	err := testutil.GatherAndCompare(mainReg, bytes.NewBufferString(`

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -301,7 +301,7 @@ func TestStoreGateway_BlocksSharding(t *testing.T) {
 			// Start the configure number of gateways.
 			var gateways []*StoreGateway
 			var gatewayIds []string
-			registries := map[string]*prometheus.Registry{}
+			registries := util.NewUserRegistries()
 
 			for i := 1; i <= testData.numGateways; i++ {
 				instanceID := fmt.Sprintf("gateway-%d", i)
@@ -333,7 +333,7 @@ func TestStoreGateway_BlocksSharding(t *testing.T) {
 
 				gateways = append(gateways, g)
 				gatewayIds = append(gatewayIds, instanceID)
-				registries[instanceID] = reg
+				registries.AddUserRegistry(instanceID, reg)
 			}
 
 			// Wait until the ring client of each gateway has synced (to avoid flaky tests on subsequent assertions).
@@ -356,7 +356,7 @@ func TestStoreGateway_BlocksSharding(t *testing.T) {
 			}
 
 			// Assert on the number of blocks loaded extracting this information from metrics.
-			metrics := util.BuildMetricFamiliesPerUserFromUserRegistries(registries)
+			metrics := registries.BuildMetricFamiliesPerUser()
 			assert.Equal(t, float64(testData.expectedBlocksLoaded), metrics.GetSumOfGauges("cortex_bucket_store_blocks_loaded"))
 			assert.Equal(t, float64(2*testData.numGateways), metrics.GetSumOfGauges("cortex_bucket_stores_tenants_discovered"))
 
@@ -550,7 +550,9 @@ func TestStoreGateway_SyncOnRingTopologyChanged(t *testing.T) {
 			defer services.StopAndAwaitTerminated(ctx, g) //nolint:errcheck
 
 			// Assert on the initial state.
-			metrics := util.BuildMetricFamiliesPerUserFromUserRegistries(map[string]*prometheus.Registry{"test": reg})
+			regs := util.NewUserRegistries()
+			regs.AddUserRegistry("test", reg)
+			metrics := regs.BuildMetricFamiliesPerUser()
 			assert.Equal(t, float64(1), metrics.GetSumOfCounters("cortex_storegateway_bucket_sync_total"))
 
 			// Change the ring topology.
@@ -563,14 +565,14 @@ func TestStoreGateway_SyncOnRingTopologyChanged(t *testing.T) {
 			// Assert whether the sync triggered or not.
 			if testData.expectedSync {
 				test.Poll(t, time.Second, float64(2), func() interface{} {
-					metrics := util.BuildMetricFamiliesPerUserFromUserRegistries(map[string]*prometheus.Registry{"test": reg})
+					metrics := regs.BuildMetricFamiliesPerUser()
 					return metrics.GetSumOfCounters("cortex_storegateway_bucket_sync_total")
 				})
 			} else {
 				// Give some time to the store-gateway to trigger the sync (if any).
 				time.Sleep(250 * time.Millisecond)
 
-				metrics := util.BuildMetricFamiliesPerUserFromUserRegistries(map[string]*prometheus.Registry{"test": reg})
+				metrics := regs.BuildMetricFamiliesPerUser()
 				assert.Equal(t, float64(1), metrics.GetSumOfCounters("cortex_storegateway_bucket_sync_total"))
 			}
 		})

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -540,9 +540,7 @@ func (r *UserRegistries) Registries() []UserRegistry {
 	defer r.regsMu.Unlock()
 
 	copy := make([]UserRegistry, 0, len(r.regs))
-	for _, reg := range r.regs {
-		copy = append(copy, reg)
-	}
+	copy = append(copy, r.regs...)
 
 	return copy
 }

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -49,10 +49,10 @@ func (m singleValueWithLabelsMap) WriteToMetricChannel(out chan<- prometheus.Met
 // Keeping map of metric name to its family makes it easier to do searches later.
 type MetricFamilyMap map[string]*dto.MetricFamily
 
-// NewUserMetricFamilies sorts output from Gatherer.Gather method into a map.
+// NewMetricFamilyMap sorts output from Gatherer.Gather method into a map.
 // Gatherer.Gather specifies that there metric families are uniquely named, and we use that fact here.
 // If they are not, this method returns error.
-func NewUserMetricFamilies(metrics []*dto.MetricFamily) (MetricFamilyMap, error) {
+func NewMetricFamilyMap(metrics []*dto.MetricFamily) (MetricFamilyMap, error) {
 	perMetricName := MetricFamilyMap{}
 
 	for _, m := range metrics {
@@ -549,7 +549,7 @@ func (r *UserRegistries) BuildMetricFamiliesPerUser() MetricFamiliesPerUser {
 		m, err := entry.reg.Gather()
 		if err == nil {
 			var mfm MetricFamilyMap // := would shadow err from outer block, and single err check will not work
-			mfm, err = NewUserMetricFamilies(m)
+			mfm, err = NewMetricFamilyMap(m)
 			if err == nil {
 				data = append(data, struct {
 					user    string


### PR DESCRIPTION
**What this PR does**:
I'm testing a cluster with 3K tenants per ingester and I've noticed some wrong query results when querying some of such cluster metrics. The problem is that when we internally aggregate multiple registry metrics, the order with which such values are summed is not stable and this could lead to slightly different values returned by `/metrics` which are then detected as counter resets (eg. 1st scrape from `/metrics` returns a metric with value `13304.675369502014` then 2nd scrape returns the same metric with value `13304.67536950197` even if internally the value hasn't changed).

The fix done in this PR is basically switching from `map` to `[]` (iteration order stability is not guaranteed for maps). The remaining `map` usage in `pkg/util/metrics_helper.go` should be safe.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
