### PR TITLE
Add ability to support strict JSON unmarshal for `limits`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Add ability to support strict JSON unmarshal for `pkg/util/validation.Limits` struct. custom `UnmarshalJSON()` will fail if input has unknown struct fields.
 * [CHANGE] Cortex chunks storage has been deprecated and it's now in maintenance mode: all Cortex users are encouraged to migrate to the blocks storage. No new features will be added to the chunks storage. The default Cortex configuration still runs the chunks engine; please check out the [blocks storage doc](https://cortexmetrics.io/docs/blocks-storage/) on how to configure Cortex to run with the blocks storage.  #4268
 * [CHANGE] The example Kubernetes manifests (stored at `k8s/`) have been removed due to a lack of proper support and maintenance. #4268
 * [CHANGE] Querier / ruler: deprecated `-store.query-chunk-limit` CLI flag (and its respective YAML config option `max_chunks_per_query`) in favour of `-querier.max-fetched-chunks-per-query` (and its respective YAML config option `max_fetched_chunks_per_query`). The new limit specifies the maximum number of chunks that can be fetched in a single query from ingesters and long-term storage: the total number of actual fetched chunks could be 2x the limit, being independently applied when querying ingesters and long-term storage. #4125

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [CHANGE] Add ability to support strict JSON unmarshal for `pkg/util/validation.Limits` struct. custom `UnmarshalJSON()` will fail if input has unknown struct fields.
+* [CHANGE] Enable strict JSON unmarshal for `pkg/util/validation.Limits` struct. The custom `UnmarshalJSON()` will now fail if the input has unknown fields. #4298
 * [CHANGE] Cortex chunks storage has been deprecated and it's now in maintenance mode: all Cortex users are encouraged to migrate to the blocks storage. No new features will be added to the chunks storage. The default Cortex configuration still runs the chunks engine; please check out the [blocks storage doc](https://cortexmetrics.io/docs/blocks-storage/) on how to configure Cortex to run with the blocks storage.  #4268
 * [CHANGE] The example Kubernetes manifests (stored at `k8s/`) have been removed due to a lack of proper support and maintenance. #4268
 * [CHANGE] Querier / ruler: deprecated `-store.query-chunk-limit` CLI flag (and its respective YAML config option `max_chunks_per_query`) in favour of `-querier.max-fetched-chunks-per-query` (and its respective YAML config option `max_fetched_chunks_per_query`). The new limit specifies the maximum number of chunks that can be fetched in a single query from ingesters and long-term storage: the total number of actual fetched chunks could be 2x the limit, being independently applied when querying ingesters and long-term storage. #4125

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -229,7 +230,10 @@ func (l *Limits) UnmarshalJSON(data []byte) error {
 	}
 
 	type plain Limits
-	return json.Unmarshal(data, (*plain)(l))
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+
+	return dec.Decode((*plain)(l))
 }
 
 func (l *Limits) copyNotificationIntegrationLimits(defaults NotificationRateLimitMap) {

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -165,6 +166,15 @@ func TestLimitsLoadingFromJson(t *testing.T) {
 
 	assert.Equal(t, 0.5, l.IngestionRate, "from json")
 	assert.Equal(t, 100, l.MaxLabelNameLength, "from defaults")
+
+	// Unmarshal should fail if input contains unknown struct fields and
+	// the decoder flag `json.Decoder.DisallowUnknownFields()` is set
+	inp = `{"unknown_fields": 100}`
+	l = Limits{}
+	dec := json.NewDecoder(strings.NewReader(inp))
+	dec.DisallowUnknownFields()
+	err = dec.Decode(&l)
+	assert.Error(t, err)
 }
 
 func TestLimitsTagsYamlMatchJson(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Main problem is currently we cannot strict unmarshal JSON for `Limits` struct using [json.DisallowUnknownFields()](https://golang.org/pkg/encoding/json/#Decoder.DisallowUnknownFields). Because custom `UnmarshalJSON` uses simple `json.Unmarshal()` function. (is it intentional?)

This PR Adds ability to support strict JSON unmarshal for `limits` struct

This is the default behaviour for YAML now.
```
	in := `{"unknown_fields": 100}`
	l := validation.Limits{}

	fmt.Println(yaml.UnmarshalStrict([]byte(in), &l))

	// yaml: unmarshal errors:
	// line 1: field unknown_fields not found in type validation.plain
```

This PR adds same behaviour if unmarshalled from JSON input as well.

**Which issue(s) this PR fixes**:
Fixes NA

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
