### PR TITLE
fix: unit test anomalous error, defer not release port correctly

### DIFF
--- a/pkg/ring/kv/memberlist/memberlist_client_test.go
+++ b/pkg/ring/kv/memberlist/memberlist_client_test.go
@@ -842,7 +842,9 @@ func getFreePorts(count int) ([]int, error) {
 		if err != nil {
 			return nil, err
 		}
-		defer l.Close()
+		if err := l.Close(); err != nil {
+			return nil, err
+		}
 		ports = append(ports, l.Addr().(*net.TCPAddr).Port)
 	}
 	return ports, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
unit test anomalous error,  port already in used. defer not release port correctly.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
