### PR TITLE
Fix flaky integration test of multi level index cache

### DIFF
--- a/integration/e2e/metrics.go
+++ b/integration/e2e/metrics.go
@@ -127,6 +127,16 @@ func Less(value float64) func(sums ...float64) bool {
 	}
 }
 
+// LessOrEqual is an isExpected function for WaitSumMetrics that returns true if given single sum is less or equal than given value.
+func LessOrEqual(value float64) func(sums ...float64) bool {
+	return func(sums ...float64) bool {
+		if len(sums) != 1 {
+			panic("less: expected one value")
+		}
+		return sums[0] <= value
+	}
+}
+
 // EqualsAmongTwo is an isExpected function for WaitSumMetrics that returns true if first sum is equal to the second.
 // NOTE: Be careful on scrapes in between of process that changes two metrics. Those are
 // usually not atomic.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Trying to fix the flaky test of https://github.com/cortexproject/cortex/actions/runs/5652118655/job/15313406382?pr=5477.

Error log

```
    querier_test.go:273: 
        	Error Trace:	/home/runner/work/cortex/cortex/integration/querier_test.go:273
        	Error:      	Received unexpected error:
        	            	unable to find metrics [thanos_store_index_cache_requests_total] with expected values. Last error: <nil>. Last values: [26]
        	Test:       	TestQuerierWithBlocksStorageRunningInMicroservicesMode/blocks_sharding_disabled,_ingester_gRPC_streaming_disabled,_multilevel_index_cache_(inmemory,_memcached),thanosEngine=false
```

Expected value is 28 but it is flaky and sometimes become 26.

Tried to reproduce this issue locally. When the flakiness happens, metrics from 2 store gateway will be below. Requests hit L0 cache so saved 2 requests to L1.

SG1:
```
thanos_store_index_cache_requests_total{component="store-gateway",item_type="ExpandedPostings",level="L0"} 4
thanos_store_index_cache_requests_total{component="store-gateway",item_type="ExpandedPostings",level="L1"} 3
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Postings",level="L0"} 3
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Postings",level="L1"} 3
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Series",level="L0"} 3
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Series",level="L1"} 2

thanos_store_index_cache_hits_total{component="store-gateway",item_type="ExpandedPostings",level="L0"} 1
thanos_store_index_cache_hits_total{component="store-gateway",item_type="ExpandedPostings",level="L1"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Postings",level="L0"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Postings",level="L1"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Series",level="L0"} 1
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Series",level="L1"} 0
```

SG2:
```
thanos_store_index_cache_requests_total{component="store-gateway",item_type="ExpandedPostings",level="L0"} 2
thanos_store_index_cache_requests_total{component="store-gateway",item_type="ExpandedPostings",level="L1"} 2
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Postings",level="L0"} 2
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Postings",level="L1"} 2
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Series",level="L0"} 0
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Series",level="L1"} 0

thanos_store_index_cache_hits_total{component="store-gateway",item_type="ExpandedPostings",level="L0"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="ExpandedPostings",level="L1"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Postings",level="L0"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Postings",level="L1"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Series",level="L0"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Series",level="L1"} 0
```

When actual value is 28, the store gateway metrics are. Requests hit L1 cache only but don't hit L0 cache, causing additional 2 requests.

SG1
```
thanos_store_index_cache_requests_total{component="store-gateway",item_type="ExpandedPostings",level="L0"} 1
thanos_store_index_cache_requests_total{component="store-gateway",item_type="ExpandedPostings",level="L1"} 1
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Postings",level="L0"} 0
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Postings",level="L1"} 0
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Series",level="L0"} 1
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Series",level="L1"} 1

thanos_store_index_cache_hits_total{component="store-gateway",item_type="ExpandedPostings",level="L0"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="ExpandedPostings",level="L1"} 1
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Postings",level="L0"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Postings",level="L1"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Series",level="L0"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Series",level="L1"} 1
```

SG2
```
thanos_store_index_cache_requests_total{component="store-gateway",item_type="ExpandedPostings",level="L0"} 5
thanos_store_index_cache_requests_total{component="store-gateway",item_type="ExpandedPostings",level="L1"} 5
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Postings",level="L0"} 5
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Postings",level="L1"} 5
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Series",level="L0"} 2
thanos_store_index_cache_requests_total{component="store-gateway",item_type="Series",level="L1"} 2

thanos_store_index_cache_hits_total{component="store-gateway",item_type="ExpandedPostings",level="L0"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="ExpandedPostings",level="L1"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Postings",level="L0"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Postings",level="L1"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Series",level="L0"} 0
thanos_store_index_cache_hits_total{component="store-gateway",item_type="Series",level="L1"} 0
```

The idea of this pr is to compare L0 metrics because it should be always 14 requests. For L1 cache metrics it can be either 12 or 14 so within 12 ~ 14 range.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
