### PR TITLE
Alertmanager: Remove alertmanager instead of pausing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   * Prevent compaction loop in TSDB on data gap.
 * [ENHANCEMENT] Return server side performance metrics for query-frontend (using Server-timing header). #3685
 * [ENHANCEMENT] Runtime Config: Add a `mode` query parameter for the runtime config endpoint. `/runtime_config?mode=diff` now shows the YAML runtime configuration with all values that differ from the defaults. #3700
+* [ENHANCEMENT] Alertmanager: Remove a tenant's alertmanager instead of pausing it as we determine it is no longer needed. #3722
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 
 ## 1.7.0 in progress

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/alertmanager/api"
 	"github.com/prometheus/alertmanager/cluster"
 	"github.com/prometheus/alertmanager/config"
@@ -80,9 +79,6 @@ type Alertmanager struct {
 	// Further, in upstream AM, this metric is handled using the config coordinator which we don't use
 	// hence we need to generate the metric ourselves.
 	configHashMetric prometheus.Gauge
-
-	activeMtx sync.Mutex
-	active    bool
 }
 
 var (
@@ -102,11 +98,9 @@ func init() {
 // New creates a new Alertmanager.
 func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 	am := &Alertmanager{
-		cfg:       cfg,
-		logger:    log.With(cfg.Logger, "user", cfg.UserID),
-		stop:      make(chan struct{}),
-		active:    false,
-		activeMtx: sync.Mutex{},
+		cfg:    cfg,
+		logger: log.With(cfg.Logger, "user", cfg.UserID),
+		stop:   make(chan struct{}),
 		configHashMetric: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "alertmanager_config_hash",
 			Help: "Hash of the currently loaded alertmanager configuration.",
@@ -269,53 +263,8 @@ func (am *Alertmanager) ApplyConfig(userID string, conf *config.Config, rawCfg s
 	go am.dispatcher.Run()
 	go am.inhibitor.Run()
 
-	// Ensure the alertmanager is set to active
-	am.activeMtx.Lock()
-	am.active = true
-	am.activeMtx.Unlock()
-
 	am.configHashMetric.Set(md5HashAsMetricValue([]byte(rawCfg)))
 	return nil
-}
-
-// IsActive returns if the alertmanager is currently running
-// or is paused
-func (am *Alertmanager) IsActive() bool {
-	am.activeMtx.Lock()
-	defer am.activeMtx.Unlock()
-	return am.active
-}
-
-// Pause running jobs in the alertmanager that are able to be restarted and sets
-// to inactives
-func (am *Alertmanager) Pause() {
-	// Set to inactive
-	am.activeMtx.Lock()
-	am.active = false
-	am.activeMtx.Unlock()
-
-	// Stop the inhibitor and dispatcher which will be recreated when
-	// a new config is applied
-	if am.inhibitor != nil {
-		am.inhibitor.Stop()
-		am.inhibitor = nil
-	}
-	if am.dispatcher != nil {
-		am.dispatcher.Stop()
-		am.dispatcher = nil
-	}
-
-	// Remove all of the active silences from the alertmanager
-	silences, _, err := am.silences.Query()
-	if err != nil {
-		level.Warn(am.logger).Log("msg", "unable to retrieve silences for removal", "err", err)
-	}
-	for _, si := range silences {
-		err = am.silences.Expire(si.Id)
-		if err != nil {
-			level.Warn(am.logger).Log("msg", "unable to remove silence", "err", err, "silence", si.Id)
-		}
-	}
 }
 
 // Stop stops the Alertmanager.

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -279,6 +279,10 @@ func (am *Alertmanager) Stop() {
 
 	am.alerts.Close()
 	close(am.stop)
+}
+
+func (am *Alertmanager) StopAndWait() {
+	am.Stop()
 	am.wg.Wait()
 }
 

--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -155,7 +155,9 @@ func (m *alertmanagerMetrics) addUserRegistry(user string, reg *prometheus.Regis
 }
 
 func (m *alertmanagerMetrics) removeUserRegistry(user string) {
-	m.regs.RemoveUserRegistry(user, true)
+	// We neeed to go for a soft deletion here, as hard deletion requires
+	// that _all_ metrics except gauges are per-user.
+	m.regs.RemoveUserRegistry(user, false)
 }
 
 func (m *alertmanagerMetrics) Describe(out chan<- *prometheus.Desc) {

--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -154,6 +154,10 @@ func (m *alertmanagerMetrics) addUserRegistry(user string, reg *prometheus.Regis
 	m.regs.AddUserRegistry(user, reg)
 }
 
+func (m *alertmanagerMetrics) removeUserRegistry(user string) {
+	m.regs.RemoveUserRegistry(user, true)
+}
+
 func (m *alertmanagerMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.alertsReceived
 	out <- m.alertsInvalid

--- a/pkg/alertmanager/alertmanager_metrics_test.go
+++ b/pkg/alertmanager/alertmanager_metrics_test.go
@@ -257,6 +257,226 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAlertmanagerMetricsRemoval(t *testing.T) {
+	mainReg := prometheus.NewPedanticRegistry()
+
+	alertmanagerMetrics := newAlertmanagerMetrics()
+	mainReg.MustRegister(alertmanagerMetrics)
+	alertmanagerMetrics.addUserRegistry("user1", populateAlertmanager(1))
+	alertmanagerMetrics.addUserRegistry("user2", populateAlertmanager(10))
+	alertmanagerMetrics.addUserRegistry("user3", populateAlertmanager(100))
+
+	alertmanagerMetrics.removeUserRegistry("user3")
+
+	//TODO: Verify that these metrics match what I expect.
+	err := testutil.GatherAndCompare(mainReg, bytes.NewBufferString(`
+    		# HELP cortex_alertmanager_alerts How many alerts by state.
+    		# TYPE cortex_alertmanager_alerts gauge
+    		cortex_alertmanager_alerts{state="active",user="user1"} 1
+    		cortex_alertmanager_alerts{state="active",user="user2"} 10
+    		cortex_alertmanager_alerts{state="suppressed",user="user1"} 2
+    		cortex_alertmanager_alerts{state="suppressed",user="user2"} 20
+
+    		# HELP cortex_alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+    		# TYPE cortex_alertmanager_alerts_invalid_total counter
+    		cortex_alertmanager_alerts_invalid_total{user="user1"} 2
+    		cortex_alertmanager_alerts_invalid_total{user="user2"} 20
+
+    		# HELP cortex_alertmanager_alerts_received_total The total number of received alerts.
+    		# TYPE cortex_alertmanager_alerts_received_total counter
+    		cortex_alertmanager_alerts_received_total{user="user1"} 10
+    		cortex_alertmanager_alerts_received_total{user="user2"} 100
+
+    		# HELP cortex_alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+    		# TYPE cortex_alertmanager_config_hash gauge
+    		cortex_alertmanager_config_hash{user="user1"} 0
+    		cortex_alertmanager_config_hash{user="user2"} 0
+
+    		# HELP cortex_alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+    		# TYPE cortex_alertmanager_nflog_gc_duration_seconds summary
+    		cortex_alertmanager_nflog_gc_duration_seconds_sum 11
+    		cortex_alertmanager_nflog_gc_duration_seconds_count 2
+
+    		# HELP cortex_alertmanager_nflog_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
+    		# TYPE cortex_alertmanager_nflog_gossip_messages_propagated_total counter
+    		cortex_alertmanager_nflog_gossip_messages_propagated_total 11
+
+    		# HELP cortex_alertmanager_nflog_queries_total Number of notification log queries were received.
+    		# TYPE cortex_alertmanager_nflog_queries_total counter
+    		cortex_alertmanager_nflog_queries_total 11
+
+    		# HELP cortex_alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+    		# TYPE cortex_alertmanager_nflog_query_duration_seconds histogram
+    		cortex_alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+    		cortex_alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+    		cortex_alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+    		cortex_alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+    		cortex_alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+    		cortex_alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+    		cortex_alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+    		cortex_alertmanager_nflog_query_duration_seconds_bucket{le="1"} 1
+    		cortex_alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 1
+    		cortex_alertmanager_nflog_query_duration_seconds_bucket{le="5"} 1
+    		cortex_alertmanager_nflog_query_duration_seconds_bucket{le="10"} 2
+    		cortex_alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 2
+    		cortex_alertmanager_nflog_query_duration_seconds_sum 11
+    		cortex_alertmanager_nflog_query_duration_seconds_count 2
+
+    		# HELP cortex_alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+    		# TYPE cortex_alertmanager_nflog_query_errors_total counter
+    		cortex_alertmanager_nflog_query_errors_total 11
+
+    		# HELP cortex_alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+    		# TYPE cortex_alertmanager_nflog_snapshot_duration_seconds summary
+    		cortex_alertmanager_nflog_snapshot_duration_seconds_sum 11
+    		cortex_alertmanager_nflog_snapshot_duration_seconds_count 2
+
+    		# HELP cortex_alertmanager_nflog_snapshot_size_bytes Size of the last notification log snapshot in bytes.
+    		# TYPE cortex_alertmanager_nflog_snapshot_size_bytes gauge
+    		cortex_alertmanager_nflog_snapshot_size_bytes 11
+
+    		# HELP cortex_alertmanager_notification_latency_seconds The latency of notifications in seconds.
+    		# TYPE cortex_alertmanager_notification_latency_seconds histogram
+    		cortex_alertmanager_notification_latency_seconds_bucket{le="1"} 13
+    		cortex_alertmanager_notification_latency_seconds_bucket{le="5"} 16
+    		cortex_alertmanager_notification_latency_seconds_bucket{le="10"} 16
+    		cortex_alertmanager_notification_latency_seconds_bucket{le="15"} 16
+    		cortex_alertmanager_notification_latency_seconds_bucket{le="20"} 16
+    		cortex_alertmanager_notification_latency_seconds_bucket{le="+Inf"} 16
+    		cortex_alertmanager_notification_latency_seconds_sum 7.7
+    		cortex_alertmanager_notification_latency_seconds_count 16
+
+    		# HELP cortex_alertmanager_notification_requests_failed_total The total number of failed notification requests.
+    		# TYPE cortex_alertmanager_notification_requests_failed_total counter
+    		cortex_alertmanager_notification_requests_failed_total{integration="email",user="user1"} 0
+    		cortex_alertmanager_notification_requests_failed_total{integration="email",user="user2"} 0
+    		cortex_alertmanager_notification_requests_failed_total{integration="opsgenie",user="user1"} 5
+    		cortex_alertmanager_notification_requests_failed_total{integration="opsgenie",user="user2"} 50
+    		cortex_alertmanager_notification_requests_failed_total{integration="pagerduty",user="user1"} 1
+    		cortex_alertmanager_notification_requests_failed_total{integration="pagerduty",user="user2"} 10
+    		cortex_alertmanager_notification_requests_failed_total{integration="pushover",user="user1"} 3
+    		cortex_alertmanager_notification_requests_failed_total{integration="pushover",user="user2"} 30
+    		cortex_alertmanager_notification_requests_failed_total{integration="slack",user="user1"} 4
+    		cortex_alertmanager_notification_requests_failed_total{integration="slack",user="user2"} 40
+    		cortex_alertmanager_notification_requests_failed_total{integration="victorops",user="user1"} 7
+    		cortex_alertmanager_notification_requests_failed_total{integration="victorops",user="user2"} 70
+    		cortex_alertmanager_notification_requests_failed_total{integration="webhook",user="user1"} 6
+    		cortex_alertmanager_notification_requests_failed_total{integration="webhook",user="user2"} 60
+    		cortex_alertmanager_notification_requests_failed_total{integration="wechat",user="user1"} 2
+    		cortex_alertmanager_notification_requests_failed_total{integration="wechat",user="user2"} 20
+
+    		# HELP cortex_alertmanager_notification_requests_total The total number of attempted notification requests.
+    		# TYPE cortex_alertmanager_notification_requests_total counter
+    		cortex_alertmanager_notification_requests_total{integration="email",user="user1"} 0
+    		cortex_alertmanager_notification_requests_total{integration="email",user="user2"} 0
+    		cortex_alertmanager_notification_requests_total{integration="opsgenie",user="user1"} 5
+    		cortex_alertmanager_notification_requests_total{integration="opsgenie",user="user2"} 50
+    		cortex_alertmanager_notification_requests_total{integration="pagerduty",user="user1"} 1
+    		cortex_alertmanager_notification_requests_total{integration="pagerduty",user="user2"} 10
+    		cortex_alertmanager_notification_requests_total{integration="pushover",user="user1"} 3
+    		cortex_alertmanager_notification_requests_total{integration="pushover",user="user2"} 30
+    		cortex_alertmanager_notification_requests_total{integration="slack",user="user1"} 4
+    		cortex_alertmanager_notification_requests_total{integration="slack",user="user2"} 40
+    		cortex_alertmanager_notification_requests_total{integration="victorops",user="user1"} 7
+    		cortex_alertmanager_notification_requests_total{integration="victorops",user="user2"} 70
+    		cortex_alertmanager_notification_requests_total{integration="webhook",user="user1"} 6
+    		cortex_alertmanager_notification_requests_total{integration="webhook",user="user2"} 60
+    		cortex_alertmanager_notification_requests_total{integration="wechat",user="user1"} 2
+    		cortex_alertmanager_notification_requests_total{integration="wechat",user="user2"} 20
+
+    		# HELP cortex_alertmanager_notifications_failed_total The total number of failed notifications.
+    		# TYPE cortex_alertmanager_notifications_failed_total counter
+    		cortex_alertmanager_notifications_failed_total{integration="email",user="user1"} 0
+    		cortex_alertmanager_notifications_failed_total{integration="email",user="user2"} 0
+    		cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user1"} 5
+    		cortex_alertmanager_notifications_failed_total{integration="opsgenie",user="user2"} 50
+    		cortex_alertmanager_notifications_failed_total{integration="pagerduty",user="user1"} 1
+    		cortex_alertmanager_notifications_failed_total{integration="pagerduty",user="user2"} 10
+    		cortex_alertmanager_notifications_failed_total{integration="pushover",user="user1"} 3
+    		cortex_alertmanager_notifications_failed_total{integration="pushover",user="user2"} 30
+    		cortex_alertmanager_notifications_failed_total{integration="slack",user="user1"} 4
+    		cortex_alertmanager_notifications_failed_total{integration="slack",user="user2"} 40
+    		cortex_alertmanager_notifications_failed_total{integration="victorops",user="user1"} 7
+    		cortex_alertmanager_notifications_failed_total{integration="victorops",user="user2"} 70
+    		cortex_alertmanager_notifications_failed_total{integration="webhook",user="user1"} 6
+    		cortex_alertmanager_notifications_failed_total{integration="webhook",user="user2"} 60
+    		cortex_alertmanager_notifications_failed_total{integration="wechat",user="user1"} 2
+    		cortex_alertmanager_notifications_failed_total{integration="wechat",user="user2"} 20
+
+    		# HELP cortex_alertmanager_notifications_total The total number of attempted notifications.
+    		# TYPE cortex_alertmanager_notifications_total counter
+    		cortex_alertmanager_notifications_total{integration="email",user="user1"} 0
+    		cortex_alertmanager_notifications_total{integration="email",user="user2"} 0
+    		cortex_alertmanager_notifications_total{integration="opsgenie",user="user1"} 5
+    		cortex_alertmanager_notifications_total{integration="opsgenie",user="user2"} 50
+    		cortex_alertmanager_notifications_total{integration="pagerduty",user="user1"} 1
+    		cortex_alertmanager_notifications_total{integration="pagerduty",user="user2"} 10
+    		cortex_alertmanager_notifications_total{integration="pushover",user="user1"} 3
+    		cortex_alertmanager_notifications_total{integration="pushover",user="user2"} 30
+    		cortex_alertmanager_notifications_total{integration="slack",user="user1"} 4
+    		cortex_alertmanager_notifications_total{integration="slack",user="user2"} 40
+    		cortex_alertmanager_notifications_total{integration="victorops",user="user1"} 7
+    		cortex_alertmanager_notifications_total{integration="victorops",user="user2"} 70
+    		cortex_alertmanager_notifications_total{integration="webhook",user="user1"} 6
+    		cortex_alertmanager_notifications_total{integration="webhook",user="user2"} 60
+    		cortex_alertmanager_notifications_total{integration="wechat",user="user1"} 2
+    		cortex_alertmanager_notifications_total{integration="wechat",user="user2"} 20
+
+    		# HELP cortex_alertmanager_silences How many silences by state.
+    		# TYPE cortex_alertmanager_silences gauge
+    		cortex_alertmanager_silences{state="active",user="user1"} 1
+    		cortex_alertmanager_silences{state="active",user="user2"} 10
+    		cortex_alertmanager_silences{state="expired",user="user1"} 2
+    		cortex_alertmanager_silences{state="expired",user="user2"} 20
+    		cortex_alertmanager_silences{state="pending",user="user1"} 3
+    		cortex_alertmanager_silences{state="pending",user="user2"} 30
+
+    		# HELP cortex_alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+    		# TYPE cortex_alertmanager_silences_gc_duration_seconds summary
+    		cortex_alertmanager_silences_gc_duration_seconds_sum 11
+    		cortex_alertmanager_silences_gc_duration_seconds_count 2
+
+    		# HELP cortex_alertmanager_silences_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
+    		# TYPE cortex_alertmanager_silences_gossip_messages_propagated_total counter
+    		cortex_alertmanager_silences_gossip_messages_propagated_total 11
+
+    		# HELP cortex_alertmanager_silences_queries_total How many silence queries were received.
+    		# TYPE cortex_alertmanager_silences_queries_total counter
+    		cortex_alertmanager_silences_queries_total 11
+
+    		# HELP cortex_alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+    		# TYPE cortex_alertmanager_silences_query_duration_seconds histogram
+    		cortex_alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 0
+    		cortex_alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 0
+    		cortex_alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 0
+    		cortex_alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 0
+    		cortex_alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 0
+    		cortex_alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 0
+    		cortex_alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 0
+    		cortex_alertmanager_silences_query_duration_seconds_bucket{le="1"} 1
+    		cortex_alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 1
+    		cortex_alertmanager_silences_query_duration_seconds_bucket{le="5"} 1
+    		cortex_alertmanager_silences_query_duration_seconds_bucket{le="10"} 2
+    		cortex_alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 2
+    		cortex_alertmanager_silences_query_duration_seconds_sum 11
+    		cortex_alertmanager_silences_query_duration_seconds_count 2
+
+    		# HELP cortex_alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+    		# TYPE cortex_alertmanager_silences_query_errors_total counter
+    		cortex_alertmanager_silences_query_errors_total 11
+
+    		# HELP cortex_alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+    		# TYPE cortex_alertmanager_silences_snapshot_duration_seconds summary
+    		cortex_alertmanager_silences_snapshot_duration_seconds_sum 11
+    		cortex_alertmanager_silences_snapshot_duration_seconds_count 2
+
+			# HELP cortex_alertmanager_silences_snapshot_size_bytes Size of the last silence snapshot in bytes.
+			# TYPE cortex_alertmanager_silences_snapshot_size_bytes gauge
+			cortex_alertmanager_silences_snapshot_size_bytes 11
+`))
+	require.NoError(t, err)
+}
+
 func populateAlertmanager(base float64) *prometheus.Registry {
 	reg := prometheus.NewRegistry()
 	s := newSilenceMetrics(reg)

--- a/pkg/alertmanager/alertmanager_metrics_test.go
+++ b/pkg/alertmanager/alertmanager_metrics_test.go
@@ -267,7 +267,12 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 	alertmanagerMetrics.addUserRegistry("user2", populateAlertmanager(10))
 	alertmanagerMetrics.addUserRegistry("user3", populateAlertmanager(100))
 
-	// Assertion before removal.
+	// In this test, we assert that metrics are "soft deleted" per the registry removal.
+	// In practice, this means several things:
+	// a) counters of removed registries are not reset.
+	// b) gauges of removed registries are removed.
+	// c) histograms/summaries (as these are just counters) are not reset.
+	// Instead of just asserting a few of these metrics we go for the whole payload to ensure our tests are sensitive to change and avoid regressions.
 	err := testutil.GatherAndCompare(mainReg, bytes.NewBufferString(`
 						# HELP cortex_alertmanager_alerts How many alerts by state.
         	            # TYPE cortex_alertmanager_alerts gauge

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -244,11 +244,11 @@ type MultitenantAlertmanager struct {
 	// effect here.
 	fallbackConfig string
 
-	// All the organization configurations that we have. Only used for instrumentation.
-	cfgs map[string]alerts.AlertConfigDesc
-
 	alertmanagersMtx sync.Mutex
 	alertmanagers    map[string]*Alertmanager
+	// Stores the current set of configurations we're running in each tenant's Alertmanager.
+	// Used for comparing configurations as we synchronize them.
+	cfgs map[string]alerts.AlertConfigDesc
 
 	logger              log.Logger
 	alertmanagerMetrics *alertmanagerMetrics
@@ -604,17 +604,16 @@ func (am *MultitenantAlertmanager) syncConfigs(cfgs map[string]alerts.AlertConfi
 
 	am.alertmanagersMtx.Lock()
 	defer am.alertmanagersMtx.Unlock()
-	for user, userAM := range am.alertmanagers {
-		if _, exists := cfgs[user]; !exists {
-			// The user alertmanager is only paused in order to retain the prometheus metrics
-			// it has reported to its registry. If a new config for this user appears, this structure
-			// will be reused.
-			level.Info(am.logger).Log("msg", "deactivating per-tenant alertmanager", "user", user)
-			userAM.Pause()
-			delete(am.cfgs, user)
-			am.multitenantMetrics.lastReloadSuccessful.DeleteLabelValues(user)
-			am.multitenantMetrics.lastReloadSuccessfulTimestamp.DeleteLabelValues(user)
-			level.Info(am.logger).Log("msg", "deactivated per-tenant alertmanager", "user", user)
+	for userID, userAM := range am.alertmanagers {
+		if _, exists := cfgs[userID]; !exists {
+			level.Info(am.logger).Log("msg", "deactivating per-tenant alertmanager", "user", userID)
+			go userAM.Stop()
+			delete(am.alertmanagers, userID)
+			delete(am.cfgs, userID)
+			am.multitenantMetrics.lastReloadSuccessful.DeleteLabelValues(userID)
+			am.multitenantMetrics.lastReloadSuccessfulTimestamp.DeleteLabelValues(userID)
+			am.alertmanagerMetrics.removeUserRegistry(userID)
+			level.Info(am.logger).Log("msg", "deactivated per-tenant alertmanager", "user", userID)
 		}
 	}
 }
@@ -749,11 +748,6 @@ func (am *MultitenantAlertmanager) ServeHTTP(w http.ResponseWriter, req *http.Re
 	am.alertmanagersMtx.Unlock()
 
 	if ok {
-		if !userAM.IsActive() {
-			level.Debug(am.logger).Log("msg", "the Alertmanager is not active", "user", userID)
-			http.Error(w, "the Alertmanager is not configured", http.StatusNotFound)
-			return
-		}
 
 		userAM.mux.ServeHTTP(w, req)
 		return

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -171,8 +171,7 @@ func (r *DefaultMultiTenantManager) newManager(ctx context.Context, userID strin
 	reg := prometheus.NewRegistry()
 	r.userManagerMetrics.AddUserRegistry(userID, reg)
 
-	logger := log.With(r.logger, "user", userID)
-	return r.managerFactory(ctx, userID, notifier, logger, reg), nil
+	return r.managerFactory(ctx, userID, notifier, r.logger, reg), nil
 }
 
 func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string) (*notifier.Manager, error) {


### PR DESCRIPTION
**What this PR does**:

Completely removes a tenant's Alertmanagers when synchronising configurations.

Before, we would "pause" the Alertmanager which would never free up the resources, and leave the Alertmanager running in-memory. 

I've also bundled a small change to a logger in the ruler that was double-logging the userID. 

**Which issue(s) this PR fixes**:
NA/NA

**Checklist**
- [x] Tests updated
- N/A Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
