### PR TITLE
Fix OTLP native histogram push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [FEATURE] Ruler: Support sending native histogram samples to Ingester. #6029
 * [FEATURE] Ruler: Add support for filtering out alerts in ListRules API. #6011
 * [FEATURE] Query Frontend: Added a query rejection mechanism to block resource-intensive queries. #6005
-* [FEATURE] OTLP: Support ingesting OTLP exponential metrics as native histograms. #6071
+* [FEATURE] OTLP: Support ingesting OTLP exponential metrics as native histograms. #6071 #6135
 * [FEATURE] Ingester: Add `ingester.instance-limits.max-inflight-query-requests` to allow limiting ingester concurrent queries. #6081
 * [FEATURE] Distributor: Add `validation.max-native-histogram-buckets` to limit max number of bucket count. Distributor will try to automatically reduce histogram resolution until it is within the bucket limit or resolution cannot be reduced anymore. #6104
 * [FEATURE] Store Gateway: Token bucket limiter. #6016

--- a/integration/e2ecortex/client.go
+++ b/integration/e2ecortex/client.go
@@ -173,7 +173,7 @@ func createDataPointsGauge(newMetric pmetric.Metric, attributes map[string]any, 
 }
 
 func createDataPointsExponentialHistogram(newMetric pmetric.Metric, attributes map[string]any, histograms []prompb.Histogram) {
-	newMetric.SetEmptyExponentialHistogram()
+	newMetric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	for _, h := range histograms {
 		datapoint := newMetric.ExponentialHistogram().DataPoints().AppendEmpty()
 		datapoint.SetTimestamp(pcommon.Timestamp(h.Timestamp * time.Millisecond.Nanoseconds()))

--- a/integration/otlp_test.go
+++ b/integration/otlp_test.go
@@ -77,7 +77,7 @@ func TestOTLP(t *testing.T) {
 
 	i := rand.Uint32()
 	histogramSeries := e2e.GenerateHistogramSeries("histogram_series", now, i, false, prompb.Label{Name: "job", Value: "test"})
-	res, err = c.Push(histogramSeries)
+	res, err = c.OTLP(histogramSeries)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 

--- a/pkg/util/push/otlp.go
+++ b/pkg/util/push/otlp.go
@@ -54,9 +54,10 @@ func OTLPHandler(sourceIPs *middleware.SourceIPExtractor, push Func) http.Handle
 		tsList := []cortexpb.PreallocTimeseries(nil)
 		for _, v := range promConverter.TimeSeries() {
 			tsList = append(tsList, cortexpb.PreallocTimeseries{TimeSeries: &cortexpb.TimeSeries{
-				Labels:    makeLabels(v.Labels),
-				Samples:   makeSamples(v.Samples),
-				Exemplars: makeExemplars(v.Exemplars),
+				Labels:     makeLabels(v.Labels),
+				Samples:    makeSamples(v.Samples),
+				Exemplars:  makeExemplars(v.Exemplars),
+				Histograms: makeHistograms(v.Histograms),
 			}})
 		}
 		prwReq.Timeseries = tsList
@@ -104,6 +105,14 @@ func makeExemplars(in []prompb.Exemplar) []cortexpb.Exemplar {
 			Value:       e.Value,
 			TimestampMs: e.Timestamp,
 		})
+	}
+	return out
+}
+
+func makeHistograms(in []prompb.Histogram) []cortexpb.Histogram {
+	out := make([]cortexpb.Histogram, 0, len(in))
+	for _, h := range in {
+		out = append(out, cortexpb.HistogramPromProtoToHistogramProto(h))
 	}
 	return out
 }

--- a/pkg/util/push/otlp_test.go
+++ b/pkg/util/push/otlp_test.go
@@ -124,6 +124,11 @@ func verifyOTLPWriteRequestHandler(t *testing.T, expectSource cortexpb.WriteRequ
 		// TODO: test more things
 		assert.Equal(t, expectSource, request.Source)
 		assert.False(t, request.SkipLabelNameValidation)
+		for _, ts := range request.Timeseries {
+			assert.NotEmpty(t, ts.Labels)
+			// Make sure at least one of sample, exemplar or histogram is set.
+			assert.True(t, len(ts.Samples) > 0 || len(ts.Exemplars) > 0 || len(ts.Histograms) > 0)
+		}
 		return &cortexpb.WriteResponse{}, nil
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Seems `Histograms` was not successfully included as part of the Push request when calling the OTLP handler. The unit test didn't catch this problem with insufficient coverage and there is a bug in the integration test where it calls `Push` instead of `OTLP` handler

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
