### PR TITLE
Fix panic caused by race condition in armon/go-metrics used by memberlist client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 * [BUGFIX] Alertmanager: don't serve HTTP requests until Alertmanager has fully started. Serving HTTP requests earlier may result in loss of configuration for the user. #3679
 * [BUGFIX] Do not log "failed to load config" if runtime config file is empty. #3706
 * [BUGFIX] Do not allow to use a runtime config file containing multiple YAML documents. #3706
+* [BUGFIX] Memberlist: fixed panic caused by race condition in `armon/go-metrics` used by memberlist client. #3724
 
 ## 1.6.0
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/armon/go-metrics v0.3.3
+	github.com/armon/go-metrics v0.3.6
 	github.com/aws/aws-sdk-go v1.35.31
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/cespare/xxhash v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,8 @@ github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQh
 github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD+gJD3GYs=
 github.com/armon/go-metrics v0.3.3 h1:a9F4rlj7EWWrbj7BYw8J8+x+ZZkJeqzNyRk8hdPF+ro=
 github.com/armon/go-metrics v0.3.3/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
+github.com/armon/go-metrics v0.3.6 h1:x/tmtOF9cDBoXH7XoAGOz2qqm1DknFD1590XmD/DUJ8=
+github.com/armon/go-metrics v0.3.6/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=

--- a/vendor/github.com/armon/go-metrics/.gitignore
+++ b/vendor/github.com/armon/go-metrics/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 
 /metrics.out
+
+.idea

