### PR TITLE
Skip TestAlertmanagerSharding to unblock Cortex development

### DIFF
--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -233,6 +233,9 @@ func TestAlertmanagerClustering(t *testing.T) {
 }
 
 func TestAlertmanagerSharding(t *testing.T) {
+	// TODO See: https://github.com/cortexproject/cortex/issues/3927
+	t.Skip("this test is skipped because of a bug in the alertmanager sharding logic, which is currently under development")
+
 	tests := map[string]struct {
 		legacyAlertStore bool
 	}{


### PR DESCRIPTION
**What this PR does**:
Most CI runs fail because of `TestAlertmanagerSharding` which is showing the replication logic is buggy (see https://github.com/cortexproject/cortex/issues/3927). Sharding is still under development and not ready yet, so I think it's better to skip that test to unblock other PRs.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
