### PR TITLE
Creating new metric around chunks bytespool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [CHANGE] Store Gateway: Remove `idle_timeout`, `max_conn_age`, `pool_size`, `min_idle_conns` fields for Redis index cache and caching bucket. #5448
 * [CHANGE] Store Gateway: Add flag `-store-gateway.sharding-ring.zone-stable-shuffle-sharding` to enable store gateway to use zone stable shuffle sharding. #5489
 * [CHANGE] Bucket Index: Add `series_max_size` and `chunk_max_size` to bucket index. #5489
+* [CHANGE] StoreGateway: Rename `cortex_bucket_store_chunk_pool_returned_bytes_total` and `cortex_bucket_store_chunk_pool_requested_bytes_total` to `cortex_bucket_store_chunk_pool_operation_bytes_total`. #5552
 * [CHANGE] Query Frontend/Querier: Make build info API disabled by default and add feature flag `api.build-info-enabled` to enable it. #5533
 * [FEATURE] Store Gateway: Add `max_downloaded_bytes_per_request` to limit max bytes to download per store gateway request.
 * [FEATURE] Added 2 flags `-alertmanager.alertmanager-client.grpc-max-send-msg-size` and ` -alertmanager.alertmanager-client.grpc-max-recv-msg-size` to configure alert manager grpc client message size limits. #5338

--- a/pkg/storegateway/chunk_bytes_pool.go
+++ b/pkg/storegateway/chunk_bytes_pool.go
@@ -12,6 +12,8 @@ type chunkBytesPool struct {
 	// Metrics.
 	requestedBytes prometheus.Counter
 	returnedBytes  prometheus.Counter
+
+	poolByteStats *prometheus.CounterVec
 }
 
 func newChunkBytesPool(minBucketSize, maxBucketSize int, maxChunkPoolBytes uint64, reg prometheus.Registerer) (*chunkBytesPool, error) {
@@ -30,6 +32,10 @@ func newChunkBytesPool(minBucketSize, maxBucketSize int, maxChunkPoolBytes uint6
 			Name: "cortex_bucket_store_chunk_pool_returned_bytes_total",
 			Help: "Total bytes returned by the chunk bytes pool.",
 		}),
+		poolByteStats: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_bucket_store_chunk_pool_bytes_total",
+			Help: "Total bytes polled by the chunk bytes pool by operation.",
+		}, []string{"operation", "stats"}),
 	}, nil
 }
 
@@ -42,9 +48,15 @@ func (p *chunkBytesPool) Get(sz int) (*[]byte, error) {
 	p.requestedBytes.Add(float64(sz))
 	p.returnedBytes.Add(float64(cap(*buffer)))
 
+	p.poolByteStats.WithLabelValues("Get", "requested").Add(float64(sz))
+	p.poolByteStats.WithLabelValues("Get", "len").Add(float64(len(*buffer)))
+	p.poolByteStats.WithLabelValues("Get", "cap").Add(float64(cap(*buffer)))
+
 	return buffer, err
 }
 
 func (p *chunkBytesPool) Put(b *[]byte) {
+	p.poolByteStats.WithLabelValues("Put", "len").Add(float64(len(*b)))
+	p.poolByteStats.WithLabelValues("Put", "cap").Add(float64(cap(*b)))
 	p.pool.Put(b)
 }

--- a/pkg/storegateway/chunk_bytes_pool.go
+++ b/pkg/storegateway/chunk_bytes_pool.go
@@ -10,9 +10,6 @@ type chunkBytesPool struct {
 	pool *pool.BucketedBytes
 
 	// Metrics.
-	requestedBytes prometheus.Counter
-	returnedBytes  prometheus.Counter
-
 	poolByteStats *prometheus.CounterVec
 }
 
