### PR TITLE
Store unregister shutdown

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4165,6 +4165,18 @@ sharding_ring:
   # CLI flag: -store-gateway.sharding-ring.instance-availability-zone
   [instance_availability_zone: <string> | default = ""]
 
+  # Unregister from the ring upon clean shutdown. It can be useful to disable
+  # for rolling restarts with consistent naming
+  # CLI flag: -store-gateway.sharding-ring.unregister-on-shutdown
+  [unregister_on_shutdown: <boolean> | default = true]
+
+  # Try writing to an additional store gateway in the presence of a gateway not
+  # in the ACTIVE state. It is useful to disable this along with
+  # -store-gateway.sharding-ring.unregister-on-shutdown=false in order to not
+  # spread blocks to extra gateways during rolling restarts with consistent naming.
+  # CLI flag: -store-gateway.sharding-ring.extend-writes
+  [extend_writes: <boolean> | default = true]
+
 # The sharding strategy to use. Supported values are: default, shuffle-sharding.
 # CLI flag: -store-gateway.sharding-strategy
 [sharding_strategy: <string> | default = "default"]

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -185,7 +185,7 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 			return nil, errors.Wrap(err, "failed to create store-gateway ring backend")
 		}
 
-		storesRing, err := ring.NewWithStoreClientAndStrategy(storesRingCfg, storegateway.RingNameForClient, storegateway.RingKey, storesRingBackend, &storegateway.BlocksReplicationStrategy{})
+		storesRing, err := ring.NewWithStoreClientAndStrategy(storesRingCfg, storegateway.RingNameForClient, storegateway.RingKey, storesRingBackend, &storegateway.BlocksReplicationStrategy{ExtendWrites: gatewayCfg.ShardingRing.ExtendWrites})
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create store-gateway ring client")
 		}

--- a/pkg/ruler/ruler_ring.go
+++ b/pkg/ruler/ruler_ring.go
@@ -77,11 +77,12 @@ func (cfg *RingConfig) ToLifecyclerConfig() (ring.BasicLifecyclerConfig, error) 
 	instancePort := ring.GetInstancePort(cfg.InstancePort, cfg.ListenPort)
 
 	return ring.BasicLifecyclerConfig{
-		ID:                  cfg.InstanceID,
-		Addr:                fmt.Sprintf("%s:%d", instanceAddr, instancePort),
-		HeartbeatPeriod:     cfg.HeartbeatPeriod,
-		TokensObservePeriod: 0,
-		NumTokens:           cfg.NumTokens,
+		ID:                   cfg.InstanceID,
+		Addr:                 fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		HeartbeatPeriod:      cfg.HeartbeatPeriod,
+		TokensObservePeriod:  0,
+		NumTokens:            cfg.NumTokens,
+		UnregisterOnShutdown: true,
 	}, nil
 }
 

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -163,7 +163,7 @@ func newStoreGateway(gatewayCfg Config, storageCfg cortex_tsdb.BlocksStorageConf
 		}
 
 		ringCfg := gatewayCfg.ShardingRing.ToRingConfig()
-		g.ring, err = ring.NewWithStoreClientAndStrategy(ringCfg, RingNameForServer, RingKey, ringStore, &BlocksReplicationStrategy{})
+		g.ring, err = ring.NewWithStoreClientAndStrategy(ringCfg, RingNameForServer, RingKey, ringStore, &BlocksReplicationStrategy{ExtendWrites: gatewayCfg.ShardingRing.ExtendWrites})
 		if err != nil {
 			return nil, errors.Wrap(err, "create ring client")
 		}

--- a/pkg/storegateway/replication_strategy.go
+++ b/pkg/storegateway/replication_strategy.go
@@ -7,7 +7,9 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring"
 )
 
-type BlocksReplicationStrategy struct{}
+type BlocksReplicationStrategy struct {
+	ExtendWrites bool
+}
 
 func (s *BlocksReplicationStrategy) Filter(instances []ring.IngesterDesc, op ring.Operation, _ int, heartbeatTimeout time.Duration, _ bool) ([]ring.IngesterDesc, int, error) {
 	// Filter out unhealthy instances.
@@ -36,7 +38,7 @@ func (s *BlocksReplicationStrategy) ShouldExtendReplicaSet(instance ring.Ingeste
 		// - JOINING: the previous replica set should be kept while an instance is JOINING
 		// - LEAVING: the instance is going to be decommissioned soon so we need to include
 		//   		  another replica in the set
-		return instance.GetState() == ring.JOINING || instance.GetState() == ring.LEAVING
+		return instance.GetState() == ring.JOINING || (instance.GetState() == ring.LEAVING && s.ExtendWrites)
 	case ring.BlocksRead:
 		return false
 	default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**: Allows prevention of unregistering store gateways from the ring on shutdown. Allows prevention of replicating store gateway shard blocks when leaving the ring.

**Which issue(s) this PR fixes**:
Fixes #2823

**Checklist**
- [X] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

Will update change log after feedback 
