### PR TITLE
Build image now supports linux/arm64 as well

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/cortexproject/build-image:2021w14_go1.16-afe06f021
+      image: quay.io/cortexproject/build-image:build-image-multiarch-1d2497ff6
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/cortexproject/build-image:2021w14_go1.16-afe06f021
+      image: quay.io/cortexproject/build-image:build-image-multiarch-1d2497ff6
     services:
       cassandra:
         image: cassandra:3.11
@@ -55,7 +55,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/cortexproject/build-image:2021w14_go1.16-afe06f021
+      image: quay.io/cortexproject/build-image:build-image-multiarch-1d2497ff6
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -173,14 +173,14 @@ jobs:
         run: |
           touch build-image/.uptodate
           MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations
-          make BUILD_IMAGE=quay.io/cortexproject/build-image:2021w14_go1.16-afe06f021 TTY='' configs-integration-test
+          make BUILD_IMAGE=quay.io/cortexproject/build-image:build-image-multiarch-1d2497ff6 TTY='' configs-integration-test
 
   deploy_website:
     needs: [build, test]
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-latest
     container:
-      image: quay.io/cortexproject/build-image:2021w14_go1.16-afe06f021
+      image: quay.io/cortexproject/build-image:build-image-multiarch-1d2497ff6
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -217,7 +217,7 @@ jobs:
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-latest
     container:
-      image: quay.io/cortexproject/build-image:2021w14_go1.16-afe06f021
+      image: quay.io/cortexproject/build-image:build-image-multiarch-1d2497ff6
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # WARNING: do not commit to a repository!
 -include Makefile.local
 
-.PHONY: all test cover clean images protos exes dist doc clean-doc check-doc
+.PHONY: all test cover clean images protos exes dist doc clean-doc check-doc push-multiarch-build-image
 .DEFAULT_GOAL := all
 
 # Version number
@@ -39,8 +39,13 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 %/$(UPTODATE): %/Dockerfile
 	@echo
 	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)$(shell basename $(@D)) $(@D)/
-	$(SUDO) docker tag $(IMAGE_PREFIX)$(shell basename $(@D)) $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG)
+	@echo
+	@echo Please use push-multiarch-build-image to build and push build image for all supported architectures.
 	touch $@
+
+push-multiarch-build-image:
+	@echo
+	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)build-image -t $(IMAGE_PREFIX)build-image:$(IMAGE_TAG) build-image/
 
 # We don't want find to scan inside a bunch of directories, to accelerate the
 # 'make: Entering directory '/go/src/github.com/cortexproject/cortex' phase.

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 # declared.
 %/$(UPTODATE): %/Dockerfile
 	@echo
-	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)$(shell basename $(@D)) $(@D)/
+	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)$(shell basename $(@D)) -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG) $(@D)/
 	@echo
 	@echo Please use push-multiarch-build-image to build and push build image for all supported architectures.
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 # declared.
 %/$(UPTODATE): %/Dockerfile
 	@echo
-	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)$(shell basename $(@D)) -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG) $(@D)/
+	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)$(shell basename $(@D)) $(@D)/
+	$(SUDO) docker tag $(IMAGE_PREFIX)$(shell basename $(@D)) $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG)
 	@echo
 	@echo Please use push-multiarch-build-image to build and push build image for all supported architectures.
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 
 push-multiarch-build-image:
 	@echo
-	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)build-image -t $(IMAGE_PREFIX)build-image:$(IMAGE_TAG) build-image/
+	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)build-image:$(IMAGE_TAG) build-image/
 
 # We don't want find to scan inside a bunch of directories, to accelerate the
 # 'make: Entering directory '/go/src/github.com/cortexproject/cortex' phase.

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 
 push-multiarch-build-image:
 	@echo
+	# Build image for each platform separately... it tends to generate fewer errors.
+	$(SUDO) docker buildx build --platform linux/amd64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) build-image/
+	$(SUDO) docker buildx build --platform linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) build-image/
+	# This command will run the same build as above, but it will reuse existing platform-specific images,
+	# put them together and push to registry.
 	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)build-image:$(IMAGE_TAG) build-image/
 
 # We don't want find to scan inside a bunch of directories, to accelerate the

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -11,20 +11,31 @@ RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN npm install -g postcss-cli@5.0.1 autoprefixer@9.8.5
 
 ENV HUGO_VERSION=0.72.0
