### PR TITLE
Adding list of Maintainers on the governance page

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -42,13 +42,17 @@ Triagers are contributors who assist in managing and organizing issues and pull 
 
 ## Github Project Administration
 
-Maintainers will be added to the collaborators list of the Cortex repository with "Write" access.
+Maintainers will be added to the collaborators list of the Cortex repository with "Write" access while Triagers will be added to the collaborators list of the Cortex repository with "Triage" access.
 
 After 6 months a maintainer will be given "Admin" access to the Cortex repository.
 
 ## Changes in Governance
 
 All changes in Governance require a 2/3 majority vote.
+
+## Cortex Team
+
+${Maintainers}
 
 ## Other Changes
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,0 @@
-Alan Protasio, Amazon Web Services <alanprot@gmail.com> (@alanprot)
-Ben Ye, Amazon Web Services <yb532204897@gmail.com> (@yeya24)
-Charlie Le, Apple <chtle4@gmail.com> (@CharlieTLe)
-Daniel Blando, Amazon Web Services <daniel@blando.com.br> (@danielblando)
-Friedrich Gonzalez, Adobe <friedrichg@gmail.com> (@friedrichg)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,9 @@
+### Maintainers
+
+| Name               | Email                 | GitHub        | Company             |
+|--------------------|-----------------------|---------------|---------------------|
+| Alan Protasio      | alanprot@gmail.com    | @alanprot     | Amazon Web Services |
+| Ben Ye             | yb532204897@gmail.com | @yeya24       | Amazon Web Services |
+| Charlie Le         | chtle4@gmail.com>     | @CharlieTLe   | Apple               |
+| Daniel Blando      | daniel@blando.com.br  | @danielblando | Amazon Web Services |
+| Friedrich Gonzalez | friedrichg@gmail.com  | @friedrichg   | Adobe               |

--- a/tools/website/web-pre.sh
+++ b/tools/website/web-pre.sh
@@ -15,7 +15,7 @@ mkdir -p ${OUTPUT_CONTENT_DIR}
 # Copy original content.
 cp -r ${ORIGINAL_CONTENT_DIR}/* ${OUTPUT_CONTENT_DIR}
 cp -r code-of-conduct.md CHANGELOG.md ${OUTPUT_CONTENT_DIR}
-cp GOVERNANCE.md ${OUTPUT_CONTENT_DIR}/contributing/governance.md
+Maintainers=`cat MAINTAINERS.md` envsubst <  GOVERNANCE.md >> ${OUTPUT_CONTENT_DIR}/contributing/governance.md
 cp images/* ${WEBSITE_DIR}/static/images
 
 # Add headers to special CODE_OF_CONDUCT.md, CHANGELOG.md and README.md files.
@@ -50,7 +50,7 @@ weight: 1
 ---
 EOT
 )" > ${OUTPUT_CONTENT_DIR}/contributing/governance.md
-tail -n +2 GOVERNANCE.md >> ${OUTPUT_CONTENT_DIR}/contributing/governance.md
+Maintainers=`cat MAINTAINERS.md` envsubst < GOVERNANCE.md | tail -n +2 >> ${OUTPUT_CONTENT_DIR}/contributing/governance.md
 
 echo "$(cat <<EOT
 ---


### PR DESCRIPTION
**What this PR does**:

Adding the list of maintainers on the governance page on cortex website.

Triagers will also be listed on the cortex governance page.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
