### PR TITLE
Add trademark notice to website footer

### DIFF
--- a/website/layouts/partials/footer.html
+++ b/website/layouts/partials/footer.html
@@ -1,29 +1,38 @@
-<footer class="row td-box td-box--dark td-box--gradient td-box--height-auto text-white p-5">
-  <div class="col-12 col-sm-4 pb-5 pb-sm-0">
-    <img src="/images/cortex-stacked-white.png" width="75px" class="img-fluid float-left" />
+<footer>
+  <div class="row td-box td-box--dark td-box--gradient td-box--height-auto text-white p-5">
+    <div class="col-12 col-sm-4 pb-5 pb-sm-0">
+      <img src="/images/cortex-stacked-white.png" width="75px" class="img-fluid float-left" />
+    </div>
+    <div class="col-12 col-sm-4 pb-5 pb-sm-0">
+      <h6 class="font-weight-bold">Community</h6>
+      <ul class="list-unstyled">
+        <li>
+          <a href="https://slack.cncf.io" class="text-reset text-white">
+            <i class="fab fa-fw fa-slack"></i>  Slack
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/cortexproject/cortex" class="text-reset text-white">
+            <i class="fab fa-fw fa-github"></i>  GitHub
+          </a>
+        </li>
+        <li>
+          <a href="https://twitter.com/cortexmetrics" class="text-reset text-white">
+            <i class="fab fa-fw fa-twitter"></i>  Twitter
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div class="col-12 col-sm-4">
+      <h6 class="font-weight-bold">About</h6>
+      <p>Cortex is an OSS licensed project as Apache License 2.0</p>
+    </div>
   </div>
-  <div class="col-12 col-sm-4 pb-5 pb-sm-0">
-    <h6 class="font-weight-bold">Community</h6>
-    <ul class="list-unstyled">
-      <li>
-        <a href="https://slack.cncf.io" class="text-reset text-white">
-          <i class="fab fa-fw fa-slack"></i>  Slack
-        </a>
-      </li>
-      <li>
-        <a href="https://github.com/cortexproject/cortex" class="text-reset text-white">
-          <i class="fab fa-fw fa-github"></i>  GitHub
-        </a>
-      </li>
-      <li>
-        <a href="https://twitter.com/cortexmetrics" class="text-reset text-white">
-          <i class="fab fa-fw fa-twitter"></i>  Twitter
-        </a>
-      </li>
-    </ul>
-  </div>
-  <div class="col-12 col-sm-4">
-    <h6 class="font-weight-bold">About</h6>
-    <p>Cortex is an OSS licensed project as Apache License 2.0</p>
+  <div class="row td-box td-box--dark td-box--gradient td-box--height-auto text-white p-5 text-center">
+    <small class="col-12 text-center">
+      © 2022 The Cortex Authors All Rights Reserved. <br />
+      The Linux Foundation has registered trademarks and uses trademarks.
+      For a list of trademarks of The Linux Foundation, please see <a class="text-light alert-link" href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage page</a>.
+    </small> 
   </div>
 </footer>


### PR DESCRIPTION
To address: https://clomonitor.io/docs/topics/checks/#legal

This is how it looks:
![image](https://user-images.githubusercontent.com/787449/199377834-bbb3b9b7-a941-47a0-b1b3-e031c74b1b98.png)
