### PR TITLE
Remove APIEnableRulesBackup config and use Ring.ReplicationFactor ins…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master / unreleased
+* [CHANGE] Ruler: Remove `experimental.ruler.api-enable-rules-backup` flag and use `ruler.ring.replication-factor` to check if rules backup is enabled
 
 ## 1.17.0 in progress
 
@@ -16,7 +17,6 @@
 * [CHANGE] Compactor: Don't halt compactor when overlapped source blocks detected. #5854
 * [CHANGE] S3 Bucket Client: Expose `-blocks-storage.s3.send-content-md5` flag and set default checksum algorithm to MD5. #5870
 * [CHANGE] Querier: Mark `querier.iterators` and `querier.batch-iterators` flags as deprecated. Now querier always use batch iterators. #5868
-* [CHANGE] Ruler: Remove `experimental.ruler.api-enable-rules-backup` flag and use `ruler.ring.replication-factor` to check if rules backup is enabled
 * [FEATURE] OTLP ingestion experimental. #5813
 * [FEATURE] Ingester: Add per-tenant new metric `cortex_ingester_tsdb_data_replay_duration_seconds`. #5477
 * [FEATURE] Query Frontend/Scheduler: Add query priority support. #5605

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [CHANGE] Compactor: Don't halt compactor when overlapped source blocks detected. #5854
 * [CHANGE] S3 Bucket Client: Expose `-blocks-storage.s3.send-content-md5` flag and set default checksum algorithm to MD5. #5870
 * [CHANGE] Querier: Mark `querier.iterators` and `querier.batch-iterators` flags as deprecated. Now querier always use batch iterators. #5868
+* [CHANGE] Ruler: Remove `experimental.ruler.api-enable-rules-backup` flag and use `ruler.ring.replication-factor` to check if rules backup is enabled
 * [FEATURE] OTLP ingestion experimental. #5813
 * [FEATURE] Ingester: Add per-tenant new metric `cortex_ingester_tsdb_data_replay_duration_seconds`. #5477
 * [FEATURE] Query Frontend/Scheduler: Add query priority support. #5605

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4271,15 +4271,6 @@ ring:
 # CLI flag: -experimental.ruler.enable-api
 [enable_api: <boolean> | default = false]
 
-# EXPERIMENTAL: Enable rulers to store a copy of rules owned by other rulers
-# with default state (state before any evaluation) and send this copy in list
-# API requests as backup in case the ruler who owns the rule fails to send its
-# rules. This allows the rules API to handle ruler outage by returning rules
-# with default state. Ring replication-factor needs to be set to 2 or more for
-# this to be useful.
-# CLI flag: -experimental.ruler.api-enable-rules-backup
-[api_enable_rules_backup: <boolean> | default = false]
-
 # EXPERIMENTAL: Remove duplicate rules in the prometheus rules and alerts API
 # response. If there are duplicate rules the rule with the latest evaluation
 # timestamp will be kept.

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -402,7 +402,7 @@ func TestRulerAPIShardingWithAPIRulesBackupEnabled(t *testing.T) {
 	testRulerAPIWithSharding(t, true)
 }
 
