### PR TITLE
Make TestSingleBinaryWithMemberlistScaling test less flaky.

### DIFF
--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/cortexproject/cortex/integration/ca"
 	"github.com/cortexproject/cortex/integration/e2e"
@@ -184,14 +183,12 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 
 	// Scale down as fast as possible but cleanly, in order to send out tombstones.
 
-	stop := errgroup.Group{}
 	for len(instances) > minCortex {
 		i := len(instances) - 1
 		c := instances[i]
 		instances = instances[:i]
-		stop.Go(func() error { return s.Stop(c) })
+		require.NoError(t, s.Stop(c))
 	}
-	require.NoError(t, stop.Wait())
 
 	// If all is working as expected, then tombstones should have propagated easily within this time period.
 	// The logging is mildly spammy, but it has proven extremely useful for debugging convergence cases.


### PR DESCRIPTION
**What this PR does**:

Make TestSingleBinaryWithMemberlistScaling test less flaky.

Scaling down the ingesters in parallel triggers a scenario in tombstone
propagation which is not trivial to fix. This change should make the
test reliable for the time being.

Signed-off-by: Steve Simpson <steve.simpson@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->
**Which issue(s) this PR fixes**:
Fixes #4289

**Checklist**
- [x] ~~Tests updated~~
- [x] ~~Documentation added~~
- [x] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~
