### PR TITLE
[Flaky test ] Using minio live probe to check if the minio is running

### DIFF
--- a/integration/e2e/db/db.go
+++ b/integration/e2e/db/db.go
@@ -33,7 +33,7 @@ func newMinio(port int, envVars map[string]string, bktNames ...string) *e2e.HTTP
 		images.Minio,
 		// Create the "cortex" bucket before starting minio
 		e2e.NewCommandWithoutEntrypoint("sh", "-c", strings.Join(commands, " && ")),
-		e2e.NewHTTPReadinessProbe(port, "/minio/health/ready", 200, 200),
+		e2e.NewHTTPReadinessProbe(port, "/minio/health/live", 200, 200),
 		port,
 	)
 	envVars["MINIO_ACCESS_KEY"] = MinioAccessKey


### PR DESCRIPTION
**What this PR does**:
Using `minio/health/live` instead of `/minio/health/ready` to determine if the minio is running.

The Liveness probe is deeper than the ready probe as explained here:

https://gist.github.com/nitisht/0c11d8c670f565b58d930b526ba0f2ed

```
 17:12:57 Starting minio-9000
17:12:57 Ports for container: e2e-cortex-test-minio-9000 Mapping: map[9000:32775]
    alertmanager_test.go:169: 
        	Error Trace:	/home/runner/work/cortex/cortex/integration/alertmanager_test.go:169
        	Error:      	Received unexpected error:
        	            	Server not initialized, please try again.
        	            	upload s3 object
        	            	github.com/thanos-io/objstore/providers/s3.(*Bucket).Upload
        	            		/home/runner/work/cortex/cortex/vendor/github.com/thanos-io/objstore/providers/s3/s3.go:514
        	            	github.com/cortexproject/cortex/integration.TestAlertmanagerClustering
        	            		/home/runner/work/cortex/cortex/integration/alertmanager_test.go:168
        	            	testing.tRunner
        	            		/opt/hostedtoolcache/go/1.21.9/x64/src/testing/testing.go:1595
        	            	runtime.goexit
        	            		/opt/hostedtoolcache/go/1.21.9/x64/src/runtime/asm_amd64.s:1650
        	Test:       	TestAlertmanagerClustering
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
