### PR TITLE
Make runtime configuration struct public

### DIFF
--- a/pkg/cortex/runtime_config.go
+++ b/pkg/cortex/runtime_config.go
@@ -17,17 +17,17 @@ var (
 	errMultipleDocuments = errors.New("the provided runtime configuration contains multiple documents")
 )
 
-// runtimeConfigValues are values that can be reloaded from configuration file while Cortex is running.
+// RuntimeConfigValues are values that can be reloaded from configuration file while Cortex is running.
 // Reloading is done by runtime_config.Manager, which also keeps the currently loaded config.
 // These values are then pushed to the components that are interested in them.
-type runtimeConfigValues struct {
+type RuntimeConfigValues struct {
 	TenantLimits map[string]*validation.Limits `yaml:"overrides"`
 
 	Multi kv.MultiRuntimeConfig `yaml:"multi_kv_config"`
 }
 
 func loadRuntimeConfig(r io.Reader) (interface{}, error) {
-	var overrides = &runtimeConfigValues{}
+	var overrides = &RuntimeConfigValues{}
 
 	decoder := yaml.NewDecoder(r)
 	decoder.SetStrict(true)
@@ -38,7 +38,7 @@ func loadRuntimeConfig(r io.Reader) (interface{}, error) {
 	}
 
 	// Ensure the provided YAML config is not composed of multiple documents,
-	if err := decoder.Decode(&runtimeConfigValues{}); !errors.Is(err, io.EOF) {
+	if err := decoder.Decode(&RuntimeConfigValues{}); !errors.Is(err, io.EOF) {
 		return nil, errMultipleDocuments
 	}
 
@@ -50,7 +50,7 @@ func tenantLimitsFromRuntimeConfig(c *runtimeconfig.Manager) validation.TenantLi
 		return nil
 	}
 	return func(userID string) *validation.Limits {
-		cfg, ok := c.GetConfig().(*runtimeConfigValues)
+		cfg, ok := c.GetConfig().(*RuntimeConfigValues)
 		if !ok || cfg == nil {
 			return nil
 		}
@@ -69,14 +69,14 @@ func multiClientRuntimeConfigChannel(manager *runtimeconfig.Manager) func() <-ch
 
 		// push initial config to the channel
 		val := manager.GetConfig()
-		if cfg, ok := val.(*runtimeConfigValues); ok && cfg != nil {
+		if cfg, ok := val.(*RuntimeConfigValues); ok && cfg != nil {
 			outCh <- cfg.Multi
 		}
 
 		ch := manager.CreateListenerChannel(1)
 		go func() {
 			for val := range ch {
-				if cfg, ok := val.(*runtimeConfigValues); ok && cfg != nil {
+				if cfg, ok := val.(*RuntimeConfigValues); ok && cfg != nil {
 					outCh <- cfg.Multi
 				}
 			}
@@ -87,7 +87,7 @@ func multiClientRuntimeConfigChannel(manager *runtimeconfig.Manager) func() <-ch
 }
 func runtimeConfigHandler(runtimeCfgManager *runtimeconfig.Manager, defaultLimits validation.Limits) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		cfg, ok := runtimeCfgManager.GetConfig().(*runtimeConfigValues)
+		cfg, ok := runtimeCfgManager.GetConfig().(*RuntimeConfigValues)
 		if !ok || cfg == nil {
 			util.WriteTextResponse(w, "runtime config file doesn't exist")
 			return
@@ -98,7 +98,7 @@ func runtimeConfigHandler(runtimeCfgManager *runtimeconfig.Manager, defaultLimit
 		case "diff":
 			// Default runtime config is just empty struct, but to make diff work,
 			// we set defaultLimits for every tenant that exists in runtime config.
-			defaultCfg := runtimeConfigValues{}
+			defaultCfg := RuntimeConfigValues{}
 			defaultCfg.TenantLimits = map[string]*validation.Limits{}
 			for k, v := range cfg.TenantLimits {
 				if v != nil {

--- a/pkg/cortex/runtime_config_test.go
+++ b/pkg/cortex/runtime_config_test.go
@@ -44,7 +44,7 @@ overrides:
 		RulerMaxRuleGroupsPerTenant: 20,
 	}
 
-	loadedLimits := runtimeCfg.(*runtimeConfigValues).TenantLimits
+	loadedLimits := runtimeCfg.(*RuntimeConfigValues).TenantLimits
 	require.Equal(t, 3, len(loadedLimits))
 	require.Equal(t, limits, *loadedLimits["1234"])
 	require.Equal(t, limits, *loadedLimits["1235"])
@@ -57,7 +57,7 @@ func TestLoadRuntimeConfig_ShouldLoadEmptyFile(t *testing.T) {
 `)
 	actual, err := loadRuntimeConfig(yamlFile)
 	require.NoError(t, err)
-	assert.Equal(t, &runtimeConfigValues{}, actual)
+	assert.Equal(t, &RuntimeConfigValues{}, actual)
 }
 
 func TestLoadRuntimeConfig_ShouldReturnErrorOnMultipleDocumentsInTheConfig(t *testing.T) {


### PR DESCRIPTION
Make the struct used for runtime configuration public to allow subscribers
to `runtimeconfig.Manager` update channels to cast messages and use the
configuration values they receive. This is useful for allowing extension
modules to use runtime configuration.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
