### PR TITLE
Add minimal support for missing routes in alertmanager distributor.

### DIFF
--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -509,6 +509,7 @@ func (c *Client) SendAlertToAlermanager(ctx context.Context, alert *model.Alert)
 	return nil
 }
 
+// CreateSilence creates a new silence and returns the unique identifier of the silence.
 func (c *Client) CreateSilence(ctx context.Context, silence types.Silence) (string, error) {
 	u := c.alertmanagerClient.URL("api/prom/api/v1/silences", nil)
 

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -509,15 +509,127 @@ func (c *Client) SendAlertToAlermanager(ctx context.Context, alert *model.Alert)
 	return nil
 }
 
-func (c *Client) CreateSilence(ctx context.Context, silence types.Silence) error {
+func (c *Client) CreateSilence(ctx context.Context, silence types.Silence) (string, error) {
 	u := c.alertmanagerClient.URL("api/prom/api/v1/silences", nil)
 
 	data, err := json.Marshal(silence)
 	if err != nil {
-		return fmt.Errorf("error marshaling the silence: %s", err)
+		return "", fmt.Errorf("error marshaling the silence: %s", err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("error creating request: %v", err)
+	}
+
+	resp, body, err := c.alertmanagerClient.Do(ctx, req)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("creating the silence failed with status %d and error %v", resp.StatusCode, string(body))
+	}
+
+	type response struct {
+		Status string `json:"status"`
+		Data   struct {
+			SilenceID string `json:"silenceID"`
+		} `json:"data"`
+	}
+
+	decoded := &response{}
+	if err := json.Unmarshal(body, decoded); err != nil {
+		return "", err
+	}
+
+	if decoded.Status != "success" {
+		return "", fmt.Errorf("unexpected response status '%s'", decoded.Status)
+	}
+
+	return decoded.Data.SilenceID, nil
+}
+
+func (c *Client) GetSilences(ctx context.Context) ([]types.Silence, error) {
+	u := c.alertmanagerClient.URL("api/prom/api/v1/silences", nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %v", err)
+	}
+
+	resp, body, err := c.alertmanagerClient.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("getting silences failed with status %d and error %v", resp.StatusCode, string(body))
+	}
+
+	type response struct {
+		Status string          `json:"status"`
+		Data   []types.Silence `json:"data"`
+	}
+
+	decoded := &response{}
+	if err := json.Unmarshal(body, decoded); err != nil {
+		return nil, err
+	}
+
+	if decoded.Status != "success" {
+		return nil, fmt.Errorf("unexpected response status '%s'", decoded.Status)
+	}
+
+	return decoded.Data, nil
+}
+
+func (c *Client) GetSilence(ctx context.Context, id string) (types.Silence, error) {
+	u := c.alertmanagerClient.URL(fmt.Sprintf("api/prom/api/v1/silence/%s", url.PathEscape(id)), nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return types.Silence{}, fmt.Errorf("error creating request: %v", err)
+	}
+
+	resp, body, err := c.alertmanagerClient.Do(ctx, req)
+	if err != nil {
+		return types.Silence{}, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return types.Silence{}, ErrNotFound
+	}
+
+	if resp.StatusCode/100 != 2 {
+		return types.Silence{}, fmt.Errorf("getting silence failed with status %d and error %v", resp.StatusCode, string(body))
+	}
+
+	type response struct {
+		Status string        `json:"status"`
+		Data   types.Silence `json:"data"`
+	}
+
+	decoded := &response{}
+	if err := json.Unmarshal(body, decoded); err != nil {
+		return types.Silence{}, err
+	}
+
+	if decoded.Status != "success" {
+		return types.Silence{}, fmt.Errorf("unexpected response status '%s'", decoded.Status)
+	}
+
+	return decoded.Data, nil
+}
+
+func (c *Client) DeleteSilence(ctx context.Context, id string) error {
+	u := c.alertmanagerClient.URL(fmt.Sprintf("api/prom/api/v1/silence/%s", url.PathEscape(id)), nil)
+
+	req, err := http.NewRequest(http.MethodDelete, u.String(), nil)
 	if err != nil {
 		return fmt.Errorf("error creating request: %v", err)
 	}
@@ -527,11 +639,53 @@ func (c *Client) CreateSilence(ctx context.Context, silence types.Silence) error
 		return err
 	}
 
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrNotFound
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("creating the silence failed with status %d and error %v", resp.StatusCode, string(body))
+		return fmt.Errorf("deleting silence failed with status %d and error %v", resp.StatusCode, string(body))
 	}
 
 	return nil
