### PR TITLE
Fix RingServiceDiscovery logic on empty ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [ENHANCEMENT] Distributor: Enable downstream projects to wrap distributor push function and access the deserialized write requests berfore/after they are pushed. #3755
 * [ENHANCEMENT] Add flag `-<prefix>.tls-server-name` to require a specific server name instead of the hostname on the certificate. #3156
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
+* [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761
 
 ## 1.7.0 in progress
 

--- a/pkg/ring/client/ring_service_discovery.go
+++ b/pkg/ring/client/ring_service_discovery.go
@@ -1,12 +1,17 @@
 package client
 
 import (
+	"errors"
+
 	"github.com/cortexproject/cortex/pkg/ring"
 )
 
 func NewRingServiceDiscovery(r ring.ReadRing) PoolServiceDiscovery {
 	return func() ([]string, error) {
 		replicationSet, err := r.GetAllHealthy(ring.Reporting)
+		if errors.Is(err, ring.ErrEmptyRing) {
+			return nil, nil
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ring/client/ring_service_discovery_test.go
+++ b/pkg/ring/client/ring_service_discovery_test.go
@@ -20,6 +20,10 @@ func TestNewRingServiceDiscovery(t *testing.T) {
 			ringErr:     errors.New("mocked error"),
 			expectedErr: errors.New("mocked error"),
 		},
+		"empty ring": {
+			ringErr:       ring.ErrEmptyRing,
+			expectedAddrs: nil,
+		},
 		"empty replication set": {
 			ringReplicationSet: ring.ReplicationSet{
 				Ingesters: []ring.IngesterDesc{},


### PR DESCRIPTION
**What this PR does**:
While checking https://github.com/cortexproject/cortex/issues/3743 I've noticed that the `ErrEmptyRing` is treated as an error, but it's actually a valid state with regards to the ring service discovery, because it just means the ring is empty. This PR fixes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
