### PR TITLE
Disable access to Alertmanager (user, or sending alerts), if it is not running.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,8 @@
 * [BUGFIX] Compactor: delete `deletion-mark.json` at last when deleting a block in order to not leave partial blocks without deletion mark in the bucket if the compactor is interrupted while deleting a block. #3660
 * [BUGFIX] Blocks storage: do not cleanup a partially uploaded block when `meta.json` upload fails. Despite failure to upload `meta.json`, this file may in some cases still appear in the bucket later. By skipping early cleanup, we avoid having corrupted blocks in the storage. #3660
 * [BUGFIX] Alertmanager: disable access to `/alertmanager/metrics` (which exposes all Cortex metrics), `/alertmanager/-/reload` and `/alertmanager/debug/*`, which were available to any authenticated user with enabled AlertManager. #3678
-* [BUGFIX] Alertmanager: don't serve HTTP requests until Alertmanager has fully started. Serving HTTP requests earlier may result in loss of configuration for the user. #3679
 * [BUGFIX] Query-Frontend: avoid creating many small sub-queries by discarding cache extents under 5 minutes #3653
+* [BUGFIX] Alertmanager: don't serve HTTP requests until Alertmanager has fully started. Serving HTTP requests earlier may result in loss of configuration for the user. #3679
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [BUGFIX] Querier: fix default value incorrectly overriding `-querier.frontend-address` in single-binary mode. #3650
 * [BUGFIX] Compactor: delete `deletion-mark.json` at last when deleting a block in order to not leave partial blocks without deletion mark in the bucket if the compactor is interrupted while deleting a block. #3660
 * [BUGFIX] Blocks storage: do not cleanup a partially uploaded block when `meta.json` upload fails. Despite failure to upload `meta.json`, this file may in some cases still appear in the bucket later. By skipping early cleanup, we avoid having corrupted blocks in the storage. #3660
+* [BUGFIX] AlertManager: don't serve HTTP requests until AlertManager has fully started. Serving HTTP requests earlier may result in loss of configuration for the user. #3679
 
 ## 1.6.0
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -470,6 +470,11 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *amco
 
 // ServeHTTP serves the Alertmanager's web UI and API.
 func (am *MultitenantAlertmanager) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if am.State() != services.Running {
+		http.Error(w, "Alertmanager not ready", http.StatusServiceUnavailable)
+		return
+	}
+
 	userID, err := tenant.TenantID(req.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -283,9 +283,11 @@ func (am *MultitenantAlertmanager) stopping(_ error) error {
 		am.Stop()
 	}
 	am.alertmanagersMtx.Unlock()
-	err := am.peer.Leave(am.cfg.PeerTimeout)
-	if err != nil {
-		level.Warn(am.logger).Log("msg", "failed to leave the cluster", "err", err)
+	if am.peer != nil { // Tests don't setup any peer.
+		err := am.peer.Leave(am.cfg.PeerTimeout)
+		if err != nil {
+			level.Warn(am.logger).Log("msg", "failed to leave the cluster", "err", err)
+		}
 	}
 	level.Debug(am.logger).Log("msg", "stopping")
 	return nil

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/alertmanager/alerts"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 var (
@@ -212,6 +213,9 @@ func TestAlertmanager_ServeHTTP(t *testing.T) {
 		DataDir:     tempDir,
 	}, nil, nil, mockStore, log.NewNopLogger(), reg)
 
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), am))
+	defer services.StopAndAwaitTerminated(context.Background(), am) //nolint:errcheck
+
 	// Request when no user configuration is present.
 	req := httptest.NewRequest("GET", externalURL.String(), nil)
 	ctx := user.InjectOrgID(req.Context(), "user1")
@@ -275,6 +279,9 @@ receivers:
 		DataDir:     tempDir,
 	}, nil, nil, mockStore, log.NewNopLogger(), nil)
 	am.fallbackConfig = fallbackCfg
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), am))
+	defer services.StopAndAwaitTerminated(context.Background(), am) //nolint:errcheck
 
 	// Request when no user configuration is present.
 	req := httptest.NewRequest("GET", externalURL.String()+"/api/v1/status", nil)

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -209,8 +210,9 @@ func TestAlertmanager_ServeHTTP(t *testing.T) {
 	// Create the Multitenant Alertmanager.
 	reg := prometheus.NewPedanticRegistry()
 	am := createMultitenantAlertmanager(&MultitenantAlertmanagerConfig{
-		ExternalURL: externalURL,
-		DataDir:     tempDir,
+		ExternalURL:  externalURL,
+		DataDir:      tempDir,
+		PollInterval: time.Minute,
 	}, nil, nil, mockStore, log.NewNopLogger(), reg)
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), am))
@@ -275,8 +277,9 @@ receivers:
 
 	// Create the Multitenant Alertmanager.
 	am := createMultitenantAlertmanager(&MultitenantAlertmanagerConfig{
-		ExternalURL: externalURL,
-		DataDir:     tempDir,
+		ExternalURL:  externalURL,
+		DataDir:      tempDir,
+		PollInterval: time.Minute,
 	}, nil, nil, mockStore, log.NewNopLogger(), nil)
 	am.fallbackConfig = fallbackCfg
 


### PR DESCRIPTION
**What this PR does**: This PR disables access to user's Alertmanager (by user, or services trying to send alert) until `MultitenantAlertmanager` has started and synced configuration for each user.

Call to tenant's AM before `MultitenantAlertmanager` is running may result in loss of configuration for this tenant.

**Checklist**
- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
