### PR TITLE
Cleanup dangling request queue metrics

### DIFF
--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -183,6 +183,7 @@ func (f *Frontend) cleanupInactiveUserMetrics(user string) {
 	f.discardedRequests.DeletePartialMatch(prometheus.Labels{
 		"user": user,
 	})
+	f.requestQueue.CleanupInactiveUserMetrics(user)
 }
 
 // RoundTripGRPC round trips a proto (instead of a HTTP request).

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -212,9 +212,9 @@ func TestFrontendMetricsCleanup(t *testing.T) {
 				# HELP cortex_query_frontend_queue_length Number of queries in the queue.
 				# TYPE cortex_query_frontend_queue_length gauge
 				cortex_query_frontend_queue_length{priority="0",type="fifo",user="1"} 0
-        	    # HELP cortex_request_queue_requests_total Total number of query requests going to the request queue.
-        	    # TYPE cortex_request_queue_requests_total counter
-        	    cortex_request_queue_requests_total{priority="0",user="1"} 1
+				# HELP cortex_request_queue_requests_total Total number of query requests going to the request queue.
+				# TYPE cortex_request_queue_requests_total counter
+				cortex_request_queue_requests_total{priority="0",user="1"} 1
 			`), "cortex_query_frontend_queue_length", "cortex_request_queue_requests_total"))
 
 			fr.cleanupInactiveUserMetrics("1")

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -212,11 +212,14 @@ func TestFrontendMetricsCleanup(t *testing.T) {
 				# HELP cortex_query_frontend_queue_length Number of queries in the queue.
 				# TYPE cortex_query_frontend_queue_length gauge
 				cortex_query_frontend_queue_length{priority="0",type="fifo",user="1"} 0
-			`), "cortex_query_frontend_queue_length"))
+        	    # HELP cortex_request_queue_requests_total Total number of query requests going to the request queue.
+        	    # TYPE cortex_request_queue_requests_total counter
+        	    cortex_request_queue_requests_total{priority="0",user="1"} 1
+			`), "cortex_query_frontend_queue_length", "cortex_request_queue_requests_total"))
 
 			fr.cleanupInactiveUserMetrics("1")
 
-			require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(""), "cortex_query_frontend_queue_length"))
+			require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(""), "cortex_query_frontend_queue_length", "cortex_request_queue_requests_total"))
 		}
 
 		testFrontend(t, defaultFrontendConfig(), handler, test, matchMaxConcurrency, nil, reg)

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -247,3 +247,7 @@ func (q *RequestQueue) QuerierDisconnecting() {
 func (q *RequestQueue) GetConnectedQuerierWorkersMetric() float64 {
 	return float64(q.connectedQuerierWorkers.Load())
 }
+
+func (q *RequestQueue) CleanupInactiveUserMetrics(user string) {
+	q.totalRequests.DeletePartialMatch(prometheus.Labels{"user": user})
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -532,6 +532,7 @@ func (s *Scheduler) cleanupMetricsForInactiveUser(user string) {
 	s.discardedRequests.DeletePartialMatch(prometheus.Labels{
 		"user": user,
 	})
+	s.requestQueue.CleanupInactiveUserMetrics(user)
 }
 
 func (s *Scheduler) getConnectedFrontendClientsMetric() float64 {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -430,7 +430,11 @@ func TestSchedulerMetrics(t *testing.T) {
 		# TYPE cortex_query_scheduler_queue_length gauge
 		cortex_query_scheduler_queue_length{priority="0",type="fifo",user="another"} 1
 		cortex_query_scheduler_queue_length{priority="0",type="fifo",user="test"} 1
-	`), "cortex_query_scheduler_queue_length"))
+        # HELP cortex_request_queue_requests_total Total number of query requests going to the request queue.
+        # TYPE cortex_request_queue_requests_total counter
+        cortex_request_queue_requests_total{priority="0",user="another"} 1
+        cortex_request_queue_requests_total{priority="0",user="test"} 1
+	`), "cortex_query_scheduler_queue_length", "cortex_request_queue_requests_total"))
 
 	scheduler.cleanupMetricsForInactiveUser("test")
 
@@ -438,7 +442,10 @@ func TestSchedulerMetrics(t *testing.T) {
 		# HELP cortex_query_scheduler_queue_length Number of queries in the queue.
 		# TYPE cortex_query_scheduler_queue_length gauge
 		cortex_query_scheduler_queue_length{priority="0",type="fifo",user="another"} 1
-	`), "cortex_query_scheduler_queue_length"))
+        # HELP cortex_request_queue_requests_total Total number of query requests going to the request queue.
+        # TYPE cortex_request_queue_requests_total counter
+        cortex_request_queue_requests_total{priority="0",user="another"} 1
+	`), "cortex_query_scheduler_queue_length", "cortex_request_queue_requests_total"))
 }
 
 func initFrontendLoop(t *testing.T, client schedulerpb.SchedulerForFrontendClient, frontendAddr string) schedulerpb.SchedulerForFrontend_FrontendLoopClient {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -430,10 +430,10 @@ func TestSchedulerMetrics(t *testing.T) {
 		# TYPE cortex_query_scheduler_queue_length gauge
 		cortex_query_scheduler_queue_length{priority="0",type="fifo",user="another"} 1
 		cortex_query_scheduler_queue_length{priority="0",type="fifo",user="test"} 1
-        # HELP cortex_request_queue_requests_total Total number of query requests going to the request queue.
-        # TYPE cortex_request_queue_requests_total counter
-        cortex_request_queue_requests_total{priority="0",user="another"} 1
-        cortex_request_queue_requests_total{priority="0",user="test"} 1
+		# HELP cortex_request_queue_requests_total Total number of query requests going to the request queue.
+		# TYPE cortex_request_queue_requests_total counter
+		cortex_request_queue_requests_total{priority="0",user="another"} 1
+		cortex_request_queue_requests_total{priority="0",user="test"} 1
 	`), "cortex_query_scheduler_queue_length", "cortex_request_queue_requests_total"))
 
 	scheduler.cleanupMetricsForInactiveUser("test")
@@ -442,9 +442,9 @@ func TestSchedulerMetrics(t *testing.T) {
 		# HELP cortex_query_scheduler_queue_length Number of queries in the queue.
 		# TYPE cortex_query_scheduler_queue_length gauge
 		cortex_query_scheduler_queue_length{priority="0",type="fifo",user="another"} 1
-        # HELP cortex_request_queue_requests_total Total number of query requests going to the request queue.
-        # TYPE cortex_request_queue_requests_total counter
-        cortex_request_queue_requests_total{priority="0",user="another"} 1
+		# HELP cortex_request_queue_requests_total Total number of query requests going to the request queue.
+		# TYPE cortex_request_queue_requests_total counter
+		cortex_request_queue_requests_total{priority="0",user="another"} 1
 	`), "cortex_query_scheduler_queue_length", "cortex_request_queue_requests_total"))
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

`cortex_request_queue_requests_total` is a high cardinality metric with `user` as its label and we didn't clean it up properly for inactive users.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
