### PR TITLE
Use RWMutex as lock for ruler userManagerMtx to allow for multiple reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [ENHANCEMENT] Upgraded Docker base images to `alpine:3.18`. #5684
 * [ENHANCEMENT] Index Cache: Multi level cache adds config `max_backfill_items` to cap max items to backfill per async operation. #5686
 * [ENHANCEMENT] Query Frontend: Log number of split queries in `query stats` log. #5703
+* [ENHANCEMENT] Ruler: Allow concurrent `GetRules`. #5737
 * [BUGFIX] Distributor: Do not use label with empty values for sharding #5717
 * [BUGFIX] Query Frontend: queries with negative offset should check whether it is cacheable or not. #5719
 * [BUGFIX] Redis Cache: pass `cache_size` config correctly. #5734

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -32,7 +32,7 @@ type DefaultMultiTenantManager struct {
 
 	// Structs for holding per-user Prometheus rules Managers
 	// and a corresponding metrics struct
-	userManagerMtx     sync.Mutex
+	userManagerMtx     sync.RWMutex
 	userManagers       map[string]RulesManager
 	userManagerMetrics *ManagerMetrics
 
@@ -250,11 +250,11 @@ func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string, userManag
 
 func (r *DefaultMultiTenantManager) GetRules(userID string) []*promRules.Group {
 	var groups []*promRules.Group
-	r.userManagerMtx.Lock()
+	r.userManagerMtx.RLock()
+	defer r.userManagerMtx.RUnlock()
 	if mngr, exists := r.userManagers[userID]; exists {
 		groups = mngr.RuleGroups()
 	}
-	r.userManagerMtx.Unlock()
 	return groups
 }
 

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -97,8 +97,8 @@ func TestSyncRuleGroups(t *testing.T) {
 }
 
 func getManager(m *DefaultMultiTenantManager, user string) RulesManager {
-	m.userManagerMtx.Lock()
-	defer m.userManagerMtx.Unlock()
+	m.userManagerMtx.RLock()
+	defer m.userManagerMtx.RUnlock()
 
 	return m.userManagers[user]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
I think ruler's `DefaultMultiTenantManager` should allow for multiple concurrent `GetRules` as long
as `SyncRuleGroups` is not running. I don't see a reason why  `GetRules` have to be sequential. 

**Which issue(s) this PR fixes**:


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
