### PR TITLE
Add list objects version to s3 config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [FEATURE] Ruler: Minimize chances of missed rule group evaluations that can occur due to OOM kills, bad underlying nodes, or due to an unhealthy ruler that appears in the ring as healthy. This feature is enabled via `-ruler.enable-ha-evaluation` flag. #6129
 * [FEATURE] Store Gateway: Add an in-memory chunk cache. #6245
 * [FEATURE] Chunk Cache: Support multi level cache and add metrics. #6249
+* [ENHANCEMENT] S3 Bucket Client: Add a list objects version configs to configure list api object version. #6280
 * [ENHANCEMENT] Query Frontend: Add new query stats metrics `cortex_query_samples_scanned_total` and `cortex_query_peak_samples` to track scannedSamples and peakSample per user. #6228
 * [ENHANCEMENT] Ingester: Add `blocks-storage.tsdb.wal-compression-type` to support zstd wal compression type. #6232
 * [ENHANCEMENT] Query Frontend: Add info field to query response. #6207

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -312,6 +312,10 @@ blocks_storage:
     # CLI flag: -blocks-storage.s3.send-content-md5
     [send_content_md5: <boolean> | default = true]
 
+    # The list api version. Supported values are: v1, v2, and ''.
+    # CLI flag: -blocks-storage.s3.list-objects-version
+    [list_objects_version: <string> | default = ""]
+
     # The s3_sse_config configures the S3 server-side encryption.
     # The CLI flags prefix for this block config is: blocks-storage
     [sse: <s3_sse_config>]

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -403,6 +403,10 @@ blocks_storage:
     # CLI flag: -blocks-storage.s3.send-content-md5
     [send_content_md5: <boolean> | default = true]
 
+    # The list api version. Supported values are: v1, v2, and ''.
+    # CLI flag: -blocks-storage.s3.list-objects-version
+    [list_objects_version: <string> | default = ""]
+
     # The s3_sse_config configures the S3 server-side encryption.
     # The CLI flags prefix for this block config is: blocks-storage
     [sse: <s3_sse_config>]

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -563,6 +563,10 @@ s3:
   # CLI flag: -alertmanager-storage.s3.send-content-md5
   [send_content_md5: <boolean> | default = true]
 
+  # The list api version. Supported values are: v1, v2, and ''.
+  # CLI flag: -alertmanager-storage.s3.list-objects-version
+  [list_objects_version: <string> | default = ""]
+
   # The s3_sse_config configures the S3 server-side encryption.
   # The CLI flags prefix for this block config is: alertmanager-storage
   [sse: <s3_sse_config>]
@@ -841,6 +845,10 @@ s3:
   # instead.
   # CLI flag: -blocks-storage.s3.send-content-md5
   [send_content_md5: <boolean> | default = true]
+
+  # The list api version. Supported values are: v1, v2, and ''.
+  # CLI flag: -blocks-storage.s3.list-objects-version
+  [list_objects_version: <string> | default = ""]
 
   # The s3_sse_config configures the S3 server-side encryption.
   # The CLI flags prefix for this block config is: blocks-storage
@@ -4611,6 +4619,10 @@ s3:
   # CLI flag: -ruler-storage.s3.send-content-md5
   [send_content_md5: <boolean> | default = true]
 
+  # The list api version. Supported values are: v1, v2, and ''.
+  # CLI flag: -ruler-storage.s3.list-objects-version
+  [list_objects_version: <string> | default = ""]
+
   # The s3_sse_config configures the S3 server-side encryption.
   # The CLI flags prefix for this block config is: ruler-storage
   [sse: <s3_sse_config>]
@@ -4897,6 +4909,10 @@ s3:
   # instead.
   # CLI flag: -runtime-config.s3.send-content-md5
   [send_content_md5: <boolean> | default = true]
+
+  # The list api version. Supported values are: v1, v2, and ''.
+  # CLI flag: -runtime-config.s3.list-objects-version
+  [list_objects_version: <string> | default = ""]
 
   # The s3_sse_config configures the S3 server-side encryption.
   # The CLI flags prefix for this block config is: runtime-config

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -102,9 +102,10 @@ func newS3Config(cfg Config) (s3.Config, error) {
 			Transport:             cfg.HTTP.Transport,
 		},
 		// Enforce signature version 2 if CLI flag is set
-		SignatureV2:      cfg.SignatureVersion == SignatureVersionV2,
-		BucketLookupType: bucketLookupType,
-		AWSSDKAuth:       cfg.AccessKeyID == "",
+		ListObjectsVersion: cfg.ListObjectsVersion,
+		SignatureV2:        cfg.SignatureVersion == SignatureVersionV2,
+		BucketLookupType:   bucketLookupType,
+		AWSSDKAuth:         cfg.AccessKeyID == "",
 	}, nil
 }
 

--- a/pkg/storage/bucket/s3/config_test.go
+++ b/pkg/storage/bucket/s3/config_test.go
@@ -168,6 +168,61 @@ func TestSSEConfig_Validate(t *testing.T) {
 	}
 }
 
+func TestS3Config_Validate(t *testing.T) {
+	tests := map[string]struct {
+		cfg         *Config
+		expectedErr error
+	}{
+		"should pass with valid config": {
+			cfg: &Config{
+				SignatureVersion:   SignatureVersionV4,
+				BucketLookupType:   BucketAutoLookup,
+				ListObjectsVersion: ListObjectsVersionV2,
+			},
+			expectedErr: nil,
+		},
+		"should fail with invalid signature version": {
+			cfg: &Config{
+				SignatureVersion:   "v3",
+				BucketLookupType:   BucketAutoLookup,
+				ListObjectsVersion: ListObjectsVersionV2,
+			},
+			expectedErr: errUnsupportedSignatureVersion,
+		},
+		"should fail with invalid bucket lookup type": {
+			cfg: &Config{
+				SignatureVersion:   SignatureVersionV4,
+				BucketLookupType:   "dummy",
+				ListObjectsVersion: ListObjectsVersionV2,
+			},
+			expectedErr: errInvalidBucketLookupType,
+		},
+		"should fail with invalid list objects version": {
+			cfg: &Config{
+				SignatureVersion:   SignatureVersionV4,
+				BucketLookupType:   BucketAutoLookup,
+				ListObjectsVersion: "v3",
+			},
+			expectedErr: errInvalidListObjectsVersion,
+		},
+		"should pass with empty list objects version": {
+			cfg: &Config{
+				SignatureVersion:   SignatureVersionV4,
+				BucketLookupType:   BucketAutoLookup,
+				ListObjectsVersion: "",
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			err := test.cfg.Validate()
+			require.Equal(t, test.expectedErr, err)
+		})
+	}
+}
+
 func TestSSEConfig_BuildMinioConfig(t *testing.T) {
 	tests := map[string]struct {
 		cfg             *SSEConfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR adds `-blocks-storage.s3.list-objects-version` to configure s3 list API version.

Use case: If users use s3 compatible backends that don't fully support `ListObjectV2`, they (including me) would want to use V1 api. 

The thanos expose it (https://github.com/thanos-io/objstore/blob/23ebe2eacadd89cf23bf0fbd931352112b4c846d/providers/s3/s3.go#L137).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
