### PR TITLE
doc: Add note about the Alertmanager URL path

### DIFF
--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -80,6 +80,8 @@ type Config struct {
 	RulePath string `yaml:"rule_path"`
 
 	// URL of the Alertmanager to send notifications to.
+	// If your are configuring the ruler to send to a Cortex Alertmanager,
+	// ensure this includes any path set in the Alertmanager external URL.
 	AlertmanagerURL string `yaml:"alertmanager_url"`
 	// Whether to use DNS SRV records to discover Alertmanager.
 	AlertmanagerDiscovery bool `yaml:"enable_alertmanager_discovery"`


### PR DESCRIPTION
I believe this can often be a source of confusion during initial
configuration because even though the implicit HTTP API prefix set
when using `--alertmanager.external-url` is documented, it is non
obvious behavior.

For example, in https://github.com/cortexproject/cortex/issues/3919.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

**Checklist**
- [x] Documentation added