### PR TITLE
Hook up partition compaction end to end implementation

### DIFF
--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -132,8 +132,6 @@ func newSingleBinary(name string, servername string, join string, testFlags map[
 			"-memberlist.left-ingesters-timeout": "600s", // effectively disable
 			// alert manager
 			"-alertmanager.web.external-url": "http://localhost/alertmanager",
-			// compactor
-			"-compactor.compaction-interval": "1s", // allow stopping quickly
 		},
 	)
 

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -132,6 +132,8 @@ func newSingleBinary(name string, servername string, join string, testFlags map[
 			"-memberlist.left-ingesters-timeout": "600s", // effectively disable
 			// alert manager
 			"-alertmanager.web.external-url": "http://localhost/alertmanager",
+			// compactor
+			"-compactor.compaction-interval": "1s", // allow stopping quickly
 		},
 	)
 

--- a/pkg/compactor/background_chunks_series_set.go
+++ b/pkg/compactor/background_chunks_series_set.go
@@ -1,0 +1,60 @@
+package compactor
+
+import (
+	"context"
+
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+type backgrounChunkSeriesSet struct {
+	nextSet chan storage.ChunkSeries
+	actual  storage.ChunkSeries
+	cs      storage.ChunkSeriesSet
+}
+
+func (b *backgrounChunkSeriesSet) Next() bool {
+	s, ok := <-b.nextSet
+	b.actual = s
+	return ok
+}
+
+func (b *backgrounChunkSeriesSet) At() storage.ChunkSeries {
+	return b.actual
+}
+
+func (b *backgrounChunkSeriesSet) Err() error {
+	return b.cs.Err()
+}
+
+func (b *backgrounChunkSeriesSet) Warnings() annotations.Annotations {
+	return b.cs.Warnings()
+}
+
+func (b *backgrounChunkSeriesSet) run(ctx context.Context) {
+	for {
+		if !b.cs.Next() {
+			close(b.nextSet)
+			return
+		}
+
+		select {
+		case b.nextSet <- b.cs.At():
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func NewBackgroundChunkSeriesSet(ctx context.Context, cs storage.ChunkSeriesSet) storage.ChunkSeriesSet {
+	r := &backgrounChunkSeriesSet{
+		cs:      cs,
+		nextSet: make(chan storage.ChunkSeries, 1000),
+	}
+
+	go func() {
+		r.run(ctx)
+	}()
+
+	return r
+}

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -152,23 +152,23 @@ func NewBlocksCleaner(
 		tenantBlocks: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_bucket_blocks_count",
 			Help: "Total number of blocks in the bucket. Includes blocks marked for deletion, but not partial blocks.",
-		}, []string{"user"}),
+		}, commonLabels),
 		tenantBlocksMarkedForDelete: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_bucket_blocks_marked_for_deletion_count",
 			Help: "Total number of blocks marked for deletion in the bucket.",
-		}, []string{"user"}),
+		}, commonLabels),
 		tenantBlocksMarkedForNoCompaction: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_bucket_blocks_marked_for_no_compaction_count",
 			Help: "Total number of blocks marked for no compaction in the bucket.",
-		}, []string{"user"}),
+		}, commonLabels),
 		tenantPartialBlocks: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_bucket_blocks_partials_count",
 			Help: "Total number of partial blocks.",
-		}, []string{"user"}),
+		}, commonLabels),
 		tenantBucketIndexLastUpdate: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_bucket_index_last_successful_update_timestamp_seconds",
 			Help: "Timestamp of the last successful update of a tenant's bucket index.",
-		}, []string{"user"}),
+		}, commonLabels),
 		tenantBlocksCleanedTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_bucket_blocks_cleaned_total",
 			Help: "Total number of blocks deleted for a tenant.",

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -762,7 +762,11 @@ func (c *Compactor) running(ctx context.Context) error {
 
 	// Run an initial compaction before starting the interval.
 	// Insert jitter right before compaction starts to avoid multiple starting compactor to be in sync
-	time.Sleep(time.Duration(rand.Int63n(int64(float64(c.compactorCfg.CompactionInterval) * 0.1))))
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(time.Duration(rand.Int63n(int64(float64(c.compactorCfg.CompactionInterval) * 0.1)))):
+	}
 	c.compactUsers(ctx)
 
 	ticker := time.NewTicker(c.compactorCfg.CompactionInterval)

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -160,6 +160,30 @@ var (
 		}
 		return compactor, plannerFactory, nil
 	}
+
+	DefaultBlockDeletableCheckerFactory = func(_ context.Context, _ objstore.InstrumentedBucket, _ log.Logger) compact.BlockDeletableChecker {
+		return compact.DefaultBlockDeletableChecker{}
+	}
+
+	PartitionCompactionBlockDeletableCheckerFactory = func(ctx context.Context, bkt objstore.InstrumentedBucket, logger log.Logger) compact.BlockDeletableChecker {
+		return NewPartitionCompactionBlockDeletableChecker()
+	}
+
+	DefaultCompactionLifecycleCallbackFactory = func(_ context.Context, _ objstore.InstrumentedBucket, _ log.Logger, _ int, _ string, _ string, _ *compactorMetrics) compact.CompactionLifecycleCallback {
+		return compact.DefaultCompactionLifecycleCallback{}
+	}
+
+	ShardedCompactionLifecycleCallbackFactory = func(ctx context.Context, userBucket objstore.InstrumentedBucket, logger log.Logger, metaSyncConcurrency int, compactDir string, userID string, compactorMetrics *compactorMetrics) compact.CompactionLifecycleCallback {
+		return NewShardedCompactionLifecycleCallback(
+			ctx,
+			userBucket,
+			logger,
+			metaSyncConcurrency,
+			compactDir,
+			userID,
+			compactorMetrics,
+		)
+	}
 )
 
 // BlocksGrouperFactory builds and returns the grouper to use to compact a tenant's blocks.
@@ -201,6 +225,22 @@ type PlannerFactory func(
 	blockVisitMarkerWriteFailed prometheus.Counter,
 	compactorMetrics *compactorMetrics,
 ) compact.Planner
+
+type CompactionLifecycleCallbackFactory func(
+	ctx context.Context,
+	userBucket objstore.InstrumentedBucket,
+	logger log.Logger,
+	metaSyncConcurrency int,
+	compactDir string,
+	userID string,
+	compactorMetrics *compactorMetrics,
+) compact.CompactionLifecycleCallback
+
+type BlockDeletableCheckerFactory func(
+	ctx context.Context,
+	bkt objstore.InstrumentedBucket,
+	logger log.Logger,
+) compact.BlockDeletableChecker
 
 // Limits defines limits used by the Compactor.
 type Limits interface {
@@ -380,6 +420,10 @@ type Compactor struct {
 
 	blocksPlannerFactory PlannerFactory
 
+	blockDeletableCheckerFactory BlockDeletableCheckerFactory
+
+	compactionLifecycleCallbackFactory CompactionLifecycleCallbackFactory
+
 	// Client used to run operations on the bucket storing blocks.
 	bucketClient objstore.InstrumentedBucket
 
@@ -436,11 +480,25 @@ func NewCompactor(compactorCfg Config, storageCfg cortex_tsdb.BlocksStorageConfi
 		}
 	}
 
+	var blockDeletableCheckerFactory BlockDeletableCheckerFactory
+	if compactorCfg.ShardingStrategy == util.ShardingStrategyShuffle && compactorCfg.CompactionStrategy == util.CompactionStrategyPartitioning {
+		blockDeletableCheckerFactory = PartitionCompactionBlockDeletableCheckerFactory
+	} else {
+		blockDeletableCheckerFactory = DefaultBlockDeletableCheckerFactory
+	}
+
+	var compactionLifecycleCallbackFactory CompactionLifecycleCallbackFactory
+	if compactorCfg.ShardingStrategy == util.ShardingStrategyShuffle && compactorCfg.CompactionStrategy == util.CompactionStrategyPartitioning {
+		compactionLifecycleCallbackFactory = ShardedCompactionLifecycleCallbackFactory
+	} else {
+		compactionLifecycleCallbackFactory = DefaultCompactionLifecycleCallbackFactory
+	}
+
 	if ingestionReplicationFactor <= 0 {
 		ingestionReplicationFactor = 1
 	}
 
-	cortexCompactor, err := newCompactor(compactorCfg, storageCfg, logger, registerer, bucketClientFactory, blocksGrouperFactory, blocksCompactorFactory, limits, ingestionReplicationFactor)
+	cortexCompactor, err := newCompactor(compactorCfg, storageCfg, logger, registerer, bucketClientFactory, blocksGrouperFactory, blocksCompactorFactory, blockDeletableCheckerFactory, compactionLifecycleCallbackFactory, limits, ingestionReplicationFactor)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create Cortex blocks compactor")
 	}
