### PR TITLE
disallow instance with older timestamp to update instance with newer …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 * [BUGFIX] Query Frontend: Fix bug of failing to cancel downstream request context in query frontend v2 mode (query scheduler enabled). #5447
 * [BUGFIX] Alertmanager: Remove the user id from state replication key metric label value. #5453
 * [BUGFIX] Compactor: Avoid cleaner concurrency issues checking global markers before all blocks. #5457
-
+* [BUGFIX] DDBKV: Disallow instance with older timestamp to update instance with newer timestamp. #5480
 ## 1.15.1 2023-04-26
 
 * [CHANGE] Alertmanager: Validating new fields on the PagerDuty AM config. #5290

--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -265,9 +265,9 @@ func (l *BasicLifecycler) registerInstance(ctx context.Context) error {
 		var exists bool
 		instanceDesc, exists = ringDesc.Ingesters[l.cfg.ID]
 		if exists {
-			level.Info(l.logger).Log("msg", "instance found in the ring", "instance", l.cfg.ID, "ring", l.ringName, "state", instanceDesc.GetState(), "tokens", len(instanceDesc.GetTokens()), "registered_at", instanceDesc.GetRegisteredAt().String())
+			level.Info(l.logger).Log("msg", "instance found in the ring", "instance", l.cfg.ID, "ip", l.cfg.Addr, "ring", l.ringName, "state", instanceDesc.GetState(), "tokens", len(instanceDesc.GetTokens()), "registered_at", instanceDesc.GetRegisteredAt().String())
 		} else {
-			level.Info(l.logger).Log("msg", "instance not found in the ring", "instance", l.cfg.ID, "ring", l.ringName)
+			level.Info(l.logger).Log("msg", "instance not found in the ring", "instance", l.cfg.ID, "ip", l.cfg.Addr, "ring", l.ringName)
 		}
 
 		// We call the delegate to get the desired state right after the initialization.

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -766,7 +766,7 @@ func (d *Desc) FindDifference(o codec.MultiKey) (interface{}, []string, error) {
 
 		//Recheck if any instance was updated by the resolveConflict
 		//All ingesters in toUpdated have already passed the timestamp check, so we can skip checking again
-		for name, _ := range toUpdated.Ingesters {
+		for name := range toUpdated.Ingesters {
 			//name must appear in out Ingesters, so we can skip the contains key check
 			toUpdated.Ingesters[name] = out.Ingesters[name]
 		}

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -748,14 +748,17 @@ func (d *Desc) FindDifference(o codec.MultiKey) (interface{}, []string, error) {
 		if !ok {
 			toDelete = append(toDelete, name)
 		} else if !ing.Equal(oing) {
-			if !tokensEqual(ing.Tokens, oing.Tokens) {
-				tokensChanged = true
-			}
 			if oing.Timestamp > ing.Timestamp {
 				toUpdated.Ingesters[name] = oing
+				if !tokensEqual(ing.Tokens, oing.Tokens) {
+					tokensChanged = true
+				}
 			} else if oing.Timestamp == ing.Timestamp && ing.State != LEFT && oing.State == LEFT {
 				// we accept LEFT even if timestamp hasn't changed
 				toUpdated.Ingesters[name] = oing
+				if !tokensEqual(ing.Tokens, oing.Tokens) {
+					tokensChanged = true
+				}
 			}
 		}
 	}

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -767,12 +767,8 @@ func (d *Desc) FindDifference(o codec.MultiKey) (interface{}, []string, error) {
 		//Recheck if any instance was updated by the resolveConflict
 		//All ingesters in toUpdated have already passed the timestamp check, so we can skip checking again
 		for name, _ := range toUpdated.Ingesters {
-			ing, ok := d.Ingesters[name]
-			//The ingester to be updated must appear in out ingesters, so ignore error check
-			oing, _ := out.Ingesters[name]
-			if !ok || !ing.Equal(oing) {
-				toUpdated.Ingesters[name] = oing
-			}
+			//name must appear in out Ingesters, so we can skip the contains key check
+			toUpdated.Ingesters[name] = out.Ingesters[name]
 		}
 	}
 

--- a/pkg/ring/model_test.go
+++ b/pkg/ring/model_test.go
@@ -630,27 +630,27 @@ func TestDesc_FindDifference(t *testing.T) {
 			toDelete: []string{},
 		},
 		"same single instance, different state": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: JOINING}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: JOINING}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: JOINING, Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: JOINING, Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"same single instance, different registered timestamp": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, RegisteredTimestamp: 1}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, RegisteredTimestamp: 2}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, RegisteredTimestamp: 2}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, RegisteredTimestamp: 1, Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, RegisteredTimestamp: 2, Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", State: ACTIVE, RegisteredTimestamp: 2, Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"instance in different zone": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Zone: "one"}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Zone: "two"}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Zone: "two"}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Zone: "one", Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Zone: "two", Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Zone: "two", Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"same instance, different address": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1"}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr2"}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr2"}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr2", Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr2", Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"more instances in one ring": {
@@ -666,15 +666,15 @@ func TestDesc_FindDifference(t *testing.T) {
 			toDelete: []string{},
 		},
 		"different tokens": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 3}}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1"}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1"}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 3}, Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"different tokens 2": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 3}}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 4}}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 4}}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 3}, Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 4}, Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr1", Tokens: []uint32{1, 2, 4}, Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"different instances, conflictTokens new lose": {
