### PR TITLE
Supress counting not-found as an error when reading alertmanager state.

### DIFF
--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -192,5 +192,5 @@ func (s *BucketAlertStore) getUserBucket(userID string) objstore.Bucket {
 }
 
 func (s *BucketAlertStore) getAlertmanagerUserBucket(userID string) objstore.Bucket {
-	return bucket.NewUserBucketClient(userID, s.amBucket, s.cfgProvider)
+	return bucket.NewUserBucketClient(userID, s.amBucket, s.cfgProvider).WithExpectedErrs(s.amBucket.IsObjNotFoundErr)
 }


### PR DESCRIPTION
**What this PR does**:

This error is expected when a new user is configured and has not
persisted any state yet, or if an alertmanager is being transitioned
from non-sharding to sharding operation.


**Checklist**
- [X] ~~Tests updated~~
- [X] ~~Documentation added~~
- [X] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~
