### PR TITLE
Add store gateway lazy expanded posting fuzz test to verify correctness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go v1.50.25
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
 	github.com/cespare/xxhash v1.1.0
-	github.com/cortexproject/promqlsmith v0.0.0-20240115062247-9ed0dfba956d
+	github.com/cortexproject/promqlsmith v0.0.0-20240326071418-c2a9ca1e89f5
 	github.com/dustin/go-humanize v1.0.1
 	github.com/efficientgo/core v1.0.0-rc.2
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb

--- a/go.sum
+++ b/go.sum
@@ -690,8 +690,8 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/coreos/go-systemd/v22 v22.4.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cortexproject/promqlsmith v0.0.0-20240115062247-9ed0dfba956d h1:VSA/aQtOyhIuxnL3YsI7/hdYhf1rWdmiJOcVPTO4dVg=
-github.com/cortexproject/promqlsmith v0.0.0-20240115062247-9ed0dfba956d/go.mod h1:by/B++NlNa8Hp+d2054cy3YR4ijhPNGnuWjUWOUppms=
+github.com/cortexproject/promqlsmith v0.0.0-20240326071418-c2a9ca1e89f5 h1:UfuB6no2X1BcKxICY63lzgY+XaPMQ/Wv4woP3p0L+mg=
+github.com/cortexproject/promqlsmith v0.0.0-20240326071418-c2a9ca1e89f5/go.mod h1:fcysbw4fOsOipXKeXPXWSh7tXrUQSUr5V4duojv0oCM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -11,9 +11,19 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/runutil"
+
+	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
 )
 
 func RunCommandAndGetOutput(name string, args ...string) ([]byte, error) {
@@ -201,4 +211,134 @@ func GetTempDirectory() (string, error) {
 	}
 
 	return absDir, nil
+}
+
+func RandRange(rnd *rand.Rand, min, max int64) int64 {
+	return rnd.Int63n(max-min) + min
+}
+
+func CreateBlock(
+	ctx context.Context,
+	rnd *rand.Rand,
+	dir string,
+	series []labels.Labels,
+	numSamples int,
+	mint, maxt int64,
+	scrapeInterval int64,
+	seriesSize int64,
+) (id ulid.ULID, err error) {
+	headOpts := tsdb.DefaultHeadOptions()
+	headOpts.ChunkDirRoot = filepath.Join(dir, "chunks")
+	headOpts.ChunkRange = 10000000000
+	h, err := tsdb.NewHead(nil, nil, nil, nil, headOpts, nil)
+	if err != nil {
+		return id, errors.Wrap(err, "create head block")
+	}
+	defer func() {
+		runutil.CloseWithErrCapture(&err, h, "TSDB Head")
+		if e := os.RemoveAll(headOpts.ChunkDirRoot); e != nil {
+			err = errors.Wrap(e, "delete chunks dir")
+		}
+	}()
+
+	app := h.Appender(ctx)
+	for i := 0; i < len(series); i++ {
+
+		var ref storage.SeriesRef
+		start := RandRange(rnd, mint, maxt)
+		for j := 0; j < numSamples; j++ {
+			if ref == 0 {
+				ref, err = app.Append(0, series[i], start, float64(i+j))
+			} else {
+				ref, err = app.Append(ref, series[i], start, float64(i+j))
+			}
+			if err != nil {
+				if rerr := app.Rollback(); rerr != nil {
+					err = errors.Wrapf(err, "rollback failed: %v", rerr)
+				}
+				return id, errors.Wrap(err, "add sample")
+			}
+			start += scrapeInterval
+			if start > maxt {
+				break
+			}
+		}
+	}
+	if err := app.Commit(); err != nil {
+		return id, errors.Wrap(err, "commit")
+	}
+
+	c, err := tsdb.NewLeveledCompactor(ctx, nil, log.NewNopLogger(), []int64{maxt - mint}, nil, nil)
+	if err != nil {
+		return id, errors.Wrap(err, "create compactor")
+	}
+
+	id, err = c.Write(dir, h, mint, maxt, nil)
+	if err != nil {
+		return id, errors.Wrap(err, "write block")
+	}
+
+	if id.Compare(ulid.ULID{}) == 0 {
+		return id, errors.Errorf("nothing to write, asked for %d samples", numSamples)
+	}
+
+	blockDir := filepath.Join(dir, id.String())
+	logger := log.NewNopLogger()
+
+	if _, err = metadata.InjectThanos(logger, blockDir, metadata.Thanos{
+		Labels: map[string]string{
+			cortex_tsdb.IngesterIDExternalLabel: "ingester-0",
+		},
+		Downsample: metadata.ThanosDownsample{Resolution: 0},
+		Source:     metadata.TestSource,
+		IndexStats: metadata.IndexStats{SeriesMaxSize: seriesSize},
+	}, nil); err != nil {
+		return id, errors.Wrap(err, "finalize block")
+	}
+
+	return id, nil
+}
+
+func gatherMaxSeriesSize(ctx context.Context, fn string) (int64, error) {
+	r, err := index.NewFileReader(fn)
+	if err != nil {
+		return 0, errors.Wrap(err, "open index file")
+	}
+	defer runutil.CloseWithErrCapture(&err, r, "gather index issue file reader")
+
+	key, value := index.AllPostingsKey()
+	p, err := r.Postings(ctx, key, value)
+	if err != nil {
+		return 0, errors.Wrap(err, "get all postings")
+	}
+
+	// As of version two all series entries are 16 byte padded. All references
+	// we get have to account for that to get the correct offset.
+	offsetMultiplier := 1
+	version := r.Version()
+	if version >= 2 {
+		offsetMultiplier = 16
+	}
+
+	// Per series.
+	var (
+		prevId        storage.SeriesRef
+		maxSeriesSize int64
+	)
+	for p.Next() {
+		id := p.At()
+		if prevId != 0 {
+			// Approximate size.
+			seriesSize := int64(id-prevId) * int64(offsetMultiplier)
+			if seriesSize > maxSeriesSize {
+				maxSeriesSize = seriesSize
+			}
+		}
+		prevId = id
+	}
+	if p.Err() != nil {
+		return 0, errors.Wrap(err, "walk postings")
+	}
+
+	return maxSeriesSize, nil
 }

