### PR TITLE
Fix ruler query failure reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [ENHANCEMENT] Memberlist: optimized receive path for processing ring state updates, to help reduce CPU utilization in large clusters. #4345
 * [ENHANCEMENT] Memberlist: expose configuration of memberlist packet compression via `-memberlist.compression=enabled`. #4346
 * [BUGFIX] HA Tracker: when cleaning up obsolete elected replicas from KV store, tracker didn't update number of cluster per user correctly. #4336
+* [BUGFIX] Ruler: fixed counting of PromQL evaluation errors as user-errors when updating `cortex_ruler_queries_failed_total`. #4335
 
 ## 1.10.0-rc.0 / 2021-06-28
 

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -318,6 +318,11 @@ func (c *Client) SetRuleGroup(rulegroup rulefmt.RuleGroup, namespace string) err
 	}
 
 	defer res.Body.Close()
+
+	if res.StatusCode != 202 {
+		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
 	return nil
 }
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -194,7 +194,7 @@ func NewQuerierHandler(
 
 	api := v1.NewAPI(
 		engine,
-		querier.NewErrorTranslateQueryable(queryable), // Translate errors to errors expected by API.
+		querier.NewErrorTranslateSampleAndChunkQueryable(queryable), // Translate errors to errors expected by API.
 		nil, // No remote write support.
 		exemplarQueryable,
 		func(context.Context) v1.TargetRetriever { return &querier.DummyTargetRetriever{} },

--- a/pkg/querier/error_translate_queryable.go
+++ b/pkg/querier/error_translate_queryable.go
@@ -69,85 +69,103 @@ func TranslateToPromqlAPIError(err error) error {
 	}
 }
 
+// ErrTranslateFn is used to translate or wrap error before returning it by functions in
+// storage.SampleAndChunkQueryable interface.
+// Input error may be nil.
+type ErrTranslateFn func(err error) error
+
 func NewErrorTranslateQueryable(q storage.Queryable) storage.Queryable {
-	return errorTranslateQueryable{q}
+	return NewErrorTranslateQueryableWithFn(q, TranslateToPromqlAPIError)
+}
+
+func NewErrorTranslateQueryableWithFn(q storage.Queryable, fn ErrTranslateFn) storage.Queryable {
+	return errorTranslateQueryable{q: q, fn: fn}
 }
 
 func NewErrorTranslateSampleAndChunkQueryable(q storage.SampleAndChunkQueryable) storage.SampleAndChunkQueryable {
-	return errorTranslateSampleAndChunkQueryable{q}
+	return NewErrorTranslateSampleAndChunkQueryableWithFn(q, TranslateToPromqlAPIError)
+}
+
+func NewErrorTranslateSampleAndChunkQueryableWithFn(q storage.SampleAndChunkQueryable, fn ErrTranslateFn) storage.SampleAndChunkQueryable {
+	return errorTranslateSampleAndChunkQueryable{q: q, fn: fn}
 }
 
 type errorTranslateQueryable struct {
-	q storage.Queryable
+	q  storage.Queryable
+	fn ErrTranslateFn
 }
 
 func (e errorTranslateQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 	q, err := e.q.Querier(ctx, mint, maxt)
-	return errorTranslateQuerier{q: q}, TranslateToPromqlAPIError(err)
+	return errorTranslateQuerier{q: q, fn: e.fn}, e.fn(err)
 }
 
 type errorTranslateSampleAndChunkQueryable struct {
-	q storage.SampleAndChunkQueryable
+	q  storage.SampleAndChunkQueryable
+	fn ErrTranslateFn
 }
 
 func (e errorTranslateSampleAndChunkQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 	q, err := e.q.Querier(ctx, mint, maxt)
-	return errorTranslateQuerier{q: q}, TranslateToPromqlAPIError(err)
+	return errorTranslateQuerier{q: q, fn: e.fn}, e.fn(err)
 }
 
 func (e errorTranslateSampleAndChunkQueryable) ChunkQuerier(ctx context.Context, mint, maxt int64) (storage.ChunkQuerier, error) {
 	q, err := e.q.ChunkQuerier(ctx, mint, maxt)
-	return errorTranslateChunkQuerier{q: q}, TranslateToPromqlAPIError(err)
+	return errorTranslateChunkQuerier{q: q, fn: e.fn}, e.fn(err)
 }
 
 type errorTranslateQuerier struct {
-	q storage.Querier
+	q  storage.Querier
+	fn ErrTranslateFn
 }
 
 func (e errorTranslateQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	values, warnings, err := e.q.LabelValues(name, matchers...)
-	return values, warnings, TranslateToPromqlAPIError(err)
+	return values, warnings, e.fn(err)
 }
 
 func (e errorTranslateQuerier) LabelNames() ([]string, storage.Warnings, error) {
 	values, warnings, err := e.q.LabelNames()
-	return values, warnings, TranslateToPromqlAPIError(err)
+	return values, warnings, e.fn(err)
 }
 
 func (e errorTranslateQuerier) Close() error {
-	return TranslateToPromqlAPIError(e.q.Close())
+	return e.fn(e.q.Close())
 }
 
 func (e errorTranslateQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 	s := e.q.Select(sortSeries, hints, matchers...)
-	return errorTranslateSeriesSet{s}
+	return errorTranslateSeriesSet{s: s, fn: e.fn}
 }
 
 type errorTranslateChunkQuerier struct {
-	q storage.ChunkQuerier
+	q  storage.ChunkQuerier
+	fn ErrTranslateFn
 }
 
 func (e errorTranslateChunkQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	values, warnings, err := e.q.LabelValues(name, matchers...)
-	return values, warnings, TranslateToPromqlAPIError(err)
+	return values, warnings, e.fn(err)
 }
 
 func (e errorTranslateChunkQuerier) LabelNames() ([]string, storage.Warnings, error) {
 	values, warnings, err := e.q.LabelNames()
-	return values, warnings, TranslateToPromqlAPIError(err)
+	return values, warnings, e.fn(err)
 }
 
 func (e errorTranslateChunkQuerier) Close() error {
-	return TranslateToPromqlAPIError(e.q.Close())
+	return e.fn(e.q.Close())
 }
 
 func (e errorTranslateChunkQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {
 	s := e.q.Select(sortSeries, hints, matchers...)
-	return errorTranslateChunkSeriesSet{s}
+	return errorTranslateChunkSeriesSet{s: s, fn: e.fn}
 }
 
 type errorTranslateSeriesSet struct {
-	s storage.SeriesSet
+	s  storage.SeriesSet
+	fn ErrTranslateFn
 }
 
 func (e errorTranslateSeriesSet) Next() bool {
@@ -159,7 +177,7 @@ func (e errorTranslateSeriesSet) At() storage.Series {
 }
 
 func (e errorTranslateSeriesSet) Err() error {
-	return TranslateToPromqlAPIError(e.s.Err())
+	return e.fn(e.s.Err())
 }
 
 func (e errorTranslateSeriesSet) Warnings() storage.Warnings {
@@ -167,7 +185,8 @@ func (e errorTranslateSeriesSet) Warnings() storage.Warnings {
 }
 
 type errorTranslateChunkSeriesSet struct {
-	s storage.ChunkSeriesSet
+	s  storage.ChunkSeriesSet
+	fn ErrTranslateFn
 }
 
 func (e errorTranslateChunkSeriesSet) Next() bool {
@@ -179,7 +198,7 @@ func (e errorTranslateChunkSeriesSet) At() storage.ChunkSeries {
 }
 
 func (e errorTranslateChunkSeriesSet) Err() error {
-	return TranslateToPromqlAPIError(e.s.Err())
+	return e.fn(e.s.Err())
 }
 
 func (e errorTranslateChunkSeriesSet) Warnings() storage.Warnings {

--- a/pkg/querier/error_translate_queryable.go
+++ b/pkg/querier/error_translate_queryable.go
@@ -69,12 +69,16 @@ func TranslateToPromqlAPIError(err error) error {
 	}
 }
 
-func NewErrorTranslateQueryable(q storage.SampleAndChunkQueryable) storage.SampleAndChunkQueryable {
+func NewErrorTranslateQueryable(q storage.Queryable) storage.Queryable {
 	return errorTranslateQueryable{q}
 }
 
+func NewErrorTranslateSampleAndChunkQueryable(q storage.SampleAndChunkQueryable) storage.SampleAndChunkQueryable {
+	return errorTranslateSampleAndChunkQueryable{q}
+}
+
 type errorTranslateQueryable struct {
-	q storage.SampleAndChunkQueryable
+	q storage.Queryable
 }
 
 func (e errorTranslateQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
@@ -82,7 +86,16 @@ func (e errorTranslateQueryable) Querier(ctx context.Context, mint, maxt int64) 
 	return errorTranslateQuerier{q: q}, TranslateToPromqlAPIError(err)
 }
 
-func (e errorTranslateQueryable) ChunkQuerier(ctx context.Context, mint, maxt int64) (storage.ChunkQuerier, error) {
+type errorTranslateSampleAndChunkQueryable struct {
+	q storage.SampleAndChunkQueryable
+}
+
+func (e errorTranslateSampleAndChunkQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+	q, err := e.q.Querier(ctx, mint, maxt)
+	return errorTranslateQuerier{q: q}, TranslateToPromqlAPIError(err)
+}
+
+func (e errorTranslateSampleAndChunkQueryable) ChunkQuerier(ctx context.Context, mint, maxt int64) (storage.ChunkQuerier, error) {
 	q, err := e.q.ChunkQuerier(ctx, mint, maxt)
 	return errorTranslateChunkQuerier{q: q}, TranslateToPromqlAPIError(err)
 }

--- a/pkg/querier/error_translate_queryable_test.go
+++ b/pkg/querier/error_translate_queryable_test.go
@@ -26,7 +26,22 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
+func wrapper(q storage.SampleAndChunkQueryable) storage.SampleAndChunkQueryable {
+	return errorTranslateSampleAndChunkQueryable{q: q}
+}
+
 func TestApiStatusCodes(t *testing.T) {
+	testWithWrapperFunc(t, wrapper)
+}
+
+// Make sure that error-translation is idempotent.
+func TestApiStatusCodesDoubleWrapper(t *testing.T) {
+	testWithWrapperFunc(t, func(q storage.SampleAndChunkQueryable) storage.SampleAndChunkQueryable {
+		return wrapper(wrapper(q))
+	})
+}
+
+func testWithWrapperFunc(t *testing.T, wrapperFn func(q storage.SampleAndChunkQueryable) storage.SampleAndChunkQueryable) {
 	for ix, tc := range []struct {
 		err            error
 		expectedString string
@@ -113,7 +128,7 @@ func TestApiStatusCodes(t *testing.T) {
 			"error from seriesset": errorTestQueryable{q: errorTestQuerier{s: errorTestSeriesSet{err: tc.err}}},
 		} {
 			t.Run(fmt.Sprintf("%s/%d", k, ix), func(t *testing.T) {
-				r := createPrometheusAPI(errorTranslateQueryable{q: q})
+				r := createPrometheusAPI(wrapperFn(q))
 				rec := httptest.NewRecorder()
 
 				req := httptest.NewRequest("GET", "/api/v1/query?query=up", nil)

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -234,6 +234,11 @@ func DefaultTenantManagerFactory(cfg Config, p Pusher, q storage.Queryable, engi
 		}, []string{"user"})
 	}
 
+	// Make sure that queryable reports errors as expected by our MetricsQueryFunc.
+	// Note that if queryable is already wrapped into ErrorTranslateQueryable, wrapping it again
+	// is fine (see TestApiStatusCodesDoubleWrapper in querier package).
+	q = querier.NewErrorTranslateQueryable(q)
+
 	return func(ctx context.Context, userID string, notifier *notifier.Manager, logger log.Logger, reg prometheus.Registerer) RulesManager {
 		var queryTime prometheus.Counter = nil
 		if rulerQuerySeconds != nil {

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -149,16 +149,30 @@ func MetricsQueryFunc(qf rules.QueryFunc, queries, failedQueries prometheus.Coun
 	return func(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
 		queries.Inc()
 		result, err := qf(ctx, qs, t)
-		// We rely on TranslateToPromqlApiError to do its job here... it returns nil, if err is nil.
-		// It returns promql.ErrStorage, if error should be reported back as 500.
-		// Other errors it returns are either for canceled or timed-out queriers (we're not reporting those as failures),
-		// or various user-errors (limits, duplicate samples, etc. ... also not failures).
-		//
-		// All errors will still be counted towards "evaluation failures" metrics and logged by Prometheus Ruler,
-		// but we only want internal errors here.
-		if _, ok := querier.TranslateToPromqlAPIError(err).(promql.ErrStorage); ok {
-			failedQueries.Inc()
+
+		// We only care about errors returned by underlying Queryable. Errors returned by PromQL engine are "user-errors",
+		// and not interesting here.
+		qerr := QueryableError{}
+		if err != nil && errors.As(err, &qerr) {
+			origErr := qerr.Unwrap()
+
+			// Not all errors returned by Queryable are interesting, only those that would result in 500 status code.
+			//
+			// We rely on TranslateToPromqlApiError to do its job here... it returns nil, if err is nil.
+			// It returns promql.ErrStorage, if error should be reported back as 500.
+			// Other errors it returns are either for canceled or timed-out queriers (we're not reporting those as failures),
+			// or various user-errors (limits, duplicate samples, etc. ... also not failures).
+			//
+			// All errors will still be counted towards "evaluation failures" metrics and logged by Prometheus Ruler,
+			// but we only want internal errors here.
+			if _, ok := querier.TranslateToPromqlAPIError(origErr).(promql.ErrStorage); ok {
+				failedQueries.Inc()
+			}
+
+			// Return unwrapped error.
+			return result, origErr
 		}
+
 		return result, err
 	}
 }
@@ -234,10 +248,10 @@ func DefaultTenantManagerFactory(cfg Config, p Pusher, q storage.Queryable, engi
 		}, []string{"user"})
 	}
 
-	// Make sure that queryable reports errors as expected by our MetricsQueryFunc.
-	// Note that if queryable is already wrapped into ErrorTranslateQueryable, wrapping it again
-	// is fine (see TestApiStatusCodesDoubleWrapper in querier package).
-	q = querier.NewErrorTranslateQueryable(q)
+	// Wrap errors returned by Queryable to our wrapper, so that we can distinguish between those errors
+	// and errors returned by PromQL engine. Errors from Queryable can be either caused by user (limits) or internal errors.
+	// Errors from PromQL are always "user" errors.
+	q = querier.NewErrorTranslateQueryableWithFn(q, WrapQueryableErrors)
 
 	return func(ctx context.Context, userID string, notifier *notifier.Manager, logger log.Logger, reg prometheus.Registerer) RulesManager {
 		var queryTime prometheus.Counter = nil
@@ -259,4 +273,24 @@ func DefaultTenantManagerFactory(cfg Config, p Pusher, q storage.Queryable, engi
 			ResendDelay:     cfg.ResendDelay,
 		})
 	}
+}
+
+type QueryableError struct {
+	err error
+}
+
+func (q QueryableError) Unwrap() error {
+	return q.err
+}
+
+func (q QueryableError) Error() string {
+	return q.err.Error()
+}
+
+func WrapQueryableErrors(err error) error {
+	if err == nil {
+		return err
+	}
+
+	return QueryableError{err: err}
 }

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -229,7 +229,7 @@ func TestMetricsQueryFuncErrors(t *testing.T) {
 			failures := prometheus.NewCounter(prometheus.CounterOpts{})
 
 			mockFunc := func(ctx context.Context, q string, t time.Time) (promql.Vector, error) {
-				return promql.Vector{}, tc.returnedError
+				return promql.Vector{}, WrapQueryableErrors(tc.returnedError)
 			}
 			qf := MetricsQueryFunc(mockFunc, queries, failures)
 


### PR DESCRIPTION
**What this PR does**: This PR fixes problem described in issue https://github.com/cortexproject/cortex/issues/4333. It does so by wrapping errors returned by supplied `Queryable` into special wrapper, that is then recognized and unwrapped by `MetricsQueryFunc`. This allows "failures" metric to be updated only if error was actually caused by internal Cortex error, and not by PromQL engine failure during evaluation (this fixes #4333), or by hitting limits.

This PR also adds integration test to check for these scenarios.

**Which issue(s) this PR fixes**:
Fixes https://github.com/cortexproject/cortex/issues/4333

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
