### PR TITLE
Delete alertmanager state objects from remote storage on user deletion.

### DIFF
--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io/ioutil"
+	"strings"
 	"sync"
 
 	"github.com/go-kit/kit/log"
@@ -121,6 +122,18 @@ func (s *BucketAlertStore) DeleteAlertConfig(ctx context.Context, userID string)
 		return nil
 	}
 	return err
+}
+
+// ListUsersWithState implements alertstore.AlertStore.
+func (s *BucketAlertStore) ListUsersWithState(ctx context.Context) ([]string, error) {
+	var userIDs []string
+
+	err := s.amBucket.Iter(ctx, "", func(key string) error {
+		userIDs = append(userIDs, strings.TrimRight(key, "/"))
+		return nil
+	})
+
+	return userIDs, err
 }
 
 // GetFullState implements alertstore.AlertStore.

--- a/pkg/alertmanager/alertstore/configdb/store.go
+++ b/pkg/alertmanager/alertstore/configdb/store.go
@@ -93,6 +93,11 @@ func (c *Store) DeleteAlertConfig(ctx context.Context, user string) error {
 	return errReadOnly
 }
 
+// ListUsersWithState implements alertstore.AlertStore.
+func (c *Store) ListUsersWithState(ctx context.Context) ([]string, error) {
+	return nil, errState
+}
+
 // GetFullState implements alertstore.AlertStore.
 func (c *Store) GetFullState(ctx context.Context, user string) (alertspb.FullStateDesc, error) {
 	return alertspb.FullStateDesc{}, errState

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -101,6 +101,11 @@ func (f *Store) DeleteAlertConfig(_ context.Context, user string) error {
 	return errReadOnly
 }
 
+// ListUsersWithState implements alertstore.AlertStore.
+func (f *Store) ListUsersWithState(ctx context.Context) ([]string, error) {
+	return nil, errState
+}
+
 // GetFullState implements alertstore.AlertStore.
 func (f *Store) GetFullState(ctx context.Context, user string) (alertspb.FullStateDesc, error) {
 	return alertspb.FullStateDesc{}, errState

--- a/pkg/alertmanager/alertstore/objectclient/store.go
+++ b/pkg/alertmanager/alertstore/objectclient/store.go
@@ -142,6 +142,11 @@ func (a *AlertStore) DeleteAlertConfig(ctx context.Context, user string) error {
 	return err
 }
 
+// ListUsersWithState implements alertstore.AlertStore.
+func (a *AlertStore) ListUsersWithState(ctx context.Context) ([]string, error) {
+	return nil, errState
+}
+
 // GetFullState implements alertstore.AlertStore.
 func (a *AlertStore) GetFullState(ctx context.Context, user string) (alertspb.FullStateDesc, error) {
 	return alertspb.FullStateDesc{}, errState

--- a/pkg/alertmanager/alertstore/store.go
+++ b/pkg/alertmanager/alertstore/store.go
@@ -40,6 +40,9 @@ type AlertStore interface {
 	// If configuration for the user doesn't exist, no error is reported.
 	DeleteAlertConfig(ctx context.Context, user string) error
 
+	// ListUsersWithState returns the list of users which have had state written.
+	ListUsersWithState(ctx context.Context) ([]string, error)
+
 	// GetFullState loads and returns the alertmanager state for the given user.
 	GetFullState(ctx context.Context, user string) (alertspb.FullStateDesc, error)
 

--- a/pkg/alertmanager/alertstore/store_test.go
+++ b/pkg/alertmanager/alertstore/store_test.go
@@ -220,6 +220,10 @@ func TestBucketAlertStore_GetSetDeleteFullState(t *testing.T) {
 
 		_, err = store.GetFullState(ctx, "user-2")
 		assert.Equal(t, alertspb.ErrNotFound, err)
+
+		users, err := store.ListUsersWithState(ctx)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []string{}, users)
 	}
 
 	// The storage contains users.
@@ -244,6 +248,10 @@ func TestBucketAlertStore_GetSetDeleteFullState(t *testing.T) {
 		exists, err = bucket.Exists(ctx, "alertmanager/user-2/fullstate")
 		require.NoError(t, err)
 		assert.True(t, exists)
+
+		users, err := store.ListUsersWithState(ctx)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []string{"user-1", "user-2"}, users)
 	}
 
 	// The storage has had user-1 deleted.
@@ -257,6 +265,10 @@ func TestBucketAlertStore_GetSetDeleteFullState(t *testing.T) {
 		res, err := store.GetFullState(ctx, "user-2")
 		require.NoError(t, err)
 		assert.Equal(t, state2, res)
+
+		users, err := store.ListUsersWithState(ctx)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []string{"user-2"}, users)
 
 		// Delete again (should be idempotent).
 		require.NoError(t, store.DeleteFullState(ctx, "user-1"))


### PR DESCRIPTION

**What this PR does**:
The same pattern as for cleaning up local state is used - checking for
state objects to clean up whenever the users are synced, and deleting
them if the user has no configuration. This means that we perform an
additional listing operation as opposed to doing it on demand, when the
user configuration is deleted. This does mean that the deletion will be
more robust against e.g. the process dying before cleaning up, or
transient storage errors causing deletion to fail.

Note that a different mechanism is used to check if a remote user state
should be deleted, compared to for local state, because every user may
not be currently active in every alertmanager instance due to sharding.
Therefore, we only delete state for users which have also have no
configuration. The user listing is re-used from the user sync.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [X] ~~Documentation added~~
- [X] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~
