### PR TITLE
Allow RF greater than number of zones to select more than one instance per zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [BUGFIX] Ring: Add JOINING state to read operation. #5346
 * [BUGFIX] Compactor: Partial block with only visit marker should be deleted even there is no deletion marker. #5342
 * [BUGFIX] KV: Etcd calls will no longer block indefinitely and will now time out after the DialTimeout period. #5392
+* [BUGFIX] Ring: Allow RF greater than number of zones to select more than one instance per zone #5411
 
 ## 1.15.1 2023-04-26
 

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -378,19 +378,26 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 			zoneAwarenessEnabled: true,
 			expectedInstances:    3,
 		},
-		"should fail if there are instances in 1 zone only on RF = 3": {
-			numInstances:         16,
-			numZones:             1,
+		"should fail if there are not enough instances": {
+			numInstances:         1,
+			numZones:             3,
 			replicationFactor:    3,
 			zoneAwarenessEnabled: true,
 			expectedErr:          "at least 2 live replicas required across different availability zones, could only find 1",
 		},
-		"should succeed if there are instances in 2 zones on RF = 3": {
+		"should succeed if there are instances in 3 zones on RF = 4": {
 			numInstances:         16,
-			numZones:             2,
-			replicationFactor:    3,
+			numZones:             3,
+			replicationFactor:    4,
 			zoneAwarenessEnabled: true,
-			expectedInstances:    2,
+			expectedInstances:    4,
+		},
+		"should succeed if there are instances in 3 zones on RF = 9": {
+			numInstances:         16,
+			numZones:             3,
+			replicationFactor:    9,
+			zoneAwarenessEnabled: true,
+			expectedInstances:    9,
 		},
 		"should succeed if there are instances in 1 zone only on RF = 3 but zone-awareness is disabled": {
 			numInstances:         16,
@@ -426,7 +433,7 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 				ringTokens:          r.GetTokens(),
 				ringTokensByZone:    r.getTokensByZone(),
 				ringInstanceByToken: r.getTokensInfo(),
-				ringZones:           getZones(r.getTokensByZone()),
+				ringZones:           []string{"zone-1", "zone-2", "zone-3"},
 				strategy:            NewDefaultReplicationStrategy(),
 				KVClient:            &MockClient{},
 			}
@@ -447,13 +454,9 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 				set, err = ring.Get(testValues[i], Write, instances, bufHosts, bufZones)
 				if testData.expectedErr != "" {
 					require.EqualError(t, err, testData.expectedErr)
+					continue // Skip the rest of the assertions if we were expecting an error.
 				} else {
 					require.NoError(t, err)
-				}
-
-				// Skip the rest of the assertions if we were expecting an error.
-				if testData.expectedErr != "" {
-					continue
 				}
 
 				// Check that we have the expected number of instances for replication.
@@ -461,12 +464,19 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 
 				// Ensure all instances are in a different zone (only if zone-awareness is enabled).
 				if testData.zoneAwarenessEnabled {
-					zones := make(map[string]struct{})
+					zones := make(map[string]int)
+					maxNumOfHostsPerZone := math.Ceil(float64(testData.replicationFactor) / float64(testData.numZones))
+
 					for i := 0; i < len(set.Instances); i++ {
-						if _, ok := zones[set.Instances[i].Zone]; ok {
-							t.Fatal("found multiple instances in the same zone")
+						if _, ok := zones[set.Instances[i].Zone]; !ok {
+							zones[set.Instances[i].Zone] = 1
+						} else {
+							zones[set.Instances[i].Zone]++
+
+							if zones[set.Instances[i].Zone] > int(maxNumOfHostsPerZone) {
+								t.Fatal("instances not spread across zones evenly")
+							}
 						}
-						zones[set.Instances[i].Zone] = struct{}{}
 					}
 				}
 			}
@@ -2020,7 +2030,7 @@ func TestRing_Get_NoMemoryAllocations(t *testing.T) {
 	buf, bufHosts, bufZones := MakeBuffersForGet()
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	numAllocs := testing.AllocsPerRun(10, func() {
+	numAllocs := testing.AllocsPerRun(100, func() {
 		set, err := ring.Get(r.Uint32(), Write, buf, bufHosts, bufZones)
 		if err != nil || len(set.Instances) != 3 {
 			t.Fail()

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -478,6 +478,10 @@ func TestRing_Get_ZoneAwareness(t *testing.T) {
 							}
 						}
 					}
+
+					if testData.replicationFactor >= testData.numZones && len(zones) != testData.numZones {
+						t.Fatalf("each zone must have at least one instance")
+					}
 				}
 			}
 		})
@@ -2030,7 +2034,7 @@ func TestRing_Get_NoMemoryAllocations(t *testing.T) {
 	buf, bufHosts, bufZones := MakeBuffersForGet()
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	numAllocs := testing.AllocsPerRun(100, func() {
+	numAllocs := testing.AllocsPerRun(10, func() {
 		set, err := ring.Get(r.Uint32(), Write, buf, bufHosts, bufZones)
 		if err != nil || len(set.Instances) != 3 {
 			t.Fail()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

`ring.Get` that should return n (or more) instances which form the replicas for the given key uses the following configs:
- `ring.cfg.ReplicationFactor` to control how many replicas you would like to use per key
- `ring.cfg.ZoneAwarenessEnabled` to allow replicas to be across the zones evenly

Problem is, when `ZoneAwarenessEnabled` is enabled and `ReplicationFactor` is greater than number of available zones, the function was silently ignoring the ReplicationFactor and returned only one instance from each zone:

https://github.com/cortexproject/cortex/blob/a307fc04ce295391f8927da19299bb5d26ecfbd8/pkg/ring/ring.go#L376-L380

RF doesn't need to be bound to number of zones, and the following scenario is valid as well:
- There are 3 available zones
- Setting RF to 6 would choose 2 instances from each zone

This PR fixes the function to be able to return max `ceil(RF/len(zones))` number of instances per zone. For instance, numOfZones = 3 and RF = 4 will return 4 instances, and each zone will have either 1 or 2 instances returned.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
