### PR TITLE
Do not resync blocks in running store gateways during rollout deployment and container restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [BUGFIX] Storage: Bucket index updater should ignore meta not found for partial blocks. #5343
 * [BUGFIX] Ring: Add JOINING state to read operation. #5346
 * [BUGFIX] Compactor: Partial block with only visit marker should be deleted even there is no deletion marker. #5342
+* [ENHANCEMENT] Do not resync blocks in running store gateways during rollout deployment and container restart. #5363
 
 ## 1.15.1 2023-04-26
 

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -147,12 +147,13 @@ func HasReplicationSetChangedWithoutState(before, after ReplicationSet) bool {
 
 // HasReplicationSetChangedWithoutStateAndAddress returns false if two replications sets
 // are the same (with possibly different timestamps, instance states and address),
-// true if they differ in any other way (number of instances, tokens, zones, ...).
+// true if they differ in any other way (number of instances, tokens, or zones).
 func HasReplicationSetChangedWithoutStateAndAddress(before, after ReplicationSet) bool {
 	return hasReplicationSetChangedExcluding(before, after, func(i *InstanceDesc) {
 		i.Timestamp = 0
 		i.State = PENDING
 		i.Addr = ""
+		i.RegisteredTimestamp = 0
 	})
 }
 

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -127,21 +127,32 @@ func (r ReplicationSet) GetAddressesWithout(exclude string) []string {
 	return addrs
 }
 
-// HasReplicationSetChanged returns true if two replications sets are the same (with possibly different timestamps),
-// false if they differ in any way (number of instances, instance states, tokens, zones, ...).
+// HasReplicationSetChanged returns false if two replications sets are the same (with possibly different timestamps),
+// true if they differ in any way (number of instances, instance states, tokens, zones, ...).
 func HasReplicationSetChanged(before, after ReplicationSet) bool {
 	return hasReplicationSetChangedExcluding(before, after, func(i *InstanceDesc) {
 		i.Timestamp = 0
 	})
 }
 
-// HasReplicationSetChangedWithoutState returns true if two replications sets
+// HasReplicationSetChangedWithoutState returns false if two replications sets
 // are the same (with possibly different timestamps and instance states),
-// false if they differ in any other way (number of instances, tokens, zones, ...).
+// true if they differ in any other way (number of instances, tokens, zones, ...).
 func HasReplicationSetChangedWithoutState(before, after ReplicationSet) bool {
 	return hasReplicationSetChangedExcluding(before, after, func(i *InstanceDesc) {
 		i.Timestamp = 0
 		i.State = PENDING
+	})
+}
+
+// HasReplicationSetChangedWithoutStateAndAddress returns false if two replications sets
+// are the same (with possibly different timestamps, instance states and address),
+// true if they differ in any other way (number of instances, tokens, zones, ...).
+func HasReplicationSetChangedWithoutStateAndAddress(before, after ReplicationSet) bool {
+	return hasReplicationSetChangedExcluding(before, after, func(i *InstanceDesc) {
+		i.Timestamp = 0
+		i.State = PENDING
+		i.Addr = ""
 	})
 }
 

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -251,9 +251,10 @@ var (
 		},
 	}
 	replicationSetChangesTestCases = map[string]struct {
-		nextState                                  ReplicationSet
-		expectHasReplicationSetChanged             bool
-		expectHasReplicationSetChangedWithoutState bool
+		nextState                                            ReplicationSet
+		expectHasReplicationSetChanged                       bool
+		expectHasReplicationSetChangedWithoutState           bool
+		expectHasReplicationSetChangedWithoutStateAndAddress bool
 	}{
 		"timestamp changed": {
 			ReplicationSet{
@@ -263,6 +264,7 @@ var (
 					{Addr: "127.0.0.3"},
 				},
 			},
+			false,
 			false,
 			false,
 		},
@@ -276,6 +278,7 @@ var (
 			},
 			true,
 			false,
+			false,
 		},
 		"more instances": {
 			ReplicationSet{
@@ -288,6 +291,30 @@ var (
 			},
 			true,
 			true,
+			true,
+		},
+		"less instances": {
+			ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "127.0.0.1"},
+					{Addr: "127.0.0.2"},
+				},
+			},
+			true,
+			true,
+			true,
+		},
+		"replaced instance": {
+			ReplicationSet{
+				Instances: []InstanceDesc{
+					{Addr: "127.0.0.1"},
+					{Addr: "127.0.0.2"},
+					{Addr: "127.0.0.5"},
+				},
+			},
+			true,
+			true,
+			false,
 		},
 	}
 )
