### PR TITLE
Handling CMK AccessDenied errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/sony/gobreaker v0.5.0
 	github.com/spf13/afero v1.9.5
 	github.com/stretchr/testify v1.8.4
-	github.com/thanos-io/objstore v0.0.0-20230522103316-23ebe2eacadd
+	github.com/thanos-io/objstore v0.0.0-20230629211010-ff1b35b9841a
 	github.com/thanos-io/promql-engine v0.0.0-20230526105742-791d78b260ea
 	github.com/thanos-io/thanos v0.31.1-0.20230627154113-7cfaf3fe2d43
 	github.com/uber/jaeger-client-go v2.30.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1160,8 +1160,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40 h1:W6vDGKCHe4wBACI1d2UgE6+50sJFhRWU4O8IB2ozzxM=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e h1:f1Zsv7OAU9iQhZwigp50Yl38W10g/vd5NC8Rdk1Jzng=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e/go.mod h1:jXcofnrSln/cLI6/dhlBxPQZEEQHVPCcFaH75M+nSzM=
-github.com/thanos-io/objstore v0.0.0-20230522103316-23ebe2eacadd h1:asQ0HomkaUXZuR3J7daBEusMS++3hkYsYM6u8gpmPWM=
-github.com/thanos-io/objstore v0.0.0-20230522103316-23ebe2eacadd/go.mod h1:5V7lzXuaxwt6XFQoA/zJrhdnQrxq1+r0bwQ1iYOq3gM=
+github.com/thanos-io/objstore v0.0.0-20230629211010-ff1b35b9841a h1:tXcVeuval1nzdHn1JXqaBmyjuEUcpDI9huPrUF04nR4=
+github.com/thanos-io/objstore v0.0.0-20230629211010-ff1b35b9841a/go.mod h1:5V7lzXuaxwt6XFQoA/zJrhdnQrxq1+r0bwQ1iYOq3gM=
 github.com/thanos-io/promql-engine v0.0.0-20230526105742-791d78b260ea h1:kzK8sBn2+mo3NAxP+XjAjAqr1hwfxxFUy5CybaBkjAI=
 github.com/thanos-io/promql-engine v0.0.0-20230526105742-791d78b260ea/go.mod h1:eIgPaXWgOhNAv6CPPrgu09r0AtT7byBTZy+7WkX0D18=
 github.com/thanos-io/thanos v0.31.1-0.20230627154113-7cfaf3fe2d43 h1:UHyTPGdDHAoNHuSce5cJ2vEi6g1v8D5ZFBWZ61uTHSM=

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -325,7 +325,7 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, firstRun b
 	idx, err := bucketindex.ReadIndex(ctx, c.bucketClient, userID, c.cfgProvider, c.logger)
 	if errors.Is(err, bucketindex.ErrIndexCorrupted) {
 		level.Warn(userLogger).Log("msg", "found a corrupted bucket index, recreating it")
-	} else if errors.Is(err, bucket.ErrCustomerManagedKeyError) {
+	} else if errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied) {
 		// Give up cleaning if we get access denied
 		level.Warn(userLogger).Log("msg", err.Error())
 		return nil

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -325,6 +325,10 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, firstRun b
 	idx, err := bucketindex.ReadIndex(ctx, c.bucketClient, userID, c.cfgProvider, c.logger)
 	if errors.Is(err, bucketindex.ErrIndexCorrupted) {
 		level.Warn(userLogger).Log("msg", "found a corrupted bucket index, recreating it")
+	} else if errors.Is(err, bucketindex.ErrCustomerManagedKeyError) {
+		// Give up cleaning if we get access denied
+		level.Warn(userLogger).Log("msg", err.Error())
+		return nil
 	} else if err != nil && !errors.Is(err, bucketindex.ErrIndexNotFound) {
 		return err
 	}

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -325,7 +325,7 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, firstRun b
 	idx, err := bucketindex.ReadIndex(ctx, c.bucketClient, userID, c.cfgProvider, c.logger)
 	if errors.Is(err, bucketindex.ErrIndexCorrupted) {
 		level.Warn(userLogger).Log("msg", "found a corrupted bucket index, recreating it")
-	} else if errors.Is(err, bucketindex.ErrCustomerManagedKeyError) {
+	} else if errors.Is(err, bucket.ErrCustomerManagedKeyError) {
 		// Give up cleaning if we get access denied
 		level.Warn(userLogger).Log("msg", err.Error())
 		return nil

--- a/pkg/querier/blocks_finder_bucket_index.go
+++ b/pkg/querier/blocks_finder_bucket_index.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
+
+	"github.com/cortexproject/cortex/pkg/util/validation"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	"github.com/cortexproject/cortex/pkg/storage/tsdb/bucketindex"

--- a/pkg/querier/blocks_finder_bucket_index.go
+++ b/pkg/querier/blocks_finder_bucket_index.go
@@ -65,7 +65,7 @@ func (f *BucketIndexBlocksFinder) GetBlocks(ctx context.Context, userID string, 
 		return nil, nil, nil
 	}
 
-	if errors.Is(err, bucketindex.ErrCustomerManagedKeyError) {
+	if errors.Is(err, bucket.ErrCustomerManagedKeyError) {
 		return nil, nil, validation.AccessDeniedError(err.Error())
 	}
 

--- a/pkg/querier/blocks_finder_bucket_index.go
+++ b/pkg/querier/blocks_finder_bucket_index.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
@@ -62,6 +63,11 @@ func (f *BucketIndexBlocksFinder) GetBlocks(ctx context.Context, userID string, 
 		// so the bucket index hasn't been created yet.
 		return nil, nil, nil
 	}
+
+	if errors.Is(err, bucketindex.ErrCustomerManagedKeyError) {
+		return nil, nil, validation.AccessDeniedError(err.Error())
+	}
+
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/querier/blocks_finder_bucket_index.go
+++ b/pkg/querier/blocks_finder_bucket_index.go
@@ -65,7 +65,7 @@ func (f *BucketIndexBlocksFinder) GetBlocks(ctx context.Context, userID string, 
 		return nil, nil, nil
 	}
 
-	if errors.Is(err, bucket.ErrCustomerManagedKeyError) {
+	if errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied) {
 		return nil, nil, validation.AccessDeniedError(err.Error())
 	}
 

--- a/pkg/querier/blocks_finder_bucket_index_test.go
+++ b/pkg/querier/blocks_finder_bucket_index_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
 	"github.com/stretchr/testify/assert"
@@ -240,4 +241,22 @@ func prepareBucketIndexBlocksFinder(t testing.TB, bkt objstore.Bucket) *BucketIn
 	})
 
 	return finder
+}
+
+func TestBucketIndexBlocksFinder_GetBlocks_KeyPermissionDenied(t *testing.T) {
+	const userID = "user-1"
+	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+
+	bkt = &cortex_testutil.MockBucketFailure{
+		Bucket: bkt,
+		GetFailures: map[string]error{
+			path.Join(userID, "bucket-index.json.gz"): cortex_testutil.ErrKeyAccessDeniedError,
+		},
+	}
+
+	finder := prepareBucketIndexBlocksFinder(t, bkt)
+
+	_, _, err := finder.GetBlocks(context.Background(), userID, 0, 100)
+	expected := validation.AccessDeniedError("error")
+	require.IsType(t, expected, err)
 }

--- a/pkg/querier/blocks_finder_bucket_index_test.go
+++ b/pkg/querier/blocks_finder_bucket_index_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/util/validation"
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
+
+	"github.com/cortexproject/cortex/pkg/util/validation"
 
 	"github.com/cortexproject/cortex/pkg/storage/tsdb/bucketindex"
 	cortex_testutil "github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"

