### PR TITLE
Get second port without closing first one to prevent port clashing

### DIFF
--- a/pkg/util/tls/test/tls_integration_test.go
+++ b/pkg/util/tls/test/tls_integration_test.go
@@ -51,21 +51,21 @@ func (h *grpcHealthCheck) Watch(_ *grpc_health_v1.HealthCheckRequest, _ grpc_hea
 	return status.Error(codes.Unimplemented, "Watching is not supported")
 }
 
-func getLocalHostPort() (int, error) {
+func getLocalHostPort() (int, func() error, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 
 	l, err := net.ListenTCP("tcp", addr)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 
-	if err := l.Close(); err != nil {
-		return 0, err
+	closePort := func() error {
+		return l.Close()
 	}
-	return l.Addr().(*net.TCPAddr).Port, nil
+	return l.Addr().(*net.TCPAddr).Port, closePort, nil
 }
 
 func newIntegrationClientServer(
@@ -80,9 +80,14 @@ func newIntegrationClientServer(
 		prometheus.DefaultRegisterer = savedRegistry
 	}()
 
-	grpcPort, err := getLocalHostPort()
+	grpcPort, closeGrpcPort, err := getLocalHostPort()
 	require.NoError(t, err)
-	httpPort, err := getLocalHostPort()
+	httpPort, closeHttpPort, err := getLocalHostPort()
+	require.NoError(t, err)
+
+	err = closeGrpcPort()
+	require.NoError(t, err)
+	err = closeHttpPort()
 	require.NoError(t, err)
 
 	cfg.HTTPListenPort = httpPort

--- a/pkg/util/tls/test/tls_integration_test.go
+++ b/pkg/util/tls/test/tls_integration_test.go
@@ -82,12 +82,12 @@ func newIntegrationClientServer(
 
 	grpcPort, closeGrpcPort, err := getLocalHostPort()
 	require.NoError(t, err)
-	httpPort, closeHttpPort, err := getLocalHostPort()
+	httpPort, closeHTTPPort, err := getLocalHostPort()
 	require.NoError(t, err)
 
 	err = closeGrpcPort()
 	require.NoError(t, err)
-	err = closeHttpPort()
+	err = closeHTTPPort()
 	require.NoError(t, err)
 
 	cfg.HTTPListenPort = httpPort


### PR DESCRIPTION
Signed-off-by: Friedrich Gonzalez <friedrichg@gmail.com>

**What this PR does**:
Get second port without closing first one to prevent port clashing

**Which issue(s) this PR fixes**:
Fixes #5038 

or tries too :) 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
