### PR TITLE
Chore: remove ingester naming from ReplicationSet

### DIFF
--- a/pkg/alertmanager/distributor.go
+++ b/pkg/alertmanager/distributor.go
@@ -189,7 +189,7 @@ func (d *Distributor) doRead(userID string, w http.ResponseWriter, r *http.Reque
 	defer sp.Finish()
 	// Until we have a mechanism to combine the results from multiple alertmanagers,
 	// we forward the request to only only of the alertmanagers.
-	amDesc := replicationSet.Ingesters[rand.Intn(len(replicationSet.Ingesters))]
+	amDesc := replicationSet.Instances[rand.Intn(len(replicationSet.Instances))]
 	resp, err := d.doRequest(ctx, amDesc, req)
 	if err != nil {
 		respondFromError(err, w, logger)

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -924,7 +924,7 @@ func (am *MultitenantAlertmanager) GetPositionForUser(userID string) int {
 	}
 
 	var position int
-	for i, instance := range set.Ingesters {
+	for i, instance := range set.Instances {
 		if instance.Addr == am.ringLifecycler.GetInstanceAddr() {
 			position = i
 			break

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -721,11 +721,11 @@ func (c *Compactor) ownUser(userID string) (bool, error) {
 		return false, err
 	}
 
-	if len(rs.Ingesters) != 1 {
-		return false, fmt.Errorf("unexpected number of compactors in the shard (expected 1, got %d)", len(rs.Ingesters))
+	if len(rs.Instances) != 1 {
+		return false, fmt.Errorf("unexpected number of compactors in the shard (expected 1, got %d)", len(rs.Instances))
 	}
 
-	return rs.Ingesters[0].Addr == c.ringLifecycler.Addr, nil
+	return rs.Instances[0].Addr == c.ringLifecycler.Addr, nil
 }
 
 func isAllowedUser(enabledUsers, disabledUsers map[string]struct{}, userID string) bool {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -912,7 +912,7 @@ func (d *Distributor) AllUserStats(ctx context.Context) ([]UserIDStats, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, ingester := range replicationSet.Ingesters {
+	for _, ingester := range replicationSet.Instances {
 		client, err := d.ingesterPool.GetClientFor(ingester.Addr)
 		if err != nil {
 			return nil, err

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -144,12 +144,12 @@ func (s *blocksStoreReplicationSet) GetClientsFor(userID string, blockIDs []ulid
 func getNonExcludedInstanceAddr(set ring.ReplicationSet, exclude []string, balancingStrategy loadBalancingStrategy) string {
 	if balancingStrategy == randomLoadBalancing {
 		// Randomize the list of instances to not always query the same one.
-		rand.Shuffle(len(set.Ingesters), func(i, j int) {
-			set.Ingesters[i], set.Ingesters[j] = set.Ingesters[j], set.Ingesters[i]
+		rand.Shuffle(len(set.Instances), func(i, j int) {
+			set.Instances[i], set.Instances[j] = set.Instances[j], set.Instances[i]
 		})
 	}
 
-	for _, instance := range set.Ingesters {
+	for _, instance := range set.Instances {
 		if !util.StringsContain(exclude, instance.Addr) {
 			return instance.Addr
 		}

--- a/pkg/querier/blocks_store_replicated_set_test.go
+++ b/pkg/querier/blocks_store_replicated_set_test.go
@@ -341,7 +341,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			// Wait until the ring client has initialised the state.
 			test.Poll(t, time.Second, true, func() interface{} {
 				all, err := r.GetAllHealthy(ring.Read)
-				return err == nil && len(all.Ingesters) > 0
+				return err == nil && len(all.Instances) > 0
 			})
 
 			clients, err := s.GetClientsFor(userID, testData.queryBlocks, testData.exclude)
@@ -399,7 +399,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor_ShouldSupportRandomLoadBalancin
 	// Wait until the ring client has initialised the state.
 	test.Poll(t, time.Second, true, func() interface{} {
 		all, err := r.GetAllHealthy(ring.Read)
-		return err == nil && len(all.Ingesters) > 0
+		return err == nil && len(all.Instances) > 0
 	})
 
 	// Request the same block multiple times and ensure the distribution of

--- a/pkg/ring/batch.go
+++ b/pkg/ring/batch.go
@@ -56,10 +56,10 @@ func DoBatch(ctx context.Context, op Operation, r ReadRing, keys []uint32, callb
 		if err != nil {
 			return err
 		}
-		itemTrackers[i].minSuccess = len(replicationSet.Ingesters) - replicationSet.MaxErrors
+		itemTrackers[i].minSuccess = len(replicationSet.Instances) - replicationSet.MaxErrors
 		itemTrackers[i].maxFailures = replicationSet.MaxErrors
 
-		for _, desc := range replicationSet.Ingesters {
+		for _, desc := range replicationSet.Instances {
 			curr, found := instances[desc.Addr]
 			if !found {
 				curr.itemTrackers = make([]*itemTracker, 0, expectedTrackers)

--- a/pkg/ring/client/ring_service_discovery.go
+++ b/pkg/ring/client/ring_service_discovery.go
@@ -17,7 +17,7 @@ func NewRingServiceDiscovery(r ring.ReadRing) PoolServiceDiscovery {
 		}
 
 		var addrs []string
-		for _, instance := range replicationSet.Ingesters {
+		for _, instance := range replicationSet.Instances {
 			addrs = append(addrs, instance.Addr)
 		}
 		return addrs, nil

--- a/pkg/ring/client/ring_service_discovery_test.go
+++ b/pkg/ring/client/ring_service_discovery_test.go
@@ -26,13 +26,13 @@ func TestNewRingServiceDiscovery(t *testing.T) {
 		},
 		"empty replication set": {
 			ringReplicationSet: ring.ReplicationSet{
-				Ingesters: []ring.InstanceDesc{},
+				Instances: []ring.InstanceDesc{},
 			},
 			expectedAddrs: nil,
 		},
 		"replication containing some endpoints": {
 			ringReplicationSet: ring.ReplicationSet{
-				Ingesters: []ring.InstanceDesc{
+				Instances: []ring.InstanceDesc{
 					{Addr: "1.1.1.1"},
 					{Addr: "2.2.2.2"},
 				},

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -6,10 +6,10 @@ import (
 	"time"
 )
 
-// ReplicationSet describes the ingesters to talk to for a given key, and how
+// ReplicationSet describes the instances to talk to for a given key, and how
 // many errors to tolerate.
 type ReplicationSet struct {
-	Ingesters []InstanceDesc
+	Instances []InstanceDesc
 
 	// Maximum number of tolerated failing instances. Max errors and max unavailable zones are
 	// mutually exclusive.
@@ -32,23 +32,23 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 	// Initialise the result tracker, which is use to keep track of successes and failures.
 	var tracker replicationSetResultTracker
 	if r.MaxUnavailableZones > 0 {
-		tracker = newZoneAwareResultTracker(r.Ingesters, r.MaxUnavailableZones)
+		tracker = newZoneAwareResultTracker(r.Instances, r.MaxUnavailableZones)
 	} else {
-		tracker = newDefaultResultTracker(r.Ingesters, r.MaxErrors)
+		tracker = newDefaultResultTracker(r.Instances, r.MaxErrors)
 	}
 
 	var (
-		ch         = make(chan instanceResult, len(r.Ingesters))
+		ch         = make(chan instanceResult, len(r.Instances))
 		forceStart = make(chan struct{}, r.MaxErrors)
 	)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// Spawn a goroutine for each instance.
-	for i := range r.Ingesters {
+	for i := range r.Instances {
 		go func(i int, ing *InstanceDesc) {
 			// Wait to send extra requests. Works only when zone-awareness is disabled.
-			if delay > 0 && r.MaxUnavailableZones == 0 && i >= len(r.Ingesters)-r.MaxErrors {
+			if delay > 0 && r.MaxUnavailableZones == 0 && i >= len(r.Instances)-r.MaxErrors {
 				after := time.NewTimer(delay)
 				defer after.Stop()
 				select {
@@ -64,10 +64,10 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 				err:      err,
 				instance: ing,
 			}
-		}(i, &r.Ingesters[i])
+		}(i, &r.Instances[i])
 	}
 
-	results := make([]interface{}, 0, len(r.Ingesters))
+	results := make([]interface{}, 0, len(r.Instances))
 
 	for !tracker.succeeded() {
 		select {
@@ -96,7 +96,7 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(cont
 
 // Includes returns whether the replication set includes the replica with the provided addr.
 func (r ReplicationSet) Includes(addr string) bool {
-	for _, instance := range r.Ingesters {
+	for _, instance := range r.Instances {
 		if instance.GetAddr() == addr {
 			return true
 		}
@@ -108,8 +108,8 @@ func (r ReplicationSet) Includes(addr string) bool {
 // GetAddresses returns the addresses of all instances within the replication set. Returned slice
 // order is not guaranteed.
 func (r ReplicationSet) GetAddresses() []string {
-	addrs := make([]string, 0, len(r.Ingesters))
-	for _, desc := range r.Ingesters {
+	addrs := make([]string, 0, len(r.Instances))
+	for _, desc := range r.Instances {
 		addrs = append(addrs, desc.Addr)
 	}
 	return addrs
@@ -118,8 +118,8 @@ func (r ReplicationSet) GetAddresses() []string {
 // HasReplicationSetChanged returns true if two replications sets are the same (with possibly different timestamps),
 // false if they differ in any way (number of instances, instance states, tokens, zones, ...).
 func HasReplicationSetChanged(before, after ReplicationSet) bool {
-	beforeInstances := before.Ingesters
-	afterInstances := after.Ingesters
+	beforeInstances := before.Instances
+	afterInstances := after.Instances
 
 	if len(beforeInstances) != len(afterInstances) {
 		return true

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -22,7 +22,7 @@ func TestReplicationSet_GetAddresses(t *testing.T) {
 		},
 		"should return instances addresses (no order guaranteed)": {
 			rs: ReplicationSet{
-				Ingesters: []InstanceDesc{
+				Instances: []InstanceDesc{
 					{Addr: "127.0.0.1"},
 					{Addr: "127.0.0.2"},
 					{Addr: "127.0.0.3"},
@@ -177,7 +177,7 @@ func TestReplicationSet_Do(t *testing.T) {
 			require.False(t, tt.maxErrors > 0 && tt.maxUnavailableZones > 0)
 
 			r := ReplicationSet{
-				Ingesters:           tt.instances,
+				Instances:           tt.instances,
 				MaxErrors:           tt.maxErrors,
 				MaxUnavailableZones: tt.maxUnavailableZones,
 			}

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -368,7 +368,7 @@ func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts, 
 	}
 
 	return ReplicationSet{
-		Ingesters: healthyInstances,
+		Instances: healthyInstances,
 		MaxErrors: maxFailure,
 	}, nil
 }
@@ -391,7 +391,7 @@ func (r *Ring) GetAllHealthy(op Operation) (ReplicationSet, error) {
 	}
 
 	return ReplicationSet{
-		Ingesters: instances,
+		Instances: instances,
 		MaxErrors: 0,
 	}, nil
 }
@@ -472,7 +472,7 @@ func (r *Ring) GetReplicationSetForOperation(op Operation) (ReplicationSet, erro
 	}
 
 	return ReplicationSet{
-		Ingesters:           healthyInstances,
+		Instances:           healthyInstances,
 		MaxErrors:           maxErrors,
 		MaxUnavailableZones: maxUnavailableZones,
 	}, nil

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -229,16 +229,16 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 				}
 
 				// Check that we have the expected number of instances for replication.
-				assert.Equal(t, testData.expectedInstances, len(set.Ingesters))
+				assert.Equal(t, testData.expectedInstances, len(set.Instances))
 
 				// Ensure all instances are in a different zone (only if zone-awareness is enabled).
 				if testData.zoneAwarenessEnabled {
 					zones := make(map[string]struct{})
-					for i := 0; i < len(set.Ingesters); i++ {
-						if _, ok := zones[set.Ingesters[i].Zone]; ok {
+					for i := 0; i < len(set.Instances); i++ {
+						if _, ok := zones[set.Instances[i].Zone]; ok {
 							t.Fatal("found multiple instances in the same zone")
 						}
-						zones[set.Ingesters[i].Zone] = struct{}{}
+						zones[set.Instances[i].Zone] = struct{}{}
 					}
 				}
 			}
@@ -738,13 +738,13 @@ func TestRing_GetReplicationSetForOperation_WithZoneAwarenessEnabled(t *testing.
 			assert.Equal(t, testData.expectedMaxUnavailableZones, replicationSet.MaxUnavailableZones)
 
 			returnAddresses := []string{}
-			for _, instance := range replicationSet.Ingesters {
+			for _, instance := range replicationSet.Instances {
 				returnAddresses = append(returnAddresses, instance.Addr)
 			}
 			for _, addr := range testData.expectedAddresses {
 				assert.Contains(t, returnAddresses, addr)
 			}
-			assert.Equal(t, len(testData.expectedAddresses), len(replicationSet.Ingesters))
+			assert.Equal(t, len(testData.expectedAddresses), len(replicationSet.Instances))
 		})
 	}
 }
@@ -874,7 +874,7 @@ func TestRing_ShuffleShard(t *testing.T) {
 					require.NoError(t, err)
 
 					countByZone := map[string]int{}
-					for _, instance := range all.Ingesters {
+					for _, instance := range all.Instances {
 						countByZone[instance.Zone]++
 					}
 
@@ -927,7 +927,7 @@ func TestRing_ShuffleShard_Stability(t *testing.T) {
 				r := ring.ShuffleShard(tenantID, size)
 				actual, err := r.GetAllHealthy(Read)
 				require.NoError(t, err)
-				assert.ElementsMatch(t, expected.Ingesters, actual.Ingesters)
+				assert.ElementsMatch(t, expected.Instances, actual.Instances)
 			}
 		}
 	}
@@ -991,8 +991,8 @@ func TestRing_ShuffleShard_Shuffling(t *testing.T) {
 		set, err := r.GetAllHealthy(Read)
 		require.NoError(t, err)
 
-		instances := make([]string, 0, len(set.Ingesters))
-		for _, instance := range set.Ingesters {
+		instances := make([]string, 0, len(set.Instances))
+		for _, instance := range set.Instances {
 			instances = append(instances, instance.Addr)
 		}
 
@@ -1159,7 +1159,7 @@ func TestRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
 	secondSet, err := secondShard.GetAllHealthy(Read)
 	require.NoError(t, err)
 
-	for _, firstInstance := range firstSet.Ingesters {
+	for _, firstInstance := range firstSet.Instances {
 		assert.True(t, secondSet.Includes(firstInstance.Addr), "new replication set is expected to include previous instance %s", firstInstance.Addr)
 	}
 
@@ -1170,7 +1170,7 @@ func TestRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
 	thirdSet, err := thirdShard.GetAllHealthy(Read)
 	require.NoError(t, err)
 
-	for _, secondInstance := range secondSet.Ingesters {
+	for _, secondInstance := range secondSet.Instances {
 		assert.True(t, thirdSet.Includes(secondInstance.Addr), "new replication set is expected to include previous instance %s", secondInstance.Addr)
 	}
 
@@ -1182,7 +1182,7 @@ func TestRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
 	require.NoError(t, err)
 
 	// We expect to have the same exact instances we had when the shard size was 6.
-	for _, secondInstance := range secondSet.Ingesters {
+	for _, secondInstance := range secondSet.Instances {
 		assert.True(t, fourthSet.Includes(secondInstance.Addr), "new replication set is expected to include previous instance %s", secondInstance.Addr)
 	}
 
@@ -1194,7 +1194,7 @@ func TestRing_ShuffleShard_ConsistencyOnShardSizeChanged(t *testing.T) {
 	require.NoError(t, err)
 
 	// We expect to have the same exact instances we had when the shard size was 3.
-	for _, firstInstance := range firstSet.Ingesters {
+	for _, firstInstance := range firstSet.Instances {
 		assert.True(t, fifthSet.Includes(firstInstance.Addr), "new replication set is expected to include previous instance %s", firstInstance.Addr)
 	}
 }
@@ -1236,7 +1236,7 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 	secondSet, err := secondShard.GetAllHealthy(Read)
 	require.NoError(t, err)
 
-	for _, firstInstance := range firstSet.Ingesters {
+	for _, firstInstance := range firstSet.Instances {
 		assert.True(t, secondSet.Includes(firstInstance.Addr), "new replication set is expected to include previous instance %s", firstInstance.Addr)
 	}
 
@@ -1259,7 +1259,7 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 	thirdSet, err := thirdShard.GetAllHealthy(Read)
 	require.NoError(t, err)
 
-	for _, secondInstance := range secondSet.Ingesters {
+	for _, secondInstance := range secondSet.Instances {
 		assert.True(t, thirdSet.Includes(secondInstance.Addr), "new replication set is expected to include previous instance %s", secondInstance.Addr)
 	}
 
@@ -1270,7 +1270,7 @@ func TestRing_ShuffleShard_ConsistencyOnZonesChanged(t *testing.T) {
 	fourthSet, err := fourthShard.GetAllHealthy(Read)
 	require.NoError(t, err)
 
-	for _, thirdInstance := range thirdSet.Ingesters {
+	for _, thirdInstance := range thirdSet.Instances {
 		assert.True(t, fourthSet.Includes(thirdInstance.Addr), "new replication set is expected to include previous instance %s", thirdInstance.Addr)
 	}
 }
@@ -1603,13 +1603,13 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 
 						// Remove the terminated instance from the history.
 						for ringTime, ringState := range history {
-							for idx, desc := range ringState.Ingesters {
+							for idx, desc := range ringState.Instances {
 								// In this simulation instance ID == instance address.
 								if desc.Addr != idToRemove {
 									continue
 								}
 
-								ringState.Ingesters = append(ringState.Ingesters[:idx], ringState.Ingesters[idx+1:]...)
+								ringState.Instances = append(ringState.Instances[:idx], ringState.Instances[idx+1:]...)
 								history[ringTime] = ringState
 								break
 							}
@@ -1735,7 +1735,7 @@ func BenchmarkRing_Get(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		set, err := ring.Get(r.Uint32(), Write, buf, bufHosts, bufZones)
-		if err != nil || len(set.Ingesters) != replicationFactor {
+		if err != nil || len(set.Instances) != replicationFactor {
 			b.Fatal()
 		}
 	}
@@ -1761,7 +1761,7 @@ func TestRing_Get_NoMemoryAllocations(t *testing.T) {
 
 	numAllocs := testing.AllocsPerRun(10, func() {
 		set, err := ring.Get(r.Uint32(), Write, buf, bufHosts, bufZones)
-		if err != nil || len(set.Ingesters) != 3 {
+		if err != nil || len(set.Instances) != 3 {
 			t.Fail()
 		}
 	})
@@ -1813,13 +1813,13 @@ func generateRingInstanceWithInfo(addr, zone string, tokens []uint32, registered
 
 // compareReplicationSets returns the list of instance addresses which differ between the two sets.
 func compareReplicationSets(first, second ReplicationSet) (added, removed []string) {
-	for _, instance := range first.Ingesters {
+	for _, instance := range first.Instances {
 		if !second.Includes(instance.Addr) {
 			added = append(added, instance.Addr)
 		}
 	}
 
-	for _, instance := range second.Ingesters {
+	for _, instance := range second.Instances {
 		if !first.Includes(instance.Addr) {
 			removed = append(removed, instance.Addr)
 		}
@@ -1870,7 +1870,7 @@ func TestRingUpdates(t *testing.T) {
 	require.NoError(t, err)
 
 	now := time.Now()
-	for _, ing := range rs.Ingesters {
+	for _, ing := range rs.Instances {
 		require.InDelta(t, now.UnixNano(), time.Unix(ing.Timestamp, 0).UnixNano(), float64(1500*time.Millisecond.Nanoseconds()))
 	}
 
@@ -1957,7 +1957,7 @@ func TestShuffleShardWithCaching(t *testing.T) {
 	test.Poll(t, 5*time.Second, numLifecyclers, func() interface{} {
 		active := 0
 		rs, _ := ring.GetReplicationSetForOperation(Read)
-		for _, ing := range rs.Ingesters {
+		for _, ing := range rs.Instances {
 			if ing.State == ACTIVE {
 				active++
 			}
@@ -1988,7 +1988,7 @@ func TestShuffleShardWithCaching(t *testing.T) {
 		require.NoError(t, err)
 
 		now := time.Now()
-		for _, ing := range rs.Ingesters {
+		for _, ing := range rs.Instances {
 			// Lifecyclers use 500ms refresh, but timestamps use 1s resolution, so we better give it some extra buffer.
 			assert.InDelta(t, now.UnixNano(), time.Unix(ing.Timestamp, 0).UnixNano(), float64(2*time.Second.Nanoseconds()))
 		}

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -385,7 +385,7 @@ func instanceOwnsRuleGroup(r ring.ReadRing, g *rulespb.RuleGroupDesc, instanceAd
 		return false, errors.Wrap(err, "error reading ring to verify rule group ownership")
 	}
 
-	return rlrs.Ingesters[0].Addr == instanceAddr, nil
+	return rlrs.Instances[0].Addr == instanceAddr, nil
 }
 
 func (r *Ruler) ServeHTTP(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
**What this PR does**:
As part of my low priority work on https://github.com/cortexproject/cortex/issues/2723, in this PR I've removed the "ingester" naming from `ReplicationSet`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
