### PR TITLE
Unify subquery step size check in a single place

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -451,11 +451,10 @@ func (t *Cortex) initDeleteRequestsStore() (serv services.Service, err error) {
 // to optimize Prometheus query requests.
 func (t *Cortex) initQueryFrontendTripperware() (serv services.Service, err error) {
 	queryAnalyzer := querysharding.NewQueryAnalyzer()
-	defaultSubQueryInterval := t.Cfg.Querier.DefaultEvaluationInterval
 	// PrometheusCodec is a codec to encode and decode Prometheus query range requests and responses.
-	prometheusCodec := queryrange.NewPrometheusCodec(false, defaultSubQueryInterval)
+	prometheusCodec := queryrange.NewPrometheusCodec(false)
 	// ShardedPrometheusCodec is same as PrometheusCodec but to be used on the sharded queries (it sum up the stats)
-	shardedPrometheusCodec := queryrange.NewPrometheusCodec(true, defaultSubQueryInterval)
+	shardedPrometheusCodec := queryrange.NewPrometheusCodec(true)
 
 	queryRangeMiddlewares, cache, err := queryrange.Middlewares(
 		t.Cfg.QueryRange,
@@ -486,7 +485,7 @@ func (t *Cortex) initQueryFrontendTripperware() (serv services.Service, err erro
 		instantquery.InstantQueryCodec,
 		t.Overrides,
 		queryAnalyzer,
-		defaultSubQueryInterval,
+		t.Cfg.Querier.DefaultEvaluationInterval,
 	)
 
 	return services.NewIdleService(nil, func(_ error) error {

--- a/pkg/querier/tripperware/instantquery/instant_query.go
+++ b/pkg/querier/tripperware/instantquery/instant_query.go
@@ -108,8 +108,7 @@ func (r *PrometheusRequest) WithStats(stats string) tripperware.Request {
 
 type instantQueryCodec struct {
 	tripperware.Codec
-	now                    func() time.Time
-	noStepSubQueryInterval time.Duration
+	now func() time.Time
 }
 
 func newInstantQueryCodec() instantQueryCodec {
@@ -139,10 +138,6 @@ func (c instantQueryCodec) DecodeRequest(_ context.Context, r *http.Request, for
 	}
 
 	result.Query = r.FormValue("query")
-	if err := tripperware.SubQueryStepSizeCheck(result.Query, c.noStepSubQueryInterval, tripperware.MaxStep); err != nil {
-		return nil, err
-	}
-
 	result.Stats = r.FormValue("stats")
 	result.Path = r.URL.Path
 

--- a/pkg/querier/tripperware/instantquery/shard_by_query_test.go
+++ b/pkg/querier/tripperware/instantquery/shard_by_query_test.go
@@ -2,7 +2,6 @@ package instantquery
 
 import (
 	"testing"
-	"time"
 
 	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 	"github.com/cortexproject/cortex/pkg/querier/tripperware/queryrange"
@@ -10,5 +9,5 @@ import (
 
 func Test_shardQuery(t *testing.T) {
 	t.Parallel()
-	tripperware.TestQueryShardQuery(t, InstantQueryCodec, queryrange.NewPrometheusCodec(true, time.Minute))
+	tripperware.TestQueryShardQuery(t, InstantQueryCodec, queryrange.NewPrometheusCodec(true))
 }

--- a/pkg/querier/tripperware/queryrange/query_range.go
+++ b/pkg/querier/tripperware/queryrange/query_range.go
@@ -46,15 +46,10 @@ var (
 
 type prometheusCodec struct {
 	sharded bool
-
-	noStepSubQueryInterval time.Duration
 }
 
-func NewPrometheusCodec(sharded bool, noStepSubQueryInterval time.Duration) *prometheusCodec { //nolint:revive
-	return &prometheusCodec{
-		sharded:                sharded,
-		noStepSubQueryInterval: noStepSubQueryInterval,
-	}
+func NewPrometheusCodec(sharded bool) *prometheusCodec { //nolint:revive
+	return &prometheusCodec{sharded: sharded}
 }
 
 // WithStartEnd clones the current `PrometheusRequest` with a new `start` and `end` timestamp.
@@ -203,10 +198,6 @@ func (c prometheusCodec) DecodeRequest(_ context.Context, r *http.Request, forwa
 	}
 
 	result.Query = r.FormValue("query")
-	if err := tripperware.SubQueryStepSizeCheck(result.Query, c.noStepSubQueryInterval, tripperware.MaxStep); err != nil {
-		return nil, err
-	}
-
 	result.Stats = r.FormValue("stats")
 	result.Path = r.URL.Path
 

--- a/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	PrometheusCodec        = NewPrometheusCodec(false, time.Minute)
-	ShardedPrometheusCodec = NewPrometheusCodec(false, time.Minute)
+	PrometheusCodec        = NewPrometheusCodec(false)
+	ShardedPrometheusCodec = NewPrometheusCodec(false)
 )
 
 func TestRoundTrip(t *testing.T) {

--- a/pkg/querier/tripperware/queryrange/query_range_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_test.go
@@ -61,10 +61,6 @@ func TestRequest(t *testing.T) {
 			url:         "api/v1/query_range?start=0&end=11001&step=1",
 			expectedErr: errStepTooSmall,
 		},
-		{
-			url:         "/api/v1/query?query=up%5B30d%3A%5D&start=123&end=456&step=10",
-			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, tripperware.ErrSubQueryStepTooSmall, 11000),
-		},
 	} {
 		tc := tc
 		t.Run(tc.url, func(t *testing.T) {

--- a/pkg/querier/tripperware/roundtrip.go
+++ b/pkg/querier/tripperware/roundtrip.go
@@ -142,15 +142,19 @@ func NewQueryTripperware(
 				activeUsers.UpdateUserTimestamp(userStr, time.Now())
 				queriesPerTenant.WithLabelValues(op, userStr).Inc()
 
-				if isQueryRange {
-					return queryrange.RoundTrip(r)
-				} else if isQuery {
-					// If the given query is not shardable, use downstream roundtripper.
+				if isQuery || isQueryRange {
 					query := r.FormValue("query")
 					// Check subquery step size.
 					if err := SubQueryStepSizeCheck(query, defaultSubQueryInterval, MaxStep); err != nil {
 						return nil, err
 					}
+				}
+
+				if isQueryRange {
+					return queryrange.RoundTrip(r)
+				} else if isQuery {
+					// If the given query is not shardable, use downstream roundtripper.
+					query := r.FormValue("query")
 
 					// If vertical sharding is not enabled for the tenant, use downstream roundtripper.
 					numShards := validation.SmallestPositiveIntPerTenant(tenantIDs, limits.QueryVerticalShardSize)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This pr removes the `noStepSubQueryInterval` param in both instant and range codec.

Also make sure we only check `SubQueryStepSizeCheck` once at the initial round tripper. No need to check individually in separate tripperwares.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
