### PR TITLE
Introducing Cortex Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <a href="https://cloud-native.slack.com/messages/cortex/"><img src="https://img.shields.io/badge/join%20slack-%23cortex-brightgreen.svg" alt="Slack" /></a>
 <a href="https://bestpractices.coreinfrastructure.org/projects/6681"><img src="https://bestpractices.coreinfrastructure.org/projects/6681/badge"></a>
 [![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/cortex/badge)](https://clomonitor.io/projects/cncf/cortex)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Cortex%20Guru-006BFF)](https://gurubase.io/g/cortex)
 
 
 # Cortex


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Cortex Guru](https://gurubase.io/g/cortex) to Gurubase. Cortex Guru uses the data from this repo and data from the [docs](https://cortexmetrics.io/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Cortex Guru", which highlights that Cortex now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Cortex Guru in Gurubase, just let me know that's totally fine.
