### PR TITLE
Disable access to /alertmanager/metrics, which exposes default registerer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [BUGFIX] Querier: fix default value incorrectly overriding `-querier.frontend-address` in single-binary mode. #3650
 * [BUGFIX] Compactor: delete `deletion-mark.json` at last when deleting a block in order to not leave partial blocks without deletion mark in the bucket if the compactor is interrupted while deleting a block. #3660
 * [BUGFIX] Blocks storage: do not cleanup a partially uploaded block when `meta.json` upload fails. Despite failure to upload `meta.json`, this file may in some cases still appear in the bucket later. By skipping early cleanup, we avoid having corrupted blocks in the storage. #3660
+* [BUGFIX] Alertmanager: disable access to /alertmanager/metrics, which exposes all Cortex metrics to any authenticated user with enabled AlertManager. #3678
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 * [BUGFIX] Querier: fix default value incorrectly overriding `-querier.frontend-address` in single-binary mode. #3650
 * [BUGFIX] Compactor: delete `deletion-mark.json` at last when deleting a block in order to not leave partial blocks without deletion mark in the bucket if the compactor is interrupted while deleting a block. #3660
 * [BUGFIX] Blocks storage: do not cleanup a partially uploaded block when `meta.json` upload fails. Despite failure to upload `meta.json`, this file may in some cases still appear in the bucket later. By skipping early cleanup, we avoid having corrupted blocks in the storage. #3660
-* [BUGFIX] Alertmanager: disable access to /alertmanager/metrics, which exposes all Cortex metrics to any authenticated user with enabled AlertManager. #3678
+* [BUGFIX] Alertmanager: disable access to `/alertmanager/metrics` (which exposes all Cortex metrics), `/alertmanager/-/reload` and `/alertmanager/debug/*`, which were available to any authenticated user with enabled AlertManager. #3678
 
 ## 1.6.0
 

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"path/filepath"
 	"sync"
 	"time"
@@ -180,6 +181,9 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 
 	ui.Register(router, webReload, log.With(am.logger, "component", "ui"))
 	am.mux = am.api.Register(router, am.cfg.ExternalURL.Path)
+	// Override prefix+/metrics, which by default exposes prometheus.DefaultRegisterer.
+	// We can override prefix+"/metrics", because router is registered into "/", so there is no conflict.
+	am.mux.Handle(path.Join(am.cfg.ExternalURL.Path, "/metrics"), http.NotFoundHandler())
 
 	am.dispatcherMetrics = dispatch.NewDispatcherMetrics(am.registry)
 	return am, nil

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -181,9 +182,17 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 
 	ui.Register(router, webReload, log.With(am.logger, "component", "ui"))
 	am.mux = am.api.Register(router, am.cfg.ExternalURL.Path)
-	// Override prefix+/metrics, which by default exposes prometheus.DefaultRegisterer.
-	// We can override prefix+"/metrics", because router is registered into "/", so there is no conflict.
-	am.mux.Handle(path.Join(am.cfg.ExternalURL.Path, "/metrics"), http.NotFoundHandler())
+
+	// Override some extra paths registered in the router (eg. /metrics which by default exposes prometheus.DefaultRegisterer).
+	// Entire router is registered in Mux to "/" path, so there is no conflict with overwriting specific paths.
+	for _, p := range []string{"/metrics", "/-/reload", "/debug/"} {
+		a := path.Join(am.cfg.ExternalURL.Path, p)
+		// Preserve end slash, as for Mux it means entire subtree.
+		if strings.HasSuffix(p, "/") {
+			a = a + "/"
+		}
+		am.mux.Handle(a, http.NotFoundHandler())
+	}
 
 	am.dispatcherMetrics = dispatch.NewDispatcherMetrics(am.registry)
 	return am, nil

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -251,14 +251,14 @@ func TestAlertmanager_ServeHTTP(t *testing.T) {
 	{
 		metricURL := externalURL.String() + "/metrics"
 		require.Equal(t, "http://localhost:8080/alertmanager/metrics", metricURL)
-		verify404(t, ctx, am, "GET", metricURL)
+		verify404(ctx, t, am, "GET", metricURL)
 	}
 
 	// Verify that POST /-/reload returns 404 even when AM is active.
 	{
 		metricURL := externalURL.String() + "/-/reload"
 		require.Equal(t, "http://localhost:8080/alertmanager/-/reload", metricURL)
-		verify404(t, ctx, am, "POST", metricURL)
+		verify404(ctx, t, am, "POST", metricURL)
 	}
 
 	// Verify that GET /debug/index returns 404 even when AM is active.
@@ -268,7 +268,7 @@ func TestAlertmanager_ServeHTTP(t *testing.T) {
 
 		metricURL := externalURL.String() + "/debug/index"
 		require.Equal(t, "http://localhost:8080/alertmanager/debug/index", metricURL)
-		verify404(t, ctx, am, "GET", metricURL)
+		verify404(ctx, t, am, "GET", metricURL)
 	}
 
 	// Pause alert manager.
@@ -286,7 +286,7 @@ func TestAlertmanager_ServeHTTP(t *testing.T) {
 	}
 }
 
