### PR TITLE
Using the `random` created on the test instead the default rand

### DIFF
--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -2442,7 +2442,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 				t.Run(testName, func(t *testing.T) {
 					// Randomise the seed but log it in case we need to reproduce the test on failure.
 					seed := time.Now().UnixNano()
-					rand.New(rand.NewSource(seed))
+					rnd := rand.New(rand.NewSource(seed))
 					t.Log("random generator seed:", seed)
 
 					// Initialise the ring.
@@ -2485,7 +2485,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 					for i := 1; i <= numEvents; i++ {
 						currTime = currTime.Add(delayBetweenEvents)
 
-						switch r := rand.Intn(100); {
+						switch r := rnd.Intn(100); {
 						case r < 80:
 							// Scale up instances by 1.
 							instanceID := fmt.Sprintf("instance-%d", nextInstanceID)
@@ -2508,7 +2508,7 @@ func TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy(t *testing.T) {
 
 							sort.Strings(instanceIDs)
 
-							idxToRemove := rand.Intn(len(instanceIDs))
+							idxToRemove := rnd.Intn(len(instanceIDs))
 							idToRemove := instanceIDs[idxToRemove]
 							delete(ringDesc.Ingesters, idToRemove)
 


### PR DESCRIPTION
**What this PR does**:
* seems we wanted to use the random with a seed to make the fuzzy test reproducible locally but we were not using the `rnd` struct with the defined seed to get the random numbers.
* This will make easier to reproduce the test locally when it fail.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
