### PR TITLE
Make TSDB max exemplars config per tenant 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master / unreleased
+* [CHANGE] Storage: Make Max exemplars config per tenant instead of global configuration. #5016
 * [CHANGE] Alertmanager: Local file disclosure vulnerability in OpsGenie configuration has been fixed. #5045
 * [ENHANCEMENT] Update Go version to 1.19.3. #4988
 * [ENHANCEMENT] Querier: limit series query to only ingesters if `start` param is not specified. #4976

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -879,11 +879,6 @@ blocks_storage:
     # CLI flag: -blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup
     [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
 
-    # Enables support for exemplars in TSDB and sets the maximum number that
-    # will be stored. 0 or less means disabled.
-    # CLI flag: -blocks-storage.tsdb.max-exemplars
-    [max_exemplars: <int> | default = 0]
-
     # True to enable snapshotting of in-memory TSDB data on disk when shutting
     # down.
     # CLI flag: -blocks-storage.tsdb.memory-snapshot-on-shutdown

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -879,9 +879,10 @@ blocks_storage:
     # CLI flag: -blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup
     [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
 
-    # Deprecated, use maxExemplars in limits instead. Enables support for
-    # exemplars in TSDB and sets the maximum number that will be stored. 0 or
-    # less means disabled.
+    # Deprecated, use maxExemplars in limits instead. If the MaxExemplars value
+    # in limits is set to zero, cortex will fallback on this value. This setting
+    # enables support for exemplars in TSDB and sets the maximum number that
+    # will be stored. 0 or less means disabled.
     # CLI flag: -blocks-storage.tsdb.max-exemplars
     [max_exemplars: <int> | default = 0]
 

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -879,6 +879,12 @@ blocks_storage:
     # CLI flag: -blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup
     [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
 
+    # Deprecated, use maxExemplars in limits instead. Enables support for
+    # exemplars in TSDB and sets the maximum number that will be stored. 0 or
+    # less means disabled.
+    # CLI flag: -blocks-storage.tsdb.max-exemplars
+    [max_exemplars: <int> | default = 0]
+
     # True to enable snapshotting of in-memory TSDB data on disk when shutting
     # down.
     # CLI flag: -blocks-storage.tsdb.memory-snapshot-on-shutdown

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -942,9 +942,10 @@ blocks_storage:
     # CLI flag: -blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup
     [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
 
-    # Deprecated, use maxExemplars in limits instead. Enables support for
-    # exemplars in TSDB and sets the maximum number that will be stored. 0 or
-    # less means disabled.
+    # Deprecated, use maxExemplars in limits instead. If the MaxExemplars value
+    # in limits is set to zero, cortex will fallback on this value. This setting
+    # enables support for exemplars in TSDB and sets the maximum number that
+    # will be stored. 0 or less means disabled.
     # CLI flag: -blocks-storage.tsdb.max-exemplars
     [max_exemplars: <int> | default = 0]
 

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -942,11 +942,6 @@ blocks_storage:
     # CLI flag: -blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup
     [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
 
-    # Enables support for exemplars in TSDB and sets the maximum number that
-    # will be stored. 0 or less means disabled.
-    # CLI flag: -blocks-storage.tsdb.max-exemplars
-    [max_exemplars: <int> | default = 0]
-
     # True to enable snapshotting of in-memory TSDB data on disk when shutting
     # down.
     # CLI flag: -blocks-storage.tsdb.memory-snapshot-on-shutdown

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -942,6 +942,12 @@ blocks_storage:
     # CLI flag: -blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup
     [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
 
+    # Deprecated, use maxExemplars in limits instead. Enables support for
+    # exemplars in TSDB and sets the maximum number that will be stored. 0 or
+    # less means disabled.
+    # CLI flag: -blocks-storage.tsdb.max-exemplars
+    [max_exemplars: <int> | default = 0]
+
     # True to enable snapshotting of in-memory TSDB data on disk when shutting
     # down.
     # CLI flag: -blocks-storage.tsdb.memory-snapshot-on-shutdown

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2622,6 +2622,10 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # e.g. remote_write.write_relabel_configs.
 [metric_relabel_configs: <relabel_config...> | default = ]
 
+# Positive value enables experiemental support for exemplars. 0 or less to disable.
+# CLI flag: -block-storage.tsdb.max-exemplars
+[max_exemplars: <int> | default = 0]
+
 # The maximum number of series for which a query can fetch samples from each
 # ingester. This limit is enforced only in the ingesters (when querying samples
 # not flushed to the storage yet) and it's a per-instance limit. This limit is

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3730,6 +3730,12 @@ tsdb:
   # CLI flag: -blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup
   [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
 
+  # Deprecated, use maxExemplars in limits instead. Enables support for
+  # exemplars in TSDB and sets the maximum number that will be stored. 0 or less
+  # means disabled.
+  # CLI flag: -blocks-storage.tsdb.max-exemplars
+  [max_exemplars: <int> | default = 0]
+
   # True to enable snapshotting of in-memory TSDB data on disk when shutting
   # down.
   # CLI flag: -blocks-storage.tsdb.memory-snapshot-on-shutdown

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2627,7 +2627,8 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 [metric_relabel_configs: <relabel_config...> | default = ]
 
 # Enables support for exemplars in TSDB and sets the maximum number that will be
-# stored. 0 or less means disabled.
+# stored. less than zero means disabled. If the value is set to zero, cortex
+# will fallback to blocks-storage.tsdb.max-exemplars value.
 # CLI flag: -block-storage.tsdb.max-exemplars
 [max_exemplars: <int> | default = 0]
 
@@ -3730,9 +3731,10 @@ tsdb:
   # CLI flag: -blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup
   [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
 
-  # Deprecated, use maxExemplars in limits instead. Enables support for
-  # exemplars in TSDB and sets the maximum number that will be stored. 0 or less
-  # means disabled.
+  # Deprecated, use maxExemplars in limits instead. If the MaxExemplars value in
+  # limits is set to zero, cortex will fallback on this value. This setting
+  # enables support for exemplars in TSDB and sets the maximum number that will
+  # be stored. 0 or less means disabled.
   # CLI flag: -blocks-storage.tsdb.max-exemplars
   [max_exemplars: <int> | default = 0]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -725,9 +725,9 @@ lifecycler:
 # CLI flag: -ingester.rate-update-period
 [rate_update_period: <duration> | default = 15s]
 
-# Period with which to update the per-user max exemplars value.
-# CLI flag: -ingester.max-exemplars-update-period
-[max_exemplars_update_period: <duration> | default = 15s]
+# Period with which to update the per-user tsdb config.
+# CLI flag: -ingester.user-tsdb-configs-update-period
+[user_tsdb_configs_update_period: <duration> | default = 15s]
 
 # Enable tracking of active series and export them as metrics.
 # CLI flag: -ingester.active-series-metrics-enabled

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2622,7 +2622,8 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # e.g. remote_write.write_relabel_configs.
 [metric_relabel_configs: <relabel_config...> | default = ]
 
-# Positive value enables experiemental support for exemplars. 0 or less to disable.
+# Enables support for exemplars in TSDB and sets the maximum number that will be
+# stored. 0 or less means disabled.
 # CLI flag: -block-storage.tsdb.max-exemplars
 [max_exemplars: <int> | default = 0]
 
@@ -3724,11 +3725,6 @@ tsdb:
   # limit the number of concurrently opening TSDB's on startup
   # CLI flag: -blocks-storage.tsdb.max-tsdb-opening-concurrency-on-startup
   [max_tsdb_opening_concurrency_on_startup: <int> | default = 10]
-
-  # Enables support for exemplars in TSDB and sets the maximum number that will
-  # be stored. 0 or less means disabled.
-  # CLI flag: -blocks-storage.tsdb.max-exemplars
-  [max_exemplars: <int> | default = 0]
 
   # True to enable snapshotting of in-memory TSDB data on disk when shutting
   # down.

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -725,6 +725,10 @@ lifecycler:
 # CLI flag: -ingester.rate-update-period
 [rate_update_period: <duration> | default = 15s]
 
+# Period with which to update the per-user max exemplars value.
+# CLI flag: -ingester.max-exemplars-update-period
+[max_exemplars_update_period: <duration> | default = 15s]
+
 # Enable tracking of active series and export them as metrics.
 # CLI flag: -ingester.active-series-metrics-enabled
 [active_series_metrics_enabled: <boolean> | default = true]

--- a/docs/configuration/runtime-config.yaml
+++ b/docs/configuration/runtime-config.yaml
@@ -1,0 +1,15 @@
+overrides:
+  tenant1:
+    ingestion_rate: 10000
+    max_exemplars: 1
+  tenant2:
+    ingestion_rate: 10000
+    max_exemplars: 0
+
+multi_kv_config:
+  mirror_enabled: false
+  primary: memberlist
+
+ingester_limits:
+  max_ingestion_rate: 42000
+  max_inflight_push_requests: 10000

--- a/docs/configuration/single-process-config-blocks-local.yaml
+++ b/docs/configuration/single-process-config-blocks-local.yaml
@@ -28,6 +28,7 @@ ingester_client:
     grpc_compression: gzip
 
 ingester:
+  max_exemplars_update_period: 10s
   lifecycler:
     # The address to advertise for this ingester.  Will be autodiscovered by
     # looking up address on eth0 or en0; can be specified if this fails.

--- a/docs/configuration/single-process-config-blocks-local.yaml
+++ b/docs/configuration/single-process-config-blocks-local.yaml
@@ -28,7 +28,6 @@ ingester_client:
     grpc_compression: gzip
 
 ingester:
-  max_exemplars_update_period: 10s
   lifecycler:
     # The address to advertise for this ingester.  Will be autodiscovered by
     # looking up address on eth0 or en0; can be specified if this fails.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1043,7 +1043,8 @@ func (i *Ingester) Push(ctx context.Context, req *cortexpb.WriteRequest) (*corte
 			})
 		}
 
-		if i.cfg.BlocksStorageConfig.TSDB.MaxExemplars > 0 {
+		maxExemplarsForUser := i.limits.MaxExemplars(userID)
+		if maxExemplarsForUser > 0 {
 			// app.AppendExemplar currently doesn't create the series, it must
 			// already exist.  If it does not then drop.
 			if ref == 0 && len(ts.Exemplars) > 0 {
@@ -1832,7 +1833,8 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 	}
 
 	enableExemplars := false
-	if i.cfg.BlocksStorageConfig.TSDB.MaxExemplars > 0 {
+	maxExemplarsForUser := i.limits.MaxExemplars(userID)
+	if maxExemplarsForUser > 0 {
 		enableExemplars = true
 	}
 	// Create a new user database
@@ -1849,7 +1851,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 		BlocksToDelete:                 userDB.blocksToDelete,
 		EnableExemplarStorage:          enableExemplars,
 		IsolationDisabled:              true,
-		MaxExemplars:                   int64(i.cfg.BlocksStorageConfig.TSDB.MaxExemplars),
+		MaxExemplars:                   int64(maxExemplarsForUser),
 		HeadChunksWriteQueueSize:       i.cfg.BlocksStorageConfig.TSDB.HeadChunksWriteQueueSize,
 		EnableMemorySnapshotOnShutdown: i.cfg.BlocksStorageConfig.TSDB.MemorySnapshotOnShutdown,
 	}, nil)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -844,12 +844,11 @@ func (i *Ingester) updateUserTSDBConfigs() {
 			},
 		}
 
-		level.Info(logutil.WithUserID(userID, i.logger)).Log("meg", "updating max exemplars configuration.")
 		// This method currently updates the MaxExemplars and OutOfOrderTimeWindow. Invoking this method
 		// with a 0 value of OutOfOrderTimeWindow simply updates Max Exemplars.
 		err := userDB.db.ApplyConfig(cfg)
 		if err != nil {
-			level.Error(logutil.WithUserID(userID, i.logger)).Log("msg", "failed to update max exemplars configuration.")
+			level.Error(logutil.WithUserID(userID, i.logger)).Log("msg", "failed to update user tsdb configuration.")
 		}
 	}
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/prometheus/prometheus/config"
 	"io"
 	"math"
 	"net/http"
@@ -13,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/prometheus/prometheus/config"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -844,6 +845,8 @@ func (i *Ingester) updateTSDBMaxExemplars() {
 		}
 
 		level.Info(logutil.WithUserID(userID, i.logger)).Log("meg", "updating max exemplars configuration.")
+		// This method currently updates the MaxExemplars and OutOfOrderTimeWindow. Invoking this method
+		// with a 0 value of OutOfOrderTimeWindow simply updates Max Exemplars.
 		err := userDB.db.ApplyConfig(cfg)
 		if err != nil {
 			level.Error(logutil.WithUserID(userID, i.logger)).Log("msg", "failed to update max exemplars configuration.")

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -774,9 +774,10 @@ func TestIngester_Push(t *testing.T) {
 			cfg := defaultIngesterTestConfig(t)
 			cfg.LifecyclerConfig.JoinAfter = 0
 			cfg.ActiveSeriesMetricsEnabled = !testData.disableActiveSeries
-			cfg.BlocksStorageConfig.TSDB.MaxExemplars = testData.maxExemplars
 
-			i, err := prepareIngesterWithBlocksStorage(t, cfg, registry)
+			limits := defaultLimitsTestConfig()
+			limits.MaxExemplars = testData.maxExemplars
+			i, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, "", registry)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 			defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -145,6 +145,9 @@ type TSDBConfig struct {
 	// How often to check for idle TSDBs for closing. DefaultCloseIdleTSDBInterval is not suitable for testing, so tests can override.
 	CloseIdleTSDBInterval time.Duration `yaml:"-"`
 
+	// Positive value enables experiemental support for exemplars. 0 or less to disable.
+	MaxExemplars int `yaml:"max_exemplars"`
+
 	// Enable snapshotting of in-memory TSDB data on disk when shutting down.
 	MemorySnapshotOnShutdown bool `yaml:"memory_snapshot_on_shutdown"`
 }
@@ -171,6 +174,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.FlushBlocksOnShutdown, "blocks-storage.tsdb.flush-blocks-on-shutdown", false, "True to flush blocks to storage on shutdown. If false, incomplete blocks will be reused after restart.")
 	f.DurationVar(&cfg.CloseIdleTSDBTimeout, "blocks-storage.tsdb.close-idle-tsdb-timeout", 0, "If TSDB has not received any data for this duration, and all blocks from TSDB have been shipped, TSDB is closed and deleted from local disk. If set to positive value, this value should be equal or higher than -querier.query-ingesters-within flag to make sure that TSDB is not closed prematurely, which could cause partial query results. 0 or negative value disables closing of idle TSDB.")
 	f.IntVar(&cfg.HeadChunksWriteQueueSize, "blocks-storage.tsdb.head-chunks-write-queue-size", chunks.DefaultWriteQueueSize, "The size of the in-memory queue used before flushing chunks to the disk.")
+	f.IntVar(&cfg.MaxExemplars, "blocks-storage.tsdb.max-exemplars", 0, "Deprecated, use maxExemplars in limits instead. Enables support for exemplars in TSDB and sets the maximum number that will be stored. 0 or less means disabled.")
 	f.BoolVar(&cfg.MemorySnapshotOnShutdown, "blocks-storage.tsdb.memory-snapshot-on-shutdown", false, "True to enable snapshotting of in-memory TSDB data on disk when shutting down.")
 }
 

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -174,7 +174,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.FlushBlocksOnShutdown, "blocks-storage.tsdb.flush-blocks-on-shutdown", false, "True to flush blocks to storage on shutdown. If false, incomplete blocks will be reused after restart.")
 	f.DurationVar(&cfg.CloseIdleTSDBTimeout, "blocks-storage.tsdb.close-idle-tsdb-timeout", 0, "If TSDB has not received any data for this duration, and all blocks from TSDB have been shipped, TSDB is closed and deleted from local disk. If set to positive value, this value should be equal or higher than -querier.query-ingesters-within flag to make sure that TSDB is not closed prematurely, which could cause partial query results. 0 or negative value disables closing of idle TSDB.")
 	f.IntVar(&cfg.HeadChunksWriteQueueSize, "blocks-storage.tsdb.head-chunks-write-queue-size", chunks.DefaultWriteQueueSize, "The size of the in-memory queue used before flushing chunks to the disk.")
-	f.IntVar(&cfg.MaxExemplars, "blocks-storage.tsdb.max-exemplars", 0, "Deprecated, use maxExemplars in limits instead. Enables support for exemplars in TSDB and sets the maximum number that will be stored. 0 or less means disabled.")
+	f.IntVar(&cfg.MaxExemplars, "blocks-storage.tsdb.max-exemplars", 0, "Deprecated, use maxExemplars in limits instead. If the MaxExemplars value in limits is set to zero, cortex will fallback on this value. This setting enables support for exemplars in TSDB and sets the maximum number that will be stored. 0 or less means disabled.")
 	f.BoolVar(&cfg.MemorySnapshotOnShutdown, "blocks-storage.tsdb.memory-snapshot-on-shutdown", false, "True to enable snapshotting of in-memory TSDB data on disk when shutting down.")
 }
 

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -145,9 +145,6 @@ type TSDBConfig struct {
 	// How often to check for idle TSDBs for closing. DefaultCloseIdleTSDBInterval is not suitable for testing, so tests can override.
 	CloseIdleTSDBInterval time.Duration `yaml:"-"`
 
-	// Positive value enables experiemental support for exemplars. 0 or less to disable.
-	MaxExemplars int `yaml:"max_exemplars"`
-
 	// Enable snapshotting of in-memory TSDB data on disk when shutting down.
 	MemorySnapshotOnShutdown bool `yaml:"memory_snapshot_on_shutdown"`
 }
