### PR TITLE
Enable AWS SDK for go authentication to fix IMDSv1 issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [FEATURE] Storage/Bucket: Added `-*.s3.bucket-lookup-type` allowing to configure the s3 bucket lookup type. #4794
 * [FEATURE] QueryFrontend: Implement experimental vertical sharding at query frontend for range/instant queries. #4863
 * [FEATURE] Querier: Added a new limit `-querier.max-fetched-data-bytes-per-query` allowing to limit the maximum size of all data in bytes that a query can fetch from each ingester and storage. #4854
+* [BUGFIX] Storage/Bucket: Enable AWS SDK for go authentication for s3 to fix IMDSv1 authentication. #4897
 * [BUGFIX] Memberlist: Add join with no retrying when starting service. #4804
 * [BUGFIX] Ruler: Fix /ruler/rule_groups returns YAML with extra fields. #4767
 * [BUGFIX] Respecting `-tracing.otel.sample-ratio` configuration when enabling OpenTelemetry tracing with X-ray. #4862

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -59,5 +59,6 @@ func newS3Config(cfg Config) (s3.Config, error) {
 		// Enforce signature version 2 if CLI flag is set
 		SignatureV2:      cfg.SignatureVersion == SignatureVersionV2,
 		BucketLookupType: bucketLookupType,
+		AWSSDKAuth:       cfg.AccessKeyID == "",
 	}, nil
 }


### PR DESCRIPTION
**What this PR does**:
~Introduces a boolean flag to enable AWS SDK for go auth~
Enables AWS SDK for go auth

**Which issue(s) this PR fixes**:
Enable IMDSv1 again #4896  and most likely other use cases

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
