### PR TITLE
[Vote] Governance update around maintainership 

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -7,13 +7,30 @@ This document defines project governance for the project.
 The Cortex project employs voting to ensure no single member can dominate the project. Any maintainer may cast a vote. To avoid having a single company dominate the project, at most two votes from maintainers working for the same company will count.
 
 For formal votes, a specific statement of what is being voted on should be added to the relevant github issue or PR, and a link to that issue or PR added to the maintainers meeting agenda document.
-Maintainers should indicate their yes/no vote on that issue or PR, and after a suitable period of time, the votes will be tallied and the outcome noted.
+
+Maintainers should indicate their yes/no vote on that issue or PR, and after a suitable period of time (minimum 2 business weeks), the votes will be tallied and the outcome noted. Mainainers who do not cast a vote, after a suitable period of time, are not included in the marjority calculation. 
+
+
+## Maintainer duties
+
+Maintainers are required to participate in the project, by joining discussions, submitting and reviewing pull requests, answering user questions, among others.
+
+Besides that, we have one concrete activity in which maintainers have to engage from time to time: releasing new versions of Cortex. This process ideally takes only a couple of hours, but requires coordination on different fronts. Even though the process is well documented, it is not without eventual glitches, so, each release needs a "Release shepherd". How it works is described in the [RELEASE.md](RELEASE.md) file.
 
 ## Changes in Maintainership
 
-New maintainers are proposed by an existing maintainer and are elected by a 2/3 majority vote.
+Contributors who are interested in becoming a maintainer, if performing relevant responsibilities, should discuss their interest with the existing maintainers. New maintainers must be nominated by an existing maintainer and must be elected by 2/3 majority vote.
 
-Maintainers can be removed by a 2/3 majority vote.
+We do not expect anyone to make a permanent commitment to be a Cortex maintainer forever. After all, circumstances change,
+people get new jobs, new interests, and may not be able to continue contributing to the project. At the same time, we need
+to keep the list of maintainers current in order to have effective governance. People may be removed from the current list
+of maintainers via one of the following ways:
+  * They can resign
+  * If they stop contributing to the project for a period of 6 months or more
+  * By a 2/3 majority vote by maintainers
+
+Former maintainers are recognized with an honorary _Emeritus Maintainer_ status, and have their names permanently
+listed in the [README](README.md) as a form of gratitude for their contributions.
 
 ## Approving PRs
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -27,7 +27,7 @@ to keep the list of maintainers current in order to have effective governance. P
 of maintainers via one of the following ways:
   * They can resign
   * If they stop contributing to the project for a period of 6 months or more
-  * By a 2/3 majority vote by maintainers
+  * By a 2/3 majority vote from active maintainers
 
 Former maintainers are recognized with an honorary _Emeritus Maintainer_ status, and have their names permanently
 listed in the [README](README.md) as a form of gratitude for their contributions.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,7 +8,7 @@ The Cortex project employs voting to ensure no single member can dominate the pr
 
 For formal votes, a specific statement of what is being voted on should be added to the relevant github issue or PR, and a link to that issue or PR added to the maintainers meeting agenda document.
 
-Maintainers should indicate their yes/no vote on that issue or PR, and after a suitable period of time (minimum 2 business weeks), the votes will be tallied and the outcome noted. Mainainers who do not cast a vote, after a suitable period of time, are not included in the marjority calculation.
+Maintainers should indicate their yes/no vote on that issue or PR, and after a suitable period of time (minimum 2 business weeks), the votes will be tallied and the outcome noted. Maintainers who do not cast a vote, after a suitable period of time, are not included in the majority calculation.
 
 
 ## Maintainer duties

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,7 +8,7 @@ The Cortex project employs voting to ensure no single member can dominate the pr
 
 For formal votes, a specific statement of what is being voted on should be added to the relevant github issue or PR, and a link to that issue or PR added to the maintainers meeting agenda document.
 
-Maintainers should indicate their yes/no vote on that issue or PR, and after a suitable period of time (minimum 2 business weeks), the votes will be tallied and the outcome noted. Mainainers who do not cast a vote, after a suitable period of time, are not included in the marjority calculation. 
+Maintainers should indicate their yes/no vote on that issue or PR, and after a suitable period of time (minimum 2 business weeks), the votes will be tallied and the outcome noted. Mainainers who do not cast a vote, after a suitable period of time, are not included in the marjority calculation.
 
 
 ## Maintainer duties

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,7 +15,7 @@ Maintainers should indicate their yes/no vote on that issue or PR, and after a s
 
 Maintainers are required to participate in the project, by joining discussions, submitting and reviewing pull requests, answering user questions, among others.
 
-Besides that, we have one concrete activity in which maintainers have to engage from time to time: releasing new versions of Cortex. This process ideally takes only a couple of hours, but requires coordination on different fronts. Even though the process is well documented, it is not without eventual glitches, so, each release needs a "Release shepherd". How it works is described in the [RELEASE.md](RELEASE.md) file.
+Besides that, we have one concrete activity in which maintainers have to engage from time to time: releasing new versions of Cortex. This process ideally takes only a couple of hours, but requires coordination on different fronts. Even though the process is well documented, it is not without eventual glitches, so, each release needs a "Release shepherd". How it works is described in the [RELEASE.md](https://github.com/cortexproject/cortex/blob/master/RELEASE.md) file.
 
 ## Changes in Maintainership
 
@@ -30,7 +30,7 @@ of maintainers via one of the following ways:
   * By a 2/3 majority vote from active maintainers
 
 Former maintainers are recognized with an honorary _Emeritus Maintainer_ status, and have their names permanently
-listed in the [README](README.md) as a form of gratitude for their contributions.
+listed in the [README](https://github.com/cortexproject/cortex/blob/master/README.md) as a form of gratitude for their contributions.
 
 ## Approving PRs
 


### PR DESCRIPTION
I would like to call an official vote to update the governance with changes around maintainership. Please see  the diff in this PR for the changes. 

Per [existing governance rule](https://cortexmetrics.io/docs/contributing/governance/#changes-in-governance), 2/3 majority votes are required for the changes to pass. 

Please cast your yes/no vote as comment in this PR, I will leave the vote open for 14 days (including weekends) or until all maintainer voted; whichever comes first.