### PR TITLE
Improve client error status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] The `status_code` label on metrics from client has changed from '200' and '500' to '2xx', '5xx' or '4xx'. #4519
 * [ENHANCEMENT] Upgraded Docker base images to `alpine:3.14`. #4514
 * [ENHANCEMENT] Updated Prometheus to latest. Includes changes from prometheus#9239, adding 15 new functions. Multiple TSDB bugfixes prometheus#9438 & prometheus#9381. #4524
 

--- a/pkg/util/middleware/grpc_test.go
+++ b/pkg/util/middleware/grpc_test.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/common/httpgrpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestErrorCode_NoError(t *testing.T) {
+	a := ErrorCode(nil)
+	assert.Equal(t, a, "2xx")
+}
+
+func TestErrorCode_Any5xx(t *testing.T) {
+	err := httpgrpc.Errorf(http.StatusNotImplemented, "Fail")
+	a := ErrorCode(err)
+	assert.Equal(t, a, "5xx")
+}
+
+func TestErrorCode_Any4xx(t *testing.T) {
+	err := httpgrpc.Errorf(http.StatusConflict, "Fail")
+	a := ErrorCode(err)
+	assert.Equal(t, a, "4xx")
+}
+
+func TestErrorCode_Canceled(t *testing.T) {
+	err := status.Errorf(codes.Canceled, "Fail")
+	a := ErrorCode(err)
+	assert.Equal(t, a, "4xx")
+}
+
+func TestErrorCode_Unknown(t *testing.T) {
+	err := status.Errorf(codes.Unknown, "Fail")
+	a := ErrorCode(err)
+	assert.Equal(t, a, "5xx")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
After a discussion about #4441, we noticed that client metrics sent from cortex could be improved. 
The main purpose is to separate 5xx and 4xx error types in the metrics. 

Current we send 200 or 500
https://github.com/cortexproject/cortex/blob/e7e05b2088d9eb109785f01bc1939f7b45791dde/vendor/github.com/weaveworks/common/instrument/instrument.go#L182-L187

I would like to introduce error types as 4xx also to make clear what are internal issues.
This change would make the status_code change from '200' and '500' to '2xx', '5xx' and '4xx'

**Which issue(s) this PR fixes**:

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