@@ -24,17 +21,9 @@ func newChunkBytesPool(minBucketSize, maxBucketSize int, maxChunkPoolBytes uint6
 
 	return &chunkBytesPool{
 		pool: upstream,
-		requestedBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_bucket_store_chunk_pool_requested_bytes_total",
-			Help: "Total bytes requested to chunk bytes pool.",
-		}),
-		returnedBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_bucket_store_chunk_pool_returned_bytes_total",
-			Help: "Total bytes returned by the chunk bytes pool.",
-		}),
 		poolByteStats: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_bucket_store_chunk_pool_bytes_total",
-			Help: "Total bytes polled by the chunk bytes pool by operation.",
+			Help: "Total bytes number of bytes pooled by operation.",
 		}, []string{"operation", "stats"}),
 	}, nil
 }
@@ -45,18 +34,14 @@ func (p *chunkBytesPool) Get(sz int) (*[]byte, error) {
 		return buffer, err
 	}
 
-	p.requestedBytes.Add(float64(sz))
-	p.returnedBytes.Add(float64(cap(*buffer)))
-
-	p.poolByteStats.WithLabelValues("Get", "requested").Add(float64(sz))
-	p.poolByteStats.WithLabelValues("Get", "len").Add(float64(len(*buffer)))
-	p.poolByteStats.WithLabelValues("Get", "cap").Add(float64(cap(*buffer)))
+	p.poolByteStats.WithLabelValues("Get", "Requested").Add(float64(sz))
+	p.poolByteStats.WithLabelValues("Get", "Cap").Add(float64(cap(*buffer)))
 
 	return buffer, err
 }
 
 func (p *chunkBytesPool) Put(b *[]byte) {
-	p.poolByteStats.WithLabelValues("Put", "len").Add(float64(len(*b)))
-	p.poolByteStats.WithLabelValues("Put", "cap").Add(float64(cap(*b)))
+	p.poolByteStats.WithLabelValues("Put", "Len").Add(float64(len(*b)))
+	p.poolByteStats.WithLabelValues("Put", "Cap").Add(float64(cap(*b)))
 	p.pool.Put(b)
 }

--- a/pkg/storegateway/chunk_bytes_pool.go
+++ b/pkg/storegateway/chunk_bytes_pool.go
@@ -22,7 +22,7 @@ func newChunkBytesPool(minBucketSize, maxBucketSize int, maxChunkPoolBytes uint6
 	return &chunkBytesPool{
 		pool: upstream,
 		poolByteStats: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_bucket_store_chunk_pool_bytes_total",
+			Name: "cortex_bucket_store_chunk_pool_operation_bytes_total",
 			Help: "Total bytes number of bytes pooled by operation.",
 		}, []string{"operation", "stats"}),
 	}, nil
@@ -34,14 +34,14 @@ func (p *chunkBytesPool) Get(sz int) (*[]byte, error) {
 		return buffer, err
 	}
 
-	p.poolByteStats.WithLabelValues("Get", "Requested").Add(float64(sz))
-	p.poolByteStats.WithLabelValues("Get", "Cap").Add(float64(cap(*buffer)))
+	p.poolByteStats.WithLabelValues("get", "requested").Add(float64(sz))
+	p.poolByteStats.WithLabelValues("get", "cap").Add(float64(cap(*buffer)))
 
 	return buffer, err
 }
 
 func (p *chunkBytesPool) Put(b *[]byte) {
-	p.poolByteStats.WithLabelValues("Put", "Len").Add(float64(len(*b)))
-	p.poolByteStats.WithLabelValues("Put", "Cap").Add(float64(cap(*b)))
+	p.poolByteStats.WithLabelValues("put", "len").Add(float64(len(*b)))
+	p.poolByteStats.WithLabelValues("put", "cap").Add(float64(cap(*b)))
 	p.pool.Put(b)
 }

