### PR TITLE
return ErrStorageObjectNotFound when a non-existent object is being deleted

### DIFF
--- a/pkg/chunk/azure/blob_storage_client.go
+++ b/pkg/chunk/azure/blob_storage_client.go
@@ -250,6 +250,9 @@ func (b *BlobStorage) DeleteObject(ctx context.Context, blobID string) error {
 	}
 
 	_, err = blockBlobURL.Delete(ctx, azblob.DeleteSnapshotsOptionInclude, azblob.BlobAccessConditions{})
+	if err != nil && isObjNotFoundErr(err) {
+		return chunk.ErrStorageObjectNotFound
+	}
 	return err
 }
 
@@ -269,7 +272,7 @@ func (b *BlobStorage) selectContainerURLFmt() string {
 	return endpoints[b.cfg.Environment].containerURLFmt
 }
 
-// isObjNotFoundErr returns true if error means that object is not found. Relevant to GetObject operations.
+// isObjNotFoundErr returns true if error means that object is not found. Relevant to GetObject and DeleteObject operations.
 func isObjNotFoundErr(err error) bool {
 	var e azblob.StorageError
 	if errors.As(err, &e) && e.ServiceCode() == azblob.ServiceCodeBlobNotFound {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This is a similar change as PR https://github.com/cortexproject/cortex/pull/4200 for the `DeleteObject` method where it would return `ErrStorageObjectNotFound` error when a non-existent object is being deleted. Sorry, I missed seeing that we do it for `DeleteObject` while working on the previous PR.
