### PR TITLE
Small HA tracker cleanup

### DIFF
--- a/integration/kv_test.go
+++ b/integration/kv_test.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/integration/e2e"
@@ -20,18 +22,95 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring/kv/etcd"
 )
 
-func TestKV_List_Delete(t *testing.T) {
-	s, err := e2e.NewScenario(networkName)
-	require.NoError(t, err)
-	defer s.Close()
+func TestKVList(t *testing.T) {
+	testKVs(t, func(t *testing.T, client kv.Client, reg *prometheus.Registry) {
+		// Create keys to list back
+		keysToCreate := []string{"key-a", "key-b", "key-c"}
+		for _, key := range keysToCreate {
+			err := client.CAS(context.Background(), key, func(in interface{}) (out interface{}, retry bool, err error) {
+				return key, false, nil
+			})
+			require.NoError(t, err, "could not create key")
+		}
 
-	// Start dependencies
+		// Get list of keys and sort them
+		keys, err := client.List(context.Background(), "")
+		require.NoError(t, err, "could not list keys")
+		sort.Strings(keys)
+		require.Equal(t, keysToCreate, keys, "returned key paths did not match created paths")
+
+		verifyClientMetrics(t, reg, map[string]uint64{
+			"List": 1,
+			"CAS":  3,
+		})
+	})
+}
+
+func TestKVDelete(t *testing.T) {
+	testKVs(t, func(t *testing.T, client kv.Client, reg *prometheus.Registry) {
+		// Create a key
+		err := client.CAS(context.Background(), "key-to-delete", func(in interface{}) (out interface{}, retry bool, err error) {
+			return "key-to-delete", false, nil
+		})
+		require.NoError(t, err, "object could not be created")
+
+		// Now delete it
+		err = client.Delete(context.Background(), "key-to-delete")
+		require.NoError(t, err)
+
+		// Get it back
+		v, err := client.Get(context.Background(), "key-to-delete")
+		require.NoError(t, err, "unexpected error")
+		require.Nil(t, v, "object was not deleted")
+
+		verifyClientMetrics(t, reg, map[string]uint64{
+			"Delete": 1,
+			"CAS":    1,
+			"GET":    1,
+		})
+	})
+}
+
+func TestKVWatchAndDelete(t *testing.T) {
+	testKVs(t, func(t *testing.T, client kv.Client, reg *prometheus.Registry) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := client.CAS(context.Background(), "key-before-watch", func(in interface{}) (out interface{}, retry bool, err error) {
+			return "value-before-watch", false, nil
+		})
+		require.NoError(t, err)
+
+		w := &watcher{}
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		go w.watch(ctx, wg, client)
+
+		err = client.CAS(context.Background(), "key-to-delete", func(in interface{}) (out interface{}, retry bool, err error) {
+			return "value-to-delete", false, nil
+		})
+		require.NoError(t, err, "object could not be created")
+
+		// Now delete it
+		err = client.Delete(context.Background(), "key-to-delete")
+		require.NoError(t, err)
+
+		// Stop the watcher
+		cancel()
+		wg.Wait()
+
+		// Consul reports:
+		// map[key-before-watch:[value-before-watch] key-to-delete:[value-to-delete]]
+		//
+		// Etcd reports:
+		// map[key-to-delete:[value-to-delete ""]]
+		t.Log(w.values)
+	})
+}
+
+func setupEtcd(t *testing.T, scenario *e2e.Scenario, reg prometheus.Registerer) kv.Client {
 	etcdSvc := e2edb.NewETCD()
-	consulSvc := e2edb.NewConsul()
-
-	require.NoError(t, s.StartAndWaitReady(etcdSvc, consulSvc))
-
-	reg := prometheus.NewRegistry()
+	require.NoError(t, scenario.StartAndWaitReady(etcdSvc))
 
 	etcdKv, err := kv.NewClient(kv.Config{
 		Store:  "etcd",
@@ -45,6 +124,13 @@ func TestKV_List_Delete(t *testing.T) {
 		},
 	}, stringCodec{}, reg)
 	require.NoError(t, err)
+
+	return etcdKv
+}
+
+func setupConsul(t *testing.T, scenario *e2e.Scenario, reg prometheus.Registerer) kv.Client {
+	consulSvc := e2edb.NewConsul()
+	require.NoError(t, scenario.StartAndWaitReady(consulSvc))
 
 	consulKv, err := kv.NewClient(kv.Config{
 		Store:  "consul",
@@ -60,58 +146,39 @@ func TestKV_List_Delete(t *testing.T) {
 	}, stringCodec{}, reg)
 	require.NoError(t, err)
 
-	kvs := []struct {
-		name string
-		kv   kv.Client
-	}{
-		{"etcd", etcdKv},
-		{"consul", consulKv},
+	return consulKv
+}
+
+func testKVs(t *testing.T, testFn func(t *testing.T, client kv.Client, reg *prometheus.Registry)) {
+	setupFns := map[string]func(t *testing.T, scenario *e2e.Scenario, reg prometheus.Registerer) kv.Client{
+		"etcd":   setupEtcd,
+		"consul": setupConsul,
 	}
 
-	for _, kv := range kvs {
-		t.Run(kv.name+"_list", func(t *testing.T) {
-			// Create keys to list back
-			keysToCreate := []string{"key-a", "key-b", "key-c"}
-			for _, key := range keysToCreate {
-				err := kv.kv.CAS(context.Background(), key, func(in interface{}) (out interface{}, retry bool, err error) {
-					return key, false, nil
-				})
-				require.NoError(t, err, "could not create key")
-			}
-
-			// Get list of keys and sort them
-			keys, err := kv.kv.List(context.Background(), "")
-			require.NoError(t, err, "could not list keys")
-			sort.Strings(keys)
-			require.Equal(t, keysToCreate, keys, "returned key paths did not match created paths")
-		})
-
-		t.Run(kv.name+"_delete", func(t *testing.T) {
-			// Create a key
-			err = kv.kv.CAS(context.Background(), "key-to-delete", func(in interface{}) (out interface{}, retry bool, err error) {
-				return "key-to-delete", false, nil
-			})
-			require.NoError(t, err, "object could not be created")
-
-			// Now delete it
-			err = kv.kv.Delete(context.Background(), "key-to-delete")
-			require.NoError(t, err)
-
-			// Get it back
-			v, err := kv.kv.Get(context.Background(), "key-to-delete")
-			require.NoError(t, err, "unexpected error")
-			require.Nil(t, v, "object was not deleted")
+	for name, setupFn := range setupFns {
+		t.Run(name, func(t *testing.T) {
+			testKVScenario(t, setupFn, testFn)
 		})
 	}
+}
 
-	// Ensure the proper histogram metrics are reported
+func testKVScenario(t *testing.T, kvSetupFn func(t *testing.T, scenario *e2e.Scenario, reg prometheus.Registerer) kv.Client, testFn func(t *testing.T, client kv.Client, reg *prometheus.Registry)) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	reg := prometheus.NewRegistry()
+	client := kvSetupFn(t, s, reg)
+	testFn(t, client, reg)
+}
+
+func verifyClientMetrics(t *testing.T, reg *prometheus.Registry, sampleCounts map[string]uint64) {
 	metrics, err := reg.Gather()
 	require.NoError(t, err)
 
 	require.Len(t, metrics, 1)
 	require.Equal(t, "cortex_kv_request_duration_seconds", metrics[0].GetName())
 	require.Equal(t, dto.MetricType_HISTOGRAM, metrics[0].GetType())
-	require.Len(t, metrics[0].GetMetric(), 8)
 
 	getMetricOperation := func(labels []*dto.LabelPair) (string, error) {
 		for _, l := range labels {
@@ -124,12 +191,9 @@ func TestKV_List_Delete(t *testing.T) {
 
 	for _, metric := range metrics[0].GetMetric() {
 		op, err := getMetricOperation(metric.Label)
+
 		require.NoErrorf(t, err, "No operation label found in metric %v", metric.String())
-		if op == "CAS" {
-			require.Equal(t, uint64(4), metric.GetHistogram().GetSampleCount())
-		} else {
-			require.Equal(t, uint64(1), metric.GetHistogram().GetSampleCount())
-		}
+		assert.Equal(t, sampleCounts[op], metric.GetHistogram().GetSampleCount(), op)
 	}
 }
 
@@ -138,3 +202,17 @@ type stringCodec struct{}
 func (c stringCodec) Decode(bb []byte) (interface{}, error) { return string(bb), nil }
 func (c stringCodec) Encode(v interface{}) ([]byte, error)  { return []byte(v.(string)), nil }
 func (c stringCodec) CodecID() string                       { return "stringCodec" }
+
+type watcher struct {
+	values map[string][]interface{}
+}
+
+func (w *watcher) watch(ctx context.Context, wg *sync.WaitGroup, client kv.Client) {
+	defer wg.Done()
+
+	w.values = map[string][]interface{}{}
+	client.WatchPrefix(ctx, "", func(key string, value interface{}) bool {
+		w.values[key] = append(w.values[key], value)
+		return true
+	})
+}

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -179,7 +179,7 @@ func (t *Cortex) initDistributorService() (serv services.Service, err error) {
 	// ruler's dependency)
 	canJoinDistributorsRing := t.Cfg.isModuleEnabled(Distributor) || t.Cfg.isModuleEnabled(All)
 
-	t.Distributor, err = distributor.New(t.Cfg.Distributor, t.Cfg.IngesterClient, t.Overrides, t.Ring, canJoinDistributorsRing, prometheus.DefaultRegisterer)
+	t.Distributor, err = distributor.New(t.Cfg.Distributor, t.Cfg.IngesterClient, t.Overrides, t.Ring, canJoinDistributorsRing, prometheus.DefaultRegisterer, util_log.Logger)
 	if err != nil {
 		return
 	}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -389,7 +389,7 @@ func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica 
 
 	// At this point we know we have both HA labels, we should lookup
 	// the cluster/instance here to see if we want to accept this sample.
-	err := d.HATracker.checkReplica(ctx, userID, cluster, replica)
+	err := d.HATracker.checkReplica(ctx, userID, cluster, replica, time.Now())
 	// checkReplica should only have returned an error if there was a real error talking to Consul, or if the replica labels don't match.
 	if err != nil { // Don't accept the sample.
 		return false, err

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -219,13 +219,13 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 	replicationFactor.Set(float64(ingestersRing.ReplicationFactor()))
 	cfg.PoolConfig.RemoteTimeout = cfg.RemoteTimeout
 
-	clusterTracker, err := newClusterTracker(cfg.HATrackerConfig, limits, reg, log.Logger)
+	haTracker, err := newHATracker(cfg.HATrackerConfig, limits, reg, log.Logger)
 	if err != nil {
 		return nil, err
 	}
 
 	subservices := []services.Service(nil)
-	subservices = append(subservices, clusterTracker)
+	subservices = append(subservices, haTracker)
 
 	// Create the configured ingestion rate limit strategy (local or global). In case
 	// it's an internal dependency and can't join the distributors ring, we skip rate
@@ -255,7 +255,7 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 		distributorsRing:     distributorsRing,
 		limits:               limits,
 		ingestionRateLimiter: limiter.NewRateLimiter(ingestionRateStrategy, 10*time.Second),
-		HATracker:            clusterTracker,
+		HATracker:            haTracker,
 		activeUsers:          util.NewActiveUsers(),
 	}
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/chunkcompat"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	util_math "github.com/cortexproject/cortex/pkg/util/math"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/test"
@@ -524,7 +525,7 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 						KVStore:         kv.Config{Mock: mock},
 						UpdateTimeout:   100 * time.Millisecond,
 						FailoverTimeout: time.Second,
-					}, trackerLimits{maxClusters: 100}, nil)
+					}, trackerLimits{maxClusters: 100}, nil, util_log.Logger)
 					require.NoError(t, err)
 					require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
 					d.HATracker = r

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -533,7 +533,7 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 
 				userID, err := tenant.TenantID(ctx)
 				assert.NoError(t, err)
-				err = d.HATracker.checkReplica(ctx, userID, tc.cluster, tc.acceptedReplica)
+				err = d.HATracker.checkReplica(ctx, userID, tc.cluster, tc.acceptedReplica, time.Now())
 				assert.NoError(t, err)
 
 				request := makeWriteRequestHA(tc.samples, tc.testReplica, tc.cluster)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
@@ -38,7 +39,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/chunkcompat"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	util_math "github.com/cortexproject/cortex/pkg/util/math"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/test"
@@ -520,12 +520,12 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 				d := ds[0]
 
 				if tc.enableTracker {
-					r, err := newClusterTracker(HATrackerConfig{
+					r, err := newHATracker(HATrackerConfig{
 						EnableHATracker: true,
 						KVStore:         kv.Config{Mock: mock},
 						UpdateTimeout:   100 * time.Millisecond,
 						FailoverTimeout: time.Second,
-					}, trackerLimits{maxClusters: 100}, nil, util_log.Logger)
+					}, trackerLimits{maxClusters: 100}, nil, log.NewNopLogger())
 					require.NoError(t, err)
 					require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
 					d.HATracker = r

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -328,7 +328,7 @@ func TestDistributor_MetricsCleanup(t *testing.T) {
 		cortex_distributor_samples_in_total{user="userA"} 5
 `), metrics...))
 
-	cleanupMetricsForUser("userA")
+	cleanupMetricsForUser("userA", log.NewNopLogger())
 
 	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(`
 		# HELP cortex_distributor_deduped_samples_total The total number of deduplicated samples.
@@ -1305,7 +1305,7 @@ func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, *rin
 		overrides, err := validation.NewOverrides(*cfg.limits, nil)
 		require.NoError(t, err)
 
-		d, err := New(distributorCfg, clientConfig, overrides, ingestersRing, true, nil)
+		d, err := New(distributorCfg, clientConfig, overrides, ingestersRing, true, nil, log.NewNopLogger())
 		require.NoError(t, err)
 		require.NoError(t, services.StartAndAwaitRunning(context.Background(), d))
 

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -44,8 +44,6 @@ func checkReplicaTimestamp(t *testing.T, duration time.Duration, c *haTracker, u
 		r := c.elected[key]
 		c.electedLock.RUnlock()
 
-		// If the replica or the timestamp don't match, we save the error
-		// to return if the expected match is not found within the timeout period
 		if r.GetReplica() != replica {
 			return fmt.Errorf("replicas did not match: %s != %s", r.GetReplica(), replica)
 		}

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -21,7 +22,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/test"
 )
@@ -121,7 +121,7 @@ func TestWatchPrefixAssignment(t *testing.T) {
 		UpdateTimeout:          time.Millisecond,
 		UpdateTimeoutJitterMax: 0,
 		FailoverTimeout:        time.Millisecond * 2,
-	}, trackerLimits{maxClusters: 100}, nil, util_log.Logger)
+	}, trackerLimits{maxClusters: 100}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
@@ -146,7 +146,7 @@ func TestCheckReplicaOverwriteTimeout(t *testing.T) {
 		UpdateTimeout:          100 * time.Millisecond,
 		UpdateTimeoutJitterMax: 0,
 		FailoverTimeout:        time.Second,
-	}, trackerLimits{maxClusters: 100}, nil, util_log.Logger)
+	}, trackerLimits{maxClusters: 100}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
@@ -184,7 +184,7 @@ func TestCheckReplicaMultiCluster(t *testing.T) {
 		UpdateTimeout:          100 * time.Millisecond,
 		UpdateTimeoutJitterMax: 0,
 		FailoverTimeout:        time.Second,
-	}, trackerLimits{maxClusters: 100}, reg, util_log.Logger)
+	}, trackerLimits{maxClusters: 100}, reg, log.NewNopLogger())
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
@@ -234,7 +234,7 @@ func TestCheckReplicaMultiClusterTimeout(t *testing.T) {
 		UpdateTimeout:          100 * time.Millisecond,
 		UpdateTimeoutJitterMax: 0,
 		FailoverTimeout:        time.Second,
-	}, trackerLimits{maxClusters: 100}, reg, util_log.Logger)
+	}, trackerLimits{maxClusters: 100}, reg, log.NewNopLogger())
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
@@ -305,7 +305,7 @@ func TestCheckReplicaUpdateTimeout(t *testing.T) {
 		UpdateTimeout:          time.Second,
 		UpdateTimeoutJitterMax: 0,
 		FailoverTimeout:        time.Second,
-	}, trackerLimits{maxClusters: 100}, nil, util_log.Logger)
+	}, trackerLimits{maxClusters: 100}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
@@ -351,7 +351,7 @@ func TestCheckReplicaMultiUser(t *testing.T) {
 		UpdateTimeout:          100 * time.Millisecond,
 		UpdateTimeoutJitterMax: 0,
 		FailoverTimeout:        time.Second,
-	}, trackerLimits{maxClusters: 100}, nil, util_log.Logger)
+	}, trackerLimits{maxClusters: 100}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
@@ -428,7 +428,7 @@ func TestCheckReplicaUpdateTimeoutJitter(t *testing.T) {
 				UpdateTimeout:          testData.updateTimeout,
 				UpdateTimeoutJitterMax: 0,
 				FailoverTimeout:        time.Second,
-			}, trackerLimits{maxClusters: 100}, nil, util_log.Logger)
+			}, trackerLimits{maxClusters: 100}, nil, log.NewNopLogger())
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 			defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
@@ -526,7 +526,7 @@ func TestHAClustersLimit(t *testing.T) {
 		UpdateTimeout:          time.Second,
 		UpdateTimeoutJitterMax: 0,
 		FailoverTimeout:        time.Second,
-	}, limits, nil, util_log.Logger)
+	}, limits, nil, log.NewNopLogger())
 
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), t1))
@@ -597,7 +597,7 @@ func (l trackerLimits) MaxHAClusters(_ string) int {
 
 func TestHATracker_MetricsCleanup(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
-	tr, err := newHATracker(HATrackerConfig{EnableHATracker: false}, nil, reg, util_log.Logger)
+	tr, err := newHATracker(HATrackerConfig{EnableHATracker: false}, nil, reg, log.NewNopLogger())
 	require.NoError(t, err)
 
 	metrics := []string{


### PR DESCRIPTION
**What this PR does**: This PR does some small code "cleanup" in HA tracker (metrics as fields, logger), and tests (removes usage of `mtime`, uses `test.Poll`). In addition to that, there is new integration test which doesn't verify behaviour, only logs it -- it shows differences in WatchPrefix and Delete behaviour between Consul (existing keys are returned via WatchPrefix, Delete doesn't send "notification" to WatchPrefix) and etcd (existing keys are not returned via WatchPrefix, but Delete "sends" notification).

**Checklist**
- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
