### PR TITLE
Fix redis cache client metrics registration error

### DIFF
--- a/pkg/storage/tsdb/index_cache.go
+++ b/pkg/storage/tsdb/index_cache.go
@@ -225,7 +225,7 @@ func NewIndexCache(cfg IndexCacheConfig, logger log.Logger, registerer prometheu
 			caches = append(caches, cache)
 			enabledItems = append(enabledItems, cfg.Memcached.EnabledItems)
 		case IndexCacheBackendRedis:
-			c, err := newRedisIndexCacheClient(cfg.Redis.ClientConfig, logger, iReg)
+			c, err := newRedisIndexCacheClient(cfg.Redis.ClientConfig, logger, registerer)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
The issue of duplicated metrics registration but different labels is due to us using a wrong metric registry. Similar to when initializing memcached client, we use `registerer`, not `iReg` https://github.com/cortexproject/cortex/blob/master/pkg/storage/tsdb/index_cache.go#L216.

Fix verified locally.

TODO:
I still need to add an integration test case to make sure we catch the regression earlier.

**Which issue(s) this PR fixes**:
Fixes #5723

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
