### PR TITLE
Support Redis dns discovery

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4353,6 +4353,15 @@ The `redis_config` configures the Redis backend cache. The supported CLI flags `
 # CLI flag: -<prefix>.redis.master-name
 [master_name: <string> | default = ""]
 
+# SRV service used to discover redis servers.
+# CLI flag: -<prefix>.redis.service
+[service: <string> | default = "redis"]
+
+# Comma separated addresses list in DNS Service Discovery format:
+# https://cortexmetrics.io/docs/configuration/arguments/#dns-service-discovery
+# CLI flag: -<prefix>.redis.addresses
+[addresses: <string> | default = ""]
+
 # Maximum time to wait before giving up on redis requests.
 # CLI flag: -<prefix>.redis.timeout
 [timeout: <duration> | default = 500ms]

--- a/pkg/chunk/cache/cache.go
+++ b/pkg/chunk/cache/cache.go
@@ -99,7 +99,11 @@ func New(cfg Config, reg prometheus.Registerer, logger log.Logger) (Cache, error
 			cfg.Redis.Expiration = cfg.DefaultValidity
 		}
 		cacheName := cfg.Prefix + "redis"
-		cache := NewRedisCache(cacheName, NewRedisClient(&cfg.Redis), reg, logger)
+		client, err := NewRedisClient(&cfg.Redis, logger)
+		if err != nil {
+			return nil, err
+		}
+		cache := NewRedisCache(cacheName, client, reg, logger)
 		caches = append(caches, NewBackground(cacheName, cfg.Background, Instrument(cacheName, cache, reg), reg))
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
The go-redis options requires multiple redis addresses for a cluster.
In some scenarios like AWS ElastiCache, a single configuration endpoint is used to resolve all cluster nodes.
    
This change adds experimental support for redis dns discovery.
This is a similar implementation to memcached ds but with just a resolver.


Signed-off-by: Siavash Safi <siavash.safi@gmail.com>

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
