### PR TITLE
Set github token permission default to read-all

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -1,4 +1,5 @@
 name: ci
+permissions: read-all
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Someone told me about https://clomonitor.io/projects/cncf/cortex during KubeCon, and that Google would make some donation on behalf of Cortex if it reaches score of 100 for security. 

I care about both security and the donation, so this PR set the default `GITHUB_TOKEN` permission to read only; conforming to https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions