### PR TITLE
Add jitter for heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * [ENHANCEMENT] Emit querier `max_concurrent` as a metric. #5362
 * [ENHANCEMENT] Do not resync blocks in running store gateways during rollout deployment and container restart. #5363
 * [ENHANCEMENT] Store Gateway: Add new metrics `cortex_bucket_store_sent_chunk_size_bytes`, `cortex_bucket_store_postings_size_bytes` and `cortex_bucket_store_empty_postings_total`. #5397
-* [ENHANCEMENT] Add jitter to lifecycler heartbeat. #
+* [ENHANCEMENT] Add jitter to lifecycler heartbeat. #5404
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [ENHANCEMENT] Emit querier `max_concurrent` as a metric. #5362
 * [ENHANCEMENT] Do not resync blocks in running store gateways during rollout deployment and container restart. #5363
 * [ENHANCEMENT] Store Gateway: Add new metrics `cortex_bucket_store_sent_chunk_size_bytes`, `cortex_bucket_store_postings_size_bytes` and `cortex_bucket_store_empty_postings_total`. #5397
+* [ENHANCEMENT] Add jitter to lifecycler heartbeat. #
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -3,6 +3,7 @@ package ring
 import (
 	"context"
 	"fmt"
+	mathrand "math/rand"
 	"sort"
 	"sync"
 	"time"
@@ -185,11 +186,22 @@ func (l *BasicLifecycler) starting(ctx context.Context) error {
 }
 
 func (l *BasicLifecycler) running(ctx context.Context) error {
-	heartbeatTickerStop, heartbeatTickerChan := newDisableableTicker(l.cfg.HeartbeatPeriod)
-	defer heartbeatTickerStop()
+	var heartbeatTickerChan <-chan time.Time
+	if uint64(l.cfg.HeartbeatPeriod) > 0 {
+		heartbeatTicker := time.NewTicker(l.cfg.HeartbeatPeriod)
+		heartbeatTicker.Stop()
+		time.AfterFunc(time.Duration(uint64(mathrand.Int63())%uint64(l.cfg.HeartbeatPeriod)), func() {
+			l.heartbeat(ctx)
+			heartbeatTicker.Reset(l.cfg.HeartbeatPeriod)
+		})
+		defer heartbeatTicker.Stop()
+
+		heartbeatTickerChan = heartbeatTicker.C
+	}
 
 	for {
 		select {
+
 		case <-heartbeatTickerChan:
 			l.heartbeat(ctx)
 

--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -201,7 +201,6 @@ func (l *BasicLifecycler) running(ctx context.Context) error {
 
 	for {
 		select {
-
 		case <-heartbeatTickerChan:
 			l.heartbeat(ctx)
 

--- a/pkg/ring/ticker.go
+++ b/pkg/ring/ticker.go
@@ -1,6 +1,8 @@
 package ring
 
-import "time"
+import (
+	"time"
+)
 
 // newDisableableTicker essentially wraps NewTicker but allows the ticker to be disabled by passing
 // zero duration as the interval. Returns a function for stopping the ticker, and the ticker channel.

--- a/pkg/ring/ticker.go
+++ b/pkg/ring/ticker.go
@@ -1,8 +1,6 @@
 package ring
 
-import (
-	"time"
-)
+import "time"
 
 // newDisableableTicker essentially wraps NewTicker but allows the ticker to be disabled by passing
 // zero duration as the interval. Returns a function for stopping the ticker, and the ticker channel.


### PR DESCRIPTION
**What this PR does**:
In some cases where the service scale at the same moment, cortex can create a influx of message in the same time. This helps spread the load in the kv store.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
