### PR TITLE
Using ingester id instead of address on the distributor metrics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [CHANGE] Upgrade Dockerfile Node version from 14x to 18x. #5906
 * [CHANGE] Ingester: Remove `-querier.query-store-for-labels-enabled` flag. Querying long-term store for labels is always enabled. #5984
 * [CHANGE] Server: Instrument `cortex_request_duration_seconds` metric with native histogram. If `native-histograms` feature is enabled in monitoring Prometheus then the metric name needs to be updated in your dashboards. #6056
+* [CHANGE] Distributor/Ingester: Change `cortex_distributor_ingester_appends_total`, `cortex_distributor_ingester_append_failures_total`, `cortex_distributor_ingester_queries_total`, and `cortex_distributor_ingester_query_failures_total` metrics to use the ingester ID instead of its IP as the label value. #6078
 * [FEATURE] Ingester: Experimental: Enable native histogram ingestion via `-blocks-storage.tsdb.enable-native-histograms` flag. #5986
 * [FEATURE] Query Frontend: Added a query rejection mechanism to block resource-intensive queries. #6005
 * [FEATURE] OTLP: Support ingesting OTLP exponential metrics as native histograms. #6071

--- a/pkg/compactor/shuffle_sharding_grouper_test.go
+++ b/pkg/compactor/shuffle_sharding_grouper_test.go
@@ -747,6 +747,10 @@ type RingMock struct {
 	mock.Mock
 }
 
+func (r *RingMock) GetInstanceIdByAddr(addr string) (string, error) {
+	return "", nil
+}
+
 func (r *RingMock) Collect(ch chan<- prometheus.Metric) {}
 
 func (r *RingMock) Describe(ch chan<- *prometheus.Desc) {}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -232,12 +232,12 @@ func TestDistributor_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_distributor_ingester_append_failures_total The total number of failed batch appends sent to ingesters.
 				# TYPE cortex_distributor_ingester_append_failures_total counter
-				cortex_distributor_ingester_append_failures_total{ingester="2",status="5xx",type="samples"} 1
+				cortex_distributor_ingester_append_failures_total{ingester="ingester-2",status="5xx",type="samples"} 1
 				# HELP cortex_distributor_ingester_appends_total The total number of batch appends sent to ingesters.
 				# TYPE cortex_distributor_ingester_appends_total counter
