### PR TITLE
StoreGateway: fix store gateway shuffle sharding consistency issue when shard size change by 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [CHANGE] Store Gateway: Rename `cortex_bucket_store_cached_postings_compression_time_seconds` to `cortex_bucket_store_cached_postings_compression_time_seconds_total`. #5431
 * [CHANGE] Store Gateway: Rename `cortex_bucket_store_cached_series_fetch_duration_seconds` to `cortex_bucket_store_series_fetch_duration_seconds` and `cortex_bucket_store_cached_postings_fetch_duration_seconds` to `cortex_bucket_store_postings_fetch_duration_seconds`. Add new metric `cortex_bucket_store_chunks_fetch_duration_seconds`. #5448
 * [CHANGE] Store Gateway: Remove `idle_timeout`, `max_conn_age`, `pool_size`, `min_idle_conns` fields for Redis index cache and caching bucket. #5448
+* [CHANGE] Store Gateway: Add flag `-store-gateway.sharding-ring.zone-stable-shuffle-sharding` to enable store gateway to use zone stable shuffle sharding. #5489
 * [FEATURE] Store Gateway: Add `max_downloaded_bytes_per_request` to limit max bytes to download per store gateway request.
 * [FEATURE] Added 2 flags `-alertmanager.alertmanager-client.grpc-max-send-msg-size` and ` -alertmanager.alertmanager-client.grpc-max-recv-msg-size` to configure alert manager grpc client message size limits. #5338
 * [FEATURE] Query Frontend: Add `cortex_rejected_queries_total` metric for throttled queries. #5356

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -54,12 +54,19 @@ The store-gateway supports two sharding strategies:
 
 - `default`
 - `shuffle-sharding`
+- `zone-stable-shuffle-sharding`
 
 The **`default`** sharding strategy spreads the blocks of each tenant across all store-gateway instances. It's the easiest form of sharding supported, but doesn't provide any workload isolation between different tenants.
 
 The **`shuffle-sharding`** strategy spreads the blocks of a tenant across a subset of store-gateway instances. This way, the number of store-gateway instances loading blocks of a single tenant is limited and the blast radius of any issue that could be introduced by the tenant's workload is limited to its shard instances.
 
 The shuffle sharding strategy can be enabled via `-store-gateway.sharding-strategy=shuffle-sharding` and requires the `-store-gateway.tenant-shard-size` flag (or their respective YAML config options) to be set to the default shard size, which is the default number of store-gateway instances each tenant should be sharded to. The shard size can then be overridden on a per-tenant basis setting the `store_gateway_tenant_shard_size` in the limits overrides.
+
+The **`zone-stable-shuffle-sharding`** strategy achieves the same as the **`shuffle-sharding`** strategy, but using a different sharding algorithm. The new sharding algorithm ensures that when zone awareness is enabled, when shard size increases or decreases by one, the replicas for any block should only change at most by one instance. This is important for querying store gateway because a block can be retried at most 3 times.
+
+Zone stable shuffle sharding can be enabled via `-store-gateway.sharding-ring.zone-stable-shuffle-sharding` CLI flag.
+
+It will become the default shuffle sharding strategy for store gateway in `v1.17.0` release and the previous shuffle sharding algorithm will be removed in `v1.18.0` release.
 
 _Please check out the [shuffle sharding documentation](../guides/shuffle-sharding.md) for more information about how it works._
 

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -288,11 +288,6 @@ store_gateway:
     # CLI flag: -store-gateway.sharding-ring.keep-instance-in-the-ring-on-shutdown
     [keep_instance_in_the_ring_on_shutdown: <boolean> | default = false]
 
-    # If true, use zone stable shuffle sharding algorithm. Otherwise, use the
-    # default shuffle sharding algorithm.
-    # CLI flag: -store-gateway.sharding-ring.zone-stable-shuffle-sharding
-    [zone_stable_shuffle_sharding: <boolean> | default = false]
-
     # Minimum time to wait for ring stability at startup. 0 to disable.
     # CLI flag: -store-gateway.sharding-ring.wait-stability-min-duration
     [wait_stability_min_duration: <duration> | default = 1m]

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -288,6 +288,11 @@ store_gateway:
     # CLI flag: -store-gateway.sharding-ring.keep-instance-in-the-ring-on-shutdown
     [keep_instance_in_the_ring_on_shutdown: <boolean> | default = false]
 
