### PR TITLE
Add more TSDB metrics for ingester to emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@
   * `-blocks-storage.s3.max-connections-per-host`: Maximum number of connections per host. 0 means no limit.
 * [ENHANCEMENT] Ingester: when tenant's TSDB is closed, Ingester now removes pushed metrics-metadata from memory, and removes metadata (`cortex_ingester_memory_metadata`, `cortex_ingester_memory_metadata_created_total`, `cortex_ingester_memory_metadata_removed_total`) and validation metrics (`cortex_discarded_samples_total`, `cortex_discarded_metadata_total`). #3782
 * [ENHANCEMENT] Distributor: cleanup metrics for inactive tenants. #3784
+* [ENHANCEMENT] Ingester: Have ingester to re-emit following TSDB metrics. #3799
+  * `cortex_ingester_tsdb_blocks_loaded`
+  * `cortex_ingester_tsdb_reloads_total`
+  * `cortex_ingester_tsdb_reloads_failures_total`
+  * `cortex_ingester_tsdb_symbol_table_size_bytes`
+  * `cortex_ingester_tsdb_storage_blocks_bytes`
+  * `cortex_ingester_tsdb_time_retentions_total`
+  * `cortex_ingester_tsdb_tombstone_cleanup_seconds`
 * [BUGFIX] Cortex: Fixed issue where fatal errors and various log messages where not logged. #3778
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@
   * `cortex_ingester_tsdb_symbol_table_size_bytes`
   * `cortex_ingester_tsdb_storage_blocks_bytes`
   * `cortex_ingester_tsdb_time_retentions_total`
-  * `cortex_ingester_tsdb_tombstone_cleanup_seconds`
 * [BUGFIX] Cortex: Fixed issue where fatal errors and various log messages where not logged. #3778
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
   * `-blocks-storage.s3.max-connections-per-host`: Maximum number of connections per host. 0 means no limit.
 * [ENHANCEMENT] Ingester: when tenant's TSDB is closed, Ingester now removes pushed metrics-metadata from memory, and removes metadata (`cortex_ingester_memory_metadata`, `cortex_ingester_memory_metadata_created_total`, `cortex_ingester_memory_metadata_removed_total`) and validation metrics (`cortex_discarded_samples_total`, `cortex_discarded_metadata_total`). #3782
 * [ENHANCEMENT] Distributor: cleanup metrics for inactive tenants. #3784
