### PR TITLE
Disable S3 SSE integration tests

### DIFF
--- a/integration/s3_storage_client_test.go
+++ b/integration/s3_storage_client_test.go
@@ -94,6 +94,11 @@ func TestS3Client(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			switch tt.name {
+			case "config-with-deprecated-sse", "config-with-sse-s3":
+				t.Skip("TODO: Issue #4543")
+			}
+
 			client, err := s3.NewS3ObjectClient(tt.cfg)
 
 			require.NoError(t, err)


### PR DESCRIPTION
**What this PR does**:
We have our CI blocked because of #4543. I propose to disable S3 SSE integration tests until we have a better solution (in the meanwhile we shouldn't block all PRs).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