+    # If true, use zone stable shuffle sharding algorithm. Otherwise, use the
+    # default shuffle sharding algorithm.
+    # CLI flag: -store-gateway.sharding-ring.zone-stable-shuffle-sharding
+    [zone_stable_shuffle_sharding: <boolean> | default = false]
+
     # Minimum time to wait for ring stability at startup. 0 to disable.
     # CLI flag: -store-gateway.sharding-ring.wait-stability-min-duration
     [wait_stability_min_duration: <duration> | default = 1m]

--- a/docs/blocks-storage/store-gateway.template
+++ b/docs/blocks-storage/store-gateway.template
@@ -54,12 +54,19 @@ The store-gateway supports two sharding strategies:
 
 - `default`
 - `shuffle-sharding`
+- `zone-stable-shuffle-sharding`
 
 The **`default`** sharding strategy spreads the blocks of each tenant across all store-gateway instances. It's the easiest form of sharding supported, but doesn't provide any workload isolation between different tenants.
 
 The **`shuffle-sharding`** strategy spreads the blocks of a tenant across a subset of store-gateway instances. This way, the number of store-gateway instances loading blocks of a single tenant is limited and the blast radius of any issue that could be introduced by the tenant's workload is limited to its shard instances.
 
 The shuffle sharding strategy can be enabled via `-store-gateway.sharding-strategy=shuffle-sharding` and requires the `-store-gateway.tenant-shard-size` flag (or their respective YAML config options) to be set to the default shard size, which is the default number of store-gateway instances each tenant should be sharded to. The shard size can then be overridden on a per-tenant basis setting the `store_gateway_tenant_shard_size` in the limits overrides.
+
+The **`zone-stable-shuffle-sharding`** strategy achieves the same as the **`shuffle-sharding`** strategy, but using a different sharding algorithm. The new sharding algorithm ensures that when zone awareness is enabled, when shard size increases or decreases by one, the replicas for any block should only change at most by one instance. This is important for querying store gateway because a block can be retried at most 3 times.
+
+Zone stable shuffle sharding can be enabled via `-store-gateway.sharding-ring.zone-stable-shuffle-sharding` CLI flag.
+
+It will become the default shuffle sharding strategy for store gateway in `v1.17.0` release and the previous shuffle sharding algorithm will be removed in `v1.18.0` release.
 
 _Please check out the [shuffle sharding documentation](../guides/shuffle-sharding.md) for more information about how it works._
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4789,6 +4789,11 @@ sharding_ring:
   # CLI flag: -store-gateway.sharding-ring.keep-instance-in-the-ring-on-shutdown
   [keep_instance_in_the_ring_on_shutdown: <boolean> | default = false]
 
+  # If true, use zone stable shuffle sharding algorithm. Otherwise, use the
+  # default shuffle sharding algorithm.
+  # CLI flag: -store-gateway.sharding-ring.zone-stable-shuffle-sharding
+  [zone_stable_shuffle_sharding: <boolean> | default = false]
+
   # Minimum time to wait for ring stability at startup. 0 to disable.
   # CLI flag: -store-gateway.sharding-ring.wait-stability-min-duration
   [wait_stability_min_duration: <duration> | default = 1m]

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4789,11 +4789,6 @@ sharding_ring:
   # CLI flag: -store-gateway.sharding-ring.keep-instance-in-the-ring-on-shutdown
   [keep_instance_in_the_ring_on_shutdown: <boolean> | default = false]
 
-  # If true, use zone stable shuffle sharding algorithm. Otherwise, use the
-  # default shuffle sharding algorithm.
-  # CLI flag: -store-gateway.sharding-ring.zone-stable-shuffle-sharding
-  [zone_stable_shuffle_sharding: <boolean> | default = false]
-
   # Minimum time to wait for ring stability at startup. 0 to disable.
   # CLI flag: -store-gateway.sharding-ring.wait-stability-min-duration
   [wait_stability_min_duration: <duration> | default = 1m]

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -106,5 +106,5 @@ Currently experimental features are:
   - `-ingester.out-of-order-time-window` (duration) CLI flag
   - `out_of_order_time_window` (duration) field in runtime config file
 - Store Gateway Zone Stable Shuffle Sharding
-  - `-zone-stable-shuffle-sharding` CLI flag
+  - `-store-gateway.sharding-ring.zone-stable-shuffle-sharding` CLI flag
   - `zone_stable_shuffle_sharding` (boolean) field in config file

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -105,3 +105,6 @@ Currently experimental features are:
   - `-blocks-storage.tsdb.out-of-order-cap-max` (int) CLI flag
   - `-ingester.out-of-order-time-window` (duration) CLI flag
   - `out_of_order_time_window` (duration) field in runtime config file
