### PR TITLE
Upload blocks no compaction marks to the global location and introduce a new `cortex_bucket_blocks_marked_for_no_compaction_count` metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 * [BUGFIX] Query Frontend: If 'LogQueriesLongerThan' is set to < 0, log all queries as described in the docs. #4633
 * [BUGFIX] Distributor: update defaultReplicationStrategy to not fail with extend-write when a single instance is unhealthy. #4636
 * [BUGFIX] Distributor: Fix race condition on `/series` introduced by #4683. #4716
+* [ENHANCEMENT] Compactor: uploading blocks no compaction marks to the global location and introduce a new metric #4729
+  * `cortex_bucket_blocks_marked_for_no_compaction_count`: Total number of blocks marked for no compaction in the bucket.
 
 ## 1.11.0 2021-11-25
 

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -45,18 +45,18 @@ type BlocksCleaner struct {
 	lastOwnedUsers []string
 
 	// Metrics.
-	runsStarted                          prometheus.Counter
-	runsCompleted                        prometheus.Counter
-	runsFailed                           prometheus.Counter
-	runsLastSuccess                      prometheus.Gauge
-	blocksCleanedTotal                   prometheus.Counter
-	blocksFailedTotal                    prometheus.Counter
-	blocksMarkedForDeletion              prometheus.Counter
-	tenantBlocks                         *prometheus.GaugeVec
-	tenantMarkedBlocks                   *prometheus.GaugeVec
-	tenantPartialBlocks                  *prometheus.GaugeVec
-	tenantBucketIndexLastUpdate          *prometheus.GaugeVec
-	blocksMarkedForNoCompactionOnStorage *prometheus.GaugeVec
+	runsStarted                 prometheus.Counter
+	runsCompleted               prometheus.Counter
+	runsFailed                  prometheus.Counter
+	runsLastSuccess             prometheus.Gauge
+	blocksCleanedTotal          prometheus.Counter
+	blocksFailedTotal           prometheus.Counter
+	blocksMarkedForDeletion     prometheus.Counter
+	tenantBlocks                *prometheus.GaugeVec
+	tenantMarkedBlocks          *prometheus.GaugeVec
+	tenantPartialBlocks         *prometheus.GaugeVec
+	tenantBucketIndexLastUpdate *prometheus.GaugeVec
+	tenantMarkedNoCompactBlocks *prometheus.GaugeVec
 }
 
 func NewBlocksCleaner(cfg BlocksCleanerConfig, bucketClient objstore.Bucket, usersScanner *cortex_tsdb.UsersScanner, cfgProvider ConfigProvider, logger log.Logger, reg prometheus.Registerer) *BlocksCleaner {
@@ -70,10 +70,6 @@ func NewBlocksCleaner(cfg BlocksCleanerConfig, bucketClient objstore.Bucket, use
 			Name: "cortex_compactor_block_cleanup_started_total",
 			Help: "Total number of blocks cleanup runs started.",
 		}),
-		blocksMarkedForNoCompactionOnStorage: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_compactor_blocks_marked_for_no_compaction_on_storage_total",
-			Help: "Total number of blocks marked for on storage.",
-		}, []string{"user"}),
 		runsCompleted: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_compactor_block_cleanup_completed_total",
 			Help: "Total number of blocks cleanup runs successfully completed.",
@@ -110,6 +106,10 @@ func NewBlocksCleaner(cfg BlocksCleanerConfig, bucketClient objstore.Bucket, use
 		tenantMarkedBlocks: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_bucket_blocks_marked_for_deletion_count",
 			Help: "Total number of blocks marked for deletion in the bucket.",
+		}, []string{"user"}),
+		tenantMarkedNoCompactBlocks: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_bucket_blocks_marked_for_no_compaction_count",
+			Help: "Total number of blocks marked for no compaction in the bucket.",
 		}, []string{"user"}),
 		tenantPartialBlocks: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_bucket_blocks_partials_count",
