### PR TITLE
Fixed TimeToMilliseconds() used in integration tests

### DIFF
--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -88,7 +88,8 @@ func PostRequest(url string) (*http.Response, error) {
 
 // TimeToMilliseconds returns the input time as milliseconds, using the same
 // formula used by Prometheus in order to get the same timestamp when asserting
-// on query results.
+// on query results. The formula we're mimicking here is Prometheus parseTime().
+// See: https://github.com/prometheus/prometheus/blob/df80dc4d3970121f2f76cba79050983ffb3cdbb0/web/api/v1/api.go#L1690-L1694
 func TimeToMilliseconds(t time.Time) int64 {
 	// Convert to seconds.
 	sec := float64(t.Unix()) + float64(t.Nanosecond())/1e9

--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -86,12 +86,21 @@ func PostRequest(url string) (*http.Response, error) {
 	return client.Post(url, "", strings.NewReader(""))
 }
 
-// timeToMilliseconds returns the input time as milliseconds, using the same
+// TimeToMilliseconds returns the input time as milliseconds, using the same
 // formula used by Prometheus in order to get the same timestamp when asserting
 // on query results.
 func TimeToMilliseconds(t time.Time) int64 {
-	// The millisecond is rounded to the nearest
-	return int64(math.Round(float64(t.UnixNano()) / 1000000))
+	// Convert to seconds.
+	sec := float64(t.Unix()) + float64(t.Nanosecond())/1e9
+
+	// Parse seconds.
+	s, ns := math.Modf(sec)
+
+	// Round nanoseconds part.
+	ns = math.Round(ns*1000) / 1000
+
+	// Convert to millis.
+	return (int64(s) * 1e3) + (int64(ns * 1e3))
 }
 
 func GenerateSeries(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector) {

--- a/integration/e2e/util_test.go
+++ b/integration/e2e/util_test.go
@@ -1,0 +1,22 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeToMilliseconds(t *testing.T) {
+	input := time.Unix(0, 1614091978491118000)
+	assert.Equal(t, int64(1614091978491), TimeToMilliseconds(input))
+
+	input = time.Unix(0, 1614091978505374000)
+	assert.Equal(t, int64(1614091978505), TimeToMilliseconds(input))
+
+	input = time.Unix(0, 1614091921796500000)
+	assert.Equal(t, int64(1614091921796), TimeToMilliseconds(input))
+
+	input = time.Unix(0, 1614092667692610000)
+	assert.Equal(t, int64(1614092667693), TimeToMilliseconds(input))
+}


### PR DESCRIPTION
**What this PR does**:
I've got an integration test failing because of the timestamp comparison (the expected timestamp was diff by 1 millis). After some investigation I've found out there 1 case where `TimeToMilliseconds()` used in integration tests doesn't actually match the rounding done in Prometheus. The case is when the nanoseconds part of the timestamp is like `xxx500000`.

This PR fixes it, using the same exact formula used by Prometheus. The test cases have been created running the Prometheus code.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
