### PR TITLE
Add redis and inmemory cache backend for blocks storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,15 @@
 * [ENHANCEMENT] Distributor: reduce CPU and memory when an high number of errors are returned by the distributor on the write path. #3990
 * [ENHANCEMENT] Put metric before label value in the "label value too long" error message. #4018
 * [ENHANCEMENT] Allow use of `y|w|d` suffixes for duration related limits and per-tenant limits. #4044
-* [BUGFIX] Ruler-API: fix bug where `/api/v1/rules/<namespace>/<group_name>` endpoint return `400` instead of `404`. #4013
+* [ENHANCEMENT] Blocks storage: added Redis support as Cache backend. #3573
+  - The following configure have been added.
+    - `-<prefix>.redis.key-prefix`
+    - `-blocks-storage.bucket-store.index-cache.backend`
+    - `-blocks-storage.bucket-store.index-cache.redis.*`
+    - `-blocks-storage.bucket-store.metadata-cache.backend`
+    - `-blocks-storage.bucket-store.metadata-cache.redis.*`
+    - `-blocks-storage.bucket-store.chunks-cache.backend.backend`
+    - `-blocks-storage.bucket-store.chunks-cache.backend.redis.*`* [BUGFIX] Ruler-API: fix bug where `/api/v1/rules/<namespace>/<group_name>` endpoint return `400` instead of `404`. #4013
 * [BUGFIX] Distributor: reverted changes done to rate limiting in #3825. #3948
 * [BUGFIX] Ingester: Fix race condition when opening and closing tsdb concurrently. #3959
 * [BUGFIX] Querier: streamline tracing spans. #3924
@@ -33,6 +41,7 @@
 * [BUGFIX] Distributor: fix issue causing distributors to not extend the replication set because of failing instances when zone-aware replication is enabled. #3977
 * [BUGFIX] Query-frontend: Fix issue where cached entry size keeps increasing when making tiny query repeatedly. #3968
 * [BUGFIX] Compactor: `-compactor.blocks-retention-period` now supports weeks (`w`) and years (`y`). #4027
+
 
 ## Blocksconvert
 

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -465,7 +465,8 @@ blocks_storage:
     [consistency_delay: <duration> | default = 0s]
 
     index_cache:
-      # The index cache backend type. Supported values: inmemory, memcached.
+      # The index cache backend type. Supported values: inmemory, memcached,
+      # redis.
       # CLI flag: -blocks-storage.bucket-store.index-cache.backend
       [backend: <string> | default = "inmemory"]
 
@@ -517,13 +518,19 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.max-item-size
         [max_item_size: <int> | default = 1048576]
 
+      # The redis_config configures the Redis backend cache.
+      # The CLI flags prefix for this block config is:
+      # blocks-storage.bucket-store.index-cache
+      [redis: <redis_config>]
+
       # Deprecated: compress postings before storing them to postings cache.
       # This option is unused and postings compression is always enabled.
       # CLI flag: -blocks-storage.bucket-store.index-cache.postings-compression-enabled
       [postings_compression_enabled: <boolean> | default = false]
 
     chunks_cache:
-      # Backend for chunks cache, if not empty. Supported values: memcached.
+      # Backend for chunks cache, if not empty. Supported values: memcached,
+      # redis.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.backend
       [backend: <string> | default = ""]
 
@@ -569,6 +576,11 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size
         [max_item_size: <int> | default = 1048576]
 
+      # The redis_config configures the Redis backend cache.
+      # The CLI flags prefix for this block config is:
+      # blocks-storage.bucket-store.chunks-cache
+      [redis: <redis_config>]
+
       # Size of each subrange that bucket object is split into for better
       # caching.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-size
@@ -589,7 +601,8 @@ blocks_storage:
       [subrange_ttl: <duration> | default = 24h]
 
     metadata_cache:
-      # Backend for metadata cache, if not empty. Supported values: memcached.
+      # Backend for metadata cache, if not empty. Supported values: memcached,
+      # redis.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.backend
       [backend: <string> | default = ""]
 
@@ -634,6 +647,11 @@ blocks_storage:
         # stored. If set to 0, no maximum size is enforced.
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size
         [max_item_size: <int> | default = 1048576]
