### PR TITLE
chore: remove global logger from the querier package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,8 @@ lint:
 	# Ensure packages that no longer use a global logger don't reintroduce it
 	faillint -paths "github.com/cortexproject/cortex/pkg/util/log.{Logger}" \
 		./pkg/ingester/... \
-		./pkg/flusher/...
+		./pkg/flusher/... \
+		./pkg/querier/...
 
 	# Validate Kubernetes spec files. Requires:
 	# https://kubeval.instrumenta.dev

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -141,7 +141,7 @@ func main() {
 
 	util_log.InitLogger(&cfg.Server)
 
-	Set the Go standard library logger to use the same logger as Cortex
+	//	Set the Go standard library logger to use the same logger as Cortex
 	stdlog.SetOutput(log.NewStdlibAdapter(util_log.Logger))
 
 	// Allocate a block of memory to alter GC behaviour. See https://github.com/golang/go/issues/23044

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	stdlog "log"
 	"math/rand"
 	"os"
 	"runtime"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -138,6 +140,9 @@ func main() {
 	}
 
 	util_log.InitLogger(&cfg.Server)
+
+	Set the Go standard library logger to use the same logger as Cortex
+	stdlog.SetOutput(log.NewStdlibAdapter(util_log.Logger))
 
 	// Allocate a block of memory to alter GC behaviour. See https://github.com/golang/go/issues/23044
 	ballast := make([]byte, ballastBytes)

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -141,7 +141,7 @@ func main() {
 
 	util_log.InitLogger(&cfg.Server)
 
-	//	Set the Go standard library logger to use the same logger as Cortex
+	// Set the Go standard library logger to use the same logger as Cortex.
 	stdlog.SetOutput(log.NewStdlibAdapter(util_log.Logger))
 
 	// Allocate a block of memory to alter GC behaviour. See https://github.com/golang/go/issues/23044

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	stdlog "log"
 	"math/rand"
 	"os"
 	"runtime"
@@ -13,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -140,9 +138,6 @@ func main() {
 	}
 
 	util_log.InitLogger(&cfg.Server)
-
-	// Set the Go standard library logger to use the same logger as Cortex.
-	stdlog.SetOutput(log.NewStdlibAdapter(util_log.Logger))
 
 	// Allocate a block of memory to alter GC behaviour. See https://github.com/golang/go/issues/23044
 	ballast := make([]byte, ballastBytes)

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -238,7 +238,7 @@ func NewQuerierHandler(
 	// TODO(gotjosh): This custom handler is temporary until we're able to vendor the changes in:
 	// https://github.com/prometheus/prometheus/pull/7125/files
 	router.Path(prefix + "/api/v1/metadata").Handler(querier.MetadataHandler(distributor))
-	router.Path(prefix + "/api/v1/read").Handler(querier.RemoteReadHandler(queryable))
+	router.Path(prefix + "/api/v1/read").Handler(querier.RemoteReadHandler(queryable, logger))
 	router.Path(prefix + "/api/v1/read").Methods("POST").Handler(promRouter)
 	router.Path(prefix+"/api/v1/query").Methods("GET", "POST").Handler(promRouter)
 	router.Path(prefix+"/api/v1/query_range").Methods("GET", "POST").Handler(promRouter)
@@ -250,7 +250,7 @@ func NewQuerierHandler(
 	// TODO(gotjosh): This custom handler is temporary until we're able to vendor the changes in:
 	// https://github.com/prometheus/prometheus/pull/7125/files
 	router.Path(legacyPrefix + "/api/v1/metadata").Handler(querier.MetadataHandler(distributor))
-	router.Path(legacyPrefix + "/api/v1/read").Handler(querier.RemoteReadHandler(queryable))
+	router.Path(legacyPrefix + "/api/v1/read").Handler(querier.RemoteReadHandler(queryable, logger))
 	router.Path(legacyPrefix + "/api/v1/read").Methods("POST").Handler(legacyPromRouter)
 	router.Path(legacyPrefix+"/api/v1/query").Methods("GET", "POST").Handler(legacyPromRouter)
 	router.Path(legacyPrefix+"/api/v1/query_range").Methods("GET", "POST").Handler(legacyPromRouter)

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -217,7 +217,7 @@ func (t *Cortex) initQueryable() (serv services.Service, err error) {
 	querierRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "querier"}, prometheus.DefaultRegisterer)
 
 	// Create a querier queryable and PromQL engine
-	t.QuerierQueryable, t.QuerierEngine = querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, t.TombstonesLoader, querierRegisterer)
+	t.QuerierQueryable, t.QuerierEngine = querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, t.TombstonesLoader, querierRegisterer, util_log.Logger)
 
 	// Register the default endpoints that are always enabled for the querier module
 	t.API.RegisterQueryable(t.QuerierQueryable, t.Distributor)
@@ -652,7 +652,8 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 
 	t.Cfg.Ruler.Ring.ListenPort = t.Cfg.Server.GRPCListenPort
 	rulerRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "ruler"}, prometheus.DefaultRegisterer)
