### PR TITLE
Compactor should skip retry without failure if there is permission denied error

### DIFF
--- a/pkg/storage/bucket/client_mock.go
+++ b/pkg/storage/bucket/client_mock.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	errObjectDoesNotExist  = errors.New("object does not exist")
-	errKeyPermissionDenied = errors.New("object key permission denied")
+	ErrKeyPermissionDenied = errors.New("object key permission denied")
 )
 
 // ClientMock mocks objstore.Bucket
@@ -188,7 +188,7 @@ func (m *ClientMock) IsObjNotFoundErr(err error) bool {
 
 // IsAccessDeniedErr mocks objstore.Bucket.IsAccessDeniedErr()
 func (m *ClientMock) IsAccessDeniedErr(err error) bool {
-	return err == errKeyPermissionDenied
+	return err == ErrKeyPermissionDenied
 }
 
 // ObjectSize mocks objstore.Bucket.Attributes()

--- a/pkg/storage/bucket/sse_bucket_client_test.go
+++ b/pkg/storage/bucket/sse_bucket_client_test.go
@@ -111,7 +111,7 @@ func Test_shouldWrapSSeErrors(t *testing.T) {
 
 	bkt := &ClientMock{}
 
-	bkt.MockGet("Test", "someContent", errKeyPermissionDenied)
+	bkt.MockGet("Test", "someContent", ErrKeyPermissionDenied)
 
 	sseBkt := NewSSEBucketClient("user-1", bkt, cfgProvider)
 


### PR DESCRIPTION
…

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Compactor should skip retry without failure if there is permission denied error. Because permission denied error caused by CMK cannot be auto resolved until operator set up the permission correctly. Also, check logic [here](https://github.com/cortexproject/cortex/blob/8282a2f538483919f0e7010c6958e4f7beb3db8e/pkg/compactor/compactor.go#L709) should prevent next compaction to start if CMK error is not fixed.

**Which issue(s) this PR fixes**:
NA

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
