### PR TITLE
Add validation to http_prefix setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761
 * [BUGFIX] Store-gateway: fixed a panic caused by a race condition when the index-header lazy loading is enabled. #3775 #3789
-* [BUGFIX] Prevent panic at start if the http_prefix setting doesn't have a valid value.
+* [BUGFIX] Prevent panic at start if the http_prefix setting doesn't have a valid value. #3796
 
 ## 1.7.0 in progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761
 * [BUGFIX] Store-gateway: fixed a panic caused by a race condition when the index-header lazy loading is enabled. #3775 #3789
+* [BUGFIX] Prevent panic at start if the http_prefix setting doesn't have a valid value.
 
 ## 1.7.0 in progress
 

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -171,6 +172,10 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 func (c *Config) Validate(log log.Logger) error {
 	if err := c.validateYAMLEmptyNodes(); err != nil {
 		return err
+	}
+
+	if c.HTTPPrefix != "" && !strings.HasPrefix(c.HTTPPrefix, "/") {
+		return errors.New("http_prefix should be empty or start with /")
 	}
 
 	if err := c.Schema.Validate(); err != nil {

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -62,6 +62,10 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
+var (
+	errInvalidHttpPrefix = errors.New("HTTP prefix should be empty or start with /")
+)
+
 // The design pattern for Cortex is a series of config objects, which are
 // registered for command line flags, and then a series of components that
 // are instantiated and composed.  Some rules of thumb:
@@ -175,7 +179,7 @@ func (c *Config) Validate(log log.Logger) error {
 	}
 
 	if c.HTTPPrefix != "" && !strings.HasPrefix(c.HTTPPrefix, "/") {
-		return errors.New("http_prefix should be empty or start with /")
+		return errInvalidHttpPrefix
 	}
 
 	if err := c.Schema.Validate(); err != nil {

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -63,7 +63,7 @@ import (
 )
 
 var (
-	errInvalidHttpPrefix = errors.New("HTTP prefix should be empty or start with /")
+	errInvalidHTTPPrefix = errors.New("HTTP prefix should be empty or start with /")
 )
 
 // The design pattern for Cortex is a series of config objects, which are
@@ -179,7 +179,7 @@ func (c *Config) Validate(log log.Logger) error {
 	}
 
 	if c.HTTPPrefix != "" && !strings.HasPrefix(c.HTTPPrefix, "/") {
-		return errInvalidHttpPrefix
+		return errInvalidHTTPPrefix
 	}
 
 	if err := c.Schema.Validate(); err != nil {

--- a/pkg/cortex/cortex_test.go
+++ b/pkg/cortex/cortex_test.go
@@ -118,7 +118,7 @@ func TestConfigValidation(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "should fail if validation is not empty or starts with /",
+			name: "should fail validation for invalid prefix",
 			getTestConfig: func() *Config {
 				configuration := newDefaultConfig()
 				configuration.HTTPPrefix = "test"

--- a/pkg/cortex/cortex_test.go
+++ b/pkg/cortex/cortex_test.go
@@ -99,14 +99,14 @@ func TestConfigValidation(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
 		getTestConfig func() *Config
-		expectedError bool
+		expectedError error
 	}{
 		{
 			name: "should pass validation if the http prefix is empty",
 			getTestConfig: func() *Config {
 				return newDefaultConfig()
 			},
-			expectedError: false,
+			expectedError: nil,
 		},
 		{
 			name: "should pass validation if the http prefix starts with /",
@@ -115,7 +115,7 @@ func TestConfigValidation(t *testing.T) {
 				configuration.HTTPPrefix = "/test"
 				return configuration
 			},
-			expectedError: false,
+			expectedError: nil,
 		},
 		{
 			name: "should fail validation for invalid prefix",
@@ -124,13 +124,13 @@ func TestConfigValidation(t *testing.T) {
 				configuration.HTTPPrefix = "test"
 				return configuration
 			},
-			expectedError: true,
+			expectedError: errInvalidHttpPrefix,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.getTestConfig().Validate(nil)
-			if tc.expectedError {
-				require.Error(t, err)
+			if tc.expectedError != nil {
+				require.Equal(t, tc.expectedError, err)
 			} else {
 				require.NoError(t, err)
 			}

--- a/pkg/cortex/cortex_test.go
+++ b/pkg/cortex/cortex_test.go
@@ -124,7 +124,7 @@ func TestConfigValidation(t *testing.T) {
 				configuration.HTTPPrefix = "test"
 				return configuration
 			},
-			expectedError: errInvalidHttpPrefix,
+			expectedError: errInvalidHTTPPrefix,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/cortex/cortex_test.go
+++ b/pkg/cortex/cortex_test.go
@@ -94,3 +94,46 @@ func TestCortex(t *testing.T) {
 	// check that compactor is configured which is not part of Target=All
 	require.NotNil(t, serviceMap[Compactor])
 }
+
+func TestConfigValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		getTestConfig func() *Config
+		expectedError bool
+	}{
+		{
+			name: "should pass validation if the http prefix is empty",
+			getTestConfig: func() *Config {
+				return newDefaultConfig()
+			},
+			expectedError: false,
+		},
+		{
+			name: "should pass validation if the http prefix starts with /",
+			getTestConfig: func() *Config {
+				configuration := newDefaultConfig()
+				configuration.HTTPPrefix = "/test"
+				return configuration
+			},
+			expectedError: false,
+		},
+		{
+			name: "should fail if validation is not empty or starts with /",
+			getTestConfig: func() *Config {
+				configuration := newDefaultConfig()
+				configuration.HTTPPrefix = "test"
+				return configuration
+			},
+			expectedError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.getTestConfig().Validate(nil)
+			if tc.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
http_prefix setting doesn't have validation so in case a user sets that
setting to a value without stating with / or empty value that would prevent
cortex to start with a panic coming from the router

Signed-off-by: Mario de Frutos <mario@defrutos.org>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR validates the `http_prefix` setting to avoid issues passing not valid values. The original issue talked about not able to reach the enpoint if the settings was `-http.prefix='""'` but right now that returns a panic from the router:

```
panic: path must begin with '/' in path '""/api/v1/*path'

goroutine 1 [running]:
github.com/julienschmidt/httprouter.(*Router).Handle(0xc000a2e720, 0x2603f7b, 0x7, 0xc0001aea80, 0xf, 0xc0000a9c80)
	/home/ethervoid/development/cortex/vendor/github.com/julienschmidt/httprouter/router.go:246 +0x24c
github.com/julienschmidt/httprouter.(*Router).OPTIONS(...)
	/home/ethervoid/development/cortex/vendor/github.com/julienschmidt/httprouter/router.go:213
github.com/prometheus/common/route.(*Router).Options(0xc000a83580, 0x2601b78, 0x6, 0xc000a835c0)
	/home/ethervoid/development/cortex/vendor/github.com/prometheus/common/route/route.go:94 +0xd8
github.com/prometheus/prometheus/web/api/v1.(*API).Register(0xc000252300, 0xc000a83580)
	/home/ethervoid/development/cortex/vendor/github.com/prometheus/prometheus/web/api/v1/api.go:285 +0xb1
github.com/cortexproject/cortex/pkg/api.NewQuerierHandler(0x0, 0x260f53c, 0xd, 0x260b3b0, 0xb, 0x0, 0x0, 0x7ffd6e426706, 0x2, 0x2a54040, ...)
	/home/ethervoid/development/cortex/pkg/api/handlers.go:235 +0xe4b
github.com/cortexproject/cortex/pkg/cortex.(*Cortex).initQuerier(0xc0008e8000, 0x0, 0xc00053b498, 0x0, 0xc00053b440)
	/home/ethervoid/development/cortex/pkg/cortex/modules.go:271 +0xf9
github.com/cortexproject/cortex/pkg/util/modules.(*Manager).initModule(0xc000116d60, 0x7ffd6e426690, 0x7, 0xc000ea8ab0, 0xc0008c4c00, 0x0, 0x0)
	/home/ethervoid/development/cortex/pkg/util/modules/modules.go:103 +0x2c2
github.com/cortexproject/cortex/pkg/util/modules.(*Manager).InitModuleServices(0xc000116d60, 0xc0002c15c0, 0x1, 0x1, 0xc00053b4f0, 0x7510c18f88e2e501, 0xc000782200)
	/home/ethervoid/development/cortex/pkg/util/modules/modules.go:75 +0x105
github.com/cortexproject/cortex/pkg/cortex.(*Cortex).Run(0xc0008e8000, 0xc0006ddb80, 0x4)
	/home/ethervoid/development/cortex/pkg/cortex/cortex.go:369 +0x2a5
main.main()
	/home/ethervoid/development/cortex/cmd/cortex/main.go:190 +0xe70
```

So it's a small change and improves the user experience and prevents possible side effects

**Which issue(s) this PR fixes**:
Fixes #1927

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
