### PR TITLE
Replace localhost with 127.0.0.1

### DIFF
--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -523,7 +523,8 @@ func (s *HTTPService) Metrics() (_ string, err error) {
 	localPort := s.networkPortsContainerToLocal[s.httpPort]
 
 	// Fetch metrics.
-	res, err := GetRequest(fmt.Sprintf("http://localhost:%d/metrics", localPort))
+        // Do not use "localhost" cause it doesn't work with dual-stack network
+	res, err := GetRequest(fmt.Sprintf("http://127.0.0.1:%d/metrics", localPort))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION


Signed-off-by: clyang82 <chuyang@redhat.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
`localhost` cannot work in dual stack network environment. Since we just use ipv4 for docker port - https://github.com/cortexproject/cortex/blob/a4bf1035478641626fcbdd5fd12325c08a2bba76/integration/e2e/service.go#L24, update to use 127.0.0.1 instead.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