@@ -174,6 +174,7 @@ func (c *BlocksCleaner) cleanUsers(ctx context.Context, firstRun bool) error {
 		if !isActive[userID] && !isDeleted[userID] {
 			c.tenantBlocks.DeleteLabelValues(userID)
 			c.tenantMarkedBlocks.DeleteLabelValues(userID)
+			c.tenantMarkedNoCompactBlocks.DeleteLabelValues(userID)
 			c.tenantPartialBlocks.DeleteLabelValues(userID)
 			c.tenantBucketIndexLastUpdate.DeleteLabelValues(userID)
 		}
@@ -245,8 +246,8 @@ func (c *BlocksCleaner) deleteUserMarkedForDeletion(ctx context.Context, userID 
 	// Given all blocks have been deleted, we can also remove the metrics.
 	c.tenantBlocks.DeleteLabelValues(userID)
 	c.tenantMarkedBlocks.DeleteLabelValues(userID)
+	c.tenantMarkedNoCompactBlocks.DeleteLabelValues(userID)
 	c.tenantPartialBlocks.DeleteLabelValues(userID)
-	c.blocksMarkedForNoCompactionOnStorage.DeleteLabelValues(userID)
 
 	if deletedBlocks > 0 {
 		level.Info(userLogger).Log("msg", "deleted blocks for tenant marked for deletion", "deletedBlocks", deletedBlocks)
@@ -337,7 +338,7 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, firstRun b
 	// Generate an updated in-memory version of the bucket index.
 	w := bucketindex.NewUpdater(c.bucketClient, userID, c.cfgProvider, c.logger)
 	idx, partials, totalBlocksBlocksMarkedForNoCompaction, err := w.UpdateIndex(ctx, idx)
-	c.blocksMarkedForNoCompactionOnStorage.WithLabelValues(userID).Set(float64(totalBlocksBlocksMarkedForNoCompaction))
+	c.tenantMarkedNoCompactBlocks.WithLabelValues(userID).Set(float64(totalBlocksBlocksMarkedForNoCompaction))
 	if err != nil {
 		return err
 	}
@@ -375,8 +376,8 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, firstRun b
 
 	c.tenantBlocks.WithLabelValues(userID).Set(float64(len(idx.Blocks)))
 	c.tenantMarkedBlocks.WithLabelValues(userID).Set(float64(len(idx.BlockDeletionMarks)))
-	c.tenantPartialBlocks.WithLabelValues(userID).Set(float64(len(partials)))
 	c.tenantBucketIndexLastUpdate.WithLabelValues(userID).SetToCurrentTime()
+	c.tenantPartialBlocks.WithLabelValues(userID).Set(float64(len(partials)))
 
 	return nil
 }

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -336,8 +336,8 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, firstRun b
 
 	// Generate an updated in-memory version of the bucket index.
 	w := bucketindex.NewUpdater(c.bucketClient, userID, c.cfgProvider, c.logger)
-	idx, partials, err := w.UpdateIndex(ctx, idx)
-	c.blocksMarkedForNoCompactionOnStorage.WithLabelValues(userID).Set(float64(idx.TotalBlocksBlocksMarkedForNoCompaction))
+	idx, partials, totalBlocksBlocksMarkedForNoCompaction, err := w.UpdateIndex(ctx, idx)
+	c.blocksMarkedForNoCompactionOnStorage.WithLabelValues(userID).Set(float64(totalBlocksBlocksMarkedForNoCompaction))
 	if err != nil {
 		return err
 	}

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -421,7 +421,7 @@ func TestBlocksCleaner_ListBlocksOutsideRetentionPeriod(t *testing.T) {
 	id3 := createTSDBBlock(t, bucketClient, "user-1", 7000, 8000, nil)
 
 	w := bucketindex.NewUpdater(bucketClient, "user-1", nil, logger)
-	idx, _, err := w.UpdateIndex(ctx, nil)
+	idx, _, _, err := w.UpdateIndex(ctx, nil)
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, []ulid.ULID{id1, id2, id3}, idx.Blocks.GetULIDs())

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1382,6 +1382,14 @@ func createDeletionMark(t *testing.T, bkt objstore.Bucket, userID string, blockI
 	require.NoError(t, bkt.Upload(context.Background(), markPath, strings.NewReader(content)))
 }
 
+func createNoCompactionMark(t *testing.T, bkt objstore.Bucket, userID string, blockID ulid.ULID) {
+	content := mockNoCompactBlockJSON(blockID.String())
+	blockPath := path.Join(userID, blockID.String())
+	markPath := path.Join(blockPath, metadata.NoCompactMarkFilename)
+
+	require.NoError(t, bkt.Upload(context.Background(), markPath, strings.NewReader(content)))
+}
+
 func findCompactorByUserID(compactors []*Compactor, logs []*concurrency.SyncBuffer, userID string) (*Compactor, *concurrency.SyncBuffer, error) {
 	var compactor *Compactor
 	var log *concurrency.SyncBuffer

--- a/pkg/storage/tsdb/bucketindex/index.go
+++ b/pkg/storage/tsdb/bucketindex/index.go
@@ -41,6 +41,9 @@ type Index struct {
 	// UpdatedAt is a unix timestamp (seconds precision) of when the index has been updated
 	// (written in the storage) the last time.
 	UpdatedAt int64 `json:"updated_at"`
+
+	// TotalBlocksBlocksMarkedForNoCompaction is then number of blocks marked for no compaction
+	TotalBlocksBlocksMarkedForNoCompaction int64 `json:"total_blocks_marked_for_no_compaction"`
 }
 
 func (idx *Index) GetUpdatedAt() time.Time {

--- a/pkg/storage/tsdb/bucketindex/index.go
+++ b/pkg/storage/tsdb/bucketindex/index.go
@@ -41,9 +41,6 @@ type Index struct {
 	// UpdatedAt is a unix timestamp (seconds precision) of when the index has been updated
 	// (written in the storage) the last time.
 	UpdatedAt int64 `json:"updated_at"`
-
-	// TotalBlocksBlocksMarkedForNoCompaction is then number of blocks marked for no compaction
-	TotalBlocksBlocksMarkedForNoCompaction int64 `json:"total_blocks_marked_for_no_compaction"`
 }
 
 func (idx *Index) GetUpdatedAt() time.Time {

--- a/pkg/storage/tsdb/bucketindex/markers.go
+++ b/pkg/storage/tsdb/bucketindex/markers.go
@@ -51,6 +51,24 @@ func IsBlockDeletionMarkFilename(name string) (ulid.ULID, bool) {
 	return id, err == nil
 }
 
+// IsBlockNoCompactMarkFilename returns whether the input filename matches the expected pattern
+// of block no compact markers stored in the markers location.
+func IsBlockNoCompactMarkFilename(name string) (ulid.ULID, bool) {
+	parts := strings.SplitN(name, "-", 2)
+	if len(parts) != 2 {
+		return ulid.ULID{}, false
+	}
+
+	// Ensure the 2nd part matches the block deletion mark filename.
+	if parts[1] != metadata.NoCompactMarkFilename {
+		return ulid.ULID{}, false
+	}
+
+	// Ensure the 1st part is a valid block ID.
+	id, err := ulid.Parse(filepath.Base(parts[0]))
+	return id, err == nil
+}
+
 // MigrateBlockDeletionMarksToGlobalLocation list all tenant's blocks and, for each of them, look for
 // a deletion mark in the block location. Found deletion marks are copied to the global markers location.
 // The migration continues on error and returns once all blocks have been checked.

--- a/pkg/storage/tsdb/bucketindex/markers.go
+++ b/pkg/storage/tsdb/bucketindex/markers.go
@@ -27,6 +27,12 @@ func BlockDeletionMarkFilepath(blockID ulid.ULID) string {
 	return fmt.Sprintf("%s/%s-%s", MarkersPathname, blockID.String(), metadata.DeletionMarkFilename)
 }
 
+// NoCompactMarkFilenameMarkFilepath returns the path, relative to the tenant's bucket location,
+// of a block no compact mark in the bucket markers location.
+func NoCompactMarkFilenameMarkFilepath(blockID ulid.ULID) string {
+	return fmt.Sprintf("%s/%s-%s", MarkersPathname, blockID.String(), metadata.NoCompactMarkFilename)
+}
+
 // IsBlockDeletionMarkFilename returns whether the input filename matches the expected pattern
 // of block deletion markers stored in the markers location.
 func IsBlockDeletionMarkFilename(name string) (ulid.ULID, bool) {

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
@@ -7,9 +7,7 @@ import (
 	"io/ioutil"
 	"path"
 
-	"github.com/oklog/ulid"
 	"github.com/thanos-io/thanos/pkg/block"
-	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/objstore"
 )
 
@@ -127,12 +125,8 @@ func (b *globalMarkersBucket) ReaderWithExpectedErrs(fn objstore.IsOpFailureExpe
 }
 
 func (b *globalMarkersBucket) isMark(name string) (string, bool) {
-	marks := map[string]func(ulid.ULID) string{
-		metadata.DeletionMarkFilename:  BlockDeletionMarkFilepath,
-		metadata.NoCompactMarkFilename: NoCompactMarkFilenameMarkFilepath,
-	}
 
-	for mark, globalFilePath := range marks {
+	for mark, globalFilePath := range MarkersMap {
 		if path.Base(name) == mark {
 			// Parse the block ID in the path. If there's not block ID, then it's not the per-block
 			// deletion mark.

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
@@ -132,14 +132,14 @@ func (b *globalMarkersBucket) isMark(name string) (string, bool) {
 		metadata.NoCompactMarkFilename: NoCompactMarkFilenameMarkFilepath,
 	}
 
-	for mark, f := range marks {
+	for mark, globalFilePath := range marks {
 		if path.Base(name) == mark {
 			// Parse the block ID in the path. If there's not block ID, then it's not the per-block
 			// deletion mark.
 			id, ok := block.IsBlockDir(path.Dir(name))
 
 			if ok {
-				return path.Clean(path.Join(path.Dir(name), "../", f(id))), ok
+				return path.Clean(path.Join(path.Dir(name), "../", globalFilePath(id))), ok
 			}
 
 			return "", ok

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
@@ -148,13 +148,3 @@ func (b *globalMarkersBucket) isMark(name string) (string, bool) {
 
 	return "", false
 }
-
-func (b *globalMarkersBucket) isBlockDeletionMark(name string) (ulid.ULID, bool) {
-	if path.Base(name) != metadata.DeletionMarkFilename {
-		return ulid.ULID{}, false
-	}
-
-	// Parse the block ID in the path. If there's not block ID, then it's not the per-block
-	// deletion mark.
-	return block.IsBlockDir(path.Dir(name))
-}

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client_test.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client_test.go
@@ -11,43 +11,114 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/objstore"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	cortex_testutil "github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"
 )
 
-func TestGlobalMarkersBucket_Delete_ShouldSucceedIfDeletionMarkDoesNotExistInTheBlockButExistInTheGlobalLocation(t *testing.T) {
-	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
-
-	ctx := context.Background()
-	bkt = BucketWithGlobalMarkers(bkt)
-
-	// Create a mocked block deletion mark in the global location.
-	blockID := ulid.MustNew(1, nil)
-	globalPath := BlockDeletionMarkFilepath(blockID)
-	require.NoError(t, bkt.Upload(ctx, globalPath, strings.NewReader("{}")))
-
-	// Ensure it exists before deleting it.
-	ok, err := bkt.Exists(ctx, globalPath)
-	require.NoError(t, err)
-	require.True(t, ok)
-
-	require.NoError(t, bkt.Delete(ctx, globalPath))
-
-	// Ensure has been actually deleted.
-	ok, err = bkt.Exists(ctx, globalPath)
-	require.NoError(t, err)
-	require.False(t, ok)
-}
-
-func TestGlobalMarkersBucket_isBlockDeletionMark(t *testing.T) {
+func TestGlobalMarker_ShouldUploadGlobalLocation(t *testing.T) {
 	block1 := ulid.MustNew(1, nil)
 
 	tests := []struct {
-		name       string
-		expectedOk bool
-		expectedID ulid.ULID
+		mark       string
+		globalpath string
+	}{
+		{
+			mark:       metadata.DeletionMarkFilename,
+			globalpath: "markers/" + block1.String() + "-deletion-mark.json",
+		},
+		{
+			mark:       metadata.NoCompactMarkFilename,
+			globalpath: "markers/" + block1.String() + "-no-compact-mark.json",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.mark, func(t *testing.T) {
+			originalPath := block1.String() + "/" + tc.mark
+			bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+
+			ctx := context.Background()
+			bkt = BucketWithGlobalMarkers(bkt)
+
+			bkt.Upload(ctx, originalPath, strings.NewReader("{}"))
+
+			// Ensure it exists on originalPath
+			ok, err := bkt.Exists(ctx, originalPath)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			// Ensure it exists on globalPath
+			ok, err = bkt.Exists(ctx, tc.globalpath)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			bkt.Delete(ctx, originalPath)
+
+			// Ensure it deleted on originalPath
+			ok, err = bkt.Exists(ctx, originalPath)
+			require.NoError(t, err)
+			require.False(t, ok)
+
+			// Ensure it exists on globalPath
+			ok, err = bkt.Exists(ctx, tc.globalpath)
+			require.NoError(t, err)
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestGlobalMarkersBucket_Delete_ShouldSucceedIfMarkDoesNotExistInTheBlockButExistInTheGlobalLocation(t *testing.T) {
+	tests := []struct {
+		name  string
+		pathF func(ulid.ULID) string
+	}{
+		{
+			name:  metadata.DeletionMarkFilename,
+			pathF: BlockDeletionMarkFilepath,
+		},
+		{
+			name:  metadata.NoCompactMarkFilename,
+			pathF: NoCompactMarkFilenameMarkFilepath,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+
+			ctx := context.Background()
+			bkt = BucketWithGlobalMarkers(bkt)
+
+			// Create a mocked block deletion mark in the global location.
+			blockID := ulid.MustNew(1, nil)
+			globalPath := tc.pathF(blockID)
+			require.NoError(t, bkt.Upload(ctx, globalPath, strings.NewReader("{}")))
+
+			// Ensure it exists before deleting it.
+			ok, err := bkt.Exists(ctx, globalPath)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			require.NoError(t, bkt.Delete(ctx, globalPath))
+
+			// Ensure has been actually deleted.
+			ok, err = bkt.Exists(ctx, globalPath)
+			require.NoError(t, err)
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestGlobalMarkersBucket_isMark(t *testing.T) {
+	block1 := ulid.MustNew(1, nil)
+
+	tests := []struct {
+		name               string
+		expectedOk         bool
+		expectedGlobalPath string
 	}{
 		{
 			name:       "",
@@ -59,13 +130,21 @@ func TestGlobalMarkersBucket_isBlockDeletionMark(t *testing.T) {
 			name:       block1.String() + "/index",
 			expectedOk: false,
 		}, {
-			name:       block1.String() + "/deletion-mark.json",
-			expectedOk: true,
-			expectedID: block1,
+			name:               block1.String() + "/deletion-mark.json",
+			expectedOk:         true,
+			expectedGlobalPath: "markers/" + block1.String() + "-deletion-mark.json",
 		}, {
-			name:       "/path/to/" + block1.String() + "/deletion-mark.json",
-			expectedOk: true,
-			expectedID: block1,
+			name:               "/path/to/" + block1.String() + "/deletion-mark.json",
+			expectedOk:         true,
+			expectedGlobalPath: "/path/to/markers/" + block1.String() + "-deletion-mark.json",
+		}, {
+			name:               block1.String() + "/no-compact-mark.json",
+			expectedOk:         true,
+			expectedGlobalPath: "markers/" + block1.String() + "-no-compact-mark.json",
+		}, {
+			name:               "/path/to/" + block1.String() + "/no-compact-mark.json",
+			expectedOk:         true,
+			expectedGlobalPath: "/path/to/markers/" + block1.String() + "-no-compact-mark.json",
 		},
 	}
 
@@ -73,9 +152,9 @@ func TestGlobalMarkersBucket_isBlockDeletionMark(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actualID, actualOk := b.isBlockDeletionMark(tc.name)
+			globalPath, actualOk := b.isMark(tc.name)
 			assert.Equal(t, tc.expectedOk, actualOk)
-			assert.Equal(t, tc.expectedID, actualID)
+			assert.Equal(t, tc.expectedGlobalPath, globalPath)
 		})
 	}
 }

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client_test.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client_test.go
@@ -43,7 +43,8 @@ func TestGlobalMarker_ShouldUploadGlobalLocation(t *testing.T) {
 			ctx := context.Background()
 			bkt = BucketWithGlobalMarkers(bkt)
 
-			bkt.Upload(ctx, originalPath, strings.NewReader("{}"))
+			err := bkt.Upload(ctx, originalPath, strings.NewReader("{}"))
+			require.NoError(t, err)
 
 			// Ensure it exists on originalPath
 			ok, err := bkt.Exists(ctx, originalPath)
@@ -55,7 +56,8 @@ func TestGlobalMarker_ShouldUploadGlobalLocation(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, ok)
 
-			bkt.Delete(ctx, originalPath)
+			err = bkt.Delete(ctx, originalPath)
+			require.NoError(t, err)
 
 			// Ensure it deleted on originalPath
 			ok, err = bkt.Exists(ctx, originalPath)

--- a/pkg/storage/tsdb/bucketindex/storage_test.go
+++ b/pkg/storage/tsdb/bucketindex/storage_test.go
@@ -52,7 +52,7 @@ func TestReadIndex_ShouldReturnTheParsedIndexOnSuccess(t *testing.T) {
 
 	// Write the index.
 	u := NewUpdater(bkt, userID, nil, logger)
-	expectedIdx, _, err := u.UpdateIndex(ctx, nil)
+	expectedIdx, _, _, err := u.UpdateIndex(ctx, nil)
 	require.NoError(t, err)
 	require.NoError(t, WriteIndex(ctx, bkt, userID, nil, expectedIdx))
 
@@ -89,7 +89,7 @@ func BenchmarkReadIndex(b *testing.B) {
 
 	// Write the index.
 	u := NewUpdater(bkt, userID, nil, logger)
-	idx, _, err := u.UpdateIndex(ctx, nil)
+	idx, _, _, err := u.UpdateIndex(ctx, nil)
 	require.NoError(b, err)
 	require.NoError(b, WriteIndex(ctx, bkt, userID, nil, idx))
 

--- a/pkg/storage/tsdb/testutil/block_mock.go
+++ b/pkg/storage/tsdb/testutil/block_mock.go
@@ -66,3 +66,23 @@ func MockStorageDeletionMark(t testing.TB, bucket objstore.Bucket, userID string
 
 	return &mark
 }
+
+func MockStorageNonCompactionMark(t testing.TB, bucket objstore.Bucket, userID string, meta tsdb.BlockMeta) *metadata.NoCompactMark {
+	mark := metadata.NoCompactMark{
+		ID:            meta.ULID,
+		Version:       metadata.NoCompactMarkVersion1,
+		NoCompactTime: time.Now().Unix(),
+		Reason:        metadata.OutOfOrderChunksNoCompactReason,
+	}
+
+	markContent, err := json.Marshal(mark)
+	if err != nil {
+		panic("failed to marshal mocked block meta")
+	}
+
+	markContentReader := strings.NewReader(string(markContent))
+	markPath := fmt.Sprintf("%s/%s/%s", userID, meta.ULID.String(), metadata.NoCompactMarkFilename)
+	require.NoError(t, bucket.Upload(context.Background(), markPath, markContentReader))
+
+	return &mark
+}

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -1213,7 +1213,7 @@ func (m *mockShardingStrategy) FilterBlocks(ctx context.Context, userID string, 
 
 func createBucketIndex(t *testing.T, bkt objstore.Bucket, userID string) *bucketindex.Index {
 	updater := bucketindex.NewUpdater(bkt, userID, nil, log.NewNopLogger())
-	idx, _, err := updater.UpdateIndex(context.Background(), nil)
+	idx, _, _, err := updater.UpdateIndex(context.Background(), nil)
 	require.NoError(t, err)
 	require.NoError(t, bucketindex.WriteIndex(context.Background(), bkt, userID, nil, idx))
 

--- a/pkg/storegateway/metadata_fetcher_filters_test.go
+++ b/pkg/storegateway/metadata_fetcher_filters_test.go
@@ -69,7 +69,7 @@ func testIgnoreDeletionMarkFilter(t *testing.T, bucketIndexEnabled bool) {
 		var err error
 
 		u := bucketindex.NewUpdater(bkt, userID, nil, logger)
-		idx, _, err = u.UpdateIndex(ctx, nil)
+		idx, _, _, err = u.UpdateIndex(ctx, nil)
 		require.NoError(t, err)
 		require.NoError(t, bucketindex.WriteIndex(ctx, bkt, userID, nil, idx))
 	}


### PR DESCRIPTION
**What this PR does**:
Follow up of https://github.com/cortexproject/cortex/pull/4707.

* Upload the `no-compact` marks to the global marks location
* Introduce a new metric to show how many blocks are marked for no compact on store.

**Which issue(s) this PR fixes**:
Fixes: https://github.com/cortexproject/cortex/issues/4727

**Checklist**
- [X] Tests updated
- [] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
