### PR TITLE
Chore: Upgrade weaveworks/common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 * [ENHANCEMENT] Memberlist: expose configuration of memberlist packet compression via `-memberlist.compression=enabled`. #4346
 * [ENHANCEMENT] Update Go version to 1.16.6. #4362
 * [ENHANCEMENT] Updated Prometheus to include changes from prometheus/prometheus#9083. Now whenever `/labels` API calls include matchers, blocks store is queried for `LabelNames` with matchers instead of `Series` calls which was inefficient. #4380
+* [ENHANCEMENT] Exemplars are now emitted for all gRPC calls and many operations tracked by histograms. #4462
+* [ENHANCEMENT] New options `-server.http-listen-network` and `-server.grpc-listen-network` allow binding as 'tcp4' or 'tcp6'. #4462
 * [BUGFIX] Compactor: compactor will no longer try to compact blocks that are already marked for deletion. Previously compactor would consider blocks marked for deletion within `-compactor.deletion-delay / 2` period as eligible for compaction. #4328
 * [BUGFIX] HA Tracker: when cleaning up obsolete elected replicas from KV store, tracker didn't update number of cluster per user correctly. #4336
 * [BUGFIX] Ruler: fixed counting of PromQL evaluation errors as user-errors when updating `cortex_ruler_queries_failed_total`. #4335

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/thanos-io/thanos v0.22.0
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
-	github.com/weaveworks/common v0.0.0-20210722103813-e649eff5ab4a
+	github.com/weaveworks/common v0.0.0-20210901124008-1fa3f9fa874c
 	go.etcd.io/bbolt v1.3.6
 	go.uber.org/atomic v1.9.0
 	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b

--- a/go.sum
+++ b/go.sum
@@ -1765,8 +1765,9 @@ github.com/weaveworks/common v0.0.0-20200914083218-61ffdd448099/go.mod h1:hz10LO
 github.com/weaveworks/common v0.0.0-20201119133501-0619918236ec/go.mod h1:ykzWac1LtVfOxdCK+jD754at1Ws9dKCwFeUzkFBffPs=
 github.com/weaveworks/common v0.0.0-20210112142934-23c8d7fa6120/go.mod h1:ykzWac1LtVfOxdCK+jD754at1Ws9dKCwFeUzkFBffPs=
 github.com/weaveworks/common v0.0.0-20210419092856-009d1eebd624/go.mod h1:ykzWac1LtVfOxdCK+jD754at1Ws9dKCwFeUzkFBffPs=
-github.com/weaveworks/common v0.0.0-20210722103813-e649eff5ab4a h1:ALomSnvy/NPeVoc4a1o7keaHHgLS76r9ZYIlwWWF+KA=
 github.com/weaveworks/common v0.0.0-20210722103813-e649eff5ab4a/go.mod h1:YU9FvnS7kUnRt6HY10G+2qHkwzP3n3Vb1XsXDsJTSp8=
+github.com/weaveworks/common v0.0.0-20210901124008-1fa3f9fa874c h1:+yzwVr4/12cUgsdjbEHq6MsKB7jWBZpZccAP6xvqTzQ=
+github.com/weaveworks/common v0.0.0-20210901124008-1fa3f9fa874c/go.mod h1:YU9FvnS7kUnRt6HY10G+2qHkwzP3n3Vb1XsXDsJTSp8=
 github.com/weaveworks/promrus v1.2.0 h1:jOLf6pe6/vss4qGHjXmGz4oDJQA+AOCqEL3FvvZGz7M=
 github.com/weaveworks/promrus v1.2.0/go.mod h1:SaE82+OJ91yqjrE1rsvBWVzNZKcHYFtMUyS1+Ogs/KA=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -20,16 +20,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/spanlogger"
 )
 
