### PR TITLE
support set async circuit breaker for memcached and redis client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [FEATURE] Tracing: Add `tracing.otel.round-robin` flag to use `round_robin` gRPC client side LB policy for sending OTLP traces. #5731
 * [FEATURE] Ruler: Add `ruler.concurrent-evals-enabled` flag to enable concurrent evaluation within a single rule group for independent rules. Maximum concurrency can be configured via `ruler.max-concurrent-evals`. #5766
 * [FEATURE] Distributor Queryable: Experimental: Add config `zone_results_quorum_metadata`. When querying ingesters using metadata APIs such as label names and values, only results from quorum number of zones will be included and merged. #5779
+* [FEATURE] Storage Cache Clients: Add config `set_async_circuit_breaker_config` to utilize the circuit breaker pattern for dynamically thresholding asynchronous set operations. Implemented in both memcached and redis cache clients. #5789
 * [ENHANCEMENT] Store Gateway: Added `-store-gateway.enabled-tenants` and `-store-gateway.disabled-tenants` to explicitly enable or disable store-gateway for specific tenants. #5638
 * [ENHANCEMENT] Compactor: Add new compactor metric `cortex_compactor_start_duration_seconds`. #5683
 * [ENHANCEMENT] Upgraded Docker base images to `alpine:3.18`. #5684

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -606,7 +606,7 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.auto-discovery
         [auto_discovery: <boolean> | default = false]
 
-        set_async_circuit_breaker:
+        set_async_circuit_breaker_config:
           # If true, enable circuit breaker.
           # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.enabled
           [enabled: <boolean> | default = false]
@@ -736,7 +736,7 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.redis.cache-size
         [cache_size: <int> | default = 0]
 
-        set_async_circuit_breaker:
+        set_async_circuit_breaker_config:
           # If true, enable circuit breaker.
           # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.enabled
           [enabled: <boolean> | default = false]
@@ -837,7 +837,7 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.auto-discovery
         [auto_discovery: <boolean> | default = false]
 
-        set_async_circuit_breaker:
+        set_async_circuit_breaker_config:
           # If true, enable circuit breaker.
           # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.enabled
           [enabled: <boolean> | default = false]
@@ -962,7 +962,7 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.cache-size
         [cache_size: <int> | default = 0]
 
-        set_async_circuit_breaker:
+        set_async_circuit_breaker_config:
           # If true, enable circuit breaker.
           # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.enabled
           [enabled: <boolean> | default = false]
@@ -1062,7 +1062,7 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.auto-discovery
         [auto_discovery: <boolean> | default = false]
 
-        set_async_circuit_breaker:
+        set_async_circuit_breaker_config:
           # If true, enable circuit breaker.
           # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.enabled
           [enabled: <boolean> | default = false]
@@ -1187,7 +1187,7 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.cache-size
         [cache_size: <int> | default = 0]
 
-        set_async_circuit_breaker:
+        set_async_circuit_breaker_config:
           # If true, enable circuit breaker.
           # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.enabled
           [enabled: <boolean> | default = false]

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -606,6 +606,35 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.auto-discovery
         [auto_discovery: <boolean> | default = false]
 
+        set_async_circuit_breaker:
+          # If true, enable circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.enabled
+          [enabled: <boolean> | default = false]
+
+          # Maximum number of requests allowed to pass through when the circuit
+          # breaker is half-open. If set to 0, by default it allows 1 request.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.half-open-max-requests
+          [half_open_max_requests: <int> | default = 10]
+
+          # Period of the open state after which the state of the circuit
+          # breaker becomes half-open. If set to 0, by default open duration is
+          # 60 seconds.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.open-duration
+          [open_duration: <duration> | default = 5s]
+
+          # Minimal requests to trigger the circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.min-requests
+          [min_requests: <int> | default = 50]
+
+          # Consecutive failures to determine if the circuit breaker should
+          # open.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.consecutive-failures
+          [consecutive_failures: <int> | default = 5]
+
+          # Failure percentage to determine if the circuit breaker should open.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.failure-percent
+          [failure_percent: <float> | default = 0.05]
+
         # Selectively cache index item types. Supported values are Postings,
         # ExpandedPostings and Series
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.enabled-items
@@ -707,6 +736,35 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.redis.cache-size
         [cache_size: <int> | default = 0]
 
+        set_async_circuit_breaker:
+          # If true, enable circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.enabled
+          [enabled: <boolean> | default = false]
+
+          # Maximum number of requests allowed to pass through when the circuit
+          # breaker is half-open. If set to 0, by default it allows 1 request.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.half-open-max-requests
+          [half_open_max_requests: <int> | default = 10]
+
+          # Period of the open state after which the state of the circuit
+          # breaker becomes half-open. If set to 0, by default open duration is
+          # 60 seconds.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.open-duration
+          [open_duration: <duration> | default = 5s]
+
+          # Minimal requests to trigger the circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.min-requests
+          [min_requests: <int> | default = 50]
+
+          # Consecutive failures to determine if the circuit breaker should
+          # open.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.consecutive-failures
+          [consecutive_failures: <int> | default = 5]
+
+          # Failure percentage to determine if the circuit breaker should open.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.failure-percent
+          [failure_percent: <float> | default = 0.05]
+
         # Selectively cache index item types. Supported values are Postings,
         # ExpandedPostings and Series
         # CLI flag: -blocks-storage.bucket-store.index-cache.redis.enabled-items
@@ -778,6 +836,35 @@ blocks_storage:
         # like GCP and AWS
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.auto-discovery
         [auto_discovery: <boolean> | default = false]
+
+        set_async_circuit_breaker:
+          # If true, enable circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.enabled
+          [enabled: <boolean> | default = false]
+
+          # Maximum number of requests allowed to pass through when the circuit
+          # breaker is half-open. If set to 0, by default it allows 1 request.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.half-open-max-requests
+          [half_open_max_requests: <int> | default = 10]
+
+          # Period of the open state after which the state of the circuit
+          # breaker becomes half-open. If set to 0, by default open duration is
+          # 60 seconds.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.open-duration
+          [open_duration: <duration> | default = 5s]
+
+          # Minimal requests to trigger the circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.min-requests
+          [min_requests: <int> | default = 50]
+
+          # Consecutive failures to determine if the circuit breaker should
+          # open.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.consecutive-failures
+          [consecutive_failures: <int> | default = 5]
+
+          # Failure percentage to determine if the circuit breaker should open.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.failure-percent
+          [failure_percent: <float> | default = 0.05]
 
       redis:
         # Comma separated list of redis addresses. Supported prefixes are: dns+
@@ -875,6 +962,35 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.cache-size
         [cache_size: <int> | default = 0]
 
+        set_async_circuit_breaker:
+          # If true, enable circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.enabled
+          [enabled: <boolean> | default = false]
+
+          # Maximum number of requests allowed to pass through when the circuit
+          # breaker is half-open. If set to 0, by default it allows 1 request.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.half-open-max-requests
+          [half_open_max_requests: <int> | default = 10]
+
+          # Period of the open state after which the state of the circuit
+          # breaker becomes half-open. If set to 0, by default open duration is
+          # 60 seconds.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.open-duration
+          [open_duration: <duration> | default = 5s]
+
+          # Minimal requests to trigger the circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.min-requests
+          [min_requests: <int> | default = 50]
+
+          # Consecutive failures to determine if the circuit breaker should
+          # open.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.consecutive-failures
+          [consecutive_failures: <int> | default = 5]
+
+          # Failure percentage to determine if the circuit breaker should open.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.failure-percent
+          [failure_percent: <float> | default = 0.05]
+
       # Size of each subrange that bucket object is split into for better
       # caching.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-size
@@ -945,6 +1061,35 @@ blocks_storage:
         # like GCP and AWS
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.auto-discovery
         [auto_discovery: <boolean> | default = false]
+
+        set_async_circuit_breaker:
+          # If true, enable circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.enabled
+          [enabled: <boolean> | default = false]
+
+          # Maximum number of requests allowed to pass through when the circuit
+          # breaker is half-open. If set to 0, by default it allows 1 request.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.half-open-max-requests
+          [half_open_max_requests: <int> | default = 10]
+
+          # Period of the open state after which the state of the circuit
+          # breaker becomes half-open. If set to 0, by default open duration is
+          # 60 seconds.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.open-duration
+          [open_duration: <duration> | default = 5s]
+
+          # Minimal requests to trigger the circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.min-requests
+          [min_requests: <int> | default = 50]
+
+          # Consecutive failures to determine if the circuit breaker should
+          # open.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.consecutive-failures
+          [consecutive_failures: <int> | default = 5]
+
+          # Failure percentage to determine if the circuit breaker should open.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.failure-percent
+          [failure_percent: <float> | default = 0.05]
 
       redis:
         # Comma separated list of redis addresses. Supported prefixes are: dns+