@@ -456,6 +514,8 @@ func newCompactor(
 	bucketClientFactory func(ctx context.Context) (objstore.InstrumentedBucket, error),
 	blocksGrouperFactory BlocksGrouperFactory,
 	blocksCompactorFactory BlocksCompactorFactory,
+	blockDeletableCheckerFactory BlockDeletableCheckerFactory,
+	compactionLifecycleCallbackFactory CompactionLifecycleCallbackFactory,
 	limits *validation.Overrides,
 	ingestionReplicationFactor int,
 ) (*Compactor, error) {
@@ -466,15 +526,17 @@ func newCompactor(
 		compactorMetrics = newDefaultCompactorMetrics(registerer)
 	}
 	c := &Compactor{
-		compactorCfg:           compactorCfg,
-		storageCfg:             storageCfg,
-		parentLogger:           logger,
-		logger:                 log.With(logger, "component", "compactor"),
-		registerer:             registerer,
-		bucketClientFactory:    bucketClientFactory,
-		blocksGrouperFactory:   blocksGrouperFactory,
-		blocksCompactorFactory: blocksCompactorFactory,
-		allowedTenants:         util.NewAllowedTenants(compactorCfg.EnabledTenants, compactorCfg.DisabledTenants),
+		compactorCfg:                       compactorCfg,
+		storageCfg:                         storageCfg,
+		parentLogger:                       logger,
+		logger:                             log.With(logger, "component", "compactor"),
+		registerer:                         registerer,
+		bucketClientFactory:                bucketClientFactory,
+		blocksGrouperFactory:               blocksGrouperFactory,
+		blocksCompactorFactory:             blocksCompactorFactory,
+		blockDeletableCheckerFactory:       blockDeletableCheckerFactory,
+		compactionLifecycleCallbackFactory: compactionLifecycleCallbackFactory,
+		allowedTenants:                     util.NewAllowedTenants(compactorCfg.EnabledTenants, compactorCfg.DisabledTenants),
 
 		CompactorStartDurationSeconds: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_compactor_start_duration_seconds",
@@ -662,12 +724,6 @@ func (c *Compactor) starting(ctx context.Context) error {
 	}, c.bucketClient, c.usersScanner, c.compactorCfg.CompactionVisitMarkerTimeout, c.limits, c.parentLogger, cleanerRingLifecyclerID, c.registerer, c.compactorCfg.CleanerVisitMarkerTimeout, c.compactorCfg.CleanerVisitMarkerFileUpdateInterval,
 		c.compactorMetrics.syncerBlocksMarkedForDeletion, c.compactorMetrics.remainingPlannedCompactions)
 
-	// Ensure an initial cleanup occurred before starting the compactor.
-	if err := services.StartAndAwaitRunning(ctx, c.blocksCleaner); err != nil {
-		c.ringSubservices.StopAsync()
-		return errors.Wrap(err, "failed to start the blocks cleaner")
-	}
-
 	if c.compactorCfg.CachingBucketEnabled {
 		matchers := cortex_tsdb.NewMatchers()
 		// Do not cache tenant deletion marker and block deletion marker for compactor
@@ -698,15 +754,26 @@ func (c *Compactor) stopping(_ error) error {
 }
 
 func (c *Compactor) running(ctx context.Context) error {
+	// Ensure an initial cleanup occurred as first thing when running compactor.
+	if err := services.StartAndAwaitRunning(ctx, c.blocksCleaner); err != nil {
+		c.ringSubservices.StopAsync()
+		return errors.Wrap(err, "failed to start the blocks cleaner")
+	}
+
 	// Run an initial compaction before starting the interval.
+	// Insert jitter right before compaction starts to avoid multiple starting compactor to be in sync
+	time.Sleep(time.Duration(rand.Int63n(int64(float64(c.compactorCfg.CompactionInterval) * 0.1))))
 	c.compactUsers(ctx)
 
-	ticker := time.NewTicker(util.DurationWithJitter(c.compactorCfg.CompactionInterval, 0.05))
+	ticker := time.NewTicker(c.compactorCfg.CompactionInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
+			// Insert jitter right before compaction starts, so that there will always
+			// have jitter even compaction time is longer than CompactionInterval
+			time.Sleep(time.Duration(rand.Int63n(int64(float64(c.compactorCfg.CompactionInterval) * 0.1))))
 			c.compactUsers(ctx)
 		case <-ctx.Done():
 			return nil
@@ -717,23 +784,19 @@ func (c *Compactor) running(ctx context.Context) error {
 }
 
 func (c *Compactor) compactUsers(ctx context.Context) {
-	failed := false
+	succeeded := false
 	interrupted := false
+	compactionErrorCount := 0
 
 	c.CompactionRunsStarted.Inc()
 
 	defer func() {
-		// interruptions and successful runs are considered
-		// mutually exclusive but we consider a run failed if any
-		// tenant runs failed even if later runs are interrupted
-		if !interrupted && !failed {
+		if succeeded && compactionErrorCount == 0 {
 			c.CompactionRunsCompleted.Inc()
 			c.CompactionRunsLastSuccess.SetToCurrentTime()
-		}
-		if interrupted {
+		} else if interrupted {
 			c.CompactionRunsInterrupted.Inc()
-		}
-		if failed {
+		} else {
 			c.CompactionRunsFailed.Inc()
 		}
 
@@ -747,7 +810,6 @@ func (c *Compactor) compactUsers(ctx context.Context) {
 	level.Info(c.logger).Log("msg", "discovering users from bucket")
 	users, err := c.discoverUsersWithRetries(ctx)
 	if err != nil {
-		failed = true
 		level.Error(c.logger).Log("msg", "failed to discover users from bucket", "err", err)
 		return
 	}
@@ -816,7 +878,7 @@ func (c *Compactor) compactUsers(ctx context.Context) {
 			}
 
 			c.CompactionRunFailedTenants.Inc()
-			failed = true
+			compactionErrorCount++
 			level.Error(c.logger).Log("msg", "failed to compact user blocks", "user", userID, "err", err)
 			continue
 		}
@@ -851,6 +913,7 @@ func (c *Compactor) compactUsers(ctx context.Context) {
 			}
 		}
 	}
+	succeeded = true
 }
 
 func (c *Compactor) compactUserWithRetries(ctx context.Context, userID string) error {
@@ -885,6 +948,11 @@ func (c *Compactor) compactUserWithRetries(ctx context.Context, userID string) e
 		retries.Wait()
 	}
 
+	err := errors.Unwrap(errors.Cause(lastErr))
+	if errors.Is(err, plannerCompletedPartitionError) || errors.Is(err, plannerVisitedPartitionError) {
+		return nil
+	}
+
 	return lastErr
 }
 
@@ -898,7 +966,12 @@ func (c *Compactor) compactUser(ctx context.Context, userID string) error {
 
 	// Filters out duplicate blocks that can be formed from two or more overlapping
 	// blocks that fully submatches the source blocks of the older blocks.
-	deduplicateBlocksFilter := block.NewDeduplicateFilter(c.compactorCfg.BlockSyncConcurrency)
+	var deduplicateBlocksFilter CortexMetadataFilter
+	if c.compactorCfg.ShardingStrategy == util.ShardingStrategyShuffle && c.compactorCfg.CompactionStrategy == util.CompactionStrategyPartitioning {
+		deduplicateBlocksFilter = &DisabledDeduplicateFilter{}
+	} else {
+		deduplicateBlocksFilter = block.NewDeduplicateFilter(c.compactorCfg.BlockSyncConcurrency)
+	}
 
 	// While fetching blocks, we filter out blocks that were marked for deletion by using IgnoreDeletionMarkFilter.
 	// No delay is used -- all blocks with deletion marker are ignored, and not considered for compaction.
@@ -966,12 +1039,14 @@ func (c *Compactor) compactUser(ctx context.Context, userID string) error {
 
 	currentCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	compactor, err := compact.NewBucketCompactor(
+	compactor, err := compact.NewBucketCompactorWithCheckerAndCallback(
 		ulogger,
 		syncer,
 		c.blocksGrouperFactory(currentCtx, c.compactorCfg, bucket, ulogger, c.BlocksMarkedForNoCompaction, c.blockVisitMarkerReadFailed, c.blockVisitMarkerWriteFailed, syncerMetrics, c.compactorMetrics, c.ring, c.ringLifecycler, c.limits, userID, noCompactMarkerFilter, c.ingestionReplicationFactor),
 		c.blocksPlannerFactory(currentCtx, bucket, ulogger, c.compactorCfg, noCompactMarkerFilter, c.ringLifecycler, userID, c.blockVisitMarkerReadFailed, c.blockVisitMarkerWriteFailed, c.compactorMetrics),
 		c.blocksCompactor,
+		c.blockDeletableCheckerFactory(currentCtx, bucket, ulogger),
+		c.compactionLifecycleCallbackFactory(currentCtx, bucket, ulogger, c.compactorCfg.MetaSyncConcurrency, c.compactDirForUser(userID), userID, c.compactorMetrics),
 		c.compactDirForUser(userID),
 		bucket,
 		c.compactorCfg.CompactionConcurrency,
@@ -982,6 +1057,7 @@ func (c *Compactor) compactUser(ctx context.Context, userID string) error {
 	}
 
 	if err := compactor.Compact(ctx); err != nil {
+		level.Warn(ulogger).Log("msg", "compaction failed with error", "err", err)
 		return errors.Wrap(err, "compaction")
 	}
 
@@ -1147,4 +1223,21 @@ func (c *Compactor) isPermissionDeniedErr(err error) bool {
 		return false
 	}
 	return s.Code() == codes.PermissionDenied
+}
+
+type CortexMetadataFilter interface {
+	block.DeduplicateFilter
+	block.MetadataFilter
+}
+
+type DisabledDeduplicateFilter struct {
+}
+
+func (f *DisabledDeduplicateFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, modified block.GaugeVec) error {
+	// don't do any deduplicate filtering
+	return nil
+}
+
+func (f *DisabledDeduplicateFilter) DuplicateIDs() []ulid.ULID {
+	return nil
 }

--- a/pkg/compactor/compactor_metrics.go
+++ b/pkg/compactor/compactor_metrics.go
@@ -40,6 +40,7 @@ type compactorMetrics struct {
 	compactionErrorsCount       *prometheus.CounterVec
 	partitionCount              *prometheus.GaugeVec
 	compactionsNotPlanned       *prometheus.CounterVec
+	compactionDuration          *prometheus.GaugeVec
 }
 
 const (
@@ -179,6 +180,10 @@ func newCompactorMetricsWithLabels(reg prometheus.Registerer, commonLabels []str
 		Name: "cortex_compactor_group_compactions_not_planned_total",
 		Help: "Total number of group compaction not planned due to error.",
 	}, compactionLabels)
+	m.compactionDuration = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		Name: "cortex_compact_group_compaction_duration_seconds",
+		Help: "Duration of completed compactions in seconds",
+	}, compactionLabels)
 
 	return &m
 }
@@ -231,6 +236,7 @@ func (m *compactorMetrics) initMetricWithCompactionLabelValues(labelValue ...str
 	m.verticalCompactions.WithLabelValues(labelValue...)
 	m.partitionCount.WithLabelValues(labelValue...)
 	m.compactionsNotPlanned.WithLabelValues(labelValue...)
+	m.compactionDuration.WithLabelValues(labelValue...)
 }
 
 func (m *compactorMetrics) deleteMetricsForDeletedTenant(userID string) {
@@ -243,4 +249,5 @@ func (m *compactorMetrics) deleteMetricsForDeletedTenant(userID string) {
 	m.verticalCompactions.DeleteLabelValues(userID)
 	m.partitionCount.DeleteLabelValues(userID)
 	m.compactionsNotPlanned.DeleteLabelValues(userID)
+	m.compactionDuration.DeleteLabelValues(userID)
 }

--- a/pkg/compactor/compactor_metrics_test.go
+++ b/pkg/compactor/compactor_metrics_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSyncerMetrics(t *testing.T) {
+func TestCompactorMetrics(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	cm := newCompactorMetricsWithLabels(reg, commonLabels, commonLabels)
 
@@ -140,6 +140,11 @@ func TestSyncerMetrics(t *testing.T) {
 			cortex_compactor_group_compactions_not_planned_total{user="aaa"} 544390
 			cortex_compactor_group_compactions_not_planned_total{user="bbb"} 555500
 			cortex_compactor_group_compactions_not_planned_total{user="ccc"} 566610
+			# HELP cortex_compact_group_compaction_duration_seconds Duration of completed compactions in seconds
+			# TYPE cortex_compact_group_compaction_duration_seconds gauge
+			cortex_compact_group_compaction_duration_seconds{user="aaa"} 577720
+			cortex_compact_group_compaction_duration_seconds{user="bbb"} 588830
+			cortex_compact_group_compaction_duration_seconds{user="ccc"} 599940
 	`))
 	require.NoError(t, err)
 
@@ -199,4 +204,7 @@ func generateTestData(cm *compactorMetrics, base float64) {
 	cm.compactionsNotPlanned.WithLabelValues("aaa").Add(49 * base)
 	cm.compactionsNotPlanned.WithLabelValues("bbb").Add(50 * base)
 	cm.compactionsNotPlanned.WithLabelValues("ccc").Add(51 * base)
+	cm.compactionDuration.WithLabelValues("aaa").Add(52 * base)
+	cm.compactionDuration.WithLabelValues("bbb").Add(53 * base)
+	cm.compactionDuration.WithLabelValues("ccc").Add(54 * base)
 }

--- a/pkg/compactor/compactor_paritioning_test.go
+++ b/pkg/compactor/compactor_paritioning_test.go
@@ -1,7 +1,6 @@
 package compactor
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/json"
@@ -10,9 +9,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
-	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -22,7 +18,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -47,7 +42,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
-func TestConfig_ShouldSupportYamlConfig(t *testing.T) {
+func TestPartitionConfig_ShouldSupportYamlConfig(t *testing.T) {
 	yamlCfg := `
 block_ranges: [2h, 48h]
 consistency_delay: 1h
@@ -55,6 +50,7 @@ block_sync_concurrency: 123
 data_dir: /tmp
 compaction_interval: 15m
 compaction_retries: 123
+compaction_strategy: partitioning
 `
 
 	cfg := Config{}
@@ -66,9 +62,10 @@ compaction_retries: 123
 	assert.Equal(t, "/tmp", cfg.DataDir)
 	assert.Equal(t, 15*time.Minute, cfg.CompactionInterval)
 	assert.Equal(t, 123, cfg.CompactionRetries)
+	assert.Equal(t, util.CompactionStrategyPartitioning, cfg.CompactionStrategy)
 }
 
-func TestConfig_ShouldSupportCliFlags(t *testing.T) {
+func TestPartitionConfig_ShouldSupportCliFlags(t *testing.T) {
 	fs := flag.NewFlagSet("", flag.PanicOnError)
 	cfg := Config{}
 	cfg.RegisterFlags(fs)
@@ -79,6 +76,7 @@ func TestConfig_ShouldSupportCliFlags(t *testing.T) {
 		"-compactor.data-dir=/tmp",
 		"-compactor.compaction-interval=15m",
 		"-compactor.compaction-retries=123",
+		"-compactor.compaction-strategy=partitioning",
 	}))
 
 	assert.Equal(t, cortex_tsdb.DurationList{2 * time.Hour, 48 * time.Hour}, cfg.BlockRanges)
@@ -87,9 +85,10 @@ func TestConfig_ShouldSupportCliFlags(t *testing.T) {
 	assert.Equal(t, "/tmp", cfg.DataDir)
 	assert.Equal(t, 15*time.Minute, cfg.CompactionInterval)
 	assert.Equal(t, 123, cfg.CompactionRetries)
+	assert.Equal(t, util.CompactionStrategyPartitioning, cfg.CompactionStrategy)
 }
 
-func TestConfig_Validate(t *testing.T) {
+func TestPartitionConfig_Validate(t *testing.T) {
 	tests := map[string]struct {
 		setup      func(cfg *Config)
 		initLimits func(*validation.Limits)
@@ -140,6 +139,29 @@ func TestConfig_Validate(t *testing.T) {
 			initLimits: func(_ *validation.Limits) {},
 			expected:   errInvalidTenantShardSize.Error(),
 		},
+		"should pass with valid compaction strategy config": {
+			setup: func(cfg *Config) {
+				cfg.ShardingEnabled = true
+				cfg.CompactionStrategy = util.CompactionStrategyPartitioning
+			},
+			initLimits: func(_ *validation.Limits) {},
+			expected:   "",
+		},
+		"should fail with bad compaction strategy": {
+			setup: func(cfg *Config) {
+				cfg.CompactionStrategy = "dummy"
+			},
+			initLimits: func(_ *validation.Limits) {},
+			expected:   errInvalidCompactionStrategy.Error(),
+		},
+		"should fail with partitioning compaction strategy but sharding disabled": {
+			setup: func(cfg *Config) {
+				cfg.ShardingEnabled = false
+				cfg.CompactionStrategy = util.CompactionStrategyPartitioning
+			},
+			initLimits: func(_ *validation.Limits) {},
+			expected:   errInvalidCompactionStrategyPartitioning.Error(),
+		},
 	}
 
 	for testName, testData := range tests {
@@ -159,7 +181,7 @@ func TestConfig_Validate(t *testing.T) {
 	}
 }
 
-func TestCompactor_SkipCompactionWhenCmkError(t *testing.T) {
+func TestPartitionCompactor_SkipCompactionWhenCmkError(t *testing.T) {
 	t.Parallel()
 	userID := "user-1"
 
@@ -182,13 +204,14 @@ func TestCompactor_SkipCompactionWhenCmkError(t *testing.T) {
 	bucketClient.MockUpload(userID+"/bucket-index.json.gz", nil)
 	bucketClient.MockExists(cortex_tsdb.GetGlobalDeletionMarkPath(userID), false, nil)
 	bucketClient.MockExists(cortex_tsdb.GetLocalDeletionMarkPath(userID), false, nil)
+	bucketClient.MockIter(userID+"/"+PartitionedGroupDirectory, nil, nil)
 
-	cfg := prepareConfig()
-	c, _, _, logs, _ := prepare(t, cfg, bucketClient, nil)
+	cfg := prepareConfigForPartitioning()
+	c, _, _, logs, _ := prepareForPartitioning(t, cfg, bucketClient, nil, nil)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() interface{} {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -196,19 +219,19 @@ func TestCompactor_SkipCompactionWhenCmkError(t *testing.T) {
 	assert.Contains(t, strings.Split(strings.TrimSpace(logs.String()), "\n"), `level=info component=compactor msg="skipping compactUser due CustomerManagedKeyError" user=user-1`)
 }
 
-func TestCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
+func TestPartitionCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 	t.Parallel()
 
 	// No user blocks stored in the bucket.
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("", []string{}, nil)
 	bucketClient.MockIter("__markers__", []string{}, nil)
-	cfg := prepareConfig()
-	c, _, _, logs, registry := prepare(t, cfg, bucketClient, nil)
+	cfg := prepareConfigForPartitioning()
+	c, _, _, logs, registry := prepareForPartitioning(t, cfg, bucketClient, nil, nil)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() interface{} {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -242,13 +265,10 @@ func TestCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 		# HELP cortex_compactor_blocks_cleaned_total Total number of blocks deleted.
 		# TYPE cortex_compactor_blocks_cleaned_total counter
 		cortex_compactor_blocks_cleaned_total 0
+
 		# HELP cortex_compactor_blocks_marked_for_no_compaction_total Total number of blocks marked for no compact during a compaction run.
 		# TYPE cortex_compactor_blocks_marked_for_no_compaction_total counter
 		cortex_compactor_blocks_marked_for_no_compaction_total 0
-
-		# HELP cortex_compactor_meta_sync_consistency_delay_seconds Configured consistency delay in seconds.
-		# TYPE cortex_compactor_meta_sync_consistency_delay_seconds gauge
-		cortex_compactor_meta_sync_consistency_delay_seconds 0
 
 		# TYPE cortex_compactor_block_cleanup_started_total counter
 		# HELP cortex_compactor_block_cleanup_started_total Total number of blocks cleanup runs started.
@@ -263,16 +283,18 @@ func TestCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 		"cortex_compactor_runs_started_total",
 		"cortex_compactor_runs_completed_total",
 		"cortex_compactor_runs_failed_total",
+		"cortex_compactor_garbage_collected_blocks_total",
 		"cortex_compactor_block_cleanup_failures_total",
 		"cortex_compactor_blocks_cleaned_total",
+		"cortex_compactor_blocks_marked_for_deletion_total",
 		"cortex_compactor_blocks_marked_for_no_compaction_total",
-		"cortex_compactor_meta_sync_consistency_delay_seconds",
 		"cortex_compactor_block_cleanup_started_total",
 		"cortex_compactor_block_cleanup_completed_total",
+		"cortex_compactor_block_cleanup_failed_total",
 	))
 }
 
-func TestCompactor_ShouldRetryCompactionOnFailureWhileDiscoveringUsersFromBucket(t *testing.T) {
+func TestPartitionCompactor_ShouldRetryCompactionOnFailureWhileDiscoveringUsersFromBucket(t *testing.T) {
 	t.Parallel()
 
 	// Fail to iterate over the bucket while discovering users.
@@ -280,11 +302,11 @@ func TestCompactor_ShouldRetryCompactionOnFailureWhileDiscoveringUsersFromBucket
 	bucketClient.MockIter("__markers__", nil, errors.New("failed to iterate the bucket"))
 	bucketClient.MockIter("", nil, errors.New("failed to iterate the bucket"))
 
-	c, _, _, logs, registry := prepare(t, prepareConfig(), bucketClient, nil)
+	c, _, _, logs, registry := prepareForPartitioning(t, prepareConfigForPartitioning(), bucketClient, nil, nil)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until all retry attempts have completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() interface{} {
 		return prom_testutil.ToFloat64(c.CompactionRunsFailed)
 	})
 
@@ -317,37 +339,38 @@ func TestCompactor_ShouldRetryCompactionOnFailureWhileDiscoveringUsersFromBucket
 		# HELP cortex_compactor_block_cleanup_failures_total Total number of blocks failed to be deleted.
 		cortex_compactor_block_cleanup_failures_total 0
 
-		# HELP cortex_compactor_blocks_cleaned_total Total number of blocks deleted.
-		# TYPE cortex_compactor_blocks_cleaned_total counter
-		cortex_compactor_blocks_cleaned_total 0
-		# HELP cortex_compactor_blocks_marked_for_no_compaction_total Total number of blocks marked for no compact during a compaction run.
-		# TYPE cortex_compactor_blocks_marked_for_no_compaction_total counter
-		cortex_compactor_blocks_marked_for_no_compaction_total 0
-
-		# HELP cortex_compactor_meta_sync_consistency_delay_seconds Configured consistency delay in seconds.
-		# TYPE cortex_compactor_meta_sync_consistency_delay_seconds gauge
-		cortex_compactor_meta_sync_consistency_delay_seconds 0
-
 		# TYPE cortex_compactor_block_cleanup_failed_total counter
 		# HELP cortex_compactor_block_cleanup_failed_total Total number of blocks cleanup runs failed.
 		cortex_compactor_block_cleanup_failed_total{user_status="active"} 1
 		cortex_compactor_block_cleanup_failed_total{user_status="deleted"} 1
+
+		# HELP cortex_compactor_blocks_cleaned_total Total number of blocks deleted.
+		# TYPE cortex_compactor_blocks_cleaned_total counter
+		cortex_compactor_blocks_cleaned_total 0
+
+		# HELP cortex_compactor_blocks_marked_for_no_compaction_total Total number of blocks marked for no compact during a compaction run.
+		# TYPE cortex_compactor_blocks_marked_for_no_compaction_total counter
+		cortex_compactor_blocks_marked_for_no_compaction_total 0
 	`),
 		"cortex_compactor_runs_started_total",
 		"cortex_compactor_runs_completed_total",
 		"cortex_compactor_runs_failed_total",
+		"cortex_compactor_garbage_collected_blocks_total",
 		"cortex_compactor_block_cleanup_failures_total",
 		"cortex_compactor_blocks_cleaned_total",
+		"cortex_compactor_blocks_marked_for_deletion_total",
 		"cortex_compactor_blocks_marked_for_no_compaction_total",
-		"cortex_compactor_meta_sync_consistency_delay_seconds",
+		"cortex_compactor_block_cleanup_started_total",
+		"cortex_compactor_block_cleanup_completed_total",
 		"cortex_compactor_block_cleanup_failed_total",
 	))
 }
 
-func TestCompactor_ShouldIncrementCompactionErrorIfFailedToCompactASingleTenant(t *testing.T) {
+func TestPartitionCompactor_ShouldIncrementCompactionErrorIfFailedToCompactASingleTenant(t *testing.T) {
 	t.Parallel()
 
 	userID := "test-user"
+	partitionedGroupID := getPartitionedGroupID(userID)
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("", []string{userID}, nil)
 	bucketClient.MockIter("__markers__", []string{}, nil)
@@ -361,24 +384,27 @@ func TestCompactor_ShouldIncrementCompactionErrorIfFailedToCompactASingleTenant(
 	bucketClient.MockGet(userID+"/01DTVP434PA9VFXSW2JKB3392D/meta.json", mockBlockMetaJSON("01DTVP434PA9VFXSW2JKB3392D"), nil)
 	bucketClient.MockGet(userID+"/01DTVP434PA9VFXSW2JKB3392D/no-compact-mark.json", "", nil)
 	bucketClient.MockGet(userID+"/01DTVP434PA9VFXSW2JKB3392D/deletion-mark.json", "", nil)
-	bucketClient.MockGet(userID+"/01DTVP434PA9VFXSW2JKB3392D/visit-mark.json", "", nil)
+	bucketClient.MockGet(userID+"/01DTVP434PA9VFXSW2JKB3392D/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockUpload(userID+"/01DTVP434PA9VFXSW2JKB3392D/partition-0-visit-mark.json", nil)
 	bucketClient.MockGet(userID+"/bucket-index-sync-status.json", "", nil)
-	bucketClient.MockUpload(userID+"/01DTVP434PA9VFXSW2JKB3392D/visit-mark.json", nil)
 	bucketClient.MockGet(userID+"/01FN6CDF3PNEWWRY5MPGJPE3EX/meta.json", mockBlockMetaJSON("01FN6CDF3PNEWWRY5MPGJPE3EX"), nil)
 	bucketClient.MockGet(userID+"/01FN6CDF3PNEWWRY5MPGJPE3EX/no-compact-mark.json", "", nil)
 	bucketClient.MockGet(userID+"/01FN6CDF3PNEWWRY5MPGJPE3EX/deletion-mark.json", "", nil)
-	bucketClient.MockGet(userID+"/01FN6CDF3PNEWWRY5MPGJPE3EX/visit-mark.json", "", nil)
-	bucketClient.MockUpload(userID+"/01FN6CDF3PNEWWRY5MPGJPE3EX/visit-mark.json", nil)
+	bucketClient.MockGet(userID+"/01FN6CDF3PNEWWRY5MPGJPE3EX/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockUpload(userID+"/01FN6CDF3PNEWWRY5MPGJPE3EX/partition-0-visit-mark.json", nil)
 	bucketClient.MockGet(userID+"/bucket-index.json.gz", "", nil)
 	bucketClient.MockUpload(userID+"/bucket-index.json.gz", nil)
 	bucketClient.MockUpload(userID+"/bucket-index-sync-status.json", nil)
+	bucketClient.MockGet(userID+"/partitioned-groups/"+partitionedGroupID+".json", "", nil)
+	bucketClient.MockUpload(userID+"/partitioned-groups/"+partitionedGroupID+".json", nil)
+	bucketClient.MockIter(userID+"/"+PartitionedGroupDirectory, nil, nil)
 
-	c, _, tsdbPlannerMock, _, registry := prepare(t, prepareConfig(), bucketClient, nil)
+	c, _, tsdbPlannerMock, _, registry := prepareForPartitioning(t, prepareConfigForPartitioning(), bucketClient, nil, nil)
 	tsdbPlannerMock.On("Plan", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*metadata.Meta{}, errors.New("Failed to plan"))
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until all retry attempts have completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() interface{} {
 		return prom_testutil.ToFloat64(c.CompactionRunsFailed)
 	})
 
@@ -403,7 +429,8 @@ func TestCompactor_ShouldIncrementCompactionErrorIfFailedToCompactASingleTenant(
 	))
 }
 
-func TestCompactor_ShouldCompactAndRemoveUserFolder(t *testing.T) {
+func TestPartitionCompactor_ShouldCompactAndRemoveUserFolder(t *testing.T) {
+	partitionedGroupID1 := getPartitionedGroupID("user-1")
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("", []string{"user-1"}, nil)
 	bucketClient.MockIter("__markers__", []string{}, nil)
@@ -417,19 +444,22 @@ func TestCompactor_ShouldCompactAndRemoveUserFolder(t *testing.T) {
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", mockBlockMetaJSON("01DTVP434PA9VFXSW2JKB3392D"), nil)
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/visit-mark.json", "", nil)
+	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/partition-0-visit-mark.json", "", nil)
 	bucketClient.MockGet("user-1/bucket-index-sync-status.json", "", nil)
 	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/meta.json", mockBlockMetaJSON("01FN6CDF3PNEWWRY5MPGJPE3EX"), nil)
 	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/visit-mark.json", "", nil)
+	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/partition-0-visit-mark.json", "", nil)
 	bucketClient.MockGet("user-1/bucket-index.json.gz", "", nil)
 	bucketClient.MockGet("user-1/bucket-index-sync-status.json", "", nil)
 	bucketClient.MockIter("user-1/markers/", nil, nil)
 	bucketClient.MockUpload("user-1/bucket-index.json.gz", nil)
 	bucketClient.MockUpload("user-1/bucket-index-sync-status.json", nil)
+	bucketClient.MockGet("user-1/partitioned-groups/"+partitionedGroupID1+".json", "", nil)
+	bucketClient.MockUpload("user-1/partitioned-groups/"+partitionedGroupID1+".json", nil)
+	bucketClient.MockIter("user-1/"+PartitionedGroupDirectory, nil, nil)
 
-	c, _, tsdbPlanner, _, _ := prepare(t, prepareConfig(), bucketClient, nil)
+	c, _, tsdbPlanner, _, _ := prepareForPartitioning(t, prepareConfigForPartitioning(), bucketClient, nil, nil)
 
 	// Make sure the user folder is created and is being used
 	// This will be called during compaction
@@ -441,7 +471,7 @@ func TestCompactor_ShouldCompactAndRemoveUserFolder(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() interface{} {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -449,8 +479,11 @@ func TestCompactor_ShouldCompactAndRemoveUserFolder(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 }
 
-func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
+func TestPartitionCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 	t.Parallel()
+
+	partitionedGroupID1 := getPartitionedGroupID("user-1")
+	partitionedGroupID2 := getPartitionedGroupID("user-2")
 
 	// Mock the bucket to contain two users, each one with one block.
 	bucketClient := &bucket.ClientMock{}
@@ -473,20 +506,20 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", mockBlockMetaJSON("01DTVP434PA9VFXSW2JKB3392D"), nil)
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/visit-mark.json", "", nil)
+	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/partition-0-visit-mark.json", "", nil)
 	bucketClient.MockGet("user-1/bucket-index-sync-status.json", "", nil)
 	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/meta.json", mockBlockMetaJSON("01FN6CDF3PNEWWRY5MPGJPE3EX"), nil)
 	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/visit-mark.json", "", nil)
+	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/partition-0-visit-mark.json", "", nil)
 	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/meta.json", mockBlockMetaJSON("01DTW0ZCPDDNV4BV83Q2SV4QAZ"), nil)
 	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/visit-mark.json", "", nil)
+	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/partition-0-visit-mark.json", "", nil)
 	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/meta.json", mockBlockMetaJSON("01FN3V83ABR9992RF8WRJZ76ZQ"), nil)
 	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/visit-mark.json", "", nil)
+	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/partition-0-visit-mark.json", "", nil)
 	bucketClient.MockGet("user-1/bucket-index.json.gz", "", nil)
 	bucketClient.MockGet("user-2/bucket-index.json.gz", "", nil)
 	bucketClient.MockGet("user-1/bucket-index-sync-status.json", "", nil)
@@ -497,8 +530,14 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 	bucketClient.MockUpload("user-2/bucket-index.json.gz", nil)
 	bucketClient.MockUpload("user-1/bucket-index-sync-status.json", nil)
 	bucketClient.MockUpload("user-2/bucket-index-sync-status.json", nil)
+	bucketClient.MockGet("user-1/partitioned-groups/"+partitionedGroupID1+".json", "", nil)
+	bucketClient.MockUpload("user-1/partitioned-groups/"+partitionedGroupID1+".json", nil)
+	bucketClient.MockGet("user-2/partitioned-groups/"+partitionedGroupID2+".json", "", nil)
+	bucketClient.MockUpload("user-2/partitioned-groups/"+partitionedGroupID2+".json", nil)
+	bucketClient.MockIter("user-1/"+PartitionedGroupDirectory, nil, nil)
+	bucketClient.MockIter("user-2/"+PartitionedGroupDirectory, nil, nil)
 
-	c, _, tsdbPlanner, logs, registry := prepare(t, prepareConfig(), bucketClient, nil)
+	c, _, tsdbPlanner, logs, registry := prepareForPartitioning(t, prepareConfigForPartitioning(), bucketClient, nil, nil)
 
 	// Mock the planner as if there's no compaction to do,
 	// in order to simplify tests (all in all, we just want to
@@ -509,7 +548,7 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() interface{} {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -524,18 +563,18 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 		`level=info component=compactor msg="compactor started"`,
 		`level=info component=compactor msg="discovering users from bucket"`,
 		`level=info component=compactor msg="discovered users from bucket" users=2`,
-		`level=info component=compactor msg="starting compaction of user blocks" user=user-1`,
-		`level=info component=compactor org_id=user-1 msg="start sync of metas"`,
-		`level=info component=compactor org_id=user-1 msg="start of GC"`,
-		`level=info component=compactor org_id=user-1 msg="start of compactions"`,
-		`level=info component=compactor org_id=user-1 msg="compaction iterations done"`,
-		`level=info component=compactor msg="successfully compacted user blocks" user=user-1`,
 		`level=info component=compactor msg="starting compaction of user blocks" user=user-2`,
 		`level=info component=compactor org_id=user-2 msg="start sync of metas"`,
 		`level=info component=compactor org_id=user-2 msg="start of GC"`,
 		`level=info component=compactor org_id=user-2 msg="start of compactions"`,
 		`level=info component=compactor org_id=user-2 msg="compaction iterations done"`,
 		`level=info component=compactor msg="successfully compacted user blocks" user=user-2`,
+		`level=info component=compactor msg="starting compaction of user blocks" user=user-1`,
+		`level=info component=compactor org_id=user-1 msg="start sync of metas"`,
+		`level=info component=compactor org_id=user-1 msg="start of GC"`,
+		`level=info component=compactor org_id=user-1 msg="start of compactions"`,
+		`level=info component=compactor org_id=user-1 msg="compaction iterations done"`,
+		`level=info component=compactor msg="successfully compacted user blocks" user=user-1`,
 	}, removeIgnoredLogs(strings.Split(strings.TrimSpace(logs.String()), "\n")))
 
 	// Instead of testing for shipper metrics, we only check our metrics here.
@@ -543,7 +582,7 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 	testedMetrics := []string{
 		"cortex_compactor_runs_started_total", "cortex_compactor_runs_completed_total", "cortex_compactor_runs_failed_total",
 		"cortex_compactor_blocks_cleaned_total", "cortex_compactor_block_cleanup_failures_total", "cortex_compactor_blocks_marked_for_deletion_total",
-		"cortex_compactor_block_cleanup_started_total", "cortex_compactor_block_cleanup_completed_total",
+		"cortex_compactor_block_cleanup_started_total", "cortex_compactor_block_cleanup_completed_total", "cortex_compactor_block_cleanup_failed_total",
 		"cortex_compactor_blocks_marked_for_no_compaction_total",
 	}
 	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
@@ -569,10 +608,10 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 
 		# HELP cortex_compactor_blocks_marked_for_deletion_total Total number of blocks marked for deletion in compactor.
 		# TYPE cortex_compactor_blocks_marked_for_deletion_total counter
-		cortex_compactor_blocks_marked_for_deletion_total{reason="compaction",user="user-1"} 0
-		cortex_compactor_blocks_marked_for_deletion_total{reason="compaction",user="user-2"} 0
-		cortex_compactor_blocks_marked_for_deletion_total{reason="retention",user="user-1"} 0
-		cortex_compactor_blocks_marked_for_deletion_total{reason="retention",user="user-2"} 0
+        cortex_compactor_blocks_marked_for_deletion_total{reason="compaction",user="user-1"} 0
+        cortex_compactor_blocks_marked_for_deletion_total{reason="compaction",user="user-2"} 0
+        cortex_compactor_blocks_marked_for_deletion_total{reason="retention",user="user-1"} 0
+        cortex_compactor_blocks_marked_for_deletion_total{reason="retention",user="user-2"} 0
 
 		# TYPE cortex_compactor_block_cleanup_started_total counter
 		# HELP cortex_compactor_block_cleanup_started_total Total number of blocks cleanup runs started.
@@ -590,10 +629,10 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 	`), testedMetrics...))
 }
 
-func TestCompactor_ShouldNotCompactBlocksMarkedForDeletion(t *testing.T) {
+func TestPartitionCompactor_ShouldNotCompactBlocksMarkedForDeletion(t *testing.T) {
 	t.Parallel()
 
-	cfg := prepareConfig()
+	cfg := prepareConfigForPartitioning()
 	cfg.DeletionDelay = 10 * time.Minute // Delete block after 10 minutes
 
 	// Mock the bucket to contain two users, each one with one block.
@@ -637,13 +676,14 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForDeletion(t *testing.T) {
 	bucketClient.MockGet("user-1/bucket-index-sync-status.json", "", nil)
 	bucketClient.MockUpload("user-1/bucket-index.json.gz", nil)
 	bucketClient.MockUpload("user-1/bucket-index-sync-status.json", nil)
+	bucketClient.MockIter("user-1/"+PartitionedGroupDirectory, nil, nil)
 
-	c, _, tsdbPlanner, logs, registry := prepare(t, cfg, bucketClient, nil)
+	c, _, tsdbPlanner, logs, registry := prepareForPartitioning(t, cfg, bucketClient, nil, nil)
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() interface{} {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -669,7 +709,7 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForDeletion(t *testing.T) {
 	testedMetrics := []string{
 		"cortex_compactor_runs_started_total", "cortex_compactor_runs_completed_total", "cortex_compactor_runs_failed_total",
 		"cortex_compactor_blocks_cleaned_total", "cortex_compactor_block_cleanup_failures_total", "cortex_compactor_blocks_marked_for_deletion_total",
-		"cortex_compactor_block_cleanup_started_total", "cortex_compactor_block_cleanup_completed_total",
+		"cortex_compactor_block_cleanup_started_total", "cortex_compactor_block_cleanup_completed_total", "cortex_compactor_block_cleanup_failed_total",
 		"cortex_compactor_blocks_marked_for_no_compaction_total",
 	}
 	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
@@ -696,7 +736,7 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForDeletion(t *testing.T) {
 		# HELP cortex_compactor_blocks_marked_for_deletion_total Total number of blocks marked for deletion in compactor.
 		# TYPE cortex_compactor_blocks_marked_for_deletion_total counter
 		cortex_compactor_blocks_marked_for_deletion_total{reason="compaction",user="user-1"} 0
-		cortex_compactor_blocks_marked_for_deletion_total{reason="retention",user="user-1"} 0
+        cortex_compactor_blocks_marked_for_deletion_total{reason="retention",user="user-1"} 0
 
 		# TYPE cortex_compactor_block_cleanup_started_total counter
 		# HELP cortex_compactor_block_cleanup_started_total Total number of blocks cleanup runs started.
@@ -714,9 +754,11 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForDeletion(t *testing.T) {
 	`), testedMetrics...))
 }
 
-func TestCompactor_ShouldNotCompactBlocksMarkedForSkipCompact(t *testing.T) {
+func TestPartitionCompactor_ShouldNotCompactBlocksMarkedForSkipCompact(t *testing.T) {
 	t.Parallel()
 
+	partitionedGroupID1 := getPartitionedGroupID("user-1")
+	partitionedGroupID2 := getPartitionedGroupID("user-2")
 	// Mock the bucket to contain two users, each one with one block.
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("", []string{"user-1", "user-2"}, nil)
@@ -738,25 +780,25 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForSkipCompact(t *testing.T) {
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", mockBlockMetaJSON("01DTVP434PA9VFXSW2JKB3392D"), nil)
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/no-compact-mark.json", mockNoCompactBlockJSON("01DTVP434PA9VFXSW2JKB3392D"), nil)
-	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/visit-mark.json", "", nil)
+	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockUpload("user-1/01DTVP434PA9VFXSW2JKB3392D/partition-0-visit-mark.json", nil)
 	bucketClient.MockGet("user-1/bucket-index-sync-status.json", "", nil)
-	bucketClient.MockUpload("user-1/01DTVP434PA9VFXSW2JKB3392D/visit-mark.json", nil)
 	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/meta.json", mockBlockMetaJSON("01FN6CDF3PNEWWRY5MPGJPE3EX"), nil)
 	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/no-compact-mark.json", mockNoCompactBlockJSON("01FN6CDF3PNEWWRY5MPGJPE3EX"), nil)
-	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/visit-mark.json", "", nil)
-	bucketClient.MockUpload("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/visit-mark.json", nil)
+	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockUpload("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/partition-0-visit-mark.json", nil)
 
 	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/meta.json", mockBlockMetaJSON("01DTW0ZCPDDNV4BV83Q2SV4QAZ"), nil)
 	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/visit-mark.json", "", nil)
-	bucketClient.MockUpload("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/visit-mark.json", nil)
+	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockUpload("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/partition-0-visit-mark.json", nil)
 	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/meta.json", mockBlockMetaJSON("01FN3V83ABR9992RF8WRJZ76ZQ"), nil)
 	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/visit-mark.json", "", nil)
-	bucketClient.MockUpload("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/visit-mark.json", nil)
+	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockUpload("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/partition-0-visit-mark.json", nil)
 
 	bucketClient.MockGet("user-1/bucket-index.json.gz", "", nil)
 	bucketClient.MockGet("user-2/bucket-index.json.gz", "", nil)
@@ -768,14 +810,20 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForSkipCompact(t *testing.T) {
 	bucketClient.MockUpload("user-2/bucket-index.json.gz", nil)
 	bucketClient.MockUpload("user-1/bucket-index-sync-status.json", nil)
 	bucketClient.MockUpload("user-2/bucket-index-sync-status.json", nil)
+	bucketClient.MockGet("user-1/partitioned-groups/"+partitionedGroupID1+".json", "", nil)
+	bucketClient.MockUpload("user-1/partitioned-groups/"+partitionedGroupID1+".json", nil)
+	bucketClient.MockGet("user-2/partitioned-groups/"+partitionedGroupID2+".json", "", nil)
+	bucketClient.MockUpload("user-2/partitioned-groups/"+partitionedGroupID2+".json", nil)
+	bucketClient.MockIter("user-1/"+PartitionedGroupDirectory, nil, nil)
+	bucketClient.MockIter("user-2/"+PartitionedGroupDirectory, nil, nil)
 
-	c, _, tsdbPlanner, _, registry := prepare(t, prepareConfig(), bucketClient, nil)
+	c, _, tsdbPlanner, _, registry := prepareForPartitioning(t, prepareConfigForPartitioning(), bucketClient, nil, nil)
 
 	tsdbPlanner.On("Plan", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*metadata.Meta{}, nil)
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
-	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() interface{} {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -795,13 +843,14 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForSkipCompact(t *testing.T) {
 	`), testedMetrics...))
 }
 
-func TestCompactor_ShouldNotCompactBlocksForUsersMarkedForDeletion(t *testing.T) {
+func TestPartitionCompactor_ShouldNotCompactBlocksForUsersMarkedForDeletion(t *testing.T) {
 	t.Parallel()
 
-	cfg := prepareConfig()
+	cfg := prepareConfigForPartitioning()
 	cfg.DeletionDelay = 10 * time.Minute      // Delete block after 10 minutes
 	cfg.TenantCleanupDelay = 10 * time.Minute // To make sure it's not 0.
 
+	partitionedGroupID1 := getPartitionedGroupID("user-1")
 	// Mock the bucket to contain two users, each one with one block.
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("", []string{"user-1"}, nil)
@@ -818,16 +867,19 @@ func TestCompactor_ShouldNotCompactBlocksForUsersMarkedForDeletion(t *testing.T)
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", mockBlockMetaJSON("01DTVP434PA9VFXSW2JKB3392D"), nil)
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/index", "some index content", nil)
 	bucketClient.MockGet("user-1/bucket-index-sync-status.json", "", nil)
-	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/visit-mark.json", "", nil)
-	bucketClient.MockUpload("user-1/01DTVP434PA9VFXSW2JKB3392D/visit-mark.json", nil)
+	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockUpload("user-1/01DTVP434PA9VFXSW2JKB3392D/partition-0-visit-mark.json", nil)
 	bucketClient.MockExists("user-1/01DTVP434PA9VFXSW2JKB3392D/deletion-mark.json", false, nil)
 
 	bucketClient.MockDelete("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", nil)
 	bucketClient.MockDelete("user-1/01DTVP434PA9VFXSW2JKB3392D/index", nil)
 	bucketClient.MockDelete("user-1/bucket-index.json.gz", nil)
 	bucketClient.MockDelete("user-1/bucket-index-sync-status.json", nil)
+	bucketClient.MockGet("user-1/partitioned-groups/"+partitionedGroupID1+".json", "", nil)
+	bucketClient.MockUpload("user-1/partitioned-groups/"+partitionedGroupID1+".json", nil)
+	bucketClient.MockIter("user-1/"+PartitionedGroupDirectory, nil, nil)
 
-	c, _, tsdbPlanner, logs, registry := prepare(t, cfg, bucketClient, nil)
+	c, _, tsdbPlanner, logs, registry := prepareForPartitioning(t, cfg, bucketClient, nil, nil)
 
 	// Mock the planner as if there's no compaction to do,
 	// in order to simplify tests (all in all, we just want to
@@ -838,7 +890,7 @@ func TestCompactor_ShouldNotCompactBlocksForUsersMarkedForDeletion(t *testing.T)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() interface{} {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() interface{} {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -858,8 +910,9 @@ func TestCompactor_ShouldNotCompactBlocksForUsersMarkedForDeletion(t *testing.T)
 	// Real shipper metrics are too variable to embed into a test.
 	testedMetrics := []string{
 		"cortex_compactor_runs_started_total", "cortex_compactor_runs_completed_total", "cortex_compactor_runs_failed_total",
-		"cortex_compactor_blocks_cleaned_total", "cortex_compactor_block_cleanup_failures_total",
-		"cortex_compactor_block_cleanup_started_total", "cortex_compactor_block_cleanup_completed_total",
+		"cortex_compactor_blocks_cleaned_total", "cortex_compactor_block_cleanup_failures_total", "cortex_compactor_blocks_marked_for_deletion_total",
+		"cortex_compactor_block_cleanup_started_total", "cortex_compactor_block_cleanup_completed_total", "cortex_compactor_block_cleanup_failed_total",
+		"cortex_bucket_blocks_count", "cortex_bucket_blocks_marked_for_deletion_count", "cortex_bucket_index_last_successful_update_timestamp_seconds",
 		"cortex_compactor_blocks_marked_for_no_compaction_total",
 	}
 	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
@@ -899,7 +952,7 @@ func TestCompactor_ShouldNotCompactBlocksForUsersMarkedForDeletion(t *testing.T)
 	`), testedMetrics...))
 }
 
-func TestCompactor_ShouldSkipOutOrOrderBlocks(t *testing.T) {
+func TestPartitionCompactor_ShouldSkipOutOrOrderBlocks(t *testing.T) {
 	bucketClient, tmpDir := cortex_storage_testutil.PrepareFilesystemBucket(t)
 	bucketClient = bucketindex.BucketWithGlobalMarkers(bucketClient)
 
@@ -920,11 +973,11 @@ func TestCompactor_ShouldSkipOutOrOrderBlocks(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, indexFileStat.Size(), n)
 
-	cfg := prepareConfig()
+	cfg := prepareConfigForPartitioning()
 	cfg.SkipBlocksWithOutOfOrderChunksEnabled = true
-	c, tsdbCompac, tsdbPlanner, _, registry := prepare(t, cfg, bucketClient, nil)
+	c, tsdbCompac, tsdbPlanner, _, registry := prepareForPartitioning(t, cfg, bucketClient, nil, nil)
 
-	tsdbCompac.On("CompactWithBlockPopulator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ulid.ULID{b1}, nil)
+	tsdbCompac.On("CompactWithBlockPopulator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(b1, nil)
 
 	tsdbPlanner.On("Plan", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*metadata.Meta{
 		{
@@ -948,7 +1001,7 @@ func TestCompactor_ShouldSkipOutOrOrderBlocks(t *testing.T) {
 	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, 5*time.Second, true, func() interface{} {
+	cortex_testutil.Poll(t, 20*time.Second, true, func() interface{} {
 		if _, err := os.Stat(path.Join(dir, "no-compact-mark.json")); err == nil {
 			return true
 		}
@@ -962,9 +1015,11 @@ func TestCompactor_ShouldSkipOutOrOrderBlocks(t *testing.T) {
 		`), "cortex_compactor_blocks_marked_for_no_compaction_total"))
 }
 
-func TestCompactor_ShouldCompactAllUsersOnShardingEnabledButOnlyOneInstanceRunning(t *testing.T) {
+func TestPartitionCompactor_ShouldCompactAllUsersOnShardingEnabledButOnlyOneInstanceRunning(t *testing.T) {
 	t.Parallel()
 
+	partitionedGroupID1 := getPartitionedGroupID("user-1")
+	partitionedGroupID2 := getPartitionedGroupID("user-2")
 	// Mock the bucket to contain two users, each one with one block.
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("", []string{"user-1", "user-2"}, nil)
@@ -986,24 +1041,24 @@ func TestCompactor_ShouldCompactAllUsersOnShardingEnabledButOnlyOneInstanceRunni
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", mockBlockMetaJSON("01DTVP434PA9VFXSW2JKB3392D"), nil)
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/visit-mark.json", "", nil)
+	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockUpload("user-1/01DTVP434PA9VFXSW2JKB3392D/partition-0-visit-mark.json", nil)
 	bucketClient.MockGet("user-1/bucket-index-sync-status.json", "", nil)
-	bucketClient.MockUpload("user-1/01DTVP434PA9VFXSW2JKB3392D/visit-mark.json", nil)
 	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/meta.json", mockBlockMetaJSON("01FN6CDF3PNEWWRY5MPGJPE3EX"), nil)
 	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/visit-mark.json", "", nil)
-	bucketClient.MockUpload("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/visit-mark.json", nil)
+	bucketClient.MockGet("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockUpload("user-1/01FN6CDF3PNEWWRY5MPGJPE3EX/partition-0-visit-mark.json", nil)
 	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/meta.json", mockBlockMetaJSON("01DTW0ZCPDDNV4BV83Q2SV4QAZ"), nil)
 	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/visit-mark.json", "", nil)
-	bucketClient.MockUpload("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/visit-mark.json", nil)
+	bucketClient.MockGet("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockUpload("user-2/01DTW0ZCPDDNV4BV83Q2SV4QAZ/partition-0-visit-mark.json", nil)
 	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/meta.json", mockBlockMetaJSON("01FN3V83ABR9992RF8WRJZ76ZQ"), nil)
 	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/deletion-mark.json", "", nil)
 	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/visit-mark.json", "", nil)
-	bucketClient.MockUpload("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/visit-mark.json", nil)
+	bucketClient.MockGet("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockUpload("user-2/01FN3V83ABR9992RF8WRJZ76ZQ/partition-0-visit-mark.json", nil)
 	bucketClient.MockGet("user-1/bucket-index.json.gz", "", nil)
 	bucketClient.MockGet("user-2/bucket-index.json.gz", "", nil)
 	bucketClient.MockGet("user-1/bucket-index-sync-status.json", "", nil)
@@ -1012,17 +1067,23 @@ func TestCompactor_ShouldCompactAllUsersOnShardingEnabledButOnlyOneInstanceRunni
 	bucketClient.MockUpload("user-2/bucket-index.json.gz", nil)
 	bucketClient.MockUpload("user-1/bucket-index-sync-status.json", nil)
 	bucketClient.MockUpload("user-2/bucket-index-sync-status.json", nil)
+	bucketClient.MockGet("user-1/partitioned-groups/"+partitionedGroupID1+".json", "", nil)
+	bucketClient.MockUpload("user-1/partitioned-groups/"+partitionedGroupID1+".json", nil)
+	bucketClient.MockGet("user-2/partitioned-groups/"+partitionedGroupID2+".json", "", nil)
+	bucketClient.MockUpload("user-2/partitioned-groups/"+partitionedGroupID2+".json", nil)
+	bucketClient.MockIter("user-1/"+PartitionedGroupDirectory, nil, nil)
+	bucketClient.MockIter("user-2/"+PartitionedGroupDirectory, nil, nil)
 
 	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
-	cfg := prepareConfig()
+	cfg := prepareConfigForPartitioning()
 	cfg.ShardingEnabled = true
 	cfg.ShardingRing.InstanceID = "compactor-1"
 	cfg.ShardingRing.InstanceAddr = "1.2.3.4"
 	cfg.ShardingRing.KVStore.Mock = ringStore
 
-	c, _, tsdbPlanner, logs, _ := prepare(t, cfg, bucketClient, nil)
+	c, _, tsdbPlanner, logs, _ := prepareForPartitioning(t, cfg, bucketClient, nil, nil)
 
 	// Mock the planner as if there's no compaction to do,
 	// in order to simplify tests (all in all, we just want to
@@ -1033,7 +1094,7 @@ func TestCompactor_ShouldCompactAllUsersOnShardingEnabledButOnlyOneInstanceRunni
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, 5*time.Second, 1.0, func() interface{} {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() interface{} {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -1064,8 +1125,7 @@ func TestCompactor_ShouldCompactAllUsersOnShardingEnabledButOnlyOneInstanceRunni
 	}, removeIgnoredLogs(strings.Split(strings.TrimSpace(logs.String()), "\n")))
 }
 
-func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndMultipleInstancesRunning(t *testing.T) {
-	t.Parallel()
+func TestPartitionCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndMultipleInstancesRunning(t *testing.T) {
 
 	numUsers := 100
 
@@ -1080,6 +1140,7 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 	bucketClient.MockIter("", userIDs, nil)
 	bucketClient.MockIter("__markers__", []string{}, nil)
 	for _, userID := range userIDs {
+		partitionedGroupID := getPartitionedGroupID(userID)
 		bucketClient.MockIter(userID+"/", []string{userID + "/01DTVP434PA9VFXSW2JKB3392D"}, nil)
 		bucketClient.MockIter(userID+"/markers/", nil, nil)
 		bucketClient.MockGet(userID+"/markers/cleaner-visit-marker.json", "", nil)
@@ -1090,12 +1151,14 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 		bucketClient.MockGet(userID+"/01DTVP434PA9VFXSW2JKB3392D/meta.json", mockBlockMetaJSON("01DTVP434PA9VFXSW2JKB3392D"), nil)
 		bucketClient.MockGet(userID+"/01DTVP434PA9VFXSW2JKB3392D/deletion-mark.json", "", nil)
 		bucketClient.MockGet(userID+"/01DTVP434PA9VFXSW2JKB3392D/no-compact-mark.json", "", nil)
-		bucketClient.MockGet(userID+"/01DTVP434PA9VFXSW2JKB3392D/visit-mark.json", "", nil)
+		bucketClient.MockGet(userID+"/01DTVP434PA9VFXSW2JKB3392D/partition-0-visit-mark.json", "", nil)
 		bucketClient.MockGet(userID+"/bucket-index-sync-status.json", "", nil)
-		bucketClient.MockUpload(userID+"/01DTVP434PA9VFXSW2JKB3392D/visit-mark.json", nil)
 		bucketClient.MockGet(userID+"/bucket-index.json.gz", "", nil)
 		bucketClient.MockUpload(userID+"/bucket-index.json.gz", nil)
 		bucketClient.MockUpload(userID+"/bucket-index-sync-status.json", nil)
+		bucketClient.MockGet(userID+"/partitioned-groups/"+partitionedGroupID+".json", "", nil)
+		bucketClient.MockUpload(userID+"/partitioned-groups/"+partitionedGroupID+".json", nil)
+		bucketClient.MockIter(userID+"/"+PartitionedGroupDirectory, nil, nil)
 	}
 
 	// Create a shared KV Store
@@ -1107,7 +1170,7 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 	var logs []*concurrency.SyncBuffer
 
 	for i := 1; i <= 2; i++ {
-		cfg := prepareConfig()
+		cfg := prepareConfigForPartitioning()
 		cfg.ShardingEnabled = true
 		cfg.ShardingRing.InstanceID = fmt.Sprintf("compactor-%d", i)
 		cfg.ShardingRing.InstanceAddr = fmt.Sprintf("127.0.0.%d", i)
@@ -1115,7 +1178,7 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 		cfg.ShardingRing.WaitStabilityMaxDuration = 10 * time.Second
 		cfg.ShardingRing.KVStore.Mock = kvstore
 
-		c, _, tsdbPlanner, l, _ := prepare(t, cfg, bucketClient, nil)
+		c, _, tsdbPlanner, l, _ := prepareForPartitioning(t, cfg, bucketClient, nil, nil)
 		defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
 
 		compactors = append(compactors, c)
@@ -1135,8 +1198,8 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 
 	// Wait until a run has been completed on each compactor
 	for _, c := range compactors {
-		cortex_testutil.Poll(t, 10*time.Second, true, func() interface{} {
-			return prom_testutil.ToFloat64(c.CompactionRunsCompleted) > 1
+		cortex_testutil.Poll(t, 20*time.Second, true, func() interface{} {
+			return prom_testutil.ToFloat64(c.CompactionRunsCompleted) >= 1
 		})
 	}
 
@@ -1148,7 +1211,7 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 	}
 }
 
-func TestCompactor_ShouldCompactOnlyShardsOwnedByTheInstanceOnShardingEnabledWithShuffleShardingAndMultipleInstancesRunning(t *testing.T) {
+func TestPartitionCompactor_ShouldCompactOnlyShardsOwnedByTheInstanceOnShardingEnabledWithShuffleShardingAndMultipleInstancesRunning(t *testing.T) {
 	t.Parallel()
 
 	numUsers := 3
@@ -1196,25 +1259,31 @@ func TestCompactor_ShouldCompactOnlyShardsOwnedByTheInstanceOnShardingEnabledWit
 		blockFiles := []string{}
 
 		for blockID, blockTimes := range blocks {
-			blockVisitMarker := BlockVisitMarker{
-				CompactorID: "test-compactor",
-				VisitTime:   time.Now().Unix(),
-				Version:     VisitMarkerVersion1,
+			groupHash := hashGroup(userID, blockTimes["startTime"], blockTimes["endTime"])
+			visitMarker := partitionVisitMarker{
+				CompactorID:        "test-compactor",
+				VisitTime:          time.Now().Unix(),
+				PartitionedGroupID: groupHash,
+				PartitionID:        0,
+				Status:             Pending,
+				Version:            PartitionVisitMarkerVersion1,
 			}
-			visitMarkerFileContent, _ := json.Marshal(blockVisitMarker)
+			visitMarkerFileContent, _ := json.Marshal(visitMarker)
 			bucketClient.MockGet(userID+"/bucket-index-sync-status.json", "", nil)
 			bucketClient.MockGet(userID+"/"+blockID+"/meta.json", mockBlockMetaJSONWithTime(blockID, userID, blockTimes["startTime"], blockTimes["endTime"]), nil)
 			bucketClient.MockGet(userID+"/"+blockID+"/deletion-mark.json", "", nil)
 			bucketClient.MockGet(userID+"/"+blockID+"/no-compact-mark.json", "", nil)
-			bucketClient.MockGet(userID+"/"+blockID+"/visit-mark.json", string(visitMarkerFileContent), nil)
-			bucketClient.MockGetRequireUpload(userID+"/"+blockID+"/visit-mark.json", string(visitMarkerFileContent), nil)
-			bucketClient.MockUpload(userID+"/"+blockID+"/visit-mark.json", nil)
+			bucketClient.MockGet(userID+"/"+blockID+"/partition-0-visit-mark.json", "", nil)
+			bucketClient.MockGet(userID+"/partitioned-groups/visit-marks/"+fmt.Sprint(groupHash)+"/partition-0-visit-mark.json", string(visitMarkerFileContent), nil)
+			bucketClient.MockGetRequireUpload(userID+"/partitioned-groups/visit-marks/"+fmt.Sprint(groupHash)+"/partition-0-visit-mark.json", string(visitMarkerFileContent), nil)
+			bucketClient.MockUpload(userID+"/partitioned-groups/visit-marks/"+fmt.Sprint(groupHash)+"/partition-0-visit-mark.json", nil)
 			// Iter with recursive so expected to get objects rather than directories.
 			blockFiles = append(blockFiles, path.Join(userID, blockID, block.MetaFilename))
 
 			// Get all of the unique group hashes so that they can be used to ensure all groups were compacted
-			groupHash := hashGroup(userID, blockTimes["startTime"], blockTimes["endTime"])
 			groupHashes[groupHash]++
+			bucketClient.MockGet(userID+"/partitioned-groups/"+fmt.Sprint(groupHash)+".json", "", nil)
+			bucketClient.MockUpload(userID+"/partitioned-groups/"+fmt.Sprint(groupHash)+".json", nil)
 		}
 
 		bucketClient.MockIter(userID+"/", blockFiles, nil)
@@ -1227,6 +1296,7 @@ func TestCompactor_ShouldCompactOnlyShardsOwnedByTheInstanceOnShardingEnabledWit
 		bucketClient.MockGet(userID+"/bucket-index.json.gz", "", nil)
 		bucketClient.MockUpload(userID+"/bucket-index.json.gz", nil)
 		bucketClient.MockUpload(userID+"/bucket-index-sync-status.json", nil)
+		bucketClient.MockIter(userID+"/"+PartitionedGroupDirectory, nil, nil)
 	}
 
 	// Create a shared KV Store
@@ -1238,7 +1308,7 @@ func TestCompactor_ShouldCompactOnlyShardsOwnedByTheInstanceOnShardingEnabledWit
 	var logs []*concurrency.SyncBuffer
 
 	for i := 1; i <= 4; i++ {
-		cfg := prepareConfig()
+		cfg := prepareConfigForPartitioning()
 		cfg.ShardingEnabled = true
 		cfg.CompactionInterval = 15 * time.Second
 		cfg.ShardingStrategy = util.ShardingStrategyShuffle
@@ -1252,7 +1322,7 @@ func TestCompactor_ShouldCompactOnlyShardsOwnedByTheInstanceOnShardingEnabledWit
 		flagext.DefaultValues(limits)
 		limits.CompactorTenantShardSize = 3
 
-		c, _, tsdbPlanner, l, _ := prepare(t, cfg, bucketClient, limits)
+		c, _, tsdbPlanner, l, _ := prepareForPartitioning(t, cfg, bucketClient, limits, nil)
 		defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
 
 		compactors = append(compactors, c)
@@ -1278,7 +1348,7 @@ func TestCompactor_ShouldCompactOnlyShardsOwnedByTheInstanceOnShardingEnabledWit
 
 	// Wait until a run has been completed on each compactor
 	for _, c := range compactors {
-		cortex_testutil.Poll(t, 60*time.Second, 2.0, func() interface{} {
+		cortex_testutil.Poll(t, 60*time.Second, 1.0, func() interface{} {
 			return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 		})
 	}
@@ -1286,7 +1356,7 @@ func TestCompactor_ShouldCompactOnlyShardsOwnedByTheInstanceOnShardingEnabledWit
 	// Ensure that each group was only compacted by exactly one compactor
 	for groupHash, blockCount := range groupHashes {
 
-		l, found, err := checkLogsForCompaction(compactors, logs, groupHash)
+		l, found, err := checkLogsForPartitionCompaction(compactors, logs, groupHash)
 		require.NoError(t, err)
 
 		// If the blockCount < 2 then the group shouldn't have been compacted, therefore not found in the logs
@@ -1294,26 +1364,20 @@ func TestCompactor_ShouldCompactOnlyShardsOwnedByTheInstanceOnShardingEnabledWit
 			assert.False(t, found)
 		} else {
 			assert.True(t, found)
-			assert.Contains(t, l.String(), fmt.Sprintf(`msg="found compactable group for user" group_hash=%d`, groupHash))
+			assert.Contains(t, l.String(), fmt.Sprintf(`group_hash=%d msg="found compactable group for user"`, groupHash))
 		}
 	}
 }
 
-// checkLogsForCompaction checks the logs to see if a compaction has happened on the groupHash,
+// checkLogsForPartitionCompaction checks the logs to see if a compaction has happened on the groupHash,
 // if there has been a compaction it will return the logs of the compactor that handled the group
 // and will return true. Otherwise this function will return a nil value for the logs and false
 // as the group was not compacted
-func checkLogsForCompaction(compactors []*Compactor, logs []*concurrency.SyncBuffer, groupHash uint32) (*concurrency.SyncBuffer, bool, error) {
+func checkLogsForPartitionCompaction(compactors []*Compactor, logs []*concurrency.SyncBuffer, groupHash uint32) (*concurrency.SyncBuffer, bool, error) {
 	var log *concurrency.SyncBuffer
 
-	// Make sure that the group_hash is only owned by a single compactor
 	for _, l := range logs {
-		owned := strings.Contains(l.String(), fmt.Sprintf(`msg="found compactable group for user" group_hash=%d`, groupHash))
-
-		// Ensure the group is not owned by multiple compactors
-		if owned && log != nil {
-			return nil, false, fmt.Errorf("group with group_hash=%d owned by multiple compactors", groupHash)
-		}
+		owned := strings.Contains(l.String(), fmt.Sprintf(`group_hash=%d msg="found compactable group for user"`, groupHash))
 		if owned {
 			log = l
 		}
@@ -1327,217 +1391,15 @@ func checkLogsForCompaction(compactors []*Compactor, logs []*concurrency.SyncBuf
 	return log, true, nil
 }
 
-func createTSDBBlock(t *testing.T, bkt objstore.Bucket, userID string, minT, maxT int64, externalLabels map[string]string) ulid.ULID {
-	// Create a temporary dir for TSDB.
-	tempDir := t.TempDir()
+func prepareConfigForPartitioning() Config {
+	compactorCfg := prepareConfig()
 
-	// Create a temporary dir for the snapshot.
-	snapshotDir := t.TempDir()
-
-	// Create a new TSDB.
-	db, err := tsdb.Open(tempDir, nil, nil, &tsdb.Options{
-		MinBlockDuration:  int64(2 * 60 * 60 * 1000), // 2h period
-		MaxBlockDuration:  int64(2 * 60 * 60 * 1000), // 2h period
-		RetentionDuration: int64(15 * 86400 * 1000),  // 15 days
-	}, nil)
-	require.NoError(t, err)
-
-	db.DisableCompactions()
-
-	// Append a sample at the beginning and one at the end of the time range.
-	for i, ts := range []int64{minT, maxT - 1} {
-		lbls := labels.Labels{labels.Label{Name: "series_id", Value: strconv.Itoa(i)}}
-
-		app := db.Appender(context.Background())
-		_, err := app.Append(0, lbls, ts, float64(i))
-		require.NoError(t, err)
-
-		err = app.Commit()
-		require.NoError(t, err)
-	}
-
-	require.NoError(t, db.Compact(context.Background()))
-	require.NoError(t, db.Snapshot(snapshotDir, true))
-
-	// Look for the created block (we expect one).
-	entries, err := os.ReadDir(snapshotDir)
-	require.NoError(t, err)
-	require.Len(t, entries, 1)
-	require.True(t, entries[0].IsDir())
-
-	blockID, err := ulid.Parse(entries[0].Name())
-	require.NoError(t, err)
-
-	// Inject Thanos external labels to the block.
-	meta := metadata.Thanos{
-		Labels: externalLabels,
-		Source: "test",
-	}
-	_, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(snapshotDir, blockID.String()), meta, nil)
-	require.NoError(t, err)
-
-	// Copy the block files to the bucket.
-	srcRoot := filepath.Join(snapshotDir, blockID.String())
-	require.NoError(t, filepath.Walk(srcRoot, func(file string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			return nil
-		}
-
-		// Read the file content in memory.
-		content, err := os.ReadFile(file)
-		if err != nil {
-			return err
-		}
-
-		// Upload it to the bucket.
-		relPath, err := filepath.Rel(srcRoot, file)
-		if err != nil {
-			return err
-		}
-
-		return bkt.Upload(context.Background(), path.Join(userID, blockID.String(), relPath), bytes.NewReader(content))
-	}))
-
-	return blockID
-}
-
-func createDeletionMark(t *testing.T, bkt objstore.Bucket, userID string, blockID ulid.ULID, deletionTime time.Time) {
-	content := mockDeletionMarkJSON(blockID.String(), deletionTime)
-	blockPath := path.Join(userID, blockID.String())
-	markPath := path.Join(blockPath, metadata.DeletionMarkFilename)
-
-	require.NoError(t, bkt.Upload(context.Background(), markPath, strings.NewReader(content)))
-}
-
-func createNoCompactionMark(t *testing.T, bkt objstore.Bucket, userID string, blockID ulid.ULID) {
-	content := mockNoCompactBlockJSON(blockID.String())
-	blockPath := path.Join(userID, blockID.String())
-	markPath := path.Join(blockPath, metadata.NoCompactMarkFilename)
-
-	require.NoError(t, bkt.Upload(context.Background(), markPath, strings.NewReader(content)))
-}
-
-func createBlockVisitMarker(t *testing.T, bkt objstore.Bucket, userID string, blockID ulid.ULID) {
-	content := mockBlockVisitMarker()
-	blockPath := path.Join(userID, blockID.String())
-	markPath := path.Join(blockPath, BlockVisitMarkerFile)
-
-	require.NoError(t, bkt.Upload(context.Background(), markPath, strings.NewReader(content)))
-}
-
-func findCompactorByUserID(compactors []*Compactor, logs []*concurrency.SyncBuffer, userID string) (*Compactor, *concurrency.SyncBuffer, error) {
-	var compactor *Compactor
-	var log *concurrency.SyncBuffer
-
-	for i, c := range compactors {
-		owned, err := c.ownUserForCompaction(userID)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// Ensure the user is not owned by multiple compactors
-		if owned && compactor != nil {
-			return nil, nil, fmt.Errorf("user %s owned by multiple compactors", userID)
-		}
-		if owned {
-			compactor = c
-			log = logs[i]
-		}
-	}
-
-	// Return an error if we've not been able to find it
-	if compactor == nil {
-		return nil, nil, fmt.Errorf("user %s not owned by any compactor", userID)
-	}
-
-	return compactor, log, nil
-}
-
-func removeIgnoredLogs(input []string) []string {
-	ignoredLogStringsMap := map[string]struct{}{
-		// Since we moved to the component logger from the global logger for the ring these lines are now expected, but are just ring setup information.
-		`level=info component=compactor msg="ring doesn't exist in KV store yet"`:                                                                                 {},
-		`level=info component=compactor msg="not loading tokens from file, tokens file path is empty"`:                                                            {},
-		`level=info component=compactor msg="instance not found in ring, adding with no tokens" ring=compactor`:                                                   {},
-		`level=debug component=compactor msg="JoinAfter expired" ring=compactor`:                                                                                  {},
-		`level=info component=compactor msg="auto-joining cluster after timeout" ring=compactor`:                                                                  {},
-		`level=info component=compactor msg="lifecycler loop() exited gracefully" ring=compactor`:                                                                 {},
-		`level=info component=compactor msg="changing instance state from" old_state=ACTIVE new_state=LEAVING ring=compactor`:                                     {},
-		`level=error component=compactor msg="failed to set state to LEAVING" ring=compactor err="Changing instance state from LEAVING -> LEAVING is disallowed"`: {},
-		`level=error component=compactor msg="failed to set state to LEAVING" ring=compactor err="Changing instance state from JOINING -> LEAVING is disallowed"`: {},
-		`level=debug component=compactor msg="unregistering instance from ring" ring=compactor`:                                                                   {},
-		`level=info component=compactor msg="instance removed from the KV store" ring=compactor`:                                                                  {},
-		`level=info component=compactor msg="observing tokens before going ACTIVE" ring=compactor`:                                                                {},
-		`level=info component=compactor msg="lifecycler entering final sleep before shutdown" final_sleep=0s`:                                                     {},
-		`level=info component=compactor msg="compactor stopped"`:                                                                                                  {},
-	}
-
-	ignoredLogStringsRegexList := []*regexp.Regexp{
-		regexp.MustCompile(`^level=(info|debug|warn) component=cleaner .+$`),
-		regexp.MustCompile(`^level=info component=compactor msg="set state" .+$`),
-	}
-
-	out := make([]string, 0, len(input))
-	durationRe := regexp.MustCompile(`\s?duration(_ms)?=\S+`)
-	executionIDRe := regexp.MustCompile(`\s?execution_id=\S+`)
-
-main:
-	for i := 0; i < len(input); i++ {
-		log := input[i]
-
-		// Remove any duration from logs.
-		log = durationRe.ReplaceAllString(log, "")
-
-		// Remove any execution_id from logs.
-		log = executionIDRe.ReplaceAllString(log, "")
-
-		if strings.Contains(log, "block.MetaFetcher") || strings.Contains(log, "block.BaseFetcher") {
-			continue
-		}
-
-		if _, exists := ignoredLogStringsMap[log]; exists {
-			continue
-		}
-
-		for _, ignoreRegex := range ignoredLogStringsRegexList {
-			if ignoreRegex.MatchString(log) {
-				continue main
-			}
-		}
-
-		out = append(out, log)
-	}
-
-	return out
-}
-
-func prepareConfig() Config {
-	compactorCfg := Config{}
-	flagext.DefaultValues(&compactorCfg)
-
-	compactorCfg.retryMinBackoff = 0
-	compactorCfg.retryMaxBackoff = 0
-
-	//Avoid jitter in startup
-	compactorCfg.CompactionInterval = 1 * time.Second
-
-	// The migration is tested in a dedicated test.
-	compactorCfg.BlockDeletionMarksMigrationEnabled = false
-
-	// Do not wait for ring stability by default, in order to speed up tests.
-	compactorCfg.ShardingRing.WaitStabilityMinDuration = 0
-	compactorCfg.ShardingRing.WaitStabilityMaxDuration = 0
-
-	// Set lower timeout for waiting on compactor to become ACTIVE in the ring for unit tests
-	compactorCfg.ShardingRing.WaitActiveInstanceTimeout = 5 * time.Second
+	compactorCfg.CompactionStrategy = util.CompactionStrategyPartitioning
 
 	return compactorCfg
 }
 
-func prepare(t *testing.T, compactorCfg Config, bucketClient objstore.InstrumentedBucket, limits *validation.Limits) (*Compactor, *tsdbCompactorMock, *tsdbPlannerMock, *concurrency.SyncBuffer, prometheus.Gatherer) {
+func prepareForPartitioning(t *testing.T, compactorCfg Config, bucketClient objstore.InstrumentedBucket, limits *validation.Limits, tsdbGrouper *tsdbGrouperMock) (*Compactor, *tsdbCompactorMock, *tsdbPlannerMock, *concurrency.SyncBuffer, prometheus.Gatherer) {
 	storageCfg := cortex_tsdb.BlocksStorageConfig{}
 	flagext.DefaultValues(&storageCfg)
 	storageCfg.BucketStore.BlockDiscoveryStrategy = string(cortex_tsdb.RecursiveDiscovery)
@@ -1575,158 +1437,91 @@ func prepare(t *testing.T, compactorCfg Config, bucketClient objstore.Instrument
 	}
 
 	var blocksGrouperFactory BlocksGrouperFactory
-	if compactorCfg.ShardingStrategy == util.ShardingStrategyShuffle {
-		blocksGrouperFactory = ShuffleShardingGrouperFactory
+	if tsdbGrouper != nil {
+		blocksGrouperFactory = func(_ context.Context, _ Config, _ objstore.InstrumentedBucket, _ log.Logger, _ prometheus.Counter, _ prometheus.Counter, _ prometheus.Counter, _ *compact.SyncerMetrics, _ *compactorMetrics, _ *ring.Ring, _ *ring.Lifecycler, _ Limits, _ string, _ *compact.GatherNoCompactionMarkFilter, _ int) compact.Grouper {
+			return tsdbGrouper
+		}
 	} else {
-		blocksGrouperFactory = DefaultBlocksGrouperFactory
+		if compactorCfg.ShardingStrategy == util.ShardingStrategyShuffle {
+			blocksGrouperFactory = ShuffleShardingGrouperFactory
+		} else {
+			blocksGrouperFactory = DefaultBlocksGrouperFactory
+		}
 	}
 
-	c, err := newCompactor(compactorCfg, storageCfg, logger, registry, bucketClientFactory, blocksGrouperFactory, blocksCompactorFactory, DefaultBlockDeletableCheckerFactory, DefaultCompactionLifecycleCallbackFactory, overrides, 1)
+	var blockDeletableCheckerFactory BlockDeletableCheckerFactory
+	if compactorCfg.ShardingStrategy == util.ShardingStrategyShuffle {
+		blockDeletableCheckerFactory = PartitionCompactionBlockDeletableCheckerFactory
+	} else {
+		blockDeletableCheckerFactory = DefaultBlockDeletableCheckerFactory
+	}
+
+	var compactionLifecycleCallbackFactory CompactionLifecycleCallbackFactory
+	if compactorCfg.ShardingStrategy == util.ShardingStrategyShuffle {
+		compactionLifecycleCallbackFactory = ShardedCompactionLifecycleCallbackFactory
+	} else {
+		compactionLifecycleCallbackFactory = DefaultCompactionLifecycleCallbackFactory
+	}
+
+	c, err := newCompactor(compactorCfg, storageCfg, logger, registry, bucketClientFactory, blocksGrouperFactory, blocksCompactorFactory, blockDeletableCheckerFactory, compactionLifecycleCallbackFactory, overrides, 1)
 	require.NoError(t, err)
 
 	return c, tsdbCompactor, tsdbPlanner, logs, registry
 }
 
-type tsdbCompactorMock struct {
+type tsdbGrouperMock struct {
 	mock.Mock
 }
 
-func (m *tsdbCompactorMock) Plan(dir string) ([]string, error) {
-	args := m.Called(dir)
-	return args.Get(0).([]string), args.Error(1)
+func (m *tsdbGrouperMock) Groups(blocks map[ulid.ULID]*metadata.Meta) (res []*compact.Group, err error) {
+	args := m.Called(blocks)
+	return args.Get(0).([]*compact.Group), args.Error(1)
 }
 
-func (m *tsdbCompactorMock) Compact(dest string, dirs []string, open []*tsdb.Block) ([]ulid.ULID, error) {
-	args := m.Called(dest, dirs, open)
-	return args.Get(0).([]ulid.ULID), args.Error(1)
+var (
+	BlockMinTime = int64(1574776800000)
+	BlockMaxTime = int64(1574784000000)
+)
+
+func getPartitionedGroupID(userID string) string {
+	return fmt.Sprint(hashGroup(userID, BlockMinTime, BlockMaxTime))
 }
 
-func (m *tsdbCompactorMock) CompactWithBlockPopulator(dest string, dirs []string, open []*tsdb.Block, blockPopulator tsdb.BlockPopulator) ([]ulid.ULID, error) {
-	args := m.Called(dest, dirs, open, blockPopulator)
-	return args.Get(0).([]ulid.ULID), args.Error(1)
-}
-
-type tsdbPlannerMock struct {
-	mock.Mock
-	noCompactMarkFilters []*compact.GatherNoCompactionMarkFilter
-}
-
-func (m *tsdbPlannerMock) Plan(ctx context.Context, metasByMinTime []*metadata.Meta, errChan chan error, extensions any) ([]*metadata.Meta, error) {
-	args := m.Called(ctx, metasByMinTime, errChan, extensions)
-	return args.Get(0).([]*metadata.Meta), args.Error(1)
-}
-
-func (m *tsdbPlannerMock) getNoCompactBlocks() []string {
-
-	result := []string{}
-
-	for _, noCompactMarkFilter := range m.noCompactMarkFilters {
-		for _, mark := range noCompactMarkFilter.NoCompactMarkedBlocks() {
-			result = append(result, mark.ID.String())
+func mockBlockGroup(userID string, ids []string, bkt *bucket.ClientMock) *compact.Group {
+	dummyCounter := prometheus.NewCounter(prometheus.CounterOpts{})
+	group, _ := compact.NewGroup(
+		log.NewNopLogger(),
+		bkt,
+		getPartitionedGroupID(userID),
+		nil,
+		0,
+		true,
+		true,
+		dummyCounter,
+		dummyCounter,
+		dummyCounter,
+		dummyCounter,
+		dummyCounter,
+		dummyCounter,
+		dummyCounter,
+		dummyCounter,
+		metadata.NoneFunc,
+		1,
+		1,
+	)
+	for _, id := range ids {
+		meta := mockBlockMeta(id)
+		err := group.AppendMeta(&metadata.Meta{
+			BlockMeta: meta,
+		})
+		if err != nil {
+			continue
 		}
 	}
-
-	return result
+	return group
 }
 
-func mockBlockMeta(id string) tsdb.BlockMeta {
-	return tsdb.BlockMeta{
-		Version: 1,
-		ULID:    ulid.MustParse(id),
-		MinTime: 1574776800000,
-		MaxTime: 1574784000000,
-		Compaction: tsdb.BlockMetaCompaction{
-			Level:   1,
-			Sources: []ulid.ULID{ulid.MustParse(id)},
-		},
-	}
-}
-
-func mockBlockMetaJSON(id string) string {
-	meta := mockBlockMeta(id)
-
-	content, err := json.Marshal(meta)
-	if err != nil {
-		panic("failed to marshal mocked block meta")
-	}
-
-	return string(content)
-}
-
-func mockNoCompactBlockJSON(id string) string {
-	meta := metadata.NoCompactMark{
-		Version:       1,
-		ID:            ulid.MustParse(id),
-		NoCompactTime: time.Now().Unix(),
-		Details:       "yolo",
-		Reason:        "testing",
-	}
-
-	content, err := json.Marshal(meta)
-	if err != nil {
-		panic("failed to marshal mocked block no compact mark")
-	}
-
-	return string(content)
-}
-
-func mockDeletionMarkJSON(id string, deletionTime time.Time) string {
-	meta := metadata.DeletionMark{
-		Version:      metadata.DeletionMarkVersion1,
-		ID:           ulid.MustParse(id),
-		DeletionTime: deletionTime.Unix(),
-	}
-
-	content, err := json.Marshal(meta)
-	if err != nil {
-		panic("failed to marshal mocked block deletion mark")
-	}
-
-	return string(content)
-}
-
-func mockBlockMetaJSONWithTime(id string, orgID string, minTime int64, maxTime int64) string {
-	meta := metadata.Meta{
-		Thanos: metadata.Thanos{
-			Labels: map[string]string{"__org_id__": orgID},
-		},
-	}
-
-	meta.BlockMeta = tsdb.BlockMeta{
-		Version: 1,
-		ULID:    ulid.MustParse(id),
-		MinTime: minTime,
-		MaxTime: maxTime,
-		Compaction: tsdb.BlockMetaCompaction{
-			Level:   1,
-			Sources: []ulid.ULID{ulid.MustParse(id)},
-		},
-	}
-
-	content, err := json.Marshal(meta)
-	if err != nil {
-		panic("failed to marshal mocked block meta")
-	}
-
-	return string(content)
-}
-
-func mockBlockVisitMarker() string {
-	blockVisitMarker := BlockVisitMarker{
-		CompactorID: "dummy",
-		VisitTime:   time.Now().Unix(),
-		Version:     1,
-	}
-
-	content, err := json.Marshal(blockVisitMarker)
-	if err != nil {
-		panic("failed to marshal mocked block visit marker")
-	}
-
-	return string(content)
-}
-
-func TestCompactor_DeleteLocalSyncFiles(t *testing.T) {
+func TestPartitionCompactor_DeleteLocalSyncFiles(t *testing.T) {
 	numUsers := 10
 
 	// Setup user IDs
@@ -1750,7 +1545,7 @@ func TestCompactor_DeleteLocalSyncFiles(t *testing.T) {
 	var compactors []*Compactor
 
 	for i := 1; i <= 2; i++ {
-		cfg := prepareConfig()
+		cfg := prepareConfigForPartitioning()
 
 		cfg.ShardingEnabled = true
 		cfg.ShardingRing.InstanceID = fmt.Sprintf("compactor-%d", i)
@@ -1760,7 +1555,7 @@ func TestCompactor_DeleteLocalSyncFiles(t *testing.T) {
 		cfg.ShardingRing.KVStore.Mock = kvstore
 
 		// Each compactor will get its own temp dir for storing local files.
-		c, _, tsdbPlanner, _, _ := prepare(t, cfg, inmem, nil)
+		c, _, tsdbPlanner, _, _ := prepareForPartitioning(t, cfg, inmem, nil, nil)
 		t.Cleanup(func() {
 			require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
 		})
@@ -1782,8 +1577,8 @@ func TestCompactor_DeleteLocalSyncFiles(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c1))
 
 	// Wait until a run has been completed on first compactor. This happens as soon as compactor starts.
-	cortex_testutil.Poll(t, 10*time.Second, 1.0, func() interface{} {
-		return prom_testutil.ToFloat64(c1.CompactionRunsCompleted)
+	cortex_testutil.Poll(t, 20*time.Second, true, func() interface{} {
+		return prom_testutil.ToFloat64(c1.CompactionRunsCompleted) >= 1
 	})
 
 	require.NoError(t, os.Mkdir(c1.metaSyncDirForUser("new-user"), 0600))
@@ -1793,7 +1588,7 @@ func TestCompactor_DeleteLocalSyncFiles(t *testing.T) {
 
 	// Now start second compactor, and wait until it runs compaction.
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c2))
-	cortex_testutil.Poll(t, 10*time.Second, 1.0, func() interface{} {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() interface{} {
 		return prom_testutil.ToFloat64(c2.CompactionRunsCompleted)
 	})
 
@@ -1810,7 +1605,7 @@ func TestCompactor_DeleteLocalSyncFiles(t *testing.T) {
 	require.Equal(t, numUsers, c1Users+c2Users)
 }
 
-func TestCompactor_ShouldFailCompactionOnTimeout(t *testing.T) {
+func TestPartitionCompactor_ShouldFailCompactionOnTimeout(t *testing.T) {
 	t.Parallel()
 
 	// Mock the bucket
@@ -1821,7 +1616,7 @@ func TestCompactor_ShouldFailCompactionOnTimeout(t *testing.T) {
 	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
-	cfg := prepareConfig()
+	cfg := prepareConfigForPartitioning()
 	cfg.ShardingEnabled = true
 	cfg.ShardingRing.InstanceID = "compactor-1"
 	cfg.ShardingRing.InstanceAddr = "1.2.3.4"
@@ -1830,7 +1625,7 @@ func TestCompactor_ShouldFailCompactionOnTimeout(t *testing.T) {
 	// Set ObservePeriod to longer than the timeout period to mock a timeout while waiting on ring to become ACTIVE
 	cfg.ShardingRing.ObservePeriod = time.Second * 10
 
-	c, _, _, logs, _ := prepare(t, cfg, bucketClient, nil)
+	c, _, _, logs, _ := prepareForPartitioning(t, cfg, bucketClient, nil, nil)
 
 	// Try to start the compactor with a bad consul kv-store. The
 	err := services.StartAndAwaitRunning(context.Background(), c)
@@ -1839,81 +1634,80 @@ func TestCompactor_ShouldFailCompactionOnTimeout(t *testing.T) {
 	assert.Equal(t, context.DeadlineExceeded, err)
 
 	assert.ElementsMatch(t, []string{
-		`level=info component=compactor msg="auto joined with new tokens" ring=compactor state=JOINING`,
 		`level=info component=compactor msg="compactor started"`,
 		`level=info component=compactor msg="waiting until compactor is ACTIVE in the ring"`,
+		`level=info component=compactor msg="auto joined with new tokens" ring=compactor state=JOINING`,
 		`level=error component=compactor msg="compactor failed to become ACTIVE in the ring" err="context deadline exceeded"`,
 	}, removeIgnoredLogs(strings.Split(strings.TrimSpace(logs.String()), "\n")))
 }
 
-func TestCompactor_ShouldNotTreatInterruptionsAsErrors(t *testing.T) {
-	bucketClient := objstore.WithNoopInstr(objstore.NewInMemBucket())
-	id := ulid.MustNew(ulid.Now(), rand.Reader)
-	require.NoError(t, bucketClient.Upload(context.Background(), "user-1/"+id.String()+"/meta.json", strings.NewReader(mockBlockMetaJSON(id.String()))))
+func TestPartitionCompactor_ShouldNotHangIfPlannerReturnNothing(t *testing.T) {
+	t.Parallel()
 
-	b1 := createTSDBBlock(t, bucketClient, "user-1", 10, 20, map[string]string{"__name__": "Teste"})
-	b2 := createTSDBBlock(t, bucketClient, "user-1", 20, 30, map[string]string{"__name__": "Teste"})
+	ss := bucketindex.Status{Status: bucketindex.CustomerManagedKeyError, Version: bucketindex.SyncStatusFileVersion}
+	content, err := json.Marshal(ss)
+	require.NoError(t, err)
 
-	c, tsdbCompactor, tsdbPlanner, logs, registry := prepare(t, prepareConfig(), bucketClient, nil)
+	partitionedGroupID := getPartitionedGroupID("user-1")
+	bucketClient := &bucket.ClientMock{}
+	bucketClient.MockIter("__markers__", []string{}, nil)
+	bucketClient.MockIter("", []string{"user-1"}, nil)
+	bucketClient.MockIter("user-1/", []string{"user-1/01DTVP434PA9VFXSW2JKB3392D", "user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ"}, nil)
+	bucketClient.MockIter("user-1/markers/", nil, nil)
+	bucketClient.MockGet("user-1/markers/cleaner-visit-marker.json", "", nil)
+	bucketClient.MockUpload("user-1/markers/cleaner-visit-marker.json", nil)
+	bucketClient.MockDelete("user-1/markers/cleaner-visit-marker.json", nil)
+	bucketClient.MockExists(cortex_tsdb.GetGlobalDeletionMarkPath("user-1"), false, nil)
+	bucketClient.MockExists(cortex_tsdb.GetLocalDeletionMarkPath("user-1"), false, nil)
+	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", mockBlockMetaJSON("01DTVP434PA9VFXSW2JKB3392D"), nil)
+	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/deletion-mark.json", "", nil)
+	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/no-compact-mark.json", "", nil)
+	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockGet("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/meta.json", mockBlockMetaJSON("01DTW0ZCPDDNV4BV83Q2SV4QAZ"), nil)
+	bucketClient.MockGet("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/deletion-mark.json", "", nil)
+	bucketClient.MockGet("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/no-compact-mark.json", "", nil)
+	bucketClient.MockGet("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/partition-0-visit-mark.json", "", nil)
+	bucketClient.MockGet("user-1/bucket-index.json.gz", "", nil)
+	bucketClient.MockGet("user-1/bucket-index-sync-status.json", string(content), nil)
+	bucketClient.MockUpload("user-1/bucket-index.json.gz", nil)
+	bucketClient.MockUpload("user-1/bucket-index-sync-status.json", nil)
+	bucketClient.MockIter("user-1/"+PartitionedGroupDirectory, nil, nil)
+	bucketClient.MockGet("user-1/partitioned-groups/visit-marks/"+string(partitionedGroupID)+"/partition-0-visit-mark.json", "", nil)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	tsdbCompactor.On("CompactWithBlockPopulator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ulid.ULID{}, context.Canceled).Run(func(args mock.Arguments) {
-		cancel()
-	})
-	tsdbPlanner.On("Plan", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*metadata.Meta{
-		{
-			BlockMeta: tsdb.BlockMeta{
-				ULID:    b1,
-				MinTime: 10,
-				MaxTime: 20,
-			},
-		},
-		{
-			BlockMeta: tsdb.BlockMeta{
-				ULID:    b2,
-				MinTime: 20,
-				MaxTime: 30,
-			},
-		},
-	}, nil)
-	require.NoError(t, services.StartAndAwaitRunning(ctx, c))
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
-	cortex_testutil.Poll(t, 1*time.Second, 1.0, func() interface{} {
-		return prom_testutil.ToFloat64(c.CompactionRunsInterrupted)
+	cfg := prepareConfigForPartitioning()
+	cfg.ShardingEnabled = true
+	cfg.ShardingRing.InstanceID = "compactor-1"
+	cfg.ShardingRing.InstanceAddr = "1.2.3.4"
+	cfg.ShardingRing.KVStore.Mock = ringStore
+
+	tsdbGrouper := tsdbGrouperMock{}
+	mockGroups := []*compact.Group{mockBlockGroup("user-1", []string{"01DTVP434PA9VFXSW2JKB3392D", "01DTW0ZCPDDNV4BV83Q2SV4QAZ"}, bucketClient)}
+	tsdbGrouper.On("Groups", mock.Anything).Return(mockGroups, nil)
+
+	c, _, tsdbPlanner, _, _ := prepareForPartitioning(t, cfg, bucketClient, nil, &tsdbGrouper)
+	tsdbPlanner.On("Plan", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*metadata.Meta{}, nil)
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
+
+	// Wait until a run has completed.
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() interface{} {
+		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
-
-	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
-		# TYPE cortex_compactor_runs_completed_total counter
-		# HELP cortex_compactor_runs_completed_total Total number of compaction runs successfully completed.
-		cortex_compactor_runs_completed_total 0
-
-		# TYPE cortex_compactor_runs_interrupted_total counter
-		# HELP cortex_compactor_runs_interrupted_total Total number of compaction runs interrupted.
-		cortex_compactor_runs_interrupted_total 1
-
-		# TYPE cortex_compactor_runs_failed_total counter
-		# HELP cortex_compactor_runs_failed_total Total number of compaction runs failed.
-		cortex_compactor_runs_failed_total 0
-	`),
-		"cortex_compactor_runs_completed_total",
-		"cortex_compactor_runs_interrupted_total",
-		"cortex_compactor_runs_failed_total",
-	))
-
-	lines := strings.Split(logs.String(), "\n")
-	require.Contains(t, lines, `level=info component=compactor msg="interrupting compaction of user blocks" user=user-1`)
-	require.NotContains(t, logs.String(), `level=error`)
 }
 
-func TestCompactor_ShouldNotFailCompactionIfAccessDeniedErrDuringMetaSync(t *testing.T) {
+func TestPartitionCompactor_ShouldNotFailCompactionIfAccessDeniedErrDuringMetaSync(t *testing.T) {
 	t.Parallel()
 
 	ss := bucketindex.Status{Status: bucketindex.Ok, Version: bucketindex.SyncStatusFileVersion}
 	content, err := json.Marshal(ss)
 	require.NoError(t, err)
 
+	partitionedGroupID := getPartitionedGroupID("user-1")
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("__markers__", []string{}, nil)
 	bucketClient.MockIter("", []string{"user-1"}, nil)
@@ -1934,17 +1728,19 @@ func TestCompactor_ShouldNotFailCompactionIfAccessDeniedErrDuringMetaSync(t *tes
 	bucketClient.MockGet("user-1/bucket-index-sync-status.json", string(content), nil)
 	bucketClient.MockUpload("user-1/bucket-index.json.gz", nil)
 	bucketClient.MockUpload("user-1/bucket-index-sync-status.json", nil)
+	bucketClient.MockIter("user-1/"+PartitionedGroupDirectory, nil, nil)
+	bucketClient.MockGet("user-1/partitioned-groups/visit-marks/"+string(partitionedGroupID)+"/partition-0-visit-mark.json", "", nil)
 
 	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
-	cfg := prepareConfig()
+	cfg := prepareConfigForPartitioning()
 	cfg.ShardingEnabled = true
 	cfg.ShardingRing.InstanceID = "compactor-1"
 	cfg.ShardingRing.InstanceAddr = "1.2.3.4"
 	cfg.ShardingRing.KVStore.Mock = ringStore
 
-	c, _, tsdbPlanner, _, _ := prepare(t, cfg, bucketClient, nil)
+	c, _, tsdbPlanner, _, _ := prepareForPartitioning(t, cfg, bucketClient, nil, nil)
 	tsdbPlanner.On("Plan", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*metadata.Meta{}, nil)
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
@@ -1957,13 +1753,14 @@ func TestCompactor_ShouldNotFailCompactionIfAccessDeniedErrDuringMetaSync(t *tes
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
 }
 
-func TestCompactor_ShouldNotFailCompactionIfAccessDeniedErrReturnedFromBucket(t *testing.T) {
+func TestPartitionCompactor_ShouldNotFailCompactionIfAccessDeniedErrReturnedFromBucket(t *testing.T) {
 	t.Parallel()
 
 	ss := bucketindex.Status{Status: bucketindex.Ok, Version: bucketindex.SyncStatusFileVersion}
 	content, err := json.Marshal(ss)
 	require.NoError(t, err)
 
+	partitionedGroupID := getPartitionedGroupID("user-1")
 	bucketClient := &bucket.ClientMock{}
 	bucketClient.MockIter("__markers__", []string{}, nil)
 	bucketClient.MockIter("", []string{"user-1"}, nil)
@@ -1984,17 +1781,19 @@ func TestCompactor_ShouldNotFailCompactionIfAccessDeniedErrReturnedFromBucket(t 
 	bucketClient.MockGet("user-1/bucket-index-sync-status.json", string(content), nil)
 	bucketClient.MockUpload("user-1/bucket-index.json.gz", nil)
 	bucketClient.MockUpload("user-1/bucket-index-sync-status.json", nil)
+	bucketClient.MockIter("user-1/"+PartitionedGroupDirectory, nil, nil)
+	bucketClient.MockGet("user-1/partitioned-groups/visit-marks/"+string(partitionedGroupID)+"/partition-0-visit-mark.json", "", nil)
 
 	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
-	cfg := prepareConfig()
+	cfg := prepareConfigForPartitioning()
 	cfg.ShardingEnabled = true
 	cfg.ShardingRing.InstanceID = "compactor-1"
 	cfg.ShardingRing.InstanceAddr = "1.2.3.4"
 	cfg.ShardingRing.KVStore.Mock = ringStore
 
-	c, _, tsdbPlanner, _, _ := prepare(t, cfg, bucketClient, nil)
+	c, _, tsdbPlanner, _, _ := prepareForPartitioning(t, cfg, bucketClient, nil, nil)
 	tsdbPlanner.On("Plan", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*metadata.Meta{}, bucket.ErrKeyPermissionDenied)
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
@@ -2005,110 +1804,4 @@ func TestCompactor_ShouldNotFailCompactionIfAccessDeniedErrReturnedFromBucket(t 
 	})
 
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
-}
-
-func TestCompactor_FailedWithRetriableError(t *testing.T) {
-	t.Parallel()
-
-	ss := bucketindex.Status{Status: bucketindex.Ok, Version: bucketindex.SyncStatusFileVersion}
-	content, err := json.Marshal(ss)
-	require.NoError(t, err)
-
-	bucketClient := &bucket.ClientMock{}
-	bucketClient.MockIter("__markers__", []string{}, nil)
-	bucketClient.MockIter("", []string{"user-1"}, nil)
-	bucketClient.MockIter("user-1/", []string{"user-1/01DTVP434PA9VFXSW2JKB3392D", "user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ", "user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", "user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/meta.json"}, nil)
-	bucketClient.MockIter("user-1/markers/", nil, nil)
-	bucketClient.MockGet("user-1/markers/cleaner-visit-marker.json", "", nil)
-	bucketClient.MockUpload("user-1/markers/cleaner-visit-marker.json", nil)
-	bucketClient.MockDelete("user-1/markers/cleaner-visit-marker.json", nil)
-	bucketClient.MockExists(cortex_tsdb.GetGlobalDeletionMarkPath("user-1"), false, nil)
-	bucketClient.MockExists(cortex_tsdb.GetLocalDeletionMarkPath("user-1"), false, nil)
-	bucketClient.MockIter("user-1/01DTVP434PA9VFXSW2JKB3392D", nil, errors.New("test retriable error"))
-	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", mockBlockMetaJSON("01DTVP434PA9VFXSW2JKB3392D"), nil)
-	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/deletion-mark.json", "", nil)
-	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/no-compact-mark.json", "", nil)
-	bucketClient.MockIter("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ", nil, errors.New("test retriable error"))
-	bucketClient.MockGet("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/meta.json", mockBlockMetaJSON("01DTW0ZCPDDNV4BV83Q2SV4QAZ"), nil)
-	bucketClient.MockGet("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/deletion-mark.json", "", nil)
-	bucketClient.MockGet("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-1/bucket-index.json.gz", "", nil)
-	bucketClient.MockGet("user-1/bucket-index-sync-status.json", string(content), nil)
-	bucketClient.MockUpload("user-1/bucket-index.json.gz", nil)
-	bucketClient.MockUpload("user-1/bucket-index-sync-status.json", nil)
-
-	cfg := prepareConfig()
-	cfg.CompactionRetries = 2
-
-	c, _, tsdbPlanner, _, registry := prepare(t, cfg, bucketClient, nil)
-	tsdbPlanner.On("Plan", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*metadata.Meta{{BlockMeta: mockBlockMeta("01DTVP434PA9VFXSW2JKB3392D")}, {BlockMeta: mockBlockMeta("01DTW0ZCPDDNV4BV83Q2SV4QAZ")}}, nil)
-
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
-
-	cortex_testutil.Poll(t, 1*time.Second, 2.0, func() interface{} {
-		return prom_testutil.ToFloat64(c.compactorMetrics.compactionErrorsCount.WithLabelValues("user-1", retriableError))
-	})
-
-	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
-
-	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
-		# HELP cortex_compactor_compaction_error_total Total number of errors from compactions.
-		# TYPE cortex_compactor_compaction_error_total counter
-		cortex_compactor_compaction_error_total{type="retriable", user="user-1"} 2
-	`),
-		"cortex_compactor_compaction_error_total",
-	))
-}
-
-func TestCompactor_FailedWithHaltError(t *testing.T) {
-	t.Parallel()
-
-	ss := bucketindex.Status{Status: bucketindex.Ok, Version: bucketindex.SyncStatusFileVersion}
-	content, err := json.Marshal(ss)
-	require.NoError(t, err)
-
-	bucketClient := &bucket.ClientMock{}
-	bucketClient.MockIter("__markers__", []string{}, nil)
-	bucketClient.MockIter("", []string{"user-1"}, nil)
-	bucketClient.MockIter("user-1/", []string{"user-1/01DTVP434PA9VFXSW2JKB3392D", "user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ", "user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", "user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/meta.json"}, nil)
-	bucketClient.MockIter("user-1/markers/", nil, nil)
-	bucketClient.MockGet("user-1/markers/cleaner-visit-marker.json", "", nil)
-	bucketClient.MockUpload("user-1/markers/cleaner-visit-marker.json", nil)
-	bucketClient.MockDelete("user-1/markers/cleaner-visit-marker.json", nil)
-	bucketClient.MockExists(cortex_tsdb.GetGlobalDeletionMarkPath("user-1"), false, nil)
-	bucketClient.MockExists(cortex_tsdb.GetLocalDeletionMarkPath("user-1"), false, nil)
-	bucketClient.MockIter("user-1/01DTVP434PA9VFXSW2JKB3392D", nil, compact.HaltError{})
-	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/meta.json", mockBlockMetaJSON("01DTVP434PA9VFXSW2JKB3392D"), nil)
-	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/deletion-mark.json", "", nil)
-	bucketClient.MockGet("user-1/01DTVP434PA9VFXSW2JKB3392D/no-compact-mark.json", "", nil)
-	bucketClient.MockIter("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ", nil, compact.HaltError{})
-	bucketClient.MockGet("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/meta.json", mockBlockMetaJSON("01DTW0ZCPDDNV4BV83Q2SV4QAZ"), nil)
-	bucketClient.MockGet("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/deletion-mark.json", "", nil)
-	bucketClient.MockGet("user-1/01DTW0ZCPDDNV4BV83Q2SV4QAZ/no-compact-mark.json", "", nil)
-	bucketClient.MockGet("user-1/bucket-index.json.gz", "", nil)
-	bucketClient.MockGet("user-1/bucket-index-sync-status.json", string(content), nil)
-	bucketClient.MockUpload("user-1/bucket-index.json.gz", nil)
-	bucketClient.MockUpload("user-1/bucket-index-sync-status.json", nil)
-
-	cfg := prepareConfig()
-	cfg.CompactionRetries = 2
-
-	c, _, tsdbPlanner, _, registry := prepare(t, cfg, bucketClient, nil)
-	tsdbPlanner.On("Plan", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*metadata.Meta{{BlockMeta: mockBlockMeta("01DTVP434PA9VFXSW2JKB3392D")}, {BlockMeta: mockBlockMeta("01DTW0ZCPDDNV4BV83Q2SV4QAZ")}}, nil)
-
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
-
-	cortex_testutil.Poll(t, 1*time.Second, 1.0, func() interface{} {
-		return prom_testutil.ToFloat64(c.compactorMetrics.compactionErrorsCount.WithLabelValues("user-1", haltError))
-	})
-
-	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
-
-	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
-		# HELP cortex_compactor_compaction_error_total Total number of errors from compactions.
-		# TYPE cortex_compactor_compaction_error_total counter
-		cortex_compactor_compaction_error_total{type="halt", user="user-1"} 1
-	`),
-		"cortex_compactor_compaction_error_total",
-	))
 }

--- a/pkg/compactor/compactor_paritioning_test.go
+++ b/pkg/compactor/compactor_paritioning_test.go
@@ -1174,8 +1174,8 @@ func TestPartitionCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEn
 		cfg.ShardingEnabled = true
 		cfg.ShardingRing.InstanceID = fmt.Sprintf("compactor-%d", i)
 		cfg.ShardingRing.InstanceAddr = fmt.Sprintf("127.0.0.%d", i)
-		cfg.ShardingRing.WaitStabilityMinDuration = 3 * time.Second
-		cfg.ShardingRing.WaitStabilityMaxDuration = 10 * time.Second
+		cfg.ShardingRing.WaitStabilityMinDuration = time.Second
+		cfg.ShardingRing.WaitStabilityMaxDuration = 5 * time.Second
 		cfg.ShardingRing.KVStore.Mock = kvstore
 
 		c, _, tsdbPlanner, l, _ := prepareForPartitioning(t, cfg, bucketClient, nil, nil)
@@ -1314,8 +1314,8 @@ func TestPartitionCompactor_ShouldCompactOnlyShardsOwnedByTheInstanceOnShardingE
 		cfg.ShardingStrategy = util.ShardingStrategyShuffle
 		cfg.ShardingRing.InstanceID = fmt.Sprintf("compactor-%d", i)
 		cfg.ShardingRing.InstanceAddr = fmt.Sprintf("127.0.0.%d", i)
-		cfg.ShardingRing.WaitStabilityMinDuration = 3 * time.Second
-		cfg.ShardingRing.WaitStabilityMaxDuration = 10 * time.Second
+		cfg.ShardingRing.WaitStabilityMinDuration = time.Second
+		cfg.ShardingRing.WaitStabilityMaxDuration = 5 * time.Second
 		cfg.ShardingRing.KVStore.Mock = kvstore
 
 		limits := &validation.Limits{}
@@ -1550,8 +1550,8 @@ func TestPartitionCompactor_DeleteLocalSyncFiles(t *testing.T) {
 		cfg.ShardingEnabled = true
 		cfg.ShardingRing.InstanceID = fmt.Sprintf("compactor-%d", i)
 		cfg.ShardingRing.InstanceAddr = fmt.Sprintf("127.0.0.%d", i)
-		cfg.ShardingRing.WaitStabilityMinDuration = 3 * time.Second
-		cfg.ShardingRing.WaitStabilityMaxDuration = 10 * time.Second
+		cfg.ShardingRing.WaitStabilityMinDuration = time.Second
+		cfg.ShardingRing.WaitStabilityMaxDuration = 5 * time.Second
 		cfg.ShardingRing.KVStore.Mock = kvstore
 
 		// Each compactor will get its own temp dir for storing local files.

--- a/pkg/compactor/compactor_paritioning_test.go
+++ b/pkg/compactor/compactor_paritioning_test.go
@@ -1198,7 +1198,7 @@ func TestPartitionCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEn
 
 	// Wait until a run has been completed on each compactor
 	for _, c := range compactors {
-		cortex_testutil.Poll(t, 20*time.Second, true, func() interface{} {
+		cortex_testutil.Poll(t, 60*time.Second, true, func() interface{} {
 			return prom_testutil.ToFloat64(c.CompactionRunsCompleted) >= 1
 		})
 	}

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1111,8 +1111,8 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 		cfg.ShardingEnabled = true
 		cfg.ShardingRing.InstanceID = fmt.Sprintf("compactor-%d", i)
 		cfg.ShardingRing.InstanceAddr = fmt.Sprintf("127.0.0.%d", i)
-		cfg.ShardingRing.WaitStabilityMinDuration = 3 * time.Second
-		cfg.ShardingRing.WaitStabilityMaxDuration = 10 * time.Second
+		cfg.ShardingRing.WaitStabilityMinDuration = time.Second
+		cfg.ShardingRing.WaitStabilityMaxDuration = 5 * time.Second
 		cfg.ShardingRing.KVStore.Mock = kvstore
 
 		c, _, tsdbPlanner, l, _ := prepare(t, cfg, bucketClient, nil)
@@ -1244,8 +1244,8 @@ func TestCompactor_ShouldCompactOnlyShardsOwnedByTheInstanceOnShardingEnabledWit
 		cfg.ShardingStrategy = util.ShardingStrategyShuffle
 		cfg.ShardingRing.InstanceID = fmt.Sprintf("compactor-%d", i)
 		cfg.ShardingRing.InstanceAddr = fmt.Sprintf("127.0.0.%d", i)
-		cfg.ShardingRing.WaitStabilityMinDuration = 3 * time.Second
-		cfg.ShardingRing.WaitStabilityMaxDuration = 10 * time.Second
+		cfg.ShardingRing.WaitStabilityMinDuration = time.Second
+		cfg.ShardingRing.WaitStabilityMaxDuration = 5 * time.Second
 		cfg.ShardingRing.KVStore.Mock = kvstore
 
 		limits := &validation.Limits{}
@@ -1522,7 +1522,7 @@ func prepareConfig() Config {
 	compactorCfg.retryMaxBackoff = 0
 
 	//Avoid jitter in startup
-	compactorCfg.CompactionInterval = 1 * time.Second
+	compactorCfg.CompactionInterval = 5 * time.Second
 
 	// The migration is tested in a dedicated test.
 	compactorCfg.BlockDeletionMarksMigrationEnabled = false
@@ -1755,8 +1755,8 @@ func TestCompactor_DeleteLocalSyncFiles(t *testing.T) {
 		cfg.ShardingEnabled = true
 		cfg.ShardingRing.InstanceID = fmt.Sprintf("compactor-%d", i)
 		cfg.ShardingRing.InstanceAddr = fmt.Sprintf("127.0.0.%d", i)
-		cfg.ShardingRing.WaitStabilityMinDuration = 3 * time.Second
-		cfg.ShardingRing.WaitStabilityMaxDuration = 10 * time.Second
+		cfg.ShardingRing.WaitStabilityMinDuration = time.Second
+		cfg.ShardingRing.WaitStabilityMaxDuration = 5 * time.Second
 		cfg.ShardingRing.KVStore.Mock = kvstore
 
 		// Each compactor will get its own temp dir for storing local files.

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1135,8 +1135,8 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 
 	// Wait until a run has been completed on each compactor
 	for _, c := range compactors {
-		cortex_testutil.Poll(t, 10*time.Second, true, func() interface{} {
-			return prom_testutil.ToFloat64(c.CompactionRunsCompleted) > 1
+		cortex_testutil.Poll(t, 60*time.Second, true, func() interface{} {
+			return prom_testutil.ToFloat64(c.CompactionRunsCompleted) >= 1
 		})
 	}
 

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1135,7 +1135,7 @@ func TestCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnShardingEnabledAndM
 
 	// Wait until a run has been completed on each compactor
 	for _, c := range compactors {
-		cortex_testutil.Poll(t, 60*time.Second, true, func() interface{} {
+		cortex_testutil.Poll(t, 120*time.Second, true, func() interface{} {
 			return prom_testutil.ToFloat64(c.CompactionRunsCompleted) >= 1
 		})
 	}

--- a/pkg/compactor/partition_compaction_complete_checker.go
+++ b/pkg/compactor/partition_compaction_complete_checker.go
@@ -1,0 +1,16 @@
+package compactor
+
+import (
+	"github.com/oklog/ulid"
+	"github.com/thanos-io/thanos/pkg/compact"
+)
+
+type PartitionCompactionBlockDeletableChecker struct{}
+
+func NewPartitionCompactionBlockDeletableChecker() *PartitionCompactionBlockDeletableChecker {
+	return &PartitionCompactionBlockDeletableChecker{}
+}
+
+func (p *PartitionCompactionBlockDeletableChecker) CanDelete(_ *compact.Group, _ ulid.ULID) bool {
+	return false
+}

--- a/pkg/compactor/sharded_block_populator.go
+++ b/pkg/compactor/sharded_block_populator.go
@@ -1,0 +1,217 @@
+package compactor
+
+import (
+	"context"
+	"io"
+	"maps"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+)
+
+type ShardedBlockPopulator struct {
+	partitionCount int
+	partitionID    int
+	logger         log.Logger
+}
+
+// PopulateBlock fills the index and chunk writers with new data gathered as the union
+// of the provided blocks. It returns meta information for the new block.
+// It expects sorted blocks input by mint.
+// The main logic is copied from tsdb.DefaultPopulateBlockFunc
+func (c ShardedBlockPopulator) PopulateBlock(ctx context.Context, metrics *tsdb.CompactorMetrics, _ log.Logger, chunkPool chunkenc.Pool, mergeFunc storage.VerticalChunkSeriesMergeFunc, blocks []tsdb.BlockReader, meta *tsdb.BlockMeta, indexw tsdb.IndexWriter, chunkw tsdb.ChunkWriter, postingsFunc tsdb.IndexReaderPostingsFunc) (err error) {
+	if len(blocks) == 0 {
+		return errors.New("cannot populate block from no readers")
+	}
+
+	var (
+		sets        []storage.ChunkSeriesSet
+		setsMtx     sync.Mutex
+		symbols     map[string]struct{}
+		closers     []io.Closer
+		overlapping bool
+	)
+	symbols = make(map[string]struct{})
+	defer func() {
+		errs := tsdb_errors.NewMulti(err)
+		if cerr := tsdb_errors.CloseAll(closers); cerr != nil {
+			errs.Add(errors.Wrap(cerr, "close"))
+		}
+		err = errs.Err()
+		metrics.PopulatingBlocks.Set(0)
+	}()
+	metrics.PopulatingBlocks.Set(1)
+
+	globalMaxt := blocks[0].Meta().MaxTime
+	g, _ := errgroup.WithContext(ctx)
+	g.SetLimit(8)
+	for i, b := range blocks {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if !overlapping {
+			if i > 0 && b.Meta().MinTime < globalMaxt {
+				metrics.OverlappingBlocks.Inc()
+				overlapping = true
+				level.Info(c.logger).Log("msg", "Found overlapping blocks during compaction", "ulid", meta.ULID)
+			}
+			if b.Meta().MaxTime > globalMaxt {
+				globalMaxt = b.Meta().MaxTime
+			}
+		}
+
+		indexr, err := b.Index()
+		if err != nil {
+			return errors.Wrapf(err, "open index reader for block %+v", b.Meta())
+		}
+		closers = append(closers, indexr)
+
+		chunkr, err := b.Chunks()
+		if err != nil {
+			return errors.Wrapf(err, "open chunk reader for block %+v", b.Meta())
+		}
+		closers = append(closers, chunkr)
+
+		tombsr, err := b.Tombstones()
+		if err != nil {
+			return errors.Wrapf(err, "open tombstone reader for block %+v", b.Meta())
+		}
+		closers = append(closers, tombsr)
+
+		all := postingsFunc(ctx, indexr)
+		g.Go(func() error {
+			shardStart := time.Now()
+			shardedPosting, syms, err := NewShardedPosting(all, uint64(c.partitionCount), uint64(c.partitionID), indexr.Series)
+			if err != nil {
+				return err
+			}
+			level.Debug(c.logger).Log("msg", "finished sharding", "duration", time.Since(shardStart))
+			// Blocks meta is half open: [min, max), so subtract 1 to ensure we don't hold samples with exact meta.MaxTime timestamp.
+			setsMtx.Lock()
+			sets = append(sets, tsdb.NewBlockChunkSeriesSet(meta.ULID, indexr, chunkr, tombsr, shardedPosting, meta.MinTime, meta.MaxTime-1, false))
+			maps.Copy(symbols, syms)
+			setsMtx.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	symbolsList := make([]string, len(symbols))
+	symbolIdx := 0
+	for symbol := range symbols {
+		symbolsList[symbolIdx] = symbol
+		symbolIdx++
+	}
+	slices.Sort(symbolsList)
+	for _, symbol := range symbolsList {
+		if err := indexw.AddSymbol(symbol); err != nil {
+			return errors.Wrap(err, "add symbol")
+		}
+	}
+
+	var (
+		ref = storage.SeriesRef(0)
+		ch  = make(chan func() error, 1000)
+	)
+
+	set := sets[0]
+	if len(sets) > 1 {
+		iCtx, cancel := context.WithCancel(ctx)
+		// Merge series using specified chunk series merger.
+		// The default one is the compacting series merger.
+		set = NewBackgroundChunkSeriesSet(iCtx, storage.NewMergeChunkSeriesSet(sets, mergeFunc))
+		defer cancel()
+	}
+
+	go func() {
+		// Iterate over all sorted chunk series.
+		for set.Next() {
+			select {
+			case <-ctx.Done():
+				ch <- func() error { return ctx.Err() }
+			default:
+			}
+			s := set.At()
+			curChksIter := s.Iterator(nil)
+
+			var chks []chunks.Meta
+			var wg sync.WaitGroup
+			r := ref
+			wg.Add(1)
+			go func() {
+				for curChksIter.Next() {
+					// We are not iterating in streaming way over chunk as
+					// it's more efficient to do bulk write for index and
+					// chunk file purposes.
+					chks = append(chks, curChksIter.At())
+				}
+				wg.Done()
+			}()
+
+			ch <- func() error {
+				wg.Wait()
+				if curChksIter.Err() != nil {
+					return errors.Wrap(curChksIter.Err(), "chunk iter")
+				}
+
+				// Skip the series with all deleted chunks.
+				if len(chks) == 0 {
+					return nil
+				}
+
+				if err := chunkw.WriteChunks(chks...); err != nil {
+					return errors.Wrap(err, "write chunks")
+				}
+				if err := indexw.AddSeries(r, s.Labels(), chks...); err != nil {
+					return errors.Wrap(err, "add series")
+				}
+
+				meta.Stats.NumChunks += uint64(len(chks))
+				meta.Stats.NumSeries++
+				for _, chk := range chks {
+					meta.Stats.NumSamples += uint64(chk.Chunk.NumSamples())
+				}
+
+				for _, chk := range chks {
+					if err := chunkPool.Put(chk.Chunk); err != nil {
+						return errors.Wrap(err, "put chunk")
+					}
+				}
+
+				return nil
+			}
+
+			ref++
+		}
+		close(ch)
+	}()
+
+	for callback := range ch {
+		err := callback()
+		if err != nil {
+			return err
+		}
+	}
+
+	if set.Err() != nil {
+		return errors.Wrap(set.Err(), "iterate compaction set")
+	}
+
+	return nil
+}

--- a/pkg/compactor/sharded_block_populator.go
+++ b/pkg/compactor/sharded_block_populator.go
@@ -10,14 +10,13 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
-	"golang.org/x/exp/slices"
-	"golang.org/x/sync/errgroup"
-
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
 )
 
 type ShardedBlockPopulator struct {

--- a/pkg/compactor/sharded_compaction_lifecycle_callback.go
+++ b/pkg/compactor/sharded_compaction_lifecycle_callback.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
@@ -19,14 +18,13 @@ import (
 )
 
 type ShardedCompactionLifecycleCallback struct {
-	ctx                            context.Context
-	userBucket                     objstore.InstrumentedBucket
-	logger                         log.Logger
-	metaSyncConcurrency            int
-	compactDir                     string
-	userID                         string
-	partitionedGroupInfoReadFailed prometheus.Counter
-	compactorMetrics               *compactorMetrics
+	ctx                 context.Context
+	userBucket          objstore.InstrumentedBucket
+	logger              log.Logger
+	metaSyncConcurrency int
+	compactDir          string
+	userID              string
+	compactorMetrics    *compactorMetrics
 
 	startTime time.Time
 }

--- a/pkg/compactor/sharded_compaction_lifecycle_callback.go
+++ b/pkg/compactor/sharded_compaction_lifecycle_callback.go
@@ -1,0 +1,110 @@
+package compactor
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/compact"
+	"github.com/thanos-io/thanos/pkg/runutil"
+
+	cortextsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"
+)
+
+type ShardedCompactionLifecycleCallback struct {
+	ctx                            context.Context
+	userBucket                     objstore.InstrumentedBucket
+	logger                         log.Logger
+	metaSyncConcurrency            int
+	compactDir                     string
+	userID                         string
+	partitionedGroupInfoReadFailed prometheus.Counter
+	compactorMetrics               *compactorMetrics
+
+	startTime time.Time
+}
+
+func NewShardedCompactionLifecycleCallback(
+	ctx context.Context,
+	userBucket objstore.InstrumentedBucket,
+	logger log.Logger,
+	metaSyncConcurrency int,
+	compactDir string,
+	userID string,
+	compactorMetrics *compactorMetrics,
+) *ShardedCompactionLifecycleCallback {
+	return &ShardedCompactionLifecycleCallback{
+		ctx:                 ctx,
+		userBucket:          userBucket,
+		logger:              logger,
+		metaSyncConcurrency: metaSyncConcurrency,
+		compactDir:          compactDir,
+		userID:              userID,
+		compactorMetrics:    compactorMetrics,
+	}
+}
+
+func (c *ShardedCompactionLifecycleCallback) PreCompactionCallback(_ context.Context, logger log.Logger, g *compact.Group, meta []*metadata.Meta) error {
+	c.startTime = time.Now()
+
+	metaExt, err := cortextsdb.ConvertToCortexMetaExtensions(g.Extensions())
+	if err != nil {
+		level.Warn(logger).Log("msg", "unable to get cortex meta extensions", "err", err)
+	} else if metaExt != nil {
+		c.compactorMetrics.compactionPlanned.WithLabelValues(c.userID, metaExt.TimeRangeStr()).Inc()
+	}
+
+	// Delete local files other than current group
+	var ignoreDirs []string
+	for _, m := range meta {
+		ignoreDirs = append(ignoreDirs, filepath.Join(g.Key(), m.ULID.String()))
+	}
+	if err := runutil.DeleteAll(c.compactDir, ignoreDirs...); err != nil {
+		level.Warn(logger).Log("msg", "failed deleting non-current compaction group files, disk space usage might have leaked.", "err", err, "dir", c.compactDir)
+	}
+	return nil
+}
+
+func (c *ShardedCompactionLifecycleCallback) PostCompactionCallback(_ context.Context, logger log.Logger, cg *compact.Group, _ ulid.ULID) error {
+	metaExt, err := cortextsdb.ConvertToCortexMetaExtensions(cg.Extensions())
+	if err != nil {
+		level.Warn(logger).Log("msg", "unable to get cortex meta extensions", "err", err)
+	} else if metaExt != nil {
+		c.compactorMetrics.compactionDuration.WithLabelValues(c.userID, metaExt.TimeRangeStr()).Set(time.Since(c.startTime).Seconds())
+	}
+	return nil
+}
+
+func (c *ShardedCompactionLifecycleCallback) GetBlockPopulator(_ context.Context, logger log.Logger, cg *compact.Group) (tsdb.BlockPopulator, error) {
+	partitionInfo, err := cortextsdb.ConvertToPartitionInfo(cg.Extensions())
+	if err != nil {
+		return nil, err
+	}
+	if partitionInfo == nil {
+		return tsdb.DefaultBlockPopulator{}, nil
+	}
+	if partitionInfo.PartitionCount <= 0 {
+		partitionInfo = &cortextsdb.PartitionInfo{
+			PartitionCount:               1,
+			PartitionID:                  partitionInfo.PartitionID,
+			PartitionedGroupID:           partitionInfo.PartitionedGroupID,
+			PartitionedGroupCreationTime: partitionInfo.PartitionedGroupCreationTime,
+		}
+		cg.SetExtensions(&cortextsdb.CortexMetaExtensions{
+			PartitionInfo: partitionInfo,
+		})
+	}
+	populateBlockFunc := ShardedBlockPopulator{
+		partitionCount: partitionInfo.PartitionCount,
+		partitionID:    partitionInfo.PartitionID,
+		logger:         logger,
+	}
+	return populateBlockFunc, nil
+}

--- a/pkg/compactor/sharded_compaction_lifecycle_callback_test.go
+++ b/pkg/compactor/sharded_compaction_lifecycle_callback_test.go
@@ -1,0 +1,96 @@
+package compactor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/compact"
+)
+
+func TestPreCompactionCallback(t *testing.T) {
+	compactDir, err := os.MkdirTemp(os.TempDir(), "compact")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(compactDir))
+	})
+
+	lifecycleCallback := ShardedCompactionLifecycleCallback{
+		compactDir: compactDir,
+	}
+
+	block1 := ulid.MustNew(1, nil)
+	block2 := ulid.MustNew(2, nil)
+	block3 := ulid.MustNew(3, nil)
+	meta := []*metadata.Meta{
+		{
+			BlockMeta: tsdb.BlockMeta{ULID: block1, MinTime: 1 * time.Hour.Milliseconds(), MaxTime: 2 * time.Hour.Milliseconds()},
+		},
+		{
+			BlockMeta: tsdb.BlockMeta{ULID: block2, MinTime: 1 * time.Hour.Milliseconds(), MaxTime: 2 * time.Hour.Milliseconds()},
+		},
+		{
+			BlockMeta: tsdb.BlockMeta{ULID: block3, MinTime: 2 * time.Hour.Milliseconds(), MaxTime: 3 * time.Hour.Milliseconds()},
+		},
+	}
+	testGroupKey := "test_group_key"
+	testGroup, _ := compact.NewGroup(
+		log.NewNopLogger(),
+		nil,
+		testGroupKey,
+		nil,
+		0,
+		true,
+		true,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		metadata.NoneFunc,
+		1,
+		1,
+	)
+	for _, m := range meta {
+		err := testGroup.AppendMeta(m)
+		require.NoError(t, err)
+	}
+
+	dummyGroupID1 := "dummy_dir_1"
+	dummyGroupID2 := "dummy_dir_2"
+	err = os.MkdirAll(filepath.Join(compactDir, testGroupKey), 0750)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(compactDir, testGroupKey, block1.String()), 0750)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(compactDir, dummyGroupID1), 0750)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(compactDir, dummyGroupID2), 0750)
+	require.NoError(t, err)
+
+	err = lifecycleCallback.PreCompactionCallback(context.Background(), log.NewNopLogger(), testGroup, meta)
+	require.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(compactDir, testGroupKey))
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+	info, err = os.Stat(filepath.Join(compactDir, testGroupKey, block1.String()))
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+	_, err = os.Stat(filepath.Join(compactDir, dummyGroupID1))
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(compactDir, dummyGroupID2))
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+}

--- a/pkg/compactor/sharded_posting.go
+++ b/pkg/compactor/sharded_posting.go
@@ -8,12 +8,11 @@ import (
 )
 
 func NewShardedPosting(postings index.Postings, partitionCount uint64, partitionID uint64, labelsFn func(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error) (index.Postings, map[string]struct{}, error) {
-	bufChks := make([]chunks.Meta, 0)
 	series := make([]storage.SeriesRef, 0)
 	symbols := make(map[string]struct{})
 	var builder labels.ScratchBuilder
 	for postings.Next() {
-		err := labelsFn(postings.At(), &builder, &bufChks)
+		err := labelsFn(postings.At(), &builder, nil)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/compactor/sharded_posting.go
+++ b/pkg/compactor/sharded_posting.go
@@ -1,0 +1,30 @@
+package compactor
+
+import (
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/index"
+)
+
+func NewShardedPosting(postings index.Postings, partitionCount uint64, partitionID uint64, labelsFn func(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error) (index.Postings, map[string]struct{}, error) {
+	bufChks := make([]chunks.Meta, 0)
+	series := make([]storage.SeriesRef, 0)
+	symbols := make(map[string]struct{})
+	var builder labels.ScratchBuilder
+	for postings.Next() {
+		err := labelsFn(postings.At(), &builder, &bufChks)
+		if err != nil {
+			return nil, nil, err
+		}
+		if builder.Labels().Hash()%partitionCount == partitionID {
+			posting := postings.At()
+			series = append(series, posting)
+			for _, label := range builder.Labels() {
+				symbols[label.Name] = struct{}{}
+				symbols[label.Value] = struct{}{}
+			}
+		}
+	}
+	return index.NewListPostings(series), symbols, nil
+}

--- a/pkg/compactor/sharded_posting.go
+++ b/pkg/compactor/sharded_posting.go
@@ -3,11 +3,12 @@ package compactor
 import (
 	"context"
 
-	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
+
+	"github.com/cortexproject/cortex/pkg/util"
 )
 
 func NewShardedPosting(ctx context.Context, postings index.Postings, partitionCount uint64, partitionID uint64, labelsFn func(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error) (index.Postings, map[string]struct{}, error) {

--- a/pkg/compactor/sharded_posting_test.go
+++ b/pkg/compactor/sharded_posting_test.go
@@ -72,7 +72,7 @@ func TestShardPostingAndSymbolBasedOnPartitionID(t *testing.T) {
 		postings, err := ir.Postings(context.Background(), k, v)
 		require.NoError(t, err)
 		postings = ir.SortedPostings(postings)
-		shardedPostings, syms, err := NewShardedPosting(postings, uint64(partitionCount), uint64(partitionID), ir.Series)
+		shardedPostings, syms, err := NewShardedPosting(context.Background(), postings, uint64(partitionCount), uint64(partitionID), ir.Series)
 		require.NoError(t, err)
 		bufChks := make([]chunks.Meta, 0)
 		expectedShardedSymbols := make(map[string]struct{})

--- a/pkg/compactor/sharded_posting_test.go
+++ b/pkg/compactor/sharded_posting_test.go
@@ -1,0 +1,109 @@
+package compactor
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/testutil/e2eutil"
+)
+
+const (
+	MetricLabelName = "__name__"
+	MetricName      = "test_metric"
+	TestLabelName   = "test_label"
+	ConstLabelName  = "const_label"
+	ConstLabelValue = "const_value"
+)
+
+func TestShardPostingAndSymbolBasedOnPartitionID(t *testing.T) {
+	partitionCount := 8
+
+	tmpdir, err := os.MkdirTemp("", "sharded_posting_test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(tmpdir))
+	})
+
+	r := rand.New(rand.NewSource(0))
+	var series []labels.Labels
+	expectedSymbols := make(map[string]bool)
+	metricName := labels.Label{Name: MetricLabelName, Value: MetricName}
+	expectedSymbols[MetricLabelName] = false
+	expectedSymbols[MetricName] = false
+	expectedSymbols[ConstLabelName] = false
+	expectedSymbols[ConstLabelValue] = false
+	expectedSeriesCount := 10
+	for i := 0; i < expectedSeriesCount; i++ {
+		labelValue := strconv.Itoa(r.Int())
+		series = append(series, labels.Labels{
+			metricName,
+			{Name: ConstLabelName, Value: ConstLabelValue},
+			{Name: TestLabelName, Value: labelValue},
+		})
+		expectedSymbols[TestLabelName] = false
+		expectedSymbols[labelValue] = false
+	}
+	blockID, err := e2eutil.CreateBlock(context.Background(), tmpdir, series, 10, time.Now().Add(-10*time.Minute).UnixMilli(), time.Now().UnixMilli(), nil, 0, metadata.NoneFunc)
+	require.NoError(t, err)
+
+	var closers []io.Closer
+	defer func() {
+		for _, c := range closers {
+			c.Close()
+		}
+	}()
+	seriesCount := 0
+	for partitionID := 0; partitionID < partitionCount; partitionID++ {
+		ir, err := index.NewFileReader(filepath.Join(tmpdir, blockID.String(), "index"))
+		closers = append(closers, ir)
+		require.NoError(t, err)
+		k, v := index.AllPostingsKey()
+		postings, err := ir.Postings(context.Background(), k, v)
+		require.NoError(t, err)
+		postings = ir.SortedPostings(postings)
+		shardedPostings, syms, err := NewShardedPosting(postings, uint64(partitionCount), uint64(partitionID), ir.Series)
+		require.NoError(t, err)
+		bufChks := make([]chunks.Meta, 0)
+		expectedShardedSymbols := make(map[string]struct{})
+		for shardedPostings.Next() {
+			var builder labels.ScratchBuilder
+			err = ir.Series(shardedPostings.At(), &builder, &bufChks)
+			require.NoError(t, err)
+			require.Equal(t, uint64(partitionID), builder.Labels().Hash()%uint64(partitionCount))
+			seriesCount++
+			for _, label := range builder.Labels() {
+				expectedShardedSymbols[label.Name] = struct{}{}
+				expectedShardedSymbols[label.Value] = struct{}{}
+			}
+		}
+		err = ir.Close()
+		if err == nil {
+			closers = closers[0 : len(closers)-1]
+		}
+		symbolsCount := 0
+		for s := range syms {
+			symbolsCount++
+			_, ok := expectedSymbols[s]
+			require.True(t, ok)
+			expectedSymbols[s] = true
+			_, ok = expectedShardedSymbols[s]
+			require.True(t, ok)
+		}
+		require.Equal(t, len(expectedShardedSymbols), symbolsCount)
+	}
+	require.Equal(t, expectedSeriesCount, seriesCount)
+	for _, visited := range expectedSymbols {
+		require.True(t, visited)
+	}
+}

--- a/vendor/github.com/thanos-io/thanos/pkg/testutil/e2eutil/copy.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/testutil/e2eutil/copy.go
@@ -1,0 +1,55 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package e2eutil
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/pkg/errors"
+	"github.com/thanos-io/thanos/pkg/runutil"
+)
+
+func Copy(t testing.TB, src, dst string) {
+	testutil.Ok(t, copyRecursive(src, dst))
+}
+
+func copyRecursive(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return os.MkdirAll(filepath.Join(dst, relPath), os.ModePerm)
+		}
+
+		if !info.Mode().IsRegular() {
+			return errors.Errorf("%s is not a regular file", path)
+		}
+
+		source, err := os.Open(filepath.Clean(path))
+		if err != nil {
+			return err
+		}
+		defer runutil.CloseWithErrCapture(&err, source, "close file")
+
+		destination, err := os.Create(filepath.Join(dst, relPath))
+		if err != nil {
+			return err
+		}
+		defer runutil.CloseWithErrCapture(&err, destination, "close file")
+
+		_, err = io.Copy(destination, source)
+		return err
+	})
+}

--- a/vendor/github.com/thanos-io/thanos/pkg/testutil/e2eutil/port.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/testutil/e2eutil/port.go
@@ -1,0 +1,20 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package e2eutil
+
+import "net"
+
+// FreePort returns port that is free now.
+func FreePort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	return l.Addr().(*net.TCPAddr).Port, l.Close()
+}

--- a/vendor/github.com/thanos-io/thanos/pkg/testutil/e2eutil/prometheus.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/testutil/e2eutil/prometheus.go
@@ -1,0 +1,818 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package e2eutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/runutil"
+)
+
+const (
+	defaultPrometheusVersion   = "v0.54.1"
+	defaultAlertmanagerVersion = "v0.20.0"
+	defaultMinioVersion        = "RELEASE.2022-07-30T05-21-40Z"
+
+	// Space delimited list of versions.
+	promPathsEnvVar       = "THANOS_TEST_PROMETHEUS_PATHS"
+	alertmanagerBinEnvVar = "THANOS_TEST_ALERTMANAGER_PATH"
+	minioBinEnvVar        = "THANOS_TEST_MINIO_PATH"
+
+	// A placeholder for actual Prometheus instance address in the scrape config.
+	PromAddrPlaceHolder = "PROMETHEUS_ADDRESS"
+)
+
+var (
+	histogramSample = histogram.Histogram{
+		Schema:        0,
+		Count:         20,
+		Sum:           -3.1415,
+		ZeroCount:     12,
+		ZeroThreshold: 0.001,
+		NegativeSpans: []histogram.Span{
+			{Offset: 0, Length: 4},
+			{Offset: 1, Length: 1},
+		},
+		NegativeBuckets: []int64{1, 2, -2, 1, -1},
+	}
+
+	floatHistogramSample = histogram.FloatHistogram{
+		ZeroThreshold: 0.01,
+		ZeroCount:     5.5,
+		Count:         15,
+		Sum:           11.5,
+		PositiveSpans: []histogram.Span{
+			{Offset: -2, Length: 2},
+			{Offset: 1, Length: 3},
+		},
+		PositiveBuckets: []float64{0.5, 0, 1.5, 2, 3.5},
+		NegativeSpans: []histogram.Span{
+			{Offset: 3, Length: 2},
+			{Offset: 3, Length: 2},
+		},
+		NegativeBuckets: []float64{1.5, 0.5, 2.5, 3},
+	}
+)
+
+func PrometheusBinary() string {
+	return "prometheus-" + defaultPrometheusVersion
+}
+
+func AlertmanagerBinary() string {
+	b := os.Getenv(alertmanagerBinEnvVar)
+	if b == "" {
+		return fmt.Sprintf("alertmanager-%s", defaultAlertmanagerVersion)
+	}
+	return b
+}
+
+func MinioBinary() string {
+	b := os.Getenv(minioBinEnvVar)
+	if b == "" {
+		return fmt.Sprintf("minio-%s", defaultMinioVersion)
+	}
+	return b
+}
+
+// Prometheus represents a test instance for integration testing.
+// It can be populated with data before being started.
+type Prometheus struct {
+	dir     string
+	db      *tsdb.DB
+	prefix  string
+	binPath string
+
+	running            bool
+	cmd                *exec.Cmd
+	disabledCompaction bool
+	addr               string
+
+	config string
+
+	stdout, stderr bytes.Buffer
+}
+
+func NewTSDB() (*tsdb.DB, error) {
+	dir, err := os.MkdirTemp("", "prometheus-test")
+	if err != nil {
+		return nil, err
+	}
+	opts := tsdb.DefaultOptions()
+	opts.RetentionDuration = math.MaxInt64
+	return tsdb.Open(dir, nil, nil, opts, nil)
+}
+
+func ForeachPrometheus(t *testing.T, testFn func(t testing.TB, p *Prometheus)) {
+	paths := os.Getenv(promPathsEnvVar)
+	if paths == "" {
+		paths = PrometheusBinary()
+	}
+
+	for _, path := range strings.Split(paths, " ") {
+		if ok := t.Run(path, func(t *testing.T) {
+			p, err := newPrometheus(path, "")
+			testutil.Ok(t, err)
+
+			testFn(t, p)
+			testutil.Ok(t, p.Stop())
+		}); !ok {
+			return
+		}
+	}
+}
+
+// NewPrometheus creates a new test Prometheus instance that will listen on local address.
+// Use ForeachPrometheus if you want to test against set of Prometheus versions.
+// TODO(bwplotka): Improve it with https://github.com/thanos-io/thanos/issues/758.
+func NewPrometheus() (*Prometheus, error) {
+	return newPrometheus("", "")
+}
+
+// NewPrometheusOnPath creates a new test Prometheus instance that will listen on local address and given prefix path.
+func NewPrometheusOnPath(prefix string) (*Prometheus, error) {
+	return newPrometheus("", prefix)
+}
+
+func newPrometheus(binPath, prefix string) (*Prometheus, error) {
+	if binPath == "" {
+		binPath = PrometheusBinary()
+	}
+
+	db, err := NewTSDB()
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Create(filepath.Join(db.Dir(), "prometheus.yml"))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// Some well-known external labels so that we can test label resorting
+	if _, err = io.WriteString(f, "global:\n  external_labels:\n    region: eu-west"); err != nil {
+		return nil, err
+	}
+
+	return &Prometheus{
+		dir:     db.Dir(),
+		db:      db,
+		prefix:  prefix,
+		binPath: binPath,
+		addr:    "<prometheus-not-started>",
+	}, nil
+}
+
+// Start running the Prometheus instance and return.
+func (p *Prometheus) Start(ctx context.Context, l log.Logger) error {
+	if p.running {
+		return errors.New("Already started")
+	}
+
+	if err := p.db.Close(); err != nil {
+		return err
+	}
+	if err := p.start(); err != nil {
+		return err
+	}
+	if err := p.waitPrometheusUp(ctx, l, p.prefix); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Prometheus) start() error {
+	port, err := FreePort()
+	if err != nil {
+		return err
+	}
+
+	var extra []string
+	if p.disabledCompaction {
+		extra = append(extra,
+			"--storage.tsdb.min-block-duration=2h",
+			"--storage.tsdb.max-block-duration=2h",
+		)
+	}
+	p.addr = fmt.Sprintf("localhost:%d", port)
+	// Write the final config to the config file.
+	// The address placeholder will be replaced with the actual address.
+	if err := p.writeConfig(strings.ReplaceAll(p.config, PromAddrPlaceHolder, p.addr)); err != nil {
+		return err
+	}
+	args := append([]string{
+		"--storage.tsdb.retention=2d", // Pass retention cause prometheus since 2.8.0 don't show default value for that flags in web/api: https://github.com/prometheus/prometheus/pull/5433.
+		"--storage.tsdb.path=" + p.db.Dir(),
+		"--web.listen-address=" + p.addr,
+		"--web.route-prefix=" + p.prefix,
+		"--web.enable-admin-api",
+		"--config.file=" + filepath.Join(p.db.Dir(), "prometheus.yml"),
+	}, extra...)
+
+	p.cmd = exec.Command(p.binPath, args...)
+	p.cmd.SysProcAttr = SysProcAttr()
+
+	p.stderr.Reset()
+	p.stdout.Reset()
+
+	p.cmd.Stdout = &p.stdout
+	p.cmd.Stderr = &p.stderr
+
+	if err := p.cmd.Start(); err != nil {
+		return fmt.Errorf("starting Prometheus failed: %w", err)
+	}
+
+	p.running = true
+	return nil
+}
+
+func (p *Prometheus) waitPrometheusUp(ctx context.Context, logger log.Logger, prefix string) error {
+	if !p.running {
+		return errors.New("method Start was not invoked.")
+	}
+	return runutil.RetryWithLog(logger, time.Second, ctx.Done(), func() error {
+		r, err := http.Get(fmt.Sprintf("http://%s%s/-/ready", p.addr, prefix))
+		if err != nil {
+			return err
+		}
+		defer runutil.ExhaustCloseWithLogOnErr(logger, r.Body, "failed to exhaust and close body")
+
+		if r.StatusCode != 200 {
+			return errors.Errorf("Got non 200 response: %v", r.StatusCode)
+		}
+		return nil
+	})
+}
+
+func (p *Prometheus) Restart(ctx context.Context, l log.Logger) error {
+	if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		return errors.Wrap(err, "failed to kill Prometheus. Kill it manually")
+	}
+	_ = p.cmd.Wait()
+	if err := p.start(); err != nil {
+		return err
+	}
+	return p.waitPrometheusUp(ctx, l, p.prefix)
+}
+
+// Dir returns TSDB dir.
+func (p *Prometheus) Dir() string {
+	return p.dir
+}
+
+// Addr returns correct address after Start method.
+func (p *Prometheus) Addr() string {
+	return p.addr + p.prefix
+}
+
+func (p *Prometheus) DisableCompaction() {
+	p.disabledCompaction = true
+}
+
+// SetConfig updates the contents of the config.
+func (p *Prometheus) SetConfig(s string) {
+	p.config = s
+}
+
+// writeConfig writes the Prometheus config to the config file.
+func (p *Prometheus) writeConfig(config string) (err error) {
+	f, err := os.Create(filepath.Join(p.dir, "prometheus.yml"))
+	if err != nil {
+		return err
+	}
+	defer runutil.CloseWithErrCapture(&err, f, "prometheus config")
+	_, err = f.Write([]byte(config))
+	return err
+}
+
+// Stop terminates Prometheus and clean up its data directory.
+func (p *Prometheus) Stop() (rerr error) {
+	if !p.running {
+		return nil
+	}
+
+	if p.cmd.Process != nil {
+		if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+			return errors.Wrapf(err, "failed to Prometheus. Kill it manually and clean %s dir", p.db.Dir())
+		}
+
+		err := p.cmd.Wait()
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				if exitErr.ExitCode() != -1 {
+					fmt.Fprintln(os.Stderr, "Prometheus exited with", exitErr.ExitCode())
+					fmt.Fprintln(os.Stderr, "stdout:\n", p.stdout.String(), "\nstderr:\n", p.stderr.String())
+				} else {
+					err = nil
+				}
+			}
+		}
+
+		if err != nil {
+			return fmt.Errorf("waiting for Prometheus to exit: %w", err)
+		}
+	}
+
+	return p.cleanup()
+}
+
+func (p *Prometheus) cleanup() error {
+	p.running = false
+	return os.RemoveAll(p.db.Dir())
+}
+
+// Appender returns a new appender to populate the Prometheus instance with data.
+// All appenders must be closed before Start is called and no new ones must be opened
+// afterwards.
+func (p *Prometheus) Appender() storage.Appender {
+	if p.running {
+		panic("Appender must not be called after start")
+	}
+	return p.db.Appender(context.Background())
+}
+
+// CreateEmptyBlock produces empty block like it was the case before fix: https://github.com/prometheus/tsdb/pull/374.
+// (Prometheus pre v2.7.0).
+func CreateEmptyBlock(dir string, mint, maxt int64, extLset labels.Labels, resolution int64) (ulid.ULID, error) {
+	entropy := rand.New(rand.NewSource(time.Now().UnixNano()))
+	uid := ulid.MustNew(ulid.Now(), entropy)
+
+	if err := os.Mkdir(path.Join(dir, uid.String()), os.ModePerm); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "close index")
+	}
+
+	if err := os.Mkdir(path.Join(dir, uid.String(), "chunks"), os.ModePerm); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "close index")
+	}
+
+	w, err := index.NewWriter(context.Background(), path.Join(dir, uid.String(), "index"))
+	if err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "new index")
+	}
+
+	if err := w.Close(); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "close index")
+	}
+
+	m := tsdb.BlockMeta{
+		Version: 1,
+		ULID:    uid,
+		MinTime: mint,
+		MaxTime: maxt,
+		Compaction: tsdb.BlockMetaCompaction{
+			Level:   1,
+			Sources: []ulid.ULID{uid},
+		},
+	}
+	b, err := json.Marshal(&m)
+	if err != nil {
+		return ulid.ULID{}, err
+	}
+
+	if err := os.WriteFile(path.Join(dir, uid.String(), "meta.json"), b, os.ModePerm); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "saving meta.json")
+	}
+
+	if _, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(dir, uid.String()), metadata.Thanos{
+		Labels:     extLset.Map(),
+		Downsample: metadata.ThanosDownsample{Resolution: resolution},
+		Source:     metadata.TestSource,
+	}, nil); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "finalize block")
+	}
+
+	return uid, nil
+}
+
+// CreateBlock writes a block with the given series and numSamples samples each.
+// Samples will be in the time range [mint, maxt).
+func CreateBlock(
+	ctx context.Context,
+	dir string,
+	series []labels.Labels,
+	numSamples int,
+	mint, maxt int64,
+	extLset labels.Labels,
+	resolution int64,
+	hashFunc metadata.HashFunc,
+) (id ulid.ULID, err error) {
+	return createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, false, hashFunc, chunkenc.ValFloat)
+}
+
+// CreateBlockWithTombstone is same as CreateBlock but leaves tombstones which mimics the Prometheus local block.
+func CreateBlockWithTombstone(
+	ctx context.Context,
+	dir string,
+	series []labels.Labels,
+	numSamples int,
+	mint, maxt int64,
+	extLset labels.Labels,
+	resolution int64,
+	hashFunc metadata.HashFunc,
+) (id ulid.ULID, err error) {
+	return createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, true, hashFunc, chunkenc.ValFloat)
+}
+
+// CreateBlockWithBlockDelay writes a block with the given series and numSamples samples each.
+// Samples will be in the time range [mint, maxt)
+// Block ID will be created with a delay of time duration blockDelay.
+func CreateBlockWithBlockDelay(
+	ctx context.Context,
+	dir string,
+	series []labels.Labels,
+	numSamples int,
+	mint, maxt int64,
+	blockDelay time.Duration,
+	extLset labels.Labels,
+	resolution int64,
+	hashFunc metadata.HashFunc,
+) (ulid.ULID, error) {
+	return createBlockWithDelay(ctx, dir, series, numSamples, mint, maxt, blockDelay, extLset, resolution, hashFunc, chunkenc.ValFloat)
+}
+
+// CreateHistogramBlockWithDelay writes a block with the given native histogram series and numSamples samples each.
+// Samples will be in the time range [mint, maxt).
+func CreateHistogramBlockWithDelay(
+	ctx context.Context,
+	dir string,
+	series []labels.Labels,
+	numSamples int,
+	mint, maxt int64,
+	blockDelay time.Duration,
+	extLset labels.Labels,
+	resolution int64,
+	hashFunc metadata.HashFunc,
+) (id ulid.ULID, err error) {
+	return createBlockWithDelay(ctx, dir, series, numSamples, mint, maxt, blockDelay, extLset, resolution, hashFunc, chunkenc.ValHistogram)
+}
+
+// CreateFloatHistogramBlockWithDelay writes a block with the given float native histogram series and numSamples samples each.
+// Samples will be in the time range [mint, maxt).
+func CreateFloatHistogramBlockWithDelay(
+	ctx context.Context,
+	dir string,
+	series []labels.Labels,
+	numSamples int,
+	mint, maxt int64,
+	blockDelay time.Duration,
+	extLset labels.Labels,
+	resolution int64,
+	hashFunc metadata.HashFunc,
+) (id ulid.ULID, err error) {
+	return createBlockWithDelay(ctx, dir, series, numSamples, mint, maxt, blockDelay, extLset, resolution, hashFunc, chunkenc.ValFloatHistogram)
+}
+
+func createBlockWithDelay(ctx context.Context, dir string, series []labels.Labels, numSamples int, mint int64, maxt int64, blockDelay time.Duration, extLset labels.Labels, resolution int64, hashFunc metadata.HashFunc, samplesType chunkenc.ValueType) (ulid.ULID, error) {
+	blockID, err := createBlock(ctx, dir, series, numSamples, mint, maxt, extLset, resolution, false, hashFunc, samplesType)
+	if err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "block creation")
+	}
+
+	id, err := ulid.New(uint64(timestamp.FromTime(timestamp.Time(int64(blockID.Time())).Add(-blockDelay))), bytes.NewReader(blockID.Entropy()))
+	if err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "create block id")
+	}
+
+	bdir := path.Join(dir, blockID.String())
+	m, err := metadata.ReadFromDir(bdir)
+	if err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "open meta file")
+	}
+
+	logger := log.NewNopLogger()
+	m.ULID = id
+	m.Compaction.Sources = []ulid.ULID{id}
+	if err := m.WriteToDir(logger, path.Join(dir, blockID.String())); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "write meta.json file")
+	}
+
+	return id, os.Rename(path.Join(dir, blockID.String()), path.Join(dir, id.String()))
+}
+
+func createBlock(
+	ctx context.Context,
+	dir string,
+	series []labels.Labels,
+	numSamples int,
+	mint, maxt int64,
+	extLset labels.Labels,
+	resolution int64,
+	tombstones bool,
+	hashFunc metadata.HashFunc,
+	sampleType chunkenc.ValueType,
+) (id ulid.ULID, err error) {
+	headOpts := tsdb.DefaultHeadOptions()
+	headOpts.ChunkDirRoot = filepath.Join(dir, "chunks")
+	headOpts.ChunkRange = 10000000000
+	headOpts.EnableNativeHistograms = *atomic.NewBool(true)
+	h, err := tsdb.NewHead(nil, nil, nil, nil, headOpts, nil)
+	if err != nil {
+		return id, errors.Wrap(err, "create head block")
+	}
+	defer func() {
+		runutil.CloseWithErrCapture(&err, h, "TSDB Head")
+		if e := os.RemoveAll(headOpts.ChunkDirRoot); e != nil {
+			err = errors.Wrap(e, "delete chunks dir")
+		}
+	}()
+
+	var g errgroup.Group
+	var timeStepSize = (maxt - mint) / int64(numSamples+1)
+	var batchSize = len(series) / runtime.GOMAXPROCS(0)
+	r := rand.New(rand.NewSource(int64(numSamples)))
+	var randMutex sync.Mutex
+
+	for len(series) > 0 {
+		l := batchSize
+		if len(series) < 1000 {
+			l = len(series)
+		}
+		batch := series[:l]
+		series = series[l:]
+
+		g.Go(func() error {
+			t := mint
+
+			for i := 0; i < numSamples; i++ {
+				app := h.Appender(ctx)
+
+				for _, lset := range batch {
+					var err error
+					if sampleType == chunkenc.ValFloat {
+						randMutex.Lock()
+						_, err = app.Append(0, lset, t, r.Float64())
+						randMutex.Unlock()
+					} else if sampleType == chunkenc.ValHistogram {
+						_, err = app.AppendHistogram(0, lset, t, &histogramSample, nil)
+					} else if sampleType == chunkenc.ValFloatHistogram {
+						_, err = app.AppendHistogram(0, lset, t, nil, &floatHistogramSample)
+					}
+					if err != nil {
+						if rerr := app.Rollback(); rerr != nil {
+							err = errors.Wrapf(err, "rollback failed: %v", rerr)
+						}
+
+						return errors.Wrap(err, "add sample")
+					}
+				}
+				if err := app.Commit(); err != nil {
+					return errors.Wrap(err, "commit")
+				}
+				t += timeStepSize
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return id, err
+	}
+	c, err := tsdb.NewLeveledCompactor(ctx, nil, log.NewNopLogger(), []int64{maxt - mint}, nil, nil)
+	if err != nil {
+		return id, errors.Wrap(err, "create compactor")
+	}
+
+	ids, err := c.Write(dir, h, mint, maxt, nil)
+	if err != nil {
+		return id, errors.Wrap(err, "write block")
+	}
+	if len(ids) == 0 {
+		return id, errors.Errorf("nothing to write, asked for %d samples", numSamples)
+	}
+	id = ids[0]
+
+	blockDir := filepath.Join(dir, id.String())
+	logger := log.NewNopLogger()
+	seriesSize, err := gatherMaxSeriesSize(ctx, filepath.Join(blockDir, "index"))
+	if err != nil {
+		return id, errors.Wrap(err, "gather max series size")
+	}
+
+	files := []metadata.File{}
+	if hashFunc != metadata.NoneFunc {
+		paths := []string{}
+		if err := filepath.Walk(blockDir, func(path string, info os.FileInfo, err error) error {
+			if info.IsDir() {
+				return nil
+			}
+			paths = append(paths, path)
+			return nil
+		}); err != nil {
+			return id, errors.Wrapf(err, "walking %s", dir)
+		}
+
+		for _, p := range paths {
+			pHash, err := metadata.CalculateHash(p, metadata.SHA256Func, log.NewNopLogger())
+			if err != nil {
+				return id, errors.Wrapf(err, "calculating hash of %s", blockDir+p)
+			}
+			files = append(files, metadata.File{
+				RelPath: strings.TrimPrefix(p, blockDir+"/"),
+				Hash:    &pHash,
+			})
+		}
+	}
+
+	if _, err = metadata.InjectThanos(logger, blockDir, metadata.Thanos{
+		Labels:     extLset.Map(),
+		Downsample: metadata.ThanosDownsample{Resolution: resolution},
+		Source:     metadata.TestSource,
+		Files:      files,
+		IndexStats: metadata.IndexStats{SeriesMaxSize: seriesSize},
+	}, nil); err != nil {
+		return id, errors.Wrap(err, "finalize block")
+	}
+
+	if !tombstones {
+		if err = os.Remove(filepath.Join(dir, id.String(), "tombstones")); err != nil {
+			return id, errors.Wrap(err, "remove tombstones")
+		}
+	}
+
+	return id, nil
+}
+
+func gatherMaxSeriesSize(ctx context.Context, fn string) (int64, error) {
+	r, err := index.NewFileReader(fn)
+	if err != nil {
+		return 0, errors.Wrap(err, "open index file")
+	}
+	defer runutil.CloseWithErrCapture(&err, r, "gather index issue file reader")
+
+	key, value := index.AllPostingsKey()
+	p, err := r.Postings(ctx, key, value)
+	if err != nil {
+		return 0, errors.Wrap(err, "get all postings")
+	}
+
+	// As of version two all series entries are 16 byte padded. All references
+	// we get have to account for that to get the correct offset.
+	offsetMultiplier := 1
+	version := r.Version()
+	if version >= 2 {
+		offsetMultiplier = 16
+	}
+
+	// Per series.
+	var (
+		prevId        storage.SeriesRef
+		maxSeriesSize int64
+	)
+	for p.Next() {
+		id := p.At()
+		if prevId != 0 {
+			// Approximate size.
+			seriesSize := int64(id-prevId) * int64(offsetMultiplier)
+			if seriesSize > maxSeriesSize {
+				maxSeriesSize = seriesSize
+			}
+		}
+		prevId = id
+	}
+	if p.Err() != nil {
+		return 0, errors.Wrap(err, "walk postings")
+	}
+
+	return maxSeriesSize, nil
+}
+
+// CreateBlockWithChurn writes a block with the given series. Start time of each series
+// will be randomized in the given time window to create churn. Only float chunk is supported right now.
+func CreateBlockWithChurn(
+	ctx context.Context,
+	rnd *rand.Rand,
+	dir string,
+	series []labels.Labels,
+	numSamples int,
+	mint, maxt int64,
+	extLset labels.Labels,
+	resolution int64,
+	scrapeInterval int64,
+	seriesSize int64,
+) (id ulid.ULID, err error) {
+	headOpts := tsdb.DefaultHeadOptions()
+	headOpts.ChunkDirRoot = filepath.Join(dir, "chunks")
+	headOpts.ChunkRange = 10000000000
+	h, err := tsdb.NewHead(nil, nil, nil, nil, headOpts, nil)
+	if err != nil {
+		return id, errors.Wrap(err, "create head block")
+	}
+	defer func() {
+		runutil.CloseWithErrCapture(&err, h, "TSDB Head")
+		if e := os.RemoveAll(headOpts.ChunkDirRoot); e != nil {
+			err = errors.Wrap(e, "delete chunks dir")
+		}
+	}()
+
+	app := h.Appender(ctx)
+	for i := 0; i < len(series); i++ {
+
+		var ref storage.SeriesRef
+		start := RandRange(rnd, mint, maxt)
+		for j := 0; j < numSamples; j++ {
+			if ref == 0 {
+				ref, err = app.Append(0, series[i], start, float64(i+j))
+			} else {
+				ref, err = app.Append(ref, series[i], start, float64(i+j))
+			}
+			if err != nil {
+				if rerr := app.Rollback(); rerr != nil {
+					err = errors.Wrapf(err, "rollback failed: %v", rerr)
+				}
+				return id, errors.Wrap(err, "add sample")
+			}
+			start += scrapeInterval
+			if start > maxt {
+				break
+			}
+		}
+	}
+	if err := app.Commit(); err != nil {
+		return id, errors.Wrap(err, "commit")
+	}
+
+	c, err := tsdb.NewLeveledCompactor(ctx, nil, log.NewNopLogger(), []int64{maxt - mint}, nil, nil)
+	if err != nil {
+		return id, errors.Wrap(err, "create compactor")
+	}
+
+	ids, err := c.Write(dir, h, mint, maxt, nil)
+	if err != nil {
+		return id, errors.Wrap(err, "write block")
+	}
+
+	if len(ids) == 0 {
+		return id, errors.Errorf("nothing to write, asked for %d samples", numSamples)
+	}
+	id = ids[0]
+
+	blockDir := filepath.Join(dir, id.String())
+	logger := log.NewNopLogger()
+
+	if _, err = metadata.InjectThanos(logger, blockDir, metadata.Thanos{
+		Labels:     extLset.Map(),
+		Downsample: metadata.ThanosDownsample{Resolution: resolution},
+		Source:     metadata.TestSource,
+		IndexStats: metadata.IndexStats{SeriesMaxSize: seriesSize},
+	}, nil); err != nil {
+		return id, errors.Wrap(err, "finalize block")
+	}
+
+	return id, nil
+}
+
+// AddDelay rewrites a given block with delay.
+func AddDelay(blockID ulid.ULID, dir string, blockDelay time.Duration) (ulid.ULID, error) {
+	id, err := ulid.New(uint64(timestamp.FromTime(timestamp.Time(int64(blockID.Time())).Add(-blockDelay))), bytes.NewReader(blockID.Entropy()))
+	if err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "create block id")
+	}
+
+	bdir := path.Join(dir, blockID.String())
+	m, err := metadata.ReadFromDir(bdir)
+	if err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "open meta file")
+	}
+
+	logger := log.NewNopLogger()
+	m.ULID = id
+	m.Compaction.Sources = []ulid.ULID{id}
+	if err := m.WriteToDir(logger, path.Join(dir, blockID.String())); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "write meta.json file")
+	}
+
+	return id, os.Rename(path.Join(dir, blockID.String()), path.Join(dir, id.String()))
+}

