### PR TITLE
Write block deletion marks in the global location too

### DIFF
--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -20,6 +19,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket/filesystem"
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/storage/tsdb/bucketindex"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -49,30 +49,31 @@ func testBlocksCleanerWithConcurrency(t *testing.T, concurrency int) {
 	// Create a bucket client on the local storage.
 	bucketClient, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
 	require.NoError(t, err)
+	bucketClient = bucketindex.BucketWithGlobalMarkers(bucketClient)
 
 	// Create blocks.
 	ctx := context.Background()
 	now := time.Now()
 	deletionDelay := 12 * time.Hour
-	block1 := createTSDBBlock(t, filepath.Join(storageDir, "user-1"), 10, 20, nil)
-	block2 := createTSDBBlock(t, filepath.Join(storageDir, "user-1"), 20, 30, nil)
-	block3 := createTSDBBlock(t, filepath.Join(storageDir, "user-1"), 30, 40, nil)
+	block1 := createTSDBBlock(t, bucketClient, "user-1", 10, 20, nil)
+	block2 := createTSDBBlock(t, bucketClient, "user-1", 20, 30, nil)
+	block3 := createTSDBBlock(t, bucketClient, "user-1", 30, 40, nil)
 	block4 := ulid.MustNew(4, rand.Reader)
 	block5 := ulid.MustNew(5, rand.Reader)
-	block6 := createTSDBBlock(t, filepath.Join(storageDir, "user-1"), 40, 50, nil)
-	block7 := createTSDBBlock(t, filepath.Join(storageDir, "user-2"), 10, 20, nil)
-	block8 := createTSDBBlock(t, filepath.Join(storageDir, "user-2"), 40, 50, nil)
-	createDeletionMark(t, filepath.Join(storageDir, "user-1"), block2, now.Add(-deletionDelay).Add(time.Hour))  // Block hasn't reached the deletion threshold yet.
-	createDeletionMark(t, filepath.Join(storageDir, "user-1"), block3, now.Add(-deletionDelay).Add(-time.Hour)) // Block reached the deletion threshold.
-	createDeletionMark(t, filepath.Join(storageDir, "user-1"), block4, now.Add(-deletionDelay).Add(time.Hour))  // Partial block hasn't reached the deletion threshold yet.
-	createDeletionMark(t, filepath.Join(storageDir, "user-1"), block5, now.Add(-deletionDelay).Add(-time.Hour)) // Partial block reached the deletion threshold.
-	require.NoError(t, bucketClient.Delete(ctx, path.Join("user-1", block6.String(), metadata.MetaFilename)))   // Partial block without deletion mark.
-	createDeletionMark(t, filepath.Join(storageDir, "user-2"), block7, now.Add(-deletionDelay).Add(-time.Hour)) // Block reached the deletion threshold.
+	block6 := createTSDBBlock(t, bucketClient, "user-1", 40, 50, nil)
+	block7 := createTSDBBlock(t, bucketClient, "user-2", 10, 20, nil)
+	block8 := createTSDBBlock(t, bucketClient, "user-2", 40, 50, nil)
+	createDeletionMark(t, bucketClient, "user-1", block2, now.Add(-deletionDelay).Add(time.Hour))             // Block hasn't reached the deletion threshold yet.
+	createDeletionMark(t, bucketClient, "user-1", block3, now.Add(-deletionDelay).Add(-time.Hour))            // Block reached the deletion threshold.
+	createDeletionMark(t, bucketClient, "user-1", block4, now.Add(-deletionDelay).Add(time.Hour))             // Partial block hasn't reached the deletion threshold yet.
+	createDeletionMark(t, bucketClient, "user-1", block5, now.Add(-deletionDelay).Add(-time.Hour))            // Partial block reached the deletion threshold.
+	require.NoError(t, bucketClient.Delete(ctx, path.Join("user-1", block6.String(), metadata.MetaFilename))) // Partial block without deletion mark.
+	createDeletionMark(t, bucketClient, "user-2", block7, now.Add(-deletionDelay).Add(-time.Hour))            // Block reached the deletion threshold.
 
 	// Blocks for user-3, marked for deletion.
 	require.NoError(t, tsdb.WriteTenantDeletionMark(context.Background(), bucketClient, "user-3"))
-	block9 := createTSDBBlock(t, filepath.Join(storageDir, "user-3"), 10, 30, nil)
-	block10 := createTSDBBlock(t, filepath.Join(storageDir, "user-3"), 30, 50, nil)
+	block9 := createTSDBBlock(t, bucketClient, "user-3", 10, 30, nil)
+	block10 := createTSDBBlock(t, bucketClient, "user-3", 30, 50, nil)
 
 	cfg := BlocksCleanerConfig{
 		DataDir:             dataDir,
@@ -96,14 +97,18 @@ func testBlocksCleanerWithConcurrency(t *testing.T, concurrency int) {
 		// Check the storage to ensure only the block which has reached the deletion threshold
 		// has been effectively deleted.
 		{path: path.Join("user-1", block1.String(), metadata.MetaFilename), expectedExists: true},
-		{path: path.Join("user-1", block2.String(), metadata.MetaFilename), expectedExists: true},
 		{path: path.Join("user-1", block3.String(), metadata.MetaFilename), expectedExists: false},
 		{path: path.Join("user-2", block7.String(), metadata.MetaFilename), expectedExists: false},
 		{path: path.Join("user-2", block8.String(), metadata.MetaFilename), expectedExists: true},
+		// Should not delete a block with deletion mark who hasn't reached the deletion threshold yet.
+		{path: path.Join("user-1", block2.String(), metadata.MetaFilename), expectedExists: true},
+		{path: path.Join("user-1", bucketindex.BlockDeletionMarkFilepath(block2)), expectedExists: true},
 		// Should delete a partial block with deletion mark who hasn't reached the deletion threshold yet.
 		{path: path.Join("user-1", block4.String(), metadata.DeletionMarkFilename), expectedExists: false},
+		{path: path.Join("user-1", bucketindex.BlockDeletionMarkFilepath(block4)), expectedExists: false},
 		// Should delete a partial block with deletion mark who has reached the deletion threshold.
 		{path: path.Join("user-1", block5.String(), metadata.DeletionMarkFilename), expectedExists: false},
+		{path: path.Join("user-1", bucketindex.BlockDeletionMarkFilepath(block5)), expectedExists: false},
 		// Should not delete a partial block without deletion mark.
 		{path: path.Join("user-1", block6.String(), "index"), expectedExists: true},
 		// Should completely delete blocks for user-3, marked for deletion

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/storage/tsdb/bucketindex"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
@@ -269,6 +270,9 @@ func (c *Compactor) starting(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize compactor objects")
 	}
+
+	// Wrap the bucket client to write block deletion marks in the global location too.
+	c.bucketClient = bucketindex.BucketWithGlobalMarkers(c.bucketClient)
 
 	// Create the users scanner.
 	c.usersScanner = cortex_tsdb.NewUsersScanner(c.bucketClient, c.ownUser, c.parentLogger)

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1,13 +1,13 @@
 package compactor
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -863,7 +863,7 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 	}
 }
 
