### PR TITLE
MergeIterator: allocate less memory at first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [CHANGE] Querier / ruler: Change `-querier.max-fetched-chunks-per-query` configuration to limit to maximum number of chunks that can be fetched in a single query. The number of chunks fetched by ingesters AND long-term storare combined should not exceed the value configured on `-querier.max-fetched-chunks-per-query`. #4260
 * [ENHANCEMENT] Add timeout for waiting on compactor to become ACTIVE in the ring. #4262
+* [ENHANCEMENT] Reduce memory used by streaming queries, particularly in ruler. #4341
 * [BUGFIX] HA Tracker: when cleaning up obsolete elected replicas from KV store, tracker didn't update number of cluster per user correctly. #4336
 
 ## 1.10.0-rc.0 / 2021-06-28

--- a/pkg/querier/batch/batch_test.go
+++ b/pkg/querier/batch/batch_test.go
@@ -27,6 +27,10 @@ func BenchmarkNewChunkMergeIterator_CreateAndIterate(b *testing.B) {
 		{numChunks: 1000, numSamplesPerChunk: 100, duplicationFactor: 3, enc: promchunk.DoubleDelta},
 		{numChunks: 1000, numSamplesPerChunk: 100, duplicationFactor: 1, enc: promchunk.PrometheusXorChunk},
 		{numChunks: 1000, numSamplesPerChunk: 100, duplicationFactor: 3, enc: promchunk.PrometheusXorChunk},
+		{numChunks: 100, numSamplesPerChunk: 100, duplicationFactor: 1, enc: promchunk.PrometheusXorChunk},
+		{numChunks: 100, numSamplesPerChunk: 100, duplicationFactor: 3, enc: promchunk.PrometheusXorChunk},
+		{numChunks: 1, numSamplesPerChunk: 100, duplicationFactor: 1, enc: promchunk.PrometheusXorChunk},
+		{numChunks: 1, numSamplesPerChunk: 100, duplicationFactor: 3, enc: promchunk.PrometheusXorChunk},
 	}
 
 	for _, scenario := range scenarios {

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -59,6 +59,7 @@ func mkChunk(t require.TestingT, from model.Time, points int, enc promchunk.Enco
 		require.Nil(t, npc)
 		ts = ts.Add(step)
 	}
+	ts = ts.Add(-step) // undo the add that we did just before exiting the loop
 	return chunk.NewChunk(userID, fp, metric, pc, from, ts)
 }
 

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -31,8 +31,8 @@ func newMergeIterator(cs []GenericChunk) *mergeIterator {
 	c := &mergeIterator{
 		its:        its,
 		h:          make(iteratorHeap, 0, len(its)),
-		batches:    make(batchStream, 0, len(its)*2*promchunk.BatchSize),
-		batchesBuf: make(batchStream, len(its)*2*promchunk.BatchSize),
+		batches:    make(batchStream, 0, len(its)),
+		batchesBuf: make(batchStream, len(its)),
 	}
 
 	for _, iter := range c.its {
@@ -112,8 +112,7 @@ func (c *mergeIterator) buildNextBatch(size int) bool {
 	for len(c.h) > 0 && (len(c.batches) == 0 || c.nextBatchEndTime() >= c.h[0].AtTime()) {
 		c.nextBatchBuf[0] = c.h[0].Batch()
 		c.batchesBuf = mergeStreams(c.batches, c.nextBatchBuf[:], c.batchesBuf, size)
-		copy(c.batches[:len(c.batchesBuf)], c.batchesBuf)
-		c.batches = c.batches[:len(c.batchesBuf)]
+		c.batches = append(c.batches[:0], c.batchesBuf...)
 
 		if c.h[0].Next(size) {
 			heap.Fix(&c.h, 0)


### PR DESCRIPTION
**What this PR does**:

We were allocating 24x the number of streams of batches, where each batch holds up to 12 samples.
By allowing `c.batches` to reallocate when needed, we avoid the need to pre-allocate enough memory for all possible scenarios.

Also fix innacurate end time on chunks test data, which was throwing off the benchmark, and add more realistic test sizes - at 15-second scrape intervals a chunk covers 30 minutes, so 1,000 chunks is about three weeks, a highly un-representative test.

**Which issue(s) this PR fixes**:
Fixes #1195

**Benchmarks**
```
name                                                                                                                             old time/op    new time/op    delta
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Bigchunk-4              12.3ms ± 4%    12.1ms ± 2%     ~     (p=0.548 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Bigchunk-4              30.3ms ± 3%    30.5ms ± 3%     ~     (p=0.548 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Varbit-4                8.96ms ± 4%    8.80ms ± 0%     ~     (p=0.190 n=5+4)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Varbit-4                21.8ms ± 3%    21.6ms ± 3%     ~     (p=0.548 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_DoubleDelta-4           10.7ms ± 4%    10.5ms ± 2%     ~     (p=0.310 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_DoubleDelta-4           26.5ms ± 3%    26.5ms ± 4%     ~     (p=0.841 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusXorChunk-4    12.4ms ± 6%    12.4ms ± 5%     ~     (p=0.690 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusXorChunk-4    31.7ms ± 4%    31.2ms ± 3%     ~     (p=0.421 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_100_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusXorChunk-4     1.23ms ± 5%    1.22ms ± 3%     ~     (p=0.548 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_100_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusXorChunk-4     3.11ms ± 2%    3.13ms ± 2%     ~     (p=0.421 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusXorChunk-4       17.2µs ± 4%    13.9µs ± 2%  -18.89%  (p=0.008 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusXorChunk-4       44.3µs ± 2%    36.4µs ± 5%  -17.86%  (p=0.008 n=5+5)

name                                                                                                                             old alloc/op   new alloc/op   delta
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Bigchunk-4              85.0kB ± 0%    74.6kB ± 0%  -12.16%  (p=0.008 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Bigchunk-4               320kB ± 0%     288kB ± 0%   -9.84%  (p=0.029 n=4+4)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Varbit-4                 213kB ± 0%     202kB ± 0%   -4.86%  (p=0.029 n=4+4)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Varbit-4                 703kB ± 0%     672kB ± 0%     ~     (p=0.079 n=4+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_DoubleDelta-4            213kB ± 0%     202kB ± 0%   -4.86%  (p=0.008 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_DoubleDelta-4            703kB ± 0%     672kB ± 0%   -4.48%  (p=0.008 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusXorChunk-4    85.0kB ± 0%    74.6kB ± 0%  -12.16%  (p=0.029 n=4+4)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusXorChunk-4     320kB ± 0%     288kB ± 0%   -9.84%  (p=0.008 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_100_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusXorChunk-4     19.6kB ± 0%     9.3kB ± 0%  -52.76%  (p=0.008 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_100_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusXorChunk-4     65.3kB ± 0%    33.8kB ± 0%  -48.25%  (p=0.008 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusXorChunk-4       11.9kB ± 0%     1.6kB ± 0%  -86.94%  (p=0.008 n=5+5)
NewChunkMergeIterator_CreateAndIterate/chunks:_1_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusXorChunk-4       35.2kB ± 0%     3.7kB ± 0%  -89.54%  (p=0.008 n=5+5)

name                                                                                                                             old allocs/op  new allocs/op  delta
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Bigchunk-4               1.01k ± 0%     1.01k ± 0%     ~     (all equal)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Bigchunk-4               3.02k ± 0%     3.02k ± 0%     ~     (all equal)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_Varbit-4                 2.01k ± 0%     2.01k ± 0%     ~     (all equal)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_Varbit-4                 6.02k ± 0%     6.02k ± 0%     ~     (all equal)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_DoubleDelta-4            3.01k ± 0%     3.01k ± 0%     ~     (all equal)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_DoubleDelta-4            9.02k ± 0%     9.02k ± 0%     ~     (all equal)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusXorChunk-4     1.01k ± 0%     1.01k ± 0%     ~     (all equal)
NewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusXorChunk-4     3.02k ± 0%     3.02k ± 0%     ~     (all equal)
NewChunkMergeIterator_CreateAndIterate/chunks:_100_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusXorChunk-4        113 ± 0%       113 ± 0%     ~     (all equal)
NewChunkMergeIterator_CreateAndIterate/chunks:_100_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusXorChunk-4        323 ± 0%       323 ± 0%     ~     (all equal)
NewChunkMergeIterator_CreateAndIterate/chunks:_1_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusXorChunk-4         14.0 ± 0%      14.0 ± 0%     ~     (all equal)
NewChunkMergeIterator_CreateAndIterate/chunks:_1_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusXorChunk-4         26.0 ± 0%      26.0 ± 0%     ~     (all equal)
```

**Checklist**
- [x] Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated 
