### PR TITLE
change the reflect package to an unsafe package

### DIFF
--- a/pkg/storage/tsdb/inmemory_index_cache.go
+++ b/pkg/storage/tsdb/inmemory_index_cache.go
@@ -2,7 +2,6 @@ package tsdb
 
 import (
 	"context"
-	"reflect"
 	"unsafe"
 
 	"github.com/VictoriaMetrics/fastcache"
@@ -122,12 +121,7 @@ func yoloBuf(s string) []byte {
 }
 
 func copyString(s string) string {
-	var b []byte
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	h.Data = (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
-	h.Len = len(s)
-	h.Cap = len(s)
-	return string(b)
+	return string(unsafe.Slice(unsafe.StringData(s), len(s)))
 }
 
 // copyToKey is required as underlying strings might be mmaped.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
as 'reflect.StringHeader' is deprecated, it is replaced with an unsafe package.

**Which issue(s) this PR fixes**:
Fixes #5774 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
