### PR TITLE
Implement memory limiter in querier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * [FEATURE] Distributor: Added a new limit `-validation.max-labels-size-bytes` allowing to limit the combined size of labels for each timeseries. #4848
 * [FEATURE] Storage/Bucket: Added `-*.s3.bucket-lookup-type` allowing to configure the s3 bucket lookup type. #4794
 * [FEATURE] QueryFrontend: Implement experimental vertical sharding at query frontend for range/instant queries. #4863
+* [FEATURE] Querier: Added a new limit `querier.max-memory-limit` allowing queriers to self protect itself from OOM. #4886
 * [BUGFIX] Memberlist: Add join with no retrying when starting service. #4804
 * [BUGFIX] Ruler: Fix /ruler/rule_groups returns YAML with extra fields. #4767
 * [BUGFIX] Respecting `-tracing.otel.sample-ratio` configuration when enabling OpenTelemetry tracing with X-ray. #4862

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -126,6 +126,12 @@ querier:
   # CLI flag: -querier.max-samples
   [max_samples: <int> | default = 50000000]
 
+  # Maximum memory limit in bytes for querier. Beyond this limit, querier will
+  # try to protect itself from OOM by throwing errors from active queries. 0
+  # means disabled.
+  # CLI flag: -querier.max-memory-limit
+  [max_memory_limit: <int> | default = 0]
+
   # Maximum lookback beyond which queries are not sent to ingester. 0 means all
   # queries are sent to ingester.
   # CLI flag: -querier.query-ingesters-within

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -804,6 +804,12 @@ The `querier_config` configures the Cortex querier.
 # CLI flag: -querier.max-samples
 [max_samples: <int> | default = 50000000]
 
+# Maximum memory limit in bytes for querier. Beyond this limit, querier will try
+# to protect itself from OOM by throwing errors from active queries. 0 means
+# disabled.
+# CLI flag: -querier.max-memory-limit
+[max_memory_limit: <int> | default = 0]
+
 # Maximum lookback beyond which queries are not sent to ingester. 0 means all
 # queries are sent to ingester.
 # CLI flag: -querier.query-ingesters-within

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -29,6 +29,7 @@ import (
 	querier_worker "github.com/cortexproject/cortex/pkg/querier/worker"
 	"github.com/cortexproject/cortex/pkg/util/concurrency"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/limiter"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -289,7 +290,7 @@ func testFrontend(t *testing.T, config CombinedFrontendConfig, handler http.Hand
 	go grpcServer.Serve(grpcListen) //nolint:errcheck
 
 	var worker services.Service
-	worker, err = querier_worker.NewQuerierWorker(workerConfig, httpgrpc_server.NewServer(handler), logger, nil)
+	worker, err = querier_worker.NewQuerierWorker(workerConfig, httpgrpc_server.NewServer(handler), logger, nil, &limiter.NoOpMemLimiter{})
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), worker))
 

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -32,6 +32,7 @@ import (
 	querier_worker "github.com/cortexproject/cortex/pkg/querier/worker"
 	"github.com/cortexproject/cortex/pkg/scheduler/queue"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/limiter"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -278,7 +279,7 @@ func testFrontend(t *testing.T, config Config, handler http.Handler, test func(a
 	go grpcServer.Serve(grpcListen) //nolint:errcheck
 
 	var worker services.Service
-	worker, err = querier_worker.NewQuerierWorker(workerConfig, httpgrpc_server.NewServer(handler), logger, nil)
+	worker, err = querier_worker.NewQuerierWorker(workerConfig, httpgrpc_server.NewServer(handler), logger, nil, &limiter.NoOpMemLimiter{})
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), worker))
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -44,6 +44,7 @@ type Config struct {
 	IngesterStreaming         bool          `yaml:"ingester_streaming"`
 	IngesterMetadataStreaming bool          `yaml:"ingester_metadata_streaming"`
 	MaxSamples                int           `yaml:"max_samples"`
+	MaxMemoryLimit            uint64        `yaml:"max_memory_limit"`
 	QueryIngestersWithin      time.Duration `yaml:"query_ingesters_within"`
 	QueryStoreForLabels       bool          `yaml:"query_store_for_labels_enabled"`
 	AtModifierEnabled         bool          `yaml:"at_modifier_enabled"`
@@ -90,6 +91,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.IngesterStreaming, "querier.ingester-streaming", true, "Use streaming RPCs to query ingester.")
 	f.BoolVar(&cfg.IngesterMetadataStreaming, "querier.ingester-metadata-streaming", false, "Use streaming RPCs for metadata APIs from ingester.")
 	f.IntVar(&cfg.MaxSamples, "querier.max-samples", 50e6, "Maximum number of samples a single query can load into memory.")
