### PR TITLE
fix: ensure zone aware ring checks filter out unavailable zones

### DIFF
--- a/pkg/ring/replication_strategy_test.go
+++ b/pkg/ring/replication_strategy_test.go
@@ -90,7 +90,7 @@ func TestRingReplicationStrategy(t *testing.T) {
 
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
 			strategy := NewDefaultReplicationStrategy()
-			liveIngesters, maxFailure, err := strategy.Filter(ingesters, Read, tc.replicationFactor, 100*time.Second, false)
+			liveIngesters, maxFailure, err := strategy.Filter(ingesters, Read, tc.replicationFactor, 100*time.Second, []string{})
 			if tc.expectedError == "" {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.liveIngesters, len(liveIngesters))
@@ -152,7 +152,7 @@ func TestIgnoreUnhealthyInstancesReplicationStrategy(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			strategy := NewIgnoreUnhealthyInstancesReplicationStrategy()
-			liveIngesters, maxFailure, err := strategy.Filter(ingesters, Read, 3, 100*time.Second, false)
+			liveIngesters, maxFailure, err := strategy.Filter(ingesters, Read, 3, 100*time.Second, []string{})
 			if tc.expectedError == "" {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.liveIngesters, len(liveIngesters))

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -388,7 +388,7 @@ func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts, 
 		instances = append(instances, instance)
 	}
 
-	if r.cfg.ZoneAwarenessEnabled && len(distinctZones) < r.cfg.ReplicationFactor / 2 {
+	if r.cfg.ZoneAwarenessEnabled && len(distinctZones) < r.cfg.ReplicationFactor/2 {
 		return ReplicationSet{}, fmt.Errorf("not enough available zones with live replicas")
 	}
 

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -388,7 +388,11 @@ func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts, 
 		instances = append(instances, instance)
 	}
 
-	healthyInstances, maxFailure, err := r.strategy.Filter(instances, op, r.cfg.ReplicationFactor, r.cfg.HeartbeatTimeout, r.cfg.ZoneAwarenessEnabled)
+	if r.cfg.ZoneAwarenessEnabled && len(distinctZones) < r.cfg.ReplicationFactor / 2 {
+		return ReplicationSet{}, fmt.Errorf("not enough available zones with live replicas")
+	}
+
+	healthyInstances, maxFailure, err := r.strategy.Filter(instances, op, r.cfg.ReplicationFactor, r.cfg.HeartbeatTimeout, distinctZones)
 	if err != nil {
 		return ReplicationSet{}, err
 	}


### PR DESCRIPTION
**What this PR does**:

- Updates the ring test to check for cases when an entire zone is unavailable
- Refactors the `ReplicationStrategy` interface to take a slice of distinct zones as opposed to a bool
- Filters out instances from unavailable zones in the default replication strategy filter

**Which issue(s) this PR fixes**:

Fixes #4291 