### PR TITLE
[BUGFIX] gRPC Storage: Fix Zero-chunk appended to result in GetChunks method. To avoid the caller getting nil pointer panic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [ENHANCEMENT] Memberlist: optimized receive path for processing ring state updates, to help reduce CPU utilization in large clusters. #4345
 * [ENHANCEMENT] Memberlist: expose configuration of memberlist packet compression via `-memberlist.compression=enabled`. #4346
 * [BUGFIX] HA Tracker: when cleaning up obsolete elected replicas from KV store, tracker didn't update number of cluster per user correctly. #4336
+* [BUGFIX] gRPC Storage: Fix Zero-chunk appended to result in GetChunks method. To avoid the caller getting nil pointer panic.
 
 ## 1.10.0-rc.0 / 2021-06-28
 

--- a/pkg/chunk/grpc/storage_client.go
+++ b/pkg/chunk/grpc/storage_client.go
@@ -103,14 +103,20 @@ func (s *StorageClient) GetChunks(ctx context.Context, input []chunk.Chunk) ([]c
 			return nil, errors.WithStack(err)
 		}
 		for _, chunkResponse := range receivedChunks.GetChunks() {
-			var c chunk.Chunk
-			if chunkResponse != nil {
+			var c *chunk.Chunk
+			for i := range req.Chunks {
+				if req.Chunks[i].Key == chunkResponse.Key {
+					c = &input[i]
+					break
+				}
+			}
+			if c != nil {
 				err = c.Decode(decodeContext, chunkResponse.Encoded)
 				if err != nil {
 					return result, err
 				}
+				result = append(result, *c)
 			}
-			result = append(result, c)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Fix Zero-chunk appended to result in GetChunks method. To avoid the caller getting nil pointer panic.
**Which issue(s) this PR fixes**:
Fixes [grafana/loki#4008](https://github.com/grafana/loki/issues/4008)
**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
