### PR TITLE
Clarify that chunks WAL is different to blocks

### DIFF
--- a/docs/chunks-storage/ingesters-with-wal.md
+++ b/docs/chunks-storage/ingesters-with-wal.md
@@ -9,7 +9,7 @@ By default, ingesters running with the chunks storage, store all their data in m
 
 To use WAL, there are some changes that needs to be made in the deployment.
 
-_This documentation refers to Cortex chunks storage engine. The Cortex blocks storage has WAL always enabled._
+_This documentation refers to Cortex chunks storage engine. To understand Blocks storage please go [here](../blocks-storage/_index.md)._
 
 ## Changes to deployment
 


### PR DESCRIPTION
User did not understand that the page on WAL storage does not apply to blocks.

Ref https://cloud-native.slack.com/archives/CCYDASBLP/p1614849933207700?thread_ts=1614828385.205500&cid=CCYDASBLP