@@ -1041,6 +1186,35 @@ blocks_storage:
         # See https://redis.io/docs/manual/client-side-caching/ for more info.
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.cache-size
         [cache_size: <int> | default = 0]
+
+        set_async_circuit_breaker:
+          # If true, enable circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.enabled
+          [enabled: <boolean> | default = false]
+
+          # Maximum number of requests allowed to pass through when the circuit
+          # breaker is half-open. If set to 0, by default it allows 1 request.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.half-open-max-requests
+          [half_open_max_requests: <int> | default = 10]
+
+          # Period of the open state after which the state of the circuit
+          # breaker becomes half-open. If set to 0, by default open duration is
+          # 60 seconds.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.open-duration
+          [open_duration: <duration> | default = 5s]
+
+          # Minimal requests to trigger the circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.min-requests
+          [min_requests: <int> | default = 50]
+
+          # Consecutive failures to determine if the circuit breaker should
+          # open.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.consecutive-failures
+          [consecutive_failures: <int> | default = 5]
+
+          # Failure percentage to determine if the circuit breaker should open.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.failure-percent
+          [failure_percent: <float> | default = 0.05]
 
       # How long to cache list of tenants in the bucket.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.tenants-list-ttl

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -717,6 +717,35 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.auto-discovery
         [auto_discovery: <boolean> | default = false]
 
+        set_async_circuit_breaker:
+          # If true, enable circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.enabled
+          [enabled: <boolean> | default = false]
+
+          # Maximum number of requests allowed to pass through when the circuit
+          # breaker is half-open. If set to 0, by default it allows 1 request.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.half-open-max-requests
+          [half_open_max_requests: <int> | default = 10]
+
+          # Period of the open state after which the state of the circuit
+          # breaker becomes half-open. If set to 0, by default open duration is
+          # 60 seconds.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.open-duration
+          [open_duration: <duration> | default = 5s]
+
+          # Minimal requests to trigger the circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.min-requests
+          [min_requests: <int> | default = 50]
+
+          # Consecutive failures to determine if the circuit breaker should
+          # open.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.consecutive-failures
+          [consecutive_failures: <int> | default = 5]
+
+          # Failure percentage to determine if the circuit breaker should open.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.failure-percent
+          [failure_percent: <float> | default = 0.05]
+
         # Selectively cache index item types. Supported values are Postings,
         # ExpandedPostings and Series
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.enabled-items
@@ -818,6 +847,35 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.redis.cache-size
         [cache_size: <int> | default = 0]
 
+        set_async_circuit_breaker:
+          # If true, enable circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.enabled
+          [enabled: <boolean> | default = false]
+
+          # Maximum number of requests allowed to pass through when the circuit
+          # breaker is half-open. If set to 0, by default it allows 1 request.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.half-open-max-requests
+          [half_open_max_requests: <int> | default = 10]
+
+          # Period of the open state after which the state of the circuit
+          # breaker becomes half-open. If set to 0, by default open duration is
+          # 60 seconds.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.open-duration
+          [open_duration: <duration> | default = 5s]
+
+          # Minimal requests to trigger the circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.min-requests
+          [min_requests: <int> | default = 50]
+
+          # Consecutive failures to determine if the circuit breaker should
+          # open.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.consecutive-failures
+          [consecutive_failures: <int> | default = 5]
+
+          # Failure percentage to determine if the circuit breaker should open.
+          # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.failure-percent
+          [failure_percent: <float> | default = 0.05]
+
         # Selectively cache index item types. Supported values are Postings,
         # ExpandedPostings and Series
         # CLI flag: -blocks-storage.bucket-store.index-cache.redis.enabled-items
@@ -889,6 +947,35 @@ blocks_storage:
         # like GCP and AWS
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.auto-discovery
         [auto_discovery: <boolean> | default = false]
+
+        set_async_circuit_breaker:
+          # If true, enable circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.enabled
+          [enabled: <boolean> | default = false]
+
+          # Maximum number of requests allowed to pass through when the circuit
+          # breaker is half-open. If set to 0, by default it allows 1 request.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.half-open-max-requests
+          [half_open_max_requests: <int> | default = 10]
+
+          # Period of the open state after which the state of the circuit
+          # breaker becomes half-open. If set to 0, by default open duration is
+          # 60 seconds.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.open-duration
+          [open_duration: <duration> | default = 5s]
+
+          # Minimal requests to trigger the circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.min-requests
+          [min_requests: <int> | default = 50]
+
+          # Consecutive failures to determine if the circuit breaker should
+          # open.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.consecutive-failures
+          [consecutive_failures: <int> | default = 5]
+
+          # Failure percentage to determine if the circuit breaker should open.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.failure-percent
+          [failure_percent: <float> | default = 0.05]
 
       redis:
         # Comma separated list of redis addresses. Supported prefixes are: dns+
@@ -986,6 +1073,35 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.cache-size
         [cache_size: <int> | default = 0]
 
+        set_async_circuit_breaker:
+          # If true, enable circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.enabled
+          [enabled: <boolean> | default = false]
+
+          # Maximum number of requests allowed to pass through when the circuit
+          # breaker is half-open. If set to 0, by default it allows 1 request.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.half-open-max-requests
+          [half_open_max_requests: <int> | default = 10]
+
+          # Period of the open state after which the state of the circuit
+          # breaker becomes half-open. If set to 0, by default open duration is
+          # 60 seconds.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.open-duration
+          [open_duration: <duration> | default = 5s]
+
+          # Minimal requests to trigger the circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.min-requests
+          [min_requests: <int> | default = 50]
+
+          # Consecutive failures to determine if the circuit breaker should
+          # open.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.consecutive-failures
+          [consecutive_failures: <int> | default = 5]
+
+          # Failure percentage to determine if the circuit breaker should open.
+          # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.failure-percent
+          [failure_percent: <float> | default = 0.05]
+
       # Size of each subrange that bucket object is split into for better
       # caching.
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-size
@@ -1056,6 +1172,35 @@ blocks_storage:
         # like GCP and AWS
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.auto-discovery
         [auto_discovery: <boolean> | default = false]
+
+        set_async_circuit_breaker:
+          # If true, enable circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.enabled
+          [enabled: <boolean> | default = false]
+
+          # Maximum number of requests allowed to pass through when the circuit
+          # breaker is half-open. If set to 0, by default it allows 1 request.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.half-open-max-requests
+          [half_open_max_requests: <int> | default = 10]
+
+          # Period of the open state after which the state of the circuit
+          # breaker becomes half-open. If set to 0, by default open duration is
+          # 60 seconds.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.open-duration
+          [open_duration: <duration> | default = 5s]
+
+          # Minimal requests to trigger the circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.min-requests
+          [min_requests: <int> | default = 50]
+
+          # Consecutive failures to determine if the circuit breaker should
+          # open.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.consecutive-failures
+          [consecutive_failures: <int> | default = 5]
+
+          # Failure percentage to determine if the circuit breaker should open.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.failure-percent
+          [failure_percent: <float> | default = 0.05]
 
       redis:
         # Comma separated list of redis addresses. Supported prefixes are: dns+
@@ -1152,6 +1297,35 @@ blocks_storage:
         # See https://redis.io/docs/manual/client-side-caching/ for more info.
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.cache-size
         [cache_size: <int> | default = 0]
+
+        set_async_circuit_breaker:
+          # If true, enable circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.enabled
+          [enabled: <boolean> | default = false]
+
+          # Maximum number of requests allowed to pass through when the circuit
+          # breaker is half-open. If set to 0, by default it allows 1 request.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.half-open-max-requests
+          [half_open_max_requests: <int> | default = 10]
+
+          # Period of the open state after which the state of the circuit
+          # breaker becomes half-open. If set to 0, by default open duration is
+          # 60 seconds.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.open-duration
+          [open_duration: <duration> | default = 5s]
+
+          # Minimal requests to trigger the circuit breaker.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.min-requests
+          [min_requests: <int> | default = 50]
+
+          # Consecutive failures to determine if the circuit breaker should
+          # open.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.consecutive-failures
+          [consecutive_failures: <int> | default = 5]
+
+          # Failure percentage to determine if the circuit breaker should open.
+          # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.failure-percent
+          [failure_percent: <float> | default = 0.05]
 
       # How long to cache list of tenants in the bucket.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.tenants-list-ttl

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -717,7 +717,7 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.auto-discovery
         [auto_discovery: <boolean> | default = false]
 
