### PR TITLE
Fix bug where adding/removing instance with RF > len(zones) will introduce more than one member change in Get replication set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [BUGFIX] Ring: Allow RF greater than number of zones to select more than one instance per zone #5411
 * [BUGFIX] Distributor: Fix potential data corruption in cases of timeout between distributors and ingesters. #5422
 * [BUGFIX] Store Gateway: Fix bug in store gateway ring comparison logic. #5426
+* [BUGFIX] Ring: Fix bug in consistency of Get func in a scaling zone-aware ring. #5429
 
 ## 1.15.1 2023-04-26
 

--- a/pkg/compactor/shuffle_sharding_grouper_test.go
+++ b/pkg/compactor/shuffle_sharding_grouper_test.go
@@ -751,7 +751,7 @@ func (r *RingMock) Collect(ch chan<- prometheus.Metric) {}
 
 func (r *RingMock) Describe(ch chan<- *prometheus.Desc) {}
 
-func (r *RingMock) Get(key uint32, op ring.Operation, bufDescs []ring.InstanceDesc, bufHosts, bufZones []string) (ring.ReplicationSet, error) {
+func (r *RingMock) Get(key uint32, op ring.Operation, bufDescs []ring.InstanceDesc, bufHosts []string, bufZones map[string]int) (ring.ReplicationSet, error) {
 	args := r.Called(key, op, bufDescs, bufHosts, bufZones)
 	return args.Get(0).(ring.ReplicationSet), args.Error(1)
 }

--- a/pkg/ring/batch.go
+++ b/pkg/ring/batch.go
@@ -78,10 +78,10 @@ func DoBatch(ctx context.Context, op Operation, r ReadRing, keys []uint32, callb
 	var (
 		bufDescs [GetBufferSize]InstanceDesc
 		bufHosts [GetBufferSize]string
-		bufZones [GetBufferSize]string
+		bufZones = make(map[string]int, GetZoneSize)
 	)
 	for i, key := range keys {
-		replicationSet, err := r.Get(key, op, bufDescs[:0], bufHosts[:0], bufZones[:0])
+		replicationSet, err := r.Get(key, op, bufDescs[:0], bufHosts[:0], bufZones)
 		if err != nil {
 			cleanup()
 			return err

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -344,6 +344,9 @@ func (r *Ring) updateRingState(ringDesc *Desc) {
 }
 
 // Get returns n (or more) instances which form the replicas for the given key.
+// This implementation guarantees:
+// - Stability: given the same ring, two invocations returns the same set for same operation.
+// - Consistency: adding/removing 1 instance from the ring returns set with no more than 1 difference for same operation.
 func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts []string, bufZones map[string]int) (ReplicationSet, error) {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -362,7 +362,7 @@ func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts [
 		// We use a slice instead of a map because it's faster to search within a
 		// slice than lookup a map for a very low number of items.
 		distinctHosts = bufHosts[:0]
-		zones         = clearZoneMap(bufZones)
+		zones         = resetZoneMap(bufZones)
 	)
 
 	for i := start; len(distinctHosts) < replicationFactor && iterations < len(r.ringTokens); i++ {
@@ -408,10 +408,10 @@ func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts [
 			if numOfInstance, ok := zones[info.Zone]; !ok {
 				zones[info.Zone] = 1
 			} else if numOfInstance < maxInstancePerZone {
-				zones[info.Zone] += 1
+				zones[info.Zone]++
 			} else {
 				// This zone will have an extra instance
-				zones[info.Zone] += 1
+				zones[info.Zone]++
 				zonesWithExtraInstance--
 			}
 		}

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -31,6 +31,10 @@ const (
 	// GetBufferSize is the suggested size of buffers passed to Ring.Get(). It's based on
 	// a typical replication factor 3, plus extra room for a JOINING + LEAVING instance.
 	GetBufferSize = 5
+
+	// GetZoneSize is the suggested size of zone map passed to Ring.Get(). It's based on
+	// a typical replication factor 3.
+	GetZoneSize = 3
 )
 
 // ReadRing represents the read interface to the ring.
@@ -39,7 +43,7 @@ type ReadRing interface {
 	// Get returns n (or more) instances which form the replicas for the given key.
 	// bufDescs, bufHosts and bufZones are slices to be overwritten for the return value
 	// to avoid memory allocation; can be nil, or created with ring.MakeBuffersForGet().
-	Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts, bufZones []string) (ReplicationSet, error)
+	Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts []string, bufZones map[string]int) (ReplicationSet, error)
 
 	// GetAllHealthy returns all healthy instances in the ring, for the given operation.
 	// This function doesn't check if the quorum is honored, so doesn't fail if the number
@@ -340,7 +344,7 @@ func (r *Ring) updateRingState(ringDesc *Desc) {
 }
 
 // Get returns n (or more) instances which form the replicas for the given key.
-func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts, bufZones []string) (ReplicationSet, error) {
+func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts []string, bufZones map[string]int) (ReplicationSet, error) {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 	if r.ringDesc == nil || len(r.ringTokens) == 0 {
@@ -348,16 +352,19 @@ func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts, 
 	}
 
 	var (
-		replicationFactor = r.cfg.ReplicationFactor
-		instances         = bufDescs[:0]
-		start             = searchToken(r.ringTokens, key)
-		iterations        = 0
+		replicationFactor      = r.cfg.ReplicationFactor
+		instances              = bufDescs[:0]
+		start                  = searchToken(r.ringTokens, key)
+		iterations             = 0
+		maxInstancePerZone     = replicationFactor / len(r.ringZones)
+		zonesWithExtraInstance = replicationFactor % len(r.ringZones)
 
 		// We use a slice instead of a map because it's faster to search within a
 		// slice than lookup a map for a very low number of items.
 		distinctHosts = bufHosts[:0]
-		distinctZones = bufZones[:0]
+		zones         = clearZoneMap(bufZones)
 	)
+
 	for i := start; len(distinctHosts) < replicationFactor && iterations < len(r.ringTokens); i++ {
 		iterations++
 		// Wrap i around in the ring.
@@ -377,7 +384,13 @@ func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts, 
 
 		// Ignore if the instances don't have a zone set.
 		if r.cfg.ZoneAwarenessEnabled && info.Zone != "" {
-			if util.StringsContain(distinctZones, info.Zone) {
+			maxNumOfInstance := maxInstancePerZone
+			// If we still have room for zones with extra instance, increase the instance threshold by 1
+			if zonesWithExtraInstance > 0 {
+				maxNumOfInstance++
+			}
+
+			if zones[info.Zone] >= maxNumOfInstance {
 				continue
 			}
 		}
@@ -392,11 +405,14 @@ func (r *Ring) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts, 
 		} else if r.cfg.ZoneAwarenessEnabled && info.Zone != "" {
 			// We should only add the zone if we are not going to extend,
 			// as we want to extend the instance in the same AZ.
-			distinctZones = append(distinctZones, info.Zone)
-
-			if len(distinctZones) == len(r.ringZones) {
-				// reset the zones to repeatedly get hosts from distinct zones
-				distinctZones = distinctZones[:0]
+			if numOfInstance, ok := zones[info.Zone]; !ok {
+				zones[info.Zone] = 1
+			} else if numOfInstance < maxInstancePerZone {
+				zones[info.Zone] += 1
+			} else {
+				// This zone will have an extra instance
+				zones[info.Zone] += 1
+				zonesWithExtraInstance--
 			}
 		}
 

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -2322,8 +2322,8 @@ func generateRingInstances(numInstances, numZones, numTokens int) map[string]Ins
 	instances := make(map[string]InstanceDesc, numInstances)
 
 	for i := 1; i <= numInstances; i++ {
-		if numZones <= 0 {
-			numZones = -i
+		if numZones == 0 {
+			numZones = i
 		}
 
 		id, desc := generateRingInstance(i, i%numZones, numTokens)
@@ -2337,10 +2337,6 @@ func generateRingInstances(numInstances, numZones, numTokens int) map[string]Ins
 func generateRingInstance(id, zone, numTokens int) (string, InstanceDesc) {
 	instanceID := fmt.Sprintf("instance-%d", id)
 	zoneID := fmt.Sprintf("zone-%d", zone)
-
-	if zone == -1 {
-		zoneID = ""
-	}
 
 	return instanceID, generateRingInstanceWithInfo(instanceID, zoneID, GenerateTokens(numTokens, nil), time.Now())
 }

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -56,9 +56,14 @@ func benchmarkBatch(b *testing.B, numInstances, numKeys int) {
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)
 	r := Ring{
-		cfg:      cfg,
-		ringDesc: desc,
-		strategy: NewDefaultReplicationStrategy(),
+		cfg:                 cfg,
+		ringDesc:            desc,
+		strategy:            NewDefaultReplicationStrategy(),
+		ringTokens:          desc.GetTokens(),
+		ringZones:           getZones(desc.getTokensByZone()),
+		ringTokensByZone:    desc.getTokensByZone(),
+		ringInstanceByToken: desc.getTokensInfo(),
+		KVClient:            &MockClient{},
 	}
 
 	ctx := context.Background()

--- a/pkg/ring/util.go
+++ b/pkg/ring/util.go
@@ -141,11 +141,19 @@ func waitStability(ctx context.Context, r *Ring, op Operation, minStability, max
 }
 
 // MakeBuffersForGet returns buffers to use with Ring.Get().
-func MakeBuffersForGet() (bufDescs []InstanceDesc, bufHosts, bufZones []string) {
+func MakeBuffersForGet() (bufDescs []InstanceDesc, bufHosts []string, bufZones map[string]int) {
 	bufDescs = make([]InstanceDesc, 0, GetBufferSize)
 	bufHosts = make([]string, 0, GetBufferSize)
-	bufZones = make([]string, 0, GetBufferSize)
+	bufZones = make(map[string]int, GetZoneSize)
 	return
+}
+
+func clearZoneMap(zones map[string]int) map[string]int {
+	for key := range zones {
+		delete(zones, key)
+	}
+
+	return zones
 }
 
 // getZones return the list zones from the provided tokens. The returned list

--- a/pkg/ring/util.go
+++ b/pkg/ring/util.go
@@ -148,7 +148,11 @@ func MakeBuffersForGet() (bufDescs []InstanceDesc, bufHosts []string, bufZones m
 	return
 }
 
-func clearZoneMap(zones map[string]int) map[string]int {
+func resetZoneMap(zones map[string]int) map[string]int {
+	if zones == nil {
+		return make(map[string]int, GetZoneSize)
+	}
+
 	for key := range zones {
 		delete(zones, key)
 	}

--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -421,3 +421,19 @@ func TestWaitInstanceState_ExitsAfterActualStateEqualsState(t *testing.T) {
 	assert.Nil(t, err)
 	ring.AssertNumberOfCalls(t, "GetInstanceState", 1)
 }
+
+func TestResetZoneMap(t *testing.T) {
+	zoneMap := map[string]int{
+		"zone-1": 2,
+		"zone-2": 2,
+	}
+
+	newZoneMap := resetZoneMap(zoneMap)
+	assert.Equal(t, 0, len(newZoneMap))
+}
+
+func TestResetZoneMap_NilAsAnArgument(t *testing.T) {
+	zoneMap := resetZoneMap(nil)
+	zoneMap["zone-1"] = 1 // this should not panic
+	assert.Equal(t, 1, len(zoneMap))
+}

--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -21,7 +21,7 @@ func (r *RingMock) Collect(ch chan<- prometheus.Metric) {}
 
 func (r *RingMock) Describe(ch chan<- *prometheus.Desc) {}
 
-func (r *RingMock) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts, bufZones []string) (ReplicationSet, error) {
+func (r *RingMock) Get(key uint32, op Operation, bufDescs []InstanceDesc, bufHosts []string, bufZones map[string]int) (ReplicationSet, error) {
 	args := r.Called(key, op, bufDescs, bufHosts, bufZones)
 	return args.Get(0).(ReplicationSet), args.Error(1)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Given the conditions:

1. Replication factor is greater than number of zones
2. One instance is added/removed from the ring

the replication set returned by `ring.Get` can contain more than one member changed. Consider the following scenario:

![RF=6_bug](https://github.com/cortexproject/cortex/assets/18124240/b44b4702-a8fe-423a-b357-291cc693a5e6)

Initial state:
- There are 12 store-gateways in the zone-aware ring that has 3 zones
- We are calling `ring.Get` for the block `01H3EBEAT3EZA6RH49Y0PGBRQ0`, which is used for querier to find list of store-gateways to query for, and store-gateways to know if it needs to sync that block
- With RF=6 and zone-aware replication, we'll return the following six pods for the block:
  - sg1, sg3, sg5, sg6, sg8, sg10

Adding a new store-gateway:
- sg13 is added such that its token falls between sg1 and sg2
- With RF=6 and zone-aware replication, we'll return the following six pods for the block:
  - sg1, sg13, sg3, sg4, sg5, sg6
- The new replication set contains 2 new members: sg13 and sg4
- Querier might be asking for the block to sg13 and sg4, but they take a while to actually load the block

This can cause query unavailability when RF is set to 9 (3 times number of zones), as adding one instance can introduce up to 3 new members. Since querier only retries 3 times, we may return 5xx in the worst case scenario.

This PR fixes this issue such that adding/removing one instance in the ring will only introduce one new instance in the replication set returned by `ring.Get`.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

