### PR TITLE
Improve async processor handling enabled items, optimize code further

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [FEATURE] Ingester: Add per-tenant new metric `cortex_ingester_tsdb_data_replay_duration_seconds`. #5477
 * [ENHANCEMENT] Store Gateway: Added `-store-gateway.enabled-tenants` and `-store-gateway.disabled-tenants` to explicitly enable or disable store-gateway for specific tenants. #5638
 * [ENHANCEMENT] Upgraded Docker base images to `alpine:3.18`. #5684
+* [ENHANCEMENT] Index Cache: Multi level cache adds config `max_backfill_items` to cap max items to backfill per async operation. #5686
 
 ## 1.16.0 2023-11-20
 

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -719,6 +719,10 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.multilevel.max-async-buffer-size
         [max_async_buffer_size: <int> | default = 10000]
 
+        # The maximum number of items to backfill per asynchronous operation.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.multilevel.max-backfill-items
+        [max_backfill_items: <int> | default = 10000]
+
     chunks_cache:
       # Backend for chunks cache, if not empty. Supported values: memcached.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.backend

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -834,6 +834,10 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.multilevel.max-async-buffer-size
         [max_async_buffer_size: <int> | default = 10000]
 
+        # The maximum number of items to backfill per asynchronous operation.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.multilevel.max-backfill-items
+        [max_backfill_items: <int> | default = 10000]
+
     chunks_cache:
       # Backend for chunks cache, if not empty. Supported values: memcached.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.backend

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1268,6 +1268,10 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.index-cache.multilevel.max-async-buffer-size
       [max_async_buffer_size: <int> | default = 10000]
 
+      # The maximum number of items to backfill per asynchronous operation.
+      # CLI flag: -blocks-storage.bucket-store.index-cache.multilevel.max-backfill-items
+      [max_backfill_items: <int> | default = 10000]
+
   chunks_cache:
     # Backend for chunks cache, if not empty. Supported values: memcached.
     # CLI flag: -blocks-storage.bucket-store.chunks-cache.backend

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/google/go-cmp v0.6.0
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	google.golang.org/protobuf v1.31.0
 )
 
