### PR TITLE
Attempt at making SyncOnRingTopologyChanges test more reliable.

### DIFF
--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -1325,18 +1325,15 @@ func TestMultitenantAlertmanager_SyncOnRingTopologyChanges(t *testing.T) {
 				return ringDesc, true, nil
 			}))
 
-			// Assert if we expected a sync or not.
+			// Assert if we expected an additional sync or not.
+			expectedSyncs := 1
 			if tt.expected {
-				test.Poll(t, time.Second, float64(2), func() interface{} {
-					metrics := regs.BuildMetricFamiliesPerUser()
-					return metrics.GetSumOfCounters("cortex_alertmanager_sync_configs_total")
-				})
-			} else {
-				time.Sleep(250 * time.Millisecond)
-
-				metrics := regs.BuildMetricFamiliesPerUser()
-				assert.Equal(t, float64(1), metrics.GetSumOfCounters("cortex_alertmanager_sync_configs_total"))
+				expectedSyncs++
 			}
+			test.Poll(t, 5*time.Second, float64(expectedSyncs), func() interface{} {
+				metrics := regs.BuildMetricFamiliesPerUser()
+				return metrics.GetSumOfCounters("cortex_alertmanager_sync_configs_total")
+			})
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:

Attempt at making SyncOnRingTopologyChanges test more reliable.

It was only waiting one second for the second sync to complete, which is
probably too harsh a deadline than necessary for overloaded systems.

Signed-off-by: Steve Simpson <steve.simpson@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**Which issue(s) this PR fixes**:
Fixes #4229

**Checklist**
- [x] ~~Tests updated~~
- [x] ~~Documentation added~~
- [x] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~
