### PR TITLE
[WIP] Optimize GetLabels and GetLabelsValues

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1693,6 +1693,7 @@ func BenchmarkDistributor_LabelsCommons(b *testing.B) {
 
 	// Start the distributor.
 	distributor, err := New(distributorCfg, clientConfig, overrides, ingestersRing, true, nil, log.NewNopLogger())
+	require.NoError(b, err)
 
 	numberOfAz := 3
 	maxNumberOfIngestersPerAz := 100
@@ -1741,9 +1742,10 @@ func BenchmarkDistributor_LabelsCommons(b *testing.B) {
 			}
 
 			for n := 0; n < b.N; n++ {
-				distributor.LabelNamesCommon(ctx, model.Now(), model.Now(), func(ctx context.Context, rs ring.ReplicationSet, req *client.LabelNamesRequest) ([]interface{}, error) {
+				_, err := distributor.LabelNamesCommon(ctx, model.Now(), model.Now(), func(ctx context.Context, rs ring.ReplicationSet, req *client.LabelNamesRequest) ([]interface{}, error) {
 					return r, nil
 				})
+				require.NoError(b, err)
 			}
 		})
 	}

--- a/pkg/util/stringutil/kmerge.go
+++ b/pkg/util/stringutil/kmerge.go
@@ -1,0 +1,85 @@
+package stringutil
+
+import (
+	"container/heap"
+)
+
+func KWayMerge(arrays ...[]string) []string {
+	k := len(arrays)
+	if k == 0 {
+		return []string{}
+	}
+	h := MinHeap{nodes: make([]*Node, 0, k), valMap: make(map[string]struct{}, k)}
+	result := make([]string, 0, len(arrays[0]))
+
+	// Initialize the h with the first element from each array
+	for i, arr := range arrays {
+		if len(arr) > 0 {
+			h.nodes = append(h.nodes, &Node{arr[0], i, 0})
+		}
+	}
+	heap.Init(&h)
+
+	// Keep popping elements from the h and adding to the result
+	for h.Len() > 0 {
+		node := h.nodes[0]
+		if len(result) == 0 || result[len(result)-1] != node.val {
+			result = append(result, node.val)
+		}
+
+		remove := true
+		// If there are more elements in the same array, add to h
+		for node.idx < len(arrays[node.array])-1 {
+			next := arrays[node.array][node.idx+1]
+			node.val = next
+			node.idx += 1
+			if !h.Contains(next) {
+				heap.Fix(&h, 0)
+				remove = false
+				break
+			}
+		}
+
+		if remove {
+			heap.Pop(&h)
+		}
+	}
+
+	return result
+}
+
+// Node struct represents an element in the heap
+type Node struct {
+	val   string
+	array int
+	idx   int
+}
+
+// MinHeap is a priority queue that stores Nodes in increasing order of val
+type MinHeap struct {
+	nodes  []*Node
+	valMap map[string]struct{}
+}
+
+func (h MinHeap) Len() int           { return len(h.nodes) }
+func (h MinHeap) Less(i, j int) bool { return h.nodes[i].val < h.nodes[j].val }
+func (h MinHeap) Swap(i, j int)      { h.nodes[i], h.nodes[j] = h.nodes[j], h.nodes[i] }
+
+func (h *MinHeap) Push(x interface{}) {
+	h.nodes = append(h.nodes, x.(*Node))
+	h.valMap[x.(*Node).val] = struct{}{}
+}
+
+func (h MinHeap) Contains(x string) bool {
+	_, ok := h.valMap[x]
+	return ok
+}
+
+func (h *MinHeap) Pop() interface{} {
+	old := h.nodes
+	n := len(old)
+	node := old[n-1]
+	h.nodes = old[:n-1]
+	delete(h.valMap, node.val)
+	return node
+}

