### PR TITLE
ingester: add max active series per user metric.

### DIFF
--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -710,6 +710,7 @@ func (i *Ingester) v2UpdateActiveSeries() {
 
 		userDB.activeSeries.Purge(purgeTime)
 		i.metrics.activeSeriesPerUser.WithLabelValues(userID).Set(float64(userDB.activeSeries.Active()))
+		i.metrics.maxActiveSeriesPerUser.WithLabelValues(userID).Set(float64(userDB.limiter.maxSeriesPerUser(userID)))
 	}
 }
 

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -57,7 +57,8 @@ type ingesterMetrics struct {
 	droppedChunks                 prometheus.Counter
 	oldestUnflushedChunkTimestamp prometheus.Gauge
 
-	activeSeriesPerUser *prometheus.GaugeVec
+	activeSeriesPerUser    *prometheus.GaugeVec
+	maxActiveSeriesPerUser *prometheus.GaugeVec
 
 	// Global limit metrics
 	maxUsersGauge           prometheus.GaugeFunc
@@ -292,10 +293,16 @@ func newIngesterMetrics(r prometheus.Registerer, createMetricsConflictingWithTSD
 			Name: "cortex_ingester_active_series",
 			Help: "Number of currently active series per user.",
 		}, []string{"user"}),
+
+		maxActiveSeriesPerUser: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_ingester_max_active_series",
+			Help: "Maximum number of active series per user.",
+		}, []string{"user"}),
 	}
 
 	if activeSeriesEnabled && r != nil {
 		r.MustRegister(m.activeSeriesPerUser)
+		r.MustRegister(m.maxActiveSeriesPerUser)
 	}
 
 	if createMetricsConflictingWithTSDB {

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -58,6 +58,7 @@ type userState struct {
 	discardedSamples      *prometheus.CounterVec
 	createdChunks         prometheus.Counter
 	activeSeriesGauge     prometheus.Gauge
+	maxActiveSeriesGauge  prometheus.Gauge
 }
 
 // DiscardedSamples metric labels
@@ -155,8 +156,9 @@ func (us *userStates) getOrCreate(userID string) *userState {
 			discardedSamples:      validation.DiscardedSamples.MustCurryWith(prometheus.Labels{"user": userID}),
 			createdChunks:         us.metrics.createdChunks,
 
-			activeSeries:      NewActiveSeries(),
-			activeSeriesGauge: us.metrics.activeSeriesPerUser.WithLabelValues(userID),
+			activeSeries:         NewActiveSeries(),
+			activeSeriesGauge:    us.metrics.activeSeriesPerUser.WithLabelValues(userID),
+			maxActiveSeriesGauge: us.metrics.maxActiveSeriesPerUser.WithLabelValues(userID),
 		}
 		state.mapper = newFPMapper(state.fpToSeries, logger)
 		stored, ok := us.states.LoadOrStore(userID, state)


### PR DESCRIPTION
Max active series per user depends on default and per-tenant limits, as
well as distributor sharding strategy and number of healthy ingesters.
To simplify alerting when a tenant is approaching this limit, add a
`cortex_ingester_max_active_series` metric that is updated when the
existing `cortex_ingester_active_series` changes.

Note: sorry if I'm missing something, but I didn't see an existing metric that I could use to alert on tenants approaching the max active series limit in a straightforward way. Let me know if this makes sense!

Signed-off-by: Josh Carp <jm.carp@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
