### PR TITLE
Module needs to wait for services from all of its dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452
 * [BUGFIX] Fixed float64 precision stability when aggregating metrics before exposing them. This could have lead to false counters resets when querying some metrics exposed by Cortex. #3506
 * [BUGFIX] Querier: the meta.json sync concurrency done when running Cortex with the blocks storage is now controlled by `-blocks-storage.bucket-store.meta-sync-concurrency` instead of the incorrect `-blocks-storage.bucket-store.block-sync-concurrency` (default values are the same). #3531
+* [BUGFIX] Querier: fixed initialization order of querier module when using blocks storage. It now (again) waits until blocks have been synchronized. #3551 
 
 ## Blocksconvert
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452
 * [BUGFIX] Fixed float64 precision stability when aggregating metrics before exposing them. This could have lead to false counters resets when querying some metrics exposed by Cortex. #3506
 * [BUGFIX] Querier: the meta.json sync concurrency done when running Cortex with the blocks storage is now controlled by `-blocks-storage.bucket-store.meta-sync-concurrency` instead of the incorrect `-blocks-storage.bucket-store.block-sync-concurrency` (default values are the same). #3531
-* [BUGFIX] Querier: fixed initialization order of querier module when using blocks storage. It now (again) waits until blocks have been synchronized. #3551 
+* [BUGFIX] Querier: fixed initialization order of querier module when using blocks storage. It now (again) waits until blocks have been synchronized. #3551
 
 ## Blocksconvert
 

--- a/pkg/util/modules/modules.go
+++ b/pkg/util/modules/modules.go
@@ -108,7 +108,7 @@ func (m *Manager) initModule(name string, initMap map[string]bool, servicesMap m
 			if s != nil {
 				// We pass servicesMap, which isn't yet complete. By the time service starts,
 				// it will be fully built, so there is no need for extra synchronization.
-				serv = newModuleServiceWrapper(servicesMap, n, s, mod.deps, m.findInverseDependencies(n, deps[ix+1:]))
+				serv = newModuleServiceWrapper(servicesMap, n, s, m.DependenciesForModule(n), m.findInverseDependencies(n, deps[ix+1:]))
 			}
 		}
 

--- a/pkg/util/modules/modules_test.go
+++ b/pkg/util/modules/modules_test.go
@@ -1,9 +1,11 @@
 package modules
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -164,4 +166,52 @@ func TestDependenciesForModule(t *testing.T) {
 
 	deps := m.DependenciesForModule("test")
 	assert.Equal(t, []string{"dep1", "dep2", "dep3"}, deps)
+}
+
+func TestModuleInitOrder(t *testing.T) {
+	var serviceA services.Service
+
+	initA := func() (services.Service, error) {
+		serviceA = services.NewIdleService(func(serviceContext context.Context) error {
+			// Slow-starting service. Delay is here to verify that service for C is not started before this service
+			// has finished starting.
+			time.Sleep(1 * time.Second)
+			return nil
+		}, nil)
+
+		return serviceA, nil
+	}
+
+	initC := func() (services.Service, error) {
+		return services.NewIdleService(func(serviceContext context.Context) error {
+			// At this point, serviceA should be Running, because "C" depends (indirectly) on "A".
+			if s := serviceA.State(); s != services.Running {
+				return fmt.Errorf("serviceA has invalid state: %v", s)
+			}
+			return nil
+		}, nil), nil
+	}
+
+	m := NewManager()
+	m.RegisterModule("A", initA)
+	m.RegisterModule("B", nil)
+	m.RegisterModule("C", initC)
+
+	// C -> B -> A. Even though B has no service, C must still wait for service A to start, before C can start.
+	require.NoError(t, m.AddDependency("B", "A"))
+	require.NoError(t, m.AddDependency("C", "B"))
+
+	servsMap, err := m.InitModuleServices("C")
+	require.NoError(t, err)
+
+	// Build service manager from services, and start it.
+	servs := []services.Service(nil)
+	for _, s := range servsMap {
+		servs = append(servs, s)
+	}
+
+	servManager, err := services.NewManager(servs...)
+	require.NoError(t, err)
+	assert.NoError(t, services.StartManagerAndAwaitHealthy(context.Background(), servManager))
+	assert.NoError(t, services.StopManagerAndAwaitStopped(context.Background(), servManager))
 }

--- a/pkg/util/modules/modules_test.go
+++ b/pkg/util/modules/modules_test.go
@@ -168,7 +168,7 @@ func TestDependenciesForModule(t *testing.T) {
 	assert.Equal(t, []string{"dep1", "dep2", "dep3"}, deps)
 }
 
-func TestModuleInitOrder(t *testing.T) {
+func TestModuleWaitsForAllDependencies(t *testing.T) {
 	var serviceA services.Service
 
 	initA := func() (services.Service, error) {


### PR DESCRIPTION
**What this PR does**: This PR fixes initialization order of Cortex internal module services. Recently introduced "queryable" (internal) module broke initialization of "querier", because "queryable" doesn't have any service that "querier" could wait for. But "querier" should really wait for all services that "queryable" depends on. This PR does that.

**Which issue(s) this PR fixes**:
Fixes #3550

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
