### PR TITLE
Sharded kv store

### DIFF
--- a/pkg/ring/kv/client.go
+++ b/pkg/ring/kv/client.go
@@ -39,9 +39,10 @@ var inmemoryStore Client
 // Consul, Etcd, Memberlist or MultiClient. It was extracted from Config to keep
 // single-client config separate from final client-config (with all the wrappers)
 type StoreConfig struct {
-	Consul consul.Config `yaml:"consul"`
-	Etcd   etcd.Config   `yaml:"etcd"`
-	Multi  MultiConfig   `yaml:"multi"`
+	Consul  consul.Config `yaml:"consul"`
+	Etcd    etcd.Config   `yaml:"etcd"`
+	Multi   MultiConfig   `yaml:"multi"`
+	Sharded ShardedConfig `yaml:"sharded"`
 
 	// Function that returns memberlist.KV store to use. By using a function, we can delay
 	// initialization of memberlist.KV until it is actually required.
@@ -153,6 +154,9 @@ func createClient(backend string, prefix string, cfg StoreConfig, codec codec.Co
 
 	case "multi":
 		client, err = buildMultiClient(cfg, codec, reg)
+
+	case "sharded":
+		client, err = buildShardedClient(cfg.Sharded, codec, reg)
 
 	// This case is for testing. The mock KV client does not do anything internally.
 	case "mock":

--- a/pkg/ring/kv/sharded.go
+++ b/pkg/ring/kv/sharded.go
@@ -1,0 +1,106 @@
+package kv
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/cortexproject/cortex/pkg/ring/kv/codec"
+	"github.com/cortexproject/cortex/pkg/util/jump"
+)
+
+// ShardedConfig for a new ShardedClient.
+type ShardedConfig struct {
+	Shards []Config `yaml:"shards"`
+}
+
+// ShardedClient implements ring.KVClient for sharded KV store.
+type ShardedClient struct {
+	cfg ShardedConfig
+
+	shards []Client
+}
+
+func buildShardedClient(cfg ShardedConfig, codec codec.Codec, reg prometheus.Registerer) (*ShardedClient, error) {
+	var shards []Client
+	for _, shardCfg := range cfg.Shards {
+		shard, err := NewClient(shardCfg, codec, reg)
+		if err != nil {
+			return nil, err
+		}
+
+		shards = append(shards, shard)
+	}
+
+	return &ShardedClient{
+		cfg:    cfg,
+		shards: shards,
+	}, nil
+}
+
+func (c *ShardedClient) List(ctx context.Context, prefix string) ([]string, error) {
+	g, ctx := errgroup.WithContext(ctx)
+
+	rss := make(chan []string)
+	for _, shard := range c.shards {
+		shard := shard
+		g.Go(func() error {
+			rs, err := shard.List(ctx, prefix)
+			if err != nil {
+				return err
+			}
+
+			rss <- rs
+			return nil
+		})
+	}
+	go func() {
+		g.Wait()
+		close(rss)
+	}()
+
+	var result []string
+	for rs := range rss {
+		result = append(result, rs...)
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *ShardedClient) WatchPrefix(ctx context.Context, prefix string, f func(string, interface{}) bool) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for _, shard := range c.shards {
+		go func(shard Client) {
+			shard.WatchPrefix(ctx, prefix, f)
+			cancel()
+		}(shard)
+	}
+
+	<-ctx.Done()
+}
+
+func (c *ShardedClient) Get(ctx context.Context, key string) (interface{}, error) {
+	i := jump.Hash(key, len(c.shards))
+	return c.shards[i].Get(ctx, key)
+}
+
+func (c *ShardedClient) Delete(ctx context.Context, key string) error {
+	i := jump.Hash(key, len(c.shards))
+	return c.shards[i].Delete(ctx, key)
+}
+
+func (c *ShardedClient) CAS(ctx context.Context, key string, f func(in interface{}) (out interface{}, retry bool, err error)) error {
+	i := jump.Hash(key, len(c.shards))
+	return c.shards[i].CAS(ctx, key, f)
+}
+
+func (c *ShardedClient) WatchKey(ctx context.Context, key string, f func(interface{}) bool) {
+	i := jump.Hash(key, len(c.shards))
+	c.shards[i].WatchKey(ctx, key, f)
+}

--- a/pkg/ring/kv/sharded_test.go
+++ b/pkg/ring/kv/sharded_test.go
@@ -1,0 +1,61 @@
+package kv
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/ring/kv/codec"
+	"github.com/cortexproject/cortex/pkg/ring/kv/etcd"
+)
+
+func TestSharded(t *testing.T) {
+	var shards []Client
+	var closers []io.Closer
+
+	defer func() {
+		for _, closer := range closers {
+			closer.Close()
+		}
+	}()
+
+	for i := 0; i < 3; i++ {
+		shard, closer, err := etcd.Mock(codec.String{})
+		require.NoError(t, err)
+		shards = append(shards, shard)
+		closers = append(closers, closer)
+	}
+
+	sharded := &ShardedClient{
+		shards: shards,
+	}
+
+	// Put three keys, selected to has to 3 different shards.
+	keys := []string{"fooo", "bar", "baz"}
+	for _, key := range keys {
+		require.NoError(t, sharded.CAS(context.Background(), key, func(in interface{}) (out interface{}, retry bool, err error) {
+			return key, false, nil
+		}))
+	}
+
+	// Make sure we can get them.
+	for _, key := range keys {
+		value, err := sharded.Get(context.Background(), key)
+		require.NoError(t, err)
+		require.Equal(t, key, value)
+	}
+
+	// Make sure we can list them.
+	actual, err := sharded.List(context.Background(), "")
+	require.NoError(t, err)
+	require.ElementsMatch(t, keys, actual)
+
+	// Make sure each shared got one key.
+	for _, shard := range shards {
+		keys, err := shard.List(context.Background(), "")
+		require.NoError(t, err)
+		require.Len(t, keys, 1)
+	}
+}

--- a/pkg/util/jump/hash.go
+++ b/pkg/util/jump/hash.go
@@ -1,0 +1,21 @@
+package jump
+
+import "github.com/cespare/xxhash"
+
+// Hash consistently chooses a hash bucket number in the range [0, numBuckets) for the given key.
+// numBuckets must be >= 1.
+//
+// Copied from github.com/dgryski/go-jump/blob/master/jump.go
+func Hash(key string, numBuckets int) int32 {
+	var cs uint64 = xxhash.Sum64String(key)
+	var b int64 = -1
+	var j int64
+
+	for j < int64(numBuckets) {
+		b = j
+		cs = cs*2862933555777941757 + 1
+		j = int64(float64(b+1) * (float64(int64(1)<<31) / float64((cs>>33)+1)))
+	}
+
+	return int32(b)
+}

--- a/pkg/util/jump/hash_test.go
+++ b/pkg/util/jump/hash_test.go
@@ -1,0 +1,29 @@
+package jump
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	keys    = 1000
+	buckets = 100
+)
+
+func TestHash(t *testing.T) {
+	counts := map[int32]int{}
+	r := rand.NewSource(1985)
+
+	for i := 0; i <= 100; i++ {
+		key := fmt.Sprintf("%064x", r.Int63())
+		j := Hash(string(key), 10)
+		counts[j] += 1
+	}
+
+	for i := int32(0); i < 10; i++ {
+		require.InEpsilon(t, keys/buckets, counts[i], 0.5)
+	}
+}


### PR DESCRIPTION
**What this PR does**:

Adds a jump-hash sharded KV implementation that should allow us scale up the etcd clusters used for HA dedupe.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
