### PR TITLE
Cleanup tenant data in ingester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   * `-blocks-storage.s3.max-idle-connections`: Maximum number of idle (keep-alive) connections across all hosts. 0 means no limit.
   * `-blocks-storage.s3.max-idle-connections-per-host`: Maximum number of idle (keep-alive) connections to keep per-host. If 0, a built-in default value is used.
   * `-blocks-storage.s3.max-connections-per-host`: Maximum number of connections per host. 0 means no limit.
+* [ENHANCEMENT] Ingester: when tenant's TSDB is closed, Ingester now removes metrics metadata from memory too, and fixes metadata and validation metrics. #3782
 * [BUGFIX] Cortex: Fixed issue where fatal errors and various log messages where not logged. #3778
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
   * `-blocks-storage.s3.max-idle-connections`: Maximum number of idle (keep-alive) connections across all hosts. 0 means no limit.
   * `-blocks-storage.s3.max-idle-connections-per-host`: Maximum number of idle (keep-alive) connections to keep per-host. If 0, a built-in default value is used.
   * `-blocks-storage.s3.max-connections-per-host`: Maximum number of connections per host. 0 means no limit.
-* [ENHANCEMENT] Ingester: when tenant's TSDB is closed, Ingester now removes metrics metadata from memory too, and fixes metadata and validation metrics. #3782
+* [ENHANCEMENT] Ingester: when tenant's TSDB is closed, Ingester now removes pushed metrics-metadata from memory, and cleans metadata (`cortex_ingester_memory_metadata`, `cortex_ingester_memory_metadata_created_total`, `cortex_ingester_memory_metadata_removed_total`) and validation metrics (`cortex_discarded_samples_total`, `cortex_discarded_metadata_total`). #3782
 * [BUGFIX] Cortex: Fixed issue where fatal errors and various log messages where not logged. #3778
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
   * `-blocks-storage.s3.max-idle-connections`: Maximum number of idle (keep-alive) connections across all hosts. 0 means no limit.
   * `-blocks-storage.s3.max-idle-connections-per-host`: Maximum number of idle (keep-alive) connections to keep per-host. If 0, a built-in default value is used.
   * `-blocks-storage.s3.max-connections-per-host`: Maximum number of connections per host. 0 means no limit.
-* [ENHANCEMENT] Ingester: when tenant's TSDB is closed, Ingester now removes pushed metrics-metadata from memory, and cleans metadata (`cortex_ingester_memory_metadata`, `cortex_ingester_memory_metadata_created_total`, `cortex_ingester_memory_metadata_removed_total`) and validation metrics (`cortex_discarded_samples_total`, `cortex_discarded_metadata_total`). #3782
+* [ENHANCEMENT] Ingester: when tenant's TSDB is closed, Ingester now removes pushed metrics-metadata from memory, and removes metadata (`cortex_ingester_memory_metadata`, `cortex_ingester_memory_metadata_created_total`, `cortex_ingester_memory_metadata_removed_total`) and validation metrics (`cortex_discarded_samples_total`, `cortex_discarded_metadata_total`). #3782
 * [BUGFIX] Cortex: Fixed issue where fatal errors and various log messages where not logged. #3778
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -652,6 +652,19 @@ func (i *Ingester) getUserMetadata(userID string) *userMetricsMetadata {
 	return i.usersMetadata[userID]
 }
 
