### PR TITLE
Upload global marker before local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [BUGFIX] QueryFrontend: fixed query_range requests when query has `start` equals to `end`. #4877
 * [BUGFIX] AlertManager: fixed issue introduced by #4495 where templates files were being deleted when using alertmanager local store. #4890
 * [BUGFIX] Ingester: fixed incorrect logging at the start of ingester block shipping logic. #4934
+* [BUGFIX] Storage/Bucket: fixed global mark missing on deletion. #4949
 
 ## 1.13.0 2022-07-14
 

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
@@ -37,13 +37,13 @@ func (b *globalMarkersBucket) Upload(ctx context.Context, name string, r io.Read
 		return err
 	}
 
-	// Upload it to the original location.
-	if err := b.parent.Upload(ctx, name, bytes.NewBuffer(body)); err != nil {
+	// Upload it to the global marker's location.
+	if err := b.parent.Upload(ctx, globalMarkPath, bytes.NewBuffer(body)); err != nil {
 		return err
 	}
 
-	// Upload it to the global markers location too.
-	return b.parent.Upload(ctx, globalMarkPath, bytes.NewBuffer(body))
+	// Upload it to the original location too.
+	return b.parent.Upload(ctx, name, bytes.NewBuffer(body))
 }
 
 // Delete implements objstore.Bucket.


### PR DESCRIPTION
Signed-off-by: Daniel Deluiggi <ddeluigg@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Change order Cortex upload markers to storage. In some situations, if the second call fails blocks can be left without being delete. This try to avoid it by always updating the global marker first

**Which issue(s) this PR fixes**:
Fixes #4872

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