@@ -684,9 +684,9 @@ func TestDesc_FindDifference(t *testing.T) {
 			toDelete: []string{},
 		},
 		"different instances, conflictTokens new win": {
-			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing5": {Addr: "addr1", Tokens: []uint32{1, 2, 3}}}},
-			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing5": {Addr: "addr1", Tokens: []uint32{1, 2, 3}}, "ing2": {Addr: "addr1", Tokens: []uint32{1, 2, 4}}}},
-			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing2": {Addr: "addr1", Tokens: []uint32{1, 2, 4}}, "ing5": {Addr: "addr1", Tokens: []uint32{3}}}},
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing5": {Addr: "addr1", Tokens: []uint32{1, 2, 3}, Timestamp: 1000}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing5": {Addr: "addr1", Tokens: []uint32{1, 2, 3}, Timestamp: 1100}, "ing2": {Addr: "addr1", Tokens: []uint32{1, 2, 4}, Timestamp: 1100}}},
+			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing2": {Addr: "addr1", Tokens: []uint32{1, 2, 4}, Timestamp: 1100}, "ing5": {Addr: "addr1", Tokens: []uint32{3}, Timestamp: 1100}}},
 			toDelete: []string{},
 		},
 		"same number of instances, using different IDs": {
@@ -694,6 +694,12 @@ func TestDesc_FindDifference(t *testing.T) {
 			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing2": {Addr: "addr1", Tokens: []uint32{1, 2, 3}}}},
 			toUpdate: &Desc{Ingesters: map[string]InstanceDesc{"ing2": {Addr: "addr1", Tokens: []uint32{1, 2, 3}}}},
 			toDelete: []string{"ing1"},
+		},
+		"old instance desc should not update newer instance desc": {
+			r1:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr_new", Tokens: []uint32{1, 2, 3}, Timestamp: int64(1000)}}},
+			r2:       &Desc{Ingesters: map[string]InstanceDesc{"ing1": {Addr: "addr_old", Tokens: []uint32{1, 2, 3}, Timestamp: int64(900)}}},
+			toUpdate: NewDesc(),
+			toDelete: []string{},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
1. Fix the FindDifference function bug in multi KV.

Background:
When we tried to switch from memberlist as primary and DDB as secondary KVStore, to DDB as primary and memberlist as secondary KV Store. We had encountered two issues.
1. New store-gatway got stuck in Leaving state
2. New store-gateway get into Active state, but in the ring page, it was displaying the old pod's IP not the IP from the new pod.

We figured out, it was because
1. when old pods (pod-1) got terminated, it updates memberlist KV, and updated DDB KV as secondary
2. When new pods (pod-1) get created, it updated DDB KV, but it failed to update memberlist KV as secondary
3. Now when older version pod (pod-2) whose is still using memberlist as primary, will revert the change in DDB when it tries to update DDB as secondary

Now two things can happen, if the revert is before the next heartbeat of pod-1, pod-1 will be waiting for the instance to be in JOINING state forever, in this case, the pod get stuck in Leaving

If the revert happens after the next heartbeat of pod-1, when store-gateway finished its initial sync, it will set its state to ACTIVE. In this case, from Leaving to Active. IP will stay reverted in DDB.


To fix this issue, we check the timestamp during the update process, if the timestamp of the instance we tried to update is smaller than current timestamp of the instance, we skip the update. This will fix the issue.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
