### PR TITLE
Fix flaky `TestShuffleShardWithCaching` test

### DIFF
--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -315,6 +315,12 @@ func (i *Lifecycler) getTokens() Tokens {
 	return i.tokens
 }
 
+func (i *Lifecycler) getStateAndTokens() (InstanceState, Tokens) {
+	i.stateMtx.RLock()
+	defer i.stateMtx.RUnlock()
+	return i.state, i.tokens
+}
+
 func (i *Lifecycler) setTokens(tokens Tokens) {
 	i.lifecyclerMetrics.tokensOwned.Set(float64(len(tokens)))
 
@@ -800,10 +806,9 @@ func (i *Lifecycler) updateConsul(ctx context.Context) error {
 			ringDesc.AddIngester(i.ID, i.Addr, i.Zone, i.getTokens(), i.GetState(), i.getRegisteredAt())
 		} else {
 			instanceDesc.Timestamp = time.Now().Unix()
-			instanceDesc.State = i.GetState()
+			instanceDesc.State, instanceDesc.Tokens = i.getStateAndTokens()
 			instanceDesc.Addr = i.Addr
 			instanceDesc.Zone = i.Zone
-			instanceDesc.Tokens = i.getTokens()
 			instanceDesc.RegisteredTimestamp = i.getRegisteredAt().Unix()
 			ringDesc.Ingesters[i.ID] = instanceDesc
 		}

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -803,6 +803,7 @@ func (i *Lifecycler) updateConsul(ctx context.Context) error {
 			instanceDesc.State = i.GetState()
 			instanceDesc.Addr = i.Addr
 			instanceDesc.Zone = i.Zone
+			instanceDesc.Tokens = i.getTokens()
 			instanceDesc.RegisteredTimestamp = i.getRegisteredAt().Unix()
 			ringDesc.Ingesters[i.ID] = instanceDesc
 		}


### PR DESCRIPTION
**What this PR does**:
Fix flaky `TestShuffleShardWithCaching` test.

There is a race condition where we flip the state from PENDING to ACTIVE and we heartbeat before storing on the KV.

This race condition became more evident after https://github.com/cortexproject/cortex/pull/5404 as now wen can heartbeat faster than the  heartbeat interval.

The fix seems to be get the tokens from the lifecycle (not only the state) when performing the heartbeat.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
