### PR TITLE
Remove flaky test case of replicationset.Do

### DIFF
--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -213,16 +213,6 @@ func TestReplicationSet_Do(t *testing.T) {
 			want:                []interface{}{1, 1, 1, 1, 1, 1},
 		},
 		{
-			name:      "max unavailable zones = 1, zoneResultsQuorum = false, should contain 5 results (2 from zone1, 2 from zone2 and 1 from zone3)",
-			instances: []InstanceDesc{{Zone: "zone1"}, {Zone: "zone2"}, {Zone: "zone3"}, {Zone: "zone1"}, {Zone: "zone2"}, {Zone: "zone3"}},
-			f: func(c context.Context, id *InstanceDesc) (interface{}, error) {
-				return 1, nil
-			},
-			maxUnavailableZones: 1,
-			want:                []interface{}{1, 1, 1, 1, 1},
-			zoneResultsQuorum:   false,
-		},
-		{
 			name:      "max unavailable zones = 1, zoneResultsQuorum = true, should contain 4 results (2 from zone1, 2 from zone2)",
 			instances: []InstanceDesc{{Zone: "zone1"}, {Zone: "zone2"}, {Zone: "zone3"}, {Zone: "zone1"}, {Zone: "zone2"}, {Zone: "zone3"}},
 			f: func(c context.Context, id *InstanceDesc) (interface{}, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Example run: https://github.com/cortexproject/cortex/actions/runs/7992293857/job/21826435951

```
--- FAIL: TestReplicationSet_Do (0.12s)
    --- FAIL: TestReplicationSet_Do/max_unavailable_zones_=_1,_zoneResultsQuorum_=_false,_should_contain_5_results_(2_from_zone1,_2_from_zone2_and_1_from_zone3) (0.00s)
        replication_set_test.go:261: 
            	Error Trace:	/__w/cortex/cortex/pkg/ring/replication_set_test.go:261
            	Error:      	Not equal: 
            	            	expected: []interface {}{1, 1, 1, 1, 1}
            	            	actual  : []interface {}{1, 1, 1, 1}
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,3 +1,2 @@
            	            	-([]interface {}) (len=5) {
            	            	- (int) 1,
            	            	+([]interface {}) (len=4) {
            	            	  (int) 1,
            	Test:       	TestReplicationSet_Do/max_unavailable_zones_=_1,_zoneResultsQuorum_=_false,_should_contain_5_results_(2_from_zone1,_2_from_zone2_and_1_from_zone3)
FAIL
```

The result `want` array might have either 4 or 5 results because replicationSet.Do() runs function `f` in different goroutines for each instance. The order of the responses is not determined. So we could get possible orders:
1. zone a, zone b, zone c, zone a, zone b -> 5 values
2. zone a, zone b, zone a, zone b -> 4 values

It is possible that responses from 2 zones got received before accepint any response from the 3rd zone, thus the test is flaky.

It is unnecessary to keep this flaky test since we already have a test case for zone results quorum enabled. https://github.com/cortexproject/cortex/blob/master/pkg/ring/replication_set_test.go#L233

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
