### PR TITLE
fix response error to be ungzipped when status code is not 2xx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 * [BUGFIX] Ingester: fixed incorrect logging at the start of ingester block shipping logic. #4934
 * [BUGFIX] Storage/Bucket: fixed global mark missing on deletion. #4949
 * [BUGFIX] QueryFrontend/Querier: fixed regression added by #4863 where we stopped compressing the response between querier and query frontend. #4960
+* [BUGFIX] QueryFrontend/Querier: fixed fix response error to be ungzipped when status code is not 2xx. #4975
 
 ## 1.13.0 2022-07-14
 

--- a/pkg/querier/tripperware/instantquery/instant_query_test.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_test.go
@@ -126,7 +126,8 @@ func TestGzippedResponse(t *testing.T) {
 					h.Set("Content-Encoding", "gzip")
 					var buf bytes.Buffer
 					w := gzip.NewWriter(&buf)
-					w.Write([]byte(tc.body))
+					_, err := w.Write([]byte(tc.body))
+					require.NoError(t, err)
 					w.Close()
 					responseBody = &buf
 				}

--- a/pkg/querier/tripperware/instantquery/instant_query_test.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_test.go
@@ -2,6 +2,7 @@ package instantquery
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/querier/tripperware"
@@ -90,6 +92,61 @@ func TestRequest(t *testing.T) {
 			require.NoError(t, err)
 			require.EqualValues(t, tc.expectedURL, rdash.RequestURI)
 		})
+	}
+}
+
+func TestGzippedResponse(t *testing.T) {
+	for _, tc := range []struct {
+		body   string
+		status int
+		err    error
+	}{
+		{
+			body:   `{"status":"success","data":{"resultType":"string","result":[1,"foo"]}}`,
+			status: 200,
+		},
+		{
+			body:   `error generic 400`,
+			status: 400,
+			err:    httpgrpc.Errorf(400, "error generic 400"),
+		},
+		{
+			status: 400,
+			err:    httpgrpc.Errorf(400, ""),
+		},
+	} {
+		for _, c := range []bool{true, false} {
+			t.Run(fmt.Sprintf("compressed %t [%s]", c, tc.body), func(t *testing.T) {
+				h := http.Header{
+					"Content-Type": []string{"application/json"},
+				}
+
+				responseBody := bytes.NewBuffer([]byte(tc.body))
+				if c {
+					h.Set("Content-Encoding", "gzip")
+					var buf bytes.Buffer
+					w := gzip.NewWriter(&buf)
+					w.Write([]byte(tc.body))
+					w.Close()
+					responseBody = &buf
+				}
+
+				response := &http.Response{
+					StatusCode: tc.status,
+					Header:     h,
+					Body:       io.NopCloser(responseBody),
+				}
+				r, err := InstantQueryCodec.DecodeResponse(context.Background(), response, nil)
+				require.Equal(t, tc.err, err)
+
+				if err == nil {
+					resp, err := json.Marshal(r)
+					require.NoError(t, err)
+
+					require.Equal(t, tc.body, string(resp))
+				}
+			})
+		}
 	}
 }
 

--- a/pkg/querier/tripperware/queryrange/query_range.go
+++ b/pkg/querier/tripperware/queryrange/query_range.go
@@ -258,10 +258,6 @@ func (prometheusCodec) EncodeRequest(ctx context.Context, r tripperware.Request)
 }
 
 func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ tripperware.Request) (tripperware.Response, error) {
-	if r.StatusCode/100 != 2 {
-		body, _ := io.ReadAll(r.Body)
-		return nil, httpgrpc.Errorf(r.StatusCode, string(body))
-	}
 	log, ctx := spanlogger.New(ctx, "ParseQueryRangeResponse") //nolint:ineffassign,staticcheck
 	defer log.Finish()
 
@@ -269,6 +265,9 @@ func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ t
 	if err != nil {
 		log.Error(err)
 		return nil, err
+	}
+	if r.StatusCode/100 != 2 {
+		return nil, httpgrpc.Errorf(r.StatusCode, string(buf))
 	}
 	log.LogFields(otlog.Int("bytes", len(buf)))
 

--- a/pkg/querier/tripperware/queryrange/query_range_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_test.go
@@ -2,7 +2,9 @@ package queryrange
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
+	"fmt"
 	io "io"
 	"net/http"
 	"strconv"
@@ -654,6 +656,61 @@ func TestMergeAPIResponses(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, output)
 		})
+	}
+}
+
+func TestGzippedResponse(t *testing.T) {
+	for _, tc := range []struct {
+		body   string
+		status int
+		err    error
+	}{
+		{
+			body:   `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"a":"b","c":"d"},"values":[[2,"2"],[3,"3"]]}],"stats":{"samples":{"totalQueryableSamples":20,"totalQueryableSamplesPerStep":[[2,2],[3,3]]}}}}`,
+			status: 200,
+		},
+		{
+			body:   `error generic 400`,
+			status: 400,
+			err:    httpgrpc.Errorf(400, `error generic 400`),
+		},
+		{
+			status: 400,
+			err:    httpgrpc.Errorf(400, ""),
+		},
+	} {
+		for _, c := range []bool{true, false} {
+			t.Run(fmt.Sprintf("compressed %t [%s]", c, tc.body), func(t *testing.T) {
+				h := http.Header{
+					"Content-Type": []string{"application/json"},
+				}
+
+				responseBody := bytes.NewBuffer([]byte(tc.body))
+				if c {
+					h.Set("Content-Encoding", "gzip")
+					var buf bytes.Buffer
+					w := gzip.NewWriter(&buf)
+					w.Write([]byte(tc.body))
+					w.Close()
+					responseBody = &buf
+				}
+
+				response := &http.Response{
+					StatusCode: tc.status,
+					Header:     h,
+					Body:       io.NopCloser(responseBody),
+				}
+				r, err := PrometheusCodec.DecodeResponse(context.Background(), response, nil)
+				require.Equal(t, tc.err, err)
+
+				if err == nil {
+					resp, err := json.Marshal(r)
+					require.NoError(t, err)
+
+					require.Equal(t, tc.body, string(resp))
+				}
+			})
+		}
 	}
 }
 

--- a/pkg/querier/tripperware/queryrange/query_range_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_test.go
@@ -690,7 +690,8 @@ func TestGzippedResponse(t *testing.T) {
 					h.Set("Content-Encoding", "gzip")
 					var buf bytes.Buffer
 					w := gzip.NewWriter(&buf)
-					w.Write([]byte(tc.body))
+					_, err := w.Write([]byte(tc.body))
+					require.NoError(t, err)
 					w.Close()
 					responseBody = &buf
 				}


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Fix response to be ungzipped when status code is not 2xx. If status code is not 2xx, Prometheus returns error like while Cortex QFE returns the gzipped response. We should always ungzipped the body.

<img width="891" alt="image (1)" src="https://user-images.githubusercontent.com/25150124/202645889-1dd3026d-4215-4511-8d0a-d87ee9f9fa53.png">
<img width="1098" alt="image (2)" src="https://user-images.githubusercontent.com/25150124/202645978-02e07824-7b2f-49de-b4a4-d954addf31b4.png">



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
