### PR TITLE
Update release document on merging release branch to master

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -112,7 +112,7 @@ To publish a stable release:
    - Create `merge-release-to-master` branch locally
    - Merge upstream `master` branch into your `merge-release-to-master` and resolve conflicts
    - Send PR to for merging your `merge-release-to-master` branch into `master`
-   - Once approved, merge the PR by using "Merge" commit. 
+   - Once approved, merge the PR by using "Merge" commit.
      - This can either be done by temporarily enabling "Allow merge commits" option in "Settings > Options".
      - Alternatively, this can be done locally by merging `merge-release-to-master` branch into `master`, and pushing resulting `master` to upstream repository. This doesn't break `master` branch protection, since PR has been approved already, and also doesn't require removing the protection.
 1. Open a PR to add the new version to the backward compatibility integration test (`integration/backward_compatibility_test.go`)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -109,11 +109,12 @@ To publish a stable release:
    - Build binaries with `make dist` and attach them to the release
    - Build packages with `make packages`, test them with `make test-packages` and attach them to the release
 1. Merge the release branch `release-x.y` to `master`
-   - Merge to `master` in the local checkout
-   - Fix any conflict and `git commit -s`
-   - Temporarily disable "Include administrators" in the [`master` branch protection rule](https://github.com/cortexproject/cortex/settings/branch_protection_rules)
-   - Push changes to upstream (please double check before pushing!)
-   - Re-enable "Include administrators" in the [`master` branch protection rule](https://github.com/cortexproject/cortex/settings/branch_protection_rules)
+   - Create `merge-release-to-master` branch locally
+   - Merge upstream `master` branch into your `merge-release-to-master` and resolve conflicts
+   - Send PR to for merging your `merge-release-to-master` branch into `master`
+   - Once approved, merge the PR by using "Merge" commit. 
+     - This can either be done by temporarily enabling "Allow merge commits" option in "Settings > Options".
+     - Alternatively, this can be done locally by merging `merge-release-to-master` branch into `master`, and pushing resulting `master` to upstream repository. This doesn't break `master` branch protection, since PR has been approved already, and also doesn't require removing the protection.
 1. Open a PR to add the new version to the backward compatibility integration test (`integration/backward_compatibility_test.go`)
 
 ### How to tag a release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -111,10 +111,10 @@ To publish a stable release:
 1. Merge the release branch `release-x.y` to `master`
    - Create `merge-release-to-master` branch locally
    - Merge upstream `master` branch into your `merge-release-to-master` and resolve conflicts
-   - Send PR to for merging your `merge-release-to-master` branch into `master`
+   - Send PR for merging your `merge-release-to-master` branch into `master`
    - Once approved, merge the PR by using "Merge" commit.
      - This can either be done by temporarily enabling "Allow merge commits" option in "Settings > Options".
-     - Alternatively, this can be done locally by merging `merge-release-to-master` branch into `master`, and pushing resulting `master` to upstream repository. This doesn't break `master` branch protection, since PR has been approved already, and also doesn't require removing the protection.
+     - Alternatively, this can be done locally by merging `merge-release-to-master` branch into `master`, and pushing resulting `master` to upstream repository. This doesn't break `master` branch protection, since PR has been approved already, and it also doesn't require removing the protection.
 1. Open a PR to add the new version to the backward compatibility integration test (`integration/backward_compatibility_test.go`)
 
 ### How to tag a release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -109,12 +109,12 @@ To publish a stable release:
    - Build binaries with `make dist` and attach them to the release
    - Build packages with `make packages`, test them with `make test-packages` and attach them to the release
 1. Merge the release branch `release-x.y` to `master`
-   - Create `merge-release-to-master` branch locally
-   - Merge upstream `master` branch into your `merge-release-to-master` and resolve conflicts
-   - Send PR for merging your `merge-release-to-master` branch into `master`
+   - Create `merge-release-X.Y-to-master` branch **from `release-X.Y` branch** locally
+   - Merge upstream `master` branch into your `merge-release-X.Y-to-master` and resolve conflicts
+   - Send PR for merging your `merge-release-X.Y-to-master` branch into `master`
    - Once approved, merge the PR by using "Merge" commit.
      - This can either be done by temporarily enabling "Allow merge commits" option in "Settings > Options".
-     - Alternatively, this can be done locally by merging `merge-release-to-master` branch into `master`, and pushing resulting `master` to upstream repository. This doesn't break `master` branch protection, since PR has been approved already, and it also doesn't require removing the protection.
+     - Alternatively, this can be done locally by merging `merge-release-X.Y-to-master` branch into `master`, and pushing resulting `master` to upstream repository. This doesn't break `master` branch protection, since PR has been approved already, and it also doesn't require removing the protection.
 1. Open a PR to add the new version to the backward compatibility integration test (`integration/backward_compatibility_test.go`)
 
 ### How to tag a release


### PR DESCRIPTION
**What this PR does**: This PR updates release document, to make sure that merging of release branch to master is done via PR.
