### PR TITLE
Tenant deletion: compactor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
   * `cortex_compactor_tenants_skipped`
   * `cortex_compactor_tenants_processing_succeeded`
   * `cortex_compactor_tenants_processing_failed`
-* [ENHANCEMENT] Added new experimental API endpoints: `POST /purger/delete_tenant` and `GET /purger/delete_tenant_status` for deleting all tenant data. Only works with blocks storage. #3549
+* [ENHANCEMENT] Added new experimental API endpoints: `POST /purger/delete_tenant` and `GET /purger/delete_tenant_status` for deleting all tenant data. Only works with blocks storage. Compactor removes blocks that belong to user marked for deletion. #3549 #3558
 * [ENHANCEMENT] Chunks storage: add option to use V2 signatures for S3 authentication. #3560
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -565,11 +565,13 @@ blocks_storage:
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.chunks-list-ttl
       [chunks_list_ttl: <duration> | default = 24h]
 
-      # How long to cache information that block metafile exists.
+      # How long to cache information that block metafile exists. Also used for
+      # user deletion mark file.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.metafile-exists-ttl
       [metafile_exists_ttl: <duration> | default = 2h]
 
-      # How long to cache information that block metafile doesn't exist.
+      # How long to cache information that block metafile doesn't exist. Also
+      # used for user deletion mark file.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.metafile-doesnt-exist-ttl
       [metafile_doesnt_exist_ttl: <duration> | default = 5m]
 

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -615,11 +615,13 @@ blocks_storage:
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.chunks-list-ttl
       [chunks_list_ttl: <duration> | default = 24h]
 
-      # How long to cache information that block metafile exists.
+      # How long to cache information that block metafile exists. Also used for
+      # user deletion mark file.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.metafile-exists-ttl
       [metafile_exists_ttl: <duration> | default = 2h]
 
-      # How long to cache information that block metafile doesn't exist.
+      # How long to cache information that block metafile doesn't exist. Also
+      # used for user deletion mark file.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.metafile-doesnt-exist-ttl
       [metafile_doesnt_exist_ttl: <duration> | default = 5m]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3831,11 +3831,13 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.metadata-cache.chunks-list-ttl
     [chunks_list_ttl: <duration> | default = 24h]
 
-    # How long to cache information that block metafile exists.
+    # How long to cache information that block metafile exists. Also used for
+    # user deletion mark file.
     # CLI flag: -blocks-storage.bucket-store.metadata-cache.metafile-exists-ttl
     [metafile_exists_ttl: <duration> | default = 2h]
 
-    # How long to cache information that block metafile doesn't exist.
+    # How long to cache information that block metafile doesn't exist. Also used
+    # for user deletion mark file.
     # CLI flag: -blocks-storage.bucket-store.metadata-cache.metafile-doesnt-exist-ttl
     [metafile_doesnt_exist_ttl: <duration> | default = 5m]
 

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -130,14 +130,14 @@ func (c *BlocksCleaner) cleanUsers(ctx context.Context) error {
 	allUsers := append(users, deleted...)
 	return concurrency.ForEachUser(ctx, allUsers, c.cfg.CleanupConcurrency, func(ctx context.Context, userID string) error {
 		if isDeleted[userID] {
-			return errors.Wrapf(c.cleanUserCompletely(ctx, userID), "failed to delete blocks for user marked for deletion: %s", userID)
+			return errors.Wrapf(c.deleteUser(ctx, userID), "failed to delete blocks for user marked for deletion: %s", userID)
 		}
 		return errors.Wrapf(c.cleanUser(ctx, userID), "failed to delete blocks for user: %s", userID)
 	})
 }
 
 // Remove all blocks for user marked for deletion.
