### PR TITLE
Optimize index queries and caching

### DIFF
--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -738,10 +738,10 @@ func (v9Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName string
 	valueHash := sha256bytes(labelValue)
 	return []IndexQuery{
 		{
-			TableName:       bucket.tableName,
-			HashValue:       fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
-			RangeValueStart: rangeValuePrefix(valueHash),
-			ValueEqual:      []byte(labelValue),
+			TableName:        bucket.tableName,
+			HashValue:        fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
+			RangeValuePrefix: rangeValuePrefix(valueHash),
+			ValueEqual:       []byte(labelValue),
 		},
 	}, nil
 }
@@ -848,10 +848,10 @@ func (s v10Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName str
 	result := make([]IndexQuery, 0, s.rowShards)
 	for i := uint32(0); i < s.rowShards; i++ {
 		result = append(result, IndexQuery{
-			TableName:       bucket.tableName,
-			HashValue:       fmt.Sprintf("%02d:%s:%s:%s", i, bucket.hashKey, metricName, labelName),
-			RangeValueStart: rangeValuePrefix(valueHash),
-			ValueEqual:      []byte(labelValue),
+			TableName:        bucket.tableName,
+			HashValue:        fmt.Sprintf("%02d:%s:%s:%s", i, bucket.hashKey, metricName, labelName),
+			RangeValuePrefix: rangeValuePrefix(valueHash),
+			ValueEqual:       []byte(labelValue),
 		})
 	}
 	return result, nil

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -90,6 +90,8 @@ type IndexQuery struct {
 	// - If RangeValuePrefix is not nil, must read all keys with that prefix.
 	// - If RangeValueStart is not nil, must read all keys from there onwards.
 	// - If neither is set, must read all keys for that row.
+	// RangeValueStart should only be used for querying Chunk IDs.
+	// If this is going to change then please take care of func isChunksQuery in pkg/chunk/storage/caching_index_client.go which relies on it.
 	RangeValuePrefix []byte
 	RangeValueStart  []byte
 

--- a/pkg/chunk/storage/bytes.go
+++ b/pkg/chunk/storage/bytes.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bytes"
+	"unsafe"
 )
 
 // Bytes exists to stop proto copying the byte array
@@ -36,4 +37,8 @@ func (bs *Bytes) Equal(other Bytes) bool {
 // Compare Bytes to other
 func (bs *Bytes) Compare(other Bytes) int {
 	return bytes.Compare(*bs, other)
+}
+
+func yoloString(buf []byte) string {
+	return *((*string)(unsafe.Pointer(&buf)))
 }

--- a/pkg/chunk/storage/caching_index_client_test.go
+++ b/pkg/chunk/storage/caching_index_client_test.go
@@ -204,61 +204,148 @@ func TestCachingStorageClientEmptyResponse(t *testing.T) {
 	assert.EqualValues(t, 1, store.queries)
 }
 
-func TestCachingStorageClientCollision(t *testing.T) {
-	// These two queries should result in one query to the cache & index, but
-	// two results, as we cache entire rows.
-	store := &mockStore{
-		results: ReadBatch{
-			Entries: []Entry{
-				{
-					Column: []byte("bar"),
-					Value:  []byte("bar"),
-				},
-				{
-					Column: []byte("baz"),
-					Value:  []byte("baz"),
-				},
+func TestCachingStorageClientStoreQueries(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		queries              []chunk.IndexQuery
+		expectedStoreQueries int
+	}{
+		{
+			name: "TableName-HashValue queries",
+			queries: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo"},
+				{TableName: "table", HashValue: "bar"},
 			},
+			expectedStoreQueries: 2,
 		},
+		{
+			name: "TableName-HashValue-RangeValuePrefix queries",
+			queries: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("baz")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("taz")},
+			},
+			expectedStoreQueries: 3,
+		},
+		{
+			name: "TableName-HashValue-RangeValuePrefix-ValueEqual queries",
+			queries: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar"), ValueEqual: []byte("one")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("baz"), ValueEqual: []byte("two")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("taz"), ValueEqual: []byte("three")},
+			},
+			expectedStoreQueries: 3,
+		},
+		{
+			name: "TableName-HashValue-RangeValueStart queries",
+			queries: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo", RangeValueStart: []byte("bar")},
+				{TableName: "table", HashValue: "foo", RangeValueStart: []byte("baz")},
+			},
+			expectedStoreQueries: 1,
+		},
+		{
+			name: "Duplicate queries",
+			queries: []chunk.IndexQuery{
+				{TableName: "table", HashValue: "foo"},
+				{TableName: "table", HashValue: "foo"},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar"), ValueEqual: []byte("one")},
+				{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar"), ValueEqual: []byte("one")},
+			},
+			expectedStoreQueries: 3,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &mockStore{
+				results: ReadBatch{
+					Entries: []Entry{
+						{
+							Column: []byte("bar"),
+							Value:  []byte("bar"),
+						},
+						{
+							Column: []byte("baz"),
+							Value:  []byte("baz"),
+						},
+					},
+				},
+			}
+			limits, err := defaultLimits()
+			require.NoError(t, err)
+			logger := log.NewNopLogger()
+			cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
+			client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger)
+
+			err = client.QueryPages(ctx, tc.queries, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
+				return true
+			})
+			require.NoError(t, err)
+			assert.EqualValues(t, tc.expectedStoreQueries, store.queries)
+
+			// If we do the query to the cache again, the underlying store shouldn't see it.
+			err = client.QueryPages(ctx, tc.queries, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
+				return true
+			})
+			require.NoError(t, err)
+			assert.EqualValues(t, tc.expectedStoreQueries, store.queries)
+		})
 	}
