### PR TITLE
[WIP] support extensions in runtimeconfig

### DIFF
--- a/pkg/util/runtimeconfig/manager.go
+++ b/pkg/util/runtimeconfig/manager.go
@@ -33,6 +33,12 @@ type ManagerConfig struct {
 	Loader   Loader `yaml:"-"`
 }
 
+type ExtensionConfig struct {
+	Name     string
+	LoadPath string
+	Loader   Loader
+}
+
 // RegisterFlags registers flags.
 func (mc *ManagerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&mc.LoadPath, "runtime-config.file", "", "File with the configuration that can be updated in runtime.")
@@ -44,17 +50,22 @@ func (mc *ManagerConfig) RegisterFlags(f *flag.FlagSet) {
 type Manager struct {
 	services.Service
 
-	cfg ManagerConfig
+	cfg           ManagerConfig
+	extensionCfgs map[string]ExtensionConfig `yaml:"-"`
 
 	listenersMtx sync.Mutex
-	listeners    []chan interface{}
+	// Keyed by config name.
+	listeners map[string][]chan interface{}
 
 	configMtx sync.RWMutex
-	config    interface{}
+	// Keyed by config name.
+	config map[string]interface{}
 
 	configLoadSuccess prometheus.Gauge
 	configHash        *prometheus.GaugeVec
 }
+
+const DefaultConfigName = "__default__"
 
 // NewRuntimeConfigManager creates an instance of Manager and starts reload config loop based on config
 func NewRuntimeConfigManager(cfg ManagerConfig, registerer prometheus.Registerer) (*Manager, error) {
@@ -63,7 +74,8 @@ func NewRuntimeConfigManager(cfg ManagerConfig, registerer prometheus.Registerer
 	}
 
 	mgr := Manager{
-		cfg: cfg,
+		cfg:           cfg,
+		extensionCfgs: make(map[string]ExtensionConfig),
 		configLoadSuccess: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_runtime_config_last_reload_successful",
 			Help: "Whether the last runtime-config reload attempt was successful.",
@@ -72,6 +84,9 @@ func NewRuntimeConfigManager(cfg ManagerConfig, registerer prometheus.Registerer
 			Name: "cortex_runtime_config_hash",
 			Help: "Hash of the currently active runtime config file.",
 		}, []string{"sha256"}),
+
+		listeners: make(map[string][]chan interface{}, 1),
+		config:    make(map[string]interface{}, 1),
 	}
 
 	mgr.Service = services.NewBasicService(mgr.start, mgr.loop, mgr.stop)
@@ -94,28 +109,60 @@ func (om *Manager) start(_ context.Context) error {
 //
 // When config manager is stopped, it closes all channels to notify receivers that they will
 // not receive any more updates.
-func (om *Manager) CreateListenerChannel(buffer int) <-chan interface{} {
+func (om *Manager) CreateListenerChannel(buffer int, cfgNames ...string) <-chan interface{} {
 	ch := make(chan interface{}, buffer)
+
+	if len(cfgNames) == 0 {
+		cfgNames = []string{DefaultConfigName}
+	}
 
 	om.listenersMtx.Lock()
 	defer om.listenersMtx.Unlock()
 
-	om.listeners = append(om.listeners, ch)
+	for _, cfgName := range cfgNames {
+		om.listeners[cfgName] = append(om.listeners[cfgName], ch)
+	}
+
 	return ch
 }
 
 // CloseListenerChannel removes given channel from list of channels to send notifications to and closes channel.
-func (om *Manager) CloseListenerChannel(listener <-chan interface{}) {
+func (om *Manager) CloseListenerChannel(listener <-chan interface{}, cfgNames ...string) {
+	if len(cfgNames) == 0 {
+		cfgNames = []string{DefaultConfigName}
+	}
+
+	closed := false
+
 	om.listenersMtx.Lock()
 	defer om.listenersMtx.Unlock()
 
-	for ix, ch := range om.listeners {
-		if ch == listener {
-			om.listeners = append(om.listeners[:ix], om.listeners[ix+1:]...)
-			close(ch)
-			break
+cfgs:
+	for _, cfgName := range cfgNames {
+		for ix, ch := range om.listeners[cfgName] {
+			if ch == listener {
+				om.listeners[cfgName] = append(om.listeners[cfgName][:ix], om.listeners[cfgName][ix+1:]...)
+				if !closed {
+					// Ensure that we only close the chan once.
+					close(ch)
+					closed = true
+					continue cfgs
+				}
+			}
 		}
 	}
+}
+
+func (om *Manager) AddExtension(cfg ExtensionConfig) error {
+	om.configMtx.Lock()
+	defer om.configMtx.Unlock()
+
+	if _, ok := om.extensionCfgs[cfg.Name]; ok {
+		return errors.New("Extension is already registered")
+	}
+
+	om.extensionCfgs[cfg.Name] = cfg
+	return nil
 }
 
 func (om *Manager) loop(ctx context.Context) error {
@@ -142,25 +189,26 @@ func (om *Manager) loop(ctx context.Context) error {
 	}
 }
 
-// loadConfig loads configuration using the loader function, and if successful,
-// stores it as current configuration and notifies listeners.
 func (om *Manager) loadConfig() error {
-	buf, err := ioutil.ReadFile(om.cfg.LoadPath)
+	cfg, hash, err := loadSingleConfig(om.cfg.LoadPath, om.cfg.Loader)
 	if err != nil {
 		om.configLoadSuccess.Set(0)
 		return err
 	}
-	hash := sha256.Sum256(buf)
+	om.setConfig(cfg, DefaultConfigName)
+	om.callListeners(cfg, DefaultConfigName)
 
-	cfg, err := om.cfg.Loader(bytes.NewReader(buf))
-	if err != nil {
-		om.configLoadSuccess.Set(0)
-		return err
+	for _, extension := range om.extensionCfgs {
+		cfg, hash, err = loadSingleConfig(extension.LoadPath, extension.Loader)
+		if err != nil {
+			om.configLoadSuccess.Set(0)
+			return err
+		}
+		om.setConfig(cfg, extension.Name)
+		om.callListeners(cfg, extension.Name)
 	}
+
 	om.configLoadSuccess.Set(1)
-
-	om.setConfig(cfg)
-	om.callListeners(cfg)
 
 	// expose hash of runtime config
 	om.configHash.Reset()
@@ -169,17 +217,35 @@ func (om *Manager) loadConfig() error {
 	return nil
 }
 
-func (om *Manager) setConfig(config interface{}) {
-	om.configMtx.Lock()
-	defer om.configMtx.Unlock()
-	om.config = config
+// loadSingleConfig loads specified configuration file using the loader function.
+// It returns the loaded file, a hash of the file, and potential errors.
+func loadSingleConfig(path string, loader Loader) (interface{}, [32]byte, error) {
+	var hash [32]byte
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, hash, err
+	}
+	hash = sha256.Sum256(buf)
+
+	cfg, err := loader(bytes.NewReader(buf))
+	if err != nil {
+		return nil, hash, err
+	}
+
+	return cfg, hash, nil
 }
 
-func (om *Manager) callListeners(newValue interface{}) {
+func (om *Manager) setConfig(config interface{}, cfgName string) {
+	om.configMtx.Lock()
+	defer om.configMtx.Unlock()
+	om.config[cfgName] = config
+}
+
+func (om *Manager) callListeners(newValue interface{}, cfgName string) {
 	om.listenersMtx.Lock()
 	defer om.listenersMtx.Unlock()
 
-	for _, ch := range om.listeners {
+	for _, ch := range om.listeners[cfgName] {
 		select {
 		case ch <- newValue:
 			// ok
@@ -194,17 +260,20 @@ func (om *Manager) stop(_ error) error {
 	om.listenersMtx.Lock()
 	defer om.listenersMtx.Unlock()
 
-	for _, ch := range om.listeners {
-		close(ch)
+	for configName := range om.listeners {
+		for _, ch := range om.listeners[configName] {
+			close(ch)
+		}
 	}
+
 	om.listeners = nil
 	return nil
 }
 
-// GetConfig returns last loaded config value, possibly nil.
+// GetConfig returns last loaded config value of the default config, possibly nil.
 func (om *Manager) GetConfig() interface{} {
 	om.configMtx.RLock()
 	defer om.configMtx.RUnlock()
 
-	return om.config
+	return om.config[DefaultConfigName]
 }

--- a/pkg/util/runtimeconfig/manager_test.go
+++ b/pkg/util/runtimeconfig/manager_test.go
@@ -283,8 +283,8 @@ func TestOverridesManager_LoadExtensionConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), overridesManager))
 
-	overridesManager.AddExtension(extensionConfig1)
-	overridesManager.AddExtension(extensionConfig2)
+	_ = overridesManager.AddExtension(extensionConfig1)
+	_ = overridesManager.AddExtension(extensionConfig2)
 
 	mainCh := overridesManager.CreateListenerChannel(1)
 	extensionCh1 := overridesManager.CreateListenerChannel(1, myExtensionName1)
@@ -296,21 +296,21 @@ func TestOverridesManager_LoadExtensionConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	expectingMsgsOnMainCh := map[int]struct{}{
-		111: struct{}{},
+		111: {},
 	}
 	expectingMsgsOnExtensionCh1 := map[int]struct{}{
-		3: struct{}{},
+		3: {},
 	}
 	expectingMsgsOnExtensionCh2 := map[int]struct{}{
-		42: struct{}{},
+		42: {},
 	}
 	expectingMsgsOnMixedCh1 := map[int]struct{}{
-		111: struct{}{},
-		3:   struct{}{},
+		111: {},
+		3:   {},
 	}
 	expectingMsgsOnMixedCh2 := map[int]struct{}{
-		3:  struct{}{},
-		42: struct{}{},
+		3:  {},
+		42: {},
 	}
 
 	timeoutCh := time.After(time.Second)


### PR DESCRIPTION
This PR extends the runtime config manager to allow users to add "extensions", which are basically additional config files to service.