### PR TITLE
Fix possible division by zero during compactor config validation

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -251,6 +251,11 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 func (cfg *Config) Validate(limits validation.Limits) error {
+	for _, blockRange := range cfg.BlockRanges {
+		if blockRange == 0 {
+			return errors.New("compactor block range period cannot be zero")
+		}
+	}
 	// Each block range period should be divisible by the previous one.
 	for i := 1; i < len(cfg.BlockRanges); i++ {
 		if cfg.BlockRanges[i]%cfg.BlockRanges[i-1] != 0 {

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -115,6 +115,13 @@ func TestConfig_Validate(t *testing.T) {
 			initLimits: func(_ *validation.Limits) {},
 			expected:   errors.Errorf(errInvalidBlockRanges, 30*time.Hour, 24*time.Hour).Error(),
 		},
+		"should fail with duration values of zero": {
+			setup: func(cfg *Config) {
+				cfg.BlockRanges = cortex_tsdb.DurationList{2 * time.Hour, 0, 24 * time.Hour, 30 * time.Hour}
+			},
+			initLimits: func(_ *validation.Limits) {},
+			expected:   errors.Errorf("compactor block range period cannot be zero").Error(),
+		},
 		"should pass with valid shuffle sharding config": {
 			setup: func(cfg *Config) {
 				cfg.ShardingStrategy = util.ShardingStrategyShuffle


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This adds additional validation logic to ensure there are no duration values of zero in the compactor's BlockRanges config. If there are, the next validation rule would panic when trying to divide by zero. 

(I considered adding the check to the existing code, but a period of 0 here is invalid anyway, for a different reason)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
