### PR TITLE
Make sure bucket index load failure will not increase if there is context error

### DIFF
--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -93,11 +93,6 @@ func NewLoader(cfg LoaderConfig, bucketClient objstore.Bucket, cfgProvider bucke
 // GetIndex returns the bucket index for the given user. It returns the in-memory cached
 // index if available, or load it from the bucket otherwise.
 func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, Status, error) {
-	if ctx.Err() != nil {
-		level.Warn(util_log.WithContext(ctx, l.logger)).Log("msg", "received context error when attempting to load bucket index", "err", ctx.Err())
-		return nil, UnknownStatus, ctx.Err()
-	}
-
 	l.indexesMx.RLock()
 	if entry := l.indexes[userID]; entry != nil {
 		idx := entry.index

--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -126,6 +126,11 @@ func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, Status, e
 		// (eg. corrupted bucket index or not existing).
 		l.cacheIndex(userID, nil, ss, err)
 
+		if ctx.Err() != nil {
+			level.Warn(util_log.WithContext(ctx, l.logger)).Log("msg", "received context error when reading bucket index", "err", ctx.Err())
+			return nil, UnknownStatus, ctx.Err()
+		}
+
 		if errors.Is(err, ErrIndexNotFound) {
 			level.Warn(l.logger).Log("msg", "bucket index not found", "user", userID)
 		} else if errors.Is(err, bucket.ErrCustomerManagedKeyAccessDenied) {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Query failure or timeout would cause context got cancelled anytime before loading bucket index. This change should make sure `cortex_bucket_index_load_failures_total` will not increase if such thing happens.

**Which issue(s) this PR fixes**:


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
