### PR TITLE
Support experimental promql functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [FEATURE] Store Gateway: Add an in-memory chunk cache. #6245
 * [FEATURE] Chunk Cache: Support multi level cache and add metrics. #6249
 * [FEATURE] Distributor: Accept multiple HA Tracker pairs in the same request. #6256
+* [ENHANCEMENT] Query Frontend/Querier: Add an experimental flag `-querier.enable-promql-experimental-functions` to enable experimental promQL functions. #6355
 * [ENHANCEMENT] OTLP: Add `-distributor.otlp-max-recv-msg-size` flag to limit OTLP request size in bytes. #6333
 * [ENHANCEMENT] S3 Bucket Client: Add a list objects version configs to configure list api object version. #6280
 * [ENHANCEMENT] OpenStack Swift: Add application credential configs for Openstack swift object storage backend. #6255

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -253,6 +253,10 @@ querier:
   # evaluation like at Query Frontend or Ruler.
   # CLI flag: -querier.ignore-max-query-length
   [ignore_max_query_length: <boolean> | default = false]
+
+  # [Experimental] If true, experimental promQL functions are enabled.
+  # CLI flag: -querier.enable-promql-experimental-functions
+  [enable_promql_experimental_functions: <boolean> | default = false]
 ```
 
 ### `blocks_storage_config`

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3997,6 +3997,10 @@ store_gateway_client:
 # like at Query Frontend or Ruler.
 # CLI flag: -querier.ignore-max-query-length
 [ignore_max_query_length: <boolean> | default = false]
+
+# [Experimental] If true, experimental promQL functions are enabled.
+# CLI flag: -querier.enable-promql-experimental-functions
+[enable_promql_experimental_functions: <boolean> | default = false]
 ```
 
 ### `query_frontend_config`

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
 	github.com/cespare/xxhash v1.1.0
-	github.com/cortexproject/promqlsmith v0.0.0-20241102030034-4051538fd914
+	github.com/cortexproject/promqlsmith v0.0.0-20241121054008-8b48fe2471ef
 	github.com/dustin/go-humanize v1.0.1
 	github.com/efficientgo/core v1.0.0-rc.3
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb

