### PR TITLE
Add metric name to metadata error

### DIFF
--- a/pkg/ingester/user_metrics_metadata.go
+++ b/pkg/ingester/user_metrics_metadata.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/prometheus/pkg/labels"
+
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
@@ -49,7 +51,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *cortexpb.MetricMetad
 
 	if err := mm.limiter.AssertMaxMetadataPerMetric(mm.userID, len(set)); err != nil {
 		validation.DiscardedMetadata.WithLabelValues(mm.userID, perMetricMetadataLimit).Inc()
-		return makeLimitError(perMetricMetadataLimit, mm.limiter.FormatError(mm.userID, err))
+		return makeMetricLimitError(perMetricMetadataLimit, labels.FromStrings(labels.MetricName, metric), mm.limiter.FormatError(mm.userID, err))
 	}
 
 	// if we have seen this metadata before, it is a no-op and we don't need to change our metrics.


### PR DESCRIPTION
Currently our errors look like this:

```
level=warn ts=2021-07-14T09:33:02.743961441Z caller=ingester.go:681 org_id=XXXX traceID=3224439dfe4ee37c msg="failed to ingest some metadata" err="per-metric metadata limit of 10 exceeded, please contact administrator to raise it (local limit: 10 global limit: 0 actual local limit: 10)"
level=warn ts=2021-07-14T09:33:02.743862184Z caller=ingester.go:681 org_id=XXXX traceID=3224439dfe4ee37c msg="failed to ingest some metadata" err="per-metric metadata limit of 10 exceeded, please contact administrator to raise it (local limit: 10 global limit: 0 actual local limit: 10)"
level=warn ts=2021-07-14T09:33:02.743728652Z caller=ingester.go:681 org_id=XXXX traceID=3224439dfe4ee37c msg="failed to ingest some metadata" err="per-metric metadata limit of 10 exceeded, please contact administrator to raise it (local limit: 10 global limit: 0 actual local limit: 10)"
level=warn ts=2021-07-14T09:33:02.743496095Z caller=ingester.go:681 org_id=XXXX traceID=3224439dfe4ee37c msg="failed to ingest some metadata" err="per-metric metadata limit of 10 exceeded, please contact administrator to raise it (local limit: 10 global limit: 0 actual local limit: 10)"
```

Knowing the series name would be helpful.