### PR TITLE
Changed default value of -blocks-storage.bucket-store.sync-interval from 5m to 15m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   * `-cluster.advertise-address` in favor of `-alertmanager.cluster.advertise-address`
   * `-cluster.peer` in favor of `-alertmanager.cluster.peers`
   * `-cluster.peer-timeout` in favor of `-alertmanager.cluster.peer-timeout`
-* [CHANGE] Blocks storage: the default value of `-blocks-storage.bucket-store.sync-interval` has been changed from `5m` to `15m`. This has been made to match with `-compactor.cleanup-interval` default setting (`15m`), which is recommended when running the blocks storage with the bucket index enabled. #3724
+* [CHANGE] Blocks storage: the default value of `-blocks-storage.bucket-store.sync-interval` has been changed from `5m` to `15m`. #3724
 * [FEATURE] Querier: Queries can be federated across multiple tenants. The tenants IDs involved need to be specified separated by a `|` character in the `X-Scope-OrgID` request header. This is an experimental feature, which can be enabled by setting `-tenant-federation.enabled=true` on all Cortex services. #3250
 * [FEATURE] Alertmanager: introduced the experimental option `-alertmanager.sharding-enabled` to shard tenants across multiple Alertmanager instances. This feature is still under heavy development and its usage is discouraged. The following new metrics are exported by the Alertmanager: #3664
   * `cortex_alertmanager_ring_check_errors_total`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   * `-cluster.advertise-address` in favor of `-alertmanager.cluster.advertise-address`
   * `-cluster.peer` in favor of `-alertmanager.cluster.peers`
   * `-cluster.peer-timeout` in favor of `-alertmanager.cluster.peer-timeout`
+* [CHANGE] Blocks storage: the default value of `-blocks-storage.bucket-store.sync-interval` has been changed from `5m` to `15m`. This has been made to match with `-compactor.cleanup-interval` default setting (`15m`), which is recommended when running the blocks storage with the bucket index enabled. #3724
 * [FEATURE] Querier: Queries can be federated across multiple tenants. The tenants IDs involved need to be specified separated by a `|` character in the `X-Scope-OrgID` request header. This is an experimental feature, which can be enabled by setting `-tenant-federation.enabled=true` on all Cortex services. #3250
 * [FEATURE] Alertmanager: introduced the experimental option `-alertmanager.sharding-enabled` to shard tenants across multiple Alertmanager instances. This feature is still under heavy development and its usage is discouraged. The following new metrics are exported by the Alertmanager: #3664
   * `cortex_alertmanager_ring_check_errors_total`

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -387,7 +387,7 @@ blocks_storage:
     # enabled), in order to look for changes (new blocks shipped by ingesters
     # and blocks deleted by retention or compaction).
     # CLI flag: -blocks-storage.bucket-store.sync-interval
-    [sync_interval: <duration> | default = 5m]
+    [sync_interval: <duration> | default = 15m]
 
     # Max size - in bytes - of a per-tenant chunk pool, used to reduce memory
     # allocations.

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -434,7 +434,7 @@ blocks_storage:
     # enabled), in order to look for changes (new blocks shipped by ingesters
     # and blocks deleted by retention or compaction).
     # CLI flag: -blocks-storage.bucket-store.sync-interval
-    [sync_interval: <duration> | default = 5m]
+    [sync_interval: <duration> | default = 15m]
 
     # Max size - in bytes - of a per-tenant chunk pool, used to reduce memory
     # allocations.

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3799,7 +3799,7 @@ bucket_store:
   # enabled), in order to look for changes (new blocks shipped by ingesters and
   # blocks deleted by retention or compaction).
   # CLI flag: -blocks-storage.bucket-store.sync-interval
-  [sync_interval: <duration> | default = 5m]
+  [sync_interval: <duration> | default = 15m]
 
   # Max size - in bytes - of a per-tenant chunk pool, used to reduce memory
   # allocations.

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -243,7 +243,7 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.BucketIndex.RegisterFlagsWithPrefix(f, "blocks-storage.bucket-store.bucket-index.")
 
 	f.StringVar(&cfg.SyncDir, "blocks-storage.bucket-store.sync-dir", "tsdb-sync", "Directory to store synchronized TSDB index headers.")
-	f.DurationVar(&cfg.SyncInterval, "blocks-storage.bucket-store.sync-interval", 5*time.Minute, "How frequently to scan the bucket, or to refresh the bucket index (if enabled), in order to look for changes (new blocks shipped by ingesters and blocks deleted by retention or compaction).")
+	f.DurationVar(&cfg.SyncInterval, "blocks-storage.bucket-store.sync-interval", 15*time.Minute, "How frequently to scan the bucket, or to refresh the bucket index (if enabled), in order to look for changes (new blocks shipped by ingesters and blocks deleted by retention or compaction).")
 	f.Uint64Var(&cfg.MaxChunkPoolBytes, "blocks-storage.bucket-store.max-chunk-pool-bytes", uint64(2*units.Gibibyte), "Max size - in bytes - of a per-tenant chunk pool, used to reduce memory allocations.")
 	f.IntVar(&cfg.MaxConcurrent, "blocks-storage.bucket-store.max-concurrent", 100, "Max number of concurrent queries to execute against the long-term storage. The limit is shared across all tenants.")
 	f.IntVar(&cfg.TenantSyncConcurrency, "blocks-storage.bucket-store.tenant-sync-concurrency", 10, "Maximum number of concurrent tenants synching blocks.")


### PR DESCRIPTION
**What this PR does**:
While rolling out the bucket index in our cluster we've realised the default value of `-blocks-storage.bucket-store.sync-interval` (5m) doesn't play nicely with the consistency check. The consistency check gives a grace period for blocks recently uploaded (and potentially not yet discovered by store-gateway) which is equal to 3x the sync-interval (so 15m by default). Considering a default caching TTL for the bucket index of 5m, there may be edge cases where the querier is including a recently uploaded block in the consistency check but the store-gateway hasn't loaded it yet.

To fix the default config, in this PR I'm proposing to increase the default value of `sync-interval` from 5m to 15m (which also look a better default value anyway).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
