### PR TITLE
Mark new querier limits as experimental

### DIFF
--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -72,3 +72,7 @@ Currently experimental features are:
 - Instance limits in ingester and distributor
 - Exemplar storage, currently in-memory only within the Ingester based on Prometheus exemplar storage (`-blocks-storage.tsdb.max-exemplars`)
 - Alertmanager: notification rate limits. (`-alertmanager.notification-rate-limit` and `-alertmanager.notification-rate-limit-per-integration`)
+- Querier limits:
+  - `-querier.max-fetched-chunks-per-query`
+  - `-querier.max-fetched-chunk-bytes-per-query`
+  - `-querier.max-fetched-series-per-query`


### PR DESCRIPTION
**What this PR does**:
After cutting Cortex 1.9 we've introduced few new querier limits. Since we're still working on it and we may soon change `-querier.max-fetched-chunks-per-query` (see #4255), in this PR I'm proposing to mark them as experimental until the config will be stable.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
