### PR TITLE
doc: Add note about use of curl for experimental Alertmanager API

### DIFF
--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -698,6 +698,9 @@ _This experimental endpoint is disabled by default and can be enabled via the `-
 
 _Requires [authentication](#authentication)._
 
+> **Note:** When using `curl` send the request body from a file, ensure that you use the `--data-binary` flag instead of `-d`, `--data`, or `--data-ascii`.
+> The latter options do not preserve carriage returns and newlines.
+
 #### Example request body
 
 ```yaml


### PR DESCRIPTION
**What this PR does**:
Adds a note about sending the Alertmanager configuration body with `curl`. I was initially unaware that `curl` stripped carriage returns and newlines from files when using `-d @<file>` and was confused to find posting JSON data worked but YAML data didn't. Knowing that information now makes this obvious but I wouldn't be surprised if someone else may experience the same confusion.

**Checklist**
- [x] Documentation added
