### PR TITLE
blocksconvert: add a mapping for tenant IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
 * [BUGFIX] Distributor: Fix race condition on `/series` introduced by #4683. #4716
 * [BUGFIX] Distributor: Fix a memory leak in distributor due to the cluster label. #4739
 
+## Blocksconvert
+
+* [ENHANCEMENT] Add a mapping for tenant IDs from chunks to blocks. #4740
+
 ## 1.11.0 2021-11-25
 
 * [CHANGE] Memberlist: Expose default configuration values to the command line options. Note that setting these explicitly to zero will no longer cause the default to be used. If the default is desired, then do set the option. The following are affected: #4276

--- a/docs/blocks-storage/convert-stored-chunks-to-blocks.md
+++ b/docs/blocks-storage/convert-stored-chunks-to-blocks.md
@@ -29,6 +29,8 @@ Tools are:
 All tools start HTTP server (see `-server.http*` options) exposing the `/metrics` endpoint.
 All tools also start gRPC server (`-server.grpc*` options), but only Scheduler exposes services on it.
 
+If you need to use different tenant IDs for blocks than you had for chunks, e.g. because you are moving data to a hosted provider, map them with `-builder.tenant-id-map`.
+
 ### Scanner
 
 Scanner is started by running `blocksconvert -target=scanner`. Scanner requires configuration for accessing Cortex Index:
@@ -82,6 +84,7 @@ Builder is started by `blocksconvert -target=builder`. It needs to be configured
 - `-gcs.bucketname` – when using GCS as chunks store (other chunks backend storages, like S3, are supported as well)
 - `-blocks-storage.*` - blocks storage configuration
 - `-builder.output-dir` - Local directory where Builder keeps the block while it is being built. Once block is uploaded to blocks storage, it is deleted from local directory.
+- `-builder.tenant-id-map` - Path to file listing mapping of chunk tenant IDs to block tenant IDs. YAML map format. Note that an ID which is not mapped is an error; use `-scheduler.allowed-users` if you need to exclude some IDs from the transfer.
 
 Multiple builders may run at the same time, each builder will receive different plan to work on from scheduler.
 Builders are CPU intensive (decoding and merging chunks), and require fast disk IO for writing blocks.


### PR DESCRIPTION
**What this PR does**:

Add a mapping for tenant IDs, for the case where you want to use different tenant IDs for blocks than you had for chunks, e.g. because you are moving data to a hosted provider.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated
