### PR TITLE
poll for metric update to avoid race causing a flaky test

### DIFF
--- a/pkg/chunk/purger/purger_test.go
+++ b/pkg/chunk/purger/purger_test.go
@@ -435,9 +435,15 @@ func TestPurger_Metrics(t *testing.T) {
 		return testutil.ToFloat64(purger.metrics.deleteRequestsProcessedTotal)
 	})
 
-	// there must be 0 pending delete requests so the age for oldest pending must be 0
-	require.InDelta(t, float64(0), testutil.ToFloat64(purger.metrics.oldestPendingDeleteRequestAgeSeconds), 1)
-	require.Equal(t, float64(0), testutil.ToFloat64(purger.metrics.pendingDeleteRequestsCount))
+	// wait until oldest pending request age becomes 0
+	test.Poll(t, 2*time.Second, float64(0), func() interface{} {
+		return testutil.ToFloat64(purger.metrics.oldestPendingDeleteRequestAgeSeconds)
+	})
+
+	// wait until pending delete requests count becomes 0
+	test.Poll(t, 2*time.Second, float64(0), func() interface{} {
+		return testutil.ToFloat64(purger.metrics.pendingDeleteRequestsCount)
+	})
 }
 
 func TestPurger_retryFailedRequests(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds polling for a metric update which otherwise causes a race resulting in falky test.

**Which issue(s) this PR fixes**:
Fixes #2776 

**Checklist**
- [x] Tests updated