### PR TITLE
Implement rate limit on data_bytes_fetched in frontend

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2720,6 +2720,18 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -frontend.max-queriers-per-tenant
 [max_queriers_per_tenant: <int> | default = 0]
 
+# [Experimental] Per-user query rate limit in data bytes fetched per second.
+# CLI flag: -frontend.query-data-bytes-rate-limit-per-user
+[query_data_bytes_rate_limit_per_user: <float> | default = 0]
+
+# [Experimental] Per-user query burst size (in data bytes fetched).
+# CLI flag: -frontend.query-data-bytes-burst-size-per-user
+[query_data_bytes_burst_size_per_user: <int> | default = 0]
+
+# [Experimental] Minimum units reserved per query (in data bytes fetched).
+# CLI flag: -frontend.query-data-bytes-reservation-per-user
+[query_data_bytes_reservation_per_user: <int> | default = 0]
+
 # Duration to delay the evaluation of rules to ensure the underlying metrics
 # have been pushed to Cortex.
 # CLI flag: -ruler.evaluation-delay-duration

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -480,7 +480,7 @@ func (t *Cortex) initQueryFrontend() (serv services.Service, err error) {
 	// Wrap roundtripper into Tripperware.
 	roundTripper = t.QueryFrontendTripperware(roundTripper)
 
-	handler := transport.NewHandler(t.Cfg.Frontend.Handler, roundTripper, util_log.Logger, prometheus.DefaultRegisterer)
+	handler := transport.NewHandler(t.Cfg.Frontend.Handler, t.Overrides, roundTripper, util_log.Logger, prometheus.DefaultRegisterer)
 	t.API.RegisterQueryFrontendHandler(handler)
 
 	if frontendV1 != nil {

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -320,6 +320,8 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 				return nil, err
 			}
 
+			reqStats.AddFetchedDataBytes(uint64(resp.Size()))
+
 			// Enforce the max chunks limits.
 			if chunkLimitErr := queryLimiter.AddChunks(resp.ChunksCount()); chunkLimitErr != nil {
 				return nil, validation.LimitError(chunkLimitErr.Error())
@@ -396,7 +398,6 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 
 	reqStats.AddFetchedSeries(uint64(len(resp.Chunkseries) + len(resp.Timeseries)))
 	reqStats.AddFetchedChunkBytes(uint64(resp.ChunksSize()))
-	reqStats.AddFetchedDataBytes(uint64(resp.Size()))
 
 	return resp, nil
 }

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/concurrency"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
+	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 const (
@@ -274,11 +275,14 @@ func testFrontend(t *testing.T, config CombinedFrontendConfig, handler http.Hand
 		frontendv1pb.RegisterFrontendServer(grpcServer, v1)
 	}
 
+	overrides, err := validation.NewOverrides(validation.Limits{}, nil)
+	require.NoError(t, err)
+
 	r := mux.NewRouter()
 	r.PathPrefix("/").Handler(middleware.Merge(
 		middleware.AuthenticateUser,
 		middleware.Tracer{},
-	).Wrap(transport.NewHandler(config.Handler, rt, logger, nil)))
+	).Wrap(transport.NewHandler(config.Handler, overrides, rt, logger, nil)))
 
 	httpServer := http.Server{
 		Handler: r,

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -68,7 +69,9 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			})
 
 			reg := prometheus.NewPedanticRegistry()
-			handler := NewHandler(tt.cfg, roundTripper, log.NewNopLogger(), reg)
+			overrides, err := validation.NewOverrides(validation.Limits{}, nil)
+			require.NoError(t, err)
+			handler := NewHandler(tt.cfg, overrides, roundTripper, log.NewNopLogger(), reg)
 
 			ctx := user.InjectOrgID(context.Background(), "12345")
 			req := httptest.NewRequest("GET", "/", nil)

