### PR TITLE
Query-frontend: discard cache extents under 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [BUGFIX] Compactor: delete `deletion-mark.json` at last when deleting a block in order to not leave partial blocks without deletion mark in the bucket if the compactor is interrupted while deleting a block. #3660
 * [BUGFIX] Blocks storage: do not cleanup a partially uploaded block when `meta.json` upload fails. Despite failure to upload `meta.json`, this file may in some cases still appear in the bucket later. By skipping early cleanup, we avoid having corrupted blocks in the storage. #3660
 * [BUGFIX] Alertmanager: disable access to `/alertmanager/metrics` (which exposes all Cortex metrics), `/alertmanager/-/reload` and `/alertmanager/debug/*`, which were available to any authenticated user with enabled AlertManager. #3678
+* [BUGFIX] Query-Frontend: avoid creating many small sub-queries by discarding cache extents under 5 minutes #3653
 
 ## 1.6.0
 

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -412,6 +412,7 @@ func toExtent(ctx context.Context, req Request, res Response) (Extent, error) {
 }
 
 // partition calculates the required requests to satisfy req given the cached data.
+// extents must be in order by start time.
 func partition(req Request, extents []Extent, extractor Extractor, minCacheExtent int64) ([]Request, []Response, error) {
 	var requests []Request
 	var cachedResponses []Response
@@ -441,6 +442,7 @@ func partition(req Request, extents []Extent, extractor Extractor, minCacheExten
 		start = extent.End
 	}
 
+	// Lastly, make a request for any data missing at the end.
 	if start < req.GetEnd() {
 		r := req.WithStartEnd(start, req.GetEnd())
 		requests = append(requests, r)

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -296,7 +296,7 @@ func (s resultsCache) handleHit(ctx context.Context, r Request, extents []Extent
 	log, ctx := spanlogger.New(ctx, "handleHit")
 	defer log.Finish()
 
-	const minCacheExtent = 5 * 60 * 1000 // 5 minutes
+	minCacheExtent := (5 * time.Minute).Milliseconds()
 	requests, responses, err := partition(r, extents, s.extractor, minCacheExtent)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -363,7 +363,7 @@ func TestPartition(t *testing.T) {
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			reqs, resps, err := partition(tc.input, tc.prevCachedResponse, PrometheusResponseExtractor{})
+			reqs, resps, err := partition(tc.input, tc.prevCachedResponse, PrometheusResponseExtractor{}, 10)
 			require.Nil(t, err)
 			require.Equal(t, tc.expectedRequests, reqs)
 			require.Equal(t, tc.expectedCachedResponse, resps)

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -340,6 +340,27 @@ func TestPartition(t *testing.T) {
 				mkAPIResponse(160, 200, 10),
 			},
 		},
+
+		// Partial hits with tiny gap.
+		{
+			input: &PrometheusRequest{
+				Start: 100,
+				End:   160,
+			},
+			prevCachedResponse: []Extent{
+				mkExtent(50, 120),
+				mkExtent(122, 130),
+			},
+			expectedRequests: []Request{
+				&PrometheusRequest{
+					Start: 120,
+					End:   160,
+				},
+			},
+			expectedCachedResponse: []Response{
+				mkAPIResponse(100, 120, 10),
+			},
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			reqs, resps, err := partition(tc.input, tc.prevCachedResponse, PrometheusResponseExtractor{})

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -363,7 +363,11 @@ func TestPartition(t *testing.T) {
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			reqs, resps, err := partition(tc.input, tc.prevCachedResponse, PrometheusResponseExtractor{}, 10)
+			s := resultsCache{
+				extractor:      PrometheusResponseExtractor{},
+				minCacheExtent: 10,
+			}
+			reqs, resps, err := s.partition(tc.input, tc.prevCachedResponse)
 			require.Nil(t, err)
 			require.Equal(t, tc.expectedRequests, reqs)
 			require.Equal(t, tc.expectedCachedResponse, resps)

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -503,7 +503,7 @@ func TestResultsCacheMaxFreshness(t *testing.T) {
 
 			// fill cache
 			key := constSplitter(day).GenerateCacheKey("1", req)
-			rc.(*resultsCache).put(ctx, key, []Extent{mkExtent(int64(modelNow)-(60*1e3), int64(modelNow))})
+			rc.(*resultsCache).put(ctx, key, []Extent{mkExtent(int64(modelNow)-(600*1e3), int64(modelNow))})
 
 			resp, err := rc.Do(ctx, req)
 			require.NoError(t, err)


### PR DESCRIPTION
**What this PR does**:
Quick but effective workaround for the case where cache contains many small extents, leading to tiny subqueries which are expensive.

The minimum allowed is passed into `partition()` so that the unit test doesn't need extensive changes.

Also added a couple of comments.

**Which issue(s) this PR fixes**:
It's not really a fix, but it cures the symptom of #3648

**Checklist**
- [x] Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
