### PR TITLE
Changing return code from storegateway for CMK errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [ENHANCEMENT] Add jitter to lifecycler heartbeat. #5404
 * [ENHANCEMENT] Store Gateway: Add config `estimated_max_series_size_bytes` and `estimated_max_chunk_size_bytes` to address data overfetch. #5401
 * [ENHANCEMENT] Distributor/Ingester: Add experimental `-distributor.sign_write_requests` flag to sign the write requests. #5430
+* [ENHANCEMENT] Store Gateway/Querier/Compactor: Handling CMK Access Denied errors. #5420 #5442
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -648,6 +648,10 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(
 						if s.Code() == codes.ResourceExhausted {
 							return validation.LimitError(s.Message())
 						}
+
+						if s.Code() == codes.PermissionDenied {
+							return validation.AccessDeniedError(s.Message())
+						}
 					}
 					return errors.Wrapf(err, "failed to receive series from %s", c.RemoteAddress())
 				}
@@ -816,6 +820,10 @@ func (q *blocksStoreQuerier) fetchLabelNamesFromStore(
 						return validation.LimitError(s.Message())
 					}
 				}
+
+				if s.Code() == codes.PermissionDenied {
+					return validation.AccessDeniedError(s.Message())
+				}
 				return errors.Wrapf(err, "failed to fetch label names from %s", c.RemoteAddress())
 			}
 
@@ -906,6 +914,10 @@ func (q *blocksStoreQuerier) fetchLabelValuesFromStore(
 				if ok {
 					if s.Code() == codes.ResourceExhausted {
 						return validation.LimitError(s.Message())
+					}
+
+					if s.Code() == codes.PermissionDenied {
+						return validation.AccessDeniedError(s.Message())
 					}
 				}
 				return errors.Wrapf(err, "failed to fetch label values from %s", c.RemoteAddress())

--- a/pkg/storage/bucket/sse_bucket_client.go
+++ b/pkg/storage/bucket/sse_bucket_client.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"io"
 
-	cortex_errors "github.com/cortexproject/cortex/pkg/util/errors"
 	"github.com/gogo/status"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/pkg/errors"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/s3"
 	"google.golang.org/grpc/codes"
+
+	cortex_errors "github.com/cortexproject/cortex/pkg/util/errors"
 
 	cortex_s3 "github.com/cortexproject/cortex/pkg/storage/bucket/s3"
 )
@@ -107,6 +108,7 @@ func (b *SSEBucketClient) Get(ctx context.Context, name string) (io.ReadCloser, 
 	r, err := b.bucket.Get(ctx, name)
 
 	if err != nil && b.IsCustomerManagedKeyError(err) {
+		// Store gateway will return the status if the returned error is an `status.Error`
 		return nil, cortex_errors.WithCause(err, status.Error(codes.PermissionDenied, err.Error()))
 	}
 

--- a/pkg/storage/bucket/sse_bucket_client.go
+++ b/pkg/storage/bucket/sse_bucket_client.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"io"
 
+	cortex_errors "github.com/cortexproject/cortex/pkg/util/errors"
+	"github.com/gogo/status"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/pkg/errors"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/s3"
+	"google.golang.org/grpc/codes"
 
 	cortex_s3 "github.com/cortexproject/cortex/pkg/storage/bucket/s3"
 )
@@ -101,12 +104,23 @@ func (b *SSEBucketClient) Iter(ctx context.Context, dir string, f func(string) e
 
 // Get implements objstore.Bucket.
 func (b *SSEBucketClient) Get(ctx context.Context, name string) (io.ReadCloser, error) {
-	return b.bucket.Get(ctx, name)
+	r, err := b.bucket.Get(ctx, name)
+
+	if err != nil && b.IsCustomerManagedKeyError(err) {
+		return nil, cortex_errors.WithCause(err, status.Error(codes.PermissionDenied, err.Error()))
+	}
+
+	return r, err
 }
 
 // GetRange implements objstore.Bucket.
 func (b *SSEBucketClient) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
-	return b.bucket.GetRange(ctx, name, off, length)
+	r, err := b.bucket.GetRange(ctx, name, off, length)
+	if err != nil && b.IsCustomerManagedKeyError(err) {
+		return nil, cortex_errors.WithCause(err, status.Error(codes.PermissionDenied, err.Error()))
+	}
+
+	return r, err
 }
 
 // Exists implements objstore.Bucket.
