### PR TITLE
Catch context error when getting bucket index

### DIFF
--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	"github.com/cortexproject/cortex/pkg/util"
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/pkg/util/services"
 )
 
@@ -93,7 +94,7 @@ func NewLoader(cfg LoaderConfig, bucketClient objstore.Bucket, cfgProvider bucke
 // index if available, or load it from the bucket otherwise.
 func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, Status, error) {
 	if ctx.Err() != nil {
-		level.Warn(l.logger).Log("msg", "received context error when attempting to load bucket index", "err", ctx.Err())
+		level.Warn(util_log.WithContext(ctx, l.logger)).Log("msg", "received context error when attempting to load bucket index", "err", ctx.Err())
 		return nil, UnknownStatus, ctx.Err()
 	}
 

--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -92,6 +92,11 @@ func NewLoader(cfg LoaderConfig, bucketClient objstore.Bucket, cfgProvider bucke
 // GetIndex returns the bucket index for the given user. It returns the in-memory cached
 // index if available, or load it from the bucket otherwise.
 func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, Status, error) {
+	if ctx.Err() != nil {
+		level.Warn(l.logger).Log("msg", "received context error when attempting to load bucket index", "err", ctx.Err())
+		return nil, UnknownStatus, ctx.Err()
+	}
+
 	l.indexesMx.RLock()
 	if entry := l.indexes[userID]; entry != nil {
 		idx := entry.index


### PR DESCRIPTION
**What this PR does**:
This PR fix the issue where the Context comes in cancelled during a query split and giving the false impression that it cannot load the bucket index.

**Checklist**
- [NA ] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`