### PR TITLE
Put ingester disable chunk trimming a feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 * [ENHANCEMENT] S3 Bucket Client: Add a list objects version configs to configure list api object version. #6280
 * [ENHANCEMENT] OpenStack Swift: Add application credential configs for Openstack swift object storage backend. #6255
 * [ENHANCEMENT] Query Frontend: Add new query stats metrics `cortex_query_samples_scanned_total` and `cortex_query_peak_samples` to track scannedSamples and peakSample per user. #6228
-* [ENHANCEMENT] Ingester: Disable chunk trimming. #6270
 * [ENHANCEMENT] Ingester: Add `blocks-storage.tsdb.wal-compression-type` to support zstd wal compression type. #6232
 * [ENHANCEMENT] Query Frontend: Add info field to query response. #6207
 * [ENHANCEMENT] Query Frontend: Add peakSample in query stats response. #6188

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [ENHANCEMENT] S3 Bucket Client: Add a list objects version configs to configure list api object version. #6280
 * [ENHANCEMENT] OpenStack Swift: Add application credential configs for Openstack swift object storage backend. #6255
 * [ENHANCEMENT] Query Frontend: Add new query stats metrics `cortex_query_samples_scanned_total` and `cortex_query_peak_samples` to track scannedSamples and peakSample per user. #6228
+* [ENHANCEMENT] Ingester: Add option `ingester.disable-chunk-trimming` to disable chunk trimming. #6300
 * [ENHANCEMENT] Ingester: Add `blocks-storage.tsdb.wal-compression-type` to support zstd wal compression type. #6232
 * [ENHANCEMENT] Query Frontend: Add info field to query response. #6207
 * [ENHANCEMENT] Query Frontend: Add peakSample in query stats response. #6188

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3073,6 +3073,13 @@ instance_limits:
 # Experimental: Enable string interning for metrics labels.
 # CLI flag: -ingester.labels-string-interning-enabled
 [labels_string_interning_enabled: <boolean> | default = false]