-	limits, err := defaultLimits()
-	require.NoError(t, err)
-	logger := log.NewNopLogger()
-	cache := cache.NewFifoCache("test", cache.FifoCacheConfig{MaxSizeItems: 10, Validity: 10 * time.Second}, nil, logger)
-	client := newCachingIndexClient(store, cache, 1*time.Second, limits, logger)
-	queries := []chunk.IndexQuery{
-		{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("bar")},
-		{TableName: "table", HashValue: "foo", RangeValuePrefix: []byte("baz")},
+}
+
+func TestQueryKey(t *testing.T) {
+	testTableName := "test"
+	testHashValue := "hash"
+	testRangeValuePrefix := []byte("prefix")
+	testRangeValueStart := []byte("start")
+	testValueEqual := []byte("equal")
+
+	for _, tc := range []struct {
+		name     string
+		query    chunk.IndexQuery
+		expected string
+	}{
+		{
+			name: "TableName-HashValue query",
+			query: chunk.IndexQuery{
+				TableName: testTableName,
+				HashValue: testHashValue,
+			},
+			expected: testTableName + sep + testHashValue,
+		},
+		{
+			name: "TableName-HashValue-RangeValuePrefix query",
+			query: chunk.IndexQuery{
+				TableName:        testTableName,
+				HashValue:        testHashValue,
+				RangeValuePrefix: testRangeValuePrefix,
+			},
+			expected: testTableName + sep + testHashValue + sep + yoloString(testRangeValuePrefix),
+		},
+		{
+			name: "TableName-HashValue-RangeValuePrefix-ValueEqual query",
+			query: chunk.IndexQuery{
+				TableName:        testTableName,
+				HashValue:        testHashValue,
+				RangeValuePrefix: testRangeValuePrefix,
+				ValueEqual:       testValueEqual,
+			},
+			expected: testTableName + sep + testHashValue + sep + yoloString(testRangeValuePrefix) + sep + yoloString(testValueEqual),
+		},
+		{
+			name: "TableName-HashValue-RangeValueStart query",
+			query: chunk.IndexQuery{
+				TableName:       testTableName,
+				HashValue:       testHashValue,
+				RangeValueStart: testRangeValueStart,
+			},
+			expected: testTableName + sep + testHashValue,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, queryKey(tc.query))
+		})
 	}
 
-	var results ReadBatch
-	err = client.QueryPages(ctx, queries, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
-		iter := batch.Iterator()
-		for iter.Next() {
-			results.Entries = append(results.Entries, Entry{
-				Column: iter.RangeValue(),
-				Value:  iter.Value(),
-			})
-		}
-		return true
-	})
-	require.NoError(t, err)
-	assert.EqualValues(t, 1, store.queries)
-	assert.EqualValues(t, store.results, results)
-
-	// If we do the query to the cache again, the underlying store shouldn't see it.
-	results = ReadBatch{}
-	err = client.QueryPages(ctx, queries, func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
-		iter := batch.Iterator()
-		for iter.Next() {
-			results.Entries = append(results.Entries, Entry{
-				Column: iter.RangeValue(),
-				Value:  iter.Value(),
-			})
-		}
-		return true
-	})
-	require.NoError(t, err)
-	assert.EqualValues(t, 1, store.queries)
-	assert.EqualValues(t, store.results, results)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
We drop some query parameters from the queries to cache all possible rows matching the HashKey, which includes just the metric name + label name for labels index entries and the metric name + series ids for chunk ids. This PR aims at the labels index query part.

In simple terms, when a query comes in for label `{foo="bar"}`, the caching index client will fetch and store all the index entries for label `foo` irrespective of the expected value from the query. While this helps with other queries looking for other label values for `foo', it is still a lot of waste of resources if the label name is present in thousands of series, and users would not search for all of them.

I have changed the code to not drop the search parameters for labels queries and keep the behaviour the as-is for the chunks queries since the chunk boundaries can vary significantly. I have also changed the `GetReadMetricLabelValueQueries` function used for building the labels queries to use `RangeValuePrefix` instead of `RangeValueStart` since the required entries would have a specific prefix which allows us to limit the search space.

I have tested this change with Loki in one of the large clusters, and it has reduced the CPU and memory usage for queriers and the amount of index cache required with similar or better query performance.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
