### PR TITLE
Fix log message missing key field

### DIFF
--- a/pkg/ring/kv/dynamodb/client.go
+++ b/pkg/ring/kv/dynamodb/client.go
@@ -78,7 +78,7 @@ func NewClient(cfg Config, cc codec.Codec, logger log.Logger, registerer prometh
 		staleData:      make(map[string]staleData),
 		backoffConfig:  backoffConfig,
 	}
-	level.Info(c.logger).Log("dynamodb kv initialized")
+	level.Info(c.logger).Log("msg", "dynamodb kv initialized")
 	return c, nil
 }
 

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -65,7 +65,7 @@ func (c *Config) Validate() error {
 			return errors.New("otlp-endpoint must be defined when using otel exporter")
 		}
 		if len(c.Otel.OltpEndpoint) > 0 {
-			level.Warn(util_log.Logger).Log("DEPRECATED: otel.oltp-endpoint is deprecated. User otel.otlp-endpoint instead.")
+			level.Warn(util_log.Logger).Log("msg", "DEPRECATED: otel.oltp-endpoint is deprecated. Use otel.otlp-endpoint instead.")
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

I saw some bad logs in our Cortex deployment:

```
ts=2023-10-08T16:52:50.695689964Z caller=client.go:81 level=info class=DynamodbKvClient component=compactor dynamodbkvinitialized=(MISSING)
```

Log function call requires a key-value pair so add `msg` here as the message key.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