--- a/pkg/querier/error_translate_queryable.go
+++ b/pkg/querier/error_translate_queryable.go
@@ -39,6 +39,9 @@ func TranslateToPromqlAPIError(err error) error {
 	case validation.LimitError:
 		// This will be returned with status code 422 by Prometheus API.
 		return err
+	case validation.AccessDeniedError:
+		// This will be returned with status code 422 by Prometheus API.
+		return err
 	default:
 		if errors.Is(err, context.Canceled) {
 			return err // 422

--- a/pkg/querier/error_translate_queryable_test.go
+++ b/pkg/querier/error_translate_queryable_test.go
@@ -44,6 +44,12 @@ func TestApiStatusCodes(t *testing.T) {
 		},
 
 		{
+			err:            validation.AccessDeniedError("access denied"),
+			expectedString: "access denied",
+			expectedCode:   422,
+		},
+
+		{
 			err:            promql.ErrTooManySamples("query execution"),
 			expectedString: "too many samples",
 			expectedCode:   422,

--- a/pkg/storage/bucket/client.go
+++ b/pkg/storage/bucket/client.go
@@ -40,6 +40,8 @@ var (
 	SupportedBackends = []string{S3, GCS, Azure, Swift, Filesystem}
 
 	ErrUnsupportedStorageBackend = errors.New("unsupported storage backend")
+
+	ErrCustomerManagedKeyError = errors.New("access denied: customer key")
 )
 
 // Config holds configuration for accessing long-term storage.

--- a/pkg/storage/bucket/client.go
+++ b/pkg/storage/bucket/client.go
@@ -41,7 +41,7 @@ var (
 
 	ErrUnsupportedStorageBackend = errors.New("unsupported storage backend")
 
-	ErrCustomerManagedKeyError = errors.New("access denied: customer key")
+	ErrCustomerManagedKeyAccessDenied = errors.New("access denied: customer key")
 )
 
 // Config holds configuration for accessing long-term storage.

--- a/pkg/storage/bucket/client_mock.go
+++ b/pkg/storage/bucket/client_mock.go
@@ -12,7 +12,10 @@ import (
 	"github.com/thanos-io/objstore"
 )
 
-var errObjectDoesNotExist = errors.New("object does not exist")
+var (
+	errObjectDoesNotExist  = errors.New("object does not exist")
+	errKeyPermissionDenied = errors.New("object key permission denied")
+)
 
 // ClientMock mocks objstore.Bucket
 type ClientMock struct {
@@ -173,6 +176,11 @@ func (m *ClientMock) Exists(ctx context.Context, name string) (bool, error) {
 // IsObjNotFoundErr mocks objstore.Bucket.IsObjNotFoundErr()
 func (m *ClientMock) IsObjNotFoundErr(err error) bool {
 	return err == errObjectDoesNotExist
+}
+
+// IsCustomerManagedKeyError mocks objstore.Bucket.IsCustomerManagedKeyError()
+func (m *ClientMock) IsCustomerManagedKeyError(err error) bool {
+	return err == errKeyPermissionDenied
 }
 
 // ObjectSize mocks objstore.Bucket.Attributes()

--- a/pkg/storage/bucket/prefixed_bucket_client.go
+++ b/pkg/storage/bucket/prefixed_bucket_client.go
@@ -73,18 +73,23 @@ func (b *PrefixedBucketClient) IsObjNotFoundErr(err error) bool {
 	return b.bucket.IsObjNotFoundErr(err)
 }
 
+// IsCustomerManagedKeyError returns true if the permissions for key used to encrypt the object was revoked.
+func (b *PrefixedBucketClient) IsCustomerManagedKeyError(err error) bool {
+	return b.bucket.IsCustomerManagedKeyError(err)
+}
+
 // Attributes returns attributes of the specified object.
 func (b *PrefixedBucketClient) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
 	return b.bucket.Attributes(ctx, b.fullName(name))
 }
 
-// WithExpectedErrs allows to specify a filter that marks certain errors as expected, so it will not increment
+// ReaderWithExpectedErrs allows to specify a filter that marks certain errors as expected, so it will not increment
 // thanos_objstore_bucket_operation_failures_total metric.
 func (b *PrefixedBucketClient) ReaderWithExpectedErrs(fn objstore.IsOpFailureExpectedFunc) objstore.BucketReader {
 	return b.WithExpectedErrs(fn)
 }
 
-// ReaderWithExpectedErrs allows to specify a filter that marks certain errors as expected, so it will not increment
+// WithExpectedErrs allows to specify a filter that marks certain errors as expected, so it will not increment
 // thanos_objstore_bucket_operation_failures_total metric.
 func (b *PrefixedBucketClient) WithExpectedErrs(fn objstore.IsOpFailureExpectedFunc) objstore.Bucket {
 	if ib, ok := b.bucket.(objstore.InstrumentedBucket); ok {

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -115,7 +115,7 @@ func (b *BucketWithRetries) retry(ctx context.Context, f func() error, operation
 		if lastErr == nil {
 			return nil
 		}
-		if b.bucket.IsObjNotFoundErr(lastErr) {
+		if b.bucket.IsObjNotFoundErr(lastErr) || b.bucket.IsCustomerManagedKeyError(lastErr) {
 			return lastErr
 		}
 		retries.Wait()
@@ -192,6 +192,10 @@ func (b *BucketWithRetries) Delete(ctx context.Context, name string) error {
 
 func (b *BucketWithRetries) IsObjNotFoundErr(err error) bool {
 	return b.bucket.IsObjNotFoundErr(err)
+}
+
+func (b *BucketWithRetries) IsCustomerManagedKeyError(err error) bool {
+	return b.bucket.IsCustomerManagedKeyError(err)
 }
 
 func (b *BucketWithRetries) Close() error {

--- a/pkg/storage/bucket/sse_bucket_client.go
+++ b/pkg/storage/bucket/sse_bucket_client.go
@@ -119,6 +119,10 @@ func (b *SSEBucketClient) IsObjNotFoundErr(err error) bool {
 	return b.bucket.IsObjNotFoundErr(err)
 }
 
+func (b *SSEBucketClient) IsCustomerManagedKeyError(err error) bool {
+	return b.bucket.IsCustomerManagedKeyError(err)
+}
+
 // Attributes implements objstore.Bucket.
 func (b *SSEBucketClient) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
 	return b.bucket.Attributes(ctx, name)

--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -115,7 +115,7 @@ func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, error) {
 
 		if errors.Is(err, ErrIndexNotFound) {
 			level.Warn(l.logger).Log("msg", "bucket index not found", "user", userID)
-		} else if errors.Is(err, bucket.ErrCustomerManagedKeyError) {
+		} else if errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied) {
 			level.Warn(l.logger).Log("msg", "key access denied when reading bucket index", "user", userID)
 		} else {
 			// We don't track ErrIndexNotFound as failure because it's a legit case (eg. a tenant just
@@ -198,7 +198,7 @@ func (l *Loader) updateCachedIndex(ctx context.Context, userID string) {
 	l.loadAttempts.Inc()
 	startTime := time.Now()
 	idx, err := ReadIndex(readCtx, l.bkt, userID, l.cfgProvider, l.logger)
-	if err != nil && !errors.Is(err, ErrIndexNotFound) && !errors.Is(err, bucket.ErrCustomerManagedKeyError) {
+	if err != nil && !errors.Is(err, ErrIndexNotFound) && !errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied) {
 		l.loadFailures.Inc()
 		level.Warn(l.logger).Log("msg", "unable to update bucket index", "user", userID, "err", err)
 		return

--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -115,7 +115,7 @@ func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, error) {
 
 		if errors.Is(err, ErrIndexNotFound) {
 			level.Warn(l.logger).Log("msg", "bucket index not found", "user", userID)
-		} else if errors.Is(err, ErrCustomerManagedKeyError) {
+		} else if errors.Is(err, bucket.ErrCustomerManagedKeyError) {
 			level.Warn(l.logger).Log("msg", "key access denied when reading bucket index", "user", userID)
 		} else {
 			// We don't track ErrIndexNotFound as failure because it's a legit case (eg. a tenant just
@@ -198,7 +198,7 @@ func (l *Loader) updateCachedIndex(ctx context.Context, userID string) {
 	l.loadAttempts.Inc()
 	startTime := time.Now()
 	idx, err := ReadIndex(readCtx, l.bkt, userID, l.cfgProvider, l.logger)
-	if err != nil && !errors.Is(err, ErrIndexNotFound) && !errors.Is(err, ErrCustomerManagedKeyError) {
+	if err != nil && !errors.Is(err, ErrIndexNotFound) && !errors.Is(err, bucket.ErrCustomerManagedKeyError) {
 		l.loadFailures.Inc()
 		level.Warn(l.logger).Log("msg", "unable to update bucket index", "user", userID, "err", err)
 		return

--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -115,6 +115,8 @@ func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, error) {
 
 		if errors.Is(err, ErrIndexNotFound) {
 			level.Warn(l.logger).Log("msg", "bucket index not found", "user", userID)
+		} else if errors.Is(err, ErrCustomerManagedKeyError) {
+			level.Warn(l.logger).Log("msg", "key access denied when reading bucket index", "user", userID)
 		} else {
 			// We don't track ErrIndexNotFound as failure because it's a legit case (eg. a tenant just
 			// started to remote write and its blocks haven't uploaded to storage yet).
@@ -196,7 +198,7 @@ func (l *Loader) updateCachedIndex(ctx context.Context, userID string) {
 	l.loadAttempts.Inc()
 	startTime := time.Now()
 	idx, err := ReadIndex(readCtx, l.bkt, userID, l.cfgProvider, l.logger)
-	if err != nil && !errors.Is(err, ErrIndexNotFound) {
+	if err != nil && !errors.Is(err, ErrIndexNotFound) && !errors.Is(err, ErrCustomerManagedKeyError) {
 		l.loadFailures.Inc()
 		level.Warn(l.logger).Log("msg", "unable to update bucket index", "user", userID, "err", err)
 		return

--- a/pkg/storage/tsdb/bucketindex/loader_test.go
+++ b/pkg/storage/tsdb/bucketindex/loader_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -569,6 +570,121 @@ func TestLoader_ShouldOffloadIndexIfIdleTimeoutIsReachedDuringBackgroundUpdates(
 		cortex_bucket_index_loads_total 2
 	`),
 		"cortex_bucket_index_loads_total",
+	))
+}
+
+func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousKeyAcessDenied(t *testing.T) {
+	user := "user-1"
+	ctx := context.Background()
+	reg := prometheus.NewPedanticRegistry()
+	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+
+	// Create the loader.
+	cfg := LoaderConfig{
+		CheckInterval:         time.Hour, // Intentionally high to not hit it.
+		UpdateOnStaleInterval: time.Hour, // Intentionally high to not hit it.
+		UpdateOnErrorInterval: 0,
+		IdleTimeout:           time.Hour, // Intentionally high to not hit it.
+	}
+
+	mockedBkt := &cortex_testutil.MockBucketFailure{
+		Bucket: bkt,
+		GetFailures: map[string]error{
+			path.Join(user, "bucket-index.json.gz"): cortex_testutil.ErrKeyAccessDeniedError,
+		},
+	}
+
+	loader := NewLoader(cfg, mockedBkt, nil, log.NewNopLogger(), reg)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, loader))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
+	})
+
+	_, err := loader.GetIndex(ctx, user)
+	require.True(t, errors.Is(err, ErrCustomerManagedKeyError))
+
+	// Check cached
+	loader.checkCachedIndexes(ctx)
+
+	loader.bkt = bkt
+
+	// Upload the bucket index.
+	idx := &Index{
+		Version: IndexVersion1,
+		Blocks: Blocks{
+			{ID: ulid.MustNew(1, nil), MinTime: 10, MaxTime: 20},
+		},
+		BlockDeletionMarks: nil,
+		UpdatedAt:          time.Now().Unix(),
+	}
+	require.NoError(t, WriteIndex(ctx, bkt, "user-1", nil, idx))
+
+	// Wait until the index has been updated in background.
+	test.Poll(t, 3*time.Second, nil, func() interface{} {
+		_, err := loader.GetIndex(ctx, "user-1")
+		// Check cached
+		loader.checkCachedIndexes(ctx)
+		return err
+	})
+
+	actualIdx, err := loader.GetIndex(ctx, "user-1")
+	require.NoError(t, err)
+	assert.Equal(t, idx, actualIdx)
+
+	// Ensure metrics have been updated accordingly.
+	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+		# HELP cortex_bucket_index_load_failures_total Total number of bucket index loading failures.
+		# TYPE cortex_bucket_index_load_failures_total counter
+		cortex_bucket_index_load_failures_total 0
+		# HELP cortex_bucket_index_loaded Number of bucket indexes currently loaded in-memory.
+		# TYPE cortex_bucket_index_loaded gauge
+		cortex_bucket_index_loaded 1
+	`),
+		"cortex_bucket_index_loaded", "cortex_bucket_index_load_failures_total",
+	))
+}
+
+func TestLoader_GetIndex_ShouldCacheKeyDeniedErrors(t *testing.T) {
+	user := "user-1"
+	ctx := context.Background()
+	reg := prometheus.NewPedanticRegistry()
+	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+
+	bkt = &cortex_testutil.MockBucketFailure{
+		Bucket: bkt,
+		GetFailures: map[string]error{
+			path.Join(user, "bucket-index.json.gz"): cortex_testutil.ErrKeyAccessDeniedError,
+		},
+	}
+
+	// Create the loader.
+	loader := NewLoader(prepareLoaderConfig(), bkt, nil, log.NewNopLogger(), reg)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, loader))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
+	})
+
+	// Request the index multiple times.
+	for i := 0; i < 10; i++ {
+		_, err := loader.GetIndex(ctx, "user-1")
+		require.True(t, errors.Is(err, ErrCustomerManagedKeyError))
+	}
+
+	// Ensure metrics have been updated accordingly.
+	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+		# HELP cortex_bucket_index_load_failures_total Total number of bucket index loading failures.
+		# TYPE cortex_bucket_index_load_failures_total counter
+		cortex_bucket_index_load_failures_total 0
+		# HELP cortex_bucket_index_loaded Number of bucket indexes currently loaded in-memory.
+		# TYPE cortex_bucket_index_loaded gauge
+		cortex_bucket_index_loaded 0
+		# HELP cortex_bucket_index_loads_total Total number of bucket index loading attempts.
+		# TYPE cortex_bucket_index_loads_total counter
+		cortex_bucket_index_loads_total 1
+	`),
+		"cortex_bucket_index_loads_total",
+		"cortex_bucket_index_load_failures_total",
+		"cortex_bucket_index_loaded",
 	))
 }
 

--- a/pkg/storage/tsdb/bucketindex/loader_test.go
+++ b/pkg/storage/tsdb/bucketindex/loader_test.go
@@ -604,7 +604,7 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousKeyAcessDenied(t *testing
 	require.True(t, errors.Is(err, ErrCustomerManagedKeyError))
 
 	// Check cached
-	loader.checkCachedIndexes(ctx)
+	require.NoError(t, loader.checkCachedIndexes(ctx))
 
 	loader.bkt = bkt
 
@@ -623,7 +623,7 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousKeyAcessDenied(t *testing
 	test.Poll(t, 3*time.Second, nil, func() interface{} {
 		_, err := loader.GetIndex(ctx, "user-1")
 		// Check cached
-		loader.checkCachedIndexes(ctx)
+		require.NoError(t, loader.checkCachedIndexes(ctx))
 		return err
 	})
 

--- a/pkg/storage/tsdb/bucketindex/loader_test.go
+++ b/pkg/storage/tsdb/bucketindex/loader_test.go
@@ -603,7 +603,7 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousKeyAcessDenied(t *testing
 	})
 
 	_, err := loader.GetIndex(ctx, user)
-	require.True(t, errors.Is(err, bucket.ErrCustomerManagedKeyError))
+	require.True(t, errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied))
 
 	// Check cached
 	require.NoError(t, loader.checkCachedIndexes(ctx))
@@ -669,7 +669,7 @@ func TestLoader_GetIndex_ShouldCacheKeyDeniedErrors(t *testing.T) {
 	// Request the index multiple times.
 	for i := 0; i < 10; i++ {
 		_, err := loader.GetIndex(ctx, "user-1")
-		require.True(t, errors.Is(err, bucket.ErrCustomerManagedKeyError))
+		require.True(t, errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied))
 	}
 
 	// Ensure metrics have been updated accordingly.

--- a/pkg/storage/tsdb/bucketindex/loader_test.go
+++ b/pkg/storage/tsdb/bucketindex/loader_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
@@ -601,7 +602,7 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousKeyAcessDenied(t *testing
 	})
 
 	_, err := loader.GetIndex(ctx, user)
-	require.True(t, errors.Is(err, ErrCustomerManagedKeyError))
+	require.True(t, errors.Is(err, bucket.ErrCustomerManagedKeyError))
 
 	// Check cached
 	require.NoError(t, loader.checkCachedIndexes(ctx))
@@ -667,7 +668,7 @@ func TestLoader_GetIndex_ShouldCacheKeyDeniedErrors(t *testing.T) {
 	// Request the index multiple times.
 	for i := 0; i < 10; i++ {
 		_, err := loader.GetIndex(ctx, "user-1")
-		require.True(t, errors.Is(err, ErrCustomerManagedKeyError))
+		require.True(t, errors.Is(err, bucket.ErrCustomerManagedKeyError))
 	}
 
 	// Ensure metrics have been updated accordingly.

--- a/pkg/storage/tsdb/bucketindex/loader_test.go
+++ b/pkg/storage/tsdb/bucketindex/loader_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
@@ -16,6 +15,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
 
 	cortex_testutil "github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"
 	"github.com/cortexproject/cortex/pkg/util/services"

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
@@ -100,6 +100,11 @@ func (b *globalMarkersBucket) IsObjNotFoundErr(err error) bool {
 	return b.parent.IsObjNotFoundErr(err)
 }
 
+// IsCustomerManagedKeyError returns true if the permissions for key used to encrypt the object was revoked.
+func (b *globalMarkersBucket) IsCustomerManagedKeyError(err error) bool {
+	return b.parent.IsCustomerManagedKeyError(err)
+}
+
 // Attributes implements objstore.Bucket.
 func (b *globalMarkersBucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
 	return b.parent.Attributes(ctx, name)

--- a/pkg/storage/tsdb/bucketindex/storage.go
+++ b/pkg/storage/tsdb/bucketindex/storage.go
@@ -17,9 +17,8 @@ import (
 )
 
 var (
-	ErrIndexNotFound           = errors.New("bucket index not found")
-	ErrIndexCorrupted          = errors.New("bucket index corrupted")
-	ErrCustomerManagedKeyError = errors.New("access denied: customer key")
+	ErrIndexNotFound  = errors.New("bucket index not found")
+	ErrIndexCorrupted = errors.New("bucket index corrupted")
 )
 
 // ReadIndex reads, parses and returns a bucket index from the bucket.
@@ -34,7 +33,7 @@ func ReadIndex(ctx context.Context, bkt objstore.Bucket, userID string, cfgProvi
 		}
 
 		if userBkt.IsCustomerManagedKeyError(err) {
-			return nil, ErrCustomerManagedKeyError
+			return nil, bucket.ErrCustomerManagedKeyError
 		}
 
 		return nil, errors.Wrap(err, "read bucket index")

--- a/pkg/storage/tsdb/bucketindex/storage.go
+++ b/pkg/storage/tsdb/bucketindex/storage.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
+	cortex_errors "github.com/cortexproject/cortex/pkg/util/errors"
 	"github.com/cortexproject/cortex/pkg/util/runutil"
 )
 
@@ -33,7 +34,7 @@ func ReadIndex(ctx context.Context, bkt objstore.Bucket, userID string, cfgProvi
 		}
 
 		if userBkt.IsCustomerManagedKeyError(err) {
-			return nil, bucket.ErrCustomerManagedKeyError
+			return nil, cortex_errors.WithCause(bucket.ErrCustomerManagedKeyAccessDenied, err)
 		}
 
 		return nil, errors.Wrap(err, "read bucket index")

--- a/pkg/storage/tsdb/bucketindex/storage.go
+++ b/pkg/storage/tsdb/bucketindex/storage.go
@@ -27,7 +27,7 @@ func ReadIndex(ctx context.Context, bkt objstore.Bucket, userID string, cfgProvi
 	userBkt := bucket.NewUserBucketClient(userID, bkt, cfgProvider)
 
 	// Get the bucket index.
-	reader, err := userBkt.WithExpectedErrs(tsdb.IsObjNotFoundOrCustomerManagedKeyErr(userBkt)).Get(ctx, IndexCompressedFilename)
+	reader, err := userBkt.WithExpectedErrs(tsdb.IsOneOfTheExpectedErrors(userBkt.IsCustomerManagedKeyError, userBkt.IsObjNotFoundErr)).Get(ctx, IndexCompressedFilename)
 	if err != nil {
 		if userBkt.IsObjNotFoundErr(err) {
 			return nil, ErrIndexNotFound

--- a/pkg/storage/tsdb/bucketindex/storage.go
+++ b/pkg/storage/tsdb/bucketindex/storage.go
@@ -6,10 +6,11 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
 	"github.com/thanos-io/objstore"
+
+	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	"github.com/cortexproject/cortex/pkg/util/runutil"

--- a/pkg/storage/tsdb/bucketindex/storage_test.go
+++ b/pkg/storage/tsdb/bucketindex/storage_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,7 +46,7 @@ func TestReadIndex_ShouldReturnErrorIfKeyAccessDeniedErr(t *testing.T) {
 		},
 	}
 	idx, err := ReadIndex(context.Background(), bkt, "user-1", nil, log.NewNopLogger())
-	require.Equal(t, ErrCustomerManagedKeyError, err)
+	require.Equal(t, bucket.ErrCustomerManagedKeyError, err)
 	require.Nil(t, idx)
 }
 

--- a/pkg/storage/tsdb/bucketindex/storage_test.go
+++ b/pkg/storage/tsdb/bucketindex/storage_test.go
@@ -36,6 +36,19 @@ func TestReadIndex_ShouldReturnErrorIfIndexIsCorrupted(t *testing.T) {
 	require.Nil(t, idx)
 }
 
+func TestReadIndex_ShouldReturnErrorIfKeyAccessDeniedErr(t *testing.T) {
+	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+	bkt = &cortex_testutil.MockBucketFailure{
+		Bucket: bkt,
+		GetFailures: map[string]error{
+			path.Join("user-1", "bucket-index.json.gz"): cortex_testutil.ErrKeyAccessDeniedError,
+		},
+	}
+	idx, err := ReadIndex(context.Background(), bkt, "user-1", nil, log.NewNopLogger())
+	require.Equal(t, ErrCustomerManagedKeyError, err)
+	require.Nil(t, idx)
+}
+
 func TestReadIndex_ShouldReturnTheParsedIndexOnSuccess(t *testing.T) {
 	const userID = "user-1"
 

--- a/pkg/storage/tsdb/bucketindex/storage_test.go
+++ b/pkg/storage/tsdb/bucketindex/storage_test.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
 
 	"github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"
 	cortex_testutil "github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"

--- a/pkg/storage/tsdb/bucketindex/storage_test.go
+++ b/pkg/storage/tsdb/bucketindex/storage_test.go
@@ -2,6 +2,7 @@ package bucketindex
 
 import (
 	"context"
+	"errors"
 	"path"
 	"strings"
 	"testing"
@@ -47,7 +48,7 @@ func TestReadIndex_ShouldReturnErrorIfKeyAccessDeniedErr(t *testing.T) {
 		},
 	}
 	idx, err := ReadIndex(context.Background(), bkt, "user-1", nil, log.NewNopLogger())
-	require.Equal(t, bucket.ErrCustomerManagedKeyError, err)
+	require.True(t, errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied))
 	require.Nil(t, idx)
 }
 

--- a/pkg/storage/tsdb/bucketindex/updater.go
+++ b/pkg/storage/tsdb/bucketindex/updater.go
@@ -132,7 +132,7 @@ func (w *Updater) updateBlockIndexEntry(ctx context.Context, id ulid.ULID) (*Blo
 	metaFile := path.Join(id.String(), block.MetaFilename)
 
 	// Get the block's meta.json file.
-	r, err := w.bkt.ReaderWithExpectedErrs(tsdb.IsObjNotFoundOrCustomerManagedKeyErr(w.bkt)).Get(ctx, metaFile)
+	r, err := w.bkt.ReaderWithExpectedErrs(tsdb.IsOneOfTheExpectedErrors(w.bkt.IsObjNotFoundErr, w.bkt.IsCustomerManagedKeyError)).Get(ctx, metaFile)
 	if w.bkt.IsObjNotFoundErr(err) {
 		return nil, ErrBlockMetaNotFound
 	}

--- a/pkg/storage/tsdb/bucketindex/updater_test.go
+++ b/pkg/storage/tsdb/bucketindex/updater_test.go
@@ -138,6 +138,50 @@ func TestUpdater_UpdateIndex_ShouldNotIncreaseOperationFailureMetric(t *testing.
 		`), "thanos_objstore_bucket_operation_failures_total"))
 }
 
+func TestUpdater_UpdateIndex_ShouldNotIncreaseOperationFailureMetricCustomerKey(t *testing.T) {
+	const userID = "user-1"
+
+	bkt, _ := testutil.PrepareFilesystemBucket(t)
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	registry := prometheus.NewRegistry()
+
+	// Mock some blocks in the storage.
+	bkt = BucketWithGlobalMarkers(bkt)
+	bkt = objstore.BucketWithMetrics("test-bucket", bkt, prometheus.WrapRegistererWithPrefix("thanos_", registry))
+	block1 := testutil.MockStorageBlock(t, bkt, userID, 10, 20)
+	block2 := testutil.MockStorageBlock(t, bkt, userID, 20, 30)
+
+	bkt = &testutil.MockBucketFailure{
+		Bucket: bkt,
+		GetFailures: map[string]error{
+			path.Join(userID, block2.ULID.String(), "meta.json"): testutil.ErrKeyAccessDeniedError,
+		},
+	}
+
+	w := NewUpdater(bkt, userID, nil, logger)
+	idx, partials, _, err := w.UpdateIndex(ctx, nil)
+	require.NoError(t, err)
+	assert.Len(t, partials, 1)
+	assert.True(t, errors.Is(partials[block2.ULID], ErrBlockMetaKeyAccessDeniedErr))
+	assertBucketIndexEqual(t, idx, bkt, userID,
+		[]tsdb.BlockMeta{block1},
+		[]*metadata.DeletionMark{})
+
+	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
+			# HELP thanos_objstore_bucket_operation_failures_total Total number of operations against a bucket that failed, but were not expected to fail in certain way from caller perspective. Those errors have to be investigated.
+			# TYPE thanos_objstore_bucket_operation_failures_total counter
+			thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="attributes"} 0
+            thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="delete"} 0
+            thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="exists"} 0
+            thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="get"} 0
+            thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="get_range"} 0
+            thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="iter"} 0
+            thanos_objstore_bucket_operation_failures_total{bucket="test-bucket",operation="upload"} 0
+		`), "thanos_objstore_bucket_operation_failures_total"))
+}
+
 func TestUpdater_UpdateIndex_ShouldSkipBlocksWithCorruptedMeta(t *testing.T) {
 	const userID = "user-1"
 

--- a/pkg/storage/tsdb/bucketindex/updater_test.go
+++ b/pkg/storage/tsdb/bucketindex/updater_test.go
@@ -164,7 +164,7 @@ func TestUpdater_UpdateIndex_ShouldNotIncreaseOperationFailureMetricCustomerKey(
 	idx, partials, _, err := w.UpdateIndex(ctx, nil)
 	require.NoError(t, err)
 	assert.Len(t, partials, 1)
-	assert.True(t, errors.Is(partials[block2.ULID], ErrBlockMetaKeyAccessDeniedErr))
+	assert.True(t, errors.Is(partials[block2.ULID], errBlockMetaKeyAccessDeniedErr))
 	assertBucketIndexEqual(t, idx, bkt, userID,
 		[]tsdb.BlockMeta{block1},
 		[]*metadata.DeletionMark{})

--- a/pkg/storage/tsdb/testutil/objstore.go
+++ b/pkg/storage/tsdb/testutil/objstore.go
@@ -6,10 +6,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
+
+	"github.com/cortexproject/cortex/pkg/util"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket/filesystem"
 )

--- a/pkg/storage/tsdb/testutil/objstore.go
+++ b/pkg/storage/tsdb/testutil/objstore.go
@@ -1,14 +1,20 @@
 package testutil
 
 import (
+	"context"
+	"io"
 	"os"
 	"testing"
 
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket/filesystem"
 )
+
+var ErrKeyAccessDeniedError = errors.New("test key access denied")
 
 func PrepareFilesystemBucket(t testing.TB) (objstore.Bucket, string) {
 	storageDir, err := os.MkdirTemp(os.TempDir(), "bucket")
@@ -22,4 +28,46 @@ func PrepareFilesystemBucket(t testing.TB) (objstore.Bucket, string) {
 	require.NoError(t, err)
 
 	return objstore.BucketWithMetrics("test", bkt, nil), storageDir
+}
+
+type MockBucketFailure struct {
+	objstore.Bucket
+
+	DeleteFailures []string
+	GetFailures    map[string]error
+}
+
+func (m *MockBucketFailure) Delete(ctx context.Context, name string) error {
+	if util.StringsContain(m.DeleteFailures, name) {
+		return errors.New("mocked delete failure")
+	}
+	return m.Bucket.Delete(ctx, name)
+}
+
+func (m *MockBucketFailure) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	if e, ok := m.GetFailures[name]; ok {
+		return nil, e
+	}
+
+	return m.Bucket.Get(ctx, name)
+}
+
+func (m *MockBucketFailure) WithExpectedErrs(expectedFunc objstore.IsOpFailureExpectedFunc) objstore.Bucket {
+	if ibkt, ok := m.Bucket.(objstore.InstrumentedBucket); ok {
+		return &MockBucketFailure{Bucket: ibkt.WithExpectedErrs(expectedFunc), DeleteFailures: m.DeleteFailures, GetFailures: m.GetFailures}
+	}
+
+	return m.WithExpectedErrs(expectedFunc)
+}
+
+func (m *MockBucketFailure) ReaderWithExpectedErrs(expectedFunc objstore.IsOpFailureExpectedFunc) objstore.BucketReader {
+	if ibkt, ok := m.Bucket.(objstore.InstrumentedBucket); ok {
+		return &MockBucketFailure{Bucket: ibkt.WithExpectedErrs(expectedFunc), DeleteFailures: m.DeleteFailures, GetFailures: m.GetFailures}
+	}
+
+	return m
+}
+
+func (m *MockBucketFailure) IsCustomerManagedKeyError(err error) bool {
+	return errors.Is(err, ErrKeyAccessDeniedError)
 }

--- a/pkg/storage/tsdb/testutil/objstore.go
+++ b/pkg/storage/tsdb/testutil/objstore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -46,6 +47,11 @@ func (m *MockBucketFailure) Delete(ctx context.Context, name string) error {
 }
 
 func (m *MockBucketFailure) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	for prefix, err := range m.GetFailures {
+		if strings.HasPrefix(name, prefix) {
+			return nil, err
+		}
+	}
 	if e, ok := m.GetFailures[name]; ok {
 		return nil, e
 	}
@@ -58,7 +64,7 @@ func (m *MockBucketFailure) WithExpectedErrs(expectedFunc objstore.IsOpFailureEx
 		return &MockBucketFailure{Bucket: ibkt.WithExpectedErrs(expectedFunc), DeleteFailures: m.DeleteFailures, GetFailures: m.GetFailures}
 	}
 
-	return m.WithExpectedErrs(expectedFunc)
+	return m
 }
 
 func (m *MockBucketFailure) ReaderWithExpectedErrs(expectedFunc objstore.IsOpFailureExpectedFunc) objstore.BucketReader {

--- a/pkg/storage/tsdb/util.go
+++ b/pkg/storage/tsdb/util.go
@@ -17,8 +17,13 @@ func HashBlockID(id ulid.ULID) uint32 {
 	return h
 }
 
-func IsObjNotFoundOrCustomerManagedKeyErr(bkt objstore.Bucket) objstore.IsOpFailureExpectedFunc {
+func IsOneOfTheExpectedErrors(f ...objstore.IsOpFailureExpectedFunc) objstore.IsOpFailureExpectedFunc {
 	return func(err error) bool {
-		return bkt.IsObjNotFoundErr(err) || bkt.IsCustomerManagedKeyError(err)
+		for _, f := range f {
+			if f(err) {
+				return true
+			}
+		}
+		return false
 	}
 }

--- a/pkg/storage/tsdb/util.go
+++ b/pkg/storage/tsdb/util.go
@@ -2,6 +2,7 @@ package tsdb
 
 import (
 	"github.com/oklog/ulid"
+	"github.com/thanos-io/objstore"
 
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 )
@@ -14,4 +15,10 @@ func HashBlockID(id ulid.ULID) uint32 {
 		h = client.HashAddByte32(h, b)
 	}
 	return h
+}
+
+func IsObjNotFoundOrCustomerManagedKeyErr(bkt objstore.Bucket) objstore.IsOpFailureExpectedFunc {
+	return func(err error) bool {
+		return bkt.IsObjNotFoundErr(err) || bkt.IsCustomerManagedKeyError(err)
+	}
 }

--- a/pkg/storegateway/bucket_index_metadata_fetcher.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher.go
@@ -68,7 +68,7 @@ func (f *BucketIndexMetadataFetcher) Fetch(ctx context.Context) (metas map[ulid.
 	start := time.Now()
 	defer func() {
 		f.metrics.SyncDuration.Observe(time.Since(start).Seconds())
-		if err != nil && !errors.Is(err, bucket.ErrCustomerManagedKeyError) {
+		if err != nil && !errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied) {
 			f.metrics.SyncFailures.Inc()
 		}
 	}()
@@ -95,14 +95,14 @@ func (f *BucketIndexMetadataFetcher) Fetch(ctx context.Context) (metas map[ulid.
 		return nil, nil, nil
 	}
 
-	if errors.Is(err, bucket.ErrCustomerManagedKeyError) {
+	if errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied) {
 		// stop the job and return the error
 		// this error should be used to return Access Denied to the caller
 		level.Error(f.logger).Log("msg", "bucket index key permission revoked", "user", f.userID, "err", err)
 		f.metrics.Synced.WithLabelValues(keyAccessDenied).Set(1)
 		f.metrics.Submit()
 
-		return nil, nil, bucket.ErrCustomerManagedKeyError
+		return nil, nil, err
 	}
 
 	if err != nil {

--- a/pkg/storegateway/bucket_index_metadata_fetcher_test.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher_test.go
@@ -106,11 +106,11 @@ func TestBucketIndexMetadataFetcher_Fetch_KeyPermissionDenied(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	ctx := context.Background()
 
-	bkt.MockGet(userID+"/bucket-index.json.gz", "c", bucketindex.ErrBlockMetaKeyAccessDeniedErr)
+	bkt.MockGet(userID+"/bucket-index.json.gz", "c", bucketindex.ErrCustomerManagedKeyError)
 
 	fetcher := NewBucketIndexMetadataFetcher(userID, bkt, NewNoShardingStrategy(), nil, log.NewNopLogger(), reg, nil)
 	metas, _, err := fetcher.Fetch(ctx)
-	require.NoError(t, err)
+	require.ErrorIs(t, bucketindex.ErrCustomerManagedKeyError, err)
 	assert.Empty(t, metas)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`

--- a/pkg/storegateway/bucket_index_metadata_fetcher_test.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher_test.go
@@ -106,11 +106,11 @@ func TestBucketIndexMetadataFetcher_Fetch_KeyPermissionDenied(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	ctx := context.Background()
 
-	bkt.MockGet(userID+"/bucket-index.json.gz", "c", bucketindex.ErrCustomerManagedKeyError)
+	bkt.MockGet(userID+"/bucket-index.json.gz", "c", bucket.ErrCustomerManagedKeyError)
 
 	fetcher := NewBucketIndexMetadataFetcher(userID, bkt, NewNoShardingStrategy(), nil, log.NewNopLogger(), reg, nil)
 	metas, _, err := fetcher.Fetch(ctx)
-	require.ErrorIs(t, bucketindex.ErrCustomerManagedKeyError, err)
+	require.ErrorIs(t, bucket.ErrCustomerManagedKeyError, err)
 	assert.Empty(t, metas)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`

--- a/pkg/storegateway/bucket_index_metadata_fetcher_test.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher_test.go
@@ -99,6 +99,53 @@ func TestBucketIndexMetadataFetcher_Fetch(t *testing.T) {
 	))
 }
 
+func TestBucketIndexMetadataFetcher_Fetch_KeyPermissionDenied(t *testing.T) {
+	const userID = "user-1"
+
+	bkt := &bucket.ClientMock{}
+	reg := prometheus.NewPedanticRegistry()
+	ctx := context.Background()
+
+	bkt.MockGet(userID+"/bucket-index.json.gz", "c", bucketindex.ErrBlockMetaKeyAccessDeniedErr)
+
+	fetcher := NewBucketIndexMetadataFetcher(userID, bkt, NewNoShardingStrategy(), nil, log.NewNopLogger(), reg, nil)
+	metas, _, err := fetcher.Fetch(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, metas)
+
+	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+		# HELP blocks_meta_modified Number of blocks whose metadata changed
+		# TYPE blocks_meta_modified gauge
+		blocks_meta_modified{modified="replica-label-removed"} 0
+		# HELP blocks_meta_sync_failures_total Total blocks metadata synchronization failures
+		# TYPE blocks_meta_sync_failures_total counter
+		blocks_meta_sync_failures_total 0
+		# HELP blocks_meta_synced Number of block metadata synced
+		# TYPE blocks_meta_synced gauge
+		blocks_meta_synced{state="corrupted-bucket-index"} 0
+		blocks_meta_synced{state="corrupted-meta-json"} 0
+		blocks_meta_synced{state="duplicate"} 0
+		blocks_meta_synced{state="failed"} 0
+		blocks_meta_synced{state="key-access-denied"} 1
+		blocks_meta_synced{state="label-excluded"} 0
+		blocks_meta_synced{state="loaded"} 0
+		blocks_meta_synced{state="marked-for-deletion"} 0
+		blocks_meta_synced{state="marked-for-no-compact"} 0
+		blocks_meta_synced{state="no-bucket-index"} 0
+		blocks_meta_synced{state="no-meta-json"} 0
+		blocks_meta_synced{state="time-excluded"} 0
+		blocks_meta_synced{state="too-fresh"} 0
+		# HELP blocks_meta_syncs_total Total blocks metadata synchronization attempts
+		# TYPE blocks_meta_syncs_total counter
+		blocks_meta_syncs_total 1
+	`),
+		"blocks_meta_modified",
+		"blocks_meta_sync_failures_total",
+		"blocks_meta_synced",
+		"blocks_meta_syncs_total",
+	))
+}
+
 func TestBucketIndexMetadataFetcher_Fetch_NoBucketIndex(t *testing.T) {
 	t.Parallel()
 	const userID = "user-1"

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -78,11 +78,6 @@ type BucketStores struct {
 	tenantsSynced     prometheus.Gauge
 }
 
-type BucketStoreWithLastError struct {
-	*store.BucketStore
-	err error
-}
-
 // NewBucketStores makes a new BucketStores.
 func NewBucketStores(cfg tsdb.BlocksStorageConfig, shardingStrategy ShardingStrategy, bucketClient objstore.Bucket, limits *validation.Overrides, logLevel logging.Level, logger log.Logger, reg prometheus.Registerer) (*BucketStores, error) {
 	cachingBucket, err := tsdb.CreateCachingBucket(cfg.BucketStore.ChunksCache, cfg.BucketStore.MetadataCache, bucketClient, logger, reg)
@@ -105,7 +100,7 @@ func NewBucketStores(cfg tsdb.BlocksStorageConfig, shardingStrategy ShardingStra
 		bucket:             cachingBucket,
 		shardingStrategy:   shardingStrategy,
 		stores:             map[string]*store.BucketStore{},
-		storesErrors: 		map[string]error{},
+		storesErrors:       map[string]error{},
 		logLevel:           logLevel,
 		bucketStoreMetrics: NewBucketStoreMetrics(),
 		metaFetcherMetrics: NewMetadataFetcherMetrics(),

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -335,7 +335,19 @@ func (u *BucketStores) LabelNames(ctx context.Context, req *storepb.LabelNamesRe
 		return &storepb.LabelNamesResponse{}, nil
 	}
 
-	return store.LabelNames(ctx, req)
+	err := u.getStoreError(userID)
+
+	if err != nil && errors.Is(err, bucket.ErrCustomerManagedKeyError) {
+		return nil, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", err)
+	}
+
+	resp, err := store.LabelNames(ctx, req)
+
+	if err != nil && errors.Is(err, bucket.ErrCustomerManagedKeyError) {
+		return resp, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", err)
+	}
+
+	return resp, err
 }
 
 // LabelValues implements the Storegateway proto service.
@@ -353,7 +365,19 @@ func (u *BucketStores) LabelValues(ctx context.Context, req *storepb.LabelValues
 		return &storepb.LabelValuesResponse{}, nil
 	}
 
-	return store.LabelValues(ctx, req)
+	err := u.getStoreError(userID)
+
+	if err != nil && errors.Is(err, bucket.ErrCustomerManagedKeyError) {
+		return nil, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", err)
+	}
+
+	resp, err := store.LabelValues(ctx, req)
+
+	if err != nil && errors.Is(err, bucket.ErrCustomerManagedKeyError) {
+		return resp, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", err)
+	}
+
+	return resp, err
 }
 
 // scanUsers in the bucket and return the list of found users. If an error occurs while

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -32,8 +32,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/cortexproject/cortex/pkg/storage/tsdb/bucketindex"
-
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util/backoff"
@@ -234,7 +232,7 @@ func (u *BucketStores) syncUsersBlocks(ctx context.Context, f func(context.Conte
 
 			for job := range jobs {
 				if err := f(ctx, job.store.BucketStore); err != nil {
-					if errors.Is(err, bucketindex.ErrCustomerManagedKeyError) {
+					if errors.Is(err, bucket.ErrCustomerManagedKeyError) {
 						job.store.err = err
 					} else {
 						errsMx.Lock()
@@ -300,7 +298,7 @@ func (u *BucketStores) Series(req *storepb.SeriesRequest, srv storepb.Store_Seri
 		return nil
 	}
 
-	if store.err != nil && errors.Is(store.err, bucketindex.ErrCustomerManagedKeyError) {
+	if store.err != nil && errors.Is(store.err, bucket.ErrCustomerManagedKeyError) {
 		return httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", store.err)
 	}
 
@@ -309,7 +307,7 @@ func (u *BucketStores) Series(req *storepb.SeriesRequest, srv storepb.Store_Seri
 		ctx:                spanCtx,
 	})
 
-	if err != nil && errors.Is(err, bucketindex.ErrCustomerManagedKeyError) {
+	if err != nil && errors.Is(err, bucket.ErrCustomerManagedKeyError) {
 		return httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", err)
 	}
 

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -76,24 +76,24 @@ func TestBucketStores_CustomerKeyError(t *testing.T) {
 
 	// Should set the error on user-1
 	require.NoError(t, stores.InitialSync(ctx))
-	require.ErrorIs(t, stores.storesErrors["user-1"], bucket.ErrCustomerManagedKeyError)
+	require.ErrorIs(t, stores.storesErrors["user-1"], bucket.ErrCustomerManagedKeyAccessDenied)
 	require.ErrorIs(t, stores.storesErrors["user-2"], nil)
 	require.NoError(t, stores.SyncBlocks(context.Background()))
-	require.ErrorIs(t, stores.storesErrors["user-1"], bucket.ErrCustomerManagedKeyError)
+	require.ErrorIs(t, stores.storesErrors["user-1"], bucket.ErrCustomerManagedKeyAccessDenied)
 	require.ErrorIs(t, stores.storesErrors["user-2"], nil)
 
 	_, _, err = querySeries(stores, "user-1", "anything", 0, 100)
-	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyError))
+	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyAccessDenied))
 	_, err = queryLabelsNames(stores, "user-1", "anything")
-	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyError))
+	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyAccessDenied))
 	_, err = queryLabelsValues(stores, "user-1", "anything")
-	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyError))
+	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyAccessDenied))
 	_, _, err = querySeries(stores, "user-2", "anything", 0, 100)
 	require.NoError(t, err)
 	_, err = queryLabelsNames(stores, "user-1", "anything")
