### PR TITLE
Fix TestStreamWriteYAMLResponse flakyness

### DIFF
--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -108,7 +108,9 @@ func TestStreamWriteYAMLResponse(t *testing.T) {
 		expectedContentType: "application/yaml",
 		value:               make(map[string]*testStruct),
 	}
-	for i := 0; i < rand.Intn(100); i++ {
+
+	// Generate some data to serialize.
+	for i := 0; i < rand.Intn(100)+1; i++ {
 		ts := testStruct{
 			Name:  "testName" + strconv.Itoa(i),
 			Value: i,


### PR DESCRIPTION
**What this PR does**:
The `TestStreamWriteYAMLResponse` is flaky when `rand.Intn(100)` returns `0`. This PR fixes it making sure we always have at least 1 entry in the map to serialize.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
