### PR TITLE
[AlertManager] Handling CMK AccessDenied errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [ENHANCEMENT] Compactor: allow unregisteronshutdown to be configurable. #5503
 * [ENHANCEMENT] Store Gateway: add metric `cortex_bucket_store_chunk_refetches_total` for number of chunk refetches. #5532
 * [ENHANCEMENT] BasicLifeCycler: allow final-sleep during shutdown #5517
+* [ENHANCEMENT] All: Handling CMK Access Denied errors. #5420 #5542
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/pkg/alertmanager/alertspb/compat.go
+++ b/pkg/alertmanager/alertspb/compat.go
@@ -3,7 +3,8 @@ package alertspb
 import "errors"
 
 var (
-	ErrNotFound = errors.New("alertmanager storage object not found")
+	ErrNotFound     = errors.New("alertmanager storage object not found")
+	ErrAccessDenied = errors.New("alertmanager storage object access denied")
 )
 
 // ToProto transforms a yaml Alertmanager config and map of template files to an AlertConfigDesc

--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/thanos-io/objstore"
+
+	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 
 	"github.com/cortexproject/cortex/pkg/alertmanager/alertspb"
 	"github.com/cortexproject/cortex/pkg/storage/bucket"

--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
@@ -76,8 +77,8 @@ func (s *BucketAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string
 	err := concurrency.ForEach(ctx, concurrency.CreateJobsFromStrings(userIDs), fetchConcurrency, func(ctx context.Context, job interface{}) error {
 		userID := job.(string)
 
-		cfg, err := s.getAlertConfig(ctx, userID)
-		if s.alertsBucket.IsObjNotFoundErr(err) {
+		cfg, uBucket, err := s.getAlertConfig(ctx, userID)
+		if uBucket.IsObjNotFoundErr(err) || uBucket.IsAccessDeniedErr(err) {
 			return nil
 		} else if err != nil {
 			return errors.Wrapf(err, "failed to fetch alertmanager config for user %s", userID)
@@ -95,9 +96,13 @@ func (s *BucketAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string
 
 // GetAlertConfig implements alertstore.AlertStore.
 func (s *BucketAlertStore) GetAlertConfig(ctx context.Context, userID string) (alertspb.AlertConfigDesc, error) {
-	cfg, err := s.getAlertConfig(ctx, userID)
-	if s.alertsBucket.IsObjNotFoundErr(err) {
+	cfg, uBucket, err := s.getAlertConfig(ctx, userID)
+	if uBucket.IsObjNotFoundErr(err) {
 		return cfg, alertspb.ErrNotFound
+	}
+
+	if uBucket.IsAccessDeniedErr(err) {
+		return cfg, alertspb.ErrAccessDenied
 	}
 
 	return cfg, err
@@ -142,8 +147,12 @@ func (s *BucketAlertStore) GetFullState(ctx context.Context, userID string) (ale
 	fs := alertspb.FullStateDesc{}
 
 	err := s.get(ctx, bkt, fullStateName, &fs)
-	if s.amBucket.IsObjNotFoundErr(err) {
+	if bkt.IsObjNotFoundErr(err) {
 		return fs, alertspb.ErrNotFound
+	}
+
+	if bkt.IsAccessDeniedErr(err) {
+		return fs, alertspb.ErrAccessDenied
 	}
 
 	return fs, err
@@ -172,10 +181,11 @@ func (s *BucketAlertStore) DeleteFullState(ctx context.Context, userID string) e
 	return err
 }
 
-func (s *BucketAlertStore) getAlertConfig(ctx context.Context, userID string) (alertspb.AlertConfigDesc, error) {
+func (s *BucketAlertStore) getAlertConfig(ctx context.Context, userID string) (alertspb.AlertConfigDesc, objstore.Bucket, error) {
 	config := alertspb.AlertConfigDesc{}
-	err := s.get(ctx, s.getUserBucket(userID), userID, &config)
-	return config, err
+	userBkt := s.getUserBucket(userID)
+	err := s.get(ctx, userBkt, userID, &config)
+	return config, userBkt, err
 }
 
 func (s *BucketAlertStore) get(ctx context.Context, bkt objstore.Bucket, name string, msg proto.Message) error {
@@ -205,5 +215,6 @@ func (s *BucketAlertStore) getUserBucket(userID string) objstore.Bucket {
 }
 
 func (s *BucketAlertStore) getAlertmanagerUserBucket(userID string) objstore.Bucket {
-	return bucket.NewUserBucketClient(userID, s.amBucket, s.cfgProvider).WithExpectedErrs(s.amBucket.IsObjNotFoundErr)
+	uBucket := bucket.NewUserBucketClient(userID, s.amBucket, s.cfgProvider)
+	return uBucket.WithExpectedErrs(tsdb.IsOneOfTheExpectedErrors(uBucket.IsAccessDeniedErr, uBucket.IsObjNotFoundErr))
 }

--- a/pkg/alertmanager/state_replication.go
+++ b/pkg/alertmanager/state_replication.go
@@ -29,6 +29,7 @@ const (
 	syncFromReplica  = "from-replica"
 	syncFromStorage  = "from-storage"
 	syncUserNotFound = "user-not-found"
+	syncAccessDenied = "user-access-denied"
 	syncFailed       = "failed"
 )
 
@@ -230,6 +231,11 @@ func (s *state) starting(ctx context.Context) error {
 	if errors.Is(err, alertspb.ErrNotFound) {
 		level.Info(s.logger).Log("msg", "no state for user in storage; proceeding", "user", s.userID)
 		s.initialSyncCompleted.WithLabelValues(syncUserNotFound).Inc()
+		return nil
+	}
+	if errors.Is(err, alertspb.ErrAccessDenied) {
+		level.Info(s.logger).Log("msg", "access deinied when trying to access user storage; proceeding", "user", s.userID)
+		s.initialSyncCompleted.WithLabelValues(syncAccessDenied).Inc()
 		return nil
 	}
 	if err == nil {


### PR DESCRIPTION
**What this PR does**:
This is a continuation of https://github.com/cortexproject/cortex/pull/5420

Handling access denied errors when cortex lose the access to the CMK (causing access denied on the objstorage).

In those cases AM will crash and fail to start as shown below:

```
  ts=2023-08-31T19:21:28.327076006Z caller=cortex.go:444 level=error msg="module failed" module=alertmanager err="invalid service state: Failed, expected: Running, failure: failed to load alertmanager configurations for owned users: failed to fetch alertmanager config for user REDACTED: User: REDACTED is not authorized to perform: kms:Decrypt on the resource associated with this ciphertext because the resource does not exist in this Region, no resource-based policies allow access, or a resource-based policy explicitly denies access"
```

This change is handling the access denied errors the same way AM handler the NotFoundErrors (ignoring) 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
