### PR TITLE
Reduce the number of series that are kept in memory while streaming from ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [BUGFIX] Distributor: Fix a memory leak in distributor due to the cluster label. #4739
 * [ENHANCEMENT] Compactor: uploading blocks no compaction marks to the global location and introduce a new metric #4729
   * `cortex_bucket_blocks_marked_for_no_compaction_count`: Total number of blocks marked for no compaction in the bucket.
+* [ENHANCEMENT] Querier: Reduce the number of series that are kept in memory while streaming from ingesters. #4745
 
 ## 1.11.0 2021-11-25
 

--- a/pkg/cortexpb/compat.go
+++ b/pkg/cortexpb/compat.go
@@ -102,6 +102,12 @@ func FromLabelAdaptersToMetric(ls []LabelAdapter) model.Metric {
 	return util.LabelsToMetric(FromLabelAdaptersToLabels(ls))
 }
 
+// FromLabelAdaptersToMetric converts []LabelAdapter to a model.Metric with copy.
+// Don't do this on any performance sensitive paths.
+func FromLabelAdaptersToMetricWithCopy(ls []LabelAdapter) model.Metric {
+	return util.LabelsToMetric(FromLabelAdaptersToLabelsWithCopy(ls))
+}
+
 // FromMetricsToLabelAdapters converts model.Metric to []LabelAdapter.
 // Don't do this on any performance sensitive paths.
 // The result is sorted.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1058,7 +1058,7 @@ func (d *Distributor) MetricsForLabelMatchersStream(ctx context.Context, from, t
 				}
 
 				for _, metric := range resp.Metric {
-					m := cortexpb.FromLabelAdaptersToMetric(metric.Labels)
+					m := cortexpb.FromLabelAdaptersToMetricWithCopy(metric.Labels)
 
 					if err := queryLimiter.AddSeries(cortexpb.FromMetricsToLabelAdapters(m)); err != nil {
 						return nil, err


### PR DESCRIPTION
Signed-off-by: 🌲 Harry 🌊 John 🏔 <johrry@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Addresses an issue where the stream response is left in the memory which increases the overall memory consumption.
Keeping a reference to `resp` will also mean that 3x the series (duplicate data fetched from all ingesters) is kept in memory.

Before this fix:
![Screen Shot 2022-06-02 at 3 17 33 PM](https://user-images.githubusercontent.com/842522/171756131-059c4030-6c83-40ac-85a5-7e84d626e76d.png)

After this fix:
![Screen Shot 2022-06-02 at 4 03 57 PM](https://user-images.githubusercontent.com/842522/171756243-e56e7970-35c6-4b29-af18-9544ede25766.png)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
