### PR TITLE
chore: update documentation to use new API paths

### DIFF
--- a/development/tsdb-blocks-storage-s3-gossip/config/grafana-agent.yaml
+++ b/development/tsdb-blocks-storage-s3-gossip/config/grafana-agent.yaml
@@ -61,4 +61,4 @@ prometheus:
                 namespace: 'tsdb-blocks-storage-s3'
 
       remote_write:
-        - url: http://distributor:8001/api/prom/push
+        - url: http://distributor:8001/api/v1/push

--- a/development/tsdb-blocks-storage-s3-gossip/config/prometheus.yaml
+++ b/development/tsdb-blocks-storage-s3-gossip/config/prometheus.yaml
@@ -54,4 +54,4 @@ scrape_configs:
           namespace: 'tsdb-blocks-storage-s3'
 
 remote_write:
-  - url: http://distributor:8001/api/prom/push
+  - url: http://distributor:8001/api/v1/push

--- a/development/tsdb-blocks-storage-s3-single-binary/config/grafana-agent.yaml
+++ b/development/tsdb-blocks-storage-s3-single-binary/config/grafana-agent.yaml
@@ -23,4 +23,4 @@ prometheus:
                 container: 'cortex-2'
 
       remote_write:
-        - url: http://cortex-1:8001/api/prom/push
+        - url: http://cortex-1:8001/api/v1/push

--- a/development/tsdb-blocks-storage-s3-single-binary/config/prometheus.yaml
+++ b/development/tsdb-blocks-storage-s3-single-binary/config/prometheus.yaml
@@ -16,4 +16,4 @@ scrape_configs:
           container: 'cortex-2'
 
 remote_write:
-  - url: http://cortex-1:8001/api/prom/push
+  - url: http://cortex-1:8001/api/v1/push

--- a/development/tsdb-blocks-storage-s3/config/grafana-agent.yaml
+++ b/development/tsdb-blocks-storage-s3/config/grafana-agent.yaml
@@ -61,4 +61,4 @@ prometheus:
                 namespace: 'tsdb-blocks-storage-s3'
 
       remote_write:
-        - url: http://distributor:8001/api/prom/push
+        - url: http://distributor:8001/api/v1/push

--- a/development/tsdb-blocks-storage-s3/config/prometheus.yaml
+++ b/development/tsdb-blocks-storage-s3/config/prometheus.yaml
@@ -54,4 +54,4 @@ scrape_configs:
           namespace: 'tsdb-blocks-storage-s3'
 
 remote_write:
-  - url: http://distributor:8001/api/prom/push
+  - url: http://distributor:8001/api/v1/push

--- a/development/tsdb-blocks-storage-swift-single-binary/config/grafana-agent.yaml
+++ b/development/tsdb-blocks-storage-swift-single-binary/config/grafana-agent.yaml
@@ -23,4 +23,4 @@ prometheus:
                 container: 'cortex-2'
 
       remote_write:
-        - url: http://localhost:8001/api/prom/push
+        - url: http://localhost:8001/api/v1/push

--- a/development/tsdb-blocks-storage-swift-single-binary/config/prometheus.yaml
+++ b/development/tsdb-blocks-storage-swift-single-binary/config/prometheus.yaml
@@ -16,4 +16,4 @@ scrape_configs:
           container: 'cortex-2'
 
 remote_write:
-  - url: http://localhost:8001/api/prom/push
+  - url: http://localhost:8001/api/v1/push

--- a/docs/chunks-storage/aws-tips.md
+++ b/docs/chunks-storage/aws-tips.md
@@ -46,7 +46,7 @@ example set of command-line parameters from a fairly modest install:
 
 ```
    -target=table-manager
-   -metrics.url=http://prometheus.monitoring.svc.cluster.local./api/prom/
+   -metrics.url=http://prometheus.monitoring.svc.cluster.local./prometheus/
    -metrics.target-queue-length=100000
    -dynamodb.url=dynamodb://us-east-1/
    -schema-config-file=/etc/schema.yaml

--- a/docs/chunks-storage/chunks-storage-getting-started.md
+++ b/docs/chunks-storage/chunks-storage-getting-started.md
@@ -42,7 +42,7 @@ Add the following to your Prometheus config (documentation/examples/prometheus.y
 
 ```yaml
 remote_write:
