### PR TITLE
Add JSON tags to Limits object for JSON serialization

### DIFF
--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"time"
@@ -32,68 +33,68 @@ func (e LimitError) Error() string {
 // limits via flags, or per-user limits via yaml config.
 type Limits struct {
 	// Distributor enforced limits.
-	IngestionRate             float64             `yaml:"ingestion_rate"`
-	IngestionRateStrategy     string              `yaml:"ingestion_rate_strategy"`
-	IngestionBurstSize        int                 `yaml:"ingestion_burst_size"`
-	AcceptHASamples           bool                `yaml:"accept_ha_samples"`
-	HAClusterLabel            string              `yaml:"ha_cluster_label"`
-	HAReplicaLabel            string              `yaml:"ha_replica_label"`
-	HAMaxClusters             int                 `yaml:"ha_max_clusters"`
-	DropLabels                flagext.StringSlice `yaml:"drop_labels"`
-	MaxLabelNameLength        int                 `yaml:"max_label_name_length"`
-	MaxLabelValueLength       int                 `yaml:"max_label_value_length"`
-	MaxLabelNamesPerSeries    int                 `yaml:"max_label_names_per_series"`
-	MaxMetadataLength         int                 `yaml:"max_metadata_length"`
-	RejectOldSamples          bool                `yaml:"reject_old_samples"`
-	RejectOldSamplesMaxAge    time.Duration       `yaml:"reject_old_samples_max_age"`
-	CreationGracePeriod       time.Duration       `yaml:"creation_grace_period"`
-	EnforceMetadataMetricName bool                `yaml:"enforce_metadata_metric_name"`
-	EnforceMetricName         bool                `yaml:"enforce_metric_name"`
-	IngestionTenantShardSize  int                 `yaml:"ingestion_tenant_shard_size"`
-	MetricRelabelConfigs      []*relabel.Config   `yaml:"metric_relabel_configs,omitempty" doc:"nocli|description=List of metric relabel configurations. Note that in most situations, it is more effective to use metrics relabeling directly in the Prometheus server, e.g. remote_write.write_relabel_configs."`
+	IngestionRate             float64             `yaml:"ingestion_rate" json:"ingestion_rate"`
+	IngestionRateStrategy     string              `yaml:"ingestion_rate_strategy" json:"ingestion_rate_strategy"`
+	IngestionBurstSize        int                 `yaml:"ingestion_burst_size" json:"ingestion_burst_size"`
+	AcceptHASamples           bool                `yaml:"accept_ha_samples" json:"accept_ha_samples"`
+	HAClusterLabel            string              `yaml:"ha_cluster_label" json:"ha_cluster_label"`
+	HAReplicaLabel            string              `yaml:"ha_replica_label" json:"ha_replica_label"`
+	HAMaxClusters             int                 `yaml:"ha_max_clusters" json:"ha_max_clusters"`
+	DropLabels                flagext.StringSlice `yaml:"drop_labels" json:"drop_labels"`
+	MaxLabelNameLength        int                 `yaml:"max_label_name_length" json:"max_label_name_length"`
+	MaxLabelValueLength       int                 `yaml:"max_label_value_length" json:"max_label_value_length"`
+	MaxLabelNamesPerSeries    int                 `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
+	MaxMetadataLength         int                 `yaml:"max_metadata_length" json:"max_metadata_length"`
+	RejectOldSamples          bool                `yaml:"reject_old_samples" json:"reject_old_samples"`
+	RejectOldSamplesMaxAge    time.Duration       `yaml:"reject_old_samples_max_age" json:"reject_old_samples_max_age"`
+	CreationGracePeriod       time.Duration       `yaml:"creation_grace_period" json:"creation_grace_period"`
+	EnforceMetadataMetricName bool                `yaml:"enforce_metadata_metric_name" json:"enforce_metadata_metric_name"`
+	EnforceMetricName         bool                `yaml:"enforce_metric_name" json:"enforce_metric_name"`
+	IngestionTenantShardSize  int                 `yaml:"ingestion_tenant_shard_size" json:"ingestion_tenant_shard_size"`
+	MetricRelabelConfigs      []*relabel.Config   `yaml:"metric_relabel_configs,omitempty" json:"metric_relabel_configs,omitempty" doc:"nocli|description=List of metric relabel configurations. Note that in most situations, it is more effective to use metrics relabeling directly in the Prometheus server, e.g. remote_write.write_relabel_configs."`
 
 	// Ingester enforced limits.
 	// Series
-	MaxSeriesPerQuery        int `yaml:"max_series_per_query"`
-	MaxSamplesPerQuery       int `yaml:"max_samples_per_query"`
-	MaxLocalSeriesPerUser    int `yaml:"max_series_per_user"`
-	MaxLocalSeriesPerMetric  int `yaml:"max_series_per_metric"`
-	MaxGlobalSeriesPerUser   int `yaml:"max_global_series_per_user"`
-	MaxGlobalSeriesPerMetric int `yaml:"max_global_series_per_metric"`
-	MinChunkLength           int `yaml:"min_chunk_length"`
+	MaxSeriesPerQuery        int `yaml:"max_series_per_query" json:"max_series_per_query"`
+	MaxSamplesPerQuery       int `yaml:"max_samples_per_query" json:"max_samples_per_query"`
+	MaxLocalSeriesPerUser    int `yaml:"max_series_per_user" json:"max_series_per_user"`
+	MaxLocalSeriesPerMetric  int `yaml:"max_series_per_metric" json:"max_series_per_metric"`
+	MaxGlobalSeriesPerUser   int `yaml:"max_global_series_per_user" json:"max_global_series_per_user"`
+	MaxGlobalSeriesPerMetric int `yaml:"max_global_series_per_metric" json:"max_global_series_per_metric"`
+	MinChunkLength           int `yaml:"min_chunk_length" json:"min_chunk_length"`
 	// Metadata
-	MaxLocalMetricsWithMetadataPerUser  int `yaml:"max_metadata_per_user"`
-	MaxLocalMetadataPerMetric           int `yaml:"max_metadata_per_metric"`
-	MaxGlobalMetricsWithMetadataPerUser int `yaml:"max_global_metadata_per_user"`
-	MaxGlobalMetadataPerMetric          int `yaml:"max_global_metadata_per_metric"`
+	MaxLocalMetricsWithMetadataPerUser  int `yaml:"max_metadata_per_user" json:"max_metadata_per_user"`
+	MaxLocalMetadataPerMetric           int `yaml:"max_metadata_per_metric" json:"max_metadata_per_metric"`
+	MaxGlobalMetricsWithMetadataPerUser int `yaml:"max_global_metadata_per_user" json:"max_global_metadata_per_user"`
+	MaxGlobalMetadataPerMetric          int `yaml:"max_global_metadata_per_metric" json:"max_global_metadata_per_metric"`
 
 	// Querier enforced limits.
-	MaxChunksPerQuery    int            `yaml:"max_chunks_per_query"`
-	MaxQueryLookback     model.Duration `yaml:"max_query_lookback"`
-	MaxQueryLength       time.Duration  `yaml:"max_query_length"`
-	MaxQueryParallelism  int            `yaml:"max_query_parallelism"`
-	CardinalityLimit     int            `yaml:"cardinality_limit"`
-	MaxCacheFreshness    time.Duration  `yaml:"max_cache_freshness"`
-	MaxQueriersPerTenant int            `yaml:"max_queriers_per_tenant"`
+	MaxChunksPerQuery    int            `yaml:"max_chunks_per_query" json:"max_chunks_per_query"`
+	MaxQueryLookback     model.Duration `yaml:"max_query_lookback" json:"max_query_lookback"`
+	MaxQueryLength       time.Duration  `yaml:"max_query_length" json:"max_query_length"`
+	MaxQueryParallelism  int            `yaml:"max_query_parallelism" json:"max_query_parallelism"`
+	CardinalityLimit     int            `yaml:"cardinality_limit" json:"cardinality_limit"`
+	MaxCacheFreshness    time.Duration  `yaml:"max_cache_freshness" json:"max_cache_freshness"`
+	MaxQueriersPerTenant int            `yaml:"max_queriers_per_tenant" json:"max_queriers_per_tenant"`
 
 	// Ruler defaults and limits.
-	RulerEvaluationDelay        time.Duration `yaml:"ruler_evaluation_delay_duration"`
-	RulerTenantShardSize        int           `yaml:"ruler_tenant_shard_size"`
-	RulerMaxRulesPerRuleGroup   int           `yaml:"ruler_max_rules_per_rule_group"`
-	RulerMaxRuleGroupsPerTenant int           `yaml:"ruler_max_rule_groups_per_tenant"`
+	RulerEvaluationDelay        time.Duration `yaml:"ruler_evaluation_delay_duration" json:"ruler_evaluation_delay_duration"`
+	RulerTenantShardSize        int           `yaml:"ruler_tenant_shard_size" json:"ruler_tenant_shard_size"`
+	RulerMaxRulesPerRuleGroup   int           `yaml:"ruler_max_rules_per_rule_group" json:"ruler_max_rules_per_rule_group"`
+	RulerMaxRuleGroupsPerTenant int           `yaml:"ruler_max_rule_groups_per_tenant" json:"ruler_max_rule_groups_per_tenant"`
 
 	// Store-gateway.
-	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size"`
+	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size" json:"store_gateway_tenant_shard_size"`
 
 	// This config doesn't have a CLI flag registered here because they're registered in
 	// their own original config struct.
-	S3SSEType                 string `yaml:"s3_sse_type" doc:"nocli|description=S3 server-side encryption type. Required to enable server-side encryption overrides for a specific tenant. If not set, the default S3 client settings are used."`
-	S3SSEKMSKeyID             string `yaml:"s3_sse_kms_key_id" doc:"nocli|description=S3 server-side encryption KMS Key ID. Ignored if the SSE type override is not set."`
-	S3SSEKMSEncryptionContext string `yaml:"s3_sse_kms_encryption_context" doc:"nocli|description=S3 server-side encryption KMS encryption context. If unset and the key ID override is set, the encryption context will not be provided to S3. Ignored if the SSE type override is not set."`
+	S3SSEType                 string `yaml:"s3_sse_type" json:"s3_sse_type" doc:"nocli|description=S3 server-side encryption type. Required to enable server-side encryption overrides for a specific tenant. If not set, the default S3 client settings are used."`
+	S3SSEKMSKeyID             string `yaml:"s3_sse_kms_key_id" json:"s3_sse_kms_key_id" doc:"nocli|description=S3 server-side encryption KMS Key ID. Ignored if the SSE type override is not set."`
+	S3SSEKMSEncryptionContext string `yaml:"s3_sse_kms_encryption_context" json:"s3_sse_kms_encryption_context" doc:"nocli|description=S3 server-side encryption KMS encryption context. If unset and the key ID override is set, the encryption context will not be provided to S3. Ignored if the SSE type override is not set."`
 
 	// Config for overrides, convenient if it goes here. [Deprecated in favor of RuntimeConfig flag in cortex.Config]
-	PerTenantOverrideConfig string        `yaml:"per_tenant_override_config"`
-	PerTenantOverridePeriod time.Duration `yaml:"per_tenant_override_period"`
+	PerTenantOverrideConfig string        `yaml:"per_tenant_override_config" json:"per_tenant_override_config"`
+	PerTenantOverridePeriod time.Duration `yaml:"per_tenant_override_period" json:"per_tenant_override_period"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -164,7 +165,7 @@ func (l *Limits) Validate(shardByAllLabels bool) error {
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// We want to set c to the defaults and then overwrite it with the input.
+	// We want to set l to the defaults and then overwrite it with the input.
 	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
 	// again, we have to hide it using a type indirection.  See prometheus/config.
 
@@ -174,6 +175,19 @@ func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	type plain Limits
 	return unmarshal((*plain)(l))
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (l *Limits) UnmarshalJSON(data []byte) error {
+	// Like the YAML method above, we want to set l to the defaults and then overwrite
+	// it with the input. We prevent an infinite loop of calling UnmarshalJSON by hiding
+	// behind type indirection.
+	if defaultLimits != nil {
+		*l = *defaultLimits
+	}
+
+	type plain Limits
+	return json.Unmarshal(data, (*plain)(l))
 }
 
 // When we load YAML from disk, we want the various per-customer limits

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -130,23 +130,22 @@ func TestLimitsLoadingFromJson(t *testing.T) {
 func TestLimitsTagsYamlMatchJson(t *testing.T) {
 	limits := reflect.TypeOf(Limits{})
 	n := limits.NumField()
-
-	yamlTags := 0
-	jsonTags := 0
+	var mismatch []string
 
 	for i := 0; i < n; i++ {
 		field := limits.Field(i)
 
-		if field.Tag.Get("yaml") != "" {
-			yamlTags++
-		}
+		// Note that we aren't requiring YAML and JSON tags to match, just that
+		// they either both exist or both don't exist.
+		hasYamlTag := field.Tag.Get("yaml") != ""
+		hasJsonTag := field.Tag.Get("json") != ""
 
-		if field.Tag.Get("json") != "" {
-			jsonTags++
+		if hasYamlTag != hasJsonTag {
+			mismatch = append(mismatch, field.Name)
 		}
 	}
 
-	assert.Equal(t, yamlTags, jsonTags, "number of yaml and json tags should match")
+	assert.Empty(t, mismatch, "expected no mismatched JSON and YAML tags")
 }
 
 func TestMetricRelabelConfigLimitsLoadingFromYaml(t *testing.T) {

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -137,10 +137,10 @@ func TestLimitsTagsYamlMatchJson(t *testing.T) {
 
 		// Note that we aren't requiring YAML and JSON tags to match, just that
 		// they either both exist or both don't exist.
-		hasYamlTag := field.Tag.Get("yaml") != ""
-		hasJsonTag := field.Tag.Get("json") != ""
+		hasYAMLTag := field.Tag.Get("yaml") != ""
+		hasJSONTag := field.Tag.Get("json") != ""
 
-		if hasYamlTag != hasJsonTag {
+		if hasYAMLTag != hasJSONTag {
 			mismatch = append(mismatch, field.Name)
 		}
 	}

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -1,6 +1,8 @@
 package validation
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -108,6 +110,43 @@ func TestLimitsLoadingFromYaml(t *testing.T) {
 
 	assert.Equal(t, 0.5, l.IngestionRate, "from yaml")
 	assert.Equal(t, 100, l.MaxLabelNameLength, "from defaults")
+}
+
+func TestLimitsLoadingFromJson(t *testing.T) {
+	SetDefaultLimitsForYAMLUnmarshalling(Limits{
+		MaxLabelNameLength: 100,
+	})
+
+	inp := `{"ingestion_rate": 0.5}`
+
+	l := Limits{}
+	err := json.Unmarshal([]byte(inp), &l)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0.5, l.IngestionRate, "from json")
+	assert.Equal(t, 100, l.MaxLabelNameLength, "from defaults")
+}
+
+func TestLimitsTagsYamlMatchJson(t *testing.T) {
+	limits := reflect.TypeOf(Limits{})
+	n := limits.NumField()
+
+	yamlTags := 0
+	jsonTags := 0
+
+	for i := 0; i < n; i++ {
+		field := limits.Field(i)
+
+		if field.Tag.Get("yaml") != "" {
+			yamlTags++
+		}
+
+		if field.Tag.Get("json") != "" {
+			jsonTags++
+		}
+	}
+
+	assert.Equal(t, yamlTags, jsonTags, "number of yaml and json tags should match")
 }
 
 func TestMetricRelabelConfigLimitsLoadingFromYaml(t *testing.T) {


### PR DESCRIPTION
This allows Limits objects to be included in JSON HTTP APIs by
downstream Cortex consumers.

Command run to update the tags:

```
perl -pi -e 's/`yaml:"([\w,\-]+)"/`yaml:"$1" json:"$1"/' pkg/util/validation/limits.go
```

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**
- [x] Tests updated