### PR TITLE
Skip instant query round tripper if sharding is not applicable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [ENHANCEMENT] Query Frontend/Query Scheduler: Increase upper bound to 60s for queue duration histogram metric. #5029
 * [ENHANCEMENT] Query Frontend: Log Vertical sharding information when `query_stats_enabled` is enabled. #5037
 * [ENHANCEMENT] Ingester: The metadata APIs should honour `querier.query-ingesters-within` when `querier.query-store-for-labels-enabled` is true. #5027
+* [ENHANCEMENT] Query Frontend: Skip instant query roundtripper if sharding is not applicable. #5062
 * [FEATURE] Querier/Query Frontend: support Prometheus /api/v1/status/buildinfo API. #4978
 * [FEATURE] Ingester: Add active series to all_user_stats page. #4972
 * [FEATURE] Ingester: Added `-blocks-storage.tsdb.head-chunks-write-queue-size` allowing to configure the size of the in-memory queue used before flushing chunks to the disk . #5000

--- a/pkg/querier/tripperware/instantquery/instant_query_middlewares.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_middlewares.go
@@ -2,6 +2,7 @@ package instantquery
 
 import (
 	"github.com/go-kit/log"
+	"github.com/thanos-io/thanos/pkg/querysharding"
 
 	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 )
@@ -9,9 +10,10 @@ import (
 func Middlewares(
 	log log.Logger,
 	limits tripperware.Limits,
+	queryAnalyzer querysharding.Analyzer,
 ) ([]tripperware.Middleware, error) {
 	var m []tripperware.Middleware
 
-	m = append(m, tripperware.ShardByMiddleware(log, limits, InstantQueryCodec))
+	m = append(m, tripperware.ShardByMiddleware(log, limits, InstantQueryCodec, queryAnalyzer))
 	return m, nil
 }

--- a/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
@@ -2,7 +2,7 @@ package queryrange
 
 import (
 	"context"
-	io "io"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/querysharding"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/user"
 
@@ -43,12 +44,14 @@ func TestRoundTrip(t *testing.T) {
 		next: http.DefaultTransport,
 	}
 
+	qa := querysharding.NewQueryAnalyzer()
 	queyrangemiddlewares, _, err := Middlewares(Config{},
 		log.NewNopLogger(),
 		mockLimits{},
 		nil,
 		nil,
 		nil,
+		qa,
 	)
 	require.NoError(t, err)
 
@@ -59,6 +62,8 @@ func TestRoundTrip(t *testing.T) {
 		nil,
 		PrometheusCodec,
 		nil,
+		nil,
+		qa,
 	)
 
 	for i, tc := range []struct {

--- a/pkg/querier/tripperware/roundtrip_test.go
+++ b/pkg/querier/tripperware/roundtrip_test.go
@@ -130,6 +130,11 @@ func TestRoundTrip(t *testing.T) {
 			limits:       defaultOverrides,
 		},
 		{
+			path:         queryNonShardable,
+			expectedBody: "bar",
+			limits:       shardingOverrides,
+		},
+		{
 			path:         query,
 			expectedBody: responseBody,
 			limits:       shardingOverrides,

--- a/pkg/querier/tripperware/roundtrip_test.go
+++ b/pkg/querier/tripperware/roundtrip_test.go
@@ -11,14 +11,19 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/querysharding"
 	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 const (
-	queryRange    = "/api/v1/query_range?end=1536716898&query=sum%28container_memory_rss%29+by+%28namespace%29&start=1536673680&stats=all&step=120"
-	query         = "/api/v1/query?time=1536716898&query=sum%28container_memory_rss%29+by+%28namespace%29&start=1536673680"
-	queryExemplar = "/api/v1/query_exemplars?query=test_exemplar_metric_total&start=2020-09-14T15:22:25.479Z&end=2020-09-14T15:23:25.479Z'"
-	responseBody  = `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[1536673680,"137"],[1536673780,"137"]]}]}}`
+	queryRange        = "/api/v1/query_range?end=1536716898&query=sum%28container_memory_rss%29+by+%28namespace%29&start=1536673680&stats=all&step=120"
+	query             = "/api/v1/query?time=1536716898&query=sum%28container_memory_rss%29+by+%28namespace%29&start=1536673680"
+	queryNonShardable = "/api/v1/query?time=1536716898&query=container_memory_rss&start=1536673680"
+	queryExemplar     = "/api/v1/query_exemplars?query=test_exemplar_metric_total&start=2020-09-14T15:22:25.479Z&end=2020-09-14T15:23:25.479Z'"
+	responseBody      = `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[1536673680,"137"],[1536673780,"137"]]}]}}`
 )
 
 type mockRequest struct {
@@ -86,22 +91,49 @@ func TestRoundTrip(t *testing.T) {
 			return mockMiddleware{}
 		}),
 	}
-	tw := NewQueryTripperware(log.NewNopLogger(),
-		nil,
-		nil,
-		middlewares,
-		middlewares,
-		mockCodec{},
-		mockCodec{},
-	)
 
+	limits := validation.Limits{}
+	flagext.DefaultValues(&limits)
+	defaultOverrides, err := validation.NewOverrides(limits, nil)
+	require.NoError(t, err)
+
+	limitsWithVerticalSharding := validation.Limits{QueryVerticalShardSize: 3}
+	shardingOverrides, err := validation.NewOverrides(limitsWithVerticalSharding, nil)
+	require.NoError(t, err)
 	for _, tc := range []struct {
 		path, expectedBody string
+		limits             Limits
 	}{
-		{"/foo", "bar"},
-		{queryExemplar, "bar"},
-		{queryRange, responseBody},
-		{query, responseBody},
+		{
+			path:         "/foo",
+			expectedBody: "bar",
+			limits:       defaultOverrides,
+		},
+		{
+			path:         queryExemplar,
+			expectedBody: "bar",
+			limits:       defaultOverrides,
+		},
+		{
+			path:         queryRange,
+			expectedBody: responseBody,
+			limits:       defaultOverrides,
+		},
+		{
+			path:         query,
+			expectedBody: "bar",
+			limits:       defaultOverrides,
+		},
+		{
+			path:         queryNonShardable,
+			expectedBody: "bar",
+			limits:       defaultOverrides,
+		},
+		{
+			path:         query,
+			expectedBody: responseBody,
+			limits:       shardingOverrides,
+		},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
 			req, err := http.NewRequest("GET", tc.path, http.NoBody)
@@ -115,6 +147,16 @@ func TestRoundTrip(t *testing.T) {
 			err = user.InjectOrgIDIntoHTTPRequest(ctx, req)
 			require.NoError(t, err)
 
+			tw := NewQueryTripperware(log.NewNopLogger(),
+				nil,
+				nil,
+				middlewares,
+				middlewares,
+				mockCodec{},
+				mockCodec{},
+				tc.limits,
+				querysharding.NewQueryAnalyzer(),
+			)
 			resp, err := tw(downstream).RoundTrip(req)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.StatusCode)

--- a/pkg/querier/tripperware/shard_by.go
+++ b/pkg/querier/tripperware/shard_by.go
@@ -20,21 +20,21 @@ import (
 func ShardByMiddleware(logger log.Logger, limits Limits, merger Merger, queryAnalyzer querysharding.Analyzer) Middleware {
 	return MiddlewareFunc(func(next Handler) Handler {
 		return shardBy{
-			next:          next,
-			limits:        limits,
-			merger:        merger,
-			logger:        logger,
-			queryAnalyzer: queryAnalyzer,
+			next:     next,
+			limits:   limits,
+			merger:   merger,
+			logger:   logger,
+			analyzer: queryAnalyzer,
 		}
 	})
 }
 
 type shardBy struct {
-	next          Handler
-	limits        Limits
-	logger        log.Logger
-	merger        Merger
-	queryAnalyzer querysharding.Analyzer
+	next     Handler
+	limits   Limits
+	logger   log.Logger
+	merger   Merger
+	analyzer querysharding.Analyzer
 }
 
 func (s shardBy) Do(ctx context.Context, r Request) (Response, error) {
@@ -52,7 +52,7 @@ func (s shardBy) Do(ctx context.Context, r Request) (Response, error) {
 	}
 
 	logger := util_log.WithContext(ctx, s.logger)
-	analysis, err := s.queryAnalyzer.Analyze(r.GetQuery())
+	analysis, err := s.analyzer.Analyze(r.GetQuery())
 	if err != nil {
 		level.Warn(logger).Log("msg", "error analyzing query", "q", r.GetQuery(), "err", err)
 	}

--- a/pkg/querier/tripperware/shard_by.go
+++ b/pkg/querier/tripperware/shard_by.go
@@ -17,13 +17,14 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
-func ShardByMiddleware(logger log.Logger, limits Limits, merger Merger) Middleware {
+func ShardByMiddleware(logger log.Logger, limits Limits, merger Merger, queryAnalyzer querysharding.Analyzer) Middleware {
 	return MiddlewareFunc(func(next Handler) Handler {
 		return shardBy{
-			next:   next,
-			limits: limits,
-			merger: merger,
-			logger: logger,
+			next:          next,
+			limits:        limits,
+			merger:        merger,
+			logger:        logger,
+			queryAnalyzer: queryAnalyzer,
 		}
 	})
 }
@@ -33,7 +34,7 @@ type shardBy struct {
 	limits        Limits
 	logger        log.Logger
 	merger        Merger
-	queryAnalyzer *querysharding.QueryAnalyzer
+	queryAnalyzer querysharding.Analyzer
 }
 
 func (s shardBy) Do(ctx context.Context, r Request) (Response, error) {

--- a/pkg/querier/tripperware/test_shard_by_query_utils.go
+++ b/pkg/querier/tripperware/test_shard_by_query_utils.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
+	thanosquerysharding "github.com/thanos-io/thanos/pkg/querysharding"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/weaveworks/common/user"
 
@@ -406,7 +407,8 @@ http_requests_total`,
 				next: http.DefaultTransport,
 			}
 
-			roundtripper := NewRoundTripper(downstream, tt.codec, nil, ShardByMiddleware(log.NewNopLogger(), mockLimits{shardSize: tt.shardSize}, tt.codec))
+			qa := thanosquerysharding.NewQueryAnalyzer()
+			roundtripper := NewRoundTripper(downstream, tt.codec, nil, ShardByMiddleware(log.NewNopLogger(), mockLimits{shardSize: tt.shardSize}, tt.codec, qa))
 
 			ctx := user.InjectOrgID(context.Background(), "1")
 


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

From the trace, the instant query tripperware adds some overhead for response serilization/deserilization. For this example, it takes 15s+ while the whole query time is 23s.

<img width="1224" alt="image" src="https://user-images.githubusercontent.com/25150124/209480609-a24b5ba0-2f4c-47e3-98f4-93df63d4c61c.png">

The issue is, if the tenant doesn't enable vertical sharding, or the query itself is not even shardable, the additional overhead is still there and we don't have a way to skip that. This pr checks whether vertical sharding is applicable before passing the request down to the tripperware.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
