### PR TITLE
Always request querier to return gzipped response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * [BUGFIX] AlertManager: fixed issue introduced by #4495 where templates files were being deleted when using alertmanager local store. #4890
 * [BUGFIX] Ingester: fixed incorrect logging at the start of ingester block shipping logic. #4934
 * [BUGFIX] Storage/Bucket: fixed global mark missing on deletion. #4949
+* [BUGFIX] QueryFrontend/Querier: fixed regression added by #4863 where we stopped compressing the response between querier and query frontend. #4960
 
 ## 1.13.0 2022-07-14
 

--- a/pkg/querier/tripperware/instantquery/instant_query.go
+++ b/pkg/querier/tripperware/instantquery/instant_query.go
@@ -203,6 +203,9 @@ func (instantQueryCodec) EncodeRequest(ctx context.Context, r tripperware.Reques
 		}
 	}
 
+	// Always ask gzip to the querier
+	h.Set("Accept-Encoding", "gzip")
+
 	req := &http.Request{
 		Method:     "GET",
 		RequestURI: u.String(), // This is what the httpgrpc code looks at.

--- a/pkg/querier/tripperware/query.go
+++ b/pkg/querier/tripperware/query.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strconv"
@@ -166,6 +166,7 @@ func BodyBuffer(res *http.Response) ([]byte, error) {
 		}
 	}
 
+	// if the response is gziped, lets unzip it here
 	if strings.EqualFold(res.Header.Get("Content-Encoding"), "gzip") {
 		gReader, err := gzip.NewReader(buf)
 
@@ -173,7 +174,7 @@ func BodyBuffer(res *http.Response) ([]byte, error) {
 			return nil, err
 		}
 
-		return ioutil.ReadAll(gReader)
+		return io.ReadAll(gReader)
 	}
 
 	return buf.Bytes(), nil

--- a/pkg/querier/tripperware/query.go
+++ b/pkg/querier/tripperware/query.go
@@ -2,11 +2,14 @@ package tripperware
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -146,19 +149,33 @@ type Buffer interface {
 }
 
 func BodyBuffer(res *http.Response) ([]byte, error) {
+	var buf *bytes.Buffer
+
 	// Attempt to cast the response body to a Buffer and use it if possible.
 	// This is because the frontend may have already read the body and buffered it.
 	if buffer, ok := res.Body.(Buffer); ok {
-		return buffer.Bytes(), nil
+		buf = bytes.NewBuffer(buffer.Bytes())
+	} else {
+		// Preallocate the buffer with the exact size so we don't waste allocations
+		// while progressively growing an initial small buffer. The buffer capacity
+		// is increased by MinRead to avoid extra allocations due to how ReadFrom()
+		// internally works.
+		buf = bytes.NewBuffer(make([]byte, 0, res.ContentLength+bytes.MinRead))
+		if _, err := buf.ReadFrom(res.Body); err != nil {
+			return nil, httpgrpc.Errorf(http.StatusInternalServerError, "error decoding response: %v", err)
+		}
 	}
-	// Preallocate the buffer with the exact size so we don't waste allocations
-	// while progressively growing an initial small buffer. The buffer capacity
-	// is increased by MinRead to avoid extra allocations due to how ReadFrom()
-	// internally works.
-	buf := bytes.NewBuffer(make([]byte, 0, res.ContentLength+bytes.MinRead))
-	if _, err := buf.ReadFrom(res.Body); err != nil {
-		return nil, httpgrpc.Errorf(http.StatusInternalServerError, "error decoding response: %v", err)
+
+	if strings.EqualFold(res.Header.Get("Content-Encoding"), "gzip") {
+		gReader, err := gzip.NewReader(buf)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return ioutil.ReadAll(gReader)
 	}
+
 	return buf.Bytes(), nil
 }
 

--- a/pkg/querier/tripperware/queryrange/query_range.go
+++ b/pkg/querier/tripperware/queryrange/query_range.go
@@ -243,6 +243,9 @@ func (prometheusCodec) EncodeRequest(ctx context.Context, r tripperware.Request)
 		}
 	}
 
+	// Always ask gzip to the querier
+	h.Set("Accept-Encoding", "gzip")
+
 	req := &http.Request{
 		Method:     "GET",
 		RequestURI: u.String(), // This is what the httpgrpc code looks at.


### PR DESCRIPTION
**What this PR does**:

Before [this](https://github.com/cortexproject/cortex/pull/4863) change, the query-frontend did not do any manipulation for instant queries and the QF was basically a proxy. 

https://github.com/cortexproject/cortex/pull/4863 changed that and introduced  middlewares also for instant queries in order to be able to manipulate the  queries and implement the `shard by` optimization.

The problem now is that we are not forwarding all the headers from the original request to the querier, including the `Accept-Encoding` one and, this means that we stopped to gzip those requests between the query-frontend and the querier.

PS: This was already the case for `query_range`

This PR is changing this behavior and making the QF always ask the querier to return the response gzipped.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [NA] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