@@ -173,7 +170,6 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.WALSegmentSizeBytes, "blocks-storage.tsdb.wal-segment-size-bytes", wal.DefaultSegmentSize, "TSDB WAL segments files max size (bytes).")
 	f.BoolVar(&cfg.FlushBlocksOnShutdown, "blocks-storage.tsdb.flush-blocks-on-shutdown", false, "True to flush blocks to storage on shutdown. If false, incomplete blocks will be reused after restart.")
 	f.DurationVar(&cfg.CloseIdleTSDBTimeout, "blocks-storage.tsdb.close-idle-tsdb-timeout", 0, "If TSDB has not received any data for this duration, and all blocks from TSDB have been shipped, TSDB is closed and deleted from local disk. If set to positive value, this value should be equal or higher than -querier.query-ingesters-within flag to make sure that TSDB is not closed prematurely, which could cause partial query results. 0 or negative value disables closing of idle TSDB.")
-	f.IntVar(&cfg.MaxExemplars, "blocks-storage.tsdb.max-exemplars", 0, "Enables support for exemplars in TSDB and sets the maximum number that will be stored. 0 or less means disabled.")
 	f.IntVar(&cfg.HeadChunksWriteQueueSize, "blocks-storage.tsdb.head-chunks-write-queue-size", chunks.DefaultWriteQueueSize, "The size of the in-memory queue used before flushing chunks to the disk.")
 	f.BoolVar(&cfg.MemorySnapshotOnShutdown, "blocks-storage.tsdb.memory-snapshot-on-shutdown", false, "True to enable snapshotting of in-memory TSDB data on disk when shutting down.")
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -55,6 +55,7 @@ type Limits struct {
 	EnforceMetricName         bool                `yaml:"enforce_metric_name" json:"enforce_metric_name"`
 	IngestionTenantShardSize  int                 `yaml:"ingestion_tenant_shard_size" json:"ingestion_tenant_shard_size"`
 	MetricRelabelConfigs      []*relabel.Config   `yaml:"metric_relabel_configs,omitempty" json:"metric_relabel_configs,omitempty" doc:"nocli|description=List of metric relabel configurations. Note that in most situations, it is more effective to use metrics relabeling directly in the Prometheus server, e.g. remote_write.write_relabel_configs."`
+	MaxExemplars              int                 `yaml:"max_exemplars" json:"max_exemplars"`
 
 	// Ingester enforced limits.
 	// Series
@@ -63,6 +64,7 @@ type Limits struct {
 	MaxLocalSeriesPerMetric  int `yaml:"max_series_per_metric" json:"max_series_per_metric"`
 	MaxGlobalSeriesPerUser   int `yaml:"max_global_series_per_user" json:"max_global_series_per_user"`
 	MaxGlobalSeriesPerMetric int `yaml:"max_global_series_per_metric" json:"max_global_series_per_metric"`
+
 	// Metadata
 	MaxLocalMetricsWithMetadataPerUser  int `yaml:"max_metadata_per_user" json:"max_metadata_per_user"`
 	MaxLocalMetadataPerMetric           int `yaml:"max_metadata_per_metric" json:"max_metadata_per_metric"`
@@ -147,6 +149,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLocalSeriesPerMetric, "ingester.max-series-per-metric", 50000, "The maximum number of active series per metric name, per ingester. 0 to disable.")
 	f.IntVar(&l.MaxGlobalSeriesPerUser, "ingester.max-global-series-per-user", 0, "The maximum number of active series per user, across the cluster before replication. 0 to disable. Supported only if -distributor.shard-by-all-labels is true.")
 	f.IntVar(&l.MaxGlobalSeriesPerMetric, "ingester.max-global-series-per-metric", 0, "The maximum number of active series per metric name, across the cluster before replication. 0 to disable.")
+	f.IntVar(&l.MaxExemplars, "block-storage.tsdb.max-exemplars", 0, "Positive value enables experimental support for exemplars. 0 or less to disable.")
 
 	f.IntVar(&l.MaxLocalMetricsWithMetadataPerUser, "ingester.max-metadata-per-user", 8000, "The maximum number of active metrics with metadata per user, per ingester. 0 to disable.")
 	f.IntVar(&l.MaxLocalMetadataPerMetric, "ingester.max-metadata-per-metric", 10, "The maximum number of metadata per metric, per ingester. 0 to disable.")
@@ -562,6 +565,11 @@ func (o *Overrides) AlertmanagerReceiversBlockCIDRNetworks(user string) []flagex
 // in the Alertmanager receivers for the given user.
 func (o *Overrides) AlertmanagerReceiversBlockPrivateAddresses(user string) bool {
 	return o.GetOverridesForUser(user).AlertmanagerReceiversBlockPrivateAddresses
+}
+
+// MaxExemplars returns the maximum number of exemplars for a given user.
+func (o *Overrides) MaxExemplars(userID string) int {
+	return o.GetOverridesForUser(userID).MaxExemplars
 }
 
 // Notification limits are special. Limits are returned in following order:

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -149,7 +149,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLocalSeriesPerMetric, "ingester.max-series-per-metric", 50000, "The maximum number of active series per metric name, per ingester. 0 to disable.")
 	f.IntVar(&l.MaxGlobalSeriesPerUser, "ingester.max-global-series-per-user", 0, "The maximum number of active series per user, across the cluster before replication. 0 to disable. Supported only if -distributor.shard-by-all-labels is true.")
 	f.IntVar(&l.MaxGlobalSeriesPerMetric, "ingester.max-global-series-per-metric", 0, "The maximum number of active series per metric name, across the cluster before replication. 0 to disable.")
