### PR TITLE
Clarify Prometheus capability in auth guide

### DIFF
--- a/docs/guides/authentication-and-authorisation.md
+++ b/docs/guides/authentication-and-authorisation.md
@@ -15,12 +15,19 @@ of protection.
 Typically this means you run Cortex behind a reverse proxy, and you must
 ensure that all callers, both machines sending data over the `remote_write`
 interface and humans sending queries from GUIs, supply credentials
-which identify them and confirm they are authorised.
-
-When configuring the `remote_write` API in Prometheus there is no way to
-add extra headers. The user and password fields of http Basic auth, or
-Bearer token, can be used to convey the tenant ID and/or credentials.
+which identify them and confirm they are authorised. When configuring the
+`remote_write` API in Prometheus, the user and password fields of http Basic
+auth, or Bearer token, can be used to convey the tenant ID and/or credentials.
 See the **Cortex-Tenant** section below for one way to solve this.
+
+In trusted environments, Prometheus can send the `X-Scope-OrgID` header itself
+by configuring the `headers` field in its [`remote_write` configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write):
+```
+remote_write:
+  - url: http://<cortex>/api/v1/push
+    headers:
+      X-Scope-OrgID: <org>
+```
 
 To disable the multi-tenant functionality, you can pass the argument
 `-auth.enabled=false` to every Cortex component, which will set the OrgID


### PR DESCRIPTION
**What this PR does**:
Since `docs/guides/authentication-and-authorisation.md` was written, [Prometheus has added support for including arbitrary headers in remote write requests](https://github.com/prometheus/prometheus/commit/509000269a6eeb6f916d353635beae83e1607400). This contradicts the language in the guide, which said there was no way to do it. I've clarified the language and provided an example configuration.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