-* [ENHANCEMENT] Ingester: Have ingester to re-emit following TSDB metrics. #3799
+* [ENHANCEMENT] Ingester: Have ingester to re-emit following TSDB metrics. #3800
   * `cortex_ingester_tsdb_blocks_loaded`
   * `cortex_ingester_tsdb_reloads_total`
   * `cortex_ingester_tsdb_reloads_failures_total`

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -259,6 +259,15 @@ type tsdbMetrics struct {
 	tsdbChunksRemovedTotal       *prometheus.Desc
 	tsdbMmapChunkCorruptionTotal *prometheus.Desc
 
+	// Follow metrics are from https://github.com/prometheus/prometheus/blob/fbe960f2c1ad9d6f5fe2f267d2559bf7ecfab6df/tsdb/db.go#L179
+	tsdbLoadedBlocks       *prometheus.Desc
+	tsdbSymbolTableSize    *prometheus.Desc
+	tsdbReloads            *prometheus.Desc
+	tsdbReloadsFailed      *prometheus.Desc
+	tsdbTimeRetentionCount *prometheus.Desc
+	tsdbTombCleanTimer     *prometheus.Desc
+	tsdbBlocksBytes        *prometheus.Desc
+
 	checkpointDeleteFail    *prometheus.Desc
 	checkpointDeleteTotal   *prometheus.Desc
 	checkpointCreationFail  *prometheus.Desc
@@ -367,6 +376,34 @@ func newTSDBMetrics(r prometheus.Registerer) *tsdbMetrics {
 			"cortex_ingester_tsdb_mmap_chunk_corruptions_total",
 			"Total number of memory-mapped TSDB chunk corruptions.",
 			nil, nil),
+		tsdbLoadedBlocks: prometheus.NewDesc(
+			"cortex_ingester_tsdb_blocks_loaded",
+			"Number of currently loaded data blocks",
+			nil, nil),
+		tsdbReloads: prometheus.NewDesc(
+			"cortex_ingester_tsdb_reloads_total",
+			"Number of times the database reloaded block data from disk.",
+			nil, nil),
+		tsdbReloadsFailed: prometheus.NewDesc(
+			"cortex_ingester_tsdb_reloads_failures_total",
+			"Number of times the database failed to reloadBlocks block data from disk.",
+			nil, nil),
+		tsdbSymbolTableSize: prometheus.NewDesc(
+			"cortex_ingester_tsdb_symbol_table_size_bytes",
+			"Size of symbol table in memory for loaded blocks",
+			[]string{"user"}, nil),
+		tsdbBlocksBytes: prometheus.NewDesc(
+			"cortex_ingester_tsdb_storage_blocks_bytes",
+			"The number of bytes that are currently used for local storage by all blocks.",
+			[]string{"user"}, nil),
+		tsdbTimeRetentionCount: prometheus.NewDesc(
+			"cortex_ingester_tsdb_time_retentions_total",
+			"The number of times that blocks were deleted because the maximum time limit was exceeded.",
+			nil, nil),
+		tsdbTombCleanTimer: prometheus.NewDesc(
+			"cortex_ingester_tsdb_tombstone_cleanup_seconds",
+			"The time taken to recompact blocks to remove tombstones.",
+			nil, nil),
 		checkpointDeleteFail: prometheus.NewDesc(
 			"cortex_ingester_tsdb_checkpoint_deletions_failed_total",
 			"Total number of TSDB checkpoint deletions that failed.",
@@ -419,6 +456,13 @@ func (sm *tsdbMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- sm.tsdbChunksCreatedTotal
 	out <- sm.tsdbChunksRemovedTotal
 	out <- sm.tsdbMmapChunkCorruptionTotal
+	out <- sm.tsdbLoadedBlocks
+	out <- sm.tsdbSymbolTableSize
+	out <- sm.tsdbReloads
+	out <- sm.tsdbReloadsFailed
+	out <- sm.tsdbTimeRetentionCount
+	out <- sm.tsdbTombCleanTimer
+	out <- sm.tsdbBlocksBytes
 	out <- sm.checkpointDeleteFail
 	out <- sm.checkpointDeleteTotal
 	out <- sm.checkpointCreationFail
@@ -456,6 +500,13 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCountersPerUser(out, sm.tsdbChunksCreatedTotal, "prometheus_tsdb_head_chunks_created_total")
 	data.SendSumOfCountersPerUser(out, sm.tsdbChunksRemovedTotal, "prometheus_tsdb_head_chunks_removed_total")
 	data.SendSumOfCounters(out, sm.tsdbMmapChunkCorruptionTotal, "prometheus_tsdb_mmap_chunk_corruptions_total")
+	data.SendSumOfGauges(out, sm.tsdbLoadedBlocks, "prometheus_tsdb_blocks_loaded")
+	data.SendSumOfCounters(out, sm.tsdbReloads, "prometheus_tsdb_reloads_total")
+	data.SendSumOfCounters(out, sm.tsdbReloadsFailed, "prometheus_tsdb_reloads_failures_total")
+	data.SendSumOfGaugesPerUser(out, sm.tsdbSymbolTableSize, "prometheus_tsdb_symbol_table_size_bytes")
+	data.SendSumOfGaugesPerUser(out, sm.tsdbBlocksBytes, "prometheus_tsdb_storage_blocks_bytes")
+	data.SendSumOfCounters(out, sm.tsdbTimeRetentionCount, "prometheus_tsdb_time_retentions_total")
+	data.SendSumOfHistograms(out, sm.tsdbTombCleanTimer, "prometheus_tsdb_tombstone_cleanup_seconds")
 	data.SendSumOfCounters(out, sm.checkpointDeleteFail, "prometheus_tsdb_checkpoint_deletions_failed_total")
 	data.SendSumOfCounters(out, sm.checkpointDeleteTotal, "prometheus_tsdb_checkpoint_deletions_total")
 	data.SendSumOfCounters(out, sm.checkpointCreationFail, "prometheus_tsdb_checkpoint_creations_failed_total")

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -265,7 +265,6 @@ type tsdbMetrics struct {
 	tsdbReloads            *prometheus.Desc
 	tsdbReloadsFailed      *prometheus.Desc
 	tsdbTimeRetentionCount *prometheus.Desc
-	tsdbTombCleanTimer     *prometheus.Desc
 	tsdbBlocksBytes        *prometheus.Desc
 
 	checkpointDeleteFail    *prometheus.Desc
@@ -400,10 +399,6 @@ func newTSDBMetrics(r prometheus.Registerer) *tsdbMetrics {
 			"cortex_ingester_tsdb_time_retentions_total",
 			"The number of times that blocks were deleted because the maximum time limit was exceeded.",
 			nil, nil),
-		tsdbTombCleanTimer: prometheus.NewDesc(
-			"cortex_ingester_tsdb_tombstone_cleanup_seconds",
-			"The time taken to recompact blocks to remove tombstones.",
-			nil, nil),
 		checkpointDeleteFail: prometheus.NewDesc(
 			"cortex_ingester_tsdb_checkpoint_deletions_failed_total",
 			"Total number of TSDB checkpoint deletions that failed.",
@@ -461,7 +456,6 @@ func (sm *tsdbMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- sm.tsdbReloads
 	out <- sm.tsdbReloadsFailed
 	out <- sm.tsdbTimeRetentionCount
-	out <- sm.tsdbTombCleanTimer
 	out <- sm.tsdbBlocksBytes
 	out <- sm.checkpointDeleteFail
 	out <- sm.checkpointDeleteTotal
@@ -501,12 +495,11 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCountersPerUser(out, sm.tsdbChunksRemovedTotal, "prometheus_tsdb_head_chunks_removed_total")
 	data.SendSumOfCounters(out, sm.tsdbMmapChunkCorruptionTotal, "prometheus_tsdb_mmap_chunk_corruptions_total")
 	data.SendSumOfGauges(out, sm.tsdbLoadedBlocks, "prometheus_tsdb_blocks_loaded")
+	data.SendSumOfGaugesPerUser(out, sm.tsdbSymbolTableSize, "prometheus_tsdb_symbol_table_size_bytes")
 	data.SendSumOfCounters(out, sm.tsdbReloads, "prometheus_tsdb_reloads_total")
 	data.SendSumOfCounters(out, sm.tsdbReloadsFailed, "prometheus_tsdb_reloads_failures_total")
-	data.SendSumOfGaugesPerUser(out, sm.tsdbSymbolTableSize, "prometheus_tsdb_symbol_table_size_bytes")
-	data.SendSumOfGaugesPerUser(out, sm.tsdbBlocksBytes, "prometheus_tsdb_storage_blocks_bytes")
 	data.SendSumOfCounters(out, sm.tsdbTimeRetentionCount, "prometheus_tsdb_time_retentions_total")
-	data.SendSumOfHistograms(out, sm.tsdbTombCleanTimer, "prometheus_tsdb_tombstone_cleanup_seconds")
+	data.SendSumOfGaugesPerUser(out, sm.tsdbBlocksBytes, "prometheus_tsdb_storage_blocks_bytes")
 	data.SendSumOfCounters(out, sm.checkpointDeleteFail, "prometheus_tsdb_checkpoint_deletions_failed_total")
 	data.SendSumOfCounters(out, sm.checkpointDeleteTotal, "prometheus_tsdb_checkpoint_deletions_total")
 	data.SendSumOfCounters(out, sm.checkpointCreationFail, "prometheus_tsdb_checkpoint_creations_failed_total")

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -167,6 +167,50 @@ func TestTSDBMetrics(t *testing.T) {
 			# HELP cortex_ingester_tsdb_mmap_chunk_corruptions_total Total number of memory-mapped TSDB chunk corruptions.
 			# TYPE cortex_ingester_tsdb_mmap_chunk_corruptions_total counter
 			cortex_ingester_tsdb_mmap_chunk_corruptions_total 2577406
+
+			# HELP cortex_ingester_tsdb_blocks_loaded Number of currently loaded data blocks
+			# TYPE cortex_ingester_tsdb_blocks_loaded gauge
+			cortex_ingester_tsdb_blocks_loaded 15
+
+			# HELP cortex_ingester_tsdb_reloads_total Number of times the database reloaded block data from disk.
+			# TYPE cortex_ingester_tsdb_reloads_total counter
+			cortex_ingester_tsdb_reloads_total 30
+
+			# HELP cortex_ingester_tsdb_reloads_failures_total Number of times the database failed to reloadBlocks block data from disk.
+			# TYPE cortex_ingester_tsdb_reloads_failures_total counter
+			cortex_ingester_tsdb_reloads_failures_total 21
+
+			# HELP cortex_ingester_tsdb_symbol_table_size_bytes Size of symbol table in memory for loaded blocks
+			# TYPE cortex_ingester_tsdb_symbol_table_size_bytes gauge
+			cortex_ingester_tsdb_symbol_table_size_bytes{user="user1"} 12641280
+			cortex_ingester_tsdb_symbol_table_size_bytes{user="user2"} 87845888
+			cortex_ingester_tsdb_symbol_table_size_bytes{user="user3"} 1022976
+
+			# HELP cortex_ingester_tsdb_storage_blocks_bytes The number of bytes that are currently used for local storage by all blocks.
+			# TYPE cortex_ingester_tsdb_storage_blocks_bytes gauge
+			cortex_ingester_tsdb_storage_blocks_bytes{user="user1"} 50565120
+			cortex_ingester_tsdb_storage_blocks_bytes{user="user2"} 351383552
+			cortex_ingester_tsdb_storage_blocks_bytes{user="user3"} 4091904
+
+			# HELP cortex_ingester_tsdb_time_retentions_total The number of times that blocks were deleted because the maximum time limit was exceeded.
+			# TYPE cortex_ingester_tsdb_time_retentions_total counter
+			cortex_ingester_tsdb_time_retentions_total 33
+
+			# HELP cortex_ingester_tsdb_tombstone_cleanup_seconds The time taken to recompact blocks to remove tombstones.
+			# TYPE cortex_ingester_tsdb_tombstone_cleanup_seconds histogram
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="1"} 0
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="2"} 0
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="4"} 0
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="8"} 0
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="16"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="32"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="64"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="128"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="256"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="512"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="+Inf"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_sum 39
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_count 3
 	`))
 	require.NoError(t, err)
 }
@@ -325,6 +369,48 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 			# HELP cortex_ingester_tsdb_mmap_chunk_corruptions_total Total number of memory-mapped TSDB chunk corruptions.
 			# TYPE cortex_ingester_tsdb_mmap_chunk_corruptions_total counter
 			cortex_ingester_tsdb_mmap_chunk_corruptions_total 2577406
+
+			# HELP cortex_ingester_tsdb_blocks_loaded Number of currently loaded data blocks
+			# TYPE cortex_ingester_tsdb_blocks_loaded gauge
+			cortex_ingester_tsdb_blocks_loaded 10
+
+			# HELP cortex_ingester_tsdb_reloads_total Number of times the database reloaded block data from disk.
+			# TYPE cortex_ingester_tsdb_reloads_total counter
+			cortex_ingester_tsdb_reloads_total 30
+
+			# HELP cortex_ingester_tsdb_reloads_failures_total Number of times the database failed to reloadBlocks block data from disk.
+			# TYPE cortex_ingester_tsdb_reloads_failures_total counter
+			cortex_ingester_tsdb_reloads_failures_total 21
+
+			# HELP cortex_ingester_tsdb_symbol_table_size_bytes Size of symbol table in memory for loaded blocks
+			# TYPE cortex_ingester_tsdb_symbol_table_size_bytes gauge
+			cortex_ingester_tsdb_symbol_table_size_bytes{user="user1"} 12641280
+			cortex_ingester_tsdb_symbol_table_size_bytes{user="user2"} 87845888
+
+			# HELP cortex_ingester_tsdb_storage_blocks_bytes The number of bytes that are currently used for local storage by all blocks.
+			# TYPE cortex_ingester_tsdb_storage_blocks_bytes gauge
+			cortex_ingester_tsdb_storage_blocks_bytes{user="user1"} 50565120
+			cortex_ingester_tsdb_storage_blocks_bytes{user="user2"} 351383552
+
+			# HELP cortex_ingester_tsdb_time_retentions_total The number of times that blocks were deleted because the maximum time limit was exceeded.
+			# TYPE cortex_ingester_tsdb_time_retentions_total counter
+			cortex_ingester_tsdb_time_retentions_total 33
+
+			# HELP cortex_ingester_tsdb_tombstone_cleanup_seconds The time taken to recompact blocks to remove tombstones.
+			# TYPE cortex_ingester_tsdb_tombstone_cleanup_seconds histogram
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="1"} 0
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="2"} 0
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="4"} 0
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="8"} 0
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="16"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="32"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="64"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="128"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="256"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="512"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="+Inf"} 3
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_sum 39
+			cortex_ingester_tsdb_tombstone_cleanup_seconds_count 3
 	`))
 	require.NoError(t, err)
 }