--- a/pkg/frontend/transport/query_throttling_strategy.go
+++ b/pkg/frontend/transport/query_throttling_strategy.go
@@ -1,0 +1,24 @@
+package transport
+
+import (
+	"github.com/cortexproject/cortex/pkg/util/limiter"
+	"github.com/cortexproject/cortex/pkg/util/validation"
+)
+
+type localStrategy struct {
+	limits *validation.Overrides
+}
+
+func newLocalQueryDataBytesRateStrategy(limits *validation.Overrides) limiter.RateLimiterStrategy {
+	return &localStrategy{
+		limits: limits,
+	}
+}
+
+func (s *localStrategy) Limit(tenantID string) float64 {
+	return s.limits.QueryDataBytesRatePerUser(tenantID)
+}
+
+func (s *localStrategy) Burst(tenantID string) int {
+	return s.limits.QueryDataBytesBurstSizePerUser(tenantID)
+}

--- a/pkg/frontend/transport/query_throttling_strategy_test.go
+++ b/pkg/frontend/transport/query_throttling_strategy_test.go
@@ -1,0 +1,42 @@
+package transport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/util/validation"
+)
+
+func TestQueryThrottlingStrategy(t *testing.T) {
+	tests := map[string]struct {
+		limits        validation.Limits
+		expectedLimit float64
+		expectedBurst int
+	}{
+		"local rate limiter should just return configured limits": {
+			limits: validation.Limits{
+				QueryDataBytesRatePerUser:      float64(1000),
+				QueryDataBytesBurstSizePerUser: 10000,
+			},
+			expectedLimit: float64(1000),
+			expectedBurst: 10000,
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			// Init limits overrides
+			overrides, err := validation.NewOverrides(testData.limits, nil)
+			require.NoError(t, err)
+
+			strategy := newLocalQueryDataBytesRateStrategy(overrides)
+
+			assert.Equal(t, strategy.Limit("test"), testData.expectedLimit)
+			assert.Equal(t, strategy.Burst("test"), testData.expectedBurst)
+		})
+	}
+}

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/scheduler/queue"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/services"
+	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 const (
@@ -262,12 +263,15 @@ func testFrontend(t *testing.T, config Config, handler http.Handler, test func(a
 	handlerCfg := transport.HandlerConfig{}
 	flagext.DefaultValues(&handlerCfg)
 
+	overrides, err := validation.NewOverrides(validation.Limits{}, nil)
+	require.NoError(t, err)
+
 	rt := transport.AdaptGrpcRoundTripperToHTTPRoundTripper(v1)
 	r := mux.NewRouter()
 	r.PathPrefix("/").Handler(middleware.Merge(
 		middleware.AuthenticateUser,
 		middleware.Tracer{},
-	).Wrap(transport.NewHandler(handlerCfg, rt, logger, nil)))
+	).Wrap(transport.NewHandler(handlerCfg, overrides, rt, logger, nil)))
 
 	httpServer := http.Server{
 		Handler: r,

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -659,6 +659,7 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 					}
 					chunksSize := countChunkBytes(s)
 					dataSize := countDataBytes(s)
+					reqStats.AddFetchedDataBytes(uint64(dataSize))
 					if chunkBytesLimitErr := queryLimiter.AddChunkBytes(chunksSize); chunkBytesLimitErr != nil {
 						return validation.LimitError(chunkBytesLimitErr.Error())
 					}
@@ -695,7 +696,6 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 
 			reqStats.AddFetchedSeries(uint64(numSeries))
 			reqStats.AddFetchedChunkBytes(uint64(chunkBytes))
-			reqStats.AddFetchedDataBytes(uint64(dataBytes))
 
 			level.Debug(spanLog).Log("msg", "received series from store-gateway",
 				"instance", c.RemoteAddress(),


### PR DESCRIPTION
Signed-off-by: 🌲 Harry 🌊 John 🏔 <johrry@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR adds a rate limit on fetched data bytes per user. What this limit enables is to throttle customers who are making high TPS heavy queries. 

The assumption here is that data_bytes_fetched is the measure of the capacity of a cluster.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
