### PR TITLE
thanosconvert: convert block meta from Thanos to Cortex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * `-ruler.alertmanager-client.tls-insecure-skip-verify`: Boolean to disable verifying the certificate.
   * `-ruler.alertmanager-client.tls-key-path`: File path to the TLS key certificate.
   * `-ruler.alertmanager-client.tls-server-name`: Expected name on the TLS certificate.
+* [FEATURE] Experimental thanosconvert: introduce an experimental tool `thanosconvert` to migrate Thanos block metadata to Cortex metadata. #3770
 * [ENHANCEMENT] Ingester: exposed metric `cortex_ingester_oldest_unshipped_block_timestamp_seconds`, tracking the unix timestamp of the oldest TSDB block not shipped to the storage yet. #3705
 * [ENHANCEMENT] Prometheus upgraded. #3739
   * Avoid unnecessary `runtime.GC()` during compactions.

--- a/cmd/thanosconvert/Dockerfile
+++ b/cmd/thanosconvert/Dockerfile
@@ -1,0 +1,9 @@
+FROM       alpine:3.12
+RUN        apk add --no-cache ca-certificates
+COPY       thanosconvert /
+ENTRYPOINT ["/thanosconvert"]
+
+ARG revision
+LABEL org.opencontainers.image.title="thanosconvert" \
+      org.opencontainers.image.source="https://github.com/cortexproject/cortex/tree/master/tools/thanosconvert" \
+      org.opencontainers.image.revision="${revision}"

--- a/cmd/thanosconvert/main.go
+++ b/cmd/thanosconvert/main.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
-	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/tools/thanosconvert"
 )
 
@@ -36,7 +36,7 @@ func main() {
 	}
 	flag.Parse()
 
-	logger, err := util.NewPrometheusLogger(loglvl, logfmt)
+	logger, err := log.NewPrometheusLogger(loglvl, logfmt)
 	if err != nil {
 		fmt.Printf("failed to create logger: %v\n", err)
 		flag.Usage()

--- a/cmd/thanosconvert/main.go
+++ b/cmd/thanosconvert/main.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/go-kit/kit/log/level"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/server"
 	"gopkg.in/yaml.v2"
 
@@ -37,8 +36,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	registry := prometheus.DefaultRegisterer
-
 	ctx := context.Background()
 
 	cfg := bucket.Config{}
@@ -54,7 +51,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	converter, err := thanosconvert.NewThanosBlockConverter(ctx, cfg, dryRun, util.Logger, registry)
+	converter, err := thanosconvert.NewThanosBlockConverter(ctx, cfg, dryRun, util.Logger)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "failed to initialize", "err", err)
 		os.Exit(1)
@@ -63,7 +60,7 @@ func main() {
 	iterCtx := context.Background()
 	results, err := converter.Run(iterCtx)
 	if err != nil {
-		level.Error(util.Logger).Log("msg", "iterate blocks", "err", err)
+		level.Error(util.Logger).Log("msg", "error while iterating blocks", "err", err)
 		os.Exit(1)
 	}
 

--- a/cmd/thanosconvert/main.go
+++ b/cmd/thanosconvert/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaveworks/common/server"
+	"gopkg.in/yaml.v2"
+
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/cortexproject/cortex/tools/thanosconvert"
+)
+
+var (
+	configFilename string
+	dryRun         bool
+)
+
+func main() {
+	serverConfig := server.Config{}
+	serverConfig.RegisterFlags(flag.CommandLine)
+	flag.StringVar(&configFilename, "config", "", "Path to bucket config YAML")
+	flag.BoolVar(&dryRun, "dry-run", false, "Don't make changes; only report what needs to be done")
+	flag.Parse()
+
+	util.InitLogger(&serverConfig)
+
+	if configFilename == "" {
+		level.Error(util.Logger).Log("msg", "-config is required")
+		os.Exit(1)
+	}
+
+	registry := prometheus.DefaultRegisterer
+
+	ctx := context.Background()
+
+	cfg := bucket.Config{}
+
+	buf, err := ioutil.ReadFile(configFilename)
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "failed to load config file", "err", err, "filename", configFilename)
+		os.Exit(1)
+	}
+	err = yaml.UnmarshalStrict(buf, &cfg)
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "failed to parse config", "err", err)
+		os.Exit(1)
+	}
+
+	converter, err := thanosconvert.NewThanosBlockConverter(ctx, cfg, dryRun, util.Logger, registry)
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "failed to initialize", "err", err)
+		os.Exit(1)
+	}
+
+	iterCtx := context.Background()
+	results, err := converter.Run(iterCtx)
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "iterate blocks", "err", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Results:")
+	for user, res := range results {
+		fmt.Printf("User %s:\n", user)
+		fmt.Printf("  Converted %d:\n  %s", len(res.ConvertedBlocks), strings.Join(res.ConvertedBlocks, ","))
+		fmt.Printf("  Unchanged %d:\n  %s", len(res.UnchangedBlocks), strings.Join(res.UnchangedBlocks, ","))
+		fmt.Printf("  Failed %d:\n  %s", len(res.FailedBlocks), strings.Join(res.FailedBlocks, ","))
+	}
+
+}

