### PR TITLE
otlpgrpc: turn on round_robin LB policy and kuberesolver for resolving k8s service endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * [CHANGE] Index Cache: Multi level cache backfilling operation becomes async. Added `-blocks-storage.bucket-store.index-cache.multilevel.max-async-concurrency` and `-blocks-storage.bucket-store.index-cache.multilevel.max-async-buffer-size` configs and metric `cortex_store_multilevel_index_cache_backfill_dropped_items_total` for number of dropped items. #5661
 * [FEATURE] Ingester: Add per-tenant new metric `cortex_ingester_tsdb_data_replay_duration_seconds`. #5477
 * [FEATURE] Query Frontend/Scheduler: Add query priority support. #5605
-* [FEATURE] Tracing: Use `round_robin` gRPC client side LB policy for sending OTLP traces. Also enables `kuberesolver` to resolve endpoints address with `kubernetes://` prefix as Kubernetes service. #5731
+* [FEATURE] Tracing: Add `kuberesolver` to resolve endpoints address with `kubernetes://` prefix as Kubernetes service. #5731
+* [FEATURE] Tracing: Add `tracing.otel.round-robin` flag to use `round_robin` gRPC client side LB policy for sending OTLP traces. #5731
 * [ENHANCEMENT] Store Gateway: Added `-store-gateway.enabled-tenants` and `-store-gateway.disabled-tenants` to explicitly enable or disable store-gateway for specific tenants. #5638
 * [ENHANCEMENT] Compactor: Add new compactor metric `cortex_compactor_start_duration_seconds`. #5683
 * [ENHANCEMENT] Upgraded Docker base images to `alpine:3.18`. #5684

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [CHANGE] Index Cache: Multi level cache backfilling operation becomes async. Added `-blocks-storage.bucket-store.index-cache.multilevel.max-async-concurrency` and `-blocks-storage.bucket-store.index-cache.multilevel.max-async-buffer-size` configs and metric `cortex_store_multilevel_index_cache_backfill_dropped_items_total` for number of dropped items. #5661
 * [FEATURE] Ingester: Add per-tenant new metric `cortex_ingester_tsdb_data_replay_duration_seconds`. #5477
 * [FEATURE] Query Frontend/Scheduler: Add query priority support. #5605
+* [FEATURE] Tracing: Use `round_robin` gRPC client side LB policy for sending OTLP traces. Also enables `kuberesolver` to resolve endpoints address with `kubernetes://` prefix as Kubernetes service. #5731
 * [ENHANCEMENT] Store Gateway: Added `-store-gateway.enabled-tenants` and `-store-gateway.disabled-tenants` to explicitly enable or disable store-gateway for specific tenants. #5638
 * [ENHANCEMENT] Compactor: Add new compactor metric `cortex_compactor_start_duration_seconds`. #5683
 * [ENHANCEMENT] Upgraded Docker base images to `alpine:3.18`. #5684

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -5024,6 +5024,12 @@ otel:
   # CLI flag: -tracing.otel.sample-ratio
   [sample_ratio: <float> | default = 0.001]
 
+  # If enabled, use round_robin gRPC load balancing policy. By default, use
+  # pick_first policy. For more details, please refer to
+  # https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#load-balancing-policies.
+  # CLI flag: -tracing.otel.round-robin
+  [round_robin: <boolean> | default = false]
+
   # Enable TLS in the GRPC client. This flag needs to be enabled when any other
   # TLS flag is set. If set to false, insecure connection to gRPC server will be
   # used.

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/google/go-cmp v0.6.0
+	github.com/sercand/kuberesolver v2.4.0+incompatible
 	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb
 	google.golang.org/protobuf v1.31.0
 )
@@ -196,7 +197,6 @@ require (
 	github.com/rs/cors v1.9.0 // indirect
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
-	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

For tracing with opentelemetry, Cortex uses otlpgrpc protocol to send traces to OTLP backends.

When you have multiple tracing backends, it is always recommended to have load balancing. Since gRPC is a long lived connection, it is more recommended to do client side loadbalancing. For more details, can refer to https://github.com/grpc/grpc/blob/master/doc/load-balancing.md. In this pr, I added an option to enable `round_robin` policy, by default it is `pick_first`.

This pr also enables `kuberesolver` support which allows to resolve endpoint with prefix `kubernetes://`, for example `kubernetes://opentelemetry-collector.tracing:4317` to be resolved as a k8s service and return the actual endpoint IPs (pod IP). This is helpful because `kuberesolver` watches the backend endpoints changes and allows client side loadbalancing to send requests to newly scaled up pods such as through HPA.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
