### PR TITLE
Retrying AlertManager UnaryPath Requests on next replica if one fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 * [ENHANCEMENT] Memberlist: optimized receive path for processing ring state updates, to help reduce CPU utilization in large clusters. #4345
 * [ENHANCEMENT] Memberlist: expose configuration of memberlist packet compression via `-memberlist.compression=enabled`. #4346
 * [ENHANCEMENT] Updated Prometheus to include changes from prometheus/prometheus#9083. Now whenever `/labels` API calls include matchers, blocks store is queried for `LabelNames` with matchers instead of `Series` calls which was inefficient. #4380
-* [ENHANCEMENT] AlertManager: Retrying AlertManager UnaryPath Requests on next replica if one fail #4422
+* [ENHANCEMENT] AlertManager: Retrying AlertManager non-quorum Requests (Get Alertmanager status, Get Alertmanager Receivers, Create/Delete AlertManager Silences) on next replica on error #4422
 * [BUGFIX] HA Tracker: when cleaning up obsolete elected replicas from KV store, tracker didn't update number of cluster per user correctly. #4336
 * [BUGFIX] Ruler: fixed counting of PromQL evaluation errors as user-errors when updating `cortex_ruler_queries_failed_total`. #4335
 * [BUGFIX] Ingester: When using block storage, prevent any reads or writes while the ingester is stopping. This will prevent accessing TSDB blocks once they have been already closed. #4304

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [ENHANCEMENT] Memberlist: optimized receive path for processing ring state updates, to help reduce CPU utilization in large clusters. #4345
 * [ENHANCEMENT] Memberlist: expose configuration of memberlist packet compression via `-memberlist.compression=enabled`. #4346
 * [ENHANCEMENT] Updated Prometheus to include changes from prometheus/prometheus#9083. Now whenever `/labels` API calls include matchers, blocks store is queried for `LabelNames` with matchers instead of `Series` calls which was inefficient. #4380
+* [ENHANCEMENT] AlertManager: Retrying AlertManager UnaryPath Requests on next replica if one fail #4422
 * [BUGFIX] HA Tracker: when cleaning up obsolete elected replicas from KV store, tracker didn't update number of cluster per user correctly. #4336
 * [BUGFIX] Ruler: fixed counting of PromQL evaluation errors as user-errors when updating `cortex_ruler_queries_failed_total`. #4335
 * [BUGFIX] Ingester: When using block storage, prevent any reads or writes while the ingester is stopping. This will prevent accessing TSDB blocks once they have been already closed. #4304

--- a/pkg/alertmanager/distributor.go
+++ b/pkg/alertmanager/distributor.go
@@ -254,14 +254,30 @@ func (d *Distributor) doUnary(userID string, w http.ResponseWriter, r *http.Requ
 	defer sp.Finish()
 	// Until we have a mechanism to combine the results from multiple alertmanagers,
 	// we forward the request to only only of the alertmanagers.
-	amDesc := replicationSet.Instances[rand.Intn(len(replicationSet.Instances))]
-	resp, err := d.doRequest(ctx, amDesc, req)
-	if err != nil {
-		respondFromError(err, w, logger)
-		return
-	}
+	instances := replicationSet.Instances
 
-	respondFromHTTPGRPCResponse(w, resp)
+	// Randomize the list of instances to not always query the same one.
+	rand.Shuffle(len(instances), func(i, j int) {
+		instances[i], instances[j] = instances[j], instances[i]
+	})
+
+	lastInstance := instances[len(instances)-1]
+
+	for _, instance := range instances {
+		resp, err := d.doRequest(ctx, instance, req)
+
+		// Only return error if there is no more instances to try
+		if err != nil && instance.Addr == lastInstance.Addr {
+			respondFromError(err, w, logger)
+			return
+		}
+
+		// Return on the first succeeded request
+		if err == nil {
+			respondFromHTTPGRPCResponse(w, resp)
+			return
+		}
+	}
 }
 
 func respondFromError(err error, w http.ResponseWriter, logger log.Logger) {

--- a/pkg/alertmanager/distributor.go
+++ b/pkg/alertmanager/distributor.go
@@ -263,7 +263,7 @@ func (d *Distributor) doUnary(userID string, w http.ResponseWriter, r *http.Requ
 
 	lastInstance := instances[len(instances)-1]
 
-	for _, instance := range instances {
+	for i, instance := range instances {
 		resp, err := d.doRequest(ctx, instance, req)
 
 		// Only return error if there is no more instances to try

--- a/pkg/alertmanager/distributor.go
+++ b/pkg/alertmanager/distributor.go
@@ -261,13 +261,11 @@ func (d *Distributor) doUnary(userID string, w http.ResponseWriter, r *http.Requ
 		instances[i], instances[j] = instances[j], instances[i]
 	})
 
-	lastInstance := instances[len(instances)-1]
-
 	for i, instance := range instances {
 		resp, err := d.doRequest(ctx, instance, req)
 
 		// Only return error if there is no more instances to try
-		if err != nil && instance.Addr == lastInstance.Addr {
+		if err != nil && i == len(instances)-1 {
 			respondFromError(err, w, logger)
 			return
 		}

--- a/pkg/alertmanager/distributor_test.go
+++ b/pkg/alertmanager/distributor_test.go
@@ -209,7 +209,7 @@ func TestDistributor_DistributeRequest(t *testing.T) {
 			route:              "/status",
 		},
 		{
-			name:               "Read /status is sent to only 2 AM when 1 is not happy",
+			name:               "Read /status is sent to 3 AM when 2 are not happy",
 			numAM:              3,
 			numHappyAM:         3,
 			failedReqCount:     2,


### PR DESCRIPTION
**What this PR does**:

AlertManager unary APIs are failing due a single alert manager fail as distributor picks a random one to forward the request.

This change only pick the replicas alert managers in case of a error.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