-func verify404(t *testing.T, ctx context.Context, am *MultitenantAlertmanager, method string, url string) {
+func verify404(ctx context.Context, t *testing.T, am *MultitenantAlertmanager, method string, url string) {
 	metricsReq := httptest.NewRequest(method, url, strings.NewReader("Hello")) // Body for POST Request.
 	w := httptest.NewRecorder()
 	am.ServeHTTP(w, metricsReq.WithContext(ctx))

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -215,13 +215,16 @@ func TestAlertmanager_ServeHTTP(t *testing.T) {
 	// Request when no user configuration is present.
 	req := httptest.NewRequest("GET", externalURL.String(), nil)
 	ctx := user.InjectOrgID(req.Context(), "user1")
-	w := httptest.NewRecorder()
 
-	am.ServeHTTP(w, req.WithContext(ctx))
+	{
+		w := httptest.NewRecorder()
+		am.ServeHTTP(w, req.WithContext(ctx))
 
-	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
-	require.Equal(t, "the Alertmanager is not configured\n", string(body))
+		resp := w.Result()
+		body, _ := ioutil.ReadAll(resp.Body)
+		require.Equal(t, 404, w.Code)
+		require.Equal(t, "the Alertmanager is not configured\n", string(body))
+	}
 
 	// Create a configuration for the user in storage.
 	mockStore.configs["user1"] = alerts.AlertConfigDesc{
@@ -233,15 +236,39 @@ func TestAlertmanager_ServeHTTP(t *testing.T) {
 	// Make the alertmanager pick it up, then pause it.
 	err = am.updateConfigs()
 	require.NoError(t, err)
+
+	// Request when AM is active.
+	{
+		w := httptest.NewRecorder()
+		am.ServeHTTP(w, req.WithContext(ctx))
+
+		require.Equal(t, 301, w.Code) // redirect to UI
+	}
+
+	// Verify that /metrics returns 404 even when AM is active.
+	{
+		metricURL := externalURL.String() + "/metrics"
+		require.Equal(t, "http://localhost:8080/alertmanager/metrics", metricURL)
+		metricsReq := httptest.NewRequest("GET", metricURL, nil)
+		w := httptest.NewRecorder()
+		am.ServeHTTP(w, metricsReq.WithContext(ctx))
+
+		require.Equal(t, 404, w.Code)
+	}
+
+	// Pause alert manager.
 	am.alertmanagers["user1"].Pause()
 
-	// Request when user configuration is paused.
-	w = httptest.NewRecorder()
-	am.ServeHTTP(w, req.WithContext(ctx))
+	{
+		// Request when user configuration is paused.
+		w := httptest.NewRecorder()
+		am.ServeHTTP(w, req.WithContext(ctx))
 
-	resp = w.Result()
-	body, _ = ioutil.ReadAll(resp.Body)
-	require.Equal(t, "the Alertmanager is not configured\n", string(body))
+		resp := w.Result()
+		body, _ := ioutil.ReadAll(resp.Body)
+		require.Equal(t, 404, w.Code)
+		require.Equal(t, "the Alertmanager is not configured\n", string(body))
+	}
 }
 
 func TestAlertmanager_ServeHTTPWithFallbackConfig(t *testing.T) {


### PR DESCRIPTION
**What this PR does**: This PR disables access to `/alertmanager/metrics` path, which exposes default registerer = all Cortex metrics on given instance.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
