### PR TITLE
Make distributor rate-limit return 5xx

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -592,11 +592,18 @@ func (d *Distributor) Push(ctx context.Context, req *ingester_client.WriteReques
 		// Ensure the request slice is reused if the request is rate limited.
 		ingester_client.ReuseSlice(req.Timeseries)
 
-		// Return a 4xx here to have the client discard the data and not retry. If a client
-		// is sending too much data consistently we will unlikely ever catch up otherwise.
-		validation.DiscardedSamples.WithLabelValues(validation.RateLimited, userID).Add(float64(validatedSamples))
-		validation.DiscardedMetadata.WithLabelValues(validation.RateLimited, userID).Add(float64(len(validatedMetadata)))
-		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, "ingestion rate limit (%v) exceeded while adding %d samples and %d metadata", d.ingestionRateLimiter.Limit(now, userID), validatedSamples, len(validatedMetadata))
+		var code int
+		/*if hard {
+			// Return a 4xx here to have the client discard the data and not retry.
+			code = http.StatusTooManyRequests
+			validation.DiscardedSamples.WithLabelValues(validation.RateLimited, userID).Add(float64(validatedSamples))
+			validation.DiscardedMetadata.WithLabelValues(validation.RateLimited, userID).Add(float64(len(validatedMetadata)))
+		} else */{
+			// Return a 5xx here to have the client retry.
+			code = http.StatusInsufficientStorage
+			validation.RateLimitedSamples.WithLabelValues(userID).Add(float64(validatedSamples))
+		}
+		return nil, httpgrpc.Errorf(code, "ingestion rate limit (%v) exceeded while adding %d samples and %d metadata", d.ingestionRateLimiter.Limit(now, userID), validatedSamples, len(validatedMetadata))
 	}
 
 	subRing := d.ingestersRing

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -73,6 +73,15 @@ var DiscardedSamples = prometheus.NewCounterVec(
 	[]string{discardReasonLabel, "user"},
 )
 
+// RateLimitedSamples is a metric of the number of samples rejected for being over the rate-limit, by user.
+var RateLimitedSamples = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "cortex_ratelimited_samples_total",
+		Help: "The total number of samples that were rejected via 5xx error as over rate-limit.",
+	},
+	[]string{"user"},
+)
+
 // DiscardedMetadata is a metric of the number of discarded metadata, by reason.
 var DiscardedMetadata = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
@@ -84,6 +93,7 @@ var DiscardedMetadata = prometheus.NewCounterVec(
 
 func init() {
 	prometheus.MustRegister(DiscardedSamples)
+	prometheus.MustRegister(RateLimitedSamples)
 	prometheus.MustRegister(DiscardedMetadata)
 }
 


### PR DESCRIPTION
This means the client will retry so the data isn't dropped.

I added a new metric for requests rejected in this way, because `cortex_discarded_samples_total` doesn't describe this case - we don't expect it to be discarded forever.

Still to do:
 * put a limit on how much this can happen, so clients don't build up data indefinitely. I left the 'hard' case in the code to allow for this enhancement.
 *  update tests to expect the different behaviour

**Which issue(s) this PR fixes**:
Fixes #2037

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