-	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyError))
+	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyAccessDenied))
 	_, err = queryLabelsValues(stores, "user-1", "anything")
-	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyError))
+	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyAccessDenied))
 
 	// Cleaning the error
 	mBucket.GetFailures = map[string]error{}

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -1,0 +1,47 @@
+package errors
+
+import "errors"
+
+type errWithCause struct {
+	error
+	cause error
+}
+
+func (e errWithCause) Error() string {
+	return e.error.Error()
+}
+
+// Cause To support errors.Cause().
+func (e errWithCause) Cause() error {
+	return e.cause
+}
+
+// Is To support errors.Is().
+func (e errWithCause) Is(err error) bool {
+	return errors.Is(err, e.error) || errors.Is(err, e.cause)
+}
+
+// Unwrap To support errors.Unwrap().
+func (e errWithCause) Unwrap() error {
+	return e.cause
+}
+
+// WithCause wrappers err with a error cause
+func WithCause(err, cause error) error {
+	return errWithCause{
+		error: err,
+		cause: cause,
+	}
+}
+
+// ErrorIs is similar to `errors.Is` but receives a function to compare
+func ErrorIs(err error, f func(err error) bool) bool {
+	for {
+		if f(err) {
+			return true
+		}
+		if err = errors.Unwrap(err); err == nil {
+			return false
+		}
+	}
+}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -24,6 +24,13 @@ const (
 	GlobalIngestionRateStrategy = "global"
 )
 
