### PR TITLE
Fix TestIngester_UpdateLabelSetMetrics test

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6376,6 +6376,8 @@ func TestIngester_UpdateLabelSetMetrics(t *testing.T) {
 	i, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, tenantLimits, blocksDir, reg, false)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
+
 	// Wait until it's ACTIVE
 	test.Poll(t, time.Second, ring.ACTIVE, func() interface{} {
 		return i.lifecycler.GetState()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Attempt to fix 
```
==================
WARNING: DATA RACE
Write at 0x0000048e5c08 by goroutine 51695:
  github.com/cortexproject/cortex/pkg/ingester.TestInstanceLimitsUnmarshal()
      /__w/cortex/cortex/pkg/ingester/instance_limits_test.go:11 +0xc8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1743 +0x44

Previous read at 0x0000048e5c08 by goroutine 51502:
  github.com/cortexproject/cortex/pkg/ingester.(*Ingester).getInstanceLimits()
      /__w/cortex/cortex/pkg/ingester/ingester.go:3171 +0xdc
  github.com/cortexproject/cortex/pkg/ingester.(*Ingester).updateLoop()
      /__w/cortex/cortex/pkg/ingester/ingester.go:927 +0x5a
  github.com/cortexproject/cortex/pkg/ingester.(*Ingester).updateLoop-fm()
      <autogenerated>:1 +0x47
  github.com/cortexproject/cortex/pkg/util/services.(*BasicService).main()
      /__w/cortex/cortex/pkg/util/services/basic_service.go:190 +0x3b7
  github.com/cortexproject/cortex/pkg/util/services.(*BasicService).StartAsync.func1.gowrap1()
      /__w/cortex/cortex/pkg/util/services/basic_service.go:119 +0x33

Goroutine 51695 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1743 +0x825
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2168 +0x85
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x226
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2166 +0x8be
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2034 +0xf17
  main.main()
      _testmain.go:221 +0x164

Goroutine 51502 (running) created at:
  github.com/cortexproject/cortex/pkg/util/services.(*BasicService).StartAsync.func1()
      /__w/cortex/cortex/pkg/util/services/basic_service.go:119 +0x1dc
  github.com/cortexproject/cortex/pkg/util/services.(*BasicService).switchState()
      /__w/cortex/cortex/pkg/util/services/basic_service.go:139 +0x115
  github.com/cortexproject/cortex/pkg/util/services.(*BasicService).StartAsync()
      /__w/cortex/cortex/pkg/util/services/basic_service.go:116 +0xb1
  github.com/cortexproject/cortex/pkg/ingester.(*Ingester).StartAsync()
      <autogenerated>:1 +0x5b
  github.com/cortexproject/cortex/pkg/util/services.StartAndAwaitRunning()
      /__w/cortex/cortex/pkg/util/services/services.go:104 +0x49
  github.com/cortexproject/cortex/pkg/ingester.TestIngester_UpdateLabelSetMetrics()
      /__w/cortex/cortex/pkg/ingester/ingester_test.go:[63](https://github.com/cortexproject/cortex/actions/runs/12918817189/job/36029740209?pr=6517#step:6:64)78 +0xa47
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1743 +0x44
==================
--- FAIL: TestInstanceLimitsUnmarshal (0.01s)
    testing.go:1399: race detected during execution of test
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
