### PR TITLE
Upgrade build image to use go 1.19

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -30,13 +30,13 @@ RUN GOARCH=$(go env GOARCH) && \
 
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.27.0
 
-RUN GO111MODULE=on go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
-	GO111MODULE=on go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
-	GO111MODULE=on go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 &&\
-	GO111MODULE=on go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 &&\
-	GO111MODULE=on go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 &&\
-	GO111MODULE=on go install github.com/fatih/faillint@v1.5.0 &&\
-	GO111MODULE=on go install github.com/campoy/embedmd@v1.0.0 &&\
+RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
+	go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
+	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 &&\
+	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 &&\
+	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 &&\
+	go install github.com/fatih/faillint@v1.5.0 &&\
+	go install github.com/campoy/embedmd@v1.0.0 &&\
 	rm -rf /go/pkg /go/src /root/.cache
 
 ENV NODE_PATH=/usr/lib/node_modules

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -30,7 +30,7 @@ RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 &&\
 	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 &&\
 	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 &&\
-	go install github.com/fatih/faillint@v1.5.0 &&\
+	go install github.com/fatih/faillint@v1.10.0 &&\
 	go install github.com/campoy/embedmd@v1.0.0 &&\
 	go install --tags extended github.com/gohugoio/hugo@${HUGO_VERSION} &&\
 	rm -rf /go/pkg /go/src /root/.cache

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -30,7 +30,7 @@ RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 &&\
 	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 &&\
 	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 &&\
-	go install github.com/fatih/faillint@v1.10.0 &&\
+	go install github.com/fatih/faillint@v1.11.0 &&\
 	go install github.com/campoy/embedmd@v1.0.0 &&\
 	go install --tags extended github.com/gohugoio/hugo@${HUGO_VERSION} &&\
 	rm -rf /go/pkg /go/src /root/.cache

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # and viceversa.
 RUN npm install -g postcss-cli@7.1.2 autoprefixer@9.8.5
 
-
 ENV SHFMT_VERSION=3.2.4
 RUN GOARCH=$(go env GOARCH) && \
 	if [ "$GOARCH" = "amd64" ]; then \

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -10,10 +10,6 @@ RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # and viceversa.
 RUN npm install -g postcss-cli@7.1.2 autoprefixer@9.8.5
 
-ENV HUGO_VERSION=v0.101.0
-RUN git clone https://github.com/gohugoio/hugo.git --branch ${HUGO_VERSION} --depth 1 && \
-	cd hugo  && go install --tags extended && cd ../ && \
-	rm -rf hugo/ && rm -rf /go/pkg /go/src /root/.cache
 
 ENV SHFMT_VERSION=3.2.4
 RUN GOARCH=$(go env GOARCH) && \
@@ -30,13 +26,14 @@ RUN GOARCH=$(go env GOARCH) && \
 
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.27.0
 
+ENV HUGO_VERSION=v0.101.0
 RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
-	go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 &&\
 	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 &&\
 	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 &&\
 	go install github.com/fatih/faillint@v1.5.0 &&\
 	go install github.com/campoy/embedmd@v1.0.0 &&\
+	go install --tags extended github.com/gohugoio/hugo@${HUGO_VERSION} &&\
 	rm -rf /go/pkg /go/src /root/.cache
 
 ENV NODE_PATH=/usr/lib/node_modules

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.8-buster
+FROM golang:1.19.0-buster
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl python-requests python-yaml file jq unzip protobuf-compiler libprotobuf-dev && \
@@ -10,8 +10,8 @@ RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # and viceversa.
 RUN npm install -g postcss-cli@7.1.2 autoprefixer@9.8.5
 
-ENV HUGO_VERSION=v0.94.3
-RUN git clone https://github.com/alvinlin123/hugo.git --branch ${HUGO_VERSION} --depth 1 && \
+ENV HUGO_VERSION=v0.101.0
+RUN git clone https://github.com/gohugoio/hugo.git --branch ${HUGO_VERSION} --depth 1 && \
 	cd hugo  && go install --tags extended && cd ../ && \
 	rm -rf hugo/ && rm -rf /go/pkg /go/src /root/.cache
 
@@ -30,15 +30,14 @@ RUN GOARCH=$(go env GOARCH) && \
 
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.27.0
 
-RUN GO111MODULE=on go get \
-	github.com/client9/misspell/cmd/misspell@v0.3.4 \
-	github.com/golang/protobuf/protoc-gen-go@v1.3.1 \
-	github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 \
-	github.com/gogo/protobuf/gogoproto@v1.3.0 \
-	github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 \
-	github.com/fatih/faillint@v1.5.0 \
-	github.com/campoy/embedmd@v1.0.0 \
-	&& rm -rf /go/pkg /go/src /root/.cache
+RUN GO111MODULE=on go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
+	GO111MODULE=on go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
+	GO111MODULE=on go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 &&\
+	GO111MODULE=on go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 &&\
+	GO111MODULE=on go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 &&\
+	GO111MODULE=on go install github.com/fatih/faillint@v1.5.0 &&\
+	GO111MODULE=on go install github.com/campoy/embedmd@v1.0.0 &&\
+	rm -rf /go/pkg /go/src /root/.cache
 
 ENV NODE_PATH=/usr/lib/node_modules
 COPY build.sh /

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -23,7 +23,7 @@ RUN GOARCH=$(go env GOARCH) && \
 	chmod +x shfmt && \
 	mv shfmt /usr/bin
 
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.27.0
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.48.0
 
 ENV HUGO_VERSION=v0.101.0
 RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\


### PR DESCRIPTION
Signed-off-by: Alvin Lin <alvinlin@amazon.com>

**What this PR does**:
Upgrade build image to use Go 1.19 so we can start using new language features like generic. 

Example build workflow run using the new build image can be found at https://github.com/alvinlin123/cortex/pull/3


**Which issue(s) this PR fixes**:
Fixes #4817