+// AccessDeniedError are errors that do not comply with the limits specified.
+type AccessDeniedError string
+
+func (e AccessDeniedError) Error() string {
+	return string(e)
+}
+
 // LimitError are errors that do not comply with the limits specified.
 type LimitError string
 

--- a/vendor/github.com/thanos-io/objstore/CHANGELOG.md
+++ b/vendor/github.com/thanos-io/objstore/CHANGELOG.md
@@ -22,6 +22,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#43](https://github.com/thanos-io/objstore/pull/43) filesystem: abort filesystem bucket operations if the context has been cancelled
 - [#44](https://github.com/thanos-io/objstore/pull/44) Add new metric to count total number of fetched bytes from bucket
 - [#50](https://github.com/thanos-io/objstore/pull/50) Add Huawei Cloud OBS Object Storage Support
+- [#59](https://github.com/thanos-io/objstore/pull/59) Adding method `IsCustomerManagedKeyError` on the bucket interface. 
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/vendor/github.com/thanos-io/objstore/inmem.go
+++ b/vendor/github.com/thanos-io/objstore/inmem.go
@@ -207,6 +207,11 @@ func (b *InMemBucket) IsObjNotFoundErr(err error) bool {
 	return errors.Is(err, errNotFound)
 }
 
+// IsCustomerManagedKeyError returns true if the permissions for key used to encrypt the object was revoked.
+func (b *InMemBucket) IsCustomerManagedKeyError(_ error) bool {
+	return false
+}
+
 func (b *InMemBucket) Close() error { return nil }
 
 // Name returns the bucket name.

--- a/vendor/github.com/thanos-io/objstore/objstore.go
+++ b/vendor/github.com/thanos-io/objstore/objstore.go
@@ -85,6 +85,9 @@ type BucketReader interface {
 	// IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
 	IsObjNotFoundErr(err error) bool
 
+	// IsCustomerManagedKeyError returns true if the permissions for key used to encrypt the object was revoked.
+	IsCustomerManagedKeyError(err error) bool
+
 	// Attributes returns information about the specified object.
 	Attributes(ctx context.Context, name string) (ObjectAttributes, error)
 }
@@ -601,6 +604,10 @@ func (b *metricBucket) Delete(ctx context.Context, name string) error {
 
 func (b *metricBucket) IsObjNotFoundErr(err error) bool {
 	return b.bkt.IsObjNotFoundErr(err)
+}
+
+func (b *metricBucket) IsCustomerManagedKeyError(err error) bool {
+	return b.bkt.IsCustomerManagedKeyError(err)
 }
 
 func (b *metricBucket) Close() error {

--- a/vendor/github.com/thanos-io/objstore/prefixed_bucket.go
+++ b/vendor/github.com/thanos-io/objstore/prefixed_bucket.go
@@ -74,6 +74,11 @@ func (p *PrefixedBucket) IsObjNotFoundErr(err error) bool {
 	return p.bkt.IsObjNotFoundErr(err)
 }
 
+// IsCustomerManagedKeyError returns true if the permissions for key used to encrypt the object was revoked.
+func (p *PrefixedBucket) IsCustomerManagedKeyError(err error) bool {
+	return p.bkt.IsCustomerManagedKeyError(err)
+}
+
 // Attributes returns information about the specified object.
 func (p PrefixedBucket) Attributes(ctx context.Context, name string) (ObjectAttributes, error) {
 	return p.bkt.Attributes(ctx, conditionalPrefix(p.prefix, name))

--- a/vendor/github.com/thanos-io/objstore/providers/azure/azure.go
+++ b/vendor/github.com/thanos-io/objstore/providers/azure/azure.go
@@ -235,6 +235,11 @@ func (b *Bucket) IsObjNotFoundErr(err error) bool {
 	return bloberror.HasCode(err, bloberror.BlobNotFound) || bloberror.HasCode(err, bloberror.InvalidURI)
 }
 
+// IsCustomerManagedKeyError returns true if the permissions for key used to encrypt the object was revoked.
+func (b *Bucket) IsCustomerManagedKeyError(_ error) bool {
+	return false
+}
+
 func (b *Bucket) getBlobReader(ctx context.Context, name string, httpRange blob.HTTPRange) (io.ReadCloser, error) {
 	level.Debug(b.logger).Log("msg", "getting blob", "blob", name, "offset", httpRange.Offset, "length", httpRange.Count)
 	if name == "" {

--- a/vendor/github.com/thanos-io/objstore/providers/filesystem/filesystem.go
+++ b/vendor/github.com/thanos-io/objstore/providers/filesystem/filesystem.go
@@ -258,6 +258,11 @@ func (b *Bucket) IsObjNotFoundErr(err error) bool {
 	return os.IsNotExist(errors.Cause(err))
 }
 
+// IsCustomerManagedKeyError returns true if the permissions for key used to encrypt the object was revoked.
+func (b *Bucket) IsCustomerManagedKeyError(_ error) bool {
+	return false
+}
+
 func (b *Bucket) Close() error { return nil }
 
 // Name returns the bucket name.

--- a/vendor/github.com/thanos-io/objstore/providers/gcs/gcs.go
+++ b/vendor/github.com/thanos-io/objstore/providers/gcs/gcs.go
@@ -188,6 +188,11 @@ func (b *Bucket) IsObjNotFoundErr(err error) bool {
 	return errors.Is(err, storage.ErrObjectNotExist)
 }
 
+// IsCustomerManagedKeyError returns true if the permissions for key used to encrypt the object was revoked.
+func (b *Bucket) IsCustomerManagedKeyError(_ error) bool {
+	return false
+}
+
 func (b *Bucket) Close() error {
 	return b.closer.Close()
 }

--- a/vendor/github.com/thanos-io/objstore/providers/s3/s3.go
+++ b/vendor/github.com/thanos-io/objstore/providers/s3/s3.go
@@ -98,6 +98,9 @@ const (
 
 	// Storage class header.
 	amzStorageClass = "X-Amz-Storage-Class"
+
+	// amzKmsKeyAccessDeniedErrorMessage is the error message returned by s3 when the permissions to the KMS key is revoked.
+	amzKmsKeyAccessDeniedErrorMessage = "The ciphertext refers to a customer master key that does not exist, does not exist in this region, or you are not allowed to access."
 )
 
 var DefaultConfig = Config{
@@ -144,7 +147,7 @@ type Config struct {
 }
 
 // SSEConfig deals with the configuration of SSE for Minio. The following options are valid:
-// kmsencryptioncontext == https://docs.aws.amazon.com/kms/latest/developerguide/services-s3.html#s3-encryption-context
+// KMSEncryptionContext == https://docs.aws.amazon.com/kms/latest/developerguide/services-s3.html#s3-encryption-context
 type SSEConfig struct {
 	Type                 string            `yaml:"type"`
 	KMSKeyID             string            `yaml:"kms_key_id"`
@@ -536,6 +539,12 @@ func (b *Bucket) Delete(ctx context.Context, name string) error {
 // IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
 func (b *Bucket) IsObjNotFoundErr(err error) bool {
 	return minio.ToErrorResponse(errors.Cause(err)).Code == "NoSuchKey"
+}
+
+// IsCustomerManagedKeyError returns true if the permissions for key used to encrypt the object was revoked.
+func (b *Bucket) IsCustomerManagedKeyError(err error) bool {
+	errResponse := minio.ToErrorResponse(errors.Cause(err))
+	return errResponse.Code == "AccessDenied" && errResponse.Message == amzKmsKeyAccessDeniedErrorMessage
 }
 
 func (b *Bucket) Close() error { return nil }

--- a/vendor/github.com/thanos-io/objstore/providers/swift/swift.go
+++ b/vendor/github.com/thanos-io/objstore/providers/swift/swift.go
@@ -290,6 +290,11 @@ func (c *Container) IsObjNotFoundErr(err error) bool {
 	return errors.Is(err, swift.ObjectNotFound)
 }
 
+// IsCustomerManagedKeyError returns true if the permissions for key used to encrypt the object was revoked.
+func (b *Container) IsCustomerManagedKeyError(_ error) bool {
+	return false
+}
+
 // Upload writes the contents of the reader as an object into the container.
 func (c *Container) Upload(_ context.Context, name string, r io.Reader) (err error) {
 	size, err := objstore.TryToGetSize(r)

--- a/vendor/github.com/thanos-io/objstore/testing.go
+++ b/vendor/github.com/thanos-io/objstore/testing.go
@@ -308,3 +308,7 @@ func (d *delayingBucket) IsObjNotFoundErr(err error) bool {
 	// No delay for a local operation.
 	return d.bkt.IsObjNotFoundErr(err)
 }
+
+func (d *delayingBucket) IsCustomerManagedKeyError(err error) bool {
+	return d.bkt.IsCustomerManagedKeyError(err)
+}

--- a/vendor/github.com/thanos-io/objstore/tracing.go
+++ b/vendor/github.com/thanos-io/objstore/tracing.go
@@ -101,6 +101,10 @@ func (t TracingBucket) IsObjNotFoundErr(err error) bool {
 	return t.bkt.IsObjNotFoundErr(err)
 }
 
+func (t TracingBucket) IsCustomerManagedKeyError(err error) bool {
+	return t.bkt.IsCustomerManagedKeyError(err)
+}
+
 func (t TracingBucket) WithExpectedErrs(expectedFunc IsOpFailureExpectedFunc) Bucket {
 	if ib, ok := t.bkt.(InstrumentedBucket); ok {
 		return TracingBucket{bkt: ib.WithExpectedErrs(expectedFunc)}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -832,7 +832,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thanos-io/objstore v0.0.0-20230522103316-23ebe2eacadd
+# github.com/thanos-io/objstore v0.0.0-20230629211010-ff1b35b9841a
 ## explicit; go 1.18
 github.com/thanos-io/objstore
 github.com/thanos-io/objstore/exthttp


### PR DESCRIPTION
**What this PR does**:

Handling CMK AccessDenied errors.
This will not fix all CMK related errors when the key is revoked so probably some other follow up PR will be needed to handle other edge cases.

Fixes:

* StoreGateway should not fail on startup when it cannot read the bucket index (access denied)
* StoreGateway should unload all the blocks when it has not access to the tenant bucket index.
* Query should return 4xx when it cannot read the bucket index due kms access denied errors.
* kms access denied errors should not be reported as bucket failures (metric)

This also update thanos objstore to bring https://github.com/thanos-io/objstore/pull/59

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
