### PR TITLE
Name services for better logging on failure

### DIFF
--- a/pkg/ring/client/pool.go
+++ b/pkg/ring/client/pool.go
@@ -151,6 +151,10 @@ func (p *Pool) Count() int {
 	return len(p.clients)
 }
 
+func (p *Pool) String() string {
+	return fmt.Sprintf("%s client pool", p.clientName)
+}
+
 func (p *Pool) removeStaleClients() {
 	// Only if service discovery has been configured.
 	if p.discovery == nil {

--- a/pkg/ring/client/pool.go
+++ b/pkg/ring/client/pool.go
@@ -69,7 +69,9 @@ func NewPool(clientName string, cfg PoolConfig, discovery PoolServiceDiscovery, 
 		clientsMetric: clientsMetric,
 	}
 
-	p.Service = services.NewTimerService(cfg.CheckInterval, nil, p.iteration, nil)
+	p.Service = services.
+		NewTimerService(cfg.CheckInterval, nil, p.iteration, nil).
+		WithName(fmt.Sprintf("%s client pool", p.clientName))
 	return p
 }
 
@@ -149,10 +151,6 @@ func (p *Pool) Count() int {
 	p.RLock()
 	defer p.RUnlock()
 	return len(p.clients)
-}
-
-func (p *Pool) String() string {
-	return fmt.Sprintf("%s client pool", p.clientName)
 }
 
 func (p *Pool) removeStaleClients() {

--- a/pkg/ring/kv/memberlist/kv_init_service.go
+++ b/pkg/ring/kv/memberlist/kv_init_service.go
@@ -45,7 +45,7 @@ func NewKVInitService(cfg *KVConfig, logger log.Logger) *KVInitService {
 		watcher: services.NewFailureWatcher(),
 		logger:  logger,
 	}
-	kvinit.Service = services.NewBasicService(nil, kvinit.running, kvinit.stopping)
+	kvinit.Service = services.NewBasicService(nil, kvinit.running, kvinit.stopping).WithName("memberlist KV service")
 	return kvinit
 }
 
@@ -160,10 +160,6 @@ func (kvs *KVInitService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		SentMessages:     sent,
 		ReceivedMessages: received,
 	}, pageTemplate, req)
-}
-
-func (kvs *KVInitService) String() string {
-	return "memberlist KV service"
 }
 
 func getFormat(req *http.Request) string {

--- a/pkg/ring/kv/memberlist/kv_init_service.go
+++ b/pkg/ring/kv/memberlist/kv_init_service.go
@@ -162,6 +162,10 @@ func (kvs *KVInitService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}, pageTemplate, req)
 }
 
+func (kvs *KVInitService) String() string {
+	return "memberlist KV service"
+}
+
 func getFormat(req *http.Request) string {
 	const viewFormat = "format"
 

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -838,3 +838,7 @@ func (i *Lifecycler) unregister(ctx context.Context) error {
 		return ringDesc, true, nil
 	})
 }
+
+func (i *Lifecycler) String() string {
+	return fmt.Sprintf("%s ring lifecycler", i.RingName)
+}

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -194,7 +194,9 @@ func NewLifecycler(cfg LifecyclerConfig, flushTransferer FlushTransferer, ringNa
 
 	tokensToOwn.WithLabelValues(l.RingName).Set(float64(cfg.NumTokens))
 
-	l.BasicService = services.NewBasicService(nil, l.loop, l.stopping)
+	l.BasicService = services.
+		NewBasicService(nil, l.loop, l.stopping).
+		WithName(fmt.Sprintf("%s ring lifecycler", ringName))
 
 	return l, nil
 }
@@ -837,8 +839,4 @@ func (i *Lifecycler) unregister(ctx context.Context) error {
 		ringDesc.RemoveIngester(i.ID)
 		return ringDesc, true, nil
 	})
