### PR TITLE
Implement periodic writing of alertmanager state to storage.

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2081,6 +2081,14 @@ alertmanager_client:
   # Skip validating server certificate.
   # CLI flag: -alertmanager.alertmanager-client.tls-insecure-skip-verify
   [tls_insecure_skip_verify: <boolean> | default = false]
+
+# The interval between persisting the current alertmanager state (notification
+# log and silences) to object storage. This state is read when all replicas for
+# a shard have failed. In this scenario, having persisted the state more
+# frequently will result in potentially fewer lost silences, and fewer duplicate
+# notifications.
+# CLI flag: -alertmanager.persist-interval
+[persist_interval: <duration> | default = 15m]
 ```
 
 ### `alertmanager_storage_config`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2083,10 +2083,10 @@ alertmanager_client:
   [tls_insecure_skip_verify: <boolean> | default = false]
 
 # The interval between persisting the current alertmanager state (notification
-# log and silences) to object storage. This state is read when all replicas for
-# a shard have failed. In this scenario, having persisted the state more
-# frequently will result in potentially fewer lost silences, and fewer duplicate
-# notifications.
+# log and silences) to object storage. This is only used when sharding is
+# enabled. This state is read when all replicas for a shard can not be
+# contacted. In this scenario, having persisted the state more frequently will
+# result in potentially fewer lost silences, and fewer duplicate notifications.
 # CLI flag: -alertmanager.persist-interval
 [persist_interval: <duration> | default = 15m]
 ```

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -81,6 +81,7 @@ type Alertmanager struct {
 	api             *api.API
 	logger          log.Logger
 	state           State
+	persister       *statePersister
 	nflog           *nflog.Log
 	silences        *silence.Silences
 	marker          types.Marker
@@ -163,7 +164,9 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 		am.state = cfg.Peer
 	} else if cfg.ShardingEnabled {
 		level.Debug(am.logger).Log("msg", "starting tenant alertmanager with ring-based replication")
-		am.state = newReplicatedStates(cfg.UserID, cfg.ReplicationFactor, cfg.Replicator, cfg.Store, am.logger, am.registry)
+		state := newReplicatedStates(cfg.UserID, cfg.ReplicationFactor, cfg.Replicator, cfg.Store, am.logger, am.registry)
+		am.state = state
+		am.persister = newStatePersister(cfg.UserID, state, cfg.Store, am.logger)
 	} else {
 		level.Debug(am.logger).Log("msg", "starting tenant alertmanager without replication")
 		am.state = &NilPeer{}
@@ -205,6 +208,12 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 	if service, ok := am.state.(services.Service); ok {
 		if err := service.StartAsync(context.Background()); err != nil {
 			return nil, errors.Wrap(err, "failed to start ring-based replication service")
+		}
+	}
+
+	if am.persister != nil {
+		if err := am.persister.StartAsync(context.Background()); err != nil {
+			return nil, errors.Wrap(err, "failed to start state persister service")
 		}
 	}
 
@@ -351,6 +360,10 @@ func (am *Alertmanager) Stop() {
 		am.dispatcher.Stop()
 	}
 
+	if am.persister != nil {
+		am.persister.StopAsync()
+	}
+
 	if service, ok := am.state.(services.Service); ok {
 		service.StopAsync()
 	}
@@ -361,6 +374,12 @@ func (am *Alertmanager) Stop() {
 
 func (am *Alertmanager) StopAndWait() {
 	am.Stop()
+
+	if am.persister != nil {
+		if err := am.persister.AwaitTerminated(context.Background()); err != nil {
+			level.Warn(am.logger).Log("msg", "error while stopping state persister service", "err", err)
+		}
+	}
 
 	if service, ok := am.state.(services.Service); ok {
 		if err := service.AwaitTerminated(context.Background()); err != nil {

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -73,6 +73,7 @@ type Config struct {
 	ReplicationFactor int
 	Replicator        Replicator
 	Store             alertstore.AlertStore
+	PersisterConfig   PersisterConfig
 }
 
 // An Alertmanager manages the alerts for one user.
@@ -166,7 +167,7 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 		level.Debug(am.logger).Log("msg", "starting tenant alertmanager with ring-based replication")
 		state := newReplicatedStates(cfg.UserID, cfg.ReplicationFactor, cfg.Replicator, cfg.Store, am.logger, am.registry)
 		am.state = state
-		am.persister = newStatePersister(cfg.UserID, state, cfg.Store, am.logger)
+		am.persister = newStatePersister(cfg.PersisterConfig, cfg.UserID, state, cfg.Store, am.logger)
 	} else {
 		level.Debug(am.logger).Log("msg", "starting tenant alertmanager without replication")
 		am.state = &NilPeer{}

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -161,7 +161,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet) {
 
 	cfg.AlertmanagerClient.RegisterFlagsWithPrefix("alertmanager.alertmanager-client", f)
 
-	f.DurationVar(&cfg.PersistInterval, "alertmanager.persist-interval", 15*time.Minute, "The interval between persisting the current alertmanager state (notification log and silences) to object storage. This state is read when all replicas for a shard have failed. In this scenario, having persisted the state more frequently will result in potentially fewer lost silences, and fewer duplicate notifications.")
+	f.DurationVar(&cfg.PersistInterval, "alertmanager.persist-interval", 15*time.Minute, "The interval between persisting the current alertmanager state (notification log and silences) to object storage. This is only used when sharding is enabled. This state is read when all replicas for a shard can not be contacted. In this scenario, having persisted the state more frequently will result in potentially fewer lost silences, and fewer duplicate notifications.")
 
 	cfg.ShardingRing.RegisterFlags(f)
 	cfg.Store.RegisterFlags(f)

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -85,6 +85,29 @@ func mockAlertmanagerConfig(t *testing.T) *MultitenantAlertmanagerConfig {
 	return cfg
 }
 
+func TestMultitenantAlertmanagerConfig_Validate(t *testing.T) {
+	// Default values only.
+	{
+		cfg := &MultitenantAlertmanagerConfig{}
+		flagext.DefaultValues(cfg)
+		assert.NoError(t, cfg.Validate())
+	}
+	// Invalid persist interval (zero).
+	{
+		cfg := &MultitenantAlertmanagerConfig{}
+		flagext.DefaultValues(cfg)
+		cfg.PersistInterval = 0
+		assert.Equal(t, errInvalidPersistInterval, cfg.Validate())
+	}
+	// Invalid persist interval (negative).
+	{
+		cfg := &MultitenantAlertmanagerConfig{}
+		flagext.DefaultValues(cfg)
+		cfg.PersistInterval = -1
+		assert.Equal(t, errInvalidPersistInterval, cfg.Validate())
+	}
+}
+
 func TestMultitenantAlertmanager_loadAndSyncConfigs(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -96,14 +96,14 @@ func TestMultitenantAlertmanagerConfig_Validate(t *testing.T) {
 	{
 		cfg := &MultitenantAlertmanagerConfig{}
 		flagext.DefaultValues(cfg)
-		cfg.PersistInterval = 0
+		cfg.Persister.Interval = 0
 		assert.Equal(t, errInvalidPersistInterval, cfg.Validate())
 	}
 	// Invalid persist interval (negative).
 	{
 		cfg := &MultitenantAlertmanagerConfig{}
 		flagext.DefaultValues(cfg)
-		cfg.PersistInterval = -1
+		cfg.Persister.Interval = -1
 		assert.Equal(t, errInvalidPersistInterval, cfg.Validate())
 	}
 }

--- a/pkg/alertmanager/state_persister.go
+++ b/pkg/alertmanager/state_persister.go
@@ -1,0 +1,100 @@
+package alertmanager
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/alertmanager/cluster/clusterpb"
+
+	"github.com/cortexproject/cortex/pkg/alertmanager/alertspb"
+	"github.com/cortexproject/cortex/pkg/alertmanager/alertstore"
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+const (
+	defaultPersistInterval = 15 * time.Minute
+	defaultPersistTimeout  = 30 * time.Second
+)
+
+type PersistableState interface {
+	State
+	GetFullState() (*clusterpb.FullState, error)
+}
+
+// statePersister periodically writes the alertmanager state to persistent storage.
+type statePersister struct {
+	services.Service
+
+	state  PersistableState
+	store  alertstore.AlertStore
+	userID string
+	logger log.Logger
+
+	interval time.Duration
+	timeout  time.Duration
+}
+
+// newStatePersister creates a new state persister.
+func newStatePersister(userID string, state PersistableState, store alertstore.AlertStore, l log.Logger) *statePersister {
+
+	s := &statePersister{
+		state:    state,
+		store:    store,
+		userID:   userID,
+		logger:   l,
+		interval: defaultPersistInterval,
+		timeout:  defaultPersistTimeout,
+	}
+
+	s.Service = services.NewBasicService(s.starting, s.running, nil)
+
+	return s
+}
+
+func (s *statePersister) starting(ctx context.Context) error {
+	// Waits until the state replicator is settled, so that state is not
+	// persisted before obtaining some initial state.
+	return s.state.WaitReady(ctx)
+}
+
+func (s *statePersister) running(ctx context.Context) error {
+	level.Debug(s.logger).Log("msg", "started state persister", "user", s.userID, "interval", s.interval)
+
+	ticker := time.NewTicker(s.interval)
+	for {
+		select {
+		case <-ticker.C:
+			if err := s.persist(ctx); err != nil {
+				level.Error(s.logger).Log("msg", "failed to persist state", "user", s.userID, "err", err)
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (s *statePersister) persist(ctx context.Context) error {
+	// Only the replica at position zero should write the state.
+	if s.state.Position() != 0 {
+		return nil
+	}
+
+	level.Debug(s.logger).Log("msg", "persisting state", "user", s.userID)
+
+	fs, err := s.state.GetFullState()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	desc := alertspb.FullStateDesc{State: fs}
+	if err := s.store.SetFullState(ctx, s.userID, desc); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/alertmanager/state_persister_test.go
+++ b/pkg/alertmanager/state_persister_test.go
@@ -1,0 +1,172 @@
+package alertmanager
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/alertmanager/cluster/clusterpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/alertmanager/alertspb"
+	"github.com/cortexproject/cortex/pkg/alertmanager/alertstore"
+	"github.com/cortexproject/cortex/pkg/util/services"
+)
+
+type fakePersistableState struct {
+	PersistableState
+
+	position int
+	readyc   chan struct{}
+
+	getResult *clusterpb.FullState
+	getError  error
+}
+
+func (f *fakePersistableState) Position() int {
+	return f.position
+}
+
+func (f *fakePersistableState) GetFullState() (*clusterpb.FullState, error) {
+	return f.getResult, f.getError
+}
+
+func newFakePersistableState() *fakePersistableState {
+	return &fakePersistableState{
+		readyc: make(chan struct{}),
+	}
+}
+
+func (f *fakePersistableState) WaitReady(ctx context.Context) error {
+	<-f.readyc
+	return nil
+}
+
+type fakeStoreSet struct {
+	user string
+	desc alertspb.FullStateDesc
+}
+
+type fakeStore struct {
+	alertstore.AlertStore
+
+	setsMtx sync.Mutex
+	sets    []fakeStoreSet
+}
+
+func (f *fakeStore) SetFullState(ctx context.Context, user string, desc alertspb.FullStateDesc) error {
+	f.setsMtx.Lock()
+	defer f.setsMtx.Unlock()
+	f.sets = append(f.sets, fakeStoreSet{user, desc})
+	return nil
+}
+
+func TestStatePersister_Position0ShouldWrite(t *testing.T) {
+	state := newFakePersistableState()
+	store := &fakeStore{}
+
+	s := newStatePersister("user-1", state, store, log.NewNopLogger())
+	s.interval = 1 * time.Second
+
+	require.NoError(t, s.StartAsync(context.Background()))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), s))
+	})
+
+	time.Sleep(5 * time.Second)
+
+	// Should not have started until the state becomes ready.
+	{
+		assert.Equal(t, services.Starting, s.Service.State())
+		store.setsMtx.Lock()
+		numSets := len(store.sets)
+		store.setsMtx.Unlock()
+		assert.Equal(t, 0, numSets)
+	}
+
+	// Should now start.
+	{
+		state.getResult = &clusterpb.FullState{
+			Parts: []clusterpb.Part{
+				{
+					Key:  "key",
+					Data: []byte("data"),
+				},
+			},
+		}
+
+		close(state.readyc)
+		require.NoError(t, s.AwaitRunning(context.Background()))
+	}
+
+	// Should receive a write to the store.
+	{
+		var storeSets []fakeStoreSet
+		require.Eventually(t, func() bool {
+			store.setsMtx.Lock()
+			storeSets = store.sets
+			store.setsMtx.Unlock()
+
+			return len(storeSets) == 1
+		}, 5*time.Second, 100*time.Millisecond)
+
+		expectedSet := alertspb.FullStateDesc{
+			State: &clusterpb.FullState{
+				Parts: []clusterpb.Part{
+					{
+						Key:  "key",
+						Data: []byte("data"),
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, "user-1", storeSets[0].user)
+		assert.Equal(t, expectedSet, storeSets[0].desc)
+	}
+}
+
+func TestStatePersister_Position1ShouldNotWrite(t *testing.T) {
+	state := newFakePersistableState()
+	state.position = 1
+	store := &fakeStore{}
+
+	s := newStatePersister("user-1", state, store, log.NewNopLogger())
+	s.interval = 1 * time.Second
+
+	require.NoError(t, s.StartAsync(context.Background()))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), s))
+	})
+
+	// Start the persister.
+	{
+		state.getResult = &clusterpb.FullState{
+			Parts: []clusterpb.Part{
+				{
+					Key:  "key",
+					Data: []byte("data"),
+				},
+			},
+		}
+
+		assert.Equal(t, services.Starting, s.Service.State())
+		close(state.readyc)
+		require.NoError(t, s.AwaitRunning(context.Background()))
+	}
+
+	// Wait for the interval to be hit a few times.
+	time.Sleep(5 * time.Second)
+
+	// Should not have stored anything.
+	{
+		assert.Equal(t, services.Running, s.Service.State())
+		store.setsMtx.Lock()
+		numSets := len(store.sets)
+		store.setsMtx.Unlock()
+		assert.Equal(t, 0, numSets)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
When ring-based/sharding replication is enabled, the alertmanager state
(silences, notification log) is periodically written to object storage
so that it can be used to recover from an all-replica outage. Only one
of the replicas is responsible for writing the state (position 0).

**Checklist**
- [X] Tests updated
- [X] ~~Documentation added~~
- [X] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~
