### PR TITLE
fix: Stale series with ruler evaluation delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [BUGFIX] Blocks storage: do not cleanup a partially uploaded block when `meta.json` upload fails. Despite failure to upload `meta.json`, this file may in some cases still appear in the bucket later. By skipping early cleanup, we avoid having corrupted blocks in the storage. #3660
 * [BUGFIX] Alertmanager: disable access to `/alertmanager/metrics` (which exposes all Cortex metrics), `/alertmanager/-/reload` and `/alertmanager/debug/*`, which were available to any authenticated user with enabled AlertManager. #3678
 * [BUGFIX] Query-Frontend: avoid creating many small sub-queries by discarding cache extents under 5 minutes #3653
+* [BUGFIX] Ruler: Ensure the stale markers generated for evaluated rules respect the configured `-ruler.evaluation-delay-duration`. This will avoid issues with samples with NaN be persisted with timestamps set ahead of the next rule evaluation. #3687
 
 ## 1.6.0
 

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -74,16 +74,12 @@ receivers:
     annotations: {}	
 `
 
-	cortexRulerEvalTimeConfigYaml = `groups:
+	cortexRulerEvalStaleNanConfigYaml = `groups:
 - name: rule
   interval: 1s
   rules:
-  - record: time_eval
-    alert: ""
-    expr: time()
-    for: 0s
-    labels: {}
-    annotations: {}	
+  - record: stale_nan_eval
+    expr: a_sometimes_stale_nan_series * 2
 `
 )
 

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"github.com/prometheus/prometheus/pkg/value"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -179,45 +182,110 @@ func TestRulerEvaluationDelay(t *testing.T) {
 	namespace := "ns"
 	user := "fake"
 
+	evaluationDelay := time.Minute * 5
+
 	configOverrides := map[string]string{
 		"-ruler.storage.local.directory":   filepath.Join(e2e.ContainerSharedDir, "ruler_configs"),
 		"-ruler.poll-interval":             "2s",
 		"-ruler.rule-path":                 filepath.Join(e2e.ContainerSharedDir, "rule_tmp/"),
-		"-ruler.evaluation-delay-duration": "5m", // 5 minutes is clarifying when seeing when a rule is evaluated
+		"-ruler.evaluation-delay-duration": evaluationDelay.String(),
 	}
 
 	// Start Cortex components.
 	require.NoError(t, copyFileToSharedDir(s, "docs/configuration/single-process-config.yaml", cortexConfigFile))
-	require.NoError(t, writeFileToSharedDir(s, filepath.Join("ruler_configs", user, namespace), []byte(cortexRulerEvalTimeConfigYaml)))
+	require.NoError(t, writeFileToSharedDir(s, filepath.Join("ruler_configs", user, namespace), []byte(cortexRulerEvalStaleNanConfigYaml)))
 	cortex := e2ecortex.NewSingleBinaryWithConfigFile("cortex", cortexConfigFile, configOverrides, "", 9009, 9095)
 	require.NoError(t, s.StartAndWaitReady(cortex))
 
 	// Create a client with the ruler address configured
-	c, err := e2ecortex.NewClient("", cortex.HTTPEndpoint(), "", cortex.HTTPEndpoint(), "")
+	c, err := e2ecortex.NewClient(cortex.HTTPEndpoint(), cortex.HTTPEndpoint(), "", cortex.HTTPEndpoint(), "")
 	require.NoError(t, err)
-
-	// Wait until the rule is evaluated
-	require.NoError(t, cortex.WaitSumMetrics(e2e.Greater(0), "cortex_prometheus_rule_evaluations_total"))
 
 	now := time.Now()
 
-	result, err := c.QueryRange("time_eval", now.Add(-10*time.Minute), now, time.Minute)
+	// Generate series that includes stale nans
+	var samplesToSend int = 10
+	series := prompb.TimeSeries{
+		Labels: []prompb.Label{
+			{Name: "__name__", Value: "a_sometimes_stale_nan_series"},
+			{Name: "instance", Value: "sometimes-stale"},
+		},
+	}
+	series.Samples = make([]prompb.Sample, samplesToSend)
+	posStale := 2
+
+	// Create samples, that are delayed by the evaluation delay with increasing values.
+	for pos := range series.Samples {
+		series.Samples[pos].Timestamp = e2e.TimeToMilliseconds(now.Add(-evaluationDelay).Add(time.Duration(pos) * time.Second))
+		series.Samples[pos].Value = float64(pos + 1)
+
+		// insert staleness marker at the positions marked by posStale
+		if pos == posStale {
+			series.Samples[pos].Value = math.Float64frombits(value.StaleNaN)
+		}
+	}
+
+	// Insert metrics
+	res, err := c.Push([]prompb.TimeSeries{series})
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+
+	// Get number of rule evaluations just after push
+	ruleEvaluationsAfterPush, err := cortex.SumMetrics([]string{"cortex_prometheus_rule_evaluations_total"})
+	require.NoError(t, err)
+
+	// Wait until the rule is evaluated for the first time
+	require.NoError(t, cortex.WaitSumMetrics(e2e.Greater(ruleEvaluationsAfterPush[0]), "cortex_prometheus_rule_evaluations_total"))
+
+	// Query the timestamp of the latest result to ensure the evaluation is delayed
+	result, err := c.Query("timestamp(stale_nan_eval)", now)
+	require.NoError(t, err)
+	require.Equal(t, model.ValVector, result.Type())
+
+	vector := result.(model.Vector)
+	require.Equal(t, 1, vector.Len(), "expect one sample returned")
+
+	// 290 seconds gives 10 seconds of slack between the rule evaluation and the query
+	// to account for CI latency, but ensures the latest evaluation was in the past.
+	var maxDiff int64 = 290_000
+	require.GreaterOrEqual(t, e2e.TimeToMilliseconds(time.Now())-int64(vector[0].Value)*1000, maxDiff)
+
+	// Wait until all the pushed samples have been evaluated by the rule. This
+	// ensures that rule results are successfully written even after a
+	// staleness period.
+	require.NoError(t, cortex.WaitSumMetrics(e2e.GreaterOrEqual(ruleEvaluationsAfterPush[0]+float64(samplesToSend)), "cortex_prometheus_rule_evaluations_total"))
+
+	// query all results to verify rules have been evaluated correctly
+	result, err = c.QueryRange("stale_nan_eval", now.Add(-evaluationDelay), now, time.Second)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, result.Type())
 