-RUN GOARCH=$(go env GOARCH) && echo $GOARCH && \
-	if [ "$GOARCH"="amd64" ]; then \
+RUN GOARCH=$(go env GOARCH) && \
+	if [ "$GOARCH" = "amd64" ]; then \
 		URL=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz; \
-	elif [ "$GOARCH"="arm64" ]; then \
+		DIGEST=28353611210d48c681f1f83a64ce36972d010e751f2794122db80f5060fe933d; \
+	elif [ "$GOARCH" = "arm64" ]; then \
 		URL=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-ARM64.tar.gz; \
+		DIGEST=17d079d07d5ec5a5e66fc1264a391dad3010662252563f4304bcbed796083206; \
 	fi && \
 	echo Downloading ${URL} && \
 	curl -s -L -o hugo.tar.gz "${URL}" && \
+	echo "$DIGEST  hugo.tar.gz" | sha256sum -c && \
 	tar xzvf hugo.tar.gz -C /usr/bin && \
 	rm hugo.tar.gz && \
 	chmod +x /usr/bin/hugo
 
 ENV SHFMT_VERSION=3.2.4
-RUN curl -fsSLo shfmt https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_$(go env GOARCH) && \
+RUN GOARCH=$(go env GOARCH) && \
+	if [ "$GOARCH" = "amd64" ]; then \
+    	DIGEST=3f5a47f8fec27fae3e06d611559a2063f5d27e4b9501171dde9959b8c60a3538; \
+    elif [ "$GOARCH" = "arm64" ]; then \
+    	DIGEST=6474d9cc08a1c9fe2ef4be7a004951998e3067d46cf55a011ddd5ff7bfab3de6; \
+    fi && \
+    URL=https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${GOARCH}; \
+    curl -fsSLo shfmt "${URL}" && \
+	echo "$DIGEST  shfmt" | sha256sum -c && \
 	chmod +x shfmt && \
 	mv shfmt /usr/bin
 

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -20,6 +20,7 @@ RUN GOARCH=$(go env GOARCH) && echo $GOARCH && \
 	echo Downloading ${URL} && \
 	curl -s -L -o hugo.tar.gz "${URL}" && \
 	tar xzvf hugo.tar.gz -C /usr/bin && \
+	rm hugo.tar.gz && \
 	chmod +x /usr/bin/hugo
 
 ENV SHFMT_VERSION=3.2.4

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -38,14 +38,12 @@ RUN GO111MODULE=on go get \
 		github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 \
 		github.com/fatih/faillint@v1.5.0 \
 		github.com/campoy/embedmd@v1.0.0 \
-	&& true
+	&& rm -rf /go/pkg /go/src
 
 # Cannot get it to run together in above go get.
 RUN GO111MODULE=on go get  \
 		github.com/instrumenta/kubeval@v0.16.1 \
-	&& true
-
-RUN rm -rf /go/pkg /go/src
+	&& rm -rf /go/pkg /go/src
 
 ENV NODE_PATH=/usr/lib/node_modules
 COPY build.sh /

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -10,44 +10,46 @@ RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # and viceversa.
 RUN npm install -g postcss-cli@5.0.1 autoprefixer@9.8.5
 
-ENV HUGO_VERSION=v0.72.0
-RUN git clone https://github.com/gohugoio/hugo.git --branch ${HUGO_VERSION} --depth 1 && \
-	cd hugo  && go install --tags extended && cd ../ && \
-	rm -rf hugo/ && rm -rf /go/pkg /go/src
-ENV SHFMT_VERSION=3.1.0
-RUN curl -fsSLo shfmt https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64 && \
-	echo "cb91ea08a075a2f96b5230f09b4e211b7c108b1c97603caceb48d117d2ac5508  shfmt" | sha256sum -c && \
+ENV HUGO_VERSION=0.72.0
+RUN GOARCH=$(go env GOARCH) && echo $GOARCH && \
+	if [ "$GOARCH"="amd64" ]; then \
+		URL=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz; \
+	elif [ "$GOARCH"="arm64" ]; then \
+		URL=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-ARM64.tar.gz; \
+	fi && \
+	echo Downloading ${URL} && \
+	curl -s -L -o hugo.tar.gz "${URL}" && \
+	tar xzvf hugo.tar.gz -C /usr/bin && \
+	chmod +x /usr/bin/hugo
+
+ENV SHFMT_VERSION=3.2.4
+RUN curl -fsSLo shfmt https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_$(go env GOARCH) && \
 	chmod +x shfmt && \
 	mv shfmt /usr/bin
