### PR TITLE
Fix ring lifecycler when 'unregister on shutdown' is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [CHANGE] Require explicit flag `-<prefix>.tls-enabled` to enable TLS in GRPC clients. Previously it was enough to specify a TLS flag to enable TLS validation. #3156
 * [CHANGE] Query-frontend: removed `-querier.split-queries-by-day` (deprecated in Cortex 0.4.0). You should use `-querier.split-queries-by-interval` instead. #3813
 * [CHANGE] Ingester: at startup, if the ingester is already registered in the ring with the `LEAVING` state, it will be switched back to `PENDING` keeping the previous tokens and then follow the normal lifecycler workflow. #3774
-* [FEATURE] Adds support to S3 server side encryption using KMS. Deprecated `-<prefix>.s3.sse-encryption`, you should use the following CLI flags that have been added. #3651
+* [FEATURE] Adds support to S3 server side encryption using KMS. Deprecated `-<prefix>.s3.sse-encryption`, you should use the following CLI flags that have been added. #3651 #3810
   - `-<prefix>.s3.sse.type`
   - `-<prefix>.s3.sse.kms-key-id`
   - `-<prefix>.s3.sse.kms-encryption-context`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * [CHANGE] Ingester: don't update internal "last updated" timestamp of TSDB if tenant only sends invalid samples. This affects how "idle" time is computed. #3727
 * [CHANGE] Require explicit flag `-<prefix>.tls-enabled` to enable TLS in GRPC clients. Previously it was enough to specify a TLS flag to enable TLS validation. #3156
 * [CHANGE] Query-frontend: removed `-querier.split-queries-by-day` (deprecated in Cortex 0.4.0). You should use `-querier.split-queries-by-interval` instead. #3813
-* [FEATURE] Adds support to S3 server side encryption using KMS. Deprecated `-<prefix>.s3.sse-encryption`, you should use the following CLI flags that have been added. #3651 #3810
+* [CHANGE] Ingester: at startup, if the ingester is already registered in the ring with the `LEAVING` state, it will be switched back to `PENDING` keeping the previous tokens and then follow the normal lifecycler workflow. #3774
+* [FEATURE] Adds support to S3 server side encryption using KMS. Deprecated `-<prefix>.s3.sse-encryption`, you should use the following CLI flags that have been added. #3651
   - `-<prefix>.s3.sse.type`
   - `-<prefix>.s3.sse.kms-key-id`
   - `-<prefix>.s3.sse.kms-encryption-context`

--- a/pkg/ring/flush.go
+++ b/pkg/ring/flush.go
@@ -31,6 +31,6 @@ func NewNoopFlushTransferer() *NoopFlushTransferer {
 func (t *NoopFlushTransferer) Flush() {}
 
 // TransferOut is a noop
-func (t *NoopFlushTransferer) TransferOut(ctx context.Context) error {
+func (t *NoopFlushTransferer) TransferOut(_ context.Context) error {
 	return nil
 }

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -567,7 +567,7 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 
 		// The instance may already be in the ring with one of the following states:
 		// - JOINING: this means it crashed due to a failed token transfer or some other reason during startup.
-		// - LEAVING: this means it crashed while shutting down and unregister from ring on shutdown is disabled.
+		// - LEAVING: this means it crashed while shutting down or unregister from ring on shutdown is disabled.
 		// In both cases, we want to set it back to PENDING in order to start the lifecycle from the beginning.
 		if instanceDesc.State == JOINING || instanceDesc.State == LEAVING {
 			level.Info(log.Logger).Log("msg", "instance already found in ring, changing state to PENDING", "state", instanceDesc.State, "ring", i.RingName)

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -223,12 +223,16 @@ func (i *Lifecycler) CheckReady(ctx context.Context) error {
 	}
 
 	if len(i.getTokens()) == 0 {
-		return fmt.Errorf("this instance owns no tokens")
+		return errors.New("this instance owns no tokens")
+	}
+
+	if currState := i.GetState(); currState != ACTIVE {
+		return fmt.Errorf("this instance state is %s while %s is expected to be ready", currState, ACTIVE)
 	}
 
 	ringDesc, ok := desc.(*Desc)
 	if !ok || ringDesc == nil {
-		return fmt.Errorf("no ring returned from the KV store")
+		return errors.New("no ring returned from the KV store")
 	}
 
 	if err := ringDesc.Ready(time.Now(), i.cfg.RingConfig.HeartbeatTimeout); err != nil {

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -583,6 +583,9 @@ func (i *Lifecycler) initRing(ctx context.Context) error {
 
 		// Update the ring if the instance has been changed.
 		if !instanceDesc.Equal(ringDesc.Ingesters[i.ID]) {
+			// Update timestamp to give gossiping client a chance register ring change.
+			instanceDesc.Timestamp = time.Now().Unix()
+
 			ringDesc.Ingesters[i.ID] = instanceDesc
 			return ringDesc, true, nil
 		}

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -1903,7 +1903,7 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 		UnregisterOnShutdown: true,
 	}
 
-	lc, err := NewLifecycler(lcCfg, &noopFlushTransferer{}, "test", "test", false, nil)
+	lc, err := NewLifecycler(lcCfg, NewNoopFlushTransferer(), "test", "test", false, nil)
 	require.NoError(t, err)
 
 	lc.AddListener(services.NewListener(nil, nil, nil, nil, func(from services.State, failure error) {


### PR DESCRIPTION
**What this PR does**:
The PR https://github.com/cortexproject/cortex/pull/3305 introduced an option to let an ingester stay in the ring on shutdown. In some of our clusters, we're already testing it (in conjunction with the option to extend writes on failure) to avoid series resharding on rollout.

When the option is used, I've noticed the following log logged by `ingester-8` at startup:
```
level=warn ts=2021-01-30T17:32:47.008963494Z caller=lifecycler.go:235 msg="found an existing instance(s) with a problem in the ring, this instance cannot become ready until this problem is resolved. The /ring http endpoint on the distributor (or single binary) provides visibility into the ring." ring=ingester err="instance ingester-8 in state LEAVING"
```

Basically, the `ingester-8` was logging that it's not ready because an ingester is in LEAVING state. Well, the ingester was itself and, despite technically correct, I found the log a bit misleading.

This made me start this PR with the aim of just improving `Lifecycler.CheckReady()` and I've ended up discovering other potential side effects of the current ring lifecycler implementation when 'unregister on shutdown' is disabled. I tried to address them in this PR:

1.  `Lifecycler.CheckReady()` should return `false` if the instance itself is not `ACTIVE`
2. If an instance is left in the ring on shutdown and the number of tokens in the config changes, the instance doesn't extends the tokens to match new configured `num-tokens`, because the `autoJoin()` logic is not triggered
3. The case "tokens already exist for this instance in the ring" is not necessarily an error condition (was logged as error), so I moved it to "info"

The ring lifecycler logic is a bit tricky, so I would be glad if several people could take a look.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
