### PR TITLE
Fix bucket index sync interval config inconsistency

### DIFF
--- a/docs/blocks-storage/bucket-index.md
+++ b/docs/blocks-storage/bucket-index.md
@@ -47,7 +47,7 @@ _Given it's a small file, lazy downloading it doesn't significantly impact on fi
 
 While in-memory, a background process will keep it **updated at periodic intervals**, so that subsequent queries from the same tenant to the same querier instance will use the cached (and periodically updated) bucket index. There are two config options involved:
 
-- `-blocks-storage.bucket-store.bucket-index.update-on-stale-interval`<br />
+- `-blocks-storage.bucket-store.sync-interval`<br />
   This option configures how frequently a cached bucket index should be refreshed.
 - `-blocks-storage.bucket-store.bucket-index.update-on-error-interval`<br />
   If downloading a bucket index fails, the failure is cached for a short time in order to avoid hammering the backend storage. This option configures how frequently a bucket index, which previously failed to load, should be tried to load again.

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -365,9 +365,9 @@ blocks_storage:
     # CLI flag: -blocks-storage.bucket-store.sync-dir
     [sync_dir: <string> | default = "tsdb-sync"]
 
-    # How frequently scan the bucket - or fetch the bucket index (if enabled) -
-    # to look for changes (new blocks shipped by ingesters and blocks removed by
-    # retention or compaction). 0 disables it.
+    # How frequently scan the bucket - or refresh the bucket index (if enabled)
+    # - to look for changes (new blocks shipped by ingesters and blocks deleted
+    # by retention or compaction).
     # CLI flag: -blocks-storage.bucket-store.sync-interval
     [sync_interval: <duration> | default = 5m]
 
@@ -639,11 +639,6 @@ blocks_storage:
       # storage via bucket index instead of bucket scanning.
       # CLI flag: -blocks-storage.bucket-store.bucket-index.enabled
       [enabled: <boolean> | default = false]
-
-      # How frequently a cached bucket index should be refreshed. This option is
-      # used only by querier.
-      # CLI flag: -blocks-storage.bucket-store.bucket-index.update-on-stale-interval
-      [update_on_stale_interval: <duration> | default = 15m]
 
       # How frequently a bucket index, which previously failed to load, should
       # be tried to load again. This option is used only by querier.

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -365,9 +365,9 @@ blocks_storage:
     # CLI flag: -blocks-storage.bucket-store.sync-dir
     [sync_dir: <string> | default = "tsdb-sync"]
 
-    # How frequently scan the bucket - or refresh the bucket index (if enabled)
-    # - to look for changes (new blocks shipped by ingesters and blocks deleted
-    # by retention or compaction).
+    # How frequently to scan the bucket, or to refresh the bucket index (if
+    # enabled), in order to look for changes (new blocks shipped by ingesters
+    # and blocks deleted by retention or compaction).
     # CLI flag: -blocks-storage.bucket-store.sync-interval
     [sync_interval: <duration> | default = 5m]
 

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -412,9 +412,9 @@ blocks_storage:
     # CLI flag: -blocks-storage.bucket-store.sync-dir
     [sync_dir: <string> | default = "tsdb-sync"]
 
-    # How frequently scan the bucket - or fetch the bucket index (if enabled) -
-    # to look for changes (new blocks shipped by ingesters and blocks removed by
-    # retention or compaction). 0 disables it.
+    # How frequently scan the bucket - or refresh the bucket index (if enabled)
+    # - to look for changes (new blocks shipped by ingesters and blocks deleted
+    # by retention or compaction).
     # CLI flag: -blocks-storage.bucket-store.sync-interval
     [sync_interval: <duration> | default = 5m]
 
@@ -686,11 +686,6 @@ blocks_storage:
       # storage via bucket index instead of bucket scanning.
       # CLI flag: -blocks-storage.bucket-store.bucket-index.enabled
       [enabled: <boolean> | default = false]
-
-      # How frequently a cached bucket index should be refreshed. This option is
-      # used only by querier.
-      # CLI flag: -blocks-storage.bucket-store.bucket-index.update-on-stale-interval
-      [update_on_stale_interval: <duration> | default = 15m]
 
       # How frequently a bucket index, which previously failed to load, should
       # be tried to load again. This option is used only by querier.

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -412,9 +412,9 @@ blocks_storage:
     # CLI flag: -blocks-storage.bucket-store.sync-dir
     [sync_dir: <string> | default = "tsdb-sync"]
 
