### PR TITLE
Fix ooo compacted blocks shipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@
 * [BUGFIX] Fix bug on objstore when configured to use S3 fips endpoints. #5540
 * [BUGFIX] Ruler: Fix bug on ruler where a failure to load a single RuleGroup would prevent rulers to sync all RuleGroup. #5563
 * [BUGFIX] Store-Gateway and AlertManager: Add a `wait_instance_time_out` to WaitInstanceState context to avoid waiting forever. #5581
-* [BUGFIX] Ingester: Allow shipper to upload compacted blocks when out of order samples is enabled. #5416
+* [BUGFIX] Ingester: Allow shipper to hot reload upload compacted blocks when out of order samples is enabled. #5416
 
 ## 1.15.1 2023-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 * [BUGFIX] Fix bug on objstore when configured to use S3 fips endpoints. #5540
 * [BUGFIX] Ruler: Fix bug on ruler where a failure to load a single RuleGroup would prevent rulers to sync all RuleGroup. #5563
 * [BUGFIX] Store-Gateway and AlertManager: Add a `wait_instance_time_out` to WaitInstanceState context to avoid waiting forever. #5581
+* [BUGFIX] Ingester: Allow shipper to upload compacted blocks when out of order samples is enabled. #5416
 
 ## 1.15.1 2023-04-26
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1967,7 +1967,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 	if maxExemplarsForUser > 0 {
 		enableExemplars = true
 	}
-	oooTimeWindow := i.limits.OutOfOrderTimeWindow(userID)
+	oooTimeWindow := time.Duration(i.limits.OutOfOrderTimeWindow(userID)).Milliseconds()
 	walCompressType := wlog.CompressionNone
 	// TODO(yeya24): expose zstd compression for WAL.
 	if i.cfg.BlocksStorageConfig.TSDB.WALCompressionEnabled {
@@ -2044,8 +2044,8 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 			func() labels.Labels { return l },
 			metadata.ReceiveSource,
 			func() bool {
-				return oooTimeWindow > 0 // Upload compacted blocks when OOO is enabled.
-			},
+				return time.Duration(i.limits.OutOfOrderTimeWindow(userID)).Milliseconds() > 0
+			}, // No need to upload compacted blocks unless out of order samples is enabled.
 			true, // Allow out of order uploads. It's fine in Cortex's context.
 			metadata.NoneFunc,
 		)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1990,7 +1990,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 		MaxExemplars:                   maxExemplarsForUser,
 		HeadChunksWriteQueueSize:       i.cfg.BlocksStorageConfig.TSDB.HeadChunksWriteQueueSize,
 		EnableMemorySnapshotOnShutdown: i.cfg.BlocksStorageConfig.TSDB.MemorySnapshotOnShutdown,
-		OutOfOrderTimeWindow:           time.Duration(oooTimeWindow).Milliseconds(),
+		OutOfOrderTimeWindow:           oooTimeWindow,
 		OutOfOrderCapMax:               i.cfg.BlocksStorageConfig.TSDB.OutOfOrderCapMax,
 	}, nil)
 	if err != nil {
@@ -2044,7 +2044,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 			func() labels.Labels { return l },
 			metadata.ReceiveSource,
 			func() bool {
-				return time.Duration(i.limits.OutOfOrderTimeWindow(userID)).Milliseconds() > 0
+				return i.limits.OutOfOrderTimeWindow(userID) > 0
 			}, // No need to upload compacted blocks unless out of order samples is enabled.
 			true, // Allow out of order uploads. It's fine in Cortex's context.
 			metadata.NoneFunc,

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1967,7 +1967,6 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 	if maxExemplarsForUser > 0 {
 		enableExemplars = true
 	}
-	oooTimeWindow := time.Duration(i.limits.OutOfOrderTimeWindow(userID)).Milliseconds()
 	walCompressType := wlog.CompressionNone
 	// TODO(yeya24): expose zstd compression for WAL.
 	if i.cfg.BlocksStorageConfig.TSDB.WALCompressionEnabled {
@@ -1990,7 +1989,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 		MaxExemplars:                   maxExemplarsForUser,
 		HeadChunksWriteQueueSize:       i.cfg.BlocksStorageConfig.TSDB.HeadChunksWriteQueueSize,
 		EnableMemorySnapshotOnShutdown: i.cfg.BlocksStorageConfig.TSDB.MemorySnapshotOnShutdown,
-		OutOfOrderTimeWindow:           oooTimeWindow,
+		OutOfOrderTimeWindow:           time.Duration(i.limits.OutOfOrderTimeWindow(userID)).Milliseconds(),
 		OutOfOrderCapMax:               i.cfg.BlocksStorageConfig.TSDB.OutOfOrderCapMax,
 	}, nil)
 	if err != nil {

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -678,6 +678,20 @@ func (r *UserRegistries) Registries() []UserRegistry {
 	return out
 }
 
+// GetPromRegistryByUser returns the Prometheus metrics registry by userID.
+func (r *UserRegistries) GetPromRegistryByUser(user string) *prometheus.Registry {
+	r.regsMu.Lock()
+	defer r.regsMu.Unlock()
+
+	for _, reg := range r.regs {
+		if reg.user == user {
+			return reg.reg
+		}
+	}
+
+	return nil
+}
+
 func (r *UserRegistries) BuildMetricFamiliesPerUser() MetricFamiliesPerUser {
 	data := MetricFamiliesPerUser{}
 	for _, entry := range r.Registries() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

If OOO is enabled, shipper needs to upload compacted blocks.
Another thing is that we supports hot reload of OOO time window so we might need to support hot reload shipper configuration as well.

**Which issue(s) this PR fixes**:
Fixes #5402

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
