### PR TITLE
DoBatch preference to 4xx if error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## master / unreleased
 * [FEATURE] Compactor: Added `-compactor.block-files-concurrency` allowing to configure number of go routines for download/upload block files during compaction. #4784
 * [ENHANCEMENT] Querier/Ruler: Retry store-gateway in case of unexpected failure, instead of failing the query. #4532
+* [ENHANCEMENT] Ring: DoBatch prioritize 4xx errors when failing. #4783
 * [FEATURE] Compactor: Added -compactor.blocks-fetch-concurrency` allowing to configure number of go routines for blocks during compaction. #4787
 
 ## 1.13.0 2022-07-14
+
 * [CHANGE] Changed default for `-ingester.min-ready-duration` from 1 minute to 15 seconds. #4539
 * [CHANGE] query-frontend: Do not print anything in the logs of `query-frontend` if a in-progress query has been canceled (context canceled) to avoid spam. #4562
 * [CHANGE] Compactor block deletion mark migration, needed when upgrading from v1.7, is now disabled by default. #4597

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -554,7 +554,7 @@ func TestPush_QuorumError(t *testing.T) {
 		_, err := d.Push(ctx, request)
 		status, ok := status.FromError(err)
 		require.True(t, ok)
-		require.True(t, status.Code() == 429 || status.Code() == 500)
+		require.Equal(t, codes.Code(429), status.Code())
 	}
 
 	// Simulating 1 error -> Should return 2xx

--- a/pkg/ring/batch.go
+++ b/pkg/ring/batch.go
@@ -152,7 +152,8 @@ func (b *batchTracker) record(sampleTrackers []*itemTracker, err error) {
 			errCount := sampleTrackers[i].recordError(err)
 			// We should return an error if we reach the maxFailure (quorum) on a given error family OR
 			// we dont have any remaining ingesters to try
-			// Ex: 2xx, 4xx, 5xx -> return 5xx
+			// Ex: 2xx, 4xx, 5xx -> return 4xx
+			// Ex: 2xx, 5xx, 4xx -> return 4xx
 			// Ex: 4xx, 4xx, _ -> return 4xx
 			// Ex: 5xx, _, 5xx -> return 5xx
 			if errCount > int32(sampleTrackers[i].maxFailures) || sampleTrackers[i].remaining.Dec() == 0 {


### PR DESCRIPTION
Signed-off-by: Daniel Blando <ddeluigg@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
After https://github.com/cortexproject/cortex/pull/4388, we started returning the error which most failed. This CR improves the logic to also prioritize 4xx if it was the same amount of 5xx errors. The logic being that in a case of 4xx and 5xx, we are predicting the customer was close to their limits and 4xx is more relevant than 5xx. The change also creates more consistency in responses.

If we had a 3 quorum
Before:
2xx, 5xx, 4xx -> returns 4xx
2xx, 4xx, 5xx -> returns 5xx
5xx, 4xx, 5xx -> returns 5xx
4xx, 5xx, 4xx -> returns 4xx

After change:
2xx, 5xx, 4xx -> returns 4xx
2xx, 4xx, 5xx -> returns 4xx
5xx, 4xx, 5xx -> returns 5xx
4xx, 5xx, 4xx -> returns 4xx

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