@@ -306,6 +333,15 @@ func TestHasReplicationSetChangedWithoutState_IgnoresTimeStampAndState(t *testin
 	for testName, testData := range replicationSetChangesTestCases {
 		t.Run(testName, func(t *testing.T) {
 			assert.Equal(t, testData.expectHasReplicationSetChangedWithoutState, HasReplicationSetChangedWithoutState(replicationSetChangesInitialState, testData.nextState), "HasReplicationSetChangedWithoutState wrong result")
+		})
+	}
+}
+
+func TestHasReplicationSetChangedWithoutStateAndAddress_IgnoresTimeStampAndStateAndAddress(t *testing.T) {
+	// Only testing difference to underlying Equal function
+	for testName, testData := range replicationSetChangesTestCases {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, testData.expectHasReplicationSetChangedWithoutStateAndAddress, HasReplicationSetChangedWithoutStateAndAddress(replicationSetChangesInitialState, testData.nextState), "HasReplicationSetChangedWithoutStateAndAddress wrong result")
 		})
 	}
 }

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -299,7 +299,8 @@ func (g *StoreGateway) running(ctx context.Context) error {
 			// replication set which we use to compare with the previous state.
 			currRingState, _ := g.ring.GetAllHealthy(BlocksOwnerSync) // nolint:errcheck
 
-			if ring.HasReplicationSetChanged(ringLastState, currRingState) {
+			// Ignore address when comparing to avoid block re-sync if tokens are persisted with tokens_file_path
+			if ring.HasReplicationSetChangedWithoutStateAndAddress(ringLastState, currRingState) {
 				ringLastState = currRingState
 				g.syncStores(ctx, syncReasonRingChange)
 			}

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -615,7 +615,7 @@ func TestStoreGateway_SyncOnRingTopologyChanged(t *testing.T) {
 			},
 			expectedSync: true,
 		},
-		"should sync when an instance changes state": {
+		"should NOT sync when an instance changes state": {
 			setupRing: func(desc *ring.Desc) {
 				desc.AddIngester("instance-1", "127.0.0.1", "", ring.Tokens{1, 2, 3}, ring.ACTIVE, registeredAt)
 				desc.AddIngester("instance-2", "127.0.0.2", "", ring.Tokens{4, 5, 6}, ring.JOINING, registeredAt)
@@ -625,7 +625,19 @@ func TestStoreGateway_SyncOnRingTopologyChanged(t *testing.T) {
 				instance.State = ring.ACTIVE
 				desc.Ingesters["instance-2"] = instance
 			},
-			expectedSync: true,
+			expectedSync: false,
+		},
+		"should NOT sync when an instance address is replaced": {
+			setupRing: func(desc *ring.Desc) {
+				desc.AddIngester("instance-1", "127.0.0.1", "", ring.Tokens{1, 2, 3}, ring.ACTIVE, registeredAt)
+				desc.AddIngester("instance-2", "127.0.0.2", "", ring.Tokens{4, 5, 6}, ring.JOINING, registeredAt)
+			},
+			updateRing: func(desc *ring.Desc) {
+				instance := desc.Ingesters["instance-2"]
+				instance.Addr = "127.0.0.3"
+				desc.Ingesters["instance-2"] = instance
+			},
+			expectedSync: false,
 		},
 		"should sync when an healthy instance becomes unhealthy": {
 			setupRing: func(desc *ring.Desc) {

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -382,7 +382,7 @@ func TestStoreGateway_BlocksSyncWithDefaultSharding_RingTopologyChangedAfterScal
 		shardingStrategy     = util.ShardingStrategyDefault
 		replicationFactor    = 3
 		numInitialGateways   = 4
-		numScaleUpGateways   = 6
+		numScaleUpGateways   = 2
 		expectedBlocksLoaded = 3 * numBlocks // blocks are replicated 3 times
 	)
 


### PR DESCRIPTION
**What this PR does**:

### Problem
Currently the logic for existing store gateway instances to re-sync block is too aggressive, leading to unnecessary re-sync when pods are restarted due to OOM or when doing rollout deployment.
Unnecessary re-sync increases chance of OOM and query unavailability.

### Current Behavior
- `ring.HasReplicationSetChanged` is used to determine whether re-sync should be performed (true if number of instances, or state/address/token of any instance changes)
- Store gateway is scaled up => Number of instances in the ring is increased, then the instance state changes from JOINING -> ACTIVE => existing instances re-sync blocks at most twice, once for number of instance change and once for state change
- Store gateway is scaled down => Instance state changes from ACTIVE -> LEAVING, then number of instances in the ring is decreased => existing instances re-sync blocks at most twice, once for state change and once for number of instance change
- Store gateway instance is restarted (OOM) => Instance state changes from ACTIVE -> JOINING -> ACTIVE => existing instances re-sync blocks at most twice, both for state change
- Store gateway instance is replaced by a new instance (rollout deployment) => Instance state changes from ACTIVE -> LEAVING, instance address changes, then new instance state changes from JOINING -> ACTIVE => existing instances re-sync blocks at most three times, twice for state change and once for address change

### Proposed Behavior

- `ring.HasReplicationSetChangedWithoutStateAndAddress` is used to determine whether re-sync should be performed (true if number of instances, or token of any instance changes)
- Store gateway is scaled up => Number of instances in the ring is increased, then the instance state changes from JOINING -> ACTIVE => existing instances re-sync blocks at most once for number of instance change
- Store gateway is scaled down => Instance state changes from ACTIVE -> LEAVING, then number of instances in the ring is decreased => existing instances re-sync blocks at most once for number of instance change
- Store gateway instance is restarted (OOM) => Instance state changes from ACTIVE -> JOINING -> ACTIVE => existing instances do not re-sync blocks
- Store gateway instance is replaced by a new instance (rollout deployment) => Instance state changes from ACTIVE -> LEAVING, instance address changes, then new instance state changes from JOINING -> ACTIVE => existing instances do not re-sync blocks if `tokens_file_path` is set. Otherwise, existing instances re-sync blocks once

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
