### PR TITLE
Remove error return value, which was always nil.

### DIFF
--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -337,26 +337,26 @@ func (u *userTSDB) setLastUpdate(t time.Time) {
 }
 
 // Checks if TSDB can be closed.
-func (u *userTSDB) shouldCloseTSDB(idleTimeout time.Duration) (tsdbCloseCheckResult, error) {
+func (u *userTSDB) shouldCloseTSDB(idleTimeout time.Duration) tsdbCloseCheckResult {
 	if u.deletionMarkFound.Load() {
-		return tsdbTenantMarkedForDeletion, nil
+		return tsdbTenantMarkedForDeletion
 	}
 
 	if !u.isIdle(time.Now(), idleTimeout) {
-		return tsdbNotIdle, nil
+		return tsdbNotIdle
 	}
 
 	// If head is not compacted, we cannot close this yet.
 	if u.Head().NumSeries() > 0 {
-		return tsdbNotCompacted, nil
+		return tsdbNotCompacted
 	}
 
 	// Ensure that all blocks have been shipped.
 	if oldest := u.getOldestUnshippedBlockTime(); oldest > 0 {
-		return tsdbNotShipped, nil
+		return tsdbNotShipped
 	}
 
-	return tsdbIdle, nil
+	return tsdbIdle
 }
 
 // TSDBState holds data structures used by the TSDB storage engine
@@ -1883,10 +1883,7 @@ func (i *Ingester) closeAndDeleteUserTSDBIfIdle(userID string) tsdbCloseCheckRes
 		return tsdbShippingDisabled
 	}
 
-	if result, err := userDB.shouldCloseTSDB(i.cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBTimeout); !result.shouldClose() {
-		if err != nil {
-			level.Error(i.logger).Log("msg", "cannot close idle TSDB", "user", userID, "err", err)
-		}
+	if result := userDB.shouldCloseTSDB(i.cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBTimeout); !result.shouldClose() {
 		return result
 	}
 
@@ -1903,10 +1900,8 @@ func (i *Ingester) closeAndDeleteUserTSDBIfIdle(userID string) tsdbCloseCheckRes
 
 	// Verify again, things may have changed during the checks and pushes.
 	tenantDeleted := false
-	if result, err := userDB.shouldCloseTSDB(i.cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBTimeout); !result.shouldClose() {
-		if err != nil {
-			level.Error(i.logger).Log("msg", "cannot close idle TSDB", "user", userID, "err", err)
-		}
+	if result := userDB.shouldCloseTSDB(i.cfg.BlocksStorageConfig.TSDB.CloseIdleTSDBTimeout); !result.shouldClose() {
+		// This will also change TSDB state back to active (via defer above).
 		return result
 	} else if result == tsdbTenantMarkedForDeletion {
 		tenantDeleted = true


### PR DESCRIPTION
**What this PR does**: This PR removes `error` return value from `shouldCloseTSDB` method. After #3705 this return value was always `nil`.

**Checklist**
- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
