### PR TITLE
Add IsModuleRegistered method to modules.Manager

### DIFF
--- a/pkg/util/modules/modules.go
+++ b/pkg/util/modules/modules.go
@@ -149,6 +149,13 @@ func (m *Manager) IsUserVisibleModule(mod string) bool {
 	return false
 }
 
+// IsModuleRegistered checks if the given module has been registered or not. Returns true
+// if the module has previously been registered via a call to RegisterModule, false otherwise.
+func (m *Manager) IsModuleRegistered(mod string) bool {
+	_, ok := m.modules[mod]
+	return ok
+}
+
 // listDeps recursively gets a list of dependencies for a passed moduleName
 func (m *Manager) listDeps(mod string) []string {
 	deps := m.modules[mod].deps

--- a/pkg/util/modules/modules_test.go
+++ b/pkg/util/modules/modules_test.go
@@ -153,6 +153,20 @@ func TestIsUserVisibleModule(t *testing.T) {
 	assert.False(t, result, "expects result be false when module does not exist")
 }
 
+func TestIsModuleRegistered(t *testing.T) {
+	successModule := "successModule"
+	failureModule := "failureModule"
+
+	m := NewManager()
+	m.RegisterModule(successModule, mockInitFunc)
+
+	var result = m.IsModuleRegistered(successModule)
+	assert.True(t, result, "module '%v' should be registered", successModule)
+
+	result = m.IsModuleRegistered(failureModule)
+	assert.False(t, result, "module '%v' should NOT be registered", failureModule)
+}
+
 func TestDependenciesForModule(t *testing.T) {
 	m := NewManager()
 	m.RegisterModule("test", nil)


### PR DESCRIPTION
Add new method for checking if a module has previously been registered
with the module Manager. This helps in cases where downstream consumers
of Cortex are conditionally adding new modules.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**
- [X] Tests updated
~- [ ] Documentation added~
~- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~
