### PR TITLE
Improve GetRules performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 * [BUGFIX] Distributor: Shuffle-Sharding with IngestionTenantShardSize == 0, default sharding strategy should be used #5189
 * [BUGFIX] Cortex: Fix GRPC stream clients not honoring overrides for call options. #5797
 * [BUGFIX] Ring DDB: Fix lifecycle for ring counting unhealthy pods as healthy. #5838
-
+* [BUGFIX] Improve GetRules performance #5805
 
 ## 1.16.0 2023-11-20
 


### PR DESCRIPTION
**What this PR does**:

Currently the manager's SyncRuleGroups and GetRules methods share the same lock. This means that if SyncRuleGroups becomes slow then GetRules will have to wait a long time to acquire the lock.

SyncRuleGroups can become slow when rule groups are updated with slow running rules because the rule group will wait for currently evaluating rule to finish before it stops

This PR fixes this problem by:

1. Using the `userManagerMtx` for it's intended purpose which is to protect the `userManagers` map
2. Convert `useManagerMtx` to RWMutex so that exclusive lock is acquired only when a new manager is created or clean up occurs at the end of `SyncRuleGroups`. By doing this, the duration of exclusive lock is reduced and the scope is reduced
3. Introduce `syncRuleMtx` to ensure `SyncRuleGroups` is executed sequentially
4. Cache the rule groups before Prometheus `rules/manager.Update` is called. This is because each Prometheus rule manager can still be responsible for large number of rule groups and if many of those rule groups have slow running rules, then ListRules will be slow. The cached rule groups will be removed as soon as update is complete

**Which issue(s) this PR fixes**:
Fixes #5745

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
