### PR TITLE
Merging slices from the labels APIs using more than 1 cpu and k-way

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
+	github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/google/go-cmp v0.6.0
 	github.com/sercand/kuberesolver/v4 v4.0.0
@@ -111,7 +112,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.19 // indirect
 	github.com/aws/smithy-go v1.13.3 // indirect
-	github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -64,6 +64,10 @@ const (
 	typeMetadata = "metadata"
 
 	instanceIngestionRateTickInterval = time.Second
+
+	// mergeSlicesParallelism is a constant of how much go routines we should use to merge slices, and
+	// it was based on empirical observation: See BenchmarkMergeSlicesParallel
+	mergeSlicesParallelism = 8
 )
 
 // Distributor is a storage.SampleAppender and a client.Querier which
@@ -959,23 +963,13 @@ func (d *Distributor) LabelValuesForLabelNameCommon(ctx context.Context, from, t
 
 	span, _ = opentracing.StartSpanFromContext(ctx, "response_merge")
 	defer span.Finish()
-	valueSet := map[string]struct{}{}
-	for _, resp := range resps {
-		for _, v := range resp.([]string) {
-			valueSet[v] = struct{}{}
-		}
+	values := make([][]string, len(resps))
+	for i, resp := range resps {
+		values[i] = resp.([]string)
 	}
-
-	values := make([]string, 0, len(valueSet))
-	for v := range valueSet {
-		values = append(values, v)
-	}
-
-	// We need the values returned to be sorted.
-	sort.Strings(values)
-	span.SetTag("result_length", len(values))
-
-	return values, nil
+	r := util.MergeSlicesParallel(mergeSlicesParallelism, values...)
+	span.SetTag("result_length", len(r))
+	return r, nil
 }
 
 // LabelValuesForLabelName returns all the label values that are associated with a given label name.
@@ -1039,22 +1033,14 @@ func (d *Distributor) LabelNamesCommon(ctx context.Context, from, to model.Time,
 
 	span, _ = opentracing.StartSpanFromContext(ctx, "response_merge")
 	defer span.Finish()
-	valueSet := map[string]struct{}{}
-	for _, resp := range resps {
-		for _, v := range resp.([]string) {
-			valueSet[v] = struct{}{}
-		}
+	values := make([][]string, len(resps))
+	for i, resp := range resps {
+		values[i] = resp.([]string)
 	}
+	r := util.MergeSlicesParallel(mergeSlicesParallelism, values...)
+	span.SetTag("result_length", len(r))
 
-	values := make([]string, 0, len(valueSet))
-	for v := range valueSet {
-		values = append(values, v)
-	}
-
-	sort.Strings(values)
-	span.SetTag("result_length", len(values))
-
-	return values, nil
+	return r, nil
 }
 
 func (d *Distributor) LabelNamesStream(ctx context.Context, from, to model.Time) ([]string, error) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1664,6 +1664,16 @@ func BenchmarkDistributor_GetLabelsValues(b *testing.B) {
 		lblValuesDuplicateRatio float64
 	}{
 		{
+			numIngesters:            16,
+			lblValuesPerIngester:    1000,
+			lblValuesDuplicateRatio: 0.67, // Final Result will have 33% of the total size - replication factor of 3 and no duplicates
+		},
+		{
+			numIngesters:            16,
+			lblValuesPerIngester:    1000,
+			lblValuesDuplicateRatio: 0.98,
+		},
+		{
 			numIngesters:            150,
 			lblValuesPerIngester:    1000,
 			lblValuesDuplicateRatio: 0.67, // Final Result will have 33% of the total size - replication factor of 3 and no duplicates

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand"
 	"net/http"
 	"sort"
 	"strconv"
@@ -1654,6 +1655,56 @@ func TestDistributor_Push_ExemplarValidation(t *testing.T) {
 	}
 }
 
+func BenchmarkDistributor_GetLabelsValues(b *testing.B) {
+	ctx := user.InjectOrgID(context.Background(), "user")
+
+	testCases := []struct {
+		numIngesters            int
+		lblValuesPerIngester    int
+		lblValuesDuplicateRatio float64
+	}{
+		{
+			numIngesters:            150,
+			lblValuesPerIngester:    1000,
+			lblValuesDuplicateRatio: 0.67, // Final Result will have 33% of the total size - replication factor of 3 and no duplicates
+		},
+		{
+			numIngesters:            150,
+			lblValuesPerIngester:    1000,
+			lblValuesDuplicateRatio: 0.98,
+		},
+		{
+			numIngesters:            500,
+			lblValuesPerIngester:    1000,
+			lblValuesDuplicateRatio: 0.67, // Final Result will have 33% of the total size - replication factor of 3 and no duplicates
+		},
+		{
+			numIngesters:            500,
+			lblValuesPerIngester:    1000,
+			lblValuesDuplicateRatio: 0.98,
+		},
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf("numIngesters%v,lblValuesPerIngester%v,lblValuesDuplicateRatio%v", tc.numIngesters, tc.lblValuesPerIngester, tc.lblValuesDuplicateRatio)
+		ds, _, _, _ := prepare(b, prepConfig{
+			numIngesters:            tc.numIngesters,
+			happyIngesters:          tc.numIngesters,
+			numDistributors:         1,
+			lblValuesPerIngester:    tc.lblValuesPerIngester,
+			lblValuesDuplicateRatio: tc.lblValuesDuplicateRatio,
+		})
+		b.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := ds[0].LabelValuesForLabelName(ctx, model.Time(time.Now().UnixMilli()), model.Time(time.Now().UnixMilli()), "__name__")
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
 func BenchmarkDistributor_Push(b *testing.B) {
 	const (
 		numSeriesPerRequest = 1000
@@ -1942,7 +1993,6 @@ func BenchmarkDistributor_Push(b *testing.B) {
 
 			for n := 0; n < b.N; n++ {
 				_, err := distributor.Push(ctx, cortexpb.ToWriteRequest(metrics, samples, nil, nil, cortexpb.API))
-
 				if testData.expectedErr == "" && err != nil {
 					b.Fatalf("no error expected but got %v", err)
 				}
@@ -2392,6 +2442,8 @@ type prepConfig struct {
 	shardByAllLabels             bool
 	shuffleShardEnabled          bool
 	shuffleShardSize             int
+	lblValuesPerIngester         int
+	lblValuesDuplicateRatio      float64
 	limits                       *validation.Limits
 	numDistributors              int
 	skipLabelNameValidation      bool
@@ -2403,13 +2455,23 @@ type prepConfig struct {
 	tokens                       [][]uint32
 }
 
+type prepState struct {
+	unusedStrings, usedStrings []string
+}
+
 func prepare(tb testing.TB, cfg prepConfig) ([]*Distributor, []*mockIngester, []*prometheus.Registry, *ring.Ring) {
+	// Strings to be used for get labels values/Names
+	var unusedStrings []string
+	if cfg.lblValuesPerIngester > 0 {
+		unusedStrings = make([]string, min(len(util.RandomStrings), cfg.numIngesters*cfg.lblValuesPerIngester))
+		copy(unusedStrings, util.RandomStrings)
+	}
+	s := &prepState{
+		unusedStrings: unusedStrings,
+	}
 	ingesters := []*mockIngester{}
 	for i := 0; i < cfg.happyIngesters; i++ {
-		ingesters = append(ingesters, &mockIngester{
-			happy:      *atomic.NewBool(true),
-			queryDelay: cfg.queryDelay,
-		})
+		ingesters = append(ingesters, newMockIngester(i, s, cfg))
 	}
 	for i := cfg.happyIngesters; i < cfg.numIngesters; i++ {
 		miError := errFail
@@ -2679,6 +2741,33 @@ type mockIngester struct {
 	metadata   map[uint32]map[cortexpb.MetricMetadata]struct{}
 	queryDelay time.Duration
 	calls      map[string]int
+	lblsValues []string
+}
+
+func newMockIngester(id int, ps *prepState, cfg prepConfig) *mockIngester {
+	lblsValues := make([]string, 0, cfg.lblValuesPerIngester)
+	usedStrings := make([]string, len(ps.usedStrings))
+	copy(usedStrings, ps.usedStrings)
+
+	for i := 0; i < cfg.lblValuesPerIngester; i++ {
+		var s string
+		if i < int(float64(cfg.lblValuesPerIngester)*cfg.lblValuesDuplicateRatio) && id > 0 {
+			index := rand.Int() % len(usedStrings)
+			s = usedStrings[index]
+			usedStrings = append(usedStrings[:index], usedStrings[index+1:]...)
+		} else {
+			s = ps.unusedStrings[0]
+			ps.usedStrings = append(ps.usedStrings, s)
+			ps.unusedStrings = ps.unusedStrings[1:]
+		}
+		lblsValues = append(lblsValues, s)
+	}
+	sort.Strings(lblsValues)
+	return &mockIngester{
+		happy:      *atomic.NewBool(true),
+		queryDelay: cfg.queryDelay,
+		lblsValues: lblsValues,
+	}
 }
 
 func (i *mockIngester) series() map[uint32]*cortexpb.PreallocTimeseries {
@@ -2703,6 +2792,12 @@ func (i *mockIngester) Check(ctx context.Context, in *grpc_health_v1.HealthCheck
 
 func (i *mockIngester) Close() error {
 	return nil
+}
+
+func (i *mockIngester) LabelValues(_ context.Context, _ *client.LabelValuesRequest, _ ...grpc.CallOption) (*client.LabelValuesResponse, error) {
+	return &client.LabelValuesResponse{
+		LabelValues: i.lblsValues,
+	}, nil
 }
 
 func (i *mockIngester) PushPreAlloc(ctx context.Context, in *cortexpb.PreallocWriteRequest, opts ...grpc.CallOption) (*cortexpb.WriteResponse, error) {

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -1,6 +1,11 @@
 package util
 
-import "unsafe"
+import (
+	"sync"
+	"unsafe"
+
+	"github.com/bboreham/go-loser"
+)
 
 // StringsContain returns true if the search value is within the list of input values.
 func StringsContain(values []string, search string) bool {
@@ -28,4 +33,94 @@ func StringsClone(s string) string {
 	b := make([]byte, len(s))
 	copy(b, s)
 	return *(*string)(unsafe.Pointer(&b))
+}
+
+// MergeSlicesParallel merge sorted slices in parallel
+// using the MergeSlicesV2 function
+func MergeSlicesParallel(parallelism int, a ...[]string) []string {
+	if parallelism <= 1 {
+		return MergeSlicesV2(a...)
+	}
+	if len(a) == 0 {
+		return nil
+	}
+	if len(a) == 1 {
+		return a[0]
+	}
+	c := make(chan []string, len(a))
+	wg := sync.WaitGroup{}
+	var r [][]string
+	p := min(parallelism, len(a)/2)
+	batchSize := len(a) / p
+
+	for i := 0; i < len(a); i += batchSize {
+		wg.Add(1)
+		go func(i int) {
+			m := min(len(a), i+batchSize)
+			c <- MergeSlicesV2(a[i:m]...)
+			wg.Done()
+		}(i)
+	}
+
+	go func() {
+		wg.Wait()
+		close(c)
+	}()
+
+	for s := range c {
+		r = append(r, s)
+	}
+
+	return MergeSlicesV2(r...)
+}
+
+func NewStringListIter(s []string) *StringListIter {
+	return &StringListIter{l: s}
+}
+
+type StringListIter struct {
+	l   []string
+	cur string
+}
+
+func (s *StringListIter) Next() bool {
+	if len(s.l) == 0 {
+		return false
+	}
+	s.cur = s.l[0]
+	s.l = s.l[1:]
+	return true
+}
+
+func (s *StringListIter) At() string { return s.cur }
+
+var MAX_STRING = string([]byte{0xff})
+
+// MergeSlicesV2 merges a set of sorted string slices into a single ones
+// while removing all duplicates.
+func MergeSlicesV2(a ...[]string) []string {
+	if len(a) == 1 {
+		return a[0]
+	}
+	its := make([]*StringListIter, 0, len(a))
+	sumLengh := 0
+	for _, s := range a {
+		sumLengh += len(s)
+		its = append(its, NewStringListIter(s))
+	}
+	lt := loser.New(its, MAX_STRING)
+
+	if sumLengh == 0 {
+		return []string{}
+	}
+
+	r := make([]string, 0, sumLengh*2/10)
+	var current string
+	for lt.Next() {
+		if lt.At() != current {
+			current = lt.At()
+			r = append(r, current)
+		}
+	}
+	return r
 }

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -36,10 +36,10 @@ func StringsClone(s string) string {
 }
 
 // MergeSlicesParallel merge sorted slices in parallel
-// using the MergeSlicesV2 function
+// using the MergeSortedSlices function
 func MergeSlicesParallel(parallelism int, a ...[]string) []string {
 	if parallelism <= 1 {
-		return MergeSlicesV2(a...)
+		return MergeSortedSlices(a...)
 	}
 	if len(a) == 0 {
 		return nil
@@ -57,7 +57,7 @@ func MergeSlicesParallel(parallelism int, a ...[]string) []string {
 		wg.Add(1)
 		go func(i int) {
 			m := min(len(a), i+batchSize)
-			c <- MergeSlicesV2(a[i:m]...)
+			c <- MergeSortedSlices(a[i:m]...)
 			wg.Done()
 		}(i)
 	}
@@ -71,7 +71,7 @@ func MergeSlicesParallel(parallelism int, a ...[]string) []string {
 		r = append(r, s)
 	}
 
-	return MergeSlicesV2(r...)
+	return MergeSortedSlices(r...)
 }
 
 func NewStringListIter(s []string) *StringListIter {
@@ -96,9 +96,9 @@ func (s *StringListIter) At() string { return s.cur }
 
 var MAX_STRING = string([]byte{0xff})
 
-// MergeSlicesV2 merges a set of sorted string slices into a single ones
+// MergeSortedSlices merges a set of sorted string slices into a single ones
 // while removing all duplicates.
-func MergeSlicesV2(a ...[]string) []string {
+func MergeSortedSlices(a ...[]string) []string {
 	if len(a) == 1 {
 		return a[0]
 	}

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -1,0 +1,129 @@
+package util
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkMergeSlicesParallel(b *testing.B) {
+	testCases := []struct {
+		inputSize       int
+		stringsPerInput int
+		duplicateRatio  float64
+	}{
+		{
+			inputSize:       100,
+			stringsPerInput: 100,
+			duplicateRatio:  0.3, // Deduped array size will be 70% of the total of the input
+		},
+		{
+			inputSize:       100,
+			stringsPerInput: 100,
+			duplicateRatio:  0.8, // Deduped array size will be 20% of the total of the input
+		},
+		{
+			inputSize:       100,
+			stringsPerInput: 100,
+			duplicateRatio:  0.95, // Deduped array size will be 5% of the total of the input
+		},
+		{
+			inputSize:       150,
+			stringsPerInput: 300,
+			duplicateRatio:  0.3,
+		},
+		{
+			inputSize:       150,
+			stringsPerInput: 300,
+			duplicateRatio:  0.8,
+		},
+		{
+			inputSize:       150,
+			stringsPerInput: 300,
+			duplicateRatio:  0.95,
+		},
+	}
+
+	type ParallelismType int
+
+	const (
+		usingMap ParallelismType = iota
+	)
+
+	parallelism := []ParallelismType{usingMap, 1, 8}
+
+	for _, tc := range testCases {
+		input := make([][]string, tc.inputSize)
+		unusedStrings := make([]string, min(len(RandomStrings), tc.inputSize*tc.stringsPerInput))
+		usedStrings := make([]string, 0, len(unusedStrings))
+		copy(unusedStrings, RandomStrings)
+
+		for i := 0; i < tc.inputSize; i++ {
+			stringsToBeReused := make([]string, len(usedStrings))
+			copy(stringsToBeReused, usedStrings)
+			for j := 0; j < tc.stringsPerInput; j++ {
+				// Get a random string already used
+				var s string
+				if j < int(float64(tc.stringsPerInput)*tc.duplicateRatio) && i > 0 {
+					index := rand.Int() % len(stringsToBeReused)
+					s = stringsToBeReused[index]
+					stringsToBeReused = append(stringsToBeReused[:index], stringsToBeReused[index+1:]...)
+				} else {
+					for {
+						s = unusedStrings[0]
+						usedStrings = append(usedStrings, s)
+						unusedStrings = unusedStrings[1:]
+						break
+					}
+				}
+				input[i] = append(input[i], s)
+			}
+			sort.Strings(input[i])
+		}
+		for _, p := range parallelism {
+			var name string
+			if p == usingMap {
+				name = fmt.Sprintf("usingMap,inputSize:%v,stringsPerInput:%v,duplicateRatio:%v", tc.inputSize, tc.stringsPerInput, tc.duplicateRatio)
+			} else {
+				name = fmt.Sprintf("parallelism:%v,inputSize:%v,stringsPerInput:%v,duplicateRatio:%v", p, tc.inputSize, tc.stringsPerInput, tc.duplicateRatio)
+			}
+			expected := sortUsingMap(input...)
+			b.Run(name, func(b *testing.B) {
+				// Run the benchmark.
+				b.ReportAllocs()
+				b.ResetTimer()
+				var r []string
+				for i := 0; i < b.N; i++ {
+					if p == usingMap {
+						r = sortUsingMap(input...)
+						require.NotEmpty(b, r)
+					} else {
+						r = MergeSlicesParallel(int(p), input...)
+						require.NotEmpty(b, r)
+					}
+				}
+				require.Equal(b, r, expected)
+			})
+		}
+	}
+}
+
+func sortUsingMap(resps ...[]string) []string {
+	valueSet := map[string]struct{}{}
+	for _, resp := range resps {
+		for _, v := range resp {
+			valueSet[v] = struct{}{}
+		}
+	}
+
+	values := make([]string, 0, len(valueSet))
+	for v := range valueSet {
+		values = append(values, v)
+	}
+
+	sort.Strings(values)
+	return values
+}

--- a/pkg/util/test_util.go
+++ b/pkg/util/test_util.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"math/rand"
+	"strings"
+)
+
+var (
+	randomChar    = "0123456789abcdef"
+	RandomStrings = []string{}
+)
+
+func init() {
+	sb := strings.Builder{}
+	for i := 0; i < 1000000; i++ {
+		sb.Reset()
+		sb.WriteString("pod://")
+		for j := 0; j < 14; j++ {
+			sb.WriteByte(randomChar[rand.Int()%len(randomChar)])
+		}
+		RandomStrings = append(RandomStrings, sb.String())
+	}
+}


### PR DESCRIPTION
**What this PR does**:
This PR changes the strategy we use to merge sorted slices containing the labels values/keys on the GetLabels and GetLabelValues APIs.

Before we were getting the response from each ingesters, adding in a map and sorting at the end to dedup/sort the response.

Now we are using Loser Tree for merge (same as used on https://github.com/prometheus/prometheus/pull/12878) and also using more than one core to merge those slices.

Benchmark from the GetLabelsValues APIs with different duplication factors (Ex: 0.67 duplication ratio means that the resulting slice will have 33% of the sum of the strings on the input slices):

```
goos: linux
goarch: amd64
pkg: github.com/cortexproject/cortex/pkg/distributor
cpu: Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
                                                                                                    │   /tmp/old   │              /tmp/new               │
                                                                                                    │    sec/op    │    sec/op     vs base               │
Distributor_GetLabelsValues/numIngesters16,lblValuesPerIngester1000,lblValuesDuplicateRatio0.67-32    1.985m ± ∞ ¹   1.204m ± ∞ ¹  -39.35% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters16,lblValuesPerIngester1000,lblValuesDuplicateRatio0.98-32    825.2µ ± ∞ ¹   572.9µ ± ∞ ¹  -30.57% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters150,lblValuesPerIngester1000,lblValuesDuplicateRatio0.67-32   23.33m ± ∞ ¹   13.31m ± ∞ ¹  -42.96% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters150,lblValuesPerIngester1000,lblValuesDuplicateRatio0.98-32   6.381m ± ∞ ¹   3.264m ± ∞ ¹  -48.84% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters500,lblValuesPerIngester1000,lblValuesDuplicateRatio0.67-32   93.35m ± ∞ ¹   50.86m ± ∞ ¹  -45.52% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters500,lblValuesPerIngester1000,lblValuesDuplicateRatio0.98-32   23.02m ± ∞ ¹   12.47m ± ∞ ¹  -45.82% (p=0.008 n=5)
geomean                                                                                               8.979m         5.166m        -42.47%
¹ need >= 6 samples for confidence interval at level 0.95

                                                                                                    │    /tmp/old    │                /tmp/new                │
                                                                                                    │      B/op      │      B/op       vs base                │
Distributor_GetLabelsValues/numIngesters16,lblValuesPerIngester1000,lblValuesDuplicateRatio0.67-32     439.2Ki ± ∞ ¹   1024.4Ki ± ∞ ¹  +133.26% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters16,lblValuesPerIngester1000,lblValuesDuplicateRatio0.98-32     111.0Ki ± ∞ ¹    429.8Ki ± ∞ ¹  +287.09% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters150,lblValuesPerIngester1000,lblValuesDuplicateRatio0.67-32    3.484Mi ± ∞ ¹   11.340Mi ± ∞ ¹  +225.53% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters150,lblValuesPerIngester1000,lblValuesDuplicateRatio0.98-32    446.0Ki ± ∞ ¹    949.8Ki ± ∞ ¹  +112.96% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters500,lblValuesPerIngester1000,lblValuesDuplicateRatio0.67-32    12.95Mi ± ∞ ¹    35.34Mi ± ∞ ¹  +172.95% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters500,lblValuesPerIngester1000,lblValuesDuplicateRatio0.98-32    995.0Ki ± ∞ ¹   2222.2Ki ± ∞ ¹  +123.33% (p=0.008 n=5)
geomean                                                                                               1003.9Ki          2.640Mi        +169.31%
¹ need >= 6 samples for confidence interval at level 0.95

                                                                                                    │   /tmp/old   │              /tmp/new               │
                                                                                                    │  allocs/op   │  allocs/op    vs base               │
Distributor_GetLabelsValues/numIngesters16,lblValuesPerIngester1000,lblValuesDuplicateRatio0.67-32     221.0 ± ∞ ¹    199.0 ± ∞ ¹   -9.95% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters16,lblValuesPerIngester1000,lblValuesDuplicateRatio0.98-32     124.0 ± ∞ ¹    188.0 ± ∞ ¹  +51.61% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters150,lblValuesPerIngester1000,lblValuesDuplicateRatio0.67-32   2514.0 ± ∞ ¹    907.0 ± ∞ ¹  -63.92% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters150,lblValuesPerIngester1000,lblValuesDuplicateRatio0.98-32    739.0 ± ∞ ¹    856.0 ± ∞ ¹  +15.83% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters500,lblValuesPerIngester1000,lblValuesDuplicateRatio0.67-32   6.985k ± ∞ ¹   2.662k ± ∞ ¹  -61.89% (p=0.008 n=5)
Distributor_GetLabelsValues/numIngesters500,lblValuesPerIngester1000,lblValuesDuplicateRatio0.98-32   2.266k ± ∞ ¹   2.606k ± ∞ ¹  +15.00% (p=0.008 n=5)
geomean                                                                                                964.7          765.7        -20.63%
``` 

Benchmark with the merge implementation in isolation:

```
goos: linux
goarch: amd64
pkg: github.com/cortexproject/cortex/pkg/util
cpu: Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
BenchmarkMergeSlicesParallel/usingMap,inputSize:100,stringsPerInput:100,duplicateRatio:0.3-32         	     484	   2308154 ns/op	  791212 B/op	     217 allocs/op
BenchmarkMergeSlicesParallel/parallelism:1,inputSize:100,stringsPerInput:100,duplicateRatio:0.3-32    	     850	   1313718 ns/op	  372744 B/op	     109 allocs/op
BenchmarkMergeSlicesParallel/parallelism:8,inputSize:100,stringsPerInput:100,duplicateRatio:0.3-32    	    1147	    973408 ns/op	  868365 B/op	     209 allocs/op
BenchmarkMergeSlicesParallel/usingMap,inputSize:100,stringsPerInput:100,duplicateRatio:0.8-32         	    1327	    830787 ns/op	  212041 B/op	      61 allocs/op
BenchmarkMergeSlicesParallel/parallelism:1,inputSize:100,stringsPerInput:100,duplicateRatio:0.8-32    	    1024	   1130711 ns/op	   94216 B/op	     106 allocs/op
BenchmarkMergeSlicesParallel/parallelism:8,inputSize:100,stringsPerInput:100,duplicateRatio:0.8-32    	    1842	    620375 ns/op	  383621 B/op	     200 allocs/op
BenchmarkMergeSlicesParallel/usingMap,inputSize:100,stringsPerInput:100,duplicateRatio:0.95-32        	    2479	    450711 ns/op	   52476 B/op	      21 allocs/op
BenchmarkMergeSlicesParallel/parallelism:1,inputSize:100,stringsPerInput:100,duplicateRatio:0.95-32   	    1136	   1020612 ns/op	   45064 B/op	     105 allocs/op
BenchmarkMergeSlicesParallel/parallelism:8,inputSize:100,stringsPerInput:100,duplicateRatio:0.95-32   	    3314	    341552 ns/op	  134249 B/op	     186 allocs/op
BenchmarkMergeSlicesParallel/usingMap,inputSize:150,stringsPerInput:300,duplicateRatio:0.3-32         	      86	  12017615 ns/op	 3187257 B/op	    1043 allocs/op
BenchmarkMergeSlicesParallel/parallelism:1,inputSize:150,stringsPerInput:300,duplicateRatio:0.3-32    	     171	   6776256 ns/op	 2434920 B/op	     161 allocs/op
BenchmarkMergeSlicesParallel/parallelism:8,inputSize:150,stringsPerInput:300,duplicateRatio:0.3-32    	     238	   4916036 ns/op	 4608115 B/op	     273 allocs/op
BenchmarkMergeSlicesParallel/usingMap,inputSize:150,stringsPerInput:300,duplicateRatio:0.8-32         	     283	   4055139 ns/op	  831591 B/op	     213 allocs/op
BenchmarkMergeSlicesParallel/parallelism:1,inputSize:150,stringsPerInput:300,duplicateRatio:0.8-32    	     216	   5447690 ns/op	  354152 B/op	     156 allocs/op
BenchmarkMergeSlicesParallel/parallelism:8,inputSize:150,stringsPerInput:300,duplicateRatio:0.8-32    	     418	   2764875 ns/op	 1953886 B/op	     258 allocs/op
BenchmarkMergeSlicesParallel/usingMap,inputSize:150,stringsPerInput:300,duplicateRatio:0.95-32        	     543	   2135988 ns/op	  212043 B/op	      61 allocs/op
BenchmarkMergeSlicesParallel/parallelism:1,inputSize:150,stringsPerInput:300,duplicateRatio:0.95-32   	     241	   4911898 ns/op	  165736 B/op	     155 allocs/op
BenchmarkMergeSlicesParallel/parallelism:8,inputSize:150,stringsPerInput:300,duplicateRatio:0.95-32   	     835	   1355215 ns/op	  572329 B/op	     239 allocs/op
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
