### PR TITLE
Improve bucket index loader to handle edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
   * `cortex_alertmanager_sync_configs_failed_total`
   * `cortex_alertmanager_tenants_discovered`
   * `cortex_alertmanager_tenants_owned`
-* [ENHANCEMENT] Blocks storage: introduced a per-tenant bucket index, periodically updated by the compactor, used to avoid full bucket scanning done by queriers, store-gateways and rulers. The bucket index is updated by the compactor during blocks cleanup, on every `-compactor.cleanup-interval`. #3553 #3555 #3561 #3583 #3625 #3711
+* [ENHANCEMENT] Blocks storage: introduced a per-tenant bucket index, periodically updated by the compactor, used to avoid full bucket scanning done by queriers, store-gateways and rulers. The bucket index is updated by the compactor during blocks cleanup, on every `-compactor.cleanup-interval`. #3553 #3555 #3561 #3583 #3625 #3711 #3715
 * [ENHANCEMENT] Blocks storage: introduced an option `-blocks-storage.bucket-store.bucket-index.enabled` to enable the usage of the bucket index in the querier, store-gateway and ruler. When enabled, the querier, store-gateway and ruler will use the bucket index to find a tenant's blocks instead of running the periodic bucket scan. The following new metrics are exported by the querier and ruler: #3614 #3625
   * `cortex_bucket_index_loads_total`
   * `cortex_bucket_index_load_failures_total`

--- a/pkg/storage/tsdb/bucketindex/loader_test.go
+++ b/pkg/storage/tsdb/bucketindex/loader_test.go
@@ -97,6 +97,45 @@ func TestLoader_GetIndex_ShouldCacheError(t *testing.T) {
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
 	})
 
+	// Write a corrupted index.
+	require.NoError(t, bkt.Upload(ctx, path.Join("user-1", IndexCompressedFilename), strings.NewReader("invalid!}")))
+
+	// Request the index multiple times.
+	for i := 0; i < 10; i++ {
+		_, err := loader.GetIndex(ctx, "user-1")
+		require.Equal(t, ErrIndexCorrupted, err)
+	}
+
+	// Ensure metrics have been updated accordingly.
+	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+		# HELP cortex_bucket_index_load_failures_total Total number of bucket index loading failures.
+		# TYPE cortex_bucket_index_load_failures_total counter
+		cortex_bucket_index_load_failures_total 1
+		# HELP cortex_bucket_index_loaded Number of bucket indexes currently loaded in-memory.
+		# TYPE cortex_bucket_index_loaded gauge
+		cortex_bucket_index_loaded 0
+		# HELP cortex_bucket_index_loads_total Total number of bucket index loading attempts.
+		# TYPE cortex_bucket_index_loads_total counter
+		cortex_bucket_index_loads_total 1
+	`),
+		"cortex_bucket_index_loads_total",
+		"cortex_bucket_index_load_failures_total",
+		"cortex_bucket_index_loaded",
+	))
+}
+
+func TestLoader_GetIndex_ShouldCacheIndexNotFoundError(t *testing.T) {
+	ctx := context.Background()
+	reg := prometheus.NewPedanticRegistry()
+	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+
+	// Create the loader.
+	loader := NewLoader(prepareLoaderConfig(), bkt, log.NewNopLogger(), reg)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, loader))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
+	})
+
 	// Request the index multiple times.
 	for i := 0; i < 10; i++ {
 		_, err := loader.GetIndex(ctx, "user-1")
@@ -107,7 +146,7 @@ func TestLoader_GetIndex_ShouldCacheError(t *testing.T) {
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 		# HELP cortex_bucket_index_load_failures_total Total number of bucket index loading failures.
 		# TYPE cortex_bucket_index_load_failures_total counter
-		cortex_bucket_index_load_failures_total 1
+		cortex_bucket_index_load_failures_total 0
 		# HELP cortex_bucket_index_loaded Number of bucket indexes currently loaded in-memory.
 		# TYPE cortex_bucket_index_loaded gauge
 		cortex_bucket_index_loaded 0
@@ -191,11 +230,67 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousLoadFailure(t *testing.T)
 	reg := prometheus.NewPedanticRegistry()
 	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
 
+	// Write a corrupted index.
+	require.NoError(t, bkt.Upload(ctx, path.Join("user-1", IndexCompressedFilename), strings.NewReader("invalid!}")))
+
 	// Create the loader.
 	cfg := LoaderConfig{
 		CheckInterval:         time.Second,
 		UpdateOnStaleInterval: time.Hour, // Intentionally high to not hit it.
 		UpdateOnErrorInterval: time.Second,
+		IdleTimeout:           time.Hour, // Intentionally high to not hit it.
+	}
+
+	loader := NewLoader(cfg, bkt, log.NewNopLogger(), reg)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, loader))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
+	})
+
+	_, err := loader.GetIndex(ctx, "user-1")
+	assert.Equal(t, ErrIndexCorrupted, err)
+
+	// Upload the bucket index.
+	idx := &Index{
+		Version: IndexVersion1,
+		Blocks: Blocks{
+			{ID: ulid.MustNew(1, nil), MinTime: 10, MaxTime: 20},
+		},
+		BlockDeletionMarks: nil,
+		UpdatedAt:          time.Now().Unix(),
+	}
+	require.NoError(t, WriteIndex(ctx, bkt, "user-1", idx))
+
+	// Wait until the index has been updated in background.
+	test.Poll(t, 3*time.Second, nil, func() interface{} {
+		_, err := loader.GetIndex(ctx, "user-1")
+		return err
+	})
+
+	actualIdx, err := loader.GetIndex(ctx, "user-1")
+	require.NoError(t, err)
+	assert.Equal(t, idx, actualIdx)
+
+	// Ensure metrics have been updated accordingly.
+	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+		# HELP cortex_bucket_index_loaded Number of bucket indexes currently loaded in-memory.
+		# TYPE cortex_bucket_index_loaded gauge
+		cortex_bucket_index_loaded 1
+	`),
+		"cortex_bucket_index_loaded",
+	))
+}
+
+func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousIndexNotFound(t *testing.T) {
+	ctx := context.Background()
+	reg := prometheus.NewPedanticRegistry()
+	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+
+	// Create the loader.
+	cfg := LoaderConfig{
+		CheckInterval:         time.Second,
+		UpdateOnStaleInterval: time.Second,
+		UpdateOnErrorInterval: time.Hour, // Intentionally high to not hit it.
 		IdleTimeout:           time.Hour, // Intentionally high to not hit it.
 	}
 
@@ -239,7 +334,7 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousLoadFailure(t *testing.T)
 	))
 }
 
