### PR TITLE
Fix `cortex_ingester_tsdb_head_samples_appended_total` metric dimentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [ENHANCEMENT] KV: Etcd Added etcd.ping-without-stream-allowed parameter to disable/enable  PermitWithoutStream #5933
 * [CHANGE] Upgrade Dockerfile Node version from 14x to 18x. #5906
 * [BUGFIX] Configsdb: Fix endline issue in db password. #5920
+* [BUGFIX] Ingester: Fix `user` and `type` labels for the `cortex_ingester_tsdb_head_samples_appended_total` TSDB metric. #5952
 
 
 ## 1.17.0 2024-04-30

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -460,7 +460,7 @@ func newTSDBMetrics(r prometheus.Registerer) *tsdbMetrics {
 		tsdbSamplesAppended: prometheus.NewDesc(
 			"cortex_ingester_tsdb_head_samples_appended_total",
 			"Total number of appended samples.",
-			[]string{"type", "user"}, nil),
+			[]string{"user", "type"}, nil),
 		tsdbOutOfOrderSamplesAppended: prometheus.NewDesc(
 			"cortex_ingester_tsdb_head_out_of_order_samples_appended_total",
 			"Total number of appended out of order samples.",

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -252,9 +252,9 @@ func TestTSDBMetrics(t *testing.T) {
         	cortex_ingester_tsdb_head_out_of_order_samples_appended_total{user="user3"} 102
         	# HELP cortex_ingester_tsdb_head_samples_appended_total Total number of appended samples.
         	# TYPE cortex_ingester_tsdb_head_samples_appended_total counter
-        	cortex_ingester_tsdb_head_samples_appended_total{type="user1",user="float"} 101
-        	cortex_ingester_tsdb_head_samples_appended_total{type="user2",user="float"} 101
-        	cortex_ingester_tsdb_head_samples_appended_total{type="user3",user="float"} 101
+			cortex_ingester_tsdb_head_samples_appended_total{type="float",user="user1"} 101
+			cortex_ingester_tsdb_head_samples_appended_total{type="float",user="user2"} 101
+			cortex_ingester_tsdb_head_samples_appended_total{type="float",user="user3"} 101
 			# HELP cortex_ingester_tsdb_checkpoint_deletions_failed_total Total number of TSDB checkpoint deletions that failed.
 			# TYPE cortex_ingester_tsdb_checkpoint_deletions_failed_total counter
 			cortex_ingester_tsdb_checkpoint_deletions_failed_total 1586096
@@ -496,8 +496,8 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
         	cortex_ingester_tsdb_head_out_of_order_samples_appended_total{user="user2"} 102
         	# HELP cortex_ingester_tsdb_head_samples_appended_total Total number of appended samples.
         	# TYPE cortex_ingester_tsdb_head_samples_appended_total counter
-        	cortex_ingester_tsdb_head_samples_appended_total{type="user1",user="float"} 101
-        	cortex_ingester_tsdb_head_samples_appended_total{type="user2",user="float"} 101
+			cortex_ingester_tsdb_head_samples_appended_total{type="float",user="user1"} 101
+			cortex_ingester_tsdb_head_samples_appended_total{type="float",user="user2"} 101
 
 			# HELP cortex_ingester_tsdb_checkpoint_deletions_failed_total Total number of TSDB checkpoint deletions that failed.
 			# TYPE cortex_ingester_tsdb_checkpoint_deletions_failed_total counter


### PR DESCRIPTION
**What this PR does**:
We have the `user` and `type` dimensions in the wrong order for this metric. This PR is fixing that.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
