### PR TITLE
Added limit for size of configuration file that tenant can upload to Alertmanager.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - `-alertmanager.receivers-firewall.block.private-addresses` renamed to `-alertmanager.receivers-firewall-block-private-addresses`
 * [CHANGE] Change default value of `-server.grpc.keepalive.min-time-between-pings` to `10s` and `-server.grpc.keepalive.ping-without-stream-allowed` to `true`. #4168
 * [FEATURE] Alertmanager: Added rate-limits to notifiers. Rate limits used by all integrations can be configured using `-alertmanager.notification-rate-limit`, while per-integration rate limits can be specified via `-alertmanager.notification-rate-limit-per-integration` parameter. Both shared and per-integration limits can be overwritten using overrides mechanism. These limits are applied on individual (per-tenant) alertmanagers. Rate-limited notifications are failed notifications. It is possible to monitor rate-limited notifications via new `cortex_alertmanager_notification_rate_limited_total` metric. #4135 #4163
+* [FEATURE] Alertmanager: Added `-alertmanager.max-config-size` limit to control size of configuration files that Cortex users can upload to Alertmanager via API. This limit is configurable per-tenant. #4201
 * [ENHANCEMENT] Alertmanager: introduced new metrics to monitor operation when using `-alertmanager.sharding-enabled`: #4149
   * `cortex_alertmanager_state_fetch_replica_state_total`
   * `cortex_alertmanager_state_fetch_replica_state_failed_total`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - `-alertmanager.receivers-firewall.block.private-addresses` renamed to `-alertmanager.receivers-firewall-block-private-addresses`
 * [CHANGE] Change default value of `-server.grpc.keepalive.min-time-between-pings` to `10s` and `-server.grpc.keepalive.ping-without-stream-allowed` to `true`. #4168
 * [FEATURE] Alertmanager: Added rate-limits to notifiers. Rate limits used by all integrations can be configured using `-alertmanager.notification-rate-limit`, while per-integration rate limits can be specified via `-alertmanager.notification-rate-limit-per-integration` parameter. Both shared and per-integration limits can be overwritten using overrides mechanism. These limits are applied on individual (per-tenant) alertmanagers. Rate-limited notifications are failed notifications. It is possible to monitor rate-limited notifications via new `cortex_alertmanager_notification_rate_limited_total` metric. #4135 #4163
-* [FEATURE] Alertmanager: Added `-alertmanager.max-config-size` limit to control size of configuration files that Cortex users can upload to Alertmanager via API. This limit is configurable per-tenant. #4201
+* [FEATURE] Alertmanager: Added `-alertmanager.max-config-size-bytes` limit to control size of configuration files that Cortex users can upload to Alertmanager via API. This limit is configurable per-tenant. #4201
 * [ENHANCEMENT] Alertmanager: introduced new metrics to monitor operation when using `-alertmanager.sharding-enabled`: #4149
   * `cortex_alertmanager_state_fetch_replica_state_total`
   * `cortex_alertmanager_state_fetch_replica_state_failed_total`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4122,8 +4122,8 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -alertmanager.notification-rate-limit-per-integration
 [alertmanager_notification_rate_limit_per_integration: <map of string to float64> | default = {}]
 
-# Maximum size of configuration file for Alertmanager that tenant can upload. 0
-# = no limit.
+# Maximum size of configuration file for Alertmanager that tenant can upload via
+# Alertmanager API. 0 = no limit.
 # CLI flag: -alertmanager.max-config-size
 [alertmanager_max_config_size: <int> | default = 0]
 ```

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4121,6 +4121,11 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # wechat, slack, victorops, pushover.
 # CLI flag: -alertmanager.notification-rate-limit-per-integration
 [alertmanager_notification_rate_limit_per_integration: <map of string to float64> | default = {}]
+
+# Maximum size of configuration file for Alertmanager that tenant can upload. 0
+# = no limit.
+# CLI flag: -alertmanager.max-config-size
+[alertmanager_max_config_size: <int> | default = 0]
 ```
 
 ### `redis_config`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4124,8 +4124,8 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 
 # Maximum size of configuration file for Alertmanager that tenant can upload via
 # Alertmanager API. 0 = no limit.
