### PR TITLE
calculate # of concurrency only once at the runner

### DIFF
--- a/pkg/util/concurrency/runner.go
+++ b/pkg/util/concurrency/runner.go
@@ -29,7 +29,8 @@ func ForEachUser(ctx context.Context, userIDs []string, concurrency int, userFun
 	errsMx := sync.Mutex{}
 
 	wg := sync.WaitGroup{}
-	for ix := 0; ix < min(concurrency, len(userIDs)); ix++ {
+	routines := min(concurrency, len(userIDs))
+	for ix := 0; ix < routines; ix++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -75,7 +76,8 @@ func ForEach(ctx context.Context, jobs []interface{}, concurrency int, jobFunc f
 
 	// Start workers to process jobs.
 	g, ctx := errgroup.WithContext(ctx)
-	for ix := 0; ix < min(concurrency, len(jobs)); ix++ {
+	routines := min(concurrency, len(jobs))
+	for ix := 0; ix < routines; ix++ {
 		g.Go(func() error {
 			for job := range ch {
 				if err := ctx.Err(); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR changes to calculate # of go-routines only once on the `runner`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
