### PR TITLE
Fix bug in store gateway ring comparison logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [BUGFIX] KV: Etcd calls will no longer block indefinitely and will now time out after the DialTimeout period. #5392
 * [BUGFIX] Ring: Allow RF greater than number of zones to select more than one instance per zone #5411
 * [BUGFIX] Distributor: Fix potential data corruption in cases of timeout between distributors and ingesters. #5422
+* [BUGFIX] Store Gateway: Fix bug in store gateway ring comparison logic. #5426
 
 ## 1.15.1 2023-04-26
 

--- a/pkg/compactor/shuffle_sharding_grouper_test.go
+++ b/pkg/compactor/shuffle_sharding_grouper_test.go
@@ -761,6 +761,11 @@ func (r *RingMock) GetAllHealthy(op ring.Operation) (ring.ReplicationSet, error)
 	return args.Get(0).(ring.ReplicationSet), args.Error(1)
 }
 
+func (r *RingMock) GetInstanceDescsForOperation(op ring.Operation) (map[string]ring.InstanceDesc, error) {
+	args := r.Called(op)
+	return args.Get(0).(map[string]ring.InstanceDesc), args.Error(1)
+}
+
 func (r *RingMock) GetReplicationSetForOperation(op ring.Operation) (ring.ReplicationSet, error) {
 	args := r.Called(op)
 	return args.Get(0).(ring.ReplicationSet), args.Error(1)

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -159,6 +159,39 @@ func (i *InstanceDesc) IsReady(storageLastUpdated time.Time, heartbeatTimeout ti
 	return nil
 }
 
+func HasInstanceDescsChanged(beforeByID, afterByID map[string]InstanceDesc, hasChanged func(b, a InstanceDesc) bool) bool {
+	if len(beforeByID) != len(afterByID) {
+		return true
+	}
+
+	for id, before := range beforeByID {
+		after := afterByID[id]
+		if hasChanged(before, after) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func HasTokensChanged(before, after InstanceDesc) bool {
+	if len(before.Tokens) != len(after.Tokens) {
+		return true
+	}
+
+	for i, token := range before.Tokens {
+		if token != after.Tokens[i] {
+			return true
+		}
+	}
+
+	return false
+}
+
+func HasZoneChanged(before, after InstanceDesc) bool {
+	return before.Zone != after.Zone
+}
+
 // Merge merges other ring into this one. Returns sub-ring that represents the change,
 // and can be sent out to other clients.
 //

--- a/pkg/ring/model_test.go
+++ b/pkg/ring/model_test.go
@@ -1,7 +1,6 @@
 package ring
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -195,7 +194,7 @@ func TestHasInstanceDescsChanged_TokensOrZone(t *testing.T) {
 			hasInstanceDescsChanged := HasInstanceDescsChanged(testData.before, testData.after, func(a, b InstanceDesc) bool {
 				return HasTokensChanged(b, a) || HasZoneChanged(b, a)
 			})
-			require.Equal(t, testData.hasChanged, hasInstanceDescsChanged)
+			assert.Equal(t, testData.hasChanged, hasInstanceDescsChanged)
 		})
 	}
 }

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -145,18 +145,6 @@ func HasReplicationSetChangedWithoutState(before, after ReplicationSet) bool {
 	})
 }
 