-func TestLoader_ShouldNotCacheErrorOnBackgroundUpdates(t *testing.T) {
+func TestLoader_ShouldNotCacheCriticalErrorOnBackgroundUpdates(t *testing.T) {
 	ctx := context.Background()
 	reg := prometheus.NewPedanticRegistry()
 	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
@@ -293,6 +388,66 @@ func TestLoader_ShouldNotCacheErrorOnBackgroundUpdates(t *testing.T) {
 	`),
 		"cortex_bucket_index_loaded",
 	))
+}
+
+func TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates(t *testing.T) {
+	ctx := context.Background()
+	reg := prometheus.NewPedanticRegistry()
+	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+
+	// Create a bucket index.
+	idx := &Index{
+		Version: IndexVersion1,
+		Blocks: Blocks{
+			{ID: ulid.MustNew(1, nil), MinTime: 10, MaxTime: 20},
+		},
+		BlockDeletionMarks: nil,
+		UpdatedAt:          time.Now().Unix(),
+	}
+	require.NoError(t, WriteIndex(ctx, bkt, "user-1", idx))
+
+	// Create the loader.
+	cfg := LoaderConfig{
+		CheckInterval:         time.Second,
+		UpdateOnStaleInterval: time.Second,
+		UpdateOnErrorInterval: time.Second,
+		IdleTimeout:           time.Hour, // Intentionally high to not hit it.
+	}
+
+	loader := NewLoader(cfg, bkt, log.NewNopLogger(), reg)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, loader))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
+	})
+
+	actualIdx, err := loader.GetIndex(ctx, "user-1")
+	require.NoError(t, err)
+	assert.Equal(t, idx, actualIdx)
+
+	// Delete the bucket index.
+	require.NoError(t, DeleteIndex(ctx, bkt, "user-1"))
+
+	// Wait until the next index load attempt occurs.
+	prevLoads := testutil.ToFloat64(loader.loadAttempts)
+	test.Poll(t, 3*time.Second, true, func() interface{} {
+		return testutil.ToFloat64(loader.loadAttempts) > prevLoads
+	})
+
+	// We expect the bucket index is not considered loaded because of the error.
+	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+			# HELP cortex_bucket_index_loaded Number of bucket indexes currently loaded in-memory.
+			# TYPE cortex_bucket_index_loaded gauge
+			cortex_bucket_index_loaded 0
+		`),
+		"cortex_bucket_index_loaded",
+	))
+
+	// Try to get the index again. We expect no load attempt because the error has been cached.
+	prevLoads = testutil.ToFloat64(loader.loadAttempts)
+	actualIdx, err = loader.GetIndex(ctx, "user-1")
+	assert.Equal(t, ErrIndexNotFound, err)
+	assert.Nil(t, actualIdx)
+	assert.Equal(t, prevLoads, testutil.ToFloat64(loader.loadAttempts))
 }
 
 func TestLoader_ShouldOffloadIndexIfNotFoundDuringBackgroundUpdates(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
While rolling out the bucket index in our of our clusters I've noticed that we have some tenants with rules but not remote writing the cluster (or started very soon to remote write so their blocks haven't been uploaded to bucket yet). Since there are no blocks in the bucket, their bucket index doesn't exist and this leads the `bucketindex.Loader` to continuously try to load their bucket index.

In this PR I'm proposing 3 changes that should relief the pressure when such edge case happens:
- Keep cached the "bucket index not found" error during background checks
- Don't increase `cortex_bucket_index_load_failures_total` on `ErrIndexNotFound` error (we already didn't do in the background check)
- In case of `ErrIndexNotFound`, update it every `UpdateOnStaleInterval` instead of `UpdateOnErrorInterval`

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
