### PR TITLE
Fix read reader multiple times in QFE

### DIFF
--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -122,7 +122,7 @@ func (c *Client) Query(query string, ts time.Time) (model.Value, error) {
 	return value, err
 }
 
-// Query runs a query range.
+// QueryRange runs a query range.
 func (c *Client) QueryRange(query string, start, end time.Time, step time.Duration) (model.Value, error) {
 	value, _, err := c.querierClient.QueryRange(context.Background(), query, promv1.Range{
 		Start: start,

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -140,7 +140,8 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// We parse form here so that we can use buf as body, in order to
 	// prevent https://github.com/cortexproject/cortex/issues/5201.
 	if err := r.ParseForm(); err != nil {
-		level.Warn(util_log.WithContext(r.Context(), f.log)).Log("msg", "unable to parse request form", "err", err)
+		writeError(w, err)
+		return
 	}
 	r.Body = io.NopCloser(&buf)
 

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -137,6 +137,12 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var buf bytes.Buffer
 	r.Body = http.MaxBytesReader(w, r.Body, f.cfg.MaxBodySize)
 	r.Body = io.NopCloser(io.TeeReader(r.Body, &buf))
+	// We parse form here so that we can use buf as body, in order to
+	// prevent https://github.com/cortexproject/cortex/issues/5201.
+	if err := r.ParseForm(); err != nil {
+		level.Warn(util_log.WithContext(r.Context(), f.log)).Log("msg", "unable to parse request form", "err", err)
+	}
+	r.Body = io.NopCloser(&buf)
 
 	startTime := time.Now()
 	resp, err := f.roundTripper.RoundTrip(r)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

To prevent reading the reader multiple times in #5201, instead we first parse the form to read the body if it is a POST request, then we set body to the buffer we copied. This could make sure we read the buf later only once.

I have added integration test cases for query frontend with vertical sharding enabled. Tests should pass after this fix.

Note: 
If it is a GET request and it sets body to non empty, in this case the buffer is nil so we will set body to nil. But I think this is fine as `ParseForm` method only cares about url params and ignores body if it is a GET request.

**Which issue(s) this PR fixes**:
Fixes #5201

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
