### PR TITLE
if no change detected, retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * [BUGFIX] Compactor: Avoid cleaner concurrency issues checking global markers before all blocks. #5457
 * [BUGFIX] DDBKV: Disallow instance with older timestamp to update instance with newer timestamp. #5480
 * [BUGFIX] Query Frontend: Handle context error before decoding and merging responses. #5499
+* [BUGFIX] DDBKV: When no change detected in ring, retry the CAS until there is change. #5502
 
 ## 1.15.1 2023-04-26
 

--- a/docs/blocks-storage/compactor.md
+++ b/docs/blocks-storage/compactor.md
@@ -221,6 +221,10 @@ compactor:
         # CLI flag: -compactor.ring.dynamodb.puller-sync-time
         [puller_sync_time: <duration> | default = 1m]
 
+        # Maximum number of retries for DDB KV CAS.
+        # CLI flag: -compactor.ring.dynamodb.max-cas-retries
+        [max_cas_retries: <int> | default = 10]
+
       # The consul_config configures the consul client.
       # The CLI flags prefix for this block config is: compactor.ring
       [consul: <consul_config>]

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -236,6 +236,10 @@ store_gateway:
         # CLI flag: -store-gateway.sharding-ring.dynamodb.puller-sync-time
         [puller_sync_time: <duration> | default = 1m]
 
+        # Maximum number of retries for DDB KV CAS.
+        # CLI flag: -store-gateway.sharding-ring.dynamodb.max-cas-retries
+        [max_cas_retries: <int> | default = 10]
+
       # The consul_config configures the consul client.
       # The CLI flags prefix for this block config is:
       # store-gateway.sharding-ring

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -322,6 +322,10 @@ sharding_ring:
       # CLI flag: -alertmanager.sharding-ring.dynamodb.puller-sync-time
       [puller_sync_time: <duration> | default = 1m]
 
+      # Maximum number of retries for DDB KV CAS.
+      # CLI flag: -alertmanager.sharding-ring.dynamodb.max-cas-retries
+      [max_cas_retries: <int> | default = 10]
+
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: alertmanager.sharding-ring
     [consul: <consul_config>]
@@ -1863,6 +1867,10 @@ sharding_ring:
       # CLI flag: -compactor.ring.dynamodb.puller-sync-time
       [puller_sync_time: <duration> | default = 1m]
 
+      # Maximum number of retries for DDB KV CAS.
+      # CLI flag: -compactor.ring.dynamodb.max-cas-retries
+      [max_cas_retries: <int> | default = 10]
+
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: compactor.ring
     [consul: <consul_config>]
@@ -2115,6 +2123,10 @@ ha_tracker:
       # CLI flag: -distributor.ha-tracker.dynamodb.puller-sync-time
       [puller_sync_time: <duration> | default = 1m]
 
+      # Maximum number of retries for DDB KV CAS.
+      # CLI flag: -distributor.ha-tracker.dynamodb.max-cas-retries
+      [max_cas_retries: <int> | default = 10]
+
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: distributor.ha-tracker
     [consul: <consul_config>]
@@ -2200,6 +2212,10 @@ ring:
       # Time to refresh local ring with information on dynamodb.
       # CLI flag: -distributor.ring.dynamodb.puller-sync-time
       [puller_sync_time: <duration> | default = 1m]
+
+      # Maximum number of retries for DDB KV CAS.
+      # CLI flag: -distributor.ring.dynamodb.max-cas-retries
+      [max_cas_retries: <int> | default = 10]
 
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: distributor.ring
@@ -2492,6 +2508,10 @@ lifecycler:
         # Time to refresh local ring with information on dynamodb.
         # CLI flag: -dynamodb.puller-sync-time
         [puller_sync_time: <duration> | default = 1m]
+
+        # Maximum number of retries for DDB KV CAS.
+        # CLI flag: -dynamodb.max-cas-retries
+        [max_cas_retries: <int> | default = 10]
 
       # The consul_config configures the consul client.
       [consul: <consul_config>]
@@ -3879,6 +3899,10 @@ ring:
       # CLI flag: -ruler.ring.dynamodb.puller-sync-time
       [puller_sync_time: <duration> | default = 1m]
 
