### PR TITLE
Fix GRPC client not honouring call options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [BUGFIX] Query Frontend: queries with negative offset should check whether it is cacheable or not. #5719
 * [BUGFIX] Redis Cache: pass `cache_size` config correctly. #5734
 * [BUGFIX] Distributor: Shuffle-Sharding with IngestionTenantShardSize == 0, default sharding strategy should be used #5189
+* [BUGFIX] Cortex: Fix GRPC stream clients not honoring overrides for call options. #5797
 
 
 ## 1.16.0 2023-11-20

--- a/pkg/util/grpcutil/util.go
+++ b/pkg/util/grpcutil/util.go
@@ -69,7 +69,7 @@ func HTTPHeaderPropagationClientInterceptor(ctx context.Context, method string, 
 func HTTPHeaderPropagationStreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string,
 	streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 	ctx = injectForwardedHeadersIntoMetadata(ctx)
-	return streamer(ctx, desc, cc, method)
+	return streamer(ctx, desc, cc, method, opts...)
 }
 
 // injectForwardedHeadersIntoMetadata implements HTTPHeaderPropagationClientInterceptor and HTTPHeaderPropagationStreamClientInterceptor


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This fixes a dormant bug because of which the streaming GRPC clients are not honoring the overrides for `MaxRecvMsgSize` and `MaxSendMsgSize`.

This issue only surfaces if the stream response size is > 4MB.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
