### PR TITLE
fix(build): docker compose environments

### DIFF
--- a/development/tsdb-blocks-storage-s3-gossip/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3-gossip/config/cortex.yaml
@@ -90,7 +90,6 @@ ruler:
       store: memberlist
 
   alertmanager_url: http://alertmanager:8010/alertmanager
-  enable_alertmanager_v2: false
 
 ruler_storage:
   backend: s3

--- a/development/tsdb-blocks-storage-s3-gossip/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3-gossip/dev.dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.18
 ENV CGO_ENABLED=0
-RUN go get github.com/go-delve/delve/cmd/dlv
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 FROM alpine:3.18
 

--- a/development/tsdb-blocks-storage-s3-gossip/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3-gossip/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 services:
 
   consul:
-    image: consul
+    image: consul:1.15.4
     command: [ "agent", "-dev" ,"-client=0.0.0.0", "-log-level=info" ]
     ports:
       - 8500:8500

--- a/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 services:
 
   consul:
-    image: consul
+    image: consul:1.15.4
     command: [ "agent", "-dev" ,"-client=0.0.0.0", "-log-level=info" ]
     ports:
       - 8500:8500

--- a/development/tsdb-blocks-storage-s3/config/cortex.yaml
+++ b/development/tsdb-blocks-storage-s3/config/cortex.yaml
@@ -80,7 +80,6 @@ ruler:
         host: consul:8500
 
   alertmanager_url: http://alertmanager-1:8031/alertmanager,http://alertmanager-2:8032/alertmanager,http://alertmanager-3:8033/alertmanager
-  enable_alertmanager_v2: false
 
 ruler_storage:
   backend: s3

--- a/development/tsdb-blocks-storage-s3/dev.dockerfile
+++ b/development/tsdb-blocks-storage-s3/dev.dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.18
 ENV CGO_ENABLED=0
-RUN go get github.com/go-delve/delve/cmd/dlv
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 FROM alpine:3.18
 

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 services:
 
   consul:
-    image: consul
+    image: consul:1.15.4
     command: [ "agent", "-dev" ,"-client=0.0.0.0", "-log-level=info" ]
     ports:
       - 8500:8500

--- a/development/tsdb-blocks-storage-swift-single-binary/docker-compose.yml
+++ b/development/tsdb-blocks-storage-swift-single-binary/docker-compose.yml
@@ -1,14 +1,13 @@
-version: '3.4'
 services:
 
   consul:
-    image: consul
+    image: consul:1.15.4
     command: [ "agent", "-dev" ,"-client=0.0.0.0", "-log-level=info" ]
     ports:
       - 8500:8500
 
   swift:
-    image: beaukode/docker-swift-onlyone-authv2-keystone
+    image: beaukode/docker-swift-onlyone-authv2-keystone:latest
     volumes:
       - .data-swift:/srv:delegated
     ports:


### PR DESCRIPTION
Fixed cortex dockerfile and updated consul docker image tag so that docker compose is able to successfully pull consul and swift images.

Removed invalid enable_alertmanager_v2 cortex config param from microservice mode config files to fix cortex start up.

cleanup: removed 'version' compose tag to silence deprecation warning

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #None

**Checklist**
- [N/A] Tests updated
- [N/A] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
