### PR TITLE
remove parallel tests if we create a query engine in the test

### DIFF
--- a/pkg/querier/blocks_consistency_checker_test.go
+++ b/pkg/querier/blocks_consistency_checker_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestBlocksConsistencyChecker_Check(t *testing.T) {
-	//parallel testing causes data race
-
 	now := time.Now()
 	uploadGracePeriod := 10 * time.Minute
 	deletionGracePeriod := 5 * time.Minute

--- a/pkg/querier/error_translate_queryable_test.go
+++ b/pkg/querier/error_translate_queryable_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestApiStatusCodes(t *testing.T) {
-	t.Parallel()
-
 	for ix, tc := range []struct {
 		err            error
 		expectedString string

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -506,7 +506,6 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 }
 
 func TestQuerier_ValidateQueryTimeRange_MaxQueryIntoFuture(t *testing.T) {
-	t.Parallel()
 	const engineLookbackDelta = 5 * time.Minute
 
 	now := time.Now()
@@ -602,7 +601,6 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryIntoFuture(t *testing.T) {
 }
 
 func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
-	t.Parallel()
 	const maxQueryLength = 30 * 24 * time.Hour
 
 	tests := map[string]struct {
@@ -679,7 +677,6 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 }
 
 func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
-	t.Parallel()
 	const (
 		engineLookbackDelta = 5 * time.Minute
 		thirtyDays          = 30 * 24 * time.Hour
@@ -1219,7 +1216,6 @@ func (q *mockStoreQuerier) Close() error {
 }
 
 func TestShortTermQueryToLTS(t *testing.T) {
-	//parallel testing causes data race
 	testCases := []struct {
 		name                 string
 		mint, maxt           time.Time


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Disable parallel test if we create a promql engine. This is to avoid the panic during mmap described in the linked issue.

**Which issue(s) this PR fixes**:
Fixes #5314

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
