### PR TITLE
Optimize ingester Push() on blocks storage when the per-user or per-metric series limit is reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   * `cortex_ruler_clients`
   * `cortex_ruler_client_request_duration_seconds`
 * [ENHANCEMENT] Query-frontend/scheduler: added querier forget delay (`-query-frontend.querier-forget-delay` and `-query-scheduler.querier-forget-delay`) to mitigate the blast radius in the event queriers crash because of a repeatedly sent "query of death" when shuffle-sharding is enabled. #3901
-* [ENHANCEMENT] Ingester: reduce CPU and memory when an high number of errors are returned by the ingester on the write path with the blocks storage. #3969
+* [ENHANCEMENT] Ingester: reduce CPU and memory when an high number of errors are returned by the ingester on the write path with the blocks storage. #3969 #3971
 * [BUGFIX] Distributor: reverted changes done to rate limiting in #3825. #3948
 * [BUGFIX] Querier: streamline tracing spans. #3924
 

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -67,7 +67,7 @@ func grpcForwardableError(userID string, code int, e error) error {
 	})
 }
 
-// Note: does not retain a reference to `err`
+// wrapWithUser prepends the user to the error. It does not retain a reference to err.
 func wrapWithUser(err error, userID string) error {
 	return fmt.Errorf("user=%s: %s", userID, err)
 }

--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -799,7 +799,9 @@ func (i *Ingester) v2Push(ctx context.Context, req *cortexpb.WriteRequest) (*cor
 				}
 
 				continue
