### PR TITLE
fix query priority throws 5xx when 4xx

### DIFF
--- a/pkg/querier/tripperware/priority.go
+++ b/pkg/querier/tripperware/priority.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	parseError = errors.New("failed to parse expr")
+	errParseExpr = errors.New("failed to parse expr")
 )
 
 func GetPriority(r *http.Request, userID string, limits Limits, now time.Time, lookbackDelta time.Duration) (int64, error) {
@@ -30,7 +30,7 @@ func GetPriority(r *http.Request, userID string, limits Limits, now time.Time, l
 	if err != nil {
 		// If query fails to be parsed, we throw a simple parse error
 		// and fail query later on querier.
-		return 0, parseError
+		return 0, errParseExpr
 	}
 
 	if len(queryPriority.Priorities) == 0 {

--- a/pkg/querier/tripperware/priority.go
+++ b/pkg/querier/tripperware/priority.go
@@ -1,6 +1,7 @@
 package tripperware
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -9,6 +10,10 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/validation"
+)
+
+var (
+	parseError = errors.New("failed to parse expr")
 )
 
 func GetPriority(r *http.Request, userID string, limits Limits, now time.Time, lookbackDelta time.Duration) (int64, error) {
@@ -23,7 +28,9 @@ func GetPriority(r *http.Request, userID string, limits Limits, now time.Time, l
 
 	expr, err := parser.ParseExpr(query)
 	if err != nil {
-		return 0, err
+		// If query fails to be parsed, we throw a simple parse error
+		// and fail query later on querier.
+		return 0, parseError
 	}
 
 	if len(queryPriority.Priorities) == 0 {

--- a/pkg/querier/tripperware/priority_test.go
+++ b/pkg/querier/tripperware/priority_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
-func Test_GetPriorityShouldReturnDefaultPriorityIfNotEnabledOrEmptyQueryString(t *testing.T) {
+func Test_GetPriorityShouldReturnDefaultPriorityIfNotEnabledOrInvalidQueryString(t *testing.T) {
 	now := time.Now()
 	limits := mockLimits{queryPriority: validation.QueryPriority{
 		Priorities: []validation.PriorityDef{
@@ -33,6 +33,7 @@ func Test_GetPriorityShouldReturnDefaultPriorityIfNotEnabledOrEmptyQueryString(t
 	type testCase struct {
 		url                  string
 		queryPriorityEnabled bool
+		err                  error
 	}
 
 	tests := map[string]testCase{
@@ -43,9 +44,19 @@ func Test_GetPriorityShouldReturnDefaultPriorityIfNotEnabledOrEmptyQueryString(t
 			url:                  "/query?query=",
 			queryPriorityEnabled: true,
 		},
+		"shouldn't return error if query is invalid": {
+			url:                  "/query?query=up[4h",
+			queryPriorityEnabled: true,
+			err:                  parseError,
+		},
 		"should miss if query string empty - range query": {
 			url:                  "/query_range?query=",
 			queryPriorityEnabled: true,
+		},
+		"shouldn't return error if query is invalid, range query": {
+			url:                  "/query_range?query=up[4h",
+			queryPriorityEnabled: true,
+			err:                  parseError,
 		},
 		"should miss if neither instant nor range query": {
 			url:                  "/series",
@@ -58,7 +69,11 @@ func Test_GetPriorityShouldReturnDefaultPriorityIfNotEnabledOrEmptyQueryString(t
 			limits.queryPriority.Enabled = testData.queryPriorityEnabled
 			req, _ := http.NewRequest(http.MethodPost, testData.url, bytes.NewReader([]byte{}))
 			priority, err := GetPriority(req, "", limits, now, 0)
-			assert.NoError(t, err)
+			if err != nil {
+				assert.Equal(t, testData.err, err)
+			} else {
+				assert.NoError(t, err)
+			}
 			assert.Equal(t, int64(0), priority)
 		})
 	}

--- a/pkg/querier/tripperware/priority_test.go
+++ b/pkg/querier/tripperware/priority_test.go
@@ -47,7 +47,7 @@ func Test_GetPriorityShouldReturnDefaultPriorityIfNotEnabledOrInvalidQueryString
 		"shouldn't return error if query is invalid": {
 			url:                  "/query?query=up[4h",
 			queryPriorityEnabled: true,
-			err:                  parseError,
+			err:                  errParseExpr,
 		},
 		"should miss if query string empty - range query": {
 			url:                  "/query_range?query=",
@@ -56,7 +56,7 @@ func Test_GetPriorityShouldReturnDefaultPriorityIfNotEnabledOrInvalidQueryString
 		"shouldn't return error if query is invalid, range query": {
 			url:                  "/query_range?query=up[4h",
 			queryPriorityEnabled: true,
-			err:                  parseError,
+			err:                  errParseExpr,
 		},
 		"should miss if neither instant nor range query": {
 			url:                  "/series",

--- a/pkg/querier/tripperware/roundtrip.go
+++ b/pkg/querier/tripperware/roundtrip.go
@@ -17,7 +17,6 @@ package tripperware
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -162,13 +161,10 @@ func NewQueryTripperware(
 
 					if limits != nil && limits.QueryPriority(userStr).Enabled {
 						priority, err := GetPriority(r, userStr, limits, now, lookbackDelta)
-						if err != nil {
-							if errors.Is(err, parseError) {
-								// If query is invalid, no need to go through tripperwares
-								// for further splitting.
-								return next.RoundTrip(r)
-							}
-							return nil, err
+						if err != nil && err == errParseExpr {
+							// If query is invalid, no need to go through tripperwares
+							// for further splitting.
+							return next.RoundTrip(r)
 						}
 						r.Header.Set(util.QueryPriorityHeaderKey, strconv.FormatInt(priority, 10))
 					}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

When a query fails to be parsed in query priority, we return parse error and the error will be converted to 5xx server error.
This pr changes the code to forward the request to querier instead and let it returns 4xx error.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
