### PR TITLE
Fix typo in the runtime configuration example

### DIFF
--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -416,7 +416,7 @@ overrides:
     max_series_per_query: 100000
 
 multi_kv_config:
-    mirror-enabled: false
+    mirror_enabled: false
     primary: memberlist
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

The mirror enabled option uses `mirror_enabled` as key as you can see [here](https://github.com/cortexproject/cortex/blob/6165acfd5dcfc99aca631fce2601b2e6e663c12f/pkg/ring/kv/multi.go#L72)

**Which issue(s) this PR fixes**:
No issue attached 

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
