### PR TITLE
Implement a heap based memory limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [CHANGE] Alertmanager: Validating new fields on the PagerDuty AM config. #5290
 * [CHANGE] Ingester: Creating label `native-histogram-sample` on the `cortex_discarded_samples_total` to keep track of discarded native histogram samples. #5289
 * [FEATURE] Store Gateway: Add `max_downloaded_bytes_per_request` to limit max bytes to download per store gateway request.
+* [FEATURE] Querier: Add a memory limiter to prevent OOMs. #5320
 * [ENHANCEMENT] Support object storage backends for runtime configuration file. #5292
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2438,6 +2438,37 @@ grpc_client_config:
   # Skip validating server certificate.
   # CLI flag: -querier.frontend-client.tls-insecure-skip-verify
   [tls_insecure_skip_verify: <boolean> | default = false]
+
+memory_limiter:
+  # Enable memory-limiter.
+  # CLI flag: -querier.memory-limiter.enabled
+  [enabled: <boolean> | default = false]
+
+  # Specifies whether to fail when the heap is above the limit. If fail fast is
+  # false, the requests will wait for the heap to go down or until the
+  # max-wait-duration.
+  # CLI flag: -querier.memory-limiter.fail-fast
+  [fail_fast: <boolean> | default = false]
+
+  # Specifies the limit above which system is considered to in red state. In red
+  # state, all except one request will be throttled.
+  # CLI flag: -querier.memory-limiter.red-threshold-bytes
+  [red_threshold_bytes: <int> | default = 0]
+
+  # Specifies the limit above which the system is considered to be in yellow
+  # state. In yellow state, new requests cannot be pulled in.
+  # CLI flag: -querier.memory-limiter.yellow-threshold-bytes
+  [yellow_threshold_bytes: <int> | default = 0]
+
+  # Configures how often to watch the heap to detect memory pressure.
+  # CLI flag: -querier.memory-limiter.check-interval
+  [check_interval: <duration> | default = 1s]
+
+  # Configures the maximum wait duration. If a goroutine were blocked for more
+  # than the max-wait-duration, it'll continue execution even under memory
+  # pressure.
+  # CLI flag: -querier.memory-limiter.max-wait-duration
+  [max_wait_duration: <duration> | default = 5s]
 ```
 
 ### `ingester_config`

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -290,6 +290,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 	var (
 		queryLimiter = limiter.QueryLimiterFromContextWithFallback(ctx)
 		reqStats     = stats.FromContext(ctx)
+		job          = limiter.JobFromContext(ctx)
 	)
 
 	// Fetch samples from multiple ingesters
@@ -309,6 +310,9 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 
 		result := &ingester_client.QueryStreamResponse{}
 		for {
+			if err := job.Continue(ctx); err != nil {
+				return nil, err
+			}
 			resp, err := stream.Recv()
 			if err == io.EOF {
 				break

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -578,6 +578,7 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 		spanLog       = spanlogger.FromContext(ctx)
 		queryLimiter  = limiter.QueryLimiterFromContextWithFallback(ctx)
 		reqStats      = stats.FromContext(ctx)
+		job           = limiter.JobFromContext(ctx)
 	)
 	matchers, shardingInfo, err := querysharding.ExtractShardingInfo(matchers)
 
@@ -628,6 +629,9 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 					return gCtx.Err()
 				}
 
+				if err := job.Continue(ctx); err != nil {
+					return err
+				}
 				resp, err := stream.Recv()
 				if err == io.EOF {
 					break

--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/cortexproject/cortex/pkg/util/limiter"
 	"github.com/cortexproject/cortex/pkg/util/test"
 )
 
@@ -25,7 +26,7 @@ func TestRecvFailDoesntCancelProcess(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := Config{}
-	mgr := newFrontendProcessor(cfg, nil, log.NewNopLogger())
+	mgr := newFrontendProcessor(cfg, &limiter.NoOpMemoryLimiter{}, nil, log.NewNopLogger())
 	running := atomic.NewBool(false)
 	go func() {
 		running.Store(true)

--- a/pkg/util/limiter/memory_limiter.go
+++ b/pkg/util/limiter/memory_limiter.go
@@ -1,0 +1,379 @@
+package limiter
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	errCheckIntervalOutOfRange = errors.New(
+		"checkInterval must be greater than zero")
+	errThresholdOutOfRange = errors.New(
+		"yellowThresholdBytes and redThresholdBytes should be greater than zero")
+	errInvlaidThreshold = errors.New(
+		"redThresholdBytes should be greather than yellowThresholdBytes")
+	errMemPressure = errors.New(
+		"undergoing memory pressure")
+)
+
+type MemoryLimiterConfig struct {
+	Enabled              bool          `yaml:"enabled"`
+	FailFast             bool          `yaml:"fail_fast"`
+	RedThresholdBytes    uint64        `yaml:"red_threshold_bytes"`
+	YellowThresholdBytes uint64        `yaml:"yellow_threshold_bytes"`
+	CheckInterval        time.Duration `yaml:"check_interval"`
+	MaxWaitDuration      time.Duration `yaml:"max_wait_duration"`
+}
+
+// RegisterFlags registers flags.
+func (cfg *MemoryLimiterConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.BoolVar(&cfg.Enabled, prefix+"memory-limiter.enabled", false, "Enable memory-limiter.")
+	f.BoolVar(&cfg.FailFast, prefix+"memory-limiter.fail-fast", false, "Specifies whether to fail when the heap is above the limit. If fail fast is false, the requests will wait for the heap to go down or until the max-wait-duration.")
+	f.DurationVar(&cfg.CheckInterval, prefix+"memory-limiter.check-interval", time.Second, "Configures how often to watch the heap to detect memory pressure.")
+	f.Uint64Var(&cfg.RedThresholdBytes, prefix+"memory-limiter.red-threshold-bytes", 0, "Specifies the limit above which system is considered to in red state. In red state, all except one request will be throttled.")
+	f.Uint64Var(&cfg.YellowThresholdBytes, prefix+"memory-limiter.yellow-threshold-bytes", 0, "Specifies the limit above which the system is considered to be in yellow state. In yellow state, new requests cannot be pulled in.")
+	f.DurationVar(&cfg.MaxWaitDuration, prefix+"memory-limiter.max-wait-duration", 5*time.Second, "Configures the maximum wait duration. If a goroutine were blocked for more than the max-wait-duration, it'll continue execution even under memory pressure.")
+}
+
+// MemoryLimiter provides a way for the service to detect memory pressure and slow itself down.
+type MemoryLimiter interface {
+	// NewJob creates a new job and adds to the job queue.
+	NewJob() Job
+
+	// Wait checks if the state of the system and blocks () until the desired state is achieved or context is done.
+	// If allowFirst is true, the first request in the queue is always allowed to succeed. This can be used to prevent deadlocks.
+	Wait(ctx context.Context, id JobID, desiredState State, allowFirst bool, failFast bool) error
+
+	// enqueue adds a job to the queue.
+	enqueue(j Job)
+
+	// dequeue removes a job from the queue.
+	dequeue(j Job)
+}
+
+type JobID int64
+
+// Job is a piece of work that the service is assigned to do.
+type Job interface {
+	// ID returns the id of the job
+	ID() JobID
+
+	// Complete ends the job and removes it from the queue.
+	Complete()
+
+	// Continue waits until the state is yellow or green.
+	Continue(ctx context.Context) error
+}
+
+type job struct {
+	failFast bool
+	id       JobID
+	limiter  MemoryLimiter
+}
+
+func (j *job) ID() JobID {
+	return j.id
+}
+
+func (j *job) Complete() {
+	j.limiter.dequeue(j)
+}
+
+func (j *job) Continue(ctx context.Context) error {
+	return j.limiter.Wait(ctx, j.id, Yellow, true, j.failFast)
+}
+
+// AddJobToContext is the helper function to add the job to context.
+func AddJobToContext(ctx context.Context, job Job) context.Context {
+	return context.WithValue(ctx, mlJobCtxkey, job)
+}
+
+// JobFromContext is the helper function to get the job from context.
+func JobFromContext(ctx context.Context) Job {
+	j, ok := ctx.Value(mlJobCtxkey).(Job)
+	if !ok {
+		return &job{
+			id:      0,
+			limiter: &NoOpMemoryLimiter{},
+		}
+	}
+	return j
+}
+
+type jobCtxKey struct{}
+
+var (
+	mlJobCtxkey = &jobCtxKey{}
+)
+
+// NewMemoryLimiter returns a new memorylimiter.
+func NewMemoryLimiter(cfg *MemoryLimiterConfig, r prometheus.Registerer, logger log.Logger) (MemoryLimiter, error) {
+	if !cfg.Enabled {
+		return &NoOpMemoryLimiter{}, nil
+	}
+
+	if cfg.CheckInterval <= 0 {
+		return nil, errCheckIntervalOutOfRange
+	}
+	if cfg.RedThresholdBytes == 0 || cfg.YellowThresholdBytes == 0 {
+		return nil, errThresholdOutOfRange
+	}
+	if cfg.YellowThresholdBytes >= cfg.RedThresholdBytes {
+		return nil, errInvlaidThreshold
+	}
+
+	ml := &HeapMemoryLimiter{
+		failFast:         cfg.FailFast,
+		memCheckInterval: cfg.CheckInterval,
+		redThreshold:     cfg.RedThresholdBytes,
+		yellowThreshold:  cfg.YellowThresholdBytes,
+		ticker:           time.NewTicker(cfg.CheckInterval),
+		readMemStatsFn:   runtime.ReadMemStats,
+		yellowCond:       newCond(cfg.MaxWaitDuration, logger),
+		greenCond:        newCond(5*time.Minute, logger),
+		logger:           logger,
+		stateGuage: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: "cortex",
+			Name:      "memory_limiter_state",
+			Help:      "The state of the memory limiter (Green is 0, Yellow is 1, Red is 2).",
+		}),
+	}
+
+	ml.start()
+	return ml, nil
+}
+
+// State is the state of the service
+//
+// Green - The service operates normally (below yellowThreshold).
+// Yellow - The service will not pull in any new work. All the current work will continue (above the yellowThreshold and below redThreshold).
+// Red - The service is undergoing severe memory pressure. All except the first job will be paused (above the redThreshold).
+type State int
+
+const (
+	Green  State = 0
+	Yellow State = 1
+	Red    State = 2
+)
+
+// HeapMemoryLimiter is the implementation of MemoryLimiter that watches Heap allocation to detect memory pressure.
+type HeapMemoryLimiter struct {
+	failFast bool // failFast specifies whether the jobs should fail immediately instead of waiting for the desired state.
+
+	redThreshold    uint64 // threshold in bytes above which the the system enters red state.
+	yellowThreshold uint64 // threshold in bytes above which the system enters yellow state. below this the system will be in green state.
+
+	yellowCond *cond // used for broadcasting when the state has changed to yellow.
+	greenCond  *cond // used for broadcasting when the state has changed to green.
+
+	jobsQueue []JobID    // FIFO queue for jobs.
+	jobsMutex sync.Mutex // mutex for accessing the queue.
+
+	state      State      // keeps track of the current status.
+	stateMutex sync.Mutex // mutex for accessing state
+
+	// memCheckInterval is the interval to read MemStats.
+	memCheckInterval time.Duration
+	ticker           *time.Ticker
+
+	// readMemStatsFn is the function to read the mem values is set as a reference to help with
+	// testing different values.
+	readMemStatsFn func(m *runtime.MemStats)
+
+	logger     log.Logger
+	stateGuage prometheus.Gauge
+}
+
+func (ml *HeapMemoryLimiter) NewJob() Job {
+	id := time.Now().UnixNano()
+	j := &job{
+		failFast: ml.failFast,
+		id:       JobID(id),
+		limiter:  ml,
+	}
+	ml.enqueue(j)
+	return j
+}
+
+// enqueue adds a job to the queue.
+func (ml *HeapMemoryLimiter) enqueue(j Job) {
+	ml.jobsMutex.Lock()
+	defer ml.jobsMutex.Unlock()
+	ml.jobsQueue = append(ml.jobsQueue, j.ID())
+}
+
+// dequeue removes a job from the queue.
+func (ml *HeapMemoryLimiter) dequeue(j Job) {
+	ml.jobsMutex.Lock()
+	defer ml.jobsMutex.Unlock()
+	for i, v := range ml.jobsQueue {
+		if v == j.ID() {
+			ml.jobsQueue = append(ml.jobsQueue[:i], ml.jobsQueue[i+1:]...)
+			break
+		}
+	}
+}
+
+// Wait provides a way for goroutines to slow down if there is memory pressure.
+// If memory pressure is detected, wait will block until the memory pressure is mitigated or the context is done.
+// If allowFirst is true, the first request in the queue will be always allowed.
+func (ml *HeapMemoryLimiter) Wait(ctx context.Context, id JobID, desiredState State, allowFirst bool, failFast bool) error {
+	if allowFirst && ml.isFirstJob(id) {
+		level.Debug(ml.logger).Log("msg", "Allowing the first job in the queue.")
+		// Allow the first job in the queue to continue.
+		return nil
+	}
+
+	ml.stateMutex.Lock()
+	currentState := ml.state
+	ml.stateMutex.Unlock()
+
+	if currentState <= desiredState {
+		// Allow if the desired state is already achieved
+		return nil
+	}
+
+	if failFast {
+		// If running in failFast mode, fail instead of waiting.
+		return errMemPressure
+	}
+
+	if desiredState == Yellow {
+		// If under memory pressure, wait for a signal before continuing
+		level.Warn(ml.logger).Log("msg", "Under memory pressure, waiting")
+		ml.yellowCond.Wait(ctx)
+	} else {
+		// If under memory pressure, wait for a signal before continuing
+		level.Warn(ml.logger).Log("msg", "Under memory pressure, waiting")
+		ml.greenCond.Wait(ctx)
+	}
+
+	return nil
+}
+
+func (ml *HeapMemoryLimiter) start() {
+	ml.updateState(Green) // start in green state.
+	go func() {
+		for range ml.ticker.C {
+			ml.checkMemLimits()
+		}
+	}()
+}
+
+// checkMemLimits checks the current heap alloc. If previously the system got out of memory pressure, it'll broadcast to goroutines to continue.
+func (ml *HeapMemoryLimiter) checkMemLimits() {
+	ms := ml.readMemStats()
+
+	ml.stateMutex.Lock()
+	prevState := ml.state
+	ml.stateMutex.Unlock()
+
+	if ms.Alloc > ml.redThreshold {
+		if prevState != Red {
+			level.Debug(ml.logger).Log("msg", "Entering Red state.")
+			ml.updateState(Red)
+		}
+	} else if ms.Alloc <= ml.redThreshold && ms.Alloc > ml.yellowThreshold {
+		if prevState != Yellow {
+			level.Debug(ml.logger).Log("msg", "Entering Yellow state.")
+			ml.updateState(Yellow)
+			ml.yellowCond.Broadcast()
+		}
+	} else {
+		// Green state
+		if prevState != Green {
+			level.Debug(ml.logger).Log("msg", "Entering Green state.")
+			ml.updateState(Green)
+			ml.yellowCond.Broadcast()
+			ml.greenCond.Broadcast()
+		}
+	}
+}
+
+func (ml *HeapMemoryLimiter) updateState(state State) {
+	ml.stateMutex.Lock()
+	defer ml.stateMutex.Unlock()
+	level.Debug(ml.logger).Log("msg", fmt.Sprintf("Updating state to %d", state))
+	ml.state = state
+	ml.stateGuage.Set(float64(state))
+}
+
+func (ml *HeapMemoryLimiter) readMemStats() *runtime.MemStats {
+	ms := &runtime.MemStats{}
+	ml.readMemStatsFn(ms)
+	return ms
+}
+
+func (ml *HeapMemoryLimiter) isFirstJob(id JobID) bool {
+	ml.jobsMutex.Lock()
+	defer ml.jobsMutex.Unlock()
+	return len(ml.jobsQueue) == 0 || ml.jobsQueue[0] == id
+}
+
+// NoOpMemoryLimiter can be used when memory limiter is disabled.
+type NoOpMemoryLimiter struct{}
+
+func (ml *NoOpMemoryLimiter) NewJob() Job {
+	return &job{
+		id:      JobID(0),
+		limiter: ml,
+	}
+}
+func (ml *NoOpMemoryLimiter) Wait(ctx context.Context, id JobID, status State, allowFirst bool, failFast bool) error {
+	return nil
+}
+func (ml *NoOpMemoryLimiter) enqueue(j Job) {}
+func (ml *NoOpMemoryLimiter) dequeue(j Job) {}
+
+func newCond(maxWait time.Duration, l log.Logger) *cond {
+	return &cond{
+		ch:      make(chan struct{}),
+		logger:  l,
+		maxWait: maxWait,
+	}
+}
+
+// cond is a wrapper around a channel that provides the functionality sync.Cond
+type cond struct {
+	mu      sync.Mutex // guards ch
+	ch      chan struct{}
+	maxWait time.Duration
+	logger  log.Logger
+}
+
+func (c *cond) Wait(ctx context.Context) {
+	c.mu.Lock()
+	ch := c.ch
+	c.mu.Unlock()
+	timer := time.NewTimer(c.maxWait)
+	defer timer.Stop()
+
+	select {
+	case <-ch:
+		level.Debug(c.logger).Log("msg", "Received signal, continuing")
+		return
+	case <-ctx.Done():
+		level.Debug(c.logger).Log("msg", "Context cancelled, continuing")
+		return
+	case <-timer.C:
+		level.Warn(c.logger).Log("msg", "Maximum wait duration elapsed, continuing anyways")
+		return
+	}
+}
+
+func (c *cond) Broadcast() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	close(c.ch)
+	c.ch = make(chan struct{})
+}

--- a/pkg/util/limiter/memory_limiter_test.go
+++ b/pkg/util/limiter/memory_limiter_test.go
@@ -1,0 +1,214 @@
+package limiter
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/common/logging"
+	"go.uber.org/atomic"
+
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
+)
+
+func TestMemoryLimiter(t *testing.T) {
+	tc := []struct {
+		name             string
+		alloc            uint64
+		redThreshold     uint64
+		yellowThreshold  uint64
+		failFast         bool
+		gc               bool
+		memAfterGC       uint64
+		waitStart        bool
+		totalRequests    int
+		pendingRequests  int
+		finishedRequests int
+		failedRequests   int
+		finalState       State
+	}{
+		{
+			name:             "state=green",
+			alloc:            0,
+			redThreshold:     80,
+			yellowThreshold:  10,
+			gc:               false,
+			totalRequests:    5,
+			pendingRequests:  0,
+			finishedRequests: 5,
+			failedRequests:   0,
+			finalState:       Yellow,
+		},
+		{
+			name:             "state=red;",
+			alloc:            100,
+			redThreshold:     80,
+			yellowThreshold:  40,
+			gc:               false,
+			totalRequests:    5,
+			pendingRequests:  4, // When under memory pressure, only the first request must finish.
+			finishedRequests: 1,
+			failedRequests:   0,
+			finalState:       Red,
+		},
+		{
+			name:             "state=red; stateAfterGC=green",
+			alloc:            100,
+			redThreshold:     80,
+			yellowThreshold:  70,
+			gc:               true,
+			memAfterGC:       0,
+			totalRequests:    5,
+			pendingRequests:  0, // Was under memory pressure, but the GC cleared the memory.
+			finishedRequests: 5, // All requests should finish after memory is cleared by GC.
+			failedRequests:   0,
+			finalState:       Green,
+		},
+		{
+			name:             "state=yellow; stateAfterGC=green",
+			alloc:            70,
+			redThreshold:     80,
+			yellowThreshold:  40,
+			gc:               true,
+			memAfterGC:       0,
+			totalRequests:    5,
+			pendingRequests:  0, // Was under memory pressure, but the GC cleared the memory.
+			finishedRequests: 5, // All requests should finish after memory is cleared by GC.
+			failedRequests:   0,
+			finalState:       Green,
+		},
+		{
+			name:             "state=red; stateAfterGC=yellow",
+			alloc:            200,
+			redThreshold:     80,
+			yellowThreshold:  10,
+			gc:               true,
+			memAfterGC:       20,
+			totalRequests:    5,
+			pendingRequests:  0, // Was under memory pressure, but the GC cleared the memory.
+			finishedRequests: 5, // All requests should finish after memory is cleared by GC.
+			failedRequests:   0,
+			finalState:       Yellow,
+		},
+		{
+			name:             "state=yellow; waitStart=true",
+			alloc:            45,
+			redThreshold:     80,
+			yellowThreshold:  40,
+			gc:               false,
+			waitStart:        true,
+			totalRequests:    5,
+			pendingRequests:  0, // All requests should wait for alloc to go below reset. No requests should be queued.
+			finishedRequests: 0, // Since no requests are queued, no requests should finish.
+			failedRequests:   0,
+			finalState:       Yellow,
+		},
+		{
+			name:             "state=red; failFast=true",
+			alloc:            90,
+			redThreshold:     80,
+			yellowThreshold:  40,
+			gc:               false,
+			failFast:         true,
+			totalRequests:    5,
+			pendingRequests:  0, // All requests should finish.
+			finishedRequests: 5, // All requests should finish.
+			failedRequests:   4, // All except the first request should fail.
+			finalState:       Red,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			finished := atomic.NewInt64(0)
+			failed := atomic.NewInt64(0)
+			workDuration := 50 * time.Millisecond
+			tickerDuration := 50 * time.Millisecond
+			alloc := atomic.Uint64{}
+			alloc.Store(tt.alloc)
+
+			reg := prometheus.NewRegistry()
+			logger, _ := util_log.NewPrometheusLogger(logging.Level{}, logging.Format{})
+			lim := &HeapMemoryLimiter{
+				failFast:         tt.failFast,
+				memCheckInterval: time.Second,
+				redThreshold:     tt.redThreshold,
+				yellowThreshold:  tt.yellowThreshold,
+				readMemStatsFn: func(m *runtime.MemStats) {
+					m.Alloc = alloc.Load()
+				},
+				ticker:     time.NewTicker(tickerDuration),
+				logger:     logger,
+				yellowCond: newCond(5*time.Second, logger),
+				greenCond:  newCond(5*time.Minute, logger),
+				stateGuage: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+					Namespace: "cortex",
+					Name:      "memory_limiter_state",
+					Help:      "The state of the memory limiter (Green is 0, Yellow is 1, Red is 2).",
+				}),
+			}
+			lim.start()
+			waitStart := tt.waitStart
+			time.Sleep(2 * tickerDuration) // Wait for at-least one iteration of the memLimiter
+
+			f := func(lim *HeapMemoryLimiter, id int64) {
+				job := lim.NewJob()
+				defer job.Complete()
+
+				for i := 0; i <= 5; i++ {
+					t.Logf("Processing request: %v data %v", id, i)
+					err := job.Continue(context.Background())
+					if err != nil {
+						failed.Inc()
+						break
+					}
+					alloc.Inc()
+					time.Sleep(workDuration)
+				}
+
+				t.Logf("Finished %d", id)
+				finished.Inc()
+			}
+
+			for i := 1; i <= tt.totalRequests; i++ {
+				id := int64(i)
+				go func() {
+					if waitStart {
+						_ = lim.Wait(context.Background(), 0, Green, false, false)
+					}
+					f(lim, id)
+				}()
+				time.Sleep(tickerDuration)
+			}
+
+			if tt.gc {
+				// Mock a gc cycle which clears the alloc.
+				alloc.Store(tt.memAfterGC)
+			}
+
+			// Give enough time for all the goroutines to finish.
+			time.Sleep(workDuration * time.Duration(tt.totalRequests*2+1))
+
+			lim.jobsMutex.Lock()
+			assert.Equal(t, tt.pendingRequests, len(lim.jobsQueue))
+			assert.Equal(t, int64(tt.finishedRequests), finished.Load())
+			assert.Equal(t, int64(tt.failedRequests), failed.Load())
+			lim.jobsMutex.Unlock()
+
+			assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+				# TYPE cortex_memory_limiter_state gauge
+				# HELP cortex_memory_limiter_state The state of the memory limiter (Green is 0, Yellow is 1, Red is 2).
+				cortex_memory_limiter_state %d
+			`, tt.finalState)),
+				"cortex_memory_limiter_state",
+			))
+		})
+	}
+}


