### PR TITLE
Follow up of 4870 - Ignore 404 on `thanos_objstore_bucket_operation_failures_total` only when fetching the markers

### DIFF
--- a/pkg/compactor/block_visit_marker.go
+++ b/pkg/compactor/block_visit_marker.go
@@ -38,9 +38,9 @@ func (b *BlockVisitMarker) isVisitedByCompactor(blockVisitMarkerTimeout time.Dur
 	return time.Now().Before(b.VisitTime.Add(blockVisitMarkerTimeout)) && b.CompactorID == compactorID
 }
 
-func ReadBlockVisitMarker(ctx context.Context, bkt objstore.Bucket, blockID string, blockVisitMarkerReadFailed prometheus.Counter) (*BlockVisitMarker, error) {
+func ReadBlockVisitMarker(ctx context.Context, bkt objstore.InstrumentedBucketReader, blockID string, blockVisitMarkerReadFailed prometheus.Counter) (*BlockVisitMarker, error) {
 	visitMarkerFile := path.Join(blockID, BlockVisitMarkerFile)
-	visitMarkerFileReader, err := bkt.Get(ctx, visitMarkerFile)
+	visitMarkerFileReader, err := bkt.ReaderWithExpectedErrs(bkt.IsObjNotFoundErr).Get(ctx, visitMarkerFile)
 	if err != nil {
 		if bkt.IsObjNotFoundErr(err) {
 			return nil, errors.Wrapf(ErrorBlockVisitMarkerNotFound, "block visit marker file: %s", visitMarkerFile)

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1538,7 +1538,7 @@ func prepare(t *testing.T, compactorCfg Config, bucketClient objstore.Bucket, li
 
 	blocksCompactorFactory := func(ctx context.Context, cfg Config, logger log.Logger, reg prometheus.Registerer) (compact.Compactor, PlannerFactory, error) {
 		return tsdbCompactor,
-			func(ctx context.Context, bkt objstore.Bucket, _ log.Logger, _ Config, noCompactMarkFilter *compact.GatherNoCompactionMarkFilter, ringLifecycle *ring.Lifecycler, _ prometheus.Counter, _ prometheus.Counter) compact.Planner {
+			func(ctx context.Context, bkt objstore.InstrumentedBucket, _ log.Logger, _ Config, noCompactMarkFilter *compact.GatherNoCompactionMarkFilter, ringLifecycle *ring.Lifecycler, _ prometheus.Counter, _ prometheus.Counter) compact.Planner {
 				tsdbPlanner.noCompactMarkFilters = append(tsdbPlanner.noCompactMarkFilters, noCompactMarkFilter)
 				return tsdbPlanner
 			},

--- a/pkg/compactor/shuffle_sharding_grouper.go
+++ b/pkg/compactor/shuffle_sharding_grouper.go
@@ -25,7 +25,7 @@ import (
 type ShuffleShardingGrouper struct {
 	ctx                         context.Context
 	logger                      log.Logger
-	bkt                         objstore.Bucket
+	bkt                         objstore.InstrumentedBucket
 	acceptMalformedIndex        bool
 	enableVerticalCompaction    bool
 	reg                         prometheus.Registerer
@@ -58,7 +58,7 @@ type ShuffleShardingGrouper struct {
 func NewShuffleShardingGrouper(
 	ctx context.Context,
 	logger log.Logger,
-	bkt objstore.Bucket,
+	bkt objstore.InstrumentedBucket,
 	acceptMalformedIndex bool,
 	enableVerticalCompaction bool,
 	reg prometheus.Registerer,

--- a/pkg/compactor/shuffle_sharding_grouper_test.go
+++ b/pkg/compactor/shuffle_sharding_grouper_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/thanos-io/objstore"
 
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -368,7 +369,7 @@ func TestShuffleShardingGrouper_Groups(t *testing.T) {
 			g := NewShuffleShardingGrouper(
 				ctx,
 				nil,
-				bkt,
+				objstore.WithNoopInstr(bkt),
 				false, // Do not accept malformed indexes
 				true,  // Enable vertical compaction
 				registerer,

--- a/pkg/compactor/shuffle_sharding_planner.go
+++ b/pkg/compactor/shuffle_sharding_planner.go
@@ -14,7 +14,7 @@ import (
 
 type ShuffleShardingPlanner struct {
 	ctx                                context.Context
-	bkt                                objstore.Bucket
+	bkt                                objstore.InstrumentedBucket
 	logger                             log.Logger
 	ranges                             []int64
 	noCompBlocksFunc                   func() map[ulid.ULID]*metadata.NoCompactMark
@@ -27,7 +27,7 @@ type ShuffleShardingPlanner struct {
 
 func NewShuffleShardingPlanner(
 	ctx context.Context,
-	bkt objstore.Bucket,
+	bkt objstore.InstrumentedBucket,
 	logger log.Logger,
 	ranges []int64,
 	noCompBlocksFunc func() map[ulid.ULID]*metadata.NoCompactMark,

--- a/pkg/compactor/shuffle_sharding_planner_test.go
+++ b/pkg/compactor/shuffle_sharding_planner_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
@@ -369,7 +370,7 @@ func TestShuffleShardingPlanner_Plan(t *testing.T) {
 			logger := log.NewLogfmtLogger(logs)
 			p := NewShuffleShardingPlanner(
 				context.Background(),
-				bkt,
+				objstore.WithNoopInstr(bkt),
 				logger,
 				testData.ranges,
 				func() map[ulid.ULID]*metadata.NoCompactMark {


### PR DESCRIPTION
**What this PR does**:

Just a follow up of https://github.com/cortexproject/cortex/pull/4870

On that PR we were not counting 404s on all buckets operations. This PR only ignores 404s when fetching the visitor marker as this error is expected there.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [NA] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
