### PR TITLE
Replace validation error with error in query limiter

### DIFF
--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -962,10 +962,9 @@ func TestQueryLimitsWithBlocksStorageRunningInMicroServices(t *testing.T) {
 	res, err = c.Push(series4)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
-
 	_, err = c.QueryRange("{__name__=~\"series_.+\"}", series1Timestamp, series4Timestamp.Add(1*time.Hour), blockRangePeriod)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "max number of series limit")
+	assert.Contains(t, err.Error(), "500")
 }
 
 func TestHashCollisionHandling(t *testing.T) {

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -235,12 +235,12 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, userID string, re
 
 			for _, series := range resp.Chunkseries {
 				if limitErr := queryLimiter.AddSeries(series.Labels); limitErr != nil {
-					return nil, limitErr
+					return nil, validation.LimitError(limitErr.Error())
 				}
 			}
 
 			if chunkBytesLimitErr := queryLimiter.AddChunkBytes(resp.ChunksSize()); chunkBytesLimitErr != nil {
-				return nil, chunkBytesLimitErr
+				return nil, validation.LimitError(chunkBytesLimitErr.Error())
 			}
 
 			for _, series := range resp.Timeseries {

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -616,7 +616,7 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 					// Add series fingerprint to query limiter; will return error if we are over the limit
 					limitErr := queryLimiter.AddSeries(cortexpb.FromLabelsToLabelAdapters(s.PromLabels()))
 					if limitErr != nil {
-						return limitErr
+						return validation.LimitError(limitErr.Error())
 					}
 
 					// Ensure the max number of chunks limit hasn't been reached (max == 0 means disabled).
@@ -631,7 +631,7 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 						chunksSize += c.Size()
 					}
 					if chunkBytesLimitErr := queryLimiter.AddChunkBytes(chunksSize); chunkBytesLimitErr != nil {
-						return chunkBytesLimitErr
+						return validation.LimitError(chunkBytesLimitErr.Error())
 					}
 				}
 

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -508,7 +508,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			},
 			limits:       &blocksStoreLimitsMock{},
 			queryLimiter: limiter.NewQueryLimiter(1, 0),
-			expectedErr:  validation.LimitError(fmt.Sprintf("The query hit the max number of series limit (limit: %d)", 1)),
+			expectedErr:  validation.LimitError(fmt.Sprintf(limiter.ErrMaxSeriesHit, 1)),
 		},
 		"max chunk bytes per query limit hit while fetching chunks": {
 			finderResult: bucketindex.Blocks{

--- a/pkg/util/limiter/query_limiter.go
+++ b/pkg/util/limiter/query_limiter.go
@@ -10,15 +10,14 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
-	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 type queryLimiterCtxKey struct{}
 
 var (
 	ctxKey              = &queryLimiterCtxKey{}
-	errMaxSeriesHit     = "The query hit the max number of series limit (limit: %d)"
-	ErrMaxChunkBytesHit = "The query hit the aggregated chunks size limit (limit: %d bytes)"
+	ErrMaxSeriesHit     = "the query hit the max number of series limit (limit: %d series)"
+	ErrMaxChunkBytesHit = "the query hit the aggregated chunks size limit (limit: %d bytes)"
 )
 
 type QueryLimiter struct {
@@ -72,7 +71,7 @@ func (ql *QueryLimiter) AddSeries(seriesLabels []cortexpb.LabelAdapter) error {
 	ql.uniqueSeries[fingerprint] = struct{}{}
 	if len(ql.uniqueSeries) > ql.maxSeriesPerQuery {
 		// Format error with max limit
-		return validation.LimitError(fmt.Sprintf(errMaxSeriesHit, ql.maxSeriesPerQuery))
+		return fmt.Errorf(ErrMaxSeriesHit, ql.maxSeriesPerQuery)
 	}
 	return nil
 }
@@ -90,7 +89,7 @@ func (ql *QueryLimiter) AddChunkBytes(chunkSizeInBytes int) error {
 		return nil
 	}
 	if ql.chunkBytesCount.Add(int64(chunkSizeInBytes)) > int64(ql.maxChunkBytesPerQuery) {
-		return validation.LimitError(fmt.Sprintf(ErrMaxChunkBytesHit, ql.maxChunkBytesPerQuery))
+		return fmt.Errorf(ErrMaxChunkBytesHit, ql.maxChunkBytesPerQuery)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Tyler Reid <tyler.reid@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This is an internal refactor to return an Error from the query limiter and wrap to be returned as a validation error in the ingester and blocks storage queryables. 

**Which issue(s) this PR fixes**:
Fixes comments from PR  #4216

**Checklist**
- [-] Tests updated
- [-] Documentation added
- [-] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
