### PR TITLE
Create `cortex_ingester_expanded_postings_cache_miss` metric

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -5553,22 +5553,22 @@ func TestExpendedPostingsCache(t *testing.T) {
 
 			if c.expectedHeadPostingCall > 0 || c.expectedBlockPostingCall > 0 {
 				metric := `
-		# HELP cortex_ingester_expanded_postings_cache_requests Total number of requests to the cache.
-		# TYPE cortex_ingester_expanded_postings_cache_requests counter
+		# HELP cortex_ingester_expanded_postings_cache_requests_total Total number of requests to the cache.
+		# TYPE cortex_ingester_expanded_postings_cache_requests_total counter
 `
 				if c.expectedBlockPostingCall > 0 {
 					metric += `
-		cortex_ingester_expanded_postings_cache_requests{cache="block"} 4
+		cortex_ingester_expanded_postings_cache_requests_total{cache="block"} 4
 `
 				}
 
 				if c.expectedHeadPostingCall > 0 {
 					metric += `
-		cortex_ingester_expanded_postings_cache_requests{cache="head"} 4
+		cortex_ingester_expanded_postings_cache_requests_total{cache="head"} 4
 `
 				}
 
-				err = testutil.GatherAndCompare(r, bytes.NewBufferString(metric), "cortex_ingester_expanded_postings_cache_requests")
+				err = testutil.GatherAndCompare(r, bytes.NewBufferString(metric), "cortex_ingester_expanded_postings_cache_requests_total")
 				require.NoError(t, err)
 			}
 
@@ -5583,22 +5583,22 @@ func TestExpendedPostingsCache(t *testing.T) {
 
 			if c.expectedHeadPostingCall > 0 || c.expectedBlockPostingCall > 0 {
 				metric := `
-		# HELP cortex_ingester_expanded_postings_cache_hits Total number of hit requests to the cache.
-		# TYPE cortex_ingester_expanded_postings_cache_hits counter
+		# HELP cortex_ingester_expanded_postings_cache_hits_total Total number of hit requests to the cache.
+		# TYPE cortex_ingester_expanded_postings_cache_hits_total counter
 `
 				if c.expectedBlockPostingCall > 0 {
 					metric += `
-		cortex_ingester_expanded_postings_cache_hits{cache="block"} 4
+		cortex_ingester_expanded_postings_cache_hits_total{cache="block"} 4
 `
 				}
 
 				if c.expectedHeadPostingCall > 0 {
 					metric += `
-		cortex_ingester_expanded_postings_cache_hits{cache="head"} 4
+		cortex_ingester_expanded_postings_cache_hits_total{cache="head"} 4
 `
 				}
 
-				err = testutil.GatherAndCompare(r, bytes.NewBufferString(metric), "cortex_ingester_expanded_postings_cache_hits")
+				err = testutil.GatherAndCompare(r, bytes.NewBufferString(metric), "cortex_ingester_expanded_postings_cache_hits_total")
 				require.NoError(t, err)
 			}
 
@@ -5644,10 +5644,10 @@ func TestExpendedPostingsCache(t *testing.T) {
 			require.Equal(t, postingsForMatchersCalls.Load(), int64(c.expectedBlockPostingCall))
 			if c.cacheConfig.Head.Enabled {
 				err = testutil.GatherAndCompare(r, bytes.NewBufferString(`
-		# HELP cortex_ingester_expanded_postings_non_cacheable_queries Total number of non cacheable queries.
-		# TYPE cortex_ingester_expanded_postings_non_cacheable_queries counter
-        cortex_ingester_expanded_postings_non_cacheable_queries{cache="head"} 1
-`), "cortex_ingester_expanded_postings_non_cacheable_queries")
+		# HELP cortex_ingester_expanded_postings_non_cacheable_queries_total Total number of non cacheable queries.
+		# TYPE cortex_ingester_expanded_postings_non_cacheable_queries_total counter
+        cortex_ingester_expanded_postings_non_cacheable_queries_total{cache="head"} 1
+`), "cortex_ingester_expanded_postings_non_cacheable_queries_total")
 				require.NoError(t, err)
 			}
 

--- a/pkg/storage/tsdb/expanded_postings_cache.go
+++ b/pkg/storage/tsdb/expanded_postings_cache.go
@@ -47,23 +47,23 @@ type ExpandedPostingsCacheMetrics struct {
 func NewPostingCacheMetrics(r prometheus.Registerer) *ExpandedPostingsCacheMetrics {
 	return &ExpandedPostingsCacheMetrics{
 		CacheRequests: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ingester_expanded_postings_cache_requests",
+			Name: "cortex_ingester_expanded_postings_cache_requests_total",
 			Help: "Total number of requests to the cache.",
 		}, []string{"cache"}),
 		CacheHits: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ingester_expanded_postings_cache_hits",
+			Name: "cortex_ingester_expanded_postings_cache_hits_total",
 			Help: "Total number of hit requests to the cache.",
 		}, []string{"cache"}),
 		CacheMiss: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ingester_expanded_postings_cache_miss",
+			Name: "cortex_ingester_expanded_postings_cache_miss_total",
 			Help: "Total number of miss requests to the cache.",
 		}, []string{"cache", "reason"}),
 		CacheEvicts: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ingester_expanded_postings_cache_evicts",
+			Name: "cortex_ingester_expanded_postings_cache_evicts_total",
 			Help: "Total number of evictions in the cache, excluding items that got evicted due to TTL.",
 		}, []string{"cache", "reason"}),
 		NonCacheableQueries: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ingester_expanded_postings_non_cacheable_queries",
+			Name: "cortex_ingester_expanded_postings_non_cacheable_queries_total",
 			Help: "Total number of non cacheable queries.",
 		}, []string{"cache"}),
 	}

--- a/pkg/storage/tsdb/expanded_postings_cache_test.go
+++ b/pkg/storage/tsdb/expanded_postings_cache_test.go
@@ -181,10 +181,11 @@ func TestFifoCacheExpire(t *testing.T) {
 				}
 
 				err := testutil.GatherAndCompare(r, bytes.NewBufferString(fmt.Sprintf(`
-		# HELP cortex_ingester_expanded_postings_cache_evicts Total number of evictions in the cache, excluding items that got evicted due to TTL.
-		# TYPE cortex_ingester_expanded_postings_cache_evicts counter
-        cortex_ingester_expanded_postings_cache_evicts{cache="test",reason="expired"} %v
-`, numberOfKeys)), "cortex_ingester_expanded_postings_cache_evicts")
+		# HELP cortex_ingester_expanded_postings_cache_miss Total number of miss requests to the cache.
+		# TYPE cortex_ingester_expanded_postings_cache_miss counter
+		cortex_ingester_expanded_postings_cache_miss{cache="test",reason="expired"} %v
+		cortex_ingester_expanded_postings_cache_miss{cache="test",reason="miss"} %v
+`, numberOfKeys, numberOfKeys)), "cortex_ingester_expanded_postings_cache_miss")
 				require.NoError(t, err)
 
 				cache.timeNow = func() time.Time {
@@ -195,12 +196,12 @@ func TestFifoCacheExpire(t *testing.T) {
 					return 2, 18, nil
 				})
 
-				// Should expire all keys again as ttl is expired
+				// Should expire all keys expired keys
 				err = testutil.GatherAndCompare(r, bytes.NewBufferString(fmt.Sprintf(`
 		# HELP cortex_ingester_expanded_postings_cache_evicts Total number of evictions in the cache, excluding items that got evicted due to TTL.
 		# TYPE cortex_ingester_expanded_postings_cache_evicts counter
         cortex_ingester_expanded_postings_cache_evicts{cache="test",reason="expired"} %v
-`, numberOfKeys*2)), "cortex_ingester_expanded_postings_cache_evicts")
+`, numberOfKeys)), "cortex_ingester_expanded_postings_cache_evicts")
 				require.NoError(t, err)
 			}
 		})

--- a/pkg/storage/tsdb/expanded_postings_cache_test.go
+++ b/pkg/storage/tsdb/expanded_postings_cache_test.go
@@ -154,10 +154,10 @@ func TestFifoCacheExpire(t *testing.T) {
 
 			if c.expectedFinalItems != numberOfKeys {
 				err := testutil.GatherAndCompare(r, bytes.NewBufferString(fmt.Sprintf(`
-		# HELP cortex_ingester_expanded_postings_cache_evicts Total number of evictions in the cache, excluding items that got evicted due to TTL.
-		# TYPE cortex_ingester_expanded_postings_cache_evicts counter
-        cortex_ingester_expanded_postings_cache_evicts{cache="test",reason="full"} %v
-`, numberOfKeys-c.expectedFinalItems)), "cortex_ingester_expanded_postings_cache_evicts")
+		# HELP cortex_ingester_expanded_postings_cache_evicts_total Total number of evictions in the cache, excluding items that got evicted due to TTL.
+		# TYPE cortex_ingester_expanded_postings_cache_evicts_total counter
+        cortex_ingester_expanded_postings_cache_evicts_total{cache="test",reason="full"} %v
+`, numberOfKeys-c.expectedFinalItems)), "cortex_ingester_expanded_postings_cache_evicts_total")
 				require.NoError(t, err)
 
 			}
