### PR TITLE
Add a security doc

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -36,6 +36,9 @@ should read:
 1. [Getting started with Cortex](getting-started/_index.md)
 1. [Information regarding configuring Cortex](configuration/_index.md)
 
+There are also individual [guides](guides/_index.md) to many tasks.
+Please review the important [security advice](guides/security.md) before deploying.
+
 For a guide to contributing to Cortex, see the [contributor guidelines](contributing/).
 
 ## Further reading

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -1,0 +1,12 @@
+---
+title: "Security"
+linkTitle: "Security"
+weight: 10
+slug: security
+---
+
+Cortex must be deployed with due care over system configuration, using principles such as "least privilege" to limit any exposure due to flaws in the source code.
+
+You must configure authorisation and authentication externally to Cortex; see [this guide](./authentication-and-authorisation.md)
+
+Information about security disclosures and mailing lists is [in the main repo](https://github.com/cortexproject/cortex/blob/master/SECURITY.md)


### PR DESCRIPTION
I thought it would be good to put a security page into the docs, so that it shows up in a search.

Content is just pointing at other resources.

