### PR TITLE
Use recursive iter in ruler store client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [CHANGE] Query-frontend: removed `-querier.split-queries-by-day` (deprecated in Cortex 0.4.0). You should use `-querier.split-queries-by-interval` instead. #3813
 * [CHANGE] Store-gateway: the chunks pool controlled by `-blocks-storage.bucket-store.max-chunk-pool-bytes` is now shared across all tenants. #3830
 * [CHANGE] Ingester: return error code 400 instead of 429 when per-user/per-tenant series/metadata limits are reached. #3833
-* [FEATURE] Experimental Ruler Storage: Add a separate set of configuration options to configure the ruler storage backend under the `-ruler-storage.` flag prefix. All blocks storage bucket clients and the config service are currently supported. Clients using this implementation will only be enabled if the existing `-ruler.storage` flags are left unset. #3805
+* [FEATURE] Experimental Ruler Storage: Add a separate set of configuration options to configure the ruler storage backend under the `-ruler-storage.` flag prefix. All blocks storage bucket clients and the config service are currently supported. Clients using this implementation will only be enabled if the existing `-ruler.storage` flags are left unset. #3805 #3864
 * [FEATURE] Adds support to S3 server-side encryption using KMS. The S3 server-side encryption config can be overridden on a per-tenant basis. Deprecated `-<prefix>.s3.sse-encryption`, you should use the following CLI flags that have been added. #3651 #3810 #3811
   - `-<prefix>.s3.sse.type`
   - `-<prefix>.s3.sse.kms-key-id`

--- a/pkg/ruler/rulestore/bucket_client.go
+++ b/pkg/ruler/rulestore/bucket_client.go
@@ -53,7 +53,7 @@ func (b *BucketRuleStore) getRuleGroup(ctx context.Context, userID, namespace, g
 
 	reader, err := userBucket.Get(ctx, objectKey)
 	if userBucket.IsObjNotFoundErr(err) {
-		level.Debug(b.logger).Log("msg", "rule group does not exist", "name", objectKey)
+		level.Debug(b.logger).Log("msg", "rule group does not exist", "user", userID, "key", objectKey)
 		return nil, rules.ErrGroupNotFound
 	}
 
@@ -252,10 +252,10 @@ func (b *BucketRuleStore) DeleteNamespace(ctx context.Context, userID string, na
 			return err
 		}
 		objectKey := getRulesGroupObjectKey(rg.Namespace, rg.Name)
-		level.Debug(b.logger).Log("msg", "deleting rule group", "namespace", namespace, "key", objectKey)
+		level.Debug(b.logger).Log("msg", "deleting rule group", "user", userID, "namespace", namespace, "key", objectKey)
 		err = userBucket.Delete(ctx, objectKey)
 		if err != nil {
-			level.Error(b.logger).Log("msg", "unable to delete rule group from namespace", "err", err, "namespace", namespace, "key", objectKey)
+			level.Error(b.logger).Log("msg", "unable to delete rule group from namespace", "user", userID, "namespace", namespace, "key", objectKey, "err", err)
 			return err
 		}
 	}

