### PR TITLE
sort ingesters when generating token lookup table fix #6513

### DIFF
--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -479,7 +479,14 @@ func (d *Desc) Clone() interface{} {
 func (d *Desc) getTokensInfo() map[uint32]instanceInfo {
 	out := map[uint32]instanceInfo{}
 
-	for instanceID, instance := range d.Ingesters {
+	keys := []string{}
+	for key, _ := range d.Ingesters {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, instanceID := range keys {
+		instance := d.Ingesters[instanceID]
 		info := instanceInfo{
 			InstanceID: instanceID,
 			Zone:       instance.Zone,

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -479,13 +479,13 @@ func (d *Desc) Clone() interface{} {
 func (d *Desc) getTokensInfo() map[uint32]instanceInfo {
 	out := map[uint32]instanceInfo{}
 
-	keys := []string{}
-	for key, _ := range d.Ingesters {
-		keys = append(keys, key)
+	instanceIDs := []string{}
+	for key := range d.Ingesters {
+		instanceIDs = append(instanceIDs, key)
 	}
-	sort.Strings(keys)
+	sort.Strings(instanceIDs)
 
-	for _, instanceID := range keys {
+	for _, instanceID := range instanceIDs {
 		instance := d.Ingesters[instanceID]
 		info := instanceInfo{
 			InstanceID: instanceID,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Sort ingesters when generating token lookup table in ring to fix consistency issues.

Since map iteration order is undefined, successive calls to `getTokensInfo()` can return different results when tokens are owned by multiple instances in the ring. I don't know enough about the ring to say whether that is expected to occur, but in the tests it does and this fixes that test.

See the linked issue for more details and here for a reproducible test: https://github.com/dsabsay/cortex/tree/flaky-ring-consistency-test-repro

I validated the test locally by running my reproducer (linked above) twice (failed both times), applying this patch and running the same test (passed both times). I don't think it's worth merging the reproducer as it takes 5mins to run utilizing 16 cores fully.

**Which issue(s) this PR fixes**:
Fixes #6513 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
