### PR TITLE
Expose KeepInstanceInTheRingOnShutdown config for store gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [FEATURE] Querier: Log query stats when querying store gateway. #5376
 * [FEATURE] Querier/StoreGateway: Allow the tenant shard sizes to be a percent of total instances. #5393
 * [FEATURE] Added the flag `-alertmanager.api-concurrency` to configure alert manager api concurrency limit. #5412
+* [FEATURE] Store Gateway: Add `-store-gateway.sharding-ring.keep-instance-in-the-ring-on-shutdown` to skip unregistering instance from the ring in shutdown. #5421
 * [ENHANCEMENT] Distributor/Ingester: Add span on push path #5319
 * [ENHANCEMENT] Support object storage backends for runtime configuration file. #5292
 * [ENHANCEMENT] Query Frontend: Reject subquery with too small step size. #5323

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -282,6 +282,12 @@ store_gateway:
     # CLI flag: -store-gateway.sharding-ring.zone-awareness-enabled
     [zone_awareness_enabled: <boolean> | default = false]
 
+    # True to keep the store gateway instance in the ring when it shuts down.
+    # The instance will then be auto-forgotten from the ring after
+    # 10*heartbeat_timeout.
+    # CLI flag: -store-gateway.sharding-ring.keep-instance-in-the-ring-on-shutdown
+    [keep_instance_in_the_ring_on_shutdown: <boolean> | default = false]
+
     # Minimum time to wait for ring stability at startup. 0 to disable.
     # CLI flag: -store-gateway.sharding-ring.wait-stability-min-duration
     [wait_stability_min_duration: <duration> | default = 1m]

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4801,6 +4801,12 @@ sharding_ring:
   # CLI flag: -store-gateway.sharding-ring.zone-awareness-enabled
   [zone_awareness_enabled: <boolean> | default = false]
 
+  # True to keep the store gateway instance in the ring when it shuts down. The
+  # instance will then be auto-forgotten from the ring after
+  # 10*heartbeat_timeout.
+  # CLI flag: -store-gateway.sharding-ring.keep-instance-in-the-ring-on-shutdown
+  [keep_instance_in_the_ring_on_shutdown: <boolean> | default = false]
+
   # Minimum time to wait for ring stability at startup. 0 to disable.
   # CLI flag: -store-gateway.sharding-ring.wait-stability-min-duration
   [wait_stability_min_duration: <duration> | default = 1m]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Add `-store-gateway.sharding-ring.keep-instance-in-the-ring-on-shutdown`.

The new config sets `KeepInstanceInTheRingOnShutdown` configuration in basic_lifecycler, which skips unregistering instance if set to true.

https://github.com/cortexproject/cortex/blob/6dd44ee4961d37d3ca2e79ef48714fee58b37839/pkg/ring/basic_lifecycler.go#L244-L252

Similar to `-ingester.unregister-on-shutdown`, this new config is helpful when you want to eliminate ring-sync during rollout deployment.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
