### PR TITLE
#4147 added `tenant_id` tag to tracing spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * [ENHANCEMENT] Distributor: Added distributors ring status section in the admin page. #4151
 * [BUGFIX] Purger: fix `Invalid null value in condition for column range` caused by `nil` value in range for WriteBatch query. #4128
 * [BUGFIX] Ingester: fixed infrequent panic caused by a race condition between TSDB mmap-ed head chunks truncation and queries. #4176
-* [ENHANCEMENT] Added `tenant_id` tag to tracing spans
+* [ENHANCEMENT] Added `tenant_ids` tag to tracing spans
 
 ## Blocksconvert
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [ENHANCEMENT] Distributor: Added distributors ring status section in the admin page. #4151
 * [BUGFIX] Purger: fix `Invalid null value in condition for column range` caused by `nil` value in range for WriteBatch query. #4128
 * [BUGFIX] Ingester: fixed infrequent panic caused by a race condition between TSDB mmap-ed head chunks truncation and queries. #4176
+* [ENHANCEMENT] Added `tenant_id` tag to tracing spans
 
 ## Blocksconvert
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@
   * `cortex_alertmanager_state_persist_failed_total`
 * [ENHANCEMENT] Blocks storage: support ingesting exemplars.  Enabled by setting new CLI flag `-blocks-storage.tsdb.max-exemplars=<n>` or config option `blocks_storage.tsdb.max_exemplars` to positive value. #4124
 * [ENHANCEMENT] Distributor: Added distributors ring status section in the admin page. #4151
+* [ENHANCEMENT] Added `tenant_ids` tag to tracing spans #4147
 * [BUGFIX] Purger: fix `Invalid null value in condition for column range` caused by `nil` value in range for WriteBatch query. #4128
 * [BUGFIX] Ingester: fixed infrequent panic caused by a race condition between TSDB mmap-ed head chunks truncation and queries. #4176
