### PR TITLE
Add ingester flag to customize message in limiter error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## master / unreleased
-* [FEATURE] Ingester: added `-admin-limit-message` to customize the message contained in limit errors.#5452
+* [FEATURE] Ingester: added `-admin-limit-message` to customize the message contained in limit errors.#5460
 * [CHANGE] AlertManager: include reason label in cortex_alertmanager_notifications_failed_total.#5409
 * [CHANGE] Query: Set CORS Origin headers for Query API #5388
 * [CHANGE] Updating prometheus/alertmanager from v0.25.0 to v0.25.1-0.20230505130626-263ca5c9438e. This includes the below changes. #5276

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master / unreleased
+* [FEATURE] Ingester: added `-admin-limit-message` to customize the message contained in limit errors.#5452
 * [CHANGE] AlertManager: include reason label in cortex_alertmanager_notifications_failed_total.#5409
 * [CHANGE] Query: Set CORS Origin headers for Query API #5388
 * [CHANGE] Updating prometheus/alertmanager from v0.25.0 to v0.25.1-0.20230505130626-263ca5c9438e. This includes the below changes. #5276

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2622,7 +2622,7 @@ instance_limits:
 [ignore_series_limit_for_metric_names: <string> | default = ""]
 
 # Flag to add site administrator contact details for customising error messages
-# CLI flag: -ingester.admin-contact
+# CLI flag: -ingester.admin-limit-message
 [admin_limit_message: <string> | default = "please contact administrator to raise it"]
 ```
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2620,6 +2620,10 @@ instance_limits:
 # max-global-series-per-metric limits.
 # CLI flag: -ingester.ignore-series-limit-for-metric-names
 [ignore_series_limit_for_metric_names: <string> | default = ""]
+
+# Flag to add site administrator contact details for customising error messages
+# CLI flag: -ingester.admin-contact
+[admin_contact: <string> | default = ""]
 ```
 
 ### `ingester_client_config`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2621,7 +2621,7 @@ instance_limits:
 # CLI flag: -ingester.ignore-series-limit-for-metric-names
 [ignore_series_limit_for_metric_names: <string> | default = ""]
 