-        set_async_circuit_breaker:
+        set_async_circuit_breaker_config:
           # If true, enable circuit breaker.
           # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.enabled
           [enabled: <boolean> | default = false]
@@ -847,7 +847,7 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.redis.cache-size
         [cache_size: <int> | default = 0]
 
-        set_async_circuit_breaker:
+        set_async_circuit_breaker_config:
           # If true, enable circuit breaker.
           # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.enabled
           [enabled: <boolean> | default = false]
@@ -948,7 +948,7 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.auto-discovery
         [auto_discovery: <boolean> | default = false]
 
-        set_async_circuit_breaker:
+        set_async_circuit_breaker_config:
           # If true, enable circuit breaker.
           # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.enabled
           [enabled: <boolean> | default = false]
@@ -1073,7 +1073,7 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.cache-size
         [cache_size: <int> | default = 0]
 
-        set_async_circuit_breaker:
+        set_async_circuit_breaker_config:
           # If true, enable circuit breaker.
           # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.enabled
           [enabled: <boolean> | default = false]
@@ -1173,7 +1173,7 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.auto-discovery
         [auto_discovery: <boolean> | default = false]
 
-        set_async_circuit_breaker:
+        set_async_circuit_breaker_config:
           # If true, enable circuit breaker.
           # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.enabled
           [enabled: <boolean> | default = false]
@@ -1298,7 +1298,7 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.cache-size
         [cache_size: <int> | default = 0]
 
-        set_async_circuit_breaker:
+        set_async_circuit_breaker_config:
           # If true, enable circuit breaker.
           # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.enabled
           [enabled: <boolean> | default = false]

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1151,6 +1151,34 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.auto-discovery
       [auto_discovery: <boolean> | default = false]
 
+      set_async_circuit_breaker:
+        # If true, enable circuit breaker.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.enabled
+        [enabled: <boolean> | default = false]
+
+        # Maximum number of requests allowed to pass through when the circuit
+        # breaker is half-open. If set to 0, by default it allows 1 request.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.half-open-max-requests
+        [half_open_max_requests: <int> | default = 10]
+
+        # Period of the open state after which the state of the circuit breaker
+        # becomes half-open. If set to 0, by default open duration is 60
+        # seconds.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.open-duration
+        [open_duration: <duration> | default = 5s]
+
+        # Minimal requests to trigger the circuit breaker.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.min-requests
+        [min_requests: <int> | default = 50]
+
+        # Consecutive failures to determine if the circuit breaker should open.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.consecutive-failures
+        [consecutive_failures: <int> | default = 5]
+
+        # Failure percentage to determine if the circuit breaker should open.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.failure-percent
+        [failure_percent: <float> | default = 0.05]
+
       # Selectively cache index item types. Supported values are Postings,
       # ExpandedPostings and Series
       # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.enabled-items
@@ -1252,6 +1280,34 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.index-cache.redis.cache-size
       [cache_size: <int> | default = 0]
 
+      set_async_circuit_breaker:
+        # If true, enable circuit breaker.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.enabled
+        [enabled: <boolean> | default = false]
+
+        # Maximum number of requests allowed to pass through when the circuit
+        # breaker is half-open. If set to 0, by default it allows 1 request.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.half-open-max-requests
+        [half_open_max_requests: <int> | default = 10]
+
+        # Period of the open state after which the state of the circuit breaker
+        # becomes half-open. If set to 0, by default open duration is 60
+        # seconds.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.open-duration
+        [open_duration: <duration> | default = 5s]
+
+        # Minimal requests to trigger the circuit breaker.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.min-requests
+        [min_requests: <int> | default = 50]
+
+        # Consecutive failures to determine if the circuit breaker should open.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.consecutive-failures
+        [consecutive_failures: <int> | default = 5]
+
+        # Failure percentage to determine if the circuit breaker should open.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.failure-percent
+        [failure_percent: <float> | default = 0.05]
+
       # Selectively cache index item types. Supported values are Postings,
       # ExpandedPostings and Series
       # CLI flag: -blocks-storage.bucket-store.index-cache.redis.enabled-items
@@ -1323,6 +1379,34 @@ bucket_store:
       # like GCP and AWS
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.auto-discovery
       [auto_discovery: <boolean> | default = false]
+
+      set_async_circuit_breaker:
+        # If true, enable circuit breaker.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.enabled
+        [enabled: <boolean> | default = false]
+
+        # Maximum number of requests allowed to pass through when the circuit
+        # breaker is half-open. If set to 0, by default it allows 1 request.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.half-open-max-requests
+        [half_open_max_requests: <int> | default = 10]
+
+        # Period of the open state after which the state of the circuit breaker
+        # becomes half-open. If set to 0, by default open duration is 60
+        # seconds.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.open-duration
+        [open_duration: <duration> | default = 5s]
+
+        # Minimal requests to trigger the circuit breaker.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.min-requests
+        [min_requests: <int> | default = 50]
+
+        # Consecutive failures to determine if the circuit breaker should open.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.consecutive-failures
+        [consecutive_failures: <int> | default = 5]
+
+        # Failure percentage to determine if the circuit breaker should open.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.failure-percent
+        [failure_percent: <float> | default = 0.05]
 
     redis:
       # Comma separated list of redis addresses. Supported prefixes are: dns+
@@ -1420,6 +1504,34 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.cache-size
       [cache_size: <int> | default = 0]
 
+      set_async_circuit_breaker:
+        # If true, enable circuit breaker.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.enabled
+        [enabled: <boolean> | default = false]
+
+        # Maximum number of requests allowed to pass through when the circuit
+        # breaker is half-open. If set to 0, by default it allows 1 request.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.half-open-max-requests
+        [half_open_max_requests: <int> | default = 10]
+
+        # Period of the open state after which the state of the circuit breaker
+        # becomes half-open. If set to 0, by default open duration is 60
+        # seconds.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.open-duration
+        [open_duration: <duration> | default = 5s]
+
+        # Minimal requests to trigger the circuit breaker.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.min-requests
+        [min_requests: <int> | default = 50]
+
+        # Consecutive failures to determine if the circuit breaker should open.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.consecutive-failures
+        [consecutive_failures: <int> | default = 5]
+
+        # Failure percentage to determine if the circuit breaker should open.
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.failure-percent
+        [failure_percent: <float> | default = 0.05]
+
     # Size of each subrange that bucket object is split into for better caching.
     # CLI flag: -blocks-storage.bucket-store.chunks-cache.subrange-size
     [subrange_size: <int> | default = 16000]
@@ -1489,6 +1601,34 @@ bucket_store:
       # like GCP and AWS
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.auto-discovery
       [auto_discovery: <boolean> | default = false]
+
+      set_async_circuit_breaker:
+        # If true, enable circuit breaker.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.enabled
+        [enabled: <boolean> | default = false]
+
+        # Maximum number of requests allowed to pass through when the circuit
+        # breaker is half-open. If set to 0, by default it allows 1 request.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.half-open-max-requests
+        [half_open_max_requests: <int> | default = 10]
+
+        # Period of the open state after which the state of the circuit breaker
+        # becomes half-open. If set to 0, by default open duration is 60
+        # seconds.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.open-duration
+        [open_duration: <duration> | default = 5s]
+
+        # Minimal requests to trigger the circuit breaker.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.min-requests
+        [min_requests: <int> | default = 50]
+
+        # Consecutive failures to determine if the circuit breaker should open.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.consecutive-failures
+        [consecutive_failures: <int> | default = 5]
+
+        # Failure percentage to determine if the circuit breaker should open.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.failure-percent
+        [failure_percent: <float> | default = 0.05]
 
     redis:
       # Comma separated list of redis addresses. Supported prefixes are: dns+
@@ -1585,6 +1725,34 @@ bucket_store:
       # https://redis.io/docs/manual/client-side-caching/ for more info.
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.cache-size
       [cache_size: <int> | default = 0]
