### PR TITLE
Update doc about to allow ingester to leave ring during scale down

### DIFF
--- a/docs/guides/ingesters-scaling-up-and-down.md
+++ b/docs/guides/ingesters-scaling-up-and-down.md
@@ -42,6 +42,9 @@ The ingesters scale down is deemed an infrequent operation and no automation is 
   - `-blocks-storage.bucket-store.metadata-cache.bucket-index-content-ttl=1m`
   - `-blocks-storage.bucket-store.metadata-cache.tenant-blocks-list-ttl=1m`
   - `-blocks-storage.bucket-store.metadata-cache.metafile-doesnt-exist-ttl=1m`
+- Allow ingester to leave the ring after shutdown
+  - `ingester.unregister-on-shutdown=true`
+  - `distributor.extend-writes=true`
 - Ingesters should be scaled down one by one:
   1. Call `/shutdown` endpoint on the ingester to shutdown
   2. Wait until the HTTP call returns successfully or "finished flushing and shipping TSDB blocks" is logged


### PR DESCRIPTION

**What this PR does**:
Update the ingester scale down doc to mention about allowing ingester to leave the ring after shutdown. 

**Which issue(s) this PR fixes**:
I didn't create an issue for this.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
