### PR TITLE
Implementing Bucket index sync status file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 * [ENHANCEMENT] Add jitter to lifecycler heartbeat. #5404
 * [ENHANCEMENT] Store Gateway: Add config `estimated_max_series_size_bytes` and `estimated_max_chunk_size_bytes` to address data overfetch. #5401
 * [ENHANCEMENT] Distributor/Ingester: Add experimental `-distributor.sign_write_requests` flag to sign the write requests. #5430
-* [ENHANCEMENT] Store Gateway/Querier/Compactor: Handling CMK Access Denied errors. #5420 #5442
+* [ENHANCEMENT] Store Gateway/Querier/Compactor: Handling CMK Access Denied errors. #5420 #5442 #5446
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -206,6 +206,11 @@ func (c *BlocksCleaner) deleteUserMarkedForDeletion(ctx context.Context, userID 
 	if err := bucketindex.DeleteIndex(ctx, c.bucketClient, userID, c.cfgProvider); err != nil {
 		return err
 	}
+
+	// Delete the bucket sync status
+	if err := bucketindex.DeleteIndexSyncStatus(ctx, c.bucketClient, userID); err != nil {
+		return err
+	}
 	c.tenantBucketIndexLastUpdate.DeleteLabelValues(userID)
 
 	var deletedBlocks, failed int
@@ -321,15 +326,40 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, firstRun b
 		}
 	}
 
+	// Reading bucket index sync stats
+	idxs, err := bucketindex.ReadSyncStatus(ctx, c.bucketClient, userID, userLogger)
+
+	if err != nil {
+		level.Warn(userLogger).Log("msg", "error reading the bucket index status", "err", err)
+		idxs = bucketindex.Status{Version: bucketindex.SyncStatusFileVersion, NonQueryableReason: bucketindex.Unknown}
+	}
+
+	idxs.Status = bucketindex.Ok
+	idxs.SyncTime = time.Now().Unix()
+
 	// Read the bucket index.
 	idx, err := bucketindex.ReadIndex(ctx, c.bucketClient, userID, c.cfgProvider, c.logger)
+
+	defer func() {
+		bucketindex.WriteSyncStatus(ctx, c.bucketClient, userID, idxs, userLogger)
+	}()
+
 	if errors.Is(err, bucketindex.ErrIndexCorrupted) {
 		level.Warn(userLogger).Log("msg", "found a corrupted bucket index, recreating it")
 	} else if errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied) {
 		// Give up cleaning if we get access denied
-		level.Warn(userLogger).Log("msg", err.Error())
+		level.Warn(userLogger).Log("msg", "customer manager key access denied", "err", err)
+		idxs.Status = bucketindex.CustomerManagedKeyError
+		// Making the tenant non queryable until 2x the cleanup interval to give time to compactors and storegateways
+		// to reload the bucket index in case the key access is re-granted
+		idxs.NonQueryableUntil = time.Now().Add(2 * c.cfg.CleanupInterval).Unix()
+		idxs.NonQueryableReason = bucketindex.CustomerManagedKeyError
+
+		// Update the bucket index update time
+		c.tenantBucketIndexLastUpdate.WithLabelValues(userID).SetToCurrentTime()
 		return nil
 	} else if err != nil && !errors.Is(err, bucketindex.ErrIndexNotFound) {
+		idxs.Status = bucketindex.GenericError
 		return err
 	}
 
@@ -348,6 +378,7 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, firstRun b
 	w := bucketindex.NewUpdater(c.bucketClient, userID, c.cfgProvider, c.logger)
 	idx, partials, totalBlocksBlocksMarkedForNoCompaction, err := w.UpdateIndex(ctx, idx)
 	if err != nil {
+		idxs.Status = bucketindex.GenericError
 		return err
 	}
 
@@ -398,7 +429,6 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, firstRun b
 	c.tenantBlocksMarkedForNoCompaction.WithLabelValues(userID).Set(float64(totalBlocksBlocksMarkedForNoCompaction))
 	c.tenantBucketIndexLastUpdate.WithLabelValues(userID).SetToCurrentTime()
 	c.tenantPartialBlocks.WithLabelValues(userID).Set(float64(len(partials)))
