### PR TITLE
Add note about thanos downsampled block migration

### DIFF
--- a/cmd/thanosconvert/main.go
+++ b/cmd/thanosconvert/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	converter, err := thanosconvert.NewThanosBlockConverter(ctx, cfg, dryRun, logger)
 	if err != nil {
-		fatal("couldn't initilize converter: %v", err)
+		fatal("couldn't initialize converter: %v", err)
 	}
 
 	iterCtx := context.Background()

--- a/docs/blocks-storage/migrate-storage-from-thanos-and-prometheus.md
+++ b/docs/blocks-storage/migrate-storage-from-thanos-and-prometheus.md
@@ -106,6 +106,10 @@ For example, when migrating a block from Thanos for the tenant `user-1`, the `th
 }
 ```
 
+Right now Cortex doesn't support downsampling so Thanos downsampled blocks are not supported. Downsampled blocks will be simply skipped by the `thanosconvert` tool.
+
+If downsampled blocks are uploaded to the Cortex bucket, they cannot be queried so please exclude them when migrating TSDB blocks.
+
 ##### When migrating from Prometheus
 
 When migrating from Prometheus, the `meta.json` file will not contain any `thanos` root-level entry and, for this reason, it would need to be generated:

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -112,6 +112,10 @@ func (bqs *blockQuerierSeries) Iterator() chunkenc.Iterator {
 	its := make([]chunkenc.Iterator, 0, len(bqs.chunks))
 
 	for _, c := range bqs.chunks {
+		// Ignore if the current chunk is not XOR chunk.
+		if c.Raw == nil {
+			continue
+		}
 		ch, err := chunkenc.FromData(chunkenc.EncXOR, c.Raw.Data)
 		if err != nil {
 			return series.NewErrIterator(errors.Wrapf(err, "failed to initialize chunk from XOR encoded raw data (series: %v min time: %d max time: %d)", bqs.Labels(), c.MinTime, c.MaxTime))


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Cortex doesn't support downsampling and cannot handle downsampled blocks migrated from Thanos.
This pr adds a note on the migration guide to avoid issues like https://github.com/cortexproject/cortex/issues/4982.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
