### PR TITLE
Deprecate -querier.ingester-streaming option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - `-alertmanager.receivers-firewall.block.cidr-networks` renamed to `-alertmanager.receivers-firewall-block-cidr-networks`
   - `-alertmanager.receivers-firewall.block.private-addresses` renamed to `-alertmanager.receivers-firewall-block-private-addresses`
 * [CHANGE] Change default value of `-server.grpc.keepalive.min-time-between-pings` to `10s` and `-server.grpc.keepalive.ping-without-stream-allowed` to `true`. #4168
+* [CHANGE] Querier: deprecated the CLI flag `-querier.ingester-streaming` (and its respective YAML config option). The default value is `true` (enabled) and future versions of Cortex will have streaming always enabled without providing a way to disable it. #4195
 * [FEATURE] Alertmanager: Added rate-limits to email notifier. Rate limits can be configured using `-alertmanager.email-notification-rate-limit` and `-alertmanager.email-notification-burst-size`. These limits are applied on individual alertmanagers. Rate-limited email notifications are failed notifications. It is possible to monitor rate-limited notifications via new `cortex_alertmanager_notification_rate_limited_total` metric. #4135
 * [ENHANCEMENT] Alertmanager: introduced new metrics to monitor operation when using `-alertmanager.sharding-enabled`: #4149
   * `cortex_alertmanager_state_fetch_replica_state_total`

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -114,7 +114,8 @@ querier:
   # CLI flag: -querier.batch-iterators
   [batch_iterators: <boolean> | default = true]
 
-  # Use streaming RPCs to query ingester.
+  # Deprecated. Future versions of Cortex will have streaming always enabled.
+  # When enabled, querier uses streaming RPCs to query ingesters.
   # CLI flag: -querier.ingester-streaming
   [ingester_streaming: <boolean> | default = true]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -835,7 +835,8 @@ The `querier_config` configures the Cortex querier.
 # CLI flag: -querier.batch-iterators
 [batch_iterators: <boolean> | default = true]
 
-# Use streaming RPCs to query ingester.
+# Deprecated. Future versions of Cortex will have streaming always enabled. When
+# enabled, querier uses streaming RPCs to query ingesters.
 # CLI flag: -querier.ingester-streaming
 [ingester_streaming: <boolean> | default = true]
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -86,7 +86,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.Timeout, "querier.timeout", 2*time.Minute, "The timeout for a query.")
 	f.BoolVar(&cfg.Iterators, "querier.iterators", false, "Use iterators to execute query, as opposed to fully materialising the series in memory.")
 	f.BoolVar(&cfg.BatchIterators, "querier.batch-iterators", true, "Use batch iterators to execute query, as opposed to fully materialising the series in memory.  Takes precedent over the -querier.iterators flag.")
-	f.BoolVar(&cfg.IngesterStreaming, "querier.ingester-streaming", true, "Use streaming RPCs to query ingester.")
+	f.BoolVar(&cfg.IngesterStreaming, "querier.ingester-streaming", true, "Deprecated. Future versions of Cortex will have streaming always enabled. When enabled, querier uses streaming RPCs to query ingesters.") // TODO remove in Cortex 1.12.
 	f.IntVar(&cfg.MaxSamples, "querier.max-samples", 50e6, "Maximum number of samples a single query can load into memory.")
 	f.DurationVar(&cfg.QueryIngestersWithin, "querier.query-ingesters-within", 0, "Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester.")
 	f.BoolVar(&cfg.QueryStoreForLabels, "querier.query-store-for-labels-enabled", false, "Query long-term store for series, label values and label names APIs. Works only with blocks engine.")


### PR DESCRIPTION
**What this PR does**:
Cortex `-querier.ingester-streaming` defaults to true, which means the querier fetches chunks/series from ingesters using gRPC streaming. The option allows to disable it but, as of today, I don't see a good reason why this should be disabled.

In this PR I'm proposing to deprecate the flag and removing it after 2 versions (we announce it in 1.10 and remove in 1.12). Once the flag is removed, we'll be able to delete some code in querier and distributor.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
