### PR TITLE
Exit Consul watch on context canceled

### DIFF
--- a/pkg/ring/kv/consul/client.go
+++ b/pkg/ring/kv/consul/client.go
@@ -2,6 +2,7 @@ package consul
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -209,6 +210,9 @@ func (c *Client) WatchKey(ctx context.Context, key string, f func(interface{}) b
 	for backoff.Ongoing() {
 		err := limiter.Wait(ctx)
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				break
+			}
 			level.Error(util.Logger).Log("msg", "error while rate-limiting", "key", key, "err", err)
 			backoff.Wait()
 			continue
@@ -266,6 +270,9 @@ func (c *Client) WatchPrefix(ctx context.Context, prefix string, f func(string, 
 	for backoff.Ongoing() {
 		err := limiter.Wait(ctx)
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				break
+			}
 			level.Error(util.Logger).Log("msg", "error while rate-limiting", "prefix", prefix, "err", err)
 			backoff.Wait()
 			continue


### PR DESCRIPTION
**What this PR does**:

Avoids log lines like this:
```
level=error ts=2020-12-18T13:11:21.058904011Z caller=client.go:212 msg="error while rate-limiting" key=store-gateway err="context canceled"
```

**Checklist**
- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - don't think this merits a changelog entry.