@@ -507,6 +593,49 @@ func populateTSDBMetrics(base float64) *prometheus.Registry {
 		Help: "Runtime of garbage collection in the head block.",
 	})
 	gcDuration.Observe(3)
+
+	loadedBlocks := promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_blocks_loaded",
+		Help: "Number of currently loaded data blocks",
+	})
+	loadedBlocks.Set(5)
+
+	reloadsTotal := promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_reloads_total",
+		Help: "Number of times the database reloaded block data from disk.",
+	})
+	reloadsTotal.Add(10)
+
+	reloadsFailed := promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_reloads_failures_total",
+		Help: "Number of times the database failed to reloadBlocks block data from disk.",
+	})
+	reloadsFailed.Add(7)
+
+	symbolTableSize := promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_symbol_table_size_bytes",
+		Help: "Size of symbol table in memory for loaded blocks",
+	})
+	symbolTableSize.Set(1024 * base)
+
+	blocksSize := promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_storage_blocks_bytes",
+		Help: "The number of bytes that are currently used for local storage by all blocks.",
+	})
+	blocksSize.Set(4096 * base)
+
+	retentionsTotal := promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_time_retentions_total",
+		Help: "The number of times that blocks were deleted because the maximum time limit was exceeded.",
+	})
+	retentionsTotal.Add(11)
+
+	tombsonteCleanSeconds := promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+		Name:    "prometheus_tsdb_tombstone_cleanup_seconds",
+		Help:    "The time taken to recompact blocks to remove tombstones.",
+		Buckets: prometheus.ExponentialBuckets(1, 2, 10),
+	})
+	tombsonteCleanSeconds.Observe(13)
 
 	return r
 }

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -195,22 +195,6 @@ func TestTSDBMetrics(t *testing.T) {
 			# HELP cortex_ingester_tsdb_time_retentions_total The number of times that blocks were deleted because the maximum time limit was exceeded.
 			# TYPE cortex_ingester_tsdb_time_retentions_total counter
 			cortex_ingester_tsdb_time_retentions_total 33
-
-			# HELP cortex_ingester_tsdb_tombstone_cleanup_seconds The time taken to recompact blocks to remove tombstones.
-			# TYPE cortex_ingester_tsdb_tombstone_cleanup_seconds histogram
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="1"} 0
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="2"} 0
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="4"} 0
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="8"} 0
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="16"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="32"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="64"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="128"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="256"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="512"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="+Inf"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_sum 39
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_count 3
 	`))
 	require.NoError(t, err)
 }
@@ -395,22 +379,6 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 			# HELP cortex_ingester_tsdb_time_retentions_total The number of times that blocks were deleted because the maximum time limit was exceeded.
 			# TYPE cortex_ingester_tsdb_time_retentions_total counter
 			cortex_ingester_tsdb_time_retentions_total 33
-
-			# HELP cortex_ingester_tsdb_tombstone_cleanup_seconds The time taken to recompact blocks to remove tombstones.
-			# TYPE cortex_ingester_tsdb_tombstone_cleanup_seconds histogram
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="1"} 0
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="2"} 0
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="4"} 0
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="8"} 0
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="16"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="32"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="64"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="128"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="256"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="512"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_bucket{le="+Inf"} 3
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_sum 39
-			cortex_ingester_tsdb_tombstone_cleanup_seconds_count 3
 	`))
 	require.NoError(t, err)
 }
