### PR TITLE
Make handler function for `/config` endpoint overrideable

### DIFF
--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -111,7 +111,14 @@ func indexHandler(httpPathPrefix string, content *IndexPageContent) http.Handler
 	}
 }
 
-func configHandler(actualCfg interface{}, defaultCfg interface{}) http.HandlerFunc {
+func (cfg *Config) configHandler(actualCfg interface{}, defaultCfg interface{}) http.HandlerFunc {
+	if cfg.CustomConfigHandler != nil {
+		return cfg.CustomConfigHandler(actualCfg, defaultCfg)
+	}
+	return DefaultConfigHandler(actualCfg, defaultCfg)
+}
+
+func DefaultConfigHandler(actualCfg interface{}, defaultCfg interface{}) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var output interface{}
 		switch r.URL.Query().Get("mode") {


### PR DESCRIPTION
**What this PR does**:

In order to be able to extend or replace the default handler function for the
`/config` endpoint, the registered handler evaluates whether a handler override
is set. If so, the custom handler function is invoked, otherwise the default
handler is used.

An example for this use-case is, that a downstream project extends the Cortex
configuration with additional configuration options, which should also be
exposed in the `/config` endpoint.


**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
