### PR TITLE
Compactor: retry compaction of a single tenant on failure instead of re-running compaction for all tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * [ENHANCEMENT] Blocks storage: added block index attributes caching support to metadata cache. The TTL can be configured via `-blocks-storage.bucket-store.metadata-cache.block-index-attributes-ttl`. #3629
 * [ENHANCEMENT] Alertmanager: Add support for Azure blob storage. #3634
 * [ENHANCEMENT] Compactor: tenants marked for deletion will now be fully cleaned up after some delay since deletion of last block. Cleanup includes removal of remaining marker files (including tenant deletion mark file) and files under `debug/metas`. #3613
-* [ENHANCEMENT] Compactor: retry compaction of a single tenant on failure instead of re-running compaction for all tenants. #3626
+* [ENHANCEMENT] Compactor: retry compaction of a single tenant on failure instead of re-running compaction for all tenants. #3627
 * [BUGFIX] Allow `-querier.max-query-lookback` use `y|w|d` suffix like deprecated `-store.max-look-back-period`. #3598
 * [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603
 * [BUGFIX] Ingester: do not close idle TSDBs while blocks shipping is in progress. #3630

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [ENHANCEMENT] Blocks storage: added block index attributes caching support to metadata cache. The TTL can be configured via `-blocks-storage.bucket-store.metadata-cache.block-index-attributes-ttl`. #3629
 * [ENHANCEMENT] Alertmanager: Add support for Azure blob storage. #3634
 * [ENHANCEMENT] Compactor: tenants marked for deletion will now be fully cleaned up after some delay since deletion of last block. Cleanup includes removal of remaining marker files (including tenant deletion mark file) and files under `debug/metas`. #3613
+* [ENHANCEMENT] Compactor: retry compaction of a single tenant on failure instead of re-running compaction for all tenants. #3626
 * [BUGFIX] Allow `-querier.max-query-lookback` use `y|w|d` suffix like deprecated `-store.max-look-back-period`. #3598
 * [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603
 * [BUGFIX] Ingester: do not close idle TSDBs while blocks shipping is in progress. #3630

--- a/docs/blocks-storage/compactor.md
+++ b/docs/blocks-storage/compactor.md
@@ -116,8 +116,7 @@ compactor:
   # CLI flag: -compactor.compaction-interval
   [compaction_interval: <duration> | default = 1h]
 
-  # How many times to retry a failed compaction during a single compaction
-  # interval
+  # How many times to retry a failed compaction within a single compaction run.
   # CLI flag: -compactor.compaction-retries
   [compaction_retries: <int> | default = 3]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4086,8 +4086,7 @@ The `compactor_config` configures the compactor for the blocks storage.
 # CLI flag: -compactor.compaction-interval
 [compaction_interval: <duration> | default = 1h]
 
-# How many times to retry a failed compaction during a single compaction
-# interval
+# How many times to retry a failed compaction within a single compaction run.
 # CLI flag: -compactor.compaction-retries
 [compaction_retries: <int> | default = 3]
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -461,7 +461,6 @@ func (c *Compactor) compactUsers(ctx context.Context) {
 	}
 
 	succeeded = true
-	return
 }
 
 func (c *Compactor) compactUserWithRetries(ctx context.Context, userID string) error {

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -367,7 +367,7 @@ func (c *Compactor) stopping(_ error) error {
 
 func (c *Compactor) running(ctx context.Context) error {
 	// Run an initial compaction before starting the interval.
-	c.compactUsers(ctx)
+	_ = c.compactUsers(ctx)
 
 	ticker := time.NewTicker(util.DurationWithJitter(c.compactorCfg.CompactionInterval, 0.05))
 	defer ticker.Stop()
@@ -375,7 +375,7 @@ func (c *Compactor) running(ctx context.Context) error {
 	for {
 		select {
 		case <-ticker.C:
-			c.compactUsers(ctx)
+			_ = c.compactUsers(ctx)
 		case <-ctx.Done():
 			return nil
 		case err := <-c.ringSubservicesWatcher.Chan():

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -383,7 +383,9 @@ func (c *Compactor) running(ctx context.Context) error {
 	}
 }
 
-func (c *Compactor) compactUsers(ctx context.Context) (succeeded bool) {
+func (c *Compactor) compactUsers(ctx context.Context) {
+	succeeded := false
+
 	c.compactionRunsStarted.Inc()
 
 	defer func() {
@@ -405,7 +407,7 @@ func (c *Compactor) compactUsers(ctx context.Context) (succeeded bool) {
 	users, err := c.discoverUsersWithRetries(ctx)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to discover users from bucket", "err", err)
-		return false
+		return
 	}
 
 	level.Info(c.logger).Log("msg", "discovered users from bucket", "users", len(users))
@@ -422,7 +424,7 @@ func (c *Compactor) compactUsers(ctx context.Context) (succeeded bool) {
 		// Ensure the context has not been canceled (ie. compactor shutdown has been triggered).
 		if ctx.Err() != nil {
 			level.Info(c.logger).Log("msg", "interrupting compaction of user blocks", "err", err)
-			return false
+			return
 		}
 
 		// Ensure the user ID belongs to our shard.
@@ -458,7 +460,8 @@ func (c *Compactor) compactUsers(ctx context.Context) (succeeded bool) {
 		level.Info(c.logger).Log("msg", "successfully compacted user blocks", "user", userID)
 	}
 
-	return true
+	succeeded = true
+	return
 }
 
 func (c *Compactor) compactUserWithRetries(ctx context.Context, userID string) error {

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -290,10 +290,6 @@ func TestCompactor_ShouldRetryCompactionOnFailureWhileDiscoveringUsersFromBucket
 		`level=error component=cleaner msg="failed to run blocks cleanup and maintenance" err="failed to discover users from bucket: failed to iterate the bucket"`,
 		`level=info component=compactor msg="discovering users from bucket"`,
 		`level=error component=compactor msg="failed to discover users from bucket" err="failed to iterate the bucket"`,
-		`level=info component=compactor msg="discovering users from bucket"`,
-		`level=error component=compactor msg="failed to discover users from bucket" err="failed to iterate the bucket"`,
-		`level=info component=compactor msg="discovering users from bucket"`,
-		`level=error component=compactor msg="failed to discover users from bucket" err="failed to iterate the bucket"`,
 	}, strings.Split(strings.TrimSpace(logs.String()), "\n"))
 
 	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`


### PR DESCRIPTION
**What this PR does**:
Currently, the compactor re-run compaction for all tenants in case at least 1 tenant failed. Despite re-running the compaction for a previously succeeded tenant doesn't redo the work, but considering each single compaction run needs to re-scan the bucket, this ends up to be pretty inefficient for Cortex clusters running with a large number of tenants.

In this PR I'm proposing to retry compaction on failure only for the failed tenants.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
