### PR TITLE
Fix cortex_ingester_tsdb_mmap_chunks_total metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [BUGFIX] Ingester: Fix issue with the minimize token generator where it was not taking in consideration the current ownerhip of an instance when generating extra tokens. #6062
 * [BUGFIX] Scheduler: Fix user queue in scheduler that was not thread-safe. #6077
 * [BUGFIX] Ingester: Include out-of-order head compaction when compacting TSDB head. #6108
+* [BUGFIX] Ingester: Fix `cortex_ingester_tsdb_mmap_chunks_total` metric. #6134
 
 ## 1.17.1 2024-05-20
 

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -632,7 +632,7 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCountersPerUserWithLabels(out, sm.tsdbOutOfOrderSamplesAppended, "prometheus_tsdb_head_out_of_order_samples_appended_total", "type")
 	data.SendSumOfCounters(out, sm.tsdbSnapshotReplayErrorTotal, "prometheus_tsdb_snapshot_replay_error_total")
 	data.SendSumOfHistograms(out, sm.tsdbOOOHistogram, "prometheus_tsdb_sample_ooo_delta")
-	data.SendSumOfGauges(out, sm.tsdbMmapChunksTotal, "prometheus_tsdb_mmap_chunks_total")
+	data.SendSumOfCounters(out, sm.tsdbMmapChunksTotal, "prometheus_tsdb_mmap_chunks_total")
 	data.SendSumOfCounters(out, sm.checkpointDeleteFail, "prometheus_tsdb_checkpoint_deletions_failed_total")
 	data.SendSumOfCounters(out, sm.checkpointDeleteTotal, "prometheus_tsdb_checkpoint_deletions_total")
 	data.SendSumOfCounters(out, sm.checkpointCreationFail, "prometheus_tsdb_checkpoint_creations_failed_total")

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -324,8 +324,8 @@ func TestTSDBMetrics(t *testing.T) {
 			# TYPE cortex_ingester_tsdb_mmap_chunk_corruptions_total counter
 			cortex_ingester_tsdb_mmap_chunk_corruptions_total 2577406
         	# HELP cortex_ingester_tsdb_mmap_chunks_total Total number of chunks that were memory-mapped.
-        	# TYPE cortex_ingester_tsdb_mmap_chunks_total gauge
-        	cortex_ingester_tsdb_mmap_chunks_total 0
+        	# TYPE cortex_ingester_tsdb_mmap_chunks_total counter
+        	cortex_ingester_tsdb_mmap_chunks_total 312
         	# HELP cortex_ingester_tsdb_out_of_order_samples_total Total number of out of order samples ingestion failed attempts due to out of order being disabled.
 			# TYPE cortex_ingester_tsdb_out_of_order_samples_total counter
         	cortex_ingester_tsdb_out_of_order_samples_total{type="float",user="user1"} 102
@@ -576,8 +576,8 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 			# TYPE cortex_ingester_tsdb_mmap_chunk_corruptions_total counter
 			cortex_ingester_tsdb_mmap_chunk_corruptions_total 2577406
         	# HELP cortex_ingester_tsdb_mmap_chunks_total Total number of chunks that were memory-mapped.
-        	# TYPE cortex_ingester_tsdb_mmap_chunks_total gauge
-        	cortex_ingester_tsdb_mmap_chunks_total 0
+        	# TYPE cortex_ingester_tsdb_mmap_chunks_total counter
+        	cortex_ingester_tsdb_mmap_chunks_total 312
         	# HELP cortex_ingester_tsdb_out_of_order_samples_total Total number of out of order samples ingestion failed attempts due to out of order being disabled.
 			# TYPE cortex_ingester_tsdb_out_of_order_samples_total counter
         	cortex_ingester_tsdb_out_of_order_samples_total{type="float",user="user1"} 102


### PR DESCRIPTION
**What this PR does**:

Fix `cortex_ingester_tsdb_mmap_chunks_total` metric. This metric is `prometheus_tsdb_mmap_chunks_total` is a counter, not a gauge. 

https://github.com/prometheus/prometheus/blob/5681ec50e1fc1e591c4dcc63eb343478ea2082ee/tsdb/head.go#L498-L501
![Screenshot 2024-08-02 at 3 41 16 PM](https://github.com/user-attachments/assets/3bf9927e-a530-44d3-81ab-3fb144c8b690)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