-	// Iterate through the values recorded and ensure they exist in the past.
 	matrix := result.(model.Matrix)
+	require.GreaterOrEqual(t, 1, matrix.Len(), "expect at least a series returned")
 
-	// 290 seconds gives 10 seconds of slack between the rule evaluation and the query
-	// to account for CI latency, but ensures the latest evalation was in the past.
-	var maxDiff int64 = 290
-
+	// Iterate through the values recorded and ensure they exist as expected.
+	inputPos := 0
 	for _, m := range matrix {
 		for _, v := range m.Values {
-			diff := now.Unix() - int64(v.Value)
-			require.GreaterOrEqual(t, diff, maxDiff)
+			// Skip values for stale positions
+			if inputPos == posStale {
+				inputPos++
+			}
+
+			expectedValue := model.SampleValue(2 * (inputPos + 1))
+			require.Equal(t, expectedValue, v.Value)
+
+			// Look for next value
+			inputPos++
+
+			// We have found all input values
+			if inputPos >= len(series.Samples) {
+				break
+			}
 		}
 	}
+	require.Equal(t, len(series.Samples), inputPos, "expect to have returned all evaluations")
+
 }
 
 func TestRulerAlertmanager(t *testing.T) {

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -1,0 +1,78 @@
+package ruler
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/pkg/value"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/ingester/client"
+)
+
+type fakePusher struct {
+	request  *client.WriteRequest
+	response *client.WriteResponse
+}
+
+func (p *fakePusher) Push(ctx context.Context, r *client.WriteRequest) (*client.WriteResponse, error) {
+	p.request = r
+	return p.response, nil
+}
+
+func TestPusherAppendable(t *testing.T) {
+	pusher := &fakePusher{}
+	pa := &PusherAppendable{
+		pusher: pusher,
+		userID: "user-1",
+	}
+
+	for _, tc := range []struct {
+		name       string
+		evalDelay  time.Duration
+		value      float64
+		expectedTS int64
+	}{
+		{
+			name:       "tenant without delay, normal value",
+			value:      1.234,
+			expectedTS: 120_000,
+		},
+		{
+			name:       "tenant without delay, stale nan value",
+			value:      math.Float64frombits(value.StaleNaN),
+			expectedTS: 120_000,
+		},
+		{
+			name:       "tenant with delay, normal value",
+			value:      1.234,
+			expectedTS: 120_000,
+			evalDelay:  time.Minute,
+		},
+		{
+			name:       "tenant with delay, stale nan value",
+			value:      math.Float64frombits(value.StaleNaN),
+			expectedTS: 60_000,
+			evalDelay:  time.Minute,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			pa.rulesLimits = &ruleLimits{
+				evalDelay: tc.evalDelay,
+			}
+
+			pusher.response = &client.WriteResponse{}
+			a := pa.Appender(ctx)
+			_, err := a.Add(nil, 120_000, tc.value)
+			require.NoError(t, err)
+
+			require.NoError(t, a.Commit())
+
+			require.Equal(t, tc.expectedTS, pusher.request.Timeseries[0].Samples[0].TimestampMs)
+
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

When ruler evaluation delay is enabled, the upstream rule evaluation logic adds staleness markers for missing series at the actual timestamp when the evaluation is run rather than the timestamp when the series was missing: (see:
https://github.com/prometheus/prometheus/blob/6c56a1faaaad07317ff585bda75b99bdba0517ad/rules/manager.go#L647-L660).

This can cause larger gaps than there actually are, as once the data becomes available again it can't be written as it would be out-of-order.

This fix shifts those staleness marker back in time by the evaluation delay set for the individual tenant.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
