### PR TITLE
Remove flags deprecated in Cortex 1.3.0 and 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## master / unreleased
 
+* [CHANGE] Ruler: removed the flag `-ruler.evaluation-delay-duration-deprecated` which was deprecated in 1.4.0. Please use the `ruler_evaluation_delay_duration` per-tenant limit instead. #3693
+* [CHANGE] Removed the flags `-<prefix>.grpc-use-gzip-compression` which were deprecated in 1.3.0: #3693
+  * `-query-scheduler.grpc-client-config.grpc-use-gzip-compression`: use `-query-scheduler.grpc-client-config.grpc-compression` instead
+  * `-frontend.grpc-client-config.grpc-use-gzip-compression`: use `-frontend.grpc-client-config.grpc-compression` instead
+  * `-ruler.client.grpc-use-gzip-compression`: use `-ruler.client.grpc-compression` instead
+  * `-bigtable.grpc-use-gzip-compression`: use `-bigtable.grpc-compression` instead
+  * `-ingester.client.grpc-use-gzip-compression`: use `-ingester.client.grpc-compression` instead
+  * `-querier.frontend-client.grpc-use-gzip-compression`: use `-querier.frontend-client.grpc-compression` instead
 * [CHANGE] Querier: it's not required to set `-frontend.query-stats-enabled=true` in the querier anymore to enable query statistics logging in the query-frontend. The flag is now required to be configured only in the query-frontend and it will be propagated to the queriers. #3595
 * [CHANGE] Blocks storage: compactor is now required when running a Cortex cluster with the blocks storage, because it also keeps the bucket index updated. #3583
 * [CHANGE] Blocks storage: block deletion marks are now stored in a per-tenant global markers/ location too, other than within the block location. The compactor, at startup, will copy deletion marks from the block location to the global location. This migration is required only once, so you can safely disable it via `-compactor.block-deletion-marks-migration-enabled=false` once new compactor has successfully started once in your cluster. #3583

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -189,11 +189,6 @@ query_scheduler:
     # CLI flag: -query-scheduler.grpc-client-config.grpc-max-send-msg-size
     [max_send_msg_size: <int> | default = 16777216]
 
-    # Deprecated: Use gzip compression when sending messages.  If true,
-    # overrides grpc-compression flag.
-    # CLI flag: -query-scheduler.grpc-client-config.grpc-use-gzip-compression
-    [use_gzip_compression: <boolean> | default = false]
-
     # Use compression when sending messages. Supported values are: 'gzip',
     # 'snappy' and '' (disable compression)
     # CLI flag: -query-scheduler.grpc-client-config.grpc-compression
@@ -915,11 +910,6 @@ grpc_client_config:
   # CLI flag: -frontend.grpc-client-config.grpc-max-send-msg-size
   [max_send_msg_size: <int> | default = 16777216]
 
-  # Deprecated: Use gzip compression when sending messages.  If true, overrides
-  # grpc-compression flag.
-  # CLI flag: -frontend.grpc-client-config.grpc-use-gzip-compression
-  [use_gzip_compression: <boolean> | default = false]
-
   # Use compression when sending messages. Supported values are: 'gzip',
   # 'snappy' and '' (disable compression)
   # CLI flag: -frontend.grpc-client-config.grpc-compression
@@ -1080,11 +1070,6 @@ ruler_client:
   # CLI flag: -ruler.client.grpc-max-send-msg-size
   [max_send_msg_size: <int> | default = 16777216]
 
-  # Deprecated: Use gzip compression when sending messages.  If true, overrides
-  # grpc-compression flag.
-  # CLI flag: -ruler.client.grpc-use-gzip-compression
-  [use_gzip_compression: <boolean> | default = false]
-
   # Use compression when sending messages. Supported values are: 'gzip',
   # 'snappy' and '' (disable compression)
   # CLI flag: -ruler.client.grpc-compression
@@ -1137,10 +1122,6 @@ ruler_client:
 # How frequently to evaluate rules
 # CLI flag: -ruler.evaluation-interval
 [evaluation_interval: <duration> | default = 1m]
-
-# Deprecated. Please use -ruler.evaluation-delay-duration instead.
-# CLI flag: -ruler.evaluation-delay-duration-deprecated
-[evaluation_delay_duration: <duration> | default = 0s]
 
 # How frequently to poll for rule changes
 # CLI flag: -ruler.poll-interval
@@ -2215,11 +2196,6 @@ bigtable:
     # CLI flag: -bigtable.grpc-max-send-msg-size
     [max_send_msg_size: <int> | default = 16777216]
 
