### PR TITLE
Introduce NamedService interface that allows service to return a name.

### DIFF
--- a/pkg/util/services/basic_service_test.go
+++ b/pkg/util/services/basic_service_test.go
@@ -313,3 +313,16 @@ func TestFailureCaseFromRunningIsPassedToStopping(t *testing.T) {
 	fc := s.FailureCase()
 	require.Equal(t, err, fc)
 }
+
+func TestServiceName(t *testing.T) {
+	s := NewIdleService(nil, nil).WithName("test name")
+	require.Equal(t, "test name", DescribeService(s))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, s.StartAsync(ctx))
+
+	// once service has started, BasicService will not allow changing the name
+	s.WithName("new")
+	require.Equal(t, "test name", DescribeService(s))
+}

--- a/pkg/util/services/failure_watcher.go
+++ b/pkg/util/services/failure_watcher.go
@@ -24,12 +24,12 @@ func (w *FailureWatcher) Chan() <-chan error {
 
 func (w *FailureWatcher) WatchService(service Service) {
 	service.AddListener(NewListener(nil, nil, nil, nil, func(from State, failure error) {
-		w.ch <- errors.Wrapf(failure, "service %v failed", service)
+		w.ch <- errors.Wrapf(failure, "service %s failed", DescribeService(service))
 	}))
 }
 
 func (w *FailureWatcher) WatchManager(manager *Manager) {
 	manager.AddListener(NewManagerListener(nil, nil, func(service Service) {
-		w.ch <- errors.Wrapf(service.FailureCase(), "service %v failed", service)
+		w.ch <- errors.Wrapf(service.FailureCase(), "service %s failed", DescribeService(service))
 	}))
 }

--- a/pkg/util/services/service.go
+++ b/pkg/util/services/service.go
@@ -53,33 +53,33 @@ func (s State) String() string {
 //                                                                      └────────┘
 //
 type Service interface {
-	// Starts Service asynchronously. Service must be in New State, otherwise error is returned.
+	// StartAsync starts Service asynchronously. Service must be in New State, otherwise error is returned.
 	// Context is used as a parent context for service own context.
 	StartAsync(ctx context.Context) error
 
-	// Waits until service gets into Running state.
+	// AwaitRunning waits until service gets into Running state.
 	// If service is in New or Starting state, this method is blocking.
 	// If service is already in Running state, returns immediately with no error.
 	// If service is in a state, from which it cannot get into Running state, error is returned immediately.
 	AwaitRunning(ctx context.Context) error
 
-	// Tell the service to stop. This method doesn't block and can be called multiple times.
+	// StopAsync tell the service to stop. This method doesn't block and can be called multiple times.
 	// If Service is New, it is Terminated without having been started nor stopped.
 	// If Service is in Starting or Running state, this initiates shutdown and returns immediately.
 	// If Service has already been stopped, this method returns immediately, without taking action.
 	StopAsync()
 
-	// Waits for the service to reach Terminated or Failed state. If service is already in one of these states,
+	// AwaitTerminated waits for the service to reach Terminated or Failed state. If service is already in one of these states,
 	// when method is called, method returns immediately.
 	// If service enters Terminated state, this method returns nil.
 	// If service enters Failed state, or context is finished before reaching Terminated or Failed, error is returned.
 	AwaitTerminated(ctx context.Context) error
 
-	// If Service is in Failed state, this method returns the error.
+	// FailureCase returns error if Service is in Failed state.
 	// If Service is not in Failed state, this method returns nil.
 	FailureCase() error
 
-	// Returns current state of the service.
+	// State returns current state of the service.
 	State() State
 
 	// AddListener adds listener to this service. Listener will be notified on subsequent state transitions
@@ -92,6 +92,14 @@ type Service interface {
 	// at once. However, multiple listeners' callbacks may execute concurrently, and listeners may execute
 	// in an order different from the one in which they were registered.
 	AddListener(listener Listener)
+}
+
+// NamedService extends Service with a name.
+type NamedService interface {
+	Service
+
+	// ServiceName returns name of the service, if it has one.
+	ServiceName() string
 }
 
 // Listener receives notifications about Service state changes.

--- a/pkg/util/services/services.go
+++ b/pkg/util/services/services.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -21,7 +22,7 @@ func NewIdleService(up StartingFn, down StoppingFn) *BasicService {
 type OneIteration func(ctx context.Context) error
 
 // Runs iteration function on every interval tick. When iteration returns error, service fails.
-func NewTimerService(interval time.Duration, start StartingFn, iter OneIteration, stop StoppingFn) Service {
+func NewTimerService(interval time.Duration, start StartingFn, iter OneIteration, stop StoppingFn) *BasicService {
 	run := func(ctx context.Context) error {
 		t := time.NewTicker(interval)
 		defer t.Stop()
@@ -129,4 +130,16 @@ func StopAndAwaitTerminated(ctx context.Context, service Service) error {
 
 	// can happen e.g. if context was canceled
 	return err
+}
+
+// DescribeService returns name of the service, if it has one, or returns string representation of the service.
+func DescribeService(service Service) string {
+	name := ""
+	if named, ok := service.(NamedService); ok {
+		name = named.ServiceName()
+	}
+	if name == "" {
+		name = fmt.Sprintf("%v", service)
+	}
+	return name
 }


### PR DESCRIPTION
**What this PR does**: This PR introduces `NamedService` interface, which extends Service with a name. `BasicService` implements this, and has new `WithName` method to set the name while service is still in `New` state. Failure watcher reports the name for failed services, if one is available.

**Checklist**
- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
