### PR TITLE
blocksconvert: Normalize labels from chunks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 * [ENHANCEMENT] Scheduler: ability to ignore users based on regexp, using `-scheduler.ignore-users-regex` flag. #3477
 * [ENHANCEMENT] Builder: Parallelize reading chunks in the final stage of building block. #3470
+* [ENHANCEMENT] Builder: remove duplicate label names from chunk. #3547
 
 ## 1.5.0 / 2020-11-09
 

--- a/tools/blocksconvert/builder/builder.go
+++ b/tools/blocksconvert/builder/builder.go
@@ -363,14 +363,14 @@ func fetchAndBuildSingleSeries(ctx context.Context, fetcher *Fetcher, chunksIds 
 
 	m, err := normalizeLabels(cs[0].Metric)
 	if err != nil {
-		return nil, nil, errors.Errorf("chunk has invalid metrics: %v", cs[0].Metric.String())
+		return nil, nil, errors.Wrapf(err, "chunk has invalid metrics: %v", cs[0].Metric.String())
 	}
 
 	// Verify that all chunks belong to the same series.
 	for _, c := range cs {
 		nm, err := normalizeLabels(c.Metric)
 		if err != nil {
-			return nil, nil, errors.Errorf("chunk has invalid metrics: %v", c.Metric.String())
+			return nil, nil, errors.Wrapf(err, "chunk has invalid metrics: %v", c.Metric.String())
 		}
 		if !labels.Equal(m, nm) {
 			return nil, nil, errors.Errorf("chunks for multiple metrics: %v, %v", m.String(), c.Metric.String())

--- a/tools/blocksconvert/builder/builder.go
+++ b/tools/blocksconvert/builder/builder.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -360,15 +361,93 @@ func fetchAndBuildSingleSeries(ctx context.Context, fetcher *Fetcher, chunksIds 
 		return nil, nil, nil
 	}
 
-	m := cs[0].Metric
+	m, err := normalizeLabels(cs[0].Metric)
+	if err != nil {
+		return nil, nil, errors.Errorf("chunk has invalid metrics: %v", cs[0].Metric.String())
+	}
+
 	// Verify that all chunks belong to the same series.
 	for _, c := range cs {
-		if !labels.Equal(m, c.Metric) {
+		nm, err := normalizeLabels(c.Metric)
+		if err != nil {
+			return nil, nil, errors.Errorf("chunk has invalid metrics: %v", c.Metric.String())
+		}
+		if !labels.Equal(m, nm) {
 			return nil, nil, errors.Errorf("chunks for multiple metrics: %v, %v", m.String(), c.Metric.String())
 		}
 	}
 
 	return m, cs, nil
+}
+
+// Labels are already sorted, but there may be duplicate label names.
+// This method verifies sortedness, and removes duplicate label names (if they have the same value).
+func normalizeLabels(lbls labels.Labels) (labels.Labels, error) {
+	err := checkLabels(lbls)
+	if err == errLabelsNotSorted {
+		sort.Sort(lbls)
+		err = checkLabels(lbls)
+	}
+
+	if err == errDuplicateLabelsSameValue {
+		lbls = removeDuplicateLabels(lbls)
+		err = checkLabels(lbls)
+	}
+
+	return lbls, err
+}
+
+var (
+	errLabelsNotSorted               = errors.New("labels not sorted")
+	errDuplicateLabelsSameValue      = errors.New("duplicate labels, same value")
+	errDuplicateLabelsDifferentValue = errors.New("duplicate labels, different values")
+)
+
+// Returns one of errLabelsNotSorted, errDuplicateLabelsSameValue, errDuplicateLabelsDifferentValue,
+// or nil, if labels are fine.
+func checkLabels(lbls labels.Labels) error {
+	prevName, prevValue := "", ""
+
+	uniqueLabels := true
+	for _, l := range lbls {
+		switch {
+		case l.Name < prevName:
+			return errLabelsNotSorted
+		case l.Name == prevName:
+			if l.Value != prevValue {
+				return errDuplicateLabelsDifferentValue
+			}
+
+			uniqueLabels = false
+		}
+
+		prevName = l.Name
+		prevValue = l.Value
+	}
+
+	if !uniqueLabels {
+		return errDuplicateLabelsSameValue
+	}
+
+	return nil
+}
+
+func removeDuplicateLabels(lbls labels.Labels) labels.Labels {
+	prevName, prevValue := "", ""
+
+	for ix := 0; ix < len(lbls); {
+		l := lbls[ix]
+		if l.Name == prevName && l.Value == prevValue {
+			lbls = append(lbls[:ix], lbls[ix+1:]...)
+			continue
+		}
+
+		prevName = l.Name
+		prevValue = l.Value
+		ix++
+	}
+
+	return lbls
 }
 
 // Finds storage configuration for given day, and builds a client.

--- a/tools/blocksconvert/builder/builder_test.go
+++ b/tools/blocksconvert/builder/builder_test.go
@@ -1,0 +1,62 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeLabels(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input labels.Labels
+
+		expectedOutput labels.Labels
+		expectedError  error
+	}{
+		"good labels": {
+			input:          fromStrings("__name__", "hello", "label1", "world"),
+			expectedOutput: fromStrings("__name__", "hello", "label1", "world"),
+			expectedError:  nil,
+		},
+		"not sorted": {
+			input:          fromStrings("label1", "world", "__name__", "hello"),
+			expectedOutput: fromStrings("__name__", "hello", "label1", "world"),
+			expectedError:  nil,
+		},
+		"duplicate with same value": {
+			input:          fromStrings("__name__", "hello", "label1", "world", "label1", "world"),
+			expectedOutput: fromStrings("__name__", "hello", "label1", "world"),
+			expectedError:  nil,
+		},
+		"not sorted, duplicate with same value": {
+			input:          fromStrings("label1", "world", "__name__", "hello", "label1", "world"),
+			expectedOutput: fromStrings("__name__", "hello", "label1", "world"),
+			expectedError:  nil,
+		},
+		"duplicate with different value": {
+			input:          fromStrings("label1", "world1", "__name__", "hello", "label1", "world2"),
+			expectedOutput: fromStrings("__name__", "hello", "label1", "world1", "label1", "world2"), // sorted
+			expectedError:  errDuplicateLabelsDifferentValue,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			out, err := normalizeLabels(tc.input)
+
+			assert.Equal(t, tc.expectedOutput, out)
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+}
+
+// Similar to labels.FromStrings, but doesn't do sorting.
+func fromStrings(ss ...string) labels.Labels {
+	if len(ss)%2 != 0 {
+		panic("invalid number of strings")
+	}
+	var res labels.Labels
+	for i := 0; i < len(ss); i += 2 {
+		res = append(res, labels.Label{Name: ss[i], Value: ss[i+1]})
+	}
+	return res
+}


### PR DESCRIPTION
**What this PR does**: During conversion of some old data, we have found chunks that have duplicate labels written in them. As long as label values are the same, we can still convert such data.

This PR implements chunks label normalization – makes sure that labels are sorted, and removes duplicate labels. If duplicate labels have different values, it will error out.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