-}
-
-func (i *Lifecycler) String() string {
-	return fmt.Sprintf("%s ring lifecycler", i.RingName)
 }

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -155,6 +155,7 @@ type Ring struct {
 	services.Service
 
 	key      string
+	name     string
 	cfg      Config
 	KVClient kv.Client
 	strategy ReplicationStrategy
@@ -215,6 +216,7 @@ func NewWithStoreClientAndStrategy(cfg Config, name, key string, store kv.Client
 
 	r := &Ring{
 		key:                  key,
+		name:                 name,
 		cfg:                  cfg,
 		KVClient:             store,
 		strategy:             strategy,
@@ -761,6 +763,10 @@ func (r *Ring) HasInstance(instanceID string) bool {
 	instances := r.ringDesc.GetIngesters()
 	_, ok := instances[instanceID]
 	return ok
+}
+
+func (r *Ring) String() string {
+	return fmt.Sprintf("%s ring client", r.name)
 }
 
 func (r *Ring) getCachedShuffledSubring(identifier string, size int) *Ring {

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -155,7 +155,6 @@ type Ring struct {
 	services.Service
 
 	key      string
-	name     string
 	cfg      Config
 	KVClient kv.Client
 	strategy ReplicationStrategy
@@ -216,7 +215,6 @@ func NewWithStoreClientAndStrategy(cfg Config, name, key string, store kv.Client
 
 	r := &Ring{
 		key:                  key,
-		name:                 name,
 		cfg:                  cfg,
 		KVClient:             store,
 		strategy:             strategy,
@@ -254,7 +252,7 @@ func NewWithStoreClientAndStrategy(cfg Config, name, key string, store kv.Client
 		),
 	}
 
-	r.Service = services.NewBasicService(nil, r.loop, nil)
+	r.Service = services.NewBasicService(nil, r.loop, nil).WithName(fmt.Sprintf("%s ring client", name))
 	return r, nil
 }
 
@@ -763,10 +761,6 @@ func (r *Ring) HasInstance(instanceID string) bool {
 	instances := r.ringDesc.GetIngesters()
 	_, ok := instances[instanceID]
 	return ok
-}
-
-func (r *Ring) String() string {
-	return fmt.Sprintf("%s ring client", r.name)
 }
 
 func (r *Ring) getCachedShuffledSubring(identifier string, size int) *Ring {


### PR DESCRIPTION
**What this PR does**:
I've got a failure while starting an ingester (was testing a change) and the related log message was this one:

```
level=error ts=2021-02-15T16:33:16.109587214Z caller=cortex.go:412 msg="module failed" module=ingester-service err="ingester subservice failed: service &{0xc00098ad80 {{{memberlist  {{consul.cortex-tsdb-dev.svc.cluster.local:8500  20000000000 false 1 1 0 0} {[] 10000000000 10 false {    false}} {  false 2000000000 0x1ecd770} 0x1ece9c0} <nil>} 600000000000 3 false false} 512 5000000000 0 0 60000000000 [eth0 en0] 30000000000 /data/tokens  false  0 ingester-5 9095} 0xc0009c2a80 0xc0009c93c0 0xc0009f6cc0 ingester-5 10.33.2.240:9095 ingester ring  0xc0003ae7b0 0xc0003ae7b8 {{0 0} 0 0 0 0} 2 [12255184 13449740 32266504 62155055 79422406 94121876 107746039 120135070 145528182 147597224 172048540 182802260 185945432 188374598 189257372 197578956 198060446 199480097 201516577 214567334 221626504 236869846 239806457 243697457 244713884 266877385 278744759 280738468 281166475 293689629 300299080 303282959 307236853 323629985 342689407 345682533 378031468 386179714 387280707 389555708 395698463 405856669 414412776 425839532 427848252 428946660 439226376 453744037 458306944 460893880 464047767 474255885 492690661 492849390 495555332 520960375 524201447 528048859 532104020 532283631 536370138 546727897 549360981 554237865 565557250 566924298 567384507 584932170 587575539 594319324 603745917 606077959 613547955 627596761 629648051 642828944 645954259 654276519 661376520 662549134 672528125 673348822 673726708 680769367 691315761 701114414 704888067 713276418 717028759 729207766 736119349 746220452 746745801 758794362 760521809 760903908 779172414 782574660 787440309 788818504 807527119 817421818 823213583 824475466 826373136 831335878 836250573 851926908 857614343 866792633 867828304 876937272 886473579 889524138 906298289 927388666 935516011 936122467 939267813 962356459 996270677 1007923538 1016436487 1022747259 1026483989 1028803027 1030622559 1034998126 1044950502 1058531238 1058566675 1075644958 1095599264 1098710856 1133596584 1138232649 1141100411 1157910227 1165818440 1172936508 1179361403 1193726510 1196858643 1200569231 1203648151 1208085570 1215425062 1231460617 1237783509 1247896732 1247959666 1262340266 1283473940 1286566534 1293688638 1298389461 1305040822 1306890816 1313125959 1319474116 1320591684 1322738998 1331798702 1342448560 1349271205 1358964611 1365715767 1368922009 1379900202 1387115727 1387554151 1408699405 1413066205 1421133072 1443879614 1446817605 1458836845 1471723947 1499527142 1502127684 1504992063 1506290893 1515870561 1518041856 1557505212 1558256856 1559593956 1564225880 1575806386 1576174964 1583848387 1586816816 1591102918 1592484355 1597265260 1606953814 1621323652 1624185463 1629283842 1633417267 1667448194 1667860229 1683640529 1687184846 1687357111 1690843360 1693340107 1698030018 1709138452 1722383059 1727602506 1746550826 1747094767 1750899588 1760972048 1771039918 1780361367 1783572732 1783830071 1788873936 1798287261 1842269288 1845984383 1849138229 1868802141 1884410060 1887407462 1894622521 1899422553 1902320110 1917805123 1929451420 1943934113 1950631542 1973181505 1981325528 1988044201 2002520338 2007879137 2014531005 2020201487 2045875085 2055063604 2059298374 2072448308 2079704389 2092982553 2106564869 2113937396 2117383105 2118413322 2118546661 2120929926 2128880482 2139217112 2144609212 2158399620 2160537785 2163836045 2181062305 2190558448 2194818184 2196433232 2211868661 2212174696 2222510534 2228350573 2234112222 2242852674 2252199645 2253752989 2270445136 2273652726 2277182479 2279288506 2311391809 2325366986 2351060936 2366350078 2368757773 2369071350 2369759311 2370238239 2376901127 2389415613 2392780557 2393435737 2411482202 2418685123 2432104861 2442544033 2445574973 2465791778 2470211393 2474914601 2481129871 2496801766 2502168795 2512344484 2526912546 2536550816 2537052529 2548764193 2553779436 2556015426 2561797268 2564691625 2602646956 2605382949 2606983435 2623415444 2656157025 2657597353 2661445899 2662675149 2663757755 2674188623 2684806349 2714367776 2718139258 2720580907 2724477059 2747127332 2750921527 2755473689 2760115704 2760421293 2785474876 2791697971 2797685865 2799235326 2802273914 2808274885 2812567781 2812978944 2829211756 2838398489 2838898550 2856115928 2857766177 2865457007 2888046871 2910735317 2919849238 2927053578 2938532214 2967271821 2970701762 2973887748 2993599359 2996958363 3007438360 3012400091 3015844968 3022243695 3046795038 3053437667 3055881657 3060893448 3062620201 3062840178 3071256252 3075728476 3093767204 3107648640 3112009227 3114593794 3120396399 3134636736 3156131165 3173748659 3201558594 3202888926 3211640370 3218067569 3227074181 3233094674 3236170353 3240931187 3247928068 3256770108 3259578677 3281873970 3289595034 3291618768 3299427766 3335786824 3354679520 3359009729 3372038086 3379223625 3394753405 3403690364 3414729923 3435486459 3437001859 3449601299 3452767858 3457213099 3458158875 3465404432 3481692190 3482558419 3489226470 3509191349 3510585823 3512684607 3513335561 3526518238 3531953076 3573876718 3587830434 3593269777 3595963499 3597254237 3597285023 3600622067 3645874294 3648727235 3656394568 3656854877 3661552794 3670593683 3673362256 3674916945 3676524051 3682307607 3682760792 3702839310 3703110511 3703394433 3709129442 3712305576 3723610081 3724688150 3728601273 3736585283 3740786099 3742660346 3744232374 3757467340 3764943728 3782264498 3783215893 3788062755 3790120793 3797268791 3804640113 3811577072 3827998581 3833561331 3845652826 3847508344 3850175763 3863642295 3871305084 3873703801 3875873786 3877883816 3914151805 3916432521 3920317943 3924784997 3935803029 3949777577 3956199747 3961217428 3968039415 3974871983 3982164835 3990282495 3990328161 3993499245 4020569837 4032218221 4060174178 4072957149 4085345385 4088640299 4090409511 4093074495 4095741274 4113233600 4118789234 4123169876 4129613582 4132427740 4133229351 4135823368 4136152379 4138775086 4138955560 4141239722 4147762536 4167103531 4170993589 4171274465 4177099765 4178706719 4181209083 4207283851 4222908912 4225144955 4229014942 4250143128 4251233319 4260708963 4267145048 4269759719 4273897866 4282706431 4288737770] {0 63745565266 0x3fcf7a0} {0 0} {13835839036137654337 77982307 0x3fcf7a0} false {{0 0} 0 0 0 0} 0 0} failed: failed to join the ring ingester: failed to CAS-update key ring: no change detected"
```

The `FailureWatcher` logs the service, which is the struct dump if no `String()` function is defined. I went through the code and added a `String()` to each service monitred by `FailureWatcher` (I hope I spot all of them).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
