### PR TITLE
Put query field at the end of query stats log

### DIFF
--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -351,11 +351,13 @@ func (f *Handler) reportQueryStats(r *http.Request, userID string, queryString u
 		} else {
 			logMessage = append(logMessage, "error", s.Message())
 		}
+	}
+	logMessage = append(logMessage, formatQueryString(queryString)...)
+	if error != nil {
 		level.Error(util_log.WithContext(r.Context(), f.log)).Log(logMessage...)
 	} else {
 		level.Info(util_log.WithContext(r.Context(), f.log)).Log(logMessage...)
 	}
-	logMessage = append(logMessage, formatQueryString(queryString)...)
 
 	var reason string
 	if statusCode == http.StatusTooManyRequests {

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -271,13 +271,13 @@ func formatGrafanaStatsFields(r *http.Request) []interface{} {
 
 // reportSlowQuery reports slow queries.
 func (f *Handler) reportSlowQuery(r *http.Request, queryString url.Values, queryResponseTime time.Duration) {
-	logMessage := append([]interface{}{
+	logMessage := []interface{}{
 		"msg", "slow query detected",
 		"method", r.Method,
 		"host", r.Host,
 		"path", r.URL.Path,
 		"time_taken", queryResponseTime.String(),
-	})
+	}
 	grafanaFields := formatGrafanaStatsFields(r)
 	if len(grafanaFields) > 0 {
 		logMessage = append(logMessage, grafanaFields...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Put the query field at the end to avoid truncating other fields in the log.

Some logging system has max length limitation. `query` param can go very long especially when users are using `*` together with Grafana template variables so the query string might contain all their label values.

When query stats log got truncated, some useful information might be missed like time range, status code, user agent, etc

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
