### PR TITLE
Fix the incorrect ordering for topk and bottomk in shardable queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 * [BUGFIX] Ingester: Ingesters returning empty response for metadata APIs. #5081
 * [BUGFIX] Ingester: Fix panic when querying metadata from blocks that are being deleted. #5119
 * [BUGFIX] Ring: Fix case when dynamodb kv reaches the limit of 25 actions per batch call. #5136
-* [BUGFIX] Query-frontend:  Fix sorted queries do not produce sorted results for shardable queries. #5148
+* [BUGFIX] Query-frontend: Fix shardable instant queries do not produce sorted results for `sort`, `sort_desc`, `topk`, `bottomk` functions. #5148, #5170
 * [BUGFIX] Querier: Fix `/api/v1/series` returning 5XX instead of 4XX when limits are hit. #5169
 * [FEATURE] Alertmanager: Add support for time_intervals. #5102
 

--- a/pkg/querier/tripperware/instantquery/instant_query.go
+++ b/pkg/querier/tripperware/instantquery/instant_query.go
@@ -305,11 +305,11 @@ func (instantQueryCodec) MergeResponse(ctx context.Context, req tripperware.Requ
 
 func vectorMerge(req tripperware.Request, resps []*PrometheusInstantQueryResponse) (*Vector, error) {
 	output := map[string]*Sample{}
-	sortAsc, sortDesc, err := parseQueryForSort(req.GetQuery())
+	metrics := []string{} // Used to preserve the order for topk and bottomk.
+	sortPlan, err := sortPlanForQuery(req.GetQuery())
 	if err != nil {
 		return nil, err
 	}
-	buf := make([]byte, 0, 1024)
 	for _, resp := range resps {
 		if resp == nil {
 			continue
@@ -324,9 +324,10 @@ func vectorMerge(req tripperware.Request, resps []*PrometheusInstantQueryRespons
 			if s == nil {
 				continue
 			}
-			metric := string(cortexpb.FromLabelAdaptersToLabels(sample.Labels).Bytes(buf))
+			metric := cortexpb.FromLabelAdaptersToLabels(sample.Labels).String()
 			if existingSample, ok := output[metric]; !ok {
 				output[metric] = s
+				metrics = append(metrics, metric) // Preserve the order of metric.
 			} else if existingSample.GetSample().TimestampMs < s.GetSample().TimestampMs {
 				// Choose the latest sample if we see overlap.
 				output[metric] = s
@@ -334,10 +335,19 @@ func vectorMerge(req tripperware.Request, resps []*PrometheusInstantQueryRespons
 		}
 	}
 
+	result := &Vector{
+		Samples: make([]*Sample, 0, len(output)),
+	}
+
 	if len(output) == 0 {
-		return &Vector{
-			Samples: make([]*Sample, 0),
-		}, nil
+		return result, nil
+	}
+
+	if sortPlan == mergeOnly {
+		for _, k := range metrics {
+			result.Samples = append(result.Samples, output[k])
+		}
+		return result, nil
 	}
 
 	type pair struct {
@@ -354,49 +364,79 @@ func vectorMerge(req tripperware.Request, resps []*PrometheusInstantQueryRespons
 	}
 
 	sort.Slice(samples, func(i, j int) bool {
-		// Order is determined by the sortFn in the query.
-		if sortAsc {
+		// Order is determined by vector
+		switch sortPlan {
+		case sortByValuesAsc:
 			return samples[i].s.Sample.Value < samples[j].s.Sample.Value
-		} else if sortDesc {
+		case sortByValuesDesc:
 			return samples[i].s.Sample.Value > samples[j].s.Sample.Value
-		} else {
-			// Fallback on sorting by labels.
-			return samples[i].metric < samples[j].metric
 		}
+		return samples[i].metric < samples[j].metric
 	})
-	result := &Vector{
-		Samples: make([]*Sample, 0, len(output)),
-	}
+
 	for _, p := range samples {
 		result.Samples = append(result.Samples, p.s)
 	}
 	return result, nil
 }
 
-func parseQueryForSort(q string) (bool, bool, error) {
+type sortPlan int
+
+const (
+	mergeOnly        sortPlan = 0
+	sortByValuesAsc  sortPlan = 1
+	sortByValuesDesc sortPlan = 2
+	sortByLabels     sortPlan = 3
+)
+
+func sortPlanForQuery(q string) (sortPlan, error) {
 	expr, err := promqlparser.ParseExpr(q)
 	if err != nil {
-		return false, false, err
+		return 0, err
 	}
-	var sortAsc bool = false
-	var sortDesc bool = false
-	done := errors.New("done")
-	promqlparser.Inspect(expr, func(n promqlparser.Node, _ []promqlparser.Node) error {
-		if n, ok := n.(*promqlparser.Call); ok {
+	// Check if the root expression is topk or bottomk
+	if aggr, ok := expr.(*promqlparser.AggregateExpr); ok {
+		if aggr.Op == promqlparser.TOPK || aggr.Op == promqlparser.BOTTOMK {
+			return mergeOnly, nil
+		}
+	}
+	checkForSort := func(expr promqlparser.Expr) (sortAsc, sortDesc bool) {
+		if n, ok := expr.(*promqlparser.Call); ok {
 			if n.Func != nil {
 				if n.Func.Name == "sort" {
 					sortAsc = true
-					return done
 				}
 				if n.Func.Name == "sort_desc" {
 					sortDesc = true
-					return done
 				}
 			}
 		}
-		return nil
-	})
-	return sortAsc, sortDesc, nil
+		return sortAsc, sortDesc
+	}
+	// Check the root expression for sort
+	if sortAsc, sortDesc := checkForSort(expr); sortAsc || sortDesc {
+		if sortAsc {
+			return sortByValuesAsc, nil
+		}
+		return sortByValuesDesc, nil
+	}
+
+	// If the root expression is a binary expression, check the LHS and RHS for sort
+	if bin, ok := expr.(*promqlparser.BinaryExpr); ok {
+		if sortAsc, sortDesc := checkForSort(bin.LHS); sortAsc || sortDesc {
+			if sortAsc {
+				return sortByValuesAsc, nil
+			}
+			return sortByValuesDesc, nil
+		}
+		if sortAsc, sortDesc := checkForSort(bin.RHS); sortAsc || sortDesc {
+			if sortAsc {
+				return sortByValuesAsc, nil
+			}
+			return sortByValuesDesc, nil
+		}
+	}
+	return sortByLabels, nil
 }
 
 func matrixMerge(resps []*PrometheusInstantQueryResponse) []tripperware.SampleStream {

--- a/pkg/querier/tripperware/instantquery/instant_query.go
+++ b/pkg/querier/tripperware/instantquery/instant_query.go
@@ -310,6 +310,7 @@ func vectorMerge(req tripperware.Request, resps []*PrometheusInstantQueryRespons
 	if err != nil {
 		return nil, err
 	}
+	buf := make([]byte, 0, 1024)
 	for _, resp := range resps {
 		if resp == nil {
 			continue
@@ -324,7 +325,7 @@ func vectorMerge(req tripperware.Request, resps []*PrometheusInstantQueryRespons
 			if s == nil {
 				continue
 			}
-			metric := cortexpb.FromLabelAdaptersToLabels(sample.Labels).String()
+			metric := string(cortexpb.FromLabelAdaptersToLabels(sample.Labels).Bytes(buf))
 			if existingSample, ok := output[metric]; !ok {
 				output[metric] = s
 				metrics = append(metrics, metric) // Preserve the order of metric.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- This ports the sharding fix implemented in Thanos: https://github.com/thanos-io/thanos/pull/6125
- If the root expr is `topk` or `bottomk`, the response will be concatenated without a global sort.
- If the AST contains `sort` or `sort_desc`, the response will be sorted by values.
- Else, the response will be sorted by labels.

Examples:
| # | Query                                                                | Merge mechanism                | Prometheus Link                                                                                                                                                                                               | Remarks                     |
|---|----------------------------------------------------------------------|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
| 1 | `1 + sort(sum by (code) (http_requests_total) )`                     | Merge and then sort by values  | [link](https://prometheus.demo.do.prometheus.io/graph?g0.expr=1%20%2B%20sort(sum%20by%20(code)%20(prometheus_http_requests_total)%20)&g0.tab=1&g0.stacked=0&g0.range_input=1h)                                | Prometheus sorts by value.  |
| 2 | `sort(topk by (code) (10, http_requests_total))`                     | Merge and then sort by values  | [link](https://prometheus.demo.do.prometheus.io/graph?g0.expr=sort(topk%20by%20(code)%20(10%2C%20prometheus_http_requests_total))&g0.tab=1&g0.stacked=0&g0.range_input=1h)                                    | Prometheus sorts by value.  |
| 3 | `topk by (code) (10,  http_requests_total)`                          | Merge responses but don't sort | [link](https://prometheus.demo.do.prometheus.io/graph?g0.expr=topk%20by%20(code)%20(10%2C%20%20http_requests_total)&g0.tab=1&g0.stacked=0&g0.range_input=1h)                                                  | Prometheus doesn't sort.    |
| 4 | `topk(5, http_requests_total) by (code) + sort(http_requests_total)` | Merge and then sort by values  | [link](https://prometheus.demo.do.prometheus.io/graph?g0.expr=topk(5%2C%20prometheus_http_requests_total)%20by%20(code)%20%2B%20sort(prometheus_http_requests_total)&g0.tab=1&g0.stacked=0&g0.range_input=1h) | Prometheus doesn't sort.    |
| 5 | `sort(http_requests_total) + topk(5, http_requests_total) by (code)` | Merge and then sort by values  | [link](https://prometheus.demo.do.prometheus.io/graph?g0.expr=sort(prometheus_http_requests_total)%20%2B%20topk(5%2C%20prometheus_http_requests_total)%20by%20(code)&g0.tab=1&g0.stacked=0&g0.range_input=1h) | Prometheus sorts by value.  |


There is discrepancy for case 4 where Prometheus doesn't sort the responses but Thanos will sort by value.

I believe the above approach will give reasonable compatibility with Prometheus without increasing the complexity in the merging logic in the frontend.
 


**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
