### PR TITLE
Add limit time for gossip on ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [BUGFIX] Distributor: update defaultReplicationStrategy to not fail with extend-write when a single instance is unhealthy. #4636
 * [BUGFIX] Distributor: Fix race condition on `/series` introduced by #4683. #4716
 * [BUGFIX] Distributor: Fix a memory leak in distributor due to the cluster label. #4739
+* [BUGFIX] Memberlist: Avoid clock skew by limiting the timestamp accepted on gossip. #
 * [ENHANCEMENT] Compactor: uploading blocks no compaction marks to the global location and introduce a new metric #4729
   * `cortex_bucket_blocks_marked_for_no_compaction_count`: Total number of blocks marked for no compaction in the bucket.
 * [ENHANCEMENT] Querier: Reduce the number of series that are kept in memory while streaming from ingesters. #4745

--- a/pkg/ring/merge_test.go
+++ b/pkg/ring/merge_test.go
@@ -128,6 +128,14 @@ func TestMerge(t *testing.T) {
 		}
 	}
 
+	futureRing := func() *Desc {
+		return &Desc{
+			Ingesters: map[string]InstanceDesc{
+				"Ing 1": {Addr: "addr1", Timestamp: time.Now().Add(31 * time.Minute).Unix(), State: ACTIVE, Tokens: []uint32{30, 40, 50}},
+			},
+		}
+	}
+
 	expectedFirstSecondThirdFourthMerge := func() *Desc {
 		return &Desc{
 			Ingesters: map[string]InstanceDesc{
@@ -180,6 +188,12 @@ func TestMerge(t *testing.T) {
 				"Ing 1": {Addr: "addr1", Timestamp: now + 10, State: LEFT, Tokens: nil},
 			},
 		}, ch)
+	}
+
+	{
+		out, err := firstRing().Merge(futureRing(), false)
+		assert.Empty(t, out)
+		assert.ErrorContains(t, err, "ingester Ing 1 timestamp in the future")
 	}
 }
 

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -209,7 +209,12 @@ func (d *Desc) mergeWithTime(mergeable memberlist.Mergeable, localCAS bool, now 
 	var updated []string
 	tokensChanged := false
 
+	maxFutureLimit := now.Add(30 * time.Minute).Unix()
 	for name, oing := range otherIngesterMap {
+		if oing.Timestamp > maxFutureLimit {
+			return nil, fmt.Errorf("ingester %s timestamp in the future, expected max of %d, got %d", name, maxFutureLimit, oing.Timestamp)
+		}
+
 		ting := thisIngesterMap[name]
 		// ting.Timestamp will be 0, if there was no such ingester in our version
 		if oing.Timestamp > ting.Timestamp {


### PR DESCRIPTION
Signed-off-by: Daniel Blando <ddeluigg@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Add a 30min window as max time to accept gossip updates. It avoids the possibility of a clock skew that can cause a non health pod to be available longer than expected.

**Which issue(s) this PR fixes**:
Fixes #4461 

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
