### PR TITLE
Fix issue where some test generate test data under src directory

### DIFF
--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -1397,28 +1397,30 @@ func TestStoreTemplateFile(t *testing.T) {
 		require.NoError(t, os.RemoveAll(tempDir))
 	})
 
-	changed, err := storeTemplateFile(templatesDir, "some-template", "content")
+	testTemplateDir := filepath.Join(tempDir, templatesDir)
+
+	changed, err := storeTemplateFile(testTemplateDir, "some-template", "content")
 	require.NoError(t, err)
 	require.True(t, changed)
 
-	changed, err = storeTemplateFile(templatesDir, "some-template", "new content")
+	changed, err = storeTemplateFile(testTemplateDir, "some-template", "new content")
 	require.NoError(t, err)
 	require.True(t, changed)
 
-	changed, err = storeTemplateFile(templatesDir, "some-template", "new content") // reusing previous content
+	changed, err = storeTemplateFile(testTemplateDir, "some-template", "new content") // reusing previous content
 	require.NoError(t, err)
 	require.False(t, changed)
 
-	_, err = storeTemplateFile(templatesDir, ".", "content")
+	_, err = storeTemplateFile(testTemplateDir, ".", "content")
 	require.Error(t, err)
 
-	_, err = storeTemplateFile(templatesDir, "..", "content")
+	_, err = storeTemplateFile(testTemplateDir, "..", "content")
 	require.Error(t, err)
 
-	_, err = storeTemplateFile(templatesDir, "./test", "content")
+	_, err = storeTemplateFile(testTemplateDir, "./test", "content")
 	require.Error(t, err)
 
-	_, err = storeTemplateFile(templatesDir, "../test", "content")
+	_, err = storeTemplateFile(testTemplateDir, "../test", "content")
 	require.Error(t, err)
 }
 

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -179,6 +179,7 @@ func mockTSDB(t *testing.T, mint model.Time, samples int, step, chunkOffset time
 	})
 
 	opts := tsdb.DefaultHeadOptions()
+	opts.ChunkDirRoot = dir
 	// We use TSDB head only. By using full TSDB DB, and appending samples to it, closing it would cause unnecessary HEAD compaction, which slows down the test.
 	head, err := tsdb.NewHead(nil, nil, nil, opts)
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does**:

Just applying boy scout rule here; I was constantly committing test generated files (yes, I like `git add  --all`) and had to use git-fu-that-I-never-rememeber to revert the commit. 

I didn't create issue nor update CHANGELOG.md because 
1. I am feeling a bit lazy :-)
2. It's a minor change in test only

Let me know if this is not acceptable.

**Which issue(s) this PR fixes**:
Didn't create PR.

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
