### PR TITLE
Query Frontend: Handle context error before decoding and merging responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@
 * [BUGFIX] Alertmanager: Remove the user id from state replication key metric label value. #5453
 * [BUGFIX] Compactor: Avoid cleaner concurrency issues checking global markers before all blocks. #5457
 * [BUGFIX] DDBKV: Disallow instance with older timestamp to update instance with newer timestamp. #5480
+* [BUGFIX] Query Frontend: Handle context error before decoding and merging responses. #5499
+
 ## 1.15.1 2023-04-26
 
 * [CHANGE] Alertmanager: Validating new fields on the PagerDuty AM config. #5290

--- a/pkg/querier/tripperware/instantquery/instant_query.go
+++ b/pkg/querier/tripperware/instantquery/instant_query.go
@@ -158,6 +158,10 @@ func (instantQueryCodec) DecodeResponse(ctx context.Context, r *http.Response, _
 	log, ctx := spanlogger.New(ctx, "PrometheusInstantQueryResponse") //nolint:ineffassign,staticcheck
 	defer log.Finish()
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	buf, err := tripperware.BodyBuffer(r, log)
 	if err != nil {
 		log.Error(err)

--- a/pkg/querier/tripperware/instantquery/instant_query.go
+++ b/pkg/querier/tripperware/instantquery/instant_query.go
@@ -266,7 +266,7 @@ func (instantQueryCodec) MergeResponse(ctx context.Context, req tripperware.Requ
 	// For now, we only shard queries that returns a vector.
 	switch promResponses[0].Data.ResultType {
 	case model.ValVector.String():
-		v, err := vectorMerge(req, promResponses)
+		v, err := vectorMerge(ctx, req, promResponses)
 		if err != nil {
 			return nil, err
 		}
@@ -280,12 +280,17 @@ func (instantQueryCodec) MergeResponse(ctx context.Context, req tripperware.Requ
 			Stats: statsMerge(promResponses),
 		}
 	case model.ValMatrix.String():
+		sampleStreams, err := matrixMerge(ctx, promResponses)
+		if err != nil {
+			return nil, err
+		}
+
 		data = PrometheusInstantQueryData{
 			ResultType: model.ValMatrix.String(),
 			Result: PrometheusInstantQueryResult{
 				Result: &PrometheusInstantQueryResult_Matrix{
 					Matrix: &Matrix{
-						SampleStreams: matrixMerge(promResponses),
+						SampleStreams: sampleStreams,
 					},
 				},
 			},
@@ -302,7 +307,7 @@ func (instantQueryCodec) MergeResponse(ctx context.Context, req tripperware.Requ
 	return res, nil
 }
 
-func vectorMerge(req tripperware.Request, resps []*PrometheusInstantQueryResponse) (*Vector, error) {
+func vectorMerge(ctx context.Context, req tripperware.Request, resps []*PrometheusInstantQueryResponse) (*Vector, error) {
 	output := map[string]*Sample{}
 	metrics := []string{} // Used to preserve the order for topk and bottomk.
 	sortPlan, err := sortPlanForQuery(req.GetQuery())
@@ -311,6 +316,9 @@ func vectorMerge(req tripperware.Request, resps []*PrometheusInstantQueryRespons
 	}
 	buf := make([]byte, 0, 1024)
 	for _, resp := range resps {
+		if err = ctx.Err(); err != nil {
+			return nil, err
+		}
 		if resp == nil {
 			continue
 		}
@@ -439,9 +447,12 @@ func sortPlanForQuery(q string) (sortPlan, error) {
 	return sortByLabels, nil
 }
 
-func matrixMerge(resps []*PrometheusInstantQueryResponse) []tripperware.SampleStream {
+func matrixMerge(ctx context.Context, resps []*PrometheusInstantQueryResponse) ([]tripperware.SampleStream, error) {
 	output := make(map[string]tripperware.SampleStream)
 	for _, resp := range resps {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if resp == nil {
 			continue
 		}
@@ -462,7 +473,7 @@ func matrixMerge(resps []*PrometheusInstantQueryResponse) []tripperware.SampleSt
 		result = append(result, output[key])
 	}
 
-	return result
+	return result, nil
 }
 
 // NewEmptyPrometheusInstantQueryResponse returns an empty successful Prometheus query range response.

--- a/pkg/querier/tripperware/instantquery/instant_query_test.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_test.go
@@ -418,6 +418,7 @@ func TestMergeResponse(t *testing.T) {
 			contents, err := io.ReadAll(dr.Body)
 			assert.Equal(t, tc.expectedErr, err)
 			assert.Equal(t, string(contents), tc.expectedResp)
+			cancelCtx()
 		})
 	}
 }

--- a/pkg/querier/tripperware/instantquery/instant_query_test.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_test.go
@@ -398,6 +398,7 @@ func TestMergeResponse(t *testing.T) {
 				dr, err := InstantQueryCodec.DecodeResponse(ctx, hr, nil)
 				assert.Equal(t, tc.expectedDecodeErr, err)
 				if err != nil {
+					cancelCtx()
 					return
 				}
 				resps = append(resps, dr)
@@ -409,6 +410,7 @@ func TestMergeResponse(t *testing.T) {
 			resp, err := InstantQueryCodec.MergeResponse(ctx, tc.req, resps...)
 			assert.Equal(t, tc.expectedErr, err)
 			if err != nil {
+				cancelCtx()
 				return
 			}
 			dr, err := InstantQueryCodec.EncodeResponse(ctx, resp)

--- a/pkg/querier/tripperware/instantquery/instant_query_test.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_test.go
@@ -218,11 +218,14 @@ func TestMergeResponse(t *testing.T) {
 		Query: "sum(up)",
 	}
 	for _, tc := range []struct {
-		name         string
-		req          tripperware.Request
-		resps        []string
-		expectedResp string
-		expectedErr  error
+		name               string
+		req                tripperware.Request
+		resps              []string
+		expectedResp       string
+		expectedErr        error
+		cancelBeforeDecode bool
+		expectedDecodeErr  error
+		cancelBeforeMerge  bool
 	}{
 		{
 			name:         "empty response",
@@ -355,10 +358,31 @@ func TestMergeResponse(t *testing.T) {
 			},
 			expectedResp: `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"bar"},"values":[[1,"1"],[2,"2"],[3,"3"]]}]}}`,
 		},
+		{
+			name: "context cancelled before decoding response",
+			req:  defaultReq,
+			resps: []string{
+				`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up","job":"foo"},"value":[1,"1"]}]}}`,
+				`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up","job":"bar"},"value":[2,"2"]}]}}`,
+			},
+			expectedDecodeErr:  context.Canceled,
+			cancelBeforeDecode: true,
+		},
+		{
+			name: "context cancelled before merging response",
+			req:  defaultReq,
+			resps: []string{
+				`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up","job":"foo"},"value":[1,"1"]}]}}`,
+				`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up","job":"bar"},"value":[2,"2"]}]}}`,
+			},
+			expectedErr:       context.Canceled,
+			cancelBeforeMerge: true,
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			ctx, cancelCtx := context.WithCancel(context.Background())
 
 			var resps []tripperware.Response
 			for _, r := range tc.resps {
@@ -367,19 +391,30 @@ func TestMergeResponse(t *testing.T) {
 					Header:     http.Header{"Content-Type": []string{"application/json"}},
 					Body:       io.NopCloser(bytes.NewBuffer([]byte(r))),
 				}
-				dr, err := InstantQueryCodec.DecodeResponse(context.Background(), hr, nil)
-				require.NoError(t, err)
+
+				if tc.cancelBeforeDecode {
+					cancelCtx()
+				}
+				dr, err := InstantQueryCodec.DecodeResponse(ctx, hr, nil)
+				assert.Equal(t, tc.expectedDecodeErr, err)
+				if err != nil {
+					return
+				}
 				resps = append(resps, dr)
 			}
-			resp, err := InstantQueryCodec.MergeResponse(context.Background(), tc.req, resps...)
-			assert.Equal(t, err, tc.expectedErr)
+
+			if tc.cancelBeforeMerge {
+				cancelCtx()
+			}
+			resp, err := InstantQueryCodec.MergeResponse(ctx, tc.req, resps...)
+			assert.Equal(t, tc.expectedErr, err)
 			if err != nil {
 				return
 			}
-			dr, err := InstantQueryCodec.EncodeResponse(context.Background(), resp)
-			assert.Equal(t, err, tc.expectedErr)
+			dr, err := InstantQueryCodec.EncodeResponse(ctx, resp)
+			assert.Equal(t, tc.expectedErr, err)
 			contents, err := io.ReadAll(dr.Body)
-			assert.Equal(t, err, tc.expectedErr)
+			assert.Equal(t, tc.expectedErr, err)
 			assert.Equal(t, string(contents), tc.expectedResp)
 		})
 	}

--- a/pkg/querier/tripperware/queryrange/query_range.go
+++ b/pkg/querier/tripperware/queryrange/query_range.go
@@ -267,6 +267,10 @@ func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ t
 	log, ctx := spanlogger.New(ctx, "ParseQueryRangeResponse") //nolint:ineffassign,staticcheck
 	defer log.Finish()
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	buf, err := tripperware.BodyBuffer(r, log)
 	if err != nil {
 		log.Error(err)
@@ -283,9 +287,6 @@ func (prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ t
 	}
 
 	for h, hv := range r.Header {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
 		resp.Headers = append(resp.Headers, &tripperware.PrometheusResponseHeader{Name: h, Values: hv})
 	}
 	return &resp, nil

--- a/pkg/querier/tripperware/queryrange/query_range_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_test.go
@@ -138,6 +138,7 @@ func TestResponse(t *testing.T) {
 			resp2, err := PrometheusCodec.EncodeResponse(context.Background(), resp)
 			require.NoError(t, err)
 			assert.Equal(t, response, resp2)
+			cancelCtx()
 		})
 	}
 }
@@ -717,9 +718,11 @@ func TestMergeAPIResponses(t *testing.T) {
 			output, err := PrometheusCodec.MergeResponse(ctx, nil, tc.input...)
 			require.Equal(t, tc.expectedErr, err)
 			if err != nil {
+				cancelCtx()
 				return
 			}
 			require.Equal(t, tc.expected, output)
+			cancelCtx()
 		})
 	}
 }

--- a/pkg/querier/tripperware/queryrange/query_range_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_test.go
@@ -93,24 +93,38 @@ func TestResponse(t *testing.T) {
 	r := *parsedResponse
 	r.Headers = respHeaders
 	for i, tc := range []struct {
-		body     string
-		expected *PrometheusResponse
+		body                  string
+		expected              *PrometheusResponse
+		expectedDecodeErr     error
+		cancelCtxBeforeDecode bool
 	}{
 		{
 			body:     responseBody,
 			expected: &r,
 		},
+		{
+			body:                  responseBody,
+			cancelCtxBeforeDecode: true,
+			expectedDecodeErr:     context.Canceled,
+		},
 	} {
 		tc := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
+			ctx, cancelCtx := context.WithCancel(context.Background())
 			response := &http.Response{
 				StatusCode: 200,
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 				Body:       io.NopCloser(bytes.NewBuffer([]byte(tc.body))),
 			}
-			resp, err := PrometheusCodec.DecodeResponse(context.Background(), response, nil)
-			require.NoError(t, err)
+			if tc.cancelCtxBeforeDecode {
+				cancelCtx()
+			}
+			resp, err := PrometheusCodec.DecodeResponse(ctx, response, nil)
+			assert.Equal(t, tc.expectedDecodeErr, err)
+			if err != nil {
+				return
+			}
 			assert.Equal(t, tc.expected, resp)
 
 			// Reset response, as the above call will have consumed the body reader.
@@ -193,9 +207,11 @@ func TestResponseWithStats(t *testing.T) {
 func TestMergeAPIResponses(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
-		name     string
-		input    []tripperware.Response
-		expected tripperware.Response
+		name        string
+		input       []tripperware.Response
+		expected    tripperware.Response
+		expectedErr error
+		cancelCtx   bool
 	}{
 		{
 			name:  "No responses shouldn't panic and return a non-null result and result type.",
@@ -208,7 +224,6 @@ func TestMergeAPIResponses(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "A single empty response shouldn't panic.",
 			input: []tripperware.Response{
@@ -227,7 +242,6 @@ func TestMergeAPIResponses(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "Multiple empty responses shouldn't panic.",
 			input: []tripperware.Response{
@@ -302,7 +316,6 @@ func TestMergeAPIResponses(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "Merging of responses when labels are in different order.",
 			input: []tripperware.Response{
@@ -327,7 +340,6 @@ func TestMergeAPIResponses(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "Merging of samples where there is single overlap.",
 			input: []tripperware.Response{
@@ -401,6 +413,41 @@ func TestMergeAPIResponses(t *testing.T) {
 			},
 		},
 		{
+			name: "Context cancel should cancel merge",
+			input: []tripperware.Response{
+				&PrometheusResponse{
+					Data: PrometheusData{
+						ResultType: matrix,
+						Result: []tripperware.SampleStream{
+							{
+								Labels: []cortexpb.LabelAdapter{},
+								Samples: []cortexpb.Sample{
+									{Value: 0, TimestampMs: 0},
+									{Value: 1, TimestampMs: 1},
+								},
+							},
+						},
+					},
+				},
+				&PrometheusResponse{
+					Data: PrometheusData{
+						ResultType: matrix,
+						Result: []tripperware.SampleStream{
+							{
+								Labels: []cortexpb.LabelAdapter{},
+								Samples: []cortexpb.Sample{
+									{Value: 2, TimestampMs: 2},
+									{Value: 3, TimestampMs: 3},
+								},
+							},
+						},
+					},
+				},
+			},
+			cancelCtx:   true,
+			expectedErr: context.Canceled,
+		},
+		{
 			name: "[stats] A single empty response shouldn't panic.",
 			input: []tripperware.Response{
 				&PrometheusResponse{
@@ -420,7 +467,6 @@ func TestMergeAPIResponses(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "[stats] Multiple empty responses shouldn't panic.",
 			input: []tripperware.Response{
@@ -448,7 +494,6 @@ func TestMergeAPIResponses(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "[stats] Basic merging of two responses.",
 			input: []tripperware.Response{
@@ -664,8 +709,15 @@ func TestMergeAPIResponses(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			output, err := PrometheusCodec.MergeResponse(context.Background(), nil, tc.input...)
-			require.NoError(t, err)
+			ctx, cancelCtx := context.WithCancel(context.Background())
+			if tc.cancelCtx {
+				cancelCtx()
+			}
+			output, err := PrometheusCodec.MergeResponse(ctx, nil, tc.input...)
+			require.Equal(t, tc.expectedErr, err)
+			if err != nil {
+				return
+			}
 			require.Equal(t, tc.expected, output)
 		})
 	}

--- a/pkg/querier/tripperware/queryrange/query_range_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_test.go
@@ -123,6 +123,7 @@ func TestResponse(t *testing.T) {
 			resp, err := PrometheusCodec.DecodeResponse(ctx, response, nil)
 			assert.Equal(t, tc.expectedDecodeErr, err)
 			if err != nil {
+				cancelCtx()
 				return
 			}
 			assert.Equal(t, tc.expected, resp)

--- a/pkg/querier/tripperware/queryrange/results_cache.go
+++ b/pkg/querier/tripperware/queryrange/results_cache.go
@@ -407,7 +407,7 @@ func (s resultsCache) handleHit(ctx context.Context, r tripperware.Request, exte
 		return nil, nil, err
 	}
 	if len(requests) == 0 {
-		response, err := s.merger.MergeResponse(context.Background(), r, responses...)
+		response, err := s.merger.MergeResponse(ctx, r, responses...)
 		// No downstream requests so no need to write back to the cache.
 		return response, nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Decoding and merging response in query frontend can take a long time, and if the context has been cancelled in the process it should stop as well.

This PR adds context error check before heavy operations within decode and merge responses.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