-    # How frequently scan the bucket - or refresh the bucket index (if enabled)
-    # - to look for changes (new blocks shipped by ingesters and blocks deleted
-    # by retention or compaction).
+    # How frequently to scan the bucket, or to refresh the bucket index (if
+    # enabled), in order to look for changes (new blocks shipped by ingesters
+    # and blocks deleted by retention or compaction).
     # CLI flag: -blocks-storage.bucket-store.sync-interval
     [sync_interval: <duration> | default = 5m]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3682,9 +3682,9 @@ bucket_store:
   # CLI flag: -blocks-storage.bucket-store.sync-dir
   [sync_dir: <string> | default = "tsdb-sync"]
 
-  # How frequently scan the bucket - or fetch the bucket index (if enabled) - to
-  # look for changes (new blocks shipped by ingesters and blocks removed by
-  # retention or compaction). 0 disables it.
+  # How frequently scan the bucket - or refresh the bucket index (if enabled) -
+  # to look for changes (new blocks shipped by ingesters and blocks deleted by
+  # retention or compaction).
   # CLI flag: -blocks-storage.bucket-store.sync-interval
   [sync_interval: <duration> | default = 5m]
 
@@ -3955,11 +3955,6 @@ bucket_store:
     # via bucket index instead of bucket scanning.
     # CLI flag: -blocks-storage.bucket-store.bucket-index.enabled
     [enabled: <boolean> | default = false]
-
-    # How frequently a cached bucket index should be refreshed. This option is
-    # used only by querier.
-    # CLI flag: -blocks-storage.bucket-store.bucket-index.update-on-stale-interval
-    [update_on_stale_interval: <duration> | default = 15m]
 
     # How frequently a bucket index, which previously failed to load, should be
     # tried to load again. This option is used only by querier.

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3682,9 +3682,9 @@ bucket_store:
   # CLI flag: -blocks-storage.bucket-store.sync-dir
   [sync_dir: <string> | default = "tsdb-sync"]
 
