### PR TITLE
Add S3 KMS support to blocks storage client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [CHANGE] Ingester: don't update internal "last updated" timestamp of TSDB if tenant only sends invalid samples. This affects how "idle" time is computed. #3727
 * [CHANGE] Require explicit flag `-<prefix>.tls-enabled` to enable TLS in GRPC clients. Previously it was enough to specify a TLS flag to enable TLS validation. #3156
-* [FEATURE] Adds support to S3 server side encryption using KMS. Deprecated `-<prefix>.s3.sse-encryption`, you should use the following CLI flags that have been added. #3651
+* [FEATURE] Adds support to S3 server side encryption using KMS. Deprecated `-<prefix>.s3.sse-encryption`, you should use the following CLI flags that have been added. #3651 #3810
   - `-<prefix>.s3.sse.type`
   - `-<prefix>.s3.sse.kms-key-id`
   - `-<prefix>.s3.sse.kms-encryption-context`

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -259,6 +259,20 @@ blocks_storage:
     # CLI flag: -blocks-storage.s3.signature-version
     [signature_version: <string> | default = "v4"]
 
+    sse:
+      # Enable AWS Server Side Encryption. Only SSE-S3 and SSE-KMS are supported
+      # CLI flag: -blocks-storage.s3.sse.type
+      [type: <string> | default = ""]
+
+      # KMS Key ID used to encrypt objects in S3
+      # CLI flag: -blocks-storage.s3.sse.kms-key-id
+      [kms_key_id: <string> | default = ""]
+
+      # KMS Encryption Context used for object encryption. It expects a JSON as
+      # a string.
+      # CLI flag: -blocks-storage.s3.sse.kms-encryption-context
+      [kms_encryption_context: <string> | default = ""]
+
     http:
       # The time an idle connection will remain idle before closing.
       # CLI flag: -blocks-storage.s3.http.idle-conn-timeout

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -268,8 +268,8 @@ blocks_storage:
       # CLI flag: -blocks-storage.s3.sse.kms-key-id
       [kms_key_id: <string> | default = ""]
 
-      # KMS Encryption Context used for object encryption. It expects a JSON as
-      # a string.
+      # KMS Encryption Context used for object encryption. It expects JSON
+      # formatted string.
       # CLI flag: -blocks-storage.s3.sse.kms-encryption-context
       [kms_encryption_context: <string> | default = ""]
 

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -306,6 +306,20 @@ blocks_storage:
     # CLI flag: -blocks-storage.s3.signature-version
     [signature_version: <string> | default = "v4"]
 
+    sse:
+      # Enable AWS Server Side Encryption. Only SSE-S3 and SSE-KMS are supported
+      # CLI flag: -blocks-storage.s3.sse.type
+      [type: <string> | default = ""]
+
+      # KMS Key ID used to encrypt objects in S3
+      # CLI flag: -blocks-storage.s3.sse.kms-key-id
+      [kms_key_id: <string> | default = ""]
+
+      # KMS Encryption Context used for object encryption. It expects a JSON as
+      # a string.
+      # CLI flag: -blocks-storage.s3.sse.kms-encryption-context
+      [kms_encryption_context: <string> | default = ""]
+
     http:
       # The time an idle connection will remain idle before closing.
       # CLI flag: -blocks-storage.s3.http.idle-conn-timeout

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -315,8 +315,8 @@ blocks_storage:
       # CLI flag: -blocks-storage.s3.sse.kms-key-id
       [kms_key_id: <string> | default = ""]
 
-      # KMS Encryption Context used for object encryption. It expects a JSON as
-      # a string.
+      # KMS Encryption Context used for object encryption. It expects JSON
+      # formatted string.
       # CLI flag: -blocks-storage.s3.sse.kms-encryption-context
       [kms_encryption_context: <string> | default = ""]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3840,6 +3840,20 @@ s3:
   # CLI flag: -blocks-storage.s3.signature-version
   [signature_version: <string> | default = "v4"]
 
