### PR TITLE
remove multiple dots in redis flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * [BUGFIX] Ingester: Fix regression on usage of cortex_ingester_queried_chunks. #6398
 * [BUGFIX] Ingester: Fix possible race condition when `active series per LabelSet` is configured. #6409
 * [BUGFIX] Query Frontend: Fix @ modifier not being applied correctly on sub queries. #6450
-* [BUGFIX] Cortex Redis flags with multiple dots #6459
+* [BUGFIX] Cortex Redis flags with multiple dots #6476 
 
 ## 1.18.1 2024-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * [BUGFIX] Ingester: Fix regression on usage of cortex_ingester_queried_chunks. #6398
 * [BUGFIX] Ingester: Fix possible race condition when `active series per LabelSet` is configured. #6409
 * [BUGFIX] Query Frontend: Fix @ modifier not being applied correctly on sub queries. #6450
-* [BUGFIX] Cortex Redis flags with multiple dots #6476 
+* [BUGFIX] Cortex Redis flags with multiple dots #6476
 
 ## 1.18.1 2024-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [BUGFIX] Ingester: Fix regression on usage of cortex_ingester_queried_chunks. #6398
 * [BUGFIX] Ingester: Fix possible race condition when `active series per LabelSet` is configured. #6409
 * [BUGFIX] Query Frontend: Fix @ modifier not being applied correctly on sub queries. #6450
+* [BUGFIX] Cortex Redis flags with multiple dots #6459
 
 ## 1.18.1 2024-10-14
 

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -755,25 +755,25 @@ blocks_storage:
         # Path to the client certificate file, which will be used for
         # authenticating with the server. Also requires the key path to be
         # configured.
-        # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-cert-path
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-cert-path
         [tls_cert_path: <string> | default = ""]
 
         # Path to the key file for the client certificate. Also requires the
         # client certificate to be configured.
-        # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-key-path
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-key-path
         [tls_key_path: <string> | default = ""]
 
         # Path to the CA certificates file to validate server certificate
         # against. If not set, the host's root CA certificates are used.
-        # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-ca-path
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-ca-path
         [tls_ca_path: <string> | default = ""]
 
         # Override the expected name on the server certificate.
-        # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-server-name
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-server-name
         [tls_server_name: <string> | default = ""]
 
         # Skip validating server certificate.
-        # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-insecure-skip-verify
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-insecure-skip-verify
         [tls_insecure_skip_verify: <boolean> | default = false]
 
         # If not zero then client-side caching is enabled. Client-side caching
@@ -990,25 +990,25 @@ blocks_storage:
         # Path to the client certificate file, which will be used for
         # authenticating with the server. Also requires the key path to be
         # configured.
-        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-cert-path
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-cert-path
         [tls_cert_path: <string> | default = ""]
 
         # Path to the key file for the client certificate. Also requires the
         # client certificate to be configured.
-        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-key-path
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-key-path
         [tls_key_path: <string> | default = ""]
 
         # Path to the CA certificates file to validate server certificate
         # against. If not set, the host's root CA certificates are used.
-        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-ca-path
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-ca-path
         [tls_ca_path: <string> | default = ""]
 
         # Override the expected name on the server certificate.
-        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-server-name
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-server-name
         [tls_server_name: <string> | default = ""]
 
         # Skip validating server certificate.
-        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-insecure-skip-verify
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-insecure-skip-verify
         [tls_insecure_skip_verify: <boolean> | default = false]
 
         # If not zero then client-side caching is enabled. Client-side caching
@@ -1231,25 +1231,25 @@ blocks_storage:
         # Path to the client certificate file, which will be used for
         # authenticating with the server. Also requires the key path to be
         # configured.
-        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-cert-path
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-cert-path
         [tls_cert_path: <string> | default = ""]
 
         # Path to the key file for the client certificate. Also requires the
         # client certificate to be configured.
-        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-key-path
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-key-path
         [tls_key_path: <string> | default = ""]
 
         # Path to the CA certificates file to validate server certificate
         # against. If not set, the host's root CA certificates are used.
-        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-ca-path
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-ca-path
         [tls_ca_path: <string> | default = ""]
 
         # Override the expected name on the server certificate.
-        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-server-name
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-server-name
         [tls_server_name: <string> | default = ""]
 
         # Skip validating server certificate.
-        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-insecure-skip-verify
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-insecure-skip-verify
         [tls_insecure_skip_verify: <boolean> | default = false]
 
         # If not zero then client-side caching is enabled. Client-side caching

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -859,25 +859,25 @@ blocks_storage:
         # Path to the client certificate file, which will be used for
         # authenticating with the server. Also requires the key path to be
         # configured.
