### PR TITLE
Enhance `cortex_ingester_inflight_push_requests`  metric

### DIFF
--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -3,7 +3,6 @@ package ingester
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/atomic"
 
 	"github.com/cortexproject/cortex/pkg/storage/tsdb"
 	"github.com/cortexproject/cortex/pkg/util"
@@ -53,10 +52,12 @@ type ingesterMetrics struct {
 	maxUsersGauge           prometheus.GaugeFunc
 	maxSeriesGauge          prometheus.GaugeFunc
 	maxIngestionRate        prometheus.GaugeFunc
-	ingestionRate           prometheus.GaugeFunc
 	maxInflightPushRequests prometheus.GaugeFunc
-	inflightRequests        prometheus.GaugeFunc
-	inflightQueryRequests   prometheus.GaugeFunc
+
+	// Current Usage
+	ingestionRate         prometheus.GaugeFunc
+	inflightRequests      prometheus.GaugeFunc
+	inflightQueryRequests prometheus.GaugeFunc
 
 	// Posting Cache Metrics
 	expandedPostingsCacheMetrics *tsdb.ExpandedPostingsCacheMetrics
@@ -67,7 +68,7 @@ func newIngesterMetrics(r prometheus.Registerer,
 	activeSeriesEnabled bool,
 	instanceLimitsFn func() *InstanceLimits,
 	ingestionRate *util_math.EwmaRate,
-	inflightPushRequests *atomic.Int64,
+	inflightPushRequests *util_math.MaxTracker,
 	maxInflightQueryRequests *util_math.MaxTracker,
 	postingsCacheEnabled bool,
 ) *ingesterMetrics {

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	util_math "github.com/cortexproject/cortex/pkg/util/math"
 )
@@ -16,10 +15,10 @@ import (
 func TestIngesterMetrics(t *testing.T) {
 	mainReg := prometheus.NewPedanticRegistry()
 	ingestionRate := util_math.NewEWMARate(0.2, instanceIngestionRateTickInterval)
-	inflightPushRequests := &atomic.Int64{}
+	inflightPushRequests := util_math.MaxTracker{}
 	maxInflightQueryRequests := util_math.MaxTracker{}
 	maxInflightQueryRequests.Track(98)
-	inflightPushRequests.Store(14)
+	inflightPushRequests.Track(14)
 
 	m := newIngesterMetrics(mainReg,
 		false,
@@ -33,7 +32,7 @@ func TestIngesterMetrics(t *testing.T) {
 			}
 		},
 		ingestionRate,
-		inflightPushRequests,
+		&inflightPushRequests,
 		&maxInflightQueryRequests,
 		false)
 


### PR DESCRIPTION
**What this PR does**:
The cortex_ingester_inflight_push_requests metric currently monitors the inflightPushRequests atomic integer directly.

This approach can be misleading, as the value fluctuates significantly and only represents the exact value at the time of scraping.

This PR modifies the metric to report the maximum number of concurrent requests observed within each one-minute interval.

I think is fine changing this metric (instead of creating a new one) as the intent was always the same.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
