### PR TITLE
doc: Fix formatting of environment variable list

### DIFF
--- a/docs/contributing/how-integration-tests-work.md
+++ b/docs/contributing/how-integration-tests-work.md
@@ -35,9 +35,9 @@ go test -v -tags=requires_docker ./integration -run "^TestChunksStorageAllIndexB
   Docker image used to run Cortex in integration tests (defaults to `quay.io/cortexproject/cortex:latest`)
 - **`CORTEX_CHECKOUT_DIR`**<br />
   The absolute path of the Cortex repository local checkout (defaults to `$GOPATH/src/github.com/cortexproject/cortex`)
--- **`E2E_TEMP_DIR`**<br />
+- **`E2E_TEMP_DIR`**<br />
   The absolute path to a directory where the integration test will create an additional temporary directory to store files generated during the test.
--- **`E2E_NETWORK_NAME`**<br />
+- **`E2E_NETWORK_NAME`**<br />
   Name of the docker network to create and use for integration tests. If no variable is set, defaults to `e2e-cortex-test`.
 
 ### The `requires_docker` tag


### PR DESCRIPTION
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Fixes two typos in the [How integration tests work](https://cortexmetrics.io/docs/contributing/how-integration-tests-work/) documentation that was preventing the environment variable list being rendered correctly.