### PR TITLE
Retry chunk pool exhaustion error at querier

### DIFF
--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -3,7 +3,6 @@ package querier
 import (
 	"context"
 	"fmt"
-	"github.com/thanos-io/thanos/pkg/pool"
 	"io"
 	"sort"
 	"strings"
@@ -24,6 +23,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/extprom"
+	"github.com/thanos-io/thanos/pkg/pool"
 	"github.com/thanos-io/thanos/pkg/store/hintspb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/thanos-io/thanos/pkg/strutil"
@@ -1114,8 +1114,6 @@ func countSamplesAndChunks(series ...*storepb.Series) (samplesCount, chunksCount
 
 // only retry connection issues
 func isRetryableError(err error) bool {
-	s := status.Convert(err)
-	s.Err()
 	switch status.Code(err) {
 	case codes.Unavailable:
 		return true


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Retry chunk pool exhaustion error at querier, but ignore it at query frontend retry middleware.

The idea is that when a request got chunk pool exhaustion error, retrying the whole query at query frontend is more expensive than retry at querier as querier only retries a single request so few blocks.

If the request still failed after 3 retries at querier, then we don't have to retry at query frontend again as the fleets might already overloaded.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
