### PR TITLE
frontend: permit passing a custom http.RoundTripper

### DIFF
--- a/pkg/frontend/config.go
+++ b/pkg/frontend/config.go
@@ -41,7 +41,7 @@ func InitFrontend(cfg CombinedFrontendConfig, limits v1.Limits, grpcListenPort i
 	switch {
 	case cfg.DownstreamURL != "":
 		// If the user has specified a downstream Prometheus, then we should use that.
-		rt, err := NewDownstreamRoundTripper(cfg.DownstreamURL)
+		rt, err := NewDownstreamRoundTripper(cfg.DownstreamURL, http.DefaultTransport)
 		return rt, nil, nil, err
 
 	case cfg.FrontendV2.SchedulerAddress != "":

--- a/pkg/frontend/downstream_roundtripper.go
+++ b/pkg/frontend/downstream_roundtripper.go
@@ -11,15 +11,16 @@ import (
 // RoundTripper that forwards requests to downstream URL.
 type downstreamRoundTripper struct {
 	downstreamURL *url.URL
+	transport     http.RoundTripper
 }
 
-func NewDownstreamRoundTripper(downstreamURL string) (http.RoundTripper, error) {
+func NewDownstreamRoundTripper(downstreamURL string, transport http.RoundTripper) (http.RoundTripper, error) {
 	u, err := url.Parse(downstreamURL)
 	if err != nil {
 		return nil, err
 	}
 
-	return &downstreamRoundTripper{downstreamURL: u}, nil
+	return &downstreamRoundTripper{downstreamURL: u, transport: transport}, nil
 }
 
 func (d downstreamRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
@@ -36,5 +37,5 @@ func (d downstreamRoundTripper) RoundTrip(r *http.Request) (*http.Response, erro
 	r.URL.Host = d.downstreamURL.Host
 	r.URL.Path = path.Join(d.downstreamURL.Path, r.URL.Path)
 	r.Host = ""
-	return http.DefaultTransport.RoundTrip(r)
+	return d.transport.RoundTrip(r)
 }


### PR DESCRIPTION
**What this PR does**:

Allow passing a custom http.RoundTripper in `downstreamRoundTripper` so
that it would be possible to pass something else other than
`http.DefaultTransport` which is limited to only two idle connections
per host.


**Which issue(s) this PR fixes**:

Part of https://github.com/cortexproject/cortex/issues/4428.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
