### PR TITLE
Changing the per labelset config to be more generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [ENHANCEMENT] Distributor/Querier: Clean stale per-ingester metrics after ingester restarts. #5930
 * [ENHANCEMENT] Distributor/Ring: Allow disabling detailed ring metrics by ring member. #5931
 * [ENHANCEMENT] KV: Etcd Added etcd.ping-without-stream-allowed parameter to disable/enable  PermitWithoutStream #5933
-* [ENHANCEMENT] Ingester: Add a new `max_series_per_label_set` limit. This limit functions similarly to `max_series_per_metric`, but allowing users to define the maximum number of series per LabelSet. #5950
+* [ENHANCEMENT] Ingester: Add a new `limits_per_label_set` limit. This limit functions similarly to `max_series_per_metric`, but allowing users to define the maximum number of series per LabelSet. #5950 #5993
 * [ENHANCEMENT] Store Gateway: Log gRPC requests together with headers configured in `http_request_headers_to_log`. #5958
 * [BUGFIX] Configsdb: Fix endline issue in db password. #5920
 * [BUGFIX] Ingester: Fix `user` and `type` labels for the `cortex_ingester_tsdb_head_samples_appended_total` TSDB metric. #5952

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3172,9 +3172,9 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -ingester.max-global-series-per-metric
 [max_global_series_per_metric: <int> | default = 0]
 
-# [Experimental] The maximum number of active series per LabelSet, across the
-# cluster before replication. Empty list to disable.
-[max_series_per_label_set: <list of MaxSeriesPerLabelSet> | default = []]
+# [Experimental] Enable limits per LabelSet. Supported limits per labelSet:
+# [max_series]
+[limits_per_label_set: <list of LimitsPerLabelSet> | default = []]
 
 # The maximum number of active metrics with metadata per user, per ingester. 0
 # to disable.
@@ -5314,11 +5314,13 @@ otel:
     [tls_insecure_skip_verify: <boolean> | default = false]
 ```
 
-### `MaxSeriesPerLabelSet`
+### `LimitsPerLabelSet`
 
 ```yaml
-# The maximum number of active series per LabelSet before replication.
-[limit: <int> | default = ]
+limits:
+  # The maximum number of active series per LabelSet, across the cluster before
+  # replication.
+  [max_series: <int> | default = ]
 
 # LabelSet which the limit should be applied.
 [label_set: <map of string (labelName) to string (labelValue)> | default = []]

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -5319,7 +5319,8 @@ otel:
 ```yaml
 limits:
   # The maximum number of active series per LabelSet, across the cluster before
-  # replication.
+  # replication. Setting the value 0 will enable the monitoring (metrics) but
+  # would not enforce any limits.
   [max_series: <int> | default = ]
 
 # LabelSet which the limit should be applied.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -943,7 +943,7 @@ func (i *Ingester) updateActiveSeries(ctx context.Context) {
 
 		userDB.activeSeries.Purge(purgeTime)
 		i.metrics.activeSeriesPerUser.WithLabelValues(userID).Set(float64(userDB.activeSeries.Active()))
-		if err := userDB.labelSetCounter.UpdateMetric(ctx, userDB, i.metrics.activeSeriesPerLabelSet); err != nil {
+		if err := userDB.labelSetCounter.UpdateMetric(ctx, userDB, i.metrics); err != nil {
 			level.Warn(i.logger).Log("msg", "failed to update per labelSet metrics", "user", userID, "err", err)
 		}
 	}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -113,18 +113,22 @@ func TestIngesterPerLabelsetLimitExceeded(t *testing.T) {
 	userID := "1"
 	registry := prometheus.NewRegistry()
 
-	limits.MaxSeriesPerLabelSet = []validation.MaxSeriesPerLabelSet{
+	limits.LimitsPerLabelSet = []validation.LimitsPerLabelSet{
 		{
 			LabelSet: labels.FromMap(map[string]string{
 				"label1": "value1",
 			}),
-			Limit: 3,
+			Limits: validation.LimitsPerLabelSetEntry{
+				MaxSeries: 3,
+			},
 		},
 		{
 			LabelSet: labels.FromMap(map[string]string{
 				"label2": "value2",
 			}),
-			Limit: 2,
+			Limits: validation.LimitsPerLabelSetEntry{
+				MaxSeries: 2,
+			},
 		},
 	}
 	tenantLimits := newMockTenantLimits(map[string]*validation.Limits{userID: &limits})
@@ -152,12 +156,12 @@ func TestIngesterPerLabelsetLimitExceeded(t *testing.T) {
 	samples := []cortexpb.Sample{{Value: 2, TimestampMs: 10}}
 
 	// Create first series within the limits
-	for _, set := range limits.MaxSeriesPerLabelSet {
+	for _, set := range limits.LimitsPerLabelSet {
 		lbls := []string{labels.MetricName, "metric_name"}
 		for _, lbl := range set.LabelSet {
 			lbls = append(lbls, lbl.Name, lbl.Value)
 		}
-		for i := 0; i < set.Limit; i++ {
+		for i := 0; i < set.Limits.MaxSeries; i++ {
 			_, err = ing.Push(ctx, cortexpb.ToWriteRequest(
 				[]labels.Labels{labels.FromStrings(append(lbls, "extraLabel", fmt.Sprintf("extraValue%v", i))...)}, samples, nil, nil, cortexpb.API))
 			require.NoError(t, err)
@@ -166,14 +170,18 @@ func TestIngesterPerLabelsetLimitExceeded(t *testing.T) {
 
 	ing.updateActiveSeries(ctx)
 	require.NoError(t, testutil.GatherAndCompare(registry, bytes.NewBufferString(`
