### PR TITLE
Fix query frontend v2 failed to cancel request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [BUGFIX] Distributor: Fix potential data corruption in cases of timeout between distributors and ingesters. #5422
 * [BUGFIX] Store Gateway: Fix bug in store gateway ring comparison logic. #5426
 * [BUGFIX] Ring: Fix bug in consistency of Get func in a scaling zone-aware ring. #5429
+* [BUGFIX] Query Frontend: Fix bug of failing to cancel downstream request context in query frontend v2 mode (query scheduler enabled). #5447
 
 ## 1.15.1 2023-04-26
 

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/cortexproject/cortex/pkg/util/grpcclient"
 	"github.com/cortexproject/cortex/pkg/util/httpgrpcutil"
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -226,7 +227,8 @@ enqueueAgain:
 			case cancelCh <- freq.queryID:
 				// cancellation sent.
 			default:
-				// failed to cancel, ignore.
+				// failed to cancel, log it.
+				level.Warn(util_log.WithContext(ctx, f.log)).Log("msg", "failed to enqueue cancellation signal", "query_id", freq.queryID)
 			}
 		}
 		return nil, ctx.Err()

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -71,6 +71,9 @@ type Frontend struct {
 
 	schedulerWorkers *frontendSchedulerWorkers
 	requests         *requestsInProgress
+
+	// Metric for number of cancellation failed to send to query scheduler.
+	cancelFailedQueries prometheus.Counter
 }
 
 type frontendRequest struct {
@@ -134,6 +137,11 @@ func NewFrontend(cfg Config, log log.Logger, reg prometheus.Registerer) (*Fronte
 		Help: "Number of schedulers this frontend is connected to.",
 	}, func() float64 {
 		return float64(f.schedulerWorkers.getWorkersCount())
+	})
+
+	f.cancelFailedQueries = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_query_frontend_cancel_failed_queries_total",
+		Help: "Total number of queries that are failed to be canceled due to cancel channel full.",
 	})
 
 	f.Service = services.NewIdleService(f.starting, f.stopping)
@@ -229,6 +237,7 @@ enqueueAgain:
 			default:
 				// failed to cancel, log it.
 				level.Warn(util_log.WithContext(ctx, f.log)).Log("msg", "failed to enqueue cancellation signal", "query_id", freq.queryID)
+				f.cancelFailedQueries.Inc()
 			}
 		}
 		return nil, ctx.Err()

--- a/pkg/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/frontend/v2/frontend_scheduler_worker.go
@@ -171,7 +171,7 @@ func newFrontendSchedulerWorker(conn *grpc.ClientConn, schedulerAddr string, fro
 		schedulerAddr: schedulerAddr,
 		frontendAddr:  frontendAddr,
 		requestCh:     requestCh,
-		cancelCh:      make(chan uint64),
+		cancelCh:      make(chan uint64, 1000), // Use buffered channel to make sure we can always enqueue to cancel request context.
 	}
 	w.ctx, w.cancel = context.WithCancel(context.Background())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

We found out that when using query frontend v2 mode (with query scheduler), sometimes queries at store gateway are not successfully canceled even if requests canceled at query frontend. We also tested the same query using query frontend v1 but there is no such issue.

After some investigation, the issue turns out the `cancelCh` being a blocking channel. So when there are a few requests to cancel, sometimes the cancellation signal cannot enqueue, resulting downstream request cannot be canceled.

```
	select {
	case <-ctx.Done():
		if cancelCh != nil {
			select {
			case cancelCh <- freq.queryID:
				// cancellation sent.
			default:
				// failed to cancel, ignore.
			}
		}
```
Using the code above, it will go to the `default` statement rather than enqueuing the cancellation successfully.

This pr switches `cancelCh` to use buffered channel with a size of 1000. It is still possible to fail to enqueue but should be much better than the block channel.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
