### PR TITLE
Respecting `-tracing.otel.sample-ratio` configuration when enabling OpenTelemetry tracing with X-ray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * [FEATURE] Storage/Bucket: Added `-*.s3.bucket-lookup-type` allowing to configure the s3 bucket lookup type. #4794
 * [BUGFIX] Memberlist: Add join with no retrying when starting service. #4804
 * [BUGFIX] Ruler: Fix /ruler/rule_groups returns YAML with extra fields. #4767
+* [BUGFIX] Respecting `-tracing.otel.sample-ratio` configuration when enabling OpenTelemetry tracing with X-ray. #4862
 
 ## 1.13.0 2022-07-14
 

--- a/pkg/tracing/sampler/sampling.go
+++ b/pkg/tracing/sampler/sampling.go
@@ -12,12 +12,17 @@ type randGenerator interface {
 }
 
 type RandomRatioBased struct {
+	sdktrace.Sampler
 	rnd      randGenerator
 	fraction float64
 }
 
+// NewRandomRatioBased crea
+// fraction parameter should be between 0 and 1 where:
+// fraction >= 1 it will always sample
+// fraction <= 0 it will never sample
 func NewRandomRatioBased(fraction float64, rnd randGenerator) sdktrace.Sampler {
-	if fraction > 1 {
+	if fraction >= 1 {
 		return sdktrace.AlwaysSample()
 	} else if fraction <= 0 {
 		return sdktrace.NeverSample()

--- a/pkg/tracing/sampler/sampling.go
+++ b/pkg/tracing/sampler/sampling.go
@@ -11,22 +11,22 @@ type randGenerator interface {
 	Float64() float64
 }
 
-type RandTraceIDRatioBased struct {
+type RandomRatioBased struct {
 	rnd      randGenerator
 	fraction float64
 }
 
-func NewRandTraceIDRatioBased(fraction float64, rnd randGenerator) sdktrace.Sampler {
+func NewRandomRatioBased(fraction float64, rnd randGenerator) sdktrace.Sampler {
 	if fraction > 1 {
 		return sdktrace.AlwaysSample()
 	} else if fraction <= 0 {
 		return sdktrace.NeverSample()
 	}
 
-	return &RandTraceIDRatioBased{rnd: rnd, fraction: fraction}
+	return &RandomRatioBased{rnd: rnd, fraction: fraction}
 }
 
-func (s *RandTraceIDRatioBased) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
+func (s *RandomRatioBased) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
 	psc := trace.SpanContextFromContext(p.ParentContext)
 	shouldSample := s.rnd.Float64() < s.fraction
 	if shouldSample {
@@ -41,6 +41,6 @@ func (s *RandTraceIDRatioBased) ShouldSample(p sdktrace.SamplingParameters) sdkt
 	}
 }
 
-func (s *RandTraceIDRatioBased) Description() string {
-	return fmt.Sprintf("RandTraceIDRatioBased{%g}", s.fraction)
+func (s *RandomRatioBased) Description() string {
+	return fmt.Sprintf("RandomRatioBased{%g}", s.fraction)
 }

--- a/pkg/tracing/sampler/sampling.go
+++ b/pkg/tracing/sampler/sampling.go
@@ -1,0 +1,46 @@
+package sampler
+
+import (
+	"fmt"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type randGenerator interface {
+	Float64() float64
+}
+
+type RandTraceIDRatioBased struct {
+	rnd      randGenerator
+	fraction float64
+}
+
+func NewRandTraceIDRatioBased(fraction float64, rnd randGenerator) sdktrace.Sampler {
+	if fraction > 1 {
+		return sdktrace.AlwaysSample()
+	} else if fraction <= 0 {
+		return sdktrace.NeverSample()
+	}
+
+	return &RandTraceIDRatioBased{rnd: rnd, fraction: fraction}
+}
+
+func (s *RandTraceIDRatioBased) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
+	psc := trace.SpanContextFromContext(p.ParentContext)
+	shouldSample := s.rnd.Float64() < s.fraction
+	if shouldSample {
+		return sdktrace.SamplingResult{
+			Decision:   sdktrace.RecordAndSample,
+			Tracestate: psc.TraceState(),
+		}
+	}
+	return sdktrace.SamplingResult{
+		Decision:   sdktrace.Drop,
+		Tracestate: psc.TraceState(),
+	}
+}
+
+func (s *RandTraceIDRatioBased) Description() string {
+	return fmt.Sprintf("RandTraceIDRatioBased{%g}", s.fraction)
+}

--- a/pkg/tracing/sampler/sampling_test.go
+++ b/pkg/tracing/sampler/sampling_test.go
@@ -1,0 +1,79 @@
+package sampler
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type mockGenerator struct {
+	mockedValue float64
+}
+
+func (g *mockGenerator) Float64() float64 {
+	return g.mockedValue
+}
+
+func Test_ShouldSample(t *testing.T) {
+	traceID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	parentCtx := trace.ContextWithSpanContext(
+		context.Background(),
+		trace.NewSpanContext(trace.SpanContextConfig{
+			TraceState: trace.TraceState{},
+		}),
+	)
+
+	tests := []struct {
+		name             string
+		samplingDecision sdktrace.SamplingDecision
+		fraction         float64
+		generator        randGenerator
+	}{
+		{
+			name:             "should always sample",
+			samplingDecision: sdktrace.RecordAndSample,
+			fraction:         1,
+			generator:        rand.New(rand.NewSource(rand.Int63())),
+		},
+		{
+			name:             "should nerver sample",
+			samplingDecision: sdktrace.Drop,
+			fraction:         0,
+			generator:        rand.New(rand.NewSource(rand.Int63())),
+		},
+		{
+			name:             "should sample when fraction is above generated",
+			samplingDecision: sdktrace.RecordAndSample,
+			fraction:         0.5,
+			generator:        &mockGenerator{0.2},
+		},
+		{
+			name:             "should not sample when fraction is not above generated",
+			samplingDecision: sdktrace.Drop,
+			fraction:         0.5,
+			generator:        &mockGenerator{0.8},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewRandTraceIDRatioBased(tt.fraction, tt.generator)
+			for i := 0; i < 100; i++ {
+
+				r := s.ShouldSample(
+					sdktrace.SamplingParameters{
+						ParentContext: parentCtx,
+						TraceID:       traceID,
+						Name:          "test",
+						Kind:          trace.SpanKindServer,
+					})
+
+				require.Equal(t, tt.samplingDecision, r.Decision)
+			}
+		})
+	}
+}

--- a/pkg/tracing/sampler/sampling_test.go
+++ b/pkg/tracing/sampler/sampling_test.go
@@ -61,7 +61,7 @@ func Test_ShouldSample(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewRandTraceIDRatioBased(tt.fraction, tt.generator)
+			s := NewRandomRatioBased(tt.fraction, tt.generator)
 			for i := 0; i < 100; i++ {
 
 				r := s.ShouldSample(

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
@@ -126,7 +127,7 @@ func newTraceProvider(name string, c Config, exporter *otlptrace.Exporter) *sdkt
 	switch strings.ToLower(c.Otel.ExporterType) {
 	case "awsxray":
 		options = append(options, sdktrace.WithIDGenerator(xray.NewIDGenerator()))
-		options = append(options, sdktrace.WithSampler(sdktrace.ParentBased(sampler.NewRandTraceIDRatioBased(c.Otel.SampleRatio, rand.New(rand.NewSource(rand.Int63()))))))
+		options = append(options, sdktrace.WithSampler(sdktrace.ParentBased(sampler.NewRandomRatioBased(c.Otel.SampleRatio, rand.New(rand.NewSource(time.Now().Unix()))))))
 	default:
 		options = append(options, sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(c.Otel.SampleRatio))))
 	}


### PR DESCRIPTION
**What this PR does**:
Creates a simple sampler as the `TraceIDRatioBased` does not work well with xray generated Ids.

See: https://pkg.go.dev/go.opentelemetry.io/contrib/propagators/aws/xray#section-readme

```
It is a general suggestion to not use the traceIDRatioSampler while also using the X-Ray IDGenerator. The non-random nature of building an X-Ray traceId may lead to unexpected sampling results.
```

This sampler simple randomly pick traces to be sampled based on the fraction received as parameter. The sample decision is then propagated via the `parentBased` sampler.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
