### PR TITLE
alertmanager/ruler: Include affected path upon config access failure

### DIFF
--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -175,12 +175,12 @@ func (s *BucketAlertStore) get(ctx context.Context, bkt objstore.Bucket, name st
 
 	buf, err := ioutil.ReadAll(readCloser)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to read alertmanager config for user %s", name)
 	}
 
 	err = proto.Unmarshal(buf, msg)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to deserialize alertmanager config for user %s", name)
 	}
 
 	return nil

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -120,7 +120,7 @@ func (f *Store) reloadConfigs() (map[string]alertspb.AlertConfigDesc, error) {
 	configs := map[string]alertspb.AlertConfigDesc{}
 	err := filepath.Walk(f.cfg.Path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.Wrap(err, "unable to walk file path")
+			return errors.Wrapf(err, "unable to walk file path at %s", path)
 		}
 
 		// Ignore files that are directories or not yaml files
@@ -132,13 +132,13 @@ func (f *Store) reloadConfigs() (map[string]alertspb.AlertConfigDesc, error) {
 		// Ensure the file is a valid Alertmanager Config.
 		_, err = config.LoadFile(path)
 		if err != nil {
-			return errors.Wrapf(err, "unable to load file %s", path)
+			return errors.Wrapf(err, "unable to load alertmanager config %s", path)
 		}
 
 		// Load the file to be returned by the store.
 		content, err := ioutil.ReadFile(path)
 		if err != nil {
-			return errors.Wrapf(err, "unable to read file %s", path)
+			return errors.Wrapf(err, "unable to read alertmanager config %s", path)
 		}
 
 		// The file name must correspond to the user tenant ID

--- a/pkg/alertmanager/alertstore/objectclient/store.go
+++ b/pkg/alertmanager/alertstore/objectclient/store.go
@@ -101,13 +101,13 @@ func (a *AlertStore) getAlertConfig(ctx context.Context, key string) (alertspb.A
 
 	buf, err := ioutil.ReadAll(readCloser)
 	if err != nil {
-		return alertspb.AlertConfigDesc{}, err
+		return alertspb.AlertConfigDesc{}, errors.Wrapf(err, "failed to read alertmanager config %s", key)
 	}
 
 	config := alertspb.AlertConfigDesc{}
 	err = config.Unmarshal(buf)
 	if err != nil {
-		return alertspb.AlertConfigDesc{}, err
+		return alertspb.AlertConfigDesc{}, errors.Wrapf(err, "failed to unmarshal alertmanager config %s", key)
 	}
 
 	return config, nil

--- a/pkg/ruler/rulestore/bucketclient/bucket_client.go
+++ b/pkg/ruler/rulestore/bucketclient/bucket_client.go
@@ -62,13 +62,13 @@ func (b *BucketRuleStore) getRuleGroup(ctx context.Context, userID, namespace, g
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to get rule group %s", objectKey)
 	}
 	defer func() { _ = reader.Close() }()
 
 	buf, err := ioutil.ReadAll(reader)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to read rule group %s", objectKey)
 	}
 
 	if rg == nil {
@@ -79,7 +79,7 @@ func (b *BucketRuleStore) getRuleGroup(ctx context.Context, userID, namespace, g
 
 	err = proto.Unmarshal(buf, rg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to unmarshal rule group %s", objectKey)
 	}
 
 	return rg, nil

--- a/pkg/ruler/rulestore/local/local.go
+++ b/pkg/ruler/rulestore/local/local.go
@@ -132,7 +132,7 @@ func (l *Client) loadAllRulesGroupsForUser(ctx context.Context, userID string) (
 	root := filepath.Join(l.cfg.Directory, userID)
 	infos, err := ioutil.ReadDir(root)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to read dir %s", root)
+		return nil, errors.Wrapf(err, "unable to read rule dir %s", root)
 	}
 
 	for _, info := range infos {
@@ -141,9 +141,10 @@ func (l *Client) loadAllRulesGroupsForUser(ctx context.Context, userID string) (
 
 		if info.Mode()&os.ModeSymlink != 0 {
 			// ioutil.ReadDir only returns result of LStat. Calling Stat resolves symlink.
-			info, err = os.Stat(filepath.Join(root, info.Name()))
+			path := filepath.Join(root, info.Name())
+			info, err = os.Stat(path)
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "unable to stat rule file %s", path)
 			}
 		}
 

--- a/pkg/ruler/rulestore/objectclient/rule_store.go
+++ b/pkg/ruler/rulestore/objectclient/rule_store.go
@@ -59,13 +59,13 @@ func (o *RuleStore) getRuleGroup(ctx context.Context, objectKey string, rg *rule
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to get rule group %s", objectKey)
 	}
 	defer func() { _ = reader.Close() }()
 
 	buf, err := ioutil.ReadAll(reader)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to read rule group %s", objectKey)
 	}
 
 	if rg == nil {
@@ -76,7 +76,7 @@ func (o *RuleStore) getRuleGroup(ctx context.Context, objectKey string, rg *rule
 
 	err = proto.Unmarshal(buf, rg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to unmarshal rule group %s", objectKey)
 	}
 
 	return rg, nil


### PR DESCRIPTION
If the alertmanager config directory contains unexpected or invalid files, mention the problematic file path alongside the underlying error.

Without the path, the problem effectively turns into a landmine, blocking even listing the contents of the bucket, with no indication of where the problem is coming from. For example this was the error on alertmanager startup when a `bucket-index.json.gz` file had gotten into the `alerts/` directory:

> level=error ts=2021-03-03T00:28:49.126516247Z caller=cortex.go:419 msg="module failed" module=alertmanager err="invalid service state: Failed, expected: Running, failure: proto: wrong wireType = 7 for field Templates"

This was originally encountered with alertmanager, but the corresponding ruler storages were updated as well for good measure.

Signed-off-by: Nick Parker <nick@nickbp.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
