### PR TITLE
support querying native histograms in query frontend

### DIFF
--- a/pkg/querier/tripperware/query.pb.go
+++ b/pkg/querier/tripperware/query.pb.go
@@ -4,6 +4,7 @@
 package tripperware
 
 import (
+	encoding_binary "encoding/binary"
 	fmt "fmt"
 	cortexpb "github.com/cortexproject/cortex/pkg/cortexpb"
 	github_com_cortexproject_cortex_pkg_cortexpb "github.com/cortexproject/cortex/pkg/cortexpb"
@@ -28,8 +29,9 @@ var _ = math.Inf
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type SampleStream struct {
-	Labels  []github_com_cortexproject_cortex_pkg_cortexpb.LabelAdapter `protobuf:"bytes,1,rep,name=labels,proto3,customtype=github.com/cortexproject/cortex/pkg/cortexpb.LabelAdapter" json:"metric"`
-	Samples []cortexpb.Sample                                           `protobuf:"bytes,2,rep,name=samples,proto3" json:"values"`
+	Labels     []github_com_cortexproject_cortex_pkg_cortexpb.LabelAdapter `protobuf:"bytes,1,rep,name=labels,proto3,customtype=github.com/cortexproject/cortex/pkg/cortexpb.LabelAdapter" json:"metric"`
+	Samples    []cortexpb.Sample                                           `protobuf:"bytes,2,rep,name=samples,proto3" json:"values"`
+	Histograms []SampleHistogramPair                                       `protobuf:"bytes,3,rep,name=histograms,proto3" json:"histograms"`
 }
 
 func (m *SampleStream) Reset()      { *m = SampleStream{} }
@@ -71,6 +73,190 @@ func (m *SampleStream) GetSamples() []cortexpb.Sample {
 	return nil
 }
 
+func (m *SampleStream) GetHistograms() []SampleHistogramPair {
+	if m != nil {
+		return m.Histograms
+	}
+	return nil
+}
+
+type SampleHistogramPair struct {
+	TimestampMs int64           `protobuf:"varint,1,opt,name=timestamp_ms,json=timestampMs,proto3" json:"timestamp_ms,omitempty"`
+	Histogram   SampleHistogram `protobuf:"bytes,2,opt,name=histogram,proto3" json:"histogram"`
+}
+
+func (m *SampleHistogramPair) Reset()      { *m = SampleHistogramPair{} }
+func (*SampleHistogramPair) ProtoMessage() {}
+func (*SampleHistogramPair) Descriptor() ([]byte, []int) {
+	return fileDescriptor_5c6ac9b241082464, []int{1}
+}
+func (m *SampleHistogramPair) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SampleHistogramPair) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SampleHistogramPair.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SampleHistogramPair) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SampleHistogramPair.Merge(m, src)
+}
+func (m *SampleHistogramPair) XXX_Size() int {
+	return m.Size()
+}
+func (m *SampleHistogramPair) XXX_DiscardUnknown() {
+	xxx_messageInfo_SampleHistogramPair.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SampleHistogramPair proto.InternalMessageInfo
+
+func (m *SampleHistogramPair) GetTimestampMs() int64 {
+	if m != nil {
+		return m.TimestampMs
+	}
+	return 0
+}
+
+func (m *SampleHistogramPair) GetHistogram() SampleHistogram {
+	if m != nil {
+		return m.Histogram
+	}
+	return SampleHistogram{}
+}
+
+type SampleHistogram struct {
+	Count   float64            `protobuf:"fixed64,1,opt,name=count,proto3" json:"count,omitempty"`
+	Sum     float64            `protobuf:"fixed64,2,opt,name=sum,proto3" json:"sum,omitempty"`
+	Buckets []*HistogramBucket `protobuf:"bytes,3,rep,name=buckets,proto3" json:"buckets,omitempty"`
+}
+
+func (m *SampleHistogram) Reset()      { *m = SampleHistogram{} }
+func (*SampleHistogram) ProtoMessage() {}
+func (*SampleHistogram) Descriptor() ([]byte, []int) {
+	return fileDescriptor_5c6ac9b241082464, []int{2}
+}
+func (m *SampleHistogram) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SampleHistogram) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SampleHistogram.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SampleHistogram) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SampleHistogram.Merge(m, src)
+}
+func (m *SampleHistogram) XXX_Size() int {
+	return m.Size()
+}
+func (m *SampleHistogram) XXX_DiscardUnknown() {
+	xxx_messageInfo_SampleHistogram.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SampleHistogram proto.InternalMessageInfo
+
+func (m *SampleHistogram) GetCount() float64 {
+	if m != nil {
+		return m.Count
+	}
+	return 0
+}
+
+func (m *SampleHistogram) GetSum() float64 {
+	if m != nil {
+		return m.Sum
+	}
+	return 0
+}
+
+func (m *SampleHistogram) GetBuckets() []*HistogramBucket {
+	if m != nil {
+		return m.Buckets
+	}
+	return nil
+}
+
+type HistogramBucket struct {
+	Boundaries int32   `protobuf:"varint,1,opt,name=boundaries,proto3" json:"boundaries,omitempty"`
+	Lower      float64 `protobuf:"fixed64,2,opt,name=lower,proto3" json:"lower,omitempty"`
+	Upper      float64 `protobuf:"fixed64,3,opt,name=upper,proto3" json:"upper,omitempty"`
+	Count      float64 `protobuf:"fixed64,4,opt,name=count,proto3" json:"count,omitempty"`
+}
+
+func (m *HistogramBucket) Reset()      { *m = HistogramBucket{} }
+func (*HistogramBucket) ProtoMessage() {}
+func (*HistogramBucket) Descriptor() ([]byte, []int) {
+	return fileDescriptor_5c6ac9b241082464, []int{3}
+}
+func (m *HistogramBucket) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *HistogramBucket) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_HistogramBucket.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *HistogramBucket) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_HistogramBucket.Merge(m, src)
+}
+func (m *HistogramBucket) XXX_Size() int {
+	return m.Size()
+}
+func (m *HistogramBucket) XXX_DiscardUnknown() {
+	xxx_messageInfo_HistogramBucket.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_HistogramBucket proto.InternalMessageInfo
+
+func (m *HistogramBucket) GetBoundaries() int32 {
+	if m != nil {
+		return m.Boundaries
+	}
+	return 0
+}
+
+func (m *HistogramBucket) GetLower() float64 {
+	if m != nil {
+		return m.Lower
+	}
+	return 0
+}
+
+func (m *HistogramBucket) GetUpper() float64 {
+	if m != nil {
+		return m.Upper
+	}
+	return 0
+}
+
+func (m *HistogramBucket) GetCount() float64 {
+	if m != nil {
+		return m.Count
+	}
+	return 0
+}
+
 type PrometheusResponseStats struct {
 	Samples *PrometheusResponseSamplesStats `protobuf:"bytes,1,opt,name=samples,proto3" json:"samples"`
 }
@@ -78,7 +264,7 @@ type PrometheusResponseStats struct {
 func (m *PrometheusResponseStats) Reset()      { *m = PrometheusResponseStats{} }
 func (*PrometheusResponseStats) ProtoMessage() {}
 func (*PrometheusResponseStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_5c6ac9b241082464, []int{1}
+	return fileDescriptor_5c6ac9b241082464, []int{4}
 }
 func (m *PrometheusResponseStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -122,7 +308,7 @@ type PrometheusResponseSamplesStats struct {
 func (m *PrometheusResponseSamplesStats) Reset()      { *m = PrometheusResponseSamplesStats{} }
 func (*PrometheusResponseSamplesStats) ProtoMessage() {}
 func (*PrometheusResponseSamplesStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_5c6ac9b241082464, []int{2}
+	return fileDescriptor_5c6ac9b241082464, []int{5}
 }
 func (m *PrometheusResponseSamplesStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -175,7 +361,7 @@ func (m *PrometheusResponseQueryableSamplesStatsPerStep) Reset() {
 }
 func (*PrometheusResponseQueryableSamplesStatsPerStep) ProtoMessage() {}
 func (*PrometheusResponseQueryableSamplesStatsPerStep) Descriptor() ([]byte, []int) {
-	return fileDescriptor_5c6ac9b241082464, []int{3}
+	return fileDescriptor_5c6ac9b241082464, []int{6}
 }
 func (m *PrometheusResponseQueryableSamplesStatsPerStep) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -226,7 +412,7 @@ type PrometheusResponseHeader struct {
 func (m *PrometheusResponseHeader) Reset()      { *m = PrometheusResponseHeader{} }
 func (*PrometheusResponseHeader) ProtoMessage() {}
 func (*PrometheusResponseHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_5c6ac9b241082464, []int{4}
+	return fileDescriptor_5c6ac9b241082464, []int{7}
 }
 func (m *PrometheusResponseHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -277,7 +463,7 @@ type PrometheusRequestHeader struct {
 func (m *PrometheusRequestHeader) Reset()      { *m = PrometheusRequestHeader{} }
 func (*PrometheusRequestHeader) ProtoMessage() {}
 func (*PrometheusRequestHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_5c6ac9b241082464, []int{5}
+	return fileDescriptor_5c6ac9b241082464, []int{8}
 }
 func (m *PrometheusRequestHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -322,6 +508,9 @@ func (m *PrometheusRequestHeader) GetValues() []string {
 
 func init() {
 	proto.RegisterType((*SampleStream)(nil), "tripperware.SampleStream")
+	proto.RegisterType((*SampleHistogramPair)(nil), "tripperware.SampleHistogramPair")
+	proto.RegisterType((*SampleHistogram)(nil), "tripperware.SampleHistogram")
+	proto.RegisterType((*HistogramBucket)(nil), "tripperware.HistogramBucket")
 	proto.RegisterType((*PrometheusResponseStats)(nil), "tripperware.PrometheusResponseStats")
 	proto.RegisterType((*PrometheusResponseSamplesStats)(nil), "tripperware.PrometheusResponseSamplesStats")
 	proto.RegisterType((*PrometheusResponseQueryableSamplesStatsPerStep)(nil), "tripperware.PrometheusResponseQueryableSamplesStatsPerStep")
@@ -332,38 +521,48 @@ func init() {
 func init() { proto.RegisterFile("query.proto", fileDescriptor_5c6ac9b241082464) }
 
 var fileDescriptor_5c6ac9b241082464 = []byte{
-	// 495 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x53, 0xbf, 0x6e, 0xd4, 0x4e,
-	0x10, 0xf6, 0x26, 0xbf, 0xdc, 0x4f, 0xac, 0x23, 0x84, 0x96, 0x20, 0x2e, 0x11, 0xac, 0x8f, 0xab,
-	0x22, 0x21, 0x7c, 0x52, 0xa8, 0x80, 0x2a, 0xae, 0x90, 0xf8, 0x77, 0xd8, 0x88, 0x82, 0x06, 0xad,
-	0x2f, 0xa3, 0x8b, 0xc1, 0xcb, 0x6e, 0x76, 0xd7, 0x10, 0x3a, 0x1e, 0x81, 0x86, 0x07, 0xa0, 0xe3,
-	0x41, 0x28, 0x52, 0x5e, 0x19, 0x51, 0x58, 0x9c, 0xaf, 0x41, 0xae, 0xf2, 0x08, 0xc8, 0x6b, 0x3b,
-	0x17, 0xe0, 0x74, 0x28, 0xa2, 0xdb, 0xfd, 0xbe, 0xf9, 0xe6, 0x9b, 0x9d, 0x9d, 0xc1, 0xee, 0x41,
-	0x06, 0xea, 0xbd, 0x2f, 0x95, 0x30, 0x82, 0xb8, 0x46, 0x25, 0x52, 0x82, 0x7a, 0xc7, 0x14, 0x6c,
-	0x6d, 0x8c, 0xc5, 0x58, 0x58, 0x7c, 0x50, 0x9d, 0xea, 0x90, 0xad, 0x3b, 0xe3, 0xc4, 0xec, 0x67,
-	0xb1, 0x3f, 0x12, 0x7c, 0x30, 0x12, 0xca, 0xc0, 0xa1, 0x54, 0xe2, 0x15, 0x8c, 0x4c, 0x73, 0x1b,
-	0xc8, 0xd7, 0xe3, 0x96, 0x88, 0x9b, 0x43, 0x2d, 0xed, 0x7f, 0x45, 0x78, 0x3d, 0x62, 0x5c, 0xa6,
-	0x10, 0x19, 0x05, 0x8c, 0x93, 0x43, 0xdc, 0x49, 0x59, 0x0c, 0xa9, 0xee, 0xa2, 0xde, 0xea, 0xb6,
-	0xbb, 0x73, 0xd9, 0x6f, 0x85, 0xfe, 0xc3, 0x0a, 0x1f, 0xb2, 0x44, 0x05, 0x0f, 0x8e, 0x72, 0xcf,
-	0xf9, 0x96, 0x7b, 0xe7, 0x32, 0xae, 0xf5, 0xbb, 0x7b, 0x4c, 0x1a, 0x50, 0x65, 0xee, 0x75, 0x38,
-	0x18, 0x95, 0x8c, 0xc2, 0xc6, 0x8f, 0xdc, 0xc5, 0xff, 0x6b, 0x5b, 0x89, 0xee, 0xae, 0x58, 0xeb,
-	0x4b, 0x73, 0xeb, 0xba, 0xc4, 0xe0, 0x62, 0xe5, 0x5b, 0x49, 0xdf, 0xb2, 0x34, 0x03, 0x1d, 0xb6,
-	0x82, 0x3e, 0xc7, 0x57, 0x87, 0x4a, 0x70, 0x30, 0xfb, 0x90, 0xe9, 0x10, 0xb4, 0x14, 0x6f, 0x34,
-	0x44, 0x86, 0x19, 0x4d, 0xc2, 0x79, 0x5a, 0xd4, 0x43, 0xdb, 0xee, 0xce, 0x4d, 0xff, 0x4c, 0x47,
-	0xfd, 0x05, 0xb2, 0x3a, 0xda, 0xaa, 0x03, 0xb7, 0xcc, 0xbd, 0x56, 0x3f, 0xb7, 0xfb, 0xb4, 0x82,
-	0xe9, 0x72, 0x21, 0x79, 0x82, 0xaf, 0x18, 0x61, 0x58, 0xfa, 0xb4, 0xfa, 0x4a, 0x16, 0xa7, 0x2d,
-	0x6b, 0x8b, 0x58, 0x0d, 0x36, 0xcb, 0xdc, 0x5b, 0x1c, 0x10, 0x2e, 0x86, 0xc9, 0x67, 0x84, 0xaf,
-	0x2d, 0x64, 0x86, 0xa0, 0x22, 0x03, 0xb2, 0x69, 0xda, 0xbd, 0xbf, 0xbc, 0xee, 0x77, 0xb5, 0xad,
-	0xb6, 0x49, 0x11, 0xf4, 0xca, 0xdc, 0x5b, 0x6a, 0x12, 0x2e, 0x65, 0xfb, 0x09, 0x3e, 0xa7, 0x23,
-	0xd9, 0xc0, 0x6b, 0xf6, 0x2f, 0xeb, 0xb6, 0x84, 0xf5, 0x85, 0xdc, 0xc0, 0xeb, 0x26, 0xe1, 0xa0,
-	0x0d, 0xe3, 0xf2, 0x25, 0xaf, 0xe6, 0xa1, 0x22, 0xdd, 0x53, 0xec, 0x91, 0xee, 0x3f, 0xc3, 0xdd,
-	0x3f, 0xad, 0xee, 0x03, 0xdb, 0x03, 0x45, 0x36, 0xf1, 0x7f, 0x8f, 0x19, 0xaf, 0x73, 0x5e, 0x08,
-	0xd6, 0xca, 0xdc, 0x43, 0xb7, 0x42, 0x0b, 0x91, 0xeb, 0xb8, 0xf3, 0xdc, 0xce, 0x8e, 0x6d, 0xd7,
-	0x29, 0xd9, 0x80, 0xfd, 0xe8, 0xd7, 0x39, 0x3a, 0xc8, 0x40, 0x9b, 0x7f, 0x4d, 0x1a, 0xec, 0x4e,
-	0xa6, 0xd4, 0x39, 0x9e, 0x52, 0xe7, 0x64, 0x4a, 0xd1, 0x87, 0x82, 0xa2, 0x2f, 0x05, 0x45, 0x47,
-	0x05, 0x45, 0x93, 0x82, 0xa2, 0xef, 0x05, 0x45, 0x3f, 0x0a, 0xea, 0x9c, 0x14, 0x14, 0x7d, 0x9c,
-	0x51, 0x67, 0x32, 0xa3, 0xce, 0xf1, 0x8c, 0x3a, 0x2f, 0xce, 0xee, 0x7d, 0xdc, 0xb1, 0xdb, 0x7a,
-	0xfb, 0x67, 0x00, 0x00, 0x00, 0xff, 0xff, 0xe4, 0x6b, 0xc1, 0x41, 0x1a, 0x04, 0x00, 0x00,
+	// 646 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x54, 0x4f, 0x4f, 0x13, 0x41,
+	0x14, 0xdf, 0x69, 0xa1, 0x84, 0x29, 0x11, 0x32, 0x60, 0x2c, 0x04, 0x67, 0xeb, 0x9e, 0x48, 0x8c,
+	0x25, 0xc1, 0xc4, 0x44, 0xbd, 0xc8, 0x9e, 0x48, 0xfc, 0x87, 0x53, 0xe2, 0xc1, 0x8b, 0x99, 0x2d,
+	0x93, 0xb2, 0xb2, 0xcb, 0x2c, 0x33, 0xb3, 0x82, 0x9e, 0xfc, 0x08, 0x5e, 0xbc, 0x78, 0xf3, 0xe6,
+	0x47, 0xe1, 0xc8, 0x91, 0x78, 0xd8, 0xc8, 0x72, 0x31, 0x3d, 0xf1, 0x11, 0xcc, 0xcc, 0xec, 0xb6,
+	0x85, 0x36, 0x35, 0xc4, 0xdb, 0xbc, 0xdf, 0x7b, 0xbf, 0xf7, 0x7b, 0xef, 0xed, 0x7b, 0x0b, 0xeb,
+	0x87, 0x29, 0x13, 0x9f, 0x5a, 0x89, 0xe0, 0x8a, 0xa3, 0xba, 0x12, 0x61, 0x92, 0x30, 0x71, 0x44,
+	0x05, 0x5b, 0x59, 0xea, 0xf2, 0x2e, 0x37, 0xf8, 0xba, 0x7e, 0xd9, 0x90, 0x95, 0xc7, 0xdd, 0x50,
+	0xed, 0xa5, 0x41, 0xab, 0xc3, 0xe3, 0xf5, 0x0e, 0x17, 0x8a, 0x1d, 0x27, 0x82, 0x7f, 0x60, 0x1d,
+	0x55, 0x58, 0xeb, 0xc9, 0x7e, 0xb7, 0x74, 0x04, 0xc5, 0xc3, 0x52, 0xbd, 0xef, 0x15, 0x38, 0xd7,
+	0xa6, 0x71, 0x12, 0xb1, 0xb6, 0x12, 0x8c, 0xc6, 0xe8, 0x18, 0xd6, 0x22, 0x1a, 0xb0, 0x48, 0x36,
+	0x40, 0xb3, 0xba, 0x56, 0xdf, 0x58, 0x6c, 0x95, 0xc4, 0xd6, 0x0b, 0x8d, 0x6f, 0xd3, 0x50, 0xf8,
+	0xcf, 0x4f, 0x32, 0xd7, 0xf9, 0x95, 0xb9, 0x37, 0x12, 0xb6, 0xfc, 0xcd, 0x5d, 0x9a, 0x28, 0x26,
+	0x7a, 0x99, 0x5b, 0x8b, 0x99, 0x12, 0x61, 0x87, 0x14, 0x7a, 0xe8, 0x09, 0x9c, 0x91, 0xa6, 0x12,
+	0xd9, 0xa8, 0x18, 0xe9, 0x85, 0x81, 0xb4, 0x2d, 0xd1, 0xbf, 0xa5, 0x75, 0x35, 0xf5, 0x23, 0x8d,
+	0x52, 0x26, 0x49, 0x49, 0x40, 0x3b, 0x10, 0xee, 0x85, 0x52, 0xf1, 0xae, 0xa0, 0xb1, 0x6c, 0x54,
+	0x0d, 0xbd, 0xd9, 0x1a, 0x9a, 0x5c, 0x91, 0x61, 0xab, 0x0c, 0x32, 0x6d, 0xa0, 0x22, 0xdd, 0x10,
+	0x97, 0x0c, 0xbd, 0xbd, 0xcf, 0x70, 0x71, 0x0c, 0x0d, 0xdd, 0x83, 0x73, 0x2a, 0x8c, 0x99, 0x54,
+	0x34, 0x4e, 0xde, 0xc7, 0x7a, 0x50, 0x60, 0xad, 0x4a, 0xea, 0x7d, 0xec, 0xa5, 0x44, 0xcf, 0xe0,
+	0x6c, 0x3f, 0x4f, 0xa3, 0xd2, 0x04, 0x6b, 0xf5, 0x8d, 0xd5, 0x49, 0xe5, 0xf8, 0x53, 0xba, 0x14,
+	0x32, 0x20, 0x79, 0x87, 0x70, 0xfe, 0x5a, 0x0c, 0x5a, 0x82, 0xd3, 0x1d, 0x9e, 0x1e, 0x28, 0x23,
+	0x08, 0x88, 0x35, 0xd0, 0x02, 0xac, 0xca, 0xd4, 0x8a, 0x00, 0xa2, 0x9f, 0xe8, 0x11, 0x9c, 0x09,
+	0xd2, 0xce, 0x3e, 0x53, 0xe5, 0x24, 0xae, 0x4a, 0x0f, 0x44, 0x4d, 0x10, 0x29, 0x83, 0x3d, 0x09,
+	0xe7, 0xaf, 0xf9, 0x10, 0x86, 0x30, 0xe0, 0xe9, 0xc1, 0x2e, 0x15, 0x21, 0xb3, 0x8d, 0x4e, 0x93,
+	0x21, 0x44, 0x97, 0x14, 0xf1, 0x23, 0x26, 0x0a, 0x79, 0x6b, 0x68, 0x34, 0xd5, 0x72, 0x8d, 0xaa,
+	0x45, 0x8d, 0x31, 0x28, 0x7f, 0x6a, 0xa8, 0x7c, 0x2f, 0x86, 0x77, 0xb6, 0x05, 0x8f, 0x99, 0xda,
+	0x63, 0xa9, 0x24, 0x4c, 0x26, 0xfc, 0x40, 0xb2, 0xb6, 0xa2, 0x4a, 0x22, 0x32, 0x58, 0x08, 0x60,
+	0x46, 0x78, 0xff, 0x4a, 0x1f, 0x63, 0x68, 0x36, 0xda, 0xb0, 0xfd, 0x7a, 0x2f, 0x73, 0x4b, 0x7e,
+	0x7f, 0x51, 0xbc, 0x6f, 0x15, 0x88, 0x27, 0x13, 0xd1, 0x6b, 0x78, 0x5b, 0x71, 0x45, 0xa3, 0x37,
+	0xfa, 0x08, 0x69, 0x10, 0x95, 0x5e, 0xfb, 0x9d, 0xfd, 0xe5, 0x5e, 0xe6, 0x8e, 0x0f, 0x20, 0xe3,
+	0x61, 0xf4, 0x03, 0xc0, 0xd5, 0xb1, 0x9e, 0x6d, 0x26, 0xda, 0x8a, 0x25, 0xc5, 0xba, 0x3f, 0xfd,
+	0x47, 0x77, 0xd7, 0xd9, 0xa6, 0xda, 0x22, 0x85, 0xdf, 0xec, 0x65, 0xee, 0x44, 0x11, 0x32, 0xd1,
+	0xeb, 0x85, 0xf0, 0x86, 0x8a, 0xfa, 0x73, 0x9a, 0x2b, 0x2c, 0xd6, 0xdf, 0x1a, 0x23, 0xb7, 0x51,
+	0x19, 0xb9, 0x0d, 0x6f, 0x07, 0x36, 0x46, 0xa5, 0xb6, 0x18, 0xdd, 0x65, 0x02, 0x2d, 0xc3, 0xa9,
+	0x57, 0x34, 0xb6, 0x39, 0x67, 0xfd, 0xe9, 0x5e, 0xe6, 0x82, 0x07, 0xc4, 0x40, 0xe8, 0x2e, 0xac,
+	0xbd, 0x35, 0x57, 0x6f, 0xc6, 0xd5, 0x77, 0x16, 0xa0, 0xd7, 0xbe, 0xba, 0x47, 0x87, 0x29, 0x93,
+	0xea, 0x7f, 0x93, 0xfa, 0x9b, 0xa7, 0xe7, 0xd8, 0x39, 0x3b, 0xc7, 0xce, 0xe5, 0x39, 0x06, 0x5f,
+	0x72, 0x0c, 0x7e, 0xe6, 0x18, 0x9c, 0xe4, 0x18, 0x9c, 0xe6, 0x18, 0xfc, 0xce, 0x31, 0xf8, 0x93,
+	0x63, 0xe7, 0x32, 0xc7, 0xe0, 0xeb, 0x05, 0x76, 0x4e, 0x2f, 0xb0, 0x73, 0x76, 0x81, 0x9d, 0x77,
+	0xc3, 0x7f, 0xec, 0xa0, 0x66, 0xfe, 0xb3, 0x0f, 0xff, 0x06, 0x00, 0x00, 0xff, 0xff, 0x33, 0x14,
+	0x72, 0x0f, 0xd4, 0x05, 0x00, 0x00,
 }
 
 func (this *SampleStream) Equal(that interface{}) bool {
@@ -400,6 +599,109 @@ func (this *SampleStream) Equal(that interface{}) bool {
 		if !this.Samples[i].Equal(&that1.Samples[i]) {
 			return false
 		}
+	}
+	if len(this.Histograms) != len(that1.Histograms) {
+		return false
+	}
+	for i := range this.Histograms {
+		if !this.Histograms[i].Equal(&that1.Histograms[i]) {
+			return false
+		}
+	}
+	return true
+}
+func (this *SampleHistogramPair) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*SampleHistogramPair)
+	if !ok {
+		that2, ok := that.(SampleHistogramPair)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.TimestampMs != that1.TimestampMs {
+		return false
+	}
+	if !this.Histogram.Equal(&that1.Histogram) {
+		return false
+	}
+	return true
+}
+func (this *SampleHistogram) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*SampleHistogram)
+	if !ok {
+		that2, ok := that.(SampleHistogram)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Count != that1.Count {
+		return false
+	}
+	if this.Sum != that1.Sum {
+		return false
+	}
+	if len(this.Buckets) != len(that1.Buckets) {
+		return false
+	}
+	for i := range this.Buckets {
+		if !this.Buckets[i].Equal(that1.Buckets[i]) {
+			return false
+		}
+	}
+	return true
+}
+func (this *HistogramBucket) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*HistogramBucket)
+	if !ok {
+		that2, ok := that.(HistogramBucket)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Boundaries != that1.Boundaries {
+		return false
+	}
+	if this.Lower != that1.Lower {
+		return false
+	}
+	if this.Upper != that1.Upper {
+		return false
+	}
+	if this.Count != that1.Count {
+		return false
 	}
 	return true
 }
@@ -554,7 +856,7 @@ func (this *SampleStream) GoString() string {
 	if this == nil {
 		return "nil"
 	}
-	s := make([]string, 0, 6)
+	s := make([]string, 0, 7)
 	s = append(s, "&tripperware.SampleStream{")
 	s = append(s, "Labels: "+fmt.Sprintf("%#v", this.Labels)+",\n")
 	if this.Samples != nil {
@@ -564,6 +866,51 @@ func (this *SampleStream) GoString() string {
 		}
 		s = append(s, "Samples: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
+	if this.Histograms != nil {
+		vs := make([]*SampleHistogramPair, len(this.Histograms))
+		for i := range vs {
+			vs[i] = &this.Histograms[i]
+		}
+		s = append(s, "Histograms: "+fmt.Sprintf("%#v", vs)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *SampleHistogramPair) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 6)
+	s = append(s, "&tripperware.SampleHistogramPair{")
+	s = append(s, "TimestampMs: "+fmt.Sprintf("%#v", this.TimestampMs)+",\n")
+	s = append(s, "Histogram: "+strings.Replace(this.Histogram.GoString(), `&`, ``, 1)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *SampleHistogram) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 7)
+	s = append(s, "&tripperware.SampleHistogram{")
+	s = append(s, "Count: "+fmt.Sprintf("%#v", this.Count)+",\n")
+	s = append(s, "Sum: "+fmt.Sprintf("%#v", this.Sum)+",\n")
+	if this.Buckets != nil {
+		s = append(s, "Buckets: "+fmt.Sprintf("%#v", this.Buckets)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *HistogramBucket) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 8)
+	s = append(s, "&tripperware.HistogramBucket{")
+	s = append(s, "Boundaries: "+fmt.Sprintf("%#v", this.Boundaries)+",\n")
+	s = append(s, "Lower: "+fmt.Sprintf("%#v", this.Lower)+",\n")
+	s = append(s, "Upper: "+fmt.Sprintf("%#v", this.Upper)+",\n")
+	s = append(s, "Count: "+fmt.Sprintf("%#v", this.Count)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
@@ -653,6 +1000,20 @@ func (m *SampleStream) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.Histograms) > 0 {
+		for iNdEx := len(m.Histograms) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Histograms[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintQuery(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
 	if len(m.Samples) > 0 {
 		for iNdEx := len(m.Samples) - 1; iNdEx >= 0; iNdEx-- {
 			{
@@ -680,6 +1041,139 @@ func (m *SampleStream) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 			i--
 			dAtA[i] = 0xa
 		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SampleHistogramPair) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SampleHistogramPair) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SampleHistogramPair) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.Histogram.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x12
+	if m.TimestampMs != 0 {
+		i = encodeVarintQuery(dAtA, i, uint64(m.TimestampMs))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SampleHistogram) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SampleHistogram) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SampleHistogram) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Buckets) > 0 {
+		for iNdEx := len(m.Buckets) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Buckets[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintQuery(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if m.Sum != 0 {
+		i -= 8
+		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Sum))))
+		i--
+		dAtA[i] = 0x11
+	}
+	if m.Count != 0 {
+		i -= 8
+		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Count))))
+		i--
+		dAtA[i] = 0x9
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *HistogramBucket) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *HistogramBucket) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *HistogramBucket) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Count != 0 {
+		i -= 8
+		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Count))))
+		i--
+		dAtA[i] = 0x21
+	}
+	if m.Upper != 0 {
+		i -= 8
+		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Upper))))
+		i--
+		dAtA[i] = 0x19
+	}
+	if m.Lower != 0 {
+		i -= 8
+		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Lower))))
+		i--
+		dAtA[i] = 0x11
+	}
+	if m.Boundaries != 0 {
+		i = encodeVarintQuery(dAtA, i, uint64(m.Boundaries))
+		i--
+		dAtA[i] = 0x8
 	}
 	return len(dAtA) - i, nil
 }
