### PR TITLE
Refactor to avoid keep the "limits override" 2 times on compactor

### DIFF
--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1663,7 +1663,7 @@ func prepare(t *testing.T, compactorCfg Config, bucketClient objstore.Bucket, li
 		blocksGrouperFactory = DefaultBlocksGrouperFactory
 	}
 
-	c, err := newCompactor(compactorCfg, storageCfg, overrides, logger, registry, bucketClientFactory, blocksGrouperFactory, blocksCompactorFactory, overrides)
+	c, err := newCompactor(compactorCfg, storageCfg, logger, registry, bucketClientFactory, blocksGrouperFactory, blocksCompactorFactory, overrides)
 	require.NoError(t, err)
 
 	return c, tsdbCompactor, tsdbPlanner, logs, registry

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -656,7 +656,7 @@ func (t *Cortex) initAlertManager() (serv services.Service, err error) {
 func (t *Cortex) initCompactor() (serv services.Service, err error) {
 	t.Cfg.Compactor.ShardingRing.ListenPort = t.Cfg.Server.GRPCListenPort
 
-	t.Compactor, err = compactor.NewCompactor(t.Cfg.Compactor, t.Cfg.BlocksStorage, t.Overrides, util_log.Logger, prometheus.DefaultRegisterer, t.Overrides)
+	t.Compactor, err = compactor.NewCompactor(t.Cfg.Compactor, t.Cfg.BlocksStorage, util_log.Logger, prometheus.DefaultRegisterer, t.Overrides)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
**What this PR does**:
This is just a small refactor:

Setting `t.Overrides` reference just once on the compactor and doing so, the same reference can be used on both interfaces: `ConfigProvider` and `Limits`.

Keeping the reference as `*validation.Overrides` is already the case on other components like ingesters:

https://github.com/cortexproject/cortex/blob/c56d882c624bf6c4ad432add8bac56fabce75862/pkg/ingester/ingester.go#L178-L187

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [NA] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
