### PR TITLE
[Vote] Ben Ye (yeya24) as new Cortex maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,4 @@
 Alan Protasio, Amazon Web Services <alanprot@gmail.com> (@alanprot)
 Alvin Lin, Amazon Web Services <alvinlin123@gmail.com> (@alvinlin123)
+Ben Ye, Amazon Web Services <yb532204897@gmail.com> (@yeya24)
 Friedrich Gonzalez, Adobe <friedrichg@gmail.com> (@friedrichg)


### PR DESCRIPTION
I would like to call for a vote to add @yeya24 as Cortex maintainer.

Ben is currently Thanos maintainer, and he had been very active in contributing to Cortex ever since he joined AWS about 1.5 months back. Here is [a list of Ben's contribution](https://github.com/cortexproject/cortex/pulls?q=author%3Ayeya24+). I can see that Ben is passionate about helping Cortex, and his experience being Thanos maintainer can be a great help.

Per [existing change in maintainership governance rule](https://cortexmetrics.io/docs/contributing/governance/#changes-in-maintainership), 2/3 majority votes are required for the changes to pass.

Please cast your yes/no vote as comment in this PR, I will leave the vote open for 14 days (including weekends) or until all maintainer voted; whichever comes first.

Signed-off-by: Alvin Lin <alvinlin@amazon.com>
