### PR TITLE
Move ring operations to packages where they are used.

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	errInvalidBlockRanges                = "compactor block range periods should be divisible by the previous one, but %s is not divisible by %s"
-	ringCompactorOp       ring.Operation = ring.NewOp(ring.ACTIVE)
+	RingOp                ring.Operation = ring.NewOp([]ring.IngesterState{ring.ACTIVE}, nil)
 )
 
 // Config holds the Compactor config.
@@ -329,7 +329,7 @@ func (c *Compactor) starting(ctx context.Context) error {
 			maxWaiting := c.compactorCfg.ShardingRing.WaitStabilityMaxDuration
 
 			level.Info(c.logger).Log("msg", "waiting until compactor ring topology is stable", "min_waiting", minWaiting.String(), "max_waiting", maxWaiting.String())
-			if err := ring.WaitRingStability(ctx, c.ring, ringCompactorOp, minWaiting, maxWaiting); err != nil {
+			if err := ring.WaitRingStability(ctx, c.ring, RingOp, minWaiting, maxWaiting); err != nil {
 				level.Warn(c.logger).Log("msg", "compactor is ring topology is not stable after the max waiting time, proceeding anyway")
 			} else {
 				level.Info(c.logger).Log("msg", "compactor is ring topology is stable")
@@ -625,7 +625,7 @@ func (c *Compactor) ownUser(userID string) (bool, error) {
 	userHash := hasher.Sum32()
 
 	// Check whether this compactor instance owns the user.
-	rs, err := c.ring.Get(userHash, ringCompactorOp, nil, nil, nil)
+	rs, err := c.ring.Get(userHash, RingOp, nil, nil, nil)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -31,7 +31,8 @@ import (
 )
 
 var (
-	errInvalidBlockRanges = "compactor block range periods should be divisible by the previous one, but %s is not divisible by %s"
+	errInvalidBlockRanges                = "compactor block range periods should be divisible by the previous one, but %s is not divisible by %s"
+	ringCompactorOp       ring.Operation = ring.NewOp(ring.ACTIVE)
 )
 
 // Config holds the Compactor config.
@@ -328,7 +329,7 @@ func (c *Compactor) starting(ctx context.Context) error {
 			maxWaiting := c.compactorCfg.ShardingRing.WaitStabilityMaxDuration
 
 			level.Info(c.logger).Log("msg", "waiting until compactor ring topology is stable", "min_waiting", minWaiting.String(), "max_waiting", maxWaiting.String())
-			if err := ring.WaitRingStability(ctx, c.ring, ring.Compactor, minWaiting, maxWaiting); err != nil {
+			if err := ring.WaitRingStability(ctx, c.ring, ringCompactorOp, minWaiting, maxWaiting); err != nil {
 				level.Warn(c.logger).Log("msg", "compactor is ring topology is not stable after the max waiting time, proceeding anyway")
 			} else {
 				level.Info(c.logger).Log("msg", "compactor is ring topology is stable")
@@ -624,7 +625,7 @@ func (c *Compactor) ownUser(userID string) (bool, error) {
 	userHash := hasher.Sum32()
 
 	// Check whether this compactor instance owns the user.
-	rs, err := c.ring.Get(userHash, ring.Compactor, nil, nil, nil)
+	rs, err := c.ring.Get(userHash, ringCompactorOp, nil, nil, nil)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -31,8 +31,8 @@ import (
 )
 
 var (
-	errInvalidBlockRanges                = "compactor block range periods should be divisible by the previous one, but %s is not divisible by %s"
-	RingOp                ring.Operation = ring.NewOp([]ring.IngesterState{ring.ACTIVE}, nil)
+	errInvalidBlockRanges = "compactor block range periods should be divisible by the previous one, but %s is not divisible by %s"
+	RingOp                = ring.NewOp([]ring.IngesterState{ring.ACTIVE}, nil)
 )
 
 // Config holds the Compactor config.

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -186,6 +186,7 @@ func (t *Cortex) initOverrides() (serv services.Service, err error) {
 func (t *Cortex) initDistributorService() (serv services.Service, err error) {
 	t.Cfg.Distributor.DistributorRing.ListenPort = t.Cfg.Server.GRPCListenPort
 	t.Cfg.Distributor.ShuffleShardingLookbackPeriod = t.Cfg.Querier.ShuffleShardingIngestersLookbackPeriod
+	t.Cfg.Distributor.ExtendWrites = t.Cfg.Ingester.LifecyclerConfig.RingConfig.ExtendWrites
 
 	// Check whether the distributor can join the distributors ring, which is
 	// whenever it's not running as an internal dependency (ie. querier or

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -102,7 +102,7 @@ func (s *blocksStoreReplicationSet) GetClientsFor(userID string, blockIDs []ulid
 		// returned replication set.
 		bufDescs, bufHosts, bufZones := ring.MakeBuffersForGet()
 
-		set, err := userRing.Get(cortex_tsdb.HashBlockID(blockID), ring.BlocksRead, bufDescs, bufHosts, bufZones)
+		set, err := userRing.Get(cortex_tsdb.HashBlockID(blockID), storegateway.BlocksRead, bufDescs, bufHosts, bufZones)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get store-gateway replication set owning the block %s", blockID.String())
 		}

--- a/pkg/ring/batch.go
+++ b/pkg/ring/batch.go
@@ -38,7 +38,7 @@ type itemTracker struct {
 // to send to that ingester.
 //
 // Not implemented as a method on Ring so we can test separately.
-func DoBatch(ctx context.Context, r ReadRing, keys []uint32, callback func(IngesterDesc, []int) error, cleanup func()) error {
+func DoBatch(ctx context.Context, op Operation, r ReadRing, keys []uint32, callback func(IngesterDesc, []int) error, cleanup func()) error {
 	if r.IngesterCount() <= 0 {
 		return fmt.Errorf("DoBatch: IngesterCount <= 0")
 	}
@@ -52,7 +52,7 @@ func DoBatch(ctx context.Context, r ReadRing, keys []uint32, callback func(Inges
 		bufZones [GetBufferSize]string
 	)
 	for i, key := range keys {
-		replicationSet, err := r.Get(key, Write, bufDescs[:0], bufHosts[:0], bufZones[:0])
+		replicationSet, err := r.Get(key, op, bufDescs[:0], bufHosts[:0], bufZones[:0])
 		if err != nil {
 			return err
 		}

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -133,32 +133,8 @@ func (i *IngesterDesc) GetRegisteredAt() time.Time {
 	return time.Unix(i.RegisteredTimestamp, 0)
 }
 
-// IsHealthy checks whether the ingester appears to be alive and heartbeating
 func (i *IngesterDesc) IsHealthy(op Operation, heartbeatTimeout time.Duration, now time.Time) bool {
-	healthy := false
-
-	switch op {
-	case Write:
-		healthy = i.State == ACTIVE
-
-	case Read:
-		healthy = (i.State == ACTIVE) || (i.State == LEAVING) || (i.State == PENDING)
-
-	case Reporting:
-		healthy = true
-
-	case BlocksSync:
-		healthy = (i.State == JOINING) || (i.State == ACTIVE) || (i.State == LEAVING)
-
-	case BlocksRead:
-		healthy = i.State == ACTIVE
-
-	case Ruler:
-		healthy = i.State == ACTIVE
-
-	case Compactor:
-		healthy = i.State == ACTIVE
-	}
+	healthy := op.IncludeInstanceInState(i.State)
 
 	return healthy && now.Unix()-i.Timestamp <= heartbeatTimeout.Milliseconds()/1000
 }

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -134,7 +134,7 @@ func (i *IngesterDesc) GetRegisteredAt() time.Time {
 }
 
 func (i *IngesterDesc) IsHealthy(op Operation, heartbeatTimeout time.Duration, now time.Time) bool {
-	healthy := op.IncludeInstanceInState(i.State)
+	healthy := op.IsInstanceInStateHealthy(i.State)
 
 	return healthy && now.Unix()-i.Timestamp <= heartbeatTimeout.Milliseconds()/1000
 }

--- a/pkg/ring/model_test.go
+++ b/pkg/ring/model_test.go
@@ -63,60 +63,6 @@ func TestIngesterDesc_IsHealthy_ForIngesterOperations(t *testing.T) {
 	}
 }
 
-func TestIngesterDesc_IsHealthy_ForStoreGatewayOperations(t *testing.T) {
-	t.Parallel()
-
-	tests := map[string]struct {
-		instance      *IngesterDesc
-		timeout       time.Duration
-		syncExpected  bool
-		queryExpected bool
-	}{
-		"ACTIVE instance with last keepalive newer than timeout": {
-			instance:      &IngesterDesc{State: ACTIVE, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
-			timeout:       time.Minute,
-			syncExpected:  true,
-			queryExpected: true,
-		},
-		"ACTIVE instance with last keepalive older than timeout": {
-			instance:      &IngesterDesc{State: ACTIVE, Timestamp: time.Now().Add(-90 * time.Second).Unix()},
-			timeout:       time.Minute,
-			syncExpected:  false,
-			queryExpected: false,
-		},
-		"JOINING instance with last keepalive newer than timeout": {
-			instance:      &IngesterDesc{State: JOINING, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
-			timeout:       time.Minute,
-			syncExpected:  true,
-			queryExpected: false,
-		},
-		"LEAVING instance with last keepalive newer than timeout": {
-			instance:      &IngesterDesc{State: LEAVING, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
-			timeout:       time.Minute,
-			syncExpected:  true,
-			queryExpected: false,
-		},
-		"PENDING instance with last keepalive newer than timeout": {
-			instance:      &IngesterDesc{State: PENDING, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
-			timeout:       time.Minute,
-			syncExpected:  false,
-			queryExpected: false,
-		},
-	}
-
-	for testName, testData := range tests {
-		testData := testData
-
-		t.Run(testName, func(t *testing.T) {
-			actual := testData.instance.IsHealthy(BlocksSync, testData.timeout, time.Now())
-			assert.Equal(t, testData.syncExpected, actual)
-
-			actual = testData.instance.IsHealthy(BlocksRead, testData.timeout, time.Now())
-			assert.Equal(t, testData.queryExpected, actual)
-		})
-	}
-}
-
 func TestIngesterDesc_GetRegisteredAt(t *testing.T) {
 	tests := map[string]struct {
 		desc     *IngesterDesc

--- a/pkg/ring/replication_strategy_test.go
+++ b/pkg/ring/replication_strategy_test.go
@@ -11,7 +11,6 @@ import (
 func TestRingReplicationStrategy(t *testing.T) {
 	for i, tc := range []struct {
 		RF, LiveIngesters, DeadIngesters int
-		op                               Operation // Will default to READ
 		ExpectedMaxFailure               int
 		ExpectedError                    string
 	}{
@@ -90,8 +89,8 @@ func TestRingReplicationStrategy(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
-			strategy := NewDefaultReplicationStrategy(true)
-			liveIngesters, maxFailure, err := strategy.Filter(ingesters, tc.op, tc.RF, 100*time.Second, false)
+			strategy := NewDefaultReplicationStrategy()
+			liveIngesters, maxFailure, err := strategy.Filter(ingesters, Read, tc.RF, 100*time.Second, false)
 			if tc.ExpectedError == "" {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.LiveIngesters, len(liveIngesters))

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -77,33 +77,33 @@ type ReadRing interface {
 
 // Operation describes which instances can be included in the replica set, based on their state.
 type Operation interface {
-	// ShouldExtendReplicaSet returns true if given a state of instance that's going to be
+	// ShouldExtendReplicaSetOnState returns true if given a state of instance that's going to be
 	// added to the replica set, the replica set size should be extended by 1
 	// more instance for the given operation.
 	ShouldExtendReplicaSetOnState(s IngesterState) bool
 
-	// Used during "filtering" phase to remove undesired instances based on their state.
-	IncludeInstanceInState(s IngesterState) bool
+	// IsInstanceInStateHealthy is used during "filtering" phase to remove undesired instances based on their state.
+	IsInstanceInStateHealthy(s IngesterState) bool
 }
 
 var (
 	// Write operation that also extends replica set, if ingester state is not ACTIVE.
-	Write Operation = NewOpWithReplicaSetExtension(func(s IngesterState) bool {
+	Write Operation = NewOp([]IngesterState{ACTIVE}, func(s IngesterState) bool {
 		// We do not want to Write to Ingesters that are not ACTIVE, but we do want
 		// to write the extra replica somewhere.  So we increase the size of the set
-		// of replicas for the key. This means we have to also increase the
-		// size of the replica set for read, but we can read from Leaving ingesters,
-		// so don't skip it in this case.
+		// of replicas for the key.
 		// NB dead ingester will be filtered later by defaultReplicationStrategy.Filter().
 		return s != ACTIVE
-	}, ACTIVE)
+	})
 
 	// WriteNoExtend is like Write, but with no replicaset extension.
-	WriteNoExtend Operation = NewOp(ACTIVE)
+	WriteNoExtend Operation = NewOp([]IngesterState{ACTIVE}, nil)
 
-	Read Operation = NewOpWithReplicaSetExtension(func(s IngesterState) bool {
+	Read Operation = NewOp([]IngesterState{ACTIVE, PENDING, LEAVING}, func(s IngesterState) bool {
+		// To match Write with extended replica set we have to also increase the
+		// size of the replica set for Read, but we can read from LEAVING ingesters.
 		return s != ACTIVE && s != LEAVING
-	}, ACTIVE, LEAVING, PENDING)
+	})
 
 	// Reporting is a special value for inquiring about health.
 	Reporting Operation = allStatesRingOperation{}
@@ -818,26 +818,24 @@ func (r *Ring) setCachedShuffledSubring(identifier string, size int, subring *Ri
 
 // Default implementation for Operation interface.
 type Op struct {
-	includedStates map[IngesterState]bool
-	extend         func(s IngesterState) bool
+	// Bitmap of instance states that should be considered for this operation.
+	states uint32
+
+	// Function that extends replica set based on instance state.
+	extend func(s IngesterState) bool
 }
 
-func NewOp(states ...IngesterState) Op {
-	is := make(map[IngesterState]bool, len(states))
+// NewOp constructs new Operation with given "healthy" states for operation, and optional function to extend replica set.
+func NewOp(states []IngesterState, shouldExtendReplicaSet func(s IngesterState) bool) Op {
+	st := uint32(0)
 	for _, s := range states {
-		is[s] = true
+		st |= (1 << s)
 	}
-	return Op{includedStates: is, extend: nil}
+	return Op{states: st, extend: shouldExtendReplicaSet}
 }
 
-func NewOpWithReplicaSetExtension(shouldExtendReplicaSet func(s IngesterState) bool, states ...IngesterState) Op {
-	op := NewOp(states...)
-	op.extend = shouldExtendReplicaSet
-	return op
-}
-
-func (op Op) IncludeInstanceInState(s IngesterState) bool {
-	return op.includedStates[s]
+func (op Op) IsInstanceInStateHealthy(s IngesterState) bool {
+	return op.states&(1<<s) > 0
 }
 
 func (op Op) ShouldExtendReplicaSetOnState(s IngesterState) bool {
@@ -849,5 +847,5 @@ func (op Op) ShouldExtendReplicaSetOnState(s IngesterState) bool {
 
 type allStatesRingOperation struct{}
 
-func (op allStatesRingOperation) IncludeInstanceInState(_ IngesterState) bool        { return true }
+func (op allStatesRingOperation) IsInstanceInStateHealthy(_ IngesterState) bool      { return true }
 func (op allStatesRingOperation) ShouldExtendReplicaSetOnState(_ IngesterState) bool { return false }

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -87,10 +87,7 @@ type Operation interface {
 }
 
 var (
-	// Write, with no replicaset extension.
-	WriteNoExtend Operation = NewOp(ACTIVE)
-
-	// Write, which extends replica set, if ingester state is not ACTIVE.
+	// Write operation that also extends replica set, if ingester state is not ACTIVE.
 	Write Operation = NewOpWithReplicaSetExtension(func(s IngesterState) bool {
 		// We do not want to Write to Ingesters that are not ACTIVE, but we do want
 		// to write the extra replica somewhere.  So we increase the size of the set
@@ -101,11 +98,14 @@ var (
 		return s != ACTIVE
 	}, ACTIVE)
 
+	// WriteNoExtend is like Write, but with no replicaset extension.
+	WriteNoExtend Operation = NewOp(ACTIVE)
+
 	Read Operation = NewOpWithReplicaSetExtension(func(s IngesterState) bool {
 		return s != ACTIVE && s != LEAVING
 	}, ACTIVE, LEAVING, PENDING)
 
-	// Special value for inquiring about health
+	// Reporting is a special value for inquiring about health.
 	Reporting Operation = allStatesRingOperation{}
 )
 

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -53,7 +53,7 @@ func benchmarkBatch(b *testing.B, numIngester, numKeys int) {
 	r := Ring{
 		cfg:      cfg,
 		ringDesc: desc,
-		strategy: NewDefaultReplicationStrategy(true),
+		strategy: NewDefaultReplicationStrategy(),
 	}
 
 	ctx := context.Background()
@@ -68,7 +68,7 @@ func benchmarkBatch(b *testing.B, numIngester, numKeys int) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		generateKeys(rnd, numKeys, keys)
-		err := DoBatch(ctx, &r, keys, callback, cleanup)
+		err := DoBatch(ctx, Write, &r, keys, callback, cleanup)
 		require.NoError(b, err)
 	}
 }
@@ -94,9 +94,9 @@ func TestDoBatchZeroIngesters(t *testing.T) {
 	r := Ring{
 		cfg:      Config{},
 		ringDesc: desc,
-		strategy: NewDefaultReplicationStrategy(true),
+		strategy: NewDefaultReplicationStrategy(),
 	}
-	require.Error(t, DoBatch(ctx, &r, keys, callback, cleanup))
+	require.Error(t, DoBatch(ctx, Write, &r, keys, callback, cleanup))
 }
 
 func TestAddIngester(t *testing.T) {
@@ -200,7 +200,7 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 				ringTokensByZone:    r.getTokensByZone(),
 				ringInstanceByToken: r.getTokensInfo(),
 				ringZones:           getZones(r.getTokensByZone()),
-				strategy:            NewDefaultReplicationStrategy(true),
+				strategy:            NewDefaultReplicationStrategy(),
 			}
 
 			ingesters := make([]IngesterDesc, 0, len(r.GetIngesters()))
@@ -294,7 +294,7 @@ func TestRing_GetAllHealthy(t *testing.T) {
 				ringTokensByZone:    ringDesc.getTokensByZone(),
 				ringInstanceByToken: ringDesc.getTokensInfo(),
 				ringZones:           getZones(ringDesc.getTokensByZone()),
-				strategy:            NewDefaultReplicationStrategy(true),
+				strategy:            NewDefaultReplicationStrategy(),
 			}
 
 			set, err := ring.GetAllHealthy(Read)
@@ -405,7 +405,7 @@ func TestRing_GetReplicationSetForOperation(t *testing.T) {
 				ringTokensByZone:    ringDesc.getTokensByZone(),
 				ringInstanceByToken: ringDesc.getTokensInfo(),
 				ringZones:           getZones(ringDesc.getTokensByZone()),
-				strategy:            NewDefaultReplicationStrategy(true),
+				strategy:            NewDefaultReplicationStrategy(),
 			}
 
 			set, err := ring.GetReplicationSetForOperation(Read)
@@ -723,7 +723,7 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 				ringTokensByZone:    ringDesc.getTokensByZone(),
 				ringInstanceByToken: ringDesc.getTokensInfo(),
 				ringZones:           getZones(ringDesc.getTokensByZone()),
-				strategy:            NewDefaultReplicationStrategy(true),
+				strategy:            NewDefaultReplicationStrategy(),
 			}
 
 			// Check the replication set has the correct settings
@@ -859,7 +859,7 @@ func TestRing_ShuffleShard(t *testing.T) {
 				ringTokensByZone:    ringDesc.getTokensByZone(),
 				ringInstanceByToken: ringDesc.getTokensInfo(),
 				ringZones:           getZones(ringDesc.getTokensByZone()),
-				strategy:            NewDefaultReplicationStrategy(true),
+				strategy:            NewDefaultReplicationStrategy(),
 			}
 
 			shardRing := ring.ShuffleShard("tenant-id", testData.shardSize)
@@ -911,7 +911,7 @@ func TestRing_ShuffleShard_Stability(t *testing.T) {
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
-		strategy:            NewDefaultReplicationStrategy(true),
+		strategy:            NewDefaultReplicationStrategy(),
 	}
 
 	for i := 1; i <= numTenants; i++ {
@@ -979,7 +979,7 @@ func TestRing_ShuffleShard_Shuffling(t *testing.T) {
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
-		strategy:            NewDefaultReplicationStrategy(true),
+		strategy:            NewDefaultReplicationStrategy(),
 	}
 
 	// Compute the shard for each tenant.
@@ -1078,7 +1078,7 @@ func TestRing_ShuffleShard_Consistency(t *testing.T) {
 				ringTokensByZone:    ringDesc.getTokensByZone(),
 				ringInstanceByToken: ringDesc.getTokensInfo(),
 				ringZones:           getZones(ringDesc.getTokensByZone()),
-				strategy:            NewDefaultReplicationStrategy(true),
+				strategy:            NewDefaultReplicationStrategy(),
 			}
 
 			// Compute the initial shard for each tenant.
@@ -1142,7 +1142,7 @@ func TestRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
-		strategy:            NewDefaultReplicationStrategy(true),
+		strategy:            NewDefaultReplicationStrategy(),
 	}
 
 	// Get the replication set with shard size = 3.
@@ -1219,7 +1219,7 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
-		strategy:            NewDefaultReplicationStrategy(true),
+		strategy:            NewDefaultReplicationStrategy(),
 	}
 
 	// Get the replication set with shard size = 2.
@@ -1478,7 +1478,7 @@ func TestRing_ShuffleShardWithLookback(t *testing.T) {
 				ringTokensByZone:    ringDesc.getTokensByZone(),
 				ringInstanceByToken: ringDesc.getTokensInfo(),
 				ringZones:           getZones(ringDesc.getTokensByZone()),
-				strategy:            NewDefaultReplicationStrategy(true),
+				strategy:            NewDefaultReplicationStrategy(),
 			}
 
 			// Replay the events on the timeline.
@@ -1543,7 +1543,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 					ringTokensByZone:    ringDesc.getTokensByZone(),
 					ringInstanceByToken: ringDesc.getTokensInfo(),
 					ringZones:           getZones(ringDesc.getTokensByZone()),
-					strategy:            NewDefaultReplicationStrategy(true),
+					strategy:            NewDefaultReplicationStrategy(),
 				}
 
 				// The simulation starts with the minimum shard size. Random events can later increase it.
@@ -1696,7 +1696,7 @@ func benchmarkShuffleSharding(b *testing.B, numInstances, numZones, numTokens, s
 		ringInstanceByToken:  ringDesc.getTokensInfo(),
 		ringZones:            getZones(ringDesc.getTokensByZone()),
 		shuffledSubringCache: map[subringCacheKey]*Ring{},
-		strategy:             NewDefaultReplicationStrategy(true),
+		strategy:             NewDefaultReplicationStrategy(),
 		lastTopologyChange:   time.Now(),
 	}
 
@@ -1724,7 +1724,7 @@ func BenchmarkRing_Get(b *testing.B) {
 		ringInstanceByToken:  ringDesc.getTokensInfo(),
 		ringZones:            getZones(ringDesc.getTokensByZone()),
 		shuffledSubringCache: map[subringCacheKey]*Ring{},
-		strategy:             NewDefaultReplicationStrategy(true),
+		strategy:             NewDefaultReplicationStrategy(),
 		lastTopologyChange:   time.Now(),
 	}
 
@@ -1752,7 +1752,7 @@ func TestRing_Get_NoMemoryAllocations(t *testing.T) {
 		ringInstanceByToken:  ringDesc.getTokensInfo(),
 		ringZones:            getZones(ringDesc.getTokensByZone()),
 		shuffledSubringCache: map[subringCacheKey]*Ring{},
-		strategy:             NewDefaultReplicationStrategy(true),
+		strategy:             NewDefaultReplicationStrategy(),
 		lastTopologyChange:   time.Now(),
 	}
 

--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -65,7 +65,7 @@ func TestWaitRingStabilityShouldReturnAsSoonAsMinStabilityIsReachedOnNoChanges(t
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
-		strategy:            NewDefaultReplicationStrategy(true),
+		strategy:            NewDefaultReplicationStrategy(),
 	}
 
 	startTime := time.Now()
@@ -100,7 +100,7 @@ func TestWaitRingStabilityShouldReturnOnceMinStabilityHasBeenReached(t *testing.
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
-		strategy:            NewDefaultReplicationStrategy(true),
+		strategy:            NewDefaultReplicationStrategy(),
 	}
 
 	// Add 1 new instance after some time.
@@ -151,7 +151,7 @@ func TestWaitRingStabilityShouldReturnErrorIfMaxWaitingIsReached(t *testing.T) {
 		ringTokensByZone:    ringDesc.getTokensByZone(),
 		ringInstanceByToken: ringDesc.getTokensInfo(),
 		ringZones:           getZones(ringDesc.getTokensByZone()),
-		strategy:            NewDefaultReplicationStrategy(true),
+		strategy:            NewDefaultReplicationStrategy(),
 	}
 
 	// Keep changing the ring.

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -368,7 +368,7 @@ func tokenForGroup(g *store.RuleGroupDesc) uint32 {
 func instanceOwnsRuleGroup(r ring.ReadRing, g *rules.RuleGroupDesc, instanceAddr string) (bool, error) {
 	hash := tokenForGroup(g)
 
-	rlrs, err := r.Get(hash, ring.Ruler, nil, nil, nil)
+	rlrs, err := r.Get(hash, ringOp, nil, nil, nil)
 	if err != nil {
 		return false, errors.Wrap(err, "error reading ring to verify rule group ownership")
 	}
@@ -410,7 +410,7 @@ func (r *Ruler) run(ctx context.Context) error {
 	var ringLastState ring.ReplicationSet
 
 	if r.cfg.EnableSharding {
-		ringLastState, _ = r.ring.GetAllHealthy(ring.Ruler)
+		ringLastState, _ = r.ring.GetAllHealthy(ringOp)
 		ringTicker := time.NewTicker(util.DurationWithJitter(r.cfg.RingCheckPeriod, 0.2))
 		defer ringTicker.Stop()
 		ringTickerChan = ringTicker.C
@@ -426,7 +426,7 @@ func (r *Ruler) run(ctx context.Context) error {
 		case <-ringTickerChan:
 			// We ignore the error because in case of error it will return an empty
 			// replication set which we use to compare with the previous state.
-			currRingState, _ := r.ring.GetAllHealthy(ring.Ruler)
+			currRingState, _ := r.ring.GetAllHealthy(ringOp)
 
 			if ring.HasReplicationSetChanged(ringLastState, currRingState) {
 				ringLastState = currRingState
@@ -688,7 +688,7 @@ func (r *Ruler) getLocalRules(userID string) ([]*GroupStateDesc, error) {
 }
 
 func (r *Ruler) getShardedRules(ctx context.Context) ([]*GroupStateDesc, error) {
-	rulers, err := r.ring.GetReplicationSetForOperation(ring.Ruler)
+	rulers, err := r.ring.GetReplicationSetForOperation(ringOp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -368,7 +368,7 @@ func tokenForGroup(g *store.RuleGroupDesc) uint32 {
 func instanceOwnsRuleGroup(r ring.ReadRing, g *rules.RuleGroupDesc, instanceAddr string) (bool, error) {
 	hash := tokenForGroup(g)
 
-	rlrs, err := r.Get(hash, ringOp, nil, nil, nil)
+	rlrs, err := r.Get(hash, RingOp, nil, nil, nil)
 	if err != nil {
 		return false, errors.Wrap(err, "error reading ring to verify rule group ownership")
 	}
@@ -410,7 +410,7 @@ func (r *Ruler) run(ctx context.Context) error {
 	var ringLastState ring.ReplicationSet
 
 	if r.cfg.EnableSharding {
-		ringLastState, _ = r.ring.GetAllHealthy(ringOp)
+		ringLastState, _ = r.ring.GetAllHealthy(RingOp)
 		ringTicker := time.NewTicker(util.DurationWithJitter(r.cfg.RingCheckPeriod, 0.2))
 		defer ringTicker.Stop()
 		ringTickerChan = ringTicker.C
@@ -426,7 +426,7 @@ func (r *Ruler) run(ctx context.Context) error {
 		case <-ringTickerChan:
 			// We ignore the error because in case of error it will return an empty
 			// replication set which we use to compare with the previous state.
-			currRingState, _ := r.ring.GetAllHealthy(ringOp)
+			currRingState, _ := r.ring.GetAllHealthy(RingOp)
 
 			if ring.HasReplicationSetChanged(ringLastState, currRingState) {
 				ringLastState = currRingState
@@ -688,7 +688,7 @@ func (r *Ruler) getLocalRules(userID string) ([]*GroupStateDesc, error) {
 }
 
 func (r *Ruler) getShardedRules(ctx context.Context) ([]*GroupStateDesc, error) {
-	rulers, err := r.ring.GetReplicationSetForOperation(ringOp)
+	rulers, err := r.ring.GetReplicationSetForOperation(RingOp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ruler/ruler_replication_strategy.go
+++ b/pkg/ruler/ruler_replication_strategy.go
@@ -8,6 +8,12 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring"
 )
 
+// ringOp is the operation used for distributing rule groups between rulers.
+var ringOp ring.Operation = ring.NewOpWithReplicaSetExtension(func(s ring.IngesterState) bool {
+	// Only ACTIVE rulers get any rule groups. If instance is not ACTIVE, we need to find another ruler.
+	return s != ring.ACTIVE
+}, ring.ACTIVE)
+
 type rulerReplicationStrategy struct {
 }
 
@@ -28,12 +34,4 @@ func (r rulerReplicationStrategy) Filter(instances []ring.IngesterDesc, op ring.
 	}
 
 	return instances, len(instances) - 1, nil
-}
-
-func (r rulerReplicationStrategy) ShouldExtendReplicaSet(instance ring.IngesterDesc, op ring.Operation) bool {
-	// Only ACTIVE rulers get any rule groups. If instance is not ACTIVE, we need to find another ruler.
-	if op == ring.Ruler && instance.GetState() != ring.ACTIVE {
-		return true
-	}
-	return false
 }

--- a/pkg/ruler/ruler_replication_strategy.go
+++ b/pkg/ruler/ruler_replication_strategy.go
@@ -8,14 +8,13 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring"
 )
 
-// ringOp is the operation used for distributing rule groups between rulers.
-var ringOp ring.Operation = ring.NewOpWithReplicaSetExtension(func(s ring.IngesterState) bool {
+// RingOp is the operation used for distributing rule groups between rulers.
+var RingOp ring.Operation = ring.NewOp([]ring.IngesterState{ring.ACTIVE}, func(s ring.IngesterState) bool {
 	// Only ACTIVE rulers get any rule groups. If instance is not ACTIVE, we need to find another ruler.
 	return s != ring.ACTIVE
-}, ring.ACTIVE)
+})
 
-type rulerReplicationStrategy struct {
-}
+type rulerReplicationStrategy struct{}
 
 func (r rulerReplicationStrategy) Filter(instances []ring.IngesterDesc, op ring.Operation, _ int, heartbeatTimeout time.Duration, _ bool) (healthy []ring.IngesterDesc, maxFailures int, err error) {
 	now := time.Now()

--- a/pkg/ruler/ruler_replication_strategy.go
+++ b/pkg/ruler/ruler_replication_strategy.go
@@ -9,7 +9,7 @@ import (
 )
 
 // RingOp is the operation used for distributing rule groups between rulers.
-var RingOp ring.Operation = ring.NewOp([]ring.IngesterState{ring.ACTIVE}, func(s ring.IngesterState) bool {
+var RingOp = ring.NewOp([]ring.IngesterState{ring.ACTIVE}, func(s ring.IngesterState) bool {
 	// Only ACTIVE rulers get any rule groups. If instance is not ACTIVE, we need to find another ruler.
 	return s != ring.ACTIVE
 })

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -271,7 +271,7 @@ func (g *StoreGateway) running(ctx context.Context) error {
 	defer syncTicker.Stop()
 
 	if g.gatewayCfg.ShardingEnabled {
-		ringLastState, _ = g.ring.GetAllHealthy(ring.BlocksSync) // nolint:errcheck
+		ringLastState, _ = g.ring.GetAllHealthy(BlocksSync) // nolint:errcheck
 		ringTicker := time.NewTicker(util.DurationWithJitter(g.gatewayCfg.ShardingRing.RingCheckPeriod, 0.2))
 		defer ringTicker.Stop()
 		ringTickerChan = ringTicker.C
@@ -284,7 +284,7 @@ func (g *StoreGateway) running(ctx context.Context) error {
 		case <-ringTickerChan:
 			// We ignore the error because in case of error it will return an empty
 			// replication set which we use to compare with the previous state.
-			currRingState, _ := g.ring.GetAllHealthy(ring.BlocksSync) // nolint:errcheck
+			currRingState, _ := g.ring.GetAllHealthy(BlocksSync) // nolint:errcheck
 
 			if ring.HasReplicationSetChanged(ringLastState, currRingState) {
 				ringLastState = currRingState

--- a/pkg/storegateway/replication_strategy.go
+++ b/pkg/storegateway/replication_strategy.go
@@ -9,16 +9,16 @@ import (
 
 var (
 	// BlocksSync is the operation run by the store-gateway to sync blocks.
-	BlocksSync ring.Operation = ring.NewOpWithReplicaSetExtension(func(s ring.IngesterState) bool {
+	BlocksSync ring.Operation = ring.NewOp([]ring.IngesterState{ring.JOINING, ring.ACTIVE, ring.LEAVING}, func(s ring.IngesterState) bool {
 		// If the instance is JOINING or LEAVING we should extend the replica set:
 		// - JOINING: the previous replica set should be kept while an instance is JOINING
 		// - LEAVING: the instance is going to be decommissioned soon so we need to include
 		//   		  another replica in the set
 		return s == ring.JOINING || s == ring.LEAVING
-	}, ring.JOINING, ring.ACTIVE, ring.LEAVING)
+	})
 
 	// BlocksRead is the operation run by the querier to query blocks via the store-gateway.
-	BlocksRead ring.Operation = ring.NewOp(ring.ACTIVE)
+	BlocksRead ring.Operation = ring.NewOp([]ring.IngesterState{ring.ACTIVE}, nil)
 )
 
 type BlocksReplicationStrategy struct{}

--- a/pkg/storegateway/replication_strategy.go
+++ b/pkg/storegateway/replication_strategy.go
@@ -7,6 +7,20 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring"
 )
 
+var (
+	// BlocksSync is the operation run by the store-gateway to sync blocks.
+	BlocksSync ring.Operation = ring.NewOpWithReplicaSetExtension(func(s ring.IngesterState) bool {
+		// If the instance is JOINING or LEAVING we should extend the replica set:
+		// - JOINING: the previous replica set should be kept while an instance is JOINING
+		// - LEAVING: the instance is going to be decommissioned soon so we need to include
+		//   		  another replica in the set
+		return s == ring.JOINING || s == ring.LEAVING
+	}, ring.JOINING, ring.ACTIVE, ring.LEAVING)
+
+	// BlocksRead is the operation run by the querier to query blocks via the store-gateway.
+	BlocksRead ring.Operation = ring.NewOp(ring.ACTIVE)
+)
+
 type BlocksReplicationStrategy struct{}
 
 func (s *BlocksReplicationStrategy) Filter(instances []ring.IngesterDesc, op ring.Operation, _ int, heartbeatTimeout time.Duration, _ bool) ([]ring.IngesterDesc, int, error) {
@@ -29,19 +43,4 @@ func (s *BlocksReplicationStrategy) Filter(instances []ring.IngesterDesc, op rin
 
 	maxFailures := len(instances) - 1
 	return instances, maxFailures, nil
-}
-
-func (s *BlocksReplicationStrategy) ShouldExtendReplicaSet(instance ring.IngesterDesc, op ring.Operation) bool {
-	switch op {
-	case ring.BlocksSync:
-		// If the instance is JOINING or LEAVING we should extend the replica set:
-		// - JOINING: the previous replica set should be kept while an instance is JOINING
-		// - LEAVING: the instance is going to be decommissioned soon so we need to include
-		//   		  another replica in the set
-		return instance.GetState() == ring.JOINING || instance.GetState() == ring.LEAVING
-	case ring.BlocksRead:
-		return false
-	default:
-		return false
-	}
 }

--- a/pkg/storegateway/replication_strategy.go
+++ b/pkg/storegateway/replication_strategy.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	// BlocksSync is the operation run by the store-gateway to sync blocks.
-	BlocksSync ring.Operation = ring.NewOp([]ring.IngesterState{ring.JOINING, ring.ACTIVE, ring.LEAVING}, func(s ring.IngesterState) bool {
+	BlocksSync = ring.NewOp([]ring.IngesterState{ring.JOINING, ring.ACTIVE, ring.LEAVING}, func(s ring.IngesterState) bool {
 		// If the instance is JOINING or LEAVING we should extend the replica set:
 		// - JOINING: the previous replica set should be kept while an instance is JOINING
 		// - LEAVING: the instance is going to be decommissioned soon so we need to include
@@ -18,7 +18,7 @@ var (
 	})
 
 	// BlocksRead is the operation run by the querier to query blocks via the store-gateway.
-	BlocksRead ring.Operation = ring.NewOp([]ring.IngesterState{ring.ACTIVE}, nil)
+	BlocksRead = ring.NewOp([]ring.IngesterState{ring.ACTIVE}, nil)
 )
 
 type BlocksReplicationStrategy struct{}

--- a/pkg/storegateway/replication_strategy_test.go
+++ b/pkg/storegateway/replication_strategy_test.go
@@ -1,0 +1,64 @@
+package storegateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cortexproject/cortex/pkg/ring"
+)
+
+func TestIngesterDesc_IsHealthy_ForStoreGatewayOperations(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		instance      *ring.IngesterDesc
+		timeout       time.Duration
+		syncExpected  bool
+		queryExpected bool
+	}{
+		"ACTIVE instance with last keepalive newer than timeout": {
+			instance:      &ring.IngesterDesc{State: ring.ACTIVE, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
+			timeout:       time.Minute,
+			syncExpected:  true,
+			queryExpected: true,
+		},
+		"ACTIVE instance with last keepalive older than timeout": {
+			instance:      &ring.IngesterDesc{State: ring.ACTIVE, Timestamp: time.Now().Add(-90 * time.Second).Unix()},
+			timeout:       time.Minute,
+			syncExpected:  false,
+			queryExpected: false,
+		},
+		"JOINING instance with last keepalive newer than timeout": {
+			instance:      &ring.IngesterDesc{State: ring.JOINING, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
+			timeout:       time.Minute,
+			syncExpected:  true,
+			queryExpected: false,
+		},
+		"LEAVING instance with last keepalive newer than timeout": {
+			instance:      &ring.IngesterDesc{State: ring.LEAVING, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
+			timeout:       time.Minute,
+			syncExpected:  true,
+			queryExpected: false,
+		},
+		"PENDING instance with last keepalive newer than timeout": {
+			instance:      &ring.IngesterDesc{State: ring.PENDING, Timestamp: time.Now().Add(-30 * time.Second).Unix()},
+			timeout:       time.Minute,
+			syncExpected:  false,
+			queryExpected: false,
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			actual := testData.instance.IsHealthy(BlocksSync, testData.timeout, time.Now())
+			assert.Equal(t, testData.syncExpected, actual)
+
+			actual = testData.instance.IsHealthy(BlocksRead, testData.timeout, time.Now())
+			assert.Equal(t, testData.queryExpected, actual)
+		})
+	}
+}

--- a/pkg/storegateway/replication_strategy_test.go
+++ b/pkg/storegateway/replication_strategy_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring"
 )
 
-func TestIngesterDesc_IsHealthy_ForStoreGatewayOperations(t *testing.T) {
+func TestIsHealthyForStoreGatewayOperations(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {

--- a/pkg/storegateway/sharding_strategy.go
+++ b/pkg/storegateway/sharding_strategy.go
@@ -126,7 +126,7 @@ func filterBlocksByRingSharding(r ring.ReadRing, instanceAddr string, metas map[
 
 	for blockID := range metas {
 		key := cortex_tsdb.HashBlockID(blockID)
-		set, err := r.Get(key, ring.BlocksSync, bufDescs, bufHosts, bufZones)
+		set, err := r.Get(key, BlocksSync, bufDescs, bufHosts, bufZones)
 
 		// If there are no healthy instances in the replication set or
 		// the replication set for this block doesn't include this instance


### PR DESCRIPTION
**What this PR does**: This PR refactors `ring.Operation` ~to interface~, which allows us to define new ring "operations" in packages where they are used. "Extension of replica set" logic has been moved from "replication strategy" to operation itself. "Replication strategy" is now only filtering unwanted instances.

Inspired by another operation being added in #3664.

**Checklist**
- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