### PR DESCRIPTION
## Problem:
In Cortex, when heavy queries are run concurrently the querier pods can run out of memory and killed. 
The fundamental problem behind OOM is that memory is allocated faster than it is reclaimed by the garbage collector.

## Solution
An idea to prevent OOMs is to implement a limiter in Cortex that can slow down the query execution when the memory usage is say 80% of the limit. The idea is to determine which state the service is in by watching the heap every X second. 
If there is memory pressure, goroutines will pause streaming data from ingesters/store-gateways. Once the memory is below threshold again the goroutines will resume. Slowing down the query execution will reduce the chance of OOMs and will also give enough time for the auto-scaling to catch up.



### How it works?
- There are three configs
  - check-interval - How often to check the heap alloc?
  - red-threshold-bytes - Threshold above which system is in red state. In RED state, everything except the first job is paused.
  - yellow-threshold-bytes - If we are below this threshold, the system is in Green state. Above this threshold, the system is in yellow state. All existing requests can continue but no new work will be pulled in.. 
- Every second, the limiter will watch the heap and check if the pod is under memory pressure. Based on the heap allocation, there are three states the service can be in.


#### States
Based on the heap allocation the state of the service is determined. States are then used to decide what is allowed.

Green - Everything is good.
Yellow - No new jobs are pulled in. Existing jobs will continue.
Red - Sever memory pressure. Only the first job in the queue is allowed to continue. Others have to wait until their turn or the service enters Green or Yellow state.

