### PR TITLE
Add more op label values to cortex_query_frontend_queries_total metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [FEATURE] Query Frontend: Support a metadata federated query when `-tenant-federation.enabled=true`. #6461
 * [FEATURE] Query Frontend: Support an exemplar federated query when `-tenant-federation.enabled=true`. #6455
 * [FEATURE] Ingester/StoreGateway: Add support for cache regex query matchers via `-ingester.matchers-cache-max-items` and `-blocks-storage.bucket-store.matchers-cache-max-items`. #6477 #6491
+* [ENHANCEMENT] Query Frontend: Add more operation label values to the `cortex_query_frontend_queries_total` metric. #6519
 * [ENHANCEMENT] Query Frontend: Add a `source` label to query stat metrics. #6470
 * [ENHANCEMENT] Query Frontend: Add a flag `-tenant-federation.max-tenant` to limit the number of tenants for federated query. #6493
 * [ENHANCEMENT] Querier: Add a `-tenant-federation.max-concurrent` flags to configure the number of worker processing federated query and add a `cortex_querier_federated_tenants_per_query` histogram to track the number of tenants per query. #6449

--- a/pkg/querier/tripperware/roundtrip.go
+++ b/pkg/querier/tripperware/roundtrip.go
@@ -37,6 +37,17 @@ import (
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
+const (
+	opTypeQuery          = "query"
+	opTypeQueryRange     = "query_range"
+	opTypeSeries         = "series"
+	opTypeRemoteRead     = "remote_read"
+	opTypeLabelNames     = "label_names"
+	opTypeLabelValues    = "label_values"
+	opTypeMetadata       = "metadata"
+	opTypeQueryExemplars = "query_exemplars"
+)
+
 // HandlerFunc is like http.HandlerFunc, but for Handler.
 type HandlerFunc func(context.Context, Request) (Response, error)
 
@@ -140,12 +151,28 @@ func NewQueryTripperware(
 				isQuery := strings.HasSuffix(r.URL.Path, "/query")
 				isQueryRange := strings.HasSuffix(r.URL.Path, "/query_range")
 				isSeries := strings.HasSuffix(r.URL.Path, "/series")
+				isRemoteRead := strings.HasSuffix(r.URL.Path, "/read")
+				isLabelNames := strings.HasSuffix(r.URL.Path, "/labels")
+				isLabelValues := strings.HasSuffix(r.URL.Path, "/values")
+				isMetadata := strings.HasSuffix(r.URL.Path, "/metadata")
+				isQueryExemplars := strings.HasSuffix(r.URL.Path, "/query_exemplars")
 
-				op := "query"
-				if isQueryRange {
-					op = "query_range"
-				} else if isSeries {
-					op = "series"
+				op := opTypeQuery
+				switch {
+				case isQueryRange:
+					op = opTypeQueryRange
+				case isSeries:
+					op = opTypeSeries
+				case isRemoteRead:
+					op = opTypeRemoteRead
+				case isLabelNames:
+					op = opTypeLabelNames
+				case isLabelValues:
+					op = opTypeLabelValues
+				case isMetadata:
+					op = opTypeMetadata
+				case isQueryExemplars:
+					op = opTypeQueryExemplars
 				}
 
 				tenantIDs, err := tenant.TenantIDs(r.Context())

--- a/pkg/querier/tripperware/roundtrip_test.go
+++ b/pkg/querier/tripperware/roundtrip_test.go
@@ -34,6 +34,10 @@ const (
 	querySubqueryStepSizeTooSmall = "/api/v1/query?query=up%5B30d%3A%5D"
 	queryExceedsMaxQueryLength    = "/api/v1/query?query=up%5B90d%5D"
 	seriesQuery                   = "/api/v1/series?match[]"
+	remoteReadQuery               = "/api/v1/read"
+	labelNamesQuery               = "/api/v1/labels"
+	labelValuesQuery              = "/api/v1/label/label/values"
+	metadataQuery                 = "/api/v1/metadata"
 
 	responseBody        = `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[1536673680,"137"],[1536673780,"137"]]}]}}`
 	instantResponseBody = `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"foo":"bar"},"values":[[1536673680,"137"],[1536673780,"137"]]}]}}`
@@ -153,7 +157,7 @@ cortex_query_frontend_queries_total{op="query", source="api", user="1"} 1
 			expectedMetric: `
 # HELP cortex_query_frontend_queries_total Total queries sent per tenant.
 # TYPE cortex_query_frontend_queries_total counter
-cortex_query_frontend_queries_total{op="query", source="api", user="1"} 1
+cortex_query_frontend_queries_total{op="query_exemplars", source="api", user="1"} 1
 `,
 		},
 		{
@@ -166,6 +170,54 @@ cortex_query_frontend_queries_total{op="query", source="api", user="1"} 1
 # HELP cortex_query_frontend_queries_total Total queries sent per tenant.
 # TYPE cortex_query_frontend_queries_total counter
 cortex_query_frontend_queries_total{op="series", source="api", user="1"} 1
+`,
+		},
+		{
+			path:             labelNamesQuery,
+			expectedBody:     "bar",
+			limits:           defaultOverrides,
+			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/1.2",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="label_names", source="api", user="1"} 1
+`,
+		},
+		{
+			path:             labelValuesQuery,
+			expectedBody:     "bar",
+			limits:           defaultOverrides,
+			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/1.2",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="label_values", source="api", user="1"} 1
+`,
+		},
+		{
+			path:             metadataQuery,
+			expectedBody:     "bar",
+			limits:           defaultOverrides,
+			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/1.2",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="metadata", source="api", user="1"} 1
+`,
+		},
+		{
+			path:             remoteReadQuery,
+			expectedBody:     "bar",
+			limits:           defaultOverrides,
+			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/1.2",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="remote_read", source="api", user="1"} 1
 `,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR adds more `op` label values to the `cortex_query_frontend_queries_total` metric.
The added label values are: `remote_read`, `label_names`, `label_values`, `metadata`, and `query_exemplars`.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
