### PR TITLE
Fail to startup Cortex if provided runtime config is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [ENHANCEMENT] Disabled in-memory shuffle-sharding subring cache in the store-gateway, ruler and compactor. This should reduce the memory utilisation in these services when shuffle-sharding is enabled, without introducing a significantly increase CPU utilisation. #3601
 * [ENHANCEMENT] Shuffle sharding: optimised subring generation used by shuffle sharding. #3601
 * [ENHANCEMENT] New /runtime_config endpoint that returns the defined runtime configuration in YAML format. The returned configuration includes overrides. #3639
+* [ENHANCEMENT] Fail to startup Cortex if provided runtime config is invalid. #3707
 * [BUGFIX] Allow `-querier.max-query-lookback` use `y|w|d` suffix like deprecated `-store.max-look-back-period`. #3598
 * [BUGFIX] Memberlist: Entry in the ring should now not appear again after using "Forget" feature (unless it's still heartbeating). #3603
 * [BUGFIX] Ingester: do not close idle TSDBs while blocks shipping is in progress. #3630

--- a/pkg/util/runtimeconfig/manager.go
+++ b/pkg/util/runtimeconfig/manager.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -74,18 +74,16 @@ func NewRuntimeConfigManager(cfg ManagerConfig, registerer prometheus.Registerer
 		}, []string{"sha256"}),
 	}
 
-	mgr.Service = services.NewBasicService(mgr.start, mgr.loop, mgr.stop)
+	mgr.Service = services.NewBasicService(mgr.starting, mgr.loop, mgr.stopping)
 	return &mgr, nil
 }
 
-func (om *Manager) start(_ context.Context) error {
-	if om.cfg.LoadPath != "" {
-		if err := om.loadConfig(); err != nil {
-			// Log but don't stop on error - we don't want to halt all ingesters because of a typo
-			level.Error(util.Logger).Log("msg", "failed to load config", "err", err)
-		}
+func (om *Manager) starting(_ context.Context) error {
+	if om.cfg.LoadPath == "" {
+		return nil
 	}
-	return nil
+
+	return errors.Wrap(om.loadConfig(), "failed to load runtime config")
 }
 
 // CreateListenerChannel creates new channel that can be used to receive new config values.
@@ -190,7 +188,7 @@ func (om *Manager) callListeners(newValue interface{}) {
 }
 
 // Stop stops the Manager
-func (om *Manager) stop(_ error) error {
+func (om *Manager) stopping(_ error) error {
 	om.listenersMtx.Lock()
 	defer om.listenersMtx.Unlock()
 

--- a/pkg/util/runtimeconfig/manager_test.go
+++ b/pkg/util/runtimeconfig/manager_test.go
@@ -111,7 +111,7 @@ func TestNewOverridesManager(t *testing.T) {
 	require.NotNil(t, overridesManager.GetConfig())
 }
 
-func TestOverridesManager_ListenerWithDefaultLimits(t *testing.T) {
+func TestManager_ListenerWithDefaultLimits(t *testing.T) {
 	tempFile, err := ioutil.TempFile("", "test-validation")
 	require.NoError(t, err)
 	require.NoError(t, tempFile.Close())
@@ -195,7 +195,7 @@ func TestOverridesManager_ListenerWithDefaultLimits(t *testing.T) {
 	require.NotNil(t, overridesManager.GetConfig())
 }
 
-func TestOverridesManager_ListenerChannel(t *testing.T) {
+func TestManager_ListenerChannel(t *testing.T) {
 	config, overridesManagerConfig := newTestOverridesManagerConfig(t, 555)
 
 	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, nil)
@@ -235,7 +235,7 @@ func TestOverridesManager_ListenerChannel(t *testing.T) {
 	}
 }
 
-func TestOverridesManager_StopClosesListenerChannels(t *testing.T) {
+func TestManager_StopClosesListenerChannels(t *testing.T) {
 	_, overridesManagerConfig := newTestOverridesManagerConfig(t, 555)
 
 	overridesManager, err := NewRuntimeConfigManager(overridesManagerConfig, nil)
@@ -253,4 +253,28 @@ func TestOverridesManager_StopClosesListenerChannels(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("channel not closed")
 	}
+}
+
+func TestManager_ShouldFastFailOnInvalidConfigAtStartup(t *testing.T) {
+	// Create an invalid runtime config file.
+	tempFile, err := ioutil.TempFile("", "invalid-config")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.Remove(tempFile.Name()))
+	})
+
+	_, err = tempFile.Write([]byte("!invalid!"))
+	require.NoError(t, err)
+	require.NoError(t, tempFile.Close())
+
+	// Create the config manager and start it.
+	cfg := ManagerConfig{
+		ReloadPeriod: time.Second,
+		LoadPath:     tempFile.Name(),
+		Loader:       testLoadOverrides,
+	}
+
+	m, err := NewRuntimeConfigManager(cfg, nil)
+	require.NoError(t, err)
+	require.Error(t, services.StartAndAwaitRunning(context.Background(), m))
 }


### PR DESCRIPTION
**What this PR does**:
Currently, Cortex can successfully startup if the provided runtime config (typically limits overrides) is invalid. We recently had an incident because of this: we rolled out ingesters with an invalid runtime config, ingesters start up correctly, but overrides were missing causing an impact on customers. Other alerts fired pretty soon, so the impact of the incident was limited.

As a retrospective, I believe we should fast fail Cortex at startup if the provided runtime config is invalid. For example, in the case of a rolling update, ingesters would stop to rollout until fixed.

I haven't changed the behaviour of an invalid config loaded while Cortex is running because, in that case, we keep the previous config and we definitely don't want to shutdown all ingesters because of this.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
