### PR TITLE
reduce file permissions as per gosec recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Reduce permissions on all files and directories created by cortex to just the user it executes as. #3713
 * [CHANGE] Ruler: removed the flag `-ruler.evaluation-delay-duration-deprecated` which was deprecated in 1.4.0. Please use the `ruler_evaluation_delay_duration` per-tenant limit instead. #3693
 * [CHANGE] Removed the flags `-<prefix>.grpc-use-gzip-compression` which were deprecated in 1.3.0: #3693
   * `-query-scheduler.grpc-client-config.grpc-use-gzip-compression`: use `-query-scheduler.grpc-client-config.grpc-compression` instead

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -262,7 +262,7 @@ type MultitenantAlertmanager struct {
 
 // NewMultitenantAlertmanager creates a new MultitenantAlertmanager.
 func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig, logger log.Logger, registerer prometheus.Registerer) (*MultitenantAlertmanager, error) {
-	err := os.MkdirAll(cfg.DataDir, 0777)
+	err := os.MkdirAll(cfg.DataDir, 0700)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Alertmanager data directory %q: %s", cfg.DataDir, err)
 	}
@@ -817,7 +817,7 @@ func createTemplateFile(dataDir, userID, fn, content string) (bool, error) {
 	}
 
 	dir := filepath.Join(dataDir, "templates", userID, filepath.Dir(fn))
-	err := os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, 0700)
 	if err != nil {
 		return false, fmt.Errorf("unable to create Alertmanager templates directory %q: %s", dir, err)
 	}
@@ -828,7 +828,7 @@ func createTemplateFile(dataDir, userID, fn, content string) (bool, error) {
 		return false, nil
 	}
 
-	if err := ioutil.WriteFile(file, []byte(content), 0644); err != nil {
+	if err := ioutil.WriteFile(file, []byte(content), 0600); err != nil {
 		return false, fmt.Errorf("unable to create Alertmanager template file %q: %s", file, err)
 	}
 

--- a/pkg/chunk/local/boltdb_table_client.go
+++ b/pkg/chunk/local/boltdb_table_client.go
@@ -36,7 +36,7 @@ func (c *TableClient) ListTables(ctx context.Context) ([]string, error) {
 }
 
 func (c *TableClient) CreateTable(ctx context.Context, desc chunk.TableDesc) error {
-	file, err := os.OpenFile(filepath.Join(c.directory, desc.Name), os.O_CREATE|os.O_RDONLY, 0666)
+	file, err := os.OpenFile(filepath.Join(c.directory, desc.Name), os.O_CREATE|os.O_RDONLY, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/chunk/local/fs_object_client.go
+++ b/pkg/chunk/local/fs_object_client.go
@@ -75,7 +75,7 @@ func (f *FSObjectClient) PutObject(_ context.Context, objectKey string, object i
 		return err
 	}
 
-	fl, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	fl, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/chunk/util/util.go
+++ b/pkg/chunk/util/util.go
@@ -121,7 +121,7 @@ func QueryFilter(callback Callback) Callback {
 func EnsureDirectory(dir string) error {
 	info, err := os.Stat(dir)
 	if os.IsNotExist(err) {
-		return os.MkdirAll(dir, 0777)
+		return os.MkdirAll(dir, 0700)
 	} else if err == nil && !info.IsDir() {
 		return fmt.Errorf("not a directory: %s", dir)
 	}

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -295,7 +295,7 @@ func (w *walWrapper) performCheckpoint(immediate bool) (err error) {
 	level.Info(util.Logger).Log("msg", "attempting checkpoint for", "dir", checkpointDir)
 	checkpointDirTemp := checkpointDir + ".tmp"
 
-	if err := os.MkdirAll(checkpointDirTemp, 0777); err != nil {
+	if err := os.MkdirAll(checkpointDirTemp, 0700); err != nil {
 		return errors.Wrap(err, "create checkpoint dir")
 	}
 	checkpoint, err := wal.New(nil, nil, checkpointDirTemp, false)

--- a/tools/blocksconvert/builder/tsdb.go
+++ b/tools/blocksconvert/builder/tsdb.go
@@ -71,7 +71,7 @@ func newTsdbBuilder(outDir string, start, end time.Time, seriesBatchLimit int, l
 	}
 
 	// Also makes blockDir, if missing
-	err = os.MkdirAll(seriesDir, 0777)
+	err = os.MkdirAll(seriesDir, 0700)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/blocksconvert/scanner/files.go
+++ b/tools/blocksconvert/scanner/files.go
@@ -61,7 +61,7 @@ func (of *openFiles) getFile(dir, filename string, headerFn func() interface{}) 
 			return nil, err
 		}
 
-		fl, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		fl, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does**:
`gosec` reports that directories and files created by cortex have too open permissions associated with it.
This CR follows the `gosec` recommendation, limiting all file and directory permissions flagged to just the user the cortex process runs on, following the Principle of Least Privilege.

In most cases this shouldn't create an issue; I'd expect production deployments to execute the cortex binary as a dedicated user already. Similarly for development purposes it's easy to assume the correct user to allow access to files for ie debugging purposes.

Unless this change raises a red flag somewhere I think we should consider adding the `gosec` testing `301`, `302` and `306` specifically to the GH workflow to ensure we don't regress.

**Which issue(s) this PR fixes**:

**Checklist**
~- [ ] Tests updated~
~- [ ] Documentation added~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
