### PR TITLE
Remove openstack swfit experimental in blocks storage

### DIFF
--- a/docs/blocks-storage/_index.md
+++ b/docs/blocks-storage/_index.md
@@ -12,7 +12,7 @@ The supported backends for the blocks storage are:
 * [Amazon S3](https://aws.amazon.com/s3)
 * [Google Cloud Storage](https://cloud.google.com/storage/)
 * [Microsoft Azure Storage](https://azure.microsoft.com/en-us/services/storage/)
-* [OpenStack Swift](https://wiki.openstack.org/wiki/Swift) (experimental)
+* [OpenStack Swift](https://wiki.openstack.org/wiki/Swift)
 * [Local Filesystem](https://thanos.io/tip/thanos/storage.md/#filesystem) (single node only)
 
 _Internally, some components are based on [Thanos](https://thanos.io), but no Thanos knowledge is required in order to run it._


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR removes Openstack swift `experimental` at `Blocks Storage` section.
In #6316, it was removed at `architecture`.
I just found out it exists `Blocks Storage` section as well..

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
