### PR TITLE
Implementing multi level index cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [ENHANCEMENT] Store Gateway: Add config `estimated_max_series_size_bytes` and `estimated_max_chunk_size_bytes` to address data overfetch. #5401
 * [ENHANCEMENT] Distributor/Ingester: Add experimental `-distributor.sign_write_requests` flag to sign the write requests. #5430
 * [ENHANCEMENT] Store Gateway/Querier/Compactor: Handling CMK Access Denied errors. #5420 #5442 #5446
+* [ENHANCEMENT] Store Gateway: Implementing multi level index cache. #5451
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -519,8 +519,9 @@ blocks_storage:
     [consistency_delay: <duration> | default = 0s]
 
     index_cache:
-      # The index cache backend type. Supported values: inmemory, memcached,
-      # redis.
+      # The index cache backend type. Multiple cache backend can be provided as
+      # a comma-separated ordered list to enable the implementation of a cache
+      # hierarchy. Supported values: inmemory, memcached, redis.
       # CLI flag: -blocks-storage.bucket-store.index-cache.backend
       [backend: <string> | default = "inmemory"]
 

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -606,8 +606,9 @@ blocks_storage:
     [consistency_delay: <duration> | default = 0s]
 
     index_cache:
-      # The index cache backend type. Supported values: inmemory, memcached,
-      # redis.
+      # The index cache backend type. Multiple cache backend can be provided as
+      # a comma-separated ordered list to enable the implementation of a cache
+      # hierarchy. Supported values: inmemory, memcached, redis.
       # CLI flag: -blocks-storage.bucket-store.index-cache.backend
       [backend: <string> | default = "inmemory"]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1045,8 +1045,9 @@ bucket_store:
   [consistency_delay: <duration> | default = 0s]
 
   index_cache:
-    # The index cache backend type. Supported values: inmemory, memcached,
-    # redis.
+    # The index cache backend type. Multiple cache backend can be provided as a
+    # comma-separated ordered list to enable the implementation of a cache
+    # hierarchy. Supported values: inmemory, memcached, redis.
     # CLI flag: -blocks-storage.bucket-store.index-cache.backend
     [backend: <string> | default = "inmemory"]
 

