### PR TITLE
fix ddb kv find difference bug and test, add write consumed capacity …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [ENHANCEMENT] Store Gateway/Querier/Compactor: Handling CMK Access Denied errors. #5420 #5442 #5446
 * [ENHANCEMENT] Store Gateway: Implementing multi level index cache. #5451
 * [ENHANCEMENT] Alertmanager: Add the alert name in error log when it get throttled. #5456
+* [ENHANCEMENT] MultiKVStore: Add write consumed capacity for DDB Batch, Put, and Delete #5479
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293
@@ -56,6 +57,7 @@
 * [BUGFIX] Query Frontend: Fix bug of failing to cancel downstream request context in query frontend v2 mode (query scheduler enabled). #5447
 * [BUGFIX] Alertmanager: Remove the user id from state replication key metric label value. #5453
 * [BUGFIX] Compactor: Avoid cleaner concurrency issues checking global markers before all blocks. #5457
+* [BUGFIX] MultiKVStore: When updating DDB KV Store, check the instance's timestamp. #5479
 
 ## 1.15.1 2023-04-26
 

--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -265,9 +265,9 @@ func (l *BasicLifecycler) registerInstance(ctx context.Context) error {
 		var exists bool
 		instanceDesc, exists = ringDesc.Ingesters[l.cfg.ID]
 		if exists {
-			level.Info(l.logger).Log("msg", "instance found in the ring", "instance", l.cfg.ID, "ring", l.ringName, "state", instanceDesc.GetState(), "tokens", len(instanceDesc.GetTokens()), "registered_at", instanceDesc.GetRegisteredAt().String())
+			level.Info(l.logger).Log("msg", "instance found in the ring", "instance", l.cfg.ID, "ip", l.cfg.Addr, "ring", l.ringName, "state", instanceDesc.GetState(), "tokens", len(instanceDesc.GetTokens()), "registered_at", instanceDesc.GetRegisteredAt().String())
 		} else {
-			level.Info(l.logger).Log("msg", "instance not found in the ring", "instance", l.cfg.ID, "ring", l.ringName)
+			level.Info(l.logger).Log("msg", "instance not found in the ring", "instance", l.cfg.ID, "ip", l.cfg.Addr, "ring", l.ringName)
 		}
 
 		// We call the delegate to get the desired state right after the initialization.

--- a/pkg/ring/kv/dynamodb/dynamodb.go
+++ b/pkg/ring/kv/dynamodb/dynamodb.go
@@ -157,28 +157,37 @@ func (kv dynamodbKV) Query(ctx context.Context, key dynamodbKey, isPrefix bool) 
 	return keys, totalCapacity, nil
 }
 
