### PR TITLE
Add Cortex 1.8.0 to backward_compatibility_test.go.

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -138,6 +138,7 @@ jobs:
           docker pull quay.io/cortexproject/cortex:v1.5.0
           docker pull quay.io/cortexproject/cortex:v1.6.0
           docker pull quay.io/cortexproject/cortex:v1.7.0
+          docker pull quay.io/cortexproject/cortex:v1.8.0
           docker pull shopify/bigtable-emulator:0.1.0
           docker pull rinscy/cassandra:3.11.0
           docker pull memcached:1.6.1

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -28,6 +28,7 @@ var (
 		"quay.io/cortexproject/cortex:v1.5.0": preCortex16Flags,
 		"quay.io/cortexproject/cortex:v1.6.0": nil,
 		"quay.io/cortexproject/cortex:v1.7.0": nil,
+		"quay.io/cortexproject/cortex:v1.8.0": nil,
 	}
 )
 


### PR DESCRIPTION
**What this PR does**: This PR adds Cortex 1.8.0 to backwards compatibility test.
