### PR TITLE
chore: Define interface api.Distributor

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -351,11 +351,16 @@ func (a *API) RegisterCompactor(c *compactor.Compactor) {
 	a.RegisterRoute("/compactor/ring", http.HandlerFunc(c.RingHandler), false, "GET", "POST")
 }
 
+type Distributor interface {
+	querier.Distributor
+	UserStatsHandler(w http.ResponseWriter, r *http.Request)
+}
+
 // RegisterQueryable registers the the default routes associated with the querier
 // module.
 func (a *API) RegisterQueryable(
 	queryable storage.SampleAndChunkQueryable,
-	distributor *distributor.Distributor,
+	distributor Distributor,
 ) {
 	// these routes are always registered to the default server
 	a.RegisterRoute("/api/v1/user_stats", http.HandlerFunc(distributor.UserStatsHandler), true, "GET")

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -23,7 +23,6 @@ import (
 	"github.com/weaveworks/common/middleware"
 
 	"github.com/cortexproject/cortex/pkg/chunk/purger"
-	"github.com/cortexproject/cortex/pkg/distributor"
 	"github.com/cortexproject/cortex/pkg/querier"
 	"github.com/cortexproject/cortex/pkg/querier/stats"
 	"github.com/cortexproject/cortex/pkg/util"
@@ -160,7 +159,7 @@ func NewQuerierHandler(
 	queryable storage.SampleAndChunkQueryable,
 	exemplarQueryable storage.ExemplarQueryable,
 	engine *promql.Engine,
-	distributor *distributor.Distributor,
+	distributor Distributor,
 	tombstonesLoader *purger.TombstonesLoader,
 	reg prometheus.Registerer,
 	logger log.Logger,


### PR DESCRIPTION
**What this PR does**:

This allows reusing the API handler while swapping out the Distributor
implementation.

In my use case I would like to use NewQuerierHandler with my own queryable, but not provide a "real" distributor implementation.

Signed-off-by: Christian Simon <simon@swine.de>

**Checklist**
- ~[ ] Tests updated~
- ~[ ] Documentation added~
- ~[ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~
