### PR TITLE
Fix status page if cluster is disabled or sharding is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [ENHANCEMENT] Added `tenant_ids` tag to tracing spans #4147
 * [BUGFIX] Purger: fix `Invalid null value in condition for column range` caused by `nil` value in range for WriteBatch query. #4128
 * [BUGFIX] Ingester: fixed infrequent panic caused by a race condition between TSDB mmap-ed head chunks truncation and queries. #4176
+* [BUGFIX] Alertmanager: fix Alertmanager status page if clustering via gossip is disabled or sharding is enabled. #4184
 * [BUGFIX] Ruler: fix `/ruler/rule_groups` endpoint doesn't work when used with object store. #4182
 
 ## Blocksconvert

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -450,6 +450,14 @@ func TestAlertmanagerSharding(t *testing.T) {
 				}
 			}
 
+			// Endpoint: GET /multitenant_alertmanager/status
+			{
+				for _, c := range clients {
+					_, err := c.GetAlertmanagerStatusPage(context.Background())
+					assert.NoError(t, err)
+				}
+			}
+
 			// Endpoint: GET /status
 			{
 				for _, c := range clients {

--- a/pkg/alertmanager/alertmanager_http.go
+++ b/pkg/alertmanager/alertmanager_http.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	statusPageTemplate = template.Must(template.New("main").Parse(`
+	ringStatusPageTemplate = template.Must(template.New("ringStatusPage").Parse(`
 	<!DOCTYPE html>
 	<html>
 		<head>
@@ -23,14 +23,43 @@ var (
 			<p>{{ .Message }}</p>
 		</body>
 	</html>`))
+
+	statusTemplate = template.Must(template.New("statusPage").Parse(`
+    <!doctype html>
+    <html>
+        <head><title>Cortex Alertmanager Status</title></head>
+        <body>
+            <h1>Cortex Alertmanager Status</h1>
+            {{ if not .ClusterInfo }}
+                <p>Alertmanager gossip-based clustering is disabled.</p>
+            {{ else }}
+                <h2>Node</h2>
+                <dl>
+                    <dt>Name</dt><dd>{{.ClusterInfo.self.Name}}</dd>
+                    <dt>Addr</dt><dd>{{.ClusterInfo.self.Addr}}</dd>
+                    <dt>Port</dt><dd>{{.ClusterInfo.self.Port}}</dd>
+                </dl>
+                <h3>Members</h3>
+                {{ with .ClusterInfo.members }}
+                <table>
+                    <tr><th>Name</th><th>Addr</th></tr>
+                    {{ range . }}
+                    <tr><td>{{ .Name }}</td><td>{{ .Addr }}</td></tr>
+                    {{ end }}
+                </table>
+                {{ else }}
+                <p>No peers</p>
+                {{ end }}
+            {{ end }}
+        </body>
+    </html>`))
 )
 
-func writeMessage(w http.ResponseWriter, message string) {
+func writeRingStatusMessage(w http.ResponseWriter, message string) {
 	w.WriteHeader(http.StatusOK)
-	err := statusPageTemplate.Execute(w, struct {
+	err := ringStatusPageTemplate.Execute(w, struct {
 		Message string
 	}{Message: message})
-
 	if err != nil {
 		level.Error(util_log.Logger).Log("msg", "unable to serve alertmanager ring page", "err", err)
 	}
@@ -38,16 +67,46 @@ func writeMessage(w http.ResponseWriter, message string) {
 
 func (am *MultitenantAlertmanager) RingHandler(w http.ResponseWriter, req *http.Request) {
 	if !am.cfg.ShardingEnabled {
-		writeMessage(w, "Alertmanager has no ring because sharding is disabled.")
+		writeRingStatusMessage(w, "Alertmanager has no ring because sharding is disabled.")
 		return
 	}
 
 	if am.State() != services.Running {
 		// we cannot read the ring before the alertmanager is in Running state,
 		// because that would lead to race condition.
-		writeMessage(w, "Alertmanager is not running yet.")
+		writeRingStatusMessage(w, "Alertmanager is not running yet.")
 		return
 	}
 
 	am.ring.ServeHTTP(w, req)
+}
+
+// GetStatusHandler returns the status handler for this multi-tenant
+// alertmanager.
+func (am *MultitenantAlertmanager) GetStatusHandler() StatusHandler {
+	return StatusHandler{
+		am: am,
+	}
+}
+
+// StatusHandler shows the status of the alertmanager.
+type StatusHandler struct {
+	am *MultitenantAlertmanager
+}
+
+// ServeHTTP serves the status of the alertmanager.
+func (s StatusHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	var clusterInfo map[string]interface{}
+	if s.am.peer != nil {
+		clusterInfo = s.am.peer.Info()
+	}
+	err := statusTemplate.Execute(w, struct {
+		ClusterInfo map[string]interface{}
+	}{
+		ClusterInfo: clusterInfo,
+	})
+	if err != nil {
+		level.Error(util_log.Logger).Log("msg", "unable to serve alertmanager status page", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }

--- a/pkg/alertmanager/alertmanager_http_test.go
+++ b/pkg/alertmanager/alertmanager_http_test.go
@@ -1,0 +1,83 @@
+package alertmanager
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/alertmanager/cluster"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultitenantAlertmanager_GetStatusHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var peer *cluster.Peer
+	{
+		logger := log.NewNopLogger()
+		createPeer := func(peers []string) (*cluster.Peer, error) {
+			return cluster.Create(
+				logger,
+				prometheus.NewRegistry(),
+				"127.0.0.1:0",
+				"",
+				peers,
+				true,
+				cluster.DefaultPushPullInterval,
+				cluster.DefaultGossipInterval,
+				cluster.DefaultTcpTimeout,
+				cluster.DefaultProbeTimeout,
+				cluster.DefaultProbeInterval,
+			)
+		}
+
+		peer1, err := createPeer(nil)
+		require.NoError(t, err)
+		require.NotNil(t, peer1)
+		err = peer1.Join(cluster.DefaultReconnectInterval, cluster.DefaultReconnectTimeout)
+		require.NoError(t, err)
+		go peer1.Settle(ctx, 0*time.Second)
+		require.NoError(t, peer1.WaitReady(ctx))
+		require.Equal(t, peer1.Status(), "ready")
+
+		peer2, err := createPeer([]string{peer1.Self().Address()})
+		require.NoError(t, err)
+		require.NotNil(t, peer2)
+		err = peer2.Join(cluster.DefaultReconnectInterval, cluster.DefaultReconnectTimeout)
+		require.NoError(t, err)
+		go peer2.Settle(ctx, 0*time.Second)
+		peer = peer2
+	}
+
+	for _, tt := range []struct {
+		am        *MultitenantAlertmanager
+		content   string
+		nocontent string
+	}{
+		{
+			am:        &MultitenantAlertmanager{peer: nil},
+			content:   "Alertmanager gossip-based clustering is disabled.",
+			nocontent: "Node",
+		},
+		{
+			am:        &MultitenantAlertmanager{peer: peer},
+			content:   "Members",
+			nocontent: "No peers",
+		},
+	} {
+		req := httptest.NewRequest("GET", "http://alertmanager.cortex/status", nil)
+		w := httptest.NewRecorder()
+		tt.am.GetStatusHandler().ServeHTTP(w, req)
+
+		resp := w.Result()
+		require.Equal(t, 200, w.Code)
+		body, _ := ioutil.ReadAll(resp.Body)
+		content := string(body)
+		require.Contains(t, content, tt.content)
+		require.NotContains(t, content, tt.nocontent)
+	}
+}

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"html/template"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -54,54 +53,14 @@ const (
 	// ringAutoForgetUnhealthyPeriods is how many consecutive timeout periods an unhealthy instance
 	// in the ring will be automatically removed.
 	ringAutoForgetUnhealthyPeriods = 5
-
-	statusPage = `
-<!doctype html>
-<html>
-	<head><title>Cortex Alertmanager Status</title></head>
-	<body>
-		<h1>Cortex Alertmanager Status</h1>
-		<h2>Node</h2>
-		<dl>
-			<dt>Name</dt><dd>{{.self.Name}}</dd>
-			<dt>Addr</dt><dd>{{.self.Addr}}</dd>
-			<dt>Port</dt><dd>{{.self.Port}}</dd>
-		</dl>
-		<h3>Members</h3>
-		{{ with .members }}
-		<table>
-		<tr><th>Name</th><th>Addr</th></tr>
-		{{ range . }}
-		<tr><td>{{ .Name }}</td><td>{{ .Addr }}</td></tr>
-		{{ end }}
-		</table>
-		{{ else }}
-		<p>No peers</p>
-		{{ end }}
-	</body>
-</html>
-`
 )
 
 var (
-	statusTemplate *template.Template
-
 	errInvalidExternalURL                  = errors.New("the configured external URL is invalid: should not end with /")
 	errShardingLegacyStorage               = errors.New("deprecated -alertmanager.storage.* not supported with -alertmanager.sharding-enabled, use -alertmanager-storage.*")
 	errShardingUnsupportedStorage          = errors.New("the configured alertmanager storage backend is not supported when sharding is enabled")
 	errZoneAwarenessEnabledWithoutZoneInfo = errors.New("the configured alertmanager has zone awareness enabled but zone is not set")
 )
-
-func init() {
-	statusTemplate = template.Must(template.New("statusPage").Funcs(map[string]interface{}{
-		"state": func(enabled bool) string {
-			if enabled {
-				return "enabled"
-			}
-			return "disabled"
-		},
-	}).Parse(statusPage))
-}
 
 // MultitenantAlertmanagerConfig is the configuration for a multitenant Alertmanager.
 type MultitenantAlertmanagerConfig struct {
@@ -1072,14 +1031,6 @@ func (am *MultitenantAlertmanager) alertmanagerFromFallbackConfig(userID string)
 	return am.alertmanagers[userID], nil
 }
 
-// GetStatusHandler returns the status handler for this multi-tenant
-// alertmanager.
-func (am *MultitenantAlertmanager) GetStatusHandler() StatusHandler {
-	return StatusHandler{
-		am: am,
-	}
-}
-
 // ReplicateStateForUser attempts to replicate a partial state sent by an alertmanager to its other replicas through the ring.
 func (am *MultitenantAlertmanager) ReplicateStateForUser(ctx context.Context, userID string, part *clusterpb.Part) error {
 	level.Debug(am.logger).Log("msg", "message received for replication", "user", userID, "key", part.Key)
@@ -1115,7 +1066,6 @@ func (am *MultitenantAlertmanager) ReplicateStateForUser(ctx context.Context, us
 // ReadFullStateForUser attempts to read the full state from each replica for user. Note that it will try to obtain and return
 // state from all replicas, but will consider it a success if state is obtained from at least one replica.
 func (am *MultitenantAlertmanager) ReadFullStateForUser(ctx context.Context, userID string) ([]*clusterpb.FullState, error) {
-
 	// Only get the set of replicas which contain the specified user.
 	key := shardByUser(userID)
 	replicationSet, err := am.ring.Get(key, RingOp, nil, nil, nil)
@@ -1312,19 +1262,6 @@ func (am *MultitenantAlertmanager) ReadState(ctx context.Context, req *alertmana
 		Status: alertmanagerpb.READ_OK,
 		State:  state,
 	}, nil
-}
-
-// StatusHandler shows the status of the alertmanager.
-type StatusHandler struct {
-	am *MultitenantAlertmanager
-}
-
-// ServeHTTP serves the status of the alertmanager.
-func (s StatusHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	err := statusTemplate.Execute(w, s.am.peer.Info())
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
 }
 
 // validateTemplateFilename validated the template filename and returns error if it's not valid.


### PR DESCRIPTION
**What this PR does**: status page not working if cluster disabled or sharding enabled, maybe we should hide the status page.


**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