+
+      set_async_circuit_breaker:
+        # If true, enable circuit breaker.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.enabled
+        [enabled: <boolean> | default = false]
+
+        # Maximum number of requests allowed to pass through when the circuit
+        # breaker is half-open. If set to 0, by default it allows 1 request.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.half-open-max-requests
+        [half_open_max_requests: <int> | default = 10]
+
+        # Period of the open state after which the state of the circuit breaker
+        # becomes half-open. If set to 0, by default open duration is 60
+        # seconds.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.open-duration
+        [open_duration: <duration> | default = 5s]
+
+        # Minimal requests to trigger the circuit breaker.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.min-requests
+        [min_requests: <int> | default = 50]
+
+        # Consecutive failures to determine if the circuit breaker should open.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.consecutive-failures
+        [consecutive_failures: <int> | default = 5]
+
+        # Failure percentage to determine if the circuit breaker should open.
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.failure-percent
+        [failure_percent: <float> | default = 0.05]
 
     # How long to cache list of tenants in the bucket.
     # CLI flag: -blocks-storage.bucket-store.metadata-cache.tenants-list-ttl

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1151,7 +1151,7 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.auto-discovery
       [auto_discovery: <boolean> | default = false]
 
-      set_async_circuit_breaker:
+      set_async_circuit_breaker_config:
         # If true, enable circuit breaker.
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.set-async.circuit-breaker.enabled
         [enabled: <boolean> | default = false]
@@ -1280,7 +1280,7 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.index-cache.redis.cache-size
       [cache_size: <int> | default = 0]
 
-      set_async_circuit_breaker:
+      set_async_circuit_breaker_config:
         # If true, enable circuit breaker.
         # CLI flag: -blocks-storage.bucket-store.index-cache.redis.set-async.circuit-breaker.enabled
         [enabled: <boolean> | default = false]
@@ -1380,7 +1380,7 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.auto-discovery
       [auto_discovery: <boolean> | default = false]
 
-      set_async_circuit_breaker:
+      set_async_circuit_breaker_config:
         # If true, enable circuit breaker.
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.memcached.set-async.circuit-breaker.enabled
         [enabled: <boolean> | default = false]
@@ -1504,7 +1504,7 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.cache-size
       [cache_size: <int> | default = 0]
 
-      set_async_circuit_breaker:
+      set_async_circuit_breaker_config:
         # If true, enable circuit breaker.
         # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.set-async.circuit-breaker.enabled
         [enabled: <boolean> | default = false]
@@ -1602,7 +1602,7 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.auto-discovery
       [auto_discovery: <boolean> | default = false]
 
-      set_async_circuit_breaker:
+      set_async_circuit_breaker_config:
         # If true, enable circuit breaker.
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.memcached.set-async.circuit-breaker.enabled
         [enabled: <boolean> | default = false]
@@ -1726,7 +1726,7 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.cache-size
       [cache_size: <int> | default = 0]
 
-      set_async_circuit_breaker:
+      set_async_circuit_breaker_config:
         # If true, enable circuit breaker.
         # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.set-async.circuit-breaker.enabled
         [enabled: <boolean> | default = false]

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/thanos-io/objstore v0.0.0-20240128223450-bdadaefbfe03
 	github.com/thanos-io/promql-engine v0.0.0-20240125175542-4a8e9731acba
-	github.com/thanos-io/thanos v0.34.1-0.20240201134136-94f971bc2b7f
+	github.com/thanos-io/thanos v0.34.2-0.20240226184600-e7cd6c1c60fb
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/weaveworks/common v0.0.0-20230728070032-dd9e68f319d5
 	go.etcd.io/etcd/api/v3 v3.5.12

--- a/go.sum
+++ b/go.sum
@@ -1401,8 +1401,8 @@ github.com/thanos-io/objstore v0.0.0-20240128223450-bdadaefbfe03 h1:VEu81Atmor2R
 github.com/thanos-io/objstore v0.0.0-20240128223450-bdadaefbfe03/go.mod h1:RMvJQnpB4QQiYGg1gF8mnPJg6IkIPY28Buh8f6b+F0c=
 github.com/thanos-io/promql-engine v0.0.0-20240125175542-4a8e9731acba h1:BFohBPqCWBpbqNO3F3lC2uZ0egSfPGQoSDloTRraPHU=
 github.com/thanos-io/promql-engine v0.0.0-20240125175542-4a8e9731acba/go.mod h1:YGk7VqhYDfhUyZjWK7ZU1JmBQKSvr5mT5Txut8oK1MA=
