### PR TITLE
Use most recent time to remove from ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * [BUGFIX] Querier: fixed panic when querying exemplars and using `-distributor.shard-by-all-labels=false`. #4473
 * [BUGFIX] Querier: honor querier minT,maxT if `nil` SelectHints are passed to Select(). #4413
 * [BUGFIX] Compactor: fixed panic while collecting Prometheus metrics. #4483
+* [BUGFIX] Memberlist: Remove entry from the ring even if the timestamp is in the future  #4501
 
 
 ## 1.10.0 / 2021-08-03

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -210,7 +210,12 @@ func (d *Desc) mergeWithTime(mergeable memberlist.Mergeable, localCAS bool, now 
 				// We are deleting entry "now", and should not keep old timestamp, because there may already be pending
 				// message in the gossip network with newer timestamp (but still older than "now").
 				// Such message would "resurrect" this deleted entry.
-				ting.Timestamp = now.Unix()
+				// If timestamp on the ring is in "the future" we need to use the timestamp of the ring
+				// otherwise the gossip message will be ignored by the peers.
+				// see https://github.com/cortexproject/cortex/blob/d3f46c53616dcdf5c670f3e3a4d371e44b10683e/pkg/ring/model.go#L192-L200
+				if ting.Timestamp < now.Unix() {
+					ting.Timestamp = now.Unix()
+				}
 				thisIngesterMap[name] = ting
 
 				updated = append(updated, name)


### PR DESCRIPTION
Signed-off-by: Daniel Blando <ddeluigg@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
We previously did a change for forget instance from the ring on [4603](https://github.com/cortexproject/cortex/pull/3603). In some rare cases the timestamp in the ring can be more recent than our current time (eg. clock skew into the future).
This change make sure we can remove the instance even if these cases occcurs

**Which issue(s) this PR fixes**:
Fixes #4461

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