@@ -119,7 +133,12 @@ func (b *SSEBucketClient) IsObjNotFoundErr(err error) bool {
 	return b.bucket.IsObjNotFoundErr(err)
 }
 
+// IsCustomerManagedKeyError implements objstore.Bucket.
 func (b *SSEBucketClient) IsCustomerManagedKeyError(err error) bool {
+	// unwrap error
+	if se, ok := err.(interface{ Err() error }); ok {
+		return b.bucket.IsCustomerManagedKeyError(se.Err()) || b.bucket.IsCustomerManagedKeyError(err)
+	}
 	return b.bucket.IsCustomerManagedKeyError(err)
 }
 

--- a/pkg/storage/bucket/sse_bucket_client_test.go
+++ b/pkg/storage/bucket/sse_bucket_client_test.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 	"testing"
 
-	cortex_testutil "github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
+
+	cortex_testutil "github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket/s3"
 	"github.com/cortexproject/cortex/pkg/util/flagext"

--- a/pkg/storage/bucket/sse_bucket_client_test.go
+++ b/pkg/storage/bucket/sse_bucket_client_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 
-	cortex_testutil "github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"
-
 	"github.com/cortexproject/cortex/pkg/storage/bucket/s3"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 )
@@ -110,13 +108,11 @@ func TestSSEBucketClient_Upload_ShouldInjectCustomSSEConfig(t *testing.T) {
 
 func Test_shouldWrapSSeErrors(t *testing.T) {
 	cfgProvider := &mockTenantConfigProvider{}
-	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
-	bkt = &cortex_testutil.MockBucketFailure{
-		Bucket: bkt,
-		GetFailures: map[string]error{
-			"Test": cortex_testutil.ErrKeyAccessDeniedError,
-		},
-	}
+
+	bkt := &ClientMock{}
+
+	bkt.MockGet("Test", "someContent", errKeyPermissionDenied)
+
 	sseBkt := NewSSEBucketClient("user-1", bkt, cfgProvider)
 
 	_, err := sseBkt.Get(context.Background(), "Test")

--- a/pkg/storage/tsdb/testutil/objstore.go
+++ b/pkg/storage/tsdb/testutil/objstore.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 	"go.uber.org/atomic"
+
+	"github.com/cortexproject/cortex/pkg/util"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket/filesystem"
 )

--- a/pkg/storage/tsdb/testutil/objstore.go
+++ b/pkg/storage/tsdb/testutil/objstore.go
@@ -109,5 +109,5 @@ func (m *MockBucketFailure) ReaderWithExpectedErrs(expectedFunc objstore.IsOpFai
 }
 
 func (m *MockBucketFailure) IsCustomerManagedKeyError(err error) bool {
-	return errors.Is(err, ErrKeyAccessDeniedError)
+	return errors.Is(errors.Cause(err), ErrKeyAccessDeniedError)
 }

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -306,17 +306,13 @@ func (u *BucketStores) Series(req *storepb.SeriesRequest, srv storepb.Store_Seri
 	err := u.getStoreError(userID)
 
 	if err != nil && cortex_errors.ErrorIs(err, u.bucket.IsCustomerManagedKeyError) {
-		return httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", err)
+		return httpgrpc.Errorf(int(codes.PermissionDenied), "store error: %s", err)
 	}
 
 	err = store.Series(req, spanSeriesServer{
 		Store_SeriesServer: srv,
 		ctx:                spanCtx,
 	})
-
-	if err != nil && cortex_errors.ErrorIs(err, u.bucket.IsCustomerManagedKeyError) {
-		return httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", err)
-	}
 
 	return err
 }
@@ -339,14 +335,10 @@ func (u *BucketStores) LabelNames(ctx context.Context, req *storepb.LabelNamesRe
 	err := u.getStoreError(userID)
 
 	if err != nil && cortex_errors.ErrorIs(err, u.bucket.IsCustomerManagedKeyError) {
-		return nil, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", err)
+		return nil, httpgrpc.Errorf(int(codes.PermissionDenied), "store error: %s", err)
 	}
 
 	resp, err := store.LabelNames(ctx, req)
-
-	if err != nil && cortex_errors.ErrorIs(err, u.bucket.IsCustomerManagedKeyError) {
-		return resp, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", err)
-	}
 
 	return resp, err
 }
@@ -369,14 +361,10 @@ func (u *BucketStores) LabelValues(ctx context.Context, req *storepb.LabelValues
 	err := u.getStoreError(userID)
 
 	if err != nil && cortex_errors.ErrorIs(err, u.bucket.IsCustomerManagedKeyError) {
-		return nil, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", err)
+		return nil, httpgrpc.Errorf(int(codes.PermissionDenied), "store error: %s", err)
 	}
 
 	resp, err := store.LabelValues(ctx, req)
-
-	if err != nil && cortex_errors.ErrorIs(err, u.bucket.IsCustomerManagedKeyError) {
-		return resp, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", err)
-	}
 
 	return resp, err
 }

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -299,13 +299,14 @@ func (u *BucketStores) Series(req *storepb.SeriesRequest, srv storepb.Store_Seri
 	}
 
 	store := u.getStore(userID)
+	userBkt := bucket.NewUserBucketClient(userID, u.bucket, u.limits)
 	if store == nil {
 		return nil
 	}
 
 	err := u.getStoreError(userID)
 
-	if err != nil && cortex_errors.ErrorIs(err, u.bucket.IsCustomerManagedKeyError) {
+	if err != nil && cortex_errors.ErrorIs(err, userBkt.IsCustomerManagedKeyError) {
 		return httpgrpc.Errorf(int(codes.PermissionDenied), "store error: %s", err)
 	}
 
@@ -328,13 +329,14 @@ func (u *BucketStores) LabelNames(ctx context.Context, req *storepb.LabelNamesRe
 	}
 
 	store := u.getStore(userID)
+	userBkt := bucket.NewUserBucketClient(userID, u.bucket, u.limits)
 	if store == nil {
 		return &storepb.LabelNamesResponse{}, nil
 	}
 
 	err := u.getStoreError(userID)
 
-	if err != nil && cortex_errors.ErrorIs(err, u.bucket.IsCustomerManagedKeyError) {
+	if err != nil && cortex_errors.ErrorIs(err, userBkt.IsCustomerManagedKeyError) {
 		return nil, httpgrpc.Errorf(int(codes.PermissionDenied), "store error: %s", err)
 	}
 
@@ -354,13 +356,14 @@ func (u *BucketStores) LabelValues(ctx context.Context, req *storepb.LabelValues
 	}
 
 	store := u.getStore(userID)
+	userBkt := bucket.NewUserBucketClient(userID, u.bucket, u.limits)
 	if store == nil {
 		return &storepb.LabelValuesResponse{}, nil
 	}
 
 	err := u.getStoreError(userID)
 
-	if err != nil && cortex_errors.ErrorIs(err, u.bucket.IsCustomerManagedKeyError) {
+	if err != nil && cortex_errors.ErrorIs(err, userBkt.IsCustomerManagedKeyError) {
 		return nil, httpgrpc.Errorf(int(codes.PermissionDenied), "store error: %s", err)
 	}
 

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -72,7 +72,7 @@ func TestBucketStores_CustomerKeyError(t *testing.T) {
 			Version:   bucketindex.IndexVersion1,
 			UpdatedAt: time.Now().Unix(),
 		}
-		b.Iter(ctx, userID, func(s string) error {
+		err := b.Iter(ctx, userID, func(s string) error {
 			if id, isBlock := block.IsBlockDir(s); isBlock {
 				metaFile := path.Join(userID, id.String(), block.MetaFilename)
 				r, err := b.Get(ctx, metaFile)
@@ -89,7 +89,9 @@ func TestBucketStores_CustomerKeyError(t *testing.T) {
 			}
 			return nil
 		})
-		bucketindex.WriteIndex(ctx, b, userID, nil, idx)
+
+		require.NoError(t, err)
+		require.NoError(t, bucketindex.WriteIndex(ctx, b, userID, nil, idx))
 		bucketIndexes[userID] = idx
 	}
 

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cortexproject/cortex/pkg/storage/tsdb/bucketindex"
 	"github.com/go-kit/log"
 	"github.com/gogo/status"
 	"github.com/oklog/ulid"
@@ -37,6 +36,8 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/cortexproject/cortex/pkg/storage/tsdb/bucketindex"
 
 	cortex_testutil "github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"
 
@@ -67,7 +68,7 @@ func TestBucketStores_CustomerKeyError(t *testing.T) {
 
 	bucketIndexes := map[string]*bucketindex.Index{}
 	// Generate Bucket Index
-	for userID, _ := range userToMetric {
+	for userID := range userToMetric {
 		idx := &bucketindex.Index{
 			Version:   bucketindex.IndexVersion1,
 			UpdatedAt: time.Now().Unix(),

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -2,18 +2,22 @@ package storegateway
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"math"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/storage/tsdb/bucketindex"
 	"github.com/go-kit/log"
+	"github.com/gogo/status"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -29,7 +33,6 @@ import (
 	"github.com/thanos-io/thanos/pkg/store"
 	"github.com/thanos-io/thanos/pkg/store/labelpb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
-	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/logging"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
@@ -46,8 +49,8 @@ import (
 
 func TestBucketStores_CustomerKeyError(t *testing.T) {
 	userToMetric := map[string]string{
-		"user-1": "series_1",
-		"user-2": "series_2",
+		"user-1": "series",
+		"user-2": "series",
 	}
 
 	ctx := context.Background()
@@ -62,52 +65,114 @@ func TestBucketStores_CustomerKeyError(t *testing.T) {
 
 	b, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
 
-	mBucket := &cortex_testutil.MockBucketFailure{
-		Bucket: b,
-		GetFailures: map[string]error{
-			"user-1": cortex_testutil.ErrKeyAccessDeniedError,
+	bucketIndexes := map[string]*bucketindex.Index{}
+	// Generate Bucket Index
+	for userID, _ := range userToMetric {
+		idx := &bucketindex.Index{
+			Version:   bucketindex.IndexVersion1,
+			UpdatedAt: time.Now().Unix(),
+		}
+		b.Iter(ctx, userID, func(s string) error {
+			if id, isBlock := block.IsBlockDir(s); isBlock {
+				metaFile := path.Join(userID, id.String(), block.MetaFilename)
+				r, err := b.Get(ctx, metaFile)
+				require.NoError(t, err)
+				metaContent, err := io.ReadAll(r)
+				require.NoError(t, err)
+				// Unmarshal it.
+				m := thanos_metadata.Meta{}
+				if err := json.Unmarshal(metaContent, &m); err != nil {
+					require.NoError(t, err)
+				}
+
+				idx.Blocks = append(idx.Blocks, bucketindex.BlockFromThanosMeta(m))
+			}
+			return nil
+		})
+		bucketindex.WriteIndex(ctx, b, userID, nil, idx)
+		bucketIndexes[userID] = idx
+	}
+
+	cases := map[string]struct {
+		mockInitialSync bool
+		GetFailures     map[string]error
+	}{
+		"should return ResourceExhausted when fail to get bucket index": {
+			mockInitialSync: true,
+			GetFailures: map[string]error{
+				"user-1/bucket-index.json.gz": cortex_testutil.ErrKeyAccessDeniedError,
+			},
+		},
+		"should return ResourceExhausted when fail to block index": {
+			mockInitialSync: false,
+			GetFailures: map[string]error{
+				"user-1/" + bucketIndexes["user-1"].Blocks[0].ID.String() + "/index": cortex_testutil.ErrKeyAccessDeniedError,
+			},
 		},
 	}
-	require.NoError(t, err)
 
-	reg := prometheus.NewPedanticRegistry()
-	stores, err := NewBucketStores(cfg, NewNoShardingStrategy(), mBucket, defaultLimitsOverrides(t), mockLoggingLevel(), log.NewNopLogger(), reg)
-	require.NoError(t, err)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			mBucket := &cortex_testutil.MockBucketFailure{
+				Bucket: b,
+			}
+			require.NoError(t, err)
 
-	// Should set the error on user-1
-	require.NoError(t, stores.InitialSync(ctx))
-	require.ErrorIs(t, stores.storesErrors["user-1"], bucket.ErrCustomerManagedKeyAccessDenied)
-	require.ErrorIs(t, stores.storesErrors["user-2"], nil)
-	require.NoError(t, stores.SyncBlocks(context.Background()))
-	require.ErrorIs(t, stores.storesErrors["user-1"], bucket.ErrCustomerManagedKeyAccessDenied)
-	require.ErrorIs(t, stores.storesErrors["user-2"], nil)
+			reg := prometheus.NewPedanticRegistry()
+			stores, err := NewBucketStores(cfg, NewNoShardingStrategy(), mBucket, defaultLimitsOverrides(t), mockLoggingLevel(), log.NewNopLogger(), reg)
+			require.NoError(t, err)
 
-	_, _, err = querySeries(stores, "user-1", "anything", 0, 100)
-	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyAccessDenied))
-	_, err = queryLabelsNames(stores, "user-1", "anything")
-	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyAccessDenied))
-	_, err = queryLabelsValues(stores, "user-1", "anything")
-	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyAccessDenied))
-	_, _, err = querySeries(stores, "user-2", "anything", 0, 100)
-	require.NoError(t, err)
-	_, err = queryLabelsNames(stores, "user-1", "anything")
-	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyAccessDenied))
-	_, err = queryLabelsValues(stores, "user-1", "anything")
-	require.Equal(t, err, httpgrpc.Errorf(int(codes.ResourceExhausted), "store error: %s", bucket.ErrCustomerManagedKeyAccessDenied))
+			if tc.mockInitialSync {
+				mBucket.GetFailures = tc.GetFailures
+			}
 
-	// Cleaning the error
-	mBucket.GetFailures = map[string]error{}
-	require.NoError(t, stores.SyncBlocks(context.Background()))
-	require.ErrorIs(t, stores.storesErrors["user-1"], nil)
-	require.ErrorIs(t, stores.storesErrors["user-2"], nil)
-	_, _, err = querySeries(stores, "user-1", "anything", 0, 100)
-	require.NoError(t, err)
-	_, _, err = querySeries(stores, "user-2", "anything", 0, 100)
-	require.NoError(t, err)
-	_, err = queryLabelsNames(stores, "user-1", "anything")
-	require.NoError(t, err)
-	_, err = queryLabelsValues(stores, "user-1", "anything")
-	require.NoError(t, err)
+			// Should set the error on user-1
+			require.NoError(t, stores.InitialSync(ctx))
+			if tc.mockInitialSync {
+				require.ErrorIs(t, stores.storesErrors["user-1"], bucket.ErrCustomerManagedKeyAccessDenied)
+				require.ErrorIs(t, stores.storesErrors["user-2"], nil)
+			}
+			require.NoError(t, stores.SyncBlocks(context.Background()))
+			if tc.mockInitialSync {
+				require.ErrorIs(t, stores.storesErrors["user-1"], bucket.ErrCustomerManagedKeyAccessDenied)
+				require.ErrorIs(t, stores.storesErrors["user-2"], nil)
+			}
+
+			mBucket.GetFailures = tc.GetFailures
+
+			_, _, err = querySeries(stores, "user-1", "series", 0, 100)
+			s, _ := status.FromError(err)
+			require.Equal(t, codes.PermissionDenied, s.Code())
+			_, err = queryLabelsNames(stores, "user-1", "series", 0, 100)
+			s, _ = status.FromError(err)
+			require.Equal(t, codes.PermissionDenied, s.Code())
+			_, err = queryLabelsValues(stores, "user-1", "series", 0, 100)
+			s, _ = status.FromError(err)
+			require.Equal(t, codes.PermissionDenied, s.Code())
+			_, _, err = querySeries(stores, "user-2", "series", 0, 100)
+			require.NoError(t, err)
+			_, err = queryLabelsNames(stores, "user-1", "series", 0, 100)
+			s, _ = status.FromError(err)
+			require.Equal(t, codes.PermissionDenied, s.Code())
+			_, err = queryLabelsValues(stores, "user-1", "series", 0, 100)
+			s, _ = status.FromError(err)
+			require.Equal(t, codes.PermissionDenied, s.Code())
+
+			// Cleaning the error
+			mBucket.GetFailures = map[string]error{}
+			require.NoError(t, stores.SyncBlocks(context.Background()))
+			require.ErrorIs(t, stores.storesErrors["user-1"], nil)
+			require.ErrorIs(t, stores.storesErrors["user-2"], nil)
+			_, _, err = querySeries(stores, "user-1", "series", 0, 100)
+			require.NoError(t, err)
+			_, _, err = querySeries(stores, "user-2", "series", 0, 100)
+			require.NoError(t, err)
+			_, err = queryLabelsNames(stores, "user-1", "series", 0, 100)
+			require.NoError(t, err)
+			_, err = queryLabelsValues(stores, "user-1", "series", 0, 100)
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestBucketStores_InitialSync(t *testing.T) {
@@ -499,8 +564,10 @@ func querySeries(stores *BucketStores, userID, metricName string, minT, maxT int
 	return srv.SeriesSet, srv.Warnings, err
 }
 
-func queryLabelsNames(stores *BucketStores, userID, metricName string) (*storepb.LabelNamesResponse, error) {
+func queryLabelsNames(stores *BucketStores, userID, metricName string, start, end int64) (*storepb.LabelNamesResponse, error) {
 	req := &storepb.LabelNamesRequest{
+		Start: start,
+		End:   end,
 		Matchers: []storepb.LabelMatcher{{
 			Type:  storepb.LabelMatcher_EQ,
 			Name:  labels.MetricName,
@@ -513,8 +580,11 @@ func queryLabelsNames(stores *BucketStores, userID, metricName string) (*storepb
 	return stores.LabelNames(ctx, req)
 }
 
-func queryLabelsValues(stores *BucketStores, userID, metricName string) (*storepb.LabelValuesResponse, error) {
+func queryLabelsValues(stores *BucketStores, userID, metricName string, start, end int64) (*storepb.LabelValuesResponse, error) {
 	req := &storepb.LabelValuesRequest{
+		Start: start,
+		End:   end,
+		Label: "__name__",
 		Matchers: []storepb.LabelMatcher{{
 			Type:  storepb.LabelMatcher_EQ,
 			Name:  labels.MetricName,

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -149,7 +149,7 @@ func TestBucketStores_CustomerKeyError(t *testing.T) {
 			_, err = queryLabelsNames(stores, "user-1", "series", 0, 100)
 			s, _ = status.FromError(err)
 			require.Equal(t, codes.PermissionDenied, s.Code())
-			_, err = queryLabelsValues(stores, "user-1", "series", 0, 100)
+			_, err = queryLabelsValues(stores, "user-1", "__name__", "series", 0, 100)
 			s, _ = status.FromError(err)
 			require.Equal(t, codes.PermissionDenied, s.Code())
 			_, _, err = querySeries(stores, "user-2", "series", 0, 100)
@@ -157,7 +157,7 @@ func TestBucketStores_CustomerKeyError(t *testing.T) {
 			_, err = queryLabelsNames(stores, "user-1", "series", 0, 100)
 			s, _ = status.FromError(err)
 			require.Equal(t, codes.PermissionDenied, s.Code())
-			_, err = queryLabelsValues(stores, "user-1", "series", 0, 100)
+			_, err = queryLabelsValues(stores, "user-1", "__name__", "series", 0, 100)
 			s, _ = status.FromError(err)
 			require.Equal(t, codes.PermissionDenied, s.Code())
 
@@ -172,7 +172,7 @@ func TestBucketStores_CustomerKeyError(t *testing.T) {
 			require.NoError(t, err)
 			_, err = queryLabelsNames(stores, "user-1", "series", 0, 100)
 			require.NoError(t, err)
-			_, err = queryLabelsValues(stores, "user-1", "series", 0, 100)
+			_, err = queryLabelsValues(stores, "user-1", "__name__", "series", 0, 100)
 			require.NoError(t, err)
 		})
 	}
@@ -583,11 +583,11 @@ func queryLabelsNames(stores *BucketStores, userID, metricName string, start, en
 	return stores.LabelNames(ctx, req)
 }
 
-func queryLabelsValues(stores *BucketStores, userID, metricName string, start, end int64) (*storepb.LabelValuesResponse, error) {
+func queryLabelsValues(stores *BucketStores, userID, labelName, metricName string, start, end int64) (*storepb.LabelValuesResponse, error) {
 	req := &storepb.LabelValuesRequest{
 		Start: start,
 		End:   end,
-		Label: "__name__",
+		Label: labelName,
 		Matchers: []storepb.LabelMatcher{{
 			Type:  storepb.LabelMatcher_EQ,
 			Name:  labels.MetricName,

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -26,6 +26,11 @@ func (e errWithCause) Unwrap() error {
 	return e.cause
 }
 
+// Err return the original error
+func (e errWithCause) Err() error {
+	return e.error
+}
+
 // WithCause wrappers err with a error cause
 func WithCause(err, cause error) error {
 	return errWithCause{

--- a/pkg/util/errors/errors_test.go
+++ b/pkg/util/errors/errors_test.go
@@ -1,0 +1,41 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	errToTest = errors.New("err")
+)
+
+func TestErrorIs(t *testing.T) {
+	type args struct {
+		err error
+		f   func(err error) bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "should unwrap error",
+			want: true,
+			args: args{
+				err: errors.Wrap(errors.Wrap(errToTest, "outer1"), "outer2"),
+				f: func(err error) bool {
+					return err == errToTest
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ErrorIs(tt.args.err, tt.args.f); got != tt.want {
+				t.Errorf("ErrorIs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:
This is a follow up of https://github.com/cortexproject/cortex/pull/5420 and basically change the return code  from `ResourceExhausted` to `PermissionDenied`.

Also adding the changelog that was forgotten on the last PR.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
