### PR TITLE
Fix ruler API

### DIFF
--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -711,7 +711,7 @@ func (r *Ruler) getShardedRules(ctx context.Context) ([]*GroupStateDesc, error) 
 			return nil, err
 		}
 		cc := NewRulerClient(conn)
-		newGrps, err := cc.Rules(ctx, nil)
+		newGrps, err := cc.Rules(ctx, &RulesRequest{})
 
 		// Close the gRPC connection regardless the RPC was successful or not.
 		if closeErr := conn.Close(); closeErr != nil {


### PR DESCRIPTION
**What this PR does**:
The grpc upgrade in #3884 has broken the ruler rules API endpoint:
```
msg="GET /api/prom/api/v1/rules (500) 4.012183ms Response: \"{\\\"status\\\":\\\"error\\\",\\\"data\\\":null,\\\"errorType\\\":\\\"server_error\\\",\\\"error\\\":\\\"unable to retrieve rules from other rulers, rpc error: code = Internal desc = grpc: error while marshaling: proto: Marshal called with nil\\\"}\"
```

This PR fixes it. An integration test will be added once #3916 gets merged, but this PR has been manually tested.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
