### PR TITLE
Do not log error if tokens file does not exist

### DIFF
--- a/pkg/ring/basic_lifecycler_delegates.go
+++ b/pkg/ring/basic_lifecycler_delegates.go
@@ -2,6 +2,7 @@ package ring
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -71,7 +72,10 @@ func (d *TokensPersistencyDelegate) OnRingInstanceRegister(lifecycler *BasicLife
 
 	tokensFromFile, err := LoadTokensFromFile(d.tokensPath)
 	if err != nil {
-		level.Error(d.logger).Log("msg", "error in getting tokens from file", "err", err)
+		if !os.IsNotExist(err) {
+			level.Error(d.logger).Log("msg", "error loading tokens from file", "err", err)
+		}
+
 		return d.next.OnRingInstanceRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
 	}
 

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -514,8 +514,8 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 
 	if i.cfg.TokensFilePath != "" {
 		tokensFromFile, err = LoadTokensFromFile(i.cfg.TokensFilePath)
-		if err != nil {
-			level.Error(util.Logger).Log("msg", "error in getting tokens from file", "err", err)
+		if err != nil && !os.IsNotExist(err) {
+			level.Error(util.Logger).Log("msg", "error loading tokens from file", "err", err)
 		}
 	} else {
 		level.Info(util.Logger).Log("msg", "not loading tokens from file, tokens file path is empty")


### PR DESCRIPTION
**What this PR does**:
When we start a new replica (eg. scale up) and it's configured to load ring tokens from file we're used to log the error "error in getting tokens from file", but I believe we shouldn't log error just because the file does not exist (it's an expected case).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
