### PR TITLE
Fix memory leak in distributor due to cluster label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [BUGFIX] Query Frontend: If 'LogQueriesLongerThan' is set to < 0, log all queries as described in the docs. #4633
 * [BUGFIX] Distributor: update defaultReplicationStrategy to not fail with extend-write when a single instance is unhealthy. #4636
 * [BUGFIX] Distributor: Fix race condition on `/series` introduced by #4683. #4716
+* [BUGFIX] Distributor: Fix a memory leak in distributor due to the cluster label. #4739
 
 ## 1.11.0 2021-11-25
 

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -471,7 +471,9 @@ func findHALabels(replicaLabel, clusterLabel string, labels []cortexpb.LabelAdap
 			replica = pair.Value
 		}
 		if pair.Name == clusterLabel {
-			cluster = pair.Value
+			// cluster label is unmarshalled into yoloString, which retains original remote write request body in memory.
+			// Hence, we clone the yoloString to allow the request body to be garbage collected.
+			cluster = util.StringsClone(pair.Value)
 		}
 	}
 

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -1,5 +1,7 @@
 package util
 
+import "unsafe"
+
 // StringsContain returns true if the search value is within the list of input values.
 func StringsContain(values []string, search string) bool {
 	for _, v := range values {
@@ -18,4 +20,12 @@ func StringsMap(values []string) map[string]bool {
 		out[v] = true
 	}
 	return out
+}
+
+// StringsClone returns a copy input s
+// see: https://github.com/golang/go/blob/master/src/strings/clone.go
+func StringsClone(s string) string {
+	b := make([]byte, len(s))
+	copy(b, s)
+	return *(*string)(unsafe.Pointer(&b))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
The HA cluster label is exposed through the distributor metrics. This can cause memory leak when one tenant sends a lot of different clusters. The metrics is only cleaned up after 30 mins.

The memory is leaked because the the `yoloString` in the request is kept alive for a longer period.

![Yolo](https://user-images.githubusercontent.com/842522/167994580-a296c06b-d487-4f9d-97e5-9f99017a6c6c.png)

The following is the memory consumed by the distributor over time without cloning the cluster label.
![Without the fix](https://user-images.githubusercontent.com/842522/167994348-8678bd9c-853c-48a5-8f7d-bf73b6210740.png)

The following is the memory consumed by distributor when cluster label was cloned.
![Cloning the cluster label](https://user-images.githubusercontent.com/842522/167994444-1f644f3b-7649-435c-b62d-550f561ae78e.png)


The above leak in `snappyDecode` appears to have disappeared.
![Leak is fixed](https://user-images.githubusercontent.com/842522/167994685-16086713-2d3b-4288-a1ee-189be2e17be0.png)




**Which issue(s) this PR fixes**:
Fixes #<issue number>



**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