-        # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-cert-path
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-cert-path
         [tls_cert_path: <string> | default = ""]
 
         # Path to the key file for the client certificate. Also requires the
         # client certificate to be configured.
-        # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-key-path
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-key-path
         [tls_key_path: <string> | default = ""]
 
         # Path to the CA certificates file to validate server certificate
         # against. If not set, the host's root CA certificates are used.
-        # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-ca-path
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-ca-path
         [tls_ca_path: <string> | default = ""]
 
         # Override the expected name on the server certificate.
-        # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-server-name
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-server-name
         [tls_server_name: <string> | default = ""]
 
         # Skip validating server certificate.
-        # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-insecure-skip-verify
+        # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-insecure-skip-verify
         [tls_insecure_skip_verify: <boolean> | default = false]
 
         # If not zero then client-side caching is enabled. Client-side caching
@@ -1094,25 +1094,25 @@ blocks_storage:
         # Path to the client certificate file, which will be used for
         # authenticating with the server. Also requires the key path to be
         # configured.
-        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-cert-path
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-cert-path
         [tls_cert_path: <string> | default = ""]
 
         # Path to the key file for the client certificate. Also requires the
         # client certificate to be configured.
-        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-key-path
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-key-path
         [tls_key_path: <string> | default = ""]
 
         # Path to the CA certificates file to validate server certificate
         # against. If not set, the host's root CA certificates are used.
-        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-ca-path
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-ca-path
         [tls_ca_path: <string> | default = ""]
 
         # Override the expected name on the server certificate.
-        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-server-name
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-server-name
         [tls_server_name: <string> | default = ""]
 
         # Skip validating server certificate.
-        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-insecure-skip-verify
+        # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-insecure-skip-verify
         [tls_insecure_skip_verify: <boolean> | default = false]
 
         # If not zero then client-side caching is enabled. Client-side caching
@@ -1335,25 +1335,25 @@ blocks_storage:
         # Path to the client certificate file, which will be used for
         # authenticating with the server. Also requires the key path to be
         # configured.
-        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-cert-path
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-cert-path
         [tls_cert_path: <string> | default = ""]
 
         # Path to the key file for the client certificate. Also requires the
         # client certificate to be configured.
-        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-key-path
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-key-path
         [tls_key_path: <string> | default = ""]
 
         # Path to the CA certificates file to validate server certificate
         # against. If not set, the host's root CA certificates are used.
-        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-ca-path
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-ca-path
         [tls_ca_path: <string> | default = ""]
 
         # Override the expected name on the server certificate.
-        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-server-name
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-server-name
         [tls_server_name: <string> | default = ""]
 
         # Skip validating server certificate.
-        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-insecure-skip-verify
+        # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-insecure-skip-verify
         [tls_insecure_skip_verify: <boolean> | default = false]
 
         # If not zero then client-side caching is enabled. Client-side caching

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1299,25 +1299,25 @@ bucket_store:
       # Path to the client certificate file, which will be used for
       # authenticating with the server. Also requires the key path to be
       # configured.
-      # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-cert-path
+      # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-cert-path
       [tls_cert_path: <string> | default = ""]
 
       # Path to the key file for the client certificate. Also requires the
       # client certificate to be configured.
-      # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-key-path
+      # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-key-path
       [tls_key_path: <string> | default = ""]
 
       # Path to the CA certificates file to validate server certificate against.
       # If not set, the host's root CA certificates are used.
-      # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-ca-path
+      # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-ca-path
       [tls_ca_path: <string> | default = ""]
 
       # Override the expected name on the server certificate.
-      # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-server-name
+      # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-server-name
       [tls_server_name: <string> | default = ""]
 
       # Skip validating server certificate.
-      # CLI flag: -blocks-storage.bucket-store.index-cache.redis..tls-insecure-skip-verify
+      # CLI flag: -blocks-storage.bucket-store.index-cache.redis.tls-insecure-skip-verify
       [tls_insecure_skip_verify: <boolean> | default = false]
 
       # If not zero then client-side caching is enabled. Client-side caching is
@@ -1532,25 +1532,25 @@ bucket_store:
       # Path to the client certificate file, which will be used for
       # authenticating with the server. Also requires the key path to be
       # configured.
-      # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-cert-path
+      # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-cert-path
       [tls_cert_path: <string> | default = ""]
 
       # Path to the key file for the client certificate. Also requires the
       # client certificate to be configured.
-      # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-key-path
+      # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-key-path
       [tls_key_path: <string> | default = ""]
 
       # Path to the CA certificates file to validate server certificate against.
       # If not set, the host's root CA certificates are used.
-      # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-ca-path
+      # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-ca-path
       [tls_ca_path: <string> | default = ""]
 
       # Override the expected name on the server certificate.
