### PR TITLE
stop the index search early based on query params

### DIFF
--- a/pkg/chunk/local/boltdb_index_client.go
+++ b/pkg/chunk/local/boltdb_index_client.go
@@ -264,16 +264,15 @@ func (b *BoltIndexClient) QueryWithCursor(_ context.Context, c *bbolt.Cursor, qu
 	var batch boltReadBatch
 
 	for k, v := c.Seek(start); k != nil; k, v = c.Next() {
-		if len(query.ValueEqual) > 0 && !bytes.Equal(v, query.ValueEqual) {
-			continue
+		if !bytes.HasPrefix(k, rowPrefix) {
+			break
 		}
 
 		if len(query.RangeValuePrefix) > 0 && !bytes.HasPrefix(k, start) {
 			break
 		}
-
-		if !bytes.HasPrefix(k, rowPrefix) {
-			break
+		if len(query.ValueEqual) > 0 && !bytes.Equal(v, query.ValueEqual) {
+			continue
 		}
 
 		// make a copy since k, v are only valid for the life of the transaction.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Based on the prefix built from query params we can break the loop early in boltdb index client.

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
