### PR TITLE
Cleanup metrics exported by distributor for inactive tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   * `-blocks-storage.s3.max-idle-connections-per-host`: Maximum number of idle (keep-alive) connections to keep per-host. If 0, a built-in default value is used.
   * `-blocks-storage.s3.max-connections-per-host`: Maximum number of connections per host. 0 means no limit.
 * [ENHANCEMENT] Ingester: when tenant's TSDB is closed, Ingester now removes pushed metrics-metadata from memory, and removes metadata (`cortex_ingester_memory_metadata`, `cortex_ingester_memory_metadata_created_total`, `cortex_ingester_memory_metadata_removed_total`) and validation metrics (`cortex_discarded_samples_total`, `cortex_discarded_metadata_total`). #3782
+* [ENHANCEMENT] Distributor: cleanup metrics for inactive tenants. #3784
 * [BUGFIX] Cortex: Fixed issue where fatal errors and various log messages where not logged. #3778
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -114,14 +114,14 @@ var (
 	// Validation errors.
 	errInvalidShardingStrategy = errors.New("invalid sharding strategy")
 	errInvalidTenantShardSize  = errors.New("invalid tenant shard size, the value must be greater than 0")
+
+	inactiveUserTimeout    = 15 * time.Minute
+	metricsCleanupInterval = inactiveUserTimeout / 5
 )
 
 const (
 	typeSamples  = "samples"
 	typeMetadata = "metadata"
-
-	// Supported sharding strategies.
-
 )
 
 // Distributor is a storage.SampleAppender and a client.Querier which
@@ -147,6 +147,8 @@ type Distributor struct {
 	// Manager for subservices (HA Tracker, distributor ring and client pool)
 	subservices        *services.Manager
 	subservicesWatcher *services.FailureWatcher
+
+	activeUsers *util.ActiveUsers
 }
 
 // Config contains the configuration require to
@@ -253,6 +255,7 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 		limits:               limits,
 		ingestionRateLimiter: limiter.NewRateLimiter(ingestionRateStrategy, 10*time.Second),
 		HATracker:            replicas,
+		activeUsers:          util.NewActiveUsers(),
 	}
 
 	subservices = append(subservices, d.ingesterPool)
@@ -273,12 +276,35 @@ func (d *Distributor) starting(ctx context.Context) error {
 }
 
 func (d *Distributor) running(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return nil
-	case err := <-d.subservicesWatcher.Chan():
-		return errors.Wrap(err, "distributor subservice failed")
+	timer := time.NewTicker(metricsCleanupInterval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-timer.C:
+			inactiveUsers := d.activeUsers.PurgeInactiveUsers(time.Now().Add(-inactiveUserTimeout).UnixNano())
+			for _, userID := range inactiveUsers {
+				cleanupMetricsForUser(userID)
+			}
+			continue
+
+		case <-ctx.Done():
+			return nil
+
+		case err := <-d.subservicesWatcher.Chan():
+			return errors.Wrap(err, "distributor subservice failed")
+		}
 	}
+}
+
+func cleanupMetricsForUser(userID string) {
+	receivedSamples.DeleteLabelValues(userID)
+	receivedMetadata.DeleteLabelValues(userID)
+	incomingSamples.DeleteLabelValues(userID)
+	incomingMetadata.DeleteLabelValues(userID)
+	nonHASamples.DeleteLabelValues(userID)
+	// dedupedSamples.DeleteLabelValues(userID) // TODO: This needs "cluster" too :-(
+	latestSeenSampleTimestampPerUser.DeleteLabelValues(userID)
 }
 
 // Called after distributor is asked to stop via StopAsync.
