### PR TITLE
Removed alertmanager flags deprecated in Cortex 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 * [CHANGE] Alertmanager now removes local files after Alertmanager is no longer running for removed or resharded user. #3910
 * [CHANGE] Alertmanager now stores local files in per-tenant folders. Files stored by Alertmanager previously are migrated to new hierarchy. Support for this migration will be removed in Cortex 1.10. #3910
+* [CHANGE] Alertmanager: removed `-cluster.` CLI flags deprecated in Cortex 1.7. The new config options to use are: #3946
+  * `-alertmanager.cluster.listen-address` instead of `-cluster.listen-address`
+  * `-alertmanager.cluster.advertise-address` instead of `-cluster.advertise-address`
+  * `-alertmanager.cluster.peers` instead of `-cluster.peer`
+  * `-alertmanager.cluster.peer-timeout` instead of `-cluster.peer-timeout`
 * [FEATURE] Ruler Storage: Added `local` backend support to the ruler storage configuration under the `-ruler-storage.` flag prefix. #3932
 * [ENHANCEMENT] Ruler: optimized `<prefix>/api/v1/rules` and `<prefix>/api/v1/alerts` when ruler sharding is enabled. #3916
 * [ENHANCEMENT] Ruler: added the following metrics when ruler sharding is enabled: #3916

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1997,22 +1997,6 @@ The `alertmanager_config` configures the Cortex alertmanager.
 # CLI flag: -alertmanager.max-recv-msg-size
 [max_recv_msg_size: <int> | default = 16777216]
 
-# Deprecated. Use -alertmanager.cluster.listen-address instead.
-# CLI flag: -cluster.listen-address
-[cluster_bind_address: <string> | default = "0.0.0.0:9094"]
-
-# Deprecated. Use -alertmanager.cluster.advertise-address instead.
-# CLI flag: -cluster.advertise-address
-[cluster_advertise_address: <string> | default = ""]
-
-# Deprecated. Use -alertmanager.cluster.peers instead.
-# CLI flag: -cluster.peer
-[peers: <list of string> | default = []]
-
-# Deprecated. Use -alertmanager.cluster.peer-timeout instead.
-# CLI flag: -cluster.peer-timeout
-[peer_timeout: <duration> | default = 15s]
-
 # Shard tenants across multiple alertmanager instances.
 # CLI flag: -alertmanager.sharding-enabled
 [sharding_enabled: <boolean> | default = false]


### PR DESCRIPTION
**What this PR does**:
In Cortex 1.7 we deprecated some alertmanager flags which can be removed in the upcoming Cortex 1.9. This PR removes them.

/cc @gotjosh @stevesg 

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
