### PR TITLE
Templates in use are being removed by alertmanager cleanup logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [BUGFIX] Ruler: Fix /ruler/rule_groups returns YAML with extra fields. #4767
 * [BUGFIX] Respecting `-tracing.otel.sample-ratio` configuration when enabling OpenTelemetry tracing with X-ray. #4862
 * [BUGFIX] QueryFrontend: fixed query_range requests when query has `start` equals to `end`. #4877
+* [BUGFIX] AlertManager: fixed issue introduced by #4495 where templates files were being deleted when using alertmanager local store. #4890
 
 ## 1.13.0 2022-07-14
 

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -154,17 +154,17 @@ func (f *Store) reloadConfigs() (map[string]alertspb.AlertConfigDesc, error) {
 		var templates []*alertspb.TemplateDesc
 
 		if _, e := os.Stat(userTemplateDir); e == nil {
-			err = filepath.Walk(filepath.Join(f.cfg.Path, user, templatesDir), func(path string, info os.FileInfo, err error) error {
+			err = filepath.Walk(userTemplateDir, func(templatePath string, info os.FileInfo, err error) error {
 				if err != nil {
-					return errors.Wrapf(err, "unable to walk file path at %s", path)
+					return errors.Wrapf(err, "unable to walk file path at %s", templatePath)
 				}
 				// Ignore files that are directories
 				if info.IsDir() {
 					return nil
 				}
-				content, err := os.ReadFile(path)
+				content, err := os.ReadFile(templatePath)
 				if err != nil {
-					return errors.Wrapf(err, "unable to read alertmanager templates %s", path)
+					return errors.Wrapf(err, "unable to read alertmanager templates %s", templatePath)
 				}
 
 				templates = append(templates, &alertspb.TemplateDesc{
@@ -175,8 +175,10 @@ func (f *Store) reloadConfigs() (map[string]alertspb.AlertConfigDesc, error) {
 			})
 
 			if err != nil {
-				return errors.Wrapf(err, "unable to load alertmanager config %s", path)
+				return errors.Wrapf(err, "unable to list alertmanager templates: %s", userTemplateDir)
 			}
+		} else if !os.IsNotExist(e) {
+			return errors.Wrapf(e, "unable to read alertmanager templates %s", path)
 		}
 
 		configs[user] = alertspb.AlertConfigDesc{

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -173,6 +173,10 @@ func (f *Store) reloadConfigs() (map[string]alertspb.AlertConfigDesc, error) {
 				})
 				return nil
 			})
+
+			if err != nil {
+				return errors.Wrapf(err, "unable to load alertmanager config %s", path)
+			}
 		}
 
 		configs[user] = alertspb.AlertConfigDesc{

--- a/pkg/alertmanager/alertstore/local/store_test.go
+++ b/pkg/alertmanager/alertstore/local/store_test.go
@@ -81,7 +81,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 	// The storage contains some configs.
 	{
 		user1Cfg := prepareAlertmanagerConfig("user-1")
-		user1Dir, user1TemplateDir := prepareUserDir(t, storeDir, "user-1")
+		user1Dir, user1TemplateDir := prepareUserDir(t, storeDir, true, "user-1")
 		require.NoError(t, os.WriteFile(filepath.Join(user1Dir, "user-1.yaml"), []byte(user1Cfg), os.ModePerm))
 
 		require.NoError(t, os.WriteFile(filepath.Join(user1TemplateDir, "template.tpl"), []byte("testTemplate"), os.ModePerm))
@@ -95,7 +95,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 
 		// Add another user config.
 		user2Cfg := prepareAlertmanagerConfig("user-2")
-		user2Dir, _ := prepareUserDir(t, storeDir, "user-2")
+		user2Dir, _ := prepareUserDir(t, storeDir, false, "user-2")
 		require.NoError(t, os.WriteFile(filepath.Join(user2Dir, "user-2.yaml"), []byte(user2Cfg), os.ModePerm))
 
 		configs, err = store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
@@ -107,11 +107,13 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 	}
 }
 
-func prepareUserDir(t *testing.T, storeDir string, user string) (userDir string, templateDir string) {
+func prepareUserDir(t *testing.T, storeDir string, createTemplateDir bool, user string) (userDir string, templateDir string) {
 	userDir = filepath.Join(storeDir, user)
 	templateDir = filepath.Join(userDir, templatesDir)
 	require.NoError(t, os.MkdirAll(userDir, os.ModePerm))
-	require.NoError(t, os.MkdirAll(templateDir, os.ModePerm))
+	if createTemplateDir {
+		require.NoError(t, os.MkdirAll(templateDir, os.ModePerm))
+	}
 	return
 }
 

--- a/pkg/alertmanager/alertstore/local/store_test.go
+++ b/pkg/alertmanager/alertstore/local/store_test.go
@@ -81,7 +81,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 	// The storage contains some configs.
 	{
 		user1Cfg := prepareAlertmanagerConfig("user-1")
-		user1Dir, user1TemplateDir := prepareUserDir(storeDir, "user-1")
+		user1Dir, user1TemplateDir := prepareUserDir(t, storeDir, "user-1")
 		require.NoError(t, os.WriteFile(filepath.Join(user1Dir, "user-1.yaml"), []byte(user1Cfg), os.ModePerm))
 
 		require.NoError(t, os.WriteFile(filepath.Join(user1TemplateDir, "template.tpl"), []byte("testTemplate"), os.ModePerm))
@@ -95,7 +95,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 
 		// Add another user config.
 		user2Cfg := prepareAlertmanagerConfig("user-2")
-		user2Dir, _ := prepareUserDir(storeDir, "user-2")
+		user2Dir, _ := prepareUserDir(t, storeDir, "user-2")
 		require.NoError(t, os.WriteFile(filepath.Join(user2Dir, "user-2.yaml"), []byte(user2Cfg), os.ModePerm))
 
 		configs, err = store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
@@ -107,11 +107,11 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 	}
 }
 
-func prepareUserDir(storeDir string, user string) (userDir string, templateDir string) {
+func prepareUserDir(t *testing.T, storeDir string, user string) (userDir string, templateDir string) {
 	userDir = filepath.Join(storeDir, user)
 	templateDir = filepath.Join(userDir, templatesDir)
-	os.MkdirAll(userDir, os.ModePerm)
-	os.MkdirAll(templateDir, os.ModePerm)
+	require.NoError(t, os.MkdirAll(userDir, os.ModePerm))
+	require.NoError(t, os.MkdirAll(templateDir, os.ModePerm))
 	return
 }
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/alertmanager/alertstore/local"
 	"github.com/go-kit/log"
 	"github.com/prometheus/alertmanager/cluster/clusterpb"
 	"github.com/prometheus/alertmanager/notify"
@@ -42,6 +41,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/alertmanager/alertspb"
 	"github.com/cortexproject/cortex/pkg/alertmanager/alertstore"
 	"github.com/cortexproject/cortex/pkg/alertmanager/alertstore/bucketclient"
+	"github.com/cortexproject/cortex/pkg/alertmanager/alertstore/local"
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
@@ -178,8 +178,8 @@ receivers:
     from: test@example.com
     smarthost: smtp:2525
 `
-	user1Dir, user1TemplateDir := prepareUserDir(storeDir, "user-1")
-	user2Dir, _ := prepareUserDir(storeDir, "user-2")
+	user1Dir, user1TemplateDir := prepareUserDir(t, storeDir, "user-1")
+	user2Dir, _ := prepareUserDir(t, storeDir, "user-2")
 	require.NoError(t, os.WriteFile(filepath.Join(user1Dir, "user-1.yaml"), []byte(config), os.ModePerm))
 	require.NoError(t, os.WriteFile(filepath.Join(user2Dir, "user-2.yaml"), []byte(config), os.ModePerm))
 	require.NoError(t, os.WriteFile(filepath.Join(user1TemplateDir, "template.tpl"), []byte("testTemplate"), os.ModePerm))
@@ -1930,11 +1930,11 @@ func prepareInMemoryAlertStore() alertstore.AlertStore {
 	return bucketclient.NewBucketAlertStore(objstore.NewInMemBucket(), nil, log.NewNopLogger())
 }
 
-func prepareUserDir(storeDir string, user string) (userDir string, templateDir string) {
+func prepareUserDir(t *testing.T, storeDir string, user string) (userDir string, templateDir string) {
 	userDir = filepath.Join(storeDir, user)
 	templateDir = filepath.Join(userDir, templatesDir)
-	os.MkdirAll(userDir, os.ModePerm)
-	os.MkdirAll(templateDir, os.ModePerm)
+	require.NoError(t, os.MkdirAll(userDir, os.ModePerm))
+	require.NoError(t, os.MkdirAll(templateDir, os.ModePerm))
 	return
 }
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -14,11 +14,13 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/alertmanager/alertstore/local"
 	"github.com/go-kit/log"
 	"github.com/prometheus/alertmanager/cluster/clusterpb"
 	"github.com/prometheus/alertmanager/notify"
@@ -156,6 +158,49 @@ func TestMultitenantAlertmanagerConfig_Validate(t *testing.T) {
 			testData.setup(t, cfg, &storageCfg)
 			assert.Equal(t, testData.expected, cfg.Validate(storageCfg))
 		})
+	}
+}
+
+func TestMultitenantAlertmanager_loadAndSyncConfigsLocalStorage(t *testing.T) {
+	storeDir := t.TempDir()
+	store, _ := local.NewStore(local.StoreConfig{Path: storeDir})
+	config := `global:
+  resolve_timeout: 1m
+  smtp_require_tls: false
+
+route:
+  receiver: 'email'
+
+receivers:
+- name: 'email'
+  email_configs:
+  - to: test@example.com
+    from: test@example.com
+    smarthost: smtp:2525
+`
+	user1Dir, user1TemplateDir := prepareUserDir(storeDir, "user-1")
+	user2Dir, _ := prepareUserDir(storeDir, "user-2")
+	require.NoError(t, os.WriteFile(filepath.Join(user1Dir, "user-1.yaml"), []byte(config), os.ModePerm))
+	require.NoError(t, os.WriteFile(filepath.Join(user2Dir, "user-2.yaml"), []byte(config), os.ModePerm))
+	require.NoError(t, os.WriteFile(filepath.Join(user1TemplateDir, "template.tpl"), []byte("testTemplate"), os.ModePerm))
+
+	originalFiles, err := listFiles(storeDir)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(originalFiles))
+
+	cfg := mockAlertmanagerConfig(t)
+	cfg.DataDir = storeDir
+	reg := prometheus.NewPedanticRegistry()
+	am, err := createMultitenantAlertmanager(cfg, nil, nil, store, nil, nil, log.NewNopLogger(), reg)
+	require.NoError(t, err)
+	for i := 0; i < 5; i++ {
+		err = am.loadAndSyncConfigs(context.Background(), reasonPeriodic)
+		require.NoError(t, err)
+		require.Len(t, am.alertmanagers, 2)
+		files, err := listFiles(storeDir)
+		require.NoError(t, err)
+		// Verify if the files were not deleted
+		require.Equal(t, originalFiles, files)
 	}
 }
 
@@ -1883,6 +1928,27 @@ func TestAlertmanager_StateReplicationWithSharding_InitialSyncFromPeers(t *testi
 // prepareInMemoryAlertStore builds and returns an in-memory alert store.
 func prepareInMemoryAlertStore() alertstore.AlertStore {
 	return bucketclient.NewBucketAlertStore(objstore.NewInMemBucket(), nil, log.NewNopLogger())
+}
+
+func prepareUserDir(storeDir string, user string) (userDir string, templateDir string) {
+	userDir = filepath.Join(storeDir, user)
+	templateDir = filepath.Join(userDir, templatesDir)
+	os.MkdirAll(userDir, os.ModePerm)
+	os.MkdirAll(templateDir, os.ModePerm)
+	return
+}
+
+func listFiles(dir string) ([]string, error) {
+	var r []string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			r = append(r, path)
+		}
+		return nil
+	})
+	sort.Strings(r)
+
+	return r, err
 }
 
 func TestSafeTemplateFilepath(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
Populating the templates when using alertmanager local store.

**Which issue(s) this PR fixes**:
Fixes #4888

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
