### PR TITLE
fix: ensure ruler returns 404 when getting missing rule group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [ENHANCEMENT] Querier / ruler: some optimizations to PromQL query engine. #3934 #3989
 * [ENHANCEMENT] Ingester: reduce CPU and memory when an high number of errors are returned by the ingester on the write path with the blocks storage. #3969 #3971 #3973
 * [ENHANCEMENT] Distributor: reduce CPU and memory when an high number of errors are returned by the distributor on the write path. #3990
+* [BUGFIX] Ruler-API: fix bug where `/api/v1/rules/<namespace>/<group_name>` endpoint return `400` instead of `404`. #4013
 * [BUGFIX] Distributor: reverted changes done to rate limiting in #3825. #3948
 * [BUGFIX] Ingester: Fix race condition when opening and closing tsdb concurrently. #3959
 * [BUGFIX] Querier: streamline tracing spans. #3924

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -321,6 +321,24 @@ func (c *Client) SetRuleGroup(rulegroup rulefmt.RuleGroup, namespace string) err
 	return nil
 }
 
+// GetRuleGroup gets a rule group.
+func (c *Client) GetRuleGroup(namespace string, groupName string) (*http.Response, error) {
+	// Create HTTP request
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/api/prom/rules/%s/%s", c.rulerAddress, url.PathEscape(namespace), url.PathEscape(groupName)), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/yaml")
+	req.Header.Set("X-Scope-OrgID", c.orgID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	// Execute HTTP request
+	return c.httpClient.Do(req.WithContext(ctx))
+}
+
 // DeleteRuleGroup deletes a rule group.
 func (c *Client) DeleteRuleGroup(namespace string, groupName string) error {
 	// Create HTTP request

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -123,6 +123,12 @@ func TestRulerAPI(t *testing.T) {
 			require.NoError(t, c.DeleteRuleGroup(namespaceOne, ruleGroup.Name))
 			require.NoError(t, c.DeleteRuleNamespace(namespaceTwo))
 
+			// Get the rule group and ensure it returns a 404
+			resp, err := c.GetRuleGroup(namespaceOne, ruleGroup.Name)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusNotFound, resp.StatusCode)
+
 			// Wait until the users manager has been terminated
 			require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(0), "cortex_ruler_managers_total"))
 

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -427,7 +427,7 @@ func (a *API) GetRuleGroup(w http.ResponseWriter, req *http.Request) {
 
 	rg, err := a.store.GetRuleGroup(req.Context(), userID, namespace, groupName)
 	if err != nil {
-		if err == rulestore.ErrGroupNotFound {
+		if errors.Is(err, rulestore.ErrGroupNotFound) {
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}


### PR DESCRIPTION
**What this PR does**:

- Fixes #4012 
- Add check in e2e `TestRulerAPI` to ensure proper behavior

**TODO**
- [x] Add regression test
- [x] Update `CHANGELOG.md`
