### PR TITLE
Optimise alertmanager config loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@
 * [ENHANCEMENT] Store-gateway: added metrics to chunk buffer pool behaviour. #3880
   * `cortex_bucket_store_chunk_pool_requested_bytes_total`
   * `cortex_bucket_store_chunk_pool_returned_bytes_total`
-* [ENHANCEMENT] Alertmanager: concurrently load alertmanager configurations from object storage. #3898
+* [ENHANCEMENT] Alertmanager: load alertmanager configurations from object storage concurrently, and only load necessary configurations, speeding configuration synchronization process and executing fewer "GET object" operations to the storage when sharding is enabled. #3898
 * [BUGFIX] Cortex: Fixed issue where fatal errors and various log messages where not logged. #3778
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 * [ENHANCEMENT] Store-gateway: added metrics to chunk buffer pool behaviour. #3880
   * `cortex_bucket_store_chunk_pool_requested_bytes_total`
   * `cortex_bucket_store_chunk_pool_returned_bytes_total`
+* [ENHANCEMENT] Alertmanager: concurrently load alertmanager configurations from object storage. #3894
 * [BUGFIX] Cortex: Fixed issue where fatal errors and various log messages where not logged. #3778
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@
 * [ENHANCEMENT] Store-gateway: added metrics to chunk buffer pool behaviour. #3880
   * `cortex_bucket_store_chunk_pool_requested_bytes_total`
   * `cortex_bucket_store_chunk_pool_returned_bytes_total`
-* [ENHANCEMENT] Alertmanager: concurrently load alertmanager configurations from object storage. #3894
+* [ENHANCEMENT] Alertmanager: concurrently load alertmanager configurations from object storage. #3898
 * [BUGFIX] Cortex: Fixed issue where fatal errors and various log messages where not logged. #3778
 * [BUGFIX] HA Tracker: don't track as error in the `cortex_kv_request_duration_seconds` metric a CAS operation intentionally aborted. #3745
 * [BUGFIX] Querier / ruler: do not log "error removing stale clients" if the ring is empty. #3761

--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -69,29 +69,6 @@ func (s *BucketAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string
 	return cfgs, nil
 }
 