@@ -181,11 +181,11 @@ func TestFifoCacheExpire(t *testing.T) {
 				}
 
 				err := testutil.GatherAndCompare(r, bytes.NewBufferString(fmt.Sprintf(`
-		# HELP cortex_ingester_expanded_postings_cache_miss Total number of miss requests to the cache.
-		# TYPE cortex_ingester_expanded_postings_cache_miss counter
-		cortex_ingester_expanded_postings_cache_miss{cache="test",reason="expired"} %v
-		cortex_ingester_expanded_postings_cache_miss{cache="test",reason="miss"} %v
-`, numberOfKeys, numberOfKeys)), "cortex_ingester_expanded_postings_cache_miss")
+		# HELP cortex_ingester_expanded_postings_cache_miss_total Total number of miss requests to the cache.
+		# TYPE cortex_ingester_expanded_postings_cache_miss_total counter
+		cortex_ingester_expanded_postings_cache_miss_total{cache="test",reason="expired"} %v
+		cortex_ingester_expanded_postings_cache_miss_total{cache="test",reason="miss"} %v
+`, numberOfKeys, numberOfKeys)), "cortex_ingester_expanded_postings_cache_miss_total")
 				require.NoError(t, err)
 
 				cache.timeNow = func() time.Time {
@@ -198,10 +198,10 @@ func TestFifoCacheExpire(t *testing.T) {
 
 				// Should expire all keys expired keys
 				err = testutil.GatherAndCompare(r, bytes.NewBufferString(fmt.Sprintf(`
-		# HELP cortex_ingester_expanded_postings_cache_evicts Total number of evictions in the cache, excluding items that got evicted due to TTL.
-		# TYPE cortex_ingester_expanded_postings_cache_evicts counter
-        cortex_ingester_expanded_postings_cache_evicts{cache="test",reason="expired"} %v
-`, numberOfKeys)), "cortex_ingester_expanded_postings_cache_evicts")
+		# HELP cortex_ingester_expanded_postings_cache_evicts_total Total number of evictions in the cache, excluding items that got evicted due to TTL.
+		# TYPE cortex_ingester_expanded_postings_cache_evicts_total counter
+        cortex_ingester_expanded_postings_cache_evicts_total{cache="test",reason="expired"} %v
+`, numberOfKeys)), "cortex_ingester_expanded_postings_cache_evicts_total")
 				require.NoError(t, err)
 			}
 		})


### PR DESCRIPTION
**What this PR does**:

Before this PR, the cache miss due `expired` as counted in the eviction metric, but the cache entry was not really evicted at that point, but rather replaced. This new metric will help to understand if increasing the "ttl" would help the cache hit ratio or not.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
