### PR TITLE
Query Partial Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [FEATURE] Distributor/Querier: Add `query_partial_data` to allow partial query data from 1 zone to be returned with a warning message. #6526
+* [FEATURE] Distributor/Querier: Add `query_partial_data` and `rules_partial_data` to allow queries/rules to be evaluated with data from a single zone, if other zones are not available. #6526
 
 ## 1.19.0 in progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [FEATURE] Distributor/Querier: Add `query_partial_data` and `rules_partial_data` to allow queries/rules to be evaluated with data from a single zone, if other zones are not available. #6526
+* [FEATURE] Querier: Add `query_partial_data` and `rules_partial_data` limits to allow queries/rules to be evaluated with data from a single zone, if other zones are not available. #6526
 
 ## 1.19.0 in progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [FEATURE] Distributor/Querier: Add `query_partial_data` to allow partial query data from 1 zone to be returned with a warning message. #6526
+
 ## 1.19.0 in progress
 
 * [CHANGE] Deprecate `-blocks-storage.tsdb.wal-compression-enabled` flag (use `blocks-storage.tsdb.wal-compression-type` instead). #6529

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [FEATURE] Querier: Add `query_partial_data` and `rules_partial_data` limits to allow queries/rules to be evaluated with data from a single zone, if other zones are not available. #6526
+* [FEATURE] Querier/Ruler: Add `query_partial_data` and `rules_partial_data` limits to allow queries/rules to be evaluated with data from a single zone, if other zones are not available. #6526
 
 ## 1.19.0 in progress
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3545,6 +3545,9 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -frontend.max-queriers-per-tenant
 [max_queriers_per_tenant: <float> | default = 0]
 
+# Enable query to return partial data with warning message.
+[query_partial_data: <boolean> | default = false]
+
 # Maximum number of outstanding requests per tenant per request queue (either
 # query frontend or query scheduler); requests beyond this error with HTTP 429.
 # CLI flag: -frontend.max-outstanding-requests-per-tenant

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3549,10 +3549,6 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # zones are not available.
 [query_partial_data: <boolean> | default = false]
 
-# Enable to allow rules to be evaluated with data from a single zone, if other
-# zones are not available.
-[rules_partial_data: <boolean> | default = false]
-
 # Maximum number of outstanding requests per tenant per request queue (either
 # query frontend or query scheduler); requests beyond this error with HTTP 429.
 # CLI flag: -frontend.max-outstanding-requests-per-tenant
@@ -3612,6 +3608,10 @@ query_rejection:
 
 # external labels for alerting rules
 [ruler_external_labels: <map of string (labelName) to string (labelValue)> | default = []]
+
+# Enable to allow rules to be evaluated with data from a single zone, if other
+# zones are not available.
+[rules_partial_data: <boolean> | default = false]
 
 # The default tenant's shard size when the shuffle-sharding strategy is used.
 # Must be set when the store-gateway sharding is enabled with the

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3545,7 +3545,8 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -frontend.max-queriers-per-tenant
 [max_queriers_per_tenant: <float> | default = 0]
 
-# Enable query to return partial data with warning message.
+# Enable to allow partial query data from 1 zone to be returned with a warning
+# message.
 [query_partial_data: <boolean> | default = false]
 
 # Maximum number of outstanding requests per tenant per request queue (either

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3545,9 +3545,13 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -frontend.max-queriers-per-tenant
 [max_queriers_per_tenant: <float> | default = 0]
 
-# Enable to allow partial query data from 1 zone to be returned with a warning
-# message.
+# Enable to allow queries to be evaluated with data from a single zone, if other
+# zones are not available.
 [query_partial_data: <boolean> | default = false]
+
+# Enable to allow rules to be evaluated with data from a single zone, if other
+# zones are not available.
+[rules_partial_data: <boolean> | default = false]
 
 # Maximum number of outstanding requests per tenant per request queue (either
 # query frontend or query scheduler); requests beyond this error with HTTP 429.

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -258,7 +258,7 @@ func (t *Cortex) initQueryable() (serv services.Service, err error) {
 	querierRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "querier"}, prometheus.DefaultRegisterer)
 
 	// Create a querier queryable and PromQL engine
-	t.QuerierQueryable, t.ExemplarQueryable, t.QuerierEngine = querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, querierRegisterer, util_log.Logger)
+	t.QuerierQueryable, t.ExemplarQueryable, t.QuerierEngine = querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, querierRegisterer, util_log.Logger, t.Overrides.QueryPartialData)
 
 	// Use distributor as default MetadataQuerier
 	t.MetadataQuerier = t.Distributor
@@ -623,7 +623,7 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 	} else {
 		rulerRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "ruler"}, prometheus.DefaultRegisterer)
 		// TODO: Consider wrapping logger to differentiate from querier module logger
-		queryable, _, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, rulerRegisterer, util_log.Logger)
+		queryable, _, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, rulerRegisterer, util_log.Logger, t.Overrides.RulesPartialData)
 
 		managerFactory := ruler.DefaultTenantManagerFactory(t.Cfg.Ruler, t.Distributor, queryable, engine, t.Overrides, metrics, prometheus.DefaultRegisterer)
 		manager, err = ruler.NewDefaultMultiTenantManager(t.Cfg.Ruler, t.Overrides, managerFactory, metrics, prometheus.DefaultRegisterer, util_log.Logger)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1177,8 +1177,8 @@ func getErrorStatus(err error) string {
 }
 
 // ForReplicationSet runs f, in parallel, for all ingesters in the input replication set.
