### PR TITLE
Revert "Prevent failed ingestion from affecting rate limiting in distributor. (#3825)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * `cortex_ruler_clients`
   * `cortex_ruler_client_request_duration_seconds`
 * [ENHANCEMENT] Query-frontend/scheduler: added querier forget delay (`-query-frontend.querier-forget-delay` and `-query-scheduler.querier-forget-delay`) to mitigate the blast radius in the event queriers crash because of a repeatedly sent "query of death" when shuffle-sharding is enabled. #3901
+* [BUGFIX] Distributor: reverted changes done to rate limiting in #3825. #3948
 
 ## 1.8.0 in progress
 

--- a/pkg/util/limiter/rate_limiter_test.go
+++ b/pkg/util/limiter/rate_limiter_test.go
@@ -45,60 +45,24 @@ func TestRateLimiter_AllowN(t *testing.T) {
 	now := time.Now()
 
 	// Tenant #1
-	assert.Equal(t, true, isOK(limiter.AllowN(now, "tenant-1", 8)))
-	assert.Equal(t, true, isOK(limiter.AllowN(now, "tenant-1", 10)))
-	assert.Equal(t, false, isOK(limiter.AllowN(now, "tenant-1", 3)))
-	assert.Equal(t, true, isOK(limiter.AllowN(now, "tenant-1", 2)))
+	assert.Equal(t, true, limiter.AllowN(now, "tenant-1", 8))
+	assert.Equal(t, true, limiter.AllowN(now, "tenant-1", 10))
+	assert.Equal(t, false, limiter.AllowN(now, "tenant-1", 3))
+	assert.Equal(t, true, limiter.AllowN(now, "tenant-1", 2))
 
-	assert.Equal(t, true, isOK(limiter.AllowN(now.Add(time.Second), "tenant-1", 8)))
-	assert.Equal(t, false, isOK(limiter.AllowN(now.Add(time.Second), "tenant-1", 3)))
-	assert.Equal(t, true, isOK(limiter.AllowN(now.Add(time.Second), "tenant-1", 2)))
+	assert.Equal(t, true, limiter.AllowN(now.Add(time.Second), "tenant-1", 8))
+	assert.Equal(t, false, limiter.AllowN(now.Add(time.Second), "tenant-1", 3))
+	assert.Equal(t, true, limiter.AllowN(now.Add(time.Second), "tenant-1", 2))
 
 	// Tenant #2
-	assert.Equal(t, true, isOK(limiter.AllowN(now, "tenant-2", 18)))
-	assert.Equal(t, true, isOK(limiter.AllowN(now, "tenant-2", 20)))
-	assert.Equal(t, false, isOK(limiter.AllowN(now, "tenant-2", 3)))
-	assert.Equal(t, true, isOK(limiter.AllowN(now, "tenant-2", 2)))
+	assert.Equal(t, true, limiter.AllowN(now, "tenant-2", 18))
+	assert.Equal(t, true, limiter.AllowN(now, "tenant-2", 20))
+	assert.Equal(t, false, limiter.AllowN(now, "tenant-2", 3))
+	assert.Equal(t, true, limiter.AllowN(now, "tenant-2", 2))
 
-	assert.Equal(t, true, isOK(limiter.AllowN(now.Add(time.Second), "tenant-2", 18)))
-	assert.Equal(t, false, isOK(limiter.AllowN(now.Add(time.Second), "tenant-2", 3)))
-	assert.Equal(t, true, isOK(limiter.AllowN(now.Add(time.Second), "tenant-2", 2)))
-}
-
-func TestRateLimiter_AllowNCancelation(t *testing.T) {
-	strategy := &staticLimitStrategy{tenants: map[string]struct {
-		limit float64
-		burst int
-	}{
-		"tenant-1": {limit: 10, burst: 20},
-	}}
-
-	limiter := NewRateLimiter(strategy, 10*time.Second)
-	now := time.Now()
-
-	assert.Equal(t, true, isOK(limiter.AllowN(now, "tenant-1", 12)))
-	assert.Equal(t, false, isOK(limiter.AllowN(now, "tenant-1", 9)))
-
-	ok1, r1 := limiter.AllowN(now, "tenant-1", 8)
-	assert.Equal(t, true, ok1)
-	r1.CancelAt(now)
-
-	assert.Equal(t, true, isOK(limiter.AllowN(now, "tenant-1", 8)))
-
-	// +10 tokens (1s)
-	nowPlus := now.Add(time.Second)
-
-	assert.Equal(t, true, isOK(limiter.AllowN(nowPlus, "tenant-1", 6)))
-	assert.Equal(t, false, isOK(limiter.AllowN(nowPlus, "tenant-1", 5)))
-
-	ok2, r2 := limiter.AllowN(nowPlus, "tenant-1", 4)
-	assert.Equal(t, true, ok2)
-	r2.CancelAt(nowPlus)
-
-	assert.Equal(t, true, isOK(limiter.AllowN(nowPlus, "tenant-1", 2)))
-	assert.Equal(t, false, isOK(limiter.AllowN(nowPlus, "tenant-1", 3)))
-	assert.Equal(t, true, isOK(limiter.AllowN(nowPlus, "tenant-1", 2)))
-	assert.Equal(t, false, isOK(limiter.AllowN(nowPlus, "tenant-1", 1)))
+	assert.Equal(t, true, limiter.AllowN(now.Add(time.Second), "tenant-2", 18))
+	assert.Equal(t, false, limiter.AllowN(now.Add(time.Second), "tenant-2", 3))
+	assert.Equal(t, true, limiter.AllowN(now.Add(time.Second), "tenant-2", 2))
 }
 
 func BenchmarkRateLimiter_CustomMultiTenant(b *testing.B) {
@@ -162,8 +126,4 @@ func (s *staticLimitStrategy) Burst(tenantID string) int {
 	}
 
 	return tenant.burst
-}
-
-func isOK(ok bool, r Reservation) bool {
-	return ok
 }


### PR DESCRIPTION
**What this PR does**:
We had an incident with a customer remote writing an high volume of out of order samples, which basically bypassed the rate limit because of the changes done in #3825 and the issue described in #3890.

Given we want to improve the rate limit, I would suggest to quickly rollback #3825 and take more time to properly address the ingestion rate limit. I think we should backport this rollback to 1.8 too. /cc @pstibrany 

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
