### PR TITLE
Upgrade Alpine to 3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [CHANGE] Index Cache: Multi level cache backfilling operation becomes async. Added `-blocks-storage.bucket-store.index-cache.multilevel.max-async-concurrency` and `-blocks-storage.bucket-store.index-cache.multilevel.max-async-buffer-size` configs and metric `cortex_store_multilevel_index_cache_backfill_dropped_items_total` for number of dropped items. #5661
 * [FEATURE] Ingester: Add per-tenant new metric `cortex_ingester_tsdb_data_replay_duration_seconds`. #5477
 * [ENHANCEMENT] Store Gateway: Added `-store-gateway.enabled-tenants` and `-store-gateway.disabled-tenants` to explicitly enable or disable store-gateway for specific tenants. #5638
-* [ENHANCEMENT] Upgraded Docker base images to `alpine:3.18`.
+* [ENHANCEMENT] Upgraded Docker base images to `alpine:3.18`. #5684
 
 ## 1.16.0 2023-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [CHANGE] Index Cache: Multi level cache backfilling operation becomes async. Added `-blocks-storage.bucket-store.index-cache.multilevel.max-async-concurrency` and `-blocks-storage.bucket-store.index-cache.multilevel.max-async-buffer-size` configs and metric `cortex_store_multilevel_index_cache_backfill_dropped_items_total` for number of dropped items. #5661
 * [FEATURE] Ingester: Add per-tenant new metric `cortex_ingester_tsdb_data_replay_duration_seconds`. #5477
 * [ENHANCEMENT] Store Gateway: Added `-store-gateway.enabled-tenants` and `-store-gateway.disabled-tenants` to explicitly enable or disable store-gateway for specific tenants. #5638
+* [ENHANCEMENT] Upgraded Docker base images to `alpine:3.18`.
 
 ## 1.16.0 2023-11-20
 

--- a/cmd/cortex/Dockerfile
+++ b/cmd/cortex/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine:3.17
+FROM       alpine:3.18
 ARG TARGETARCH
 
 RUN        apk add --no-cache ca-certificates

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine:3.17
+FROM       alpine:3.18
 ARG TARGETARCH
 
 RUN        apk add --no-cache ca-certificates

--- a/cmd/test-exporter/Dockerfile
+++ b/cmd/test-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine:3.17
+FROM       alpine:3.18
 ARG TARGETARCH
 RUN        apk add --no-cache ca-certificates
 COPY       test-exporter-$TARGETARCH /test-exporter

--- a/cmd/thanosconvert/Dockerfile
+++ b/cmd/thanosconvert/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine:3.17
+FROM       alpine:3.18
 ARG TARGETARCH
 RUN        apk add --no-cache ca-certificates
 COPY       thanosconvert-$TARGETARCH /thanosconvert

--- a/development/tsdb-blocks-storage-s3-gossip/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3-gossip/dev.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.18
 ENV CGO_ENABLED=0
 RUN go get github.com/go-delve/delve/cmd/dlv
 
-FROM alpine:3.17
+FROM alpine:3.18
 
 RUN     mkdir /cortex
 WORKDIR /cortex

--- a/development/tsdb-blocks-storage-s3-single-binary/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3-single-binary/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.18
 
 RUN     mkdir /cortex
 WORKDIR /cortex

--- a/development/tsdb-blocks-storage-s3/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3/dev.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.18
 ENV CGO_ENABLED=0
 RUN go get github.com/go-delve/delve/cmd/dlv
 
-FROM alpine:3.17
+FROM alpine:3.18
 
 RUN     mkdir /cortex
 WORKDIR /cortex

--- a/development/tsdb-blocks-storage-swift-single-binary/dev.dockerfile
+++ b/development/tsdb-blocks-storage-swift-single-binary/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.18
 
 RUN     mkdir /cortex
 WORKDIR /cortex

--- a/packaging/fpm/Dockerfile
+++ b/packaging/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.18
 
 RUN apk add --no-cache \
         ruby \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Upgrades Alpine to 3.18. Intended to fix several security vulnerabilities in alpine packages. In particular, Jfrog Xray is flagging `CVE-2022-48174`. I'm unsure if it's correct, as the image has the latest busybox in 3.17. Regardless, it's much easier to upgrade to keep scans clean instead of tracking various false positives. I have some 3.18 images and this vuln does not show up.

**Which issue(s) this PR fixes**:
None

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
