### PR TITLE
Close old TSDB faster.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 * [ENHANCEMENT] Blocks storage: enabled caching of `meta.json` attributes, configurable via `-blocks-storage.bucket-store.metadata-cache.metafile-attributes-ttl`. #3528
 * [ENHANCEMENT] Compactor: added a config validation check to fail fast if the compactor has been configured invalid block range periods (each period is expected to be a multiple of the previous one). #3534
 * [ENHANCEMENT] Blocks storage: concurrently fetch deletion marks from object storage. #3538
-* [ENHANCEMENT] Blocks storage ingester: ingester can now close idle TSDB and delete local data. #3491
+* [ENHANCEMENT] Blocks storage ingester: ingester can now close idle TSDB and delete local data. #3491 #3552
 * [ENHANCEMENT] Blocks storage: add option to use V2 signatures for S3 authentication. #3540
 * [ENHANCEMENT] Exported process metrics to monitor the number of memory map areas allocated. #3537
   * - `process_memory_map_areas`

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -18,7 +18,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -1235,7 +1234,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 	if db.Head().NumSeries() > 0 {
 		// If there are series in the head, use max time from head. If this time is too old,
 		// TSDB will be eligible for flushing and closing sooner, unless more data is pushed to it quickly.
-		userDB.setLastUpdate(timestamp.Time(db.Head().MaxTime()))
+		userDB.setLastUpdate(util.TimeFromMillis(db.Head().MaxTime()))
 	} else {
 		// If head is empty (eg. new TSDB), don't close it right after.
 		userDB.setLastUpdate(time.Now())


### PR DESCRIPTION
**What this PR does**: When opening existing TSDB, set last update time of TSDB to oldest timestamp from the head. This will make ingester to flush and close it sooner (unless more data is pushed to TSDB).

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