--- a/docs/blocks-storage/migrate-storage-from-thanos-and-prometheus.md
+++ b/docs/blocks-storage/migrate-storage-from-thanos-and-prometheus.md
@@ -18,18 +18,57 @@ The Cortex blocks storage has few requirements that should be considered when mi
 
 ## How to migrate the storage
 
-Currently, no tool is provided to migrate TSDB blocks from Thanos / Prometheus to Cortex, but writing an automation should be fairly easy. This automation could do the following:
-
-1. Upload TSDB blocks from Thanos / Prometheus to Cortex bucket
-2. Manipulate `meta.json` file for each block in the Cortex bucket
-
 ### Upload TSDB blocks to Cortex bucket
 
 TSDB blocks stored in Prometheus local disk or Thanos bucket should be copied/uploaded to the Cortex bucket at the location `bucket://<tenant-id>/` (when Cortex is running with auth disabled then `<tenant-id>` must be `fake`).
 
-### Manipulate `meta.json` file
+### Migrate block metadata (`meta.json`) to Cortex
 
-For each block copied/uploaded to the Cortex bucket, the `meta.json` should be manipulated. The easiest approach would be iterating the tenants and blocks in the bucket and for each block:
+For each block copied/uploaded to the Cortex bucket, there are a few changes required to the `meta.json`.
+
+#### Automatically migrate metadata using the `thanosconvert` tool
+
+`thanosconvert` can iterate over a Cortex bucket and make sure that each `meta.json` has the correct `thanos` > `labels` layout.
+
+⚠️  `thanosconvert` will modify files in the bucket you specify. It's recommended that you have backups or enable object versioning before running this tool.
+
+To run `thanosconvert`, you need to provide a YAML file with bucket configuration in the same format as the [blocks storage bucket configuration](../configuration/config-file-reference.md#blocks_storage_config). For example, for s3:
+```yaml
+# bucket-config.yaml
+backend: s3
+s3:
+  endpoint: s3.us-east-1.amazonaws.com
+  bucket_name: my-cortex-bucket
+```
+
+You can run thanosconvert directly using Go:
+```bash
+go install github.com/cortexproject/cortex/cmd/thanosconvert
+thanosconvert
+```
+
+Or use the provided docker image:
+```bash
+docker run quay.io/cortexproject/thanosconvert
+```
+
+You can run the tool in dry-run mode first to find out what which blocks it will migrate:
+
+```bash
+thanosconvert -config ./bucket-config.yaml -dry-run
+```
+
+Once you're happy with the results, you can run without dry run to migrate blocks:
+```bash
+thanosconvert -config ./bucket-config.yaml
+```
+
+You can cancel a conversion in progress (with Ctrl+C) and rerun `thanosconvert`. It won't change any blocks which have been written by Cortex or already converted from Thanos, so you can run `thanosconvert` multiple times.
+
+
+#### Migrate metadata manually
+
+If you need to migrate the block metadata manually, you need to:
 
 1. Download the `meta.json` to the local filesystem
 2. Decode the JSON
@@ -43,7 +82,8 @@ The `meta.json` should be manipulated in order to ensure:
 - The `thanos` > `labels` do not contain any Thanos-specific external label
 - The `thanos` > `labels` contain the Cortex-specific external label `"__org_id__": "<tenant-id>"`
 
-#### When migrating from Thanos
+
+##### When migrating from Thanos
 
 When migrating from Thanos, the easiest approach would be keep the existing `thanos` root-level entry as is, except:
 
@@ -66,7 +106,7 @@ For example, when migrating a block from Thanos for the tenant `user-1`, the `th
 }
 ```
 
-#### When migrating from Prometheus
+##### When migrating from Prometheus
 
 When migrating from Prometheus, the `meta.json` file will not contain any `thanos` root-level entry and, for this reason, it would need to be generated:
 

--- a/docs/blocks-storage/migrate-storage-from-thanos-and-prometheus.md
+++ b/docs/blocks-storage/migrate-storage-from-thanos-and-prometheus.md
@@ -30,9 +30,9 @@ For each block copied/uploaded to the Cortex bucket, there are a few changes req
 
 `thanosconvert` can iterate over a Cortex bucket and make sure that each `meta.json` has the correct `thanos` > `labels` layout.
 
-⚠️  `thanosconvert` will modify files in the bucket you specify. It's recommended that you have backups or enable object versioning before running this tool.
+⚠ Warning ⚠ `thanosconvert` will modify files in the bucket you specify. It's recommended that you have backups or enable object versioning before running this tool.
 
-To run `thanosconvert`, you need to provide a YAML file with bucket configuration in the same format as the [blocks storage bucket configuration](../configuration/config-file-reference.md#blocks_storage_config). For example, for s3:
+To run `thanosconvert`, you need to provide it with the bucket configuration in the same format as the [blocks storage bucket configuration](../configuration/config-file-reference.md#blocks_storage_config).
 ```yaml
 # bucket-config.yaml
 backend: s3

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -68,3 +68,4 @@ Currently experimental features are:
   - The block deletion marks migration support in the compactor (`-compactor.block-deletion-marks-migration-enabled`) is temporarily and will be removed in future versions
 - Querier: tenant federation
 - Alertmanager: Sharding of tenants across multiple instances
+- The thanosconvert tool for converting Thanos block metadata to Cortex

--- a/tools/thanosconvert/thanosconvert.go
+++ b/tools/thanosconvert/thanosconvert.go
@@ -1,0 +1,195 @@
+package thanosconvert
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/objstore"
+
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
+)
+
+// ThanosBlockConverter converts blocks written by Thanos to make them readable by Cortex
+type ThanosBlockConverter struct {
+	logger log.Logger
+	bkt    objstore.Bucket
+	dryRun bool
+}
+
+type PerUserResults struct {
+	FailedBlocks, ConvertedBlocks, UnchangedBlocks []string
+}
+
+func NewPerUserResults() PerUserResults {
+	return PerUserResults{
+		FailedBlocks:    []string{},
+		ConvertedBlocks: []string{},
+		UnchangedBlocks: []string{},
+	}
+}
+
+func (r *PerUserResults) AddFailed(blockID string) {
+	r.FailedBlocks = append(r.FailedBlocks, blockID)
+}
+func (r *PerUserResults) AddConverted(blockID string) {
+	r.ConvertedBlocks = append(r.ConvertedBlocks, blockID)
+}
+
+func (r *PerUserResults) AddUnchanged(blockID string) {
+	r.UnchangedBlocks = append(r.UnchangedBlocks, blockID)
+}
+
+type Results map[string]PerUserResults
+
+// NewThanosBlockConverter creates a ThanosBlockConverter
+func NewThanosBlockConverter(ctx context.Context, cfg bucket.Config, dryRun bool, logger log.Logger, reg prometheus.Registerer) (*ThanosBlockConverter, error) {
+	bkt, err := bucket.NewClient(ctx, cfg, "thanosconvert", logger, reg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ThanosBlockConverter{
+		bkt:    bkt,
+		logger: logger,
+		dryRun: dryRun,
+	}, err
+}
+
+// Run iterates over all blocks from all users in a bucket
+func (c ThanosBlockConverter) Run(ctx context.Context) (Results, error) {
+	results := make(Results)
+
+	// discover users in the bucket
+	var users []string
+	err := c.bkt.Iter(ctx, "", func(o string) error {
+		users = append(users, strings.TrimSuffix(o, "/"))
+		return nil
+	})
+	if err != nil {
+		return results, err
+	}
+	level.Info(c.logger).Log("msg", "Scanned tenants")
+
+	for _, u := range users {
+		r, err := c.convertUser(ctx, u)
+		results[u] = r
+		if err != nil {
+			return results, errors.Wrap(err, fmt.Sprintf("error converting user %s", u))
+		}
+	}
+	return results, nil
+}
+
+func (c ThanosBlockConverter) convertUser(ctx context.Context, user string) (PerUserResults, error) {
+	results := PerUserResults{}
+
+	err := c.bkt.Iter(ctx, user, func(o string) error {
+		// get block ID from path
+
+		parts := strings.Split(o, "/")
+		if len(parts) != 3 {
+			// this seems pretty bad, let's bail out
+			return errors.Errorf("couldn't parse bucket path %s as {user}/{block}/", o)
+		}
+		blockID := parts[1]
+		level.Debug(c.logger).Log("msg", "Processing block", "block", blockID)
+
+		// retrieve meta.json
+
+		metaKey := fmt.Sprintf("%s/%s/meta.json", user, blockID)
+		r, err := c.bkt.Get(ctx, metaKey)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Get meta.json", "block", blockID, "meta_key", metaKey, "err", err.Error())
+			results.AddFailed(blockID)
+			return nil
+		}
+
+		meta := &metadata.Meta{}
+		decoder := json.NewDecoder(r)
+		err = decoder.Decode(meta)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "decode meta.json into metadata.Meta", "block", blockID, "meta_key", metaKey, "err", err.Error())
+			results.AddFailed(blockID)
+			return nil
+		}
+
+		// convert and upload if appropriate
+
+		newMeta, changesRequired := convertMetadata(*meta, user)
+
+		if len(changesRequired) > 0 {
+			if c.dryRun {
+				level.Debug(c.logger).Log("msg", "Block requires changes, not uploading due to dry run", "block", blockID, "changes_required", strings.Join(changesRequired, ","))
+			} else {
+				level.Debug(c.logger).Log("msg", "Block requires changes, uploading new meta.json", "block", blockID, "changes_required", strings.Join(changesRequired, ","))
+				if err := c.uploadNewMeta(ctx, user, blockID, newMeta); err != nil {
+					level.Error(c.logger).Log("msg", "Update meta.json", "block", blockID, "meta_key", metaKey, "err", err.Error())
+					results.AddFailed(blockID)
+					return nil
+				}
+			}
+			results.AddConverted(blockID)
+		} else {
+			results.AddUnchanged(blockID)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return results, err
+	}
+
+	return results, nil
+}
+
+func (c *ThanosBlockConverter) uploadNewMeta(ctx context.Context, user, blockID string, meta metadata.Meta) error {
+	key := fmt.Sprintf("%s/%s/meta.json", user, blockID)
+
+	var body bytes.Buffer
+	enc := json.NewEncoder(&body)
+	if err := enc.Encode(meta); err != nil {
+		return errors.Wrap(err, "encode json")
+	}
+
+	if err := c.bkt.Upload(ctx, key, &body); err != nil {
+		return errors.Wrap(err, "upload to bucket")
+	}
+	return nil
+}
+
+func convertMetadata(meta metadata.Meta, expectedUser string) (metadata.Meta, []string) {
+	var changesRequired []string
+
+	if meta.Thanos.Labels == nil {
+		// TODO: no "thanos" entry could mean this block is corrupt - should we bail out instead?
+		meta.Thanos.Labels = map[string]string{}
+		// don't need to add to changesRequired, since the code below will notice lack of org id
+	}
+
+	org, ok := meta.Thanos.Labels["__org_id__"]
+	if !ok {
+		changesRequired = append(changesRequired, "add __org_id__ label")
+	} else if org != expectedUser {
+		changesRequired = append(changesRequired, fmt.Sprintf("change __org_id__ from %s to %s", org, expectedUser))
+	}
+
+	// remove __org_id__ so that we can see if there are any other labels
+	delete(meta.Thanos.Labels, "__org_id__")
+	if len(meta.Thanos.Labels) > 0 {
+		changesRequired = append(changesRequired, "remove extra Thanos labels")
+	}
+
+	meta.Thanos.Labels = map[string]string{
+		"__org_id__": expectedUser,
+	}
+
+	return meta, changesRequired
+}

--- a/tools/thanosconvert/thanosconvert_test.go
+++ b/tools/thanosconvert/thanosconvert_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
-	"github.com/cortexproject/cortex/pkg/util"
+	utillog "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 func stringNotEmpty(v string) bool {
@@ -214,7 +214,7 @@ func getLogger() log.Logger {
 		panic(err)
 	}
 
-	logger, err := util.NewPrometheusLogger(l, f)
+	logger, err := utillog.NewPrometheusLogger(l, f)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/thanosconvert/thanosconvert_test.go
+++ b/tools/thanosconvert/thanosconvert_test.go
@@ -327,6 +327,23 @@ func TestConvertMetadata(t *testing.T) {
 			changesRequired: []string{"add __org_id__ label"},
 		},
 		{
+			name:         "nil labels map",
+			expectedUser: "user1",
+			in: metadata.Meta{
+				Thanos: metadata.Thanos{
+					Labels: nil,
+				},
+			},
+			out: metadata.Meta{
+				Thanos: metadata.Thanos{
+					Labels: map[string]string{
+						cortex_tsdb.TenantIDExternalLabel: "user1",
+					},
+				},
+			},
+			changesRequired: []string{"add __org_id__ label"},
+		},
+		{
 			name:         "remove extra Thanos labels",
 			expectedUser: "user1",
 			in: metadata.Meta{

--- a/tools/thanosconvert/thanosconvert_test.go
+++ b/tools/thanosconvert/thanosconvert_test.go
@@ -1,0 +1,355 @@
+package thanosconvert
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/weaveworks/common/logging"
+
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+func stringNotEmpty(v string) bool {
+	return v != ""
+}
+
+type fakeBucket map[string]map[string]metadata.Meta
+
+func TestThanosBlockConverter(t *testing.T) {
+	tests := []struct {
+		name       string
+		bucketData fakeBucket
+		assertions func(*testing.T, *bucket.ClientMock, Results, error)
+	}{
+		{
+			name:       "empty bucket is a noop",
+			bucketData: fakeBucket{},
+			assertions: func(t *testing.T, bkt *bucket.ClientMock, results Results, err error) {
+				bkt.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
+				bkt.AssertNotCalled(t, "Upload", mock.Anything, mock.Anything, mock.Anything)
+				assert.Len(t, results, 0, "expected no users in results")
+			},
+		},
+		{
+			name:       "user with no blocks is a noop",
+			bucketData: fakeBucket{"user1": map[string]metadata.Meta{}},
+			assertions: func(t *testing.T, bkt *bucket.ClientMock, results Results, err error) {
+				bkt.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
+				bkt.AssertNotCalled(t, "Upload", mock.Anything, mock.Anything, mock.Anything)
+				assert.Contains(t, results, "user1")
+				assert.Len(t, results["user1"].FailedBlocks, 0)
+				assert.Len(t, results["user1"].ConvertedBlocks, 0)
+				assert.Len(t, results["user1"].UnchangedBlocks, 0)
+			},
+		},
+		{
+			name: "bucket fully converted is a noop",
+			bucketData: fakeBucket{
+				"user1": map[string]metadata.Meta{
+					"block1": CortexMeta("user1"),
+					"block2": CortexMeta("user1"),
+					"block3": CortexMeta("user1"),
+				},
+				"user2": map[string]metadata.Meta{
+					"block1": CortexMeta("user2"),
+					"block2": CortexMeta("user2"),
+				},
+				"user3": map[string]metadata.Meta{
+					"block1": CortexMeta("user3"),
+				},
+			},
+			assertions: func(t *testing.T, bkt *bucket.ClientMock, results Results, err error) {
+				bkt.AssertNotCalled(t, "Upload", mock.Anything, mock.Anything, mock.Anything)
+				assert.Len(t, results, 3, "expected users in results")
+
+				assert.Len(t, results["user1"].FailedBlocks, 0)
+				assert.Len(t, results["user1"].ConvertedBlocks, 0)
+				assert.ElementsMatch(t, results["user1"].UnchangedBlocks, []string{"block1", "block2", "block3"})
+
+				assert.Len(t, results["user2"].FailedBlocks, 0)
+				assert.Len(t, results["user2"].ConvertedBlocks, 0)
+				assert.ElementsMatch(t, results["user2"].UnchangedBlocks, []string{"block1", "block2"})
+
+				assert.Len(t, results["user3"].FailedBlocks, 0)
+				assert.Len(t, results["user3"].ConvertedBlocks, 0)
+				assert.ElementsMatch(t, results["user3"].UnchangedBlocks, []string{"block1"})
+
+			},
+		},
+		{
+			name: "bucket with some blocks to convert",
+			bucketData: fakeBucket{
+				"user1": map[string]metadata.Meta{
+					"block1": CortexMeta("user1"),
+					"block2": ThanosMeta(),
+					"block3": CortexMeta("user1"),
+				},
+				"user2": map[string]metadata.Meta{
+					"block1": CortexMeta("user2"),
+					"block2": CortexMeta("user2"),
+				},
+				"user3": map[string]metadata.Meta{
+					"block1": ThanosMeta(),
+				},
+			},
+			assertions: func(t *testing.T, bkt *bucket.ClientMock, results Results, err error) {
+				assert.Len(t, results, 3, "expected users in results")
+
+				assert.Len(t, results["user1"].FailedBlocks, 0)
+				assert.ElementsMatch(t, results["user1"].ConvertedBlocks, []string{"block2"})
+				assert.ElementsMatch(t, results["user1"].UnchangedBlocks, []string{"block1", "block3"})
+
+				assert.Len(t, results["user2"].FailedBlocks, 0)
+				assert.Len(t, results["user2"].ConvertedBlocks, 0)
+				assert.ElementsMatch(t, results["user2"].UnchangedBlocks, []string{"block1", "block2"})
+
+				assert.Len(t, results["user3"].FailedBlocks, 0)
+				assert.ElementsMatch(t, results["user3"].ConvertedBlocks, []string{"block1"})
+				assert.Len(t, results["user3"].UnchangedBlocks, 0)
+
+				bkt.AssertNumberOfCalls(t, "Upload", 2)
+			},
+		},
+		{
+			name: "bucket with failed blocks",
+			bucketData: fakeBucket{
+				"user1": map[string]metadata.Meta{
+					"block1":                 CortexMeta("user1"),
+					"block_with_get_failure": CortexMeta("user1"),
+					"block3":                 CortexMeta("user1"),
+				},
+				"user2": map[string]metadata.Meta{
+					"block1": CortexMeta("user2"),
+					"block2": CortexMeta("user2"),
+				},
+				"user3": map[string]metadata.Meta{
+					"block_with_upload_failure": ThanosMeta(),
+					"block_with_malformed_meta": ThanosMeta(),
+				},
+			},
+			assertions: func(t *testing.T, bkt *bucket.ClientMock, results Results, err error) {
+				assert.Len(t, results["user1"].FailedBlocks, 1)
+				assert.Len(t, results["user2"].FailedBlocks, 0)
+				assert.Len(t, results["user3"].FailedBlocks, 2)
+			},
+		},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(t *testing.T) {
+
+			bkt := MockBucket(test.bucketData)
+
+			converter := &ThanosBlockConverter{
+				logger: GetLogger(),
+				dryRun: false,
+				bkt:    bkt,
+			}
+
+			ctx := context.Background()
+			results, err := converter.Run(ctx)
+			test.assertions(t, bkt, results, err)
+		})
+	}
+}
+
+func CortexMeta(user string) metadata.Meta {
+	return metadata.Meta{
+		Thanos: metadata.Thanos{
+			Labels: map[string]string{
+				"__org_id__": user,
+			},
+		},
+	}
+}
+
+func ThanosMeta() metadata.Meta {
+	return metadata.Meta{
+		Thanos: metadata.Thanos{
+			Labels: map[string]string{
+				"cluster": "foo",
+			},
+		},
+	}
+}
+
+func GetLogger() log.Logger {
+
+	l := logging.Level{}
+	if err := l.Set("info"); err != nil {
+		panic(err)
+	}
+	f := logging.Format{}
+	if err := f.Set("logfmt"); err != nil {
+		panic(err)
+	}
+
+	logger, err := util.NewPrometheusLogger(l, f)
+	if err != nil {
+		panic(err)
+	}
+	return logger
+}
+
+func MockBucket(data fakeBucket) *bucket.ClientMock {
+
+	bkt := bucket.ClientMock{}
+	bkt.On("Iter", mock.Anything, "", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		// we're iterating over the top level users
+		f := args.Get(2).(func(string) error)
+		for user := range data {
+			if err := f(user); err != nil {
+				panic(err)
+			}
+		}
+	})
+
+	bkt.On("Iter", mock.Anything, mock.MatchedBy(stringNotEmpty), mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		// we're iterating over blocks within a user
+		user := args.String(1)
+		f := args.Get(2).(func(string) error)
+		if _, ok := data[user]; !ok {
+			panic(fmt.Sprintf("key %s not found in fake bucket data", user))
+		}
+		for block := range data[user] {
+			if err := f(fmt.Sprintf("%s/%s/", user, block)); err != nil {
+				panic(err)
+			}
+		}
+	})
+
+	for user, blocks := range data {
+		for block, meta := range blocks {
+
+			var body bytes.Buffer
+			enc := json.NewEncoder(&body)
+			if err := enc.Encode(meta); err != nil {
+				panic(err)
+			}
+			key := fmt.Sprintf("%s/%s/meta.json", user, block)
+			switch block {
+			case "block_with_get_failure":
+				bkt.On("Get", mock.Anything, key).Return(nil, errors.Errorf("test error in Get"))
+			case "block_with_malformed_meta":
+				bkt.On("Get", mock.Anything, key).Return(ioutil.NopCloser(bytes.NewBufferString("invalid json")), nil)
+			default:
+				bkt.On("Get", mock.Anything, key).Return(ioutil.NopCloser(&body), nil)
+			}
+
+			switch block {
+			case "block_with_upload_failure":
+				bkt.On("Upload", mock.Anything, key, mock.Anything).Return(errors.Errorf("test error in Upload"))
+			default:
+				bkt.On("Upload", mock.Anything, key, mock.Anything).Return(nil)
+			}
+		}
+	}
+
+	return &bkt
+}
+
+func TestConvertMetadata(t *testing.T) {
+	tests := []struct {
+		name            string
+		expectedUser    string
+		in              metadata.Meta
+		out             metadata.Meta
+		changesRequired []string
+	}{
+		{
+			name:         "no changes required",
+			expectedUser: "user1",
+			in: metadata.Meta{
+				Thanos: metadata.Thanos{
+					Labels: map[string]string{
+						"__org_id__": "user1",
+					},
+				},
+			},
+			out: metadata.Meta{
+				Thanos: metadata.Thanos{
+					Labels: map[string]string{
+						"__org_id__": "user1",
+					},
+				},
+			},
+			changesRequired: []string{},
+		},
+		{
+			name:         "add __org_id__ label",
+			expectedUser: "user1",
+			in: metadata.Meta{
+				Thanos: metadata.Thanos{
+					Labels: map[string]string{},
+				},
+			},
+			out: metadata.Meta{
+				Thanos: metadata.Thanos{
+					Labels: map[string]string{
+						"__org_id__": "user1",
+					},
+				},
+			},
+			changesRequired: []string{"add __org_id__ label"},
+		},
+		{
+			name:         "remove extra Thanos labels",
+			expectedUser: "user1",
+			in: metadata.Meta{
+				Thanos: metadata.Thanos{
+					Labels: map[string]string{
+						"__org_id__": "user1",
+						"extra":      "label",
+						"cluster":    "foo",
+					},
+				},
+			},
+			out: metadata.Meta{
+				Thanos: metadata.Thanos{
+					Labels: map[string]string{
+						"__org_id__": "user1",
+					},
+				},
+			},
+			changesRequired: []string{"remove extra Thanos labels"},
+		},
+		{
+			name:         "fix __org_id__",
+			expectedUser: "user1",
+			in: metadata.Meta{
+				Thanos: metadata.Thanos{
+					Labels: map[string]string{
+						"__org_id__": "wrong_user",
+					},
+				},
+			},
+			out: metadata.Meta{
+				Thanos: metadata.Thanos{
+					Labels: map[string]string{
+						"__org_id__": "user1",
+					},
+				},
+			},
+			changesRequired: []string{"change __org_id__ from wrong_user to user1"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out, changesRequired := convertMetadata(test.in, test.expectedUser)
+			assert.Equal(t, test.out, out)
+			assert.ElementsMatch(t, changesRequired, test.changesRequired)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

thanosconvert is a small tool to iterate over a bucket and convert block-level metadata (in meta.json) so that it is readable by Cortex. This tool assumes that users have already copied Thanos blocks over to a destination bucket, with blocks organised by user at the top level.

This is a relatively simple serial implementation - it's pretty quick to run so making it concurrent is probably unnecessary, at least for a v1. I've only tested this with S3, but since it uses `github.com/thanos-io/thanos/pkg/objstore` it should work with all the other supported block stores. It reuses the same `pkg/storage/bucket.Config` struct for bucket configuration so should be easy to configure for users who already have the store-gateway/querier running.

It's idempotent so is safe to run multiple times against the same bucket, and leaves Cortex blocks untouched. It will log any errors it encounters but keeps going.

I'm happy that this is mostly complete, but there's a few things left to do - I'd love some feedback before I finish it off!

**Which issue(s) this PR fixes**:
Fixes #2920

**Checklist**
- [x] Add CLI usage message
- [x] Clean up, comment public API methods
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
