### PR TITLE
Add distributor per labelset received samples metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [ENHANCEMENT] Distributor: Add a new `-distributor.num-push-workers` flag to use a goroutine worker pool when sending data from distributor to ingesters. #6406
 * [ENHANCEMENT] Ingester: If a limit per label set entry doesn't have any label, use it as the default partition to catch all series that doesn't match any other label sets entries. #6435
 * [ENHANCEMENT] Querier: Add new `cortex_querier_codec_response_size` metric to track the size of the encoded query responses from queriers. #6444
+* [ENHANCEMENT] Distributor: Added `cortex_distributor_received_samples_per_labelset_total` metric to calculate ingestion rate per label set. #6443
 * [BUGFIX] Runtime-config: Handle absolute file paths when working directory is not / #6224
 * [BUGFIX] Ruler: Allow rule evaluation to complete during shutdown. #6326
 * [BUGFIX] Ring: update ring with new ip address when instance is lost, rejoins, but heartbeat is disabled.  #6271

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -926,8 +926,10 @@ func (d *Distributor) prepareSeriesKeys(ctx context.Context, req *cortexpb.Write
 	validatedExemplars := 0
 	limitsPerLabelSet := d.limits.LimitsPerLabelSet(userID)
 
-	var labelSetCounters map[uint64]*samplesLabelSetEntry
-	var firstPartialErr error
+	var (
+		labelSetCounters map[uint64]*samplesLabelSetEntry
+		firstPartialErr  error
+	)
 
 	latestSampleTimestampMs := int64(0)
 	defer func() {
@@ -1044,7 +1046,8 @@ func (d *Distributor) prepareSeriesKeys(ctx context.Context, req *cortexpb.Write
 		}
 
 		matchedLabelSetLimits := validation.LimitsPerLabelSetsForSeries(limitsPerLabelSet, cortexpb.FromLabelAdaptersToLabels(validatedSeries.Labels))
-		if len(matchedLabelSetLimits) > 0 {
+		if len(matchedLabelSetLimits) > 0 && labelSetCounters == nil {
+			// TODO: use pool.
 			labelSetCounters = make(map[uint64]*samplesLabelSetEntry, len(matchedLabelSetLimits))
 		}
 		for _, l := range matchedLabelSetLimits {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -926,7 +926,7 @@ func (d *Distributor) prepareSeriesKeys(ctx context.Context, req *cortexpb.Write
 	validatedExemplars := 0
 	limitsPerLabelSet := d.limits.LimitsPerLabelSet(userID)
 
-	labelSetCounters := make(map[uint64]*samplesLabelSetEntry)
+	var labelSetCounters map[uint64]*samplesLabelSetEntry
 	var firstPartialErr error
 
 	latestSampleTimestampMs := int64(0)
@@ -1043,7 +1043,11 @@ func (d *Distributor) prepareSeriesKeys(ctx context.Context, req *cortexpb.Write
 			continue
 		}
 
-		for _, l := range validation.LimitsPerLabelSetsForSeries(limitsPerLabelSet, cortexpb.FromLabelAdaptersToLabels(validatedSeries.Labels)) {
+		matchedLabelSetLimits := validation.LimitsPerLabelSetsForSeries(limitsPerLabelSet, cortexpb.FromLabelAdaptersToLabels(validatedSeries.Labels))
+		if len(matchedLabelSetLimits) > 0 {
+			labelSetCounters = make(map[uint64]*samplesLabelSetEntry, len(matchedLabelSetLimits))
+		}
+		for _, l := range matchedLabelSetLimits {
 			if c, exists := labelSetCounters[l.Hash]; exists {
 				c.floatSamples += int64(len(ts.Samples))
 				c.histogramSamples += int64(len(ts.Histograms))

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4135,16 +4135,12 @@ func TestDistributor_PushLabelSetMetrics(t *testing.T) {
 	_, err = ds[0].Push(ctx, req)
 	require.NoError(t, err)
 
-	ds[0].updateLabelSetMetrics()
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_distributor_received_samples_per_labelset_total The total number of received samples per label set, excluding rejected and deduped samples.
 		# TYPE cortex_distributor_received_samples_per_labelset_total counter
 		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"one\"}",type="float",user="user"} 2
-		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"one\"}",type="histogram",user="user"} 0
 		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"two\"}",type="float",user="user"} 1
-		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"two\"}",type="histogram",user="user"} 0
 		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="user"} 1
-		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="user"} 0
 		`), "cortex_distributor_received_samples_per_labelset_total"))
 
 	// Push more series.
@@ -4166,20 +4162,14 @@ func TestDistributor_PushLabelSetMetrics(t *testing.T) {
 	req = mockWriteRequest(inputSeries, 1, 1, false)
 	_, err = ds[0].Push(ctx2, req)
 	require.NoError(t, err)
-	ds[0].updateLabelSetMetrics()
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_distributor_received_samples_per_labelset_total The total number of received samples per label set, excluding rejected and deduped samples.
 		# TYPE cortex_distributor_received_samples_per_labelset_total counter
 		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"one\"}",type="float",user="user"} 2
-		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"one\"}",type="histogram",user="user"} 0
 		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"two\"}",type="float",user="user"} 2
 		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"two\"}",type="float",user="user2"} 1
-		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"two\"}",type="histogram",user="user"} 0
-		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"two\"}",type="histogram",user="user2"} 0
 		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="user"} 2
 		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="user2"} 1
-		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="user"} 0
-		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="user2"} 0
 		`), "cortex_distributor_received_samples_per_labelset_total"))
 
 	// Remove existing limits and add new limits