-# CLI flag: -alertmanager.max-config-size
-[alertmanager_max_config_size: <int> | default = 0]
+# CLI flag: -alertmanager.max-config-size-bytes
+[alertmanager_max_config_size_bytes: <int> | default = 0]
 ```
 
 ### `redis_config`

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -3,6 +3,7 @@ package alertmanager
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -32,6 +33,7 @@ const (
 	errDeletingConfiguration = "unable to delete the Alertmanager config"
 	errNoOrgID               = "unable to determine the OrgID"
 	errListAllUser           = "unable to list the Alertmanager users"
+	errConfigurationTooBig   = "Alertmanager configuration is too big, limit: %d bytes"
 
 	fetchConcurrency = 16
 )
@@ -98,10 +100,27 @@ func (am *MultitenantAlertmanager) SetUserConfig(w http.ResponseWriter, r *http.
 		return
 	}
 
-	payload, err := ioutil.ReadAll(r.Body)
+	var input io.Reader
+	maxConfigSize := am.limits.AlertmanagerMaxConfigSize(userID)
+	if maxConfigSize > 0 {
+		// LimitReader will return EOF after reading specified number of bytes. To check if
+		// we have read too many bytes, allow one extra byte.
+		input = io.LimitReader(r.Body, int64(maxConfigSize)+1)
+	} else {
+		input = r.Body
+	}
+
+	payload, err := ioutil.ReadAll(input)
 	if err != nil {
 		level.Error(logger).Log("msg", errReadingConfiguration, "err", err.Error())
 		http.Error(w, fmt.Sprintf("%s: %s", errReadingConfiguration, err.Error()), http.StatusBadRequest)
+		return
+	}
+
+	if maxConfigSize > 0 && len(payload) > maxConfigSize {
+		msg := fmt.Sprintf(errConfigurationTooBig, maxConfigSize)
+		level.Error(logger).Log("msg", msg)
+		http.Error(w, msg, http.StatusBadRequest)
 		return
 	}
 

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -119,7 +119,7 @@ func (am *MultitenantAlertmanager) SetUserConfig(w http.ResponseWriter, r *http.
 
 	if maxConfigSize > 0 && len(payload) > maxConfigSize {
 		msg := fmt.Sprintf(errConfigurationTooBig, maxConfigSize)
-		level.Error(logger).Log("msg", msg)
+		level.Warn(logger).Log("msg", msg)
 		http.Error(w, msg, http.StatusBadRequest)
 		return
 	}

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -246,6 +246,9 @@ type Limits interface {
 	// NotificationBurstSize returns burst-size for rate limiter for given integration type. If 0, no notifications are allowed except
 	// when limit == rate.Inf.
 	NotificationBurstSize(tenant string, integration string) int
+
+	// AlertmanagerMaxConfigSize returns max size of configuration file that user is allowed to upload. If 0, there is no limit.
+	AlertmanagerMaxConfigSize(tenant string) int
 }
 
 // A MultitenantAlertmanager manages Alertmanager instances for multiple

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -1867,7 +1867,7 @@ receivers:
 
 	reg := prometheus.NewPedanticRegistry()
 	cfg := mockAlertmanagerConfig(t)
-	am, err := createMultitenantAlertmanager(cfg, nil, nil, store, nil, limits, log.NewNopLogger(), reg)
+	am, err := createMultitenantAlertmanager(cfg, nil, nil, store, nil, &limits, log.NewNopLogger(), reg)
 	require.NoError(t, err)
 
 	err = am.loadAndSyncConfigs(context.Background(), reasonPeriodic)
@@ -1942,20 +1942,25 @@ func (f *passthroughAlertmanagerClientPool) GetClientFor(addr string) (Client, e
 type mockAlertManagerLimits struct {
 	emailNotificationRateLimit rate.Limit
 	emailNotificationBurst     int
+	maxConfigSize              int
 }
 
-func (m mockAlertManagerLimits) AlertmanagerReceiversBlockCIDRNetworks(user string) []flagext.CIDR {
+func (m *mockAlertManagerLimits) AlertmanagerMaxConfigSize(tenant string) int {
+	return m.maxConfigSize
+}
+
+func (m *mockAlertManagerLimits) AlertmanagerReceiversBlockCIDRNetworks(user string) []flagext.CIDR {
 	panic("implement me")
 }
 
-func (m mockAlertManagerLimits) AlertmanagerReceiversBlockPrivateAddresses(user string) bool {
+func (m *mockAlertManagerLimits) AlertmanagerReceiversBlockPrivateAddresses(user string) bool {
 	panic("implement me")
 }
 
-func (m mockAlertManagerLimits) NotificationRateLimit(_ string, integration string) rate.Limit {
+func (m *mockAlertManagerLimits) NotificationRateLimit(_ string, integration string) rate.Limit {
 	return m.emailNotificationRateLimit
 }
 
-func (m mockAlertManagerLimits) NotificationBurstSize(_ string, integration string) int {
+func (m *mockAlertManagerLimits) NotificationBurstSize(_ string, integration string) int {
 	return m.emailNotificationBurst
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -103,9 +103,10 @@ type Limits struct {
 	AlertmanagerReceiversBlockCIDRNetworks     flagext.CIDRSliceCSV `yaml:"alertmanager_receivers_firewall_block_cidr_networks" json:"alertmanager_receivers_firewall_block_cidr_networks"`
 	AlertmanagerReceiversBlockPrivateAddresses bool                 `yaml:"alertmanager_receivers_firewall_block_private_addresses" json:"alertmanager_receivers_firewall_block_private_addresses"`
 
-	// Alertmanager limits
 	NotificationRateLimit               float64                  `yaml:"alertmanager_notification_rate_limit" json:"alertmanager_notification_rate_limit"`
 	NotificationRateLimitPerIntegration NotificationRateLimitMap `yaml:"alertmanager_notification_rate_limit_per_integration" json:"alertmanager_notification_rate_limit_per_integration"`
+
+	AlertmanagerMaxConfigSize int `yaml:"alertmanager_max_config_size" json:"alertmanager_max_config_size"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -173,6 +174,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 		l.NotificationRateLimitPerIntegration = NotificationRateLimitMap{}
 	}
 	f.Var(&l.NotificationRateLimitPerIntegration, "alertmanager.notification-rate-limit-per-integration", "Per-integration notification rate limits. Value is a map, where each key is integration name and value is a rate-limit (float). On command line, this map is given in JSON format. Rate limit has the same meaning as -alertmanager.notification-rate-limit, but only applies for specific integration. Allowed integration names: "+strings.Join(allowedIntegrationNames, ", ")+".")
