### PR TITLE
Preserve ingester state on restart

### DIFF
--- a/pkg/ring/basic_lifecycler_delegates.go
+++ b/pkg/ring/basic_lifecycler_delegates.go
@@ -70,7 +70,7 @@ func (d *TokensPersistencyDelegate) OnRingInstanceRegister(lifecycler *BasicLife
 		return d.next.OnRingInstanceRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
 	}
 
-	tokensFromFile, err := LoadTokensFromFile(d.tokensPath)
+	tokenFile, err := LoadTokenFile(d.tokensPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			level.Error(d.logger).Log("msg", "error loading tokens from file", "err", err)
@@ -78,6 +78,7 @@ func (d *TokensPersistencyDelegate) OnRingInstanceRegister(lifecycler *BasicLife
 
 		return d.next.OnRingInstanceRegister(lifecycler, ringDesc, instanceExists, instanceID, instanceDesc)
 	}
+	tokensFromFile := tokenFile.Tokens
 
 	// Signal the next delegate that the tokens have been loaded, miming the
 	// case the instance exist in the ring (which is OK because the lifecycler
@@ -94,7 +95,8 @@ func (d *TokensPersistencyDelegate) OnRingInstanceRegister(lifecycler *BasicLife
 
 func (d *TokensPersistencyDelegate) OnRingInstanceTokens(lifecycler *BasicLifecycler, tokens Tokens) {
 	if d.tokensPath != "" {
-		if err := tokens.StoreToFile(d.tokensPath); err != nil {
+		tokenFile := TokenFile{Tokens: tokens}
+		if err := tokenFile.StoreToFile(d.tokensPath); err != nil {
 			level.Error(d.logger).Log("msg", "error storing tokens to disk", "path", d.tokensPath, "err", err)
 		}
 	}

--- a/pkg/ring/lifecycler_test.go
+++ b/pkg/ring/lifecycler_test.go
@@ -716,7 +716,7 @@ func TestRestartIngester_DisabledHeartbeat_unregister_on_shutdown_false(t *testi
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), l2))
 }
 
-func TestTokensOnDisk(t *testing.T) {
+func TestTokenFileOnDisk(t *testing.T) {
 	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
@@ -756,6 +756,17 @@ func TestTokensOnDisk(t *testing.T) {
 			len(desc.Ingesters["ing1"].Tokens) == 512
 	})
 
+	// Change state from ACTIVE to READONLY
+	l1.ChangeState(context.Background(), READONLY)
+	test.Poll(t, 1000*time.Millisecond, true, func() interface{} {
+		d, err := r.KVClient.Get(context.Background(), ringKey)
+		require.NoError(t, err)
+
+		desc, ok := d.(*Desc)
+		return ok &&
+			desc.Ingesters["ing1"].State == READONLY
+	})
+
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), l1))
 
 	// Start new ingester at same token directory.
@@ -776,7 +787,7 @@ func TestTokensOnDisk(t *testing.T) {
 		}
 		return ok &&
 			len(desc.Ingesters) == 1 &&
-			desc.Ingesters["ing2"].State == ACTIVE &&
+			desc.Ingesters["ing2"].State == READONLY &&
 			len(desc.Ingesters["ing2"].Tokens) == 512
 	})
 

--- a/pkg/ring/token_file.go
+++ b/pkg/ring/token_file.go
@@ -1,0 +1,66 @@
+package ring
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"sort"
+)
+
+type TokenFile struct {
+	PreviousState InstanceState `json:"previousState"`
+	Tokens        Tokens        `json:"tokens"`
+}
+
+// StoreToFile stores the tokens in the given directory.
+func (l TokenFile) StoreToFile(tokenFilePath string) error {
+	if tokenFilePath == "" {
+		return errors.New("path is empty")
+	}
+
+	// If any operations failed further in the function, we keep the temporary
+	// file hanging around for debugging.
+	f, err := os.Create(tokenFilePath + ".tmp")
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		// If the file was not closed, then there must already be an error, hence ignore
+		// the error (if any) from f.Close(). If the file was already closed, then
+		// we would ignore the error in that case too.
+		_ = f.Close()
+	}()
+
+	b, err := json.Marshal(l)
+	if err != nil {
+		return err
+	}
+	if _, err = f.Write(b); err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	// Tokens successfully written, replace the temporary file with the actual file path.
+	return os.Rename(f.Name(), tokenFilePath)
+}
+
+func LoadTokenFile(tokenFilePath string) (*TokenFile, error) {
+	b, err := os.ReadFile(tokenFilePath)
+	if err != nil {
+		return nil, err
+	}
+	t := TokenFile{}
+	err = json.Unmarshal(b, &t)
+
+	// Tokens may have been written to file by an older version which
+	// doesn't guarantee sorted tokens, so we enforce sorting here.
+	if !sort.IsSorted(t.Tokens) {
+		sort.Sort(t.Tokens)
+	}
+
+	return &t, err
+}

