### PR TITLE
Add info about cortex-tenant to the docs in Auth guide

### DIFF
--- a/docs/guides/authentication-and-authorisation.md
+++ b/docs/guides/authentication-and-authorisation.md
@@ -20,6 +20,7 @@ which identify them and confirm they are authorised.
 When configuring the `remote_write` API in Prometheus there is no way to
 add extra headers. The user and password fields of http Basic auth, or
 Bearer token, can be used to convey the tenant ID and/or credentials.
+See the **Cortex-Tenant** section below for one way to solve this.
 
 To disable the multi-tenant functionality, you can pass the argument
 `-auth.enabled=false` to every Cortex component, which will set the OrgID
@@ -30,3 +31,14 @@ should be the same as the one you use to query the data. If they don't match
 you won't see any data. As of now, you can't see series from other tenants.
 
 For more information regarding the tenant ID limits, refer to: [Tenant ID limitations](./limitations.md#tenant-id-naming)
+
+### Cortex-Tenant
+
+One way to add `X-Scope-OrgID` to Prometheus requests is to use a [cortex-tenant](https://github.com/blind-oracle/cortex-tenant)
+proxy which is able to extract the tenant ID from Prometheus labels.
+
+It can be placed between Prometheus and Cortex and will search for a predefined
+label and use its value as `X-Scope-OrgID` header when proxying the timeseries to Cortex.
+
+This can help to run Cortex in a trusted environment where you want to separate your metrics
+into distinct namespaces by some criteria (teams, applications etc)

--- a/docs/guides/authentication-and-authorisation.md
+++ b/docs/guides/authentication-and-authorisation.md
@@ -43,4 +43,4 @@ label and use its value as `X-Scope-OrgID` header when proxying the timeseries t
 This can help to run Cortex in a trusted environment where you want to separate your metrics
 into distinct namespaces by some criteria (e.g. teams, applications, etc).
 
-Be advised that **cortex-tenant** is a third-party comminity project and it's not maintained by Cortex team.
+Be advised that **cortex-tenant** is a third-party community project and it's not maintained by Cortex team.

--- a/docs/guides/authentication-and-authorisation.md
+++ b/docs/guides/authentication-and-authorisation.md
@@ -41,4 +41,6 @@ It can be placed between Prometheus and Cortex and will search for a predefined
 label and use its value as `X-Scope-OrgID` header when proxying the timeseries to Cortex.
 
 This can help to run Cortex in a trusted environment where you want to separate your metrics
-into distinct namespaces by some criteria (teams, applications etc)
+into distinct namespaces by some criteria (e.g. teams, applications, etc).
+
+Be advised that **cortex-tenant** is a third-party comminity project and it's not maintained by Cortex team.


### PR DESCRIPTION
**What this PR does**:
Adds a section in Auth guide that mentions cortex-tenant proxy that can be used to add tenant headers to Prometheus write requests based on labels.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
