### PR TITLE
Ring: remove redundant 'LEAVING' status in Operation construction

### DIFF
--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -866,7 +866,7 @@ func NewOp(healthyStates []InstanceState, shouldExtendReplicaSet func(s Instance
 	}
 
 	if shouldExtendReplicaSet != nil {
-		for _, s := range []InstanceState{ACTIVE, LEAVING, PENDING, JOINING, LEAVING, LEFT} {
+		for _, s := range []InstanceState{ACTIVE, LEAVING, PENDING, JOINING, LEFT} {
 			if shouldExtendReplicaSet(s) {
 				op |= (0x10000 << s)
 			}


### PR DESCRIPTION
Signed-off-by: lanmengran1 <lanmengran1@jd.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Remove redundant 'LEAVING' status in Operation construction

**Which issue(s) this PR fixes**:
NA

**Checklist**
- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
