### PR TITLE
Apply WaitStabilityMinDuration when syncing blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [ENHANCEMENT] Store Gateway: Add new metrics `cortex_bucket_store_sent_chunk_size_bytes`, `cortex_bucket_store_postings_size_bytes` and `cortex_bucket_store_empty_postings_total`. #5397
 * [ENHANCEMENT] Add jitter to lifecycler heartbeat. #5404
 * [ENHANCEMENT] Store Gateway: Add config `estimated_max_series_size_bytes` and `estimated_max_chunk_size_bytes` to address data overfetch. #5401
+* [ENHANCEMENT] Store Gateway: Apply WaitStabilityMinDuration when syncing blocks #5406
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -282,13 +282,14 @@ store_gateway:
     # CLI flag: -store-gateway.sharding-ring.zone-awareness-enabled
     [zone_awareness_enabled: <boolean> | default = false]
 
-    # Minimum time to wait for ring stability at startup. 0 to disable.
+    # Minimum time to wait for ring stability at startup and ring change. 0 to
+    # disable.
     # CLI flag: -store-gateway.sharding-ring.wait-stability-min-duration
     [wait_stability_min_duration: <duration> | default = 1m]
 
-    # Maximum time to wait for ring stability at startup. If the store-gateway
-    # ring keeps changing after this period of time, the store-gateway will
-    # start anyway.
+    # Maximum time to wait for ring stability at startup and ring change. If the
+    # store-gateway ring keeps changing after this period of time, the
+    # store-gateway will start or sync anyway.
     # CLI flag: -store-gateway.sharding-ring.wait-stability-max-duration
     [wait_stability_max_duration: <duration> | default = 5m]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4797,13 +4797,14 @@ sharding_ring:
   # CLI flag: -store-gateway.sharding-ring.zone-awareness-enabled
   [zone_awareness_enabled: <boolean> | default = false]
 
-  # Minimum time to wait for ring stability at startup. 0 to disable.
+  # Minimum time to wait for ring stability at startup and ring change. 0 to
+  # disable.
   # CLI flag: -store-gateway.sharding-ring.wait-stability-min-duration
   [wait_stability_min_duration: <duration> | default = 1m]
 
-  # Maximum time to wait for ring stability at startup. If the store-gateway
-  # ring keeps changing after this period of time, the store-gateway will start
-  # anyway.
+  # Maximum time to wait for ring stability at startup and ring change. If the
+  # store-gateway ring keeps changing after this period of time, the
+  # store-gateway will start or sync anyway.
   # CLI flag: -store-gateway.sharding-ring.wait-stability-max-duration
   [wait_stability_max_duration: <duration> | default = 5m]
 

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -145,10 +145,9 @@ func HasReplicationSetChangedWithoutState(before, after ReplicationSet) bool {
 	})
 }
 
