### PR TITLE
limit get series API call time range when start param is not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 * [FEATURE] Querier/Query Frontend: support Prometheus /api/v1/status/buildinfo API. #4978
+* [ENHANCEMENT] Querier: limit series query to only ingesters if `start` param is not been specified. #4976
 
 ## 1.14.0 in progress
 

--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -341,7 +341,9 @@ GET,POST <prometheus-http-prefix>/api/v1/series
 GET,POST <legacy-http-prefix>/api/v1/series
 ```
 
-Find series by label matchers. Differently than Prometheus and due to scalability and performances reasons, Cortex currently ignores the `start` and `end` request parameters and always fetches the series from in-memory data stored in the ingesters. There is experimental support to query the long-term store with the *blocks* storage engine when `-querier.query-store-for-labels-enabled` is set.
+Find series by label matchers. Differently than Prometheus and due to scalability and performances reasons, if `-querier.query-store-for-labels-enabled` is not set or if `start` param is not specified, Cortex currently always fetches series from data stored in the ingesters.
+
+If `-querier.query-store-for-labels-enabled` is configured, Cortex also queries the long-term store with the *blocks* storage engine.
 
 _For more information, please check out the Prometheus [series endpoint](https://prometheus.io/docs/prometheus/latest/querying/api/#finding-series-by-label-matchers) documentation._
 

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -108,9 +108,9 @@ func (q *distributorQuerier) Select(sortSeries bool, sp *storage.SelectHints, ma
 		)
 
 		if q.streamingMetadata {
-			ms, err = q.distributor.MetricsForLabelMatchersStream(ctx, model.Time(q.mint), model.Time(q.maxt), matchers...)
+			ms, err = q.distributor.MetricsForLabelMatchersStream(ctx, model.Time(minT), model.Time(maxT), matchers...)
 		} else {
-			ms, err = q.distributor.MetricsForLabelMatchers(ctx, model.Time(q.mint), model.Time(q.maxt), matchers...)
+			ms, err = q.distributor.MetricsForLabelMatchers(ctx, model.Time(minT), model.Time(maxT), matchers...)
 		}
 
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

1. We ensure select start time is always a non-negative value (we set it to 0 if it is < 0) to avoid int64 overflow issue. 
2. For `/api/v1/series` API and start time of 0, we just fallback to query ingesters only to avoid OOM kills. This should work well for those clients who don't support specifying `start` on series API. 

**Which issue(s) this PR fixes**:

`/api/v1/series` API supports optional `start` and `end` parameters. Since Cortex uses the Prometheus API code, right now if `start` is not specified, it will use the min value here https://github.com/prometheus/prometheus/blob/main/web/api/v1/api.go#L725. This happens for some clients that don't configure these params.

The issue here is that if start time is too small, we will end up querying all the data for the tenant. For series API this usually means we need to fetch a lot of data and do a lot of series duplications. It is really easy to get OOM killed.

https://github.com/cortexproject/cortex/blob/master/pkg/querier/querier.go#L344 Here we checks the max query length. However, it is broken because the `endTime.Sub(startTime)` overflows int64.

**Other notes**:
1. Why `maxQueryLookback` is not enough?
`maxQueryLookback` could limit the start time. But since `maxQueryLookback` is a limit which applies to both `query`, `query range` and `series` queries, We might not want to use the same range for all those 3 queries. For example, you may want to query 3 months data for query range but querying 3 months data using `Series` might not make sense in terms of performance. And if `maxQueryLookback` is not set then we don't have a fallback mechanism to protect ourselves. 

2. What if the user specifies `start` but `start` is a really small value?
We ignore this case for now because this usually is not a valid use case. If the user intentionally does this, it is better to use `maxQueryLookback`.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
