### PR TITLE
Update go version in build image to 1.16.6

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:build-image-multiarch-1d2497ff6
+      image: quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:build-image-multiarch-1d2497ff6
+      image: quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f
     services:
       cassandra:
         image: cassandra:3.11
@@ -55,7 +55,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:build-image-multiarch-1d2497ff6
+      image: quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -98,8 +98,8 @@ jobs:
       - name: Upgrade golang
         run: |
           cd /tmp
-          wget https://dl.google.com/go/go1.16.3.linux-amd64.tar.gz
-          tar -zxvf go1.16.3.linux-amd64.tar.gz
+          wget https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz
+          tar -zxvf go1.16.6.linux-amd64.tar.gz
           sudo rm -fr /usr/local/go
           sudo mv /tmp/go /usr/local/go
           cd -
@@ -174,14 +174,14 @@ jobs:
         run: |
           touch build-image/.uptodate
           MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations
-          make BUILD_IMAGE=quay.io/cortexproject/build-image:build-image-multiarch-1d2497ff6 TTY='' configs-integration-test
+          make BUILD_IMAGE=quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f TTY='' configs-integration-test
 
   deploy_website:
     needs: [build, test]
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:build-image-multiarch-1d2497ff6
+      image: quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -218,7 +218,7 @@ jobs:
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:build-image-multiarch-1d2497ff6
+      image: quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 * [FEATURE] Ruler: Add new `-ruler.query-stats-enabled` which when enabled will report the `cortex_ruler_query_seconds_total` as a per-user metric that tracks the sum of the wall time of executing queries in the ruler in seconds. #4317
 
+* [CHANGE] Update Go version to 1.16.6. #4362
 * [CHANGE] Querier / ruler: Change `-querier.max-fetched-chunks-per-query` configuration to limit to maximum number of chunks that can be fetched in a single query. The number of chunks fetched by ingesters AND long-term storare combined should not exceed the value configured on `-querier.max-fetched-chunks-per-query`. #4260
 * [CHANGE] Memberlist: the `memberlist_kv_store_value_bytes` has been removed due to values no longer being stored in-memory as encoded bytes. #4345
 * [ENHANCEMENT] Add timeout for waiting on compactor to become ACTIVE in the ring. #4262

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ build-image/$(UPTODATE): build-image/*
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER := true
 BUILD_IMAGE ?= $(IMAGE_PREFIX)build-image
-LATEST_BUILD_IMAGE_TAG ?= build-image-multiarch-1d2497ff6
+LATEST_BUILD_IMAGE_TAG ?= 20210713_update-go-1.16.6-178ab0c4f
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3-buster
+FROM golang:1.16.6-buster
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl python-requests python-yaml file jq unzip protobuf-compiler libprotobuf-dev && \

--- a/docs/contributing/how-to-upgrade-golang-version.md
+++ b/docs/contributing/how-to-upgrade-golang-version.md
@@ -14,6 +14,7 @@ To upgrade the Golang version:
    - Update the Docker image tag in `.github/workflows/*`
 2. Upgrade integration tests version
    - Update the Golang version installed in the `integration` job in `.github/workflows/*`
+3. Upgrade the reference to the latest build image called `LATEST_BUILD_IMAGE_TAG` in `Makefile`
 
 If the minimum support Golang version should be upgraded as well:
 


### PR DESCRIPTION
**What this PR does**:

Update go version in build image to 1.16.6. This addresses CVE-2021-34558.

https://github.com/golang/go/issues/47143

This now needs a maintainer to push a build image and update references  (see https://cortexmetrics.io/docs/contributing/how-to-update-the-build-image/)