-func createTSDBBlock(t *testing.T, dir string, minT, maxT int64, externalLabels map[string]string) ulid.ULID {
+func createTSDBBlock(t *testing.T, bkt objstore.Bucket, userID string, minT, maxT int64, externalLabels map[string]string) ulid.ULID {
 	// Create a temporary dir for TSDB.
 	tempDir, err := ioutil.TempDir(os.TempDir(), "tsdb")
 	require.NoError(t, err)
@@ -916,24 +916,37 @@ func createTSDBBlock(t *testing.T, dir string, minT, maxT int64, externalLabels 
 	_, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(snapshotDir, blockID.String()), meta, nil)
 	require.NoError(t, err)
 
-	// Ensure the output directory exists.
-	require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+	// Copy the block files to the bucket.
+	srcRoot := filepath.Join(snapshotDir, blockID.String())
+	require.NoError(t, filepath.Walk(srcRoot, func(file string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
 
-	// Copy the block files to the storage dir.
-	require.NoError(t, exec.Command("cp", "-r", filepath.Join(snapshotDir, blockID.String()), dir).Run())
+		// Read the file content in memory.
+		content, err := ioutil.ReadFile(file)
+		if err != nil {
+			return err
+		}
+
+		// Upload it to the bucket.
+		relPath, err := filepath.Rel(srcRoot, file)
+		if err != nil {
+			return err
+		}
+
+		return bkt.Upload(context.Background(), path.Join(userID, blockID.String(), relPath), bytes.NewReader(content))
+	}))
 
 	return blockID
 }
 
-func createDeletionMark(t *testing.T, dir string, blockID ulid.ULID, deletionTime time.Time) {
+func createDeletionMark(t *testing.T, bkt objstore.Bucket, userID string, blockID ulid.ULID, deletionTime time.Time) {
 	content := mockDeletionMarkJSON(blockID.String(), deletionTime)
-	blockPath := filepath.Join(dir, blockID.String())
-	markPath := filepath.Join(blockPath, metadata.DeletionMarkFilename)
+	blockPath := path.Join(userID, blockID.String())
+	markPath := path.Join(blockPath, metadata.DeletionMarkFilename)
 
-	// Ensure the block directory exists.
-	require.NoError(t, os.MkdirAll(blockPath, os.ModePerm))
-
-	require.NoError(t, ioutil.WriteFile(markPath, []byte(content), os.ModePerm))
+	require.NoError(t, bkt.Upload(context.Background(), markPath, strings.NewReader(content)))
 }
 
 func findCompactorByUserID(compactors []*Compactor, logs []*concurrency.SyncBuffer, userID string) (*Compactor, *concurrency.SyncBuffer, error) {

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -538,6 +538,7 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForDeletion(t *testing.T) {
 	bucketClient.MockIter("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ", []string{"user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/meta.json", "user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/deletion-mark.json"}, nil)
 	bucketClient.MockDelete("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/meta.json", nil)
 	bucketClient.MockDelete("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/deletion-mark.json", nil)
+	bucketClient.MockDelete("user-1/markers/01DTW0ZCPDDNV4BV83Q2SV4QAZ-deletion-mark.json", nil)
 	bucketClient.MockDelete("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ", nil)
 
 	c, _, tsdbPlanner, logs, registry, cleanup := prepare(t, cfg, bucketClient)

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -919,6 +919,9 @@ func createTSDBBlock(t *testing.T, bkt objstore.Bucket, userID string, minT, max
 	// Copy the block files to the bucket.
 	srcRoot := filepath.Join(snapshotDir, blockID.String())
 	require.NoError(t, filepath.Walk(srcRoot, func(file string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() {
 			return nil
 		}

--- a/pkg/storage/tsdb/bucketindex/index.go
+++ b/pkg/storage/tsdb/bucketindex/index.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	IndexFilename = "bucket-index.json"
-	IndexVersion1 = 1
+	IndexFilename           = "bucket-index.json"
+	IndexCompressedFilename = IndexFilename + ".gz"
+	IndexVersion1           = 1
 
 	SegmentsFormatUnknown = ""
 

--- a/pkg/storage/tsdb/bucketindex/markers.go
+++ b/pkg/storage/tsdb/bucketindex/markers.go
@@ -1,0 +1,43 @@
+package bucketindex
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/oklog/ulid"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+)
+
+const (
+	MarkersPathname = "markers"
+)
+
+// BlockDeletionMarkFilepath returns the path, relative to the tenant's bucket location,
+// of a block deletion mark in the bucket markers location.
+func BlockDeletionMarkFilepath(blockID ulid.ULID) string {
+	return fmt.Sprintf("%s/%s-%s", MarkersPathname, blockID.String(), metadata.DeletionMarkFilename)
+}
+
+// BlockDeletionMarkFilename returns the filename to use when storing a block deletion mark
+// in the bucket markers location.
+func BlockDeletionMarkFilename(blockID ulid.ULID) string {
+	return fmt.Sprintf("%s-%s", blockID.String(), metadata.DeletionMarkFilename)
+}
+
+// IsBlockDeletionMarkFilename returns whether the input filename matches the expected pattern
+// of block deletion markers stored in the markers location.
+func IsBlockDeletionMarkFilename(name string) (ulid.ULID, bool) {
+	parts := strings.SplitN(name, "-", 2)
+	if len(parts) != 2 {
+		return ulid.ULID{}, false
+	}
+
+	// Ensure the 2nd part matches the block deletion mark filename.
+	if parts[1] != metadata.DeletionMarkFilename {
+		return ulid.ULID{}, false
+	}
+
+	// Ensure the 1st part is a valid block ID.
+	return block.IsBlockDir(parts[0])
+}

--- a/pkg/storage/tsdb/bucketindex/markers.go
+++ b/pkg/storage/tsdb/bucketindex/markers.go
@@ -19,12 +19,6 @@ func BlockDeletionMarkFilepath(blockID ulid.ULID) string {
 	return fmt.Sprintf("%s/%s-%s", MarkersPathname, blockID.String(), metadata.DeletionMarkFilename)
 }
 
-// BlockDeletionMarkFilename returns the filename to use when storing a block deletion mark
-// in the bucket markers location.
-func BlockDeletionMarkFilename(blockID ulid.ULID) string {
-	return fmt.Sprintf("%s-%s", blockID.String(), metadata.DeletionMarkFilename)
-}
-
 // IsBlockDeletionMarkFilename returns whether the input filename matches the expected pattern
 // of block deletion markers stored in the markers location.
 func IsBlockDeletionMarkFilename(name string) (ulid.ULID, bool) {

--- a/pkg/storage/tsdb/bucketindex/markers.go
+++ b/pkg/storage/tsdb/bucketindex/markers.go
@@ -2,10 +2,10 @@ package bucketindex
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/oklog/ulid"
-	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 )
 
@@ -39,5 +39,6 @@ func IsBlockDeletionMarkFilename(name string) (ulid.ULID, bool) {
 	}
 
 	// Ensure the 1st part is a valid block ID.
-	return block.IsBlockDir(parts[0])
+	id, err := ulid.Parse(filepath.Base(parts[0]))
+	return id, err == nil
 }

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
@@ -14,15 +14,17 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore"
 )
 
+// globalMarkersBucket is a bucket client which stores markers (eg. block deletion marks) in a per-tenant
+// global location too.
 type globalMarkersBucket struct {
-	objstore.Bucket
+	parent objstore.Bucket
 }
 
 // BucketWithGlobalMarkers wraps the input bucket into a bucket which also keeps track of markers
 // in the global markers location.
 func BucketWithGlobalMarkers(b objstore.Bucket) objstore.Bucket {
 	return &globalMarkersBucket{
-		Bucket: b,
+		parent: b,
 	}
 }
 
@@ -30,7 +32,7 @@ func BucketWithGlobalMarkers(b objstore.Bucket) objstore.Bucket {
 func (b *globalMarkersBucket) Upload(ctx context.Context, name string, r io.Reader) error {
 	blockID, ok := b.isBlockDeletionMark(name)
 	if !ok {
-		return b.Bucket.Upload(ctx, name, r)
+		return b.parent.Upload(ctx, name, r)
 	}
 
 	// Read the marker.
@@ -40,33 +42,73 @@ func (b *globalMarkersBucket) Upload(ctx context.Context, name string, r io.Read
 	}
 
 	// Upload it to the original location.
-	if err := b.Bucket.Upload(ctx, name, bytes.NewReader(body)); err != nil {
+	if err := b.parent.Upload(ctx, name, bytes.NewReader(body)); err != nil {
 		return err
 	}
 
 	// Upload it to the global markers location too.
 	globalMarkPath := path.Clean(path.Join(path.Dir(name), "../", BlockDeletionMarkFilepath(blockID)))
-	return b.Bucket.Upload(ctx, globalMarkPath, bytes.NewReader(body))
+	return b.parent.Upload(ctx, globalMarkPath, bytes.NewReader(body))
 }
 
 // Delete implements objstore.Bucket.
 func (b *globalMarkersBucket) Delete(ctx context.Context, name string) error {
 	// Call the parent.
-	if err := b.Bucket.Delete(ctx, name); err != nil {
+	if err := b.parent.Delete(ctx, name); err != nil {
 		return err
 	}
 
 	// Delete the marker in the global markers location too.
 	if blockID, ok := b.isBlockDeletionMark(name); ok {
 		globalMarkPath := path.Clean(path.Join(path.Dir(name), "../", BlockDeletionMarkFilepath(blockID)))
-		if err := b.Bucket.Delete(ctx, globalMarkPath); err != nil {
-			if !b.IsObjNotFoundErr(err) {
+		if err := b.parent.Delete(ctx, globalMarkPath); err != nil {
+			if !b.parent.IsObjNotFoundErr(err) {
 				return err
 			}
 		}
 	}
 
 	return nil
+}
+
+// Name implements objstore.Bucket.
+func (b *globalMarkersBucket) Name() string {
+	return b.parent.Name()
+}
+
+// Close implements objstore.Bucket.
+func (b *globalMarkersBucket) Close() error {
+	return b.parent.Close()
+}
+
+// Iter implements objstore.Bucket.
+func (b *globalMarkersBucket) Iter(ctx context.Context, dir string, f func(string) error) error {
+	return b.parent.Iter(ctx, dir, f)
+}
+
+// Get implements objstore.Bucket.
+func (b *globalMarkersBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	return b.parent.Get(ctx, name)
+}
+
+// GetRange implements objstore.Bucket.
+func (b *globalMarkersBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	return b.parent.GetRange(ctx, name, off, length)
+}
+
+// Exists implements objstore.Bucket.
+func (b *globalMarkersBucket) Exists(ctx context.Context, name string) (bool, error) {
+	return b.parent.Exists(ctx, name)
+}
+
+// IsObjNotFoundErr implements objstore.Bucket.
+func (b *globalMarkersBucket) IsObjNotFoundErr(err error) bool {
+	return b.parent.IsObjNotFoundErr(err)
+}
+
+// Attributes implements objstore.Bucket.
+func (b *globalMarkersBucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
+	return b.parent.Attributes(ctx, name)
 }
 
 func (b *globalMarkersBucket) isBlockDeletionMark(name string) (ulid.ULID, bool) {

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"path"
-	"strings"
 
 	"github.com/oklog/ulid"
 	"github.com/thanos-io/thanos/pkg/block"
@@ -118,10 +117,5 @@ func (b *globalMarkersBucket) isBlockDeletionMark(name string) (ulid.ULID, bool)
 
 	// Parse the block ID in the path. If there's not block ID, then it's not the per-block
 	// deletion mark.
-	parts := strings.Split(name, "/")
-	if len(parts) < 2 {
-		return ulid.ULID{}, false
-	}
-
-	return block.IsBlockDir(parts[len(parts)-2])
+	return block.IsBlockDir(path.Dir(name))
 }

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
@@ -1,0 +1,85 @@
+package bucketindex
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"path"
+	"strings"
+
+	"github.com/oklog/ulid"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+type globalMarkersBucket struct {
+	objstore.InstrumentedBucket
+}
+
+// BucketWithGlobalMarkers wraps the input bucket into a bucket which also keeps track of markers
+// in the global markers location.
+func BucketWithGlobalMarkers(b objstore.InstrumentedBucket) objstore.InstrumentedBucket {
+	return &globalMarkersBucket{
+		InstrumentedBucket: b,
+	}
+}
+
+// Upload implements objstore.Bucket.
+func (b *globalMarkersBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+	blockID, ok := b.isBlockDeletionMark(name)
+	if !ok {
+		return b.InstrumentedBucket.Upload(ctx, name, r)
+	}
+
+	// Read the marker.
+	body, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	// Upload it to the original location.
+	if err := b.InstrumentedBucket.Upload(ctx, name, bytes.NewReader(body)); err != nil {
+		return err
+	}
+
+	// Upload it to the global markers location too.
+	globalMarkPath := path.Clean(path.Join(path.Dir(name), "../", BlockDeletionMarkFilepath(blockID)))
+	return b.InstrumentedBucket.Upload(ctx, globalMarkPath, bytes.NewReader(body))
+}
+
+// Delete implements objstore.Bucket.
+func (b *globalMarkersBucket) Delete(ctx context.Context, name string) error {
+	// Call the parent.
+	if err := b.InstrumentedBucket.Delete(ctx, name); err != nil {
+		return err
+	}
+
+	// Delete the marker in the global markers location too.
+	if blockID, ok := b.isBlockDeletionMark(name); ok {
+		globalMarkPath := path.Clean(path.Join(path.Dir(name), "../", BlockDeletionMarkFilepath(blockID)))
+		if err := b.InstrumentedBucket.Delete(ctx, globalMarkPath); err != nil {
+			if !b.IsObjNotFoundErr(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (b *globalMarkersBucket) isBlockDeletionMark(name string) (ulid.ULID, bool) {
+	if path.Base(name) != metadata.DeletionMarkFilename {
+		return ulid.ULID{}, false
+	}
+
+	// Parse the block ID in the path. If there's not block ID, then it's not the per-block
+	// deletion mark.
+	parts := strings.Split(name, "/")
+	if len(parts) < 2 {
+		return ulid.ULID{}, false
+	}
+
+	return block.IsBlockDir(parts[len(parts)-2])
+}

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client_test.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client_test.go
@@ -1,0 +1,75 @@
+package bucketindex
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/oklog/ulid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGlobalMarkersBucket_Delete_ShouldSucceedIfDeletionMarkDoesNotExistInTheBlockButExistInTheGlobalLocation(t *testing.T) {
+	bkt, cleanup := prepareFilesystemBucket(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	bkt = BucketWithGlobalMarkers(bkt)
+
+	// Create a mocked block deletion mark in the global location.
+	blockID := ulid.MustNew(1, nil)
+	globalPath := BlockDeletionMarkFilepath(blockID)
+	require.NoError(t, bkt.Upload(ctx, globalPath, strings.NewReader("{}")))
+
+	// Ensure it exists before deleting it.
+	ok, err := bkt.Exists(ctx, globalPath)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.NoError(t, bkt.Delete(ctx, globalPath))
+
+	// Ensure has been actually deleted.
+	ok, err = bkt.Exists(ctx, globalPath)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestGlobalMarkersBucket_isBlockDeletionMark(t *testing.T) {
+	block1 := ulid.MustNew(1, nil)
+
+	tests := []struct {
+		name       string
+		expectedOk bool
+		expectedID ulid.ULID
+	}{
+		{
+			name:       "",
+			expectedOk: false,
+		}, {
+			name:       "deletion-mark.json",
+			expectedOk: false,
+		}, {
+			name:       block1.String() + "/index",
+			expectedOk: false,
+		}, {
+			name:       block1.String() + "/deletion-mark.json",
+			expectedOk: true,
+			expectedID: block1,
+		}, {
+			name:       "/path/to/" + block1.String() + "/deletion-mark.json",
+			expectedOk: true,
+			expectedID: block1,
+		},
+	}
+
+	b := BucketWithGlobalMarkers(nil).(*globalMarkersBucket)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualID, actualOk := b.isBlockDeletionMark(tc.name)
+			assert.Equal(t, tc.expectedOk, actualOk)
+			assert.Equal(t, tc.expectedID, actualID)
+		})
+	}
+}

--- a/pkg/storage/tsdb/bucketindex/markers_test.go
+++ b/pkg/storage/tsdb/bucketindex/markers_test.go
@@ -22,16 +22,16 @@ func TestBlockDeletionMarkFilename(t *testing.T) {
 func TestIsBlockDeletionMarkFilename(t *testing.T) {
 	expected := ulid.MustNew(1, nil)
 
-	actual, ok := IsBlockDeletionMarkFilename("xxx")
+	_, ok := IsBlockDeletionMarkFilename("xxx")
 	assert.False(t, ok)
 
-	actual, ok = IsBlockDeletionMarkFilename("xxx-deletion-mark.json")
+	_, ok = IsBlockDeletionMarkFilename("xxx-deletion-mark.json")
 	assert.False(t, ok)
 
-	actual, ok = IsBlockDeletionMarkFilename("tenant-deletion-mark.json")
+	_, ok = IsBlockDeletionMarkFilename("tenant-deletion-mark.json")
 	assert.False(t, ok)
 
-	actual, ok = IsBlockDeletionMarkFilename(expected.String() + "-deletion-mark.json")
+	actual, ok := IsBlockDeletionMarkFilename(expected.String() + "-deletion-mark.json")
 	assert.True(t, ok)
 	assert.Equal(t, expected, actual)
 }

--- a/pkg/storage/tsdb/bucketindex/markers_test.go
+++ b/pkg/storage/tsdb/bucketindex/markers_test.go
@@ -1,0 +1,37 @@
+package bucketindex
+
+import (
+	"testing"
+
+	"github.com/oklog/ulid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlockDeletionMarkFilepath(t *testing.T) {
+	id := ulid.MustNew(1, nil)
+
+	assert.Equal(t, "markers/"+id.String()+"-deletion-mark.json", BlockDeletionMarkFilepath(id))
+}
+
+func TestBlockDeletionMarkFilename(t *testing.T) {
+	id := ulid.MustNew(1, nil)
+
+	assert.Equal(t, id.String()+"-deletion-mark.json", BlockDeletionMarkFilename(id))
+}
+
+func TestIsBlockDeletionMarkFilename(t *testing.T) {
+	expected := ulid.MustNew(1, nil)
+
+	actual, ok := IsBlockDeletionMarkFilename("xxx")
+	assert.False(t, ok)
+
+	actual, ok = IsBlockDeletionMarkFilename("xxx-deletion-mark.json")
+	assert.False(t, ok)
+
+	actual, ok = IsBlockDeletionMarkFilename("tenant-deletion-mark.json")
+	assert.False(t, ok)
+
+	actual, ok = IsBlockDeletionMarkFilename(expected.String() + "-deletion-mark.json")
+	assert.True(t, ok)
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/storage/tsdb/bucketindex/markers_test.go
+++ b/pkg/storage/tsdb/bucketindex/markers_test.go
@@ -13,12 +13,6 @@ func TestBlockDeletionMarkFilepath(t *testing.T) {
 	assert.Equal(t, "markers/"+id.String()+"-deletion-mark.json", BlockDeletionMarkFilepath(id))
 }
 
-func TestBlockDeletionMarkFilename(t *testing.T) {
-	id := ulid.MustNew(1, nil)
-
-	assert.Equal(t, id.String()+"-deletion-mark.json", BlockDeletionMarkFilename(id))
-}
-
 func TestIsBlockDeletionMarkFilename(t *testing.T) {
 	expected := ulid.MustNew(1, nil)
 

--- a/pkg/storage/tsdb/bucketindex/reader.go
+++ b/pkg/storage/tsdb/bucketindex/reader.go
@@ -4,7 +4,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"io/ioutil"
 
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
@@ -40,14 +39,10 @@ func ReadIndex(ctx context.Context, bkt objstore.Bucket, userID string, logger l
 	}
 	defer runutil.CloseWithLogOnErr(logger, gzipReader, "close bucket index gzip reader")
 
-	content, err := ioutil.ReadAll(gzipReader)
-	if err != nil {
-		return nil, errors.Wrap(err, "read bucket index")
-	}
-
 	// Deserialize it.
 	index := &Index{}
-	if err := json.Unmarshal(content, index); err != nil {
+	d := json.NewDecoder(gzipReader)
+	if err := d.Decode(index); err != nil {
 		return nil, ErrIndexCorrupted
 	}
 

--- a/pkg/storage/tsdb/bucketindex/reader.go
+++ b/pkg/storage/tsdb/bucketindex/reader.go
@@ -1,0 +1,55 @@
+package bucketindex
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/thanos-io/thanos/pkg/runutil"
+
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
+)
+
+var (
+	ErrIndexNotFound  = errors.New("bucket index not found")
+	ErrIndexCorrupted = errors.New("bucket index corrupted")
+)
+
+// ReadIndex reads, parses and returns a bucket index from the bucket.
+func ReadIndex(ctx context.Context, bkt objstore.Bucket, userID string, logger log.Logger) (*Index, error) {
+	bkt = bucket.NewUserBucketClient(userID, bkt)
+
+	// Get the bucket index.
+	reader, err := bkt.Get(ctx, IndexCompressedFilename)
+	if err != nil {
+		if bkt.IsObjNotFoundErr(err) {
+			return nil, ErrIndexNotFound
+		}
+		return nil, errors.Wrap(err, "read bucket index")
+	}
+	defer runutil.CloseWithLogOnErr(logger, reader, "close bucket index reader")
+
+	// Read all the content.
+	gzipReader, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, ErrIndexCorrupted
+	}
+	defer runutil.CloseWithLogOnErr(logger, gzipReader, "close bucket index gzip reader")
+
+	content, err := ioutil.ReadAll(gzipReader)
+	if err != nil {
+		return nil, errors.Wrap(err, "read bucket index")
+	}
+
+	// Deserialize it.
+	index := &Index{}
+	if err := json.Unmarshal(content, index); err != nil {
+		return nil, ErrIndexCorrupted
+	}
+
+	return index, nil
+}

--- a/pkg/storage/tsdb/bucketindex/reader_test.go
+++ b/pkg/storage/tsdb/bucketindex/reader_test.go
@@ -47,7 +47,7 @@ func TestReadIndex_ShouldReturnTheParsedIndexOnSuccess(t *testing.T) {
 	defer cleanup()
 
 	// Mock some blocks in the storage.
-	bkt = BucketWithMarkersIndex(bkt)
+	bkt = BucketWithGlobalMarkers(bkt)
 	testutil.MockStorageBlock(t, bkt, userID, 10, 20)
 	testutil.MockStorageBlock(t, bkt, userID, 20, 30)
 	testutil.MockStorageDeletionMark(t, bkt, userID, testutil.MockStorageBlock(t, bkt, userID, 30, 40))
@@ -77,7 +77,7 @@ func BenchmarkReadIndex(b *testing.B) {
 	defer cleanup()
 
 	// Mock some blocks and deletion marks in the storage.
-	bkt = BucketWithMarkersIndex(bkt)
+	bkt = BucketWithGlobalMarkers(bkt)
 	for i := 0; i < numBlocks; i++ {
 		minT := int64(i * 10)
 		maxT := int64((i + 1) * 10)

--- a/pkg/storage/tsdb/bucketindex/reader_test.go
+++ b/pkg/storage/tsdb/bucketindex/reader_test.go
@@ -1,0 +1,64 @@
+package bucketindex
+
+import (
+	"context"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"
+)
+
+func TestReadIndex_ShouldReturnErrorIfIndexDoesNotExist(t *testing.T) {
+	bkt, cleanup := prepareFilesystemBucket(t)
+	defer cleanup()
+
+	idx, err := ReadIndex(context.Background(), bkt, "user-1", log.NewNopLogger())
+	require.Equal(t, ErrIndexNotFound, err)
+	require.Nil(t, idx)
+}
+
+func TestReadIndex_ShouldReturnErrorIfIndexIsCorrupted(t *testing.T) {
+	const userID = "user-1"
+
+	ctx := context.Background()
+	bkt, cleanup := prepareFilesystemBucket(t)
+	defer cleanup()
+
+	// Write a corrupted index.
+	bkt.Upload(ctx, path.Join(userID, IndexFilename), strings.NewReader("invalid!}"))
+
+	idx, err := ReadIndex(ctx, bkt, userID, log.NewNopLogger())
+	require.Equal(t, ErrIndexCorrupted, err)
+	require.Nil(t, idx)
+}
+
+func TestReadIndex_ShouldReturnTheParsedIndexOnSuccess(t *testing.T) {
+	const userID = "user-1"
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	bkt, cleanup := prepareFilesystemBucket(t)
+	defer cleanup()
+
+	// Mock some blocks in the storage.
+	bkt = BucketWithMarkersIndex(bkt)
+	testutil.MockStorageBlock(t, bkt, userID, 10, 20)
+	testutil.MockStorageBlock(t, bkt, userID, 20, 30)
+	testutil.MockStorageDeletionMark(t, bkt, userID, testutil.MockStorageBlock(t, bkt, userID, 30, 40))
+
+	// Write the index.
+	w := NewWriter(bkt, userID, logger)
+	expectedIdx, err := w.WriteIndex(ctx, nil)
+	require.NoError(t, err)
+
+	// Read it back and compare.
+	actualIdx, err := ReadIndex(ctx, bkt, userID, logger)
+	require.NoError(t, err)
+	assert.Equal(t, expectedIdx, actualIdx)
+}

--- a/pkg/storage/tsdb/bucketindex/writer.go
+++ b/pkg/storage/tsdb/bucketindex/writer.go
@@ -1,0 +1,260 @@
+package bucketindex
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"path"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	json "github.com/json-iterator/go"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/thanos-io/thanos/pkg/runutil"
+
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+var (
+	errBlockMetaNotFound          = errors.New("block meta.json not found")
+	errBlockMetaCorrupted         = errors.New("block meta.json corrupted")
+	errBlockDeletionMarkNotFound  = errors.New("block deletion mark not found")
+	errBlockDeletionMarkCorrupted = errors.New("block deletion mark corrupted")
+)
+
+// Writer is responsible to generate and write a bucket index.
+type Writer struct {
+	bkt    objstore.InstrumentedBucket
+	logger log.Logger
+}
+
+func NewWriter(bkt objstore.InstrumentedBucket, userID string, logger log.Logger) *Writer {
+	return &Writer{
+		bkt:    bucket.NewUserBucketClient(userID, bkt),
+		logger: util.WithUserID(userID, logger),
+	}
+}
+
+// WriteIndex generates the bucket index and writes it to the storage. If the old index is not
+// passed in input, then the bucket index will be generated from scratch.
+func (w *Writer) WriteIndex(ctx context.Context, old *Index) (*Index, error) {
+	idx, err := w.GenerateIndex(ctx, old)
+	if err != nil {
+		return nil, errors.Wrap(err, "generate bucket index")
+	}
+
+	// Marshal the index.
+	content, err := json.Marshal(idx)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal bucket index")
+	}
+
+	// Upload the index to the storage.
+	if err := w.bkt.Upload(ctx, IndexFilename, bytes.NewReader(content)); err != nil {
+		return nil, errors.Wrap(err, "upload bucket index")
+	}
+
+	return idx, nil
+}
+
+// GenerateIndex generates the bucket index and returns it, without storing it to the storage.
+// If the old index is not passed in input, then the bucket index will be generated from scratch.
+func (w *Writer) GenerateIndex(ctx context.Context, old *Index) (*Index, error) {
+	var oldBlocks []*Block
+	var oldBlockDeletionMarks []*BlockDeletionMark
+
+	// Read the old index, if provided.
+	if old != nil {
+		oldBlocks = old.Blocks
+		oldBlockDeletionMarks = old.BlockDeletionMarks
+	}
+
+	blocks, err := w.generateBlocksIndex(ctx, oldBlocks)
+	if err != nil {
+		return nil, err
+	}
+
+	blockDeletionMarks, err := w.generateBlockDeletionMarksIndex(ctx, oldBlockDeletionMarks)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Index{
+		Version:            IndexVersion1,
+		Blocks:             blocks,
+		BlockDeletionMarks: blockDeletionMarks,
+		UpdatedAt:          time.Now().Unix(),
+	}, nil
+}
+
+func (w *Writer) generateBlocksIndex(ctx context.Context, old []*Block) ([]*Block, error) {
+	out := make([]*Block, 0, len(old))
+	discovered := map[ulid.ULID]struct{}{}
+
+	// Find all blocks in the storage.
+	err := w.bkt.Iter(ctx, "", func(name string) error {
+		if id, ok := block.IsBlockDir(name); ok {
+			discovered[id] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "list blocks")
+	}
+
+	// Since blocks are immutable, all blocks already existing in the index can just be copied.
+	for _, b := range old {
+		if _, ok := discovered[b.ID]; ok {
+			out = append(out, b)
+			delete(discovered, b.ID)
+		}
+	}
+
+	// Remaining blocks are new ones and we have to fetch the meta.json for each of them, in order
+	// to find out if their upload has been completed (meta.json is uploaded last) and get the block
+	// information to store in the bucket index.
+	for id := range discovered {
+		b, err := w.generateBlockIndexEntry(ctx, id)
+		if errors.Is(err, errBlockMetaNotFound) {
+			level.Warn(w.logger).Log("msg", "skipped partial block when generating bucket index", "block", id.String())
+			continue
+		}
+		if errors.Is(err, errBlockMetaCorrupted) {
+			level.Error(w.logger).Log("msg", "skipped block with corrupted meta.json when generating bucket index", "block", id.String(), "err", err)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, b)
+	}
+
+	return out, nil
+}
+
+func (w *Writer) generateBlockIndexEntry(ctx context.Context, id ulid.ULID) (*Block, error) {
+	metaFile := path.Join(id.String(), block.MetaFilename)
+
+	// Get the block's meta.json file.
+	r, err := w.bkt.ReaderWithExpectedErrs(w.bkt.IsObjNotFoundErr).Get(ctx, metaFile)
+	if w.bkt.IsObjNotFoundErr(err) {
+		return nil, errBlockMetaNotFound
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "get block meta file: %v", metaFile)
+	}
+	defer runutil.CloseWithLogOnErr(w.logger, r, "close get block meta file")
+
+	metaContent, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, errors.Wrapf(err, "read block meta file: %v", metaFile)
+	}
+
+	// Unmarshal it.
+	m := metadata.Meta{}
+	if err := json.Unmarshal(metaContent, &m); err != nil {
+		return nil, errors.Wrapf(errBlockMetaCorrupted, "unmarshal block meta file %s: %v", metaFile, err)
+	}
+
+	if m.Version != metadata.TSDBVersion1 {
+		return nil, errors.Errorf("unexpected block meta version: %s version: %d", metaFile, m.Version)
+	}
+
+	block := BlockFromThanosMeta(m)
+
+	// Get the meta.json attributes.
+	attrs, err := w.bkt.Attributes(ctx, metaFile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "read meta file attributes: %v", metaFile)
+	}
+
+	// Since the meta.json file is the last file of a block being uploaded and it's immutable
+	// we can safely assume that the last modified timestamp of the meta.json is the time when
+	// the block has completed to be uploaded.
+	block.UploadedAt = attrs.LastModified.Unix()
+
+	return block, nil
+}
+
+func (w *Writer) generateBlockDeletionMarksIndex(ctx context.Context, old []*BlockDeletionMark) ([]*BlockDeletionMark, error) {
+	out := make([]*BlockDeletionMark, 0, len(old))
+	discovered := map[ulid.ULID]struct{}{}
+
+	// Find all markers in the storage.
+	err := w.bkt.Iter(ctx, MarkersPathname+"/", func(name string) error {
+		if blockID, ok := IsBlockDeletionMarkFilename(path.Base(name)); ok {
+			discovered[blockID] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "list block deletion marks")
+	}
+
+	// Since deletion marks are immutable, all markers already existing in the index can just be copied.
+	for _, m := range old {
+		if _, ok := discovered[m.ID]; ok {
+			out = append(out, m)
+			delete(discovered, m.ID)
+		}
+	}
+
+	// Remaining markers are new ones and we have to fetch them.
+	for id := range discovered {
+		m, err := w.generateBlockDeletionMarkIndexEntry(ctx, id)
+		if errors.Is(err, errBlockDeletionMarkNotFound) {
+			// This could happen if the block is permanently deleted between the "list objects" and now.
+			level.Warn(w.logger).Log("msg", "skipped missing block deletion mark when generating bucket index", "block", id.String())
+			continue
+		}
+		if errors.Is(err, errBlockDeletionMarkCorrupted) {
+			level.Error(w.logger).Log("msg", "skipped corrupted block deletion mark when generating bucket index", "block", id.String(), "err", err)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, m)
+	}
+
+	return out, nil
+}
+
+func (w *Writer) generateBlockDeletionMarkIndexEntry(ctx context.Context, id ulid.ULID) (*BlockDeletionMark, error) {
+	markFile := path.Join(id.String(), metadata.DeletionMarkFilename)
+
+	// Get the block's deletion mark file.
+	r, err := w.bkt.ReaderWithExpectedErrs(w.bkt.IsObjNotFoundErr).Get(ctx, markFile)
+	if w.bkt.IsObjNotFoundErr(err) {
+		return nil, errBlockDeletionMarkNotFound
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "get block deletion mark: %v", markFile)
+	}
+	defer runutil.CloseWithLogOnErr(w.logger, r, "close get block deletion mark")
+
+	markContent, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, errors.Wrapf(err, "read block deletion mark: %v", markFile)
+	}
+
+	// Unmarshal it.
+	m := metadata.DeletionMark{}
+	if err := json.Unmarshal(markContent, &m); err != nil {
+		return nil, errors.Wrapf(errBlockDeletionMarkCorrupted, "unmarshal block deletion mark %s: %v", markFile, err)
+	}
+
+	if m.Version != metadata.DeletionMarkVersion1 {
+		return nil, errors.Errorf("unexpected deletion mark version: %s version: %d", markFile, m.Version)
+	}
+
+	return BlockDeletionMarkFromThanosMarker(&m), nil
+}

--- a/pkg/storage/tsdb/bucketindex/writer.go
+++ b/pkg/storage/tsdb/bucketindex/writer.go
@@ -31,11 +31,11 @@ var (
 
 // Writer is responsible to generate and write a bucket index.
 type Writer struct {
-	bkt    objstore.InstrumentedBucket
+	bkt    objstore.Bucket
 	logger log.Logger
 }
 
-func NewWriter(bkt objstore.InstrumentedBucket, userID string, logger log.Logger) *Writer {
+func NewWriter(bkt objstore.Bucket, userID string, logger log.Logger) *Writer {
 	return &Writer{
 		bkt:    bucket.NewUserBucketClient(userID, bkt),
 		logger: util.WithUserID(userID, logger),
@@ -156,7 +156,7 @@ func (w *Writer) generateBlockIndexEntry(ctx context.Context, id ulid.ULID) (*Bl
 	metaFile := path.Join(id.String(), block.MetaFilename)
 
 	// Get the block's meta.json file.
-	r, err := w.bkt.ReaderWithExpectedErrs(w.bkt.IsObjNotFoundErr).Get(ctx, metaFile)
+	r, err := w.bkt.Get(ctx, metaFile)
 	if w.bkt.IsObjNotFoundErr(err) {
 		return nil, ErrBlockMetaNotFound
 	}
@@ -245,7 +245,7 @@ func (w *Writer) generateBlockDeletionMarkIndexEntry(ctx context.Context, id uli
 	markFile := path.Join(id.String(), metadata.DeletionMarkFilename)
 
 	// Get the block's deletion mark file.
-	r, err := w.bkt.ReaderWithExpectedErrs(w.bkt.IsObjNotFoundErr).Get(ctx, markFile)
+	r, err := w.bkt.Get(ctx, markFile)
 	if w.bkt.IsObjNotFoundErr(err) {
 		return nil, ErrBlockDeletionMarkNotFound
 	}

--- a/pkg/storage/tsdb/bucketindex/writer_test.go
+++ b/pkg/storage/tsdb/bucketindex/writer_test.go
@@ -1,0 +1,207 @@
+package bucketindex
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/objstore"
+
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
+	"github.com/cortexproject/cortex/pkg/storage/bucket/filesystem"
+	"github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"
+)
+
+func TestWriter_WriteIndex(t *testing.T) {
+	const userID = "user-1"
+
+	bkt, cleanup := prepareFilesystemBucket(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	// Generate the initial index.
+	bkt = BucketWithMarkersIndex(bkt)
+	block1 := testutil.MockStorageBlock(t, bkt, userID, 10, 20)
+	block2 := testutil.MockStorageBlock(t, bkt, userID, 20, 30)
+	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2)
+
+	w := NewWriter(bkt, userID, logger)
+	returnedIdx, err := w.WriteIndex(ctx, nil)
+	require.NoError(t, err)
+	writtenIdx, err := ReadIndex(ctx, bkt, userID, logger)
+	require.NoError(t, err)
+
+	for _, idx := range []*Index{returnedIdx, writtenIdx} {
+		assertBucketIndexEqual(t, idx, bkt, userID,
+			[]tsdb.BlockMeta{block1, block2},
+			[]*metadata.DeletionMark{block2Mark})
+	}
+
+	// Create new blocks, and generate a new index.
+	block3 := testutil.MockStorageBlock(t, bkt, userID, 30, 40)
+	block4 := testutil.MockStorageBlock(t, bkt, userID, 40, 50)
+	block4Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block4)
+
+	returnedIdx, err = w.WriteIndex(ctx, returnedIdx)
+	require.NoError(t, err)
+	writtenIdx, err = ReadIndex(ctx, bkt, userID, logger)
+	require.NoError(t, err)
+
+	for _, idx := range []*Index{returnedIdx, writtenIdx} {
+		assertBucketIndexEqual(t, idx, bkt, userID,
+			[]tsdb.BlockMeta{block1, block2, block3, block4},
+			[]*metadata.DeletionMark{block2Mark, block4Mark})
+	}
+
+	// Hard delete a block and generate a new index.
+	require.NoError(t, block.Delete(ctx, log.NewNopLogger(), bucket.NewUserBucketClient(userID, bkt), block2.ULID))
+
+	returnedIdx, err = w.WriteIndex(ctx, returnedIdx)
+	require.NoError(t, err)
+	writtenIdx, err = ReadIndex(ctx, bkt, userID, logger)
+	require.NoError(t, err)
+
+	for _, idx := range []*Index{returnedIdx, writtenIdx} {
+		assertBucketIndexEqual(t, idx, bkt, userID,
+			[]tsdb.BlockMeta{block1, block3, block4},
+			[]*metadata.DeletionMark{block4Mark})
+	}
+}
+
+func TestWriter_GenerateIndex_ShouldSkipPartialBlocks(t *testing.T) {
+	const userID = "user-1"
+
+	bkt, cleanup := prepareFilesystemBucket(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	// Mock some blocks in the storage.
+	bkt = BucketWithMarkersIndex(bkt)
+	block1 := testutil.MockStorageBlock(t, bkt, userID, 10, 20)
+	block2 := testutil.MockStorageBlock(t, bkt, userID, 20, 30)
+	block3 := testutil.MockStorageBlock(t, bkt, userID, 30, 40)
+	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2)
+
+	// Delete a block's meta.json to simulate a partial block.
+	require.NoError(t, bkt.Delete(ctx, path.Join(userID, block3.ULID.String(), metadata.MetaFilename)))
+
+	w := NewWriter(bkt, userID, logger)
+	idx, err := w.GenerateIndex(ctx, nil)
+	require.NoError(t, err)
+	assertBucketIndexEqual(t, idx, bkt, userID,
+		[]tsdb.BlockMeta{block1, block2},
+		[]*metadata.DeletionMark{block2Mark})
+}
+
+func TestWriter_GenerateIndex_ShouldSkipBlocksWithCorruptedMeta(t *testing.T) {
+	const userID = "user-1"
+
+	bkt, cleanup := prepareFilesystemBucket(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	// Mock some blocks in the storage.
+	bkt = BucketWithMarkersIndex(bkt)
+	block1 := testutil.MockStorageBlock(t, bkt, userID, 10, 20)
+	block2 := testutil.MockStorageBlock(t, bkt, userID, 20, 30)
+	block3 := testutil.MockStorageBlock(t, bkt, userID, 30, 40)
+	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2)
+
+	// Overwrite a block's meta.json with invalid data.
+	require.NoError(t, bkt.Upload(ctx, path.Join(userID, block3.ULID.String(), metadata.MetaFilename), bytes.NewReader([]byte("invalid!}"))))
+
+	w := NewWriter(bkt, userID, logger)
+	idx, err := w.GenerateIndex(ctx, nil)
+	require.NoError(t, err)
+	assertBucketIndexEqual(t, idx, bkt, userID,
+		[]tsdb.BlockMeta{block1, block2},
+		[]*metadata.DeletionMark{block2Mark})
+}
+
+func TestWriter_GenerateIndex_NoTenantInTheBucket(t *testing.T) {
+	const userID = "user-1"
+
+	ctx := context.Background()
+	bkt, cleanup := prepareFilesystemBucket(t)
+	defer cleanup()
+
+	for _, oldIdx := range []*Index{nil, {}} {
+		w := NewWriter(bkt, userID, log.NewNopLogger())
+		idx, err := w.GenerateIndex(ctx, oldIdx)
+
+		require.NoError(t, err)
+		assert.Equal(t, IndexVersion1, idx.Version)
+		assert.InDelta(t, time.Now().Unix(), idx.UpdatedAt, 2)
+		assert.Len(t, idx.Blocks, 0)
+		assert.Len(t, idx.BlockDeletionMarks, 0)
+	}
+}
+
+func prepareFilesystemBucket(t *testing.T) (objstore.InstrumentedBucket, func()) {
+	storageDir, err := ioutil.TempDir(os.TempDir(), "")
+	require.NoError(t, err)
+
+	bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
+	require.NoError(t, err)
+
+	cleanup := func() {
+		require.NoError(t, os.RemoveAll(storageDir))
+	}
+
+	return objstore.BucketWithMetrics("test", bkt, nil), cleanup
+}
+
+func getBlockUploadedAt(t *testing.T, bkt objstore.Bucket, userID string, blockID ulid.ULID) int64 {
+	metaFile := path.Join(userID, blockID.String(), block.MetaFilename)
+
+	attrs, err := bkt.Attributes(context.Background(), metaFile)
+	require.NoError(t, err)
+
+	return attrs.LastModified.Unix()
+}
+
+func assertBucketIndexEqual(t *testing.T, idx *Index, bkt objstore.Bucket, userID string, expectedBlocks []tsdb.BlockMeta, expectedDeletionMarks []*metadata.DeletionMark) {
+	assert.Equal(t, IndexVersion1, idx.Version)
+	assert.InDelta(t, time.Now().Unix(), idx.UpdatedAt, 2)
+
+	// Build the list of expected block index entries.
+	var expectedBlockEntries []*Block
+	for _, b := range expectedBlocks {
+		expectedBlockEntries = append(expectedBlockEntries, &Block{
+			ID:         b.ULID,
+			MinTime:    b.MinTime,
+			MaxTime:    b.MaxTime,
+			UploadedAt: getBlockUploadedAt(t, bkt, userID, b.ULID),
+		})
+	}
+
+	assert.ElementsMatch(t, expectedBlockEntries, idx.Blocks)
+
+	// Build the list of expected block deletion mark index entries.
+	var expectedMarkEntries []*BlockDeletionMark
+	for _, m := range expectedDeletionMarks {
+		expectedMarkEntries = append(expectedMarkEntries, &BlockDeletionMark{
+			ID:           m.ID,
+			DeletionTime: m.DeletionTime,
+		})
+	}
+
+	assert.ElementsMatch(t, expectedMarkEntries, idx.BlockDeletionMarks)
+}

--- a/pkg/storage/tsdb/bucketindex/writer_test.go
+++ b/pkg/storage/tsdb/bucketindex/writer_test.go
@@ -154,7 +154,7 @@ func TestWriter_GenerateIndex_NoTenantInTheBucket(t *testing.T) {
 	}
 }
 
-func prepareFilesystemBucket(t testing.TB) (objstore.InstrumentedBucket, func()) {
+func prepareFilesystemBucket(t testing.TB) (objstore.Bucket, func()) {
 	storageDir, err := ioutil.TempDir(os.TempDir(), "")
 	require.NoError(t, err)
 

--- a/pkg/storage/tsdb/bucketindex/writer_test.go
+++ b/pkg/storage/tsdb/bucketindex/writer_test.go
@@ -33,7 +33,7 @@ func TestWriter_WriteIndex(t *testing.T) {
 	logger := log.NewNopLogger()
 
 	// Generate the initial index.
-	bkt = BucketWithMarkersIndex(bkt)
+	bkt = BucketWithGlobalMarkers(bkt)
 	block1 := testutil.MockStorageBlock(t, bkt, userID, 10, 20)
 	block2 := testutil.MockStorageBlock(t, bkt, userID, 20, 30)
 	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2)
@@ -91,7 +91,7 @@ func TestWriter_GenerateIndex_ShouldSkipPartialBlocks(t *testing.T) {
 	logger := log.NewNopLogger()
 
 	// Mock some blocks in the storage.
-	bkt = BucketWithMarkersIndex(bkt)
+	bkt = BucketWithGlobalMarkers(bkt)
 	block1 := testutil.MockStorageBlock(t, bkt, userID, 10, 20)
 	block2 := testutil.MockStorageBlock(t, bkt, userID, 20, 30)
 	block3 := testutil.MockStorageBlock(t, bkt, userID, 30, 40)
@@ -118,7 +118,7 @@ func TestWriter_GenerateIndex_ShouldSkipBlocksWithCorruptedMeta(t *testing.T) {
 	logger := log.NewNopLogger()
 
 	// Mock some blocks in the storage.
-	bkt = BucketWithMarkersIndex(bkt)
+	bkt = BucketWithGlobalMarkers(bkt)
 	block1 := testutil.MockStorageBlock(t, bkt, userID, 10, 20)
 	block2 := testutil.MockStorageBlock(t, bkt, userID, 20, 30)
 	block3 := testutil.MockStorageBlock(t, bkt, userID, 30, 40)

--- a/pkg/storage/tsdb/bucketindex/writer_test.go
+++ b/pkg/storage/tsdb/bucketindex/writer_test.go
@@ -154,7 +154,7 @@ func TestWriter_GenerateIndex_NoTenantInTheBucket(t *testing.T) {
 	}
 }
 
-func prepareFilesystemBucket(t *testing.T) (objstore.InstrumentedBucket, func()) {
+func prepareFilesystemBucket(t testing.TB) (objstore.InstrumentedBucket, func()) {
 	storageDir, err := ioutil.TempDir(os.TempDir(), "")
 	require.NoError(t, err)
 
@@ -168,7 +168,7 @@ func prepareFilesystemBucket(t *testing.T) (objstore.InstrumentedBucket, func())
 	return objstore.BucketWithMetrics("test", bkt, nil), cleanup
 }
 
-func getBlockUploadedAt(t *testing.T, bkt objstore.Bucket, userID string, blockID ulid.ULID) int64 {
+func getBlockUploadedAt(t testing.TB, bkt objstore.Bucket, userID string, blockID ulid.ULID) int64 {
 	metaFile := path.Join(userID, blockID.String(), block.MetaFilename)
 
 	attrs, err := bkt.Attributes(context.Background(), metaFile)
@@ -177,7 +177,7 @@ func getBlockUploadedAt(t *testing.T, bkt objstore.Bucket, userID string, blockI
 	return attrs.LastModified.Unix()
 }
 
-func assertBucketIndexEqual(t *testing.T, idx *Index, bkt objstore.Bucket, userID string, expectedBlocks []tsdb.BlockMeta, expectedDeletionMarks []*metadata.DeletionMark) {
+func assertBucketIndexEqual(t testing.TB, idx *Index, bkt objstore.Bucket, userID string, expectedBlocks []tsdb.BlockMeta, expectedDeletionMarks []*metadata.DeletionMark) {
 	assert.Equal(t, IndexVersion1, idx.Version)
 	assert.InDelta(t, time.Now().Unix(), idx.UpdatedAt, 2)
 

--- a/pkg/storage/tsdb/testutil/block_mock.go
+++ b/pkg/storage/tsdb/testutil/block_mock.go
@@ -1,0 +1,64 @@
+package testutil
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+func MockStorageBlock(t *testing.T, bucket objstore.Bucket, userID string, minT, maxT int64) tsdb.BlockMeta {
+	// Generate a block ID whose timestamp matches the maxT (for simplicity we assume it
+	// has been compacted and shipped in zero time, even if not realistic).
+	id := ulid.MustNew(uint64(maxT), rand.Reader)
+
+	meta := tsdb.BlockMeta{
+		Version: 1,
+		ULID:    id,
+		MinTime: minT,
+		MaxTime: maxT,
+		Compaction: tsdb.BlockMetaCompaction{
+			Level:   1,
+			Sources: []ulid.ULID{id},
+		},
+	}
+
+	metaContent, err := json.Marshal(meta)
+	if err != nil {
+		panic("failed to marshal mocked block meta")
+	}
+
+	metaContentReader := strings.NewReader(string(metaContent))
+	metaPath := fmt.Sprintf("%s/%s/meta.json", userID, id.String())
+	require.NoError(t, bucket.Upload(context.Background(), metaPath, metaContentReader))
+
+	return meta
+}
+
+func MockStorageDeletionMark(t *testing.T, bucket objstore.Bucket, userID string, meta tsdb.BlockMeta) *metadata.DeletionMark {
+	mark := metadata.DeletionMark{
+		ID:           meta.ULID,
+		DeletionTime: time.Now().Add(-time.Minute).Unix(),
+		Version:      metadata.DeletionMarkVersion1,
+	}
+
+	markContent, err := json.Marshal(mark)
+	if err != nil {
+		panic("failed to marshal mocked block meta")
+	}
+
+	markContentReader := strings.NewReader(string(markContent))
+	markPath := fmt.Sprintf("%s/%s/%s", userID, meta.ULID.String(), metadata.DeletionMarkFilename)
+	require.NoError(t, bucket.Upload(context.Background(), markPath, markContentReader))
+
+	return &mark
+}

--- a/pkg/storage/tsdb/testutil/block_mock.go
+++ b/pkg/storage/tsdb/testutil/block_mock.go
@@ -16,7 +16,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/objstore"
 )
 
-func MockStorageBlock(t *testing.T, bucket objstore.Bucket, userID string, minT, maxT int64) tsdb.BlockMeta {
+func MockStorageBlock(t testing.TB, bucket objstore.Bucket, userID string, minT, maxT int64) tsdb.BlockMeta {
 	// Generate a block ID whose timestamp matches the maxT (for simplicity we assume it
 	// has been compacted and shipped in zero time, even if not realistic).
 	id := ulid.MustNew(uint64(maxT), rand.Reader)
@@ -44,7 +44,7 @@ func MockStorageBlock(t *testing.T, bucket objstore.Bucket, userID string, minT,
 	return meta
 }
 
-func MockStorageDeletionMark(t *testing.T, bucket objstore.Bucket, userID string, meta tsdb.BlockMeta) *metadata.DeletionMark {
+func MockStorageDeletionMark(t testing.TB, bucket objstore.Bucket, userID string, meta tsdb.BlockMeta) *metadata.DeletionMark {
 	mark := metadata.DeletionMark{
 		ID:           meta.ULID,
 		DeletionTime: time.Now().Add(-time.Minute).Unix(),


### PR DESCRIPTION
**What this PR does**:
This is another preliminary step required to implement the bucket index, as designed in https://github.com/cortexproject/cortex/pull/3554. In this PR:

- Introduce bucket index reader and writer (but not plugged in yet)
- Introduce a bucket client wrapper used to store block deletion marks in the per-tenant global location too
- Plug the bucket client wrapper in the compactor (which is the component deleting blocks)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