@@ -217,7 +218,6 @@ require (
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 // indirect
 	golang.org/x/crypto v0.15.0 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/oauth2 v0.14.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect

--- a/pkg/storage/tsdb/multilevel_cache.go
+++ b/pkg/storage/tsdb/multilevel_cache.go
@@ -3,6 +3,7 @@ package tsdb
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 
 	"github.com/oklog/ulid"
@@ -21,18 +22,22 @@ const (
 )
 
 type multiLevelCache struct {
-	caches []storecache.IndexCache
+	postingsCaches, seriesCaches, expandedPostingCaches []storecache.IndexCache
 
-	fetchLatency         *prometheus.HistogramVec
-	backFillLatency      *prometheus.HistogramVec
-	backfillProcessor    *cacheutil.AsyncOperationProcessor
-	backfillDroppedItems *prometheus.CounterVec
+	fetchLatency                    *prometheus.HistogramVec
+	backFillLatency                 *prometheus.HistogramVec
+	backfillProcessor               *cacheutil.AsyncOperationProcessor
+	backfillDroppedPostings         prometheus.Counter
+	backfillDroppedSeries           prometheus.Counter
+	backfillDroppedExpandedPostings prometheus.Counter
+
+	maxBackfillItems int
 }
 
 func (m *multiLevelCache) StorePostings(blockID ulid.ULID, l labels.Label, v []byte, tenant string) {
 	wg := sync.WaitGroup{}
-	wg.Add(len(m.caches))
-	for _, c := range m.caches {
+	wg.Add(len(m.postingsCaches))
+	for _, c := range m.postingsCaches {
 		cache := c
 		go func() {
 			defer wg.Done()
@@ -48,9 +53,9 @@ func (m *multiLevelCache) FetchMultiPostings(ctx context.Context, blockID ulid.U
 
 	misses = keys
 	hits = map[labels.Label][]byte{}
-	backfillItems := make([]map[labels.Label][]byte, len(m.caches)-1)
-	for i, c := range m.caches {
-		if i < len(m.caches)-1 {
+	backfillItems := make([]map[labels.Label][]byte, len(m.postingsCaches)-1)
+	for i, c := range m.postingsCaches {
+		if i < len(m.postingsCaches)-1 {
 			backfillItems[i] = map[labels.Label][]byte{}
 		}
 		if ctx.Err() != nil {
@@ -76,14 +81,20 @@ func (m *multiLevelCache) FetchMultiPostings(ctx context.Context, blockID ulid.U
 		backFillTimer := prometheus.NewTimer(m.backFillLatency.WithLabelValues(cacheTypePostings))
 		defer backFillTimer.ObserveDuration()
 		for i, values := range backfillItems {
-			for lbl, b := range values {
-				lbl := lbl
-				b := b
-				if err := m.backfillProcessor.EnqueueAsync(func() {
-					m.caches[i].StorePostings(blockID, lbl, b, tenant)
-				}); errors.Is(err, cacheutil.ErrAsyncBufferFull) {
-					m.backfillDroppedItems.WithLabelValues(cacheTypePostings).Inc()
+			i := i
+			values := values
+			if err := m.backfillProcessor.EnqueueAsync(func() {
+				cnt := 0
+				for lbl, b := range values {
+					m.postingsCaches[i].StorePostings(blockID, lbl, b, tenant)
+					cnt++
+					if cnt == m.maxBackfillItems {
+						m.backfillDroppedSeries.Add(float64(len(values) - cnt))
+						return
+					}
 				}
+			}); errors.Is(err, cacheutil.ErrAsyncBufferFull) {
+				m.backfillDroppedPostings.Add(float64(len(values)))
 			}
 		}
 	}()
@@ -93,8 +104,8 @@ func (m *multiLevelCache) FetchMultiPostings(ctx context.Context, blockID ulid.U
 
 func (m *multiLevelCache) StoreExpandedPostings(blockID ulid.ULID, matchers []*labels.Matcher, v []byte, tenant string) {
 	wg := sync.WaitGroup{}
-	wg.Add(len(m.caches))
-	for _, c := range m.caches {
+	wg.Add(len(m.expandedPostingCaches))
+	for _, c := range m.expandedPostingCaches {
 		cache := c
 		go func() {
 			defer wg.Done()
@@ -108,7 +119,7 @@ func (m *multiLevelCache) FetchExpandedPostings(ctx context.Context, blockID uli
 	timer := prometheus.NewTimer(m.fetchLatency.WithLabelValues(cacheTypeExpandedPostings))
 	defer timer.ObserveDuration()
 
-	for i, c := range m.caches {
+	for i, c := range m.expandedPostingCaches {
 		if ctx.Err() != nil {
 			return nil, false
 		}
@@ -116,9 +127,9 @@ func (m *multiLevelCache) FetchExpandedPostings(ctx context.Context, blockID uli
 			if i > 0 {
 				backFillTimer := prometheus.NewTimer(m.backFillLatency.WithLabelValues(cacheTypeExpandedPostings))
 				if err := m.backfillProcessor.EnqueueAsync(func() {
-					m.caches[i-1].StoreExpandedPostings(blockID, matchers, d, tenant)
+					m.expandedPostingCaches[i-1].StoreExpandedPostings(blockID, matchers, d, tenant)
 				}); errors.Is(err, cacheutil.ErrAsyncBufferFull) {
-					m.backfillDroppedItems.WithLabelValues(cacheTypeExpandedPostings).Inc()
+					m.backfillDroppedExpandedPostings.Inc()
 				}
 				backFillTimer.ObserveDuration()
 			}
@@ -131,8 +142,8 @@ func (m *multiLevelCache) FetchExpandedPostings(ctx context.Context, blockID uli
 
 func (m *multiLevelCache) StoreSeries(blockID ulid.ULID, id storage.SeriesRef, v []byte, tenant string) {
 	wg := sync.WaitGroup{}
-	wg.Add(len(m.caches))
-	for _, c := range m.caches {
+	wg.Add(len(m.seriesCaches))
+	for _, c := range m.seriesCaches {
 		cache := c
 		go func() {
 			defer wg.Done()
@@ -148,10 +159,10 @@ func (m *multiLevelCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULI
 
 	misses = ids
 	hits = map[storage.SeriesRef][]byte{}
-	backfillItems := make([]map[storage.SeriesRef][]byte, len(m.caches)-1)
+	backfillItems := make([]map[storage.SeriesRef][]byte, len(m.seriesCaches)-1)
 
-	for i, c := range m.caches {
-		if i < len(m.caches)-1 {
+	for i, c := range m.seriesCaches {
+		if i < len(m.seriesCaches)-1 {
 			backfillItems[i] = map[storage.SeriesRef][]byte{}
 		}
 		if ctx.Err() != nil {
@@ -177,14 +188,20 @@ func (m *multiLevelCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULI
 		backFillTimer := prometheus.NewTimer(m.backFillLatency.WithLabelValues(cacheTypeSeries))
 		defer backFillTimer.ObserveDuration()
 		for i, values := range backfillItems {
-			for ref, b := range values {
-				ref := ref
-				b := b
-				if err := m.backfillProcessor.EnqueueAsync(func() {
-					m.caches[i].StoreSeries(blockID, ref, b, tenant)
-				}); errors.Is(err, cacheutil.ErrAsyncBufferFull) {
-					m.backfillDroppedItems.WithLabelValues(cacheTypeSeries).Inc()
+			i := i
+			values := values
+			if err := m.backfillProcessor.EnqueueAsync(func() {
+				cnt := 0
+				for ref, b := range values {
+					m.seriesCaches[i].StoreSeries(blockID, ref, b, tenant)
+					cnt++
+					if cnt == m.maxBackfillItems {
+						m.backfillDroppedSeries.Add(float64(len(values) - cnt))
+						return
+					}
 				}
+			}); errors.Is(err, cacheutil.ErrAsyncBufferFull) {
+				m.backfillDroppedSeries.Add(float64(len(values)))
 			}
 		}
 	}()
@@ -192,14 +209,33 @@ func (m *multiLevelCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULI
 	return hits, misses
 }
 
-func newMultiLevelCache(reg prometheus.Registerer, cfg MultiLevelIndexCacheConfig, c ...storecache.IndexCache) storecache.IndexCache {
+func filterCachesByItem(enabledItems [][]string, cachedItem string, c ...storecache.IndexCache) []storecache.IndexCache {
+	filteredCaches := make([]storecache.IndexCache, 0, len(c))
+	for i := range enabledItems {
+		if len(enabledItems[i]) == 0 || slices.Contains(enabledItems[i], cachedItem) {
+			filteredCaches = append(filteredCaches, c[i])
+		}
+	}
+	return filteredCaches
+}
+
+func newMultiLevelCache(reg prometheus.Registerer, cfg MultiLevelIndexCacheConfig, enabledItems [][]string, c ...storecache.IndexCache) storecache.IndexCache {
 	if len(c) == 1 {
-		return c[0]
+		if len(enabledItems[0]) == 0 {
+			return c[0]
+		}
+		return storecache.NewFilteredIndexCache(c[0], enabledItems[0])
 	}
 
+	backfillDroppedItems := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_store_multilevel_index_cache_backfill_dropped_items_total",
+		Help: "Total number of items dropped due to async buffer full when backfilling multilevel cache ",
+	}, []string{"item_type"})
 	return &multiLevelCache{
-		caches:            c,
-		backfillProcessor: cacheutil.NewAsyncOperationProcessor(cfg.MaxAsyncBufferSize, cfg.MaxAsyncConcurrency),
+		postingsCaches:        filterCachesByItem(enabledItems, cacheTypePostings, c...),
+		seriesCaches:          filterCachesByItem(enabledItems, cacheTypeSeries, c...),
+		expandedPostingCaches: filterCachesByItem(enabledItems, cacheTypeExpandedPostings, c...),
+		backfillProcessor:     cacheutil.NewAsyncOperationProcessor(cfg.MaxAsyncBufferSize, cfg.MaxAsyncConcurrency),
 		fetchLatency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "cortex_store_multilevel_index_cache_fetch_duration_seconds",
 			Help:    "Histogram to track latency to fetch items from multi level index cache",
@@ -210,9 +246,9 @@ func newMultiLevelCache(reg prometheus.Registerer, cfg MultiLevelIndexCacheConfi
 			Help:    "Histogram to track latency to backfill items from multi level index cache",
 			Buckets: []float64{0.01, 0.1, 0.3, 0.6, 1, 3, 6, 10, 15, 20, 25, 30, 40, 50, 60, 90},
 		}, []string{"item_type"}),
-		backfillDroppedItems: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_store_multilevel_index_cache_backfill_dropped_items_total",
-			Help: "Total number of items dropped due to async buffer full when backfilling multilevel cache ",
-		}, []string{"item_type"}),
+		backfillDroppedPostings:         backfillDroppedItems.WithLabelValues(cacheTypePostings),
+		backfillDroppedSeries:           backfillDroppedItems.WithLabelValues(cacheTypeSeries),
+		backfillDroppedExpandedPostings: backfillDroppedItems.WithLabelValues(cacheTypeExpandedPostings),
+		maxBackfillItems:                cfg.MaxBackfillItems,
 	}
 }

--- a/pkg/storage/tsdb/multilevel_cache.go
+++ b/pkg/storage/tsdb/multilevel_cache.go
@@ -3,7 +3,6 @@ package tsdb
 import (
 	"context"
 	"errors"
-	"slices"
 	"sync"
 
 	"github.com/oklog/ulid"
@@ -13,6 +12,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/thanos-io/thanos/pkg/cacheutil"
 	storecache "github.com/thanos-io/thanos/pkg/store/cache"
+	"golang.org/x/exp/slices"
 )
 
 const (

--- a/pkg/storage/tsdb/multilevel_cache.go
+++ b/pkg/storage/tsdb/multilevel_cache.go
@@ -83,13 +83,16 @@ func (m *multiLevelCache) FetchMultiPostings(ctx context.Context, blockID ulid.U
 		for i, values := range backfillItems {
 			i := i
 			values := values
+			if len(values) == 0 {
+				continue
+			}
 			if err := m.backfillProcessor.EnqueueAsync(func() {
 				cnt := 0
 				for lbl, b := range values {
 					m.postingsCaches[i].StorePostings(blockID, lbl, b, tenant)
 					cnt++
 					if cnt == m.maxBackfillItems {
-						m.backfillDroppedSeries.Add(float64(len(values) - cnt))
+						m.backfillDroppedPostings.Add(float64(len(values) - cnt))
 						return
 					}
 				}
@@ -190,6 +193,9 @@ func (m *multiLevelCache) FetchMultiSeries(ctx context.Context, blockID ulid.ULI
 		for i, values := range backfillItems {
 			i := i
 			values := values
+			if len(values) == 0 {
+				continue
+			}
 			if err := m.backfillProcessor.EnqueueAsync(func() {
 				cnt := 0
 				for ref, b := range values {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Refactored multilevel cache code to integrate it better with cache items filtering.
By filtering caches in multilevel cache itself, we can avoid putting unnecessary tasks into the async processor queue.

We observed that when backfilling  a large amount of items (10M+), even if the operation is async, putting all items into the backfill queue can already take 20s+.

This change also refactor the async queue operation to not enqueue items one by one, instead we enqueue the whole items that need backfilling, and we have a cap to avoid backfilling too much data

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