+
+      # The redis_config configures the Redis backend cache.
+      # The CLI flags prefix for this block config is:
+      # blocks-storage.bucket-store.metadata-cache
+      [redis: <redis_config>]
 
       # How long to cache list of tenants in the bucket.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.tenants-list-ttl

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -530,7 +530,7 @@ blocks_storage:
 
     chunks_cache:
       # Backend for chunks cache, if not empty. Supported values: memcached,
-      # redis.
+      # redis, inmemory.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.backend
       [backend: <string> | default = ""]
 
@@ -581,6 +581,16 @@ blocks_storage:
       # blocks-storage.bucket-store.chunks-cache
       [redis: <redis_config>]
 
+      inmemory:
+        # The overall maximum size of stored in memory.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.inmemory.max-size
+        [max_size: <int> | default = 262144000]
+
+        # The maximum size of an item stored in memory. Bigger items are not
+        # stored. Must specify a value less than max_size.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.inmemory.max-item-size
+        [max_item_size: <int> | default = 131072000]
+
       # Size of each subrange that bucket object is split into for better
       # caching.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-size
@@ -602,7 +612,7 @@ blocks_storage:
 
     metadata_cache:
       # Backend for metadata cache, if not empty. Supported values: memcached,
-      # redis.
+      # redis, inmemory.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.backend
       [backend: <string> | default = ""]
 
@@ -652,6 +662,16 @@ blocks_storage:
       # The CLI flags prefix for this block config is:
       # blocks-storage.bucket-store.metadata-cache
       [redis: <redis_config>]
+
+      inmemory:
+        # The overall maximum size of stored in memory.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.inmemory.max-size
+        [max_size: <int> | default = 262144000]
+
+        # The maximum size of an item stored in memory. Bigger items are not
+        # stored. Must specify a value less than max_size.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.inmemory.max-item-size
+        [max_item_size: <int> | default = 131072000]
 
       # How long to cache list of tenants in the bucket.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.tenants-list-ttl

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -511,7 +511,8 @@ blocks_storage:
     [consistency_delay: <duration> | default = 0s]
 
     index_cache:
-      # The index cache backend type. Supported values: inmemory, memcached.
+      # The index cache backend type. Supported values: inmemory, memcached,
+      # redis.
       # CLI flag: -blocks-storage.bucket-store.index-cache.backend
       [backend: <string> | default = "inmemory"]
 
@@ -563,13 +564,19 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.max-item-size
         [max_item_size: <int> | default = 1048576]
 
+      # The redis_config configures the Redis backend cache.
+      # The CLI flags prefix for this block config is:
+      # blocks-storage.bucket-store.index-cache
+      [redis: <redis_config>]
+
       # Deprecated: compress postings before storing them to postings cache.
       # This option is unused and postings compression is always enabled.
       # CLI flag: -blocks-storage.bucket-store.index-cache.postings-compression-enabled
       [postings_compression_enabled: <boolean> | default = false]
 
     chunks_cache:
-      # Backend for chunks cache, if not empty. Supported values: memcached.
+      # Backend for chunks cache, if not empty. Supported values: memcached,
+      # redis.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.backend
       [backend: <string> | default = ""]
 
@@ -615,6 +622,11 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size
         [max_item_size: <int> | default = 1048576]
 
+      # The redis_config configures the Redis backend cache.
+      # The CLI flags prefix for this block config is:
+      # blocks-storage.bucket-store.chunks-cache
+      [redis: <redis_config>]
+
       # Size of each subrange that bucket object is split into for better
       # caching.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-size
@@ -635,7 +647,8 @@ blocks_storage:
       [subrange_ttl: <duration> | default = 24h]
 
     metadata_cache:
-      # Backend for metadata cache, if not empty. Supported values: memcached.
+      # Backend for metadata cache, if not empty. Supported values: memcached,
+      # redis.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.backend
       [backend: <string> | default = ""]
 
@@ -680,6 +693,11 @@ blocks_storage:
         # stored. If set to 0, no maximum size is enforced.
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size
         [max_item_size: <int> | default = 1048576]
+
+      # The redis_config configures the Redis backend cache.
+      # The CLI flags prefix for this block config is:
+      # blocks-storage.bucket-store.metadata-cache
+      [redis: <redis_config>]
 
       # How long to cache list of tenants in the bucket.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.tenants-list-ttl

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -576,7 +576,7 @@ blocks_storage:
 
     chunks_cache:
       # Backend for chunks cache, if not empty. Supported values: memcached,
