### PR TITLE
Optimize the decoding of SampleStream

### DIFF
--- a/pkg/querier/tripperware/instantquery/instant_query_test.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_test.go
@@ -11,14 +11,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/querier/tripperware"
+
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
-
-	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 )
 
 func TestRequest(t *testing.T) {
@@ -493,7 +493,6 @@ func Benchmark_Decode(b *testing.B) {
 
 			body, err := json.Marshal(r)
 			require.NoError(b, err)
-
 
 			b.ResetTimer()
 			b.ReportAllocs()

--- a/pkg/querier/tripperware/instantquery/instant_query_test.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_test.go
@@ -11,14 +11,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/querier/tripperware"
-
-	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/cortexpb"
+	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 )
 
 func TestRequest(t *testing.T) {

--- a/pkg/querier/tripperware/instantquery/instant_query_test.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/cortexpb"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
@@ -443,4 +445,68 @@ func Test_sortPlanForQuery(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Benchmark_Decode(b *testing.B) {
+	maxSamplesCount := 1000000
+	samples := make([]tripperware.SampleStream, maxSamplesCount)
+
+	for i := 0; i < maxSamplesCount; i++ {
+		samples[i].Labels = append(samples[i].Labels, cortexpb.LabelAdapter{Name: fmt.Sprintf("Sample%v", i), Value: fmt.Sprintf("Value%v", i)})
+		samples[i].Labels = append(samples[i].Labels, cortexpb.LabelAdapter{Name: fmt.Sprintf("Sample2%v", i), Value: fmt.Sprintf("Value2%v", i)})
+		samples[i].Labels = append(samples[i].Labels, cortexpb.LabelAdapter{Name: fmt.Sprintf("Sample3%v", i), Value: fmt.Sprintf("Value3%v", i)})
+		samples[i].Samples = append(samples[i].Samples, cortexpb.Sample{TimestampMs: int64(i), Value: float64(i)})
+	}
+
+	for name, tc := range map[string]struct {
+		sampleStream []tripperware.SampleStream
+	}{
+		"100 samples": {
+			sampleStream: samples[:100],
+		},
+		"1000 samples": {
+			sampleStream: samples[:1000],
+		},
+		"10000 samples": {
+			sampleStream: samples[:10000],
+		},
+		"100000 samples": {
+			sampleStream: samples[:100000],
+		},
+		"1000000 samples": {
+			sampleStream: samples[:1000000],
+		},
+	} {
+		b.Run(name, func(b *testing.B) {
+			r := PrometheusInstantQueryResponse{
+				Data: PrometheusInstantQueryData{
+					ResultType: model.ValMatrix.String(),
+					Result: PrometheusInstantQueryResult{
+						Result: &PrometheusInstantQueryResult_Matrix{
+							Matrix: &Matrix{
+								SampleStreams: tc.sampleStream,
+							},
+						},
+					},
+				},
+			}
+
+			body, err := json.Marshal(r)
+			require.NoError(b, err)
+
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				response := &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewBuffer(body)),
+				}
+				_, err := InstantQueryCodec.DecodeResponse(context.Background(), response, nil)
+				require.NoError(b, err)
+			}
+		})
+	}
+
 }

--- a/pkg/querier/tripperware/query.go
+++ b/pkg/querier/tripperware/query.go
@@ -83,6 +83,31 @@ type Request interface {
 	WithStats(stats string) Request
 }
 