-type observableVecCollector struct {
-	v prometheus.ObserverVec
-}
-
-func (observableVecCollector) Register()                                                  {}
-func (observableVecCollector) Before(ctx context.Context, method string, start time.Time) {}
-func (o observableVecCollector) After(ctx context.Context, method, statusCode string, start time.Time) {
-	o.v.WithLabelValues(method, statusCode).Observe(time.Since(start).Seconds())
-}
-
 // MemcachedConfig is config to make a Memcached
 type MemcachedConfig struct {
 	Expiration time.Duration `yaml:"expiration"`
@@ -51,7 +41,7 @@ type Memcached struct {
 	memcache MemcachedClient
 	name     string
 
-	requestDuration observableVecCollector
+	requestDuration *instr.HistogramCollector
 
 	wg      sync.WaitGroup
 	inputCh chan *work
@@ -67,8 +57,8 @@ func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string, reg 
 		memcache: client,
 		name:     name,
 		logger:   logger,
-		requestDuration: observableVecCollector{
-			v: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		requestDuration: instr.NewHistogramCollector(
+			promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "cortex",
 				Name:      "memcache_request_duration_seconds",
 				Help:      "Total time spent in seconds doing memcache requests.",
@@ -76,7 +66,7 @@ func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string, reg 
 				Buckets:     prometheus.ExponentialBuckets(0.000016, 4, 8),
 				ConstLabels: prometheus.Labels{"name": name},
 			}, []string{"method", "status_code"}),
-		},
+		),
 	}
 
 	if cfg.BatchSize == 0 || cfg.Parallelism == 0 {

--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -24,9 +24,9 @@ type observableVecCollector struct {
 	v prometheus.ObserverVec
 }
 
-func (observableVecCollector) Register()                             {}
-func (observableVecCollector) Before(method string, start time.Time) {}
-func (o observableVecCollector) After(method, statusCode string, start time.Time) {
+func (observableVecCollector) Register()                                                  {}
+func (observableVecCollector) Before(ctx context.Context, method string, start time.Time) {}
+func (o observableVecCollector) After(ctx context.Context, method, statusCode string, start time.Time) {
 	o.v.WithLabelValues(method, statusCode).Observe(time.Since(start).Seconds())
 }
 

--- a/pkg/chunk/cache/redis_cache.go
+++ b/pkg/chunk/cache/redis_cache.go
@@ -19,7 +19,7 @@ type RedisCache struct {
 	name            string
 	redis           *RedisClient
 	logger          log.Logger
-	requestDuration observableVecCollector
+	requestDuration *instr.HistogramCollector
 }
 
 // NewRedisCache creates a new RedisCache
@@ -29,15 +29,15 @@ func NewRedisCache(name string, redisClient *RedisClient, reg prometheus.Registe
 		name:   name,
 		redis:  redisClient,
 		logger: logger,
-		requestDuration: observableVecCollector{
-			v: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		requestDuration: instr.NewHistogramCollector(
+			promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 				Namespace:   "cortex",
 				Name:        "rediscache_request_duration_seconds",
 				Help:        "Total time spent in seconds doing Redis requests.",
 				Buckets:     prometheus.ExponentialBuckets(0.000016, 4, 8),
 				ConstLabels: prometheus.Labels{"name": name},
 			}, []string{"method", "status_code"}),
-		},
+		),
 	}
 	if err := cache.redis.Ping(context.Background()); err != nil {
 		level.Error(logger).Log("msg", "error connecting to redis", "name", name, "err", err)

--- a/pkg/querier/queryrange/instrumentation.go
+++ b/pkg/querier/queryrange/instrumentation.go
@@ -58,7 +58,7 @@ type NoopCollector struct{}
 func (c *NoopCollector) Register() {}
 
 // Before implements instrument.Collector.
-func (c *NoopCollector) Before(method string, start time.Time) {}
+func (c *NoopCollector) Before(ctx context.Context, method string, start time.Time) {}
 
 // After implements instrument.Collector.
-func (c *NoopCollector) After(method, statusCode string, start time.Time) {}
+func (c *NoopCollector) After(ctx context.Context, method, statusCode string, start time.Time) {}

--- a/pkg/util/log/wrappers.go
+++ b/pkg/util/log/wrappers.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	kitlog "github.com/go-kit/kit/log"
-	"github.com/weaveworks/common/middleware"
+	"github.com/weaveworks/common/tracing"
 
 	"github.com/cortexproject/cortex/pkg/tenant"
 )
