### PR TITLE
Add junit reporting to integration tests

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -147,9 +147,18 @@ jobs:
           export CORTEX_IMAGE="${CORTEX_IMAGE_PREFIX}cortex:$IMAGE_TAG"
           export CORTEX_CHECKOUT_DIR="/go/src/github.com/cortexproject/cortex"
           echo "Running integration tests with image: $CORTEX_IMAGE"
-          go test -tags=requires_docker -timeout 1800s -v -count=1 ./integration/...
+          go get -u github.com/jstemmer/go-junit-report@v0.9.1
+          go test -tags=requires_docker -timeout 1800s -v -count=1 ./integration/... 2>&1 | tee >(go-junit-report > test_integration.xml)
         env:
           IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.6
+        if: always()
+        with:
+          check_name: Integration Test Results
+          report_individual_runs: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: 'test_*.xml'
 
   integration-configs-db:
     needs: build

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -147,18 +147,11 @@ jobs:
           export CORTEX_IMAGE="${CORTEX_IMAGE_PREFIX}cortex:$IMAGE_TAG"
           export CORTEX_CHECKOUT_DIR="/go/src/github.com/cortexproject/cortex"
           echo "Running integration tests with image: $CORTEX_IMAGE"
-          go get -u github.com/jstemmer/go-junit-report@v0.9.1
-          go test -tags=requires_docker -timeout 1800s -v -count=1 ./integration/... 2>&1 | tee >(go-junit-report > test_integration.xml)
+          go get -u github.com/simonswine/go-github-action-report@v0.1.5
+          git checkout go.mod go.sum
+          go test -tags=requires_docker -timeout 1800s -v -count=1 ./integration/... | $(go env GOPATH)/bin/go-github-action-report
         env:
           IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.6
-        if: always()
-        with:
-          check_name: Integration Test Results
-          report_individual_runs: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: 'test_*.xml'
 
   integration-configs-db:
     needs: build


### PR DESCRIPTION
**What this PR does**:

This might help getting a better overview over integration tests failing in the Github actions. I sometimes even use the xml format locally to get a quicker idea which tests have failed.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
