### PR TITLE
blocksconvert: optionally reduce timestamp jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 * [BUGFIX] Ruler Storage: ignore objects with empty namespace or group in the name. #3999
 * [BUGFIX] Distributor: fix issue causing distributors to not extend the replication set because of failing instances when zone-aware replication is enabled. #3977
 
+## Blocksconvert
+
+* [ENHANCEMENT] Builder: add `-builder.timestamp-tolerance` option which may reduce block size by rounding timestamps to make difference whole seconds. #3891
+
 ## 1.8.0 in progress
 
 * [CHANGE] Alertmanager: Don't expose cluster information to tenants via the `/alertmanager/api/v1/status` API endpoint when operating with clustering enabled.

--- a/tools/blocksconvert/builder/builder.go
+++ b/tools/blocksconvert/builder/builder.go
@@ -38,10 +38,11 @@ type Config struct {
 	OutputDirectory string
 	Concurrency     int
 
-	ChunkCacheConfig cache.Config
-	UploadBlock      bool
-	DeleteLocalBlock bool
-	SeriesBatchSize  int
+	ChunkCacheConfig   cache.Config
+	UploadBlock        bool
+	DeleteLocalBlock   bool
+	SeriesBatchSize    int
+	TimestampTolerance int
 
 	PlanProcessorConfig planprocessor.Config
 }
@@ -55,6 +56,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.UploadBlock, "builder.upload", true, "Upload generated blocks to storage.")
 	f.BoolVar(&cfg.DeleteLocalBlock, "builder.delete-local-blocks", true, "Delete local files after uploading block.")
 	f.IntVar(&cfg.SeriesBatchSize, "builder.series-batch-size", defaultSeriesBatchSize, "Number of series to keep in memory before batch-write to temp file. Lower to decrease memory usage during the block building.")
