### PR TITLE
Optional goleak.VerifyTestMain() everywhere to help finding leaks in …

### DIFF
--- a/cmd/cortex/goleak_main_test.go
+++ b/cmd/cortex/goleak_main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/cmd/query-tee/goleak_main_test.go
+++ b/cmd/query-tee/goleak_main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/alertmanager/alertstore/bucketclient/goleak_bucketclient_test.go
+++ b/pkg/alertmanager/alertstore/bucketclient/goleak_bucketclient_test.go
@@ -1,0 +1,14 @@
+package bucketclient
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/alertmanager/alertstore/goleak_alertstore_test.go
+++ b/pkg/alertmanager/alertstore/goleak_alertstore_test.go
@@ -1,0 +1,14 @@
+package alertstore
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/alertmanager/alertstore/local/goleak_local_test.go
+++ b/pkg/alertmanager/alertstore/local/goleak_local_test.go
@@ -1,0 +1,14 @@
+package local
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/alertmanager/alertstore/objectclient/goleak_objectclient_test.go
+++ b/pkg/alertmanager/alertstore/objectclient/goleak_objectclient_test.go
@@ -1,0 +1,14 @@
+package objectclient
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/alertmanager/goleak_alertmanager_test.go
+++ b/pkg/alertmanager/goleak_alertmanager_test.go
@@ -1,0 +1,14 @@
+package alertmanager
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/api/goleak_api_test.go
+++ b/pkg/api/goleak_api_test.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/chunk/aws/goleak_aws_test.go
+++ b/pkg/chunk/aws/goleak_aws_test.go
@@ -1,0 +1,14 @@
+package aws
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/chunk/cache/goleak_cache_test.go
+++ b/pkg/chunk/cache/goleak_cache_test.go
@@ -1,0 +1,14 @@
+package cache
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/chunk/cassandra/goleak_cassandra_test.go
+++ b/pkg/chunk/cassandra/goleak_cassandra_test.go
@@ -1,0 +1,14 @@
+package cassandra
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/chunk/encoding/goleak_encoding_test.go
+++ b/pkg/chunk/encoding/goleak_encoding_test.go
@@ -1,0 +1,14 @@
+package encoding
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/chunk/goleak_chunk_test.go
+++ b/pkg/chunk/goleak_chunk_test.go
@@ -1,0 +1,14 @@
+package chunk
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/chunk/grpc/goleak_grpc_test.go
+++ b/pkg/chunk/grpc/goleak_grpc_test.go
@@ -1,0 +1,14 @@
+package grpc
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/chunk/local/goleak_local_test.go
+++ b/pkg/chunk/local/goleak_local_test.go
@@ -1,0 +1,14 @@
+package local
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/chunk/purger/goleak_purger_test.go
+++ b/pkg/chunk/purger/goleak_purger_test.go
@@ -1,0 +1,14 @@
+package purger
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/chunk/storage/goleak_storage_test.go
+++ b/pkg/chunk/storage/goleak_storage_test.go
@@ -1,0 +1,14 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/chunk/util/goleak_util_test.go
+++ b/pkg/chunk/util/goleak_util_test.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/compactor/goleak_compactor_test.go
+++ b/pkg/compactor/goleak_compactor_test.go
@@ -1,0 +1,14 @@
+package compactor
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/configs/api/goleak_api_test.go
+++ b/pkg/configs/api/goleak_api_test.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/configs/client/goleak_client_test.go
+++ b/pkg/configs/client/goleak_client_test.go
@@ -1,0 +1,14 @@
+package client
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/configs/legacy_promql/goleak_promql_test.go
+++ b/pkg/configs/legacy_promql/goleak_promql_test.go
@@ -1,0 +1,14 @@
+package promql
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/configs/userconfig/goleak_userconfig_test.go
+++ b/pkg/configs/userconfig/goleak_userconfig_test.go
@@ -1,0 +1,14 @@
+package userconfig
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/cortex/goleak_cortex_test.go
+++ b/pkg/cortex/goleak_cortex_test.go
@@ -1,0 +1,14 @@
+package cortex
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/cortexpb/goleak_cortexpb_test.go
+++ b/pkg/cortexpb/goleak_cortexpb_test.go
@@ -1,0 +1,14 @@
+package cortexpb
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/distributor/goleak_distributor_test.go
+++ b/pkg/distributor/goleak_distributor_test.go
@@ -1,0 +1,14 @@
+package distributor
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/frontend/goleak_frontend_test.go
+++ b/pkg/frontend/goleak_frontend_test.go
@@ -1,0 +1,14 @@
+package frontend
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/frontend/transport/goleak_transport_test.go
+++ b/pkg/frontend/transport/goleak_transport_test.go
@@ -1,0 +1,14 @@
+package transport
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/frontend/v1/goleak_v1_test.go
+++ b/pkg/frontend/v1/goleak_v1_test.go
@@ -1,0 +1,14 @@
+package v1
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/frontend/v2/goleak_v2_test.go
+++ b/pkg/frontend/v2/goleak_v2_test.go
@@ -1,0 +1,14 @@
+package v2
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/ingester/client/goleak_client_test.go
+++ b/pkg/ingester/client/goleak_client_test.go
@@ -1,0 +1,14 @@
+package client
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/ingester/goleak_ingester_test.go
+++ b/pkg/ingester/goleak_ingester_test.go
@@ -1,0 +1,14 @@
+package ingester
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/ingester/index/goleak_index_test.go
+++ b/pkg/ingester/index/goleak_index_test.go
@@ -1,0 +1,14 @@
+package index
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/prom1/storage/metric/goleak_metric_test.go
+++ b/pkg/prom1/storage/metric/goleak_metric_test.go
@@ -1,0 +1,14 @@
+package metric
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/querier/astmapper/goleak_astmapper_test.go
+++ b/pkg/querier/astmapper/goleak_astmapper_test.go
@@ -1,0 +1,14 @@
+package astmapper
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/querier/batch/goleak_batch_test.go
+++ b/pkg/querier/batch/goleak_batch_test.go
@@ -1,0 +1,14 @@
+package batch
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/querier/goleak_querier_test.go
+++ b/pkg/querier/goleak_querier_test.go
@@ -1,0 +1,14 @@
+package querier
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/querier/iterators/goleak_iterators_test.go
+++ b/pkg/querier/iterators/goleak_iterators_test.go
@@ -1,0 +1,14 @@
+package iterators
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/querier/queryrange/goleak_queryrange_test.go
+++ b/pkg/querier/queryrange/goleak_queryrange_test.go
@@ -1,0 +1,14 @@
+package queryrange
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/querier/series/goleak_series_test.go
+++ b/pkg/querier/series/goleak_series_test.go
@@ -1,0 +1,14 @@
+package series
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/querier/tenantfederation/goleak_tenantfederation_test.go
+++ b/pkg/querier/tenantfederation/goleak_tenantfederation_test.go
@@ -1,0 +1,14 @@
+package tenantfederation
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/querier/worker/goleak_worker_test.go
+++ b/pkg/querier/worker/goleak_worker_test.go
@@ -1,0 +1,14 @@
+package worker
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/ring/client/goleak_client_test.go
+++ b/pkg/ring/client/goleak_client_test.go
@@ -1,0 +1,14 @@
+package client
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/ring/goleak_ring_test.go
+++ b/pkg/ring/goleak_ring_test.go
@@ -1,0 +1,14 @@
+package ring
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/ruler/goleak_ruler_test.go
+++ b/pkg/ruler/goleak_ruler_test.go
@@ -1,0 +1,14 @@
+package ruler
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/ruler/rulestore/bucketclient/goleak_bucketclient_test.go
+++ b/pkg/ruler/rulestore/bucketclient/goleak_bucketclient_test.go
@@ -1,0 +1,14 @@
+package bucketclient
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/ruler/rulestore/configdb/goleak_configdb_test.go
+++ b/pkg/ruler/rulestore/configdb/goleak_configdb_test.go
@@ -1,0 +1,14 @@
+package configdb
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/ruler/rulestore/local/goleak_local_test.go
+++ b/pkg/ruler/rulestore/local/goleak_local_test.go
@@ -1,0 +1,14 @@
+package local
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/ruler/rulestore/objectclient/goleak_objectclient_test.go
+++ b/pkg/ruler/rulestore/objectclient/goleak_objectclient_test.go
@@ -1,0 +1,14 @@
+package objectclient
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/scheduler/goleak_scheduler_test.go
+++ b/pkg/scheduler/goleak_scheduler_test.go
@@ -1,0 +1,14 @@
+package scheduler
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/scheduler/queue/goleak_queue_test.go
+++ b/pkg/scheduler/queue/goleak_queue_test.go
@@ -1,0 +1,14 @@
+package queue
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/storage/bucket/goleak_bucket_test.go
+++ b/pkg/storage/bucket/goleak_bucket_test.go
@@ -1,0 +1,14 @@
+package bucket
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/storage/bucket/s3/goleak_s3_test.go
+++ b/pkg/storage/bucket/s3/goleak_s3_test.go
@@ -1,0 +1,14 @@
+package s3
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/storage/tsdb/bucketindex/goleak_bucketindex_test.go
+++ b/pkg/storage/tsdb/bucketindex/goleak_bucketindex_test.go
@@ -1,0 +1,14 @@
+package bucketindex
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/storage/tsdb/goleak_tsdb_test.go
+++ b/pkg/storage/tsdb/goleak_tsdb_test.go
@@ -1,0 +1,14 @@
+package tsdb
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/storegateway/goleak_storegateway_test.go
+++ b/pkg/storegateway/goleak_storegateway_test.go
@@ -1,0 +1,14 @@
+package storegateway
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/tenant/goleak_tenant_test.go
+++ b/pkg/tenant/goleak_tenant_test.go
@@ -1,0 +1,14 @@
+package tenant
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/testexporter/correctness/goleak_correctness_test.go
+++ b/pkg/testexporter/correctness/goleak_correctness_test.go
@@ -1,0 +1,14 @@
+package correctness
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/util/extract/goleak_extract_test.go
+++ b/pkg/util/extract/goleak_extract_test.go
@@ -1,0 +1,14 @@
+package extract
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/util/goleak_util_test.go
+++ b/pkg/util/goleak_util_test.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/util/limiter/goleak_limiter_test.go
+++ b/pkg/util/limiter/goleak_limiter_test.go
@@ -1,0 +1,14 @@
+package limiter
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/util/process/goleak_process_test.go
+++ b/pkg/util/process/goleak_process_test.go
@@ -1,0 +1,14 @@
+package process
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/util/push/goleak_push_test.go
+++ b/pkg/util/push/goleak_push_test.go
@@ -1,0 +1,14 @@
+package push
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/util/spanlogger/goleak_spanlogger_test.go
+++ b/pkg/util/spanlogger/goleak_spanlogger_test.go
@@ -1,0 +1,14 @@
+package spanlogger
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/pkg/util/validation/goleak_validation_test.go
+++ b/pkg/util/validation/goleak_validation_test.go
@@ -1,0 +1,14 @@
+package validation
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/tools/blocksconvert/builder/goleak_builder_test.go
+++ b/tools/blocksconvert/builder/goleak_builder_test.go
@@ -1,0 +1,14 @@
+package builder
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/tools/blocksconvert/goleak_blocksconvert_test.go
+++ b/tools/blocksconvert/goleak_blocksconvert_test.go
@@ -1,0 +1,14 @@
+package blocksconvert
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/tools/blocksconvert/scanner/goleak_scanner_test.go
+++ b/tools/blocksconvert/scanner/goleak_scanner_test.go
@@ -1,0 +1,14 @@
+package scanner
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/tools/blocksconvert/scheduler/goleak_scheduler_test.go
+++ b/tools/blocksconvert/scheduler/goleak_scheduler_test.go
@@ -1,0 +1,14 @@
+package scheduler
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/tools/doc-generator/goleak_main_test.go
+++ b/tools/doc-generator/goleak_main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/tools/querytee/goleak_querytee_test.go
+++ b/tools/querytee/goleak_querytee_test.go
@@ -1,0 +1,14 @@
+package querytee
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}

--- a/tools/thanosconvert/goleak_thanosconvert_test.go
+++ b/tools/thanosconvert/goleak_thanosconvert_test.go
@@ -1,0 +1,14 @@
+package thanosconvert
+
+import (
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("CORTEX_TEST_GOLEAK") == "1" {
+		goleak.VerifyTestMain(m)
+	}
+}


### PR DESCRIPTION
…unit tests.

Based on @stevesg 's suggestion I've created a pull request to integrate goleak.VerifyTestMain() into every test. Bu I made this optional. This let us test for unit tests only if desired and it won't break any other "normal" unit tests.

First I tried to make the optional run of goleak.VerifyTestMain() selectable by a command line switch or a flag. This was all a bit confusing and may break some future extensions. So I decided to make is selectable by an environment variable called CORTEX_TEST_GOLEAK. If that variable has been set to 1 goleak.VerifyTestMain() will run while testing. If it hasn't been set it won't run and all will work as before.

**What this PR does**:
It adds goleak.VerifyTest() to all unit tests. It is optional to enable.

**Which issue(s) this PR fixes**:
Preparation to fix "Unit tests leak goroutines" #3962
