### PR TITLE
Fix: PostingCache promise should fetch data only once

### DIFF
--- a/pkg/storage/tsdb/expanded_postings_cache_test.go
+++ b/pkg/storage/tsdb/expanded_postings_cache_test.go
@@ -18,7 +18,7 @@ func Test_ShouldFetchPromiseOnlyOnce(t *testing.T) {
 		Ttl:      time.Hour,
 		MaxBytes: 10 << 20,
 	}
-	m := NewPostingCacheMetrics(prometheus.DefaultRegisterer)
+	m := NewPostingCacheMetrics(prometheus.NewPedanticRegistry())
 	cache := newFifoCache[int](cfg, "test", m, time.Now)
 	calls := atomic.Int64{}
 	concurrency := 100
@@ -46,7 +46,7 @@ func Test_ShouldFetchPromiseOnlyOnce(t *testing.T) {
 func TestFifoCacheDisabled(t *testing.T) {
 	cfg := PostingsCacheConfig{}
 	cfg.Enabled = false
-	m := NewPostingCacheMetrics(prometheus.DefaultRegisterer)
+	m := NewPostingCacheMetrics(prometheus.NewPedanticRegistry())
 	timeNow := time.Now
 	cache := newFifoCache[int](cfg, "test", m, timeNow)
 	old, loaded := cache.getPromiseForKey("key1", func() (int, int64, error) {

--- a/pkg/storage/tsdb/expanded_postings_cache_test.go
+++ b/pkg/storage/tsdb/expanded_postings_cache_test.go
@@ -1,7 +1,6 @@
 package tsdb
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -54,9 +53,7 @@ func TestFifoCacheDisabled(t *testing.T) {
 		return 1, 0, nil
 	})
 	require.False(t, loaded)
-	v, err := old.result(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, 1, v)
+	require.Equal(t, 1, old.v)
 	require.False(t, cache.contains("key1"))
 }
 
@@ -101,17 +98,13 @@ func TestFifoCacheExpire(t *testing.T) {
 					return 1, 8, nil
 				})
 				require.False(t, loaded)
-				v, err := p.result(context.Background())
-				require.NoError(t, err)
-				require.Equal(t, 1, v)
+				require.Equal(t, 1, p.v)
 				require.True(t, cache.contains(key))
 				p, loaded = cache.getPromiseForKey(key, func() (int, int64, error) {
 					return 1, 0, nil
 				})
 				require.True(t, loaded)
-				v, err = p.result(context.Background())
-				require.NoError(t, err)
-				require.Equal(t, 1, v)
+				require.Equal(t, 1, p.v)
 			}
 
 			totalCacheSize := 0
@@ -137,10 +130,8 @@ func TestFifoCacheExpire(t *testing.T) {
 						return 2, 18, nil
 					})
 					require.False(t, loaded)
-					v, err := p.result(context.Background())
-					require.NoError(t, err)
 					// New value
-					require.Equal(t, 2, v)
+					require.Equal(t, 2, p.v)
 					// Total Size Updated
 					require.Equal(t, originalSize+10, cache.cachedBytes)
 				}


### PR DESCRIPTION
**What this PR does**:
Follow up of https://github.com/cortexproject/cortex/pull/6296

Under concurrency, we are fetching the postings multiples times for the same key.

The reason for that is we load the previous promise from the cache but the promise does not have the ts set yet and so, we assume is expired:

See:

https://github.com/cortexproject/cortex/blob/2e5488af4fc582b6f63afa4ec0543f31aef161c5/pkg/storage/tsdb/expanded_postings_cache.go#L320-L332


This PR is simplifying the implementation and waiting the loaded promise to finish before checking if is expired.

First commit of the PR has only the test showing the problem.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
