### PR TITLE
Fix updateCachedShippedBlocks - Thanos Update

### DIFF
--- a/pkg/ingester/ingester_v2.go
+++ b/pkg/ingester/ingester_v2.go
@@ -310,7 +310,7 @@ func (u *userTSDB) blocksToDelete(blocks []*tsdb.Block) map[ulid.ULID]struct{} {
 // updateCachedShipperBlocks reads the shipper meta file and updates the cached shipped blocks.
 func (u *userTSDB) updateCachedShippedBlocks() error {
 	shipperMeta, err := shipper.ReadMetaFile(u.db.Dir())
-	if os.IsNotExist(err) {
+	if os.IsNotExist(err) || os.IsNotExist(errors.Cause(err)) {
 		// If the meta file doesn't exist it means the shipper hasn't run yet.
 		shipperMeta = &shipper.Meta{}
 	} else if err != nil {


### PR DESCRIPTION
**What this PR does**:
Fixing updateCachedShippedBlocks function.

With the thanos update, we started to see the following error:

```
level=error ts=2022-07-28T02:35:59.814001241Z caller=ingester_v2.go:1753 org_id=blah msg="failed to update cached shipped blocks after shipper initialisation" err="failed to read /data/tsdb/blah/thanos.shipper.json: open /data/tsdb/blah/thanos.shipper.json: no such file or directory"
```

As thanos changed the error type:

https://github.com/thanos-io/thanos/pull/5174


It does not seems to be a big issue (or not a issue at all) as when the file does not exists there is nothing to update anyway - but the log line is ugly!

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
