### PR TITLE
Optimize distributor push on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [ENHANCEMENT] Query-frontend/scheduler: added querier forget delay (`-query-frontend.querier-forget-delay` and `-query-scheduler.querier-forget-delay`) to mitigate the blast radius in the event queriers crash because of a repeatedly sent "query of death" when shuffle-sharding is enabled. #3901
 * [ENHANCEMENT] Query-frontend: reduced memory allocations when serializing query response. #3964
 * [ENHANCEMENT] Ingester: reduce CPU and memory when an high number of errors are returned by the ingester on the write path with the blocks storage. #3969 #3971 #3973
+* [ENHANCEMENT] Distributor: reduce CPU and memory when an high number of errors are returned by the distributor on the write path. #3990
 * [BUGFIX] Distributor: reverted changes done to rate limiting in #3825. #3948
 * [BUGFIX] Ingester: Fix race condition when opening and closing tsdb concurrently. #3959
 * [BUGFIX] Querier: streamline tracing spans. #3924

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -549,7 +549,7 @@ func (d *Distributor) Push(ctx context.Context, req *cortexpb.WriteRequest) (*co
 		// Errors in validation are considered non-fatal, as one series in a request may contain
 		// invalid data but all the remaining series could be perfectly valid.
 		if validationErr != nil && firstPartialErr == nil {
-			firstPartialErr = validationErr.ToHTTPGRPCError()
+			firstPartialErr = httpgrpc.Errorf(http.StatusBadRequest, validationErr.Error())
 		}
 
 		// validateSeries would have returned an emptyPreallocSeries if there were no valid samples.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -410,7 +410,7 @@ func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica 
 // Validates a single series from a write request. Will remove labels if
 // any are configured to be dropped for the user ID.
 // Returns the validated series with it's labels/samples, and any error.
-func (d *Distributor) validateSeries(ts cortexpb.PreallocTimeseries, userID string, skipLabelNameValidation bool) (cortexpb.PreallocTimeseries, error) {
+func (d *Distributor) validateSeries(ts cortexpb.PreallocTimeseries, userID string, skipLabelNameValidation bool) (cortexpb.PreallocTimeseries, validation.ValidationError) {
 	d.labelsHistogram.Observe(float64(len(ts.Labels)))
 	if err := validation.ValidateLabels(d.limits, userID, ts.Labels, skipLabelNameValidation); err != nil {
 		return emptyPreallocSeries, err
@@ -544,12 +544,12 @@ func (d *Distributor) Push(ctx context.Context, req *cortexpb.WriteRequest) (*co
 		}
 
 		skipLabelNameValidation := d.cfg.SkipLabelNameValidation || req.GetSkipLabelNameValidation()
-		validatedSeries, err := d.validateSeries(ts, userID, skipLabelNameValidation)
+		validatedSeries, validationErr := d.validateSeries(ts, userID, skipLabelNameValidation)
 
 		// Errors in validation are considered non-fatal, as one series in a request may contain
 		// invalid data but all the remaining series could be perfectly valid.
-		if err != nil && firstPartialErr == nil {
-			firstPartialErr = err
+		if validationErr != nil && firstPartialErr == nil {
+			firstPartialErr = validationErr.ToHTTPGRPCError()
 		}
 
 		// validateSeries would have returned an emptyPreallocSeries if there were no valid samples.

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -969,6 +969,247 @@ func TestDistributor_Push_LabelNameValidation(t *testing.T) {
 	}
 }
 
+func BenchmarkDistributor_PushOnError(b *testing.B) {
+	const (
+		numSeriesPerRequest = 1000
+	)
+
+	tests := map[string]struct {
+		prepareConfig func(limits *validation.Limits)
+		prepareSeries func() ([]labels.Labels, []cortexpb.Sample)
+		expectedErr   string
+	}{
+		"ingestion rate limit reached": {
+			prepareConfig: func(limits *validation.Limits) {
+				limits.IngestionRate = 1
+				limits.IngestionBurstSize = 1
+			},
+			prepareSeries: func() ([]labels.Labels, []cortexpb.Sample) {
+				metrics := make([]labels.Labels, numSeriesPerRequest)
+				samples := make([]cortexpb.Sample, numSeriesPerRequest)
+
+				for i := 0; i < numSeriesPerRequest; i++ {
+					lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+					for i := 0; i < 10; i++ {
+						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
+					}
+
+					metrics[i] = lbls.Labels()
+					samples[i] = cortexpb.Sample{
+						Value:       float64(i),
+						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
+					}
+				}
+
+				return metrics, samples
+			},
+			expectedErr: "ingestion rate limit",
+		},
+		"too many labels limit reached": {
+			prepareConfig: func(limits *validation.Limits) {
+				limits.MaxLabelNamesPerSeries = 30
+			},
+			prepareSeries: func() ([]labels.Labels, []cortexpb.Sample) {
+				metrics := make([]labels.Labels, numSeriesPerRequest)
+				samples := make([]cortexpb.Sample, numSeriesPerRequest)
+
+				for i := 0; i < numSeriesPerRequest; i++ {
+					lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+					for i := 1; i < 31; i++ {
+						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
+					}
+
+					metrics[i] = lbls.Labels()
+					samples[i] = cortexpb.Sample{
+						Value:       float64(i),
+						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
+					}
+				}
+
+				return metrics, samples
+			},
+			expectedErr: "series has too many labels",
+		},
+		"max label name length limit reached": {
+			prepareConfig: func(limits *validation.Limits) {
+				limits.MaxLabelNameLength = 1024
+			},
+			prepareSeries: func() ([]labels.Labels, []cortexpb.Sample) {
+				metrics := make([]labels.Labels, numSeriesPerRequest)
+				samples := make([]cortexpb.Sample, numSeriesPerRequest)
+
+				for i := 0; i < numSeriesPerRequest; i++ {
+					lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+					for i := 0; i < 10; i++ {
+						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
+					}
+
+					// Add a label with a very long name.
+					lbls.Set(fmt.Sprintf("xxx_%0.2000d", 1), "xxx")
+
+					metrics[i] = lbls.Labels()
+					samples[i] = cortexpb.Sample{
+						Value:       float64(i),
+						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
+					}
+				}
+
+				return metrics, samples
+			},
+			expectedErr: "label name too long",
+		},
+		"max label value length limit reached": {
+			prepareConfig: func(limits *validation.Limits) {
+				limits.MaxLabelValueLength = 1024
+			},
+			prepareSeries: func() ([]labels.Labels, []cortexpb.Sample) {
+				metrics := make([]labels.Labels, numSeriesPerRequest)
+				samples := make([]cortexpb.Sample, numSeriesPerRequest)
+
+				for i := 0; i < numSeriesPerRequest; i++ {
+					lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+					for i := 0; i < 10; i++ {
+						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
+					}
+
+					// Add a label with a very long value.
+					lbls.Set("xxx", fmt.Sprintf("xxx_%0.2000d", 1))
+
+					metrics[i] = lbls.Labels()
+					samples[i] = cortexpb.Sample{
+						Value:       float64(i),
+						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
+					}
+				}
+
+				return metrics, samples
+			},
+			expectedErr: "label value too long",
+		},
+		"timestamp too old": {
+			prepareConfig: func(limits *validation.Limits) {
+				limits.RejectOldSamples = true
+				limits.RejectOldSamplesMaxAge = time.Hour
+			},
+			prepareSeries: func() ([]labels.Labels, []cortexpb.Sample) {
+				metrics := make([]labels.Labels, numSeriesPerRequest)
+				samples := make([]cortexpb.Sample, numSeriesPerRequest)
+
+				for i := 0; i < numSeriesPerRequest; i++ {
+					lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+					for i := 0; i < 10; i++ {
+						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
+					}
+
+					metrics[i] = lbls.Labels()
+					samples[i] = cortexpb.Sample{
+						Value:       float64(i),
+						TimestampMs: time.Now().Add(-2*time.Hour).UnixNano() / int64(time.Millisecond),
+					}
+				}
+
+				return metrics, samples
+			},
+			expectedErr: "timestamp too old",
+		},
+		"timestamp too new": {
+			prepareConfig: func(limits *validation.Limits) {
+				limits.CreationGracePeriod = time.Minute
+			},
+			prepareSeries: func() ([]labels.Labels, []cortexpb.Sample) {
+				metrics := make([]labels.Labels, numSeriesPerRequest)
+				samples := make([]cortexpb.Sample, numSeriesPerRequest)
+
+				for i := 0; i < numSeriesPerRequest; i++ {
+					lbls := labels.NewBuilder(labels.Labels{{Name: model.MetricNameLabel, Value: "foo"}})
+					for i := 0; i < 10; i++ {
+						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
+					}
+
+					metrics[i] = lbls.Labels()
+					samples[i] = cortexpb.Sample{
+						Value:       float64(i),
+						TimestampMs: time.Now().Add(time.Hour).UnixNano() / int64(time.Millisecond),
+					}
+				}
+
+				return metrics, samples
+			},
+			expectedErr: "timestamp too new",
+		},
+	}
+
+	for testName, testData := range tests {
+		b.Run(testName, func(b *testing.B) {
+			// Create an in-memory KV store for the ring with 1 ingester registered.
+			kvStore := consul.NewInMemoryClient(ring.GetCodec())
+			err := kvStore.CAS(context.Background(), ring.IngesterRingKey,
+				func(_ interface{}) (interface{}, bool, error) {
+					d := &ring.Desc{}
+					d.AddIngester("ingester-1", "127.0.0.1", "", ring.GenerateTokens(128, nil), ring.ACTIVE, time.Now())
+					return d, true, nil
+				},
+			)
+			require.NoError(b, err)
+
+			ingestersRing, err := ring.New(ring.Config{
+				KVStore:           kv.Config{Mock: kvStore},
+				HeartbeatTimeout:  60 * time.Minute,
+				ReplicationFactor: 1,
+			}, ring.IngesterRingKey, ring.IngesterRingKey, nil)
+			require.NoError(b, err)
+			require.NoError(b, services.StartAndAwaitRunning(context.Background(), ingestersRing))
+			b.Cleanup(func() {
+				require.NoError(b, services.StopAndAwaitTerminated(context.Background(), ingestersRing))
+			})
+
+			test.Poll(b, time.Second, 1, func() interface{} {
+				return ingestersRing.InstancesCount()
+			})
+
+			// Prepare the distributor configuration.
+			var distributorCfg Config
+			var clientConfig client.Config
+			limits := validation.Limits{}
+			flagext.DefaultValues(&distributorCfg, &clientConfig, &limits)
+
+			limits.IngestionRate = 0 // Unlimited.
+			testData.prepareConfig(&limits)
+
+			distributorCfg.ShardByAllLabels = true
+			distributorCfg.IngesterClientFactory = func(addr string) (ring_client.PoolClient, error) {
+				return &noopIngester{}, nil
+			}
+
+			overrides, err := validation.NewOverrides(limits, nil)
+			require.NoError(b, err)
+
+			// Start the distributor.
+			distributor, err := New(distributorCfg, clientConfig, overrides, ingestersRing, true, nil, log.NewNopLogger())
+			require.NoError(b, err)
+			require.NoError(b, services.StartAndAwaitRunning(context.Background(), distributor))
+
+			b.Cleanup(func() {
+				require.NoError(b, services.StopAndAwaitTerminated(context.Background(), distributor))
+			})
+
+			// Prepare the series to remote write before starting the benchmark.
+			metrics, samples := testData.prepareSeries()
+
+			// Run the benchmark.
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for n := 0; n < b.N; n++ {
+				_, err := distributor.Push(ctx, cortexpb.ToWriteRequest(metrics, samples, nil, cortexpb.API))
+				if err == nil || !strings.Contains(err.Error(), testData.expectedErr) {
+					b.Fatalf("expected %v error but got %v", testData.expectedErr, err)
+				}
+			}
+		})
+	}
+}
+
 func TestSlowQueries(t *testing.T) {
 	nameMatcher := mustEqualMatcher(model.MetricNameLabel, "foo")
 	nIngesters := 3
@@ -1659,6 +1900,20 @@ func (i *mockIngester) countCalls(name string) int {
 	defer i.Unlock()
 
 	return i.calls[name]
+}
+
+// noopIngester is a mocked ingester which does nothing.
+type noopIngester struct {
+	client.IngesterClient
+	grpc_health_v1.HealthClient
+}
+
+func (i *noopIngester) Close() error {
+	return nil
+}
+
+func (i *noopIngester) Push(ctx context.Context, req *cortexpb.WriteRequest, opts ...grpc.CallOption) (*cortexpb.WriteResponse, error) {
+	return nil, nil
 }
 
 type stream struct {

--- a/pkg/util/validation/errors.go
+++ b/pkg/util/validation/errors.go
@@ -2,25 +2,17 @@ package validation
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/prometheus/common/model"
-	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 )
 
-// ValidationError is an error returned by series validation. It provides a function to convert
-// the error into an HTTPGRPC error.
+// ValidationError is an error returned by series validation.
 //
 // nolint:golint ignore stutter warning
-type ValidationError interface {
-	error
-
-	// ToHTTPGRPCError returns the httpgrpc version of the error.
-	ToHTTPGRPCError() error
-}
+type ValidationError error
 
 // genericValidationError is a basic implementation of ValidationError which can be used when the
 // error format only contains the cause and the series.
@@ -30,12 +22,8 @@ type genericValidationError struct {
 	series  []cortexpb.LabelAdapter
 }
 
-func (e *genericValidationError) ToHTTPGRPCError() error {
-	return httpgrpc.Errorf(http.StatusBadRequest, e.message, e.cause, formatLabelSet(e.series))
-}
-
 func (e *genericValidationError) Error() string {
-	return e.ToHTTPGRPCError().Error()
+	return fmt.Sprintf(e.message, e.cause, formatLabelSet(e.series))
 }
 
 func newLabelNameTooLongError(series []cortexpb.LabelAdapter, labelName string) ValidationError {
@@ -90,15 +78,10 @@ func newTooManyLabelsError(series []cortexpb.LabelAdapter, limit int) Validation
 	}
 }
 
-func (e *tooManyLabelsError) ToHTTPGRPCError() error {
-	return httpgrpc.Errorf(
-		http.StatusBadRequest,
+func (e *tooManyLabelsError) Error() string {
+	return fmt.Sprintf(
 		"series has too many labels (actual: %d, limit: %d) series: '%s'",
 		len(e.series), e.limit, cortexpb.FromLabelAdaptersToMetric(e.series).String())
-}
-
-func (e *tooManyLabelsError) Error() string {
-	return e.ToHTTPGRPCError().Error()
 }
 
 type noMetricNameError struct{}
@@ -107,12 +90,8 @@ func newNoMetricNameError() ValidationError {
 	return &noMetricNameError{}
 }
 
-func (e *noMetricNameError) ToHTTPGRPCError() error {
-	return httpgrpc.Errorf(http.StatusBadRequest, "sample missing metric name")
-}
-
 func (e *noMetricNameError) Error() string {
-	return e.ToHTTPGRPCError().Error()
+	return "sample missing metric name"
 }
 
 type invalidMetricNameError struct {
@@ -125,12 +104,8 @@ func newInvalidMetricNameError(metricName string) ValidationError {
 	}
 }
 
-func (e *invalidMetricNameError) ToHTTPGRPCError() error {
-	return httpgrpc.Errorf(http.StatusBadRequest, "sample invalid metric name: %.200q", e.metricName)
-}
-
 func (e *invalidMetricNameError) Error() string {
-	return e.ToHTTPGRPCError().Error()
+	return fmt.Sprintf("sample invalid metric name: %.200q", e.metricName)
 }
 
 // sampleValidationError is a ValidationError implementation suitable for sample validation errors.
@@ -140,12 +115,8 @@ type sampleValidationError struct {
 	timestamp  int64
 }
 
-func (e *sampleValidationError) ToHTTPGRPCError() error {
-	return httpgrpc.Errorf(http.StatusBadRequest, e.message, e.timestamp, e.metricName)
-}
-
 func (e *sampleValidationError) Error() string {
-	return e.ToHTTPGRPCError().Error()
+	return fmt.Sprintf(e.message, e.timestamp, e.metricName)
 }
 
 func newSampleTimestampTooOldError(metricName string, timestamp int64) ValidationError {

--- a/pkg/util/validation/errors.go
+++ b/pkg/util/validation/errors.go
@@ -1,0 +1,191 @@
+package validation
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/prometheus/common/model"
+	"github.com/weaveworks/common/httpgrpc"
+
+	"github.com/cortexproject/cortex/pkg/cortexpb"
+)
+
+// ValidationError is an error returned by series validation. It provides a function to convert
+// the error into an HTTPGRPC error.
+//
+// nolint:golint ignore stutter warning
+type ValidationError interface {
+	error
+
+	// ToHTTPGRPCError returns the httpgrpc version of the error.
+	ToHTTPGRPCError() error
+}
+
+// genericValidationError is a basic implementation of ValidationError which can be used when the
+// error format only contains the cause and the series.
+type genericValidationError struct {
+	message string
+	cause   string
+	series  []cortexpb.LabelAdapter
+}
+
+func (e *genericValidationError) ToHTTPGRPCError() error {
+	return httpgrpc.Errorf(http.StatusBadRequest, e.message, e.cause, formatLabelSet(e.series))
+}
+
+func (e *genericValidationError) Error() string {
+	return e.ToHTTPGRPCError().Error()
+}
+
+func newLabelNameTooLongError(series []cortexpb.LabelAdapter, labelName string) ValidationError {
+	return &genericValidationError{
+		message: "label name too long: %.200q metric %.200q",
+		cause:   labelName,
+		series:  series,
+	}
+}
+
+func newLabelValueTooLongError(series []cortexpb.LabelAdapter, labelValue string) ValidationError {
+	return &genericValidationError{
+		message: "label value too long: %.200q metric %.200q",
+		cause:   labelValue,
+		series:  series,
+	}
+}
+
+func newInvalidLabelError(series []cortexpb.LabelAdapter, labelName string) ValidationError {
+	return &genericValidationError{
+		message: "sample invalid label: %.200q metric %.200q",
+		cause:   labelName,
+		series:  series,
+	}
+}
+
+func newDuplicatedLabelError(series []cortexpb.LabelAdapter, labelName string) ValidationError {
+	return &genericValidationError{
+		message: "duplicate label name: %.200q metric %.200q",
+		cause:   labelName,
+		series:  series,
+	}
+}
+
+func newLabelsNotSortedError(series []cortexpb.LabelAdapter, labelName string) ValidationError {
+	return &genericValidationError{
+		message: "labels not sorted: %.200q metric %.200q",
+		cause:   labelName,
+		series:  series,
+	}
+}
+
+type tooManyLabelsError struct {
+	series []cortexpb.LabelAdapter
+	limit  int
+}
+
+func newTooManyLabelsError(series []cortexpb.LabelAdapter, limit int) ValidationError {
+	return &tooManyLabelsError{
+		series: series,
+		limit:  limit,
+	}
+}
+
+func (e *tooManyLabelsError) ToHTTPGRPCError() error {
+	return httpgrpc.Errorf(
+		http.StatusBadRequest,
+		"series has too many labels (actual: %d, limit: %d) series: '%s'",
+		len(e.series), e.limit, cortexpb.FromLabelAdaptersToMetric(e.series).String())
+}
+
+func (e *tooManyLabelsError) Error() string {
+	return e.ToHTTPGRPCError().Error()
+}
+
+type noMetricNameError struct{}
+
+func newNoMetricNameError() ValidationError {
+	return &noMetricNameError{}
+}
+
+func (e *noMetricNameError) ToHTTPGRPCError() error {
+	return httpgrpc.Errorf(http.StatusBadRequest, "sample missing metric name")
+}
+
+func (e *noMetricNameError) Error() string {
+	return e.ToHTTPGRPCError().Error()
+}
+
+type invalidMetricNameError struct {
+	metricName string
+}
+
+func newInvalidMetricNameError(metricName string) ValidationError {
+	return &invalidMetricNameError{
+		metricName: metricName,
+	}
+}
+
+func (e *invalidMetricNameError) ToHTTPGRPCError() error {
+	return httpgrpc.Errorf(http.StatusBadRequest, "sample invalid metric name: %.200q", e.metricName)
+}
+
+func (e *invalidMetricNameError) Error() string {
+	return e.ToHTTPGRPCError().Error()
+}
+
+// sampleValidationError is a ValidationError implementation suitable for sample validation errors.
+type sampleValidationError struct {
+	message    string
+	metricName string
+	timestamp  int64
+}
+
+func (e *sampleValidationError) ToHTTPGRPCError() error {
+	return httpgrpc.Errorf(http.StatusBadRequest, e.message, e.timestamp, e.metricName)
+}
+
+func (e *sampleValidationError) Error() string {
+	return e.ToHTTPGRPCError().Error()
+}
+
+func newSampleTimestampTooOldError(metricName string, timestamp int64) ValidationError {
+	return &sampleValidationError{
+		message:    "timestamp too old: %d metric: %.200q",
+		metricName: metricName,
+		timestamp:  timestamp,
+	}
+}
+
+func newSampleTimestampTooNewError(metricName string, timestamp int64) ValidationError {
+	return &sampleValidationError{
+		message:    "timestamp too new: %d metric: %.200q",
+		metricName: metricName,
+		timestamp:  timestamp,
+	}
+}
+
+// formatLabelSet formats label adapters as a metric name with labels, while preserving
+// label order, and keeping duplicates. If there are multiple "__name__" labels, only
+// first one is used as metric name, other ones will be included as regular labels.
+func formatLabelSet(ls []cortexpb.LabelAdapter) string {
+	metricName, hasMetricName := "", false
+
+	labelStrings := make([]string, 0, len(ls))
+	for _, l := range ls {
+		if l.Name == model.MetricNameLabel && !hasMetricName && l.Value != "" {
+			metricName = l.Value
+			hasMetricName = true
+		} else {
+			labelStrings = append(labelStrings, fmt.Sprintf("%s=%q", l.Name, l.Value))
+		}
+	}
+
+	if len(labelStrings) == 0 {
+		if hasMetricName {
+			return metricName
+		}
+		return "{}"
+	}
+
+	return fmt.Sprintf("%s{%s}", metricName, strings.Join(labelStrings, ", "))
+}

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -1,7 +1,6 @@
 package validation
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -30,17 +29,6 @@ const (
 	metricNameTooLong = "metric_name_too_long"
 	helpTooLong       = "help_too_long"
 	unitTooLong       = "unit_too_long"
-
-	errMissingMetricName  = "sample missing metric name"
-	errInvalidMetricName  = "sample invalid metric name: %.200q"
-	errInvalidLabel       = "sample invalid label: %.200q metric %.200q"
-	errLabelNameTooLong   = "label name too long: %.200q metric %.200q"
-	errLabelValueTooLong  = "label value too long: %.200q metric %.200q"
-	errTooManyLabels      = "series has too many labels (actual: %d, limit: %d) series: '%s'"
-	errTooOld             = "timestamp too old: %d metric: %.200q"
-	errTooNew             = "timestamp too new: %d metric: %.200q"
-	errDuplicateLabelName = "duplicate label name: %.200q metric %.200q"
-	errLabelsNotSorted    = "labels not sorted: %.200q metric %.200q"
 
 	// ErrQueryTooLong is used in chunk store, querier and query frontend.
 	ErrQueryTooLong = "the query time range exceeds the limit (query length: %s, limit: %s)"
@@ -94,16 +82,17 @@ type SampleValidationConfig interface {
 	CreationGracePeriod(userID string) time.Duration
 }
 
-// ValidateSample returns an err if the sample is invalid.
-func ValidateSample(cfg SampleValidationConfig, userID string, metricName string, s cortexpb.Sample) error {
+// ValidateSample returns an err if the sample is invalid. The returned ValidationError
+// provides a function to convert it to an HTTPGRPC error.
+func ValidateSample(cfg SampleValidationConfig, userID string, metricName string, s cortexpb.Sample) ValidationError {
 	if cfg.RejectOldSamples(userID) && model.Time(s.TimestampMs) < model.Now().Add(-cfg.RejectOldSamplesMaxAge(userID)) {
 		DiscardedSamples.WithLabelValues(greaterThanMaxSampleAge, userID).Inc()
-		return httpgrpc.Errorf(http.StatusBadRequest, errTooOld, model.Time(s.TimestampMs), metricName)
+		return newSampleTimestampTooOldError(metricName, s.TimestampMs)
 	}
 
 	if model.Time(s.TimestampMs) > model.Now().Add(cfg.CreationGracePeriod(userID)) {
 		DiscardedSamples.WithLabelValues(tooFarInFuture, userID).Inc()
-		return httpgrpc.Errorf(http.StatusBadRequest, errTooNew, model.Time(s.TimestampMs), metricName)
+		return newSampleTimestampTooNewError(metricName, s.TimestampMs)
 	}
 
 	return nil
@@ -117,61 +106,51 @@ type LabelValidationConfig interface {
 	MaxLabelValueLength(userID string) int
 }
 
-// ValidateLabels returns an err if the labels are invalid.
-func ValidateLabels(cfg LabelValidationConfig, userID string, ls []cortexpb.LabelAdapter, skipLabelNameValidation bool) error {
+// ValidateLabels returns an err if the labels are invalid. The returned ValidationError
+// provides a function to convert it to an HTTPGRPC error.
+func ValidateLabels(cfg LabelValidationConfig, userID string, ls []cortexpb.LabelAdapter, skipLabelNameValidation bool) ValidationError {
 	if cfg.EnforceMetricName(userID) {
 		metricName, err := extract.MetricNameFromLabelAdapters(ls)
 		if err != nil {
 			DiscardedSamples.WithLabelValues(missingMetricName, userID).Inc()
-			return httpgrpc.Errorf(http.StatusBadRequest, errMissingMetricName)
+			return newNoMetricNameError()
 		}
 
 		if !model.IsValidMetricName(model.LabelValue(metricName)) {
 			DiscardedSamples.WithLabelValues(invalidMetricName, userID).Inc()
-			return httpgrpc.Errorf(http.StatusBadRequest, errInvalidMetricName, metricName)
+			return newInvalidMetricNameError(metricName)
 		}
 	}
 
 	numLabelNames := len(ls)
 	if numLabelNames > cfg.MaxLabelNamesPerSeries(userID) {
 		DiscardedSamples.WithLabelValues(maxLabelNamesPerSeries, userID).Inc()
-		return httpgrpc.Errorf(http.StatusBadRequest, errTooManyLabels, numLabelNames, cfg.MaxLabelNamesPerSeries(userID), cortexpb.FromLabelAdaptersToMetric(ls).String())
+		return newTooManyLabelsError(ls, cfg.MaxLabelNamesPerSeries(userID))
 	}
 
 	maxLabelNameLength := cfg.MaxLabelNameLength(userID)
 	maxLabelValueLength := cfg.MaxLabelValueLength(userID)
 	lastLabelName := ""
 	for _, l := range ls {
-		var errTemplate string
-		var reason string
-		var cause interface{}
 		if !skipLabelNameValidation && !model.LabelName(l.Name).IsValid() {
-			reason = invalidLabel
-			errTemplate = errInvalidLabel
-			cause = l.Name
+			DiscardedSamples.WithLabelValues(invalidLabel, userID).Inc()
+			return newInvalidLabelError(ls, l.Name)
 		} else if len(l.Name) > maxLabelNameLength {
-			reason = labelNameTooLong
-			errTemplate = errLabelNameTooLong
-			cause = l.Name
+			DiscardedSamples.WithLabelValues(labelNameTooLong, userID).Inc()
+			return newLabelNameTooLongError(ls, l.Name)
 		} else if len(l.Value) > maxLabelValueLength {
-			reason = labelValueTooLong
-			errTemplate = errLabelValueTooLong
-			cause = l.Value
+			DiscardedSamples.WithLabelValues(labelValueTooLong, userID).Inc()
+			return newLabelValueTooLongError(ls, l.Value)
 		} else if cmp := strings.Compare(lastLabelName, l.Name); cmp >= 0 {
 			if cmp == 0 {
-				reason = duplicateLabelNames
-				errTemplate = errDuplicateLabelName
-				cause = l.Name
+				DiscardedSamples.WithLabelValues(duplicateLabelNames, userID).Inc()
+				return newDuplicatedLabelError(ls, l.Name)
 			} else {
-				reason = labelsNotSorted
-				errTemplate = errLabelsNotSorted
-				cause = l.Name
+				DiscardedSamples.WithLabelValues(labelsNotSorted, userID).Inc()
+				return newLabelsNotSortedError(ls, l.Name)
 			}
 		}
-		if errTemplate != "" {
-			DiscardedSamples.WithLabelValues(reason, userID).Inc()
-			return httpgrpc.Errorf(http.StatusBadRequest, errTemplate, cause, formatLabelSet(ls))
-		}
+
 		lastLabelName = l.Name
 	}
 	return nil
@@ -214,32 +193,6 @@ func ValidateMetadata(cfg MetadataValidationConfig, userID string, metadata *cor
 	}
 
 	return nil
-}
-
-// this function formats label adapters as a metric name with labels, while preserving
-// label order, and keeping duplicates. If there are multiple "__name__" labels, only
-// first one is used as metric name, other ones will be included as regular labels.
-func formatLabelSet(ls []cortexpb.LabelAdapter) string {
-	metricName, hasMetricName := "", false
-
-	labelStrings := make([]string, 0, len(ls))
-	for _, l := range ls {
-		if l.Name == model.MetricNameLabel && !hasMetricName && l.Value != "" {
-			metricName = l.Value
-			hasMetricName = true
-		} else {
-			labelStrings = append(labelStrings, fmt.Sprintf("%s=%q", l.Name, l.Value))
-		}
-	}
-
-	if len(labelStrings) == 0 {
-		if hasMetricName {
-			return metricName
-		}
-		return "{}"
-	}
-
-	return fmt.Sprintf("%s{%s}", metricName, strings.Join(labelStrings, ", "))
 }
 
 func DeletePerUserValidationMetrics(userID string, log log.Logger) {

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -82,8 +82,7 @@ type SampleValidationConfig interface {
 	CreationGracePeriod(userID string) time.Duration
 }
 
-// ValidateSample returns an err if the sample is invalid. The returned ValidationError
-// provides a function to convert it to an HTTPGRPC error.
+// ValidateSample returns an err if the sample is invalid.
 func ValidateSample(cfg SampleValidationConfig, userID string, metricName string, s cortexpb.Sample) ValidationError {
 	if cfg.RejectOldSamples(userID) && model.Time(s.TimestampMs) < model.Now().Add(-cfg.RejectOldSamplesMaxAge(userID)) {
 		DiscardedSamples.WithLabelValues(greaterThanMaxSampleAge, userID).Inc()
@@ -106,8 +105,7 @@ type LabelValidationConfig interface {
 	MaxLabelValueLength(userID string) int
 }
 
-// ValidateLabels returns an err if the labels are invalid. The returned ValidationError
-// provides a function to convert it to an HTTPGRPC error.
+// ValidateLabels returns an err if the labels are invalid.
 func ValidateLabels(cfg LabelValidationConfig, userID string, ls []cortexpb.LabelAdapter, skipLabelNameValidation bool) ValidationError {
 	if cfg.EnforceMetricName(userID) {
 		metricName, err := extract.MetricNameFromLabelAdapters(ls)

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -145,10 +145,10 @@ func ValidateLabels(cfg LabelValidationConfig, userID string, ls []cortexpb.Labe
 			if cmp == 0 {
 				DiscardedSamples.WithLabelValues(duplicateLabelNames, userID).Inc()
 				return newDuplicatedLabelError(ls, l.Name)
-			} else {
-				DiscardedSamples.WithLabelValues(labelsNotSorted, userID).Inc()
-				return newLabelsNotSortedError(ls, l.Name)
 			}
+
+			DiscardedSamples.WithLabelValues(labelsNotSorted, userID).Inc()
+			return newLabelsNotSortedError(ls, l.Name)
 		}
 
 		lastLabelName = l.Name

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -69,17 +69,20 @@ func TestValidateLabels(t *testing.T) {
 		{
 			map[model.LabelName]model.LabelValue{},
 			false,
-			httpgrpc.Errorf(http.StatusBadRequest, errMissingMetricName),
+			newNoMetricNameError(),
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: " "},
 			false,
-			httpgrpc.Errorf(http.StatusBadRequest, errInvalidMetricName, " "),
+			newInvalidMetricNameError(" "),
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "valid", "foo ": "bar"},
 			false,
-			httpgrpc.Errorf(http.StatusBadRequest, errInvalidLabel, "foo ", `valid{foo ="bar"}`),
+			newInvalidLabelError([]cortexpb.LabelAdapter{
+				{Name: model.MetricNameLabel, Value: "valid"},
+				{Name: "foo ", Value: "bar"},
+			}, "foo "),
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "valid"},
@@ -89,17 +92,27 @@ func TestValidateLabels(t *testing.T) {
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "badLabelName", "this_is_a_really_really_long_name_that_should_cause_an_error": "test_value_please_ignore"},
 			false,
-			httpgrpc.Errorf(http.StatusBadRequest, errLabelNameTooLong, "this_is_a_really_really_long_name_that_should_cause_an_error", `badLabelName{this_is_a_really_really_long_name_that_should_cause_an_error="test_value_please_ignore"}`),
+			newLabelNameTooLongError([]cortexpb.LabelAdapter{
+				{Name: model.MetricNameLabel, Value: "badLabelName"},
+				{Name: "this_is_a_really_really_long_name_that_should_cause_an_error", Value: "test_value_please_ignore"},
+			}, "this_is_a_really_really_long_name_that_should_cause_an_error"),
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "badLabelValue", "much_shorter_name": "test_value_please_ignore_no_really_nothing_to_see_here"},
 			false,
-			httpgrpc.Errorf(http.StatusBadRequest, errLabelValueTooLong, "test_value_please_ignore_no_really_nothing_to_see_here", `badLabelValue{much_shorter_name="test_value_please_ignore_no_really_nothing_to_see_here"}`),
+			newLabelValueTooLongError([]cortexpb.LabelAdapter{
+				{Name: model.MetricNameLabel, Value: "badLabelValue"},
+				{Name: "much_shorter_name", Value: "test_value_please_ignore_no_really_nothing_to_see_here"},
+			}, "test_value_please_ignore_no_really_nothing_to_see_here"),
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "foo", "bar": "baz", "blip": "blop"},
 			false,
-			httpgrpc.Errorf(http.StatusBadRequest, errTooManyLabels, 3, 2, `foo{bar="baz", blip="blop"}`),
+			newTooManyLabelsError([]cortexpb.LabelAdapter{
+				{Name: model.MetricNameLabel, Value: "foo"},
+				{Name: "bar", Value: "baz"},
+				{Name: "blip", Value: "blop"},
+			}, 2),
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "foo", "invalid%label&name": "bar"},
@@ -107,7 +120,6 @@ func TestValidateLabels(t *testing.T) {
 			nil,
 		},
 	} {
-
 		err := ValidateLabels(cfg, userID, cortexpb.FromMetricsToLabelAdapters(c.metric), c.skipLabelNameValidation)
 		assert.Equal(t, c.err, err, "wrong error")
 	}
@@ -209,12 +221,17 @@ func TestValidateLabelOrder(t *testing.T) {
 
 	userID := "testUser"
 
-	err := ValidateLabels(cfg, userID, []cortexpb.LabelAdapter{
+	actual := ValidateLabels(cfg, userID, []cortexpb.LabelAdapter{
 		{Name: model.MetricNameLabel, Value: "m"},
 		{Name: "b", Value: "b"},
 		{Name: "a", Value: "a"},
 	}, false)
-	assert.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, errLabelsNotSorted, "a", `m{b="b", a="a"}`), err)
+	expected := newLabelsNotSortedError([]cortexpb.LabelAdapter{
+		{Name: model.MetricNameLabel, Value: "m"},
+		{Name: "b", Value: "b"},
+		{Name: "a", Value: "a"},
+	}, "a")
+	assert.Equal(t, expected, actual)
 }
 
 func TestValidateLabelDuplication(t *testing.T) {
@@ -225,16 +242,25 @@ func TestValidateLabelDuplication(t *testing.T) {
 
 	userID := "testUser"
 
-	err := ValidateLabels(cfg, userID, []cortexpb.LabelAdapter{
+	actual := ValidateLabels(cfg, userID, []cortexpb.LabelAdapter{
 		{Name: model.MetricNameLabel, Value: "a"},
 		{Name: model.MetricNameLabel, Value: "b"},
 	}, false)
-	assert.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, errDuplicateLabelName, "__name__", `a{__name__="b"}`), err)
+	expected := newDuplicatedLabelError([]cortexpb.LabelAdapter{
+		{Name: model.MetricNameLabel, Value: "a"},
+		{Name: model.MetricNameLabel, Value: "b"},
+	}, model.MetricNameLabel)
+	assert.Equal(t, expected, actual)
 
-	err = ValidateLabels(cfg, userID, []cortexpb.LabelAdapter{
+	actual = ValidateLabels(cfg, userID, []cortexpb.LabelAdapter{
 		{Name: model.MetricNameLabel, Value: "a"},
 		{Name: "a", Value: "a"},
 		{Name: "a", Value: "a"},
 	}, false)
-	assert.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, errDuplicateLabelName, "a", `a{a="a", a="a"}`), err)
+	expected = newDuplicatedLabelError([]cortexpb.LabelAdapter{
+		{Name: model.MetricNameLabel, Value: "a"},
+		{Name: "a", Value: "a"},
+		{Name: "a", Value: "a"},
+	}, "a")
+	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
**What this PR does**:
Following up the work done in ingesters to optimize the unhappy path (#3969 #3971 #3973), in this PR I'm introducing a benchmark for the `Distributor.Push()` on validation error and optimizing it.

Contrary to the ingester, for the distributor I didn't pick the path of returning static errors from `ValidateLabels()` and `ValidateSample()` and then offer a function to format them because the formatting function ended up to replicate the validation logic too. What I'm proposing in this PR is returning a `ValidationError` which can be converted to HTTPGRPC error. We still have 1 allocation for each series/sample but, as you can see from the benchmark, the impact is minimal: the real optimization is not having to format an httpgrpc error each time.

**Benchmark:**

```
Distributor_PushOnError/max_label_name_length_limit_reached-12     15.8ms ± 0%     5.0ms ± 1%  -68.46%  (p=0.016 n=4+5)
Distributor_PushOnError/max_label_value_length_limit_reached-12    35.9ms ± 1%     3.0ms ± 0%  -91.75%  (p=0.016 n=5+4)
Distributor_PushOnError/timestamp_too_old-12                       2.37ms ± 0%    1.03ms ± 1%  -56.72%  (p=0.016 n=4+5)
Distributor_PushOnError/timestamp_too_new-12                       2.37ms ± 1%    1.03ms ± 2%  -56.60%  (p=0.016 n=4+5)
Distributor_PushOnError/ingestion_rate_limit_reached-12             877µs ± 0%     869µs ± 0%   -0.91%  (p=0.029 n=4+4)
Distributor_PushOnError/too_many_labels_limit_reached-12           19.6ms ± 0%     1.3ms ± 1%  -93.44%  (p=0.008 n=5+5)

name                                                             old alloc/op   new alloc/op   delta
Distributor_PushOnError/max_label_name_length_limit_reached-12     11.2MB ± 0%     0.1MB ± 0%  -98.85%  (p=0.008 n=5+5)
Distributor_PushOnError/max_label_value_length_limit_reached-12    13.3MB ± 0%     0.1MB ± 0%  -99.03%  (p=0.008 n=5+5)
Distributor_PushOnError/timestamp_too_old-12                        824kB ± 0%     118kB ± 0%  -85.71%  (p=0.008 n=5+5)
Distributor_PushOnError/timestamp_too_new-12                        824kB ± 0%     118kB ± 0%  -85.72%  (p=0.008 n=5+5)
Distributor_PushOnError/ingestion_rate_limit_reached-12            85.2kB ± 0%    85.3kB ± 0%     ~     (p=0.056 n=5+5)
Distributor_PushOnError/too_many_labels_limit_reached-12           10.1MB ± 0%     0.1MB ± 0%  -99.07%  (p=0.008 n=5+5)

name                                                             old allocs/op  new allocs/op  delta
Distributor_PushOnError/max_label_name_length_limit_reached-12      58.1k ± 0%      3.1k ± 0%  -94.69%  (p=0.008 n=5+5)
Distributor_PushOnError/max_label_value_length_limit_reached-12     59.1k ± 0%      3.1k ± 0%  -94.79%  (p=0.008 n=5+5)
Distributor_PushOnError/timestamp_too_old-12                        19.0k ± 0%      5.0k ± 0%  -73.56%  (p=0.008 n=5+5)
Distributor_PushOnError/timestamp_too_new-12                        19.0k ± 0%      5.0k ± 0%  -73.56%  (p=0.008 n=5+5)
Distributor_PushOnError/ingestion_rate_limit_reached-12             4.03k ± 0%     4.03k ± 0%     ~     (p=0.167 n=5+5)
Distributor_PushOnError/too_many_labels_limit_reached-12             114k ± 0%        3k ± 0%  -97.26%  (p=0.008 n=5+5)
```

_No optimization to ingestion rate limit but added to the benchmark to measure it too._

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
