### PR TITLE
Move tenant-deletion-mark to a global dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@
 * [ENHANCEMENT] Ingester: Added new ingester TSDB metrics `cortex_ingester_tsdb_head_samples_appended_total`, `cortex_ingester_tsdb_head_out_of_order_samples_appended_total`, `cortex_ingester_tsdb_snapshot_replay_error_total`, `cortex_ingester_tsdb_sample_ooo_delta` and `cortex_ingester_tsdb_mmap_chunks_total`. #5624
 * [ENHANCEMENT] Query Frontend: Handle context error before decoding and merging responses. #5499
 * [ENHANCEMENT] Store-Gateway and AlertManager: Add a `wait_instance_time_out` to context to avoid waiting forever. #5581
-* [ENHANCEMENT] Store-Gateway: Move the `tenant-deletion-mark.json`` to a global dir. #5676
+* [ENHANCEMENT] Blocks storage: Move the tenant deletion mark from `<tenantID>/markers/tenant-deletion-mark.json` to  `__markers__/<tenantID>/tenant-deletion-mark.json`. #5676
 * [BUGFIX] Compactor: Fix possible division by zero during compactor config validation. #5535
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 * [ENHANCEMENT] Ingester: Added new ingester TSDB metrics `cortex_ingester_tsdb_head_samples_appended_total`, `cortex_ingester_tsdb_head_out_of_order_samples_appended_total`, `cortex_ingester_tsdb_snapshot_replay_error_total`, `cortex_ingester_tsdb_sample_ooo_delta` and `cortex_ingester_tsdb_mmap_chunks_total`. #5624
 * [ENHANCEMENT] Query Frontend: Handle context error before decoding and merging responses. #5499
 * [ENHANCEMENT] Store-Gateway and AlertManager: Add a `wait_instance_time_out` to context to avoid waiting forever. #5581
+* [ENHANCEMENT] Store-Gateway: Move the `tenant-deletion-mark.json`` to a global dir. #5676
 * [BUGFIX] Compactor: Fix possible division by zero during compactor config validation. #5535
 * [BUGFIX] Ruler: Validate if rule group can be safely converted back to rule group yaml from protobuf message #5265
 * [BUGFIX] Querier: Convert gRPC `ResourceExhausted` status code from store gateway to 422 limit error. #5286

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -293,16 +293,14 @@ func (c *BlocksCleaner) deleteUserMarkedForDeletion(ctx context.Context, userID 
 		level.Info(userLogger).Log("msg", "deleted files under "+block.DebugMetas+" for tenant marked for deletion", "count", deleted)
 	}
 
-	// Tenant deletion mark file is inside Markers as well.
 	if deleted, err := bucket.DeletePrefix(ctx, userBucket, bucketindex.MarkersPathname, userLogger); err != nil {
 		return errors.Wrap(err, "failed to delete marker files")
 	} else if deleted > 0 {
 		level.Info(userLogger).Log("msg", "deleted marker files for tenant marked for deletion", "count", deleted)
 	}
 