-// ListAlertConfigs implements alertstore.AlertStore.
-func (s *BucketAlertStore) ListAlertConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error) {
-	cfgs := map[string]alertspb.AlertConfigDesc{}
-
-	err := s.bucket.Iter(ctx, "", func(key string) error {
-		userID := key
-
-		cfg, err := s.getAlertConfig(ctx, userID)
-		if err != nil {
-			return errors.Wrapf(err, "failed to fetch alertmanager config for user %s", userID)
-		}
-
-		cfgs[cfg.User] = cfg
-		return nil
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return cfgs, nil
-}
-
 // GetAlertConfig implements alertstore.AlertStore.
 func (s *BucketAlertStore) GetAlertConfig(ctx context.Context, userID string) (alertspb.AlertConfigDesc, error) {
 	cfg, err := s.getAlertConfig(ctx, userID)

--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -51,6 +51,24 @@ func (s *BucketAlertStore) ListAllUsers(ctx context.Context) ([]string, error) {
 	return userIDs, nil
 }
 
+// GetAlertConfigs implements alertstore.AlertStore.
+func (s *BucketAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error) {
+	cfgs := make(map[string]alertspb.AlertConfigDesc, len(userIDs))
+
+	for _, userID := range userIDs {
+		cfg, err := s.getAlertConfig(ctx, userID)
+		if s.bucket.IsObjNotFoundErr(err) {
+			continue
+		} else if err != nil {
+			return nil, errors.Wrapf(err, "failed to fetch alertmanager config for user %s", userID)
+		}
+
+		cfgs[userID] = cfg
+	}
+
+	return cfgs, nil
+}
+
 // ListAlertConfigs implements alertstore.AlertStore.
 func (s *BucketAlertStore) ListAlertConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error) {
 	cfgs := map[string]alertspb.AlertConfigDesc{}

--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -35,6 +35,22 @@ func NewBucketAlertStore(bkt objstore.Bucket, cfgProvider bucket.TenantConfigPro
 	}
 }
 
+// ListAllUsers implements alertstore.AlertStore.
+func (s *BucketAlertStore) ListAllUsers(ctx context.Context) ([]string, error) {
+	var userIDs []string
+
+	err := s.bucket.Iter(ctx, "", func(key string) error {
+		userIDs = append(userIDs, key)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return userIDs, nil
+}
+
 // ListAlertConfigs implements alertstore.AlertStore.
 func (s *BucketAlertStore) ListAlertConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error) {
 	cfgs := map[string]alertspb.AlertConfigDesc{}

--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -59,7 +59,9 @@ func (s *BucketAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string
 		cfgs   = make(map[string]alertspb.AlertConfigDesc, len(userIDs))
 	)
 
-	err := concurrency.ForEachUser(ctx, userIDs, fetchConcurrency, func(ctx context.Context, userID string) error {
+	err := concurrency.ForEach(ctx, concurrency.CreateJobsFromStrings(userIDs), fetchConcurrency, func(ctx context.Context, job interface{}) error {
+		userID := job.(string)
+
 		cfg, err := s.getAlertConfig(ctx, userID)
 		if s.bucket.IsObjNotFoundErr(err) {
 			return nil

--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -49,11 +49,7 @@ func (s *BucketAlertStore) ListAllUsers(ctx context.Context) ([]string, error) {
 		return nil
 	})
 
-	if err != nil {
-		return nil, err
-	}
-
-	return userIDs, nil
+	return userIDs, err
 }
 
 // GetAlertConfigs implements alertstore.AlertStore.
@@ -78,11 +74,7 @@ func (s *BucketAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string
 		return nil
 	})
 
-	if err != nil {
-		return nil, err
-	}
-
-	return cfgs, nil
+	return cfgs, err
 }
 
 // GetAlertConfig implements alertstore.AlertStore.

--- a/pkg/alertmanager/alertstore/configdb/store.go
+++ b/pkg/alertmanager/alertstore/configdb/store.go
@@ -94,7 +94,6 @@ func (c *Store) DeleteAlertConfig(ctx context.Context, user string) error {
 
 func (c *Store) reloadConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error) {
 	configs, err := c.configClient.GetAlerts(ctx, c.since)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/alertmanager/alertstore/configdb/store.go
+++ b/pkg/alertmanager/alertstore/configdb/store.go
@@ -48,6 +48,24 @@ func (c *Store) ListAllUsers(ctx context.Context) ([]string, error) {
 	return userIDs, nil
 }
 
+// GetAlertConfigs implements alertstore.AlertStore.
+func (c *Store) GetAlertConfigs(ctx context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error) {
+	// Refresh the local state.
+	configs, err := c.reloadConfigs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make(map[string]alertspb.AlertConfigDesc, len(userIDs))
+	for _, userID := range userIDs {
+		if cfg, ok := configs[userID]; ok {
+			filtered[userID] = cfg
+		}
+	}
+
+	return filtered, nil
+}
+
 // ListAlertConfigs implements alertstore.AlertStore.
 func (c *Store) ListAlertConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error) {
 	return c.reloadConfigs(ctx)
@@ -55,7 +73,7 @@ func (c *Store) ListAlertConfigs(ctx context.Context) (map[string]alertspb.Alert
 
 // GetAlertConfig implements alertstore.AlertStore.
 func (c *Store) GetAlertConfig(ctx context.Context, user string) (alertspb.AlertConfigDesc, error) {
-	// Refresh the local state before fetching a specific one.
+	// Refresh the local state.
 	configs, err := c.reloadConfigs(ctx)
 	if err != nil {
 		return alertspb.AlertConfigDesc{}, err

--- a/pkg/alertmanager/alertstore/configdb/store.go
+++ b/pkg/alertmanager/alertstore/configdb/store.go
@@ -66,11 +66,6 @@ func (c *Store) GetAlertConfigs(ctx context.Context, userIDs []string) (map[stri
 	return filtered, nil
 }
 
-// ListAlertConfigs implements alertstore.AlertStore.
-func (c *Store) ListAlertConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error) {
-	return c.reloadConfigs(ctx)
-}
-
 // GetAlertConfig implements alertstore.AlertStore.
 func (c *Store) GetAlertConfig(ctx context.Context, user string) (alertspb.AlertConfigDesc, error) {
 	// Refresh the local state.

--- a/pkg/alertmanager/alertstore/configdb/store.go
+++ b/pkg/alertmanager/alertstore/configdb/store.go
@@ -33,9 +33,53 @@ func NewStore(c client.Client) *Store {
 	}
 }
 
+// ListAllUsers implements alertstore.AlertStore.
+func (c *Store) ListAllUsers(ctx context.Context) ([]string, error) {
+	configs, err := c.reloadConfigs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	userIDs := make([]string, 0, len(configs))
+	for userID := range configs {
+		userIDs = append(userIDs, userID)
+	}
+
+	return userIDs, nil
+}
+
 // ListAlertConfigs implements alertstore.AlertStore.
 func (c *Store) ListAlertConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error) {
+	return c.reloadConfigs(ctx)
+}
 
+// GetAlertConfig implements alertstore.AlertStore.
+func (c *Store) GetAlertConfig(ctx context.Context, user string) (alertspb.AlertConfigDesc, error) {
+	// Refresh the local state before fetching a specific one.
+	configs, err := c.reloadConfigs(ctx)
+	if err != nil {
+		return alertspb.AlertConfigDesc{}, err
+	}
+
+	cfg, exists := configs[user]
+	if !exists {
+		return alertspb.AlertConfigDesc{}, alertspb.ErrNotFound
+	}
+
+	return cfg, nil
+}
+
+// SetAlertConfig implements alertstore.AlertStore.
+func (c *Store) SetAlertConfig(ctx context.Context, cfg alertspb.AlertConfigDesc) error {
+	return errReadOnly
+}
+
+// DeleteAlertConfig implements alertstore.AlertStore.
+func (c *Store) DeleteAlertConfig(ctx context.Context, user string) error {
+	return errReadOnly
+}
+
+func (c *Store) reloadConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error) {
 	configs, err := c.configClient.GetAlerts(ctx, c.since)
 
 	if err != nil {
@@ -66,32 +110,4 @@ func (c *Store) ListAlertConfigs(ctx context.Context) (map[string]alertspb.Alert
 	c.since = configs.GetLatestConfigID()
 
 	return c.alertConfigs, nil
-}
-
-// GetAlertConfig implements alertstore.AlertStore.
-func (c *Store) GetAlertConfig(ctx context.Context, user string) (alertspb.AlertConfigDesc, error) {
-
-	// Refresh the local state before fetching an specific one.
-	_, err := c.ListAlertConfigs(ctx)
-	if err != nil {
-		return alertspb.AlertConfigDesc{}, err
-	}
-
-	cfg, exists := c.alertConfigs[user]
-
-	if !exists {
-		return alertspb.AlertConfigDesc{}, alertspb.ErrNotFound
-	}
-
-	return cfg, nil
-}
-
-// SetAlertConfig implements alertstore.AlertStore.
-func (c *Store) SetAlertConfig(ctx context.Context, cfg alertspb.AlertConfigDesc) error {
-	return errReadOnly
-}
-
-// DeleteAlertConfig implements alertstore.AlertStore.
-func (c *Store) DeleteAlertConfig(ctx context.Context, user string) error {
-	return errReadOnly
 }

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -104,13 +104,13 @@ func (f *Store) reloadConfigs() (map[string]alertspb.AlertConfigDesc, error) {
 		// Ensure the file is a valid Alertmanager Config.
 		_, err = config.LoadFile(path)
 		if err != nil {
-			return errors.Wrap(err, "unable to load file "+path)
+			return errors.Wrapf(err, "unable to load file %s", path)
 		}
 
 		// Load the file to be returned by the store.
 		content, err := ioutil.ReadFile(path)
 		if err != nil {
-			return errors.Wrap(err, "unable to read file "+path)
+			return errors.Wrapf(err, "unable to read file %s", path)
 		}
 
 		// The file name must correspond to the user tenant ID

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -57,11 +57,6 @@ func (f *Store) ListAllUsers(_ context.Context) ([]string, error) {
 	return userIDs, nil
 }
 
-// ListAlertConfigs implements alertstore.AlertStore.
-func (f *Store) ListAlertConfigs(_ context.Context) (map[string]alertspb.AlertConfigDesc, error) {
-	return f.reloadConfigs()
-}
-
 // GetAlertConfigs implements alertstore.AlertStore.
 func (c *Store) GetAlertConfigs(_ context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error) {
 	configs, err := c.reloadConfigs()

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -58,8 +58,8 @@ func (f *Store) ListAllUsers(_ context.Context) ([]string, error) {
 }
 
 // GetAlertConfigs implements alertstore.AlertStore.
-func (c *Store) GetAlertConfigs(_ context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error) {
-	configs, err := c.reloadConfigs()
+func (f *Store) GetAlertConfigs(_ context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error) {
+	configs, err := f.reloadConfigs()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -135,9 +135,5 @@ func (f *Store) reloadConfigs() (map[string]alertspb.AlertConfigDesc, error) {
 		return nil
 	})
 
-	if err != nil {
-		return nil, err
-	}
-
-	return configs, nil
+	return configs, err
 }

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -62,6 +62,23 @@ func (f *Store) ListAlertConfigs(_ context.Context) (map[string]alertspb.AlertCo
 	return f.reloadConfigs()
 }
 
+// GetAlertConfigs implements alertstore.AlertStore.
+func (c *Store) GetAlertConfigs(_ context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error) {
+	configs, err := c.reloadConfigs()
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make(map[string]alertspb.AlertConfigDesc, len(userIDs))
+	for _, userID := range userIDs {
+		if cfg, ok := configs[userID]; ok {
+			filtered[userID] = cfg
+		}
+	}
+
+	return filtered, nil
+}
+
 // GetAlertConfig implements alertstore.AlertStore.
 func (f *Store) GetAlertConfig(_ context.Context, user string) (alertspb.AlertConfigDesc, error) {
 	cfgs, err := f.reloadConfigs()

--- a/pkg/alertmanager/alertstore/local/store_test.go
+++ b/pkg/alertmanager/alertstore/local/store_test.go
@@ -61,6 +61,10 @@ func TestStore_GetAlertConfig(t *testing.T) {
 		config, err := store.GetAlertConfig(ctx, "user-1")
 		require.NoError(t, err)
 		assert.Equal(t, user1Cfg, config.RawConfig)
+
+		config, err = store.GetAlertConfig(ctx, "user-2")
+		require.NoError(t, err)
+		assert.Equal(t, user2Cfg, config.RawConfig)
 	}
 }
 

--- a/pkg/alertmanager/alertstore/local/store_test.go
+++ b/pkg/alertmanager/alertstore/local/store_test.go
@@ -1,0 +1,98 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/alertmanager/alertspb"
+)
+
+func TestStore_ListAllUsers(t *testing.T) {
+	ctx := context.Background()
+	store, storeDir := prepareLocalStore(t)
+
+	// The storage is empty.
+	{
+		users, err := store.ListAllUsers(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, users)
+	}
+
+	// The storage contains some users.
+	{
+		user1Cfg := prepareAlertmanagerConfig("user-1")
+		user2Cfg := prepareAlertmanagerConfig("user-2")
+		require.NoError(t, ioutil.WriteFile(filepath.Join(storeDir, "user-1.yaml"), []byte(user1Cfg), os.ModePerm))
+		require.NoError(t, ioutil.WriteFile(filepath.Join(storeDir, "user-2.yaml"), []byte(user2Cfg), os.ModePerm))
+
+		// The following file is expected to be skipped.
+		require.NoError(t, ioutil.WriteFile(filepath.Join(storeDir, "user-3.unsupported-extension"), []byte{}, os.ModePerm))
+
+		users, err := store.ListAllUsers(ctx)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"user-1", "user-2"}, users)
+	}
+}
+
+func TestAlertStore_GetAlertConfig(t *testing.T) {
+	ctx := context.Background()
+	store, storeDir := prepareLocalStore(t)
+
+	// The user has no config.
+	{
+		_, err := store.GetAlertConfig(ctx, "user-1")
+		assert.Equal(t, alertspb.ErrNotFound, err)
+	}
+
+	// The user has a config
+	{
+		user1Cfg := prepareAlertmanagerConfig("user-1")
+		user2Cfg := prepareAlertmanagerConfig("user-2")
+		require.NoError(t, ioutil.WriteFile(filepath.Join(storeDir, "user-1.yaml"), []byte(user1Cfg), os.ModePerm))
+		require.NoError(t, ioutil.WriteFile(filepath.Join(storeDir, "user-2.yaml"), []byte(user2Cfg), os.ModePerm))
+
+		config, err := store.GetAlertConfig(ctx, "user-1")
+		require.NoError(t, err)
+		assert.Equal(t, user1Cfg, config.RawConfig)
+	}
+}
+
+func prepareLocalStore(t *testing.T) (store *Store, storeDir string) {
+	var err error
+
+	// Create a temporarily directory for the storage.
+	storeDir, err = ioutil.TempDir(os.TempDir(), "local")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(storeDir))
+	})
+
+	store, err = NewStore(StoreConfig{Path: storeDir})
+	require.NoError(t, err)
+	return
+}
+
+func prepareAlertmanagerConfig(userID string) string {
+	return fmt.Sprintf(`
+global:
+  smtp_smarthost: 'localhost:25'
+  smtp_from: 'alertmanager@example.org'
+  smtp_auth_username: 'alertmanager'
+  smtp_auth_password: 'password'
+
+route:
+  receiver: send-email
+
+receivers:
+  - name: send-email
+    email_configs:
+      - to: '%s@localhost'
+`, userID)
+}

--- a/pkg/alertmanager/alertstore/objectclient/store.go
+++ b/pkg/alertmanager/alertstore/objectclient/store.go
@@ -82,11 +82,7 @@ func (a *AlertStore) GetAlertConfigs(ctx context.Context, userIDs []string) (map
 		return nil
 	})
 
-	if err != nil {
-		return nil, err
-	}
-
-	return cfgs, nil
+	return cfgs, err
 }
 
 func (a *AlertStore) getAlertConfig(ctx context.Context, key string) (alertspb.AlertConfigDesc, error) {

--- a/pkg/alertmanager/alertstore/objectclient/store.go
+++ b/pkg/alertmanager/alertstore/objectclient/store.go
@@ -67,7 +67,9 @@ func (a *AlertStore) GetAlertConfigs(ctx context.Context, userIDs []string) (map
 		cfgs   = make(map[string]alertspb.AlertConfigDesc, len(userIDs))
 	)
 
-	err := concurrency.ForEachUser(ctx, userIDs, fetchConcurrency, func(ctx context.Context, userID string) error {
+	err := concurrency.ForEach(ctx, concurrency.CreateJobsFromStrings(userIDs), fetchConcurrency, func(ctx context.Context, job interface{}) error {
+		userID := job.(string)
+
 		cfg, err := a.getAlertConfig(ctx, path.Join(alertPrefix, userID))
 		if errors.Is(err, chunk.ErrStorageObjectNotFound) {
 			return nil

--- a/pkg/alertmanager/alertstore/objectclient/store.go
+++ b/pkg/alertmanager/alertstore/objectclient/store.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io/ioutil"
 	"path"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/thanos-io/thanos/pkg/runutil"
@@ -34,6 +35,22 @@ func NewAlertStore(client chunk.ObjectClient, logger log.Logger) *AlertStore {
 		client: client,
 		logger: logger,
 	}
+}
+
+// ListAllUsers implements alertstore.AlertStore.
+func (a *AlertStore) ListAllUsers(ctx context.Context) ([]string, error) {
+	objs, _, err := a.client.List(ctx, alertPrefix, "")
+	if err != nil {
+		return nil, err
+	}
+
+	userIDs := make([]string, 0, len(objs))
+	for _, obj := range objs {
+		userID := strings.TrimPrefix(obj.Key, alertPrefix)
+		userIDs = append(userIDs, userID)
+	}
+
+	return userIDs, nil
 }
 
 // ListAlertConfigs implements alertstore.AlertStore.

--- a/pkg/alertmanager/alertstore/objectclient/store.go
+++ b/pkg/alertmanager/alertstore/objectclient/store.go
@@ -72,26 +72,6 @@ func (a *AlertStore) GetAlertConfigs(ctx context.Context, userIDs []string) (map
 	return cfgs, nil
 }
 
-// ListAlertConfigs implements alertstore.AlertStore.
-func (a *AlertStore) ListAlertConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error) {
-	objs, _, err := a.client.List(ctx, alertPrefix, "")
-	if err != nil {
-		return nil, err
-	}
-
-	cfgs := map[string]alertspb.AlertConfigDesc{}
-
-	for _, obj := range objs {
-		cfg, err := a.getAlertConfig(ctx, obj.Key)
-		if err != nil {
-			return nil, err
-		}
-		cfgs[cfg.User] = cfg
-	}
-
-	return cfgs, nil
-}
-
 func (a *AlertStore) getAlertConfig(ctx context.Context, key string) (alertspb.AlertConfigDesc, error) {
 	readCloser, err := a.client.GetObject(ctx, key)
 	if err != nil {

--- a/pkg/alertmanager/alertstore/store.go
+++ b/pkg/alertmanager/alertstore/store.go
@@ -22,6 +22,9 @@ import (
 
 // AlertStore stores and configures users rule configs
 type AlertStore interface {
+	// ListAllUsers returns all users with alertmanager configuration.
+	ListAllUsers(ctx context.Context) ([]string, error)
+
 	// ListAlertConfigs loads and returns the alertmanager configuration for all users.
 	ListAlertConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error)
 

--- a/pkg/alertmanager/alertstore/store.go
+++ b/pkg/alertmanager/alertstore/store.go
@@ -30,9 +30,6 @@ type AlertStore interface {
 	// error but the returned configs will not include the missing users.
 	GetAlertConfigs(ctx context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error)
 
-	// ListAlertConfigs loads and returns the alertmanager configuration for all users.
-	ListAlertConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error)
-
 	// GetAlertConfig loads and returns the alertmanager configuration for the given user.
 	GetAlertConfig(ctx context.Context, user string) (alertspb.AlertConfigDesc, error)
 

--- a/pkg/alertmanager/alertstore/store.go
+++ b/pkg/alertmanager/alertstore/store.go
@@ -25,7 +25,7 @@ type AlertStore interface {
 	// ListAllUsers returns all users with alertmanager configuration.
 	ListAllUsers(ctx context.Context) ([]string, error)
 
-	// GetAlertConfigs loads and returns the alertmanager configuration for all the given users.
+	// GetAlertConfigs loads and returns the alertmanager configuration for given users.
 	// If any of the provided users has no configuration, then this function does not return an
 	// error but the returned configs will not include the missing users.
 	GetAlertConfigs(ctx context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error)

--- a/pkg/alertmanager/alertstore/store.go
+++ b/pkg/alertmanager/alertstore/store.go
@@ -25,6 +25,11 @@ type AlertStore interface {
 	// ListAllUsers returns all users with alertmanager configuration.
 	ListAllUsers(ctx context.Context) ([]string, error)
 
+	// GetAlertConfigs loads and returns the alertmanager configuration for all the given users.
+	// If any of the provided users has no configuration, then this function does not return an
+	// error but the returned configs will not include the missing users.
+	GetAlertConfigs(ctx context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error)
+
 	// ListAlertConfigs loads and returns the alertmanager configuration for all users.
 	ListAlertConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error)
 

--- a/pkg/alertmanager/alertstore/store_test.go
+++ b/pkg/alertmanager/alertstore/store_test.go
@@ -15,6 +15,31 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk"
 )
 
+func TestAlertStore_ListAllUsers(t *testing.T) {
+	runForEachAlertStore(t, func(t *testing.T, store AlertStore) {
+		ctx := context.Background()
+		user1Cfg := alertspb.AlertConfigDesc{User: "user-1", RawConfig: "content-1"}
+		user2Cfg := alertspb.AlertConfigDesc{User: "user-2", RawConfig: "content-2"}
+
+		// The storage is empty.
+		{
+			users, err := store.ListAllUsers(ctx)
+			require.NoError(t, err)
+			assert.Empty(t, users)
+		}
+
+		// The storage contains some users.
+		{
+			require.NoError(t, store.SetAlertConfig(ctx, user1Cfg))
+			require.NoError(t, store.SetAlertConfig(ctx, user2Cfg))
+
+			users, err := store.ListAllUsers(ctx)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, []string{"user-1", "user-2"}, users)
+		}
+	})
+}
+
 func TestAlertStore_ListAlertConfigs(t *testing.T) {
 	runForEachAlertStore(t, func(t *testing.T, store AlertStore) {
 		ctx := context.Background()

--- a/pkg/alertmanager/alertstore/store_test.go
+++ b/pkg/alertmanager/alertstore/store_test.go
@@ -60,6 +60,10 @@ func TestAlertStore_SetAndGetAlertConfig(t *testing.T) {
 			config, err := store.GetAlertConfig(ctx, "user-1")
 			require.NoError(t, err)
 			assert.Equal(t, user1Cfg, config)
+
+			config, err = store.GetAlertConfig(ctx, "user-2")
+			require.NoError(t, err)
+			assert.Equal(t, user2Cfg, config)
 		}
 	})
 }

--- a/pkg/alertmanager/alertstore/store_test.go
+++ b/pkg/alertmanager/alertstore/store_test.go
@@ -28,7 +28,7 @@ func TestAlertStore_ListAllUsers(t *testing.T) {
 			assert.Empty(t, users)
 		}
 
-		// The storage contains some users.
+		// The storage contains users.
 		{
 			require.NoError(t, store.SetAlertConfig(ctx, user1Cfg))
 			require.NoError(t, store.SetAlertConfig(ctx, user2Cfg))

--- a/pkg/alertmanager/alertstore/store_test.go
+++ b/pkg/alertmanager/alertstore/store_test.go
@@ -92,6 +92,42 @@ func TestAlertStore_SetAndGetAlertConfig(t *testing.T) {
 	})
 }
 
+func TestStore_GetAlertConfigs(t *testing.T) {
+	runForEachAlertStore(t, func(t *testing.T, store AlertStore) {
+		ctx := context.Background()
+		user1Cfg := alertspb.AlertConfigDesc{User: "user-1", RawConfig: "content-1"}
+		user2Cfg := alertspb.AlertConfigDesc{User: "user-2", RawConfig: "content-2"}
+
+		// The storage is empty.
+		{
+			configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
+			require.NoError(t, err)
+			assert.Empty(t, configs)
+		}
+
+		// The storage contains some configs.
+		{
+			require.NoError(t, store.SetAlertConfig(ctx, user1Cfg))
+
+			configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
+			require.NoError(t, err)
+			assert.Contains(t, configs, "user-1")
+			assert.NotContains(t, configs, "user-2")
+			assert.Equal(t, user1Cfg, configs["user-1"])
+
+			// Add another user config.
+			require.NoError(t, store.SetAlertConfig(ctx, user2Cfg))
+
+			configs, err = store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
+			require.NoError(t, err)
+			assert.Contains(t, configs, "user-1")
+			assert.Contains(t, configs, "user-2")
+			assert.Equal(t, user1Cfg, configs["user-1"])
+			assert.Equal(t, user2Cfg, configs["user-2"])
+		}
+	})
+}
+
 func TestAlertStore_DeleteAlertConfig(t *testing.T) {
 	runForEachAlertStore(t, func(t *testing.T, store AlertStore) {
 		ctx := context.Background()

--- a/pkg/alertmanager/alertstore/store_test.go
+++ b/pkg/alertmanager/alertstore/store_test.go
@@ -40,34 +40,6 @@ func TestAlertStore_ListAllUsers(t *testing.T) {
 	})
 }
 
-func TestAlertStore_ListAlertConfigs(t *testing.T) {
-	runForEachAlertStore(t, func(t *testing.T, store AlertStore) {
-		ctx := context.Background()
-		user1Cfg := alertspb.AlertConfigDesc{User: "user-1", RawConfig: "content-1"}
-		user2Cfg := alertspb.AlertConfigDesc{User: "user-2", RawConfig: "content-2"}
-
-		// The storage is empty.
-		{
-			configs, err := store.ListAlertConfigs(ctx)
-			require.NoError(t, err)
-			assert.Empty(t, configs)
-		}
-
-		// The storage contains some configs.
-		{
-			require.NoError(t, store.SetAlertConfig(ctx, user1Cfg))
-			require.NoError(t, store.SetAlertConfig(ctx, user2Cfg))
-
-			configs, err := store.ListAlertConfigs(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, map[string]alertspb.AlertConfigDesc{
-				"user-1": user1Cfg,
-				"user-2": user2Cfg,
-			}, configs)
-		}
-	})
-}
-
 func TestAlertStore_SetAndGetAlertConfig(t *testing.T) {
 	runForEachAlertStore(t, func(t *testing.T, store AlertStore) {
 		ctx := context.Background()

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -2,14 +2,12 @@ package alertmanager
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/cortexproject/cortex/pkg/alertmanager/alertspb"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 
 	"github.com/stretchr/testify/require"
@@ -125,7 +123,7 @@ template_files:
 	}
 
 	am := &MultitenantAlertmanager{
-		store:  noopAlertStore{},
+		store:  prepareFilesystemAlertStore(t),
 		logger: util_log.Logger,
 	}
 	for _, tc := range testCases {
@@ -149,22 +147,4 @@ template_files:
 
 		})
 	}
-}
-
-type noopAlertStore struct{}
-
-func (noopAlertStore) ListAllUsers(ctx context.Context) ([]string, error) {
-	return nil, nil
-}
-func (noopAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error) {
-	return nil, nil
-}
-func (noopAlertStore) GetAlertConfig(ctx context.Context, user string) (alertspb.AlertConfigDesc, error) {
-	return alertspb.AlertConfigDesc{}, nil
-}
-func (noopAlertStore) SetAlertConfig(ctx context.Context, cfg alertspb.AlertConfigDesc) error {
-	return nil
-}
-func (noopAlertStore) DeleteAlertConfig(ctx context.Context, user string) error {
-	return nil
 }

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -153,6 +153,12 @@ template_files:
 
 type noopAlertStore struct{}
 
+func (noopAlertStore) ListAllUsers(ctx context.Context) ([]string, error) {
+	return nil, nil
+}
+func (noopAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error) {
+	return nil, nil
+}
 func (noopAlertStore) ListAlertConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error) {
 	return nil, nil
 }

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -159,9 +159,6 @@ func (noopAlertStore) ListAllUsers(ctx context.Context) ([]string, error) {
 func (noopAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error) {
 	return nil, nil
 }
-func (noopAlertStore) ListAlertConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error) {
-	return nil, nil
-}
 func (noopAlertStore) GetAlertConfig(ctx context.Context, user string) (alertspb.AlertConfigDesc, error) {
 	return alertspb.AlertConfigDesc{}, nil
 }

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -123,7 +123,7 @@ template_files:
 	}
 
 	am := &MultitenantAlertmanager{
-		store:  prepareFilesystemAlertStore(t),
+		store:  prepareInMemoryAlertStore(),
 		logger: util_log.Logger,
 	}
 	for _, tc := range testCases {

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"hash/fnv"
 	"html/template"
 	"io/ioutil"
 	"net/http"
@@ -571,51 +570,49 @@ func (am *MultitenantAlertmanager) stopping(_ error) error {
 
 // loadAlertmanagerConfigs Loads (and filters) the alertmanagers configuration from object storage, taking into consideration the sharding strategy.
 func (am *MultitenantAlertmanager) loadAlertmanagerConfigs(ctx context.Context) (map[string]alertspb.AlertConfigDesc, error) {
-	configs, err := am.store.ListAlertConfigs(ctx)
+	// Find all users with an alertmanager config.
+	userIDs, err := am.store.ListAllUsers(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to list users with alertmanager configuration")
 	}
+	numUsersDiscovered := len(userIDs)
 
-	// Without any sharding, we return _all_ the configs and there's nothing else for us to do.
-	if !am.cfg.ShardingEnabled {
-		am.tenantsDiscovered.Set(float64(len(configs)))
-		am.tenantsOwned.Set(float64(len(configs)))
-		return configs, nil
-	}
-
-	ownedConfigs := map[string]alertspb.AlertConfigDesc{}
-	for userID, cfg := range configs {
-		owned, err := am.isConfigOwned(userID)
-		if err != nil {
-			am.ringCheckErrors.Inc()
-			level.Error(am.logger).Log("msg", "failed to load alertmanager configuration for user", "user", userID, "err", err)
+	// Filter out users not owned by this shard.
+	for i := 0; i < len(userIDs); {
+		if !am.isUserOwned(userIDs[i]) {
+			userIDs = append(userIDs[:i], userIDs[i+1:]...)
 			continue
 		}
 
-		if owned {
-			level.Debug(am.logger).Log("msg", "alertmanager configuration owned", "user", userID)
-			ownedConfigs[userID] = cfg
-		} else {
-			level.Debug(am.logger).Log("msg", "alertmanager configuration not owned, ignoring", "user", userID)
-		}
+		i++
+	}
+	numUsersOwned := len(userIDs)
+
+	// Load the configs for the owned users.
+	configs, err := am.store.GetAlertConfigs(ctx, userIDs)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load alertmanager configurations for owned users")
 	}
 
-	am.tenantsDiscovered.Set(float64(len(configs)))
-	am.tenantsOwned.Set(float64(len(ownedConfigs)))
-	return ownedConfigs, nil
+	am.tenantsDiscovered.Set(float64(numUsersDiscovered))
+	am.tenantsOwned.Set(float64(numUsersOwned))
+	return configs, nil
 }
 
-func (am *MultitenantAlertmanager) isConfigOwned(userID string) (bool, error) {
-	ringHasher := fnv.New32a()
-	// Hasher never returns err.
-	_, _ = ringHasher.Write([]byte(userID))
-
-	alertmanagers, err := am.ring.Get(ringHasher.Sum32(), RingOp, nil, nil, nil)
-	if err != nil {
-		return false, errors.Wrap(err, "error reading ring to verify config ownership")
+func (am *MultitenantAlertmanager) isUserOwned(userID string) bool {
+	// If sharding is disabled, any alertmanager instance owns all users.
+	if !am.cfg.ShardingEnabled {
+		return true
 	}
 
-	return alertmanagers.Includes(am.ringLifecycler.GetInstanceAddr()), nil
+	alertmanagers, err := am.ring.Get(shardByUser(userID), RingOp, nil, nil, nil)
+	if err != nil {
+		am.ringCheckErrors.Inc()
+		level.Error(am.logger).Log("msg", "failed to load alertmanager configuration for user", "user", userID, "err", err)
+		return false
+	}
+
+	return alertmanagers.Includes(am.ringLifecycler.GetInstanceAddr())
 }
 
 func (am *MultitenantAlertmanager) syncConfigs(cfgs map[string]alertspb.AlertConfigDesc) {

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -608,7 +608,7 @@ func (am *MultitenantAlertmanager) isUserOwned(userID string) bool {
 	alertmanagers, err := am.ring.Get(shardByUser(userID), RingOp, nil, nil, nil)
 	if err != nil {
 		am.ringCheckErrors.Inc()
-		level.Error(am.logger).Log("msg", "failed to load alertmanager configuration for user", "user", userID, "err", err)
+		level.Error(am.logger).Log("msg", "failed to load alertmanager configuration", "user", userID, "err", err)
 		return false
 	}
 

--- a/pkg/ruler/rulestore/store.go
+++ b/pkg/ruler/rulestore/store.go
@@ -22,6 +22,7 @@ var (
 // Methods starting with "List" prefix may return partially loaded groups: with only group Name, Namespace and User fields set.
 // To make sure that rules within each group are loaded, client must use LoadRuleGroups method.
 type RuleStore interface {
+	// ListAllUsers returns all users with rule groups configured.
 	ListAllUsers(ctx context.Context) ([]string, error)
 
 	// ListAllRuleGroups returns all rule groups for all users.

--- a/pkg/util/concurrency/runner_test.go
+++ b/pkg/util/concurrency/runner_test.go
@@ -12,6 +12,66 @@ import (
 	"go.uber.org/atomic"
 )
 
+func TestForEachUser(t *testing.T) {
+	var (
+		ctx = context.Background()
+
+		// Keep track of processed users.
+		processedMx sync.Mutex
+		processed   []string
+	)
+
+	input := []string{"a", "b", "c"}
+
+	err := ForEachUser(ctx, input, 2, func(ctx context.Context, user string) error {
+		processedMx.Lock()
+		defer processedMx.Unlock()
+		processed = append(processed, user)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, input, processed)
+}
+
+func TestForEachUser_ShouldContinueOnErrorButReturnIt(t *testing.T) {
+	var (
+		ctx = context.Background()
+
+		// Keep the processed users count.
+		processed atomic.Int32
+	)
+
+	input := []string{"a", "b", "c"}
+
+	err := ForEachUser(ctx, input, 2, func(ctx context.Context, user string) error {
+		if processed.CAS(0, 1) {
+			return errors.New("the first request is failing")
+		}
+
+		// Wait 1s and increase the number of processed jobs, unless the context get canceled earlier.
+		select {
+		case <-time.After(time.Second):
+			processed.Add(1)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		return nil
+	})
+
+	require.EqualError(t, err, "the first request is failing")
+
+	// Since we expect it continues on error, the number of processed users should be equal to the input length.
+	assert.Equal(t, int32(len(input)), processed.Load())
+}
+
+func TestForEachUser_ShouldReturnImmediatelyOnNoUsersProvided(t *testing.T) {
+	require.NoError(t, ForEachUser(context.Background(), nil, 2, func(ctx context.Context, user string) error {
+		return nil
+	}))
+}
+
 func TestForEach(t *testing.T) {
 	var (
 		ctx = context.Background()
@@ -63,4 +123,10 @@ func TestForEach_ShouldBreakOnFirstError(t *testing.T) {
 	// Since we expect the first error interrupts the workers, we should only see
 	// 1 job processed (the one which immediately returned error).
 	assert.Equal(t, int32(1), processed.Load())
+}
+
+func TestForEach_ShouldReturnImmediatelyOnNoJobsProvided(t *testing.T) {
+	require.NoError(t, ForEach(context.Background(), nil, 2, func(ctx context.Context, job interface{}) error {
+		return nil
+	}))
 }

--- a/pkg/util/concurrency/runner_test.go
+++ b/pkg/util/concurrency/runner_test.go
@@ -1,0 +1,66 @@
+package concurrency
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestForEach(t *testing.T) {
+	var (
+		ctx = context.Background()
+
+		// Keep track of processed jobs.
+		processedMx sync.Mutex
+		processed   []string
+	)
+
+	jobs := []string{"a", "b", "c"}
+
+	err := ForEach(ctx, CreateJobsFromStrings(jobs), 2, func(ctx context.Context, job interface{}) error {
+		processedMx.Lock()
+		defer processedMx.Unlock()
+		processed = append(processed, job.(string))
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, jobs, processed)
+}
+
+func TestForEach_ShouldBreakOnFirstError(t *testing.T) {
+	var (
+		ctx = context.Background()
+
+		// Keep the processed jobs count.
+		processed atomic.Int32
+	)
+
+	err := ForEach(ctx, []interface{}{"a", "b", "c"}, 2, func(ctx context.Context, job interface{}) error {
+		if processed.CAS(0, 1) {
+			return errors.New("the first request is failing")
+		}
+
+		// Wait 1s and increase the number of processed jobs, unless the context get canceled earlier.
+		select {
+		case <-time.After(time.Second):
+			processed.Add(1)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		return nil
+	})
+
+	require.EqualError(t, err, "the first request is failing")
+
+	// Since we expect the first error interrupts the workers, we should only see
+	// 1 job processed (the one which immediately returned error).
+	assert.Equal(t, int32(1), processed.Load())
+}


### PR DESCRIPTION
**What this PR does**:
There are two bottlenecks in the alertmanager configs loading from the object storage:
1. Configs are loaded sequentially
2. When alertmanager sharding is enabled, we load configs for all users, regardless they're owned by the alertmanager replica

This PR addresses both issues. To do it I had to refactor the `AlertStore` interface to split between the listing of users and loading of configs for the owned users:
1. Removed `ListAlertConfigs`
2. Added `ListAllUsers` and `GetAlertConfigs` (reason why I've added `GetAlertConfigs` instead of calling `GetAlertConfig` for every user is because with `GetAlertConfigs` the configdb implementation is optimised)
3. Added concurrent fetching to `GetAlertConfigs` in the object store client implementations

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
