### PR TITLE
Add timeout on lifecycler heartbeat

### DIFF
--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -468,7 +468,7 @@ func (i *Lifecycler) loop(ctx context.Context) error {
 		// We are jittering for at least half of the time and max the time of the heartbeat.
 		// If we jitter too soon, we can have problems of concurrency with autoJoin leaving the instance on ACTIVE without tokens
 		time.AfterFunc(time.Duration(uint64(i.cfg.HeartbeatPeriod/2)+uint64(mathrand.Int63())%uint64(i.cfg.HeartbeatPeriod/2)), func() {
-			i.heartbeat()
+			i.heartbeat(ctx)
 			heartbeatTicker.Reset(i.cfg.HeartbeatPeriod)
 		})
 		defer heartbeatTicker.Stop()
@@ -530,7 +530,7 @@ func (i *Lifecycler) loop(ctx context.Context) error {
 			}
 
 		case <-heartbeatTickerChan:
-			i.heartbeat()
+			i.heartbeat(ctx)
 		case f := <-i.actorChan:
 			f()
 
@@ -541,8 +541,9 @@ func (i *Lifecycler) loop(ctx context.Context) error {
 	}
 }
 
-func (i *Lifecycler) heartbeat() {
+func (i *Lifecycler) heartbeat(ctx context.Context) {
 	i.lifecyclerMetrics.consulHeartbeats.Inc()
+	ctx, _ = context.WithTimeout(ctx, i.cfg.HeartbeatPeriod)
 	if err := i.updateConsul(context.Background()); err != nil {
 		level.Error(i.logger).Log("msg", "failed to write to the KV store, sleeping", "ring", i.RingName, "err", err)
 	}

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -543,8 +543,9 @@ func (i *Lifecycler) loop(ctx context.Context) error {
 
 func (i *Lifecycler) heartbeat(ctx context.Context) {
 	i.lifecyclerMetrics.consulHeartbeats.Inc()
-	ctx, _ = context.WithTimeout(ctx, i.cfg.HeartbeatPeriod)
-	if err := i.updateConsul(context.Background()); err != nil {
+	ctx, cancel := context.WithTimeout(ctx, i.cfg.HeartbeatPeriod)
+	defer cancel()
+	if err := i.updateConsul(ctx); err != nil {
 		level.Error(i.logger).Log("msg", "failed to write to the KV store, sleeping", "ring", i.RingName, "err", err)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds a timeout context to the lifecycler heartbeat to prevent requests to the ring from waiting indefinitely in case of a network issue.

**Which issue(s) this PR fixes**:
Fixes #6211

**Checklist**
- [ N/A ] Tests updated
- [ X ] Documentation added
- [ X ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
