### PR TITLE
Consider query select time in max query length check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [ENHANCEMENT] AlertManager: Retrying AlertManager Delete Silence on error #5794
 * [ENHANCEMENT] Ingester: Add new ingester metric `cortex_ingester_max_inflight_query_requests`. #5798
 * [ENHANCEMENT] Query: Added `query_storage_wall_time` to Query Frontend and Ruler query stats log for wall time spent on fetching data from storage. Query evaluation is not included. #5799
+* [ENHANCEMENT] Query: Added additional max query length check at Query Frontend and Ruler. Added `-querier.ignore-max-query-length` flag to disable max query length check at Querier. #5808
 * [BUGFIX] Distributor: Do not use label with empty values for sharding #5717
 * [BUGFIX] Query Frontend: queries with negative offset should check whether it is cacheable or not. #5719
 * [BUGFIX] Redis Cache: pass `cache_size` config correctly. #5734

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -233,6 +233,12 @@ querier:
   # engine.
   # CLI flag: -querier.thanos-engine
   [thanos_engine: <boolean> | default = false]
+
+  # If enabled, ignore max query length check at Querier select method. Users
+  # can choose to ignore it since the validation can be done before Querier
+  # evaluation like at Query Frontend or Ruler.
+  # CLI flag: -querier.ignore-max-query-length
+  [ignore_max_query_length: <boolean> | default = false]
 ```
 
 ### `blocks_storage_config`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3714,6 +3714,12 @@ store_gateway_client:
 # engine.
 # CLI flag: -querier.thanos-engine
 [thanos_engine: <boolean> | default = false]
+
+# If enabled, ignore max query length check at Querier select method. Users can
+# choose to ignore it since the validation can be done before Querier evaluation
+# like at Query Frontend or Ruler.
+# CLI flag: -querier.ignore-max-query-length
+[ignore_max_query_length: <boolean> | default = false]
 ```
 
 ### `query_frontend_config`

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -457,12 +457,13 @@ func (t *Cortex) initQueryFrontendTripperware() (serv services.Service, err erro
 		queryAnalyzer,
 		prometheusCodec,
 		shardedPrometheusCodec,
+		t.Cfg.Querier.LookbackDelta,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	instantQueryMiddlewares, err := instantquery.Middlewares(util_log.Logger, t.Overrides, queryAnalyzer)
+	instantQueryMiddlewares, err := instantquery.Middlewares(util_log.Logger, t.Overrides, queryAnalyzer, t.Cfg.Querier.LookbackDelta)
 	if err != nil {
 		return nil, err
 	}
@@ -548,6 +549,7 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 		return nil, nil
 	}
 
+	t.Cfg.Ruler.LookbackDelta = t.Cfg.Querier.LookbackDelta
 	t.Cfg.Ruler.Ring.ListenPort = t.Cfg.Server.GRPCListenPort
 	metrics := ruler.NewRuleEvalMetrics(t.Cfg.Ruler, prometheus.DefaultRegisterer)
 

