### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/ring/tokens_test.go
+++ b/pkg/ring/tokens_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestTokens_Serialization(t *testing.T) {
-	tokens := make(Tokens, 512)
+	tokens := make(Tokens, 0, 512)
 	for i := 0; i < 512; i++ {
 		tokens = append(tokens, uint32(rand.Int31()))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

The intention here should be to initialize a slice with a capacity of 512 rather than initializing the length of this slice.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
