### PR TITLE
Remove tracing oltp endpoint flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [CHANGE] Ingesters: Enable 'snappy-block' compression on ingester clients by default. #6148
 * [CHANGE] Ruler: Scheduling `ruler.evaluation-delay-duration` to be deprecated. Use the highest value between `ruler.evaluation-delay-duration` and `ruler.query-offset` #6149
 * [CHANGE] Querier: Remove `-querier.at-modifier-enabled` flag. #6157
+* [CHANGE] Tracing: Remove deprecated `oltp_endpoint` config entirely. #6158
 * [FEATURE] Ingester/Distributor: Experimental: Enable native histogram ingestion via `-blocks-storage.tsdb.enable-native-histograms` flag. #5986 #6010 #6020
 * [FEATURE] Querier: Enable querying native histogram chunks. #5944 #6031
 * [FEATURE] Query Frontend: Support native histogram in query frontend response. #5996 #6043

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -38,7 +38,6 @@ type Config struct {
 }
 
 type Otel struct {
-	OltpEndpoint   string              `yaml:"oltp_endpoint" json:"oltp_endpoint" doc:"hidden"`
 	OtlpEndpoint   string              `yaml:"otlp_endpoint" json:"otlp_endpoint"`
 	ExporterType   string              `yaml:"exporter_type" json:"exporter_type"`
 	SampleRatio    float64             `yaml:"sample_ratio" json:"sample_ratio"`
@@ -53,7 +52,6 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	p := "tracing"
 	f.StringVar(&c.Type, p+".type", JaegerType, "Tracing type. OTEL and JAEGER are currently supported. For jaeger `JAEGER_AGENT_HOST` environment variable should also be set. See: https://cortexmetrics.io/docs/guides/tracing .")
 	f.Float64Var(&c.Otel.SampleRatio, p+".otel.sample-ratio", 0.001, "Fraction of traces to be sampled. Fractions >= 1 means sampling if off and everything is traced.")
-	f.StringVar(&c.Otel.OltpEndpoint, p+".otel.oltp-endpoint", "", "DEPRECATED: use otel.otlp-endpoint instead.")
 	f.StringVar(&c.Otel.OtlpEndpoint, p+".otel.otlp-endpoint", "", "otl collector endpoint that the driver will use to send spans.")
 	f.StringVar(&c.Otel.ExporterType, p+".otel.exporter-type", "", "enhance/modify traces/propagators for specific exporter. If empty, OTEL defaults will apply. Supported values are: `awsxray.`")
 	f.BoolVar(&c.Otel.TLSEnabled, p+".otel.tls-enabled", c.Otel.TLSEnabled, "Enable TLS in the GRPC client. This flag needs to be enabled when any other TLS flag is set. If set to false, insecure connection to gRPC server will be used.")
@@ -64,11 +62,8 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 func (c *Config) Validate() error {
 	switch strings.ToLower(c.Type) {
 	case OtelType:
-		if (c.Otel.OtlpEndpoint == "") && (c.Otel.OltpEndpoint == "") {
+		if c.Otel.OtlpEndpoint == "" {
 			return errors.New("otlp-endpoint must be defined when using otel exporter")
-		}
-		if len(c.Otel.OltpEndpoint) > 0 {
-			level.Warn(util_log.Logger).Log("msg", "DEPRECATED: otel.oltp-endpoint is deprecated. Use otel.otlp-endpoint instead.")
 		}
 	}
 
@@ -90,15 +85,7 @@ func SetupTracing(ctx context.Context, name string, c Config) (func(context.Cont
 	case OtelType:
 		util_log.Logger.Log("msg", "creating otel exporter")
 
-		if (len(c.Otel.OtlpEndpoint) > 0) && (len(c.Otel.OltpEndpoint) > 0) {
-			level.Warn(util_log.Logger).Log("msg", "DEPRECATED: otel.otlp and otel.oltp both set, using otel.otlp because otel.oltp is deprecated")
-		}
-
 		endpoint := c.Otel.OtlpEndpoint
-		if (c.Otel.OtlpEndpoint == "") && (len(c.Otel.OltpEndpoint) > 0) {
-			level.Warn(util_log.Logger).Log("msg", "DEPRECATED: otel.oltp is deprecated use otel.otlp")
-			endpoint = c.Otel.OltpEndpoint
-		}
 		options := []otlptracegrpc.Option{
 			otlptracegrpc.WithEndpoint(endpoint),
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

`oltp_endpoint` config was marked as deprecated since release v1.15.0. We already keep it for 2 releases and we can remove the flag.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
