### PR TITLE
Document runtime config

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -168,6 +168,44 @@ runtime_config:
   # CLI flag: -runtime-config.file
   [file: <string> | default = ""]
 
+  # Overrides default global limits (defined in limits_config) on a per-tenant basis.
+  # Specify tenant-specific limits using the same fields available in limits_config.
+  # Each tenant is defined as a key-value pair, where the key is the tenant ID
+  # and the value is an object with tenant-specific limits.
+  #
+  # Refer to the (https://cortexmetrics.io/docs/configuration/configuration-file/#limits_config)
+  # documentation for a description of available fields and to
+  # [https://cortexmetrics.io/docs/configuration/arguments/#runtime-configuration-file]
+  # for the example usage.
+  [overrides: <limits_config_per_tenant>]
+
+  # Switch to a different store  (eg. consul -> etcd)
+  multi_kv_config:
+    # Updated store name
+    [primary: <string> | default = ""]
+
+    # Enable mirroring
+    [mirror_enabled: <boolean> | default = false]
+
+  # Enable streaming entire chunks instead of individual samples to the
+  # querier
+  [ingester_stream_chunks_when_using_blocks: <boolean> | default = false]
+
+  # Configures limits used by ingester. Reaching any of these 
+  # will result returning an internal error in Push method.
+  ingester_limits:
+    # Ingester's maximum push rate
+    [max_ingestion_rate: <float> | default 0]
+
+    # Ingester's maximum tenant count
+    [max_tenants: <int> | default = 0]
+
+    # Ingester's max series limit
+    [max_series: <int> | default = 0]
+
+    # Ingester's max inflight push requests
+    [max_inflight_push_requests: <int> | default = 0]
+
 # The memberlist_config configures the Gossip memberlist.
 [memberlist: <memberlist_config>]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -179,31 +179,34 @@ runtime_config:
   # for the example usage.
   [overrides: <limits_config_per_tenant>]
 
-  # Switch to a different store  (eg. consul -> etcd)
+  # Allows switching to a different store (e.g., consul to etcd) and
+  # enabling/disabling mirroring without requiring a restart.
   multi_kv_config:
-    # Updated store name
+    # The primary store used by MultiClient. Can be updated at runtime to switch
+    # between different stores, enabling smooth migration.
     [primary: <string> | default = ""]
 
-    # Enable mirroring
+    # Indicates whether mirroring is enabled or disabled. If not specified,
+    # no change is made to the current mirroring state.
     [mirror_enabled: <boolean> | default = false]
 
   # Enable streaming entire chunks instead of individual samples to the
   # querier
   [ingester_stream_chunks_when_using_blocks: <boolean> | default = false]
 
-  # Configures limits used by ingester. Reaching any of these 
-  # will result returning an internal error in Push method.
+  # Configures the ingester's limits. If any of these limits are reached,
+  # an internal error will be returned in the Push method.
   ingester_limits:
-    # Ingester's maximum push rate
+    # Maximum ingestion rate for the ingester, in samples per second.
     [max_ingestion_rate: <float> | default 0]
 
-    # Ingester's maximum tenant count
+    # Maximum number of tenants allowed in the ingester.
     [max_tenants: <int> | default = 0]
 
-    # Ingester's max series limit
+    # Maximum number of series allowed in the ingester.
     [max_series: <int> | default = 0]
 
-    # Ingester's max inflight push requests
+    # Maximum number of inflight push requests allowed in the ingester.
     [max_inflight_push_requests: <int> | default = 0]
 
 # The memberlist_config configures the Gossip memberlist.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Provides documentation for `runtime_config`

**Which issue(s) this PR fixes**:
Fixes #5153 

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]

Side Note: While I was writing a documentation for `runtime_config`, I saw this enhancement in `CHANGELOG.md` file:

`[ENHANCEMENT] Ingester (blocks storage): Ingester can now stream entire chunks instead of individual samples to the querier. At the moment this feature must be explicitly enabled either by using -ingester.stream-chunks-when-using-blocks flag or ingester_stream_chunks_when_using_blocks (boolean) field in runtime config file, but these configuration options are temporary and will be removed when feature is stable. #3889`

It was written on `2021-03-24`. I think it may have been forgotten. I wonder should we open an issue to address this change?
