### PR TITLE
Add logs to investigate TestMultitenantAlertmanager_FirewallShouldBlockHTTPBasedReceiversWhenEnabled flaky in CI

### DIFF
--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/concurrency"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
-	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -868,7 +867,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *amco
 	newAM, err := New(&Config{
 		UserID:            userID,
 		TenantDataDir:     tenantDir,
-		Logger:            util_log.Logger,
+		Logger:            am.logger,
 		Peer:              am.peer,
 		PeerTimeout:       am.cfg.Cluster.PeerTimeout,
 		Retention:         am.cfg.Retention,


### PR DESCRIPTION
**What this PR does**:
I can't understand why `TestMultitenantAlertmanager_FirewallShouldBlockHTTPBasedReceiversWhenEnabled` is flaky in CI (see #4138). I've run it with `-count=100` locally and succeeded.

In this PR I'm proposing to add alertmanager logs to test output, so I can see if the alert gets received by the dispatcher and if the dispatcher succeed/fail sending it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
