### PR TITLE
Fix/concurrent map interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [FEATURE] Compactor: Add `-compactor.skip-blocks-with-out-of-order-chunks-enabled` configuration to mark blocks containing index with out-of-order chunks for no compact instead of halting the compaction
 * [FEATURE] Querier/Query-Frontend: Add `-querier.per-step-stats-enabled` and `-frontend.cache-queryable-samples-stats` configurations to enable query sample statistics
 * [FEATURE] Add shuffle sharding for the compactor #4433
+* [BUGFIX] Distributor: Fix race condition on `/series` introduced by #4683.
 
 ## 1.12.0 in progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [FEATURE] Compactor: Add `-compactor.skip-blocks-with-out-of-order-chunks-enabled` configuration to mark blocks containing index with out-of-order chunks for no compact instead of halting the compaction
 * [FEATURE] Querier/Query-Frontend: Add `-querier.per-step-stats-enabled` and `-frontend.cache-queryable-samples-stats` configurations to enable query sample statistics
 * [FEATURE] Add shuffle sharding for the compactor #4433
-* [BUGFIX] Distributor: Fix race condition on `/series` introduced by #4683.
+* [BUGFIX] Distributor: Fix race condition on `/series` introduced by #4683. #4716
 
 ## 1.12.0 in progress
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -981,11 +981,13 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 	}
 
 	result := make([]metric.Metric, 0, len(metrics))
+	mutex.Lock()
 	for _, m := range metrics {
 		result = append(result, metric.Metric{
 			Metric: m,
 		})
 	}
+	mutex.Unlock()
 	return result, nil
 }
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -980,8 +980,8 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 		return nil, err
 	}
 
-	result := make([]metric.Metric, 0, len(metrics))
 	mutex.Lock()