-func (kv dynamodbKV) Delete(ctx context.Context, key dynamodbKey) error {
+func (kv dynamodbKV) Delete(ctx context.Context, key dynamodbKey) (float64, error) {
 	input := &dynamodb.DeleteItemInput{
 		TableName: kv.tableName,
 		Key:       generateItemKey(key),
 	}
-	_, err := kv.ddbClient.DeleteItemWithContext(ctx, input)
-	return err
+	totalCapacity := float64(0)
+	output, err := kv.ddbClient.DeleteItemWithContext(ctx, input)
+	if err != nil {
+		totalCapacity = getCapacityUnits(output.ConsumedCapacity)
+	}
+	return totalCapacity, err
 }
 
-func (kv dynamodbKV) Put(ctx context.Context, key dynamodbKey, data []byte) error {
+func (kv dynamodbKV) Put(ctx context.Context, key dynamodbKey, data []byte) (float64, error) {
 	input := &dynamodb.PutItemInput{
 		TableName: kv.tableName,
 		Item:      kv.generatePutItemRequest(key, data),
 	}
-	_, err := kv.ddbClient.PutItemWithContext(ctx, input)
-	return err
+	totalCapacity := float64(0)
+	output, err := kv.ddbClient.PutItemWithContext(ctx, input)
+	if err != nil {
+		totalCapacity = getCapacityUnits(output.ConsumedCapacity)
+	}
+	return totalCapacity, err
 }
 
-func (kv dynamodbKV) Batch(ctx context.Context, put map[dynamodbKey][]byte, delete []dynamodbKey) error {
+func (kv dynamodbKV) Batch(ctx context.Context, put map[dynamodbKey][]byte, delete []dynamodbKey) (float64, error) {
+	totalCapacity := float64(0)
 	writeRequestSize := len(put) + len(delete)
 	if writeRequestSize == 0 {
-		return nil
+		return totalCapacity, nil
 	}
 
 	writeRequestsSlices := make([][]*dynamodb.WriteRequest, int(math.Ceil(float64(writeRequestSize)/float64(DdbBatchSizeLimit))))
@@ -220,15 +229,17 @@ func (kv dynamodbKV) Batch(ctx context.Context, put map[dynamodbKey][]byte, dele
 
 		resp, err := kv.ddbClient.BatchWriteItemWithContext(ctx, input)
 		if err != nil {
-			return err
+			return totalCapacity, err
 		}
-
+		for _, consumedCapacity := range resp.ConsumedCapacity {
+			totalCapacity += getCapacityUnits(consumedCapacity)
+		}
 		if resp.UnprocessedItems != nil && len(resp.UnprocessedItems) > 0 {
-			return fmt.Errorf("error processing batch request for %s requests", resp.UnprocessedItems)
+			return totalCapacity, fmt.Errorf("error processing batch request for %s requests", resp.UnprocessedItems)
 		}
 	}
 
-	return nil
+	return totalCapacity, nil
 }
 
 func (kv dynamodbKV) generatePutItemRequest(key dynamodbKey, data []byte) map[string]*dynamodb.AttributeValue {

--- a/pkg/ring/kv/dynamodb/dynamodb_test.go
+++ b/pkg/ring/kv/dynamodb/dynamodb_test.go
@@ -23,7 +23,7 @@ func Test_TTLDisabled(t *testing.T) {
 	}
 
 	ddb := newDynamodbClientMock("TEST", ddbClientMock, 0)
-	err := ddb.Put(context.TODO(), dynamodbKey{primaryKey: "test", sortKey: "test1"}, []byte("TEST"))
+	_, err := ddb.Put(context.TODO(), dynamodbKey{primaryKey: "test", sortKey: "test1"}, []byte("TEST"))
 	require.NoError(t, err)
 
 }
@@ -41,7 +41,7 @@ func Test_TTL(t *testing.T) {
 	}
 
 	ddb := newDynamodbClientMock("TEST", ddbClientMock, 5*time.Hour)
-	err := ddb.Put(context.TODO(), dynamodbKey{primaryKey: "test", sortKey: "test1"}, []byte("TEST"))
+	_, err := ddb.Put(context.TODO(), dynamodbKey{primaryKey: "test", sortKey: "test1"}, []byte("TEST"))
 	require.NoError(t, err)
 }
 
@@ -72,7 +72,7 @@ func Test_Batch(t *testing.T) {
 	}
 
 	ddb := newDynamodbClientMock(tableName, ddbClientMock, 5*time.Hour)
-	err := ddb.Batch(context.TODO(), update, delete)
+	_, err := ddb.Batch(context.TODO(), update, delete)
 	require.NoError(t, err)
 }
 
@@ -120,7 +120,7 @@ func Test_BatchSlices(t *testing.T) {
 				delete = append(delete, ddbKeyDelete)
 			}
 
-			err := ddb.Batch(context.TODO(), nil, delete)
+			_, err := ddb.Batch(context.TODO(), nil, delete)
 			require.NoError(t, err)
 			require.EqualValues(t, tc.expectedCalls, numOfCalls)
 
@@ -134,7 +134,7 @@ func Test_EmptyBatch(t *testing.T) {
 	ddbClientMock := &mockDynamodb{}
 
 	ddb := newDynamodbClientMock(tableName, ddbClientMock, 5*time.Hour)
-	err := ddb.Batch(context.TODO(), nil, nil)
+	_, err := ddb.Batch(context.TODO(), nil, nil)
 	require.NoError(t, err)
 }
 
@@ -159,7 +159,7 @@ func Test_Batch_UnprocessedItems(t *testing.T) {
 	}
 
 	ddb := newDynamodbClientMock(tableName, ddbClientMock, 5*time.Hour)
-	err := ddb.Batch(context.TODO(), nil, delete)
+	_, err := ddb.Batch(context.TODO(), nil, delete)
 	require.Errorf(t, err, "error processing batch dynamodb")
 }
 
