### PR TITLE
Exposing Thanos accept-malformed-index to Cortex compactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [FEATURE] Store Gateway: Add `max_downloaded_bytes_per_request` to limit max bytes to download per store gateway request.
 * [ENHANCEMENT] Support object storage backends for runtime configuration file. #5292
 * [ENHANCEMENT] Query Frontend: Reject subquery with too small step size. #5323
+* [ENHANCEMENT] Compactor: Exposing Thanos accept-malformed-index to Cortex compactor. #5334
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/docs/blocks-storage/compactor.md
+++ b/docs/blocks-storage/compactor.md
@@ -277,4 +277,8 @@ compactor:
   # compaction.
   # CLI flag: -compactor.block-visit-marker-file-update-interval
   [block_visit_marker_file_update_interval: <duration> | default = 1m]
+
+  # When enabled, index verification will ignore out of order label names.
+  # CLI flag: -compactor.accept-malformed-index
+  [accept_malformed_index: <boolean> | default = false]
 ```

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1929,6 +1929,10 @@ sharding_ring:
 # How frequently block visit marker file should be updated duration compaction.
 # CLI flag: -compactor.block-visit-marker-file-update-interval
 [block_visit_marker_file_update_interval: <duration> | default = 1m]
+
+# When enabled, index verification will ignore out of order label names.
+# CLI flag: -compactor.accept-malformed-index
+[accept_malformed_index: <boolean> | default = false]
 ```
 
 ### `configs_config`

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -56,8 +56,8 @@ var (
 		return compact.NewDefaultGrouper(
 			logger,
 			bkt,
-			false, // Do not accept malformed indexes
-			true,  // Enable vertical compaction
+			cfg.AcceptMalformedIndex,
+			true, // Enable vertical compaction
 			reg,
 			blocksMarkedForDeletion,
 			garbageCollectedBlocks,
@@ -72,8 +72,8 @@ var (
 			ctx,
 			logger,
 			bkt,
-			false, // Do not accept malformed indexes
-			true,  // Enable vertical compaction
+			cfg.AcceptMalformedIndex,
+			true, // Enable vertical compaction
 			reg,
 			blocksMarkedForDeletion,
 			blocksMarkedForNoCompaction,
@@ -208,6 +208,8 @@ type Config struct {
 	// Block visit marker file config
 	BlockVisitMarkerTimeout            time.Duration `yaml:"block_visit_marker_timeout"`
 	BlockVisitMarkerFileUpdateInterval time.Duration `yaml:"block_visit_marker_file_update_interval"`
+
+	AcceptMalformedIndex bool `yaml:"accept_malformed_index"`
 }
 
 // RegisterFlags registers the Compactor flags.
@@ -244,6 +246,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	f.DurationVar(&cfg.BlockVisitMarkerTimeout, "compactor.block-visit-marker-timeout", 5*time.Minute, "How long block visit marker file should be considered as expired and able to be picked up by compactor again.")
 	f.DurationVar(&cfg.BlockVisitMarkerFileUpdateInterval, "compactor.block-visit-marker-file-update-interval", 1*time.Minute, "How frequently block visit marker file should be updated duration compaction.")
+
+	f.BoolVar(&cfg.AcceptMalformedIndex, "compactor.accept-malformed-index", false, "When enabled, index verification will ignore out of order label names.")
 }
 
 func (cfg *Config) Validate(limits validation.Limits) error {

--- a/pkg/compactor/shuffle_sharding_grouper.go
+++ b/pkg/compactor/shuffle_sharding_grouper.go
@@ -249,8 +249,8 @@ mainLoop:
 			groupKey,
 			externalLabels,
 			resolution,
-			false, // No malformed index.
-			true,  // Enable vertical compaction.
+			g.acceptMalformedIndex,
+			true, // Enable vertical compaction.
 			g.compactions.WithLabelValues(groupKey),
 			g.compactionRunsStarted.WithLabelValues(groupKey),
 			g.compactionRunsCompleted.WithLabelValues(groupKey),


### PR DESCRIPTION
**What this PR does**:
Exposing Thanos `accept-malformed-index` (https://github.com/thanos-io/thanos/blob/7000066202b4f0f8b2ecab548c5c8d08dfa89532/pkg/compact/compact.go#L340) to Cortex compactor

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
