### PR TITLE
Retry more errors in block storage querier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * [ENHANCEMENT] Store Gateway: add metric `cortex_bucket_store_chunk_refetches_total` for number of chunk refetches. #5532
 * [ENHANCEMENT] BasicLifeCycler: allow final-sleep during shutdown #5517
 * [ENHANCEMENT] All: Handling CMK Access Denied errors. #5420 #5542
+* [ENHANCEMENT] Querier: Retry store gateway chunk pool exhaustion error and client connection closing gRPC error. #5558
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 * [ENHANCEMENT] Store Gateway: add metric `cortex_bucket_store_chunk_refetches_total` for number of chunk refetches. #5532
 * [ENHANCEMENT] BasicLifeCycler: allow final-sleep during shutdown #5517
 * [ENHANCEMENT] All: Handling CMK Access Denied errors. #5420 #5542
-* [ENHANCEMENT] Querier: Retry store gateway chunk pool exhaustion error and client connection closing gRPC error. #5558
+* [ENHANCEMENT] Querier: Retry store gateway client connection closing gRPC error. #5558
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -1123,8 +1123,6 @@ func isRetryableError(err error) bool {
 	case codes.Canceled:
 		return strings.Contains(err.Error(), "grpc: the client connection is closing")
 	// TODO(yeya24): change Thanos to use ResourceExhausted for chunk pool error.
-	case codes.Unknown:
-		return strings.Contains(err.Error(), "allocate chunk bytes")
 	default:
 		return false
 	}

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -1122,7 +1122,6 @@ func isRetryableError(err error) bool {
 	// https://github.com/grpc/grpc-go/blob/03172006f5d168fc646d87928d85cb9c4a480291/clientconn.go#L67
 	case codes.Canceled:
 		return strings.Contains(err.Error(), "grpc: the client connection is closing")
-	// TODO(yeya24): change Thanos to use ResourceExhausted for chunk pool error.
 	default:
 		return false
 	}

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -1118,6 +1118,13 @@ func isRetryableError(err error) bool {
 		return true
 	case codes.ResourceExhausted:
 		return errors.Is(err, storegateway.ErrTooManyInflightRequests)
+	// Client side connection closing, this error happens during store gateway deployment.
+	// https://github.com/grpc/grpc-go/blob/03172006f5d168fc646d87928d85cb9c4a480291/clientconn.go#L67
+	case codes.Canceled:
+		return strings.Contains(err.Error(), "grpc: the client connection is closing")
+	// TODO(yeya24): change Thanos to use ResourceExhausted for chunk pool error.
+	case codes.Unknown:
+		return strings.Contains(err.Error(), "allocate chunk bytes")
 	default:
 		return false
 	}

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -647,7 +647,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 				map[BlocksStoreClient][]ulid.ULID{
 					&storeGatewayClientMock{
 						remoteAddr:      "1.1.1.1",
-						mockedSeriesErr: grpc.ErrClientConnClosing,
+						mockedSeriesErr: status.Error(codes.Canceled, "grpc: the client connection is closing"),
 					}: {block1},
 				},
 				map[BlocksStoreClient][]ulid.ULID{

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -668,35 +668,6 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 				},
 			},
 		},
-		"multiple store-gateways has the block, but one of them fails to return due to chunk pool exhaustion": {
-			finderResult: bucketindex.Blocks{
-				{ID: block1},
-			},
-			storeSetResponses: []interface{}{
-				map[BlocksStoreClient][]ulid.ULID{
-					&storeGatewayClientMock{
-						remoteAddr:      "1.1.1.1",
-						mockedSeriesErr: status.Error(codes.Unknown, "load chunks: populate chunk: allocate chunk bytes: pool exhausted"),
-					}: {block1},
-				},
-				map[BlocksStoreClient][]ulid.ULID{
-					&storeGatewayClientMock{remoteAddr: "2.2.2.2", mockedSeriesResponses: []*storepb.SeriesResponse{
-						mockSeriesResponse(labels.Labels{metricNameLabel, series1Label}, minT, 2),
-						mockHintsResponse(block1),
-					}}: {block1},
-				},
-			},
-			limits:       &blocksStoreLimitsMock{},
-			queryLimiter: noOpQueryLimiter,
-			expectedSeries: []seriesResult{
-				{
-					lbls: labels.New(metricNameLabel, series1Label),
-					values: []valueResult{
-						{t: minT, v: 2},
-					},
-				},
-			},
-		},
 		"all store-gateways return PermissionDenied": {
 			finderResult: bucketindex.Blocks{
 				{ID: block1},


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

We don't want to retry all 5xxs as in Thanos most of the errors will become `Unknown` gRPC status code, which becomes 5xx in Cortex. But not all of them are retriable.

This pr adds retry client conn closing error. 

Previously only `codes.Unavailable` got retried. This will cause issues for instant query as we only retry range queries. And the querier retry feature is not fully utilized.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
