### PR TITLE
Parallelize distributor tests

### DIFF
--- a/pkg/distributor/distributor_ring_test.go
+++ b/pkg/distributor/distributor_ring_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestRingConfig_DefaultConfigToLifecyclerConfig(t *testing.T) {
+	t.Parallel()
 	cfg := RingConfig{}
 	expected := ring.LifecyclerConfig{}
 
@@ -30,6 +31,7 @@ func TestRingConfig_DefaultConfigToLifecyclerConfig(t *testing.T) {
 }
 
 func TestRingConfig_CustomConfigToLifecyclerConfig(t *testing.T) {
+	t.Parallel()
 	cfg := RingConfig{}
 	expected := ring.LifecyclerConfig{}
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -57,6 +57,7 @@ var (
 )
 
 func TestConfig_Validate(t *testing.T) {
+	t.Parallel()
 	tests := map[string]struct {
 		initConfig func(*Config)
 		initLimits func(*validation.Limits)
@@ -109,6 +110,7 @@ func TestConfig_Validate(t *testing.T) {
 }
 
 func TestDistributor_Push(t *testing.T) {
+	t.Parallel()
 	// Metrics to assert on.
 	lastSeenTimestamp := "cortex_distributor_latest_seen_sample_timestamp_seconds"
 	distributorAppend := "cortex_distributor_ingester_appends_total"
@@ -291,6 +293,7 @@ func TestDistributor_Push(t *testing.T) {
 }
 
 func TestDistributor_MetricsCleanup(t *testing.T) {
+	t.Parallel()
 	dists, _, regs, _ := prepare(t, prepConfig{
 		numDistributors: 1,
 	})
@@ -399,6 +402,7 @@ func TestDistributor_MetricsCleanup(t *testing.T) {
 }
 
 func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
+	t.Parallel()
 	type testPush struct {
 		samples       int
 		metadata      int
@@ -494,6 +498,7 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 }
 
 func TestPush_QuorumError(t *testing.T) {
+	t.Parallel()
 
 	var limits validation.Limits
 	flagext.DefaultValues(&limits)
@@ -604,6 +609,7 @@ func TestPush_QuorumError(t *testing.T) {
 }
 
 func TestDistributor_PushInstanceLimits(t *testing.T) {
+	t.Parallel()
 
 	type testPush struct {
 		samples       int
@@ -754,6 +760,7 @@ func TestDistributor_PushInstanceLimits(t *testing.T) {
 }
 
 func TestDistributor_PushHAInstances(t *testing.T) {
+	t.Parallel()
 	ctx := user.InjectOrgID(context.Background(), "user")
 
 	for i, tc := range []struct {
@@ -841,6 +848,7 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 }
 
 func TestDistributor_PushQuery(t *testing.T) {
+	t.Parallel()
 	const shuffleShardSize = 5
 
 	ctx := user.InjectOrgID(context.Background(), "user")
@@ -1016,6 +1024,7 @@ func TestDistributor_PushQuery(t *testing.T) {
 }
 
 func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunksPerQueryLimitIsReached(t *testing.T) {
+	t.Parallel()
 	const maxChunksLimit = 30 // Chunks are duplicated due to replication factor.
 
 	ctx := user.InjectOrgID(context.Background(), "user")
@@ -1072,6 +1081,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunksPerQueryLimitIsReac
 }
 
 func TestDistributor_QueryStream_ShouldReturnErrorIfMaxSeriesPerQueryLimitIsReached(t *testing.T) {
+	t.Parallel()
 	const maxSeriesLimit = 10
 
 	ctx := user.InjectOrgID(context.Background(), "user")
@@ -1124,6 +1134,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxSeriesPerQueryLimitIsReac
 }
 
 func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIsReached(t *testing.T) {
+	t.Parallel()
 	const seriesToAdd = 10
 
 	ctx := user.InjectOrgID(context.Background(), "user")
@@ -1193,6 +1204,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIs
 }
 
 func TestDistributor_QueryStream_ShouldReturnErrorIfMaxDataBytesPerQueryLimitIsReached(t *testing.T) {
+	t.Parallel()
 	const seriesToAdd = 10
 
 	ctx := user.InjectOrgID(context.Background(), "user")
@@ -1262,6 +1274,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxDataBytesPerQueryLimitIsR
 }
 
 func TestDistributor_Push_LabelRemoval(t *testing.T) {
+	t.Parallel()
 	ctx := user.InjectOrgID(context.Background(), "user")
 
 	type testcase struct {
@@ -1350,6 +1363,7 @@ func TestDistributor_Push_LabelRemoval(t *testing.T) {
 }
 
 func TestDistributor_Push_LabelRemoval_RemovingNameLabelWillError(t *testing.T) {
+	t.Parallel()
 	ctx := user.InjectOrgID(context.Background(), "user")
 	type testcase struct {
 		inputSeries    labels.Labels
@@ -1391,6 +1405,7 @@ func TestDistributor_Push_LabelRemoval_RemovingNameLabelWillError(t *testing.T) 
 }
 
 func TestDistributor_Push_ShouldGuaranteeShardingTokenConsistencyOverTheTime(t *testing.T) {
+	t.Parallel()
 	ctx := user.InjectOrgID(context.Background(), "user")
 	tests := map[string]struct {
 		inputSeries    labels.Labels
@@ -1497,6 +1512,7 @@ func TestDistributor_Push_ShouldGuaranteeShardingTokenConsistencyOverTheTime(t *
 }
 
 func TestDistributor_Push_LabelNameValidation(t *testing.T) {
+	t.Parallel()
 	inputLabels := labels.Labels{
 		{Name: model.MetricNameLabel, Value: "foo"},
 		{Name: "999.illegal", Value: "baz"},
@@ -1550,6 +1566,7 @@ func TestDistributor_Push_LabelNameValidation(t *testing.T) {
 }
 
 func TestDistributor_Push_ExemplarValidation(t *testing.T) {
+	t.Parallel()
 	ctx := user.InjectOrgID(context.Background(), "user")
 	manyLabels := []string{model.MetricNameLabel, "test"}
 	for i := 1; i < 31; i++ {
@@ -1909,6 +1926,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 }
 
 func TestSlowQueries(t *testing.T) {
+	t.Parallel()
 	ctx := user.InjectOrgID(context.Background(), "user")
 	nameMatcher := mustEqualMatcher(model.MetricNameLabel, "foo")
 	nIngesters := 3
@@ -1939,6 +1957,7 @@ func TestSlowQueries(t *testing.T) {
 }
 
 func TestDistributor_MetricsForLabelMatchers_SingleSlowIngester(t *testing.T) {
+	t.Parallel()
 	// Create distributor
 	ds, ing, _, _ := prepare(t, prepConfig{
 		numIngesters:        3,
@@ -1969,6 +1988,7 @@ func TestDistributor_MetricsForLabelMatchers_SingleSlowIngester(t *testing.T) {
 }
 
 func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
+	t.Parallel()
 	const numIngesters = 5
 
 	fixtures := []struct {
@@ -2251,6 +2271,7 @@ func BenchmarkDistributor_MetricsForLabelMatchers(b *testing.B) {
 }
 
 func TestDistributor_MetricsMetadata(t *testing.T) {
+	t.Parallel()
 	const numIngesters = 5
 
 	tests := map[string]struct {
@@ -2956,6 +2977,7 @@ outer:
 }
 
 func TestDistributorValidation(t *testing.T) {
+	t.Parallel()
 	ctx := user.InjectOrgID(context.Background(), "1")
 	now := model.Now()
 	future, past := now.Add(5*time.Hour), now.Add(-25*time.Hour)
@@ -3051,6 +3073,7 @@ func TestDistributorValidation(t *testing.T) {
 }
 
 func TestRemoveReplicaLabel(t *testing.T) {
+	t.Parallel()
 	replicaLabel := "replica"
 	clusterLabel := "cluster"
 	cases := []struct {
@@ -3096,6 +3119,7 @@ func TestRemoveReplicaLabel(t *testing.T) {
 
 // This is not great, but we deal with unsorted labels when validating labels.
 func TestShardByAllLabelsReturnsWrongResultsForUnsortedLabels(t *testing.T) {
+	t.Parallel()
 	val1 := shardByAllLabels("test", []cortexpb.LabelAdapter{
 		{Name: "__name__", Value: "foo"},
 		{Name: "bar", Value: "baz"},
@@ -3112,6 +3136,7 @@ func TestShardByAllLabelsReturnsWrongResultsForUnsortedLabels(t *testing.T) {
 }
 
 func TestSortLabels(t *testing.T) {
+	t.Parallel()
 	sorted := []cortexpb.LabelAdapter{
 		{Name: "__name__", Value: "foo"},
 		{Name: "bar", Value: "baz"},
@@ -3139,6 +3164,7 @@ func TestSortLabels(t *testing.T) {
 }
 
 func TestDistributor_Push_Relabel(t *testing.T) {
+	t.Parallel()
 	ctx := user.InjectOrgID(context.Background(), "user")
 
 	type testcase struct {
@@ -3244,6 +3270,7 @@ func TestDistributor_Push_Relabel(t *testing.T) {
 }
 
 func TestDistributor_Push_RelabelDropWillExportMetricOfDroppedSamples(t *testing.T) {
+	t.Parallel()
 	metricRelabelConfigs := []*relabel.Config{
 		{
 			SourceLabels: []model.LabelName{"__name__"},

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -117,7 +117,7 @@ func TestDistributor_Push(t *testing.T) {
 	lastSeenTimestamp := "cortex_distributor_latest_seen_sample_timestamp_seconds"
 	distributorAppend := "cortex_distributor_ingester_appends_total"
 	distributorAppendFailure := "cortex_distributor_ingester_append_failures_total"
-	ctx := user.InjectOrgID(context.Background(), "user")
+	ctx := user.InjectOrgID(context.Background(), "userDistributorPush")
 
 	type samplesIn struct {
 		num              int
@@ -149,7 +149,7 @@ func TestDistributor_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
 				# TYPE cortex_distributor_latest_seen_sample_timestamp_seconds gauge
-				cortex_distributor_latest_seen_sample_timestamp_seconds{user="user"} 123456789.004
+				cortex_distributor_latest_seen_sample_timestamp_seconds{user="userDistributorPush"} 123456789.004
 			`,
 		},
 		"A push to 2 happy ingesters should succeed": {
@@ -162,7 +162,7 @@ func TestDistributor_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
 				# TYPE cortex_distributor_latest_seen_sample_timestamp_seconds gauge
-				cortex_distributor_latest_seen_sample_timestamp_seconds{user="user"} 123456789.004
+				cortex_distributor_latest_seen_sample_timestamp_seconds{user="userDistributorPush"} 123456789.004
 			`,
 		},
 		"A push to 1 happy ingesters should fail": {
@@ -174,7 +174,7 @@ func TestDistributor_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
 				# TYPE cortex_distributor_latest_seen_sample_timestamp_seconds gauge
-				cortex_distributor_latest_seen_sample_timestamp_seconds{user="user"} 123456789.009
+				cortex_distributor_latest_seen_sample_timestamp_seconds{user="userDistributorPush"} 123456789.009
 			`,
 		},
 		"A push to 0 happy ingesters should fail": {
@@ -186,7 +186,7 @@ func TestDistributor_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
 				# TYPE cortex_distributor_latest_seen_sample_timestamp_seconds gauge
-				cortex_distributor_latest_seen_sample_timestamp_seconds{user="user"} 123456789.009
+				cortex_distributor_latest_seen_sample_timestamp_seconds{user="userDistributorPush"} 123456789.009
 			`,
 		},
 		"A push exceeding burst size should fail": {
@@ -199,7 +199,7 @@ func TestDistributor_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
 				# TYPE cortex_distributor_latest_seen_sample_timestamp_seconds gauge
-				cortex_distributor_latest_seen_sample_timestamp_seconds{user="user"} 123456789.024
+				cortex_distributor_latest_seen_sample_timestamp_seconds{user="userDistributorPush"} 123456789.024
 			`,
 		},
 		"A push to ingesters should report the correct metrics with no metadata": {
@@ -3193,7 +3193,7 @@ func TestSortLabels(t *testing.T) {
 
 func TestDistributor_Push_Relabel(t *testing.T) {
 	t.Parallel()
-	ctx := user.InjectOrgID(context.Background(), "user")
+	ctx := user.InjectOrgID(context.Background(), "userDistributorPushRelabel")
 
 	type testcase struct {
 		name                 string
@@ -3338,7 +3338,7 @@ func TestDistributor_Push_RelabelDropWillExportMetricOfDroppedSamples(t *testing
 
 	// Push the series to the distributor
 	req := mockWriteRequest(inputSeries, 1, 1)
-	ctx := user.InjectOrgID(context.Background(), "user1")
+	ctx := user.InjectOrgID(context.Background(), "userDistributorPushRelabelDropWillExportMetricOfDroppedSamples")
 	_, err = ds[0].Push(ctx, req)
 	require.NoError(t, err)
 
@@ -3354,10 +3354,10 @@ func TestDistributor_Push_RelabelDropWillExportMetricOfDroppedSamples(t *testing
 	expectedMetrics := `
 		# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 		# TYPE cortex_discarded_samples_total counter
-		cortex_discarded_samples_total{reason="relabel_configuration",user="user1"} 1
+		cortex_discarded_samples_total{reason="relabel_configuration",user="userDistributorPushRelabelDropWillExportMetricOfDroppedSamples"} 1
 		# HELP cortex_distributor_received_samples_total The total number of received samples, excluding rejected and deduped samples.
 		# TYPE cortex_distributor_received_samples_total counter
-		cortex_distributor_received_samples_total{user="user1"} 1
+		cortex_distributor_received_samples_total{user="userDistributorPushRelabelDropWillExportMetricOfDroppedSamples"} 1
 		`
 
 	require.NoError(t, testutil.GatherAndCompare(regs[0], strings.NewReader(expectedMetrics), metrics...))

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -96,7 +96,9 @@ func TestConfig_Validate(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData // Needed for t.Parallel to work correctly
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			cfg := Config{}
 			limits := validation.Limits{}
 			flagext.DefaultValues(&cfg, &limits)
@@ -258,7 +260,11 @@ func TestDistributor_Push(t *testing.T) {
 		},
 	} {
 		for _, shardByAllLabels := range []bool{true, false} {
+			tc := tc
+			name := name
+			shardByAllLabels := shardByAllLabels
 			t.Run(fmt.Sprintf("[%s](shardByAllLabels=%v)", name, shardByAllLabels), func(t *testing.T) {
+				t.Parallel()
 				limits := &validation.Limits{}
 				flagext.DefaultValues(limits)
 				limits.IngestionRate = 20
@@ -465,6 +471,7 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 		testData := testData
 
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			limits := &validation.Limits{}
 			flagext.DefaultValues(limits)
 			limits.IngestionRateStrategy = testData.ingestionRateStrategy
@@ -719,6 +726,7 @@ func TestDistributor_PushInstanceLimits(t *testing.T) {
 		testData := testData
 
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			limits := &validation.Limits{}
 			flagext.DefaultValues(limits)
 
@@ -810,7 +818,10 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 		},
 	} {
 		for _, shardByAllLabels := range []bool{true, false} {
+			tc := tc
+			shardByAllLabels := shardByAllLabels
 			t.Run(fmt.Sprintf("[%d](shardByAllLabels=%v)", i, shardByAllLabels), func(t *testing.T) {
+				t.Parallel()
 				var limits validation.Limits
 				flagext.DefaultValues(&limits)
 				limits.AcceptHASamples = true
@@ -980,7 +991,9 @@ func TestDistributor_PushQuery(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ds, ingesters, _, _ := prepare(t, prepConfig{
 				numIngesters:        tc.numIngesters,
 				happyIngesters:      tc.happyIngesters,
@@ -1483,7 +1496,9 @@ func TestDistributor_Push_ShouldGuaranteeShardingTokenConsistencyOverTheTime(t *
 	limits.AcceptHASamples = true
 
 	for testName, testData := range tests {
+		testData := testData
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			ds, ingesters, _, _ := prepare(t, prepConfig{
 				numIngesters:     2,
 				happyIngesters:   2,
@@ -1544,7 +1559,9 @@ func TestDistributor_Push_LabelNameValidation(t *testing.T) {
 	}
 
 	for testName, tc := range tests {
+		tc := tc
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			ds, _, _, _ := prepare(t, prepConfig{
 				numIngesters:            2,
 				happyIngesters:          2,
@@ -1607,7 +1624,9 @@ func TestDistributor_Push_ExemplarValidation(t *testing.T) {
 	}
 
 	for testName, tc := range tests {
+		tc := tc
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			ds, _, _, _ := prepare(t, prepConfig{
 				numIngesters:     2,
 				happyIngesters:   2,
@@ -1932,7 +1951,10 @@ func TestSlowQueries(t *testing.T) {
 	nIngesters := 3
 	for _, shardByAllLabels := range []bool{true, false} {
 		for happy := 0; happy <= nIngesters; happy++ {
+			shardByAllLabels := shardByAllLabels
+			happy := happy
 			t.Run(fmt.Sprintf("%t/%d", shardByAllLabels, happy), func(t *testing.T) {
+				t.Parallel()
 				var expectedErr error
 				if nIngesters-happy > 1 {
 					expectedErr = errFail
@@ -2122,7 +2144,9 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			now := model.Now()
 
 			// Create distributor
@@ -2296,7 +2320,9 @@ func TestDistributor_MetricsMetadata(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			// Create distributor
 			ds, ingesters, _, _ := prepare(t, prepConfig{
 				numIngesters:        numIngesters,
@@ -3049,7 +3075,9 @@ func TestDistributorValidation(t *testing.T) {
 			err: httpgrpc.Errorf(http.StatusBadRequest, `metadata missing metric name`),
 		},
 	} {
+		tc := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 			var limits validation.Limits
 			flagext.DefaultValues(&limits)
 
@@ -3237,7 +3265,9 @@ func TestDistributor_Push_Relabel(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			var err error
 			var limits validation.Limits
 			flagext.DefaultValues(&limits)

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -116,7 +116,9 @@ func TestHATrackerConfig_Validate(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, testData.expectedErr, testData.cfg.Validate())
 		})
 	}
@@ -124,6 +126,7 @@ func TestHATrackerConfig_Validate(t *testing.T) {
 
 // Test that values are set in the HATracker after WatchPrefix has found it in the KVStore.
 func TestWatchPrefixAssignment(t *testing.T) {
+	t.Parallel()
 	cluster := "c1"
 	replica := "r1"
 
@@ -154,6 +157,7 @@ func TestWatchPrefixAssignment(t *testing.T) {
 }
 
 func TestCheckReplicaOverwriteTimeout(t *testing.T) {
+	t.Parallel()
 	replica1 := "replica1"
 	replica2 := "replica2"
 
@@ -191,6 +195,7 @@ func TestCheckReplicaOverwriteTimeout(t *testing.T) {
 }
 
 func TestCheckReplicaMultiCluster(t *testing.T) {
+	t.Parallel()
 	replica1 := "replica1"
 	replica2 := "replica2"
 
@@ -241,6 +246,7 @@ func TestCheckReplicaMultiCluster(t *testing.T) {
 }
 
 func TestCheckReplicaMultiClusterTimeout(t *testing.T) {
+	t.Parallel()
 	replica1 := "replica1"
 	replica2 := "replica2"
 
@@ -310,6 +316,7 @@ func TestCheckReplicaMultiClusterTimeout(t *testing.T) {
 
 // Test that writes only happen every update timeout.
 func TestCheckReplicaUpdateTimeout(t *testing.T) {
+	t.Parallel()
 	replica := "r1"
 	cluster := "c1"
 	user := "user"
@@ -360,6 +367,7 @@ func TestCheckReplicaUpdateTimeout(t *testing.T) {
 
 // Test that writes only happen every write timeout.
 func TestCheckReplicaMultiUser(t *testing.T) {
+	t.Parallel()
 	replica := "r1"
 	cluster := "c1"
 
@@ -441,7 +449,9 @@ func TestCheckReplicaUpdateTimeoutJitter(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			// Init HA tracker
 			codec := GetReplicaDescCodec()
 			kvStore, closer := consul.NewInMemoryClient(codec, log.NewNopLogger(), nil)
@@ -483,6 +493,7 @@ func TestCheckReplicaUpdateTimeoutJitter(t *testing.T) {
 }
 
 func TestFindHALabels(t *testing.T) {
+	t.Parallel()
 	replicaLabel, clusterLabel := "replica", "cluster"
 	type expectedOutput struct {
 		cluster string
@@ -530,6 +541,7 @@ func TestFindHALabels(t *testing.T) {
 }
 
 func TestHATrackerConfig_ShouldCustomizePrefixDefaultValue(t *testing.T) {
+	t.Parallel()
 	haConfig := HATrackerConfig{}
 	ringConfig := ring.Config{}
 	flagext.DefaultValues(&haConfig)
@@ -540,6 +552,7 @@ func TestHATrackerConfig_ShouldCustomizePrefixDefaultValue(t *testing.T) {
 }
 
 func TestHAClustersLimit(t *testing.T) {
+	t.Parallel()
 	const userID = "user"
 
 	codec := GetReplicaDescCodec()
@@ -611,6 +624,7 @@ func waitForClustersUpdate(t *testing.T, expected int, tr *haTracker, userID str
 }
 
 func TestTooManyClustersError(t *testing.T) {
+	t.Parallel()
 	var err error = tooManyClustersError{limit: 10}
 	assert.True(t, errors.Is(err, tooManyClustersError{}))
 	assert.True(t, errors.Is(err, &tooManyClustersError{}))
@@ -625,6 +639,7 @@ func TestTooManyClustersError(t *testing.T) {
 }
 
 func TestReplicasNotMatchError(t *testing.T) {
+	t.Parallel()
 	var err error = replicasNotMatchError{replica: "a", elected: "b"}
 	assert.True(t, errors.Is(err, replicasNotMatchError{}))
 	assert.True(t, errors.Is(err, &replicasNotMatchError{}))
@@ -647,6 +662,7 @@ func (l trackerLimits) MaxHAClusters(_ string) int {
 }
 
 func TestHATracker_MetricsCleanup(t *testing.T) {
+	t.Parallel()
 	reg := prometheus.NewPedanticRegistry()
 	tr, err := newHATracker(HATrackerConfig{EnableHATracker: false}, nil, reg, log.NewNopLogger())
 	require.NoError(t, err)
@@ -705,6 +721,7 @@ func TestHATracker_MetricsCleanup(t *testing.T) {
 }
 
 func TestCheckReplicaCleanup(t *testing.T) {
+	t.Parallel()
 	replica := "r1"
 	cluster := "c1"
 	userID := "user"

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -198,6 +198,7 @@ func TestCheckReplicaMultiCluster(t *testing.T) {
 	t.Parallel()
 	replica1 := "replica1"
 	replica2 := "replica2"
+	user := "userCheckReplicaMultiCluster"
 
 	reg := prometheus.NewPedanticRegistry()
 	c, err := newHATracker(HATrackerConfig{
@@ -214,21 +215,21 @@ func TestCheckReplicaMultiCluster(t *testing.T) {
 	now := time.Now()
 
 	// Write the first time.
-	err = c.checkReplica(context.Background(), "user", "c1", replica1, now)
+	err = c.checkReplica(context.Background(), user, "c1", replica1, now)
 	assert.NoError(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica1, now)
+	err = c.checkReplica(context.Background(), user, "c2", replica1, now)
 	assert.NoError(t, err)
 
 	// Reject samples from replica 2 in each cluster.
-	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)
+	err = c.checkReplica(context.Background(), user, "c1", replica2, now)
 	assert.Error(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica2, now)
+	err = c.checkReplica(context.Background(), user, "c2", replica2, now)
 	assert.Error(t, err)
 
 	// We should still accept from replica 1.
-	err = c.checkReplica(context.Background(), "user", "c1", replica1, now)
+	err = c.checkReplica(context.Background(), user, "c1", replica1, now)
 	assert.NoError(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica1, now)
+	err = c.checkReplica(context.Background(), user, "c2", replica1, now)
 	assert.NoError(t, err)
 
 	// We expect no CAS operation failures.
@@ -249,6 +250,7 @@ func TestCheckReplicaMultiClusterTimeout(t *testing.T) {
 	t.Parallel()
 	replica1 := "replica1"
 	replica2 := "replica2"
+	user := "userCheckReplicaMultiClusterTimeout"
 
 	reg := prometheus.NewPedanticRegistry()
 	c, err := newHATracker(HATrackerConfig{
@@ -265,39 +267,39 @@ func TestCheckReplicaMultiClusterTimeout(t *testing.T) {
 	now := time.Now()
 
 	// Write the first time.
-	err = c.checkReplica(context.Background(), "user", "c1", replica1, now)
+	err = c.checkReplica(context.Background(), user, "c1", replica1, now)
 	assert.NoError(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica1, now)
+	err = c.checkReplica(context.Background(), user, "c2", replica1, now)
 	assert.NoError(t, err)
 
 	// Reject samples from replica 2 in each cluster.
-	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)
+	err = c.checkReplica(context.Background(), user, "c1", replica2, now)
 	assert.Error(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica2, now)
+	err = c.checkReplica(context.Background(), user, "c2", replica2, now)
 	assert.Error(t, err)
 
 	// Accept a sample for replica1 in C2.
 	now = now.Add(500 * time.Millisecond)
-	err = c.checkReplica(context.Background(), "user", "c2", replica1, now)
+	err = c.checkReplica(context.Background(), user, "c2", replica1, now)
 	assert.NoError(t, err)
 
 	// Reject samples from replica 2 in each cluster.
-	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)
+	err = c.checkReplica(context.Background(), user, "c1", replica2, now)
 	assert.Error(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica2, now)
+	err = c.checkReplica(context.Background(), user, "c2", replica2, now)
 	assert.Error(t, err)
 
 	// Wait more than the failover timeout.
 	now = now.Add(1100 * time.Millisecond)
 
 	// Accept a sample from c1/replica2.
-	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)
+	err = c.checkReplica(context.Background(), user, "c1", replica2, now)
 	assert.NoError(t, err)
 
 	// We should still accept from c2/replica1 but reject from c1/replica1.
-	err = c.checkReplica(context.Background(), "user", "c1", replica1, now)
+	err = c.checkReplica(context.Background(), user, "c1", replica1, now)
 	assert.Error(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica1, now)
+	err = c.checkReplica(context.Background(), user, "c2", replica1, now)
 	assert.NoError(t, err)
 
 	// We expect no CAS operation failures.
@@ -724,7 +726,7 @@ func TestCheckReplicaCleanup(t *testing.T) {
 	t.Parallel()
 	replica := "r1"
 	cluster := "c1"
-	userID := "user"
+	userID := "userCheckReplicaCleanup"
 	ctx := user.InjectOrgID(context.Background(), userID)
 
 	reg := prometheus.NewPedanticRegistry()

--- a/pkg/distributor/ingestion_rate_strategy_test.go
+++ b/pkg/distributor/ingestion_rate_strategy_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestIngestionRateStrategy(t *testing.T) {
+	t.Parallel()
 	tests := map[string]struct {
 		limits        validation.Limits
 		ring          ReadLifecycler
@@ -59,6 +60,7 @@ func TestIngestionRateStrategy(t *testing.T) {
 		testData := testData
 
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			var strategy limiter.RateLimiterStrategy
 
 			// Init limits overrides

--- a/pkg/distributor/query_test.go
+++ b/pkg/distributor/query_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestMergeSamplesIntoFirstDuplicates(t *testing.T) {
+	t.Parallel()
 	a := []cortexpb.Sample{
 		{Value: 1.084537996, TimestampMs: 1583946732744},
 		{Value: 1.086111723, TimestampMs: 1583946750366},
@@ -47,6 +48,7 @@ func TestMergeSamplesIntoFirstDuplicates(t *testing.T) {
 }
 
 func TestMergeSamplesIntoFirst(t *testing.T) {
+	t.Parallel()
 	a := []cortexpb.Sample{
 		{Value: 1, TimestampMs: 10},
 		{Value: 2, TimestampMs: 20},
@@ -84,6 +86,7 @@ func TestMergeSamplesIntoFirst(t *testing.T) {
 }
 
 func TestMergeSamplesIntoFirstNilA(t *testing.T) {
+	t.Parallel()
 	b := []cortexpb.Sample{
 		{Value: 1, TimestampMs: 5},
 		{Value: 2, TimestampMs: 15},
@@ -99,6 +102,7 @@ func TestMergeSamplesIntoFirstNilA(t *testing.T) {
 }
 
 func TestMergeSamplesIntoFirstNilB(t *testing.T) {
+	t.Parallel()
 	a := []cortexpb.Sample{
 		{Value: 1, TimestampMs: 10},
 		{Value: 2, TimestampMs: 20},
@@ -113,6 +117,7 @@ func TestMergeSamplesIntoFirstNilB(t *testing.T) {
 }
 
 func TestMergeExemplars(t *testing.T) {
+	t.Parallel()
 	now := timestamp.FromTime(time.Now())
 	exemplar1 := cortexpb.Exemplar{Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "trace-1")), TimestampMs: now, Value: 1}
 	exemplar2 := cortexpb.Exemplar{Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "trace-2")), TimestampMs: now + 1, Value: 2}
@@ -171,7 +176,9 @@ func TestMergeExemplars(t *testing.T) {
 				{Labels: labels2, Exemplars: []cortexpb.Exemplar{exemplar3, exemplar4}}},
 		},
 	} {
+		c := c
 		t.Run(fmt.Sprint("test", i), func(t *testing.T) {
+			t.Parallel()
 			rA := &ingester_client.ExemplarQueryResponse{Timeseries: c.seriesA}
 			rB := &ingester_client.ExemplarQueryResponse{Timeseries: c.seriesB}
 			e := mergeExemplarQueryResponses([]interface{}{rA, rB})


### PR DESCRIPTION
Signed-off-by: Friedrich Gonzalez <friedrichg@gmail.com>

**What this PR does**:
Makes all distributors tests in parallel to speed them up

In my machine:

Previous: 
```
go test ./pkg/distributor/ -v -count 1 -parallel 1
ok  	github.com/cortexproject/cortex/pkg/distributor	48.067s
```
After:
```
go test ./pkg/distributor/ -v -count 1
ok  	github.com/cortexproject/cortex/pkg/distributor	15.635s
```

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
