### PR TITLE
Add new metrics to aid troubleshooting tombstone convergence.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
 * [ENHANCEMENT] Added zone-awareness support to alertmanager for use when sharding is enabled. When zone-awareness is enabled, alerts will be replicated across availability zones. #4204
 * [ENHANCEMENT] Added `tenant_ids` tag to tracing spans #4147
 * [ENHANCEMENT] Ring, query-frontend: Avoid using automatic private IPs (APIPA) when discovering IP address from the interface during the registration of the instance in the ring, or by query-frontend when used with query-scheduler. APIPA still used as last resort with logging indicating usage. #4032
+* [ENHANCEMENT] Memberlist: introduced new metrics to aid troubleshooting tombstone convergence: #4231
+  * `memberlist_client_kv_store_value_tombstones`
+  * `memberlist_client_kv_store_value_tombstones_removed_total`
+  * `memberlist_client_messages_to_broadcast_dropped_total`
 * [BUGFIX] Purger: fix `Invalid null value in condition for column range` caused by `nil` value in range for WriteBatch query. #4128
 * [BUGFIX] Ingester: fixed infrequent panic caused by a race condition between TSDB mmap-ed head chunks truncation and queries. #4176
 * [BUGFIX] Alertmanager: fix Alertmanager status page if clustering via gossip is disabled or sharding is enabled. #4184

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -86,15 +86,23 @@ func testSingleBinaryEnv(t *testing.T, tlsEnabled bool) {
 	require.NoError(t, cortex2.WaitSumMetrics(e2e.Equals(3*512), "cortex_ring_tokens_total"))
 	require.NoError(t, cortex3.WaitSumMetrics(e2e.Equals(3*512), "cortex_ring_tokens_total"))
 
+	// All Cortex servers should initially have no tombstones; nobody has left yet.
+	require.NoError(t, cortex3.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"))
+	require.NoError(t, cortex3.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"))
+	require.NoError(t, cortex3.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"))
+
 	require.NoError(t, s.Stop(cortex1))
 	require.NoError(t, cortex2.WaitSumMetrics(e2e.Equals(2*512), "cortex_ring_tokens_total"))
 	require.NoError(t, cortex2.WaitSumMetrics(e2e.Equals(2), "memberlist_client_cluster_members_count"))
+	require.NoError(t, cortex3.WaitSumMetrics(e2e.Equals(1), "memberlist_client_kv_store_value_tombstones"))
 	require.NoError(t, cortex3.WaitSumMetrics(e2e.Equals(2*512), "cortex_ring_tokens_total"))
 	require.NoError(t, cortex3.WaitSumMetrics(e2e.Equals(2), "memberlist_client_cluster_members_count"))
+	require.NoError(t, cortex3.WaitSumMetrics(e2e.Equals(1), "memberlist_client_kv_store_value_tombstones"))
 
 	require.NoError(t, s.Stop(cortex2))
 	require.NoError(t, cortex3.WaitSumMetrics(e2e.Equals(1*512), "cortex_ring_tokens_total"))
 	require.NoError(t, cortex3.WaitSumMetrics(e2e.Equals(1), "memberlist_client_cluster_members_count"))
+	require.NoError(t, cortex3.WaitSumMetrics(e2e.Equals(2), "memberlist_client_kv_store_value_tombstones"))
 
 	require.NoError(t, s.Stop(cortex3))
 }

--- a/pkg/ring/kv/memberlist/memberlist_client_test.go
+++ b/pkg/ring/kv/memberlist/memberlist_client_test.go
@@ -83,8 +83,9 @@ func (d *data) MergeContent() []string {
 	return out
 }
 
-func (d *data) RemoveTombstones(limit time.Time) {
+func (d *data) RemoveTombstones(limit time.Time) (_, _ int) {
 	// nothing to do
+	return
 }
 
 func (d *data) getAllTokens() []uint32 {
@@ -870,8 +871,9 @@ func (dc distributedCounter) MergeContent() []string {
 	return out
 }
 
-func (dc distributedCounter) RemoveTombstones(limit time.Time) {
+func (dc distributedCounter) RemoveTombstones(limit time.Time) (_, _ int) {
 	// nothing to do
+	return
 }
 
 type distributedCounterCodec struct{}

--- a/pkg/ring/kv/memberlist/mergeable.go
+++ b/pkg/ring/kv/memberlist/mergeable.go
@@ -38,5 +38,6 @@ type Mergeable interface {
 	// Remove tombstones older than given limit from this mergeable.
 	// If limit is zero time, remove all tombstones. Memberlist client calls this method with zero limit each
 	// time when client is accessing value from the store. It can be used to hide tombstones from the clients.
-	RemoveTombstones(limit time.Time)
+	// Returns the total number of tombstones present and the number of removed tombstones by this invocation.
+	RemoveTombstones(limit time.Time) (total, removed int)
 }

--- a/pkg/ring/kv/memberlist/metrics.go
+++ b/pkg/ring/kv/memberlist/metrics.go
@@ -84,6 +84,13 @@ func (m *KV) createAndRegisterMetrics() {
 		Help:      "Total size of messages waiting in the broadcast queue",
 	})
 
+	m.numberOfBroadcastMessagesDropped = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: m.cfg.MetricsNamespace,
+		Subsystem: subsystem,
+		Name:      "messages_to_broadcast_dropped_total",
+		Help:      "Number of broadcast messages intended to be sent but were dropped due to encoding errors or for being too big",
+	})
+
 	m.casAttempts = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: m.cfg.MetricsNamespace,
 		Subsystem: subsystem,
@@ -114,6 +121,20 @@ func (m *KV) createAndRegisterMetrics() {
 		prometheus.BuildFQName(m.cfg.MetricsNamespace, subsystem, "kv_store_value_bytes"), // gauge
 		"Sizes of values in KV Store in bytes",
 		[]string{"key"}, nil)
+
+	m.storeTombstones = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: m.cfg.MetricsNamespace,
+		Subsystem: subsystem,
+		Name:      "kv_store_value_tombstones",
+		Help:      "Number of tombstones currently present in KV store values",
+	}, []string{"key"})
+
+	m.storeRemovedTombstones = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: m.cfg.MetricsNamespace,
+		Subsystem: subsystem,
+		Name:      "kv_store_value_tombstones_removed_total",
+		Help:      "Total number of tombstones which have been removed from KV store values",
+	}, []string{"key"})
 
 	m.memberlistMembersCount = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: m.cfg.MetricsNamespace,