+
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.27.0
-RUN GO111MODULE=on go get -tags netgo \
+
+RUN GO111MODULE=on go get \
 		github.com/client9/misspell/cmd/misspell@v0.3.4 \
 		github.com/golang/protobuf/protoc-gen-go@v1.3.1 \
 		github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 \
 		github.com/gogo/protobuf/gogoproto@v1.3.0 \
-		github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 && \
-	rm -rf /go/pkg /go/src
+		github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 \
+		github.com/fatih/faillint@v1.5.0 \
+		github.com/campoy/embedmd@v1.0.0 \
+	&& true
 
-ENV KUBEVAL_VERSION=0.15.0
-RUN curl -Ls https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz -o /tmp/kubeval-linux-amd64.tar.gz && \
-	tar -xf /tmp/kubeval-linux-amd64.tar.gz -C /tmp && \
-	cp /tmp/kubeval /usr/local/bin && \
-	rm -f /tmp/kubeval*
+# Cannot get it to run together in above go get.
+RUN GO111MODULE=on go get  \
+		github.com/instrumenta/kubeval@v0.16.1 \
+	&& true
+
+RUN rm -rf /go/pkg /go/src
 
 ENV NODE_PATH=/usr/lib/node_modules
 COPY build.sh /
 ENV GOCACHE=/go/cache
 ENTRYPOINT ["/build.sh"]
-
-# Install faillint used to lint go imports in CI.
-ENV FAILLINT_VERSION=1.5.0
-RUN GO111MODULE=on go get github.com/fatih/faillint@v${FAILLINT_VERSION} && \
-    rm -rf /go/pkg /go/src
-
-# Install embedmd used to embed content into markdown files.
-ENV EMBEDMD_VERSION=1.0.0
-RUN GO111MODULE=on go get github.com/campoy/embedmd@v${EMBEDMD_VERSION} && \
-    rm -rf /go/pkg /go/src
 
 ARG revision
 LABEL org.opencontainers.image.title="build-image" \

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -13,7 +13,7 @@ RUN npm install -g postcss-cli@5.0.1 autoprefixer@9.8.5
 ENV HUGO_VERSION=v0.72.0
 RUN git clone https://github.com/gohugoio/hugo.git --branch ${HUGO_VERSION} --depth 1 && \
 	cd hugo  && go install --tags extended && cd ../ && \
-	rm -rf hugo/ && rm -rf /go/pkg /go/src
+	rm -rf hugo/ && rm -rf /go/pkg /go/src /root/.cache
 
 ENV SHFMT_VERSION=3.2.4
 RUN GOARCH=$(go env GOARCH) && \
@@ -38,12 +38,12 @@ RUN GO111MODULE=on go get \
 		github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 \
 		github.com/fatih/faillint@v1.5.0 \
 		github.com/campoy/embedmd@v1.0.0 \
-	&& rm -rf /go/pkg /go/src
+	&& rm -rf /go/pkg /go/src /root/.cache
 
 # Cannot get it to run together in above go get.
 RUN GO111MODULE=on go get  \
 		github.com/instrumenta/kubeval@v0.16.1 \
-	&& rm -rf /go/pkg /go/src
+	&& rm -rf /go/pkg /go/src /root/.cache
 
 ENV NODE_PATH=/usr/lib/node_modules
 COPY build.sh /

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -10,21 +10,10 @@ RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # and viceversa.
 RUN npm install -g postcss-cli@5.0.1 autoprefixer@9.8.5
 
