### PR TITLE
allow compactor to use bucket index when sync metas

### DIFF
--- a/docs/blocks-storage/compactor.md
+++ b/docs/blocks-storage/compactor.md
@@ -298,4 +298,9 @@ compactor:
   # When enabled, index verification will ignore out of order label names.
   # CLI flag: -compactor.accept-malformed-index
   [accept_malformed_index: <boolean> | default = false]
+
+  # When enabled and bucket index is also enabled in bucket store, bucket index
+  # metadata fetcher will be used in syncer
+  # CLI flag: -compactor.bucket-index-metadata-fetcher-enabled
+  [bucket_index_metadata_fetcher_enabled: <boolean> | default = false]
 ```

--- a/docs/blocks-storage/compactor.md
+++ b/docs/blocks-storage/compactor.md
@@ -303,4 +303,8 @@ compactor:
   # metadata fetcher will be used in syncer
   # CLI flag: -compactor.bucket-index-metadata-fetcher-enabled
   [bucket_index_metadata_fetcher_enabled: <boolean> | default = false]
+
+  # When enabled, caching bucket will be used
+  # CLI flag: -compactor.caching-bucket-enabled
+  [caching_bucket_enabled: <boolean> | default = false]
 ```

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1995,6 +1995,10 @@ sharding_ring:
 # metadata fetcher will be used in syncer
 # CLI flag: -compactor.bucket-index-metadata-fetcher-enabled
 [bucket_index_metadata_fetcher_enabled: <boolean> | default = false]
+
+# When enabled, caching bucket will be used
+# CLI flag: -compactor.caching-bucket-enabled
+[caching_bucket_enabled: <boolean> | default = false]
 ```
 
 ### `configs_config`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1990,6 +1990,11 @@ sharding_ring:
 # When enabled, index verification will ignore out of order label names.
 # CLI flag: -compactor.accept-malformed-index
 [accept_malformed_index: <boolean> | default = false]
+
+# When enabled and bucket index is also enabled in bucket store, bucket index
+# metadata fetcher will be used in syncer
+# CLI flag: -compactor.bucket-index-metadata-fetcher-enabled
+[bucket_index_metadata_fetcher_enabled: <boolean> | default = false]
 ```
 
 ### `configs_config`

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/cortexproject/cortex/pkg/storegateway"
+	"github.com/thanos-io/thanos/pkg/extprom"
 	"hash/fnv"
 	"math/rand"
 	"os"
