### PR TITLE
Adds new metric for dropped samples in ingester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [ENHANCEMENT] Add metric `distributor_discarded_samples_total` exposing the total of dropped samples due to relabeling configuration. #4503
 * [CHANGE] Changed default for `-ingester.min-ready-duration` from 1 minute to 15 seconds. #4539
 * [CHANGE] query-frontend: Do not print anything in the logs of `query-frontend` if a in-progress query has been canceled (context canceled). #4562
 * [ENHANCEMENT] Ruler: Add `-ruler.disable-rule-group-label` to disable the `rule_group` label on exported metrics. #4571

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [ENHANCEMENT] Add metric `distributor_discarded_samples_total` exposing the total of dropped samples due to relabeling configuration. #4503
+* [ENHANCEMENT] Keep track of discarded samples due to relabel configuration in `cortex_discarded_samples_total`. #4503
 * [CHANGE] Changed default for `-ingester.min-ready-duration` from 1 minute to 15 seconds. #4539
 * [CHANGE] query-frontend: Do not print anything in the logs of `query-frontend` if a in-progress query has been canceled (context canceled). #4562
 * [ENHANCEMENT] Ruler: Add `-ruler.disable-rule-group-label` to disable the `rule_group` label on exported metrics. #4571

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -94,7 +94,7 @@ type Distributor struct {
 	// Metrics
 	queryDuration                    *instrument.HistogramCollector
 	receivedSamples                  *prometheus.CounterVec
-	discardedSamples                  *prometheus.CounterVec
+	discardedSamples                 *prometheus.CounterVec
 	receivedExemplars                *prometheus.CounterVec
 	receivedMetadata                 *prometheus.CounterVec
 	incomingSamples                  *prometheus.CounterVec

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -711,7 +711,7 @@ func (d *Distributor) Push(ctx context.Context, req *cortexpb.WriteRequest) (*co
 	}
 
 	d.receivedSamples.WithLabelValues(userID).Add(float64(validatedSamples))
-	d.receivedExemplars.WithLabelValues(userID).Add(float64(validatedExemplars))
+	d.receivedExemplars.WithLabelValues(userID).Add((float64(validatedExemplars)))
 	d.receivedMetadata.WithLabelValues(userID).Add(float64(len(validatedMetadata)))
 
 	if len(seriesKeys) == 0 && len(metadataKeys) == 0 {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -638,7 +638,7 @@ func (d *Distributor) Push(ctx context.Context, req *cortexpb.WriteRequest) (*co
 		if mrc := d.limits.MetricRelabelConfigs(userID); len(mrc) > 0 {
 			l := relabel.Process(cortexpb.FromLabelAdaptersToLabels(ts.Labels), mrc...)
 			if len(l) == 0 {
-				// all labels are gone, therefore the __name__ label is not present, samples will be discarded
+				// all labels are gone, samples will be discarded
 				validation.DiscardedSamples.WithLabelValues(
 					validation.DroppedByRelabelConfiguration,
 					userID,
@@ -659,7 +659,7 @@ func (d *Distributor) Push(ctx context.Context, req *cortexpb.WriteRequest) (*co
 			removeLabel(labelName, &ts.Labels)
 		}
 
-		if len(ts.Labels) == 0 || wasNameLabelRemoved(ts.Labels) {
+		if len(ts.Labels) == 0 {
 			validation.DiscardedExemplars.WithLabelValues(
 				validation.DroppedByUserConfigurationOverride,
 				userID,
@@ -791,19 +791,6 @@ func (d *Distributor) Push(ctx context.Context, req *cortexpb.WriteRequest) (*co
 		return nil, err
 	}
 	return &cortexpb.WriteResponse{}, firstPartialErr
-}
-
-func wasNameLabelRemoved(labels []cortexpb.LabelAdapter) bool {
-	const nameLabel = "__name__"
-
-	for i := 0; i < len(labels); i++ {
-		pair := labels[i]
-		if pair.Name == nameLabel {
-			return false
-		}
-	}
-
-	return true
 }
 
 func sortLabelsIfNeeded(labels []cortexpb.LabelAdapter) {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -638,7 +638,7 @@ func (d *Distributor) Push(ctx context.Context, req *cortexpb.WriteRequest) (*co
 		if mrc := d.limits.MetricRelabelConfigs(userID); len(mrc) > 0 {
 			l := relabel.Process(cortexpb.FromLabelAdaptersToLabels(ts.Labels), mrc...)
 			if len(l) == 0 {
-				// all labels are gone, therefore the __name__ label is not present, metric will be discarded
+				// all labels are gone, therefore the __name__ label is not present, samples will be discarded
 				validation.DiscardedSamples.WithLabelValues(
 					validation.DroppedByRelabelConfiguration,
 					userID,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2779,6 +2779,7 @@ func TestDistributor_Push_RelabelDropWillExportMetricOfDroppedSamples(t *testing
 		limits:           &limits,
 	})
 
+	regs[0].MustRegister(validation.DiscardedSamples)
 	validation.DiscardedSamples.Reset()
 
 	// Push the series to the distributor
@@ -2799,7 +2800,7 @@ func TestDistributor_Push_RelabelDropWillExportMetricOfDroppedSamples(t *testing
 	expectedMetrics := `
 		# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 		# TYPE cortex_discarded_samples_total counter
-		cortex_discarded_samples_total{reason="relabel_configuration",user="user"} 1
+		cortex_discarded_samples_total{reason="relabel_configuration",user="user1"} 1
 		# HELP cortex_distributor_received_samples_total The total number of received samples, excluding rejected and deduped samples.
 		# TYPE cortex_distributor_received_samples_total counter
 		cortex_distributor_received_samples_total{user="user1"} 1

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2781,6 +2781,7 @@ func TestDistributor_Push_RelabelDropWillExportMetricOfDroppedSamples(t *testing
 		limits:           &limits,
 	})
 	reg := regs[0]
+	reg.MustRegister(validation.DiscardedSamples)
 	defer stopAll(ds, r)
 
 	// Push the series to the distributor
@@ -2796,14 +2797,14 @@ func TestDistributor_Push_RelabelDropWillExportMetricOfDroppedSamples(t *testing
 		assert.Equal(t, 1, len(timeseries))
 	}
 
-	metrics := []string{"cortex_distributor_received_samples_total", "cortex_distributor_discarded_samples_total"}
+	metrics := []string{"cortex_distributor_received_samples_total", "cortex_discarded_samples_total"}
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+		# TYPE cortex_discarded_samples_total counter
+		cortex_discarded_samples_total{reason="relabel_configuration",user="user"} 1
 		# HELP cortex_distributor_received_samples_total The total number of received samples, excluding rejected and deduped samples.
 		# TYPE cortex_distributor_received_samples_total counter
 		cortex_distributor_received_samples_total{user="user"} 1
-		# HELP cortex_distributor_discarded_samples_total The total number of samples which were discarded due to relabel configuration.
-		# TYPE cortex_distributor_discarded_samples_total counter
-		cortex_distributor_discarded_samples_total{user="user"} 1
 		`), metrics...))
 }
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2720,14 +2720,13 @@ func TestDistributor_Push_Relabel(t *testing.T) {
 			flagext.DefaultValues(&limits)
 			limits.MetricRelabelConfigs = tc.metricRelabelConfigs
 
-			ds, ingesters,  _ := prepare(t, prepConfig{
+			ds, ingesters, _ := prepare(t, prepConfig{
 				numIngesters:     2,
 				happyIngesters:   2,
 				numDistributors:  1,
 				shardByAllLabels: true,
 				limits:           &limits,
 			})
-
 
 			// Push the series to the distributor
 			req := mockWriteRequest(tc.inputSeries, 1, 1)
@@ -2772,14 +2771,13 @@ func TestDistributor_Push_RelabelDropWillExportMetricOfDroppedSamples(t *testing
 	flagext.DefaultValues(&limits)
 	limits.MetricRelabelConfigs = metricRelabelConfigs
 
-	ds, ingesters, r, regs := prepare(t, prepConfig{
+	ds, ingesters, regs := prepare(t, prepConfig{
 		numIngesters:     2,
 		happyIngesters:   2,
 		numDistributors:  1,
 		shardByAllLabels: true,
 		limits:           &limits,
 	})
-	defer stopAll(ds, r)
 
 	validation.DiscardedSamples.Reset()
 
@@ -2807,7 +2805,7 @@ func TestDistributor_Push_RelabelDropWillExportMetricOfDroppedSamples(t *testing
 		cortex_distributor_received_samples_total{user="user1"} 1
 		`
 
-	testutil.GatherAndCompare(regs[0], strings.NewReader(expectedMetrics), metrics...)
+	require.NoError(t, testutil.GatherAndCompare(regs[0], strings.NewReader(expectedMetrics), metrics...))
 }
 
 func countMockIngestersCalls(ingesters []mockIngester, name string) int {

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -59,6 +59,8 @@ const (
 
 	// DroppedByRelabelConfiguration Samples can also be discarded because of relabeling configuration
 	DroppedByRelabelConfiguration = "relabel_configuration"
+	// DroppedByUserConfigurationOverride Samples discarded due to user configuration removing label __name__
+	DroppedByUserConfigurationOverride = "user_label_removal_configuration"
 
 	// The combined length of the label names and values of an Exemplar's LabelSet MUST NOT exceed 128 UTF-8 characters
 	// https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -34,16 +34,16 @@ const (
 	// ErrQueryTooLong is used in chunk store, querier and query frontend.
 	ErrQueryTooLong = "the query time range exceeds the limit (query length: %s, limit: %s)"
 
-	missingMetricName       = "missing_metric_name"
-	invalidMetricName       = "metric_name_invalid"
-	greaterThanMaxSampleAge = "greater_than_max_sample_age"
-	maxLabelNamesPerSeries  = "max_label_names_per_series"
-	tooFarInFuture          = "too_far_in_future"
-	invalidLabel            = "label_invalid"
-	labelNameTooLong        = "label_name_too_long"
-	duplicateLabelNames     = "duplicate_label_names"
-	labelsNotSorted         = "labels_not_sorted"
-	labelValueTooLong       = "label_value_too_long"
+	missingMetricName             = "missing_metric_name"
+	invalidMetricName             = "metric_name_invalid"
+	greaterThanMaxSampleAge       = "greater_than_max_sample_age"
+	maxLabelNamesPerSeries        = "max_label_names_per_series"
+	tooFarInFuture                = "too_far_in_future"
+	invalidLabel                  = "label_invalid"
+	labelNameTooLong              = "label_name_too_long"
+	duplicateLabelNames           = "duplicate_label_names"
+	labelsNotSorted               = "labels_not_sorted"
+	labelValueTooLong             = "label_value_too_long"
 
 	// Exemplar-specific validation reasons
 	exemplarLabelsMissing    = "exemplar_labels_missing"
@@ -56,6 +56,9 @@ const (
 
 	// Too many HA clusters is one of the reasons for discarding samples.
 	TooManyHAClusters = "too_many_ha_clusters"
+
+	// DroppedByRelabelConfiguration Samples can also be discarded because of relabeling configuration
+	DroppedByRelabelConfiguration = "relabel_configuration"
 
 	// The combined length of the label names and values of an Exemplar's LabelSet MUST NOT exceed 128 UTF-8 characters
 	// https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -34,16 +34,16 @@ const (
 	// ErrQueryTooLong is used in chunk store, querier and query frontend.
 	ErrQueryTooLong = "the query time range exceeds the limit (query length: %s, limit: %s)"
 
-	missingMetricName             = "missing_metric_name"
-	invalidMetricName             = "metric_name_invalid"
-	greaterThanMaxSampleAge       = "greater_than_max_sample_age"
-	maxLabelNamesPerSeries        = "max_label_names_per_series"
-	tooFarInFuture                = "too_far_in_future"
-	invalidLabel                  = "label_invalid"
-	labelNameTooLong              = "label_name_too_long"
-	duplicateLabelNames           = "duplicate_label_names"
-	labelsNotSorted               = "labels_not_sorted"
-	labelValueTooLong             = "label_value_too_long"
+	missingMetricName       = "missing_metric_name"
+	invalidMetricName       = "metric_name_invalid"
+	greaterThanMaxSampleAge = "greater_than_max_sample_age"
+	maxLabelNamesPerSeries  = "max_label_names_per_series"
+	tooFarInFuture          = "too_far_in_future"
+	invalidLabel            = "label_invalid"
+	labelNameTooLong        = "label_name_too_long"
+	duplicateLabelNames     = "duplicate_label_names"
+	labelsNotSorted         = "labels_not_sorted"
+	labelValueTooLong       = "label_value_too_long"
 
 	// Exemplar-specific validation reasons
 	exemplarLabelsMissing    = "exemplar_labels_missing"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**: As described in #3954, this PR adds a new metric `distributor_discarded_samples_total` to represent 
the number of dropped samples due to relabeling configuration.

**Which issue(s) this PR fixes**: 
Fixes #3954

**Checklist**
- [X] Tests updated
- [x] Documentation added (N/A ?)
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
