### PR TITLE
Add additional tracing span for merging labels responses

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -884,6 +884,12 @@ func (d *Distributor) ForReplicationSet(ctx context.Context, replicationSet ring
 }
 
 func (d *Distributor) LabelValuesForLabelNameCommon(ctx context.Context, from, to model.Time, labelName model.LabelName, f func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelValuesRequest) ([]interface{}, error), matchers ...*labels.Matcher) ([]string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Distributor.LabelValues", opentracing.Tags{
+		"name":  labelName,
+		"start": from.Unix(),
+		"end":   to.Unix(),
+	})
+	defer span.Finish()
 	replicationSet, err := d.GetIngestersForMetadata(ctx)
 	if err != nil {
 		return nil, err
@@ -899,6 +905,8 @@ func (d *Distributor) LabelValuesForLabelNameCommon(ctx context.Context, from, t
 		return nil, err
 	}
 
+	span, _ = opentracing.StartSpanFromContext(ctx, "response_merge")
+	defer span.Finish()
 	valueSet := map[string]struct{}{}
 	for _, resp := range resps {
 		for _, v := range resp.([]string) {
@@ -913,11 +921,12 @@ func (d *Distributor) LabelValuesForLabelNameCommon(ctx context.Context, from, t
 
 	// We need the values returned to be sorted.
 	sort.Strings(values)
+	span.SetTag("result_length", len(values))
 
 	return values, nil
 }
 
-// LabelValuesForLabelName returns all of the label values that are associated with a given label name.
+// LabelValuesForLabelName returns all the label values that are associated with a given label name.
 func (d *Distributor) LabelValuesForLabelName(ctx context.Context, from, to model.Time, labelName model.LabelName, matchers ...*labels.Matcher) ([]string, error) {
 	return d.LabelValuesForLabelNameCommon(ctx, from, to, labelName, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelValuesRequest) ([]interface{}, error) {
 		return d.ForReplicationSet(ctx, rs, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
@@ -930,7 +939,7 @@ func (d *Distributor) LabelValuesForLabelName(ctx context.Context, from, to mode
 	}, matchers...)
 }
 
-// LabelValuesForLabelName returns all of the label values that are associated with a given label name.
+// LabelValuesForLabelNameStream returns all the label values that are associated with a given label name.
 func (d *Distributor) LabelValuesForLabelNameStream(ctx context.Context, from, to model.Time, labelName model.LabelName, matchers ...*labels.Matcher) ([]string, error) {
 	return d.LabelValuesForLabelNameCommon(ctx, from, to, labelName, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelValuesRequest) ([]interface{}, error) {
 		return d.ForReplicationSet(ctx, rs, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
@@ -957,6 +966,11 @@ func (d *Distributor) LabelValuesForLabelNameStream(ctx context.Context, from, t
 }
 
 func (d *Distributor) LabelNamesCommon(ctx context.Context, from, to model.Time, f func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelNamesRequest) ([]interface{}, error)) ([]string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Distributor.LabelNames", opentracing.Tags{
+		"start": from.Unix(),
+		"end":   to.Unix(),
+	})
+	defer span.Finish()
 	replicationSet, err := d.GetIngestersForMetadata(ctx)
 	if err != nil {
 		return nil, err
@@ -971,6 +985,8 @@ func (d *Distributor) LabelNamesCommon(ctx context.Context, from, to model.Time,
 		return nil, err
 	}
 
+	span, _ = opentracing.StartSpanFromContext(ctx, "response_merge")
+	defer span.Finish()
 	valueSet := map[string]struct{}{}
 	for _, resp := range resps {
 		for _, v := range resp.([]string) {
@@ -984,6 +1000,7 @@ func (d *Distributor) LabelNamesCommon(ctx context.Context, from, to model.Time,
 	}
 
 	sort.Strings(values)
+	span.SetTag("result_length", len(values))
 
 	return values, nil
 }
@@ -1013,7 +1030,7 @@ func (d *Distributor) LabelNamesStream(ctx context.Context, from, to model.Time)
 	})
 }
 
-// LabelNames returns all of the label names.
+// LabelNames returns all the label names.
 func (d *Distributor) LabelNames(ctx context.Context, from, to model.Time) ([]string, error) {
 	return d.LabelNamesCommon(ctx, from, to, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelNamesRequest) ([]interface{}, error) {
 		return d.ForReplicationSet(ctx, rs, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

We are seeing very high latencies on label related APIs. Having the additional info in the trace span can help us troubleshoot the issue and understand the bottleneck. Especially to see how long it takes to merge responses and deduplicate.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
