### PR TITLE
Replace sort.Slice with slices.SortFunc

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	io "io"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -25,6 +25,7 @@ import (
 	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/user"
 	"go.uber.org/atomic"
+	"golang.org/x/exp/slices"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/cortexproject/cortex/pkg/ha"
@@ -873,8 +874,8 @@ func sortLabelsIfNeeded(labels []cortexpb.LabelAdapter) {
 		return
 	}
 
-	sort.Slice(labels, func(i, j int) bool {
-		return strings.Compare(labels[i].Name, labels[j].Name) < 0
+	slices.SortFunc(labels, func(a, b cortexpb.LabelAdapter) int {
+		return strings.Compare(a.Name, b.Name)
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

I see `sort.Slice` under `sortLabelsIfNeeded` taking 3% CPU time of distributor.
Similar idea of https://github.com/prometheus/prometheus/pull/12539 from upstream prometheus as the new function should have a better performance. Unsure how much this could help, need some benchmark.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