--- a/integration/e2e/util.go
+++ b/integration/e2e/util.go
@@ -246,11 +246,7 @@ func CreateBlock(
 		var ref storage.SeriesRef
 		start := RandRange(rnd, mint, maxt)
 		for j := 0; j < numSamples; j++ {
-			if ref == 0 {
-				ref, err = app.Append(0, series[i], start, float64(i+j))
-			} else {
-				ref, err = app.Append(ref, series[i], start, float64(i+j))
-			}
+			ref, err = app.Append(ref, series[i], start, float64(i+j))
 			if err != nil {
 				if rerr := app.Rollback(); rerr != nil {
 					err = errors.Wrapf(err, "rollback failed: %v", rerr)

--- a/integration/e2ecortex/storage.go
+++ b/integration/e2ecortex/storage.go
@@ -89,3 +89,7 @@ func (c *S3Client) Delete(prefix string) error {
 		return c.writer.Delete(context.Background(), entry)
 	})
 }
+
+func (c *S3Client) GetBucket() objstore.Bucket {
+	return c.writer
+}

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -388,13 +388,7 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzz(t *testing.T) {
 		labelSet1 []model.LabelSet
 		labelSet2 []model.LabelSet
 	)
-	for retries.Ongoing() {
-		labelSet1, err = c1.Series([]string{`{job="test"}`}, start, end)
-		require.NoError(t, err)
-
-		retries.Wait()
-	}
-	retries.Reset()
+	// Wait until both Store Gateways load the block.
 	for retries.Ongoing() {
 		labelSet1, err = c1.Series([]string{`{job="test"}`}, start, end)
 		require.NoError(t, err)
@@ -422,7 +416,6 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzz(t *testing.T) {
 		res1, newRes1, res2, newRes2 []model.LabelSet
 	}
 
-	now = time.Now()
 	cases := make([]*testCase, 0, 1000)
 	for i := 0; i < 1000; i++ {
 		matchers := ps.WalkSelectors()

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -4,25 +4,34 @@
 package integration
 
 import (
+	"context"
 	"math/rand"
 	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/cortexproject/promqlsmith"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/block"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
 
 	"github.com/cortexproject/cortex/integration/e2e"
 	e2edb "github.com/cortexproject/cortex/integration/e2e/db"
 	"github.com/cortexproject/cortex/integration/e2ecortex"
+	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
+	"github.com/cortexproject/cortex/pkg/util/backoff"
+	"github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/cortexproject/promqlsmith"
 )
 
 func TestVerticalShardingFuzz(t *testing.T) {
@@ -45,7 +54,6 @@ func TestVerticalShardingFuzz(t *testing.T) {
 		"-blocks-storage.tsdb.retention-period":             "2h",
 		"-blocks-storage.bucket-store.index-cache.backend":  tsdb.IndexCacheBackendInMemory,
 		"-blocks-storage.bucket-store.bucket-index.enabled": "true",
-		"-querier.ingester-streaming":                       "true",
 		"-querier.query-store-for-labels-enabled":           "true",
 		// Ingester.
 		"-ring.store":      "consul",
@@ -280,4 +288,196 @@ var comparer = cmp.Comparer(func(x, y model.Value) bool {
 		return compareFloats(float64(sx.Value), float64(sy.Value))
 	}
 	return false
+})
+
+func TestStoreGatewayLazyExpandedPostingsSeriesFuzz(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Start dependencies.
+	consul1 := e2edb.NewConsulWithName("consul1")
+	consul2 := e2edb.NewConsulWithName("consul2")
+	require.NoError(t, s.StartAndWaitReady(consul1, consul2))
+
+	flags := mergeFlags(BlocksStorageFlags(), map[string]string{
+		"-blocks-storage.bucket-store.index-cache.backend": tsdb.IndexCacheBackendInMemory,
+		"-querier.query-store-for-labels-enabled":          "true",
+		"-ring.store":                                "consul",
+		"-consul.hostname":                           consul1.NetworkHTTPEndpoint(),
+		"-store-gateway.sharding-enabled":            "false",
+		"-blocks-storage.bucket-store.sync-interval": "1s",
+	})
+	// Enable lazy expanded postings.
+	flags2 := mergeFlags(flags, map[string]string{
+		"-blocks-storage.bucket-store.lazy-expanded-postings-enabled": "true",
+	})
+
+	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+	require.NoError(t, s.StartAndWaitReady(minio))
+
+	// Start Cortex replicas.
+	ingester1 := e2ecortex.NewIngester("ingester-1", e2ecortex.RingStoreConsul, consul1.NetworkHTTPEndpoint(), flags, "")
+	ingester2 := e2ecortex.NewIngester("ingester-2", e2ecortex.RingStoreConsul, consul2.NetworkHTTPEndpoint(), flags2, "")
+	storeGateway1 := e2ecortex.NewStoreGateway("store-gateway-1", e2ecortex.RingStoreConsul, consul1.NetworkHTTPEndpoint(), flags, "")
+	storeGateway2 := e2ecortex.NewStoreGateway("store-gateway-2", e2ecortex.RingStoreConsul, consul2.NetworkHTTPEndpoint(), flags2, "")
+	require.NoError(t, s.StartAndWaitReady(ingester1, ingester2, storeGateway1, storeGateway2))
+
+	querier1 := e2ecortex.NewQuerier("querier-1", e2ecortex.RingStoreConsul, consul1.NetworkHTTPEndpoint(), mergeFlags(flags, map[string]string{
+		"-querier.store-gateway-addresses": strings.Join([]string{storeGateway1.NetworkGRPCEndpoint()}, ","),
+	}), "")
+	querier2 := e2ecortex.NewQuerier("querier-2", e2ecortex.RingStoreConsul, consul2.NetworkHTTPEndpoint(), mergeFlags(flags2, map[string]string{
+		"-querier.store-gateway-addresses": strings.Join([]string{storeGateway2.NetworkGRPCEndpoint()}, ","),
+	}), "")
+	require.NoError(t, s.StartAndWaitReady(querier1, querier2))
+
+	// Wait until Cortex replicas have updated the ring state.
+	require.NoError(t, querier1.WaitSumMetrics(e2e.Equals(float64(512)), "cortex_ring_tokens_total"))
+	require.NoError(t, querier2.WaitSumMetrics(e2e.Equals(float64(512)), "cortex_ring_tokens_total"))
+
+	now := time.Now()
+	// Push some series to Cortex.
+	start := now.Add(-time.Minute * 20)
+	startMs := start.UnixMilli()
+	end := now.Add(-time.Minute * 10)
+	endMs := end.UnixMilli()
+	numSeries := 1000
+	numSamples := 50
+	lbls := make([]labels.Labels, 0, numSeries)
+	scrapeInterval := (10 * time.Second).Milliseconds()
+	metricName := "http_requests_total"
+	statusCodes := []string{"200", "400", "404", "500", "502"}
+	for i := 0; i < numSeries; i++ {
+		lbl := labels.Labels{
+			{Name: labels.MetricName, Value: metricName},
+			{Name: "job", Value: "test"},
+			{Name: "series", Value: strconv.Itoa(i % 200)},
+			{Name: "status_code", Value: statusCodes[i%5]},
+		}
+		lbls = append(lbls, lbl)
+	}
+	ctx := context.Background()
+	rnd := rand.New(rand.NewSource(time.Now().Unix()))
+
+	dir := t.TempDir()
+	storage, err := e2ecortex.NewS3ClientForMinio(minio, flags["-blocks-storage.s3.bucket-name"])
+	require.NoError(t, err)
+	bkt := bucket.NewUserBucketClient("user-1", storage.GetBucket(), nil)
+	id, err := e2e.CreateBlock(ctx, rnd, dir, lbls, numSamples, start.UnixMilli(), end.UnixMilli(), scrapeInterval, 10)
+	require.NoError(t, err)
+	err = block.Upload(ctx, log.Logger, bkt, filepath.Join(dir, id.String()), metadata.NoneFunc)
+	require.NoError(t, err)
+
+	// Wait for store to sync blocks.
+	require.NoError(t, storeGateway1.WaitSumMetricsWithOptions(e2e.Equals(float64(1)), []string{"cortex_blocks_meta_synced"}, e2e.WaitMissingMetrics))
+	require.NoError(t, storeGateway2.WaitSumMetricsWithOptions(e2e.Equals(float64(1)), []string{"cortex_blocks_meta_synced"}, e2e.WaitMissingMetrics))
+	require.NoError(t, storeGateway1.WaitSumMetricsWithOptions(e2e.Equals(float64(1)), []string{"cortex_bucket_store_blocks_loaded"}, e2e.WaitMissingMetrics))
+	require.NoError(t, storeGateway2.WaitSumMetricsWithOptions(e2e.Equals(float64(1)), []string{"cortex_bucket_store_blocks_loaded"}, e2e.WaitMissingMetrics))
+
+	c1, err := e2ecortex.NewClient("", querier1.HTTPEndpoint(), "", "", "user-1")
+	require.NoError(t, err)
+	c2, err := e2ecortex.NewClient("", querier2.HTTPEndpoint(), "", "", "user-1")
+	require.NoError(t, err)
+	retries := backoff.New(ctx, backoff.Config{
+		MinBackoff: 5 * time.Second,
+		MaxBackoff: 10 * time.Second,
+		MaxRetries: 5,
+	})
+
+	var (
+		labelSet1 []model.LabelSet
+		labelSet2 []model.LabelSet
+	)
+	for retries.Ongoing() {
+		labelSet1, err = c1.Series([]string{`{job="test"}`}, start, end)
+		require.NoError(t, err)
+
+		retries.Wait()
+	}
+	retries.Reset()
+	for retries.Ongoing() {
+		labelSet1, err = c1.Series([]string{`{job="test"}`}, start, end)
+		require.NoError(t, err)
+		labelSet2, err = c2.Series([]string{`{job="test"}`}, start, end)
+		require.NoError(t, err)
+
+		if cmp.Equal(labelSet1, labelSet2, labelSetsComparer) {
+			break
+		}
+
+		retries.Wait()
+	}
+
+	opts := []promqlsmith.Option{
+		promqlsmith.WithEnforceLabelMatchers([]*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, metricName),
+			labels.MustNewMatcher(labels.MatchEqual, "job", "test"),
+		}),
+	}
+	ps := promqlsmith.New(rnd, lbls, opts...)
+
+	type testCase struct {
+		matchers                     string
+		start, end                   int64
+		res1, newRes1, res2, newRes2 []model.LabelSet
+	}
+
+	now = time.Now()
+	cases := make([]*testCase, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		matchers := ps.WalkSelectors()
+		matcherStrings := storepb.PromMatchersToString(matchers...)
+		minT := e2e.RandRange(rnd, startMs, endMs)
+		maxT := e2e.RandRange(rnd, minT+1, endMs)
+
+		res1, err := c1.Series([]string{matcherStrings}, time.UnixMilli(minT), time.UnixMilli(maxT))
+		require.NoError(t, err)
+		res2, err := c2.Series([]string{matcherStrings}, time.UnixMilli(minT), time.UnixMilli(maxT))
+		require.NoError(t, err)
+
+		// Try again and let requests hit cache.
+		newRes1, err := c1.Series([]string{matcherStrings}, time.UnixMilli(minT), time.UnixMilli(maxT))
+		require.NoError(t, err)
+		newRes2, err := c2.Series([]string{matcherStrings}, time.UnixMilli(minT), time.UnixMilli(maxT))
+		require.NoError(t, err)
+
+		cases = append(cases, &testCase{
+			matchers: matcherStrings,
+			start:    minT,
+			end:      maxT,
+			res1:     res1,
+			newRes1:  newRes1,
+			res2:     res2,
+			newRes2:  newRes2,
+		})
+	}
+
+	failures := 0
+	for i, tc := range cases {
+		if !cmp.Equal(tc.res1, tc.res2, labelSetsComparer) {
+			t.Logf("case %d results mismatch.\n%s\nres1 len: %d data: %s\nres2 len: %d data: %s\n", i, tc.matchers, len(tc.res1), tc.res1, len(tc.res2), tc.res2)
+			failures++
+		} else if !cmp.Equal(tc.res1, tc.newRes1, labelSetsComparer) {
+			t.Logf("case %d old and new res1 mismatch.\n%s\nres1 len: %d data: %s\nnew_res1 len: %d data: %s\n", i, tc.matchers, len(tc.res1), tc.res1, len(tc.newRes1), tc.newRes1)
+			failures++
+		} else if !cmp.Equal(tc.res2, tc.newRes2, labelSetsComparer) {
+			t.Logf("case %d old and new res2 mismatch.\n%s\nres2 len: %d data: %s\nnew_res2 len: %d data: %s\n", i, tc.matchers, len(tc.res2), tc.res2, len(tc.newRes2), tc.newRes2)
+			failures++
+		}
+	}
+	if failures > 0 {
+		require.Failf(t, "finished store gateway lazy expanded posting fuzzing tests", "%d test cases failed", failures)
+	}
+}
+
+var labelSetsComparer = cmp.Comparer(func(x, y []model.LabelSet) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	for i := 0; i < len(x); i++ {
+		if !x[i].Equal(y[i]) {
+			return false
+		}
+	}
+	return true
 })

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cortexproject/promqlsmith"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prometheus/common/model"
@@ -31,7 +32,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util/backoff"
 	"github.com/cortexproject/cortex/pkg/util/log"
-	"github.com/cortexproject/promqlsmith"
 )
 
 func TestVerticalShardingFuzz(t *testing.T) {

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -455,7 +455,7 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzz(t *testing.T) {
 		}
 	}
 	if failures > 0 {
-		t.Logf("finished store gateway lazy expanded posting fuzzing tests", "%d test cases failed", failures)
+		t.Logf("finished store gateway lazy expanded posting fuzzing tests, %d test cases failed", failures)
 		// TODO: switch to Fail after we fix the bug in upstream Thanos.
 		//require.Failf(t, "finished store gateway lazy expanded posting fuzzing tests", "%d test cases failed", failures)
 	}

--- a/vendor/github.com/cortexproject/promqlsmith/opts.go
+++ b/vendor/github.com/cortexproject/promqlsmith/opts.go
@@ -3,6 +3,7 @@ package promqlsmith
 import (
 	"time"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"golang.org/x/exp/slices"
 )
@@ -81,6 +82,8 @@ type options struct {
 	enableAtModifier       bool
 	enableVectorMatching   bool
 	atModifierMaxTimestamp int64
+
+	enforceLabelMatchers []*labels.Matcher
 }
 
 func (o *options) applyDefaults() {
@@ -161,5 +164,11 @@ func WithEnabledFunctions(enabledFunctions []*parser.Function) Option {
 func WithEnabledExprs(enabledExprs []ExprType) Option {
 	return optionFunc(func(o *options) {
 		o.enabledExprs = enabledExprs
+	})
+}
+
+func WithEnforceLabelMatchers(matchers []*labels.Matcher) Option {
+	return optionFunc(func(o *options) {
+		o.enforceLabelMatchers = matchers
 	})
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -288,7 +288,7 @@ github.com/coreos/go-semver/semver
 ## explicit; go 1.12
 github.com/coreos/go-systemd/v22/activation
 github.com/coreos/go-systemd/v22/journal
-# github.com/cortexproject/promqlsmith v0.0.0-20240115062247-9ed0dfba956d
+# github.com/cortexproject/promqlsmith v0.0.0-20240326071418-c2a9ca1e89f5
 ## explicit; go 1.20
 github.com/cortexproject/promqlsmith
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Added an integration test which utilizes `promqlsmith` as a random query generator to generate random matchers.

The test case will run 2 sets of queriers and store gateways. One with lazy expanded posting enabled and one isn't.
Test case creates a block with predefined series and upload the block to minio used in the integration test.

Then run GetSeries API 1000 times with randomly generated matchers and compare whether the two results are the same or not.

I plan to create another test case in another pr to compare Prometheus and Store Gateway with lazy expanded postings enabled.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
