### PR TITLE
Add HTTP endpoint to show overrides (#1324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
   - Ruler: `-ruler.storage.swift.auth-version`, `-ruler.storage.swift.max-retries`, `-ruler.storage.swift.connect-timeout`, `-ruler.storage.swift.request-timeout`.
 * [ENHANCEMENT] Disabled in-memory shuffle-sharding subring cache in the store-gateway, ruler and compactor. This should reduce the memory utilisation in these services when shuffle-sharding is enabled, without introducing a significantly increase CPU utilisation. #3601
 * [ENHANCEMENT] Shuffle sharding: optimised subring generation used by shuffle sharding. #3601
-* [ENHANCEMENT] New /runtime_config endpoint that returns the defined runtime configuration in YAML format. #3639
+* [ENHANCEMENT] New /runtime_config endpoint that returns the defined runtime configuration in YAML format. The returned configuration includes overrides. #3639
 * [BUGFIX] Allow `-querier.max-query-lookback` use `y|w|d` suffix like deprecated `-store.max-look-back-period`. #3598
 * [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603
 * [BUGFIX] Ingester: do not close idle TSDBs while blocks shipping is in progress. #3630

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
   - Ruler: `-ruler.storage.swift.auth-version`, `-ruler.storage.swift.max-retries`, `-ruler.storage.swift.connect-timeout`, `-ruler.storage.swift.request-timeout`.
 * [ENHANCEMENT] Disabled in-memory shuffle-sharding subring cache in the store-gateway, ruler and compactor. This should reduce the memory utilisation in these services when shuffle-sharding is enabled, without introducing a significantly increase CPU utilisation. #3601
 * [ENHANCEMENT] Shuffle sharding: optimised subring generation used by shuffle sharding. #3601
-* [ENHANCEMENT] New /overrides endpoint that returns the limit overrides configuration in YAML format
+* [ENHANCEMENT] New /runtime_config/overrides endpoint that returns the defined runtime configuration in YAML format. #3639
 * [BUGFIX] Allow `-querier.max-query-lookback` use `y|w|d` suffix like deprecated `-store.max-look-back-period`. #3598
 * [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603
 * [BUGFIX] Ingester: do not close idle TSDBs while blocks shipping is in progress. #3630

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
   - Ruler: `-ruler.storage.swift.auth-version`, `-ruler.storage.swift.max-retries`, `-ruler.storage.swift.connect-timeout`, `-ruler.storage.swift.request-timeout`.
 * [ENHANCEMENT] Disabled in-memory shuffle-sharding subring cache in the store-gateway, ruler and compactor. This should reduce the memory utilisation in these services when shuffle-sharding is enabled, without introducing a significantly increase CPU utilisation. #3601
 * [ENHANCEMENT] Shuffle sharding: optimised subring generation used by shuffle sharding. #3601
-* [ENHANCEMENT] New /runtime_config/overrides endpoint that returns the defined runtime configuration in YAML format. #3639
+* [ENHANCEMENT] New /runtime_config endpoint that returns the defined runtime configuration in YAML format. #3639
 * [BUGFIX] Allow `-querier.max-query-lookback` use `y|w|d` suffix like deprecated `-store.max-look-back-period`. #3598
 * [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603
 * [BUGFIX] Ingester: do not close idle TSDBs while blocks shipping is in progress. #3630

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   - Ruler: `-ruler.storage.swift.auth-version`, `-ruler.storage.swift.max-retries`, `-ruler.storage.swift.connect-timeout`, `-ruler.storage.swift.request-timeout`.
 * [ENHANCEMENT] Disabled in-memory shuffle-sharding subring cache in the store-gateway, ruler and compactor. This should reduce the memory utilisation in these services when shuffle-sharding is enabled, without introducing a significantly increase CPU utilisation. #3601
 * [ENHANCEMENT] Shuffle sharding: optimised subring generation used by shuffle sharding. #3601
+* [ENHANCEMENT] New /overrides endpoint that returns the limit overrides configuration in YAML format
 * [BUGFIX] Allow `-querier.max-query-lookback` use `y|w|d` suffix like deprecated `-store.max-look-back-period`. #3598
 * [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603
 * [BUGFIX] Ingester: do not close idle TSDBs while blocks shipping is in progress. #3630

--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -19,6 +19,7 @@ For the sake of clarity, in this document we have grouped API endpoints by servi
 | --- | ------- | -------- |
 | [Index page](#index-page) | _All services_ | `GET /` |
 | [Configuration](#configuration) | _All services_ | `GET /config` |
+| [Overrides](#overrides) | _All services_ | `GET /overrides` |
 | [Services status](#services-status) | _All services_ | `GET /services` |
 | [Readiness probe](#readiness-probe) | _All services_ | `GET /ready` |
 | [Metrics](#metrics) | _All services_ | `GET /metrics` |
@@ -122,6 +123,14 @@ GET /config?mode=defaults
 ```
 
 Displays the configuration using only the default values.
+
+### Overrides
+
+```
+GET /overrides
+```
+
+Displays the limit overrides, per tenant, currently applied to Cortex (in YAML format), including default values.
 
 ### Services status
 

--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -19,7 +19,7 @@ For the sake of clarity, in this document we have grouped API endpoints by servi
 | --- | ------- | -------- |
 | [Index page](#index-page) | _All services_ | `GET /` |
 | [Configuration](#configuration) | _All services_ | `GET /config` |
-| [Runtime Configuration](#runtime-config) | _All services_ | `GET /runtime_config` |
+| [Runtime Configuration](#runtime-configuration) | _All services_ | `GET /runtime_config` |
 | [Services status](#services-status) | _All services_ | `GET /services` |
 | [Readiness probe](#readiness-probe) | _All services_ | `GET /ready` |
 | [Metrics](#metrics) | _All services_ | `GET /metrics` |

--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -130,7 +130,7 @@ Displays the configuration using only the default values.
 GET /runtime_config
 ```
 
-Displays the runtime configuration currently applied to Cortex (in YAML format), including default values.
+Displays the runtime configuration currently applied to Cortex (in YAML format), including default values. Please be aware that the configuration will be available only if Cortex is configured with a valid `-runtime-config.file`.
 
 ### Services status
 

--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -19,7 +19,7 @@ For the sake of clarity, in this document we have grouped API endpoints by servi
 | --- | ------- | -------- |
 | [Index page](#index-page) | _All services_ | `GET /` |
 | [Configuration](#configuration) | _All services_ | `GET /config` |
-| [Overrides](#overrides) | _All services_ | `GET /runtime_config/overrides` |
+| [Runtime Configuration](#runtime-config) | _All services_ | `GET /runtime_config` |
 | [Services status](#services-status) | _All services_ | `GET /services` |
 | [Readiness probe](#readiness-probe) | _All services_ | `GET /ready` |
 | [Metrics](#metrics) | _All services_ | `GET /metrics` |
@@ -124,13 +124,13 @@ GET /config?mode=defaults
 
 Displays the configuration using only the default values.
 
-### Overrides
+### Runtime Configuration
 
 ```
-GET /runtime_config/overrides
+GET /runtime_config
 ```
 
-Displays the limit overrides, per tenant, currently applied to Cortex (in YAML format), including default values.
+Displays the runtime configuration currently applied to Cortex (in YAML format), including default values.
 
 ### Services status
 

--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -130,7 +130,7 @@ Displays the configuration using only the default values.
 GET /runtime_config
 ```
 
-Displays the runtime configuration currently applied to Cortex (in YAML format), including default values. Please be aware that the configuration will be available only if Cortex is configured with a valid `-runtime-config.file`.
+Displays the runtime configuration currently applied to Cortex (in YAML format), including default values. Please be aware that the endpoint will be only available if Cortex is configured with the `-runtime-config.file` option.
 
 ### Services status
 

--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -19,7 +19,7 @@ For the sake of clarity, in this document we have grouped API endpoints by servi
 | --- | ------- | -------- |
 | [Index page](#index-page) | _All services_ | `GET /` |
 | [Configuration](#configuration) | _All services_ | `GET /config` |
-| [Overrides](#overrides) | _All services_ | `GET /overrides` |
+| [Overrides](#overrides) | _All services_ | `GET /runtime_config/overrides` |
 | [Services status](#services-status) | _All services_ | `GET /services` |
 | [Readiness probe](#readiness-probe) | _All services_ | `GET /ready` |
 | [Metrics](#metrics) | _All services_ | `GET /metrics` |
@@ -127,7 +127,7 @@ Displays the configuration using only the default values.
 ### Overrides
 
 ```
-GET /overrides
+GET /runtime_config/overrides
 ```
 
 Displays the limit overrides, per tenant, currently applied to Cortex (in YAML format), including default values.

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -286,7 +286,7 @@ Multi KV also reacts on changes done via runtime configuration. It uses this sec
 
 ```yaml
 multi_kv_config:
-    mirror-enabled: false
+    mirror_enabled: false
     primary: memberlist
 ```
 
@@ -421,6 +421,8 @@ multi_kv_config:
 ```
 
 When running Cortex on Kubernetes, store this file in a config map and mount it in each services' containers.  When changing the values there is no need to restart the services, unless otherwise specified.
+
+The `/runtime_config` endpoint returns the runtime configuration, including the overrides.
 
 ## Ingester, Distributor & Querier limits.
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
+
 	"github.com/NYTimes/gziphandler"
 	"github.com/felixge/fgprof"
 	"github.com/go-kit/kit/log"
@@ -173,6 +175,13 @@ func (a *API) RegisterAPI(httpPathPrefix string, actualCfg interface{}, defaultC
 	a.RegisterRoute("/config", configHandler(actualCfg, defaultCfg), false, "GET")
 	a.RegisterRoute("/", indexHandler(httpPathPrefix, a.indexPage), false, "GET")
 	a.RegisterRoute("/debug/fgprof", fgprof.Handler(), false, "GET")
+}
+
+// RegisterOverrides registers the endpoints associates with the configuration overrides
+func (a *API) RegisterOverrides(runtimeCfgManager *runtimeconfig.Manager) {
+	a.indexPage.AddLink(SectionAdminEndpoints, "/overrides", "Current Overrides Config")
+
+	a.RegisterRoute("/overrides", overridesHandler(runtimeCfgManager), false, "GET")
 }
 
 // RegisterDistributor registers the endpoints associated with the distributor.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -177,11 +177,11 @@ func (a *API) RegisterAPI(httpPathPrefix string, actualCfg interface{}, defaultC
 	a.RegisterRoute("/debug/fgprof", fgprof.Handler(), false, "GET")
 }
 
-// RegisterOverrides registers the endpoints associates with the configuration overrides
-func (a *API) RegisterOverrides(runtimeCfgManager *runtimeconfig.Manager) {
-	a.indexPage.AddLink(SectionAdminEndpoints, "/overrides", "Current Overrides Config")
+// RegisterRuntimeConfig registers the endpoints associates with the runtime configuration
+func (a *API) RegisterRuntimeConfig(runtimeCfgManager *runtimeconfig.Manager) {
+	a.indexPage.AddLink(SectionAdminEndpoints, "/runtime_config/overrides", "Current Overrides Config")
 
-	a.RegisterRoute("/overrides", overridesHandler(runtimeCfgManager), false, "GET")
+	a.RegisterRoute("/runtime_config/overrides", overridesHandler(runtimeCfgManager), false, "GET")
 }
 
 // RegisterDistributor registers the endpoints associated with the distributor.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
-
 	"github.com/NYTimes/gziphandler"
 	"github.com/felixge/fgprof"
 	"github.com/go-kit/kit/log"
@@ -35,6 +33,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/storegateway"
 	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
 	"github.com/cortexproject/cortex/pkg/util/push"
+	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
 )
 
 type Config struct {
@@ -179,7 +178,7 @@ func (a *API) RegisterAPI(httpPathPrefix string, actualCfg interface{}, defaultC
 
 // RegisterRuntimeConfig registers the endpoints associates with the runtime configuration
 func (a *API) RegisterRuntimeConfig(runtimeCfgManager *runtimeconfig.Manager) {
-	a.indexPage.AddLink(SectionAdminEndpoints, "/runtime_config", "Current Runtime Config")
+	a.indexPage.AddLink(SectionAdminEndpoints, "/runtime_config", "Current Runtime Config (incl. Overrides)")
 
 	a.RegisterRoute("/runtime_config", runtimeConfigHandler(runtimeCfgManager), false, "GET")
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -179,9 +179,9 @@ func (a *API) RegisterAPI(httpPathPrefix string, actualCfg interface{}, defaultC
 
 // RegisterRuntimeConfig registers the endpoints associates with the runtime configuration
 func (a *API) RegisterRuntimeConfig(runtimeCfgManager *runtimeconfig.Manager) {
-	a.indexPage.AddLink(SectionAdminEndpoints, "/runtime_config/overrides", "Current Overrides Config")
+	a.indexPage.AddLink(SectionAdminEndpoints, "/runtime_config", "Current Runtime Config")
 
-	a.RegisterRoute("/runtime_config/overrides", overridesHandler(runtimeCfgManager), false, "GET")
+	a.RegisterRoute("/runtime_config", runtimeConfigHandler(runtimeCfgManager), false, "GET")
 }
 
 // RegisterDistributor registers the endpoints associated with the distributor.

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/querier"
 	"github.com/cortexproject/cortex/pkg/querier/stats"
 	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
 )
 
 const (
@@ -218,6 +219,22 @@ func configHandler(actualCfg interface{}, defaultCfg interface{}) http.HandlerFu
 		}
 
 		util.WriteYAMLResponse(w, output)
+	}
+}
+
+func overridesHandler(runtimeCfgManager *runtimeconfig.Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		out, err := yaml.Marshal(runtimeCfgManager.GetConfig())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/yaml")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(out); err != nil {
+			level.Error(util.Logger).Log("msg", "error writing response", "err", err)
+		}
 	}
 }
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -222,7 +222,7 @@ func configHandler(actualCfg interface{}, defaultCfg interface{}) http.HandlerFu
 	}
 }
 
-func overridesHandler(runtimeCfgManager *runtimeconfig.Manager) http.HandlerFunc {
+func runtimeConfigHandler(runtimeCfgManager *runtimeconfig.Manager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		out, err := yaml.Marshal(runtimeCfgManager.GetConfig())
 		if err != nil {
@@ -230,7 +230,7 @@ func overridesHandler(runtimeCfgManager *runtimeconfig.Manager) http.HandlerFunc
 			return
 		}
 
-		w.Header().Set("Content-Type", "text/yaml")
+		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 		if _, err := w.Write(out); err != nil {
 			level.Error(util.Logger).Log("msg", "error writing response", "err", err)

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -226,7 +226,7 @@ func runtimeConfigHandler(runtimeCfgManager *runtimeconfig.Manager) http.Handler
 	return func(w http.ResponseWriter, r *http.Request) {
 		runtimeConfig := runtimeCfgManager.GetConfig()
 		if runtimeConfig == nil {
-			http.Error(w, "runtime config file doesn't exist", http.StatusInternalServerError)
+			util.WriteTextResponse(w, "runtime config file doesn't exist")
 			return
 		}
 		util.WriteYAMLResponse(w, runtimeConfig)

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -224,17 +224,12 @@ func configHandler(actualCfg interface{}, defaultCfg interface{}) http.HandlerFu
 
 func runtimeConfigHandler(runtimeCfgManager *runtimeconfig.Manager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		out, err := yaml.Marshal(runtimeCfgManager.GetConfig())
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		runtimeConfig := runtimeCfgManager.GetConfig()
+		if runtimeConfig == nil {
+			http.Error(w, "runtime config file doesn't exist", http.StatusInternalServerError)
 			return
 		}
-
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write(out); err != nil {
-			level.Error(util.Logger).Log("msg", "error writing response", "err", err)
-		}
+		util.WriteYAMLResponse(w, runtimeConfig)
 	}
 }
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -178,7 +178,6 @@ func (t *Cortex) initRuntimeConfig() (services.Service, error) {
 
 func (t *Cortex) initOverrides() (serv services.Service, err error) {
 	t.Overrides, err = validation.NewOverrides(t.Cfg.LimitsConfig, tenantLimitsFromRuntimeConfig(t.RuntimeConfig))
-
 	// overrides don't have operational state, nor do they need to do anything more in starting/stopping phase,
 	// so there is no need to return any service.
 	return nil, err

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -177,6 +177,8 @@ func (t *Cortex) initRuntimeConfig() (services.Service, error) {
 
 func (t *Cortex) initOverrides() (serv services.Service, err error) {
 	t.Overrides, err = validation.NewOverrides(t.Cfg.LimitsConfig, tenantLimitsFromRuntimeConfig(t.RuntimeConfig))
+
+	t.API.RegisterOverrides(t.RuntimeConfig)
 	// overrides don't have operational state, nor do they need to do anything more in starting/stopping phase,
 	// so there is no need to return any service.
 	return nil, err
@@ -829,7 +831,7 @@ func (t *Cortex) setupModuleManager() error {
 		API:                      {Server},
 		MemberlistKV:             {API},
 		Ring:                     {API, RuntimeConfig, MemberlistKV},
-		Overrides:                {RuntimeConfig},
+		Overrides:                {RuntimeConfig, API},
 		Distributor:              {DistributorService, API},
 		DistributorService:       {Ring, Overrides},
 		Store:                    {Overrides, DeleteRequestsStore},

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -172,13 +172,13 @@ func (t *Cortex) initRuntimeConfig() (services.Service, error) {
 
 	serv, err := runtimeconfig.NewRuntimeConfigManager(t.Cfg.RuntimeConfig, prometheus.DefaultRegisterer)
 	t.RuntimeConfig = serv
+	t.API.RegisterRuntimeConfig(t.RuntimeConfig)
 	return serv, err
 }
 
 func (t *Cortex) initOverrides() (serv services.Service, err error) {
 	t.Overrides, err = validation.NewOverrides(t.Cfg.LimitsConfig, tenantLimitsFromRuntimeConfig(t.RuntimeConfig))
 
-	t.API.RegisterOverrides(t.RuntimeConfig)
 	// overrides don't have operational state, nor do they need to do anything more in starting/stopping phase,
 	// so there is no need to return any service.
 	return nil, err
@@ -830,8 +830,9 @@ func (t *Cortex) setupModuleManager() error {
 	deps := map[string][]string{
 		API:                      {Server},
 		MemberlistKV:             {API},
+		RuntimeConfig:            {API},
 		Ring:                     {API, RuntimeConfig, MemberlistKV},
-		Overrides:                {RuntimeConfig, API},
+		Overrides:                {RuntimeConfig},
 		Distributor:              {DistributorService, API},
 		DistributorService:       {Ring, Overrides},
 		Store:                    {Overrides, DeleteRequestsStore},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR introduces a new endpoint that would retrieve the override configuration, per tenant, that is loaded as part of the runtime configuration

**Which issue(s) this PR fixes**:
Fixes #1324

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