@@ -162,10 +183,13 @@ func (m *KV) createAndRegisterMetrics() {
 		m.totalSizeOfPushes,
 		m.totalSizeOfPulls,
 		m.totalSizeOfBroadcastMessagesInQueue,
+		m.numberOfBroadcastMessagesDropped,
 		m.casAttempts,
 		m.casFailures,
 		m.casSuccesses,
 		m.watchPrefixDroppedNotifications,
+		m.storeTombstones,
+		m.storeRemovedTombstones,
 		m.memberlistMembersCount,
 		m.memberlistHealthScore,
 	}

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -377,11 +377,12 @@ func resolveConflicts(normalizedIngesters map[string]InstanceDesc) {
 func (d *Desc) RemoveTombstones(limit time.Time) (total, removed int) {
 	for n, ing := range d.Ingesters {
 		if ing.State == LEFT {
-			total++
 			if limit.IsZero() || time.Unix(ing.Timestamp, 0).Before(limit) {
 				// remove it
 				delete(d.Ingesters, n)
 				removed++
+			} else {
+				total++
 			}
 		}
 	}

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -374,15 +374,18 @@ func resolveConflicts(normalizedIngesters map[string]InstanceDesc) {
 }
 
 // RemoveTombstones removes LEFT ingesters older than given time limit. If time limit is zero, remove all LEFT ingesters.
-func (d *Desc) RemoveTombstones(limit time.Time) {
-	removed := 0
+func (d *Desc) RemoveTombstones(limit time.Time) (total, removed int) {
 	for n, ing := range d.Ingesters {
-		if ing.State == LEFT && (limit.IsZero() || time.Unix(ing.Timestamp, 0).Before(limit)) {
-			// remove it
-			delete(d.Ingesters, n)
-			removed++
+		if ing.State == LEFT {
+			total++
+			if limit.IsZero() || time.Unix(ing.Timestamp, 0).Before(limit) {
+				// remove it
+				delete(d.Ingesters, n)
+				removed++
+			}
 		}
 	}
+	return
 }
 
 func (d *Desc) getTokensInfo() map[uint32]instanceInfo {


### PR DESCRIPTION
**What this PR does**:
Add new metrics to aid troubleshooting tombstone convergence.

- `memberlist_client_kv_store_value_tombstones`
    Expose the number of tombstones currently in the value for each key
    in the store. If the tombstones are being propagated as expected,
    then each instance should have the same value for this metric.
- `memberlist_client_kv_store_value_tombstones_removed_total`
    Count the number of tombstones which have been removed because they
    aged out. This can be used to troubleshoot whether tombstones are
    being removed too soon (i.e. before the state is converged).
- `memberlist_client_messages_to_broadcast_dropped_total`
    Count occurrences of messages being quietly dropped when they were
    expecting to have been broadcast. As log messages already existed
    for these events, the logs have had the `key` field added instead
    of exposing per-key metrics, for consistency with other metrics
    of this nature in the package.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**Checklist**
- [X] Tests updated
- [X] ~~Documentation added~~
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
