### PR TITLE
Log error when ruler write fails

### DIFF
--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -34,7 +34,7 @@ func (p *fakePusher) Push(ctx context.Context, r *cortexpb.WriteRequest) (*corte
 
 func TestPusherAppendable(t *testing.T) {
 	pusher := &fakePusher{}
-	pa := NewPusherAppendable(pusher, "user-1", nil, prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+	pa := NewPusherAppendable(pusher, "user-1", nil, prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}), log.NewNopLogger())
 
 	for _, tc := range []struct {
 		name       string
@@ -154,7 +154,7 @@ func TestPusherErrors(t *testing.T) {
 			writes := prometheus.NewCounter(prometheus.CounterOpts{})
 			failures := prometheus.NewCounter(prometheus.CounterOpts{})
 
-			pa := NewPusherAppendable(pusher, "user-1", ruleLimits{evalDelay: 10 * time.Second}, writes, failures)
+			pa := NewPusherAppendable(pusher, "user-1", ruleLimits{evalDelay: 10 * time.Second}, writes, failures, log.NewNopLogger())
 
 			lbls, err := parser.ParseMetric("foo_bar")
 			require.NoError(t, err)


### PR DESCRIPTION
**What this PR does**:
Currently when ruler writes failed we increment a metric but we don't log the error making it hard to debug ruler write failures. This PR logs the ruler write error message.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