-
 	return nil
 }
 

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -350,9 +350,9 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, firstRun b
 		// Give up cleaning if we get access denied
 		level.Warn(userLogger).Log("msg", "customer manager key access denied", "err", err)
 		idxs.Status = bucketindex.CustomerManagedKeyError
-		// Making the tenant non queryable until 2x the cleanup interval to give time to compactors and storegateways
+		// Making the tenant non queryable until 3x the cleanup interval to give time to compactors and storegateways
 		// to reload the bucket index in case the key access is re-granted
-		idxs.NonQueryableUntil = time.Now().Add(2 * c.cfg.CleanupInterval).Unix()
+		idxs.NonQueryableUntil = time.Now().Add(3 * c.cfg.CleanupInterval).Unix()
 		idxs.NonQueryableReason = bucketindex.CustomerManagedKeyError
 
 		// Update the bucket index update time

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -675,6 +675,15 @@ func (c *Compactor) compactUsers(ctx context.Context) {
 			continue
 		}
 
+		// Skipping compaction if the  bucket index failed to sync due CMK errors.
+		if idxs, err := bucketindex.ReadSyncStatus(ctx, c.bucketClient, userID, util_log.WithUserID(userID, c.logger)); err == nil {
+			if idxs.Status == bucketindex.CustomerManagedKeyError {
+				c.compactionRunSkippedTenants.Inc()
+				level.Info(c.logger).Log("msg", "skipping compactUser due CustomerManagedKeyError", "user", userID)
+				continue
+			}
+		}
+
 		ownedUsers[userID] = struct{}{}
 
 		if markedForDeletion, err := cortex_tsdb.TenantDeletionMarkExists(ctx, c.bucketClient, userID); err != nil {

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -675,7 +675,7 @@ func (c *Compactor) compactUsers(ctx context.Context) {
 			continue
 		}
 
-		// Skipping compaction if the  bucket index failed to sync due CMK errors.
+		// Skipping compaction if the  bucket index failed to sync due to CMK errors.
 		if idxs, err := bucketindex.ReadSyncStatus(ctx, c.bucketClient, userID, util_log.WithUserID(userID, c.logger)); err == nil {
 			if idxs.Status == bucketindex.CustomerManagedKeyError {
 				c.compactionRunSkippedTenants.Inc()

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2292,7 +2292,7 @@ func (i *Ingester) shipBlocks(ctx context.Context, allowed *util.AllowedTenants)
 		defer userDB.casState(activeShipping, active)
 
 		if idxs, err := bucketindex.ReadSyncStatus(ctx, i.TSDBState.bucket, userID, logutil.WithContext(ctx, i.logger)); err == nil {
-			// Skip blocks shipping if the bucket index failed to sync due CMK errors.
+			// Skip blocks shipping if the bucket index failed to sync due to CMK errors.
 			if idxs.Status == bucketindex.CustomerManagedKeyError {
 				level.Info(logutil.WithContext(ctx, i.logger)).Log("msg", "skipping shipping blocks due CustomerManagedKeyError", "user", userID)
 				return nil

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -16,6 +16,8 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 
+	"github.com/cortexproject/cortex/pkg/storage/tsdb/bucketindex"
+
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gogo/status"
@@ -2288,6 +2290,14 @@ func (i *Ingester) shipBlocks(ctx context.Context, allowed *util.AllowedTenants)
 			return nil
 		}
 		defer userDB.casState(activeShipping, active)
+
+		if idxs, err := bucketindex.ReadSyncStatus(ctx, i.TSDBState.bucket, userID, logutil.WithContext(ctx, i.logger)); err == nil {
+			// Skip blocks shipping if the bucket index failed to sync due CMK errors.
+			if idxs.Status == bucketindex.CustomerManagedKeyError {
+				level.Info(logutil.WithContext(ctx, i.logger)).Log("msg", "skipping shipping blocks due CustomerManagedKeyError", "user", userID)
+				return nil
+			}
+		}
 
 		uploaded, err := userDB.shipper.Sync(ctx)
 		if err != nil {

--- a/pkg/querier/blocks_finder_bucket_index_test.go
+++ b/pkg/querier/blocks_finder_bucket_index_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
+
 	"github.com/cortexproject/cortex/pkg/util/validation"
 
 	"github.com/cortexproject/cortex/pkg/storage/tsdb/bucketindex"
@@ -219,6 +221,59 @@ func TestBucketIndexBlocksFinder_GetBlocks_BucketIndexIsTooOld(t *testing.T) {
 
 	_, _, err := finder.GetBlocks(ctx, userID, 10, 20)
 	require.Equal(t, errBucketIndexTooOld, err)
+}
+
+func TestBucketIndexBlocksFinder_GetBlocks_BucketIndexIsTooOldWithCustomerKeyError(t *testing.T) {
+	t.Parallel()
+
+	const userID = "user-1"
+
+	ctx := context.Background()
+	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+
+	require.NoError(t, bucketindex.WriteIndex(ctx, bkt, userID, nil, &bucketindex.Index{
+		Version:            bucketindex.IndexVersion1,
+		Blocks:             bucketindex.Blocks{},
+		BlockDeletionMarks: bucketindex.BlockDeletionMarks{},
+		UpdatedAt:          time.Now().Unix(),
+	}))
+
+	testCases := map[string]struct {
+		err error
+		ss  bucketindex.Status
+	}{
+		"should return AccessDeniedError when CustomerManagedKeyError and still not queryable": {
+			err: validation.AccessDeniedError(bucket.ErrCustomerManagedKeyAccessDenied.Error()),
+			ss: bucketindex.Status{
+				Version:            bucketindex.SyncStatusFileVersion,
+				SyncTime:           time.Now().Unix(),
+				Status:             bucketindex.Ok,
+				NonQueryableReason: bucketindex.CustomerManagedKeyError,
+				NonQueryableUntil:  time.Now().Add(time.Minute * 10).Unix(),
+			},
+		},
+		"should not return error after NonQueryableUntil": {
+			ss: bucketindex.Status{
+				Version:            bucketindex.SyncStatusFileVersion,
+				SyncTime:           time.Now().Unix(),
+				Status:             bucketindex.Ok,
+				NonQueryableReason: bucketindex.CustomerManagedKeyError,
+				NonQueryableUntil:  time.Now().Add(-time.Minute * 10).Unix(),
+			},
+		},
+		"should not return error when UnknownStatus": {
+			ss: bucketindex.UnknownStatus,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			bucketindex.WriteSyncStatus(ctx, bkt, userID, tc.ss, log.NewNopLogger())
+			finder := prepareBucketIndexBlocksFinder(t, bkt)
+			_, _, err := finder.GetBlocks(ctx, userID, 10, 20)
+			require.Equal(t, tc.err, err)
+		})
+	}
 }
 
 func prepareBucketIndexBlocksFinder(t testing.TB, bkt objstore.Bucket) *BucketIndexBlocksFinder {

--- a/pkg/querier/blocks_finder_bucket_index_test.go
+++ b/pkg/querier/blocks_finder_bucket_index_test.go
@@ -272,6 +272,9 @@ func TestBucketIndexBlocksFinder_GetBlocks_BucketIndexIsTooOldWithCustomerKeyErr
 			finder := prepareBucketIndexBlocksFinder(t, bkt)
 			_, _, err := finder.GetBlocks(ctx, userID, 10, 20)
 			require.Equal(t, tc.err, err)
+			// Doing 2 times to return from the cache
+			_, _, err = finder.GetBlocks(ctx, userID, 10, 20)
+			require.Equal(t, tc.err, err)
 		})
 	}
 }

--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -101,7 +101,7 @@ func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, Status, e
 		// We don't check if the index is stale because it's the responsibility
 		// of the background job to keep it updated.
 		entry.requestedAt.Store(time.Now().Unix())
-		return idx, UnknownStatus, err
+		return idx, entry.syncStatus, err
 	}
 	l.indexesMx.RUnlock()
 

