### PR TITLE
chore: remove global logger from the ruler package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,8 @@ lint:
 	faillint -paths "github.com/cortexproject/cortex/pkg/util/log.{Logger}" \
 		./pkg/ingester/... \
 		./pkg/flusher/... \
-		./pkg/querier/...
+		./pkg/querier/... \
+		./pkg/ruler/...
 
 	# Validate Kubernetes spec files. Requires:
 	# https://kubeval.instrumenta.dev

--- a/integration/chunks_storage_backends_test.go
+++ b/integration/chunks_storage_backends_test.go
@@ -246,7 +246,7 @@ func TestSwiftRuleStorage(t *testing.T) {
 	store, err := ruler.NewRuleStorage(ruler.RuleStoreConfig{
 		Type:  "swift",
 		Swift: swiftConfig(swift),
-	}, nil)
+	}, nil, log.NewNopLogger())
 	require.NoError(t, err)
 	ctx := context.Background()
 

--- a/pkg/chunk/purger/tenant_deletion_api_test.go
+++ b/pkg/chunk/purger/tenant_deletion_api_test.go
@@ -182,7 +182,7 @@ func verifyExpectedDeletedRuleGroupsForUser(t *testing.T, api *TenantDeletionAPI
 
 func setupRuleGroupsStore(t *testing.T, ruleGroups []ruleGroupKey) (*chunk.MockStorage, rules.RuleStore) {
 	obj := chunk.NewMockStorage()
-	rs := objectclient.NewRuleStore(obj, 5)
+	rs := objectclient.NewRuleStore(obj, 5, log.NewNopLogger())
 
 	// "upload" rule groups
 	for _, key := range ruleGroups {

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -646,11 +646,10 @@ func (t *Cortex) initRulerStorage() (serv services.Service, err error) {
 	}
 
 	if !t.Cfg.Ruler.StoreConfig.IsDefaults() {
-		t.RulerStorage, err = ruler.NewRuleStorage(t.Cfg.Ruler.StoreConfig, rules.FileLoader{})
+		t.RulerStorage, err = ruler.NewRuleStorage(t.Cfg.Ruler.StoreConfig, rules.FileLoader{}, util_log.Logger)
 	} else {
 		t.RulerStorage, err = rulestore.NewRuleStore(context.Background(), t.Cfg.RulerStorage, t.Overrides, util_log.Logger, prometheus.DefaultRegisterer)
 	}
-
 	return
 }
 
@@ -688,7 +687,7 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 
 	// If the API is enabled, register the Ruler API
 	if t.Cfg.Ruler.EnableAPI {
-		t.API.RegisterRulerAPI(ruler.NewAPI(t.Ruler, t.RulerStorage))
+		t.API.RegisterRulerAPI(ruler.NewAPI(t.Ruler, t.RulerStorage, util_log.Logger))
 	}
 
 	return t.Ruler, nil

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -123,18 +123,21 @@ func respondError(logger log.Logger, w http.ResponseWriter, msg string) {
 type API struct {
 	ruler *Ruler
 	store rules.RuleStore
+
+	logger log.Logger
 }
 
 // NewAPI returns a new API struct with the provided ruler and rule store
-func NewAPI(r *Ruler, s rules.RuleStore) *API {
+func NewAPI(r *Ruler, s rules.RuleStore, logger log.Logger) *API {
 	return &API{
-		ruler: r,
-		store: s,
+		ruler:  r,
+		store:  s,
+		logger: logger,
 	}
 }
 
 func (a *API) PrometheusRules(w http.ResponseWriter, req *http.Request) {
-	logger := util_log.WithContext(req.Context(), util_log.Logger)
+	logger := util_log.WithContext(req.Context(), a.logger)
 	userID, err := tenant.TenantID(req.Context())
 	if err != nil || userID == "" {
 		level.Error(logger).Log("msg", "error extracting org id from context", "err", err)
@@ -226,7 +229,7 @@ func (a *API) PrometheusRules(w http.ResponseWriter, req *http.Request) {
 }
 
 func (a *API) PrometheusAlerts(w http.ResponseWriter, req *http.Request) {
-	logger := util_log.WithContext(req.Context(), util_log.Logger)
+	logger := util_log.WithContext(req.Context(), a.logger)
 	userID, err := tenant.TenantID(req.Context())
 	if err != nil || userID == "" {
 		level.Error(logger).Log("msg", "error extracting org id from context", "err", err)
@@ -381,7 +384,7 @@ func parseRequest(req *http.Request, requireNamespace, requireGroup bool) (strin
 }
 
 func (a *API) ListRules(w http.ResponseWriter, req *http.Request) {
-	logger := util_log.WithContext(req.Context(), util_log.Logger)
+	logger := util_log.WithContext(req.Context(), a.logger)
 
 	userID, namespace, _, err := parseRequest(req, false, false)
 	if err != nil {
@@ -415,7 +418,7 @@ func (a *API) ListRules(w http.ResponseWriter, req *http.Request) {
 }
 
 func (a *API) GetRuleGroup(w http.ResponseWriter, req *http.Request) {
-	logger := util_log.WithContext(req.Context(), util_log.Logger)
+	logger := util_log.WithContext(req.Context(), a.logger)
 	userID, namespace, groupName, err := parseRequest(req, true, true)
 	if err != nil {
 		respondError(logger, w, err.Error())
@@ -437,7 +440,7 @@ func (a *API) GetRuleGroup(w http.ResponseWriter, req *http.Request) {
 }
 
 func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
-	logger := util_log.WithContext(req.Context(), util_log.Logger)
+	logger := util_log.WithContext(req.Context(), a.logger)
 	userID, namespace, _, err := parseRequest(req, true, false)
 	if err != nil {
 		respondError(logger, w, err.Error())
@@ -506,7 +509,7 @@ func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 }
 
 func (a *API) DeleteNamespace(w http.ResponseWriter, req *http.Request) {
-	logger := util_log.WithContext(req.Context(), util_log.Logger)
+	logger := util_log.WithContext(req.Context(), a.logger)
 
 	userID, namespace, _, err := parseRequest(req, true, false)
 	if err != nil {
@@ -528,7 +531,7 @@ func (a *API) DeleteNamespace(w http.ResponseWriter, req *http.Request) {
 }
 
 func (a *API) DeleteRuleGroup(w http.ResponseWriter, req *http.Request) {
-	logger := util_log.WithContext(req.Context(), util_log.Logger)
+	logger := util_log.WithContext(req.Context(), a.logger)
 
 	userID, namespace, groupName, err := parseRequest(req, true, true)
 	if err != nil {

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-kit/kit/log"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/user"
@@ -27,7 +28,7 @@ func TestRuler_rules(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	a := NewAPI(r, r.store)
+	a := NewAPI(r, r.store, log.NewNopLogger())
 
 	req := requestFor(t, "GET", "https://localhost:8080/api/prom/api/v1/rules", nil, "user1")
 	w := httptest.NewRecorder()
@@ -84,7 +85,7 @@ func TestRuler_rules_special_characters(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	a := NewAPI(r, r.store)
+	a := NewAPI(r, r.store, log.NewNopLogger())
 
 	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/prom/api/v1/rules", nil, "user1")
 	w := httptest.NewRecorder()
@@ -141,7 +142,7 @@ func TestRuler_alerts(t *testing.T) {
 	defer rcleanup()
 	defer r.StopAsync()
 
-	a := NewAPI(r, r.store)
+	a := NewAPI(r, r.store, log.NewNopLogger())
 
 	req := requestFor(t, http.MethodGet, "https://localhost:8080/api/prom/api/v1/alerts", nil, "user1")
 	w := httptest.NewRecorder()
@@ -177,7 +178,7 @@ func TestRuler_Create(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	a := NewAPI(r, r.store)
+	a := NewAPI(r, r.store, log.NewNopLogger())
 
 	tc := []struct {
 		name   string
@@ -268,7 +269,7 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 	defer rcleanup()
 	defer services.StopAndAwaitTerminated(context.Background(), r) //nolint:errcheck
 
-	a := NewAPI(r, r.store)
+	a := NewAPI(r, r.store, log.NewNopLogger())
 
 	router := mux.NewRouter()
 	router.Path("/api/v1/rules/{namespace}").Methods(http.MethodDelete).HandlerFunc(a.DeleteNamespace)
@@ -309,7 +310,7 @@ func TestRuler_Limits(t *testing.T) {
 
 	r.limits = &ruleLimits{maxRuleGroups: 1, maxRulesPerRuleGroup: 1}
 
-	a := NewAPI(r, r.store)
+	a := NewAPI(r, r.store, log.NewNopLogger())
 
 	tc := []struct {
 		name   string

--- a/pkg/ruler/ruler_ring.go
+++ b/pkg/ruler/ruler_ring.go
@@ -6,12 +6,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-kit/kit/log/level"
-
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/ring/kv"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 const (
@@ -54,8 +51,7 @@ type RingConfig struct {
 func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		level.Error(util_log.Logger).Log("msg", "failed to get hostname", "err", err)
-		os.Exit(1)
+		panic(fmt.Errorf("failed to get hostname, %w", err))
 	}
 
 	// Ring flags

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -93,7 +92,7 @@ func testSetup(t *testing.T, cfg Config) (*promql.Engine, storage.QueryableFunc,
 		os.RemoveAll(dir)
 	}
 
-	tracker := promql.NewActiveQueryTracker(dir, 20, util_log.Logger)
+	tracker := promql.NewActiveQueryTracker(dir, 20, log.NewNopLogger())
 
 	engine := promql.NewEngine(promql.EngineOpts{
 		MaxSamples:         1e6,
@@ -125,12 +124,12 @@ func newManager(t *testing.T, cfg Config) (*DefaultMultiTenantManager, func()) {
 
 func newRuler(t *testing.T, cfg Config) (*Ruler, func()) {
 	engine, noopQueryable, pusher, logger, overrides, cleanup := testSetup(t, cfg)
-	storage, err := NewRuleStorage(cfg.StoreConfig, promRules.FileLoader{})
+	storage, err := NewRuleStorage(cfg.StoreConfig, promRules.FileLoader{}, log.NewNopLogger())
 	require.NoError(t, err)
 
 	reg := prometheus.NewRegistry()
 	managerFactory := DefaultTenantManagerFactory(cfg, pusher, noopQueryable, engine, overrides)
-	manager, err := NewDefaultMultiTenantManager(cfg, managerFactory, reg, util_log.Logger)
+	manager, err := NewDefaultMultiTenantManager(cfg, managerFactory, reg, log.NewNopLogger())
 	require.NoError(t, err)
 
 	ruler, err := NewRuler(

--- a/pkg/ruler/rules/objectclient/rule_store_test.go
+++ b/pkg/ruler/rules/objectclient/rule_store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ type testGroup struct {
 
 func TestListRules(t *testing.T) {
 	obj := chunk.NewMockStorage()
-	rs := NewRuleStore(obj, 5)
+	rs := NewRuleStore(obj, 5, log.NewNopLogger())
 
 	groups := []testGroup{
 		{user: "user1", namespace: "hello", ruleGroup: rulefmt.RuleGroup{Name: "first testGroup"}},
@@ -91,7 +92,7 @@ func TestListRules(t *testing.T) {
 
 func TestLoadRules(t *testing.T) {
 	obj := chunk.NewMockStorage()
-	rs := NewRuleStore(obj, 5)
+	rs := NewRuleStore(obj, 5, log.NewNopLogger())
 
 	groups := []testGroup{
 		{user: "user1", namespace: "hello", ruleGroup: rulefmt.RuleGroup{Name: "first testGroup", Interval: model.Duration(time.Minute), Rules: []rulefmt.RuleNode{{

--- a/pkg/ruler/rules/objectclient/rule_store_test.go
+++ b/pkg/ruler/rules/objectclient/rule_store_test.go
@@ -160,7 +160,7 @@ func TestLoadRules(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	obj := chunk.NewMockStorage()
-	rs := NewRuleStore(obj, 5)
+	rs := NewRuleStore(obj, 5, log.NewNopLogger())
 
 	groups := []testGroup{
 		{user: "user1", namespace: "A", ruleGroup: rulefmt.RuleGroup{Name: "1"}},


### PR DESCRIPTION
**What this PR does**:

- Removes the global logger from the ruler package
- Adds a faillint rule for usage of the global logger in the ruler package

**Which issue(s) this PR fixes**:
Slowly working to complete #3779 
