### PR TITLE
Fix S3 BucketWithRetries upload empty content issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [ENHANCEMENT] Update Go version to 1.20.1. #5159
 * [ENHANCEMENT] Distributor: Reuse byte slices when serializing requests from distributors to ingesters. #5193
 * [ENHANCEMENT] Query Frontend: Add number of chunks and samples fetched in query stats. #5198
+* [ENHANCEMENT] Implement grpc.Compressor.DecompressedSize for snappy to optimize memory allocations. #5213
 * [FEATURE] Querier/Query Frontend: support Prometheus /api/v1/status/buildinfo API. #4978
 * [FEATURE] Ingester: Add active series to all_user_stats page. #4972
 * [FEATURE] Ingester: Added `-blocks-storage.tsdb.head-chunks-write-queue-size` allowing to configure the size of the in-memory queue used before flushing chunks to the disk . #5000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [BUGFIX] Query-frontend: Fix shardable instant queries do not produce sorted results for `sort`, `sort_desc`, `topk`, `bottomk` functions. #5148, #5170
 * [BUGFIX] Querier: Fix `/api/v1/series` returning 5XX instead of 4XX when limits are hit. #5169
 * [BUGFIX] Compactor: Fix issue that shuffle sharding planner return error if block is under visit by other compactor. #5188
+* [BUGFIX] Fix S3 BucketWithRetries upload empty content issue #5217
 * [FEATURE] Alertmanager: Add support for time_intervals. #5102
 
 ## 1.14.0 2022-12-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 * [ENHANCEMENT] Update Go version to 1.20.1. #5159
 * [ENHANCEMENT] Distributor: Reuse byte slices when serializing requests from distributors to ingesters. #5193
 * [ENHANCEMENT] Query Frontend: Add number of chunks and samples fetched in query stats. #5198
-* [ENHANCEMENT] Implement grpc.Compressor.DecompressedSize for snappy to optimize memory allocations. #5213
 * [FEATURE] Querier/Query Frontend: support Prometheus /api/v1/status/buildinfo API. #4978
 * [FEATURE] Ingester: Add active series to all_user_stats page. #4972
 * [FEATURE] Ingester: Added `-blocks-storage.tsdb.head-chunks-write-queue-size` allowing to configure the size of the in-memory queue used before flushing chunks to the disk . #5000

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/s3"
@@ -92,6 +93,7 @@ func newS3Config(cfg Config) (s3.Config, error) {
 }
 
 type BucketWithRetries struct {
+	logger           log.Logger
 	bucket           objstore.Bucket
 	operationRetries int
 	retryMinBackoff  time.Duration
@@ -114,6 +116,9 @@ func (b *BucketWithRetries) retry(ctx context.Context, f func() error) error {
 			return lastErr
 		}
 		retries.Wait()
+	}
+	if lastErr != nil {
+		level.Error(b.logger).Log("msg", "bucket operation fail after retries", "err", lastErr)
 	}
 	return lastErr
 }

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -162,6 +162,8 @@ func (b *BucketWithRetries) Exists(ctx context.Context, name string) (exists boo
 func (b *BucketWithRetries) Upload(ctx context.Context, name string, r io.Reader) error {
 	rs, ok := r.(io.ReadSeeker)
 	if !ok {
+		// Skip retry if incoming Reader is not seekable to avoid
+		// loading entire content into memory
 		return b.bucket.Upload(ctx, name, r)
 	}
 	return b.retry(ctx, func() error {

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -30,6 +30,7 @@ func NewBucketClient(cfg Config, name string, logger log.Logger) (objstore.Bucke
 		return nil, err
 	}
 	return &BucketWithRetries{
+		logger:           logger,
 		bucket:           bucket,
 		operationRetries: defaultOperationRetries,
 		retryMinBackoff:  defaultRetryMinBackoff,
@@ -49,6 +50,7 @@ func NewBucketReaderClient(cfg Config, name string, logger log.Logger) (objstore
 		return nil, err
 	}
 	return &BucketWithRetries{
+		logger:           logger,
 		bucket:           bucket,
 		operationRetries: defaultOperationRetries,
 		retryMinBackoff:  defaultRetryMinBackoff,
@@ -120,7 +122,7 @@ func (b *BucketWithRetries) retry(ctx context.Context, f func() error) error {
 	if lastErr != nil {
 		level.Error(b.logger).Log("msg", "bucket operation fail after retries", "err", lastErr)
 	}
-	return lastErr
+	return nil
 }
 
 func (b *BucketWithRetries) Name() string {

--- a/pkg/storage/bucket/s3/bucket_client_test.go
+++ b/pkg/storage/bucket/s3/bucket_client_test.go
@@ -45,16 +45,16 @@ func TestBucketWithRetries_UploadNonSeekable(t *testing.T) {
 		retryMaxBackoff:  time.Second,
 	}
 
-	input := &FakeReader{}
+	input := &fakeReader{}
 	err := b.Upload(context.Background(), "dummy", input)
 	require.Errorf(t, err, "empty byte slice")
 	require.Equal(t, maxFailCount, m.FailCount)
 }
 
-type FakeReader struct {
+type fakeReader struct {
 }
 
-func (f *FakeReader) Read(p []byte) (n int, err error) {
+func (f *fakeReader) Read(p []byte) (n int, err error) {
 	return 0, fmt.Errorf("empty byte slice")
 }
 

--- a/pkg/util/grpcencoding/snappy/snappy.go
+++ b/pkg/util/grpcencoding/snappy/snappy.go
@@ -51,6 +51,20 @@ func (c *compressor) Decompress(r io.Reader) (io.Reader, error) {
 	return reader{dr, &c.readersPool}, nil
 }
 
+// If a Compressor implements DecompressedSize(compressedBytes []byte) int,
+// gRPC will call it to determine the size of the buffer allocated for the
+// result of decompression.
+// Return -1 to indicate unknown size.
+//
+// This is an EXPERIMENTAL feature of grpc-go.
+func (c *compressor) DecompressedSize(compressedBytes []byte) int {
+	decompressedSize, err := snappy.DecodedLen(compressedBytes)
+	if err != nil {
+		return -1
+	}
+	return decompressedSize
+}
+
 type writeCloser struct {
 	writer *snappy.Writer
 	pool   *sync.Pool

--- a/pkg/util/grpcencoding/snappy/snappy.go
+++ b/pkg/util/grpcencoding/snappy/snappy.go
@@ -51,20 +51,6 @@ func (c *compressor) Decompress(r io.Reader) (io.Reader, error) {
 	return reader{dr, &c.readersPool}, nil
 }
 
-// If a Compressor implements DecompressedSize(compressedBytes []byte) int,
-// gRPC will call it to determine the size of the buffer allocated for the
-// result of decompression.
-// Return -1 to indicate unknown size.
-//
-// This is an EXPERIMENTAL feature of grpc-go.
-func (c *compressor) DecompressedSize(compressedBytes []byte) int {
-	decompressedSize, err := snappy.DecodedLen(compressedBytes)
-	if err != nil {
-		return -1
-	}
-	return decompressedSize
-}
-
 type writeCloser struct {
 	writer *snappy.Writer
 	pool   *sync.Pool


### PR DESCRIPTION
**What this PR does**:
`BucketWithRetries` for S3 reused the same Reader inside retry logic which caused empty content got uploaded during retry. This PR should fix this problem by only retrying upload operation if the input Reader is seekable.

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
