### PR TITLE
Remove inadvertant global variable in integration tests

### DIFF
--- a/integration/ingester_limits_test.go
+++ b/integration/ingester_limits_test.go
@@ -80,6 +80,7 @@ func TestIngesterGlobalLimits(t *testing.T) {
 			time.Sleep(2 * time.Second)
 
 			now := time.Now()
+			userID := "e2e-user"
 			client, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", userID)
 			require.NoError(t, err)
 

--- a/integration/ingester_sharding_test.go
+++ b/integration/ingester_sharding_test.go
@@ -80,6 +80,7 @@ func TestIngesterSharding(t *testing.T) {
 
 			// Push series.
 			now := time.Now()
+			userID := "e2e-user"
 			expectedVectors := map[string]model.Vector{}
 
 			client, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -113,6 +113,7 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 
 	// Push a series for each user to Cortex.
 	now := time.Now()
+	userID := "e2e-user"
 
 	distClient, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", userID)
 	require.NoError(t, err)

--- a/integration/zone_aware_test.go
+++ b/integration/zone_aware_test.go
@@ -62,6 +62,7 @@ func TestZoneAwareReplication(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
+	userID := "e2e-user"
 	client, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Remove a global variable in a chunks integration test that was shared
among unrelated tests and use local variables.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