+	f.Uint64Var(&cfg.MaxMemoryLimit, "querier.max-memory-limit", 0, "Maximum memory limit in bytes for querier. Beyond this limit, querier will try to protect itself from OOM by throwing errors from active queries. 0 means disabled.")
 	f.DurationVar(&cfg.QueryIngestersWithin, "querier.query-ingesters-within", 0, "Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester.")
 	f.BoolVar(&cfg.QueryStoreForLabels, "querier.query-store-for-labels-enabled", false, "Query long-term store for series, label values and label names APIs. Works only with blocks engine.")
 	f.BoolVar(&cfg.AtModifierEnabled, "querier.at-modifier-enabled", false, "Enable the @ modifier in PromQL.")

--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/cortexproject/cortex/pkg/util/limiter"
 	"github.com/cortexproject/cortex/pkg/util/test"
 )
 
@@ -24,7 +25,7 @@ func TestRecvFailDoesntCancelProcess(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := Config{}
-	mgr := newFrontendProcessor(cfg, nil, log.NewNopLogger())
+	mgr := newFrontendProcessor(cfg, nil, log.NewNopLogger(), &limiter.NoOpMemLimiter{})
 	running := atomic.NewBool(false)
 	go func() {
 		running.Store(true)

--- a/pkg/util/limiter/memory_limiter.go
+++ b/pkg/util/limiter/memory_limiter.go
@@ -1,0 +1,139 @@
+package limiter
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/go-kit/log/level"
+)
+
+type memLimiterCtxKey struct{}
+type requestIDCtxKey struct{}
+
+type MemLimiter interface {
+	RemoveRequest(requestID string)
+	AddRequest(requestID string)
+	LoadBytes(dataBytes int, requestID string) error
+}
+
+var (
+	mlCtxKey             = &memLimiterCtxKey{}
+	mlRidCtxKey          = &requestIDCtxKey{}
+	ErrMaxMemoryLimitHit = "continuing to execute the query will potentially cause OOM"
+)
+
+func AddMemLimiterToContext(ctx context.Context, limiter MemLimiter) context.Context {
+	return context.WithValue(ctx, mlCtxKey, limiter)
+}
+
+// MemLimiterFromContextWithFallback returns a MemLimiter from the current context.
+// If there is not a MemLimiter on the context it will return a new no-op limiter.
+func MemLimiterFromContextWithFallback(ctx context.Context) MemLimiter {
+	ml, ok := ctx.Value(mlCtxKey).(MemLimiter)
+	if !ok {
+		ml = NewNoOpMemLimiter()
+	}
+	return ml
+}
+
+func RequestIDFromContextWithFallback(ctx context.Context) string {
+	requestID, ok := ctx.Value(mlRidCtxKey).(string)
+	if !ok {
+		// If there's no limiter return empty requestID
+		return ""
+	}
+	return requestID
+}
+
+func AddRequestIDToContext(ctx context.Context, requestID string) context.Context {
+	level.Warn(util_log.Logger).Log("msg", "Adding requestID to context", "request", requestID)
+	return context.WithValue(ctx, mlRidCtxKey, requestID)
+}
+
+// No-Op limiter
+type NoOpMemLimiter struct{}
+
+func (gl *NoOpMemLimiter) AddRequest(requestID string)                     {}
+func (gl *NoOpMemLimiter) RemoveRequest(requestID string)                  {}
+func (gl *NoOpMemLimiter) LoadBytes(dataBytes int, requestID string) error { return nil }
+
+func NewNoOpMemLimiter() MemLimiter {
+	return &NoOpMemLimiter{}
+}
+
+// Heap based memory limiter.
+type HeapMemLimiter struct {
+	mutex            sync.RWMutex // mutex for accessing the requests queue
+	queue            []string     // All the active requests
+	heapLimitInBytes uint64
+	memStats         *runtime.MemStats // Only used for mocking
+}
+
+// NewHeapMemLimiter makes a new heap based memory limiter.
+func NewHeapMemLimiter(heapLimitInBytes uint64) MemLimiter {
+	return &HeapMemLimiter{
+		heapLimitInBytes: heapLimitInBytes,
+		memStats:         nil,
+	}
+}
+
+func (l *HeapMemLimiter) AddRequest(requestID string) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.queue = append(l.queue, requestID)
+	level.Debug(util_log.Logger).Log("msg", "Added requestID to queue", "request", requestID, "active requests", fmt.Sprintf("%v", l.queue))
+}
+
+func (l *HeapMemLimiter) RemoveRequest(requestID string) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	for i, v := range l.queue {
+		if v == requestID {
+			l.queue = append(l.queue[:i], l.queue[i+1:]...)
+			break
+		}
+	}
+	level.Warn(util_log.Logger).Log("msg", "Removed requestID from queue", "request", requestID, "active requests", fmt.Sprintf("%v", l.queue))
+}
+
+// AddDataBytes adds the input data size in bytes and returns an error if the limit is reached.
+func (l *HeapMemLimiter) LoadBytes(dataBytes int, requestID string) error {
+	level.Debug(util_log.Logger).Log("msg", "Adding bytes for Request", "request", requestID, "bytes", fmt.Sprintf("(adding: %d)", dataBytes))
+	if l.heapLimitInBytes == 0 {
+		return nil
+	}
+
+	heapAlloc := l.getHeapAlloc()
+
+	if heapAlloc >= uint64(l.heapLimitInBytes) {
+		level.Warn(util_log.Logger).Log("msg", "Current heap alloc is higher than limit", "heapalloc", heapAlloc, "limit", l.heapLimitInBytes)
+		if l.isFirstRequest(requestID) {
+			// Always allow the first request to succeed to avoid any deadlock.
+			level.Warn(util_log.Logger).Log("msg", "Loading bytes above limit for the first request in queue", "request", requestID)
+			return nil
+		}
+		level.Warn(util_log.Logger).Log("msg", "Failing request because it could potentially cause OOM", "request", requestID, "heap", heapAlloc, "limit", l.heapLimitInBytes)
+		return fmt.Errorf(ErrMaxMemoryLimitHit)
+	}
+	return nil
+}
+
+func (l *HeapMemLimiter) getHeapAlloc() uint64 {
+	if l.memStats != nil {
+		return l.memStats.HeapAlloc
+	}
+
+	var rm runtime.MemStats
+	runtime.ReadMemStats(&rm)
+	return rm.HeapAlloc
+}
+
+func (l *HeapMemLimiter) isFirstRequest(requestID string) bool {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	return len(l.queue) == 0 || l.queue[0] == requestID
+}

