### PR TITLE
Purge expired postings cache items due inactivity

### DIFF
--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -30,7 +30,7 @@ const (
 	// How often are open TSDBs checked for being idle and closed.
 	DefaultCloseIdleTSDBInterval = 5 * time.Minute
 
-	// How often we should proactively expire expired cache entries
+	// How often expired items are cleaned from the PostingsCache
 	ExpandedCachingExpireInterval = 5 * time.Minute
 
 	// How often to check for tenant deletion mark.
@@ -159,7 +159,7 @@ type TSDBConfig struct {
 	// How often to check for idle TSDBs for closing. DefaultCloseIdleTSDBInterval is not suitable for testing, so tests can override.
 	CloseIdleTSDBInterval time.Duration `yaml:"-"`
 
-	// How often are open TSDBs checked for being idle and closed. ExpandedCachingExpireInterval is not suitable for testing, so tests can override.
+	// How often expired items are cleaned from the PostingsCache. ExpandedCachingExpireInterval is not suitable for testing, so tests can override.
 	ExpandedCachingExpireInterval time.Duration `yaml:"-"`
 
 	// Positive value enables experimental support for exemplars. 0 or less to disable.

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -30,6 +30,9 @@ const (
 	// How often are open TSDBs checked for being idle and closed.
 	DefaultCloseIdleTSDBInterval = 5 * time.Minute
 
+	// How often we should proactively expire expired cache entries
+	ExpandedCachingExpireInterval = 5 * time.Minute
+
 	// How often to check for tenant deletion mark.
 	DeletionMarkCheckInterval = 1 * time.Hour
 
@@ -155,6 +158,9 @@ type TSDBConfig struct {
 
 	// How often to check for idle TSDBs for closing. DefaultCloseIdleTSDBInterval is not suitable for testing, so tests can override.
 	CloseIdleTSDBInterval time.Duration `yaml:"-"`
+
+	// How often are open TSDBs checked for being idle and closed. ExpandedCachingExpireInterval is not suitable for testing, so tests can override.
+	ExpandedCachingExpireInterval time.Duration `yaml:"-"`
 
 	// Positive value enables experimental support for exemplars. 0 or less to disable.
 	MaxExemplars int `yaml:"max_exemplars"`

--- a/pkg/storage/tsdb/expanded_postings_cache.go
+++ b/pkg/storage/tsdb/expanded_postings_cache.go
@@ -124,6 +124,8 @@ func (f *ExpandedPostingsCacheFactory) NewExpandedPostingsCache(userId string, m
 type ExpandedPostingsCache interface {
 	PostingsForMatchers(ctx context.Context, blockID ulid.ULID, ix tsdb.IndexReader, ms ...*labels.Matcher) (index.Postings, error)
 	ExpireSeries(metric labels.Labels)
+	PurgeExpiredItems()
+	Size() int
 }
 
 type blocksPostingsForMatchersCache struct {
@@ -164,6 +166,15 @@ func (c *blocksPostingsForMatchersCache) ExpireSeries(metric labels.Labels) {
 		return
 	}
 	c.seedByHash.incrementSeed(c.userId, metricName)
+}
+
+func (c *blocksPostingsForMatchersCache) PurgeExpiredItems() {
+	c.headCache.expire()
+	c.blocksCache.expire()
+}
+
+func (c *blocksPostingsForMatchersCache) Size() int {
+	return c.headCache.size() + c.blocksCache.size()
 }
 
 func (c *blocksPostingsForMatchersCache) PostingsForMatchers(ctx context.Context, blockID ulid.ULID, ix tsdb.IndexReader, ms ...*labels.Matcher) (index.Postings, error) {
@@ -363,6 +374,12 @@ func (c *fifoCache[V]) expire() {
 		c.metrics.CacheEvicts.WithLabelValues(c.name, reason).Inc()
 		c.evictHead()
 	}
+}
+
+func (c *fifoCache[V]) size() int {
+	c.cachedMtx.RLock()
+	defer c.cachedMtx.RUnlock()
+	return c.cached.Len()
 }
 
 func (c *fifoCache[V]) getPromiseForKey(k string, fetch func() (V, int64, error)) (*cacheEntryPromise[V], bool) {


### PR DESCRIPTION
**What this PR does**:
Create a background routine to purge expired items from the postings cache.

Before this change, items can linger indefinitely in the cache if no new items were aded.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
