### PR TITLE
Use temp dir for ruler LoadPartialGroups test

### DIFF
--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -1930,6 +1930,7 @@ func Test_LoadPartialGroups(t *testing.T) {
 	store := newMockRuleStore(allRules, map[string]error{user1: fmt.Errorf("test")})
 	u, _ := url.Parse("")
 	cfg := Config{
+		RulePath:         t.TempDir(),
 		EnableSharding:   true,
 		ExternalURL:      flagext.URLValue{URL: u},
 		PollInterval:     time.Millisecond * 100,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- This one test was not using the temp dir for storing rules.
- The following files were always created when running tests locally:
  - `pkg/ruler/user2/namespace`
  - `pkg/ruler/user3/namespace`



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
