### PR TITLE
Add rule information to query paramters sent to the QFE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [FEATURE] Update prometheus alertmanager version to v0.28.0 and add new integration msteamsv2, jira, and rocketchat. #6590
 * [FEATURE] Ingester: Add a `-ingester.enable-ooo-native-histograms` flag to enable out-of-order native histogram ingestion per tenant. It only takes effect when `-blocks-storage.tsdb.enable-native-histograms=true` and `-ingester.out-of-order-time-window` > 0. It is applied after the restart if it is changed at runtime through the runtime config. #6626
 * [ENHANCEMENT] Querier: limit label APIs to query only ingesters if `start` param is not been specified. #6618
+* [ENHANCEMENT] Ruler: Add rule information (group name, namespace, name, and kind) to query parameters sent to the Query Frontend to leave rule information logs on query stats. #6539
 * [ENHANCEMENT] Alertmanager: Add new limits `-alertmanager.max-silences-count` and `-alertmanager.max-silences-size-bytes` for limiting silences per tenant. #6605
 * [ENHANCEMENT] Update prometheus version to v3.1.0. #6583
 * [ENHANCEMENT] Add `compactor.auto-forget-delay` for compactor to auto forget compactors after X minutes without heartbeat. #6533

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4854,7 +4854,9 @@ ring:
 [disabled_tenants: <string> | default = ""]
 
 # Report query statistics for ruler queries to complete as a per user metric and
