### PR TITLE
Avoid leaking secrets on /config HTTP API endpoint

### DIFF
--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -195,7 +195,7 @@ func TestAlertmanagerClustering(t *testing.T) {
 				Insecure:         true,
 				BucketNames:      alertsBucketName,
 				AccessKeyID:      e2edb.MinioAccessKey,
-				SecretAccessKey:  e2edb.MinioSecretKey,
+				SecretAccessKey:  flagext.Secret{Value: e2edb.MinioSecretKey},
 			})
 			require.NoError(t, err)
 
@@ -261,7 +261,7 @@ func TestAlertmanagerSharding(t *testing.T) {
 				Insecure:         true,
 				BucketNames:      alertsBucketName,
 				AccessKeyID:      e2edb.MinioAccessKey,
-				SecretAccessKey:  e2edb.MinioSecretKey,
+				SecretAccessKey:  flagext.Secret{Value: e2edb.MinioSecretKey},
 			})
 			require.NoError(t, err)
 
@@ -624,7 +624,7 @@ func TestAlertmanagerShardingScaling(t *testing.T) {
 				Insecure:         true,
 				BucketNames:      alertsBucketName,
 				AccessKeyID:      e2edb.MinioAccessKey,
-				SecretAccessKey:  e2edb.MinioSecretKey,
+				SecretAccessKey:  flagext.Secret{Value: e2edb.MinioSecretKey},
 			})
 			require.NoError(t, err)
 

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cortexproject/cortex/integration/e2ecortex"
 	"github.com/cortexproject/cortex/pkg/alertmanager/alertspb"
 	s3 "github.com/cortexproject/cortex/pkg/chunk/aws"
+	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
 
 const simpleAlertmanagerConfig = `route:

--- a/integration/s3_storage_client_test.go
+++ b/integration/s3_storage_client_test.go
@@ -46,7 +46,7 @@ func TestS3Client(t *testing.T) {
 				S3ForcePathStyle: true,
 				Insecure:         true,
 				AccessKeyID:      e2edb.MinioAccessKey,
-				SecretAccessKey:  e2edb.MinioSecretKey,
+				SecretAccessKey:  flagext.Secret{Value: e2edb.MinioSecretKey},
 			},
 		},
 		{
@@ -79,7 +79,7 @@ func TestS3Client(t *testing.T) {
 				S3ForcePathStyle: true,
 				Insecure:         true,
 				AccessKeyID:      e2edb.MinioAccessKey,
-				SecretAccessKey:  e2edb.MinioSecretKey,
+				SecretAccessKey:  flagext.Secret{Value: e2edb.MinioSecretKey},
 				SSEEncryption:    true,
 			},
 		},

--- a/integration/s3_storage_client_test.go
+++ b/integration/s3_storage_client_test.go
@@ -68,7 +68,7 @@ func TestS3Client(t *testing.T) {
 				BucketNames:      bucketName,
 				S3ForcePathStyle: true,
 				AccessKeyID:      e2edb.MinioAccessKey,
-				SecretAccessKey:  e2edb.MinioSecretKey,
+				SecretAccessKey:  flagext.Secret{Value: e2edb.MinioSecretKey},
 			},
 		},
 		{
@@ -91,7 +91,7 @@ func TestS3Client(t *testing.T) {
 				S3ForcePathStyle: true,
 				Insecure:         true,
 				AccessKeyID:      e2edb.MinioAccessKey,
-				SecretAccessKey:  e2edb.MinioSecretKey,
+				SecretAccessKey:  flagext.Secret{Value: e2edb.MinioSecretKey},
 				SSEConfig: cortex_s3.SSEConfig{
 					Type: "SSE-S3",
 				},

--- a/pkg/chunk/aws/s3_storage_client.go
+++ b/pkg/chunk/aws/s3_storage_client.go
@@ -68,7 +68,7 @@ type S3Config struct {
 	Endpoint         string              `yaml:"endpoint"`
 	Region           string              `yaml:"region"`
 	AccessKeyID      string              `yaml:"access_key_id"`
-	SecretAccessKey  string              `yaml:"secret_access_key"`
+	SecretAccessKey  flagext.Secret      `yaml:"secret_access_key"`
 	Insecure         bool                `yaml:"insecure"`
 	SSEEncryption    bool                `yaml:"sse_encryption"`
 	HTTPConfig       HTTPConfig          `yaml:"http_config"`
@@ -100,7 +100,7 @@ func (cfg *S3Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.Endpoint, prefix+"s3.endpoint", "", "S3 Endpoint to connect to.")
 	f.StringVar(&cfg.Region, prefix+"s3.region", "", "AWS region to use.")
 	f.StringVar(&cfg.AccessKeyID, prefix+"s3.access-key-id", "", "AWS Access Key ID")
-	f.StringVar(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "", "AWS Secret Access Key")
+	f.Var(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "AWS Secret Access Key")
 	f.BoolVar(&cfg.Insecure, prefix+"s3.insecure", false, "Disable https on s3 connection.")
 
 	// TODO Remove in Cortex 1.10.0
@@ -226,13 +226,13 @@ func buildS3Config(cfg S3Config) (*aws.Config, []string, error) {
 		s3Config = s3Config.WithRegion(cfg.Region)
 	}
 
-	if cfg.AccessKeyID != "" && cfg.SecretAccessKey == "" ||
-		cfg.AccessKeyID == "" && cfg.SecretAccessKey != "" {
+	if cfg.AccessKeyID != "" && cfg.SecretAccessKey.Value == "" ||
+		cfg.AccessKeyID == "" && cfg.SecretAccessKey.Value != "" {
 		return nil, nil, errors.New("must supply both an Access Key ID and Secret Access Key or neither")
 	}
 
-	if cfg.AccessKeyID != "" && cfg.SecretAccessKey != "" {
-		creds := credentials.NewStaticCredentials(cfg.AccessKeyID, cfg.SecretAccessKey, "")
+	if cfg.AccessKeyID != "" && cfg.SecretAccessKey.Value != "" {
+		creds := credentials.NewStaticCredentials(cfg.AccessKeyID, cfg.SecretAccessKey.Value, "")
 		s3Config = s3Config.WithCredentials(creds)
 	}
 

--- a/pkg/chunk/aws/s3_storage_client_test.go
+++ b/pkg/chunk/aws/s3_storage_client_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
 
 type RoundTripperFunc func(*http.Request) (*http.Response, error)
@@ -31,7 +33,7 @@ func TestRequestMiddleware(t *testing.T) {
 		S3ForcePathStyle: true,
 		Insecure:         true,
 		AccessKeyID:      "key",
-		SecretAccessKey:  "secret",
+		SecretAccessKey:  flagext.Secret{Value: "secret"},
 	}
 
 	tests := []struct {


### PR DESCRIPTION
**What this PR does**:
Remove consul ACLToken and S3 secret_access_key (chunk storage) from output of /config endpoint