### PR TITLE
Memberlist status page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [ENHANCEMENT] Memberlist: add status page with available details about memberlist-based KV store and memberlist cluster. It's also possible to view KV values in Go struct or JSON format, or download for inspection. #3575
+
 ## 1.6.0-rc.0 in progress
 
 * [CHANGE] Query Frontend: deprecate `-querier.compress-http-responses` in favour of `-api.response-compression-enabled`. #3544
@@ -50,7 +52,6 @@
   * `cortex_compactor_tenants_processing_failed`
 * [ENHANCEMENT] Added new experimental API endpoints: `POST /purger/delete_tenant` and `GET /purger/delete_tenant_status` for deleting all tenant data. Only works with blocks storage. Compactor removes blocks that belong to user marked for deletion. #3549 #3558
 * [ENHANCEMENT] Chunks storage: add option to use V2 signatures for S3 authentication. #3560
-* [ENHANCEMENT] Memberlist: add status page with available details about memberlist-based KV store and memberlist cluster. It's also possible to view KV values in Go struct or JSON format, or download for inspection. #3575
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
   * `cortex_compactor_tenants_processing_failed`
 * [ENHANCEMENT] Added new experimental API endpoints: `POST /purger/delete_tenant` and `GET /purger/delete_tenant_status` for deleting all tenant data. Only works with blocks storage. Compactor removes blocks that belong to user marked for deletion. #3549 #3558
 * [ENHANCEMENT] Chunks storage: add option to use V2 signatures for S3 authentication. #3560
+* [ENHANCEMENT] Memberlist: add status page with available details about memberlist-based KV store and memberlist cluster. #3575
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
   * `cortex_compactor_tenants_processing_failed`
 * [ENHANCEMENT] Added new experimental API endpoints: `POST /purger/delete_tenant` and `GET /purger/delete_tenant_status` for deleting all tenant data. Only works with blocks storage. Compactor removes blocks that belong to user marked for deletion. #3549 #3558
 * [ENHANCEMENT] Chunks storage: add option to use V2 signatures for S3 authentication. #3560
-* [ENHANCEMENT] Memberlist: add status page with available details about memberlist-based KV store and memberlist cluster. #3575
+* [ENHANCEMENT] Memberlist: add status page with available details about memberlist-based KV store and memberlist cluster. It's also possible to view KV values in Go struct or JSON format, or download for inspection. #3575
 * [BUGFIX] Blocks storage ingester: fixed some cases leading to a TSDB WAL corruption after a partial write to disk. #3423
 * [BUGFIX] Blocks storage: Fix the race between ingestion and `/flush` call resulting in overlapping blocks. #3422
 * [BUGFIX] Querier: fixed `-querier.max-query-into-future` which wasn't correctly enforced on range queries. #3452

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -358,3 +358,8 @@ func (a *API) RegisterServiceMapHandler(handler http.Handler) {
 	a.indexPage.AddLink(SectionAdminEndpoints, "/services", "Service Status")
 	a.RegisterRoute("/services", handler, false, "GET")
 }
+
+func (a *API) RegisterMemberlistKV(handler http.Handler) {
+	a.indexPage.AddLink(SectionAdminEndpoints, "/memberlist", "Memberlist Status")
+	a.RegisterRoute("/memberlist", handler, false, "GET")
+}

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -717,6 +717,7 @@ func (t *Cortex) initMemberlistKV() (services.Service, error) {
 		ring.GetCodec(),
 	}
 	t.MemberlistKV = memberlist.NewKVInitService(&t.Cfg.MemberlistKV, util.Logger)
+	t.API.RegisterMemberlistKV(t.MemberlistKV)
 
 	// Update the config.
 	t.Cfg.Distributor.DistributorRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
