### PR TITLE
Fail query fuzzer test if inconsistent

### DIFF
--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -157,6 +157,7 @@ func TestVerticalShardingFuzz(t *testing.T) {
 		})
 	}
 
+	failures := 0
 	for i, tc := range cases {
 		qt := "instant query"
 		if !tc.instantQuery {
@@ -165,10 +166,15 @@ func TestVerticalShardingFuzz(t *testing.T) {
 		if tc.err1 != nil || tc.err2 != nil {
 			if !cmp.Equal(tc.err1, tc.err2) {
 				t.Logf("case %d error mismatch.\n%s: %s\nerr1: %v\nerr2: %v\n", i, qt, tc.query, tc.err1, tc.err2)
+				failures++
 			}
 		} else if !sameModelValue(tc.res1, tc.res2) {
 			t.Logf("case %d results mismatch.\n%s: %s\nres1: %s\nres2: %s\n", i, qt, tc.query, tc.res1.String(), tc.res2.String())
+			failures++
 		}
+	}
+	if failures > 0 {
+		require.Fail(t, "failed %d test cases", failures)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Previous in the query fuzzer integration test, we only log the failed cases but didn't fail the test itself. 
Because at that time, we have many known cases of vertical sharding that could cause inconsistent results. Now since those known issues are fixed, we can enable to fail the fuzzer test so that we can know it failed and check workflows in detail.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
