### PR TITLE
Making ingester head compaction jitter Zone aware.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master / unreleased
 * [ENHANCEMENT] Query Frontend/Querier: Added store gateway postings touched count and touched size in Querier stats and log in Query Frontend. #5892
 * [ENHANCEMENT] Query Frontend/Querier: Returns `warnings` on prometheus query responses. #5916
-* [ENHANCEMENT] Ingester: Allowing to configure `-blocks-storage.tsdb.head-compaction-interval` flag up to 30 min and add a jitter on the first head compaction. #5919
+* [ENHANCEMENT] Ingester: Allowing to configure `-blocks-storage.tsdb.head-compaction-interval` flag up to 30 min and add a jitter on the first head compaction. #5919 #5928
 * [ENHANCEMENT] Distributor: Added `max_inflight_push_requests` config to ingester client to protect distributor from OOMKilled. #5917
 * [CHANGE] Upgrade Dockerfile Node version from 14x to 18x. #5906
 * [BUGFIX] Configsdb: Fix endline issue in db password. #5920

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2409,7 +2409,9 @@ func (i *Ingester) compactionLoop(ctx context.Context) error {
 	infoFunc := func() (int, int) {
 		if i.cfg.LifecyclerConfig.RingConfig.ZoneAwarenessEnabled {
 			zones := i.lifecycler.Zones()
-			return slices.Index(zones, i.lifecycler.Zone), len(zones)
+			if len(zones) != 0 {
+				return slices.Index(zones, i.lifecycler.Zone), len(zones)
+			}
 		}
 
 		// Lets create the slot based on the hash id

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -71,7 +71,6 @@ const (
 
 	// Jitter applied to the idle timeout to prevent compaction in all ingesters concurrently.
 	compactionIdleTimeoutJitter = 0.25
-	initialHeadCompactionJitter = 0.5
 
 	instanceIngestionRateTickInterval = time.Second
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -2405,20 +2406,23 @@ func (i *Ingester) shipBlocks(ctx context.Context, allowed *util.AllowedTenants)
 }
 
 func (i *Ingester) compactionLoop(ctx context.Context) error {
-	// Apply a jitter on the first head compaction
-	firstHeadCompaction := true
-	ticker := time.NewTicker(util.DurationWithPositiveJitter(i.cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval, initialHeadCompactionJitter))
+	infoFunc := func() (int, int) {
+		if i.cfg.LifecyclerConfig.RingConfig.ZoneAwarenessEnabled {
+			zones := i.lifecycler.Zones()
+			return slices.Index(zones, i.lifecycler.Zone), len(zones)
+		}
+
+		// Lets create the slot based on the hash id
+		i := int(client.HashAdd32(client.HashNew32(), i.lifecycler.ID) % 10)
+		return i, 10
+	}
+	ticker := util.NewSlottedTicker(infoFunc, i.cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval)
 	defer ticker.Stop()
 
 	for ctx.Err() == nil {
 		select {
 		case <-ticker.C:
 			i.compactBlocks(ctx, false, nil)
-			// Reset the ticker to run the configured interval on the first head compaction
-			if firstHeadCompaction {
-				ticker.Reset(i.cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval)
-				firstHeadCompaction = false
-			}
 
 		case req := <-i.TSDBState.forceCompactTrigger:
 			i.compactBlocks(ctx, true, req.users)

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -175,8 +175,8 @@ func NewSlottedTicker(sf SlotInfoFunc, d time.Duration) *SlottedTicker {
 		shouldReset: true,
 	}
 	slitIndex, totalSlots := sf()
+	st.ticker = time.NewTicker(st.nextInterval())
 	go func() {
-		st.ticker = time.NewTicker(st.nextInterval())
 		for ctx.Err() == nil {
 			select {
 			case t := <-st.ticker.C:
@@ -216,6 +216,6 @@ func (t *SlottedTicker) nextInterval() time.Duration {
 	for slot.Before(time.Now()) {
 		slot = slot.Add(t.d)
 	}
-	i := slot.Sub(time.Now())
+	i := time.Until(slot)
 	return i + PositiveJitter(slotSize, 1)
 }

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -3,8 +3,6 @@ package util
 import (
 	"bytes"
 	"fmt"
-	"github.com/cortexproject/cortex/pkg/util/test"
-	"go.uber.org/atomic"
 	"net/http"
 	"strconv"
 	"testing"
@@ -13,6 +11,9 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/cortexproject/cortex/pkg/util/test"
 )
 
 func TestTimeFromMillis(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
https://github.com/cortexproject/cortex/pull/5919 We introduced a jitter on the head compaction. This PR is proposing to change that jitter to take in consideration the AZ of the ingester.

Lets say we configure to have a head compaction interval set at 15 minutes across 3 Availability Zones (AZs). Prior to this change, the ingesters would determine a random jitter and perform the head compaction at any minute within each 15-minute interval. This change ensure that within every 15-minute interval, Ingesters in AZ1 execute head compaction from minute 0 to 5, those in AZ2 from minute 5 to 10, and those in AZ3 from minute 10 to 15.

I added a log on every tick to show the time of the tick and the AZ of the ingester on a 15 minutes period:

| aws.az | tick_time | count(*) |
| --- | --- | --- |
| us-east-1d | 2024-05-06 18:59 | 1 |
| us-east-1d | 2024-05-06 18:58 | 9 |
| us-east-1d | 2024-05-06 18:57 | 7 |
| us-east-1d | 2024-05-06 18:56 | 11 |
| us-east-1d | 2024-05-06 18:55 | 6 |
| us-east-1b | 2024-05-06 18:54 | 11 |
| us-east-1b | 2024-05-06 18:53 | 5 |
| us-east-1b | 2024-05-06 18:52 | 7 |
| us-east-1b | 2024-05-06 18:51 | 8 |
| us-east-1b | 2024-05-06 18:50 | 11 |
| us-east-1a | 2024-05-06 18:49 | 5 |
| us-east-1a | 2024-05-06 18:48 | 10 |
| us-east-1a | 2024-05-06 18:47 | 8 |
| us-east-1a | 2024-05-06 18:46 | 8 |
| us-east-1a | 2024-05-06 18:45 | 8 |
---

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
