### PR TITLE
scanner: Retry failed uploads

### DIFF
--- a/tools/blocksconvert/scanner/scanner.go
+++ b/tools/blocksconvert/scanner/scanner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/cortexproject/cortex/pkg/chunk/aws"
 	"github.com/cortexproject/cortex/pkg/chunk/storage"
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/tools/blocksconvert"
@@ -431,9 +432,25 @@ func uploadPlansConcurrently(ctx context.Context, log log.Logger, dir string, bu
 				src := filepath.Join(dir, filepath.FromSlash(p))
 				dst := path.Join(bucketPrefix, p)
 
-				err := objstore.UploadFile(ctx, log, bucket, src, dst)
-				if err != nil {
-					return err
+				boff := util.NewBackoff(ctx, util.BackoffConfig{
+					MinBackoff: 1 * time.Second,
+					MaxBackoff: 5 * time.Second,
+					MaxRetries: 5,
+				})
+
+				for boff.Ongoing() {
+					err := objstore.UploadFile(ctx, log, bucket, src, dst)
+
+					if err == nil {
+						break
+					}
+
+					level.Warn(log).Log("msg", "failed to upload block", "err", err)
+					boff.Wait()
+				}
+
+				if boff.Err() != nil {
+					return boff.Err()
 				}
 			}
 			return nil


### PR DESCRIPTION
Signed-off-by: Benjamin Charron <benjamin.charron@ubisoft.com>

**What this PR does**: Retry block uploads in blocksconvert/scanner

**Which issue(s) this PR fixes**:
Fixes #4187

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
