### PR TITLE
Fix ruler storage single binary mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [BUGFIX] Ruler: Honor the evaluation delay for the `ALERTS` and `ALERTS_FOR_STATE` series. #4227
 * [BUGFIX] Fixed cache fetch error on Redis Cluster. #4056
 * [BUGFIX] Ingester: fix issue where runtime limits erroneously override default limits. #4246
+* [BUGFIX] Ruler: fix ruler startup in single-binary mode when the new `ruler_storage` is used. #4252
 
 ## Blocksconvert
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 * [BUGFIX] Ruler: Honor the evaluation delay for the `ALERTS` and `ALERTS_FOR_STATE` series. #4227
 * [BUGFIX] Fixed cache fetch error on Redis Cluster. #4056
 * [BUGFIX] Ingester: fix issue where runtime limits erroneously override default limits. #4246
-* [BUGFIX] Ruler: fix ruler startup in single-binary mode when the new `ruler_storage` is used. #4252
+* [BUGFIX] Ruler: fix startup in single-binary mode when the new `ruler_storage` is used. #4252
 
 ## Blocksconvert
 

--- a/docs/configuration/single-process-config-blocks-gossip-1.yaml
+++ b/docs/configuration/single-process-config-blocks-gossip-1.yaml
@@ -90,11 +90,12 @@ frontend_worker:
 ruler:
   enable_api: true
   enable_sharding: true
-  storage:
-    type: local
-    local:
-      directory: /tmp/cortex/rules
   ring:
     num_tokens: 512
     kvstore:
       store: memberlist
+
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/cortex/rules

--- a/docs/configuration/single-process-config-blocks-gossip-2.yaml
+++ b/docs/configuration/single-process-config-blocks-gossip-2.yaml
@@ -89,11 +89,12 @@ frontend_worker:
 ruler:
   enable_api: true
   enable_sharding: true
-  storage:
-    type: local
-    local:
-      directory: /tmp/cortex/rules
   ring:
     num_tokens: 512
     kvstore:
       store: memberlist
+
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/cortex/rules

--- a/docs/configuration/single-process-config-blocks-tls.yaml
+++ b/docs/configuration/single-process-config-blocks-tls.yaml
@@ -102,7 +102,8 @@ frontend_worker:
 ruler:
   enable_api: true
   enable_sharding: false
-  storage:
-    type: local
-    local:
-      directory: /tmp/cortex/rules
+
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/cortex/rules

--- a/docs/configuration/single-process-config-blocks.yaml
+++ b/docs/configuration/single-process-config-blocks.yaml
@@ -88,7 +88,8 @@ frontend_worker:
 ruler:
   enable_api: true
   enable_sharding: false
-  storage:
-    type: local
-    local:
-      directory: /tmp/cortex/rules
+
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/cortex/rules

--- a/docs/configuration/single-process-config.md
+++ b/docs/configuration/single-process-config.md
@@ -104,8 +104,9 @@ frontend_worker:
 ruler:
   enable_api: true
   enable_sharding: false