-// HasReplicationSetChangedWithoutStateAndAddress returns false if two replications sets
-// are the same (with possibly different timestamps, instance states and address),
-// true if they differ in any other way (number of instances, tokens, or zones).
-func HasReplicationSetChangedWithoutStateAndAddress(before, after ReplicationSet) bool {
-	return hasReplicationSetChangedExcluding(before, after, func(i *InstanceDesc) {
-		i.Timestamp = 0
-		i.State = PENDING
-		i.Addr = ""
-		i.RegisteredTimestamp = 0
-	})
-}
-
 // Do comparison of replicasets, but apply a function first
 // to be able to exclude (reset) some values
 func hasReplicationSetChangedExcluding(before, after ReplicationSet, exclude func(*InstanceDesc)) bool {

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -251,10 +251,9 @@ var (
 		},
 	}
 	replicationSetChangesTestCases = map[string]struct {
-		nextState                                            ReplicationSet
-		expectHasReplicationSetChanged                       bool
-		expectHasReplicationSetChangedWithoutState           bool
-		expectHasReplicationSetChangedWithoutStateAndAddress bool
+		nextState                                  ReplicationSet
+		expectHasReplicationSetChanged             bool
+		expectHasReplicationSetChangedWithoutState bool
 	}{
 		"timestamp changed": {
 			ReplicationSet{
@@ -264,7 +263,6 @@ var (
 					{Addr: "127.0.0.3"},
 				},
 			},
-			false,
 			false,
 			false,
 		},
@@ -278,7 +276,6 @@ var (
 			},
 			true,
 			false,
-			false,
 		},
 		"more instances": {
 			ReplicationSet{
@@ -291,7 +288,6 @@ var (
 			},
 			true,
 			true,
-			true,
 		},
 		"less instances": {
 			ReplicationSet{
@@ -300,7 +296,6 @@ var (
 					{Addr: "127.0.0.2"},
 				},
 			},
-			true,
 			true,
 			true,
 		},
@@ -314,7 +309,6 @@ var (
 			},
 			true,
 			true,
-			false,
 		},
 	}
 )
