### PR TITLE
Adding the -etcd.ping-without-stream-allowed parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [ENHANCEMENT] Distributor: Added `max_inflight_push_requests` config to ingester client to protect distributor from OOMKilled. #5917
 * [ENHANCEMENT] Distributor/Querier: Clean stale per-ingester metrics after ingester restarts. #5930
 * [ENHANCEMENT] Distributor/Ring: Allow disabling detailed ring metrics by ring member. #5931
-* [ENHANCEMENT] KV: Etcd Added etcd.ping-without-stream-allowed parameter to disable/enable  PermitWithoutStream #5897
+* [ENHANCEMENT] KV: Etcd Added etcd.ping-without-stream-allowed parameter to disable/enable  PermitWithoutStream #5933
 * [CHANGE] Upgrade Dockerfile Node version from 14x to 18x. #5906
 * [BUGFIX] Configsdb: Fix endline issue in db password. #5920
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 * [ENHANCEMENT] Distributor: Added `max_inflight_push_requests` config to ingester client to protect distributor from OOMKilled. #5917
 * [ENHANCEMENT] Distributor/Querier: Clean stale per-ingester metrics after ingester restarts. #5930
 * [ENHANCEMENT] Distributor/Ring: Allow disabling detailed ring metrics by ring member. #5931
+* [ENHANCEMENT] KV: Etcd Added etcd.ping-without-stream-allowed parameter to disable/enable  PermitWithoutStream #5897
 * [CHANGE] Upgrade Dockerfile Node version from 14x to 18x. #5906
 * [BUGFIX] Configsdb: Fix endline issue in db password. #5920
-* [ENHANCEMENT] KV: Etcd Added etcd.ping-without-stream-allowed parameter to disable/enable  PermitWithoutStream #5897
 
 
 ## 1.17.0 2024-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * [ENHANCEMENT] Distributor/Ring: Allow disabling detailed ring metrics by ring member. #5931
 * [CHANGE] Upgrade Dockerfile Node version from 14x to 18x. #5906
 * [BUGFIX] Configsdb: Fix endline issue in db password. #5920
+* [ENHANCEMENT] KV: Etcd Added etcd.ping-without-stream-allowed parameter to disable/enable  PermitWithoutStream #5897
+
 
 ## 1.17.0 2024-04-30
 

--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -160,6 +160,9 @@ prefix these flags with `distributor.ha-tracker.`
    The trusted CA file path.
 - `etcd.tls-insecure-skip-verify`
    Skip validating server certificate.
+- `etcd.ping-without-stream-allowd'`
+   Enable/Disable  PermitWithoutStream  parameter
+
 
 #### memberlist
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2834,6 +2834,13 @@ lifecycler:
     # CLI flag: -distributor.excluded-zones
     [excluded_zones: <string> | default = ""]
 
+    # Set to true to enable ring detailed metrics. These metrics provide
+    # detailed information, such as token count and ownership per tenant.
+    # Disabling them can significantly decrease the number of metrics emitted by
+    # the distributors.
+    # CLI flag: -ring.detailed-metrics-enabled
+    [detailed_metrics_enabled: <boolean> | default = true]
+
   # Number of tokens for each ingester.
   # CLI flag: -ingester.num-tokens
   [num_tokens: <int> | default = 128]

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2606,6 +2606,10 @@ The `etcd_config` configures the etcd client. The supported CLI flags `<prefix>`
 # Etcd password.
 # CLI flag: -<prefix>.etcd.password
 [password: <string> | default = ""]
+
+# Send Keepalive pings with no streams.
+# CLI flag: -<prefix>.etcd.ping-without-stream-allowed
+[ping-without-stream-allowed: <boolean> | default = true]
 ```
 
 ### `fifo_cache_config`
@@ -2829,13 +2833,6 @@ lifecycler:
     # excluded zones will be filtered out from the ring.
     # CLI flag: -distributor.excluded-zones
     [excluded_zones: <string> | default = ""]
-
-    # Set to true to enable ring detailed metrics. These metrics provide
-    # detailed information, such as token count and ownership per tenant.
-    # Disabling them can significantly decrease the number of metrics emitted by
-    # the distributors.
-    # CLI flag: -ring.detailed-metrics-enabled
-    [detailed_metrics_enabled: <boolean> | default = true]
 
   # Number of tokens for each ingester.
   # CLI flag: -ingester.num-tokens

--- a/pkg/ring/kv/etcd/etcd.go
+++ b/pkg/ring/kv/etcd/etcd.go
@@ -27,8 +27,9 @@ type Config struct {
 	EnableTLS   bool                   `yaml:"tls_enabled"`
 	TLS         cortextls.ClientConfig `yaml:",inline"`
 
-	UserName string `yaml:"username"`
-	Password string `yaml:"password"`
+	UserName            string `yaml:"username"`
+	Password            string `yaml:"password"`
+	PermitWithoutStream bool   `yaml:"ping-without-stream-allowed"`
 }
 
 // Clientv3Facade is a subset of all Etcd client operations that are required
@@ -59,6 +60,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.EnableTLS, prefix+"etcd.tls-enabled", false, "Enable TLS.")
 	f.StringVar(&cfg.UserName, prefix+"etcd.username", "", "Etcd username.")
 	f.StringVar(&cfg.Password, prefix+"etcd.password", "", "Etcd password.")
+	f.BoolVar(&cfg.PermitWithoutStream, prefix+"etcd.ping-without-stream-allowed", true, "Send Keepalive pings with no streams.")
 	cfg.TLS.RegisterFlagsWithPrefix(prefix+"etcd", f)
 }
 
@@ -102,7 +104,7 @@ func New(cfg Config, codec codec.Codec, logger log.Logger) (*Client, error) {
 		//   to server without any active streams (enabled)
 		DialKeepAliveTime:    10 * time.Second,
 		DialKeepAliveTimeout: 2 * cfg.DialTimeout,
-		PermitWithoutStream:  true,
+		PermitWithoutStream:  cfg.PermitWithoutStream,
 		TLS:                  tlsConfig,
 		Username:             cfg.UserName,
 		Password:             cfg.Password,


### PR DESCRIPTION
Adding the -etcd.ping-without-stream-allowed parameter

**What this PR does**:

This parameter allows the setting of the PermitWithoutStream  so it can be disabled  (default behaviour is still true).
Allowing to set this Parameter  is a solution for 

https://github.com/cortexproject/cortex/issues/5897



**Which issue(s) this PR fixes**:
Fixes #5897 

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
