### PR TITLE
Add Retries to Sync Blocks

### DIFF
--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -161,6 +161,8 @@ func (u *BucketStores) syncUsersBlocksWithRetries(ctx context.Context, s *store.
 	var lastErr error
 
 	retries := util.NewBackoff(ctx, util.BackoffConfig{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: 10 * time.Second,
 		MaxRetries: 3,
 	})
 

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -174,6 +174,10 @@ func (u *BucketStores) syncUsersBlocksWithRetries(ctx context.Context, f func(co
 		retries.Wait()
 	}
 
+	if lastErr == nil {
+		return retries.Err()
+	}
+
 	return lastErr
 }
 

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -164,16 +164,17 @@ func (u *BucketStores) syncUsersBlocksWithRetries(ctx context.Context, f func(co
 		MaxRetries: 3,
 	})
 
+	var lastErr error
 	for retries.Ongoing() {
-		err := u.syncUsersBlocks(ctx, f)
-		if err == nil {
-			return err
+		lastErr = u.syncUsersBlocks(ctx, f)
+		if lastErr == nil {
+			return nil
 		}
 
 		retries.Wait()
 	}
 
-	return retries.Err()
+	return lastErr
 }
 
 func (u *BucketStores) syncUsersBlocks(ctx context.Context, f func(context.Context, *store.BucketStore) error) (returnErr error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Adds retries to `BucketStore.SyncBlocks` with `BucketStores.syncUsersBlocksWithRetries`.

Although this fixes one part of #3802, I think that the bigger issue may be the initial sync (`BucketStores.InitialSync`), which also ends up calling `BucketStore.SyncBlocks`, but after going through `BucketStore.InitialSync` in Thanos. Maybe retries should be added there in some fashion.

https://github.com/cortexproject/cortex/blob/c28d326289ee186f18c3149a452fea12ca3007e2/pkg/storegateway/bucket_stores.go#L138-L143
https://github.com/cortexproject/cortex/blob/c28d326289ee186f18c3149a452fea12ca3007e2/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go#L463-L466

**Which issue(s) this PR fixes**:
Fixes #3802

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
