### PR TITLE
Skip listing rule groups in CreateRuleGroup api if max rule groups limit is not set

### DIFF
--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -527,17 +527,19 @@ func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	rgs, err := a.store.ListRuleGroupsForUserAndNamespace(req.Context(), userID, "")
-	if err != nil {
-		level.Error(logger).Log("msg", "unable to fetch current rule groups for validation", "err", err.Error(), "user", userID)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	if a.ruler.HasMaxRuleGroupsLimit(userID) {
+		rgs, err := a.store.ListRuleGroupsForUserAndNamespace(req.Context(), userID, "")
+		if err != nil {
+			level.Error(logger).Log("msg", "unable to fetch current rule groups for validation", "err", err.Error(), "user", userID)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 
-	if err := a.ruler.AssertMaxRuleGroups(userID, len(rgs)+1); err != nil {
-		level.Error(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+		if err := a.ruler.AssertMaxRuleGroups(userID, len(rgs)+1); err != nil {
+			level.Error(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 	}
 
 	rgProto := rulespb.ToProto(userID, namespace, rg)

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -939,6 +939,12 @@ func (r *Ruler) Rules(ctx context.Context, in *RulesRequest) (*RulesResponse, er
 	return &RulesResponse{Groups: groupDescs}, nil
 }
 
+// HasMaxRuleGroupsLimit check if RulerMaxRuleGroupsPerTenant limit is set for the userID.
+func (r *Ruler) HasMaxRuleGroupsLimit(userID string) bool {
+	limit := r.limits.RulerMaxRuleGroupsPerTenant(userID)
+	return limit > 0
+}
+
 // AssertMaxRuleGroups limit has not been reached compared to the current
 // number of total rule groups in input and returns an error if so.
 func (r *Ruler) AssertMaxRuleGroups(userID string, rg int) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
With this PR the `ListRuleGroupsForUserAndNamespace` function should not be called in the `CreateRuleGroup` endpoint if the `MaxRuleGroups` limit for the tenant is not set. The existing tests for the validation should still pass after this change.

**Which issue(s) this PR fixes**:
Fixes #5646

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
