### PR TITLE
Added PrometheusLoggerFactory to InitLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [ENHANCEMENT] Add length and limit to labelNameTooLongError and labelValueTooLongError #4595
 * [ENHANCEMENT] Add jitter to rejoinInterval. #4747
 * [ENHANCEMENT] Compactor: uploading blocks no compaction marks to the global location and introduce a new metric #4729
+* [ENHANCEMENT] Logger: add possibility to implement `PrometheusLoggerFactory` to InitLogger #4786
   * `cortex_bucket_blocks_marked_for_no_compaction_count`: Total number of blocks marked for no compaction in the bucket.
 * [ENHANCEMENT] Querier: Reduce the number of series that are kept in memory while streaming from ingesters. #4745
 * [BUGFIX] AlertManager: remove stale template files. #4495

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -38,7 +38,8 @@ func init() {
 // InitLogger initialises the global gokit logger (util_log.Logger) and overrides the
 // default logger for the server.
 func InitLogger(cfg *server.Config) {
-	l, err := NewPrometheusLogger(cfg.LogLevel, cfg.LogFormat)
+	factory := NewPrometheusLoggerFactory()
+	l, err := factory(cfg.LogLevel, cfg.LogFormat)
 	if err != nil {
 		panic(err)
 	}
@@ -79,6 +80,17 @@ func NewPrometheusLogger(l logging.Level, format logging.Format) (log.Logger, er
 	// return a Logger without caller information, shouldn't use directly
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	return logger, nil
+}
+
+type PrometheusLoggerFactory func(l logging.Level,
+	format logging.Format) (log.Logger, error)
+
+func NewPrometheusLoggerFactory() PrometheusLoggerFactory {
+	return func(l logging.Level,
+		format logging.Format) (log.Logger, error) {
+		return NewPrometheusLogger(l, format)
+	}
+
 }
 
 // Log increments the appropriate Prometheus counter depending on the log level.


### PR DESCRIPTION
Base of new default factory for PrometheusLogger

Does not support user selection of alternative factories 
Options to implement this behavior
1. Add additional logger.config, similar to existing configs, to be used in construction of loggers, with support for factory selection
2. Modify server.config to add selection of which factory to use (would require modification of vendored code)
3. Wrap server.config to add factory selection, without modifying vendored code (potentially require modification of large number of functions to use new wrapper config instead of base server config)
4. Others?