### PR TITLE
add configurable final-sleep time for basic lifecycler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [ENHANCEMENT] DDBKV: Change metric name from dynamodb_kv_read_capacity_total to dynamodb_kv_consumed_capacity_total and include Delete, Put, Batch dimension. #5481
 * [ENHANCEMENT] Compactor: allow unregisteronshutdown to be configurable. #5503
 * [ENHANCEMENT] Store Gateway: add metric `cortex_bucket_store_chunk_refetches_total` for number of chunk refetches. #5532
+* [ENHANCEMENT] BasicLifeCycler: allow final-sleep during shutdown #5517
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -309,7 +309,8 @@ store_gateway:
     # CLI flag: -store-gateway.sharding-ring.wait-stability-max-duration
     [wait_stability_max_duration: <duration> | default = 5m]
 
-    # The sleep seconds when store-gateway is shutting down.
+    # The sleep seconds when store-gateway is shutting down. Need to be close to
+    # or larger than KV Store information propagation delay
     # CLI flag: -store-gateway.sharding-ring.final-sleep
     [final_sleep: <duration> | default = 0s]
 

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -309,6 +309,10 @@ store_gateway:
     # CLI flag: -store-gateway.sharding-ring.wait-stability-max-duration
     [wait_stability_max_duration: <duration> | default = 5m]
 
+    # The sleep seconds when store-gateway is shutting down.
+    # CLI flag: -store-gateway.sharding-ring.final-sleep
+    [final_sleep: <duration> | default = 0s]
+
     # Name of network interface to read address from.
     # CLI flag: -store-gateway.sharding-ring.instance-interface-names
     [instance_interface_names: <list of string> | default = [eth0 en0]]

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -369,9 +369,10 @@ sharding_ring:
   # CLI flag: -alertmanager.sharding-ring.zone-awareness-enabled
   [zone_awareness_enabled: <boolean> | default = false]
 
-  # The sleep seconds when alertmanager is shutting down.
+  # The sleep seconds when alertmanager is shutting down. Need to be close to or
+  # larger than KV Store information propagation delay
   # CLI flag: -alertmanager.sharding-ring.final-sleep
-  [final_sleep: <duration> | default = 30s]
+  [final_sleep: <duration> | default = 0s]
 
   # Name of network interface to read address from.
   # CLI flag: -alertmanager.sharding-ring.instance-interface-names
@@ -3949,9 +3950,10 @@ ring:
   # CLI flag: -ruler.ring.num-tokens
   [num_tokens: <int> | default = 128]
 
-  # The sleep seconds when ruler is shutting down.
+  # The sleep seconds when ruler is shutting down. Need to be close to or larger
+  # than KV Store information propagation delay
   # CLI flag: -ruler.ring.final-sleep
-  [final_sleep: <duration> | default = 30s]
+  [final_sleep: <duration> | default = 0s]
 
 # Period with which to attempt to flush rule groups.
 # CLI flag: -ruler.flush-period
@@ -4844,7 +4846,8 @@ sharding_ring:
   # CLI flag: -store-gateway.sharding-ring.wait-stability-max-duration
   [wait_stability_max_duration: <duration> | default = 5m]
 
-  # The sleep seconds when store-gateway is shutting down.
+  # The sleep seconds when store-gateway is shutting down. Need to be close to
+  # or larger than KV Store information propagation delay
   # CLI flag: -store-gateway.sharding-ring.final-sleep
   [final_sleep: <duration> | default = 0s]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -369,6 +369,10 @@ sharding_ring:
   # CLI flag: -alertmanager.sharding-ring.zone-awareness-enabled
   [zone_awareness_enabled: <boolean> | default = false]
 
+  # The sleep seconds when alertmanager is shutting down.
+  # CLI flag: -alertmanager.sharding-ring.final-sleep
+  [final_sleep: <duration> | default = 30s]
+
   # Name of network interface to read address from.
   # CLI flag: -alertmanager.sharding-ring.instance-interface-names
   [instance_interface_names: <list of string> | default = [eth0 en0]]
@@ -3945,6 +3949,10 @@ ring:
   # CLI flag: -ruler.ring.num-tokens
   [num_tokens: <int> | default = 128]
 
+  # The sleep seconds when ruler is shutting down.
+  # CLI flag: -ruler.ring.final-sleep
+  [final_sleep: <duration> | default = 30s]
+
 # Period with which to attempt to flush rule groups.
 # CLI flag: -ruler.flush-period
 [flush_period: <duration> | default = 1m]
