### PR TITLE
initialize querier stats in QFE only if it is not enabled

### DIFF
--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -120,14 +120,12 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Initialise the stats in the context and make sure it's propagated
 	// down the request chain.
 	if f.cfg.QueryStatsEnabled {
-		var ctx context.Context
 		// Check if querier stats is enabled in the context.
 		stats = querier_stats.FromContext(r.Context())
 		if stats == nil {
+			var ctx context.Context
 			stats, ctx = querier_stats.ContextWithEmptyStats(r.Context())
 			r = r.WithContext(ctx)
-		} else {
-			ctx = r.Context()
 		}
 	}
 

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -121,8 +121,14 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// down the request chain.
 	if f.cfg.QueryStatsEnabled {
 		var ctx context.Context
-		stats, ctx = querier_stats.ContextWithEmptyStats(r.Context())
-		r = r.WithContext(ctx)
+		// Check if querier stats is enabled in the context.
+		stats = querier_stats.FromContext(r.Context())
+		if stats == nil {
+			stats, ctx = querier_stats.ContextWithEmptyStats(r.Context())
+			r = r.WithContext(ctx)
+		} else {
+			ctx = r.Context()
+		}
 	}
 
 	defer func() {


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Only initialize query stats if it is not enabled. If stats exist in the context then we don't initalize a new one.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
