### PR TITLE
Add additional bucket store metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,14 @@
 * [ENHANCEMENT] Improving Performance on the API Gzip Handler. #5347
 * [ENHANCEMENT] Dynamodb: Add `puller-sync-time` to allow different pull time for ring. #5357
 * [ENHANCEMENT] Emit querier `max_concurrent` as a metric. #5362
+* [ENHANCEMENT] Do not resync blocks in running store gateways during rollout deployment and container restart. #5363
+* [ENHANCEMENT] Store Gateway: Add new metrics `cortex_bucket_store_sent_chunk_size_bytes`, `cortex_bucket_store_postings_size_bytes` and `cortex_bucket_store_empty_postings_total`. #5397
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293
 * [BUGFIX] Storage: Bucket index updater should ignore meta not found for partial blocks. #5343
 * [BUGFIX] Ring: Add JOINING state to read operation. #5346
 * [BUGFIX] Compactor: Partial block with only visit marker should be deleted even there is no deletion marker. #5342
-* [ENHANCEMENT] Do not resync blocks in running store gateways during rollout deployment and container restart. #5363
 
 ## 1.15.1 2023-04-26
 

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -27,6 +27,9 @@ type BucketStoreMetrics struct {
 	seriesRefetches       *prometheus.Desc
 	resultSeriesCount     *prometheus.Desc
 	queriesDropped        *prometheus.Desc
+	chunkSizeBytes        *prometheus.Desc
+	postingsSizeBytes     *prometheus.Desc
+	emptyPostingCount     *prometheus.Desc
 
 	cachedPostingsCompressions           *prometheus.Desc
 	cachedPostingsCompressionErrors      *prometheus.Desc
@@ -109,6 +112,18 @@ func NewBucketStoreMetrics() *BucketStoreMetrics {
 			"cortex_bucket_store_queries_dropped_total",
 			"Number of queries that were dropped due to the max chunks per query limit.",
 			nil, nil),
+		chunkSizeBytes: prometheus.NewDesc(
+			"cortex_bucket_store_sent_chunk_size_bytes",
+			"Size in bytes of the chunks for the single series, which is adequate to the gRPC message size sent to querier.",
+			nil, nil),
+		postingsSizeBytes: prometheus.NewDesc(
+			"cortex_bucket_store_postings_size_bytes",
+			"Size in bytes of the postings for a single series call.",
+			nil, nil),
+		emptyPostingCount: prometheus.NewDesc(
+			"cortex_bucket_store_empty_postings_total",
+			"Total number of empty postings when fetching block series.",
+			nil, nil),
 
 		cachedPostingsCompressions: prometheus.NewDesc(
 			"cortex_bucket_store_cached_postings_compressions_total",
@@ -187,6 +202,9 @@ func (m *BucketStoreMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.seriesRefetches
 	out <- m.resultSeriesCount
 	out <- m.queriesDropped
+	out <- m.chunkSizeBytes
+	out <- m.postingsSizeBytes
+	out <- m.emptyPostingCount
 
 	out <- m.cachedPostingsCompressions
 	out <- m.cachedPostingsCompressionErrors
@@ -225,6 +243,9 @@ func (m *BucketStoreMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCounters(out, m.seriesRefetches, "thanos_bucket_store_series_refetches_total")
 	data.SendSumOfHistograms(out, m.resultSeriesCount, "thanos_bucket_store_series_result_series")
 	data.SendSumOfCounters(out, m.queriesDropped, "thanos_bucket_store_queries_dropped_total")
+	data.SendSumOfHistograms(out, m.chunkSizeBytes, "thanos_bucket_store_sent_chunk_size_bytes")
+	data.SendSumOfHistograms(out, m.postingsSizeBytes, "thanos_bucket_store_postings_size_bytes")
+	data.SendSumOfCounters(out, m.emptyPostingCount, "thanos_bucket_store_empty_postings_total")
 
 	data.SendSumOfCountersWithLabels(out, m.cachedPostingsCompressions, "thanos_bucket_store_cached_postings_compressions_total", "op")
 	data.SendSumOfCountersWithLabels(out, m.cachedPostingsCompressionErrors, "thanos_bucket_store_cached_postings_compression_errors_total", "op")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Add some other bucket store metrics from store gateway. They are:
- `cortex_bucket_store_sent_chunk_size_bytes` a histogram to understand how much chunk size per request
- `cortex_bucket_store_postings_size_bytes ` a histogram to understand how much posting size we have per request
- `cortex_bucket_store_empty_postings_total ` a counter to know how many empty postings we have

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
