### PR TITLE
compatibility query fuzz test with results cache enabled

### DIFF
--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -1023,8 +1023,9 @@ func TestResultsCacheBackwardCompatibilityQueryFuzz(t *testing.T) {
 			"-frontend.query-vertical-shard-size": "2",
 			"-frontend.max-cache-freshness":       "1m",
 			// Enable results cache.
-			"-querier.cache-results":        "true",
-			"-frontend.memcached.addresses": "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
+			"-querier.cache-results":             "true",
+			"-querier.split-queries-by-interval": "24h",
+			"-frontend.memcached.addresses":      "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
 		},
 	)
 	// make alert manager config dir

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -1114,6 +1114,7 @@ func TestResultsCacheBackwardCompatibilityQueryFuzz(t *testing.T) {
 	}
 
 	run := 1000
+	step := 5 * time.Minute
 	cases := make([]*testCase, 0, run)
 	var (
 		expr  parser.Expr
@@ -1128,7 +1129,7 @@ func TestResultsCacheBackwardCompatibilityQueryFuzz(t *testing.T) {
 			}
 		}
 		// We don't care the query results here. Just to fill the cache with partial result.
-		_, _ = c1.QueryRange(query, start, start.Add(time.Minute*30), scrapeInterval)
+		_, _ = c1.QueryRange(query, start, start.Add(time.Minute*30), step)
 		cases = append(cases, &testCase{
 			query: query,
 		})
@@ -1137,8 +1138,8 @@ func TestResultsCacheBackwardCompatibilityQueryFuzz(t *testing.T) {
 	for i := 0; i < run; i++ {
 		c := cases[i]
 		// If not bypassing cache, we expect this query to fetch part of the query results as well as reusing some existing cached result.
-		c.res1, c.err1 = c2.QueryRange(c.query, start, end, scrapeInterval)
-		c.res2, c.err2 = c2ByPassCache.QueryRange(c.query, start, end, scrapeInterval)
+		c.res1, c.err1 = c2.QueryRange(c.query, start, end, step)
+		c.res2, c.err2 = c2ByPassCache.QueryRange(c.query, start, end, step)
 	}
 
 	failures := 0

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -1113,7 +1113,7 @@ func TestResultsCacheBackwardCompatibilityQueryFuzz(t *testing.T) {
 		err1, err2 error
 	}
 
-	run := 1000
+	run := 100
 	step := 5 * time.Minute
 	cases := make([]*testCase, 0, run)
 	var (

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -1108,9 +1108,9 @@ func TestResultsCacheBackwardCompatibilityQueryFuzz(t *testing.T) {
 	ps := promqlsmith.New(rnd, lbls, opts...)
 
 	type testCase struct {
-		query            string
-		res1, res2, res3 model.Value
-		err1, err2, err3 error
+		query      string
+		res1, res2 model.Value
+		err1, err2 error
 	}
 
 	run := 100


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Existing query fuzz tests don't enable results cache.

This PR adds a new query fuzz test focusing on catching results cache compatibility issue.

The workflow is like follows:

1. Run two Cortex containers with previous image and latest image. They share the same result cache.
2. Run a range query with time [start, start + 30m] against a Cortex container with previous release image to fill results cache.
3. Run the same range query with time [start, end] against a Cortex container with the latest image.
4. Run the same range query with time [start, end] but with results cache bypassed and compare the query result got from last step.

The test is a bit overlapped with the existing query result compatibility test because compatibility issue also cause results cache to go wrong. But it also catches changes of the result cache itself. For example, https://github.com/cortexproject/cortex/pull/6196

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
