### PR TITLE
Avoid over allocating strings.Builder when creating cache key

### DIFF
--- a/pkg/storage/tsdb/expanded_postings_cache_test.go
+++ b/pkg/storage/tsdb/expanded_postings_cache_test.go
@@ -8,11 +8,42 @@ import (
 	"testing"
 	"time"
 
+	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 )
+
+func TestCacheKey(t *testing.T) {
+	blockID := ulid.MustNew(1, nil)
+	seed := "seed123"
+	matchers := []*labels.Matcher{
+		{
+			Type:  labels.MatchEqual,
+			Name:  "name_1",
+			Value: "value_1",
+		},
+		{
+			Type:  labels.MatchNotEqual,
+			Name:  "name_2",
+			Value: "value_2",
+		},
+		{
+			Type:  labels.MatchRegexp,
+			Name:  "name_3",
+			Value: "value_4",
+		},
+		{
+			Type:  labels.MatchNotRegexp,
+			Name:  "name_5",
+			Value: "value_4",
+		},
+	}
+	r := cacheKey(seed, blockID, matchers...)
+	require.Equal(t, "seed123|00000000010000000000000000|name_1=value_1|name_2!=value_2|name_3=~value_4|name_5!~value_4|", r)
+}
 
 func Test_ShouldFetchPromiseOnlyOnce(t *testing.T) {
 	cfg := PostingsCacheConfig{


### PR DESCRIPTION
**What this PR does**:
Small fix to avoid over-allocating the build when creating the cache key.


Before this change we were adding the blocks and seed size for every matcher while we only really use those values once per key.
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
