### PR TITLE
Add json format otlp ingestion test

### DIFF
--- a/pkg/util/push/otlp_test.go
+++ b/pkg/util/push/otlp_test.go
@@ -20,21 +20,40 @@ import (
 func TestOTLPWriteHandler(t *testing.T) {
 	exportRequest := generateOTLPWriteRequest(t)
 
-	buf, err := exportRequest.MarshalProto()
-	require.NoError(t, err)
+	t.Run("Test proto format write", func(t *testing.T) {
+		buf, err := exportRequest.MarshalProto()
+		require.NoError(t, err)
 
-	req, err := http.NewRequest("", "", bytes.NewReader(buf))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/x-protobuf")
+		req, err := http.NewRequest("", "", bytes.NewReader(buf))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/x-protobuf")
 
-	push := verifyOTLPWriteRequestHandler(t, cortexpb.API)
-	handler := OTLPHandler(nil, push)
+		push := verifyOTLPWriteRequestHandler(t, cortexpb.API)
+		handler := OTLPHandler(nil, push)
 
-	recorder := httptest.NewRecorder()
-	handler.ServeHTTP(recorder, req)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
 
-	resp := recorder.Result()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+		resp := recorder.Result()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+	t.Run("Test json format write", func(t *testing.T) {
+		buf, err := exportRequest.MarshalJSON()
+		require.NoError(t, err)
+
+		req, err := http.NewRequest("", "", bytes.NewReader(buf))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		push := verifyOTLPWriteRequestHandler(t, cortexpb.API)
+		handler := OTLPHandler(nil, push)
+
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+
+		resp := recorder.Result()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
 }
 
 func generateOTLPWriteRequest(t *testing.T) pmetricotlp.ExportRequest {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR adds `json` format otlp ingestion test. The decoder support both of `proto` and `json` format (https://github.com/prometheus/prometheus/blob/main/storage/remote/codec.go#L883). But, the existing test only covers the `proto` format ingestion.

This PR adds a test making sure the `json` format of the otlp push request also ingests well.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