-    # Deprecated: Use gzip compression when sending messages.  If true,
-    # overrides grpc-compression flag.
-    # CLI flag: -bigtable.grpc-use-gzip-compression
-    [use_gzip_compression: <boolean> | default = false]
-
     # Use compression when sending messages. Supported values are: 'gzip',
     # 'snappy' and '' (disable compression)
     # CLI flag: -bigtable.grpc-compression
@@ -2740,11 +2716,6 @@ grpc_client_config:
   # CLI flag: -ingester.client.grpc-max-send-msg-size
   [max_send_msg_size: <int> | default = 16777216]
 
-  # Deprecated: Use gzip compression when sending messages.  If true, overrides
-  # grpc-compression flag.
-  # CLI flag: -ingester.client.grpc-use-gzip-compression
-  [use_gzip_compression: <boolean> | default = false]
-
   # Use compression when sending messages. Supported values are: 'gzip',
   # 'snappy' and '' (disable compression)
   # CLI flag: -ingester.client.grpc-compression
@@ -2841,11 +2812,6 @@ grpc_client_config:
   # gRPC client max send message size (bytes).
   # CLI flag: -querier.frontend-client.grpc-max-send-msg-size
   [max_send_msg_size: <int> | default = 16777216]
-
-  # Deprecated: Use gzip compression when sending messages.  If true, overrides
-  # grpc-compression flag.
-  # CLI flag: -querier.frontend-client.grpc-use-gzip-compression
-  [use_gzip_compression: <boolean> | default = false]
 
   # Use compression when sending messages. Supported values are: 'gzip',
   # 'snappy' and '' (disable compression)

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/scheduler"
 	"github.com/cortexproject/cortex/pkg/storegateway"
 	"github.com/cortexproject/cortex/pkg/util"
-	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/modules"
 	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
 	"github.com/cortexproject/cortex/pkg/util/services"
