### PR TITLE
Deprecated old alertmanager storage config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * [CHANGE] Alertmanager now removes local files after Alertmanager is no longer running for removed or resharded user. #3910
 * [CHANGE] Alertmanager now stores local files in per-tenant folders. Files stored by Alertmanager previously are migrated to new hierarchy. Support for this migration will be removed in Cortex 1.11. #3910
-* [CHANGE] Ruler: deprecated `-ruler.storage.*` CLI flags (and their respective YAML config options) in favour of `-ruler-storage.*`. The deprecated config will be removed in Cortex 1.11. #3944
+* [CHANGE] Ruler: deprecated `-ruler.storage.*` CLI flags (and their respective YAML config options) in favour of `-ruler-storage.*`. The deprecated config will be removed in Cortex 1.11. #3945
+* [CHANGE] Alertmanager: deprecated `-alertmanager.storage.*` CLI flags (and their respective YAML config options) in favour of `-alertmanager-storage.*`. The deprecated config will be removed in Cortex 1.11. #4002
 * [CHANGE] Alertmanager: removed `-cluster.` CLI flags deprecated in Cortex 1.7. The new config options to use are: #3946
   * `-alertmanager.cluster.listen-address` instead of `-cluster.listen-address`
   * `-alertmanager.cluster.advertise-address` instead of `-cluster.advertise-address`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -162,213 +162,9 @@ tenant_federation:
 # The alertmanager_config configures the Cortex alertmanager.
 [alertmanager: <alertmanager_config>]
 
