### PR TITLE
Add thanosconvert binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ cmd/test-exporter/test-exporter
 cmd/cortex/cortex
 cmd/query-tee/query-tee
 cmd/blocksconvert/blocksconvert
+cmd/thanosconvert/thanosconvert
 .uptodate
 .pkg
 .cache


### PR DESCRIPTION
To tidy up my screen.

There is a second group of lines with comment `# Binaries built from ./cmd`, but I couldn't work out what that was for so I left it alone.
