### PR TITLE
Refactored do not unregister ingester on shutdown option

### DIFF
--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -220,7 +220,7 @@ GET,POST /ingester/shutdown
 GET,POST /shutdown
 ```
 
-Flushes in-memory time series data from ingester to the long-term storage, and shuts down the ingester service. Notice that the other Cortex services are still running, and the operator (or any automation) is expected to terminate the process with a `SIGINT` / `SIGTERM` signal after the shutdown endpoint returns. In the meantime, `/ready` will not return 200. This endpoint will unregister the ingester from the ring even if `-ingester.unregister-from-ring` is disabled.
+Flushes in-memory time series data from ingester to the long-term storage, and shuts down the ingester service. Notice that the other Cortex services are still running, and the operator (or any automation) is expected to terminate the process with a `SIGINT` / `SIGTERM` signal after the shutdown endpoint returns. In the meantime, `/ready` will not return 200. This endpoint will unregister the ingester from the ring even if `-ingester.unregister-on-shutdown` is disabled.
 
 _This API endpoint is usually used by scale down automations._
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -622,7 +622,7 @@ lifecycler:
 
     # Try writing to an additional ingester in the presence of an ingester not
     # in the ACTIVE state. It is useful to disable this along with
-    # -ingester.unregister-from-ring=false in order to not spread samples to
+    # -ingester.unregister-on-shutdown=false in order to not spread samples to
     # extra ingesters during rolling restarts with consistent naming.
     # CLI flag: -distributor.extend-writes
     [extend_writes: <boolean> | default = true]
@@ -670,8 +670,8 @@ lifecycler:
   # Unregister from the ring upon clean shutdown. It can be useful to disable
   # for rolling restarts with consistent naming in conjunction with
   # -distributor.extend-writes=false.
-  # CLI flag: -ingester.unregister-from-ring
-  [unregister_from_ring: <boolean> | default = true]
+  # CLI flag: -ingester.unregister-on-shutdown
+  [unregister_on_shutdown: <boolean> | default = true]
 
 # Number of times to try and transfer chunks before falling back to flushing.
 # Negative value or zero disables hand-over. This feature is supported only by

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -58,3 +58,5 @@ Currently experimental features are:
 - Scalable query-frontend (when using query-scheduler)
 - Querying store for series, labels APIs (`-querier.query-store-for-labels-enabled`)
 - Blocks storage: lazy mmap of block indexes in the store-gateway (`-blocks-storage.bucket-store.index-header-lazy-loading-enabled`)
+- Ingester: do not unregister from ring on shutdown (`-ingester.unregister-on-shutdown=false`)
+- Distributor: do not extend writes on unhealthy ingesters (`-distributor.extend-writes=false`)

--- a/pkg/compactor/compactor_ring.go
+++ b/pkg/compactor/compactor_ring.go
@@ -84,7 +84,7 @@ func (cfg *RingConfig) ToLifecyclerConfig() ring.LifecyclerConfig {
 	lc.Port = cfg.InstancePort
 	lc.ID = cfg.InstanceID
 	lc.InfNames = cfg.InstanceInterfaceNames
-	lc.UnregisterFromRing = true
+	lc.UnregisterOnShutdown = true
 	lc.HeartbeatPeriod = cfg.HeartbeatPeriod
 	lc.ObservePeriod = 0
 	lc.JoinAfter = 0

--- a/pkg/distributor/distributor_ring.go
+++ b/pkg/distributor/distributor_ring.go
@@ -76,7 +76,7 @@ func (cfg *RingConfig) ToLifecyclerConfig() ring.LifecyclerConfig {
 	lc.Port = cfg.InstancePort
 	lc.ID = cfg.InstanceID
 	lc.InfNames = cfg.InstanceInterfaceNames
-	lc.UnregisterFromRing = true
+	lc.UnregisterOnShutdown = true
 	lc.HeartbeatPeriod = cfg.HeartbeatPeriod
 	lc.ObservePeriod = 0
 	lc.NumTokens = 1

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -397,13 +397,13 @@ func (i *Ingester) ShutdownHandler(w http.ResponseWriter, r *http.Request) {
 	i.lifecycler.SetFlushOnShutdown(true)
 
 	// In the case of an HTTP shutdown, we want to unregister no matter what.
-	originalUnregister := i.lifecycler.ShouldUnregisterFromRing()
-	i.lifecycler.SetUnregisterFromRing(true)
+	originalUnregister := i.lifecycler.ShouldUnregisterOnShutdown()
+	i.lifecycler.SetUnregisterOnShutdown(true)
 
 	_ = services.StopAndAwaitTerminated(context.Background(), i)
 	// Set state back to original.
 	i.lifecycler.SetFlushOnShutdown(originalFlush)
-	i.lifecycler.SetUnregisterFromRing(originalUnregister)
+	i.lifecycler.SetUnregisterOnShutdown(originalUnregister)
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -67,7 +67,7 @@ func TestIngesterRestart(t *testing.T) {
 	config := defaultIngesterTestConfig()
 	clientConfig := defaultClientTestConfig()
 	limits := defaultLimitsTestConfig()
-	config.LifecyclerConfig.UnregisterFromRing = false
+	config.LifecyclerConfig.UnregisterOnShutdown = false
 
 	{
 		_, ingester := newTestStore(t, config, clientConfig, limits, nil)
@@ -100,7 +100,7 @@ func TestIngester_ShutdownHandler(t *testing.T) {
 			config := defaultIngesterTestConfig()
 			clientConfig := defaultClientTestConfig()
 			limits := defaultLimitsTestConfig()
-			config.LifecyclerConfig.UnregisterFromRing = unregister
+			config.LifecyclerConfig.UnregisterOnShutdown = unregister
 			_, ingester := newTestStore(t, config, clientConfig, limits, nil)
 
 			// Make sure the ingester has been added to the ring.

--- a/pkg/ring/replication_strategy.go
+++ b/pkg/ring/replication_strategy.go
@@ -21,7 +21,7 @@ type defaultReplicationStrategy struct {
 	ExtendWrites bool
 }
 
-func NewDefaultReplicationStrategy(extendWrites bool) *defaultReplicationStrategy {
+func NewDefaultReplicationStrategy(extendWrites bool) ReplicationStrategy {
 	return &defaultReplicationStrategy{
 		ExtendWrites: extendWrites,
 	}

--- a/pkg/ring/replication_strategy.go
+++ b/pkg/ring/replication_strategy.go
@@ -17,8 +17,14 @@ type ReplicationStrategy interface {
 	ShouldExtendReplicaSet(instance IngesterDesc, op Operation) bool
 }
 
-type DefaultReplicationStrategy struct {
+type defaultReplicationStrategy struct {
 	ExtendWrites bool
+}
+
+func NewDefaultReplicationStrategy(extendWrites bool) *defaultReplicationStrategy {
+	return &defaultReplicationStrategy{
+		ExtendWrites: extendWrites,
+	}
 }
 
 // Filter decides, given the set of ingesters eligible for a key,
@@ -27,7 +33,7 @@ type DefaultReplicationStrategy struct {
 // - Filters out dead ingesters so the one doesn't even try to write to them.
 // - Checks there is enough ingesters for an operation to succeed.
 // The ingesters argument may be overwritten.
-func (s *DefaultReplicationStrategy) Filter(ingesters []IngesterDesc, op Operation, replicationFactor int, heartbeatTimeout time.Duration, zoneAwarenessEnabled bool) ([]IngesterDesc, int, error) {
+func (s *defaultReplicationStrategy) Filter(ingesters []IngesterDesc, op Operation, replicationFactor int, heartbeatTimeout time.Duration, zoneAwarenessEnabled bool) ([]IngesterDesc, int, error) {
 	// We need a response from a quorum of ingesters, which is n/2 + 1.  In the
 	// case of a node joining/leaving, the actual replica set might be bigger
 	// than the replication factor, so use the bigger or the two.
@@ -65,13 +71,13 @@ func (s *DefaultReplicationStrategy) Filter(ingesters []IngesterDesc, op Operati
 	return ingesters, len(ingesters) - minSuccess, nil
 }
 
-func (s *DefaultReplicationStrategy) ShouldExtendReplicaSet(ingester IngesterDesc, op Operation) bool {
+func (s *defaultReplicationStrategy) ShouldExtendReplicaSet(ingester IngesterDesc, op Operation) bool {
 	// We do not want to Write to Ingesters that are not ACTIVE, but we do want
 	// to write the extra replica somewhere.  So we increase the size of the set
 	// of replicas for the key. This means we have to also increase the
 	// size of the replica set for read, but we can read from Leaving ingesters,
 	// so don't skip it in this case.
-	// NB dead ingester will be filtered later by DefaultReplicationStrategy.Filter().
+	// NB dead ingester will be filtered later by defaultReplicationStrategy.Filter().
 	if op == Write {
 		if s.ExtendWrites {
 			return ingester.State != ACTIVE

--- a/pkg/ring/replication_strategy_test.go
+++ b/pkg/ring/replication_strategy_test.go
@@ -90,7 +90,7 @@ func TestRingReplicationStrategy(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
-			strategy := &DefaultReplicationStrategy{}
+			strategy := NewDefaultReplicationStrategy(true)
 			liveIngesters, maxFailure, err := strategy.Filter(ingesters, tc.op, tc.RF, 100*time.Second, false)
 			if tc.ExpectedError == "" {
 				assert.NoError(t, err)

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -127,7 +127,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.HeartbeatTimeout, prefix+"ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which ingesters are skipped for reads/writes.")
 	f.IntVar(&cfg.ReplicationFactor, prefix+"distributor.replication-factor", 3, "The number of ingesters to write to and read from.")
 	f.BoolVar(&cfg.ZoneAwarenessEnabled, prefix+"distributor.zone-awareness-enabled", false, "True to enable the zone-awareness and replicate ingested samples across different availability zones.")
-	f.BoolVar(&cfg.ExtendWrites, prefix+"distributor.extend-writes", true, "Try writing to an additional ingester in the presence of an ingester not in the ACTIVE state. It is useful to disable this along with -ingester.unregister-from-ring=false in order to not spread samples to extra ingesters during rolling restarts with consistent naming.")
+	f.BoolVar(&cfg.ExtendWrites, prefix+"distributor.extend-writes", true, "Try writing to an additional ingester in the presence of an ingester not in the ACTIVE state. It is useful to disable this along with -ingester.unregister-on-shutdown=false in order to not spread samples to extra ingesters during rolling restarts with consistent naming.")
 }
 
 // Ring holds the information about the members of the consistent hash ring.
@@ -180,7 +180,7 @@ func New(cfg Config, name, key string, reg prometheus.Registerer) (*Ring, error)
 		return nil, err
 	}
 
-	return NewWithStoreClientAndStrategy(cfg, name, key, store, &DefaultReplicationStrategy{ExtendWrites: cfg.ExtendWrites})
+	return NewWithStoreClientAndStrategy(cfg, name, key, store, NewDefaultReplicationStrategy(cfg.ExtendWrites))
 }
 
 func NewWithStoreClientAndStrategy(cfg Config, name, key string, store kv.Client, strategy ReplicationStrategy) (*Ring, error) {

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -53,7 +53,7 @@ func benchmarkBatch(b *testing.B, numIngester, numKeys int) {
 	r := Ring{
 		cfg:      cfg,
 		ringDesc: desc,
-		strategy: &DefaultReplicationStrategy{},
+		strategy: NewDefaultReplicationStrategy(true),
 	}
 
 	ctx := context.Background()
@@ -94,7 +94,7 @@ func TestDoBatchZeroIngesters(t *testing.T) {
 	r := Ring{
 		cfg:      Config{},
 		ringDesc: desc,
-		strategy: &DefaultReplicationStrategy{},
+		strategy: NewDefaultReplicationStrategy(true),
 	}
 	require.Error(t, DoBatch(ctx, &r, keys, callback, cleanup))
 }
@@ -199,7 +199,7 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 				ringTokens:       r.getTokens(),
 				ringTokensByZone: r.getTokensByZone(),
 				ringZones:        getZones(r.getTokensByZone()),
-				strategy:         &DefaultReplicationStrategy{},
+				strategy:         NewDefaultReplicationStrategy(true),
 			}
 
 			ingesters := make([]IngesterDesc, 0, len(r.GetIngesters()))
@@ -290,7 +290,7 @@ func TestRing_GetAllHealthy(t *testing.T) {
 				ringTokens:       ringDesc.getTokens(),
 				ringTokensByZone: ringDesc.getTokensByZone(),
 				ringZones:        getZones(ringDesc.getTokensByZone()),
-				strategy:         &DefaultReplicationStrategy{},
+				strategy:         NewDefaultReplicationStrategy(true),
 			}
 
 			set, err := ring.GetAllHealthy(Read)
@@ -400,7 +400,7 @@ func TestRing_GetReplicationSetForOperation(t *testing.T) {
 				ringTokens:       ringDesc.getTokens(),
 				ringTokensByZone: ringDesc.getTokensByZone(),
 				ringZones:        getZones(ringDesc.getTokensByZone()),
-				strategy:         &DefaultReplicationStrategy{},
+				strategy:         NewDefaultReplicationStrategy(true),
 			}
 
 			set, err := ring.GetReplicationSetForOperation(Read)
@@ -717,7 +717,7 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 				ringTokens:       ringDesc.getTokens(),
 				ringTokensByZone: ringDesc.getTokensByZone(),
 				ringZones:        getZones(ringDesc.getTokensByZone()),
-				strategy:         &DefaultReplicationStrategy{},
+				strategy:         NewDefaultReplicationStrategy(true),
 			}
 
 			// Check the replication set has the correct settings
@@ -852,7 +852,7 @@ func TestRing_ShuffleShard(t *testing.T) {
 				ringTokens:       ringDesc.getTokens(),
 				ringTokensByZone: ringDesc.getTokensByZone(),
 				ringZones:        getZones(ringDesc.getTokensByZone()),
-				strategy:         &DefaultReplicationStrategy{},
+				strategy:         NewDefaultReplicationStrategy(true),
 			}
 
 			shardRing := ring.ShuffleShard("tenant-id", testData.shardSize)
@@ -903,7 +903,7 @@ func TestRing_ShuffleShard_Stability(t *testing.T) {
 		ringTokens:       ringDesc.getTokens(),
 		ringTokensByZone: ringDesc.getTokensByZone(),
 		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         &DefaultReplicationStrategy{},
+		strategy:         NewDefaultReplicationStrategy(true),
 	}
 
 	for i := 1; i <= numTenants; i++ {
@@ -970,7 +970,7 @@ func TestRing_ShuffleShard_Shuffling(t *testing.T) {
 		ringTokens:       ringDesc.getTokens(),
 		ringTokensByZone: ringDesc.getTokensByZone(),
 		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         &DefaultReplicationStrategy{},
+		strategy:         NewDefaultReplicationStrategy(true),
 	}
 
 	// Compute the shard for each tenant.
@@ -1068,7 +1068,7 @@ func TestRing_ShuffleShard_Consistency(t *testing.T) {
 				ringTokens:       ringDesc.getTokens(),
 				ringTokensByZone: ringDesc.getTokensByZone(),
 				ringZones:        getZones(ringDesc.getTokensByZone()),
-				strategy:         &DefaultReplicationStrategy{},
+				strategy:         NewDefaultReplicationStrategy(true),
 			}
 
 			// Compute the initial shard for each tenant.
@@ -1130,7 +1130,7 @@ func TestRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
 		ringTokens:       ringDesc.getTokens(),
 		ringTokensByZone: ringDesc.getTokensByZone(),
 		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         &DefaultReplicationStrategy{},
+		strategy:         NewDefaultReplicationStrategy(true),
 	}
 
 	// Get the replication set with shard size = 3.
@@ -1206,7 +1206,7 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 		ringTokens:       ringDesc.getTokens(),
 		ringTokensByZone: ringDesc.getTokensByZone(),
 		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         &DefaultReplicationStrategy{},
+		strategy:         NewDefaultReplicationStrategy(true),
 	}
 
 	// Get the replication set with shard size = 2.
@@ -1463,7 +1463,7 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 				ringTokens:       ringDesc.getTokens(),
 				ringTokensByZone: ringDesc.getTokensByZone(),
 				ringZones:        getZones(ringDesc.getTokensByZone()),
-				strategy:         &DefaultReplicationStrategy{},
+				strategy:         NewDefaultReplicationStrategy(true),
 			}
 
 			// Replay the events on the timeline.
@@ -1525,7 +1525,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 					ringTokens:       ringDesc.getTokens(),
 					ringTokensByZone: ringDesc.getTokensByZone(),
 					ringZones:        getZones(ringDesc.getTokensByZone()),
-					strategy:         &DefaultReplicationStrategy{},
+					strategy:         NewDefaultReplicationStrategy(true),
 				}
 
 				// The simulation starts with the minimum shard size. Random events can later increase it.
@@ -1662,7 +1662,7 @@ func benchmarkShuffleSharding(b *testing.B, numInstances, numZones, shardSize in
 		ringTokens:         ringDesc.getTokens(),
 		ringTokensByZone:   ringDesc.getTokensByZone(),
 		ringZones:          getZones(ringDesc.getTokensByZone()),
-		strategy:           &DefaultReplicationStrategy{},
+		strategy:           NewDefaultReplicationStrategy(true),
 		lastTopologyChange: time.Now(),
 	}
 
@@ -1800,15 +1800,15 @@ func TestRingUpdates(t *testing.T) {
 
 func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecyclerID int, zones int) *Lifecycler {
 	lcCfg := LifecyclerConfig{
-		RingConfig:         cfg,
-		NumTokens:          16,
-		HeartbeatPeriod:    heartbeat,
-		ObservePeriod:      0,
-		JoinAfter:          0,
-		Zone:               fmt.Sprintf("zone-%d", lifecyclerID%zones),
-		Addr:               fmt.Sprintf("addr-%d", lifecyclerID),
-		ID:                 fmt.Sprintf("ingester-%d", lifecyclerID),
-		UnregisterFromRing: true,
+		RingConfig:           cfg,
+		NumTokens:            16,
+		HeartbeatPeriod:      heartbeat,
+		ObservePeriod:        0,
+		JoinAfter:            0,
+		Zone:                 fmt.Sprintf("zone-%d", lifecyclerID%zones),
+		Addr:                 fmt.Sprintf("addr-%d", lifecyclerID),
+		ID:                   fmt.Sprintf("ingester-%d", lifecyclerID),
+		UnregisterOnShutdown: true,
 	}
 
 	lc, err := NewLifecycler(lcCfg, &noopFlushTransferer{}, "test", "test", false, nil)

--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -64,7 +64,7 @@ func TestWaitRingStabilityShouldReturnAsSoonAsMinStabilityIsReachedOnNoChanges(t
 		ringTokens:       ringDesc.getTokens(),
 		ringTokensByZone: ringDesc.getTokensByZone(),
 		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         &DefaultReplicationStrategy{},
+		strategy:         NewDefaultReplicationStrategy(true),
 	}
 
 	startTime := time.Now()
@@ -98,7 +98,7 @@ func TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached(t *testing.
 		ringTokens:       ringDesc.getTokens(),
 		ringTokensByZone: ringDesc.getTokensByZone(),
 		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         &DefaultReplicationStrategy{},
+		strategy:         NewDefaultReplicationStrategy(true),
 	}
 
 	// Add 1 new instance after some time.
@@ -146,7 +146,7 @@ func TestWaitRingStabilityShouldReturnErrorIfMaxWaitingIsReached(t *testing.T) {
 		ringTokens:       ringDesc.getTokens(),
 		ringTokensByZone: ringDesc.getTokensByZone(),
 		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         &DefaultReplicationStrategy{},
+		strategy:         NewDefaultReplicationStrategy(true),
 	}
 
 	// Keep changing the ring.


### PR DESCRIPTION
**What this PR does**:
@csmarchbanks did a great job in #3305 to introduce an option to avoid unregistering ingesters on shutdown. I would like to propose a couple of small changes:

1. Mark it experimental (while we gain some confidence about side effects of it)
2. Rename `-ingester.unregister-from-ring` to `-ingester.unregister-on-shutdown` for better clarity (does it?)
3. Introduce a `NewDefaultReplicationStrategy()` and unexport `defaultReplicationStrategy` to make sure whoever uses it outside the `pkg/ring` package doesn't forget to correctly configure the new `extendWrites` option

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
