### PR TITLE
fix querier panics when query exemplars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [BUGFIX] Querier: After query-frontend restart, querier may have lower than configured concurrency. #4417
 * [BUGFIX] Memberlist: forward only changes, not entire original message. #4419
 * [BUGFIX] Memberlist: don't accept old tombstones as incoming change, and don't forward such messages to other gossip members. #4420
+* [BUGFIX] Querier: querier panics when query exemplars. #4469
 
 ## 1.10.0 / 2021-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 * [BUGFIX] Querier: After query-frontend restart, querier may have lower than configured concurrency. #4417
 * [BUGFIX] Memberlist: forward only changes, not entire original message. #4419
 * [BUGFIX] Memberlist: don't accept old tombstones as incoming change, and don't forward such messages to other gossip members. #4420
-* [BUGFIX] Querier: querier panics when query exemplars. #4469
+* [BUGFIX] Querier: fixed panic when querying exemplars and using `-distributor.shard-by-all-labels=false`. #4473
 
 ## 1.10.0 / 2021-08-03
 

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -59,7 +59,7 @@ func (d *Distributor) QueryExemplars(ctx context.Context, from, to model.Time, m
 		}
 
 		// We ask for all ingesters without passing matchers because exemplar queries take in an array of array of label matchers.
-		replicationSet, err := d.GetIngestersForQuery(ctx, nil)
+		replicationSet, err := d.GetIngestersForQuery(ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
What this PR does:
fix querier panics when query exemplars

Which issue(s) this PR fixes:
Fixes #4469

The panic:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x14497b5]

goroutine 1295 [running]:
github.com/opentracing-contrib/go-stdlib/nethttp.MiddlewareFunc.func5.1(0xc000a1fc08, 0x2d46780, 0xc00113f560)
	/data/fuxi_ci_workspace/612d9ff956bed87ff117ab16/cmd/pkg/mod/github.com/opentracing-contrib/go-stdlib@v1.0.0/nethttp/server.go:150 +0x1ab
panic(0x242fb40, 0x3e2f400)
	/data/fuxi_ci_workspace/612d9ff956bed87ff117ab16_cache/buildbox/go-1.16.3/src/runtime/panic.go:965 +0x1b9
github.com/cortexproject/cortex/pkg/util/extract.MetricNameMatcherFromMatchers(0xc000942578, 0x1, 0x1, 0xc000af2e80, 0x20, 0x0, 0x0, 0x14f9b45)
	/data/fuxi_ci_workspace/612d9ff956bed87ff117ab16/pkg/util/extract/extract.go:58 +0x75
github.com/cortexproject/cortex/pkg/distributor.(*Distributor).GetIngestersForQuery(0xc000664000, 0x2d18a20, 0xc0010b66c0, 0xc000942578, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, ...)
	/data/fuxi_ci_workspace/612d9ff956bed87ff117ab16/pkg/distributor/query.go:138 +0x133
github.com/cortexproject/cortex/pkg/distributor.(*Distributor).QueryExemplars.func1(0x2d18a20, 0xc0010b66c0, 0x1a, 0xc0469b556a0f3025)
	/data/fuxi_ci_workspace/612d9ff956bed87ff117ab16/pkg/distributor/query.go:67 +0x119
```

