### PR TITLE
Add AM aggregation group metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [FEATURE] Query Frontend: Add `-frontend.retry-on-too-many-outstanding-requests` to re-enqueue 429 requests if there are multiple query-schedulers available. #5496
 * [FEATURE] Store Gateway: Add `-blocks-storage.bucket-store.max-inflight-requests` for store gateways to reject further requests upon reaching the limit. #5553
 * [FEATURE] Store Gateway: Add `cortex_bucket_store_block_load_duration_seconds` histogram to track time to load blocks. #5580
+* [FEATURE] AlertManager: Add `cortex_alertmanager_dispatcher_aggregation_groups` and `cortex_alertmanager_dispatcher_alert_processing_duration_seconds` metrics for dispatcher. #5592
 * [ENHANCEMENT] Distributor/Ingester: Add span on push path #5319
 * [ENHANCEMENT] Support object storage backends for runtime configuration file. #5292
 * [ENHANCEMENT] Query Frontend: Reject subquery with too small step size. #5323

--- a/pkg/alertmanager/alertmanager_metrics_test.go
+++ b/pkg/alertmanager/alertmanager_metrics_test.go
@@ -60,6 +60,14 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		cortex_alertmanager_config_hash{user="user1"} 0
 		cortex_alertmanager_config_hash{user="user2"} 0
 		cortex_alertmanager_config_hash{user="user3"} 0
+		# HELP cortex_alertmanager_dispatcher_alert_processing_duration_seconds Summary of latencies for the processing of alerts.
+		# TYPE cortex_alertmanager_dispatcher_alert_processing_duration_seconds summary
+		cortex_alertmanager_dispatcher_alert_processing_duration_seconds_sum{user="user1"} 0
+		cortex_alertmanager_dispatcher_alert_processing_duration_seconds_count{user="user1"} 0
+		cortex_alertmanager_dispatcher_alert_processing_duration_seconds_sum{user="user2"} 0
+		cortex_alertmanager_dispatcher_alert_processing_duration_seconds_count{user="user2"} 0
+		cortex_alertmanager_dispatcher_alert_processing_duration_seconds_sum{user="user3"} 0
+		cortex_alertmanager_dispatcher_alert_processing_duration_seconds_count{user="user3"} 0
 		# HELP cortex_alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
 		# TYPE cortex_alertmanager_nflog_gc_duration_seconds summary
 		cortex_alertmanager_nflog_gc_duration_seconds_sum 111
@@ -354,6 +362,14 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
         	            cortex_alertmanager_config_hash{user="user1"} 0
         	            cortex_alertmanager_config_hash{user="user2"} 0
         	            cortex_alertmanager_config_hash{user="user3"} 0
+						# HELP cortex_alertmanager_dispatcher_alert_processing_duration_seconds Summary of latencies for the processing of alerts.
+						# TYPE cortex_alertmanager_dispatcher_alert_processing_duration_seconds summary
+						cortex_alertmanager_dispatcher_alert_processing_duration_seconds_sum{user="user1"} 0
+						cortex_alertmanager_dispatcher_alert_processing_duration_seconds_count{user="user1"} 0
+						cortex_alertmanager_dispatcher_alert_processing_duration_seconds_sum{user="user2"} 0
+						cortex_alertmanager_dispatcher_alert_processing_duration_seconds_count{user="user2"} 0
+						cortex_alertmanager_dispatcher_alert_processing_duration_seconds_sum{user="user3"} 0
+						cortex_alertmanager_dispatcher_alert_processing_duration_seconds_count{user="user3"} 0
 
         	            # HELP cortex_alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
         	            # TYPE cortex_alertmanager_nflog_gc_duration_seconds summary
@@ -649,6 +665,12 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
     		# TYPE cortex_alertmanager_config_hash gauge
     		cortex_alertmanager_config_hash{user="user1"} 0
     		cortex_alertmanager_config_hash{user="user2"} 0
+			# HELP cortex_alertmanager_dispatcher_alert_processing_duration_seconds Summary of latencies for the processing of alerts.
+			# TYPE cortex_alertmanager_dispatcher_alert_processing_duration_seconds summary
+			cortex_alertmanager_dispatcher_alert_processing_duration_seconds_sum{user="user1"} 0
+			cortex_alertmanager_dispatcher_alert_processing_duration_seconds_count{user="user1"} 0
+			cortex_alertmanager_dispatcher_alert_processing_duration_seconds_sum{user="user2"} 0
+			cortex_alertmanager_dispatcher_alert_processing_duration_seconds_count{user="user2"} 0
 
     		# HELP cortex_alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
     		# TYPE cortex_alertmanager_nflog_gc_duration_seconds summary


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR emits the `alertmanager_dispatcher_aggregation_groups` and `alertmanager_dispatcher_alert_processing_duration_seconds` metrics from alertmanager dispatcher. 
![image](https://github.com/cortexproject/cortex/assets/3273867/5f7c1cdf-4e63-4a11-98ed-dda0fbcbe3ac)


**Which issue(s) this PR fixes**:
Fixes #5588

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
