### PR TITLE
docs: Fix broken link in architecture page

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ Cortex consists of multiple horizontally scalable microservices. Each microservi
 
 ## The role of Prometheus
 
-Prometheus instances scrape samples from various targets and then push them to Cortex (using Prometheus' [remote write API](https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations)). That remote write API emits batched [Snappy](https://google.github.io/snappy/)-compressed [Protocol Buffer](https://developers.google.com/protocol-buffers/) messages inside the body of an HTTP `PUT` request.
+Prometheus instances scrape samples from various targets and then push them to Cortex (using Prometheus' [remote write API](https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations)). That remote write API emits batched [Snappy](https://github.com/google/snappy)-compressed [Protocol Buffer](https://developers.google.com/protocol-buffers/) messages inside the body of an HTTP `PUT` request.
 
 Cortex requires that each HTTP request bear a header specifying a tenant ID for the request. Request authentication and authorization are handled by an external reverse proxy.
 


### PR DESCRIPTION
**What this PR does**:
This PR fixes a broken link in the `architecture` page of the docs.

**Which issue(s) this PR fixes**:
Fixes # 
NA

**Checklist**
- [ ] Tests updated - NA
- [ ] Documentation added - NA
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

A couple of questions:
- Would you prefer https://opensource.google/projects/snappy as the hyperlink instead?
- Do I need to add to the CHANGELOG for a documentation fix? (sorry, I couldn't find anything on the `Contributing` page, maybe I missed something?)