### PR TITLE
fix random string used in test allocating 50MB in Cortex binary

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -57,6 +57,14 @@ var (
 	emptyResponse = &cortexpb.WriteResponse{}
 )
 
+var (
+	randomStrings = []string{}
+)
+
+func init() {
+	randomStrings = util.GenerateRandomStrings()
+}
+
 func TestConfig_Validate(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {
@@ -2466,8 +2474,8 @@ func prepare(tb testing.TB, cfg prepConfig) ([]*Distributor, []*mockIngester, []
 	// Strings to be used for get labels values/Names
 	var unusedStrings []string
 	if cfg.lblValuesPerIngester > 0 {
-		unusedStrings = make([]string, min(len(util.RandomStrings), cfg.numIngesters*cfg.lblValuesPerIngester))
-		copy(unusedStrings, util.RandomStrings)
+		unusedStrings = make([]string, min(len(randomStrings), cfg.numIngesters*cfg.lblValuesPerIngester))
+		copy(unusedStrings, randomStrings)
 	}
 	s := &prepState{
 		unusedStrings: unusedStrings,

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -48,6 +48,7 @@ func BenchmarkMergeSlicesParallel(b *testing.B) {
 		},
 	}
 
+	randomStrings := GenerateRandomStrings()
 	type ParallelismType int
 
 	const (
@@ -58,9 +59,9 @@ func BenchmarkMergeSlicesParallel(b *testing.B) {
 
 	for _, tc := range testCases {
 		input := make([][]string, tc.inputSize)
-		unusedStrings := make([]string, min(len(RandomStrings), tc.inputSize*tc.stringsPerInput))
+		unusedStrings := make([]string, min(len(randomStrings), tc.inputSize*tc.stringsPerInput))
 		usedStrings := make([]string, 0, len(unusedStrings))
-		copy(unusedStrings, RandomStrings)
+		copy(unusedStrings, randomStrings)
 
 		for i := 0; i < tc.inputSize; i++ {
 			stringsToBeReused := make([]string, len(usedStrings))

--- a/pkg/util/test_util.go
+++ b/pkg/util/test_util.go
@@ -5,12 +5,9 @@ import (
 	"strings"
 )
 
-var (
-	randomChar    = "0123456789abcdef"
-	RandomStrings = []string{}
-)
-
-func init() {
+func GenerateRandomStrings() []string {
+	randomChar := "0123456789abcdef"
+	randomStrings := make([]string, 0, 1000000)
 	sb := strings.Builder{}
 	for i := 0; i < 1000000; i++ {
 		sb.Reset()
@@ -18,6 +15,7 @@ func init() {
 		for j := 0; j < 14; j++ {
 			sb.WriteByte(randomChar[rand.Int()%len(randomChar)])
 		}
-		RandomStrings = append(RandomStrings, sb.String())
+		randomStrings = append(randomStrings, sb.String())
 	}
+	return randomStrings
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

We initialize `RandomStrings` in `pkg/util/test_util.go` which allocates 50MB data in heap in Cortex binary. This variable is used only in tests. The increased also showed up in the heap dump below.

<img width="1459" alt="image" src="https://github.com/cortexproject/cortex/assets/25150124/c980bfd0-114a-4d64-af33-77eebf4005ee">


In this PR I removed the global variable for `RandomStrings` in `pkg/util` and move it to specific test files instead. This should reduce the memory usage in heap.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
