### PR TITLE
Using subring on getShardedRules when shuffle sharding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [BUGFIX] Querier: After query-frontend restart, querier may have lower than configured concurrency. #4417
 * [BUGFIX] Memberlist: forward only changes, not entire original message. #4419
 * [BUGFIX] Memberlist: don't accept old tombstones as incoming change, and don't forward such messages to other gossip members. #4420
+* [ENHANCEMENT] Rulers: Using shuffle sharding subring on GetRules API. #4466
 
 ## 1.10.0 / 2021-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [ENHANCEMENT] Updated Prometheus to include changes from prometheus/prometheus#9083. Now whenever `/labels` API calls include matchers, blocks store is queried for `LabelNames` with matchers instead of `Series` calls which was inefficient. #4380
 * [ENHANCEMENT] Exemplars are now emitted for all gRPC calls and many operations tracked by histograms. #4462
 * [ENHANCEMENT] New options `-server.http-listen-network` and `-server.grpc-listen-network` allow binding as 'tcp4' or 'tcp6'. #4462
+* [ENHANCEMENT] Rulers: Using shuffle sharding subring on GetRules API. #4466
 * [BUGFIX] Fixes a panic in the query-tee when comparing result. #4465
 * [BUGFIX] Frontend: Fixes @ modifier functions (start/end) when splitting queries by time. #4464
 * [BUGFIX] Compactor: compactor will no longer try to compact blocks that are already marked for deletion. Previously compactor would consider blocks marked for deletion within `-compactor.deletion-delay / 2` period as eligible for compaction. #4328
@@ -50,7 +51,6 @@
 * [BUGFIX] Querier: After query-frontend restart, querier may have lower than configured concurrency. #4417
 * [BUGFIX] Memberlist: forward only changes, not entire original message. #4419
 * [BUGFIX] Memberlist: don't accept old tombstones as incoming change, and don't forward such messages to other gossip members. #4420
-* [ENHANCEMENT] Rulers: Using shuffle sharding subring on GetRules API. #4466
 
 ## 1.10.0 / 2021-08-03
 

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -651,7 +651,7 @@ func (r *Ruler) GetRules(ctx context.Context) ([]*GroupStateDesc, error) {
 	}
 
 	if r.cfg.EnableSharding {
-		return r.getShardedRules(ctx)
+		return r.getShardedRules(ctx, userID)
 	}
 
 	return r.getLocalRules(userID)
@@ -744,8 +744,14 @@ func (r *Ruler) getLocalRules(userID string) ([]*GroupStateDesc, error) {
 	return groupDescs, nil
 }
 
-func (r *Ruler) getShardedRules(ctx context.Context) ([]*GroupStateDesc, error) {
-	rulers, err := r.ring.GetReplicationSetForOperation(RingOp)
+func (r *Ruler) getShardedRules(ctx context.Context, userID string) ([]*GroupStateDesc, error) {
+	ring := ring.ReadRing(r.ring)
+
+	if shardSize := r.limits.RulerTenantShardSize(userID); shardSize > 0 && r.cfg.ShardingStrategy == util.ShardingStrategyShuffle {
+		ring = r.ring.ShuffleShard(userID, shardSize)
+	}
+
+	rulers, err := ring.GetReplicationSetForOperation(RingOp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -427,11 +427,14 @@ func TestGetRules(t *testing.T) {
 					require.NoError(t, err)
 					require.Equal(t, len(allRulesByUser[u]), len(rules))
 					if tc.sharding {
-						mockPoolLClient := r.clientsPool.(*mockRulerClientsPool)
+						mockPoolClient := r.clientsPool.(*mockRulerClientsPool)
 
-						// Right now we are calling all rules even with shuffle sharding
-						require.Equal(t, int32(len(rulerAddrMap)), mockPoolLClient.numberOfCalls.Load())
-						mockPoolLClient.numberOfCalls.Store(0)
+						if tc.shardingStrategy == util.ShardingStrategyShuffle {
+							require.Equal(t, int32(tc.shuffleShardSize), mockPoolClient.numberOfCalls.Load())
+						} else {
+							require.Equal(t, int32(len(rulerAddrMap)), mockPoolClient.numberOfCalls.Load())
+						}
+						mockPoolClient.numberOfCalls.Store(0)
 					}
 				})
 			}


### PR DESCRIPTION
**What this PR does**:

GetRules API should call only the rulers on the tenant's subring when sharding strategy is set to `ShardingStrategyShuffle`.

Right now we are calling all rulers in the `GetRules` api even if the   sharding strategy is set to `ShardingStrategyShuffle`. In this case, we should only call the rules in the tenant subring as those rules are the only ones that can load rules from this tenant.  This change is specially important as right now we need all the rulers in the [ring to be available](https://github.com/cortexproject/cortex/blob/master/pkg/ruler/ruler.go#L763) or cortex will return an error - this means that if we have shardSize = 3 but 100 rulers in total, we will return 5xx if any of the 100 rules are down (for instance during deployment), even though the callers rules are spread only on 3 of them.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
