### PR TITLE
Implement unsupported methods in local rulestore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   * `cortex_ruler_clients`
   * `cortex_ruler_client_request_duration_seconds`
 * [ENHANCEMENT] Query-frontend/scheduler: added querier forget delay (`-query-frontend.querier-forget-delay` and `-query-scheduler.querier-forget-delay`) to mitigate the blast radius in the event queriers crash because of a repeatedly sent "query of death" when shuffle-sharding is enabled. #3901
+* [ENHANCEMENT] Ruler: support the `GetRuleGroup`, `SetRuleGroup`, `DeleteRuleGroup` and `DeleteNamespace` methods for the local rulestore client
 * [BUGFIX] Distributor: reverted changes done to rate limiting in #3825. #3948
 
 ## 1.8.0 in progress

--- a/pkg/ruler/rulestore/local/local.go
+++ b/pkg/ruler/rulestore/local/local.go
@@ -8,7 +8,9 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
 	promRules "github.com/prometheus/prometheus/rules"
+	"gopkg.in/yaml.v3"
 
 	"github.com/cortexproject/cortex/pkg/ruler/rulespb"
 )
@@ -108,28 +110,79 @@ func (l *Client) LoadRuleGroups(_ context.Context, _ map[string]rulespb.RuleGrou
 
 // GetRuleGroup implements RuleStore
 func (l *Client) GetRuleGroup(ctx context.Context, userID, namespace, group string) (*rulespb.RuleGroupDesc, error) {
-	return nil, errors.New("GetRuleGroup unsupported in rule local store")
+	groups, err := l.loadAllRulesGroupsForUserAndNamespace(ctx, userID, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, g := range groups {
+		if g.Name == group {
+			return g, nil
+		}
+	}
+
+	return nil, errors.Errorf("group %s not found", group)
 }
 
 // SetRuleGroup implements RuleStore
 func (l *Client) SetRuleGroup(ctx context.Context, userID, namespace string, group *rulespb.RuleGroupDesc) error {
-	return errors.New("SetRuleGroup unsupported in rule local store")
+	groups, err := l.loadAllRulesGroupsForUserAndNamespace(ctx, userID, namespace)
+	if err != nil {
+		return err
+	}
+
+	for i, g := range groups {
+		if g.Name == group.Name {
+			if g == group {
+				// The rule group hasn't changed
+				return nil
+			}
+
+			groups[i] = group
+			return l.saveRuleGroupsForUserAndNamespace(userID, namespace, groups)
+		}
+	}
+
+	groups = append(groups, group)
+
+	return l.saveRuleGroupsForUserAndNamespace(userID, namespace, groups)
 }
 
 // DeleteRuleGroup implements RuleStore
-func (l *Client) DeleteRuleGroup(ctx context.Context, userID, namespace string, group string) error {
-	return errors.New("DeleteRuleGroup unsupported in rule local store")
+func (l *Client) DeleteRuleGroup(ctx context.Context, userID, namespace, group string) error {
+	groups, err := l.loadAllRulesGroupsForUserAndNamespace(ctx, userID, namespace)
+	if err != nil {
+		return err
+	}
+
+	for i, g := range groups {
+		if g.Name == group {
+			groups = append(groups[:i], groups[i+1:]...)
+			return l.saveRuleGroupsForUserAndNamespace(userID, namespace, groups)
+		}
+	}
+
+	return errors.Errorf("group %s not found", group)
 }
 
 // DeleteNamespace implements RulerStore
 func (l *Client) DeleteNamespace(ctx context.Context, userID, namespace string) error {
-	return errors.New("DeleteNamespace unsupported in rule local store")
+	filename := filepath.Join(l.cfg.Directory, userID, namespace)
+	return errors.Wrapf(os.Remove(filename), "error removing rule groups file %s", filename)
 }
 
 func (l *Client) loadAllRulesGroupsForUser(ctx context.Context, userID string) (rulespb.RuleGroupList, error) {
 	var allLists rulespb.RuleGroupList
 
 	root := filepath.Join(l.cfg.Directory, userID)
+
+	_, err := os.Stat(root)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, errors.Wrapf(err, "unable to stat dir %s", root)
+	} else if os.IsNotExist(err) {
+		return rulespb.RuleGroupList{}, nil
+	}
+
 	infos, err := ioutil.ReadDir(root)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read dir %s", root)
@@ -165,6 +218,13 @@ func (l *Client) loadAllRulesGroupsForUser(ctx context.Context, userID string) (
 func (l *Client) loadAllRulesGroupsForUserAndNamespace(_ context.Context, userID string, namespace string) (rulespb.RuleGroupList, error) {
 	filename := filepath.Join(l.cfg.Directory, userID, namespace)
 
+	_, err := os.Stat(filename)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, errors.Wrapf(err, "unable to stat dir %s", filename)
+	} else if os.IsNotExist(err) {
+		return rulespb.RuleGroupList{}, nil
+	}
+
 	rulegroups, allErrors := l.loader.Load(filename)
 	if len(allErrors) > 0 {
 		return nil, errors.Wrapf(allErrors[0], "error parsing %s", filename)
@@ -178,4 +238,27 @@ func (l *Client) loadAllRulesGroupsForUserAndNamespace(_ context.Context, userID
 	}
 
 	return list, nil
+}
+
+func (l *Client) saveRuleGroupsForUserAndNamespace(userID, namespace string, ruleGroups rulespb.RuleGroupList) error {
+	var list []rulefmt.RuleGroup
+	for _, group := range ruleGroups {
+		list = append(list, rulespb.FromProto(group))
+	}
+
+	g := rulefmt.RuleGroups{Groups: list}
+	out, err := yaml.Marshal(g)
+	if err != nil {
+		return errors.Wrap(err, "unable to marshal rule groups")
+	}
+
+	filename := filepath.Join(l.cfg.Directory, userID, namespace)
+	dir := filepath.Dir(filename)
+
+	err = os.MkdirAll(dir, 07777)
+	if err != nil {
+		return errors.Wrapf(err, "error creating rule groups file dir %s", dir)
+	}
+
+	return errors.Wrapf(ioutil.WriteFile(filename, out, 0777), "error writing rule groups file %s", filename)
 }

--- a/pkg/ruler/rulestore/local/local_test.go
+++ b/pkg/ruler/rulestore/local/local_test.go
@@ -133,6 +133,7 @@ func TestClient_LoadAllRuleGroups(t *testing.T) {
 	}
 
 	err = client.SetRuleGroup(ctx, user1, namespace3, rulespb.ToProto(user1, namespace3, ruleGroups.Groups[1]))
+	require.NoError(t, err)
 
 	group, err = client.GetRuleGroup(ctx, user1, namespace3, ruleGroups.Groups[1].Name)
 	require.NoError(t, err)
@@ -141,7 +142,7 @@ func TestClient_LoadAllRuleGroups(t *testing.T) {
 	err = client.DeleteRuleGroup(ctx, user1, namespace3, ruleGroups.Groups[0].Name)
 	require.NoError(t, err)
 
-	group, err = client.GetRuleGroup(ctx, user1, namespace3, ruleGroups.Groups[0].Name)
+	_, err = client.GetRuleGroup(ctx, user1, namespace3, ruleGroups.Groups[0].Name)
 	require.Error(t, err)
 
 	err = client.DeleteNamespace(ctx, user1, namespace3)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR implements the `GetRuleGroup`, `SetRuleGroup`, `DeleteRuleGroup`, and `DeleteNamespace` methods for the local rulestore client, which were previously unsupported. I came across this while working with [Loki](https://github.com/grafana/loki).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
