### PR TITLE
Fix flakey MaxChunkBytesPerQueryLimit test

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1916,7 +1916,6 @@ func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, *rin
 	// Use a real ring with a mock KV store to test ring RF logic.
 	ingesterDescs := map[string]ring.InstanceDesc{}
 	ingestersByAddr := map[string]*mockIngester{}
-
 	for i := range ingesters {
 		addr := fmt.Sprintf("%d", i)
 		ingesterDescs[addr] = ring.InstanceDesc{
@@ -1940,6 +1939,7 @@ func prepare(t *testing.T, cfg prepConfig) ([]*Distributor, []mockIngester, *rin
 	)
 	require.NoError(t, err)
 
+	// Use a default replication factor of 3 if there isn't a provided replication factor.
 	rf := cfg.replicationFactor
 	if rf == 0 {
 		rf = 3

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1013,7 +1013,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIs
 
 	// Prepare distributors.
 	// Use replication factor of 2 to always read all the chunks from both ingesters,
-	// this prevents us from getting chunks from a slow ingester and double counting chunks in the limiter.
+	// this guarantees us to always read the same chunks and have a stable test.
 	ds, _, r, _ := prepare(t, prepConfig{
 		numIngesters:      2,
 		happyIngesters:    2,


### PR DESCRIPTION


Signed-off-by: Tyler Reid <tyler.reid@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Add replication factor flag to the prepConfig Struct. Use replication factor 2 in TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIsReached test to make the test stable

**Which issue(s) this PR fixes**:

**Checklist**
- [ X ] Tests updated
- [-] Documentation added
- [-] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
