### PR TITLE
Ensure missing runtime ingester settings are nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 * [BUGFIX] Ruler: fix `/ruler/rule_groups` endpoint doesn't work when used with object store. #4182
 * [BUGFIX] Ruler: Honor the evaluation delay for the `ALERTS` and `ALERTS_FOR_STATE` series. #4227
 * [BUGFIX] Fixed cache fetch error on Redis Cluster. #4056
-* [BUGFIX] Ingester: fix instance where runtime limits erroneously overrode default limits. #4228
+* [BUGFIX] Ingester: fix issue where runtime limits erroneously override default limits. #4246
 
 ## Blocksconvert
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [BUGFIX] Ruler: fix `/ruler/rule_groups` endpoint doesn't work when used with object store. #4182
 * [BUGFIX] Ruler: Honor the evaluation delay for the `ALERTS` and `ALERTS_FOR_STATE` series. #4227
 * [BUGFIX] Fixed cache fetch error on Redis Cluster. #4056
+* [BUGFIX] Ingester: fix instance where runtime limits erroneously overrode default limits. #4228
 
 ## Blocksconvert
 

--- a/pkg/cortex/runtime_config.go
+++ b/pkg/cortex/runtime_config.go
@@ -28,7 +28,7 @@ type runtimeConfigValues struct {
 
 	IngesterChunkStreaming *bool `yaml:"ingester_stream_chunks_when_using_blocks"`
 
-	IngesterLimits ingester.InstanceLimits `yaml:"ingester_limits"`
+	IngesterLimits *ingester.InstanceLimits `yaml:"ingester_limits"`
 }
 
 // runtimeConfigTenantLimits provides per-tenant limit overrides based on a runtimeconfig.Manager
@@ -134,7 +134,7 @@ func ingesterInstanceLimits(manager *runtimeconfig.Manager) func() *ingester.Ins
 	return func() *ingester.InstanceLimits {
 		val := manager.GetConfig()
 		if cfg, ok := val.(*runtimeConfigValues); ok && cfg != nil {
-			return &cfg.IngesterLimits
+			return cfg.IngesterLimits
 		}
 		return nil
 	}

--- a/pkg/cortex/runtime_config_test.go
+++ b/pkg/cortex/runtime_config_test.go
@@ -60,6 +60,20 @@ func TestLoadRuntimeConfig_ShouldLoadEmptyFile(t *testing.T) {
 	assert.Equal(t, &runtimeConfigValues{}, actual)
 }
 
+func TestLoadRuntimeConfig_MissingPointerFieldsAreNil(t *testing.T) {
+	yamlFile := strings.NewReader(`
+# This is an empty YAML.
+`)
+	actual, err := loadRuntimeConfig(yamlFile)
+	require.NoError(t, err)
+
+	actualCfg, ok := actual.(*runtimeConfigValues)
+	require.Truef(t, ok, "expected to be able to cast %+v to runtimeConfigValues", actual)
+
+	// Ensure that when settings are omitted, the pointers are nil. See #4228
+	assert.Nil(t, actualCfg.IngesterLimits)
+}
+
 func TestLoadRuntimeConfig_ShouldReturnErrorOnMultipleDocumentsInTheConfig(t *testing.T) {
 	cases := []string{
 		`


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**What this PR does**:

Make sure that omitted or missing ingester configuration that is
part of runtime configuration is treated as `nil` instead of an
empty object. This fixes an issue where the settings in the empty
object were overriding global default ingester limits.

**Which issue(s) this PR fixes**:

Fixes #4228

**Checklist**
- [X] Tests updated
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
