### PR TITLE
update tenant retention proposal doc with implemented status

### DIFF
--- a/docs/proposals/tenant_retention.md
+++ b/docs/proposals/tenant_retention.md
@@ -7,7 +7,7 @@ slug: tenant-retention
 
 - Author: [Allenzhli](https://github.com/Allenzhli)
 - Date: January 2021
-- Status: Proposed
+- Status: Accepted, Implemented in [PR #3879](https://github.com/cortexproject/cortex/pull/3879)
 
 ## Retention of tenant data
 

--- a/docs/proposals/tenant_retention.md
+++ b/docs/proposals/tenant_retention.md
@@ -7,7 +7,7 @@ slug: tenant-retention
 
 - Author: [Allenzhli](https://github.com/Allenzhli)
 - Date: January 2021
-- Status: Accepted, Implemented in [PR #3879](https://github.com/cortexproject/cortex/pull/3879)
+- Status: Accepted, Implemented in [PR #3879](https://github.com/cortexproject/cortex/pull/3879).
 
 ## Retention of tenant data
 


### PR DESCRIPTION
I was recently very confused by the existence and status of this tenant retention proposal document. Since the creation of this proposal, PR #3879 was implemented and now this document just adds confusion.

**What this PR does**:
Sets the status of the "tenant_retention.md" document to accepted and implemented.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
