### PR TITLE
Re-enable proxy_url for alertmanager receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [CHANGE] Fix incorrectly named `cortex_cache_fetched_keys` and `cortex_cache_hits` metrics. Renamed to `cortex_cache_fetched_keys_total` and `cortex_cache_hits_total` respectively. #4686
 * [CHANGE] Enable Thanos series limiter in store-gateway. #4702
 * [CHANGE] Distributor: Apply `max_fetched_series_per_query` limit for `/series` API. #4683
+* [CHANGE] Re-enable the `proxy_url` option for receiver configuration. #4741
 * [FEATURE] Ruler: Add `external_labels` option to tag all alerts with a given set of labels. #4499
 * [FEATURE] Compactor: Add `-compactor.skip-blocks-with-out-of-order-chunks-enabled` configuration to mark blocks containing index with out-of-order chunks for no compact instead of halting the compaction. #4707
 * [FEATURE] Querier/Query-Frontend: Add `-querier.per-step-stats-enabled` and `-frontend.cache-queryable-samples-stats` configurations to enable query sample statistics. #4708

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -43,7 +43,6 @@ const (
 var (
 	errPasswordFileNotAllowed        = errors.New("setting password_file, bearer_token_file and credentials_file is not allowed")
 	errOAuth2SecretFileNotAllowed    = errors.New("setting OAuth2 client_secret_file is not allowed")
-	errProxyURLNotAllowed            = errors.New("setting proxy_url is not allowed")
 	errTLSFileNotAllowed             = errors.New("setting TLS ca_file, cert_file and key_file is not allowed")
 	errSlackAPIURLFileNotAllowed     = errors.New("setting Slack api_url_file and global slack_api_url_file is not allowed")
 	errVictorOpsAPIKeyFileNotAllowed = errors.New("setting VictorOps api_key_file is not allowed")
@@ -409,9 +408,6 @@ func validateReceiverHTTPConfig(cfg commoncfg.HTTPClientConfig) error {
 	}
 	if cfg.BearerTokenFile != "" {
 		return errPasswordFileNotAllowed
-	}
-	if cfg.ProxyURL.URL != nil {
-		return errProxyURLNotAllowed
 	}
 	if cfg.OAuth2 != nil && cfg.OAuth2.ClientSecretFile != "" {
 		return errOAuth2SecretFileNotAllowed

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -372,22 +372,6 @@ alertmanager_config: |
 			err: errors.Wrap(errOAuth2SecretFileNotAllowed, "error validating Alertmanager config"),
 		},
 		{
-			name: "Should return error if receiver's HTTP proxy_url is set",
-			cfg: `
-alertmanager_config: |
-  receivers:
-    - name: default-receiver
-      webhook_configs:
-        - url: http://localhost
-          http_config:
-            proxy_url: http://localhost
-
-  route:
-    receiver: 'default-receiver'
-`,
-			err: errors.Wrap(errProxyURLNotAllowed, "error validating Alertmanager config"),
-		},
-		{
 			name: "Should return error if global slack_api_url_file is set",
 			cfg: `
 alertmanager_config: |


### PR DESCRIPTION
**What this PR does**:
It re-enables the `proxy_url` option for alertmanager receivers.

⚠️ Reverts part of a security change! Review well ⚠️ 

Originally introduced with #4129 . We believe this might have been an overly cautious fix and propose to re-enable this option again. This seems to be the consensus in the follow-up discussion. https://github.com/cortexproject/cortex/pull/4129#issuecomment-1120097455 by @alvinlin123 

**Which issue(s) this PR fixes**:
Fixes #4680 

**Checklist**
- [x] Tests updated
- [x] ~Documentation added~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
