### PR TITLE
Cherry pick "upgrade to Go 1.20.4" from main branch

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:upgrade-to-go1.20.1-pr-5159
+      image: quay.io/cortexproject/build-image:upgrade-to-go-1.20.4-6025f83e5
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:upgrade-to-go1.20.1-pr-5159
+      image: quay.io/cortexproject/build-image:upgrade-to-go-1.20.4-6025f83e5
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:upgrade-to-go1.20.1-pr-5159
+      image: quay.io/cortexproject/build-image:upgrade-to-go-1.20.4-6025f83e5
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -189,14 +189,14 @@ jobs:
         run: |
           touch build-image/.uptodate
           MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations
-          make BUILD_IMAGE=quay.io/cortexproject/build-image:upgrade-to-go1.20.1-pr-5159 TTY='' configs-integration-test
+          make BUILD_IMAGE=quay.io/cortexproject/build-image:upgrade-to-go-1.20.4-6025f83e5 TTY='' configs-integration-test
 
   deploy_website:
     needs: [build, test]
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:upgrade-to-go1.20.1-pr-5159
+      image: quay.io/cortexproject/build-image:upgrade-to-go-1.20.4-6025f83e5
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -238,7 +238,7 @@ jobs:
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:upgrade-to-go1.20.1-pr-5159
+      image: quay.io/cortexproject/build-image:upgrade-to-go-1.20.4-6025f83e5
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ build-image/$(UPTODATE): build-image/*
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER := true
 BUILD_IMAGE ?= $(IMAGE_PREFIX)build-image
-LATEST_BUILD_IMAGE_TAG ?= upgrade-to-go1.20.1-e6945e022
+LATEST_BUILD_IMAGE_TAG ?= upgrade-to-go-1.20.4-6025f83e5
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.20.1-buster
+FROM golang:1.20.4-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
-RUN apt-get update && apt-get install -y curl python-requests python-yaml file jq unzip protobuf-compiler libprotobuf-dev && \
+RUN apt-get update && apt-get install -y curl file jq unzip protobuf-compiler libprotobuf-dev && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Cherry pick change from main branch to address critical CVEs.