-* [ENHANCEMENT] Added `tenant_ids` tag to tracing spans
 
 ## Blocksconvert
 

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -137,7 +137,7 @@ type mergeQuerier struct {
 // For the label "original_" + `idLabelName it will return all the values
 // of the underlying queriers for `idLabelName`.
 func (m *mergeQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
-	log, _ := spanlogger.New(m.ctx, "mergeQuerier.labelValues")
+	log, _ := spanlogger.New(m.ctx, "mergeQuerier.LabelValues")
 	defer log.Span.Finish()
 	if name == m.idLabelName {
 		return m.ids, nil, nil
@@ -158,7 +158,7 @@ func (m *mergeQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]
 // queriers. It also adds the `idLabelName` and if present in the original
 // results the original `idLabelName`.
 func (m *mergeQuerier) LabelNames() ([]string, storage.Warnings, error) {
-	log, _ := spanlogger.New(m.ctx, "mergeQuerier.labelNames")
+	log, _ := spanlogger.New(m.ctx, "mergeQuerier.LabelNames")
 	defer log.Span.Finish()
 	labelNames, warnings, err := m.mergeDistinctStringSlice(func(ctx context.Context, q storage.Querier) ([]string, storage.Warnings, error) {
 		return q.LabelNames()
@@ -280,7 +280,7 @@ type selectJob struct {
 // matching. The forwarded labelSelector is not containing those that operate
 // on `idLabelName`.
 func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	log, ctx := spanlogger.New(m.ctx, "mergeQuerier.select")
+	log, ctx := spanlogger.New(m.ctx, "mergeQuerier.Select")
 	defer log.Span.Finish()
 	matchedValues, filteredMatchers := filterValuesByMatchers(m.idLabelName, m.ids, matchers...)
 	var jobs = make([]interface{}, len(matchedValues))

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util/concurrency"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
 const (
@@ -96,6 +97,9 @@ type mergeQueryable struct {
 // Querier returns a new mergeQuerier, which aggregates results from multiple
 // underlying queriers into a single result.
 func (m *mergeQueryable) Querier(ctx context.Context, mint int64, maxt int64) (storage.Querier, error) {
+	// TODO: it's necessary to think how to override context inside querier
+	//  to mark spans created inside querier as child of a span created inside
+	//  methods of merged querier.
 	ids, queriers, err := m.callback(ctx, mint, maxt)
 	if err != nil {
 		return nil, err
@@ -133,6 +137,8 @@ type mergeQuerier struct {
 // For the label "original_" + `idLabelName it will return all the values
 // of the underlying queriers for `idLabelName`.
 func (m *mergeQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+	log, _ := spanlogger.New(m.ctx, "mergeQuerier.labelValues")
+	defer log.Span.Finish()
 	if name == m.idLabelName {
 		return m.ids, nil, nil
 	}
@@ -152,6 +158,8 @@ func (m *mergeQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]
 // queriers. It also adds the `idLabelName` and if present in the original
 // results the original `idLabelName`.
 func (m *mergeQuerier) LabelNames() ([]string, storage.Warnings, error) {
+	log, _ := spanlogger.New(m.ctx, "mergeQuerier.labelNames")
+	defer log.Span.Finish()
 	labelNames, warnings, err := m.mergeDistinctStringSlice(func(ctx context.Context, q storage.Querier) ([]string, storage.Warnings, error) {
 		return q.LabelNames()
 	})
@@ -272,6 +280,8 @@ type selectJob struct {
 // matching. The forwarded labelSelector is not containing those that operate
 // on `idLabelName`.
 func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	log, ctx := spanlogger.New(m.ctx, "mergeQuerier.select")
+	defer log.Span.Finish()
 	matchedValues, filteredMatchers := filterValuesByMatchers(m.idLabelName, m.ids, matchers...)
 	var jobs = make([]interface{}, len(matchedValues))
 	var seriesSets = make([]storage.SeriesSet, len(matchedValues))
@@ -305,7 +315,7 @@ func (m *mergeQuerier) Select(sortSeries bool, hints *storage.SelectHints, match
 		return nil
 	}
 
-	err := concurrency.ForEach(m.ctx, jobs, maxConcurrency, run)
+	err := concurrency.ForEach(ctx, jobs, maxConcurrency, run)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -137,7 +137,7 @@ type mergeQuerier struct {
 // For the label "original_" + `idLabelName it will return all the values
 // of the underlying queriers for `idLabelName`.
 func (m *mergeQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
-	log, ctx := spanlogger.New(m.ctx, "mergeQuerier.LabelValues")
+	log, _ := spanlogger.New(m.ctx, "mergeQuerier.LabelValues")
 	defer log.Span.Finish()
 	if name == m.idLabelName {
 		return m.ids, nil, nil
@@ -149,7 +149,7 @@ func (m *mergeQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]
 		name = m.idLabelName
 	}
 
-	return m.mergeDistinctStringSlice(ctx, func(ctx context.Context,
+	return m.mergeDistinctStringSlice(func(ctx context.Context,
 		q storage.Querier) ([]string, storage.Warnings, error) {
 		return q.LabelValues(name, matchers...)
 	})
@@ -159,10 +159,9 @@ func (m *mergeQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]
 // queriers. It also adds the `idLabelName` and if present in the original
 // results the original `idLabelName`.
 func (m *mergeQuerier) LabelNames() ([]string, storage.Warnings, error) {
-	log, ctx := spanlogger.New(m.ctx, "mergeQuerier.LabelNames")
+	log, _ := spanlogger.New(m.ctx, "mergeQuerier.LabelNames")
 	defer log.Span.Finish()
-	labelNames, warnings, err := m.mergeDistinctStringSlice(ctx, func(ctx context.Context,
-		q storage.Querier) ([]string, storage.Warnings, error) {
+	labelNames, warnings, err := m.mergeDistinctStringSlice(func(ctx context.Context, q storage.Querier) ([]string, storage.Warnings, error) {
 		return q.LabelNames()
 	})
 	if err != nil {
@@ -206,8 +205,7 @@ type stringSliceFuncJob struct {
 // on per querier in parallel. It removes duplicates and sorts the result. It
 // doesn't require the output of the stringSliceFunc to be sorted, as results
 // of LabelValues are not sorted.
-func (m *mergeQuerier) mergeDistinctStringSlice(ctx context.Context,
-	f stringSliceFunc) ([]string, storage.Warnings, error) {
+func (m *mergeQuerier) mergeDistinctStringSlice(f stringSliceFunc) ([]string, storage.Warnings, error) {
 	var jobs = make([]interface{}, len(m.ids))
 
 	for pos := range m.ids {
@@ -232,7 +230,7 @@ func (m *mergeQuerier) mergeDistinctStringSlice(ctx context.Context,
 		return nil
 	}
 
-	err := concurrency.ForEach(ctx, jobs, maxConcurrency, run)
+	err := concurrency.ForEach(m.ctx, jobs, maxConcurrency, run)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -149,8 +149,7 @@ func (m *mergeQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]
 		name = m.idLabelName
 	}
 
-	return m.mergeDistinctStringSlice(func(ctx context.Context,
-		q storage.Querier) ([]string, storage.Warnings, error) {
+	return m.mergeDistinctStringSlice(func(ctx context.Context, q storage.Querier) ([]string, storage.Warnings, error) {
 		return q.LabelValues(name, matchers...)
 	})
 }

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/querier/series"
 	"github.com/cortexproject/cortex/pkg/tenant"
-	sl "github.com/cortexproject/cortex/pkg/util/spanlogger"
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
 const (
@@ -143,7 +143,7 @@ func (m *mockSeriesSet) Warnings() storage.Warnings {
 }
 
 func (m mockTenantQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	log, _ := sl.New(m.ctx, "mockTenantQuerier.select")
+	log, _ := spanlogger.New(m.ctx, "mockTenantQuerier.select")
 	defer log.Span.Finish()
 	var matrix model.Matrix
 
@@ -507,9 +507,9 @@ func TestTracingMergeQueryable(t *testing.T) {
 
 	require.NoError(t, seriesSet.Err())
 	spans := mockTracer.FinishedSpans()
-	assertSpanExist(t, spans, "mergeQuerier.select", map[string]string{sl.TenantIDTagName: "team-a|team-b"})
-	assertSpanExist(t, spans, "mockTenantQuerier.select", map[string]string{sl.TenantIDTagName: "team-a"})
-	assertSpanExist(t, spans, "mockTenantQuerier.select", map[string]string{sl.TenantIDTagName: "team-b"})
+	assertSpanExist(t, spans, "mergeQuerier.select", map[string]string{spanlogger.TenantIDTagName: "team-a|team-b"})
+	assertSpanExist(t, spans, "mockTenantQuerier.select", map[string]string{spanlogger.TenantIDTagName: "team-a"})
+	assertSpanExist(t, spans, "mockTenantQuerier.select", map[string]string{spanlogger.TenantIDTagName: "team-b"})
 }
 
 func assertSpanExist(t *testing.T,

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -508,7 +508,7 @@ func TestTracingMergeQueryable(t *testing.T) {
 
 	require.NoError(t, seriesSet.Err())
 	spans := mockTracer.FinishedSpans()
-	assertSpanExist(t, spans, "mergeQuerier.select", expectedTag{spanlogger.TenantIDTagName,
+	assertSpanExist(t, spans, "mergeQuerier.Select", expectedTag{spanlogger.TenantIDTagName,
 		[]string{"team-a", "team-b"}})
 	assertSpanExist(t, spans, "mockTenantQuerier.select", expectedTag{spanlogger.TenantIDTagName,
 		[]string{"team-a"}})

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	sl "github.com/cortexproject/cortex/pkg/util/spanlogger"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/prometheus/common/model"
@@ -21,6 +20,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/querier/series"
 	"github.com/cortexproject/cortex/pkg/tenant"
+	sl "github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
 const (
@@ -507,9 +507,9 @@ func TestTracingMergeQueryable(t *testing.T) {
 
 	require.NoError(t, seriesSet.Err())
 	spans := mockTracer.FinishedSpans()
-	assertSpanExist(t, spans, "mergeQuerier.select", map[string]string{sl.TenantIdTagName: "team-a|team-b"})
-	assertSpanExist(t, spans, "mockTenantQuerier.select", map[string]string{sl.TenantIdTagName: "team-a"})
-	assertSpanExist(t, spans, "mockTenantQuerier.select", map[string]string{sl.TenantIdTagName: "team-b"})
+	assertSpanExist(t, spans, "mergeQuerier.select", map[string]string{sl.TenantIDTagName: "team-a|team-b"})
+	assertSpanExist(t, spans, "mockTenantQuerier.select", map[string]string{sl.TenantIDTagName: "team-a"})
+	assertSpanExist(t, spans, "mockTenantQuerier.select", map[string]string{sl.TenantIDTagName: "team-b"})
 }
 
 func assertSpanExist(t *testing.T,

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -8,15 +8,15 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
-	"github.com/weaveworks/common/user"
 
+	"github.com/cortexproject/cortex/pkg/tenant"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 type loggerCtxMarker struct{}
 
 const (
-	TenantIdTagName = "tenant_id"
+	TenantIDTagName = "tenant_id"
 )
 
 var (
@@ -39,8 +39,8 @@ func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, 
 // retrieved with FromContext or FromContextWithFallback.
 func NewWithLogger(ctx context.Context, l log.Logger, method string, kvps ...interface{}) (*SpanLogger, context.Context) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, method)
-	if orgId, err := user.ExtractOrgID(ctx); err == nil {
-		span.SetTag(TenantIdTagName, orgId)
+	if ids, _ := tenant.TenantIDs(ctx); ids != nil {
+		span.SetTag(TenantIDTagName, tenant.JoinTenantIDs(ids))
 	}
 	logger := &SpanLogger{
 		Logger: log.With(util_log.WithContext(ctx, l), "method", method),

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -40,7 +40,7 @@ func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, 
 func NewWithLogger(ctx context.Context, l log.Logger, method string, kvps ...interface{}) (*SpanLogger, context.Context) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, method)
 	if ids, _ := tenant.TenantIDs(ctx); ids != nil {
-		span.SetTag(TenantIDTagName, tenant.JoinTenantIDs(ids))
+		span.SetTag(TenantIDTagName, ids)
 	}
 	logger := &SpanLogger{
 		Logger: log.With(util_log.WithContext(ctx, l), "method", method),

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -16,7 +16,7 @@ import (
 type loggerCtxMarker struct{}
 
 const (
-	TenantIDTagName = "tenant_id"
+	TenantIDTagName = "tenant_ids"
 )
 
 var (
@@ -39,7 +39,7 @@ func New(ctx context.Context, method string, kvps ...interface{}) (*SpanLogger, 
 // retrieved with FromContext or FromContextWithFallback.
 func NewWithLogger(ctx context.Context, l log.Logger, method string, kvps ...interface{}) (*SpanLogger, context.Context) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, method)
-	if ids, _ := tenant.TenantIDs(ctx); ids != nil {
+	if ids, _ := tenant.TenantIDs(ctx); len(ids) > 0 {
 		span.SetTag(TenantIDTagName, ids)
 	}
 	logger := &SpanLogger{

--- a/pkg/util/spanlogger/spanlogger_test.go
+++ b/pkg/util/spanlogger/spanlogger_test.go
@@ -50,7 +50,7 @@ func TestSpanLogger_CustomLogger(t *testing.T) {
 func TestSpanCreatedWithTenantTag(t *testing.T) {
 	mockSpan := createSpan(user.InjectOrgID(context.Background(), "team-a"))
 
-	require.Equal(t, "team-a", mockSpan.Tag(TenantIDTagName))
+	require.Equal(t, []string{"team-a"}, mockSpan.Tag(TenantIDTagName))
 }
 
 func TestSpanCreatedWithoutTenantTag(t *testing.T) {

--- a/pkg/util/spanlogger/spanlogger_test.go
+++ b/pkg/util/spanlogger/spanlogger_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 
 	"github.com/go-kit/kit/log"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
 )
 
 func TestSpanLogger_Log(t *testing.T) {
@@ -42,6 +45,27 @@ func TestSpanLogger_CustomLogger(t *testing.T) {
 		{"msg", "fallback spanlogger"},
 	}
 	require.Equal(t, expect, logged)
+}
+
+func TestSpanCreatedWithTenantTag(t *testing.T) {
+	mockSpan := createSpan(user.InjectOrgID(context.Background(), "team-a"))
+
+	require.Equal(t, "team-a", mockSpan.Tag(TenantIdTagName))
+}
+
+func TestSpanCreatedWithoutTenantTag(t *testing.T) {
+	mockSpan := createSpan(context.Background())
+
+	_, exist := mockSpan.Tags()[TenantIdTagName]
+	require.False(t, exist)
+}
+
+func createSpan(ctx context.Context) *mocktracer.MockSpan {
+	mockTracer := mocktracer.New()
+	opentracing.SetGlobalTracer(mockTracer)
+
+	logger, _ := New(ctx, "name")
+	return logger.Span.(*mocktracer.MockSpan)
 }
 
 type funcLogger func(keyvals ...interface{}) error

--- a/pkg/util/spanlogger/spanlogger_test.go
+++ b/pkg/util/spanlogger/spanlogger_test.go
@@ -50,13 +50,13 @@ func TestSpanLogger_CustomLogger(t *testing.T) {
 func TestSpanCreatedWithTenantTag(t *testing.T) {
 	mockSpan := createSpan(user.InjectOrgID(context.Background(), "team-a"))
 
-	require.Equal(t, "team-a", mockSpan.Tag(TenantIdTagName))
+	require.Equal(t, "team-a", mockSpan.Tag(TenantIDTagName))
 }
 
 func TestSpanCreatedWithoutTenantTag(t *testing.T) {
 	mockSpan := createSpan(context.Background())
 
-	_, exist := mockSpan.Tags()[TenantIdTagName]
+	_, exist := mockSpan.Tags()[TenantIDTagName]
 	require.False(t, exist)
 }
 

--- a/vendor/github.com/opentracing/opentracing-go/mocktracer/mocklogrecord.go
+++ b/vendor/github.com/opentracing/opentracing-go/mocktracer/mocklogrecord.go
@@ -1,0 +1,105 @@
+package mocktracer
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/opentracing/opentracing-go/log"
+)
+
+// MockLogRecord represents data logged to a Span via Span.LogFields or
+// Span.LogKV.
+type MockLogRecord struct {
+	Timestamp time.Time
+	Fields    []MockKeyValue
+}
+
+// MockKeyValue represents a single key:value pair.
+type MockKeyValue struct {
+	Key string
+
+	// All MockLogRecord values are coerced to strings via fmt.Sprint(), though
+	// we retain their type separately.
+	ValueKind   reflect.Kind
+	ValueString string
+}
+
+// EmitString belongs to the log.Encoder interface
+func (m *MockKeyValue) EmitString(key, value string) {
+	m.Key = key
+	m.ValueKind = reflect.TypeOf(value).Kind()
+	m.ValueString = fmt.Sprint(value)
+}
+
+// EmitBool belongs to the log.Encoder interface
+func (m *MockKeyValue) EmitBool(key string, value bool) {
+	m.Key = key
+	m.ValueKind = reflect.TypeOf(value).Kind()
+	m.ValueString = fmt.Sprint(value)
+}
+
+// EmitInt belongs to the log.Encoder interface
+func (m *MockKeyValue) EmitInt(key string, value int) {
+	m.Key = key
+	m.ValueKind = reflect.TypeOf(value).Kind()
+	m.ValueString = fmt.Sprint(value)
+}
+
+// EmitInt32 belongs to the log.Encoder interface
+func (m *MockKeyValue) EmitInt32(key string, value int32) {
+	m.Key = key
+	m.ValueKind = reflect.TypeOf(value).Kind()
+	m.ValueString = fmt.Sprint(value)
+}
+
+// EmitInt64 belongs to the log.Encoder interface
+func (m *MockKeyValue) EmitInt64(key string, value int64) {
+	m.Key = key
+	m.ValueKind = reflect.TypeOf(value).Kind()
+	m.ValueString = fmt.Sprint(value)
+}
+
+// EmitUint32 belongs to the log.Encoder interface
+func (m *MockKeyValue) EmitUint32(key string, value uint32) {
+	m.Key = key
+	m.ValueKind = reflect.TypeOf(value).Kind()
+	m.ValueString = fmt.Sprint(value)
+}
+
+// EmitUint64 belongs to the log.Encoder interface
+func (m *MockKeyValue) EmitUint64(key string, value uint64) {
+	m.Key = key
+	m.ValueKind = reflect.TypeOf(value).Kind()
+	m.ValueString = fmt.Sprint(value)
+}
+
+// EmitFloat32 belongs to the log.Encoder interface
+func (m *MockKeyValue) EmitFloat32(key string, value float32) {
+	m.Key = key
+	m.ValueKind = reflect.TypeOf(value).Kind()
+	m.ValueString = fmt.Sprint(value)
+}
+
+// EmitFloat64 belongs to the log.Encoder interface
+func (m *MockKeyValue) EmitFloat64(key string, value float64) {
+	m.Key = key
+	m.ValueKind = reflect.TypeOf(value).Kind()
+	m.ValueString = fmt.Sprint(value)
+}
+
+// EmitObject belongs to the log.Encoder interface
+func (m *MockKeyValue) EmitObject(key string, value interface{}) {
+	m.Key = key
+	m.ValueKind = reflect.TypeOf(value).Kind()
+	m.ValueString = fmt.Sprint(value)
+}
+
+// EmitLazyLogger belongs to the log.Encoder interface
+func (m *MockKeyValue) EmitLazyLogger(value log.LazyLogger) {
+	var meta MockKeyValue
+	value(&meta)
+	m.Key = meta.Key
+	m.ValueKind = meta.ValueKind
+	m.ValueString = meta.ValueString
+}

--- a/vendor/github.com/opentracing/opentracing-go/mocktracer/mockspan.go
+++ b/vendor/github.com/opentracing/opentracing-go/mocktracer/mockspan.go
@@ -1,0 +1,284 @@
+package mocktracer
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
+)
+
+// MockSpanContext is an opentracing.SpanContext implementation.
+//
+// It is entirely unsuitable for production use, but appropriate for tests
+// that want to verify tracing behavior in other frameworks/applications.
+//
+// By default all spans have Sampled=true flag, unless {"sampling.priority": 0}
+// tag is set.
+type MockSpanContext struct {
+	TraceID int
+	SpanID  int
+	Sampled bool
+	Baggage map[string]string
+}
+
+var mockIDSource = uint32(42)
+
+func nextMockID() int {
+	return int(atomic.AddUint32(&mockIDSource, 1))
+}
+
+// ForeachBaggageItem belongs to the SpanContext interface
+func (c MockSpanContext) ForeachBaggageItem(handler func(k, v string) bool) {
+	for k, v := range c.Baggage {
+		if !handler(k, v) {
+			break
+		}
+	}
+}
+
+// WithBaggageItem creates a new context with an extra baggage item.
+func (c MockSpanContext) WithBaggageItem(key, value string) MockSpanContext {
+	var newBaggage map[string]string
+	if c.Baggage == nil {
+		newBaggage = map[string]string{key: value}
+	} else {
+		newBaggage = make(map[string]string, len(c.Baggage)+1)
+		for k, v := range c.Baggage {
+			newBaggage[k] = v
+		}
+		newBaggage[key] = value
+	}
+	// Use positional parameters so the compiler will help catch new fields.
+	return MockSpanContext{c.TraceID, c.SpanID, c.Sampled, newBaggage}
+}
+
+// MockSpan is an opentracing.Span implementation that exports its internal
+// state for testing purposes.
+type MockSpan struct {
+	sync.RWMutex
+
+	ParentID int
+
+	OperationName string
+	StartTime     time.Time
+	FinishTime    time.Time
+
+	// All of the below are protected by the embedded RWMutex.
+	SpanContext MockSpanContext
+	tags        map[string]interface{}
+	logs        []MockLogRecord
+	tracer      *MockTracer
+}
+
+func newMockSpan(t *MockTracer, name string, opts opentracing.StartSpanOptions) *MockSpan {
+	tags := opts.Tags
+	if tags == nil {
+		tags = map[string]interface{}{}
+	}
+	traceID := nextMockID()
+	parentID := int(0)
+	var baggage map[string]string
+	sampled := true
+	if len(opts.References) > 0 {
+		traceID = opts.References[0].ReferencedContext.(MockSpanContext).TraceID
+		parentID = opts.References[0].ReferencedContext.(MockSpanContext).SpanID
+		sampled = opts.References[0].ReferencedContext.(MockSpanContext).Sampled
+		baggage = opts.References[0].ReferencedContext.(MockSpanContext).Baggage
+	}
+	spanContext := MockSpanContext{traceID, nextMockID(), sampled, baggage}
+	startTime := opts.StartTime
+	if startTime.IsZero() {
+		startTime = time.Now()
+	}
+	return &MockSpan{
+		ParentID:      parentID,
+		OperationName: name,
+		StartTime:     startTime,
+		tags:          tags,
+		logs:          []MockLogRecord{},
+		SpanContext:   spanContext,
+
+		tracer: t,
+	}
+}
+
+// Tags returns a copy of tags accumulated by the span so far
+func (s *MockSpan) Tags() map[string]interface{} {
+	s.RLock()
+	defer s.RUnlock()
+	tags := make(map[string]interface{})
+	for k, v := range s.tags {
+		tags[k] = v
+	}
+	return tags
+}
+
+// Tag returns a single tag
+func (s *MockSpan) Tag(k string) interface{} {
+	s.RLock()
+	defer s.RUnlock()
+	return s.tags[k]
+}
+
+// Logs returns a copy of logs accumulated in the span so far
+func (s *MockSpan) Logs() []MockLogRecord {
+	s.RLock()
+	defer s.RUnlock()
+	logs := make([]MockLogRecord, len(s.logs))
+	copy(logs, s.logs)
+	return logs
+}
+
+// Context belongs to the Span interface
+func (s *MockSpan) Context() opentracing.SpanContext {
+	s.Lock()
+	defer s.Unlock()
+	return s.SpanContext
+}
+
+// SetTag belongs to the Span interface
+func (s *MockSpan) SetTag(key string, value interface{}) opentracing.Span {
+	s.Lock()
+	defer s.Unlock()
+	if key == string(ext.SamplingPriority) {
+		if v, ok := value.(uint16); ok {
+			s.SpanContext.Sampled = v > 0
+			return s
+		}
+		if v, ok := value.(int); ok {
+			s.SpanContext.Sampled = v > 0
+			return s
+		}
+	}
+	s.tags[key] = value
+	return s
+}
+
+// SetBaggageItem belongs to the Span interface
+func (s *MockSpan) SetBaggageItem(key, val string) opentracing.Span {
+	s.Lock()
+	defer s.Unlock()
+	s.SpanContext = s.SpanContext.WithBaggageItem(key, val)
+	return s
+}
+
+// BaggageItem belongs to the Span interface
+func (s *MockSpan) BaggageItem(key string) string {
+	s.RLock()
+	defer s.RUnlock()
+	return s.SpanContext.Baggage[key]
+}
+
+// Finish belongs to the Span interface
+func (s *MockSpan) Finish() {
+	s.Lock()
+	s.FinishTime = time.Now()
+	s.Unlock()
+	s.tracer.recordSpan(s)
+}
+
+// FinishWithOptions belongs to the Span interface
+func (s *MockSpan) FinishWithOptions(opts opentracing.FinishOptions) {
+	s.Lock()
+	s.FinishTime = opts.FinishTime
+	s.Unlock()
+
+	// Handle any late-bound LogRecords.
+	for _, lr := range opts.LogRecords {
+		s.logFieldsWithTimestamp(lr.Timestamp, lr.Fields...)
+	}
+	// Handle (deprecated) BulkLogData.
+	for _, ld := range opts.BulkLogData {
+		if ld.Payload != nil {
+			s.logFieldsWithTimestamp(
+				ld.Timestamp,
+				log.String("event", ld.Event),
+				log.Object("payload", ld.Payload))
+		} else {
+			s.logFieldsWithTimestamp(
+				ld.Timestamp,
+				log.String("event", ld.Event))
+		}
+	}
+
+	s.tracer.recordSpan(s)
+}
+
+// String allows printing span for debugging
+func (s *MockSpan) String() string {
+	return fmt.Sprintf(
+		"traceId=%d, spanId=%d, parentId=%d, sampled=%t, name=%s",
+		s.SpanContext.TraceID, s.SpanContext.SpanID, s.ParentID,
+		s.SpanContext.Sampled, s.OperationName)
+}
+
+// LogFields belongs to the Span interface
+func (s *MockSpan) LogFields(fields ...log.Field) {
+	s.logFieldsWithTimestamp(time.Now(), fields...)
+}
+
+// The caller MUST NOT hold s.Lock
+func (s *MockSpan) logFieldsWithTimestamp(ts time.Time, fields ...log.Field) {
+	lr := MockLogRecord{
+		Timestamp: ts,
+		Fields:    make([]MockKeyValue, len(fields)),
+	}
+	for i, f := range fields {
+		outField := &(lr.Fields[i])
+		f.Marshal(outField)
+	}
+
+	s.Lock()
+	defer s.Unlock()
+	s.logs = append(s.logs, lr)
+}
+
+// LogKV belongs to the Span interface.
+//
+// This implementations coerces all "values" to strings, though that is not
+// something all implementations need to do. Indeed, a motivated person can and
+// probably should have this do a typed switch on the values.
+func (s *MockSpan) LogKV(keyValues ...interface{}) {
+	if len(keyValues)%2 != 0 {
+		s.LogFields(log.Error(fmt.Errorf("Non-even keyValues len: %v", len(keyValues))))
+		return
+	}
+	fields, err := log.InterleavedKVToFields(keyValues...)
+	if err != nil {
+		s.LogFields(log.Error(err), log.String("function", "LogKV"))
+		return
+	}
+	s.LogFields(fields...)
+}
+
+// LogEvent belongs to the Span interface
+func (s *MockSpan) LogEvent(event string) {
+	s.LogFields(log.String("event", event))
+}
+
+// LogEventWithPayload belongs to the Span interface
+func (s *MockSpan) LogEventWithPayload(event string, payload interface{}) {
+	s.LogFields(log.String("event", event), log.Object("payload", payload))
+}
+
+// Log belongs to the Span interface
+func (s *MockSpan) Log(data opentracing.LogData) {
+	panic("MockSpan.Log() no longer supported")
+}
+
+// SetOperationName belongs to the Span interface
+func (s *MockSpan) SetOperationName(operationName string) opentracing.Span {
+	s.Lock()
+	defer s.Unlock()
+	s.OperationName = operationName
+	return s
+}
+
+// Tracer belongs to the Span interface
+func (s *MockSpan) Tracer() opentracing.Tracer {
+	return s.tracer
+}

--- a/vendor/github.com/opentracing/opentracing-go/mocktracer/mocktracer.go
+++ b/vendor/github.com/opentracing/opentracing-go/mocktracer/mocktracer.go
@@ -1,0 +1,105 @@
+package mocktracer
+
+import (
+	"sync"
+
+	"github.com/opentracing/opentracing-go"
+)
+
+// New returns a MockTracer opentracing.Tracer implementation that's intended
+// to facilitate tests of OpenTracing instrumentation.
+func New() *MockTracer {
+	t := &MockTracer{
+		finishedSpans: []*MockSpan{},
+		injectors:     make(map[interface{}]Injector),
+		extractors:    make(map[interface{}]Extractor),
+	}
+
+	// register default injectors/extractors
+	textPropagator := new(TextMapPropagator)
+	t.RegisterInjector(opentracing.TextMap, textPropagator)
+	t.RegisterExtractor(opentracing.TextMap, textPropagator)
+
+	httpPropagator := &TextMapPropagator{HTTPHeaders: true}
+	t.RegisterInjector(opentracing.HTTPHeaders, httpPropagator)
+	t.RegisterExtractor(opentracing.HTTPHeaders, httpPropagator)
+
+	return t
+}
+
+// MockTracer is only intended for testing OpenTracing instrumentation.
+//
+// It is entirely unsuitable for production use, but appropriate for tests
+// that want to verify tracing behavior in other frameworks/applications.
+type MockTracer struct {
+	sync.RWMutex
+	finishedSpans []*MockSpan
+	injectors     map[interface{}]Injector
+	extractors    map[interface{}]Extractor
+}
+
+// FinishedSpans returns all spans that have been Finish()'ed since the
+// MockTracer was constructed or since the last call to its Reset() method.
+func (t *MockTracer) FinishedSpans() []*MockSpan {
+	t.RLock()
+	defer t.RUnlock()
+	spans := make([]*MockSpan, len(t.finishedSpans))
+	copy(spans, t.finishedSpans)
+	return spans
+}
+
+// Reset clears the internally accumulated finished spans. Note that any
+// extant MockSpans will still append to finishedSpans when they Finish(),
+// even after a call to Reset().
+func (t *MockTracer) Reset() {
+	t.Lock()
+	defer t.Unlock()
+	t.finishedSpans = []*MockSpan{}
+}
+
+// StartSpan belongs to the Tracer interface.
+func (t *MockTracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
+	sso := opentracing.StartSpanOptions{}
+	for _, o := range opts {
+		o.Apply(&sso)
+	}
+	return newMockSpan(t, operationName, sso)
+}
+
+// RegisterInjector registers injector for given format
+func (t *MockTracer) RegisterInjector(format interface{}, injector Injector) {
+	t.injectors[format] = injector
+}
+
+// RegisterExtractor registers extractor for given format
+func (t *MockTracer) RegisterExtractor(format interface{}, extractor Extractor) {
+	t.extractors[format] = extractor
+}
+
+// Inject belongs to the Tracer interface.
+func (t *MockTracer) Inject(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {
+	spanContext, ok := sm.(MockSpanContext)
+	if !ok {
+		return opentracing.ErrInvalidSpanContext
+	}
+	injector, ok := t.injectors[format]
+	if !ok {
+		return opentracing.ErrUnsupportedFormat
+	}
+	return injector.Inject(spanContext, carrier)
+}
+
+// Extract belongs to the Tracer interface.
+func (t *MockTracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
+	extractor, ok := t.extractors[format]
+	if !ok {
+		return nil, opentracing.ErrUnsupportedFormat
+	}
+	return extractor.Extract(carrier)
+}
+
+func (t *MockTracer) recordSpan(span *MockSpan) {
+	t.Lock()
+	defer t.Unlock()
+	t.finishedSpans = append(t.finishedSpans, span)
+}

--- a/vendor/github.com/opentracing/opentracing-go/mocktracer/propagation.go
+++ b/vendor/github.com/opentracing/opentracing-go/mocktracer/propagation.go
@@ -1,0 +1,120 @@
+package mocktracer
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/opentracing/opentracing-go"
+)
+
+const mockTextMapIdsPrefix = "mockpfx-ids-"
+const mockTextMapBaggagePrefix = "mockpfx-baggage-"
+
+var emptyContext = MockSpanContext{}
+
+// Injector is responsible for injecting SpanContext instances in a manner suitable
+// for propagation via a format-specific "carrier" object. Typically the
+// injection will take place across an RPC boundary, but message queues and
+// other IPC mechanisms are also reasonable places to use an Injector.
+type Injector interface {
+	// Inject takes `SpanContext` and injects it into `carrier`. The actual type
+	// of `carrier` depends on the `format` passed to `Tracer.Inject()`.
+	//
+	// Implementations may return opentracing.ErrInvalidCarrier or any other
+	// implementation-specific error if injection fails.
+	Inject(ctx MockSpanContext, carrier interface{}) error
+}
+
+// Extractor is responsible for extracting SpanContext instances from a
+// format-specific "carrier" object. Typically the extraction will take place
+// on the server side of an RPC boundary, but message queues and other IPC
+// mechanisms are also reasonable places to use an Extractor.
+type Extractor interface {
+	// Extract decodes a SpanContext instance from the given `carrier`,
+	// or (nil, opentracing.ErrSpanContextNotFound) if no context could
+	// be found in the `carrier`.
+	Extract(carrier interface{}) (MockSpanContext, error)
+}
+
+// TextMapPropagator implements Injector/Extractor for TextMap and HTTPHeaders formats.
+type TextMapPropagator struct {
+	HTTPHeaders bool
+}
+
+// Inject implements the Injector interface
+func (t *TextMapPropagator) Inject(spanContext MockSpanContext, carrier interface{}) error {
+	writer, ok := carrier.(opentracing.TextMapWriter)
+	if !ok {
+		return opentracing.ErrInvalidCarrier
+	}
+	// Ids:
+	writer.Set(mockTextMapIdsPrefix+"traceid", strconv.Itoa(spanContext.TraceID))
+	writer.Set(mockTextMapIdsPrefix+"spanid", strconv.Itoa(spanContext.SpanID))
+	writer.Set(mockTextMapIdsPrefix+"sampled", fmt.Sprint(spanContext.Sampled))
+	// Baggage:
+	for baggageKey, baggageVal := range spanContext.Baggage {
+		safeVal := baggageVal
+		if t.HTTPHeaders {
+			safeVal = url.QueryEscape(baggageVal)
+		}
+		writer.Set(mockTextMapBaggagePrefix+baggageKey, safeVal)
+	}
+	return nil
+}
+
+// Extract implements the Extractor interface
+func (t *TextMapPropagator) Extract(carrier interface{}) (MockSpanContext, error) {
+	reader, ok := carrier.(opentracing.TextMapReader)
+	if !ok {
+		return emptyContext, opentracing.ErrInvalidCarrier
+	}
+	rval := MockSpanContext{0, 0, true, nil}
+	err := reader.ForeachKey(func(key, val string) error {
+		lowerKey := strings.ToLower(key)
+		switch {
+		case lowerKey == mockTextMapIdsPrefix+"traceid":
+			// Ids:
+			i, err := strconv.Atoi(val)
+			if err != nil {
+				return err
+			}
+			rval.TraceID = i
+		case lowerKey == mockTextMapIdsPrefix+"spanid":
+			// Ids:
+			i, err := strconv.Atoi(val)
+			if err != nil {
+				return err
+			}
+			rval.SpanID = i
+		case lowerKey == mockTextMapIdsPrefix+"sampled":
+			b, err := strconv.ParseBool(val)
+			if err != nil {
+				return err
+			}
+			rval.Sampled = b
+		case strings.HasPrefix(lowerKey, mockTextMapBaggagePrefix):
+			// Baggage:
+			if rval.Baggage == nil {
+				rval.Baggage = make(map[string]string)
+			}
+			safeVal := val
+			if t.HTTPHeaders {
+				// unescape errors are ignored, nothing can be done
+				if rawVal, err := url.QueryUnescape(val); err == nil {
+					safeVal = rawVal
+				}
+			}
+			rval.Baggage[lowerKey[len(mockTextMapBaggagePrefix):]] = safeVal
+		}
+		return nil
+	})
+	if rval.TraceID == 0 || rval.SpanID == 0 {
+		return emptyContext, opentracing.ErrSpanContextNotFound
+	}
+	if err != nil {
+		return emptyContext, err
+	}
+	return rval, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -404,6 +404,7 @@ github.com/opentracing-contrib/go-stdlib/nethttp
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
+github.com/opentracing/opentracing-go/mocktracer
 # github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
1. added logic to add tag `tenant_id` to tracing spans if tenant is defined in context.
2. added additional tracing spans to merge_querier's methods

**Which issue(s) this PR fixes**:
Fixes #4147

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
