### PR TITLE
Specify hints to TSDB querier when querying series

### DIFF
--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -1095,7 +1095,13 @@ func (i *Ingester) v2MetricsForLabelMatchers(ctx context.Context, req *client.Me
 			return nil, ctx.Err()
 		}
 
-		seriesSet := q.Select(true, nil, matchers...)
+		hints := &storage.SelectHints{
+			Start: mint,
+			End:   maxt,
+			Func:  "series", // There is no series function, this token is used for lookups that don't need samples.
+		}
+
+		seriesSet := q.Select(true, hints, matchers...)
 		sets = append(sets, seriesSet)
 	}
 


### PR DESCRIPTION
**What this PR does**:
I was investigating some working set memory spikes in ingesters while serving heavy queries to `/api/v1/series`. In the ingester the logic is in `v2MetricsForLabelMatchers()` (when running the blocks storage) and I've noticed that we're not passing any `storage.SelectHints` to `db.Select()`.

I thought it could help but, looking at the benchmark, it doesn't. Further investigating in TSDB, I don't see a good reason why passing `Func: "series"` should help, considering chunks are lazy fetched when iterating samples (and we don't iterate samples). I think it was different in the past, maybe before `ChunkQuerier()` was introduced.

However, I believe it's better to implement series fetching the same way as Prometheus, so in this PR I'm proposing to pass hints anyway.

```
name                                    old time/op    new time/op    delta
_Ingester_v2MetricsForLabelMatchers-12    73.3ms ± 3%    72.7ms ± 2%    ~     (p=0.841 n=5+5)

name                                    old alloc/op   new alloc/op   delta
_Ingester_v2MetricsForLabelMatchers-12    26.7MB ± 0%    26.7MB ± 0%  +0.00%  (p=0.008 n=5+5)

name                                    old allocs/op  new allocs/op  delta
_Ingester_v2MetricsForLabelMatchers-12      700k ± 0%      700k ± 0%  +0.00%  (p=0.008 n=5+5)
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
