### PR TITLE
Scan tenants upfront in the querier.BlocksScanner in order to improve its cacheability

### DIFF
--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -36,7 +36,7 @@ type BlocksCleaner struct {
 	cfg          BlocksCleanerConfig
 	logger       log.Logger
 	bucketClient objstore.Bucket
-	usersScanner *UsersScanner
+	usersScanner *cortex_tsdb.UsersScanner
 
 	// Metrics.
 	runsStarted        prometheus.Counter
@@ -47,7 +47,7 @@ type BlocksCleaner struct {
 	blocksFailedTotal  prometheus.Counter
 }
 
-func NewBlocksCleaner(cfg BlocksCleanerConfig, bucketClient objstore.Bucket, usersScanner *UsersScanner, logger log.Logger, reg prometheus.Registerer) *BlocksCleaner {
+func NewBlocksCleaner(cfg BlocksCleanerConfig, bucketClient objstore.Bucket, usersScanner *cortex_tsdb.UsersScanner, logger log.Logger, reg prometheus.Registerer) *BlocksCleaner {
 	c := &BlocksCleaner{
 		cfg:          cfg,
 		bucketClient: bucketClient,

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 
 	"github.com/cortexproject/cortex/pkg/storage/backend/filesystem"
+	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -77,7 +78,7 @@ func testBlocksCleanerWithConcurrency(t *testing.T, concurrency int) {
 	}
 
 	logger := log.NewNopLogger()
-	scanner := NewUsersScanner(bucketClient, func(_ string) (bool, error) { return true, nil }, logger)
+	scanner := tsdb.NewUsersScanner(bucketClient, tsdb.AllUsers, logger)
 
 	cleaner := NewBlocksCleaner(cfg, bucketClient, scanner, logger, nil)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, cleaner))

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -104,7 +104,7 @@ type Compactor struct {
 	createDependencies func(ctx context.Context) (objstore.Bucket, tsdb.Compactor, compact.Planner, error)
 
 	// Users scanner, used to discover users from the bucket.
-	usersScanner *UsersScanner
+	usersScanner *cortex_tsdb.UsersScanner
 
 	// Blocks cleaner is responsible to hard delete blocks marked for deletion.
 	blocksCleaner *BlocksCleaner
@@ -235,7 +235,7 @@ func (c *Compactor) starting(ctx context.Context) error {
 	}
 
 	// Create the users scanner.
-	c.usersScanner = NewUsersScanner(c.bucketClient, c.ownUser, c.parentLogger)
+	c.usersScanner = cortex_tsdb.NewUsersScanner(c.bucketClient, c.ownUser, c.parentLogger)
 
 	// Initialize the compactors ring if sharding is enabled.
 	if c.compactorCfg.ShardingEnabled {

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -47,6 +47,7 @@ type BlocksScanner struct {
 	logger          log.Logger
 	bucketClient    objstore.Bucket
 	fetchersMetrics *storegateway.MetadataFetcherMetrics
+	usersScanner    *cortex_tsdb.UsersScanner
 
 	// We reuse the metadata fetcher instance for a given tenant both because of performance
 	// reasons (the fetcher keeps a in-memory cache) and being able to collect and group metrics.
@@ -69,6 +70,7 @@ func NewBlocksScanner(cfg BlocksScannerConfig, bucketClient objstore.Bucket, log
 		logger:            logger,
 		bucketClient:      bucketClient,
 		fetchers:          make(map[string]userFetcher),
+		usersScanner:      cortex_tsdb.NewUsersScanner(bucketClient, cortex_tsdb.AllUsers, logger),
 		userMetas:         make(map[string][]*BlockMeta),
 		userMetasLookup:   make(map[string]map[ulid.ULID]*BlockMeta),
 		userDeletionMarks: map[string]map[ulid.ULID]*metadata.DeletionMark{},
@@ -171,6 +173,12 @@ func (d *BlocksScanner) scanBucket(ctx context.Context) (returnErr error) {
 		}
 	}(time.Now())
 
+	// Discover all users first. This helps cacheability of the object store call.
+	userIDs, err := d.usersScanner.ScanUsers(ctx)
+	if err != nil {
+		return err
+	}
+
 	jobsChan := make(chan string)
 	resMx := sync.Mutex{}
 	resMetas := map[string][]*BlockMeta{}
@@ -210,21 +218,16 @@ func (d *BlocksScanner) scanBucket(ctx context.Context) (returnErr error) {
 		}()
 	}
 
-	// Iterate the bucket to discover users.
-	err := d.bucketClient.Iter(ctx, "", func(s string) error {
-		userID := strings.TrimSuffix(s, "/")
+	// Push a job for each user whose blocks need to be discovered.
+	for _, userID := range userIDs {
 		select {
 		case jobsChan <- userID:
-			return nil
+		// Nothing to do.
 		case <-ctx.Done():
-			return ctx.Err()
+			resMx.Lock()
+			resErrs.Add(ctx.Err())
+			resMx.Unlock()
 		}
-	})
-
-	if err != nil {
-		resMx.Lock()
-		resErrs.Add(err)
-		resMx.Unlock()
 	}
 
 	// Wait until all workers completed.

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -219,6 +219,7 @@ func (d *BlocksScanner) scanBucket(ctx context.Context) (returnErr error) {
 	}
 
 	// Push a job for each user whose blocks need to be discovered.
+pushJobsLoop:
 	for _, userID := range userIDs {
 		select {
 		case jobsChan <- userID:
@@ -227,6 +228,7 @@ func (d *BlocksScanner) scanBucket(ctx context.Context) (returnErr error) {
 			resMx.Lock()
 			resErrs.Add(ctx.Err())
 			resMx.Unlock()
+			break pushJobsLoop
 		}
 	}
 

--- a/pkg/querier/blocks_scanner_test.go
+++ b/pkg/querier/blocks_scanner_test.go
@@ -162,7 +162,7 @@ func TestBlocksScanner_StopWhileRunningTheInitialScanOnManyTenants(t *testing.T)
 	time.Sleep(time.Second)
 
 	stopTime := time.Now()
-	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), s))
+	_ = services.StopAndAwaitTerminated(context.Background(), s)
 
 	// Expect to stop before having completed the full sync (which is expected to take
 	// 1s for each tenant due to the delay introduced in the mock).
@@ -200,7 +200,7 @@ func TestBlocksScanner_StopWhileRunningTheInitialScanOnManyBlocks(t *testing.T) 
 	time.Sleep(time.Second)
 
 	stopTime := time.Now()
-	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), s))
+	_ = services.StopAndAwaitTerminated(context.Background(), s)
 
 	// Expect to stop before having completed the full sync (which is expected to take
 	// 1s for each block due to the delay introduced in the mock).

