### PR TITLE
ring: Restart initRing with unexpected token count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [FEATURE] Ruler: Add `external_labels` option to tag all alerts with a given set of labels.
+* [BUGFIX] Ingester: Restart initRing with unexpected token count to ensure configuration is always obeyed. #1876
 
 ## 1.12.0 in pgoress
 


### PR DESCRIPTION
**What this PR does**:

This commit updates the ingester initRing logic so that the number of
tokens per ingester stated in configuration is obeyed. Currently, when
an ingester starts up, it blindly accepts the tokens pulled from the
ring for its ID. Thus the counts between configuration and what is found
in the ring can be different.

**Which issue(s) this PR fixes**:
Fixes #1876.

**Checklist**
- [X] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