-// HasReplicationSetChangedWithoutStateAndAddress returns false if two replications sets
-// are the same (with possibly different timestamps, instance states and address),
-// true if they differ in any other way (number of instances, tokens, or zones).
-func HasReplicationSetChangedWithoutStateAndAddress(before, after ReplicationSet) bool {
+// HasReplicationSetTokensOrZonesChanged returns true if two replications sets
+// are different in number of instances, tokens and zones, false otherwise.
+func HasReplicationSetTokensOrZonesChanged(before, after ReplicationSet) bool {
 	return hasReplicationSetChangedExcluding(before, after, func(i *InstanceDesc) {
 		i.Timestamp = 0
 		i.State = PENDING

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -341,7 +341,7 @@ func TestHasReplicationSetChangedWithoutStateAndAddress_IgnoresTimeStampAndState
 	// Only testing difference to underlying Equal function
 	for testName, testData := range replicationSetChangesTestCases {
 		t.Run(testName, func(t *testing.T) {
-			assert.Equal(t, testData.expectHasReplicationSetChangedWithoutStateAndAddress, HasReplicationSetChangedWithoutStateAndAddress(replicationSetChangesInitialState, testData.nextState), "HasReplicationSetChangedWithoutStateAndAddress wrong result")
+			assert.Equal(t, testData.expectHasReplicationSetChangedWithoutStateAndAddress, HasReplicationSetTokensOrZonesChanged(replicationSetChangesInitialState, testData.nextState), "HasReplicationSetChangedWithoutStateAndAddress wrong result")
 		})
 	}
 }

--- a/pkg/ring/util.go
+++ b/pkg/ring/util.go
@@ -99,13 +99,11 @@ func WaitRingStability(ctx context.Context, r *Ring, op Operation, minStability,
 	return waitStability(ctx, r, op, minStability, maxWaiting, HasReplicationSetChanged)
 }
 
-// WaitRingTokensStability waits for the Ring to be unchanged at
-// least for minStability time period, excluding transitioning between
-// allowed states (e.g. JOINING->ACTIVE if allowed by op).
-// This can be used to avoid wasting resources on moving data around
+// WaitRingTokensAndZonesStability waits for the Ring tokens and zones to be unchanged at least
+// for minStability time period. This can be used to avoid wasting resources on moving data around
 // due to multiple changes in the Ring.
-func WaitRingTokensStability(ctx context.Context, r *Ring, op Operation, minStability, maxWaiting time.Duration) error {
-	return waitStability(ctx, r, op, minStability, maxWaiting, HasReplicationSetChangedWithoutState)
+func WaitRingTokensAndZonesStability(ctx context.Context, r *Ring, op Operation, minStability, maxWaiting time.Duration) error {
+	return waitStability(ctx, r, op, minStability, maxWaiting, HasReplicationSetTokensOrZonesChanged)
 }
 
 func waitStability(ctx context.Context, r *Ring, op Operation, minStability, maxWaiting time.Duration, isChanged func(ReplicationSet, ReplicationSet) bool) error {

--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -138,7 +138,7 @@ func TestWaitRingStability_ShouldReturnAsSoonAsMinStabilityIsReachedOnNoChanges(
 	assert.Less(t, elapsedTime, 2*minStability)
 }
 
-func TestWaitRingTokensStability_ShouldReturnAsSoonAsMinStabilityIsReachedOnNoChanges(t *testing.T) {
+func TestWaitRingTokensAndZonesStability_ShouldReturnAsSoonAsMinStabilityIsReachedOnNoChanges(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -149,7 +149,7 @@ func TestWaitRingTokensStability_ShouldReturnAsSoonAsMinStabilityIsReachedOnNoCh
 	ring := createStartingRing()
 
 	startTime := time.Now()
-	require.NoError(t, WaitRingTokensStability(context.Background(), ring, Reporting, minStability, maxWaiting))
+	require.NoError(t, WaitRingTokensAndZonesStability(context.Background(), ring, Reporting, minStability, maxWaiting))
 	elapsedTime := time.Since(startTime)
 
 	assert.GreaterOrEqual(t, elapsedTime, minStability)
@@ -195,7 +195,7 @@ func TestWaitRingStability_ShouldReturnOnceMinStabilityOfInstancesHasBeenReached
 	assert.LessOrEqual(t, elapsedTime, minStability+addInstanceAfter+3*time.Second)
 }
 
-func TestWaitRingTokensStability_ShouldReturnOnceMinStabilityOfInstancesHasBeenReached(t *testing.T) {
+func TestWaitRingTokensAndZonesStability_ShouldReturnOnceMinStabilityOfInstancesHasBeenReached(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -210,7 +210,7 @@ func TestWaitRingTokensStability_ShouldReturnOnceMinStabilityOfInstancesHasBeenR
 	addInstanceAfterSomeTime(ring, addInstanceAfter)
 
 	startTime := time.Now()
-	require.NoError(t, WaitRingTokensStability(context.Background(), ring, Reporting, minStability, maxWaiting))
+	require.NoError(t, WaitRingTokensAndZonesStability(context.Background(), ring, Reporting, minStability, maxWaiting))
 	elapsedTime := time.Since(startTime)
 
 	assert.GreaterOrEqual(t, elapsedTime, minStability+addInstanceAfter)
@@ -264,7 +264,7 @@ func TestWaitRingStability_ShouldReturnErrorIfInstancesAddedAndMaxWaitingIsReach
 	assert.GreaterOrEqual(t, elapsedTime, maxWaiting)
 }
 
-func TestWaitRingTokensStability_ShouldReturnErrorIfInstancesAddedAndMaxWaitingIsReached(t *testing.T) {
+func TestWaitRingTokensAndZonesStability_ShouldReturnErrorIfInstancesAddedAndMaxWaitingIsReached(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -278,7 +278,7 @@ func TestWaitRingTokensStability_ShouldReturnErrorIfInstancesAddedAndMaxWaitingI
 	defer close(done)
 
 	startTime := time.Now()
-	require.Equal(t, context.DeadlineExceeded, WaitRingTokensStability(context.Background(), ring, Reporting, minStability, maxWaiting))
+	require.Equal(t, context.DeadlineExceeded, WaitRingTokensAndZonesStability(context.Background(), ring, Reporting, minStability, maxWaiting))
 	elapsedTime := time.Since(startTime)
 
 	assert.GreaterOrEqual(t, elapsedTime, maxWaiting)
@@ -335,7 +335,7 @@ func TestWaitRingStability_ShouldReturnErrorIfInstanceStateIsChangingAndMaxWaiti
 	assert.GreaterOrEqual(t, elapsedTime, maxWaiting)
 }
 
-func TestWaitRingTokensStability_ShouldReturnOnceMinStabilityOfInstancesHasBeenReachedWhileStateCanChange(t *testing.T) {
+func TestWaitRingTokensAndZonesStability_ShouldReturnOnceMinStabilityOfInstancesHasBeenReachedWhileStateCanChange(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -350,7 +350,7 @@ func TestWaitRingTokensStability_ShouldReturnOnceMinStabilityOfInstancesHasBeenR
 	defer close(done)
 
 	startTime := time.Now()
-	require.NoError(t, WaitRingTokensStability(context.Background(), ring, Reporting, minStability, maxWaiting))
+	require.NoError(t, WaitRingTokensAndZonesStability(context.Background(), ring, Reporting, minStability, maxWaiting))
 	elapsedTime := time.Since(startTime)
 
 	assert.GreaterOrEqual(t, elapsedTime, minStability)

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -209,7 +209,7 @@ func TestBucketStores_SyncBlocks(t *testing.T) {
 
 	// Generate another block and sync blocks again.
 	generateStorageBlock(t, storageDir, userID, metricName, 100, 200, 15)
-	require.NoError(t, stores.SyncBlocks(ctx, false))
+	require.NoError(t, stores.SyncBlocks(ctx))
 
 	seriesSet, warnings, err = querySeries(stores, userID, metricName, 150, 180)
 	require.NoError(t, err)
@@ -257,9 +257,8 @@ func TestBucketStores_syncUsersBlocks(t *testing.T) {
 		shouldUpdateUserList bool
 	}{
 		"when sharding is disabled all users should be synced": {
-			shardingStrategy:     NewNoShardingStrategy(),
-			expectedStores:       3,
-			shouldUpdateUserList: true,
+			shardingStrategy: NewNoShardingStrategy(),
+			expectedStores:   3,
 		},
 		"when sharding is enabled only stores for filtered users should be created": {
 			shardingStrategy: func() ShardingStrategy {
@@ -267,17 +266,7 @@ func TestBucketStores_syncUsersBlocks(t *testing.T) {
 				s.On("FilterUsers", mock.Anything, allUsers).Return([]string{"user-1", "user-2"})
 				return s
 			}(),
-			expectedStores:       2,
-			shouldUpdateUserList: true,
-		},
-		"should not sync any blocks if shouldUpdateUserList was never true": {
-			shardingStrategy: func() ShardingStrategy {
-				s := &mockShardingStrategy{}
-				s.On("FilterUsers", mock.Anything, allUsers).Return([]string{"user-1", "user-2"})
-				return s
-			}(),
-			expectedStores:       0,
-			shouldUpdateUserList: false,
+			expectedStores: 2,
 		},
 	}
 
@@ -294,7 +283,7 @@ func TestBucketStores_syncUsersBlocks(t *testing.T) {
 
 			// Sync user stores and count the number of times the callback is called.
 			var storesCount atomic.Int32
-			err = stores.syncUsersBlocks(context.Background(), testData.shouldUpdateUserList, func(ctx context.Context, bs *store.BucketStore) error {
+			err = stores.syncUsersBlocks(context.Background(), func(ctx context.Context, bs *store.BucketStore) error {
 				storesCount.Inc()
 				return nil
 			})
@@ -505,7 +494,7 @@ func TestBucketStores_deleteLocalFilesForExcludedTenants(t *testing.T) {
 
 	// Single user left in shard.
 	sharding.users = []string{user1}
-	require.NoError(t, stores.SyncBlocks(ctx, true))
+	require.NoError(t, stores.SyncBlocks(ctx))
 	require.Equal(t, []string{user1}, getUsersInDir(t, cfg.BucketStore.SyncDir))
 
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
@@ -522,7 +511,7 @@ func TestBucketStores_deleteLocalFilesForExcludedTenants(t *testing.T) {
 
 	// No users left in this shard.
 	sharding.users = nil
-	require.NoError(t, stores.SyncBlocks(ctx, true))
+	require.NoError(t, stores.SyncBlocks(ctx))
 	require.Equal(t, []string(nil), getUsersInDir(t, cfg.BucketStore.SyncDir))
 
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
@@ -536,7 +525,7 @@ func TestBucketStores_deleteLocalFilesForExcludedTenants(t *testing.T) {
 
 	// We can always get user back.
 	sharding.users = []string{user1}
-	require.NoError(t, stores.SyncBlocks(ctx, true))
+	require.NoError(t, stores.SyncBlocks(ctx))
 	require.Equal(t, []string{user1}, getUsersInDir(t, cfg.BucketStore.SyncDir))
 
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -372,10 +372,6 @@ func (g *StoreGateway) waitRingStability(ctx context.Context, reason string) {
 	minWaiting := g.gatewayCfg.ShardingRing.WaitStabilityMinDuration
 	maxWaiting := g.gatewayCfg.ShardingRing.WaitStabilityMaxDuration
 
-	if !g.gatewayCfg.ShardingEnabled || minWaiting <= 0 {
-		return
-	}
-
 	level.Info(g.logger).Log("msg", "waiting until store-gateway ring topology is stable", "min_waiting", minWaiting.String(), "max_waiting", maxWaiting.String(), "reason", reason)
 	if err := ring.WaitRingTokensAndZonesStability(ctx, g.ring, BlocksOwnerSync, minWaiting, maxWaiting); err != nil {
 		level.Warn(g.logger).Log("msg", "store-gateway ring topology is not stable after the max waiting time, proceeding anyway", "reason", reason)

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -102,8 +102,8 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.ZoneAwarenessEnabled, ringFlagsPrefix+"zone-awareness-enabled", false, "True to enable zone-awareness and replicate blocks across different availability zones.")
 
 	// Wait stability flags.
-	f.DurationVar(&cfg.WaitStabilityMinDuration, ringFlagsPrefix+"wait-stability-min-duration", time.Minute, "Minimum time to wait for ring stability at startup. 0 to disable.")
-	f.DurationVar(&cfg.WaitStabilityMaxDuration, ringFlagsPrefix+"wait-stability-max-duration", 5*time.Minute, "Maximum time to wait for ring stability at startup. If the store-gateway ring keeps changing after this period of time, the store-gateway will start anyway.")
+	f.DurationVar(&cfg.WaitStabilityMinDuration, ringFlagsPrefix+"wait-stability-min-duration", time.Minute, "Minimum time to wait for ring stability at startup and ring change. 0 to disable.")
+	f.DurationVar(&cfg.WaitStabilityMaxDuration, ringFlagsPrefix+"wait-stability-max-duration", 5*time.Minute, "Maximum time to wait for ring stability at startup and ring change. If the store-gateway ring keeps changing after this period of time, the store-gateway will start or sync anyway.")
 
 	// Instance flags
 	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -854,7 +854,7 @@ func TestStoreGateway_PeriodicSyncShouldNotUpdateUserList(t *testing.T) {
 
 	// Force update user list
 	g.syncStores(ctx, "test", true)
-	g.waitRingStability(ctx)
+	g.waitRingStability(ctx, "test")
 
 	// Verify user-2 blocks are also synced
 	time.Sleep(time.Second)

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -763,6 +763,105 @@ func TestStoreGateway_SyncOnRingTopologyChanged(t *testing.T) {
 	}
 }
 
+func TestStoreGateway_syncStoresShouldWaitRingStability(t *testing.T) {
+	registeredAt := time.Now()
+	bucketClient, storageDir := cortex_testutil.PrepareFilesystemBucket(t)
+
+	// This tests uses real TSDB blocks. 24h time range, 2h block range period,
+	now := time.Now()
+	mockTSDB(t, path.Join(storageDir, "user-1"), 1, 12, now.Add(-24*time.Hour).Unix()*1000, now.Unix()*1000)
+
+	gatewayCfg := mockGatewayConfig()
+	gatewayCfg.ShardingEnabled = true
+	gatewayCfg.ShardingRing.RingCheckPeriod = time.Hour          // Disable sync ticker
+	gatewayCfg.ShardingRing.WaitStabilityMinDuration = time.Hour // Make rings never stable
+	gatewayCfg.ShardingRing.WaitStabilityMaxDuration = 2 * time.Hour
+
+	storageCfg := mockStorageConfig(t)
+	storageCfg.BucketStore.SyncInterval = time.Hour // Disable sync ticker
+
+	reg := prometheus.NewPedanticRegistry()
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	ctx := context.Background()
+	g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, defaultLimitsOverrides(t), mockLoggingLevel(), log.NewNopLogger(), reg)
+	require.NoError(t, err)
+
+	require.NoError(t, ringStore.CAS(ctx, RingKey, func(in interface{}) (interface{}, bool, error) {
+		ringDesc := ring.GetOrCreateRingDesc(in)
+		ringDesc.AddIngester("instance-1", "127.0.0.1", "", ring.Tokens{1, 2, 3}, ring.ACTIVE, registeredAt)
+		return ringDesc, true, nil
+	}))
+
+	syncCtx, cancelCtx := context.WithTimeout(ctx, 3*time.Second)
+	g.syncStores(syncCtx, "test", true)
+	cancelCtx()
+
+	// No blocks should be synced
+	regs := util.NewUserRegistries()
+	regs.AddUserRegistry("test", reg)
+	metrics := regs.BuildMetricFamiliesPerUser()
+	assert.Equal(t, float64(0), metrics.GetSumOfGauges("cortex_bucket_store_blocks_loaded"))
+}
+
+func TestStoreGateway_PeriodicSyncShouldNotUpdateUserList(t *testing.T) {
+	registeredAt := time.Now()
+	bucketClient, storageDir := cortex_testutil.PrepareFilesystemBucket(t)
+
+	// This tests uses real TSDB blocks. 24h time range, 2h block range period
+	now := time.Now()
+	mockTSDB(t, path.Join(storageDir, "user-1"), 1, 12, now.Add(-24*time.Hour).Unix()*1000, now.Unix()*1000)
+
+	ctx := context.Background()
+	gatewayCfg := mockGatewayConfig()
+	gatewayCfg.ShardingEnabled = true
+	gatewayCfg.ShardingRing.RingCheckPeriod = time.Hour // Do not trigger the ring change sync in this test.
+
+	storageCfg := mockStorageConfig(t)
+	storageCfg.BucketStore.SyncInterval = 100 * time.Millisecond
+
+	reg := prometheus.NewPedanticRegistry()
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, defaultLimitsOverrides(t), mockLoggingLevel(), log.NewNopLogger(), reg)
+	require.NoError(t, err)
+
+	require.NoError(t, ringStore.CAS(ctx, RingKey, func(in interface{}) (interface{}, bool, error) {
+		ringDesc := ring.GetOrCreateRingDesc(in)
+		ringDesc.AddIngester("instance-1", "127.0.0.1", "", ring.Tokens{1, 2, 3}, ring.ACTIVE, registeredAt)
+		return ringDesc, true, nil
+	}))
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, g))
+	defer services.StopAndAwaitTerminated(ctx, g) //nolint:errcheck
+
+	// Assert on the initial state.
+	regs := util.NewUserRegistries()
+	regs.AddUserRegistry("test", reg)
+	metrics := regs.BuildMetricFamiliesPerUser()
+	assert.Equal(t, float64(12), metrics.GetSumOfGauges("cortex_bucket_store_blocks_loaded"))
+
+	// Add more blocks, and extra user
+	mockTSDB(t, path.Join(storageDir, "user-1"), 1, 3, now.Unix()*1000, now.Add(6*time.Hour).Unix()*1000)
+	mockTSDB(t, path.Join(storageDir, "user-2"), 1, 3, now.Unix()*1000, now.Add(6*time.Hour).Unix()*1000)
+
+	// Verify only user-1 blocks are synced
+	time.Sleep(time.Second)
+	metrics = regs.BuildMetricFamiliesPerUser()
+	assert.Equal(t, float64(12+3), metrics.GetSumOfGauges("cortex_bucket_store_blocks_loaded"))
+
+	// Force update user list
+	g.syncStores(ctx, "test", true)
+	g.waitRingStability(ctx)
+
+	// Verify user-2 blocks are also synced
+	time.Sleep(time.Second)
+	metrics = regs.BuildMetricFamiliesPerUser()
+	assert.Equal(t, float64(12+3+3), metrics.GetSumOfGauges("cortex_bucket_store_blocks_loaded"))
+}
+
 func TestStoreGateway_RingLifecyclerShouldAutoForgetUnhealthyInstances(t *testing.T) {
 	const unhealthyInstanceID = "unhealthy-id"
 	const heartbeatTimeout = time.Minute

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -795,8 +795,7 @@ func TestStoreGateway_syncStoresShouldWaitRingStability(t *testing.T) {
 	}))
 
 	syncCtx, cancelCtx := context.WithTimeout(ctx, 3*time.Second)
-	ringState, _ := g.ring.GetAllHealthy(BlocksOwnerSync)
-	g.syncStores(syncCtx, ringState, "test")
+	g.syncStores(syncCtx, "test")
 	cancelCtx()
 
 	// No blocks should be synced


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Currently the `WaitStabilityMinDuration` and `WaitStabilityMaxDuration` are only used for new store gateway instance joining the ring, to make sure the ring info is propagated to all members of the ring before doing initial sync.

But this config was not used to existing members of the ring -- for example, when two new members are joining within a split second, there is a possibility of an existing member starts syncing block with only one member added to its ring (since it simply polls for any ring change every 5 second without any stability check). This is not desired when we are scaling up/down more than one store-gateway at once, or when we are doing rollout deployment.

This PR makes the periodic and ring-change block sync to wait for ring token and zone stability, before kicking off block sync.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
