### PR TITLE
Mark mem ballast flag as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGE] Ingester: Disable uploading compacted blocks and overlapping compaction in ingester. #5735
 * [CHANGE] Distributor: Count the number of rate-limited samples in `distributor_samples_in_total`. #5714
 * [CHANGE] Ruler: Remove `cortex_ruler_write_requests_total`, `cortex_ruler_write_requests_failed_total`, `cortex_ruler_queries_total`, `cortex_ruler_queries_failed_total`, and `cortex_ruler_query_seconds_total` metrics for the tenant when the ruler deletes the manager for the tenant. #5772
+* [CHANGE] Main: Mark `mem-ballast-size-bytes` flag as deprecated. #5816
 * [CHANGE] Querier: Mark `-querier.ingester-streaming` flag as deprecated. Now query ingester streaming is always enabled. #5817
 * [FEATURE] Ingester: Add per-tenant new metric `cortex_ingester_tsdb_data_replay_duration_seconds`. #5477
 * [FEATURE] Query Frontend/Scheduler: Add query priority support. #5605

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -101,7 +101,7 @@ func main() {
 	flag.BoolVar(&printModules, "modules", false, "List available values that can be used as target.")
 
 	//lint:ignore faillint Need to pass the global logger like this for warning on deprecated methods
-	flagext.DeprecatedFlag(flag.CommandLine, "mem-ballast-size-bytes", "Deprecated: Setting this flag will not take any effect. Size of memory ballast to allocate", util_log.Logger)
+	flagext.DeprecatedFlag(flag.CommandLine, "mem-ballast-size-bytes", "Deprecated: Setting this flag will not take any effect, for similar functionality use GOMEMLIMIT. Size of memory ballast to allocate", util_log.Logger)
 
 	usage := flag.CommandLine.Usage
 	flag.CommandLine.Usage = func() { /* don't do anything by default, we will print usage ourselves, but only when requested. */ }

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -96,11 +96,13 @@ func main() {
 	_ = flag.CommandLine.Bool(configExpandENV, false, "Expands ${var} or $var in config according to the values of the environment variables.")
 
 	flag.IntVar(&eventSampleRate, "event.sample-rate", 0, "How often to sample observability events (0 = never).")
-	flag.IntVar(&ballastBytes, "mem-ballast-size-bytes", 0, "Size of memory ballast to allocate.")
 	flag.IntVar(&mutexProfileFraction, "debug.mutex-profile-fraction", 0, "Fraction of mutex contention events that are reported in the mutex profile. On average 1/rate events are reported. 0 to disable.")
 	flag.IntVar(&blockProfileRate, "debug.block-profile-rate", 0, "Fraction of goroutine blocking events that are reported in the blocking profile. 1 to include every blocking event in the profile, 0 to disable.")
 	flag.BoolVar(&printVersion, "version", false, "Print Cortex version and exit.")
 	flag.BoolVar(&printModules, "modules", false, "List available values that can be used as target.")
+
+	//lint:ignore faillint Need to pass the global logger like this for warning on deprecated methods
+	flagext.DeprecatedFlag(flag.CommandLine, "mem-ballast-size-bytes", "Deprecated: Setting this flag will not take any effect. Size of memory ballast to allocate", util_log.Logger)
 
 	usage := flag.CommandLine.Usage
 	flag.CommandLine.Usage = func() { /* don't do anything by default, we will print usage ourselves, but only when requested. */ }
@@ -151,10 +153,6 @@ func main() {
 	}
 
 	util_log.InitLogger(&cfg.Server)
-
-	// Allocate a block of memory to alter GC behaviour. See https://github.com/golang/go/issues/23044
-	ballast := make([]byte, ballastBytes)
-
 	util.InitEvents(eventSampleRate)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
@@ -203,7 +201,6 @@ func main() {
 	err = t.Run()
 	cancelFn()
 
-	runtime.KeepAlive(ballast)
 	util_log.CheckFatal("running cortex", err)
 }
 

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -61,7 +61,6 @@ func main() {
 	var (
 		cfg                  cortex.Config
 		eventSampleRate      int
-		ballastBytes         int
 		mutexProfileFraction int
 		blockProfileRate     int
 		printVersion         bool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Deprecate `mem-ballast-size-bytes` flag.


**Which issue(s) this PR fixes**:
Fixes #5283

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