-# Flag to add site administrator contact details for customising error messages
+# Customize the message contained in limit errors
 # CLI flag: -ingester.admin-limit-message
 [admin_limit_message: <string> | default = "please contact administrator to raise it"]
 ```

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2623,7 +2623,7 @@ instance_limits:
 
 # Flag to add site administrator contact details for customising error messages
 # CLI flag: -ingester.admin-contact
-[admin_contact: <string> | default = ""]
+[admin_limit_message: <string> | default = "please contact administrator to raise it"]
 ```
 
 ### `ingester_client_config`

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -126,7 +126,7 @@ type Config struct {
 	ingesterClientFactory func(addr string, cfg client.Config) (client.HealthAndIngesterClient, error)
 
 	// For admin contact details
-	AdminContactDetails string `yaml:"admin_contact"`
+	AdminLimitMessage string `yaml:"admin_limit_message"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -148,7 +148,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	f.StringVar(&cfg.IgnoreSeriesLimitForMetricNames, "ingester.ignore-series-limit-for-metric-names", "", "Comma-separated list of metric names, for which -ingester.max-series-per-metric and -ingester.max-global-series-per-metric limits will be ignored. Does not affect max-series-per-user or max-global-series-per-metric limits.")
 
-	f.StringVar(&cfg.AdminContactDetails, "ingester.admin-contact", "", "Add site administrator contact details for customising error messages")
+	f.StringVar(&cfg.AdminLimitMessage, "ingester.admin-limit-message", "please contact administrator to raise it", "Customize the message contained in limit errors")
+
 }
 
 func (cfg *Config) getIgnoreSeriesLimitForMetricNamesMap() map[string]struct{} {
@@ -659,7 +660,7 @@ func New(cfg Config, limits *validation.Overrides, registerer prometheus.Registe
 		cfg.DistributorShardByAllLabels,
 		cfg.LifecyclerConfig.RingConfig.ReplicationFactor,
 		cfg.LifecyclerConfig.RingConfig.ZoneAwarenessEnabled,
-		cfg.AdminContactDetails,
+		cfg.AdminLimitMessage,
 	)
 
 	i.TSDBState.shipperIngesterID = i.lifecycler.ID

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -124,6 +124,9 @@ type Config struct {
 
 	// For testing, you can override the address and ID of this ingester.
 	ingesterClientFactory func(addr string, cfg client.Config) (client.HealthAndIngesterClient, error)
+
+	// For admin contact details
+	AdminContactDetails string `yaml:"admin_contact"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -144,6 +147,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Int64Var(&cfg.DefaultLimits.MaxInflightPushRequests, "ingester.instance-limits.max-inflight-push-requests", 0, "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
 
 	f.StringVar(&cfg.IgnoreSeriesLimitForMetricNames, "ingester.ignore-series-limit-for-metric-names", "", "Comma-separated list of metric names, for which -ingester.max-series-per-metric and -ingester.max-global-series-per-metric limits will be ignored. Does not affect max-series-per-user or max-global-series-per-metric limits.")
+
+	f.StringVar(&cfg.AdminContactDetails, "ingester.admin-contact", "", "Add site administrator contact details for customising error messages")
 }
 
 func (cfg *Config) getIgnoreSeriesLimitForMetricNamesMap() map[string]struct{} {
@@ -653,7 +658,9 @@ func New(cfg Config, limits *validation.Overrides, registerer prometheus.Registe
 		cfg.DistributorShardingStrategy,
 		cfg.DistributorShardByAllLabels,
 		cfg.LifecyclerConfig.RingConfig.ReplicationFactor,
-		cfg.LifecyclerConfig.RingConfig.ZoneAwarenessEnabled)
+		cfg.LifecyclerConfig.RingConfig.ZoneAwarenessEnabled,
+		cfg.AdminContactDetails,
+	)
 
 	i.TSDBState.shipperIngesterID = i.lifecycler.ID
 

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -34,6 +34,7 @@ type Limiter struct {
 	shuffleShardingEnabled bool
 	shardByAllLabels       bool
 	zoneAwarenessEnabled   bool
+	adminContact           string
 }
 
 // NewLimiter makes a new in-memory series limiter
@@ -44,6 +45,7 @@ func NewLimiter(
 	shardByAllLabels bool,
 	replicationFactor int,
 	zoneAwarenessEnabled bool,
+	adminContact string,
 ) *Limiter {
 	return &Limiter{
 		limits:                 limits,
@@ -52,6 +54,7 @@ func NewLimiter(
 		shuffleShardingEnabled: shardingStrategy == util.ShardingStrategyShuffle,
 		shardByAllLabels:       shardByAllLabels,
 		zoneAwarenessEnabled:   zoneAwarenessEnabled,
+		adminContact:           adminContact,
 	}
 }
 
@@ -121,36 +124,52 @@ func (l *Limiter) formatMaxSeriesPerUserError(userID string) error {
 	actualLimit := l.maxSeriesPerUser(userID)
 	localLimit := l.limits.MaxLocalSeriesPerUser(userID)
 	globalLimit := l.limits.MaxGlobalSeriesPerUser(userID)
+	adminContact := l.adminContact
+	if len(l.adminContact) > 0 {
+		adminContact = "(" + l.adminContact + ") "
+	}
 
-	return fmt.Errorf("per-user series limit of %d exceeded, please contact administrator to raise it (local limit: %d global limit: %d actual local limit: %d)",
-		minNonZero(localLimit, globalLimit), localLimit, globalLimit, actualLimit)
+	return fmt.Errorf("per-user series limit of %d exceeded, please contact administrator %sto raise it (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), adminContact, localLimit, globalLimit, actualLimit)
 }
 
 func (l *Limiter) formatMaxSeriesPerMetricError(userID string) error {
 	actualLimit := l.maxSeriesPerMetric(userID)
 	localLimit := l.limits.MaxLocalSeriesPerMetric(userID)
 	globalLimit := l.limits.MaxGlobalSeriesPerMetric(userID)
+	adminContact := l.adminContact
+	if len(l.adminContact) > 0 {
+		adminContact = "(" + l.adminContact + ") "
+	}
 
-	return fmt.Errorf("per-metric series limit of %d exceeded, please contact administrator to raise it (local limit: %d global limit: %d actual local limit: %d)",
-		minNonZero(localLimit, globalLimit), localLimit, globalLimit, actualLimit)
+	return fmt.Errorf("per-metric series limit of %d exceeded, please contact administrator %sto raise it (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), adminContact, localLimit, globalLimit, actualLimit)
 }
 
 func (l *Limiter) formatMaxMetadataPerUserError(userID string) error {
 	actualLimit := l.maxMetadataPerUser(userID)
 	localLimit := l.limits.MaxLocalMetricsWithMetadataPerUser(userID)
 	globalLimit := l.limits.MaxGlobalMetricsWithMetadataPerUser(userID)
+	adminContact := l.adminContact
+	if len(l.adminContact) > 0 {
+		adminContact = "(" + l.adminContact + ") "
+	}
 
-	return fmt.Errorf("per-user metric metadata limit of %d exceeded, please contact administrator to raise it (local limit: %d global limit: %d actual local limit: %d)",
-		minNonZero(localLimit, globalLimit), localLimit, globalLimit, actualLimit)
+	return fmt.Errorf("per-user metric metadata limit of %d exceeded, please contact administrator %sto raise it (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), adminContact, localLimit, globalLimit, actualLimit)
 }
 
 func (l *Limiter) formatMaxMetadataPerMetricError(userID string) error {
 	actualLimit := l.maxMetadataPerMetric(userID)
 	localLimit := l.limits.MaxLocalMetadataPerMetric(userID)
 	globalLimit := l.limits.MaxGlobalMetadataPerMetric(userID)
+	adminContact := l.adminContact
+	if len(l.adminContact) > 0 {
+		adminContact = "(" + l.adminContact + ") "
+	}
 
-	return fmt.Errorf("per-metric metadata limit of %d exceeded, please contact administrator to raise it (local limit: %d global limit: %d actual local limit: %d)",
-		minNonZero(localLimit, globalLimit), localLimit, globalLimit, actualLimit)
+	return fmt.Errorf("per-metric metadata limit of %d exceeded, please contact administrator %sto raise it (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), adminContact, localLimit, globalLimit, actualLimit)
 }
 
 func (l *Limiter) maxSeriesPerMetric(userID string) int {

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -34,7 +34,7 @@ type Limiter struct {
 	shuffleShardingEnabled bool
 	shardByAllLabels       bool
 	zoneAwarenessEnabled   bool
-	adminContact           string
+	AdminLimitMessage      string
 }
 
 // NewLimiter makes a new in-memory series limiter
@@ -45,7 +45,7 @@ func NewLimiter(
 	shardByAllLabels bool,
 	replicationFactor int,
 	zoneAwarenessEnabled bool,
-	adminContact string,
+	AdminLimitMessage string,
 ) *Limiter {
 	return &Limiter{
 		limits:                 limits,
@@ -54,7 +54,7 @@ func NewLimiter(
 		shuffleShardingEnabled: shardingStrategy == util.ShardingStrategyShuffle,
 		shardByAllLabels:       shardByAllLabels,
 		zoneAwarenessEnabled:   zoneAwarenessEnabled,
-		adminContact:           adminContact,
+		AdminLimitMessage:      AdminLimitMessage,
 	}
 }
 
@@ -124,52 +124,36 @@ func (l *Limiter) formatMaxSeriesPerUserError(userID string) error {
 	actualLimit := l.maxSeriesPerUser(userID)
 	localLimit := l.limits.MaxLocalSeriesPerUser(userID)
 	globalLimit := l.limits.MaxGlobalSeriesPerUser(userID)
-	adminContact := l.adminContact
-	if len(l.adminContact) > 0 {
-		adminContact = "(" + l.adminContact + ") "
-	}
 
-	return fmt.Errorf("per-user series limit of %d exceeded, please contact administrator %sto raise it (local limit: %d global limit: %d actual local limit: %d)",
-		minNonZero(localLimit, globalLimit), adminContact, localLimit, globalLimit, actualLimit)
+	return fmt.Errorf("per-user series limit of %d exceeded, %s (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), l.AdminLimitMessage, localLimit, globalLimit, actualLimit)
 }
 
 func (l *Limiter) formatMaxSeriesPerMetricError(userID string) error {
 	actualLimit := l.maxSeriesPerMetric(userID)
 	localLimit := l.limits.MaxLocalSeriesPerMetric(userID)
 	globalLimit := l.limits.MaxGlobalSeriesPerMetric(userID)
-	adminContact := l.adminContact
-	if len(l.adminContact) > 0 {
-		adminContact = "(" + l.adminContact + ") "
-	}
 
-	return fmt.Errorf("per-metric series limit of %d exceeded, please contact administrator %sto raise it (local limit: %d global limit: %d actual local limit: %d)",
-		minNonZero(localLimit, globalLimit), adminContact, localLimit, globalLimit, actualLimit)
+	return fmt.Errorf("per-metric series limit of %d exceeded, %s (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), l.AdminLimitMessage, localLimit, globalLimit, actualLimit)
 }
 
 func (l *Limiter) formatMaxMetadataPerUserError(userID string) error {
 	actualLimit := l.maxMetadataPerUser(userID)
 	localLimit := l.limits.MaxLocalMetricsWithMetadataPerUser(userID)
 	globalLimit := l.limits.MaxGlobalMetricsWithMetadataPerUser(userID)
-	adminContact := l.adminContact
-	if len(l.adminContact) > 0 {
-		adminContact = "(" + l.adminContact + ") "
-	}
 
-	return fmt.Errorf("per-user metric metadata limit of %d exceeded, please contact administrator %sto raise it (local limit: %d global limit: %d actual local limit: %d)",
-		minNonZero(localLimit, globalLimit), adminContact, localLimit, globalLimit, actualLimit)
+	return fmt.Errorf("per-user metric metadata limit of %d exceeded, %s (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), l.AdminLimitMessage, localLimit, globalLimit, actualLimit)
 }
 
 func (l *Limiter) formatMaxMetadataPerMetricError(userID string) error {
 	actualLimit := l.maxMetadataPerMetric(userID)
 	localLimit := l.limits.MaxLocalMetadataPerMetric(userID)
 	globalLimit := l.limits.MaxGlobalMetadataPerMetric(userID)
-	adminContact := l.adminContact
-	if len(l.adminContact) > 0 {
-		adminContact = "(" + l.adminContact + ") "
-	}
 
-	return fmt.Errorf("per-metric metadata limit of %d exceeded, please contact administrator %sto raise it (local limit: %d global limit: %d actual local limit: %d)",
-		minNonZero(localLimit, globalLimit), adminContact, localLimit, globalLimit, actualLimit)
+	return fmt.Errorf("per-metric metadata limit of %d exceeded, %s (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), l.AdminLimitMessage, localLimit, globalLimit, actualLimit)
 }
 
 func (l *Limiter) maxSeriesPerMetric(userID string) int {

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -223,12 +223,12 @@ func runLimiterMaxFunctionTest(
 			require.NoError(t, err)
 
 			// Assert on default sharding strategy.
-			limiter := NewLimiter(overrides, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, testData.ringZoneAwarenessEnabled)
+			limiter := NewLimiter(overrides, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, testData.ringZoneAwarenessEnabled, "")
 			actual := runMaxFn(limiter)
 			assert.Equal(t, testData.expectedDefaultSharding, actual)
 
 			// Assert on shuffle sharding strategy.
-			limiter = NewLimiter(overrides, ring, util.ShardingStrategyShuffle, testData.shardByAllLabels, testData.ringReplicationFactor, testData.ringZoneAwarenessEnabled)
+			limiter = NewLimiter(overrides, ring, util.ShardingStrategyShuffle, testData.shardByAllLabels, testData.ringReplicationFactor, testData.ringZoneAwarenessEnabled, "")
 			actual = runMaxFn(limiter)
 			assert.Equal(t, testData.expectedShuffleSharding, actual)
 		})
@@ -290,7 +290,7 @@ func TestLimiter_AssertMaxSeriesPerMetric(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false)
+			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
 			actual := limiter.AssertMaxSeriesPerMetric("test", testData.series)
 
 			assert.Equal(t, testData.expected, actual)
@@ -352,7 +352,7 @@ func TestLimiter_AssertMaxMetadataPerMetric(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false)
+			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
 			actual := limiter.AssertMaxMetadataPerMetric("test", testData.metadata)
 
 			assert.Equal(t, testData.expected, actual)
@@ -415,7 +415,7 @@ func TestLimiter_AssertMaxSeriesPerUser(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false)
+			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
 			actual := limiter.AssertMaxSeriesPerUser("test", testData.series)
 
 			assert.Equal(t, testData.expected, actual)
@@ -478,7 +478,7 @@ func TestLimiter_AssertMaxMetricsWithMetadataPerUser(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false)
+			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
 			actual := limiter.AssertMaxMetricsWithMetadataPerUser("test", testData.metadata)
 
 			assert.Equal(t, testData.expected, actual)
@@ -501,7 +501,7 @@ func TestLimiter_FormatError(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, true, 3, false)
+	limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, true, 3, false, "")
 
 	actual := limiter.FormatError("user-1", errMaxSeriesPerUserLimitExceeded)
 	assert.EqualError(t, actual, "per-user series limit of 100 exceeded, please contact administrator to raise it (local limit: 0 global limit: 100 actual local limit: 100)")

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -501,7 +501,7 @@ func TestLimiter_FormatError(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, true, 3, false, "")
+	limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, true, 3, false, "please contact administrator to raise it")
 
 	actual := limiter.FormatError("user-1", errMaxSeriesPerUserLimitExceeded)
 	assert.EqualError(t, actual, "per-user series limit of 100 exceeded, please contact administrator to raise it (local limit: 0 global limit: 100 actual local limit: 100)")

--- a/pkg/ingester/user_state_test.go
+++ b/pkg/ingester/user_state_test.go
@@ -77,7 +77,7 @@ func TestMetricCounter(t *testing.T) {
 
 			// We're testing code that's not dependant on sharding strategy, replication factor, etc. To simplify the test,
 			// we use local limit only.
-			limiter := NewLimiter(overrides, nil, util.ShardingStrategyDefault, true, 3, false)
+			limiter := NewLimiter(overrides, nil, util.ShardingStrategyDefault, true, 3, false, "")
 			mc := newMetricCounter(limiter, ignored)
 
 			for i := 0; i < tc.series; i++ {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds an admin contact address flag to the ingester and uses it while printing error messages when hitting limits.

**Which issue(s) this PR fixes**:
Fixes #5452 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
