### PR TITLE
Lru cache

### DIFF
--- a/pkg/storage/tsdb/expanded_postings_cache_test.go
+++ b/pkg/storage/tsdb/expanded_postings_cache_test.go
@@ -77,7 +77,7 @@ func TestLru(t *testing.T) {
 		key := RepeatStringIfNeeded(fmt.Sprintf("key%d", i), keySize)
 		_, hit := cache.getPromiseForKey(key, func() (int, int64, error) { return 1, 1, nil })
 		require.False(t, hit)
-		require.Equal(t, key, cache.cached.Back().Value)
+		require.Equal(t, key, cache.lruList.Back().Value)
 		assertCacheItemsCount(t, cache, i+1)
 	}
 
@@ -85,7 +85,7 @@ func TestLru(t *testing.T) {
 		key := RepeatStringIfNeeded(fmt.Sprintf("key%d", i), keySize)
 		_, hit := cache.getPromiseForKey(key, func() (int, int64, error) { return 1, 1, nil })
 		require.True(t, hit)
-		require.Equal(t, key, cache.cached.Back().Value)
+		require.Equal(t, key, cache.lruList.Back().Value)
 		assertCacheItemsCount(t, cache, maxNumberOfCachedItems)
 	}
 
@@ -104,7 +104,7 @@ func TestLru(t *testing.T) {
 		key := RepeatStringIfNeeded(fmt.Sprintf("key_new%d", i), keySize)
 		_, hit := cache.getPromiseForKey(key, func() (int, int64, error) { return 1, 1, nil })
 		require.False(t, hit)
-		require.Equal(t, maxNumberOfCachedItems, cache.cached.Len())
+		require.Equal(t, maxNumberOfCachedItems, cache.lruList.Len())
 	}
 
 	for i := 0; i < maxNumberOfCachedItems; i++ {
@@ -244,7 +244,7 @@ func RepeatStringIfNeeded(seed string, length int) string {
 }
 
 func assertCacheItemsCount[T any](t *testing.T, cache *lruCache[T], size int) {
-	require.Equal(t, size, cache.cached.Len())
+	require.Equal(t, size, cache.lruList.Len())
 	count := 0
 	cache.cachedValues.Range(func(k, v any) bool {
 		count++


### PR DESCRIPTION
**What this PR does**:

Previously, the postings cache used a FIFO (First-In, First-Out) strategy for expiring items.

This PR updates the expiration strategy to LRU (Least Recently Used).

The implementation remains largely the same, with the key difference being that items are now moved to the back of the list whenever they are accessed. (items are expired from the front of the queue).

https://github.com/cortexproject/cortex/compare/master...alanprot:lru-cache?expand=1#diff-2fbd6f34014d2c606685456d6f0ff05de42c9df131c81bc28c6e225a89f5b7ecR343


I will keep this in draft for now. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