--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -91,7 +91,7 @@ func NewLoader(cfg LoaderConfig, bucketClient objstore.Bucket, cfgProvider bucke
 
 // GetIndex returns the bucket index for the given user. It returns the in-memory cached
 // index if available, or load it from the bucket otherwise.
-func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, error) {
+func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, Status, error) {
 	l.indexesMx.RLock()
 	if entry := l.indexes[userID]; entry != nil {
 		idx := entry.index
@@ -101,7 +101,7 @@ func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, error) {
 		// We don't check if the index is stale because it's the responsibility
 		// of the background job to keep it updated.
 		entry.requestedAt.Store(time.Now().Unix())
-		return idx, err
+		return idx, UnknownStatus, err
 	}
 	l.indexesMx.RUnlock()
 
@@ -111,7 +111,7 @@ func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, error) {
 	if err != nil {
 		// Cache the error, to avoid hammering the object store in case of persistent issues
 		// (eg. corrupted bucket index or not existing).
-		l.cacheIndex(userID, nil, err)
+		l.cacheIndex(userID, nil, UnknownStatus, err)
 
 		if errors.Is(err, ErrIndexNotFound) {
 			level.Warn(l.logger).Log("msg", "bucket index not found", "user", userID)
@@ -124,25 +124,31 @@ func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, error) {
 			level.Error(l.logger).Log("msg", "unable to load bucket index", "user", userID, "err", err)
 		}
 
-		return nil, err
+		return nil, UnknownStatus, err
+	}
+
+	ss, err := ReadSyncStatus(ctx, l.bkt, userID, l.logger)
+
+	if err != nil {
+		level.Warn(l.logger).Log("msg", "unable to read bucket index status", "user", userID, "err", err)
 	}
 
 	// Cache the index.
-	l.cacheIndex(userID, idx, nil)
+	l.cacheIndex(userID, idx, ss, nil)
 
 	elapsedTime := time.Since(startTime)
 	l.loadDuration.Observe(elapsedTime.Seconds())
 	level.Info(l.logger).Log("msg", "loaded bucket index", "user", userID, "duration", elapsedTime)
-	return idx, nil
+	return idx, ss, nil
 }
 
