### PR TITLE
Reuse write request from distributor to Ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [ENHANCEMENT] Upgraded Docker base images to `alpine:3.17`. #5132
 * [ENHANCEMENT] Add retry logic to S3 bucket client. #5135
 * [ENHANCEMENT] Update Go version to 1.20.1. #5159
+* [ENHANCEMENT] Distributor: Reuse byte slices when serializing requests from distributors to ingesters. #5193
 * [FEATURE] Querier/Query Frontend: support Prometheus /api/v1/status/buildinfo API. #4978
 * [FEATURE] Ingester: Add active series to all_user_stats page. #4972
 * [FEATURE] Ingester: Added `-blocks-storage.tsdb.head-chunks-write-queue-size` allowing to configure the size of the in-memory queue used before flushing chunks to the disk . #5000

--- a/pkg/cortexpb/slicesPool.go
+++ b/pkg/cortexpb/slicesPool.go
@@ -9,7 +9,7 @@ type byteSlicePools struct {
 	pools []sync.Pool
 }
 
-func NewSlicePool(pools int) *byteSlicePools {
+func newSlicePool(pools int) *byteSlicePools {
 	sp := byteSlicePools{}
 	sp.init(pools)
 	return &sp
@@ -39,7 +39,7 @@ func (sp *byteSlicePools) getSlice(size int) []byte {
 }
 
 func (sp *byteSlicePools) reuseSlice(s []byte) {
-	index := int(math.Ceil(math.Log2(float64(cap(s)))))
+	index := int(math.Floor(math.Log2(float64(cap(s)))))
 
 	if index < 0 || index >= len(sp.pools) {
 		return

--- a/pkg/cortexpb/slicesPool.go
+++ b/pkg/cortexpb/slicesPool.go
@@ -40,6 +40,7 @@ func (sp *byteSlicePools) getSlice(size int) *[]byte {
 		return &buf
 	}
 
+	// if the size is < than the minPoolSizePower we return an array from the first pool
 	if index < 0 {
 		index = 0
 	}
@@ -52,12 +53,8 @@ func (sp *byteSlicePools) getSlice(size int) *[]byte {
 func (sp *byteSlicePools) reuseSlice(s *[]byte) {
 	index := int(math.Floor(math.Log2(float64(cap(*s))))) - minPoolSizePower
 
-	if index >= len(sp.pools) {
+	if index >= len(sp.pools) || index < 0 {
 		return
-	}
-
-	if index < 0 {
-		index = 0
 	}
 
 	sp.pools[index].Put(s)

--- a/pkg/cortexpb/slicesPool.go
+++ b/pkg/cortexpb/slicesPool.go
@@ -1,0 +1,49 @@
+package cortexpb
+
+import (
+	"math"
+	"sync"
+)
+
+type byteSlicePools struct {
+	pools []sync.Pool
+}
+
+func NewSlicePool(pools int) *byteSlicePools {
+	sp := byteSlicePools{}
+	sp.init(pools)
+	return &sp
+}
+
+func (sp *byteSlicePools) init(pools int) {
+	sp.pools = make([]sync.Pool, pools)
+	for i := 0; i < pools; i++ {
+		size := int(math.Pow(2, float64(i)))
+		sp.pools[i] = sync.Pool{
+			New: func() interface{} {
+				return make([]byte, 0, size)
+			},
+		}
+	}
+}
+
+func (sp *byteSlicePools) getSlice(size int) []byte {
+	index := int(math.Ceil(math.Log2(float64(size))))
+
+	if index < 0 || index >= len(sp.pools) {
+		return make([]byte, size)
+	}
+
+	s := sp.pools[index].Get().([]byte)
+	return s[:size]
+}
+
+func (sp *byteSlicePools) reuseSlice(s []byte) {
+	index := int(math.Ceil(math.Log2(float64(cap(s)))))
+
+	if index < 0 || index >= len(sp.pools) {
+		return
+	}
+
+	sp.pools[index].Put(s)
+}

--- a/pkg/cortexpb/slicesPool_test.go
+++ b/pkg/cortexpb/slicesPool_test.go
@@ -1,0 +1,18 @@
+package cortexpb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestByteSlicePools(t *testing.T) {
+	sut := NewSlicePool(20)
+
+	for i := 0; i < 1024*1024; i = i + 128 {
+		s := sut.getSlice(i)
+		assert.Equal(t, len(s), i)
+		sut.reuseSlice(s)
+	}
+
+}

--- a/pkg/cortexpb/slicesPool_test.go
+++ b/pkg/cortexpb/slicesPool_test.go
@@ -7,12 +7,10 @@ import (
 )
 
 func TestByteSlicePools(t *testing.T) {
-	sut := NewSlicePool(20)
-
+	sut := newSlicePool(20)
 	for i := 0; i < 1024*1024; i = i + 128 {
 		s := sut.getSlice(i)
 		assert.Equal(t, len(s), i)
 		sut.reuseSlice(s)
 	}
-
 }

--- a/pkg/cortexpb/slicesPool_test.go
+++ b/pkg/cortexpb/slicesPool_test.go
@@ -10,7 +10,7 @@ func TestByteSlicePools(t *testing.T) {
 	sut := newSlicePool(20)
 	for i := 0; i < 1024*1024; i = i + 128 {
 		s := sut.getSlice(i)
-		assert.Equal(t, len(s), i)
+		assert.Equal(t, len(*s), i)
 		sut.reuseSlice(s)
 	}
 }

--- a/pkg/cortexpb/slicesPool_test.go
+++ b/pkg/cortexpb/slicesPool_test.go
@@ -19,3 +19,12 @@ func TestFuzzyByteSlicePools(t *testing.T) {
 		sut.reuseSlice(s)
 	}
 }
+
+func TestReturnSliceSmallerThanMin(t *testing.T) {
+	sut := newSlicePool(20)
+	size := 3
+	buff := make([]byte, 0, size)
+	sut.reuseSlice(&buff)
+	buff2 := sut.getSlice(size * 2)
+	assert.Equal(t, len(*buff2), size*2)
+}

--- a/pkg/cortexpb/slicesPool_test.go
+++ b/pkg/cortexpb/slicesPool_test.go
@@ -1,16 +1,21 @@
 package cortexpb
 
 import (
+	"math"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestByteSlicePools(t *testing.T) {
+func TestFuzzyByteSlicePools(t *testing.T) {
 	sut := newSlicePool(20)
-	for i := 0; i < 1024*1024; i = i + 128 {
-		s := sut.getSlice(i)
-		assert.Equal(t, len(*s), i)
+	maxByteSize := int(math.Pow(2, 20+minPoolSizePower-1))
+
+	for i := 0; i < 1000; i++ {
+		size := rand.Int() % maxByteSize
+		s := sut.getSlice(size)
+		assert.Equal(t, len(*s), size)
 		sut.reuseSlice(s)
 	}
 }

--- a/pkg/cortexpb/timeseries.go
+++ b/pkg/cortexpb/timeseries.go
@@ -45,7 +45,7 @@ var (
 			}
 		},
 	}
-	bytePool = NewSlicePool(20)
+	bytePool = newSlicePool(20)
 )
 
 // PreallocConfig configures how structures will be preallocated to optimise
@@ -82,11 +82,11 @@ func (p *PreallocTimeseries) Unmarshal(dAtA []byte) error {
 	return p.TimeSeries.Unmarshal(dAtA)
 }
 
-func (m *PreallocWriteRequest) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
+func (p *PreallocWriteRequest) Marshal() (dAtA []byte, err error) {
+	size := p.Size()
 	dAtA = bytePool.getSlice(size)
-	m.data = dAtA
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	p.data = dAtA
+	n, err := p.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cortexpb/timeseries.go
+++ b/pkg/cortexpb/timeseries.go
@@ -37,6 +37,15 @@ var (
 			}
 		},
 	}
+
+	writeRequestPool = sync.Pool{
+		New: func() interface{} {
+			return &PreallocWriteRequest{
+				WriteRequest: WriteRequest{},
+			}
+		},
+	}
+	bytePool = NewSlicePool(20)
 )
 
 // PreallocConfig configures how structures will be preallocated to optimise
@@ -53,6 +62,7 @@ func (PreallocConfig) RegisterFlags(f *flag.FlagSet) {
 // PreallocWriteRequest is a WriteRequest which preallocs slices on Unmarshal.
 type PreallocWriteRequest struct {
 	WriteRequest
+	data []byte
 }
 
 // Unmarshal implements proto.Message.
@@ -70,6 +80,30 @@ type PreallocTimeseries struct {
 func (p *PreallocTimeseries) Unmarshal(dAtA []byte) error {
 	p.TimeSeries = TimeseriesFromPool()
 	return p.TimeSeries.Unmarshal(dAtA)
+}
+
+func (m *PreallocWriteRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = bytePool.getSlice(size)
+	m.data = dAtA
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func ReuseWriteRequest(req *PreallocWriteRequest) {
+	if req.data != nil {
+		bytePool.reuseSlice(req.data)
+		req.data = nil
+	}
+
+	writeRequestPool.Put(req)
+}
+
+func PreallocWriteRequestFromPool() *PreallocWriteRequest {
+	return writeRequestPool.Get().(*PreallocWriteRequest)
 }
 
 // LabelAdapter is a labels.Label that can be marshalled to/from protos.

--- a/pkg/cortexpb/timeseries.go
+++ b/pkg/cortexpb/timeseries.go
@@ -62,7 +62,7 @@ func (PreallocConfig) RegisterFlags(f *flag.FlagSet) {
 // PreallocWriteRequest is a WriteRequest which preallocs slices on Unmarshal.
 type PreallocWriteRequest struct {
 	WriteRequest
-	data []byte
+	data *[]byte
 }
 
 // Unmarshal implements proto.Message.
@@ -84,8 +84,8 @@ func (p *PreallocTimeseries) Unmarshal(dAtA []byte) error {
 
 func (p *PreallocWriteRequest) Marshal() (dAtA []byte, err error) {
 	size := p.Size()
-	dAtA = bytePool.getSlice(size)
-	p.data = dAtA
+	p.data = bytePool.getSlice(size)
+	dAtA = *p.data
 	n, err := p.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err

--- a/pkg/cortexpb/timeseries.go
+++ b/pkg/cortexpb/timeseries.go
@@ -98,7 +98,9 @@ func ReuseWriteRequest(req *PreallocWriteRequest) {
 		bytePool.reuseSlice(req.data)
 		req.data = nil
 	}
-
+	req.Source = 0
+	req.Metadata = nil
+	req.Timeseries = nil
 	writeRequestPool.Put(req)
 }
 

--- a/pkg/cortexpb/timeseries_test.go
+++ b/pkg/cortexpb/timeseries_test.go
@@ -1,8 +1,10 @@
 package cortexpb
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,4 +65,57 @@ func TestTimeseriesFromPool(t *testing.T) {
 		assert.Len(t, reused.Labels, 0)
 		assert.Len(t, reused.Samples, 0)
 	})
+}
+
+func BenchmarkMarshallWriteRequest(b *testing.B) {
+	ts := PreallocTimeseriesSliceFromPool()
+
+	for i := 0; i < 100; i++ {
+		ts = append(ts, PreallocTimeseries{TimeSeries: TimeseriesFromPool()})
+		ts[i].Labels = []LabelAdapter{
+			{Name: "foo", Value: "bar"},
+			{Name: "very long label name", Value: "very long label value"},
+			{Name: "very long label name 2", Value: "very long label value 2"},
+			{Name: "very long label name 3", Value: "very long label value 3"},
+			{Name: "int", Value: fmt.Sprint(i)},
+		}
+		ts[i].Samples = []Sample{{Value: 1, TimestampMs: 2}}
+	}
+
+	tests := []struct {
+		name                string
+		writeRequestFactory func() proto.Marshaler
+		clean               func(in interface{})
+	}{
+		{
+			name: "no-pool",
+			writeRequestFactory: func() proto.Marshaler {
+				return &WriteRequest{Timeseries: ts}
+			},
+			clean: func(in interface{}) {},
+		},
+		{
+			name: "pool",
+			writeRequestFactory: func() proto.Marshaler {
+				w := PreallocWriteRequestFromPool()
+				w.Timeseries = ts
+				return w
+			},
+			clean: func(in interface{}) {
+				ReuseWriteRequest(in.(*PreallocWriteRequest))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				w := tc.writeRequestFactory()
+				_, err := w.Marshal()
+				require.NoError(b, err)
+				tc.clean(w)
+			}
+			b.ReportAllocs()
+		})
+	}
 }

--- a/pkg/cortexpb/timeseries_test.go
+++ b/pkg/cortexpb/timeseries_test.go
@@ -95,7 +95,18 @@ func BenchmarkMarshallWriteRequest(b *testing.B) {
 			clean: func(in interface{}) {},
 		},
 		{
-			name: "pool",
+			name: "byte pool",
+			writeRequestFactory: func() proto.Marshaler {
+				w := &PreallocWriteRequest{}
+				w.Timeseries = ts
+				return w
+			},
+			clean: func(in interface{}) {
+				ReuseWriteRequest(in.(*PreallocWriteRequest))
+			},
+		},
+		{
+			name: "byte and write pool",
 			writeRequestFactory: func() proto.Marshaler {
 				w := PreallocWriteRequestFromPool()
 				w.Timeseries = ts

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2688,6 +2688,10 @@ func (i *mockIngester) Close() error {
 	return nil
 }
 
+func (i *mockIngester) PushPreAlloc(ctx context.Context, in *cortexpb.PreallocWriteRequest, opts ...grpc.CallOption) (*cortexpb.WriteResponse, error) {
+	return i.Push(ctx, &in.WriteRequest, opts...)
+}
+
 func (i *mockIngester) Push(ctx context.Context, req *cortexpb.WriteRequest, opts ...grpc.CallOption) (*cortexpb.WriteResponse, error) {
 	i.Lock()
 	defer i.Unlock()

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"context"
 	"flag"
 
+	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -24,12 +26,22 @@ type HealthAndIngesterClient interface {
 	IngesterClient
 	grpc_health_v1.HealthClient
 	Close() error
+	PushPreAlloc(ctx context.Context, in *cortexpb.PreallocWriteRequest, opts ...grpc.CallOption) (*cortexpb.WriteResponse, error)
 }
 
 type closableHealthAndIngesterClient struct {
 	IngesterClient
 	grpc_health_v1.HealthClient
 	conn *grpc.ClientConn
+}
+
+func (c *closableHealthAndIngesterClient) PushPreAlloc(ctx context.Context, in *cortexpb.PreallocWriteRequest, opts ...grpc.CallOption) (*cortexpb.WriteResponse, error) {
+	out := new(cortexpb.WriteResponse)
+	err := c.conn.Invoke(ctx, "/cortex.Ingester/Push", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // MakeIngesterClient makes a new IngesterClient

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -5,8 +5,8 @@ import (
 	"flag"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
-
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
+
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -5,13 +5,13 @@ import (
 	"flag"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
+
+	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
-
-	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 )
 
 var ingesterClientRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
**What this PR does**:

Just some tentative to reuse the write requests and the byte slices when marshaling the write requests from distributors to ingesters.

Bench Results: 

```
BenchmarkMarshallWriteRequest/no-pool-16         	   40658	     29358 ns/op	   19136 B/op	       2 allocs/op
BenchmarkMarshallWriteRequest/no-pool-16         	   40474	     29386 ns/op	   19136 B/op	       2 allocs/op
BenchmarkMarshallWriteRequest/no-pool-16         	   40921	     29294 ns/op	   19136 B/op	       2 allocs/op
BenchmarkMarshallWriteRequest/no-pool-16         	   40840	     29317 ns/op	   19136 B/op	       2 allocs/op
BenchmarkMarshallWriteRequest/no-pool-16         	   40756	     29344 ns/op	   19136 B/op	       2 allocs/op
BenchmarkMarshallWriteRequest/byte_pool-16       	   44792	     26797 ns/op	     104 B/op	       1 allocs/op
BenchmarkMarshallWriteRequest/byte_pool-16       	   44408	     26797 ns/op	     106 B/op	       1 allocs/op
BenchmarkMarshallWriteRequest/byte_pool-16       	   44719	     26799 ns/op	     105 B/op	       1 allocs/op
BenchmarkMarshallWriteRequest/byte_pool-16       	   44761	     26792 ns/op	     105 B/op	       1 allocs/op
BenchmarkMarshallWriteRequest/byte_pool-16       	   44568	     26796 ns/op	     105 B/op	       1 allocs/op
BenchmarkMarshallWriteRequest/byte_and_write_pool-16         	   44536	     26646 ns/op	       0 B/op	       0 allocs/op
BenchmarkMarshallWriteRequest/byte_and_write_pool-16         	   45062	     26622 ns/op	       0 B/op	       0 allocs/op
BenchmarkMarshallWriteRequest/byte_and_write_pool-16         	   44780	     26826 ns/op	       0 B/op	       0 allocs/op
BenchmarkMarshallWriteRequest/byte_and_write_pool-16         	   45090	     26625 ns/op	       0 B/op	       0 allocs/op
BenchmarkMarshallWriteRequest/byte_and_write_pool-16         	   44688	     26822 ns/op	       0 B/op	       0 allocs/op
```

```
## no-pool x byte_pool
name                     old time/op    new time/op    delta
MarshallWriteRequest-16    29.3µs ± 0%    26.8µs ± 0%   -8.67%  (p=0.008 n=5+5)

name                     old alloc/op   new alloc/op   delta
MarshallWriteRequest-16    19.1kB ± 0%     0.1kB ± 1%  -99.45%  (p=0.008 n=5+5)

name                     old allocs/op  new allocs/op  delta
MarshallWriteRequest-16      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)



## byte_pool x byte_and_write_pool
name                     old time/op    new time/op    delta
MarshallWriteRequest-16    26.8µs ± 0%    26.7µs ± 0%      ~     (p=0.651 n=5+5)

name                     old alloc/op   new alloc/op   delta
MarshallWriteRequest-16      105B ± 1%        0B       -100.00%  (p=0.008 n=5+5)

name                     old allocs/op  new allocs/op  delta
MarshallWriteRequest-16      1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)


## no-pool x byte_and_write_pool
name                     old time/op    new time/op    delta
MarshallWriteRequest-16    29.3µs ± 0%    26.7µs ± 0%    -8.97%  (p=0.008 n=5+5)

name                     old alloc/op   new alloc/op   delta
MarshallWriteRequest-16    19.1kB ± 0%     0.0kB       -100.00%  (p=0.008 n=5+5)

name                     old allocs/op  new allocs/op  delta
MarshallWriteRequest-16      2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
```



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
