### PR TITLE
Query frontend with scheduler fixes

### DIFF
--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -321,7 +321,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: cortex
-    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18013 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=querier -server.http-listen-port=8013 -server.grpc-listen-port=9013 -querier.scheduler-address=query-scheduler:9011 -log.level=debug"]
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18013 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=querier -server.http-listen-port=8013 -server.grpc-listen-port=9013 -querier.scheduler-address=query-scheduler:9011 -querier.frontend-address= -log.level=debug"]
     depends_on:
       - consul
       - minio

--- a/development/tsdb-blocks-storage-s3/goland/TSDB Query-frontend (using scheduler).run.xml
+++ b/development/tsdb-blocks-storage-s3/goland/TSDB Query-frontend (using scheduler).run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Query-frontend (using scheduler)" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18012">
+    <option name="disconnectOption" value="ASK" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/development/tsdb-blocks-storage-s3/goland/TSDB Query-scheduler.run.xml
+++ b/development/tsdb-blocks-storage-s3/goland/TSDB Query-scheduler.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Query-scheduler" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18011">
+    <option name="disconnectOption" value="ASK" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/pkg/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/frontend/v2/frontend_scheduler_worker.go
@@ -237,7 +237,7 @@ func (w *frontendSchedulerWorker) schedulerLoop(loop schedulerpb.SchedulerForFro
 		if err != nil {
 			return err
 		}
-		return errors.Errorf("unexpected status received: %v", resp.Status)
+		return errors.Errorf("unexpected status received for init: %v", resp.Status)
 	}
 
 	ctx := loop.Context()
@@ -308,10 +308,14 @@ func (w *frontendSchedulerWorker) schedulerLoop(loop schedulerpb.SchedulerForFro
 				return err
 			}
 
-			// Not interested in cancellation response.
-			_, err = loop.Recv()
+			resp, err := loop.Recv()
 			if err != nil {
 				return err
+			}
+
+			// Scheduler may be shutting down, report that.
+			if resp.Status != schedulerpb.OK {
+				return errors.Errorf("unexpected status received for cancellation: %v", resp.Status)
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does**: Small fixes to query-frontend code:
- use context from the stream, not just worker context (in practice, it doesn't make a difference – it doesn't detect closed connection to the scheduler earlier)
- check for returned status when forwarding cancellation request
- fix docker-compose config for querier-with-scheduler
- added GoLand launch configs for querier-scheduler and query-frontend-with-scheduler

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