-func (l *Loader) cacheIndex(userID string, idx *Index, err error) {
+func (l *Loader) cacheIndex(userID string, idx *Index, ss Status, err error) {
 	l.indexesMx.Lock()
 	defer l.indexesMx.Unlock()
 
 	// Not an issue if, due to concurrency, another index was already cached
 	// and we overwrite it: last will win.
-	l.indexes[userID] = newCachedIndex(idx, err)
+	l.indexes[userID] = newCachedIndex(idx, ss, err)
 }
 
 // checkCachedIndexes checks all cached indexes and, for each of them, does two things:
@@ -240,8 +246,9 @@ func (l *Loader) countLoadedIndexesMetric() float64 {
 type cachedIndex struct {
 	// We cache either the index or the error occurred while fetching it. They're
 	// mutually exclusive.
-	index *Index
-	err   error
+	index      *Index
+	syncStatus Status
+	err        error
 
 	// Unix timestamp (seconds) of when the index has been updated from the storage the last time.
 	updatedAt atomic.Int64
@@ -250,10 +257,11 @@ type cachedIndex struct {
 	requestedAt atomic.Int64
 }
 
-func newCachedIndex(idx *Index, err error) *cachedIndex {
+func newCachedIndex(idx *Index, ss Status, err error) *cachedIndex {
 	entry := &cachedIndex{
-		index: idx,
-		err:   err,
+		index:      idx,
+		err:        err,
+		syncStatus: ss,
 	}
 
 	now := time.Now()

--- a/pkg/storage/tsdb/bucketindex/loader_test.go
+++ b/pkg/storage/tsdb/bucketindex/loader_test.go
@@ -65,7 +65,7 @@ func TestLoader_GetIndex_ShouldLazyLoadBucketIndex(t *testing.T) {
 
 	// Request the index multiple times.
 	for i := 0; i < 10; i++ {
-		actualIdx, err := loader.GetIndex(ctx, "user-1")
+		actualIdx, _, err := loader.GetIndex(ctx, "user-1")
 		require.NoError(t, err)
 		assert.Equal(t, idx, actualIdx)
 	}
@@ -105,7 +105,7 @@ func TestLoader_GetIndex_ShouldCacheError(t *testing.T) {
 
 	// Request the index multiple times.
 	for i := 0; i < 10; i++ {
-		_, err := loader.GetIndex(ctx, "user-1")
+		_, _, err := loader.GetIndex(ctx, "user-1")
 		require.Equal(t, ErrIndexCorrupted, err)
 	}
 
@@ -141,7 +141,7 @@ func TestLoader_GetIndex_ShouldCacheIndexNotFoundError(t *testing.T) {
 
 	// Request the index multiple times.
 	for i := 0; i < 10; i++ {
-		_, err := loader.GetIndex(ctx, "user-1")
+		_, _, err := loader.GetIndex(ctx, "user-1")
 		require.Equal(t, ErrIndexNotFound, err)
 	}
 
@@ -193,7 +193,7 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousLoadSuccess(t *testing.T)
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
 	})
 
-	actualIdx, err := loader.GetIndex(ctx, "user-1")
+	actualIdx, _, err := loader.GetIndex(ctx, "user-1")
 	require.NoError(t, err)
 	assert.Equal(t, idx, actualIdx)
 
@@ -203,14 +203,14 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousLoadSuccess(t *testing.T)
 
 	// Wait until the index has been updated in background.
 	test.Poll(t, 3*time.Second, 2, func() interface{} {
-		actualIdx, err := loader.GetIndex(ctx, "user-1")
+		actualIdx, _, err := loader.GetIndex(ctx, "user-1")
 		if err != nil {
 			return 0
 		}
 		return len(actualIdx.Blocks)
 	})
 
-	actualIdx, err = loader.GetIndex(ctx, "user-1")
+	actualIdx, _, err = loader.GetIndex(ctx, "user-1")
 	require.NoError(t, err)
 	assert.Equal(t, idx, actualIdx)
 
@@ -250,7 +250,7 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousLoadFailure(t *testing.T)
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
 	})
 
-	_, err := loader.GetIndex(ctx, "user-1")
+	_, _, err := loader.GetIndex(ctx, "user-1")
 	assert.Equal(t, ErrIndexCorrupted, err)
 
 	// Upload the bucket index.
@@ -266,11 +266,11 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousLoadFailure(t *testing.T)
 
 	// Wait until the index has been updated in background.
 	test.Poll(t, 3*time.Second, nil, func() interface{} {
-		_, err := loader.GetIndex(ctx, "user-1")
+		_, _, err := loader.GetIndex(ctx, "user-1")
 		return err
 	})
 
-	actualIdx, err := loader.GetIndex(ctx, "user-1")
+	actualIdx, _, err := loader.GetIndex(ctx, "user-1")
 	require.NoError(t, err)
 	assert.Equal(t, idx, actualIdx)
 
@@ -303,7 +303,7 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousIndexNotFound(t *testing.
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
 	})
 
-	_, err := loader.GetIndex(ctx, "user-1")
+	_, _, err := loader.GetIndex(ctx, "user-1")
 	assert.Equal(t, ErrIndexNotFound, err)
 
 	// Upload the bucket index.
@@ -319,11 +319,11 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousIndexNotFound(t *testing.
 
 	// Wait until the index has been updated in background.
 	test.Poll(t, 3*time.Second, nil, func() interface{} {
-		_, err := loader.GetIndex(ctx, "user-1")
+		_, _, err := loader.GetIndex(ctx, "user-1")
 		return err
 	})
 
-	actualIdx, err := loader.GetIndex(ctx, "user-1")
+	actualIdx, _, err := loader.GetIndex(ctx, "user-1")
 	require.NoError(t, err)
 	assert.Equal(t, idx, actualIdx)
 
@@ -367,7 +367,7 @@ func TestLoader_ShouldNotCacheCriticalErrorOnBackgroundUpdates(t *testing.T) {
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
 	})
 
-	actualIdx, err := loader.GetIndex(ctx, "user-1")
+	actualIdx, _, err := loader.GetIndex(ctx, "user-1")
 	require.NoError(t, err)
 	assert.Equal(t, idx, actualIdx)
 
@@ -379,7 +379,7 @@ func TestLoader_ShouldNotCacheCriticalErrorOnBackgroundUpdates(t *testing.T) {
 		return testutil.ToFloat64(loader.loadFailures) > 0
 	})
 
-	actualIdx, err = loader.GetIndex(ctx, "user-1")
+	actualIdx, _, err = loader.GetIndex(ctx, "user-1")
 	require.NoError(t, err)
 	assert.Equal(t, idx, actualIdx)
 
@@ -423,7 +423,7 @@ func TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates(t *testing.T) {
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
 	})
 
-	actualIdx, err := loader.GetIndex(ctx, "user-1")
+	actualIdx, _, err := loader.GetIndex(ctx, "user-1")
 	require.NoError(t, err)
 	assert.Equal(t, idx, actualIdx)
 
@@ -447,7 +447,7 @@ func TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates(t *testing.T) {
 
 	// Try to get the index again. We expect no load attempt because the error has been cached.
 	prevLoads = testutil.ToFloat64(loader.loadAttempts)
-	actualIdx, err = loader.GetIndex(ctx, "user-1")
+	actualIdx, _, err = loader.GetIndex(ctx, "user-1")
 	assert.Equal(t, ErrIndexNotFound, err)
 	assert.Nil(t, actualIdx)
 	assert.Equal(t, prevLoads, testutil.ToFloat64(loader.loadAttempts))
@@ -483,7 +483,7 @@ func TestLoader_ShouldOffloadIndexIfNotFoundDuringBackgroundUpdates(t *testing.T
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
 	})
 
-	actualIdx, err := loader.GetIndex(ctx, "user-1")
+	actualIdx, _, err := loader.GetIndex(ctx, "user-1")
 	require.NoError(t, err)
 	assert.Equal(t, idx, actualIdx)
 
@@ -495,7 +495,7 @@ func TestLoader_ShouldOffloadIndexIfNotFoundDuringBackgroundUpdates(t *testing.T
 		return testutil.ToFloat64(loader.loaded)
 	})
 
