### PR TITLE
Add cortex_query_samples_total metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [ENHANCEMENT] Ruler: Add support for filtering by `state` and `health` field on Rules API. #6040
 * [ENHANCEMENT] Compactor: Split cleaner cycle for active and deleted tenants. #6112
 * [ENHANCEMENT] Compactor: Introduce cleaner visit marker. #6113
+* [ENHANCEMENT] Query Frontend: Add cortex_query_samples_total metric. #6142
 * [BUGFIX] Configsdb: Fix endline issue in db password. #5920
 * [BUGFIX] Ingester: Fix `user` and `type` labels for the `cortex_ingester_tsdb_head_samples_appended_total` TSDB metric. #5952
 * [BUGFIX] Querier: Enforce max query length check for `/api/v1/series` API even though `ignoreMaxQueryLength` is set to true. #6018

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -188,7 +188,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name:               "test handler with stats enabled",
 			cfg:                HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics:    3,
+			expectedMetrics:    4,
 			roundTripperFunc:   roundTripper,
 			expectedStatusCode: http.StatusOK,
 		},
@@ -202,7 +202,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name:            "test handler with reasonResponseTooLarge",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics: 3,
+			expectedMetrics: 4,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusRequestEntityTooLarge,
@@ -218,7 +218,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name:            "test handler with reasonTooManyRequests",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics: 3,
+			expectedMetrics: 4,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusTooManyRequests,
@@ -234,7 +234,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name:            "test handler with reasonTooManySamples",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics: 3,
+			expectedMetrics: 4,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusUnprocessableEntity,
@@ -250,7 +250,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name:            "test handler with reasonTooLongRange",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics: 3,
+			expectedMetrics: 4,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusUnprocessableEntity,
@@ -266,7 +266,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name:            "test handler with reasonSeriesFetched",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics: 3,
+			expectedMetrics: 4,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusUnprocessableEntity,
@@ -282,7 +282,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name:            "test handler with reasonChunksFetched",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics: 3,
+			expectedMetrics: 4,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusUnprocessableEntity,
@@ -298,7 +298,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name:            "test handler with reasonChunkBytesFetched",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics: 3,
+			expectedMetrics: 4,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusUnprocessableEntity,
@@ -314,7 +314,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name:            "test handler with reasonDataBytesFetched",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics: 3,
+			expectedMetrics: 4,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusUnprocessableEntity,
@@ -330,7 +330,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name:            "test handler with reasonSeriesLimitStoreGateway",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics: 3,
+			expectedMetrics: 4,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusUnprocessableEntity,
@@ -346,7 +346,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name:            "test handler with reasonChunksLimitStoreGateway",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics: 3,
+			expectedMetrics: 4,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusUnprocessableEntity,
@@ -362,7 +362,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			name:            "test handler with reasonBytesLimitStoreGateway",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
-			expectedMetrics: 3,
+			expectedMetrics: 4,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusUnprocessableEntity,
@@ -393,6 +393,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				reg,
 				"cortex_query_seconds_total",
 				"cortex_query_fetched_series_total",
+				"cortex_query_samples_total",
 				"cortex_query_fetched_chunks_bytes_total",
 			)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Add a new per tenant metric called _cortex_query_samples_total_ which contains the number of fetched samples for each query requests. It provides an accurate count of fetched samples for each tenants.
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `x`, `[BUGFIX]`
