### PR TITLE
Adding v1.7.0 to back-compat tests & github actions

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -137,6 +137,7 @@ jobs:
           docker pull quay.io/cortexproject/cortex:v1.4.0
           docker pull quay.io/cortexproject/cortex:v1.5.0
           docker pull quay.io/cortexproject/cortex:v1.6.0
+          docker pull quay.io/cortexproject/cortex:v1.7.0
           docker pull shopify/bigtable-emulator:0.1.0
           docker pull rinscy/cassandra:3.11.0
           docker pull memcached:1.6.1

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -27,6 +27,7 @@ var (
 		"quay.io/cortexproject/cortex:v1.4.0": preCortex16Flags,
 		"quay.io/cortexproject/cortex:v1.5.0": preCortex16Flags,
 		"quay.io/cortexproject/cortex:v1.6.0": nil,
+		"quay.io/cortexproject/cortex:v1.7.0": nil,
 	}
 )
 


### PR DESCRIPTION
**What this PR does**: Adds v1.7.0 to the back-compatibility tests executed by the build pipeline
