### PR TITLE
Documented how to scale up / down ingesters

### DIFF
--- a/docs/guides/ingesters-rolling-updates.md
+++ b/docs/guides/ingesters-rolling-updates.md
@@ -15,6 +15,8 @@ In this document we describe the techniques employed to safely handle rolling up
 - [Chunks storage with WAL enabled](#chunks-storage-with-wal-enabled)
 - [Chunks storage with WAL disabled](#chunks-storage-with-wal-disabled-hand-over)
 
+_If you're looking how to scale up / down ingesters, please refer to the [dedicated guide](./ingesters-scaling-up-and-down.md)._
+
 ## Blocks storage
 
 The Cortex [blocks storage](../blocks-storage/_index.md) requires ingesters to run with a persistent disk where the TSDB WAL and blocks are stored (eg. a StatefulSet when deployed on Kubernetes).
@@ -31,7 +33,7 @@ The rolling update procedure for a Cortex cluster running the chunks storage dep
 
 ### Chunks storage with WAL enabled
 
-Similarly to the blocks storage, when Cortex is running the chunks storage with WAL enabled, it requires ingesters to run with a persistent disk where the WAL is stored (eg. a StatefulSet when deployed on Kubernetes).
+Similarly to the blocks storage, when Cortex is running the [chunks storage](../chunks-storage/_index.md) with WAL enabled, it requires ingesters to run with a persistent disk where the WAL is stored (eg. a StatefulSet when deployed on Kubernetes).
 
 During a rolling update, the leaving ingester closes the WAL, synchronize the data to disk (`fsync`) and releases the disk resources.
 The new ingester, which is expected to reuse the same disk of the leaving one, will replay the WAL on startup in order to load back in memory the time series data.
@@ -40,7 +42,7 @@ _For more information about the WAL, please refer to [Ingesters with WAL](../chu
 
 ### Chunks storage with WAL disabled (hand-over)
 
-When Cortex is running the chunks storage with WAL disabled, Cortex supports on-the-fly series hand-over between a leaving ingester and a joining one.
+When Cortex is running the [chunks storage](../chunks-storage/_index.md) with WAL disabled, Cortex supports on-the-fly series hand-over between a leaving ingester and a joining one.
 
 The hand-over is based on the ingesters state stored in the ring. Each ingester could be in one of the following **states**:
 

--- a/docs/guides/ingesters-scaling-up-and-down.md
+++ b/docs/guides/ingesters-scaling-up-and-down.md
@@ -27,7 +27,7 @@ The procedure to adopt when scaling down ingesters depends on your Cortex setup:
 
 ### Blocks storage
 
-When Cortex is running the [blocks storage](../blocks-storage/_index.md), ingesters don't flush series to blocks at shutdown by default. However, Cortex ingesters expose an API endpoint [`/shutdown`](../api/_index.md#shutdown) that can be called to flush series to blocks and upload them to the long-term storage before the ingester terminates.
+When Cortex is running the [blocks storage](../blocks-storage/_index.md), ingesters don't flush series to blocks at shutdown by default. However, Cortex ingesters expose an API endpoint [`/shutdown`](../api/_index.md#shutdown) that can be called to flush series to blocks and upload blocks to the long-term storage before the ingester terminates.
 
 Even if ingester blocks are compacted and shipped to the storage at shutdown, it takes some time for queriers and store-gateways to discover the newly uploaded blocks. This is due to the fact that the blocks storage runs a periodic scanning of the storage bucket to discover blocks. If two or more ingesters are scaled down in a short period of time, queriers may miss some data at query time due to series that were stored in the terminated ingesters but their blocks haven't been discovered yet.
 

--- a/docs/guides/ingesters-scaling-up-and-down.md
+++ b/docs/guides/ingesters-scaling-up-and-down.md
@@ -11,7 +11,7 @@ _If you're looking how to run ingesters rolling updates, please refer to the [de
 
 ## Scaling up
 
-Adding more ingesters to a Cortex cluster is considered a safe operation. When a new ingester startups, it will register to the [hash ring](../architecture.md#the-hash-ring) and the distributors will reshard received series accordingly.
+Adding more ingesters to a Cortex cluster is considered a safe operation. When a new ingester starts, it will register to the [hash ring](../architecture.md#the-hash-ring) and the distributors will reshard received series accordingly.
 
 No special care is required to take when scaling up ingesters.
 

--- a/docs/guides/ingesters-scaling-up-and-down.md
+++ b/docs/guides/ingesters-scaling-up-and-down.md
@@ -17,7 +17,7 @@ No special care is required to take when scaling up ingesters.
 
 ## Scaling down
 
-A running ingester holds several hours of time series data in memory, before they're flushed to the long-term storage.  When an ingester shutdowns, because of a scale down operation, the in-memory data must not be discarded in order to avoid any data loss.
+A running ingester holds several hours of time series data in memory, before they're flushed to the long-term storage.  When an ingester shuts down, because of a scale down operation, the in-memory data must not be discarded in order to avoid any data loss.
 
 The procedure to adopt when scaling down ingesters depends on your Cortex setup:
 

--- a/docs/guides/ingesters-scaling-up-and-down.md
+++ b/docs/guides/ingesters-scaling-up-and-down.md
@@ -44,7 +44,7 @@ The ingesters scale down is deemed an infrequent operation and no automation is 
   - `-blocks-storage.bucket-store.metadata-cache.metafile-doesnt-exist-ttl=1m`
 - Ingesters should be scaled down one by one:
   1. Call `/shutdown` endpoint on the ingester to shutdown
-  2. Wait until the API terminates or "finished flushing and shipping TSDB blocks" is logged
+  2. Wait until the HTTP call returns successfully or "finished flushing and shipping TSDB blocks" is logged
   3. Terminate the ingester process (the `/shutdown` will not do it)
   4. Wait 2x the maximum between `-blocks-storage.bucket-store.sync-interval` and `-compactor.cleanup-interval`
 

--- a/docs/guides/ingesters-scaling-up-and-down.md
+++ b/docs/guides/ingesters-scaling-up-and-down.md
@@ -1,0 +1,65 @@
+---
+title: "Ingesters scaling up and down"
+linkTitle: "Ingesters scaling up and down"
+weight: 10
+slug: ingesters-scaling-up-and-down
+---
+
+This guide explains how to scale up and down ingesters.
+
+_If you're looking how to run ingesters rolling updates, please refer to the [dedicated guide](./ingesters-rolling-updates.md)._
+
+## Scaling up
+
+Adding more ingesters to a Cortex cluster is considered a safe operation. When a new ingester startups, it will register to the [hash ring](../architecture.md#the-hash-ring) and the distributors will reshard received series accordingly.
+
+No special care is required to take when scaling up ingesters.
+
+## Scaling down
+
+A running ingester holds several hours of time series data in memory, before they're flushed to the long-term storage.  When an ingester shutdowns, because of a scale down operation, the in-memory data must not be discarded in order to avoid any data loss.
+
+The procedure to adopt when scaling down ingesters depends on your Cortex setup:
+
+- [Blocks storage](#blocks-storage)
+- [Chunks storage with WAL enabled](#chunks-storage-with-wal-enabled)
+- [Chunks storage with WAL disabled](#chunks-storage-with-wal-disabled-hand-over)
+
+### Blocks storage
+
+When Cortex is running the [blocks storage](../blocks-storage/_index.md), ingesters don't flush series to blocks at shutdown by default. However, Cortex ingesters expose an API endpoint [`/shutdown`](../api/_index.md#shutdown) that can be called to flush series to blocks and upload them to the long-term storage before the ingester terminates.
+
+Even if ingester blocks are compacted and shipped to the storage at shutdown, it takes some time for queriers and store-gateways to discover the newly uploaded blocks. This is due to the fact that the blocks storage runs a periodic scanning of the storage bucket to discover blocks. If two or more ingesters are scaled down in a short period of time, queriers may miss some data at query time due to series that were stored in the terminated ingesters but their blocks haven't been discovered yet.
+
+The ingesters scale down is deemed an infrequent operation and no automation is currently provided. However, if you need to scale down ingesters, please be aware of the following:
+
+- Configure queriers and rulers to always query the storage
+  - `-querier.query-store-after=0s`
+- Frequently scan the storage bucket
+  - `-blocks-storage.bucket-store.sync-interval=5m`
+  - `-compactor.cleanup-interval=5m`
+- Lower bucket scanning cache TTLs
+  - `-blocks-storage.bucket-store.metadata-cache.bucket-index-content-ttl=1m`
+  - `-blocks-storage.bucket-store.metadata-cache.tenant-blocks-list-ttl=1m`
+  - `-blocks-storage.bucket-store.metadata-cache.metafile-doesnt-exist-ttl=1m`
+- Ingesters should be scaled down one by one:
+  1. Call `/shutdown` endpoint on the ingester to shutdown
+  2. Wait until the API terminates or "finished flushing and shipping TSDB blocks" is logged
+  3. Terminate the ingester process (the `/shutdown` will not do it)
+  4. Wait 2x the maximum between `-blocks-storage.bucket-store.sync-interval` and `-compactor.cleanup-interval`
+
+### Chunks storage with WAL enabled
+
+When Cortex is running the [chunks storage](../chunks-storage/_index.md) with WAL enabled, ingesters don't flush series chunks to storage at shutdown by default. However, Cortex ingesters expose an API endpoint [`/shutdown`](../api/_index.md#shutdown) that can be called to flush chunks to the long-term storage before the ingester terminates.
+
+The procedure to scale down ingesters -- one by one -- should be:
+
+1. Call `/shutdown` endpoint on the ingester to shutdown
+2. Wait until the API terminates or "flushing of chunks complete" is logged
+3. Terminate the ingester process (the `/shutdown` will not do it)
+
+_For more information about the chunks storage WAL, please refer to [Ingesters with WAL](../chunks-storage/ingesters-with-wal.md)._
+
+### Chunks storage with WAL disabled
+
+When Cortex is running the chunks storage with WAL disabled, ingesters flush series chunks to the storage at shutdown if no `PENDING` ingester (to transfer series to) is found. Because of this, it's safe to scale down ingesters with no special care in this setup.

--- a/docs/guides/ingesters-scaling-up-and-down.md
+++ b/docs/guides/ingesters-scaling-up-and-down.md
@@ -46,7 +46,7 @@ The ingesters scale down is deemed an infrequent operation and no automation is 
   1. Call `/shutdown` endpoint on the ingester to shutdown
   2. Wait until the HTTP call returns successfully or "finished flushing and shipping TSDB blocks" is logged
   3. Terminate the ingester process (the `/shutdown` will not do it)
-  4. Wait 2x the maximum between `-blocks-storage.bucket-store.sync-interval` and `-compactor.cleanup-interval`
+  4. Before proceeding to the next ingester, wait 2x the maximum between `-blocks-storage.bucket-store.sync-interval` and `-compactor.cleanup-interval`
 
 ### Chunks storage with WAL enabled
 

--- a/docs/guides/ingesters-scaling-up-and-down.md
+++ b/docs/guides/ingesters-scaling-up-and-down.md
@@ -55,7 +55,7 @@ When Cortex is running the [chunks storage](../chunks-storage/_index.md) with WA
 The procedure to scale down ingesters -- one by one -- should be:
 
 1. Call `/shutdown` endpoint on the ingester to shutdown
-2. Wait until the API terminates or "flushing of chunks complete" is logged
+2.  Wait until the HTTP call returns successfully or "flushing of chunks complete" is logged
 3. Terminate the ingester process (the `/shutdown` will not do it)
 
 _For more information about the chunks storage WAL, please refer to [Ingesters with WAL](../chunks-storage/ingesters-with-wal.md)._


### PR DESCRIPTION
**What this PR does**:
Scaling up ingesters is easy, but scaling down is tricky, especially when running the blocks storage. This PR attempts to document it.

**Which issue(s) this PR fixes**:
Fixes #3104

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
