### PR TITLE
Use labels Bytes() rather than String() for map key

### DIFF
--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -257,10 +257,11 @@ func (d *Distributor) queryIngestersExemplars(ctx context.Context, replicationSe
 func mergeExemplarQueryResponses(results []interface{}) *ingester_client.ExemplarQueryResponse {
 	var keys []string
 	exemplarResults := make(map[string]cortexpb.TimeSeries)
+	buf := make([]byte, 0, 1024)
 	for _, result := range results {
 		r := result.(*ingester_client.ExemplarQueryResponse)
 		for _, ts := range r.Timeseries {
-			lbls := cortexpb.FromLabelAdaptersToLabels(ts.Labels).String()
+			lbls := string(cortexpb.FromLabelAdaptersToLabels(ts.Labels).Bytes(buf))
 			e, ok := exemplarResults[lbls]
 			if !ok {
 				exemplarResults[lbls] = ts

--- a/pkg/querier/tripperware/instantquery/instant_query.go
+++ b/pkg/querier/tripperware/instantquery/instant_query.go
@@ -299,6 +299,7 @@ func (instantQueryCodec) MergeResponse(ctx context.Context, responses ...tripper
 
 func vectorMerge(resps []*PrometheusInstantQueryResponse) *Vector {
 	output := map[string]*Sample{}
+	buf := make([]byte, 0, 1024)
 	for _, resp := range resps {
 		if resp == nil {
 			continue
@@ -313,7 +314,7 @@ func vectorMerge(resps []*PrometheusInstantQueryResponse) *Vector {
 			if s == nil {
 				continue
 			}
-			metric := cortexpb.FromLabelAdaptersToLabels(sample.Labels).String()
+			metric := string(cortexpb.FromLabelAdaptersToLabels(sample.Labels).Bytes(buf))
 			if existingSample, ok := output[metric]; !ok {
 				output[metric] = s
 			} else if existingSample.GetSample().TimestampMs < s.GetSample().TimestampMs {

--- a/pkg/querier/tripperware/merge.go
+++ b/pkg/querier/tripperware/merge.go
@@ -8,8 +8,9 @@ import (
 
 // MergeSampleStreams deduplicates sample streams using a map.
 func MergeSampleStreams(output map[string]SampleStream, sampleStreams []SampleStream) {
+	buf := make([]byte, 0, 1024)
 	for _, stream := range sampleStreams {
-		metric := cortexpb.FromLabelAdaptersToLabels(stream.Labels).String()
+		metric := string(cortexpb.FromLabelAdaptersToLabels(stream.Labels).Bytes(buf))
 		existing, ok := output[metric]
 		if !ok {
 			existing = SampleStream{

--- a/pkg/querier/tripperware/merge_test.go
+++ b/pkg/querier/tripperware/merge_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
+	ingester_client "github.com/cortexproject/cortex/pkg/ingester/client"
 )
 
 func TestMergeSampleStreams(t *testing.T) {
@@ -34,7 +35,7 @@ func TestMergeSampleStreams(t *testing.T) {
 				},
 			},
 			expectedOutput: map[string]SampleStream{
-				lbls.String(): {
+				ingester_client.LabelsToKeyString(lbls): {
 					Labels: cortexpb.FromLabelsToLabelAdapters(lbls),
 					Samples: []cortexpb.Sample{
 						{Value: 0, TimestampMs: 0},
@@ -63,7 +64,7 @@ func TestMergeSampleStreams(t *testing.T) {
 				},
 			},
 			expectedOutput: map[string]SampleStream{
-				lbls.String(): {
+				ingester_client.LabelsToKeyString(lbls): {
 					Labels: cortexpb.FromLabelsToLabelAdapters(lbls),
 					Samples: []cortexpb.Sample{
 						{Value: 0, TimestampMs: 0},
@@ -109,7 +110,7 @@ func TestMergeSampleStreams(t *testing.T) {
 				},
 			},
 			expectedOutput: map[string]SampleStream{
-				lbls.String(): {
+				ingester_client.LabelsToKeyString(lbls): {
 					Labels: cortexpb.FromLabelsToLabelAdapters(lbls),
 					Samples: []cortexpb.Sample{
 						{Value: 0, TimestampMs: 0},
@@ -118,7 +119,7 @@ func TestMergeSampleStreams(t *testing.T) {
 						{Value: 4, TimestampMs: 4},
 					},
 				},
-				lbls1.String(): {
+				ingester_client.LabelsToKeyString(lbls1): {
 					Labels: cortexpb.FromLabelsToLabelAdapters(lbls1),
 					Samples: []cortexpb.Sample{
 						{Value: 0, TimestampMs: 0},


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Use `string(labels.Bytes())` instead of `labels.String()` for the deduplication map key. Since we don't have to print the map key, we just use the key to find the samples and as long as it remains the same sorting order, we can safely replace the method.

Benchmark 

```
name    old time/op    new time/op    delta
Label-10    9.60µs ± 0%    1.60µs ± 0%   ~     (p=1.000 n=1+1)

name    old alloc/op   new alloc/op   delta
Label-10    7.79kB ± 0%    3.71kB ± 0%   ~     (p=1.000 n=1+1)

name    old allocs/op  new allocs/op  delta
Label-10       111 ± 0%         2 ± 0%   ~     (p=1.000 n=1+1)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
