### PR TITLE
Add query metrics to ruler query stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [ENHANCEMENT] Ruler: Add new ruler metric `cortex_ruler_rule_groups_in_store` that is the total rule groups per tenant in store, which can be used to compare with `cortex_prometheus_rule_group_rules` to count the number of rule groups that are not loaded by a ruler. #5869
+* [ENHANCEMENT] Ruler: Add query statistics metrics when --ruler.query-stats-enabled=true. #6173
 
 ## 1.18.0 in progress
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4366,8 +4366,8 @@ ring:
 # CLI flag: -ruler.disabled-tenants
 [disabled_tenants: <string> | default = ""]
 
-# Report the wall time for ruler queries to complete as a per user metric and as
-# an info level log message.
+# Report query statistics for ruler queries to complete as a per user metric and
+# as an info level log message.
 # CLI flag: -ruler.query-stats-enabled
 [query_stats_enabled: <boolean> | default = false]
 

--- a/pkg/ruler/manager_metrics.go
+++ b/pkg/ruler/manager_metrics.go
@@ -225,11 +225,15 @@ func (m *ManagerMetrics) Collect(out chan<- prometheus.Metric) {
 }
 
 type RuleEvalMetrics struct {
-	TotalWritesVec    *prometheus.CounterVec
-	FailedWritesVec   *prometheus.CounterVec
-	TotalQueriesVec   *prometheus.CounterVec
-	FailedQueriesVec  *prometheus.CounterVec
-	RulerQuerySeconds *prometheus.CounterVec
+	TotalWritesVec       *prometheus.CounterVec
+	FailedWritesVec      *prometheus.CounterVec
+	TotalQueriesVec      *prometheus.CounterVec
+	FailedQueriesVec     *prometheus.CounterVec
+	RulerQuerySeconds    *prometheus.CounterVec
+	RulerQuerySeries     *prometheus.CounterVec
+	RulerQuerySamples    *prometheus.CounterVec
+	RulerQueryChunkBytes *prometheus.CounterVec
+	RulerQueryDataBytes  *prometheus.CounterVec
 }
 
 func NewRuleEvalMetrics(cfg Config, reg prometheus.Registerer) *RuleEvalMetrics {
@@ -256,6 +260,22 @@ func NewRuleEvalMetrics(cfg Config, reg prometheus.Registerer) *RuleEvalMetrics 
 			Name: "cortex_ruler_query_seconds_total",
 			Help: "Total amount of wall clock time spent processing queries by the ruler.",
 		}, []string{"user"})
+		m.RulerQuerySeries = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_ruler_fetched_series_total",
+			Help: "Number of series fetched to execute a query by the ruler.",
+		}, []string{"user"})
+		m.RulerQuerySamples = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_ruler_samples_total",
+			Help: "Number of samples fetched to execute a query by the ruler.",
+		}, []string{"user"})
+		m.RulerQueryChunkBytes = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_ruler_fetched_chunks_bytes_total",
+			Help: "Size of all chunks fetched to execute a query in bytes by the ruler.",
+		}, []string{"user"})
+		m.RulerQueryDataBytes = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_ruler_fetched_data_bytes_total",
+			Help: "Size of all data fetched to execute a query in bytes by the ruler.",
+		}, []string{"user"})
 	}
 
 	return m
@@ -269,6 +289,18 @@ func (m *RuleEvalMetrics) deletePerUserMetrics(userID string) {
 
 	if m.RulerQuerySeconds != nil {
 		m.RulerQuerySeconds.DeleteLabelValues(userID)
+	}
+	if m.RulerQuerySeries != nil {
+		m.RulerQuerySeries.DeleteLabelValues(userID)
+	}
+	if m.RulerQuerySamples != nil {
+		m.RulerQuerySamples.DeleteLabelValues(userID)
+	}
+	if m.RulerQueryChunkBytes != nil {
+		m.RulerQueryChunkBytes.DeleteLabelValues(userID)
+	}
+	if m.RulerQueryDataBytes != nil {
+		m.RulerQueryDataBytes.DeleteLabelValues(userID)
 	}
 }
 

--- a/pkg/ruler/manager_metrics_test.go
+++ b/pkg/ruler/manager_metrics_test.go
@@ -574,8 +574,16 @@ func TestRuleEvalMetricsDeletePerUserMetrics(t *testing.T) {
 	m.FailedQueriesVec.WithLabelValues("fake2").Add(10)
 	m.RulerQuerySeconds.WithLabelValues("fake1").Add(10)
 	m.RulerQuerySeconds.WithLabelValues("fake2").Add(10)
+	m.RulerQuerySeries.WithLabelValues("fake1").Add(10)
+	m.RulerQuerySeries.WithLabelValues("fake2").Add(10)
+	m.RulerQuerySamples.WithLabelValues("fake1").Add(10)
+	m.RulerQuerySamples.WithLabelValues("fake2").Add(10)
+	m.RulerQueryChunkBytes.WithLabelValues("fake1").Add(10)
+	m.RulerQueryChunkBytes.WithLabelValues("fake2").Add(10)
+	m.RulerQueryDataBytes.WithLabelValues("fake1").Add(10)
+	m.RulerQueryDataBytes.WithLabelValues("fake2").Add(10)
 
-	metricNames := []string{"cortex_ruler_write_requests_total", "cortex_ruler_write_requests_failed_total", "cortex_ruler_queries_total", "cortex_ruler_queries_failed_total", "cortex_ruler_query_seconds_total"}
+	metricNames := []string{"cortex_ruler_write_requests_total", "cortex_ruler_write_requests_failed_total", "cortex_ruler_queries_total", "cortex_ruler_queries_failed_total", "cortex_ruler_query_seconds_total", "cortex_ruler_fetched_series_total", "cortex_ruler_samples_total", "cortex_ruler_fetched_chunks_bytes_total", "cortex_ruler_fetched_data_bytes_total"}
 	gm, err := reg.Gather()
 	require.NoError(t, err)
 	mfm, err := util.NewMetricFamilyMap(gm)

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -217,7 +217,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.EnabledTenants, "ruler.enabled-tenants", "Comma separated list of tenants whose rules this ruler can evaluate. If specified, only these tenants will be handled by ruler, otherwise this ruler can process rules from all tenants. Subject to sharding.")
 	f.Var(&cfg.DisabledTenants, "ruler.disabled-tenants", "Comma separated list of tenants whose rules this ruler cannot evaluate. If specified, a ruler that would normally pick the specified tenant(s) for processing will ignore them instead. Subject to sharding.")
 
-	f.BoolVar(&cfg.EnableQueryStats, "ruler.query-stats-enabled", false, "Report the wall time for ruler queries to complete as a per user metric and as an info level log message.")
+	f.BoolVar(&cfg.EnableQueryStats, "ruler.query-stats-enabled", false, "Report query statistics for ruler queries to complete as a per user metric and as an info level log message.")
 	f.BoolVar(&cfg.DisableRuleGroupLabel, "ruler.disable-rule-group-label", false, "Disable the rule_group label on exported metrics")
 
 	cfg.RingCheckPeriod = 5 * time.Second


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Add query statistics metrics to Ruler when _--ruler.query-stats-enabled=true_ to track how many data are fetched by the alerting rule or recording rules for each tenants. 
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
