### PR TITLE
Update single instance, single process example in the getting started document

### DIFF
--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -57,6 +57,11 @@ $ docker run --rm -d --name=grafana -p 3000:3000 grafana/grafana
 
 In [the Grafana UI](http://localhost:3000) (username/password admin/admin), add a Prometheus datasource for Cortex (`http://host.docker.internal:9009/prometheus`).
 
+If you are on a Linux machine, `http://host.docker.internal:9009` might not work for you.
+In this case, you will need to use the IP address of your host machine.
+You can usually get it by running `hostname -I | awk '{print $1}'` in your terminal.
+For example, if the IP is `192.168.1.100`, use `http://192.168.1.100:9009/prometheus`.
+
 **To clean up:** press CTRL-C in both terminals (for Cortex and Prometheus).
 
 ## Horizontally scale out


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
I was following [the single instance, single process set up](https://cortexmetrics.io/docs/getting-started/#single-instance-single-process) for Cortex but when I was trying to add data source using `http://host.docker.internal`, I was getting this error:

`Error reading Prometheus: Post "http://host.docker.internal:9009/prometheus/api/v1/query": dial tcp: lookup host.docker.internal on 192.168.1.1:53: no such host`

I guess, `host.docker.internal` is not supported before Ubuntu 20.04. Even though I am using Ubuntu 22.04, I still got that error.

So, I created this PR for the folks who face this problem so that they can run `hostname -I | awk '{print $1}'` and paste the result to Grafana and can have Grafana up and running.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
