### PR TITLE
Update distributors CPU usage in capacity planning doc

### DIFF
--- a/docs/guides/capacity-planning.md
+++ b/docs/guides/capacity-planning.md
@@ -51,7 +51,7 @@ Now, some rules of thumb:
  2. Each million series (including churn) consumes 15GB of chunk
  storage and 4GB of index, per day (so multiply by the retention
  period).
- 3. Each 100,000 samples/sec arriving takes 1 CPU in distributors.
+ 3. Each 10,000 samples/sec arriving takes about 1 CPU core in distributors.
  Distributors don't need much RAM.
 
 If you turn on compression between distributors and ingesters (for

--- a/docs/guides/capacity-planning.md
+++ b/docs/guides/capacity-planning.md
@@ -51,8 +51,12 @@ Now, some rules of thumb:
  2. Each million series (including churn) consumes 15GB of chunk
  storage and 4GB of index, per day (so multiply by the retention
  period).
- 3. Each 10,000 samples/sec arriving takes about 1 CPU core in distributors.
- Distributors don't need much RAM.
+ 3. The distributors CPU utilization depends on the specific Cortex cluster
+    setup, while they don't need much RAM. Typically, distributors are capable
+    to process between 20,000 and 100,000 samples/sec with 1 CPU core. It's also
+    highly recommended to configure Prometheus `max_samples_per_send` to 1,000
+    samples, in order to reduce the distributors CPU utilization given the same
+    total samples/sec throughput.
 
 If you turn on compression between distributors and ingesters (for
 example to save on inter-zone bandwidth charges at AWS/GCP) they will use


### PR DESCRIPTION
**What this PR does**:
I was doing the math to check how much CPU and memory a distributor takes by sample/sec and my math doesn't match with our documentation, so I'm updating it (don't know where 100K samples/sec per core did come from).

@bboreham what do you see in your clusters?

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
