### PR TITLE
[1.12 branch] Update Go to 1.17.8

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Upgrade golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.17.8
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install Docker Client

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.5-buster
+FROM golang:1.17.8-buster
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl python-requests python-yaml file jq unzip protobuf-compiler libprotobuf-dev && \


### PR DESCRIPTION
**What this PR does**:
Pulls in:
go1.17.6 (released 2022-01-06) includes fixes to the compiler, linker,
  runtime, and the crypto/x509, net/http, and reflect packages.
[details](https://github.com/golang/go/issues?q=milestone%3AGo1.17.6+label%3ACherryPickApproved)

go1.17.7 (released 2022-02-10) includes security fixes to the
  crypto/elliptic, math/big packages and to the go command, as well as
  bug fixes to the compiler, linker, runtime, the go command, and the
  debug/macho, debug/pe, and net/http/httptest packages.
[details](https://github.com/golang/go/issues?q=milestone%3AGo1.17.7+label%3ACherryPickApproved)

go1.17.8 (released 2022-03-03) includes a security fix to the
  regexp/syntax package, as well as bug fixes to the compiler, runtime,
  the go command, and the crypto/x509, and net packages.
[details](https://github.com/golang/go/issues?q=milestone%3AGo1.17.8+label%3ACherryPickApproved)

**Checklist**
- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
