### PR TITLE
Bucket index updater should ignore meta not found for partial blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293
+* [BUGFIX] Storage: Bucket index updater should ignore meta not found for partial blocks. #5343
 
 ## 1.15.1 2023-04-26
 

--- a/pkg/storage/tsdb/bucketindex/updater.go
+++ b/pkg/storage/tsdb/bucketindex/updater.go
@@ -123,7 +123,7 @@ func (w *Updater) updateBlockIndexEntry(ctx context.Context, id ulid.ULID) (*Blo
 	metaFile := path.Join(id.String(), block.MetaFilename)
 
 	// Get the block's meta.json file.
-	r, err := w.bkt.Get(ctx, metaFile)
+	r, err := w.bkt.ReaderWithExpectedErrs(w.bkt.IsObjNotFoundErr).Get(ctx, metaFile)
 	if w.bkt.IsObjNotFoundErr(err) {
 		return nil, ErrBlockMetaNotFound
 	}

--- a/pkg/storage/tsdb/bucketindex/updater_test.go
+++ b/pkg/storage/tsdb/bucketindex/updater_test.go
@@ -3,8 +3,6 @@ package bucketindex
 import (
 	"bytes"
 	"context"
-	"github.com/prometheus/client_golang/prometheus"
-	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"path"
 	"strings"
 	"testing"
@@ -13,6 +11,8 @@ import (
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/storage/tsdb/bucketindex/updater_test.go
+++ b/pkg/storage/tsdb/bucketindex/updater_test.go
@@ -3,7 +3,10 @@ package bucketindex
 import (
 	"bytes"
 	"context"
+	"github.com/prometheus/client_golang/prometheus"
+	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -90,6 +93,49 @@ func TestUpdater_UpdateIndex_ShouldSkipPartialBlocks(t *testing.T) {
 
 	assert.Len(t, partials, 1)
 	assert.True(t, errors.Is(partials[block3.ULID], ErrBlockMetaNotFound))
+}
+
+func TestUpdater_UpdateIndex_ShouldNotIncreaseOperationFailureMetric(t *testing.T) {
+	const userID = "user-1"
+
+	bkt, _ := testutil.PrepareFilesystemBucket(t)
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	registry := prometheus.NewRegistry()
+
+	// Mock some blocks in the storage.
+	bkt = BucketWithGlobalMarkers(bkt)
+	bkt = objstore.BucketWithMetrics("test-bucket", bkt, registry)
+	block1 := testutil.MockStorageBlock(t, bkt, userID, 10, 20)
+	block2 := testutil.MockStorageBlock(t, bkt, userID, 20, 30)
+	block3 := testutil.MockStorageBlock(t, bkt, userID, 30, 40)
+	block2Mark := testutil.MockStorageDeletionMark(t, bkt, userID, block2)
+
+	// Delete a block's meta.json to simulate a partial block.
+	require.NoError(t, bkt.Delete(ctx, path.Join(userID, block3.ULID.String(), metadata.MetaFilename)))
+
+	w := NewUpdater(bkt, userID, nil, logger)
+	idx, partials, _, err := w.UpdateIndex(ctx, nil)
+	require.NoError(t, err)
+	assertBucketIndexEqual(t, idx, bkt, userID,
+		[]tsdb.BlockMeta{block1, block2},
+		[]*metadata.DeletionMark{block2Mark})
+
+	assert.Len(t, partials, 1)
+	assert.True(t, errors.Is(partials[block3.ULID], ErrBlockMetaNotFound))
+
+	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
+			# HELP thanos_objstore_bucket_operation_failures_total Total number of operations against a bucket that failed, but were not expected to fail in certain way from caller perspective. Those errors have to be investigated.
+			# TYPE thanos_objstore_bucket_operation_failures_total counter
+			thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="attributes"} 0
+            thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="delete"} 0
+            thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="exists"} 0
+            thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="get"} 0
+            thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="get_range"} 0
+            thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="iter"} 0
+            thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="upload"} 0
+		`), "thanos_objstore_bucket_operation_failures_total"))
 }
 
 func TestUpdater_UpdateIndex_ShouldSkipBlocksWithCorruptedMeta(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
Bucket index updater should ignore meta not found for partial blocks to avoid increasing `thanos_objstore_bucket_operation_failures_total` metric when checking partial blocks.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
