### PR TITLE
StoreGateway: Optimize filtering users during intial sync

### DIFF
--- a/pkg/storegateway/bucket_index_metadata_fetcher.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher.go
@@ -59,7 +59,7 @@ func (f *BucketIndexMetadataFetcher) Fetch(ctx context.Context) (metas map[ulid.
 	f.metrics.ResetTx()
 
 	// Check whether the user belongs to the shard.
-	if len(f.strategy.FilterUsers(ctx, []string{f.userID})) != 1 {
+	if len(f.strategy.FilterUsers(ctx, []string{f.userID}, false)) != 1 {
 		f.metrics.Submit()
 		return nil, nil, nil
 	}

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -410,7 +410,7 @@ func TestBucketStores_syncUsersBlocks(t *testing.T) {
 		"when sharding is enabled only stores for filtered users should be created": {
 			shardingStrategy: func() ShardingStrategy {
 				s := &mockShardingStrategy{}
-				s.On("FilterUsers", mock.Anything, allUsers, true).Return([]string{"user-1", "user-2"})
+				s.On("FilterUsers", mock.Anything, allUsers).Return([]string{"user-1", "user-2"})
 				return s
 			}(),
 			expectedStores: 2,

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -364,7 +364,7 @@ func (g *StoreGateway) syncStores(ctx context.Context, reason string) {
 	level.Info(g.logger).Log("msg", "synchronizing TSDB blocks for all users", "reason", reason)
 	g.bucketSync.WithLabelValues(reason).Inc()
 
-	if err := g.stores.SyncBlocks(ctx); err != nil {
+	if err := g.stores.SyncBlocks(ctx, reason); err != nil {
 		level.Warn(g.logger).Log("msg", "failed to synchronize TSDB blocks", "reason", reason, "err", err)
 	} else {
 		level.Info(g.logger).Log("msg", "successfully synchronized TSDB blocks for all users", "reason", reason)

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -1294,7 +1294,7 @@ type mockShardingStrategy struct {
 	mock.Mock
 }
 
-func (m *mockShardingStrategy) FilterUsers(ctx context.Context, userIDs []string) []string {
+func (m *mockShardingStrategy) FilterUsers(ctx context.Context, userIDs []string, parallel bool) []string {
 	args := m.Called(ctx, userIDs)
 	return args.Get(0).([]string)
 }

--- a/pkg/storegateway/sharding_strategy_test.go
+++ b/pkg/storegateway/sharding_strategy_test.go
@@ -651,7 +651,7 @@ func TestShuffleShardingStrategy(t *testing.T) {
 				// Assert on filter users.
 				for _, expected := range testData.expectedUsers {
 					filter := NewShuffleShardingStrategy(r, expected.instanceID, expected.instanceAddr, testData.limits, log.NewNopLogger(), allowedTenants, zoneStableShuffleSharding) //nolint:govet
-					assert.Equal(t, expected.users, filter.FilterUsers(ctx, []string{userID}))
+					assert.Equal(t, expected.users, filter.FilterUsers(ctx, []string{userID}, true))
 				}
 
 				// Assert on filter blocks.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- Finding the sub ring for a user is a computationally expensive if
- It takes about 46 ms to compute the sub ring for a user under these conditions.
  - 512 tokens per store-gateway
  - 350 store-gateways
  - shard size = 90%
- If there are lots of users in the cluster, the total time can be a lot.
  - For example if there are 20,000 users it'll take about ~15 mins to filter users.
  - `20,000 * 46ms / 1000ms / 60s = ~15 mins`
- This is an attempt at optimizing this by using additional cores on the machine.
- Instead of using a single go routine (which runs on a single core), we can use `runtime.NumCPU()` concurrency to filter users in multiple cores.


**Results**:
I saw significant improvement in filtering. The time went from 15 mins to 3 mins.

Before:
```
ts=2023-11-23T02:49:58.737035299Z caller=bucket_stores.go:233 level=info msg="Finished filtering users" users=37115 elapsed=32m37.846198184s
```

After:
```
ts=2023-11-23T22:29:07.14464567Z caller=bucket_stores.go:233 level=info msg="Finished filtering users" users=37580 elapsed=3m44.923125472s
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
