### PR TITLE
Fix split range queries with wrong boundaries

### DIFF
--- a/pkg/querier/queryrange/split_by_interval.go
+++ b/pkg/querier/queryrange/split_by_interval.go
@@ -74,13 +74,15 @@ func splitQuery(r Request, interval time.Duration) ([]Request, error) {
 		return nil, err
 	}
 	var reqs []Request
-	for start := r.GetStart(); start < r.GetEnd(); start = nextIntervalBoundary(start, r.GetStep(), interval) + r.GetStep() {
-		end := nextIntervalBoundary(start, r.GetStep(), interval)
+	for start, startWithStep := r.GetStart(), r.GetStart(); start < r.GetEnd(); {
+		end := nextIntervalBoundary(startWithStep, r.GetStep(), interval)
 		if end+r.GetStep() >= r.GetEnd() {
 			end = r.GetEnd()
 		}
 
 		reqs = append(reqs, r.WithQuery(query).WithStartEnd(start, end))
+		start = end
+		startWithStep = end + r.GetStep()
 	}
 	return reqs, nil
 }

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -148,7 +148,7 @@ func TestSplitQuery(t *testing.T) {
 					Query: "foo @ 0.000",
 				},
 				&PrometheusRequest{
-					Start: 24 * 3600 * seconds,
+					Start: (24 * 3600 * seconds) - (15 * seconds),
 					End:   2 * 24 * 3600 * seconds,
 					Step:  15 * seconds,
 					Query: "foo @ 0.000",
@@ -171,7 +171,7 @@ func TestSplitQuery(t *testing.T) {
 					Query: "foo",
 				},
 				&PrometheusRequest{
-					Start: 3 * 3600 * seconds,
+					Start: (3 * 3600 * seconds) - (15 * seconds),
 					End:   2 * 3 * 3600 * seconds,
 					Step:  15 * seconds,
 					Query: "foo",
@@ -194,13 +194,13 @@ func TestSplitQuery(t *testing.T) {
 					Query: "foo",
 				},
 				&PrometheusRequest{
-					Start: 24 * 3600 * seconds,
+					Start: (24 * 3600 * seconds) - (15 * seconds),
 					End:   (2 * 24 * 3600 * seconds) - (15 * seconds),
 					Step:  15 * seconds,
 					Query: "foo",
 				},
 				&PrometheusRequest{
-					Start: 2 * 24 * 3600 * seconds,
+					Start: (2 * 24 * 3600 * seconds) - (15 * seconds),
 					End:   3 * 24 * 3600 * seconds,
 					Step:  15 * seconds,
 					Query: "foo",
@@ -223,13 +223,13 @@ func TestSplitQuery(t *testing.T) {
 					Query: "foo",
 				},
 				&PrometheusRequest{
-					Start: 3 * 3600 * seconds,
+					Start: (3 * 3600 * seconds) - (15 * seconds),
 					End:   (2 * 3 * 3600 * seconds) - (15 * seconds),
 					Step:  15 * seconds,
 					Query: "foo",
 				},
 				&PrometheusRequest{
-					Start: 2 * 3 * 3600 * seconds,
+					Start: (2 * 3 * 3600 * seconds) - (15 * seconds),
 					End:   3 * 3 * 3600 * seconds,
 					Step:  15 * seconds,
 					Query: "foo",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
The original splitQuery add a gap(step) between boundaries, in my point of view, we may lose some data points because of this.

We should strictly align the boundaries.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
