### PR TITLE
Removing fingerprint calculator from the lock on the GetSeries API

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1028,8 +1028,9 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 				if err := queryLimiter.AddSeries(cortexpb.FromMetricsToLabelAdapters(m)); err != nil {
 					return nil, err
 				}
+				fingerprint := m.Fingerprint()
 				mutex.Lock()
-				(*metrics)[m.Fingerprint()] = m
+				(*metrics)[fingerprint] = m
 				mutex.Unlock()
 			}
 
@@ -1060,11 +1061,13 @@ func (d *Distributor) MetricsForLabelMatchersStream(ctx context.Context, from, t
 				for _, metric := range resp.Metric {
 					m := cortexpb.FromLabelAdaptersToMetricWithCopy(metric.Labels)
 
-					if err := queryLimiter.AddSeries(cortexpb.FromMetricsToLabelAdapters(m)); err != nil {
+					if err := queryLimiter.AddSeries(metric.Labels); err != nil {
 						return nil, err
 					}
+
+					fingerprint := m.Fingerprint()
 					mutex.Lock()
-					(*metrics)[m.Fingerprint()] = m
+					(*metrics)[fingerprint] = m
 					mutex.Unlock()
 				}
 			}

--- a/pkg/util/limiter/query_limiter_test.go
+++ b/pkg/util/limiter/query_limiter_test.go
@@ -45,9 +45,31 @@ func TestQueryLimiter_AddSeriers_ShouldReturnErrorOnLimitExceeded(t *testing.T) 
 	)
 
 	var (
-		series1 = labels.FromMap(map[string]string{
-			labels.MetricName: metricName + "_1",
+		series1 = []cortexpb.LabelAdapter{
+			{
+				Name:  labels.MetricName,
+				Value: metricName + "_1",
+			},
+			{
+				Name:  "series1",
+				Value: "1",
+			},
+		}
+
+		series1OtherOrderLabels = []cortexpb.LabelAdapter{
+			{
+				Name:  "series1",
+				Value: "1",
+			},
+			{
+				Name:  labels.MetricName,
+				Value: metricName + "_1",
+			},
+		}
+
+		series1FromMap = labels.FromMap(map[string]string{
 			"series1":         "1",
+			labels.MetricName: metricName + "_1",
 		})
 		series2 = labels.FromMap(map[string]string{
 			labels.MetricName: metricName + "_2",
@@ -55,7 +77,11 @@ func TestQueryLimiter_AddSeriers_ShouldReturnErrorOnLimitExceeded(t *testing.T) 
 		})
 		limiter = NewQueryLimiter(1, 0, 0)
 	)
-	err := limiter.AddSeries(cortexpb.FromLabelsToLabelAdapters(series1))
+	err := limiter.AddSeries(series1)
+	require.NoError(t, err)
+	err = limiter.AddSeries(cortexpb.FromLabelsToLabelAdapters(series1FromMap))
+	require.NoError(t, err)
+	err = limiter.AddSeries(series1OtherOrderLabels)
 	require.NoError(t, err)
 	err = limiter.AddSeries(cortexpb.FromLabelsToLabelAdapters(series2))
 	require.Error(t, err)


### PR DESCRIPTION
**What this PR does**:

Removes the series fingerprint calculation from the locked code.
We are sorting the series labels and calculating the hash to get the fingerprint. This code can be a little heavy and there is no reason to be locked.

This changed improved the latency on retrieving 1M series from ~37 seconds to ~29 seconds.

<img width="647" alt="Screen Shot 2022-06-28 at 10 06 55 AM" src="https://user-images.githubusercontent.com/4027760/176242116-a3c8950b-8512-4da5-a607-bfa650e58c58.png">


**Checklist**
- [NA] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