-				cortex_distributor_ingester_appends_total{ingester="0",type="samples"} 1
-				cortex_distributor_ingester_appends_total{ingester="1",type="samples"} 1
-				cortex_distributor_ingester_appends_total{ingester="2",type="samples"} 1
+				cortex_distributor_ingester_appends_total{ingester="ingester-0",type="samples"} 1
+				cortex_distributor_ingester_appends_total{ingester="ingester-1",type="samples"} 1
+				cortex_distributor_ingester_appends_total{ingester="ingester-2",type="samples"} 1
 			`,
 		},
 		"A push to ingesters should report the correct metrics with no samples": {
@@ -251,12 +251,12 @@ func TestDistributor_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_distributor_ingester_append_failures_total The total number of failed batch appends sent to ingesters.
 				# TYPE cortex_distributor_ingester_append_failures_total counter
-				cortex_distributor_ingester_append_failures_total{ingester="2",status="5xx",type="metadata"} 1
+				cortex_distributor_ingester_append_failures_total{ingester="ingester-2",status="5xx",type="metadata"} 1
 				# HELP cortex_distributor_ingester_appends_total The total number of batch appends sent to ingesters.
 				# TYPE cortex_distributor_ingester_appends_total counter
-				cortex_distributor_ingester_appends_total{ingester="0",type="metadata"} 1
-				cortex_distributor_ingester_appends_total{ingester="1",type="metadata"} 1
-				cortex_distributor_ingester_appends_total{ingester="2",type="metadata"} 1
+				cortex_distributor_ingester_appends_total{ingester="ingester-0",type="metadata"} 1
+				cortex_distributor_ingester_appends_total{ingester="ingester-1",type="metadata"} 1
+				cortex_distributor_ingester_appends_total{ingester="ingester-2",type="metadata"} 1
 			`,
 		},
 		"A push to overloaded ingesters should report the correct metrics": {
@@ -268,14 +268,14 @@ func TestDistributor_Push(t *testing.T) {
 			expectedResponse: emptyResponse,
 			ingesterError:    httpgrpc.Errorf(http.StatusTooManyRequests, "Fail"),
 			expectedMetrics: `
-				# HELP cortex_distributor_ingester_append_failures_total The total number of failed batch appends sent to ingesters.
-				# TYPE cortex_distributor_ingester_append_failures_total counter
-				cortex_distributor_ingester_append_failures_total{ingester="2",status="4xx",type="metadata"} 1
 				# HELP cortex_distributor_ingester_appends_total The total number of batch appends sent to ingesters.
 				# TYPE cortex_distributor_ingester_appends_total counter
-				cortex_distributor_ingester_appends_total{ingester="0",type="metadata"} 1
-				cortex_distributor_ingester_appends_total{ingester="1",type="metadata"} 1
-				cortex_distributor_ingester_appends_total{ingester="2",type="metadata"} 1
+				cortex_distributor_ingester_appends_total{ingester="ingester-0",type="metadata"} 1
+				cortex_distributor_ingester_appends_total{ingester="ingester-1",type="metadata"} 1
+				cortex_distributor_ingester_appends_total{ingester="ingester-2",type="metadata"} 1
+				# HELP cortex_distributor_ingester_append_failures_total The total number of failed batch appends sent to ingesters.
+				# TYPE cortex_distributor_ingester_append_failures_total counter
+				cortex_distributor_ingester_append_failures_total{ingester="ingester-2",status="4xx",type="metadata"} 1
 			`,
 		},
 		"A push to 3 happy ingesters should succeed, histograms": {
@@ -436,14 +436,16 @@ func TestDistributor_MetricsCleanup(t *testing.T) {
 	d.latestSeenSampleTimestampPerUser.WithLabelValues("userA").Set(1111)
 
 	h, _, _ := r.GetAllInstanceDescs(ring.WriteNoExtend)
-	d.ingesterAppends.WithLabelValues(h[0].Addr, typeMetadata).Inc()
-	d.ingesterAppendFailures.WithLabelValues(h[0].Addr, typeMetadata, "2xx").Inc()
-	d.ingesterAppends.WithLabelValues(h[1].Addr, typeMetadata).Inc()
-	d.ingesterAppendFailures.WithLabelValues(h[1].Addr, typeMetadata, "2xx").Inc()
-	d.ingesterQueries.WithLabelValues(h[0].Addr).Inc()
-	d.ingesterQueries.WithLabelValues(h[1].Addr).Inc()
-	d.ingesterQueryFailures.WithLabelValues(h[0].Addr).Inc()
-	d.ingesterQueryFailures.WithLabelValues(h[1].Addr).Inc()
+	ingId0, _ := r.GetInstanceIdByAddr(h[0].Addr)
+	ingId1, _ := r.GetInstanceIdByAddr(h[1].Addr)
+	d.ingesterAppends.WithLabelValues(ingId0, typeMetadata).Inc()
+	d.ingesterAppendFailures.WithLabelValues(ingId0, typeMetadata, "2xx").Inc()
+	d.ingesterAppends.WithLabelValues(ingId1, typeMetadata).Inc()
+	d.ingesterAppendFailures.WithLabelValues(ingId1, typeMetadata, "2xx").Inc()
+	d.ingesterQueries.WithLabelValues(ingId0).Inc()
+	d.ingesterQueries.WithLabelValues(ingId1).Inc()
+	d.ingesterQueryFailures.WithLabelValues(ingId0).Inc()
+	d.ingesterQueryFailures.WithLabelValues(ingId1).Inc()
 
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_distributor_deduped_samples_total The total number of deduplicated samples.
@@ -489,27 +491,27 @@ func TestDistributor_MetricsCleanup(t *testing.T) {
 		
 		# HELP cortex_distributor_ingester_append_failures_total The total number of failed batch appends sent to ingesters.
 		# TYPE cortex_distributor_ingester_append_failures_total counter
-		cortex_distributor_ingester_append_failures_total{ingester="0",status="2xx",type="metadata"} 1
-		cortex_distributor_ingester_append_failures_total{ingester="1",status="2xx",type="metadata"} 1
+		cortex_distributor_ingester_append_failures_total{ingester="ingester-0",status="2xx",type="metadata"} 1
+		cortex_distributor_ingester_append_failures_total{ingester="ingester-1",status="2xx",type="metadata"} 1
 		# HELP cortex_distributor_ingester_appends_total The total number of batch appends sent to ingesters.
 		# TYPE cortex_distributor_ingester_appends_total counter
-		cortex_distributor_ingester_appends_total{ingester="0",type="metadata"} 1
-		cortex_distributor_ingester_appends_total{ingester="1",type="metadata"} 1
+		cortex_distributor_ingester_appends_total{ingester="ingester-0",type="metadata"} 1
+		cortex_distributor_ingester_appends_total{ingester="ingester-1",type="metadata"} 1
 		# HELP cortex_distributor_ingester_queries_total The total number of queries sent to ingesters.
 		# TYPE cortex_distributor_ingester_queries_total counter
-		cortex_distributor_ingester_queries_total{ingester="0"} 1
-		cortex_distributor_ingester_queries_total{ingester="1"} 1
+		cortex_distributor_ingester_queries_total{ingester="ingester-0"} 1
+		cortex_distributor_ingester_queries_total{ingester="ingester-1"} 1
 		# HELP cortex_distributor_ingester_query_failures_total The total number of failed queries sent to ingesters.
 		# TYPE cortex_distributor_ingester_query_failures_total counter
-		cortex_distributor_ingester_query_failures_total{ingester="0"} 1
-		cortex_distributor_ingester_query_failures_total{ingester="1"} 1
+		cortex_distributor_ingester_query_failures_total{ingester="ingester-0"} 1
+		cortex_distributor_ingester_query_failures_total{ingester="ingester-1"} 1
 		`), metrics...))
 
 	d.cleanupInactiveUser("userA")
 
 	err := r.KVClient.CAS(context.Background(), ingester.RingKey, func(in interface{}) (interface{}, bool, error) {
 		r := in.(*ring.Desc)
-		delete(r.Ingesters, "0")
+		delete(r.Ingesters, "ingester-0")
 		return in, true, nil
 	})
 
@@ -556,16 +558,16 @@ func TestDistributor_MetricsCleanup(t *testing.T) {
 
 		# HELP cortex_distributor_ingester_append_failures_total The total number of failed batch appends sent to ingesters.
 		# TYPE cortex_distributor_ingester_append_failures_total counter
-		cortex_distributor_ingester_append_failures_total{ingester="1",status="2xx",type="metadata"} 1
+		cortex_distributor_ingester_append_failures_total{ingester="ingester-1",status="2xx",type="metadata"} 1
 		# HELP cortex_distributor_ingester_appends_total The total number of batch appends sent to ingesters.
 		# TYPE cortex_distributor_ingester_appends_total counter
-		cortex_distributor_ingester_appends_total{ingester="1",type="metadata"} 1
+		cortex_distributor_ingester_appends_total{ingester="ingester-1",type="metadata"} 1
 		# HELP cortex_distributor_ingester_queries_total The total number of queries sent to ingesters.
 		# TYPE cortex_distributor_ingester_queries_total counter
-		cortex_distributor_ingester_queries_total{ingester="1"} 1
+		cortex_distributor_ingester_queries_total{ingester="ingester-1"} 1
 		# HELP cortex_distributor_ingester_query_failures_total The total number of failed queries sent to ingesters.
 		# TYPE cortex_distributor_ingester_query_failures_total counter
-		cortex_distributor_ingester_query_failures_total{ingester="1"} 1
+		cortex_distributor_ingester_query_failures_total{ingester="ingester-1"} 1
 		`), metrics...))
 }
 
