### PR TITLE
Create new `cortex_querier_codec_response_size` histogram to track the size of the encoded Query responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [ENHANCEMENT] Ingester: Make sure unregistered ingester joining the ring after WAL replay. #6277
 * [ENHANCEMENT] Distributor: Add a new `-distributor.num-push-workers` flag to use a goroutine worker pool when sending data from distributor to ingesters. #6406
 * [ENHANCEMENT] Ingester: If a limit per label set entry doesn't have any label, use it as the default partition to catch all series that doesn't match any other label sets entries. #6435
+* [ENHANCEMENT] Querier: Add new `cortex_querier_codec_response_size` metric to track the size of the encoded query responses from queriers. #6444
 * [BUGFIX] Runtime-config: Handle absolute file paths when working directory is not / #6224
 * [BUGFIX] Ruler: Allow rule evaluation to complete during shutdown. #6326
 * [BUGFIX] Ring: update ring with new ip address when instance is lost, rejoins, but heartbeat is disabled.  #6271

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -197,7 +197,7 @@ func NewQuerierHandler(
 	api := v1.NewAPI(
 		engine,
 		querier.NewErrorTranslateSampleAndChunkQueryable(queryable), // Translate errors to errors expected by API.
-		nil,                                                         // No remote write support.
+		nil, // No remote write support.
 		exemplarQueryable,
 		func(ctx context.Context) v1.ScrapePoolsRetriever { return nil },
 		func(context.Context) v1.TargetRetriever { return &querier.DummyTargetRetriever{} },
@@ -234,7 +234,7 @@ func NewQuerierHandler(
 	// Let's clear all codecs to create the instrumented ones
 	api.ClearCodecs()
 	cm := codec.NewInstrumentedCodecMetrics(reg)
-	
+
 	api.InstallCodec(codec.NewInstrumentedCodec(v1.JSONCodec{}, cm))
 	// Install Protobuf codec to give the option for using either.
 	api.InstallCodec(codec.NewInstrumentedCodec(codec.ProtobufCodec{CortexInternal: false}, cm))

--- a/pkg/querier/codec/instrumented_codec.go
+++ b/pkg/querier/codec/instrumented_codec.go
@@ -1,0 +1,57 @@
+package codec
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
+	"github.com/weaveworks/common/middleware"
+)
+
+type InstrumentedCodecMetrics struct {
+	responseSizeHistogram *prometheus.HistogramVec
+}
+
+func NewInstrumentedCodecMetrics(reg prometheus.Registerer) *InstrumentedCodecMetrics {
+	return &InstrumentedCodecMetrics{
+		responseSizeHistogram: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:                       "cortex",
+			Name:                            "querier_codec_response_size",
+			Help:                            "Size of the encoded prometheus response from the queriers.",
+			Buckets:                         middleware.BodySizeBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"content_type"}),
+	}
+}
+
+type InstrumentedCodec struct {
+	uc v1.Codec
+
+	metrics *InstrumentedCodecMetrics
+}
+
+func (c *InstrumentedCodec) ContentType() v1.MIMEType {
+	return c.uc.ContentType()
+}
+
+func (c *InstrumentedCodec) CanEncode(resp *v1.Response) bool {
+	return c.uc.CanEncode(resp)
+}
+
+func (c *InstrumentedCodec) Encode(resp *v1.Response) ([]byte, error) {
+	b, err := c.uc.Encode(resp)
+	if err == nil {
+		c.metrics.responseSizeHistogram.WithLabelValues(c.uc.ContentType().String()).Observe(float64(len((b))))
+	}
+	return b, err
+}
+
+func NewInstrumentedCodec(uc v1.Codec, m *InstrumentedCodecMetrics) v1.Codec {
+	return &InstrumentedCodec{
+		uc:      uc,
+		metrics: m,
+	}
+}


### PR DESCRIPTION
**What this PR does**:
We already have a similar metric `cortex_querier_response_message_bytes_bucket` but this metric shows the response size after the compression (gzip).

This new metric tracks the size of the request before the compression. This can be useful as the responses are decompressed on QF and it can cause OOM errors.

In a future PR we may wanna create an option to limit the size of the responses from Queriers, so we protect QF from OOM.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