--- a/pkg/querier/tripperware/instantquery/instant_query_middlewares.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_middlewares.go
@@ -1,6 +1,8 @@
 package instantquery
 
 import (
+	"time"
+
 	"github.com/go-kit/log"
 	"github.com/thanos-io/thanos/pkg/querysharding"
 
@@ -11,9 +13,11 @@ func Middlewares(
 	log log.Logger,
 	limits tripperware.Limits,
 	queryAnalyzer querysharding.Analyzer,
+	lookbackDelta time.Duration,
 ) ([]tripperware.Middleware, error) {
-	var m []tripperware.Middleware
-
-	m = append(m, tripperware.ShardByMiddleware(log, limits, InstantQueryCodec, queryAnalyzer))
+	m := []tripperware.Middleware{
+		NewLimitsMiddleware(limits, lookbackDelta),
+		tripperware.ShardByMiddleware(log, limits, InstantQueryCodec, queryAnalyzer),
+	}
 	return m, nil
 }

--- a/pkg/querier/tripperware/instantquery/limits.go
+++ b/pkg/querier/tripperware/instantquery/limits.go
@@ -1,12 +1,10 @@
-package queryrange
+package instantquery
 
 import (
 	"context"
 	"net/http"
 	"time"
 
-	"github.com/go-kit/log/level"
-	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/weaveworks/common/httpgrpc"
@@ -46,42 +44,8 @@ func (l limitsMiddleware) Do(ctx context.Context, r tripperware.Request) (trippe
 		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 
-	// Clamp the time range based on the max query lookback.
-
-	if maxQueryLookback := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, l.MaxQueryLookback); maxQueryLookback > 0 {
-		minStartTime := util.TimeToMillis(time.Now().Add(-maxQueryLookback))
-
-		if r.GetEnd() < minStartTime {
-			// The request is fully outside the allowed range, so we can return an
-			// empty response.
-			level.Debug(log).Log(
-				"msg", "skipping the execution of the query because its time range is before the 'max query lookback' setting",
-				"reqStart", util.FormatTimeMillis(r.GetStart()),
-				"redEnd", util.FormatTimeMillis(r.GetEnd()),
-				"maxQueryLookback", maxQueryLookback)
-
-			return NewEmptyPrometheusResponse(), nil
-		}
-
-		if r.GetStart() < minStartTime {
-			// Replace the start time in the request.
-			level.Debug(log).Log(
-				"msg", "the start time of the query has been manipulated because of the 'max query lookback' setting",
-				"original", util.FormatTimeMillis(r.GetStart()),
-				"updated", util.FormatTimeMillis(minStartTime))
-
-			r = r.WithStartEnd(minStartTime, r.GetEnd())
-		}
-	}
-
 	// Enforce the max query length.
-	maxQueryLength := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, l.MaxQueryLength)
-	if maxQueryLength > 0 {
-		queryLen := timestamp.Time(r.GetEnd()).Sub(timestamp.Time(r.GetStart()))
-		if queryLen > maxQueryLength {
-			return nil, httpgrpc.Errorf(http.StatusBadRequest, validation.ErrQueryTooLong, queryLen, maxQueryLength)
-		}
-
+	if maxQueryLength := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, l.MaxQueryLength); maxQueryLength > 0 {
 		expr, err := parser.ParseExpr(r.GetQuery())
 		if err != nil {
 			// Let Querier propagates the parsing error.

--- a/pkg/querier/tripperware/instantquery/limits_test.go
+++ b/pkg/querier/tripperware/instantquery/limits_test.go
@@ -1,0 +1,109 @@
+package instantquery
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/querier/tripperware"
+	"github.com/cortexproject/cortex/pkg/util/validation"
+)
+
+func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
+	t.Parallel()
+	const (
+		thirtyDays = 30 * 24 * time.Hour
+	)
+
+	tests := map[string]struct {
+		maxQueryLength time.Duration
+		query          string
+		expectedErr    string
+	}{
+		"should skip validation if max length is disabled": {
+			maxQueryLength: 0,
+		},
+		"even though failed to parse expression, should return no error since request will pass to next middleware": {
+			query:          `up[`,
+			maxQueryLength: thirtyDays,
+		},
+		"should succeed on a query not exceeding time range": {
+			query:          `up`,
+			maxQueryLength: thirtyDays,
+		},
+		"should succeed on a query not exceeding time range2": {
+			query:          `up[29d]`,
+			maxQueryLength: thirtyDays,
+		},
+		"should succeed on a query not exceeding time range3": {
+			query:          `rate(up[29d]) + rate(test[29d])`,
+			maxQueryLength: thirtyDays,
+		},
+		"should fail on a query exceeding time range": {
+			query:          `rate(up[31d])`,
+			maxQueryLength: thirtyDays,
+			expectedErr:    "the query time range exceeds the limit",
+		},
+		"should fail on a query exceeding time range, work for multiple selects": {
+			query:          `rate(up[20d]) + rate(up[20d] offset 20d)`,
+			maxQueryLength: thirtyDays,
+			expectedErr:    "the query time range exceeds the limit",
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			req := &PrometheusRequest{Query: testData.query}
+
+			limits := &mockLimits{maxQueryLength: testData.maxQueryLength}
+			middleware := NewLimitsMiddleware(limits, 5*time.Minute)
+
+			innerRes := NewEmptyPrometheusInstantQueryResponse()
+			inner := &mockHandler{}
+			inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
+
+			ctx := user.InjectOrgID(context.Background(), "test")
+			outer := middleware.Wrap(inner)
+			res, err := outer.Do(ctx, req)
+
+			if testData.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), testData.expectedErr)
+				assert.Nil(t, res)
+				assert.Len(t, inner.Calls, 0)
+			} else {
+				// We expect the response returned by the inner handler.
+				require.NoError(t, err)
+				assert.Same(t, innerRes, res)
+
+				// The time range of the request passed to the inner handler should have not been manipulated.
+				require.Len(t, inner.Calls, 1)
+			}
+		})
+	}
+}
+
+type mockLimits struct {
+	validation.Overrides
+	maxQueryLength time.Duration
+}
+
+func (m mockLimits) MaxQueryLength(string) time.Duration {
+	return m.maxQueryLength
+}
+
+type mockHandler struct {
+	mock.Mock
+}
+
+func (m *mockHandler) Do(ctx context.Context, req tripperware.Request) (tripperware.Response, error) {
+	args := m.Called(ctx, req)
+	return args.Get(0).(tripperware.Response), args.Error(1)
+}

