### PR TITLE
Add _total suffix to cached posting compression time metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [CHANGE] Ruler: Added user label to `cortex_ruler_write_requests_total`, `cortex_ruler_write_requests_failed_total`, `cortex_ruler_queries_total`, and `cortex_ruler_queries_failed_total` metrics. #5312
 * [CHANGE] Alertmanager: Validating new fields on the PagerDuty AM config. #5290
 * [CHANGE] Ingester: Creating label `native-histogram-sample` on the `cortex_discarded_samples_total` to keep track of discarded native histogram samples. #5289
+* [CHANGE] Store Gateway: Rename `cortex_bucket_store_cached_postings_compression_time_seconds` to `cortex_bucket_store_cached_postings_compression_time_seconds_total`. #5431
 * [FEATURE] Store Gateway: Add `max_downloaded_bytes_per_request` to limit max bytes to download per store gateway request.
 * [FEATURE] Added 2 flags `-alertmanager.alertmanager-client.grpc-max-send-msg-size` and ` -alertmanager.alertmanager-client.grpc-max-recv-msg-size` to configure alert manager grpc client message size limits. #5338
 * [FEATURE] Query Frontend: Add `cortex_rejected_queries_total` metric for throttled queries. #5356

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -134,7 +134,7 @@ func NewBucketStoreMetrics() *BucketStoreMetrics {
 			"Number of postings compression and decompression errors.",
 			[]string{"op"}, nil),
 		cachedPostingsCompressionTimeSeconds: prometheus.NewDesc(
-			"cortex_bucket_store_cached_postings_compression_time_seconds",
+			"cortex_bucket_store_cached_postings_compression_time_seconds_total",
 			"Time spent compressing and decompressing postings when storing to / reading from postings cache.",
 			[]string{"op"}, nil),
 		cachedPostingsOriginalSizeBytes: prometheus.NewDesc(

--- a/pkg/storegateway/bucket_store_metrics_test.go
+++ b/pkg/storegateway/bucket_store_metrics_test.go
@@ -384,10 +384,10 @@ func TestBucketStoreMetrics(t *testing.T) {
 			cortex_bucket_store_cached_postings_compression_errors_total{op="encode"} 1170988
 			cortex_bucket_store_cached_postings_compression_errors_total{op="decode"} 1193507
 
-			# HELP cortex_bucket_store_cached_postings_compression_time_seconds Time spent compressing and decompressing postings when storing to / reading from postings cache.
-			# TYPE cortex_bucket_store_cached_postings_compression_time_seconds counter
-			cortex_bucket_store_cached_postings_compression_time_seconds{op="encode"} 1216026
-			cortex_bucket_store_cached_postings_compression_time_seconds{op="decode"} 1238545
+			# HELP cortex_bucket_store_cached_postings_compression_time_seconds_total Time spent compressing and decompressing postings when storing to / reading from postings cache.
+			# TYPE cortex_bucket_store_cached_postings_compression_time_seconds_total counter
+			cortex_bucket_store_cached_postings_compression_time_seconds_total{op="encode"} 1216026
+			cortex_bucket_store_cached_postings_compression_time_seconds_total{op="decode"} 1238545
 
 			# HELP cortex_bucket_store_cached_postings_original_size_bytes_total Original size of postings stored into cache.
 			# TYPE cortex_bucket_store_cached_postings_original_size_bytes_total counter


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Rename `cortex_bucket_store_cached_postings_compression_time_seconds` to `cortex_bucket_store_cached_postings_compression_time_seconds_total`.

The metric in Thanos is `thanos_bucket_store_cached_postings_compression_time_seconds_total`. It is a counter, not a histogram so add `_total` suffix to the Cortex metric as well.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
