### PR TITLE
Install get test on the build image

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.23.2-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
-RUN apt-get update && apt-get install -y curl file jq unzip protobuf-compiler libprotobuf-dev && \
+RUN apt-get update && apt-get install -y curl file gettext jq unzip protobuf-compiler libprotobuf-dev && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
**What this PR does**:
We now need `envsubst` command to build the website assets:

See:
![Screenshot 2024-11-21 at 5 16 44 PM](https://github.com/user-attachments/assets/a3d3bedc-aa7c-4643-8a80-acbbbc90c61a)




**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