@@ -4198,8 +4188,6 @@ func TestDistributor_PushLabelSetMetrics(t *testing.T) {
 		# TYPE cortex_distributor_received_samples_per_labelset_total counter
 		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="user"} 2
 		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="user2"} 1
-		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="user"} 0
-		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="user2"} 0
 		`), "cortex_distributor_received_samples_per_labelset_total"))
 
 	// Metrics from `user` got removed but `user2` metric should remain.
@@ -4208,7 +4196,6 @@ func TestDistributor_PushLabelSetMetrics(t *testing.T) {
 		# HELP cortex_distributor_received_samples_per_labelset_total The total number of received samples per label set, excluding rejected and deduped samples.
 		# TYPE cortex_distributor_received_samples_per_labelset_total counter
 		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="user2"} 1
-		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="user2"} 0
 		`), "cortex_distributor_received_samples_per_labelset_total"))
 }
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -420,6 +420,7 @@ func TestDistributor_MetricsCleanup(t *testing.T) {
 		"cortex_distributor_metadata_in_total",
 		"cortex_distributor_non_ha_samples_received_total",
 		"cortex_distributor_latest_seen_sample_timestamp_seconds",
+		"cortex_distributor_received_samples_per_labelset_total",
 	}
 
 	allMetrics := append(removedMetrics, permanentMetrics...)
@@ -438,6 +439,8 @@ func TestDistributor_MetricsCleanup(t *testing.T) {
 	d.nonHASamples.WithLabelValues("userA").Add(5)
 	d.dedupedSamples.WithLabelValues("userA", "cluster1").Inc() // We cannot clean this metric
 	d.latestSeenSampleTimestampPerUser.WithLabelValues("userA").Set(1111)
+	d.receivedSamplesPerLabelSet.WithLabelValues("userA", sampleMetricTypeFloat, "{}").Add(5)
+	d.receivedSamplesPerLabelSet.WithLabelValues("userA", sampleMetricTypeHistogram, "{}").Add(10)
 
 	h, _, _ := r.GetAllInstanceDescs(ring.WriteNoExtend)
 	ingId0, _ := r.GetInstanceIdByAddr(h[0].Addr)
@@ -472,6 +475,11 @@ func TestDistributor_MetricsCleanup(t *testing.T) {
 		# TYPE cortex_distributor_received_metadata_total counter
 		cortex_distributor_received_metadata_total{user="userA"} 5
 		cortex_distributor_received_metadata_total{user="userB"} 10
+
+		# HELP cortex_distributor_received_samples_per_labelset_total The total number of received samples per label set, excluding rejected and deduped samples.
+		# TYPE cortex_distributor_received_samples_per_labelset_total counter
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="userA"} 5
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="userA"} 10
 
 		# HELP cortex_distributor_received_samples_total The total number of received samples, excluding rejected and deduped samples.
 		# TYPE cortex_distributor_received_samples_total counter
