### PR TITLE
Disable parallel tests when thanos engine is enabled

### DIFF
--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -1336,7 +1336,6 @@ func TestBlocksStoreQuerier_SelectSortedShouldHonorQueryStoreAfter(t *testing.T)
 }
 
 func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
-	t.Parallel()
 	logger := log.NewNopLogger()
 	opts := promql.EngineOpts{
 		Logger:     logger,
@@ -1368,10 +1367,6 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 	}
 	for _, thanosEngine := range []bool{false, true} {
 		t.Run(fmt.Sprintf("thanos engine enabled=%t", thanosEngine), func(t *testing.T) {
-			if !thanosEngine {
-				//parallel testing for non thanos engine
-				t.Parallel()
-			}
 			var queryEngine v1.QueryEngine
 			if thanosEngine {
 				queryEngine = engine.New(engine.Opts{

--- a/pkg/querier/chunk_store_queryable_test.go
+++ b/pkg/querier/chunk_store_queryable_test.go
@@ -24,8 +24,6 @@ import (
 var _ SeriesWithChunks = &chunkSeries{}
 
 func TestChunkQueryable(t *testing.T) {
-	t.Parallel()
-
 	opts := promql.EngineOpts{
 		Logger:             log.NewNopLogger(),
 		ActiveQueryTracker: promql.NewActiveQueryTracker(t.TempDir(), 10, log.NewNopLogger()),
@@ -37,7 +35,6 @@ func TestChunkQueryable(t *testing.T) {
 			for _, encoding := range encodings {
 				for _, query := range queries {
 					t.Run(fmt.Sprintf("%s/%s/%s/ thanos engine enabled = %t", testcase.name, encoding.name, query.query, thanosEngine), func(t *testing.T) {
-						//parallel testing causes data race
 						var queryEngine v1.QueryEngine
 						if thanosEngine {
 							queryEngine = engine.New(engine.Opts{

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -156,7 +156,6 @@ var (
 )
 
 func TestShouldSortSeriesIfQueryingMultipleQueryables(t *testing.T) {
-	//parallel testing causes data race
 	start := time.Now().Add(-2 * time.Hour)
 	end := time.Now()
 	ctx := user.InjectOrgID(context.Background(), "0")
@@ -269,10 +268,6 @@ func TestShouldSortSeriesIfQueryingMultipleQueryables(t *testing.T) {
 		for _, thanosEngine := range []bool{false, true} {
 			thanosEngine := thanosEngine
 			t.Run(tc.name+fmt.Sprintf(", thanos engine: %s", strconv.FormatBool(thanosEngine)), func(t *testing.T) {
-				if !thanosEngine {
-					//parallel testing for non thanos engine
-					t.Parallel()
-				}
 				wDistributorQueriable := &wrappedSampleAndChunkQueryable{QueryableWithFilter: tc.distributorQueryable}
 				var wQueriables []QueryableWithFilter
 				for _, queriable := range tc.storeQueriables {
@@ -315,7 +310,6 @@ func TestShouldSortSeriesIfQueryingMultipleQueryables(t *testing.T) {
 }
 
 func TestQuerier(t *testing.T) {
-	t.Parallel()
 	var cfg Config
 	flagext.DefaultValues(&cfg)
 
@@ -340,7 +334,6 @@ func TestQuerier(t *testing.T) {
 					for _, iterators := range []bool{false, true} {
 						iterators := iterators
 						t.Run(fmt.Sprintf("%s/%s/streaming=%t/iterators=%t", query.query, encoding.name, streaming, iterators), func(t *testing.T) {
-							//parallel testing cause data race
 							var queryEngine v1.QueryEngine
 							if thanosEngine {
 								queryEngine = engine.New(engine.Opts{
@@ -412,7 +405,6 @@ func mockTSDB(t *testing.T, labels []labels.Labels, mint model.Time, samples int
 }
 
 func TestNoHistoricalQueryToIngester(t *testing.T) {
-	//parallel testing causes data race
 	testCases := []struct {
 		name                 string
 		mint, maxt           time.Time
@@ -470,7 +462,6 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 			for _, c := range testCases {
 				cfg.QueryIngestersWithin = c.queryIngestersWithin
 				t.Run(fmt.Sprintf("IngesterStreaming=%t,thanosEngine=%t,queryIngestersWithin=%v, test=%s", cfg.IngesterStreaming, thanosEngine, c.queryIngestersWithin, c.name), func(t *testing.T) {
-					//parallel testing causes data race
 					var queryEngine v1.QueryEngine
 					if thanosEngine {
 						queryEngine = engine.New(engine.Opts{
@@ -569,60 +560,49 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryIntoFuture(t *testing.T) {
 
 	for _, ingesterStreaming := range []bool{true, false} {
 		cfg.IngesterStreaming = ingesterStreaming
-		for _, thanosEngine := range []bool{true, false} {
-			for name, c := range tests {
-				cfg.MaxQueryIntoFuture = c.maxQueryIntoFuture
-				t.Run(fmt.Sprintf("%s (ingester streaming enabled = %t, thanos engine enabled = %t)", name, cfg.IngesterStreaming, thanosEngine), func(t *testing.T) {
-					//parallel testing causes data race
-					var queryEngine v1.QueryEngine
-					if thanosEngine {
-						queryEngine = engine.New(engine.Opts{
-							EngineOpts:        opts,
-							LogicalOptimizers: logicalplan.AllOptimizers,
-						})
-					} else {
-						queryEngine = promql.NewEngine(opts)
-					}
+		for name, c := range tests {
+			cfg.MaxQueryIntoFuture = c.maxQueryIntoFuture
+			t.Run(fmt.Sprintf("%s (ingester streaming enabled = %t)", name, cfg.IngesterStreaming), func(t *testing.T) {
+				queryEngine := promql.NewEngine(opts)
 
-					// We don't need to query any data for this test, so an empty store is fine.
-					chunkStore := &emptyChunkStore{}
-					distributor := &MockDistributor{}
-					distributor.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Matrix{}, nil)
-					distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&client.QueryStreamResponse{}, nil)
+				// We don't need to query any data for this test, so an empty store is fine.
+				chunkStore := &emptyChunkStore{}
+				distributor := &MockDistributor{}
+				distributor.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Matrix{}, nil)
+				distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&client.QueryStreamResponse{}, nil)
 
-					overrides, err := validation.NewOverrides(DefaultLimitsConfig(), nil)
-					require.NoError(t, err)
+				overrides, err := validation.NewOverrides(DefaultLimitsConfig(), nil)
+				require.NoError(t, err)
 
-					ctx := user.InjectOrgID(context.Background(), "0")
-					queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(cfg, chunkStore))}
-					queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
-					query, err := queryEngine.NewRangeQuery(ctx, queryable, nil, "dummy", c.queryStartTime, c.queryEndTime, time.Minute)
-					require.NoError(t, err)
+				ctx := user.InjectOrgID(context.Background(), "0")
+				queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(cfg, chunkStore))}
+				queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
+				query, err := queryEngine.NewRangeQuery(ctx, queryable, nil, "dummy", c.queryStartTime, c.queryEndTime, time.Minute)
+				require.NoError(t, err)
 
-					r := query.Exec(ctx)
-					require.Nil(t, r.Err)
+				r := query.Exec(ctx)
+				require.Nil(t, r.Err)
 
-					_, err = r.Matrix()
-					require.Nil(t, err)
+				_, err = r.Matrix()
+				require.Nil(t, err)
 
-					if !c.expectedSkipped {
-						// Assert on the time range of the actual executed query (5s delta).
-						delta := float64(5000)
-						require.Len(t, distributor.Calls, 1)
-						assert.InDelta(t, util.TimeToMillis(c.expectedStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
-						assert.InDelta(t, util.TimeToMillis(c.expectedEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
-					} else {
-						// Ensure no query has been executed (because skipped).
-						assert.Len(t, distributor.Calls, 0)
-					}
-				})
-			}
+				if !c.expectedSkipped {
+					// Assert on the time range of the actual executed query (5s delta).
+					delta := float64(5000)
+					require.Len(t, distributor.Calls, 1)
+					assert.InDelta(t, util.TimeToMillis(c.expectedStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
+					assert.InDelta(t, util.TimeToMillis(c.expectedEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
+				} else {
+					// Ensure no query has been executed (because skipped).
+					assert.Len(t, distributor.Calls, 0)
+				}
+			})
 		}
 	}
 }
 
 func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
-	//parallel testing causes data race
+	t.Parallel()
 	const maxQueryLength = 30 * 24 * time.Hour
 
 	tests := map[string]struct {
@@ -664,52 +644,42 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 		Timeout:            1 * time.Minute,
 	}
 	for testName, testData := range tests {
-		for _, thanosEngine := range []bool{true, false} {
-			t.Run(fmt.Sprintf("%s, (thanos engine enabled = %t)", testName, thanosEngine), func(t *testing.T) {
-				//parallel testing causes data race
-				var cfg Config
-				flagext.DefaultValues(&cfg)
+		t.Run(fmt.Sprintf("%s", testName), func(t *testing.T) {
+			//parallel testing causes data race
+			var cfg Config
+			flagext.DefaultValues(&cfg)
 
-				limits := DefaultLimitsConfig()
-				limits.MaxQueryLength = model.Duration(maxQueryLength)
-				overrides, err := validation.NewOverrides(limits, nil)
-				require.NoError(t, err)
+			limits := DefaultLimitsConfig()
+			limits.MaxQueryLength = model.Duration(maxQueryLength)
+			overrides, err := validation.NewOverrides(limits, nil)
+			require.NoError(t, err)
 
-				// We don't need to query any data for this test, so an empty store is fine.
-				chunkStore := &emptyChunkStore{}
-				distributor := &emptyDistributor{}
+			// We don't need to query any data for this test, so an empty store is fine.
+			chunkStore := &emptyChunkStore{}
+			distributor := &emptyDistributor{}
 
-				queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(cfg, chunkStore))}
-				queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
+			queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(cfg, chunkStore))}
+			queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
 
-				var queryEngine v1.QueryEngine
-				if thanosEngine {
-					queryEngine = engine.New(engine.Opts{
-						EngineOpts:        opts,
-						LogicalOptimizers: logicalplan.AllOptimizers,
-					})
-				} else {
-					queryEngine = promql.NewEngine(opts)
-				}
-				ctx := user.InjectOrgID(context.Background(), "test")
-				query, err := queryEngine.NewRangeQuery(ctx, queryable, nil, testData.query, testData.queryStartTime, testData.queryEndTime, time.Minute)
-				require.NoError(t, err)
+			queryEngine := promql.NewEngine(opts)
+			ctx := user.InjectOrgID(context.Background(), "test")
+			query, err := queryEngine.NewRangeQuery(ctx, queryable, nil, testData.query, testData.queryStartTime, testData.queryEndTime, time.Minute)
+			require.NoError(t, err)
 
-				r := query.Exec(ctx)
+			r := query.Exec(ctx)
 
-				if testData.expected != nil {
-					require.NotNil(t, r.Err)
-					assert.True(t, strings.Contains(testData.expected.Error(), r.Err.Error()))
-				} else {
-					assert.Nil(t, r.Err)
-				}
-			})
-		}
+			if testData.expected != nil {
+				require.NotNil(t, r.Err)
+				assert.True(t, strings.Contains(testData.expected.Error(), r.Err.Error()))
+			} else {
+				assert.Nil(t, r.Err)
+			}
+		})
 	}
 }
 
 func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
-	//parallel testing causes data race
+	t.Parallel()
 	const (
 		engineLookbackDelta = 5 * time.Minute
 		thirtyDays          = 30 * 24 * time.Hour
@@ -797,7 +767,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 		LookbackDelta:      engineLookbackDelta,
 		Timeout:            1 * time.Minute,
 	}
-
+	queryEngine := promql.NewEngine(opts)
 	for _, ingesterStreaming := range []bool{true, false} {
 		expectedMethodForLabelMatchers := "MetricsForLabelMatchers"
 		expectedMethodForLabelNames := "LabelNames"
@@ -808,193 +778,176 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 			expectedMethodForLabelValues = "LabelValuesForLabelNameStream"
 		}
 		for testName, testData := range tests {
-			for _, thanosEngine := range []bool{true, false} {
-				t.Run(fmt.Sprintf("%s, thanos engine enabled = %t", testName, thanosEngine), func(t *testing.T) {
-					//parallel testing causes data race
-					ctx := user.InjectOrgID(context.Background(), "test")
+			t.Run(fmt.Sprintf("%s", testName), func(t *testing.T) {
+				ctx := user.InjectOrgID(context.Background(), "test")
 
-					var cfg Config
-					flagext.DefaultValues(&cfg)
-					cfg.IngesterStreaming = ingesterStreaming
-					cfg.IngesterMetadataStreaming = ingesterStreaming
+				var cfg Config
+				flagext.DefaultValues(&cfg)
+				cfg.IngesterStreaming = ingesterStreaming
+				cfg.IngesterMetadataStreaming = ingesterStreaming
 
-					limits := DefaultLimitsConfig()
-					limits.MaxQueryLookback = testData.maxQueryLookback
-					overrides, err := validation.NewOverrides(limits, nil)
+				limits := DefaultLimitsConfig()
+				limits.MaxQueryLookback = testData.maxQueryLookback
+				overrides, err := validation.NewOverrides(limits, nil)
+				require.NoError(t, err)
+
+				// We don't need to query any data for this test, so an empty store is fine.
+				chunkStore := &emptyChunkStore{}
+				queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(cfg, chunkStore))}
+
+				t.Run("query range", func(t *testing.T) {
+					if testData.query == "" {
+						return
+					}
+					distributor := &MockDistributor{}
+					distributor.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Matrix{}, nil)
+					distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&client.QueryStreamResponse{}, nil)
+
+					queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
 					require.NoError(t, err)
 
-					// We don't need to query any data for this test, so an empty store is fine.
-					chunkStore := &emptyChunkStore{}
-					queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(cfg, chunkStore))}
+					query, err := queryEngine.NewRangeQuery(ctx, queryable, nil, testData.query, testData.queryStartTime, testData.queryEndTime, time.Minute)
+					require.NoError(t, err)
 
-					t.Run("query range", func(t *testing.T) {
-						//parallel testing data race
-						if testData.query == "" {
-							return
-						}
-						distributor := &MockDistributor{}
-						distributor.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Matrix{}, nil)
-						distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&client.QueryStreamResponse{}, nil)
+					r := query.Exec(ctx)
+					require.Nil(t, r.Err)
 
-						queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
-						require.NoError(t, err)
+					_, err = r.Matrix()
+					require.Nil(t, err)
 
-						var queryEngine v1.QueryEngine
-						if thanosEngine {
-							queryEngine = engine.New(engine.Opts{
-								EngineOpts:        opts,
-								LogicalOptimizers: logicalplan.AllOptimizers,
-							})
-						} else {
-							queryEngine = promql.NewEngine(opts)
-						}
-						query, err := queryEngine.NewRangeQuery(ctx, queryable, nil, testData.query, testData.queryStartTime, testData.queryEndTime, time.Minute)
-						require.NoError(t, err)
-
-						r := query.Exec(ctx)
-						require.Nil(t, r.Err)
-
-						_, err = r.Matrix()
-						require.Nil(t, err)
-
-						if !testData.expectedSkipped {
-							// Assert on the time range of the actual executed query (5s delta).
-							delta := float64(5000)
-							require.Len(t, distributor.Calls, 1)
-							assert.InDelta(t, util.TimeToMillis(testData.expectedQueryStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
-							assert.InDelta(t, util.TimeToMillis(testData.expectedQueryEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
-						} else {
-							// Ensure no query has been executed (because skipped).
-							assert.Len(t, distributor.Calls, 0)
-						}
-					})
-
-					t.Run("series", func(t *testing.T) {
-						//parallel testing causes data race
-						distributor := &MockDistributor{}
-						distributor.On("MetricsForLabelMatchers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]metric.Metric{}, nil)
-						distributor.On("MetricsForLabelMatchersStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]metric.Metric{}, nil)
-
-						queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
-						q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
-						require.NoError(t, err)
-
-						// We apply the validation here again since when initializing querier we change the start/end time,
-						// but when querying series we don't validate again. So we should pass correct hints here.
-						start, end, err := validateQueryTimeRange(ctx, "test", util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime), overrides, 0)
-						// Skipped query will hit errEmptyTimeRange during validation.
-						if !testData.expectedSkipped {
-							require.NoError(t, err)
-						}
-
-						hints := &storage.SelectHints{
-							Start: start,
-							End:   end,
-							Func:  "series",
-						}
-						matcher := labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "test")
-
-						set := q.Select(false, hints, matcher)
-						require.False(t, set.Next()) // Expected to be empty.
-						require.NoError(t, set.Err())
-
-						if !testData.expectedSkipped {
-							// Assert on the time range of the actual executed query (5s delta).
-							delta := float64(5000)
-							require.Len(t, distributor.Calls, 1)
-							assert.Equal(t, expectedMethodForLabelMatchers, distributor.Calls[0].Method)
-							assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
-							assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
-						} else {
-							// Ensure no query has been executed (because skipped).
-							assert.Len(t, distributor.Calls, 0)
-						}
-					})
-
-					t.Run("label names", func(t *testing.T) {
-						t.Parallel()
-						distributor := &MockDistributor{}
-						distributor.On("LabelNames", mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
-						distributor.On("LabelNamesStream", mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
-
-						queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
-						q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
-						require.NoError(t, err)
-
-						_, _, err = q.LabelNames()
-						require.NoError(t, err)
-
-						if !testData.expectedSkipped {
-							// Assert on the time range of the actual executed query (5s delta).
-							delta := float64(5000)
-							require.Len(t, distributor.Calls, 1)
-							assert.Equal(t, expectedMethodForLabelNames, distributor.Calls[0].Method)
-							assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
-							assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
-						} else {
-							// Ensure no query has been executed (because skipped).
-							assert.Len(t, distributor.Calls, 0)
-						}
-					})
-
-					t.Run("label names with matchers", func(t *testing.T) {
-						//parallel testing causes data race
-						matchers := []*labels.Matcher{
-							labels.MustNewMatcher(labels.MatchNotEqual, "route", "get_user"),
-						}
-						distributor := &MockDistributor{}
-						distributor.On("MetricsForLabelMatchers", mock.Anything, mock.Anything, mock.Anything, matchers).Return([]metric.Metric{}, nil)
-						distributor.On("MetricsForLabelMatchersStream", mock.Anything, mock.Anything, mock.Anything, matchers).Return([]metric.Metric{}, nil)
-
-						queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
-						q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
-						require.NoError(t, err)
-
-						_, _, err = q.LabelNames(matchers...)
-						require.NoError(t, err)
-
-						if !testData.expectedSkipped {
-							// Assert on the time range of the actual executed query (5s delta).
-							delta := float64(5000)
-							require.Len(t, distributor.Calls, 1)
-							assert.Equal(t, expectedMethodForLabelMatchers, distributor.Calls[0].Method)
-							args := distributor.Calls[0].Arguments
-							assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataStartTime), int64(args.Get(1).(model.Time)), delta)
-							assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataEndTime), int64(args.Get(2).(model.Time)), delta)
-							assert.Equal(t, matchers, args.Get(3).([]*labels.Matcher))
-						} else {
-							// Ensure no query has been executed (because skipped).
-							assert.Len(t, distributor.Calls, 0)
-						}
-					})
-
-					t.Run("label values", func(t *testing.T) {
-						//parallel testing causes data race
-						distributor := &MockDistributor{}
-						distributor.On("LabelValuesForLabelName", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
-						distributor.On("LabelValuesForLabelNameStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
-
-						queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
-						q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
-						require.NoError(t, err)
-
-						_, _, err = q.LabelValues(labels.MetricName)
-						require.NoError(t, err)
-
-						if !testData.expectedSkipped {
-							// Assert on the time range of the actual executed query (5s delta).
-							delta := float64(5000)
-							require.Len(t, distributor.Calls, 1)
-							assert.Equal(t, expectedMethodForLabelValues, distributor.Calls[0].Method)
-							assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
-							assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
-						} else {
-							// Ensure no query has been executed executed (because skipped).
-							assert.Len(t, distributor.Calls, 0)
-						}
-					})
+					if !testData.expectedSkipped {
+						// Assert on the time range of the actual executed query (5s delta).
+						delta := float64(5000)
+						require.Len(t, distributor.Calls, 1)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedQueryStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedQueryEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
+					} else {
+						// Ensure no query has been executed (because skipped).
+						assert.Len(t, distributor.Calls, 0)
+					}
 				})
-			}
+
+				t.Run("series", func(t *testing.T) {
+					distributor := &MockDistributor{}
+					distributor.On("MetricsForLabelMatchers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]metric.Metric{}, nil)
+					distributor.On("MetricsForLabelMatchersStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]metric.Metric{}, nil)
+
+					queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
+					q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
+					require.NoError(t, err)
+
+					// We apply the validation here again since when initializing querier we change the start/end time,
+					// but when querying series we don't validate again. So we should pass correct hints here.
+					start, end, err := validateQueryTimeRange(ctx, "test", util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime), overrides, 0)
+					// Skipped query will hit errEmptyTimeRange during validation.
+					if !testData.expectedSkipped {
+						require.NoError(t, err)
+					}
+
+					hints := &storage.SelectHints{
+						Start: start,
+						End:   end,
+						Func:  "series",
+					}
+					matcher := labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "test")
+
+					set := q.Select(false, hints, matcher)
+					require.False(t, set.Next()) // Expected to be empty.
+					require.NoError(t, set.Err())
+
+					if !testData.expectedSkipped {
+						// Assert on the time range of the actual executed query (5s delta).
+						delta := float64(5000)
+						require.Len(t, distributor.Calls, 1)
+						assert.Equal(t, expectedMethodForLabelMatchers, distributor.Calls[0].Method)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
+					} else {
+						// Ensure no query has been executed (because skipped).
+						assert.Len(t, distributor.Calls, 0)
+					}
+				})
+
+				t.Run("label names", func(t *testing.T) {
+					distributor := &MockDistributor{}
+					distributor.On("LabelNames", mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
+					distributor.On("LabelNamesStream", mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
+
+					queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
+					q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
+					require.NoError(t, err)
+
+					_, _, err = q.LabelNames()
+					require.NoError(t, err)
+
+					if !testData.expectedSkipped {
+						// Assert on the time range of the actual executed query (5s delta).
+						delta := float64(5000)
+						require.Len(t, distributor.Calls, 1)
+						assert.Equal(t, expectedMethodForLabelNames, distributor.Calls[0].Method)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
+					} else {
+						// Ensure no query has been executed (because skipped).
+						assert.Len(t, distributor.Calls, 0)
+					}
+				})
+
+				t.Run("label names with matchers", func(t *testing.T) {
+					matchers := []*labels.Matcher{
+						labels.MustNewMatcher(labels.MatchNotEqual, "route", "get_user"),
+					}
+					distributor := &MockDistributor{}
+					distributor.On("MetricsForLabelMatchers", mock.Anything, mock.Anything, mock.Anything, matchers).Return([]metric.Metric{}, nil)
+					distributor.On("MetricsForLabelMatchersStream", mock.Anything, mock.Anything, mock.Anything, matchers).Return([]metric.Metric{}, nil)
+
+					queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
+					q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
+					require.NoError(t, err)
+
+					_, _, err = q.LabelNames(matchers...)
+					require.NoError(t, err)
+
+					if !testData.expectedSkipped {
+						// Assert on the time range of the actual executed query (5s delta).
+						delta := float64(5000)
+						require.Len(t, distributor.Calls, 1)
+						assert.Equal(t, expectedMethodForLabelMatchers, distributor.Calls[0].Method)
+						args := distributor.Calls[0].Arguments
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataStartTime), int64(args.Get(1).(model.Time)), delta)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataEndTime), int64(args.Get(2).(model.Time)), delta)
+						assert.Equal(t, matchers, args.Get(3).([]*labels.Matcher))
+					} else {
+						// Ensure no query has been executed (because skipped).
+						assert.Len(t, distributor.Calls, 0)
+					}
+				})
+
+				t.Run("label values", func(t *testing.T) {
+					distributor := &MockDistributor{}
+					distributor.On("LabelValuesForLabelName", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
+					distributor.On("LabelValuesForLabelNameStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
+
+					queryable, _, _ := New(cfg, overrides, distributor, queryables, purger.NewNoopTombstonesLoader(), nil, log.NewNopLogger())
+					q, err := queryable.Querier(ctx, util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
+					require.NoError(t, err)
+
+					_, _, err = q.LabelValues(labels.MetricName)
+					require.NoError(t, err)
+
+					if !testData.expectedSkipped {
+						// Assert on the time range of the actual executed query (5s delta).
+						delta := float64(5000)
+						require.Len(t, distributor.Calls, 1)
+						assert.Equal(t, expectedMethodForLabelValues, distributor.Calls[0].Method)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataStartTime), int64(distributor.Calls[0].Arguments.Get(1).(model.Time)), delta)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedMetadataEndTime), int64(distributor.Calls[0].Arguments.Get(2).(model.Time)), delta)
+					} else {
+						// Ensure no query has been executed(because skipped).
+						assert.Len(t, distributor.Calls, 0)
+					}
+				})
+			})
 		}
 	}
 }

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -644,7 +644,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 		Timeout:            1 * time.Minute,
 	}
 	for testName, testData := range tests {
-		t.Run(fmt.Sprintf("%s", testName), func(t *testing.T) {
+		t.Run(testName, func(t *testing.T) {
 			//parallel testing causes data race
 			var cfg Config
 			flagext.DefaultValues(&cfg)
@@ -778,7 +778,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 			expectedMethodForLabelValues = "LabelValuesForLabelNameStream"
 		}
 		for testName, testData := range tests {
-			t.Run(fmt.Sprintf("%s", testName), func(t *testing.T) {
+			t.Run(testName, func(t *testing.T) {
 				ctx := user.InjectOrgID(context.Background(), "test")
 
 				var cfg Config


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This pr tries to disable parallel tests if thanos engine is enabled. We saw data race in our tests previously because we are also parallelize the initialization of the thanos query engine. However, the initialization is not thread safe.

So this pr I am trying to disable parallelization for it and also just removed thanos engine tests if possible in some tests, in order to make tests execution faster.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
