### PR TITLE
Fix incorrectly named cache metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [FEATURE] Ruler: Add `external_labels` option to tag all alerts with a given set of labels.
+* [CHANGE] Fix incorrectly named `cortex_cache_fetched_keys` and `cortex_cache_hits` metrics. Renamed to `cortex_cache_fetched_keys_total` and `cortex_cache_hits_total` respectively. #4686
 
 ## 1.12.0 in progress
 

--- a/pkg/chunk/cache/instrumented.go
+++ b/pkg/chunk/cache/instrumented.go
@@ -38,14 +38,14 @@ func Instrument(name string, cache Cache, reg prometheus.Registerer) Cache {
 
 		fetchedKeys: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace:   "cortex",
-			Name:        "cache_fetched_keys",
+			Name:        "cache_fetched_keys_total",
 			Help:        "Total count of keys requested from cache.",
 			ConstLabels: prometheus.Labels{"name": name},
 		}),
 
 		hits: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace:   "cortex",
-			Name:        "cache_hits",
+			Name:        "cache_hits_total",
 			Help:        "Total count of keys found in cache.",
 			ConstLabels: prometheus.Labels{"name": name},
 		}),


### PR DESCRIPTION
Signed-off-by: 🌲 Harry 🌊 John 🏔 <johrry@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
The following query-frontend cache metrics are incorrectly named.
```
# HELP cortex_cache_fetched_keys Total count of keys requested from cache.
# TYPE cortex_cache_fetched_keys counter
cortex_cache_fetched_keys{name="frontend.memcache"} 872
# HELP cortex_cache_hits Total count of keys found in cache.
# TYPE cortex_cache_hits counter
cortex_cache_hits{name="frontend.memcache"} 869
```

These counter metrics are not ending in `total` as per the convention. 

**Which issue(s) this PR fixes**:
Fixes #4685

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
