### PR TITLE
add context cancellation checks on merging GetLabel slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [ENHANCEMENT] Query: Added additional max query length check at Query Frontend and Ruler. Added `-querier.ignore-max-query-length` flag to disable max query length check at Querier. #5808
 * [ENHANCEMENT] Querier: Add context error check when converting Metrics to SeriesSet for GetSeries on distributorQuerier. #5827
 * [ENHANCEMENT] Ruler: Improve GetRules response time by refactoring mutexes and introducing a temporary rules cache in `ruler/manager.go`. #5805
+* [ENHANCEMENT] Querier: Add context error check when merging slices from ingesters for GetLabel operations. #5837
 * [BUGFIX] Distributor: Do not use label with empty values for sharding #5717
 * [BUGFIX] Query Frontend: queries with negative offset should check whether it is cacheable or not. #5719
 * [BUGFIX] Redis Cache: pass `cache_size` config correctly. #5734

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -973,7 +973,10 @@ func (d *Distributor) LabelValuesForLabelNameCommon(ctx context.Context, from, t
 	for i, resp := range resps {
 		values[i] = resp.([]string)
 	}
-	r := util.MergeSlicesParallel(mergeSlicesParallelism, values...)
+	r, err := util.MergeSlicesParallel(ctx, mergeSlicesParallelism, values...)
+	if err != nil {
+		return nil, err
+	}
 	span.SetTag("result_length", len(r))
 	return r, nil
 }
@@ -1043,7 +1046,10 @@ func (d *Distributor) LabelNamesCommon(ctx context.Context, from, to model.Time,
 	for i, resp := range resps {
 		values[i] = resp.([]string)
 	}
-	r := util.MergeSlicesParallel(mergeSlicesParallelism, values...)
+	r, err := util.MergeSlicesParallel(ctx, mergeSlicesParallelism, values...)
+	if err != nil {
+		return nil, err
+	}
 	span.SetTag("result_length", len(r))
 
 	return r, nil

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -96,12 +97,14 @@ func BenchmarkMergeSlicesParallel(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
 				var r []string
+				var err error
 				for i := 0; i < b.N; i++ {
 					if p == usingMap {
 						r = sortUsingMap(input...)
 						require.NotEmpty(b, r)
 					} else {
-						r = MergeSlicesParallel(int(p), input...)
+						r, err = MergeSlicesParallel(context.Background(), int(p), input...)
+						require.NoError(b, err)
 						require.NotEmpty(b, r)
 					}
 				}


### PR DESCRIPTION

**What this PR does**:
Add context error check while merging slices for GetLabel operations

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