--- a/pkg/ruler/rulestore/bucket_client.go
+++ b/pkg/ruler/rulestore/bucket_client.go
@@ -49,7 +49,7 @@ func NewBucketRuleStore(bkt objstore.Bucket, cfgProvider bucket.TenantConfigProv
 // getRuleGroup loads and return a rules group. If existing rule group is supplied, it is Reset and reused. If nil, new RuleGroupDesc is allocated.
 func (b *BucketRuleStore) getRuleGroup(ctx context.Context, userID, namespace, groupName string, rg *rules.RuleGroupDesc) (*rules.RuleGroupDesc, error) {
 	userBucket := bucket.NewUserBucketClient(userID, b.bucket, b.cfgProvider)
-	objectKey := getRulesGroupObjectKey(namespace, groupName)
+	objectKey := getRuleGroupObjectKey(namespace, groupName)
 
 	reader, err := userBucket.Get(ctx, objectKey)
 	if userBucket.IsObjNotFoundErr(err) {
@@ -222,13 +222,13 @@ func (b *BucketRuleStore) SetRuleGroup(ctx context.Context, userID string, names
 		return err
 	}
 
-	return userBucket.Upload(ctx, getRulesGroupObjectKey(namespace, group.Name), bytes.NewBuffer(data))
+	return userBucket.Upload(ctx, getRuleGroupObjectKey(namespace, group.Name), bytes.NewBuffer(data))
 }
 
 // DeleteRuleGroup implements rules.RuleStore.
 func (b *BucketRuleStore) DeleteRuleGroup(ctx context.Context, userID string, namespace string, group string) error {
 	userBucket := bucket.NewUserBucketClient(userID, b.bucket, b.cfgProvider)
-	err := userBucket.Delete(ctx, getRulesGroupObjectKey(namespace, group))
+	err := userBucket.Delete(ctx, getRuleGroupObjectKey(namespace, group))
 	if b.bucket.IsObjNotFoundErr(err) {
 		return rules.ErrGroupNotFound
 	}
@@ -251,7 +251,7 @@ func (b *BucketRuleStore) DeleteNamespace(ctx context.Context, userID string, na
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		objectKey := getRulesGroupObjectKey(rg.Namespace, rg.Name)
+		objectKey := getRuleGroupObjectKey(rg.Namespace, rg.Name)
 		level.Debug(b.logger).Log("msg", "deleting rule group", "user", userID, "namespace", namespace, "key", objectKey)
 		err = userBucket.Delete(ctx, objectKey)
 		if err != nil {
@@ -271,7 +271,7 @@ func getNamespacePrefix(namespace string) string {
 	return base64.URLEncoding.EncodeToString([]byte(namespace)) + objstore.DirDelim
 }
 
-func getRulesGroupObjectKey(namespace, group string) string {
+func getRuleGroupObjectKey(namespace, group string) string {
 	return getNamespacePrefix(namespace) + base64.URLEncoding.EncodeToString([]byte(group))
 }
 

--- a/pkg/ruler/rulestore/bucket_client.go
+++ b/pkg/ruler/rulestore/bucket_client.go
@@ -132,7 +132,7 @@ func (b *BucketRuleStore) ListRuleGroupsForUserAndNamespace(ctx context.Context,
 
 	// The prefix to list objects depends on whether the namespace has been
 	// specified in the request.
-	prefix := objstore.DirDelim
+	prefix := ""
 	if namespace != "" {
 		prefix = getNamespacePrefix(namespace)
 	}

--- a/pkg/ruler/rulestore/bucket_client_test.go
+++ b/pkg/ruler/rulestore/bucket_client_test.go
@@ -193,12 +193,12 @@ func TestDelete(t *testing.T) {
 			require.Error(t, rs.DeleteNamespace(canceled, "user1", ""))
 
 			require.Equal(t, []string{
-				"rules/user1/" + generateRuleObjectKey("A", "1"),
-				"rules/user1/" + generateRuleObjectKey("A", "2"),
-				"rules/user1/" + generateRuleObjectKey("B", "3"),
-				"rules/user1/" + generateRuleObjectKey("C", "4"),
-				"rules/user2/" + generateRuleObjectKey("second", "group"),
-				"rules/user3/" + generateRuleObjectKey("third", "group"),
+				"rules/user1/" + getRulesGroupObjectKey("A", "1"),
+				"rules/user1/" + getRulesGroupObjectKey("A", "2"),
+				"rules/user1/" + getRulesGroupObjectKey("B", "3"),
+				"rules/user1/" + getRulesGroupObjectKey("C", "4"),
+				"rules/user2/" + getRulesGroupObjectKey("second", "group"),
+				"rules/user3/" + getRulesGroupObjectKey("third", "group"),
 			}, getSortedObjectKeys(bucketClient))
 		}
 
@@ -208,9 +208,9 @@ func TestDelete(t *testing.T) {
 			require.NoError(t, rs.DeleteNamespace(context.Background(), "user1", "A"))
 
 			require.Equal(t, []string{
-				"rules/user1/" + generateRuleObjectKey("B", "3"),
-				"rules/user1/" + generateRuleObjectKey("C", "4"),
-				"rules/user3/" + generateRuleObjectKey("third", "group"),
+				"rules/user1/" + getRulesGroupObjectKey("B", "3"),
+				"rules/user1/" + getRulesGroupObjectKey("C", "4"),
+				"rules/user3/" + getRulesGroupObjectKey("third", "group"),
 			}, getSortedObjectKeys(bucketClient))
 		}
 
@@ -219,7 +219,7 @@ func TestDelete(t *testing.T) {
 			require.NoError(t, rs.DeleteNamespace(context.Background(), "user1", ""))
 
 			require.Equal(t, []string{
-				"rules/user3/" + generateRuleObjectKey("third", "group"),
+				"rules/user3/" + getRulesGroupObjectKey("third", "group"),
 			}, getSortedObjectKeys(bucketClient))
 		}
 

--- a/pkg/ruler/rulestore/bucket_client_test.go
+++ b/pkg/ruler/rulestore/bucket_client_test.go
@@ -193,12 +193,12 @@ func TestDelete(t *testing.T) {
 			require.Error(t, rs.DeleteNamespace(canceled, "user1", ""))
 
 			require.Equal(t, []string{
-				"rules/user1/" + getRulesGroupObjectKey("A", "1"),
-				"rules/user1/" + getRulesGroupObjectKey("A", "2"),
-				"rules/user1/" + getRulesGroupObjectKey("B", "3"),
-				"rules/user1/" + getRulesGroupObjectKey("C", "4"),
-				"rules/user2/" + getRulesGroupObjectKey("second", "group"),
-				"rules/user3/" + getRulesGroupObjectKey("third", "group"),
+				"rules/user1/" + getRuleGroupObjectKey("A", "1"),
+				"rules/user1/" + getRuleGroupObjectKey("A", "2"),
+				"rules/user1/" + getRuleGroupObjectKey("B", "3"),
+				"rules/user1/" + getRuleGroupObjectKey("C", "4"),
+				"rules/user2/" + getRuleGroupObjectKey("second", "group"),
+				"rules/user3/" + getRuleGroupObjectKey("third", "group"),
 			}, getSortedObjectKeys(bucketClient))
 		}
 
@@ -208,9 +208,9 @@ func TestDelete(t *testing.T) {
 			require.NoError(t, rs.DeleteNamespace(context.Background(), "user1", "A"))
 
 			require.Equal(t, []string{
-				"rules/user1/" + getRulesGroupObjectKey("B", "3"),
-				"rules/user1/" + getRulesGroupObjectKey("C", "4"),
-				"rules/user3/" + getRulesGroupObjectKey("third", "group"),
+				"rules/user1/" + getRuleGroupObjectKey("B", "3"),
+				"rules/user1/" + getRuleGroupObjectKey("C", "4"),
+				"rules/user3/" + getRuleGroupObjectKey("third", "group"),
 			}, getSortedObjectKeys(bucketClient))
 		}
 
@@ -219,7 +219,7 @@ func TestDelete(t *testing.T) {
 			require.NoError(t, rs.DeleteNamespace(context.Background(), "user1", ""))
 
 			require.Equal(t, []string{
-				"rules/user3/" + getRulesGroupObjectKey("third", "group"),
+				"rules/user3/" + getRuleGroupObjectKey("third", "group"),
 			}, getSortedObjectKeys(bucketClient))
 		}
 


### PR DESCRIPTION
**What this PR does**:
In the PR https://github.com/cortexproject/cortex/pull/3867 I've backported the recursive `bucket.Iter()` support. In this PR I'm using it to optimise `BucketRuleStore` implementation.

Few other changes done along the way to `BucketRuleStore`:
- Refactored generateRuleObjectKey() for better clarity
- Updated functions comments
- Added 'user' to all logs

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
