### PR TITLE
Fix race that can cause nil reference when using expanded postings

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2808,6 +2808,9 @@ func (i *Ingester) expirePostingsCache(ctx context.Context) error {
 			return nil
 		}
 		userDB := i.getTSDB(userID)
+		if userDB == nil || userDB.postingCache == nil {
+			continue
+		}
 		userDB.postingCache.PurgeExpiredItems()
 	}
 


### PR DESCRIPTION
**What this PR does**:
https://github.com/cortexproject/cortex/pull/6502 added a background check to expire the expandedPonstings cache.

This new code can have a race that can cause panic.

This PR is fixing this possible race condition. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
