### PR TITLE
Runtime config endpoint now supports diff parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Avoid unnecessary `runtime.GC()` during compactions.
   * Prevent compaction loop in TSDB on data gap.
 * [ENHANCEMENT] Return server side performance metrics for query-frontend (using Server-timing header). #3685
+* [ENHANCEMENT] Runtime Config: Add a `mode` query parameter for the runtime config endpoint. `/runtime_config?mode=diff` now shows the YAML runtime configuration with all values that differ from the defaults. #3700
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 
 ## 1.7.0 in progress

--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -117,7 +117,7 @@ Displays the configuration currently applied to Cortex (in YAML format), includi
 GET /config?mode=diff
 ```
 
-Displays the configuration currently applied to Cortex (in YAML format) as before, but containing only the values that differ from the  default values.
+Displays the configuration currently applied to Cortex (in YAML format) as before, but containing only the values that differ from the default values.
 
 ```
 GET /config?mode=defaults
@@ -132,6 +132,14 @@ GET /runtime_config
 ```
 
 Displays the runtime configuration currently applied to Cortex (in YAML format), including default values. Please be aware that the endpoint will be only available if Cortex is configured with the `-runtime-config.file` option.
+
+#### Different modes
+
+```
+GET /runtime_config?mode=diff
+```
+
+Displays the runtime configuration currently applied to Cortex (in YAML format) as before, but containing only the values that differ from the default values.
 
 ### Services status
 

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -422,7 +422,7 @@ multi_kv_config:
 
 When running Cortex on Kubernetes, store this file in a config map and mount it in each services' containers.  When changing the values there is no need to restart the services, unless otherwise specified.
 
-The `/runtime_config` endpoint returns the runtime configuration, including the overrides.
+The `/runtime_config` endpoint returns the whole runtime configuration, including the overrides. In case you want to get only the non-default values of the configuration you can pass the `mode` parameter with the `diff` value.
 
 ## Ingester, Distributor & Querier limits.
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"flag"
-	"github.com/cortexproject/cortex/pkg/util/validation"
 	"net/http"
 	"strings"
 	"time"
@@ -35,6 +34,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
 	"github.com/cortexproject/cortex/pkg/util/push"
 	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
+	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 type Config struct {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -33,8 +33,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/storegateway"
 	"github.com/cortexproject/cortex/pkg/storegateway/storegatewaypb"
 	"github.com/cortexproject/cortex/pkg/util/push"
-	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
-	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 type Config struct {
@@ -180,11 +178,11 @@ func (a *API) RegisterAPI(httpPathPrefix string, actualCfg interface{}, defaultC
 }
 
 // RegisterRuntimeConfig registers the endpoints associates with the runtime configuration
-func (a *API) RegisterRuntimeConfig(runtimeCfgManager *runtimeconfig.Manager, defaultLimits validation.Limits) {
+func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc) {
 	a.indexPage.AddLink(SectionAdminEndpoints, "/runtime_config", "Current Runtime Config (incl. Overrides)")
 	a.indexPage.AddLink(SectionAdminEndpoints, "/runtime_config?mode=diff", "Current Runtime Config (show only values that differ from the defaults)")
 
-	a.RegisterRoute("/runtime_config", runtimeConfigHandler(runtimeCfgManager, defaultLimits), false, "GET")
+	a.RegisterRoute("/runtime_config", runtimeConfigHandler, false, "GET")
 }
 
 // RegisterDistributor registers the endpoints associated with the distributor.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"flag"
+	"github.com/cortexproject/cortex/pkg/util/validation"
 	"net/http"
 	"strings"
 	"time"
@@ -179,10 +180,11 @@ func (a *API) RegisterAPI(httpPathPrefix string, actualCfg interface{}, defaultC
 }
 
 // RegisterRuntimeConfig registers the endpoints associates with the runtime configuration
-func (a *API) RegisterRuntimeConfig(runtimeCfgManager *runtimeconfig.Manager) {
+func (a *API) RegisterRuntimeConfig(runtimeCfgManager *runtimeconfig.Manager, defaultLimits validation.Limits) {
 	a.indexPage.AddLink(SectionAdminEndpoints, "/runtime_config", "Current Runtime Config (incl. Overrides)")
+	a.indexPage.AddLink(SectionAdminEndpoints, "/runtime_config?mode=diff", "Current Runtime Config (show only values that differ from the defaults)")
 
-	a.RegisterRoute("/runtime_config", runtimeConfigHandler(runtimeCfgManager), false, "GET")
+	a.RegisterRoute("/runtime_config", runtimeConfigHandler(runtimeCfgManager, defaultLimits), false, "GET")
 }
 
 // RegisterDistributor registers the endpoints associated with the distributor.

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/cortexproject/cortex/pkg/util/validation"
 	"html/template"
 	"net/http"
 	"path"
@@ -34,6 +33,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/querier/stats"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
+	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 const (
@@ -249,7 +249,6 @@ func runtimeConfigHandler(runtimeCfgManager *runtimeconfig.Manager, defaultLimit
 		}
 		switch r.URL.Query().Get("mode") {
 		case "diff":
-			output = nil
 			defaultLimitsObj, err := yamlMarshalUnmarshal(defaultLimits)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -159,7 +159,7 @@ func (t *Cortex) initRuntimeConfig() (services.Service, error) {
 
 	serv, err := runtimeconfig.NewRuntimeConfigManager(t.Cfg.RuntimeConfig, prometheus.DefaultRegisterer)
 	t.RuntimeConfig = serv
-	t.API.RegisterRuntimeConfig(t.RuntimeConfig)
+	t.API.RegisterRuntimeConfig(t.RuntimeConfig, t.Cfg.LimitsConfig)
 	return serv, err
 }
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -159,7 +159,7 @@ func (t *Cortex) initRuntimeConfig() (services.Service, error) {
 
 	serv, err := runtimeconfig.NewRuntimeConfigManager(t.Cfg.RuntimeConfig, prometheus.DefaultRegisterer)
 	t.RuntimeConfig = serv
-	t.API.RegisterRuntimeConfig(t.RuntimeConfig, t.Cfg.LimitsConfig)
+	t.API.RegisterRuntimeConfig(runtimeConfigHandler(t.RuntimeConfig, t.Cfg.LimitsConfig))
 	return serv, err
 }
 

--- a/pkg/cortex/runtime_config.go
+++ b/pkg/cortex/runtime_config.go
@@ -3,10 +3,12 @@ package cortex
 import (
 	"errors"
 	"io"
+	"net/http"
 
 	"gopkg.in/yaml.v2"
 
 	"github.com/cortexproject/cortex/pkg/ring/kv"
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/runtimeconfig"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
@@ -81,5 +83,60 @@ func multiClientRuntimeConfigChannel(manager *runtimeconfig.Manager) func() <-ch
 		}()
 
 		return outCh
+	}
+}
+
+func diffLimitsConfig(defaultConfig, actualConfig map[interface{}]interface{}) (map[interface{}]interface{}, error) {
+	output := make(map[interface{}]interface{})
+	for tenant, tenantValues := range actualConfig {
+		tenantValuesObj, err := util.YAMLMarshalUnmarshal(tenantValues)
+		if err != nil {
+			return nil, err
+		}
+		tenantDiff, err := util.DiffConfig(defaultConfig, tenantValuesObj)
+		if err != nil {
+			return nil, err
+		}
+		output[tenant] = tenantDiff
+	}
+	return output, nil
+}
+
+func runtimeConfigHandler(runtimeCfgManager *runtimeconfig.Manager, defaultLimits validation.Limits) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var output interface{}
+		runtimeConfig := runtimeCfgManager.GetConfig()
+		if runtimeConfig == nil {
+			util.WriteTextResponse(w, "runtime config file doesn't exist")
+			return
+		}
+		switch r.URL.Query().Get("mode") {
+		case "diff":
+			defaultLimitsObj, err := util.YAMLMarshalUnmarshal(defaultLimits)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			runtimeCfgObj, err := util.YAMLMarshalUnmarshal(runtimeConfig)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			limitsCfgObj, err := util.YAMLMarshalUnmarshal(runtimeCfgObj["overrides"])
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			limitsDiff, err := diffLimitsConfig(defaultLimitsObj, limitsCfgObj)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			runtimeCfgObj["overrides"] = limitsDiff
+			output = runtimeCfgObj
+		default:
+			output = runtimeConfig
+		}
+		util.WriteYAMLResponse(w, output)
 	}
 }

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -1,0 +1,64 @@
+package util
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// DiffConfig utility function that returns the diff between two config map objects
+func DiffConfig(defaultConfig, actualConfig map[interface{}]interface{}) (map[interface{}]interface{}, error) {
+	output := make(map[interface{}]interface{})
+
+	for key, value := range actualConfig {
+
+		defaultValue, ok := defaultConfig[key]
+		if !ok {
+			output[key] = value
+			continue
+		}
+
+		switch v := value.(type) {
+		case int:
+			defaultV, ok := defaultValue.(int)
+			if !ok || defaultV != v {
+				output[key] = v
+			}
+		case string:
+			defaultV, ok := defaultValue.(string)
+			if !ok || defaultV != v {
+				output[key] = v
+			}
+		case bool:
+			defaultV, ok := defaultValue.(bool)
+			if !ok || defaultV != v {
+				output[key] = v
+			}
+		case []interface{}:
+			defaultV, ok := defaultValue.([]interface{})
+			if !ok || !reflect.DeepEqual(defaultV, v) {
+				output[key] = v
+			}
+		case float64:
+			defaultV, ok := defaultValue.(float64)
+			if !ok || !reflect.DeepEqual(defaultV, v) {
+				output[key] = v
+			}
+		case map[interface{}]interface{}:
+			defaultV, ok := defaultValue.(map[interface{}]interface{})
+			if !ok {
+				output[key] = value
+			}
+			diff, err := DiffConfig(defaultV, v)
+			if err != nil {
+				return nil, err
+			}
+			if len(diff) > 0 {
+				output[key] = diff
+			}
+		default:
+			return nil, fmt.Errorf("unsupported type %T", v)
+		}
+	}
+
+	return output, nil
+}

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -43,6 +43,10 @@ func DiffConfig(defaultConfig, actualConfig map[interface{}]interface{}) (map[in
 			if !ok || !reflect.DeepEqual(defaultV, v) {
 				output[key] = v
 			}
+		case nil:
+			if defaultValue != nil {
+				output[key] = v
+			}
 		case map[interface{}]interface{}:
 			defaultV, ok := defaultValue.(map[interface{}]interface{})
 			if !ok {

--- a/pkg/util/yaml.go
+++ b/pkg/util/yaml.go
@@ -1,0 +1,19 @@
+package util
+
+import "gopkg.in/yaml.v2"
+
+// YAMLMarshalUnmarshal utility function that converts a YAML interface in a map
+// doing marshal and unmarshal of the parameter
+func YAMLMarshalUnmarshal(in interface{}) (map[interface{}]interface{}, error) {
+	yamlBytes, err := yaml.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+
+	object := make(map[interface{}]interface{})
+	if err := yaml.Unmarshal(yamlBytes, object); err != nil {
+		return nil, err
+	}
+
+	return object, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR introduces a new parameter for the `/runtime_config` endpoint that will allow the user to filter the outcome and just get the non-default values of the runtime configuration.

I've tried to add tests for the `runtimeConfigurationHandler` but given that the handler depends on `runtimeConfigManager`  the tests become very complex unless we're able to mock the `runtimeConfigManager`

**Which issue(s) this PR fixes**:
Fixes #3672

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
