### PR TITLE
Remove `query_store_for_labels_enabled` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [CHANGE] Upgrade Dockerfile Node version from 14x to 18x. #5906
+* [CHANGE] Ingester: Remove `-querier.query-store-for-labels-enabled` flag. Querying long-term store for labels is always enabled. #5984
 * [ENHANCEMENT] Query Frontend/Querier: Added store gateway postings touched count and touched size in Querier stats and log in Query Frontend. #5892
 * [ENHANCEMENT] Query Frontend/Querier: Returns `warnings` on prometheus query responses. #5916
 * [ENHANCEMENT] Ingester: Allowing to configure `-blocks-storage.tsdb.head-compaction-interval` flag up to 30 min and add a jitter on the first head compaction. #5919 #5928

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -117,12 +117,6 @@ querier:
   # CLI flag: -querier.query-ingesters-within
   [query_ingesters_within: <duration> | default = 0s]
 
-  # Deprecated (Querying long-term store for labels will be always enabled in
-  # the future.): Query long-term store for series, label values and label names
-  # APIs.
-  # CLI flag: -querier.query-store-for-labels-enabled
-  [query_store_for_labels_enabled: <boolean> | default = false]
-
   # Enable returning samples stats per steps in query response.
   # CLI flag: -querier.per-step-stats-enabled
   [per_step_stats_enabled: <boolean> | default = false]

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3644,11 +3644,6 @@ The `querier_config` configures the Cortex querier.
 # CLI flag: -querier.query-ingesters-within
 [query_ingesters_within: <duration> | default = 0s]
 
-# Deprecated (Querying long-term store for labels will be always enabled in the
-# future.): Query long-term store for series, label values and label names APIs.
-# CLI flag: -querier.query-store-for-labels-enabled
-[query_store_for_labels_enabled: <boolean> | default = false]
-
 # Enable returning samples stats per steps in query response.
 # CLI flag: -querier.per-step-stats-enabled
 [per_step_stats_enabled: <boolean> | default = false]

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -361,18 +361,6 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		}
 