+	result := make([]metric.Metric, 0, len(metrics))
 	for _, m := range metrics {
 		result = append(result, metric.Metric{
 			Metric: m,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1866,7 +1866,8 @@ func TestDistributor_MetricsForLabelMatchers_SingleSlowIngester(t *testing.T) {
 	}
 
 	for i := 0; i < 50; i++ {
-		ds[0].MetricsForLabelMatchers(ctx, now, now, mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test"))
+		_, err := ds[0].MetricsForLabelMatchers(ctx, now, now, mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test"))
+		require.NoError(t, err)
 	}
 }
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1842,7 +1842,6 @@ func TestSlowQueries(t *testing.T) {
 }
 
 func TestDistributor_MetricsForLabelMatchers_SingleSlowIngester(t *testing.T) {
-
 	// Create distributor
 	ds, ing, _, _ := prepare(t, prepConfig{
 		numIngesters:        3,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1841,6 +1841,36 @@ func TestSlowQueries(t *testing.T) {
 	}
 }
 
+func TestDistributor_MetricsForLabelMatchers_SingleSlowIngester(t *testing.T) {
+
+	// Create distributor
+	ds, ing, _, _ := prepare(t, prepConfig{
+		numIngesters:        3,
+		happyIngesters:      3,
+		numDistributors:     1,
+		shardByAllLabels:    true,
+		shuffleShardEnabled: true,
+		shuffleShardSize:    3,
+		replicationFactor:   3,
+	})
+
+	ing[2].queryDelay = 50 * time.Millisecond
+
+	ctx := user.InjectOrgID(context.Background(), "test")
+
+	now := model.Now()
+
+	for i := 0; i < 100; i++ {
+		req := mockWriteRequest([]labels.Labels{{{Name: labels.MetricName, Value: "test"}, {Name: "app", Value: "m"}, {Name: "uniq8", Value: strconv.Itoa(i)}}}, 1, now.Unix())
+		_, err := ds[0].Push(ctx, req)
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < 50; i++ {
+		ds[0].MetricsForLabelMatchers(ctx, now, now, mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test"))
+	}
+}
+
 func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 	const numIngesters = 5
 
@@ -2192,10 +2222,10 @@ type prepConfig struct {
 	errFail                      error
 }
 
-func prepare(tb testing.TB, cfg prepConfig) ([]*Distributor, []mockIngester, []*prometheus.Registry, *ring.Ring) {
-	ingesters := []mockIngester{}
+func prepare(tb testing.TB, cfg prepConfig) ([]*Distributor, []*mockIngester, []*prometheus.Registry, *ring.Ring) {
+	ingesters := []*mockIngester{}
 	for i := 0; i < cfg.happyIngesters; i++ {
-		ingesters = append(ingesters, mockIngester{
+		ingesters = append(ingesters, &mockIngester{
 			happy:      *atomic.NewBool(true),
 			queryDelay: cfg.queryDelay,
 		})
@@ -2206,7 +2236,7 @@ func prepare(tb testing.TB, cfg prepConfig) ([]*Distributor, []mockIngester, []*
 			miError = cfg.errFail
 		}
 
-		ingesters = append(ingesters, mockIngester{
+		ingesters = append(ingesters, &mockIngester{
 			queryDelay: cfg.queryDelay,
 			failResp:   *atomic.NewError(miError),
 		})
@@ -2225,7 +2255,7 @@ func prepare(tb testing.TB, cfg prepConfig) ([]*Distributor, []mockIngester, []*
 			RegisteredTimestamp: time.Now().Add(-2 * time.Hour).Unix(),
 			Tokens:              []uint32{uint32((math.MaxUint32 / cfg.numIngesters) * i)},
 		}
-		ingestersByAddr[addr] = &ingesters[i]
+		ingestersByAddr[addr] = ingesters[i]
 	}
 
 	kvStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
@@ -2637,6 +2667,7 @@ func (i *mockIngester) QueryStream(ctx context.Context, req *client.QueryRequest
 }
 
 func (i *mockIngester) MetricsForLabelMatchers(ctx context.Context, req *client.MetricsForLabelMatchersRequest, opts ...grpc.CallOption) (*client.MetricsForLabelMatchersResponse, error) {
+	time.Sleep(i.queryDelay)
 	i.Lock()
 	defer i.Unlock()
 
@@ -3098,7 +3129,7 @@ func TestDistributor_Push_RelabelDropWillExportMetricOfDroppedSamples(t *testing
 	require.NoError(t, testutil.GatherAndCompare(regs[0], strings.NewReader(expectedMetrics), metrics...))
 }
 
-func countMockIngestersCalls(ingesters []mockIngester, name string) int {
+func countMockIngestersCalls(ingesters []*mockIngester, name string) int {
 	count := 0
 	for i := 0; i < len(ingesters); i++ {
 		if ingesters[i].countCalls(name) > 0 {


### PR DESCRIPTION
**What this PR does**:

Fix race condition on `/series`.

`ForReplicationSet` can still invoke the callback after the quorum has reached and this can cause the `metrics` map to be write and read at the same time.

```
=== RUN   TestDistributor_MetricsForLabelMatchers_SingleSlowIngester
fatal error: concurrent map iteration and map write

goroutine 89 [running]:
runtime.throw({0x1efcf2d, 0x0})
	/usr/local/go/src/runtime/panic.go:1198 +0x71 fp=0xc000a47c28 sp=0xc000a47bf8 pc=0x10383b1
runtime.mapiternext(0xc000a47da0)
	/usr/local/go/src/runtime/map.go:858 +0x4eb fp=0xc000a47c98 sp=0xc000a47c28 pc=0x10112cb
github.com/cortexproject/cortex/pkg/distributor.(*Distributor).MetricsForLabelMatchers(0x0, {0x21c53d8, 0xc0007f13e0}, 0x1ec9e30, 0x4, {0xc000a47ee0, 0x1, 0x1})
	/Users/approtas/workspaces/cortex/pkg/distributor/distributor.go:985 +0x325 fp=0xc000a47e10 sp=0xc000a47c98 pc=0x1bef3e5
github.com/cortexproject/cortex/pkg/distributor.TestDistributor_MetricsForLabelMatchers_SingleSlowIngester(0x1)
	/Users/approtas/workspaces/cortex/pkg/distributor/distributor_test.go:1870 +0x30e fp=0xc000a47f70 sp=0xc000a47e10 pc=0x1c09b8e
testing.tRunner(0xc0001d0d00, 0x1f3d210)
	/usr/local/go/src/testing/testing.go:1259 +0x102 fp=0xc000a47fc0 sp=0xc000a47f70 pc=0x11156c2
```

**Checklist**
- [X] Tests updated
- [ NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