+- Store Gateway Zone Stable Shuffle Sharding
+  - `-zone-stable-shuffle-sharding` CLI flag
+  - `zone_stable_shuffle_sharding` (boolean) field in config file

--- a/pkg/compactor/shuffle_sharding_grouper_test.go
+++ b/pkg/compactor/shuffle_sharding_grouper_test.go
@@ -784,6 +784,11 @@ func (r *RingMock) ShuffleShard(identifier string, size int) ring.ReadRing {
 	return args.Get(0).(ring.ReadRing)
 }
 
+func (r *RingMock) ShuffleShardWithZoneStability(identifier string, size int) ring.ReadRing {
+	args := r.Called(identifier, size)
+	return args.Get(0).(ring.ReadRing)
+}
+
 func (r *RingMock) GetInstanceState(instanceID string) (ring.InstanceState, error) {
 	args := r.Called(instanceID)
 	return args.Get(0).(ring.InstanceState), args.Error(1)

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -228,7 +228,7 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 			return nil, errors.Wrap(err, "failed to create store-gateway ring client")
 		}
 
-		stores, err = newBlocksStoreReplicationSet(storesRing, gatewayCfg.ShardingStrategy, randomLoadBalancing, limits, querierCfg.StoreGatewayClient, logger, reg, storesRingCfg.ZoneAwarenessEnabled)
+		stores, err = newBlocksStoreReplicationSet(storesRing, gatewayCfg.ShardingStrategy, randomLoadBalancing, limits, querierCfg.StoreGatewayClient, logger, reg, storesRingCfg.ZoneAwarenessEnabled, gatewayCfg.ShardingRing.ZoneStableShuffleSharding)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create store set")
 		}

--- a/pkg/querier/blocks_store_replicated_set_test.go
+++ b/pkg/querier/blocks_store_replicated_set_test.go
@@ -585,7 +585,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			}
 
 			reg := prometheus.NewPedanticRegistry()
-			s, err := newBlocksStoreReplicationSet(r, testData.shardingStrategy, noLoadBalancing, limits, ClientConfig{}, log.NewNopLogger(), reg, testData.zoneAwarenessEnabled)
+			s, err := newBlocksStoreReplicationSet(r, testData.shardingStrategy, noLoadBalancing, limits, ClientConfig{}, log.NewNopLogger(), reg, testData.zoneAwarenessEnabled, true)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 			defer services.StopAndAwaitTerminated(ctx, s) //nolint:errcheck
@@ -647,7 +647,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor_ShouldSupportRandomLoadBalancin
 
 	limits := &blocksStoreLimitsMock{}
 	reg := prometheus.NewPedanticRegistry()
