### PR TITLE
storegateway: Add a metric for chunk pool inuse bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [ENHANCEMENT] Ingester/Store Gateway Clients: Introduce an experimental HealthCheck handler to quickly fail requests directed to unhealthy targets. #6225 #6257
 * [ENHANCEMENT] Upgrade build image and Go version to 1.23.2. #6261 #6262
 * [ENHANCEMENT] Querier/Ruler: Expose `store_gateway_consistency_check_max_attempts` for max retries when querying store gateway in consistency check. #6276
+* [ENHANCEMENT] StoreGateway: Add new `cortex_bucket_store_chunk_pool_inuse_bytes` metric to track the usage in chunk pool. #6310
 * [BUGFIX] Runtime-config: Handle absolute file paths when working directory is not / #6224
 
 ## 1.18.1 2024-10-14

--- a/pkg/storegateway/chunk_bytes_pool.go
+++ b/pkg/storegateway/chunk_bytes_pool.go
@@ -10,7 +10,8 @@ type chunkBytesPool struct {
 	pool *pool.BucketedPool[byte]
 
 	// Metrics.
-	poolByteStats *prometheus.CounterVec
+	poolByteStats  *prometheus.CounterVec
+	poolInUseBytes prometheus.GaugeFunc
 }
 
 func newChunkBytesPool(minBucketSize, maxBucketSize int, maxChunkPoolBytes uint64, reg prometheus.Registerer) (*chunkBytesPool, error) {
@@ -25,6 +26,12 @@ func newChunkBytesPool(minBucketSize, maxBucketSize int, maxChunkPoolBytes uint6
 			Name: "cortex_bucket_store_chunk_pool_operation_bytes_total",
 			Help: "Total bytes number of bytes pooled by operation.",
 		}, []string{"operation", "stats"}),
+		poolInUseBytes: promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "cortex_bucket_store_chunk_pool_inuse_bytes",
+			Help: "Total bytes in use in the chunk pool.",
+		}, func() float64 {
+			return float64(upstream.UsedBytes())
+		}),
 	}, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- Adding a new metric for tracking in-use bytes in store-gateway.
- This should help us catch leaks in the pool more easily

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
