### PR TITLE
Update to latest github.com/weaveworks/common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [ENHANCEMENT] Alertmanager: validate configured `-alertmanager.web.external-url` and fail if ends with `/`. #4081
 * [ENHANCEMENT] Allow configuration of Cassandra's host selection policy. #4069
 * [ENHANCEMENT] Store-gateway: retry synching blocks if a per-tenant sync fails. #3975 #4088
+* [ENHANCEMENT] Add metric `cortex_tcp_connections` exposing the current number of accepted TCP connections. #4099
 * [BUGFIX] Ruler-API: fix bug where `/api/v1/rules/<namespace>/<group_name>` endpoint return `400` instead of `404`. #4013
 * [BUGFIX] Distributor: reverted changes done to rate limiting in #3825. #3948
 * [BUGFIX] Ingester: Fix race condition when opening and closing tsdb concurrently. #3959

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/thanos-io/thanos v0.13.1-0.20210401085038-d7dff0c84d17
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
-	github.com/weaveworks/common v0.0.0-20210112142934-23c8d7fa6120
+	github.com/weaveworks/common v0.0.0-20210419092856-009d1eebd624
 	go.etcd.io/bbolt v1.3.5
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200520232829-54ba9589114f
 	go.etcd.io/etcd/client/v3 v3.5.0-alpha.0.0.20210225194612-fa82d11a958a

--- a/go.sum
+++ b/go.sum
@@ -1168,8 +1168,9 @@ github.com/weaveworks/common v0.0.0-20200206153930-760e36ae819a/go.mod h1:6enWAq
 github.com/weaveworks/common v0.0.0-20200625145055-4b1847531bc9/go.mod h1:c98fKi5B9u8OsKGiWHLRKus6ToQ1Tubeow44ECO1uxY=
 github.com/weaveworks/common v0.0.0-20200914083218-61ffdd448099/go.mod h1:hz10LOsAdzC3K/iXaKoFxOKTDRgxJl+BTGX1GY+TzO4=
 github.com/weaveworks/common v0.0.0-20201119133501-0619918236ec/go.mod h1:ykzWac1LtVfOxdCK+jD754at1Ws9dKCwFeUzkFBffPs=
-github.com/weaveworks/common v0.0.0-20210112142934-23c8d7fa6120 h1:zQtcwREXYNvW116ipgc0bRDg1avD2b6QP0RGPLlPWkc=
 github.com/weaveworks/common v0.0.0-20210112142934-23c8d7fa6120/go.mod h1:ykzWac1LtVfOxdCK+jD754at1Ws9dKCwFeUzkFBffPs=
+github.com/weaveworks/common v0.0.0-20210419092856-009d1eebd624 h1:rbPhNKTbWNWchMqGWKKVYUocxiAk1ii5b8D/C49v/Lg=
+github.com/weaveworks/common v0.0.0-20210419092856-009d1eebd624/go.mod h1:ykzWac1LtVfOxdCK+jD754at1Ws9dKCwFeUzkFBffPs=
 github.com/weaveworks/promrus v1.2.0 h1:jOLf6pe6/vss4qGHjXmGz4oDJQA+AOCqEL3FvvZGz7M=
 github.com/weaveworks/promrus v1.2.0/go.mod h1:SaE82+OJ91yqjrE1rsvBWVzNZKcHYFtMUyS1+Ogs/KA=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=

--- a/vendor/github.com/weaveworks/common/middleware/counting_listener.go
+++ b/vendor/github.com/weaveworks/common/middleware/counting_listener.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"net"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// CountingListener returns a Listener that increments a Prometheus gauge when
+// a connection is accepted, and decrements the gauge when the connection is closed.
+func CountingListener(l net.Listener, g prometheus.Gauge) net.Listener {
+	return &countingListener{Listener: l, gauge: g}
+}
+
+type countingListener struct {
+	net.Listener
+	gauge prometheus.Gauge
+}
+
+func (c *countingListener) Accept() (net.Conn, error) {
+	conn, err := c.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	c.gauge.Inc()
+	return &countingListenerConn{Conn: conn, gauge: c.gauge}, nil
+}
+
+type countingListenerConn struct {
+	net.Conn
+	gauge prometheus.Gauge
+	once  sync.Once
+}
+
+func (l *countingListenerConn) Close() error {
+	err := l.Conn.Close()
+
+	// Only ever decrement the gauge once in case of badly behaving callers.
+	l.once.Do(func() { l.gauge.Dec() })
+
+	return err
+}

--- a/vendor/github.com/weaveworks/common/middleware/instrument.go
+++ b/vendor/github.com/weaveworks/common/middleware/instrument.go
@@ -104,13 +104,25 @@ func (i Instrument) getRouteName(r *http.Request) string {
 
 func getRouteName(routeMatcher RouteMatcher, r *http.Request) string {
 	var routeMatch mux.RouteMatch
-	if routeMatcher != nil && routeMatcher.Match(r, &routeMatch) {
-		if name := routeMatch.Route.GetName(); name != "" {
-			return name
-		}
-		if tmpl, err := routeMatch.Route.GetPathTemplate(); err == nil {
-			return MakeLabelValue(tmpl)
-		}
+	if routeMatcher == nil || !routeMatcher.Match(r, &routeMatch) {
+		return ""
+	}
+
+	if routeMatch.MatchErr == mux.ErrNotFound {
+		return "notfound"
+	}
+
+	if routeMatch.Route == nil {
+		return ""
+	}
+
+	if name := routeMatch.Route.GetName(); name != "" {
+		return name
+	}
+
+	tmpl, err := routeMatch.Route.GetPathTemplate()
+	if err == nil {
+		return MakeLabelValue(tmpl)
 	}
 
 	return ""

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -622,7 +622,7 @@ github.com/uber/jaeger-client-go/utils
 # github.com/uber/jaeger-lib v2.4.0+incompatible
 github.com/uber/jaeger-lib/metrics
 github.com/uber/jaeger-lib/metrics/prometheus
-# github.com/weaveworks/common v0.0.0-20210112142934-23c8d7fa6120
+# github.com/weaveworks/common v0.0.0-20210419092856-009d1eebd624
 ## explicit
 github.com/weaveworks/common/aws
 github.com/weaveworks/common/errors


### PR DESCRIPTION
**What this PR does**:
Update to latest github.com/weaveworks/common in order to inherit `tcp_connections` metric.

**Checklist**
- [X] ~~Tests updated~~
- [X] ~~Documentation added~~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
