### PR TITLE
Make iterations metric per rule_group

### DIFF
--- a/pkg/ruler/manager_metrics.go
+++ b/pkg/ruler/manager_metrics.go
@@ -44,13 +44,13 @@ func NewManagerMetrics() *ManagerMetrics {
 		IterationsMissed: prometheus.NewDesc(
 			"cortex_prometheus_rule_group_iterations_missed_total",
 			"The total number of rule group evaluations missed due to slow rule group evaluation.",
-			[]string{"user"},
+			[]string{"user", "rule_group"},
 			nil,
 		),
 		IterationsScheduled: prometheus.NewDesc(
 			"cortex_prometheus_rule_group_iterations_total",
 			"The total number of scheduled rule group evaluations, whether executed or missed.",
-			[]string{"user"},
+			[]string{"user", "rule_group"},
 			nil,
 		),
 		EvalTotal: prometheus.NewDesc(
@@ -134,9 +134,8 @@ func (m *ManagerMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfSummariesPerUser(out, m.EvalDuration, "prometheus_rule_evaluation_duration_seconds")
 	data.SendSumOfSummariesPerUser(out, m.IterationDuration, "prometheus_rule_group_duration_seconds")
 
-	data.SendSumOfCountersPerUser(out, m.IterationsMissed, "prometheus_rule_group_iterations_missed_total")
-	data.SendSumOfCountersPerUser(out, m.IterationsScheduled, "prometheus_rule_group_iterations_total")
-
+	data.SendSumOfCountersPerUserWithLabels(out, m.IterationsMissed, "prometheus_rule_group_iterations_missed_total", "rule_group")
+	data.SendSumOfCountersPerUserWithLabels(out, m.IterationsScheduled, "prometheus_rule_group_iterations_total", "rule_group")
 	data.SendSumOfCountersPerUserWithLabels(out, m.EvalTotal, "prometheus_rule_evaluations_total", "rule_group")
 	data.SendSumOfCountersPerUserWithLabels(out, m.EvalFailures, "prometheus_rule_evaluation_failures_total", "rule_group")
 	data.SendSumOfGaugesPerUserWithLabels(out, m.GroupInterval, "prometheus_rule_group_interval_seconds", "rule_group")


### PR DESCRIPTION
So I have a feeling we didn't do `rule_group` for those metrics on purpose. The metric output doesn't have the iterations metrics anymore. 