### PR TITLE
fix retry on markers

### DIFF
--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client.go
@@ -38,12 +38,12 @@ func (b *globalMarkersBucket) Upload(ctx context.Context, name string, r io.Read
 	}
 
 	// Upload it to the global marker's location.
-	if err := b.parent.Upload(ctx, globalMarkPath, bytes.NewBuffer(body)); err != nil {
+	if err := b.parent.Upload(ctx, globalMarkPath, bytes.NewReader(body)); err != nil {
 		return err
 	}
 
 	// Upload it to the original location too.
-	return b.parent.Upload(ctx, name, bytes.NewBuffer(body))
+	return b.parent.Upload(ctx, name, bytes.NewReader(body))
 }
 
 // Delete implements objstore.Bucket.

--- a/pkg/storage/tsdb/bucketindex/markers_bucket_client_test.go
+++ b/pkg/storage/tsdb/bucketindex/markers_bucket_client_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cortexproject/cortex/pkg/storage/bucket/s3"
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -16,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+
+	"github.com/cortexproject/cortex/pkg/storage/bucket/s3"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	cortex_testutil "github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"
@@ -199,7 +200,7 @@ func TestBucketWithGlobalMarkers_ShouldRetryUpload(t *testing.T) {
 				originalPath := block1.String() + "/" + tc.mark
 				err := bkt.Upload(ctx, originalPath, strings.NewReader("{}"))
 				require.Equal(t, errors.New("test"), err)
-				require.Equal(t, mBucket.UploadCalls, 5)
+				require.Equal(t, mBucket.UploadCalls.Load(), int32(5))
 			})
 		}
 

--- a/pkg/storage/tsdb/testutil/objstore.go
+++ b/pkg/storage/tsdb/testutil/objstore.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
+	"go.uber.org/atomic"
 
 	"github.com/cortexproject/cortex/pkg/util"
 
@@ -39,8 +40,8 @@ type MockBucketFailure struct {
 	GetFailures    map[string]error
 	UploadFailures map[string]error
 
-	UploadCalls int
-	GetCalls    int
+	UploadCalls atomic.Int32
+	GetCalls    atomic.Int32
 }
 
 func (m *MockBucketFailure) Delete(ctx context.Context, name string) error {
@@ -51,7 +52,7 @@ func (m *MockBucketFailure) Delete(ctx context.Context, name string) error {
 }
 
 func (m *MockBucketFailure) Get(ctx context.Context, name string) (io.ReadCloser, error) {
-	m.GetCalls++
+	m.GetCalls.Add(1)
 	for prefix, err := range m.GetFailures {
 		if strings.HasPrefix(name, prefix) {
 			return nil, err
@@ -65,7 +66,7 @@ func (m *MockBucketFailure) Get(ctx context.Context, name string) (io.ReadCloser
 }
 
 func (m *MockBucketFailure) Upload(ctx context.Context, name string, r io.Reader) error {
-	m.UploadCalls++
+	m.UploadCalls.Add(1)
 	for prefix, err := range m.UploadFailures {
 		if strings.HasPrefix(name, prefix) {
 			return err


### PR DESCRIPTION
**What this PR does**:
Fix objstore retry when uploading markers.

These operations were not being retried as we were wrapping the original `io.Reader` into a `bytes.NewBuffer` which is not seek-able. The fix is simply to wrap them into a `bytes.NewReader` instead `bytes.NewBuffer`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
