### PR TITLE
Fixed ingester ReadOnly state related bugs

### DIFF
--- a/pkg/ingester/http_admin.go
+++ b/pkg/ingester/http_admin.go
@@ -43,7 +43,7 @@ const tpl = `
 					{{ range .Stats }}
 					<tr>
 						<td>{{ .UserID }}</td>
-						<td align='right'>{{ .UserStats.LoadBlocks }}</td>
+						<td align='right'>{{ .UserStats.LoadedBlocks }}</td>
 						<td align='right'>{{ .UserStats.NumSeries }}</td>
 						<td align='right'>{{ .UserStats.ActiveSeries }}</td>
 						<td align='right'>{{ printf "%.2f" .UserStats.IngestionRate }}</td>

--- a/pkg/ingester/http_admin_test.go
+++ b/pkg/ingester/http_admin_test.go
@@ -1,0 +1,37 @@
+package ingester
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserStatsPageRendered(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/ingester/all_user_stats", nil)
+	res := httptest.NewRecorder()
+	userStats := []UserIDStats{
+		{
+			UserID: "123",
+			UserStats: UserStats{
+				IngestionRate:     11.11,
+				NumSeries:         2222,
+				APIIngestionRate:  33.33,
+				RuleIngestionRate: 44.44,
+				ActiveSeries:      5555,
+				LoadedBlocks:      6666,
+			},
+		},
+	}
+	AllUserStatsRender(res, req, userStats, 3)
+	assert.Equal(t, http.StatusOK, res.Code)
+	body := res.Body.String()
+	assert.Regexp(t, "<td.+123.+/td>", body)
+	assert.Regexp(t, "<td.+11.11.+/td>", body)
+	assert.Regexp(t, "<td.+2222.+/td>", body)
+	assert.Regexp(t, "<td.+33.33.+/td>", body)
+	assert.Regexp(t, "<td.+44.44.+/td>", body)
+	assert.Regexp(t, "<td.+5555.+/td>", body)
+	assert.Regexp(t, "<td.+6666.+/td>", body)
+}

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -153,7 +153,7 @@ func (i *InstanceDesc) IsReady(storageLastUpdated time.Time, heartbeatTimeout ti
 	if !i.IsHeartbeatHealthy(heartbeatTimeout, storageLastUpdated) {
 		return fmt.Errorf("instance %s past heartbeat timeout", i.Addr)
 	}
-	if i.State != ACTIVE {
+	if i.State != ACTIVE && i.State != READONLY {
 		return fmt.Errorf("instance %s in state %v", i.Addr, i.State)
 	}
 	return nil

--- a/pkg/ring/model_test.go
+++ b/pkg/ring/model_test.go
@@ -275,6 +275,20 @@ func TestDesc_Ready(t *testing.T) {
 	if err := r.IsReady(now, 10*time.Second); err != nil {
 		t.Fatal("expected ready, got", err)
 	}
+
+	r = &Desc{
+		Ingesters: map[string]InstanceDesc{
+			"ing1": {
+				Tokens:    []uint32{100, 200, 300},
+				State:     READONLY,
+				Timestamp: now.Unix(),
+			},
+		},
+	}
+
+	if err := r.IsReady(now, 10*time.Second); err != nil {
+		t.Fatal("expected readonly ingester as ready, but got", err)
+	}
 }
 
 func TestDesc_getTokensByZone(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Fixed the following bugs related to ReadOnly state of ingester:

- `/ingester/all_user_stats` endpoint cannot have web page rendered properly. `LoadedBlocks` field got wrong name in template.
- Ingester with `ReadOnly` state is not considered as ready which would cause rolling update stuck if there is at least one ingester in `ReadOnly` state.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