--- a/pkg/querier/tripperware/queryrange/query_range_middlewares.go
+++ b/pkg/querier/tripperware/queryrange/query_range_middlewares.go
@@ -79,11 +79,12 @@ func Middlewares(
 	queryAnalyzer querysharding.Analyzer,
 	prometheusCodec tripperware.Codec,
 	shardedPrometheusCodec tripperware.Codec,
+	lookbackDelta time.Duration,
 ) ([]tripperware.Middleware, cache.Cache, error) {
 	// Metric used to keep track of each middleware execution duration.
 	metrics := tripperware.NewInstrumentMiddlewareMetrics(registerer)
 
-	queryRangeMiddleware := []tripperware.Middleware{NewLimitsMiddleware(limits)}
+	queryRangeMiddleware := []tripperware.Middleware{NewLimitsMiddleware(limits, lookbackDelta)}
 	if cfg.AlignQueriesWithStep {
 		queryRangeMiddleware = append(queryRangeMiddleware, tripperware.InstrumentMiddleware("step_align", metrics), StepAlignMiddleware)
 	}

--- a/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
@@ -60,6 +60,7 @@ func TestRoundTrip(t *testing.T) {
 		qa,
 		PrometheusCodec,
 		ShardedPrometheusCodec,
+		5*time.Minute,
 	)
 	require.NoError(t, err)
 

--- a/pkg/querier/tripperware/queryrange/split_by_interval_test.go
+++ b/pkg/querier/tripperware/queryrange/split_by_interval_test.go
@@ -309,7 +309,7 @@ func TestSplitByDay(t *testing.T) {
 			roundtripper := tripperware.NewRoundTripper(singleHostRoundTripper{
 				host: u.Host,
 				next: http.DefaultTransport,
-			}, PrometheusCodec, nil, NewLimitsMiddleware(mockLimits{}), SplitByIntervalMiddleware(interval, mockLimits{}, PrometheusCodec, nil))
+			}, PrometheusCodec, nil, NewLimitsMiddleware(mockLimits{}, 5*time.Minute), SplitByIntervalMiddleware(interval, mockLimits{}, PrometheusCodec, nil))
 
 			req, err := http.NewRequest("GET", tc.path, http.NoBody)
 			require.NoError(t, err)

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -136,6 +136,9 @@ type Config struct {
 
 	RingCheckPeriod time.Duration `yaml:"-"`
 
+	// Field will be populated during runtime.
+	LookbackDelta time.Duration `yaml:"-"`
+
 	EnableQueryStats      bool `yaml:"query_stats_enabled"`
 	DisableRuleGroupLabel bool `yaml:"disable_rule_group_label"`
 }

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -87,6 +87,7 @@ type ruleLimits struct {
 	maxRulesPerRuleGroup int
 	maxRuleGroups        int
 	disabledRuleGroups   validation.DisabledRuleGroups
+	maxQueryLength       time.Duration
 }
 
 func (r ruleLimits) EvaluationDelay(_ string) time.Duration {
@@ -108,6 +109,8 @@ func (r ruleLimits) RulerMaxRulesPerRuleGroup(_ string) int {
 func (r ruleLimits) DisabledRuleGroups(userID string) validation.DisabledRuleGroups {
 	return r.disabledRuleGroups
 }
+
+func (r ruleLimits) MaxQueryLength(_ string) time.Duration { return r.maxQueryLength }
 
 func newEmptyQueryable() storage.Queryable {
 	return storage.QueryableFunc(func(mint, maxt int64) (storage.Querier, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Right now, there is a check for max query length in the query frontend query range middleware. It only checks the `start` and `end` parameter of range query API and see if it exceeds a maximum time range.

However, this check doesn't analyze the query string itself. For example, `up[60d]`. The time window `60d` can be very large and exceeds the limit. However, it is not checked at query frontend.

To fix this issue, there is another checkfor max query length at Querier right now, which happens per `Select` only and it considers the time range of the query itself. For example, `up[60d]` can be rejected at Querier if the limit is configured as 30d.

However, this solution isn't perfect because a query can have multiple selects. `rate(up[25d]) + rate(up[25d] offset 25d) + rate(up[25]  offset 50d)` actually queries 75 days of data but each select only queries 25 day time range so it will be allowed.

To address this issue in a better, additional check logic is added in Query Frontend to analyze the whole query and see the max time range it queries. With this check, the check at Querier can actually be turned off.

Overall changes:
1. Additional max query length check at Query Frontend Query Range Middleware
2. Added the same logic to Query Frontend Instant Query Middleware. Previously there is no max query length check for instant query
3. Added the same logic to Ruler. Previously Ruler relies on max query length at Querier level
4. Added a new flag `querier.ignore-max-query-length` to disable checking max query length at Querier.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
