### PR TITLE
Added target to fetch build image, instead of building it locally.

### DIFF
--- a/docs/contributing/how-to-update-the-build-image.md
+++ b/docs/contributing/how-to-update-the-build-image.md
@@ -9,5 +9,5 @@ The build image currently can only be updated by a Cortex maintainer. If you're 
 
 1. Update `build-image/Docker`.
 2. Build the and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for linux/amd64 and linux/arm64). Pushing to `quay.io/cortexproject/build-image` repository can only be done by a maintainer. Running this step successfully requires [Docker Buildx](https://docs.docker.com/buildx/working-with-buildx/), but does not require a specific platform.
-3. Replace the image tag in `.github/workflows/*` (_there may be multiple references_)
+3. Replace the image tag in `.github/workflows/*` (_there may be multiple references_) and Makefile (variable `LATEST_BUILD_IMAGE_TAG`).
 4. Open a PR and make sure the CI with new build-image passes


### PR DESCRIPTION
**What this PR does**: This PR adds `fetch-build-image` target to Makefile, for fetching latest build image. This can be faster than building the image locally. Image can still be built locally by running `rm build-image/.uptodate && make build-image/.uptodate` as usual.

**Checklist**
- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
