### PR TITLE
fix: panic on distributor ha_tracker kvstore memberlist config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [FEATURE] Compactor: Added `-compactor.block-files-concurrency` allowing to configure number of go routines for download/upload block files during compaction. #4784
 * [FEATURE] Compactor: Added -compactor.blocks-fetch-concurrency` allowing to configure number of go routines for blocks during compaction. #4787
 * [BUGFIX] Memberlist: Add join with no retrying when starting service. #4804
+* [BUGFIX] Distributor: Fix HA Tracker kvstore memberlist panic. #4811
 
 
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -768,6 +768,7 @@ func (t *Cortex) initMemberlistKV() (services.Service, error) {
 	t.Cfg.MemberlistKV.MetricsRegisterer = reg
 	t.Cfg.MemberlistKV.Codecs = []codec.Codec{
 		ring.GetCodec(),
+		distributor.GetReplicaDescCodec(),
 	}
 	dnsProviderReg := prometheus.WrapRegistererWithPrefix(
 		"cortex_",
@@ -782,6 +783,7 @@ func (t *Cortex) initMemberlistKV() (services.Service, error) {
 
 	// Update the config.
 	t.Cfg.Distributor.DistributorRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
+	t.Cfg.Distributor.HATrackerConfig.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Cfg.Ingester.LifecyclerConfig.RingConfig.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Cfg.StoreGateway.ShardingRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Cfg.Compactor.ShardingRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV


### PR DESCRIPTION
Signed-off-by: Benjamin Bourgeais <wixdesq@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**: 

When choosing the memberlist kv store for  the HA Tracker feature on the distributor, cortex crashes. Upon closer inspection, it seems that the MemberlisKV function was nil. I added the missing initialization for it to work.

**Which issue(s) this PR fixes**: None, I directly fixed the bug (one liner).

**Checklist**
- [ ] Tests updated
- [ ] Documentation added (no new feature, just a fix for an existing behavior)
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