@@ -2717,8 +2719,9 @@ func prepare(tb testing.TB, cfg prepConfig) ([]*Distributor, []*mockIngester, []
 		} else {
 			tokens = []uint32{uint32((math.MaxUint32 / cfg.numIngesters) * i)}
 		}
-		addr := fmt.Sprintf("%d", i)
-		ingesterDescs[addr] = ring.InstanceDesc{
+		ingester := fmt.Sprintf("ingester-%d", i)
+		addr := fmt.Sprintf("ip-ingester-%d", i)
+		ingesterDescs[ingester] = ring.InstanceDesc{
 			Addr:                addr,
 			Zone:                "",
 			State:               ring.ACTIVE,

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -2,11 +2,11 @@ package distributor
 
 import (
 	"context"
-	"github.com/go-kit/log/level"
 	"io"
 	"sort"
 	"time"
 
+	"github.com/go-kit/log/level"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -166,11 +166,12 @@ func (d *Distributor) queryIngestersExemplars(ctx context.Context, replicationSe
 			return nil, err
 		}
 
-		resp, err := client.(ingester_client.IngesterClient).QueryExemplars(ctx, req)
 		ingesterId, err := d.ingestersRing.GetInstanceIdByAddr(ing.Addr)
 		if err != nil {
 			level.Warn(d.log).Log("msg", "instance not found in the ring", "addr", ing.Addr, "err", err)
 		}
+
+		resp, err := client.(ingester_client.IngesterClient).QueryExemplars(ctx, req)
 
 		d.ingesterQueries.WithLabelValues(ingesterId).Inc()
 		if err != nil {

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -2,6 +2,7 @@ package distributor
 
 import (
 	"context"
+	"github.com/go-kit/log/level"
 	"io"
 	"sort"
 	"time"
@@ -166,9 +167,14 @@ func (d *Distributor) queryIngestersExemplars(ctx context.Context, replicationSe
 		}
 
 		resp, err := client.(ingester_client.IngesterClient).QueryExemplars(ctx, req)
-		d.ingesterQueries.WithLabelValues(ing.Addr).Inc()
+		ingesterId, err := d.ingestersRing.GetInstanceIdByAddr(ing.Addr)
 		if err != nil {
-			d.ingesterQueryFailures.WithLabelValues(ing.Addr).Inc()
+			level.Warn(d.log).Log("msg", "instance not found in the ring", "addr", ing.Addr, "err", err)
+		}
+
+		d.ingesterQueries.WithLabelValues(ingesterId).Inc()
+		if err != nil {
+			d.ingesterQueryFailures.WithLabelValues(ingesterId).Inc()
 			return nil, err
 		}
 
@@ -225,11 +231,17 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 		if err != nil {
 			return nil, err
 		}
-		d.ingesterQueries.WithLabelValues(ing.Addr).Inc()
+
+		ingesterId, err := d.ingestersRing.GetInstanceIdByAddr(ing.Addr)
+		if err != nil {
+			level.Warn(d.log).Log("msg", "instance not found in the ring", "addr", ing.Addr, "err", err)
+		}
+
+		d.ingesterQueries.WithLabelValues(ingesterId).Inc()
 
 		stream, err := client.(ingester_client.IngesterClient).QueryStream(ctx, req)
 		if err != nil {
-			d.ingesterQueryFailures.WithLabelValues(ing.Addr).Inc()
+			d.ingesterQueryFailures.WithLabelValues(ingesterId).Inc()
 			return nil, err
 		}
 		defer stream.CloseSend() //nolint:errcheck
@@ -242,7 +254,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 			} else if err != nil {
 				// Do not track a failure if the context was canceled.
 				if !grpcutil.IsGRPCContextCanceled(err) {
-					d.ingesterQueryFailures.WithLabelValues(ing.Addr).Inc()
+					d.ingesterQueryFailures.WithLabelValues(ingesterId).Inc()
 				}
 
 				return nil, err

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -527,6 +527,16 @@ func (d *Desc) getTokensByZone() map[string][]uint32 {
 	return MergeTokensByZone(zones)
 }
 
+// getInstancesByAddr returns instances id by its address
+func (d *Desc) getInstancesByAddr() map[string]string {
+	instancesByAddMap := make(map[string]string, len(d.Ingesters))
+	for id, instance := range d.Ingesters {
+		instancesByAddMap[instance.Addr] = id
+	}
+
+	return instancesByAddMap
+}
+
 type CompareResult int
 
 // CompareResult responses

--- a/pkg/ring/util_test.go
+++ b/pkg/ring/util_test.go
@@ -17,6 +17,10 @@ type RingMock struct {
 	mock.Mock
 }
 
+func (r *RingMock) GetInstanceIdByAddr(addr string) (string, error) {
+	return "", nil
+}
+
 func (r *RingMock) Collect(ch chan<- prometheus.Metric) {}
 
 func (r *RingMock) Describe(ch chan<- *prometheus.Desc) {}


### PR DESCRIPTION
**What this PR does**:

Change the metrics `cortex_distributor_ingester_appends_total`, `cortex_distributor_ingester_append_failures_total`, `cortex_distributor_ingester_queries_total`, and `cortex_distributor_ingester_query_failures_total` to use the ingester ID instead of the IP as the label value.

Previously, we used the IP as the label value, which made it challenging to correlate IP addresses with specific ingesters and resulted in unclear dashboard graphs.

With this change, the ingester ID will be used instead of the IP.

Before:
![Screenshot 2024-07-10 at 5 01 13 PM](https://github.com/cortexproject/cortex/assets/4027760/8ad302f0-6300-4c02-8fb2-5a7946a78166)


After:
![Screenshot 2024-07-10 at 5 02 27 PM](https://github.com/cortexproject/cortex/assets/4027760/79f4c644-2002-4325-8f80-0c1e2eb626d9)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
