### PR TITLE
docs: fix markdown link for other otel collectors

### DIFF
--- a/docs/guides/tracing.md
+++ b/docs/guides/tracing.md
@@ -50,7 +50,7 @@ In order to send traces, you will need to set up an OpenTelemetry Collector. The
 multiple destinations such as [AWS X-Ray](https://aws-otel.github.io/docs/getting-started/x-ray),
 [Google Cloud](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter),
 [DataDog](https://docs.datadoghq.com/tracing/trace_collection/open_standards/otel_collector_datadog_exporter/) and
-[others(https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter). OpenTelemetry Collector
+[others](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter). OpenTelemetry Collector
 provides a [helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector/examples/deployment-otlp-traces)
 to set up the environment.
 


### PR DESCRIPTION
**What this PR does**:
Fixes the markdown link for other otel collectors in the tracing guide.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
