### PR TITLE
fix cortex_compactor_remaining_planned_compactions not set after plan generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [BUGFIX] Memberlist: Avoid clock skew by limiting the timestamp accepted on gossip. #4750
 * [BUGFIX] Compactor: skip compaction if there is only 1 block available for shuffle-sharding compactor. #4756
 * [BUGFIX] Compactor: Fixes #4770 - an edge case in compactor with shulffle sharding where compaction stops when a tenant stops ingesting samples. #4771
+* [BUGFIX] Compactor: fix cortex_compactor_remaining_planned_compactions not set after plan generation for shuffle sharding compactor. #4772
 
 ## 1.11.0 2021-11-25
 

--- a/pkg/compactor/shuffle_sharding_grouper.go
+++ b/pkg/compactor/shuffle_sharding_grouper.go
@@ -134,7 +134,7 @@ func (g *ShuffleShardingGrouper) Groups(blocks map[ulid.ULID]*metadata.Meta) (re
 	}
 	// Metrics for the remaining planned compactions
 	var remainingCompactions = 0.
-	defer g.remainingPlannedCompactions.Set(remainingCompactions)
+	defer func() { g.remainingPlannedCompactions.Set(remainingCompactions) }()
 
 	for _, mainBlocks := range mainGroups {
 		for _, group := range groupBlocksByCompactableRanges(mainBlocks, g.compactorCfg.BlockRanges.ToMilliseconds()) {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
`cortex_compactor_remaining_planned_compactions` is not getting set as plans are generated. This PR fixes the issue

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
