### PR TITLE
Add signing release artifacts instruction

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -97,6 +97,19 @@ To publish a release candidate:
    - Build binaries with `make dist` and attach them to the release
    - Build packages with `make packages`, test them with `make test-packages` and attach them to the release
 
+### Sign the release artifacts
+1. Create and `cd` to an empty directory
+1. Download the artifacts you just attached: 
+   ```bash
+   curl -H "Authorization: Bearer <your GitHub API token>" -s https://api.github.com/repos/cortexproject/cortex/releases/tags/<release name> \ 
+   | grep "browser_download_url" \ 
+   | cut -d: -f2- \ 
+   | tr -d "\"" \ 
+   | wget -qi -
+   ```
+1. Sign the files with your PGP key: `ls | xargs -L 1 gpg --armor --detach-sign`
+1. Attach the generated `.asc` files to the release
+
 ### Publish a stable release
 
 To publish a stable release:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -99,12 +99,12 @@ To publish a release candidate:
 
 ### Sign the release artifacts
 1. Create and `cd` to an empty directory
-1. Download the artifacts you just attached: 
+1. Download the artifacts you just attached:
    ```bash
-   curl -H "Authorization: Bearer <your GitHub API token>" -s https://api.github.com/repos/cortexproject/cortex/releases/tags/<release name> \ 
-   | grep "browser_download_url" \ 
-   | cut -d: -f2- \ 
-   | tr -d "\"" \ 
+   curl -H "Authorization: Bearer <your GitHub API token>" -s https://api.github.com/repos/cortexproject/cortex/releases/tags/<release name> \
+   | grep "browser_download_url" \
+   | cut -d: -f2- \
+   | tr -d "\"" \
    | wget -qi -
    ```
 1. Sign the files with your PGP key: `ls | xargs -L 1 gpg --armor --detach-sign`


### PR DESCRIPTION
Signed-off-by: Alvin Lin <alvinlin@amazon.com>

This is to conform with https://github.com/ossf/scorecard/blob/084bcd90098bababa68c6abfe28dc777bfc4b060/docs/checks.md#signed-releases. Why? Because it's the right thing to do with added benefit of Google will make donation on Cortex's behalf: https://www.cncf.io/blog/2022/10/12/whats-new-at-kubecon-cloudnativecon-north-america-in-the-motor-city-or-is-it-motown-or-the-paris-of-the-midwest/ 