-	// Deleting global markers for the user
-	if err := c.bucketClient.Delete(ctx, cortex_tsdb.GetGlobalDeletionMarkPath(userID)); err != nil {
-		return errors.Wrap(err, "failed to delete global marker file")
+	if err := cortex_tsdb.DeleteTenantDeletionMark(ctx, c.bucketClient, userID); err != nil {
+		return errors.Wrap(err, "failed to delete tenant deletion mark")
 	}
 
 	return nil

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -300,6 +300,11 @@ func (c *BlocksCleaner) deleteUserMarkedForDeletion(ctx context.Context, userID 
 		level.Info(userLogger).Log("msg", "deleted marker files for tenant marked for deletion", "count", deleted)
 	}
 
+	// Deleting global markers for the user
+	if err := c.bucketClient.Delete(ctx, cortex_tsdb.GetGlobalDeletionMarkPath(userID)); err != nil {
+		return errors.Wrap(err, "failed to delete global marker file")
+	}
+
 	return nil
 }
 

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -209,15 +209,24 @@ func testBlocksCleanerWithOptions(t *testing.T, options testBlocksCleanerOptions
 		{path: path.Join("user-3", block9.String(), "index"), expectedExists: false},
 		{path: path.Join("user-3", block10.String(), metadata.MetaFilename), expectedExists: false},
 		{path: path.Join("user-3", block10.String(), "index"), expectedExists: false},
-		// Tenant deletion mark is not removed.
-		{path: path.Join("user-3", tsdb.TenantDeletionMarkPath), expectedExists: true},
-		// User-4 is removed fully.
-		{path: path.Join("user-4", tsdb.TenantDeletionMarkPath), expectedExists: options.user4FilesExist},
 		{path: path.Join("user-4", block.DebugMetas, "meta.json"), expectedExists: options.user4FilesExist},
 	} {
 		exists, err := bucketClient.Exists(ctx, tc.path)
 		require.NoError(t, err)
 		assert.Equal(t, tc.expectedExists, exists, tc.path)
+	}
+
+	// Check if tenant deletion mark exists
+	for _, tc := range []struct {
+		user           string
+		expectedExists bool
+	}{
+		{"user-3", true},
+		{"user-4", options.user4FilesExist},
+	} {
+		exists, err := tsdb.TenantDeletionMarkExists(ctx, bucketClient, tc.user)
+		require.NoError(t, err)
+		assert.Equal(t, tc.expectedExists, exists, tc.user)
 	}
 
 	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsStarted))

--- a/pkg/purger/tenant_deletion_api_test.go
+++ b/pkg/purger/tenant_deletion_api_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"path"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -35,8 +34,9 @@ func TestDeleteTenant(t *testing.T) {
 		api.DeleteTenant(resp, req.WithContext(ctx))
 
 		require.Equal(t, http.StatusOK, resp.Code)
-		objs := bkt.Objects()
-		require.NotNil(t, objs[path.Join("fake", tsdb.TenantDeletionMarkPath)])
+		exists, err := tsdb.TenantDeletionMarkExists(ctx, bkt, "fake")
+		require.NoError(t, err)
+		require.True(t, exists)
 	}
 }
 

--- a/pkg/querier/blocks_finder_bucket_scan_test.go
+++ b/pkg/querier/blocks_finder_bucket_scan_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 	"strings"
 	"testing"
 	"time"
