### PR TITLE
Fix TestStoreGateway_InitialSyncWithWaitRingStability flakyness

### DIFF
--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -300,7 +300,10 @@ func TestStoreGateway_InitialSyncWithWaitRingStability(t *testing.T) {
 				t.Log("random generator seed:", seed)
 
 				ctx := context.Background()
-				ringStore := consul.NewInMemoryClient(ring.GetCodec())
+				ringStore := consul.NewInMemoryClientWithConfig(ring.GetCodec(), consul.Config{
+					MaxCasRetries: 20,
+					CasRetryDelay: 500 * time.Millisecond,
+				})
 
 				// Create the configured number of gateways.
 				var gateways []*StoreGateway


### PR DESCRIPTION
**What this PR does**:
The `TestStoreGateway_InitialSyncWithWaitRingStability` is flaky and fails with this error:
```
=== RUN   TestStoreGateway_InitialSyncWithWaitRingStability/shuffle_sharding_strategy,_20_gateways,_RF_=_3,_SS_=_3_(bucket_index_enabled_=_false)
    gateway_test.go:300: random generator seed: 1624370314782121000
    gateway_test.go:347:
        	Error Trace:	gateway_test.go:347
        	Error:      	Received unexpected error:
        	            	invalid service state: Failed, expected: Running, failure: unable to start store-gateway dependencies: not healthy, 0 terminated, 1 failed: [register instance in the ring: failed to CAS store-gateway]
        	Test:       	TestStoreGateway_InitialSyncWithWaitRingStability/shuffle_sharding_strategy,_20_gateways,_RF_=_3,_SS_=_3_(bucket_index_enabled_=_false)
```

We've experienced a similar issue CASing the in-memory consul in the test `TestShuffleShardWithCaching` and, at that time, we solved it increasing retries and adding a delay between retries. Getting back to `TestStoreGateway_InitialSyncWithWaitRingStability`, I'm able to reproduce the issue locally in `master` but I can't reproduce it after this PR's change 🤞 

**Which issue(s) this PR fixes**:
Fixes #4290

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
