### PR TITLE
Fix queries failing right after scaling up store-gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [BUGFIX] Fixed cache fetch error on Redis Cluster. #4056
 * [BUGFIX] Ingester: fix issue where runtime limits erroneously override default limits. #4246
 * [BUGFIX] Ruler: fix startup in single-binary mode when the new `ruler_storage` is used. #4252
+* [BUGFIX] Querier: fix queries failing with "at least 1 healthy replica required, could only find 0" error right after scaling up store-gateways until they're ACTIVE in the ring. #4263
 
 ## Blocksconvert
 

--- a/pkg/querier/blocks_store_replicated_set_test.go
+++ b/pkg/querier/blocks_store_replicated_set_test.go
@@ -179,6 +179,20 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 				"127.0.0.4": {block3, block4},
 			},
 		},
+		"default sharding, multiple instances in the ring are JOINING, the requested block + its replicas only belongs to JOINING instances": {
+			shardingStrategy:  util.ShardingStrategyDefault,
+			replicationFactor: 2,
+			setup: func(d *ring.Desc) {
+				d.AddIngester("instance-1", "127.0.0.1", "", []uint32{block1Hash + 1}, ring.JOINING, registeredAt)
+				d.AddIngester("instance-2", "127.0.0.2", "", []uint32{block2Hash + 1}, ring.JOINING, registeredAt)
+				d.AddIngester("instance-3", "127.0.0.3", "", []uint32{block3Hash + 1}, ring.JOINING, registeredAt)
+				d.AddIngester("instance-4", "127.0.0.4", "", []uint32{block4Hash + 1}, ring.ACTIVE, registeredAt)
+			},
+			queryBlocks: []ulid.ULID{block1},
+			expectedClients: map[string][]ulid.ULID{
+				"127.0.0.4": {block1},
+			},
+		},
 		//
 		// Sharding strategy: shuffle sharding
 		//

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -41,7 +41,13 @@ var (
 	})
 
 	// BlocksRead is the operation run by the querier to query blocks via the store-gateway.
-	BlocksRead = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
+	BlocksRead = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, func(s ring.InstanceState) bool {
+		// Blocks can only be queried from ACTIVE instances. However, if the block belongs to
+		// a non-active instance, then we should extend the replication set and try to query it
+		// from the next ACTIVE instance in the ring (which is expected to have it because the
+		// BlocksSync operation extends the replication set too).
+		return s != ring.ACTIVE
+	})
 )
 
 // RingConfig masks the ring lifecycler config which contains


### PR DESCRIPTION
**What this PR does**:
This PR fixes the issue described in #4224.

When scaling up a number of store-gateways >= replication factor, if a block (+ its replicas) belongs to all JOINING instances, then the query will fail with the "at least 1 healthy replica required, could only find 0" error until at least 1 of these store-gateway instances is ACTIVE.

The issue is caused by `storegateway.BlocksRead` operation because it doesn't extend the replication set for non-ACTIVE instances, while it should (given we do extend it in the `BlocksSync` operation to keep blocks loaded in the original instance until the new instance holding that block is ACTIVE).

I've been able to manually reproduce it in a testing Cortex cluster, while I can't reproduce it anymore after this PR change.

**Which issue(s) this PR fixes**:
Fixes #4224

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
