### PR TITLE
Update faillint for go 1.22

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -30,7 +30,7 @@ RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 &&\
 	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 &&\
 	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 &&\
-	go install github.com/fatih/faillint@v1.11.0 &&\
+	go install github.com/fatih/faillint@v1.13.0 &&\
 	go install github.com/campoy/embedmd@v1.0.0 &&\
 	go install --tags extended github.com/gohugoio/hugo@${HUGO_VERSION} &&\
 	rm -rf /go/pkg /go/src /root/.cache


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- Updating faillint to support go 1.22

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