@@ -4079,6 +4087,129 @@ func TestDistributor_Push_RelabelDropWillExportMetricOfDroppedSamples(t *testing
 			require.Equal(t, receivedHistogramSamples, float64(0))
 		}
 	}
+}
+
+func TestDistributor_PushLabelSetMetrics(t *testing.T) {
+	t.Parallel()
+	inputSeries := []labels.Labels{
+		{
+			{Name: "__name__", Value: "foo"},
+			{Name: "cluster", Value: "one"},
+		},
+		{
+			{Name: "__name__", Value: "bar"},
+			{Name: "cluster", Value: "one"},
+		},
+		{
+			{Name: "__name__", Value: "bar"},
+			{Name: "cluster", Value: "two"},
+		},
+		{
+			{Name: "__name__", Value: "foo"},
+			{Name: "cluster", Value: "three"},
+		},
+	}
+
+	var err error
+	var limits validation.Limits
+	flagext.DefaultValues(&limits)
+	limits.LimitsPerLabelSet = []validation.LimitsPerLabelSet{
+		{Hash: 0, LabelSet: labels.FromStrings("cluster", "one")},
+		{Hash: 1, LabelSet: labels.FromStrings("cluster", "two")},
+		{Hash: 2, LabelSet: labels.EmptyLabels()},
+	}
+
+	ds, _, regs, _ := prepare(t, prepConfig{
+		numIngesters:     2,
+		happyIngesters:   2,
+		numDistributors:  1,
+		shardByAllLabels: true,
+		limits:           &limits,
+	})
+	reg := regs[0]
+
+	// Push the series to the distributor
+	id := "user"
+	req := mockWriteRequest(inputSeries, 1, 1, false)
+	ctx := user.InjectOrgID(context.Background(), id)
+	_, err = ds[0].Push(ctx, req)
+	require.NoError(t, err)
+
+	ds[0].updateLabelSetMetrics()
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_distributor_received_samples_per_labelset_total The total number of received samples per label set, excluding rejected and deduped samples.
+		# TYPE cortex_distributor_received_samples_per_labelset_total counter
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"one\"}",type="float",user="user"} 2
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"one\"}",type="histogram",user="user"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"two\"}",type="float",user="user"} 1
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"two\"}",type="histogram",user="user"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="user"} 1
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="user"} 0
+		`), "cortex_distributor_received_samples_per_labelset_total"))
+
+	// Push more series.
+	inputSeries = []labels.Labels{
+		{
+			{Name: "__name__", Value: "baz"},
+			{Name: "cluster", Value: "two"},
+		},
+		{
+			{Name: "__name__", Value: "foo"},
+			{Name: "cluster", Value: "four"},
+		},
+	}
+	// Write the same request twice for different users.
+	req = mockWriteRequest(inputSeries, 1, 1, false)
+	ctx2 := user.InjectOrgID(context.Background(), "user2")
+	_, err = ds[0].Push(ctx, req)
+	require.NoError(t, err)
+	req = mockWriteRequest(inputSeries, 1, 1, false)
+	_, err = ds[0].Push(ctx2, req)
+	require.NoError(t, err)
+	ds[0].updateLabelSetMetrics()
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_distributor_received_samples_per_labelset_total The total number of received samples per label set, excluding rejected and deduped samples.
+		# TYPE cortex_distributor_received_samples_per_labelset_total counter
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"one\"}",type="float",user="user"} 2
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"one\"}",type="histogram",user="user"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"two\"}",type="float",user="user"} 2
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"two\"}",type="float",user="user2"} 1
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"two\"}",type="histogram",user="user"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"two\"}",type="histogram",user="user2"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="user"} 2
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="user2"} 1
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="user"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="user2"} 0
+		`), "cortex_distributor_received_samples_per_labelset_total"))
+
+	// Remove existing limits and add new limits
+	limits.LimitsPerLabelSet = []validation.LimitsPerLabelSet{
+		{Hash: 3, LabelSet: labels.FromStrings("cluster", "three")},
+		{Hash: 4, LabelSet: labels.FromStrings("cluster", "four")},
+		{Hash: 2, LabelSet: labels.EmptyLabels()},
+	}
+	ds[0].limits, err = validation.NewOverrides(limits, nil)
+	require.NoError(t, err)
+	ds[0].updateLabelSetMetrics()
+	// Old label set metrics are removed. New label set metrics will be added when
+	// new requests come in.
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_distributor_received_samples_per_labelset_total The total number of received samples per label set, excluding rejected and deduped samples.
+		# TYPE cortex_distributor_received_samples_per_labelset_total counter
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="user"} 2
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="user2"} 1
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="user"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="user2"} 0
+		`), "cortex_distributor_received_samples_per_labelset_total"))
+
+	// Metrics from `user` got removed but `user2` metric should remain.
+	ds[0].cleanupInactiveUser(id)
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_distributor_received_samples_per_labelset_total The total number of received samples per label set, excluding rejected and deduped samples.
+		# TYPE cortex_distributor_received_samples_per_labelset_total counter
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="user2"} 1
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="user2"} 0
+		`), "cortex_distributor_received_samples_per_labelset_total"))
 }
 
 func countMockIngestersCalls(ingesters []*mockIngester, name string) int {

--- a/pkg/distributor/metrics.go
+++ b/pkg/distributor/metrics.go
@@ -1,0 +1,105 @@
+package distributor
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/cortexproject/cortex/pkg/util"
+)
+
+const (
+	numMetricCounterShards = 128
+)
+
+type labelSetCounter struct {
+	shards []*labelSetCounterShard
+}
+
+func newLabelSetCounter() *labelSetCounter {
+	shards := make([]*labelSetCounterShard, 0, numMetricCounterShards)
+	for i := 0; i < numMetricCounterShards; i++ {
+		shards = append(shards, &labelSetCounterShard{
+			RWMutex:       &sync.RWMutex{},
+			valuesCounter: map[string]map[uint64]*samplesLabelSetEntry{},
+		})
+	}
+	return &labelSetCounter{shards: shards}
+}
+
+type labelSetCounterShard struct {
+	*sync.RWMutex
+	valuesCounter map[string]map[uint64]*samplesLabelSetEntry
+}
+
+type samplesLabelSetEntry struct {
+	floatSamples     int64
+	histogramSamples int64
+	labels           labels.Labels
+}
+
+func (s *samplesLabelSetEntry) reset() {
+	s.floatSamples = 0
+	s.histogramSamples = 0
+}
+
+func (m *labelSetCounter) increaseSamplesLabelSet(userId string, hash uint64, labelSet labels.Labels, floatSamples, histogramSamples int64) {
+	s := m.shards[util.HashFP(model.Fingerprint(hash))%numMetricCounterShards]
+	s.Lock()
+	defer s.Unlock()
+	if userEntry, ok := s.valuesCounter[userId]; ok {
+		if e, ok2 := userEntry[hash]; ok2 {
+			e.floatSamples += floatSamples
+			e.histogramSamples += histogramSamples
+		} else {
+			userEntry[hash] = &samplesLabelSetEntry{
+				floatSamples:     floatSamples,
+				histogramSamples: histogramSamples,
+				labels:           labelSet,
+			}
+		}
+	} else {
+		s.valuesCounter[userId] = map[uint64]*samplesLabelSetEntry{
+			hash: {
+				floatSamples:     floatSamples,
+				histogramSamples: histogramSamples,
+				labels:           labelSet,
+			},
+		}
+	}
+}
+
+func (m *labelSetCounter) updateMetrics(userSet map[string]map[uint64]struct{}, receivedSamplesPerLabelSet *prometheus.CounterVec) {
+	for i := 0; i < numMetricCounterShards; i++ {
+		shard := m.shards[i]
+		shard.Lock()
+
+		for user, userEntry := range shard.valuesCounter {
+			limits, ok := userSet[user]
+			if !ok {
+				// If user is removed, we will delete user metrics in cleanupInactiveUser loop
+				// so skip deleting metrics here.
+				delete(shard.valuesCounter, user)
+				continue
+			}
+			for h, entry := range userEntry {
+				labelSetStr := entry.labels.String()
+				// This limit no longer exists.
+				if _, ok := limits[h]; !ok {
+					delete(userEntry, h)
+					receivedSamplesPerLabelSet.DeleteLabelValues(user, sampleMetricTypeFloat, labelSetStr)
+					receivedSamplesPerLabelSet.DeleteLabelValues(user, sampleMetricTypeHistogram, labelSetStr)
+					continue
+				}
+				receivedSamplesPerLabelSet.WithLabelValues(user, sampleMetricTypeFloat, labelSetStr).Add(float64(entry.floatSamples))
+				receivedSamplesPerLabelSet.WithLabelValues(user, sampleMetricTypeHistogram, labelSetStr).Add(float64(entry.histogramSamples))
+				// Reset entry counter to 0. Delete it only if it is removed from the limit.
+				entry.reset()
+			}
+		}
+
+		shard.Unlock()
+	}
+}

