### PR TITLE
Using `sortSeries` from Select to decided to sort the response on DistributorQueryable

### DIFF
--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -85,7 +85,7 @@ type distributorQuerier struct {
 
 // Select implements storage.Querier interface.
 // The bool passed is ignored because the series is always sorted.
-func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+func (q *distributorQuerier) Select(sortSeries bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 	log, ctx := spanlogger.New(q.ctx, "distributorQuerier.Select")
 	defer log.Span.Finish()
 
@@ -116,7 +116,7 @@ func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 		if err != nil {
 			return storage.ErrSeriesSet(err)
 		}
-		return series.MetricsToSeriesSet(ms)
+		return series.MetricsToSeriesSet(sortSeries, ms)
 	}
 
 	// If queryIngestersWithin is enabled, we do manipulate the query mint to query samples up until
@@ -139,7 +139,7 @@ func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 	}
 
 	if q.streaming {
-		return q.streamingSelect(ctx, minT, maxT, matchers)
+		return q.streamingSelect(ctx, sortSeries, minT, maxT, matchers)
 	}
 
 	matrix, err := q.distributor.Query(ctx, model.Time(minT), model.Time(maxT), matchers...)
@@ -148,10 +148,10 @@ func (q *distributorQuerier) Select(_ bool, sp *storage.SelectHints, matchers ..
 	}
 
 	// Using MatrixToSeriesSet (and in turn NewConcreteSeriesSet), sorts the series.
-	return series.MatrixToSeriesSet(matrix)
+	return series.MatrixToSeriesSet(sortSeries, matrix)
 }
 
