### PR TITLE
Fix any should be all in docs/architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,7 +117,7 @@ Cortex supports two hashing strategies:
 1. Hash the metric name and tenant ID (default)
 2. Hash the metric name, labels and tenant ID (enabled with `-distributor.shard-by-all-labels=true`)
 
-The trade-off associated with the latter is that writes are more balanced across ingesters but each query needs to talk to any ingester since a metric could be spread across multiple ingesters given different label sets.
+The trade-off associated with the latter is that writes are more balanced across ingesters but each query needs to talk to all ingesters since a metric could be spread across multiple ingesters given different label sets.
 
 #### The hash ring
 


### PR DESCRIPTION
**What this PR does**:

I understand that any should be all when talking about queries when using the metric name, labels and Tenant ID as the hashing strategy.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
