### PR TITLE
Adding compatibility tests for 1.13 and 1.14

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -132,6 +132,8 @@ jobs:
           docker pull quay.io/cortexproject/cortex:v1.9.0
           docker pull quay.io/cortexproject/cortex:v1.10.0
           docker pull quay.io/cortexproject/cortex:v1.11.1
+          docker pull quay.io/cortexproject/cortex:v1.13.1
+          docker pull quay.io/cortexproject/cortex:v1.14.0
           docker pull shopify/bigtable-emulator:0.1.0
           docker pull memcached:1.6.1
           docker pull bouncestorage/swift-aio:55ba4331

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -27,6 +27,8 @@ var (
 		"quay.io/cortexproject/cortex:v1.9.0":  preCortex110Flags,
 		"quay.io/cortexproject/cortex:v1.10.0": nil,
 		"quay.io/cortexproject/cortex:v1.11.1": nil,
+		"quay.io/cortexproject/cortex:v1.13.1": nil,
+		"quay.io/cortexproject/cortex:v1.14.0": nil,
 	}
 )
 


### PR DESCRIPTION
Last step of: https://github.com/cortexproject/cortex/blob/master/RELEASE.md#publish-a-stable-release

```
Open a PR to add the new version to the backward compatibility integration test (integration/backward_compatibility_test.go)

```
