### PR TITLE
Add new ListRuleRingOp to ruler and add more logs to the changeState in basic lifecycler

### DIFF
--- a/pkg/ring/basic_lifecycler.go
+++ b/pkg/ring/basic_lifecycler.go
@@ -469,20 +469,21 @@ func (l *BasicLifecycler) heartbeat(ctx context.Context) {
 // changeState of the instance within the ring. This function is guaranteed
 // to be called within the lifecycler main goroutine.
 func (l *BasicLifecycler) changeState(ctx context.Context, state InstanceState) error {
+	oldState := l.GetState()
 	err := l.updateInstance(ctx, func(_ *Desc, i *InstanceDesc) bool {
 		// No-op if the state hasn't changed.
 		if i.State == state {
 			return false
 		}
-
 		i.State = state
 		return true
 	})
 
 	if err != nil {
-		level.Warn(l.logger).Log("msg", "failed to change instance state in the ring", "from", l.GetState(), "to", state, "err", err)
+		level.Info(l.logger).Log("msg", "failed to change instance state in the ring", "from", oldState, "to", state, "ring", l.ringName, "err", err)
+	} else {
+		level.Info(l.logger).Log("msg", "successfully changed instance state from", "old_state", oldState, "to", state, "ring", l.ringName)
 	}
-
 	return err
 }
 

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -930,7 +930,7 @@ func NewOp(healthyStates []InstanceState, shouldExtendReplicaSet func(s Instance
 	}
 
 	if shouldExtendReplicaSet != nil {
-		for _, s := range []InstanceState{ACTIVE, LEAVING, PENDING, JOINING, LEAVING, LEFT} {
+		for _, s := range []InstanceState{ACTIVE, LEAVING, PENDING, JOINING, LEFT} {
 			if shouldExtendReplicaSet(s) {
 				op |= (0x10000 << s)
 			}

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -878,7 +878,7 @@ func (r *Ruler) getShardedRules(ctx context.Context, userID string, rulesRequest
 		ring = r.ring.ShuffleShard(userID, shardSize)
 	}
 
-	rulers, err := ring.GetReplicationSetForOperation(RingOp)
+	rulers, err := ring.GetReplicationSetForOperation(ListRuleRingOp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ruler/ruler_ring.go
+++ b/pkg/ruler/ruler_ring.go
@@ -26,6 +26,13 @@ var RingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, func(s ring.InstanceS
 	return s != ring.ACTIVE
 })
 
+// ListRuleRingOp is the operation used for getting rule groups from rulers.
+var ListRuleRingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, func(s ring.InstanceState) bool {
+	// Although LEAVING ruler does not get any rule groups. If it is excluded, list rule will fail because not enough healthy instance.
+	// So we still try to read from the LEAVING ruler, although it might return empty result
+	return s != ring.ACTIVE && s != ring.LEAVING
+})
+
 // RingConfig masks the ring lifecycler config which contains
 // many options not really required by the rulers ring. This config
 // is used to strip down the config to the minimum, and avoid confusion

--- a/pkg/ruler/ruler_ring.go
+++ b/pkg/ruler/ruler_ring.go
@@ -27,10 +27,10 @@ var RingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, func(s ring.InstanceS
 })
 
 // ListRuleRingOp is the operation used for getting rule groups from rulers.
-var ListRuleRingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, func(s ring.InstanceState) bool {
+var ListRuleRingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE, ring.LEAVING}, func(s ring.InstanceState) bool {
 	// Although LEAVING ruler does not get any rule groups. If it is excluded, list rule will fail because not enough healthy instance.
-	// So we still try to read from the LEAVING ruler, although it might return empty result
-	return s != ring.ACTIVE && s != ring.LEAVING
+	// So we still consider LEAVING as healthy. We also want to extend the listRule calls when the instance in the shard is not ACTIVE
+	return s != ring.ACTIVE
 })
 
 // RingConfig masks the ring lifecycler config which contains


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
1. Since ruler is not HA yet, when a ruler stopping, it briefly set it self to LEAVING first, and then removes itself from the KVStore.

There is some period of time when other ruler thinks this ruler is in LEAVING state, causing list rule 5xx with error `too many unhealthy instances in the ring`

If we consider LEAVING rule as healthy when list rules, we won't encounter this problem. And LEAVING ruler will still serve list rule request and after about 1min, the ruler will be removed from KV and ring, then request won't go to this ruler anymore.

2. Also added some log in changeState in basic lifecycler, so we have better visibility of the state change of instance.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