-	_, err = loader.GetIndex(ctx, "user-1")
+	_, _, err = loader.GetIndex(ctx, "user-1")
 	require.Equal(t, ErrIndexNotFound, err)
 
 	// Ensure metrics have been updated accordingly.
@@ -538,7 +538,7 @@ func TestLoader_ShouldOffloadIndexIfIdleTimeoutIsReachedDuringBackgroundUpdates(
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
 	})
 
-	actualIdx, err := loader.GetIndex(ctx, "user-1")
+	actualIdx, _, err := loader.GetIndex(ctx, "user-1")
 	require.NoError(t, err)
 	assert.Equal(t, idx, actualIdx)
 
@@ -561,7 +561,7 @@ func TestLoader_ShouldOffloadIndexIfIdleTimeoutIsReachedDuringBackgroundUpdates(
 	))
 
 	// Load it again.
-	actualIdx, err = loader.GetIndex(ctx, "user-1")
+	actualIdx, _, err = loader.GetIndex(ctx, "user-1")
 	require.NoError(t, err)
 	assert.Equal(t, idx, actualIdx)
 
@@ -602,7 +602,7 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousKeyAcessDenied(t *testing
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, loader))
 	})
 
-	_, err := loader.GetIndex(ctx, user)
+	_, _, err := loader.GetIndex(ctx, user)
 	require.True(t, errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied))
 
 	// Check cached