-	f.IntVar(&l.MaxExemplars, "block-storage.tsdb.max-exemplars", 0, "Enables support for exemplars in TSDB and sets the maximum number that will be stored. 0 or less means disabled.")
+	f.IntVar(&l.MaxExemplars, "block-storage.tsdb.max-exemplars", 0, "Enables support for exemplars in TSDB and sets the maximum number that will be stored. less than zero means disabled. If the value is set to zero, cortex will fallback to blocks-storage.tsdb.max-exemplars value.")
 
 	f.IntVar(&l.MaxLocalMetricsWithMetadataPerUser, "ingester.max-metadata-per-user", 8000, "The maximum number of active metrics with metadata per user, per ingester. 0 to disable.")
 	f.IntVar(&l.MaxLocalMetadataPerMetric, "ingester.max-metadata-per-metric", 10, "The maximum number of metadata per metric, per ingester. 0 to disable.")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -149,7 +149,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLocalSeriesPerMetric, "ingester.max-series-per-metric", 50000, "The maximum number of active series per metric name, per ingester. 0 to disable.")
 	f.IntVar(&l.MaxGlobalSeriesPerUser, "ingester.max-global-series-per-user", 0, "The maximum number of active series per user, across the cluster before replication. 0 to disable. Supported only if -distributor.shard-by-all-labels is true.")
 	f.IntVar(&l.MaxGlobalSeriesPerMetric, "ingester.max-global-series-per-metric", 0, "The maximum number of active series per metric name, across the cluster before replication. 0 to disable.")