@@ -901,6 +1395,68 @@ func (m *SampleStream) Size() (n int) {
 			n += 1 + l + sovQuery(uint64(l))
 		}
 	}
+	if len(m.Histograms) > 0 {
+		for _, e := range m.Histograms {
+			l = e.Size()
+			n += 1 + l + sovQuery(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *SampleHistogramPair) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.TimestampMs != 0 {
+		n += 1 + sovQuery(uint64(m.TimestampMs))
+	}
+	l = m.Histogram.Size()
+	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *SampleHistogram) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Count != 0 {
+		n += 9
+	}
+	if m.Sum != 0 {
+		n += 9
+	}
+	if len(m.Buckets) > 0 {
+		for _, e := range m.Buckets {
+			l = e.Size()
+			n += 1 + l + sovQuery(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *HistogramBucket) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Boundaries != 0 {
+		n += 1 + sovQuery(uint64(m.Boundaries))
+	}
+	if m.Lower != 0 {
+		n += 9
+	}
+	if m.Upper != 0 {
+		n += 9
+	}
+	if m.Count != 0 {
+		n += 9
+	}
 	return n
 }
 
@@ -1003,9 +1559,56 @@ func (this *SampleStream) String() string {
 		repeatedStringForSamples += fmt.Sprintf("%v", f) + ","
 	}
 	repeatedStringForSamples += "}"
+	repeatedStringForHistograms := "[]SampleHistogramPair{"
+	for _, f := range this.Histograms {
+		repeatedStringForHistograms += strings.Replace(strings.Replace(f.String(), "SampleHistogramPair", "SampleHistogramPair", 1), `&`, ``, 1) + ","
+	}
+	repeatedStringForHistograms += "}"
 	s := strings.Join([]string{`&SampleStream{`,
 		`Labels:` + fmt.Sprintf("%v", this.Labels) + `,`,
 		`Samples:` + repeatedStringForSamples + `,`,
+		`Histograms:` + repeatedStringForHistograms + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *SampleHistogramPair) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&SampleHistogramPair{`,
+		`TimestampMs:` + fmt.Sprintf("%v", this.TimestampMs) + `,`,
+		`Histogram:` + strings.Replace(strings.Replace(this.Histogram.String(), "SampleHistogram", "SampleHistogram", 1), `&`, ``, 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *SampleHistogram) String() string {
+	if this == nil {
+		return "nil"
+	}
+	repeatedStringForBuckets := "[]*HistogramBucket{"
+	for _, f := range this.Buckets {
+		repeatedStringForBuckets += strings.Replace(f.String(), "HistogramBucket", "HistogramBucket", 1) + ","
+	}
+	repeatedStringForBuckets += "}"
+	s := strings.Join([]string{`&SampleHistogram{`,
+		`Count:` + fmt.Sprintf("%v", this.Count) + `,`,
+		`Sum:` + fmt.Sprintf("%v", this.Sum) + `,`,
+		`Buckets:` + repeatedStringForBuckets + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *HistogramBucket) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&HistogramBucket{`,
+		`Boundaries:` + fmt.Sprintf("%v", this.Boundaries) + `,`,
+		`Lower:` + fmt.Sprintf("%v", this.Lower) + `,`,
+		`Upper:` + fmt.Sprintf("%v", this.Upper) + `,`,
+		`Count:` + fmt.Sprintf("%v", this.Count) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -1174,6 +1777,359 @@ func (m *SampleStream) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Histograms", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Histograms = append(m.Histograms, SampleHistogramPair{})
+			if err := m.Histograms[len(m.Histograms)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SampleHistogramPair) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SampleHistogramPair: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SampleHistogramPair: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TimestampMs", wireType)
+			}
+			m.TimestampMs = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.TimestampMs |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Histogram", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Histogram.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SampleHistogram) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SampleHistogram: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SampleHistogram: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Count", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
+			m.Count = float64(math.Float64frombits(v))
+		case 2:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sum", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
+			m.Sum = float64(math.Float64frombits(v))
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Buckets", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Buckets = append(m.Buckets, &HistogramBucket{})
+			if err := m.Buckets[len(m.Buckets)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *HistogramBucket) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: HistogramBucket: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: HistogramBucket: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Boundaries", wireType)
+			}
+			m.Boundaries = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Boundaries |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Lower", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
+			m.Lower = float64(math.Float64frombits(v))
+		case 3:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Upper", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
+			m.Upper = float64(math.Float64frombits(v))
+		case 4:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Count", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
+			m.Count = float64(math.Float64frombits(v))
 		default:
 			iNdEx = preIndex
 			skippy, err := skipQuery(dAtA[iNdEx:])

--- a/pkg/querier/tripperware/query.proto
+++ b/pkg/querier/tripperware/query.proto
@@ -13,6 +13,25 @@ option (gogoproto.unmarshaler_all) = true;
 message SampleStream {
   repeated cortexpb.LabelPair labels = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "metric", (gogoproto.customtype) = "github.com/cortexproject/cortex/pkg/cortexpb.LabelAdapter"];
   repeated cortexpb.Sample samples = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "values"];
+  repeated SampleHistogramPair histograms = 3 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "histograms"];
+}
+
+message SampleHistogramPair {
+  int64 timestamp_ms = 1;
+  SampleHistogram histogram = 2 [(gogoproto.nullable) = false];
+}
+
+message SampleHistogram {
+  double count = 1;
+  double sum = 2;
+  repeated HistogramBucket buckets = 3;
+}
+
+message HistogramBucket {
+  int32 boundaries = 1;
+  double lower = 2;
+  double upper = 3;
+  double count = 4;
 }
 
 message PrometheusResponseStats {

--- a/pkg/querier/tripperware/query_test.go
+++ b/pkg/querier/tripperware/query_test.go
@@ -1,60 +1,195 @@
 package tripperware
 
 import (
-	stdjson "encoding/json"
-	"fmt"
+	"math"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
-func TestMarshalSampleStream(t *testing.T) {
-	t.Parallel()
-	for i, tc := range []struct {
-		sampleStream SampleStream
+// Same as https://github.com/prometheus/client_golang/blob/v1.19.1/api/prometheus/v1/api_test.go#L1577.
+func TestSampleHistogramPairJSONSerialization(t *testing.T) {
+	tests := []struct {
+		name     string
+		point    SampleHistogramPair
+		expected string
 	}{
 		{
-			sampleStream: SampleStream{
-				Samples: []cortexpb.Sample{{Value: 1, TimestampMs: 1}},
+			name: "empty histogram",
+			point: SampleHistogramPair{
+				TimestampMs: 0,
+				Histogram:   SampleHistogram{},
 			},
+			expected: `[0,{"count":"0","sum":"0"}]`,
 		},
 		{
-			sampleStream: SampleStream{
-				Labels:  cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{"foo": "bar"})),
-				Samples: []cortexpb.Sample{{Value: 1, TimestampMs: 1}},
+			name: "histogram with NaN/Inf and no buckets",
+			point: SampleHistogramPair{
+				TimestampMs: 0,
+				Histogram: SampleHistogram{
+					Count: math.NaN(),
+					Sum:   math.Inf(1),
+				},
 			},
+			expected: `[0,{"count":"NaN","sum":"+Inf"}]`,
 		},
 		{
-			sampleStream: SampleStream{
-				Labels:  cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{"foo": "bar", "test": "test", "a": "b"})),
-				Samples: []cortexpb.Sample{{Value: 1, TimestampMs: 1}, {Value: 2, TimestampMs: 2}, {Value: 3, TimestampMs: 3}},
+			name: "six-bucket histogram",
+			point: SampleHistogramPair{
+				TimestampMs: 1,
+				Histogram:   testHistogram1,
 			},
+			expected: `[0.001,{"count":"13.5","sum":"3897.1","buckets":[[1,"-4870.992343051145","-4466.7196729968955","1"],[1,"-861.0779292198035","-789.6119426088657","2"],[1,"-558.3399591246119","-512","3"],[0,"2048","2233.3598364984477","1.5"],[0,"2896.3093757400984","3158.4477704354626","2.5"],[0,"4466.7196729968955","4870.992343051145","3.5"]]}]`,
 		},
-	} {
-		tc := tc
-		t.Run(fmt.Sprintf("test-case-%d", i), func(t *testing.T) {
-			t.Parallel()
-			out1, err := json.Marshal(tc.sampleStream)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := json.Marshal(test.point)
 			require.NoError(t, err)
-			out2, err := tc.sampleStream.MarshalJSON()
+			require.Equal(t, test.expected, string(b))
+
+			// To test Unmarshal we will Unmarshal then re-Marshal. This way we
+			// can do a string compare, otherwise NaN values don't show equivalence
+			// properly.
+			var sp SampleHistogramPair
+			err = json.Unmarshal(b, &sp)
 			require.NoError(t, err)
-			require.Equal(t, out1, out2)
+
+			b, err = json.Marshal(sp)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, string(b))
 		})
 	}
 }
 
-// MarshalJSON implements json.Marshaler.
-func (s *SampleStream) MarshalJSON() ([]byte, error) {
-	stream := struct {
-		Metric model.Metric      `json:"metric"`
-		Values []cortexpb.Sample `json:"values"`
+// Same as https://github.com/prometheus/client_golang/blob/v1.19.1/api/prometheus/v1/api_test.go#L1682.
+func TestSampleStreamJSONSerialization(t *testing.T) {
+	floats, histograms := generateData(1, 5)
+
+	tests := []struct {
+		name         string
+		stream       SampleStream
+		expectedJSON string
 	}{
-		Metric: cortexpb.FromLabelAdaptersToMetric(s.Labels),
-		Values: s.Samples,
+		{
+			"floats",
+			*floats[0],
+			`{"metric":{"__name__":"timeseries_0","foo":"bar"},"values":[[1677587259.055,"1"],[1677587244.055,"2"],[1677587229.055,"3"],[1677587214.055,"4"],[1677587199.055,"5"]]}`,
+		},
+		{
+			"histograms",
+			*histograms[0],
+			`{"metric":{"__name__":"timeseries_0","foo":"bar"},"histograms":[[1677587259.055,{"count":"13.5","sum":"0.1","buckets":[[1,"-4870.992343051145","-4466.7196729968955","1"],[1,"-861.0779292198035","-789.6119426088657","2"],[1,"-558.3399591246119","-512","3"],[0,"2048","2233.3598364984477","1.5"],[0,"2896.3093757400984","3158.4477704354626","2.5"],[0,"4466.7196729968955","4870.992343051145","3.5"]]}],[1677587244.055,{"count":"27","sum":"0.2","buckets":[[1,"-4870.992343051145","-4466.7196729968955","2"],[1,"-861.0779292198035","-789.6119426088657","4"],[1,"-558.3399591246119","-512","6"],[0,"2048","2233.3598364984477","3"],[0,"2896.3093757400984","3158.4477704354626","5"],[0,"4466.7196729968955","4870.992343051145","7"]]}],[1677587229.055,{"count":"40.5","sum":"0.30000000000000004","buckets":[[1,"-4870.992343051145","-4466.7196729968955","3"],[1,"-861.0779292198035","-789.6119426088657","6"],[1,"-558.3399591246119","-512","9"],[0,"2048","2233.3598364984477","4.5"],[0,"2896.3093757400984","3158.4477704354626","7.5"],[0,"4466.7196729968955","4870.992343051145","10.5"]]}],[1677587214.055,{"count":"54","sum":"0.4","buckets":[[1,"-4870.992343051145","-4466.7196729968955","4"],[1,"-861.0779292198035","-789.6119426088657","8"],[1,"-558.3399591246119","-512","12"],[0,"2048","2233.3598364984477","6"],[0,"2896.3093757400984","3158.4477704354626","10"],[0,"4466.7196729968955","4870.992343051145","14"]]}],[1677587199.055,{"count":"67.5","sum":"0.5","buckets":[[1,"-4870.992343051145","-4466.7196729968955","5"],[1,"-861.0779292198035","-789.6119426088657","10"],[1,"-558.3399591246119","-512","15"],[0,"2048","2233.3598364984477","7.5"],[0,"2896.3093757400984","3158.4477704354626","12.5"],[0,"4466.7196729968955","4870.992343051145","17.5"]]}]]}`,
+		},
+		{
+			"both",
+			SampleStream{
+				Labels:     floats[0].Labels,
+				Samples:    floats[0].Samples,
+				Histograms: histograms[0].Histograms,
+			},
+			`{"metric":{"__name__":"timeseries_0","foo":"bar"},"values":[[1677587259.055,"1"],[1677587244.055,"2"],[1677587229.055,"3"],[1677587214.055,"4"],[1677587199.055,"5"]],"histograms":[[1677587259.055,{"count":"13.5","sum":"0.1","buckets":[[1,"-4870.992343051145","-4466.7196729968955","1"],[1,"-861.0779292198035","-789.6119426088657","2"],[1,"-558.3399591246119","-512","3"],[0,"2048","2233.3598364984477","1.5"],[0,"2896.3093757400984","3158.4477704354626","2.5"],[0,"4466.7196729968955","4870.992343051145","3.5"]]}],[1677587244.055,{"count":"27","sum":"0.2","buckets":[[1,"-4870.992343051145","-4466.7196729968955","2"],[1,"-861.0779292198035","-789.6119426088657","4"],[1,"-558.3399591246119","-512","6"],[0,"2048","2233.3598364984477","3"],[0,"2896.3093757400984","3158.4477704354626","5"],[0,"4466.7196729968955","4870.992343051145","7"]]}],[1677587229.055,{"count":"40.5","sum":"0.30000000000000004","buckets":[[1,"-4870.992343051145","-4466.7196729968955","3"],[1,"-861.0779292198035","-789.6119426088657","6"],[1,"-558.3399591246119","-512","9"],[0,"2048","2233.3598364984477","4.5"],[0,"2896.3093757400984","3158.4477704354626","7.5"],[0,"4466.7196729968955","4870.992343051145","10.5"]]}],[1677587214.055,{"count":"54","sum":"0.4","buckets":[[1,"-4870.992343051145","-4466.7196729968955","4"],[1,"-861.0779292198035","-789.6119426088657","8"],[1,"-558.3399591246119","-512","12"],[0,"2048","2233.3598364984477","6"],[0,"2896.3093757400984","3158.4477704354626","10"],[0,"4466.7196729968955","4870.992343051145","14"]]}],[1677587199.055,{"count":"67.5","sum":"0.5","buckets":[[1,"-4870.992343051145","-4466.7196729968955","5"],[1,"-861.0779292198035","-789.6119426088657","10"],[1,"-558.3399591246119","-512","15"],[0,"2048","2233.3598364984477","7.5"],[0,"2896.3093757400984","3158.4477704354626","12.5"],[0,"4466.7196729968955","4870.992343051145","17.5"]]}]]}`,
+		},
 	}
-	return stdjson.Marshal(stream)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := json.Marshal(test.stream)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedJSON, string(b))
+
+			var stream SampleStream
+			err = json.Unmarshal(b, &stream)
+			require.NoError(t, err)
+			require.Equal(t, test.stream, stream)
+		})
+	}
+}
+
+func generateData(timeseries, datapoints int) (floatMatrix, histogramMatrix []*SampleStream) {
+	for i := 0; i < timeseries; i++ {
+		lset := labels.FromMap(map[string]string{
+			model.MetricNameLabel: "timeseries_" + strconv.Itoa(i),
+			"foo":                 "bar",
+		})
+		now := model.Time(1677587274055).Time()
+		floats := make([]cortexpb.Sample, datapoints)
+		histograms := make([]SampleHistogramPair, datapoints)
+
+		for x := datapoints; x > 0; x-- {
+			f := float64(x)
+			floats[x-1] = cortexpb.Sample{
+				// Set the time back assuming a 15s interval. Since this is used for
+				// Marshal/Unmarshal testing the actual interval doesn't matter.
+				TimestampMs: util.TimeToMillis(now.Add(time.Second * -15 * time.Duration(x))),
+				Value:       f,
+			}
+			histograms[x-1] = SampleHistogramPair{
+				TimestampMs: util.TimeToMillis(now.Add(time.Second * -15 * time.Duration(x))),
+				Histogram: SampleHistogram{
+					Count: 13.5 * f,
+					Sum:   .1 * f,
+					Buckets: []*HistogramBucket{
+						{
+							Boundaries: 1,
+							Lower:      -4870.992343051145,
+							Upper:      -4466.7196729968955,
+							Count:      1 * f,
+						},
+						{
+							Boundaries: 1,
+							Lower:      -861.0779292198035,
+							Upper:      -789.6119426088657,
+							Count:      2 * f,
+						},
+						{
+							Boundaries: 1,
+							Lower:      -558.3399591246119,
+							Upper:      -512,
+							Count:      3 * f,
+						},
+						{
+							Boundaries: 0,
+							Lower:      2048,
+							Upper:      2233.3598364984477,
+							Count:      1.5 * f,
+						},
+						{
+							Boundaries: 0,
+							Lower:      2896.3093757400984,
+							Upper:      3158.4477704354626,
+							Count:      2.5 * f,
+						},
+						{
+							Boundaries: 0,
+							Lower:      4466.7196729968955,
+							Upper:      4870.992343051145,
+							Count:      3.5 * f,
+						},
+					},
+				},
+			}
+		}
+
+		fss := &SampleStream{
+			Labels:  cortexpb.FromLabelsToLabelAdapters(lset),
+			Samples: floats,
+		}
+		hss := &SampleStream{
+			Labels:     cortexpb.FromLabelsToLabelAdapters(lset),
+			Histograms: histograms,
+		}
+
+		floatMatrix = append(floatMatrix, fss)
+		histogramMatrix = append(histogramMatrix, hss)
+	}
+	return
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Support querying native histograms in query frontend.
Have to copy and change quite a bit of serialization code from client_golang since we use our own protobuf type.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
