### PR TITLE
Support ruler to retrieve proto format query response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [CHANGE] Change default value of `-blocks-storage.bucket-store.index-cache.multilevel.max-async-concurrency` from `50` to `3` #6265
 * [CHANGE] Enable Compactor and Alertmanager in target all. #6204
 * [CHANGE] Update the `cortex_ingester_inflight_push_requests` metric to represent the maximum number of inflight requests recorded in the last minute. #6437
+* [FEATURE] Ruler: Add an experimental flag `-ruler.query-response-format` to retrieve query response as a proto format. #6345
 * [FEATURE] Ruler: Pagination support for List Rules API. #6299
 * [FEATURE] Query Frontend/Querier: Add protobuf codec `-api.querier-default-codec` and the option to choose response compression type `-querier.response-compression`. #5527
 * [FEATURE] Ruler: Experimental: Add `ruler.frontend-address` to allow query to query frontends instead of ingesters. #6151

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4317,6 +4317,12 @@ The `ruler_config` configures the Cortex ruler.
 # CLI flag: -ruler.frontend-address
 [frontend_address: <string> | default = ""]
 
+# [Experimental] Query response format to get query results from Query Frontend
+# when the rule evaluation. It will only take effect when
+# `-ruler.frontend-address` is configured. Supported values: json,protobuf
+# CLI flag: -ruler.query-response-format
+[query_response_format: <string> | default = "protobuf"]
+
 frontend_client:
   # gRPC client max receive message size (bytes).
   # CLI flag: -ruler.frontendClient.grpc-max-recv-msg-size

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -35,7 +35,9 @@ Cortex is an actively developed project and we want to encourage the introductio
 
 Currently experimental features are:
 
-- Ruler: Evaluate rules to query frontend instead of ingesters (enabled via `-ruler.frontend-address` )
+- Ruler
+  - Evaluate rules to query frontend instead of ingesters (enabled via `-ruler.frontend-address`).
+  - When `-ruler.frontend-address` is specified, the response format can be specified (via `-ruler.query-response-format`).
 - S3 Server Side Encryption (SSE) using KMS (including per-tenant KMS config overrides).
 - Azure blob storage.
 - Zone awareness based replication.

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/sercand/kuberesolver/v5 v5.1.1
 	github.com/tjhop/slog-gokit v0.1.2
 	go.opentelemetry.io/collector/pdata v1.22.0
@@ -189,7 +190,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/ncw/swift v1.0.53 // indirect
 	github.com/oklog/run v1.1.0 // indirect