--- a/pkg/storage/tsdb/users_scanner.go
+++ b/pkg/storage/tsdb/users_scanner.go
@@ -1,4 +1,4 @@
-package compactor
+package tsdb
 
 import (
 	"context"
@@ -8,6 +8,12 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/thanos-io/thanos/pkg/objstore"
 )
+
+// AllUsers returns true to each call and should be used whenever the UsersScanner should not filter out
+// any user due to sharding.
+func AllUsers(_ string) (bool, error) {
+	return true, nil
+}
 
 type UsersScanner struct {
 	bucketClient objstore.Bucket

--- a/pkg/storage/tsdb/users_scanner_test.go
+++ b/pkg/storage/tsdb/users_scanner_test.go
@@ -1,4 +1,4 @@
-package compactor
+package tsdb
 
 import (
 	"context"
@@ -8,12 +8,10 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
 )
 
 func TestUsersScanner_ScanUsers_ShouldReturnedOwnedUsersOnly(t *testing.T) {
-	bucketClient := &cortex_tsdb.BucketClientMock{}
+	bucketClient := &BucketClientMock{}
 	bucketClient.MockIter("", []string{"user-1", "user-2", "user-3"}, nil)
 
 	isOwned := func(userID string) (bool, error) {
@@ -30,7 +28,7 @@ func TestUsersScanner_ScanUsers_ShouldReturnedOwnedUsersOnly(t *testing.T) {
 func TestUsersScanner_ScanUsers_ShouldReturnUsersForWhichOwnerCheckFailed(t *testing.T) {
 	expected := []string{"user-1", "user-2"}
 
-	bucketClient := &cortex_tsdb.BucketClientMock{}
+	bucketClient := &BucketClientMock{}
 	bucketClient.MockIter("", expected, nil)
 
 	isOwned := func(userID string) (bool, error) {


### PR DESCRIPTION
**What this PR does**:
A "list objects" API call is called once the iteration is done, but it's cached with the timestamp of when the iteration has started. If the iteration is slow, the caching of the "list objects" API response is not much effective. Similarly to what we already did in other components, I would like to propose to get the full list of tenants upfront in the querier (so that the response will be cached) and then sync each tenant blocks.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