-func (c *BlocksCleaner) cleanUserCompletely(ctx context.Context, userID string) error {
+func (c *BlocksCleaner) deleteUser(ctx context.Context, userID string) error {
 	userLogger := util.WithUserID(userID, c.logger)
 	userBucket := bucket.NewUserBucketClient(userID, c.bucketClient)
 

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -100,31 +100,84 @@ func (c *BlocksCleaner) ticker(ctx context.Context) error {
 }
 
 func (c *BlocksCleaner) runCleanup(ctx context.Context) {
-	level.Info(c.logger).Log("msg", "started hard deletion of blocks marked for deletion")
+	level.Info(c.logger).Log("msg", "started hard deletion of blocks marked for deletion, and blocks for tenants marked for deletion")
 	c.runsStarted.Inc()
 
 	if err := c.cleanUsers(ctx); err == nil {
-		level.Info(c.logger).Log("msg", "successfully completed hard deletion of blocks marked for deletion")
+		level.Info(c.logger).Log("msg", "successfully completed hard deletion of blocks marked for deletion, and blocks for tenants marked for deletion")
 		c.runsCompleted.Inc()
 		c.runsLastSuccess.SetToCurrentTime()
 	} else if errors.Is(err, context.Canceled) {
-		level.Info(c.logger).Log("msg", "canceled hard deletion of blocks marked for deletion", "err", err)
+		level.Info(c.logger).Log("msg", "canceled hard deletion of blocks marked for deletion, and blocks for tenants marked for deletion", "err", err)
 		return
 	} else {
-		level.Error(c.logger).Log("msg", "failed to hard delete blocks marked for deletion", "err", err.Error())
+		level.Error(c.logger).Log("msg", "failed to hard delete blocks marked for deletion, and blocks for tenants marked for deletion", "err", err.Error())
 		c.runsFailed.Inc()
 	}
 }
 
 func (c *BlocksCleaner) cleanUsers(ctx context.Context) error {
-	users, err := c.usersScanner.ScanUsers(ctx)
+	users, deleted, err := c.usersScanner.ScanUsers(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to discover users from bucket")
 	}
 
-	return concurrency.ForEachUser(ctx, users, c.cfg.CleanupConcurrency, func(ctx context.Context, userID string) error {
-		return errors.Wrapf(c.cleanUser(ctx, userID), "failed to delete user blocks (user: %s)", userID)
+	isDeleted := map[string]bool{}
+	for _, userID := range deleted {
+		isDeleted[userID] = true
+	}
+
+	allUsers := append(users, deleted...)
+	return concurrency.ForEachUser(ctx, allUsers, c.cfg.CleanupConcurrency, func(ctx context.Context, userID string) error {
+		if isDeleted[userID] {
+			return errors.Wrapf(c.cleanUserCompletely(ctx, userID), "failed to delete blocks for user marked for deletion: %s", userID)
+		}
+		return errors.Wrapf(c.cleanUser(ctx, userID), "failed to delete blocks for user: %s", userID)
 	})
+}
+
+// Remove all blocks for user marked for deletion.
+func (c *BlocksCleaner) cleanUserCompletely(ctx context.Context, userID string) error {
+	userLogger := util.WithUserID(userID, c.logger)
+	userBucket := bucket.NewUserBucketClient(userID, c.bucketClient)
+
+	level.Info(userLogger).Log("msg", "deleting blocks for user marked for deletion")
+
+	var deleted, failed int
+	err := userBucket.Iter(ctx, "", func(name string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		id, ok := block.IsBlockDir(name)
+		if !ok {
+			return nil
+		}
+
+		err := block.Delete(ctx, userLogger, userBucket, id)
+		if err != nil {
+			failed++
+			c.blocksFailedTotal.Inc()
+			level.Warn(userLogger).Log("msg", "failed to delete block", "block", id, "err", err)
+			return nil // Continue with other blocks.
+		}
+
+		deleted++
+		c.blocksCleanedTotal.Inc()
+		level.Info(userLogger).Log("msg", "deleted block", "block", id)
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if failed > 0 {
+		return errors.Errorf("failed to delete %d blocks", failed)
+	}
+
+	level.Info(userLogger).Log("msg", "finished deleting blocks for user marked for deletion", "deletedBlocks", deleted)
+	return nil
 }
 
 func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string) error {

--- a/pkg/querier/blocks_scanner.go
+++ b/pkg/querier/blocks_scanner.go
@@ -176,7 +176,7 @@ func (d *BlocksScanner) scanBucket(ctx context.Context) (returnErr error) {
 	}(time.Now())
 
 	// Discover all users first. This helps cacheability of the object store call.
-	userIDs, err := d.usersScanner.ScanUsers(ctx)
+	userIDs, _, err := d.usersScanner.ScanUsers(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/querier/blocks_scanner_test.go
+++ b/pkg/querier/blocks_scanner_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	"github.com/cortexproject/cortex/pkg/storage/bucket/filesystem"
+	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/storage/tsdb/bucketindex"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
@@ -101,6 +103,7 @@ func TestBlocksScanner_InitialScanFailure(t *testing.T) {
 	// Mock the storage to simulate a failure when reading objects.
 	bucket.MockIter("", []string{"user-1"}, nil)
 	bucket.MockIter("user-1/", []string{"user-1/01DTVP434PA9VFXSW2JKB3392D"}, nil)
+	bucket.MockExists(path.Join("user-1", cortex_tsdb.TenantDeletionMarkPath), false, nil)
 	bucket.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", "invalid", errors.New("mocked error"))
 
 	require.NoError(t, s.StartAsync(ctx))
@@ -145,6 +148,7 @@ func TestBlocksScanner_StopWhileRunningTheInitialScanOnManyTenants(t *testing.T)
 		bucket.MockIterWithCallback(tenantID+"/", []string{}, nil, func() {
 			time.Sleep(time.Second)
 		})
+		bucket.MockExists(path.Join(tenantID, cortex_tsdb.TenantDeletionMarkPath), false, nil)
 	}
 
 	cacheDir, err := ioutil.TempDir(os.TempDir(), "blocks-scanner-test-cache")

--- a/pkg/storage/bucket/client_mock.go
+++ b/pkg/storage/bucket/client_mock.go
@@ -96,6 +96,10 @@ func (m *ClientMock) MockDelete(name string, err error) {
 	m.On("Delete", mock.Anything, name).Return(err)
 }
 
+func (m *ClientMock) MockExists(name string, exists bool, err error) {
+	m.On("Exists", mock.Anything, name).Return(exists, err)
+}
+
 // GetRange mocks objstore.Bucket.GetRange()
 func (m *ClientMock) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
 	args := m.Called(ctx, name, off, length)

--- a/pkg/storage/tsdb/caching_bucket.go
+++ b/pkg/storage/tsdb/caching_bucket.go
@@ -124,8 +124,6 @@ func CreateCachingBucket(chunksConfig ChunksCacheConfig, metadataConfig Metadata
 		cfg.CacheGet("metafile", metadataCache, isMetaFile, metadataConfig.MetafileMaxSize, metadataConfig.MetafileContentTTL, metadataConfig.MetafileExistsTTL, metadataConfig.MetafileDoesntExistTTL)
 		cfg.CacheAttributes("metafile", metadataCache, isMetaFile, metadataConfig.MetafileAttributesTTL)
 
-		cfg.CacheExists("tenant-deletion-mark", metadataCache, isTenantDeletionMark, metadataConfig.MetafileExistsTTL, metadataConfig.MetafileDoesntExistTTL)
-
 		codec := snappyIterCodec{storecache.JSONIterCodec{}}
 		cfg.CacheIter("tenants-iter", metadataCache, isTenantsDir, metadataConfig.TenantsListTTL, codec)
 		cfg.CacheIter("tenant-blocks-iter", metadataCache, isTenantBlocksDir, metadataConfig.TenantBlocksListTTL, codec)
@@ -164,15 +162,11 @@ var chunksMatcher = regexp.MustCompile(`^.*/chunks/\d+$`)
 func isTSDBChunkFile(name string) bool { return chunksMatcher.MatchString(name) }
 
 func isMetaFile(name string) bool {
-	return strings.HasSuffix(name, "/"+metadata.MetaFilename) || strings.HasSuffix(name, "/"+metadata.DeletionMarkFilename)
+	return strings.HasSuffix(name, "/"+metadata.MetaFilename) || strings.HasSuffix(name, "/"+metadata.DeletionMarkFilename) || strings.HasSuffix(name, "/"+TenantDeletionMarkPath)
 }
 
 func isTenantsDir(name string) bool {
 	return name == ""
-}
-
-func isTenantDeletionMark(name string) bool {
-	return strings.HasSuffix(name, "/"+TenantDeletionMarkPath)
 }
 
 var tenantDirMatcher = regexp.MustCompile("^[^/]+/?$")

--- a/pkg/storage/tsdb/users_scanner.go
+++ b/pkg/storage/tsdb/users_scanner.go
@@ -33,10 +33,8 @@ func NewUsersScanner(bucketClient objstore.Bucket, isOwned func(userID string) (
 // and list of users marked for deletion.
 //
 // If sharding is enabled, returned lists contains only the users owned by this instance.
-func (s *UsersScanner) ScanUsers(ctx context.Context) ([]string, []string, error) {
-	var users []string
-
-	err := s.bucketClient.Iter(ctx, "", func(entry string) error {
+func (s *UsersScanner) ScanUsers(ctx context.Context) (users, markedForDeletion []string, err error) {
+	err = s.bucketClient.Iter(ctx, "", func(entry string) error {
 		users = append(users, strings.TrimSuffix(entry, "/"))
 		return nil
 	})
@@ -46,7 +44,6 @@ func (s *UsersScanner) ScanUsers(ctx context.Context) ([]string, []string, error
 
 	// Check users for being owned by instance, and split users into non-deleted and deleted.
 	// We do these checks after listing all users, to improve cacheability of Iter (result is only cached at the end of Iter call).
-	var markedForDeletion []string
 	for ix := 0; ix < len(users); {
 		userID := users[ix]
 
@@ -71,5 +68,5 @@ func (s *UsersScanner) ScanUsers(ctx context.Context) ([]string, []string, error
 		ix++
 	}
 
-	return users, markedForDeletion, err
+	return users, markedForDeletion, nil
 }

--- a/pkg/storage/tsdb/users_scanner.go
+++ b/pkg/storage/tsdb/users_scanner.go
@@ -29,25 +29,47 @@ func NewUsersScanner(bucketClient objstore.Bucket, isOwned func(userID string) (
 	}
 }
 
-// ScanUsers returns a fresh list of users found in the storage. If sharding is enabled,
-// the returned list contains only the users owned by this instance.
-func (s *UsersScanner) ScanUsers(ctx context.Context) ([]string, error) {
+// ScanUsers returns a fresh list of users found in the storage, that are not marked for deletion,
+// and list of users marked for deletion.
+//
+// If sharding is enabled, returned lists contains only the users owned by this instance.
+func (s *UsersScanner) ScanUsers(ctx context.Context) ([]string, []string, error) {
 	var users []string
 
 	err := s.bucketClient.Iter(ctx, "", func(entry string) error {
-		userID := strings.TrimSuffix(entry, "/")
+		users = append(users, strings.TrimSuffix(entry, "/"))
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Check users for being owned by instance, and split users into non-deleted and deleted.
+	// We do these checks after listing all users, to improve cacheability of Iter (result is only cached at the end of Iter call).
+	var markedForDeletion []string
+	for ix := 0; ix < len(users); {
+		userID := users[ix]
 
 		// Check if it's owned by this instance.
 		owned, err := s.isOwned(userID)
 		if err != nil {
 			level.Warn(s.logger).Log("msg", "unable to check if user is owned by this shard", "user", userID, "err", err)
 		} else if !owned {
-			return nil
+			users = append(users[:ix], users[ix+1:]...)
+			continue
 		}
 
-		users = append(users, userID)
-		return nil
-	})
+		deletionMarkExists, err := TenantDeletionMarkExists(ctx, s.bucketClient, userID)
+		if err != nil {
+			level.Warn(s.logger).Log("msg", "unable to check if user is marked for deletion", "user", userID, "err", err)
+		} else if deletionMarkExists {
+			users = append(users[:ix], users[ix+1:]...)
+			markedForDeletion = append(markedForDeletion, userID)
+			continue
+		}
 
-	return users, err
+		ix++
+	}
+
+	return users, markedForDeletion, err
 }

--- a/pkg/storage/tsdb/users_scanner_test.go
+++ b/pkg/storage/tsdb/users_scanner_test.go
@@ -3,6 +3,7 @@ package tsdb
 import (
 	"context"
 	"errors"
+	"path"
 	"testing"
 
 	"github.com/go-kit/kit/log"
@@ -14,31 +15,37 @@ import (
 
 func TestUsersScanner_ScanUsers_ShouldReturnedOwnedUsersOnly(t *testing.T) {
 	bucketClient := &bucket.ClientMock{}
-	bucketClient.MockIter("", []string{"user-1", "user-2", "user-3"}, nil)
+	bucketClient.MockIter("", []string{"user-1", "user-2", "user-3", "user-4"}, nil)
+	bucketClient.MockExists(path.Join("user-1", TenantDeletionMarkPath), false, nil)
+	bucketClient.MockExists(path.Join("user-3", TenantDeletionMarkPath), true, nil)
 
 	isOwned := func(userID string) (bool, error) {
 		return userID == "user-1" || userID == "user-3", nil
 	}
 
 	s := NewUsersScanner(bucketClient, isOwned, log.NewNopLogger())
-	actual, err := s.ScanUsers(context.Background())
+	actual, deleted, err := s.ScanUsers(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"user-1", "user-3"}, actual)
+	assert.Equal(t, []string{"user-1"}, actual)
+	assert.Equal(t, []string{"user-3"}, deleted)
 
 }
 
-func TestUsersScanner_ScanUsers_ShouldReturnUsersForWhichOwnerCheckFailed(t *testing.T) {
+func TestUsersScanner_ScanUsers_ShouldReturnUsersForWhichOwnerCheckOrTenantDeletionCheckFailed(t *testing.T) {
 	expected := []string{"user-1", "user-2"}
 
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("", expected, nil)
+	bucketClient.MockExists(path.Join("user-1", TenantDeletionMarkPath), false, nil)
+	bucketClient.MockExists(path.Join("user-2", TenantDeletionMarkPath), false, errors.New("fail"))
 
 	isOwned := func(userID string) (bool, error) {
 		return false, errors.New("failed to check if user is owned")
 	}
 
 	s := NewUsersScanner(bucketClient, isOwned, log.NewNopLogger())
-	actual, err := s.ScanUsers(context.Background())
+	actual, deleted, err := s.ScanUsers(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, expected, actual)
+	assert.Empty(t, deleted)
 }


### PR DESCRIPTION
**What this PR does**: This PR builds on #3549. In this PR, compactor component checks for tenant deletion marker, and 1) it will skip such users when doing compaction, and 2) its blocks cleaner component will actually remove all blocks for such users.

~Draft until #3549 is merged.~ Rebased on top of master.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
