### PR TITLE
Add length and limit to error messages when label names and values are too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [ENHANCEMENT] Query Frontend: Add setting `-frontend.forward-headers-list` in frontend  to configure the set of headers from the requests to be forwarded to downstream requests. #4486
 * [ENHANCEMENT] Blocks storage: Add `-blocks-storage.azure.http.*`, `-alertmanager-storage.azure.http.*`, and `-ruler-storage.azure.http.*` to configure the Azure storage client. #4581
 * [ENHANCEMENT] Optimise memberlist receive path when used as a backing store for rings with a large number of members. #4601
+* [ENHANCEMENT] Add length and limit to labelNameTooLongError and labelValueTooLongError #4595
 * [BUGFIX] AlertManager: remove stale template files. #4495
 * [BUGFIX] Distributor: fix bug in query-exemplar where some results would get dropped. #4582
 * [BUGFIX] Update Thanos dependency: compactor tracing support, azure blocks storage memory fix. #4585

--- a/pkg/util/validation/errors.go
+++ b/pkg/util/validation/errors.go
@@ -27,29 +27,43 @@ func (e *genericValidationError) Error() string {
 	return fmt.Sprintf(e.message, e.cause, formatLabelSet(e.series))
 }
 
-func newLabelNameTooLongError(series []cortexpb.LabelAdapter, labelName string) ValidationError {
-	return &genericValidationError{
-		message: "label name too long: %.200q metric %.200q",
-		cause:   labelName,
-		series:  series,
+// labelNameTooLongError is a customized ValidationError, in that the cause and the series are
+// formatted in different order in Error.
+type labelNameTooLongError struct {
+	labelName string
+	series    []cortexpb.LabelAdapter
+	limit     int
+}
+
+func (e *labelNameTooLongError) Error() string {
+	return fmt.Sprintf("label name too long for metric (actual: %d, limit: %d) metric: %.200q label name: %.200q", len(e.labelName), e.limit, formatLabelSet(e.series), e.labelName)
+}
+
+func newLabelNameTooLongError(series []cortexpb.LabelAdapter, labelName string, limit int) ValidationError {
+	return &labelNameTooLongError{
+		labelName: labelName,
+		series:    series,
+		limit:     limit,
 	}
 }
 
 // labelValueTooLongError is a customized ValidationError, in that the cause and the series are
-// are formatted in different order in Error.
+// formatted in different order in Error.
 type labelValueTooLongError struct {
 	labelValue string
 	series     []cortexpb.LabelAdapter
+	limit      int
 }
 
 func (e *labelValueTooLongError) Error() string {
-	return fmt.Sprintf("label value too long for metric: %.200q label value: %.200q", formatLabelSet(e.series), e.labelValue)
+	return fmt.Sprintf("label value too long for metric (actual: %d, limit: %d) metric: %.200q label value: %.200q", len(e.labelValue), e.limit, formatLabelSet(e.series), e.labelValue)
 }
 
-func newLabelValueTooLongError(series []cortexpb.LabelAdapter, labelValue string) ValidationError {
+func newLabelValueTooLongError(series []cortexpb.LabelAdapter, labelValue string, limit int) ValidationError {
 	return &labelValueTooLongError{
 		labelValue: labelValue,
 		series:     series,
+		limit:      limit,
 	}
 }
 

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -201,10 +201,10 @@ func ValidateLabels(cfg LabelValidationConfig, userID string, ls []cortexpb.Labe
 			return newInvalidLabelError(ls, l.Name)
 		} else if len(l.Name) > maxLabelNameLength {
 			DiscardedSamples.WithLabelValues(labelNameTooLong, userID).Inc()
-			return newLabelNameTooLongError(ls, l.Name)
+			return newLabelNameTooLongError(ls, l.Name, maxLabelNameLength)
 		} else if len(l.Value) > maxLabelValueLength {
 			DiscardedSamples.WithLabelValues(labelValueTooLong, userID).Inc()
-			return newLabelValueTooLongError(ls, l.Value)
+			return newLabelValueTooLongError(ls, l.Value, maxLabelValueLength)
 		} else if cmp := strings.Compare(lastLabelName, l.Name); cmp >= 0 {
 			if cmp == 0 {
 				DiscardedSamples.WithLabelValues(duplicateLabelNames, userID).Inc()

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -95,7 +95,7 @@ func TestValidateLabels(t *testing.T) {
 			newLabelNameTooLongError([]cortexpb.LabelAdapter{
 				{Name: model.MetricNameLabel, Value: "badLabelName"},
 				{Name: "this_is_a_really_really_long_name_that_should_cause_an_error", Value: "test_value_please_ignore"},
-			}, "this_is_a_really_really_long_name_that_should_cause_an_error"),
+			}, "this_is_a_really_really_long_name_that_should_cause_an_error", cfg.maxLabelNameLength),
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "badLabelValue", "much_shorter_name": "test_value_please_ignore_no_really_nothing_to_see_here"},
@@ -103,7 +103,7 @@ func TestValidateLabels(t *testing.T) {
 			newLabelValueTooLongError([]cortexpb.LabelAdapter{
 				{Name: model.MetricNameLabel, Value: "badLabelValue"},
 				{Name: "much_shorter_name", Value: "test_value_please_ignore_no_really_nothing_to_see_here"},
-			}, "test_value_please_ignore_no_really_nothing_to_see_here"),
+			}, "test_value_please_ignore_no_really_nothing_to_see_here", cfg.maxLabelValueLength),
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "foo", "bar": "baz", "blip": "blop"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR adds length and limit to labelNameTooLongError and labelValueTooLongError, so it will be easier to know what values should be set.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
