### PR TITLE
Fixed TestMultitenantAlertmanager_FirewallShouldBlockHTTPBasedReceiversWhenEnabled flakyness

### DIFF
--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -292,6 +292,7 @@ func TestMultitenantAlertmanager_FirewallShouldBlockHTTPBasedReceiversWhenEnable
 route:
   receiver: webhook
   group_wait: 0s
+  group_interval: 1s
 
 receivers:
   - name: webhook
@@ -306,6 +307,7 @@ receivers:
 route:
   receiver: pagerduty
   group_wait: 0s
+  group_interval: 1s
 
 receivers:
   - name: pagerduty
@@ -321,6 +323,7 @@ receivers:
 route:
   receiver: slack
   group_wait: 0s
+  group_interval: 1s
 
 receivers:
   - name: slack
@@ -336,6 +339,7 @@ receivers:
 route:
   receiver: opsgenie
   group_wait: 0s
+  group_interval: 1s
 
 receivers:
   - name: opsgenie
@@ -351,6 +355,7 @@ receivers:
 route:
   receiver: wechat
   group_wait: 0s
+  group_interval: 1s
 
 receivers:
   - name: wechat


### PR DESCRIPTION
**What this PR does**:
I've finally found the root cause of `TestMultitenantAlertmanager_FirewallShouldBlockHTTPBasedReceiversWhenEnabled` flakyness. It's a (not easy to trigger) race condition in the Alertmanager which causes the `GroupWait` to get ignored on the 1st alert of a group and actually trigger once `GroupInterval` is hit.

I've opened an [issue in the Prometheus Alertmanager](https://github.com/prometheus/alertmanager/issues/2562). In the meanwhile this is a PR to fix the flakyness just setting `group_interval` to a very low value too.

**Which issue(s) this PR fixes**:
Fixes #4138

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
