### PR TITLE
Check context before notifying frontend and scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * [ENHANCEMENT] All: Handling CMK Access Denied errors. #5420 #5542
 * [ENHANCEMENT] Querier: Retry store gateway client connection closing gRPC error. #5558
 * [ENHANCEMENT] QueryFrontend: Add generic retry for all APIs. #5561.
+* [ENHANCEMENT] Querier: Check context before notifying scheduler and frontend. #5565
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286
 * [BUGFIX] Alertmanager: Route web-ui requests to the alertmanager distributor when sharding is enabled. #5293

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -158,6 +158,10 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 			logger := util_log.WithContext(ctx, sp.log)
 			sp.runRequest(ctx, logger, request.QueryID, request.FrontendAddress, request.StatsEnabled, request.HttpRequest)
 
+			if err = ctx.Err(); err != nil {
+				return
+			}
+
 			// Report back to scheduler that processing of the query has finished.
 			if err := c.Send(&schedulerpb.QuerierToScheduler{}); err != nil {
 				level.Error(logger).Log("msg", "error notifying scheduler about finished query", "err", err, "addr", address)
@@ -185,6 +189,10 @@ func (sp *schedulerProcessor) runRequest(ctx context.Context, logger log.Logger,
 	}
 	if statsEnabled {
 		level.Info(logger).Log("msg", "finished request", "status_code", response.Code, "response_size", len(response.GetBody()))
+	}
+
+	if err = ctx.Err(); err != nil {
+		return
 	}
 
 	// Ensure responses that are too big are not retried.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

We have two extra logs when the query times out:

```
ts=2023-08-29T15:57:55.2976267Z caller=scheduler_processor.go:187 level=info msg="finished request" status_code=499 response_size=95

ts=2023-08-29T15:57:55.297738564Z caller=scheduler_processor.go:211 level=error msg="error notifying frontend about finished query" err="rpc error: code = Canceled desc = context canceled" frontend=10.1.121.156:9095

ts=2023-08-29T15:57:55.297766783Z caller=scheduler_processor.go:163 level=error msg="error notifying scheduler about finished query" err=EOF addr=10.1.126.155:9095
```

We can check the context before notifying the frontend and scheduler if context error is not nil.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