@@ -811,6 +812,7 @@ func (t *Cortex) setupModuleManager() error {
 	// Add dependencies
 	deps := map[string][]string{
 		API:                      {Server},
+		MemberlistKV:             {API},
 		Ring:                     {API, RuntimeConfig, MemberlistKV},
 		Overrides:                {RuntimeConfig},
 		Distributor:              {DistributorService, API},

--- a/pkg/ring/kv/memberlist/kv_init_service.go
+++ b/pkg/ring/kv/memberlist/kv_init_service.go
@@ -2,10 +2,17 @@ package memberlist
 
 import (
 	"context"
+	"html/template"
+	"net/http"
+	"sort"
 	"sync"
+	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/hashicorp/memberlist"
+	"go.uber.org/atomic"
 
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -22,7 +29,7 @@ type KVInitService struct {
 	init sync.Once
 
 	// state
-	kv      *KV
+	kv      atomic.Value
 	err     error
 	watcher *services.FailureWatcher
 }
@@ -40,12 +47,19 @@ func NewKVInitService(cfg *KVConfig, logger log.Logger) *KVInitService {
 // This method will initialize Memberlist.KV on first call, and add it to service failure watcher.
 func (kvs *KVInitService) GetMemberlistKV() (*KV, error) {
 	kvs.init.Do(func() {
-		kvs.kv = NewKV(*kvs.cfg, kvs.logger)
-		kvs.watcher.WatchService(kvs.kv)
-		kvs.err = kvs.kv.StartAsync(context.Background())
+		kv := NewKV(*kvs.cfg, kvs.logger)
+		kvs.watcher.WatchService(kv)
+		kvs.err = kv.StartAsync(context.Background())
+
+		kvs.kv.Store(kv)
 	})
 
-	return kvs.kv, kvs.err
+	return kvs.getKV(), kvs.err
+}
+
+// Returns KV if it was initialized, or nil.
+func (kvs *KVInitService) getKV() *KV {
+	return kvs.kv.Load().(*KV)
 }
 
 func (kvs *KVInitService) running(ctx context.Context) error {
@@ -59,9 +73,111 @@ func (kvs *KVInitService) running(ctx context.Context) error {
 }
 
 func (kvs *KVInitService) stopping(_ error) error {
-	if kvs.kv == nil {
+	kv := kvs.getKV()
+	if kv == nil {
 		return nil
 	}
 
-	return services.StopAndAwaitTerminated(context.Background(), kvs.kv)
+	return services.StopAndAwaitTerminated(context.Background(), kv)
 }
+
+func (kvs *KVInitService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	kv := kvs.getKV()
+	var ml *memberlist.Memberlist
+	var store map[string]valueDesc
+
+	if kv != nil {
+		ml = kv.memberlist
+		store = kv.storeCopy()
+	}
+
+	members := ml.Members()
+	sort.Slice(members, func(i, j int) bool {
+		return members[i].Name < members[j].Name
+	})
+
+	util.RenderHTTPResponse(w, pageData{
+		Now:           time.Now(),
+		Initialized:   kv != nil,
+		Memberlist:    ml,
+		SortedMembers: members,
+		Store:         store,
+	}, pageTemplate, req)
+}
+
+type pageData struct {
+	Now           time.Time
+	Initialized   bool
+	Memberlist    *memberlist.Memberlist
+	SortedMembers []*memberlist.Node
+	Store         map[string]valueDesc
+}
+
+var pageTemplate = template.Must(template.New("webpage").Parse(pageContent))
+
+const pageContent = `
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>Cortex Memberlist Status</title>
+	</head>
+	<body>
+		<h1>Cortex Memberlist Status</h1>
+		<p>Current time: {{ .Now }}</p>
+
+		{{ if .Initialized }}
+		<ul>
+		<li>Health Score: {{ .Memberlist.GetHealthScore }} (lower = better, 0 = healthy)</li>
+		<li>Members: {{ .Memberlist.NumMembers }}</li>
+		</ul>
+
+		<h2>KV Store</h2>
+
+		<table width="100%" border="1">
+			<thead>
+				<tr>
+					<th>Key</th>
+					<th>Value Details</th>
+				</tr>
+			</thead>
+
+			<tbody>
+				{{ range $k, $v := .Store }}
+				<tr>
+					<td>{{ $k }}</td>
+					<td>{{ $v }}</td>
+				</tr>
+				{{ end }}
+			</tbody>
+		</table>
+
+		<h2>Memberlist Cluster Members</h2>
+
+		<table width="100%" border="1">
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>Address</th>
+					<th>State</th>
+				</tr>
+			</thead>
+
+			<tbody>
+				{{ range .SortedMembers }}
+				<tr>
+					<td>{{ .Name }}</td>
+					<td>{{ .Address }}</td>
+					<td>{{ .State }}</td>
+				</tr>
+				{{ end }}
+			</tbody>
+		</table>
+
+		<p>State: 0 = Alive, 1 = Suspect, 2 = Dead, 3 = Left</p>
+
+		{{ else }}
+		<p>This Cortex instance doesn't use memberlist.</p>
+		{{ end }}
+	</body>
+</html>`

--- a/pkg/ring/kv/memberlist/kv_init_service.go
+++ b/pkg/ring/kv/memberlist/kv_init_service.go
@@ -177,11 +177,11 @@ func download(w http.ResponseWriter, store map[string]valueDesc, key string) {
 
 	val := store[key]
 
-	w.WriteHeader(200)
-	w.Header().Add("content-type", "application/binary")
+	w.Header().Add("content-type", "application/octet-stream")
 	// Set content-length so that client knows whether it has received full response or not.
 	w.Header().Add("content-length", strconv.Itoa(len(val.value)))
 	w.Header().Add("content-disposition", fmt.Sprintf("attachment; filename=%d-%s", val.version, key))
+	w.WriteHeader(200)
 
 	// Ignore errors, we cannot do anything about them.
 	_, _ = w.Write(val.value)

--- a/pkg/ring/kv/memberlist/kv_init_service.go
+++ b/pkg/ring/kv/memberlist/kv_init_service.go
@@ -152,6 +152,8 @@ const pageContent = `
 			</tbody>
 		</table>
 
+		<p>Note that value "version" is node-specific. It starts with 0 (on restart), and increases on each received update. Size is in bytes.</p> 
+
 		<h2>Memberlist Cluster Members</h2>
 
 		<table width="100%" border="1">

--- a/pkg/ring/kv/memberlist/kv_init_service_test.go
+++ b/pkg/ring/kv/memberlist/kv_init_service_test.go
@@ -1,0 +1,36 @@
+package memberlist
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/memberlist"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPage(t *testing.T) {
+	require.NoError(t, pageTemplate.Execute(&bytes.Buffer{}, pageData{
+		Now:           time.Now(),
+		Initialized:   false,
+		Memberlist:    nil,
+		SortedMembers: nil,
+		Store:         nil,
+	}))
+
+	conf := memberlist.DefaultLANConfig()
+	ml, err := memberlist.Create(conf)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = ml.Shutdown()
+	})
+
+	require.NoError(t, pageTemplate.Execute(&bytes.Buffer{}, pageData{
+		Now:           time.Now(),
+		Initialized:   true,
+		Memberlist:    ml,
+		SortedMembers: ml.Members(),
+		Store:         nil,
+	}))
+}

--- a/pkg/ring/kv/memberlist/memberlist_client.go
+++ b/pkg/ring/kv/memberlist/memberlist_client.go
@@ -267,6 +267,10 @@ type valueDesc struct {
 	codecID string
 }
 
+func (v valueDesc) String() string {
+	return fmt.Sprintf("size: %d, version: %d, codec: %s", len(v.value), v.version, v.codecID)
+}
+
 var (
 	// if merge fails because of CAS version mismatch, this error is returned. CAS operation reacts on it
 	errVersionMismatch  = errors.New("version mismatch")
@@ -1150,4 +1154,15 @@ func computeNewValue(incoming Mergeable, stored []byte, c codec.Codec, cas bool)
 	// otherwise we have two mergeables, so merge them
 	change, err := oldVal.Merge(incoming, cas)
 	return oldVal, change, err
+}
+
+func (m *KV) storeCopy() map[string]valueDesc {
+	m.storeMu.Lock()
+	defer m.storeMu.Unlock()
+
+	result := make(map[string]valueDesc, len(m.store))
+	for k, v := range m.store {
+		result[k] = v
+	}
+	return result
 }


### PR DESCRIPTION
**What this PR does**: This PR adds memberlist status page to Cortex. Status page shows memberlist cluster members, and some details about KV store that members are gossiping about. There is also possibility to inspect values in JSON or Go struct format, or download for offline inspection.

<img width="1355" alt="Screenshot 2020-12-09 at 13 42 22" src="https://user-images.githubusercontent.com/895919/101631319-71f44680-3a24-11eb-8a7e-2aaf48a54e55.png">

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
