### PR TITLE
treat interrupted compactions different than failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [CHANGE] Disables TSDB isolation. #4825
 * [CHANGE] Drops support Prometheus 1.x rule format on configdb. #4826
 * [CHANGE] Removes `-ingester.stream-chunks-when-using-blocks` experimental flag and stream chunks by default when `querier.ingester-streaming` is enabled. #4864
+* [CHANGE] Compactor: Added `cortex_compactor_runs_interrupted_total` to separate compaction interruptions from failures
 * [ENHANCEMENT] AlertManager: Retrying AlertManager Get Requests (Get Alertmanager status, Get Alertmanager Receivers) on next replica on error #4840
 * [ENHANCEMENT] Querier/Ruler: Retry store-gateway in case of unexpected failure, instead of failing the query. #4532 #4839
 * [ENHANCEMENT] Ring: DoBatch prioritize 4xx errors when failing. #4783


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR adds "interruption" as a new category of compaction outcome.  Currently, compaction starts and then it either fails or succeeds according to metrics.  In the event of a graceful shutdown, an ongoing compaction is recorded as a failure and `cortex_compactor_runs_failed_total` and `cortex_compactor_tenants_processing_failed` are incremented.  This makes it cumbersome to monitor for compaction failures.  After this PR, compactions interrupted by shutdown will not be recorded as failures but rather as "interruptions".

**Notes**:
Ideally, we could also verify in unit tests that `cortex_compactor_tenants_processing_failed` is not incremented, but this would require more complicated refactoring because `cortex_compactor_tenants_processing_*` metrics are reset at the end of compaction runs.

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