@@ -178,7 +178,7 @@ func Test_Batch_Error(t *testing.T) {
 	}
 
 	ddb := newDynamodbClientMock(tableName, ddbClientMock, 5*time.Hour)
-	err := ddb.Batch(context.TODO(), nil, delete)
+	_, err := ddb.Batch(context.TODO(), nil, delete)
 	require.Errorf(t, err, "mocked error")
 }
 

--- a/pkg/ring/kv/dynamodb/metrics.go
+++ b/pkg/ring/kv/dynamodb/metrics.go
@@ -29,8 +29,8 @@ func newDynamoDbMetrics(registerer prometheus.Registerer) *dynamodbMetrics {
 	}, []string{"operation", "status_code"}))
 
 	dynamodbUsageMetrics := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-		Name: "dynamodb_kv_read_capacity_total",
-		Help: "Total used read capacity on dynamodb",
+		Name: "dynamodb_kv_read_write_capacity_total",
+		Help: "Total used read / write capacity on dynamodb",
 	}, []string{"operation"})
 
 	dynamodbMetrics := dynamodbMetrics{
@@ -66,19 +66,25 @@ func (d dynamodbInstrumentation) Query(ctx context.Context, key dynamodbKey, isP
 
 func (d dynamodbInstrumentation) Delete(ctx context.Context, key dynamodbKey) error {
 	return instrument.CollectedRequest(ctx, "Delete", d.ddbMetrics.dynamodbRequestDuration, errorCode, func(ctx context.Context) error {
-		return d.kv.Delete(ctx, key)
+		totalCapacity, err := d.kv.Delete(ctx, key)
+		d.ddbMetrics.dynamodbUsageMetrics.WithLabelValues("Delete").Add(totalCapacity)
+		return err
 	})
 }
 
 func (d dynamodbInstrumentation) Put(ctx context.Context, key dynamodbKey, data []byte) error {
 	return instrument.CollectedRequest(ctx, "Put", d.ddbMetrics.dynamodbRequestDuration, errorCode, func(ctx context.Context) error {
-		return d.kv.Put(ctx, key, data)
+		totalCapacity, err := d.kv.Put(ctx, key, data)
+		d.ddbMetrics.dynamodbUsageMetrics.WithLabelValues("Put").Add(totalCapacity)
+		return err
 	})
 }
 
 func (d dynamodbInstrumentation) Batch(ctx context.Context, put map[dynamodbKey][]byte, delete []dynamodbKey) error {
 	return instrument.CollectedRequest(ctx, "Batch", d.ddbMetrics.dynamodbRequestDuration, errorCode, func(ctx context.Context) error {
-		return d.kv.Batch(ctx, put, delete)
+		totalCapacity, err := d.kv.Batch(ctx, put, delete)
+		d.ddbMetrics.dynamodbUsageMetrics.WithLabelValues("Batch").Add(totalCapacity)
+		return err
 	})
 }
 

--- a/pkg/ring/model_test.go
+++ b/pkg/ring/model_test.go
@@ -630,27 +630,27 @@ func TestDesc_FindDifference(t *testing.T) {
 			toDelete: []string{},
 		},
 		"same single instance, different state": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: JOINING}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: JOINING}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: JOINING, Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: JOINING, Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"same single instance, different registered timestamp": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, RegisteredTimestamp: 1}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, RegisteredTimestamp: 2}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, RegisteredTimestamp: 2}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, RegisteredTimestamp: 1, Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, RegisteredTimestamp: 2, Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, RegisteredTimestamp: 2, Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"instance in different zone": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Zone: "one"}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Zone: "two"}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Zone: "two"}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Zone: "one", Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Zone: "two", Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Zone: "two", Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"same instance, different address": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1"}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr2"}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr2"}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr2", Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr2", Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"more instances in one ring": {