+	f.IntVar(&l.AlertmanagerMaxConfigSize, "alertmanager.max-config-size", 0, "Maximum size of configuration file for Alertmanager that tenant can upload. 0 = no limit.")
 }
 
 // Validate the limits config and returns an error if the validation
@@ -571,6 +573,10 @@ func (o *Overrides) NotificationBurstSize(user string, integration string) int {
 	}
 
 	return int(l)
+}
+
+func (o *Overrides) AlertmanagerMaxConfigSize(userID string) int {
+	return o.getOverridesForUser(userID).AlertmanagerMaxConfigSize
 }
 
 func (o *Overrides) getOverridesForUser(userID string) *Limits {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -106,7 +106,7 @@ type Limits struct {
 	NotificationRateLimit               float64                  `yaml:"alertmanager_notification_rate_limit" json:"alertmanager_notification_rate_limit"`
 	NotificationRateLimitPerIntegration NotificationRateLimitMap `yaml:"alertmanager_notification_rate_limit_per_integration" json:"alertmanager_notification_rate_limit_per_integration"`
 
-	AlertmanagerMaxConfigSize int `yaml:"alertmanager_max_config_size" json:"alertmanager_max_config_size"`
+	AlertmanagerMaxConfigSizeBytes int `yaml:"alertmanager_max_config_size_bytes" json:"alertmanager_max_config_size_bytes"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -174,7 +174,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 		l.NotificationRateLimitPerIntegration = NotificationRateLimitMap{}
 	}
 	f.Var(&l.NotificationRateLimitPerIntegration, "alertmanager.notification-rate-limit-per-integration", "Per-integration notification rate limits. Value is a map, where each key is integration name and value is a rate-limit (float). On command line, this map is given in JSON format. Rate limit has the same meaning as -alertmanager.notification-rate-limit, but only applies for specific integration. Allowed integration names: "+strings.Join(allowedIntegrationNames, ", ")+".")
-	f.IntVar(&l.AlertmanagerMaxConfigSize, "alertmanager.max-config-size", 0, "Maximum size of configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.")
+	f.IntVar(&l.AlertmanagerMaxConfigSizeBytes, "alertmanager.max-config-size-bytes", 0, "Maximum size of configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.")
 }
 
 // Validate the limits config and returns an error if the validation
@@ -576,7 +576,7 @@ func (o *Overrides) NotificationBurstSize(user string, integration string) int {
 }
 
 func (o *Overrides) AlertmanagerMaxConfigSize(userID string) int {
-	return o.getOverridesForUser(userID).AlertmanagerMaxConfigSize
+	return o.getOverridesForUser(userID).AlertmanagerMaxConfigSizeBytes
 }
 
 func (o *Overrides) getOverridesForUser(userID string) *Limits {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -174,7 +174,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 		l.NotificationRateLimitPerIntegration = NotificationRateLimitMap{}
 	}
 	f.Var(&l.NotificationRateLimitPerIntegration, "alertmanager.notification-rate-limit-per-integration", "Per-integration notification rate limits. Value is a map, where each key is integration name and value is a rate-limit (float). On command line, this map is given in JSON format. Rate limit has the same meaning as -alertmanager.notification-rate-limit, but only applies for specific integration. Allowed integration names: "+strings.Join(allowedIntegrationNames, ", ")+".")
-	f.IntVar(&l.AlertmanagerMaxConfigSize, "alertmanager.max-config-size", 0, "Maximum size of configuration file for Alertmanager that tenant can upload. 0 = no limit.")
+	f.IntVar(&l.AlertmanagerMaxConfigSize, "alertmanager.max-config-size", 0, "Maximum size of configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.")
 }
 
 // Validate the limits config and returns an error if the validation


### PR DESCRIPTION
**What this PR does**: This PR introduces new limit in Alertmanager: limit for size of configuration file that tenant can upload.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
