### PR TITLE
Filter empty labels from sharding key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * [ENHANCEMENT] Upgraded Docker base images to `alpine:3.18`. #5684
 * [ENHANCEMENT] Index Cache: Multi level cache adds config `max_backfill_items` to cap max items to backfill per async operation. #5686
 * [ENHANCEMENT] Query Frontend: Log number of split queries in `query stats` log. #5703
+* [BUGFIX] Distributor: Do not use label with empty values for sharding #5717
+
 
 ## 1.16.0 2023-11-20
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -466,8 +466,10 @@ func shardByUser(userID string) uint32 {
 func shardByAllLabels(userID string, labels []cortexpb.LabelAdapter) uint32 {
 	h := shardByUser(userID)
 	for _, label := range labels {
-		h = ingester_client.HashAdd32(h, label.Name)
-		h = ingester_client.HashAdd32(h, label.Value)
+		if len(label.Value) > 0 {
+			h = ingester_client.HashAdd32(h, label.Name)
+			h = ingester_client.HashAdd32(h, label.Value)
+		}
 	}
 	return h
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Prometheus drops labels which are empty
https://github.com/prometheus/prometheus/blob/69abd6d9f65a6358025461510237366f1d939c70/tsdb/head_append.go#L429

When creating the sharding token in distributor for income timeserie we use all labels to create the token. We end up in a situation where after dropping labels with empty values, we have the same timeserie in multiple ingesters. This change ignore labels with empty values to be used by sharding.

**Which issue(s) this PR fixes**:


**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
