### PR TITLE
querier: exhaust response body before closing

### DIFF
--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -18,6 +18,8 @@ package queryrange
 import (
 	"context"
 	"flag"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -289,7 +291,10 @@ func (q roundTripper) Do(ctx context.Context, r Request) (Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = response.Body.Close() }()
+	defer func() {
+		io.Copy(ioutil.Discard, io.LimitReader(response.Body, 1024))
+		_ = response.Body.Close()
+	}()
 
 	return q.codec.DecodeResponse(ctx, response, r)
 }


### PR DESCRIPTION
**What this PR does**:

Exhaust the whole body of the response before closing to facilitate
re-use of keep-alive connections as per the documentation here:
https://pkg.go.dev/net/http#Client.Get

```
Caller should close resp.Body when done reading from it.
```

Also some discussion here:
https://groups.google.com/g/golang-nuts/c/148riho42sU
https://github.com/cortexproject/cortex/issues/4428


**Which issue(s) this PR fixes**:
It fixes a part of https://github.com/cortexproject/cortex/issues/4428.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

Not sure if any CHANGELOG changes are needed :thinking: 