### PR TITLE
Fix returning 5XX for limits errors in series API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [BUGFIX] Ingester: Fix panic when querying metadata from blocks that are being deleted. #5119
 * [BUGFIX] Ring: Fix case when dynamodb kv reaches the limit of 25 actions per batch call. #5136
 * [BUGFIX] Query-frontend:  Fix sorted queries do not produce sorted results for shardable queries. #5148
+* [BUGFIX] Querier: Fix `/api/v1/series` returning 5XX instead of 4XX when limits are hit. #5169
 * [FEATURE] Alertmanager: Add support for time_intervals. #5102
 
 ## 1.14.0 2022-12-02

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1034,11 +1034,11 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 				return nil, err
 			}
 			if err := queryLimiter.AddDataBytes(resp.Size()); err != nil {
-				return nil, err
+				return nil, validation.LimitError(err.Error())
 			}
 			for _, m := range resp.Metric {
 				if err := queryLimiter.AddSeries(m.Labels); err != nil {
-					return nil, err
+					return nil, validation.LimitError(err.Error())
 				}
 				m := cortexpb.FromLabelAdaptersToMetric(m.Labels)
 				fingerprint := m.Fingerprint()
@@ -1065,7 +1065,7 @@ func (d *Distributor) MetricsForLabelMatchersStream(ctx context.Context, from, t
 			for {
 				resp, err := stream.Recv()
 				if err := queryLimiter.AddDataBytes(resp.Size()); err != nil {
-					return nil, err
+					return nil, validation.LimitError(err.Error())
 				}
 
 				if err == io.EOF {
@@ -1078,7 +1078,7 @@ func (d *Distributor) MetricsForLabelMatchersStream(ctx context.Context, from, t
 					m := cortexpb.FromLabelAdaptersToMetricWithCopy(metric.Labels)
 
 					if err := queryLimiter.AddSeries(metric.Labels); err != nil {
-						return nil, err
+						return nil, validation.LimitError(err.Error())
 					}
 
 					fingerprint := m.Fingerprint()

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2173,7 +2173,7 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 				metrics, err := ds[0].MetricsForLabelMatchers(ctx, now, now, testData.matchers...)
 
 				if testData.expectedErr != nil {
-					assert.EqualError(t, err, testData.expectedErr.Error())
+					assert.ErrorIs(t, err, testData.expectedErr)
 					return
 				}
 
@@ -2190,7 +2190,7 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 			{
 				metrics, err := ds[0].MetricsForLabelMatchersStream(ctx, now, now, testData.matchers...)
 				if testData.expectedErr != nil {
-					assert.EqualError(t, err, testData.expectedErr.Error())
+					assert.ErrorIs(t, err, testData.expectedErr)
 					return
 				}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- This PR fixes a bug in the `/api/v1/series` which returns status code `500` when the query hits the limits.
- The validation error is converted into a 422 error here: https://github.com/cortexproject/cortex/blob/master/pkg/querier/error_translate_queryable.go#L39
- Therefore the error should be wrapped inside `validation.LimitError`. We do this in other APIs: https://github.com/cortexproject/cortex/blob/master/pkg/distributor/query.go#L326

```
level=warn ts=2023-02-23T00:00:00Z caller=logging.go:86 msg="POST /prometheus/api/v1/series (500) 1.232489841s Response: \"{\\\"status\\\":\\\"error\\\",\\\"errorType\\\":\\\"internal\\\",\\\"error\\\":\\\"the query hit the aggregated data size limit (limit: 1000000000 bytes)\\\"}\" ws: false; Accept: application/json, text/plain, <TRUNCATED>
```

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
