### PR TITLE
Fix query frontend incorrect error response format

### DIFF
--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -203,12 +203,12 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func formatGrafanaStatsFields(r *http.Request) []interface{} {
-	fields := make([]interface{}, 0, 2)
+	fields := make([]interface{}, 0, 4)
 	if dashboardUID := r.Header.Get("X-Dashboard-Uid"); dashboardUID != "" {
-		fields = append(fields, dashboardUID)
+		fields = append(fields, "X-Dashboard-Uid", dashboardUID)
 	}
 	if panelID := r.Header.Get("X-Panel-Id"); panelID != "" {
-		fields = append(fields, panelID)
+		fields = append(fields, "X-Panel-Id", panelID)
 	}
 	return fields
 }

--- a/pkg/querier/tripperware/queryrange/split_by_interval.go
+++ b/pkg/querier/tripperware/queryrange/split_by_interval.go
@@ -47,7 +47,12 @@ func (s splitByInterval) Do(ctx context.Context, r tripperware.Request) (tripper
 	// to line up the boundaries with step.
 	reqs, err := splitQuery(r, s.interval(r))
 	if err != nil {
-		return nil, err
+		// If the query itself is bad, we don't return error but send the query
+		// to querier to return the expected error message. This is not very efficient
+		// but should be okay for now.
+		// TODO(yeya24): query frontend can reuse the Prometheus API handler and return
+		// expected error message locally without passing it to the querier through network.
+		return s.next.Do(ctx, r)
 	}
 	s.splitByCounter.Add(float64(len(reqs)))
 


### PR DESCRIPTION
**What this PR does**:

This pr mainly fixes #5252. The issue is that when parsing the query expression, we returned the error directly in Query Frontend. However, Grafana expects the response to be the Prometheus format, but we only returned the error itself. This is very similar to https://github.com/thanos-io/thanos/pull/5684.

Also fixed a small issue for Grafana query fields.  We are expecting both key and value but here it only adds a value.

**Which issue(s) this PR fixes**:
Fixes #5252 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
