### PR TITLE
Enforce series and sample limits on streaming queries to ingester from querier

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -49,7 +49,8 @@ import (
 var (
 	errFail       = fmt.Errorf("Fail")
 	emptyResponse = &cortexpb.WriteResponse{}
-	ctx           = user.InjectOrgID(context.Background(), "user")
+	testUserID    = "user"
+	ctx           = user.InjectOrgID(context.Background(), testUserID)
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -710,12 +711,12 @@ func TestDistributor_PushQuery(t *testing.T) {
 			assert.Equal(t, &cortexpb.WriteResponse{}, writeResponse)
 			assert.Nil(t, err)
 
-			response, err := ds[0].Query(ctx, 0, 10, tc.matchers...)
+			response, err := ds[0].Query(ctx, testUserID, 0, 10, tc.matchers...)
 			sort.Sort(response)
 			assert.Equal(t, tc.expectedResponse, response)
 			assert.Equal(t, tc.expectedError, err)
 
-			series, err := ds[0].QueryStream(ctx, 0, 10, tc.matchers...)
+			series, err := ds[0].QueryStream(ctx, testUserID, 0, 10, tc.matchers...)
 			assert.Equal(t, tc.expectedError, err)
 
 			if series == nil {
@@ -1006,10 +1007,10 @@ func TestSlowQueries(t *testing.T) {
 				})
 				defer stopAll(ds, r)
 
-				_, err := ds[0].Query(ctx, 0, 10, nameMatcher)
+				_, err := ds[0].Query(ctx, testUserID, 0, 10, nameMatcher)
 				assert.Equal(t, expectedErr, err)
 
-				_, err = ds[0].QueryStream(ctx, 0, 10, nameMatcher)
+				_, err = ds[0].QueryStream(ctx, testUserID, 0, 10, nameMatcher)
 				assert.Equal(t, expectedErr, err)
 			})
 		}

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -249,6 +249,10 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, userID string, re
 		}
 	}
 
+	if len(hashToChunkseries) > maxSeries || len(hashToTimeSeries) > maxSeries {
+		return nil, fmt.Errorf("exceeded maximum number of series in a query (limit %d)", maxSeries)
+	}
+
 	resp := &ingester_client.QueryStreamResponse{
 		Chunkseries: make([]ingester_client.TimeSeriesChunk, 0, len(hashToChunkseries)),
 		Timeseries:  make([]ingester_client.TimeSeries, 0, len(hashToTimeSeries)),

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -737,10 +737,10 @@ type errDistributor struct{}
 
 var errDistributorError = fmt.Errorf("errDistributorError")
 
-func (m *errDistributor) Query(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error) {
+func (m *errDistributor) Query(ctx context.Context, userID string, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error) {
 	return nil, errDistributorError
 }
-func (m *errDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
+func (m *errDistributor) QueryStream(ctx context.Context, userID string, from, to model.Time, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
 	return nil, errDistributorError
 }
 func (m *errDistributor) LabelValuesForLabelName(context.Context, model.Time, model.Time, model.LabelName, ...*labels.Matcher) ([]string, error) {
@@ -777,11 +777,11 @@ func (c *emptyChunkStore) IsCalled() bool {
 
 type emptyDistributor struct{}
 
-func (d *emptyDistributor) Query(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error) {
+func (d *emptyDistributor) Query(ctx context.Context, userID string, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error) {
 	return nil, nil
 }
 
-func (d *emptyDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
+func (d *emptyDistributor) QueryStream(ctx context.Context, userID string, from, to model.Time, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
 	return &client.QueryStreamResponse{}, nil
 }
 


### PR DESCRIPTION
**What this PR does**:
Count how many series and samples have been received by the querier, and stop processing if the limit is exceeded.

I check the sample limit only when samples are received (not chunks) and only after de-duplicating, which means the limit isn't very good protection against memory blow-up.

I also refactored the way `userID` is received by `Query()` and `QueryStream()` functions: I changed it from an indirect property of the `Context` to an explicit parameter. I needed `userID` to find the limits and couldn't bear adding another call to `tenant.TenantID()`.

I haven't renamed the CLI flags from `ingester.max...`; thought I would post this as a draft and see what people think.

**Which issue(s) this PR fixes**:
Partial fix for #3669

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
