### PR TITLE
Abandoning release 1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master / unreleased
 
+* [CHANGE] Changed default for `-ingester.min-ready-duration` from 1 minute to 15 seconds. #4539
+* [CHANGE] query-frontend: Do not print anything in the logs of `query-frontend` if a in-progress query has been canceled (context canceled) to avoid spam. #4562
+* [CHANGE] Compactor block deletion mark migration, needed when upgrading from v1.7, is now disabled by default. #4597
+* [CHANGE] The `status_code` label on gRPC client metrics has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. 4601
+* [CHANGE] Memberlist: changed probe interval from `1s` to `5s` and probe timeout from `500ms` to `2s`. #4601
 * [CHANGE] Fix incorrectly named `cortex_cache_fetched_keys` and `cortex_cache_hits` metrics. Renamed to `cortex_cache_fetched_keys_total` and `cortex_cache_hits_total` respectively. #4686
 * [CHANGE] Enable Thanos series limiter in store-gateway. #4702
 * [CHANGE] Distributor: Apply `max_fetched_series_per_query` limit for `/series` API. #4683
@@ -9,15 +14,6 @@
 * [FEATURE] Compactor: Add `-compactor.skip-blocks-with-out-of-order-chunks-enabled` configuration to mark blocks containing index with out-of-order chunks for no compact instead of halting the compaction
 * [FEATURE] Querier/Query-Frontend: Add `-querier.per-step-stats-enabled` and `-frontend.cache-queryable-samples-stats` configurations to enable query sample statistics
 * [FEATURE] Add shuffle sharding for the compactor #4433
-* [BUGFIX] Distributor: Fix race condition on `/series` introduced by #4683. #4716
-
-## 1.12.0 in progress
-
-* [CHANGE] Changed default for `-ingester.min-ready-duration` from 1 minute to 15 seconds. #4539
-* [CHANGE] query-frontend: Do not print anything in the logs of `query-frontend` if a in-progress query has been canceled (context canceled) to avoid spam. #4562
-* [CHANGE] Compactor block deletion mark migration, needed when upgrading from v1.7, is now disabled by default. #4597
-* [CHANGE] The `status_code` label on gRPC client metrics has changed from '200' and '500' to '2xx', '5xx', '4xx', 'cancel' or 'error'. 4601
-* [CHANGE] Memberlist: changed probe interval from `1s` to `5s` and probe timeout from `500ms` to `2s`. #4601
 * [ENHANCEMENT] Update Go version to 1.17.8. #4602 #4604 #4658
 * [ENHANCEMENT] Keep track of discarded samples due to bad relabel configuration in `cortex_discarded_samples_total`. #4503
 * [ENHANCEMENT] Ruler: Add `-ruler.disable-rule-group-label` to disable the `rule_group` label on exported metrics. #4571
@@ -38,6 +34,7 @@
 * [BUGFIX] Memberlist: fixed corrupted packets when sending compound messages with more than 255 messages or messages bigger than 64KB. #4601
 * [BUGFIX] Query Frontend: If 'LogQueriesLongerThan' is set to < 0, log all queries as described in the docs. #4633
 * [BUGFIX] Distributor: update defaultReplicationStrategy to not fail with extend-write when a single instance is unhealthy. #4636
+* [BUGFIX] Distributor: Fix race condition on `/series` introduced by #4683. #4716
 
 ## 1.11.0 2021-11-25
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,7 +27,7 @@ Our goal is to provide a new minor release every 6 weeks. This is a new process 
 | v1.9.0         | 2021-04-29                                 | Goutham Veeramachaneni (@gouthamve)         |
 | v1.10.0        | 2021-06-25                                 | Bryan Boreham (@bboreham)                   |
 | v1.11.0        | 2021-08-06                                 | Marco Pracucci (@pracucci)                  |
-| v1.12.0        | 2022-02-17                                 | Alvin Lin (@alvinlin123)                    |
+| v1.12.0        | 2022-02-17                                 | _Abandoned_                                 |
 
 ## Release shepherd responsibilities
 


### PR DESCRIPTION
Abandoning release 1.12 per public Slack channel post: 


> Hi folks, I would like to propose to abandon the current 1.12 release because we are currently working on getting some highly asked features (like parallel compactor) into the main branch. I think it would be a more useful release if the release contains those features. I will apply [lazy consensus](https://community.apache.org/committers/lazyConsensus.html). Please do give me a shout if you feel release 1.12 should go ahead as it is. If no strong objection, then I will start the abandoning process on Thursday April 14 2022. 

I had 4 thumbs up and no push back by the time I submit this PR. 