-  # How frequently scan the bucket - or refresh the bucket index (if enabled) -
-  # to look for changes (new blocks shipped by ingesters and blocks deleted by
-  # retention or compaction).
+  # How frequently to scan the bucket, or to refresh the bucket index (if
+  # enabled), in order to look for changes (new blocks shipped by ingesters and
+  # blocks deleted by retention or compaction).
   # CLI flag: -blocks-storage.bucket-store.sync-interval
   [sync_interval: <duration> | default = 5m]
 

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -172,7 +172,7 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 		finder = NewBucketIndexBlocksFinder(BucketIndexBlocksFinderConfig{
 			IndexLoader: bucketindex.LoaderConfig{
 				CheckInterval:         time.Minute,
-				UpdateOnStaleInterval: storageCfg.BucketStore.BucketIndex.UpdateOnStaleInterval,
+				UpdateOnStaleInterval: storageCfg.BucketStore.SyncInterval,
 				UpdateOnErrorInterval: storageCfg.BucketStore.BucketIndex.UpdateOnErrorInterval,
 				IdleTimeout:           storageCfg.BucketStore.BucketIndex.IdleTimeout,
 			},

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -243,7 +243,7 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.BucketIndex.RegisterFlagsWithPrefix(f, "blocks-storage.bucket-store.bucket-index.")
 
 	f.StringVar(&cfg.SyncDir, "blocks-storage.bucket-store.sync-dir", "tsdb-sync", "Directory to store synchronized TSDB index headers.")
-	f.DurationVar(&cfg.SyncInterval, "blocks-storage.bucket-store.sync-interval", 5*time.Minute, "How frequently scan the bucket - or refresh the bucket index (if enabled) - to look for changes (new blocks shipped by ingesters and blocks deleted by retention or compaction).")
+	f.DurationVar(&cfg.SyncInterval, "blocks-storage.bucket-store.sync-interval", 5*time.Minute, "How frequently to scan the bucket, or to refresh the bucket index (if enabled), in order to look for changes (new blocks shipped by ingesters and blocks deleted by retention or compaction).")
 	f.Uint64Var(&cfg.MaxChunkPoolBytes, "blocks-storage.bucket-store.max-chunk-pool-bytes", uint64(2*units.Gibibyte), "Max size - in bytes - of a per-tenant chunk pool, used to reduce memory allocations.")
 	f.IntVar(&cfg.MaxConcurrent, "blocks-storage.bucket-store.max-concurrent", 100, "Max number of concurrent queries to execute against the long-term storage. The limit is shared across all tenants.")
 	f.IntVar(&cfg.TenantSyncConcurrency, "blocks-storage.bucket-store.tenant-sync-concurrency", 10, "Maximum number of concurrent tenants synching blocks.")

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -243,7 +243,7 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.BucketIndex.RegisterFlagsWithPrefix(f, "blocks-storage.bucket-store.bucket-index.")
 
 	f.StringVar(&cfg.SyncDir, "blocks-storage.bucket-store.sync-dir", "tsdb-sync", "Directory to store synchronized TSDB index headers.")
-	f.DurationVar(&cfg.SyncInterval, "blocks-storage.bucket-store.sync-interval", 5*time.Minute, "How frequently scan the bucket - or fetch the bucket index (if enabled) - to look for changes (new blocks shipped by ingesters and blocks removed by retention or compaction). 0 disables it.")
+	f.DurationVar(&cfg.SyncInterval, "blocks-storage.bucket-store.sync-interval", 5*time.Minute, "How frequently scan the bucket - or refresh the bucket index (if enabled) - to look for changes (new blocks shipped by ingesters and blocks deleted by retention or compaction).")
 	f.Uint64Var(&cfg.MaxChunkPoolBytes, "blocks-storage.bucket-store.max-chunk-pool-bytes", uint64(2*units.Gibibyte), "Max size - in bytes - of a per-tenant chunk pool, used to reduce memory allocations.")
 	f.IntVar(&cfg.MaxConcurrent, "blocks-storage.bucket-store.max-concurrent", 100, "Max number of concurrent queries to execute against the long-term storage. The limit is shared across all tenants.")
 	f.IntVar(&cfg.TenantSyncConcurrency, "blocks-storage.bucket-store.tenant-sync-concurrency", 10, "Maximum number of concurrent tenants synching blocks.")
@@ -277,7 +277,6 @@ func (cfg *BucketStoreConfig) Validate() error {
 
 type BucketIndexConfig struct {
 	Enabled               bool          `yaml:"enabled"`
-	UpdateOnStaleInterval time.Duration `yaml:"update_on_stale_interval"`
 	UpdateOnErrorInterval time.Duration `yaml:"update_on_error_interval"`
 	IdleTimeout           time.Duration `yaml:"idle_timeout"`
 	MaxStalePeriod        time.Duration `yaml:"max_stale_period"`
@@ -285,7 +284,6 @@ type BucketIndexConfig struct {
 
 func (cfg *BucketIndexConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.Enabled, prefix+"enabled", false, "True to enable querier and store-gateway to discover blocks in the storage via bucket index instead of bucket scanning.")
-	f.DurationVar(&cfg.UpdateOnStaleInterval, prefix+"update-on-stale-interval", 15*time.Minute, "How frequently a cached bucket index should be refreshed. This option is used only by querier.")
 	f.DurationVar(&cfg.UpdateOnErrorInterval, prefix+"update-on-error-interval", time.Minute, "How frequently a bucket index, which previously failed to load, should be tried to load again. This option is used only by querier.")
 	f.DurationVar(&cfg.IdleTimeout, prefix+"idle-timeout", time.Hour, "How long a unused bucket index should be cached. Once this timeout expires, the unused bucket index is removed from the in-memory cache. This option is used only by querier.")
 	f.DurationVar(&cfg.MaxStalePeriod, prefix+"max-stale-period", time.Hour, "The maximum allowed age of a bucket index (last updated) before queries start failing because the bucket index is too old. The bucket index is periodically updated by the compactor, while this check is enforced in the querier (at query time).")


### PR DESCRIPTION
**What this PR does**:
We currently have 2 options to configure how frequently the bucket should be synced:

- `-blocks-storage.bucket-store.bucket-index.update-on-stale-interval`: used only by the querier when bucket index is enabled
- `-blocks-storage.bucket-store.sync-interval`: used by store-gateway in any case, and also by querier when bucket index is disabled

I believe this would lead to misunderstandings, so in this PR I'm proposing to remove the `update-on-stale-interval` config at all and always use `sync-interval`. The bucket index is marked as experimental, so this is not a breaking change.

_No CHANGELOG entry because bucket index was introduced after cutting `1.6.0`._

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
