### PR TITLE
QFE: Fix @ modifier for subquery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * [BUGFIX] Ring: update ring with new ip address when instance is lost, rejoins, but heartbeat is disabled.  #6271
 * [BUGFIX] Ingester: Fix regression on usage of cortex_ingester_queried_chunks. #6398
 * [BUGFIX] Ingester: Fix possible race condition when `active series per LabelSet` is configured. #6409
+* [BUGFIX] Query Frontend: Fix @ modifier not being applied correctly on sub queries. #6450
 
 ## 1.18.1 2024-10-14
 

--- a/pkg/querier/tripperware/queryrange/split_by_interval.go
+++ b/pkg/querier/tripperware/queryrange/split_by_interval.go
@@ -110,6 +110,15 @@ func evaluateAtModifierFunction(query string, start, end int64) (string, error) 
 			}
 			selector.StartOrEnd = 0
 		}
+		if selector, ok := n.(*parser.SubqueryExpr); ok {
+			switch selector.StartOrEnd {
+			case parser.START:
+				selector.Timestamp = &start
+			case parser.END:
+				selector.Timestamp = &end
+			}
+			selector.StartOrEnd = 0
+		}
 		return nil
 	})
 	return expr.String(), err

--- a/pkg/querier/tripperware/queryrange/split_by_interval_test.go
+++ b/pkg/querier/tripperware/queryrange/split_by_interval_test.go
@@ -378,6 +378,14 @@ func Test_evaluateAtModifier(t *testing.T) {
 			[10m:])`,
 		},
 		{
+			in:       `irate(kube_pod_info{namespace="test"}[1h:1m] @ start())`,
+			expected: `irate(kube_pod_info{namespace="test"}[1h:1m] @ 1546300.800)`,
+		},
+		{
+			in:       `irate(kube_pod_info{namespace="test"} @ end()[1h:1m] @ start())`,
+			expected: `irate(kube_pod_info{namespace="test"} @ 1646300.800 [1h:1m] @ 1546300.800)`,
+		},
+		{
 			// parse error: @ modifier must be preceded by an instant vector selector or range vector selector or a subquery
 			in:                "sum(http_requests_total[5m]) @ 10.001",
 			expectedErrorCode: http.StatusBadRequest,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- Fixes @ modifier for sub query
- When sub queries are split by QFE, currently the @ modifier is not applied. This causes wrong results as the @ modifier will be applied on querier.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
