### PR TITLE
Fix rand int63n panic in query fuzz test

### DIFF
--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -421,7 +421,7 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzz(t *testing.T) {
 		matchers := ps.WalkSelectors()
 		matcherStrings := storepb.PromMatchersToString(matchers...)
 		minT := e2e.RandRange(rnd, startMs, endMs)
-		maxT := e2e.RandRange(rnd, minT+1, endMs)
+		maxT := e2e.RandRange(rnd, minT, endMs)
 
 		res1, err := c1.Series([]string{matcherStrings}, time.UnixMilli(minT), time.UnixMilli(maxT))
 		require.NoError(t, err)
@@ -430,7 +430,7 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzz(t *testing.T) {
 
 		// Try again with a different timestamp and let requests hit posting cache.
 		minT = e2e.RandRange(rnd, startMs, endMs)
-		maxT = e2e.RandRange(rnd, minT+1, endMs)
+		maxT = e2e.RandRange(rnd, minT, endMs)
 		newRes1, err := c1.Series([]string{matcherStrings}, time.UnixMilli(minT), time.UnixMilli(maxT))
 		require.NoError(t, err)
 		newRes2, err := c2.Series([]string{matcherStrings}, time.UnixMilli(minT), time.UnixMilli(maxT))
@@ -586,7 +586,7 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzzWithPrometheus(t *testing.T) 
 		matchers := ps.WalkSelectors()
 		matcherStrings := storepb.PromMatchersToString(matchers...)
 		minT := e2e.RandRange(rnd, startMs, endMs)
-		maxT := e2e.RandRange(rnd, minT+1, endMs)
+		maxT := e2e.RandRange(rnd, minT, endMs)
 
 		res1, err := c1.Series([]string{matcherStrings}, time.UnixMilli(minT), time.UnixMilli(maxT))
 		require.NoError(t, err)
@@ -595,7 +595,7 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzzWithPrometheus(t *testing.T) 
 
 		// Try again with a different timestamp and let requests hit posting cache.
 		minT = e2e.RandRange(rnd, startMs, endMs)
-		maxT = e2e.RandRange(rnd, minT+1, endMs)
+		maxT = e2e.RandRange(rnd, minT, endMs)
 		newRes1, err := c1.Series([]string{matcherStrings}, time.UnixMilli(minT), time.UnixMilli(maxT))
 		require.NoError(t, err)
 		newRes2, err := c2.Series([]string{matcherStrings}, time.UnixMilli(minT), time.UnixMilli(maxT))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

RandRange implementation:

```
func RandRange(rnd *rand.Rand, min, max int64) int64 {
	return rnd.Int63n(max-min) + min
}
```

`rnd.Int63n` requires the input to be > 0, otherwise it panics.

minT can have value [startMs, endMs-1]. Then minT + 1 can be endMs at maximum.  When calculating `maxT = e2e.RandRange(rnd, minT + 1, endMs)` it is possible to cause possible. I ran into this issue locally.
```
minT := e2e.RandRange(rnd, startMs, endMs)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
