### PR TITLE
Log query params in query frontend when error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## master / unreleased
 * [ENHANCEMENT] Update Go version to 1.19.3. #4988
+* [ENHANCEMENT] Querier: limit series query to only ingesters if `start` param is not specified. #4976
 * [FEATURE] Querier/Query Frontend: support Prometheus /api/v1/status/buildinfo API. #4978
-* [ENHANCEMENT] Querier: limit series query to only ingesters if `start` param is not been specified. #4976
-
 * [FEATURE] Ingester: Add active series to all_user_stats page. #4972
+* [FEATURE] Query Frontend: Log query params in query frontend even if error happens. #5005
 
 ## 1.14.0 in progress
 

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -223,9 +223,10 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 		} else {
 			logMessage = append(logMessage, "error", s.Message())
 		}
+		level.Error(util_log.WithContext(r.Context(), f.log)).Log(logMessage...)
+	} else {
+		level.Info(util_log.WithContext(r.Context(), f.log)).Log(logMessage...)
 	}
-
-	level.Info(util_log.WithContext(r.Context(), f.log)).Log(logMessage...)
 }
 
 func (f *Handler) parseRequestQueryString(r *http.Request, bodyBuf bytes.Buffer) url.Values {

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"google.golang.org/grpc/status"
 	"io"
 	"net/http"
 	"net/url"
@@ -21,6 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/httpgrpc/server"
+	"google.golang.org/grpc/status"
 
 	querier_stats "github.com/cortexproject/cortex/pkg/querier/stats"
 	"github.com/cortexproject/cortex/pkg/tenant"


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Right now if a query fails at query frontend, no query parameters will be logged so we don't have any visibility about what's the failed query and why it failed.

This pr always log query params to make sure we catch them.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
