### PR TITLE
Catch context error in the s3 bucket client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [ENHANCEMENT] Querier: Batch Iterator optimization to prevent transversing it multiple times query ranges steps does not overlap. #5237
+* [BUGFIX] Catch context error in the s3 bucket client. #5240
 
 ## 1.15.0 in progress
 

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -124,7 +124,7 @@ func (b *BucketWithRetries) retry(ctx context.Context, f func() error, operation
 		level.Error(b.logger).Log("msg", "bucket operation fail after retries", "err", lastErr, "operation", operationInfo)
 		return lastErr
 	}
-	return nil
+	return retries.Err()
 }
 
 func (b *BucketWithRetries) Name() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Store gateway may panic if the s3 client return nil error with some nil value.
```
panic: runtime error: invalid memory address or nil pointer dereference
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x12a2e04]

goroutine 10142 [running]:
github.com/thanos-io/objstore.(*timingReadCloser).Close(0xc01643ea80)
        /go/src/github.com/cortexproject/cortex/vendor/github.com/thanos-io/objstore/objstore.go:638 +0x24
github.com/thanos-io/objstore.(*tracingReadCloser).Close(0xc0187b2e80)
        /go/src/github.com/cortexproject/cortex/vendor/github.com/thanos-io/objstore/tracing.go:149 +0x2d
github.com/thanos-io/thanos/pkg/runutil.CloseWithLogOnErr({0x3e2b8c0, 0xc000dafb80}, {0x7f16340f7a60?, 0xc0187b2e80?}, {0x373dd29, 0x21}, {0x0, 0x0, 0x0})
        /go/src/github.com/cortexproject/cortex/vendor/github.com/thanos-io/thanos/pkg/runutil/runutil.go:111 +0x77
panic({0x31628e0, 0x5903850})
        /usr/local/go/src/runtime/panic.go:884 +0x213
github.com/thanos-io/objstore.(*timingReadCloser).Read(0xc01643ea80, {0xc0106c1b80?, 0xc004424eb0?, 0xc0187ff860?})
        /go/src/github.com/cortexproject/cortex/vendor/github.com/thanos-io/objstore/objstore.go:650 +0x29
github.com/thanos-io/objstore.(*tracingReadCloser).Read(0xc0187b2e80, {0xc0106c1b80?, 0xc0106c1b80?, 0x0?})
        /go/src/github.com/cortexproject/cortex/vendor/github.com/thanos-io/objstore/tracing.go:138 +0x32
bytes.(*Buffer).ReadFrom(0xc001729d70, {0x7f16340f7a80, 0xc0187b2e80})
        /usr/local/go/src/bytes/buffer.go:202 +0x98
github.com/thanos-io/thanos/pkg/store.(*bucketBlock).readIndexRange(0xc000261180, {0x3e55d38, 0xc004424eb0}, 0x0?, 0x48)
        /go/src/github.com/cortexproject/cortex/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go:2008 +0x1e5
github.com/thanos-io/thanos/pkg/s
```

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