@@ -38,7 +38,7 @@ func WithContext(ctx context.Context, l kitlog.Logger) kitlog.Logger {
 		l = WithUserID(userID, l)
 	}
 
-	traceID, ok := middleware.ExtractTraceID(ctx)
+	traceID, ok := tracing.ExtractTraceID(ctx)
 	if !ok {
 		return l
 	}

--- a/pkg/util/log/wrappers.go
+++ b/pkg/util/log/wrappers.go
@@ -38,7 +38,7 @@ func WithContext(ctx context.Context, l kitlog.Logger) kitlog.Logger {
 		l = WithUserID(userID, l)
 	}
 
-	traceID, ok := tracing.ExtractTraceID(ctx)
+	traceID, ok := tracing.ExtractSampledTraceID(ctx)
 	if !ok {
 		return l
 	}

--- a/vendor/github.com/weaveworks/common/middleware/http_tracing.go
+++ b/vendor/github.com/weaveworks/common/middleware/http_tracing.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
-	jaeger "github.com/uber/jaeger-client-go"
-	"golang.org/x/net/context"
 )
 
 // Dummy dependency to enforce that we have a nethttp version newer
@@ -39,33 +37,4 @@ func (t Tracer) Wrap(next http.Handler) http.Handler {
 	}
 
 	return nethttp.Middleware(opentracing.GlobalTracer(), next, options...)
-}
-
-// ExtractTraceID extracts the trace id, if any from the context.
-func ExtractTraceID(ctx context.Context) (string, bool) {
-	sp := opentracing.SpanFromContext(ctx)
-	if sp == nil {
-		return "", false
-	}
-	sctx, ok := sp.Context().(jaeger.SpanContext)
-	if !ok {
-		return "", false
-	}
-
-	return sctx.TraceID().String(), true
-}
-
-// ExtractSampledTraceID works like ExtractTraceID but the returned bool is only
-// true if the returned trace id is sampled.
-func ExtractSampledTraceID(ctx context.Context) (string, bool) {
-	sp := opentracing.SpanFromContext(ctx)
-	if sp == nil {
-		return "", false
-	}
-	sctx, ok := sp.Context().(jaeger.SpanContext)
-	if !ok {
-		return "", false
-	}
-
-	return sctx.TraceID().String(), sctx.IsSampled()
 }

--- a/vendor/github.com/weaveworks/common/middleware/logging.go
+++ b/vendor/github.com/weaveworks/common/middleware/logging.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/weaveworks/common/logging"
+	"github.com/weaveworks/common/tracing"
 	"github.com/weaveworks/common/user"
 )
 
@@ -21,7 +22,7 @@ type Log struct {
 // logWithRequest information from the request and context as fields.
 func (l Log) logWithRequest(r *http.Request) logging.Interface {
 	localLog := l.Log
-	traceID, ok := ExtractTraceID(r.Context())
+	traceID, ok := tracing.ExtractTraceID(r.Context())
 	if ok {
 		localLog = localLog.WithField("traceID", traceID)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -672,7 +672,7 @@ github.com/uber/jaeger-client-go/utils
 # github.com/uber/jaeger-lib v2.4.1+incompatible
 github.com/uber/jaeger-lib/metrics
 github.com/uber/jaeger-lib/metrics/prometheus
-# github.com/weaveworks/common v0.0.0-20210722103813-e649eff5ab4a
+# github.com/weaveworks/common v0.0.0-20210901124008-1fa3f9fa874c
 ## explicit
 github.com/weaveworks/common/aws
 github.com/weaveworks/common/errors


### PR DESCRIPTION
**What this PR does**:
I suggest we upgrade weaveworks/common dependency to [1fa3f9fa874c](https://github.com/weaveworks/common/commit/1fa3f9fa874c).

The key changes in the new version of weaveworks/common are that `instrument.Collector.Before` and `instrument.Collector.After` now take a context argument and that `ExtractTraceID` was moved to the `tracing` package. Also, `server.New` takes a new configuration parameter `cfg.GRPCListenNetwork`.

I think the only change that could have any practical effect would be the switch to `cfg.GRPCListenNetwork` in `server.New`. I frankly don't know if that would affect Cortex.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
