### PR TITLE
Don't propagate cancel signal to the Prometheus rules manager context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [ENHANCEMENT] Querier/Ruler: Expose `store_gateway_consistency_check_max_attempts` for max retries when querying store gateway in consistency check. #6276
 * [ENHANCEMENT] StoreGateway: Add new `cortex_bucket_store_chunk_pool_inuse_bytes` metric to track the usage in chunk pool. #6310
 * [BUGFIX] Runtime-config: Handle absolute file paths when working directory is not / #6224
+* [BUGFIX] Ruler: Allow rule evaluation to complete during shutdown. #6326
 
 ## 1.18.1 2024-10-14
 

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -67,7 +67,7 @@ func TestRuler_rules(t *testing.T) {
 							Alerts: []*Alert{},
 						},
 					},
-					Interval: 60,
+					Interval: 10,
 				},
 			},
 		},
@@ -123,7 +123,7 @@ func TestRuler_rules_special_characters(t *testing.T) {
 							Alerts: []*Alert{},
 						},
 					},
-					Interval: 60,
+					Interval: 10,
 				},
 			},
 		},
@@ -178,7 +178,7 @@ func TestRuler_rules_limit(t *testing.T) {
 							Alerts: []*Alert{},
 						},
 					},
-					Interval: 60,
+					Interval: 10,
 				},
 			},
 		},
@@ -342,7 +342,7 @@ func TestRuler_DeleteNamespace(t *testing.T) {
 
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "name: group1\ninterval: 1m\nrules:\n    - record: UP_RULE\n      expr: up\n    - alert: UP_ALERT\n      expr: up < 1\n", w.Body.String())
+	require.Equal(t, "name: group1\ninterval: 10s\nrules:\n    - record: UP_RULE\n      expr: up\n    - alert: UP_ALERT\n      expr: up < 1\n", w.Body.String())
 
 	// Delete namespace1
 	req = requestFor(t, http.MethodDelete, "https://localhost:8080/api/v1/rules/namespace1", nil, "user1")

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -341,11 +341,15 @@ func DefaultTenantManagerFactory(cfg Config, p Pusher, q storage.Queryable, engi
 			queryFunc = metricsQueryFunc
 		}
 
+		// We let the Prometheus rules manager control the context so that there is a chance
+		// for graceful shutdown of rules that are still in execution even in case the cortex context is canceled.
+		prometheusContext := user.InjectOrgID(context.WithoutCancel(ctx), userID)
+
 		return rules.NewManager(&rules.ManagerOptions{
 			Appendable:             NewPusherAppendable(p, userID, overrides, totalWrites, failedWrites),
 			Queryable:              q,
 			QueryFunc:              queryFunc,
-			Context:                user.InjectOrgID(ctx, userID),
+			Context:                prometheusContext,
 			ExternalURL:            cfg.ExternalURL.URL,
 			NotifyFunc:             SendAlerts(notifier, cfg.ExternalURL.URL.String()),
 			Logger:                 log.With(logger, "user", userID),

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -19,7 +19,7 @@ type mockRuleStore struct {
 
 var (
 	delim               = "/"
-	interval, _         = time.ParseDuration("1m")
+	interval, _         = time.ParseDuration("10s")
 	mockRulesNamespaces = map[string]rulespb.RuleGroupList{
 		"user1": {
 			&rulespb.RuleGroupDesc{


### PR DESCRIPTION
**What this PR does**:

* Allow rules that are being evaluated to successfully complete/timeout when rulers are shutdown. Before this PR, we were canceling the context right away, wasting all the work performed by the queries.

This is done by removing the cancel signal of the context passed to the Prometheus rules manager. Instead we are going to rely on the shutdown mechanism of the rules manager and timeout of the queries executed by the rules.

In the unit tests I tried to avoid adding sleeps and instead used channels to coordinate the execution of the queries to simulate the problem. 

**Checklist**
- [X] Tests updated
- [ ]  Documentation added - N.A.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