-      # redis.
+      # redis, inmemory.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.backend
       [backend: <string> | default = ""]
 
@@ -627,6 +627,16 @@ blocks_storage:
       # blocks-storage.bucket-store.chunks-cache
       [redis: <redis_config>]
 
+      inmemory:
+        # The overall maximum size of stored in memory.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.inmemory.max-size
+        [max_size: <int> | default = 262144000]
+
+        # The maximum size of an item stored in memory. Bigger items are not
+        # stored. Must specify a value less than max_size.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.inmemory.max-item-size
+        [max_item_size: <int> | default = 131072000]
+
       # Size of each subrange that bucket object is split into for better
       # caching.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-size
@@ -648,7 +658,7 @@ blocks_storage:
 
     metadata_cache:
       # Backend for metadata cache, if not empty. Supported values: memcached,
-      # redis.
+      # redis, inmemory.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.backend
       [backend: <string> | default = ""]
 
@@ -698,6 +708,16 @@ blocks_storage:
       # The CLI flags prefix for this block config is:
       # blocks-storage.bucket-store.metadata-cache
       [redis: <redis_config>]
+
+      inmemory:
+        # The overall maximum size of stored in memory.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.inmemory.max-size
+        [max_size: <int> | default = 262144000]
+
+        # The maximum size of an item stored in memory. Bigger items are not
+        # stored. Must specify a value less than max_size.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.inmemory.max-item-size
+        [max_item_size: <int> | default = 131072000]
 
       # How long to cache list of tenants in the bucket.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.tenants-list-ttl

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4592,7 +4592,7 @@ bucket_store:
 
   chunks_cache:
     # Backend for chunks cache, if not empty. Supported values: memcached,
-    # redis.
+    # redis, inmemory.
     # CLI flag: -blocks-storage.bucket-store.chunks-cache.backend
     [backend: <string> | default = ""]
 
@@ -4643,6 +4643,16 @@ bucket_store:
     # blocks-storage.bucket-store.chunks-cache
     [redis: <redis_config>]
 
+    inmemory:
+      # The overall maximum size of stored in memory.
+      # CLI flag: -blocks-storage.bucket-store.chunks-cache.inmemory.max-size
+      [max_size: <int> | default = 262144000]
+
+      # The maximum size of an item stored in memory. Bigger items are not
+      # stored. Must specify a value less than max_size.
+      # CLI flag: -blocks-storage.bucket-store.chunks-cache.inmemory.max-item-size
+      [max_item_size: <int> | default = 131072000]
+
     # Size of each subrange that bucket object is split into for better caching.
     # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-size
     [subrange_size: <int> | default = 16000]
@@ -4663,7 +4673,7 @@ bucket_store:
 
   metadata_cache:
     # Backend for metadata cache, if not empty. Supported values: memcached,
-    # redis.
+    # redis, inmemory.
     # CLI flag: -blocks-storage.bucket-store.metadata-cache.backend
     [backend: <string> | default = ""]
 
@@ -4713,6 +4723,16 @@ bucket_store:
     # The CLI flags prefix for this block config is:
     # blocks-storage.bucket-store.metadata-cache
     [redis: <redis_config>]
+
+    inmemory:
+      # The overall maximum size of stored in memory.
+      # CLI flag: -blocks-storage.bucket-store.metadata-cache.inmemory.max-size
+      [max_size: <int> | default = 262144000]
+
+      # The maximum size of an item stored in memory. Bigger items are not
+      # stored. Must specify a value less than max_size.
+      # CLI flag: -blocks-storage.bucket-store.metadata-cache.inmemory.max-item-size
+      [max_item_size: <int> | default = 131072000]
 
     # How long to cache list of tenants in the bucket.
     # CLI flag: -blocks-storage.bucket-store.metadata-cache.tenants-list-ttl

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4018,6 +4018,9 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 
 The `redis_config` configures the Redis backend cache. The supported CLI flags `<prefix>` used to reference this config block are:
 
+- `blocks-storage.bucket-store.chunks-cache`
+- `blocks-storage.bucket-store.index-cache`
+- `blocks-storage.bucket-store.metadata-cache`
 - `frontend`
 - `store.chunks-cache`
 - `store.index-cache-read`
