### PR TITLE
fix: ensure global loggers are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   * `-blocks-storage.s3.max-idle-connections`: Maximum number of idle (keep-alive) connections across all hosts. 0 means no limit.
   * `-blocks-storage.s3.max-idle-connections-per-host`: Maximum number of idle (keep-alive) connections to keep per-host. If 0, a built-in default value is used.
   * `-blocks-storage.s3.max-connections-per-host`: Maximum number of connections per host. 0 means no limit.
+* [BUGFIX] Cortex: Fixed issue where fatal errors and various log messages where not logged. #3778
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761
 * [BUGFIX] Store-gateway: fixed a panic caused by a race condition when the index-header lazy loading is enabled. #3775

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -44,7 +44,11 @@ func InitLogger(cfg *server.Config) {
 	}
 
 	// when use util.Logger, skip 3 stack frames.
-	Logger = log.With(l, "caller", log.Caller(3))
+	logutil.Logger = log.With(l, "caller", log.Caller(3))
+
+	// Ensure the Logger is updated to point to the package logger
+	// TODO: Make this sane and use a single log global
+	Logger = logutil.Logger
 
 	// cfg.Log wraps log function, skip 4 stack frames to get caller information.
 	// this works in go 1.12, but doesn't work in versions earlier.


### PR DESCRIPTION
**What this PR does**:

We have two global loggers in Cortex. However, only one is being set. This is causing `CheckFatal` error messages in the main.go file to not be logged.

A more permanent fix is to consolidate on a single global logger or remove the use of a global logger entirely. This PR ensures they are both set to the same underlying logger as a quick fix to this issue.


**Which issue(s) this PR fixes**:

**Before PR:**

```sh
$ cortex git:(fix_logger) ✗ ./cmd/cortex/cortex
level=info ts=2021-02-02T23:31:35.982989857Z caller=main.go:188 msg="Starting Cortex" version="(version=1.6.0, branch=fix_logger, revision=972bb3b1e)"
```

**After PR:**

```sh
$ cortex git:(fix_logger) ✗ ./cmd/cortex/cortex
ts=2021-02-02T23:26:24.904426209Z caller=log.go:49 test=test
level=info ts=2021-02-02T23:26:24.905421014Z caller=main.go:188 msg="Starting Cortex" version="(version=1.6.0, branch=fix_logger, revision=1ee520459)"
level=info ts=2021-02-02T23:26:24.905691041Z caller=modules.go:613 msg="RulerStorage is not configured in single binary mode and will not be started."
level=error ts=2021-02-02T23:26:24.905821125Z caller=log.go:27 msg="error running cortex" err="listen tcp :80: bind: permission denied\nerror initialising module: server\ngithub.com/cortexproject/cortex/pkg/util/modules.(*Manager).initModule\n\t/go/src/github.com/cortexproject/cortex/pkg/util/modules/modules.go:105\ngithub.com/cortexproject/cortex/pkg/util/modules.(*Manager).InitModuleServices\n\t/go/src/github.com/cortexproject/cortex/pkg/util/modules/modules.go:75\ngithub.com/cortexproject/cortex/pkg/cortex.(*Cortex).Run\n\t/go/src/github.com/cortexproject/cortex/pkg/cortex/cortex.go:366\nmain.main\n\t/go/src/github.com/cortexproject/cortex/cmd/cortex/main.go:190\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373"
```

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