--- a/pkg/querier/codec/protobuf_codec.go
+++ b/pkg/querier/codec/protobuf_codec.go
@@ -25,8 +25,8 @@ func (p ProtobufCodec) ContentType() v1.MIMEType {
 	if !p.CortexInternal {
 		return v1.MIMEType{Type: "application", SubType: "x-protobuf"}
 	}
-	// TODO: switch to use constants.
-	return v1.MIMEType{Type: "application", SubType: "x-cortex-query+proto"}
+
+	return v1.MIMEType{Type: "application", SubType: tripperware.QueryResponseCortexMIMESubType}
 }
 
 func (p ProtobufCodec) CanEncode(resp *v1.Response) bool {

--- a/pkg/querier/codec/protobuf_codec_test.go
+++ b/pkg/querier/codec/protobuf_codec_test.go
@@ -46,6 +46,7 @@ func TestProtobufCodec_Encode(t *testing.T) {
 		expected       *tripperware.PrometheusResponse
 	}{
 		{
+			name: "vector",
 			data: &v1.QueryData{
 				ResultType: parser.ValueTypeVector,
 				Result: promql.Vector{
@@ -89,6 +90,7 @@ func TestProtobufCodec_Encode(t *testing.T) {
 			},
 		},
 		{
+			name: "scalar",
 			data: &v1.QueryData{
 				ResultType: parser.ValueTypeScalar,
 				Result:     promql.Scalar{T: 1000, V: 1},
@@ -106,6 +108,7 @@ func TestProtobufCodec_Encode(t *testing.T) {
 			},
 		},
 		{
+			name: "matrix",
 			data: &v1.QueryData{
 				ResultType: parser.ValueTypeMatrix,
 				Result: promql.Matrix{
@@ -151,39 +154,7 @@ func TestProtobufCodec_Encode(t *testing.T) {
 			},
 		},
 		{
-			data: &v1.QueryData{
-				ResultType: parser.ValueTypeMatrix,
-				Result: promql.Matrix{
-					promql.Series{
-						Floats: []promql.FPoint{{F: 1, T: 1000}},
-						Metric: labels.FromStrings("__name__", "foo"),
-					},
-				},
-			},
-			expected: &tripperware.PrometheusResponse{
-				Status: tripperware.StatusSuccess,
-				Data: tripperware.PrometheusData{
-					ResultType: model.ValMatrix.String(),
-					Result: tripperware.PrometheusQueryResult{
-						Result: &tripperware.PrometheusQueryResult_Matrix{
-							Matrix: &tripperware.Matrix{
-								SampleStreams: []tripperware.SampleStream{
-									{
-										Labels: []cortexpb.LabelAdapter{
-											{Name: "__name__", Value: "foo"},
-										},
-										Samples: []cortexpb.Sample{
-											{Value: 1, TimestampMs: 1000},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
+			name: "matrix with multiple float samples",
 			data: &v1.QueryData{
 				ResultType: parser.ValueTypeMatrix,
 				Result: promql.Matrix{
@@ -227,6 +198,7 @@ func TestProtobufCodec_Encode(t *testing.T) {
 			},
 		},
 		{
+			name: "matrix with histogram and not cortex internal",
 			data: &v1.QueryData{
 				ResultType: parser.ValueTypeMatrix,
 				Result: promql.Matrix{
@@ -316,6 +288,7 @@ func TestProtobufCodec_Encode(t *testing.T) {
 			},
 		},
 		{
+			name: "vector with histogram and not cortex internal",
 			data: &v1.QueryData{
 				ResultType: parser.ValueTypeVector,
 				Result: promql.Vector{
@@ -404,7 +377,7 @@ func TestProtobufCodec_Encode(t *testing.T) {
 			},
 		},
 		{
-			name:           "cortex internal with native histogram",
+			name:           "vector with histogram and cortex internal",
 			cortexInternal: true,
 			data: &v1.QueryData{
 				ResultType: parser.ValueTypeVector,

--- a/pkg/querier/tripperware/queryrange/marshaling_test.go
+++ b/pkg/querier/tripperware/queryrange/marshaling_test.go
@@ -80,7 +80,7 @@ func BenchmarkPrometheusCodec_EncodeResponse(b *testing.B) {
 	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
-		_, err := PrometheusCodec.EncodeResponse(context.Background(), res)
+		_, err := PrometheusCodec.EncodeResponse(context.Background(), nil, res)
 		require.NoError(b, err)
 	}
 }

--- a/pkg/querier/tripperware/queryrange/query_range.go
+++ b/pkg/querier/tripperware/queryrange/query_range.go
@@ -230,7 +230,7 @@ func (c prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _
 	return &resp, nil
 }
 
-func (prometheusCodec) EncodeResponse(ctx context.Context, res tripperware.Response) (*http.Response, error) {
+func (prometheusCodec) EncodeResponse(ctx context.Context, _ *http.Request, res tripperware.Response) (*http.Response, error) {
 	sp, _ := opentracing.StartSpanFromContext(ctx, "APIResponse.ToHTTPResponse")
 	defer sp.Finish()
 

--- a/pkg/querier/tripperware/queryrange/query_range_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_test.go
@@ -307,7 +307,7 @@ func TestResponse(t *testing.T) {
 				Body:          io.NopCloser(bytes.NewBuffer([]byte(tc.jsonBody))),
 				ContentLength: int64(len(tc.jsonBody)),
 			}
-			resp2, err := PrometheusCodec.EncodeResponse(context.Background(), resp)
+			resp2, err := PrometheusCodec.EncodeResponse(context.Background(), nil, resp)
 			require.NoError(t, err)
 			assert.Equal(t, response, resp2)
 			cancelCtx()
@@ -431,7 +431,7 @@ func TestResponseWithStats(t *testing.T) {
 				Body:          io.NopCloser(bytes.NewBuffer([]byte(tc.jsonBody))),
 				ContentLength: int64(len(tc.jsonBody)),
 			}
-			resp2, err := PrometheusCodec.EncodeResponse(context.Background(), resp)
+			resp2, err := PrometheusCodec.EncodeResponse(context.Background(), nil, resp)
 			require.NoError(t, err)
 			assert.Equal(t, response, resp2)
 		})

--- a/pkg/querier/tripperware/queryrange/split_by_interval_test.go
+++ b/pkg/querier/tripperware/queryrange/split_by_interval_test.go
@@ -276,7 +276,7 @@ func TestSplitByDay(t *testing.T) {
 	mergedResponse, err := PrometheusCodec.MergeResponse(context.Background(), nil, parsedResponse, parsedResponse)
 	require.NoError(t, err)
 
-	mergedHTTPResponse, err := PrometheusCodec.EncodeResponse(context.Background(), mergedResponse)
+	mergedHTTPResponse, err := PrometheusCodec.EncodeResponse(context.Background(), nil, mergedResponse)
 	require.NoError(t, err)
 
 	mergedHTTPResponseBody, err := io.ReadAll(mergedHTTPResponse.Body)

--- a/pkg/querier/tripperware/roundtrip.go
+++ b/pkg/querier/tripperware/roundtrip.go
@@ -17,6 +17,7 @@ package tripperware
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -115,7 +116,7 @@ func NewQueryTripperware(
 	queriesPerTenant := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_query_frontend_queries_total",
 		Help: "Total queries sent per tenant.",
-	}, []string{"op", "user"})
+	}, []string{"op", "source", "user"})
 
 	rejectedQueriesPerTenant := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_query_frontend_rejected_queries_total",
@@ -156,7 +157,8 @@ func NewQueryTripperware(
 				now := time.Now()
 				userStr := tenant.JoinTenantIDs(tenantIDs)
 				activeUsers.UpdateUserTimestamp(userStr, now)
-				queriesPerTenant.WithLabelValues(op, userStr).Inc()
+				source := getSource(r.Header.Get("User-Agent"))
+				queriesPerTenant.WithLabelValues(op, source, userStr).Inc()
 
 				if maxSubQuerySteps > 0 && (isQuery || isQueryRange) {
 					query := r.FormValue("query")
@@ -211,7 +213,7 @@ func (q roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	return q.codec.EncodeResponse(r.Context(), response)
+	return q.codec.EncodeResponse(r.Context(), r, response)
 }
 
 // Do implements Handler.
@@ -239,4 +241,14 @@ func (q roundTripper) Do(ctx context.Context, r Request) (Response, error) {
 	}()
 
 	return q.codec.DecodeResponse(ctx, response, r)
+}
+
+func getSource(userAgent string) string {
+	fmt.Println("userAgent", userAgent)
+	if strings.Contains(userAgent, RulerUserAgent) {
+		// caller is ruler
+		return SourceRuler
+	}
+
+	return SourceAPI
 }

--- a/pkg/querier/tripperware/roundtrip_test.go
+++ b/pkg/querier/tripperware/roundtrip_test.go
@@ -3,6 +3,7 @@ package tripperware
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +13,10 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/version"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/thanos/pkg/querysharding"
 	"github.com/weaveworks/common/httpgrpc"
@@ -59,7 +63,7 @@ func (c mockCodec) DecodeRequest(_ context.Context, r *http.Request, _ []string)
 	return mockRequest{}, nil
 }
 
-func (c mockCodec) EncodeResponse(_ context.Context, resp Response) (*http.Response, error) {
+func (c mockCodec) EncodeResponse(_ context.Context, _ *http.Request, resp Response) (*http.Response, error) {
 	r := resp.(*mockResponse)
 	return &http.Response{
 		Header: http.Header{
@@ -125,48 +129,92 @@ func TestRoundTrip(t *testing.T) {
 		expectedErr        error
 		limits             Limits
 		maxSubQuerySteps   int64
+		userAgent          string
+		expectedMetric     string
 	}{
 		{
 			path:             "/foo",
 			expectedBody:     "bar",
 			limits:           defaultOverrides,
 			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/1.0",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="query", source="api", user="1"} 1
+`,
 		},
 		{
 			path:             queryExemplar,
 			expectedBody:     "bar",
 			limits:           defaultOverrides,
 			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/1.1",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="query", source="api", user="1"} 1
+`,
 		},
 		{
 			path:             seriesQuery,
 			expectedBody:     "bar",
 			limits:           defaultOverrides,
 			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/1.2",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="series", source="api", user="1"} 1
+`,
 		},
 		{
 			path:             queryRange,
 			expectedBody:     responseBody,
 			limits:           defaultOverrides,
 			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/1.0",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="query_range", source="api", user="1"} 1
+`,
 		},
 		{
 			path:             query,
 			expectedBody:     instantResponseBody,
 			limits:           defaultOverrides,
 			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/1.1",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="query", source="api", user="1"} 1
+`,
 		},
 		{
 			path:             queryNonShardable,
 			expectedBody:     instantResponseBody,
 			limits:           defaultOverrides,
 			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/1.2",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="query", source="api", user="1"} 1
+`,
 		},
 		{
 			path:             query,
 			expectedBody:     instantResponseBody,
 			limits:           shardingOverrides,
 			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/1.0",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="query", source="api", user="1"} 1
+`,
 		},
 		// Shouldn't hit subquery step limit because max steps is set to 0 so this check is disabled.
 		{
@@ -174,6 +222,12 @@ func TestRoundTrip(t *testing.T) {
 			expectedBody:     instantResponseBody,
 			limits:           defaultOverrides,
 			maxSubQuerySteps: 0,
+			userAgent:        "dummyUserAgent/1.0",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="query", source="api", user="1"} 1
+`,
 		},
 		// Shouldn't hit subquery step limit because max steps is higher, which is 100K.
 		{
@@ -181,12 +235,24 @@ func TestRoundTrip(t *testing.T) {
 			expectedBody:     instantResponseBody,
 			limits:           defaultOverrides,
 			maxSubQuerySteps: 100000,
+			userAgent:        "dummyUserAgent/1.0",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="query", source="api", user="1"} 1
+`,
 		},
 		{
 			path:             querySubqueryStepSizeTooSmall,
 			expectedErr:      httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryStepTooSmall, 11000),
 			limits:           defaultOverrides,
 			maxSubQuerySteps: 11000,
+			userAgent:        fmt.Sprintf("%s/%s", RulerUserAgent, version.Version),
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="query", source="ruler", user="1"} 1
+`,
 		},
 		{
 			// The query should go to instant query middlewares rather than forwarding to next.
@@ -194,6 +260,12 @@ func TestRoundTrip(t *testing.T) {
 			expectedBody:     instantResponseBody,
 			limits:           defaultOverrides,
 			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/2.0",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="query", source="api", user="1"} 1
+`,
 		},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
@@ -209,8 +281,11 @@ func TestRoundTrip(t *testing.T) {
 			err = user.InjectOrgIDIntoHTTPRequest(ctx, req)
 			require.NoError(t, err)
 
+			req.Header.Set("User-Agent", tc.userAgent)
+
+			reg := prometheus.NewPedanticRegistry()
 			tw := NewQueryTripperware(log.NewNopLogger(),
-				nil,
+				reg,
 				nil,
 				rangeMiddlewares,
 				instantMiddlewares,
@@ -231,6 +306,7 @@ func TestRoundTrip(t *testing.T) {
 				bs, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedBody, string(bs))
+				require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(tc.expectedMetric), "cortex_query_frontend_queries_total"))
 			} else {
 				require.Equal(t, tc.expectedErr, err)
 			}

--- a/pkg/ruler/frontend_client_pool.go
+++ b/pkg/ruler/frontend_client_pool.go
@@ -20,6 +20,7 @@ import (
 
 type frontendPool struct {
 	timeout              time.Duration
+	queryResponseFormat  string
 	prometheusHTTPPrefix string
 	grpcConfig           grpcclient.Config
 
@@ -29,6 +30,7 @@ type frontendPool struct {
 func newFrontendPool(cfg Config, log log.Logger, reg prometheus.Registerer) *client.Pool {
 	p := &frontendPool{
 		timeout:              cfg.FrontendTimeout,
+		queryResponseFormat:  cfg.QueryResponseFormat,
 		prometheusHTTPPrefix: cfg.PrometheusHTTPPrefix,
 		grpcConfig:           cfg.GRPCClientConfig,
 		frontendClientRequestDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
@@ -68,7 +70,7 @@ func (f *frontendPool) createFrontendClient(addr string) (client.PoolClient, err
 	}
 
 	return &frontendClient{
-		FrontendClient: NewFrontendClient(httpgrpc.NewHTTPClient(conn), f.timeout, f.prometheusHTTPPrefix),
+		FrontendClient: NewFrontendClient(httpgrpc.NewHTTPClient(conn), f.timeout, f.prometheusHTTPPrefix, f.queryResponseFormat),
 		HealthClient:   grpc_health_v1.NewHealthClient(conn),
 	}, nil
 }

--- a/pkg/ruler/frontend_client_test.go
+++ b/pkg/ruler/frontend_client_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc"
+
+	"github.com/cortexproject/cortex/pkg/cortexpb"
+	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 )
 
 type mockHTTPGRPCClient func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error)
@@ -28,7 +31,7 @@ func TestTimeout(t *testing.T) {
 	}
 	ctx := context.Background()
 	ctx = user.InjectOrgID(ctx, "userID")
-	frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus")
+	frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus", "json")
 	_, err := frontendClient.InstantQuery(ctx, "query", time.Now())
 	require.Equal(t, context.DeadlineExceeded, err)
 }
@@ -37,12 +40,12 @@ func TestNoOrgId(t *testing.T) {
 	mockClientFn := func(ctx context.Context, _ *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
 		return nil, nil
 	}
-	frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus")
+	frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus", "json")
 	_, err := frontendClient.InstantQuery(context.Background(), "query", time.Now())
 	require.Equal(t, user.ErrNoOrgID, err)
 }
 
-func TestInstantQuery(t *testing.T) {
+func TestInstantQueryJsonCodec(t *testing.T) {
 	tests := []struct {
 		description  string
 		responseBody string
@@ -148,10 +151,195 @@ func TestInstantQuery(t *testing.T) {
 			}
 			ctx := context.Background()
 			ctx = user.InjectOrgID(ctx, "userID")
-			frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus")
+			frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus", "json")
 			vector, err := frontendClient.InstantQuery(ctx, "query", time.Now())
 			require.Equal(t, test.expected, vector)
 			require.Equal(t, test.expectedErr, err)
+		})
+	}
+}
+
+func TestInstantQueryProtoCodec(t *testing.T) {
+	var tests = []struct {
+		description  string
+		responseBody *tripperware.PrometheusResponse
+		expected     promql.Vector
+		expectedErr  error
+	}{
+		{
+			description: "empty vector",
+			responseBody: &tripperware.PrometheusResponse{
+				Status: "success",
+				Data: tripperware.PrometheusData{
+					ResultType: "vector",
+					Result: tripperware.PrometheusQueryResult{
+						Result: &tripperware.PrometheusQueryResult_Vector{
+							Vector: &tripperware.Vector{
+								Samples: []tripperware.Sample{},
+							},
+						},
+					},
+				},
+			},
+			expected:    promql.Vector{},
+			expectedErr: nil,
+		},
+		{
+			description: "vector with series",
+			responseBody: &tripperware.PrometheusResponse{
+				Status: "success",
+				Data: tripperware.PrometheusData{
+					ResultType: "vector",
+					Result: tripperware.PrometheusQueryResult{
+						Result: &tripperware.PrometheusQueryResult_Vector{
+							Vector: &tripperware.Vector{
+								Samples: []tripperware.Sample{
+									{
+										Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromStrings("foo", "bar")),
+										Sample: &cortexpb.Sample{
+											Value:       1.234,
+											TimestampMs: 1724146338123,
+										},
+									},
+									{
+										Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromStrings("bar", "baz")),
+										Sample: &cortexpb.Sample{
+											Value:       5.678,
+											TimestampMs: 1724146338456,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: promql.Vector{
+				{
+					Metric: labels.FromStrings("foo", "bar"),
+					T:      1724146338123,
+					F:      1.234,
+				},
+				{
+					Metric: labels.FromStrings("bar", "baz"),
+					T:      1724146338456,
+					F:      5.678,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			description: "get scalar",
+			responseBody: &tripperware.PrometheusResponse{
+				Status: "success",
+				Data: tripperware.PrometheusData{
+					ResultType: "scalar",
+					Result: tripperware.PrometheusQueryResult{
+						Result: &tripperware.PrometheusQueryResult_RawBytes{
+							RawBytes: []byte(`{"resultType":"scalar","result":[1724146338.123,"1.234"]}`),
+						},
+					},
+				},
+			},
+			expected: promql.Vector{
+				{
+					Metric: labels.EmptyLabels(),
+					T:      1724146338123,
+					F:      1.234,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			description: "get matrix",
+			responseBody: &tripperware.PrometheusResponse{
+				Status: "success",
+				Data: tripperware.PrometheusData{
+					ResultType: "matrix",
+					Result: tripperware.PrometheusQueryResult{
+						Result: &tripperware.PrometheusQueryResult_Matrix{
+							Matrix: &tripperware.Matrix{
+								SampleStreams: []tripperware.SampleStream{},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New("rule result is not a vector or scalar"),
+		},
+		{
+			description: "get string",
+			responseBody: &tripperware.PrometheusResponse{
+				Status: "success",
+				Data: tripperware.PrometheusData{
+					ResultType: "string",
+					Result: tripperware.PrometheusQueryResult{
+						Result: &tripperware.PrometheusQueryResult_RawBytes{
+							RawBytes: []byte(`{"resultType":"string","result":[1724146338.123,"string"]}`),
+						},
+					},
+				},
+			},
+			expectedErr: errors.New("rule result is not a vector or scalar"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			mockClientFn := func(ctx context.Context, _ *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+				d, err := test.responseBody.Marshal()
+				if err != nil {
+					return nil, err
+				}
+				return &httpgrpc.HTTPResponse{
+					Code: http.StatusOK,
+					Headers: []*httpgrpc.Header{
+						{Key: "Content-Type", Values: []string{"application/x-cortex-query+proto"}},
+					},
+					Body: d,
+				}, nil
+			}
+			ctx := context.Background()
+			ctx = user.InjectOrgID(ctx, "userID")
+			frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus", "protobuf")
+			vector, err := frontendClient.InstantQuery(ctx, "query", time.Now())
+			require.Equal(t, test.expected, vector)
+			require.Equal(t, test.expectedErr, err)
+		})
+	}
+}
+
+func Test_extractHeader(t *testing.T) {
+	tests := []struct {
+		description    string
+		headers        []*httpgrpc.Header
+		expectedOutput string
+	}{
+		{
+			description: "cortex query proto",
+			headers: []*httpgrpc.Header{
+				{
+					Key:    "Content-Type",
+					Values: []string{"application/x-cortex-query+proto"},
+				},
+			},
+			expectedOutput: "application/x-cortex-query+proto",
+		},
+		{
+			description: "json",
+			headers: []*httpgrpc.Header{
+				{
+					Key:    "Content-Type",
+					Values: []string{"application/json"},
+				},
+			},
+			expectedOutput: "application/json",
+		},
+	}
+
+	target := "Content-Type"
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			require.Equal(t, test.expectedOutput, extractHeader(test.headers, target))
 		})
 	}
 }

--- a/pkg/ruler/frontend_decoder.go
+++ b/pkg/ruler/frontend_decoder.go
@@ -10,6 +10,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 
+	"github.com/cortexproject/cortex/pkg/cortexpb"
+	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 	"github.com/cortexproject/cortex/pkg/util/api"
 )
 
@@ -18,9 +20,19 @@ const (
 )
 
 type JsonDecoder struct{}
-type Warning []string
+type ProtobufDecoder struct{}
+type Warnings []string
 
-func (j JsonDecoder) Decode(body []byte) (promql.Vector, Warning, error) {
+type Decoder interface {
+	Decode(body []byte) (promql.Vector, Warnings, error)
+	ContentType() string
+}
+
+func (j JsonDecoder) ContentType() string {
+	return "application/json"
+}
+
+func (j JsonDecoder) Decode(body []byte) (promql.Vector, Warnings, error) {
 	var response api.Response
 
 	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&response); err != nil {
@@ -48,7 +60,7 @@ func (j JsonDecoder) Decode(body []byte) (promql.Vector, Warning, error) {
 		if err := json.Unmarshal(data.Result, &scalar); err != nil {
 			return nil, nil, err
 		}
-		return j.scalarToPromQLVector(scalar), response.Warnings, nil
+		return scalarToPromQLVector(scalar), response.Warnings, nil
 	case model.ValVector:
 		var vector model.Vector
 		if err := json.Unmarshal(data.Result, &vector); err != nil {
@@ -79,10 +91,72 @@ func (j JsonDecoder) vectorToPromQLVector(vector model.Vector) promql.Vector {
 	return v
 }
 
-func (j JsonDecoder) scalarToPromQLVector(scalar model.Scalar) promql.Vector {
+func (p ProtobufDecoder) ContentType() string {
+	return tripperware.QueryResponseCortexMIMEType
+}
+
+func (p ProtobufDecoder) Decode(body []byte) (promql.Vector, Warnings, error) {
+	resp := tripperware.PrometheusResponse{}
+	if err := resp.Unmarshal(body); err != nil {
+		return nil, nil, err
+	}
+
+	if resp.Status == statusError {
+		return nil, resp.Warnings, fmt.Errorf("failed to execute query with error: %s", resp.Error)
+	}
+
+	switch resp.Data.ResultType {
+	case "scalar":
+		data := struct {
+			Type   model.ValueType `json:"resultType"`
+			Result json.RawMessage `json:"result"`
+		}{}
+
+		if err := json.Unmarshal(resp.Data.Result.GetRawBytes(), &data); err != nil {
+			return nil, nil, err
+		}
+
+		var s model.Scalar
+		if err := json.Unmarshal(data.Result, &s); err != nil {
+			return nil, nil, err
+		}
+		return scalarToPromQLVector(s), resp.Warnings, nil
+	case "vector":
+		return p.vectorToPromQLVector(resp.Data.Result.GetVector()), resp.Warnings, nil
+	default:
+		return nil, resp.Warnings, errors.New("rule result is not a vector or scalar")
+	}
+}
+
+func (p ProtobufDecoder) vectorToPromQLVector(vector *tripperware.Vector) promql.Vector {
+	v := make([]promql.Sample, 0, len(vector.Samples))
+	for _, sample := range vector.Samples {
+		metric := cortexpb.FromLabelAdaptersToLabels(sample.Labels)
+
+		if sample.Sample != nil {
+			v = append(v, promql.Sample{
+				T:      sample.Sample.TimestampMs,
+				F:      sample.Sample.Value,
+				Metric: metric,
+			})
+		}
+
+		if sample.RawHistogram != nil {
+			v = append(v, promql.Sample{
+				T:      sample.RawHistogram.TimestampMs,
+				H:      cortexpb.FloatHistogramProtoToFloatHistogram(*sample.RawHistogram),
+				Metric: metric,
+			})
+		}
+	}
+
+	return v
+}
+
+func scalarToPromQLVector(s model.Scalar) promql.Vector {
 	return promql.Vector{promql.Sample{
-		T:      int64(scalar.Timestamp),
-		F:      float64(scalar.Value),
+		T:      int64(s.Timestamp),
+		F:      float64(s.Value),
 		Metric: labels.Labels{},
 	}}
 }

--- a/pkg/ruler/frontend_decoder_test.go
+++ b/pkg/ruler/frontend_decoder_test.go
@@ -4,19 +4,186 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/cortexpb"
+	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 )
 
-func TestDecode(t *testing.T) {
-	jsonDecoder := JsonDecoder{}
+func TestProtoDecode(t *testing.T) {
+	tests := []struct {
+		description     string
+		resp            *tripperware.PrometheusResponse
+		expectedVector  promql.Vector
+		expectedWarning []string
+		expectedErr     error
+	}{
+		{
+			description: "vector",
+			resp: &tripperware.PrometheusResponse{
+				Status: "success",
+				Data: tripperware.PrometheusData{
+					ResultType: "vector",
+					Result: tripperware.PrometheusQueryResult{
+						Result: &tripperware.PrometheusQueryResult_Vector{
+							Vector: &tripperware.Vector{
+								Samples: []tripperware.Sample{
+									{
+										Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromStrings("foo", "bar")),
+										Sample: &cortexpb.Sample{
+											Value:       1.234,
+											TimestampMs: 1724146338123,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Warnings: []string{"a", "b", "c"},
+			},
+			expectedVector: promql.Vector{
+				{
+					Metric: labels.FromStrings("foo", "bar"),
+					T:      1724146338123,
+					F:      1.234,
+				},
+			},
+			expectedWarning: []string{"a", "b", "c"},
+		},
+		{
+			description: "vector with raw histogram",
+			resp: &tripperware.PrometheusResponse{
+				Status: "success",
+				Data: tripperware.PrometheusData{
+					ResultType: "vector",
+					Result: tripperware.PrometheusQueryResult{
+						Result: &tripperware.PrometheusQueryResult_Vector{
+							Vector: &tripperware.Vector{
+								Samples: []tripperware.Sample{
+									{
+										Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromStrings("foo", "bar")),
+										RawHistogram: &cortexpb.Histogram{
+											Count:          &cortexpb.Histogram_CountFloat{CountFloat: 10},
+											Sum:            20,
+											Schema:         2,
+											ZeroThreshold:  0.001,
+											ZeroCount:      &cortexpb.Histogram_ZeroCountFloat{ZeroCountFloat: 12},
+											NegativeSpans:  []cortexpb.BucketSpan{{Offset: 2, Length: 2}},
+											NegativeCounts: []float64{2, 1},
+											PositiveSpans:  []cortexpb.BucketSpan{{Offset: 3, Length: 2}, {Offset: 1, Length: 3}},
+											PositiveCounts: []float64{1, 2, 2, 1, 1},
+											TimestampMs:    1724146338123,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Warnings: []string{"a", "b", "c"},
+			},
+			expectedVector: promql.Vector{
+				{
+					Metric: labels.FromStrings("foo", "bar"),
+					T:      1724146338123,
+					H: &histogram.FloatHistogram{
+						Schema:          2,
+						ZeroThreshold:   0.001,
+						ZeroCount:       12,
+						Count:           10,
+						Sum:             20,
+						PositiveSpans:   []histogram.Span{{Offset: 3, Length: 2}, {Offset: 1, Length: 3}},
+						NegativeSpans:   []histogram.Span{{Offset: 2, Length: 2}},
+						PositiveBuckets: []float64{1, 2, 2, 1, 1},
+						NegativeBuckets: []float64{2, 1},
+						CustomValues:    nil,
+					},
+				},
+			},
+			expectedWarning: []string{"a", "b", "c"},
+		},
+		{
+			description: "matrix",
+			resp: &tripperware.PrometheusResponse{
+				Status: "success",
+				Data: tripperware.PrometheusData{
+					ResultType: "matrix",
+					Result: tripperware.PrometheusQueryResult{
+						Result: &tripperware.PrometheusQueryResult_Matrix{},
+					},
+				},
+				Warnings: []string{"a", "b", "c"},
+			},
+			expectedVector:  nil,
+			expectedWarning: []string{"a", "b", "c"},
+			expectedErr:     errors.New("rule result is not a vector or scalar"),
+		},
+		{
+			description: "scalar",
+			resp: &tripperware.PrometheusResponse{
+				Status: "success",
+				Data: tripperware.PrometheusData{
+					ResultType: "scalar",
+					Result: tripperware.PrometheusQueryResult{
+						Result: &tripperware.PrometheusQueryResult_RawBytes{
+							RawBytes: []byte(`{"resultType":"scalar","result":[1724146338.123,"1.234"]}`),
+						},
+					},
+				},
+				Warnings: []string{"a", "b", "c"},
+			},
+			expectedVector: promql.Vector{
+				{
+					Metric: labels.EmptyLabels(),
+					T:      1724146338123,
+					F:      1.234,
+				},
+			},
+			expectedWarning: []string{"a", "b", "c"},
+		},
+		{
+			description: "string",
+			resp: &tripperware.PrometheusResponse{
+				Status: "success",
+				Data: tripperware.PrometheusData{
+					ResultType: "string",
+					Result: tripperware.PrometheusQueryResult{
+						Result: &tripperware.PrometheusQueryResult_RawBytes{
+							RawBytes: []byte(`{"resultType":"string","result":[1724146338.123,"1.234"]}`),
+						},
+					},
+				},
+				Warnings: []string{"a", "b", "c"},
+			},
+			expectedVector:  nil,
+			expectedWarning: []string{"a", "b", "c"},
+			expectedErr:     errors.New("rule result is not a vector or scalar"),
+		},
+	}
 
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			b, err := test.resp.Marshal()
+			require.NoError(t, err)
+
+			vector, _, err := protobufDecoder.Decode(b)
+			require.Equal(t, test.expectedErr, err)
+			require.Equal(t, test.expectedVector, vector)
+			require.Equal(t, test.expectedWarning, test.resp.Warnings)
+		})
+	}
+}
+
+func TestJsonDecode(t *testing.T) {
 	tests := []struct {
 		description     string
 		body            string
 		expectedVector  promql.Vector
-		expectedWarning Warning
+		expectedWarning Warnings
 		expectedErr     error
 	}{
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

In #6151, we can retrieve query results from Query frontends when the rules are evaluated. The limitation was, since we only support `json` format, we cannot retrieve query results including the `native histogram`.

To address this concern, this PR adds `-ruler.query-response-format` flag, which specifies which format to use when retrieving query results from the Query frontend. The supported values are `protobuf` and `json`, so we can retrieve proto format query results when we set the value to `protobuf`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
