### PR TITLE
[Vote] Charlie Le (CharlieTLe) as new Cortex maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,5 @@
 Alan Protasio, Amazon Web Services <alanprot@gmail.com> (@alanprot)
 Alvin Lin, Amazon Web Services <alvinlin123@gmail.com> (@alvinlin123)
 Ben Ye, Amazon Web Services <yb532204897@gmail.com> (@yeya24)
+Charlie Le, Apple <chtle4@gmail.com> (@CharlieTLe)
 Friedrich Gonzalez, Adobe <friedrichg@gmail.com> (@friedrichg)


### PR DESCRIPTION
I would like to call for a vote to add @CharlieTLe as Cortex mantainer.

Charlie has been very active in contributing to Cortex. Here is [a list of Charlie's contribution](https://github.com/cortexproject/cortex/issues?q=author%3ACharlieTLe). I can see Charlie is very invested in Cortex and will continue to do so in the years to come.

Per [existing change in maintainership governance rule](https://cortexmetrics.io/docs/contributing/governance/#changes-in-maintainership), 2/3 majority votes are required for the changes to pass.

Please cast your yes/no vote as comment in this PR, I will leave the vote open for 14 days (including weekends) or until all maintainer voted; whichever comes first.
