### PR TITLE
Hot fix to avoid process to block indefinitely on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 * [BUGFIX] Frontend, Query-scheduler: allow querier to notify about shutdown without providing any authentication. #4066
 * [BUGFIX] Querier: fixed race condition causing queries to fail right after querier startup with the "empty ring" error. #4068
 * [BUGFIX] Compactor: Increment `cortex_compactor_runs_failed_total` if compactor failed compact a single tenant. #4094
+* [BUGFIX] Tracing: hot fix to avoid the Jaeger tracing client to indefinitely block the Cortex process shutdown in case the HTTP connection to the tracing backend is blocked. #4134
 
 ## Blocksconvert
 

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -153,10 +153,10 @@ func main() {
 		}
 
 		// Setting the environment variable JAEGER_AGENT_HOST enables tracing.
-		if trace, err := tracing.NewFromEnv(name); err != nil {
+		// Do NOT call trace.Close() because of an known issue which could cause the process to block indefinitely
+		// on shutdown. See: https://github.com/jaegertracing/jaeger-client-go/issues/577
+		if _, err := tracing.NewFromEnv(name); err != nil {
 			level.Error(util_log.Logger).Log("msg", "Failed to setup tracing", "err", err.Error())
-		} else {
-			defer trace.Close()
 		}
 	}
 


### PR DESCRIPTION
**What this PR does**:
We're rolling out ingesters in a production cluster and we've found a critical issue causing them getting stuck indefinitely while shutting down. The issue is related to the jaeger client and [described here](https://github.com/jaegertracing/jaeger-client-go/issues/577). In this PR I'm proposing an hot fix: do not call `tracer.Close()` at shutdown. Since the process is exiting anyway, it shouldn't cause any real issue.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
