### PR TITLE
Schedule next Cortex releases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,7 +26,7 @@ Our goal is to provide a new minor release every 6 weeks. This is a new process 
 | v1.8.0         | 2021-03-01                                 | Peter Štibraný (@pstibrany)                 |
 | v1.9.0         | 2021-04-12                                 | Goutham Veeramachaneni (@gouthamve)         |
 | v1.10.0        | 2021-06-06                                 | Marco Pracucci (@pracucci)                  |
-| v1.11.0        | 2021-07-18                                 |                                             |
+| v1.11.0        | 2021-07-18                                 | Bryan Boreham (@bboreham)                   |
 | v1.12.0        | 2021-08-29                                 |                                             |
 
 ## Release shepherd responsibilities

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,6 +25,9 @@ Our goal is to provide a new minor release every 6 weeks. This is a new process 
 | v1.7.0         | 2021-01-18                                 | Ken Haines (@khaines)                       |
 | v1.8.0         | 2021-03-01                                 | Peter Štibraný (@pstibrany)                 |
 | v1.9.0         | 2021-04-12                                 | Goutham Veeramachaneni (@gouthamve)         |
+| v1.10.0        | 2021-06-06                                 | Marco Pracucci (@pracucci)                  |
+| v1.11.0        | 2021-07-18                                 |                                             |
+| v1.12.0        | 2021-08-29                                 |                                             |
 
 ## Release shepherd responsibilities
 


### PR DESCRIPTION
**What this PR does**:
In this PR I'm proposing next Cortex releases schedule. 1.10 has been scheduled 6 weeks after from 1.9 release candidate, which was delayed by few weeks compared to the original schedule.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
