### PR TITLE
Fix conflict schema url when initializing resources

### DIFF
--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -19,7 +19,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
 	"github.com/cortexproject/cortex/pkg/tracing/migration"
 	"github.com/cortexproject/cortex/pkg/tracing/sampler"
@@ -119,7 +119,6 @@ func SetupTracing(ctx context.Context, name string, c Config) (func(context.Cont
 		}
 
 		r, err := newResource(ctx, name, c.Otel.ExtraDetectors)
-
 		if err != nil {
 			return nil, fmt.Errorf("creating tracing resource: %w", err)
 		}
@@ -158,14 +157,10 @@ func newTraceProvider(r *resource.Resource, c Config, exporter *otlptrace.Export
 }
 
 func newResource(ctx context.Context, target string, detectors []resource.Detector) (*resource.Resource, error) {
-	r, err := resource.New(ctx, resource.WithHost(), resource.WithDetectors(detectors...))
-
-	if err != nil {
-		return nil, err
+	opts := []resource.Option{
+		resource.WithHost(),
+		resource.WithDetectors(detectors...),
+		resource.WithAttributes(semconv.ServiceNameKey.String(target)),
 	}
-
-	return resource.Merge(r, resource.NewWithAttributes(
-		semconv.SchemaURL,
-		semconv.ServiceNameKey.String(target),
-	))
+	return resource.New(ctx, opts...)
 }

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -1,0 +1,21 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+)
+
+func TestNewResource(t *testing.T) {
+	ctx := context.Background()
+	target := "ingester"
+	r, err := newResource(ctx, target, nil)
+	require.NoError(t, err)
+
+	set := r.Set()
+	name, ok := set.Value(semconv.ServiceNameKey)
+	require.True(t, ok)
+	require.Equal(t, name.AsString(), target)
+}


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

We are merging 2 resources in `newResource` when initializing. However, one resource is using the schema URL for v1.12.0 while another one is using the schema URL for v1.17.0.

In order to fix this, I removed merging two resources, instead just statically set the service name attribute.

**Which issue(s) this PR fixes**:

https://github.com/cortexproject/cortex/issues/5139

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
