### PR TITLE
skip compaction if there is only 1 block available for shuffle-sharding compactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 * [BUGFIX] Ruler: Fixed leaking notifiers after users are removed #4718
 * [BUGFIX] Distributor: Fix a memory leak in distributor due to the cluster label. #4739
 * [BUGFIX] Memberlist: Avoid clock skew by limiting the timestamp accepted on gossip. #4750
-
+* [BUGFIX] Compactor: skip compaction if there is only 1 block available for shuffle-sharding compactor. #4756
 
 ## 1.11.0 2021-11-25
 

--- a/pkg/compactor/shuffle_sharding_planner.go
+++ b/pkg/compactor/shuffle_sharding_planner.go
@@ -46,5 +46,9 @@ func (p *ShuffleShardingPlanner) Plan(_ context.Context, metasByMinTime []*metad
 		resultMetas = append(resultMetas, b)
 	}
 
+	if len(resultMetas) < 2 {
+		return nil, nil
+	}
+
 	return resultMetas, nil
 }

--- a/pkg/compactor/shuffle_sharding_planner_test.go
+++ b/pkg/compactor/shuffle_sharding_planner_test.go
@@ -16,6 +16,7 @@ import (
 func TestShuffleShardingPlanner_Plan(t *testing.T) {
 	block1ulid := ulid.MustNew(1, nil)
 	block2ulid := ulid.MustNew(2, nil)
+	block3ulid := ulid.MustNew(3, nil)
 
 	tests := map[string]struct {
 		ranges          []int64
@@ -137,6 +138,13 @@ func TestShuffleShardingPlanner_Plan(t *testing.T) {
 						MaxTime: 2 * time.Hour.Milliseconds(),
 					},
 				},
+				{
+					BlockMeta: tsdb.BlockMeta{
+						ULID:    block3ulid,
+						MinTime: 1 * time.Hour.Milliseconds(),
+						MaxTime: 2 * time.Hour.Milliseconds(),
+					},
+				},
 			},
 			expected: []*metadata.Meta{
 				{
@@ -146,7 +154,35 @@ func TestShuffleShardingPlanner_Plan(t *testing.T) {
 						MaxTime: 2 * time.Hour.Milliseconds(),
 					},
 				},
+				{
+					BlockMeta: tsdb.BlockMeta{
+						ULID:    block3ulid,
+						MinTime: 1 * time.Hour.Milliseconds(),
+						MaxTime: 2 * time.Hour.Milliseconds(),
+					},
+				},
 			},
+		},
+		"test should not compact if there is only 1 compactable block": {
+			ranges:          []int64{2 * time.Hour.Milliseconds()},
+			noCompactBlocks: map[ulid.ULID]*metadata.NoCompactMark{block1ulid: {}},
+			blocks: []*metadata.Meta{
+				{
+					BlockMeta: tsdb.BlockMeta{
+						ULID:    block1ulid,
+						MinTime: 1 * time.Hour.Milliseconds(),
+						MaxTime: 2 * time.Hour.Milliseconds(),
+					},
+				},
+				{
+					BlockMeta: tsdb.BlockMeta{
+						ULID:    block2ulid,
+						MinTime: 1 * time.Hour.Milliseconds(),
+						MaxTime: 2 * time.Hour.Milliseconds(),
+					},
+				},
+			},
+			expected: []*metadata.Meta{},
 		},
 	}
 


### PR DESCRIPTION
Currently the shuffle-sharding compactor will continuously compact a single block into a new block, if there is another compactable block marked for no compaction.


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

The compactor will skip compaction groups with only 1 block, after checking for blocks marked for no compact.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
