### PR TITLE
avoid allocating new label Builder in loop

### DIFF
--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -715,6 +715,7 @@ func GetLabels(c prometheus.Collector, filter map[string]string) ([]labels.Label
 	errs := tsdb_errors.NewMulti()
 	var result []labels.Labels
 	dtoMetric := &dto.Metric{}
+	lbls := labels.NewBuilder(nil)
 
 nextMetric:
 	for m := range ch {
@@ -725,7 +726,7 @@ nextMetric:
 			continue
 		}
 
-		lbls := labels.NewBuilder(nil)
+		lbls.Reset(nil)
 		for _, lp := range dtoMetric.Label {
 			n := lp.GetName()
 			v := lp.GetValue()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**: it avoids allocation a new `label.Builder` in the loop when `GetLabels` is called. This small change improves runtime for this particular method up to 50%:

### before

```
pkg: github.com/cortexproject/cortex/pkg/util
BenchmarkGetLabels_SmallSet
BenchmarkGetLabels_SmallSet-8   	  273496	      3827 ns/op
PASS

pkg: github.com/cortexproject/cortex/pkg/util
BenchmarkGetLabels_MediumSet
BenchmarkGetLabels_MediumSet-8   	     654	   1624579 ns/op
PASS
```

### after 

```
pkg: github.com/cortexproject/cortex/pkg/util
BenchmarkGetLabels_SmallSet
BenchmarkGetLabels_SmallSet-8   	  407936	      2681 ns/op
PASS

pkg: github.com/cortexproject/cortex/pkg/util
BenchmarkGetLabels_MediumSet
BenchmarkGetLabels_MediumSet-8   	    1357	    853821 ns/op
PASS
```


**Checklist**
- [x] Tests updated
- ~[ ] Documentation added~
- ~[ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~
