### PR TITLE
Add enable delayed compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [FEATURE] Ruler: Minimize chances of missed rule group evaluations that can occur due to OOM kills, bad underlying nodes, or due to an unhealthy ruler that appears in the ring as healthy. This feature is enabled via `-ruler.enable-ha-evaluation` flag. #6129
 * [FEATURE] Store Gateway: Add an in-memory chunk cache. #6245
 * [FEATURE] Chunk Cache: Support multi level cache and add metrics. #6249
+* [ENHANCEMENT] Ingester: Experimental: Add `blocks-storage.tsdb.enable-delayed-compaction` to support tsdb compaction with random delay. #6284
 * [ENHANCEMENT] Ingester: Add `blocks-storage.tsdb.wal-compression-type` to support zstd wal compression type. #6232
 * [ENHANCEMENT] Query Frontend: Add info field to query response. #6207
 * [ENHANCEMENT] Query Frontend: Add peakSample in query stats response. #6188

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -1528,4 +1528,8 @@ blocks_storage:
     # [EXPERIMENTAL] True to enable native histogram.
     # CLI flag: -blocks-storage.tsdb.enable-native-histograms
     [enable_native_histograms: <boolean> | default = false]
+
+    # [EXPERIMENTAL] True to enable delayed compaction.
+    # CLI flag: -blocks-storage.tsdb.enable-delayed-compaction
+    [enable_delayed_compaction: <boolean> | default = false]
 ```

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -1619,4 +1619,8 @@ blocks_storage:
     # [EXPERIMENTAL] True to enable native histogram.
     # CLI flag: -blocks-storage.tsdb.enable-native-histograms
     [enable_native_histograms: <boolean> | default = false]
+
+    # [EXPERIMENTAL] True to enable delayed compaction.
+    # CLI flag: -blocks-storage.tsdb.enable-delayed-compaction
+    [enable_delayed_compaction: <boolean> | default = false]
 ```

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2049,6 +2049,10 @@ tsdb:
   # [EXPERIMENTAL] True to enable native histogram.
   # CLI flag: -blocks-storage.tsdb.enable-native-histograms
   [enable_native_histograms: <boolean> | default = false]
+
+  # [EXPERIMENTAL] True to enable delayed compaction.
+  # CLI flag: -blocks-storage.tsdb.enable-delayed-compaction
+  [enable_delayed_compaction: <boolean> | default = false]
 ```
 
 ### `compactor_config`

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -116,3 +116,5 @@ Currently experimental features are:
   - Enable string interning for metrics labels by setting `-ingester.labels-string-interning-enabled` on Ingester.
 - Query-frontend: query rejection (`-frontend.query-rejection.enabled`)
 - Querier: protobuf codec (`-api.querier-default-codec`)
+- Ingester: Enable TSDB compaction delay
+  - `-blocks-storage.tsdb.enable-delayed-compaction` (boolean) CLI flag

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2199,6 +2199,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 		OutOfOrderCapMax:               i.cfg.BlocksStorageConfig.TSDB.OutOfOrderCapMax,
 		EnableOverlappingCompaction:    false, // Always let compactors handle overlapped blocks, e.g. OOO blocks.
 		EnableNativeHistograms:         i.cfg.BlocksStorageConfig.TSDB.EnableNativeHistograms,
+		EnableDelayedCompaction:        i.cfg.BlocksStorageConfig.TSDB.EnableDelayedCompaction,
 	}, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open TSDB: %s", udir)

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -166,6 +166,9 @@ type TSDBConfig struct {
 
 	// Enable native histogram ingestion.
 	EnableNativeHistograms bool `yaml:"enable_native_histograms"`
+
+	// Enable deployed compaction
+	EnableDelayedCompaction bool `yaml:"enable_delayed_compaction"`
 }
 
 // RegisterFlags registers the TSDBConfig flags.
@@ -195,6 +198,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.MemorySnapshotOnShutdown, "blocks-storage.tsdb.memory-snapshot-on-shutdown", false, "True to enable snapshotting of in-memory TSDB data on disk when shutting down.")
 	f.Int64Var(&cfg.OutOfOrderCapMax, "blocks-storage.tsdb.out-of-order-cap-max", tsdb.DefaultOutOfOrderCapMax, "[EXPERIMENTAL] Configures the maximum number of samples per chunk that can be out-of-order.")
 	f.BoolVar(&cfg.EnableNativeHistograms, "blocks-storage.tsdb.enable-native-histograms", false, "[EXPERIMENTAL] True to enable native histogram.")
+	f.BoolVar(&cfg.EnableDelayedCompaction, "blocks-storage.tsdb.enable-delayed-compaction", false, "[EXPERIMENTAL] True to enable delayed compaction.")
 }
 
 // Validate the config.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR adds `-blocks-storage.tsdb.enable-delayed-compaction` to compact TSDBs in Ingester with random delay.
(Upstream prometheus PR: https://github.com/prometheus/prometheus/pull/12532, Issue: https://github.com/prometheus/prometheus/issues/8278)

Current behavior runs all of TSDB compaction simultaneously for every 2h (chunk range).
The problem is CPU and Disk of Ingesters spike every 2 our.
Periodic resource spike system resources could make capacity planning hard.

To address this concern, the Prometheus added the option for delaying TSDB compaction by adding some random delay.
Adding this option to the Cortex would be useful as the Ingester operates many TSDBs.
So, this PR adds it to Cortex and I expect it spreads system resources usage.

Here is my cortex cluster system resource usage:

<img width="1869" alt="스크린샷 2024-10-23 오후 1 43 48" src="https://github.com/user-attachments/assets/4eb874fd-2179-42f1-b4bb-7cfac22be94c">
^ CPU usage of Ingesters
<img width="1869" alt="스크린샷 2024-10-23 오후 1 44 14" src="https://github.com/user-attachments/assets/2f5ae8ff-a57c-47f4-8ba5-afa1c020eadd">
^ Disk write bytes/s of Ingesters

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
