### PR TITLE
Tenant deletion when using blocks storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
   * `cortex_compactor_tenants_skipped`
   * `cortex_compactor_tenants_processing_succeeded`
   * `cortex_compactor_tenants_processing_failed`
+* [ENHANCEMENT] Added new experimental API endpoints: `POST /purger/delete_tenant` and `GET /purger/delete_tenant_status` for deleting all tenant data. Only works with blocks storage. #3549
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452

--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -56,6 +56,8 @@ For the sake of clarity, in this document we have grouped API endpoints by servi
 | [Delete series](#delete-series) | Purger | `PUT,POST <prometheus-http-prefix>/api/v1/admin/tsdb/delete_series` |
 | [List delete requests](#list-delete-requests) | Purger | `GET <prometheus-http-prefix>/api/v1/admin/tsdb/delete_series` |
 | [Cancel delete request](#cancel-delete-request) | Purger | `PUT,POST <prometheus-http-prefix>/api/v1/admin/tsdb/cancel_delete_request` |
+| [Tenant delete request](#tenant-delete-request) | Purger | `POST /purger/delete_tenant` |
+| [Tenant delete status](#tenant-delete-status) | Purger | `GET /purger/delete_tenant_status` |
 | [Store-gateway ring status](#store-gateway-ring-status) | Store-gateway | `GET /store-gateway/ring` |
 | [Compactor ring status](#compactor-ring-status) | Compactor | `GET /compactor/ring` |
 | [Get rule files](#get-rule-files) | Configs API (deprecated) | `GET /api/prom/configs/rules` |
@@ -737,6 +739,26 @@ Cancel a delete request while the request is still in the grace period (before t
 | URL query parameter | Description |
 | ------------------- | ----------- |
 | `request_id` | Deletion request ID to cancel. Can be obtained by the [List delete requests](#list-delete-requests) endpoint. |
+
+_Requires [authentication](#authentication)._
+
+### Tenant Delete Request
+
+```
+POST /purger/delete_tenant
+```
+
+Request deletion of ALL tenant data. Only works with blocks storage. Experimental.
+
+_Requires [authentication](#authentication)._
+
+### Tenant Delete Status
+
+```
+GET /purger/delete_tenant_status
+```
+
+Returns status of tenant deletion. Output format to be defined. Experimental.
 
 _Requires [authentication](#authentication)._
 

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -61,3 +61,4 @@ Currently experimental features are:
 - Ingester: do not unregister from ring on shutdown (`-ingester.unregister-on-shutdown=false`)
 - Distributor: do not extend writes on unhealthy ingesters (`-distributor.extend-writes=false`)
 - Ingester: close idle TSDB and remove them from local disk (`-blocks-storage.tsdb.close-idle-tsdb-timeout`)
+- Tenant Deletion in Purger, for blocks storage.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -215,10 +215,10 @@ func (a *API) RegisterIngester(i Ingester, pushConfig distributor.Config) {
 	a.RegisterRoute("/push", push.Handler(pushConfig, a.sourceIPs, i.Push), true, "POST") // For testing and debugging.
 }
 
-// RegisterPurger registers the endpoints associated with the Purger/DeleteStore. They do not exactly
+// RegisterChunksPurger registers the endpoints associated with the Purger/DeleteStore. They do not exactly
 // match the Prometheus API but mirror it closely enough to justify their routing under the Prometheus
 // component/
-func (a *API) RegisterPurger(store *purger.DeleteStore, deleteRequestCancelPeriod time.Duration) {
+func (a *API) RegisterChunksPurger(store *purger.DeleteStore, deleteRequestCancelPeriod time.Duration) {
 	deleteRequestHandler := purger.NewDeleteRequestHandler(store, deleteRequestCancelPeriod, prometheus.DefaultRegisterer)
 
 	a.RegisterRoute(a.cfg.PrometheusHTTPPrefix+"/api/v1/admin/tsdb/delete_series", http.HandlerFunc(deleteRequestHandler.AddDeleteRequestHandler), true, "PUT", "POST")
@@ -229,6 +229,11 @@ func (a *API) RegisterPurger(store *purger.DeleteStore, deleteRequestCancelPerio
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/admin/tsdb/delete_series", http.HandlerFunc(deleteRequestHandler.AddDeleteRequestHandler), true, "PUT", "POST")
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/admin/tsdb/delete_series", http.HandlerFunc(deleteRequestHandler.GetAllDeleteRequestsHandler), true, "GET")
 	a.RegisterRoute(a.cfg.LegacyHTTPPrefix+"/api/v1/admin/tsdb/cancel_delete_request", http.HandlerFunc(deleteRequestHandler.CancelDeleteRequestHandler), true, "PUT", "POST")
+}
+
+func (a *API) RegisterBlocksPurger(api *purger.BlocksPurgerAPI) {
+	a.RegisterRoute("/purger/delete_tenant", http.HandlerFunc(api.DeleteTenant), true, "POST")
+	a.RegisterRoute("/purger/delete_tenant_status", http.HandlerFunc(api.DeleteTenantStatus), true, "GET")
 }
 
 // RegisterRuler registers routes associated with the Ruler service.

--- a/pkg/chunk/purger/blocks_purger_api.go
+++ b/pkg/chunk/purger/blocks_purger_api.go
@@ -1,0 +1,121 @@
+package purger
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/thanos-io/thanos/pkg/objstore"
+
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
+	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/tenant"
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+type BlocksPurgerAPI struct {
+	bucketClient objstore.Bucket
+	logger       log.Logger
+}
+
+func NewBlocksPurgerAPI(storageCfg cortex_tsdb.BlocksStorageConfig, logger log.Logger, reg prometheus.Registerer) (*BlocksPurgerAPI, error) {
+	bucketClient, err := createBucketClient(storageCfg, logger, reg)
+	if err != nil {
+		return nil, err
+	}
+
+	return newBlocksPurgerAPI(bucketClient, logger), nil
+}
+
+func newBlocksPurgerAPI(bkt objstore.Bucket, logger log.Logger) *BlocksPurgerAPI {
+	return &BlocksPurgerAPI{bucketClient: bkt, logger: logger}
+}
+
+func (api *BlocksPurgerAPI) DeleteTenant(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	userID, err := tenant.TenantID(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	err = cortex_tsdb.WriteTenantDeletionMark(r.Context(), api.bucketClient, userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	level.Info(api.logger).Log("msg", "tenant deletion marker created", "user", userID)
+
+	w.WriteHeader(http.StatusOK)
+}
+
+type DeleteTenantStatusResponse struct {
+	TenantID                  string `json:"tenant_id"`
+	BlocksDeleted             bool   `json:"blocks_deleted"`
+	RuleGroupsDeleted         bool   `json:"rule_groups_deleted"`
+	AlertManagerConfigDeleted bool   `json:"alert_manager_config_deleted"`
+}
+
+func (api *BlocksPurgerAPI) DeleteTenantStatus(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	userID, err := tenant.TenantID(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	result := DeleteTenantStatusResponse{}
+	result.TenantID = userID
+	result.BlocksDeleted, err = api.checkBlocksForUser(ctx, userID)
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	util.WriteJSONResponse(w, result)
+}
+
+func (api *BlocksPurgerAPI) checkBlocksForUser(ctx context.Context, userID string) (bool, error) {
+	var errBlockFound = errors.New("block found")
+
+	userBucket := bucket.NewUserBucketClient(userID, api.bucketClient)
+	err := userBucket.Iter(ctx, "", func(s string) error {
+		s = strings.TrimSuffix(s, "/")
+
+		_, err := ulid.Parse(s)
+		if err != nil {
+			// not block, keep looking
+			return nil
+		}
+
+		// Used as shortcut to stop iteration.
+		return errBlockFound
+	})
+
+	if errors.Is(err, errBlockFound) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	// No blocks found, all good.
+	return true, nil
+}
+
+func createBucketClient(cfg cortex_tsdb.BlocksStorageConfig, logger log.Logger, reg prometheus.Registerer) (objstore.Bucket, error) {
+	bucketClient, err := bucket.NewClient(context.Background(), cfg.Bucket, "purger", logger, reg)
+	if err != nil {
+		return nil, errors.Wrap(err, "create bucket client")
+	}
+
+	return bucketClient, nil
+}

--- a/pkg/chunk/purger/blocks_purger_api_test.go
+++ b/pkg/chunk/purger/blocks_purger_api_test.go
@@ -1,0 +1,90 @@
+package purger
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/storage/tsdb"
+)
+
+func TestDeleteTenant(t *testing.T) {
+	bkt := objstore.NewInMemBucket()
+	api := newBlocksPurgerAPI(bkt, log.NewNopLogger())
+
+	{
+		resp := httptest.NewRecorder()
+		api.DeleteTenant(resp, &http.Request{})
+		require.Equal(t, http.StatusBadRequest, resp.Code)
+	}
+
+	{
+		ctx := context.Background()
+		ctx = user.InjectOrgID(ctx, "fake")
+
+		req := &http.Request{}
+		resp := httptest.NewRecorder()
+		api.DeleteTenant(resp, req.WithContext(ctx))
+
+		require.Equal(t, http.StatusOK, resp.Code)
+		objs := bkt.Objects()
+		require.NotNil(t, objs[path.Join("fake", tsdb.TenantDeletionMarkPath)])
+	}
+}
+
+func TestDeleteTenantStatus(t *testing.T) {
+	const username = "user"
+
+	for name, tc := range map[string]struct {
+		objects               map[string][]byte
+		expectedBlocksDeleted bool
+	}{
+		"empty": {
+			objects:               nil,
+			expectedBlocksDeleted: true,
+		},
+
+		"no user objects": {
+			objects: map[string][]byte{
+				"different-user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
+			},
+			expectedBlocksDeleted: true,
+		},
+
+		"non-block files": {
+			objects: map[string][]byte{
+				"user/deletion-mark.json": []byte("data"),
+			},
+			expectedBlocksDeleted: true,
+		},
+
+		"block files": {
+			objects: map[string][]byte{
+				"user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
+			},
+			expectedBlocksDeleted: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			bkt := objstore.NewInMemBucket()
+			// "upload" objects
+			for objName, data := range tc.objects {
+				require.NoError(t, bkt.Upload(context.Background(), objName, bytes.NewReader(data)))
+			}
+
+			api := newBlocksPurgerAPI(bkt, log.NewNopLogger())
+
+			res, err := api.checkBlocksForUser(context.Background(), username)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedBlocksDeleted, res)
+		})
+	}
+}

--- a/pkg/chunk/purger/purger.go
+++ b/pkg/chunk/purger/purger.go
@@ -85,7 +85,7 @@ type deleteRequestWithLogger struct {
 	logger log.Logger // logger is initialized with userID and requestID to add context to every log generated using this
 }
 
-// Config holds config for Purger
+// Config holds config for chunks Purger
 type Config struct {
 	Enable                    bool          `yaml:"enable"`
 	NumWorkers                int           `yaml:"num_workers"`
@@ -108,7 +108,7 @@ type workerJob struct {
 	logger          log.Logger
 }
 
-// Purger does the purging of data which is requested to be deleted
+// Purger does the purging of data which is requested to be deleted. Purger only works for chunks.
 type Purger struct {
 	services.Service
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -72,6 +72,8 @@ const (
 	Compactor                string = "compactor"
 	StoreGateway             string = "store-gateway"
 	MemberlistKV             string = "memberlist-kv"
+	ChunksPurger             string = "chunks-purger"
+	BlocksPurger             string = "blocks-purger"
 	Purger                   string = "purger"
 	QueryScheduler           string = "query-scheduler"
 	All                      string = "all"
@@ -437,7 +439,7 @@ func (t *Cortex) initChunkStore() (serv services.Service, err error) {
 }
 
 func (t *Cortex) initDeleteRequestsStore() (serv services.Service, err error) {
-	if !t.Cfg.PurgerConfig.Enable {
+	if t.Cfg.Storage.Engine != storage.StorageEngineChunks || !t.Cfg.PurgerConfig.Enable {
 		// until we need to explicitly enable delete series support we need to do create TombstonesLoader without DeleteStore which acts as noop
 		t.TombstonesLoader = purger.NewTombstonesLoader(nil, nil)
 
@@ -725,8 +727,8 @@ func (t *Cortex) initMemberlistKV() (services.Service, error) {
 	return t.MemberlistKV, nil
 }
 
-func (t *Cortex) initPurger() (services.Service, error) {
-	if !t.Cfg.PurgerConfig.Enable {
+func (t *Cortex) initChunksPurger() (services.Service, error) {
+	if t.Cfg.Storage.Engine != storage.StorageEngineChunks || !t.Cfg.PurgerConfig.Enable {
 		return nil, nil
 	}
 
@@ -740,9 +742,23 @@ func (t *Cortex) initPurger() (services.Service, error) {
 		return nil, err
 	}
 
-	t.API.RegisterPurger(t.DeletesStore, t.Cfg.PurgerConfig.DeleteRequestCancelPeriod)
+	t.API.RegisterChunksPurger(t.DeletesStore, t.Cfg.PurgerConfig.DeleteRequestCancelPeriod)
 
 	return t.Purger, nil
+}
+
+func (t *Cortex) initBlocksPurger() (services.Service, error) {
+	if t.Cfg.Storage.Engine != storage.StorageEngineBlocks {
+		return nil, nil
+	}
+
+	purgerAPI, err := purger.NewBlocksPurgerAPI(t.Cfg.BlocksStorage, util.Logger, prometheus.DefaultRegisterer)
+	if err != nil {
+		return nil, err
+	}
+
+	t.API.RegisterBlocksPurger(purgerAPI)
+	return nil, nil
 }
 
 func (t *Cortex) initQueryScheduler() (services.Service, error) {
@@ -785,7 +801,9 @@ func (t *Cortex) setupModuleManager() error {
 	mm.RegisterModule(AlertManager, t.initAlertManager)
 	mm.RegisterModule(Compactor, t.initCompactor)
 	mm.RegisterModule(StoreGateway, t.initStoreGateway)
-	mm.RegisterModule(Purger, t.initPurger)
+	mm.RegisterModule(ChunksPurger, t.initChunksPurger, modules.UserInvisibleModule)
+	mm.RegisterModule(BlocksPurger, t.initBlocksPurger, modules.UserInvisibleModule)
+	mm.RegisterModule(Purger, nil)
 	mm.RegisterModule(QueryScheduler, t.initQueryScheduler)
 	mm.RegisterModule(All, nil)
 
@@ -812,7 +830,9 @@ func (t *Cortex) setupModuleManager() error {
 		AlertManager:             {API},
 		Compactor:                {API, MemberlistKV},
 		StoreGateway:             {API, Overrides, MemberlistKV},
-		Purger:                   {Store, DeleteRequestsStore, API},
+		ChunksPurger:             {Store, DeleteRequestsStore, API},
+		BlocksPurger:             {Store, API},
+		Purger:                   {ChunksPurger, BlocksPurger},
 		All:                      {QueryFrontend, Querier, Ingester, Distributor, TableManager, Purger, StoreGateway, Ruler},
 	}
 	for mod, targets := range deps {

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -30,6 +30,9 @@ const (
 
 	// How often are open TSDBs checked for being idle and closed.
 	DefaultCloseIdleTSDBInterval = 5 * time.Minute
+
+	// How often to check for tenant deletion mark.
+	DeletionMarkCheckInterval = 1 * time.Hour
 )
 
 // Validation errors

--- a/pkg/storage/tsdb/tenant_deletion_mark.go
+++ b/pkg/storage/tsdb/tenant_deletion_mark.go
@@ -1,0 +1,40 @@
+package tsdb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+// Relative to user-specific prefix.
+const TenantDeletionMarkPath = "markers/tenant-deletion-mark.json"
+
+type TenantDeletionMark struct {
+	// Unix timestamp when deletion marker was created.
+	DeletionTime int64 `json:"deletion_time"`
+}
+
+// Checks for deletion mark for tenant. Errors other than "object not found" are returned.
+func TenantDeletionMarkExists(ctx context.Context, bkt objstore.BucketReader, userID string) (bool, error) {
+	markerFile := path.Join(userID, TenantDeletionMarkPath)
+
+	return bkt.Exists(ctx, markerFile)
+}
+
+// Uploads deletion mark to the tenant "directory".
+func WriteTenantDeletionMark(ctx context.Context, bkt objstore.Bucket, userID string) error {
+	m := &TenantDeletionMark{DeletionTime: time.Now().Unix()}
+
+	data, err := json.Marshal(m)
+	if err != nil {
+		return errors.Wrap(err, "serialize tenant deletion mark")
+	}
+
+	markerFile := path.Join(userID, TenantDeletionMarkPath)
+	return errors.Wrap(bkt.Upload(ctx, markerFile, bytes.NewReader(data)), "upload tenant deletion mark")
+}

--- a/pkg/storage/tsdb/tenant_deletion_mark_test.go
+++ b/pkg/storage/tsdb/tenant_deletion_mark_test.go
@@ -1,0 +1,51 @@
+package tsdb
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+func TestTenantDeletionMarkExists(t *testing.T) {
+	const username = "user"
+
+	for name, tc := range map[string]struct {
+		objects map[string][]byte
+		exists  bool
+	}{
+		"empty": {
+			objects: nil,
+			exists:  false,
+		},
+
+		"mark doesn't exist": {
+			objects: map[string][]byte{
+				"user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
+			},
+			exists: false,
+		},
+
+		"mark exists": {
+			objects: map[string][]byte{
+				"user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
+				"user/" + TenantDeletionMarkPath:            []byte("data"),
+			},
+			exists: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			bkt := objstore.NewInMemBucket()
+			// "upload" objects
+			for objName, data := range tc.objects {
+				require.NoError(t, bkt.Upload(context.Background(), objName, bytes.NewReader(data)))
+			}
+
+			res, err := TenantDeletionMarkExists(context.Background(), bkt, username)
+			require.NoError(t, err)
+			require.Equal(t, tc.exists, res)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**: This PR introduces new API for tenant deletion when using blocks storage. There are two API endpoints: one to trigger tenant deletion (it really only writes mark file with tenant prefix), another one to check for status (= check for blocks).

In this PR ingester checks for tenant deletion mark, and 1) stops shipping blocks for such tenant, and 2) closes TSDB faster (if closing is enabled).

In subsequent PRs, more components will react on deletion mark:
- compactor will clean up blocks in the bucket
- ruler will clean up rule groups, and stop rule evaluation [ruler will use separate marker in its own bucket]
- alertmanager will clean up its per-tenant config and state [alertmanager will use separate marker in its own bucket]

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