--- a/pkg/distributor/metrics_test.go
+++ b/pkg/distributor/metrics_test.go
@@ -1,0 +1,122 @@
+package distributor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabelSetCounter(t *testing.T) {
+	counter := newLabelSetCounter()
+
+	metricName := "cortex_distributor_received_samples_per_labelset_total"
+	reg := prometheus.NewPedanticRegistry()
+	dummyCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: metricName,
+		Help: "",
+	}, []string{"user", "type", "labelset"})
+	reg.MustRegister(dummyCounter)
+
+	userID := "1"
+	userID2 := "2"
+	userID3 := "3"
+
+	counter.increaseSamplesLabelSet(userID, 0, labels.FromStrings("foo", "bar"), 10, 0)
+	counter.increaseSamplesLabelSet(userID, 1, labels.FromStrings("foo", "baz"), 0, 5)
+	counter.increaseSamplesLabelSet(userID, 3, labels.EmptyLabels(), 20, 20)
+	counter.increaseSamplesLabelSet(userID2, 0, labels.FromStrings("foo", "bar"), 100, 5)
+	counter.increaseSamplesLabelSet(userID2, 2, labels.FromStrings("cluster", "us-west-2"), 0, 100)
+
+	userSet := map[string]map[uint64]struct {
+	}{
+		userID:  {0: struct{}{}, 1: struct{}{}, 2: struct{}{}, 3: struct{}{}},
+		userID2: {0: struct{}{}, 1: struct{}{}, 2: struct{}{}, 3: struct{}{}},
+	}
+	counter.updateMetrics(userSet, dummyCounter)
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# TYPE cortex_distributor_received_samples_per_labelset_total counter
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"us-west-2\"}",type="float",user="2"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"us-west-2\"}",type="histogram",user="2"} 100
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="float",user="1"} 10
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="float",user="2"} 100
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="histogram",user="1"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="histogram",user="2"} 5
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"baz\"}",type="float",user="1"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"baz\"}",type="histogram",user="1"} 5
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="1"} 20
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="1"} 20
+		`), metricName))
+
+	// Increment metrics and add a new user.
+	counter.increaseSamplesLabelSet(userID, 3, labels.EmptyLabels(), 20, 20)
+	counter.increaseSamplesLabelSet(userID2, 2, labels.FromStrings("cluster", "us-west-2"), 0, 100)
+	counter.increaseSamplesLabelSet(userID2, 4, labels.FromStrings("cluster", "us-west-2"), 10, 10)
+	counter.increaseSamplesLabelSet(userID3, 4, labels.FromStrings("cluster", "us-east-1"), 30, 30)
+	userSet = map[string]map[uint64]struct {
+	}{
+		userID:  {0: struct{}{}, 1: struct{}{}, 2: struct{}{}, 3: struct{}{}},
+		userID2: {0: struct{}{}, 1: struct{}{}, 2: struct{}{}, 3: struct{}{}, 4: struct{}{}},
+		userID3: {0: struct{}{}, 1: struct{}{}, 2: struct{}{}, 3: struct{}{}, 4: struct{}{}},
+	}
+	counter.updateMetrics(userSet, dummyCounter)
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# TYPE cortex_distributor_received_samples_per_labelset_total counter
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"us-east-1\"}",type="float",user="3"} 30
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"us-east-1\"}",type="histogram",user="3"} 30
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"us-west-2\"}",type="float",user="2"} 10
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"us-west-2\"}",type="histogram",user="2"} 210
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="float",user="1"} 10
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="float",user="2"} 100
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="histogram",user="1"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="histogram",user="2"} 5
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"baz\"}",type="float",user="1"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"baz\"}",type="histogram",user="1"} 5
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="1"} 40
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="1"} 40
+		`), metricName))
+
+	// Remove user 2. But metrics for user 2 not cleaned up as it is expected to be cleaned up
+	// in cleanupInactiveUser loop. It is expected to have 3 minutes delay in this case.
+	delete(userSet, userID2)
+	counter.updateMetrics(userSet, dummyCounter)
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# TYPE cortex_distributor_received_samples_per_labelset_total counter
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"us-east-1\"}",type="float",user="3"} 30
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"us-east-1\"}",type="histogram",user="3"} 30
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"us-west-2\"}",type="float",user="2"} 10
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"us-west-2\"}",type="histogram",user="2"} 210
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="float",user="1"} 10
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="float",user="2"} 100
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="histogram",user="1"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="histogram",user="2"} 5
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"baz\"}",type="float",user="1"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"baz\"}",type="histogram",user="1"} 5
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="float",user="1"} 40
+		cortex_distributor_received_samples_per_labelset_total{labelset="{}",type="histogram",user="1"} 40
+		`), metricName))
+
+	// Simulate existing limits removed for each user.
+	userSet = map[string]map[uint64]struct {
+	}{
+		userID:  {0: struct{}{}},
+		userID2: {},
+		userID3: {},
+	}
+	counter.updateMetrics(userSet, dummyCounter)
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# TYPE cortex_distributor_received_samples_per_labelset_total counter
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"us-west-2\"}",type="float",user="2"} 10
+		cortex_distributor_received_samples_per_labelset_total{labelset="{cluster=\"us-west-2\"}",type="histogram",user="2"} 210
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="float",user="1"} 10
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="float",user="2"} 100
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="histogram",user="1"} 0
+		cortex_distributor_received_samples_per_labelset_total{labelset="{foo=\"bar\"}",type="histogram",user="2"} 5
+		`), metricName))
+}