+func (i *Ingester) deleteUserMetadata(userID string) {
+	i.usersMetadataMtx.Lock()
+	um := i.usersMetadata[userID]
+	delete(i.usersMetadata, userID)
+	i.usersMetadataMtx.Unlock()
+
+	if um != nil {
+		// We need call purge to update i.metrics.memMetadata correctly (it counts number of metrics with metadata in memory).
+		// Passing zero time means purge everything.
+		um.purge(time.Time{})
+	}
+}
+
 func (i *Ingester) getUsersWithMetadata() []string {
 	i.usersMetadataMtx.RLock()
 	defer i.usersMetadataMtx.RUnlock()

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1747,8 +1747,12 @@ func (i *Ingester) closeAndDeleteUserTSDBIfIdle(userID string) tsdbCloseCheckRes
 	i.userStatesMtx.Unlock()
 
 	i.metrics.memUsers.Dec()
-	i.metrics.activeSeriesPerUser.DeleteLabelValues(userID)
 	i.TSDBState.tsdbMetrics.removeRegistryForUser(userID)
+
+	i.deleteUserMetadata(userID)
+	i.metrics.deletePerUserMetrics(userID)
+
+	validation.DeletePerUserValidationMetrics(userID)
 
 	// And delete local data.
 	if err := os.RemoveAll(dir); err != nil {

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1752,7 +1752,7 @@ func (i *Ingester) closeAndDeleteUserTSDBIfIdle(userID string) tsdbCloseCheckRes
 	i.deleteUserMetadata(userID)
 	i.metrics.deletePerUserMetrics(userID)
 
-	validation.DeletePerUserValidationMetrics(userID)
+	validation.DeletePerUserValidationMetrics(userID, i.logger)
 
 	// And delete local data.
 	if err := os.RemoveAll(dir); err != nil {

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -2542,7 +2542,7 @@ func verifyCompactedHead(t *testing.T, i *Ingester, expected bool) {
 func pushSingleSampleWithMetadata(t *testing.T, i *Ingester) {
 	ctx := user.InjectOrgID(context.Background(), userID)
 	req, _, _ := mockWriteRequest(labels.Labels{{Name: labels.MetricName, Value: "test"}}, 0, util.TimeToMillis(time.Now()))
-	req.Metadata = append(req.Metadata, &client.MetricMetadata{MetricFamilyName: "test", Help: fmt.Sprintf("a help for metric"), Unit: "", Type: client.COUNTER})
+	req.Metadata = append(req.Metadata, &client.MetricMetadata{MetricFamilyName: "test", Help: "a help for metric", Unit: "", Type: client.COUNTER})
 	_, err := i.v2Push(ctx, req)
 	require.NoError(t, err)
 }

--- a/pkg/ingester/ingester_v2_test.go
+++ b/pkg/ingester/ingester_v2_test.go
@@ -1803,7 +1803,7 @@ func TestIngester_dontShipBlocksWhenTenantDeletionMarkerIsPresent(t *testing.T) 
 		return i.lifecycler.GetState()
 	})
 
-	pushSingleSample(t, i)
+	pushSingleSampleWithMetadata(t, i)
 	i.compactBlocks(context.Background(), true)
 	i.shipBlocks(context.Background())
 
@@ -1818,7 +1818,7 @@ func TestIngester_dontShipBlocksWhenTenantDeletionMarkerIsPresent(t *testing.T) 
 	db.lastDeletionMarkCheck.Store(0)
 
 	// After writing tenant deletion mark,
-	pushSingleSample(t, i)
+	pushSingleSampleWithMetadata(t, i)
 	i.compactBlocks(context.Background(), true)
 	i.shipBlocks(context.Background())
 
@@ -1975,7 +1975,7 @@ func TestIngester_flushing(t *testing.T) {
 				cfg.BlocksStorageConfig.TSDB.KeepUserTSDBOpenOnShutdown = true
 			},
 			action: func(t *testing.T, i *Ingester, reg *prometheus.Registry) {
-				pushSingleSample(t, i)
+				pushSingleSampleWithMetadata(t, i)
 
 				// Nothing shipped yet.
 				require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
@@ -2005,7 +2005,7 @@ func TestIngester_flushing(t *testing.T) {
 			},
 
 			action: func(t *testing.T, i *Ingester, reg *prometheus.Registry) {
-				pushSingleSample(t, i)
+				pushSingleSampleWithMetadata(t, i)
 
 				// Nothing shipped yet.
 				require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
@@ -2031,7 +2031,7 @@ func TestIngester_flushing(t *testing.T) {
 			},
 
 			action: func(t *testing.T, i *Ingester, reg *prometheus.Registry) {
-				pushSingleSample(t, i)
+				pushSingleSampleWithMetadata(t, i)
 
 				// Nothing shipped yet.
 				require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
@@ -2178,7 +2178,7 @@ func TestIngester_ForFlush(t *testing.T) {
 	})
 
 	// Push some data.
-	pushSingleSample(t, i)
+	pushSingleSampleWithMetadata(t, i)
 
 	// Stop ingester.
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), i))
@@ -2355,7 +2355,7 @@ func TestIngesterCompactIdleBlock(t *testing.T) {
 		return i.lifecycler.GetState()
 	})
 
