### PR TITLE
Use bytes reader to retry file upload to S3

### DIFF
--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -116,7 +116,7 @@ func (s *BucketAlertStore) SetAlertConfig(ctx context.Context, cfg alertspb.Aler
 		return err
 	}
 
-	return s.getUserBucket(cfg.User).Upload(ctx, cfg.User, bytes.NewBuffer(cfgBytes))
+	return s.getUserBucket(cfg.User).Upload(ctx, cfg.User, bytes.NewReader(cfgBytes))
 }
 
 // DeleteAlertConfig implements alertstore.AlertStore.
@@ -168,7 +168,7 @@ func (s *BucketAlertStore) SetFullState(ctx context.Context, userID string, fs a
 		return err
 	}
 
-	return bkt.Upload(ctx, fullStateName, bytes.NewBuffer(fsBytes))
+	return bkt.Upload(ctx, fullStateName, bytes.NewReader(fsBytes))
 }
 
 // DeleteFullState implements alertstore.AlertStore.

--- a/pkg/ruler/rulestore/bucketclient/bucket_client.go
+++ b/pkg/ruler/rulestore/bucketclient/bucket_client.go
@@ -252,7 +252,7 @@ func (b *BucketRuleStore) SetRuleGroup(ctx context.Context, userID string, names
 		return err
 	}
 
-	return userBucket.Upload(ctx, getRuleGroupObjectKey(namespace, group.Name), bytes.NewBuffer(data))
+	return userBucket.Upload(ctx, getRuleGroupObjectKey(namespace, group.Name), bytes.NewReader(data))
 }
 
 // DeleteRuleGroup implements rules.RuleStore.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

In S3 bucket with retries client, we require input object to be a `Seeker` so that the request is retriable.

For ruler and alertmanager, some upload operations still use `bytes.NewBuffer`, which doesn't implement `Seeker` so that upload to S3 operation may fail without any retries.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
