### PR TITLE
Increase number of buckets for ingester_client_request_duration_seconds

### DIFF
--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -20,7 +20,7 @@ var ingesterClientRequestDuration = promauto.NewHistogramVec(prometheus.Histogra
 	Namespace: "cortex",
 	Name:      "ingester_client_request_duration_seconds",
 	Help:      "Time spent doing Ingester requests.",
-	Buckets:   prometheus.ExponentialBuckets(0.001, 4, 6),
+	Buckets:   prometheus.ExponentialBuckets(0.001, 4, 7),
 }, []string{"operation", "status_code"})
 var ingesterClientInflightPushRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "cortex",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Create one more bucket for ingester client request time histogram.
Today we have 6 bucket which are
`[1, 4, 16, 64, 256, 1024]` ms
Cortex default timeout is 2s
```
f.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")
```

It would be benefital to add a new bucket which would be `4096s`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