+      # Maximum number of retries for DDB KV CAS.
+      # CLI flag: -ruler.ring.dynamodb.max-cas-retries
+      [max_cas_retries: <int> | default = 10]
+
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: ruler.ring
     [consul: <consul_config>]
@@ -4741,6 +4765,10 @@ sharding_ring:
       # Time to refresh local ring with information on dynamodb.
       # CLI flag: -store-gateway.sharding-ring.dynamodb.puller-sync-time
       [puller_sync_time: <duration> | default = 1m]
+
+      # Maximum number of retries for DDB KV CAS.
+      # CLI flag: -store-gateway.sharding-ring.dynamodb.max-cas-retries
+      [max_cas_retries: <int> | default = 10]
 
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: store-gateway.sharding-ring

--- a/pkg/ring/kv/dynamodb/client.go
+++ b/pkg/ring/kv/dynamodb/client.go
@@ -192,7 +192,7 @@ func (c *Client) CAS(ctx context.Context, key string, f func(in interface{}) (ou
 
 		if len(putRequests) == 0 && len(deleteRequests) == 0 {
 			// no change detected, retry
-			level.Error(c.logger).Log("msg", "finding difference", "key", key, "err", err)
+			level.Error(c.logger).Log("msg", "finding difference", "key", key, "err", errNoChangeDeleted)
 			continue
 		}
 

--- a/pkg/ring/kv/dynamodb/client_test.go
+++ b/pkg/ring/kv/dynamodb/client_test.go
@@ -54,9 +54,10 @@ func Test_CAS_Backoff(t *testing.T) {
 
 	ddbMock.On("Query").Return(map[string][]byte{}, expectedErr).Once()
 	ddbMock.On("Query").Return(map[string][]byte{}, nil).Once()
+	ddbMock.On("Batch", context.TODO(), map[dynamodbKey][]byte{}, []dynamodbKey{{primaryKey: "test", sortKey: "childkey"}}).Once()
 	codecMock.On("DecodeMultiKey").Return(descMock, nil).Twice()
 	descMock.On("Clone").Return(descMock).Once()
-	descMock.On("FindDifference", descMock).Return(descMock, []string{}, nil).Once()
+	descMock.On("FindDifference", descMock).Return(descMock, []string{"childkey"}, nil).Once()
 	codecMock.On("EncodeMultiKey").Return(map[string][]byte{}, nil).Twice()
 
 	err := c.CAS(context.TODO(), key, func(in interface{}) (out interface{}, retry bool, err error) {

--- a/pkg/ring/kv/dynamodb/metrics.go
+++ b/pkg/ring/kv/dynamodb/metrics.go
@@ -19,6 +19,7 @@ type dynamodbInstrumentation struct {
 type dynamodbMetrics struct {
 	dynamodbRequestDuration *instrument.HistogramCollector
 	dynamodbUsageMetrics    *prometheus.CounterVec
+	dynamodbCasAttempts     prometheus.Counter
 }
 
 func newDynamoDbMetrics(registerer prometheus.Registerer) *dynamodbMetrics {
@@ -33,9 +34,15 @@ func newDynamoDbMetrics(registerer prometheus.Registerer) *dynamodbMetrics {
 		Help: "Total consumed capacity on dynamodb",
 	}, []string{"operation"})
 
+	dynamodbCasAttempts := promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+		Name: "dynamodb_kv_cas_attempt_total",
+		Help: "DynamoDB KV Store Attempted CAS operations",
+	})
+
 	dynamodbMetrics := dynamodbMetrics{
 		dynamodbRequestDuration: dynamodbRequestDurationCollector,
 		dynamodbUsageMetrics:    dynamodbUsageMetrics,
+		dynamodbCasAttempts:     dynamodbCasAttempts,
 	}
 	return &dynamodbMetrics
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Right now in DDB KV, if the instance change its state very fast (within 1 sec), then the change of state will be rejected, because the timestamp of the instance didn't change. And the timestamp of the instance has 1 sec resolution. (https://github.com/cortexproject/cortex/blob/master/pkg/ring/ring.proto#L22)

So if no change detected (because the change is rejected), we retry the CAS (i.e. the f callback function), so the timestamp of the instance is updated. So next retry will succeed. This is similar idea in memberlist (https://github.com/cortexproject/cortex/blob/master/pkg/ring/kv/memberlist/memberlist_client.go#L838)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