-# as an info level log message.
+# as an info level log message. It works only when the -ruler.frontend-address
+# is not configured. When -ruler.frontend-address enabled, the Query Frontend
+# tracks query statistics logs and metrics.
 # CLI flag: -ruler.query-stats-enabled
 [query_stats_enabled: <boolean> | default = false]
 

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -184,7 +184,20 @@ func EngineQueryFunc(engine promql.QueryEngine, frontendClient *frontendClient, 
 		}
 
 		if frontendClient != nil {
-			v, err := frontendClient.InstantQuery(ctx, qs, t)
+			// query parameters sent to the Query Frontend to leave rule information logs on query stats
+			queryParams := map[string]string{}
+
+			if origin := ctx.Value(promql.QueryOrigin{}); origin != nil {
+				queryLabels := origin.(map[string]interface{})
+				rgMap := queryLabels["ruleGroup"].(map[string]string)
+				queryParams["rule_group"] = rgMap["name"]
+				queryParams["rule_namespace"] = rgMap["file"]
+			}
+			ruleDetail := rules.FromOriginContext(ctx)
+			queryParams["rule"] = ruleDetail.Name
+			queryParams["rule_kind"] = ruleDetail.Kind
+
+			v, err := frontendClient.InstantQuery(ctx, qs, t, queryParams)
 			if err != nil {
 				return nil, err
 			}
@@ -333,7 +346,9 @@ func DefaultTenantManagerFactory(cfg Config, p Pusher, q storage.Queryable, engi
 		totalWrites := evalMetrics.TotalWritesVec.WithLabelValues(userID)
 		failedWrites := evalMetrics.FailedWritesVec.WithLabelValues(userID)
 
-		if cfg.FrontendAddress != "" {
+		shouldEvalFromQFE := cfg.FrontendAddress != ""
+		if shouldEvalFromQFE {
+			// evaluate rules via Query-Frontend
 			c, err := frontendPool.GetClientFor(cfg.FrontendAddress)
 			if err != nil {
 				return nil, err
@@ -343,7 +358,7 @@ func DefaultTenantManagerFactory(cfg Config, p Pusher, q storage.Queryable, engi
 		var queryFunc rules.QueryFunc
 		engineQueryFunc := EngineQueryFunc(engine, client, q, overrides, userID, cfg.LookbackDelta)
 		metricsQueryFunc := MetricsQueryFunc(engineQueryFunc, totalQueries, failedQueries)
-		if cfg.EnableQueryStats {
+		if cfg.EnableQueryStats && !shouldEvalFromQFE {
 			queryFunc = RecordAndReportRuleQueryMetrics(metricsQueryFunc, userID, evalMetrics, logger)
 		} else {
 			queryFunc = metricsQueryFunc

--- a/pkg/ruler/frontend_client_test.go
+++ b/pkg/ruler/frontend_client_test.go
@@ -32,7 +32,7 @@ func TestTimeout(t *testing.T) {
 	ctx := context.Background()
 	ctx = user.InjectOrgID(ctx, "userID")
 	frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus", "json")
-	_, err := frontendClient.InstantQuery(ctx, "query", time.Now())
+	_, err := frontendClient.InstantQuery(ctx, "query", time.Now(), nil)
 	require.Equal(t, context.DeadlineExceeded, err)
 }
 
@@ -41,7 +41,7 @@ func TestNoOrgId(t *testing.T) {
 		return nil, nil
 	}
 	frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus", "json")
-	_, err := frontendClient.InstantQuery(context.Background(), "query", time.Now())
+	_, err := frontendClient.InstantQuery(context.Background(), "query", time.Now(), nil)
 	require.Equal(t, user.ErrNoOrgID, err)
 }
 
@@ -152,7 +152,7 @@ func TestInstantQueryJsonCodec(t *testing.T) {
 			ctx := context.Background()
 			ctx = user.InjectOrgID(ctx, "userID")
 			frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus", "json")
-			vector, err := frontendClient.InstantQuery(ctx, "query", time.Now())
+			vector, err := frontendClient.InstantQuery(ctx, "query", time.Now(), nil)
 			require.Equal(t, test.expected, vector)
 			require.Equal(t, test.expectedErr, err)
 		})
@@ -301,7 +301,7 @@ func TestInstantQueryProtoCodec(t *testing.T) {
 			ctx := context.Background()
 			ctx = user.InjectOrgID(ctx, "userID")
 			frontendClient := NewFrontendClient(mockHTTPGRPCClient(mockClientFn), time.Second*5, "/prometheus", "protobuf")
-			vector, err := frontendClient.InstantQuery(ctx, "query", time.Now())
+			vector, err := frontendClient.InstantQuery(ctx, "query", time.Now(), nil)
 			require.Equal(t, test.expected, vector)
 			require.Equal(t, test.expectedErr, err)
 		})

--- a/pkg/ruler/manager_metrics.go
+++ b/pkg/ruler/manager_metrics.go
@@ -255,7 +255,7 @@ func NewRuleEvalMetrics(cfg Config, reg prometheus.Registerer) *RuleEvalMetrics 
 			Help: "Number of failed queries by ruler.",
 		}, []string{"user"}),
 	}
-	if cfg.EnableQueryStats {
+	if cfg.EnableQueryStats && cfg.FrontendAddress == "" {
 		m.RulerQuerySeconds = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_ruler_query_seconds_total",
 			Help: "Total amount of wall clock time spent processing queries by the ruler.",

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -249,7 +249,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.EnabledTenants, "ruler.enabled-tenants", "Comma separated list of tenants whose rules this ruler can evaluate. If specified, only these tenants will be handled by ruler, otherwise this ruler can process rules from all tenants. Subject to sharding.")
 	f.Var(&cfg.DisabledTenants, "ruler.disabled-tenants", "Comma separated list of tenants whose rules this ruler cannot evaluate. If specified, a ruler that would normally pick the specified tenant(s) for processing will ignore them instead. Subject to sharding.")
 
-	f.BoolVar(&cfg.EnableQueryStats, "ruler.query-stats-enabled", false, "Report query statistics for ruler queries to complete as a per user metric and as an info level log message.")
+	f.BoolVar(&cfg.EnableQueryStats, "ruler.query-stats-enabled", false, "Report query statistics for ruler queries to complete as a per user metric and as an info level log message. It works only when the -ruler.frontend-address is not configured. When -ruler.frontend-address enabled, the Query Frontend tracks query statistics logs and metrics.")
 	f.BoolVar(&cfg.DisableRuleGroupLabel, "ruler.disable-rule-group-label", false, "Disable the rule_group label on exported metrics")
 
 	f.BoolVar(&cfg.EnableHAEvaluation, "ruler.enable-ha-evaluation", false, "Enable high availability")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

When the `-ruler.frontend-address` is configured, the Ruler evaluates rules via QFE. But, all of the values of the query stats logs and metrics in the Ruler are `0` because the QFE doesn't send query stat.

In Ruler, for example:
the query stats logs are:
```
cortex_ruler_query_seconds_total=0.003627083 query_wall_time_seconds=0s query_storage_wall_time_seconds=0s fetched_series_count=0 fetched_chunks_count=0 fetched_samples_count=0 fetched_chunks_bytes=0 fetched_data_bytes=0
``` 
Also, the values of these metrics are all `0`
```
cortex_ruler_fetched_series_total, cortex_ruler_samples_total, cortex_ruler_fetched_chunks_bytes_total ...
```

To address it, this PR adds rule information to query parameters sent to the QFE to leave rule information logs on query stats.
For the metric, #6470 add the `source` label to categorize query stat metric. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
