### PR TITLE
Federated ruler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [ENHANCEMENT] Updated Prometheus to include changes from prometheus/prometheus#9083. Now whenever `/labels` API calls include matchers, blocks store is queried for `LabelNames` with matchers instead of `Series` calls which was inefficient. #4380
 * [ENHANCEMENT] Exemplars are now emitted for all gRPC calls and many operations tracked by histograms. #4462
 * [ENHANCEMENT] New options `-server.http-listen-network` and `-server.grpc-listen-network` allow binding as 'tcp4' or 'tcp6'. #4462
+* [ENHANCEMENT] Ruler/Alertmanager: Add support for Federated tenant rules and alerts #4403
 * [BUGFIX] Fixes a panic in the query-tee when comparing result. #4465
 * [BUGFIX] Frontend: Fixes @ modifier functions (start/end) when splitting queries by time. #4464
 * [BUGFIX] Compactor: compactor will no longer try to compact blocks that are already marked for deletion. Previously compactor would consider blocks marked for deletion within `-compactor.deletion-delay / 2` period as eligible for compaction. #4328

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -58,12 +58,13 @@ type UserConfig struct {
 func (am *MultitenantAlertmanager) GetUserConfig(w http.ResponseWriter, r *http.Request) {
 	logger := util_log.WithContext(r.Context(), am.logger)
 
-	userID, err := tenant.TenantID(r.Context())
+	tenantIDs, err := tenant.TenantIDs(r.Context())
 	if err != nil {
 		level.Error(logger).Log("msg", errNoOrgID, "err", err.Error())
 		http.Error(w, fmt.Sprintf("%s: %s", errNoOrgID, err.Error()), http.StatusUnauthorized)
 		return
 	}
+	userID := tenant.JoinTenantIDs(tenantIDs)
 
 	cfg, err := am.store.GetAlertConfig(r.Context(), userID)
 	if err != nil {
@@ -95,12 +96,13 @@ func (am *MultitenantAlertmanager) GetUserConfig(w http.ResponseWriter, r *http.
 
 func (am *MultitenantAlertmanager) SetUserConfig(w http.ResponseWriter, r *http.Request) {
 	logger := util_log.WithContext(r.Context(), am.logger)
-	userID, err := tenant.TenantID(r.Context())
+	tenantIDs, err := tenant.TenantIDs(r.Context())
 	if err != nil {
 		level.Error(logger).Log("msg", errNoOrgID, "err", err.Error())
 		http.Error(w, fmt.Sprintf("%s: %s", errNoOrgID, err.Error()), http.StatusUnauthorized)
 		return
 	}
+	userID := tenant.JoinTenantIDs(tenantIDs)
 
 	var input io.Reader
 	maxConfigSize := am.limits.AlertmanagerMaxConfigSize(userID)
@@ -155,12 +157,13 @@ func (am *MultitenantAlertmanager) SetUserConfig(w http.ResponseWriter, r *http.
 // Note that if no config exists for a user, StatusOK is returned.
 func (am *MultitenantAlertmanager) DeleteUserConfig(w http.ResponseWriter, r *http.Request) {
 	logger := util_log.WithContext(r.Context(), am.logger)
-	userID, err := tenant.TenantID(r.Context())
+	tenantIDs, err := tenant.TenantIDs(r.Context())
 	if err != nil {
 		level.Error(logger).Log("msg", errNoOrgID, "err", err.Error())
 		http.Error(w, fmt.Sprintf("%s: %s", errNoOrgID, err.Error()), http.StatusUnauthorized)
 		return
 	}
+	userID := tenant.JoinTenantIDs(tenantIDs)
 
 	err = am.store.DeleteAlertConfig(r.Context(), userID)
 	if err != nil {

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -630,7 +630,7 @@ func TestMultitenantAlertmanager_DeleteUserConfig(t *testing.T) {
 
 func TestAMConfigListUserConfig(t *testing.T) {
 	testCases := map[string]*UserConfig{
-		"user1": {
+		"user1|user2|user3": {
 			AlertmanagerConfig: `
 global:
   resolve_timeout: 5m

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -630,6 +630,24 @@ func TestMultitenantAlertmanager_DeleteUserConfig(t *testing.T) {
 
 func TestAMConfigListUserConfig(t *testing.T) {
 	testCases := map[string]*UserConfig{
+		"user1": {
+			AlertmanagerConfig: `
+global:
+  resolve_timeout: 5m
+route:
+  receiver: route1
+  group_by:
+  - '...'
+  continue: false
+receivers:
+- name: route1
+  webhook_configs:
+  - send_resolved: true
+    http_config: {}
+    url: http://alertmanager/api/notifications?orgId=1&rrid=7
+    max_alerts: 0
+`,
+		},
 		"user1|user2|user3": {
 			AlertmanagerConfig: `
 global:
@@ -693,7 +711,7 @@ receivers:
 
 	err = am.loadAndSyncConfigs(context.Background(), reasonPeriodic)
 	require.NoError(t, err)
-	require.Len(t, am.alertmanagers, 2)
+	require.Len(t, am.alertmanagers, 3)
 
 	router := mux.NewRouter()
 	router.Path("/multitenant_alertmanager/configs").Methods(http.MethodGet).HandlerFunc(am.ListAllConfigs)

--- a/pkg/alertmanager/distributor.go
+++ b/pkg/alertmanager/distributor.go
@@ -122,11 +122,12 @@ func (d *Distributor) DistributeRequest(w http.ResponseWriter, r *http.Request) 
 	d.requestsInFlight.Add(1)
 	defer d.requestsInFlight.Done()
 
-	userID, err := tenant.TenantID(r.Context())
+	tenantIDs, err := tenant.TenantIDs(r.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
+	userID := tenant.JoinTenantIDs(tenantIDs)
 
 	logger := util_log.WithContext(r.Context(), d.logger)
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -1003,11 +1003,12 @@ func (am *MultitenantAlertmanager) HandleRequest(ctx context.Context, in *httpgr
 
 // serveRequest serves the Alertmanager's web UI and API.
 func (am *MultitenantAlertmanager) serveRequest(w http.ResponseWriter, req *http.Request) {
-	userID, err := tenant.TenantID(req.Context())
+	tenantIDs, err := tenant.TenantIDs(req.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
+	userID := tenant.JoinTenantIDs(tenantIDs)
 	am.alertmanagersMtx.Lock()
 	userAM, ok := am.alertmanagers[userID]
 	am.alertmanagersMtx.Unlock()
@@ -1148,10 +1149,11 @@ func (am *MultitenantAlertmanager) ReadFullStateForUser(ctx context.Context, use
 
 // UpdateState implements the Alertmanager service.
 func (am *MultitenantAlertmanager) UpdateState(ctx context.Context, part *clusterpb.Part) (*alertmanagerpb.UpdateStateResponse, error) {
-	userID, err := tenant.TenantID(ctx)
+	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, err
 	}
+	userID := tenant.JoinTenantIDs(tenantIDs)
 
 	am.alertmanagersMtx.Lock()
 	userAM, ok := am.alertmanagers[userID]
@@ -1254,10 +1256,11 @@ func (am *MultitenantAlertmanager) getPerUserDirectories() map[string]string {
 
 // UpdateState implements the Alertmanager service.
 func (am *MultitenantAlertmanager) ReadState(ctx context.Context, req *alertmanagerpb.ReadStateRequest) (*alertmanagerpb.ReadStateResponse, error) {
-	userID, err := tenant.TenantID(ctx)
+	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, err
 	}
+	userID := tenant.JoinTenantIDs(tenantIDs)
 
 	am.alertmanagersMtx.Lock()
 	userAM, ok := am.alertmanagers[userID]

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -662,8 +662,9 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 	rulerRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "ruler"}, prometheus.DefaultRegisterer)
 	// TODO: Consider wrapping logger to differentiate from querier module logger
 	queryable, _, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, t.TombstonesLoader, rulerRegisterer, util_log.Logger)
+	mq := tenantfederation.NewQueryable(queryable, false)
 
-	managerFactory := ruler.DefaultTenantManagerFactory(t.Cfg.Ruler, t.Distributor, queryable, engine, t.Overrides, prometheus.DefaultRegisterer)
+	managerFactory := ruler.DefaultTenantManagerFactory(t.Cfg.Ruler, t.Distributor, mq, engine, t.Overrides, prometheus.DefaultRegisterer)
 	manager, err := ruler.NewDefaultMultiTenantManager(t.Cfg.Ruler, managerFactory, prometheus.DefaultRegisterer, util_log.Logger)
 	if err != nil {
 		return nil, err

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -238,7 +238,7 @@ func (t *Cortex) initTenantFederation() (serv services.Service, err error) {
 		// single tenant. This allows for a less impactful enabling of tenant
 		// federation.
 		byPassForSingleQuerier := true
-		t.QuerierQueryable = querier.NewSampleAndChunkQueryable(tenantfederation.NewQueryable(t.QuerierQueryable, byPassForSingleQuerier))
+		t.QuerierQueryable = querier.NewSampleAndChunkQueryable(tenantfederation.NewQueryable(t.QuerierQueryable, byPassForSingleQuerier, t.Cfg.TenantFederation))
 	}
 	return nil, nil
 }
@@ -662,7 +662,7 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 	rulerRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "ruler"}, prometheus.DefaultRegisterer)
 	// TODO: Consider wrapping logger to differentiate from querier module logger
 	queryable, _, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, t.TombstonesLoader, rulerRegisterer, util_log.Logger)
-	mq := tenantfederation.NewQueryable(queryable, false)
+	mq := tenantfederation.NewQueryable(queryable, false, t.Cfg.TenantFederation)
 
 	managerFactory := ruler.DefaultTenantManagerFactory(t.Cfg.Ruler, t.Distributor, mq, engine, t.Overrides, prometheus.DefaultRegisterer)
 	manager, err := ruler.NewDefaultMultiTenantManager(t.Cfg.Ruler, managerFactory, prometheus.DefaultRegisterer, util_log.Logger)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -967,7 +967,6 @@ func (d *Distributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetad
 			return nil, err
 		}
 		req := &ingester_client.MetricsMetadataRequest{}
-		// TODO(gotjosh): We only need to look in all the ingesters if shardByAllLabels is enabled.
 		resps, err := d.ForReplicationSet(ctx, replicationSet, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			return client.MetricsMetadata(ctx, req)
 		})

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -21,7 +21,7 @@ import (
 const (
 	defaultTenantLabel   = "__tenant_id__"
 	retainExistingPrefix = "original_"
-	maxConcurrency       = 16
+	maxConcurrency       = 60
 )
 
 // NewQueryable returns a queryable that iterates through all the tenant IDs

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -257,7 +257,9 @@ type mergeQueryableScenario struct {
 
 func (s *mergeQueryableScenario) init() (storage.Querier, error) {
 	// initialize with default tenant label
-	q := NewQueryable(&s.queryable, !s.doNotByPassSingleQuerier)
+	q := NewQueryable(&s.queryable, !s.doNotByPassSingleQuerier, Config{
+		MaxConcurrency: 16,
+	})
 
 	// inject tenants into context
 	ctx := context.Background()
@@ -334,7 +336,9 @@ type labelValuesScenario struct {
 func TestMergeQueryable_Querier(t *testing.T) {
 	t.Run("querying without a tenant specified should error", func(t *testing.T) {
 		queryable := &mockTenantQueryableWithFilter{}
-		q := NewQueryable(queryable, false /* byPassWithSingleQuerier */)
+		q := NewQueryable(queryable, false /* bypasswithsinglequerier */, Config{
+			MaxConcurrency: 16,
+		})
 		// Create a context with no tenant specified.
 		ctx := context.Background()
 
@@ -873,7 +877,9 @@ func TestTracingMergeQueryable(t *testing.T) {
 	// set a multi tenant resolver
 	tenant.WithDefaultResolver(tenant.NewMultiResolver())
 	filter := mockTenantQueryableWithFilter{}
-	q := NewQueryable(&filter, false)
+	q := NewQueryable(&filter, false, Config{
+		MaxConcurrency: 16,
+	})
 	// retrieve querier if set
 	querier, err := q.Querier(ctx, mint, maxt)
 	require.NoError(t, err)

--- a/pkg/querier/tenantfederation/tenant_federation.go
+++ b/pkg/querier/tenantfederation/tenant_federation.go
@@ -6,9 +6,11 @@ import (
 
 type Config struct {
 	// Enabled switches on support for multi tenant query federation
-	Enabled bool `yaml:"enabled"`
+	Enabled        bool `yaml:"enabled"`
+	MaxConcurrency int  `yaml:"max-concurrency"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.Enabled, "tenant-federation.enabled", false, "If enabled on all Cortex services, queries can be federated across multiple tenants. The tenant IDs involved need to be specified separated by a `|` character in the `X-Scope-OrgID` header (experimental).")
+	f.IntVar(&cfg.MaxConcurrency, "tenant-federation.max-concurrency", 16, "Maximum concurrent federated sub queries used when evaluating a federated query")
 }

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -138,8 +138,8 @@ func NewAPI(r *Ruler, s rulestore.RuleStore, logger log.Logger) *API {
 
 func (a *API) PrometheusRules(w http.ResponseWriter, req *http.Request) {
 	logger := util_log.WithContext(req.Context(), a.logger)
-	userID, err := tenant.TenantID(req.Context())
-	if err != nil || userID == "" {
+	tenantIDs, err := tenant.TenantIDs(req.Context())
+	if err != nil || len(tenantIDs) == 0 {
 		level.Error(logger).Log("msg", "error extracting org id from context", "err", err)
 		respondError(logger, w, "no valid org id found")
 		return
@@ -230,8 +230,8 @@ func (a *API) PrometheusRules(w http.ResponseWriter, req *http.Request) {
 
 func (a *API) PrometheusAlerts(w http.ResponseWriter, req *http.Request) {
 	logger := util_log.WithContext(req.Context(), a.logger)
-	userID, err := tenant.TenantID(req.Context())
-	if err != nil || userID == "" {
+	tenantIDs, err := tenant.TenantIDs(req.Context())
+	if err != nil || len(tenantIDs) == 0 {
 		level.Error(logger).Log("msg", "error extracting org id from context", "err", err)
 		respondError(logger, w, "no valid org id found")
 		return
@@ -359,10 +359,11 @@ func parseGroupName(params map[string]string) (string, error) {
 // and returns them in that order. It also allows users to require a namespace or group name and return
 // an error if it they can not be parsed.
 func parseRequest(req *http.Request, requireNamespace, requireGroup bool) (string, string, string, error) {
-	userID, err := tenant.TenantID(req.Context())
+	tenantIDs, err := tenant.TenantIDs(req.Context())
 	if err != nil {
 		return "", "", "", user.ErrNoOrgID
 	}
+	userID := tenant.JoinTenantIDs(tenantIDs)
 
 	vars := mux.Vars(req)
 

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -240,7 +240,7 @@ rules:
 			router.Path("/api/v1/rules/{namespace}").Methods("POST").HandlerFunc(a.CreateRuleGroup)
 			router.Path("/api/v1/rules/{namespace}/{groupName}").Methods("GET").HandlerFunc(a.GetRuleGroup)
 			// POST
-			req := requestFor(t, http.MethodPost, "https://localhost:8080/api/v1/rules/namespace", strings.NewReader(tt.input), "user1")
+			req := requestFor(t, http.MethodPost, "https://localhost:8080/api/v1/rules/namespace", strings.NewReader(tt.input), "user1|user2|user3")
 			w := httptest.NewRecorder()
 
 			router.ServeHTTP(w, req)
@@ -248,7 +248,7 @@ rules:
 
 			if tt.err == nil {
 				// GET
-				req = requestFor(t, http.MethodGet, "https://localhost:8080/api/v1/rules/namespace/test", nil, "user1")
+				req = requestFor(t, http.MethodGet, "https://localhost:8080/api/v1/rules/namespace/test", nil, "user1|user2|user3")
 				w = httptest.NewRecorder()
 
 				router.ServeHTTP(w, req)

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -3,6 +3,7 @@ package ruler
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/cortexproject/cortex/pkg/querier"
+	"github.com/cortexproject/cortex/pkg/tenant"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
@@ -36,7 +38,7 @@ type PusherAppender struct {
 	ctx             context.Context
 	pusher          Pusher
 	labels          []labels.Labels
-	samples         []cortexpb.Sample
+	samples         map[string][]cortexpb.Sample
 	userID          string
 	evaluationDelay time.Duration
 }
@@ -56,7 +58,19 @@ func (a *PusherAppender) Append(_ uint64, l labels.Labels, t int64, v float64) (
 		t -= a.evaluationDelay.Milliseconds()
 	}
 
-	a.samples = append(a.samples, cortexpb.Sample{
+	userID := a.userID
+	if tenant.IsCompositeTenantID(userID) {
+		// Set seed based on a hash of the series so same series always goes to same subtenant
+		src := rand.NewSource(int64(l.Copy().Hash()))
+		r := rand.New(src)
+		userIDs, err := tenant.TenantIDsFromOrgID(userID)
+		if err != nil {
+			return 0, err
+		}
+		i := r.Intn(len(userIDs))
+		userID = userIDs[i]
+	}
+	a.samples[userID] = append(a.samples[userID], cortexpb.Sample{
 		TimestampMs: t,
 		Value:       v,
 	})
@@ -72,23 +86,26 @@ func (a *PusherAppender) Commit() error {
 
 	// Since a.pusher is distributor, client.ReuseSlice will be called in a.pusher.Push.
 	// We shouldn't call client.ReuseSlice here.
-	_, err := a.pusher.Push(user.InjectOrgID(a.ctx, a.userID), cortexpb.ToWriteRequest(a.labels, a.samples, nil, cortexpb.RULE))
+	var err error
+	for userID, samples := range a.samples {
+		_, err = a.pusher.Push(user.InjectOrgID(a.ctx, userID), cortexpb.ToWriteRequest(a.labels, samples, nil, cortexpb.RULE))
 
-	if err != nil {
-		// Don't report errors that ended with 4xx HTTP status code (series limits, duplicate samples, out of order, etc.)
-		if resp, ok := httpgrpc.HTTPResponseFromError(err); !ok || resp.Code/100 != 4 {
-			a.failedWrites.Inc()
+		if err != nil {
+			// Don't report errors that ended with 4xx HTTP status code (series limits, duplicate samples, out of order, etc.)
+			if resp, ok := httpgrpc.HTTPResponseFromError(err); !ok || resp.Code/100 != 4 {
+				a.failedWrites.Inc()
+			}
 		}
 	}
 
 	a.labels = nil
-	a.samples = nil
+	a.samples = map[string][]cortexpb.Sample{}
 	return err
 }
 
 func (a *PusherAppender) Rollback() error {
 	a.labels = nil
-	a.samples = nil
+	a.samples = map[string][]cortexpb.Sample{}
 	return nil
 }
 
@@ -122,6 +139,7 @@ func (t *PusherAppendable) Appender(ctx context.Context) storage.Appender {
 		pusher:          t.pusher,
 		userID:          t.userID,
 		evaluationDelay: t.rulesLimits.EvaluationDelay(t.userID),
+		samples:         map[string][]cortexpb.Sample{},
 	}
 }
 

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -3,7 +3,6 @@ package ruler
 import (
 	"context"
 	"errors"
-	"math/rand"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -60,14 +59,12 @@ func (a *PusherAppender) Append(_ uint64, l labels.Labels, t int64, v float64) (
 
 	userID := a.userID
 	if tenant.IsCompositeTenantID(userID) {
-		// Set seed based on a hash of the series so same series always goes to same subtenant
-		src := rand.NewSource(int64(l.Copy().Hash()))
-		r := rand.New(src)
 		userIDs, err := tenant.TenantIDsFromOrgID(userID)
 		if err != nil {
 			return 0, err
 		}
-		i := r.Intn(len(userIDs))
+		// Mod the hash of the series so same series always goes to same subtenant
+		i := int(l.Copy().Hash()) % len(userIDs)
 		userID = userIDs[i]
 	}
 	a.samples[userID] = append(a.samples[userID], cortexpb.Sample{

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
+	"github.com/cortexproject/cortex/pkg/tenant"
 )
 
 type fakePusher struct {
@@ -28,13 +29,17 @@ type fakePusher struct {
 }
 
 func (p *fakePusher) Push(ctx context.Context, r *cortexpb.WriteRequest) (*cortexpb.WriteResponse, error) {
+	_, err := tenant.TenantID(ctx)
+	if err != nil {
+		return nil, err
+	}
 	p.request = r
 	return p.response, p.err
 }
 
 func TestPusherAppendable(t *testing.T) {
 	pusher := &fakePusher{}
-	pa := NewPusherAppendable(pusher, "user-1", nil, prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+	pa := NewPusherAppendable(pusher, "1|2|3|4|5", nil, prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
 
 	for _, tc := range []struct {
 		name       string

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -645,10 +645,11 @@ func filterRuleGroups(userID string, ruleGroups []*rulespb.RuleGroupDesc, ring r
 // GetRules retrieves the running rules from this ruler and all running rulers in the ring if
 // sharding is enabled
 func (r *Ruler) GetRules(ctx context.Context) ([]*GroupStateDesc, error) {
-	userID, err := tenant.TenantID(ctx)
+	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id found in context")
 	}
+	userID := tenant.JoinTenantIDs(tenantIDs)
 
 	if r.cfg.EnableSharding {
 		return r.getShardedRules(ctx)
@@ -788,10 +789,11 @@ func (r *Ruler) getShardedRules(ctx context.Context) ([]*GroupStateDesc, error) 
 
 // Rules implements the rules service
 func (r *Ruler) Rules(ctx context.Context, in *RulesRequest) (*RulesResponse, error) {
-	userID, err := tenant.TenantID(ctx)
+	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("no user id found in context")
 	}
+	userID := tenant.JoinTenantIDs(tenantIDs)
 
 	groupDescs, err := r.getLocalRules(userID)
 	if err != nil {
@@ -835,13 +837,14 @@ func (r *Ruler) AssertMaxRulesPerRuleGroup(userID string, rules int) error {
 func (r *Ruler) DeleteTenantConfiguration(w http.ResponseWriter, req *http.Request) {
 	logger := util_log.WithContext(req.Context(), r.logger)
 
-	userID, err := tenant.TenantID(req.Context())
+	tenantIDs, err := tenant.TenantIDs(req.Context())
 	if err != nil {
 		// When Cortex is running, it uses Auth Middleware for checking X-Scope-OrgID and injecting tenant into context.
 		// Auth Middleware sends http.StatusUnauthorized if X-Scope-OrgID is missing, so we do too here, for consistency.
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
+	userID := tenant.JoinTenantIDs(tenantIDs)
 
 	err = r.store.DeleteNamespace(req.Context(), userID, "") // Empty namespace = delete all rule groups.
 	if err != nil && !errors.Is(err, rulestore.ErrGroupNamespaceNotFound) {

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -68,6 +68,10 @@ func ValidTenantID(s string) error {
 	return nil
 }
 
+func IsCompositeTenantID(s string) bool {
+	return strings.Contains(s, tenantIDsLabelSeparator)
+}
+
 func JoinTenantIDs(tenantIDs []string) string {
 	return strings.Join(tenantIDs, tenantIDsLabelSeparator)
 }


### PR DESCRIPTION
**What this PR does**:
This PR adds support for multitenant rules and alerts to ruler and alertmanager. A multitenant rule is one whose query spans multiple tenants e.g. a rule stored in `foo|bar` would query both tenant `foo` and `bar` when evaluating the rule and store the resulting rules timeseries in either `foo` or `bar`, but always in the same subtenant.

Using a setup of 20 tenants `0`, `1`, ... `19` fed bogus metrics with avalanche and the following recording rule stored in the composite tenant `0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19`
I saw

![Screenshot 2021-08-25 at 13-28-38 Explore - Cortex - Grafana](https://user-images.githubusercontent.com/5222797/130860128-55df4832-290f-4162-9e9e-f9cd644e16c4.png)


from the following rule file

```yaml
name: record_rule_eg
interval: 10s
rules:
  - record: record_rule_eg
    expr: sum(avalanche_metric_m_4_10017)
```

**Which issue(s) this PR fixes**:
Fixes #4403 

**Open Question**:
I noticed when adding a corresponding alertmanager config for the `0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19` tenant, alerts were always sent to the composite tenant with the subtenants lexographically sorted e.g. `0|1|10|11|12|13|14|15|16|17|18|19|2|3|4|5|6|7|8|9`. Should I introduce forcible sorting of subtenants when creating rule groups as well to reduce confusion?

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
