### PR TITLE
No need to check alert state in sendAlerts()

### DIFF
--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -344,10 +344,6 @@ func SendAlerts(n sender, externalURL string) promRules.NotifyFunc {
 		var res []*notifier.Alert
 
 		for _, alert := range alerts {
-			// Only send actually firing alerts.
-			if alert.State == promRules.StatePending {
-				continue
-			}
 			a := &notifier.Alert{
 				StartsAt:     alert.FiredAt,
 				Labels:       alert.Labels,


### PR DESCRIPTION
**What this PR does**:
While reviewing #4017, I've compared our `SendAlerts()` implementation with Prometheus one and I've noticed we do filter out pending alerts while Prometheus doesn't. The reason why Prometheus doesn't do it in its `sendAlerts()` is because pending alerts are now filtered out before calling it, so we can remove it from Cortex too. I've also took the opportunity to 

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