-ENV HUGO_VERSION=0.72.0
-RUN GOARCH=$(go env GOARCH) && \
-	if [ "$GOARCH" = "amd64" ]; then \
-		URL=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz; \
-		DIGEST=28353611210d48c681f1f83a64ce36972d010e751f2794122db80f5060fe933d; \
-	elif [ "$GOARCH" = "arm64" ]; then \
-		URL=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-ARM64.tar.gz; \
-		DIGEST=17d079d07d5ec5a5e66fc1264a391dad3010662252563f4304bcbed796083206; \
-	fi && \
-	echo Downloading ${URL} && \
-	curl -s -L -o hugo.tar.gz "${URL}" && \
-	echo "$DIGEST  hugo.tar.gz" | sha256sum -c && \
-	tar xzvf hugo.tar.gz -C /usr/bin && \
-	rm hugo.tar.gz && \
-	chmod +x /usr/bin/hugo
+ENV HUGO_VERSION=v0.72.0
+RUN git clone https://github.com/gohugoio/hugo.git --branch ${HUGO_VERSION} --depth 1 && \
+	cd hugo  && go install --tags extended && cd ../ && \
+	rm -rf hugo/ && rm -rf /go/pkg /go/src
 
 ENV SHFMT_VERSION=3.2.4
 RUN GOARCH=$(go env GOARCH) && \

--- a/docs/contributing/how-to-update-the-build-image.md
+++ b/docs/contributing/how-to-update-the-build-image.md
@@ -8,6 +8,6 @@ slug: how-to-update-the-build-image
 The build image currently can only be updated by a Cortex maintainer. If you're not a maintainer you can still open a PR with the changes, asking a maintainer to assist you publishing the updated image. The procedure is:
 
 1. Update `build-image/Docker`.
-2. Build the and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for linux/amd64 and linux/arm64). Pushing to `quay.io/cortexproject/build-image` repository can only be done by a maintainer. Running this step successfully requires [BuildKit to be enabled in Docker features](https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds), but does not require a specific platform.
+2. Build the and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for linux/amd64 and linux/arm64). Pushing to `quay.io/cortexproject/build-image` repository can only be done by a maintainer. Running this step successfully requires [Docker Buildx](https://docs.docker.com/buildx/working-with-buildx/), but does not require a specific platform.
 3. Replace the image tag in `.github/workflows/*` (_there may be multiple references_)
 4. Open a PR and make sure the CI with new build-image passes

--- a/docs/contributing/how-to-update-the-build-image.md
+++ b/docs/contributing/how-to-update-the-build-image.md
@@ -8,6 +8,6 @@ slug: how-to-update-the-build-image
 The build image currently can only be updated by a Cortex maintainer. If you're not a maintainer you can still open a PR with the changes, asking a maintainer to assist you publishing the updated image. The procedure is:
 
 1. Update `build-image/Docker`.
-2. Build the and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for linux/amd64 and linux/arm64). Pushing to `quay.io/cortexproject/build-image` repository can only be done by a maintainer.
+2. Build the and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for linux/amd64 and linux/arm64). Pushing to `quay.io/cortexproject/build-image` repository can only be done by a maintainer. Running this step successfully requires [BuildKit to be enabled in Docker features](https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds), but does not require a specific platform.
 3. Replace the image tag in `.github/workflows/*` (_there may be multiple references_)
 4. Open a PR and make sure the CI with new build-image passes

--- a/docs/contributing/how-to-update-the-build-image.md
+++ b/docs/contributing/how-to-update-the-build-image.md
@@ -7,8 +7,7 @@ slug: how-to-update-the-build-image
 
 The build image currently can only be updated by a Cortex maintainer. If you're not a maintainer you can still open a PR with the changes, asking a maintainer to assist you publishing the updated image. The procedure is:
 
-1. Update `build-image/Docker`
-2. Build the image running `make build-image/.uptodate`
-3. Publish the image to the repository running `docker push quay.io/cortexproject/build-image:TAG` (this can only be done by a maintainer)
-4. Replace the image tag in `.github/workflows/*` (_there may be multiple references_)
-5. Open a PR and make sure the CI with new build-image passes
+1. Update `build-image/Docker`.
+2. Build the and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for linux/amd64 and linux/arm64). Pushing to `quay.io/cortexproject/build-image` repository can only be done by a maintainer.
+3. Replace the image tag in `.github/workflows/*` (_there may be multiple references_)
+4. Open a PR and make sure the CI with new build-image passes


### PR DESCRIPTION
Build-image can be built for linux/amd64 (as before) and also linux/arm64 platform.

Added new Makefile target to build multi-arch build image. Such image can only be pushed to repository, and not used locally by Docker. Docker only fetches platform-specific image, when it doesn't have one locally.

To use the feature, one needs to [enable `buildkit` feature](https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds) in docker config. Building amd64 and arm64 should work regardless of host platform -- docker will simply run non-native platform under qemu.
