### PR TITLE
Add a configuration for an index cache ttl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [FEATURE] Store Gateway: Add an in-memory chunk cache. #6245
 * [FEATURE] Chunk Cache: Support multi level cache and add metrics. #6249
 * [ENHANCEMENT] Query Frontend: Add new query stats metrics `cortex_query_samples_scanned_total` and `cortex_query_peak_samples` to track scannedSamples and peakSample per user. #6228
+* [ENHANCEMENT] Index Cache: Add a configuration for an index cache ttl. #6234
 * [ENHANCEMENT] Ingester: Add `blocks-storage.tsdb.wal-compression-type` to support zstd wal compression type. #6232
 * [ENHANCEMENT] Query Frontend: Add info field to query response. #6207
 * [ENHANCEMENT] Query Frontend: Add peakSample in query stats response. #6188

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -666,6 +666,10 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.enabled-items
         [enabled_items: <list of string> | default = []]
 
+        # How long to cache an index for a block.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.index-ttl
+        [index_ttl: <duration> | default = 24h]
+
       redis:
         # Comma separated list of redis addresses. Supported prefixes are: dns+
         # (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query,
@@ -795,6 +799,10 @@ blocks_storage:
         # ExpandedPostings and Series
         # CLI flag: -blocks-storage.bucket-store.index-cache.redis.enabled-items
         [enabled_items: <list of string> | default = []]
+
+        # How long to cache an index for a block.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.index-ttl
+        [index_ttl: <duration> | default = 24h]
 
       multilevel:
         # The maximum number of concurrent asynchronous operations can occur

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -757,6 +757,10 @@ blocks_storage:
         # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.enabled-items
         [enabled_items: <list of string> | default = []]
 
+        # How long to cache an index for a block.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.index-ttl
+        [index_ttl: <duration> | default = 24h]
+
       redis:
         # Comma separated list of redis addresses. Supported prefixes are: dns+
         # (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query,
@@ -886,6 +890,10 @@ blocks_storage:
         # ExpandedPostings and Series
         # CLI flag: -blocks-storage.bucket-store.index-cache.redis.enabled-items
         [enabled_items: <list of string> | default = []]
+
+        # How long to cache an index for a block.
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.index-ttl
+        [index_ttl: <duration> | default = 24h]
 
       multilevel:
         # The maximum number of concurrent asynchronous operations can occur

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1194,6 +1194,10 @@ bucket_store:
       # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.enabled-items
       [enabled_items: <list of string> | default = []]
 
+      # How long to cache an index for a block.
+      # CLI flag: -blocks-storage.bucket-store.index-cache.memcached.index-ttl
+      [index_ttl: <duration> | default = 24h]
+
     redis:
       # Comma separated list of redis addresses. Supported prefixes are: dns+
       # (looked up as an A/AAAA query), dnssrv+ (looked up as a SRV query,
@@ -1322,6 +1326,10 @@ bucket_store:
       # ExpandedPostings and Series
       # CLI flag: -blocks-storage.bucket-store.index-cache.redis.enabled-items
       [enabled_items: <list of string> | default = []]
+
+      # How long to cache an index for a block.
+      # CLI flag: -blocks-storage.bucket-store.index-cache.redis.index-ttl
+      [index_ttl: <duration> | default = 24h]
 
     multilevel:
       # The maximum number of concurrent asynchronous operations can occur when


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

Add a configuration for an index cache ttl. The index cache ttl can be configured by `-blocks-storage.bucket-store.index-cache.redis.index-ttl` and `-blocks-storage.bucket-store.index-cache.memcached.index-ttl`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
