### PR TITLE
Expanded Postings Cache can cache results without the nearly created series under high load.

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -61,6 +61,24 @@ jobs:
           ln -s $GITHUB_WORKSPACE/* /go/src/github.com/cortexproject/cortex
       - name: Run Tests
         run: make BUILD_IN_CONTAINER=false test
+  test-no-race:
+    runs-on: ubuntu-20.04
+    container:
+      image: quay.io/cortexproject/build-image:master-0ddced051
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Git safe.directory
+        run: |
+          echo "this step is needed because when running in container, actions/checkout does not set safe.directory effectively."
+          echo "See https://github.com/actions/runner/issues/2033. We should use --system instead of --global"
+          git config --system --add safe.directory $GITHUB_WORKSPACE
+      - name: Sym Link Expected Path to Workspace
+        run: |
+          mkdir -p /go/src/github.com/cortexproject/cortex
+          ln -s $GITHUB_WORKSPACE/* /go/src/github.com/cortexproject/cortex
+      - name: Run Tests
+        run: make BUILD_IN_CONTAINER=false test-no-race
 
   security:
     name: CodeQL

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,9 @@ lint:
 test:
 	go test -tags netgo -timeout 30m -race -count 1 ./...
 
+test-no-race:
+	go test -tags netgo -timeout 30m -count 1 ./...
+
 cover:
 	$(eval COVERDIR := $(shell mktemp -d coverage.XXXXXXXXXX))
 	$(eval COVERFILE := $(shell mktemp $(COVERDIR)/unit.XXXXXXXXXX))

--- a/pkg/ingester/ingester_no_race_test.go
+++ b/pkg/ingester/ingester_no_race_test.go
@@ -1,0 +1,90 @@
+//go:build !race
+
+package ingester
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
+
+	"github.com/cortexproject/cortex/pkg/cortexpb"
+	"github.com/cortexproject/cortex/pkg/ingester/client"
+	"github.com/cortexproject/cortex/pkg/ring"
+	"github.com/cortexproject/cortex/pkg/util/services"
+	"github.com/cortexproject/cortex/pkg/util/test"
+)
+
+// Running this test without race check as there is a known prometheus race condition.
+// See https://github.com/prometheus/prometheus/pull/15141 and https://github.com/prometheus/prometheus/pull/15316
+func TestExpandedCachePostings_Race(t *testing.T) {
+	cfg := defaultIngesterTestConfig(t)
+	cfg.BlocksStorageConfig.TSDB.BlockRanges = []time.Duration{2 * time.Hour}
+	cfg.LifecyclerConfig.JoinAfter = 0
+	cfg.BlocksStorageConfig.TSDB.PostingsCache.Head.Enabled = true
+
+	r := prometheus.NewRegistry()
+	i, err := prepareIngesterWithBlocksStorage(t, cfg, r)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
+
+	// Wait until the ingester is ACTIVE
+	test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {
+		return i.lifecycler.GetState()
+	})
+
+	ctx := user.InjectOrgID(context.Background(), "test")
+
+	wg := sync.WaitGroup{}
+	labelNames := 100
+	seriesPerLabelName := 200
+
+	for j := 0; j < labelNames; j++ {
+		metricName := fmt.Sprintf("test_metric_%d", j)
+		wg.Add(seriesPerLabelName * 2)
+		for k := 0; k < seriesPerLabelName; k++ {
+			go func() {
+				defer wg.Done()
+				_, err := i.Push(ctx, cortexpb.ToWriteRequest(
+					[]labels.Labels{labels.FromStrings(labels.MetricName, metricName, "k", strconv.Itoa(k))},
+					[]cortexpb.Sample{{Value: 1, TimestampMs: 9}}, nil, nil, cortexpb.API))
+				require.NoError(t, err)
+			}()
+
+			go func() {
+				defer wg.Done()
+				err := i.QueryStream(&client.QueryRequest{
+					StartTimestampMs: 0,
+					EndTimestampMs:   math.MaxInt64,
+					Matchers:         []*client.LabelMatcher{{Type: client.EQUAL, Name: labels.MetricName, Value: metricName}},
+				}, &mockQueryStreamServer{ctx: ctx})
+				require.NoError(t, err)
+			}()
+		}
+
+		wg.Wait()
+
+		s := &mockQueryStreamServer{ctx: ctx}
+		err = i.QueryStream(&client.QueryRequest{
+			StartTimestampMs: 0,
+			EndTimestampMs:   math.MaxInt64,
+			Matchers:         []*client.LabelMatcher{{Type: client.EQUAL, Name: labels.MetricName, Value: metricName}},
+		}, s)
+		require.NoError(t, err)
+
+		set, err := seriesSetFromResponseStream(s)
+		require.NoError(t, err)
+		res, err := client.MatrixFromSeriesSet(set)
+		require.NoError(t, err)
+		require.Equal(t, seriesPerLabelName, res.Len())
+	}
+}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -5273,6 +5273,69 @@ func TestExpendedPostingsCacheIsolation(t *testing.T) {
 	wg.Wait()
 }
 
+func TestExpandedCachePostings_Race(t *testing.T) {
+	cfg := defaultIngesterTestConfig(t)
+	cfg.BlocksStorageConfig.TSDB.BlockRanges = []time.Duration{2 * time.Hour}
+	cfg.LifecyclerConfig.JoinAfter = 0
+	cfg.BlocksStorageConfig.TSDB.PostingsCache.Head.Enabled = true
+
+	r := prometheus.NewRegistry()
+	i, err := prepareIngesterWithBlocksStorage(t, cfg, r)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
+
+	// Wait until the ingester is ACTIVE
+	test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {
+		return i.lifecycler.GetState()
+	})
+
+	ctx := user.InjectOrgID(context.Background(), "test")
+
+	wg := sync.WaitGroup{}
+
+	for j := 0; j < 100; j++ {
+		metricName := fmt.Sprintf("test_metric_%d", j)
+		wg.Add(200)
+		for k := 0; k < 100; k++ {
+
+			go func() {
+				defer wg.Done()
+				_, err := i.Push(ctx, cortexpb.ToWriteRequest(
+					[]labels.Labels{labels.FromStrings(labels.MetricName, metricName, "k", strconv.Itoa(k))},
+					[]cortexpb.Sample{{Value: 1, TimestampMs: 9}}, nil, nil, cortexpb.API))
+				require.NoError(t, err)
+			}()
+
+			go func() {
+				defer wg.Done()
+				err := i.QueryStream(&client.QueryRequest{
+					StartTimestampMs: 0,
+					EndTimestampMs:   math.MaxInt64,
+					Matchers:         []*client.LabelMatcher{{Type: client.EQUAL, Name: labels.MetricName, Value: metricName}},
+				}, &mockQueryStreamServer{ctx: ctx})
+				require.NoError(t, err)
+			}()
+		}
+
+		wg.Wait()
+
+		s := &mockQueryStreamServer{ctx: ctx}
+		err = i.QueryStream(&client.QueryRequest{
+			StartTimestampMs: 0,
+			EndTimestampMs:   math.MaxInt64,
+			Matchers:         []*client.LabelMatcher{{Type: client.EQUAL, Name: labels.MetricName, Value: metricName}},
+		}, s)
+		require.NoError(t, err)
+
+		set, err := seriesSetFromResponseStream(s)
+		require.NoError(t, err)
+		res, err := client.MatrixFromSeriesSet(set)
+		require.NoError(t, err)
+		require.Equal(t, 100, res.Len())
+	}
+}
+
 func TestExpendedPostingsCache(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
 	cfg.BlocksStorageConfig.TSDB.BlockRanges = []time.Duration{2 * time.Hour}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -5273,69 +5273,6 @@ func TestExpendedPostingsCacheIsolation(t *testing.T) {
 	wg.Wait()
 }
 
-func TestExpandedCachePostings_Race(t *testing.T) {
-	cfg := defaultIngesterTestConfig(t)
-	cfg.BlocksStorageConfig.TSDB.BlockRanges = []time.Duration{2 * time.Hour}
-	cfg.LifecyclerConfig.JoinAfter = 0
-	cfg.BlocksStorageConfig.TSDB.PostingsCache.Head.Enabled = true
-
-	r := prometheus.NewRegistry()
-	i, err := prepareIngesterWithBlocksStorage(t, cfg, r)
-	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
-
-	// Wait until the ingester is ACTIVE
-	test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() interface{} {
-		return i.lifecycler.GetState()
-	})
-
-	ctx := user.InjectOrgID(context.Background(), "test")
-
-	wg := sync.WaitGroup{}
-
-	for j := 0; j < 100; j++ {
-		metricName := fmt.Sprintf("test_metric_%d", j)
-		wg.Add(200)
-		for k := 0; k < 100; k++ {
-
-			go func() {
-				defer wg.Done()
-				_, err := i.Push(ctx, cortexpb.ToWriteRequest(
-					[]labels.Labels{labels.FromStrings(labels.MetricName, metricName, "k", strconv.Itoa(k))},
-					[]cortexpb.Sample{{Value: 1, TimestampMs: 9}}, nil, nil, cortexpb.API))
-				require.NoError(t, err)
-			}()
-
-			go func() {
-				defer wg.Done()
-				err := i.QueryStream(&client.QueryRequest{
-					StartTimestampMs: 0,
-					EndTimestampMs:   math.MaxInt64,
-					Matchers:         []*client.LabelMatcher{{Type: client.EQUAL, Name: labels.MetricName, Value: metricName}},
-				}, &mockQueryStreamServer{ctx: ctx})
-				require.NoError(t, err)
-			}()
-		}
-
-		wg.Wait()
-
-		s := &mockQueryStreamServer{ctx: ctx}
-		err = i.QueryStream(&client.QueryRequest{
-			StartTimestampMs: 0,
-			EndTimestampMs:   math.MaxInt64,
-			Matchers:         []*client.LabelMatcher{{Type: client.EQUAL, Name: labels.MetricName, Value: metricName}},
-		}, s)
-		require.NoError(t, err)
-
-		set, err := seriesSetFromResponseStream(s)
-		require.NoError(t, err)
-		res, err := client.MatrixFromSeriesSet(set)
-		require.NoError(t, err)
-		require.Equal(t, 100, res.Len())
-	}
-}
-
 func TestExpendedPostingsCache(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
 	cfg.BlocksStorageConfig.TSDB.BlockRanges = []time.Duration{2 * time.Hour}


### PR DESCRIPTION
**What this PR does**:

#6296 introduced an experimental flag to cache expanded postings, including postings from the head blocks. In that PR, the TSDB PostCreation hook is used to "expire" cache keys when new metrics are added for a specific metric name.

The issue happens under scenarios of high concurrency, where a key may be expired before the new series are available for querying, leading to cached results that exclude the new series.

The root cause is that the PostCreation hook is invoked after the series is created but before it is added to memPostings:

  Relevant code:
 * Hook Invocation: https://github.com/prometheus/prometheus/blob/e1bfdd22571d874e1f9154d1a35ce3a8569ded36/tsdb/head.go#L2042
 * New Series added to the memPostings: https://github.com/prometheus/prometheus/blob/e1bfdd22571d874e1f9154d1a35ce3a8569ded36/tsdb/head.go#L1714-L1732

Moving the hook invocation to occur after line 1732 resolves the issue.

~This PR currently only includes a test that demonstrates the problem.~

This PR implements a workaround to expire the series after the "commit". This workaround can be removed if the the PR on prometheus is accepted.



cc @GiedriusS


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
