### PR TITLE
Update cache on CAS for DDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [BUGFIX] Redis Cache: pass `cache_size` config correctly. #5734
 * [BUGFIX] Distributor: Shuffle-Sharding with IngestionTenantShardSize == 0, default sharding strategy should be used #5189
 * [BUGFIX] Cortex: Fix GRPC stream clients not honoring overrides for call options. #5797
+* [BUGFIX] Ring DDB: Fix lifecycle for ring counting unhealthy pods as healthy. #5838
 
 
 ## 1.16.0 2023-11-20

--- a/pkg/ring/kv/dynamodb/client.go
+++ b/pkg/ring/kv/dynamodb/client.go
@@ -189,7 +189,12 @@ func (c *Client) CAS(ctx context.Context, key string, f func(in interface{}) (ou
 		}
 
 		if len(putRequests) > 0 || len(deleteRequests) > 0 {
-			return c.kv.Batch(ctx, putRequests, deleteRequests)
+			err = c.kv.Batch(ctx, putRequests, deleteRequests)
+			if err != nil {
+				return err
+			}
+			c.updateStaleData(key, r, time.Now().UTC())
+			return nil
 		}
 
 		if len(putRequests) == 0 && len(deleteRequests) == 0 {

--- a/pkg/ring/kv/dynamodb/client_test.go
+++ b/pkg/ring/kv/dynamodb/client_test.go
@@ -228,6 +228,40 @@ func Test_WatchKey_UpdateStale(t *testing.T) {
 	})
 }
 
+func Test_CAS_UpdateStale(t *testing.T) {
+	ddbMock := NewDynamodbClientMock()
+	codecMock := &CodecMock{}
+	descMock := &DescMock{}
+	descMockResult := &DescMock{id: "result"}
+	startTime := time.Now().UTC().Add(-time.Millisecond)
+
+	c := NewClientMock(ddbMock, codecMock, TestLogger{}, prometheus.NewPedanticRegistry(), defaultPullTime, defaultBackoff)
+	expectedUpdatedKeys := []string{"t1", "t2"}
+	expectedUpdated := map[string][]byte{
+		expectedUpdatedKeys[0]: []byte(expectedUpdatedKeys[0]),
+		expectedUpdatedKeys[1]: []byte(expectedUpdatedKeys[1]),
+	}
+	expectedBatch := map[dynamodbKey][]byte{
+		{primaryKey: key, sortKey: expectedUpdatedKeys[0]}: []byte(expectedUpdatedKeys[0]),
+		{primaryKey: key, sortKey: expectedUpdatedKeys[1]}: []byte(expectedUpdatedKeys[1]),
+	}
+
+	ddbMock.On("Query").Return(map[string][]byte{}, nil).Once()
+	codecMock.On("DecodeMultiKey").Return(descMock, nil).Once()
+	descMock.On("Clone").Return(descMock).Once()
+	descMock.On("FindDifference", descMockResult).Return(descMockResult, []string{}, nil).Once()
+	codecMock.On("EncodeMultiKey").Return(expectedUpdated, nil).Once()
+	ddbMock.On("Batch", context.TODO(), expectedBatch, []dynamodbKey{}).Once()
+
+	err := c.CAS(context.TODO(), key, func(in interface{}) (out interface{}, retry bool, err error) {
+		return descMockResult, true, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, descMockResult, c.staleData[key].data)
+	require.True(t, startTime.Before(c.staleData[key].timestamp))
+}
+
 func Test_WatchPrefix(t *testing.T) {
 	ddbMock := NewDynamodbClientMock()
 	codecMock := &CodecMock{}
@@ -365,6 +399,7 @@ func (m *CodecMock) DecodeMultiKey(map[string][]byte) (interface{}, error) {
 }
 
 type DescMock struct {
+	id string
 	mock.Mock
 }
 

--- a/pkg/ring/kv/dynamodb/client_test.go
+++ b/pkg/ring/kv/dynamodb/client_test.go
@@ -232,7 +232,7 @@ func Test_CAS_UpdateStale(t *testing.T) {
 	ddbMock := NewDynamodbClientMock()
 	codecMock := &CodecMock{}
 	descMock := &DescMock{}
-	descMockResult := &DescMock{id: "result"}
+	descMockResult := &DescMock{}
 	startTime := time.Now().UTC().Add(-time.Millisecond)
 
 	c := NewClientMock(ddbMock, codecMock, TestLogger{}, prometheus.NewPedanticRegistry(), defaultPullTime, defaultBackoff)
@@ -399,7 +399,6 @@ func (m *CodecMock) DecodeMultiKey(map[string][]byte) (interface{}, error) {
 }
 
 type DescMock struct {
-	id string
 	mock.Mock
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
We are now also updating the staleData on CAS operation.
The CAS operation is mostly used via lifecycle and did not had any data before. This change start to also have stale data on lifecycle. This is mainly important because the ring of a lifecycle is used by distributor to check local limits.

**Which issue(s) this PR fixes**:
When using DDB and having unhealthy distributors on the ring, the healthInstancesCount on the ring was calculated wrong because the staleData was not set and by that the timestamp from the last update was empty making the heartbeat of pods be always healthy. This introduce stale data to lifecycle which is used to check for local limits.

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
