### PR TITLE
Ingester: Always upload compacted blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [CHANGE] StoreGateway: Rename `cortex_bucket_store_chunk_pool_returned_bytes_total` and `cortex_bucket_store_chunk_pool_requested_bytes_total` to `cortex_bucket_store_chunk_pool_operation_bytes_total`. #5552
 * [CHANGE] Query Frontend/Querier: Make build info API disabled by default and add feature flag `api.build-info-enabled` to enable it. #5533
 * [CHANGE] Purger: Do no use S3 tenant kms key when uploading deletion marker. #5575
+* [CHANGE] Ingester: Shipper always upload compacted blocks. #5625
 * [FEATURE] Store Gateway: Add `max_downloaded_bytes_per_request` to limit max bytes to download per store gateway request.
 * [FEATURE] Added 2 flags `-alertmanager.alertmanager-client.grpc-max-send-msg-size` and ` -alertmanager.alertmanager-client.grpc-max-recv-msg-size` to configure alert manager grpc client message size limits. #5338
 * [FEATURE] Query Frontend: Add `cortex_rejected_queries_total` metric for throttled queries. #5356

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2044,7 +2044,9 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 			func() labels.Labels { return l },
 			metadata.ReceiveSource,
 			func() bool {
-				return oooTimeWindow > 0 // Upload compacted blocks when OOO is enabled.
+				// Allow uploading compacted blocks. It is fine since compacted
+				//  blocks should only happen when OOO is enabled in ingester.
+				return true
 			},
 			true, // Allow out of order uploads. It's fine in Cortex's context.
 			metadata.NoneFunc,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Make ingester shipper always upload compacted blocks.

For ingesters, compacted blocks should never happen unless OOO samples is enabled. It should be fine to always enabled it.

And since vertical compaction is enabled in compactor, uploading compacted blocks should be safe.

Supercedes https://github.com/cortexproject/cortex/pull/5416

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
