### PR TITLE
refactor bucket client to pass config directly

### DIFF
--- a/pkg/storage/bucket/azure/bucket_client.go
+++ b/pkg/storage/bucket/azure/bucket_client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/exthttp"
 	"github.com/thanos-io/objstore/providers/azure"
-	yaml "gopkg.in/yaml.v2"
 )
 
 func NewBucketClient(cfg Config, hedgedRoundTripper func(rt http.RoundTripper) http.RoundTripper, name string, logger log.Logger) (objstore.Bucket, error) {
@@ -32,12 +31,5 @@ func NewBucketClient(cfg Config, hedgedRoundTripper func(rt http.RoundTripper) h
 		},
 	}
 
-	// Thanos currently doesn't support passing the config as is, but expects a YAML,
-	// so we're going to serialize it.
-	serialized, err := yaml.Marshal(bucketConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return azure.NewBucket(logger, serialized, name, hedgedRoundTripper)
+	return azure.NewBucketWithConfig(logger, bucketConfig, name, hedgedRoundTripper)
 }

--- a/pkg/storage/bucket/gcs/bucket_client.go
+++ b/pkg/storage/bucket/gcs/bucket_client.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/gcs"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // NewBucketClient creates a new GCS bucket client
@@ -17,12 +16,5 @@ func NewBucketClient(ctx context.Context, cfg Config, hedgedRoundTripper func(rt
 		ServiceAccount: cfg.ServiceAccount.Value,
 	}
 
-	// Thanos currently doesn't support passing the config as is, but expects a YAML,
-	// so we're going to serialize it.
-	serialized, err := yaml.Marshal(bucketConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return gcs.NewBucket(ctx, logger, serialized, name, hedgedRoundTripper)
+	return gcs.NewBucketWithConfig(ctx, logger, bucketConfig, name, hedgedRoundTripper)
 }

--- a/pkg/storage/bucket/swift/bucket_client.go
+++ b/pkg/storage/bucket/swift/bucket_client.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/swift"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // NewBucketClient creates a new Swift bucket client
@@ -40,12 +39,5 @@ func NewBucketClient(cfg Config, hedgedRoundTripper func(rt http.RoundTripper) h
 		UseDynamicLargeObjects: false,
 	}
 
-	// Thanos currently doesn't support passing the config as is, but expects a YAML,
-	// so we're going to serialize it.
-	serialized, err := yaml.Marshal(bucketConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return swift.NewContainer(logger, serialized, hedgedRoundTripper)
+	return swift.NewContainerFromConfig(logger, &bucketConfig, false, hedgedRoundTripper)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR refactors bucket client init code to pass config directly to the Thanos instead of serializing it.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
