### PR TITLE
Add AWS to adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -2,6 +2,7 @@
 
 This is the list of organisations that are using Cortex in **production environments** to power their metrics and monitoring systems. Please send PRs to add or remove organisations.
 
+* [Amazon Web Services (AWS)](https://aws.amazon.com/prometheus)
 * [Aspen Mesh](https://aspenmesh.io/)
 * [Buoyant](https://buoyant.io/)
 * [DigitalOcean](https://www.digitalocean.com/)


### PR DESCRIPTION
https://aws.amazon.com/prometheus/faqs/ mentions that Cortex powers the service. I'm curious if you'd be open to being listed as an adopter @ranton256