-	pushSingleSample(t, i)
+	pushSingleSampleWithMetadata(t, i)
 
 	i.compactBlocks(context.Background(), false)
 	verifyCompactedHead(t, i, false)
@@ -2393,7 +2393,7 @@ func TestIngesterCompactIdleBlock(t *testing.T) {
     `), memSeriesCreatedTotalName, memSeriesRemovedTotalName, "cortex_ingester_memory_users"))
 
 	// Pushing another sample still works.
-	pushSingleSample(t, i)
+	pushSingleSampleWithMetadata(t, i)
 	verifyCompactedHead(t, i, false)
 
 	require.NoError(t, testutil.GatherAndCompare(r, strings.NewReader(`
@@ -2437,8 +2437,11 @@ func TestIngesterCompactAndCloseIdleTSDB(t *testing.T) {
 		return i.lifecycler.GetState()
 	})
 
-	pushSingleSample(t, i)
+	pushSingleSampleWithMetadata(t, i)
 	i.v2UpdateActiveSeries()
+
+	metricsToCheck := []string{memSeriesCreatedTotalName, memSeriesRemovedTotalName, "cortex_ingester_memory_users", "cortex_ingester_active_series",
+		"cortex_ingester_memory_metadata", "cortex_ingester_memory_metadata_created_total", "cortex_ingester_memory_metadata_removed_total"}
 
 	require.NoError(t, testutil.GatherAndCompare(r, strings.NewReader(`
 		# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
@@ -2456,7 +2459,15 @@ func TestIngesterCompactAndCloseIdleTSDB(t *testing.T) {
 		# HELP cortex_ingester_active_series Number of currently active series per user.
 		# TYPE cortex_ingester_active_series gauge
 		cortex_ingester_active_series{user="1"} 1
-    `), memSeriesCreatedTotalName, memSeriesRemovedTotalName, "cortex_ingester_memory_users", "cortex_ingester_active_series"))
+
+		# HELP cortex_ingester_memory_metadata The current number of metadata in memory.
+		# TYPE cortex_ingester_memory_metadata gauge
+		cortex_ingester_memory_metadata 1
+
+		# HELP cortex_ingester_memory_metadata_created_total The total number of metadata that were created per user
+		# TYPE cortex_ingester_memory_metadata_created_total counter
+		cortex_ingester_memory_metadata_created_total{user="1"} 1
+    `), metricsToCheck...))
 
 	// Wait until TSDB has been closed and removed.
 	test.Poll(t, 10*time.Second, 0, func() interface{} {
@@ -2482,10 +2493,14 @@ func TestIngesterCompactAndCloseIdleTSDB(t *testing.T) {
 
 		# HELP cortex_ingester_active_series Number of currently active series per user.
 		# TYPE cortex_ingester_active_series gauge
-    `), memSeriesCreatedTotalName, memSeriesRemovedTotalName, "cortex_ingester_memory_users", "cortex_ingester_active_series"))
+
+		# HELP cortex_ingester_memory_metadata The current number of metadata in memory.
+		# TYPE cortex_ingester_memory_metadata gauge
+		cortex_ingester_memory_metadata 0
+    `), metricsToCheck...))
 
 	// Pushing another sample will recreate TSDB.
-	pushSingleSample(t, i)
+	pushSingleSampleWithMetadata(t, i)
 	i.v2UpdateActiveSeries()
 
 	// User is back.
@@ -2505,7 +2520,15 @@ func TestIngesterCompactAndCloseIdleTSDB(t *testing.T) {
 		# HELP cortex_ingester_active_series Number of currently active series per user.
 		# TYPE cortex_ingester_active_series gauge
 		cortex_ingester_active_series{user="1"} 1
-    `), memSeriesCreatedTotalName, memSeriesRemovedTotalName, "cortex_ingester_memory_users", "cortex_ingester_active_series"))
+
+		# HELP cortex_ingester_memory_metadata The current number of metadata in memory.
+		# TYPE cortex_ingester_memory_metadata gauge
+		cortex_ingester_memory_metadata 1
+
+		# HELP cortex_ingester_memory_metadata_created_total The total number of metadata that were created per user
+		# TYPE cortex_ingester_memory_metadata_created_total counter
+		cortex_ingester_memory_metadata_created_total{user="1"} 1
+    `), metricsToCheck...))
 }
 
 func verifyCompactedHead(t *testing.T, i *Ingester, expected bool) {
@@ -2516,9 +2539,10 @@ func verifyCompactedHead(t *testing.T, i *Ingester, expected bool) {
 	require.Equal(t, expected, h.NumSeries() == 0)
 }
 
-func pushSingleSample(t *testing.T, i *Ingester) {
+func pushSingleSampleWithMetadata(t *testing.T, i *Ingester) {
 	ctx := user.InjectOrgID(context.Background(), userID)
 	req, _, _ := mockWriteRequest(labels.Labels{{Name: labels.MetricName, Value: "test"}}, 0, util.TimeToMillis(time.Now()))
+	req.Metadata = append(req.Metadata, &client.MetricMetadata{MetricFamilyName: "test", Help: fmt.Sprintf("a help for metric"), Unit: "", Type: client.COUNTER})
 	_, err := i.v2Push(ctx, req)
 	require.NoError(t, err)
 }
@@ -2623,7 +2647,7 @@ func TestIngester_CloseTSDBsOnShutdown(t *testing.T) {
 	})
 
 	// Push some data.
-	pushSingleSample(t, i)
+	pushSingleSampleWithMetadata(t, i)
 
 	db := i.getTSDB(userID)
 	require.NotNil(t, db)
@@ -2761,7 +2785,7 @@ func TestIngesterPushErrorDuringForcedCompaction(t *testing.T) {
 	})
 
 	// Push a sample, it should succeed.
-	pushSingleSample(t, i)
+	pushSingleSampleWithMetadata(t, i)
 
 	// We mock a flushing by setting the boolean.
 	db := i.getTSDB(userID)
@@ -2776,7 +2800,7 @@ func TestIngesterPushErrorDuringForcedCompaction(t *testing.T) {
 
 	// Ingestion is successful after a flush.
 	require.True(t, db.casState(forceCompacting, active))
-	pushSingleSample(t, i)
+	pushSingleSampleWithMetadata(t, i)
 }
 
 func TestIngesterNoFlushWithInFlightRequest(t *testing.T) {
@@ -2796,7 +2820,7 @@ func TestIngesterNoFlushWithInFlightRequest(t *testing.T) {
 
 	// Push few samples.
 	for j := 0; j < 5; j++ {
-		pushSingleSample(t, i)
+		pushSingleSampleWithMetadata(t, i)
 	}
 
 	// Verifying that compaction won't happen when a request is in flight.

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -225,7 +225,7 @@ func (m *ingesterMetrics) deletePerUserMetrics(userID string) {
 		m.memSeriesCreatedTotal.DeleteLabelValues(userID)
 	}
 
-	if m.memMetadataRemovedTotal != nil {
+	if m.memSeriesRemovedTotal != nil {
 		m.memSeriesRemovedTotal.DeleteLabelValues(userID)
 	}
 }

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -223,6 +223,9 @@ func (m *ingesterMetrics) deletePerUserMetrics(userID string) {
 
 	if m.memSeriesCreatedTotal != nil {
 		m.memSeriesCreatedTotal.DeleteLabelValues(userID)
+	}
+
+	if m.memMetadataRemovedTotal != nil {
 		m.memSeriesRemovedTotal.DeleteLabelValues(userID)
 	}
 }

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -216,6 +216,17 @@ func newIngesterMetrics(r prometheus.Registerer, createMetricsConflictingWithTSD
 	return m
 }
 
+func (m *ingesterMetrics) deletePerUserMetrics(userID string) {
+	m.memMetadataCreatedTotal.DeleteLabelValues(userID)
+	m.memMetadataRemovedTotal.DeleteLabelValues(userID)
+	m.activeSeriesPerUser.DeleteLabelValues(userID)
+
+	if m.memSeriesCreatedTotal != nil {
+		m.memSeriesCreatedTotal.DeleteLabelValues(userID)
+		m.memSeriesRemovedTotal.DeleteLabelValues(userID)
+	}
+}
+
 // TSDB metrics collector. Each tenant has its own registry, that TSDB code uses.
 type tsdbMetrics struct {
 	// Metrics aggregated from Thanos shipper.

--- a/pkg/ingester/user_metrics_metadata.go
+++ b/pkg/ingester/user_metrics_metadata.go
@@ -63,6 +63,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *client.MetricMetadat
 	return nil
 }
 
+// If deadline is zero, all metadata is purged.
 func (mm *userMetricsMetadata) purge(deadline time.Time) {
 	mm.mtx.Lock()
 	defer mm.mtx.Unlock()
@@ -93,10 +94,11 @@ func (mm *userMetricsMetadata) toClientMetadata() []*client.MetricMetadata {
 
 type metricMetadataSet map[client.MetricMetadata]time.Time
 
+// If deadline is zero time, all metrics are purged.
 func (mms metricMetadataSet) purge(deadline time.Time) int {
 	var deleted int
 	for metadata, t := range mms {
-		if deadline.After(t) {
+		if deadline.IsZero() || deadline.After(t) {
 			delete(mms, metadata)
 			deleted++
 		}

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/pkg/labels"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
@@ -699,4 +700,44 @@ func GetSumOfHistogramSampleCount(families []*dto.MetricFamily, metricName strin
 	}
 
 	return sum
+}
+
+func GetLabels(c prometheus.Collector, filter map[string]string) ([]labels.Labels, error) {
+	ch := make(chan prometheus.Metric, 128)
+
+	go func() {
+		defer close(ch)
+		c.Collect(ch)
+	}()
+
+	errs := tsdb_errors.NewMulti()
+
+	var result []labels.Labels
+
+	dtoMetric := &dto.Metric{}
+nextMetric:
+	for m := range ch {
+		err := m.Write(dtoMetric)
+		if err != nil {
+			errs.Add(err)
+			// We cannot return here, to avoid blocking goroutine calling c.Collect()
+			continue
+		}
+
+		lbls := labels.NewBuilder(nil)
+		for _, lp := range dtoMetric.Label {
+			n := lp.GetName()
+			v := lp.GetValue()
+
+			filterValue, ok := filter[n]
+			if ok && filterValue != v {
+				continue nextMetric
+			}
+
+			lbls.Set(lp.GetName(), lp.GetValue())
+		}
+		result = append(result, lbls.Labels())
+	}
+
+	return result, errs.Err()
 }

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -702,6 +702,8 @@ func GetSumOfHistogramSampleCount(families []*dto.MetricFamily, metricName strin
 	return sum
 }
 
+// GetLables returns list of label combinations used by this collector at the time of call.
+// This can be used to find and delete unused metrics.
 func GetLabels(c prometheus.Collector, filter map[string]string) ([]labels.Labels, error) {
 	ch := make(chan prometheus.Metric, 128)
 
@@ -711,10 +713,9 @@ func GetLabels(c prometheus.Collector, filter map[string]string) ([]labels.Label
 	}()
 
 	errs := tsdb_errors.NewMulti()
-
 	var result []labels.Labels
-
 	dtoMetric := &dto.Metric{}
+
 nextMetric:
 	for m := range ch {
 		err := m.Write(dtoMetric)

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -61,6 +61,29 @@ const (
 	TooManyHAClusters = "too_many_ha_clusters"
 )
 
+// allDiscardedSampleReasons is used when cleaning up metrics for a user.
+var allDiscardedSampleReasons = []string{
+	missingMetricName,
+	invalidMetricName,
+	greaterThanMaxSampleAge,
+	maxLabelNamesPerSeries,
+	tooFarInFuture,
+	invalidLabel,
+	labelNameTooLong,
+	duplicateLabelNames,
+	labelsNotSorted,
+	labelValueTooLong,
+	RateLimited,
+	TooManyHAClusters,
+}
+
+var allDiscardedMetadataReasons = []string{
+	missingMetricName,
+	metricNameTooLong,
+	helpTooLong,
+	unitTooLong,
+}
+
 // DiscardedSamples is a metric of the number of discarded samples, by reason.
 var DiscardedSamples = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
@@ -237,4 +260,14 @@ func formatLabelSet(ls []client.LabelAdapter) string {
 	}
 
 	return fmt.Sprintf("%s{%s}", metricName, strings.Join(labelStrings, ", "))
+}
+
+func DeletePerUserValidationMetrics(userID string) {
+	for _, reason := range allDiscardedSampleReasons {
+		DiscardedSamples.DeleteLabelValues(reason, userID)
+	}
+
+	for _, reason := range allDiscardedMetadataReasons {
+		DiscardedMetadata.DeleteLabelValues(reason, userID)
+	}
 }

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -14,7 +15,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/extract"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 const (
@@ -242,13 +242,13 @@ func formatLabelSet(ls []client.LabelAdapter) string {
 	return fmt.Sprintf("%s{%s}", metricName, strings.Join(labelStrings, ", "))
 }
 
-func DeletePerUserValidationMetrics(userID string) {
+func DeletePerUserValidationMetrics(userID string, log log.Logger) {
 	filter := map[string]string{"user": userID}
 
 	{
 		lbls, err := util.GetLabels(DiscardedSamples, filter)
 		if err != nil {
-			level.Warn(util_log.Logger).Log("msg", "failed to remove cortex_discarded_samples_total metric for user", "user", userID, "err", err)
+			level.Warn(log).Log("msg", "failed to remove cortex_discarded_samples_total metric for user", "user", userID, "err", err)
 		}
 		for _, l := range lbls {
 			DiscardedSamples.Delete(l.Map())
@@ -258,7 +258,7 @@ func DeletePerUserValidationMetrics(userID string) {
 	{
 		lbls, err := util.GetLabels(DiscardedMetadata, filter)
 		if err != nil {
-			level.Warn(util_log.Logger).Log("msg", "failed to remove cortex_discarded_metadata_total metric for user", "user", userID, "err", err)
+			level.Warn(log).Log("msg", "failed to remove cortex_discarded_metadata_total metric for user", "user", userID, "err", err)
 		}
 		for _, l := range lbls {
 			DiscardedMetadata.Delete(l.Map())

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 type validateLabelsCfg struct {
@@ -126,7 +127,7 @@ func TestValidateLabels(t *testing.T) {
 			cortex_discarded_samples_total{reason="random reason",user="different user"} 1
 	`), "cortex_discarded_samples_total"))
 