@@ -4835,6 +4843,10 @@ sharding_ring:
   # anyway.
   # CLI flag: -store-gateway.sharding-ring.wait-stability-max-duration
   [wait_stability_max_duration: <duration> | default = 5m]
+
+  # The sleep seconds when store-gateway is shutting down.
+  # CLI flag: -store-gateway.sharding-ring.final-sleep
+  [final_sleep: <duration> | default = 0s]
 
   # Name of network interface to read address from.
   # CLI flag: -store-gateway.sharding-ring.instance-interface-names

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -108,3 +108,7 @@ Currently experimental features are:
 - Store Gateway Zone Stable Shuffle Sharding
   - `-store-gateway.sharding-ring.zone-stable-shuffle-sharding` CLI flag
   - `zone_stable_shuffle_sharding` (boolean) field in config file
+- Basic Lifecycler (Storegateway, Alertmanager, Ruler) Final Sleep on shutdown, which tells the pod wait before shutdown, allowing a delay to propagate ring changes.
+  - `-ruler.ring.final-sleep` (duration) CLI flag
+  - `store-gateway.sharding-ring.final-sleep` (duration) CLI flag
+  - `alertmanager-sharding-ring.final-sleep` (duration) CLI flag

--- a/pkg/alertmanager/alertmanager_ring.go
+++ b/pkg/alertmanager/alertmanager_ring.go
@@ -81,7 +81,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.KVStore.RegisterFlagsWithPrefix(rfprefix, "alertmanagers/", f)
 	f.DurationVar(&cfg.HeartbeatPeriod, rfprefix+"heartbeat-period", 15*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
 	f.DurationVar(&cfg.HeartbeatTimeout, rfprefix+"heartbeat-timeout", time.Minute, "The heartbeat timeout after which alertmanagers are considered unhealthy within the ring. 0 = never (timeout disabled).")
-	f.DurationVar(&cfg.FinalSleep, rfprefix+"final-sleep", 30*time.Second, "The sleep seconds when alertmanager is shutting down.")
+	f.DurationVar(&cfg.FinalSleep, rfprefix+"final-sleep", 0*time.Second, "The sleep seconds when alertmanager is shutting down. Need to be close to or larger than KV Store information propagation delay")
 	f.IntVar(&cfg.ReplicationFactor, rfprefix+"replication-factor", 3, "The replication factor to use when sharding the alertmanager.")
 	f.BoolVar(&cfg.ZoneAwarenessEnabled, rfprefix+"zone-awareness-enabled", false, "True to enable zone-awareness and replicate alerts across different availability zones.")
 

--- a/pkg/alertmanager/alertmanager_ring.go
+++ b/pkg/alertmanager/alertmanager_ring.go
@@ -49,6 +49,8 @@ type RingConfig struct {
 	ReplicationFactor    int           `yaml:"replication_factor"`
 	ZoneAwarenessEnabled bool          `yaml:"zone_awareness_enabled"`
 
+	FinalSleep time.Duration `yaml:"final_sleep"`
+
 	// Instance details
 	InstanceID             string   `yaml:"instance_id" doc:"hidden"`
 	InstanceInterfaceNames []string `yaml:"instance_interface_names"`
@@ -79,6 +81,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.KVStore.RegisterFlagsWithPrefix(rfprefix, "alertmanagers/", f)
 	f.DurationVar(&cfg.HeartbeatPeriod, rfprefix+"heartbeat-period", 15*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
 	f.DurationVar(&cfg.HeartbeatTimeout, rfprefix+"heartbeat-timeout", time.Minute, "The heartbeat timeout after which alertmanagers are considered unhealthy within the ring. 0 = never (timeout disabled).")
+	f.DurationVar(&cfg.FinalSleep, rfprefix+"final-sleep", 30*time.Second, "The sleep seconds when alertmanager is shutting down.")
 	f.IntVar(&cfg.ReplicationFactor, rfprefix+"replication-factor", 3, "The replication factor to use when sharding the alertmanager.")
 	f.BoolVar(&cfg.ZoneAwarenessEnabled, rfprefix+"zone-awareness-enabled", false, "True to enable zone-awareness and replicate alerts across different availability zones.")
 
@@ -110,6 +113,7 @@ func (cfg *RingConfig) ToLifecyclerConfig(logger log.Logger) (ring.BasicLifecycl
 		TokensObservePeriod: 0,
 		Zone:                cfg.InstanceZone,
 		NumTokens:           RingNumTokens,
+		FinalSleep:          cfg.FinalSleep,
 	}, nil
 }
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -82,6 +82,7 @@ func mockAlertmanagerConfig(t *testing.T) *MultitenantAlertmanagerConfig {
 	cfg.ShardingRing.InstanceID = "test"
 	cfg.ShardingRing.InstanceAddr = "127.0.0.1"
 	cfg.PollInterval = time.Minute
+	cfg.ShardingRing.FinalSleep = 0
 
 	return cfg
 }

--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -55,6 +55,8 @@ type BasicLifecyclerConfig struct {
 	// If true lifecycler doesn't unregister instance from the ring when it's stopping. Default value is false,
 	// which means unregistering.
 	KeepInstanceInTheRingOnShutdown bool
+
+	FinalSleep time.Duration
 }
 
 // BasicLifecycler is a basic ring lifecycler which allows to hook custom
@@ -225,6 +227,7 @@ func (l *BasicLifecycler) stopping(runningError error) error {
 	go func() {
 		defer close(done)
 		l.delegate.OnRingInstanceStopping(l)
+		time.Sleep(l.cfg.FinalSleep)
 	}()
 
 	// Heartbeat while the stopping delegate function is running.

--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -227,7 +227,6 @@ func (l *BasicLifecycler) stopping(runningError error) error {
 	go func() {
 		defer close(done)
 		l.delegate.OnRingInstanceStopping(l)
-		time.Sleep(l.cfg.FinalSleep)
 	}()
 
 	// Heartbeat while the stopping delegate function is running.
@@ -254,6 +253,7 @@ heartbeatLoop:
 		level.Info(l.logger).Log("msg", "instance removed from the ring", "ring", l.ringName)
 	}
 
+	time.Sleep(l.cfg.FinalSleep)
 	return nil
 }
 

--- a/pkg/ruler/ruler_ring.go
+++ b/pkg/ruler/ruler_ring.go
@@ -42,6 +42,8 @@ type RingConfig struct {
 	InstanceAddr           string   `yaml:"instance_addr" doc:"hidden"`
 	NumTokens              int      `yaml:"num_tokens"`
 
+	FinalSleep time.Duration `yaml:"final_sleep"`
+
 	// Injected internally
 	ListenPort int `yaml:"-"`
 
@@ -60,6 +62,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.KVStore.RegisterFlagsWithPrefix("ruler.ring.", "rulers/", f)
 	f.DurationVar(&cfg.HeartbeatPeriod, "ruler.ring.heartbeat-period", 5*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
 	f.DurationVar(&cfg.HeartbeatTimeout, "ruler.ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which rulers are considered unhealthy within the ring. 0 = never (timeout disabled).")
+	f.DurationVar(&cfg.FinalSleep, "ruler.ring.final-sleep", 30*time.Second, "The sleep seconds when ruler is shutting down.")
 
 	// Instance flags
 	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}
@@ -86,6 +89,7 @@ func (cfg *RingConfig) ToLifecyclerConfig(logger log.Logger) (ring.BasicLifecycl
 		HeartbeatPeriod:     cfg.HeartbeatPeriod,
 		TokensObservePeriod: 0,
 		NumTokens:           cfg.NumTokens,
+		FinalSleep:          cfg.FinalSleep,
 	}, nil
 }
 

--- a/pkg/ruler/ruler_ring.go
+++ b/pkg/ruler/ruler_ring.go
@@ -62,7 +62,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.KVStore.RegisterFlagsWithPrefix("ruler.ring.", "rulers/", f)
 	f.DurationVar(&cfg.HeartbeatPeriod, "ruler.ring.heartbeat-period", 5*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
 	f.DurationVar(&cfg.HeartbeatTimeout, "ruler.ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which rulers are considered unhealthy within the ring. 0 = never (timeout disabled).")
-	f.DurationVar(&cfg.FinalSleep, "ruler.ring.final-sleep", 30*time.Second, "The sleep seconds when ruler is shutting down.")
+	f.DurationVar(&cfg.FinalSleep, "ruler.ring.final-sleep", 0*time.Second, "The sleep seconds when ruler is shutting down. Need to be close to or larger than KV Store information propagation delay")
 
 	// Instance flags
 	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -74,6 +74,7 @@ func defaultRulerConfig(t testing.TB) Config {
 	cfg.Ring.ListenPort = 0
 	cfg.Ring.InstanceAddr = "localhost"
 	cfg.Ring.InstanceID = "localhost"
+	cfg.Ring.FinalSleep = 0
 	cfg.EnableQueryStats = false
 
 	return cfg

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -73,6 +73,8 @@ type RingConfig struct {
 	WaitStabilityMinDuration time.Duration `yaml:"wait_stability_min_duration"`
 	WaitStabilityMaxDuration time.Duration `yaml:"wait_stability_max_duration"`
 
+	FinalSleep time.Duration `yaml:"final_sleep"`
+
 	// Instance details
 	InstanceID             string   `yaml:"instance_id" doc:"hidden"`
 	InstanceInterfaceNames []string `yaml:"instance_interface_names"`
@@ -108,6 +110,8 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	// Wait stability flags.
 	f.DurationVar(&cfg.WaitStabilityMinDuration, ringFlagsPrefix+"wait-stability-min-duration", time.Minute, "Minimum time to wait for ring stability at startup. 0 to disable.")
 	f.DurationVar(&cfg.WaitStabilityMaxDuration, ringFlagsPrefix+"wait-stability-max-duration", 5*time.Minute, "Maximum time to wait for ring stability at startup. If the store-gateway ring keeps changing after this period of time, the store-gateway will start anyway.")
+
+	f.DurationVar(&cfg.FinalSleep, ringFlagsPrefix+"final-sleep", 0*time.Second, "The sleep seconds when store-gateway is shutting down.")
 
 	// Instance flags
 	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}
@@ -150,5 +154,6 @@ func (cfg *RingConfig) ToLifecyclerConfig(logger log.Logger) (ring.BasicLifecycl
 		TokensObservePeriod:             0,
 		NumTokens:                       RingNumTokens,
 		KeepInstanceInTheRingOnShutdown: cfg.KeepInstanceInTheRingOnShutdown,
+		FinalSleep:                      cfg.FinalSleep,
 	}, nil
 }

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -111,7 +111,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.WaitStabilityMinDuration, ringFlagsPrefix+"wait-stability-min-duration", time.Minute, "Minimum time to wait for ring stability at startup. 0 to disable.")
 	f.DurationVar(&cfg.WaitStabilityMaxDuration, ringFlagsPrefix+"wait-stability-max-duration", 5*time.Minute, "Maximum time to wait for ring stability at startup. If the store-gateway ring keeps changing after this period of time, the store-gateway will start anyway.")
 
-	f.DurationVar(&cfg.FinalSleep, ringFlagsPrefix+"final-sleep", 0*time.Second, "The sleep seconds when store-gateway is shutting down.")
+	f.DurationVar(&cfg.FinalSleep, ringFlagsPrefix+"final-sleep", 0*time.Second, "The sleep seconds when store-gateway is shutting down. Need to be close to or larger than KV Store information propagation delay")
 
 	// Instance flags
 	cfg.InstanceInterfaceNames = []string{"eth0", "en0"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Add a configurable final sleep to the ruler/alertmanager/store-gateway lifecycler. This is to overcome the information delay in the ring if DDB KV is used as the backend.
e.g Ruler-1 is stopping and set it self to LEAVING. The information takes about 30s to reach other ruler, within in this 30s, if other ruler takes a GetRules call, it will iterate all the rulers that it thinks are healthy. It will wrongfully think the LEAVING ruler is healthy. But in reality, the LEAVING ruler already shutdown itself (because we don't have any delay). Then the GetRules will fail (because we don't have HA, and we can not tolerate a single ruler failure)

The solution is to add a delay when the ruler set itself to LEAVING, during this LEAVING time, if other ruler send the request. This LEAVING ruler should be able to handle the request. After other ruler realized this ruler is LEAVING, they will stop to send further request to the LEAVING ruler. So we will be okay from then on.

Similar idea as in the lifeCycler, when the ingester is shutting itself down. I can still do the processShutdown duties and final sleep for 30s to scrape the metrics.

-----
Version 2:
Found out that if we sleep right after the instance is set to LEAVING. Then during this sleep time, other instances know this instance is LEAVING (but this instance is still in the ring), then we have another problem. https://github.com/cortexproject/cortex/blob/master/pkg/ring/ring.go#L556

So the error just changed from `unable to retrieve rules from ruler` to `too many unhealthy instances in the ring`

This is not what we wanted.

So, we propose to sleep after the instance is removed from the Ring. Then next heartbeat of the other instances will see this instance is removed. Then we won't have the `too many unhealthy instances in the ring`

This is a workaround for components that are still not HA yet (eg. ruler)


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
