### PR TITLE
skipLabelNameValidation can now be set per request so no longer needed in config

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -170,10 +170,6 @@ type Config struct {
 	// for testing and for extending the ingester by adding calls to the client
 	IngesterClientFactory ring_client.PoolFactory `yaml:"-"`
 
-	// when true the distributor does not validate the label name, Cortex doesn't directly use
-	// this (and should never use it) but this feature is used by other projects built on top of it
-	SkipLabelNameValidation bool `yaml:"-"`
-
 	// This config is dynamically injected because defined in the querier config.
 	ShuffleShardingLookbackPeriod time.Duration `yaml:"-"`
 }
@@ -496,8 +492,7 @@ func (d *Distributor) Push(ctx context.Context, req *ingester_client.WriteReques
 			return nil, err
 		}
 
-		skipLabelNameValidation := d.cfg.SkipLabelNameValidation || req.GetSkipLabelNameValidation()
-		validatedSeries, err := d.validateSeries(ts, userID, skipLabelNameValidation)
+		validatedSeries, err := d.validateSeries(ts, userID, req.GetSkipLabelNameValidation())
 
 		// Errors in validation are considered non-fatal, as one series in a request may contain
 		// invalid data but all the remaining series could be perfectly valid.

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -840,7 +840,6 @@ func TestDistributor_Push_LabelNameValidation(t *testing.T) {
 	}
 	tests := map[string]struct {
 		inputLabels                labels.Labels
-		skipLabelNameValidationCfg bool
 		skipLabelNameValidationReq bool
 		errExpected                bool
 		errMessage                 string
@@ -849,11 +848,6 @@ func TestDistributor_Push_LabelNameValidation(t *testing.T) {
 			inputLabels: inputLabels,
 			errExpected: true,
 			errMessage:  `sample invalid label: "999.illegal" metric "foo{999.illegal=\"baz\"}"`,
-		},
-		"label name validation can be skipped via config": {
-			inputLabels:                inputLabels,
-			skipLabelNameValidationCfg: true,
-			errExpected:                false,
 		},
 		"label name validation can be skipped via WriteRequest parameter": {
 			inputLabels:                inputLabels,
@@ -865,11 +859,10 @@ func TestDistributor_Push_LabelNameValidation(t *testing.T) {
 	for testName, tc := range tests {
 		t.Run(testName, func(t *testing.T) {
 			ds, _, _ := prepare(t, prepConfig{
-				numIngesters:            2,
-				happyIngesters:          2,
-				numDistributors:         1,
-				shuffleShardSize:        1,
-				skipLabelNameValidation: tc.skipLabelNameValidationCfg,
+				numIngesters:     2,
+				happyIngesters:   2,
+				numDistributors:  1,
+				shuffleShardSize: 1,
 			})
 			req := mockWriteRequest(tc.inputLabels, 42, 100000)
 			req.SkipLabelNameValidation = tc.skipLabelNameValidationReq
@@ -1124,7 +1117,6 @@ type prepConfig struct {
 	shuffleShardSize             int
 	limits                       *validation.Limits
 	numDistributors              int
-	skipLabelNameValidation      bool
 }
 
 func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, *ring.Ring) {
@@ -1203,7 +1195,6 @@ func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, *rin
 		distributorCfg.DistributorRing.InstanceID = strconv.Itoa(i)
 		distributorCfg.DistributorRing.KVStore.Mock = kvStore
 		distributorCfg.DistributorRing.InstanceAddr = "127.0.0.1"
-		distributorCfg.SkipLabelNameValidation = cfg.skipLabelNameValidation
 
 		if cfg.shuffleShardEnabled {
 			distributorCfg.ShardingStrategy = util.ShardingStrategyShuffle


### PR DESCRIPTION
Was moved to a `WriteRequest` parameter in https://github.com/cortexproject/cortex/pull/3736

Signed-off-by: Trevor Whitney <trevorjwhitney@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Remove `SkipLabelNameValidation` from the distributor config as it can now be configured per request.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
