### PR TITLE
Add functions to access cortexpb pool

### DIFF
--- a/pkg/cortexpb/compat.go
+++ b/pkg/cortexpb/compat.go
@@ -22,13 +22,13 @@ import (
 // It gets timeseries from the pool, so ReuseSlice() should be called when done.
 func ToWriteRequest(lbls []labels.Labels, samples []Sample, metadata []*MetricMetadata, source WriteRequest_SourceEnum) *WriteRequest {
 	req := &WriteRequest{
-		Timeseries: slicePool.Get().([]PreallocTimeseries),
+		Timeseries: PreallocTimeseriesSliceFromPool(),
 		Metadata:   metadata,
 		Source:     source,
 	}
 
 	for i, s := range samples {
-		ts := timeSeriesPool.Get().(*TimeSeries)
+		ts := TimeseriesFromPool()
 		ts.Labels = append(ts.Labels, FromLabelsToLabelAdapters(lbls[i])...)
 		ts.Samples = append(ts.Samples, s)
 		req.Timeseries = append(req.Timeseries, PreallocTimeseries{TimeSeries: ts})

--- a/pkg/cortexpb/timeseries_test.go
+++ b/pkg/cortexpb/timeseries_test.go
@@ -3,6 +3,7 @@ package cortexpb
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,4 +25,42 @@ func TestLabelAdapter_Marshal(t *testing.T) {
 			require.EqualValues(t, tt.bs, lbs)
 		})
 	}
+}
+
+func TestPreallocTimeseriesSliceFromPool(t *testing.T) {
+	t.Run("new instance is provided when not available to reuse", func(t *testing.T) {
+		first := PreallocTimeseriesSliceFromPool()
+		second := PreallocTimeseriesSliceFromPool()
+
+		assert.NotSame(t, first, second)
+	})
+
+	t.Run("instance is cleaned before reusing", func(t *testing.T) {
+		slice := PreallocTimeseriesSliceFromPool()
+		slice = append(slice, PreallocTimeseries{TimeSeries: &TimeSeries{}})
+		ReuseSlice(slice)
+
+		reused := PreallocTimeseriesSliceFromPool()
+		assert.Len(t, reused, 0)
+	})
+}
+
+func TestTimeseriesFromPool(t *testing.T) {
+	t.Run("new instance is provided when not available to reuse", func(t *testing.T) {
+		first := TimeseriesFromPool()
+		second := TimeseriesFromPool()
+
+		assert.NotSame(t, first, second)
+	})
+
+	t.Run("instance is cleaned before reusing", func(t *testing.T) {
+		ts := TimeseriesFromPool()
+		ts.Labels = []LabelAdapter{{Name: "foo", Value: "bar"}}
+		ts.Samples = []Sample{{Value: 1, TimestampMs: 2}}
+		ReuseTimeseries(ts)
+
+		reused := TimeseriesFromPool()
+		assert.Len(t, reused.Labels, 0)
+		assert.Len(t, reused.Samples, 0)
+	})
 }


### PR DESCRIPTION
**What this PR does**:
This commit adds functions to retrieve items from both poolsi in `cortexpb` package.

**Which issue(s) this PR fixes**:
`ToWriteRequest` already exposes entities (slice of PreallocTimeseries and \*TimeSeries) retrieved from the pool, and encourages usage of ReuseSlice on them, however there was no way to obtain them without using that function.

If that package's user wants to build a WriteRequest itself (for example, if more than one Sample per metric is desired) then it's useful to retrieve those slice and struct pointers from the pool.

**Checklist**
- [x] Tests updated
- [ ] Documentation added (does not apply)
- [ ] `CHANGELOG.md` updated (not updated as this doesn't change the functionality)
