### PR TITLE
Using Ingester Id as a tiebreaker for MinimizeSpreadTokenGenerator

### DIFF
--- a/pkg/ring/token_generator.go
+++ b/pkg/ring/token_generator.go
@@ -100,9 +100,10 @@ func (g *MinimizeSpreadTokenGenerator) GenerateTokens(ring *Desc, id, zone strin
 			tokensPerInstanceWithDistance[i] = &totalTokenPerInstance{id: i, zone: instance.Zone}
 
 			if len(instance.Tokens) == 0 {
-				// If there is more than one instance with no tokens, lets only use
-				// MinimizeSpread token algorithm on the last one
-				if instance.RegisteredTimestamp < ring.Ingesters[id].RegisteredTimestamp {
+				// If there is more than one ingester with no tokens, use MinimizeSpread only for the first registered ingester.
+				// In case of a tie, use the ingester ID as a tiebreaker.
+				if instance.RegisteredTimestamp < ring.Ingesters[id].RegisteredTimestamp ||
+					(instance.RegisteredTimestamp == ring.Ingesters[id].RegisteredTimestamp && i < id) {
 					if force {
 						return g.innerGenerator.GenerateTokens(ring, id, zone, numTokens, true)
 					} else {

--- a/pkg/ring/token_generator_test.go
+++ b/pkg/ring/token_generator_test.go
@@ -122,6 +122,16 @@ func TestMinimizeSpreadTokenGenerator(t *testing.T) {
 	require.Len(t, tokens, 0)
 	tokens = minimizeTokenGenerator.GenerateTokens(rindDesc, "pendingIngester-2", zones[0], 512, false)
 	require.Len(t, tokens, 512)
+
+	// Should generate tokens only for the ingesters with the smaller Id when multiples ingesters does not have tokens
+	// and have the same registered time
+	now := time.Now()
+	rindDesc.AddIngester("pendingIngester-1", "pendingIngester-1", zones[0], []uint32{}, PENDING, now)
+	rindDesc.AddIngester("pendingIngester-2", "pendingIngester-2", zones[0], []uint32{}, PENDING, now)
+	tokens = minimizeTokenGenerator.GenerateTokens(rindDesc, "pendingIngester-1", zones[0], 512, false)
+	require.Len(t, tokens, 512)
+	tokens = minimizeTokenGenerator.GenerateTokens(rindDesc, "pendingIngester-2", zones[0], 512, false)
+	require.Len(t, tokens, 0)
 }
 
 func generateTokensForIngesters(t *testing.T, rindDesc *Desc, prefix string, zones []string, minimizeTokenGenerator *MinimizeSpreadTokenGenerator, dups map[uint32]bool) {


### PR DESCRIPTION
**What this PR does**:
Fix cases where 2 ingesters have the same `RegisteredTimestamp` and end up generating the same tokens for the MinimizeSpreadToken token generation strategy. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