-func (d *Distributor) ForReplicationSet(ctx context.Context, replicationSet ring.ReplicationSet, zoneResultsQuorum bool, f func(context.Context, ingester_client.IngesterClient) (interface{}, error)) ([]interface{}, error) {
-	return replicationSet.Do(ctx, d.cfg.ExtraQueryDelay, zoneResultsQuorum, func(ctx context.Context, ing *ring.InstanceDesc) (interface{}, error) {
+func (d *Distributor) ForReplicationSet(ctx context.Context, replicationSet ring.ReplicationSet, zoneResultsQuorum bool, partialDataEnabled bool, f func(context.Context, ingester_client.IngesterClient) (interface{}, error)) ([]interface{}, error) {
+	return replicationSet.Do(ctx, d.cfg.ExtraQueryDelay, zoneResultsQuorum, partialDataEnabled, func(ctx context.Context, ing *ring.InstanceDesc) (interface{}, error) {
 		client, err := d.ingesterPool.GetClientFor(ing.Addr)
 		if err != nil {
 			return nil, err
@@ -1228,9 +1228,9 @@ func (d *Distributor) LabelValuesForLabelNameCommon(ctx context.Context, from, t
 }
 
 // LabelValuesForLabelName returns all the label values that are associated with a given label name.
-func (d *Distributor) LabelValuesForLabelName(ctx context.Context, from, to model.Time, labelName model.LabelName, hint *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
-	return d.LabelValuesForLabelNameCommon(ctx, from, to, labelName, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelValuesRequest) ([]interface{}, error) {
-		return d.ForReplicationSet(ctx, rs, d.cfg.ZoneResultsQuorumMetadata, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
+func (d *Distributor) LabelValuesForLabelName(ctx context.Context, from, to model.Time, label model.LabelName, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
+	return d.LabelValuesForLabelNameCommon(ctx, from, to, label, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelValuesRequest) ([]interface{}, error) {
+		return d.ForReplicationSet(ctx, rs, d.cfg.ZoneResultsQuorumMetadata, partialDataEnabled, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			resp, err := client.LabelValues(ctx, req)
 			if err != nil {
 				return nil, err
@@ -1241,9 +1241,9 @@ func (d *Distributor) LabelValuesForLabelName(ctx context.Context, from, to mode
 }
 
 // LabelValuesForLabelNameStream returns all the label values that are associated with a given label name.
-func (d *Distributor) LabelValuesForLabelNameStream(ctx context.Context, from, to model.Time, labelName model.LabelName, hint *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
-	return d.LabelValuesForLabelNameCommon(ctx, from, to, labelName, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelValuesRequest) ([]interface{}, error) {
-		return d.ForReplicationSet(ctx, rs, d.cfg.ZoneResultsQuorumMetadata, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
+func (d *Distributor) LabelValuesForLabelNameStream(ctx context.Context, from, to model.Time, label model.LabelName, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
+	return d.LabelValuesForLabelNameCommon(ctx, from, to, label, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelValuesRequest) ([]interface{}, error) {
+		return d.ForReplicationSet(ctx, rs, d.cfg.ZoneResultsQuorumMetadata, partialDataEnabled, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			stream, err := client.LabelValuesStream(ctx, req)
 			if err != nil {
 				return nil, err
@@ -1307,9 +1307,9 @@ func (d *Distributor) LabelNamesCommon(ctx context.Context, from, to model.Time,
 	return r, nil
 }
 
-func (d *Distributor) LabelNamesStream(ctx context.Context, from, to model.Time, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
+func (d *Distributor) LabelNamesStream(ctx context.Context, from model.Time, to model.Time, hints *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
 	return d.LabelNamesCommon(ctx, from, to, hints, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelNamesRequest) ([]interface{}, error) {
-		return d.ForReplicationSet(ctx, rs, d.cfg.ZoneResultsQuorumMetadata, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
+		return d.ForReplicationSet(ctx, rs, d.cfg.ZoneResultsQuorumMetadata, partialDataEnabled, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			stream, err := client.LabelNamesStream(ctx, req)
 			if err != nil {
 				return nil, err
@@ -1333,9 +1333,9 @@ func (d *Distributor) LabelNamesStream(ctx context.Context, from, to model.Time,
 }
 
 // LabelNames returns all the label names.
-func (d *Distributor) LabelNames(ctx context.Context, from, to model.Time, hint *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
+func (d *Distributor) LabelNames(ctx context.Context, from model.Time, to model.Time, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
 	return d.LabelNamesCommon(ctx, from, to, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelNamesRequest) ([]interface{}, error) {
-		return d.ForReplicationSet(ctx, rs, d.cfg.ZoneResultsQuorumMetadata, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
+		return d.ForReplicationSet(ctx, rs, d.cfg.ZoneResultsQuorumMetadata, partialDataEnabled, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			resp, err := client.LabelNames(ctx, req)
 			if err != nil {
 				return nil, err
@@ -1346,9 +1346,9 @@ func (d *Distributor) LabelNames(ctx context.Context, from, to model.Time, hint 
 }
 
 // MetricsForLabelMatchers gets the metrics that match said matchers
-func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, hint *storage.SelectHints, matchers ...*labels.Matcher) ([]model.Metric, error) {
+func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, hint *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
 	return d.metricsForLabelMatchersCommon(ctx, from, through, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.MetricsForLabelMatchersRequest, metrics *map[model.Fingerprint]model.Metric, mutex *sync.Mutex, queryLimiter *limiter.QueryLimiter) error {
-		_, err := d.ForReplicationSet(ctx, rs, false, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
+		_, err := d.ForReplicationSet(ctx, rs, false, false, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			resp, err := client.MetricsForLabelMatchers(ctx, req)
 			if err != nil {
 				return nil, err
@@ -1375,9 +1375,9 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 	}, matchers...)
 }
 
-func (d *Distributor) MetricsForLabelMatchersStream(ctx context.Context, from, through model.Time, hint *storage.SelectHints, matchers ...*labels.Matcher) ([]model.Metric, error) {
+func (d *Distributor) MetricsForLabelMatchersStream(ctx context.Context, from, through model.Time, hint *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
 	return d.metricsForLabelMatchersCommon(ctx, from, through, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.MetricsForLabelMatchersRequest, metrics *map[model.Fingerprint]model.Metric, mutex *sync.Mutex, queryLimiter *limiter.QueryLimiter) error {
-		_, err := d.ForReplicationSet(ctx, rs, false, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
+		_, err := d.ForReplicationSet(ctx, rs, false, false, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			stream, err := client.MetricsForLabelMatchersStream(ctx, req)
 			if err != nil {
 				return nil, err
@@ -1453,7 +1453,7 @@ func (d *Distributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetad
 
 	req := &ingester_client.MetricsMetadataRequest{}
 	// TODO(gotjosh): We only need to look in all the ingesters if shardByAllLabels is enabled.
-	resps, err := d.ForReplicationSet(ctx, replicationSet, d.cfg.ZoneResultsQuorumMetadata, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
+	resps, err := d.ForReplicationSet(ctx, replicationSet, d.cfg.ZoneResultsQuorumMetadata, false, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 		return client.MetricsMetadata(ctx, req)
 	})
 	if err != nil {
@@ -1495,7 +1495,7 @@ func (d *Distributor) UserStats(ctx context.Context) (*ingester.UserStats, error
 	replicationSet.MaxErrors = 0
 
 	req := &ingester_client.UserStatsRequest{}
-	resps, err := d.ForReplicationSet(ctx, replicationSet, false, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
+	resps, err := d.ForReplicationSet(ctx, replicationSet, false, false, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 		return client.UserStats(ctx, req)
 	})
 	if err != nil {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1228,8 +1228,8 @@ func (d *Distributor) LabelValuesForLabelNameCommon(ctx context.Context, from, t
 }
 
 // LabelValuesForLabelName returns all the label values that are associated with a given label name.
-func (d *Distributor) LabelValuesForLabelName(ctx context.Context, from, to model.Time, label model.LabelName, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
-	return d.LabelValuesForLabelNameCommon(ctx, from, to, label, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelValuesRequest) ([]interface{}, error) {
+func (d *Distributor) LabelValuesForLabelName(ctx context.Context, from, to model.Time, labelName model.LabelName, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
+	return d.LabelValuesForLabelNameCommon(ctx, from, to, labelName, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelValuesRequest) ([]interface{}, error) {
 		return d.ForReplicationSet(ctx, rs, d.cfg.ZoneResultsQuorumMetadata, partialDataEnabled, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			resp, err := client.LabelValues(ctx, req)
 			if err != nil {
@@ -1241,8 +1241,8 @@ func (d *Distributor) LabelValuesForLabelName(ctx context.Context, from, to mode
 }
 
 // LabelValuesForLabelNameStream returns all the label values that are associated with a given label name.
-func (d *Distributor) LabelValuesForLabelNameStream(ctx context.Context, from, to model.Time, label model.LabelName, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
-	return d.LabelValuesForLabelNameCommon(ctx, from, to, label, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelValuesRequest) ([]interface{}, error) {
+func (d *Distributor) LabelValuesForLabelNameStream(ctx context.Context, from, to model.Time, labelName model.LabelName, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
+	return d.LabelValuesForLabelNameCommon(ctx, from, to, labelName, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelValuesRequest) ([]interface{}, error) {
 		return d.ForReplicationSet(ctx, rs, d.cfg.ZoneResultsQuorumMetadata, partialDataEnabled, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			stream, err := client.LabelValuesStream(ctx, req)
 			if err != nil {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1307,7 +1307,7 @@ func (d *Distributor) LabelNamesCommon(ctx context.Context, from, to model.Time,
 	return r, nil
 }
 
-func (d *Distributor) LabelNamesStream(ctx context.Context, from model.Time, to model.Time, hints *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
+func (d *Distributor) LabelNamesStream(ctx context.Context, from, to model.Time, hints *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
 	return d.LabelNamesCommon(ctx, from, to, hints, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelNamesRequest) ([]interface{}, error) {
 		return d.ForReplicationSet(ctx, rs, d.cfg.ZoneResultsQuorumMetadata, partialDataEnabled, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			stream, err := client.LabelNamesStream(ctx, req)
@@ -1333,7 +1333,7 @@ func (d *Distributor) LabelNamesStream(ctx context.Context, from model.Time, to 
 }
 
 // LabelNames returns all the label names.
-func (d *Distributor) LabelNames(ctx context.Context, from model.Time, to model.Time, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
+func (d *Distributor) LabelNames(ctx context.Context, from, to model.Time, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
 	return d.LabelNamesCommon(ctx, from, to, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.LabelNamesRequest) ([]interface{}, error) {
 		return d.ForReplicationSet(ctx, rs, d.cfg.ZoneResultsQuorumMetadata, partialDataEnabled, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			resp, err := client.LabelNames(ctx, req)
@@ -1348,7 +1348,7 @@ func (d *Distributor) LabelNames(ctx context.Context, from model.Time, to model.
 // MetricsForLabelMatchers gets the metrics that match said matchers
 func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, hint *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
 	return d.metricsForLabelMatchersCommon(ctx, from, through, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.MetricsForLabelMatchersRequest, metrics *map[model.Fingerprint]model.Metric, mutex *sync.Mutex, queryLimiter *limiter.QueryLimiter) error {
-		_, err := d.ForReplicationSet(ctx, rs, false, false, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
+		_, err := d.ForReplicationSet(ctx, rs, false, partialDataEnabled, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			resp, err := client.MetricsForLabelMatchers(ctx, req)
 			if err != nil {
 				return nil, err
@@ -1377,7 +1377,7 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 
 func (d *Distributor) MetricsForLabelMatchersStream(ctx context.Context, from, through model.Time, hint *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
 	return d.metricsForLabelMatchersCommon(ctx, from, through, hint, func(ctx context.Context, rs ring.ReplicationSet, req *ingester_client.MetricsForLabelMatchersRequest, metrics *map[model.Fingerprint]model.Metric, mutex *sync.Mutex, queryLimiter *limiter.QueryLimiter) error {
-		_, err := d.ForReplicationSet(ctx, rs, false, false, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
+		_, err := d.ForReplicationSet(ctx, rs, false, partialDataEnabled, func(ctx context.Context, client ingester_client.IngesterClient) (interface{}, error) {
 			stream, err := client.MetricsForLabelMatchersStream(ctx, req)
 			if err != nil {
 				return nil, err

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1316,7 +1316,7 @@ func TestDistributor_PushQuery(t *testing.T) {
 			assert.Nil(t, err)
 
 			var response model.Matrix
-			series, err := ds[0].QueryStream(ctx, 0, 10, tc.matchers...)
+			series, err := ds[0].QueryStream(ctx, 0, 10, false, tc.matchers...)
 			assert.Equal(t, tc.expectedError, err)
 
 			if series == nil {
@@ -1378,7 +1378,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunksPerQueryLimitIsReac
 
 		// Since the number of series (and thus chunks) is equal to the limit (but doesn't
 		// exceed it), we expect a query running on all series to succeed.
-		queryRes, err := ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+		queryRes, err := ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, false, allSeriesMatchers...)
 		require.NoError(t, err)
 		assert.Len(t, queryRes.Chunkseries, initialSeries)
 
@@ -1396,7 +1396,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunksPerQueryLimitIsReac
 
 		// Since the number of series (and thus chunks) is exceeding to the limit, we expect
 		// a query running on all series to fail.
-		_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+		_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, false, allSeriesMatchers...)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "the query hit the max number of chunks limit")
 	}
@@ -1440,7 +1440,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxSeriesPerQueryLimitIsReac
 
 		// Since the number of series is equal to the limit (but doesn't
 		// exceed it), we expect a query running on all series to succeed.
-		queryRes, err := ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+		queryRes, err := ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, false, allSeriesMatchers...)
 		require.NoError(t, err)
 		assert.Len(t, queryRes.Chunkseries, initialSeries)
 
@@ -1456,7 +1456,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxSeriesPerQueryLimitIsReac
 
 		// Since the number of series is exceeding the limit, we expect
 		// a query running on all series to fail.
-		_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+		_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, false, allSeriesMatchers...)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "max number of series limit")
 	}
@@ -1494,7 +1494,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIs
 		writeRes, err := ds[0].Push(ctx, writeReq)
 		assert.Equal(t, &cortexpb.WriteResponse{}, writeRes)
 		assert.Nil(t, err)
-		chunkSizeResponse, err := ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+		chunkSizeResponse, err := ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, false, allSeriesMatchers...)
 		require.NoError(t, err)
 
 		// Use the resulting chunks size to calculate the limit as (series to add + our test series) * the response chunk size.
@@ -1516,7 +1516,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIs
 
 		// Since the number of chunk bytes is equal to the limit (but doesn't
 		// exceed it), we expect a query running on all series to succeed.
-		queryRes, err := ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+		queryRes, err := ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, false, allSeriesMatchers...)
 		require.NoError(t, err)
 		assert.Len(t, queryRes.Chunkseries, seriesToAdd)
 
@@ -1532,7 +1532,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIs
 
 		// Since the aggregated chunk size is exceeding the limit, we expect
 		// a query running on all series to fail.
-		_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+		_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, false, allSeriesMatchers...)
 		require.Error(t, err)
 		assert.Equal(t, err, validation.LimitError(fmt.Sprintf(limiter.ErrMaxChunkBytesHit, maxBytesLimit)))
 	}
@@ -1571,7 +1571,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxDataBytesPerQueryLimitIsR
 		writeRes, err := ds[0].Push(ctx, writeReq)
 		assert.Equal(t, &cortexpb.WriteResponse{}, writeRes)
 		assert.Nil(t, err)
-		dataSizeResponse, err := ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+		dataSizeResponse, err := ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, false, allSeriesMatchers...)
 		require.NoError(t, err)
 
 		// Use the resulting chunks size to calculate the limit as (series to add + our test series) * the response chunk size.
@@ -1593,7 +1593,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxDataBytesPerQueryLimitIsR
 
 		// Since the number of chunk bytes is equal to the limit (but doesn't
 		// exceed it), we expect a query running on all series to succeed.
-		queryRes, err := ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+		queryRes, err := ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, false, allSeriesMatchers...)
 		require.NoError(t, err)
 		assert.Len(t, queryRes.Chunkseries, seriesToAdd)
 
@@ -1609,7 +1609,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxDataBytesPerQueryLimitIsR
 
 		// Since the aggregated chunk size is exceeding the limit, we expect
 		// a query running on all series to fail.
-		_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+		_, err = ds[0].QueryStream(ctx, math.MinInt32, math.MaxInt32, false, allSeriesMatchers...)
 		require.Error(t, err)
 		assert.Equal(t, err, validation.LimitError(fmt.Sprintf(limiter.ErrMaxDataBytesHit, maxBytesLimit)))
 	}
@@ -2065,7 +2065,7 @@ func BenchmarkDistributor_GetLabelsValues(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_, err := ds[0].LabelValuesForLabelName(ctx, model.Time(time.Now().UnixMilli()), model.Time(time.Now().UnixMilli()), "__name__", nil)
+				_, err := ds[0].LabelValuesForLabelName(ctx, model.Time(time.Now().UnixMilli()), model.Time(time.Now().UnixMilli()), "__name__", nil, false)
 				require.NoError(b, err)
 			}
 		})
@@ -2397,7 +2397,7 @@ func TestSlowQueries(t *testing.T) {
 					shardByAllLabels: shardByAllLabels,
 				})
 
-				_, err := ds[0].QueryStream(ctx, 0, 10, nameMatcher)
+				_, err := ds[0].QueryStream(ctx, 0, 10, false, nameMatcher)
 				assert.Equal(t, expectedErr, err)
 			})
 		}
@@ -2431,7 +2431,7 @@ func TestDistributor_MetricsForLabelMatchers_SingleSlowIngester(t *testing.T) {
 		}
 
 		for i := 0; i < 50; i++ {
-			_, err := ds[0].MetricsForLabelMatchers(ctx, now, now, nil, mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test"))
+			_, err := ds[0].MetricsForLabelMatchers(ctx, now, now, nil, false, mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test"))
 			require.NoError(t, err)
 		}
 	}
@@ -2600,7 +2600,7 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 				}
 
 				{
-					metrics, err := ds[0].MetricsForLabelMatchers(ctx, now, now, nil, testData.matchers...)
+					metrics, err := ds[0].MetricsForLabelMatchers(ctx, now, now, nil, false, testData.matchers...)
 
 					if testData.expectedErr != nil {
 						assert.ErrorIs(t, err, testData.expectedErr)
@@ -2618,7 +2618,7 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 				}
 
 				{
-					metrics, err := ds[0].MetricsForLabelMatchersStream(ctx, now, now, nil, testData.matchers...)
+					metrics, err := ds[0].MetricsForLabelMatchersStream(ctx, now, now, nil, false, testData.matchers...)
 					if testData.expectedErr != nil {
 						assert.ErrorIs(t, err, testData.expectedErr)
 						return
@@ -2705,7 +2705,7 @@ func BenchmarkDistributor_MetricsForLabelMatchers(b *testing.B) {
 
 			for n := 0; n < b.N; n++ {
 				now := model.Now()
-				metrics, err := ds[0].MetricsForLabelMatchers(ctx, now, now, nil, testData.matchers...)
+				metrics, err := ds[0].MetricsForLabelMatchers(ctx, now, now, nil, false, testData.matchers...)
 
 				if testData.expectedErr != nil {
 					assert.EqualError(b, err, testData.expectedErr.Error())

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -331,7 +331,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 
 	if partialdata.IsPartialDataError(err) {
 		level.Info(d.log).Log("msg", "returning partial data")
-		return resp, partialdata.Error{}
+		return resp, err
 	}
 
 	return resp, nil

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -223,10 +223,11 @@ func mergeExemplarQueryResponses(results []interface{}) *ingester_client.Exempla
 // queryIngesterStream queries the ingesters using the new streaming API.
 func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ring.ReplicationSet, req *ingester_client.QueryRequest) (*ingester_client.QueryStreamResponse, error) {
 	var (
-		queryLimiter       = limiter.QueryLimiterFromContextWithFallback(ctx)
-		reqStats           = stats.FromContext(ctx)
-		partialDataEnabled = partialdata.FromContext(ctx)
+		queryLimiter = limiter.QueryLimiterFromContextWithFallback(ctx)
+		reqStats     = stats.FromContext(ctx)
 	)
+
+	partialDataEnabled := false // TODO: jungjust
 
 	// Fetch samples from multiple ingesters
 	results, err := replicationSet.Do(ctx, d.cfg.ExtraQueryDelay, false, func(ctx context.Context, ing *ring.InstanceDesc) (interface{}, error) {

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -185,7 +185,7 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, sortSeries boo
 	seriesSet := series.NewConcreteSeriesSet(sortSeries, serieses)
 
 	if returnPartialData {
-		warning := annotations.Annotations(nil)
+		warning := seriesSet.Warnings()
 		return series.NewSeriesSetWithWarnings(seriesSet, warning.Add(err))
 	}
 

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -147,8 +147,7 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, sortSeries boo
 		return storage.ErrSeriesSet(err)
 	}
 
-	partialDataEnabled := q.partialDataEnabled(userID)
-	ctx = partialdata.ContextWithPartialData(ctx, partialDataEnabled)
+	partialDataEnabled := q.partialDataEnabled(userID) // TODO: jungjust
 	results, err := q.distributor.QueryStream(ctx, model.Time(minT), model.Time(maxT), matchers...)
 
 	returnPartialData := partialdata.ReturnPartialData(err, partialDataEnabled)

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -179,11 +179,9 @@ func TestIngesterStreaming(t *testing.T) {
 				d.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(queryResponse, partialdata.Error{})
 			}
 
-			limits := validation.Limits{QueryPartialData: partialDataEnabled}
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
-
-			queryable := newDistributorQueryable(d, true, true, batch.NewChunkMergeIterator, 0, overrides)
+			queryable := newDistributorQueryable(d, true, true, batch.NewChunkMergeIterator, 0, func(string) bool {
+				return partialDataEnabled
+			})
 			querier, err := queryable.Querier(mint, maxt)
 			require.NoError(t, err)
 

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -173,7 +173,7 @@ func TestIngesterStreaming(t *testing.T) {
 			}
 			var partialDataErr error
 			if partialDataEnabled {
-				partialDataErr = partialdata.Error{}
+				partialDataErr = partialdata.ErrPartialData
 			}
 			d.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(queryResponse, partialDataErr)
 
@@ -204,7 +204,7 @@ func TestIngesterStreaming(t *testing.T) {
 			require.NoError(t, seriesSet.Err())
 
 			if partialDataEnabled {
-				require.Contains(t, seriesSet.Warnings(), partialdata.ErrorMsg)
+				require.Contains(t, seriesSet.Warnings(), partialdata.ErrPartialData.Error())
 			}
 		}
 	}
@@ -233,7 +233,7 @@ func TestDistributorQuerier_LabelNames(t *testing.T) {
 
 					var partialDataErr error
 					if partialDataEnabled {
-						partialDataErr = partialdata.Error{}
+						partialDataErr = partialdata.ErrPartialData
 					}
 					if labelNamesWithMatchers {
 						d.On("LabelNames", mock.Anything, model.Time(mint), model.Time(maxt), mock.Anything, someMatchers).
@@ -257,7 +257,7 @@ func TestDistributorQuerier_LabelNames(t *testing.T) {
 					names, warnings, err := querier.LabelNames(ctx, nil, someMatchers...)
 					require.NoError(t, err)
 					if partialDataEnabled {
-						assert.Contains(t, warnings, partialdata.ErrorMsg)
+						assert.Contains(t, warnings, partialdata.ErrPartialData.Error())
 					} else {
 						assert.Empty(t, warnings)
 					}

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/cortexproject/cortex/pkg/ingester/client"
 	"github.com/cortexproject/cortex/pkg/querier/batch"
+	"github.com/cortexproject/cortex/pkg/querier/partialdata"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/chunkcompat"
 	"github.com/cortexproject/cortex/pkg/util/validation"
@@ -89,7 +90,7 @@ func TestDistributorQuerier_SelectShouldHonorQueryIngestersWithin(t *testing.T) 
 				distributor.On("MetricsForLabelMatchersStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]model.Metric{}, nil)
 
 				ctx := user.InjectOrgID(context.Background(), "test")
-				queryable := newDistributorQueryable(distributor, streamingMetadataEnabled, true, nil, testData.queryIngestersWithin)
+				queryable := newDistributorQueryable(distributor, streamingMetadataEnabled, true, nil, testData.queryIngestersWithin, queryPartialDataDisabledFn)
 				querier, err := queryable.Querier(testData.queryMinT, testData.queryMaxT)
 				require.NoError(t, err)
 
@@ -128,7 +129,7 @@ func TestDistributorQueryableFilter(t *testing.T) {
 	t.Parallel()
 
 	d := &MockDistributor{}
-	dq := newDistributorQueryable(d, false, true, nil, 1*time.Hour)
+	dq := newDistributorQueryable(d, false, true, nil, 1*time.Hour, queryPartialDataDisabledFn)
 
 	now := time.Now()
 
@@ -146,14 +147,15 @@ func TestIngesterStreaming(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
-	for _, enc := range encodings {
-		promChunk := util.GenerateChunk(t, time.Second, model.TimeFromUnix(now.Unix()), 10, enc)
-		clientChunks, err := chunkcompat.ToChunks([]chunk.Chunk{promChunk})
-		require.NoError(t, err)
 
-		d := &MockDistributor{}
-		d.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
-			&client.QueryStreamResponse{
+	for _, enc := range encodings {
+		for _, partialDataEnabled := range []bool{false, true} {
+			promChunk := util.GenerateChunk(t, time.Second, model.TimeFromUnix(now.Unix()), 10, enc)
+			clientChunks, err := chunkcompat.ToChunks([]chunk.Chunk{promChunk})
+			require.NoError(t, err)
+
+			d := &MockDistributor{}
+			queryResponse := &client.QueryStreamResponse{
 				Chunkseries: []client.TimeSeriesChunk{
 					{
 						Labels: []cortexpb.LabelAdapter{
@@ -168,31 +170,42 @@ func TestIngesterStreaming(t *testing.T) {
 						Chunks: clientChunks,
 					},
 				},
-			},
-			nil)
+			}
+			d.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(queryResponse, nil)
 
-		ctx := user.InjectOrgID(context.Background(), "0")
-		queryable := newDistributorQueryable(d, true, true, batch.NewChunkMergeIterator, 0)
-		querier, err := queryable.Querier(mint, maxt)
-		require.NoError(t, err)
+			ctx := user.InjectOrgID(context.Background(), "0")
+			partialDataFn := queryPartialDataDisabledFn
+			if partialDataEnabled {
+				partialDataFn = queryPartialDataEnabledFn
+				d = &MockDistributor{}
+				d.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(queryResponse, partialdata.Error{})
+			}
+			queryable := newDistributorQueryable(d, true, true, batch.NewChunkMergeIterator, 0, partialDataFn)
+			querier, err := queryable.Querier(mint, maxt)
+			require.NoError(t, err)
 
-		seriesSet := querier.Select(ctx, true, &storage.SelectHints{Start: mint, End: maxt})
-		require.NoError(t, seriesSet.Err())
+			seriesSet := querier.Select(ctx, true, &storage.SelectHints{Start: mint, End: maxt})
+			require.NoError(t, seriesSet.Err())
 
-		require.True(t, seriesSet.Next())
-		series := seriesSet.At()
-		require.Equal(t, labels.Labels{{Name: "bar", Value: "baz"}}, series.Labels())
-		chkIter := series.Iterator(nil)
-		require.Equal(t, enc.ChunkValueType(), chkIter.Next())
+			require.True(t, seriesSet.Next())
+			series := seriesSet.At()
+			require.Equal(t, labels.Labels{{Name: "bar", Value: "baz"}}, series.Labels())
+			chkIter := series.Iterator(nil)
+			require.Equal(t, enc.ChunkValueType(), chkIter.Next())
 
-		require.True(t, seriesSet.Next())
-		series = seriesSet.At()
-		require.Equal(t, labels.Labels{{Name: "foo", Value: "bar"}}, series.Labels())
-		chkIter = series.Iterator(chkIter)
-		require.Equal(t, enc.ChunkValueType(), chkIter.Next())
+			require.True(t, seriesSet.Next())
+			series = seriesSet.At()
+			require.Equal(t, labels.Labels{{Name: "foo", Value: "bar"}}, series.Labels())
+			chkIter = series.Iterator(chkIter)
+			require.Equal(t, enc.ChunkValueType(), chkIter.Next())
 
-		require.False(t, seriesSet.Next())
-		require.NoError(t, seriesSet.Err())
+			require.False(t, seriesSet.Next())
+			require.NoError(t, seriesSet.Err())
+
+			if partialDataEnabled {
+				require.NotEmpty(t, seriesSet.Warnings())
+			}
+		}
 	}
 }
 
@@ -228,7 +241,7 @@ func TestDistributorQuerier_LabelNames(t *testing.T) {
 						Return(metrics, nil)
 				}
 
-				queryable := newDistributorQueryable(d, streamingEnabled, labelNamesWithMatchers, nil, 0)
+				queryable := newDistributorQueryable(d, streamingEnabled, labelNamesWithMatchers, nil, 0, nil)
 				querier, err := queryable.Querier(mint, maxt)
 				require.NoError(t, err)
 
@@ -240,4 +253,12 @@ func TestDistributorQuerier_LabelNames(t *testing.T) {
 			})
 		}
 	}
+}
+
+func queryPartialDataEnabledFn(string) bool {
+	return true
+}
+
+func queryPartialDataDisabledFn(string) bool {
+	return false
 }

--- a/pkg/querier/lazyquery/lazyquery.go
+++ b/pkg/querier/lazyquery/lazyquery.go
@@ -79,5 +79,8 @@ func (s *lazySeriesSet) Err() error {
 
 // Warnings implements storage.SeriesSet.
 func (s *lazySeriesSet) Warnings() annotations.Annotations {
-	return nil
+	if s.next == nil {
+		s.next = <-s.future
+	}
+	return s.next.Warnings()
 }

--- a/pkg/querier/partialdata/partia_data.go
+++ b/pkg/querier/partialdata/partia_data.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 )
 
-const (
-	partialDataCtxKey   string = "partialDataCtxKey"
-	partialDataErrorMsg string = "Query result may contain partial data."
+type partialDataCtxKey struct{}
+
+var (
+	ctxKey              = &partialDataCtxKey{}
+	partialDataErrorMsg = "Query result may contain partial data."
 )
 
 type Error struct{}
@@ -18,13 +20,13 @@ func (e Error) Error() string {
 
 func ContextWithPartialData(ctx context.Context, isEnabled bool) context.Context {
 	if isEnabled {
-		return context.WithValue(ctx, partialDataCtxKey, isEnabled)
+		return context.WithValue(ctx, ctxKey, isEnabled)
 	}
 	return ctx
 }
 
 func FromContext(ctx context.Context) bool {
-	o := ctx.Value(partialDataCtxKey)
+	o := ctx.Value(ctxKey)
 	if o == nil {
 		return false
 	}

--- a/pkg/querier/partialdata/partia_data.go
+++ b/pkg/querier/partialdata/partia_data.go
@@ -6,14 +6,8 @@ import (
 
 type IsCfgEnabledFunc func(userID string) bool
 
-const ErrorMsg string = "Query result may contain partial data."
-
-type Error struct{}
-
-func (e Error) Error() string {
-	return ErrorMsg
-}
+var ErrPartialData = errors.New("query result may contain partial data")
 
 func IsPartialDataError(err error) bool {
-	return errors.As(err, &Error{})
+	return errors.Is(err, ErrPartialData)
 }

--- a/pkg/querier/partialdata/partia_data.go
+++ b/pkg/querier/partialdata/partia_data.go
@@ -1,0 +1,36 @@
+package partialdata
+
+import (
+	"context"
+	"errors"
+)
+
+const (
+	ctxKey              string = "partialDataCtxKey"
+	partialDataErrorMsg string = "This query result may contain partial data."
+)
+
+type Error struct{}
+
+func (e Error) Error() string {
+	return partialDataErrorMsg
+}
+
+func ContextWithPartialData(ctx context.Context, isEnabled bool) context.Context {
+	if isEnabled {
+		return context.WithValue(ctx, ctxKey, isEnabled)
+	}
+	return ctx
+}
+
+func FromContext(ctx context.Context) bool {
+	o := ctx.Value(ctxKey)
+	if o == nil {
+		return false
+	}
+	return o.(bool)
+}
+
+func ReturnPartialData(err error, isEnabled bool) bool {
+	return isEnabled && errors.As(err, &Error{})
+}

--- a/pkg/querier/partialdata/partia_data.go
+++ b/pkg/querier/partialdata/partia_data.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	ctxKey              string = "partialDataCtxKey"
-	partialDataErrorMsg string = "This query result may contain partial data."
+	partialDataErrorMsg string = "Query result may contain partial data."
 )
 
 type Error struct{}

--- a/pkg/querier/partialdata/partia_data.go
+++ b/pkg/querier/partialdata/partia_data.go
@@ -15,3 +15,7 @@ func (e Error) Error() string {
 func ReturnPartialData(err error, isEnabled bool) bool {
 	return isEnabled && errors.As(err, &Error{})
 }
+
+func IsPartialDataError(err error) bool {
+	return errors.As(err, &Error{})
+}

--- a/pkg/querier/partialdata/partia_data.go
+++ b/pkg/querier/partialdata/partia_data.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 )
 
+type IsCfgEnabledFunc func(userID string) bool
+
 const ErrorMsg string = "Query result may contain partial data."
 
 type Error struct{}

--- a/pkg/querier/partialdata/partia_data.go
+++ b/pkg/querier/partialdata/partia_data.go
@@ -8,14 +8,15 @@ import (
 type partialDataCtxKey struct{}
 
 var (
-	ctxKey              = &partialDataCtxKey{}
-	partialDataErrorMsg = "Query result may contain partial data."
+	ctxKey = &partialDataCtxKey{}
 )
+
+const ErrorMsg string = "Query result may contain partial data."
 
 type Error struct{}
 
 func (e Error) Error() string {
-	return partialDataErrorMsg
+	return ErrorMsg
 }
 
 func ContextWithPartialData(ctx context.Context, isEnabled bool) context.Context {

--- a/pkg/querier/partialdata/partia_data.go
+++ b/pkg/querier/partialdata/partia_data.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	ctxKey              string = "partialDataCtxKey"
+	partialDataCtxKey   string = "partialDataCtxKey"
 	partialDataErrorMsg string = "Query result may contain partial data."
 )
 
@@ -18,13 +18,13 @@ func (e Error) Error() string {
 
 func ContextWithPartialData(ctx context.Context, isEnabled bool) context.Context {
 	if isEnabled {
-		return context.WithValue(ctx, ctxKey, isEnabled)
+		return context.WithValue(ctx, partialDataCtxKey, isEnabled)
 	}
 	return ctx
 }
 
 func FromContext(ctx context.Context) bool {
-	o := ctx.Value(ctxKey)
+	o := ctx.Value(partialDataCtxKey)
 	if o == nil {
 		return false
 	}

--- a/pkg/querier/partialdata/partia_data.go
+++ b/pkg/querier/partialdata/partia_data.go
@@ -12,10 +12,6 @@ func (e Error) Error() string {
 	return ErrorMsg
 }
 
-func ReturnPartialData(err error, isEnabled bool) bool {
-	return isEnabled && errors.As(err, &Error{})
-}
-
 func IsPartialDataError(err error) bool {
 	return errors.As(err, &Error{})
 }

--- a/pkg/querier/partialdata/partia_data.go
+++ b/pkg/querier/partialdata/partia_data.go
@@ -1,14 +1,7 @@
 package partialdata
 
 import (
-	"context"
 	"errors"
-)
-
-type partialDataCtxKey struct{}
-
-var (
-	ctxKey = &partialDataCtxKey{}
 )
 
 const ErrorMsg string = "Query result may contain partial data."
@@ -17,21 +10,6 @@ type Error struct{}
 
 func (e Error) Error() string {
 	return ErrorMsg
-}
-
-func ContextWithPartialData(ctx context.Context, isEnabled bool) context.Context {
-	if isEnabled {
-		return context.WithValue(ctx, ctxKey, isEnabled)
-	}
-	return ctx
-}
-
-func FromContext(ctx context.Context) bool {
-	o := ctx.Value(ctxKey)
-	if o == nil {
-		return false
-	}
-	return o.(bool)
 }
 
 func ReturnPartialData(err error, isEnabled bool) bool {

--- a/pkg/querier/partialdata/partial_data_test.go
+++ b/pkg/querier/partialdata/partial_data_test.go
@@ -1,22 +1,11 @@
 package partialdata
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestPartialData_Context(t *testing.T) {
-	assert.False(t, FromContext(context.Background()))
-
-	ctx := ContextWithPartialData(context.Background(), false)
-	assert.False(t, FromContext(ctx))
-
-	ctx = ContextWithPartialData(context.Background(), true)
-	assert.True(t, FromContext(ctx))
-}
 
 func TestPartialData_ReturnPartialData(t *testing.T) {
 	assert.False(t, ReturnPartialData(fmt.Errorf(""), false))

--- a/pkg/querier/partialdata/partial_data_test.go
+++ b/pkg/querier/partialdata/partial_data_test.go
@@ -1,0 +1,26 @@
+package partialdata
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPartialData_Context(t *testing.T) {
+	assert.False(t, FromContext(context.Background()))
+
+	ctx := ContextWithPartialData(context.Background(), false)
+	assert.False(t, FromContext(ctx))
+
+	ctx = ContextWithPartialData(context.Background(), true)
+	assert.True(t, FromContext(ctx))
+}
+
+func TestPartialData_ReturnPartialData(t *testing.T) {
+	assert.False(t, ReturnPartialData(fmt.Errorf(""), false))
+	assert.False(t, ReturnPartialData(fmt.Errorf(""), true))
+	assert.False(t, ReturnPartialData(Error{}, false))
+	assert.True(t, ReturnPartialData(Error{}, true))
+}

--- a/pkg/querier/partialdata/partial_data_test.go
+++ b/pkg/querier/partialdata/partial_data_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 func TestPartialData_ReturnPartialData(t *testing.T) {
-	assert.False(t, ReturnPartialData(fmt.Errorf(""), false))
-	assert.False(t, ReturnPartialData(fmt.Errorf(""), true))
-	assert.False(t, ReturnPartialData(Error{}, false))
-	assert.True(t, ReturnPartialData(Error{}, true))
+	assert.False(t, IsPartialDataError(fmt.Errorf("")))
+	assert.True(t, IsPartialDataError(Error{}))
 }

--- a/pkg/querier/partialdata/partial_data_test.go
+++ b/pkg/querier/partialdata/partial_data_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestPartialData_ReturnPartialData(t *testing.T) {
 	assert.False(t, IsPartialDataError(fmt.Errorf("")))
-	assert.True(t, IsPartialDataError(Error{}))
+	assert.True(t, IsPartialDataError(ErrPartialData))
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/querier/batch"
 	"github.com/cortexproject/cortex/pkg/querier/lazyquery"
+	"github.com/cortexproject/cortex/pkg/querier/partialdata"
 	querier_stats "github.com/cortexproject/cortex/pkg/querier/stats"
 	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
@@ -172,10 +173,10 @@ func getChunksIteratorFunction(_ Config) chunkIteratorFunc {
 }
 
 // New builds a queryable and promql engine.
-func New(cfg Config, limits *validation.Overrides, distributor Distributor, stores []QueryableWithFilter, reg prometheus.Registerer, logger log.Logger) (storage.SampleAndChunkQueryable, storage.ExemplarQueryable, promql.QueryEngine) {
+func New(cfg Config, limits *validation.Overrides, distributor Distributor, stores []QueryableWithFilter, reg prometheus.Registerer, logger log.Logger, isPartialDataEnabled partialdata.IsCfgEnabledFunc) (storage.SampleAndChunkQueryable, storage.ExemplarQueryable, promql.QueryEngine) {
 	iteratorFunc := getChunksIteratorFunction(cfg)
 
-	distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, iteratorFunc, cfg.QueryIngestersWithin, limits)
+	distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, iteratorFunc, cfg.QueryIngestersWithin, isPartialDataEnabled)
 
 	ns := make([]QueryableWithFilter, len(stores))
 	for ix, s := range stores {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -175,7 +175,7 @@ func getChunksIteratorFunction(_ Config) chunkIteratorFunc {
 func New(cfg Config, limits *validation.Overrides, distributor Distributor, stores []QueryableWithFilter, reg prometheus.Registerer, logger log.Logger) (storage.SampleAndChunkQueryable, storage.ExemplarQueryable, promql.QueryEngine) {
 	iteratorFunc := getChunksIteratorFunction(cfg)
 
-	distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, iteratorFunc, cfg.QueryIngestersWithin, limits.QueryPartialData)
+	distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, iteratorFunc, cfg.QueryIngestersWithin, limits)
 
 	ns := make([]QueryableWithFilter, len(stores))
 	for ix, s := range stores {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -175,7 +175,7 @@ func getChunksIteratorFunction(_ Config) chunkIteratorFunc {
 func New(cfg Config, limits *validation.Overrides, distributor Distributor, stores []QueryableWithFilter, reg prometheus.Registerer, logger log.Logger) (storage.SampleAndChunkQueryable, storage.ExemplarQueryable, promql.QueryEngine) {
 	iteratorFunc := getChunksIteratorFunction(cfg)
 
-	distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, iteratorFunc, cfg.QueryIngestersWithin)
+	distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, iteratorFunc, cfg.QueryIngestersWithin, limits.QueryPartialData)
 
 	ns := make([]QueryableWithFilter, len(stores))
 	for ix, s := range stores {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -444,7 +444,7 @@ func TestLimits(t *testing.T) {
 			response: &streamResponse,
 		}
 
-		distributorQueryableStreaming := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, batch.NewChunkMergeIterator, cfg.QueryIngestersWithin, queryPartialDataDisabledFn)
+		distributorQueryableStreaming := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, batch.NewChunkMergeIterator, cfg.QueryIngestersWithin, nil)
 
 		tCases := []struct {
 			name                 string
@@ -1701,29 +1701,4 @@ func (m *mockQueryableWithFilter) Querier(_, _ int64) (storage.Querier, error) {
 func (m *mockQueryableWithFilter) UseQueryable(_ time.Time, _, _ int64) bool {
 	m.useQueryableCalled = true
 	return true
-}
-
-type mockChunkStore struct {
-	chunks []chunk.Chunk
-}
-
-func (m mockChunkStore) Get() ([]chunk.Chunk, error) {
-	return m.chunks, nil
-}
-
-func makeMockChunkStore(t require.TestingT, numChunks int, enc promchunk.Encoding) (mockChunkStore, model.Time) {
-	chks, from := makeMockChunks(t, numChunks, enc, 0)
-	return mockChunkStore{chks}, from
-}
-
-func makeMockChunks(t require.TestingT, numChunks int, enc promchunk.Encoding, from model.Time, additionalLabels ...labels.Label) ([]chunk.Chunk, model.Time) {
-	var (
-		chunks = make([]chunk.Chunk, 0, numChunks)
-	)
-	for i := 0; i < numChunks; i++ {
-		c := util.GenerateChunk(t, sampleRate, from, int(samplesPerChunk), enc, additionalLabels...)
-		chunks = append(chunks, c)
-		from = from.Add(chunkOffset)
-	}
-	return chunks, from
 }

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -298,7 +298,7 @@ func TestShouldSortSeriesIfQueryingMultipleQueryables(t *testing.T) {
 		}
 
 		distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&unorderedResponse, nil)
-		distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, batch.NewChunkMergeIterator, cfg.QueryIngestersWithin)
+		distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, batch.NewChunkMergeIterator, cfg.QueryIngestersWithin, queryPartialDataDisabledFn)
 
 		tCases := []struct {
 			name                 string
@@ -444,7 +444,7 @@ func TestLimits(t *testing.T) {
 			response: &streamResponse,
 		}
 
-		distributorQueryableStreaming := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, batch.NewChunkMergeIterator, cfg.QueryIngestersWithin)
+		distributorQueryableStreaming := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, batch.NewChunkMergeIterator, cfg.QueryIngestersWithin, queryPartialDataDisabledFn)
 
 		tCases := []struct {
 			name                 string

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -580,7 +580,7 @@ func TestQuerier(t *testing.T) {
 					require.NoError(t, err)
 
 					queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}
-					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger())
+					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger(), nil)
 					testRangeQuery(t, queryable, queryEngine, through, query, enc)
 				})
 			}
@@ -602,7 +602,7 @@ func TestQuerierMetric(t *testing.T) {
 	queryables := []QueryableWithFilter{}
 	r := prometheus.NewRegistry()
 	reg := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "querier"}, r)
-	New(cfg, overrides, distributor, queryables, reg, log.NewNopLogger())
+	New(cfg, overrides, distributor, queryables, reg, log.NewNopLogger(), nil)
 	assert.NoError(t, promutil.GatherAndCompare(r, strings.NewReader(`
 		# HELP cortex_max_concurrent_queries The maximum number of concurrent queries.
 		# TYPE cortex_max_concurrent_queries gauge
@@ -684,7 +684,7 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 					require.NoError(t, err)
 
 					ctx := user.InjectOrgID(context.Background(), "0")
-					queryable, _, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}, nil, log.NewNopLogger())
+					queryable, _, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}, nil, log.NewNopLogger(), nil)
 					query, err := queryEngine.NewRangeQuery(ctx, queryable, nil, "dummy", c.mint, c.maxt, 1*time.Minute)
 					require.NoError(t, err)
 
@@ -778,7 +778,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryIntoFuture(t *testing.T) {
 
 			ctx := user.InjectOrgID(context.Background(), "0")
 			queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}
-			queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger())
+			queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger(), nil)
 			query, err := queryEngine.NewRangeQuery(ctx, queryable, nil, "dummy", c.queryStartTime, c.queryEndTime, time.Minute)
 			require.NoError(t, err)
 
@@ -871,7 +871,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 			distributor := &emptyDistributor{}
 
 			queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}
-			queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger())
+			queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger(), nil)
 
 			queryEngine := promql.NewEngine(opts)
 			ctx := user.InjectOrgID(context.Background(), "test")
@@ -910,7 +910,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength_Series(t *testing.T) {
 	distributor := &emptyDistributor{}
 
 	queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}
-	queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger())
+	queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger(), nil)
 
 	ctx := user.InjectOrgID(context.Background(), "test")
 	now := time.Now()
@@ -969,7 +969,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength_Labels(t *testing.T) {
 			distributor := &emptyDistributor{}
 
 			queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}
-			queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger())
+			queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger(), nil)
 
 			ctx := user.InjectOrgID(context.Background(), "test")
 
@@ -1120,7 +1120,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 					distributor := &MockDistributor{}
 					distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&client.QueryStreamResponse{}, nil)
 
-					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger())
+					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger(), nil)
 					require.NoError(t, err)
 
 					query, err := queryEngine.NewRangeQuery(ctx, queryable, nil, testData.query, testData.queryStartTime, testData.queryEndTime, time.Minute)
@@ -1149,7 +1149,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 					distributor.On("MetricsForLabelMatchers", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]model.Metric{}, nil)
 					distributor.On("MetricsForLabelMatchersStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]model.Metric{}, nil)
 
-					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger())
+					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger(), nil)
 					q, err := queryable.Querier(util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
 					require.NoError(t, err)
 
@@ -1190,7 +1190,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 					distributor.On("LabelNames", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
 					distributor.On("LabelNamesStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
 
-					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger())
+					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger(), nil)
 					q, err := queryable.Querier(util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
 					require.NoError(t, err)
 
@@ -1218,7 +1218,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 					distributor.On("MetricsForLabelMatchers", mock.Anything, mock.Anything, mock.Anything, mock.Anything, matchers).Return([]model.Metric{}, nil)
 					distributor.On("MetricsForLabelMatchersStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything, matchers).Return([]model.Metric{}, nil)
 
-					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger())
+					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger(), nil)
 					q, err := queryable.Querier(util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
 					require.NoError(t, err)
 
@@ -1245,7 +1245,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 					distributor.On("LabelValuesForLabelName", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
 					distributor.On("LabelValuesForLabelNameStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]string{}, nil)
 
-					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger())
+					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger(), nil)
 					q, err := queryable.Querier(util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
 					require.NoError(t, err)
 
@@ -1582,7 +1582,7 @@ func TestShortTermQueryToLTS(t *testing.T) {
 			overrides, err := validation.NewOverrides(DefaultLimitsConfig(), nil)
 			require.NoError(t, err)
 
-			queryable, _, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}, nil, log.NewNopLogger())
+			queryable, _, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}, nil, log.NewNopLogger(), nil)
 			ctx := user.InjectOrgID(context.Background(), "0")
 			query, err := engine.NewRangeQuery(ctx, queryable, nil, "dummy", c.mint, c.maxt, 1*time.Minute)
 			require.NoError(t, err)

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -298,7 +298,7 @@ func TestShouldSortSeriesIfQueryingMultipleQueryables(t *testing.T) {
 		}
 
 		distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&unorderedResponse, nil)
-		distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, batch.NewChunkMergeIterator, cfg.QueryIngestersWithin, queryPartialDataDisabledFn)
+		distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, batch.NewChunkMergeIterator, cfg.QueryIngestersWithin, nil)
 
 		tCases := []struct {
 			name                 string
@@ -1365,28 +1365,28 @@ type errDistributor struct{}
 
 var errDistributorError = fmt.Errorf("errDistributorError")
 
-func (m *errDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
+func (m *errDistributor) QueryStream(ctx context.Context, from, to model.Time, partialDataEnabled bool, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
 	return nil, errDistributorError
 }
 func (m *errDistributor) QueryExemplars(ctx context.Context, from, to model.Time, matchers ...[]*labels.Matcher) (*client.ExemplarQueryResponse, error) {
 	return nil, errDistributorError
 }
-func (m *errDistributor) LabelValuesForLabelName(context.Context, model.Time, model.Time, model.LabelName, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+func (m *errDistributor) LabelValuesForLabelName(context.Context, model.Time, model.Time, model.LabelName, *storage.LabelHints, bool, ...*labels.Matcher) ([]string, error) {
 	return nil, errDistributorError
 }
-func (m *errDistributor) LabelValuesForLabelNameStream(context.Context, model.Time, model.Time, model.LabelName, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+func (m *errDistributor) LabelValuesForLabelNameStream(context.Context, model.Time, model.Time, model.LabelName, *storage.LabelHints, bool, ...*labels.Matcher) ([]string, error) {
 	return nil, errDistributorError
 }
-func (m *errDistributor) LabelNames(context.Context, model.Time, model.Time, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+func (m *errDistributor) LabelNames(context.Context, model.Time, model.Time, *storage.LabelHints, bool, ...*labels.Matcher) ([]string, error) {
 	return nil, errDistributorError
 }
-func (m *errDistributor) LabelNamesStream(context.Context, model.Time, model.Time, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+func (m *errDistributor) LabelNamesStream(context.Context, model.Time, model.Time, *storage.LabelHints, bool, ...*labels.Matcher) ([]string, error) {
 	return nil, errDistributorError
 }
-func (m *errDistributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, hints *storage.SelectHints, matchers ...*labels.Matcher) ([]model.Metric, error) {
+func (m *errDistributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, hint *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
 	return nil, errDistributorError
 }
-func (m *errDistributor) MetricsForLabelMatchersStream(ctx context.Context, from, through model.Time, hints *storage.SelectHints, matchers ...*labels.Matcher) ([]model.Metric, error) {
+func (m *errDistributor) MetricsForLabelMatchersStream(ctx context.Context, from, through model.Time, hint *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
 	return nil, errDistributorError
 }
 
@@ -1414,7 +1414,7 @@ func (c *emptyChunkStore) IsCalled() bool {
 
 type emptyDistributor struct{}
 
-func (d *emptyDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
+func (d *emptyDistributor) QueryStream(ctx context.Context, from, to model.Time, partialDataEnabled bool, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
 	return &client.QueryStreamResponse{}, nil
 }
 
@@ -1422,27 +1422,27 @@ func (d *emptyDistributor) QueryExemplars(ctx context.Context, from, to model.Ti
 	return nil, nil
 }
 
-func (d *emptyDistributor) LabelValuesForLabelName(context.Context, model.Time, model.Time, model.LabelName, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+func (d *emptyDistributor) LabelValuesForLabelName(context.Context, model.Time, model.Time, model.LabelName, *storage.LabelHints, bool, ...*labels.Matcher) ([]string, error) {
 	return nil, nil
 }
 
-func (d *emptyDistributor) LabelValuesForLabelNameStream(context.Context, model.Time, model.Time, model.LabelName, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+func (d *emptyDistributor) LabelValuesForLabelNameStream(context.Context, model.Time, model.Time, model.LabelName, *storage.LabelHints, bool, ...*labels.Matcher) ([]string, error) {
 	return nil, nil
 }
 
-func (d *emptyDistributor) LabelNames(context.Context, model.Time, model.Time, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+func (d *emptyDistributor) LabelNames(context.Context, model.Time, model.Time, *storage.LabelHints, bool, ...*labels.Matcher) ([]string, error) {
 	return nil, nil
 }
 
-func (d *emptyDistributor) LabelNamesStream(context.Context, model.Time, model.Time, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+func (d *emptyDistributor) LabelNamesStream(context.Context, model.Time, model.Time, *storage.LabelHints, bool, ...*labels.Matcher) ([]string, error) {
 	return nil, nil
 }
 
-func (d *emptyDistributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, hints *storage.SelectHints, matchers ...*labels.Matcher) ([]model.Metric, error) {
+func (d *emptyDistributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, hint *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
 	return nil, nil
 }
 
-func (d *emptyDistributor) MetricsForLabelMatchersStream(ctx context.Context, from, through model.Time, hints *storage.SelectHints, matchers ...*labels.Matcher) ([]model.Metric, error) {
+func (d *emptyDistributor) MetricsForLabelMatchersStream(ctx context.Context, from, through model.Time, hint *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
 	return nil, nil
 }
 
@@ -1701,4 +1701,29 @@ func (m *mockQueryableWithFilter) Querier(_, _ int64) (storage.Querier, error) {
 func (m *mockQueryableWithFilter) UseQueryable(_ time.Time, _, _ int64) bool {
 	m.useQueryableCalled = true
 	return true
+}
+
+type mockChunkStore struct {
+	chunks []chunk.Chunk
+}
+
+func (m mockChunkStore) Get() ([]chunk.Chunk, error) {
+	return m.chunks, nil
+}
+
+func makeMockChunkStore(t require.TestingT, numChunks int, enc promchunk.Encoding) (mockChunkStore, model.Time) {
+	chks, from := makeMockChunks(t, numChunks, enc, 0)
+	return mockChunkStore{chks}, from
+}
+
+func makeMockChunks(t require.TestingT, numChunks int, enc promchunk.Encoding, from model.Time, additionalLabels ...labels.Label) ([]chunk.Chunk, model.Time) {
+	var (
+		chunks = make([]chunk.Chunk, 0, numChunks)
+	)
+	for i := 0; i < numChunks; i++ {
+		c := util.GenerateChunk(t, sampleRate, from, int(samplesPerChunk), enc, additionalLabels...)
+		chunks = append(chunks, c)
+		from = from.Add(chunkOffset)
+	}
+	return chunks, from
 }

--- a/pkg/querier/testutils.go
+++ b/pkg/querier/testutils.go
@@ -33,11 +33,11 @@ func (m *MockDistributor) QueryStream(ctx context.Context, from, to model.Time, 
 	args := m.Called(ctx, from, to, matchers)
 	return args.Get(0).(*client.QueryStreamResponse), args.Error(1)
 }
-func (m *MockDistributor) LabelValuesForLabelName(ctx context.Context, from, to model.Time, label model.LabelName, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
+func (m *MockDistributor) LabelValuesForLabelName(ctx context.Context, from, to model.Time, lbl model.LabelName, hints *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
 	args := m.Called(ctx, from, to, lbl, hints, matchers)
 	return args.Get(0).([]string), args.Error(1)
 }
-func (m *MockDistributor) LabelValuesForLabelNameStream(ctx context.Context, from, to model.Time, label model.LabelName, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
+func (m *MockDistributor) LabelValuesForLabelNameStream(ctx context.Context, from, to model.Time, lbl model.LabelName, hints *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
 	args := m.Called(ctx, from, to, lbl, hints, matchers)
 	return args.Get(0).([]string), args.Error(1)
 }
@@ -49,11 +49,11 @@ func (m *MockDistributor) LabelNamesStream(ctx context.Context, from model.Time,
 	args := m.Called(ctx, from, to, hints, matchers)
 	return args.Get(0).([]string), args.Error(1)
 }
-func (m *MockDistributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, hint *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
+func (m *MockDistributor) MetricsForLabelMatchers(ctx context.Context, from, to model.Time, hints *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
 	args := m.Called(ctx, from, to, hints, matchers)
 	return args.Get(0).([]model.Metric), args.Error(1)
 }
-func (m *MockDistributor) MetricsForLabelMatchersStream(ctx context.Context, from, through model.Time, hint *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
+func (m *MockDistributor) MetricsForLabelMatchersStream(ctx context.Context, from, to model.Time, hints *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
 	args := m.Called(ctx, from, to, hints, matchers)
 	return args.Get(0).([]model.Metric), args.Error(1)
 }

--- a/pkg/querier/testutils.go
+++ b/pkg/querier/testutils.go
@@ -29,31 +29,31 @@ func (m *MockDistributor) QueryExemplars(ctx context.Context, from, to model.Tim
 	args := m.Called(ctx, from, to, matchers)
 	return args.Get(0).(*client.ExemplarQueryResponse), args.Error(1)
 }
-func (m *MockDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
+func (m *MockDistributor) QueryStream(ctx context.Context, from, to model.Time, partialDataEnabled bool, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
 	args := m.Called(ctx, from, to, matchers)
 	return args.Get(0).(*client.QueryStreamResponse), args.Error(1)
 }
-func (m *MockDistributor) LabelValuesForLabelName(ctx context.Context, from, to model.Time, lbl model.LabelName, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
+func (m *MockDistributor) LabelValuesForLabelName(ctx context.Context, from, to model.Time, label model.LabelName, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
 	args := m.Called(ctx, from, to, lbl, hints, matchers)
 	return args.Get(0).([]string), args.Error(1)
 }
-func (m *MockDistributor) LabelValuesForLabelNameStream(ctx context.Context, from, to model.Time, lbl model.LabelName, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
+func (m *MockDistributor) LabelValuesForLabelNameStream(ctx context.Context, from, to model.Time, label model.LabelName, hint *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, error) {
 	args := m.Called(ctx, from, to, lbl, hints, matchers)
 	return args.Get(0).([]string), args.Error(1)
 }
-func (m *MockDistributor) LabelNames(ctx context.Context, from, to model.Time, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
+func (m *MockDistributor) LabelNames(ctx context.Context, from model.Time, to model.Time, hints *storage.LabelHints, b bool, matchers ...*labels.Matcher) ([]string, error) {
 	args := m.Called(ctx, from, to, hints, matchers)
 	return args.Get(0).([]string), args.Error(1)
 }
-func (m *MockDistributor) LabelNamesStream(ctx context.Context, from, to model.Time, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
+func (m *MockDistributor) LabelNamesStream(ctx context.Context, from model.Time, to model.Time, hints *storage.LabelHints, b bool, matchers ...*labels.Matcher) ([]string, error) {
 	args := m.Called(ctx, from, to, hints, matchers)
 	return args.Get(0).([]string), args.Error(1)
 }
-func (m *MockDistributor) MetricsForLabelMatchers(ctx context.Context, from, to model.Time, hints *storage.SelectHints, matchers ...*labels.Matcher) ([]model.Metric, error) {
+func (m *MockDistributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, hint *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
 	args := m.Called(ctx, from, to, hints, matchers)
 	return args.Get(0).([]model.Metric), args.Error(1)
 }
-func (m *MockDistributor) MetricsForLabelMatchersStream(ctx context.Context, from, to model.Time, hints *storage.SelectHints, matchers ...*labels.Matcher) ([]model.Metric, error) {
+func (m *MockDistributor) MetricsForLabelMatchersStream(ctx context.Context, from, through model.Time, hint *storage.SelectHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]model.Metric, error) {
 	args := m.Called(ctx, from, to, hints, matchers)
 	return args.Get(0).([]model.Metric), args.Error(1)
 }
@@ -68,7 +68,7 @@ type MockLimitingDistributor struct {
 	response *client.QueryStreamResponse
 }
 
-func (m *MockLimitingDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
+func (m *MockLimitingDistributor) QueryStream(ctx context.Context, from, to model.Time, partialDataEnabled bool, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
 	var (
 		queryLimiter = limiter.QueryLimiterFromContextWithFallback(ctx)
 	)

--- a/pkg/querier/tripperware/limits.go
+++ b/pkg/querier/tripperware/limits.go
@@ -30,4 +30,7 @@ type Limits interface {
 	QueryPriority(userID string) validation.QueryPriority
 
 	QueryRejection(userID string) validation.QueryRejection
+
+	// QueryPartialData returns whether query result from a single zone is returned as a possible partial result.
+	QueryPartialData(userID string) bool
 }

--- a/pkg/querier/tripperware/limits.go
+++ b/pkg/querier/tripperware/limits.go
@@ -30,7 +30,4 @@ type Limits interface {
 	QueryPriority(userID string) validation.QueryPriority
 
 	QueryRejection(userID string) validation.QueryRejection
-
-	// QueryPartialData returns whether query result from a single zone is returned as a possible partial result.
-	QueryPartialData(userID string) bool
 }

--- a/pkg/querier/tripperware/queryrange/results_cache.go
+++ b/pkg/querier/tripperware/queryrange/results_cache.go
@@ -297,7 +297,7 @@ func (s resultsCache) shouldCacheResponse(ctx context.Context, req tripperware.R
 		return false
 	}
 	if res, ok := r.(*tripperware.PrometheusResponse); ok {
-		partialDataErr := partialdata.Error{}
+		partialDataErr := partialdata.ErrPartialData
 		for _, warning := range res.Warnings {
 			if warning == partialDataErr.Error() {
 				return false

--- a/pkg/querier/tripperware/queryrange/results_cache.go
+++ b/pkg/querier/tripperware/queryrange/results_cache.go
@@ -295,6 +295,11 @@ func (s resultsCache) shouldCacheResponse(ctx context.Context, req tripperware.R
 	if !s.isOffsetCachable(ctx, req) {
 		return false
 	}
+	if res, ok := r.(*tripperware.PrometheusResponse); ok {
+		if len(res.Warnings) > 0 {
+			return false
+		}
+	}
 
 	return true
 }

--- a/pkg/querier/tripperware/queryrange/results_cache.go
+++ b/pkg/querier/tripperware/queryrange/results_cache.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/cortexproject/cortex/pkg/querier"
+	"github.com/cortexproject/cortex/pkg/querier/partialdata"
 	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
@@ -296,8 +297,11 @@ func (s resultsCache) shouldCacheResponse(ctx context.Context, req tripperware.R
 		return false
 	}
 	if res, ok := r.(*tripperware.PrometheusResponse); ok {
-		if len(res.Warnings) > 0 {
-			return false
+		partialDataErr := partialdata.Error{}
+		for _, warning := range res.Warnings {
+			if warning == partialDataErr.Error() {
+				return false
+			}
 		}
 	}
 

--- a/pkg/querier/tripperware/queryrange/results_cache.go
+++ b/pkg/querier/tripperware/queryrange/results_cache.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -297,12 +298,7 @@ func (s resultsCache) shouldCacheResponse(ctx context.Context, req tripperware.R
 		return false
 	}
 	if res, ok := r.(*tripperware.PrometheusResponse); ok {
-		partialDataErr := partialdata.ErrPartialData
-		for _, warning := range res.Warnings {
-			if warning == partialDataErr.Error() {
-				return false
-			}
-		}
+		return !slices.Contains(res.Warnings, partialdata.ErrPartialData.Error())
 	}
 
 	return true

--- a/pkg/querier/tripperware/queryrange/results_cache_test.go
+++ b/pkg/querier/tripperware/queryrange/results_cache_test.go
@@ -554,6 +554,20 @@ func TestShouldCache(t *testing.T) {
 			input:    tripperware.Response(&tripperware.PrometheusResponse{}),
 			expected: false,
 		},
+		{
+			name:    "contains warning",
+			request: &tripperware.PrometheusRequest{Query: "metric"},
+			input: tripperware.Response(&tripperware.PrometheusResponse{
+				Headers: []*tripperware.PrometheusResponseHeader{
+					{
+						Name:   "meaninglessheader",
+						Values: []string{},
+					},
+				},
+				Warnings: []string{"some warning"},
+			}),
+			expected: false,
+		},
 	} {
 		{
 			t.Run(tc.name, func(t *testing.T) {

--- a/pkg/querier/tripperware/queryrange/results_cache_test.go
+++ b/pkg/querier/tripperware/queryrange/results_cache_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/cortexpb"
+	"github.com/cortexproject/cortex/pkg/querier/partialdata"
 	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
@@ -555,7 +556,7 @@ func TestShouldCache(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:    "contains warning",
+			name:    "contains partial data warning",
 			request: &tripperware.PrometheusRequest{Query: "metric"},
 			input: tripperware.Response(&tripperware.PrometheusResponse{
 				Headers: []*tripperware.PrometheusResponseHeader{
@@ -564,9 +565,23 @@ func TestShouldCache(t *testing.T) {
 						Values: []string{},
 					},
 				},
-				Warnings: []string{"some warning"},
+				Warnings: []string{partialdata.ErrorMsg},
 			}),
 			expected: false,
+		},
+		{
+			name:    "contains other warning",
+			request: &tripperware.PrometheusRequest{Query: "metric"},
+			input: tripperware.Response(&tripperware.PrometheusResponse{
+				Headers: []*tripperware.PrometheusResponseHeader{
+					{
+						Name:   "meaninglessheader",
+						Values: []string{},
+					},
+				},
+				Warnings: []string{"other warning"},
+			}),
+			expected: true,
 		},
 	} {
 		{

--- a/pkg/querier/tripperware/queryrange/results_cache_test.go
+++ b/pkg/querier/tripperware/queryrange/results_cache_test.go
@@ -565,7 +565,7 @@ func TestShouldCache(t *testing.T) {
 						Values: []string{},
 					},
 				},
-				Warnings: []string{partialdata.ErrorMsg},
+				Warnings: []string{partialdata.ErrPartialData.Error()},
 			}),
 			expected: false,
 		},

--- a/pkg/querier/tripperware/test_shard_by_query_utils.go
+++ b/pkg/querier/tripperware/test_shard_by_query_utils.go
@@ -509,6 +509,8 @@ func (m mockLimits) QueryRejection(userID string) validation.QueryRejection {
 	return m.queryRejection
 }
 
+func (m mockLimits) QueryPartialData(string) bool { return false }
+
 type singleHostRoundTripper struct {
 	host string
 	next http.RoundTripper

--- a/pkg/querier/tripperware/test_shard_by_query_utils.go
+++ b/pkg/querier/tripperware/test_shard_by_query_utils.go
@@ -509,8 +509,6 @@ func (m mockLimits) QueryRejection(userID string) validation.QueryRejection {
 	return m.queryRejection
 }
 
-func (m mockLimits) QueryPartialData(string) bool { return false }
-
 type singleHostRoundTripper struct {
 	host string
 	next http.RoundTripper

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -102,7 +102,7 @@ track:
 	}
 
 	if partialDataEnabled && trackerFailed {
-		return tracker.getResults(), partialdata.Error{}
+		return tracker.getResults(), partialdata.ErrPartialData
 	}
 
 	return tracker.getResults(), nil

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -41,12 +41,13 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, zoneResults
 	}
 
 	var (
-		ch                 = make(chan instanceResult, len(r.Instances))
-		forceStart         = make(chan struct{}, r.MaxErrors)
-		partialDataEnabled = partialdata.FromContext(ctx)
+		ch         = make(chan instanceResult, len(r.Instances))
+		forceStart = make(chan struct{}, r.MaxErrors)
 	)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	partialDataEnabled := false // TODO: jungjust
 
 	// Spawn a goroutine for each instance.
 	for i := range r.Instances {

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -25,7 +25,7 @@ type ReplicationSet struct {
 // Do function f in parallel for all replicas in the set, erroring is we exceed
 // MaxErrors and returning early otherwise. zoneResultsQuorum allows only include
 // results from zones that already reach quorum to improve performance.
-func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, zoneResultsQuorum bool, f func(context.Context, *InstanceDesc) (interface{}, error)) ([]interface{}, error) {
+func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, zoneResultsQuorum bool, partialDataEnabled bool, f func(context.Context, *InstanceDesc) (interface{}, error)) ([]interface{}, error) {
 	type instanceResult struct {
 		res      interface{}
 		err      error
@@ -46,8 +46,6 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, zoneResults
 	)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-
-	partialDataEnabled := false // TODO: jungjust
 
 	// Spawn a goroutine for each instance.
 	for i := range r.Instances {

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -86,7 +86,6 @@ func TestReplicationSet_GetAddressesWithout(t *testing.T) {
 var (
 	errFailure     = errors.New("failed")
 	errZoneFailure = errors.New("zone failed")
-	errPartialData = errors.New("query result may contain partial data")
 )
 
 // Return a function that fails starting from failAfter times

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -262,7 +262,7 @@ func TestReplicationSet_Do(t *testing.T) {
 					cancel()
 				})
 			}
-			got, err := r.Do(ctx, tt.delay, tt.zoneResultsQuorum, tt.f)
+			got, err := r.Do(ctx, tt.delay, tt.zoneResultsQuorum, tt.queryPartialData, tt.f)
 			if tt.expectedError != nil {
 				assert.Equal(t, tt.expectedError, err)
 			} else {

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -201,7 +201,7 @@ func TestReplicationSet_Do(t *testing.T) {
 			maxUnavailableZones: 1,
 			queryPartialData:    true,
 			want:                []interface{}{1},
-			expectedError:       partialdata.Error{},
+			expectedError:       partialdata.ErrPartialData,
 		},
 		{
 			name:                "with partial data enabled, should fail on instances failing in all zones",

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -254,7 +254,7 @@ func TestReplicationSet_Do(t *testing.T) {
 				MaxErrors:           tt.maxErrors,
 				MaxUnavailableZones: tt.maxUnavailableZones,
 			}
-			ctx := partialdata.ContextWithPartialData(context.Background(), tt.queryPartialData)
+			ctx := context.Background()
 			if tt.cancelContextDelay > 0 {
 				var cancel context.CancelFunc
 				ctx, cancel = context.WithCancel(ctx)

--- a/pkg/ring/replication_set_tracker_test.go
+++ b/pkg/ring/replication_set_tracker_test.go
@@ -399,6 +399,29 @@ func TestZoneAwareResultTracker(t *testing.T) {
 				assert.False(t, tracker.failed())
 			},
 		},
+		"failInAllZones should return true only if all zones have failed, regardless of max unavailable zones": {
+			instances:           []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6},
+			maxUnavailableZones: 1,
+			run: func(t *testing.T, tracker *zoneAwareResultTracker) {
+				// Zone-a
+				tracker.done(&instance1, nil, errors.New("test"))
+				assert.False(t, tracker.succeeded())
+				assert.False(t, tracker.failed())
+				assert.False(t, tracker.failedInAllZones())
+
+				// Zone-b
+				tracker.done(&instance3, nil, errors.New("test"))
+				assert.False(t, tracker.succeeded())
+				assert.True(t, tracker.failed())
+				assert.False(t, tracker.failedInAllZones())
+
+				// Zone-c
+				tracker.done(&instance5, nil, errors.New("test"))
+				assert.False(t, tracker.succeeded())
+				assert.True(t, tracker.failed())
+				assert.True(t, tracker.failedInAllZones())
+			},
+		},
 	}
 
 	for testName, testCase := range tests {

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -223,7 +223,7 @@ func testQueryableFunc(querierTestConfig *querier.TestConfig, reg prometheus.Reg
 		querierTestConfig.Cfg.ActiveQueryTrackerDir = ""
 
 		overrides, _ := validation.NewOverrides(querier.DefaultLimitsConfig(), nil)
-		q, _, _ := querier.New(querierTestConfig.Cfg, overrides, querierTestConfig.Distributor, querierTestConfig.Stores, reg, logger)
+		q, _, _ := querier.New(querierTestConfig.Cfg, overrides, querierTestConfig.Distributor, querierTestConfig.Stores, reg, logger, nil)
 		return func(mint, maxt int64) (storage.Querier, error) {
 			return q.Querier(mint, maxt)
 		}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -171,6 +171,7 @@ type Limits struct {
 	MaxCacheFreshness            model.Duration `yaml:"max_cache_freshness" json:"max_cache_freshness"`
 	MaxQueriersPerTenant         float64        `yaml:"max_queriers_per_tenant" json:"max_queriers_per_tenant"`
 	QueryVerticalShardSize       int            `yaml:"query_vertical_shard_size" json:"query_vertical_shard_size" doc:"hidden"`
+	QueryPartialData             bool           `yaml:"query_partial_data" json:"query_partial_data" doc:"nocli|description=Enable query to return partial data with warning message.|default=false"`
 
 	// Query Frontend / Scheduler enforced limits.
 	MaxOutstandingPerTenant     int           `yaml:"max_outstanding_requests_per_tenant" json:"max_outstanding_requests_per_tenant"`
@@ -724,6 +725,11 @@ func (o *Overrides) MaxQueriersPerUser(userID string) float64 {
 // QueryVerticalShardSize returns the number of shards to use when distributing shardable PromQL queries.
 func (o *Overrides) QueryVerticalShardSize(userID string) int {
 	return o.GetOverridesForUser(userID).QueryVerticalShardSize
+}
+
+// QueryPartialData returns whether query result from a single zone is returned as a possible partial result.
+func (o *Overrides) QueryPartialData(userID string) bool {
+	return o.GetOverridesForUser(userID).QueryPartialData
 }
 
 // MaxQueryParallelism returns the limit to the number of split queries the

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -171,7 +171,8 @@ type Limits struct {
 	MaxCacheFreshness            model.Duration `yaml:"max_cache_freshness" json:"max_cache_freshness"`
 	MaxQueriersPerTenant         float64        `yaml:"max_queriers_per_tenant" json:"max_queriers_per_tenant"`
 	QueryVerticalShardSize       int            `yaml:"query_vertical_shard_size" json:"query_vertical_shard_size" doc:"hidden"`
-	QueryPartialData             bool           `yaml:"query_partial_data" json:"query_partial_data" doc:"nocli|description=Enable to allow partial query data from 1 zone to be returned with a warning message.|default=false"`
+	QueryPartialData             bool           `yaml:"query_partial_data" json:"query_partial_data" doc:"nocli|description=Enable to allow queries to be evaluated with data from a single zone, if other zones are not available.|default=false"`
+	RulesPartialData             bool           `yaml:"rules_partial_data" json:"rules_partial_data" doc:"nocli|description=Enable to allow rules to be evaluated with data from a single zone, if other zones are not available.|default=false"`
 
 	// Query Frontend / Scheduler enforced limits.
 	MaxOutstandingPerTenant     int           `yaml:"max_outstanding_requests_per_tenant" json:"max_outstanding_requests_per_tenant"`
@@ -727,9 +728,14 @@ func (o *Overrides) QueryVerticalShardSize(userID string) int {
 	return o.GetOverridesForUser(userID).QueryVerticalShardSize
 }
 
-// QueryPartialData returns whether query result from a single zone is returned as a possible partial result.
+// QueryPartialData returns whether query may be evaluated with data from a single zone, if other zones are not available.
 func (o *Overrides) QueryPartialData(userID string) bool {
 	return o.GetOverridesForUser(userID).QueryPartialData
+}
+
+// RulesPartialData returns whether rule may be evaluated with data from a single zone, if other zones are not available.
+func (o *Overrides) RulesPartialData(userID string) bool {
+	return o.GetOverridesForUser(userID).RulesPartialData
 }
 
 // MaxQueryParallelism returns the limit to the number of split queries the

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -172,7 +172,6 @@ type Limits struct {
 	MaxQueriersPerTenant         float64        `yaml:"max_queriers_per_tenant" json:"max_queriers_per_tenant"`
 	QueryVerticalShardSize       int            `yaml:"query_vertical_shard_size" json:"query_vertical_shard_size" doc:"hidden"`
 	QueryPartialData             bool           `yaml:"query_partial_data" json:"query_partial_data" doc:"nocli|description=Enable to allow queries to be evaluated with data from a single zone, if other zones are not available.|default=false"`
-	RulesPartialData             bool           `yaml:"rules_partial_data" json:"rules_partial_data" doc:"nocli|description=Enable to allow rules to be evaluated with data from a single zone, if other zones are not available.|default=false"`
 
 	// Query Frontend / Scheduler enforced limits.
 	MaxOutstandingPerTenant     int           `yaml:"max_outstanding_requests_per_tenant" json:"max_outstanding_requests_per_tenant"`
@@ -188,6 +187,7 @@ type Limits struct {
 	RulerMaxRuleGroupsPerTenant int            `yaml:"ruler_max_rule_groups_per_tenant" json:"ruler_max_rule_groups_per_tenant"`
 	RulerQueryOffset            model.Duration `yaml:"ruler_query_offset" json:"ruler_query_offset"`
 	RulerExternalLabels         labels.Labels  `yaml:"ruler_external_labels" json:"ruler_external_labels" doc:"nocli|description=external labels for alerting rules"`
+	RulesPartialData            bool           `yaml:"rules_partial_data" json:"rules_partial_data" doc:"nocli|description=Enable to allow rules to be evaluated with data from a single zone, if other zones are not available.|default=false"`
 
 	// Store-gateway.
 	StoreGatewayTenantShardSize  float64 `yaml:"store_gateway_tenant_shard_size" json:"store_gateway_tenant_shard_size"`
@@ -733,11 +733,6 @@ func (o *Overrides) QueryPartialData(userID string) bool {
 	return o.GetOverridesForUser(userID).QueryPartialData
 }
 
-// RulesPartialData returns whether rule may be evaluated with data from a single zone, if other zones are not available.
-func (o *Overrides) RulesPartialData(userID string) bool {
-	return o.GetOverridesForUser(userID).RulesPartialData
-}
-
 // MaxQueryParallelism returns the limit to the number of split queries the
 // frontend will process in parallel.
 func (o *Overrides) MaxQueryParallelism(userID string) int {
@@ -855,6 +850,11 @@ func (o *Overrides) RulerQueryOffset(userID string) time.Duration {
 		return evaluationDelay
 	}
 	return ruleOffset
+}
+
+// RulesPartialData returns whether rule may be evaluated with data from a single zone, if other zones are not available.
+func (o *Overrides) RulesPartialData(userID string) bool {
+	return o.GetOverridesForUser(userID).RulesPartialData
 }
 
 // StoreGatewayTenantShardSize returns the store-gateway shard size for a given user.

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -171,7 +171,7 @@ type Limits struct {
 	MaxCacheFreshness            model.Duration `yaml:"max_cache_freshness" json:"max_cache_freshness"`
 	MaxQueriersPerTenant         float64        `yaml:"max_queriers_per_tenant" json:"max_queriers_per_tenant"`
 	QueryVerticalShardSize       int            `yaml:"query_vertical_shard_size" json:"query_vertical_shard_size" doc:"hidden"`
-	QueryPartialData             bool           `yaml:"query_partial_data" json:"query_partial_data" doc:"nocli|description=Enable query to return partial data with warning message.|default=false"`
+	QueryPartialData             bool           `yaml:"query_partial_data" json:"query_partial_data" doc:"nocli|description=Enable to allow partial query data from 1 zone to be returned with a warning message.|default=false"`
 
 	// Query Frontend / Scheduler enforced limits.
 	MaxOutstandingPerTenant     int           `yaml:"max_outstanding_requests_per_tenant" json:"max_outstanding_requests_per_tenant"`

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -638,6 +638,36 @@ tenant2:
 	require.Equal(t, 5, ov.MaxDownloadedBytesPerRequest("tenant3"))
 }
 
+func TestQueryPartialDataOverridesPerTenant(t *testing.T) {
+	SetDefaultLimitsForYAMLUnmarshalling(Limits{})
+
+	baseYAML := `
+query_partial_data: false`
+	overridesYAML := `
+tenant1:
+  query_partial_data: true
+tenant2:
+  query_partial_data: false
+`
+
+	l := Limits{}
+	err := yaml.UnmarshalStrict([]byte(baseYAML), &l)
+	require.NoError(t, err)
+
+	overrides := map[string]*Limits{}
+	err = yaml.Unmarshal([]byte(overridesYAML), &overrides)
+	require.NoError(t, err, "parsing overrides")
+
+	tl := newMockTenantLimits(overrides)
+
+	ov, err := NewOverrides(l, tl)
+	require.NoError(t, err)
+
+	require.True(t, ov.QueryPartialData("tenant1"))
+	require.False(t, ov.QueryPartialData("tenant2"))
+	require.False(t, ov.QueryPartialData("tenant3"))
+}
+
 func TestHasQueryAttributeRegexChanged(t *testing.T) {
 	l := Limits{
 		QueryPriority: QueryPriority{

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -638,17 +638,18 @@ tenant2:
 	require.Equal(t, 5, ov.MaxDownloadedBytesPerRequest("tenant3"))
 }
 
-func TestQueryPartialDataOverridesPerTenant(t *testing.T) {
+func TestPartialDataOverridesPerTenant(t *testing.T) {
 	SetDefaultLimitsForYAMLUnmarshalling(Limits{})
 
 	baseYAML := `
-query_partial_data: false`
+query_partial_data: false
+rules_partial_data: false`
 	overridesYAML := `
 tenant1:
   query_partial_data: true
 tenant2:
-  query_partial_data: false
-`
+  query_partial_data: true
+  rules_partial_data: true`
 
 	l := Limits{}
 	err := yaml.UnmarshalStrict([]byte(baseYAML), &l)
@@ -664,8 +665,11 @@ tenant2:
 	require.NoError(t, err)
 
 	require.True(t, ov.QueryPartialData("tenant1"))
-	require.False(t, ov.QueryPartialData("tenant2"))
+	require.False(t, ov.RulesPartialData("tenant1"))
+	require.True(t, ov.QueryPartialData("tenant2"))
+	require.True(t, ov.RulesPartialData("tenant2"))
 	require.False(t, ov.QueryPartialData("tenant3"))
+	require.False(t, ov.RulesPartialData("tenant3"))
 }
 
 func TestHasQueryAttributeRegexChanged(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR introduces new limits (tenant config) of `query_partial_data` and `rules_partial_data`, which allows tenants to receive 2xx with a warning message when querying ingesters fail in zones greater than max unavailable zones, but less than all available zones.

For example, in the following scenario,
- Total zone count: 3
- Max unavailable zone: 1
- Zones where ingesters are failing: 2

Current behavior always returns 5xx:

<img width="1710" alt="Screenshot 2024-12-04 at 3 04 36 PM" src="https://github.com/user-attachments/assets/966f8880-4e0b-4510-8191-68b4d99147d3" />

But with this feature enabled, customers will receive data with warning message "Query result may contain partial data".

<img width="1712" alt="Screenshot 2024-12-09 at 4 05 08 PM" src="https://github.com/user-attachments/assets/a84edfe9-31ba-4af7-b2ac-ffcb178adcf0" />

This is useful for cortex setup that replicates ingested data across different zones. In this case, even if ingesters from different zones go down, there is a high probability of full data available in ingesters from the remaining zone(s). In such case, tenants would rather want to receive 2xx than 5xx.

To summarize:
1. Ingesters failing across 0 to `MaxUnavailableZones` will return status code 200
1. Ingesters failing across `MaxUnavailableZones` to `TotalZones - 1` will return status code 200 with a warning message
1. Ingesters failing in all zones will return status code 500

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [X] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
