### PR TITLE
Optimised Ring.ShuffleShard() and disabled subring cache in store-gateway, ruler and compactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [ENHANCEMENT] Compactor: tenants marked for deletion will now be fully cleaned up after some delay since deletion of last block. Cleanup includes removal of remaining marker files (including tenant deletion mark file) and files under `debug/metas`. #3613
 * [ENHANCEMENT] Compactor: retry compaction of a single tenant on failure instead of re-running compaction for all tenants. #3627
 * [ENHANCEMENT] Querier: Implement result caching for tenant query federation. #3640
+* [ENHANCEMENT] Disabled in-memory shuffle-sharding subring cache in the store-gateway, ruler and compactor. This should reduce the memory utilisation in these services when shuffle-sharding is enabled, without introducing a significantly increase CPU utilisation. #3601
 * [BUGFIX] Allow `-querier.max-query-lookback` use `y|w|d` suffix like deprecated `-store.max-look-back-period`. #3598
 * [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603
 * [BUGFIX] Ingester: do not close idle TSDBs while blocks shipping is in progress. #3630

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [ENHANCEMENT] Compactor: retry compaction of a single tenant on failure instead of re-running compaction for all tenants. #3627
 * [ENHANCEMENT] Querier: Implement result caching for tenant query federation. #3640
 * [ENHANCEMENT] Disabled in-memory shuffle-sharding subring cache in the store-gateway, ruler and compactor. This should reduce the memory utilisation in these services when shuffle-sharding is enabled, without introducing a significantly increase CPU utilisation. #3601
+* [ENHANCEMENT] Shuffle sharding: optimised subring generation used by shuffle sharding. #3601
 * [BUGFIX] Allow `-querier.max-query-lookback` use `y|w|d` suffix like deprecated `-store.max-look-back-period`. #3598
 * [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603
 * [BUGFIX] Ingester: do not close idle TSDBs while blocks shipping is in progress. #3630

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -624,7 +624,7 @@ func (c *Compactor) ownUser(userID string) (bool, error) {
 	userHash := hasher.Sum32()
 
 	// Check whether this compactor instance owns the user.
-	rs, err := c.ring.Get(userHash, ring.Compactor, []ring.IngesterDesc{})
+	rs, err := c.ring.Get(userHash, ring.Compactor, nil, nil, nil)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/compactor/compactor_ring.go
+++ b/pkg/compactor/compactor_ring.go
@@ -79,6 +79,7 @@ func (cfg *RingConfig) ToLifecyclerConfig() ring.LifecyclerConfig {
 
 	// Configure lifecycler
 	lc.RingConfig = rc
+	lc.RingConfig.SubringCacheDisabled = true
 	lc.ListenPort = cfg.ListenPort
 	lc.Addr = cfg.InstanceAddr
 	lc.Port = cfg.InstancePort

--- a/pkg/compactor/compactor_ring_test.go
+++ b/pkg/compactor/compactor_ring_test.go
@@ -20,6 +20,7 @@ func TestRingConfig_DefaultConfigToLifecyclerConfig(t *testing.T) {
 	// intentionally overridden
 	expected.ListenPort = cfg.ListenPort
 	expected.RingConfig.ReplicationFactor = 1
+	expected.RingConfig.SubringCacheDisabled = true
 	expected.NumTokens = 512
 	expected.MinReadyDuration = 0
 	expected.FinalSleep = 0
@@ -45,6 +46,7 @@ func TestRingConfig_CustomConfigToLifecyclerConfig(t *testing.T) {
 	// ring config
 	expected.HeartbeatPeriod = cfg.HeartbeatPeriod
 	expected.RingConfig.HeartbeatTimeout = cfg.HeartbeatTimeout
+	expected.RingConfig.SubringCacheDisabled = true
 	expected.ID = cfg.InstanceID
 	expected.InfNames = cfg.InstanceInterfaceNames
 	expected.Port = cfg.InstancePort

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -97,7 +97,7 @@ func (d *Distributor) GetIngestersForQuery(ctx context.Context, matchers ...*lab
 		metricNameMatcher, _, ok := extract.MetricNameMatcherFromMatchers(matchers)
 
 		if ok && metricNameMatcher.Type == labels.MatchEqual {
-			return d.ingestersRing.Get(shardByMetricName(userID, metricNameMatcher.Value), ring.Read, nil)
+			return d.ingestersRing.Get(shardByMetricName(userID, metricNameMatcher.Value), ring.Read, nil, nil, nil)
 		}
 	}
 

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -98,12 +98,11 @@ func (s *blocksStoreReplicationSet) GetClientsFor(userID string, blockIDs []ulid
 
 	// Find the replication set of each block we need to query.
 	for _, blockID := range blockIDs {
-		// Buffer internally used by the ring (give extra room for a JOINING + LEAVING instance).
 		// Do not reuse the same buffer across multiple Get() calls because we do retain the
 		// returned replication set.
-		buf := make([]ring.IngesterDesc, 0, userRing.ReplicationFactor()+2)
+		bufDescs, bufHosts, bufZones := ring.MakeBuffersForGet()
 
-		set, err := userRing.Get(cortex_tsdb.HashBlockID(blockID), ring.BlocksRead, buf)
+		set, err := userRing.Get(cortex_tsdb.HashBlockID(blockID), ring.BlocksRead, bufDescs, bufHosts, bufZones)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get store-gateway replication set owning the block %s", blockID.String())
 		}

--- a/pkg/ring/batch.go
+++ b/pkg/ring/batch.go
@@ -46,10 +46,13 @@ func DoBatch(ctx context.Context, r ReadRing, keys []uint32, callback func(Inges
 	itemTrackers := make([]itemTracker, len(keys))
 	ingesters := make(map[string]ingester, r.IngesterCount())
 
-	const maxExpectedReplicationSet = 5 // Typical replication factor 3, plus one for inactive plus one for luck.
-	var descs [maxExpectedReplicationSet]IngesterDesc
+	var (
+		bufDescs [GetBufferSize]IngesterDesc
+		bufHosts [GetBufferSize]string
+		bufZones [GetBufferSize]string
+	)
 	for i, key := range keys {
-		replicationSet, err := r.Get(key, Write, descs[:0])
+		replicationSet, err := r.Get(key, Write, bufDescs[:0], bufHosts[:0], bufZones[:0])
 		if err != nil {
 			return err
 		}

--- a/pkg/ring/http.go
+++ b/pkg/ring/http.go
@@ -131,13 +131,14 @@ func (r *Ring) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	sort.Strings(ingesterIDs)
 
+	now := time.Now()
 	ingesters := []interface{}{}
 	_, owned := r.countTokens()
 	for _, id := range ingesterIDs {
 		ing := r.ringDesc.Ingesters[id]
 		heartbeatTimestamp := time.Unix(ing.Timestamp, 0)
 		state := ing.State.String()
-		if !r.IsHealthy(&ing, Reporting, time.Now()) {
+		if !r.IsHealthy(&ing, Reporting, now) {
 			state = unhealthy
 		}
 
@@ -178,7 +179,7 @@ func (r *Ring) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		ShowTokens bool          `json:"-"`
 	}{
 		Ingesters:  ingesters,
-		Now:        time.Now(),
+		Now:        now,
 		ShowTokens: tokensParam == "true",
 	}, pageTemplate, req)
 }

--- a/pkg/ring/http.go
+++ b/pkg/ring/http.go
@@ -132,12 +132,12 @@ func (r *Ring) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	sort.Strings(ingesterIDs)
 
 	ingesters := []interface{}{}
-	_, owned := countTokens(r.ringDesc, r.ringTokens)
+	_, owned := r.countTokens()
 	for _, id := range ingesterIDs {
 		ing := r.ringDesc.Ingesters[id]
 		heartbeatTimestamp := time.Unix(ing.Timestamp, 0)
 		state := ing.State.String()
-		if !r.IsHealthy(&ing, Reporting) {
+		if !r.IsHealthy(&ing, Reporting, time.Now()) {
 			state = unhealthy
 		}
 

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -751,13 +751,14 @@ func (i *Lifecycler) changeState(ctx context.Context, state IngesterState) error
 func (i *Lifecycler) updateCounters(ringDesc *Desc) {
 	healthyInstancesCount := 0
 	zones := map[string]struct{}{}
+	now := time.Now()
 
 	if ringDesc != nil {
 		for _, ingester := range ringDesc.Ingesters {
 			zones[ingester.Zone] = struct{}{}
 
 			// Count the number of healthy instances for Write operation.
-			if ingester.IsHealthy(Write, i.cfg.RingConfig.HeartbeatTimeout) {
+			if ingester.IsHealthy(Write, i.cfg.RingConfig.HeartbeatTimeout, now) {
 				healthyInstancesCount++
 			}
 		}

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -751,9 +751,10 @@ func (i *Lifecycler) changeState(ctx context.Context, state IngesterState) error
 func (i *Lifecycler) updateCounters(ringDesc *Desc) {
 	healthyInstancesCount := 0
 	zones := map[string]struct{}{}
-	now := time.Now()
 
 	if ringDesc != nil {
+		now := time.Now()
+
 		for _, ingester := range ringDesc.Ingesters {
 			zones[ingester.Zone] = struct{}{}
 

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -437,7 +437,7 @@ func (d *Desc) getTokensInfo() map[uint32]instanceInfo {
 	return out
 }
 
-// getTokens returns sorted list of tokens with ingester IDs, owned by each ingester in the ring.
+// getTokens returns sorted list of tokens owned by all instances within the ring.
 func (d *Desc) getTokens() []uint32 {
 	instances := make([][]uint32, 0, len(d.Ingesters))
 	for _, instance := range d.Ingesters {
@@ -456,13 +456,7 @@ func (d *Desc) getTokensByZone() map[string][]uint32 {
 	}
 
 	// Merge tokens per zone.
-	out := make(map[string][]uint32, len(zones))
-	for zone, tokens := range zones {
-		out[zone] = MergeTokens(tokens)
-	}
-
-	return out
-
+	return MergeTokensByZone(zones)
 }
 
 type CompareResult int

--- a/pkg/ring/model_test.go
+++ b/pkg/ring/model_test.go
@@ -256,6 +256,46 @@ func TestDesc_getTokensByZone(t *testing.T) {
 	}
 }
 
+func TestDesc_TokensFor(t *testing.T) {
+	tests := map[string]struct {
+		desc         *Desc
+		expectedMine Tokens
+		expectedAll  Tokens
+	}{
+		"empty ring": {
+			desc:         &Desc{Ingesters: map[string]IngesterDesc{}},
+			expectedMine: Tokens(nil),
+			expectedAll:  Tokens{},
+		},
+		"single zone": {
+			desc: &Desc{Ingesters: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Tokens: []uint32{1, 5}, Zone: ""},
+				"instance-2": {Addr: "127.0.0.1", Tokens: []uint32{2, 4}, Zone: ""},
+				"instance-3": {Addr: "127.0.0.1", Tokens: []uint32{3, 6}, Zone: ""},
+			}},
+			expectedMine: Tokens{1, 5},
+			expectedAll:  Tokens{1, 2, 3, 4, 5, 6},
+		},
+		"multiple zones": {
+			desc: &Desc{Ingesters: map[string]IngesterDesc{
+				"instance-1": {Addr: "127.0.0.1", Tokens: []uint32{1, 5}, Zone: "zone-1"},
+				"instance-2": {Addr: "127.0.0.1", Tokens: []uint32{2, 4}, Zone: "zone-1"},
+				"instance-3": {Addr: "127.0.0.1", Tokens: []uint32{3, 6}, Zone: "zone-2"},
+			}},
+			expectedMine: Tokens{1, 5},
+			expectedAll:  Tokens{1, 2, 3, 4, 5, 6},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actualMine, actualAll := testData.desc.TokensFor("instance-1")
+			assert.Equal(t, testData.expectedMine, actualMine)
+			assert.Equal(t, testData.expectedAll, actualAll)
+		})
+	}
+}
+
 func TestDesc_RingsCompare(t *testing.T) {
 	tests := map[string]struct {
 		r1, r2   *Desc

--- a/pkg/ring/model_test.go
+++ b/pkg/ring/model_test.go
@@ -336,7 +336,7 @@ func TestDesc_RingsCompare(t *testing.T) {
 	}
 }
 
-func TestMergeTokenDesc(t *testing.T) {
+func TestMergeTokens(t *testing.T) {
 	tests := map[string]struct {
 		input    [][]uint32
 		expected []uint32
@@ -373,12 +373,12 @@ func TestMergeTokenDesc(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			assert.Equal(t, testData.expected, MergeTokenDesc(testData.input))
+			assert.Equal(t, testData.expected, MergeTokens(testData.input))
 		})
 	}
 }
 
-func TestMergeTokenDescByZone(t *testing.T) {
+func TestMergeTokensByZone(t *testing.T) {
 	tests := map[string]struct {
 		input    map[string][][]uint32
 		expected map[string][]uint32
@@ -418,7 +418,7 @@ func TestMergeTokenDescByZone(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			assert.Equal(t, testData.expected, MergeTokenDescByZone(testData.input))
+			assert.Equal(t, testData.expected, MergeTokensByZone(testData.input))
 		})
 	}
 }

--- a/pkg/ring/model_test.go
+++ b/pkg/ring/model_test.go
@@ -51,13 +51,13 @@ func TestIngesterDesc_IsHealthy_ForIngesterOperations(t *testing.T) {
 		testData := testData
 
 		t.Run(testName, func(t *testing.T) {
-			actual := testData.ingester.IsHealthy(Write, testData.timeout)
+			actual := testData.ingester.IsHealthy(Write, testData.timeout, time.Now())
 			assert.Equal(t, testData.writeExpected, actual)
 
-			actual = testData.ingester.IsHealthy(Read, testData.timeout)
+			actual = testData.ingester.IsHealthy(Read, testData.timeout, time.Now())
 			assert.Equal(t, testData.readExpected, actual)
 
-			actual = testData.ingester.IsHealthy(Reporting, testData.timeout)
+			actual = testData.ingester.IsHealthy(Reporting, testData.timeout, time.Now())
 			assert.Equal(t, testData.reportExpected, actual)
 		})
 	}
@@ -108,10 +108,10 @@ func TestIngesterDesc_IsHealthy_ForStoreGatewayOperations(t *testing.T) {
 		testData := testData
 
 		t.Run(testName, func(t *testing.T) {
-			actual := testData.instance.IsHealthy(BlocksSync, testData.timeout)
+			actual := testData.instance.IsHealthy(BlocksSync, testData.timeout, time.Now())
 			assert.Equal(t, testData.syncExpected, actual)
 
-			actual = testData.instance.IsHealthy(BlocksRead, testData.timeout)
+			actual = testData.instance.IsHealthy(BlocksRead, testData.timeout, time.Now())
 			assert.Equal(t, testData.queryExpected, actual)
 		})
 	}
@@ -220,11 +220,11 @@ func TestDesc_Ready(t *testing.T) {
 func TestDesc_getTokensByZone(t *testing.T) {
 	tests := map[string]struct {
 		desc     *Desc
-		expected map[string][]TokenDesc
+		expected map[string][]uint32
 	}{
 		"empty ring": {
 			desc:     &Desc{Ingesters: map[string]IngesterDesc{}},
-			expected: map[string][]TokenDesc{},
+			expected: map[string][]uint32{},
 		},
 		"single zone": {
 			desc: &Desc{Ingesters: map[string]IngesterDesc{
@@ -232,15 +232,8 @@ func TestDesc_getTokensByZone(t *testing.T) {
 				"instance-2": {Addr: "127.0.0.1", Tokens: []uint32{2, 4}, Zone: ""},
 				"instance-3": {Addr: "127.0.0.1", Tokens: []uint32{3, 6}, Zone: ""},
 			}},
-			expected: map[string][]TokenDesc{
-				"": {
-					{Token: 1, Ingester: "instance-1", Zone: ""},
-					{Token: 2, Ingester: "instance-2", Zone: ""},
-					{Token: 3, Ingester: "instance-3", Zone: ""},
-					{Token: 4, Ingester: "instance-2", Zone: ""},
-					{Token: 5, Ingester: "instance-1", Zone: ""},
-					{Token: 6, Ingester: "instance-3", Zone: ""},
-				},
+			expected: map[string][]uint32{
+				"": {1, 2, 3, 4, 5, 6},
 			},
 		},
 		"multiple zones": {
@@ -249,17 +242,9 @@ func TestDesc_getTokensByZone(t *testing.T) {
 				"instance-2": {Addr: "127.0.0.1", Tokens: []uint32{2, 4}, Zone: "zone-1"},
 				"instance-3": {Addr: "127.0.0.1", Tokens: []uint32{3, 6}, Zone: "zone-2"},
 			}},
-			expected: map[string][]TokenDesc{
-				"zone-1": {
-					{Token: 1, Ingester: "instance-1", Zone: "zone-1"},
-					{Token: 2, Ingester: "instance-2", Zone: "zone-1"},
-					{Token: 4, Ingester: "instance-2", Zone: "zone-1"},
-					{Token: 5, Ingester: "instance-1", Zone: "zone-1"},
-				},
-				"zone-2": {
-					{Token: 3, Ingester: "instance-3", Zone: "zone-2"},
-					{Token: 6, Ingester: "instance-3", Zone: "zone-2"},
-				},
+			expected: map[string][]uint32{
+				"zone-1": {1, 2, 4, 5},
+				"zone-2": {3, 6},
 			},
 		},
 	}
@@ -347,6 +332,93 @@ func TestDesc_RingsCompare(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			assert.Equal(t, testData.expected, testData.r1.RingCompare(testData.r2))
 			assert.Equal(t, testData.expected, testData.r2.RingCompare(testData.r1))
+		})
+	}
+}
+
+func TestMergeTokenDesc(t *testing.T) {
+	tests := map[string]struct {
+		input    [][]uint32
+		expected []uint32
+	}{
+		"empty input": {
+			input:    nil,
+			expected: []uint32{},
+		},
+		"single instance in input": {
+			input: [][]uint32{
+				{1, 3, 4, 8},
+			},
+			expected: []uint32{1, 3, 4, 8},
+		},
+		"multiple instances in input": {
+			input: [][]uint32{
+				{1, 3, 4, 8},
+				{0, 2, 6, 9},
+				{5, 7, 10, 11},
+			},
+			expected: []uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+		},
+		"some instances have no tokens": {
+			input: [][]uint32{
+				{1, 3, 4, 8},
+				{},
+				{0, 2, 6, 9},
+				{},
+				{5, 7, 10, 11},
+			},
+			expected: []uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, testData.expected, MergeTokenDesc(testData.input))
+		})
+	}
+}
+
+func TestMergeTokenDescByZone(t *testing.T) {
+	tests := map[string]struct {
+		input    map[string][][]uint32
+		expected map[string][]uint32
+	}{
+		"empty input": {
+			input:    nil,
+			expected: map[string][]uint32{},
+		},
+		"single zone": {
+			input: map[string][][]uint32{
+				"zone-1": {
+					{1, 3, 4, 8},
+					{2, 5, 6, 7},
+				},
+			},
+			expected: map[string][]uint32{
+				"zone-1": {1, 2, 3, 4, 5, 6, 7, 8},
+			},
+		},
+		"multiple zones": {
+			input: map[string][][]uint32{
+				"zone-1": {
+					{1, 3, 4, 8},
+					{2, 5, 6, 7},
+				},
+				"zone-2": {
+					{3, 5},
+					{2, 4},
+				},
+			},
+			expected: map[string][]uint32{
+				"zone-1": {1, 2, 3, 4, 5, 6, 7, 8},
+				"zone-2": {2, 3, 4, 5},
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, testData.expected, MergeTokenDescByZone(testData.input))
 		})
 	}
 }

--- a/pkg/ring/replication_strategy.go
+++ b/pkg/ring/replication_strategy.go
@@ -42,12 +42,13 @@ func (s *defaultReplicationStrategy) Filter(ingesters []IngesterDesc, op Operati
 	}
 
 	minSuccess := (replicationFactor / 2) + 1
+	now := time.Now()
 
 	// Skip those that have not heartbeated in a while. NB these are still
 	// included in the calculation of minSuccess, so if too many failed ingesters
 	// will cause the whole write to fail.
 	for i := 0; i < len(ingesters); {
-		if ingesters[i].IsHealthy(op, heartbeatTimeout) {
+		if ingesters[i].IsHealthy(op, heartbeatTimeout, now) {
 			i++
 		} else {
 			ingesters = append(ingesters[:i], ingesters[i+1:]...)
@@ -91,8 +92,8 @@ func (s *defaultReplicationStrategy) ShouldExtendReplicaSet(ingester IngesterDes
 }
 
 // IsHealthy checks whether an ingester appears to be alive and heartbeating
-func (r *Ring) IsHealthy(ingester *IngesterDesc, op Operation) bool {
-	return ingester.IsHealthy(op, r.cfg.HeartbeatTimeout)
+func (r *Ring) IsHealthy(ingester *IngesterDesc, op Operation, now time.Time) bool {
+	return ingester.IsHealthy(op, r.cfg.HeartbeatTimeout, now)
 }
 
 // ReplicationFactor of the ring.

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -278,7 +278,7 @@ func (r *Ring) loop(ctx context.Context) error {
 		}
 
 		now := time.Now()
-		ringTokens := ringDesc.getTokens()
+		ringTokens := ringDesc.GetTokens()
 		ringTokensByZone := ringDesc.getTokensByZone()
 		ringInstanceByToken := ringDesc.getTokensInfo()
 		ringZones := getZones(ringTokensByZone)
@@ -721,7 +721,7 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 		cfg:              r.cfg,
 		strategy:         r.strategy,
 		ringDesc:         shardDesc,
-		ringTokens:       shardDesc.getTokens(),
+		ringTokens:       shardDesc.GetTokens(),
 		ringTokensByZone: shardTokensByZone,
 		ringZones:        getZones(shardTokensByZone),
 

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -195,11 +195,12 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 					ReplicationFactor:    testData.replicationFactor,
 					ZoneAwarenessEnabled: testData.zoneAwarenessEnabled,
 				},
-				ringDesc:         r,
-				ringTokens:       r.getTokens(),
-				ringTokensByZone: r.getTokensByZone(),
-				ringZones:        getZones(r.getTokensByZone()),
-				strategy:         NewDefaultReplicationStrategy(true),
+				ringDesc:            r,
+				ringTokens:          r.getTokens(),
+				ringTokensByZone:    r.getTokensByZone(),
+				ringInstanceByToken: r.getTokensInfo(),
+				ringZones:           getZones(r.getTokensByZone()),
+				strategy:            NewDefaultReplicationStrategy(true),
 			}
 
 			ingesters := make([]IngesterDesc, 0, len(r.GetIngesters()))
@@ -207,13 +208,15 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 				ingesters = append(ingesters, v)
 			}
 
+			_, bufHosts, bufZones := MakeBuffersForGet()
+
 			// Use the GenerateTokens to get an array of random uint32 values.
 			testValues := GenerateTokens(testCount, nil)
 
 			var set ReplicationSet
 			var err error
 			for i := 0; i < testCount; i++ {
-				set, err = ring.Get(testValues[i], Write, ingesters)
+				set, err = ring.Get(testValues[i], Write, ingesters, bufHosts, bufZones)
 				if testData.expectedErr != "" {
 					require.EqualError(t, err, testData.expectedErr)
 				} else {
@@ -285,12 +288,13 @@ func TestRing_GetAllHealthy(t *testing.T) {
 			}
 
 			ring := Ring{
-				cfg:              Config{HeartbeatTimeout: heartbeatTimeout},
-				ringDesc:         ringDesc,
-				ringTokens:       ringDesc.getTokens(),
-				ringTokensByZone: ringDesc.getTokensByZone(),
-				ringZones:        getZones(ringDesc.getTokensByZone()),
-				strategy:         NewDefaultReplicationStrategy(true),
+				cfg:                 Config{HeartbeatTimeout: heartbeatTimeout},
+				ringDesc:            ringDesc,
+				ringTokens:          ringDesc.getTokens(),
+				ringTokensByZone:    ringDesc.getTokensByZone(),
+				ringInstanceByToken: ringDesc.getTokensInfo(),
+				ringZones:           getZones(ringDesc.getTokensByZone()),
+				strategy:            NewDefaultReplicationStrategy(true),
 			}
 
 			set, err := ring.GetAllHealthy(Read)
@@ -396,11 +400,12 @@ func TestRing_GetReplicationSetForOperation(t *testing.T) {
 					HeartbeatTimeout:  heartbeatTimeout,
 					ReplicationFactor: testData.ringReplicationFactor,
 				},
-				ringDesc:         ringDesc,
-				ringTokens:       ringDesc.getTokens(),
-				ringTokensByZone: ringDesc.getTokensByZone(),
-				ringZones:        getZones(ringDesc.getTokensByZone()),
-				strategy:         NewDefaultReplicationStrategy(true),
+				ringDesc:            ringDesc,
+				ringTokens:          ringDesc.getTokens(),
+				ringTokensByZone:    ringDesc.getTokensByZone(),
+				ringInstanceByToken: ringDesc.getTokensInfo(),
+				ringZones:           getZones(ringDesc.getTokensByZone()),
+				strategy:            NewDefaultReplicationStrategy(true),
 			}
 
 			set, err := ring.GetReplicationSetForOperation(Read)
@@ -713,11 +718,12 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 					ZoneAwarenessEnabled: true,
 					ReplicationFactor:    testData.replicationFactor,
 				},
-				ringDesc:         ringDesc,
-				ringTokens:       ringDesc.getTokens(),
-				ringTokensByZone: ringDesc.getTokensByZone(),
-				ringZones:        getZones(ringDesc.getTokensByZone()),
-				strategy:         NewDefaultReplicationStrategy(true),
+				ringDesc:            ringDesc,
+				ringTokens:          ringDesc.getTokens(),
+				ringTokensByZone:    ringDesc.getTokensByZone(),
+				ringInstanceByToken: ringDesc.getTokensInfo(),
+				ringZones:           getZones(ringDesc.getTokensByZone()),
+				strategy:            NewDefaultReplicationStrategy(true),
 			}
 
 			// Check the replication set has the correct settings
@@ -848,11 +854,12 @@ func TestRing_ShuffleShard(t *testing.T) {
 					HeartbeatTimeout:     time.Hour,
 					ZoneAwarenessEnabled: testData.zoneAwarenessEnabled,
 				},
-				ringDesc:         ringDesc,
-				ringTokens:       ringDesc.getTokens(),
-				ringTokensByZone: ringDesc.getTokensByZone(),
-				ringZones:        getZones(ringDesc.getTokensByZone()),
-				strategy:         NewDefaultReplicationStrategy(true),
+				ringDesc:            ringDesc,
+				ringTokens:          ringDesc.getTokens(),
+				ringTokensByZone:    ringDesc.getTokensByZone(),
+				ringInstanceByToken: ringDesc.getTokensInfo(),
+				ringZones:           getZones(ringDesc.getTokensByZone()),
+				strategy:            NewDefaultReplicationStrategy(true),
 			}
 
 			shardRing := ring.ShuffleShard("tenant-id", testData.shardSize)
@@ -893,17 +900,18 @@ func TestRing_ShuffleShard_Stability(t *testing.T) {
 	)
 
 	// Initialise the ring.
-	ringDesc := &Desc{Ingesters: generateRingInstances(numInstances, numZones)}
+	ringDesc := &Desc{Ingesters: generateRingInstances(numInstances, numZones, 128)}
 	ring := Ring{
 		cfg: Config{
 			HeartbeatTimeout:     time.Hour,
 			ZoneAwarenessEnabled: true,
 		},
-		ringDesc:         ringDesc,
-		ringTokens:       ringDesc.getTokens(),
-		ringTokensByZone: ringDesc.getTokensByZone(),
-		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         NewDefaultReplicationStrategy(true),
+		ringDesc:            ringDesc,
+		ringTokens:          ringDesc.getTokens(),
+		ringTokensByZone:    ringDesc.getTokensByZone(),
+		ringInstanceByToken: ringDesc.getTokensInfo(),
+		ringZones:           getZones(ringDesc.getTokensByZone()),
+		strategy:            NewDefaultReplicationStrategy(true),
 	}
 
 	for i := 1; i <= numTenants; i++ {
@@ -966,11 +974,12 @@ func TestRing_ShuffleShard_Shuffling(t *testing.T) {
 			HeartbeatTimeout:     time.Hour,
 			ZoneAwarenessEnabled: true,
 		},
-		ringDesc:         ringDesc,
-		ringTokens:       ringDesc.getTokens(),
-		ringTokensByZone: ringDesc.getTokensByZone(),
-		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         NewDefaultReplicationStrategy(true),
+		ringDesc:            ringDesc,
+		ringTokens:          ringDesc.getTokens(),
+		ringTokensByZone:    ringDesc.getTokensByZone(),
+		ringInstanceByToken: ringDesc.getTokensInfo(),
+		ringZones:           getZones(ringDesc.getTokensByZone()),
+		strategy:            NewDefaultReplicationStrategy(true),
 	}
 
 	// Compute the shard for each tenant.
@@ -1058,17 +1067,18 @@ func TestRing_ShuffleShard_Consistency(t *testing.T) {
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
 			// Initialise the ring.
-			ringDesc := &Desc{Ingesters: generateRingInstances(s.numInstances, s.numZones)}
+			ringDesc := &Desc{Ingesters: generateRingInstances(s.numInstances, s.numZones, 128)}
 			ring := Ring{
 				cfg: Config{
 					HeartbeatTimeout:     time.Hour,
 					ZoneAwarenessEnabled: true,
 				},
-				ringDesc:         ringDesc,
-				ringTokens:       ringDesc.getTokens(),
-				ringTokensByZone: ringDesc.getTokensByZone(),
-				ringZones:        getZones(ringDesc.getTokensByZone()),
-				strategy:         NewDefaultReplicationStrategy(true),
+				ringDesc:            ringDesc,
+				ringTokens:          ringDesc.getTokens(),
+				ringTokensByZone:    ringDesc.getTokensByZone(),
+				ringInstanceByToken: ringDesc.getTokensInfo(),
+				ringZones:           getZones(ringDesc.getTokensByZone()),
+				strategy:            NewDefaultReplicationStrategy(true),
 			}
 
 			// Compute the initial shard for each tenant.
@@ -1082,7 +1092,7 @@ func TestRing_ShuffleShard_Consistency(t *testing.T) {
 			// Update the ring.
 			switch s.ringChange {
 			case add:
-				newID, newDesc := generateRingInstance(s.numInstances+1, 0)
+				newID, newDesc := generateRingInstance(s.numInstances+1, 0, 128)
 				ringDesc.Ingesters[newID] = newDesc
 			case remove:
 				// Remove the first one.
@@ -1094,6 +1104,7 @@ func TestRing_ShuffleShard_Consistency(t *testing.T) {
 
 			ring.ringTokens = ringDesc.getTokens()
 			ring.ringTokensByZone = ringDesc.getTokensByZone()
+			ring.ringInstanceByToken = ringDesc.getTokensInfo()
 			ring.ringZones = getZones(ringDesc.getTokensByZone())
 
 			// Compute the update shard for each tenant and compare it with the initial one.
@@ -1115,7 +1126,7 @@ func TestRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
 	// Create 30 instances in 3 zones.
 	ringInstances := map[string]IngesterDesc{}
 	for i := 0; i < 30; i++ {
-		name, desc := generateRingInstance(i, i%3)
+		name, desc := generateRingInstance(i, i%3, 128)
 		ringInstances[name] = desc
 	}
 
@@ -1126,11 +1137,12 @@ func TestRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
 			HeartbeatTimeout:     time.Hour,
 			ZoneAwarenessEnabled: true,
 		},
-		ringDesc:         ringDesc,
-		ringTokens:       ringDesc.getTokens(),
-		ringTokensByZone: ringDesc.getTokensByZone(),
-		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         NewDefaultReplicationStrategy(true),
+		ringDesc:            ringDesc,
+		ringTokens:          ringDesc.getTokens(),
+		ringTokensByZone:    ringDesc.getTokensByZone(),
+		ringInstanceByToken: ringDesc.getTokensInfo(),
+		ringZones:           getZones(ringDesc.getTokensByZone()),
+		strategy:            NewDefaultReplicationStrategy(true),
 	}
 
 	// Get the replication set with shard size = 3.
@@ -1191,7 +1203,7 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 	// Create 20 instances in 2 zones.
 	ringInstances := map[string]IngesterDesc{}
 	for i := 0; i < 20; i++ {
-		name, desc := generateRingInstance(i, i%2)
+		name, desc := generateRingInstance(i, i%2, 128)
 		ringInstances[name] = desc
 	}
 
@@ -1202,11 +1214,12 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 			HeartbeatTimeout:     time.Hour,
 			ZoneAwarenessEnabled: true,
 		},
-		ringDesc:         ringDesc,
-		ringTokens:       ringDesc.getTokens(),
-		ringTokensByZone: ringDesc.getTokensByZone(),
-		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         NewDefaultReplicationStrategy(true),
+		ringDesc:            ringDesc,
+		ringTokens:          ringDesc.getTokens(),
+		ringTokensByZone:    ringDesc.getTokensByZone(),
+		ringInstanceByToken: ringDesc.getTokensInfo(),
+		ringZones:           getZones(ringDesc.getTokensByZone()),
+		strategy:            NewDefaultReplicationStrategy(true),
 	}
 
 	// Get the replication set with shard size = 2.
@@ -1229,13 +1242,14 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 
 	// Scale up cluster, adding 10 instances in 1 new zone.
 	for i := 20; i < 30; i++ {
-		name, desc := generateRingInstance(i, 2)
+		name, desc := generateRingInstance(i, 2, 128)
 		ringInstances[name] = desc
 	}
 
 	ring.ringDesc.Ingesters = ringInstances
 	ring.ringTokens = ringDesc.getTokens()
 	ring.ringTokensByZone = ringDesc.getTokensByZone()
+	ring.ringInstanceByToken = ringDesc.getTokensInfo()
 	ring.ringZones = getZones(ringDesc.getTokensByZone())
 
 	// Increase shard size to 6.
@@ -1459,11 +1473,12 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 					HeartbeatTimeout:     time.Hour,
 					ZoneAwarenessEnabled: true,
 				},
-				ringDesc:         ringDesc,
-				ringTokens:       ringDesc.getTokens(),
-				ringTokensByZone: ringDesc.getTokensByZone(),
-				ringZones:        getZones(ringDesc.getTokensByZone()),
-				strategy:         NewDefaultReplicationStrategy(true),
+				ringDesc:            ringDesc,
+				ringTokens:          ringDesc.getTokens(),
+				ringTokensByZone:    ringDesc.getTokensByZone(),
+				ringInstanceByToken: ringDesc.getTokensInfo(),
+				ringZones:           getZones(ringDesc.getTokensByZone()),
+				strategy:            NewDefaultReplicationStrategy(true),
 			}
 
 			// Replay the events on the timeline.
@@ -1474,12 +1489,14 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 
 					ring.ringTokens = ringDesc.getTokens()
 					ring.ringTokensByZone = ringDesc.getTokensByZone()
+					ring.ringInstanceByToken = ringDesc.getTokensInfo()
 					ring.ringZones = getZones(ringDesc.getTokensByZone())
 				case remove:
 					delete(ringDesc.Ingesters, event.instanceID)
 
 					ring.ringTokens = ringDesc.getTokens()
 					ring.ringTokensByZone = ringDesc.getTokensByZone()
+					ring.ringInstanceByToken = ringDesc.getTokensInfo()
 					ring.ringZones = getZones(ringDesc.getTokensByZone())
 				case test:
 					rs, err := ring.ShuffleShardWithLookback(userID, event.shardSize, lookbackPeriod, time.Now()).GetAllHealthy(Read)
@@ -1514,18 +1531,19 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 				t.Log("random generator seed:", seed)
 
 				// Initialise the ring.
-				ringDesc := &Desc{Ingesters: generateRingInstances(numInstances, numZones)}
+				ringDesc := &Desc{Ingesters: generateRingInstances(numInstances, numZones, 128)}
 				ring := Ring{
 					cfg: Config{
 						HeartbeatTimeout:     time.Hour,
 						ZoneAwarenessEnabled: true,
 						ReplicationFactor:    3,
 					},
-					ringDesc:         ringDesc,
-					ringTokens:       ringDesc.getTokens(),
-					ringTokensByZone: ringDesc.getTokensByZone(),
-					ringZones:        getZones(ringDesc.getTokensByZone()),
-					strategy:         NewDefaultReplicationStrategy(true),
+					ringDesc:            ringDesc,
+					ringTokens:          ringDesc.getTokens(),
+					ringTokensByZone:    ringDesc.getTokensByZone(),
+					ringInstanceByToken: ringDesc.getTokensInfo(),
+					ringZones:           getZones(ringDesc.getTokensByZone()),
+					strategy:            NewDefaultReplicationStrategy(true),
 				}
 
 				// The simulation starts with the minimum shard size. Random events can later increase it.
@@ -1562,6 +1580,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 
 						ring.ringTokens = ringDesc.getTokens()
 						ring.ringTokensByZone = ringDesc.getTokensByZone()
+						ring.ringInstanceByToken = ringDesc.getTokensInfo()
 						ring.ringZones = getZones(ringDesc.getTokensByZone())
 					case r < 90:
 						// Scale down instances by 1. To make tests reproducible we get the instance IDs, sort them
@@ -1579,6 +1598,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 
 						ring.ringTokens = ringDesc.getTokens()
 						ring.ringTokensByZone = ringDesc.getTokensByZone()
+						ring.ringInstanceByToken = ringDesc.getTokensInfo()
 						ring.ringZones = getZones(ringDesc.getTokensByZone())
 
 						// Remove the terminated instance from the history.
@@ -1634,7 +1654,7 @@ func BenchmarkRing_ShuffleShard(b *testing.B) {
 		for _, numZones := range []int{1, 3} {
 			for _, shardSize := range []int{3, 10, 30} {
 				b.Run(fmt.Sprintf("num instances = %d, num zones = %d, shard size = %d", numInstances, numZones, shardSize), func(b *testing.B) {
-					benchmarkShuffleSharding(b, numInstances, numZones, shardSize, false)
+					benchmarkShuffleSharding(b, numInstances, numZones, 128, shardSize, false)
 				})
 			}
 		}
@@ -1646,34 +1666,78 @@ func BenchmarkRing_ShuffleShardCached(b *testing.B) {
 		for _, numZones := range []int{1, 3} {
 			for _, shardSize := range []int{3, 10, 30} {
 				b.Run(fmt.Sprintf("num instances = %d, num zones = %d, shard size = %d", numInstances, numZones, shardSize), func(b *testing.B) {
-					benchmarkShuffleSharding(b, numInstances, numZones, shardSize, true)
+					benchmarkShuffleSharding(b, numInstances, numZones, 128, shardSize, true)
 				})
 			}
 		}
 	}
 }
 
-func benchmarkShuffleSharding(b *testing.B, numInstances, numZones, shardSize int, cache bool) {
-	// Initialise the ring.
-	ringDesc := &Desc{Ingesters: generateRingInstances(numInstances, numZones)}
-	ring := Ring{
-		cfg:                Config{HeartbeatTimeout: time.Hour, ZoneAwarenessEnabled: true},
-		ringDesc:           ringDesc,
-		ringTokens:         ringDesc.getTokens(),
-		ringTokensByZone:   ringDesc.getTokensByZone(),
-		ringZones:          getZones(ringDesc.getTokensByZone()),
-		strategy:           NewDefaultReplicationStrategy(true),
-		lastTopologyChange: time.Now(),
-	}
+func BenchmarkRing_ShuffleShard_512Tokens(b *testing.B) {
+	const (
+		numInstances = 30
+		numZones     = 3
+		numTokens    = 512
+		shardSize    = 9
+		cacheEnabled = false
+	)
 
-	if cache {
-		ring.shuffledSubringCache = map[subringCacheKey]*Ring{}
+	benchmarkShuffleSharding(b, numInstances, numZones, numTokens, shardSize, cacheEnabled)
+}
+
+func benchmarkShuffleSharding(b *testing.B, numInstances, numZones, numTokens, shardSize int, cache bool) {
+	// Initialise the ring.
+	ringDesc := &Desc{Ingesters: generateRingInstances(numInstances, numZones, numTokens)}
+	ring := Ring{
+		cfg:                  Config{HeartbeatTimeout: time.Hour, ZoneAwarenessEnabled: true, SubringCacheDisabled: !cache},
+		ringDesc:             ringDesc,
+		ringTokens:           ringDesc.getTokens(),
+		ringTokensByZone:     ringDesc.getTokensByZone(),
+		ringInstanceByToken:  ringDesc.getTokensInfo(),
+		ringZones:            getZones(ringDesc.getTokensByZone()),
+		shuffledSubringCache: map[subringCacheKey]*Ring{},
+		strategy:             NewDefaultReplicationStrategy(true),
+		lastTopologyChange:   time.Now(),
 	}
 
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
 		ring.ShuffleShard("tenant-1", shardSize)
+	}
+}
+
+func BenchmarkRing_Get(b *testing.B) {
+	const (
+		numInstances      = 100
+		numZones          = 3
+		replicationFactor = 3
+	)
+
+	// Initialise the ring.
+	ringDesc := &Desc{Ingesters: generateRingInstances(numInstances, numZones, numTokens)}
+	ring := Ring{
+		cfg:                  Config{HeartbeatTimeout: time.Hour, ZoneAwarenessEnabled: true, SubringCacheDisabled: true, ReplicationFactor: replicationFactor},
+		ringDesc:             ringDesc,
+		ringTokens:           ringDesc.getTokens(),
+		ringTokensByZone:     ringDesc.getTokensByZone(),
+		ringInstanceByToken:  ringDesc.getTokensInfo(),
+		ringZones:            getZones(ringDesc.getTokensByZone()),
+		shuffledSubringCache: map[subringCacheKey]*Ring{},
+		strategy:             NewDefaultReplicationStrategy(true),
+		lastTopologyChange:   time.Now(),
+	}
+
+	buf, bufHosts, bufZones := MakeBuffersForGet()
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		set, err := ring.Get(r.Uint32(), Write, buf, bufHosts, bufZones)
+		if err != nil || len(set.Ingesters) != replicationFactor {
+			b.Fatal()
+		}
 	}
 }
 
@@ -1690,22 +1754,22 @@ func generateTokensLinear(instanceID, numInstances, numTokens int) []uint32 {
 	return tokens
 }
 
-func generateRingInstances(numInstances, numZones int) map[string]IngesterDesc {
+func generateRingInstances(numInstances, numZones, numTokens int) map[string]IngesterDesc {
 	instances := make(map[string]IngesterDesc, numInstances)
 
 	for i := 1; i <= numInstances; i++ {
-		id, desc := generateRingInstance(i, i%numZones)
+		id, desc := generateRingInstance(i, i%numZones, numTokens)
 		instances[id] = desc
 	}
 
 	return instances
 }
 
-func generateRingInstance(id, zone int) (string, IngesterDesc) {
+func generateRingInstance(id, zone, numTokens int) (string, IngesterDesc) {
 	instanceID := fmt.Sprintf("instance-%d", id)
 	zoneID := fmt.Sprintf("zone-%d", zone)
 
-	return instanceID, generateRingInstanceWithInfo(instanceID, zoneID, GenerateTokens(128, nil), time.Now())
+	return instanceID, generateRingInstanceWithInfo(instanceID, zoneID, GenerateTokens(numTokens, nil), time.Now())
 }
 
 func generateRingInstanceWithInfo(addr, zone string, tokens []uint32, registeredAt time.Time) IngesterDesc {

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -196,7 +196,7 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 					ZoneAwarenessEnabled: testData.zoneAwarenessEnabled,
 				},
 				ringDesc:            r,
-				ringTokens:          r.getTokens(),
+				ringTokens:          r.GetTokens(),
 				ringTokensByZone:    r.getTokensByZone(),
 				ringInstanceByToken: r.getTokensInfo(),
 				ringZones:           getZones(r.getTokensByZone()),
@@ -290,7 +290,7 @@ func TestRing_GetAllHealthy(t *testing.T) {
 			ring := Ring{
 				cfg:                 Config{HeartbeatTimeout: heartbeatTimeout},
 				ringDesc:            ringDesc,
-				ringTokens:          ringDesc.getTokens(),
+				ringTokens:          ringDesc.GetTokens(),
 				ringTokensByZone:    ringDesc.getTokensByZone(),
 				ringInstanceByToken: ringDesc.getTokensInfo(),
 				ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -401,7 +401,7 @@ func TestRing_GetReplicationSetForOperation(t *testing.T) {
 					ReplicationFactor: testData.ringReplicationFactor,
 				},
 				ringDesc:            ringDesc,
-				ringTokens:          ringDesc.getTokens(),
+				ringTokens:          ringDesc.GetTokens(),
 				ringTokensByZone:    ringDesc.getTokensByZone(),
 				ringInstanceByToken: ringDesc.getTokensInfo(),
 				ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -719,7 +719,7 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 					ReplicationFactor:    testData.replicationFactor,
 				},
 				ringDesc:            ringDesc,
-				ringTokens:          ringDesc.getTokens(),
+				ringTokens:          ringDesc.GetTokens(),
 				ringTokensByZone:    ringDesc.getTokensByZone(),
 				ringInstanceByToken: ringDesc.getTokensInfo(),
 				ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -855,7 +855,7 @@ func TestRing_ShuffleShard(t *testing.T) {
 					ZoneAwarenessEnabled: testData.zoneAwarenessEnabled,
 				},
 				ringDesc:            ringDesc,
-				ringTokens:          ringDesc.getTokens(),
+				ringTokens:          ringDesc.GetTokens(),
 				ringTokensByZone:    ringDesc.getTokensByZone(),
 				ringInstanceByToken: ringDesc.getTokensInfo(),
 				ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -907,7 +907,7 @@ func TestRing_ShuffleShard_Stability(t *testing.T) {
 			ZoneAwarenessEnabled: true,
 		},
 		ringDesc:            ringDesc,
-		ringTokens:          ringDesc.getTokens(),
+		ringTokens:          ringDesc.GetTokens(),
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -975,7 +975,7 @@ func TestRing_ShuffleShard_Shuffling(t *testing.T) {
 			ZoneAwarenessEnabled: true,
 		},
 		ringDesc:            ringDesc,
-		ringTokens:          ringDesc.getTokens(),
+		ringTokens:          ringDesc.GetTokens(),
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -1074,7 +1074,7 @@ func TestRing_ShuffleShard_Consistency(t *testing.T) {
 					ZoneAwarenessEnabled: true,
 				},
 				ringDesc:            ringDesc,
-				ringTokens:          ringDesc.getTokens(),
+				ringTokens:          ringDesc.GetTokens(),
 				ringTokensByZone:    ringDesc.getTokensByZone(),
 				ringInstanceByToken: ringDesc.getTokensInfo(),
 				ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -1102,7 +1102,7 @@ func TestRing_ShuffleShard_Consistency(t *testing.T) {
 				}
 			}
 
-			ring.ringTokens = ringDesc.getTokens()
+			ring.ringTokens = ringDesc.GetTokens()
 			ring.ringTokensByZone = ringDesc.getTokensByZone()
 			ring.ringInstanceByToken = ringDesc.getTokensInfo()
 			ring.ringZones = getZones(ringDesc.getTokensByZone())
@@ -1138,7 +1138,7 @@ func TestRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
 			ZoneAwarenessEnabled: true,
 		},
 		ringDesc:            ringDesc,
-		ringTokens:          ringDesc.getTokens(),
+		ringTokens:          ringDesc.GetTokens(),
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -1215,7 +1215,7 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 			ZoneAwarenessEnabled: true,
 		},
 		ringDesc:            ringDesc,
-		ringTokens:          ringDesc.getTokens(),
+		ringTokens:          ringDesc.GetTokens(),
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -1247,7 +1247,7 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 	}
 
 	ring.ringDesc.Ingesters = ringInstances
-	ring.ringTokens = ringDesc.getTokens()
+	ring.ringTokens = ringDesc.GetTokens()
 	ring.ringTokensByZone = ringDesc.getTokensByZone()
 	ring.ringInstanceByToken = ringDesc.getTokensInfo()
 	ring.ringZones = getZones(ringDesc.getTokensByZone())
@@ -1474,7 +1474,7 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 					ZoneAwarenessEnabled: true,
 				},
 				ringDesc:            ringDesc,
-				ringTokens:          ringDesc.getTokens(),
+				ringTokens:          ringDesc.GetTokens(),
 				ringTokensByZone:    ringDesc.getTokensByZone(),
 				ringInstanceByToken: ringDesc.getTokensInfo(),
 				ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -1487,14 +1487,14 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 				case add:
 					ringDesc.Ingesters[event.instanceID] = event.instanceDesc
 
-					ring.ringTokens = ringDesc.getTokens()
+					ring.ringTokens = ringDesc.GetTokens()
 					ring.ringTokensByZone = ringDesc.getTokensByZone()
 					ring.ringInstanceByToken = ringDesc.getTokensInfo()
 					ring.ringZones = getZones(ringDesc.getTokensByZone())
 				case remove:
 					delete(ringDesc.Ingesters, event.instanceID)
 
-					ring.ringTokens = ringDesc.getTokens()
+					ring.ringTokens = ringDesc.GetTokens()
 					ring.ringTokensByZone = ringDesc.getTokensByZone()
 					ring.ringInstanceByToken = ringDesc.getTokensInfo()
 					ring.ringZones = getZones(ringDesc.getTokensByZone())
@@ -1539,7 +1539,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 						ReplicationFactor:    3,
 					},
 					ringDesc:            ringDesc,
-					ringTokens:          ringDesc.getTokens(),
+					ringTokens:          ringDesc.GetTokens(),
 					ringTokensByZone:    ringDesc.getTokensByZone(),
 					ringInstanceByToken: ringDesc.getTokensInfo(),
 					ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -1578,7 +1578,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 
 						ringDesc.Ingesters[instanceID] = generateRingInstanceWithInfo(instanceID, zoneID, GenerateTokens(128, nil), currTime)
 
-						ring.ringTokens = ringDesc.getTokens()
+						ring.ringTokens = ringDesc.GetTokens()
 						ring.ringTokensByZone = ringDesc.getTokensByZone()
 						ring.ringInstanceByToken = ringDesc.getTokensInfo()
 						ring.ringZones = getZones(ringDesc.getTokensByZone())
@@ -1596,7 +1596,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 						idToRemove := ingesterIDs[idxToRemove]
 						delete(ringDesc.Ingesters, idToRemove)
 
-						ring.ringTokens = ringDesc.getTokens()
+						ring.ringTokens = ringDesc.GetTokens()
 						ring.ringTokensByZone = ringDesc.getTokensByZone()
 						ring.ringInstanceByToken = ringDesc.getTokensInfo()
 						ring.ringZones = getZones(ringDesc.getTokensByZone())
@@ -1691,7 +1691,7 @@ func benchmarkShuffleSharding(b *testing.B, numInstances, numZones, numTokens, s
 	ring := Ring{
 		cfg:                  Config{HeartbeatTimeout: time.Hour, ZoneAwarenessEnabled: true, SubringCacheDisabled: !cache},
 		ringDesc:             ringDesc,
-		ringTokens:           ringDesc.getTokens(),
+		ringTokens:           ringDesc.GetTokens(),
 		ringTokensByZone:     ringDesc.getTokensByZone(),
 		ringInstanceByToken:  ringDesc.getTokensInfo(),
 		ringZones:            getZones(ringDesc.getTokensByZone()),
@@ -1719,7 +1719,7 @@ func BenchmarkRing_Get(b *testing.B) {
 	ring := Ring{
 		cfg:                  Config{HeartbeatTimeout: time.Hour, ZoneAwarenessEnabled: true, SubringCacheDisabled: true, ReplicationFactor: replicationFactor},
 		ringDesc:             ringDesc,
-		ringTokens:           ringDesc.getTokens(),
+		ringTokens:           ringDesc.GetTokens(),
 		ringTokensByZone:     ringDesc.getTokensByZone(),
 		ringInstanceByToken:  ringDesc.getTokensInfo(),
 		ringZones:            getZones(ringDesc.getTokensByZone()),

--- a/pkg/ring/util.go
+++ b/pkg/ring/util.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GenerateTokens make numTokens unique random tokens, none of which clash
-// with takenTokens.
+// with takenTokens. Generated tokens are sorted.
 func GenerateTokens(numTokens int, takenTokens []uint32) []uint32 {
 	if numTokens <= 0 {
 		return []uint32{}
@@ -23,7 +23,7 @@ func GenerateTokens(numTokens int, takenTokens []uint32) []uint32 {
 		used[v] = true
 	}
 
-	tokens := []uint32{}
+	tokens := make([]uint32, 0, numTokens)
 	for i := 0; i < numTokens; {
 		candidate := r.Uint32()
 		if used[candidate] {
@@ -33,6 +33,11 @@ func GenerateTokens(numTokens int, takenTokens []uint32) []uint32 {
 		tokens = append(tokens, candidate)
 		i++
 	}
+
+	// Ensure returned tokens are sorted.
+	sort.Slice(tokens, func(i, j int) bool {
+		return tokens[i] < tokens[j]
+	})
 
 	return tokens
 }
@@ -116,9 +121,17 @@ func WaitRingStability(ctx context.Context, r *Ring, op Operation, minStability,
 	}
 }
 
+// MakeBuffersForGet returns buffers to use with Ring.Get().
+func MakeBuffersForGet() (bufDescs []IngesterDesc, bufHosts, bufZones []string) {
+	bufDescs = make([]IngesterDesc, 0, GetBufferSize)
+	bufHosts = make([]string, 0, GetBufferSize)
+	bufZones = make([]string, 0, GetBufferSize)
+	return
+}
+
 // getZones return the list zones from the provided tokens. The returned list
 // is guaranteed to be sorted.
-func getZones(tokens map[string][]TokenDesc) []string {
+func getZones(tokens map[string][]uint32) []string {
 	var zones []string
 
 	for zone := range tokens {
@@ -130,9 +143,9 @@ func getZones(tokens map[string][]TokenDesc) []string {
 }
 
 // searchToken returns the offset of the tokens entry holding the range for the provided key.
-func searchToken(tokens []TokenDesc, key uint32) int {
+func searchToken(tokens []uint32, key uint32) int {
 	i := sort.Search(len(tokens), func(x int) bool {
-		return tokens[x].Token > key
+		return tokens[x] > key
 	})
 	if i >= len(tokens) {
 		i = 0

--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -59,12 +59,13 @@ func TestWaitRingStabilityShouldReturnAsSoonAsMinStabilityIsReachedOnNoChanges(t
 	}}
 
 	ring := &Ring{
-		cfg:              Config{HeartbeatTimeout: time.Minute},
-		ringDesc:         ringDesc,
-		ringTokens:       ringDesc.getTokens(),
-		ringTokensByZone: ringDesc.getTokensByZone(),
-		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         NewDefaultReplicationStrategy(true),
+		cfg:                 Config{HeartbeatTimeout: time.Minute},
+		ringDesc:            ringDesc,
+		ringTokens:          ringDesc.getTokens(),
+		ringTokensByZone:    ringDesc.getTokensByZone(),
+		ringInstanceByToken: ringDesc.getTokensInfo(),
+		ringZones:           getZones(ringDesc.getTokensByZone()),
+		strategy:            NewDefaultReplicationStrategy(true),
 	}
 
 	startTime := time.Now()
@@ -93,12 +94,13 @@ func TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached(t *testing.
 	}}
 
 	ring := &Ring{
-		cfg:              Config{HeartbeatTimeout: time.Minute},
-		ringDesc:         ringDesc,
-		ringTokens:       ringDesc.getTokens(),
-		ringTokensByZone: ringDesc.getTokensByZone(),
-		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         NewDefaultReplicationStrategy(true),
+		cfg:                 Config{HeartbeatTimeout: time.Minute},
+		ringDesc:            ringDesc,
+		ringTokens:          ringDesc.getTokens(),
+		ringTokensByZone:    ringDesc.getTokensByZone(),
+		ringInstanceByToken: ringDesc.getTokensInfo(),
+		ringZones:           getZones(ringDesc.getTokensByZone()),
+		strategy:            NewDefaultReplicationStrategy(true),
 	}
 
 	// Add 1 new instance after some time.
@@ -113,6 +115,7 @@ func TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached(t *testing.
 		ring.ringDesc = ringDesc
 		ring.ringTokens = ringDesc.getTokens()
 		ring.ringTokensByZone = ringDesc.getTokensByZone()
+		ring.ringInstanceByToken = ringDesc.getTokensInfo()
 		ring.ringZones = getZones(ringDesc.getTokensByZone())
 	}()
 
@@ -142,12 +145,13 @@ func TestWaitRingStabilityShouldReturnErrorIfMaxWaitingIsReached(t *testing.T) {
 	}}
 
 	ring := &Ring{
-		cfg:              Config{HeartbeatTimeout: time.Minute},
-		ringDesc:         ringDesc,
-		ringTokens:       ringDesc.getTokens(),
-		ringTokensByZone: ringDesc.getTokensByZone(),
-		ringZones:        getZones(ringDesc.getTokensByZone()),
-		strategy:         NewDefaultReplicationStrategy(true),
+		cfg:                 Config{HeartbeatTimeout: time.Minute},
+		ringDesc:            ringDesc,
+		ringTokens:          ringDesc.getTokens(),
+		ringTokensByZone:    ringDesc.getTokensByZone(),
+		ringInstanceByToken: ringDesc.getTokensInfo(),
+		ringZones:           getZones(ringDesc.getTokensByZone()),
+		strategy:            NewDefaultReplicationStrategy(true),
 	}
 
 	// Keep changing the ring.
@@ -166,6 +170,7 @@ func TestWaitRingStabilityShouldReturnErrorIfMaxWaitingIsReached(t *testing.T) {
 				ring.ringDesc = ringDesc
 				ring.ringTokens = ringDesc.getTokens()
 				ring.ringTokensByZone = ringDesc.getTokensByZone()
+				ring.ringInstanceByToken = ringDesc.getTokensInfo()
 				ring.ringZones = getZones(ringDesc.getTokensByZone())
 
 				ring.mtx.Unlock()

--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -61,7 +61,7 @@ func TestWaitRingStabilityShouldReturnAsSoonAsMinStabilityIsReachedOnNoChanges(t
 	ring := &Ring{
 		cfg:                 Config{HeartbeatTimeout: time.Minute},
 		ringDesc:            ringDesc,
-		ringTokens:          ringDesc.getTokens(),
+		ringTokens:          ringDesc.GetTokens(),
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -96,7 +96,7 @@ func TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached(t *testing.
 	ring := &Ring{
 		cfg:                 Config{HeartbeatTimeout: time.Minute},
 		ringDesc:            ringDesc,
-		ringTokens:          ringDesc.getTokens(),
+		ringTokens:          ringDesc.GetTokens(),
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -113,7 +113,7 @@ func TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached(t *testing.
 		instanceID := fmt.Sprintf("instance-%d", len(ringDesc.Ingesters)+1)
 		ringDesc.Ingesters[instanceID] = IngesterDesc{Addr: instanceID, State: ACTIVE, Timestamp: time.Now().Unix()}
 		ring.ringDesc = ringDesc
-		ring.ringTokens = ringDesc.getTokens()
+		ring.ringTokens = ringDesc.GetTokens()
 		ring.ringTokensByZone = ringDesc.getTokensByZone()
 		ring.ringInstanceByToken = ringDesc.getTokensInfo()
 		ring.ringZones = getZones(ringDesc.getTokensByZone())
@@ -147,7 +147,7 @@ func TestWaitRingStabilityShouldReturnErrorIfMaxWaitingIsReached(t *testing.T) {
 	ring := &Ring{
 		cfg:                 Config{HeartbeatTimeout: time.Minute},
 		ringDesc:            ringDesc,
-		ringTokens:          ringDesc.getTokens(),
+		ringTokens:          ringDesc.GetTokens(),
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
@@ -168,7 +168,7 @@ func TestWaitRingStabilityShouldReturnErrorIfMaxWaitingIsReached(t *testing.T) {
 				instanceID := fmt.Sprintf("instance-%d", len(ringDesc.Ingesters)+1)
 				ringDesc.Ingesters[instanceID] = IngesterDesc{Addr: instanceID, State: ACTIVE, Timestamp: time.Now().Unix()}
 				ring.ringDesc = ringDesc
-				ring.ringTokens = ringDesc.getTokens()
+				ring.ringTokens = ringDesc.GetTokens()
 				ring.ringTokensByZone = ringDesc.getTokensByZone()
 				ring.ringInstanceByToken = ringDesc.getTokensInfo()
 				ring.ringZones = getZones(ringDesc.getTokensByZone())

--- a/pkg/ruler/lifecycle.go
+++ b/pkg/ruler/lifecycle.go
@@ -13,7 +13,7 @@ func (r *Ruler) OnRingInstanceRegister(_ *ring.BasicLifecycler, ringDesc ring.De
 		tokens = instanceDesc.GetTokens()
 	}
 
-	_, takenTokens := ringDesc.TokensFor(instanceID)
+	takenTokens := ringDesc.GetTokens()
 	newTokens := ring.GenerateTokens(r.cfg.Ring.NumTokens-len(tokens), takenTokens)
 
 	// Tokens sorting will be enforced by the parent caller.

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -368,7 +368,7 @@ func tokenForGroup(g *store.RuleGroupDesc) uint32 {
 func instanceOwnsRuleGroup(r ring.ReadRing, g *rules.RuleGroupDesc, instanceAddr string) (bool, error) {
 	hash := tokenForGroup(g)
 
-	rlrs, err := r.Get(hash, ring.Ruler, []ring.IngesterDesc{})
+	rlrs, err := r.Get(hash, ring.Ruler, nil, nil, nil)
 	if err != nil {
 		return false, errors.Wrap(err, "error reading ring to verify rule group ownership")
 	}

--- a/pkg/ruler/ruler_replication_strategy.go
+++ b/pkg/ruler/ruler_replication_strategy.go
@@ -12,9 +12,11 @@ type rulerReplicationStrategy struct {
 }
 
 func (r rulerReplicationStrategy) Filter(instances []ring.IngesterDesc, op ring.Operation, _ int, heartbeatTimeout time.Duration, _ bool) (healthy []ring.IngesterDesc, maxFailures int, err error) {
+	now := time.Now()
+
 	// Filter out unhealthy instances.
 	for i := 0; i < len(instances); {
-		if instances[i].IsHealthy(op, heartbeatTimeout) {
+		if instances[i].IsHealthy(op, heartbeatTimeout, now) {
 			i++
 		} else {
 			instances = append(instances[:i], instances[i+1:]...)

--- a/pkg/ruler/ruler_ring.go
+++ b/pkg/ruler/ruler_ring.go
@@ -91,6 +91,7 @@ func (cfg *RingConfig) ToRingConfig() ring.Config {
 
 	rc.KVStore = cfg.KVStore
 	rc.HeartbeatTimeout = cfg.HeartbeatTimeout
+	rc.SubringCacheDisabled = true
 
 	// Each rule group is loaded to *exactly* one ruler.
 	rc.ReplicationFactor = 1

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -339,7 +339,7 @@ func (g *StoreGateway) OnRingInstanceRegister(_ *ring.BasicLifecycler, ringDesc 
 		tokens = instanceDesc.GetTokens()
 	}
 
-	_, takenTokens := ringDesc.TokensFor(instanceID)
+	takenTokens := ringDesc.GetTokens()
 	newTokens := ring.GenerateTokens(RingNumTokens-len(tokens), takenTokens)
 
 	// Tokens sorting will be enforced by the parent caller.

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -92,6 +92,7 @@ func (cfg *RingConfig) ToRingConfig() ring.Config {
 	rc.HeartbeatTimeout = cfg.HeartbeatTimeout
 	rc.ReplicationFactor = cfg.ReplicationFactor
 	rc.ZoneAwarenessEnabled = cfg.ZoneAwarenessEnabled
+	rc.SubringCacheDisabled = true
 
 	return rc
 }

--- a/pkg/storegateway/replication_strategy.go
+++ b/pkg/storegateway/replication_strategy.go
@@ -10,9 +10,11 @@ import (
 type BlocksReplicationStrategy struct{}
 
 func (s *BlocksReplicationStrategy) Filter(instances []ring.IngesterDesc, op ring.Operation, _ int, heartbeatTimeout time.Duration, _ bool) ([]ring.IngesterDesc, int, error) {
+	now := time.Now()
+
 	// Filter out unhealthy instances.
 	for i := 0; i < len(instances); {
-		if instances[i].IsHealthy(op, heartbeatTimeout) {
+		if instances[i].IsHealthy(op, heartbeatTimeout, now) {
 			i++
 		} else {
 			instances = append(instances[:i], instances[i+1:]...)

--- a/pkg/storegateway/sharding_strategy.go
+++ b/pkg/storegateway/sharding_strategy.go
@@ -122,11 +122,11 @@ func (s *ShuffleShardingStrategy) FilterBlocks(_ context.Context, userID string,
 }
 
 func filterBlocksByRingSharding(r ring.ReadRing, instanceAddr string, metas map[ulid.ULID]*metadata.Meta, synced *extprom.TxGaugeVec, logger log.Logger) {
-	buf, bufHosts, bufZones := ring.MakeBuffersForGet()
+	bufDescs, bufHosts, bufZones := ring.MakeBuffersForGet()
 
 	for blockID := range metas {
 		key := cortex_tsdb.HashBlockID(blockID)
-		set, err := r.Get(key, ring.BlocksSync, buf, bufHosts, bufZones)
+		set, err := r.Get(key, ring.BlocksSync, bufDescs, bufHosts, bufZones)
 
 		// If there are no healthy instances in the replication set or
 		// the replication set for this block doesn't include this instance

--- a/pkg/storegateway/sharding_strategy.go
+++ b/pkg/storegateway/sharding_strategy.go
@@ -122,12 +122,11 @@ func (s *ShuffleShardingStrategy) FilterBlocks(_ context.Context, userID string,
 }
 
 func filterBlocksByRingSharding(r ring.ReadRing, instanceAddr string, metas map[ulid.ULID]*metadata.Meta, synced *extprom.TxGaugeVec, logger log.Logger) {
-	// Buffer internally used by the ring (give extra room for a JOINING + LEAVING instance).
-	buf := make([]ring.IngesterDesc, 0, r.ReplicationFactor()+2)
+	buf, bufHosts, bufZones := ring.MakeBuffersForGet()
 
 	for blockID := range metas {
 		key := cortex_tsdb.HashBlockID(blockID)
-		set, err := r.Get(key, ring.BlocksSync, buf)
+		set, err := r.Get(key, ring.BlocksSync, buf, bufHosts, bufZones)
 
 		// If there are no healthy instances in the replication set or
 		// the replication set for this block doesn't include this instance

--- a/pkg/storegateway/sharding_strategy_test.go
+++ b/pkg/storegateway/sharding_strategy_test.go
@@ -609,8 +609,9 @@ func TestShuffleShardingStrategy(t *testing.T) {
 			}))
 
 			cfg := ring.Config{
-				ReplicationFactor: testData.replicationFactor,
-				HeartbeatTimeout:  time.Minute,
+				ReplicationFactor:    testData.replicationFactor,
+				HeartbeatTimeout:     time.Minute,
+				SubringCacheDisabled: true,
 			}
 
 			r, err := ring.NewWithStoreClientAndStrategy(cfg, "test", "test", store, &BlocksReplicationStrategy{})


### PR DESCRIPTION
**What this PR does**:
We've been reported an high memory utilisation in the store-gateway when shuffle-sharding is enabled and the cluster has a large number of tenants and replicas. This memory utilisation increase is caused by the in-memory subring cache used by the shuffle-sharding, which is used to reduce the CPU utilisation due to the expensive computation of the subring. 

However, store-gateway, ruler and compactor use `Ring.ShuffleShard()` only to check whether a tenant/block/rulegroup belongs to their own shard and this operation is run, for each tenant, only at a regular interval (it doesn't depend on QPS). 

Disabling subring cache is a possible solution (proposed in this PR), but then CPU utilisation is expected to increase. For this reason, in this PR I've also worked to optimise `Ring.ShuffleShard()` paying attention to not increase CPU time for `Ring.Get()` (problem is that it's easy to optimise `ShuffleShard()` but hard to do without impacting `Get()`).


## BenchmarkRing_ShuffleShard_512Tokens (512 tokens per instance)

```
benchmark                                   old ns/op     new ns/op     delta
BenchmarkRing_ShuffleShard_512Tokens-12     1396063       389304        -72.11%

benchmark                                   old allocs     new allocs     delta
BenchmarkRing_ShuffleShard_512Tokens-12     60             59             -1.67%

benchmark                                   old bytes     new bytes     delta
BenchmarkRing_ShuffleShard_512Tokens-12     681775        58226         -91.46%
```

## BenchmarkRing_Get

```
benchmark                                   old ns/op     new ns/op     delta
BenchmarkRing_Get-12                        853           764           -10.43%

benchmark                                   old allocs     new allocs     delta
BenchmarkRing_Get-12                        0              0              +0.00%

benchmark                                   old bytes     new bytes     delta
BenchmarkRing_Get-12                        0             0             +0.00%
```

## BenchmarkRing_ShuffleShard (128 tokens per instance)

```
BenchmarkRing_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_3-12              100674        32002         -68.21%
BenchmarkRing_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_10-12             393978        152904        -61.19%
BenchmarkRing_ShuffleShard/num_instances_=_50,_num_zones_=_1,_shard_size_=_30-12             1316209       639339        -51.43%
BenchmarkRing_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_3-12              117988        48928         -58.53%
BenchmarkRing_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_10-12             525024        183298        -65.09%
BenchmarkRing_ShuffleShard/num_instances_=_50,_num_zones_=_3,_shard_size_=_30-12             1221208       558804        -54.24%
BenchmarkRing_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_3-12             112511        37656         -66.53%
BenchmarkRing_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_10-12            408735        153631        -62.41%
BenchmarkRing_ShuffleShard/num_instances_=_100,_num_zones_=_1,_shard_size_=_30-12            1328229       655980        -50.61%
BenchmarkRing_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_3-12             121937        49367         -59.51%
BenchmarkRing_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_10-12            466278        176984        -62.04%
BenchmarkRing_ShuffleShard/num_instances_=_100,_num_zones_=_3,_shard_size_=_30-12            1265773       562446        -55.57%
BenchmarkRing_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_3-12            95741         31072         -67.55%
BenchmarkRing_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_10-12           376408        143209        -61.95%
BenchmarkRing_ShuffleShard/num_instances_=_1000,_num_zones_=_1,_shard_size_=_30-12           1328692       616708        -53.59%
BenchmarkRing_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_3-12            114967        47096         -59.04%
BenchmarkRing_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_10-12           441547        176075        -60.12%
BenchmarkRing_ShuffleShard/num_instances_=_1000,_num_zones_=_3,_shard_size_=_30-12           1288778       551126        -57.24%
```


**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