-		// In this test we do ensure that the /series start/end time is ignored and Cortex
-		// always returns series in ingesters memory. No need to repeat it for each user.
-		if userID == 0 {
-			start := now.Add(-1000 * time.Hour)
-			end := now.Add(-999 * time.Hour)
-
-			result, err := c.Series([]string{"series_1"}, start, end)
-			require.NoError(t, err)
-			require.Len(t, result, 1)
-			assert.Equal(t, model.LabelSet{labels.MetricName: "series_1"}, result[0])
-		}
-
 		// No need to repeat the query 400 test for each user.
 		if userID == 0 {
 			start := time.Unix(1595846748, 806*1e6)
@@ -400,7 +388,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 
 	wg.Wait()
 
-	extra := float64(3)
+	extra := float64(2)
 	if cfg.testMissingMetricName {
 		extra++
 	}

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -403,7 +403,6 @@ func (t *Cortex) initIngesterService() (serv services.Service, err error) {
 	t.Cfg.Ingester.DistributorShardingStrategy = t.Cfg.Distributor.ShardingStrategy
 	t.Cfg.Ingester.DistributorShardByAllLabels = t.Cfg.Distributor.ShardByAllLabels
 	t.Cfg.Ingester.InstanceLimitsFn = ingesterInstanceLimits(t.RuntimeConfig)
-	t.Cfg.Ingester.QueryStoreForLabels = t.Cfg.Querier.QueryStoreForLabels
 	t.Cfg.Ingester.QueryIngestersWithin = t.Cfg.Querier.QueryIngestersWithin
 	t.tsdbIngesterConfig()
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -120,7 +120,6 @@ type Config struct {
 	DistributorShardByAllLabels bool   `yaml:"-"`
 
 	// Injected at runtime and read from querier config.
-	QueryStoreForLabels  bool          `yaml:"-"`
 	QueryIngestersWithin time.Duration `yaml:"-"`
 
 	DefaultLimits    InstanceLimits         `yaml:"instance_limits"`
@@ -1426,7 +1425,7 @@ func (i *Ingester) labelsValuesCommon(ctx context.Context, req *client.LabelValu
 		return &client.LabelValuesResponse{}, cleanup, nil
 	}
 
-	mint, maxt, err := metadataQueryRange(startTimestampMs, endTimestampMs, db, i.cfg.QueryStoreForLabels, i.cfg.QueryIngestersWithin)
+	mint, maxt, err := metadataQueryRange(startTimestampMs, endTimestampMs, db, i.cfg.QueryIngestersWithin)
 	if err != nil {
 		return nil, cleanup, err
 	}
@@ -1506,7 +1505,7 @@ func (i *Ingester) labelNamesCommon(ctx context.Context, req *client.LabelNamesR
 		return &client.LabelNamesResponse{}, cleanup, nil
 	}
 
-	mint, maxt, err := metadataQueryRange(req.StartTimestampMs, req.EndTimestampMs, db, i.cfg.QueryStoreForLabels, i.cfg.QueryIngestersWithin)
+	mint, maxt, err := metadataQueryRange(req.StartTimestampMs, req.EndTimestampMs, db, i.cfg.QueryIngestersWithin)
 	if err != nil {
 		return nil, cleanup, err
 	}
@@ -1586,7 +1585,7 @@ func (i *Ingester) metricsForLabelMatchersCommon(ctx context.Context, req *clien
 		return nil, cleanup, err
 	}
 
-	mint, maxt, err := metadataQueryRange(req.StartTimestampMs, req.EndTimestampMs, db, i.cfg.QueryStoreForLabels, i.cfg.QueryIngestersWithin)
+	mint, maxt, err := metadataQueryRange(req.StartTimestampMs, req.EndTimestampMs, db, i.cfg.QueryIngestersWithin)
 	if err != nil {
 		return nil, cleanup, err
 	}
@@ -2755,8 +2754,8 @@ func (i *Ingester) flushHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // metadataQueryRange returns the best range to query for metadata queries based on the timerange in the ingester.
-func metadataQueryRange(queryStart, queryEnd int64, db *userTSDB, queryStoreForLabels bool, queryIngestersWithin time.Duration) (mint, maxt int64, err error) {
-	if queryIngestersWithin > 0 && queryStoreForLabels {
+func metadataQueryRange(queryStart, queryEnd int64, db *userTSDB, queryIngestersWithin time.Duration) (mint, maxt int64, err error) {
+	if queryIngestersWithin > 0 {
 		// If the feature for querying metadata from store-gateway is enabled,
 		// then we don't want to manipulate the mint and maxt.
 		return queryStart, queryEnd, nil

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -2184,7 +2184,6 @@ func Test_Ingester_MetricsForLabelMatchers(t *testing.T) {
 		to                   int64
 		matchers             []*client.LabelMatchers
 		expected             []*cortexpb.Metric
-		queryStoreForLabels  bool
 		queryIngestersWithin time.Duration
 	}{
 		"should return an empty response if no metric match": {
@@ -2254,7 +2253,6 @@ func Test_Ingester_MetricsForLabelMatchers(t *testing.T) {
 			expected: []*cortexpb.Metric{
 				{Labels: cortexpb.FromLabelsToLabelAdapters(fixtures[0].lbls)},
 			},
-			queryStoreForLabels:  true,
 			queryIngestersWithin: time.Hour,
 		},
 		"should not return duplicated metrics on overlapping matchers": {
@@ -2323,7 +2321,6 @@ func Test_Ingester_MetricsForLabelMatchers(t *testing.T) {
 				EndTimestampMs:   testData.to,
 				MatchersSet:      testData.matchers,
 			}
-			i.cfg.QueryStoreForLabels = testData.queryStoreForLabels
 			i.cfg.QueryIngestersWithin = testData.queryIngestersWithin
 			res, err := i.MetricsForLabelMatchers(ctx, req)
 			require.NoError(t, err)

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -190,7 +190,7 @@ func TestShouldSortSeriesIfQueryingMultipleQueryables(t *testing.T) {
 	}
 
 	distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&unorderedResponse, nil)
-	distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, batch.NewChunkMergeIterator, cfg.QueryIngestersWithin, cfg.QueryStoreForLabels)
+	distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, batch.NewChunkMergeIterator, cfg.QueryIngestersWithin)
 
 	tCases := []struct {
 		name                 string
@@ -363,7 +363,7 @@ func TestLimits(t *testing.T) {
 		response: &streamResponse,
 	}
 
-	distributorQueryableStreaming := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, batch.NewChunkMergeIterator, cfg.QueryIngestersWithin, cfg.QueryStoreForLabels)
+	distributorQueryableStreaming := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, batch.NewChunkMergeIterator, cfg.QueryIngestersWithin)
 
 	tCases := []struct {
 		name                 string


### PR DESCRIPTION
**What this PR does**:
This configuration is deprecated for a long time.

This PR is removing this config from the codebase:

```
# Deprecated (Querying long-term store for labels will be always enabled in the
# future.): Query long-term store for series, label values and label names APIs.
# CLI flag: -querier.query-store-for-labels-enabled
[query_store_for_labels_enabled: <boolean> | default = false]
```



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
