### PR TITLE
Fixed race condition causing queries to fail right after querier startup with the "empty ring" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     * `-memberlist.tls-ca-path`
     * `-memberlist.tls-server-name`
     * `-memberlist.tls-insecure-skip-verify`
+* [CHANGE] Cortex now fast fails on startup if unable to connect to the ring backend. #4068
 * [FEATURE] Ruler: added `local` backend support to the ruler storage configuration under the `-ruler-storage.` flag prefix. #3932
 * [ENHANCEMENT] Upgraded Docker base images to `alpine:3.13`. #4042
 * [ENHANCEMENT] Blocks storage: reduce ingester memory by eliminating series reference cache. #3951
@@ -48,6 +49,7 @@
 * [BUGFIX] Querier: returning 422 (instead of 500) when query hits `max_chunks_per_query` limit with block storage, when the limit is hit in the store-gateway. #3937
 * [BUGFIX] Ruler: Rule group limit enforcement should now allow the same number of rules in a group as the limit. #3615
 * [BUGFIX] Frontend, Query-scheduler: allow querier to notify about shutdown without providing any authentication. #4066
+* [BUGFIX] Querier: fixed race condition causing queries to fail right after querier startup with the "empty ring" error. #4068
 
 ## Blocksconvert
 

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -370,7 +370,7 @@ func NewAlertmanagerWithTLS(name string, flags map[string]string, image string) 
 	)
 }
 