@@ -629,13 +597,5 @@ func populateTSDBMetrics(base float64) *prometheus.Registry {
 		Help: "The number of times that blocks were deleted because the maximum time limit was exceeded.",
 	})
 	retentionsTotal.Add(11)
-
-	tombsonteCleanSeconds := promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-		Name:    "prometheus_tsdb_tombstone_cleanup_seconds",
-		Help:    "The time taken to recompact blocks to remove tombstones.",
-		Buckets: prometheus.ExponentialBuckets(1, 2, 10),
-	})
-	tombsonteCleanSeconds.Observe(13)
-
 	return r
 }


### PR DESCRIPTION
Signed-off-by: Alvin Lin <alvinlin@amazon.com>


**What this PR does**:

This PR update the ingester to emit some metrics defined in [TSDB's db.go](https://github.com/prometheus/prometheus/blob/fbe960f2c1ad9d6f5fe2f267d2559bf7ecfab6df/tsdb/db.go#L257). 

I did not emit compaction related metrics because ingester already emit compaction metrics (`prometheus_tsdb_compactions_total` and `prometheus_tsdb_compaction_duration_seconds`) from TSDB's compactor, which is enough to get an over view of the compaction status. 

For `prometheus_tsdb_symbol_table_size_bytes` and `prometheus_tsdb_storage_blocks_bytes` I decided to emit per user metric because it can help to identify "top talker" and react accordingly. 

**Which issue(s) this PR fixes**:
Fixes #3799

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
