### PR TITLE
Upgrade the go version used in integration tests

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -98,8 +98,8 @@ jobs:
       - name: Upgrade golang
         run: |
           cd /tmp
-          wget https://dl.google.com/go/go1.14.9.linux-amd64.tar.gz
-          tar -zxvf go1.14.9.linux-amd64.tar.gz
+          wget https://dl.google.com/go/go1.16.3.linux-amd64.tar.gz
+          tar -zxvf go1.16.3.linux-amd64.tar.gz
           sudo rm -fr /usr/local/go
           sudo mv /tmp/go /usr/local/go
           cd -


### PR DESCRIPTION
**What this PR does**:
@damnever correctly pointed out in https://github.com/cortexproject/cortex/pull/4184#discussion_r636086842 that we're not running integration tests with go 1.16, like the rest of the project. This PR fixes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
