### PR TITLE
Implement max series limit in distributor for `/series` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [FEATURE] Ruler: Add `external_labels` option to tag all alerts with a given set of labels.
 * [CHANGE] Fix incorrectly named `cortex_cache_fetched_keys` and `cortex_cache_hits` metrics. Renamed to `cortex_cache_fetched_keys_total` and `cortex_cache_hits_total` respectively. #4686
 * [CHANGE] Enable Thanos series limiter in store-gateway. #4702
+* [CHANGE] Distributor: Apply `max_fetched_series_per_query` limit for `/series` API. #4683
 
 ## 1.12.0 in progress
 


### PR DESCRIPTION
Signed-off-by: 🌲 Harry 🌊 John 🏔 <johrry@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR enforces the `max_fetched_series_per_query` limit for `/api/v1/series` API.

**Which issue(s) this PR fixes**:
Fixes #4667

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