-			} else if cause == errMaxSeriesPerUserLimitExceeded || cause == errMaxSeriesPerMetricLimitExceeded {
+			}
+
+			if cause == errMaxSeriesPerUserLimitExceeded || cause == errMaxSeriesPerMetricLimitExceeded {
 				switch cause {
 				case errMaxSeriesPerUserLimitExceeded:
 					if firstPartialErr == nil {

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -4,16 +4,18 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/pkg/errors"
+
 	"github.com/cortexproject/cortex/pkg/util"
 	util_math "github.com/cortexproject/cortex/pkg/util/math"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
-const (
-	errMaxSeriesPerMetricLimitExceeded   = "per-metric series limit of %d exceeded, please contact administrator to raise it. (local limit: %d global limit: %d actual local limit: %d)"
-	errMaxSeriesPerUserLimitExceeded     = "per-user series limit of %d exceeded, please contact administrator to raise it. (local limit: %d global limit: %d actual local limit: %d)"
-	errMaxMetadataPerMetricLimitExceeded = "per-metric metadata limit of %d exceeded, please contact administrator to raise it. (local limit: %d global limit: %d actual local limit: %d)"
-	errMaxMetadataPerUserLimitExceeded   = "per-user metric metadata limit of %d exceeded, please contact administrator to raise it. (local limit: %d global limit: %d actual local limit: %d)"
+var (
+	errMaxSeriesPerMetricLimitExceeded   = errors.New("per-metric series limit exceeded")
+	errMaxMetadataPerMetricLimitExceeded = errors.New("per-metric metadata limit exceeded")
+	errMaxSeriesPerUserLimitExceeded     = errors.New("per-user series limit exceeded")
+	errMaxMetadataPerUserLimitExceeded   = errors.New("per-user metric metadata limit exceeded")
 )
 
 // RingCount is the interface exposed by a ring implementation which allows
@@ -56,64 +58,99 @@ func NewLimiter(
 // AssertMaxSeriesPerMetric limit has not been reached compared to the current
 // number of series in input and returns an error if so.
 func (l *Limiter) AssertMaxSeriesPerMetric(userID string, series int) error {
-	actualLimit := l.maxSeriesPerMetric(userID)
-	if series < actualLimit {
+	if actualLimit := l.maxSeriesPerMetric(userID); series < actualLimit {
 		return nil
 	}
 
-	localLimit := l.limits.MaxLocalSeriesPerMetric(userID)
-	globalLimit := l.limits.MaxGlobalSeriesPerMetric(userID)
-
-	return fmt.Errorf(errMaxSeriesPerMetricLimitExceeded, minNonZero(localLimit, globalLimit), localLimit, globalLimit, actualLimit)
+	return errMaxSeriesPerMetricLimitExceeded
 }
 
 // AssertMaxMetadataPerMetric limit has not been reached compared to the current
 // number of metadata per metric in input and returns an error if so.
 func (l *Limiter) AssertMaxMetadataPerMetric(userID string, metadata int) error {
-	actualLimit := l.maxMetadataPerMetric(userID)
-
-	if metadata < actualLimit {
+	if actualLimit := l.maxMetadataPerMetric(userID); metadata < actualLimit {
 		return nil
 	}
 
-	localLimit := l.limits.MaxLocalMetadataPerMetric(userID)
-	globalLimit := l.limits.MaxGlobalMetadataPerMetric(userID)
-
-	return fmt.Errorf(errMaxMetadataPerMetricLimitExceeded, minNonZero(localLimit, globalLimit), localLimit, globalLimit, actualLimit)
+	return errMaxMetadataPerMetricLimitExceeded
 }
 
 // AssertMaxSeriesPerUser limit has not been reached compared to the current
 // number of series in input and returns an error if so.
 func (l *Limiter) AssertMaxSeriesPerUser(userID string, series int) error {
-	actualLimit := l.maxSeriesPerUser(userID)
-	if series < actualLimit {
+	if actualLimit := l.maxSeriesPerUser(userID); series < actualLimit {
 		return nil
 	}
 
-	localLimit := l.limits.MaxLocalSeriesPerUser(userID)
-	globalLimit := l.limits.MaxGlobalSeriesPerUser(userID)
-
-	return fmt.Errorf(errMaxSeriesPerUserLimitExceeded, minNonZero(localLimit, globalLimit), localLimit, globalLimit, actualLimit)
+	return errMaxSeriesPerUserLimitExceeded
 }
 
 // AssertMaxMetricsWithMetadataPerUser limit has not been reached compared to the current
 // number of metrics with metadata in input and returns an error if so.
 func (l *Limiter) AssertMaxMetricsWithMetadataPerUser(userID string, metrics int) error {
-	actualLimit := l.maxMetadataPerUser(userID)
-
-	if metrics < actualLimit {
+	if actualLimit := l.maxMetadataPerUser(userID); metrics < actualLimit {
 		return nil
 	}
 
-	localLimit := l.limits.MaxLocalMetricsWithMetadataPerUser(userID)
-	globalLimit := l.limits.MaxGlobalMetricsWithMetadataPerUser(userID)
-
-	return fmt.Errorf(errMaxMetadataPerUserLimitExceeded, minNonZero(localLimit, globalLimit), localLimit, globalLimit, actualLimit)
+	return errMaxMetadataPerUserLimitExceeded
 }
 
 // MaxSeriesPerQuery returns the maximum number of series a query is allowed to hit.
 func (l *Limiter) MaxSeriesPerQuery(userID string) int {
 	return l.limits.MaxSeriesPerQuery(userID)
+}
+
+// FormatError returns the input error enriched with the actual limits for the given user.
+// It acts as pass-through if the input error is unknown.
+func (l *Limiter) FormatError(userID string, err error) error {
+	switch err {
+	case errMaxSeriesPerUserLimitExceeded:
+		return l.formatMaxSeriesPerUserError(userID)
+	case errMaxSeriesPerMetricLimitExceeded:
+		return l.formatMaxSeriesPerMetricError(userID)
+	case errMaxMetadataPerUserLimitExceeded:
+		return l.formatMaxMetadataPerUserError(userID)
+	case errMaxMetadataPerMetricLimitExceeded:
+		return l.formatMaxMetadataPerMetricError(userID)
+	default:
+		return err
+	}
+}
+
+func (l *Limiter) formatMaxSeriesPerUserError(userID string) error {
+	actualLimit := l.maxSeriesPerUser(userID)
+	localLimit := l.limits.MaxLocalSeriesPerUser(userID)
+	globalLimit := l.limits.MaxGlobalSeriesPerUser(userID)
+
+	return fmt.Errorf("per-user series limit of %d exceeded, please contact administrator to raise it (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), localLimit, globalLimit, actualLimit)
+}
+
+func (l *Limiter) formatMaxSeriesPerMetricError(userID string) error {
+	actualLimit := l.maxSeriesPerMetric(userID)
+	localLimit := l.limits.MaxLocalSeriesPerMetric(userID)
+	globalLimit := l.limits.MaxGlobalSeriesPerMetric(userID)
+
+	return fmt.Errorf("per-metric series limit of %d exceeded, please contact administrator to raise it (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), localLimit, globalLimit, actualLimit)
+}
+
+func (l *Limiter) formatMaxMetadataPerUserError(userID string) error {
+	actualLimit := l.maxMetadataPerUser(userID)
+	localLimit := l.limits.MaxLocalMetricsWithMetadataPerUser(userID)
+	globalLimit := l.limits.MaxGlobalMetricsWithMetadataPerUser(userID)
+
+	return fmt.Errorf("per-user metric metadata limit of %d exceeded, please contact administrator to raise it (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), localLimit, globalLimit, actualLimit)
+}
+
+func (l *Limiter) formatMaxMetadataPerMetricError(userID string) error {
+	actualLimit := l.maxMetadataPerMetric(userID)
+	localLimit := l.limits.MaxLocalMetadataPerMetric(userID)
+	globalLimit := l.limits.MaxGlobalMetadataPerMetric(userID)
+
+	return fmt.Errorf("per-metric metadata limit of %d exceeded, please contact administrator to raise it (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), localLimit, globalLimit, actualLimit)
 }
 
 func (l *Limiter) maxSeriesPerMetric(userID string) int {

--- a/pkg/ingester/user_metrics_metadata.go
+++ b/pkg/ingester/user_metrics_metadata.go
@@ -41,7 +41,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *cortexpb.MetricMetad
 		// Verify that the user can create more metric metadata given we don't have a set for that metric name.
 		if err := mm.limiter.AssertMaxMetricsWithMetadataPerUser(mm.userID, len(mm.metricToMetadata)); err != nil {
 			validation.DiscardedMetadata.WithLabelValues(mm.userID, perUserMetadataLimit).Inc()
-			return makeLimitError(perUserMetadataLimit, err)
+			return makeLimitError(perUserMetadataLimit, mm.limiter.FormatError(mm.userID, err))
 		}
 		set = metricMetadataSet{}
 		mm.metricToMetadata[metric] = set
@@ -49,7 +49,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *cortexpb.MetricMetad
 
 	if err := mm.limiter.AssertMaxMetadataPerMetric(mm.userID, len(set)); err != nil {
 		validation.DiscardedMetadata.WithLabelValues(mm.userID, perMetricMetadataLimit).Inc()
-		return makeLimitError(perMetricMetadataLimit, err)
+		return makeLimitError(perMetricMetadataLimit, mm.limiter.FormatError(mm.userID, err))
 	}
 
 	// if we have seen this metadata before, it is a no-op and we don't need to change our metrics.

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -229,7 +229,7 @@ func (u *userState) createSeriesWithFingerprint(fp model.Fingerprint, metric lab
 
 	if !recovery {
 		if err := u.limiter.AssertMaxSeriesPerUser(u.userID, u.fpToSeries.length()); err != nil {
-			return nil, makeLimitError(perUserSeriesLimit, err)
+			return nil, makeLimitError(perUserSeriesLimit, u.limiter.FormatError(u.userID, err))
 		}
 	}
 
@@ -243,7 +243,7 @@ func (u *userState) createSeriesWithFingerprint(fp model.Fingerprint, metric lab
 		// Check if the per-metric limit has been exceeded
 		if err = u.seriesInMetric.canAddSeriesFor(u.userID, metricName); err != nil {
 			// WARNING: returns a reference to `metric`
-			return nil, makeMetricLimitError(perMetricSeriesLimit, cortexpb.FromLabelAdaptersToLabels(metric), err)
+			return nil, makeMetricLimitError(perMetricSeriesLimit, cortexpb.FromLabelAdaptersToLabels(metric), u.limiter.FormatError(u.userID, err))
 		}
 	}
 


### PR DESCRIPTION
**What this PR does**:
Following up the PR https://github.com/cortexproject/cortex/pull/3969, in this PR I'm optimizing the `v2Push()` when an high volume of per-user/series limit is reached.

In the profile I've seen much CPU and memory is consumed formatting the `Limiter` error. The idea in this PR is to return static errors from `Limiter`, offer a `FormatError()` function and then format only the 1st partial error in `v2Push()`.

_Metadata and chunks storage hasn't been changed._

**Benchmark:**

The benchmarks are on top of https://github.com/cortexproject/cortex/pull/3969 (I merged #3969 first and then worked on this PR):

```
_Ingester_v2PushOnError/failure:_per-user_series_limit_reached,_scenario:_no_concurrency-12        1.19ms ± 0%    0.63ms ± 1%  -46.91%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-user_series_limit_reached,_scenario:_low_concurrency-12       29.9ms ± 8%    16.4ms ±11%  -45.24%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-user_series_limit_reached,_scenario:_high_concurrency-12       360ms ±14%     194ms ± 9%  -46.12%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-metric_series_limit_reached,_scenario:_high_concurrency-12     1.04s ± 2%     0.33s ± 4%  -68.81%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-metric_series_limit_reached,_scenario:_no_concurrency-12      1.31ms ± 1%    0.69ms ± 2%  -47.38%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-metric_series_limit_reached,_scenario:_low_concurrency-12      105ms ±11%      30ms ± 7%  -71.19%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_bound_samples,_scenario:_no_concurrency-12                  362µs ± 3%     298µs ± 1%  -17.65%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_bound_samples,_scenario:_low_concurrency-12                8.54ms ± 6%    8.54ms ±15%     ~     (p=0.690 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_bound_samples,_scenario:_high_concurrency-12               86.1ms ± 2%    87.9ms ±13%     ~     (p=0.841 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_order_samples,_scenario:_no_concurrency-12                  351µs ±11%     304µs ± 7%  -13.45%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_order_samples,_scenario:_low_concurrency-12                6.70ms ±10%    7.53ms ±15%     ~     (p=0.095 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_order_samples,_scenario:_high_concurrency-12               74.3ms ±12%    72.9ms ±11%     ~     (p=0.690 n=5+5)

name                                                                                             old alloc/op   new alloc/op   delta
_Ingester_v2PushOnError/failure:_per-user_series_limit_reached,_scenario:_no_concurrency-12         655kB ± 0%     407kB ± 0%  -37.91%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-user_series_limit_reached,_scenario:_low_concurrency-12       67.3MB ± 0%    41.6MB ± 0%  -38.17%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-user_series_limit_reached,_scenario:_high_concurrency-12       861MB ± 8%     495MB ± 9%  -42.51%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-metric_series_limit_reached,_scenario:_high_concurrency-12     686MB ± 2%     430MB ± 6%  -37.33%  (p=0.016 n=4+5)
_Ingester_v2PushOnError/failure:_per-metric_series_limit_reached,_scenario:_no_concurrency-12       655kB ± 0%     406kB ± 0%  -38.06%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-metric_series_limit_reached,_scenario:_low_concurrency-12     67.2MB ± 3%    41.2MB ± 2%  -38.61%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_bound_samples,_scenario:_no_concurrency-12                 99.0kB ± 0%    99.0kB ± 0%     ~     (p=0.103 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_bound_samples,_scenario:_low_concurrency-12                10.4MB ± 1%    10.4MB ± 1%     ~     (p=0.841 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_bound_samples,_scenario:_high_concurrency-12                106MB ± 2%     133MB ±20%     ~     (p=0.063 n=4+5)
_Ingester_v2PushOnError/failure:_out_of_order_samples,_scenario:_no_concurrency-12                 2.15kB ± 1%    2.15kB ± 1%     ~     (p=1.000 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_order_samples,_scenario:_low_concurrency-12                 447kB ±52%     433kB ±50%     ~     (p=1.000 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_order_samples,_scenario:_high_concurrency-12               29.5MB ±86%   26.9MB ±103%     ~     (p=1.000 n=5+5)

name                                                                                             old allocs/op  new allocs/op  delta
_Ingester_v2PushOnError/failure:_per-user_series_limit_reached,_scenario:_no_concurrency-12         9.03k ± 0%     5.04k ± 0%  -44.26%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-user_series_limit_reached,_scenario:_low_concurrency-12         910k ± 0%      507k ± 0%  -44.24%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-user_series_limit_reached,_scenario:_high_concurrency-12       9.73M ± 2%     5.33M ± 3%  -45.18%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-metric_series_limit_reached,_scenario:_high_concurrency-12     9.05M ± 0%     5.10M ± 2%  -43.69%  (p=0.016 n=4+5)
_Ingester_v2PushOnError/failure:_per-metric_series_limit_reached,_scenario:_no_concurrency-12       9.04k ± 0%     5.04k ± 0%  -44.23%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_per-metric_series_limit_reached,_scenario:_low_concurrency-12       909k ± 1%      507k ± 1%  -44.28%  (p=0.008 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_bound_samples,_scenario:_no_concurrency-12                  2.04k ± 0%     2.04k ± 0%     ~     (all equal)
_Ingester_v2PushOnError/failure:_out_of_bound_samples,_scenario:_low_concurrency-12                  206k ± 0%      206k ± 0%     ~     (p=0.841 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_bound_samples,_scenario:_high_concurrency-12                2.06M ± 0%     2.15M ± 4%     ~     (p=0.063 n=4+5)
_Ingester_v2PushOnError/failure:_out_of_order_samples,_scenario:_no_concurrency-12                   40.0 ± 0%      40.0 ± 0%     ~     (all equal)
_Ingester_v2PushOnError/failure:_out_of_order_samples,_scenario:_low_concurrency-12                 4.74k ±16%     4.67k ±16%     ~     (p=1.000 n=5+5)
_Ingester_v2PushOnError/failure:_out_of_order_samples,_scenario:_high_concurrency-12                 128k ±69%      119k ±81%     ~     (p=1.000 n=5+5)
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
