### PR TITLE
Add a metric for the compaction interval config value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [ENHANCEMENT] Put metric before label value in the "label value too long" error message. #4018
 * [ENHANCEMENT] Allow use of `y|w|d` suffixes for duration related limits and per-tenant limits. #4044
 * [ENHANCEMENT] Query-frontend: Small optimization on top of PR #3968 to avoid unnecessary Extents merging. #4026
+* [ENHANCEMENT] Add a metric `cortex_compactor_compaction_interval_seconds` for the compaction interval config value. #4040
 * [BUGFIX] Ruler-API: fix bug where `/api/v1/rules/<namespace>/<group_name>` endpoint return `400` instead of `404`. #4013
 * [BUGFIX] Distributor: reverted changes done to rate limiting in #3825. #3948
 * [BUGFIX] Ingester: Fix race condition when opening and closing tsdb concurrently. #3959

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -219,6 +219,7 @@ type Compactor struct {
 	compactionRunSkippedTenants    prometheus.Gauge
 	compactionRunSucceededTenants  prometheus.Gauge
 	compactionRunFailedTenants     prometheus.Gauge
+	compactionRunInterval          prometheus.Gauge
 	blocksMarkedForDeletion        prometheus.Counter
 	garbageCollectedBlocks         prometheus.Counter
 
@@ -303,6 +304,10 @@ func newCompactor(
 		compactionRunFailedTenants: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_compactor_tenants_processing_failed",
 			Help: "Number of tenants failed processing during the current compaction run. Reset to 0 when compactor is idle.",
+		}),
+		compactionRunInterval: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_compactor_run_interval_seconds",
+			Help: "The configured interval on which compaction is run in seconds. Useful when compared to the last successful run metric to accurately detect multiple failed compaction runs.",
 		}),
 		blocksMarkedForDeletion: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
 			Name:        blocksMarkedForDeletionName,
@@ -427,6 +432,9 @@ func (c *Compactor) starting(ctx context.Context) error {
 		c.ringSubservices.StopAsync()
 		return errors.Wrap(err, "failed to start the blocks cleaner")
 	}
+
+	// The last successful compaction run metric is exposed as seconds since epoch, so we need to use seconds for this metric.
+	c.compactionRunInterval.Set(c.compactorCfg.CompactionInterval.Seconds())
 
 	return nil
 }

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -129,8 +129,8 @@ func TestCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 	// No user blocks stored in the bucket.
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("", []string{}, nil)
-
-	c, _, _, logs, registry := prepare(t, prepareConfig(), bucketClient)
+	cfg := prepareConfig()
+	c, _, _, logs, registry := prepare(t, cfg, bucketClient)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
@@ -139,6 +139,8 @@ func TestCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 	})
 
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
+
+	assert.Equal(t, prom_testutil.ToFloat64(c.compactionRunInterval), cfg.CompactionInterval.Seconds())
 
 	assert.Equal(t, []string{
 		`level=info component=cleaner msg="started blocks cleanup and maintenance"`,


### PR DESCRIPTION
Adds a metric to the compactor that exposes the configured `CompactionInterval` as a gauge, in seconds. The intention is to be able to use this metric, the last successful compaction timestamp metric, and `time()` to more accurately calculate the # of compactions in a row that have failed. This would improve [this](https://github.com/grafana/cortex-jsonnet/blob/main/cortex-mixin/alerts/compactor.libsonnet#L66-L80) alert in cortex-jsonnet which is hardcoded to look for > 1 failures in a 2h time period.

I added a quick check to the first test I found that actually started the compactor, just to confirm the metric was being set. If you'd like a more indepth test, or to move that check to it's own test, just let me know.

Signed-off-by: Callum Styan <callumstyan@gmail.com>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
