### PR TITLE
Update go version to 1.21.3

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Upgrade golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.21.0
+          go-version: 1.21.3
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install Docker Client

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:feature-master-update-to-go-1.21-050c36e7b
+      image: quay.io/cortexproject/build-image:update-go-1.21.3-e38685e50
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:feature-master-update-to-go-1.21-050c36e7b
+      image: quay.io/cortexproject/build-image:update-go-1.21.3-e38685e50
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:feature-master-update-to-go-1.21-050c36e7b
+      image: quay.io/cortexproject/build-image:update-go-1.21.3-e38685e50
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -193,14 +193,14 @@ jobs:
         run: |
           touch build-image/.uptodate
           MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations
-          make BUILD_IMAGE=quay.io/cortexproject/build-image:feature-master-update-to-go-1.21-050c36e7b TTY='' configs-integration-test
+          make BUILD_IMAGE=quay.io/cortexproject/build-image:update-go-1.21.3-e38685e50 TTY='' configs-integration-test
 
   deploy_website:
     needs: [build, test]
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:feature-master-update-to-go-1.21-050c36e7b
+      image: quay.io/cortexproject/build-image:update-go-1.21.3-e38685e50
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -242,7 +242,7 @@ jobs:
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/cortexproject/build-image:feature-master-update-to-go-1.21-050c36e7b
+      image: quay.io/cortexproject/build-image:update-go-1.21.3-e38685e50
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ build-image/$(UPTODATE): build-image/*
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER := true
 BUILD_IMAGE ?= $(IMAGE_PREFIX)build-image
-LATEST_BUILD_IMAGE_TAG ?= feature-master-update-to-go-1.21-050c36e7b
+LATEST_BUILD_IMAGE_TAG ?= update-go-1.21.3-e38685e50
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.0-bullseye
+FROM golang:1.21.3-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl file jq unzip protobuf-compiler libprotobuf-dev && \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Bump to latest go version before making the release.

go 1.21.3 pathces a CVE in go 1.21.0 https://github.com/golang/go/issues/63417.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