@@ -4026,52 +4029,66 @@ The `redis_config` configures the Redis backend cache. The supported CLI flags `
 &nbsp;
 
 ```yaml
-# Redis Server endpoint to use for caching. A comma-separated list of endpoints
-# for Redis Cluster or Redis Sentinel. If empty, no redis will be used.
+# Cache config for metadata in blocks storage. Redis Server endpoint to use for
+# caching. A comma-separated list of endpoints for Redis Cluster or Redis
+# Sentinel. If empty, no redis will be used.
 # CLI flag: -<prefix>.redis.endpoint
 [endpoint: <string> | default = ""]
 
-# Redis Sentinel master name. An empty string for Redis Server or Redis Cluster.
+# Cache config for metadata in blocks storage. Redis Sentinel master name. An
+# empty string for Redis Server or Redis Cluster.
 # CLI flag: -<prefix>.redis.master-name
 [master_name: <string> | default = ""]
 
-# Maximum time to wait before giving up on redis requests.
+# Cache config for metadata in blocks storage. Maximum time to wait before
+# giving up on redis requests.
 # CLI flag: -<prefix>.redis.timeout
 [timeout: <duration> | default = 500ms]
 
-# How long keys stay in the redis.
+# Cache config for metadata in blocks storage. How long keys stay in the redis.
 # CLI flag: -<prefix>.redis.expiration
 [expiration: <duration> | default = 0s]
 
-# Database index.
+# Cache config for metadata in blocks storage. Database index.
 # CLI flag: -<prefix>.redis.db
 [db: <int> | default = 0]
 
-# Maximum number of connections in the pool.
+# Cache config for metadata in blocks storage. Maximum number of connections in
+# the pool.
 # CLI flag: -<prefix>.redis.pool-size
 [pool_size: <int> | default = 0]
 
-# Password to use when connecting to redis.
+# Cache config for metadata in blocks storage. Password to use when connecting
+# to redis.
 # CLI flag: -<prefix>.redis.password
 [password: <string> | default = ""]
 
-# Enable connecting to redis with TLS.
+# Cache config for metadata in blocks storage. Enable connecting to redis with
+# TLS.
 # CLI flag: -<prefix>.redis.tls-enabled
 [tls_enabled: <boolean> | default = false]
 
-# Skip validating server certificate.
+# Cache config for metadata in blocks storage. Skip validating server
+# certificate.
 # CLI flag: -<prefix>.redis.tls-insecure-skip-verify
 [tls_insecure_skip_verify: <boolean> | default = false]
 
-# Close connections after remaining idle for this duration. If the value is
-# zero, then idle connections are not closed.
+# Cache config for metadata in blocks storage. Close connections after remaining
+# idle for this duration. If the value is zero, then idle connections are not
+# closed.
 # CLI flag: -<prefix>.redis.idle-timeout
 [idle_timeout: <duration> | default = 0s]
 
-# Close connections older than this duration. If the value is zero, then the
-# pool does not close connections based on age.
+# Cache config for metadata in blocks storage. Close connections older than this
+# duration. If the value is zero, then the pool does not close connections based
+# on age.
 # CLI flag: -<prefix>.redis.max-connection-age
 [max_connection_age: <duration> | default = 0s]
