### PR TITLE
Make mergeQueryable more generically usable

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -233,7 +233,11 @@ func (t *Cortex) initQueryable() (serv services.Service, err error) {
 // Enable merge querier if multi tenant query federation is enabled
 func (t *Cortex) initTenantFederation() (serv services.Service, err error) {
 	if t.Cfg.TenantFederation.Enabled {
-		t.QuerierQueryable = querier.NewSampleAndChunkQueryable(tenantfederation.NewQueryable(t.QuerierQueryable))
+		// Make sure the mergeQuerier is only used for request with more than a
+		// single tenant. This allows for a less impactful enabling of tenant
+		// federation.
+		byPassForSingleQuerier := true
+		t.QuerierQueryable = querier.NewSampleAndChunkQueryable(tenantfederation.NewQueryable(t.QuerierQueryable, byPassForSingleQuerier))
 	}
 	return nil, nil
 }

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -18,88 +18,128 @@ import (
 )
 
 const (
-	defaultTenantLabel         = "__tenant_id__"
-	retainExistingPrefix       = "original_"
-	originalDefaultTenantLabel = retainExistingPrefix + defaultTenantLabel
-	maxConcurrency             = 16
+	defaultTenantLabel   = "__tenant_id__"
+	retainExistingPrefix = "original_"
+	maxConcurrency       = 16
 )
 
 // NewQueryable returns a queryable that iterates through all the tenant IDs
 // that are part of the request and aggregates the results from each tenant's
 // Querier by sending of subsequent requests.
-// The result contains a label tenantLabelName to identify the tenant ID that
+// The result contains a label "__tenant_id__" to identify the tenant ID that
 // it originally resulted from.
-// If the label tenantLabelName is already existing, its value is overwritten
+// If the label "__tenant_id__" is already existing, its value is overwritten
 // by the tenant ID and the previous value is exposed through a new label
-// prefixed with "original_". This behaviour is not implemented recursively
+// prefixed with "original_". This behaviour is not implemented recursively.
 func NewQueryable(upstream storage.Queryable) storage.Queryable {
+	return NewMergeQueryable(defaultTenantLabel, tenantQuerierCallback(upstream))
+}
+
+func tenantQuerierCallback(queryable storage.Queryable) MergeQuerierCallback {
+	return func(ctx context.Context, mint int64, maxt int64) ([]string, []storage.Querier, bool, error) {
+		tenantIDs, err := tenant.TenantIDs(ctx)
+		if err != nil {
+			return nil, nil, false, err
+		}
+
+		var queriers = make([]storage.Querier, len(tenantIDs))
+		for pos, tenantID := range tenantIDs {
+			q, err := queryable.Querier(
+				user.InjectOrgID(ctx, tenantID),
+				mint,
+				maxt,
+			)
+			if err != nil {
+				return nil, nil, false, err
+			}
+			queriers[pos] = q
+		}
+
+		// ensure to byPass a single querier and avoid adding a tenant label to
+		// ensure backward compatabiltiy when enabling multi-tenant query
+		// federation.
+		byPassWithSingleQuerier := true
+
+		return tenantIDs, queriers, byPassWithSingleQuerier, nil
+	}
+}
+
+// MergeQuerierCallback returns the underlying queriers and their IDs relevant
+// for the query.
+// If the callback returns exactly a single querier,
+// byPassWithSingleQuerierUsing determines if it should still be using the
+// mergeQuerier (and adding a `idLabelName` label) or if just the underlying
+// querier should be returned.
+type MergeQuerierCallback func(ctx context.Context, mint int64, maxt int64) (ids []string, queriers []storage.Querier, byPassWithSingleQuerier bool, err error)
+
+// NewMergeQueryable returns a queryable that merges results from multiple
+// underlying Queryables. The underlying queryables and its label values to be
+// considered are returned by a MergeQuerierCallback.
+// Results contain a label `idLabelName` to identify the underlying queryable
+// that it originally resulted from.
+// If the label `idLabelName` is already existing, its value is overwritten and
+// the previous value is exposed through a new label prefixed with "original_".
+// This behaviour is not implemented recursively.
+func NewMergeQueryable(idLabelName string, callback MergeQuerierCallback) storage.Queryable {
 	return &mergeQueryable{
-		upstream: upstream,
+		idLabelName: idLabelName,
+		callback:    callback,
 	}
 }
 
 type mergeQueryable struct {
-	upstream storage.Queryable
+	idLabelName string
+	callback    MergeQuerierCallback
 }
 
 // Querier returns a new mergeQuerier, which aggregates results from multiple
-// tenants into a single result.
+// underlying queriers into a single result.
 func (m *mergeQueryable) Querier(ctx context.Context, mint int64, maxt int64) (storage.Querier, error) {
-	tenantIDs, err := tenant.TenantIDs(ctx)
+	ids, queriers, byPassWithSingleQuerier, err := m.callback(ctx, mint, maxt)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(tenantIDs) <= 1 {
-		return m.upstream.Querier(ctx, mint, maxt)
-	}
-
-	var queriers = make([]storage.Querier, len(tenantIDs))
-	for pos, tenantID := range tenantIDs {
-		q, err := m.upstream.Querier(
-			user.InjectOrgID(ctx, tenantID),
-			mint,
-			maxt,
-		)
-		if err != nil {
-			return nil, err
-		}
-		queriers[pos] = q
+	// by pass when only single querier is returned
+	if byPassWithSingleQuerier && len(queriers) == 1 {
+		return queriers[0], nil
 	}
 
 	return &mergeQuerier{
-		ctx:       ctx,
-		queriers:  queriers,
-		tenantIDs: tenantIDs,
+		ctx:         ctx,
+		idLabelName: m.idLabelName,
+		queriers:    queriers,
+		ids:         ids,
 	}, nil
 }
 
 // mergeQuerier aggregates the results from underlying queriers and adds a
-// label tenantLabelName to identify the tenant ID that the metric resulted
+// label `idLabelName` to identify the queryable that the metric resulted
 // from.
-// If the label tenantLabelName is already existing, its value is
-// overwritten by the tenant ID and the previous value is exposed through a new
-// label prefixed with "original_". This behaviour is not implemented recursively
+// If the label `idLabelName` is already existing, its value is overwritten and
+// the previous value is exposed through a new label prefixed with "original_".
+// This behaviour is not implemented recursively
 type mergeQuerier struct {
-	ctx       context.Context
-	queriers  []storage.Querier
-	tenantIDs []string
+	ctx         context.Context
+	queriers    []storage.Querier
+	idLabelName string
+	ids         []string
 }
 
-// LabelValues returns all potential values for a label name.
-// It is not safe to use the strings beyond the lifefime of the querier.
-// For the label "tenantLabelName" it will return all the tenant IDs available.
-// For the label "original_" + tenantLabelName it will return all the values
-// of the underlying queriers for tenantLabelName.
+// LabelValues returns all potential values for a label name.  It is not safe
+// to use the strings beyond the lifefime of the querier.
+// For the label `idLabelName` it will return all the underlying ids available.
+// For the label "original_" + `idLabelName it will return all the values
+// of the underlying queriers for `idLabelName`.
 func (m *mergeQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
-	if name == defaultTenantLabel {
-		return m.tenantIDs, nil, nil
+	if name == m.idLabelName {
+		return m.ids, nil, nil
 	}
 
-	// ensure the name of a retained tenant id label gets handled under the
-	// original label name
-	if name == originalDefaultTenantLabel {
-		name = defaultTenantLabel
+	// ensure the name of a retained label gets handled under the original
+	// label name
+	if name == retainExistingPrefix+m.idLabelName {
+		name = m.idLabelName
 	}
 
 	return m.mergeDistinctStringSlice(func(ctx context.Context, q storage.Querier) ([]string, storage.Warnings, error) {
@@ -108,8 +148,8 @@ func (m *mergeQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]
 }
 
 // LabelNames returns all the unique label names present in the underlying
-// queriers. It also adds the defaultTenantLabel and if present in the original
-// results the originalDefaultTenantLabel
+// queriers. It also adds the `idLabelName` and if present in the original
+// results the original `idLabelName`.
 func (m *mergeQuerier) LabelNames() ([]string, storage.Warnings, error) {
 	labelNames, warnings, err := m.mergeDistinctStringSlice(func(ctx context.Context, q storage.Querier) ([]string, storage.Warnings, error) {
 		return q.LabelNames()
@@ -118,19 +158,19 @@ func (m *mergeQuerier) LabelNames() ([]string, storage.Warnings, error) {
 		return nil, nil, err
 	}
 
-	// check if the tenant label exists in the original result
-	var tenantLabelExists bool
-	labelPos := sort.SearchStrings(labelNames, defaultTenantLabel)
-	if labelPos < len(labelNames) && labelNames[labelPos] == defaultTenantLabel {
-		tenantLabelExists = true
+	// check if the `idLabelName` exists in the original result
+	var idLabelNameExists bool
+	labelPos := sort.SearchStrings(labelNames, m.idLabelName)
+	if labelPos < len(labelNames) && labelNames[labelPos] == m.idLabelName {
+		idLabelNameExists = true
 	}
 
-	labelToAdd := defaultTenantLabel
+	labelToAdd := m.idLabelName
 
-	// if defaultTenantLabel already exists, we need to add the
-	// originalDefaultTenantLabel
-	if tenantLabelExists {
-		labelToAdd = originalDefaultTenantLabel
+	// if `idLabelName` already exists, we need to add the name prefix with
+	// retainExistingPrefix.
+	if idLabelNameExists {
+		labelToAdd = retainExistingPrefix + m.idLabelName
 		labelPos = sort.SearchStrings(labelNames, labelToAdd)
 	}
 
@@ -146,7 +186,7 @@ type stringSliceFunc func(context.Context, storage.Querier) ([]string, storage.W
 
 type stringSliceFuncJob struct {
 	querier  storage.Querier
-	tenantID string
+	id       string
 	result   []string
 	warnings storage.Warnings
 }
@@ -156,12 +196,12 @@ type stringSliceFuncJob struct {
 // doesn't require the output of the stringSliceFunc to be sorted, as results
 // of LabelValues are not sorted.
 func (m *mergeQuerier) mergeDistinctStringSlice(f stringSliceFunc) ([]string, storage.Warnings, error) {
-	var jobs = make([]interface{}, len(m.tenantIDs))
+	var jobs = make([]interface{}, len(m.ids))
 
-	for pos := range m.tenantIDs {
+	for pos := range m.ids {
 		jobs[pos] = &stringSliceFuncJob{
-			querier:  m.queriers[pos],
-			tenantID: m.tenantIDs[pos],
+			querier: m.queriers[pos],
+			id:      m.ids[pos],
 		}
 	}
 
@@ -174,7 +214,7 @@ func (m *mergeQuerier) mergeDistinctStringSlice(f stringSliceFunc) ([]string, st
 		var err error
 		job.result, job.warnings, err = f(ctx, job.querier)
 		if err != nil {
-			return errors.Wrapf(err, "error querying %s %s", rewriteLabelName(defaultTenantLabel), job.tenantID)
+			return errors.Wrapf(err, "error querying %s %s", rewriteLabelName(m.idLabelName), job.id)
 		}
 
 		return nil
@@ -199,7 +239,7 @@ func (m *mergeQuerier) mergeDistinctStringSlice(f stringSliceFunc) ([]string, st
 		}
 
 		for _, w := range job.warnings {
-			warnings = append(warnings, errors.Wrapf(w, "warning querying %s %s", rewriteLabelName(defaultTenantLabel), job.tenantID))
+			warnings = append(warnings, errors.Wrapf(w, "warning querying %s %s", rewriteLabelName(m.idLabelName), job.id))
 		}
 	}
 
@@ -214,35 +254,35 @@ func (m *mergeQuerier) mergeDistinctStringSlice(f stringSliceFunc) ([]string, st
 // Close releases the resources of the Querier.
 func (m *mergeQuerier) Close() error {
 	errs := tsdb_errors.NewMulti()
-	for pos, tenantID := range m.tenantIDs {
-		errs.Add(errors.Wrapf(m.queriers[pos].Close(), "failed to close querier for %s %s", rewriteLabelName(defaultTenantLabel), tenantID))
+	for pos, id := range m.ids {
+		errs.Add(errors.Wrapf(m.queriers[pos].Close(), "failed to close querier for %s %s", rewriteLabelName(m.idLabelName), id))
 	}
 	return errs.Err()
 }
 
 type selectJob struct {
-	pos      int
-	querier  storage.Querier
-	tenantID string
+	pos     int
+	querier storage.Querier
+	id      string
 }
 
 // Select returns a set of series that matches the given label matchers. If the
-// tenantLabelName is matched on it only considers those queriers matching. The
-// forwarded labelSelector is not containing those that operate on
-// tenantLabelName.
+// `idLabelName` is matched on, it only considers those queriers
+// matching. The forwarded labelSelector is not containing those that operate
+// on `idLabelName`.
 func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	matchedTenants, filteredMatchers := filterValuesByMatchers(defaultTenantLabel, m.tenantIDs, matchers...)
-	var jobs = make([]interface{}, len(matchedTenants))
-	var seriesSets = make([]storage.SeriesSet, len(matchedTenants))
+	matchedValues, filteredMatchers := filterValuesByMatchers(m.idLabelName, m.ids, matchers...)
+	var jobs = make([]interface{}, len(matchedValues))
+	var seriesSets = make([]storage.SeriesSet, len(matchedValues))
 	var jobPos int
-	for tenantPos := range m.tenantIDs {
-		if _, matched := matchedTenants[m.tenantIDs[tenantPos]]; !matched {
+	for labelPos := range m.ids {
+		if _, matched := matchedValues[m.ids[labelPos]]; !matched {
 			continue
 		}
 		jobs[jobPos] = &selectJob{
-			pos:      jobPos,
-			querier:  m.queriers[tenantPos],
-			tenantID: m.tenantIDs[tenantPos],
+			pos:     jobPos,
+			querier: m.queriers[labelPos],
+			id:      m.ids[labelPos],
 		}
 		jobPos++
 	}
@@ -256,8 +296,8 @@ func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, match
 			upstream: job.querier.Select(sortSeries, hints, filteredMatchers...),
 			labels: labels.Labels{
 				{
-					Name:  defaultTenantLabel,
-					Value: job.tenantID,
+					Name:  m.idLabelName,
+					Value: job.id,
 				},
 			},
 		}
@@ -272,32 +312,32 @@ func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, match
 	return storage.NewMergeSeriesSet(seriesSets, storage.ChainedSeriesMerge)
 }
 
-// filterValuesByMatchers applies matchers to inputed labelName and
-// labelValues. A map of matched values is returned and also all label matchers
-// not matching the labelName.
-// In case a label matcher is set on a label conflicting with tenantLabelName,
-// we need to rename this labelMatcher's name to its original name. This is
-// used to as part of Select in the mergeQueryable, to ensure only relevant
-// queries are considered and the forwarded matchers do not contain matchers on
-// the tenantLabelName.
-func filterValuesByMatchers(labelName string, labelValues []string, matchers ...*labels.Matcher) (matchedValues map[string]struct{}, unrelatedMatchers []*labels.Matcher) {
+// filterValuesByMatchers applies matchers to inputed `idLabelName` and
+// `ids`. A map of matched values is returned and also all label matchers not
+// matching the `idLabelName`.
+// In case a label matcher is set on a label conflicting with `idLabelName`, we
+// need to rename this labelMatcher's name to its original name. This is used
+// to as part of Select in the mergeQueryable, to ensure only relevant queries
+// are considered and the forwarded matchers do not contain matchers on the
+// `idLabelName`.
+func filterValuesByMatchers(idLabelName string, ids []string, matchers ...*labels.Matcher) (matchedIDs map[string]struct{}, unrelatedMatchers []*labels.Matcher) {
 	// this contains the matchers which are not related to labelName
 	unrelatedMatchers = make([]*labels.Matcher, 0, len(matchers))
 
 	// build map of values to consider for the matchers
-	matchedValues = make(map[string]struct{}, len(labelValues))
-	for _, value := range labelValues {
-		matchedValues[value] = struct{}{}
+	matchedIDs = make(map[string]struct{}, len(ids))
+	for _, value := range ids {
+		matchedIDs[value] = struct{}{}
 	}
 
 	for _, m := range matchers {
-		if m.Name != labelName {
+		if m.Name != idLabelName {
 			// check if has the retained label name
-			if m.Name == originalDefaultTenantLabel {
+			if m.Name == retainExistingPrefix+idLabelName {
 				// rewrite label to the original name, by copying matcher and
 				// replacing the label name
 				rewrittenM := *m
-				rewrittenM.Name = labelName
+				rewrittenM.Name = idLabelName
 				unrelatedMatchers = append(unrelatedMatchers, &rewrittenM)
 			} else {
 				unrelatedMatchers = append(unrelatedMatchers, m)
@@ -305,14 +345,14 @@ func filterValuesByMatchers(labelName string, labelValues []string, matchers ...
 			continue
 		}
 
-		for value := range matchedValues {
+		for value := range matchedIDs {
 			if !m.Matches(value) {
-				delete(matchedValues, value)
+				delete(matchedIDs, value)
 			}
 		}
 	}
 
-	return matchedValues, unrelatedMatchers
+	return matchedIDs, unrelatedMatchers
 }
 
 type addLabelsSeriesSet struct {

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	maxt, mint = 0, 10
+	maxt, mint                 = 0, 10
+	originalDefaultTenantLabel = retainExistingPrefix + defaultTenantLabel
 )
 
 type mockTenantQueryableWithFilter struct {

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -227,6 +227,9 @@ type mergeQueryableTestCase struct {
 	expectedLabelValues map[string][]string
 	selectorCases       []selectorTestCase
 
+	// do not bypass in the case of single queriers
+	doNotByPassSingleQuerier bool
+
 	// storage.Warnings expected when querying
 	expectedWarnings []string
 
@@ -252,6 +255,15 @@ func TestMergeQueryable(t *testing.T) {
 			expectedLabelValues: map[string][]string{
 				"instance": {"host1", "host2.team-a"},
 			},
+		},
+		{
+			name:       "single tenant without bypass",
+			tenants:    []string{"team-a"},
+			labelNames: []string{"__tenant_id__", "instance", "tenant-team-a"},
+			expectedLabelValues: map[string][]string{
+				"instance": {"host1", "host2.team-a"},
+			},
+			doNotByPassSingleQuerier: true,
 		},
 		{
 			name:       "three tenants",
@@ -363,7 +375,7 @@ func TestMergeQueryable(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// initialize with default tenant label
-			q := NewQueryable(&tc.queryable)
+			q := NewQueryable(&tc.queryable, !tc.doNotByPassSingleQuerier)
 
 			// inject context if set
 			ctx := context.Background()


### PR DESCRIPTION
**What this PR does**:

This change allows to use a mergeQueryable (by external projects), to aggregate results from multiple underlying Queryables.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
