### PR TITLE
Changing client healthcheck config cli argument

### DIFF
--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -209,17 +209,17 @@ querier:
     healthcheck_config:
       # The number of consecutive failed health checks required before
       # considering a target unhealthy. 0 means disabled.
-      # CLI flag: -querier.store-gateway-client.unhealthy-threshold
+      # CLI flag: -querier.store-gateway-client.healthcheck.unhealthy-threshold
       [unhealthy_threshold: <int> | default = 0]
 
       # The approximate amount of time between health checks of an individual
       # target.
-      # CLI flag: -querier.store-gateway-client.interval
+      # CLI flag: -querier.store-gateway-client.healthcheck.interval
       [interval: <duration> | default = 5s]
 
       # The amount of time during which no response from a target means a failed
       # health check.
-      # CLI flag: -querier.store-gateway-client.timeout
+      # CLI flag: -querier.store-gateway-client.healthcheck.timeout
       [timeout: <duration> | default = 1s]
 
   # If enabled, store gateway query stats will be logged using `info` log level.

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3256,17 +3256,17 @@ grpc_client_config:
   healthcheck_config:
     # The number of consecutive failed health checks required before considering
     # a target unhealthy. 0 means disabled.
-    # CLI flag: -ingester.client.unhealthy-threshold
+    # CLI flag: -ingester.client.healthcheck.unhealthy-threshold
     [unhealthy_threshold: <int> | default = 0]
 
     # The approximate amount of time between health checks of an individual
     # target.
-    # CLI flag: -ingester.client.interval
+    # CLI flag: -ingester.client.healthcheck.interval
     [interval: <duration> | default = 5s]
 
     # The amount of time during which no response from a target means a failed
     # health check.
-    # CLI flag: -ingester.client.timeout
+    # CLI flag: -ingester.client.healthcheck.timeout
     [timeout: <duration> | default = 1s]
 
 # Max inflight push requests that this ingester client can handle. This limit is
@@ -4004,17 +4004,17 @@ store_gateway_client:
   healthcheck_config:
     # The number of consecutive failed health checks required before considering
     # a target unhealthy. 0 means disabled.
-    # CLI flag: -querier.store-gateway-client.unhealthy-threshold
+    # CLI flag: -querier.store-gateway-client.healthcheck.unhealthy-threshold
     [unhealthy_threshold: <int> | default = 0]
 
     # The approximate amount of time between health checks of an individual
     # target.
-    # CLI flag: -querier.store-gateway-client.interval
+    # CLI flag: -querier.store-gateway-client.healthcheck.interval
     [interval: <duration> | default = 5s]
 
     # The amount of time during which no response from a target means a failed
     # health check.
-    # CLI flag: -querier.store-gateway-client.timeout
+    # CLI flag: -querier.store-gateway-client.healthcheck.timeout
     [timeout: <duration> | default = 1s]
 
 # If enabled, store gateway query stats will be logged using `info` log level.

--- a/pkg/util/grpcclient/health_check.go
+++ b/pkg/util/grpcclient/health_check.go
@@ -34,9 +34,9 @@ type HealthCheckConfig struct {
 
 // RegisterFlagsWithPrefix for Config.
 func (cfg *HealthCheckConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.Int64Var(&cfg.UnhealthyThreshold, prefix+".unhealthy-threshold", 0, "The number of consecutive failed health checks required before considering a target unhealthy. 0 means disabled.")
-	f.DurationVar(&cfg.Timeout, prefix+".timeout", 1*time.Second, "The amount of time during which no response from a target means a failed health check.")
-	f.DurationVar(&cfg.Interval, prefix+".interval", 5*time.Second, "The approximate amount of time between health checks of an individual target.")
+	f.Int64Var(&cfg.UnhealthyThreshold, prefix+".healthcheck.unhealthy-threshold", 0, "The number of consecutive failed health checks required before considering a target unhealthy. 0 means disabled.")
+	f.DurationVar(&cfg.Timeout, prefix+".healthcheck.timeout", 1*time.Second, "The amount of time during which no response from a target means a failed health check.")
+	f.DurationVar(&cfg.Interval, prefix+".healthcheck.interval", 5*time.Second, "The approximate amount of time between health checks of an individual target.")
 }
 
 type healthCheckClient struct {


### PR DESCRIPTION
**What this PR does**:
Adds `healthcheck` prefix on the health check CLI config.
The config before was, for instance, `-querier.store-gateway-client.timeout` which is very confusing.

This feature is marked as experimental and its not being released (even as experimental) yet, so we should be ok to just rename it.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [NA] Tests updated
- [NA ] Documentation added
- [NA ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