--- a/vendor/github.com/thanos-io/thanos/pkg/testutil/e2eutil/rand.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/testutil/e2eutil/rand.go
@@ -1,0 +1,11 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package e2eutil
+
+import "math/rand"
+
+// RandRange returns a random int64 from [min, max].
+func RandRange(rnd *rand.Rand, min, max int64) int64 {
+	return rnd.Int63n(max-min) + min
+}

--- a/vendor/github.com/thanos-io/thanos/pkg/testutil/e2eutil/sysprocattr.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/testutil/e2eutil/sysprocattr.go
@@ -1,0 +1,13 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+//go:build !linux
+// +build !linux
+
+package e2eutil
+
+import "syscall"
+
+func SysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}

--- a/vendor/github.com/thanos-io/thanos/pkg/testutil/e2eutil/sysprocattr_linux.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/testutil/e2eutil/sysprocattr_linux.go
@@ -1,0 +1,13 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package e2eutil
+
+import "syscall"
+
+func SysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		// For linux only, kill this if the go test process dies before the cleanup.
+		Pdeathsig: syscall.SIGKILL,
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1038,6 +1038,7 @@ github.com/thanos-io/thanos/pkg/store/storepb/prompb
 github.com/thanos-io/thanos/pkg/strutil
 github.com/thanos-io/thanos/pkg/targets/targetspb
 github.com/thanos-io/thanos/pkg/tenancy
+github.com/thanos-io/thanos/pkg/testutil/e2eutil
 github.com/thanos-io/thanos/pkg/tls
 github.com/thanos-io/thanos/pkg/tracing
 github.com/thanos-io/thanos/pkg/tracing/interceptors


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Implement partitioning compaction related lifecycle functions to make partitioning compaction end to end working.

- `PartitionCompactionBlockDeletableChecker` makes sure no parent blocks got deleted after each compaction. Cleaner would handle parent blocks clean up for partitioning compaction.
- `ShardedBlockPopulator` would use `ShardedPosting` to including particular series in the result block.
- `ShardedCompactionLifecycleCallback`is used to emit partitioning compaction metrics at beginning and end of compaction. It also initialize `ShardedBlockPopulator` for each compaction.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
