### PR TITLE
fix panic in inverted index delete operation when expected fp is not present

### DIFF
--- a/pkg/ingester/index/index.go
+++ b/pkg/ingester/index/index.go
@@ -246,7 +246,7 @@ func (shard *indexShard) delete(labels labels.Labels, fp model.Fingerprint) {
 		})
 
 		// see if search didn't find fp which matches the condition which means we don't have to do anything.
-		if j == len(fingerprints.fps) {
+		if j < len(fingerprints.fps) && fingerprints.fps[j] == fp {
 			continue
 		}
 		fingerprints.fps = fingerprints.fps[:j+copy(fingerprints.fps[j:], fingerprints.fps[j+1:])]

--- a/pkg/ingester/index/index.go
+++ b/pkg/ingester/index/index.go
@@ -244,6 +244,11 @@ func (shard *indexShard) delete(labels labels.Labels, fp model.Fingerprint) {
 		j := sort.Search(len(fingerprints.fps), func(i int) bool {
 			return fingerprints.fps[i] >= fp
 		})
+
+		// see if search didn't find fp which matches the condition which means we don't have to do anything.
+		if j == len(fingerprints.fps) {
+			continue
+		}
 		fingerprints.fps = fingerprints.fps[:j+copy(fingerprints.fps[j:], fingerprints.fps[j+1:])]
 
 		if len(fingerprints.fps) == 0 {

--- a/pkg/ingester/index/index.go
+++ b/pkg/ingester/index/index.go
@@ -246,7 +246,7 @@ func (shard *indexShard) delete(labels labels.Labels, fp model.Fingerprint) {
 		})
 
 		// see if search didn't find fp which matches the condition which means we don't have to do anything.
-		if j < len(fingerprints.fps) && fingerprints.fps[j] == fp {
+		if j >= len(fingerprints.fps) || fingerprints.fps[j] != fp {
 			continue
 		}
 		fingerprints.fps = fingerprints.fps[:j+copy(fingerprints.fps[j:], fingerprints.fps[j+1:])]


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
We noticed a panic in one of the Loki ingesters when flushing chunks. The stack trace was 
```
panic: runtime error: slice bounds out of range [3:2]
goroutine 114 [running]:
github.com/cortexproject/cortex/pkg/ingester/index.(*indexShard).delete(0xc004bee870, 0xc005c82340, 0xd, 0xd, 0xdd5778b83ef6a735)
	/src/loki/vendor/github.com/cortexproject/cortex/pkg/ingester/index/index.go:247 +0x4f6
github.com/cortexproject/cortex/pkg/ingester/index.(*InvertedIndex).Delete(0xc00090f540, 0xc005c82340, 0xd, 0xd, 0xdd5778b83ef6a735)
	/src/loki/vendor/github.com/cortexproject/cortex/pkg/ingester/index/index.go:85 +0x85
github.com/grafana/loki/pkg/ingester.(*Ingester).removeFlushedChunks(0xc000701400, 0xc000477040, 0xc01d7fc3c0)
	/src/loki/pkg/ingester/flush.go:305 +0x245
github.com/grafana/loki/pkg/ingester.(*Ingester).sweepInstance(0xc000701400, 0xc000477040, 0x0)
	/src/loki/pkg/ingester/flush.go:159 +0x138
github.com/grafana/loki/pkg/ingester.(*Ingester).sweepUsers(0xc000701400, 0xc00bc9ff00)
	/src/loki/pkg/ingester/flush.go:149 +0x6c
github.com/grafana/loki/pkg/ingester.(*Ingester).loop(0xc000701400)
	/src/loki/pkg/ingester/ingester.go:247 +0xc5
created by github.com/grafana/loki/pkg/ingester.(*Ingester).starting
	/src/loki/pkg/ingester/ingester.go:196 +0x1cf
```
This was due to [sort.Search](https://golang.org/src/sort/search.go?s=2246:2286#L49) not finding the expected fp and returning the length of input slice while the code [here](https://github.com/cortexproject/cortex/blob/master/pkg/ingester/index/index.go#L247) was not checking if search found the element or not. So when the element is not found it was trying to access an element beyond the actual length of the slice.
This code fixes it by checking the response from `sort.Search` to see if it found the element or not.

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
