### PR TITLE
Fix StateReplicationWithSharding_InitialSyncFromPeers flaking.

### DIFF
--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -1820,7 +1820,14 @@ func TestAlertmanager_StateReplicationWithSharding_InitialSyncFromPeers(t *testi
 			{
 				metrics := registries.BuildMetricFamiliesPerUser()
 				assert.Equal(t, float64(1), metrics.GetSumOfGauges("cortex_alertmanager_silences"))
-				assert.Equal(t, float64(1), metrics.GetSumOfCounters("cortex_alertmanager_state_replication_total"))
+			}
+			// 2.c. Wait for the silence replication to be attempted; note this is asynchronous.
+			{
+				test.Poll(t, 5*time.Second, float64(1), func() interface{} {
+					metrics := registries.BuildMetricFamiliesPerUser()
+					return metrics.GetSumOfCounters("cortex_alertmanager_state_replication_total")
+				})
+				metrics := registries.BuildMetricFamiliesPerUser()
 				assert.Equal(t, float64(0), metrics.GetSumOfCounters("cortex_alertmanager_state_replication_failed_total"))
 			}
 


### PR DESCRIPTION
**What this PR does**:
Fix StateReplicationWithSharding_InitialSyncFromPeers flaking.

The test is writing a single silence and  checking a metric which
indicates whether replicating the silence has been attempted yet.
This is so we can check later on that no replication activity
occurs. The assertions later on in the test are passing, but the
first one is not, indicating that the replication doesn't trigger
early enough. This makes sense because the replication is not
synchronous with the writing of the silence.

Signed-off-by: Steve Simpson <steve.simpson@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**Which issue(s) this PR fixes**:
Fixes #4160

**Checklist**
- [x] ~~Tests updated~~
- [x] ~~Documentation added~~
- [x] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~