--- a/go.sum
+++ b/go.sum
@@ -944,8 +944,8 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/coreos/go-systemd/v22 v22.4.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cortexproject/promqlsmith v0.0.0-20241102030034-4051538fd914 h1:UhI6yOSqMz3ln8FGaZRLbJTKzPHRaVwewoTa6N5PU5k=
-github.com/cortexproject/promqlsmith v0.0.0-20241102030034-4051538fd914/go.mod h1:ypUb6BfnDVr7QrBgAxtzRqZ573swvka0BdCkPqa2A5g=
+github.com/cortexproject/promqlsmith v0.0.0-20241121054008-8b48fe2471ef h1:wR21ZiKkA+wN2KG43qrK33IkFduY9JUa6th6P2KEU0o=
+github.com/cortexproject/promqlsmith v0.0.0-20241121054008-8b48fe2471ef/go.mod h1:xbYQa0KX6Eh6YWbTBfZ9kK3N4hRxX+ZPIfVIY2U/y00=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -508,6 +508,7 @@ func (t *Cortex) initQueryFrontendTripperware() (serv services.Service, err erro
 		t.Cfg.Querier.DefaultEvaluationInterval,
 		t.Cfg.Querier.MaxSubQuerySteps,
 		t.Cfg.Querier.LookbackDelta,
+		t.Cfg.Querier.EnablePromQLExperimentalFunctions,
 	)
 
 	return services.NewIdleService(nil, func(_ error) error {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -542,7 +542,6 @@ func TestLimits(t *testing.T) {
 }
 
 func TestQuerier(t *testing.T) {
-	t.Parallel()
 	var cfg Config
 	flagext.DefaultValues(&cfg)
 	const chunks = 24
@@ -610,7 +609,6 @@ func TestQuerierMetric(t *testing.T) {
 }
 
 func TestNoHistoricalQueryToIngester(t *testing.T) {
-	t.Parallel()
 	testCases := []struct {
 		name                 string
 		mint, maxt           time.Time
@@ -711,7 +709,6 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 }
 
 func TestQuerier_ValidateQueryTimeRange_MaxQueryIntoFuture(t *testing.T) {
-	t.Parallel()
 	const engineLookbackDelta = 5 * time.Minute
 
 	now := time.Now()
@@ -929,7 +926,6 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength_Series(t *testing.T) {
 }
 
 func TestQuerier_ValidateQueryTimeRange_MaxQueryLength_Labels(t *testing.T) {
-	t.Parallel()
 	const maxQueryLength = 30 * 24 * time.Hour
 	tests := map[string]struct {
 		startTime            time.Time
@@ -1002,7 +998,6 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength_Labels(t *testing.T) {
 }
 
 func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
-	t.Parallel()
 	const (
 		engineLookbackDelta = 5 * time.Minute
 		thirtyDays          = 30 * 24 * time.Hour
@@ -1511,7 +1506,6 @@ func (q *mockStoreQuerier) Close() error {
 }
 
 func TestShortTermQueryToLTS(t *testing.T) {
-	t.Parallel()
 	testCases := []struct {
 		name                 string
 		mint, maxt           time.Time

--- a/pkg/querier/tripperware/merge.go
+++ b/pkg/querier/tripperware/merge.go
@@ -288,9 +288,9 @@ func sortPlanForQuery(q string) (sortPlan, error) {
 	if err != nil {
 		return 0, err
 	}
-	// Check if the root expression is topk or bottomk
+	// Check if the root expression is topk, bottomk, limitk, or limit_ratio
 	if aggr, ok := expr.(*promqlparser.AggregateExpr); ok {
-		if aggr.Op == promqlparser.TOPK || aggr.Op == promqlparser.BOTTOMK {
+		if aggr.Op == promqlparser.TOPK || aggr.Op == promqlparser.BOTTOMK || aggr.Op == promqlparser.LIMITK || aggr.Op == promqlparser.LIMIT_RATIO {
 			return mergeOnly, nil
 		}
 	}
@@ -301,6 +301,12 @@ func sortPlanForQuery(q string) (sortPlan, error) {
 					sortAsc = true
 				}
 				if n.Func.Name == "sort_desc" {
+					sortDesc = true
+				}
+				if n.Func.Name == "sort_by_label" {
+					sortAsc = true
+				}
+				if n.Func.Name == "sort_by_label_desc" {
 					sortDesc = true
 				}
 			}

--- a/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
@@ -80,6 +80,7 @@ func TestRoundTrip(t *testing.T) {
 		time.Minute,
 		0,
 		0,
+		false,
 	)
 
 	for i, tc := range []struct {

--- a/pkg/querier/tripperware/roundtrip.go
+++ b/pkg/querier/tripperware/roundtrip.go
@@ -27,6 +27,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/thanos-io/thanos/pkg/querysharding"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
@@ -104,7 +105,12 @@ func NewQueryTripperware(
 	defaultSubQueryInterval time.Duration,
 	maxSubQuerySteps int64,
 	lookbackDelta time.Duration,
+	enablePromQLExperimentalFunctions bool,
 ) Tripperware {
+
+	// set EnableExperimentalFunctions
+	parser.EnableExperimentalFunctions = enablePromQLExperimentalFunctions
+
 	// Per tenant query metrics.
 	queriesPerTenant := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_query_frontend_queries_total",

--- a/pkg/querier/tripperware/roundtrip_test.go
+++ b/pkg/querier/tripperware/roundtrip_test.go
@@ -221,6 +221,7 @@ func TestRoundTrip(t *testing.T) {
 				time.Minute,
 				tc.maxSubQuerySteps,
 				0,
+				false,
 			)
 			resp, err := tw(downstream).RoundTrip(req)
 			if tc.expectedErr == nil {

--- a/vendor/github.com/cortexproject/promqlsmith/opts.go
+++ b/vendor/github.com/cortexproject/promqlsmith/opts.go
@@ -33,6 +33,11 @@ var (
 		parser.COUNT_VALUES,
 	}
 
+	experimentalPromQLAggrs = []parser.ItemType{
+		parser.LIMITK,
+		parser.LIMIT_RATIO,
+	}
+
 	defaultSupportedBinOps = []parser.ItemType{
 		parser.SUB,
 		parser.ADD,
@@ -52,7 +57,8 @@ var (
 		parser.LUNLESS,
 	}
 
-	defaultSupportedFuncs []*parser.Function
+	defaultSupportedFuncs      []*parser.Function
+	experimentalSupportedFuncs []*parser.Function
 )
 
 func init() {
@@ -60,6 +66,8 @@ func init() {
 		// Ignore experimental functions for now.
 		if !f.Experimental {
 			defaultSupportedFuncs = append(defaultSupportedFuncs, f)
+		} else {
+			experimentalSupportedFuncs = append(experimentalSupportedFuncs, f)
 		}
 	}
 }
@@ -70,10 +78,11 @@ type options struct {
 	enabledFuncs  []*parser.Function
 	enabledBinops []parser.ItemType
 
-	enableOffset           bool
-	enableAtModifier       bool
-	enableVectorMatching   bool
-	atModifierMaxTimestamp int64
+	enableOffset                      bool
+	enableAtModifier                  bool
+	enableVectorMatching              bool
+	enableExperimentalPromQLFunctions bool
+	atModifierMaxTimestamp            int64
 
 	enforceLabelMatchers []*labels.Matcher
 }
@@ -93,6 +102,11 @@ func (o *options) applyDefaults() {
 
 	if len(o.enabledFuncs) == 0 {
 		o.enabledFuncs = defaultSupportedFuncs
+	}
+
+	if o.enableExperimentalPromQLFunctions {
+		o.enabledAggrs = append(o.enabledAggrs, experimentalPromQLAggrs...)
+		o.enabledFuncs = append(o.enabledFuncs, experimentalSupportedFuncs...)
 	}
 
 	if o.atModifierMaxTimestamp == 0 {
@@ -132,6 +146,12 @@ func WithEnableAtModifier(enableAtModifier bool) Option {
 func WithEnableVectorMatching(enableVectorMatching bool) Option {
 	return optionFunc(func(o *options) {
 		o.enableVectorMatching = enableVectorMatching
+	})
+}
+
+func WithEnableExperimentalPromQLFunctions(enableExperimentalPromQLFunctions bool) Option {
+	return optionFunc(func(o *options) {
+		o.enableExperimentalPromQLFunctions = enableExperimentalPromQLFunctions
 	})
 }
 

--- a/vendor/github.com/cortexproject/promqlsmith/promqlsmith.go
+++ b/vendor/github.com/cortexproject/promqlsmith/promqlsmith.go
@@ -40,10 +40,11 @@ var (
 type PromQLSmith struct {
 	rnd *rand.Rand
 
-	enableOffset           bool
-	enableAtModifier       bool
-	enableVectorMatching   bool
-	atModifierMaxTimestamp int64
+	enableOffset             bool
+	enableAtModifier         bool
+	enableVectorMatching     bool
+	enableExperimentalPromQL bool
+	atModifierMaxTimestamp   int64
 
 	seriesSet       []labels.Labels
 	labelNames      []string
@@ -65,17 +66,18 @@ func New(rnd *rand.Rand, seriesSet []labels.Labels, opts ...Option) *PromQLSmith
 	options.applyDefaults()
 
 	ps := &PromQLSmith{
-		rnd:                    rnd,
-		seriesSet:              filterEmptySeries(seriesSet),
-		supportedExprs:         options.enabledExprs,
-		supportedAggrs:         options.enabledAggrs,
-		supportedBinops:        options.enabledBinops,
-		supportedFuncs:         options.enabledFuncs,
-		enableOffset:           options.enableOffset,
-		enableAtModifier:       options.enableAtModifier,
-		atModifierMaxTimestamp: options.atModifierMaxTimestamp,
-		enableVectorMatching:   options.enableVectorMatching,
-		enforceMatchers:        options.enforceLabelMatchers,
+		rnd:                      rnd,
+		seriesSet:                filterEmptySeries(seriesSet),
+		supportedExprs:           options.enabledExprs,
+		supportedAggrs:           options.enabledAggrs,
+		supportedBinops:          options.enabledBinops,
+		supportedFuncs:           options.enabledFuncs,
+		enableOffset:             options.enableOffset,
+		enableAtModifier:         options.enableAtModifier,
+		atModifierMaxTimestamp:   options.atModifierMaxTimestamp,
+		enableVectorMatching:     options.enableVectorMatching,
+		enableExperimentalPromQL: options.enableExperimentalPromQLFunctions,
+		enforceMatchers:          options.enforceLabelMatchers,
 	}
 	ps.labelNames, ps.labelValues = labelNameAndValuesFromLabelSet(seriesSet)
 	return ps

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -303,8 +303,8 @@ github.com/coreos/go-semver/semver
 ## explicit; go 1.12
 github.com/coreos/go-systemd/v22/activation
 github.com/coreos/go-systemd/v22/journal
-# github.com/cortexproject/promqlsmith v0.0.0-20241102030034-4051538fd914
-## explicit; go 1.21.0
+# github.com/cortexproject/promqlsmith v0.0.0-20241121054008-8b48fe2471ef
+## explicit; go 1.22.0
 github.com/cortexproject/promqlsmith
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR adds an experimental flag `querier.enable-promql-experimental-functions ` to enable experimental promQL functions to be used.

This PR tests experimental promQL functions except `limitk` and `limit_ratio`. These are the sampling aggregator returns subnet of the input samples. So, we should devise another test to verify the compatibility between Cortex and Prometheus.   

**Which issue(s) this PR fixes**:
Fixes #6307 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
