### PR TITLE
Expose some ruler types to ease reuse.

### DIFF
--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -231,7 +231,7 @@ func TestMetricsQueryFuncErrors(t *testing.T) {
 				return promql.Vector{}, tc.returnedError
 			}
 
-			qf := metricsQueryFunc(mockFunc, queries, failures)
+			qf := MetricsQueryFunc(mockFunc, queries, failures)
 
 			_, err := qf(context.Background(), "test", time.Now())
 			require.Equal(t, tc.returnedError, err)


### PR DESCRIPTION
**What this PR does**: This trivial PR exposes some internal ruler types, to ease reuse by other projects.

**Checklist**
- [ ] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
