### PR TITLE
Put trace span from QueryStream under Select

### DIFF
--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -116,7 +116,7 @@ func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 	}
 
 	if q.streaming {
-		return q.streamingSelect(minT, maxT, matchers)
+		return q.streamingSelect(ctx, minT, maxT, matchers)
 	}
 
 	matrix, err := q.distributor.Query(ctx, model.Time(minT), model.Time(maxT), matchers...)
@@ -128,13 +128,13 @@ func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 	return series.MatrixToSeriesSet(matrix)
 }
 
-func (q *distributorQuerier) streamingSelect(minT, maxT int64, matchers []*labels.Matcher) storage.SeriesSet {
-	userID, err := tenant.TenantID(q.ctx)
+func (q *distributorQuerier) streamingSelect(ctx context.Context, minT, maxT int64, matchers []*labels.Matcher) storage.SeriesSet {
+	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}
 
-	results, err := q.distributor.QueryStream(q.ctx, model.Time(minT), model.Time(maxT), matchers...)
+	results, err := q.distributor.QueryStream(ctx, model.Time(minT), model.Time(maxT), matchers...)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}


### PR DESCRIPTION
Illustration of the problem lots of spans apparently at the same level:

![image](https://user-images.githubusercontent.com/8125524/103776005-c04a3480-5026-11eb-95bb-0d28dabad7e2.png)

This PR puts `Distributor.QueryStream` under `distributorQuerier.Select`.

`distributorQuerier.Select` should really go under `querier.Select`, but that's harder to fix because we are using a Prometheus interface that doesn't have a Context parameter.

**Checklist**
- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated
