### PR TITLE
Update build image go version to 1.22.5

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.11-bullseye
+FROM golang:1.22.5-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl file jq unzip protobuf-compiler libprotobuf-dev && \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- Updates the build image to use go 1.22.5
- Will update the go.mod in a follow up PR


Reason for updating:
- I want to bring in the latest version of Thanos PromQL engine. They've updated to 1.22 [here](https://github.com/thanos-io/promql-engine/blob/main/go.mod#L3)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
