### PR TITLE
Don't initialize ingester userStates in blocks ingester.

### DIFF
--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -434,8 +434,6 @@ func NewV2(cfg Config, clientConfig client.Config, limits *validation.Overrides,
 		cfg.LifecyclerConfig.RingConfig.ReplicationFactor,
 		cfg.LifecyclerConfig.RingConfig.ZoneAwarenessEnabled)
 
-	i.userStates = newUserStates(i.limiter, cfg, i.metrics)
-
 	i.TSDBState.shipperIngesterID = i.lifecycler.ID
 
 	i.BasicService = services.NewBasicService(i.startingV2, i.updateLoop, i.stoppingV2)


### PR DESCRIPTION
**What this PR does**: This tiny change removes initialization of `userStates` in blocks-based ingster. From what I can see, this isn't used on code paths in blocks ingester.

**Checklist**
- [NA] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
