### PR TITLE
Fixed no compact block got grouped in shuffle sharding grouper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [FEATURE] Build ARM docker images. #5041
 * [BUGFIX] Updated `golang.org/x/net` dependency to fix CVE-2022-27664. #5008
 * [BUGFIX] Fix panic when otel and xray tracing is enabled. #5044
+* [BUGFIX] Fixed no compact block got grouped in shuffle sharding grouper. #5055
 
 ## 1.14.0 2022-12-02
 


### PR DESCRIPTION
Signed-off-by: Alex Le <leqiyue@amazon.com>

**What this PR does**:
Fixed no compact block got grouped in shuffle sharding grouper which caused blocks with no compact marker were always grouped and tried to be compacted. With concurrency set to 1, this would prevent new blocks got compacted.

**Checklist**
- [X] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
