### PR TITLE
Avoid concurrency cleaners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [BUGFIX] Ring: Fix bug in consistency of Get func in a scaling zone-aware ring. #5429
 * [BUGFIX] Query Frontend: Fix bug of failing to cancel downstream request context in query frontend v2 mode (query scheduler enabled). #5447
 * [BUGFIX] Alertmanager: Remove the user id from state replication key metric label value. #5453
+* [BUGFIX] Compactor: Avoid cleaner concurrency issues checking global markers before all blocks. #5457
 
 ## 1.15.1 2023-04-26
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Improve cases where we have cleaner concurrency for the same tenant.
Compactor can run cleaner for the same tenant at the same time (eg. ring resharding)
In that case we can have some concurrence issues with deletion blockers
Example:
Compactor1 - c1
Compactor2 - c2

T0 - c1 start cleaner (list blocks and deletion markers)
T1 - c2 start cleaner (list blocks)
T2 - c1 start deletes all blocks and global markers
T3 - c2 continue cleaning (list global markers)

In this scenario, it is possible that c2 will find a block but not the global marker because c1 already delete it. Leaving a dangling block on the index causing consistency check failures at queries.

To avoid this scenario, we are changing the order we look for blocks. First global markers and then all blocks. We also make a check to make sure we are not adding a deletion block back as valid block. A block marked for deletion should not go back to be a valid block

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
