### PR TITLE
Remove flapping test in tracing sampling

### DIFF
--- a/pkg/tracing/sampler/sampling_test.go
+++ b/pkg/tracing/sampler/sampling_test.go
@@ -40,10 +40,6 @@ func Test_ShouldSample(t *testing.T) {
 			name:     "should sample 10%",
 			fraction: 0.1,
 		},
-		{
-			name:     "should sample 1%",
-			fraction: 0.01,
-		},
 	}
 
 	totalIterations := 10000


### PR DESCRIPTION
Signed-off-by: Friedrich Gonzalez <friedrichg@gmail.com>

**What this PR does**: Remove flapping test in tracing sampling

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`


This was flapping like this
```
--- FAIL: Test_ShouldSample (0.13s)
    --- FAIL: Test_ShouldSample/should_sample_1% (0.03s)
        sampling_test.go:70: 
            	Error Trace:	/__w/cortex/cortex/pkg/tracing/sampler/sampling_test.go:70
            	Error:      	Max difference between 100 and 127 allowed is 10, but difference was -27
            	Test:       	Test_ShouldSample/should_sample_1%

```