### PR TITLE
Improve delete index query signature.

### DIFF
--- a/pkg/chunk/purger/delete_requests_store.go
+++ b/pkg/chunk/purger/delete_requests_store.go
@@ -142,21 +142,29 @@ func (ds *DeleteStore) addDeleteRequest(ctx context.Context, userID string, crea
 
 // GetDeleteRequestsByStatus returns all delete requests for given status.
 func (ds *DeleteStore) GetDeleteRequestsByStatus(ctx context.Context, status DeleteRequestStatus) ([]DeleteRequest, error) {
-	return ds.queryDeleteRequests(ctx, []chunk.IndexQuery{
-		{TableName: ds.cfg.RequestsTableName, HashValue: string(deleteRequestID), ValueEqual: []byte(status)}})
+	return ds.queryDeleteRequests(ctx, chunk.IndexQuery{
+		TableName:  ds.cfg.RequestsTableName,
+		HashValue:  string(deleteRequestID),
+		ValueEqual: []byte(status),
+	})
 }
 
 // GetDeleteRequestsForUserByStatus returns all delete requests for a user with given status.
 func (ds *DeleteStore) GetDeleteRequestsForUserByStatus(ctx context.Context, userID string, status DeleteRequestStatus) ([]DeleteRequest, error) {
-	return ds.queryDeleteRequests(ctx, []chunk.IndexQuery{
-		{TableName: ds.cfg.RequestsTableName, HashValue: string(deleteRequestID), RangeValuePrefix: []byte(userID), ValueEqual: []byte(status)},
+	return ds.queryDeleteRequests(ctx, chunk.IndexQuery{
+		TableName:        ds.cfg.RequestsTableName,
+		HashValue:        string(deleteRequestID),
+		RangeValuePrefix: []byte(userID),
+		ValueEqual:       []byte(status),
 	})
 }
 
 // GetAllDeleteRequestsForUser returns all delete requests for a user.
 func (ds *DeleteStore) GetAllDeleteRequestsForUser(ctx context.Context, userID string) ([]DeleteRequest, error) {
-	return ds.queryDeleteRequests(ctx, []chunk.IndexQuery{
-		{TableName: ds.cfg.RequestsTableName, HashValue: string(deleteRequestID), RangeValuePrefix: []byte(userID)},
+	return ds.queryDeleteRequests(ctx, chunk.IndexQuery{
+		TableName:        ds.cfg.RequestsTableName,
+		HashValue:        string(deleteRequestID),
+		RangeValuePrefix: []byte(userID),
 	})
 }
 
@@ -180,8 +188,10 @@ func (ds *DeleteStore) UpdateStatus(ctx context.Context, userID, requestID strin
 func (ds *DeleteStore) GetDeleteRequest(ctx context.Context, userID, requestID string) (*DeleteRequest, error) {
 	userIDAndRequestID := fmt.Sprintf("%s:%s", userID, requestID)
 
-	deleteRequests, err := ds.queryDeleteRequests(ctx, []chunk.IndexQuery{
-		{TableName: ds.cfg.RequestsTableName, HashValue: string(deleteRequestID), RangeValuePrefix: []byte(userIDAndRequestID)},
+	deleteRequests, err := ds.queryDeleteRequests(ctx, chunk.IndexQuery{
+		TableName:        ds.cfg.RequestsTableName,
+		HashValue:        string(deleteRequestID),
+		RangeValuePrefix: []byte(userIDAndRequestID),
 	})
 
 	if err != nil {
@@ -210,9 +220,9 @@ func (ds *DeleteStore) GetPendingDeleteRequestsForUser(ctx context.Context, user
 	return pendingDeleteRequests, nil
 }
 
-func (ds *DeleteStore) queryDeleteRequests(ctx context.Context, deleteQuery []chunk.IndexQuery) ([]DeleteRequest, error) {
+func (ds *DeleteStore) queryDeleteRequests(ctx context.Context, deleteQuery chunk.IndexQuery) ([]DeleteRequest, error) {
 	deleteRequests := []DeleteRequest{}
-	err := ds.indexClient.QueryPages(ctx, deleteQuery, func(query chunk.IndexQuery, batch chunk.ReadBatch) (shouldContinue bool) {
+	err := ds.indexClient.QueryPages(ctx, []chunk.IndexQuery{deleteQuery}, func(query chunk.IndexQuery, batch chunk.ReadBatch) (shouldContinue bool) {
 		itr := batch.Iterator()
 		for itr.Next() {
 			userID, requestID := splitUserIDAndRequestID(string(itr.RangeValue()))

--- a/pkg/chunk/purger/delete_requests_store.go
+++ b/pkg/chunk/purger/delete_requests_store.go
@@ -222,6 +222,7 @@ func (ds *DeleteStore) GetPendingDeleteRequestsForUser(ctx context.Context, user
 
 func (ds *DeleteStore) queryDeleteRequests(ctx context.Context, deleteQuery chunk.IndexQuery) ([]DeleteRequest, error) {
 	deleteRequests := []DeleteRequest{}
+	// No need to lock inside the callback since we run a single index query.
 	err := ds.indexClient.QueryPages(ctx, []chunk.IndexQuery{deleteQuery}, func(query chunk.IndexQuery, batch chunk.ReadBatch) (shouldContinue bool) {
 		itr := batch.Iterator()
 		for itr.Next() {


### PR DESCRIPTION
At first I thought `queryDeleteRequests` was creating a race because it can be called with multiple index query and querypage from the index client can run in parallel.

However then I realized that it is always used with a single query and so it will always run sequentially.

So I changed the signature to make sure we never use this with multiple queries in the future.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>