--- a/pkg/util/limiter/memory_limiter_test.go
+++ b/pkg/util/limiter/memory_limiter_test.go
@@ -1,0 +1,100 @@
+package limiter
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	firstRequest  = "firstRequest"
+	secondRequest = "secondRequest"
+)
+
+func TestHeapMemLimiter_LoadBytes_ShouldReturnNoErrorWhenHeapAllocIsNotExceedingLimit(t *testing.T) {
+	fakeMemStats := &runtime.MemStats{
+		HeapAlloc: 0,
+	}
+
+	l := &HeapMemLimiter{
+		heapLimitInBytes: 100,
+		memStats:         fakeMemStats,
+	}
+	l.AddRequest(firstRequest)
+	l.AddRequest(secondRequest)
+	assert.NoError(t, l.LoadBytes(100, firstRequest))
+	assert.NoError(t, l.LoadBytes(100, secondRequest))
+}
+
+func TestHeapMemLimiter_LoadBytes_ShouldNeverReturnErrorForFirstRequest(t *testing.T) {
+	fakeMemStats := &runtime.MemStats{
+		HeapAlloc: 1000000,
+	}
+
+	l := &HeapMemLimiter{
+		heapLimitInBytes: 100,
+		memStats:         fakeMemStats,
+	}
+	l.AddRequest(firstRequest)
+	l.AddRequest(secondRequest)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(2)
+		go func() {
+			assert.NoError(t, l.LoadBytes(100, firstRequest))
+			wg.Done()
+		}()
+		go func() {
+			assert.Error(t, fmt.Errorf(ErrMaxMemoryLimitHit), l.LoadBytes(100, secondRequest))
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestHeapMemLimiter_AddorRemoveRequests_ShouldWorkCorrectlyWhenDoneConcurrently(t *testing.T) {
+	l := &HeapMemLimiter{
+		heapLimitInBytes: 0,
+	}
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			l.AddRequest(fmt.Sprintf("request-%d", i))
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < 10; i++ {
+		r := fmt.Sprintf("request-%d", i)
+		assert.Truef(t, contains(l.queue, r), "Queue doesn't contain all requests. queue: %v, request: %s", l.queue, r)
+	}
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			l.RemoveRequest(fmt.Sprintf("request-%d", i))
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Zerof(t, len(l.queue), "Expected queue to be empty: %v", l.queue)
+}
+
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Signed-off-by: 🌲 Harry 🌊 John 🏔 <johrry@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Currently the limits in Querier is good enough to protect a single query from OOM killing queriers. However, when tenants make several heavy queries concurrently, it can exhaust the memory in queriers and cause OOMs.
This PR is just an idea on how queriers can protect itself from OOM kills. Whenever a query is loading bytes, it'll take a look at the current HeapAlloc. If the HeapAlloc is beyond the limit the queries will fail. The frontend/scheduler will retry 3 times before failing the query.

i would like to get feedback on this approach. I ran some perf tests with 60 GB queriers and the memory_limit set to 40 GB. The limit protected queriers from getting OOM killed during my tests.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