-				# HELP cortex_ingester_active_series_per_labelset Number of currently active series per user and labelset.
-				# TYPE cortex_ingester_active_series_per_labelset gauge
-				cortex_ingester_active_series_per_labelset{labelset="{label1=\"value1\"}",user="1"} 3
-				cortex_ingester_active_series_per_labelset{labelset="{label2=\"value2\"}",user="1"} 2
-	`), "cortex_ingester_active_series_per_labelset", "cortex_discarded_samples_total"))
+				# HELP cortex_ingester_limits_per_labelset Limits per user and labelset.
+				# TYPE cortex_ingester_limits_per_labelset gauge
+				cortex_ingester_limits_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_limits_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+				# HELP cortex_ingester_usage_per_labelset Current usage per user and labelset.
+				# TYPE cortex_ingester_usage_per_labelset gauge
+				cortex_ingester_usage_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_usage_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+	`), "cortex_ingester_usage_per_labelset", "cortex_ingester_limits_per_labelset", "cortex_discarded_samples_total"))
 
 	// Should impose limits
-	for _, set := range limits.MaxSeriesPerLabelSet {
+	for _, set := range limits.LimitsPerLabelSet {
 		lbls := []string{labels.MetricName, "metric_name"}
 		for _, lbl := range set.LabelSet {
 			lbls = append(lbls, lbl.Name, lbl.Value)
@@ -191,29 +199,39 @@ func TestIngesterPerLabelsetLimitExceeded(t *testing.T) {
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
 				cortex_discarded_samples_total{reason="per_labelset_series_limit",user="1"} 2
-				# HELP cortex_ingester_active_series_per_labelset Number of currently active series per user and labelset.
-				# TYPE cortex_ingester_active_series_per_labelset gauge
-				cortex_ingester_active_series_per_labelset{labelset="{label1=\"value1\"}",user="1"} 3
-				cortex_ingester_active_series_per_labelset{labelset="{label2=\"value2\"}",user="1"} 2
-	`), "cortex_ingester_active_series_per_labelset", "cortex_discarded_samples_total"))
+				# HELP cortex_ingester_limits_per_labelset Limits per user and labelset.
+				# TYPE cortex_ingester_limits_per_labelset gauge
+				cortex_ingester_limits_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_limits_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+				# HELP cortex_ingester_usage_per_labelset Current usage per user and labelset.
+				# TYPE cortex_ingester_usage_per_labelset gauge
+				cortex_ingester_usage_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_usage_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+	`), "cortex_ingester_usage_per_labelset", "cortex_ingester_limits_per_labelset", "cortex_discarded_samples_total"))
 
 	// Should apply composite limits
-	limits.MaxSeriesPerLabelSet = append(limits.MaxSeriesPerLabelSet,
-		validation.MaxSeriesPerLabelSet{LabelSet: labels.FromMap(map[string]string{
+	limits.LimitsPerLabelSet = append(limits.LimitsPerLabelSet,
+		validation.LimitsPerLabelSet{LabelSet: labels.FromMap(map[string]string{
 			"comp1": "compValue1",
 		}),
-			Limit: 10,
+			Limits: validation.LimitsPerLabelSetEntry{
+				MaxSeries: 10,
+			},
 		},
-		validation.MaxSeriesPerLabelSet{LabelSet: labels.FromMap(map[string]string{
+		validation.LimitsPerLabelSet{LabelSet: labels.FromMap(map[string]string{
 			"comp2": "compValue2",
 		}),
-			Limit: 10,
+			Limits: validation.LimitsPerLabelSetEntry{
+				MaxSeries: 10,
+			},
 		},
-		validation.MaxSeriesPerLabelSet{LabelSet: labels.FromMap(map[string]string{
+		validation.LimitsPerLabelSet{LabelSet: labels.FromMap(map[string]string{
 			"comp1": "compValue1",
 			"comp2": "compValue2",
 		}),
-			Limit: 2,
+			Limits: validation.LimitsPerLabelSetEntry{
+				MaxSeries: 2,
+			},
 		},
 	)
 
@@ -228,14 +246,21 @@ func TestIngesterPerLabelsetLimitExceeded(t *testing.T) {
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
 				cortex_discarded_samples_total{reason="per_labelset_series_limit",user="1"} 2
-				# HELP cortex_ingester_active_series_per_labelset Number of currently active series per user and labelset.
-				# TYPE cortex_ingester_active_series_per_labelset gauge
-				cortex_ingester_active_series_per_labelset{labelset="{comp1=\"compValue1\", comp2=\"compValue2\"}",user="1"} 0
-				cortex_ingester_active_series_per_labelset{labelset="{comp1=\"compValue1\"}",user="1"} 0
-				cortex_ingester_active_series_per_labelset{labelset="{comp2=\"compValue2\"}",user="1"} 0
-				cortex_ingester_active_series_per_labelset{labelset="{label1=\"value1\"}",user="1"} 3
-				cortex_ingester_active_series_per_labelset{labelset="{label2=\"value2\"}",user="1"} 2
-	`), "cortex_ingester_active_series_per_labelset", "cortex_discarded_samples_total"))
+				# HELP cortex_ingester_limits_per_labelset Limits per user and labelset.
+				# TYPE cortex_ingester_limits_per_labelset gauge
+				cortex_ingester_limits_per_labelset{labelset="{comp1=\"compValue1\", comp2=\"compValue2\"}",limit="max_series",user="1"} 2
+				cortex_ingester_limits_per_labelset{labelset="{comp1=\"compValue1\"}",limit="max_series",user="1"} 10
+				cortex_ingester_limits_per_labelset{labelset="{comp2=\"compValue2\"}",limit="max_series",user="1"} 10
+				cortex_ingester_limits_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_limits_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+				# HELP cortex_ingester_usage_per_labelset Current usage per user and labelset.
+				# TYPE cortex_ingester_usage_per_labelset gauge
+				cortex_ingester_usage_per_labelset{labelset="{comp1=\"compValue1\", comp2=\"compValue2\"}",limit="max_series",user="1"} 0
+				cortex_ingester_usage_per_labelset{labelset="{comp1=\"compValue1\"}",limit="max_series",user="1"} 0
+				cortex_ingester_usage_per_labelset{labelset="{comp2=\"compValue2\"}",limit="max_series",user="1"} 0
+				cortex_ingester_usage_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_usage_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+	`), "cortex_ingester_usage_per_labelset", "cortex_ingester_limits_per_labelset", "cortex_discarded_samples_total"))
 
 	// Adding 5 metrics with only 1 label
 	for i := 0; i < 5; i++ {
@@ -266,22 +291,31 @@ func TestIngesterPerLabelsetLimitExceeded(t *testing.T) {
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
 				cortex_discarded_samples_total{reason="per_labelset_series_limit",user="1"} 3
-				# HELP cortex_ingester_active_series_per_labelset Number of currently active series per user and labelset.
-				# TYPE cortex_ingester_active_series_per_labelset gauge
-				cortex_ingester_active_series_per_labelset{labelset="{label1=\"value1\"}",user="1"} 3
-				cortex_ingester_active_series_per_labelset{labelset="{label2=\"value2\"}",user="1"} 2
-				cortex_ingester_active_series_per_labelset{labelset="{comp1=\"compValue1\", comp2=\"compValue2\"}",user="1"} 2
-				cortex_ingester_active_series_per_labelset{labelset="{comp1=\"compValue1\"}",user="1"} 7
-				cortex_ingester_active_series_per_labelset{labelset="{comp2=\"compValue2\"}",user="1"} 2
-	`), "cortex_ingester_active_series_per_labelset", "cortex_discarded_samples_total"))
+				# HELP cortex_ingester_limits_per_labelset Limits per user and labelset.
+				# TYPE cortex_ingester_limits_per_labelset gauge
+				cortex_ingester_limits_per_labelset{labelset="{comp1=\"compValue1\", comp2=\"compValue2\"}",limit="max_series",user="1"} 2
+				cortex_ingester_limits_per_labelset{labelset="{comp1=\"compValue1\"}",limit="max_series",user="1"} 10
+				cortex_ingester_limits_per_labelset{labelset="{comp2=\"compValue2\"}",limit="max_series",user="1"} 10
+				cortex_ingester_limits_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_limits_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+				# HELP cortex_ingester_usage_per_labelset Current usage per user and labelset.
+				# TYPE cortex_ingester_usage_per_labelset gauge
+				cortex_ingester_usage_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_usage_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+				cortex_ingester_usage_per_labelset{labelset="{comp1=\"compValue1\", comp2=\"compValue2\"}",limit="max_series",user="1"} 2
+				cortex_ingester_usage_per_labelset{labelset="{comp1=\"compValue1\"}",limit="max_series",user="1"} 7
+				cortex_ingester_usage_per_labelset{labelset="{comp2=\"compValue2\"}",limit="max_series",user="1"} 2
+		`), "cortex_ingester_usage_per_labelset", "cortex_ingester_limits_per_labelset", "cortex_discarded_samples_total"))
 
 	// Should bootstrap and apply limits when configuration change
-	limits.MaxSeriesPerLabelSet = append(limits.MaxSeriesPerLabelSet,
-		validation.MaxSeriesPerLabelSet{LabelSet: labels.FromMap(map[string]string{
+	limits.LimitsPerLabelSet = append(limits.LimitsPerLabelSet,
+		validation.LimitsPerLabelSet{LabelSet: labels.FromMap(map[string]string{
 			labels.MetricName: "metric_name",
 			"comp2":           "compValue2",
 		}),
-			Limit: 3, // we already have 2 so we need to allow 1 more
+			Limits: validation.LimitsPerLabelSetEntry{
+				MaxSeries: 3, // we already have 2 so we need to allow 1 more
+			},
 		},
 	)
 
@@ -304,29 +338,41 @@ func TestIngesterPerLabelsetLimitExceeded(t *testing.T) {
 
 	ing.updateActiveSeries(ctx)
 	require.NoError(t, testutil.GatherAndCompare(registry, bytes.NewBufferString(`
-				# HELP cortex_ingester_active_series_per_labelset Number of currently active series per user and labelset.
-				# TYPE cortex_ingester_active_series_per_labelset gauge
-				cortex_ingester_active_series_per_labelset{labelset="{__name__=\"metric_name\", comp2=\"compValue2\"}",user="1"} 3
-				cortex_ingester_active_series_per_labelset{labelset="{label1=\"value1\"}",user="1"} 3
-				cortex_ingester_active_series_per_labelset{labelset="{label2=\"value2\"}",user="1"} 2
-				cortex_ingester_active_series_per_labelset{labelset="{comp1=\"compValue1\", comp2=\"compValue2\"}",user="1"} 2
-				cortex_ingester_active_series_per_labelset{labelset="{comp1=\"compValue1\"}",user="1"} 7
-				cortex_ingester_active_series_per_labelset{labelset="{comp2=\"compValue2\"}",user="1"} 3
-	`), "cortex_ingester_active_series_per_labelset"))
+				# HELP cortex_ingester_limits_per_labelset Limits per user and labelset.
+				# TYPE cortex_ingester_limits_per_labelset gauge
+				cortex_ingester_limits_per_labelset{labelset="{__name__=\"metric_name\", comp2=\"compValue2\"}",limit="max_series",user="1"} 3
+				cortex_ingester_limits_per_labelset{labelset="{comp1=\"compValue1\", comp2=\"compValue2\"}",limit="max_series",user="1"} 2
+				cortex_ingester_limits_per_labelset{labelset="{comp1=\"compValue1\"}",limit="max_series",user="1"} 10
+				cortex_ingester_limits_per_labelset{labelset="{comp2=\"compValue2\"}",limit="max_series",user="1"} 10
+				cortex_ingester_limits_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_limits_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+				# HELP cortex_ingester_usage_per_labelset Current usage per user and labelset.
+				# TYPE cortex_ingester_usage_per_labelset gauge
+				cortex_ingester_usage_per_labelset{labelset="{__name__=\"metric_name\", comp2=\"compValue2\"}",limit="max_series",user="1"} 3
+				cortex_ingester_usage_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_usage_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+				cortex_ingester_usage_per_labelset{labelset="{comp1=\"compValue1\", comp2=\"compValue2\"}",limit="max_series",user="1"} 2
+				cortex_ingester_usage_per_labelset{labelset="{comp1=\"compValue1\"}",limit="max_series",user="1"} 7
+				cortex_ingester_usage_per_labelset{labelset="{comp2=\"compValue2\"}",limit="max_series",user="1"} 3
+	`), "cortex_ingester_usage_per_labelset", "cortex_ingester_limits_per_labelset"))
 
 	// Should remove metrics when the limits is removed
-	limits.MaxSeriesPerLabelSet = limits.MaxSeriesPerLabelSet[:2]
+	limits.LimitsPerLabelSet = limits.LimitsPerLabelSet[:2]
 	b, err = json.Marshal(limits)
 	require.NoError(t, err)
 	require.NoError(t, limits.UnmarshalJSON(b))
 	tenantLimits.setLimits(userID, &limits)
 	ing.updateActiveSeries(ctx)
 	require.NoError(t, testutil.GatherAndCompare(registry, bytes.NewBufferString(`
-				# HELP cortex_ingester_active_series_per_labelset Number of currently active series per user and labelset.
-				# TYPE cortex_ingester_active_series_per_labelset gauge
-				cortex_ingester_active_series_per_labelset{labelset="{label1=\"value1\"}",user="1"} 3
-				cortex_ingester_active_series_per_labelset{labelset="{label2=\"value2\"}",user="1"} 2
-	`), "cortex_ingester_active_series_per_labelset"))
+				# HELP cortex_ingester_limits_per_labelset Limits per user and labelset.
+				# TYPE cortex_ingester_limits_per_labelset gauge
+				cortex_ingester_limits_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_limits_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+				# HELP cortex_ingester_usage_per_labelset Current usage per user and labelset.
+				# TYPE cortex_ingester_usage_per_labelset gauge
+				cortex_ingester_usage_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_usage_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+	`), "cortex_ingester_usage_per_labelset", "cortex_ingester_limits_per_labelset"))
 
 	// Should persist between restarts
 	services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
@@ -336,11 +382,15 @@ func TestIngesterPerLabelsetLimitExceeded(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ing))
 	ing.updateActiveSeries(ctx)
 	require.NoError(t, testutil.GatherAndCompare(registry, bytes.NewBufferString(`
-				# HELP cortex_ingester_active_series_per_labelset Number of currently active series per user and labelset.
-				# TYPE cortex_ingester_active_series_per_labelset gauge
-				cortex_ingester_active_series_per_labelset{labelset="{label1=\"value1\"}",user="1"} 3
-				cortex_ingester_active_series_per_labelset{labelset="{label2=\"value2\"}",user="1"} 2
-	`), "cortex_ingester_active_series_per_labelset"))
+				# HELP cortex_ingester_limits_per_labelset Limits per user and labelset.
+				# TYPE cortex_ingester_limits_per_labelset gauge
+				cortex_ingester_limits_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_limits_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+				# HELP cortex_ingester_usage_per_labelset Current usage per user and labelset.
+				# TYPE cortex_ingester_usage_per_labelset gauge
+				cortex_ingester_usage_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 3
+				cortex_ingester_usage_per_labelset{labelset="{label2=\"value2\"}",limit="max_series",user="1"} 2
+	`), "cortex_ingester_usage_per_labelset", "cortex_ingester_limits_per_labelset"))
 	services.StopAndAwaitTerminated(context.Background(), ing) //nolint:errcheck
 
 }

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -2,10 +2,11 @@ package ingester
 
 import (
 	"errors"
-	"github.com/prometheus/prometheus/model/labels"
+
 	"math"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -2,6 +2,7 @@ package ingester
 
 import (
 	"errors"
+	"github.com/prometheus/prometheus/model/labels"
 	"math"
 	"testing"
 
@@ -419,6 +420,90 @@ func TestLimiter_AssertMaxSeriesPerUser(t *testing.T) {
 			actual := limiter.AssertMaxSeriesPerUser("test", testData.series)
 
 			assert.Equal(t, testData.expected, actual)
+		})
+	}
+}
+
+func TestLimiter_AssertMaxSeriesPerLabelSet(t *testing.T) {
+
+	tests := map[string]struct {
+		limits                validation.Limits
+		expected              error
+		ringReplicationFactor int
+		ringIngesterCount     int
+		shardByAllLabels      bool
+		series                int
+	}{
+		"both local and global limit are disabled": {
+			ringReplicationFactor: 3,
+			ringIngesterCount:     10,
+			series:                200,
+			shardByAllLabels:      true,
+			limits: validation.Limits{
+				LimitsPerLabelSet: []validation.LimitsPerLabelSet{
+					{
+						LabelSet: labels.FromMap(map[string]string{"foo": "bar"}),
+						Limits: validation.LimitsPerLabelSetEntry{
+							MaxSeries: 0,
+						},
+					},
+				},
+			},
+		},
+		"current number of series is above the limit": {
+			ringReplicationFactor: 3,
+			ringIngesterCount:     10,
+			series:                200,
+			shardByAllLabels:      true,
+			expected:              errMaxSeriesPerLabelSetLimitExceeded{globalLimit: 10, localLimit: 3},
+			limits: validation.Limits{
+				LimitsPerLabelSet: []validation.LimitsPerLabelSet{
+					{
+						LabelSet: labels.FromMap(map[string]string{"foo": "bar"}),
+						Limits: validation.LimitsPerLabelSetEntry{
+							MaxSeries: 10,
+						},
+					},
+				},
+			},
+		},
+		"current number of series is below the limit and shard by all labels": {
+			ringReplicationFactor: 3,
+			ringIngesterCount:     10,
+			series:                2,
+			shardByAllLabels:      true,
+			limits: validation.Limits{
+				LimitsPerLabelSet: []validation.LimitsPerLabelSet{
+					{
+						LabelSet: labels.FromMap(map[string]string{"foo": "bar"}),
+						Limits: validation.LimitsPerLabelSetEntry{
+							MaxSeries: 10,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			// Mock the ring
+			ring := &ringCountMock{}
+			ring.On("HealthyInstancesCount").Return(testData.ringIngesterCount)
+			ring.On("ZonesCount").Return(1)
+
+			// Mock limits
+			limits, err := validation.NewOverrides(testData.limits, nil)
+			require.NoError(t, err)
+
+			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
+			actual := limiter.AssertMaxSeriesPerLabelSet("test", labels.FromStrings("foo", "bar"), func(set validation.LimitsPerLabelSet) (int, error) {
+				return testData.series, nil
+			})
+
+			assert.Equal(t, actual, testData.expected)
 		})
 	}
 }

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -37,8 +37,9 @@ type ingesterMetrics struct {
 	memSeriesRemovedTotal   *prometheus.CounterVec
 	memMetadataRemovedTotal *prometheus.CounterVec
 
-	activeSeriesPerUser     *prometheus.GaugeVec
-	activeSeriesPerLabelSet *prometheus.GaugeVec
+	activeSeriesPerUser *prometheus.GaugeVec
+	limitsPerLabelSet   *prometheus.GaugeVec
+	usagePerLabelSet    *prometheus.GaugeVec
 
 	// Global limit metrics
 	maxUsersGauge           prometheus.GaugeFunc
@@ -212,10 +213,15 @@ func newIngesterMetrics(r prometheus.Registerer,
 			return 0
 		}),
 
-		activeSeriesPerLabelSet: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_ingester_active_series_per_labelset",
-			Help: "Number of currently active series per user and labelset.",
-		}, []string{"user", "labelset"}),
+		limitsPerLabelSet: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_ingester_limits_per_labelset",
+			Help: "Limits per user and labelset.",
+		}, []string{"user", "limit", "labelset"}),
+
+		usagePerLabelSet: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_ingester_usage_per_labelset",
+			Help: "Current usage per user and labelset.",
+		}, []string{"user", "limit", "labelset"}),
 
 		// Not registered automatically, but only if activeSeriesEnabled is true.
 		activeSeriesPerUser: prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/index"
@@ -115,7 +114,7 @@ func newLabelSetCounter(limiter *Limiter) *labelSetCounter {
 }
 
 func (m *labelSetCounter) canAddSeriesForLabelSet(ctx context.Context, u *userTSDB, metric labels.Labels) error {
-	return m.limiter.AssertMaxSeriesPerLabelSet(u.userID, metric, func(set validation.MaxSeriesPerLabelSet) (int, error) {
+	return m.limiter.AssertMaxSeriesPerLabelSet(u.userID, metric, func(set validation.LimitsPerLabelSet) (int, error) {
 		s := m.shards[util.HashFP(model.Fingerprint(set.Hash))%numMetricCounterShards]
 		s.RLock()
 		if r, ok := s.valuesCounter[set.Hash]; ok {
@@ -129,7 +128,7 @@ func (m *labelSetCounter) canAddSeriesForLabelSet(ctx context.Context, u *userTS
 	})
 }
 
-func (m *labelSetCounter) backFillLimit(ctx context.Context, u *userTSDB, limit validation.MaxSeriesPerLabelSet, s *labelSetCounterShard) (int, error) {
+func (m *labelSetCounter) backFillLimit(ctx context.Context, u *userTSDB, limit validation.LimitsPerLabelSet, s *labelSetCounterShard) (int, error) {
 	ir, err := u.db.Head().Index()
 	if err != nil {
 		return 0, err
@@ -171,7 +170,7 @@ func (m *labelSetCounter) backFillLimit(ctx context.Context, u *userTSDB, limit 
 }
 
 func (m *labelSetCounter) increaseSeriesLabelSet(u *userTSDB, metric labels.Labels) {
-	limits := m.limiter.maxSeriesPerLabelSet(u.userID, metric)
+	limits := m.limiter.limitsPerLabelSets(u.userID, metric)
 	for _, l := range limits {
 		s := m.shards[util.HashFP(model.Fingerprint(l.Hash))%numMetricCounterShards]
 		s.Lock()
@@ -188,7 +187,7 @@ func (m *labelSetCounter) increaseSeriesLabelSet(u *userTSDB, metric labels.Labe
 }
 
 func (m *labelSetCounter) decreaseSeriesLabelSet(u *userTSDB, metric labels.Labels) {
-	limits := m.limiter.maxSeriesPerLabelSet(u.userID, metric)
+	limits := m.limiter.limitsPerLabelSets(u.userID, metric)
 	for _, l := range limits {
 		s := m.shards[util.HashFP(model.Fingerprint(l.Hash))%numMetricCounterShards]
 		s.Lock()
@@ -199,9 +198,9 @@ func (m *labelSetCounter) decreaseSeriesLabelSet(u *userTSDB, metric labels.Labe
 	}
 }
 
-func (m *labelSetCounter) UpdateMetric(ctx context.Context, u *userTSDB, vec *prometheus.GaugeVec) error {
-	currentLbsLimitHash := map[uint64]validation.MaxSeriesPerLabelSet{}
-	for _, l := range m.limiter.limits.MaxSeriesPerLabelSet(u.userID) {
+func (m *labelSetCounter) UpdateMetric(ctx context.Context, u *userTSDB, metrics *ingesterMetrics) error {
+	currentLbsLimitHash := map[uint64]validation.LimitsPerLabelSet{}
+	for _, l := range m.limiter.limits.LimitsPerLabelSet(u.userID) {
 		currentLbsLimitHash[l.Hash] = l
 	}
 
@@ -211,11 +210,13 @@ func (m *labelSetCounter) UpdateMetric(ctx context.Context, u *userTSDB, vec *pr
 		for h, entry := range s.valuesCounter {
 			// This limit no longer exists
 			if _, ok := currentLbsLimitHash[h]; !ok {
-				vec.DeleteLabelValues(u.userID, entry.labels.String())
+				metrics.usagePerLabelSet.DeleteLabelValues(u.userID, "max_series", entry.labels.String())
+				metrics.limitsPerLabelSet.DeleteLabelValues(u.userID, "max_series", entry.labels.String())
 				continue
 			}
+			metrics.usagePerLabelSet.WithLabelValues(u.userID, "max_series", entry.labels.String()).Set(float64(entry.count))
+			metrics.limitsPerLabelSet.WithLabelValues(u.userID, "max_series", entry.labels.String()).Set(float64(currentLbsLimitHash[h].Limits.MaxSeries))
 			delete(currentLbsLimitHash, h)
-			vec.WithLabelValues(u.userID, entry.labels.String()).Set(float64(entry.count))
 		}
 		s.RUnlock()
 	}
@@ -227,7 +228,8 @@ func (m *labelSetCounter) UpdateMetric(ctx context.Context, u *userTSDB, vec *pr
 		if err != nil {
 			return err
 		}
-		vec.WithLabelValues(u.userID, l.LabelSet.String()).Set(float64(count))
+		metrics.usagePerLabelSet.WithLabelValues(u.userID, "max_series", l.LabelSet.String()).Set(float64(count))
+		metrics.limitsPerLabelSet.WithLabelValues(u.userID, "max_series", l.LabelSet.String()).Set(float64(l.Limits.MaxSeries))
 	}
 
 	return nil

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -208,14 +208,15 @@ func (m *labelSetCounter) UpdateMetric(ctx context.Context, u *userTSDB, metrics
 		s := m.shards[i]
 		s.RLock()
 		for h, entry := range s.valuesCounter {
+			lbls := entry.labels.String()
 			// This limit no longer exists
 			if _, ok := currentLbsLimitHash[h]; !ok {
-				metrics.usagePerLabelSet.DeleteLabelValues(u.userID, "max_series", entry.labels.String())
-				metrics.limitsPerLabelSet.DeleteLabelValues(u.userID, "max_series", entry.labels.String())
+				metrics.usagePerLabelSet.DeleteLabelValues(u.userID, "max_series", lbls)
+				metrics.limitsPerLabelSet.DeleteLabelValues(u.userID, "max_series", lbls)
 				continue
 			}
-			metrics.usagePerLabelSet.WithLabelValues(u.userID, "max_series", entry.labels.String()).Set(float64(entry.count))
-			metrics.limitsPerLabelSet.WithLabelValues(u.userID, "max_series", entry.labels.String()).Set(float64(currentLbsLimitHash[h].Limits.MaxSeries))
+			metrics.usagePerLabelSet.WithLabelValues(u.userID, "max_series", lbls).Set(float64(entry.count))
+			metrics.limitsPerLabelSet.WithLabelValues(u.userID, "max_series", lbls).Set(float64(currentLbsLimitHash[h].Limits.MaxSeries))
 			delete(currentLbsLimitHash, h)
 		}
 		s.RUnlock()
@@ -228,8 +229,9 @@ func (m *labelSetCounter) UpdateMetric(ctx context.Context, u *userTSDB, metrics
 		if err != nil {
 			return err
 		}
-		metrics.usagePerLabelSet.WithLabelValues(u.userID, "max_series", l.LabelSet.String()).Set(float64(count))
-		metrics.limitsPerLabelSet.WithLabelValues(u.userID, "max_series", l.LabelSet.String()).Set(float64(l.Limits.MaxSeries))
+		lbls := l.LabelSet.String()
+		metrics.usagePerLabelSet.WithLabelValues(u.userID, "max_series", lbls).Set(float64(count))
+		metrics.limitsPerLabelSet.WithLabelValues(u.userID, "max_series", lbls).Set(float64(l.Limits.MaxSeries))
 	}
 
 	return nil

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -78,7 +78,7 @@ type TimeWindow struct {
 }
 
 type LimitsPerLabelSetEntry struct {
-	MaxSeries int `yaml:"max_series" json:"max_series" doc:"nocli|description=The maximum number of active series per LabelSet, across the cluster before replication."`
+	MaxSeries int `yaml:"max_series" json:"max_series" doc:"nocli|description=The maximum number of active series per LabelSet, across the cluster before replication. Setting the value 0 will enable the monitoring (metrics) but would not enforce any limits."`
 }
 
 type LimitsPerLabelSet struct {

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -174,6 +174,37 @@ func TestLimitsTagsYamlMatchJson(t *testing.T) {
 	assert.Empty(t, mismatch, "expected no mismatched JSON and YAML tags")
 }
 
+func TestOverrides_LimitsPerLabelSet(t *testing.T) {
+	inputYAML := `
+limits_per_label_set:
+  - label_set:
+      labelName1: LabelValue1
+    limits:
+      max_series: 10
+`
+
+	limitsYAML := Limits{}
+	err := yaml.Unmarshal([]byte(inputYAML), &limitsYAML)
+	require.NoError(t, err)
+	require.Len(t, limitsYAML.LimitsPerLabelSet, 1)
+	require.Len(t, limitsYAML.LimitsPerLabelSet[0].LabelSet, 1)
+	require.Equal(t, limitsYAML.LimitsPerLabelSet[0].Limits.MaxSeries, 10)
+
+	duplicatedInputYAML := `
+limits_per_label_set:
+  - label_set:
+      labelName1: LabelValue1
+    limits:
+      max_series: 10
+  - label_set:
+      labelName1: LabelValue1
+    limits:
+      max_series: 10
+`
+	err = yaml.Unmarshal([]byte(duplicatedInputYAML), &limitsYAML)
+	require.Equal(t, err, errDuplicatePerLabelSetLimit)
+}
+
 func TestLimitsStringDurationYamlMatchJson(t *testing.T) {
 	inputYAML := `
 max_query_lookback: 1s


### PR DESCRIPTION
**What this PR does**:
MaxSeriesPerLabelset was introduced on https://github.com/cortexproject/cortex/pull/5950 but the configuration format would not allow us in the future to configure more limits as "samples ingested per labelset"

This PR is just changing the configuration to be a bit more generic where we can extend to other limits in the future:

Config Before:

```
max_series_per_label_set:
  - label_set:
      labelName1: LabelValue1
    limit: 10
  - label_set:
      labelName1: LabelValue1
      labelName2: LabelValue2
    limit: 3
```

Config Now:

```
limits_per_label_set:
  - label_set:
      labelName1: LabelValue1
    limits:
      max_series: 10
  - label_set:
      labelName1: LabelValue1
      labelName2: LabelValue2
    limits:
      max_series: 3
```

We also changed the usage metric from `cortex_ingester_active_series_per_labelset ` to `cortex_ingester_usage_per_labelset` and created a new metric with the configured limit: `cortex_ingester_limits_per_labelset` as follow:

```
cortex_ingester_limits_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 10
cortex_ingester_usage_per_labelset{labelset="{label1=\"value1\"}",limit="max_series",user="1"} 2
```



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
