### PR TITLE
Fix link to voting section from how to become a maintainer page 

### DIFF
--- a/docs/contributing/how-to-add-a-maintainer.md
+++ b/docs/contributing/how-to-add-a-maintainer.md
@@ -5,7 +5,7 @@ weight: 10
 slug: how-to-add-a-maintainer
 ---
 
-New maintainers are proposed by an existing maintainer and are elected by [majority vote](./_index.md#changes-in-maintainership). Once the vote passed, the following steps should be done to add a new member to the maintainers team:
+New maintainers are proposed by an existing maintainer and are elected by [majority vote](./governance.md#voting). Once the vote passed, the following steps should be done to add a new member to the maintainers team:
 
 1. Submit a PR to add the new member to `MAINTAINERS`
 2. Invite to [GitHub organization](https://github.com/orgs/cortexproject/people)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Fix link to voting section from how to become a maintainer page 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
Signed-off-by: Jérôme Decq <decqj@amazon.com>Signed-off-by: Jérôme Decq <decqj@amazon.com>