-	DeletePerUserValidationMetrics(userID)
+	DeletePerUserValidationMetrics(userID, util_log.Logger)
 
 	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
@@ -191,7 +192,7 @@ func TestValidateMetadata(t *testing.T) {
 			cortex_discarded_metadata_total{reason="random reason",user="different user"} 1
 	`), "cortex_discarded_metadata_total"))
 
-	DeletePerUserValidationMetrics(userID)
+	DeletePerUserValidationMetrics(userID, util_log.Logger)
 
 	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
 			# HELP cortex_discarded_metadata_total The total number of metadata that were discarded.

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -2,10 +2,14 @@ package validation
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
@@ -106,6 +110,24 @@ func TestValidateLabels(t *testing.T) {
 		err := ValidateLabels(cfg, userID, client.FromMetricsToLabelAdapters(c.metric), c.skipLabelNameValidation)
 		assert.Equal(t, c.err, err, "wrong error")
 	}
+
+	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
+			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+			# TYPE cortex_discarded_samples_total counter
+			cortex_discarded_samples_total{reason="label_invalid",user="testUser"} 1
+			cortex_discarded_samples_total{reason="label_name_too_long",user="testUser"} 1
+			cortex_discarded_samples_total{reason="label_value_too_long",user="testUser"} 1
+			cortex_discarded_samples_total{reason="max_label_names_per_series",user="testUser"} 1
+			cortex_discarded_samples_total{reason="metric_name_invalid",user="testUser"} 1
+			cortex_discarded_samples_total{reason="missing_metric_name",user="testUser"} 1
+	`), "cortex_discarded_samples_total"))
+
+	DeletePerUserValidationMetrics(userID)
+
+	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
+			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+			# TYPE cortex_discarded_samples_total counter
+	`), "cortex_discarded_samples_total"))
 }
 
 func TestValidateMetadata(t *testing.T) {
@@ -150,6 +172,22 @@ func TestValidateMetadata(t *testing.T) {
 			assert.Equal(t, c.err, err, "wrong error")
 		})
 	}
+
+	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
+			# HELP cortex_discarded_metadata_total The total number of metadata that were discarded.
+			# TYPE cortex_discarded_metadata_total counter
+			cortex_discarded_metadata_total{reason="help_too_long",user="testUser"} 1
+			cortex_discarded_metadata_total{reason="metric_name_too_long",user="testUser"} 1
+			cortex_discarded_metadata_total{reason="missing_metric_name",user="testUser"} 1
+			cortex_discarded_metadata_total{reason="unit_too_long",user="testUser"} 1
+	`), "cortex_discarded_metadata_total"))
+
+	DeletePerUserValidationMetrics(userID)
+
+	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
+			# HELP cortex_discarded_metadata_total The total number of metadata that were discarded.
+			# TYPE cortex_discarded_metadata_total counter
+	`), "cortex_discarded_metadata_total"))
 }
 
 func TestValidateLabelOrder(t *testing.T) {

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -111,6 +111,8 @@ func TestValidateLabels(t *testing.T) {
 		assert.Equal(t, c.err, err, "wrong error")
 	}
 
+	DiscardedSamples.WithLabelValues("random reason", "different user").Inc()
+
 	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 			# TYPE cortex_discarded_samples_total counter
@@ -120,6 +122,8 @@ func TestValidateLabels(t *testing.T) {
 			cortex_discarded_samples_total{reason="max_label_names_per_series",user="testUser"} 1
 			cortex_discarded_samples_total{reason="metric_name_invalid",user="testUser"} 1
 			cortex_discarded_samples_total{reason="missing_metric_name",user="testUser"} 1
+
+			cortex_discarded_samples_total{reason="random reason",user="different user"} 1
 	`), "cortex_discarded_samples_total"))
 
 	DeletePerUserValidationMetrics(userID)