-	queryable, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, t.TombstonesLoader, rulerRegisterer)
+	// TODO: Consider wrapping logger to differentiate from querier module logger
+	queryable, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, t.TombstonesLoader, rulerRegisterer, util_log.Logger)
 
 	managerFactory := ruler.DefaultTenantManagerFactory(t.Cfg.Ruler, t.Distributor, queryable, engine, t.Overrides)
 	manager, err := ruler.NewDefaultMultiTenantManager(t.Cfg.Ruler, managerFactory, prometheus.DefaultRegisterer, util_log.Logger)

--- a/pkg/querier/astmapper/parallel.go
+++ b/pkg/querier/astmapper/parallel.go
@@ -1,9 +1,12 @@
 package astmapper
 
 import (
-	"log"
+	"fmt"
 
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/prometheus/promql/parser"
+
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 var summableAggregates = map[parser.ItemType]struct{}{
@@ -87,7 +90,7 @@ func CanParallelize(node parser.Node) bool {
 		return true
 
 	default:
-		log.Printf("err=\"CanParallel: unhandled node type %T\"", node)
+		level.Error(util_log.Logger).Log("err", fmt.Sprintf("CanParallel: unhandled node type %T", node)) //lint:ignore faillint allow global logger for now
 		return false
 	}
 

--- a/pkg/querier/astmapper/parallel.go
+++ b/pkg/querier/astmapper/parallel.go
@@ -1,12 +1,7 @@
 package astmapper
 
 import (
-	"fmt"
-
-	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/prometheus/promql/parser"
-
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 var summableAggregates = map[parser.ItemType]struct{}{
@@ -90,7 +85,9 @@ func CanParallelize(node parser.Node) bool {
 		return true
 
 	default:
-		level.Error(util_log.Logger).Log("err", fmt.Sprintf("CanParallel: unhandled node type %T", node))
+		// Should never occur, unknown types will return errors when parsed. However, the best course of
+		// action is to return false. AST type errors from the expression will be returned the next time in
+		// the request lifecylce that it is parsed.
 		return false
 	}
 

--- a/pkg/querier/astmapper/parallel.go
+++ b/pkg/querier/astmapper/parallel.go
@@ -1,6 +1,8 @@
 package astmapper
 
 import (
+	"log"
+
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
@@ -85,9 +87,7 @@ func CanParallelize(node parser.Node) bool {
 		return true
 
 	default:
-		// Should never occur, unknown types will return errors when parsed. However, the best course of
-		// action is to return false. AST type errors from the expression will be returned the next time in
-		// the request lifecylce that it is parsed.
+		log.Printf("err=\"CanParallel: unhandled node type %T\"", node)
 		return false
 	}
 

--- a/pkg/querier/chunk_tar_test.go
+++ b/pkg/querier/chunk_tar_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/querier/batch"
 	"github.com/cortexproject/cortex/pkg/querier/chunkstore"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 func getTarDataFromEnv(t testing.TB) (query string, from, through time.Time, step time.Duration, store chunkstore.ChunkStore) {
@@ -55,14 +55,14 @@ func runRangeQuery(t testing.TB, query string, from, through time.Time, step tim
 	dir, err := ioutil.TempDir("", t.Name())
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
-	queryTracker := promql.NewActiveQueryTracker(dir, 1, util_log.Logger)
+	queryTracker := promql.NewActiveQueryTracker(dir, 1, log.NewNopLogger())
 
 	if len(query) == 0 || store == nil {
 		return
 	}
 	queryable := newChunkStoreQueryable(store, batch.NewChunkMergeIterator)
 	engine := promql.NewEngine(promql.EngineOpts{
-		Logger:             util_log.Logger,
+		Logger:             log.NewNopLogger(),
 		ActiveQueryTracker: queryTracker,
 		MaxSamples:         math.MaxInt32,
 		Timeout:            10 * time.Minute,

--- a/pkg/querier/duplicates_test.go
+++ b/pkg/querier/duplicates_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -13,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 func TestDuplicatesSamples(t *testing.T) {
@@ -88,7 +88,7 @@ func runPromQLAndGetJSONResult(t *testing.T, query string, ts client.TimeSeries,
 	tq := &testQueryable{ts: newTimeSeriesSeriesSet([]client.TimeSeries{ts})}
 
 	engine := promql.NewEngine(promql.EngineOpts{
-		Logger:     util_log.Logger,
+		Logger:     log.NewNopLogger(),
 		Timeout:    10 * time.Second,
 		MaxSamples: 1e6,
 	})

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -28,7 +29,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
@@ -167,7 +167,7 @@ func New(cfg Config, limits *validation.Overrides, distributor Distributor, stor
 	})
 
 	engine := promql.NewEngine(promql.EngineOpts{
-		Logger:             util_log.Logger,
+		Logger:             log.NewNopLogger(),
 		Reg:                reg,
 		ActiveQueryTracker: createActiveQueryTracker(cfg),
 		MaxSamples:         cfg.MaxSamples,
@@ -199,7 +199,7 @@ func createActiveQueryTracker(cfg Config) *promql.ActiveQueryTracker {
 	dir := cfg.ActiveQueryTrackerDir
 
 	if dir != "" {
-		return promql.NewActiveQueryTracker(dir, cfg.MaxConcurrent, util_log.Logger)
+		return promql.NewActiveQueryTracker(dir, cfg.MaxConcurrent, log.NewNopLogger())
 	}
 
 	return nil

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/cortexproject/cortex/pkg/chunk/purger"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 
 	"github.com/prometheus/common/model"
@@ -260,10 +260,10 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 	dir, err := ioutil.TempDir("", t.Name())
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
-	queryTracker := promql.NewActiveQueryTracker(dir, 10, util_log.Logger)
+	queryTracker := promql.NewActiveQueryTracker(dir, 10, log.NewNopLogger())
 
 	engine := promql.NewEngine(promql.EngineOpts{
-		Logger:             util_log.Logger,
+		Logger:             log.NewNopLogger(),
 		ActiveQueryTracker: queryTracker,
 		MaxSamples:         1e6,
 		Timeout:            1 * time.Minute,
@@ -345,7 +345,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryIntoFuture(t *testing.T) {
 	}
 
 	engine := promql.NewEngine(promql.EngineOpts{
-		Logger:        util_log.Logger,
+		Logger:        log.NewNopLogger(),
 		MaxSamples:    1e6,
 		Timeout:       1 * time.Minute,
 		LookbackDelta: engineLookbackDelta,
@@ -449,7 +449,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 
 			// Create the PromQL engine to execute the query.
 			engine := promql.NewEngine(promql.EngineOpts{
-				Logger:             util_log.Logger,
+				Logger:             log.NewNopLogger(),
 				ActiveQueryTracker: nil,
 				MaxSamples:         1e6,
 				Timeout:            1 * time.Minute,
@@ -541,7 +541,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 
 	// Create the PromQL engine to execute the queries.
 	engine := promql.NewEngine(promql.EngineOpts{
-		Logger:             util_log.Logger,
+		Logger:             log.NewNopLogger(),
 		ActiveQueryTracker: nil,
 		MaxSamples:         1e6,
 		LookbackDelta:      engineLookbackDelta,
@@ -702,11 +702,11 @@ func testRangeQuery(t testing.TB, queryable storage.Queryable, end model.Time, q
 	dir, err := ioutil.TempDir("", "test_query")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
-	queryTracker := promql.NewActiveQueryTracker(dir, 10, util_log.Logger)
+	queryTracker := promql.NewActiveQueryTracker(dir, 10, log.NewNopLogger())
 
 	from, through, step := time.Unix(0, 0), end.Time(), q.step
 	engine := promql.NewEngine(promql.EngineOpts{
-		Logger:             util_log.Logger,
+		Logger:             log.NewNopLogger(),
 		ActiveQueryTracker: queryTracker,
 		MaxSamples:         1e6,
 		Timeout:            1 * time.Minute,
@@ -842,10 +842,10 @@ func TestShortTermQueryToLTS(t *testing.T) {
 	dir, err := ioutil.TempDir("", t.Name())
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
-	queryTracker := promql.NewActiveQueryTracker(dir, 10, util_log.Logger)
+	queryTracker := promql.NewActiveQueryTracker(dir, 10, log.NewNopLogger())
 
 	engine := promql.NewEngine(promql.EngineOpts{
-		Logger:             util_log.Logger,
+		Logger:             log.NewNopLogger(),
 		ActiveQueryTracker: queryTracker,
 		MaxSamples:         1e6,
 		Timeout:            1 * time.Minute,

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -159,7 +159,7 @@ func TestQuerier(t *testing.T) {
 						require.NoError(t, err)
 
 						queryables := []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore)), UseAlwaysQueryable(db)}
-						queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+						queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil, log.NewNopLogger())
 						testRangeQuery(t, queryable, through, query)
 					})
 				}
@@ -280,7 +280,7 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 				overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
 				require.NoError(t, err)
 
-				queryable, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}, purger.NewTombstonesLoader(nil, nil), nil)
+				queryable, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}, purger.NewTombstonesLoader(nil, nil), nil, log.NewNopLogger())
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 
@@ -369,7 +369,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryIntoFuture(t *testing.T) {
 				require.NoError(t, err)
 
 				queryables := []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}
-				queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+				queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil, log.NewNopLogger())
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.queryStartTime, c.queryEndTime, time.Minute)
 				require.NoError(t, err)
 
@@ -445,7 +445,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 			distributor := &emptyDistributor{}
 
 			queryables := []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}
-			queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+			queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil, log.NewNopLogger())
 
 			// Create the PromQL engine to execute the query.
 			engine := promql.NewEngine(promql.EngineOpts{
@@ -571,7 +571,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 					distributor.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Matrix{}, nil)
 					distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&client.QueryStreamResponse{}, nil)
 
-					queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+					queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil, log.NewNopLogger())
 					require.NoError(t, err)
 
 					query, err := engine.NewRangeQuery(queryable, testData.query, testData.queryStartTime, testData.queryEndTime, time.Minute)
@@ -599,7 +599,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 					distributor := &mockDistributor{}
 					distributor.On("MetricsForLabelMatchers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]metric.Metric{}, nil)
 
-					queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+					queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil, log.NewNopLogger())
 					q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
 					require.NoError(t, err)
 
@@ -631,7 +631,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 					distributor := &mockDistributor{}
 					distributor.On("LabelNames", mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
 
-					queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+					queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil, log.NewNopLogger())
 					q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
 					require.NoError(t, err)
 
@@ -655,7 +655,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 					distributor := &mockDistributor{}
 					distributor.On("LabelValuesForLabelName", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
 
-					queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil)
+					queryable, _ := New(cfg, overrides, distributor, queryables, purger.NewTombstonesLoader(nil, nil), nil, log.NewNopLogger())
 					q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
 					require.NoError(t, err)
 
@@ -866,7 +866,7 @@ func TestShortTermQueryToLTS(t *testing.T) {
 				overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
 				require.NoError(t, err)
 
-				queryable, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}, purger.NewTombstonesLoader(nil, nil), nil)
+				queryable, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewChunkStoreQueryable(cfg, chunkStore))}, purger.NewTombstonesLoader(nil, nil), nil, log.NewNopLogger())
 				query, err := engine.NewRangeQuery(queryable, "dummy", c.mint, c.maxt, 1*time.Minute)
 				require.NoError(t, err)
 

--- a/pkg/querier/queryrange/promql_test.go
+++ b/pkg/querier/queryrange/promql_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -16,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/querier/astmapper"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 var (
@@ -26,7 +26,7 @@ var (
 	ctx    = context.Background()
 	engine = promql.NewEngine(promql.EngineOpts{
 		Reg:                prometheus.DefaultRegisterer,
-		Logger:             util_log.Logger,
+		Logger:             log.NewNopLogger(),
 		Timeout:            1 * time.Hour,
 		MaxSamples:         10e6,
 		ActiveQueryTracker: nil,

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/util"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 func TestQueryshardingMiddleware(t *testing.T) {
@@ -77,7 +76,7 @@ func TestQueryshardingMiddleware(t *testing.T) {
 	for _, c := range testExpr {
 		t.Run(c.name, func(t *testing.T) {
 			engine := promql.NewEngine(promql.EngineOpts{
-				Logger:     util_log.Logger,
+				Logger:     log.NewNopLogger(),
 				Reg:        nil,
 				MaxSamples: 1000,
 				Timeout:    time.Minute,
@@ -552,7 +551,7 @@ func BenchmarkQuerySharding(b *testing.B) {
 			time.Millisecond / 10,
 		} {
 			engine := promql.NewEngine(promql.EngineOpts{
-				Logger:     util_log.Logger,
+				Logger:     log.NewNopLogger(),
 				Reg:        nil,
 				MaxSamples: 100000000,
 				Timeout:    time.Minute,

--- a/pkg/querier/queryrange/results_cache_test.go
+++ b/pkg/querier/queryrange/results_cache_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 const (
@@ -106,7 +105,7 @@ func mkExtent(start, end int64) Extent {
 
 func TestShouldCache(t *testing.T) {
 	maxCacheTime := int64(150 * 1000)
-	c := &resultsCache{logger: util_log.Logger, cacheGenNumberLoader: newMockCacheGenNumberLoader()}
+	c := &resultsCache{logger: log.NewNopLogger(), cacheGenNumberLoader: newMockCacheGenNumberLoader()}
 	for _, tc := range []struct {
 		name                   string
 		request                Request

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/chunk"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 func TestRoundTrip(t *testing.T) {
@@ -47,13 +46,13 @@ func TestRoundTrip(t *testing.T) {
 	}
 
 	tw, _, err := NewTripperware(Config{},
-		util_log.Logger,
+		log.NewNopLogger(),
 		mockLimits{},
 		PrometheusCodec,
 		nil,
 		chunk.SchemaConfig{},
 		promql.EngineOpts{
-			Logger:     util_log.Logger,
+			Logger:     log.NewNopLogger(),
 			Reg:        nil,
 			MaxSamples: 1000,
 			Timeout:    time.Minute,

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -3,23 +3,24 @@ package querier
 import (
 	"net/http"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/prometheus/storage"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/util"
-	"github.com/cortexproject/cortex/pkg/util/log"
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 // Queries are a set of matchers with time ranges - should not get into megabytes
 const maxRemoteReadQuerySize = 1024 * 1024
 
 // RemoteReadHandler handles Prometheus remote read requests.
-func RemoteReadHandler(q storage.Queryable) http.Handler {
+func RemoteReadHandler(q storage.Queryable, logger log.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		var req client.ReadRequest
-		logger := log.WithContext(r.Context(), log.Logger)
+		logger := util_log.WithContext(r.Context(), logger)
 		if err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRemoteReadQuerySize, &req, util.RawSnappy); err != nil {
 			level.Error(logger).Log("msg", "failed to parse proto", "err", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-kit/kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/common/model"
@@ -36,7 +37,7 @@ func TestRemoteReadHandler(t *testing.T) {
 			},
 		}, nil
 	})
-	handler := RemoteReadHandler(q)
+	handler := RemoteReadHandler(q, log.NewNopLogger())
 
 	requestBody, err := proto.Marshal(&client.ReadRequest{
 		Queries: []*client.QueryRequest{

--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/pkg/util/test"
 )
 
@@ -23,7 +23,7 @@ func TestRecvFailDoesntCancelProcess(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := Config{}
-	mgr := newFrontendProcessor(cfg, nil, util_log.Logger)
+	mgr := newFrontendProcessor(cfg, nil, log.NewNopLogger())
 	running := atomic.NewBool(false)
 	go func() {
 		running.Store(true)

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/test"
 )
@@ -68,7 +68,7 @@ func TestResetConcurrency(t *testing.T) {
 				MaxConcurrentRequests: tt.maxConcurrent,
 			}
 
-			w, err := newQuerierWorkerWithProcessor(cfg, util_log.Logger, &mockProcessor{}, "", nil)
+			w, err := newQuerierWorkerWithProcessor(cfg, log.NewNopLogger(), &mockProcessor{}, "", nil)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), w))
 


### PR DESCRIPTION
**What this PR does**:

- Remove the util_log.Logger from all files in the querier package and subpackages.
- Add a faillint rule to trigger when the global logger is used in the querier package.

**Which issue(s) this PR fixes**:
Related #3779

