### PR TITLE
Cleanup obsolete local files for alertmanager.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [ENHANCEMENT] Ruler: added the following metrics when ruler sharding is enabled: #3916
   * `cortex_ruler_clients`
   * `cortex_ruler_client_request_duration_seconds`
+* [ENHANCEMENT] Alertmanager: cleanup obsolete local files after Alertmanager is no longer running for removed or resharded user. #3910
 
 ## 1.8.0 in progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## master / unreleased
 
+* [CHANGE] Alertmanager: clean obsolete local files after Alertmanager is no longer running for removed or resharded user. #3910
 * [ENHANCEMENT] Ruler: optimized `<prefix>/api/v1/rules` and `<prefix>/api/v1/alerts` when ruler sharding is enabled. #3916
 * [ENHANCEMENT] Ruler: added the following metrics when ruler sharding is enabled: #3916
   * `cortex_ruler_clients`
   * `cortex_ruler_client_request_duration_seconds`
-* [ENHANCEMENT] Alertmanager: cleanup obsolete local files after Alertmanager is no longer running for removed or resharded user. #3910
 
 ## 1.8.0 in progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master / unreleased
 
 * [CHANGE] Alertmanager now removes local files after Alertmanager is no longer running for removed or resharded user. #3910
-* [CHANGE] Alertmanager now stores local files in per-tenant folders. Files stored by Alertmanager previously are migrated to new hierarchy. #3910
+* [CHANGE] Alertmanager now stores local files in per-tenant folders. Files stored by Alertmanager previously are migrated to new hierarchy. Support for this migration will be removed in Cortex 1.10. #3910
 * [ENHANCEMENT] Ruler: optimized `<prefix>/api/v1/rules` and `<prefix>/api/v1/alerts` when ruler sharding is enabled. #3916
 * [ENHANCEMENT] Ruler: added the following metrics when ruler sharding is enabled: #3916
   * `cortex_ruler_clients`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## master / unreleased
 
-* [CHANGE] Alertmanager: clean obsolete local files after Alertmanager is no longer running for removed or resharded user. #3910
+* [CHANGE] Alertmanager now removes local files after Alertmanager is no longer running for removed or resharded user. #3910
+* [CHANGE] Alertmanager now stores local files in per-tenant folders. Files stored by Alertmanager previously are migrated to new hierarchy. #3910
 * [ENHANCEMENT] Ruler: optimized `<prefix>/api/v1/rules` and `<prefix>/api/v1/alerts` when ruler sharding is enabled. #3916
 * [ENHANCEMENT] Ruler: added the following metrics when ruler sharding is enabled: #3916
   * `cortex_ruler_clients`

--- a/development/tsdb-blocks-storage-s3/config/rules.yaml
+++ b/development/tsdb-blocks-storage-s3/config/rules.yaml
@@ -4,3 +4,13 @@ groups:
     rules:
       - record: up:count
         expr: count(up)
