### PR TITLE
Fixed meta.json sync concurrency config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452
 * [BUGFIX] Fixed float64 precision stability when aggregating metrics before exposing them. This could have lead to false counters resets when querying some metrics exposed by Cortex. #3506
+* [BUGFIX] Querier: the meta.json sync concurrency done when running Cortex with the blocks storage is now controlled by `-blocks-storage.bucket-store.meta-sync-concurrency` instead of the incorrect `-blocks-storage.bucket-store.block-sync-concurrency` (default values are the same). #3531
 
 ## Blocksconvert
 

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -166,7 +166,7 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 	scanner := NewBlocksScanner(BlocksScannerConfig{
 		ScanInterval:             storageCfg.BucketStore.SyncInterval,
 		TenantsConcurrency:       storageCfg.BucketStore.TenantSyncConcurrency,
-		MetasConcurrency:         storageCfg.BucketStore.BlockSyncConcurrency,
+		MetasConcurrency:         storageCfg.BucketStore.MetaSyncConcurrency,
 		CacheDir:                 storageCfg.BucketStore.SyncDir,
 		ConsistencyDelay:         storageCfg.BucketStore.ConsistencyDelay,
 		IgnoreDeletionMarksDelay: storageCfg.BucketStore.IgnoreDeletionMarksDelay,


### PR DESCRIPTION
**What this PR does**:
I just realised the config option used to create the meta syncher was `-blocks-storage.bucket-store.block-sync-concurrency` instead of `-blocks-storage.bucket-store.meta-sync-concurrency`. In this PR I'm fixing it. I do not consider it a real breaking change because defaults are the same.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