##### Green state
![MemoryLimiter_green(1)](https://user-images.githubusercontent.com/842522/236551650-c2c046a8-8c63-43b6-b545-9757ace3528b.png)



In the green state, the heap allocation is below the reset limit. There is no memory pressure and new requests can be pulled in from the queue.

##### Yellow state
![MemoryLimiter_yellow(3)](https://user-images.githubusercontent.com/842522/236551750-90596a6a-2af0-4372-aede-7d36bc655500.png)

In the yellow state, the heap allocation is above the reset limit but below the memory limit. No new requests can be pulled in. All the existing requests in the querier will continue executing.

##### Red state
![MemoryLimiter_Red(2)](https://user-images.githubusercontent.com/842522/236551781-2bb39217-ff17-4669-b3b5-4979fe37f85b.png)

In the red state, the heap allocation is above the memory limit. No new requests can be pulled in. Also the existing requests will be slowed down. Only the first requests in the queue will be allowed to continue execution unimpeded.



#### Test Results
I tested this code in a test cluster. First test I ran with the memory limiter disabled. I noticed a lot of querier OOMs.

![Screenshot 2023-05-04 at 12 11 17 PM](https://user-images.githubusercontent.com/842522/236305335-7ef0c1e9-ff94-4613-8fd2-2d0b2861cb07.png)


In my second test, I enabled the memory limiter with the following configuration. The querier pods had a limit of 60 GiB. No querier OOMs were observed. During the high TPS event, the requests were throttled and dropped/timed out instead of the pod getting OOM killed. This should give enough time for auto-scaling to catch up.
```
    Args:
      exec cortex \
        -target=querier \
        -querier.memory-limiter.reset-limit-bytes=20000000000 \ # 20 Gib
        -querier.memory-limiter.check-interval=100ms \
        -querier.memory-limiter.enabled=true \
        -querier.memory-limiter.memory-limit-bytes=40000000000 \ 40 Gib
        -config.file=/etc/config/config.yml

    Environment:
       GOMEMLIMIT: 40GiB
```

![Screenshot 2023-05-04 at 12 15 37 PM](https://user-images.githubusercontent.com/842522/236306199-07c64886-1996-46e5-8b4e-e658e44c067f.png)


#### Checklist**
- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
