### PR TITLE
Add alertmanager config to single process documents

### DIFF
--- a/docs/configuration/single-process-config-blocks-gossip-1.yaml
+++ b/docs/configuration/single-process-config-blocks-gossip-1.yaml
@@ -96,3 +96,12 @@ ruler_storage:
   backend: local
   local:
     directory: /tmp/cortex/rules
+
+alertmanager:
+  external_url: http://localhost/alertmanager
+
+alertmanager_storage:
+  backend: local
+  local:
+    # Make sure file exist
+    path: /tmp/cortex/alerts

--- a/docs/configuration/single-process-config-blocks-gossip-2.yaml
+++ b/docs/configuration/single-process-config-blocks-gossip-2.yaml
@@ -95,3 +95,12 @@ ruler_storage:
   backend: local
   local:
     directory: /tmp/cortex/rules
+
+alertmanager:
+  external_url: http://localhost/alertmanager
+
+alertmanager_storage:
+  backend: local
+  local:
+    # Make sure file exist
+    path: /tmp/cortex/alerts

--- a/docs/configuration/single-process-config-blocks-local.yaml
+++ b/docs/configuration/single-process-config-blocks-local.yaml
@@ -88,3 +88,12 @@ ruler_storage:
   backend: local
   local:
     directory: /tmp/cortex/rules
+
+alertmanager:
+  external_url: http://localhost/alertmanager
+
+alertmanager_storage:
+  backend: local
+  local:
+    # Make sure file exist
+    path: /tmp/cortex/alerts

--- a/docs/configuration/single-process-config-blocks-tls.yaml
+++ b/docs/configuration/single-process-config-blocks-tls.yaml
@@ -102,3 +102,12 @@ ruler_storage:
   backend: local
   local:
     directory: /tmp/cortex/rules
+
+alertmanager:
+  external_url: http://localhost/alertmanager
+
+alertmanager_storage:
+  backend: local
+  local:
+    # Make sure file exist
+    path: /tmp/cortex/alerts

--- a/docs/configuration/single-process-config-blocks.yaml
+++ b/docs/configuration/single-process-config-blocks.yaml
@@ -88,3 +88,12 @@ ruler_storage:
   backend: local
   local:
     directory: /tmp/cortex/rules
+
+alertmanager:
+  external_url: http://localhost/alertmanager
+
+alertmanager_storage:
+  backend: local
+  local:
+    # Make sure file exist
+    path: /tmp/cortex/alerts


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

#6204 added Alertmanager to `all` target.

However, single process documents do not contain alertmanager configs, so the Cortex fails to start using these configs.
This PR adds alertmanager configs to single process documents.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
