### PR TITLE
Remove mention of CNCF calendar for community meetings, which is usually out of sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ For security issues see https://github.com/cortexproject/cortex/security/policy
 
 ## Community Meetings
 
-The Cortex community call happens every two weeks on Thursday, alternating at 1200 UTC and 1700 UTC. To get a calendar invite join the [google groups](https://groups.google.com/forum/#!forum/cortex-monitoring).
+The Cortex community call happens every two weeks on Thursday, alternating at 1200 UTC and 1700 UTC. Meeting notes are held [here](https://docs.google.com/document/d/1shtXSAqp3t7fiC-9uZcKkq3mgwsItAJlH6YW6x1joZo/edit).
 
-Meeting notes are held [here](https://docs.google.com/document/d/1shtXSAqp3t7fiC-9uZcKkq3mgwsItAJlH6YW6x1joZo/edit).
+ To get a calendar invite join the [google groups](https://groups.google.com/forum/#!forum/cortex-monitoring) to ask for one.
 
 ## Hosted Cortex (Prometheus as a service)
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ For security issues see https://github.com/cortexproject/cortex/security/policy
 
 ## Community Meetings
 
-The Cortex community call happens every two weeks on Thursday, alternating at 1200 UTC and 1700 UTC. To get a calendar invite join the [google groups](https://groups.google.com/forum/#!forum/cortex-monitoring) or check out [the CNCF community calendar](https://www.cncf.io/calendar/).
+The Cortex community call happens every two weeks on Thursday, alternating at 1200 UTC and 1700 UTC. To get a calendar invite join the [google groups](https://groups.google.com/forum/#!forum/cortex-monitoring).
 
 Meeting notes are held [here](https://docs.google.com/document/d/1shtXSAqp3t7fiC-9uZcKkq3mgwsItAJlH6YW6x1joZo/edit).
 


### PR DESCRIPTION
Let's just have one source of truth for community meeting invite, which is the Google group. 