+
+  - name: example2
+    rules:
+      - alert: TooManyServices
+        expr: count(up) > 1
+        for: 1m
+        labels:
+          severity: page
+        annotations:
+          summary: Too many services

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -47,6 +47,7 @@ const (
 	// MaintenancePeriod is used for periodic storing of silences and notifications to local file.
 	maintenancePeriod = 15 * time.Minute
 
+	// Filenames used within tenant-directory
 	notificationLogSnapshot = "notifications"
 	silencesSnapshot        = "silences"
 	templatesDir            = "templates"

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -153,14 +153,14 @@ func validateUserConfig(logger log.Logger, cfg alertspb.AlertConfigDesc) error {
 	// not to configured data dir, and on the flipside, it'll fail if we can't write
 	// to tmpDir. Ignoring both cases for now as they're ultra rare but will revisit if
 	// we see this in the wild.
-	tmpDir, err := ioutil.TempDir("", "validate-config")
+	userTempDir, err := ioutil.TempDir("", "validate-config-"+cfg.User)
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpDir)
+	defer os.RemoveAll(userTempDir)
 
 	for _, tmpl := range cfg.Templates {
-		_, err := createTemplateFile(tmpDir, cfg.User, tmpl.Filename, tmpl.Body)
+		_, err := storeTemplateFile(userTempDir, tmpl.Filename, tmpl.Body)
 		if err != nil {
 			level.Error(logger).Log("msg", "unable to create template file", "err", err, "user", cfg.User)
 			return fmt.Errorf("unable to create template file '%s'", tmpl.Filename)
@@ -169,7 +169,7 @@ func validateUserConfig(logger log.Logger, cfg alertspb.AlertConfigDesc) error {
 
 	templateFiles := make([]string, len(amCfg.Templates))
 	for i, t := range amCfg.Templates {
-		templateFiles[i] = filepath.Join(tmpDir, "templates", cfg.User, t)
+		templateFiles[i] = filepath.Join(userTempDir, t)
 	}
 
 	_, err = template.FromGlobs(templateFiles...)

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -1144,17 +1144,21 @@ func (s StatusHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-func storeTemplateFile(tenantTemplateDir, templateFileName, content string) (changed bool, _ error) {
+// storeTemplateFile stores template file with given content into specific directory.
+// Since templateFileName is provided by end-user, it is verified that it doesn't do any path-traversal.
+// Returns true, if file content has changed (new or updated file), false if file with the same name
+// and content was already stored locally.
+func storeTemplateFile(dir, templateFileName, content string) (bool, error) {
 	if templateFileName != filepath.Base(templateFileName) {
 		return false, fmt.Errorf("template file name '%s' is not not valid", templateFileName)
 	}
 
-	err := os.MkdirAll(tenantTemplateDir, 0755)
+	err := os.MkdirAll(dir, 0755)
 	if err != nil {
-		return false, fmt.Errorf("unable to create Alertmanager templates directory %q: %s", tenantTemplateDir, err)
+		return false, fmt.Errorf("unable to create Alertmanager templates directory %q: %s", dir, err)
 	}
 
-	file := filepath.Join(tenantTemplateDir, templateFileName)
+	file := filepath.Join(dir, templateFileName)
 	// Check if the template file already exists and if it has changed
 	if tmpl, err := ioutil.ReadFile(file); err == nil && string(tmpl) == content {
 		return false, nil

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -22,6 +22,7 @@ import (
 	amconfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/httpgrpc/server"
 	"github.com/weaveworks/common/user"
@@ -448,44 +449,9 @@ func (h *handlerForGRPCServer) ServeHTTP(w http.ResponseWriter, req *http.Reques
 }
 
 func (am *MultitenantAlertmanager) starting(ctx context.Context) (err error) {
-	// Migrate any existing configuration from old format to new one.
-	{
-		st, err := am.getObsoleteFilesPerUser()
-		if err != nil {
-			return errors.Wrap(err, "failed to migrate existing files")
-		}
-
-		for userID, files := range st {
-			tenantDir := filepath.Join(am.cfg.DataDir, userID)
-			err := os.MkdirAll(tenantDir, 0777)
-			if err != nil {
-				return errors.Wrapf(err, "failed to create per-tenant directory %v", tenantDir)
-			}
-
-			if files.notificationLogSnapshot != "" {
-				target := filepath.Join(tenantDir, notificationLogSnapshot)
-				err := os.Rename(files.notificationLogSnapshot, target)
-				if err != nil {
-					return errors.Wrapf(err, "failed to move notification snapshot from %v to %v", files.notificationLogSnapshot, target)
-				}
-			}
-
-			if files.silencesSnapshot != "" {
-				target := filepath.Join(tenantDir, silencesSnapshot)
-				err := os.Rename(files.silencesSnapshot, target)
-				if err != nil {
-					return errors.Wrapf(err, "failed to move silences snapshot from %v to %v", files.silencesSnapshot, target)
-				}
-			}
-
-			if files.templatesDir != "" {
-				target := filepath.Join(tenantDir, templatesDir)
-				err := os.Rename(files.templatesDir, target)
-				if err != nil {
-					return errors.Wrapf(err, "failed to move templates directory from %v to %v", files.templatesDir, target)
-				}
-			}
-		}
+	err = am.migrateStateFilesToPerTenantDirectories()
+	if err != nil {
+		return err
 	}
 
 	defer func() {
@@ -539,6 +505,118 @@ func (am *MultitenantAlertmanager) starting(ctx context.Context) (err error) {
 	}
 
 	return nil
+}
+
+// migrateStateFilesToPerTenantDirectories migrate any existing configuration from old place to new hierarchy.
+func (am *MultitenantAlertmanager) migrateStateFilesToPerTenantDirectories() error {
+	migrate := func(from, to string) error {
+		level.Info(am.logger).Log("msg", "migrating AM state", "from", from, "to", to)
+		err := os.Rename(from, to)
+		return errors.Wrapf(err, "failed to migrate from %v to %v", from, to)
+	}
+
+	st, err := am.getObsoleteFilesPerUser()
+	if err != nil {
+		return errors.Wrap(err, "failed to migrate existing files")
+	}
+
+	for userID, files := range st {
+		tenantDir := filepath.Join(am.cfg.DataDir, userID)
+		err := os.MkdirAll(tenantDir, 0777)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create per-tenant directory %v", tenantDir)
+		}
+
+		errs := tsdb_errors.NewMulti()
+
+		if files.notificationLogSnapshot != "" {
+			errs.Add(migrate(files.notificationLogSnapshot, filepath.Join(tenantDir, notificationLogSnapshot)))
+		}
+
+		if files.silencesSnapshot != "" {
+			errs.Add(migrate(files.silencesSnapshot, filepath.Join(tenantDir, silencesSnapshot)))
+		}
+
+		if files.templatesDir != "" {
+			errs.Add(migrate(files.templatesDir, filepath.Join(tenantDir, templatesDir)))
+		}
+
+		if err := errs.Err(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type obsoleteStateFiles struct {
+	notificationLogSnapshot string
+	silencesSnapshot        string
+	templatesDir            string
+}
+
+// getObsoleteFilesPerUser returns per-user set of files that should be migrated from old structure to new structure.
+func (am *MultitenantAlertmanager) getObsoleteFilesPerUser() (map[string]obsoleteStateFiles, error) {
+	files, err := ioutil.ReadDir(am.cfg.DataDir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list dir %v", am.cfg.DataDir)
+	}
+
+	// old names
+	const (
+		notificationLogPrefix = "nflog:"
+		silencesPrefix        = "silences:"
+		templates             = "templates"
+	)
+
+	result := map[string]obsoleteStateFiles{}
+
+	for _, f := range files {
+		fullPath := filepath.Join(am.cfg.DataDir, f.Name())
+
+		if f.IsDir() {
+			// Process templates dir.
+			if f.Name() != templates {
+				// Ignore other files -- those are likely per tenant directories.
+				continue
+			}
+
+			templateDirs, err := ioutil.ReadDir(fullPath)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to list dir %v", fullPath)
+			}
+
+			// Previously templates directory contained per-tenant subdirectory.
+			for _, d := range templateDirs {
+				if d.IsDir() {
+					v := result[d.Name()]
+					v.templatesDir = filepath.Join(fullPath, d.Name())
+					result[d.Name()] = v
+				} else {
+					level.Warn(am.logger).Log("msg", "ignoring unknown local file", "file", filepath.Join(fullPath, d.Name()))
+				}
+			}
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(f.Name(), notificationLogPrefix):
+			userID := strings.TrimPrefix(f.Name(), notificationLogPrefix)
+			v := result[userID]
+			v.notificationLogSnapshot = fullPath
+			result[userID] = v
+
+		case strings.HasPrefix(f.Name(), silencesPrefix):
+			userID := strings.TrimPrefix(f.Name(), silencesPrefix)
+			v := result[userID]
+			v.silencesSnapshot = fullPath
+			result[userID] = v
+
+		default:
+			level.Warn(am.logger).Log("msg", "ignoring unknown local data file", "file", fullPath)
+		}
+	}
+
+	return result, nil
 }
 
 func (am *MultitenantAlertmanager) run(ctx context.Context) error {
@@ -1000,18 +1078,18 @@ func (am *MultitenantAlertmanager) UpdateState(ctx context.Context, part *cluste
 	return &alertmanagerpb.UpdateStateResponse{Status: alertmanagerpb.OK}, nil
 }
 
-// deleteUnusedLocalUserState finds local files that we no longer need, and deletes them.
+// deleteUnusedLocalUserState deletes local files for users that we no longer need.
 func (am *MultitenantAlertmanager) deleteUnusedLocalUserState() {
 	userDirs := am.getPerUserDirectories()
 
 	// And delete remaining files.
 	for userID, dir := range userDirs {
 		am.alertmanagersMtx.Lock()
-		_, exists := am.alertmanagers[userID]
+		userAM := am.alertmanagers[userID]
 		am.alertmanagersMtx.Unlock()
 
 		// Don't delete directory if AM for user still exists.
-		if exists {
+		if userAM != nil {
 			continue
 		}
 
@@ -1044,76 +1122,6 @@ func (am *MultitenantAlertmanager) getPerUserDirectories() map[string]string {
 		result[f.Name()] = fullPath
 	}
 	return result
-}
-
-type obsoleteStateFiles struct {
-	notificationLogSnapshot string
-	silencesSnapshot        string
-	templatesDir            string
-}
-
-// getObsoleteFilesPerUser returns per-user set of files that should be migrated from old structure to new structure.
-func (am *MultitenantAlertmanager) getObsoleteFilesPerUser() (map[string]obsoleteStateFiles, error) {
-	files, err := ioutil.ReadDir(am.cfg.DataDir)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list dir %v", am.cfg.DataDir)
-	}
-
-	const (
-		notificationLogPrefix = "nflog:"
-		silencesPrefix        = "silences:"
-		templates             = "templates"
-	)
-
-	result := map[string]obsoleteStateFiles{}
-
-	for _, f := range files {
-		fullPath := filepath.Join(am.cfg.DataDir, f.Name())
-
-		if f.IsDir() {
-			// Process templates dir.
-			if f.Name() != templates {
-				// Ignore other files -- those are likely per tenant directories.
-				continue
-			}
-
-			templateDirs, err := ioutil.ReadDir(fullPath)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to list dir %v", fullPath)
-			}
-
-			// Previously templates directory contained per-tenant subdirectory.
-			for _, d := range templateDirs {
-				if d.IsDir() {
-					v := result[d.Name()]
-					v.templatesDir = filepath.Join(fullPath, d.Name())
-					result[d.Name()] = v
-				} else {
-					level.Warn(am.logger).Log("msg", "ignoring unknown local file", "file", filepath.Join(fullPath, d.Name()))
-				}
-			}
-			continue
-		}
-
-		switch {
-		case strings.HasPrefix(f.Name(), notificationLogPrefix):
-			userID := strings.TrimPrefix(f.Name(), notificationLogPrefix)
-			v := result[userID]
-			v.notificationLogSnapshot = fullPath
-			result[userID] = v
-
-		case strings.HasPrefix(f.Name(), silencesPrefix):
-			userID := strings.TrimPrefix(f.Name(), silencesPrefix)
-			v := result[userID]
-			v.silencesSnapshot = fullPath
-			result[userID] = v
-
-		default:
-			level.Warn(am.logger).Log("msg", "ignoring unknown local data file", "file", fullPath)
-		}
-	}
-
-	return result, nil
 }
 
 // StatusHandler shows the status of the alertmanager.

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -989,8 +989,8 @@ func (am *MultitenantAlertmanager) getSnapshotFilesPerUser() map[string][]string
 		fullPath := filepath.Join(am.cfg.DataDir, f.Name())
 
 		switch {
-		case strings.HasPrefix(f.Name(), nflogPrefix):
-			userID := strings.TrimPrefix(f.Name(), nflogPrefix)
+		case strings.HasPrefix(f.Name(), notificationLogPrefix):
+			userID := strings.TrimPrefix(f.Name(), notificationLogPrefix)
 			result[userID] = append(result[userID], fullPath)
 
 		case strings.HasPrefix(f.Name(), silencesPrefix):

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -507,7 +507,8 @@ func (am *MultitenantAlertmanager) starting(ctx context.Context) (err error) {
 	return nil
 }
 
-// migrateStateFilesToPerTenantDirectories migrate any existing configuration from old place to new hierarchy.
+// migrateStateFilesToPerTenantDirectories migrates any existing configuration from old place to new hierarchy.
+// TODO: Remove in Cortex 1.10.
 func (am *MultitenantAlertmanager) migrateStateFilesToPerTenantDirectories() error {
 	migrate := func(from, to string) error {
 		level.Info(am.logger).Log("msg", "migrating AM state", "from", from, "to", to)
@@ -1106,6 +1107,8 @@ func (am *MultitenantAlertmanager) deleteUnusedLocalUserState() {
 	}
 }
 
+// getPerUserDirectories returns map of users to their directories (full path). Only users with local
+// directory are returned.
 func (am *MultitenantAlertmanager) getPerUserDirectories() map[string]string {
 	files, err := ioutil.ReadDir(am.cfg.DataDir)
 	if err != nil {

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -511,14 +511,14 @@ func (am *MultitenantAlertmanager) starting(ctx context.Context) (err error) {
 // TODO: Remove in Cortex 1.10.
 func (am *MultitenantAlertmanager) migrateStateFilesToPerTenantDirectories() error {
 	migrate := func(from, to string) error {
-		level.Info(am.logger).Log("msg", "migrating AM state", "from", from, "to", to)
+		level.Info(am.logger).Log("msg", "migrating alertmanager state", "from", from, "to", to)
 		err := os.Rename(from, to)
-		return errors.Wrapf(err, "failed to migrate from %v to %v", from, to)
+		return errors.Wrapf(err, "failed to migrate alertmanager state from %v to %v", from, to)
 	}
 
 	st, err := am.getObsoleteFilesPerUser()
 	if err != nil {
-		return errors.Wrap(err, "failed to migrate existing files")
+		return errors.Wrap(err, "failed to migrate alertmanager state files")
 	}
 
 	for userID, files := range st {
@@ -593,7 +593,7 @@ func (am *MultitenantAlertmanager) getObsoleteFilesPerUser() (map[string]obsolet
 					v.templatesDir = filepath.Join(fullPath, d.Name())
 					result[d.Name()] = v
 				} else {
-					level.Warn(am.logger).Log("msg", "ignoring unknown local file", "file", filepath.Join(fullPath, d.Name()))
+					level.Warn(am.logger).Log("msg", "ignoring unknown local file while migrating local alertmanager state files", "file", filepath.Join(fullPath, d.Name()))
 				}
 			}
 			continue
@@ -613,7 +613,7 @@ func (am *MultitenantAlertmanager) getObsoleteFilesPerUser() (map[string]obsolet
 			result[userID] = v
 
 		default:
-			level.Warn(am.logger).Log("msg", "ignoring unknown local data file", "file", fullPath)
+			level.Warn(am.logger).Log("msg", "ignoring unknown local data file while migrating local alertmanager state files", "file", fullPath)
 		}
 	}
 
@@ -1122,7 +1122,7 @@ func (am *MultitenantAlertmanager) getPerUserDirectories() map[string]string {
 		fullPath := filepath.Join(am.cfg.DataDir, f.Name())
 
 		if !f.IsDir() {
-			level.Warn(am.logger).Log("msg", "ignoring local file", "file", fullPath)
+			level.Warn(am.logger).Log("msg", "ignoring unexpected file while scanning local alertmanager configs", "file", fullPath)
 			continue
 		}
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -986,10 +986,6 @@ func (am *MultitenantAlertmanager) getSnapshotFilesPerUser() map[string][]string
 	result := map[string][]string{}
 
 	for _, f := range files {
-		if f.IsDir() {
-			continue
-		}
-
 		fullPath := filepath.Join(am.cfg.DataDir, f.Name())
 
 		switch {

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -216,8 +216,8 @@ func TestMultitenantAlertmanager_deleteObsoleteLocalFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	testUser1File1 := createFile(t, cfg.DataDir, silencesPrefix+user1)
-	testUser1File2 := createFile(t, cfg.DataDir, nflogPrefix+user1)
-	testUser2File := createFile(t, cfg.DataDir, nflogPrefix+user2)
+	testUser1File2 := createFile(t, cfg.DataDir, notificationLogPrefix+user1)
+	testUser2File := createFile(t, cfg.DataDir, notificationLogPrefix+user2)
 
 	files := am.getSnapshotFilesPerUser()
 	require.Equal(t, 2, len(files))


### PR DESCRIPTION
**What this PR does**: This PR implements cleanup of local files on alertmanager when AM is no longer running for given user.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