-func testRulerAPIWithSharding(t *testing.T, enableAPIRulesBackup bool) {
+func testRulerAPIWithSharding(t *testing.T, enableRulesBackup bool) {
 	const numRulesGroups = 100
 
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -459,9 +459,8 @@ func testRulerAPIWithSharding(t *testing.T, enableAPIRulesBackup bool) {
 		// Enable the bucket index so we can skip the initial bucket scan.
 		"-blocks-storage.bucket-store.bucket-index.enabled": "true",
 	}
-	if enableAPIRulesBackup {
+	if enableRulesBackup {
 		overrides["-ruler.ring.replication-factor"] = "3"
-		overrides["-experimental.ruler.api-enable-rules-backup"] = "true"
 	}
 	rulerFlags := mergeFlags(
 		BlocksStorageFlags(),
@@ -556,8 +555,8 @@ func testRulerAPIWithSharding(t *testing.T, enableAPIRulesBackup bool) {
 		},
 	}
 	// For each test case, fetch the rules with configured filters, and ensure the results match.
-	if enableAPIRulesBackup {
-		err := ruler2.Kill() // if api-enable-rules-backup is enabled the APIs should be able to handle a ruler going down
+	if enableRulesBackup {
+		err := ruler2.Kill() // if rules backup is enabled the APIs should be able to handle a ruler going down
 		require.NoError(t, err)
 	}
 	for name, tc := range testCases {

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -116,7 +116,7 @@ func NewDefaultMultiTenantManager(cfg Config, managerFactory ManagerFactory, eva
 		registry: reg,
 		logger:   logger,
 	}
-	if cfg.APIEnableRulesBackup {
+	if cfg.RulesBackupEnabled() {
 		m.rulesBackupManager = newRulesBackupManager(cfg, logger, reg)
 	}
 	return m, nil

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -262,7 +262,9 @@ func TestBackupRules(t *testing.T) {
 		1 * time.Millisecond,
 	}
 	ruleManagerFactory := RuleManagerFactory(nil, waitDurations)
-	m, err := NewDefaultMultiTenantManager(Config{RulePath: dir, APIEnableRulesBackup: true}, ruleManagerFactory, evalMetrics, reg, log.NewNopLogger())
+	config := Config{RulePath: dir}
+	config.Ring.ReplicationFactor = 3
+	m, err := NewDefaultMultiTenantManager(config, ruleManagerFactory, evalMetrics, reg, log.NewNopLogger())
 	require.NoError(t, err)
 
 	const user1 = "testUser"

--- a/pkg/ruler/ruler_ring.go
+++ b/pkg/ruler/ruler_ring.go
@@ -144,7 +144,10 @@ func GetReplicationSetForListRule(r ring.ReadRing, cfg *RingConfig) (ring.Replic
 	// to 0, and then we update them whether zone-awareness is enabled or not.
 	maxErrors := 0
 	maxUnavailableZones := 0
-	if cfg.ZoneAwarenessEnabled {
+	// Because ring's Get method returns a number of ruler equal to the replication factor even if there is only 1 zone
+	// and ZoneAwarenessEnabled, we can consider that ZoneAwarenessEnabled is disabled if there is only 1 zone since
+	// rules are still replicated to rulers in the same zone.
+	if cfg.ZoneAwarenessEnabled && len(ringZones) > 1 {
 		numReplicatedZones := min(len(ringZones), r.ReplicationFactor())
 		// Given that quorum is not required, we only need at least one of the zone to be healthy to succeed. But we
 		// also need to handle case when RF < number of zones.

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -473,6 +473,11 @@ func TestGetRules(t *testing.T) {
 		"ruler2": "b",
 		"ruler3": "c",
 	}
+	rulerAZSingleZone := map[string]string{
+		"ruler1": "a",
+		"ruler2": "a",
+		"ruler3": "a",
+	}
 
 	expectedRules := expectedRulesMap{
 		"ruler1": map[string]rulespb.RuleGroupList{
@@ -700,6 +705,24 @@ func TestGetRules(t *testing.T) {
 			enableZoneAwareReplication: true,
 			rulerStateMap:              rulerStateMapOnePending,
 			rulerAZMap:                 rulerAZEvenSpread,
+			replicationFactor:          3,
+			rulesRequest: RulesRequest{
+				Type: recordingRuleFilter,
+			},
+			expectedCount: map[string]int{
+				"user1": 3,
+				"user2": 5,
+				"user3": 1,
+			},
+			expectedClientCallCount: 2, // one of the ruler is pending, so we don't expect that ruler to be called
+		},
+		"Shuffle Sharding and ShardSize = 3 and AZ replication with API Rules backup enabled and one ruler in pending state and rulers are in same az": {
+			sharding:                   true,
+			shuffleShardSize:           3,
+			shardingStrategy:           util.ShardingStrategyShuffle,
+			enableZoneAwareReplication: true,
+			rulerStateMap:              rulerStateMapOnePending,
+			rulerAZMap:                 rulerAZSingleZone,
 			replicationFactor:          3,
 			rulesRequest: RulesRequest{
 				Type: recordingRuleFilter,

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -349,7 +349,7 @@ func TestGetRules(t *testing.T) {
 		rulerStateMap              map[string]ring.InstanceState
 		rulerAZMap                 map[string]string
 		expectedError              error
-		enableAPIRulesBackup       bool
+		replicationFactor          int
 		enableZoneAwareReplication bool
 	}
 
@@ -541,7 +541,7 @@ func TestGetRules(t *testing.T) {
 				"user2": 9,
 				"user3": 3,
 			},
-			enableAPIRulesBackup:    true,
+			replicationFactor:       3,
 			expectedClientCallCount: len(expectedRules),
 		},
 		"Shuffle Sharding and ShardSize = 2 with Rule Type Filter": {
@@ -633,11 +633,11 @@ func TestGetRules(t *testing.T) {
 			expectedClientCallCount: 0,
 		},
 		"Shuffle Sharding and ShardSize = 3 with API Rules backup enabled": {
-			sharding:             true,
-			shuffleShardSize:     3,
-			shardingStrategy:     util.ShardingStrategyShuffle,
-			rulerStateMap:        rulerStateMapAllActive,
-			enableAPIRulesBackup: true,
+			sharding:          true,
+			shuffleShardSize:  3,
+			shardingStrategy:  util.ShardingStrategyShuffle,
+			rulerStateMap:     rulerStateMapAllActive,
+			replicationFactor: 3,
 			rulesRequest: RulesRequest{
 				Type: recordingRuleFilter,
 			},
@@ -649,11 +649,11 @@ func TestGetRules(t *testing.T) {
 			expectedClientCallCount: 3,
 		},
 		"Shuffle Sharding and ShardSize = 3 with API Rules backup enabled and one ruler is in Pending state": {
-			sharding:             true,
-			shuffleShardSize:     3,
-			shardingStrategy:     util.ShardingStrategyShuffle,
-			rulerStateMap:        rulerStateMapOnePending,
-			enableAPIRulesBackup: true,
+			sharding:          true,
+			shuffleShardSize:  3,
+			shardingStrategy:  util.ShardingStrategyShuffle,
+			rulerStateMap:     rulerStateMapOnePending,
+			replicationFactor: 3,
 			rulesRequest: RulesRequest{
 				Type: recordingRuleFilter,
 			},
@@ -665,11 +665,11 @@ func TestGetRules(t *testing.T) {
 			expectedClientCallCount: 2, // one of the ruler is pending, so we don't expect that ruler to be called
 		},
 		"Shuffle Sharding and ShardSize = 3 with API Rules backup enabled and two ruler is in Pending state": {
-			sharding:             true,
-			shuffleShardSize:     3,
-			shardingStrategy:     util.ShardingStrategyShuffle,
-			rulerStateMap:        rulerStateMapTwoPending,
-			enableAPIRulesBackup: true,
+			sharding:          true,
+			shuffleShardSize:  3,
+			shardingStrategy:  util.ShardingStrategyShuffle,
+			rulerStateMap:     rulerStateMapTwoPending,
+			replicationFactor: 3,
 			rulesRequest: RulesRequest{
 				Type: recordingRuleFilter,
 			},
@@ -682,7 +682,7 @@ func TestGetRules(t *testing.T) {
 			enableZoneAwareReplication: true,
 			rulerStateMap:              rulerStateMapAllActive,
 			rulerAZMap:                 rulerAZEvenSpread,
-			enableAPIRulesBackup:       true,
+			replicationFactor:          3,
 			rulesRequest: RulesRequest{
 				Type: recordingRuleFilter,
 			},
@@ -700,7 +700,7 @@ func TestGetRules(t *testing.T) {
 			enableZoneAwareReplication: true,
 			rulerStateMap:              rulerStateMapOnePending,
 			rulerAZMap:                 rulerAZEvenSpread,
-			enableAPIRulesBackup:       true,
+			replicationFactor:          3,
 			rulesRequest: RulesRequest{
 				Type: recordingRuleFilter,
 			},
@@ -718,7 +718,7 @@ func TestGetRules(t *testing.T) {
 			enableZoneAwareReplication: true,
 			rulerStateMap:              rulerStateMapTwoPending,
 			rulerAZMap:                 rulerAZEvenSpread,
-			enableAPIRulesBackup:       true,
+			replicationFactor:          3,
 			rulesRequest: RulesRequest{
 				Type: recordingRuleFilter,
 			},
@@ -741,7 +741,6 @@ func TestGetRules(t *testing.T) {
 
 				cfg.ShardingStrategy = tc.shardingStrategy
 				cfg.EnableSharding = tc.sharding
-				cfg.APIEnableRulesBackup = tc.enableAPIRulesBackup
 
 				cfg.Ring = RingConfig{
 					InstanceID:   id,
@@ -751,8 +750,8 @@ func TestGetRules(t *testing.T) {
 					},
 					ReplicationFactor: 1,
 				}
-				if tc.enableAPIRulesBackup {
-					cfg.Ring.ReplicationFactor = 3
+				if tc.replicationFactor > 0 {
+					cfg.Ring.ReplicationFactor = tc.replicationFactor
 					cfg.Ring.ZoneAwarenessEnabled = tc.enableZoneAwareReplication
 				}
 				if tc.enableZoneAwareReplication {
@@ -877,7 +876,7 @@ func TestGetRules(t *testing.T) {
 				numberOfRulers := len(rulerAddrMap)
 				require.Equal(t, totalConfiguredRules*numberOfRulers, totalLoadedRules)
 			}
-			if tc.enableAPIRulesBackup && tc.sharding && tc.expectedError == nil {
+			if tc.replicationFactor > 1 && tc.sharding && tc.expectedError == nil {
 				// all rules should be backed up
 				require.Equal(t, totalConfiguredRules, len(ruleBackupCount))
 				var hasUnhealthyRuler bool
@@ -896,7 +895,7 @@ func TestGetRules(t *testing.T) {
 					}
 				}
 			} else {
-				// If APIEnableRulesBackup is disabled, rulers should not back up any rules
+				// If rules backup is disabled, rulers should not back up any rules
 				require.Equal(t, 0, len(ruleBackupCount))
 			}
 		})
@@ -983,7 +982,6 @@ func TestGetRulesFromBackup(t *testing.T) {
 
 		cfg.ShardingStrategy = util.ShardingStrategyShuffle
 		cfg.EnableSharding = true
-		cfg.APIEnableRulesBackup = true
 		cfg.EvaluationInterval = 5 * time.Minute
 
 		cfg.Ring = RingConfig{
@@ -1141,16 +1139,15 @@ func TestSharding(t *testing.T) {
 	type expectedRulesMap map[string]map[string]rulespb.RuleGroupList
 
 	type testCase struct {
-		sharding             bool
-		shardingStrategy     string
-		enableAPIRulesBackup bool
-		replicationFactor    int
-		shuffleShardSize     int
-		setupRing            func(*ring.Desc)
-		enabledUsers         []string
-		disabledUsers        []string
-		expectedRules        expectedRulesMap
-		expectedBackupRules  expectedRulesMap
+		sharding            bool
+		shardingStrategy    string
+		replicationFactor   int
+		shuffleShardSize    int
+		setupRing           func(*ring.Desc)
+		enabledUsers        []string
+		disabledUsers       []string
+		expectedRules       expectedRulesMap
+		expectedBackupRules expectedRulesMap
 	}
 
 	const (
@@ -1524,12 +1521,11 @@ func TestSharding(t *testing.T) {
 		},
 
 		"shuffle sharding, three rulers, shard size 2, enable api backup": {
-			sharding:             true,
-			replicationFactor:    2,
-			shardingStrategy:     util.ShardingStrategyShuffle,
-			enableAPIRulesBackup: true,
-			shuffleShardSize:     2,
-			enabledUsers:         []string{user1},
+			sharding:          true,
+			replicationFactor: 2,
+			shardingStrategy:  util.ShardingStrategyShuffle,
+			shuffleShardSize:  2,
+			enabledUsers:      []string{user1},
 
 			setupRing: func(desc *ring.Desc) {
 				desc.AddIngester(ruler1, ruler1Addr, "", sortTokens([]uint32{userToken(user1, 0) + 1, user1Group1Token + 1}), ring.ACTIVE, time.Now())
@@ -1566,9 +1562,8 @@ func TestSharding(t *testing.T) {
 			setupRuler := func(id string, host string, port int, forceRing *ring.Ring) *Ruler {
 				store := newMockRuleStore(allRules, nil)
 				cfg := Config{
-					EnableSharding:       tc.sharding,
-					APIEnableRulesBackup: tc.enableAPIRulesBackup,
-					ShardingStrategy:     tc.shardingStrategy,
+					EnableSharding:   tc.sharding,
+					ShardingStrategy: tc.shardingStrategy,
 					Ring: RingConfig{
 						InstanceID:   id,
 						InstanceAddr: host,
@@ -1657,7 +1652,7 @@ func TestSharding(t *testing.T) {
 
 			require.Equal(t, tc.expectedRules, expected)
 
-			if !tc.enableAPIRulesBackup {
+			if tc.replicationFactor <= 1 {
 				require.Equal(t, 0, len(expectedBackup[ruler1]))
 				require.Equal(t, 0, len(expectedBackup[ruler2]))
 				require.Equal(t, 0, len(expectedBackup[ruler3]))


### PR DESCRIPTION
…tead

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR removes the `-experimental.ruler.api-enable-rules-backup` config because it only makes sense if `ruler.ring.replication-factor` is set to a value greater than 1. So instead of having the a dedicated config we just infer that rules backup is enabled if `ruler.ring.replication-factor` is greater than 1. 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
