### PR TITLE
Support Ruler to query Query Frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [FEATURE] Ruler: Experimental: Add `ruler.frontend-address` to allow query to query frontends instead of ingesters. #6151
 * [FEATURE] Ruler: Minimize chances of missed rule group evaluations that can occur due to OOM kills, bad underlying nodes, or due to an unhealthy ruler that appears in the ring as healthy. This feature is enabled via `-ruler.enable-ha-evaluation` flag. #6129
 * [ENHANCEMENT] Ruler: Add new ruler metric `cortex_ruler_rule_groups_in_store` that is the total rule groups per tenant in store, which can be used to compare with `cortex_prometheus_rule_group_rules` to count the number of rule groups that are not loaded by a ruler. #5869
 * [ENHANCEMENT] Ingester/Ring: New `READONLY` status on ring to be used by Ingester. New ingester API to change mode of ingester #6163

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4067,6 +4067,80 @@ The `redis_config` configures the Redis backend cache.
 The `ruler_config` configures the Cortex ruler.
 
 ```yaml
+# [Experimental] GRPC listen address of the Query Frontend, in host:port format.
+# If set, Ruler queries to Query Frontends via gRPC. If not set, ruler queries
+# to Ingesters directly.
+# CLI flag: -ruler.frontend-address
+[frontend_address: <string> | default = ""]
+
+frontend_client:
+  # gRPC client max receive message size (bytes).
+  # CLI flag: -ruler.frontendClient.grpc-max-recv-msg-size
+  [max_recv_msg_size: <int> | default = 104857600]
+
+  # gRPC client max send message size (bytes).
+  # CLI flag: -ruler.frontendClient.grpc-max-send-msg-size
+  [max_send_msg_size: <int> | default = 16777216]
+
+  # Use compression when sending messages. Supported values are: 'gzip',
+  # 'snappy', 'snappy-block' ,'zstd' and '' (disable compression)
+  # CLI flag: -ruler.frontendClient.grpc-compression
+  [grpc_compression: <string> | default = ""]
+
+  # Rate limit for gRPC client; 0 means disabled.
+  # CLI flag: -ruler.frontendClient.grpc-client-rate-limit
+  [rate_limit: <float> | default = 0]
+
+  # Rate limit burst for gRPC client.
+  # CLI flag: -ruler.frontendClient.grpc-client-rate-limit-burst
+  [rate_limit_burst: <int> | default = 0]
+
+  # Enable backoff and retry when we hit ratelimits.
+  # CLI flag: -ruler.frontendClient.backoff-on-ratelimits
+  [backoff_on_ratelimits: <boolean> | default = false]
+
+  backoff_config:
+    # Minimum delay when backing off.
+    # CLI flag: -ruler.frontendClient.backoff-min-period
+    [min_period: <duration> | default = 100ms]
+
+    # Maximum delay when backing off.
+    # CLI flag: -ruler.frontendClient.backoff-max-period
+    [max_period: <duration> | default = 10s]
+
+    # Number of times to backoff and retry before failing.
+    # CLI flag: -ruler.frontendClient.backoff-retries
+    [max_retries: <int> | default = 10]
+
+  # Enable TLS in the GRPC client. This flag needs to be enabled when any other
+  # TLS flag is set. If set to false, insecure connection to gRPC server will be
+  # used.
+  # CLI flag: -ruler.frontendClient.tls-enabled
+  [tls_enabled: <boolean> | default = false]
+
+  # Path to the client certificate file, which will be used for authenticating
+  # with the server. Also requires the key path to be configured.
+  # CLI flag: -ruler.frontendClient.tls-cert-path
+  [tls_cert_path: <string> | default = ""]
+
+  # Path to the key file for the client certificate. Also requires the client
+  # certificate to be configured.
+  # CLI flag: -ruler.frontendClient.tls-key-path
+  [tls_key_path: <string> | default = ""]
+
+  # Path to the CA certificates file to validate server certificate against. If
+  # not set, the host's root CA certificates are used.
+  # CLI flag: -ruler.frontendClient.tls-ca-path
+  [tls_ca_path: <string> | default = ""]
+
+  # Override the expected name on the server certificate.
+  # CLI flag: -ruler.frontendClient.tls-server-name
+  [tls_server_name: <string> | default = ""]
+
+  # Skip validating server certificate.
+  # CLI flag: -ruler.frontendClient.tls-insecure-skip-verify
+  [tls_insecure_skip_verify: <boolean> | default = false]
+
 # URL of alerts return path.
 # CLI flag: -ruler.external.url
 [external_url: <url> | default = ]

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -35,6 +35,7 @@ Cortex is an actively developed project and we want to encourage the introductio
 
 Currently experimental features are:
 
+- Ruler: Evaluate rules to query frontend instead of ingesters (enabled via `-ruler.frontend-address` )
 - S3 Server Side Encryption (SSE) using KMS (including per-tenant KMS config overrides).
 - Azure blob storage.
 - Zone awareness based replication.

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -548,6 +548,8 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 	}
 
 	t.Cfg.Ruler.LookbackDelta = t.Cfg.Querier.LookbackDelta
+	t.Cfg.Ruler.FrontendTimeout = t.Cfg.Querier.Timeout
+	t.Cfg.Ruler.PrometheusHTTPPrefix = t.Cfg.API.PrometheusHTTPPrefix
 	t.Cfg.Ruler.Ring.ListenPort = t.Cfg.Server.GRPCListenPort
 	metrics := ruler.NewRuleEvalMetrics(t.Cfg.Ruler, prometheus.DefaultRegisterer)
 

--- a/pkg/ruler/frontend_client.go
+++ b/pkg/ruler/frontend_client.go
@@ -1,0 +1,105 @@
+package ruler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/version"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/util/spanlogger"
+)
+
+const (
+	orgIDHeader      = "X-Scope-OrgID"
+	instantQueryPath = "/api/v1/query"
+	mimeTypeForm     = "application/x-www-form-urlencoded"
+	contentTypeJSON  = "application/json"
+)
+
+type FrontendClient struct {
+	client               httpgrpc.HTTPClient
+	timeout              time.Duration
+	prometheusHTTPPrefix string
+	jsonDecoder          JsonDecoder
+}
+
+func NewFrontendClient(client httpgrpc.HTTPClient, timeout time.Duration, prometheusHTTPPrefix string) *FrontendClient {
+	return &FrontendClient{
+		client:               client,
+		timeout:              timeout,
+		prometheusHTTPPrefix: prometheusHTTPPrefix,
+		jsonDecoder:          JsonDecoder{},
+	}
+}
+
+func (p *FrontendClient) makeRequest(ctx context.Context, qs string, ts time.Time) (*httpgrpc.HTTPRequest, error) {
+	args := make(url.Values)
+	args.Set("query", qs)
+	if !ts.IsZero() {
+		args.Set("time", ts.Format(time.RFC3339Nano))
+	}
+	body := []byte(args.Encode())
+
+	//lint:ignore faillint wrapper around upstream method
+	orgID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	req := &httpgrpc.HTTPRequest{
+		Method: http.MethodPost,
+		Url:    p.prometheusHTTPPrefix + instantQueryPath,
+		Body:   body,
+		Headers: []*httpgrpc.Header{
+			{Key: textproto.CanonicalMIMEHeaderKey("User-Agent"), Values: []string{fmt.Sprintf("Cortex/%s", version.Version)}},
+			{Key: textproto.CanonicalMIMEHeaderKey("Content-Type"), Values: []string{mimeTypeForm}},
+			{Key: textproto.CanonicalMIMEHeaderKey("Content-Length"), Values: []string{strconv.Itoa(len(body))}},
+			{Key: textproto.CanonicalMIMEHeaderKey("Accept"), Values: []string{contentTypeJSON}},
+			{Key: textproto.CanonicalMIMEHeaderKey(orgIDHeader), Values: []string{orgID}},
+		},
+	}
+
+	return req, nil
+}
+
+func (p *FrontendClient) InstantQuery(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
+	log, ctx := spanlogger.New(ctx, "FrontendClient.InstantQuery")
+	defer log.Span.Finish()
+
+	req, err := p.makeRequest(ctx, qs, t)
+	if err != nil {
+		level.Error(log).Log("err", err, "query", qs)
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	resp, err := p.client.Handle(ctx, req)
+
+	if err != nil {
+		level.Error(log).Log("err", err, "query", qs)
+		return nil, err
+	}
+
+	vector, warning, err := p.jsonDecoder.Decode(resp.Body)
+	if err != nil {
+		level.Error(log).Log("err", err, "query", qs)
+		return nil, err
+	}
+
+	if len(warning) > 0 {
+		level.Warn(log).Log("warnings", warning, "query", qs)
+	}
+
+	return vector, nil
+}

--- a/pkg/ruler/frontend_client_pool.go
+++ b/pkg/ruler/frontend_client_pool.go
@@ -1,0 +1,84 @@
+package ruler
+
+import (
+	"time"
+
+	"github.com/go-kit/log"
+	otgrpc "github.com/opentracing-contrib/go-grpc"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/middleware"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/cortexproject/cortex/pkg/ring/client"
+	"github.com/cortexproject/cortex/pkg/util/grpcclient"
+	cortexmiddleware "github.com/cortexproject/cortex/pkg/util/middleware"
+)
+
+type frontendPool struct {
+	timeout              time.Duration
+	prometheusHTTPPrefix string
+	grpcConfig           grpcclient.Config
+
+	frontendClientRequestDuration *prometheus.HistogramVec
+}
+
+func newFrontendPool(cfg Config, log log.Logger, reg prometheus.Registerer) *client.Pool {
+	p := &frontendPool{
+		timeout:              cfg.FrontendTimeout,
+		prometheusHTTPPrefix: cfg.PrometheusHTTPPrefix,
+		grpcConfig:           cfg.GRPCClientConfig,
+		frontendClientRequestDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "cortex_ruler_query_frontend_request_duration_seconds",
+			Help:    "Time spend doing requests to frontend.",
+			Buckets: prometheus.ExponentialBuckets(0.001, 4, 6),
+		}, []string{"operation", "status_code"}),
+	}
+
+	frontendClientsGauge := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		Name: "cortex_ruler_query_frontend_clients",
+		Help: "The current number of clients connected to query-frontend.",
+	})
+
+	poolConfig := client.PoolConfig{
+		CheckInterval:      time.Minute,
+		HealthCheckEnabled: true,
+		HealthCheckTimeout: 10 * time.Second,
+	}
+
+	return client.NewPool("frontend", poolConfig, nil, p.createFrontendClient, frontendClientsGauge, log)
+}
+
+func (f *frontendPool) createFrontendClient(addr string) (client.PoolClient, error) {
+	opts, err := f.grpcConfig.DialOption([]grpc.UnaryClientInterceptor{
+		otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()),
+		middleware.ClientUserHeaderInterceptor,
+		cortexmiddleware.PrometheusGRPCUnaryInstrumentation(f.frontendClientRequestDuration),
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := grpc.NewClient(addr, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &frontendClient{
+		FrontendClient: NewFrontendClient(httpgrpc.NewHTTPClient(conn), f.timeout, f.prometheusHTTPPrefix),
+		HealthClient:   grpc_health_v1.NewHealthClient(conn),
+	}, nil
+}
+
+type frontendClient struct {
+	*FrontendClient
+	grpc_health_v1.HealthClient
+	conn *grpc.ClientConn
+}
+
+func (f *frontendClient) Close() error {
+	return f.conn.Close()
+}

--- a/pkg/ruler/frontend_client_test.go
+++ b/pkg/ruler/frontend_client_test.go
@@ -1,0 +1,157 @@
+package ruler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/user"
+	"google.golang.org/grpc"
+)
+
+type mockHTTPGRPCClient func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error)
+
+func (c mockHTTPGRPCClient) Handle(ctx context.Context, req *httpgrpc.HTTPRequest, opts ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+	return c(ctx, req, opts...)
+}
+
+func TestTimeout(t *testing.T) {
+	mockClientFn := func(ctx context.Context, _ *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	ctx := context.Background()
+	ctx = user.InjectOrgID(ctx, "userID")
+	frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus")
+	_, err := frontendClient.InstantQuery(ctx, "query", time.Now())
+	require.Equal(t, context.DeadlineExceeded, err)
+}
+
+func TestNoOrgId(t *testing.T) {
+	mockClientFn := func(ctx context.Context, _ *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+		return nil, nil
+	}
+	frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus")
+	_, err := frontendClient.InstantQuery(context.Background(), "query", time.Now())
+	require.Equal(t, user.ErrNoOrgID, err)
+}
+
+func TestInstantQuery(t *testing.T) {
+	tests := []struct {
+		description  string
+		responseBody string
+		expected     promql.Vector
+		expectedErr  error
+	}{
+		{
+			description: "empty vector",
+			responseBody: `{
+					"status": "success",
+					"data": {"resultType":"vector","result":[]}
+				}`,
+			expected:    promql.Vector{},
+			expectedErr: nil,
+		},
+		{
+			description: "vector with series",
+			responseBody: `{
+					"status": "success",
+					"data": {
+						"resultType": "vector",
+						"result": [
+							{
+								"metric": {"foo":"bar"},
+								"value": [1724146338.123,"1.234"]
+							},
+							{
+								"metric": {"bar":"baz"},
+								"value": [1724146338.456,"5.678"]
+							}
+						]
+					}
+				}`,
+			expected: promql.Vector{
+				{
+					Metric: labels.FromStrings("foo", "bar"),
+					T:      1724146338123,
+					F:      1.234,
+				},
+				{
+					Metric: labels.FromStrings("bar", "baz"),
+					T:      1724146338456,
+					F:      5.678,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			description: "get scalar",
+			responseBody: `{
+					"status": "success",
+					"data": {"resultType":"scalar","result":[1724146338.123,"1.234"]}
+				}`,
+			expected: promql.Vector{
+				{
+					Metric: labels.EmptyLabels(),
+					T:      1724146338123,
+					F:      1.234,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			description: "get matrix",
+			responseBody: `{
+					"status": "success",
+					"data": {"resultType":"matrix","result":[]}
+				}`,
+			expected:    nil,
+			expectedErr: errors.New("rule result is not a vector or scalar"),
+		},
+		{
+			description: "get string",
+			responseBody: `{
+					"status": "success",
+					"data": {"resultType":"string","result":[1724146338.123,"string"]}
+				}`,
+			expected:    nil,
+			expectedErr: errors.New("rule result is not a vector or scalar"),
+		},
+		{
+			description: "get error",
+			responseBody: `{
+					"status": "error",
+					"errorType": "errorExec",
+					"error": "something wrong"
+				}`,
+			expected:    nil,
+			expectedErr: errors.New("failed to execute query with error: something wrong"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			mockClientFn := func(ctx context.Context, _ *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+				return &httpgrpc.HTTPResponse{
+					Code: http.StatusOK,
+					Headers: []*httpgrpc.Header{
+						{Key: "Content-Type", Values: []string{"application/json"}},
+					},
+					Body: []byte(test.responseBody),
+				}, nil
+			}
+			ctx := context.Background()
+			ctx = user.InjectOrgID(ctx, "userID")
+			frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus")
+			vector, err := frontendClient.InstantQuery(ctx, "query", time.Now())
+			require.Equal(t, test.expected, vector)
+			require.Equal(t, test.expectedErr, err)
+		})
+	}
+}

--- a/pkg/ruler/frontend_decoder.go
+++ b/pkg/ruler/frontend_decoder.go
@@ -1,0 +1,87 @@
+package ruler
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+)
+
+const (
+	statusError = "error"
+)
+
+type JsonDecoder struct{}
+type Warning []string
+
+func (j JsonDecoder) Decode(body []byte) (promql.Vector, Warning, error) {
+	var response struct {
+		Status    string          `json:"status"`
+		Data      json.RawMessage `json:"data"`
+		ErrorType string          `json:"errorType"`
+		Warnings  Warning         `json:"warnings"`
+		Error     string          `json:"error"`
+	}
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&response); err != nil {
+		return nil, nil, err
+	}
+	if response.Status == statusError {
+		return nil, response.Warnings, fmt.Errorf("failed to execute query with error: %s", response.Error)
+	}
+	data := struct {
+		Type   model.ValueType `json:"resultType"`
+		Result json.RawMessage `json:"result"`
+	}{}
+
+	if err := json.Unmarshal(response.Data, &data); err != nil {
+		return nil, response.Warnings, err
+	}
+
+	switch data.Type {
+	case model.ValScalar:
+		var scalar model.Scalar
+		if err := json.Unmarshal(data.Result, &scalar); err != nil {
+			return nil, nil, err
+		}
+		return j.scalarToPromQLVector(scalar), response.Warnings, nil
+	case model.ValVector:
+		var vector model.Vector
+		if err := json.Unmarshal(data.Result, &vector); err != nil {
+			return nil, nil, err
+		}
+		return j.vectorToPromQLVector(vector), response.Warnings, nil
+	default:
+		return nil, response.Warnings, errors.New("rule result is not a vector or scalar")
+	}
+}
+
+func (j JsonDecoder) vectorToPromQLVector(vector model.Vector) promql.Vector {
+	v := make([]promql.Sample, 0, len(vector))
+	for _, sample := range vector {
+		metric := make([]labels.Label, 0, len(sample.Metric))
+		for k, v := range sample.Metric {
+			metric = append(metric, labels.Label{
+				Name:  string(k),
+				Value: string(v),
+			})
+		}
+		v = append(v, promql.Sample{
+			T:      int64(sample.Timestamp),
+			F:      float64(sample.Value),
+			Metric: metric,
+		})
+	}
+	return v
+}
+
+func (j JsonDecoder) scalarToPromQLVector(scalar model.Scalar) promql.Vector {
+	return promql.Vector{promql.Sample{
+		T:      int64(scalar.Timestamp),
+		F:      float64(scalar.Value),
+		Metric: labels.Labels{},
+	}}
+}

--- a/pkg/ruler/frontend_decoder_test.go
+++ b/pkg/ruler/frontend_decoder_test.go
@@ -1,0 +1,123 @@
+package ruler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecode(t *testing.T) {
+	jsonDecoder := JsonDecoder{}
+
+	tests := []struct {
+		description     string
+		body            string
+		expectedVector  promql.Vector
+		expectedWarning Warning
+		expectedErr     error
+	}{
+		{
+			description: "empty vector",
+			body: `{
+					"status": "success",
+					"data": {"resultType":"vector","result":[]}
+				}`,
+			expectedVector:  promql.Vector{},
+			expectedErr:     nil,
+			expectedWarning: nil,
+		},
+		{
+			description: "vector with series",
+			body: `{
+					"status": "success",
+					"data": {
+						"resultType": "vector",
+						"result": [
+							{
+								"metric": {"foo":"bar"},
+								"value": [1724146338.123,"1.234"]
+							},
+							{
+								"metric": {"bar":"baz"},
+								"value": [1724146338.456,"5.678"]
+							}
+						]
+					}
+				}`,
+			expectedVector: promql.Vector{
+				{
+					Metric: labels.FromStrings("foo", "bar"),
+					T:      1724146338123,
+					F:      1.234,
+				},
+				{
+					Metric: labels.FromStrings("bar", "baz"),
+					T:      1724146338456,
+					F:      5.678,
+				},
+			},
+			expectedErr:     nil,
+			expectedWarning: nil,
+		},
+		{
+			description: "scalar",
+			body: `{
+					"status": "success",
+					"data": {"resultType":"scalar","result":[1724146338.123,"1.234"]}
+				}`,
+			expectedVector: promql.Vector{
+				{
+					Metric: labels.EmptyLabels(),
+					T:      1724146338123,
+					F:      1.234,
+				},
+			},
+			expectedErr:     nil,
+			expectedWarning: nil,
+		},
+		{
+			description: "matrix",
+			body: `{
+					"status": "success",
+					"data": {"resultType":"matrix","result":[]}
+				}`,
+			expectedVector:  nil,
+			expectedErr:     errors.New("rule result is not a vector or scalar"),
+			expectedWarning: nil,
+		},
+		{
+			description: "string",
+			body: `{
+					"status": "success",
+					"data": {"resultType":"string","result":[1724146338.123,"string"]}
+				}`,
+			expectedVector:  nil,
+			expectedErr:     errors.New("rule result is not a vector or scalar"),
+			expectedWarning: nil,
+		},
+		{
+			description: "error with warnings",
+			body: `{
+					"status": "error",
+					"errorType": "errorExec",
+					"error": "something wrong",
+					"warnings": ["a","b","c"]
+				}`,
+			expectedVector:  nil,
+			expectedErr:     errors.New("failed to execute query with error: something wrong"),
+			expectedWarning: []string{"a", "b", "c"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			vector, warning, err := jsonDecoder.Decode([]byte(test.body))
+			require.Equal(t, test.expectedVector, vector)
+			require.Equal(t, test.expectedWarning, warning)
+			require.Equal(t, test.expectedErr, err)
+		})
+	}
+}

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
+	"github.com/cortexproject/cortex/pkg/ring/client"
 	"github.com/cortexproject/cortex/pkg/ruler/rulespb"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/test"
@@ -304,13 +305,13 @@ func getManager(m *DefaultMultiTenantManager, user string) RulesManager {
 }
 
 func RuleManagerFactory(groupsToReturn [][]*promRules.Group, waitDurations []time.Duration) ManagerFactory {
-	return func(_ context.Context, _ string, _ *notifier.Manager, _ log.Logger, _ prometheus.Registerer) RulesManager {
+	return func(_ context.Context, _ string, _ *notifier.Manager, _ log.Logger, _ *client.Pool, _ prometheus.Registerer) (RulesManager, error) {
 		return &mockRulesManager{
 			done:           make(chan struct{}),
 			groupsToReturn: groupsToReturn,
 			waitDurations:  waitDurations,
 			iteration:      -1,
-		}
+		}, nil
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Add `ruler.frontend-address` to allow query to query frontends instead of ingesters. If `-ruler.frontend-address` is set, rulers query to query frontends for evaluating rules. It can support query frontend features like vertical query sharding.

**Which issue(s) this PR fixes**:
Fixes #5105 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
