### PR TITLE
Do not log "failed to load config" if runtime config file is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * [BUGFIX] Ruler: Ensure the stale markers generated for evaluated rules respect the configured `-ruler.evaluation-delay-duration`. This will avoid issues with samples with NaN be persisted with timestamps set ahead of the next rule evaluation. #3687
 * [BUGFIX] Alertmanager: don't serve HTTP requests until Alertmanager has fully started. Serving HTTP requests earlier may result in loss of configuration for the user. #3679
 * [BUGFIX] Do not log "failed to load config" if runtime config file is empty. #3706
+* [BUGFIX] Do not allow to use a runtime config file containing multiple YAML documents. #3706
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [BUGFIX] Query-Frontend: avoid creating many small sub-queries by discarding cache extents under 5 minutes #3653
 * [BUGFIX] Ruler: Ensure the stale markers generated for evaluated rules respect the configured `-ruler.evaluation-delay-duration`. This will avoid issues with samples with NaN be persisted with timestamps set ahead of the next rule evaluation. #3687
 * [BUGFIX] Alertmanager: don't serve HTTP requests until Alertmanager has fully started. Serving HTTP requests earlier may result in loss of configuration for the user. #3679
+* [BUGFIX] Do not log "failed to load config" if runtime config file is empty. #3706
 
 ## 1.6.0
 

--- a/pkg/cortex/runtime_config.go
+++ b/pkg/cortex/runtime_config.go
@@ -31,8 +31,7 @@ func loadRuntimeConfig(r io.Reader) (interface{}, error) {
 	decoder.SetStrict(true)
 
 	// Decode the first document. An empty document (EOF) is OK.
-	err := decoder.Decode(&overrides)
-	if err != nil && !errors.Is(err, io.EOF) {
+	if err := decoder.Decode(&overrides); err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 

--- a/pkg/cortex/runtime_config.go
+++ b/pkg/cortex/runtime_config.go
@@ -35,7 +35,7 @@ func loadRuntimeConfig(r io.Reader) (interface{}, error) {
 		return nil, err
 	}
 
-	// Ensure the provided YAML config is not composed by multiple documents,
+	// Ensure the provided YAML config is not composed of multiple documents,
 	if err := decoder.Decode(&runtimeConfigValues{}); !errors.Is(err, io.EOF) {
 		return nil, errMultipleDocuments
 	}

--- a/pkg/cortex/runtime_config.go
+++ b/pkg/cortex/runtime_config.go
@@ -2,6 +2,7 @@ package cortex
 
 import (
 	"io"
+	"io/ioutil"
 
 	"gopkg.in/yaml.v2"
 
@@ -20,11 +21,13 @@ type runtimeConfigValues struct {
 }
 
 func loadRuntimeConfig(r io.Reader) (interface{}, error) {
-	var overrides = &runtimeConfigValues{}
+	content, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
 
-	decoder := yaml.NewDecoder(r)
-	decoder.SetStrict(true)
-	if err := decoder.Decode(&overrides); err != nil {
+	var overrides = &runtimeConfigValues{}
+	if err := yaml.UnmarshalStrict(content, overrides); err != nil {
 		return nil, err
 	}
 

--- a/pkg/cortex/runtime_config_test.go
+++ b/pkg/cortex/runtime_config_test.go
@@ -59,3 +59,41 @@ func TestLoadRuntimeConfig_ShouldLoadEmptyFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, &runtimeConfigValues{}, actual)
 }
+
+func TestLoadRuntimeConfig_ShouldReturnErrorOnMultipleDocumentsInTheConfig(t *testing.T) {
+	cases := []string{
+		`
+---
+---
+`, `
+---
+overrides:
+  '1234':
+    ingestion_burst_size: 123
+---
+overrides:
+  '1234':
+    ingestion_burst_size: 123
+`, `
+---
+# This is an empty YAML.
+---
+overrides:
+  '1234':
+    ingestion_burst_size: 123
+`, `
+---
+overrides:
+  '1234':
+    ingestion_burst_size: 123
+---
+# This is an empty YAML.
+`,
+	}
+
+	for _, tc := range cases {
+		actual, err := loadRuntimeConfig(strings.NewReader(tc))
+		assert.Equal(t, errMultipleDocuments, err)
+		assert.Nil(t, actual)
+	}
+}

--- a/pkg/cortex/runtime_config_test.go
+++ b/pkg/cortex/runtime_config_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/util/validation"
@@ -12,7 +13,7 @@ import (
 // Given limits are usually loaded via a config file, and that
 // a configmap is limited to 1MB, we need to minimise the limits file.
 // One way to do it is via YAML anchors.
-func TestLoadingAnchoredRuntimeYAML(t *testing.T) {
+func TestLoadRuntimeConfig_ShouldLoadAnchoredYAML(t *testing.T) {
 	yamlFile := strings.NewReader(`
 overrides:
   '1234': &id001
@@ -48,4 +49,13 @@ overrides:
 	require.Equal(t, limits, *loadedLimits["1234"])
 	require.Equal(t, limits, *loadedLimits["1235"])
 	require.Equal(t, limits, *loadedLimits["1236"])
+}
+
+func TestLoadRuntimeConfig_ShouldLoadEmptyFile(t *testing.T) {
+	yamlFile := strings.NewReader(`
+# This is an empty YAML.
+`)
+	actual, err := loadRuntimeConfig(yamlFile)
+	require.NoError(t, err)
+	assert.Equal(t, &runtimeConfigValues{}, actual)
 }

--- a/pkg/util/runtimeconfig/manager.go
+++ b/pkg/util/runtimeconfig/manager.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -148,14 +148,14 @@ func (om *Manager) loadConfig() error {
 	buf, err := ioutil.ReadFile(om.cfg.LoadPath)
 	if err != nil {
 		om.configLoadSuccess.Set(0)
-		return err
+		return errors.Wrap(err, "read file")
 	}
 	hash := sha256.Sum256(buf)
 
 	cfg, err := om.cfg.Loader(bytes.NewReader(buf))
 	if err != nil {
 		om.configLoadSuccess.Set(0)
-		return err
+		return errors.Wrap(err, "load file")
 	}
 	om.configLoadSuccess.Set(1)
 


### PR DESCRIPTION
**What this PR does**:
We recently introduced an empty `runtime.yaml` in the local dev env setup `development/tsdb-blocks-storage-s3/config/`, but I've just realised the config fails to load because empty (no YAML node). Should an empty config be legit? If so, then this PR fixes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