--- a/pkg/ring/token_file_test.go
+++ b/pkg/ring/token_file_test.go
@@ -1,0 +1,46 @@
+package ring
+
+import (
+	"encoding/json"
+	"math/rand"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenFile_Serialization(t *testing.T) {
+	tokens := make(Tokens, 0, 512)
+	for i := 0; i < 512; i++ {
+		tokens = append(tokens, uint32(rand.Int31()))
+	}
+	tokenFile := TokenFile{
+		PreviousState: READONLY,
+		Tokens:        tokens,
+	}
+	b, err := json.Marshal(tokenFile)
+	require.NoError(t, err)
+
+	unmarshaledTokenFile := TokenFile{}
+	require.NoError(t, json.Unmarshal(b, &unmarshaledTokenFile))
+	require.Equal(t, tokens, unmarshaledTokenFile.Tokens)
+	require.Equal(t, READONLY, unmarshaledTokenFile.PreviousState)
+}
+
+func TestLoadTokenFile_ShouldGuaranteeSortedTokens(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Store tokens to file.
+	origTokens := Tokens{1, 5, 3}
+	orig := TokenFile{
+		Tokens: origTokens,
+	}
+
+	require.NoError(t, orig.StoreToFile(filepath.Join(tmpDir, "tokens")))
+
+	// Read back and ensure they're sorted.
+	actual, err := LoadTokenFile(filepath.Join(tmpDir, "tokens"))
+	require.NoError(t, err)
+	assert.Equal(t, Tokens{1, 3, 5}, actual.Tokens)
+}

--- a/pkg/ring/tokens.go
+++ b/pkg/ring/tokens.go
@@ -1,9 +1,6 @@
 package ring
 
 import (
-	"encoding/json"
-	"errors"
-	"os"
 	"sort"
 )
 
@@ -31,77 +28,4 @@ func (t Tokens) Equals(other Tokens) bool {
 	}
 
 	return true
-}
-
-// StoreToFile stores the tokens in the given directory.
-func (t Tokens) StoreToFile(tokenFilePath string) error {
-	if tokenFilePath == "" {
-		return errors.New("path is empty")
-	}
-
-	// If any operations failed further in the function, we keep the temporary
-	// file hanging around for debugging.
-	f, err := os.Create(tokenFilePath + ".tmp")
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		// If the file was not closed, then there must already be an error, hence ignore
-		// the error (if any) from f.Close(). If the file was already closed, then
-		// we would ignore the error in that case too.
-		_ = f.Close()
-	}()
-
-	b, err := t.Marshal()
-	if err != nil {
-		return err
-	}
-	if _, err = f.Write(b); err != nil {
-		return err
-	}
-
-	if err := f.Close(); err != nil {
-		return err
-	}
-
-	// Tokens successfully written, replace the temporary file with the actual file path.
-	return os.Rename(f.Name(), tokenFilePath)
-}
-
-// LoadTokensFromFile loads tokens from given file path.
-func LoadTokensFromFile(tokenFilePath string) (Tokens, error) {
-	b, err := os.ReadFile(tokenFilePath)
-	if err != nil {
-		return nil, err
-	}
-	var t Tokens
-	err = t.Unmarshal(b)
-
-	// Tokens may have been written to file by an older version which
-	// doesn't guarantee sorted tokens, so we enforce sorting here.
-	if !sort.IsSorted(t) {
-		sort.Sort(t)
-	}
-
-	return t, err
-}
-
-// Marshal encodes the tokens into JSON.
-func (t Tokens) Marshal() ([]byte, error) {
-	return json.Marshal(tokensJSON{Tokens: t})
-}
-
-// Unmarshal reads the tokens from JSON byte stream.
-func (t *Tokens) Unmarshal(b []byte) error {
-	tj := tokensJSON{}
-	if err := json.Unmarshal(b, &tj); err != nil {
-		return err
-	}
-	*t = tj.Tokens
-	return nil
-}
-
-type tokensJSON struct {
-	Tokens []uint32 `json:"tokens"`
 }

--- a/pkg/ring/tokens_test.go
+++ b/pkg/ring/tokens_test.go
@@ -1,27 +1,10 @@
 package ring
 
 import (
-	"math/rand"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestTokens_Serialization(t *testing.T) {
-	tokens := make(Tokens, 0, 512)
-	for i := 0; i < 512; i++ {
-		tokens = append(tokens, uint32(rand.Int31()))
-	}
-
-	b, err := tokens.Marshal()
-	require.NoError(t, err)
-
-	var unmarshaledTokens Tokens
-	require.NoError(t, unmarshaledTokens.Unmarshal(b))
-	require.Equal(t, tokens, unmarshaledTokens)
-}
 
 func TestTokens_Equals(t *testing.T) {
 	tests := []struct {
@@ -55,17 +38,4 @@ func TestTokens_Equals(t *testing.T) {
 		assert.Equal(t, c.expected, c.first.Equals(c.second))
 		assert.Equal(t, c.expected, c.second.Equals(c.first))
 	}
-}
-
-func TestLoadTokensFromFile_ShouldGuaranteeSortedTokens(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Store tokens to file.
-	orig := Tokens{1, 5, 3}
-	require.NoError(t, orig.StoreToFile(filepath.Join(tmpDir, "tokens")))
-
-	// Read back and ensure they're sorted.
-	actual, err := LoadTokensFromFile(filepath.Join(tmpDir, "tokens"))
-	require.NoError(t, err)
-	assert.Equal(t, Tokens{1, 3, 5}, actual)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Since READONLY state was introduced, ingester would be put back on ACTIVE state after restart. Because the state is hard coded in lifecycler. This PR would preserve ring state in token file right before shutting down and during initialization of lifecycler, state would be restored by reading previous state from token file.

**Which issue(s) this PR fixes**:
NA

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