+
+# Disable trimming of matching series chunks based on query Start and End time.
+# When disabled, the result may contain samples outside the queried time range
+# but select performances may be improved. Note that certain query results might
+# change by changing this option.
+# CLI flag: -ingester.disable-chunk-trimming
+[disable_chunk_trimming: <boolean> | default = false]
 ```
 
 ### `ingester_client_config`

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -37,7 +37,6 @@ import (
 )
 
 func TestDisableChunkTrimmingFuzz(t *testing.T) {
-	noneChunkTrimmingImage := "quay.io/cortexproject/cortex:v1.18.0"
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()
@@ -47,7 +46,7 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 	consul2 := e2edb.NewConsulWithName("consul2")
 	require.NoError(t, s.StartAndWaitReady(consul1, consul2))
 
-	flags1 := mergeFlags(
+	flags := mergeFlags(
 		AlertmanagerLocalFlags(),
 		map[string]string{
 			"-store.engine":                                     blocksStorageEngine,
@@ -61,8 +60,7 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 			"-blocks-storage.bucket-store.bucket-index.enabled": "true",
 			"-querier.query-store-for-labels-enabled":           "true",
 			// Ingester.
-			"-ring.store":      "consul",
-			"-consul.hostname": consul1.NetworkHTTPEndpoint(),
+			"-ring.store": "consul",
 			// Distributor.
 			"-distributor.replication-factor": "1",
 			// Store-gateway.
@@ -71,41 +69,26 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 			"-alertmanager.web.external-url": "http://localhost/alertmanager",
 		},
 	)
-	flags2 := mergeFlags(
-		AlertmanagerLocalFlags(),
-		map[string]string{
-			"-store.engine":                                     blocksStorageEngine,
-			"-blocks-storage.backend":                           "filesystem",
-			"-blocks-storage.tsdb.head-compaction-interval":     "4m",
-			"-blocks-storage.tsdb.block-ranges-period":          "2h",
-			"-blocks-storage.tsdb.ship-interval":                "1h",
-			"-blocks-storage.bucket-store.sync-interval":        "15m",
-			"-blocks-storage.tsdb.retention-period":             "2h",
-			"-blocks-storage.bucket-store.index-cache.backend":  tsdb.IndexCacheBackendInMemory,
-			"-blocks-storage.bucket-store.bucket-index.enabled": "true",
-			"-querier.query-store-for-labels-enabled":           "true",
-			// Ingester.
-			"-ring.store":      "consul",
-			"-consul.hostname": consul2.NetworkHTTPEndpoint(),
-			// Distributor.
-			"-distributor.replication-factor": "1",
-			// Store-gateway.
-			"-store-gateway.sharding-enabled": "false",
-			// alert manager
-			"-alertmanager.web.external-url": "http://localhost/alertmanager",
-		},
-	)
+
 	// make alert manager config dir
 	require.NoError(t, writeFileToSharedDir(s, "alertmanager_configs", []byte{}))
 
 	path1 := path.Join(s.SharedDir(), "cortex-1")
 	path2 := path.Join(s.SharedDir(), "cortex-2")
 
-	flags1 = mergeFlags(flags1, map[string]string{"-blocks-storage.filesystem.dir": path1})
-	flags2 = mergeFlags(flags2, map[string]string{"-blocks-storage.filesystem.dir": path2})
+	flags1 := mergeFlags(flags1, map[string]string{
+		"-blocks-storage.filesystem.dir": path1,
+		"-consul.hostname":               consul1.NetworkHTTPEndpoint(),
+	})
+	// Disable chunk trimming for Cortex 2.
+	flags2 := mergeFlags(flags, map[string]string{
+		"-blocks-storage.filesystem.dir":   path2,
+		"-consul.hostname":                 consul2.NetworkHTTPEndpoint(),
+		"-ingester.disable-chunk-trimming": "true",
+	})
 	// Start Cortex replicas.
 	cortex1 := e2ecortex.NewSingleBinary("cortex-1", flags1, "")
-	cortex2 := e2ecortex.NewSingleBinary("cortex-2", flags2, noneChunkTrimmingImage)
+	cortex2 := e2ecortex.NewSingleBinary("cortex-2", flags2, "")
 	require.NoError(t, s.StartAndWaitReady(cortex1, cortex2))
 
 	// Wait until Cortex replicas have updated the ring state.
@@ -162,9 +145,18 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 	queryEnd := time.Now().Add(-time.Minute * 20)
 	cases := make([]*testCase, 0, 200)
 	testRun := 500
+	var (
+		expr  parser.Expr
+		query string
+	)
 	for i := 0; i < testRun; i++ {
-		expr := ps.WalkRangeQuery()
-		query := expr.Pretty(0)
+		for {
+			expr = ps.WalkRangeQuery()
+			query = expr.Pretty(0)
+			if !strings.Contains(query, "timestamp") {
+				break
+			}
+		}
 		res1, err1 := c1.QueryRange(query, queryStart, queryEnd, scrapeInterval)
 		res2, err2 := c2.QueryRange(query, queryStart, queryEnd, scrapeInterval)
 		cases = append(cases, &testCase{

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -76,7 +77,7 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 	path1 := path.Join(s.SharedDir(), "cortex-1")
 	path2 := path.Join(s.SharedDir(), "cortex-2")
 
-	flags1 := mergeFlags(flags1, map[string]string{
+	flags1 := mergeFlags(flags, map[string]string{
 		"-blocks-storage.filesystem.dir": path1,
 		"-consul.hostname":               consul1.NetworkHTTPEndpoint(),
 	})

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1983,9 +1983,8 @@ func (i *Ingester) queryStreamChunks(ctx context.Context, db *userTSDB, from, th
 		return 0, 0, 0, err
 	}
 	hints := &storage.SelectHints{
-		Start:           from,
-		End:             through,
-		DisableTrimming: true,
+		Start: from,
+		End:   through,
 	}
 	// It's not required to return sorted series because series are sorted by the Cortex querier.
 	ss := q.Select(ctx, false, hints, matchers...)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -137,6 +137,11 @@ type Config struct {
 	AdminLimitMessage string `yaml:"admin_limit_message"`
 
 	LabelsStringInterningEnabled bool `yaml:"labels_string_interning_enabled"`
+
+	// DisableChunkTrimming allows to disable trimming of matching series chunks based on query Start and End time.
+	// When disabled, the result may contain samples outside the queried time range but Select() performances
+	// may be improved.
+	DisableChunkTrimming bool `yaml:"disable_chunk_trimming"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -163,6 +168,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.AdminLimitMessage, "ingester.admin-limit-message", "please contact administrator to raise it", "Customize the message contained in limit errors")
 
 	f.BoolVar(&cfg.LabelsStringInterningEnabled, "ingester.labels-string-interning-enabled", false, "Experimental: Enable string interning for metrics labels.")
