### PR TITLE
Run local KES for S3 integration tests

### DIFF
--- a/integration/certs.go
+++ b/integration/certs.go
@@ -1,0 +1,51 @@
+//go:build requires_docker
+// +build requires_docker
+
+package integration
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"os"
+	"path/filepath"
+
+	"github.com/cortexproject/cortex/integration/ca"
+)
+
+func writeCerts(dir string, dnsNames ...string) error {
+	// set the ca
+	cert := ca.New("Test")
+
+	// Ensure the entire path of directories exist.
+	if err := os.MkdirAll(filepath.Join(dir, "certs"), os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := cert.WriteCACertificate(filepath.Join(dir, caCertFile)); err != nil {
+		return err
+	}
+
+	// server certificate
+	if err := cert.WriteCertificate(
+		&x509.Certificate{
+			Subject:     pkix.Name{CommonName: "client"},
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		},
+		filepath.Join(dir, clientCertFile),
+		filepath.Join(dir, clientKeyFile),
+	); err != nil {
+		return err
+	}
+	if err := cert.WriteCertificate(
+		&x509.Certificate{
+			Subject:     pkix.Name{CommonName: "server"},
+			DNSNames:    dnsNames,
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		},
+		filepath.Join(dir, serverCertFile),
+		filepath.Join(dir, serverKeyFile),
+	); err != nil {
+		return err
+	}
+	return nil
+}

--- a/integration/e2e/images/images.go
+++ b/integration/e2e/images/images.go
@@ -7,7 +7,8 @@ package images
 
 var (
 	Memcached        = "memcached:1.6.1"
-	Minio            = "minio/minio:RELEASE.2019-12-30T05-45-39Z"
+	Minio            = "minio/minio:RELEASE.2021-10-13T00-23-17Z"
+	KES              = "minio/kes:v0.17.1"
 	Consul           = "consul:1.8.4"
 	ETCD             = "gcr.io/etcd-development/etcd:v3.4.7"
 	DynamoDB         = "amazon/dynamodb-local:1.11.477"


### PR DESCRIPTION
**What this PR does**:

Instead of calling out to play.min.io, run the KES service locally in a container.
Generate its key and cert instead of downloading them from GitHub.

By depending on fewer third-party services we reduce test failures.

Extract function to generate PKI certificates.
Update to more recent Minio image; not using the very latest KES because it removed `--root` which is useful.
Re-enable the SSE tests (see #4545)

**Which issue(s) this PR fixes**:
Fixes #4543 

**Checklist**
- [x] Tests updated
- NA Documentation added
- NA CHANGELOG.md - not a user-visible change.