@@ -96,7 +95,8 @@ func TestBucketScanBlocksFinder_InitialScanFailure(t *testing.T) {
 	// Mock the storage to simulate a failure when reading objects.
 	bucket.MockIter("", []string{"user-1"}, nil)
 	bucket.MockIter("user-1/", []string{"user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json"}, nil)
-	bucket.MockExists(path.Join("user-1", cortex_tsdb.TenantDeletionMarkPath), false, nil)
+	bucket.MockExists(cortex_tsdb.GetGlobalDeletionMarkPath("user-1"), false, nil)
+	bucket.MockExists(cortex_tsdb.GetLocalDeletionMarkPath("user-1"), false, nil)
 	bucket.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", "invalid", errors.New("mocked error"))
 
 	require.NoError(t, s.StartAsync(ctx))
@@ -143,7 +143,8 @@ func TestBucketScanBlocksFinder_StopWhileRunningTheInitialScanOnManyTenants(t *t
 		bucket.MockIterWithCallback(tenantID+"/", []string{}, nil, func() {
 			time.Sleep(time.Second)
 		})
-		bucket.MockExists(path.Join(tenantID, cortex_tsdb.TenantDeletionMarkPath), false, nil)
+		bucket.MockExists(cortex_tsdb.GetGlobalDeletionMarkPath(tenantID), false, nil)
+		bucket.MockExists(cortex_tsdb.GetLocalDeletionMarkPath(tenantID), false, nil)
 	}
 
 	cfg := prepareBucketScanBlocksFinderConfig()

--- a/pkg/storage/tsdb/caching_bucket.go
+++ b/pkg/storage/tsdb/caching_bucket.go
@@ -183,7 +183,7 @@ var chunksMatcher = regexp.MustCompile(`^.*/chunks/\d+$`)
 func isTSDBChunkFile(name string) bool { return chunksMatcher.MatchString(name) }
 
 func isMetaFile(name string) bool {
-	return strings.HasSuffix(name, "/"+metadata.MetaFilename) || strings.HasSuffix(name, "/"+metadata.DeletionMarkFilename) || strings.HasSuffix(name, "/"+TenantDeletionMarkPath)
+	return strings.HasSuffix(name, "/"+metadata.MetaFilename) || strings.HasSuffix(name, "/"+metadata.DeletionMarkFilename) || strings.HasSuffix(name, "/"+TenantDeletionMarkFile)
 }
 
 func isBlockIndexFile(name string) bool {

--- a/pkg/storage/tsdb/tenant_deletion_mark.go
+++ b/pkg/storage/tsdb/tenant_deletion_mark.go
@@ -15,8 +15,7 @@ import (
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
-// Relative to user-specific prefix.
-const TenantDeletionMarkPath = "tenant-deletion-mark.json"
+const TenantDeletionMarkFile = "tenant-deletion-mark.json"
 
 type TenantDeletionMark struct {
 	// Unix timestamp when deletion marker was created.
@@ -63,11 +62,11 @@ func ReadTenantDeletionMark(ctx context.Context, bkt objstore.BucketReader, user
 }
 
 func GetLocalDeletionMarkPath(userID string) string {
-	return path.Join(userID, "markers", TenantDeletionMarkPath)
+	return path.Join(userID, "markers", TenantDeletionMarkFile)
 }
 
 func GetGlobalDeletionMarkPath(userID string) string {
-	return path.Join(util.GlobalMarkersDir, userID, TenantDeletionMarkPath)
+	return path.Join(util.GlobalMarkersDir, userID, TenantDeletionMarkFile)
 }
 
 func exists(ctx context.Context, bkt objstore.BucketReader, markerFile string) (bool, error) {

--- a/pkg/storage/tsdb/tenant_deletion_mark.go
+++ b/pkg/storage/tsdb/tenant_deletion_mark.go
@@ -11,11 +11,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/thanos-io/objstore"
 
+	"github.com/cortexproject/cortex/pkg/util"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
 // Relative to user-specific prefix.
-const TenantDeletionMarkPath = "markers/tenant-deletion-mark.json"
+const TenantDeletionMarkPath = "tenant-deletion-mark.json"
 
 type TenantDeletionMark struct {
 	// Unix timestamp when deletion marker was created.
@@ -31,15 +32,49 @@ func NewTenantDeletionMark(deletionTime time.Time) *TenantDeletionMark {
 
 // Checks for deletion mark for tenant. Errors other than "object not found" are returned.
 func TenantDeletionMarkExists(ctx context.Context, bkt objstore.BucketReader, userID string) (bool, error) {
-	markerFile := path.Join(userID, TenantDeletionMarkPath)
+	markerFile := GetGlobalDeletionMarkPath(userID)
+	if globalExists, err := exists(ctx, bkt, markerFile); err != nil {
+		return false, err
+	} else if globalExists {
+		return true, nil
+	}
 
-	return bkt.Exists(ctx, markerFile)
+	markerFile = GetLocalDeletionMarkPath(userID)
+	return exists(ctx, bkt, markerFile)
 }
 
 // Uploads deletion mark to the tenant location in the bucket.
 func WriteTenantDeletionMark(ctx context.Context, bkt objstore.Bucket, userID string, mark *TenantDeletionMark) error {
-	markerFile := path.Join(userID, TenantDeletionMarkPath)
+	markerFile := GetGlobalDeletionMarkPath(userID)
+	return write(ctx, bkt, markerFile, mark)
+}
 
+// Returns tenant deletion mark for given user, if it exists. If it doesn't exist, returns nil mark, and no error.
+func ReadTenantDeletionMark(ctx context.Context, bkt objstore.BucketReader, userID string) (*TenantDeletionMark, error) {
+	markerFile := GetGlobalDeletionMarkPath(userID)
+	if mark, err := read(ctx, bkt, markerFile); err != nil {
+		return nil, err
+	} else if mark != nil {
+		return mark, nil
+	}
+
+	markerFile = GetLocalDeletionMarkPath(userID)
+	return read(ctx, bkt, markerFile)
+}
+
+func GetLocalDeletionMarkPath(userID string) string {
+	return path.Join(userID, "markers", TenantDeletionMarkPath)
+}
+
+func GetGlobalDeletionMarkPath(userID string) string {
+	return path.Join(util.GlobalMarkersDir, userID, TenantDeletionMarkPath)
+}
+
+func exists(ctx context.Context, bkt objstore.BucketReader, markerFile string) (bool, error) {
+	return bkt.Exists(ctx, markerFile)
+}
+
+func write(ctx context.Context, bkt objstore.Bucket, markerFile string, mark *TenantDeletionMark) error {
 	data, err := json.Marshal(mark)
 	if err != nil {
 		return errors.Wrap(err, "serialize tenant deletion mark")
@@ -48,10 +83,7 @@ func WriteTenantDeletionMark(ctx context.Context, bkt objstore.Bucket, userID st
 	return errors.Wrap(bkt.Upload(ctx, markerFile, bytes.NewReader(data)), "upload tenant deletion mark")
 }
 
-// Returns tenant deletion mark for given user, if it exists. If it doesn't exist, returns nil mark, and no error.
-func ReadTenantDeletionMark(ctx context.Context, bkt objstore.BucketReader, userID string) (*TenantDeletionMark, error) {
-	markerFile := path.Join(userID, TenantDeletionMarkPath)
-
+func read(ctx context.Context, bkt objstore.BucketReader, markerFile string) (*TenantDeletionMark, error) {
 	r, err := bkt.Get(ctx, markerFile)
 	if err != nil {
 		if bkt.IsObjNotFoundErr(err) {

--- a/pkg/storage/tsdb/tenant_deletion_mark.go
+++ b/pkg/storage/tsdb/tenant_deletion_mark.go
@@ -61,6 +61,17 @@ func ReadTenantDeletionMark(ctx context.Context, bkt objstore.BucketReader, user
 	return read(ctx, bkt, markerFile)
 }
 
+// Deletes the tenant deletion mark for given user if it exists.
+func DeleteTenantDeletionMark(ctx context.Context, bkt objstore.Bucket, userID string) error {
+	if err := bkt.Delete(ctx, GetGlobalDeletionMarkPath(userID)); err != nil {
+		return err
+	}
+	if err := bkt.Delete(ctx, GetLocalDeletionMarkPath(userID)); err != nil {
+		return err
+	}
+	return nil
+}
+
 func GetLocalDeletionMarkPath(userID string) string {
 	return path.Join(userID, "markers", TenantDeletionMarkFile)
 }

--- a/pkg/storage/tsdb/tenant_deletion_mark_test.go
+++ b/pkg/storage/tsdb/tenant_deletion_mark_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/thanos-io/objstore"
 )
 
-func TestTenantDeletionMarkExists(t *testing.T) {
+func TestTenantLocalDeletionMarkExists(t *testing.T) {
 	const username = "user"
 
 	for name, tc := range map[string]struct {
@@ -33,6 +33,59 @@ func TestTenantDeletionMarkExists(t *testing.T) {
 			objects: map[string][]byte{
 				"user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
 				"user/" + TenantDeletionMarkPath:            []byte("data"),
+			},
+			exists: true,
+		},
+		"mark exists - upload via WriteTenantDeletionMark": {
+			objects: map[string][]byte{
+				"user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
+			},
+			deletedUsers: []string{"user"},
+			exists:       true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			bkt := objstore.NewInMemBucket()
+			// "upload" objects
+			for objName, data := range tc.objects {
+				require.NoError(t, bkt.Upload(context.Background(), objName, bytes.NewReader(data)))
+			}
+
+			for _, user := range tc.deletedUsers {
+				require.NoError(t, WriteTenantDeletionMark(context.Background(), bkt, user, &TenantDeletionMark{}))
+			}
+
+			res, err := TenantDeletionMarkExists(context.Background(), bkt, username)
+			require.NoError(t, err)
+			require.Equal(t, tc.exists, res)
+		})
+	}
+}
+
+func TestTenantGlobalDeletionMarkExists(t *testing.T) {
+	const username = "user"
+
+	for name, tc := range map[string]struct {
+		objects      map[string][]byte
+		exists       bool
+		deletedUsers []string
+	}{
+		"empty": {
+			objects: nil,
+			exists:  false,
+		},
+
+		"mark doesn't exist": {
+			objects: map[string][]byte{
+				"user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
+			},
+			exists: false,
+		},
+
+		"mark exists": {
+			objects: map[string][]byte{
+				"user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
+				"markers/user/" + TenantDeletionMarkPath:    []byte("data"),
 			},
 			exists: true,
 		},

--- a/pkg/storage/tsdb/tenant_deletion_mark_test.go
+++ b/pkg/storage/tsdb/tenant_deletion_mark_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/thanos-io/objstore"
 )
 
-func TestTenantLocalDeletionMarkExists(t *testing.T) {
+func TestTenantDeletionMarkExists(t *testing.T) {
 	const username = "user"
 
 	for name, tc := range map[string]struct {
@@ -29,63 +29,17 @@ func TestTenantLocalDeletionMarkExists(t *testing.T) {
 			exists: false,
 		},
 
-		"mark exists": {
+		"local mark exists": {
 			objects: map[string][]byte{
 				"user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
-				"user/" + TenantDeletionMarkPath:            []byte("data"),
+				GetLocalDeletionMarkPath("user"):            []byte("data"),
 			},
 			exists: true,
 		},
-		"mark exists - upload via WriteTenantDeletionMark": {
+		"global mark exists": {
 			objects: map[string][]byte{
 				"user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
-			},
-			deletedUsers: []string{"user"},
-			exists:       true,
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			bkt := objstore.NewInMemBucket()
-			// "upload" objects
-			for objName, data := range tc.objects {
-				require.NoError(t, bkt.Upload(context.Background(), objName, bytes.NewReader(data)))
-			}
-
-			for _, user := range tc.deletedUsers {
-				require.NoError(t, WriteTenantDeletionMark(context.Background(), bkt, user, &TenantDeletionMark{}))
-			}
-
-			res, err := TenantDeletionMarkExists(context.Background(), bkt, username)
-			require.NoError(t, err)
-			require.Equal(t, tc.exists, res)
-		})
-	}
-}
-
-func TestTenantGlobalDeletionMarkExists(t *testing.T) {
-	const username = "user"
-
-	for name, tc := range map[string]struct {
-		objects      map[string][]byte
-		exists       bool
-		deletedUsers []string
-	}{
-		"empty": {
-			objects: nil,
-			exists:  false,
-		},
-
-		"mark doesn't exist": {
-			objects: map[string][]byte{
-				"user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
-			},
-			exists: false,
-		},
-
-		"mark exists": {
-			objects: map[string][]byte{
-				"user/01EQK4QKFHVSZYVJ908Y7HH9E0/meta.json": []byte("data"),
-				"markers/user/" + TenantDeletionMarkPath:    []byte("data"),
+				GetGlobalDeletionMarkPath("user"):           []byte("data"),
 			},
 			exists: true,
 		},

--- a/pkg/storage/tsdb/users_scanner.go
+++ b/pkg/storage/tsdb/users_scanner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/thanos-io/objstore"
@@ -11,7 +12,10 @@ import (
 
 // AllUsers returns true to each call and should be used whenever the UsersScanner should not filter out
 // any user due to sharding.
-func AllUsers(_ string) (bool, error) {
+func AllUsers(user string) (bool, error) {
+	if user == util.GlobalMarkersDir {
+		return false, nil
+	}
 	return true, nil
 }
 

--- a/pkg/storage/tsdb/users_scanner_test.go
+++ b/pkg/storage/tsdb/users_scanner_test.go
@@ -3,7 +3,6 @@ package tsdb
 import (
 	"context"
 	"errors"
-	"path"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -16,8 +15,10 @@ import (
 func TestUsersScanner_ScanUsers_ShouldReturnedOwnedUsersOnly(t *testing.T) {
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("", []string{"user-1", "user-2", "user-3", "user-4"}, nil)
-	bucketClient.MockExists(path.Join("user-1", TenantDeletionMarkPath), false, nil)
-	bucketClient.MockExists(path.Join("user-3", TenantDeletionMarkPath), true, nil)
+	bucketClient.MockExists(GetGlobalDeletionMarkPath("user-1"), false, nil)
+	bucketClient.MockExists(GetLocalDeletionMarkPath("user-1"), false, nil)
+	bucketClient.MockExists(GetGlobalDeletionMarkPath("user-3"), true, nil)
+	bucketClient.MockExists(GetLocalDeletionMarkPath("user-3"), true, nil)
 
 	isOwned := func(userID string) (bool, error) {
 		return userID == "user-1" || userID == "user-3", nil
@@ -36,8 +37,10 @@ func TestUsersScanner_ScanUsers_ShouldReturnUsersForWhichOwnerCheckOrTenantDelet
 
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("", expected, nil)
-	bucketClient.MockExists(path.Join("user-1", TenantDeletionMarkPath), false, nil)
-	bucketClient.MockExists(path.Join("user-2", TenantDeletionMarkPath), false, errors.New("fail"))
+	bucketClient.MockExists(GetGlobalDeletionMarkPath("user-1"), false, nil)
+	bucketClient.MockExists(GetLocalDeletionMarkPath("user-1"), false, nil)
+
+	bucketClient.MockExists(GetGlobalDeletionMarkPath("user-2"), false, errors.New("fail"))
 
 	isOwned := func(userID string) (bool, error) {
 		return false, errors.New("failed to check if user is owned")

--- a/pkg/util/allowed_tenants.go
+++ b/pkg/util/allowed_tenants.go
@@ -37,7 +37,7 @@ func NewAllowedTenants(enabled []string, disabled []string) *AllowedTenants {
 
 func (a *AllowedTenants) IsAllowed(tenantID string) bool {
 	if tenantID == GlobalMarkersDir {
-		// This is reserverd for global markers
+		// __markers__ is reserved for global markers and no tenant should be allowed to have that name.
 		return false
 	}
 

--- a/pkg/util/allowed_tenants.go
+++ b/pkg/util/allowed_tenants.go
@@ -1,5 +1,7 @@
 package util
 
+const GlobalMarkersDir = "__markers__"
+
 // AllowedTenants that can answer whether tenant is allowed or not based on configuration.
 // Default value (nil) allows all tenants.
 type AllowedTenants struct {
@@ -34,6 +36,11 @@ func NewAllowedTenants(enabled []string, disabled []string) *AllowedTenants {
 }
 
 func (a *AllowedTenants) IsAllowed(tenantID string) bool {
+	if tenantID == GlobalMarkersDir {
+		// This is reserverd for global markers
+		return false
+	}
+
 	if a == nil {
 		return true
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- If the `tenant_cleanup_delay` is large (say 24h), a deleted tenant can be continued to be synced by the store-gateways.
- This is because the  `s3://<bucket>/<tenantID>/markers/tenant-deletion-mark.json` will be kept for 24h after the tenant has been deleted.
- If there are a lots of users being created and deleted in the cluster (canary testing), there could be a lot of deleted users synced by the store-gateway.
- This change moves the `tenant-deletion-mark.json` to a global markers directory. 
  - `s3://<bucket>/__markers__/<tenantID>/tenant-deletion-mark.json`
- The string `__markers__` is treated as special an no tenants are allowed to have that name.
- With this change, the tenants can immediately be cleaned up by the cleaner after deletion and no longer has to stay active until `tenant_cleanup_delay`.

**Which issue(s) this PR fixes**:
Fixes #5674 and #5675

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