@@ -623,13 +623,13 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousKeyAcessDenied(t *testing
 
 	// Wait until the index has been updated in background.
 	test.Poll(t, 3*time.Second, nil, func() interface{} {
-		_, err := loader.GetIndex(ctx, "user-1")
+		_, _, err := loader.GetIndex(ctx, "user-1")
 		// Check cached
 		require.NoError(t, loader.checkCachedIndexes(ctx))
 		return err
 	})
 
-	actualIdx, err := loader.GetIndex(ctx, "user-1")
+	actualIdx, _, err := loader.GetIndex(ctx, "user-1")
 	require.NoError(t, err)
 	assert.Equal(t, idx, actualIdx)
 
@@ -668,7 +668,7 @@ func TestLoader_GetIndex_ShouldCacheKeyDeniedErrors(t *testing.T) {
 
 	// Request the index multiple times.
 	for i := 0; i < 10; i++ {
-		_, err := loader.GetIndex(ctx, "user-1")
+		_, _, err := loader.GetIndex(ctx, "user-1")
 		require.True(t, errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied))
 	}
 

--- a/pkg/storage/tsdb/bucketindex/storage.go
+++ b/pkg/storage/tsdb/bucketindex/storage.go
@@ -5,8 +5,11 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"io"
+	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/thanos-io/objstore"
 
@@ -17,10 +20,51 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/runutil"
 )
 
