### PR TITLE
Fix broadcast of large messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [FEATURE] Ruler: Add `external_labels` option to tag all alerts with a given set of labels.
 
-## 1.12.0 in pgoress
+## 1.12.0 in progress
 
 * [CHANGE] Changed default for `-ingester.min-ready-duration` from 1 minute to 15 seconds. #4539
 * [CHANGE] query-frontend: Do not print anything in the logs of `query-frontend` if a in-progress query has been canceled (context canceled) to avoid spam. #4562
@@ -29,7 +29,6 @@
 * [BUGFIX] Update Thanos dependency: compactor tracing support, azure blocks storage memory fix. #4585
 * [BUGFIX] Set appropriate `Content-Type` header for /services endpoint, which previously hard-coded `text/plain`. #4596
 * [BUGFIX] Querier: Disable query scheduler SRV DNS lookup, which removes noisy log messages about "failed DNS SRV record lookup". #4601
-* [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #4601
 * [BUGFIX] Query Frontend: If 'LogQueriesLongerThan' is set to < 0, log all queries as described in the docs. #4633
 * [BUGFIX] Distributor: update defaultReplicationStrategy to not fail with extend-write when a single instance is unhealthy. #4636
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [FEATURE] Ruler: Add `external_labels` option to tag all alerts with a given set of labels.
+* [FEATURE] Memberlist: Add `-memberlist.enable-broadcast-of-large-messages` option to enable broadcast of messages with more than 64KB.
 
 ## 1.12.0 in progress
 
@@ -29,6 +30,7 @@
 * [BUGFIX] Update Thanos dependency: compactor tracing support, azure blocks storage memory fix. #4585
 * [BUGFIX] Set appropriate `Content-Type` header for /services endpoint, which previously hard-coded `text/plain`. #4596
 * [BUGFIX] Querier: Disable query scheduler SRV DNS lookup, which removes noisy log messages about "failed DNS SRV record lookup". #4601
+* [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #4601
 * [BUGFIX] Query Frontend: If 'LogQueriesLongerThan' is set to < 0, log all queries as described in the docs. #4633
 * [BUGFIX] Distributor: update defaultReplicationStrategy to not fail with extend-write when a single instance is unhealthy. #4636
 

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -270,6 +270,8 @@ Flags for configuring KV store based on memberlist library:
 - `memberlist.dead-node-reclaim-time`
    How soon can dead's node name be reused by a new node (using different IP). Disabled by default, name reclaim is not allowed until `gossip-to-dead-nodes-time` expires. This can be useful to set to low numbers when reusing node names, eg. in stateful sets.
    If memberlist library detects that new node is trying to reuse the name of previous node, it will log message like this: `Conflicting address for ingester-6. Mine: 10.44.12.251:7946 Theirs: 10.44.12.54:7946 Old state: 2`. Node states are: "alive" = 0, "suspect" = 1 (doesn't respond, will be marked as dead if it doesn't respond), "dead" = 2.
+- `memberlist.enable-broadcast-of-large-messages`
+   Enables the broadcast of messages with more than 64KB. Defaults to false. It can be safely enabled after migration to 1.12.0.
 
 #### Multi KV
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3965,6 +3965,11 @@ The `memberlist_config` configures the Gossip memberlist.
 # CLI flag: -memberlist.message-history-buffer-bytes
 [message_history_buffer_bytes: <int> | default = 0]
 
+# Enable the broadcast of messages with more than 64KB. This can be safely
+# enabled after migration to 1.12.0.
+# CLI flag: -memberlist.enable-broadcast-of-large-messages
+[enable_broadcast_of_large_messages: <boolean> | default = false]
+
 # IP address to listen on for gossip messages. Multiple addresses may be
 # specified. Defaults to 0.0.0.0
 # CLI flag: -memberlist.bind-addr

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3965,11 +3965,6 @@ The `memberlist_config` configures the Gossip memberlist.
 # CLI flag: -memberlist.message-history-buffer-bytes
 [message_history_buffer_bytes: <int> | default = 0]
 
-# Enable the broadcast of messages with more than 64KB. This can be safely
-# enabled after migration to 1.12.0.
-# CLI flag: -memberlist.enable-broadcast-of-large-messages
-[enable_broadcast_of_large_messages: <boolean> | default = false]
-
 # IP address to listen on for gossip messages. Multiple addresses may be
 # specified. Defaults to 0.0.0.0
 # CLI flag: -memberlist.bind-addr
@@ -4013,6 +4008,11 @@ The `memberlist_config` configures the Gossip memberlist.
 # Skip validating server certificate.
 # CLI flag: -memberlist.tls-insecure-skip-verify
 [tls_insecure_skip_verify: <boolean> | default = false]
+
+# Enable the broadcast of messages with more than 64KB. This can be safely
+# enabled after migration to 1.12.0.
+# CLI flag: -memberlist.enable-broadcast-of-large-messages
+[enable_broadcast_of_large_messages: <boolean> | default = false]
 ```
 
 ### `limits_config`

--- a/go.mod
+++ b/go.mod
@@ -98,3 +98,6 @@ replace github.com/thanos-io/thanos v0.22.0 => github.com/thanos-io/thanos v0.19
 // Pin aws-sdk to version prior to go-kit update, to reduce the bulk of change.
 // Un-pin once Cortex 1.11 is released.
 replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.40.37
+
+// Replace memberlist with Grafana's fork which includes some fixes that haven't been merged upstream yet
+replace github.com/hashicorp/memberlist v0.2.4 => github.com/grafana/memberlist v0.2.5-0.20211201083710-c7bc8e9df94b

--- a/go.sum
+++ b/go.sum
@@ -865,6 +865,8 @@ github.com/grafana/dskit v0.0.0-20211021180445-3bd016e9d7f1 h1:Qf+/W3Tup0nO21tgJ
 github.com/grafana/dskit v0.0.0-20211021180445-3bd016e9d7f1/go.mod h1:uPG2nyK4CtgNDmWv7qyzYcdI+S90kHHRWvHnBtEMBXM=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85 h1:xLuzPoOzdfNb/RF/IENCw+oLVdZB4G21VPhkHBgwSHY=
 github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85/go.mod h1:crI9WX6p0IhrqB+DqIUHulRW853PaNFf7o4UprV//3I=
+github.com/grafana/memberlist v0.2.5-0.20211201083710-c7bc8e9df94b h1:UlCBLaqvS4wVYNrMKSfqTBVsed/EOY9dnenhYZMUnrA=
+github.com/grafana/memberlist v0.2.5-0.20211201083710-c7bc8e9df94b/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/go.sum
+++ b/go.sum
@@ -943,8 +943,6 @@ github.com/hashicorp/memberlist v0.1.4/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/memberlist v0.2.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/memberlist v0.2.3/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/hashicorp/memberlist v0.2.4 h1:OOhYzSvFnkFQXm1ysE8RjXTHsqSRDyP4emusC9K7DYg=
-github.com/hashicorp/memberlist v0.2.4/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.0/go.mod h1:YL0HO+FifKOW2u1ke99DGVu1zhcpZzNwrLIqBC7vbYU=
 github.com/hashicorp/serf v0.9.5 h1:EBWvyu9tcRszt3Bxp3KNssBMP1KuHWyO51lz9+786iM=

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -167,7 +167,7 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 	// Scale up instances. These numbers seem enough to reliably reproduce some unwanted
 	// consequences of slow propagation, such as missing tombstones.
 
-	maxCortex := 20
+	maxCortex := 30
 	minCortex := 3
 	instances := make([]*e2ecortex.CortexService, 0)
 
@@ -187,6 +187,7 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 	for _, c := range instances {
 		require.NoError(t, c.WaitSumMetrics(e2e.Equals(float64(maxCortex)), "cortex_ring_members"))
 		require.NoError(t, c.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"))
+		require.NoError(t, c.WaitSumMetrics(e2e.Equals(0), "memberlist_client_received_broadcasts_invalid_total"))
 	}
 
 	// Scale down as fast as possible but cleanly, in order to send out tombstones.

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -117,16 +117,17 @@ func testSingleBinaryEnv(t *testing.T, tlsEnabled bool, flags map[string]string)
 
 func newSingleBinary(name string, servername string, join string, testFlags map[string]string) *e2ecortex.CortexService {
 	flags := map[string]string{
-		"-ingester.final-sleep":              "0s",
-		"-ingester.join-after":               "0s", // join quickly
-		"-ingester.min-ready-duration":       "0s",
-		"-ingester.concurrent-flushes":       "10",
-		"-ingester.max-transfer-retries":     "0", // disable
-		"-ingester.num-tokens":               "512",
-		"-ingester.observe-period":           "5s", // to avoid conflicts in tokens
-		"-ring.store":                        "memberlist",
-		"-memberlist.bind-port":              "8000",
-		"-memberlist.left-ingesters-timeout": "600s", // effectively disable
+		"-ingester.final-sleep":                          "0s",
+		"-ingester.join-after":                           "0s", // join quickly
+		"-ingester.min-ready-duration":                   "0s",
+		"-ingester.concurrent-flushes":                   "10",
+		"-ingester.max-transfer-retries":                 "0", // disable
+		"-ingester.num-tokens":                           "512",
+		"-ingester.observe-period":                       "5s", // to avoid conflicts in tokens
+		"-ring.store":                                    "memberlist",
+		"-memberlist.bind-port":                          "8000",
+		"-memberlist.left-ingesters-timeout":             "600s", // effectively disable
+		"-memberlist.enable-broadcast-of-large-messages": "true",
 	}
 
 	if join != "" {

--- a/pkg/ring/kv/memberlist/memberlist_client.go
+++ b/pkg/ring/kv/memberlist/memberlist_client.go
@@ -195,7 +195,7 @@ func (cfg *KVConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.EnableCompression, prefix+"memberlist.compression-enabled", mlDefaults.EnableCompression, "Enable message compression. This can be used to reduce bandwidth usage at the cost of slightly more CPU utilization.")
 	f.StringVar(&cfg.AdvertiseAddr, prefix+"memberlist.advertise-addr", mlDefaults.AdvertiseAddr, "Gossip address to advertise to other members in the cluster. Used for NAT traversal.")
 	f.IntVar(&cfg.AdvertisePort, prefix+"memberlist.advertise-port", mlDefaults.AdvertisePort, "Gossip port to advertise to other members in the cluster. Used for NAT traversal.")
-	f.BoolVar(&cfg.EnableBroadcastOfLargeMessages, prefix+"memberlist.enable-broadcast-of-large-messages", false, "Enable or not the broadcast of messages with more than 64KB.")
+	f.BoolVar(&cfg.EnableBroadcastOfLargeMessages, prefix+"memberlist.enable-broadcast-of-large-messages", false, "Enable the broadcast of messages with more than 64KB. This can be safely enabled after migration to 1.12.0.")
 
 	cfg.TCPTransport.RegisterFlagsWithPrefix(f, prefix)
 }

--- a/vendor/github.com/hashicorp/memberlist/net.go
+++ b/vendor/github.com/hashicorp/memberlist/net.go
@@ -739,11 +739,17 @@ func (m *Memberlist) sendMsg(a Address, msg []byte) error {
 	msgs = append(msgs, msg)
 	msgs = append(msgs, extra...)
 
-	// Create a compound message
-	compound := makeCompoundMessage(msgs)
+	// Create one or more compound messages.
+	compounds := makeCompoundMessages(msgs)
 
-	// Send the message
-	return m.rawSendMsgPacket(a, nil, compound.Bytes())
+	// Send the messages.
+	for _, compound := range compounds {
+		if err := m.rawSendMsgPacket(a, nil, compound.Bytes()); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // rawSendMsgPacket is used to send message via packet to another host without

--- a/vendor/github.com/hashicorp/memberlist/state.go
+++ b/vendor/github.com/hashicorp/memberlist/state.go
@@ -606,10 +606,12 @@ func (m *Memberlist) gossip() {
 				m.logger.Printf("[ERR] memberlist: Failed to send gossip to %s: %s", addr, err)
 			}
 		} else {
-			// Otherwise create and send a compound message
-			compound := makeCompoundMessage(msgs)
-			if err := m.rawSendMsgPacket(node.FullAddress(), &node, compound.Bytes()); err != nil {
-				m.logger.Printf("[ERR] memberlist: Failed to send gossip to %s: %s", addr, err)
+			// Otherwise create and send one or more compound messages
+			compounds := makeCompoundMessages(msgs)
+			for _, compound := range compounds {
+				if err := m.rawSendMsgPacket(node.FullAddress(), &node, compound.Bytes()); err != nil {
+					m.logger.Printf("[ERR] memberlist: Failed to send gossip to %s: %s", addr, err)
+				}
 			}
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -392,7 +392,7 @@ github.com/hashicorp/go-sockaddr
 # github.com/hashicorp/golang-lru v0.5.4
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
-# github.com/hashicorp/memberlist v0.2.4
+# github.com/hashicorp/memberlist v0.2.4 => github.com/grafana/memberlist v0.2.5-0.20211201083710-c7bc8e9df94b
 ## explicit
 github.com/hashicorp/memberlist
 # github.com/hashicorp/serf v0.9.5


### PR DESCRIPTION
**What this PR does**:
Reverting https://github.com/grafana/dskit/pull/85 as pods are failing to unmarshal large messages causing `failed to unmarshal received KV Pair` errors. This can be verified by increasing the number of cortex instances on the `TestSingleBinaryWithMemberlistScaling` integration test.

I tried to update cortex to include https://github.com/grafana/memberlist/pull/1 but the problem persisted.

This also seems to be related to pods getting OOM killed: https://github.com/cortexproject/cortex/issues/4668

**Which issue(s) this PR fixes**:
Fixes #4668 (still need to be confirmed).

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
