### PR TITLE
Fixed 'could not guess file size' when uploading global deletion marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761
 * [BUGFIX] Store-gateway: fixed a panic caused by a race condition when the index-header lazy loading is enabled. #3775 #3789
+* [BUGFIX] Compactor: fixed "could not guess file size" log when uploading blocks deletion marks to the global location. #3807
 
 ## 1.7.0 in progress
 

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
@@ -41,13 +41,13 @@ func (b *globalMarkersBucket) Upload(ctx context.Context, name string, r io.Read
 	}
 
 	// Upload it to the original location.
-	if err := b.parent.Upload(ctx, name, bytes.NewReader(body)); err != nil {
+	if err := b.parent.Upload(ctx, name, bytes.NewBuffer(body)); err != nil {
 		return err
 	}
 
 	// Upload it to the global markers location too.
 	globalMarkPath := path.Clean(path.Join(path.Dir(name), "../", BlockDeletionMarkFilepath(blockID)))
-	return b.parent.Upload(ctx, globalMarkPath, bytes.NewReader(body))
+	return b.parent.Upload(ctx, globalMarkPath, bytes.NewBuffer(body))
 }
 
 // Delete implements objstore.Bucket.


### PR DESCRIPTION
**What this PR does**:
Thanos has a function `TryToGetSize()` used by some object store clients to detect the size of the upload:
https://github.com/thanos-io/thanos/blob/c1bb8ad5fc3ebdf491aa712493da930830de27dd/pkg/objstore/objstore.go#L108

When this function is not able to guess it, upload is less performant for some backends and the application logs "could not guess file size".

In this PR I've fixed the detection of the size when we upload the deletion marks in the global markers location.

**Which issue(s) this PR fixes**:
Fixes #3766

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
