### PR TITLE
Return a more friendly error message when there is no configuration file

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -85,7 +85,7 @@ func main() {
 		}
 	} else if len(args) == 0 {
 
-		fmt.Fprintf(os.Stderr, "Error loading config ,config.yaml does not exist, please set config.file for custom config path .for example:-config.file=./docs/configuration/single-process-config-blocks-local.yaml")
+		fmt.Fprintf(os.Stderr, "please set configuration file. For example: -config.file=./docs/configuration/single-process-config-blocks-local.yaml")
 		if testMode {
 			return
 		}

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -84,12 +84,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else if len(args) == 0 {
-
 		fmt.Fprintf(os.Stderr, "please set configuration file. For example: -config.file=./docs/configuration/single-process-config-blocks-local.yaml")
-		if testMode {
-			return
-		}
-		os.Exit(1)
 	}
 
 	// Ignore -config.file and -config.expand-env here, since it was already parsed, but it's still present on command line.

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -82,6 +82,12 @@ func main() {
 			}
 			os.Exit(1)
 		}
+	} else {
+		fmt.Fprintf(os.Stderr, "Error loading config ,config.yaml does not exist, please set config.file for custom config path .for example:-config.file=./docs/configuration/single-process-config-blocks-local.yaml")
+		if testMode {
+			return
+		}
+		os.Exit(1)
 	}
 
 	// Ignore -config.file and -config.expand-env here, since it was already parsed, but it's still present on command line.

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -85,6 +85,9 @@ func main() {
 		}
 	} else if len(args) == 0 {
 		fmt.Fprintf(os.Stderr, "please set configuration file. For example: -config.file=./docs/configuration/single-process-config-blocks-local.yaml\n")
+		if testMode {
+			return
+		}
 		os.Exit(1)
 	}
 

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -84,7 +84,8 @@ func main() {
 			os.Exit(1)
 		}
 	} else if len(args) == 0 {
-		fmt.Fprintf(os.Stderr, "please set configuration file. For example: -config.file=./docs/configuration/single-process-config-blocks-local.yaml")
+		fmt.Fprintf(os.Stderr, "please set configuration file. For example: -config.file=./docs/configuration/single-process-config-blocks-local.yaml\n")
+		os.Exit(1)
 	}
 
 	// Ignore -config.file and -config.expand-env here, since it was already parsed, but it's still present on command line.

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -68,7 +68,8 @@ func main() {
 		printModules         bool
 	)
 
-	configFile, expandENV := parseConfigFileParameter(os.Args[1:])
+	args := os.Args[1:]
+	configFile, expandENV := parseConfigFileParameter(args)
 
 	// This sets default values from flags to the config.
 	// It needs to be called before parsing the config file!
@@ -82,7 +83,8 @@ func main() {
 			}
 			os.Exit(1)
 		}
