### PR TITLE
Support label_join and label_replace in query fuzz tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
 	github.com/cespare/xxhash v1.1.0
-	github.com/cortexproject/promqlsmith v0.0.0-20241101182713-3eec5725bc3f
+	github.com/cortexproject/promqlsmith v0.0.0-20241102030034-4051538fd914
 	github.com/dustin/go-humanize v1.0.1
 	github.com/efficientgo/core v1.0.0-rc.3
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb

--- a/go.sum
+++ b/go.sum
@@ -944,8 +944,8 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/coreos/go-systemd/v22 v22.4.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cortexproject/promqlsmith v0.0.0-20241101182713-3eec5725bc3f h1:5C8PGy3GN+qqQatdDMU5bXFIspoIngMuyD7UCWkMiRA=
-github.com/cortexproject/promqlsmith v0.0.0-20241101182713-3eec5725bc3f/go.mod h1:ypUb6BfnDVr7QrBgAxtzRqZ573swvka0BdCkPqa2A5g=
+github.com/cortexproject/promqlsmith v0.0.0-20241102030034-4051538fd914 h1:UhI6yOSqMz3ln8FGaZRLbJTKzPHRaVwewoTa6N5PU5k=
+github.com/cortexproject/promqlsmith v0.0.0-20241102030034-4051538fd914/go.mod h1:ypUb6BfnDVr7QrBgAxtzRqZ573swvka0BdCkPqa2A5g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -125,7 +125,7 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 	serieses := make([]prompb.TimeSeries, numSeries)
 	lbls := make([]labels.Labels, numSeries)
 	for i := 0; i < numSeries; i++ {
-		series := e2e.GenerateSeriesWithSamples("test_series"), start, scrapeInterval, i*numSamples, numSamples, prompb.Label{Name: "job", Value: "test"}, prompb.Label{Name: "series", Value: strconv.Itoa(i)})
+		series := e2e.GenerateSeriesWithSamples("test_series", start, scrapeInterval, i*numSamples, numSamples, prompb.Label{Name: "job", Value: "test"}, prompb.Label{Name: "series", Value: strconv.Itoa(i)})
 		serieses[i] = series
 
 		builder := labels.NewBuilder(labels.EmptyLabels())

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -42,9 +41,6 @@ var enabledFunctions []*parser.Function
 
 func init() {
 	for _, f := range parser.Functions {
-		if slices.Contains(f.ArgTypes, parser.ValueTypeString) {
-			continue
-		}
 		// Ignore native histogram functions for now as our test cases are only float samples.
 		if strings.Contains(f.Name, "histogram") && f.Name != "histogram_quantile" {
 			continue
@@ -129,7 +125,7 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 	serieses := make([]prompb.TimeSeries, numSeries)
 	lbls := make([]labels.Labels, numSeries)
 	for i := 0; i < numSeries; i++ {
-		series := e2e.GenerateSeriesWithSamples(fmt.Sprintf("test_series_%d", i), start, scrapeInterval, i*numSamples, numSamples, prompb.Label{Name: "job", Value: "test"})
+		series := e2e.GenerateSeriesWithSamples("test_series"), start, scrapeInterval, i*numSamples, numSamples, prompb.Label{Name: "job", Value: "test"}, prompb.Label{Name: "series", Value: strconv.Itoa(i)})
 		serieses[i] = series
 
 		builder := labels.NewBuilder(labels.EmptyLabels())
@@ -175,7 +171,8 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 		for {
 			expr = ps.WalkRangeQuery()
 			query = expr.Pretty(0)
-			if !strings.Contains(query, "timestamp") {
+			// timestamp is a known function that break with disable chunk trimming.
+			if isValidQuery(expr, 5) && !strings.Contains(query, "timestamp") {
 				break
 			}
 		}

--- a/vendor/github.com/cortexproject/promqlsmith/opts.go
+++ b/vendor/github.com/cortexproject/promqlsmith/opts.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-	"golang.org/x/exp/slices"
 )
 
 var (
@@ -58,9 +57,6 @@ var (
 
 func init() {
 	for _, f := range parser.Functions {
-		if slices.Contains(f.ArgTypes, parser.ValueTypeString) {
-			continue
-		}
 		// Ignore experimental functions for now.
 		if !f.Experimental {
 			defaultSupportedFuncs = append(defaultSupportedFuncs, f)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -303,7 +303,7 @@ github.com/coreos/go-semver/semver
 ## explicit; go 1.12
 github.com/coreos/go-systemd/v22/activation
 github.com/coreos/go-systemd/v22/journal
-# github.com/cortexproject/promqlsmith v0.0.0-20241101182713-3eec5725bc3f
+# github.com/cortexproject/promqlsmith v0.0.0-20241102030034-4051538fd914
 ## explicit; go 1.21.0
 github.com/cortexproject/promqlsmith
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Upgrade promqlsmith to https://github.com/cortexproject/promqlsmith/pull/129 to support `label_join` and `label_replace`.

Improved existing `TestDisableChunkTrimmingFuzz` test case to generate multiple series under a single metric name as well as reducing the generated queries' complexity.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
