### PR TITLE
Upgrade fpm image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,6 +330,8 @@ FPM_OPTS := fpm -s dir -v $(VERSION) -n cortex -f \
 	--url "https://github.com/cortexproject/cortex"
 
 PACKAGE_IN_CONTAINER := true
+
+# The fpm image can be built from packaging/fpm//Dockerfile
 PACKAGE_IMAGE ?= $(IMAGE_PREFIX)fpm
 ifeq ($(PACKAGE_IN_CONTAINER), true)
 

--- a/packaging/fpm/Dockerfile
+++ b/packaging/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.13
 
 RUN apk add --no-cache \
         ruby \
@@ -11,7 +11,7 @@ RUN apk add --no-cache \
         make \
         rpm \
         tar \
-        && gem install --no-ri --no-rdoc fpm
+        && gem install --no-document fpm
 
 COPY package.sh /
 ENTRYPOINT ["/package.sh"]


### PR DESCRIPTION
I was doing 1.13.1 release and got an error `https://quay.io/repository/cortexproject/fpm not found` when doing `make packages`, which used to work before.  I am not sure how `https://quay.io/repository/cortexproject/fpm` was removed from quay.io, but we gotta move on with our lives. 

With some reverse-engineering I determined that the `https://quay.io/repository/cortexproject/fpm` was built from `packaging/fpm/Dockerfile`, so I built that and pushed it to `quay.io/repository/cortexproject/fpm`, then ran `make packages` again, which completed successfully. 

I had to upgrade Alpine version in `packaging/fpm/Dockerfile` in order to be able to install the latest `ruby` successfully. I also had to change the command line arg for doc generation for `gem install` because [--no-ri --no-rdoc are deprecated](https://stackoverflow.com/questions/57475842/what-to-use-instead-of-no-ri-for-gem-install).