-alertmanager_storage:
-  # Backend storage to use. Supported backends are: s3, gcs, azure, swift,
-  # filesystem, configdb, local.
-  # CLI flag: -alertmanager-storage.backend
-  [backend: <string> | default = "s3"]
-
-  s3:
-    # The S3 bucket endpoint. It could be an AWS S3 endpoint listed at
-    # https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an
-    # S3-compatible service in hostname:port format.
-    # CLI flag: -alertmanager-storage.s3.endpoint
-    [endpoint: <string> | default = ""]
-
-    # S3 region. If unset, the client will issue a S3 GetBucketLocation API call
-    # to autodetect it.
-    # CLI flag: -alertmanager-storage.s3.region
-    [region: <string> | default = ""]
-
-    # S3 bucket name
-    # CLI flag: -alertmanager-storage.s3.bucket-name
-    [bucket_name: <string> | default = ""]
-
-    # S3 secret access key
-    # CLI flag: -alertmanager-storage.s3.secret-access-key
-    [secret_access_key: <string> | default = ""]
-
-    # S3 access key ID
-    # CLI flag: -alertmanager-storage.s3.access-key-id
-    [access_key_id: <string> | default = ""]
-
-    # If enabled, use http:// for the S3 endpoint instead of https://. This
-    # could be useful in local dev/test environments while using an
-    # S3-compatible backend storage, like Minio.
-    # CLI flag: -alertmanager-storage.s3.insecure
-    [insecure: <boolean> | default = false]
-
-    # The signature version to use for authenticating against S3. Supported
-    # values are: v4, v2.
-    # CLI flag: -alertmanager-storage.s3.signature-version
-    [signature_version: <string> | default = "v4"]
-
-    # The s3_sse_config configures the S3 server-side encryption.
-    # The CLI flags prefix for this block config is: alertmanager-storage
-    [sse: <s3_sse_config>]
-
-    http:
-      # The time an idle connection will remain idle before closing.
-      # CLI flag: -alertmanager-storage.s3.http.idle-conn-timeout
-      [idle_conn_timeout: <duration> | default = 1m30s]
-
-      # The amount of time the client will wait for a servers response headers.
-      # CLI flag: -alertmanager-storage.s3.http.response-header-timeout
-      [response_header_timeout: <duration> | default = 2m]
-
-      # If the client connects to S3 via HTTPS and this option is enabled, the
-      # client will accept any certificate and hostname.
-      # CLI flag: -alertmanager-storage.s3.http.insecure-skip-verify
-      [insecure_skip_verify: <boolean> | default = false]
-
-      # Maximum time to wait for a TLS handshake. 0 means no limit.
-      # CLI flag: -alertmanager-storage.s3.tls-handshake-timeout
-      [tls_handshake_timeout: <duration> | default = 10s]
-
-      # The time to wait for a server's first response headers after fully
-      # writing the request headers if the request has an Expect header. 0 to
-      # send the request body immediately.
-      # CLI flag: -alertmanager-storage.s3.expect-continue-timeout
-      [expect_continue_timeout: <duration> | default = 1s]
-
-      # Maximum number of idle (keep-alive) connections across all hosts. 0
-      # means no limit.
-      # CLI flag: -alertmanager-storage.s3.max-idle-connections
-      [max_idle_connections: <int> | default = 100]
-
-      # Maximum number of idle (keep-alive) connections to keep per-host. If 0,
-      # a built-in default value is used.
-      # CLI flag: -alertmanager-storage.s3.max-idle-connections-per-host
-      [max_idle_connections_per_host: <int> | default = 100]
-
-      # Maximum number of connections per host. 0 means no limit.
-      # CLI flag: -alertmanager-storage.s3.max-connections-per-host
-      [max_connections_per_host: <int> | default = 0]
-
-  gcs:
-    # GCS bucket name
-    # CLI flag: -alertmanager-storage.gcs.bucket-name
-    [bucket_name: <string> | default = ""]
-
-    # JSON representing either a Google Developers Console
-    # client_credentials.json file or a Google Developers service account key
-    # file. If empty, fallback to Google default logic.
-    # CLI flag: -alertmanager-storage.gcs.service-account
-    [service_account: <string> | default = ""]
-
-  azure:
-    # Azure storage account name
-    # CLI flag: -alertmanager-storage.azure.account-name
-    [account_name: <string> | default = ""]
-
-    # Azure storage account key
-    # CLI flag: -alertmanager-storage.azure.account-key
-    [account_key: <string> | default = ""]
-
-    # Azure storage container name
-    # CLI flag: -alertmanager-storage.azure.container-name
-    [container_name: <string> | default = ""]
-
-    # Azure storage endpoint suffix without schema. The account name will be
-    # prefixed to this value to create the FQDN
-    # CLI flag: -alertmanager-storage.azure.endpoint-suffix
-    [endpoint_suffix: <string> | default = ""]
-
-    # Number of retries for recoverable errors
-    # CLI flag: -alertmanager-storage.azure.max-retries
-    [max_retries: <int> | default = 20]
-
-  swift:
-    # OpenStack Swift authentication API version. 0 to autodetect.
-    # CLI flag: -alertmanager-storage.swift.auth-version
-    [auth_version: <int> | default = 0]
-
-    # OpenStack Swift authentication URL
-    # CLI flag: -alertmanager-storage.swift.auth-url
-    [auth_url: <string> | default = ""]
-
-    # OpenStack Swift username.
-    # CLI flag: -alertmanager-storage.swift.username
-    [username: <string> | default = ""]
-
-    # OpenStack Swift user's domain name.
-    # CLI flag: -alertmanager-storage.swift.user-domain-name
-    [user_domain_name: <string> | default = ""]
-
-    # OpenStack Swift user's domain ID.
-    # CLI flag: -alertmanager-storage.swift.user-domain-id
-    [user_domain_id: <string> | default = ""]
-
-    # OpenStack Swift user ID.
-    # CLI flag: -alertmanager-storage.swift.user-id
-    [user_id: <string> | default = ""]
-
-    # OpenStack Swift API key.
-    # CLI flag: -alertmanager-storage.swift.password
-    [password: <string> | default = ""]
-
-    # OpenStack Swift user's domain ID.
-    # CLI flag: -alertmanager-storage.swift.domain-id
-    [domain_id: <string> | default = ""]
-
-    # OpenStack Swift user's domain name.
-    # CLI flag: -alertmanager-storage.swift.domain-name
-    [domain_name: <string> | default = ""]
-
-    # OpenStack Swift project ID (v2,v3 auth only).
-    # CLI flag: -alertmanager-storage.swift.project-id
-    [project_id: <string> | default = ""]
-
-    # OpenStack Swift project name (v2,v3 auth only).
-    # CLI flag: -alertmanager-storage.swift.project-name
-    [project_name: <string> | default = ""]
-
-    # ID of the OpenStack Swift project's domain (v3 auth only), only needed if
-    # it differs the from user domain.
-    # CLI flag: -alertmanager-storage.swift.project-domain-id
-    [project_domain_id: <string> | default = ""]
-
-    # Name of the OpenStack Swift project's domain (v3 auth only), only needed
-    # if it differs from the user domain.
-    # CLI flag: -alertmanager-storage.swift.project-domain-name
-    [project_domain_name: <string> | default = ""]
-
-    # OpenStack Swift Region to use (v2,v3 auth only).
-    # CLI flag: -alertmanager-storage.swift.region-name
-    [region_name: <string> | default = ""]
-
-    # Name of the OpenStack Swift container to put chunks in.
-    # CLI flag: -alertmanager-storage.swift.container-name
-    [container_name: <string> | default = ""]
-
-    # Max retries on requests error.
-    # CLI flag: -alertmanager-storage.swift.max-retries
-    [max_retries: <int> | default = 3]
-
-    # Time after which a connection attempt is aborted.
-    # CLI flag: -alertmanager-storage.swift.connect-timeout
-    [connect_timeout: <duration> | default = 10s]
-
-    # Time after which an idle request is aborted. The timeout watchdog is reset
-    # each time some data is received, so the timeout triggers after X time no
-    # data is received on a request.
-    # CLI flag: -alertmanager-storage.swift.request-timeout
-    [request_timeout: <duration> | default = 5s]
-
-  filesystem:
-    # Local filesystem storage directory.
-    # CLI flag: -alertmanager-storage.filesystem.dir
-    [dir: <string> | default = ""]
-
-  # The configstore_config configures the config database storing rules and
-  # alerts, and is used by the Cortex alertmanager.
-  # The CLI flags prefix for this block config is: alertmanager-storage
-  [configdb: <configstore_config>]
-
-  local:
-    # Path at which alertmanager configurations are stored.
-    # CLI flag: -alertmanager-storage.local.path
-    [path: <string> | default = ""]
+# The alertmanager_storage_config configures the Cortex alertmanager storage
+# backend.
+[alertmanager_storage: <alertmanager_storage_config>]
 
 runtime_config:
   # How often to check runtime config file.