-func (q *distributorQuerier) streamingSelect(ctx context.Context, minT, maxT int64, matchers []*labels.Matcher) storage.SeriesSet {
+func (q *distributorQuerier) streamingSelect(ctx context.Context, sortSeries bool, minT, maxT int64, matchers []*labels.Matcher) storage.SeriesSet {
 	results, err := q.distributor.QueryStream(ctx, model.Time(minT), model.Time(maxT), matchers...)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
@@ -170,7 +170,6 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, minT, maxT int
 		}
 
 		ls := cortexpb.FromLabelAdaptersToLabels(result.Labels)
-		sort.Sort(ls)
 
 		chunks, err := chunkcompat.FromChunks(ls, result.Chunks)
 		if err != nil {
@@ -187,7 +186,7 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, minT, maxT int
 	}
 
 	if len(serieses) > 0 {
-		sets = append(sets, series.NewConcreteSeriesSet(serieses))
+		sets = append(sets, series.NewConcreteSeriesSet(sortSeries, serieses))
 	}
 
 	if len(sets) == 0 {

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -148,7 +148,7 @@ func (q *distributorQuerier) Select(sortSeries bool, sp *storage.SelectHints, ma
 	}
 
 	// Using MatrixToSeriesSet (and in turn NewConcreteSeriesSet), sorts the series.
-	return series.MatrixToSeriesSet(true, matrix)
+	return series.MatrixToSeriesSet(sortSeries, matrix)
 }
 
 func (q *distributorQuerier) streamingSelect(ctx context.Context, sortSeries bool, minT, maxT int64, matchers []*labels.Matcher) storage.SeriesSet {

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -159,7 +159,7 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, sortSeries boo
 
 	sets := []storage.SeriesSet(nil)
 	if len(results.Timeseries) > 0 {
-		sets = append(sets, newTimeSeriesSeriesSet(results.Timeseries))
+		sets = append(sets, newTimeSeriesSeriesSet(sortSeries, results.Timeseries))
 	}
 
 	serieses := make([]storage.Series, 0, len(results.Chunkseries))

--- a/pkg/querier/duplicates_test.go
+++ b/pkg/querier/duplicates_test.go
@@ -85,7 +85,7 @@ func dedupeSorted(samples []cortexpb.Sample) []cortexpb.Sample {
 }
 
 func runPromQLAndGetJSONResult(t *testing.T, query string, ts cortexpb.TimeSeries, step time.Duration) string {
-	tq := &testQueryable{ts: newTimeSeriesSeriesSet([]cortexpb.TimeSeries{ts})}
+	tq := &testQueryable{ts: newTimeSeriesSeriesSet(true, []cortexpb.TimeSeries{ts})}
 
 	engine := promql.NewEngine(promql.EngineOpts{
 		Logger:     log.NewNopLogger(),

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -359,6 +359,7 @@ func (q querier) Select(sortSeries bool, sp *storage.SelectHints, matchers ...*l
 	sets := make(chan storage.SeriesSet, len(q.queriers))
 	for _, querier := range q.queriers {
 		go func(querier storage.Querier) {
+			// We should always select sorted here as we will need to merge the series
 			sets <- querier.Select(true, sp, matchers...)
 		}(querier)
 	}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -359,7 +359,7 @@ func (q querier) Select(sortSeries bool, sp *storage.SelectHints, matchers ...*l
 	sets := make(chan storage.SeriesSet, len(q.queriers))
 	for _, querier := range q.queriers {
 		go func(querier storage.Querier) {
-			sets <- querier.Select(sortSeries, sp, matchers...)
+			sets <- querier.Select(true, sp, matchers...)
 		}(querier)
 	}
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -655,5 +655,5 @@ func partitionChunks(chunks []chunk.Chunk, mint, maxt int64, iteratorFunc chunkI
 		})
 	}
 
-	return seriesset.NewConcreteSeriesSet(series)
+	return seriesset.NewConcreteSeriesSet(true, series)
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -288,7 +288,7 @@ type querier struct {
 
 // Select implements storage.Querier interface.
 // The bool passed is ignored because the series is always sorted.
-func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+func (q querier) Select(sortSeries bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 	log, ctx := spanlogger.New(q.ctx, "querier.Select")
 	defer log.Span.Finish()
 
@@ -347,7 +347,7 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 	}
 
 	if len(q.queriers) == 1 {
-		seriesSet := q.queriers[0].Select(true, sp, matchers...)
+		seriesSet := q.queriers[0].Select(sortSeries, sp, matchers...)
 
 		if tombstones.Len() != 0 {
 			seriesSet = series.NewDeletedSeriesSet(seriesSet, tombstones, model.Interval{Start: startTime, End: endTime})
@@ -359,7 +359,7 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 	sets := make(chan storage.SeriesSet, len(q.queriers))
 	for _, querier := range q.queriers {
 		go func(querier storage.Querier) {
-			sets <- querier.Select(true, sp, matchers...)
+			sets <- querier.Select(sortSeries, sp, matchers...)
 		}(querier)
 	}
 

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -90,11 +90,11 @@ type mockQuerier struct {
 	matrix model.Matrix
 }
 
-func (m mockQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+func (m mockQuerier) Select(sortSeries bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 	if sp == nil {
 		panic(fmt.Errorf("select params must be set"))
 	}
-	return series.MatrixToSeriesSet(m.matrix)
+	return series.MatrixToSeriesSet(sortSeries, m.matrix)
 }
 
 func (m mockQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {

--- a/pkg/querier/series/series_set.go
+++ b/pkg/querier/series/series_set.go
@@ -35,9 +35,11 @@ type ConcreteSeriesSet struct {
 }
 
 // NewConcreteSeriesSet instantiates an in-memory series set from a series
-// Series will be sorted by labels.
-func NewConcreteSeriesSet(series []storage.Series) storage.SeriesSet {
-	sort.Sort(byLabels(series))
+// Series will be sorted by labels if sortSeries is set.
+func NewConcreteSeriesSet(sortSeries bool, series []storage.Series) storage.SeriesSet {
+	if sortSeries {
+		sort.Sort(byLabels(series))
+	}
 	return &ConcreteSeriesSet{
 		cur:    -1,
 		series: series,
@@ -151,8 +153,8 @@ func (e errIterator) Err() error {
 }
 
 // MatrixToSeriesSet creates a storage.SeriesSet from a model.Matrix
-// Series will be sorted by labels.
-func MatrixToSeriesSet(m model.Matrix) storage.SeriesSet {
+// Series will be sorted by labels if sortSeries is set.
+func MatrixToSeriesSet(sortSeries bool, m model.Matrix) storage.SeriesSet {
 	series := make([]storage.Series, 0, len(m))
 	for _, ss := range m {
 		series = append(series, &ConcreteSeries{
@@ -160,11 +162,11 @@ func MatrixToSeriesSet(m model.Matrix) storage.SeriesSet {
 			samples: ss.Values,
 		})
 	}
-	return NewConcreteSeriesSet(series)
+	return NewConcreteSeriesSet(sortSeries, series)
 }
 
 // MetricsToSeriesSet creates a storage.SeriesSet from a []metric.Metric
-func MetricsToSeriesSet(ms []metric.Metric) storage.SeriesSet {
+func MetricsToSeriesSet(sortSeries bool, ms []metric.Metric) storage.SeriesSet {
 	series := make([]storage.Series, 0, len(ms))
 	for _, m := range ms {
 		series = append(series, &ConcreteSeries{
@@ -172,7 +174,7 @@ func MetricsToSeriesSet(ms []metric.Metric) storage.SeriesSet {
 			samples: nil,
 		})
 	}
-	return NewConcreteSeriesSet(series)
+	return NewConcreteSeriesSet(sortSeries, series)
 }
 
 func metricToLabels(m model.Metric) labels.Labels {

--- a/pkg/querier/series/series_set_test.go
+++ b/pkg/querier/series/series_set_test.go
@@ -19,7 +19,7 @@ func TestConcreteSeriesSet(t *testing.T) {
 		labels:  labels.FromStrings("foo", "baz"),
 		samples: []model.SamplePair{{Value: 3, Timestamp: 4}},
 	}
-	c := NewConcreteSeriesSet([]storage.Series{series2, series1})
+	c := NewConcreteSeriesSet(true, []storage.Series{series2, series1})
 	require.True(t, c.Next())
 	require.Equal(t, series1, c.At())
 	require.True(t, c.Next())
@@ -40,7 +40,7 @@ func TestMatrixToSeriesSetSortsMetricLabels(t *testing.T) {
 			Values: []model.SamplePair{{Timestamp: 0, Value: 0}},
 		},
 	}
-	ss := MatrixToSeriesSet(matrix)
+	ss := MatrixToSeriesSet(true, matrix)
 	require.True(t, ss.Next())
 	require.NoError(t, ss.Err())
 

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -172,7 +172,7 @@ func (m mockTenantQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*
 	}
 
 	return &mockSeriesSet{
-		upstream: series.MatrixToSeriesSet(matrix),
+		upstream: series.MatrixToSeriesSet(false, matrix),
 		warnings: m.warnings,
 		queryErr: m.queryErr,
 	}

--- a/pkg/querier/timeseries_series_set.go
+++ b/pkg/querier/timeseries_series_set.go
@@ -16,8 +16,11 @@ type timeSeriesSeriesSet struct {
 	i  int
 }
 
-func newTimeSeriesSeriesSet(series []cortexpb.TimeSeries) *timeSeriesSeriesSet {
-	sort.Sort(byTimeSeriesLabels(series))
+func newTimeSeriesSeriesSet(sortSeries bool, series []cortexpb.TimeSeries) *timeSeriesSeriesSet {
+	if sortSeries {
+		sort.Sort(byTimeSeriesLabels(series))
+	}
+
 	return &timeSeriesSeriesSet{
 		ts: series,
 		i:  -1,

--- a/pkg/querier/timeseries_series_set_test.go
+++ b/pkg/querier/timeseries_series_set_test.go
@@ -27,7 +27,7 @@ func TestTimeSeriesSeriesSet(t *testing.T) {
 		},
 	}
 
-	ss := newTimeSeriesSeriesSet(timeseries)
+	ss := newTimeSeriesSeriesSet(true, timeseries)
 
 	require.True(t, ss.Next())
 	series := ss.At()
@@ -47,7 +47,7 @@ func TestTimeSeriesSeriesSet(t *testing.T) {
 		Value:       1.618,
 		TimestampMs: 2345,
 	})
-	ss = newTimeSeriesSeriesSet(timeseries)
+	ss = newTimeSeriesSeriesSet(true, timeseries)
 
 	require.True(t, ss.Next())
 	it = ss.At().Iterator()

--- a/pkg/querier/tripperware/queryrange/series_test.go
+++ b/pkg/querier/tripperware/queryrange/series_test.go
@@ -53,7 +53,7 @@ func Test_ResponseToSamples(t *testing.T) {
 
 	streams, err := ResponseToSamples(input)
 	require.Nil(t, err)
-	set := NewSeriesSet(streams)
+	set := NewSeriesSet(false, streams)
 
 	setCt := 0
 

--- a/pkg/querier/tripperware/queryrange/value.go
+++ b/pkg/querier/tripperware/queryrange/value.go
@@ -104,7 +104,7 @@ func ResponseToSamples(resp tripperware.Response) ([]tripperware.SampleStream, e
 
 // NewSeriesSet returns an in memory storage.SeriesSet from a []SampleStream
 // As NewSeriesSet uses NewConcreteSeriesSet to implement SeriesSet, result will be sorted by label names.
-func NewSeriesSet(results []tripperware.SampleStream) storage.SeriesSet {
+func NewSeriesSet(sortSeries bool, results []tripperware.SampleStream) storage.SeriesSet {
 	set := make([]storage.Series, 0, len(results))
 
 	for _, stream := range results {
@@ -122,5 +122,5 @@ func NewSeriesSet(results []tripperware.SampleStream) storage.SeriesSet {
 		}
 		set = append(set, series.NewConcreteSeries(ls, samples))
 	}
-	return series.NewConcreteSeriesSet(set)
+	return series.NewConcreteSeriesSet(sortSeries, set)
 }


### PR DESCRIPTION
**What this PR does**:

We are always sorting the response even when its not needed.

We still need to sort the series if we are querying multiples backends (ex: ingesters + store-gateways) as the result needs to be sorted in order to be merged [here](https://github.com/cortexproject/cortex/blob/28a8a37efb94ffd1f5482f4f58667f144fc456b3/pkg/querier/querier.go#L388).

#### Why we don't need to sort when querying only one backend?

* Each backend should be responsible to not returning duplicated timeseries:
   * When querying ingesters the dedup happens [here](https://github.com/cortexproject/cortex/blob/28a8a37efb94ffd1f5482f4f58667f144fc456b3/pkg/distributor/query.go#L356-L380)
  * When querying store gateways this flag is [ignored](https://github.com/cortexproject/cortex/blob/28a8a37efb94ffd1f5482f4f58667f144fc456b3/pkg/querier/blocks_store_queryable.go#L321) as the series are already sorted on tsdb
 
#### Why sorting matters?

This sort can add considerable latency when fetching millions of timeseries  as it have to sort all those using those tags.

Prometheus itself does similar thing on the remote_read code:

https://github.com/prometheus/prometheus/blob/d56d0a9d52c8614fdf1c5c652061929ede562f3e/storage/remote/read.go#L174

https://github.com/prometheus/prometheus/blob/d56d0a9d52c8614fdf1c5c652061929ede562f3e/storage/remote/codec.go#L148-L164


Im also removing [this](https://github.com/cortexproject/cortex/blob/dd4240d6d02a48bdd732b57a266b0c4192bb5e1e/pkg/querier/distributor_queryable.go#L173) extra sort as it seems to not be needed as both ingesters and store-gateways should return the labels already sorted as we already make this assumption in other places like [here](https://github.com/cortexproject/cortex/blob/dd4240d6d02a48bdd732b57a266b0c4192bb5e1e/pkg/distributor/query.go#L361) and [here](https://github.com/cortexproject/cortex/blob/dd4240d6d02a48bdd732b57a266b0c4192bb5e1e/pkg/ingester/client/compat.go#L244-L250)

This change will also benefit GetSeries when update prometheus: See https://github.com/prometheus/prometheus/issues/11311

before/after: 

![Screen Shot 2022-09-16 at 4 13 55 PM](https://user-images.githubusercontent.com/4027760/190829378-9e34c708-4daf-463c-bdfc-c98a73e94364.png)
![Screen Shot 2022-09-16 at 4 14 08 PM](https://user-images.githubusercontent.com/4027760/190829403-82e83e90-ac65-4bf9-955b-d09453888f9e.png)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
