### PR TITLE
[Querier] Deprecate `-querier.compress-http-responses-deprecated`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 ## master / unreleased
 
-<<<<<<< HEAD
 ## 1.6.0-rc.0 in progress
 
-=======
 * [CHANGE] Query Frontend: deprecate `-querier.compress-http-responses` in favour of `-api.response-compression-enabled`. #3544
->>>>>>> 572de8827 ([Querier] Deprecate `-querier.compress-http-responses`)
 * [CHANGE] Querier: deprecated `-store.max-look-back-period`. You should use `-querier.max-query-lookback` instead. #3452
 * [CHANGE] Blocks storage: increased `-blocks-storage.bucket-store.chunks-cache.attributes-ttl` default from `24h` to `168h` (1 week). #3528
 * [CHANGE] Blocks storage: the config option `-blocks-storage.bucket-store.index-cache.postings-compression-enabled` has been deprecated and postings compression is always enabled. #3538

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## master / unreleased
 
+<<<<<<< HEAD
 ## 1.6.0-rc.0 in progress
 
+=======
+* [CHANGE] Query Frontend: deprecate `-querier.compress-http-responses` in favour of `-api.response-compression-enabled`. #3544
+>>>>>>> 572de8827 ([Querier] Deprecate `-querier.compress-http-responses`)
 * [CHANGE] Querier: deprecated `-store.max-look-back-period`. You should use `-querier.max-query-lookback` instead. #3452
 * [CHANGE] Blocks storage: increased `-blocks-storage.bucket-store.chunks-cache.attributes-ttl` default from `24h` to `168h` (1 week). #3528
 * [CHANGE] Blocks storage: the config option `-blocks-storage.bucket-store.index-cache.postings-compression-enabled` has been deprecated and postings compression is always enabled. #3538

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -967,7 +967,8 @@ grpc_client_config:
 # CLI flag: -frontend.instance-interface-names
 [instance_interface_names: <list of string> | default = [eth0 en0]]
 
-# Compress HTTP responses.
+# This flag is about to be deprecated. Please use
+# -api.response-compression-enabled instead.
 # CLI flag: -querier.compress-http-responses
 [compress_responses: <boolean> | default = false]
 

--- a/pkg/frontend/config.go
+++ b/pkg/frontend/config.go
@@ -21,7 +21,7 @@ type CombinedFrontendConfig struct {
 	FrontendV2 v2.Config               `yaml:",inline"`
 
 	// Deprecated. Replaced with pkg/api/Config.ResponseCompression field.
-	// TODO: To be removed in Cortex 1.7.
+	// TODO: To be removed in Cortex 1.8.
 	CompressResponses bool `yaml:"compress_responses"`
 
 	DownstreamURL string `yaml:"downstream_url"`

--- a/pkg/frontend/config.go
+++ b/pkg/frontend/config.go
@@ -20,8 +20,11 @@ type CombinedFrontendConfig struct {
 	FrontendV1 v1.Config               `yaml:",inline"`
 	FrontendV2 v2.Config               `yaml:",inline"`
 
-	CompressResponses bool   `yaml:"compress_responses"`
-	DownstreamURL     string `yaml:"downstream_url"`
+	// Deprecated. Replaced with pkg/api/Config.ResponseCompression field.
+	// TODO: To be removed in Cortex 1.7.
+	CompressResponses bool `yaml:"compress_responses"`
+
+	DownstreamURL string `yaml:"downstream_url"`
 }
 
 func (cfg *CombinedFrontendConfig) RegisterFlags(f *flag.FlagSet) {
@@ -29,7 +32,8 @@ func (cfg *CombinedFrontendConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.FrontendV1.RegisterFlags(f)
 	cfg.FrontendV2.RegisterFlags(f)
 
-	f.BoolVar(&cfg.CompressResponses, "querier.compress-http-responses", false, "Compress HTTP responses.")
+	f.BoolVar(&cfg.CompressResponses, "querier.compress-http-responses", false, "This flag is about to be deprecated. Please use -api.response-compression-enabled instead.")
+
 	f.StringVar(&cfg.DownstreamURL, "frontend.downstream-url", "", "URL of downstream Prometheus.")
 }
 


### PR DESCRIPTION
**What this PR does**:
Deprecate `-querier.compress-http-responses-deprecated` In favour of `-api.response-compression-enabled` which applies to every other API endpoint we register.

**Which issue(s) this PR fixes**:
A follow up from #3536 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