+  sse:
+    # Enable AWS Server Side Encryption. Only SSE-S3 and SSE-KMS are supported
+    # CLI flag: -blocks-storage.s3.sse.type
+    [type: <string> | default = ""]
+
+    # KMS Key ID used to encrypt objects in S3
+    # CLI flag: -blocks-storage.s3.sse.kms-key-id
+    [kms_key_id: <string> | default = ""]
+
+    # KMS Encryption Context used for object encryption. It expects a JSON as a
+    # string.
+    # CLI flag: -blocks-storage.s3.sse.kms-encryption-context
+    [kms_encryption_context: <string> | default = ""]
+
   http:
     # The time an idle connection will remain idle before closing.
     # CLI flag: -blocks-storage.s3.http.idle-conn-timeout

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1312,8 +1312,8 @@ storage:
       # CLI flag: -ruler.storage.s3.sse.kms-key-id
       [kms_key_id: <string> | default = ""]
 
-      # KMS Encryption Context used for object encryption. It expects a JSON as
-      # a string.
+      # KMS Encryption Context used for object encryption. It expects JSON
+      # formatted string.
       # CLI flag: -ruler.storage.s3.sse.kms-encryption-context
       [kms_encryption_context: <string> | default = ""]
 
@@ -1801,8 +1801,8 @@ storage:
       # CLI flag: -alertmanager.storage.s3.sse.kms-key-id
       [kms_key_id: <string> | default = ""]
 
-      # KMS Encryption Context used for object encryption. It expects a JSON as
-      # a string.
+      # KMS Encryption Context used for object encryption. It expects JSON
+      # formatted string.
       # CLI flag: -alertmanager.storage.s3.sse.kms-encryption-context
       [kms_encryption_context: <string> | default = ""]
 
@@ -2333,8 +2333,8 @@ aws:
     # CLI flag: -s3.sse.kms-key-id
     [kms_key_id: <string> | default = ""]
 
-    # KMS Encryption Context used for object encryption. It expects a JSON as a
-    # string.
+    # KMS Encryption Context used for object encryption. It expects JSON
+    # formatted string.
     # CLI flag: -s3.sse.kms-encryption-context
     [kms_encryption_context: <string> | default = ""]
 
@@ -3849,8 +3849,8 @@ s3:
     # CLI flag: -blocks-storage.s3.sse.kms-key-id
     [kms_key_id: <string> | default = ""]
 
-    # KMS Encryption Context used for object encryption. It expects a JSON as a
-    # string.
+    # KMS Encryption Context used for object encryption. It expects JSON
+    # formatted string.
     # CLI flag: -blocks-storage.s3.sse.kms-encryption-context
     [kms_encryption_context: <string> | default = ""]
 

--- a/integration/s3_storage_client_test.go
+++ b/integration/s3_storage_client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cortexproject/cortex/integration/e2e"
 	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
 	s3 "github.com/cortexproject/cortex/pkg/chunk/aws"
+	cortex_s3 "github.com/cortexproject/cortex/pkg/storage/bucket/s3"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
 