-- url: http://localhost:9009/api/prom/push
+- url: http://localhost:9009/api/v1/push
 ```
 
 And start Prometheus with that config file:
@@ -57,7 +57,7 @@ Your Prometheus instance will now start pushing data to Cortex.  To query that d
 $ docker run --rm -d --name=grafana -p 3000:3000 grafana/grafana
 ```
 
-In [the Grafana UI](http://localhost:3000) (username/password admin/admin), add a Prometheus datasource for Cortex (`http://host.docker.internal:9009/api/prom`).
+In [the Grafana UI](http://localhost:3000) (username/password admin/admin), add a Prometheus datasource for Cortex (`http://host.docker.internal:9009/prometheus`).
 
 **To clean up:** press CTRL-C in both terminals (for Cortex and Prometheus).
 
@@ -104,7 +104,7 @@ Point Prometheus at the first:
 
 ```yaml
 remote_write:
-- url: http://localhost:9001/api/prom/push
+- url: http://localhost:9001/api/v1/push
 ```
 
 ```sh
@@ -117,7 +117,7 @@ And Grafana at the second:
 $ docker run -d --name=grafana --network=cortex -p 3000:3000 grafana/grafana
 ```
 
-In [the Grafana UI](http://localhost:3000) (username/password admin/admin), add a Prometheus datasource for Cortex (`http://cortex2:9009/api/prom`).
+In [the Grafana UI](http://localhost:3000) (username/password admin/admin), add a Prometheus datasource for Cortex (`http://cortex2:9009/prometheus`).
 
 **To clean up:** CTRL-C the Prometheus process and run:
 
@@ -172,14 +172,14 @@ Configure Prometheus to send data to the first replica:
 
 ```yaml
 remote_write:
-- url: http://localhost:9001/api/prom/push
+- url: http://localhost:9001/api/v1/push
 ```
 
 ```sh
 $ ./prometheus --config.file=./documentation/examples/prometheus.yml
 ```
 
-In Grafana, add a datasource for the 3rd Cortex replica (`http://cortex3:9009/api/prom`)
+In Grafana, add a datasource for the 3rd Cortex replica (`http://cortex3:9009/prometheus`)
 and verify the same data appears in both Prometheus and Cortex.
 
 To show that Cortex can tolerate a node failure, hard kill one of the Cortex replicas:

--- a/docs/chunks-storage/running-chunks-storage-with-cassandra.md
+++ b/docs/chunks-storage/running-chunks-storage-with-cassandra.md
@@ -165,7 +165,7 @@ Add the following section to your Prometheus configuration file. This will confi
 
 ```
 remote_write:
-   - url: http://localhost:9009/api/prom/push
+   - url: http://localhost:9009/api/v1/push
 ```
 ## Configure Grafana to visualise metrics
 
@@ -175,6 +175,6 @@ Run grafana to visualise metrics from Cortex:
 docker run -d --name=grafana -p 3000:3000 grafana/grafana
 ```
 
-Add a data source in Grafana by selecting Prometheus as the data source type and use the Cortex URL to query metrics: `http://localhost:9009/api/prom`.
+Add a data source in Grafana by selecting Prometheus as the data source type and use the Cortex URL to query metrics: `http://localhost:9009/prometheus`.
 
 Finally, You can monitor Cortex's reads & writes by creating the dashboard. If you're looking for ready to use dashboards, you can take a look at Grafana's [Cortex dashboards and alerts](https://github.com/grafana/cortex-jsonnet/) (Jsonnet) or Weaveworks's [Cortex dashboards](https://github.com/weaveworks/cortex-dashboards) (Python).

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -21,7 +21,7 @@ The Cortex maintainers commit to ensuring future version of Cortex can read data
 
 ## API Compatibility
 
-Cortex strives to be 100% API compatible with Prometheus (under `/api/prom/*`); any deviation from this is considered a bug, except:
+Cortex strives to be 100% API compatible with Prometheus (under `/prometheus/*` and `/api/prom/*`); any deviation from this is considered a bug, except:
 
 - Requiring the `__name__` label on queries when querying the [chunks storage](../chunks-storage/_index.md) (queries to ingesters or clusters running the blocks storage are not affected).
 - For queries to the `/api/v1/series`, `/api/v1/labels` and `/api/v1/label/{name}/values` endpoints, query's time range is ignored and the data is always fetched from ingesters. There is experimental support to query the long-term store with the *blocks* storage engine when `-querier.query-store-for-labels-enabled` is set.

--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -41,7 +41,7 @@ Add the following to your Prometheus config (documentation/examples/prometheus.y
 
 ```yaml
 remote_write:
-- url: http://localhost:9009/api/prom/push
+- url: http://localhost:9009/api/v1/push
 ```
 
 And start Prometheus with that config file:
@@ -56,7 +56,7 @@ Your Prometheus instance will now start pushing data to Cortex.  To query that d
 $ docker run --rm -d --name=grafana -p 3000:3000 grafana/grafana
 ```
 
-In [the Grafana UI](http://localhost:3000) (username/password admin/admin), add a Prometheus datasource for Cortex (`http://host.docker.internal:9009/api/prom`).
+In [the Grafana UI](http://localhost:3000) (username/password admin/admin), add a Prometheus datasource for Cortex (`http://host.docker.internal:9009/prometheus`).
 
 **To clean up:** press CTRL-C in both terminals (for Cortex and Prometheus).
 
@@ -103,7 +103,7 @@ Point Prometheus at the first:
 
 ```yaml
 remote_write:
-- url: http://localhost:9001/api/prom/push
+- url: http://localhost:9001/api/v1/push
 ```
 
 ```sh
@@ -116,7 +116,7 @@ And Grafana at the second:
 $ docker run -d --name=grafana --network=cortex -p 3000:3000 grafana/grafana
 ```
 
-In [the Grafana UI](http://localhost:3000) (username/password admin/admin), add a Prometheus datasource for Cortex (`http://cortex2:9009/api/prom`).
+In [the Grafana UI](http://localhost:3000) (username/password admin/admin), add a Prometheus datasource for Cortex (`http://cortex2:9009/prometheus`).
 
 **To clean up:** CTRL-C the Prometheus process and run:
 
@@ -171,14 +171,14 @@ Configure Prometheus to send data to the first replica:
 
 ```yaml
 remote_write:
-- url: http://localhost:9001/api/prom/push
+- url: http://localhost:9001/api/v1/push
 ```
 
 ```sh
 $ ./prometheus --config.file=./documentation/examples/prometheus.yml
 ```
 
-In Grafana, add a datasource for the 3rd Cortex replica (`http://cortex3:9009/api/prom`)
+In Grafana, add a datasource for the 3rd Cortex replica (`http://cortex3:9009/prometheus`)
 and verify the same data appears in both Prometheus and Cortex.
 
 To show that Cortex can tolerate a node failure, hard kill one of the Cortex replicas:

--- a/docs/guides/gossip-ring-getting-started.md
+++ b/docs/guides/gossip-ring-getting-started.md
@@ -33,13 +33,13 @@ Download Prometheus and configure it to use our first Cortex instance for remote
 
 ```yaml
 remote_write:
-- url: http://localhost:9109/api/prom/push
+- url: http://localhost:9109/api/v1/push
 ```
 
 After starting Prometheus, it will now start pushing data to Cortex. Distributor component in Cortex will
 distribute incoming samples between the two instances.
 
-To query that data, you can configure your Grafana instance to use http://localhost:9109/api/prom (first Cortex) as a Prometheus data source.
+To query that data, you can configure your Grafana instance to use http://localhost:9109/prometheus (first Cortex) as a Prometheus data source.
 
 ## How it works
 

--- a/docs/operations/query-auditor.md
+++ b/docs/operations/query-auditor.md
@@ -29,12 +29,12 @@ It currently only supports queries with `Matrix` response types.
 
 ```yaml
 control:
-  host: http://localhost:8080/api/prom
+  host: http://localhost:8080/prometheus
   headers:
     "X-Scope-OrgID": 1234
 
 test:
-  host: http://localhost:8081/api/prom
+  host: http://localhost:8081/prometheus
   headers:
     "X-Scope-OrgID": 1234
 

--- a/k8s/alertmanager-dep.yaml
+++ b/k8s/alertmanager-dep.yaml
@@ -22,6 +22,6 @@ spec:
         - -log.level=debug
         - -server.http-listen-port=80
         - -alertmanager.configs.url=http://configs.default.svc.cluster.local:80
-        - -alertmanager.web.external-url=/api/prom/alertmanager
+        - -alertmanager.web.external-url=/alertmanager
         ports:
         - containerPort: 80

--- a/k8s/nginx-config.yaml
+++ b/k8s/nginx-config.yaml
@@ -27,6 +27,10 @@ data:
         listen 80;
         proxy_set_header X-Scope-OrgID 0;
 
+        location = /api/v1/push {
+          proxy_pass      http://distributor.default.svc.cluster.local$request_uri;
+        }
+        
         location = /api/prom/push {
           proxy_pass      http://distributor.default.svc.cluster.local$request_uri;
         }
@@ -36,6 +40,10 @@ data:
         }
         location = /all_user_stats {
           proxy_pass      http://distributor.default.svc.cluster.local$request_uri;
+        }
+        
+        location ~ /prometheus/.* {
+          proxy_pass      http://query-frontend.default.svc.cluster.local$request_uri;
         }
 
         location ~ /api/prom/.* {

--- a/k8s/retrieval-config.yaml
+++ b/k8s/retrieval-config.yaml
@@ -9,7 +9,7 @@ data:
       scrape_interval: 30s # By default, scrape targets every 15 seconds.
 
     remote_write:
-      - url: http://nginx.default.svc.cluster.local:80/api/prom/push
+      - url: http://nginx.default.svc.cluster.local:80/api/v1/push
 
     scrape_configs:
     - job_name: 'kubernetes-pods'

--- a/k8s/ruler-dep.yaml
+++ b/k8s/ruler-dep.yaml
@@ -22,7 +22,7 @@ spec:
         - -log.level=debug
         - -server.http-listen-port=80
         - -ruler.configs.url=http://configs.default.svc.cluster.local:80
-        - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/api/prom/alertmanager/
+        - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager/
         - -consul.hostname=consul.default.svc.cluster.local:8500
         - -s3.url=s3://cortex:supersecret@default.svc.cluster.local:9000/cortex
         - -s3.force-path-style=true

--- a/tools/query-audit/example-config.yaml
+++ b/tools/query-audit/example-config.yaml
@@ -1,10 +1,10 @@
 control:
-  host: http://localhost:8080/api/prom
+  host: http://localhost:8080/prometheus
   headers:
     "X-Scope-OrgID": 1234
 
 test:
-  host: http://localhost:8081/api/prom
+  host: http://localhost:8081/prometheus
   headers:
     "X-Scope-OrgID": 1234
 


### PR DESCRIPTION
**What this PR does**:

- Update all documentation to use the `/api/v1/push` and `/prometheus` routes where relevant
- Example Nginx configs have been updated to support both endpoints
