### PR TITLE
Avoid concurrency between heartbeat and autoJoin

### DIFF
--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -2632,7 +2632,7 @@ func startLifecycler(t *testing.T, cfg Config, heartbeat time.Duration, lifecycl
 func TestShuffleShardWithCaching(t *testing.T) {
 	inmem, closer := consul.NewInMemoryClientWithConfig(GetCodec(), consul.Config{
 		MaxCasRetries: 20,
-		CasRetryDelay: 500 * time.Millisecond,
+		CasRetryDelay: 100 * time.Millisecond,
 	}, log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
@@ -2660,8 +2660,6 @@ func TestShuffleShardWithCaching(t *testing.T) {
 
 		lcs = append(lcs, lc)
 	}
-
-	time.Sleep(5 * time.Second)
 
 	// Wait until all instances in the ring are ACTIVE.
 	test.Poll(t, 5*time.Second, numLifecyclers, func() interface{} {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Add a min value to jitter delay.
Improve flake test

**Which issue(s) this PR fixes**:
On #5404 while adding jitter to heartbeat, we increased the chance of a concurrency issue between autoJoin and heartbeat. We do have in some cases where autoJoin fails and need to retry situations where a instance can go to ACTIVE with no tokens.
On #5428, we try to mitigate it by also synicng the tokens, but this can create performance overhead when we have conflict tokens between instances.
We are here adding a min value for the jitter to avoid concurrency and braking tests. 

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
