### PR TITLE
fix leaking notifier in ruler when user is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@
 * [FEATURE] Compactor: Add `-compactor.skip-blocks-with-out-of-order-chunks-enabled` configuration to mark blocks containing index with out-of-order chunks for no compact instead of halting the compaction
 * [FEATURE] Querier/Query-Frontend: Add `-querier.per-step-stats-enabled` and `-frontend.cache-queryable-samples-stats` configurations to enable query sample statistics
 * [FEATURE] Add shuffle sharding for the compactor #4433
+* [BUGFIX] Distributor: Fix race condition on `/series` introduced by #4683. #4716
+* [BUGFIX] Ruler: Fixed leaking notifiers after users are removed #4718
+
+## 1.12.0 in progress
+
+* [CHANGE] Changed default for `-ingester.min-ready-duration` from 1 minute to 15 seconds. #4539
+* [CHANGE] query-frontend: Do not print anything in the logs of `query-frontend` if a in-progress query has been canceled (context canceled) to avoid spam. #4562
+* [CHANGE] Compactor block deletion mark migration, needed when upgrading from v1.7, is now disabled by default. #4597
+* [CHANGE] The `status_code` label on gRPC client metrics has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. 4601
+* [CHANGE] Memberlist: changed probe interval from `1s` to `5s` and probe timeout from `500ms` to `2s`. #4601
 * [ENHANCEMENT] Update Go version to 1.17.8. #4602 #4604 #4658
 * [ENHANCEMENT] Keep track of discarded samples due to bad relabel configuration in `cortex_discarded_samples_total`. #4503
 * [ENHANCEMENT] Ruler: Add `-ruler.disable-rule-group-label` to disable the `rule_group` label on exported metrics. #4571

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,6 @@
 * [FEATURE] Compactor: Add `-compactor.skip-blocks-with-out-of-order-chunks-enabled` configuration to mark blocks containing index with out-of-order chunks for no compact instead of halting the compaction
 * [FEATURE] Querier/Query-Frontend: Add `-querier.per-step-stats-enabled` and `-frontend.cache-queryable-samples-stats` configurations to enable query sample statistics
 * [FEATURE] Add shuffle sharding for the compactor #4433
-* [BUGFIX] Distributor: Fix race condition on `/series` introduced by #4683. #4716
-* [BUGFIX] Ruler: Fixed leaking notifiers after users are removed #4718
-
-## 1.12.0 in progress
-
-* [CHANGE] Changed default for `-ingester.min-ready-duration` from 1 minute to 15 seconds. #4539
-* [CHANGE] query-frontend: Do not print anything in the logs of `query-frontend` if a in-progress query has been canceled (context canceled) to avoid spam. #4562
-* [CHANGE] Compactor block deletion mark migration, needed when upgrading from v1.7, is now disabled by default. #4597
-* [CHANGE] The `status_code` label on gRPC client metrics has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. 4601
-* [CHANGE] Memberlist: changed probe interval from `1s` to `5s` and probe timeout from `500ms` to `2s`. #4601
 * [ENHANCEMENT] Update Go version to 1.17.8. #4602 #4604 #4658
 * [ENHANCEMENT] Keep track of discarded samples due to bad relabel configuration in `cortex_discarded_samples_total`. #4503
 * [ENHANCEMENT] Ruler: Add `-ruler.disable-rule-group-label` to disable the `rule_group` label on exported metrics. #4571
@@ -45,6 +35,7 @@
 * [BUGFIX] Query Frontend: If 'LogQueriesLongerThan' is set to < 0, log all queries as described in the docs. #4633
 * [BUGFIX] Distributor: update defaultReplicationStrategy to not fail with extend-write when a single instance is unhealthy. #4636
 * [BUGFIX] Distributor: Fix race condition on `/series` introduced by #4683. #4716
