### PR TITLE
Handle the case of large step causing single pt extents

### DIFF
--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -479,8 +479,14 @@ func (s resultsCache) partition(req Request, extents []Extent) ([]Request, []Res
 		if extent.GetEnd() < start || extent.Start > req.GetEnd() {
 			continue
 		}
+
 		// If this extent is tiny, discard it: more efficient to do a few larger queries
-		if extent.End-extent.Start < s.minCacheExtent {
+
+		// However if the step is large enough, we would end up with a request with a single step
+		// inside the split query. For example, if the step size is more than 12h and the interval is 24h.
+		// When this happens, we set the start and end time of the split request to the same value.
+		// This means the extent's start and end time would be same, even if the timerange covers several hours.
+		if (req.GetStart() != req.GetEnd()) && (extent.End-extent.Start < s.minCacheExtent) {
 			continue
 		}
 

--- a/pkg/querier/queryrange/results_cache.go
+++ b/pkg/querier/queryrange/results_cache.go
@@ -482,7 +482,7 @@ func (s resultsCache) partition(req Request, extents []Extent) ([]Request, []Res
 
 		// If this extent is tiny, discard it: more efficient to do a few larger queries.
 
-		// However if the step is large enough, the split_query_by_interval middlware would generate a query with same start and end.
+		// However if the step is large enough, the split_query_by_interval middleware would generate a query with same start and end.
 		// For example, if the step size is more than 12h and the interval is 24h.
 		// This means the extent's start and end time would be same, even if the timerange covers several hours.
 		if (req.GetStart() != req.GetEnd()) && (extent.End-extent.Start < s.minCacheExtent) {

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -447,6 +447,20 @@ func TestPartition(t *testing.T) {
 				mkAPIResponse(100, 120, 10),
 			},
 		},
+		// Test when hit has a large step and only a single sample extent.
+		{
+			// If there is a only a single sample in the split interval, start and end will be the same.
+			input: &PrometheusRequest{
+				Start: 100,
+				End:   100,
+			},
+			prevCachedResponse: []Extent{
+				mkExtent(100, 100),
+			},
+			expectedCachedResponse: []Response{
+				mkAPIResponse(100, 105, 10),
+			},
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			s := resultsCache{

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -447,6 +447,22 @@ func TestPartition(t *testing.T) {
 				mkAPIResponse(100, 120, 10),
 			},
 		},
+		// Extent is outside the range and the request has a single step (same start and end).
+		{
+			input: &PrometheusRequest{
+				Start: 100,
+				End:   100,
+			},
+			prevCachedResponse: []Extent{
+				mkExtent(50, 90),
+			},
+			expectedRequests: []Request{
+				&PrometheusRequest{
+					Start: 100,
+					End:   100,
+				},
+			},
+		},
 		// Test when hit has a large step and only a single sample extent.
 		{
 			// If there is a only a single sample in the split interval, start and end will be the same.


### PR DESCRIPTION
We noticed that we were ignoring samples if the step is 24h and this
fixes it.