### PR TITLE
Clarify that ingester WAL config applies only to chunks storage

### DIFF
--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -385,21 +385,6 @@ It also talks to a KVStore and has it's own copies of the same flags used by the
    Where you don't want to cache every chunk written by ingesters, but you do want to take advantage of chunk write deduplication, this option will make ingesters write a placeholder to the cache for each chunk.
    Make sure you configure ingesters with a different cache to queriers, which need the whole value.
 
-#### WAL
-
-- `-ingester.wal-dir`
-   Directory where the WAL data should be stored and/or recovered from.
-
-- `-ingester.wal-enabled`
-
-   Setting this to `true` enables writing to WAL during ingestion.
-
-- `-ingester.checkpoint-duration`
-   This is the interval at which checkpoints should be created.
-
-- `-ingester.recover-from-wal`
-   Set this to `true` to recover data from an existing WAL. The data is recovered even if WAL is disabled and this is set to `true`. The WAL dir needs to be set for this.
-
 #### Flusher
 
 - `-flusher.wal-dir`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -549,6 +549,8 @@ ring:
 The `ingester_config` configures the Cortex ingester.
 
 ```yaml
+# Configures the Write-Ahead Log (WAL) for the Cortex chunks storage. This
+# config is ignored when running the Cortex blocks storage.
 walconfig:
   # Enable writing of ingested data into WAL.
   # CLI flag: -ingester.wal-enabled

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -50,7 +50,7 @@ var (
 
 // Config for an Ingester.
 type Config struct {
-	WALConfig        WALConfig             `yaml:"walconfig"`
+	WALConfig        WALConfig             `yaml:"walconfig" doc:"description=Configures the Write-Ahead Log (WAL) for the Cortex chunks storage. This config is ignored when running the Cortex blocks storage."`
 	LifecyclerConfig ring.LifecyclerConfig `yaml:"lifecycler"`
 
 	// Config for transferring chunks. Zero or negative = no retries.


### PR DESCRIPTION
**What this PR does**:
In this PR I try to clarify that the ingester WAL config applies only to chunks storage.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
