### PR TITLE
Try to fix TestMultitenantAlertmanager_FirewallShouldBlockHTTPBasedReceiversWhenEnabled flakyness

### DIFF
--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -363,7 +363,13 @@ receivers:
 
 	for receiverName, testData := range tests {
 		for _, firewallEnabled := range []bool{true, false} {
-			t.Run(fmt.Sprintf("%s firewall: %v", receiverName, firewallEnabled), func(t *testing.T) {
+			receiverName := receiverName
+			testData := testData
+			firewallEnabled := firewallEnabled
+
+			t.Run(fmt.Sprintf("receiver=%s firewall enabled=%v", receiverName, firewallEnabled), func(t *testing.T) {
+				t.Parallel()
+
 				ctx := context.Background()
 				userID := "user-1"
 				serverInvoked := atomic.NewBool(false)
@@ -435,7 +441,7 @@ receivers:
 
 				// Ensure the server endpoint has not been called if firewall is enabled. Since the alert is delivered
 				// asynchronously, we should pool it for a short period.
-				deadline := time.Now().Add(time.Second)
+				deadline := time.Now().Add(3 * time.Second)
 				for {
 					if time.Now().After(deadline) || serverInvoked.Load() {
 						break


### PR DESCRIPTION
**What this PR does**:
We've seen `TestMultitenantAlertmanager_FirewallShouldBlockHTTPBasedReceiversWhenEnabled` failing in this CI run https://github.com/cortexproject/cortex/runs/2436609218:
```
--- FAIL: TestMultitenantAlertmanager_FirewallShouldBlockHTTPBasedReceiversWhenEnabled (9.33s)
    --- FAIL: TestMultitenantAlertmanager_FirewallShouldBlockHTTPBasedReceiversWhenEnabled/wechat_firewall:_false (1.31s)
        multitenant_test.go:446: 
            	Error Trace:	multitenant_test.go:446
            	Error:      	Not equal: 
            	            	expected: true
            	            	actual  : false
            	Test:       	TestMultitenantAlertmanager_FirewallShouldBlockHTTPBasedReceiversWhenEnabled/wechat_firewall:_false
```

The failing test was testing the case firewall is disabled and so, we expect the notification to be sent. The test currently has a max waiting time of 1s, which may be too low. I've increased it to 3s to see if that fixes the flakyness and, in order to speed up that test, I've also enabled the parallel execution.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