@@ -333,15 +327,6 @@ func TestHasReplicationSetChangedWithoutState_IgnoresTimeStampAndState(t *testin
 	for testName, testData := range replicationSetChangesTestCases {
 		t.Run(testName, func(t *testing.T) {
 			assert.Equal(t, testData.expectHasReplicationSetChangedWithoutState, HasReplicationSetChangedWithoutState(replicationSetChangesInitialState, testData.nextState), "HasReplicationSetChangedWithoutState wrong result")
-		})
-	}
-}
-
-func TestHasReplicationSetChangedWithoutStateAndAddress_IgnoresTimeStampAndStateAndAddress(t *testing.T) {
-	// Only testing difference to underlying Equal function
-	for testName, testData := range replicationSetChangesTestCases {
-		t.Run(testName, func(t *testing.T) {
-			assert.Equal(t, testData.expectHasReplicationSetChangedWithoutStateAndAddress, HasReplicationSetChangedWithoutStateAndAddress(replicationSetChangesInitialState, testData.nextState), "HasReplicationSetChangedWithoutStateAndAddress wrong result")
 		})
 	}
 }

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -46,6 +46,9 @@ type ReadRing interface {
 	// of unhealthy instances is greater than the tolerated max unavailable.
 	GetAllHealthy(op Operation) (ReplicationSet, error)
 
+	// GetInstanceDescsForOperation returns map of InstanceDesc with instance ID as the keys.
+	GetInstanceDescsForOperation(op Operation) (map[string]InstanceDesc, error)
+
 	// GetReplicationSetForOperation returns all instances where the input operation should be executed.
 	// The resulting ReplicationSet doesn't necessarily contains all healthy instances
 	// in the ring, but could contain the minimum set of instances required to execute

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -2279,6 +2279,8 @@ func TestShuffleShardWithCaching(t *testing.T) {
 		lcs = append(lcs, lc)
 	}
 
+	time.Sleep(5 * time.Second)
+
 	// Wait until all instances in the ring are ACTIVE.
 	test.Poll(t, 5*time.Second, numLifecyclers, func() interface{} {
 		active := 0

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -555,6 +555,36 @@ func TestRing_GetAllHealthy(t *testing.T) {
 	}
 }
 
+func TestRing_GetInstanceDescsForOperation(t *testing.T) {
+	now := time.Now().Unix()
+	twoMinutesAgo := time.Now().Add(-2 * time.Minute).Unix()
+
+	ringDesc := &Desc{Ingesters: map[string]InstanceDesc{
+		"instance-1": {Addr: "127.0.0.1", Tokens: []uint32{1}, State: ACTIVE, Timestamp: now},
+		"instance-2": {Addr: "127.0.0.2", Tokens: []uint32{2}, State: LEAVING, Timestamp: now},          // not healthy state
+		"instance-3": {Addr: "127.0.0.3", Tokens: []uint32{3}, State: ACTIVE, Timestamp: twoMinutesAgo}, // heartbeat timed out
+	}}
+
+	ring := Ring{
+		cfg:                 Config{HeartbeatTimeout: time.Minute},
+		ringDesc:            ringDesc,
+		ringTokens:          ringDesc.GetTokens(),
+		ringTokensByZone:    ringDesc.getTokensByZone(),
+		ringInstanceByToken: ringDesc.getTokensInfo(),
+		ringZones:           getZones(ringDesc.getTokensByZone()),
+		strategy:            NewDefaultReplicationStrategy(),
+		KVClient:            &MockClient{},
+	}
+
+	testOp := NewOp([]InstanceState{ACTIVE}, nil)
+
+	instanceDescs, err := ring.GetInstanceDescsForOperation(testOp)
+	require.NoError(t, err)
+	require.EqualValues(t, map[string]InstanceDesc{
+		"instance-1": {Addr: "127.0.0.1", Tokens: []uint32{1}, State: ACTIVE, Timestamp: now},
+	}, instanceDescs)
+}
+
 func TestRing_GetReplicationSetForOperation(t *testing.T) {
 	now := time.Now()
 

--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -31,6 +31,11 @@ func (r *RingMock) GetAllHealthy(op Operation) (ReplicationSet, error) {
 	return args.Get(0).(ReplicationSet), args.Error(1)
 }
 
+func (r *RingMock) GetInstanceDescsForOperation(op Operation) (map[string]InstanceDesc, error) {
+	args := r.Called(op)
+	return args.Get(0).(map[string]InstanceDesc), args.Error(1)
+}
+
 func (r *RingMock) GetReplicationSetForOperation(op Operation) (ReplicationSet, error) {
 	args := r.Called(op)
 	return args.Get(0).(ReplicationSet), args.Error(1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

During rollout deployment of store gateway, the ring check logic is expected to return true only if:

1. Number of instances in the ring changed
2. Tokens of the instances have changed
3. Zone of the instances have changed

However, the comparison logic`hasReplicationSetChangedExcluding` sorts the instance descriptions by address before comparing, returning true when the new instance address changes the order of the instances:

1. Before: [{Addr: 127.0.0.1, Tokens: {1, 2, 3}}, {Addr: 127.0.0.2, Tokens: {4, 5, 6}]
2. After: [{Addr: 127.0.0.3, Tokens: {1, 2, 3}}, {Addr: 127.0.0.2, Tokens: {4, 5, 6}]
3. hasRingChanged should return false, but it was returning true because of:

https://github.com/cortexproject/cortex/blob/ca0ce934d3e2d0ff0ab64c97971c04a8ba535ca3/pkg/ring/replication_set.go#L162-L171

Ideally, we want to compare instance description of same instance ID from the ring, but `ReplicationSet` does not contain the instance ID information. 

In this PR, I've created new function `ring.GetInstanceDescsForOperation` that returns `map[string]InstanceDesc`, and `HasInstanceDescsChanged` function that compares two maps with instance ID from the ring. 

Originally I tried to continue using `ReplicationSet` for the comparison. However, @yeya24 helped me to realize that I need extra information about the instance IDs, and the struct is already widely used in other codes mainly to get unsorted list of healthy instances for an operation. Rather than introducing an extra field that's conditionally used, I decided to create a new dedicated function that can make ring change logic simpler.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
