### PR TITLE
Distributor default sharding should support default 0 value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [BUGFIX] Distributor: Do not use label with empty values for sharding #5717
 * [BUGFIX] Query Frontend: queries with negative offset should check whether it is cacheable or not. #5719
 * [BUGFIX] Redis Cache: pass `cache_size` config correctly. #5734
+* [BUGFIX] Ingester: Shuffle-Sharding with IngestionTenantShardSize == 0, default sharding strategy should be used #5189
 
 
 ## 1.16.0 2023-11-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * [BUGFIX] Distributor: Do not use label with empty values for sharding #5717
 * [BUGFIX] Query Frontend: queries with negative offset should check whether it is cacheable or not. #5719
 * [BUGFIX] Redis Cache: pass `cache_size` config correctly. #5734
-* [BUGFIX] Ingester: Shuffle-Sharding with IngestionTenantShardSize == 0, default sharding strategy should be used #5189
+* [BUGFIX] Distributor: Shuffle-Sharding with IngestionTenantShardSize == 0, default sharding strategy should be used #5189
 
 
 ## 1.16.0 2023-11-20

--- a/integration/ingester_sharding_test.go
+++ b/integration/ingester_sharding_test.go
@@ -27,15 +27,27 @@ func TestIngesterSharding(t *testing.T) {
 		tenantShardSize             int
 		expectedIngestersWithSeries int
 	}{
-		"default sharding strategy should spread series across all ingesters": {
+		//Default Sharding Strategy
+		"default sharding strategy should be ignored and spread across all ingesters": {
 			shardingStrategy:            "default",
 			tenantShardSize:             2, // Ignored by default strategy.
 			expectedIngestersWithSeries: 3,
 		},
+		"default sharding strategy should spread series across all ingesters": {
+			shardingStrategy:            "default",
+			tenantShardSize:             0, // Ignored by default strategy.
+			expectedIngestersWithSeries: 3,
+		},
+		//Shuffle Sharding Strategy
 		"shuffle-sharding strategy should spread series across the configured shard size number of ingesters": {
 			shardingStrategy:            "shuffle-sharding",
 			tenantShardSize:             2,
 			expectedIngestersWithSeries: 2,
+		},
+		"Tenant Shard Size of 0 should leverage all ingesters": {
+			shardingStrategy:            "shuffle-sharding",
+			tenantShardSize:             0,
+			expectedIngestersWithSeries: 3,
 		},
 	}
 
@@ -125,7 +137,7 @@ func TestIngesterSharding(t *testing.T) {
 			// We expect that only ingesters belonging to tenant's shard have been queried if
 			// shuffle sharding is enabled.
 			expectedIngesters := ingesters.NumInstances()
-			if testData.shardingStrategy == "shuffle-sharding" {
+			if testData.shardingStrategy == "shuffle-sharding" && testData.tenantShardSize > 0 {
 				expectedIngesters = testData.tenantShardSize
 			}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -49,7 +49,7 @@ var (
 
 	// Validation errors.
 	errInvalidShardingStrategy = errors.New("invalid sharding strategy")
-	errInvalidTenantShardSize  = errors.New("invalid tenant shard size, the value must be a positive integer")
+	errInvalidTenantShardSize  = errors.New("invalid tenant shard size, the value must be greater than 0")
 
 	// Distributor instance limits errors.
 	errTooManyInflightPushRequests    = errors.New("too many inflight push requests in distributor")
@@ -178,12 +178,8 @@ func (cfg *Config) Validate(limits validation.Limits) error {
 		return errInvalidShardingStrategy
 	}
 
-	if limits.IngestionTenantShardSize < 0 {
+	if cfg.ShardingStrategy == util.ShardingStrategyShuffle && limits.IngestionTenantShardSize < 0 {
 		return errInvalidTenantShardSize
-	}
-
-	if limits.IngestionTenantShardSize == 0 && cfg.ShardingStrategy == util.ShardingStrategyShuffle {
-		level.Warn(util_log.Logger).Log("msg", "identified sharding strategy: %s, with shard size of 0, this will fallback to default sharding strategy", util.ShardingStrategyShuffle)
 	}
 
 	haHATrackerConfig := cfg.HATrackerConfig.ToHATrackerConfig()
@@ -587,20 +583,8 @@ func (d *Distributor) Push(ctx context.Context, req *cortexpb.WriteRequest) (*co
 	inflight := d.inflightPushRequests.Inc()
 	defer d.inflightPushRequests.Dec()
 
-	if d.cfg.InstanceLimits.MaxInflightPushRequests > 0 && inflight > int64(d.cfg.InstanceLimits.MaxInflightPushRequests) {
-		return nil, errTooManyInflightPushRequests
-	}
-
-	if d.cfg.InstanceLimits.MaxIngestionRate > 0 {
-		if rate := d.ingestionRate.Rate(); rate >= d.cfg.InstanceLimits.MaxIngestionRate {
-			return nil, errMaxSamplesPushRateLimitReached
-		}
-	}
-
 	now := time.Now()
 	d.activeUsers.UpdateUserTimestamp(userID, now)
-
-	removeReplica := false
 
 	numSamples := 0
 	numExemplars := 0
@@ -614,6 +598,17 @@ func (d *Distributor) Push(ctx context.Context, req *cortexpb.WriteRequest) (*co
 	// Count the total number of metadata in.
 	d.incomingMetadata.WithLabelValues(userID).Add(float64(len(req.Metadata)))
 
+	if d.cfg.InstanceLimits.MaxInflightPushRequests > 0 && inflight > int64(d.cfg.InstanceLimits.MaxInflightPushRequests) {
+		return nil, errTooManyInflightPushRequests
+	}
+
+	if d.cfg.InstanceLimits.MaxIngestionRate > 0 {
+		if rate := d.ingestionRate.Rate(); rate >= d.cfg.InstanceLimits.MaxIngestionRate {
+			return nil, errMaxSamplesPushRateLimitReached
+		}
+	}
+
+	removeReplica := false
 	// Cache user limit with overrides so we spend less CPU doing locking. See issue #4904
 	limits := d.limits.GetOverridesForUser(userID)
 
@@ -678,10 +673,11 @@ func (d *Distributor) Push(ctx context.Context, req *cortexpb.WriteRequest) (*co
 	// totalN included samples and metadata. Ingester follows this pattern when computing its ingestion rate.
 	d.ingestionRate.Add(int64(totalN))
 
-	// Determine Shuffle Sharding Strategy
-	subRing, err := d.GetShuffleShardingRing(ctx)
-	if err != nil {
-		return nil, err
+	subRing := d.ingestersRing
+
+	// Obtain a subring if required.
+	if d.cfg.ShardingStrategy == util.ShardingStrategyShuffle {
+		subRing = d.ingestersRing.ShuffleShard(userID, limits.IngestionTenantShardSize)
 	}
 
 	keys := append(seriesKeys, metadataKeys...)
@@ -693,23 +689,6 @@ func (d *Distributor) Push(ctx context.Context, req *cortexpb.WriteRequest) (*co
 	}
 
 	return &cortexpb.WriteResponse{}, firstPartialErr
-}
-
-func (d *Distributor) GetShuffleShardingRing(ctx context.Context) (ring.ReadRing, error) {
-	userID, err := tenant.TenantID(ctx)
-	if err != nil {
-		return nil, err
-	}
-	//Get any overrides for the current tenant
-	limits := d.limits.GetOverridesForUser(userID)
-	//Retrieves all the current ingesters rings.
-	subRing := d.ingestersRing
-	//Determines if Shuffle Sharding is enabled and or the overrides has a Sharding Strategy of greater than 0.
-	if d.cfg.ShardingStrategy == util.ShardingStrategyShuffle && limits.IngestionTenantShardSize > 0 {
-		subRing = d.ingestersRing.ShuffleShard(userID, limits.IngestionTenantShardSize)
-	}
-
-	return subRing, nil
 }
 
 func (d *Distributor) doBatch(ctx context.Context, req *cortexpb.WriteRequest, subRing ring.ReadRing, keys []uint32, initialMetadataIndex int, validatedMetadata []*cortexpb.MetricMetadata, validatedTimeseries []cortexpb.PreallocTimeseries, userID string) error {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -49,7 +49,7 @@ var (
 
 	// Validation errors.
 	errInvalidShardingStrategy = errors.New("invalid sharding strategy")
-	errInvalidTenantShardSize  = errors.New("invalid tenant shard size, the value must be greater than 0")
+	errInvalidTenantShardSize  = errors.New("invalid tenant shard size. The value must be greater than or equal to 0")
 
 	// Distributor instance limits errors.
 	errTooManyInflightPushRequests    = errors.New("too many inflight push requests in distributor")

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -76,14 +76,14 @@ func TestConfig_Validate(t *testing.T) {
 			initLimits: func(_ *validation.Limits) {},
 			expected:   errInvalidShardingStrategy,
 		},
-		"should fail if the default shard size is 0 on when sharding strategy = shuffle-sharding": {
+		"should pass sharding strategy when IngestionTenantShardSize = 0": {
 			initConfig: func(cfg *Config) {
 				cfg.ShardingStrategy = "shuffle-sharding"
 			},
 			initLimits: func(limits *validation.Limits) {
 				limits.IngestionTenantShardSize = 0
 			},
-			expected: errInvalidTenantShardSize,
+			expected: nil,
 		},
 		"should pass if the default shard size > 0 on when sharding strategy = shuffle-sharding": {
 			initConfig: func(cfg *Config) {
@@ -93,6 +93,13 @@ func TestConfig_Validate(t *testing.T) {
 				limits.IngestionTenantShardSize = 3
 			},
 			expected: nil,
+		},
+		"should fail because the ingestionTenantShardSize is a non-positive number": {
+			initConfig: func(_ *Config) {},
+			initLimits: func(limits *validation.Limits) {
+				limits.IngestionTenantShardSize = -1
+			},
+			expected: errInvalidTenantShardSize,
 		},
 	}
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -95,7 +95,9 @@ func TestConfig_Validate(t *testing.T) {
 			expected: nil,
 		},
 		"should fail because the ingestionTenantShardSize is a non-positive number": {
-			initConfig: func(_ *Config) {},
+			initConfig: func(cfg *Config) {
+				cfg.ShardingStrategy = "shuffle-sharding"
+			},
 			initLimits: func(limits *validation.Limits) {
 				limits.IngestionTenantShardSize = -1
 			},


### PR DESCRIPTION
There is a discrepancy between the current behavior of the system and the documented functionality regarding the setting of the ingestion_tenant_shard_size parameter.
Current Behavior

When attempting to set the -distributor.ingestion-tenant-shard-size flag to 0, the system throws an error.
Expected Behavior (As Per Documentation)

The documentation states the following:
```
# The default tenant's shard size when the shuffle-sharding strategy is used.
# Must be set both on ingesters and distributors. When this setting is specified
# in the per-tenant overrides, a value of 0 disables shuffle sharding for the
# tenant.
# CLI flag: -distributor.ingestion-tenant-shard-size
[ingestion_tenant_shard_size: <int> | default = 0]
```

According to this, setting the value to 0 should **be supported** and is intended to disable shuffle sharding for the tenant.
**Rationale for Setting the Value to 0**

The intention behind setting the ingestion_tenant_shard_size to 0 by default is to enable shuffle-sharding, while also allowing a tenant to utilize the entire ring as the shard size. This setup is crucial for overwriting settings for specific tenants who might require shuffle sharding. The issue was identified during an attempt to configure our ingesters with the zero value.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR addresses the exception that is thrown, warns a customer when the combination of shuffle sharding enabled and ingestion_tenant_shard_size == 0. Also addressing the `Push()` function to check and update the ring topology accordingly. 

**Which issue(s) this PR fixes**:
Fixes #5189

Related: #5250

**Checklist**
- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
