### PR TITLE
alertmanager and ruler irsa is failing, added support to it and also f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 
 ## 1.7.0 in progress
-
+* [ENHANCEMENT] Added support for web indentity tokens
+  * `s3.session-token`
 * [CHANGE] FramedSnappy encoding support has been removed from Push and Remote Read APIs. This means Prometheus 1.6 support has been removed and the oldest Prometheus version supported in the remote write is 1.7. #3682
 * [CHANGE] Ruler: removed the flag `-ruler.evaluation-delay-duration-deprecated` which was deprecated in 1.4.0. Please use the `ruler_evaluation_delay_duration` per-tenant limit instead. #3693
 * [CHANGE] Removed the flags `-<prefix>.grpc-use-gzip-compression` which were deprecated in 1.3.0: #3693

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -4,7 +4,7 @@ ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl python-requests python-yaml file jq unzip protobuf-compiler libprotobuf-dev && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update && apt-get install -y nodejs npm && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install website builder dependencies. Whenever you change these version, please also change website/package.json
 # and viceversa.

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1233,6 +1233,10 @@ storage:
     # CLI flag: -ruler.storage.s3.secret-access-key
     [secret_access_key: <string> | default = ""]
 
+    # AWS Session Token
+    # CLI flag: -ruler.storage.s3.session-token
+    [session_token: <string> | default = ""]
+
     # Disable https on s3 connection.
     # CLI flag: -ruler.storage.s3.insecure
     [insecure: <boolean> | default = false]
@@ -1672,6 +1676,10 @@ storage:
     # AWS Secret Access Key
     # CLI flag: -alertmanager.storage.s3.secret-access-key
     [secret_access_key: <string> | default = ""]
+
+    # AWS Session Token
+    # CLI flag: -ruler.storage.s3.session-token
+    [session_token: <string> | default = ""]
 
     # Disable https on s3 connection.
     # CLI flag: -alertmanager.storage.s3.insecure

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1678,7 +1678,7 @@ storage:
     [secret_access_key: <string> | default = ""]
 
     # AWS Session Token
-    # CLI flag: -ruler.storage.s3.session-token
+    # CLI flag: -alertmanager.storage.s3.session-token
     [session_token: <string> | default = ""]
 
     # Disable https on s3 connection.

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -212,16 +212,17 @@ func buildS3Config(cfg S3Config) (*aws.Config, []string, error) {
 	}
 
 	role := os.Getenv("AWS_ROLE_ARN")
-	webIdentityToken, err := ioutil.ReadFile(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"))
-	if err != nil {
-		return nil, nil, err
-	}
-	token := string(webIdentityToken)
+	webIdentityToken := os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")
 
 	if cfg.AccessKeyID != "" && cfg.SecretAccessKey == "" ||
 		cfg.AccessKeyID == "" && cfg.SecretAccessKey != "" ||
 		cfg.AccessKeyID == "" && cfg.SecretAccessKey == "" {
-		if role != "" && token != "" {
+		if role != "" && webIdentityToken != "" {
+			webIdentityReadToken, err := ioutil.ReadFile(webIdentityToken)
+			if err != nil {
+				return nil, nil, err
+			}
+			token := string(webIdentityReadToken)
 			sess, err := session.NewSession(s3Config)
 			if err != nil {
 				return nil, nil, errors.Wrap(err, "failed to create new s3 session")

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -104,6 +104,7 @@ func (cfg *S3Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.Region, prefix+"s3.region", "", "AWS region to use.")
 	f.StringVar(&cfg.AccessKeyID, prefix+"s3.access-key-id", "", "AWS Access Key ID")
 	f.StringVar(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "", "AWS Secret Access Key")
+        f.StringVar(&cfg.SessionToken, prefix+"s3.session-token", "", "AWS session token")
 	f.BoolVar(&cfg.Insecure, prefix+"s3.insecure", false, "Disable https on s3 connection.")
 	f.BoolVar(&cfg.SSEEncryption, prefix+"s3.sse-encryption", false, "Enable AES256 AWS Server Side Encryption")
 

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -213,6 +213,9 @@ func buildS3Config(cfg S3Config) (*aws.Config, []string, error) {
 
 	role := os.Getenv("AWS_ROLE_ARN")
 	webIdentityToken, err := ioutil.ReadFile(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"))
+	if err != nil {
+		return nil, nil, err
+	}
 	token := string(webIdentityToken)
 
 	if cfg.AccessKeyID != "" && cfg.SecretAccessKey == "" ||

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -104,7 +104,7 @@ func (cfg *S3Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.Region, prefix+"s3.region", "", "AWS region to use.")
 	f.StringVar(&cfg.AccessKeyID, prefix+"s3.access-key-id", "", "AWS Access Key ID")
 	f.StringVar(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "", "AWS Secret Access Key")
-        f.StringVar(&cfg.SessionToken, prefix+"s3.session-token", "", "AWS session token")
+	f.StringVar(&cfg.SessionToken, prefix+"s3.session-token", "", "AWS session token")
 	f.BoolVar(&cfg.Insecure, prefix+"s3.insecure", false, "Disable https on s3 connection.")
 	f.BoolVar(&cfg.SSEEncryption, prefix+"s3.sse-encryption", false, "Enable AES256 AWS Server Side Encryption")
 
@@ -214,7 +214,8 @@ func buildS3Config(cfg S3Config) (*aws.Config, []string, error) {
 	role := os.Getenv("AWS_ROLE_ARN")
 
 	if cfg.AccessKeyID != "" && cfg.SecretAccessKey == "" ||
-		cfg.AccessKeyID == "" && cfg.SecretAccessKey != "" {
+		cfg.AccessKeyID == "" && cfg.SecretAccessKey != "" || 
+		cfg.AccessKeyID == "" && cfg.SecretAccessKey == "" {
 		if role != "" {
 			sess, err := session.NewSession(s3Config)
 			if err != nil {
@@ -227,7 +228,6 @@ func buildS3Config(cfg S3Config) (*aws.Config, []string, error) {
 			}
 			token := string(webIndentityToken)
 			sessName := strconv.FormatInt(time.Now().UnixNano(), 10)
-			role := os.Getenv("AWS_ROLE_ARN")
 			req, sessCred := awsSTS.AssumeRoleWithWebIdentityRequest(
 				&sts.AssumeRoleWithWebIdentityInput{
 					RoleSessionName:  &sessName,


### PR DESCRIPTION
…ixed buy in dockerfile

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

Adding support to iam role for service account(irsa) and fixed dockerfile.

**Which issue(s) this PR fixes**:
irsa is failing from alertmanager and ruler pod 
`level=warn ts=2021-01-25T11:29:36.056182464Z caller=multitenant.go:304 component=MultiTenantAlertmanager msg="error fetching all configurations, backing off" err="WebIdentityErr: failed to retrieve credentials\ncaused by: SerializationError: failed to unmarshal error message\n\tstatus code: 405`

Ingestor, storage gateway, compactor are using different s3 sdk cortex/vendor/github.com/thanos-io/thanos/pkg/objstore/s3/s3.go, 
 alertmanager and ruler using s3 client defined in cortex/pkg/chunk/aws/s3_storage_client.go so we are seeing issue for these services.

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

