### PR TITLE
Update getting started guide, seaweedfs setup, and healthchecks in docker-compose

### DIFF
--- a/docs/getting-started/Makefile
+++ b/docs/getting-started/Makefile
@@ -1,9 +1,7 @@
 # Description: This Makefile is used to generate the dashboards, alerts, and rules files from the cortex-jsonnet repo.
 # It uses a customized mixin.libsonnet file to generate the files.
 
-all:
-	# Clone the cortex-jsonnet repository
-	git clone https://github.com/cortexproject/cortex-jsonnet --depth 1
+all: cortex-jsonnet
 	# Show the diff between the mixin.libsonnet file and the cortex-jsonnet/cortex-mixin/mixin.libsonnet file
 	git --no-pager diff --no-index cortex-jsonnet/cortex-mixin/mixin.libsonnet mixin.libsonnet || true
 	# Copy the mixin.libsonnet file to the cortex-jsonnet directory
@@ -14,6 +12,10 @@ all:
 	rm -rf dashboards alerts.yaml rules.yaml
 	# Copy the files from the cortex-jsonnet/cortex-mixin/out directory to the current directory
 	mv cortex-jsonnet/cortex-mixin/out/* .
+
+cortex-jsonnet:
+	# Clone the cortex-jsonnet repository
+	git clone https://github.com/cortexproject/cortex-jsonnet --depth 1
 
 clean:
 	# Remove the cortex-jsonnet directory

--- a/docs/getting-started/docker-compose.yaml
+++ b/docs/getting-started/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     ports:
       - "9009:9009"
     healthcheck:
-        test: wget -qO- http://localhost:9009/ready
+        test: wget -qO- http://127.0.0.1:9009/ready
         interval: 10s
         timeout: 10s
         retries: 3
@@ -58,7 +58,7 @@ services:
     volumes:
       - ./seaweedfs-config.json:/workspace/seaweedfs-config.json:ro
     healthcheck:
-      test: wget -qO- http://localhost:8333/status
+      test: wget -qO- http://127.0.0.1:8333/status
       interval: 10s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
**What this PR does**:
- Adds more info to the getting started guide on what's in the guides
- Sets up seaweedfs before other services in single binary mode guide
- Fix healthchecks in docker-compose
- Set up recipe for cortex-jsonnet in Makefile