-github.com/thanos-io/thanos v0.34.1-0.20240201134136-94f971bc2b7f h1:UiC5sz+udt21idrpdepOrRWT8i5eFFiJYq5eZfErlew=
-github.com/thanos-io/thanos v0.34.1-0.20240201134136-94f971bc2b7f/go.mod h1:bcqHW+37C8GTiwokbUNHClNIS0qb5R4qXfNSvNCGHFU=
+github.com/thanos-io/thanos v0.34.2-0.20240226184600-e7cd6c1c60fb h1:/kpKf+GpBGcA0/+HmBF2VCDJuQYDJaml7JV1/YtDA/U=
+github.com/thanos-io/thanos v0.34.2-0.20240226184600-e7cd6c1c60fb/go.mod h1:bcqHW+37C8GTiwokbUNHClNIS0qb5R4qXfNSvNCGHFU=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab h1:7ZR3hmisBWw77ZpO1/o86g+JV3VKlk3d48jopJxzTjU=
 github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab/go.mod h1:eheTFp954zcWZXCU8d0AT76ftsQOTo4DTqkN/h3k1MY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -827,7 +827,7 @@ func (c *Compactor) compactUser(ctx context.Context, userID string) error {
 	// out of order chunks or index file too big.
 	noCompactMarkerFilter := compact.NewGatherNoCompactionMarkFilter(ulogger, bucket, c.compactorCfg.MetaSyncConcurrency)
 
-	var blockIDsFetcher block.BlockIDsFetcher
+	var blockIDsFetcher block.Lister
 	var fetcherULogger log.Logger
 	if c.storageCfg.BucketStore.BucketIndex.Enabled {
 		fetcherULogger = log.With(ulogger, "blockIdsFetcher", "BucketIndexBlockIDsFetcher")
@@ -835,7 +835,7 @@ func (c *Compactor) compactUser(ctx context.Context, userID string) error {
 
 	} else {
 		fetcherULogger = log.With(ulogger, "blockIdsFetcher", "BaseBlockIDsFetcher")
-		blockIDsFetcher = block.NewBaseBlockIDsFetcher(fetcherULogger, bucket)
+		blockIDsFetcher = block.NewRecursiveLister(fetcherULogger, bucket)
 	}
 
 	fetcher, err := block.NewMetaFetcher(

--- a/pkg/querier/blocks_finder_bucket_scan.go
+++ b/pkg/querier/blocks_finder_bucket_scan.go
@@ -384,7 +384,7 @@ func (d *BucketScanBlocksFinder) createMetaFetcher(userID string) (block.Metadat
 		filters = append(filters, storegateway.NewIgnoreNonQueryableBlocksFilter(d.logger, d.cfg.IgnoreBlocksWithin))
 	}
 
-	blockIdsFetcher := block.NewBaseBlockIDsFetcher(userLogger, userBucket)
+	blockIdsFetcher := block.NewRecursiveLister(userLogger, userBucket)
 	f, err := block.NewMetaFetcher(
 		userLogger,
 		d.cfg.MetasConcurrency,

--- a/pkg/storage/tsdb/bucketindex/block_ids_fetcher.go
+++ b/pkg/storage/tsdb/bucketindex/block_ids_fetcher.go
@@ -18,12 +18,12 @@ type BlockIDsFetcher struct {
 	bkt                 objstore.Bucket
 	userID              string
 	cfgProvider         bucket.TenantConfigProvider
-	baseBlockIDsFetcher block.BlockIDsFetcher
+	baseBlockIDsFetcher block.Lister
 }
 
 func NewBlockIDsFetcher(logger log.Logger, bkt objstore.Bucket, userID string, cfgProvider bucket.TenantConfigProvider) *BlockIDsFetcher {
 	userBkt := bucket.NewUserBucketClient(userID, bkt, cfgProvider)
-	baseBlockIDsFetcher := block.NewBaseBlockIDsFetcher(logger, userBkt)
+	baseBlockIDsFetcher := block.NewRecursiveLister(logger, userBkt)
 	return &BlockIDsFetcher{
 		logger:              logger,
 		bkt:                 bkt,

--- a/pkg/storage/tsdb/caching_bucket.go
+++ b/pkg/storage/tsdb/caching_bucket.go
@@ -139,9 +139,9 @@ func CreateCachingBucket(chunksConfig ChunksCacheConfig, metadataConfig Metadata
 		cfg.CacheGet("bucket-index", metadataCache, matchers.GetBucketIndexMatcher(), metadataConfig.BucketIndexMaxSize, metadataConfig.BucketIndexContentTTL /* do not cache exist / not exist: */, 0, 0)
 
 		codec := snappyIterCodec{storecache.JSONIterCodec{}}
-		cfg.CacheIter("tenants-iter", metadataCache, matchers.GetTenantsIterMatcher(), metadataConfig.TenantsListTTL, codec)
-		cfg.CacheIter("tenant-blocks-iter", metadataCache, matchers.GetTenantBlocksIterMatcher(), metadataConfig.TenantBlocksListTTL, codec)
-		cfg.CacheIter("chunks-iter", metadataCache, matchers.GetChunksIterMatcher(), metadataConfig.ChunksListTTL, codec)
+		cfg.CacheIter("tenants-iter", metadataCache, matchers.GetTenantsIterMatcher(), metadataConfig.TenantsListTTL, codec, "")
+		cfg.CacheIter("tenant-blocks-iter", metadataCache, matchers.GetTenantBlocksIterMatcher(), metadataConfig.TenantBlocksListTTL, codec, "")
+		cfg.CacheIter("chunks-iter", metadataCache, matchers.GetChunksIterMatcher(), metadataConfig.ChunksListTTL, codec, "")
 	}
 
 	if !cachingConfigured {

--- a/pkg/storage/tsdb/circuit_breaker.go
+++ b/pkg/storage/tsdb/circuit_breaker.go
@@ -1,0 +1,35 @@
+package tsdb
+
+import (
+	"flag"
+	"time"
+)
+
+// CircuitBreakerConfig is the config for the circuit breaker.
+type CircuitBreakerConfig struct {
+	// Enabled enables circuit breaker.
+	Enabled bool `yaml:"enabled"`
+
+	// HalfOpenMaxRequests is the maximum number of requests allowed to pass through
+	// when the circuit breaker is half-open.
+	// If set to 0, the circuit breaker allows only 1 request.
+	HalfOpenMaxRequests uint `yaml:"half_open_max_requests"`
+	// OpenDuration is the period of the open state after which the state of the circuit breaker becomes half-open.
+	// If set to 0, the circuit breaker utilizes the default value of 60 seconds.
+	OpenDuration time.Duration `yaml:"open_duration"`
+	// MinRequests is minimal requests to trigger the circuit breaker.
+	MinRequests uint `yaml:"min_requests"`
+	// ConsecutiveFailures represents consecutive failures based on CircuitBreakerMinRequests to determine if the circuit breaker should open.
+	ConsecutiveFailures uint `yaml:"consecutive_failures"`
+	// FailurePercent represents the failure percentage, which is based on CircuitBreakerMinRequests, to determine if the circuit breaker should open.
+	FailurePercent float64 `yaml:"failure_percent"`
+}
+
+func (cfg *CircuitBreakerConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
+	f.BoolVar(&cfg.Enabled, prefix+"circuit-breaker.enabled", false, "If true, enable circuit breaker.")
+	f.UintVar(&cfg.HalfOpenMaxRequests, prefix+"circuit-breaker.half-open-max-requests", 10, "Maximum number of requests allowed to pass through when the circuit breaker is half-open. If set to 0, by default it allows 1 request.")
+	f.DurationVar(&cfg.OpenDuration, prefix+"circuit-breaker.open-duration", 5*time.Second, "Period of the open state after which the state of the circuit breaker becomes half-open. If set to 0, by default open duration is 60 seconds.")
+	f.UintVar(&cfg.MinRequests, prefix+"circuit-breaker.min-requests", 50, "Minimal requests to trigger the circuit breaker.")
+	f.UintVar(&cfg.ConsecutiveFailures, prefix+"circuit-breaker.consecutive-failures", 5, "Consecutive failures to determine if the circuit breaker should open.")
+	f.Float64Var(&cfg.FailurePercent, prefix+"circuit-breaker.failure-percent", 0.05, "Failure percentage to determine if the circuit breaker should open.")
+}

--- a/pkg/storage/tsdb/memcache_client_config.go
+++ b/pkg/storage/tsdb/memcache_client_config.go
@@ -19,7 +19,7 @@ type MemcachedClientConfig struct {
 	MaxGetMultiBatchSize   int                  `yaml:"max_get_multi_batch_size"`
 	MaxItemSize            int                  `yaml:"max_item_size"`
 	AutoDiscovery          bool                 `yaml:"auto_discovery"`
-	SetAsyncCircuitBreaker CircuitBreakerConfig `yaml:"set_async_circuit_breaker"`
+	SetAsyncCircuitBreaker CircuitBreakerConfig `yaml:"set_async_circuit_breaker_config"`
 }
 
 func (cfg *MemcachedClientConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {

--- a/pkg/storage/tsdb/memcache_client_config.go
+++ b/pkg/storage/tsdb/memcache_client_config.go
@@ -10,15 +10,16 @@ import (
 )
 
 type MemcachedClientConfig struct {
-	Addresses              string        `yaml:"addresses"`
-	Timeout                time.Duration `yaml:"timeout"`
-	MaxIdleConnections     int           `yaml:"max_idle_connections"`
-	MaxAsyncConcurrency    int           `yaml:"max_async_concurrency"`
-	MaxAsyncBufferSize     int           `yaml:"max_async_buffer_size"`
-	MaxGetMultiConcurrency int           `yaml:"max_get_multi_concurrency"`
-	MaxGetMultiBatchSize   int           `yaml:"max_get_multi_batch_size"`
-	MaxItemSize            int           `yaml:"max_item_size"`
-	AutoDiscovery          bool          `yaml:"auto_discovery"`
+	Addresses              string               `yaml:"addresses"`
+	Timeout                time.Duration        `yaml:"timeout"`
+	MaxIdleConnections     int                  `yaml:"max_idle_connections"`
+	MaxAsyncConcurrency    int                  `yaml:"max_async_concurrency"`
+	MaxAsyncBufferSize     int                  `yaml:"max_async_buffer_size"`
+	MaxGetMultiConcurrency int                  `yaml:"max_get_multi_concurrency"`
+	MaxGetMultiBatchSize   int                  `yaml:"max_get_multi_batch_size"`
+	MaxItemSize            int                  `yaml:"max_item_size"`
+	AutoDiscovery          bool                 `yaml:"auto_discovery"`
+	SetAsyncCircuitBreaker CircuitBreakerConfig `yaml:"set_async_circuit_breaker"`
 }
 
 func (cfg *MemcachedClientConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
@@ -31,6 +32,7 @@ func (cfg *MemcachedClientConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefi
 	f.IntVar(&cfg.MaxGetMultiBatchSize, prefix+"max-get-multi-batch-size", 0, "The maximum number of keys a single underlying get operation should run. If more keys are specified, internally keys are split into multiple batches and fetched concurrently, honoring the max concurrency. If set to 0, the max batch size is unlimited.")
 	f.IntVar(&cfg.MaxItemSize, prefix+"max-item-size", 1024*1024, "The maximum size of an item stored in memcached. Bigger items are not stored. If set to 0, no maximum size is enforced.")
 	f.BoolVar(&cfg.AutoDiscovery, prefix+"auto-discovery", false, "Use memcached auto-discovery mechanism provided by some cloud provider like GCP and AWS")
+	cfg.SetAsyncCircuitBreaker.RegisterFlagsWithPrefix(f, prefix+"set-async.")
 }
 
 func (cfg *MemcachedClientConfig) GetAddresses() []string {
@@ -62,5 +64,13 @@ func (cfg MemcachedClientConfig) ToMemcachedClientConfig() cacheutil.MemcachedCl
 		MaxItemSize:               model.Bytes(cfg.MaxItemSize),
 		DNSProviderUpdateInterval: 30 * time.Second,
 		AutoDiscovery:             cfg.AutoDiscovery,
+		SetAsyncCircuitBreaker: cacheutil.CircuitBreakerConfig{
+			Enabled:             cfg.SetAsyncCircuitBreaker.Enabled,
+			HalfOpenMaxRequests: uint32(cfg.SetAsyncCircuitBreaker.HalfOpenMaxRequests),
+			OpenDuration:        cfg.SetAsyncCircuitBreaker.OpenDuration,
+			MinRequests:         uint32(cfg.SetAsyncCircuitBreaker.MinRequests),
+			ConsecutiveFailures: uint32(cfg.SetAsyncCircuitBreaker.ConsecutiveFailures),
+			FailurePercent:      cfg.SetAsyncCircuitBreaker.FailurePercent,
+		},
 	}
 }

--- a/pkg/storage/tsdb/redis_client_config.go
+++ b/pkg/storage/tsdb/redis_client_config.go
@@ -38,6 +38,9 @@ type RedisClientConfig struct {
 	// instead of fetching data each time.
 	// See https://redis.io/docs/manual/client-side-caching/ for info.
 	CacheSize int `yaml:"cache_size"`
+
+	// SetAsyncCircuitBreaker configures the circuit breaker for SetAsync operations.
+	SetAsyncCircuitBreaker CircuitBreakerConfig `yaml:"set_async_circuit_breaker"`
 }
 
 func (cfg *RedisClientConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
@@ -58,6 +61,7 @@ func (cfg *RedisClientConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix st
 	f.IntVar(&cfg.CacheSize, prefix+"cache-size", 0, "If not zero then client-side caching is enabled. Client-side caching is when data is stored in memory instead of fetching data each time. See https://redis.io/docs/manual/client-side-caching/ for more info.")
 	f.BoolVar(&cfg.TLSEnabled, prefix+"tls-enabled", false, "Whether to enable tls for redis connection.")
 	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
+	cfg.SetAsyncCircuitBreaker.RegisterFlagsWithPrefix(f, prefix+"set-async.")
 }
 
 // Validate the config.
@@ -100,5 +104,13 @@ func (cfg *RedisClientConfig) ToRedisClientConfig() cacheutil.RedisClientConfig 
 			InsecureSkipVerify: cfg.TLS.InsecureSkipVerify,
 		},
 		CacheSize: model.Bytes(cfg.CacheSize),
+		SetAsyncCircuitBreaker: cacheutil.CircuitBreakerConfig{
+			Enabled:             cfg.SetAsyncCircuitBreaker.Enabled,
+			HalfOpenMaxRequests: uint32(cfg.SetAsyncCircuitBreaker.HalfOpenMaxRequests),
+			OpenDuration:        cfg.SetAsyncCircuitBreaker.OpenDuration,
+			MinRequests:         uint32(cfg.SetAsyncCircuitBreaker.MinRequests),
+			ConsecutiveFailures: uint32(cfg.SetAsyncCircuitBreaker.ConsecutiveFailures),
+			FailurePercent:      cfg.SetAsyncCircuitBreaker.FailurePercent,
+		},
 	}
 }

--- a/pkg/storage/tsdb/redis_client_config.go
+++ b/pkg/storage/tsdb/redis_client_config.go
@@ -40,7 +40,7 @@ type RedisClientConfig struct {
 	CacheSize int `yaml:"cache_size"`
 
 	// SetAsyncCircuitBreaker configures the circuit breaker for SetAsync operations.
-	SetAsyncCircuitBreaker CircuitBreakerConfig `yaml:"set_async_circuit_breaker"`
+	SetAsyncCircuitBreaker CircuitBreakerConfig `yaml:"set_async_circuit_breaker_config"`
 }
 
 func (cfg *RedisClientConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -553,7 +553,7 @@ func (u *BucketStores) getOrCreateStore(userID string) (*store.BucketStore, erro
 		fetcherBkt := NewShardingBucketReaderAdapter(userID, u.shardingStrategy, userBkt)
 
 		var err error
-		blockIdsFetcher := block.NewBaseBlockIDsFetcher(userLogger, fetcherBkt)
+		blockIdsFetcher := block.NewRecursiveLister(userLogger, fetcherBkt)
 		fetcher, err = block.NewMetaFetcher(
 			userLogger,
 			u.cfg.BucketStore.MetaSyncConcurrency,

--- a/vendor/github.com/thanos-io/thanos/pkg/block/fetcher.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/block/fetcher.go
@@ -170,26 +170,27 @@ func DefaultModifiedLabelValues() [][]string {
 	}
 }
 
-// Fetcher interface to retieve blockId information from a bucket.
-type BlockIDsFetcher interface {
-	// GetActiveBlocksIDs returning it via channel (streaming) and response.
+// Lister lists block IDs from a bucket.
+type Lister interface {
+	// GetActiveAndPartialBlockIDs GetActiveBlocksIDs returning it via channel (streaming) and response.
 	// Active blocks are blocks which contain meta.json, while partial blocks are blocks without meta.json
 	GetActiveAndPartialBlockIDs(ctx context.Context, ch chan<- ulid.ULID) (partialBlocks map[ulid.ULID]bool, err error)
 }
 
-type BaseBlockIDsFetcher struct {
+// RecursiveLister lists block IDs by recursively iterating through a bucket.
+type RecursiveLister struct {
 	logger log.Logger
 	bkt    objstore.InstrumentedBucketReader
 }
 
-func NewBaseBlockIDsFetcher(logger log.Logger, bkt objstore.InstrumentedBucketReader) *BaseBlockIDsFetcher {
-	return &BaseBlockIDsFetcher{
+func NewRecursiveLister(logger log.Logger, bkt objstore.InstrumentedBucketReader) *RecursiveLister {
+	return &RecursiveLister{
 		logger: logger,
 		bkt:    bkt,
 	}
 }
 
-func (f *BaseBlockIDsFetcher) GetActiveAndPartialBlockIDs(ctx context.Context, ch chan<- ulid.ULID) (partialBlocks map[ulid.ULID]bool, err error) {
+func (f *RecursiveLister) GetActiveAndPartialBlockIDs(ctx context.Context, ch chan<- ulid.ULID) (partialBlocks map[ulid.ULID]bool, err error) {
 	partialBlocks = make(map[ulid.ULID]bool)
 	err = f.bkt.Iter(ctx, "", func(name string) error {
 		parts := strings.Split(name, "/")
@@ -216,6 +217,74 @@ func (f *BaseBlockIDsFetcher) GetActiveAndPartialBlockIDs(ctx context.Context, c
 	return partialBlocks, err
 }
 
+// ConcurrentLister lists block IDs by doing a top level iteration of the bucket
+// followed by one Exists call for each discovered block to detect partial blocks.
+type ConcurrentLister struct {
+	logger log.Logger
+	bkt    objstore.InstrumentedBucketReader
+}
+
+func NewConcurrentLister(logger log.Logger, bkt objstore.InstrumentedBucketReader) *ConcurrentLister {
+	return &ConcurrentLister{
+		logger: logger,
+		bkt:    bkt,
+	}
+}
+
+func (f *ConcurrentLister) GetActiveAndPartialBlockIDs(ctx context.Context, ch chan<- ulid.ULID) (partialBlocks map[ulid.ULID]bool, err error) {
+	const concurrency = 64
+
+	partialBlocks = make(map[ulid.ULID]bool)
+	var (
+		metaChan = make(chan ulid.ULID, concurrency)
+		eg, gCtx = errgroup.WithContext(ctx)
+		mu       sync.Mutex
+	)
+	for i := 0; i < concurrency; i++ {
+		eg.Go(func() error {
+			for uid := range metaChan {
+				// TODO(bwplotka): If that causes problems (obj store rate limits), add longer ttl to cached items.
+				// For 1y and 100 block sources this generates ~1.5-3k HEAD RPM. AWS handles 330k RPM per prefix.
+				// TODO(bwplotka): Consider filtering by consistency delay here (can't do until compactor healthyOverride work).
+				metaFile := path.Join(uid.String(), MetaFilename)
+				ok, err := f.bkt.Exists(gCtx, metaFile)
+				if err != nil {
+					return errors.Wrapf(err, "meta.json file exists: %v", uid)
+				}
+				if !ok {
+					mu.Lock()
+					partialBlocks[uid] = true
+					mu.Unlock()
+					continue
+				}
+				ch <- uid
+			}
+			return nil
+		})
+	}
+
+	if err = f.bkt.Iter(ctx, "", func(name string) error {
+		id, ok := IsBlockDir(name)
+		if !ok {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case metaChan <- id:
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	close(metaChan)
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return partialBlocks, nil
+}
+
 type MetadataFetcher interface {
 	Fetch(ctx context.Context) (metas map[ulid.ULID]*metadata.Meta, partial map[ulid.ULID]error, err error)
 	UpdateOnChange(func([]metadata.Meta, error))
@@ -234,10 +303,10 @@ type MetadataFilter interface {
 // BaseFetcher is a struct that synchronizes filtered metadata of all block in the object storage with the local state.
 // Go-routine safe.
 type BaseFetcher struct {
-	logger          log.Logger
-	concurrency     int
-	bkt             objstore.InstrumentedBucketReader
-	blockIDsFetcher BlockIDsFetcher
+	logger         log.Logger
+	concurrency    int
+	bkt            objstore.InstrumentedBucketReader
+	blockIDsLister Lister
 
 	// Optional local directory to cache meta.json files.
 	cacheDir string
@@ -249,12 +318,12 @@ type BaseFetcher struct {
 }
 
 // NewBaseFetcher constructs BaseFetcher.
-func NewBaseFetcher(logger log.Logger, concurrency int, bkt objstore.InstrumentedBucketReader, blockIDsFetcher BlockIDsFetcher, dir string, reg prometheus.Registerer) (*BaseFetcher, error) {
+func NewBaseFetcher(logger log.Logger, concurrency int, bkt objstore.InstrumentedBucketReader, blockIDsFetcher Lister, dir string, reg prometheus.Registerer) (*BaseFetcher, error) {
 	return NewBaseFetcherWithMetrics(logger, concurrency, bkt, blockIDsFetcher, dir, NewBaseFetcherMetrics(reg))
 }
 
 // NewBaseFetcherWithMetrics constructs BaseFetcher.
-func NewBaseFetcherWithMetrics(logger log.Logger, concurrency int, bkt objstore.InstrumentedBucketReader, blockIDsFetcher BlockIDsFetcher, dir string, metrics *BaseFetcherMetrics) (*BaseFetcher, error) {
+func NewBaseFetcherWithMetrics(logger log.Logger, concurrency int, bkt objstore.InstrumentedBucketReader, blockIDsLister Lister, dir string, metrics *BaseFetcherMetrics) (*BaseFetcher, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -268,24 +337,24 @@ func NewBaseFetcherWithMetrics(logger log.Logger, concurrency int, bkt objstore.
 	}
 
 	return &BaseFetcher{
-		logger:          log.With(logger, "component", "block.BaseFetcher"),
-		concurrency:     concurrency,
-		bkt:             bkt,
-		blockIDsFetcher: blockIDsFetcher,
-		cacheDir:        cacheDir,
-		cached:          map[ulid.ULID]*metadata.Meta{},
-		syncs:           metrics.Syncs,
+		logger:         log.With(logger, "component", "block.BaseFetcher"),
+		concurrency:    concurrency,
+		bkt:            bkt,
+		blockIDsLister: blockIDsLister,
+		cacheDir:       cacheDir,
+		cached:         map[ulid.ULID]*metadata.Meta{},
+		syncs:          metrics.Syncs,
 	}, nil
 }
 
 // NewRawMetaFetcher returns basic meta fetcher without proper handling for eventual consistent backends or partial uploads.
 // NOTE: Not suitable to use in production.
-func NewRawMetaFetcher(logger log.Logger, bkt objstore.InstrumentedBucketReader, blockIDsFetcher BlockIDsFetcher) (*MetaFetcher, error) {
+func NewRawMetaFetcher(logger log.Logger, bkt objstore.InstrumentedBucketReader, blockIDsFetcher Lister) (*MetaFetcher, error) {
 	return NewMetaFetcher(logger, 1, bkt, blockIDsFetcher, "", nil, nil)
 }
 
 // NewMetaFetcher returns meta fetcher.
-func NewMetaFetcher(logger log.Logger, concurrency int, bkt objstore.InstrumentedBucketReader, blockIDsFetcher BlockIDsFetcher, dir string, reg prometheus.Registerer, filters []MetadataFilter) (*MetaFetcher, error) {
+func NewMetaFetcher(logger log.Logger, concurrency int, bkt objstore.InstrumentedBucketReader, blockIDsFetcher Lister, dir string, reg prometheus.Registerer, filters []MetadataFilter) (*MetaFetcher, error) {
 	b, err := NewBaseFetcher(logger, concurrency, bkt, blockIDsFetcher, dir, reg)
 	if err != nil {
 		return nil, err
@@ -294,7 +363,7 @@ func NewMetaFetcher(logger log.Logger, concurrency int, bkt objstore.Instrumente
 }
 
 // NewMetaFetcherWithMetrics returns meta fetcher.
-func NewMetaFetcherWithMetrics(logger log.Logger, concurrency int, bkt objstore.InstrumentedBucketReader, blockIDsFetcher BlockIDsFetcher, dir string, baseFetcherMetrics *BaseFetcherMetrics, fetcherMetrics *FetcherMetrics, filters []MetadataFilter) (*MetaFetcher, error) {
+func NewMetaFetcherWithMetrics(logger log.Logger, concurrency int, bkt objstore.InstrumentedBucketReader, blockIDsFetcher Lister, dir string, baseFetcherMetrics *BaseFetcherMetrics, fetcherMetrics *FetcherMetrics, filters []MetadataFilter) (*MetaFetcher, error) {
 	b, err := NewBaseFetcherWithMetrics(logger, concurrency, bkt, blockIDsFetcher, dir, baseFetcherMetrics)
 	if err != nil {
 		return nil, err
@@ -445,7 +514,7 @@ func (f *BaseFetcher) fetchMetadata(ctx context.Context) (interface{}, error) {
 	// Workers scheduled, distribute blocks.
 	eg.Go(func() error {
 		defer close(ch)
-		partialBlocks, err = f.blockIDsFetcher.GetActiveAndPartialBlockIDs(ctx, ch)
+		partialBlocks, err = f.blockIDsLister.GetActiveAndPartialBlockIDs(ctx, ch)
 		return err
 	})
 

--- a/vendor/github.com/thanos-io/thanos/pkg/cache/caching_bucket_config.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/cache/caching_bucket_config.go
@@ -64,8 +64,9 @@ type OperationConfig struct {
 // Operation-specific configs.
 type IterConfig struct {
 	OperationConfig
-	TTL   time.Duration
-	Codec IterCodec
+	TTL        time.Duration
+	Codec      IterCodec
+	ConfigHash string
 }
 
 type ExistsConfig struct {
@@ -105,11 +106,12 @@ func newOperationConfig(cache Cache, matcher func(string) bool) OperationConfig 
 }
 
 // CacheIter configures caching of "Iter" operation for matching directories.
-func (cfg *CachingBucketConfig) CacheIter(configName string, cache Cache, matcher func(string) bool, ttl time.Duration, codec IterCodec) {
+func (cfg *CachingBucketConfig) CacheIter(configName string, cache Cache, matcher func(string) bool, ttl time.Duration, codec IterCodec, configHash string) {
 	cfg.iter[configName] = &IterConfig{
 		OperationConfig: newOperationConfig(cache, matcher),
 		TTL:             ttl,
 		Codec:           codec,
+		ConfigHash:      configHash,
 	}
 }
 

--- a/vendor/github.com/thanos-io/thanos/pkg/cacheutil/cacheutil.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/cacheutil/cacheutil.go
@@ -5,10 +5,27 @@ package cacheutil
 
 import (
 	"context"
+	"time"
 
+	"github.com/pkg/errors"
+	"github.com/sony/gobreaker"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/thanos-io/thanos/pkg/gate"
+)
+
+var (
+	errCircuitBreakerConsecutiveFailuresNotPositive = errors.New("circuit breaker: consecutive failures must be greater than 0")
+	errCircuitBreakerFailurePercentInvalid          = errors.New("circuit breaker: failure percent must be in range (0,1]")
+
+	defaultCircuitBreakerConfig = CircuitBreakerConfig{
+		Enabled:             false,
+		HalfOpenMaxRequests: 10,
+		OpenDuration:        5 * time.Second,
+		MinRequests:         50,
+		ConsecutiveFailures: 5,
+		FailurePercent:      0.05,
+	}
 )
 
 // doWithBatch do func with batch and gate. batchSize==0 means one batch. gate==nil means no gate.
@@ -39,4 +56,74 @@ func doWithBatch(ctx context.Context, totalSize int, batchSize int, ga gate.Gate
 		})
 	}
 	return g.Wait()
+}
+
+// CircuitBreaker implements the circuit breaker pattern https://en.wikipedia.org/wiki/Circuit_breaker_design_pattern.
+type CircuitBreaker interface {
+	Execute(func() error) error
+}
+
+// CircuitBreakerConfig is the config for the circuite breaker.
+type CircuitBreakerConfig struct {
+	// Enabled enables circuite breaker.
+	Enabled bool `yaml:"enabled"`
+
+	// HalfOpenMaxRequests is the maximum number of requests allowed to pass through
+	// when the circuit breaker is half-open.
+	// If set to 0, the circuit breaker allows only 1 request.
+	HalfOpenMaxRequests uint32 `yaml:"half_open_max_requests"`
+	// OpenDuration is the period of the open state after which the state of the circuit breaker becomes half-open.
+	// If set to 0, the circuit breaker utilizes the default value of 60 seconds.
+	OpenDuration time.Duration `yaml:"open_duration"`
+	// MinRequests is minimal requests to trigger the circuit breaker.
+	MinRequests uint32 `yaml:"min_requests"`
+	// ConsecutiveFailures represents consecutive failures based on CircuitBreakerMinRequests to determine if the circuit breaker should open.
+	ConsecutiveFailures uint32 `yaml:"consecutive_failures"`
+	// FailurePercent represents the failure percentage, which is based on CircuitBreakerMinRequests, to determine if the circuit breaker should open.
+	FailurePercent float64 `yaml:"failure_percent"`
+}
+
+func (c CircuitBreakerConfig) validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.ConsecutiveFailures == 0 {
+		return errCircuitBreakerConsecutiveFailuresNotPositive
+	}
+	if c.FailurePercent <= 0 || c.FailurePercent > 1 {
+		return errCircuitBreakerFailurePercentInvalid
+	}
+	return nil
+}
+
+type noopCircuitBreaker struct{}
+
+func (noopCircuitBreaker) Execute(f func() error) error { return f() }
+
+type gobreakerCircuitBreaker struct {
+	*gobreaker.CircuitBreaker
+}
+
+func (cb gobreakerCircuitBreaker) Execute(f func() error) error {
+	_, err := cb.CircuitBreaker.Execute(func() (any, error) {
+		return nil, f()
+	})
+	return err
+}
+
+func newCircuitBreaker(name string, config CircuitBreakerConfig) CircuitBreaker {
+	if !config.Enabled {
+		return noopCircuitBreaker{}
+	}
+	return gobreakerCircuitBreaker{gobreaker.NewCircuitBreaker(gobreaker.Settings{
+		Name:        name,
+		MaxRequests: config.HalfOpenMaxRequests,
+		Interval:    10 * time.Second,
+		Timeout:     config.OpenDuration,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.Requests >= config.MinRequests &&
+				(counts.ConsecutiveFailures >= uint32(config.ConsecutiveFailures) ||
+					float64(counts.TotalFailures)/float64(counts.Requests) >= config.FailurePercent)
+		},
+	})}
 }

--- a/vendor/github.com/thanos-io/thanos/pkg/cacheutil/redis_client.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/cacheutil/redis_client.go
@@ -39,6 +39,8 @@ var (
 		TLSConfig:              TLSConfig{},
 		MaxAsyncConcurrency:    20,
 		MaxAsyncBufferSize:     10000,
+
+		SetAsyncCircuitBreaker: defaultCircuitBreakerConfig,
 	}
 )
 
@@ -118,6 +120,9 @@ type RedisClientConfig struct {
 
 	// MaxAsyncConcurrency specifies the maximum number of SetAsync goroutines.
 	MaxAsyncConcurrency int `yaml:"max_async_concurrency"`
+
+	// SetAsyncCircuitBreaker configures the circuit breaker for SetAsync operations.
+	SetAsyncCircuitBreaker CircuitBreakerConfig `yaml:"set_async_circuit_breaker_config"`
 }
 
 func (c *RedisClientConfig) validate() error {
@@ -131,6 +136,9 @@ func (c *RedisClientConfig) validate() error {
 		}
 	}
 
+	if err := c.SetAsyncCircuitBreaker.validate(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -150,6 +158,8 @@ type RedisClient struct {
 	durationGetMulti prometheus.Observer
 
 	p *AsyncOperationProcessor
+
+	setAsyncCircuitBreaker CircuitBreaker
 }
 
 // NewRedisClient makes a new RedisClient.
@@ -232,7 +242,9 @@ func NewRedisClientWithConfig(logger log.Logger, name string, config RedisClient
 			config.MaxSetMultiConcurrency,
 			gate.Sets,
 		),
+		setAsyncCircuitBreaker: newCircuitBreaker("redis-set-async", config.SetAsyncCircuitBreaker),
 	}
+
 	duration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "thanos_redis_operation_duration_seconds",
 		Help:    "Duration of operations against redis.",
@@ -249,7 +261,10 @@ func NewRedisClientWithConfig(logger log.Logger, name string, config RedisClient
 func (c *RedisClient) SetAsync(key string, value []byte, ttl time.Duration) error {
 	return c.p.EnqueueAsync(func() {
 		start := time.Now()
-		if err := c.client.Do(context.Background(), c.client.B().Set().Key(key).Value(rueidis.BinaryString(value)).ExSeconds(int64(ttl.Seconds())).Build()).Error(); err != nil {
+		err := c.setAsyncCircuitBreaker.Execute(func() error {
+			return c.client.Do(context.Background(), c.client.B().Set().Key(key).Value(rueidis.BinaryString(value)).ExSeconds(int64(ttl.Seconds())).Build()).Error()
+		})
+		if err != nil {
 			level.Warn(c.logger).Log("msg", "failed to set item into redis", "err", err, "key", key, "value_size", len(value))
 			return
 		}

--- a/vendor/github.com/thanos-io/thanos/pkg/pool/pool.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/pool/pool.go
@@ -35,7 +35,7 @@ type BucketedBytes struct {
 	sizes     []int
 	maxTotal  uint64
 	usedTotal uint64
-	mtx       sync.Mutex
+	mtx       sync.RWMutex
 
 	new func(s int) *[]byte
 }
@@ -136,4 +136,11 @@ func (p *BucketedBytes) Put(b *[]byte) {
 	} else {
 		p.usedTotal -= uint64(sz)
 	}
+}
+
+func (p *BucketedBytes) UsedBytes() uint64 {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	return p.usedTotal
 }

--- a/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/store/bucket.go
@@ -14,7 +14,6 @@ import (
 	"math"
 	"os"
 	"path"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -737,7 +736,7 @@ func (s *BucketStore) getBlock(id ulid.ULID) *bucketBlock {
 func (s *BucketStore) addBlock(ctx context.Context, meta *metadata.Meta) (err error) {
 	var dir string
 	if s.dir != "" {
-		dir = filepath.Join(s.dir, meta.ULID.String())
+		dir = path.Join(s.dir, meta.ULID.String())
 	}
 	start := time.Now()
 

--- a/vendor/github.com/thanos-io/thanos/pkg/store/cache/caching_bucket.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/store/cache/caching_bucket.go
@@ -133,7 +133,7 @@ func (cb *CachingBucket) Iter(ctx context.Context, dir string, f func(string) er
 
 	cb.operationRequests.WithLabelValues(objstore.OpIter, cfgName).Inc()
 
-	iterVerb := cachekey.BucketCacheKey{Verb: cachekey.IterVerb, Name: dir}
+	iterVerb := cachekey.BucketCacheKey{Verb: cachekey.IterVerb, Name: dir, ObjectStorageConfigHash: cfg.ConfigHash}
 	opts := objstore.ApplyIterOptions(options...)
 	if opts.Recursive {
 		iterVerb.Verb = cachekey.IterRecursiveVerb

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -937,7 +937,7 @@ github.com/thanos-io/promql-engine/extlabels
 github.com/thanos-io/promql-engine/logicalplan
 github.com/thanos-io/promql-engine/query
 github.com/thanos-io/promql-engine/ringbuffer
-# github.com/thanos-io/thanos v0.34.1-0.20240201134136-94f971bc2b7f
+# github.com/thanos-io/thanos v0.34.2-0.20240226184600-e7cd6c1c60fb
 ## explicit; go 1.21
 github.com/thanos-io/thanos/pkg/block
 github.com/thanos-io/thanos/pkg/block/indexheader


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Updated Thanos version to latest main https://github.com/thanos-io/thanos/commit/e7cd6c1c60fb3287b4ae7cd27092d5695f55bdbd.

Added circuit breaker support to Cortex cache clients using the feature added in Thanos https://github.com/thanos-io/thanos/pull/7010.

This is helpful to prevent overloading external caches using `SET` requests such as memcached.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
