### PR TITLE
Close bucket store for users with no blocks synced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 * [ENHANCEMENT] Ingester: Added new ingester TSDB metrics `cortex_ingester_tsdb_head_samples_appended_total`, `cortex_ingester_tsdb_head_out_of_order_samples_appended_total`, `cortex_ingester_tsdb_snapshot_replay_error_total`, `cortex_ingester_tsdb_sample_ooo_delta` and `cortex_ingester_tsdb_mmap_chunks_total`. #5624
 * [ENHANCEMENT] Query Frontend: Handle context error before decoding and merging responses. #5499
 * [ENHANCEMENT] Store-Gateway and AlertManager: Add a `wait_instance_time_out` to context to avoid waiting forever. #5581
+* [ENHANCEMENT] Store Gateway: Close bucket store for users with no blocks synced. #5674 
 * [BUGFIX] Compactor: Fix possible division by zero during compactor config validation. #5535
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -196,6 +196,8 @@ func TestBucketStores_InitialSync(t *testing.T) {
 		generateStorageBlock(t, storageDir, userID, metricName, 10, 100, 15)
 	}
 
+	generateDeletedUser(t, storageDir, "user-3")
+
 	bucket, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
 	require.NoError(t, err)
 
@@ -595,6 +597,16 @@ func generateStorageBlock(t *testing.T, storageDir, userID string, metricName st
 
 	// Snapshot TSDB to the storage directory.
 	require.NoError(t, db.Snapshot(userDir, true))
+}
+
+func generateDeletedUser(t *testing.T, storageDir, userID string) {
+	// Create a directory for the user (if doesn't already exist).
+	userDir := filepath.Join(storageDir, userID)
+	if _, err := os.Stat(userDir); err != nil {
+		require.NoError(t, os.Mkdir(userDir, os.ModePerm))
+	}
+
+	require.NoError(t, os.Mkdir(filepath.Join(userDir, "markers"), os.ModePerm))
 }
 
 func querySeries(stores *BucketStores, userID, metricName string, minT, maxT int64) ([]*storepb.Series, annotations.Annotations, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- If the `tenant_cleanup_delay` is large (say 24h), a deleted tenant can be continued to be synced by the store-gateways.
- This is because the  `s3://<bucket>/<tenantID>/markers/tenant-deletion-mark.json` will be kept for 24h after the tenant has been deleted.
- If there are a lots of users being created and deleted in the cluster (canary testing), there could be a lot of deleted users synced by the store-gateway.
- One of the problems with having too many active users is the number of metrics that store-gateways will keep around. If there are 50K deleted users synced by a store-gateway and a total of 300 store-gateways in the cluster that'll be 15 million series.
- This change ensures that if no blocks are loaded for a tenant, their bucket stores can be closed immediately and the blocks_loaded metrics can be removed.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