@@ -127,6 +131,7 @@ func TestValidateLabels(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 			# TYPE cortex_discarded_samples_total counter
+			cortex_discarded_samples_total{reason="random reason",user="different user"} 1
 	`), "cortex_discarded_samples_total"))
 }
 
@@ -173,6 +178,8 @@ func TestValidateMetadata(t *testing.T) {
 		})
 	}
 
+	DiscardedMetadata.WithLabelValues("random reason", "different user").Inc()
+
 	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
 			# HELP cortex_discarded_metadata_total The total number of metadata that were discarded.
 			# TYPE cortex_discarded_metadata_total counter
@@ -180,6 +187,8 @@ func TestValidateMetadata(t *testing.T) {
 			cortex_discarded_metadata_total{reason="metric_name_too_long",user="testUser"} 1
 			cortex_discarded_metadata_total{reason="missing_metric_name",user="testUser"} 1
 			cortex_discarded_metadata_total{reason="unit_too_long",user="testUser"} 1
+
+			cortex_discarded_metadata_total{reason="random reason",user="different user"} 1
 	`), "cortex_discarded_metadata_total"))
 
 	DeletePerUserValidationMetrics(userID)
@@ -187,6 +196,7 @@ func TestValidateMetadata(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
 			# HELP cortex_discarded_metadata_total The total number of metadata that were discarded.
 			# TYPE cortex_discarded_metadata_total counter
+			cortex_discarded_metadata_total{reason="random reason",user="different user"} 1
 	`), "cortex_discarded_metadata_total"))
 }
 


### PR DESCRIPTION
**What this PR does**: This PR does additional cleanup of in-memory data when tenant's TSDB is closed in ingester. Specifically:
- We now remove tenant's metadata still in memory, and update metadata-related metrics
- We remove all validation metrics for removed tenant.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