+func decodeSampleStream(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+	lbls := labels.Labels{}
+	samples := []cortexpb.Sample{}
+	for field := iter.ReadObject(); field != ""; field = iter.ReadObject() {
+		switch field {
+		case "metric":
+			iter.ReadVal(&lbls)
+		case "values":
+			for  {
+				if !iter.ReadArray() {
+					break
+				}
+				s := cortexpb.Sample{}
+				cortexpb.SampleJsoniterDecode(unsafe.Pointer(&s), iter)
+				samples = append(samples, s)
+			}
+		}
+	}
+
+	*(*SampleStream)(ptr) = SampleStream{
+		Samples: samples,
+		Labels: cortexpb.FromLabelsToLabelAdapters(lbls),
+	}
+}
+
 func encodeSampleStream(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	ss := (*SampleStream)(ptr)
 	stream.WriteObjectStart()
@@ -160,6 +185,7 @@ func init() {
 	jsoniter.RegisterTypeEncoderFunc("tripperware.PrometheusResponseQueryableSamplesStatsPerStep", PrometheusResponseQueryableSamplesStatsPerStepJsoniterEncode, func(unsafe.Pointer) bool { return false })
 	jsoniter.RegisterTypeDecoderFunc("tripperware.PrometheusResponseQueryableSamplesStatsPerStep", PrometheusResponseQueryableSamplesStatsPerStepJsoniterDecode)
 	jsoniter.RegisterTypeEncoderFunc("tripperware.SampleStream", encodeSampleStream, func(unsafe.Pointer) bool { return false })
+	jsoniter.RegisterTypeDecoderFunc("tripperware.SampleStream", decodeSampleStream)
 }
 
 func EncodeTime(t int64) string {

--- a/pkg/querier/tripperware/query.go
+++ b/pkg/querier/tripperware/query.go
@@ -91,7 +91,7 @@ func decodeSampleStream(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 		case "metric":
 			iter.ReadVal(&lbls)
 		case "values":
-			for  {
+			for {
 				if !iter.ReadArray() {
 					break
 				}
@@ -104,7 +104,7 @@ func decodeSampleStream(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 
 	*(*SampleStream)(ptr) = SampleStream{
 		Samples: samples,
-		Labels: cortexpb.FromLabelsToLabelAdapters(lbls),
+		Labels:  cortexpb.FromLabelsToLabelAdapters(lbls),
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:
Create jsoniter SampleStream Decoder to optimize its deserialization.

QueryFrontend can benefit from this as it deserialize the responses from the queriers:

```
goos: linux
goarch: amd64
pkg: github.com/cortexproject/cortex/pkg/querier/tripperware/instantquery
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
                           │   /tmp/old   │              /tmp/new               │
                           │    sec/op    │    sec/op     vs base               │
_Decode/100_samples-32       280.5µ ± ∞ ¹   209.3µ ± ∞ ¹  -25.36% (p=0.008 n=5)
_Decode/1000_samples-32      2.875m ± ∞ ¹   2.133m ± ∞ ¹  -25.82% (p=0.008 n=5)
_Decode/10000_samples-32     28.83m ± ∞ ¹   21.55m ± ∞ ¹  -25.24% (p=0.008 n=5)
_Decode/100000_samples-32    304.5m ± ∞ ¹   247.3m ± ∞ ¹  -18.79% (p=0.008 n=5)
_Decode/1000000_samples-32    3.060 ± ∞ ¹    2.379 ± ∞ ¹  -22.27% (p=0.008 n=5)
geomean                      29.32m         22.42m        -23.54%
¹ need >= 6 samples for confidence interval at level 0.95

                           │   /tmp/old    │               /tmp/new               │
                           │     B/op      │     B/op       vs base               │
_Decode/100_samples-32       129.3Ki ± ∞ ¹   109.1Ki ± ∞ ¹  -15.67% (p=0.008 n=5)
_Decode/1000_samples-32      1.213Mi ± ∞ ¹   1.001Mi ± ∞ ¹  -17.49% (p=0.008 n=5)
_Decode/10000_samples-32     15.64Mi ± ∞ ¹   13.36Mi ± ∞ ¹  -14.53% (p=0.008 n=5)
_Decode/100000_samples-32    150.7Mi ± ∞ ¹   127.8Mi ± ∞ ¹  -15.18% (p=0.008 n=5)
_Decode/1000000_samples-32   1.422Gi ± ∞ ¹   1.185Gi ± ∞ ¹  -16.66% (p=0.008 n=5)
geomean                      13.93Mi         11.72Mi        -15.91%
¹ need >= 6 samples for confidence interval at level 0.95

                           │   /tmp/old   │              /tmp/new               │
                           │  allocs/op   │  allocs/op    vs base               │
_Decode/100_samples-32       2.839k ± ∞ ¹   2.239k ± ∞ ¹  -21.13% (p=0.008 n=5)
_Decode/1000_samples-32      28.05k ± ∞ ¹   22.05k ± ∞ ¹  -21.39% (p=0.008 n=5)
_Decode/10000_samples-32     280.1k ± ∞ ¹   220.1k ± ∞ ¹  -21.42% (p=0.008 n=5)
_Decode/100000_samples-32    2.800M ± ∞ ¹   2.200M ± ∞ ¹  -21.43% (p=0.008 n=5)
_Decode/1000000_samples-32   28.00M ± ∞ ¹   22.00M ± ∞ ¹  -21.43% (p=0.008 n=5)
geomean                      280.9k         220.9k        -21.36%
¹ need >= 6 samples for confidence interval at level 0.95
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
