### PR TITLE
Fix race condition on ingester client metric

### DIFF
--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -73,10 +73,9 @@ func (c *closableHealthAndIngesterClient) Push(ctx context.Context, in *cortexpb
 
 func (c *closableHealthAndIngesterClient) handlePushRequest(mainFunc func() (*cortexpb.WriteResponse, error)) (*cortexpb.WriteResponse, error) {
 	currentInflight := c.inflightRequests.Inc()
-	c.inflightPushRequests.WithLabelValues(c.addr).Inc()
+	c.inflightPushRequests.WithLabelValues(c.addr).Set(float64(currentInflight))
 	defer func() {
-		c.inflightPushRequests.WithLabelValues(c.addr).Dec()
-		c.inflightRequests.Dec()
+		c.inflightPushRequests.WithLabelValues(c.addr).Set(float64(c.inflightRequests.Dec()))
 	}()
 	if c.maxInflightPushRequests > 0 && currentInflight > c.maxInflightPushRequests {
 		return nil, errTooManyInflightPushRequests


### PR DESCRIPTION
**What this PR does**:
Fix race condition when we may report wrong metric if we close one ingester client while the second one is already running and sending request.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
