### PR TITLE
Don't update lastUpdateTime if TSDB isn't updated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Ingester: don't update internal "last updated" timestamp of TSDB if tenant only sends invalid samples. This affects how "idle" time is computed. #3727 
 
 ## 1.7.0 in progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [CHANGE] Ingester: don't update internal "last updated" timestamp of TSDB if tenant only sends invalid samples. This affects how "idle" time is computed. #3727 
+* [CHANGE] Ingester: don't update internal "last updated" timestamp of TSDB if tenant only sends invalid samples. This affects how "idle" time is computed. #3727
 
 ## 1.7.0 in progress
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -767,7 +767,10 @@ func (i *Ingester) v2Push(ctx context.Context, req *client.WriteRequest) (*clien
 	}
 	i.TSDBState.appenderCommitDuration.Observe(time.Since(startCommit).Seconds())
 
-	db.setLastUpdate(time.Now())
+	// If only invalid samples are pushed, don't change "last update", as TSDB was not modified.
+	if succeededSamplesCount > 0 {
+		db.setLastUpdate(time.Now())
+	}
 
 	// Increment metrics only if the samples have been successfully committed.
 	// If the code didn't reach this point, it means that we returned an error

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -1894,6 +1894,51 @@ func (m *shipperMock) Sync(ctx context.Context) (uploaded int, err error) {
 	return args.Int(0), args.Error(1)
 }
 
+func TestIngester_invalidSamplesDontChangeLastUpdateTime(t *testing.T) {
+	cfg := defaultIngesterTestConfig()
+	cfg.LifecyclerConfig.JoinAfter = 0
+
+	// Create ingester
+	i, cleanup, err := newIngesterMockWithTSDBStorage(cfg, nil)
+	require.NoError(t, err)
+	defer cleanup()
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
+
+	// Wait until it's ACTIVE
+	test.Poll(t, 1*time.Second, ring.ACTIVE, func() interface{} {
+		return i.lifecycler.GetState()
+	})
+
+	ctx := user.InjectOrgID(context.Background(), userID)
+	sampleTimestamp := int64(model.Now())
+
+	{
+		req, _, _ := mockWriteRequest(labels.Labels{{Name: labels.MetricName, Value: "test"}}, 0, sampleTimestamp)
+		_, err = i.v2Push(ctx, req)
+		require.NoError(t, err)
+	}
+
+	db := i.getTSDB(userID)
+	lastUpdate := db.lastUpdate.Load()
+
+	// Wait until 1 second passes.
+	test.Poll(t, 1*time.Second, time.Now().Unix()+1, func() interface{} {
+		return time.Now().Unix()
+	})
+
+	// Push another sample to the same metric and timestamp, with different value. We expect to get error.
+	{
+		req, _, _ := mockWriteRequest(labels.Labels{{Name: labels.MetricName, Value: "test"}}, 1, sampleTimestamp)
+		_, err = i.v2Push(ctx, req)
+		require.Error(t, err)
+	}
+
+	// Make sure last update hasn't changed.
+	require.Equal(t, lastUpdate, db.lastUpdate.Load())
+}
+
 func TestIngester_flushing(t *testing.T) {
 	for name, tc := range map[string]struct {
 		setupIngester func(cfg *Config)


### PR DESCRIPTION
**What this PR does**: This PR modified ingester to not update "lastUpdate" time if push request didn't contain any sample that was appended to TSDB.

Without doing this change, continuous push of bad samples will keep TSDB in memory with unflushed data. If "good" sample arrives much later, all old data will be finally put to block.

With this change, ingester will eventually flush and close such TSDB, and remove local data. After closing, next push of valid or invalid sample will reopen TSDB again (and then later close, if no valid samples arrive), but at least old samples will not be kept in the memory for a long time.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
