### PR TITLE
Using tls client config as the other clients on cortex

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3989,10 +3989,6 @@ otel:
   # CLI flag: -tracing.otel.oltp-endpoint
   [oltp_endpoint: <string> | default = ""]
 
-  # Disables client transport security for the exporter.
-  # CLI flag: -tracing.otel.insecure
-  [insecure: <boolean> | default = false]
-
   # enhance/modify traces/propagators for specific exporter. If empty, OTEL
   # defaults will apply. Supported values are: `awsxray.`
   # CLI flag: -tracing.otel.exporter-type
@@ -4002,4 +3998,34 @@ otel:
   # everything is traced.
   # CLI flag: -tracing.otel.sample-ration
   [sample_ratio: <float> | default = 0.001]
+
+  # Enable TLS in the GRPC client. This flag needs to be enabled when any other
+  # TLS flag is set. If set to false, insecure connection to gRPC server will be
+  # used.
+  # CLI flag: -tracing.otel.tls-enabled
+  [tls_enabled: <boolean> | default = false]
+
+  tls:
+    # Path to the client certificate file, which will be used for authenticating
+    # with the server. Also requires the key path to be configured.
+    # CLI flag: -tracing.otel.tls.tls-cert-path
+    [tls_cert_path: <string> | default = ""]
+
+    # Path to the key file for the client certificate. Also requires the client
+    # certificate to be configured.
+    # CLI flag: -tracing.otel.tls.tls-key-path
+    [tls_key_path: <string> | default = ""]
+
+    # Path to the CA certificates file to validate server certificate against.
+    # If not set, the host's root CA certificates are used.
+    # CLI flag: -tracing.otel.tls.tls-ca-path
+    [tls_ca_path: <string> | default = ""]
+
+    # Override the expected name on the server certificate.
+    # CLI flag: -tracing.otel.tls.tls-server-name
+    [tls_server_name: <string> | default = ""]
+
+    # Skip validating server certificate.
+    # CLI flag: -tracing.otel.tls.tls-insecure-skip-verify
+    [tls_insecure_skip_verify: <boolean> | default = false]
 ```

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -2,20 +2,22 @@ package tracing
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"strings"
 
+	"github.com/cortexproject/cortex/pkg/util/tls"
 	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
 	"github.com/weaveworks/common/tracing"
-	"go.opentelemetry.io/otel/propagation"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/opentracing/opentracing-go"
 	"go.opentelemetry.io/contrib/propagators/aws/xray"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
@@ -35,10 +37,11 @@ type Config struct {
 }
 
 type Otel struct {
-	OltpEndpoint string  `yaml:"oltp_endpoint" json:"oltp_endpoint"`
-	Insecure     bool    `yaml:"insecure" json:"insecure"`
-	ExporterType string  `yaml:"exporter_type" json:"exporter_type"`
-	SampleRatio  float64 `yaml:"sample_ratio" json:"sample_ratio"`
+	OltpEndpoint string           `yaml:"oltp_endpoint" json:"oltp_endpoint"`
+	ExporterType string           `yaml:"exporter_type" json:"exporter_type"`
+	SampleRatio  float64          `yaml:"sample_ratio" json:"sample_ratio"`
+	TLSEnabled   bool             `yaml:"tls_enabled"`
+	Tls          tls.ClientConfig `yaml:"tls"`
 }
 
 // RegisterFlags registers flag.
@@ -47,8 +50,9 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&c.Type, p+".type", JaegerType, "Tracing type. OTEL and JAEGER are currently supported. For jaeger `JAEGER_AGENT_HOST` environment variable should also be set. See: https://cortexmetrics.io/docs/guides/tracing .")
 	f.Float64Var(&c.Otel.SampleRatio, p+".otel.sample-ration", 0.001, "Fraction of traces to be sampled. Fractions >= 1 means sampling if off and everything is traced.")
 	f.StringVar(&c.Otel.OltpEndpoint, p+".otel.oltp-endpoint", "", "otl collector endpoint that the driver will use to send spans.")
-	f.BoolVar(&c.Otel.Insecure, p+".otel.insecure", false, "Disables client transport security for the exporter.")
 	f.StringVar(&c.Otel.ExporterType, p+".otel.exporter-type", "", "enhance/modify traces/propagators for specific exporter. If empty, OTEL defaults will apply. Supported values are: `awsxray.`")
+	f.BoolVar(&c.Otel.TLSEnabled, p+".otel.tls-enabled", c.Otel.TLSEnabled, "Enable TLS in the GRPC client. This flag needs to be enabled when any other TLS flag is set. If set to false, insecure connection to gRPC server will be used.")
+	c.Otel.Tls.RegisterFlagsWithPrefix(p+".otel.tls", f)
 }
 
 func (c *Config) Validate() error {
@@ -81,7 +85,13 @@ func SetupTracing(ctx context.Context, name string, c Config) (func(context.Cont
 			otlptracegrpc.WithEndpoint(c.Otel.OltpEndpoint),
 		}
 
-		if c.Otel.Insecure {
+		if c.Otel.TLSEnabled {
+			tlsConfig, err := c.Otel.Tls.GetTLSConfig()
+			if err != nil {
+				return nil, errors.Wrap(err, "error creating grpc dial options")
+			}
+			options = append(options, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig)))
+		} else {
 			options = append(options, otlptracegrpc.WithInsecure())
 		}
 

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cortexproject/cortex/pkg/util/tls"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/weaveworks/common/tracing"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/tracing/migration"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/cortexproject/cortex/pkg/util/tls"
 )
 
 const (
@@ -41,7 +41,7 @@ type Otel struct {
 	ExporterType string           `yaml:"exporter_type" json:"exporter_type"`
 	SampleRatio  float64          `yaml:"sample_ratio" json:"sample_ratio"`
 	TLSEnabled   bool             `yaml:"tls_enabled"`
-	Tls          tls.ClientConfig `yaml:"tls"`
+	TLS          tls.ClientConfig `yaml:"tls"`
 }
 
 // RegisterFlags registers flag.
@@ -52,7 +52,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&c.Otel.OltpEndpoint, p+".otel.oltp-endpoint", "", "otl collector endpoint that the driver will use to send spans.")
 	f.StringVar(&c.Otel.ExporterType, p+".otel.exporter-type", "", "enhance/modify traces/propagators for specific exporter. If empty, OTEL defaults will apply. Supported values are: `awsxray.`")
 	f.BoolVar(&c.Otel.TLSEnabled, p+".otel.tls-enabled", c.Otel.TLSEnabled, "Enable TLS in the GRPC client. This flag needs to be enabled when any other TLS flag is set. If set to false, insecure connection to gRPC server will be used.")
-	c.Otel.Tls.RegisterFlagsWithPrefix(p+".otel.tls", f)
+	c.Otel.TLS.RegisterFlagsWithPrefix(p+".otel.tls", f)
 }
 
 func (c *Config) Validate() error {
@@ -86,7 +86,7 @@ func SetupTracing(ctx context.Context, name string, c Config) (func(context.Cont
 		}
 
 		if c.Otel.TLSEnabled {
-			tlsConfig, err := c.Otel.Tls.GetTLSConfig()
+			tlsConfig, err := c.Otel.TLS.GetTLSConfig()
 			if err != nil {
 				return nil, errors.Wrap(err, "error creating grpc dial options")
 			}


### PR DESCRIPTION
**What this PR does**:
Use the existing TLS config as the other clients as, for example:

https://github.com/cortexproject/cortex/blob/04bb64dcb3842fd11a9b46e2ca9666eb3e0681a7/pkg/alertmanager/alertmanager_client.go#L35-L40

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