-	f.IntVar(&l.MaxExemplars, "block-storage.tsdb.max-exemplars", 0, "Positive value enables experimental support for exemplars. 0 or less to disable.")
+	f.IntVar(&l.MaxExemplars, "block-storage.tsdb.max-exemplars", 0, "Enables support for exemplars in TSDB and sets the maximum number that will be stored. 0 or less means disabled.")
 
 	f.IntVar(&l.MaxLocalMetricsWithMetadataPerUser, "ingester.max-metadata-per-user", 8000, "The maximum number of active metrics with metadata per user, per ingester. 0 to disable.")
 	f.IntVar(&l.MaxLocalMetadataPerMetric, "ingester.max-metadata-per-metric", 10, "The maximum number of metadata per metric, per ingester. 0 to disable.")
@@ -567,7 +567,7 @@ func (o *Overrides) AlertmanagerReceiversBlockPrivateAddresses(user string) bool
 	return o.GetOverridesForUser(user).AlertmanagerReceiversBlockPrivateAddresses
 }
 
-// MaxExemplars returns the maximum number of exemplars for a given user.
+// MaxExemplars gets the maximum number of exemplars that will be stored per user. 0 or less means disabled.
 func (o *Overrides) MaxExemplars(userID string) int {
 	return o.GetOverridesForUser(userID).MaxExemplars
 }


### PR DESCRIPTION
Signed-off-by: sahnib <sahnib@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Makes TSDB max exemplars config per tenant. **Note that the MaxExemplars value is passed down to prometheus tsdb at `tsdb.Open` call, hence this configuration would not be hot loaded at this time - unless the ingesters re-open the database handle, or go through a restart.**. 

**Which issue(s) this PR fixes**:
Fixes [#5016](https://github.com/cortexproject/cortex/issues/5016)

**Checklist**
- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