--- a/pkg/util/stringutil/kmerge.go
+++ b/pkg/util/stringutil/kmerge.go
@@ -32,7 +32,7 @@ func KWayMerge(arrays ...[]string) []string {
 		for node.idx < len(arrays[node.array])-1 {
 			next := arrays[node.array][node.idx+1]
 			node.val = next
-			node.idx += 1
+			node.idx++
 			if !h.Contains(next) {
 				heap.Fix(&h, 0)
 				remove = false

--- a/pkg/util/stringutil/kmerge_test.go
+++ b/pkg/util/stringutil/kmerge_test.go
@@ -16,8 +16,12 @@ func Test_kWayMerge(t *testing.T) {
 			arrays: [][]string{
 				{"a", "c", "e"},
 				{"c", "d", "f"},
+				{"c", "f"},
+				{"k", "m"},
+				{"b"},
+				{"a"},
 			},
-			want: []string{"a", "c", "d", "e", "f"},
+			want: []string{"a", "b", "c", "d", "e", "f", "k", "m"},
 		},
 	}
 

--- a/pkg/util/stringutil/kmerge_test.go
+++ b/pkg/util/stringutil/kmerge_test.go
@@ -1,0 +1,31 @@
+package stringutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_kWayMerge(t *testing.T) {
+	tests := []struct {
+		name   string
+		arrays [][]string
+		want   []string
+	}{
+		{
+			name: "test",
+			arrays: [][]string{
+				{"a", "c", "e"},
+				{"c", "d", "f"},
+			},
+			want: []string{"a", "c", "d", "e", "f"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := KWayMerge(tt.arrays...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("kWayMerge() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Using k-merge to merge responses from different ingesters:

This is still a wip: DO NOT MERGE.

Preliminary bench results:

```
goos: linux
goarch: amd64
pkg: github.com/cortexproject/cortex/pkg/distributor
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
                                           │   /tmp/old    │              /tmp/new               │
                                           │    sec/op     │    sec/op     vs base               │
Distributor_LabelsCommons/10_ingesters-32     61.14m ± ∞ ¹   17.79m ± ∞ ¹  -70.91% (p=0.008 n=5)
Distributor_LabelsCommons/50_ingesters-32     435.5m ± ∞ ¹   101.0m ± ∞ ¹  -76.81% (p=0.008 n=5)
Distributor_LabelsCommons/100_ingesters-32   1012.2m ± ∞ ¹   198.6m ± ∞ ¹  -80.38% (p=0.008 n=5)
geomean                                       299.8m         70.92m	   -76.35%
¹ need >= 6 samples for confidence interval at level 0.95

                                           │   /tmp/old    │               /tmp/new               │
                                           │     B/op	   │     B/op       vs base               │
Distributor_LabelsCommons/10_ingesters-32    6.871Mi ± ∞ ¹   7.269Mi ± ∞ ¹   +5.79% (p=0.008 n=5)
Distributor_LabelsCommons/50_ingesters-32    47.97Mi ± ∞ ¹   38.23Mi ± ∞ ¹  -20.31% (p=0.008 n=5)
Distributor_LabelsCommons/100_ingesters-32   95.80Mi ± ∞ ¹   75.70Mi ± ∞ ¹  -20.98% (p=0.008 n=5)
geomean                                      31.61Mi         27.61Mi        -12.66%
¹ need >= 6 samples for confidence interval at level 0.95

                                           │   /tmp/old    │              /tmp/new              │
                                           │   allocs/op   │  allocs/op   vs base               │
Distributor_LabelsCommons/10_ingesters-32    3926.00 ± ∞ ¹   57.00 ± ∞ ¹  -98.55% (p=0.008 n=5)
Distributor_LabelsCommons/50_ingesters-32    19077.0 ± ∞ ¹   198.0 ± ∞ ¹  -98.96% (p=0.008 n=5)
Distributor_LabelsCommons/100_ingesters-32   38438.0 ± ∞ ¹   391.0 ± ∞ ¹  -98.98% (p=0.008 n=5)
geomean                                       14.23k         164.0        -98.85%
```


**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
