### PR TITLE
Add new limit: max_series_label_size_bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [FEATURE] Compactor: Added configurations for Azure MSI in blocks-storage, ruler-storage and alertmanager-storage. #4818
 * [FEATURE] Ruler: Add support to pass custom implementations of queryable and pusher. #4782
 * [FEATURE] Create OpenTelemetry Bridge for Tracing. Now cortex can send traces to multiple destinations using OTEL Collectors. #4834
+* [FEATURE] Distributor: Added a new limit `-validation.max-labels-size-bytes` allowing to limit the combined size of labels for each timeseries. #4848
 * [BUGFIX] Memberlist: Add join with no retrying when starting service. #4804
 * [BUGFIX] Ruler: Fix /ruler/rule_groups returns YAML with extra fields. #4767
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2553,6 +2553,11 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -validation.max-label-names-per-series
 [max_label_names_per_series: <int> | default = 30]
 
+# Maximum combined size in bytes of all labels and label values accepted for a
+# series. 0 to disable the limit.
+# CLI flag: -validation.max-labels-size-bytes
+[max_labels_size_bytes: <int> | default = 0]
+
 # Maximum length accepted for metric metadata. Metadata refers to Metric Name,
 # HELP and UNIT.
 # CLI flag: -validation.max-metadata-length

--- a/pkg/util/validation/errors.go
+++ b/pkg/util/validation/errors.go
@@ -68,6 +68,26 @@ func newLabelValueTooLongError(series []cortexpb.LabelAdapter, labelValue string
 	}
 }
 
+// labelsSizeBytesExceededError is a customized ValidationError, in that the cause and the series are
+// formatted in different order in Error.
+type labelsSizeBytesExceededError struct {
+	labelsSizeBytes int
+	series          []cortexpb.LabelAdapter
+	limit           int
+}
+
+func (e *labelsSizeBytesExceededError) Error() string {
+	return fmt.Sprintf("labels size bytes exceeded for metric (actual: %d, limit: %d) metric: %.200q", e.labelsSizeBytes, e.limit, formatLabelSet(e.series))
+}
+
+func labelSizeBytesExceededError(series []cortexpb.LabelAdapter, labelsSizeBytes int, limit int) ValidationError {
+	return &labelsSizeBytesExceededError{
+		labelsSizeBytes: labelsSizeBytes,
+		series:          series,
+		limit:           limit,
+	}
+}
+
 func newInvalidLabelError(series []cortexpb.LabelAdapter, labelName string) ValidationError {
 	return &genericValidationError{
 		message: "sample invalid label: %.200q metric %.200q",

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -46,6 +46,7 @@ type Limits struct {
 	MaxLabelNameLength        int                 `yaml:"max_label_name_length" json:"max_label_name_length"`
 	MaxLabelValueLength       int                 `yaml:"max_label_value_length" json:"max_label_value_length"`
 	MaxLabelNamesPerSeries    int                 `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
+	MaxLabelsSizeBytes        int                 `yaml:"max_labels_size_bytes" json:"max_labels_size_bytes"`
 	MaxMetadataLength         int                 `yaml:"max_metadata_length" json:"max_metadata_length"`
 	RejectOldSamples          bool                `yaml:"reject_old_samples" json:"reject_old_samples"`
 	RejectOldSamplesMaxAge    model.Duration      `yaml:"reject_old_samples_max_age" json:"reject_old_samples_max_age"`
@@ -126,6 +127,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLabelNameLength, "validation.max-length-label-name", 1024, "Maximum length accepted for label names")
 	f.IntVar(&l.MaxLabelValueLength, "validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
 	f.IntVar(&l.MaxLabelNamesPerSeries, "validation.max-label-names-per-series", 30, "Maximum number of label names per series.")
+	f.IntVar(&l.MaxLabelsSizeBytes, "validation.max-labels-size-bytes", 0, "Maximum combined size in bytes of all labels and label values accepted for a series. 0 to disable the limit.")
 	f.IntVar(&l.MaxMetadataLength, "validation.max-metadata-length", 1024, "Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT.")
 	f.BoolVar(&l.RejectOldSamples, "validation.reject-old-samples", false, "Reject old samples.")
 	_ = l.RejectOldSamplesMaxAge.Set("14d")
@@ -325,6 +327,11 @@ func (o *Overrides) MaxLabelValueLength(userID string) int {
 // MaxLabelNamesPerSeries returns maximum number of label/value pairs timeseries.
 func (o *Overrides) MaxLabelNamesPerSeries(userID string) int {
 	return o.getOverridesForUser(userID).MaxLabelNamesPerSeries
+}
+
+// MaxLabelsSizeBytes returns maximum number of label/value pairs timeseries.
+func (o *Overrides) MaxLabelsSizeBytes(userID string) int {
+	return o.getOverridesForUser(userID).MaxLabelsSizeBytes
 }
 
 // MaxMetadataLength returns maximum length metadata can be. Metadata refers

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -92,21 +92,25 @@ func TestOverridesManager_GetOverrides(t *testing.T) {
 
 	require.Equal(t, 100, ov.MaxLabelNamesPerSeries("user1"))
 	require.Equal(t, 0, ov.MaxLabelValueLength("user1"))
+	require.Equal(t, 0, ov.MaxLabelsSizeBytes("user1"))
 
 	// Update limits for tenant user1. We only update single field, the rest is copied from defaults.
 	// (That is how limits work when loaded from YAML)
 	l := defaults
 	l.MaxLabelValueLength = 150
+	l.MaxLabelsSizeBytes = 10
 
 	tenantLimits["user1"] = &l
 
 	// Checking whether overrides were enforced
 	require.Equal(t, 100, ov.MaxLabelNamesPerSeries("user1"))
 	require.Equal(t, 150, ov.MaxLabelValueLength("user1"))
+	require.Equal(t, 10, ov.MaxLabelsSizeBytes("user1"))
 
 	// Verifying user2 limits are not impacted by overrides
 	require.Equal(t, 100, ov.MaxLabelNamesPerSeries("user2"))
 	require.Equal(t, 0, ov.MaxLabelValueLength("user2"))
+	require.Equal(t, 0, ov.MaxLabelsSizeBytes("user2"))
 }
 
 func TestLimitsLoadingFromYaml(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: 🌲 Harry 🌊 John 🏔 <johrry@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR introduces a new limit `max_series_label_size_bytes`.
Currently, it is possible for users of Cortex to OOM kill distributors and ingesters by increasing the size of each label and label value. For instance, a user can send 1 million series with each series having 30 labels of maximum size. `1 million * 30 labels * 3 KB per label = 85 GB`.

This new limit can prevent this from happening by rejecting series that have a combined label size greater than this limit.
Example: if the `max_series_label_size_bytes` is set to 10 KB, any series that exceed will be rejected. 1 million active series for a user will consume `1 million * 10 KB = 9 GB`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