--- a/go.mod
+++ b/go.mod
@@ -51,9 +51,9 @@ require (
 	github.com/sony/gobreaker v0.5.0
 	github.com/spf13/afero v1.9.5
 	github.com/stretchr/testify v1.8.4
-	github.com/thanos-io/objstore v0.0.0-20230629211010-ff1b35b9841a
+	github.com/thanos-io/objstore v0.0.0-20230710163637-47c0118da0ca
 	github.com/thanos-io/promql-engine v0.0.0-20230526105742-791d78b260ea
-	github.com/thanos-io/thanos v0.31.1-0.20230711160112-df3a5f808726
+	github.com/thanos-io/thanos v0.31.1-0.20230712154708-a395c5dbd054
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/weaveworks/common v0.0.0-20221201103051-7c2720a9024d
 	go.etcd.io/etcd/api/v3 v3.5.8

--- a/go.sum
+++ b/go.sum
@@ -1160,12 +1160,12 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40 h1:W6vDGKCHe4wBACI1d2UgE6+50sJFhRWU4O8IB2ozzxM=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e h1:f1Zsv7OAU9iQhZwigp50Yl38W10g/vd5NC8Rdk1Jzng=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e/go.mod h1:jXcofnrSln/cLI6/dhlBxPQZEEQHVPCcFaH75M+nSzM=
-github.com/thanos-io/objstore v0.0.0-20230629211010-ff1b35b9841a h1:tXcVeuval1nzdHn1JXqaBmyjuEUcpDI9huPrUF04nR4=
-github.com/thanos-io/objstore v0.0.0-20230629211010-ff1b35b9841a/go.mod h1:5V7lzXuaxwt6XFQoA/zJrhdnQrxq1+r0bwQ1iYOq3gM=
+github.com/thanos-io/objstore v0.0.0-20230710163637-47c0118da0ca h1:JRF7i58HovirZQVJGwCClQsMK6CCmK2fvialXjeoSpI=
+github.com/thanos-io/objstore v0.0.0-20230710163637-47c0118da0ca/go.mod h1:5V7lzXuaxwt6XFQoA/zJrhdnQrxq1+r0bwQ1iYOq3gM=
 github.com/thanos-io/promql-engine v0.0.0-20230526105742-791d78b260ea h1:kzK8sBn2+mo3NAxP+XjAjAqr1hwfxxFUy5CybaBkjAI=
 github.com/thanos-io/promql-engine v0.0.0-20230526105742-791d78b260ea/go.mod h1:eIgPaXWgOhNAv6CPPrgu09r0AtT7byBTZy+7WkX0D18=
-github.com/thanos-io/thanos v0.31.1-0.20230711160112-df3a5f808726 h1:DcjKUBKKMckA48Eua9H37+lOs13xDUx1PxixIs9hHHo=
-github.com/thanos-io/thanos v0.31.1-0.20230711160112-df3a5f808726/go.mod h1:bDBl+vJEBXNkMvedh10vjDbvYkPyI6r2JJYJG0lLZTo=
+github.com/thanos-io/thanos v0.31.1-0.20230712154708-a395c5dbd054 h1:kBuXA0B+jXX89JAJTymw7g/v/4jyjCSgfPcWQeFUOoM=
+github.com/thanos-io/thanos v0.31.1-0.20230712154708-a395c5dbd054/go.mod h1:C0Cdk0kFFEDS3qkTgScF9ONSjrPxqnScGPoIgah3NJY=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab h1:7ZR3hmisBWw77ZpO1/o86g+JV3VKlk3d48jopJxzTjU=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab/go.mod h1:eheTFp954zcWZXCU8d0AT76ftsQOTo4DTqkN/h3k1MY=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/storage/tsdb/index_cache.go
+++ b/pkg/storage/tsdb/index_cache.go
@@ -51,7 +51,10 @@ func (cfg *IndexCacheConfig) RegisterFlags(f *flag.FlagSet) {
 }
 
 func (cfg *IndexCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
-	f.StringVar(&cfg.Backend, prefix+"backend", IndexCacheBackendDefault, fmt.Sprintf("The index cache backend type. Supported values: %s.", strings.Join(supportedIndexCacheBackends, ", ")))
+	f.StringVar(&cfg.Backend, prefix+"backend", IndexCacheBackendDefault, fmt.Sprintf("The index cache backend type. " +
+		"Multiple cache backend can be provided as a comma-separated ordered list to enable the implementation of a cache hierarchy. " +
+		"Supported values: %s.",
+	strings.Join(supportedIndexCacheBackends, ", ")))
 
 	cfg.InMemory.RegisterFlagsWithPrefix(f, prefix+"inmemory.")
 	cfg.Memcached.RegisterFlagsWithPrefix(f, prefix+"memcached.")

--- a/pkg/storage/tsdb/index_cache.go
+++ b/pkg/storage/tsdb/index_cache.go
@@ -139,7 +139,7 @@ func newInMemoryIndexCache(cfg InMemoryIndexCacheConfig, logger log.Logger, regi
 		maxItemSize = maxCacheSize
 	}
 
-	return storecache.NewInMemoryIndexCacheWithConfig(logger, registerer, storecache.InMemoryIndexCacheConfig{
+	return storecache.NewInMemoryIndexCacheWithConfig(logger, nil, registerer, storecache.InMemoryIndexCacheConfig{
 		MaxSize:     maxCacheSize,
 		MaxItemSize: maxItemSize,
 	})
@@ -160,5 +160,5 @@ func newRedisIndexCache(cfg RedisClientConfig, logger log.Logger, registerer pro
 		return nil, errors.Wrapf(err, "create index cache redis client")
 	}
 
-	return storecache.NewRemoteIndexCache(logger, client, registerer)
+	return storecache.NewRemoteIndexCache(logger, client, nil, registerer)
 }

--- a/pkg/storage/tsdb/multilevel_cache.go
+++ b/pkg/storage/tsdb/multilevel_cache.go
@@ -100,7 +100,7 @@ func (m *multiLevelCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULI
 }
 
 func newMultiLevelCache(c ...storecache.IndexCache) storecache.IndexCache {
-	if len(c) == 0 {
+	if len(c) == 1 {
 		return c[0]
 	}
 	return &multiLevelCache{

--- a/pkg/storage/tsdb/multilevel_cache.go
+++ b/pkg/storage/tsdb/multilevel_cache.go
@@ -1,0 +1,109 @@
+package tsdb
+
+import (
+	"context"
+	"sync"
+
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	storecache "github.com/thanos-io/thanos/pkg/store/cache"
+)
+
+type multiLevelCache struct {
+	caches []storecache.IndexCache
+}
+
+func (m *multiLevelCache) StorePostings(blockID ulid.ULID, l labels.Label, v []byte) {
+	wg := sync.WaitGroup{}
+	wg.Add(len(m.caches))
+	for _, c := range m.caches {
+		cache := c
+		go func() {
+			defer wg.Done()
+			cache.StorePostings(blockID, l, v)
+		}()
+	}
+	wg.Wait()
+}
+
+func (m *multiLevelCache) FetchMultiPostings(ctx context.Context, blockID ulid.ULID, keys []labels.Label) (hits map[labels.Label][]byte, misses []labels.Label) {
+	misses = keys
+	hits = map[labels.Label][]byte{}
+	for _, c := range m.caches {
+		h, m := c.FetchMultiPostings(ctx, blockID, misses)
+		misses = m
+
+		for label, bytes := range h {
+			hits[label] = bytes
+		}
+		if len(misses) == 0 {
+			break
+		}
+	}
+
+	return hits, misses
+}
+
+func (m *multiLevelCache) StoreExpandedPostings(blockID ulid.ULID, matchers []*labels.Matcher, v []byte) {
+	wg := sync.WaitGroup{}
+	wg.Add(len(m.caches))
+	for _, c := range m.caches {
+		cache := c
+		go func() {
+			defer wg.Done()
+			cache.StoreExpandedPostings(blockID, matchers, v)
+		}()
+	}
+	wg.Wait()
+}
+
+func (m *multiLevelCache) FetchExpandedPostings(ctx context.Context, blockID ulid.ULID, matchers []*labels.Matcher) ([]byte, bool) {
+	for _, c := range m.caches {
+		if d, h := c.FetchExpandedPostings(ctx, blockID, matchers); h {
+			return d, h
+		}
+	}
+
+	return []byte{}, false
+}
+
+func (m *multiLevelCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, v []byte) {
+	wg := sync.WaitGroup{}
+	wg.Add(len(m.caches))
+	for _, c := range m.caches {
+		cache := c
+		go func() {
+			defer wg.Done()
+			cache.StoreSeries(blockID, id, v)
+		}()
+	}
+	wg.Wait()
+}
+
+func (m *multiLevelCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
+	misses = ids
+	hits = map[storage.SeriesRef][]byte{}
+	for _, c := range m.caches {
+		h, m := c.FetchMultiSeries(ctx, blockID, misses)
+		misses = m
+
+		for label, bytes := range h {
+			hits[label] = bytes
+		}
+		if len(misses) == 0 {
+			break
+		}
+	}
+
+	return hits, misses
+}
+
+func newMultiLevelCache(c ...storecache.IndexCache) storecache.IndexCache {
+	if len(c) == 0 {
+		return c[0]
+	}
+	return &multiLevelCache{
+		caches: c,
+	}
+}

--- a/pkg/storage/tsdb/multilevel_cache_test.go
+++ b/pkg/storage/tsdb/multilevel_cache_test.go
@@ -1,0 +1,255 @@
+package tsdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+	storecache "github.com/thanos-io/thanos/pkg/store/cache"
+)
+
+func Test_MultiIndexCacheInstantiation(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	s, err := miniredis.Run()
+	if err != nil {
+		testutil.Ok(t, err)
+	}
+	defer s.Close()
+
+	cfg := IndexCacheConfig{
+		Backend: "inmemory,redis",
+		Redis: RedisClientConfig{
+			Addresses: s.Addr(),
+		},
+	}
+	_, err = NewIndexCache(cfg, log.NewNopLogger(), reg)
+	require.NoError(t, err)
+}
+
+func Test_MultiLevelCache(t *testing.T) {
+	bID, _ := ulid.Parse("01D78XZ44G0000000000000000")
+	ctx := context.Background()
+	l1 := labels.Label{
+		Name:  "test",
+		Value: "test",
+	}
+
+	l2 := labels.Label{
+		Name:  "test2",
+		Value: "test2",
+	}
+
+	matcher, err := labels.NewMatcher(labels.MatchEqual, "name", "value")
+	require.NoError(t, err)
+
+	v := make([]byte, 100)
+
+	testCases := map[string]struct {
+		m1ExpectedCalls map[string][][]interface{}
+		m2ExpectedCalls map[string][][]interface{}
+		m1MockedCalls   map[string][]interface{}
+		m2MockedCalls   map[string][]interface{}
+		call            func(storecache.IndexCache)
+	}{
+		"[StorePostings] Should store on all caches": {
+			m1ExpectedCalls: map[string][][]interface{}{
+				"StorePostings": {{bID, l1, v}},
+			},
+			m2ExpectedCalls: map[string][][]interface{}{
+				"StorePostings": {{bID, l1, v}},
+			},
+			call: func(cache storecache.IndexCache) {
+				cache.StorePostings(bID, l1, v)
+			},
+		},
+		"[StoreSeries] Should store on all caches": {
+			m1ExpectedCalls: map[string][][]interface{}{
+				"StoreSeries": {{bID, storage.SeriesRef(1), v}},
+			},
+			m2ExpectedCalls: map[string][][]interface{}{
+				"StoreSeries": {{bID, storage.SeriesRef(1), v}},
+			},
+			call: func(cache storecache.IndexCache) {
+				cache.StoreSeries(bID, 1, v)
+			},
+		},
+		"[StoreExpandedPostings] Should store on all caches": {
+			m1ExpectedCalls: map[string][][]interface{}{
+				"StoreExpandedPostings": {{bID, []*labels.Matcher{matcher}, v}},
+			},
+			m2ExpectedCalls: map[string][][]interface{}{
+				"StoreExpandedPostings": {{bID, []*labels.Matcher{matcher}, v}},
+			},
+			call: func(cache storecache.IndexCache) {
+				cache.StoreExpandedPostings(bID, []*labels.Matcher{matcher}, v)
+			},
+		},
+		"[FetchMultiPostings] Should fallback when all misses": {
+			m1ExpectedCalls: map[string][][]interface{}{
+				"FetchMultiPostings": {{bID, []labels.Label{l1, l2}}},
+			},
+			m2ExpectedCalls: map[string][][]interface{}{
+				"FetchMultiPostings": {{bID, []labels.Label{l1, l2}}},
+			},
+			call: func(cache storecache.IndexCache) {
+				cache.FetchMultiPostings(ctx, bID, []labels.Label{l1, l2})
+			},
+		},
+		"[FetchMultiPostings] should fallback only the missing keys on l1": {
+			m1ExpectedCalls: map[string][][]interface{}{
+				"FetchMultiPostings": {{bID, []labels.Label{l1, l2}}},
+			},
+			m2ExpectedCalls: map[string][][]interface{}{
+				"FetchMultiPostings": {{bID, []labels.Label{l2}}},
+			},
+			m1MockedCalls: map[string][]interface{}{
+				"FetchMultiPostings": {map[labels.Label][]byte{l1: make([]byte, 1)}, []labels.Label{l2}},
+			},
+			call: func(cache storecache.IndexCache) {
+				cache.FetchMultiPostings(ctx, bID, []labels.Label{l1, l2})
+			},
+		},
+		"[FetchMultiPostings] should not fallback when all hit on l1": {
+			m1ExpectedCalls: map[string][][]interface{}{
+				"FetchMultiPostings": {{bID, []labels.Label{l1, l2}}},
+			},
+			m2ExpectedCalls: map[string][][]interface{}{},
+			m1MockedCalls: map[string][]interface{}{
+				"FetchMultiPostings": {map[labels.Label][]byte{l1: make([]byte, 1), l2: make([]byte, 1)}, []labels.Label{}},
+			},
+			call: func(cache storecache.IndexCache) {
+				cache.FetchMultiPostings(ctx, bID, []labels.Label{l1, l2})
+			},
+		},
+		"[FetchMultiSeries] Should fallback when all misses": {
+			m1ExpectedCalls: map[string][][]interface{}{
+				"FetchMultiSeries": {{bID, []storage.SeriesRef{1, 2}}},
+			},
+			m2ExpectedCalls: map[string][][]interface{}{
+				"FetchMultiSeries": {{bID, []storage.SeriesRef{1, 2}}},
+			},
+			call: func(cache storecache.IndexCache) {
+				cache.FetchMultiSeries(ctx, bID, []storage.SeriesRef{1, 2})
+			},
+		},
+		"[FetchMultiSeries] should fallback only the missing keys on l1": {
+			m1ExpectedCalls: map[string][][]interface{}{
+				"FetchMultiSeries": {{bID, []storage.SeriesRef{1, 2}}},
+			},
+			m2ExpectedCalls: map[string][][]interface{}{
+				"FetchMultiSeries": {{bID, []storage.SeriesRef{2}}},
+			},
+			m1MockedCalls: map[string][]interface{}{
+				"FetchMultiSeries": {map[storage.SeriesRef][]byte{1: make([]byte, 1)}, []storage.SeriesRef{2}},
+			},
+			call: func(cache storecache.IndexCache) {
+				cache.FetchMultiSeries(ctx, bID, []storage.SeriesRef{1, 2})
+			},
+		},
+		"[FetchMultiSeries] should not fallback when all hit on l1": {
+			m1ExpectedCalls: map[string][][]interface{}{
+				"FetchMultiSeries": {{bID, []storage.SeriesRef{1, 2}}},
+			},
+			m2ExpectedCalls: map[string][][]interface{}{},
+			m1MockedCalls: map[string][]interface{}{
+				"FetchMultiSeries": {map[storage.SeriesRef][]byte{1: make([]byte, 1), 2: make([]byte, 1)}, []storage.SeriesRef{}},
+			},
+			call: func(cache storecache.IndexCache) {
+				cache.FetchMultiSeries(ctx, bID, []storage.SeriesRef{1, 2})
+			},
+		},
+		"[FetchExpandedPostings] Should fallback when miss": {
+			m1ExpectedCalls: map[string][][]interface{}{
+				"FetchExpandedPostings": {{bID, []*labels.Matcher{matcher}}},
+			},
+			m2ExpectedCalls: map[string][][]interface{}{
+				"FetchExpandedPostings": {{bID, []*labels.Matcher{matcher}}},
+			},
+			call: func(cache storecache.IndexCache) {
+				cache.FetchExpandedPostings(ctx, bID, []*labels.Matcher{matcher})
+			},
+		},
+		"[FetchExpandedPostings] should not fallback when all hit on l1": {
+			m1ExpectedCalls: map[string][][]interface{}{
+				"FetchExpandedPostings": {{bID, []*labels.Matcher{matcher}}},
+			},
+			m2ExpectedCalls: map[string][][]interface{}{},
+			m1MockedCalls: map[string][]interface{}{
+				"FetchExpandedPostings": {[]byte{}, true},
+			},
+			call: func(cache storecache.IndexCache) {
+				cache.FetchExpandedPostings(ctx, bID, []*labels.Matcher{matcher})
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			m1 := newMockIndexCache(tc.m1MockedCalls)
+			m2 := newMockIndexCache(tc.m2MockedCalls)
+			c := newMultiLevelCache(m1, m2)
+			tc.call(c)
+			require.Equal(t, tc.m1ExpectedCalls, m1.calls)
+			require.Equal(t, tc.m2ExpectedCalls, m2.calls)
+		})
+	}
+}
+
+func newMockIndexCache(mockedCalls map[string][]interface{}) *mockIndexCache {
+	return &mockIndexCache{
+		calls:       map[string][][]interface{}{},
+		mockedCalls: mockedCalls,
+	}
+}
+
+type mockIndexCache struct {
+	calls       map[string][][]interface{}
+	mockedCalls map[string][]interface{}
+}
+
+func (m *mockIndexCache) StorePostings(blockID ulid.ULID, l labels.Label, v []byte) {
+	m.calls["StorePostings"] = append(m.calls["StorePostings"], []interface{}{blockID, l, v})
+}
+
+func (m *mockIndexCache) FetchMultiPostings(_ context.Context, blockID ulid.ULID, keys []labels.Label) (hits map[labels.Label][]byte, misses []labels.Label) {
+	m.calls["FetchMultiPostings"] = append(m.calls["FetchMultiPostings"], []interface{}{blockID, keys})
+	if m, ok := m.mockedCalls["FetchMultiPostings"]; ok {
+		return m[0].(map[labels.Label][]byte), m[1].([]labels.Label)
+	}
+
+	return map[labels.Label][]byte{}, keys
+}
+
+func (m *mockIndexCache) StoreExpandedPostings(blockID ulid.ULID, matchers []*labels.Matcher, v []byte) {
+	m.calls["StoreExpandedPostings"] = append(m.calls["StoreExpandedPostings"], []interface{}{blockID, matchers, v})
+}
+
+func (m *mockIndexCache) FetchExpandedPostings(_ context.Context, blockID ulid.ULID, matchers []*labels.Matcher) ([]byte, bool) {
+	m.calls["FetchExpandedPostings"] = append(m.calls["FetchExpandedPostings"], []interface{}{blockID, matchers})
+	if m, ok := m.mockedCalls["FetchExpandedPostings"]; ok {
+		return m[0].([]byte), m[1].(bool)
+	}
+
+	return []byte{}, false
+}
+
+func (m *mockIndexCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, v []byte) {
+	m.calls["StoreSeries"] = append(m.calls["StoreSeries"], []interface{}{blockID, id, v})
+}
+
+func (m *mockIndexCache) FetchMultiSeries(_ context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {
+	m.calls["FetchMultiSeries"] = append(m.calls["FetchMultiSeries"], []interface{}{blockID, ids})
+	if m, ok := m.mockedCalls["FetchMultiSeries"]; ok {
+		return m[0].(map[storage.SeriesRef][]byte), m[1].([]storage.SeriesRef)
+	}
+
+	return map[storage.SeriesRef][]byte{}, ids
+}

--- a/vendor/github.com/thanos-io/objstore/CHANGELOG.md
+++ b/vendor/github.com/thanos-io/objstore/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 - [#33](https://github.com/thanos-io/objstore/pull/33) Tracing: Add `ContextWithTracer()` to inject the tracer into the context.
 - [#34](https://github.com/thanos-io/objstore/pull/34) Fix ignored options when creating shared credential Azure client.
+- [#62](https://github.com/thanos-io/objstore/pull/62) S3: Fix ignored context cancellation in `Iter` method. 
 
 ### Added
 - [#15](https://github.com/thanos-io/objstore/pull/15) Add Oracle Cloud Infrastructure Object Storage Bucket support.

--- a/vendor/github.com/thanos-io/objstore/providers/s3/s3.go
+++ b/vendor/github.com/thanos-io/objstore/providers/s3/s3.go
@@ -418,7 +418,7 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 		}
 	}
 
-	return nil
+	return ctx.Err()
 }
 
 func (b *Bucket) getRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {

--- a/vendor/github.com/thanos-io/thanos/pkg/store/cache/cache.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/store/cache/cache.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/oklog/ulid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"golang.org/x/crypto/blake2b"
@@ -52,6 +54,25 @@ type IndexCache interface {
 	// FetchMultiSeries fetches multiple series - each identified by ID - from the cache
 	// and returns a map containing cache hits, along with a list of missing IDs.
 	FetchMultiSeries(ctx context.Context, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef)
+}
+
+// Common metrics that should be used by all cache implementations.
+type commonMetrics struct {
+	requestTotal *prometheus.CounterVec
+	hitsTotal    *prometheus.CounterVec
+}
+
+func newCommonMetrics(reg prometheus.Registerer) *commonMetrics {
+	return &commonMetrics{
+		requestTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_store_index_cache_requests_total",
+			Help: "Total number of items requests to the cache.",
+		}, []string{"item_type"}),
+		hitsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_store_index_cache_hits_total",
+			Help: "Total number of items requests to the cache that were a hit.",
+		}, []string{"item_type"}),
+	}
 }
 
 type cacheKey struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -832,7 +832,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thanos-io/objstore v0.0.0-20230629211010-ff1b35b9841a
+# github.com/thanos-io/objstore v0.0.0-20230710163637-47c0118da0ca
 ## explicit; go 1.18
 github.com/thanos-io/objstore
 github.com/thanos-io/objstore/exthttp
@@ -863,7 +863,7 @@ github.com/thanos-io/promql-engine/logicalplan
 github.com/thanos-io/promql-engine/parser
 github.com/thanos-io/promql-engine/query
 github.com/thanos-io/promql-engine/worker
-# github.com/thanos-io/thanos v0.31.1-0.20230711160112-df3a5f808726
+# github.com/thanos-io/thanos v0.31.1-0.20230712154708-a395c5dbd054
 ## explicit; go 1.18
 github.com/thanos-io/thanos/pkg/block
 github.com/thanos-io/thanos/pkg/block/indexheader


### PR DESCRIPTION
**What this PR does**:
Implementing multi-level caching for the index cache.

With the PR we will be able to configure multiples caching layers like for example "inMemory" as L1 cache and "memcache" as l2 cache.

The configuration will now accept a `Comma separated ordered list of index cache backend type` and cortex will use the cache in order (l1,l2,ln).

Currently we don't "backfill" the data from a Ln+1 to a Ln cache but this can be implemented in the future.

PS: This change should be a NoOp if only 1 cache is configured.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
