### PR TITLE
Memberlist: fix "forget"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [ENHANCEMENT] Memberlist: add status page (/memberlist) with available details about memberlist-based KV store and memberlist cluster. It's also possible to view KV values in Go struct or JSON format, or download for inspection. #3575
 * [ENHANCEMENT] Memberlist: client can now keep a size-bounded buffer with sent and received messages and display them in the admin UI (/memberlist) for troubleshooting. #3581
 * [BUGFIX] Query-Frontend: `cortex_query_seconds_total` now return seconds not nanoseconds. #3589
+* [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603 
 
 ## 1.6.0-rc.0 in progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * [ENHANCEMENT] Memberlist: add status page (/memberlist) with available details about memberlist-based KV store and memberlist cluster. It's also possible to view KV values in Go struct or JSON format, or download for inspection. #3575
 * [ENHANCEMENT] Memberlist: client can now keep a size-bounded buffer with sent and received messages and display them in the admin UI (/memberlist) for troubleshooting. #3581
 * [BUGFIX] Query-Frontend: `cortex_query_seconds_total` now return seconds not nanoseconds. #3589
-* [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603 
+* [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603
 
 ## 1.6.0-rc.0 in progress
 


### PR DESCRIPTION
**What this PR does**: This PR fixes bug in "forget" feature when using memberlist.

When using memberlist (gossip), "forgetting" an entry doesn't delete it from the KV store, but sets entry to the "LEFT" state instead. Reason is that memberlist needs something to gossip about, and it can gossip about "LEFT" entry but not deleted entry. Unfortunately during this step, we didn't set Timestamp to current time, but reused last Timestamp of the entry. If there was already another message in the gossip network with higher timestamp, such message would eventually propagate everywhere, "resurrecting" the forgotten entry (because of higher timestamp, even though it's still in the past).

Solution is to set entry timestamp to "now" when setting entry to LEFT state.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