@@ -537,7 +538,7 @@ func (c *Compactor) starting(ctx context.Context) error {
 
 	// Wrap the bucket client with caching layer if caching bucket is enabled.
 	if c.compactorCfg.CachingBucketEnabled {
-		c.bucketClient, err = cortex_tsdb.CreateCachingBucket(c.storageCfg.BucketStore.ChunksCache, c.storageCfg.BucketStore.MetadataCache, c.bucketClient, c.logger, c.registerer)
+		c.bucketClient, err = cortex_tsdb.CreateCachingBucket(c.storageCfg.BucketStore.ChunksCache, c.storageCfg.BucketStore.MetadataCache, c.bucketClient, c.logger, extprom.WrapRegistererWith(prometheus.Labels{"component": "compactor"}, c.registerer))
 		if err != nil {
 			return errors.Wrapf(err, "create caching bucket")
 		}

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -499,9 +499,9 @@ func newCompactor(
 		// Instance the right strategy.
 		switch c.compactorCfg.ShardingStrategy {
 		case util.ShardingStrategyDefault:
-			c.shardingStrategy = storegateway.NewDefaultShardingStrategy(c.ring, c.ringLifecycler.Addr, logger, c.allowedTenants)
+			c.shardingStrategy = NewDefaultShardingStrategy(c.ring, c.ringLifecycler.Addr, logger, c.allowedTenants)
 		case util.ShardingStrategyShuffle:
-			c.shardingStrategy = storegateway.NewShuffleShardingStrategy(c.ring, lifecyclerCfg.ID, lifecyclerCfg.Addr, limits, logger, c.allowedTenants, c.compactorCfg.ShardingRing.ZoneStableShuffleSharding)
+			c.shardingStrategy = NewShuffleShardingStrategy(c.ring, lifecyclerCfg.ID, lifecyclerCfg.Addr, limits, logger, c.allowedTenants, c.compactorCfg.ShardingRing.ZoneStableShuffleSharding)
 		default:
 			return nil, errInvalidShardingStrategy
 		}
@@ -833,7 +833,7 @@ func (c *Compactor) compactUser(ctx context.Context, userID string) error {
 	if c.storageCfg.BucketStore.BucketIndex.Enabled && c.compactorCfg.BucketIndexMetadataFetcherEnabled {
 		fetcher = storegateway.NewBucketIndexMetadataFetcher(
 			userID,
-			bucket,
+			c.bucketClient,
 			c.shardingStrategy,
 			c.limits,
 			ulogger,

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -250,6 +250,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.BlockVisitMarkerFileUpdateInterval, "compactor.block-visit-marker-file-update-interval", 1*time.Minute, "How frequently block visit marker file should be updated duration compaction.")
 
 	f.BoolVar(&cfg.AcceptMalformedIndex, "compactor.accept-malformed-index", false, "When enabled, index verification will ignore out of order label names.")
+	f.BoolVar(&cfg.BucketIndexMetadataFetcherEnabled, "compactor.bucket-index-metadata-fetcher-enabled", false, "When enabled and bucket index is also enabled in bucket store, bucket index metadata fetcher will be used in syncer")
 }
 
 func (cfg *Config) Validate(limits validation.Limits) error {
@@ -818,7 +819,7 @@ func (c *Compactor) compactUser(ctx context.Context, userID string) error {
 		deduplicateBlocksFilter,
 		noCompactMarkerFilter,
 	}
-	if c.compactorCfg.BucketIndexMetadataFetcherEnabled {
+	if c.storageCfg.BucketStore.BucketIndex.Enabled && c.compactorCfg.BucketIndexMetadataFetcherEnabled {
 		fetcher = storegateway.NewBucketIndexMetadataFetcher(
 			userID,
 			bucket,

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -498,14 +498,14 @@ func newCompactor(
 		// Instance the right strategy.
 		switch c.compactorCfg.ShardingStrategy {
 		case util.ShardingStrategyDefault:
-			c.shardingStrategy = storegateway.NewDefaultShardingStrategy(c.ring, c.ringLifecycler.Addr, logger)
+			c.shardingStrategy = storegateway.NewDefaultShardingStrategy(c.ring, c.ringLifecycler.Addr, logger, c.allowedTenants)
 		case util.ShardingStrategyShuffle:
-			c.shardingStrategy = storegateway.NewShuffleShardingStrategy(c.ring, lifecyclerCfg.ID, lifecyclerCfg.Addr, limits, logger, c.compactorCfg.ShardingRing.ZoneStableShuffleSharding)
+			c.shardingStrategy = storegateway.NewShuffleShardingStrategy(c.ring, lifecyclerCfg.ID, lifecyclerCfg.Addr, limits, logger, c.allowedTenants, c.compactorCfg.ShardingRing.ZoneStableShuffleSharding)
 		default:
 			return nil, errInvalidShardingStrategy
 		}
 	} else {
-		c.shardingStrategy = storegateway.NewNoShardingStrategy()
+		c.shardingStrategy = storegateway.NewNoShardingStrategy(logger, c.allowedTenants)
 	}
 
 	c.Service = services.NewBasicService(c.starting, c.running, c.stopping)

--- a/pkg/compactor/compactor_ring.go
+++ b/pkg/compactor/compactor_ring.go
@@ -39,7 +39,8 @@ type RingConfig struct {
 
 	WaitActiveInstanceTimeout time.Duration `yaml:"wait_active_instance_timeout"`
 
-	ObservePeriod time.Duration `yaml:"-"`
+	ObservePeriod             time.Duration `yaml:"-"`
+	ZoneStableShuffleSharding bool          `yaml:"zone_stable_shuffle_sharding" doc:"hidden"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -70,6 +71,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
 
 	// Timeout durations
 	f.DurationVar(&cfg.WaitActiveInstanceTimeout, "compactor.ring.wait-active-instance-timeout", 10*time.Minute, "Timeout for waiting on compactor to become ACTIVE in the ring.")
+	f.BoolVar(&cfg.ZoneStableShuffleSharding, "compactor.ring.zone-stable-shuffle-sharding", false, "If true, use zone stable shuffle sharding algorithm. Otherwise, use the default shuffle sharding algorithm.")
 }
 
 // ToLifecyclerConfig returns a LifecyclerConfig based on the compactor

--- a/pkg/compactor/sharding_strategy.go
+++ b/pkg/compactor/sharding_strategy.go
@@ -1,0 +1,169 @@
+package compactor
+
+import (
+	"context"
+	"github.com/cortexproject/cortex/pkg/util/validation"
+	"hash/fnv"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/oklog/ulid"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+
+	"github.com/cortexproject/cortex/pkg/ring"
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+const (
+	shardExcludedMeta = "shard-excluded"
+)
+
+func filterDisallowedTenants(userIDs []string, logger log.Logger, allowedTenants *util.AllowedTenants) []string {
+	filteredUserIDs := []string{}
+	for _, userID := range userIDs {
+		if !allowedTenants.IsAllowed(userID) {
+			level.Debug(logger).Log("msg", "ignoring storage gateway for user, not allowed", "user", userID)
+			continue
+		}
+
+		filteredUserIDs = append(filteredUserIDs, userID)
+	}
+
+	return filteredUserIDs
+}
+
+// NoShardingStrategy is a no-op strategy. When this strategy is used, no tenant/block is filtered out.
+type NoShardingStrategy struct {
+	logger         log.Logger
+	allowedTenants *util.AllowedTenants
+}
+
+func NewNoShardingStrategy(logger log.Logger, allowedTenants *util.AllowedTenants) *NoShardingStrategy {
+	return &NoShardingStrategy{
+		logger:         logger,
+		allowedTenants: allowedTenants,
+	}
+}
+
+func (s *NoShardingStrategy) FilterUsers(_ context.Context, userIDs []string) []string {
+	return filterDisallowedTenants(userIDs, s.logger, s.allowedTenants)
+}
+
+func (s *NoShardingStrategy) FilterBlocks(_ context.Context, _ string, _ map[ulid.ULID]*metadata.Meta, _ map[ulid.ULID]struct{}, _ block.GaugeVec) error {
+	return nil
+}
+
+// DefaultShardingStrategy is a sharding strategy based on the hash ring formed by store-gateways.
+// Not go-routine safe.
+type DefaultShardingStrategy struct {
+	r              *ring.Ring
+	instanceAddr   string
+	logger         log.Logger
+	allowedTenants *util.AllowedTenants
+}
+
+// NewDefaultShardingStrategy creates DefaultShardingStrategy.
+func NewDefaultShardingStrategy(r *ring.Ring, instanceAddr string, logger log.Logger, allowedTenants *util.AllowedTenants) *DefaultShardingStrategy {
+	return &DefaultShardingStrategy{
+		r:            r,
+		instanceAddr: instanceAddr,
+		logger:       logger,
+
+		allowedTenants: allowedTenants,
+	}
+}
+
+// FilterUsers implements ShardingStrategy.
+func (s *DefaultShardingStrategy) FilterUsers(_ context.Context, userIDs []string) []string {
+	var filteredIDs []string
+	for _, userID := range filterDisallowedTenants(userIDs, s.logger, s.allowedTenants) {
+		// Hash the user ID.
+		hasher := fnv.New32a()
+		_, _ = hasher.Write([]byte(userID))
+		userHash := hasher.Sum32()
+		// Check whether this compactor instance owns the user.
+		rs, err := s.r.Get(userHash, RingOp, nil, nil, nil)
+		if err != nil {
+			continue
+		}
+		if len(rs.Instances) != 1 {
+			continue
+		}
+		if rs.Instances[0].Addr == s.instanceAddr {
+			filteredIDs = append(filteredIDs, userID)
+		}
+	}
+	return filteredIDs
+}
+
+// FilterBlocks implements ShardingStrategy.
+func (s *DefaultShardingStrategy) FilterBlocks(_ context.Context, _ string, metas map[ulid.ULID]*metadata.Meta, loaded map[ulid.ULID]struct{}, synced block.GaugeVec) error {
+	return nil
+}
+
+// ShuffleShardingStrategy is a shuffle sharding strategy, based on the hash ring formed by store-gateways,
+// where each tenant blocks are sharded across a subset of store-gateway instances.
+type ShuffleShardingStrategy struct {
+	r            *ring.Ring
+	instanceID   string
+	instanceAddr string
+	limits       *validation.Overrides
+	logger       log.Logger
+
+	zoneStableShuffleSharding bool
+	allowedTenants            *util.AllowedTenants
+}
+
+// NewShuffleShardingStrategy makes a new ShuffleShardingStrategy.
+func NewShuffleShardingStrategy(r *ring.Ring, instanceID, instanceAddr string, limits *validation.Overrides, logger log.Logger, allowedTenants *util.AllowedTenants, zoneStableShuffleSharding bool) *ShuffleShardingStrategy {
+	return &ShuffleShardingStrategy{
+		r:            r,
+		instanceID:   instanceID,
+		instanceAddr: instanceAddr,
+		limits:       limits,
+		logger:       logger,
+
+		zoneStableShuffleSharding: zoneStableShuffleSharding,
+		allowedTenants:            allowedTenants,
+	}
+}
+
+// FilterUsers implements ShardingStrategy.
+func (s *ShuffleShardingStrategy) FilterUsers(_ context.Context, userIDs []string) []string {
+	var filteredIDs []string
+	for _, userID := range filterDisallowedTenants(userIDs, s.logger, s.allowedTenants) {
+		subRing := GetShuffleShardingSubring(s.r, userID, s.limits, s.zoneStableShuffleSharding)
+
+		// Include the user only if it belongs to this store-gateway shard.
+		if subRing.HasInstance(s.instanceID) {
+			filteredIDs = append(filteredIDs, userID)
+		}
+	}
+
+	return filteredIDs
+}
+
+// FilterBlocks implements ShardingStrategy.
+func (s *ShuffleShardingStrategy) FilterBlocks(_ context.Context, userID string, metas map[ulid.ULID]*metadata.Meta, loaded map[ulid.ULID]struct{}, synced block.GaugeVec) error {
+	return nil
+}
+
+// GetShuffleShardingSubring returns the subring to be used for a given user. This function
+// should be used both by store-gateway and querier in order to guarantee the same logic is used.
+func GetShuffleShardingSubring(ring *ring.Ring, userID string, limits *validation.Overrides, zoneStableShuffleSharding bool) ring.ReadRing {
+	shardSize := limits.CompactorTenantShardSize(userID)
+
+	// A shard size of 0 means shuffle sharding is disabled for this specific user,
+	// so we just return the full ring so that blocks will be sharded across all store-gateways.
+	if shardSize <= 0 {
+		return ring
+	}
+
+	if zoneStableShuffleSharding {
+		// Zone stability is required for store gateway when shuffle shard, see
+		// https://github.com/cortexproject/cortex/issues/5467 for more details.
+		return ring.ShuffleShardWithZoneStability(userID, shardSize)
+	}
+	return ring.ShuffleShard(userID, shardSize)
+}

--- a/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go
@@ -141,8 +141,12 @@ func (s *Syncer) SyncMetas(ctx context.Context) error {
 	if err != nil {
 		return retry(err)
 	}
-	s.blocks = metas
-	s.partial = partial
+	if metas != nil {
+		s.blocks = metas
+	}
+	if partial != nil {
+		s.partial = partial
+	}
 	return nil
 }
 

--- a/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/compact/compact.go
@@ -141,12 +141,8 @@ func (s *Syncer) SyncMetas(ctx context.Context) error {
 	if err != nil {
 		return retry(err)
 	}
-	if metas != nil {
-		s.blocks = metas
-	}
-	if partial != nil {
-		s.partial = partial
-	}
+	s.blocks = metas
+	s.partial = partial
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

1. Added configuration in compactor to allow compactors to use bucket-index-meta-data-fetcher when fetching metas.
2. Use cachingBucket (from store-gateway) for compactor
The idea is to reduce ListObject calls to object store.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
