### PR TITLE
Small enhancement to doc generator to account for slices

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2857,7 +2857,7 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # List of metric relabel configurations. Note that in most situations, it is
 # more effective to use metrics relabeling directly in the Prometheus server,
 # e.g. remote_write.write_relabel_configs.
-[metric_relabel_configs: <relabel_config...> | default = ]
+[metric_relabel_configs: <relabel_config...> | default = []]
 
 # Enables support for exemplars in TSDB and sets the maximum number that will be
 # stored. less than zero means disabled. If the value is set to zero, cortex
@@ -3099,7 +3099,7 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 [alertmanager_max_alerts_size_bytes: <int> | default = 0]
 
 # list of rule groups to disable
-[disabled_rule_groups: <list of rule groups to disable> | default = ]
+[disabled_rule_groups: <list of DisabledRuleGroup> | default = []]
 ```
 
 ### `memberlist_config`
@@ -3719,7 +3719,7 @@ The `ruler_config` configures the Cortex ruler.
 [external_url: <url> | default = ]
 
 # Labels to add to all alerts.
-[external_labels: <map of string to string> | default = ]
+[external_labels: <list of Label> | default = []]
 
 ruler_client:
   # gRPC client max receive message size (bytes).
@@ -4931,4 +4931,22 @@ otel:
     # Skip validating server certificate.
     # CLI flag: -tracing.otel.tls.tls-insecure-skip-verify
     [tls_insecure_skip_verify: <boolean> | default = false]
+```
+
+### `DisabledRuleGroup`
+
+```yaml
+# namespace in which the rule group belongs
+[namespace: <string> | default = ""]
+
+# name of the rule group
+[name: <string> | default = ""]
+```
+
+### `Label`
+
+```yaml
+[name: <string> | default = ""]
+
+[value: <string> | default = ""]
 ```

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -39,9 +39,9 @@ func (e LimitError) Error() string {
 }
 
 type DisabledRuleGroup struct {
-	Namespace string `yaml:"namespace"`
-	Name      string `yaml:"name"`
-	User      string `yaml:"-"`
+	Namespace string `yaml:"namespace" doc:"nocli|description=namespace in which the rule group belongs"`
+	Name      string `yaml:"name" doc:"nocli|description=name of the rule group"`
+	User      string `yaml:"-" doc:"nocli"`
 }
 
 type DisabledRuleGroups []DisabledRuleGroup

--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -46,6 +46,11 @@ const (
 )
 
 var (
+	typesToIgnoreCLI = map[string]bool{
+		"labels.Label": true,
+		"flagext.CIDR": true,
+	}
+
 	// Ordered list of root blocks. The order is the same order that will
 	// follow the markdown generation.
 	rootBlocks = []rootBlock{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

When we added a slice of struct to limits config, we noticed the doc generator produces something like below

[disabled_rule_groups: <list of rule groups to disable> | default = ]

It would be nice to document the structure of DisabledRuleGroup type in the documentation. This PR modifies the parse function and if the config is a slice of struct, then it appends a [root block at the end](https://github.com/cortexproject/cortex/pull/5557/files#diff-cb926e77cd909b1b1b3c064945736ad4515cd2bb5a6a81f46bc59542bdb6409aR4936)

However if we want to insert a root block right after the current block, then it would require some additional changes

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
