### PR TITLE
Upate update build image instruction with things to note about GOPROXY

### DIFF
--- a/docs/contributing/how-to-update-the-build-image.md
+++ b/docs/contributing/how-to-update-the-build-image.md
@@ -8,6 +8,9 @@ slug: how-to-update-the-build-image
 The build image currently can only be updated by a Cortex maintainer. If you're not a maintainer you can still open a PR with the changes, asking a maintainer to assist you publishing the updated image. The procedure is:
 
 1. Update `build-image/Docker`.
-2. Build the and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for linux/amd64 and linux/arm64). Pushing to `quay.io/cortexproject/build-image` repository can only be done by a maintainer. Running this step successfully requires [Docker Buildx](https://docs.docker.com/buildx/working-with-buildx/), but does not require a specific platform.
-3. Replace the image tag in `.github/workflows/*` (_there may be multiple references_) and Makefile (variable `LATEST_BUILD_IMAGE_TAG`).
-4. Open a PR and make sure the CI with new build-image passes
+1. Run `go env` and make sure `GOPROXY=https://proxy.golang.org,direct` (Go's default). Some environment may required `GOPROXY=direct`, and if you push a build image with this, build workflow on GitHub will take a lot longer to download modules.
+1. Build the and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for linux/amd64 and linux/arm64). Pushing to `quay.io/cortexproject/build-image` repository can only be done by a maintainer. Running this step successfully requires [Docker Buildx](https://docs.docker.com/buildx/working-with-buildx/), but does not require a specific platform.
+1. Replace the image tag in `.github/workflows/*` (_there may be multiple references_) and Makefile (variable `LATEST_BUILD_IMAGE_TAG`).
+1. Open a PR and make sure the CI with new build-image passes
+
+


### PR DESCRIPTION
I was notified that after [my change to upgrade Hugo](https://github.com/cortexproject/cortex/commit/234bddec3cfa591ff65158ab5ffc13868846a2a1), *Check Vendor Directory* build step started to take a lot longer (from 4 min to 40 min...). 

The reason was because the new build image I published had `GOPROXY=direct`, which was caused by the machine I build the build image is configured to not use any proxy. 

I thought it'd be nice to add this to doc so that next time I build a build image, I will remember this issue. 
