### PR TITLE
Fix race on chunks multilevel cache + Optimize to avoid refetching already found keys. 

### DIFF
--- a/pkg/storage/tsdb/multilevel_chunk_cache.go
+++ b/pkg/storage/tsdb/multilevel_chunk_cache.go
@@ -98,6 +98,7 @@ func (m *multiLevelChunkCache) Fetch(ctx context.Context, keys []string) map[str
 	timer := prometheus.NewTimer(m.fetchLatency.WithLabelValues())
 	defer timer.ObserveDuration()
 
+	missingKeys := keys
 	hits := map[string][]byte{}
 	backfillItems := make([]map[string][]byte, len(m.caches)-1)
 
@@ -108,12 +109,22 @@ func (m *multiLevelChunkCache) Fetch(ctx context.Context, keys []string) map[str
 		if ctx.Err() != nil {
 			return nil
 		}
-		if data := c.Fetch(ctx, keys); len(data) > 0 {
+		if data := c.Fetch(ctx, missingKeys); len(data) > 0 {
 			for k, d := range data {
 				hits[k] = d
 			}
 
 			if i > 0 && len(hits) > 0 {
+				// lets fetch only the mising keys
+				m := missingKeys[:0]
+				for _, key := range missingKeys {
+					if _, ok := hits[key]; !ok {
+						m = append(m, key)
+					}
+				}
+
+				missingKeys = m
+
 				for k, b := range hits {
 					backfillItems[i-1][k] = b
 				}

--- a/pkg/storage/tsdb/multilevel_chunk_cache.go
+++ b/pkg/storage/tsdb/multilevel_chunk_cache.go
@@ -114,7 +114,9 @@ func (m *multiLevelChunkCache) Fetch(ctx context.Context, keys []string) map[str
 			}
 
 			if i > 0 && len(hits) > 0 {
-				backfillItems[i-1] = hits
+				for k, b := range hits {
+					backfillItems[i-1][k] = b
+				}
 			}
 
 			if len(hits) == len(keys) {

--- a/pkg/storage/tsdb/multilevel_chunk_cache_test.go
+++ b/pkg/storage/tsdb/multilevel_chunk_cache_test.go
@@ -120,12 +120,14 @@ func Test_MultiLevelChunkCacheFetch(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		m1ExistingData      map[string][]byte
-		m2ExistingData      map[string][]byte
-		expectedM1Data      map[string][]byte
-		expectedM2Data      map[string][]byte
-		expectedFetchedData map[string][]byte
-		fetchKeys           []string
+		m1ExistingData        map[string][]byte
+		m2ExistingData        map[string][]byte
+		expectedM1Data        map[string][]byte
+		expectedM2Data        map[string][]byte
+		expectedFetchedData   map[string][]byte
+		expectedM1FetchedKeys []string
+		expectedM2FetchedKeys []string
+		fetchKeys             []string
 	}{
 		"fetched data should be union of m1, m2 and 'key2' and `key3' should be backfilled to m1": {
 			m1ExistingData: map[string][]byte{
@@ -135,6 +137,8 @@ func Test_MultiLevelChunkCacheFetch(t *testing.T) {
 				"key2": []byte("value2"),
 				"key3": []byte("value3"),
 			},
+			expectedM1FetchedKeys: []string{"key1", "key2", "key3"},
+			expectedM2FetchedKeys: []string{"key2", "key3"},
 			expectedM1Data: map[string][]byte{
 				"key1": []byte("value1"),
 				"key2": []byte("value2"),
@@ -158,6 +162,8 @@ func Test_MultiLevelChunkCacheFetch(t *testing.T) {
 			m2ExistingData: map[string][]byte{
 				"key2": []byte("value2"),
 			},
+			expectedM1FetchedKeys: []string{"key1", "key2", "key3"},
+			expectedM2FetchedKeys: []string{"key2", "key3"},
 			expectedM1Data: map[string][]byte{
 				"key1": []byte("value1"),
 				"key2": []byte("value2"),
@@ -196,6 +202,8 @@ type mockChunkCache struct {
 	mu   sync.Mutex
 	name string
 	data map[string][]byte
+
+	fetchedKeys []string
 }
 
 func newMockChunkCache(name string, data map[string][]byte) *mockChunkCache {
@@ -219,6 +227,7 @@ func (m *mockChunkCache) Fetch(_ context.Context, keys []string) map[string][]by
 	h := map[string][]byte{}
 
 	for _, k := range keys {
+		m.fetchedKeys = append(m.fetchedKeys, k)
 		if _, ok := m.data[k]; ok {
 			h[k] = m.data[k]
 		}


### PR DESCRIPTION
**What this PR does**:

We can have a race when we partially fetch data on the multilevel cache. The reason for that is internally, the object store changes the dic returned by the cache and this races with the cache internal implementation.

Ex: https://github.com/thanos-io/thanos/blob/d6d19c568f8dc6005a9184d3a5a994da4f0d8c75/pkg/store/cache/caching_bucket.go#L469

Right now this PR only have the unit test demonstrating the issue.

PS: I also optimized the cache to not fetch keys that were already found on the previous cache implementation.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
