### PR TITLE
prevent not found objects from incrementing thanos_objstore_bucket_operation_failures_total during deletion marker migration

### DIFF
--- a/pkg/storage/tsdb/bucketindex/markers.go
+++ b/pkg/storage/tsdb/bucketindex/markers.go
@@ -49,7 +49,8 @@ func IsBlockDeletionMarkFilename(name string) (ulid.ULID, bool) {
 // a deletion mark in the block location. Found deletion marks are copied to the global markers location.
 // The migration continues on error and returns once all blocks have been checked.
 func MigrateBlockDeletionMarksToGlobalLocation(ctx context.Context, bkt objstore.Bucket, userID string, cfgProvider bucket.TenantConfigProvider) error {
-	userBucket := bucket.NewUserBucketClient(userID, bkt, cfgProvider)
+	bucket := bucket.NewUserBucketClient(userID, bkt, cfgProvider)
+	userBucket := bucket.WithExpectedErrs(bucket.IsObjNotFoundErr)
 
 	// Find all blocks in the storage.
 	var blocks []ulid.ULID


### PR DESCRIPTION
we've seen `thanos_objstore_bucket_operation_failures_total` increment without an error log,
and we suspect this is related to deletion marker migration.

this change prevents the metric from incrementing as not found values is actually expected in this
code path.

I've added a test case to ensure the particular metric stays 0 as it is expected behaviour.
