### PR TITLE
Remove config options deprecated in Cortex 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   * `-alertmanager.cluster.advertise-address` instead of `-cluster.advertise-address`
   * `-alertmanager.cluster.peers` instead of `-cluster.peer`
   * `-alertmanager.cluster.peer-timeout` instead of `-cluster.peer-timeout`
+* [CHANGE] Blocks storage: removed the config option `-blocks-storage.bucket-store.index-cache.postings-compression-enabled`, which was deprecated in Cortex 1.6. Postings compression is always enabled. #4101
+* [CHANGE] Querier: removed the config option `-store.max-look-back-period`, which was deprecated in Cortex 1.6 and was used only by the chunks storage. You should use `-querier.max-query-lookback` instead. #4101
+* [CHANGE] Query Frontend: removed the config option `-querier.compress-http-responses`, which was deprecated in Cortex 1.6. You should use`-api.response-compression-enabled` instead. #4101
 * [FEATURE] Memberlist: add TLS configuration options for the memberlist transport layer used by the gossip KV store. #4046
   * New flags added for memberlist communication:
     * `-memberlist.tls-enabled`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 * [CHANGE] Blocks storage: removed the config option `-blocks-storage.bucket-store.index-cache.postings-compression-enabled`, which was deprecated in Cortex 1.6. Postings compression is always enabled. #4101
 * [CHANGE] Querier: removed the config option `-store.max-look-back-period`, which was deprecated in Cortex 1.6 and was used only by the chunks storage. You should use `-querier.max-query-lookback` instead. #4101
 * [CHANGE] Query Frontend: removed the config option `-querier.compress-http-responses`, which was deprecated in Cortex 1.6. You should use`-api.response-compression-enabled` instead. #4101
+* [FEATURE] The following features have been marked as stable: #4101
+  - Shuffle-sharding
+  - Querier support for querying chunks and blocks store at the same time
+  - Tracking of active series and exporting them as metrics (`-ingester.active-series-metrics-enabled` and related flags)
+  - Blocks storage: lazy mmap of block indexes in the store-gateway (`-blocks-storage.bucket-store.index-header-lazy-loading-enabled`)
+  - Ingester: close idle TSDB and remove them from local disk (`-blocks-storage.tsdb.close-idle-tsdb-timeout`)
 * [FEATURE] Memberlist: add TLS configuration options for the memberlist transport layer used by the gossip KV store. #4046
   * New flags added for memberlist communication:
     * `-memberlist.tls-enabled`

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -517,11 +517,6 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.max-item-size
         [max_item_size: <int> | default = 1048576]
 
-      # Deprecated: compress postings before storing them to postings cache.
-      # This option is unused and postings compression is always enabled.
-      # CLI flag: -blocks-storage.bucket-store.index-cache.postings-compression-enabled
-      [postings_compression_enabled: <boolean> | default = false]
-
     chunks_cache:
       # Backend for chunks cache, if not empty. Supported values: memcached.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.backend

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -563,11 +563,6 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.max-item-size
         [max_item_size: <int> | default = 1048576]
 
-      # Deprecated: compress postings before storing them to postings cache.
-      # This option is unused and postings compression is always enabled.
-      # CLI flag: -blocks-storage.bucket-store.index-cache.postings-compression-enabled
-      [postings_compression_enabled: <boolean> | default = false]
-
     chunks_cache:
       # Backend for chunks cache, if not empty. Supported values: memcached.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.backend

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1058,11 +1058,6 @@ grpc_client_config:
 # CLI flag: -frontend.instance-interface-names
 [instance_interface_names: <list of string> | default = [eth0 en0]]
 
-# This flag is about to be deprecated. Please use
-# -api.response-compression-enabled instead.
-# CLI flag: -querier.compress-http-responses
-[compress_responses: <boolean> | default = false]
-
 # URL of downstream Prometheus.
 # CLI flag: -frontend.downstream-url
 [downstream_url: <string> | default = ""]
@@ -3436,11 +3431,6 @@ write_dedupe_cache_config:
 # Cache index entries older than this period. 0 to disable.
 # CLI flag: -store.cache-lookups-older-than
 [cache_lookups_older_than: <duration> | default = 0s]
-
-# Deprecated: use -querier.max-query-lookback instead. Limit how long back data
-# can be queried. This setting applies to chunks storage only.
-# CLI flag: -store.max-look-back-period
-[max_look_back_period: <duration> | default = 0s]
 ```
 
 ### `ingester_client_config`
@@ -4652,11 +4642,6 @@ bucket_store:
       # stored. If set to 0, no maximum size is enforced.
       # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.max-item-size
       [max_item_size: <int> | default = 1048576]
-
-    # Deprecated: compress postings before storing them to postings cache. This
-    # option is unused and postings compression is always enabled.
-    # CLI flag: -blocks-storage.bucket-store.index-cache.postings-compression-enabled
-    [postings_compression_enabled: <boolean> | default = false]
 
   chunks_cache:
     # Backend for chunks cache, if not empty. Supported values: memcached.

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -40,16 +40,12 @@ Currently experimental features are:
 - S3 Server Side Encryption (SSE) using KMS (including per-tenant KMS config overrides).
 - Azure blob storage.
 - Zone awareness based replication.
-- Shuffle sharding (both read and write path).
 - Ruler API (to PUT rules).
 - Alertmanager API
 - Memcached client DNS-based service discovery.
 - Delete series APIs.
 - In-memory (FIFO) and Redis cache.
 - gRPC Store.
-- Querier support for querying chunks and blocks store at the same time.
-- Tracking of active series and exporting them as metrics (`-ingester.active-series-metrics-enabled` and related flags)
-- Shuffle-sharding of queriers in the query-frontend (i.e. use of `-frontend.max-queriers-per-tenant` flag with non-zero value).
 - TLS configuration in gRPC and HTTP clients.
 - TLS configuration in Etcd client.
 - Blocksconvert tools
@@ -57,10 +53,8 @@ Currently experimental features are:
 - Metric relabeling in the distributor.
 - Scalable query-frontend (when using query-scheduler)
 - Querying store for series, labels APIs (`-querier.query-store-for-labels-enabled`)
-- Blocks storage: lazy mmap of block indexes in the store-gateway (`-blocks-storage.bucket-store.index-header-lazy-loading-enabled`)
 - Ingester: do not unregister from ring on shutdown (`-ingester.unregister-on-shutdown=false`)
 - Distributor: do not extend writes on unhealthy ingesters (`-distributor.extend-writes=false`)
-- Ingester: close idle TSDB and remove them from local disk (`-blocks-storage.tsdb.close-idle-tsdb-timeout`)
 - Tenant Deletion in Purger, for blocks storage.
 - Query-frontend: query stats tracking (`-frontend.query-stats-enabled`)
 - Blocks storage bucket index
@@ -72,5 +66,5 @@ Currently experimental features are:
 - HA Tracker: cleanup of old replicas from KV Store.
 - Flags for configuring whether blocks-ingester streams samples or chunks are temporary, and will be removed when feature is tested:
   - `-ingester.stream-chunks-when-using-blocks` CLI flag
-  - `ingester_stream_chunks_when_using_blocks` (boolean) field in runtime config file
+  - `-ingester_stream_chunks_when_using_blocks` (boolean) field in runtime config file
 - Instance limits in ingester and distributor

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -103,7 +103,7 @@ func (cfg *S3Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "", "AWS Secret Access Key")
 	f.BoolVar(&cfg.Insecure, prefix+"s3.insecure", false, "Disable https on s3 connection.")
 
-	// TODO Remove in Cortex 1.9.0
+	// TODO Remove in Cortex 1.10.0
 	f.BoolVar(&cfg.SSEEncryption, prefix+"s3.sse-encryption", false, "Enable AWS Server Side Encryption [Deprecated: Use .sse instead. if s3.sse-encryption is enabled, it assumes .sse.type SSE-S3]")
 
 	cfg.SSEConfig.RegisterFlagsWithPrefix(prefix+"s3.sse.", f)

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/NYTimes/gziphandler"
 	"github.com/go-kit/kit/log/level"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
@@ -563,10 +562,6 @@ func (t *Cortex) initQueryFrontend() (serv services.Service, err error) {
 	roundTripper = t.QueryFrontendTripperware(roundTripper)
 
 	handler := transport.NewHandler(t.Cfg.Frontend.Handler, roundTripper, util_log.Logger, prometheus.DefaultRegisterer)
-	if t.Cfg.Frontend.CompressResponses {
-		handler = gziphandler.GzipHandler(handler)
-	}
-
 	t.API.RegisterQueryFrontendHandler(handler)
 
 	if frontendV1 != nil {

--- a/pkg/frontend/config.go
+++ b/pkg/frontend/config.go
@@ -20,10 +20,6 @@ type CombinedFrontendConfig struct {
 	FrontendV1 v1.Config               `yaml:",inline"`
 	FrontendV2 v2.Config               `yaml:",inline"`
 
-	// Deprecated. Replaced with pkg/api/Config.ResponseCompression field.
-	// TODO: To be removed in Cortex 1.8.
-	CompressResponses bool `yaml:"compress_responses"`
-
 	DownstreamURL string `yaml:"downstream_url"`
 }
 
@@ -31,8 +27,6 @@ func (cfg *CombinedFrontendConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.Handler.RegisterFlags(f)
 	cfg.FrontendV1.RegisterFlags(f)
 	cfg.FrontendV2.RegisterFlags(f)
-
-	f.BoolVar(&cfg.CompressResponses, "querier.compress-http-responses", false, "This flag is about to be deprecated. Please use -api.response-compression-enabled instead.")
 
 	f.StringVar(&cfg.DownstreamURL, "frontend.downstream-url", "", "URL of downstream Prometheus.")
 }

--- a/pkg/storage/tsdb/index_cache.go
+++ b/pkg/storage/tsdb/index_cache.go
@@ -37,10 +37,9 @@ var (
 )
 
 type IndexCacheConfig struct {
-	Backend             string                   `yaml:"backend"`
-	InMemory            InMemoryIndexCacheConfig `yaml:"inmemory"`
-	Memcached           MemcachedClientConfig    `yaml:"memcached"`
-	PostingsCompression bool                     `yaml:"postings_compression_enabled"`
+	Backend   string                   `yaml:"backend"`
+	InMemory  InMemoryIndexCacheConfig `yaml:"inmemory"`
+	Memcached MemcachedClientConfig    `yaml:"memcached"`
 }
 
 func (cfg *IndexCacheConfig) RegisterFlags(f *flag.FlagSet) {
@@ -49,7 +48,6 @@ func (cfg *IndexCacheConfig) RegisterFlags(f *flag.FlagSet) {
 
 func (cfg *IndexCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.StringVar(&cfg.Backend, prefix+"backend", IndexCacheBackendDefault, fmt.Sprintf("The index cache backend type. Supported values: %s.", strings.Join(supportedIndexCacheBackends, ", ")))
-	f.BoolVar(&cfg.PostingsCompression, prefix+"postings-compression-enabled", false, "Deprecated: compress postings before storing them to postings cache. This option is unused and postings compression is always enabled.") // TODO remove in v1.8.0.
 
 	cfg.InMemory.RegisterFlagsWithPrefix(f, prefix+"inmemory.")
 	cfg.Memcached.RegisterFlagsWithPrefix(f, prefix+"memcached.")


### PR DESCRIPTION
**What this PR does**:
We're about to cut Cortex 1.9.0, so it's time to remove config options which were deprecated in Cortex 1.6. I've also took the opportunity to mark some features we're using in prod since a long time (and that we don't expect their config to change) as stable.

I've spoken to Josh and he mentioned Alertmanager and Ruler API may still be subject to change so I haven't marked them as stable even if we're running them in prod since months.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
