### PR TITLE
Retry WriteIndex on bucketUpload

### DIFF
--- a/pkg/storage/tsdb/bucketindex/storage.go
+++ b/pkg/storage/tsdb/bucketindex/storage.go
@@ -125,7 +125,7 @@ func WriteIndex(ctx context.Context, bkt objstore.Bucket, userID string, cfgProv
 	}
 
 	// Upload the index to the storage.
-	if err := bkt.Upload(ctx, IndexCompressedFilename, &gzipContent); err != nil {
+	if err := bkt.Upload(ctx, IndexCompressedFilename, bytes.NewReader(gzipContent.Bytes())); err != nil {
 		return errors.Wrap(err, "upload bucket index")
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Return a Reader which implement Seek interface to be able to retry the upload of index in s3

https://github.com/cortexproject/cortex/blob/baa9d27889a1790359a80943685d4c7695e66e9e/pkg/storage/bucket/s3/bucket_client.go#L176

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
