### PR TITLE
Fix docker port parsing in integration tests

### DIFF
--- a/integration/e2e/service_test.go
+++ b/integration/e2e/service_test.go
@@ -173,10 +173,10 @@ metric_b 1000
 }
 
 func TestParseDockerPort(t *testing.T) {
-	actual, err := parseDockerIPv4Port("")
+	_, err := parseDockerIPv4Port("")
 	assert.Error(t, err)
 
-	actual, err = parseDockerIPv4Port("0.0.0.0:36999")
+	actual, err := parseDockerIPv4Port("0.0.0.0:36999")
 	assert.NoError(t, err)
 	assert.Equal(t, 36999, actual)
 

--- a/integration/e2e/service_test.go
+++ b/integration/e2e/service_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/util"
@@ -169,4 +170,21 @@ metric_b 1000
 		MaxRetries: 50,
 	})
 	require.NoError(t, s.WaitSumMetrics(Equals(math.NaN()), "metric_a"))
+}
+
+func TestParseDockerPort(t *testing.T) {
+	actual, err := parseDockerIPv4Port("")
+	assert.Error(t, err)
+
+	actual, err = parseDockerIPv4Port("0.0.0.0:36999")
+	assert.NoError(t, err)
+	assert.Equal(t, 36999, actual)
+
+	actual, err = parseDockerIPv4Port("0.0.0.0:49155\n:::49156")
+	assert.NoError(t, err)
+	assert.Equal(t, 49155, actual)
+
+	actual, err = parseDockerIPv4Port(":::49156\n0.0.0.0:49155")
+	assert.NoError(t, err)
+	assert.Equal(t, 49155, actual)
 }


### PR DESCRIPTION
**What this PR does**:
Integration tests are failing with the error:
```
        	Error:      	Received unexpected error:
        	            	unable to get mapping for port 9000 (output: 0.0.0.0:49159
        	            	:::49160); service: minio-9000
```

Looking at the output, I believe GitHub actions enabled IPv6 on the runners and so we're both getting IPv4 and IPv6 port mapping, which is breaking the parsing.

If my hypothesis is correct, this PR should fix it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