+
+# Cache config for metadata in blocks storage. Adds the given value to the
+# beginning of the key.
+# CLI flag: -<prefix>.redis.key-prefix
+[key_prefix: <string> | default = ""]
 ```
 
 ### `memcached_config`
@@ -4510,7 +4527,8 @@ bucket_store:
   [consistency_delay: <duration> | default = 0s]
 
   index_cache:
-    # The index cache backend type. Supported values: inmemory, memcached.
+    # The index cache backend type. Supported values: inmemory, memcached,
+    # redis.
     # CLI flag: -blocks-storage.bucket-store.index-cache.backend
     [backend: <string> | default = "inmemory"]
 
@@ -4562,13 +4580,19 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.max-item-size
       [max_item_size: <int> | default = 1048576]
 
+    # The redis_config configures the Redis backend cache.
+    # The CLI flags prefix for this block config is:
+    # blocks-storage.bucket-store.index-cache
+    [redis: <redis_config>]
+
     # Deprecated: compress postings before storing them to postings cache. This
     # option is unused and postings compression is always enabled.
     # CLI flag: -blocks-storage.bucket-store.index-cache.postings-compression-enabled
     [postings_compression_enabled: <boolean> | default = false]
 
   chunks_cache:
-    # Backend for chunks cache, if not empty. Supported values: memcached.
+    # Backend for chunks cache, if not empty. Supported values: memcached,
+    # redis.
     # CLI flag: -blocks-storage.bucket-store.chunks-cache.backend
     [backend: <string> | default = ""]
 
@@ -4614,6 +4638,11 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size
       [max_item_size: <int> | default = 1048576]
 
+    # The redis_config configures the Redis backend cache.
+    # The CLI flags prefix for this block config is:
+    # blocks-storage.bucket-store.chunks-cache
+    [redis: <redis_config>]
+
     # Size of each subrange that bucket object is split into for better caching.
     # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-size
     [subrange_size: <int> | default = 16000]
@@ -4633,7 +4662,8 @@ bucket_store:
     [subrange_ttl: <duration> | default = 24h]
 
   metadata_cache:
-    # Backend for metadata cache, if not empty. Supported values: memcached.
+    # Backend for metadata cache, if not empty. Supported values: memcached,
+    # redis.
     # CLI flag: -blocks-storage.bucket-store.metadata-cache.backend
     [backend: <string> | default = ""]
 
@@ -4678,6 +4708,11 @@ bucket_store:
       # stored. If set to 0, no maximum size is enforced.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size
       [max_item_size: <int> | default = 1048576]
+
+    # The redis_config configures the Redis backend cache.
+    # The CLI flags prefix for this block config is:
+    # blocks-storage.bucket-store.metadata-cache
+    [redis: <redis_config>]
 
     # How long to cache list of tenants in the bucket.
     # CLI flag: -blocks-storage.bucket-store.metadata-cache.tenants-list-ttl

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.0-alpha.0.0.20210225194612-fa82d11a958a
 	go.etcd.io/etcd/server/v3 v3.5.0-alpha.0.0.20210225194612-fa82d11a958a
 	go.uber.org/atomic v1.7.0
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/net v0.0.0-20210324051636-2c4c8ecb7826
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba

--- a/pkg/chunk/cache/redis_cache.go
+++ b/pkg/chunk/cache/redis_cache.go
@@ -52,7 +52,7 @@ func (c *RedisCache) Fetch(ctx context.Context, keys []string) (found []string, 
 
 // Store stores the key in the cache.
 func (c *RedisCache) Store(ctx context.Context, keys []string, bufs [][]byte) {
-	err := c.redis.MSet(ctx, keys, bufs)
+	err := c.redis.MSet(ctx, keys, bufs, 0)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to put to redis", "name", c.name, "err", err)
 	}

--- a/pkg/chunk/cache/redis_cache_test.go
+++ b/pkg/chunk/cache/redis_cache_test.go
@@ -57,8 +57,8 @@ func mockRedisCache() (*RedisCache, error) {
 
 	}
 	redisClient := &RedisClient{
-		expiration: time.Minute,
-		timeout:    100 * time.Millisecond,
+		defaultExpiration: time.Minute,
+		timeout:           100 * time.Millisecond,
 		rdb: redis.NewUniversalClient(&redis.UniversalOptions{
 			Addrs: []string{redisServer.Addr()},
 		}),

--- a/pkg/storage/tsdb/inmemory_cache_config.go
+++ b/pkg/storage/tsdb/inmemory_cache_config.go
@@ -1,0 +1,25 @@
+package tsdb
+
+import (
+	"flag"
+
+	"github.com/thanos-io/thanos/pkg/cache"
+	"github.com/thanos-io/thanos/pkg/model"
+)
+
+type InMemoryCacheConfig struct {
+	MaxSize     uint64 `yaml:"max_size"`
+	MaxItemSize uint64 `yaml:"max_item_size"`
+}
+
+func (cfg *InMemoryCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
+	f.Uint64Var(&cfg.MaxSize, prefix+"inmemory.max-size", 250*1024*1024, "The overall maximum size of stored in memory.")
+	f.Uint64Var(&cfg.MaxItemSize, prefix+"inmemory.max-item-size", 125*1024*1024, "The maximum size of an item stored in memory. Bigger items are not stored. Must specify a value less than max_size.")
+}
+
+func (cfg InMemoryCacheConfig) ToThanosConfig() cache.InMemoryCacheConfig {
+	return cache.InMemoryCacheConfig{
+		MaxSize:     model.Bytes(cfg.MaxSize),
+		MaxItemSize: model.Bytes(cfg.MaxItemSize),
+	}
+}

--- a/pkg/storage/tsdb/redis_cache.go
+++ b/pkg/storage/tsdb/redis_cache.go
@@ -1,0 +1,66 @@
+package tsdb
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/thanos-io/thanos/pkg/cache"
+
+	chunkCache "github.com/cortexproject/cortex/pkg/chunk/cache"
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+)
+
+// impl thanos cache interface
+var _ cache.Cache = &RedisCache{}
+
+type RedisCache struct {
+	redisClient *chunkCache.RedisClient
+	logger      log.Logger
+	name        string
+}
+
+// NewRedisCache creates a new RedisCache
+func NewRedisCache(name string, redisClient *chunkCache.RedisClient, logger log.Logger) *RedisCache {
+	util_log.WarnExperimentalUse("Redis cache")
+	cache := &RedisCache{
+		name:        name,
+		redisClient: redisClient,
+		logger:      logger,
+	}
+	if err := cache.redisClient.Ping(context.Background()); err != nil {
+		level.Error(logger).Log("msg", "error connecting to redis", "name", name, "err", err)
+	}
+	return cache
+}
+
+func (r *RedisCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+	keys := make([]string, 0, len(data))
+	values := make([][]byte, 0, len(data))
+	for key, value := range data {
+		keys = append(keys, key)
+		values = append(values, value)
+	}
+	err := r.redisClient.MSet(ctx, keys, values, ttl)
+	if err != nil {
+		level.Error(r.logger).Log("msg", "failed to put to redis", "name", r.name, "err", err)
+	}
+}
+
+func (r *RedisCache) Fetch(ctx context.Context, keys []string) map[string][]byte {
+	response, err := r.redisClient.MGet(ctx, keys)
+	if err != nil {
+		level.Error(r.logger).Log("msg", "failed to get from redis", "name", r.name, "err", err)
+	}
+
+	result := make(map[string][]byte)
+	for index, value := range response {
+		if len(value) != 0 {
+			key := keys[index]
+			result[key] = value
+		}
+	}
+
+	return result
+}

--- a/pkg/storage/tsdb/redis_index_cache.go
+++ b/pkg/storage/tsdb/redis_index_cache.go
@@ -1,0 +1,149 @@
+package tsdb
+
+import (
+	"context"
+	"encoding/base64"
+	"strconv"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/pkg/labels"
+	storecache "github.com/thanos-io/thanos/pkg/store/cache"
+	"golang.org/x/crypto/blake2b"
+
+	chunkCache "github.com/cortexproject/cortex/pkg/chunk/cache"
+)
+
+const (
+	cacheTypePostings string = "Postings"
+	cacheTypeSeries   string = "Series"
+)
+
+// impl thanos cache interface
+var _ storecache.IndexCache = &RedisIndexCache{}
+
+type RedisIndexCache struct {
+	redisClient *chunkCache.RedisClient
+	logger      log.Logger
+
+	requests *prometheus.CounterVec
+	hits     *prometheus.CounterVec
+}
+
+// NewRedisIndexCache creates a new RedisIndexCache
+func NewRedisIndexCache(redisClient *chunkCache.RedisClient, logger log.Logger, reg prometheus.Registerer) (*RedisIndexCache, error) {
+	r := &RedisIndexCache{
+		redisClient: redisClient,
+		logger:      logger,
+	}
+
+	r.requests = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "thanos_store_index_cache_requests_total",
+		Help: "Total number of items requests to the cache.",
+	}, []string{"item_type"})
+	r.requests.WithLabelValues(cacheTypePostings)
+	r.requests.WithLabelValues(cacheTypeSeries)
+
+	r.hits = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "thanos_store_index_cache_hits_total",
+		Help: "Total number of items requests to the cache that were a hit.",
+	}, []string{"item_type"})
+	r.hits.WithLabelValues(cacheTypePostings)
+	r.hits.WithLabelValues(cacheTypeSeries)
+
+	return r, nil
+}
+
+func (r *RedisIndexCache) StorePostings(ctx context.Context, blockID ulid.ULID, l labels.Label, v []byte) {
+	key := cacheKey(blockID, cacheKeyPostings(l))
+
+	err := r.redisClient.MSet(ctx, []string{key}, [][]byte{v}, 0)
+	if err != nil {
+		level.Error(r.logger).Log("msg", "failed to cache postings in redis", "err", err)
+	}
+}
+
+func (r *RedisIndexCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, lbls []labels.Label) (hits map[labels.Label][]byte, misses []labels.Label) {
+	hits = map[labels.Label][]byte{}
+
+	keys := make([]string, 0, len(lbls))
+	for _, lbl := range lbls {
+		keys = append(keys, cacheKey(blockID, cacheKeyPostings(lbl)))
+	}
+
+	r.requests.WithLabelValues(cacheTypePostings).Add(float64(len(keys)))
+	response, err := r.redisClient.MGet(ctx, keys)
+	if err != nil {
+		level.Error(r.logger).Log("msg", "failed to fetch postings in redis", "err", err)
+		return nil, lbls
+	}
+
+	for index, value := range response {
+		label := lbls[index]
+		if len(value) == 0 {
+			misses = append(misses, label)
+		} else {
+			hits[label] = value
+		}
+	}
+
+	r.hits.WithLabelValues(cacheTypePostings).Add(float64(len(hits)))
+	return
+}
+
+func (r *RedisIndexCache) StoreSeries(ctx context.Context, blockID ulid.ULID, id uint64, v []byte) {
+	key := cacheKey(blockID, cacheKeySeries(id))
+
+	err := r.redisClient.MSet(ctx, []string{key}, [][]byte{v}, 0)
+	if err != nil {
+		level.Error(r.logger).Log("msg", "failed to cache series in redis", "err", err)
+	}
+}
+
+func (r *RedisIndexCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []uint64) (hits map[uint64][]byte, misses []uint64) {
+	hits = map[uint64][]byte{}
+
+	keys := make([]string, 0, len(ids))
+	for _, id := range ids {
+		keys = append(keys, cacheKey(blockID, cacheKeySeries(id)))
+	}
+
+	r.requests.WithLabelValues(cacheTypeSeries).Add(float64(len(keys)))
+
+	response, err := r.redisClient.MGet(ctx, keys)
+	if err != nil {
+		level.Error(r.logger).Log("msg", "failed to fetch postings in redis", "err", err)
+		return nil, ids
+	}
+
+	for index, value := range response {
+		id := ids[index]
+		if len(value) == 0 {
+			misses = append(misses, id)
+		} else {
+			hits[id] = value
+		}
+	}
+
+	r.hits.WithLabelValues(cacheTypeSeries).Add(float64(len(hits)))
+	return
+}
+
+type cacheKeyPostings labels.Label
+type cacheKeySeries uint64
+
+func cacheKey(block ulid.ULID, key interface{}) string {
+	switch k := key.(type) {
+	case cacheKeyPostings:
+		lbl := k
+		lblHash := blake2b.Sum256([]byte(lbl.Name + ":" + lbl.Value))
+		return "P:" + block.String() + ":" + base64.RawURLEncoding.EncodeToString(lblHash[0:])
+	case cacheKeySeries:
+		return "S:" + block.String() + ":" + strconv.FormatUint(uint64(k), 10)
+	default:
+		return ""
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -790,6 +790,7 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad => golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9
+## explicit
 golang.org/x/crypto/argon2
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blake2b


### PR DESCRIPTION
**What this PR does**:
- add Redis cache backend 
- add configure options
  - `-blocks-storage.bucket-store.index-cache.backend=redis` 
  - `-blocks-storage.bucket-store.index-cache.redis.*`
  - `-blocks-storage.bucket-store.metadata-cache.backend=redis`
  - `-blocks-storage.bucket-store.metadata-cache.redis.*`
  - `-blocks-storage.bucket-store.chunks-cache.backend.backend=redis`
  - `-blocks-storage.bucket-store.chunks-cache.backend.redis.*`
  - `-blocks-storage.bucket-store.metadata-cache.inmemory.*`
  - `-blocks-storage.bucket-store.chunks-cache.inmemory.*`

**Which issue(s) this PR fixes**:
fix #3568 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
