### PR TITLE
Initialize instant query codec with correct eval interval

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -456,6 +456,7 @@ func (t *Cortex) initQueryFrontendTripperware() (serv services.Service, err erro
 	prometheusCodec := queryrange.NewPrometheusCodec(false, defaultSubQueryInterval)
 	// ShardedPrometheusCodec is same as PrometheusCodec but to be used on the sharded queries (it sum up the stats)
 	shardedPrometheusCodec := queryrange.NewPrometheusCodec(true, defaultSubQueryInterval)
+	instantQueryCodec := instantquery.NewInstantQueryCodec(defaultSubQueryInterval)
 
 	queryRangeMiddlewares, cache, err := queryrange.Middlewares(
 		t.Cfg.QueryRange,
@@ -472,7 +473,7 @@ func (t *Cortex) initQueryFrontendTripperware() (serv services.Service, err erro
 		return nil, err
 	}
 
-	instantQueryMiddlewares, err := instantquery.Middlewares(util_log.Logger, t.Overrides, queryAnalyzer)
+	instantQueryMiddlewares, err := instantquery.Middlewares(util_log.Logger, t.Overrides, queryAnalyzer, instantQueryCodec)
 	if err != nil {
 		return nil, err
 	}
@@ -483,7 +484,7 @@ func (t *Cortex) initQueryFrontendTripperware() (serv services.Service, err erro
 		queryRangeMiddlewares,
 		instantQueryMiddlewares,
 		prometheusCodec,
-		instantquery.InstantQueryCodec,
+		instantQueryCodec,
 		t.Overrides,
 		queryAnalyzer,
 		defaultSubQueryInterval,

--- a/pkg/querier/tripperware/instantquery/instant_query.go
+++ b/pkg/querier/tripperware/instantquery/instant_query.go
@@ -31,8 +31,6 @@ import (
 )
 
 var (
-	InstantQueryCodec tripperware.Codec = newInstantQueryCodec()
-
 	json = jsoniter.Config{
 		EscapeHTML:             false, // No HTML in our responses.
 		SortMapKeys:            true,
@@ -112,8 +110,8 @@ type instantQueryCodec struct {
 	noStepSubQueryInterval time.Duration
 }
 
-func newInstantQueryCodec() instantQueryCodec {
-	return instantQueryCodec{now: time.Now}
+func NewInstantQueryCodec(noStepSubQueryInterval time.Duration) instantQueryCodec {
+	return instantQueryCodec{now: time.Now, noStepSubQueryInterval: noStepSubQueryInterval}
 }
 
 func (resp *PrometheusInstantQueryResponse) HTTPHeaders() map[string][]string {

--- a/pkg/querier/tripperware/instantquery/instant_query_middlewares.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_middlewares.go
@@ -11,9 +11,10 @@ func Middlewares(
 	log log.Logger,
 	limits tripperware.Limits,
 	queryAnalyzer querysharding.Analyzer,
+	codec instantQueryCodec,
 ) ([]tripperware.Middleware, error) {
 	var m []tripperware.Middleware
 
-	m = append(m, tripperware.ShardByMiddleware(log, limits, InstantQueryCodec, queryAnalyzer))
+	m = append(m, tripperware.ShardByMiddleware(log, limits, codec, queryAnalyzer))
 	return m, nil
 }

--- a/pkg/querier/tripperware/instantquery/shard_by_query_test.go
+++ b/pkg/querier/tripperware/instantquery/shard_by_query_test.go
@@ -10,5 +10,5 @@ import (
 
 func Test_shardQuery(t *testing.T) {
 	t.Parallel()
-	tripperware.TestQueryShardQuery(t, InstantQueryCodec, queryrange.NewPrometheusCodec(true, time.Minute))
+	tripperware.TestQueryShardQuery(t, codec, queryrange.NewPrometheusCodec(true, time.Minute))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Now instant query tripperware in QFE is using a globally initialized `instantquery.InstantQueryCodec` which doesn't set `noStepSubQueryInterval` at all. This will cause the subquery check to fail because it will try to divide by 0. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
