### PR TITLE
chore: update Dockerfiles to use Alpine 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * `-alertmanager.cluster.peers` instead of `-cluster.peer`
   * `-alertmanager.cluster.peer-timeout` instead of `-cluster.peer-timeout`
 * [FEATURE] Ruler: added `local` backend support to the ruler storage configuration under the `-ruler-storage.` flag prefix. #3932
+* [ENHANCEMENT] Upgraded Docker base images to `alpine:3.12`. #4042
 * [ENHANCEMENT] Blocks storage: reduce ingester memory by eliminating series reference cache. #3951
 * [ENHANCEMENT] Ruler: optimized `<prefix>/api/v1/rules` and `<prefix>/api/v1/alerts` when ruler sharding is enabled. #3916
 * [ENHANCEMENT] Ruler: added the following metrics when ruler sharding is enabled: #3916

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   * `-alertmanager.cluster.peers` instead of `-cluster.peer`
   * `-alertmanager.cluster.peer-timeout` instead of `-cluster.peer-timeout`
 * [FEATURE] Ruler: added `local` backend support to the ruler storage configuration under the `-ruler-storage.` flag prefix. #3932
-* [ENHANCEMENT] Upgraded Docker base images to `alpine:3.12`. #4042
+* [ENHANCEMENT] Upgraded Docker base images to `alpine:3.13`. #4042
 * [ENHANCEMENT] Blocks storage: reduce ingester memory by eliminating series reference cache. #3951
 * [ENHANCEMENT] Ruler: optimized `<prefix>/api/v1/rules` and `<prefix>/api/v1/alerts` when ruler sharding is enabled. #3916
 * [ENHANCEMENT] Ruler: added the following metrics when ruler sharding is enabled: #3916

--- a/cmd/blocksconvert/Dockerfile
+++ b/cmd/blocksconvert/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine:3.12
+FROM       alpine:3.13
 RUN        apk add --no-cache ca-certificates
 COPY       blocksconvert /
 ENTRYPOINT ["/blocksconvert"]

--- a/cmd/cortex/Dockerfile
+++ b/cmd/cortex/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine:3.12
+FROM       alpine:3.13
 RUN        apk add --no-cache ca-certificates
 COPY       migrations /migrations/
 COPY       cortex /bin/cortex

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine:3.12
+FROM       alpine:3.13
 RUN        apk add --no-cache ca-certificates
 COPY       query-tee /
 ENTRYPOINT ["/query-tee"]

--- a/cmd/test-exporter/Dockerfile
+++ b/cmd/test-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine:3.12
+FROM       alpine:3.13
 RUN        apk add --no-cache ca-certificates
 COPY       test-exporter /
 ENTRYPOINT ["/test-exporter"]

--- a/cmd/thanosconvert/Dockerfile
+++ b/cmd/thanosconvert/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine:3.12
+FROM       alpine:3.13
 RUN        apk add --no-cache ca-certificates
 COPY       thanosconvert /
 ENTRYPOINT ["/thanosconvert"]

--- a/development/tsdb-blocks-storage-s3-gossip/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3-gossip/dev.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.14
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 RUN go get github.com/go-delve/delve/cmd/dlv
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN     mkdir /cortex
 WORKDIR /cortex

--- a/development/tsdb-blocks-storage-s3-single-binary/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3-single-binary/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN     mkdir /cortex
 WORKDIR /cortex

--- a/development/tsdb-blocks-storage-s3/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3/dev.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.14
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 RUN go get github.com/go-delve/delve/cmd/dlv
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN     mkdir /cortex
 WORKDIR /cortex

--- a/development/tsdb-blocks-storage-swift-single-binary/dev.dockerfile
+++ b/development/tsdb-blocks-storage-swift-single-binary/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN     mkdir /cortex
 WORKDIR /cortex


### PR DESCRIPTION
**What this PR does**:

- Upgrades the Alpine image to the latest minor version `3.13`

**Which issue(s) this PR fixes**:

Fixes #4041


[**Alpine Release Notes**](https://alpinelinux.org/posts/Alpine-3.13.0-released.html) <-- _for anyone interested_


