### PR TITLE
Perform final tenant cleanup after last block is deleted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [ENHANCEMENT] Memberlist: client can now keep a size-bounded buffer with sent and received messages and display them in the admin UI (/memberlist) for troubleshooting. #3581 #3602
 * [ENHANCEMENT] Blocks storage: added block index attributes caching support to metadata cache. The TTL can be configured via `-blocks-storage.bucket-store.metadata-cache.block-index-attributes-ttl`. #3629
 * [ENHANCEMENT] Alertmanager: Add support for Azure blob storage. #3634
+* [ENHANCEMENT] Compactor: tenants marked for deletion will now be fully cleaned up after some delay since deletion of last block. Cleanup includes removal of remaining marker files (including tenant deletion mark file) and files under `debug/metas`. #3613
 * [BUGFIX] Allow `-querier.max-query-lookback` use `y|w|d` suffix like deprecated `-store.max-look-back-period`. #3598
 * [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603
 

--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -101,6 +101,7 @@ compactor:
   data_dir:            /tmp/cortex-compactor
   consistency_delay:   1m
   sharding_enabled:    true
+  cleanup_interval:    1m
   tenant_cleanup_delay: 1m
   sharding_ring:
     kvstore:

--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -101,6 +101,7 @@ compactor:
   data_dir:            /tmp/cortex-compactor
   consistency_delay:   1m
   sharding_enabled:    true
+  tenant_cleanup_delay: 1m
   sharding_ring:
     kvstore:
       store: consul

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -336,3 +336,24 @@ services:
       - 18013:18013
     volumes:
       - ./config:/cortex/config
+
+  purger:
+    build:
+      context:    .
+      dockerfile: dev.dockerfile
+    image: cortex
+    command: ["sh", "-c", "sleep 3 && exec ./dlv exec ./cortex --listen=:18014 --headless=true --api-version=2 --accept-multiclient --continue -- -config.file=./config/cortex.yaml -target=purger -server.http-listen-port=8014 -server.grpc-listen-port=9014"]
+    depends_on:
+      - consul
+      - minio
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_TAGS=app=querier-scheduler
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
+    ports:
+      - 8014:8014
+      - 18014:18014
+    volumes:
+      - ./config:/cortex/config

--- a/docs/blocks-storage/compactor.md
+++ b/docs/blocks-storage/compactor.md
@@ -143,6 +143,11 @@ compactor:
   # CLI flag: -compactor.deletion-delay
   [deletion_delay: <duration> | default = 12h]
 
+  # For tenants marked for deletion, this is time between deleting of last
+  # block, and doing final cleanup (marker files, debug files) of the tenant.
+  # CLI flag: -compactor.tenant-cleanup-delay
+  [tenant_cleanup_delay: <duration> | default = 6h]
+
   # When enabled, at compactor startup the bucket will be scanned and all found
   # deletion marks inside the block location will be copied to the markers
   # global location too. This option can (and should) be safely disabled as soon

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4113,6 +4113,11 @@ The `compactor_config` configures the compactor for the blocks storage.
 # CLI flag: -compactor.deletion-delay
 [deletion_delay: <duration> | default = 12h]
 
+# For tenants marked for deletion, this is time between deleting of last block,
+# and doing final cleanup (marker files, debug files) of the tenant.
+# CLI flag: -compactor.tenant-cleanup-delay
+[tenant_cleanup_delay: <duration> | default = 6h]
+
 # When enabled, at compactor startup the bucket will be scanned and all found
 # deletion marks inside the block location will be copied to the markers global
 # location too. This option can (and should) be safely disabled as soon as the

--- a/pkg/chunk/purger/blocks_purger_api.go
+++ b/pkg/chunk/purger/blocks_purger_api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -44,7 +45,7 @@ func (api *BlocksPurgerAPI) DeleteTenant(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	err = cortex_tsdb.WriteTenantDeletionMark(r.Context(), api.bucketClient, userID)
+	err = cortex_tsdb.WriteTenantDeletionMark(r.Context(), api.bucketClient, userID, cortex_tsdb.NewTenantDeletionMark(time.Now()))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -58,8 +59,8 @@ func (api *BlocksPurgerAPI) DeleteTenant(w http.ResponseWriter, r *http.Request)
 type DeleteTenantStatusResponse struct {
 	TenantID                  string `json:"tenant_id"`
 	BlocksDeleted             bool   `json:"blocks_deleted"`
-	RuleGroupsDeleted         bool   `json:"rule_groups_deleted"`
-	AlertManagerConfigDeleted bool   `json:"alert_manager_config_deleted"`
+	RuleGroupsDeleted         bool   `json:"rule_groups_deleted,omitempty"`
+	AlertManagerConfigDeleted bool   `json:"alert_manager_config_deleted,omitempty"`
 }
 
 func (api *BlocksPurgerAPI) DeleteTenantStatus(w http.ResponseWriter, r *http.Request) {

--- a/pkg/chunk/purger/blocks_purger_api.go
+++ b/pkg/chunk/purger/blocks_purger_api.go
@@ -59,8 +59,8 @@ func (api *BlocksPurgerAPI) DeleteTenant(w http.ResponseWriter, r *http.Request)
 type DeleteTenantStatusResponse struct {
 	TenantID                  string `json:"tenant_id"`
 	BlocksDeleted             bool   `json:"blocks_deleted"`
-	RuleGroupsDeleted         bool   `json:"rule_groups_deleted,omitempty"`
-	AlertManagerConfigDeleted bool   `json:"alert_manager_config_deleted,omitempty"`
+	RuleGroupsDeleted         bool   `json:"rule_groups_deleted,omitempty"`          // Not yet supported.
+	AlertManagerConfigDeleted bool   `json:"alert_manager_config_deleted,omitempty"` // Not yet supported.
 }
 
 func (api *BlocksPurgerAPI) DeleteTenantStatus(w http.ResponseWriter, r *http.Request) {

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -651,13 +651,15 @@ func TestCompactor_ShouldNotCompactBlocksForUsersMarkedForDeletion(t *testing.T)
 	t.Parallel()
 
 	cfg := prepareConfig()
-	cfg.DeletionDelay = 10 * time.Minute // Delete block after 10 minutes
+	cfg.DeletionDelay = 10 * time.Minute      // Delete block after 10 minutes
+	cfg.TenantCleanupDelay = 10 * time.Minute // To make sure it's not 0.
 
 	// Mock the bucket to contain two users, each one with one block.
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("", []string{"user-1"}, nil)
 	bucketClient.MockIter("user-1/", []string{"user-1/01DTVP434PA9VFXSW2JKB3392D"}, nil)
-	bucketClient.MockExists(path.Join("user-1", cortex_tsdb.TenantDeletionMarkPath), true, nil)
+	bucketClient.MockGet(path.Join("user-1", cortex_tsdb.TenantDeletionMarkPath), `{"deletion_time": 1}`, nil)
+	bucketClient.MockUpload(path.Join("user-1", cortex_tsdb.TenantDeletionMarkPath), nil)
 
 	bucketClient.MockIter("user-1/01DTVP434PA9VFXSW2JKB3392D", []string{"user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", "user-1/01DTVP434PA9VFXSW2JKB3392D/index"}, nil)
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", mockBlockMetaJSON("01DTVP434PA9VFXSW2JKB3392D"), nil)
@@ -694,7 +696,7 @@ func TestCompactor_ShouldNotCompactBlocksForUsersMarkedForDeletion(t *testing.T)
 		`level=debug component=cleaner org_id=user-1 msg="deleted file" file=01DTVP434PA9VFXSW2JKB3392D/meta.json bucket=mock`,
 		`level=debug component=cleaner org_id=user-1 msg="deleted file" file=01DTVP434PA9VFXSW2JKB3392D/index bucket=mock`,
 		`level=info component=cleaner org_id=user-1 msg="deleted block" block=01DTVP434PA9VFXSW2JKB3392D`,
-		`level=info component=cleaner org_id=user-1 msg="finished deleting blocks for user marked for deletion" deletedBlocks=1`,
+		`level=info component=cleaner org_id=user-1 msg="deleted blocks for user marked for deletion" deletedBlocks=1`,
 		`level=info component=cleaner msg="successfully completed blocks cleanup and maintenance"`,
 		`level=info component=compactor msg="discovering users from bucket"`,
 		`level=info component=compactor msg="discovered users from bucket" users=1`,

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -697,6 +697,7 @@ func TestCompactor_ShouldNotCompactBlocksForUsersMarkedForDeletion(t *testing.T)
 		`level=debug component=cleaner org_id=user-1 msg="deleted file" file=01DTVP434PA9VFXSW2JKB3392D/index bucket=mock`,
 		`level=info component=cleaner org_id=user-1 msg="deleted block" block=01DTVP434PA9VFXSW2JKB3392D`,
 		`level=info component=cleaner org_id=user-1 msg="deleted blocks for user marked for deletion" deletedBlocks=1`,
+		`level=info component=cleaner org_id=user-1 msg="updating finished time in tenant deletion mark"`,
 		`level=info component=cleaner msg="successfully completed blocks cleanup and maintenance"`,
 		`level=info component=compactor msg="discovering users from bucket"`,
 		`level=info component=compactor msg="discovered users from bucket" users=1`,

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -692,11 +692,11 @@ func TestCompactor_ShouldNotCompactBlocksForUsersMarkedForDeletion(t *testing.T)
 
 	assert.ElementsMatch(t, []string{
 		`level=info component=cleaner msg="started blocks cleanup and maintenance"`,
-		`level=info component=cleaner org_id=user-1 msg="deleting blocks for user marked for deletion"`,
+		`level=info component=cleaner org_id=user-1 msg="deleting blocks for tenant marked for deletion"`,
 		`level=debug component=cleaner org_id=user-1 msg="deleted file" file=01DTVP434PA9VFXSW2JKB3392D/meta.json bucket=mock`,
 		`level=debug component=cleaner org_id=user-1 msg="deleted file" file=01DTVP434PA9VFXSW2JKB3392D/index bucket=mock`,
 		`level=info component=cleaner org_id=user-1 msg="deleted block" block=01DTVP434PA9VFXSW2JKB3392D`,
-		`level=info component=cleaner org_id=user-1 msg="deleted blocks for user marked for deletion" deletedBlocks=1`,
+		`level=info component=cleaner org_id=user-1 msg="deleted blocks for tenant marked for deletion" deletedBlocks=1`,
 		`level=info component=cleaner org_id=user-1 msg="updating finished time in tenant deletion mark"`,
 		`level=info component=cleaner msg="successfully completed blocks cleanup and maintenance"`,
 		`level=info component=compactor msg="discovering users from bucket"`,

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -1822,7 +1822,7 @@ func TestIngester_dontShipBlocksWhenTenantDeletionMarkerIsPresent(t *testing.T) 
 	numObjects := len(bucket.Objects())
 	require.NotZero(t, numObjects)
 
-	require.NoError(t, cortex_tsdb.WriteTenantDeletionMark(context.Background(), bucket, userID))
+	require.NoError(t, cortex_tsdb.WriteTenantDeletionMark(context.Background(), bucket, userID, cortex_tsdb.NewTenantDeletionMark(time.Now())))
 	numObjects++ // For deletion marker
 
 	db := i.getTSDB(userID)

--- a/pkg/storage/bucket/bucket_util.go
+++ b/pkg/storage/bucket/bucket_util.go
@@ -1,0 +1,33 @@
+package bucket
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+// DeletePrefix removes all objects with given prefix, recursively.
+// It returns number of deleted objects.
+// If deletion of any object fails, it returns error and stops.
+func DeletePrefix(ctx context.Context, bkt objstore.Bucket, prefix string, logger log.Logger) (int, error) {
+	result := 0
+	err := bkt.Iter(ctx, prefix, func(name string) error {
+		if strings.HasSuffix(name, objstore.DirDelim) {
+			deleted, err := DeletePrefix(ctx, bkt, name, logger)
+			result += deleted
+			return err
+		}
+
+		if err := bkt.Delete(ctx, name); err != nil {
+			return err
+		}
+		result++
+		level.Debug(logger).Log("msg", "deleted file", "file", name)
+		return nil
+	})
+
+	return result, err
+}

--- a/pkg/storage/bucket/bucket_util_test.go
+++ b/pkg/storage/bucket/bucket_util_test.go
@@ -1,0 +1,28 @@
+package bucket
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+func TestDeletePrefix(t *testing.T) {
+	mem := objstore.NewInMemBucket()
+
+	require.NoError(t, mem.Upload(context.Background(), "obj", strings.NewReader("hello")))
+	require.NoError(t, mem.Upload(context.Background(), "prefix/1", strings.NewReader("hello")))
+	require.NoError(t, mem.Upload(context.Background(), "prefix/2", strings.NewReader("hello")))
+	require.NoError(t, mem.Upload(context.Background(), "prefix/sub1/3", strings.NewReader("hello")))
+	require.NoError(t, mem.Upload(context.Background(), "prefix/sub2/4", strings.NewReader("hello")))
+	require.NoError(t, mem.Upload(context.Background(), "outside/obj", strings.NewReader("hello")))
+
+	del, err := DeletePrefix(context.Background(), mem, "prefix", log.NewNopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, 4, del)
+	assert.Equal(t, 2, len(mem.Objects()))
+}

--- a/pkg/storage/tsdb/tenant_deletion_mark.go
+++ b/pkg/storage/tsdb/tenant_deletion_mark.go
@@ -7,8 +7,11 @@ import (
 	"path"
 	"time"
 
+	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/thanos-io/thanos/pkg/objstore"
+
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 // Relative to user-specific prefix.
@@ -17,6 +20,13 @@ const TenantDeletionMarkPath = "markers/tenant-deletion-mark.json"
 type TenantDeletionMark struct {
 	// Unix timestamp when deletion marker was created.
 	DeletionTime int64 `json:"deletion_time"`
+
+	// Unix timestamp when cleanup was finished.
+	FinishedTime int64 `json:"finished_time,omitempty"`
+}
+
+func NewTenantDeletionMark(deletionTime time.Time) *TenantDeletionMark {
+	return &TenantDeletionMark{DeletionTime: deletionTime.Unix()}
 }
 
 // Checks for deletion mark for tenant. Errors other than "object not found" are returned.
@@ -27,14 +37,40 @@ func TenantDeletionMarkExists(ctx context.Context, bkt objstore.BucketReader, us
 }
 
 // Uploads deletion mark to the tenant "directory".
-func WriteTenantDeletionMark(ctx context.Context, bkt objstore.Bucket, userID string) error {
-	m := &TenantDeletionMark{DeletionTime: time.Now().Unix()}
-
-	data, err := json.Marshal(m)
+func WriteTenantDeletionMark(ctx context.Context, bkt objstore.Bucket, userID string, mark *TenantDeletionMark) error {
+	data, err := json.Marshal(mark)
 	if err != nil {
 		return errors.Wrap(err, "serialize tenant deletion mark")
 	}
 
 	markerFile := path.Join(userID, TenantDeletionMarkPath)
 	return errors.Wrap(bkt.Upload(ctx, markerFile, bytes.NewReader(data)), "upload tenant deletion mark")
+}
+
+// Returns tenant deletion mark for given user, if it exists. If it doesn't exist, returns nil mark, and no error.
+func ReadTenantDeletionMark(ctx context.Context, bkt objstore.BucketReader, userID string) (*TenantDeletionMark, error) {
+	markerFile := path.Join(userID, TenantDeletionMarkPath)
+
+	r, err := bkt.Get(ctx, markerFile)
+	if err != nil {
+		if bkt.IsObjNotFoundErr(err) {
+			return nil, nil
+		}
+
+		return nil, errors.Wrapf(err, "failed to read deletion mark object: %s", markerFile)
+	}
+
+	mark := &TenantDeletionMark{}
+	err = json.NewDecoder(r).Decode(mark)
+
+	// Close reader before dealing with decode error.
+	if closeErr := r.Close(); closeErr != nil {
+		level.Warn(util.Logger).Log("msg", "failed to close bucket reader", "err", closeErr)
+	}
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to decode deletion mark object: %s", markerFile)
+	}
+
+	return mark, nil
 }


### PR DESCRIPTION
**What this PR does**: This PR implements final tenant cleanup after some delay since last tenant's block has been deleted. Cleanup will remove all remaining marker files (including tenant deletion), and meta.json files stored under `<tenant>/debug/meta` prefix.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
