### PR TITLE
Add Memberlist config setting: HandoffQueueDepth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@
 * [BUGFIX] Ingester: When using block storage, prevent any reads or writes while the ingester is stopping. This will prevent accessing TSDB blocks once they have been already closed. #4304
 * [BUGFIX] Ingester: fixed ingester stuck on start up (LEAVING ring state) when `-ingester.heartbeat-period=0` and `-ingester.unregister-on-shutdown=false`. #4366
 * [FEATURE] Memberlist: expose configuration of memberlist handoff queue depth via `-memberlist.handoff-queue-depth`. #4402
+* [BUGFIX] Ingester: panic during shutdown while fetching batches from cache. #4397
+* [BUGFIX] Querier: After query-frontend restart, querier may have lower than configured concurrency. #4417
+* [BUGFIX] Memberlist: forward only changes, not entire original message. #4419
+* [BUGFIX] Memberlist: don't accept old tombstones as incoming change, and don't forward such messages to other gossip members. #4420
+* [BUGFIX] Querier: fixed panic when querying exemplars and using `-distributor.shard-by-all-labels=false`. #4473
+* [BUGFIX] Querier: honor querier minT,maxT if `nil` SelectHints are passed to Select(). #4413
+* [BUGFIX] Compactor: fixed panic while collecting Prometheus metrics. #4483
 
 ## 1.10.0 / 2021-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,14 +49,7 @@
 * [BUGFIX] Ruler: fixed counting of PromQL evaluation errors as user-errors when updating `cortex_ruler_queries_failed_total`. #4335
 * [BUGFIX] Ingester: When using block storage, prevent any reads or writes while the ingester is stopping. This will prevent accessing TSDB blocks once they have been already closed. #4304
 * [BUGFIX] Ingester: fixed ingester stuck on start up (LEAVING ring state) when `-ingester.heartbeat-period=0` and `-ingester.unregister-on-shutdown=false`. #4366
-* [BUGFIX] Ingester: panic during shutdown while fetching batches from cache. #4397
-* [BUGFIX] Querier: After query-frontend restart, querier may have lower than configured concurrency. #4417
-* [BUGFIX] Memberlist: forward only changes, not entire original message. #4419
-* [BUGFIX] Memberlist: don't accept old tombstones as incoming change, and don't forward such messages to other gossip members. #4420
-* [BUGFIX] Querier: fixed panic when querying exemplars and using `-distributor.shard-by-all-labels=false`. #4473
-* [BUGFIX] Querier: honor querier minT,maxT if `nil` SelectHints are passed to Select(). #4413
-* [BUGFIX] Compactor: fixed panic while collecting Prometheus metrics. #4483
-
+* [FEATURE] Memberlist: expose configuration of memberlist handoff queue depth via `-memberlist.handoff-queue-depth`. #4402
 
 ## 1.10.0 / 2021-08-03
 

--- a/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go
+++ b/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go
@@ -186,6 +186,7 @@ func (cfg *KVConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.DurationVar(&cfg.DeadNodeReclaimTime, prefix+"memberlist.dead-node-reclaim-time", mlDefaults.DeadNodeReclaimTime, "How soon can dead node's name be reclaimed with new address. 0 to disable.")
 	f.IntVar(&cfg.MessageHistoryBufferBytes, prefix+"memberlist.message-history-buffer-bytes", 0, "How much space to use for keeping received and sent messages in memory for troubleshooting (two buffers). 0 to disable.")
 	f.BoolVar(&cfg.EnableCompression, prefix+"memberlist.compression-enabled", mlDefaults.EnableCompression, "Enable message compression. This can be used to reduce bandwidth usage at the cost of slightly more CPU utilization.")
+	f.IntVar(&cfg.HandoffQueueDepth, prefix+"memberlist.handoff-queue-depth", 1024, "Size of Memberlist's internal channel which handles UDP messages. The size of this determines the size of the queue which Memberlist will keep while UDP messages are handled.")
 
 	cfg.TCPTransport.RegisterFlags(f, prefix)
 }


### PR DESCRIPTION
**What this PR does**:

Add a config setting to memberlist to control HandoffQueueDepth

**Which issue(s) this PR fixes**:
```
{"caller":"memberlist_logger.go:74","level":"warn","msg":"handler queue full, dropping message (8) from=192.168.25.7:7946","ts":"2021-08-05T07:04:16.904377526Z"}
```

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
