### PR TITLE
Add Apple as an Adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -2,6 +2,7 @@
 
 This is the list of organisations that are using Cortex in **production environments** to power their metrics and monitoring systems. Please send PRs to add or remove organisations.
 
+* [Apple](https://www.apple.com)
 * [Adobe](https://www.adobe.com)
 * [Amazon Web Services (AWS)](https://aws.amazon.com/prometheus)
 * [Aspen Mesh](https://aspenmesh.io/)

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -2,9 +2,9 @@
 
 This is the list of organisations that are using Cortex in **production environments** to power their metrics and monitoring systems. Please send PRs to add or remove organisations.
 
-* [Apple](https://www.apple.com)
 * [Adobe](https://www.adobe.com)
 * [Amazon Web Services (AWS)](https://aws.amazon.com/prometheus)
+* [Apple](https://www.apple.com)
 * [Aspen Mesh](https://aspenmesh.io/)
 * [Buoyant](https://buoyant.io/)
 * [DigitalOcean](https://www.digitalocean.com/)


### PR DESCRIPTION
What this PR does: Adds Apple as an Adopter

We use and contribute to the Cortex project. We operate Cortex in multiple regions and availability zones to provide a resilient datastore service for AIML observability metric workloads with ingestion rates of a billion+ per minute.