### PR TITLE
distributor: optionally auto-forget unhealthy instances

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -597,6 +597,11 @@ instance_limits:
   # unlimited.
   # CLI flag: -distributor.instance-limits.max-inflight-push-requests
   [max_inflight_push_requests: <int> | default = 0]
+
+# Enable to remove unhealthy distributors from the ring after
+# `ring.kvstore.heartbeat_timeout`
+# CLI flag: -distributor.autoforget-unhealthy
+[autoforget_unhealthy: <boolean> | default = false]
 ```
 
 ### `ingester_config`


### PR DESCRIPTION
Implementation adapted from https://github.com/grafana/loki/pull/3919.

Note: #1521 is about ingesters, but @alanprot suggested using this approach for distributors as well, so I thought I would start there. I'm submitting this as a draft for feedback. I'll figure out testing if the maintainers think this makes sense.

Related to #1521.

Signed-off-by: Josh Carp <jm.carp@gmail.com>

**What this PR does**:

**Which issue(s) this PR fixes**:
Partly fixes #1521.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