@@ -666,15 +666,15 @@ func TestDesc_FindDifference(t *testing.T) {
 			toDelete: []string{},
 		},
 		"different tokens": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 3}}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1"}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1"}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 3}, Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"different tokens 2": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 3}}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 4}}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 4}}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 3}, Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 4}, Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 4}, Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"different instances, conflictTokens new lose": {
@@ -684,9 +684,9 @@ func TestDesc_FindDifference(t *testing.T) {
 			toDelete: []string{},
 		},
 		"different instances, conflictTokens new win": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing5": {Addr: "addr1", Tokens: []uint32{1, 2, 3}}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing5": {Addr: "addr1", Tokens: []uint32{1, 2, 3}}, "ing2": {Addr: "addr1", Tokens: []uint32{1, 2, 4}}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing2": {Addr: "addr1", Tokens: []uint32{1, 2, 4}}, "ing5": {Addr: "addr1", Tokens: []uint32{3}}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing5": {Addr: "addr1", Tokens: []uint32{1, 2, 3}, Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing5": {Addr: "addr1", Tokens: []uint32{1, 2, 3}, Timestamp: 1100}, "ing2": {Addr: "addr1", Tokens: []uint32{1, 2, 4}}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing2": {Addr: "addr1", Tokens: []uint32{1, 2, 4}}, "ing5": {Addr: "addr1", Tokens: []uint32{3}, Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"same number of instances, using different IDs": {
@@ -694,6 +694,12 @@ func TestDesc_FindDifference(t *testing.T) {
 			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing2": {Addr: "addr1", Tokens: []uint32{1, 2, 3}}}},
 			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing2": {Addr: "addr1", Tokens: []uint32{1, 2, 3}}}},
 			toDelete: []string{"ing1"},
+		},
+		"old instance desc should not update newer instance desc": {
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr_new", Tokens: []uint32{1, 2, 3}, Timestamp: int64(1000)}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr_old", Tokens: []uint32{1, 2, 3}, Timestamp: int64(900)}}},
+			toUpdate: NewDesc(),
+			toDelete: []string{},
 		},
 	}
 


### PR DESCRIPTION
…metrics

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
1. Fix the FindDifference function bug in multi KV.
2. Add write consumed capacity (renamed the original metrics name from dynamodb_kv_read_capacity_total to dynamodb_kv_read_write_capacity_total)

Background:
When we tried to switch from memberlist as primary and DDB as secondary KVStore, to DDB as primary and memberlist as secondary KV Store. We had encountered two issues.
1. New store-gatway got stuck in Leaving state
2. New store-gateway get into Active state, but in the ring page, it was displaying the old pod's IP not the IP from the new pod.

We figured out, it was because
1. when old pods (pod-1) got terminated, it updates memberlist KV, and updated DDB KV as secondary
2. When new pods (pod-1) get created, it updated DDB KV, but it failed to update memberlist KV as secondary
3. Now when older version pod (pod-2) whose is still using memberlist as primary, will revert the change in DDB when it tries to update DDB as secondary

Now two things can happen, if the revert is before the next heartbeat of pod-1, pod-1 will be waiting for the instance to be in JOINING state forever, but in this case, the pod get stuck in Leaving

If the revert happens after the next heartbeat of pod-1, after store-gateway finished its initial sync, it will set its state to ACTIVE. In this case, from Leaving to Active. IP will stay reverted in DDB.


To fix this issue, we check the timestamp during the update process, if the timestamp of the instance we tried to update is smaller than current timestamp of the instance, we skip the update. This will fix the issue.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
