### PR TITLE
Fix race when stopping chunks memcached client

### DIFF
--- a/pkg/chunk/cache/memcached.go
+++ b/pkg/chunk/cache/memcached.go
@@ -89,7 +89,14 @@ func NewMemcached(cfg MemcachedConfig, client MemcachedClient, name string, reg 
 						batchID: input.batchID,
 					}
 					res.found, res.bufs, res.missed = c.fetch(input.ctx, input.keys)
-					input.resultCh <- res
+					// No-one will be reading from resultCh if we were asked to quit
+					// during the fetch, so check again before writing to it.
+					select {
+					case <-c.quit:
+						return
+					default:
+						input.resultCh <- res
+					}
 				}
 			}
 		}()
@@ -214,7 +221,6 @@ loopResults:
 			results[result.batchID] = result
 		}
 	}
-	close(resultsCh)
 
 	for _, result := range results {
 		if result == nil {


### PR DESCRIPTION
We need to check again if we have been asked to quit before writing to the results chan.

Also, the reader of that chan should not close it, because this can trigger a panic in a writer. The chan will be cleaned up by garbage-collection once all the readers and writers have exited on quit.

**Which issue(s) this PR fixes**:
Fixes #4508 

**Checklist**
- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated
