### PR TITLE
add support for 'AdvertiseAddr' and 'AdvertisePort' in memberlist config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * [CHANGE] Update Go version to 1.16.6. #4362
 * [CHANGE] Querier / ruler: Change `-querier.max-fetched-chunks-per-query` configuration to limit to maximum number of chunks that can be fetched in a single query. The number of chunks fetched by ingesters AND long-term storare combined should not exceed the value configured on `-querier.max-fetched-chunks-per-query`. #4260
 * [CHANGE] Memberlist: the `memberlist_kv_store_value_bytes` has been removed due to values no longer being stored in-memory as encoded bytes. #4345
+* [CHANGE] Memberlist: allow specifying address and port advertised to the memberlist ring by setting the following configuration: #4387
+   * `-memberlist.advertise_addr`
+   * `-memberlist.advertise_port`
 * [CHANGE] Prevent path traversal attack from users able to control the HTTP header `X-Scope-OrgID`. #4375 (CVE-2021-36157)
   * Users only have control of the HTTP header when Cortex is not frontend by an auth proxy validating the tenant IDs
 * [CHANGE] Some files and directories created by Mimir components on local disk now have stricter permissions, and are only readable by owner, but not group or others. #4394

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3863,6 +3863,16 @@ The `memberlist_config` configures the Gossip memberlist.
 # CLI flag: -memberlist.bind-port
 [bind_port: <int> | default = 7946]
 
+# IP address to advertise to memberlist cluster. Used for NAT traversal.
+# Defaults to first IP specified in `-memberlist.bind-addr` or
+# `sockaddr.GetPrivateIP()` if that IP is 0.0.0.0
+# CLI flag: -memberlist.advertise-addr
+[advertise_addr: <string> | default = ""]
+
+# Port to advertise to memberlist cluster. Used for NAT traversal.
+# CLI flag: -memberlist.advertise-port
+[advertise_port: <int> | default = 7946]
+
 # Timeout used when connecting to other nodes to send packet.
 # CLI flag: -memberlist.packet-dial-timeout
 [packet_dial_timeout: <duration> | default = 5s]

--- a/pkg/ring/kv/memberlist/memberlist_client.go
+++ b/pkg/ring/kv/memberlist/memberlist_client.go
@@ -138,6 +138,10 @@ type KVConfig struct {
 	DeadNodeReclaimTime time.Duration `yaml:"dead_node_reclaim_time"`
 	EnableCompression   bool          `yaml:"compression_enabled"`
 
+	// ip:port to advertise other cluster members. Used for NAT traversal
+	AdvertiseAddr string `yaml:"advertise_addr"`
+	AdvertisePort int    `yaml:"advertise_port"`
+
 	// List of members to join
 	JoinMembers      flagext.StringSlice `yaml:"join_members"`
 	MinJoinBackoff   time.Duration       `yaml:"min_join_backoff"`
@@ -189,6 +193,8 @@ func (cfg *KVConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.DurationVar(&cfg.DeadNodeReclaimTime, prefix+"memberlist.dead-node-reclaim-time", mlDefaults.DeadNodeReclaimTime, "How soon can dead node's name be reclaimed with new address. 0 to disable.")
 	f.IntVar(&cfg.MessageHistoryBufferBytes, prefix+"memberlist.message-history-buffer-bytes", 0, "How much space to use for keeping received and sent messages in memory for troubleshooting (two buffers). 0 to disable.")
 	f.BoolVar(&cfg.EnableCompression, prefix+"memberlist.compression-enabled", mlDefaults.EnableCompression, "Enable message compression. This can be used to reduce bandwidth usage at the cost of slightly more CPU utilization.")
+	f.StringVar(&cfg.AdvertiseAddr, prefix+"memberlist.advertise-addr", mlDefaults.AdvertiseAddr, "Gossip address to advertise to other members in the cluster. Used for NAT traversal.")
+	f.IntVar(&cfg.AdvertisePort, prefix+"memberlist.advertise-port", mlDefaults.AdvertisePort, "Gossip port to advertise to other members in the cluster. Used for NAT traversal.")
 
 	cfg.TCPTransport.RegisterFlags(f, prefix)
 }
@@ -383,6 +389,9 @@ func (m *KV) buildMemberlistConfig() (*memberlist.Config, error) {
 	mlCfg.GossipToTheDeadTime = m.cfg.GossipToTheDeadTime
 	mlCfg.DeadNodeReclaimTime = m.cfg.DeadNodeReclaimTime
 	mlCfg.EnableCompression = m.cfg.EnableCompression
+
+	mlCfg.AdvertiseAddr = m.cfg.AdvertiseAddr
+	mlCfg.AdvertisePort = m.cfg.AdvertisePort
 
 	if m.cfg.NodeName != "" {
 		mlCfg.Name = m.cfg.NodeName


### PR DESCRIPTION
**What this PR does**:
Adds 'advertise_addr' and 'advertise_port' to memberlist configuration to support the service being NATed behind another ip.

**Which issue(s) this PR fixes**:
Fixes #4359 

**Checklist**
~- [ ] Tests updated~ - unsure how to add these. If you can point me in the right direction, happy to take this on
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