--- a/vendor/github.com/armon/go-metrics/metrics.go
+++ b/vendor/github.com/armon/go-metrics/metrics.go
@@ -228,12 +228,12 @@ func (m *Metrics) allowMetric(key []string, labels []Label) (bool, []Label) {
 func (m *Metrics) collectStats() {
 	for {
 		time.Sleep(m.ProfileInterval)
-		m.emitRuntimeStats()
+		m.EmitRuntimeStats()
 	}
 }
 
 // Emits various runtime statsitics
-func (m *Metrics) emitRuntimeStats() {
+func (m *Metrics) EmitRuntimeStats() {
 	// Export number of Goroutines
 	numRoutines := runtime.NumGoroutine()
 	m.SetGauge([]string{"runtime", "num_goroutines"}, float32(numRoutines))

--- a/vendor/github.com/armon/go-metrics/prometheus/prometheus.go
+++ b/vendor/github.com/armon/go-metrics/prometheus/prometheus.go
@@ -5,11 +5,11 @@ package prometheus
 import (
 	"fmt"
 	"log"
+	"math"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
-
-	"regexp"
 
 	"github.com/armon/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -29,6 +29,27 @@ type PrometheusOpts struct {
 	// Expiration is the duration a metric is valid for, after which it will be
 	// untracked. If the value is zero, a metric is never expired.
 	Expiration time.Duration
+	Registerer prometheus.Registerer
+
+	// Gauges, Summaries, and Counters allow us to pre-declare metrics by giving their Name, Help, and ConstLabels to
+	// the PrometheusSink when it is created. Metrics declared in this way will be initialized at zero and will not be
+	// deleted when their expiry is reached.
+	// - Gauges and Summaries will be set to NaN when they expire.
+	// - Counters continue to Collect their last known value.
+	// Ex:
+	// PrometheusOpts{
+	//     Expiration: 10 * time.Second,
+	//     Gauges: []GaugeDefinition{
+	//         {
+	//	         Name: []string{ "application", "component", "measurement"},
+	//           Help: "application_component_measurement provides an example of how to declare static metrics",
+	//           ConstLabels: []metrics.Label{ { Name: "my_label", Value: "does_not_change" }, },
+	//         },
+	//     },
+	// }
+	GaugeDefinitions   []GaugeDefinition
+	SummaryDefinitions []SummaryDefinition
+	CounterDefinitions []CounterDefinition
 }
 
 type PrometheusSink struct {
@@ -36,8 +57,48 @@ type PrometheusSink struct {
 	gauges     sync.Map
 	summaries  sync.Map
 	counters   sync.Map
-	updates    sync.Map
 	expiration time.Duration
+	help       map[string]string
+}
+
+// GaugeDefinition can be provided to PrometheusOpts to declare a constant gauge that is not deleted on expiry.
+type GaugeDefinition struct {
+	Name        []string
+	ConstLabels []metrics.Label
+	Help        string
+}
+
+type gauge struct {
+	prometheus.Gauge
+	updatedAt time.Time
+	// canDelete is set if the metric is created during runtime so we know it's ephemeral and can delete it on expiry.
+	canDelete bool
+}
+
+// SummaryDefinition can be provided to PrometheusOpts to declare a constant summary that is not deleted on expiry.
+type SummaryDefinition struct {
+	Name        []string
+	ConstLabels []metrics.Label
+	Help        string
+}
+
+type summary struct {
+	prometheus.Summary
+	updatedAt time.Time
+	canDelete bool
+}
+
+// CounterDefinition can be provided to PrometheusOpts to declare a constant counter that is not deleted on expiry.
+type CounterDefinition struct {
+	Name        []string
+	ConstLabels []metrics.Label
+	Help        string
+}
+
+type counter struct {
+	prometheus.Counter
+	updatedAt time.Time
+	canDelete bool
 }
 
 // NewPrometheusSink creates a new PrometheusSink using the default options.
@@ -51,11 +112,20 @@ func NewPrometheusSinkFrom(opts PrometheusOpts) (*PrometheusSink, error) {
 		gauges:     sync.Map{},
 		summaries:  sync.Map{},
 		counters:   sync.Map{},
-		updates:    sync.Map{},
 		expiration: opts.Expiration,
+		help:       make(map[string]string),
 	}
 
-	return sink, prometheus.Register(sink)
+	initGauges(&sink.gauges, opts.GaugeDefinitions, sink.help)
+	initSummaries(&sink.summaries, opts.SummaryDefinitions, sink.help)
+	initCounters(&sink.counters, opts.CounterDefinitions, sink.help)
+
+	reg := opts.Registerer
+	if reg == nil {
+		reg = prometheus.DefaultRegisterer
+	}
+
+	return sink, reg.Register(sink)
 }
 
 // Describe is needed to meet the Collector interface.
@@ -72,40 +142,104 @@ func (p *PrometheusSink) Collect(c chan<- prometheus.Metric) {
 	expire := p.expiration != 0
 	now := time.Now()
 	p.gauges.Range(func(k, v interface{}) bool {
-		last, _ := p.updates.Load(k)
-		if expire && last.(time.Time).Add(p.expiration).Before(now) {
-			p.updates.Delete(k)
-			p.gauges.Delete(k)
-		} else {
-			v.(prometheus.Gauge).Collect(c)
+		if v == nil {
+			return true
 		}
+		g := v.(*gauge)
+		lastUpdate := g.updatedAt
+		if expire && lastUpdate.Add(p.expiration).Before(now) {
+			if g.canDelete {
+				p.gauges.Delete(k)
+				return true
+			}
+			// We have not observed the gauge this interval so we don't know its value.
+			g.Set(math.NaN())
+		}
+		g.Collect(c)
 		return true
 	})
 	p.summaries.Range(func(k, v interface{}) bool {
-		last, _ := p.updates.Load(k)
-		if expire && last.(time.Time).Add(p.expiration).Before(now) {
-			p.updates.Delete(k)
-			p.summaries.Delete(k)
-		} else {
-			v.(prometheus.Summary).Collect(c)
+		if v == nil {
+			return true
 		}
+		s := v.(*summary)
+		lastUpdate := s.updatedAt
+		if expire && lastUpdate.Add(p.expiration).Before(now) {
+			if s.canDelete {
+				p.summaries.Delete(k)
+				return true
+			}
+			// We have observed nothing in this interval.
+			s.Observe(math.NaN())
+		}
+		s.Collect(c)
 		return true
 	})
 	p.counters.Range(func(k, v interface{}) bool {
-		last, _ := p.updates.Load(k)
-		if expire && last.(time.Time).Add(p.expiration).Before(now) {
-			p.updates.Delete(k)
-			p.counters.Delete(k)
-		} else {
-			v.(prometheus.Counter).Collect(c)
+		if v == nil {
+			return true
 		}
+		count := v.(*counter)
+		lastUpdate := count.updatedAt
+		if expire && lastUpdate.Add(p.expiration).Before(now) {
+			if count.canDelete {
+				p.counters.Delete(k)
+				return true
+			}
+			// Counters remain at their previous value when not observed, so we do not set it to NaN.
+		}
+		count.Collect(c)
 		return true
 	})
 }
 
+func initGauges(m *sync.Map, gauges []GaugeDefinition, help map[string]string) {
+	for _, g := range gauges {
+		key, hash := flattenKey(g.Name, g.ConstLabels)
+		help[fmt.Sprintf("gauge.%s", key)] = g.Help
+		pG := prometheus.NewGauge(prometheus.GaugeOpts{
+			Name:        key,
+			Help:        g.Help,
+			ConstLabels: prometheusLabels(g.ConstLabels),
+		})
+		m.Store(hash, &gauge{Gauge: pG})
+	}
+	return
+}
+
+func initSummaries(m *sync.Map, summaries []SummaryDefinition, help map[string]string) {
+	for _, s := range summaries {
+		key, hash := flattenKey(s.Name, s.ConstLabels)
+		help[fmt.Sprintf("summary.%s", key)] = s.Help
+		pS := prometheus.NewSummary(prometheus.SummaryOpts{
+			Name:        key,
+			Help:        s.Help,
+			MaxAge:      10 * time.Second,
+			ConstLabels: prometheusLabels(s.ConstLabels),
+			Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		})
+		m.Store(hash, &summary{Summary: pS})
+	}
+	return
+}
+
+func initCounters(m *sync.Map, counters []CounterDefinition, help map[string]string) {
+	for _, c := range counters {
+		key, hash := flattenKey(c.Name, c.ConstLabels)
+		help[fmt.Sprintf("counter.%s", key)] = c.Help
+		pC := prometheus.NewCounter(prometheus.CounterOpts{
+			Name:        key,
+			Help:        c.Help,
+			ConstLabels: prometheusLabels(c.ConstLabels),
+		})
+		m.Store(hash, &counter{Counter: pC})
+	}
+	return
+}
+
 var forbiddenChars = regexp.MustCompile("[ .=\\-/]")
 
-func (p *PrometheusSink) flattenKey(parts []string, labels []metrics.Label) (string, string) {
+func flattenKey(parts []string, labels []metrics.Label) (string, string) {
 	key := strings.Join(parts, "_")
 	key = forbiddenChars.ReplaceAllString(key, "_")
 
@@ -130,18 +264,41 @@ func (p *PrometheusSink) SetGauge(parts []string, val float32) {
 }
 
 func (p *PrometheusSink) SetGaugeWithLabels(parts []string, val float32, labels []metrics.Label) {
-	key, hash := p.flattenKey(parts, labels)
-	g, ok := p.gauges.Load(hash)
-	if !ok {
-		g = prometheus.NewGauge(prometheus.GaugeOpts{
+	key, hash := flattenKey(parts, labels)
+	pg, ok := p.gauges.Load(hash)
+
+	// The sync.Map underlying gauges stores pointers to our structs. If we need to make updates,
+	// rather than modifying the underlying value directly, which would be racy, we make a local
+	// copy by dereferencing the pointer we get back, making the appropriate changes, and then
+	// storing a pointer to our local copy. The underlying Prometheus types are threadsafe,
+	// so there's no issues there. It's possible for racy updates to occur to the updatedAt
+	// value, but since we're always setting it to time.Now(), it doesn't really matter.
+	if ok {
+		localGauge := *pg.(*gauge)
+		localGauge.Set(float64(val))
+		localGauge.updatedAt = time.Now()
+		p.gauges.Store(hash, &localGauge)
+
+		// The gauge does not exist, create the gauge and allow it to be deleted
+	} else {
+		help := key
+		existingHelp, ok := p.help[fmt.Sprintf("gauge.%s", key)]
+		if ok {
+			help = existingHelp
+		}
+		g := prometheus.NewGauge(prometheus.GaugeOpts{
 			Name:        key,
-			Help:        key,
+			Help:        help,
 			ConstLabels: prometheusLabels(labels),
 		})
-		p.gauges.Store(hash, g)
+		g.Set(float64(val))
+		pg = &gauge{
+			Gauge:     g,
+			updatedAt: time.Now(),
+			canDelete: true,
+		}
+		p.gauges.Store(hash, pg)
 	}
-	g.(prometheus.Gauge).Set(float64(val))
-	p.updates.Store(hash, time.Now())
 }
 
 func (p *PrometheusSink) AddSample(parts []string, val float32) {
@@ -149,20 +306,38 @@ func (p *PrometheusSink) AddSample(parts []string, val float32) {
 }
 
 func (p *PrometheusSink) AddSampleWithLabels(parts []string, val float32, labels []metrics.Label) {
-	key, hash := p.flattenKey(parts, labels)
-	g, ok := p.summaries.Load(hash)
-	if !ok {
-		g = prometheus.NewSummary(prometheus.SummaryOpts{
+	key, hash := flattenKey(parts, labels)
+	ps, ok := p.summaries.Load(hash)
+
+	// Does the summary already exist for this sample type?
+	if ok {
+		localSummary := *ps.(*summary)
+		localSummary.Observe(float64(val))
+		localSummary.updatedAt = time.Now()
+		p.summaries.Store(hash, &localSummary)
+
+		// The summary does not exist, create the Summary and allow it to be deleted
+	} else {
+		help := key
+		existingHelp, ok := p.help[fmt.Sprintf("summary.%s", key)]
+		if ok {
+			help = existingHelp
+		}
+		s := prometheus.NewSummary(prometheus.SummaryOpts{
 			Name:        key,
-			Help:        key,
+			Help:        help,
 			MaxAge:      10 * time.Second,
 			ConstLabels: prometheusLabels(labels),
 			Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		})
-		p.summaries.Store(hash, g)
+		s.Observe(float64(val))
+		ps = &summary{
+			Summary:   s,
+			updatedAt: time.Now(),
+			canDelete: true,
+		}
+		p.summaries.Store(hash, ps)
 	}
-	g.(prometheus.Summary).Observe(float64(val))
-	p.updates.Store(hash, time.Now())
 }
 
 // EmitKey is not implemented. Prometheus doesn’t offer a type for which an
@@ -176,20 +351,40 @@ func (p *PrometheusSink) IncrCounter(parts []string, val float32) {
 }
 
 func (p *PrometheusSink) IncrCounterWithLabels(parts []string, val float32, labels []metrics.Label) {
-	key, hash := p.flattenKey(parts, labels)
-	g, ok := p.counters.Load(hash)
-	if !ok {
-		g = prometheus.NewCounter(prometheus.CounterOpts{
+	key, hash := flattenKey(parts, labels)
+	pc, ok := p.counters.Load(hash)
+
+	// Does the counter exist?
+	if ok {
+		localCounter := *pc.(*counter)
+		localCounter.Add(float64(val))
+		localCounter.updatedAt = time.Now()
+		p.counters.Store(hash, &localCounter)
+
+		// The counter does not exist yet, create it and allow it to be deleted
+	} else {
+		help := key
+		existingHelp, ok := p.help[fmt.Sprintf("counter.%s", key)]
+		if ok {
+			help = existingHelp
+		}
+		c := prometheus.NewCounter(prometheus.CounterOpts{
 			Name:        key,
-			Help:        key,
+			Help:        help,
 			ConstLabels: prometheusLabels(labels),
 		})
-		p.counters.Store(hash, g)
+		c.Add(float64(val))
+		pc = &counter{
+			Counter:   c,
+			updatedAt: time.Now(),
+			canDelete: true,
+		}
+		p.counters.Store(hash, pc)
 	}
-	g.(prometheus.Counter).Add(float64(val))
-	p.updates.Store(hash, time.Now())
 }
 
+// PrometheusPushSink wraps a normal prometheus sink and provides an address and facilities to export it to an address
+// on an interval.
 type PrometheusPushSink struct {
 	*PrometheusSink
 	pusher       *push.Pusher
@@ -198,13 +393,12 @@ type PrometheusPushSink struct {
 	stopChan     chan struct{}
 }
 
-func NewPrometheusPushSink(address string, pushIterval time.Duration, name string) (*PrometheusPushSink, error) {
-
+// NewPrometheusPushSink creates a PrometheusPushSink by taking an address, interval, and destination name.
+func NewPrometheusPushSink(address string, pushInterval time.Duration, name string) (*PrometheusPushSink, error) {
 	promSink := &PrometheusSink{
 		gauges:     sync.Map{},
 		summaries:  sync.Map{},
 		counters:   sync.Map{},
-		updates:    sync.Map{},
 		expiration: 60 * time.Second,
 	}
 
@@ -214,7 +408,7 @@ func NewPrometheusPushSink(address string, pushIterval time.Duration, name strin
 		promSink,
 		pusher,
 		address,
-		pushIterval,
+		pushInterval,
 		make(chan struct{}),
 	}
 

--- a/vendor/github.com/armon/go-metrics/start.go
+++ b/vendor/github.com/armon/go-metrics/start.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/go-immutable-radix"
+	iradix "github.com/hashicorp/go-immutable-radix"
 )
 
 // Config is used to configure metrics settings
@@ -46,6 +46,11 @@ var globalMetrics atomic.Value // *Metrics
 func init() {
 	// Initialize to a blackhole sink to avoid errors
 	globalMetrics.Store(&Metrics{sink: &BlackholeSink{}})
+}
+
+// Default returns the shared global metrics instance.
+func Default() *Metrics {
+	return globalMetrics.Load().(*Metrics)
 }
 
 // DefaultConfig provides a sane default configuration

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -44,7 +44,7 @@ github.com/alicebob/gopher-json
 ## explicit
 github.com/alicebob/miniredis
 github.com/alicebob/miniredis/server
-# github.com/armon/go-metrics v0.3.3
+# github.com/armon/go-metrics v0.3.6
 ## explicit
 github.com/armon/go-metrics
 github.com/armon/go-metrics/prometheus


### PR DESCRIPTION
**What this PR does**:
It was reported an ingester panic (https://github.com/cortexproject/cortex/issues/3721). According to the stack trace, it should be a race condition in `armon/go-metrics` which was fixed in https://github.com/armon/go-metrics/pull/109.

This PR upgrades `armon/go-metrics` to the latest version.

**Which issue(s) this PR fixes**:
Fixes #3721

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