--- a/pkg/util/active_user.go
+++ b/pkg/util/active_user.go
@@ -95,17 +95,14 @@ func (m *ActiveUsers) PurgeInactiveUsers(deadline int64) []string {
 }
 
 func (m *ActiveUsers) ActiveUsers(deadline int64) []string {
+	active := make([]string, 0, len(m.timestamps))
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	m.mu.RLock()
-	active := make([]string, 0, len(m.timestamps))
-
 	for userID, ts := range m.timestamps {
 		if ts.Load() > deadline {
 			active = append(active, userID)
 		}
 	}
-	m.mu.RUnlock()
 	return active
 }
 

--- a/pkg/util/active_user_test.go
+++ b/pkg/util/active_user_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"runtime"
+	"sort"
 	"strconv"
 	"sync"
 	"testing"
@@ -26,6 +27,28 @@ func TestActiveUser(t *testing.T) {
 	as.UpdateUserTimestamp("test1", 17)
 	require.Equal(t, []string{"test3"}, as.PurgeInactiveUsers(16))
 	require.Equal(t, []string{"test1"}, as.PurgeInactiveUsers(20))
+}
+
+func TestActiveUser_ActiveUsers(t *testing.T) {
+	as := NewActiveUsers()
+	as.UpdateUserTimestamp("test1", 5)
+	as.UpdateUserTimestamp("test2", 10)
+	as.UpdateUserTimestamp("test3", 15)
+
+	users := as.ActiveUsers(0)
+	sort.Strings(users)
+	require.Equal(t, []string{"test1", "test2", "test3"}, users)
+
+	users = as.ActiveUsers(5)
+	sort.Strings(users)
+	require.Equal(t, []string{"test2", "test3"}, users)
+
+	users = as.ActiveUsers(10)
+	sort.Strings(users)
+	require.Equal(t, []string{"test3"}, users)
+
+	users = as.ActiveUsers(15)
+	require.Equal(t, []string{}, users)
 }
 
 func TestActiveUserConcurrentUpdateAndPurge(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

With limits per label set change, we have visibility of usage of each label set in Ingester.

This PR adds new `cortex_distributor_received_samples_per_labelset_total` in distributor so that we can get ingestion rate per label set.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