+
+	f.BoolVar(&cfg.DisableChunkTrimming, "ingester.disable-chunk-trimming", false, "Disable trimming of matching series chunks based on query Start and End time. When disabled, the result may contain samples outside the queried time range but select performances may be improved. Note that certain query results might change by changing this option.")
 }
 
 func (cfg *Config) Validate() error {
@@ -1983,8 +1990,9 @@ func (i *Ingester) queryStreamChunks(ctx context.Context, db *userTSDB, from, th
 		return 0, 0, 0, err
 	}
 	hints := &storage.SelectHints{
-		Start: from,
-		End:   through,
+		Start:           from,
+		End:             through,
+		DisableTrimming: i.cfg.DisableChunkTrimming,
 	}
 	// It's not required to return sorted series because series are sorted by the Cortex querier.
 	ss := q.Select(ctx, false, hints, matchers...)


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com><!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This changes https://github.com/cortexproject/cortex/pull/6270 to mark the behavior optional under a feature flag.

We noticed that query result got changed if disabling chunk trimming for the following test case, captured by fuzz test.

https://github.com/cortexproject/cortex/actions/runs/11621920479/job/32367371250?pr=6298 

The failure seems correctly captured as `timestamp` function returns timestamp of the sample so if certain samples are not trimmed then the result changes.

I think the behavior is not intended but let's make disable chunk trimming a feature flag for now and users can enable it at their own risk

```
query_fuzz_test.go:188: case 296 results mismatch.
        range query: timestamp({__name__="test_series_3"} @ end() offset 3m21s)
        res1: {job="test"} =>
        1730421141.171 @[1730419941.189]
        1730421141.171 @[1730419971.189]
        1730421141.171 @[1730420001.189]
        1730421141.171 @[1730420031.189]
        1730421141.171 @[1730420061.189]
        1730421141.171 @[1730420091.189]
        1730421141.171 @[1730420121.189]
        1730421141.171 @[1730420151.189]
        1730421141.171 @[1730420181.189]
        1730421141.171 @[1730420211.189]
        1730421141.171 @[1730420241.189]
        1730421141.171 @[1730420271.189]
        1730421141.171 @[1730420301.189]
        1730421141.171 @[1730420331.189]
        1730421141.171 @[1730420361.189]
        1730421141.171 @[1730420391.189]
        1730421141.171 @[1730420421.189]
        1730421141.171 @[1730420451.189]
        1730421141.171 @[1730420481.189]
        1730421141.171 @[1730420511.189]
        1730421141.171 @[1730420[54](https://github.com/cortexproject/cortex/actions/runs/11621920479/job/32367371250?pr=6298#step:10:55)1.189]
        1730421141.171 @[1730420571.189]
        1730421141.171 @[1730420601.189]
        1730421141.171 @[1730420631.189]
        1730421141.171 @[1730420661.189]
        1730421141.171 @[1730420691.189]
        1730421141.171 @[1730420721.189]
        1730421141.171 @[1730420751.189]
        1730421141.171 @[1730420781.189]
        1730421141.171 @[1730420811.189]
        1730421141.171 @[1730420841.189]
        1730421141.171 @[1730420871.189]
        1730421141.171 @[1730420901.189]
        1730421141.171 @[1730420931.189]
        1730421141.171 @[1730420961.189]
        1730421141.171 @[1730420991.189]
        1730421141.171 @[1730421021.189]
        1730421141.171 @[1730421051.189]
        1730421141.171 @[1730421081.189]
        1730421141.171 @[1730421111.189]
        1730421141.171 @[1730421141.189]
        res2: {job="test"} =>
        1730420931.171 @[1730419941.189]
        1730420931.171 @[1730419971.189]
        1730420931.171 @[1730420001.189]
        1730420931.171 @[1730420031.189]
        1730420931.171 @[1730420061.189]
        1730420931.171 @[1730420091.189]
        1730420931.171 @[1730420121.189]
        1730420931.171 @[1730420151.189]
        1730420931.171 @[1730420181.189]
        1730420931.171 @[1730420211.189]
        1730420931.171 @[1730420241.189]
        1730420931.171 @[1730420271.189]
        1730420931.171 @[1730420301.189]
        1730420931.171 @[1730420331.189]
        1730420931.171 @[1730420361.189]
        1730420931.171 @[1730420391.189]
        1730420931.171 @[1730420421.189]
        1730420931.171 @[1730420451.189]
        1730420931.171 @[1730420481.189]
        1730420931.171 @[1730420511.189]
        1730420931.171 @[1730420541.189]
        1730420931.171 @[1730420[57](https://github.com/cortexproject/cortex/actions/runs/11621920479/job/32367371250?pr=6298#step:10:58)1.189]
        1730420931.171 @[1730420601.189]
        1730420931.171 @[1730420631.189]
        1730420931.171 @[1730420661.189]
        1730420931.171 @[1730420691.189]
        1730420931.171 @[1730420721.189]
        1730420931.171 @[1730420751.189]
        1730420931.171 @[1730420781.189]
        1730420931.171 @[1730420811.189]
        1730420931.171 @[1730420841.189]
        1730420931.171 @[1730420871.189]
        1730420931.171 @[1730420901.189]
        1730420931.171 @[1730420931.189]
        1730420931.171 @[17304209[61](https://github.com/cortexproject/cortex/actions/runs/11621920479/job/32367371250?pr=6298#step:10:62).189]
        1730420931.171 @[1730420991.189]
        1730420931.171 @[1730421021.189]
        1730420931.171 @[1730421051.189]
        1730420931.171 @[1730421081.189]
        1730420931.171 @[1730421111.189]
        1730420931.171 @[1730421141.189]
    query_fuzz_test.go:193: 
        	Error Trace:	/home/runner/work/cortex/cortex/integration/query_fuzz_test.go:193
        	Error:      	finished query fuzzing tests
        	Test:       	TestDisableChunkTrimmingFuzz
        	Messages:   	1 test cases failed
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