+// SyncStatus is an enum for the possibles sync status.
+type SyncStatus string
+
+// Possible SyncStatus.
+const (
+	Ok                      SyncStatus = "Ok"
+	GenericError            SyncStatus = "GenericError"
+	CustomerManagedKeyError SyncStatus = "CustomerManagedKeyError"
+	Unknown                 SyncStatus = "Unknown"
+)
+
+const (
+	// SyncStatusFile is the known json filename for representing the most recent bucket index sync.
+	SyncStatusFile = "bucket-index-sync-status.json"
+	// SyncStatusFileVersion is the current supported version of bucket-index-sync-status.json file.
+	SyncStatusFileVersion = 1
+)
+
 var (
 	ErrIndexNotFound  = errors.New("bucket index not found")
 	ErrIndexCorrupted = errors.New("bucket index corrupted")
+
+	UnknownStatus = Status{
+		Version:            SyncStatusFileVersion,
+		Status:             Unknown,
+		NonQueryableReason: Unknown,
+	}
 )
+
+type Status struct {
+	// SyncTime is a unix timestamp of when the bucket index was synced
+	SyncTime int64 `json:"sync_ime"`
+	// Version of the file.
+	Version int `json:"version"`
+	// Last Sync status
+	Status SyncStatus `json:"status"`
+	// Should not allow query until this time
+	NonQueryableUntil int64 `json:"non_queryable_until"`
+	// Should not allow query until this time
+	NonQueryableReason SyncStatus `json:"non_queryable_reason"`
+}
+
+func (s *Status) GetNonQueryableUntil() time.Time {
+	return time.Unix(s.NonQueryableUntil, 0)
+}
 
 // ReadIndex reads, parses and returns a bucket index from the bucket.
 func ReadIndex(ctx context.Context, bkt objstore.Bucket, userID string, cfgProvider bucket.TenantConfigProvider, logger log.Logger) (*Index, error) {
@@ -98,4 +142,70 @@ func DeleteIndex(ctx context.Context, bkt objstore.Bucket, userID string, cfgPro
 		return errors.Wrap(err, "delete bucket index")
 	}
 	return nil
+}
+
+// DeleteIndexSyncStatus deletes the bucket index sync status file from the storage. No error is returned if the file
+// does not exist.
+func DeleteIndexSyncStatus(ctx context.Context, bkt objstore.Bucket, userID string) error {
+	// Inject the user/tenant prefix.
+	bkt = bucket.NewPrefixedBucketClient(bkt, userID)
+
+	err := bkt.Delete(ctx, SyncStatusFile)
+	if err != nil && !bkt.IsObjNotFoundErr(err) {
+		return errors.Wrap(err, "delete bucket index")
+	}
+	return nil
+}
+
+// WriteSyncStatus upload the sync status file with the corresponding SyncStatus
+// This file is not encrypted using the CMK configuration
+func WriteSyncStatus(ctx context.Context, bkt objstore.Bucket, userID string, ss Status, logger log.Logger) {
+	// Inject the user/tenant prefix.
+	bkt = bucket.NewPrefixedBucketClient(bkt, userID)
+
+	// Marshal the index.
+	content, err := json.Marshal(ss)
+	if err != nil {
+		level.Warn(logger).Log("msg", "failed to write bucket index status", "err", err)
+		return
+	}
+
+	// Upload sync stats.
+	if err := bkt.Upload(ctx, SyncStatusFile, bytes.NewReader(content)); err != nil {
+		level.Warn(logger).Log("msg", "failed to upload index sync status", "err", err)
+	}
+}
+
+// ReadSyncStatus retrieves the SyncStatus from the sync status file
+// If the file is not found, it returns `Unknown`
+func ReadSyncStatus(ctx context.Context, b objstore.Bucket, userID string, logger log.Logger) (Status, error) {
+	// Inject the user/tenant prefix.
+	bkt := bucket.NewPrefixedBucketClient(b, userID)
+
+	reader, err := bkt.WithExpectedErrs(bkt.IsObjNotFoundErr).Get(ctx, SyncStatusFile)
+
+	if err != nil {
+		if bkt.IsObjNotFoundErr(err) {
+			return UnknownStatus, nil
+		}
+		return UnknownStatus, err
+	}
+
+	defer runutil.CloseWithLogOnErr(logger, reader, "close sync status reader")
+
+	content, err := io.ReadAll(reader)
+
+	if err != nil {
+		return UnknownStatus, err
+	}
+
+	s := Status{}
+	if err = json.Unmarshal(content, &s); err != nil {
+		return UnknownStatus, errors.Wrap(err, "error unmarshalling sync status")
+	}
+	if s.Version != SyncStatusFileVersion {
+		return UnknownStatus, errors.New("bucket index sync version mismatch")
+	}
+
+	return s, nil
 }

