### PR TITLE
Don't force amd64 arch when building docker image for development

### DIFF
--- a/development/tsdb-blocks-storage-s3-gossip/compose-up.sh
+++ b/development/tsdb-blocks-storage-s3-gossip/compose-up.sh
@@ -5,6 +5,6 @@ set -e
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -gcflags "all=-N -l" -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build distributor
+CGO_ENABLED=0 GOOS=linux go build -mod=vendor -gcflags "all=-N -l" -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex
+docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build distributor 
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@

--- a/development/tsdb-blocks-storage-s3-gossip/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3-gossip/dev.dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.16
-ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+ENV CGO_ENABLED=0
 RUN go get github.com/go-delve/delve/cmd/dlv
 
 FROM alpine:3.13

--- a/development/tsdb-blocks-storage-s3-single-binary/compose-up.sh
+++ b/development/tsdb-blocks-storage-s3-single-binary/compose-up.sh
@@ -2,6 +2,6 @@
 
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex && \
+CGO_ENABLED=0 GOOS=linux go build -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex && \
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build cortex-1 && \
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@

--- a/development/tsdb-blocks-storage-s3/compose-up.sh
+++ b/development/tsdb-blocks-storage-s3/compose-up.sh
@@ -5,6 +5,7 @@ set -e
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -gcflags "all=-N -l" -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build distributor
+# GOARCH is not changed.
+CGO_ENABLED=0 GOOS=linux go build -mod=vendor -gcflags "all=-N -l" -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex
+docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build distributor 
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@

--- a/development/tsdb-blocks-storage-s3/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3/dev.dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.16
-ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+ENV CGO_ENABLED=0
 RUN go get github.com/go-delve/delve/cmd/dlv
 
 FROM alpine:3.13

--- a/development/tsdb-blocks-storage-swift-single-binary/compose-up.sh
+++ b/development/tsdb-blocks-storage-swift-single-binary/compose-up.sh
@@ -2,6 +2,6 @@
 
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex && \
+CGO_ENABLED=0 GOOS=linux go build -o ${SCRIPT_DIR}/cortex ${SCRIPT_DIR}/../../cmd/cortex && \
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build cortex-1 && \
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@


### PR DESCRIPTION
**What this PR does**: This PR removes setting of `GOARCH=amd64` in devel environments. This makes go to use the same architecture as host system, instead of emulating amd64 when running Docker in different environment. (eg. on Apple Silicon)
