### PR TITLE
Add fallback config capability for local store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [BUGFIX] Querier: Disable query scheduler SRV DNS lookup, which removes noisy log messages about "failed DNS SRV record lookup". #4601
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #4601
 * [BUGIX] Query Frontend: If 'LogQueriesLongerThan' is set to < 0, log all queries as described in the docs. #4633
+* [ENHACEMENT] Alertmanager: If `fallback_config_file` is set, alertmanager will now attempt to use the fallback config for the tenant rather than returning an error message without trying. #4646
 
 ## 1.11.0 2021-11-25
 


### PR DESCRIPTION
Signed-off-by: Akash Sirimanna <asirimanna@tesla.com>

**What this PR does**:
Currently, alertmanager's fallback configuration capability for uninitialized tenants does not work on the `local` storage type. Despite much of the API not being implemented due to some local filesystems being read only, I thought I might take a crack at having this capability added for the local store as it would be very useful.

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
