### PR TITLE
can not use errors wrap, otherwise httpgrpc error will be converted t…

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -17,7 +17,6 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
@@ -284,10 +283,7 @@ func TestDistributor_Push(t *testing.T) {
 				request := makeWriteRequest(tc.samples.startTimestampMs, tc.samples.num, tc.metadata)
 				response, err := ds[0].Push(ctx, request)
 				assert.Equal(t, tc.expectedResponse, response)
-				if err != nil {
-					err = errors.Cause(err)
-				}
-				assert.Equal(t, tc.expectedError, err)
+				assert.Equal(t, status.Code(tc.expectedError), status.Code(err))
 
 				// Check tracked Prometheus metrics. Since the Push() response is sent as soon as the quorum
 				// is reached, when we reach this point the 3rd ingester may not have received series/metadata

--- a/pkg/ring/batch.go
+++ b/pkg/ring/batch.go
@@ -3,12 +3,12 @@ package ring
 import (
 	"context"
 	"fmt"
-	"github.com/cortexproject/cortex/pkg/util/httpgrpcutil"
 	"sync"
 
+	"go.uber.org/atomic"
 	"google.golang.org/grpc/status"
 
-	"go.uber.org/atomic"
+	"github.com/cortexproject/cortex/pkg/util/httpgrpcutil"
 )
 
 type batchTracker struct {
@@ -152,7 +152,7 @@ func (b *batchTracker) record(instance instance, err error) {
 		if err != nil {
 			// Track the number of errors by error family, and if it exceeds maxFailures
 			// shortcut the waiting rpc.
-			wrappedErr := httpgrpcutil.WrapHttpGrpcError(err, "addr=%s state=%s zone=%s", instance.desc.Addr, instance.desc.State, instance.desc.Zone)
+			wrappedErr := httpgrpcutil.WrapHTTPGrpcError(err, "addr=%s state=%s zone=%s", instance.desc.Addr, instance.desc.State, instance.desc.Zone)
 			errCount := instance.itemTrackers[i].recordError(wrappedErr)
 			// We should return an error if we reach the maxFailure (quorum) on a given error family OR
 			// we dont have any remaining ingesters to try
@@ -162,13 +162,13 @@ func (b *batchTracker) record(instance instance, err error) {
 			// Ex: 5xx, _, 5xx -> return 5xx
 			if errCount > int32(sampleTrackers[i].maxFailures) {
 				if b.rpcsFailed.Inc() == 1 {
-					b.err <- httpgrpcutil.WrapHttpGrpcError(sampleTrackers[i].getError(), "maxFailure (quorum) on a given error family")
+					b.err <- httpgrpcutil.WrapHTTPGrpcError(sampleTrackers[i].getError(), "maxFailure (quorum) on a given error family")
 				}
 				continue
 			}
 			if sampleTrackers[i].remaining.Dec() == 0 {
 				if b.rpcsFailed.Inc() == 1 {
-					b.err <- httpgrpcutil.WrapHttpGrpcError(sampleTrackers[i].getError(), "not enough remaining instances to try")
+					b.err <- httpgrpcutil.WrapHTTPGrpcError(sampleTrackers[i].getError(), "not enough remaining instances to try")
 				}
 				continue
 			}
@@ -187,7 +187,7 @@ func (b *batchTracker) record(instance instance, err error) {
 			// Ex: 4xx, 5xx, 2xx
 			if sampleTrackers[i].remaining.Dec() == 0 {
 				if b.rpcsFailed.Inc() == 1 {
-					b.err <- httpgrpcutil.WrapHttpGrpcError(sampleTrackers[i].getError(), "not enough remaining instances to try")
+					b.err <- httpgrpcutil.WrapHTTPGrpcError(sampleTrackers[i].getError(), "not enough remaining instances to try")
 				}
 			}
 		}

--- a/pkg/util/httpgrpcutil/errors.go
+++ b/pkg/util/httpgrpcutil/errors.go
@@ -2,11 +2,12 @@ package httpgrpcutil
 
 import (
 	"fmt"
-	"github.com/weaveworks/common/httpgrpc"
 	"net/http"
+
+	"github.com/weaveworks/common/httpgrpc"
 )
 
-func WrapHttpGrpcError(err error, format string, args ...interface{}) error {
+func WrapHTTPGrpcError(err error, format string, args ...interface{}) error {
 	if err == nil {
 		return nil
 	}

--- a/pkg/util/httpgrpcutil/errors.go
+++ b/pkg/util/httpgrpcutil/errors.go
@@ -1,0 +1,23 @@
+package httpgrpcutil
+
+import (
+	"fmt"
+	"github.com/weaveworks/common/httpgrpc"
+	"net/http"
+)
+
+func WrapHttpGrpcError(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	msg := fmt.Sprintf(format, args...)
+	resp, ok := httpgrpc.HTTPResponseFromError(err)
+	if !ok {
+		return httpgrpc.Errorf(http.StatusInternalServerError, "%s, %s", msg, err)
+	}
+	return httpgrpc.ErrorFromHTTPResponse(&httpgrpc.HTTPResponse{
+		Code:    resp.Code,
+		Headers: resp.Headers,
+		Body:    []byte(fmt.Sprintf("%s, %s", msg, err)),
+	})
+}


### PR DESCRIPTION
…o err, which will be considered as 5xx error later

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Previous PR https://github.com/cortexproject/cortex/pull/5514 introduced an error. When httpgrpc error was wrapped with errors.Wrapf. It will cause problem in dowstream, eg. https://github.com/cortexproject/cortex/blob/master/pkg/util/push/push.go#L47

Once wrapped, the error is not a httpgrpc error anymore, we will hit the not okay path. And 5xx httpgrpc error will be returned, causing all errors been converted to 500 error.

This PR tries to wrap the error, but still produce httpgrpc error with the same status code. and error message prepended with extra message provided by the caller.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