--- a/pkg/storage/tsdb/caching_bucket.go
+++ b/pkg/storage/tsdb/caching_bucket.go
@@ -136,7 +136,7 @@ func CreateCachingBucket(chunksConfig ChunksCacheConfig, metadataConfig Metadata
 		cfg.CacheGet("metafile", metadataCache, isMetaFile, metadataConfig.MetafileMaxSize, metadataConfig.MetafileContentTTL, metadataConfig.MetafileExistsTTL, metadataConfig.MetafileDoesntExistTTL)
 		cfg.CacheAttributes("metafile", metadataCache, isMetaFile, metadataConfig.MetafileAttributesTTL)
 		cfg.CacheAttributes("block-index", metadataCache, isBlockIndexFile, metadataConfig.BlockIndexAttributesTTL)
-		cfg.CacheGet("bucket-index", metadataCache, isBucketIndexFile, metadataConfig.BucketIndexMaxSize, metadataConfig.BucketIndexContentTTL /* do not cache exist / not exist: */, 0, 0)
+		cfg.CacheGet("bucket-index", metadataCache, isBucketIndexFiles, metadataConfig.BucketIndexMaxSize, metadataConfig.BucketIndexContentTTL /* do not cache exist / not exist: */, 0, 0)
 
 		codec := snappyIterCodec{storecache.JSONIterCodec{}}
 		cfg.CacheIter("tenants-iter", metadataCache, isTenantsDir, metadataConfig.TenantsListTTL, codec)
@@ -196,9 +196,9 @@ func isBlockIndexFile(name string) bool {
 	return err == nil
 }
 
-func isBucketIndexFile(name string) bool {
+func isBucketIndexFiles(name string) bool {
 	// TODO can't reference bucketindex because of a circular dependency. To be fixed.
-	return strings.HasSuffix(name, "/bucket-index.json.gz")
+	return strings.HasSuffix(name, "/bucket-index.json.gz") || strings.HasSuffix(name, "/bucket-index-sync-status.json")
 }
 
 func isTenantsDir(name string) bool {

--- a/pkg/storage/tsdb/caching_bucket_test.go
+++ b/pkg/storage/tsdb/caching_bucket_test.go
@@ -17,11 +17,12 @@ func TestIsTenantDir(t *testing.T) {
 }
 
 func TestIsBucketIndexFile(t *testing.T) {
-	assert.False(t, isBucketIndexFile(""))
-	assert.False(t, isBucketIndexFile("test"))
-	assert.False(t, isBucketIndexFile("test/block"))
-	assert.False(t, isBucketIndexFile("test/block/chunks"))
-	assert.True(t, isBucketIndexFile("test/bucket-index.json.gz"))
+	assert.False(t, isBucketIndexFiles(""))
+	assert.False(t, isBucketIndexFiles("test"))
+	assert.False(t, isBucketIndexFiles("test/block"))
+	assert.False(t, isBucketIndexFiles("test/block/chunks"))
+	assert.True(t, isBucketIndexFiles("test/bucket-index.json.gz"))
+	assert.True(t, isBucketIndexFiles("test/bucket-index-sync-status.json"))
 }
 
 func TestIsBlockIndexFile(t *testing.T) {

--- a/pkg/storage/tsdb/testutil/objstore.go
+++ b/pkg/storage/tsdb/testutil/objstore.go
@@ -110,5 +110,5 @@ func (m *MockBucketFailure) ReaderWithExpectedErrs(expectedFunc objstore.IsOpFai
 }
 
 func (m *MockBucketFailure) IsCustomerManagedKeyError(err error) bool {
-	return errors.Is(errors.Cause(err), ErrKeyAccessDeniedError)
+	return ErrKeyAccessDeniedError == err
 }


### PR DESCRIPTION
**What this PR does**:

This PR introduce a new file to be saved together with the bucket index with the status of the last sync (bucket index update).

The bucket sync status is used on ingesters/queriers/storegateways/compactors to halt any operation for a given tenant if the bucket index could not be updated due CMK errors.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
