### PR TITLE
Share Config for Expanded Postings Cache Size Across All Tenants

### DIFF
--- a/pkg/storage/tsdb/expanded_postings_cache.go
+++ b/pkg/storage/tsdb/expanded_postings_cache.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/oklog/ulid"
@@ -19,6 +18,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/segmentio/fasthash/fnv1a"
+	"go.uber.org/atomic"
 
 	"github.com/cortexproject/cortex/pkg/util/extract"
 	logutil "github.com/cortexproject/cortex/pkg/util/log"

--- a/pkg/storage/tsdb/expanded_postings_cache_test.go
+++ b/pkg/storage/tsdb/expanded_postings_cache_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 func TestCacheKey(t *testing.T) {


### PR DESCRIPTION

**What this PR does**:
For Cortex clusters with a large number of tenants, the cache size can grow unbounded.

This PR modifies the configuration to make the cache size a global setting shared across all tenants.

Since this configuration is still experimental and hasn't been officially released, i think it's ok to adjust its behavior at this stage.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