+	f.IntVar(&cfg.TimestampTolerance, "builder.timestamp-tolerance", 0, "Adjust sample timestamps by up to this many ms to align them to an exact number of seconds apart.")
 }
 
 func NewBuilder(cfg Config, scfg blocksconvert.SharedConfig, l log.Logger, reg prometheus.Registerer) (services.Service, error) {
@@ -195,7 +197,7 @@ func (p *builderProcessor) ProcessPlanEntries(ctx context.Context, planEntryCh c
 		return "", errors.Wrap(err, "failed to create chunk fetcher")
 	}
 
-	tsdbBuilder, err := newTsdbBuilder(p.builder.cfg.OutputDirectory, p.dayStart, p.dayEnd, p.builder.cfg.SeriesBatchSize, p.log,
+	tsdbBuilder, err := newTsdbBuilder(p.builder.cfg.OutputDirectory, p.dayStart, p.dayEnd, p.builder.cfg.TimestampTolerance, p.builder.cfg.SeriesBatchSize, p.log,
 		p.builder.processedSeries, p.builder.writtenSamples, p.builder.seriesInMemory)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create TSDB builder")

--- a/tools/blocksconvert/builder/builder.go
+++ b/tools/blocksconvert/builder/builder.go
@@ -42,7 +42,7 @@ type Config struct {
 	UploadBlock        bool
 	DeleteLocalBlock   bool
 	SeriesBatchSize    int
-	TimestampTolerance int
+	TimestampTolerance time.Duration
 
 	PlanProcessorConfig planprocessor.Config
 }
@@ -56,7 +56,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.UploadBlock, "builder.upload", true, "Upload generated blocks to storage.")
 	f.BoolVar(&cfg.DeleteLocalBlock, "builder.delete-local-blocks", true, "Delete local files after uploading block.")
 	f.IntVar(&cfg.SeriesBatchSize, "builder.series-batch-size", defaultSeriesBatchSize, "Number of series to keep in memory before batch-write to temp file. Lower to decrease memory usage during the block building.")
-	f.IntVar(&cfg.TimestampTolerance, "builder.timestamp-tolerance", 0, "Adjust sample timestamps by up to this many ms to align them to an exact number of seconds apart.")
+	f.DurationVar(&cfg.TimestampTolerance, "builder.timestamp-tolerance", 0, "Adjust sample timestamps by up to this to align them to an exact number of seconds apart.")
 }
 
 func NewBuilder(cfg Config, scfg blocksconvert.SharedConfig, l log.Logger, reg prometheus.Registerer) (services.Service, error) {

--- a/tools/blocksconvert/builder/tsdb.go
+++ b/tools/blocksconvert/builder/tsdb.go
@@ -45,8 +45,9 @@ type tsdbBuilder struct {
 	unsortedChunksWriterMu sync.Mutex
 	unsortedChunksWriter   tsdb.ChunkWriter
 
-	startTime model.Time
-	endTime   model.Time
+	startTime          model.Time
+	endTime            model.Time
+	timestampTolerance int
 
 	series    *seriesList
 	seriesDir string
@@ -56,7 +57,7 @@ type tsdbBuilder struct {
 	seriesInMemory  prometheus.Gauge
 }
 
-func newTsdbBuilder(outDir string, start, end time.Time, seriesBatchLimit int, log log.Logger, processedSeries, writtenSamples prometheus.Counter, seriesInMemory prometheus.Gauge) (*tsdbBuilder, error) {
+func newTsdbBuilder(outDir string, start, end time.Time, timestampTolerance int, seriesBatchLimit int, log log.Logger, processedSeries, writtenSamples prometheus.Counter, seriesInMemory prometheus.Gauge) (*tsdbBuilder, error) {
 	id, err := ulid.New(ulid.Now(), rand.Reader)
 	if err != nil {
 		return nil, errors.Wrap(err, "create ULID")
@@ -89,6 +90,7 @@ func newTsdbBuilder(outDir string, start, end time.Time, seriesBatchLimit int, l
 		unsortedChunksWriter: unsortedChunksWriter,
 		startTime:            model.TimeFromUnixNano(start.UnixNano()),
 		endTime:              model.TimeFromUnixNano(end.UnixNano()),
+		timestampTolerance:   timestampTolerance,
 		series:               newSeriesList(seriesBatchLimit, seriesDir),
 		seriesDir:            seriesDir,
 
@@ -138,6 +140,17 @@ func (d *tsdbBuilder) buildSingleSeries(metric labels.Labels, cs []chunk.Chunk) 
 			app, err = ch.Chunk.Appender()
 			if err != nil {
 				return err
+			}
+		}
+
+		// If gap since last scrape is very close to an exact number of seconds, tighten it up
+		if d.timestampTolerance != 0 && ch.MaxTime != 0 {
+			gap := t - ch.MaxTime
+			seconds := ((gap + 500) / 1000)
+			diff := int(gap - seconds*1000)
+			// Don't go past endTime.
+			if diff != 0 && diff >= -d.timestampTolerance && diff <= d.timestampTolerance && ch.MaxTime+seconds*1000 <= int64(d.endTime) {
+				t = ch.MaxTime + seconds*1000
 			}
 		}
 

--- a/tools/blocksconvert/builder/tsdb.go
+++ b/tools/blocksconvert/builder/tsdb.go
@@ -47,7 +47,7 @@ type tsdbBuilder struct {
 
 	startTime          model.Time
 	endTime            model.Time
-	timestampTolerance int
+	timestampTolerance int // in milliseconds
 
 	series    *seriesList
 	seriesDir string
@@ -57,7 +57,7 @@ type tsdbBuilder struct {
 	seriesInMemory  prometheus.Gauge
 }
 
-func newTsdbBuilder(outDir string, start, end time.Time, timestampTolerance int, seriesBatchLimit int, log log.Logger, processedSeries, writtenSamples prometheus.Counter, seriesInMemory prometheus.Gauge) (*tsdbBuilder, error) {
+func newTsdbBuilder(outDir string, start, end time.Time, timestampTolerance time.Duration, seriesBatchLimit int, log log.Logger, processedSeries, writtenSamples prometheus.Counter, seriesInMemory prometheus.Gauge) (*tsdbBuilder, error) {
 	id, err := ulid.New(ulid.Now(), rand.Reader)
 	if err != nil {
 		return nil, errors.Wrap(err, "create ULID")
@@ -90,7 +90,7 @@ func newTsdbBuilder(outDir string, start, end time.Time, timestampTolerance int,
 		unsortedChunksWriter: unsortedChunksWriter,
 		startTime:            model.TimeFromUnixNano(start.UnixNano()),
 		endTime:              model.TimeFromUnixNano(end.UnixNano()),
-		timestampTolerance:   timestampTolerance,
+		timestampTolerance:   int(timestampTolerance.Milliseconds()),
 		series:               newSeriesList(seriesBatchLimit, seriesDir),
 		seriesDir:            seriesDir,
 

--- a/tools/blocksconvert/builder/tsdb_test.go
+++ b/tools/blocksconvert/builder/tsdb_test.go
@@ -44,7 +44,7 @@ func TestTsdbBuilder(t *testing.T) {
 	samplesCounter := prometheus.NewCounter(prometheus.CounterOpts{})
 	inMemory := prometheus.NewGauge(prometheus.GaugeOpts{})
 
-	b, err := newTsdbBuilder(dir, yesterdayStart, yesterdayEnd, 33, util_log.Logger, seriesCounter, samplesCounter, inMemory)
+	b, err := newTsdbBuilder(dir, yesterdayStart, yesterdayEnd, 33, 0, util_log.Logger, seriesCounter, samplesCounter, inMemory)
 	require.NoError(t, err)
 
 	seriesCount := 200


### PR DESCRIPTION
Run with `-builder.timestamp-tolerance=5` to adjust sample timestamps by up to 5ms to align them to an exact number of seconds apart, thereby reducing the size of blocks in memory or on disk.

Prometheus started doing this in version 2.22, so this option is most useful for data gathered from older versions.

See https://github.com/prometheus/prometheus/issues/7846 for background info.

I have not run before/after tests with this code; I didn't know how to re-run over the same data and keep both versions for comparison.