### PR TITLE
chore: add 1.6.0 to backwards compatibility tests

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -136,6 +136,7 @@ jobs:
           docker pull quay.io/cortexproject/cortex:v1.3.0
           docker pull quay.io/cortexproject/cortex:v1.4.0
           docker pull quay.io/cortexproject/cortex:v1.5.0
+          docker pull quay.io/cortexproject/cortex:v1.6.0
           docker pull shopify/bigtable-emulator:0.1.0
           docker pull rinscy/cassandra:3.11.0
           docker pull memcached:1.6.1

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -26,6 +26,7 @@ var (
 		"quay.io/cortexproject/cortex:v1.3.0": preCortex14Flags,
 		"quay.io/cortexproject/cortex:v1.4.0": preCortex16Flags,
 		"quay.io/cortexproject/cortex:v1.5.0": preCortex16Flags,
+		"quay.io/cortexproject/cortex:v1.6.0": nil,
 	}
 )
 


### PR DESCRIPTION
- Final step in the 1.6.0 release