+* [BUGFIX] Ruler: Fixed leaking notifiers after users are removed #4718
 
 ## 1.11.0 2021-11-25
 

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -164,15 +164,15 @@ func (r *DefaultMultiTenantManager) syncRulesToManager(ctx context.Context, user
 // newManager creates a prometheus rule manager wrapped with a user id
 // configured storage, appendable, notifier, and instrumentation
 func (r *DefaultMultiTenantManager) newManager(ctx context.Context, userID string) (RulesManager, error) {
-	// Create a new Prometheus registry and register it within
-	// our metrics struct for the provided user if it doesn't already exist.
-	reg := prometheus.NewRegistry()
-	r.userManagerMetrics.AddUserRegistry(userID, reg)
-
-	notifier, err := r.getOrCreateNotifier(userID, reg)
+	notifier, err := r.getOrCreateNotifier(userID)
 	if err != nil {
 		return nil, err
 	}
+
+	// Create a new Prometheus registry and register it within
+	// our metrics struct for the provided user.
+	reg := prometheus.NewRegistry()
+	r.userManagerMetrics.AddUserRegistry(userID, reg)
 
 	return r.managerFactory(ctx, userID, notifier, r.logger, reg), nil
 }
@@ -188,7 +188,7 @@ func (r *DefaultMultiTenantManager) removeNotifier(userID string) {
 	delete(r.notifiers, userID)
 }
 
-func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string, userManagerRegistry prometheus.Registerer) (*notifier.Manager, error) {
+func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string) (*notifier.Manager, error) {
 	r.notifiersMtx.Lock()
 	defer r.notifiersMtx.Unlock()
 
@@ -199,7 +199,7 @@ func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string, userManag
 		return n.notifier, nil
 	}
 
