### PR TITLE
docs: reconcile service list with `cortex -modules`

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,10 +73,14 @@ The Cortex services are:
 - [Distributor](#distributor)
 - [Ingester](#ingester)
 - [Querier](#querier)
-- [Query frontend](#query-frontend) (optional)
-- [Ruler](#ruler) (optional)
+- [Compactor](./blocks-storage/compactor.md) (required for blocks storage)
+- [Store gateway](./blocks-storage/store-gateway.md) (required for blocks storage)
 - [Alertmanager](#alertmanager) (optional)
 - [Configs API](#configs-api) (optional)
+- [Overrides exporter](./guides/overrides-exporter.md) (optional)
+- [Query frontend](#query-frontend) (optional)
+- [Query scheduler](./operations/scalable-query-frontend.md#query-scheduler) (optional)
+- [Ruler](#ruler) (optional)
 
 ### Distributor
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Docs-only update to reconcile the list of services in architecture.md with the output of `cortex -modules`. Sorry if I missed this elsewhere, but I hadn't seen a list of all cortex services in one place in the docs.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