-      # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-server-name
+      # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-server-name
       [tls_server_name: <string> | default = ""]
 
       # Skip validating server certificate.
-      # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis..tls-insecure-skip-verify
+      # CLI flag: -blocks-storage.bucket-store.chunks-cache.redis.tls-insecure-skip-verify
       [tls_insecure_skip_verify: <boolean> | default = false]
 
       # If not zero then client-side caching is enabled. Client-side caching is
@@ -1770,25 +1770,25 @@ bucket_store:
       # Path to the client certificate file, which will be used for
       # authenticating with the server. Also requires the key path to be
       # configured.
-      # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-cert-path
+      # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-cert-path
       [tls_cert_path: <string> | default = ""]
 
       # Path to the key file for the client certificate. Also requires the
       # client certificate to be configured.
-      # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-key-path
+      # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-key-path
       [tls_key_path: <string> | default = ""]
 
       # Path to the CA certificates file to validate server certificate against.
       # If not set, the host's root CA certificates are used.
-      # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-ca-path
+      # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-ca-path
       [tls_ca_path: <string> | default = ""]
 
       # Override the expected name on the server certificate.
-      # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-server-name
+      # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-server-name
       [tls_server_name: <string> | default = ""]
 
       # Skip validating server certificate.
-      # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis..tls-insecure-skip-verify
+      # CLI flag: -blocks-storage.bucket-store.metadata-cache.redis.tls-insecure-skip-verify
       [tls_insecure_skip_verify: <boolean> | default = false]
 
       # If not zero then client-side caching is enabled. Client-side caching is

--- a/pkg/storage/tsdb/redis_client_config.go
+++ b/pkg/storage/tsdb/redis_client_config.go
@@ -2,7 +2,6 @@ package tsdb
 
 import (
 	"flag"
-
 	"time"
 
 	"github.com/pkg/errors"
@@ -60,7 +59,7 @@ func (cfg *RedisClientConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix st
 	f.StringVar(&cfg.MasterName, prefix+"master-name", "", "Specifies the master's name. Must be not empty for Redis Sentinel.")
 	f.IntVar(&cfg.CacheSize, prefix+"cache-size", 0, "If not zero then client-side caching is enabled. Client-side caching is when data is stored in memory instead of fetching data each time. See https://redis.io/docs/manual/client-side-caching/ for more info.")
 	f.BoolVar(&cfg.TLSEnabled, prefix+"tls-enabled", false, "Whether to enable tls for redis connection.")
-	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
+	cfg.TLS.RegisterFlagsWithPrefix(prefix[:len(prefix)-1], f)
 	cfg.SetAsyncCircuitBreaker.RegisterFlagsWithPrefix(f, prefix+"set-async.")
 }
 


### PR DESCRIPTION
Fixes  #[6459](https://github.com/cortexproject/cortex/issues/6459)

```
cortex/cmd/cortex$ go run main.go -help | grep redis | grep tls
  -blocks-storage.bucket-store.chunks-cache.redis.tls-ca-path string
  -blocks-storage.bucket-store.chunks-cache.redis.tls-cert-path string
  -blocks-storage.bucket-store.chunks-cache.redis.tls-enabled
        Whether to enable tls for redis connection.
  -blocks-storage.bucket-store.chunks-cache.redis.tls-insecure-skip-verify
  -blocks-storage.bucket-store.chunks-cache.redis.tls-key-path string
  -blocks-storage.bucket-store.chunks-cache.redis.tls-server-name string
  -blocks-storage.bucket-store.index-cache.redis.tls-ca-path string
  -blocks-storage.bucket-store.index-cache.redis.tls-cert-path string
  -blocks-storage.bucket-store.index-cache.redis.tls-enabled
        Whether to enable tls for redis connection.
  -blocks-storage.bucket-store.index-cache.redis.tls-insecure-skip-verify
  -blocks-storage.bucket-store.index-cache.redis.tls-key-path string
  -blocks-storage.bucket-store.index-cache.redis.tls-server-name string
  -blocks-storage.bucket-store.metadata-cache.redis.tls-ca-path string
  -blocks-storage.bucket-store.metadata-cache.redis.tls-cert-path string
  -blocks-storage.bucket-store.metadata-cache.redis.tls-enabled
        Whether to enable tls for redis connection.
  -blocks-storage.bucket-store.metadata-cache.redis.tls-insecure-skip-verify
  -blocks-storage.bucket-store.metadata-cache.redis.tls-key-path string
  -blocks-storage.bucket-store.metadata-cache.redis.tls-server-name string
  -frontend.redis.tls-enabled
  -frontend.redis.tls-insecure-skip-verify
```