### PR TITLE
S3 bucket: Don't retry when ctx cancel

### DIFF
--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -3,12 +3,12 @@ package s3
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/s3"

--- a/pkg/storage/bucket/s3/bucket_client_test.go
+++ b/pkg/storage/bucket/s3/bucket_client_test.go
@@ -34,6 +34,14 @@ func TestBucketWithRetries_ShouldRetry(t *testing.T) {
 			err:        errKeyDenied,
 			retryCount: 1,
 		},
+		"should not retry when context canceled": {
+			err:        context.Canceled,
+			retryCount: 1,
+		},
+		"should not retry when context deadline exceeded": {
+			err:        context.DeadlineExceeded,
+			retryCount: 1,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

I noticed that store gateway still retry even when the context is canceled when fetching data from S3. Explicitly check the errors so we don't have to retry and wait for the backoff time.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
