### PR TITLE
chore: remove unnecessary level filter

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -85,7 +85,7 @@ func newPrometheusLoggerFrom(logger log.Logger, logLevel logging.Level, keyvals 
 	// Ref: https://github.com/go-kit/log/issues/14#issuecomment-945038252
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, keyvals...)
-	logger = level.NewFilter(logger, LevelFilter(logLevel.String()))
+	logger = level.NewFilter(logger, logLevel.Gokit)
 
 	// Initialise counters for all supported levels:
 	for _, level := range supportedLevels {

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -123,24 +123,6 @@ func CheckFatal(location string, err error) {
 	}
 }
 
-// TODO(dannyk): remove once weaveworks/common updates to go-kit/log
-//
-//	-> we can then revert to using Level.Gokit
-func LevelFilter(l string) level.Option {
-	switch l {
-	case "debug":
-		return level.AllowDebug()
-	case "info":
-		return level.AllowInfo()
-	case "warn":
-		return level.AllowWarn()
-	case "error":
-		return level.AllowError()
-	default:
-		return level.AllowAll()
-	}
-}
-
 func HeaderMapFromContext(ctx context.Context) map[string]string {
 	headerMap, ok := ctx.Value(headerMapContextKey).(map[string]string)
 	if !ok {


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

**What this PR does**:

Clean up the logging code a bit before we switch to use slog.

`LevelFilter` is not needed anymore as the common package already switch to use `go-kit/log`. See the TODO comment there.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