-	reg := prometheus.WrapRegistererWith(prometheus.Labels{"user": userID}, userManagerRegistry)
+	reg := prometheus.WrapRegistererWith(prometheus.Labels{"user": userID}, r.registry)
 	reg = prometheus.WrapRegistererWithPrefix("cortex_", reg)
 	n = newRulerNotifier(&notifier.Options{
 		QueueCapacity: r.cfg.NotificationQueueCapacity,

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -177,7 +177,7 @@ func (r *DefaultMultiTenantManager) newManager(ctx context.Context, userID strin
 	return r.managerFactory(ctx, userID, notifier, r.logger, reg), nil
 }
 
-func (r *DefaultMultiTenantManager) removeNotifier(userID string) error {
+func (r *DefaultMultiTenantManager) removeNotifier(userID string) {
 	r.notifiersMtx.Lock()
 	defer r.notifiersMtx.Unlock()
 
@@ -185,7 +185,6 @@ func (r *DefaultMultiTenantManager) removeNotifier(userID string) error {
 		n.stop()
 	}
 	delete(r.notifiers, userID)
-	return nil
 }
 
 func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string) (*notifier.Manager, error) {

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -199,11 +199,9 @@ func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string, userManag
 		return n.notifier, nil
 	}
 
-	reg := prometheus.WrapRegistererWith(prometheus.Labels{"user": userID}, userManagerRegistry)
-	reg = prometheus.WrapRegistererWithPrefix("cortex_", reg)
 	n = newRulerNotifier(&notifier.Options{
 		QueueCapacity: r.cfg.NotificationQueueCapacity,
-		Registerer:    reg,
+		Registerer:    userManagerRegistry,
 		Do: func(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
 			// Note: The passed-in context comes from the Prometheus notifier
 			// and does *not* contain the userID. So it needs to be added to the context

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -164,15 +164,15 @@ func (r *DefaultMultiTenantManager) syncRulesToManager(ctx context.Context, user
 // newManager creates a prometheus rule manager wrapped with a user id
 // configured storage, appendable, notifier, and instrumentation
 func (r *DefaultMultiTenantManager) newManager(ctx context.Context, userID string) (RulesManager, error) {
-	notifier, err := r.getOrCreateNotifier(userID)
+	// Create a new Prometheus registry and register it within
+	// our metrics struct for the provided user if it doesn't already exist.
+	reg := prometheus.NewRegistry()
+	r.userManagerMetrics.AddUserRegistry(userID, reg)
+
+	notifier, err := r.getOrCreateNotifier(userID, reg)
 	if err != nil {
 		return nil, err
 	}
-
-	// Create a new Prometheus registry and register it within
-	// our metrics struct for the provided user.
-	reg := prometheus.NewRegistry()
-	r.userManagerMetrics.AddUserRegistry(userID, reg)
 
 	return r.managerFactory(ctx, userID, notifier, r.logger, reg), nil
 }
@@ -188,7 +188,7 @@ func (r *DefaultMultiTenantManager) removeNotifier(userID string) {
 	delete(r.notifiers, userID)
 }
 
-func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string) (*notifier.Manager, error) {
+func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string, userManagerRegistry prometheus.Registerer) (*notifier.Manager, error) {
 	r.notifiersMtx.Lock()
 	defer r.notifiersMtx.Unlock()
 
@@ -199,7 +199,7 @@ func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string) (*notifie
 		return n.notifier, nil
 	}
 
-	reg := prometheus.WrapRegistererWith(prometheus.Labels{"user": userID}, r.registry)
+	reg := prometheus.WrapRegistererWith(prometheus.Labels{"user": userID}, userManagerRegistry)
 	reg = prometheus.WrapRegistererWithPrefix("cortex_", reg)
 	n = newRulerNotifier(&notifier.Options{
 		QueueCapacity: r.cfg.NotificationQueueCapacity,

--- a/pkg/ruler/manager_metrics.go
+++ b/pkg/ruler/manager_metrics.go
@@ -23,6 +23,14 @@ type ManagerMetrics struct {
 	GroupLastDuration    *prometheus.Desc
 	GroupRules           *prometheus.Desc
 	GroupLastEvalSamples *prometheus.Desc
+
+	NotificationLatency       *prometheus.Desc
+	NotificationErrors        *prometheus.Desc
+	NotificationSent          *prometheus.Desc
+	NotificationDropped       *prometheus.Desc
+	NotificationQueueLength   *prometheus.Desc
+	NotificationQueueCapacity *prometheus.Desc
+	AlertmanagersDiscovered   *prometheus.Desc
 }
 
 // NewManagerMetrics returns a ManagerMetrics struct
@@ -101,6 +109,51 @@ func NewManagerMetrics(disableRuleGroupLabel bool) *ManagerMetrics {
 			commonLabels,
 			nil,
 		),
+
+		// Prometheus' ruler's notification metrics
+		NotificationLatency: prometheus.NewDesc(
+			"q",
+			"Latency quantiles for sending alert notifications.",
+			[]string{"user"},
+			nil,
+		),
+
+		NotificationErrors: prometheus.NewDesc(
+			"cortex_prometheus_notifications_errors_total",
+			"Total number of errors sending alert notifications.",
+			[]string{"user", "alertmanager"},
+			nil,
+		),
+		NotificationSent: prometheus.NewDesc(
+			"cortex_prometheus_notifications_sent_total",
+			"Total number of alerts sent.",
+			[]string{"user", "alertmanager"},
+			nil,
+		),
+		NotificationDropped: prometheus.NewDesc(
+			"cortex_prometheus_notifications_dropped_total",
+			"Total number of alerts dropped due to errors when sending to Alertmanager.",
+			[]string{"user"},
+			nil,
+		),
+		NotificationQueueLength: prometheus.NewDesc(
+			"cortex_prometheus_notifications_queue_length",
+			"The number of alert notifications in the queue.",
+			[]string{"user"},
+			nil,
+		),
+		NotificationQueueCapacity: prometheus.NewDesc(
+			"cortex_prometheus_notifications_queue_capacity",
+			"The capacity of the alert notifications queue.",
+			[]string{"user"},
+			nil,
+		),
+		AlertmanagersDiscovered: prometheus.NewDesc(
+			"cortex_prometheus_notifications_alertmanagers_discovered",
+			"The number of alertmanagers discovered and active.",
+			[]string{"user"},
+			nil,
+		),
 	}
 }
 
@@ -127,6 +180,14 @@ func (m *ManagerMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.GroupLastDuration
 	out <- m.GroupRules
 	out <- m.GroupLastEvalSamples
+
+	out <- m.NotificationLatency
+	out <- m.NotificationErrors
+	out <- m.NotificationSent
+	out <- m.NotificationDropped
+	out <- m.NotificationQueueLength
+	out <- m.NotificationQueueCapacity
+	out <- m.AlertmanagersDiscovered
 }
 
 // Collect implements the Collector interface
@@ -152,4 +213,12 @@ func (m *ManagerMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfGaugesPerUserWithLabels(out, m.GroupLastDuration, "prometheus_rule_group_last_duration_seconds", labels...)
 	data.SendSumOfGaugesPerUserWithLabels(out, m.GroupRules, "prometheus_rule_group_rules", labels...)
 	data.SendSumOfGaugesPerUserWithLabels(out, m.GroupLastEvalSamples, "prometheus_rule_group_last_evaluation_samples", labels...)
+
+	data.SendSumOfSummariesPerUser(out, m.NotificationLatency, "prometheus_notifications_latency_seconds")
+	data.SendSumOfCountersPerUserWithLabels(out, m.NotificationErrors, "prometheus_notifications_errors_total", "alertmanager")
+	data.SendSumOfCountersPerUserWithLabels(out, m.NotificationSent, "prometheus_notifications_sent_total", "alertmanager")
+	data.SendSumOfGaugesPerUser(out, m.NotificationDropped, "prometheus_notifications_dropped_total")
+	data.SendSumOfGaugesPerUser(out, m.NotificationQueueLength, "prometheus_notifications_queue_length")
+	data.SendSumOfGaugesPerUser(out, m.NotificationQueueCapacity, "prometheus_notifications_queue_capacity")
+	data.SendSumOfGaugesPerUser(out, m.AlertmanagersDiscovered, "prometheus_notifications_alertmanagers_discovered")
 }

--- a/pkg/ruler/manager_metrics.go
+++ b/pkg/ruler/manager_metrics.go
@@ -217,7 +217,7 @@ func (m *ManagerMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfSummariesPerUser(out, m.NotificationLatency, "prometheus_notifications_latency_seconds")
 	data.SendSumOfCountersPerUserWithLabels(out, m.NotificationErrors, "prometheus_notifications_errors_total", "alertmanager")
 	data.SendSumOfCountersPerUserWithLabels(out, m.NotificationSent, "prometheus_notifications_sent_total", "alertmanager")
-	data.SendSumOfGaugesPerUser(out, m.NotificationDropped, "prometheus_notifications_dropped_total")
+	data.SendSumOfCountersPerUser(out, m.NotificationDropped, "prometheus_notifications_dropped_total")
 	data.SendSumOfGaugesPerUser(out, m.NotificationQueueLength, "prometheus_notifications_queue_length")
 	data.SendSumOfGaugesPerUser(out, m.NotificationQueueCapacity, "prometheus_notifications_queue_capacity")
 	data.SendSumOfGaugesPerUser(out, m.AlertmanagersDiscovered, "prometheus_notifications_alertmanagers_discovered")

--- a/pkg/ruler/manager_metrics.go
+++ b/pkg/ruler/manager_metrics.go
@@ -112,7 +112,7 @@ func NewManagerMetrics(disableRuleGroupLabel bool) *ManagerMetrics {
 
 		// Prometheus' ruler's notification metrics
 		NotificationLatency: prometheus.NewDesc(
-			"q",
+			"cortex_prometheus_notifications_latency_seconds",
 			"Latency quantiles for sending alert notifications.",
 			[]string{"user"},
 			nil,

--- a/pkg/ruler/manager_metrics_test.go
+++ b/pkg/ruler/manager_metrics_test.go
@@ -34,6 +34,14 @@ cortex_prometheus_last_evaluation_samples{rule_group="group_one",user="user3"} 1
 cortex_prometheus_last_evaluation_samples{rule_group="group_two",user="user1"} 1000
 cortex_prometheus_last_evaluation_samples{rule_group="group_two",user="user2"} 10000
 cortex_prometheus_last_evaluation_samples{rule_group="group_two",user="user3"} 100000
+# HELP cortex_prometheus_notifications_latency_seconds Latency quantiles for sending alert notifications.
+# TYPE cortex_prometheus_notifications_latency_seconds summary
+cortex_prometheus_notifications_latency_seconds_sum{user="user1"} 0
+cortex_prometheus_notifications_latency_seconds_count{user="user1"} 0
+cortex_prometheus_notifications_latency_seconds_sum{user="user2"} 0
+cortex_prometheus_notifications_latency_seconds_count{user="user2"} 0
+cortex_prometheus_notifications_latency_seconds_sum{user="user3"} 0
+cortex_prometheus_notifications_latency_seconds_count{user="user3"} 0
 # HELP cortex_prometheus_rule_evaluation_duration_seconds The duration for a rule to execute.
 # TYPE cortex_prometheus_rule_evaluation_duration_seconds summary
 cortex_prometheus_rule_evaluation_duration_seconds{user="user1",quantile="0.5"} 1
@@ -153,6 +161,14 @@ func TestManagerMetricsWithoutRuleGroupLabel(t *testing.T) {
 cortex_prometheus_last_evaluation_samples{user="user1"} 2000
 cortex_prometheus_last_evaluation_samples{user="user2"} 20000
 cortex_prometheus_last_evaluation_samples{user="user3"} 200000
+# HELP cortex_prometheus_notifications_latency_seconds Latency quantiles for sending alert notifications.
+# TYPE cortex_prometheus_notifications_latency_seconds summary
+cortex_prometheus_notifications_latency_seconds_sum{user="user1"} 0
+cortex_prometheus_notifications_latency_seconds_count{user="user1"} 0
+cortex_prometheus_notifications_latency_seconds_sum{user="user2"} 0
+cortex_prometheus_notifications_latency_seconds_count{user="user2"} 0
+cortex_prometheus_notifications_latency_seconds_sum{user="user3"} 0
+cortex_prometheus_notifications_latency_seconds_count{user="user3"} 0
 # HELP cortex_prometheus_rule_evaluation_duration_seconds The duration for a rule to execute.
 # TYPE cortex_prometheus_rule_evaluation_duration_seconds summary
 cortex_prometheus_rule_evaluation_duration_seconds{user="user1",quantile="0.5"} 1

--- a/pkg/ruler/manager_metrics_test.go
+++ b/pkg/ruler/manager_metrics_test.go
@@ -34,14 +34,53 @@ cortex_prometheus_last_evaluation_samples{rule_group="group_one",user="user3"} 1
 cortex_prometheus_last_evaluation_samples{rule_group="group_two",user="user1"} 1000
 cortex_prometheus_last_evaluation_samples{rule_group="group_two",user="user2"} 10000
 cortex_prometheus_last_evaluation_samples{rule_group="group_two",user="user3"} 100000
+# HELP cortex_prometheus_notifications_alertmanagers_discovered The number of alertmanagers discovered and active.
+# TYPE cortex_prometheus_notifications_alertmanagers_discovered gauge
+cortex_prometheus_notifications_alertmanagers_discovered{user="user1"} 1
+cortex_prometheus_notifications_alertmanagers_discovered{user="user2"} 10
+cortex_prometheus_notifications_alertmanagers_discovered{user="user3"} 100
+# HELP cortex_prometheus_notifications_dropped_total Total number of alerts dropped due to errors when sending to Alertmanager.
+# TYPE cortex_prometheus_notifications_dropped_total counter
+cortex_prometheus_notifications_dropped_total{user="user1"} 1
+cortex_prometheus_notifications_dropped_total{user="user2"} 10
+cortex_prometheus_notifications_dropped_total{user="user3"} 100
+# HELP cortex_prometheus_notifications_errors_total Total number of errors sending alert notifications.
+# TYPE cortex_prometheus_notifications_errors_total counter
+cortex_prometheus_notifications_errors_total{alertmanager="alertmanager_1",user="user1"} 1
+cortex_prometheus_notifications_errors_total{alertmanager="alertmanager_1",user="user2"} 10
+cortex_prometheus_notifications_errors_total{alertmanager="alertmanager_1",user="user3"} 100
 # HELP cortex_prometheus_notifications_latency_seconds Latency quantiles for sending alert notifications.
 # TYPE cortex_prometheus_notifications_latency_seconds summary
-cortex_prometheus_notifications_latency_seconds_sum{user="user1"} 0
-cortex_prometheus_notifications_latency_seconds_count{user="user1"} 0
-cortex_prometheus_notifications_latency_seconds_sum{user="user2"} 0
-cortex_prometheus_notifications_latency_seconds_count{user="user2"} 0
-cortex_prometheus_notifications_latency_seconds_sum{user="user3"} 0
-cortex_prometheus_notifications_latency_seconds_count{user="user3"} 0
+cortex_prometheus_notifications_latency_seconds{user="user1",quantile="0.5"} 1
+cortex_prometheus_notifications_latency_seconds{user="user1",quantile="0.9"} 1
+cortex_prometheus_notifications_latency_seconds{user="user1",quantile="0.99"} 1
+cortex_prometheus_notifications_latency_seconds_sum{user="user1"} 1
+cortex_prometheus_notifications_latency_seconds_count{user="user1"} 1
+cortex_prometheus_notifications_latency_seconds{user="user2",quantile="0.5"} 10
+cortex_prometheus_notifications_latency_seconds{user="user2",quantile="0.9"} 10
+cortex_prometheus_notifications_latency_seconds{user="user2",quantile="0.99"} 10
+cortex_prometheus_notifications_latency_seconds_sum{user="user2"} 10
+cortex_prometheus_notifications_latency_seconds_count{user="user2"} 1
+cortex_prometheus_notifications_latency_seconds{user="user3",quantile="0.5"} 100
+cortex_prometheus_notifications_latency_seconds{user="user3",quantile="0.9"} 100
+cortex_prometheus_notifications_latency_seconds{user="user3",quantile="0.99"} 100
+cortex_prometheus_notifications_latency_seconds_sum{user="user3"} 100
+cortex_prometheus_notifications_latency_seconds_count{user="user3"} 1
+# HELP cortex_prometheus_notifications_queue_capacity The capacity of the alert notifications queue.
+# TYPE cortex_prometheus_notifications_queue_capacity gauge
+cortex_prometheus_notifications_queue_capacity{user="user1"} 1
+cortex_prometheus_notifications_queue_capacity{user="user2"} 10
+cortex_prometheus_notifications_queue_capacity{user="user3"} 100
+# HELP cortex_prometheus_notifications_queue_length The number of alert notifications in the queue.
+# TYPE cortex_prometheus_notifications_queue_length gauge
+cortex_prometheus_notifications_queue_length{user="user1"} 1
+cortex_prometheus_notifications_queue_length{user="user2"} 10
+cortex_prometheus_notifications_queue_length{user="user3"} 100
+# HELP cortex_prometheus_notifications_sent_total Total number of alerts sent.
+# TYPE cortex_prometheus_notifications_sent_total counter
+cortex_prometheus_notifications_sent_total{alertmanager="alertmanager_1",user="user1"} 1
+cortex_prometheus_notifications_sent_total{alertmanager="alertmanager_1",user="user2"} 10
+cortex_prometheus_notifications_sent_total{alertmanager="alertmanager_1",user="user3"} 100
 # HELP cortex_prometheus_rule_evaluation_duration_seconds The duration for a rule to execute.
 # TYPE cortex_prometheus_rule_evaluation_duration_seconds summary
 cortex_prometheus_rule_evaluation_duration_seconds{user="user1",quantile="0.5"} 1
@@ -161,14 +200,53 @@ func TestManagerMetricsWithoutRuleGroupLabel(t *testing.T) {
 cortex_prometheus_last_evaluation_samples{user="user1"} 2000
 cortex_prometheus_last_evaluation_samples{user="user2"} 20000
 cortex_prometheus_last_evaluation_samples{user="user3"} 200000
+# HELP cortex_prometheus_notifications_alertmanagers_discovered The number of alertmanagers discovered and active.
+# TYPE cortex_prometheus_notifications_alertmanagers_discovered gauge
+cortex_prometheus_notifications_alertmanagers_discovered{user="user1"} 1
+cortex_prometheus_notifications_alertmanagers_discovered{user="user2"} 10
+cortex_prometheus_notifications_alertmanagers_discovered{user="user3"} 100
+# HELP cortex_prometheus_notifications_dropped_total Total number of alerts dropped due to errors when sending to Alertmanager.
+# TYPE cortex_prometheus_notifications_dropped_total counter
+cortex_prometheus_notifications_dropped_total{user="user1"} 1
+cortex_prometheus_notifications_dropped_total{user="user2"} 10
+cortex_prometheus_notifications_dropped_total{user="user3"} 100
+# HELP cortex_prometheus_notifications_errors_total Total number of errors sending alert notifications.
+# TYPE cortex_prometheus_notifications_errors_total counter
+cortex_prometheus_notifications_errors_total{alertmanager="alertmanager_1",user="user1"} 1
+cortex_prometheus_notifications_errors_total{alertmanager="alertmanager_1",user="user2"} 10
+cortex_prometheus_notifications_errors_total{alertmanager="alertmanager_1",user="user3"} 100
 # HELP cortex_prometheus_notifications_latency_seconds Latency quantiles for sending alert notifications.
 # TYPE cortex_prometheus_notifications_latency_seconds summary
-cortex_prometheus_notifications_latency_seconds_sum{user="user1"} 0
-cortex_prometheus_notifications_latency_seconds_count{user="user1"} 0
-cortex_prometheus_notifications_latency_seconds_sum{user="user2"} 0
-cortex_prometheus_notifications_latency_seconds_count{user="user2"} 0
-cortex_prometheus_notifications_latency_seconds_sum{user="user3"} 0
-cortex_prometheus_notifications_latency_seconds_count{user="user3"} 0
+cortex_prometheus_notifications_latency_seconds{user="user1",quantile="0.5"} 1
+cortex_prometheus_notifications_latency_seconds{user="user1",quantile="0.9"} 1
+cortex_prometheus_notifications_latency_seconds{user="user1",quantile="0.99"} 1
+cortex_prometheus_notifications_latency_seconds_sum{user="user1"} 1
+cortex_prometheus_notifications_latency_seconds_count{user="user1"} 1
+cortex_prometheus_notifications_latency_seconds{user="user2",quantile="0.5"} 10
+cortex_prometheus_notifications_latency_seconds{user="user2",quantile="0.9"} 10
+cortex_prometheus_notifications_latency_seconds{user="user2",quantile="0.99"} 10
+cortex_prometheus_notifications_latency_seconds_sum{user="user2"} 10
+cortex_prometheus_notifications_latency_seconds_count{user="user2"} 1
+cortex_prometheus_notifications_latency_seconds{user="user3",quantile="0.5"} 100
+cortex_prometheus_notifications_latency_seconds{user="user3",quantile="0.9"} 100
+cortex_prometheus_notifications_latency_seconds{user="user3",quantile="0.99"} 100
+cortex_prometheus_notifications_latency_seconds_sum{user="user3"} 100
+cortex_prometheus_notifications_latency_seconds_count{user="user3"} 1
+# HELP cortex_prometheus_notifications_queue_capacity The capacity of the alert notifications queue.
+# TYPE cortex_prometheus_notifications_queue_capacity gauge
+cortex_prometheus_notifications_queue_capacity{user="user1"} 1
+cortex_prometheus_notifications_queue_capacity{user="user2"} 10
+cortex_prometheus_notifications_queue_capacity{user="user3"} 100
+# HELP cortex_prometheus_notifications_queue_length The number of alert notifications in the queue.
+# TYPE cortex_prometheus_notifications_queue_length gauge
+cortex_prometheus_notifications_queue_length{user="user1"} 1
+cortex_prometheus_notifications_queue_length{user="user2"} 10
+cortex_prometheus_notifications_queue_length{user="user3"} 100
+# HELP cortex_prometheus_notifications_sent_total Total number of alerts sent.
+# TYPE cortex_prometheus_notifications_sent_total counter
+cortex_prometheus_notifications_sent_total{alertmanager="alertmanager_1",user="user1"} 1
+cortex_prometheus_notifications_sent_total{alertmanager="alertmanager_1",user="user2"} 10
+cortex_prometheus_notifications_sent_total{alertmanager="alertmanager_1",user="user3"} 100
 # HELP cortex_prometheus_rule_evaluation_duration_seconds The duration for a rule to execute.
 # TYPE cortex_prometheus_rule_evaluation_duration_seconds summary
 cortex_prometheus_rule_evaluation_duration_seconds{user="user1",quantile="0.5"} 1
@@ -277,22 +355,37 @@ func populateManager(base float64) *prometheus.Registry {
 	metrics.groupLastEvalSamples.WithLabelValues("group_one").Add(base * 1000)
 	metrics.groupLastEvalSamples.WithLabelValues("group_two").Add(base * 1000)
 
+	metrics.notificationsLatency.WithLabelValues("alertmanager_1").Observe(base)
+	metrics.notificationsErrors.WithLabelValues("alertmanager_1").Add(base)
+	metrics.notificationsSent.WithLabelValues("alertmanager_1").Add(base)
+	metrics.notificationsDropped.Add(base)
+	metrics.notificationsQueueLength.Set(base)
+	metrics.notificationsQueueCapacity.Set(base)
+	metrics.notificationsAlertmanagersDiscovered.Set(base)
 	return r
 }
 
 // Copied from github.com/prometheus/rules/manager.go
+// and github.com/prometheus/notifier/notifier.go
 type groupMetrics struct {
-	evalDuration         prometheus.Summary
-	iterationDuration    prometheus.Summary
-	iterationsMissed     *prometheus.CounterVec
-	iterationsScheduled  *prometheus.CounterVec
-	evalTotal            *prometheus.CounterVec
-	evalFailures         *prometheus.CounterVec
-	groupInterval        *prometheus.GaugeVec
-	groupLastEvalTime    *prometheus.GaugeVec
-	groupLastDuration    *prometheus.GaugeVec
-	groupRules           *prometheus.GaugeVec
-	groupLastEvalSamples *prometheus.GaugeVec
+	evalDuration                         prometheus.Summary
+	iterationDuration                    prometheus.Summary
+	iterationsMissed                     *prometheus.CounterVec
+	iterationsScheduled                  *prometheus.CounterVec
+	evalTotal                            *prometheus.CounterVec
+	evalFailures                         *prometheus.CounterVec
+	groupInterval                        *prometheus.GaugeVec
+	groupLastEvalTime                    *prometheus.GaugeVec
+	groupLastDuration                    *prometheus.GaugeVec
+	groupRules                           *prometheus.GaugeVec
+	groupLastEvalSamples                 *prometheus.GaugeVec
+	notificationsLatency                 *prometheus.SummaryVec
+	notificationsErrors                  *prometheus.CounterVec
+	notificationsSent                    *prometheus.CounterVec
+	notificationsDropped                 prometheus.Counter
+	notificationsQueueLength             prometheus.Gauge
+	notificationsQueueCapacity           prometheus.Gauge
+	notificationsAlertmanagersDiscovered prometheus.Gauge
 }
 
 func newGroupMetrics(r prometheus.Registerer) *groupMetrics {
@@ -371,8 +464,53 @@ func newGroupMetrics(r prometheus.Registerer) *groupMetrics {
 			},
 			[]string{"rule_group"},
 		),
+		notificationsLatency: promauto.With(r).NewSummaryVec(
+			prometheus.SummaryOpts{
+				Name:       "prometheus_notifications_latency_seconds",
+				Help:       "Latency quantiles for sending alert notifications.",
+				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+			},
+			[]string{"alertmanager"},
+		),
+		notificationsErrors: promauto.With(r).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "prometheus_notifications_errors_total",
+				Help: "Latency quantiles for sending alert notifications.",
+			},
+			[]string{"alertmanager"},
+		),
+		notificationsSent: promauto.With(r).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "prometheus_notifications_sent_total",
+				Help: "Total number of errors sending alert notifications",
+			},
+			[]string{"alertmanager"},
+		),
+		notificationsDropped: promauto.With(r).NewCounter(
+			prometheus.CounterOpts{
+				Name: "prometheus_notifications_dropped_total",
+				Help: "Total number of alerts dropped due to errors when sending to Alertmanager.",
+			},
+		),
+		notificationsQueueLength: promauto.With(r).NewGauge(
+			prometheus.GaugeOpts{
+				Name: "prometheus_notifications_queue_length",
+				Help: "The number of alert notifications in the queue.",
+			},
+		),
+		notificationsQueueCapacity: promauto.With(r).NewGauge(
+			prometheus.GaugeOpts{
+				Name: "prometheus_notifications_queue_capacity",
+				Help: "The capacity of the alert notifications queue.",
+			},
+		),
+		notificationsAlertmanagersDiscovered: promauto.With(r).NewGauge(
+			prometheus.GaugeOpts{
+				Name: "prometheus_notifications_alertmanagers_discovered",
+				Help: "The number of alertmanagers discovered and active.",
+			},
+		),
 	}
-
 	return m
 }
 

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -50,7 +50,7 @@ func TestSyncRuleGroups(t *testing.T) {
 		return mgr.(*mockRulesManager).running.Load()
 	})
 
-	// Verify that user rule groups are now cached locally, and notifiers are created
+	// Verify that user rule groups are now cached locally and notifiers are created.
 	{
 		users, err := m.mapper.users()
 		_, ok := m.notifiers[user]

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -50,11 +50,13 @@ func TestSyncRuleGroups(t *testing.T) {
 		return mgr.(*mockRulesManager).running.Load()
 	})
 
-	// Verify that user rule groups are now cached locally.
+	// Verify that user rule groups are now cached locally, and notifiers are created
 	{
 		users, err := m.mapper.users()
+		_, ok := m.notifiers[user]
 		require.NoError(t, err)
 		require.Equal(t, []string{user}, users)
+		require.True(t, ok)
 	}
 
 	// Passing empty map / nil stops all managers.
@@ -69,8 +71,10 @@ func TestSyncRuleGroups(t *testing.T) {
 	// Verify that local rule groups were removed.
 	{
 		users, err := m.mapper.users()
+		_, ok := m.notifiers[user]
 		require.NoError(t, err)
 		require.Equal(t, []string(nil), users)
+		require.False(t, ok)
 	}
 
 	// Resync same rules as before. Previously this didn't restart the manager.

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -260,7 +260,7 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 	manager := newManager(t, cfg)
 	defer manager.Stop()
 
-	n, err := manager.getOrCreateNotifier("1")
+	n, err := manager.getOrCreateNotifier("1", manager.registry)
 	require.NoError(t, err)
 
 	// Loop until notifier discovery syncs up

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -274,7 +274,7 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 	defer rcleanup()
 	defer manager.Stop()
 
-	n, err := manager.getOrCreateNotifier("1")
+	n, err := manager.getOrCreateNotifier("1", manager.registry)
 	require.NoError(t, err)
 
 	// Loop until notifier discovery syncs up

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -274,7 +274,7 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 	defer rcleanup()
 	defer manager.Stop()
 
-	n, err := manager.getOrCreateNotifier("1", manager.registry)
+	n, err := manager.getOrCreateNotifier("1")
 	require.NoError(t, err)
 
 	// Loop until notifier discovery syncs up

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -275,10 +275,10 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 
 	// Ensure we have metrics in the notifier.
 	assert.NoError(t, prom_testutil.GatherAndCompare(manager.registry.(*prometheus.Registry), strings.NewReader(`
-		# HELP cortex_prometheus_notifications_dropped_total Total number of alerts dropped due to errors when sending to Alertmanager.
-		# TYPE cortex_prometheus_notifications_dropped_total counter
-		cortex_prometheus_notifications_dropped_total{user="1"} 0
-	`), "cortex_prometheus_notifications_dropped_total"))
+		# HELP prometheus_notifications_dropped_total Total number of alerts dropped due to errors when sending to Alertmanager.
+		# TYPE prometheus_notifications_dropped_total counter
+		prometheus_notifications_dropped_total 0
+	`), "prometheus_notifications_dropped_total"))
 }
 
 func TestRuler_Rules(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Stops notifier when a user is removed from ruler.

Currently if a user is removed from ruler, the notifier keeps on accumulating. If a cluster has high churn, memory will grow at a faster pace


![Screen Shot 2022-04-13 at 7 57 22 PM](https://user-images.githubusercontent.com/3461710/163305045-80ac1494-c031-4276-b4ac-7647a540cc2b.png)

**Which issue(s) this PR fixes**:


Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
