### PR TITLE
Check type assertion in alertmanager.go

### DIFF
--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -367,7 +367,10 @@ func (am *Alertmanager) StopAndWait() {
 }
 
 func (am *Alertmanager) mergePartialExternalState(part *clusterpb.Part) error {
-	return am.state.(*state).MergePartialState(part)
+	if state, ok := am.state.(*state); ok {
+		return state.MergePartialState(part)
+	}
+	return errors.New("ring-based replication not configured")
 }
 
 // buildIntegrationsMap builds a map of name to the list of integration notifiers off of a

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -370,7 +370,7 @@ func (am *Alertmanager) mergePartialExternalState(part *clusterpb.Part) error {
 	if state, ok := am.state.(*state); ok {
 		return state.MergePartialState(part)
 	}
-	return errors.New("ring-based replication not configured")
+	return errors.New("ring-based sharding not enabled")
 }
 
 // buildIntegrationsMap builds a map of name to the list of integration notifiers off of a


### PR DESCRIPTION
**What this PR does**:
Check a type assertion in alertmanager.go which could fail if one alertmanager was configured with ring-based replication (sharding) enabled, and another configured without it enabled.
