### PR TITLE
[Chore] return nil when inmemory index cache init fail

### DIFF
--- a/pkg/storage/tsdb/index_cache.go
+++ b/pkg/storage/tsdb/index_cache.go
@@ -208,7 +208,7 @@ func NewIndexCache(cfg IndexCacheConfig, logger log.Logger, registerer prometheu
 		case IndexCacheBackendInMemory:
 			c, err := newInMemoryIndexCache(cfg.InMemory, logger, iReg)
 			if err != nil {
-				return c, err
+				return nil, err
 			}
 			caches = append(caches, c)
 			enabledItems = append(enabledItems, cfg.InMemory.EnabledItems)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

Return nil when in-memory index cache fails like other caches (Memcached and Redis)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
