### PR TITLE
Add release 1.11.1 to the backwards compatibility matrix

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -130,6 +130,7 @@ jobs:
           docker pull quay.io/cortexproject/cortex:v1.8.0
           docker pull quay.io/cortexproject/cortex:v1.9.0
           docker pull quay.io/cortexproject/cortex:v1.10.0
+          docker pull quay.io/cortexproject/cortex:v1.11.1
           docker pull shopify/bigtable-emulator:0.1.0
           docker pull memcached:1.6.1
           docker pull bouncestorage/swift-aio:55ba4331

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -26,6 +26,7 @@ var (
 		"quay.io/cortexproject/cortex:v1.8.0":  preCortex110Flags,
 		"quay.io/cortexproject/cortex:v1.9.0":  preCortex110Flags,
 		"quay.io/cortexproject/cortex:v1.10.0": nil,
+		"quay.io/cortexproject/cortex:v1.11.1": nil,
 	}
 )
 


### PR DESCRIPTION
This normally was done after release, let's see how can we pick it up.


Update: Looks like it worked on the first try :)