### PR TITLE
Improve formatting of timestamp too new/old error

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1724,7 +1724,7 @@ func TestDistributorValidation(t *testing.T) {
 				TimestampMs: int64(past),
 				Value:       2,
 			}},
-			err: httpgrpc.Errorf(http.StatusBadRequest, "sample for 'testmetric' has timestamp too old: %d", past),
+			err: httpgrpc.Errorf(http.StatusBadRequest, `timestamp too old: %d metric: "testmetric"`, past),
 		},
 
 		// Test validation fails for samples from the future.
@@ -1734,7 +1734,7 @@ func TestDistributorValidation(t *testing.T) {
 				TimestampMs: int64(future),
 				Value:       4,
 			}},
-			err: httpgrpc.Errorf(http.StatusBadRequest, "sample for 'testmetric' has timestamp too new: %d", future),
+			err: httpgrpc.Errorf(http.StatusBadRequest, `timestamp too new: %d metric: "testmetric"`, future),
 		},
 
 		// Test maximum labels names per series.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -49,6 +49,8 @@ const (
 var (
 	// This is initialised if the WAL is enabled and the records are fetched from this pool.
 	recordPool sync.Pool
+
+	errIngesterStopping = errors.New("ingester stopping")
 )
 
 // Config for an Ingester.
@@ -535,7 +537,7 @@ func (i *Ingester) append(ctx context.Context, userID string, labels labelPairs,
 		}
 	}()
 	if i.stopped {
-		return fmt.Errorf("ingester stopping")
+		return errIngesterStopping
 	}
 
 	// getOrCreateSeries copies the memory for `labels`, except on the error path.
@@ -624,7 +626,7 @@ func (i *Ingester) appendMetadata(userID string, m *cortexpb.MetricMetadata) err
 	i.userStatesMtx.RLock()
 	if i.stopped {
 		i.userStatesMtx.RUnlock()
-		return fmt.Errorf("ingester stopping")
+		return errIngesterStopping
 	}
 	i.userStatesMtx.RUnlock()
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -452,7 +452,7 @@ func (i *Ingester) Push(ctx context.Context, req *cortexpb.WriteRequest) (*corte
 
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("no user id")
+		return nil, err
 	}
 
 	// Given metadata is a best-effort approach, and we don't halt on errors
@@ -955,7 +955,7 @@ func (i *Ingester) MetricsMetadata(ctx context.Context, req *client.MetricsMetad
 
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("no user id")
+		return nil, err
 	}
 
 	userMetadata := i.getUserMetadata(userID)

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -705,7 +705,7 @@ func (i *Ingester) v2Push(ctx context.Context, req *cortexpb.WriteRequest) (*cor
 	i.userStatesMtx.RLock()
 	if i.stopped {
 		i.userStatesMtx.RUnlock()
-		return nil, fmt.Errorf("ingester stopping")
+		return nil, errIngesterStopping
 	}
 	i.userStatesMtx.RUnlock()
 

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -693,7 +693,7 @@ func (i *Ingester) v2Push(ctx context.Context, req *cortexpb.WriteRequest) (*cor
 
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("no user id")
+		return nil, err
 	}
 
 	db, err := i.getOrCreateTSDB(userID, false)

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -2,7 +2,6 @@ package ingester
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -181,7 +180,7 @@ func (us *userStates) teardown() {
 func (us *userStates) getViaContext(ctx context.Context) (*userState, bool, error) {
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
-		return nil, false, fmt.Errorf("no user id")
+		return nil, false, err
 	}
 	state, ok := us.get(userID)
 	return state, ok, nil


### PR DESCRIPTION
**What this PR does**:
Given Prometheus truncate logs to the first 512 characters (see https://github.com/prometheus/prometheus/pull/8017) it's important to put most valuable information at the beginning of the error messages. I took another look if it's true for all distributor and ingester errors and I think it is.

I've just found the timestamp too new/old error format which could be reversed (done in this PR). I also took the opportunity to:
- Directly return the TenantID() error instead of generating a new one
- Reuse a shared error for 'ingester stopping'

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
