### PR TITLE
Add concurrency to the mergeQueryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [ENHANCEMENT] Allow configuration of Cassandra's host selection policy. #4069
 * [ENHANCEMENT] Store-gateway: retry synching blocks if a per-tenant sync fails. #3975 #4088
 * [ENHANCEMENT] Add metric `cortex_tcp_connections` exposing the current number of accepted TCP connections. #4099
+* [ENHANCEMENT] Querier: Allow federated queries to run concurrently. #4065
 * [BUGFIX] Ruler-API: fix bug where `/api/v1/rules/<namespace>/<group_name>` endpoint return `400` instead of `404`. #4013
 * [BUGFIX] Distributor: reverted changes done to rate limiting in #3825. #3948
 * [BUGFIX] Ingester: Fix race condition when opening and closing tsdb concurrently. #3959

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -349,12 +349,12 @@ func (m *addLabelsSeriesSet) Warnings() storage.Warnings {
 	return warnings
 }
 
-// rewrite label name to be better readable in error output
+// rewrite label name to be more readable in error output
 func rewriteLabelName(s string) string {
 	return strings.TrimRight(strings.TrimLeft(s, "_"), "_")
 }
 
-// this outputs a better readable error format
+// this outputs a more readable error format
 func labelsToString(labels labels.Labels) string {
 	parts := make([]string, len(labels))
 	for pos, l := range labels {

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -267,8 +267,9 @@ func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, match
 
 	err := concurrency.ForEach(m.ctx, jobs, maxConcurrency, run)
 	if err != nil {
-		panic(fmt.Sprintf("this should never happen: %v", err))
+		return storage.ErrSeriesSet(err)
 	}
+
 	return storage.NewMergeSeriesSet(seriesSets, storage.ChainedSeriesMerge)
 }
 

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -222,9 +222,9 @@ func (m *mergeQuerier) Close() error {
 }
 
 type selectJob struct {
-	seriesSet *storage.SeriesSet
-	querier   storage.Querier
-	tenantID  string
+	pos      int
+	querier  storage.Querier
+	tenantID string
 }
 
 // Select returns a set of series that matches the given label matchers. If the
@@ -241,9 +241,9 @@ func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, match
 			continue
 		}
 		jobs[jobPos] = &selectJob{
-			seriesSet: &seriesSets[jobPos],
-			querier:   m.queriers[tenantPos],
-			tenantID:  m.tenantIDs[tenantPos],
+			pos:      jobPos,
+			querier:  m.queriers[tenantPos],
+			tenantID: m.tenantIDs[tenantPos],
 		}
 		jobPos++
 	}
@@ -253,7 +253,7 @@ func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, match
 		if !ok {
 			return fmt.Errorf("unexpected type %T", jobIntf)
 		}
-		*job.seriesSet = &addLabelsSeriesSet{
+		seriesSets[job.pos] = &addLabelsSeriesSet{
 			upstream: job.querier.Select(sortSeries, hints, filteredMatchers...),
 			labels: labels.Labels{
 				{

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -330,7 +330,7 @@ func (m *addLabelsSeriesSet) Err() error {
 // Warnings could be return even iteration has not failed with error.
 func (m *addLabelsSeriesSet) Warnings() storage.Warnings {
 	upstream := m.upstream.Warnings()
-	var warnings = make(storage.Warnings, len(upstream))
+	warnings := make(storage.Warnings, len(upstream))
 	for pos := range upstream {
 		warnings[pos] = errors.Wrapf(upstream[pos], "warning querying %s", m.labels.String())
 	}

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -165,6 +165,11 @@ func (m *mergeQuerier) mergeDistinctStringSlice(f stringSliceFunc) ([]string, st
 	}
 
 	run := func(ctx context.Context, jobIntf interface{}) error {
+		// end early when context has ended
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		job, ok := jobIntf.(*stringSliceFuncJob)
 		if !ok {
 			return fmt.Errorf("unexpected type %T", jobIntf)
@@ -249,6 +254,11 @@ func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, match
 	}
 
 	run := func(ctx context.Context, jobIntf interface{}) error {
+		// end early when context has ended
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		job, ok := jobIntf.(*selectJob)
 		if !ok {
 			return fmt.Errorf("unexpected type %T", jobIntf)

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -165,11 +165,6 @@ func (m *mergeQuerier) mergeDistinctStringSlice(f stringSliceFunc) ([]string, st
 	}
 
 	run := func(ctx context.Context, jobIntf interface{}) error {
-		// end early when context has ended
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-
 		job, ok := jobIntf.(*stringSliceFuncJob)
 		if !ok {
 			return fmt.Errorf("unexpected type %T", jobIntf)
@@ -254,11 +249,6 @@ func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, match
 	}
 
 	run := func(ctx context.Context, jobIntf interface{}) error {
-		// end early when context has ended
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-
 		job, ok := jobIntf.(*selectJob)
 		if !ok {
 			return fmt.Errorf("unexpected type %T", jobIntf)

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -351,8 +351,8 @@ func TestMergeQueryable(t *testing.T) {
 				"team-c": storage.Warnings([]error{errors.New("out of office")}),
 			},
 			expectedWarnings: []string{
-				`warning querying {__tenant_id__="team-b"}: don't like them`,
-				`warning querying {__tenant_id__="team-c"}: out of office`,
+				`warning querying tenant_id team-b: don't like them`,
+				`warning querying tenant_id team-c: out of office`,
 			},
 		},
 		{
@@ -365,7 +365,7 @@ func TestMergeQueryable(t *testing.T) {
 			queryErrByTenant: map[string]error{
 				"team-b": errors.New("failure xyz"),
 			},
-			expectedQueryErr: errors.New("error querying {__tenant_id__=\"team-b\"}: failure xyz"),
+			expectedQueryErr: errors.New("error querying tenant_id team-b: failure xyz"),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -127,7 +127,7 @@ func (m *mockSeriesSet) Next() bool {
 	return m.upstream.Next()
 }
 
-// At returns full series. Returned series should be iteratable even after Next is called.
+// At returns full series. Returned series should be iterable even after Next is called.
 func (m *mockSeriesSet) At() storage.Series {
 	return m.upstream.At()
 }
@@ -139,7 +139,7 @@ func (m *mockSeriesSet) Err() error {
 }
 
 // A collection of warnings for the whole set.
-// Warnings could be return even iteration has not failed with error.
+// Warnings could be returned even if iteration has not failed with error.
 func (m *mockSeriesSet) Warnings() storage.Warnings {
 	return m.warnings
 }
@@ -443,9 +443,7 @@ func assertEqualWarnings(t *testing.T, exp []string, act storage.Warnings) {
 	for pos := range act {
 		actStrings[pos] = act[pos].Error()
 	}
-	sort.Strings(exp)
-	sort.Strings(actStrings)
-	assert.Equal(t, exp, actStrings)
+	assert.ElementsMatch(t, exp, actStrings)
 }
 
 func TestSetLabelsRetainExisting(t *testing.T) {

--- a/pkg/util/concurrency/runner.go
+++ b/pkg/util/concurrency/runner.go
@@ -81,6 +81,10 @@ func ForEach(ctx context.Context, jobs []interface{}, concurrency int, jobFunc f
 	for ix := 0; ix < util_math.Min(concurrency, len(jobs)); ix++ {
 		g.Go(func() error {
 			for job := range ch {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+
 				if err := jobFunc(ctx, job); err != nil {
 					return err
 				}


### PR DESCRIPTION
This should significantly parallelize tenant federation queries. This also extends and aligns the error and warning wrapping and adds tests for those cases.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- ~[ ] Documentation added~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
