### PR TITLE
add support for msi in bucket client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ENHANCEMENT] Ring: DoBatch prioritize 4xx errors when failing. #4783
 * [FEATURE] Compactor: Added `-compactor.block-files-concurrency` allowing to configure number of go routines for download/upload block files during compaction. #4784
 * [FEATURE] Compactor: Added -compactor.blocks-fetch-concurrency` allowing to configure number of go routines for blocks during compaction. #4787
+* [FEATURE] Compactor: Added configurations for Azure MSI in blocks-storage, ruler-storage and alertmanager-storage. #4818
 * [BUGFIX] Memberlist: Add join with no retrying when starting service. #4804
 
 

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -348,6 +348,15 @@ blocks_storage:
     # CLI flag: -blocks-storage.azure.max-retries
     [max_retries: <int> | default = 20]
 
+    # Azure storage MSI resource. Either this or account key must be set.
+    # CLI flag: -blocks-storage.azure.msi-resource
+    [msi_resource: <string> | default = ""]
+
+    # Azure storage MSI resource managed identity client Id. If not supplied
+    # system assigned identity is used
+    # CLI flag: -blocks-storage.azure.user-assigned-id
+    [user_assigned_id: <string> | default = ""]
+
     http:
       # The time an idle connection will remain idle before closing.
       # CLI flag: -blocks-storage.azure.http.idle-conn-timeout

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -404,6 +404,15 @@ blocks_storage:
     # CLI flag: -blocks-storage.azure.max-retries
     [max_retries: <int> | default = 20]
 
+    # Azure storage MSI resource. Either this or account key must be set.
+    # CLI flag: -blocks-storage.azure.msi-resource
+    [msi_resource: <string> | default = ""]
+
+    # Azure storage MSI resource managed identity client Id. If not supplied
+    # system assigned identity is used
+    # CLI flag: -blocks-storage.azure.user-assigned-id
+    [user_assigned_id: <string> | default = ""]
+
     http:
       # The time an idle connection will remain idle before closing.
       # CLI flag: -blocks-storage.azure.http.idle-conn-timeout

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1791,6 +1791,15 @@ azure:
   # CLI flag: -ruler-storage.azure.max-retries
   [max_retries: <int> | default = 20]
 
+  # Azure storage MSI resource. Either this or account key must be set.
+  # CLI flag: -ruler-storage.azure.msi-resource
+  [msi_resource: <string> | default = ""]
+
+  # Azure storage MSI resource managed identity client Id. If not supplied
+  # system assigned identity is used
+  # CLI flag: -ruler-storage.azure.user-assigned-id
+  [user_assigned_id: <string> | default = ""]
+
   http:
     # The time an idle connection will remain idle before closing.
     # CLI flag: -ruler-storage.azure.http.idle-conn-timeout
@@ -2372,6 +2381,15 @@ azure:
   # Number of retries for recoverable errors
   # CLI flag: -alertmanager-storage.azure.max-retries
   [max_retries: <int> | default = 20]
+
+  # Azure storage MSI resource. Either this or account key must be set.
+  # CLI flag: -alertmanager-storage.azure.msi-resource
+  [msi_resource: <string> | default = ""]
+
+  # Azure storage MSI resource managed identity client Id. If not supplied
+  # system assigned identity is used
+  # CLI flag: -alertmanager-storage.azure.user-assigned-id
+  [user_assigned_id: <string> | default = ""]
 
   http:
     # The time an idle connection will remain idle before closing.
@@ -4723,6 +4741,15 @@ azure:
   # Number of retries for recoverable errors
   # CLI flag: -blocks-storage.azure.max-retries
   [max_retries: <int> | default = 20]
+
+  # Azure storage MSI resource. Either this or account key must be set.
+  # CLI flag: -blocks-storage.azure.msi-resource
+  [msi_resource: <string> | default = ""]
+
+  # Azure storage MSI resource managed identity client Id. If not supplied
+  # system assigned identity is used
+  # CLI flag: -blocks-storage.azure.user-assigned-id
+  [user_assigned_id: <string> | default = ""]
 
   http:
     # The time an idle connection will remain idle before closing.

--- a/pkg/storage/bucket/azure/bucket_client.go
+++ b/pkg/storage/bucket/azure/bucket_client.go
@@ -15,6 +15,8 @@ func NewBucketClient(cfg Config, name string, logger log.Logger) (objstore.Bucke
 		ContainerName:      cfg.ContainerName,
 		Endpoint:           cfg.Endpoint,
 		MaxRetries:         cfg.MaxRetries,
+		MSIResource:        cfg.MSIResource,
+		UserAssignedID:     cfg.UserAssignedID,
 		HTTPConfig: azure.HTTPConfig{
 			IdleConnTimeout:       model.Duration(cfg.IdleConnTimeout),
 			ResponseHeaderTimeout: model.Duration(cfg.ResponseHeaderTimeout),

--- a/pkg/storage/bucket/azure/config.go
+++ b/pkg/storage/bucket/azure/config.go
@@ -14,6 +14,8 @@ type Config struct {
 	ContainerName      string         `yaml:"container_name"`
 	Endpoint           string         `yaml:"endpoint_suffix"`
 	MaxRetries         int            `yaml:"max_retries"`
+	MSIResource        string         `yaml:"msi_resource"`
+	UserAssignedID     string         `yaml:"user_assigned_id"`
 
 	http.Config `yaml:"http"`
 }
@@ -30,5 +32,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.ContainerName, prefix+"azure.container-name", "", "Azure storage container name")
 	f.StringVar(&cfg.Endpoint, prefix+"azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN")
 	f.IntVar(&cfg.MaxRetries, prefix+"azure.max-retries", 20, "Number of retries for recoverable errors")
+	f.StringVar(&cfg.MSIResource, prefix+"azure.msi-resource", "", "Azure storage MSI resource. Either this or account key must be set.")
+	f.StringVar(&cfg.UserAssignedID, prefix+"azure.user-assigned-id", "", "Azure storage MSI resource managed identity client Id. If not supplied system assigned identity is used")
 	cfg.Config.RegisterFlagsWithPrefix(prefix+"azure.", f)
 }

--- a/pkg/storage/bucket/azure/config_test.go
+++ b/pkg/storage/bucket/azure/config_test.go
@@ -45,6 +45,8 @@ account_name: test-account-name
 account_key: test-account-key
 container_name: test-container-name
 endpoint_suffix: test-endpoint-suffix
+msi_resource: test-msi-resource
+user_assigned_id: test-user-assigned-id
 max_retries: 1
 http:
   idle_conn_timeout: 2s
@@ -61,6 +63,8 @@ http:
 				StorageAccountKey:  flagext.Secret{Value: "test-account-key"},
 				ContainerName:      "test-container-name",
 				Endpoint:           "test-endpoint-suffix",
+				MSIResource:        "test-msi-resource",
+				UserAssignedID:     "test-user-assigned-id",
 				MaxRetries:         1,
 				Config: http.Config{
 					IdleConnTimeout:       2 * time.Second,


### PR DESCRIPTION
This PR adds configuration for azure bucket client (ruler/block-storage/alert-manager) to use MSI, by propegating the config to thanos code, which already supported MSI.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
