### PR TITLE
Allow downstream projects to customise compactor

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -170,7 +170,7 @@ type Compactor struct {
 
 	// Functions that creates bucket client, grouper, planner and compactor using the context.
 	// Useful for injecting mock objects from tests.
-	createBucketClient     func(ctx context.Context) (objstore.Bucket, error)
+	bucketClientFactory    func(ctx context.Context) (objstore.Bucket, error)
 	blocksGrouperFactory   BlocksGrouperFactory
 	blocksCompactorFactory BlocksCompactorFactory
 
@@ -249,7 +249,7 @@ func newCompactor(
 		logger:                 log.With(logger, "component", "compactor"),
 		registerer:             registerer,
 		syncerMetrics:          newSyncerMetrics(registerer),
-		createBucketClient:     bucketClientFactory,
+		bucketClientFactory:    bucketClientFactory,
 		blocksGrouperFactory:   blocksGrouperFactory,
 		blocksCompactorFactory: blocksCompactorFactory,
 
@@ -323,7 +323,7 @@ func (c *Compactor) starting(ctx context.Context) error {
 	var err error
 
 	// Create bucket client.
-	c.bucketClient, err = c.createBucketClient(ctx)
+	c.bucketClient, err = c.bucketClientFactory(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to create bucket client")
 	}

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1068,9 +1068,15 @@ func prepare(t *testing.T, compactorCfg Config, bucketClient objstore.Bucket) (*
 	logger := log.NewLogfmtLogger(logs)
 	registry := prometheus.NewRegistry()
 
-	c, err := newCompactor(compactorCfg, storageCfg, logger, registry, func(ctx context.Context) (objstore.Bucket, tsdb.Compactor, compact.Planner, error) {
-		return bucketClient, tsdbCompactor, tsdbPlanner, nil
-	})
+	createBucketClient := func(ctx context.Context) (objstore.Bucket, error) {
+		return bucketClient, nil
+	}
+
+	createBlocksCompactor := func(ctx context.Context) (GrouperFactory, compact.Compactor, compact.Planner, error) {
+		return DefaultGrouperFactory, tsdbCompactor, tsdbPlanner, nil
+	}
+
+	c, err := newCompactor(compactorCfg, storageCfg, logger, registry, createBucketClient, createBlocksCompactor)
 	require.NoError(t, err)
 
 	return c, tsdbCompactor, tsdbPlanner, logs, registry, cleanup

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1068,15 +1068,15 @@ func prepare(t *testing.T, compactorCfg Config, bucketClient objstore.Bucket) (*
 	logger := log.NewLogfmtLogger(logs)
 	registry := prometheus.NewRegistry()
 
-	createBucketClient := func(ctx context.Context) (objstore.Bucket, error) {
+	bucketClientFactory := func(ctx context.Context) (objstore.Bucket, error) {
 		return bucketClient, nil
 	}
 
-	createBlocksCompactor := func(ctx context.Context) (GrouperFactory, compact.Compactor, compact.Planner, error) {
-		return DefaultGrouperFactory, tsdbCompactor, tsdbPlanner, nil
+	blocksCompactorFactory := func(ctx context.Context, cfg Config, logger log.Logger, reg prometheus.Registerer) (compact.Compactor, compact.Planner, error) {
+		return tsdbCompactor, tsdbPlanner, nil
 	}
 
-	c, err := newCompactor(compactorCfg, storageCfg, logger, registry, createBucketClient, createBlocksCompactor)
+	c, err := newCompactor(compactorCfg, storageCfg, logger, registry, bucketClientFactory, DefaultBlocksGrouperFactory, blocksCompactorFactory)
 	require.NoError(t, err)
 
 	return c, tsdbCompactor, tsdbPlanner, logs, registry, cleanup


### PR DESCRIPTION
**What this PR does**:
In this PR I've refactored a bit the compactor to allow downstream projects to customise the compactor, specifically the grouper, planner and compactor. This refactoring is expected to be a no-op for Cortex (unless I'm introducing any bug).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
