### PR TITLE
Synchronous call to rulerNotifier.run()

### DIFF
--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -206,7 +206,7 @@ func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string) (*notifie
 		},
 	}, log.With(r.logger, "user", userID))
 
-	go n.run()
+	n.run()
 
 	// This should never fail, unless there's a programming mistake.
 	if err := n.applyConfig(r.notifierCfg); err != nil {

--- a/pkg/ruler/notifier.go
+++ b/pkg/ruler/notifier.go
@@ -39,6 +39,7 @@ func newRulerNotifier(o *notifier.Options, l gklog.Logger) *rulerNotifier {
 	}
 }
 
+// run starts the notifier. This function doesn't block and returns immediately.
 func (rn *rulerNotifier) run() {
 	rn.wg.Add(2)
 	go func() {


### PR DESCRIPTION
**What this PR does**:
I was checking the issue reported at https://github.com/cortexproject/cortex/issues/3624. I've not been able to reproduce it (I tried adding few `time.Sleep()`), but something that popped my eyes is that `rulerNotifier.run()` should be called synchronously and not via `go n.run()`.

**Which issue(s) this PR fixes**:
Maybe #3624 but not sure.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