-	} else {
+	} else if len(args) == 0 {
+
 		fmt.Fprintf(os.Stderr, "Error loading config ,config.yaml does not exist, please set config.file for custom config path .for example:-config.file=./docs/configuration/single-process-config-blocks-local.yaml")
 		if testMode {
 			return

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -42,7 +42,7 @@ func TestFlagParsing(t *testing.T) {
 		},
 
 		"default values": {
-			stdoutMessage: "please set configuration file. For example: -config.file=./docs/configuration/single-process-config-blocks-local.yaml\n",
+			stderrMessage: "please set configuration file. For example: -config.file=./docs/configuration/single-process-config-blocks-local.yaml\n",
 		},
 
 		"config": {

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -42,7 +42,8 @@ func TestFlagParsing(t *testing.T) {
 		},
 
 		"default values": {
-			stdoutMessage: "target: all\n",
+			stdoutMessage: "",
+			stderrMessage: "Error loading config ,config.yaml does not exist, please set config.file for custom config path .for example:-config.file=./docs/configuration/single-process-config-blocks-local.yaml",
 		},
 
 		"config": {

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -42,7 +42,7 @@ func TestFlagParsing(t *testing.T) {
 		},
 
 		"default values": {
-			stdoutMessage: "target: all\n",
+			stdoutMessage: "please set configuration file. For example: -config.file=./docs/configuration/single-process-config-blocks-local.yaml\n",
 		},
 
 		"config": {

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -42,8 +42,7 @@ func TestFlagParsing(t *testing.T) {
 		},
 
 		"default values": {
-			stdoutMessage: "",
-			stderrMessage: "Error loading config ,config.yaml does not exist, please set config.file for custom config path .for example:-config.file=./docs/configuration/single-process-config-blocks-local.yaml",
+			stdoutMessage: "target: all\n",
 		},
 
 		"config": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Due to the capacity problem of prometheus, we are trying to find a long-term storage system. We are currently investigating cortex. After starting from the source code for the first time, we found that the startup log cannot be understood. 

```
GOPATH=/Users/fuling/go #gosetup
/usr/local/go/bin/go build -o /private/var/folders/yg/39mj_zbd46532cfbdh1f8fx40000gp/T/GoLand/___go_build_github_com_cortexproject_cortex_cmd_cortex github.com/cortexproject/cortex/cmd/cortex #gosetup
/private/var/folders/yg/39mj_zbd46532cfbdh1f8fx40000gp/T/GoLand/___go_build_github_com_cortexproject_cortex_cmd_cortex
level=info ts=2023-04-24T02:22:01.29409Z caller=main.go:194 msg="Starting Cortex" version="(version=, branch=, revision=7ef779119d1d2e8bcb63f4099dac3f39979880ac)"
level=warn ts=2023-04-24T02:22:01.294151Z caller=cortex.go:388 msg="skipped registration of custom process metrics collector" err="unsupported platform"
level=info ts=2023-04-24T02:22:01.294515Z caller=server.go:323 http=[::]:80 grpc=[::]:9095 msg="server listening on addresses"
level=error ts=2023-04-24T02:22:01.296044Z caller=log.go:117 msg="error running cortex" err="no s3 endpoint in config file\ngithub.com/thanos-io/objstore/providers/s3.validate\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/vendor/github.com/thanos-io/objstore/providers/s3/s3.go:349\ngithub.com/thanos-io/objstore/providers/s3.NewBucketWithConfig\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/vendor/github.com/thanos-io/objstore/providers/s3/s3.go:219\ngithub.com/cortexproject/cortex/pkg/storage/bucket/s3.NewBucketClient\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/storage/bucket/s3/bucket_client.go:29\ngithub.com/cortexproject/cortex/pkg/storage/bucket.NewClient\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/storage/bucket/client.go:102\ngithub.com/cortexproject/cortex/pkg/ingester.New\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/ingester/ingester.go:608\ngithub.com/cortexproject/cortex/pkg/cortex.(*Cortex).initIngesterService\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/cortex/modules.go:404\ngithub.com/cortexproject/cortex/pkg/util/modules.(*Manager).initModule\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/util/modules/modules.go:106\ngithub.com/cortexproject/cortex/pkg/util/modules.(*Manager).InitModuleServices\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/util/modules/modules.go:78\ngithub.com/cortexproject/cortex/pkg/cortex.(*Cortex).Run\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/cortex/cortex.go:398\nmain.main\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/cmd/cortex/main.go:196\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1594\nfailed to create the bucket client\ngithub.com/cortexproject/cortex/pkg/ingester.New\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/ingester/ingester.go:610\ngithub.com/cortexproject/cortex/pkg/cortex.(*Cortex).initIngesterService\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/cortex/modules.go:404\ngithub.com/cortexproject/cortex/pkg/util/modules.(*Manager).initModule\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/util/modules/modules.go:106\ngithub.com/cortexproject/cortex/pkg/util/modules.(*Manager).InitModuleServices\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/util/modules/modules.go:78\ngithub.com/cortexproject/cortex/pkg/cortex.(*Cortex).Run\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/cortex/cortex.go:398\nmain.main\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/cmd/cortex/main.go:196\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1594\nerror initialising module: ingester-service\ngithub.com/cortexproject/cortex/pkg/util/modules.(*Manager).initModule\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/util/modules/modules.go:108\ngithub.com/cortexproject/cortex/pkg/util/modules.(*Manager).InitModuleServices\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/util/modules/modules.go:78\ngithub.com/cortexproject/cortex/pkg/cortex.(*Cortex).Run\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/pkg/cortex/cortex.go:398\nmain.main\n\t/Users/fuling/go/src/github.com/cortexproject/cortex/cmd/cortex/main.go:196\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1594"

```
According to the documentation, cortex cannot be started directly, and a configuration file must be required. 
![image](https://user-images.githubusercontent.com/9583245/233886338-300f458c-eefc-4c7d-a0e0-31731616624c.png)

So we modified the error log
```log
Error loading config ,config.yaml does not exist, please set config.file for custom config path .for example:-config.file=./docs/configuration/single-process-config-blocks-local.yaml
Process finished with the exit code 1
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
