### PR TITLE
Expire long-running e2e containers in Drone CI

### DIFF
--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -294,6 +294,9 @@ func (s *ConcreteService) WaitReady() (err error) {
 func (s *ConcreteService) buildDockerRunArgs(networkName, sharedDir string) []string {
 	args := []string{"run", "--rm", "--net=" + networkName, "--name=" + networkName + "-" + s.name, "--hostname=" + s.name}
 
+	// For Drone CI users, expire the container after 6 hours using drone-gc
+	args = append(args, "--label", fmt.Sprintf("io.drone.expires=%d", time.Now().Add(6*time.Hour).Unix()))
+
 	// Mount the shared/ directory into the container
 	args = append(args, "-v", fmt.Sprintf("%s:%s:z", sharedDir, ContainerSharedDir))
 


### PR DESCRIPTION
**What this PR does**:
By adding the `io.drone.expires` label to all e2e containers, they will be cleaned up if they are left dangling following a failed test

drone-gc cleanup code: https://github.com/drone/drone-gc/blob/3ac5240928e6f6b00d1930262d2f833e36c8dfcb/gc/util.go#L55

**Which issue(s) this PR fixes**:
None

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