@@ -84,7 +85,7 @@ func TestS3Client(t *testing.T) {
 				Insecure:         true,
 				AccessKeyID:      e2edb.MinioAccessKey,
 				SecretAccessKey:  e2edb.MinioSecretKey,
-				SSEConfig: s3.SSEConfig{
+				SSEConfig: cortex_s3.SSEConfig{
 					Type: "SSE-S3",
 				},
 			},

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaveworks/common/instrument"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
+	cortex_s3 "github.com/cortexproject/cortex/pkg/storage/bucket/s3"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
@@ -64,15 +65,15 @@ type S3Config struct {
 	S3ForcePathStyle bool
 
 	BucketNames      string
-	Endpoint         string     `yaml:"endpoint"`
-	Region           string     `yaml:"region"`
-	AccessKeyID      string     `yaml:"access_key_id"`
-	SecretAccessKey  string     `yaml:"secret_access_key"`
-	Insecure         bool       `yaml:"insecure"`
-	SSEEncryption    bool       `yaml:"sse_encryption"`
-	HTTPConfig       HTTPConfig `yaml:"http_config"`
-	SignatureVersion string     `yaml:"signature_version"`
-	SSEConfig        SSEConfig  `yaml:"sse"`
+	Endpoint         string              `yaml:"endpoint"`
+	Region           string              `yaml:"region"`
+	AccessKeyID      string              `yaml:"access_key_id"`
+	SecretAccessKey  string              `yaml:"secret_access_key"`
+	Insecure         bool                `yaml:"insecure"`
+	SSEEncryption    bool                `yaml:"sse_encryption"`
+	HTTPConfig       HTTPConfig          `yaml:"http_config"`
+	SignatureVersion string              `yaml:"signature_version"`
+	SSEConfig        cortex_s3.SSEConfig `yaml:"sse"`
 
 	Inject InjectRequestMiddleware `yaml:"-"`
 }
@@ -165,8 +166,8 @@ func buildSSEParsedConfig(cfg S3Config) (*SSEParsedConfig, error) {
 
 	// deprecated, but if used it assumes SSE-S3 type
 	if cfg.SSEEncryption {
-		return NewSSEParsedConfig(SSEConfig{
-			Type: SSES3,
+		return NewSSEParsedConfig(cortex_s3.SSEConfig{
+			Type: cortex_s3.SSES3,
 		})
 	}
 

--- a/pkg/chunk/aws/sse_config.go
+++ b/pkg/chunk/aws/sse_config.go
@@ -3,20 +3,15 @@ package aws
 import (
 	"encoding/base64"
 	"encoding/json"
-	"flag"
 
 	"github.com/pkg/errors"
+
+	cortex_s3 "github.com/cortexproject/cortex/pkg/storage/bucket/s3"
 )
 
 const (
-	// SSEKMS config type constant to configure S3 server side encryption using KMS
-	// https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
-	SSEKMS     = "SSE-KMS"
 	sseKMSType = "aws:kms"
-	// SSES3 config type constant to configure S3 server side encryption with AES-256
-	// https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html
-	SSES3     = "SSE-S3"
-	sseS3Type = "AES256"
+	sseS3Type  = "AES256"
 )
 
 // SSEParsedConfig configures server side encryption (SSE)
@@ -27,29 +22,14 @@ type SSEParsedConfig struct {
 	KMSEncryptionContext *string
 }
 
-// SSEConfig configures S3 server side encryption
-// struct that is going to receive user input (through config file or CLI)
-type SSEConfig struct {
-	Type                 string `yaml:"type"`
-	KMSKeyID             string `yaml:"kms_key_id"`
-	KMSEncryptionContext string `yaml:"kms_encryption_context"`
-}
-
-// RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
-func (cfg *SSEConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.StringVar(&cfg.Type, prefix+"type", "", "Enable AWS Server Side Encryption. Only SSE-S3 and SSE-KMS are supported")
-	f.StringVar(&cfg.KMSKeyID, prefix+"kms-key-id", "", "KMS Key ID used to encrypt objects in S3")
-	f.StringVar(&cfg.KMSEncryptionContext, prefix+"kms-encryption-context", "", "KMS Encryption Context used for object encryption. It expects a JSON as a string.")
-}
-
 // NewSSEParsedConfig creates a struct to configure server side encryption (SSE)
-func NewSSEParsedConfig(cfg SSEConfig) (*SSEParsedConfig, error) {
+func NewSSEParsedConfig(cfg cortex_s3.SSEConfig) (*SSEParsedConfig, error) {
 	switch cfg.Type {
-	case SSES3:
+	case cortex_s3.SSES3:
 		return &SSEParsedConfig{
 			ServerSideEncryption: sseS3Type,
 		}, nil
-	case SSEKMS:
+	case cortex_s3.SSEKMS:
 		if cfg.KMSKeyID == "" {
 			return nil, errors.New("KMS key id must be passed when SSE-KMS encryption is selected")
 		}

--- a/pkg/chunk/aws/sse_config_test.go
+++ b/pkg/chunk/aws/sse_config_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+
+	cortex_s3 "github.com/cortexproject/cortex/pkg/storage/bucket/s3"
 )
 
 func TestNewSSEParsedConfig(t *testing.T) {
@@ -15,14 +17,14 @@ func TestNewSSEParsedConfig(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		params      SSEConfig
+		params      cortex_s3.SSEConfig
 		expected    *SSEParsedConfig
 		expectedErr error
 	}{
 		{
 			name: "Test SSE encryption with SSES3 type",
-			params: SSEConfig{
-				Type: SSES3,
+			params: cortex_s3.SSEConfig{
+				Type: cortex_s3.SSES3,
 			},
 			expected: &SSEParsedConfig{
 				ServerSideEncryption: sseS3Type,
@@ -30,8 +32,8 @@ func TestNewSSEParsedConfig(t *testing.T) {
 		},
 		{
 			name: "Test SSE encryption with SSEKMS type without context",
-			params: SSEConfig{
-				Type:     SSEKMS,
+			params: cortex_s3.SSEConfig{
+				Type:     cortex_s3.SSEKMS,
 				KMSKeyID: kmsKeyID,
 			},
 			expected: &SSEParsedConfig{
@@ -41,8 +43,8 @@ func TestNewSSEParsedConfig(t *testing.T) {
 		},
 		{
 			name: "Test SSE encryption with SSEKMS type with context",
-			params: SSEConfig{
-				Type:                 SSEKMS,
+			params: cortex_s3.SSEConfig{
+				Type:                 cortex_s3.SSEKMS,
 				KMSKeyID:             kmsKeyID,
 				KMSEncryptionContext: kmsEncryptionContext,
 			},
@@ -54,23 +56,23 @@ func TestNewSSEParsedConfig(t *testing.T) {
 		},
 		{
 			name: "Test invalid SSE type",
-			params: SSEConfig{
+			params: cortex_s3.SSEConfig{
 				Type: "invalid",
 			},
 			expectedErr: errors.New("SSE type is empty or invalid"),
 		},
 		{
 			name: "Test SSE encryption with SSEKMS type without KMS Key ID",
-			params: SSEConfig{
-				Type:     SSEKMS,
+			params: cortex_s3.SSEConfig{
+				Type:     cortex_s3.SSEKMS,
 				KMSKeyID: "",
 			},
 			expectedErr: errors.New("KMS key id must be passed when SSE-KMS encryption is selected"),
 		},
 		{
 			name: "Test SSE with invalid KMS encryption context JSON",
-			params: SSEConfig{
-				Type:                 SSEKMS,
+			params: cortex_s3.SSEConfig{
+				Type:                 cortex_s3.SSEKMS,
 				KMSKeyID:             kmsKeyID,
 				KMSEncryptionContext: `INVALID_JSON`,
 			},

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -9,21 +9,37 @@ import (
 
 // NewBucketClient creates a new S3 bucket client
 func NewBucketClient(cfg Config, name string, logger log.Logger) (objstore.Bucket, error) {
-	return s3.NewBucketWithConfig(logger, newS3Config(cfg), name)
+	s3Cfg, err := newS3Config(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return s3.NewBucketWithConfig(logger, s3Cfg, name)
 }
 
 // NewBucketReaderClient creates a new S3 bucket client
 func NewBucketReaderClient(cfg Config, name string, logger log.Logger) (objstore.BucketReader, error) {
-	return s3.NewBucketWithConfig(logger, newS3Config(cfg), name)
+	s3Cfg, err := newS3Config(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return s3.NewBucketWithConfig(logger, s3Cfg, name)
 }
 
-func newS3Config(cfg Config) s3.Config {
+func newS3Config(cfg Config) (s3.Config, error) {
+	sseCfg, err := cfg.SSE.BuildThanosConfig()
+	if err != nil {
+		return s3.Config{}, err
+	}
+
 	return s3.Config{
 		Bucket:    cfg.BucketName,
 		Endpoint:  cfg.Endpoint,
 		AccessKey: cfg.AccessKeyID,
 		SecretKey: cfg.SecretAccessKey.Value,
 		Insecure:  cfg.Insecure,
+		SSEConfig: sseCfg,
 		HTTPConfig: s3.HTTPConfig{
 			IdleConnTimeout:       model.Duration(cfg.HTTP.IdleConnTimeout),
 			ResponseHeaderTimeout: model.Duration(cfg.HTTP.ResponseHeaderTimeout),
@@ -37,5 +53,5 @@ func newS3Config(cfg Config) s3.Config {
 		},
 		// Enforce signature version 2 if CLI flag is set
 		SignatureV2: cfg.SignatureVersion == SignatureVersionV2,
-	}
+	}, nil
 }

--- a/pkg/storage/bucket/s3/config.go
+++ b/pkg/storage/bucket/s3/config.go
@@ -160,12 +160,12 @@ func (cfg *SSEConfig) BuildThanosConfig() (s3.SSEConfig, error) {
 	}
 }
 
-func parseKMSEncryptionContext(data string) (decoded map[string]string, err error) {
+func parseKMSEncryptionContext(data string) (map[string]string, error) {
 	if data == "" {
 		return nil, nil
 	}
 
-	err = json.Unmarshal([]byte(data), &decoded)
-	err = errors.Wrap(err, "unable to parse KMS encryption context")
-	return
+	decoded := map[string]string{}
+	err := errors.Wrap(json.Unmarshal([]byte(data), &decoded), "unable to parse KMS encryption context")
+	return decoded, err
 }

--- a/pkg/storage/bucket/s3/config.go
+++ b/pkg/storage/bucket/s3/config.go
@@ -1,12 +1,15 @@
 package s3
 
 import (
-	"errors"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/objstore/s3"
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
@@ -15,11 +18,22 @@ import (
 const (
 	SignatureVersionV4 = "v4"
 	SignatureVersionV2 = "v2"
+
+	// SSEKMS config type constant to configure S3 server side encryption using KMS
+	// https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
+	SSEKMS = "SSE-KMS"
+
+	// SSES3 config type constant to configure S3 server side encryption with AES-256
+	// https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html
+	SSES3 = "SSE-S3"
 )
 
 var (
 	supportedSignatureVersions     = []string{SignatureVersionV4, SignatureVersionV2}
+	supportedSSETypes              = []string{SSEKMS, SSES3}
 	errUnsupportedSignatureVersion = errors.New("unsupported signature version")
+	errUnsupportedSSEType          = errors.New("unsupported S3 SSE type")
+	errInvalidSSEContext           = errors.New("invalid S3 SSE encryption context")
 )
 
 // HTTPConfig stores the http.Transport configuration for the s3 minio client.
@@ -58,6 +72,7 @@ type Config struct {
 	Insecure         bool           `yaml:"insecure"`
 	SignatureVersion string         `yaml:"signature_version"`
 
+	SSE  SSEConfig  `yaml:"sse"`
 	HTTP HTTPConfig `yaml:"http"`
 }
 
@@ -74,6 +89,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.Endpoint, prefix+"s3.endpoint", "", "The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.")
 	f.BoolVar(&cfg.Insecure, prefix+"s3.insecure", false, "If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.")
 	f.StringVar(&cfg.SignatureVersion, prefix+"s3.signature-version", SignatureVersionV4, fmt.Sprintf("The signature version to use for authenticating against S3. Supported values are: %s.", strings.Join(supportedSignatureVersions, ", ")))
+	cfg.SSE.RegisterFlagsWithPrefix(prefix+"s3.sse.", f)
 	cfg.HTTP.RegisterFlagsWithPrefix(prefix, f)
 }
 
@@ -82,5 +98,74 @@ func (cfg *Config) Validate() error {
 	if !util.StringsContain(supportedSignatureVersions, cfg.SignatureVersion) {
 		return errUnsupportedSignatureVersion
 	}
+
+	if err := cfg.SSE.Validate(); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// SSEConfig configures S3 server side encryption
+// struct that is going to receive user input (through config file or CLI)
+type SSEConfig struct {
+	Type                 string `yaml:"type"`
+	KMSKeyID             string `yaml:"kms_key_id"`
+	KMSEncryptionContext string `yaml:"kms_encryption_context"`
+}
+
+func (cfg *SSEConfig) RegisterFlags(f *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefix("", f)
+}
+
+// RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
+func (cfg *SSEConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.Type, prefix+"type", "", "Enable AWS Server Side Encryption. Only SSE-S3 and SSE-KMS are supported")
+	f.StringVar(&cfg.KMSKeyID, prefix+"kms-key-id", "", "KMS Key ID used to encrypt objects in S3")
+	f.StringVar(&cfg.KMSEncryptionContext, prefix+"kms-encryption-context", "", "KMS Encryption Context used for object encryption. It expects a JSON as a string.")
+}
+
+func (cfg *SSEConfig) Validate() error {
+	if cfg.Type != "" && !util.StringsContain(supportedSSETypes, cfg.Type) {
+		return errUnsupportedSSEType
+	}
+
+	if _, err := parseKMSEncryptionContext(cfg.KMSEncryptionContext); err != nil {
+		return errInvalidSSEContext
+	}
+
+	return nil
+}
+
+// BuildThanosConfig builds the SSE config expected by the Thanos client.
+func (cfg *SSEConfig) BuildThanosConfig() (s3.SSEConfig, error) {
+	switch cfg.Type {
+	case SSEKMS:
+		encryptionCtx, err := parseKMSEncryptionContext(cfg.KMSEncryptionContext)
+		if err != nil {
+			return s3.SSEConfig{}, err
+		}
+
+		return s3.SSEConfig{
+			Type:                 s3.SSEKMS,
+			KMSKeyID:             cfg.KMSKeyID,
+			KMSEncryptionContext: encryptionCtx,
+		}, nil
+	case SSES3:
+		return s3.SSEConfig{
+			Type: s3.SSES3,
+		}, nil
+	default:
+		return s3.SSEConfig{}, nil
+	}
+}
+
+func parseKMSEncryptionContext(data string) (decoded map[string]string, err error) {
+	if data == "" {
+		return nil, nil
+	}
+
+	err = json.Unmarshal([]byte(data), &decoded)
+	err = errors.Wrap(err, "unable to parse KMS encryption context")
+	return
 }

--- a/pkg/storage/bucket/s3/config.go
+++ b/pkg/storage/bucket/s3/config.go
@@ -122,7 +122,7 @@ func (cfg *SSEConfig) RegisterFlags(f *flag.FlagSet) {
 func (cfg *SSEConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.Type, prefix+"type", "", "Enable AWS Server Side Encryption. Only SSE-S3 and SSE-KMS are supported")
 	f.StringVar(&cfg.KMSKeyID, prefix+"kms-key-id", "", "KMS Key ID used to encrypt objects in S3")
-	f.StringVar(&cfg.KMSEncryptionContext, prefix+"kms-encryption-context", "", "KMS Encryption Context used for object encryption. It expects a JSON as a string.")
+	f.StringVar(&cfg.KMSEncryptionContext, prefix+"kms-encryption-context", "", "KMS Encryption Context used for object encryption. It expects JSON formatted string.")
 }
 
 func (cfg *SSEConfig) Validate() error {

--- a/pkg/storage/bucket/s3/config_test.go
+++ b/pkg/storage/bucket/s3/config_test.go
@@ -1,0 +1,69 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cortexproject/cortex/pkg/util/flagext"
+)
+
+func TestSSEConfig_Validate(t *testing.T) {
+	tests := map[string]struct {
+		setup    func() *SSEConfig
+		expected error
+	}{
+		"should pass with default config": {
+			setup: func() *SSEConfig {
+				cfg := &SSEConfig{}
+				flagext.DefaultValues(cfg)
+
+				return cfg
+			},
+		},
+		"should fail on invalid SSE type": {
+			setup: func() *SSEConfig {
+				return &SSEConfig{
+					Type: "unknown",
+				}
+			},
+			expected: errUnsupportedSSEType,
+		},
+		"should fail on invalid SSE KMS encryption context": {
+			setup: func() *SSEConfig {
+				return &SSEConfig{
+					Type:                 SSEKMS,
+					KMSEncryptionContext: "!{}!",
+				}
+			},
+			expected: errInvalidSSEContext,
+		},
+		"should pass on valid SSE KMS encryption context": {
+			setup: func() *SSEConfig {
+				return &SSEConfig{
+					Type:                 SSEKMS,
+					KMSEncryptionContext: `{"department": "10103.0"}`,
+				}
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, testData.expected, testData.setup().Validate())
+		})
+	}
+}
+
+func TestParseKMSEncryptionContext(t *testing.T) {
+	actual, err := parseKMSEncryptionContext("")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string(nil), actual)
+
+	expected := map[string]string{
+		"department": "10103.0",
+	}
+	actual, err = parseKMSEncryptionContext(`{"department": "10103.0"}`)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
**What this PR does**:
In the PR https://github.com/cortexproject/cortex/pull/3651 we've added S3 server-side encryption support for the chunks storage client. This PR adds the support (with same exact CLI flags / YAML config naming) to the blocks storage client too.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