+}
+
+func (c *Client) GetReceivers(ctx context.Context) ([]string, error) {
+	u := c.alertmanagerClient.URL("api/prom/api/v1/receivers", nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %v", err)
+	}
+
+	resp, body, err := c.alertmanagerClient.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("getting receivers failed with status %d and error %v", resp.StatusCode, string(body))
+	}
+
+	type response struct {
+		Status string   `json:"status"`
+		Data   []string `json:"data"`
+	}
+
+	decoded := &response{}
+	if err := json.Unmarshal(body, decoded); err != nil {
+		return nil, err
+	}
+
+	if decoded.Status != "success" {
+		return nil, fmt.Errorf("unexpected response status '%s'", decoded.Status)
+	}
+
+	return decoded.Data, nil
 }
 
 func (c *Client) PostRequest(url string, body io.Reader) (*http.Response, error) {

--- a/pkg/alertmanager/distributor.go
+++ b/pkg/alertmanager/distributor.go
@@ -131,7 +131,6 @@ func (d *Distributor) DistributeRequest(w http.ResponseWriter, r *http.Request) 
 	}
 
 	http.Error(w, "route not supported by distributor", http.StatusNotFound)
-	return
 }
 
 func (d *Distributor) doWrite(userID string, w http.ResponseWriter, r *http.Request, logger log.Logger) {

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -1204,7 +1204,7 @@ func TestAlertmanager_StateReplicationWithSharding(t *testing.T) {
 			reqCtx := user.InjectOrgID(req.Context(), userID)
 			{
 				w := httptest.NewRecorder()
-				multitenantAM.ServeHTTP(w, req.WithContext(reqCtx))
+				multitenantAM.serveRequest(w, req.WithContext(reqCtx))
 
 				resp := w.Result()
 				body, _ := ioutil.ReadAll(resp.Body)
@@ -1360,7 +1360,7 @@ func TestAlertmanager_StateReplicationWithSharding_InitialSyncFromPeers(t *testi
 				reqCtx := user.InjectOrgID(req.Context(), userID)
 				{
 					w := httptest.NewRecorder()
-					i.ServeHTTP(w, req.WithContext(reqCtx))
+					i.serveRequest(w, req.WithContext(reqCtx))
 
 					resp := w.Result()
 					body, _ := ioutil.ReadAll(resp.Body)
@@ -1375,7 +1375,7 @@ func TestAlertmanager_StateReplicationWithSharding_InitialSyncFromPeers(t *testi
 				reqCtx := user.InjectOrgID(req.Context(), userID)
 				{
 					w := httptest.NewRecorder()
-					i.ServeHTTP(w, req.WithContext(reqCtx))
+					i.serveRequest(w, req.WithContext(reqCtx))
 
 					resp := w.Result()
 					body, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Add and test the following routes to the alertmanager distributor (in use only when sharding is enabled):
- `POST   /alertmanager/api/v1/silences`
- `GET    /alertmanager/api/v1/silences`
- `GET    /alertmanager/api/v1/silence/{id}`
- `DELETE /alertmanager/api/v1/silence/{id}`
- `GET    /alertmanager/api/v1/status`
- `POST   /alertmanager/api/v1/receivers`

All requests are simply forwarded to a single randomly chosen replica
of the shard which contains the user.

~~Note I've had to incorporate the fix from https://github.com/cortexproject/cortex/pull/4083 in this PR.~~ Rebased.

**Checklist**
- [X] Tests updated
- [X] ~~Documentation added~~
- [X] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~
