### PR TITLE
Log query requests in QFE before query execution

### DIFF
--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -234,7 +234,7 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"method", r.Method,
 			"path", r.URL.Path,
 		}, formatQueryString(queryString)...)
-		level.Info(util_log.WithContext(r.Context(), f.log)).Log(logMessage...)	
+		level.Info(util_log.WithContext(r.Context(), f.log)).Log(logMessage...)
 	}
 
 	startTime := time.Now()

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -225,16 +225,27 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Body = io.NopCloser(&buf)
 	}
 
+	// Log request
+	if f.cfg.QueryStatsEnabled {
+		queryString = f.parseRequestQueryString(r, buf)
+		logMessage := append([]interface{}{
+			"msg", "query request",
+			"component", "query-frontend",
+			"method", r.Method,
+			"path", r.URL.Path,
+		}, formatQueryString(queryString)...)
+		level.Info(util_log.WithContext(r.Context(), f.log)).Log(logMessage...)	
+	}
+
 	startTime := time.Now()
 	resp, err := f.roundTripper.RoundTrip(r)
 	queryResponseTime := time.Since(startTime)
 
-	// Check whether we should parse the query string.
+	// Check if we need to parse the query string to avoid parsing twice.
 	shouldReportSlowQuery := f.cfg.LogQueriesLongerThan != 0 && queryResponseTime > f.cfg.LogQueriesLongerThan
-	if shouldReportSlowQuery || f.cfg.QueryStatsEnabled {
+	if shouldReportSlowQuery && !f.cfg.QueryStatsEnabled {
 		queryString = f.parseRequestQueryString(r, buf)
 	}
-
 	if shouldReportSlowQuery {
 		f.reportSlowQuery(r, queryString, queryResponseTime)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Add logging for query requests in QFE before query execution. Query requests are logged only if `query_stats_enabled` is enabled. This is useful for debugging queries that failed to return to QFE. 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
