### PR TITLE
Overwriting permissions on security related jobs

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -59,6 +59,10 @@ jobs:
   security:
     name: CodeQL
     runs-on: ubuntu-20.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

CodeQL is breaking in master branch because of the following errors: `Error: Resource not accessible by integration`. This PR adds the appropriate permissions for the job to be able to submit back to the security tab under the master branch. Our permission set is `read-only` by default, this overrides that specific behavior for this particular "Security" related job.

Looking at the job's setup - the security events is set to read, I believe this should be set to "Write". This is also why I believe it's not reporting the status to the Security Tab.

<img width="280" alt="image" src="https://github.com/cortexproject/cortex/assets/107317815/32492fce-3e5f-4cd8-bb0c-1d5033af6e3e">


**Which issue(s) this PR fixes**:
Fixes #5761 

**Related Issue:**
https://github.com/github/codeql/issues/8843

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
