### PR TITLE
Chore: fix chunkenc.Iterator comment

### DIFF
--- a/pkg/querier/iterators/chunk_merge_iterator.go
+++ b/pkg/querier/iterators/chunk_merge_iterator.go
@@ -19,7 +19,7 @@ type chunkMergeIterator struct {
 	currErr   error
 }
 
-// NewChunkMergeIterator creates a storage.SeriesIterator for a set of chunks.
+// NewChunkMergeIterator creates a chunkenc.Iterator for a set of chunks.
 func NewChunkMergeIterator(cs []chunk.Chunk, _, _ model.Time) chunkenc.Iterator {
 	its := buildIterators(cs)
 	c := &chunkMergeIterator{


### PR DESCRIPTION
**What this PR does**:
While reviewing #4218 I've noticed `iteratorAdapter` comments says it implements `storage.SeriesIterator` but, after many refactoring iterations in Prometheus, it currently implements `chunkenc.Iterator`. This PR fixes the comments accordingly.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
