### PR TITLE
Fix for alertmanagers not configuring users before becoming ACTIVE.

### DIFF
--- a/pkg/alertmanager/alertmanager_ring.go
+++ b/pkg/alertmanager/alertmanager_ring.go
@@ -32,6 +32,12 @@ var RingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, func(s ring.InstanceS
 	return s != ring.ACTIVE
 })
 
+// UserOwnedRingOp is the operation used for checking if a user is owned by an alertmanager.
+var UserOwnedRingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE, ring.JOINING}, func(s ring.InstanceState) bool {
+	// A user is owned by an alertmanager in both ACTIVE and JOINING states.
+	return (s != ring.ACTIVE && s != ring.JOINING)
+})
+
 // RingConfig masks the ring lifecycler config which contains
 // many options not really required by the alertmanager ring. This config
 // is used to strip down the config to the minimum, and avoid confusion

--- a/pkg/alertmanager/alertmanager_ring.go
+++ b/pkg/alertmanager/alertmanager_ring.go
@@ -32,10 +32,9 @@ var RingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, func(s ring.InstanceS
 	return s != ring.ACTIVE
 })
 
-// UserOwnedRingOp is the operation used for checking if a user is owned by an alertmanager.
-var UserOwnedRingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE, ring.JOINING}, func(s ring.InstanceState) bool {
-	// A user is owned by an alertmanager in both ACTIVE and JOINING states.
-	return (s != ring.ACTIVE && s != ring.JOINING)
+// SyncRingOp is the operation used for checking if a user is owned by an alertmanager.
+var SyncRingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE, ring.JOINING}, func(s ring.InstanceState) bool {
+	return s != ring.ACTIVE
 })
 
 // RingConfig masks the ring lifecycler config which contains

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -710,7 +710,7 @@ func (am *MultitenantAlertmanager) isUserOwned(userID string) bool {
 		return true
 	}
 
-	alertmanagers, err := am.ring.Get(shardByUser(userID), RingOp, nil, nil, nil)
+	alertmanagers, err := am.ring.Get(shardByUser(userID), UserOwnedRingOp, nil, nil, nil)
 	if err != nil {
 		am.ringCheckErrors.Inc()
 		level.Error(am.logger).Log("msg", "failed to load alertmanager configuration", "user", userID, "err", err)

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -710,7 +710,7 @@ func (am *MultitenantAlertmanager) isUserOwned(userID string) bool {
 		return true
 	}
 
-	alertmanagers, err := am.ring.Get(shardByUser(userID), UserOwnedRingOp, nil, nil, nil)
+	alertmanagers, err := am.ring.Get(shardByUser(userID), SyncRingOp, nil, nil, nil)
 	if err != nil {
 		am.ringCheckErrors.Inc()
 		level.Error(am.logger).Log("msg", "failed to load alertmanager configuration", "user", userID, "err", err)


### PR DESCRIPTION
**What this PR does**:

(Only applies to sharding operation)

Currently when the alertmanager joins the sharding ring, it tries to
load user configurations, and checks the ring to see what users it
should be servicing. Once finished, the alertmanager changes it's state
to ACTIVE.

However, when performing this initial sync of user configurations, the
alertmanager is in the JOINING state, but checking if a user is owned
requires an instance to be in the ACTIVE state. Therefore, the initial
sync will _never_ configure any users, but the instance will be
considered ACTIVE.

This change fixes the initial sync by considering a user to be owned by
the instance if it is in either the ACTIVE or JOINING state.

Note this fix should address the sporadic integration test failures:
The distributor forwards requests to an instance which it believes is
configured, but the request then fails, because it is not ready yet.

**Checklist**
- [X] ~~Tests updated~~
- [X] ~~Documentation added~~
- [X] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~
