### PR TITLE
QueryFronted should send request to queriers when query_range has start==end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [BUGFIX] Memberlist: Add join with no retrying when starting service. #4804
 * [BUGFIX] Ruler: Fix /ruler/rule_groups returns YAML with extra fields. #4767
 * [BUGFIX] Respecting `-tracing.otel.sample-ratio` configuration when enabling OpenTelemetry tracing with X-ray. #4862
+* [BUGFIX] QueryFrontend: fixed query_range requests when query has `start` equals to `end`. #4877
 
 ## 1.13.0 2022-07-14
 

--- a/pkg/querier/tripperware/queryrange/split_by_interval.go
+++ b/pkg/querier/tripperware/queryrange/split_by_interval.go
@@ -69,6 +69,11 @@ func (s splitByInterval) Do(ctx context.Context, r tripperware.Request) (tripper
 }
 
 func splitQuery(r tripperware.Request, interval time.Duration) ([]tripperware.Request, error) {
+	// If Start == end we should just run the original request
+	if r.GetStart() == r.GetEnd() {
+		return []tripperware.Request{r}, nil
+	}
+
 	// Replace @ modifier function to their respective constant values in the query.
 	// This way subqueries will be evaluated at the same time as the parent query.
 	query, err := evaluateAtModifierFunction(r.GetQuery(), r.GetStart(), r.GetEnd())
@@ -76,7 +81,7 @@ func splitQuery(r tripperware.Request, interval time.Duration) ([]tripperware.Re
 		return nil, err
 	}
 	var reqs []tripperware.Request
-	for start := r.GetStart(); start <= r.GetEnd(); start = nextIntervalBoundary(start, r.GetStep(), interval) + r.GetStep() {
+	for start := r.GetStart(); start < r.GetEnd(); start = nextIntervalBoundary(start, r.GetStep(), interval) + r.GetStep() {
 		end := nextIntervalBoundary(start, r.GetStep(), interval)
 		if end+r.GetStep() >= r.GetEnd() {
 			end = r.GetEnd()

--- a/pkg/querier/tripperware/queryrange/split_by_interval.go
+++ b/pkg/querier/tripperware/queryrange/split_by_interval.go
@@ -76,7 +76,7 @@ func splitQuery(r tripperware.Request, interval time.Duration) ([]tripperware.Re
 		return nil, err
 	}
 	var reqs []tripperware.Request
-	for start := r.GetStart(); start < r.GetEnd(); start = nextIntervalBoundary(start, r.GetStep(), interval) + r.GetStep() {
+	for start := r.GetStart(); start <= r.GetEnd(); start = nextIntervalBoundary(start, r.GetStep(), interval) + r.GetStep() {
 		end := nextIntervalBoundary(start, r.GetStep(), interval)
 		if end+r.GetStep() >= r.GetEnd() {
 			end = r.GetEnd()

--- a/pkg/querier/tripperware/queryrange/split_by_interval_test.go
+++ b/pkg/querier/tripperware/queryrange/split_by_interval_test.go
@@ -86,6 +86,23 @@ func TestSplitQuery(t *testing.T) {
 		},
 		{
 			input: &PrometheusRequest{
+				Start: 60 * 60 * seconds,
+				End:   60 * 60 * seconds,
+				Step:  15 * seconds,
+				Query: "foo",
+			},
+			expected: []tripperware.Request{
+				&PrometheusRequest{
+					Start: 60 * 60 * seconds,
+					End:   60 * 60 * seconds,
+					Step:  15 * seconds,
+					Query: "foo",
+				},
+			},
+			interval: day,
+		},
+		{
+			input: &PrometheusRequest{
 				Start: 0,
 				End:   60 * 60 * seconds,
 				Step:  15 * seconds,


### PR DESCRIPTION
**What this PR does**:
Right now, if we send a query range with the start == end, queryfrontend short circuit  the request and return an empty response.

We should still send this request as prometheus returns 1 step in such scenarios.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
