### PR TITLE
Cleanup local sync dirs for users that don't belong to store-gateways shard anymore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * [ENHANCEMENT] Blocks storage: added `-blocks-storage.s3.region` support to S3 client configuration. #3811
 * [ENHANCEMENT] Distributor: Remove cached subrings for inactive users when using shuffle sharding. #3849
 * [ENHANCEMENT] Compactor: cleanup local files for users that are no longer owned by compactor. #3851
+* [ENHANCEMENT] Store-gateway: close empty bucket stores, and delete leftover local files for tenats that no longer belong to store-gateway. #3853
 * [BUGFIX] Cortex: Fixed issue where fatal errors and various log messages where not logged. #3778
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -167,6 +167,10 @@ func (m *BucketStoreMetrics) AddUserRegistry(user string, reg *prometheus.Regist
 	m.regs.AddUserRegistry(user, reg)
 }
 
+func (m *BucketStoreMetrics) RemoveUserRegistry(user string) {
+	m.regs.RemoveUserRegistry(user, false)
+}
+
 func (m *BucketStoreMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.blockLoads
 	out <- m.blockLoadFailures

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -325,7 +325,8 @@ var (
 	errBucketStoreNotFound = errors.New("bucket store not found")
 )
 
-// closeEmptyBucketStore closes bucket store for given user, if it is empty, and removes it from
+// closeEmptyBucketStore closes bucket store for given user, if it is empty,
+// and removes it from bucket stores map and metrics.
 // If bucket store doesn't exist, returns errBucketStoreNotFound.
 // If bucket store is not empty, returns errBucketStoreNotEmpty.
 // Otherwise returns error from closing the bucket store.

--- a/pkg/storegateway/metadata_fetcher_metrics.go
+++ b/pkg/storegateway/metadata_fetcher_metrics.go
@@ -56,6 +56,10 @@ func (m *MetadataFetcherMetrics) AddUserRegistry(user string, reg *prometheus.Re
 	m.regs.AddUserRegistry(user, reg)
 }
 
+func (m *MetadataFetcherMetrics) RemoveUserRegistry(user string) {
+	m.regs.RemoveUserRegistry(user, false)
+}
+
 func (m *MetadataFetcherMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.syncs
 	out <- m.syncFailures


### PR DESCRIPTION
**What this PR does**: This PR implements cleanup of local sync directories for users that no longer belong to store-gateway shard. (~Tests are still missing here, but logic should be solid.~ Added tests.)

**Which issue(s) this PR fixes**:
Fixes #3698

**Checklist**
- [x] Tests updated [TODO]
- [ ] Documentation added
- [x] `CHANGELOG.md` updated [TODO]

