### PR TITLE
QueryFrontend: Return server side performance information on server-timing header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [ENHANCEMENT] Prometheus upgraded. #3739
   * Avoid unnecessary `runtime.GC()` during compactions.
   * Prevent compaction loop in TSDB on data gap.
+* [ENHANCEMENT] Return server side performance metrics for query-frontend (using Server-timing header). #3685
 
 ## 1.7.0 in progress
 


### PR DESCRIPTION
**What this PR does**:
* Creates a Util class that can be used on any handler to add server side performance information on [server-timing](https://www.w3.org/TR/server-timing/) http header 
* Return `server-timing` header with querier wall time information on query requests when `-frontend.query-stats-enabled=true`
* Return `server-timing` header with `request_duration` on any request on query-frontend

We may want to create a config to enable this feature.

Result on chrome:

![image](https://user-images.githubusercontent.com/4027760/104512630-5b9d5580-55a3-11eb-916c-4ebf1a199874.png)

**Which issue(s) this PR fixes**:
Enhancement of #3595
**Checklist**
- [✓] Tests updated
- [✓] No Documentation needed
- [✓] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
