### PR TITLE
Replace use of global loggers in the module subsystem

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -827,7 +827,7 @@ func (t *Cortex) initQueryScheduler() (services.Service, error) {
 }
 
 func (t *Cortex) setupModuleManager() error {
-	mm := modules.NewManager()
+	mm := modules.NewManager(util_log.Logger)
 
 	// Register all modules here.
 	// RegisterModule(name string, initFn func()(services.Service, error))

--- a/pkg/util/modules/module_service_wrapper.go
+++ b/pkg/util/modules/module_service_wrapper.go
@@ -1,13 +1,15 @@
 package modules
 
 import (
+	"github.com/go-kit/kit/log"
+
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
 // This function wraps module service, and adds waiting for dependencies to start before starting,
 // and dependant modules to stop before stopping this module service.
-func newModuleServiceWrapper(serviceMap map[string]services.Service, mod string, modServ services.Service, startDeps []string, stopDeps []string) services.Service {
+func newModuleServiceWrapper(serviceMap map[string]services.Service, mod string, logger log.Logger, modServ services.Service, startDeps []string, stopDeps []string) services.Service {
 	getDeps := func(deps []string) map[string]services.Service {
 		r := map[string]services.Service{}
 		for _, m := range deps {
@@ -19,7 +21,7 @@ func newModuleServiceWrapper(serviceMap map[string]services.Service, mod string,
 		return r
 	}
 
-	return util.NewModuleService(mod, modServ,
+	return util.NewModuleService(mod, logger, modServ,
 		func(_ string) map[string]services.Service {
 			return getDeps(startDeps)
 		},

--- a/pkg/util/modules/modules.go
+++ b/pkg/util/modules/modules.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 
 	"github.com/cortexproject/cortex/pkg/util/services"
@@ -25,6 +26,7 @@ type module struct {
 // in the right order of dependencies.
 type Manager struct {
 	modules map[string]*module
+	logger  log.Logger
 }
 
 // UserInvisibleModule is an option for `RegisterModule` that marks module not visible to user. Modules are user visible by default.
@@ -33,9 +35,10 @@ func UserInvisibleModule(m *module) {
 }
 
 // NewManager creates a new Manager
-func NewManager() *Manager {
+func NewManager(logger log.Logger) *Manager {
 	return &Manager{
 		modules: make(map[string]*module),
+		logger:  logger,
 	}
 }
 
@@ -108,7 +111,7 @@ func (m *Manager) initModule(name string, initMap map[string]bool, servicesMap m
 			if s != nil {
 				// We pass servicesMap, which isn't yet complete. By the time service starts,
 				// it will be fully built, so there is no need for extra synchronization.
-				serv = newModuleServiceWrapper(servicesMap, n, s, m.DependenciesForModule(n), m.findInverseDependencies(n, deps[ix+1:]))
+				serv = newModuleServiceWrapper(servicesMap, n, m.logger, s, m.DependenciesForModule(n), m.findInverseDependencies(n, deps[ix+1:]))
 			}
 		}
 

--- a/pkg/util/modules/modules_test.go
+++ b/pkg/util/modules/modules_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -36,7 +37,7 @@ func TestDependencies(t *testing.T) {
 		},
 	}
 
-	mm := NewManager()
+	mm := NewManager(log.NewNopLogger())
 	for name, mod := range testModules {
 		mm.RegisterModule(name, mod.initFn)
 	}
@@ -75,7 +76,7 @@ func TestDependencies(t *testing.T) {
 }
 
 func TestRegisterModuleDefaultsToUserVisible(t *testing.T) {
-	sut := NewManager()
+	sut := NewManager(log.NewNopLogger())
 	sut.RegisterModule("module1", mockInitFunc)
 
 	m := sut.modules["module1"]
@@ -88,7 +89,7 @@ func TestFunctionalOptAtTheEndWins(t *testing.T) {
 	userVisibleMod := func(option *module) {
 		option.userVisible = true
 	}
-	sut := NewManager()
+	sut := NewManager(log.NewNopLogger())
 	sut.RegisterModule("mod1", mockInitFunc, UserInvisibleModule, userVisibleMod, UserInvisibleModule)
 
 	m := sut.modules["mod1"]
@@ -98,7 +99,7 @@ func TestFunctionalOptAtTheEndWins(t *testing.T) {
 }
 
 func TestGetAllUserVisibleModulesNames(t *testing.T) {
-	sut := NewManager()
+	sut := NewManager(log.NewNopLogger())
 	sut.RegisterModule("userVisible3", mockInitFunc)
 	sut.RegisterModule("userVisible2", mockInitFunc)
 	sut.RegisterModule("userVisible1", mockInitFunc)
@@ -111,7 +112,7 @@ func TestGetAllUserVisibleModulesNames(t *testing.T) {
 }
 
 func TestGetAllUserVisibleModulesNamesHasNoDupWithDependency(t *testing.T) {
-	sut := NewManager()
+	sut := NewManager(log.NewNopLogger())
 	sut.RegisterModule("userVisible1", mockInitFunc)
 	sut.RegisterModule("userVisible2", mockInitFunc)
 	sut.RegisterModule("userVisible3", mockInitFunc)
@@ -125,7 +126,7 @@ func TestGetAllUserVisibleModulesNamesHasNoDupWithDependency(t *testing.T) {
 }
 
 func TestGetEmptyListWhenThereIsNoUserVisibleModule(t *testing.T) {
-	sut := NewManager()
+	sut := NewManager(log.NewNopLogger())
 	sut.RegisterModule("internal1", mockInitFunc, UserInvisibleModule)
 	sut.RegisterModule("internal2", mockInitFunc, UserInvisibleModule)
 	sut.RegisterModule("internal3", mockInitFunc, UserInvisibleModule)
@@ -139,7 +140,7 @@ func TestGetEmptyListWhenThereIsNoUserVisibleModule(t *testing.T) {
 func TestIsUserVisibleModule(t *testing.T) {
 	userVisibleModName := "userVisible"
 	internalModName := "internal"
-	sut := NewManager()
+	sut := NewManager(log.NewNopLogger())
 	sut.RegisterModule(userVisibleModName, mockInitFunc)
 	sut.RegisterModule(internalModName, mockInitFunc, UserInvisibleModule)
 
@@ -157,7 +158,7 @@ func TestIsModuleRegistered(t *testing.T) {
 	successModule := "successModule"
 	failureModule := "failureModule"
 
-	m := NewManager()
+	m := NewManager(log.NewNopLogger())
 	m.RegisterModule(successModule, mockInitFunc)
 
 	var result = m.IsModuleRegistered(successModule)
@@ -168,7 +169,7 @@ func TestIsModuleRegistered(t *testing.T) {
 }
 
 func TestDependenciesForModule(t *testing.T) {
-	m := NewManager()
+	m := NewManager(log.NewNopLogger())
 	m.RegisterModule("test", nil)
 	m.RegisterModule("dep1", nil)
 	m.RegisterModule("dep2", nil)
@@ -206,7 +207,7 @@ func TestModuleWaitsForAllDependencies(t *testing.T) {
 		}, nil), nil
 	}
 
-	m := NewManager()
+	m := NewManager(log.NewNopLogger())
 	m.RegisterModule("A", initA)
 	m.RegisterModule("B", nil)
 	m.RegisterModule("C", initC)


### PR DESCRIPTION
In prep for moving the "modules" package to dskit, replace uses
of the global Cortex logger with an injected one.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