-func NewRuler(name string, flags map[string]string, image string) *CortexService {
+func NewRuler(name string, consulAddress string, flags map[string]string, image string) *CortexService {
 	if image == "" {
 		image = GetDefaultImage()
 	}
@@ -381,6 +381,9 @@ func NewRuler(name string, flags map[string]string, image string) *CortexService
 		e2e.NewCommandWithoutEntrypoint("cortex", e2e.BuildArgs(e2e.MergeFlags(map[string]string{
 			"-target":    "ruler",
 			"-log.level": "warn",
+			// Configure the ingesters ring backend
+			"-ring.store":      "consul",
+			"-consul.hostname": consulAddress,
 		}, flags))...),
 		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
 		httpPort,

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -54,13 +54,14 @@ func TestRulerAPI(t *testing.T) {
 			defer s.Close()
 
 			// Start dependencies.
+			consul := e2edb.NewConsul()
 			dynamo := e2edb.NewDynamoDB()
 			minio := e2edb.NewMinio(9000, rulestoreBucketName)
-			require.NoError(t, s.StartAndWaitReady(minio, dynamo))
+			require.NoError(t, s.StartAndWaitReady(consul, minio, dynamo))
 
 			// Start Cortex components.
 			require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
-			ruler := e2ecortex.NewRuler("ruler", mergeFlags(ChunksStorageFlags(), RulerFlags(testCfg.legacyRuleStore)), "")
+			ruler := e2ecortex.NewRuler("ruler", consul.NetworkHTTPEndpoint(), mergeFlags(ChunksStorageFlags(), RulerFlags(testCfg.legacyRuleStore)), "")
 			require.NoError(t, s.StartAndWaitReady(ruler))
 
 			// Create a client with the ruler address configured
@@ -360,8 +361,8 @@ func TestRulerSharding(t *testing.T) {
 	)
 
 	// Start rulers.
-	ruler1 := e2ecortex.NewRuler("ruler-1", rulerFlags, "")
-	ruler2 := e2ecortex.NewRuler("ruler-2", rulerFlags, "")
+	ruler1 := e2ecortex.NewRuler("ruler-1", consul.NetworkHTTPEndpoint(), rulerFlags, "")
+	ruler2 := e2ecortex.NewRuler("ruler-2", consul.NetworkHTTPEndpoint(), rulerFlags, "")
 	rulers := e2ecortex.NewCompositeCortexService(ruler1, ruler2)
 	require.NoError(t, s.StartAndWaitReady(ruler1, ruler2))
 
@@ -401,9 +402,10 @@ func TestRulerAlertmanager(t *testing.T) {
 	defer s.Close()
 
 	// Start dependencies.
+	consul := e2edb.NewConsul()
 	dynamo := e2edb.NewDynamoDB()
 	minio := e2edb.NewMinio(9000, rulestoreBucketName)
-	require.NoError(t, s.StartAndWaitReady(minio, dynamo))
+	require.NoError(t, s.StartAndWaitReady(consul, minio, dynamo))
 
 	// Have at least one alertmanager configuration.
 	require.NoError(t, writeFileToSharedDir(s, "alertmanager_configs/user-1.yaml", []byte(cortexAlertmanagerUserConfigYaml)))
@@ -424,7 +426,7 @@ func TestRulerAlertmanager(t *testing.T) {
 
 	// Start Ruler.
 	require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
-	ruler := e2ecortex.NewRuler("ruler", mergeFlags(ChunksStorageFlags(), RulerFlags(false), configOverrides), "")
+	ruler := e2ecortex.NewRuler("ruler", consul.NetworkHTTPEndpoint(), mergeFlags(ChunksStorageFlags(), RulerFlags(false), configOverrides), "")
 	require.NoError(t, s.StartAndWaitReady(ruler))
 
 	// Create a client with the ruler address configured
@@ -450,9 +452,10 @@ func TestRulerAlertmanagerTLS(t *testing.T) {
 	defer s.Close()
 
 	// Start dependencies.
+	consul := e2edb.NewConsul()
 	dynamo := e2edb.NewDynamoDB()
 	minio := e2edb.NewMinio(9000, rulestoreBucketName)
-	require.NoError(t, s.StartAndWaitReady(minio, dynamo))
+	require.NoError(t, s.StartAndWaitReady(consul, minio, dynamo))
 
 	// set the ca
 	cert := ca.New("Ruler/Alertmanager Test")
@@ -503,7 +506,7 @@ func TestRulerAlertmanagerTLS(t *testing.T) {
 
 	// Start Ruler.
 	require.NoError(t, writeFileToSharedDir(s, cortexSchemaConfigFile, []byte(cortexSchemaConfigYaml)))
-	ruler := e2ecortex.NewRuler("ruler", mergeFlags(ChunksStorageFlags(), RulerFlags(false), configOverrides), "")
+	ruler := e2ecortex.NewRuler("ruler", consul.NetworkHTTPEndpoint(), mergeFlags(ChunksStorageFlags(), RulerFlags(false), configOverrides), "")
 	require.NoError(t, s.StartAndWaitReady(ruler))
 
 	// Create a client with the ruler address configured

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -4,7 +4,6 @@ package ring
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"math"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cortexproject/cortex/pkg/ring/kv"
@@ -255,8 +255,25 @@ func NewWithStoreClientAndStrategy(cfg Config, name, key string, store kv.Client
 		),
 	}
 
-	r.Service = services.NewBasicService(nil, r.loop, nil).WithName(fmt.Sprintf("%s ring client", name))
+	r.Service = services.NewBasicService(r.starting, r.loop, nil).WithName(fmt.Sprintf("%s ring client", name))
 	return r, nil
+}
+
+func (r *Ring) starting(ctx context.Context) error {
+	// Get the initial ring state so that, as soon as the service will be running, the in-memory
+	// ring would be already populated and there's no race condition between when the service is
+	// running and the WatchKey() callback is called for the first time.
+	value, err := r.KVClient.Get(ctx, r.key)
+	if err != nil {
+		return errors.Wrap(err, "unable to initialise ring state")
+	}
+	if value == nil {
+		level.Info(log.Logger).Log("msg", "ring doesn't exist in KV store yet")
+		return nil
+	}
+
+	r.updateRingState(value.(*Desc))
+	return nil
 }
 
 func (r *Ring) loop(ctx context.Context) error {
@@ -266,44 +283,46 @@ func (r *Ring) loop(ctx context.Context) error {
 			return true
 		}
 
-		ringDesc := value.(*Desc)
-
-		r.mtx.RLock()
-		prevRing := r.ringDesc
-		r.mtx.RUnlock()
-
-		rc := prevRing.RingCompare(ringDesc)
-		if rc == Equal || rc == EqualButStatesAndTimestamps {
-			// No need to update tokens or zones. Only states and timestamps
-			// have changed. (If Equal, nothing has changed, but that doesn't happen
-			// when watching the ring for updates).
-			r.mtx.Lock()
-			r.ringDesc = ringDesc
-			r.mtx.Unlock()
-			return true
-		}
-
-		now := time.Now()
-		ringTokens := ringDesc.GetTokens()
-		ringTokensByZone := ringDesc.getTokensByZone()
-		ringInstanceByToken := ringDesc.getTokensInfo()
-		ringZones := getZones(ringTokensByZone)
-
-		r.mtx.Lock()
-		defer r.mtx.Unlock()
-		r.ringDesc = ringDesc
-		r.ringTokens = ringTokens
-		r.ringTokensByZone = ringTokensByZone
-		r.ringInstanceByToken = ringInstanceByToken
-		r.ringZones = ringZones
-		r.lastTopologyChange = now
-		if r.shuffledSubringCache != nil {
-			// Invalidate all cached subrings.
-			r.shuffledSubringCache = make(map[subringCacheKey]*Ring)
-		}
+		r.updateRingState(value.(*Desc))
 		return true
 	})
 	return nil
+}
+
+func (r *Ring) updateRingState(ringDesc *Desc) {
+	r.mtx.RLock()
+	prevRing := r.ringDesc
+	r.mtx.RUnlock()
+
+	rc := prevRing.RingCompare(ringDesc)
+	if rc == Equal || rc == EqualButStatesAndTimestamps {
+		// No need to update tokens or zones. Only states and timestamps
+		// have changed. (If Equal, nothing has changed, but that doesn't happen
+		// when watching the ring for updates).
+		r.mtx.Lock()
+		r.ringDesc = ringDesc
+		r.mtx.Unlock()
+		return
+	}
+
+	now := time.Now()
+	ringTokens := ringDesc.GetTokens()
+	ringTokensByZone := ringDesc.getTokensByZone()
+	ringInstanceByToken := ringDesc.getTokensInfo()
+	ringZones := getZones(ringTokensByZone)
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	r.ringDesc = ringDesc
+	r.ringTokens = ringTokens
+	r.ringTokensByZone = ringTokensByZone
+	r.ringInstanceByToken = ringInstanceByToken
+	r.ringZones = ringZones
+	r.lastTopologyChange = now
+	if r.shuffledSubringCache != nil {
+		// Invalidate all cached subrings.
+		r.shuffledSubringCache = make(map[subringCacheKey]*Ring)
+	}
 }
 
 // Get returns n (or more) instances which form the replicas for the given key.


### PR DESCRIPTION
**What this PR does**:
We just experienced a query failing with "empty ring" right after the querier has started. This is caused by the fact that the querier worker may connect to the query-frontend (or query-scheduler) and get a job before the ring client has initialised its state (which is when the `WatchKey()` callback is called for the first time).

In this PR I'm proposing to fix it introducing a `starting()` function to the `Ring` client service and read the initial read state while in the starting phase. Due to how dependencies are started and given the ring is a dependency of the querier, the ring is started before the querier worker service and this guarantees that, when the querier worker will be started, the ring has already initialised.

I've also made a change to fast fail the ring if an error occurs while fetching the initial ring state (ring key not existing is still OK). I think having a Cortex service fast failing if unable to talk to the ring backend should be fine (and probably a nice to have property), but if you foresee any potential issue I can change it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
