### PR TITLE
[main branch] Update Go to 1.17.8 (#4658)

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:master-f0c5aab05
+      image: quay.io/cortexproject/build-image:update-go-1-17-8-6aed4de76
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:master-f0c5aab05
+      image: quay.io/cortexproject/build-image:update-go-1-17-8-6aed4de76
     services:
       cassandra:
         image: cassandra:3.11
@@ -55,7 +55,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:master-f0c5aab05
+      image: quay.io/cortexproject/build-image:update-go-1-17-8-6aed4de76
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -98,7 +98,7 @@ jobs:
       - name: Upgrade golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.17.8
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install Docker Client
@@ -171,14 +171,14 @@ jobs:
         run: |
           touch build-image/.uptodate
           MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations
-          make BUILD_IMAGE=quay.io/cortexproject/build-image:master-f0c5aab05 TTY='' configs-integration-test
+          make BUILD_IMAGE=quay.io/cortexproject/build-image:update-go-1-17-8-6aed4de76 TTY='' configs-integration-test
 
   deploy_website:
     needs: [build, test]
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:master-f0c5aab05
+      image: quay.io/cortexproject/build-image:update-go-1-17-8-6aed4de76
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -215,7 +215,7 @@ jobs:
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:master-f0c5aab05
+      image: quay.io/cortexproject/build-image:update-go-1-17-8-6aed4de76
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * [CHANGE] The `status_code` label on gRPC client metrics has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. 4601
 * [CHANGE] Memberlist: changed probe interval from `1s` to `5s` and probe timeout from `500ms` to `2s`. #4601
 * [FEATURE] Add shuffle sharding grouper and planner within compactor to allow further work towards parallelizing compaction #4624
-* [ENHANCEMENT] Update Go version to 1.17.5. #4602 #4604
+* [ENHANCEMENT] Update Go version to 1.17.8. #4602 #4604 #4658
 * [ENHANCEMENT] Keep track of discarded samples due to bad relabel configuration in `cortex_discarded_samples_total`. #4503
 * [ENHANCEMENT] Ruler: Add `-ruler.disable-rule-group-label` to disable the `rule_group` label on exported metrics. #4571
 * [ENHANCEMENT] Query federation: improve performance in MergeQueryable by memoizing labels. #4502

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ build-image/$(UPTODATE): build-image/*
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER := true
 BUILD_IMAGE ?= $(IMAGE_PREFIX)build-image
-LATEST_BUILD_IMAGE_TAG ?= master-f0c5aab05
+LATEST_BUILD_IMAGE_TAG ?= update-go-1-17-8-6aed4de76
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.5-buster
+FROM golang:1.17.8-buster
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl python-requests python-yaml file jq unzip protobuf-compiler libprotobuf-dev && \


### PR DESCRIPTION
* Update Go to 1.17.8

Pulls in:
go1.17.6 (released 2022-01-06) includes fixes to the compiler, linker,
  runtime, and the crypto/x509, net/http, and reflect packages.
[details](https://github.com/golang/go/issues?q=milestone%3AGo1.17.6+label%3ACherryPickApproved)

go1.17.7 (released 2022-02-10) includes security fixes to the
  crypto/elliptic, math/big packages and to the go command, as well as
  bug fixes to the compiler, linker, runtime, the go command, and the
  debug/macho, debug/pe, and net/http/httptest packages.
[details](https://github.com/golang/go/issues?q=milestone%3AGo1.17.7+label%3ACherryPickApproved)

go1.17.8 (released 2022-03-03) includes a security fix to the
  regexp/syntax package, as well as bug fixes to the compiler, runtime,
  the go command, and the crypto/x509, and net packages.
[details](https://github.com/golang/go/issues?q=milestone%3AGo1.17.8+label%3ACherryPickApproved)

Signed-off-by: Bryan Boreham <bjboreham@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
