### PR TITLE
Stepping down as Cortex maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,4 @@
 Alan Protasio, Amazon Web Services <alanprot@gmail.com> (@alanprot)
-Alvin Lin, Amazon Web Services <alvinlin123@gmail.com> (@alvinlin123)
 Ben Ye, Amazon Web Services <yb532204897@gmail.com> (@yeya24)
 Charlie Le, Apple <chtle4@gmail.com> (@CharlieTLe)
 Friedrich Gonzalez, Adobe <friedrichg@gmail.com> (@friedrichg)


### PR DESCRIPTION
I can't believe this day would come, but I am stepping down as Cortex maintainer because I no longer have capacity to give Cortex the love it needs anymore. Also, Cortex is in good hands with existing maintainers from diverse set of companies.

It's been a fun ride. I still remember my [first Cortex PR](https://github.com/cortexproject/cortex/pull/2741) that allows me to build Cortex in my employer's network, and [the day I became maintainer 3 years ago](https://github.com/cortexproject/cortex/commit/b4daa22055ffec14311d8b5d2d9429f1bd575dad). It was full of joys and emotions. But there is always an end to a party, and for me it's today. 

Thank you all for the great work and support thus far!
