### PR TITLE
Added missing requires_docker tag to zone_aware_test.go

### DIFF
--- a/integration/zone_aware_test.go
+++ b/integration/zone_aware_test.go
@@ -1,3 +1,5 @@
+// +build requires_docker
+
 package integration
 
 import (


### PR DESCRIPTION
**What this PR does**: Fixes zone_aware_test.go, to make it an integration test, and skip when running `go test ./...`.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
