### PR TITLE
Backfilling the new limits when updating the metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [ENHANCEMENT] Distributor/Querier: Clean stale per-ingester metrics after ingester restarts. #5930
 * [ENHANCEMENT] Distributor/Ring: Allow disabling detailed ring metrics by ring member. #5931
 * [ENHANCEMENT] KV: Etcd Added etcd.ping-without-stream-allowed parameter to disable/enable  PermitWithoutStream #5933
+* [ENHANCEMENT] Ingester: Add a new `max_series_per_label_set` limit. This limit functions similarly to `max_series_per_metric`, but allowing users to define the maximum number of series per LabelSet. #5950 
 * [CHANGE] Upgrade Dockerfile Node version from 14x to 18x. #5906
 * [CHANGE] Query Frontend/Ruler: Omit empty data field in API response. #5953 #5954
 * [BUGFIX] Configsdb: Fix endline issue in db password. #5920

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [ENHANCEMENT] Distributor/Querier: Clean stale per-ingester metrics after ingester restarts. #5930
 * [ENHANCEMENT] Distributor/Ring: Allow disabling detailed ring metrics by ring member. #5931
 * [ENHANCEMENT] KV: Etcd Added etcd.ping-without-stream-allowed parameter to disable/enable  PermitWithoutStream #5933
-* [ENHANCEMENT] Ingester: Add a new `max_series_per_label_set` limit. This limit functions similarly to `max_series_per_metric`, but allowing users to define the maximum number of series per LabelSet. #5950 
+* [ENHANCEMENT] Ingester: Add a new `max_series_per_label_set` limit. This limit functions similarly to `max_series_per_metric`, but allowing users to define the maximum number of series per LabelSet. #5950
 * [CHANGE] Upgrade Dockerfile Node version from 14x to 18x. #5906
 * [CHANGE] Query Frontend/Ruler: Omit empty data field in API response. #5953 #5954
 * [BUGFIX] Configsdb: Fix endline issue in db password. #5920

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -105,6 +105,8 @@ func (l *Limiter) AssertMaxMetricsWithMetadataPerUser(userID string, metrics int
 	return errMaxMetadataPerUserLimitExceeded
 }
 
+// AssertMaxSeriesPerLabelSet limit has not been reached compared to the current
+// number of metrics with metadata in input and returns an error if so.
 func (l *Limiter) AssertMaxSeriesPerLabelSet(userID string, metric labels.Labels, f func(validation.MaxSeriesPerLabelSet) (int, error)) error {
 	m := l.maxSeriesPerLabelSet(userID, metric)
 	for _, limit := range m {


### PR DESCRIPTION
**What this PR does**:
Follow up of https://github.com/cortexproject/cortex/pull/5950

This PR is adding some missing things:
* Changelog
* Add the `per_labelset_series_limit` dimention on the `cortex_discarded_samples_total` metric
* Backfill the new limits when Updating the `cortex_ingester_active_series_per_labelset`
   * Before this change, a new metric "matching" the new limits needed to be added so we could backfill it. 


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
