### PR TITLE
[Release 1.11] Update to Go v1.16.15

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f
+      image: quay.io/cortexproject/build-image:release-1.11-go-1-16-15-ebfea1212
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f
+      image: quay.io/cortexproject/build-image:release-1.11-go-1-16-15-ebfea1212
     services:
       cassandra:
         image: cassandra:3.11
@@ -55,7 +55,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f
+      image: quay.io/cortexproject/build-image:release-1.11-go-1-16-15-ebfea1212
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -98,8 +98,8 @@ jobs:
       - name: Upgrade golang
         run: |
           cd /tmp
-          wget https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz
-          tar -zxvf go1.16.6.linux-amd64.tar.gz
+          wget https://dl.google.com/go/go1.16.15.linux-amd64.tar.gz
+          tar -zxvf go1.16.15.linux-amd64.tar.gz
           sudo rm -fr /usr/local/go
           sudo mv /tmp/go /usr/local/go
           cd -
@@ -175,14 +175,14 @@ jobs:
         run: |
           touch build-image/.uptodate
           MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations
-          make BUILD_IMAGE=quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f TTY='' configs-integration-test
+          make BUILD_IMAGE=quay.io/cortexproject/build-image:release-1.11-go-1-16-15-ebfea1212 TTY='' configs-integration-test
 
   deploy_website:
     needs: [build, test]
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f
+      image: quay.io/cortexproject/build-image:release-1.11-go-1-16-15-ebfea1212
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -219,7 +219,7 @@ jobs:
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:20210713_update-go-1.16.6-178ab0c4f
+      image: quay.io/cortexproject/build-image:release-1.11-go-1-16-15-ebfea1212
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## master / unreleased
 
 
+## 1.11.1 2022-03-08
+* [ENHANCEMENT] Build with Go 1.16.15 to address CVE-2022-24921 "stack exhaustion via a deeply nested expression" #4663
+
 ## 1.11.0 2021-11-25
 * [BUGFIX] Update go-kit package to fix spurious log messages #4544
 * [CHANGE] Memberlist: Expose default configuration values to the command line options. Note that setting these explicitly to zero will no longer cause the default to be used. If the default is desired, then do set the option. The following are affected: #4276

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ build-image/$(UPTODATE): build-image/*
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER := true
 BUILD_IMAGE ?= $(IMAGE_PREFIX)build-image
-LATEST_BUILD_IMAGE_TAG ?= 20210713_update-go-1.16.6-178ab0c4f
+LATEST_BUILD_IMAGE_TAG ?= release-1.11-go-1-16-15-ebfea1212
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-buster
+FROM golang:1.16.15-buster
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl python-requests python-yaml file jq unzip protobuf-compiler libprotobuf-dev && \


### PR DESCRIPTION
To address https://github.com/advisories/GHSA-6685-ffxp-xm6f "stack exhaustion via a deeply nested expression".

This is for an upcoming patch release v1.11.1.

Note we always recommend that Cortex is run behind an authenticating front-end; if this front-end restricts queries (or all requests) to a moderate length before they reach Cortex then attackers cannot exploit this vulnerability which uses a message of over 2MB.
For example if Nginx is used as a front-end, it limits requests to 1MB by default.

**Checklist**
- NA Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated
