### PR TITLE
Fix integration TestAlertmanagerSharding flaking.

### DIFF
--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -531,6 +531,12 @@ func TestAlertmanagerSharding(t *testing.T) {
 				require.NoError(t, err)
 				err = c3.SendAlertToAlermanager(context.Background(), alert(3, 2))
 				require.NoError(t, err)
+
+				// Wait for the alerts to be received by every replica.
+				require.NoError(t, alertmanagers.WaitSumMetricsWithOptions(
+					e2e.Equals(float64(3*testCfg.replicationFactor)),
+					[]string{"cortex_alertmanager_alerts_received_total"},
+					e2e.SkipMissingMetrics))
 			}
 
 			// Endpoint: GET /v1/alerts


### PR DESCRIPTION
**What this PR does**:

Fix integration TestAlertmanagerSharding flaking.

This change will make the test reliable until I can spend more time
investigating. It seems that posting alerts is not fully synchronous
as was expected when writing the test, so the test can be fixed by
waiting for all instances to receive the alert.

Signed-off-by: Steve Simpson <steve.simpson@grafana.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**Which issue(s) this PR fixes**:
Fixes #3927 

**Checklist**
- [x] ~~Tests updated~~
- [x] ~~Documentation added~~
- [x] ~~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~~
