### PR TITLE
Increase stalebot threshold from 60d to 90d

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Days without any activity until an issue is labeled as stale
-daysUntilStale: 60
+daysUntilStale: 90
 
 # Days after having the stale label that the issue will be closed
 daysUntilClose: 15


### PR DESCRIPTION
**What this PR does**:
Stalebot triggers more frequently than we're able to address issues. I would propose to increase the threshold from 60d to 90d.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
