### PR TITLE
Fix concurrency in TestWatchPrefix

### DIFF
--- a/pkg/ring/kv/kv_test.go
+++ b/pkg/ring/kv/kv_test.go
@@ -181,8 +181,8 @@ func TestWatchPrefix(t *testing.T) {
 
 		wg := sync.WaitGroup{}
 
+		wg.Add(1)
 		go func() {
-			wg.Add(1)
 			defer wg.Done()
 
 			// start watching before we even start generating values. values will be buffered
@@ -193,7 +193,6 @@ func TestWatchPrefix(t *testing.T) {
 		}()
 
 		gen := func(p string) {
-			wg.Add(1)
 			defer wg.Done()
 
 			start := time.Now()
@@ -214,6 +213,7 @@ func TestWatchPrefix(t *testing.T) {
 			t.Log("Generator finished in", time.Since(start))
 		}
 
+		wg.Add(2)
 		go gen(prefix)
 		go gen(prefix2) // we don't want to see these keys reported
 


### PR DESCRIPTION
**What this PR does**:
Similarly to @jtlisi, I just experienced this flaky test https://github.com/cortexproject/cortex/issues/3786 too. I noticed that the failing test is `TestList` but the rate condition is in `TestWatchPrefix`:

```
WARNING: DATA RACE
Read at 0x00c0000e4043 by goroutine 135:
  testing.(*common).logDepth()
      /usr/local/go/src/testing/testing.go:725 +0x151
  testing.(*common).log()
      /usr/local/go/src/testing/testing.go:712 +0x77
  testing.(*common).Log()
      /usr/local/go/src/testing/testing.go:751 +0x1d
  github.com/cortexproject/cortex/pkg/ring/kv.TestWatchPrefix.func1.2()
      /__w/cortex/cortex/pkg/ring/kv/kv_test.go:204 +0x3a2
```

I'm not sure of this PR fixes the flaky test, but one cause could be that `TestWatchPrefix` doesn't wait until its goroutines terminate. This means that `t.Log("Generator finished in", time.Since(start))` may be called after the `TestWatchPrefix` terminates and once the next test (which is `TestList`) runs.

**Which issue(s) this PR fixes**:
Fixes #3786 (optimistically)

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
