### PR TITLE
Fixed TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached flakyness

### DIFF
--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -80,7 +80,7 @@ func TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached(t *testing.
 	const (
 		minStability     = 3 * time.Second
 		addInstanceAfter = 2 * time.Second
-		maxWaiting       = 10 * time.Second
+		maxWaiting       = 15 * time.Second
 	)
 
 	// Init the ring.
@@ -120,7 +120,8 @@ func TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached(t *testing.
 	require.NoError(t, WaitRingStability(context.Background(), ring, Reporting, minStability, maxWaiting))
 	elapsedTime := time.Since(startTime)
 
-	assert.InDelta(t, minStability+addInstanceAfter, elapsedTime, float64(2*time.Second))
+	assert.GreaterOrEqual(t, elapsedTime.Milliseconds(), (minStability + addInstanceAfter).Milliseconds())
+	assert.LessOrEqual(t, elapsedTime.Milliseconds(), (minStability + addInstanceAfter + 3*time.Second).Milliseconds())
 }
 
 func TestWaitRingStabilityShouldReturnErrorIfMaxWaitingIsReached(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
The test `TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached` is flaky. I added few prints to see why it is and I found out. The output of the prints:

```
=== RUN   TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached
=== PAUSE TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached
=== CONT  TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached
2020-11-23 19:23:00.470076 +0100 CET m=+6.016058520 new check - same state since 1.000763607s
2020-11-23 19:23:01.470597 +0100 CET m=+7.016606163 new check - same state since 2.001311481s
2020-11-23 19:23:01.470643 +0100 CET m=+7.016651378 added new instance
2020-11-23 19:23:02.470561 +0100 CET m=+8.016592519 new check - different state
2020-11-23 19:23:03.469636 +0100 CET m=+9.015686825 new check - same state since 999.087339ms
2020-11-23 19:23:04.470177 +0100 CET m=+10.016243932 new check - same state since 1.999643476s
2020-11-23 19:23:05.469321 +0100 CET m=+11.015401430 new check - same state since 2.998800744s
2020-11-23 19:23:06.470489 +0100 CET m=+12.016579591 new check - same state since 3.999978871s
2020-11-23 19:23:06.470571 +0100 CET m=+12.016662304 stability reached in 7.001390783s
    util_test.go:131:
        	Error Trace:	util_test.go:131
        	Error:      	Max difference between 5s and 7.001390783s allowed is 2e+09, but difference was -2.001390783e+09
        	Test:       	TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached
```

The reason is that, due to when the ticker runs (every 1s), it may take 3 or 4 runs to hit the min stability waiting period of 3s. In the example above, the 1st time runs after sligthly less than 1s and this means we need 4 runs to hit the 3s waiting period.

I modified the test to increase the tolerance (from 2 to 3s) but also not using `assert.InDelta()` in order to ensure the actual time is always >= min waiting time (`InDelta()` wouldn't guarantee it).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
