### PR TITLE
Disable alertmanager sharding tests.

### DIFF
--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -233,6 +233,8 @@ func TestAlertmanagerClustering(t *testing.T) {
 }
 
 func TestAlertmanagerSharding(t *testing.T) {
+	t.Skip("Flaky test under investigation")
+
 	tests := map[string]struct {
 		legacyAlertStore bool
 	}{

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -1026,6 +1026,8 @@ func TestAlertmanager_ReplicasPosition(t *testing.T) {
 }
 
 func TestAlertmanager_StateReplicationWithSharding(t *testing.T) {
+	t.Skip("Flaky test under investigation")
+
 	tc := []struct {
 		name              string
 		replicationFactor int


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Disable alertmanager sharding unit test and integration tests while investigating them.
