### PR TITLE
Add new query inflight request on ingester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [FEATURE] Ingester: Experimental: Enable native histogram ingestion via `-blocks-storage.tsdb.enable-native-histograms` flag. #5986
 * [FEATURE] Query Frontend: Added a query rejection mechanism to block resource-intensive queries. #6005
 * [FEATURE] OTLP: Support ingesting OTLP exponential metrics as native histograms. #6071
+* [FEATURE] Ingester: Add `ingester.instance-limits.max-inflight-query-requests` to allow limiting ingester concurrent queries. #6081
 * [ENHANCEMENT] rulers: Add support to persist tokens in rulers. #5987
 * [ENHANCEMENT] Query Frontend/Querier: Added store gateway postings touched count and touched size in Querier stats and log in Query Frontend. #5892
 * [ENHANCEMENT] Query Frontend/Querier: Returns `warnings` on prometheus query responses. #5916

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2961,6 +2961,11 @@ instance_limits:
   # CLI flag: -ingester.instance-limits.max-inflight-push-requests
   [max_inflight_push_requests: <int> | default = 0]
 
+  # Max inflight query requests that this ingester can handle (across all
+  # tenants). Additional requests will be rejected. 0 = unlimited.
+  # CLI flag: -ingester.instance-limits.max-inflight-query-requests
+  [max_inflight_query_requests: <int> | default = 0]
+
 # Comma-separated list of metric names, for which
 # -ingester.max-series-per-metric and -ingester.max-global-series-per-metric
 # limits will be ignored. Does not affect max-series-per-user or

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -2279,7 +2279,7 @@ func Test_Ingester_LabelValues(t *testing.T) {
 	}
 }
 
-func Test_Ingester_LabelValue_MaxInflighQueryRequest(t *testing.T) {
+func Test_Ingester_LabelValue_MaxInflightQueryRequest(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
 	cfg.DefaultLimits.MaxInflightQueryRequests = 1
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, prometheus.NewRegistry())
@@ -2437,7 +2437,7 @@ func Test_Ingester_Query(t *testing.T) {
 	}
 }
 
-func Test_Ingester_Query_MaxInflighQueryRequest(t *testing.T) {
+func Test_Ingester_Query_MaxInflightQueryRequest(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
 	cfg.DefaultLimits.MaxInflightQueryRequests = 1
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, prometheus.NewRegistry())
@@ -5005,7 +5005,7 @@ func TestIngester_MaxExemplarsFallBack(t *testing.T) {
 	require.Equal(t, maxExemplars, int64(5))
 }
 
-func Test_Ingester_QueryExemplar_MaxInflighQueryRequest(t *testing.T) {
+func Test_Ingester_QueryExemplar_MaxInflightQueryRequest(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
 	cfg.DefaultLimits.MaxInflightQueryRequests = 1
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, prometheus.NewRegistry())

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -2304,6 +2304,7 @@ func Test_Ingester_LabelValue_MaxInflightQueryRequest(t *testing.T) {
 	rreq := &client.LabelValuesRequest{}
 	_, err = i.LabelValues(ctx, rreq)
 	require.Error(t, err)
+	require.Equal(t, err, errTooManyInflightQueryRequests)
 }
 
 func Test_Ingester_Query(t *testing.T) {
@@ -2463,6 +2464,7 @@ func Test_Ingester_Query_MaxInflightQueryRequest(t *testing.T) {
 	s := &mockQueryStreamServer{ctx: ctx}
 	err = i.QueryStream(rreq, s)
 	require.Error(t, err)
+	require.Equal(t, err, errTooManyInflightQueryRequests)
 }
 
 func TestIngester_Query_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {
@@ -5030,6 +5032,7 @@ func Test_Ingester_QueryExemplar_MaxInflightQueryRequest(t *testing.T) {
 	rreq := &client.ExemplarQueryRequest{}
 	_, err = i.QueryExemplars(ctx, rreq)
 	require.Error(t, err)
+	require.Equal(t, err, errTooManyInflightQueryRequests)
 }
 
 func generateSamplesForLabel(l labels.Labels, count int) *cortexpb.WriteRequest {

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -8,15 +8,17 @@ var (
 	errMaxUsersLimitReached           = errors.New("cannot create TSDB: ingesters's max tenants limit reached")
 	errMaxSeriesLimitReached          = errors.New("cannot add series: ingesters's max series limit reached")
 	errTooManyInflightPushRequests    = errors.New("cannot push: too many inflight push requests in ingester")
+	errTooManyInflightQueryRequests   = errors.New("cannot push: too many inflight query requests in ingester")
 )
 
 // InstanceLimits describes limits used by ingester. Reaching any of these will result in Push method to return
 // (internal) error.
 type InstanceLimits struct {
-	MaxIngestionRate        float64 `yaml:"max_ingestion_rate"`
-	MaxInMemoryTenants      int64   `yaml:"max_tenants"`
-	MaxInMemorySeries       int64   `yaml:"max_series"`
-	MaxInflightPushRequests int64   `yaml:"max_inflight_push_requests"`
+	MaxIngestionRate         float64 `yaml:"max_ingestion_rate"`
+	MaxInMemoryTenants       int64   `yaml:"max_tenants"`
+	MaxInMemorySeries        int64   `yaml:"max_series"`
+	MaxInflightPushRequests  int64   `yaml:"max_inflight_push_requests"`
+	MaxInflightQueryRequests int64   `yaml:"max_inflight_query_requests"`
 }
 
 // Sets default limit values for unmarshalling.

--- a/pkg/ingester/instance_limits_test.go
+++ b/pkg/ingester/instance_limits_test.go
@@ -9,10 +9,11 @@ import (
 
 func TestInstanceLimitsUnmarshal(t *testing.T) {
 	defaultInstanceLimits = &InstanceLimits{
-		MaxIngestionRate:        10,
-		MaxInMemoryTenants:      20,
-		MaxInMemorySeries:       30,
-		MaxInflightPushRequests: 40,
+		MaxIngestionRate:         10,
+		MaxInMemoryTenants:       20,
+		MaxInMemorySeries:        30,
+		MaxInflightPushRequests:  40,
+		MaxInflightQueryRequests: 50,
 	}
 
 	l := InstanceLimits{}
@@ -24,6 +25,7 @@ max_tenants: 50000
 	require.NoError(t, yaml.UnmarshalStrict([]byte(input), &l))
 	require.Equal(t, float64(125.678), l.MaxIngestionRate)
 	require.Equal(t, int64(50000), l.MaxInMemoryTenants)
-	require.Equal(t, int64(30), l.MaxInMemorySeries)       // default value
-	require.Equal(t, int64(40), l.MaxInflightPushRequests) // default value
+	require.Equal(t, int64(30), l.MaxInMemorySeries)        // default value
+	require.Equal(t, int64(40), l.MaxInflightPushRequests)  // default value
+	require.Equal(t, int64(50), l.MaxInflightQueryRequests) // default value
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR extended work done at #5798.
From tests, it was noticed that the metrics is accurate but does not show the impacting volume on ingester. I am proposing to remove from the metric any pre and post execution and count the metric only when the ingester is actually resolving the query. That from tests is when we see issues with CPU usage on ingesters.
Also adding a new ingester instance limit, similar to the existent `max_inflight_push_requests` to limit the max number of inflight queries on ingesters. The reads are from any GET operation on ingesters.

**Checklist**
- [X] Tests updated
- [] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
