### PR TITLE
Optimize Write Signature calculation

### DIFF
--- a/pkg/cortexpb/extensions_test.go
+++ b/pkg/cortexpb/extensions_test.go
@@ -10,6 +10,32 @@ import (
 	"github.com/weaveworks/common/user"
 )
 
+func BenchmarkSignRequest(b *testing.B) {
+	ctx := context.Background()
+	ctx = user.InjectOrgID(ctx, "user-1")
+
+	tests := []struct {
+		size int
+	}{
+		{size: 10},
+		{size: 100},
+		{size: 1000},
+		{size: 10000},
+	}
+
+	for _, tc := range tests {
+		b.Run(fmt.Sprintf("WriteRequestSize: %v", tc.size), func(b *testing.B) {
+			wr := createWriteRequest(tc.size, true, "family1", "help1", "unit")
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := wr.Sign(ctx)
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
 func TestWriteRequest_Sign(t *testing.T) {
 	ctx := context.Background()
 	ctx = user.InjectOrgID(ctx, "user-1")


### PR DESCRIPTION
**What this PR does**:

Optimize how we calculate the write signature:

Before we were falling back to use a less optimal way to calculate when the signature input was > "maxBufferSize" and now we are reusing that buffer to calculate the hash in "batchs"

Benchmark Results:

```
goos: linux
goarch: amd64
pkg: github.com/cortexproject/cortex/pkg/cortexpb
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
                                       │   /tmp/old   │              /tmp/new               │
                                       │    sec/op    │    sec/op     vs base               │
SignRequest/WriteRequestSize:_10-32	 1.032µ ± ∞ ¹   1.038µ ± ∞ ¹	    ~ (p=0.111 n=5)
SignRequest/WriteRequestSize:_100-32     5.182µ ± ∞ ¹   4.224µ ± ∞ ¹  -18.49% (p=0.008 n=5)
SignRequest/WriteRequestSize:_1000-32    48.09µ ± ∞ ¹   35.85µ ± ∞ ¹  -25.44% (p=0.008 n=5)
SignRequest/WriteRequestSize:_10000-32   514.5µ ± ∞ ¹   368.9µ ± ∞ ¹  -28.30% (p=0.008 n=5)
geomean                                  19.07µ         15.52µ        -18.64%
¹ need >= 6 samples for confidence interval at level 0.95

                                       │  /tmp/old   │              /tmp/new               │
                                       │    B/op     │    B/op      vs base                │
SignRequest/WriteRequestSize:_10-32      32.00 ± ∞ ¹   32.00 ± ∞ ¹	 ~ (p=1.000 n=5) ²
SignRequest/WriteRequestSize:_100-32     32.00 ± ∞ ¹   32.00 ± ∞ ¹	 ~ (p=1.000 n=5) ²
SignRequest/WriteRequestSize:_1000-32	 32.00 ± ∞ ¹   32.00 ± ∞ ¹	 ~ (p=1.000 n=5) ²
SignRequest/WriteRequestSize:_10000-32   34.00 ± ∞ ¹   33.00 ± ∞ ¹  -2.94% (p=0.048 n=5)
geomean                                  32.49         32.25        -0.74%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

                                       │  /tmp/old   │              /tmp/new               │
                                       │  allocs/op  │  allocs/op   vs base                │
SignRequest/WriteRequestSize:_10-32      2.000 ± ∞ ¹   2.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
SignRequest/WriteRequestSize:_100-32     2.000 ± ∞ ¹   2.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
SignRequest/WriteRequestSize:_1000-32	 2.000 ± ∞ ¹   2.000 ± ∞ ¹	 ~ (p=1.000 n=5) ²
SignRequest/WriteRequestSize:_10000-32   2.000 ± ∞ ¹   2.000 ± ∞ ¹	 ~ (p=1.000 n=5) ²
geomean                              	 2.000         2.000        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
