### PR TITLE
Make querier_sharding_test less brittle

### DIFF
--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -55,7 +55,7 @@ func TestQuerierNoShardingWithQueryScheduler(t *testing.T) {
 
 func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 	// Going to high starts hitting file descriptor limit, since we run all queriers concurrently.
-	const batch = 100
+	const batchSize = 100
 	const numQueries = 500
 
 	s, err := e2e.NewScenario(networkName)
@@ -142,7 +142,7 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 		require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(2), "cortex_query_frontend_connected_clients"))
 	}
 
-	batches := generateBatches(batch, numQueries)
+	batches := generateBatches(batchSize, numQueries)
 
 	wg := sync.WaitGroup{}
 

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -55,7 +55,7 @@ func TestQuerierNoShardingWithQueryScheduler(t *testing.T) {
 
 func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 	// Going to high starts hitting file descriptor limit, since we run all queriers concurrently.
-	const numQueries = 100
+	const numQueries = 500
 
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -71,6 +71,7 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 		"-querier.query-ingesters-within":              "12h", // Required by the test on query /series out of ingesters time range
 		"-frontend.memcached.addresses":                "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
 		"-querier.max-outstanding-requests-per-tenant": strconv.Itoa(numQueries), // To avoid getting errors.
+		"-querier.max-concurrent":                      strconv.Itoa(numQueries),
 	})
 
 	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])


### PR DESCRIPTION
I am guessing that by increasing number of queries (sample space), we are less likely to deviated from the assertion of `require.InDelta(t, 0, diff, numQueries*0.20)`. 

By empirical data, if I start more than 100 queries concurrently, I get HTTP 429 error; so I implemented some batching logic on top of the original `numQueries`. I have tuned bunch of config in Cortex and could not get rid of the HTTP 429, so I came to believe the 429 may be caused by the file description issue mentioned in the original comment.


Signed-off-by: Alvin Lin <alvinlin@amazon.com>