-  storage:
-    type: local
-    local:
-      directory: /tmp/cortex/rules
+
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/cortex/rules
 ```

--- a/docs/configuration/single-process-config.yaml
+++ b/docs/configuration/single-process-config.yaml
@@ -91,7 +91,8 @@ frontend_worker:
 ruler:
   enable_api: true
   enable_sharding: false
-  storage:
-    type: local
-    local:
-      directory: /tmp/cortex/rules
+
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/cortex/rules

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -152,7 +152,7 @@ func TestRulerAPISingleBinary(t *testing.T) {
 	user := "fake"
 
 	configOverrides := map[string]string{
-		"-ruler.storage.local.directory": filepath.Join(e2e.ContainerSharedDir, "ruler_configs"),
+		"-ruler-storage.local.directory": filepath.Join(e2e.ContainerSharedDir, "ruler_configs"),
 		"-ruler.poll-interval":           "2s",
 		"-ruler.rule-path":               filepath.Join(e2e.ContainerSharedDir, "rule_tmp/"),
 	}
@@ -210,7 +210,7 @@ func TestRulerEvaluationDelay(t *testing.T) {
 	evaluationDelay := time.Minute * 5
 
 	configOverrides := map[string]string{
-		"-ruler.storage.local.directory":   filepath.Join(e2e.ContainerSharedDir, "ruler_configs"),
+		"-ruler-storage.local.directory":   filepath.Join(e2e.ContainerSharedDir, "ruler_configs"),
 		"-ruler.poll-interval":             "2s",
 		"-ruler.rule-path":                 filepath.Join(e2e.ContainerSharedDir, "rule_tmp/"),
 		"-ruler.evaluation-delay-duration": evaluationDelay.String(),

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -637,7 +637,7 @@ func (t *Cortex) initRulerStorage() (serv services.Service, err error) {
 	// unfortunately there is no way to generate a "default" config and compare default against actual
 	// to determine if it's unconfigured.  the following check, however, correctly tests this.
 	// Single binary integration tests will break if this ever drifts
-	if t.Cfg.isModuleEnabled(All) && t.Cfg.Ruler.StoreConfig.IsDefaults() {
+	if t.Cfg.isModuleEnabled(All) && t.Cfg.Ruler.StoreConfig.IsDefaults() && t.Cfg.RulerStorage.IsDefaults() {
 		level.Info(util_log.Logger).Log("msg", "Ruler storage is not configured in single binary mode and will not be started.")
 		return
 	}

--- a/pkg/cortex/modules_test.go
+++ b/pkg/cortex/modules_test.go
@@ -2,6 +2,7 @@ package cortex
 
 import (
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -97,5 +98,68 @@ func TestAPIConfig(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestCortex_InitRulerStorage(t *testing.T) {
+	tests := map[string]struct {
+		config       *Config
+		expectedInit bool
+	}{
+		"should init the ruler storage with target=ruler": {
+			config: func() *Config {
+				cfg := newDefaultConfig()
+				cfg.Target = []string{"ruler"}
+				cfg.RulerStorage.Backend = "local"
+				cfg.RulerStorage.Local.Directory = os.TempDir()
+				return cfg
+			}(),
+			expectedInit: true,
+		},
+		"should not init the ruler storage on default config with target=all": {
+			config: func() *Config {
+				cfg := newDefaultConfig()
+				cfg.Target = []string{"all"}
+				return cfg
+			}(),
+			expectedInit: false,
+		},
+		"should init the ruler storage on legacy ruler storage config with target=all": {
+			config: func() *Config {
+				cfg := newDefaultConfig()
+				cfg.Target = []string{"all"}
+				cfg.Ruler.StoreConfig.Type = "local"
+				cfg.Ruler.StoreConfig.Local.Directory = os.TempDir()
+				return cfg
+			}(),
+			expectedInit: true,
+		},
+		"should init the ruler storage on ruler storage config with target=all": {
+			config: func() *Config {
+				cfg := newDefaultConfig()
+				cfg.Target = []string{"all"}
+				cfg.RulerStorage.Backend = "local"
+				cfg.RulerStorage.Local.Directory = os.TempDir()
+				return cfg
+			}(),
+			expectedInit: true,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			cortex := &Cortex{
+				Server: &server.Server{},
+				Cfg:    *testData.config,
+			}
+
+			_, err := cortex.initRulerStorage()
+			require.NoError(t, err)
+
+			if testData.expectedInit {
+				assert.NotNil(t, cortex.RulerStorage)
+			} else {
+				assert.Nil(t, cortex.RulerStorage)
+			}
+		})
+	}
 }

--- a/pkg/ruler/rulestore/config.go
+++ b/pkg/ruler/rulestore/config.go
@@ -2,11 +2,13 @@ package rulestore
 
 import (
 	"flag"
+	"reflect"
 
 	"github.com/cortexproject/cortex/pkg/configs/client"
 	"github.com/cortexproject/cortex/pkg/ruler/rulestore/configdb"
 	"github.com/cortexproject/cortex/pkg/ruler/rulestore/local"
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
+	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
 
 // Config configures a rule store.
@@ -24,4 +26,12 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.ConfigDB.RegisterFlagsWithPrefix(prefix, f)
 	cfg.Local.RegisterFlagsWithPrefix(prefix, f)
 	cfg.RegisterFlagsWithPrefix(prefix, f)
+}
+
+// IsDefaults returns true if the storage options have not been set.
+func (cfg *Config) IsDefaults() bool {
+	defaults := Config{}
+	flagext.DefaultValues(&defaults)
+
+	return reflect.DeepEqual(*cfg, defaults)
 }

--- a/pkg/ruler/rulestore/config_test.go
+++ b/pkg/ruler/rulestore/config_test.go
@@ -1,0 +1,43 @@
+package rulestore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cortexproject/cortex/pkg/util/flagext"
+)
+
+func TestIsDefaults(t *testing.T) {
+	tests := map[string]struct {
+		setup    func(cfg *Config)
+		expected bool
+	}{
+		"should return true if the config only contains default values": {
+			setup: func(cfg *Config) {
+				flagext.DefaultValues(cfg)
+			},
+			expected: true,
+		},
+		"should return false if the config contains zero values": {
+			setup:    func(cfg *Config) {},
+			expected: false,
+		},
+		"should return false if the config contains default values and some overrides": {
+			setup: func(cfg *Config) {
+				flagext.DefaultValues(cfg)
+				cfg.Backend = "local"
+			},
+			expected: false,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			cfg := Config{}
+			testData.setup(&cfg)
+
+			assert.Equal(t, testData.expected, cfg.IsDefaults())
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:
In #3805 we've introduced `-ruler-storage.*` and then we depreacted the old `-ruler.storage`.

We have a check in `initRulerStorage()` to not start the ruler at all when Cortex has been started in single-binary mode and the ruler hasn't been configured. However, we forgot to add a check in the new ruler storage config, which should be fixed by this PR.

**Which issue(s) this PR fixes**:
Fixes #4239

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
