### PR TITLE
switch encoding/json to json iter

### DIFF
--- a/pkg/querier/tripperware/instantquery/instant_query.go
+++ b/pkg/querier/tripperware/instantquery/instant_query.go
@@ -30,7 +30,8 @@ import (
 
 var (
 	InstantQueryCodec tripperware.Codec = newInstantQueryCodec()
-	json                                = jsoniter.Config{
+
+	json = jsoniter.Config{
 		EscapeHTML:             false, // No HTML in our responses.
 		SortMapKeys:            true,
 		ValidateJsonRawMessage: true,
@@ -155,7 +156,7 @@ func (instantQueryCodec) DecodeResponse(ctx context.Context, r *http.Response, _
 	log, ctx := spanlogger.New(ctx, "PrometheusInstantQueryResponse") //nolint:ineffassign,staticcheck
 	defer log.Finish()
 
-	buf, err := tripperware.BodyBuffer(r)
+	buf, err := tripperware.BodyBuffer(r, log)
 	if err != nil {
 		log.Error(err)
 		return nil, err

--- a/pkg/querier/tripperware/query.go
+++ b/pkg/querier/tripperware/query.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/json"
 	"io"
 	"net/http"
 	"sort"
@@ -13,6 +12,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/opentracing/opentracing-go"
@@ -20,6 +20,15 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
+	"github.com/cortexproject/cortex/pkg/util/runutil"
+)
+
+var (
+	json = jsoniter.Config{
+		EscapeHTML:             false, // No HTML in our responses.
+		SortMapKeys:            true,
+		ValidateJsonRawMessage: true,
+	}.Froze()
 )
 
 // Codec is used to encode/decode query range requests and responses so they can be passed down to middlewares.
@@ -73,6 +82,32 @@ type Request interface {
 	WithStats(stats string) Request
 }
 
+func encodeSampleStream(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	ss := (*SampleStream)(ptr)
+	stream.WriteObjectStart()
+
+	stream.WriteObjectField(`metric`)
+	lbls, err := cortexpb.FromLabelAdaptersToLabels(ss.Labels).MarshalJSON()
+	if err != nil {
+		stream.Error = err
+		return
+	}
+	stream.SetBuffer(append(stream.Buffer(), lbls...))
+	stream.WriteMore()
+
+	stream.WriteObjectField(`values`)
+	stream.WriteArrayStart()
+	for i, sample := range ss.Samples {
+		if i != 0 {
+			stream.WriteMore()
+		}
+		cortexpb.SampleJsoniterEncode(unsafe.Pointer(&sample), stream)
+	}
+	stream.WriteArrayEnd()
+
+	stream.WriteObjectEnd()
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (s *SampleStream) UnmarshalJSON(data []byte) error {
 	var stream struct {
@@ -85,18 +120,6 @@ func (s *SampleStream) UnmarshalJSON(data []byte) error {
 	s.Labels = cortexpb.FromMetricsToLabelAdapters(stream.Metric)
 	s.Samples = stream.Values
 	return nil
-}
-
-// MarshalJSON implements json.Marshaler.
-func (s *SampleStream) MarshalJSON() ([]byte, error) {
-	stream := struct {
-		Metric model.Metric      `json:"metric"`
-		Values []cortexpb.Sample `json:"values"`
-	}{
-		Metric: cortexpb.FromLabelAdaptersToMetric(s.Labels),
-		Values: s.Samples,
-	}
-	return json.Marshal(stream)
 }
 
 func PrometheusResponseQueryableSamplesStatsPerStepJsoniterDecode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
@@ -135,6 +158,7 @@ func PrometheusResponseQueryableSamplesStatsPerStepJsoniterEncode(ptr unsafe.Poi
 func init() {
 	jsoniter.RegisterTypeEncoderFunc("tripperware.PrometheusResponseQueryableSamplesStatsPerStep", PrometheusResponseQueryableSamplesStatsPerStepJsoniterEncode, func(unsafe.Pointer) bool { return false })
 	jsoniter.RegisterTypeDecoderFunc("tripperware.PrometheusResponseQueryableSamplesStatsPerStep", PrometheusResponseQueryableSamplesStatsPerStepJsoniterDecode)
+	jsoniter.RegisterTypeEncoderFunc("tripperware.SampleStream", encodeSampleStream, func(unsafe.Pointer) bool { return false })
 }
 
 func EncodeTime(t int64) string {
@@ -148,7 +172,7 @@ type Buffer interface {
 	Bytes() []byte
 }
 
-func BodyBuffer(res *http.Response) ([]byte, error) {
+func BodyBuffer(res *http.Response, logger log.Logger) ([]byte, error) {
 	var buf *bytes.Buffer
 
 	// Attempt to cast the response body to a Buffer and use it if possible.
@@ -169,10 +193,10 @@ func BodyBuffer(res *http.Response) ([]byte, error) {
 	// if the response is gziped, lets unzip it here
 	if strings.EqualFold(res.Header.Get("Content-Encoding"), "gzip") {
 		gReader, err := gzip.NewReader(buf)
-
 		if err != nil {
 			return nil, err
 		}
+		defer runutil.CloseWithLogOnErr(logger, gReader, "close gzip reader")
 
 		return io.ReadAll(gReader)
 	}

--- a/pkg/querier/tripperware/query_test.go
+++ b/pkg/querier/tripperware/query_test.go
@@ -1,0 +1,56 @@
+package tripperware
+
+import (
+	stdjson "encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/cortexproject/cortex/pkg/cortexpb"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalSampleStream(t *testing.T) {
+	for i, tc := range []struct {
+		sampleStream SampleStream
+	}{
+		{
+			sampleStream: SampleStream{
+				Samples: []cortexpb.Sample{{Value: 1, TimestampMs: 1}},
+			},
+		},
+		{
+			sampleStream: SampleStream{
+				Labels:  cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{"foo": "bar"})),
+				Samples: []cortexpb.Sample{{Value: 1, TimestampMs: 1}},
+			},
+		},
+		{
+			sampleStream: SampleStream{
+				Labels:  cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{"foo": "bar", "test": "test", "a": "b"})),
+				Samples: []cortexpb.Sample{{Value: 1, TimestampMs: 1}, {Value: 2, TimestampMs: 2}, {Value: 3, TimestampMs: 3}},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("test-case-%d", i), func(t *testing.T) {
+			out1, err := json.Marshal(tc.sampleStream)
+			require.NoError(t, err)
+			out2, err := tc.sampleStream.MarshalJSON()
+			require.NoError(t, err)
+			require.Equal(t, out1, out2)
+		})
+	}
+}
+
+// MarshalJSON implements json.Marshaler.
+func (s *SampleStream) MarshalJSON() ([]byte, error) {
+	stream := struct {
+		Metric model.Metric      `json:"metric"`
+		Values []cortexpb.Sample `json:"values"`
+	}{
+		Metric: cortexpb.FromLabelAdaptersToMetric(s.Labels),
+		Values: s.Samples,
+	}
+	return stdjson.Marshal(stream)
+}

--- a/pkg/querier/tripperware/query_test.go
+++ b/pkg/querier/tripperware/query_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/cortexpb"
 )
 
 func TestMarshalSampleStream(t *testing.T) {

--- a/pkg/querier/tripperware/queryrange/query_range.go
+++ b/pkg/querier/tripperware/queryrange/query_range.go
@@ -261,7 +261,7 @@ func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ t
 	log, ctx := spanlogger.New(ctx, "ParseQueryRangeResponse") //nolint:ineffassign,staticcheck
 	defer log.Finish()
 
-	buf, err := tripperware.BodyBuffer(r)
+	buf, err := tripperware.BodyBuffer(r, log)
 	if err != nil {
 		log.Error(err)
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
`SampleStream` will be marshal/unmarshalled in query frontend for instant query response. Right now, it uses `encoding/json` library for json serialization. This PR switches it to json iter library which should provide better performance.

Existing tests should still pass.

Benchmark

UnMarshal

```
name                              old time/op    new time/op    delta
SampleStreamUnmarshalJSONITER-10    1.64ms ± 0%    1.05ms ± 0%   ~     (p=1.000 n=1+1)                          

name                              old alloc/op   new alloc/op   delta
SampleStreamUnmarshalJSONITER-10     934kB ± 0%    1090kB ± 0%   ~     (p=1.000 n=1+1)

name                              old allocs/op  new allocs/op  delta
SampleStreamUnmarshalJSONITER-10      49.0 ± 0%      53.0 ± 0%   ~     (p=1.000 n=1+1)
```

Marshal

```
name                            old time/op    new time/op    delta
SampleStreamMarshalJSONITER-10    2.29ms ± 0%    1.40ms ± 0%   ~     (p=1.000 n=1+1)

name                            old alloc/op   new alloc/op   delta
SampleStreamMarshalJSONITER-10     636kB ± 0%     436kB ± 0%   ~     (p=1.000 n=1+1)

name                            old allocs/op  new allocs/op  delta
SampleStreamMarshalJSONITER-10     20.0k ± 0%     20.0k ± 0%   ~     (p=1.000 n=1+1)
```


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
