### PR TITLE
Optimized metric name extraction in distributor

### DIFF
--- a/pkg/util/extract/extract.go
+++ b/pkg/util/extract/extract.go
@@ -14,12 +14,24 @@ var (
 )
 
 // MetricNameFromLabelAdapters extracts the metric name from a list of LabelPairs.
+// The returned metric name string is a copy of the label value.
 func MetricNameFromLabelAdapters(labels []cortexpb.LabelAdapter) (string, error) {
+	unsafeMetricName, err := UnsafeMetricNameFromLabelAdapters(labels)
+	if err != nil {
+		return "", err
+	}
+
+	// Force a string copy since LabelAdapter is often a pointer into
+	// a large gRPC buffer which we don't want to keep alive on the heap.
+	return string([]byte(unsafeMetricName)), nil
+}
+
+// UnsafeMetricNameFromLabelAdapters extracts the metric name from a list of LabelPairs.
+// The returned metric name string is a reference to the label value (no copy).
+func UnsafeMetricNameFromLabelAdapters(labels []cortexpb.LabelAdapter) (string, error) {
 	for _, label := range labels {
 		if label.Name == model.MetricNameLabel {
-			// Force a string copy since LabelAdapter is often a pointer into
-			// a large gRPC buffer which we don't want to keep alive on the heap.
-			return string([]byte(label.Value)), nil
+			return label.Value, nil
 		}
 	}
 	return "", errNoMetricNameLabel


### PR DESCRIPTION
**What this PR does**:
https://github.com/cortexproject/cortex/pull/3990 had the subtle con that the series labels are retained in the `ValidationError`. Instead of trying to solve it (which could undo the performance benefit got in that PR) I'm proposing to document it and leverage on it to further optimize the metric name extraction.

```
name                                                      old time/op    new time/op    delta
Distributor_Push/too_many_labels_limit_reached-12           1.26ms ± 1%    1.23ms ± 0%   -2.13%  (p=0.008 n=5+5)
Distributor_Push/max_label_name_length_limit_reached-12     4.97ms ± 1%    4.95ms ± 0%     ~     (p=0.190 n=5+4)
Distributor_Push/max_label_value_length_limit_reached-12    2.96ms ± 0%    2.94ms ± 2%     ~     (p=0.190 n=4+5)
Distributor_Push/timestamp_too_old-12                       1.02ms ± 0%    0.97ms ± 0%   -5.21%  (p=0.008 n=5+5)
Distributor_Push/timestamp_too_new-12                       1.02ms ± 1%    0.97ms ± 2%   -4.87%  (p=0.008 n=5+5)
Distributor_Push/all_samples_successfully_pushed-12         1.18ms ± 1%    1.13ms ± 1%   -4.37%  (p=0.008 n=5+5)
Distributor_Push/ingestion_rate_limit_reached-12             874µs ± 0%     821µs ± 0%   -6.08%  (p=0.008 n=5+5)

name                                                      old alloc/op   new alloc/op   delta
Distributor_Push/too_many_labels_limit_reached-12           94.4kB ± 0%    91.2kB ± 0%   -3.37%  (p=0.008 n=5+5)
Distributor_Push/max_label_name_length_limit_reached-12      129kB ± 0%     126kB ± 0%   -2.53%  (p=0.008 n=5+5)
Distributor_Push/max_label_value_length_limit_reached-12     130kB ± 0%     126kB ± 0%   -2.51%  (p=0.008 n=5+5)
Distributor_Push/timestamp_too_old-12                        118kB ± 0%     111kB ± 0%   -5.59%  (p=0.008 n=5+5)
Distributor_Push/timestamp_too_new-12                        118kB ± 0%     111kB ± 0%   -5.64%  (p=0.008 n=5+5)
Distributor_Push/all_samples_successfully_pushed-12          168kB ± 0%     162kB ± 0%   -3.75%  (p=0.008 n=5+5)
Distributor_Push/ingestion_rate_limit_reached-12            85.2kB ± 0%    78.8kB ± 0%   -7.50%  (p=0.008 n=5+5)

name                                                      old allocs/op  new allocs/op  delta
Distributor_Push/too_many_labels_limit_reached-12            3.13k ± 0%     2.13k ± 0%  -31.93%  (p=0.000 n=5+4)
Distributor_Push/max_label_name_length_limit_reached-12      3.08k ± 0%     2.08k ± 0%     ~     (p=0.079 n=4+5)
Distributor_Push/max_label_value_length_limit_reached-12     3.08k ± 0%     2.08k ± 0%  -32.47%  (p=0.008 n=5+5)
Distributor_Push/timestamp_too_old-12                        5.03k ± 0%     3.03k ± 0%  -39.75%  (p=0.008 n=5+5)
Distributor_Push/timestamp_too_new-12                        5.03k ± 0%     3.03k ± 0%  -39.75%  (p=0.008 n=5+5)
Distributor_Push/all_samples_successfully_pushed-12          4.04k ± 0%     2.04k ± 0%  -49.55%  (p=0.000 n=5+4)
Distributor_Push/ingestion_rate_limit_reached-12             4.03k ± 0%     2.03k ± 0%  -49.62%  (p=0.008 n=5+5)
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
