### PR TITLE
update defaultReplicationStrategy to not fail with extend-write when a single instance is unhealthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@
 * [BUGFIX] Set appropriate `Content-Type` header for /services endpoint, which previously hard-coded `text/plain`. #4596
 * [BUGFIX] Querier: Disable query scheduler SRV DNS lookup, which removes noisy log messages about "failed DNS SRV record lookup". #4601
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #4601
-* [BUGIX] Query Frontend: If 'LogQueriesLongerThan' is set to < 0, log all queries as described in the docs. #4633
+* [BUGFIX] Query Frontend: If 'LogQueriesLongerThan' is set to < 0, log all queries as described in the docs. #4633
+* [BUGFIX] Distributor: update defaultReplicationStrategy to not fail with extend-write when a single instance is unhealthy. #4636
 
 ## 1.11.0 2021-11-25
 

--- a/pkg/ring/replication_strategy_test.go
+++ b/pkg/ring/replication_strategy_test.go
@@ -68,14 +68,14 @@ func TestRingReplicationStrategy(t *testing.T) {
 			replicationFactor:  3,
 			liveIngesters:      3,
 			deadIngesters:      1,
-			expectedMaxFailure: 0,
+			expectedMaxFailure: 1,
 		},
 
 		{
-			replicationFactor: 3,
-			liveIngesters:     2,
-			deadIngesters:     2,
-			expectedError:     "at least 3 live replicas required, could only find 2 - unhealthy instances: dead1,dead2",
+			replicationFactor:  3,
+			liveIngesters:      2,
+			deadIngesters:      2,
+			expectedMaxFailure: 0,
 		},
 	} {
 		ingesters := []InstanceDesc{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Instead of calculating replication factor in the beginning, calculate it after unhealthy instances have been filtered out. This avoid failure where we have a replication factor of 3, and we have a single unhealthy ingester.

**Which issue(s) this PR fixes**:
Fixes #4626

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