@@ -2073,6 +1869,8 @@ sharding_ring:
 # CLI flag: -alertmanager.configs.auto-webhook-root
 [auto_webhook_root: <string> | default = ""]
 
+# Deprecated. Use -alertmanager-storage.* CLI flags and their respective YAML
+# config options instead.
 storage:
   # Type of backend to use to store alertmanager configs. Supported values are:
   # "configdb", "gcs", "s3", "local".
@@ -2283,6 +2081,219 @@ alertmanager_client:
   # Skip validating server certificate.
   # CLI flag: -alertmanager.alertmanager-client.tls-insecure-skip-verify
   [tls_insecure_skip_verify: <boolean> | default = false]
+```
+
+### `alertmanager_storage_config`
+
+The `alertmanager_storage_config` configures the Cortex alertmanager storage backend.
+
+```yaml
+# Backend storage to use. Supported backends are: s3, gcs, azure, swift,
+# filesystem, configdb, local.
+# CLI flag: -alertmanager-storage.backend
+[backend: <string> | default = "s3"]
+
+s3:
+  # The S3 bucket endpoint. It could be an AWS S3 endpoint listed at
+  # https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an
+  # S3-compatible service in hostname:port format.
+  # CLI flag: -alertmanager-storage.s3.endpoint
+  [endpoint: <string> | default = ""]
+
+  # S3 region. If unset, the client will issue a S3 GetBucketLocation API call
+  # to autodetect it.
+  # CLI flag: -alertmanager-storage.s3.region
+  [region: <string> | default = ""]
+
+  # S3 bucket name
+  # CLI flag: -alertmanager-storage.s3.bucket-name
+  [bucket_name: <string> | default = ""]
+
+  # S3 secret access key
+  # CLI flag: -alertmanager-storage.s3.secret-access-key
+  [secret_access_key: <string> | default = ""]
+
+  # S3 access key ID
+  # CLI flag: -alertmanager-storage.s3.access-key-id
+  [access_key_id: <string> | default = ""]
+
+  # If enabled, use http:// for the S3 endpoint instead of https://. This could
+  # be useful in local dev/test environments while using an S3-compatible
+  # backend storage, like Minio.
+  # CLI flag: -alertmanager-storage.s3.insecure
+  [insecure: <boolean> | default = false]
+
+  # The signature version to use for authenticating against S3. Supported values
+  # are: v4, v2.
+  # CLI flag: -alertmanager-storage.s3.signature-version
+  [signature_version: <string> | default = "v4"]
+
+  # The s3_sse_config configures the S3 server-side encryption.
+  # The CLI flags prefix for this block config is: alertmanager-storage
+  [sse: <s3_sse_config>]
+
+  http:
+    # The time an idle connection will remain idle before closing.
+    # CLI flag: -alertmanager-storage.s3.http.idle-conn-timeout
+    [idle_conn_timeout: <duration> | default = 1m30s]
+
+    # The amount of time the client will wait for a servers response headers.
+    # CLI flag: -alertmanager-storage.s3.http.response-header-timeout
+    [response_header_timeout: <duration> | default = 2m]
+
+    # If the client connects to S3 via HTTPS and this option is enabled, the
+    # client will accept any certificate and hostname.
+    # CLI flag: -alertmanager-storage.s3.http.insecure-skip-verify
+    [insecure_skip_verify: <boolean> | default = false]
+
+    # Maximum time to wait for a TLS handshake. 0 means no limit.
+    # CLI flag: -alertmanager-storage.s3.tls-handshake-timeout
+    [tls_handshake_timeout: <duration> | default = 10s]
+
+    # The time to wait for a server's first response headers after fully writing
+    # the request headers if the request has an Expect header. 0 to send the
+    # request body immediately.
+    # CLI flag: -alertmanager-storage.s3.expect-continue-timeout
+    [expect_continue_timeout: <duration> | default = 1s]
+
+    # Maximum number of idle (keep-alive) connections across all hosts. 0 means
+    # no limit.
+    # CLI flag: -alertmanager-storage.s3.max-idle-connections
+    [max_idle_connections: <int> | default = 100]
+
+    # Maximum number of idle (keep-alive) connections to keep per-host. If 0, a
+    # built-in default value is used.
+    # CLI flag: -alertmanager-storage.s3.max-idle-connections-per-host
+    [max_idle_connections_per_host: <int> | default = 100]
+
+    # Maximum number of connections per host. 0 means no limit.
+    # CLI flag: -alertmanager-storage.s3.max-connections-per-host
+    [max_connections_per_host: <int> | default = 0]
+
+gcs:
+  # GCS bucket name
+  # CLI flag: -alertmanager-storage.gcs.bucket-name
+  [bucket_name: <string> | default = ""]
+
+  # JSON representing either a Google Developers Console client_credentials.json
+  # file or a Google Developers service account key file. If empty, fallback to
+  # Google default logic.
+  # CLI flag: -alertmanager-storage.gcs.service-account
+  [service_account: <string> | default = ""]
+
+azure:
+  # Azure storage account name
+  # CLI flag: -alertmanager-storage.azure.account-name
+  [account_name: <string> | default = ""]
+
+  # Azure storage account key
+  # CLI flag: -alertmanager-storage.azure.account-key
+  [account_key: <string> | default = ""]
+
+  # Azure storage container name
+  # CLI flag: -alertmanager-storage.azure.container-name
+  [container_name: <string> | default = ""]
+
+  # Azure storage endpoint suffix without schema. The account name will be
+  # prefixed to this value to create the FQDN
+  # CLI flag: -alertmanager-storage.azure.endpoint-suffix
+  [endpoint_suffix: <string> | default = ""]
+
+  # Number of retries for recoverable errors
+  # CLI flag: -alertmanager-storage.azure.max-retries
+  [max_retries: <int> | default = 20]
+
+swift:
+  # OpenStack Swift authentication API version. 0 to autodetect.
+  # CLI flag: -alertmanager-storage.swift.auth-version
+  [auth_version: <int> | default = 0]
+
+  # OpenStack Swift authentication URL
+  # CLI flag: -alertmanager-storage.swift.auth-url
+  [auth_url: <string> | default = ""]
+
+  # OpenStack Swift username.
+  # CLI flag: -alertmanager-storage.swift.username
+  [username: <string> | default = ""]
+
+  # OpenStack Swift user's domain name.
+  # CLI flag: -alertmanager-storage.swift.user-domain-name
+  [user_domain_name: <string> | default = ""]
+
+  # OpenStack Swift user's domain ID.
+  # CLI flag: -alertmanager-storage.swift.user-domain-id
+  [user_domain_id: <string> | default = ""]
+
+  # OpenStack Swift user ID.
+  # CLI flag: -alertmanager-storage.swift.user-id
+  [user_id: <string> | default = ""]
+
+  # OpenStack Swift API key.
+  # CLI flag: -alertmanager-storage.swift.password
+  [password: <string> | default = ""]
+
+  # OpenStack Swift user's domain ID.
+  # CLI flag: -alertmanager-storage.swift.domain-id
+  [domain_id: <string> | default = ""]
+
+  # OpenStack Swift user's domain name.
+  # CLI flag: -alertmanager-storage.swift.domain-name
+  [domain_name: <string> | default = ""]
+
+  # OpenStack Swift project ID (v2,v3 auth only).
+  # CLI flag: -alertmanager-storage.swift.project-id
+  [project_id: <string> | default = ""]
+
+  # OpenStack Swift project name (v2,v3 auth only).
+  # CLI flag: -alertmanager-storage.swift.project-name
+  [project_name: <string> | default = ""]
+
+  # ID of the OpenStack Swift project's domain (v3 auth only), only needed if it
+  # differs the from user domain.
+  # CLI flag: -alertmanager-storage.swift.project-domain-id
+  [project_domain_id: <string> | default = ""]
+
+  # Name of the OpenStack Swift project's domain (v3 auth only), only needed if
+  # it differs from the user domain.
+  # CLI flag: -alertmanager-storage.swift.project-domain-name
+  [project_domain_name: <string> | default = ""]
+
+  # OpenStack Swift Region to use (v2,v3 auth only).
+  # CLI flag: -alertmanager-storage.swift.region-name
+  [region_name: <string> | default = ""]
+
+  # Name of the OpenStack Swift container to put chunks in.
+  # CLI flag: -alertmanager-storage.swift.container-name
+  [container_name: <string> | default = ""]
+
+  # Max retries on requests error.
+  # CLI flag: -alertmanager-storage.swift.max-retries
+  [max_retries: <int> | default = 3]
+
+  # Time after which a connection attempt is aborted.
+  # CLI flag: -alertmanager-storage.swift.connect-timeout
+  [connect_timeout: <duration> | default = 10s]
+
+  # Time after which an idle request is aborted. The timeout watchdog is reset
+  # each time some data is received, so the timeout triggers after X time no
+  # data is received on a request.
+  # CLI flag: -alertmanager-storage.swift.request-timeout
+  [request_timeout: <duration> | default = 5s]
+
+filesystem:
+  # Local filesystem storage directory.
+  # CLI flag: -alertmanager-storage.filesystem.dir
+  [dir: <string> | default = ""]
+
+# The configstore_config configures the config database storing rules and
+# alerts, and is used by the Cortex alertmanager.
+# The CLI flags prefix for this block config is: alertmanager-storage
+[configdb: <configstore_config>]
+
+local:
+  # Path at which alertmanager configurations are stored.
+  # CLI flag: -alertmanager-storage.local.path
+  [path: <string> | default = ""]
 ```
 
 ### `table_manager_config`

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -70,7 +70,6 @@ Currently experimental features are:
 - Alertmanager: Sharding of tenants across multiple instances
 - The thanosconvert tool for converting Thanos block metadata to Cortex
 - HA Tracker: cleanup of old replicas from KV Store.
-- Alertmanager storage: backend client configuration options using a config fields similar to the blocks storage backend clients.
 - Flags for configuring whether blocks-ingester streams samples or chunks are temporary, and will be removed when feature is tested:
   - `-ingester.stream-chunks-when-using-blocks` CLI flag
   - `ingester_stream_chunks_when_using_blocks` (boolean) field in runtime config file

--- a/pkg/alertmanager/alertstore/config.go
+++ b/pkg/alertmanager/alertstore/config.go
@@ -15,6 +15,7 @@ import (
 )
 
 // LegacyConfig configures the alertmanager storage backend using the legacy storage clients.
+// TODO remove this legacy config in Cortex 1.11.
 type LegacyConfig struct {
 	Type     string        `yaml:"type"`
 	ConfigDB client.Config `yaml:"configdb"`

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -112,7 +112,7 @@ type MultitenantAlertmanagerConfig struct {
 	FallbackConfigFile string `yaml:"fallback_config_file"`
 	AutoWebhookRoot    string `yaml:"auto_webhook_root"`
 
-	Store   alertstore.LegacyConfig `yaml:"storage"`
+	Store   alertstore.LegacyConfig `yaml:"storage" doc:"description=Deprecated. Use -alertmanager-storage.* CLI flags and their respective YAML config options instead."`
 	Cluster ClusterConfig           `yaml:"cluster"`
 
 	EnableAPI bool `yaml:"enable_api"`

--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/weaveworks/common/server"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager"
+	"github.com/cortexproject/cortex/pkg/alertmanager/alertstore"
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/chunk/purger"
@@ -92,6 +93,11 @@ var (
 			name:       "alertmanager_config",
 			structType: reflect.TypeOf(alertmanager.MultitenantAlertmanagerConfig{}),
 			desc:       "The alertmanager_config configures the Cortex alertmanager.",
+		},
+		{
+			name:       "alertmanager_storage_config",
+			structType: reflect.TypeOf(alertstore.Config{}),
+			desc:       "The alertmanager_storage_config configures the Cortex alertmanager storage backend.",
 		},
 		{
 			name:       "table_manager_config",


### PR DESCRIPTION
**What this PR does**:
In #3888 we introduced the new alertmanager storage config. In this PR I'm proposing to deprecate the old storage config, so that it will be officially marked as deprecated in Cortex 1.9 and then removed in 1.11.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
