### PR TITLE
Factor out object read/write from BucketAlertStore into ProtobufStore.

### DIFF
--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -1,15 +1,12 @@
 package bucketclient
 
 import (
-	"bytes"
 	"context"
-	"io/ioutil"
 	"sync"
 
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/thanos-io/thanos/pkg/objstore"
-	"github.com/thanos-io/thanos/pkg/runutil"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager/alertspb"
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
@@ -27,29 +24,18 @@ const (
 // BucketAlertStore is used to support the AlertStore interface against an object storage backend. It is implemented
 // using the Thanos objstore.Bucket interface
 type BucketAlertStore struct {
-	bucket      objstore.Bucket
-	cfgProvider bucket.TenantConfigProvider
-	logger      log.Logger
+	store *ProtobufStore
 }
 
 func NewBucketAlertStore(bkt objstore.Bucket, cfgProvider bucket.TenantConfigProvider, logger log.Logger) *BucketAlertStore {
 	return &BucketAlertStore{
-		bucket:      bucket.NewPrefixedBucketClient(bkt, alertsPrefix),
-		cfgProvider: cfgProvider,
-		logger:      logger,
+		store: NewProtobufStore(alertsPrefix, bkt, cfgProvider, logger),
 	}
 }
 
 // ListAllUsers implements alertstore.AlertStore.
 func (s *BucketAlertStore) ListAllUsers(ctx context.Context) ([]string, error) {
-	var userIDs []string
-
-	err := s.bucket.Iter(ctx, "", func(key string) error {
-		userIDs = append(userIDs, key)
-		return nil
-	})
-
-	return userIDs, err
+	return s.store.ListAllUsers(ctx)
 }
 
 // GetAlertConfigs implements alertstore.AlertStore.
@@ -62,8 +48,9 @@ func (s *BucketAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string
 	err := concurrency.ForEach(ctx, concurrency.CreateJobsFromStrings(userIDs), fetchConcurrency, func(ctx context.Context, job interface{}) error {
 		userID := job.(string)
 
-		cfg, err := s.getAlertConfig(ctx, userID)
-		if s.bucket.IsObjNotFoundErr(err) {
+		cfg := alertspb.AlertConfigDesc{}
+		err := s.store.Get(ctx, userID, &cfg)
+		if s.store.IsNotFoundErr(err) {
 			return nil
 		} else if err != nil {
 			return errors.Wrapf(err, "failed to fetch alertmanager config for user %s", userID)
@@ -81,8 +68,9 @@ func (s *BucketAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string
 
 // GetAlertConfig implements alertstore.AlertStore.
 func (s *BucketAlertStore) GetAlertConfig(ctx context.Context, userID string) (alertspb.AlertConfigDesc, error) {
-	cfg, err := s.getAlertConfig(ctx, userID)
-	if s.bucket.IsObjNotFoundErr(err) {
+	cfg := alertspb.AlertConfigDesc{}
+	err := s.store.Get(ctx, userID, &cfg)
+	if s.store.IsNotFoundErr(err) {
 		return cfg, alertspb.ErrNotFound
 	}
 
@@ -91,48 +79,10 @@ func (s *BucketAlertStore) GetAlertConfig(ctx context.Context, userID string) (a
 
 // SetAlertConfig implements alertstore.AlertStore.
 func (s *BucketAlertStore) SetAlertConfig(ctx context.Context, cfg alertspb.AlertConfigDesc) error {
-	cfgBytes, err := cfg.Marshal()
-	if err != nil {
-		return err
-	}
-
-	return s.getUserBucket(cfg.User).Upload(ctx, cfg.User, bytes.NewBuffer(cfgBytes))
+	return s.store.Set(ctx, cfg.User, &cfg)
 }
 
 // DeleteAlertConfig implements alertstore.AlertStore.
 func (s *BucketAlertStore) DeleteAlertConfig(ctx context.Context, userID string) error {
-	userBkt := s.getUserBucket(userID)
-
-	err := userBkt.Delete(ctx, userID)
-	if userBkt.IsObjNotFoundErr(err) {
-		return nil
-	}
-	return err
-}
-
-func (s *BucketAlertStore) getAlertConfig(ctx context.Context, userID string) (alertspb.AlertConfigDesc, error) {
-	readCloser, err := s.getUserBucket(userID).Get(ctx, userID)
-	if err != nil {
-		return alertspb.AlertConfigDesc{}, err
-	}
-
-	defer runutil.CloseWithLogOnErr(s.logger, readCloser, "close alertmanager config reader")
-
-	buf, err := ioutil.ReadAll(readCloser)
-	if err != nil {
-		return alertspb.AlertConfigDesc{}, err
-	}
-
-	config := alertspb.AlertConfigDesc{}
-	err = config.Unmarshal(buf)
-	if err != nil {
-		return alertspb.AlertConfigDesc{}, err
-	}
-
-	return config, nil
-}
-
-func (s *BucketAlertStore) getUserBucket(userID string) objstore.Bucket {
-	// Inject server-side encryption based on the tenant config.
-	return bucket.NewSSEBucketClient(userID, s.bucket, s.cfgProvider)
+	return s.store.Delete(ctx, userID)
 }

--- a/pkg/alertmanager/alertstore/bucketclient/protobuf_store.go
+++ b/pkg/alertmanager/alertstore/bucketclient/protobuf_store.go
@@ -1,0 +1,95 @@
+package bucketclient
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+
+	"github.com/go-kit/kit/log"
+	"github.com/gogo/protobuf/proto"
+	"github.com/thanos-io/thanos/pkg/objstore"
+	"github.com/thanos-io/thanos/pkg/runutil"
+
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
+)
+
+// ProtobufStore is used to read/write protobuf messages to object storage backend. It is implemented
+// using the Thanos objstore.Bucket interface
+type ProtobufStore struct {
+	bucket      objstore.Bucket
+	cfgProvider bucket.TenantConfigProvider
+	logger      log.Logger
+}
+
+func NewProtobufStore(prefix string, bkt objstore.Bucket, cfgProvider bucket.TenantConfigProvider, logger log.Logger) *ProtobufStore {
+	return &ProtobufStore{
+		bucket:      bucket.NewPrefixedBucketClient(bkt, prefix),
+		cfgProvider: cfgProvider,
+		logger:      logger,
+	}
+}
+
+// ListAllUsers returns all users with an entry in the store.
+func (s *ProtobufStore) ListAllUsers(ctx context.Context) ([]string, error) {
+	var userIDs []string
+
+	err := s.bucket.Iter(ctx, "", func(key string) error {
+		userIDs = append(userIDs, key)
+		return nil
+	})
+
+	return userIDs, err
+}
+
+// Set writes the content for an entry in the store for a particular user.
+func (s *ProtobufStore) Set(ctx context.Context, userID string, msg proto.Message) error {
+	msgBytes, err := proto.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	return s.getUserBucket(userID).Upload(ctx, userID, bytes.NewBuffer(msgBytes))
+}
+
+// Delete removes the entry in the store for a particular user.
+func (s *ProtobufStore) Delete(ctx context.Context, userID string) error {
+	userBkt := s.getUserBucket(userID)
+
+	err := userBkt.Delete(ctx, userID)
+	if userBkt.IsObjNotFoundErr(err) {
+		return nil
+	}
+	return err
+}
+
+// Get reads the content for an entry in the store for a particular user.
+func (s *ProtobufStore) Get(ctx context.Context, userID string, msg proto.Message) error {
+	readCloser, err := s.getUserBucket(userID).Get(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	defer runutil.CloseWithLogOnErr(s.logger, readCloser, "close bucket reader")
+
+	buf, err := ioutil.ReadAll(readCloser)
+	if err != nil {
+		return err
+	}
+
+	err = proto.Unmarshal(buf, msg)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// IsObjNotFoundErr returns true if the error indicates the entry being read does not exist.
+func (s *ProtobufStore) IsNotFoundErr(err error) bool {
+	return s.bucket.IsObjNotFoundErr(err)
+}
+
+func (s *ProtobufStore) getUserBucket(userID string) objstore.Bucket {
+	// Inject server-side encryption based on the tenant config.
+	return bucket.NewSSEBucketClient(userID, s.bucket, s.cfgProvider)
+}

--- a/pkg/alertmanager/alertstore/bucketclient/protobuf_store_test.go
+++ b/pkg/alertmanager/alertstore/bucketclient/protobuf_store_test.go
@@ -1,0 +1,84 @@
+package bucketclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/objstore"
+)
+
+// For testing, use one of the generic built-in protobuf types (Struct) to
+// avoid having to generate a dedicated message just for the sake of this test.
+
+func makeTestMessage(content string) *types.Struct {
+	return &types.Struct{Fields: map[string]*types.Value{content: nil}}
+}
+
+func TestProtobufStore(t *testing.T) {
+	bucket := objstore.NewInMemBucket()
+	store := NewProtobufStore("prefix", bucket, nil, log.NewNopLogger())
+	ctx := context.Background()
+
+	msg1 := makeTestMessage("one")
+	msg2 := makeTestMessage("two")
+
+	// The storage is empty.
+	{
+		users, err := store.ListAllUsers(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, users)
+
+		res := &types.Struct{}
+		err = store.Get(ctx, "user-1", res)
+		assert.True(t, store.IsNotFoundErr(err))
+	}
+
+	// The storage contains users.
+	{
+		require.NoError(t, store.Set(ctx, "user-1", makeTestMessage("one")))
+		require.NoError(t, store.Set(ctx, "user-2", makeTestMessage("two")))
+
+		users, err := store.ListAllUsers(ctx)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"user-1", "user-2"}, users)
+
+		res1 := &types.Struct{}
+		require.NoError(t, store.Get(ctx, "user-1", res1))
+		assert.Equal(t, msg1, res1)
+
+		res2 := &types.Struct{}
+		require.NoError(t, store.Get(ctx, "user-2", res2))
+		assert.Equal(t, msg2, res2)
+
+		// Ensure the config is stored at the expected location. Without this check
+		// we have no guarantee that the objects are stored at the expected location.
+		exists, err := bucket.Exists(ctx, "prefix/user-1")
+		require.NoError(t, err)
+		assert.True(t, exists)
+
+		exists, err = bucket.Exists(ctx, "prefix/user-2")
+		require.NoError(t, err)
+		assert.True(t, exists)
+	}
+
+	// The storage has had user-1 deleted.
+	{
+		require.NoError(t, store.Delete(ctx, "user-1"))
+
+		// Ensure the correct entry has been deleted.
+		res1 := &types.Struct{}
+		err := store.Get(ctx, "user-1", res1)
+		assert.True(t, store.IsNotFoundErr(err))
+
+		res2 := &types.Struct{}
+		require.NoError(t, store.Get(ctx, "user-2", res2))
+		assert.Equal(t, msg2, res2)
+
+		// Delete again (should be idempotent).
+		require.NoError(t, store.Delete(ctx, "user-1"))
+	}
+}


### PR DESCRIPTION
**What this PR does**:
Factor out object read/write from BucketAlertStore into ProtobufStore. The BucketAlertStore is 90% of what I need for persisting the notifications/silences state, so it seems wasteful to copy/paste it.
