### PR TITLE
Dynamodb kv batch on slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [BUGFIX] Tracing: Fix missing object storage span instrumentation. #5074
 * [BUGFIX] Ingester: Ingesters returning empty response for metadata APIs. #5081
 * [BUGFIX] Ingester: Fix panic when querying metadata from blocks that are being deleted. #5119
+* [BUGFIX] Ring: Fix case when dynamodb kv reaches the limit of 25 actions per batch call. #5136
 * [FEATURE] Alertmanager: Add support for time_intervals. #5102
 
 ## 1.14.0 2022-12-02

--- a/pkg/ring/kv/dynamodb/client.go
+++ b/pkg/ring/kv/dynamodb/client.go
@@ -70,6 +70,7 @@ func NewClient(cfg Config, cc codec.Codec, logger log.Logger, registerer prometh
 		ddbMetrics: ddbMetrics,
 		staleData:  make(map[string]staleData),
 	}
+	level.Info(c.logger).Log("dynamodb kv initialized")
 	return c, nil
 }
 

--- a/pkg/ring/kv/dynamodb/dynamodb.go
+++ b/pkg/ring/kv/dynamodb/dynamodb.go
@@ -3,6 +3,7 @@ package dynamodb
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -176,38 +177,53 @@ func (kv dynamodbKV) Batch(ctx context.Context, put map[dynamodbKey][]byte, dele
 		return nil
 	}
 
-	writeRequests := make([]*dynamodb.WriteRequest, 0, writeRequestSize)
+	// Current limit of 25 actions per batch
+	// https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
+	writeRequestsSlices := make([][]*dynamodb.WriteRequest, int(math.Ceil(float64(writeRequestSize)/25.0)))
+	for i := 0; i < len(writeRequestsSlices); i++ {
+		writeRequestsSlices[i] = make([]*dynamodb.WriteRequest, 0, 25)
+	}
+
+	currIdx := 0
 	for key, data := range put {
 		item := kv.generatePutItemRequest(key, data)
-		writeRequests = append(writeRequests, &dynamodb.WriteRequest{
+		writeRequestsSlices[currIdx] = append(writeRequestsSlices[currIdx], &dynamodb.WriteRequest{
 			PutRequest: &dynamodb.PutRequest{
 				Item: item,
 			},
 		})
+		if len(writeRequestsSlices[currIdx]) == 25 {
+			currIdx++
+		}
 	}
 
 	for _, key := range delete {
 		item := generateItemKey(key)
-		writeRequests = append(writeRequests, &dynamodb.WriteRequest{
+		writeRequestsSlices[currIdx] = append(writeRequestsSlices[currIdx], &dynamodb.WriteRequest{
 			DeleteRequest: &dynamodb.DeleteRequest{
 				Key: item,
 			},
 		})
+		if len(writeRequestsSlices[currIdx]) == 25 {
+			currIdx++
+		}
 	}
 
-	input := &dynamodb.BatchWriteItemInput{
-		RequestItems: map[string][]*dynamodb.WriteRequest{
-			*kv.tableName: writeRequests,
-		},
-	}
+	for _, slice := range writeRequestsSlices {
+		input := &dynamodb.BatchWriteItemInput{
+			RequestItems: map[string][]*dynamodb.WriteRequest{
+				*kv.tableName: slice,
+			},
+		}
 
-	resp, err := kv.ddbClient.BatchWriteItemWithContext(ctx, input)
-	if err != nil {
-		return err
-	}
+		resp, err := kv.ddbClient.BatchWriteItemWithContext(ctx, input)
+		if err != nil {
+			return err
+		}
 
-	if resp.UnprocessedItems != nil && len(resp.UnprocessedItems) > 0 {
-		return fmt.Errorf("error processing batch request for %s requests", resp.UnprocessedItems)
+		if resp.UnprocessedItems != nil && len(resp.UnprocessedItems) > 0 {
+			return fmt.Errorf("error processing batch request for %s requests", resp.UnprocessedItems)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Daniel Deluiggi <ddeluigg@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Dynamodb has limitations on size of batch request. The current limit is at 25 actions per request.
https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
Adding slices on batch for ddb kv store.

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
