### PR TITLE
Fix data race on expanded postings Cache

### DIFF
--- a/pkg/storage/tsdb/expanded_postings_cache.go
+++ b/pkg/storage/tsdb/expanded_postings_cache.go
@@ -302,7 +302,7 @@ func newSeedByHash(size int) *seedByHash {
 func (s *seedByHash) getSeed(userId string, v string) string {
 	h := memHashString(userId, v)
 	i := h % uint64(len(s.seedByHash))
-	l := h % uint64(len(s.strippedLock))
+	l := i % uint64(len(s.strippedLock))
 	s.strippedLock[l].RLock()
 	defer s.strippedLock[l].RUnlock()
 	return strconv.Itoa(s.seedByHash[i])
@@ -311,7 +311,7 @@ func (s *seedByHash) getSeed(userId string, v string) string {
 func (s *seedByHash) incrementSeed(userId string, v string) {
 	h := memHashString(userId, v)
 	i := h % uint64(len(s.seedByHash))
-	l := h % uint64(len(s.strippedLock))
+	l := i % uint64(len(s.strippedLock))
 	s.strippedLock[l].Lock()
 	defer s.strippedLock[l].Unlock()
 	s.seedByHash[i]++


### PR DESCRIPTION
**What this PR does**:
 We are using the wrong index on the stripped lock, causing data race.
 
 This fix the issue by using the correct index on the stripped lock.
 
First commit has the test showing the race (failing): https://github.com/cortexproject/cortex/actions/runs/11981212549/job/33407007009

```
==================
WARNING: DATA RACE
Read at 0x00c004dc8010 by goroutine 18675:
  github.com/cortexproject/cortex/pkg/storage/tsdb.(*seedByHash).incrementSeed()
      /__w/cortex/cortex/pkg/storage/tsdb/expanded_postings_cache.go:317 +0x208
  github.com/cortexproject/cortex/pkg/storage/tsdb.(*blocksPostingsForMatchersCache).ExpireSeries()
      /__w/cortex/cortex/pkg/storage/tsdb/expanded_postings_cache.go:1[61](https://github.com/cortexproject/cortex/actions/runs/11981212549/job/33407007009#step:6:62) +0x157
  github.com/cortexproject/cortex/pkg/ingester.(*userTSDB).PostCreation()
      /__w/cortex/cortex/pkg/ingester/ingester.go:4[62](https://github.com/cortexproject/cortex/actions/runs/11981212549/job/33407007009#step:6:63) +0x315
  github.com/prometheus/prometheus/tsdb.(*stripeSeries).getOrSet()
      /__w/cortex/cortex/vendor/github.com/prometheus/prometheus/tsdb/head.go:2031 +0x2cd
  github.com/prometheus/prometheus/tsdb.(*Head).getOrCreateWithID()
      /__w/cortex/cortex/vendor/github.com/prometheus/prometheus/tsdb/head.go:1703 +0x13d
  github.com/prometheus/prometheus/tsdb.(*Head).getOrCreate()
      /__w/cortex/cortex/vendor/github.com/prometheus/prometheus/tsdb/head.go:1699 +0xe4
  github.com/prometheus/prometheus/tsdb.(*headAppender).getOrCreate()
      /__w/cortex/cortex/vendor/github.com/prometheus/prometheus/tsdb/head_append.go:438 +0x4ab
  github.com/prometheus/prometheus/tsdb.(*headAppender).Append()
      /__w/cortex/cortex/vendor/github.com/prometheus/prometheus/tsdb/head_append.go:334 +0x13b
  github.com/prometheus/prometheus/tsdb.(*initAppender).Append()
      /__w/cortex/cortex/vendor/github.com/prometheus/prometheus/tsdb/head_append.go:52 +0x137
  github.com/prometheus/prometheus/tsdb.(*dbAppender).Append()
      <autogenerated>:1 +0xa1
  github.com/cortexproject/cortex/pkg/ingester.(*Ingester).Push()
      /__w/cortex/cortex/pkg/ingester/ingester.go:1234 +0x3078
  github.com/cortexproject/cortex/pkg/ingester.TestExpendedPostingsCacheIsolation.func1()
      /__w/cortex/cortex/pkg/ingester/ingester_test.go:5117 +0x404
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
