### PR TITLE
Add default partition when no matching labelset liimits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,12 @@
 * [ENHANCEMENT] Add new option `-server.grpc_server-num-stream-workers` to configure the number of worker goroutines that should be used to process incoming streams. #6386
 * [ENHANCEMENT] Distributor: Return HTTP 5XX instead of HTTP 4XX when instance limits are hit. #6358
 * [ENHANCEMENT] Ingester: Make sure unregistered ingester joining the ring after WAL replay. #6277
+* [ENHANCEMENT] Distributor: Add a new `-distributor.num-push-workers` flag to use a goroutine worker pool when sending data from distributor to ingesters. #6406
+* [ENHANCEMENT] Ingester: If a limit per label set entry doesn't have any label, use it as the default partition to catch all series that doesn't match any other label sets entries. #6435
 * [BUGFIX] Runtime-config: Handle absolute file paths when working directory is not / #6224
 * [BUGFIX] Ruler: Allow rule evaluation to complete during shutdown. #6326
 * [BUGFIX] Ring: update ring with new ip address when instance is lost, rejoins, but heartbeat is disabled.  #6271
 * [BUGFIX] Ingester: Fix regression on usage of cortex_ingester_queried_chunks. #6398
-* [ENHANCEMENT] Distributor: Add a new `-distributor.num-push-workers` flag to use a goroutine worker pool when sending data from distributor to ingesters. #6406
 * [BUGFIX] Ingester: Fix possible race condition when `active series per LabelSet` is configured. #6409
 
 ## 1.18.1 2024-10-14

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -5770,7 +5770,9 @@ limits:
   # would not enforce any limits.
   [max_series: <int> | default = ]
 