@@ -143,19 +142,6 @@ func (t *Cortex) initRing() (serv services.Service, err error) {
 }
 
 func (t *Cortex) initRuntimeConfig() (services.Service, error) {
-	// We need to modify LimitsConfig before calling SetDefaultLimitsForYAMLUnmarshalling later in this method
-	// but also if runtime-config is not used, for setting limits used by initOverrides.
-	// TODO: Remove this in Cortex 1.6.
-	if t.Cfg.Ruler.EvaluationDelay != 0 && t.Cfg.LimitsConfig.RulerEvaluationDelay == 0 {
-		t.Cfg.LimitsConfig.RulerEvaluationDelay = t.Cfg.Ruler.EvaluationDelay
-
-		// No need to report if this field isn't going to be used.
-		if t.Cfg.isModuleEnabled(Ruler) || t.Cfg.isModuleEnabled(All) {
-			flagext.DeprecatedFlagsUsed.Inc()
-			level.Warn(util.Logger).Log("msg", "Using DEPRECATED YAML config field ruler.evaluation_delay_duration, please use limits.ruler_evaluation_delay_duration instead.")
-		}
-	}
-
 	if t.Cfg.RuntimeConfig.LoadPath == "" {
 		t.Cfg.RuntimeConfig.LoadPath = t.Cfg.LimitsConfig.PerTenantOverrideConfig
 		t.Cfg.RuntimeConfig.ReloadPeriod = t.Cfg.LimitsConfig.PerTenantOverridePeriod

--- a/pkg/querier/store_gateway_client.go
+++ b/pkg/querier/store_gateway_client.go
@@ -71,7 +71,7 @@ func newStoreGatewayClientPool(discovery client.PoolServiceDiscovery, tlsCfg tls
 	clientCfg := grpcclient.Config{
 		MaxRecvMsgSize:      100 << 20,
 		MaxSendMsgSize:      16 << 20,
-		UseGzipCompression:  false,
+		GRPCCompression:     "",
 		RateLimit:           0,
 		RateLimitBurst:      0,
 		BackoffOnRatelimits: false,

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -67,9 +67,6 @@ type Config struct {
 	ClientTLSConfig grpcclient.ConfigWithTLS `yaml:"ruler_client"`
 	// How frequently to evaluate rules by default.
 	EvaluationInterval time.Duration `yaml:"evaluation_interval"`
-	// Deprecated. Replaced with pkg/util/validation/Limits.RulerEvaluationDelay field.
-	// TODO: To be removed in Cortex 1.6.
-	EvaluationDelay time.Duration `yaml:"evaluation_delay_duration"`
 	// How frequently to poll for updated rules.
 	PollInterval time.Duration `yaml:"poll_interval"`
 	// Rule Storage and Polling configuration.
@@ -142,7 +139,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.ExternalURL.URL, _ = url.Parse("") // Must be non-nil
 	f.Var(&cfg.ExternalURL, "ruler.external.url", "URL of alerts return path.")
 	f.DurationVar(&cfg.EvaluationInterval, "ruler.evaluation-interval", 1*time.Minute, "How frequently to evaluate rules")
-	f.DurationVar(&cfg.EvaluationDelay, "ruler.evaluation-delay-duration-deprecated", 0, "Deprecated. Please use -ruler.evaluation-delay-duration instead.")
 	f.DurationVar(&cfg.PollInterval, "ruler.poll-interval", 1*time.Minute, "How frequently to poll for rule changes")
 
 	f.StringVar(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "", "Comma-separated list of URL(s) of the Alertmanager(s) to send notifications to. Each Alertmanager URL is treated as a separate group in the configuration. Multiple Alertmanagers in HA per group can be supported by using DNS resolution via -ruler.alertmanager-discovery.")

--- a/pkg/util/grpcclient/grpcclient.go
+++ b/pkg/util/grpcclient/grpcclient.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -13,19 +12,17 @@ import (
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/cortexproject/cortex/pkg/util"
-	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/grpc/encoding/snappy"
 	"github.com/cortexproject/cortex/pkg/util/tls"
 )
 
 // Config for a gRPC client.
 type Config struct {
-	MaxRecvMsgSize     int     `yaml:"max_recv_msg_size"`
-	MaxSendMsgSize     int     `yaml:"max_send_msg_size"`
-	UseGzipCompression bool    `yaml:"use_gzip_compression"` // TODO: Remove this deprecated option in v1.6.0.
-	GRPCCompression    string  `yaml:"grpc_compression"`
-	RateLimit          float64 `yaml:"rate_limit"`
-	RateLimitBurst     int     `yaml:"rate_limit_burst"`
+	MaxRecvMsgSize  int     `yaml:"max_recv_msg_size"`
+	MaxSendMsgSize  int     `yaml:"max_send_msg_size"`
+	GRPCCompression string  `yaml:"grpc_compression"`
+	RateLimit       float64 `yaml:"rate_limit"`
+	RateLimitBurst  int     `yaml:"rate_limit_burst"`
 
 	BackoffOnRatelimits bool               `yaml:"backoff_on_ratelimits"`
 	BackoffConfig       util.BackoffConfig `yaml:"backoff_config"`
@@ -40,7 +37,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxRecvMsgSize, prefix+".grpc-max-recv-msg-size", 100<<20, "gRPC client max receive message size (bytes).")
 	f.IntVar(&cfg.MaxSendMsgSize, prefix+".grpc-max-send-msg-size", 16<<20, "gRPC client max send message size (bytes).")
-	f.BoolVar(&cfg.UseGzipCompression, prefix+".grpc-use-gzip-compression", false, "Deprecated: Use gzip compression when sending messages.  If true, overrides grpc-compression flag.")
 	f.StringVar(&cfg.GRPCCompression, prefix+".grpc-compression", "", "Use compression when sending messages. Supported values are: 'gzip', 'snappy' and '' (disable compression)")
 	f.Float64Var(&cfg.RateLimit, prefix+".grpc-client-rate-limit", 0., "Rate limit for gRPC client; 0 means disabled.")
 	f.IntVar(&cfg.RateLimitBurst, prefix+".grpc-client-rate-limit-burst", 0, "Rate limit burst for gRPC client.")
@@ -50,10 +46,6 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 }
 
 func (cfg *Config) Validate(log log.Logger) error {
-	if cfg.UseGzipCompression {
-		flagext.DeprecatedFlagsUsed.Inc()
-		level.Warn(log).Log("msg", "running with DEPRECATED option use_gzip_compression, use grpc_compression instead.")
-	}
 	switch cfg.GRPCCompression {
 	case gzip.Name, snappy.Name, "":
 		// valid
@@ -68,12 +60,8 @@ func (cfg *Config) CallOptions() []grpc.CallOption {
 	var opts []grpc.CallOption
 	opts = append(opts, grpc.MaxCallRecvMsgSize(cfg.MaxRecvMsgSize))
 	opts = append(opts, grpc.MaxCallSendMsgSize(cfg.MaxSendMsgSize))
-	compression := cfg.GRPCCompression
-	if cfg.UseGzipCompression {
-		compression = gzip.Name
-	}
-	if compression != "" {
-		opts = append(opts, grpc.UseCompressor(compression))
+	if cfg.GRPCCompression != "" {
+		opts = append(opts, grpc.UseCompressor(cfg.GRPCCompression))
 	}
 	return opts
 }


### PR DESCRIPTION
**What this PR does**:
In Cortex 1.3.0 and 1.4.0 we deprecated a couple of CLI flags. According to our deprecation policy, we keep the deprecated flags for 2 releases after the announcement. Given 1.6.0 has been released, we can now remove them.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
