### PR TITLE
Fix Cortex logo in the website

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ check-white-noise: clean-white-noise
 	@git diff --exit-code --quiet -- '*.md' || (echo "Please remove trailing whitespaces running 'make clean-white-noise'" && false)
 
 web-serve:
-	cd website && hugo --config config.toml -v server
+	cd website && hugo --config config.toml --minify -v server
 
 # Generate binaries for a Cortex release
 dist dist/cortex-linux-amd64 dist/cortex-darwin-amd64 dist/query-tee-linux-amd64 dist/query-tee-darwin-amd64 dist/cortex-linux-amd64-sha-256 dist/cortex-darwin-amd64-sha-256 dist/query-tee-linux-amd64-sha-256 dist/query-tee-darwin-amd64-sha-256:

--- a/website/layouts/partials/navbar.html
+++ b/website/layouts/partials/navbar.html
@@ -1,7 +1,7 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
 <nav class="js-navbar-scroll navbar navbar-expand navbar-dark flex-column flex-md-row td-navbar {{ if $cover }}{{else}}navbar-nocover{{end}}">
 	<a id="cortex-logo" class="navbar-brand {{ if $cover }}d-none{{end}}" href="{{ .Site.Home.RelPermalink }}">
-		<span class="navbar-logo">{{ with resources.Get "icons/logo-white.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}</span>
+		<span class="navbar-logo">{{ with resources.Get "icons/logo-white.svg" }}{{ ( . ).Content | safeHTML }}{{ end }}</span>
 	</a>
 	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
 		<ul class="navbar-nav mt-2 mt-lg-0">


### PR DESCRIPTION
**What this PR does**:
I finally understood the root cause of the truncated Cortex logo in the published website:
![Screenshot 2020-12-11 at 12 19 26](https://user-images.githubusercontent.com/1701904/101897623-2029f880-3bab-11eb-864b-7bde1aa7aefc.png)

It's caused by the minification. Wasn't able to reproduce it locally because minification was disabled. I've now enabled `--minify` in `make web-serve` too and removing the minification fixes it:
![Screenshot 2020-12-11 at 12 20 32](https://user-images.githubusercontent.com/1701904/101897734-48195c00-3bab-11eb-977a-a809bf843ba1.png)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
