### PR TITLE
Upgrade to use prometheus v2.55.1 in fuzz

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -193,7 +193,7 @@ jobs:
           elif [ "$TEST_TAGS" = "integration_query_fuzz" ]; then
             docker pull quay.io/cortexproject/cortex:v1.18.1 
             docker pull quay.io/prometheus/prometheus:v2.51.0
-            docker pull quay.io/prometheus/prometheus:v2.55.0
+            docker pull quay.io/prometheus/prometheus:v2.55.1
           fi
           docker pull memcached:1.6.1
           docker pull redis:7.0.4-alpine

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -1070,7 +1070,7 @@ func TestBackwardCompatibilityQueryFuzz(t *testing.T) {
 
 // TestPrometheusCompatibilityQueryFuzz compares Cortex with latest Prometheus release.
 func TestPrometheusCompatibilityQueryFuzz(t *testing.T) {
-	prometheusLatestImage := "quay.io/prometheus/prometheus:v2.55.0"
+	prometheusLatestImage := "quay.io/prometheus/prometheus:v2.55.1"
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Use Prometheus v2.55.1 image in query fuzz as it fixes a query regression.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