@@ -397,6 +423,10 @@ func (d *Distributor) Push(ctx context.Context, req *ingester_client.WriteReques
 	if err != nil {
 		return nil, err
 	}
+
+	now := time.Now()
+	d.activeUsers.UpdateUserTimestamp(userID, now.UnixNano())
+
 	source := util.GetSourceIPsFromOutgoingCtx(ctx)
 
 	var firstPartialErr error
@@ -540,7 +570,6 @@ func (d *Distributor) Push(ctx context.Context, req *ingester_client.WriteReques
 		return &ingester_client.WriteResponse{}, firstPartialErr
 	}
 
-	now := time.Now()
 	totalN := validatedSamples + len(validatedMetadata)
 	if !d.ingestionRateLimiter.AllowN(now, userID, totalN) {
 		// Ensure the request slice is reused if the request is rate limited.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -306,15 +306,12 @@ func cleanupMetricsForUser(userID string) {
 	nonHASamples.DeleteLabelValues(userID)
 	latestSeenSampleTimestampPerUser.DeleteLabelValues(userID)
 
-	lbls, err := util.GetLabels(dedupedSamples, map[string]string{"user": userID})
-	if err != nil {
+	if err := util.DeleteMatchingLabels(dedupedSamples, map[string]string{"user": userID}); err != nil {
 		level.Warn(log.Logger).Log("msg", "failed to remove cortex_distributor_deduped_samples_total metric for user", "user", userID, "err", err)
-	}
-	for _, ls := range lbls {
-		dedupedSamples.Delete(ls.Map())
 	}
 
 	validation.DeletePerUserValidationMetrics(userID, log.Logger)
+	cleanupHATrackerMetricsForUser(userID, log.Logger)
 }
 
 // Called after distributor is asked to stop via StopAsync.

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -266,6 +266,96 @@ func TestDistributor_Push(t *testing.T) {
 	}
 }
 
+func TestDistributor_MetricsCleanup(t *testing.T) {
+	receivedSamples.Reset()
+	receivedMetadata.Reset()
+	incomingSamples.Reset()
+	incomingMetadata.Reset()
+	nonHASamples.Reset()
+	dedupedSamples.Reset()
+	latestSeenSampleTimestampPerUser.Reset()
+
+	metrics := []string{
+		"cortex_distributor_received_samples_total",
+		"cortex_distributor_received_metadata_total",
+		"cortex_distributor_deduped_samples_total",
+		"cortex_distributor_samples_in_total",
+		"cortex_distributor_metadata_in_total",
+		"cortex_distributor_non_ha_samples_received_total",
+		"cortex_distributor_latest_seen_sample_timestamp_seconds",
+	}
+
+	receivedSamples.WithLabelValues("userA").Add(5)
+	receivedSamples.WithLabelValues("userB").Add(10)
+	receivedMetadata.WithLabelValues("userA").Add(5)
+	receivedMetadata.WithLabelValues("userB").Add(10)
+	incomingSamples.WithLabelValues("userA").Add(5)
+	incomingMetadata.WithLabelValues("userA").Add(5)
+	nonHASamples.WithLabelValues("userA").Add(5)
+	dedupedSamples.WithLabelValues("userA", "cluster1").Inc() // We cannot clean this metric
+	latestSeenSampleTimestampPerUser.WithLabelValues("userA").Set(1111)
+
+	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
+		# HELP cortex_distributor_deduped_samples_total The total number of deduplicated samples.
+		# TYPE cortex_distributor_deduped_samples_total counter
+		cortex_distributor_deduped_samples_total{cluster="cluster1",user="userA"} 1
+
+		# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
+		# TYPE cortex_distributor_latest_seen_sample_timestamp_seconds gauge
+		cortex_distributor_latest_seen_sample_timestamp_seconds{user="userA"} 1111
+
+		# HELP cortex_distributor_metadata_in_total The total number of metadata the have come in to the distributor, including rejected.
+		# TYPE cortex_distributor_metadata_in_total counter
+		cortex_distributor_metadata_in_total{user="userA"} 5
+
+		# HELP cortex_distributor_non_ha_samples_received_total The total number of received samples for a user that has HA tracking turned on, but the sample didn't contain both HA labels.
+		# TYPE cortex_distributor_non_ha_samples_received_total counter
+		cortex_distributor_non_ha_samples_received_total{user="userA"} 5
+
+		# HELP cortex_distributor_received_metadata_total The total number of received metadata, excluding rejected.
+		# TYPE cortex_distributor_received_metadata_total counter
+		cortex_distributor_received_metadata_total{user="userA"} 5
+		cortex_distributor_received_metadata_total{user="userB"} 10
+
+		# HELP cortex_distributor_received_samples_total The total number of received samples, excluding rejected and deduped samples.
+		# TYPE cortex_distributor_received_samples_total counter
+		cortex_distributor_received_samples_total{user="userA"} 5
+		cortex_distributor_received_samples_total{user="userB"} 10
+
+		# HELP cortex_distributor_samples_in_total The total number of samples that have come in to the distributor, including rejected or deduped samples.
+		# TYPE cortex_distributor_samples_in_total counter
+		cortex_distributor_samples_in_total{user="userA"} 5
+`), metrics...))
+
+	cleanupMetricsForUser("userA")
+
+	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
+		# HELP cortex_distributor_deduped_samples_total The total number of deduplicated samples.
+		# TYPE cortex_distributor_deduped_samples_total counter
+		cortex_distributor_deduped_samples_total{cluster="cluster1",user="userA"} 1
+
+		# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
+		# TYPE cortex_distributor_latest_seen_sample_timestamp_seconds gauge
+
+		# HELP cortex_distributor_metadata_in_total The total number of metadata the have come in to the distributor, including rejected.
+		# TYPE cortex_distributor_metadata_in_total counter
+
+		# HELP cortex_distributor_non_ha_samples_received_total The total number of received samples for a user that has HA tracking turned on, but the sample didn't contain both HA labels.
+		# TYPE cortex_distributor_non_ha_samples_received_total counter
+
+		# HELP cortex_distributor_received_metadata_total The total number of received metadata, excluding rejected.
+		# TYPE cortex_distributor_received_metadata_total counter
+		cortex_distributor_received_metadata_total{user="userB"} 10
+
+		# HELP cortex_distributor_received_samples_total The total number of received samples, excluding rejected and deduped samples.
+		# TYPE cortex_distributor_received_samples_total counter
+		cortex_distributor_received_samples_total{user="userB"} 10
+
+		# HELP cortex_distributor_samples_in_total The total number of samples that have come in to the distributor, including rejected or deduped samples.
+		# TYPE cortex_distributor_samples_in_total counter
+`), metrics...))
+}
+
 func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 	type testPush struct {
 		samples       int

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -332,7 +332,6 @@ func TestDistributor_MetricsCleanup(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
 		# HELP cortex_distributor_deduped_samples_total The total number of deduplicated samples.
 		# TYPE cortex_distributor_deduped_samples_total counter
-		cortex_distributor_deduped_samples_total{cluster="cluster1",user="userA"} 1
 
 		# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
 		# TYPE cortex_distributor_latest_seen_sample_timestamp_seconds gauge

--- a/pkg/util/active_user.go
+++ b/pkg/util/active_user.go
@@ -1,0 +1,86 @@
+package util
+
+import (
+	"sync"
+
+	"go.uber.org/atomic"
+)
+
+type ActiveUsers struct {
+	mu         sync.RWMutex
+	timestamps map[string]*atomic.Int64 // As long as unit used by Update and Purge is the same, it doesn't matter what it is.
+}
+
+func NewActiveUsers() *ActiveUsers {
+	return &ActiveUsers{
+		timestamps: map[string]*atomic.Int64{},
+	}
+}
+
+func (m *ActiveUsers) UpdateUserTimestamp(userID string, ts int64) {
+	m.mu.RLock()
+	u := m.timestamps[userID]
+	m.mu.RUnlock()
+
+	if u != nil {
+		u.Store(ts)
+		return
+	}
+
+	// Pre-allocate new atomic to avoid doing allocation with lock held.
+	newAtomic := atomic.NewInt64(ts)
+
+	// We need RW lock to create new entry.
+	m.mu.Lock()
+	u = m.timestamps[userID]
+
+	if u != nil {
+		// Unlock first to reduce contention.
+		m.mu.Unlock()
+
+		u.Store(ts)
+		return
+	}
+
+	m.timestamps[userID] = newAtomic
+	m.mu.Unlock()
+}
+
+func (m *ActiveUsers) PurgeInactiveUsers(deadline int64) []string {
+	m.mu.RLock()
+	inactive := make([]string, 0, len(m.timestamps))
+
+	for userID, ts := range m.timestamps {
+		if ts.Load() <= deadline {
+			inactive = append(inactive, userID)
+		}
+	}
+	m.mu.RUnlock()
+
+	if len(inactive) == 0 {
+		return nil
+	}
+
+	for ix := 0; ix < len(inactive); {
+		userID := inactive[ix]
+		deleted := false
+
+		m.mu.Lock()
+		u := m.timestamps[userID]
+		if u != nil && u.Load() <= deadline {
+			delete(m.timestamps, userID)
+			deleted = true
+		}
+		m.mu.Unlock()
+
+		if deleted {
+			// keep it in the output
+			ix++
+		} else {
+			// not really inactive, remove it from output
+			inactive = append(inactive[:ix], inactive[ix+1:]...)
+		}
+	}
+
+	return inactive
+}

--- a/pkg/util/active_user.go
+++ b/pkg/util/active_user.go
@@ -6,6 +6,8 @@ import (
 	"go.uber.org/atomic"
 )
 
+// ActiveUsers keeps track of latest user's activity timestamp,
+// and allows purging users that are no longer active.
 type ActiveUsers struct {
 	mu         sync.RWMutex
 	timestamps map[string]*atomic.Int64 // As long as unit used by Update and Purge is the same, it doesn't matter what it is.
@@ -46,7 +48,9 @@ func (m *ActiveUsers) UpdateUserTimestamp(userID string, ts int64) {
 	m.mu.Unlock()
 }
 
+// PurgeInactiveUsers removes users that were last active before given deadline, and returns removed users.
 func (m *ActiveUsers) PurgeInactiveUsers(deadline int64) []string {
+	// Find inactive users with read-lock.
 	m.mu.RLock()
 	inactive := make([]string, 0, len(m.timestamps))
 
@@ -61,6 +65,7 @@ func (m *ActiveUsers) PurgeInactiveUsers(deadline int64) []string {
 		return nil
 	}
 
+	// Cleanup inactive users.
 	for ix := 0; ix < len(inactive); {
 		userID := inactive[ix]
 		deleted := false

--- a/pkg/util/active_user_test.go
+++ b/pkg/util/active_user_test.go
@@ -1,0 +1,141 @@
+package util
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestActiveUser(t *testing.T) {
+	as := NewActiveUsers()
+	as.UpdateUserTimestamp("test1", 5)
+	as.UpdateUserTimestamp("test2", 10)
+	as.UpdateUserTimestamp("test3", 15)
+
+	require.Nil(t, as.PurgeInactiveUsers(2))
+	require.Equal(t, []string{"test1"}, as.PurgeInactiveUsers(5))
+	require.Nil(t, as.PurgeInactiveUsers(7))
+	require.Equal(t, []string{"test2"}, as.PurgeInactiveUsers(12))
+
+	as.UpdateUserTimestamp("test1", 17)
+	require.Equal(t, []string{"test3"}, as.PurgeInactiveUsers(16))
+	require.Equal(t, []string{"test1"}, as.PurgeInactiveUsers(20))
+}
+
+func TestActiveUserConcurrentUpdateAndPurge(t *testing.T) {
+	count := 10
+
+	as := NewActiveUsers()
+
+	done := sync.WaitGroup{}
+	stop := atomic.NewBool(false)
+
+	latestTS := atomic.NewInt64(0)
+
+	for j := 0; j < count; j++ {
+		done.Add(1)
+
+		go func() {
+			defer done.Done()
+
+			for !stop.Load() {
+				ts := latestTS.Inc()
+
+				// In each cycle, we update different user.
+				as.UpdateUserTimestamp(fmt.Sprintf("%d", ts), ts)
+
+				time.Sleep(1 * time.Millisecond)
+			}
+		}()
+	}
+
+	previousLatest := int64(0)
+	for i := 0; i < 10; i++ {
+		time.Sleep(100 * time.Millisecond)
+
+		latest := latestTS.Load()
+		require.True(t, latest > previousLatest)
+
+		purged := as.PurgeInactiveUsers(latest)
+		require.NotEmpty(t, purged)
+	}
+
+	stop.Store(true)
+	done.Wait()
+
+	// Final purge.
+	latest := latestTS.Load()
+	as.PurgeInactiveUsers(latest)
+
+	// Purging again doesn't do anything.
+	purged := as.PurgeInactiveUsers(latest)
+	require.Empty(t, purged)
+}
+
+func BenchmarkActiveUsers_UpdateUserTimestamp(b *testing.B) {
+	for _, c := range []int{0, 5, 10, 25, 50, 100} {
+		b.Run(strconv.Itoa(c), func(b *testing.B) {
+			as := NewActiveUsers()
+
+			startGoroutinesDoingUpdates(b, c, as)
+
+			for i := 0; i < b.N; i++ {
+				as.UpdateUserTimestamp("test", int64(i))
+			}
+		})
+	}
+}
+
+func BenchmarkActiveUsers_Purge(b *testing.B) {
+	for _, c := range []int{0, 5, 10, 25, 50, 100} {
+		b.Run(strconv.Itoa(c), func(b *testing.B) {
+			as := NewActiveUsers()
+
+			startGoroutinesDoingUpdates(b, c, as)
+
+			for i := 0; i < b.N; i++ {
+				as.PurgeInactiveUsers(int64(i))
+			}
+		})
+	}
+}
+
+func startGoroutinesDoingUpdates(b *testing.B, count int, as *ActiveUsers) {
+	done := sync.WaitGroup{}
+	stop := atomic.NewBool(false)
+
+	started := sync.WaitGroup{}
+	for j := 0; j < count; j++ {
+		done.Add(1)
+		started.Add(1)
+		userID := fmt.Sprintf("user-%d", j)
+		go func() {
+			defer done.Done()
+			started.Done()
+
+			ts := int64(0)
+			for !stop.Load() {
+				ts++
+				as.UpdateUserTimestamp(userID, ts)
+
+				// Give other goroutines a chance too.
+				if ts%1000 == 0 {
+					runtime.Gosched()
+				}
+			}
+		}()
+	}
+	started.Wait()
+
+	b.Cleanup(func() {
+		// Ask goroutines to stop, and then wait until they do.
+		stop.Store(true)
+		done.Wait()
+	})
+}

--- a/pkg/util/active_user_test.go
+++ b/pkg/util/active_user_test.go
@@ -62,6 +62,8 @@ func TestActiveUserConcurrentUpdateAndPurge(t *testing.T) {
 		latest := latestTS.Load()
 		require.True(t, latest > previousLatest)
 
+		previousLatest = latest
+
 		purged := as.PurgeInactiveUsers(latest)
 		require.NotEmpty(t, purged)
 	}

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -245,23 +245,10 @@ func formatLabelSet(ls []client.LabelAdapter) string {
 func DeletePerUserValidationMetrics(userID string, log log.Logger) {
 	filter := map[string]string{"user": userID}
 
-	{
-		lbls, err := util.GetLabels(DiscardedSamples, filter)
-		if err != nil {
-			level.Warn(log).Log("msg", "failed to remove cortex_discarded_samples_total metric for user", "user", userID, "err", err)
-		}
-		for _, l := range lbls {
-			DiscardedSamples.Delete(l.Map())
-		}
+	if err := util.DeleteMatchingLabels(DiscardedSamples, filter); err != nil {
+		level.Warn(log).Log("msg", "failed to remove cortex_discarded_samples_total metric for user", "user", userID, "err", err)
 	}
-
-	{
-		lbls, err := util.GetLabels(DiscardedMetadata, filter)
-		if err != nil {
-			level.Warn(log).Log("msg", "failed to remove cortex_discarded_metadata_total metric for user", "user", userID, "err", err)
-		}
-		for _, l := range lbls {
-			DiscardedMetadata.Delete(l.Map())
-		}
+	if err := util.DeleteMatchingLabels(DiscardedMetadata, filter); err != nil {
+		level.Warn(log).Log("msg", "failed to remove cortex_discarded_metadata_total metric for user", "user", userID, "err", err)
 	}
 }


### PR DESCRIPTION
**What this PR does**: This PR adds tracking of active tenants to distributor. Inactive tenants will have their metrics unexported by distributor. Inactivity limit is currently hardcoded to 15 mins.

(I plan to use same technique in querier and query-frontend, but that will be separate PR)

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
