### PR TITLE
Clean up ingester client inflightPushRequests on close

### DIFF
--- a/pkg/ingester/client/client_test.go
+++ b/pkg/ingester/client/client_test.go
@@ -104,8 +104,9 @@ func createTestIngesterClient(maxInflightPushRequests int64, currentInflightRequ
 	client := &closableHealthAndIngesterClient{
 		IngesterClient:          &mockIngester{},
 		conn:                    &mockClientConn{},
+		addr:                    "dummy_addr",
 		maxInflightPushRequests: maxInflightPushRequests,
-		inflightPushRequests:    prometheus.NewGaugeVec(prometheus.GaugeOpts{}, nil),
+		inflightPushRequests:    prometheus.NewGaugeVec(prometheus.GaugeOpts{}, []string{"ingester"}),
 	}
 	client.inflightRequests.Add(currentInflightRequests)
 	return client

--- a/pkg/ingester/client/client_test.go
+++ b/pkg/ingester/client/client_test.go
@@ -105,7 +105,7 @@ func createTestIngesterClient(maxInflightPushRequests int64, currentInflightRequ
 		IngesterClient:          &mockIngester{},
 		conn:                    &mockClientConn{},
 		maxInflightPushRequests: maxInflightPushRequests,
-		inflightPushRequests:    prometheus.NewGauge(prometheus.GaugeOpts{}),
+		inflightPushRequests:    prometheus.NewGaugeVec(prometheus.GaugeOpts{}, nil),
 	}
 	client.inflightRequests.Add(currentInflightRequests)
 	return client


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

In last PR https://github.com/cortexproject/cortex/pull/5917, new metric `ingester_client_inflight_push_requests` for ingester client was introduced. This metric got ingester address as label. This metric should be cleaned when client is closed to avoid high cardinality. 

**Which issue(s) this PR fixes**:


**Checklist**
- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
