### PR TITLE
Added timeouts to contexts when calling etcd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [BUGFIX] Storage: Bucket index updater should ignore meta not found for partial blocks. #5343
 * [BUGFIX] Ring: Add JOINING state to read operation. #5346
 * [BUGFIX] Compactor: Partial block with only visit marker should be deleted even there is no deletion marker. #5342
+* [BUGFIX] KV: Etcd calls will no longer block indefinitely and will now time out after the DialTimeout period. #5392
 
 ## 1.15.1 2023-04-26
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds context timeouts to calls to etcd from the KV store etcd implementation.

When called with a context without deadline, underlying calls to etcd from the etcd implementation of KV store can block forever when etcd is unavailable, emitting no logs or KV metrics indicating the problem.

For consistency and predictability, this PR adds timeouts to the context at the KV store level, rather than relying on clients of the KV store to specify deadlines at every call. This allows calls to timeout and emit metrics that can be alerted and acted on.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
