### PR TITLE
Fix: check mset key and value length is equal

### DIFF
--- a/pkg/chunk/cache/redis_client.go
+++ b/pkg/chunk/cache/redis_client.go
@@ -94,6 +94,10 @@ func (c *RedisClient) MSet(ctx context.Context, keys []string, values [][]byte) 
 		defer cancel()
 	}
 
+	if len(keys) != len(values) {
+		return fmt.Errorf("MSet the length of keys and values not equal, len(keys)=%d, len(values)=%d", len(keys), len(values))
+	}
+
 	pipe := c.rdb.TxPipeline()
 	for i := range keys {
 		pipe.Set(ctx, keys[i], values[i], c.expiration)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
 check mset key and value length is equal, this maybe let the cortex panic

**Which issue(s) this PR fixes**:
No

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
