### PR TITLE
allow compactor unregisteronshutdown to be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [ENHANCEMENT] Alertmanager: Add the alert name in error log when it get throttled. #5456
 * [ENHANCEMENT] Querier: Retry store gateway on different zones when zone awareness is enabled. #5476
 * [ENHANCEMENT] DDBKV: Change metric name from dynamodb_kv_read_capacity_total to dynamodb_kv_consumed_capacity_total and include Delete, Put, Batch dimension. #5481
+* [ENHANCEMENT] Compactor: allow unregisteronshutdown to be configurable. #5503
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/docs/blocks-storage/compactor.md
+++ b/docs/blocks-storage/compactor.md
@@ -273,6 +273,10 @@ compactor:
     # CLI flag: -compactor.ring.tokens-file-path
     [tokens_file_path: <string> | default = ""]
 
+    # Unregister the compactor during shutdown if true.
+    # CLI flag: -compactor.ring.unregister-on-shutdown
+    [unregister_on_shutdown: <boolean> | default = true]
+
     # Timeout for waiting on compactor to become ACTIVE in the ring.
     # CLI flag: -compactor.ring.wait-active-instance-timeout
     [wait_active_instance_timeout: <duration> | default = 10m]

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1915,6 +1915,10 @@ sharding_ring:
   # CLI flag: -compactor.ring.tokens-file-path
   [tokens_file_path: <string> | default = ""]
 
+  # Unregister the compactor during shutdown if true.
+  # CLI flag: -compactor.ring.unregister-on-shutdown
+  [unregister_on_shutdown: <boolean> | default = true]
+
   # Timeout for waiting on compactor to become ACTIVE in the ring.
   # CLI flag: -compactor.ring.wait-active-instance-timeout
   [wait_active_instance_timeout: <duration> | default = 10m]

--- a/pkg/compactor/compactor_ring.go
+++ b/pkg/compactor/compactor_ring.go
@@ -32,6 +32,7 @@ type RingConfig struct {
 	InstancePort           int      `yaml:"instance_port" doc:"hidden"`
 	InstanceAddr           string   `yaml:"instance_addr" doc:"hidden"`
 	TokensFilePath         string   `yaml:"tokens_file_path"`
+	UnregisterOnShutdown   bool     `yaml:"unregister_on_shutdown"`
 
 	// Injected internally
 	ListenPort int `yaml:"-"`
@@ -65,6 +66,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.InstancePort, "compactor.ring.instance-port", 0, "Port to advertise in the ring (defaults to server.grpc-listen-port).")
 	f.StringVar(&cfg.InstanceID, "compactor.ring.instance-id", hostname, "Instance ID to register in the ring.")
 	f.StringVar(&cfg.TokensFilePath, "compactor.ring.tokens-file-path", "", "File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.")
+	f.BoolVar(&cfg.UnregisterOnShutdown, "compactor.ring.unregister-on-shutdown", true, "Unregister the compactor during shutdown if true.")
 
 	// Timeout durations
 	f.DurationVar(&cfg.WaitActiveInstanceTimeout, "compactor.ring.wait-active-instance-timeout", 10*time.Minute, "Timeout for waiting on compactor to become ACTIVE in the ring.")
@@ -94,7 +96,7 @@ func (cfg *RingConfig) ToLifecyclerConfig() ring.LifecyclerConfig {
 	lc.Port = cfg.InstancePort
 	lc.ID = cfg.InstanceID
 	lc.InfNames = cfg.InstanceInterfaceNames
-	lc.UnregisterOnShutdown = true
+	lc.UnregisterOnShutdown = cfg.UnregisterOnShutdown
 	lc.HeartbeatPeriod = cfg.HeartbeatPeriod
 	lc.ObservePeriod = cfg.ObservePeriod
 	lc.JoinAfter = 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Allow the compactor ring unregisteronshutdown to be configurable. So during compactor statefulset rollout restart, the ring topology can stay the same, without causing resharding and re download of blocks.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