-# LabelSet which the limit should be applied.
+# LabelSet which the limit should be applied. If no labels are provided, it
+# becomes the default partition which matches any series that doesn't match any
+# other explicitly defined label sets.'
 [label_set: <map of string (labelName) to string (labelValue)> | default = []]
 ```
 

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -500,7 +500,7 @@ func TestLimiter_AssertMaxSeriesPerLabelSet(t *testing.T) {
 			require.NoError(t, err)
 
 			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
-			actual := limiter.AssertMaxSeriesPerLabelSet("test", labels.FromStrings("foo", "bar"), func(set validation.LimitsPerLabelSet) (int, error) {
+			actual := limiter.AssertMaxSeriesPerLabelSet("test", labels.FromStrings("foo", "bar"), func(limits []validation.LimitsPerLabelSet, limit validation.LimitsPerLabelSet) (int, error) {
 				return testData.series, nil
 			})
 

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -139,6 +139,7 @@ func (m *labelSetCounter) backFillLimit(ctx context.Context, u *userTSDB, forceB
 		}
 	}
 
+	defer s.Unlock()
 	ir, err := u.db.Head().Index()
 	if err != nil {
 		return 0, err
@@ -155,7 +156,6 @@ func (m *labelSetCounter) backFillLimit(ctx context.Context, u *userTSDB, forceB
 		count:  totalCount,
 		labels: limit.LabelSet,
 	}
-	s.Unlock()
 	return totalCount, nil
 }
 

--- a/pkg/ingester/user_state_test.go
+++ b/pkg/ingester/user_state_test.go
@@ -1,8 +1,15 @@
 package ingester
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -92,3 +99,271 @@ func TestMetricCounter(t *testing.T) {
 		})
 	}
 }
+
+func TestGetCardinalityForLimitsPerLabelSet(t *testing.T) {
+	ctx := context.Background()
+	testErr := errors.New("err")
+	for _, tc := range []struct {
+		name   string
+		ir     tsdb.IndexReader
+		limits []validation.LimitsPerLabelSet
+		idx    int
+		cnt    int
+		err    error
+	}{
+		{
+			name: "single label",
+			ir: &mockIndexReader{postings: map[string]map[string]index.Postings{
+				"foo": {"bar": index.NewListPostings([]storage.SeriesRef{1, 2, 3, 4, 5})},
+			}},
+			limits: []validation.LimitsPerLabelSet{
+				{LabelSet: labels.FromStrings("foo", "bar")},
+			},
+			cnt: 5,
+		},
+		{
+			name: "multiple limits",
+			ir: &mockIndexReader{postings: map[string]map[string]index.Postings{
+				"job": {"test": index.NewListPostings([]storage.SeriesRef{5, 6, 7, 8})},
+				"foo": {"bar": index.NewListPostings([]storage.SeriesRef{1, 2, 3, 4, 5})},
+			}},
+			limits: []validation.LimitsPerLabelSet{
+				{LabelSet: labels.FromStrings("job", "test")},
+				{LabelSet: labels.FromStrings("foo", "bar")},
+			},
+			idx: 1,
+			cnt: 5,
+		},
+		{
+			name: "2 labels intersect",
+			ir: &mockIndexReader{postings: map[string]map[string]index.Postings{
+				"foo": {"bar": index.NewListPostings([]storage.SeriesRef{1, 2, 3, 4, 5})},
+				"job": {"prometheus": index.NewListPostings([]storage.SeriesRef{1, 3, 5})},
+			}},
+			limits: []validation.LimitsPerLabelSet{
+				{LabelSet: labels.FromStrings("foo", "bar", "job", "prometheus")},
+			},
+			cnt: 3,
+		},
+		{
+			name: "error",
+			ir: &mockIndexReader{postings: map[string]map[string]index.Postings{
+				"foo": {"bar": index.ErrPostings(testErr)},
+				"job": {"prometheus": index.NewListPostings([]storage.SeriesRef{1, 3, 5})},
+			}},
+			limits: []validation.LimitsPerLabelSet{
+				{LabelSet: labels.FromStrings("foo", "bar", "job", "prometheus")},
+			},
+			err: testErr,
+		},
+		{
+			name: "no match and no default partition",
+			ir: &mockIndexReader{postings: map[string]map[string]index.Postings{
+				"job": {"test": index.NewListPostings([]storage.SeriesRef{5, 6, 7, 8})},
+				"foo": {"bar": index.NewListPostings([]storage.SeriesRef{1, 2, 3, 4, 5})},
+			}},
+			limits: []validation.LimitsPerLabelSet{
+				{LabelSet: labels.FromStrings("foo", "baz")},
+			},
+			idx: 0,
+			cnt: 0,
+		},
+		{
+			name: "no match",
+			ir: &mockIndexReader{postings: map[string]map[string]index.Postings{
+				"job": {"test": index.NewListPostings([]storage.SeriesRef{5, 6, 7, 8})},
+				"foo": {"bar": index.NewListPostings([]storage.SeriesRef{1, 2, 3, 4, 5})},
+			}},
+			limits: []validation.LimitsPerLabelSet{
+				{LabelSet: labels.FromStrings("foo", "baz")},
+			},
+			cnt: 0,
+		},
+		{
+			// Total cardinality 12. Cardinality of existing label set limits 8.
+			// Default partition cardinality 4.
+			name: "default partition",
+			ir: &mockIndexReader{postings: map[string]map[string]index.Postings{
+				"job": {"test": index.NewListPostings([]storage.SeriesRef{3, 4, 5, 6, 7, 8})},
+				"foo": {"bar": index.NewListPostings([]storage.SeriesRef{1, 2, 3, 4, 5})},
+				"":    {"": index.NewListPostings([]storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12})},
+			}},
+			limits: []validation.LimitsPerLabelSet{
+				{Hash: 1, LabelSet: labels.FromStrings("foo", "bar")},
+				{Hash: 2, LabelSet: labels.FromStrings("job", "test")},
+				{}, // Default partition.
+			},
+			idx: 2,
+			cnt: 4,
+		},
+		{
+			name: "default partition with error getting postings",
+			ir: &mockIndexReader{postings: map[string]map[string]index.Postings{
+				"job": {"test": index.NewListPostings([]storage.SeriesRef{5, 6, 7, 8})},
+				"foo": {"bar": index.NewListPostings([]storage.SeriesRef{1, 2, 3, 4, 5})},
+				"":    {"": index.ErrPostings(testErr)},
+			}},
+			limits: []validation.LimitsPerLabelSet{
+				{Hash: 1, LabelSet: labels.FromStrings("foo", "bar")},
+				{Hash: 2, LabelSet: labels.FromStrings("job", "test")},
+				{}, // Default partition.
+			},
+			idx: 2,
+			err: testErr,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cnt, err := getCardinalityForLimitsPerLabelSet(ctx, tc.ir, tc.limits, tc.limits[tc.idx])
+			if err != nil {
+				require.EqualError(t, err, tc.err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.cnt, cnt)
+			}
+		})
+	}
+}
+
+func TestGetPostingForLabels(t *testing.T) {
+	ctx := context.Background()
+	testErr := errors.New("err")
+	for _, tc := range []struct {
+		name     string
+		ir       tsdb.IndexReader
+		lbls     labels.Labels
+		postings []storage.SeriesRef
+		err      error
+	}{
+		{
+			name: "single label",
+			ir: &mockIndexReader{postings: map[string]map[string]index.Postings{
+				"foo": {"bar": index.NewListPostings([]storage.SeriesRef{1, 2, 3, 4, 5})},
+			}},
+			lbls:     labels.FromStrings("foo", "bar"),
+			postings: []storage.SeriesRef{1, 2, 3, 4, 5},
+		},
+		{
+			name: "intersect",
+			ir: &mockIndexReader{postings: map[string]map[string]index.Postings{
+				"foo": {"bar": index.NewListPostings([]storage.SeriesRef{1, 2, 3, 4, 5})},
+				"job": {"prometheus": index.NewListPostings([]storage.SeriesRef{1, 3, 5})},
+			}},
+			lbls:     labels.FromStrings("foo", "bar", "job", "prometheus"),
+			postings: []storage.SeriesRef{1, 3, 5},
+		},
+		{
+			name: "error",
+			ir: &mockIndexReader{postings: map[string]map[string]index.Postings{
+				"foo": {"bar": index.ErrPostings(testErr)},
+				"job": {"prometheus": index.NewListPostings([]storage.SeriesRef{1, 3, 5})},
+			}},
+			lbls:     labels.FromStrings("foo", "bar", "job", "prometheus"),
+			postings: []storage.SeriesRef{1, 3, 5},
+			err:      testErr,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := getPostingForLabels(ctx, tc.ir, tc.lbls)
+			if err != nil {
+				require.EqualError(t, err, tc.err.Error())
+			} else {
+				require.NoError(t, err)
+				series := make([]storage.SeriesRef, 0)
+				for p.Next() {
+					series = append(series, p.At())
+				}
+				if tc.err != nil {
+					require.EqualError(t, p.Err(), tc.err.Error())
+				} else {
+					require.Equal(t, tc.postings, series)
+				}
+			}
+		})
+	}
+}
+
+func TestGetPostingCardinality(t *testing.T) {
+	testErr := errors.New("err")
+	for _, tc := range []struct {
+		name        string
+		p           index.Postings
+		cardinality int
+		err         error
+	}{
+		{
+			name: "empty",
+			p:    index.EmptyPostings(),
+		},
+		{
+			name: "err",
+			p:    index.ErrPostings(testErr),
+			err:  testErr,
+		},
+		{
+			name:        "cardinality",
+			p:           index.NewListPostings([]storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+			cardinality: 10,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cnt, err := getPostingCardinality(tc.p)
+			if tc.err != nil {
+				require.EqualError(t, err, tc.err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.cardinality, cnt)
+			}
+		})
+	}
+}
+
+type mockIndexReader struct {
+	postings map[string]map[string]index.Postings
+}
+
+func (ir *mockIndexReader) Postings(ctx context.Context, name string, values ...string) (index.Postings, error) {
+	if entries, ok := ir.postings[name]; ok {
+		if postings, ok2 := entries[values[0]]; ok2 {
+			return postings, nil
+		}
+	}
+	return index.EmptyPostings(), nil
+}
+
+func (ir *mockIndexReader) Symbols() index.StringIter { return nil }
+
+func (ir *mockIndexReader) SortedLabelValues(ctx context.Context, name string, matchers ...*labels.Matcher) ([]string, error) {
+	return nil, nil
+}
+
+func (ir *mockIndexReader) LabelValues(ctx context.Context, name string, matchers ...*labels.Matcher) ([]string, error) {
+	return nil, nil
+}
+
+func (ir *mockIndexReader) PostingsForLabelMatching(ctx context.Context, name string, match func(value string) bool) index.Postings {
+	return nil
+}
+
+func (ir *mockIndexReader) SortedPostings(index.Postings) index.Postings { return nil }
+
+func (ir *mockIndexReader) ShardedPostings(p index.Postings, shardIndex, shardCount uint64) index.Postings {
+	return nil
+}
+
+func (ir *mockIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
+	return nil
+}
+
+func (ir *mockIndexReader) LabelNames(ctx context.Context, matchers ...*labels.Matcher) ([]string, error) {
+	return nil, nil
+}
+
+func (ir *mockIndexReader) LabelValueFor(ctx context.Context, id storage.SeriesRef, label string) (string, error) {
+	return "", nil
+}
+
+func (ir *mockIndexReader) LabelNamesFor(ctx context.Context, postings index.Postings) ([]string, error) {
+	return nil, nil
+}
+
+func (ir *mockIndexReader) Close() error { return nil }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -109,7 +109,7 @@ type LimitsPerLabelSetEntry struct {
 
 type LimitsPerLabelSet struct {
 	Limits   LimitsPerLabelSetEntry `yaml:"limits" json:"limits" doc:"nocli"`
-	LabelSet labels.Labels          `yaml:"label_set" json:"label_set" doc:"nocli|description=LabelSet which the limit should be applied."`
+	LabelSet labels.Labels          `yaml:"label_set" json:"label_set" doc:"nocli|description=LabelSet which the limit should be applied. If no labels are provided, it becomes the default partition which matches any series that doesn't match any other explicitly defined label sets.'"`
 	Id       string                 `yaml:"-" json:"-" doc:"nocli"`
 	Hash     uint64                 `yaml:"-" json:"-" doc:"nocli"`
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

We added per labelset limits in Per LabelSet, which allows users to define `subtenants` within a user by defining labelsets and we can apply limits such as active series to throttle the usage of each subtenant.

There is a scenario where `team` label is used to define subtenants for a user. However, there might be a lot of teams and it is not easy to set limits for every team explicitly. Instead, users can define labelsets limits for some of the large teams and use put rest of teams using a catch all limit. This is called the default partition, which means it matches series that doesn't match any of the existing labelset limits.

Default partition doesn't have any label defined. In the example below, the second limit is the default partition and it should match all series that with name != prometheus_build_info.

```
    limits_per_label_set:
      - limits:
          max_series: 10000
        label_set:
          __name__: prometheus_build_info
      - limits:
          max_series: 10000
        label_set:
```

Metrics for default partition looks like below.
```
cortex_ingester_limits_per_labelset{labelset="{}",limit="max_series",user="1"} 2
cortex_ingester_usage_per_labelset{labelset="{}",limit="max_series",user="1"} 2
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
