### PR TITLE
queryrange: retry: do not retry if context is canceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [CHANGE] Changed default for `-ingester.min-ready-duration` from 1 minute to 15 seconds. #4539
 * [ENHANCEMENT] Added new ring related config `-ingester.readiness-check-ring-health` when enabled the readiness probe will succeed only after all instances are ACTIVE and healthy in the ring, this is enabled by default. #4539
+* [CHANGE] Do not print anything in the logs of `query-frontend` if a in-progress query has been canceled (context canceled). #4562
 * [ENHANCEMENT] Added new ring related config `-distributor.excluded-zones` when set this will exclude the comma-separated zones from the ring, default is "". #4539
 * [ENHANCEMENT] Upgraded Docker base images to `alpine:3.14`. #4514
 * [ENHANCEMENT] Updated Prometheus to latest. Includes changes from prometheus#9239, adding 15 new functions. Multiple TSDB bugfixes prometheus#9438 & prometheus#9381. #4524

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [CHANGE] Changed default for `-ingester.min-ready-duration` from 1 minute to 15 seconds. #4539
 * [ENHANCEMENT] Added new ring related config `-ingester.readiness-check-ring-health` when enabled the readiness probe will succeed only after all instances are ACTIVE and healthy in the ring, this is enabled by default. #4539
-* [CHANGE] Do not print anything in the logs of `query-frontend` if a in-progress query has been canceled (context canceled). #4562
+* [CHANGE] query-frontend: Do not print anything in the logs of `query-frontend` if a in-progress query has been canceled (context canceled). #4562
 * [ENHANCEMENT] Added new ring related config `-distributor.excluded-zones` when set this will exclude the comma-separated zones from the ring, default is "". #4539
 * [ENHANCEMENT] Upgraded Docker base images to `alpine:3.14`. #4514
 * [ENHANCEMENT] Updated Prometheus to latest. Includes changes from prometheus#9239, adding 15 new functions. Multiple TSDB bugfixes prometheus#9438 & prometheus#9381. #4524

--- a/pkg/querier/queryrange/retry.go
+++ b/pkg/querier/queryrange/retry.go
@@ -2,6 +2,7 @@ package queryrange
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -64,6 +65,10 @@ func (r retry) Do(ctx context.Context, req Request) (Response, error) {
 		resp, err := r.next.Do(ctx, req)
 		if err == nil {
 			return resp, nil
+		}
+
+		if errors.Is(err, context.Canceled) {
+			return nil, err
 		}
 
 		// Retry if we get a HTTP 500 or a non-HTTP error.


### PR DESCRIPTION
**What this PR does**:

My Thanos instance is spamming this whenever the user cancels a query
that is being executed:

```
{"caller":"retry.go:73","err":"context canceled","level":"error","msg":"error processing request","org_id":"anonymous","try":0,"ts":"2021-11-23T13:35:09.275914072Z"}
```

It doesn't mean anything bad so let's stop the spam. Thus, do not perform the
retrying logic if the context has been canceled. Later on this is handled in:

```go
	resp, err := f.roundTripper.RoundTrip(r)
	queryResponseTime := time.Since(startTime)

	if err != nil {
		writeError(w, err)
		return
	}
```

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
