### PR TITLE
log when a request starts running in querier

### DIFF
--- a/pkg/querier/worker/frontend_processor.go
+++ b/pkg/querier/worker/frontend_processor.go
@@ -142,6 +142,9 @@ func (fp *frontendProcessor) runRequest(ctx context.Context, request *httpgrpc.H
 	}
 	ctx = util_log.ContextWithHeaderMap(ctx, headerMap)
 	logger := util_log.WithContext(ctx, fp.log)
+	if statsEnabled {
+		level.Info(logger).Log("msg", "started running request")
+	}
 
 	response, err := fp.handler.Handle(ctx, request)
 	if err != nil {

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -156,6 +156,9 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 				ctx = spanCtx
 			}
 			logger := util_log.WithContext(ctx, sp.log)
+			if request.StatsEnabled {
+				level.Info(logger).Log("msg", "started running request")
+			}
 			sp.runRequest(ctx, logger, request.QueryID, request.FrontendAddress, request.StatsEnabled, request.HttpRequest)
 
 			if err = ctx.Err(); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
The PR adds a log when a querier starts running a request. We currently log when a querier finishes a request but we do not log when it picks one up. If the log for finishing the request is missing, it is hard to identify if querier successfully received the request or not.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