-	s, err := newBlocksStoreReplicationSet(r, util.ShardingStrategyDefault, randomLoadBalancing, limits, ClientConfig{}, log.NewNopLogger(), reg, false)
+	s, err := newBlocksStoreReplicationSet(r, util.ShardingStrategyDefault, randomLoadBalancing, limits, ClientConfig{}, log.NewNopLogger(), reg, false, false)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 	defer services.StopAndAwaitTerminated(ctx, s) //nolint:errcheck
@@ -716,7 +716,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor_ZoneAwareness(t *testing.T) {
 
 	limits := &blocksStoreLimitsMock{}
 	reg := prometheus.NewPedanticRegistry()
-	s, err := newBlocksStoreReplicationSet(r, util.ShardingStrategyDefault, randomLoadBalancing, limits, ClientConfig{}, log.NewNopLogger(), reg, true)
+	s, err := newBlocksStoreReplicationSet(r, util.ShardingStrategyDefault, randomLoadBalancing, limits, ClientConfig{}, log.NewNopLogger(), reg, true, false)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 	defer services.StopAndAwaitTerminated(ctx, s) //nolint:errcheck

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -68,6 +68,12 @@ type ReadRing interface {
 	// and size (number of instances).
 	ShuffleShard(identifier string, size int) ReadRing
 
+	// ShuffleShardWithZoneStability does the same as ShuffleShard but using a different shuffle sharding algorithm.
+	// It doesn't round up shard size to be divisible to number of zones and make sure when scaling up/down one
+	// shard size at a time, at most 1 instance can be changed.
+	// It is only used in Store Gateway for now.
+	ShuffleShardWithZoneStability(identifier string, size int) ReadRing
+
 	// GetInstanceState returns the current state of an instance or an error if the
 	// instance does not exist in the ring.
 	GetInstanceState(instanceID string) (InstanceState, error)
@@ -200,6 +206,8 @@ type Ring struct {
 type subringCacheKey struct {
 	identifier string
 	shardSize  int
+
+	zoneStableSharding bool
 }
 
 // New creates a new Ring. Being a service, Ring needs to be started to do anything.
@@ -659,24 +667,16 @@ func (r *Ring) updateRingMetrics(compareResult CompareResult) {
 // - Stability: given the same ring, two invocations returns the same result.
 //
 // - Consistency: adding/removing 1 instance from the ring generates a resulting
-// subring with no more then 1 difference.
+// subring with no more than 1 difference.
 //
 // - Shuffling: probabilistically, for a large enough cluster each identifier gets a different
 // set of instances, with a reduced number of overlapping instances between two identifiers.
 func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
-	// Nothing to do if the shard size is not smaller then the actual ring.
-	if size <= 0 || r.InstancesCount() <= size {
-		return r
-	}
+	return r.shuffleShardWithCache(identifier, size, false)
+}
 
-	if cached := r.getCachedShuffledSubring(identifier, size); cached != nil {
-		return cached
-	}
-
-	result := r.shuffleShard(identifier, size, 0, time.Now())
-
-	r.setCachedShuffledSubring(identifier, size, result)
-	return result
+func (r *Ring) ShuffleShardWithZoneStability(identifier string, size int) ReadRing {
+	return r.shuffleShardWithCache(identifier, size, true)
 }
 
 // ShuffleShardWithLookback is like ShuffleShard() but the returned subring includes all instances
@@ -687,25 +687,52 @@ func (r *Ring) ShuffleShard(identifier string, size int) ReadRing {
 //
 // This function doesn't support caching.
 func (r *Ring) ShuffleShardWithLookback(identifier string, size int, lookbackPeriod time.Duration, now time.Time) ReadRing {
-	// Nothing to do if the shard size is not smaller then the actual ring.
+	// Nothing to do if the shard size is not smaller than the actual ring.
 	if size <= 0 || r.InstancesCount() <= size {
 		return r
 	}
 
-	return r.shuffleShard(identifier, size, lookbackPeriod, now)
+	return r.shuffleShard(identifier, size, lookbackPeriod, now, false)
 }
 
-func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Duration, now time.Time) *Ring {
+func (r *Ring) shuffleShardWithCache(identifier string, size int, zoneStableSharding bool) ReadRing {
+	// Nothing to do if the shard size is not smaller than the actual ring.
+	if size <= 0 || r.InstancesCount() <= size {
+		return r
+	}
+
+	if cached := r.getCachedShuffledSubring(identifier, size, zoneStableSharding); cached != nil {
+		return cached
+	}
+
+	result := r.shuffleShard(identifier, size, 0, time.Now(), zoneStableSharding)
+
+	r.setCachedShuffledSubring(identifier, size, zoneStableSharding, result)
+	return result
+}
+
+func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Duration, now time.Time, zoneStableSharding bool) *Ring {
 	lookbackUntil := now.Add(-lookbackPeriod).Unix()
 
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 
-	var numInstancesPerZone int
-	var actualZones []string
+	var (
+		numInstancesPerZone    int
+		actualZones            []string
+		zonesWithExtraInstance int
+	)
 
 	if r.cfg.ZoneAwarenessEnabled {
-		numInstancesPerZone = shardUtil.ShuffleShardExpectedInstancesPerZone(size, len(r.ringZones))
+		if zoneStableSharding {
+			numInstancesPerZone = size / len(r.ringZones)
+			zonesWithExtraInstance = size % len(r.ringZones)
+			if zonesWithExtraInstance > 0 {
+				numInstancesPerZone++
+			}
+		} else {
+			numInstancesPerZone = shardUtil.ShuffleShardExpectedInstancesPerZone(size, len(r.ringZones))
+		}
 		actualZones = r.ringZones
 	} else {
 		numInstancesPerZone = size
@@ -778,6 +805,12 @@ func (r *Ring) shuffleShard(identifier string, size int, lookbackPeriod time.Dur
 				break
 			}
 		}
+		if zoneStableSharding && zonesWithExtraInstance > 0 {
+			zonesWithExtraInstance--
+			if zonesWithExtraInstance == 0 {
+				numInstancesPerZone--
+			}
+		}
 	}
 
 	// Build a read-only ring for the shard.
@@ -828,7 +861,7 @@ func (r *Ring) HasInstance(instanceID string) bool {
 	return ok
 }
 
-func (r *Ring) getCachedShuffledSubring(identifier string, size int) *Ring {
+func (r *Ring) getCachedShuffledSubring(identifier string, size int, zoneStableSharding bool) *Ring {
 	if r.cfg.SubringCacheDisabled {
 		return nil
 	}
@@ -837,7 +870,7 @@ func (r *Ring) getCachedShuffledSubring(identifier string, size int) *Ring {
 	defer r.mtx.RUnlock()
 
 	// if shuffledSubringCache map is nil, reading it returns default value (nil pointer).
-	cached := r.shuffledSubringCache[subringCacheKey{identifier: identifier, shardSize: size}]
+	cached := r.shuffledSubringCache[subringCacheKey{identifier: identifier, shardSize: size, zoneStableSharding: zoneStableSharding}]
 	if cached == nil {
 		return nil
 	}
@@ -856,7 +889,7 @@ func (r *Ring) getCachedShuffledSubring(identifier string, size int) *Ring {
 	return cached
 }
 
-func (r *Ring) setCachedShuffledSubring(identifier string, size int, subring *Ring) {
+func (r *Ring) setCachedShuffledSubring(identifier string, size int, zoneStableSharding bool, subring *Ring) {
 	if subring == nil || r.cfg.SubringCacheDisabled {
 		return
 	}
@@ -868,7 +901,7 @@ func (r *Ring) setCachedShuffledSubring(identifier string, size int, subring *Ri
 	// (which can happen between releasing the read lock and getting read-write lock).
 	// Note that shuffledSubringCache can be only nil when set by test.
 	if r.shuffledSubringCache != nil && r.lastTopologyChange.Equal(subring.lastTopologyChange) {
-		r.shuffledSubringCache[subringCacheKey{identifier: identifier, shardSize: size}] = subring
+		r.shuffledSubringCache[subringCacheKey{identifier: identifier, shardSize: size, zoneStableSharding: zoneStableSharding}] = subring
 	}
 }
 

--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -54,6 +54,11 @@ func (r *RingMock) ShuffleShard(identifier string, size int) ReadRing {
 	return args.Get(0).(ReadRing)
 }
 
+func (r *RingMock) ShuffleShardWithZoneStability(identifier string, size int) ReadRing {
+	args := r.Called(identifier, size)
+	return args.Get(0).(ReadRing)
+}
+
 func (r *RingMock) GetInstanceState(instanceID string) (InstanceState, error) {
 	args := r.Called(instanceID)
 	return args.Get(0).(InstanceState), args.Error(1)

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -174,7 +174,7 @@ func newStoreGateway(gatewayCfg Config, storageCfg cortex_tsdb.BlocksStorageConf
 		case util.ShardingStrategyDefault:
 			shardingStrategy = NewDefaultShardingStrategy(g.ring, lifecyclerCfg.Addr, logger)
 		case util.ShardingStrategyShuffle:
-			shardingStrategy = NewShuffleShardingStrategy(g.ring, lifecyclerCfg.ID, lifecyclerCfg.Addr, limits, logger)
+			shardingStrategy = NewShuffleShardingStrategy(g.ring, lifecyclerCfg.ID, lifecyclerCfg.Addr, limits, logger, g.gatewayCfg.ShardingRing.ZoneStableShuffleSharding)
 		default:
 			return nil, errInvalidShardingStrategy
 		}

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -67,7 +67,7 @@ type RingConfig struct {
 	TokensFilePath                  string        `yaml:"tokens_file_path"`
 	ZoneAwarenessEnabled            bool          `yaml:"zone_awareness_enabled"`
 	KeepInstanceInTheRingOnShutdown bool          `yaml:"keep_instance_in_the_ring_on_shutdown"`
-	ZoneStableShuffleSharding       bool          `yaml:"zone_stable_shuffle_sharding"`
+	ZoneStableShuffleSharding       bool          `yaml:"zone_stable_shuffle_sharding" doc:"hidden"`
 
 	// Wait ring stability.
 	WaitStabilityMinDuration time.Duration `yaml:"wait_stability_min_duration"`

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -67,6 +67,7 @@ type RingConfig struct {
 	TokensFilePath                  string        `yaml:"tokens_file_path"`
 	ZoneAwarenessEnabled            bool          `yaml:"zone_awareness_enabled"`
 	KeepInstanceInTheRingOnShutdown bool          `yaml:"keep_instance_in_the_ring_on_shutdown"`
+	ZoneStableShuffleSharding       bool          `yaml:"zone_stable_shuffle_sharding"`
 
 	// Wait ring stability.
 	WaitStabilityMinDuration time.Duration `yaml:"wait_stability_min_duration"`
@@ -102,6 +103,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.TokensFilePath, ringFlagsPrefix+"tokens-file-path", "", "File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.")
 	f.BoolVar(&cfg.ZoneAwarenessEnabled, ringFlagsPrefix+"zone-awareness-enabled", false, "True to enable zone-awareness and replicate blocks across different availability zones.")
 	f.BoolVar(&cfg.KeepInstanceInTheRingOnShutdown, ringFlagsPrefix+"keep-instance-in-the-ring-on-shutdown", false, "True to keep the store gateway instance in the ring when it shuts down. The instance will then be auto-forgotten from the ring after 10*heartbeat_timeout.")
+	f.BoolVar(&cfg.ZoneStableShuffleSharding, ringFlagsPrefix+"zone-stable-shuffle-sharding", false, "If true, use zone stable shuffle sharding algorithm. Otherwise, use the default shuffle sharding algorithm.")
 
 	// Wait stability flags.
 	f.DurationVar(&cfg.WaitStabilityMinDuration, ringFlagsPrefix+"wait-stability-min-duration", time.Minute, "Minimum time to wait for ring stability at startup. 0 to disable.")

--- a/pkg/storegateway/sharding_strategy.go
+++ b/pkg/storegateway/sharding_strategy.go
@@ -182,7 +182,9 @@ func GetShuffleShardingSubring(ring *ring.Ring, userID string, limits ShardingLi
 		return ring
 	}
 
-	return ring.ShuffleShard(userID, shardSize)
+	// Zone stability is required for store gateway when shuffle shard, see
+	// https://github.com/cortexproject/cortex/issues/5467 for more details.
+	return ring.ShuffleShardWithZoneStability(userID, shardSize)
 }
 
 type shardingMetadataFilterAdapter struct {

--- a/pkg/storegateway/sharding_strategy.go
+++ b/pkg/storegateway/sharding_strategy.go
@@ -87,16 +87,20 @@ type ShuffleShardingStrategy struct {
 	instanceAddr string
 	limits       ShardingLimits
 	logger       log.Logger
+
+	zoneStableShuffleSharding bool
 }
 
 // NewShuffleShardingStrategy makes a new ShuffleShardingStrategy.
-func NewShuffleShardingStrategy(r *ring.Ring, instanceID, instanceAddr string, limits ShardingLimits, logger log.Logger) *ShuffleShardingStrategy {
+func NewShuffleShardingStrategy(r *ring.Ring, instanceID, instanceAddr string, limits ShardingLimits, logger log.Logger, zoneStableShuffleSharding bool) *ShuffleShardingStrategy {
 	return &ShuffleShardingStrategy{
 		r:            r,
 		instanceID:   instanceID,
 		instanceAddr: instanceAddr,
 		limits:       limits,
 		logger:       logger,
+
+		zoneStableShuffleSharding: zoneStableShuffleSharding,
 	}
 }
 
@@ -105,7 +109,7 @@ func (s *ShuffleShardingStrategy) FilterUsers(_ context.Context, userIDs []strin
 	var filteredIDs []string
 
 	for _, userID := range userIDs {
-		subRing := GetShuffleShardingSubring(s.r, userID, s.limits)
+		subRing := GetShuffleShardingSubring(s.r, userID, s.limits, s.zoneStableShuffleSharding)
 
 		// Include the user only if it belongs to this store-gateway shard.
 		if subRing.HasInstance(s.instanceID) {
@@ -118,7 +122,7 @@ func (s *ShuffleShardingStrategy) FilterUsers(_ context.Context, userIDs []strin
 
 // FilterBlocks implements ShardingStrategy.
 func (s *ShuffleShardingStrategy) FilterBlocks(_ context.Context, userID string, metas map[ulid.ULID]*metadata.Meta, loaded map[ulid.ULID]struct{}, synced block.GaugeVec) error {
-	subRing := GetShuffleShardingSubring(s.r, userID, s.limits)
+	subRing := GetShuffleShardingSubring(s.r, userID, s.limits, s.zoneStableShuffleSharding)
 	filterBlocksByRingSharding(subRing, s.instanceAddr, metas, loaded, synced, s.logger)
 	return nil
 }
@@ -173,7 +177,7 @@ func filterBlocksByRingSharding(r ring.ReadRing, instanceAddr string, metas map[
 
 // GetShuffleShardingSubring returns the subring to be used for a given user. This function
 // should be used both by store-gateway and querier in order to guarantee the same logic is used.
-func GetShuffleShardingSubring(ring *ring.Ring, userID string, limits ShardingLimits) ring.ReadRing {
+func GetShuffleShardingSubring(ring *ring.Ring, userID string, limits ShardingLimits, zoneStableShuffleSharding bool) ring.ReadRing {
 	shardSize := util.DynamicShardSize(limits.StoreGatewayTenantShardSize(userID), ring.InstancesCount())
 
 	// A shard size of 0 means shuffle sharding is disabled for this specific user,
@@ -182,9 +186,12 @@ func GetShuffleShardingSubring(ring *ring.Ring, userID string, limits ShardingLi
 		return ring
 	}
 
-	// Zone stability is required for store gateway when shuffle shard, see
-	// https://github.com/cortexproject/cortex/issues/5467 for more details.
-	return ring.ShuffleShardWithZoneStability(userID, shardSize)
+	if zoneStableShuffleSharding {
+		// Zone stability is required for store gateway when shuffle shard, see
+		// https://github.com/cortexproject/cortex/issues/5467 for more details.
+		return ring.ShuffleShardWithZoneStability(userID, shardSize)
+	}
+	return ring.ShuffleShard(userID, shardSize)
 }
 
 type shardingMetadataFilterAdapter struct {

--- a/pkg/storegateway/sharding_strategy_test.go
+++ b/pkg/storegateway/sharding_strategy_test.go
@@ -2,6 +2,8 @@ package storegateway
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -595,71 +597,73 @@ func TestShuffleShardingStrategy(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
-		testName := testName
-		testData := testData
+		for _, zoneStableShuffleSharding := range []bool{false, true} {
+			testName := testName
+			testData := testData
 
-		t.Run(testName, func(t *testing.T) {
-			t.Parallel()
+			t.Run(fmt.Sprintf("%s %s", testName, strconv.FormatBool(zoneStableShuffleSharding)), func(t *testing.T) {
+				t.Parallel()
 
-			ctx := context.Background()
-			store, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
-			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+				ctx := context.Background()
+				store, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+				t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
-			// Initialize the ring state.
-			require.NoError(t, store.CAS(ctx, "test", func(in interface{}) (interface{}, bool, error) {
-				d := ring.NewDesc()
-				testData.setupRing(d)
-				return d, true, nil
-			}))
+				// Initialize the ring state.
+				require.NoError(t, store.CAS(ctx, "test", func(in interface{}) (interface{}, bool, error) {
+					d := ring.NewDesc()
+					testData.setupRing(d)
+					return d, true, nil
+				}))
 
-			cfg := ring.Config{
-				ReplicationFactor:    testData.replicationFactor,
-				HeartbeatTimeout:     time.Minute,
-				SubringCacheDisabled: true,
-			}
-
-			r, err := ring.NewWithStoreClientAndStrategy(cfg, "test", "test", store, ring.NewIgnoreUnhealthyInstancesReplicationStrategy(), nil, nil)
-			require.NoError(t, err)
-			require.NoError(t, services.StartAndAwaitRunning(ctx, r))
-			defer services.StopAndAwaitTerminated(ctx, r) //nolint:errcheck
-
-			// Wait until the ring client has synced.
-			require.NoError(t, ring.WaitInstanceState(ctx, r, "instance-1", ring.ACTIVE))
-
-			// Assert on filter users.
-			for _, expected := range testData.expectedUsers {
-				filter := NewShuffleShardingStrategy(r, expected.instanceID, expected.instanceAddr, testData.limits, log.NewNopLogger())
-				assert.Equal(t, expected.users, filter.FilterUsers(ctx, []string{userID}))
-			}
-
-			// Assert on filter blocks.
-			for _, expected := range testData.expectedBlocks {
-				filter := NewShuffleShardingStrategy(r, expected.instanceID, expected.instanceAddr, testData.limits, log.NewNopLogger())
-				synced := extprom.NewTxGaugeVec(nil, prometheus.GaugeOpts{}, []string{"state"})
-				synced.WithLabelValues(shardExcludedMeta).Set(0)
-
-				metas := map[ulid.ULID]*metadata.Meta{
-					block1: {},
-					block2: {},
-					block3: {},
-					block4: {},
+				cfg := ring.Config{
+					ReplicationFactor:    testData.replicationFactor,
+					HeartbeatTimeout:     time.Minute,
+					SubringCacheDisabled: true,
 				}
 
-				err = filter.FilterBlocks(ctx, userID, metas, map[ulid.ULID]struct{}{}, synced)
+				r, err := ring.NewWithStoreClientAndStrategy(cfg, "test", "test", store, ring.NewIgnoreUnhealthyInstancesReplicationStrategy(), nil, nil)
 				require.NoError(t, err)
+				require.NoError(t, services.StartAndAwaitRunning(ctx, r))
+				defer services.StopAndAwaitTerminated(ctx, r) //nolint:errcheck
 
-				var actualBlocks []ulid.ULID
-				for id := range metas {
-					actualBlocks = append(actualBlocks, id)
+				// Wait until the ring client has synced.
+				require.NoError(t, ring.WaitInstanceState(ctx, r, "instance-1", ring.ACTIVE))
+
+				// Assert on filter users.
+				for _, expected := range testData.expectedUsers {
+					filter := NewShuffleShardingStrategy(r, expected.instanceID, expected.instanceAddr, testData.limits, log.NewNopLogger(), zoneStableShuffleSharding)
+					assert.Equal(t, expected.users, filter.FilterUsers(ctx, []string{userID}))
 				}
 
-				assert.ElementsMatch(t, expected.blocks, actualBlocks)
+				// Assert on filter blocks.
+				for _, expected := range testData.expectedBlocks {
+					filter := NewShuffleShardingStrategy(r, expected.instanceID, expected.instanceAddr, testData.limits, log.NewNopLogger(), zoneStableShuffleSharding)
+					synced := extprom.NewTxGaugeVec(nil, prometheus.GaugeOpts{}, []string{"state"})
+					synced.WithLabelValues(shardExcludedMeta).Set(0)
 
-				// Assert on the metric used to keep track of the blocks filtered out.
-				synced.Submit()
-				assert.Equal(t, float64(numAllBlocks-len(expected.blocks)), testutil.ToFloat64(synced))
-			}
-		})
+					metas := map[ulid.ULID]*metadata.Meta{
+						block1: {},
+						block2: {},
+						block3: {},
+						block4: {},
+					}
+
+					err = filter.FilterBlocks(ctx, userID, metas, map[ulid.ULID]struct{}{}, synced)
+					require.NoError(t, err)
+
+					var actualBlocks []ulid.ULID
+					for id := range metas {
+						actualBlocks = append(actualBlocks, id)
+					}
+
+					assert.ElementsMatch(t, expected.blocks, actualBlocks)
+
+					// Assert on the metric used to keep track of the blocks filtered out.
+					synced.Submit()
+					assert.Equal(t, float64(numAllBlocks-len(expected.blocks)), testutil.ToFloat64(synced))
+				}
+			})
+		}
 	}
 }
 

--- a/pkg/storegateway/sharding_strategy_test.go
+++ b/pkg/storegateway/sharding_strategy_test.go
@@ -631,13 +631,13 @@ func TestShuffleShardingStrategy(t *testing.T) {
 
 				// Assert on filter users.
 				for _, expected := range testData.expectedUsers {
-					filter := NewShuffleShardingStrategy(r, expected.instanceID, expected.instanceAddr, testData.limits, log.NewNopLogger(), zoneStableShuffleSharding)
+					filter := NewShuffleShardingStrategy(r, expected.instanceID, expected.instanceAddr, testData.limits, log.NewNopLogger(), zoneStableShuffleSharding) //nolint:govet
 					assert.Equal(t, expected.users, filter.FilterUsers(ctx, []string{userID}))
 				}
 
 				// Assert on filter blocks.
 				for _, expected := range testData.expectedBlocks {
-					filter := NewShuffleShardingStrategy(r, expected.instanceID, expected.instanceAddr, testData.limits, log.NewNopLogger(), zoneStableShuffleSharding)
+					filter := NewShuffleShardingStrategy(r, expected.instanceID, expected.instanceAddr, testData.limits, log.NewNopLogger(), zoneStableShuffleSharding) //nolint:govet
 					synced := extprom.NewTxGaugeVec(nil, prometheus.GaugeOpts{}, []string{"state"})
 					synced.WithLabelValues(shardExcludedMeta).Set(0)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Add a new method `ShuffleShardWithZoneStability ` in `ReadRing` interface. It does the same thing as `ShuffleShard` but makes a slight change:
1. It doesn't round up shard size to be multiple of `numZones` when zone awareness is enabled.

If shardSize is divisible by `numZones`, the behavior should be the same.
If shardSize is not divisible by `numZones`, for example, shard size 8 and num zones is 3. Then 2 zones are assigned to have 3 instances and 1 zone has 2 instances. Because we iterate over zones using the same order so we can ensure the consistency.



**Which issue(s) this PR fixes**:
Fixes #5467 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