--- a/pkg/storegateway/chunk_bytes_pool_test.go
+++ b/pkg/storegateway/chunk_bytes_pool_test.go
@@ -31,11 +31,11 @@ func TestChunkBytesPool_Get(t *testing.T) {
 	p.Put(b)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(fmt.Sprintf(`
-		# HELP cortex_bucket_store_chunk_pool_bytes_total Total bytes number of bytes pooled by operation.
-		# TYPE cortex_bucket_store_chunk_pool_bytes_total counter
-		cortex_bucket_store_chunk_pool_bytes_total{operation="Get",stats="Cap"} %d
-		cortex_bucket_store_chunk_pool_bytes_total{operation="Get",stats="Requested"} %d
-		cortex_bucket_store_chunk_pool_bytes_total{operation="Put",stats="Cap"} %d
-		cortex_bucket_store_chunk_pool_bytes_total{operation="Put",stats="Len"} %d
+		# HELP cortex_bucket_store_chunk_pool_operation_bytes_total Total bytes number of bytes pooled by operation.
+		# TYPE cortex_bucket_store_chunk_pool_operation_bytes_total counter
+		cortex_bucket_store_chunk_pool_operation_bytes_total{operation="get",stats="cap"} %d
+		cortex_bucket_store_chunk_pool_operation_bytes_total{operation="get",stats="requested"} %d
+		cortex_bucket_store_chunk_pool_operation_bytes_total{operation="put",stats="cap"} %d
+		cortex_bucket_store_chunk_pool_operation_bytes_total{operation="put",stats="len"} %d
 	`, store.EstimatedMaxChunkSize*3, store.EstimatedMaxChunkSize*2, store.EstimatedMaxChunkSize*2, len(testBytes)))))
 }

--- a/pkg/storegateway/chunk_bytes_pool_test.go
+++ b/pkg/storegateway/chunk_bytes_pool_test.go
@@ -19,20 +19,23 @@ func TestChunkBytesPool_Get(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	p, err := newChunkBytesPool(cortex_tsdb.ChunkPoolDefaultMinBucketSize, cortex_tsdb.ChunkPoolDefaultMaxBucketSize, 0, reg)
 	require.NoError(t, err)
-
+	testBytes := []byte("test")
 	_, err = p.Get(store.EstimatedMaxChunkSize - 1)
 	require.NoError(t, err)
 
-	_, err = p.Get(store.EstimatedMaxChunkSize + 1)
+	b, err := p.Get(store.EstimatedMaxChunkSize + 1)
 	require.NoError(t, err)
 
-	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(fmt.Sprintf(`
-		# HELP cortex_bucket_store_chunk_pool_requested_bytes_total Total bytes requested to chunk bytes pool.
-		# TYPE cortex_bucket_store_chunk_pool_requested_bytes_total counter
-		cortex_bucket_store_chunk_pool_requested_bytes_total %d
+	*b = append(*b, testBytes...)
 
-		# HELP cortex_bucket_store_chunk_pool_returned_bytes_total Total bytes returned by the chunk bytes pool.
-		# TYPE cortex_bucket_store_chunk_pool_returned_bytes_total counter
-		cortex_bucket_store_chunk_pool_returned_bytes_total %d
-	`, store.EstimatedMaxChunkSize*2, store.EstimatedMaxChunkSize*3))))
+	p.Put(b)
+
+	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(fmt.Sprintf(`
+		# HELP cortex_bucket_store_chunk_pool_bytes_total Total bytes number of bytes pooled by operation.
+		# TYPE cortex_bucket_store_chunk_pool_bytes_total counter
+		cortex_bucket_store_chunk_pool_bytes_total{operation="Get",stats="Cap"} %d
+		cortex_bucket_store_chunk_pool_bytes_total{operation="Get",stats="Requested"} %d
+		cortex_bucket_store_chunk_pool_bytes_total{operation="Put",stats="Cap"} %d
+		cortex_bucket_store_chunk_pool_bytes_total{operation="Put",stats="Len"} %d
+	`, store.EstimatedMaxChunkSize*3, store.EstimatedMaxChunkSize*2, store.EstimatedMaxChunkSize*2, len(testBytes)))))
 }


### PR DESCRIPTION

**What this PR does**:
Create new `cortex_bucket_store_chunk_pool_bytes_total` to add metrics around the byte slices returned to the pool.

This metric has a overlap with the existing ones - which should be deprecated if this PR is accepted.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
