### PR TITLE
Allowing to disabled detailed ring metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [ENHANCEMENT] Ingester: Allowing to configure `-blocks-storage.tsdb.head-compaction-interval` flag up to 30 min and add a jitter on the first head compaction. #5919 #5928
 * [ENHANCEMENT] Distributor: Added `max_inflight_push_requests` config to ingester client to protect distributor from OOMKilled. #5917
 * [ENHANCEMENT] Distributor/Querier: Clean stale per-ingester metrics after ingester restarts. #5930
+* [ENHANCEMENT] Distributor/Ring: Allow disabling detailed ring metrics by ring member. #5931
 * [CHANGE] Upgrade Dockerfile Node version from 14x to 18x. #5906
 * [BUGFIX] Configsdb: Fix endline issue in db password. #5920
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2830,6 +2830,13 @@ lifecycler:
     # CLI flag: -distributor.excluded-zones
     [excluded_zones: <string> | default = ""]
 
+    # Set to true to enable ring detailed metrics. These metrics provide
+    # detailed information, such as token count and ownership per tenant.
+    # Disabling them can significantly decrease the number of metrics emitted by
+    # the distributors.
+    # CLI flag: -ring.detailed-metrics-enabled
+    [detailed_metrics_enabled: <boolean> | default = true]
+
   # Number of tokens for each ingester.
   # CLI flag: -ingester.num-tokens
   [num_tokens: <int> | default = 128]

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -2984,28 +2984,13 @@ func userToken(user, zone string, skip int) uint32 {
 }
 
 func TestUpdateMetrics(t *testing.T) {
-	cfg := Config{
-		KVStore:              kv.Config{},
-		HeartbeatTimeout:     0, // get healthy stats
-		ReplicationFactor:    3,
-		ZoneAwarenessEnabled: true,
-	}
-
-	registry := prometheus.NewRegistry()
-
-	// create the ring to set up metrics, but do not start
-	ring, err := NewWithStoreClientAndStrategy(cfg, testRingName, testRingKey, &MockClient{}, NewDefaultReplicationStrategy(), registry, log.NewNopLogger())
-	require.NoError(t, err)
-
-	ringDesc := Desc{
-		Ingesters: map[string]InstanceDesc{
-			"A": {Addr: "127.0.0.1", Timestamp: 22, Tokens: []uint32{math.MaxUint32 / 4, (math.MaxUint32 / 4) * 3}},
-			"B": {Addr: "127.0.0.2", Timestamp: 11, Tokens: []uint32{(math.MaxUint32 / 4) * 2, math.MaxUint32}},
-		},
-	}
-	ring.updateRingState(&ringDesc)
-
-	err = testutil.GatherAndCompare(registry, bytes.NewBufferString(`
+	testCase := []struct {
+		DetailedMetricsEnabled bool
+		Expected               string
+	}{
+		{
+			DetailedMetricsEnabled: true,
+			Expected: `
 		# HELP ring_member_ownership_percent The percent ownership of the ring by member
 		# TYPE ring_member_ownership_percent gauge
 		ring_member_ownership_percent{member="A",name="test"} 0.49999999976716936
@@ -3031,8 +3016,59 @@ func TestUpdateMetrics(t *testing.T) {
 		# HELP ring_tokens_total Number of tokens in the ring
 		# TYPE ring_tokens_total gauge
 		ring_tokens_total{name="test"} 4
-	`))
-	assert.NoError(t, err)
+	`,
+		},
+		{
+			DetailedMetricsEnabled: false,
+			Expected: `
+		# HELP ring_members Number of members in the ring
+		# TYPE ring_members gauge
+		ring_members{name="test",state="ACTIVE"} 2
+		ring_members{name="test",state="JOINING"} 0
+		ring_members{name="test",state="LEAVING"} 0
+		ring_members{name="test",state="PENDING"} 0
+		ring_members{name="test",state="Unhealthy"} 0
+		# HELP ring_oldest_member_timestamp Timestamp of the oldest member in the ring.
+		# TYPE ring_oldest_member_timestamp gauge
+		ring_oldest_member_timestamp{name="test",state="ACTIVE"} 11
+		ring_oldest_member_timestamp{name="test",state="JOINING"} 0
+		ring_oldest_member_timestamp{name="test",state="LEAVING"} 0
+		ring_oldest_member_timestamp{name="test",state="PENDING"} 0
+		ring_oldest_member_timestamp{name="test",state="Unhealthy"} 0
+		# HELP ring_tokens_total Number of tokens in the ring
+		# TYPE ring_tokens_total gauge
+		ring_tokens_total{name="test"} 4
+	`,
+		},
+	}
+
+	for _, tc := range testCase {
+		t.Run(fmt.Sprintf("DetailedMetricsEnabled=%v", tc.DetailedMetricsEnabled), func(t *testing.T) {
+			cfg := Config{
+				KVStore:                kv.Config{},
+				HeartbeatTimeout:       0, // get healthy stats
+				ReplicationFactor:      3,
+				ZoneAwarenessEnabled:   true,
+				DetailedMetricsEnabled: tc.DetailedMetricsEnabled,
+			}
+			registry := prometheus.NewRegistry()
+
+			// create the ring to set up metrics, but do not start
+			ring, err := NewWithStoreClientAndStrategy(cfg, testRingName, testRingKey, &MockClient{}, NewDefaultReplicationStrategy(), registry, log.NewNopLogger())
+			require.NoError(t, err)
+
+			ringDesc := Desc{
+				Ingesters: map[string]InstanceDesc{
+					"A": {Addr: "127.0.0.1", Timestamp: 22, Tokens: []uint32{math.MaxUint32 / 4, (math.MaxUint32 / 4) * 3}},
+					"B": {Addr: "127.0.0.2", Timestamp: 11, Tokens: []uint32{(math.MaxUint32 / 4) * 2, math.MaxUint32}},
+				},
+			}
+			ring.updateRingState(&ringDesc)
+
+			err = testutil.GatherAndCompare(registry, bytes.NewBufferString(tc.Expected))
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func TestUpdateMetricsWithRemoval(t *testing.T) {

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -3073,10 +3073,11 @@ func TestUpdateMetrics(t *testing.T) {
 
 func TestUpdateMetricsWithRemoval(t *testing.T) {
 	cfg := Config{
-		KVStore:              kv.Config{},
-		HeartbeatTimeout:     0, // get healthy stats
-		ReplicationFactor:    3,
-		ZoneAwarenessEnabled: true,
+		KVStore:                kv.Config{},
+		HeartbeatTimeout:       0, // get healthy stats
+		ReplicationFactor:      3,
+		ZoneAwarenessEnabled:   true,
+		DetailedMetricsEnabled: true,
 	}
 
 	registry := prometheus.NewRegistry()


### PR DESCRIPTION
**What this PR does**:
Creates a flag to allow disabling the "detailed ring metrics"

The metrics indicate the ownership or token count per ingester. However, since they are generated by the distributor, they can rapidly generate a large number of metrics. (every distributor will emit the same value)

Those metrics are not super useful as they only change when we have a configuration change (number of tokens) or a scale up /down of ingesters (ownership) -> Both of these informations are already on the ring page on the distributor.
![Screenshot 2024-05-07 at 11 42 43 AM](https://github.com/cortexproject/cortex/assets/4027760/5d7d3b7c-6201-4383-b33a-bb139ef7a252)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
