### PR TITLE
Ignore not found errors when compacting users

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -733,6 +733,11 @@ func (c *Compactor) compactUserWithRetries(ctx context.Context, userID string) e
 
 func (c *Compactor) compactUser(ctx context.Context, userID string) error {
 	bucket := bucket.NewUserBucketClient(userID, c.bucketClient, c.cfgProvider)
+
+	if ib, ok := bucket.WithExpectedErrs(bucket.IsObjNotFoundErr).(objstore.InstrumentedBucket); ok {
+		bucket = ib
+	}
+
 	reg := prometheus.NewRegistry()
 	defer c.syncerMetrics.gatherThanosSyncerMetrics(reg)
 


### PR DESCRIPTION
Signed-off-by: Alan Protasio <approtas@amazon.com>
**What this PR does**:

Ignore not found errors when compacting users.

https://github.com/cortexproject/cortex/pull/4805 introduced a new markers that is being called on the shuffle sharding grouper and  its expected to receive 404, causing `thanos_objstore_bucket_operation_failures_total` metric to spike.

With this change, we should not count 404s towards `thanos_objstore_bucket_operation_failures_total`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [NA] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
