### PR TITLE
Add timeout for dynamodb ring kv

### DIFF
--- a/docs/blocks-storage/compactor.md
+++ b/docs/blocks-storage/compactor.md
@@ -225,8 +225,7 @@ compactor:
         # CLI flag: -compactor.ring.dynamodb.max-cas-retries
         [max_cas_retries: <int> | default = 10]
 
-        # Timeout of dynamoDbClient requests. By default it is 2 times of
-        # dynamodb.puller-sync-time.
+        # Timeout of dynamoDbClient requests. Default is 2m.
         # CLI flag: -compactor.ring.dynamodb.timeout
         [timeout: <duration> | default = 2m]
 

--- a/docs/blocks-storage/compactor.md
+++ b/docs/blocks-storage/compactor.md
@@ -225,6 +225,11 @@ compactor:
         # CLI flag: -compactor.ring.dynamodb.max-cas-retries
         [max_cas_retries: <int> | default = 10]
 
+        # Timeout of dynamoDbClient requests. By default it is 2 times of
+        # dynamodb.puller-sync-time.
+        # CLI flag: -compactor.ring.dynamodb.timeout
+        [timeout: <duration> | default = 2m]
+
       # The consul_config configures the consul client.
       # The CLI flags prefix for this block config is: compactor.ring
       [consul: <consul_config>]

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -240,8 +240,7 @@ store_gateway:
         # CLI flag: -store-gateway.sharding-ring.dynamodb.max-cas-retries
         [max_cas_retries: <int> | default = 10]
 
-        # Timeout of dynamoDbClient requests. By default it is 2 times of
-        # dynamodb.puller-sync-time.
+        # Timeout of dynamoDbClient requests. Default is 2m.
         # CLI flag: -store-gateway.sharding-ring.dynamodb.timeout
         [timeout: <duration> | default = 2m]
 

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -240,6 +240,11 @@ store_gateway:
         # CLI flag: -store-gateway.sharding-ring.dynamodb.max-cas-retries
         [max_cas_retries: <int> | default = 10]
 
+        # Timeout of dynamoDbClient requests. By default it is 2 times of
+        # dynamodb.puller-sync-time.
+        # CLI flag: -store-gateway.sharding-ring.dynamodb.timeout
+        [timeout: <duration> | default = 2m]
+
       # The consul_config configures the consul client.
       # The CLI flags prefix for this block config is:
       # store-gateway.sharding-ring

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -341,8 +341,7 @@ sharding_ring:
       # CLI flag: -alertmanager.sharding-ring.dynamodb.max-cas-retries
       [max_cas_retries: <int> | default = 10]
 
-      # Timeout of dynamoDbClient requests. By default it is 2 times of
-      # dynamodb.puller-sync-time.
+      # Timeout of dynamoDbClient requests. Default is 2m.
       # CLI flag: -alertmanager.sharding-ring.dynamodb.timeout
       [timeout: <duration> | default = 2m]
 
@@ -2291,8 +2290,7 @@ sharding_ring:
       # CLI flag: -compactor.ring.dynamodb.max-cas-retries
       [max_cas_retries: <int> | default = 10]
 
-      # Timeout of dynamoDbClient requests. By default it is 2 times of
-      # dynamodb.puller-sync-time.
+      # Timeout of dynamoDbClient requests. Default is 2m.
       # CLI flag: -compactor.ring.dynamodb.timeout
       [timeout: <duration> | default = 2m]
 
@@ -2605,8 +2603,7 @@ ha_tracker:
       # CLI flag: -distributor.ha-tracker.dynamodb.max-cas-retries
       [max_cas_retries: <int> | default = 10]
 
-      # Timeout of dynamoDbClient requests. By default it is 2 times of
-      # dynamodb.puller-sync-time.
+      # Timeout of dynamoDbClient requests. Default is 2m.
       # CLI flag: -distributor.ha-tracker.dynamodb.timeout
       [timeout: <duration> | default = 2m]
 
@@ -2704,8 +2701,7 @@ ring:
       # CLI flag: -distributor.ring.dynamodb.max-cas-retries
       [max_cas_retries: <int> | default = 10]
 
-      # Timeout of dynamoDbClient requests. By default it is 2 times of
-      # dynamodb.puller-sync-time.
+      # Timeout of dynamoDbClient requests. Default is 2m.
       # CLI flag: -distributor.ring.dynamodb.timeout
       [timeout: <duration> | default = 2m]
 
@@ -3037,8 +3033,7 @@ lifecycler:
         # CLI flag: -dynamodb.max-cas-retries
         [max_cas_retries: <int> | default = 10]
 
-        # Timeout of dynamoDbClient requests. By default it is 2 times of
-        # dynamodb.puller-sync-time.
+        # Timeout of dynamoDbClient requests. Default is 2m.
         # CLI flag: -dynamodb.timeout
         [timeout: <duration> | default = 2m]
 
@@ -4691,8 +4686,7 @@ ring:
       # CLI flag: -ruler.ring.dynamodb.max-cas-retries
       [max_cas_retries: <int> | default = 10]
 
-      # Timeout of dynamoDbClient requests. By default it is 2 times of
-      # dynamodb.puller-sync-time.
+      # Timeout of dynamoDbClient requests. Default is 2m.
       # CLI flag: -ruler.ring.dynamodb.timeout
       [timeout: <duration> | default = 2m]
 
@@ -5687,8 +5681,7 @@ sharding_ring:
       # CLI flag: -store-gateway.sharding-ring.dynamodb.max-cas-retries
       [max_cas_retries: <int> | default = 10]
 
-      # Timeout of dynamoDbClient requests. By default it is 2 times of
-      # dynamodb.puller-sync-time.
+      # Timeout of dynamoDbClient requests. Default is 2m.
       # CLI flag: -store-gateway.sharding-ring.dynamodb.timeout
       [timeout: <duration> | default = 2m]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -341,6 +341,11 @@ sharding_ring:
       # CLI flag: -alertmanager.sharding-ring.dynamodb.max-cas-retries
       [max_cas_retries: <int> | default = 10]
 
+      # Timeout of dynamoDbClient requests. By default it is 2 times of
+      # dynamodb.puller-sync-time.
+      # CLI flag: -alertmanager.sharding-ring.dynamodb.timeout
+      [timeout: <duration> | default = 2m]
+
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: alertmanager.sharding-ring
     [consul: <consul_config>]
@@ -2286,6 +2291,11 @@ sharding_ring:
       # CLI flag: -compactor.ring.dynamodb.max-cas-retries
       [max_cas_retries: <int> | default = 10]
 
+      # Timeout of dynamoDbClient requests. By default it is 2 times of
+      # dynamodb.puller-sync-time.
+      # CLI flag: -compactor.ring.dynamodb.timeout
+      [timeout: <duration> | default = 2m]
+
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: compactor.ring
     [consul: <consul_config>]
@@ -2595,6 +2605,11 @@ ha_tracker:
       # CLI flag: -distributor.ha-tracker.dynamodb.max-cas-retries
       [max_cas_retries: <int> | default = 10]
 
+      # Timeout of dynamoDbClient requests. By default it is 2 times of
+      # dynamodb.puller-sync-time.
+      # CLI flag: -distributor.ha-tracker.dynamodb.timeout
+      [timeout: <duration> | default = 2m]
+
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: distributor.ha-tracker
     [consul: <consul_config>]
@@ -2688,6 +2703,11 @@ ring:
       # Maximum number of retries for DDB KV CAS.
       # CLI flag: -distributor.ring.dynamodb.max-cas-retries
       [max_cas_retries: <int> | default = 10]
+
+      # Timeout of dynamoDbClient requests. By default it is 2 times of
+      # dynamodb.puller-sync-time.
+      # CLI flag: -distributor.ring.dynamodb.timeout
+      [timeout: <duration> | default = 2m]
 
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: distributor.ring
@@ -3016,6 +3036,11 @@ lifecycler:
         # Maximum number of retries for DDB KV CAS.
         # CLI flag: -dynamodb.max-cas-retries
         [max_cas_retries: <int> | default = 10]
+
+        # Timeout of dynamoDbClient requests. By default it is 2 times of
+        # dynamodb.puller-sync-time.
+        # CLI flag: -dynamodb.timeout
+        [timeout: <duration> | default = 2m]
 
       # The consul_config configures the consul client.
       [consul: <consul_config>]
@@ -4666,6 +4691,11 @@ ring:
       # CLI flag: -ruler.ring.dynamodb.max-cas-retries
       [max_cas_retries: <int> | default = 10]
 
+      # Timeout of dynamoDbClient requests. By default it is 2 times of
+      # dynamodb.puller-sync-time.
+      # CLI flag: -ruler.ring.dynamodb.timeout
+      [timeout: <duration> | default = 2m]
+
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: ruler.ring
     [consul: <consul_config>]
@@ -5656,6 +5686,11 @@ sharding_ring:
       # Maximum number of retries for DDB KV CAS.
       # CLI flag: -store-gateway.sharding-ring.dynamodb.max-cas-retries
       [max_cas_retries: <int> | default = 10]
+
+      # Timeout of dynamoDbClient requests. By default it is 2 times of
+      # dynamodb.puller-sync-time.
+      # CLI flag: -store-gateway.sharding-ring.dynamodb.timeout
+      [timeout: <duration> | default = 2m]
 
     # The consul_config configures the consul client.
     # The CLI flags prefix for this block config is: store-gateway.sharding-ring

--- a/pkg/ring/kv/dynamodb/client.go
+++ b/pkg/ring/kv/dynamodb/client.go
@@ -54,7 +54,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, prefix string) {
 	f.DurationVar(&cfg.TTL, prefix+"dynamodb.ttl-time", 0, "Time to expire items on dynamodb.")
 	f.DurationVar(&cfg.PullerSyncTime, prefix+"dynamodb.puller-sync-time", 60*time.Second, "Time to refresh local ring with information on dynamodb.")
 	f.IntVar(&cfg.MaxCasRetries, prefix+"dynamodb.max-cas-retries", maxCasRetries, "Maximum number of retries for DDB KV CAS.")
-	f.DurationVar(&cfg.Timeout, prefix+"dynamodb.timeout", 2*cfg.PullerSyncTime, "Timeout of dynamoDbClient requests. By default it is 2 times of dynamodb.puller-sync-time.")
+	f.DurationVar(&cfg.Timeout, prefix+"dynamodb.timeout", 2*time.Minute, "Timeout of dynamoDbClient requests. Default is 2m.")
 }
 
 func NewClient(cfg Config, cc codec.Codec, logger log.Logger, registerer prometheus.Registerer) (*Client, error) {

--- a/pkg/ring/kv/dynamodb/client.go
+++ b/pkg/ring/kv/dynamodb/client.go
@@ -54,6 +54,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, prefix string) {
 	f.DurationVar(&cfg.TTL, prefix+"dynamodb.ttl-time", 0, "Time to expire items on dynamodb.")
 	f.DurationVar(&cfg.PullerSyncTime, prefix+"dynamodb.puller-sync-time", 60*time.Second, "Time to refresh local ring with information on dynamodb.")
 	f.IntVar(&cfg.MaxCasRetries, prefix+"dynamodb.max-cas-retries", maxCasRetries, "Maximum number of retries for DDB KV CAS.")
+	f.DurationVar(&cfg.Timeout, prefix+"dynamodb.timeout", 2*cfg.PullerSyncTime, "Timeout of dynamoDbClient requests. By default it is 2 times of dynamodb.puller-sync-time.")
 }
 
 func NewClient(cfg Config, cc codec.Codec, logger log.Logger, registerer prometheus.Registerer) (*Client, error) {
@@ -73,7 +74,7 @@ func NewClient(cfg Config, cc codec.Codec, logger log.Logger, registerer prometh
 	var kv dynamoDbClient
 	kv = dynamodbInstrumentation{kv: dynamoDB, ddbMetrics: ddbMetrics}
 	if cfg.Timeout > 0 {
-		kv = newDynamoDbKVWithTimeout(kv, cfg.Timeout)
+		kv = newDynamodbKVWithTimeout(kv, cfg.Timeout)
 	}
 	c := &Client{
 		kv:             kv,

--- a/pkg/ring/kv/dynamodb/dynamodb.go
+++ b/pkg/ring/kv/dynamodb/dynamodb.go
@@ -259,40 +259,40 @@ func (kv dynamodbKV) generatePutItemRequest(key dynamodbKey, data []byte) map[st
 	return item
 }
 
-type dynamoDbKVWithTimeout struct {
+type dynamodbKVWithTimeout struct {
 	ddbClient dynamoDbClient
 	timeout   time.Duration
 }
 
-func newDynamoDbKVWithTimeout(client dynamoDbClient, timeout time.Duration) *dynamoDbKVWithTimeout {
-	return &dynamoDbKVWithTimeout{ddbClient: client, timeout: timeout}
+func newDynamodbKVWithTimeout(client dynamoDbClient, timeout time.Duration) *dynamodbKVWithTimeout {
+	return &dynamodbKVWithTimeout{ddbClient: client, timeout: timeout}
 }
 
-func (d *dynamoDbKVWithTimeout) List(ctx context.Context, key dynamodbKey) ([]string, float64, error) {
+func (d *dynamodbKVWithTimeout) List(ctx context.Context, key dynamodbKey) ([]string, float64, error) {
 	ctx, cancel := context.WithTimeout(ctx, d.timeout)
 	defer cancel()
 	return d.ddbClient.List(ctx, key)
 }
 
-func (d *dynamoDbKVWithTimeout) Query(ctx context.Context, key dynamodbKey, isPrefix bool) (map[string][]byte, float64, error) {
+func (d *dynamodbKVWithTimeout) Query(ctx context.Context, key dynamodbKey, isPrefix bool) (map[string][]byte, float64, error) {
 	ctx, cancel := context.WithTimeout(ctx, d.timeout)
 	defer cancel()
 	return d.ddbClient.Query(ctx, key, isPrefix)
 }
 
-func (d *dynamoDbKVWithTimeout) Delete(ctx context.Context, key dynamodbKey) error {
+func (d *dynamodbKVWithTimeout) Delete(ctx context.Context, key dynamodbKey) error {
 	ctx, cancel := context.WithTimeout(ctx, d.timeout)
 	defer cancel()
 	return d.ddbClient.Delete(ctx, key)
 }
 
-func (d *dynamoDbKVWithTimeout) Put(ctx context.Context, key dynamodbKey, data []byte) error {
+func (d *dynamodbKVWithTimeout) Put(ctx context.Context, key dynamodbKey, data []byte) error {
 	ctx, cancel := context.WithTimeout(ctx, d.timeout)
 	defer cancel()
 	return d.ddbClient.Put(ctx, key, data)
 }
 
-func (d *dynamoDbKVWithTimeout) Batch(ctx context.Context, put map[dynamodbKey][]byte, delete []dynamodbKey) error {
+func (d *dynamodbKVWithTimeout) Batch(ctx context.Context, put map[dynamodbKey][]byte, delete []dynamodbKey) error {
 	ctx, cancel := context.WithTimeout(ctx, d.timeout)
 	defer cancel()
 	return d.ddbClient.Batch(ctx, put, delete)

--- a/pkg/ring/kv/dynamodb/dynamodb.go
+++ b/pkg/ring/kv/dynamodb/dynamodb.go
@@ -259,6 +259,45 @@ func (kv dynamodbKV) generatePutItemRequest(key dynamodbKey, data []byte) map[st
 	return item
 }
 
+type dynamoDbKVWithTimeout struct {
+	ddbClient dynamoDbClient
+	timeout   time.Duration
+}
+
+func newDynamoDbKVWithTimeout(client dynamoDbClient, timeout time.Duration) *dynamoDbKVWithTimeout {
+	return &dynamoDbKVWithTimeout{ddbClient: client, timeout: timeout}
+}
+
+func (d *dynamoDbKVWithTimeout) List(ctx context.Context, key dynamodbKey) ([]string, float64, error) {
+	ctx, cancel := context.WithTimeout(ctx, d.timeout)
+	defer cancel()
+	return d.ddbClient.List(ctx, key)
+}
+
+func (d *dynamoDbKVWithTimeout) Query(ctx context.Context, key dynamodbKey, isPrefix bool) (map[string][]byte, float64, error) {
+	ctx, cancel := context.WithTimeout(ctx, d.timeout)
+	defer cancel()
+	return d.ddbClient.Query(ctx, key, isPrefix)
+}
+
+func (d *dynamoDbKVWithTimeout) Delete(ctx context.Context, key dynamodbKey) error {
+	ctx, cancel := context.WithTimeout(ctx, d.timeout)
+	defer cancel()
+	return d.ddbClient.Delete(ctx, key)
+}
+
+func (d *dynamoDbKVWithTimeout) Put(ctx context.Context, key dynamodbKey, data []byte) error {
+	ctx, cancel := context.WithTimeout(ctx, d.timeout)
+	defer cancel()
+	return d.ddbClient.Put(ctx, key, data)
+}
+
+func (d *dynamoDbKVWithTimeout) Batch(ctx context.Context, put map[dynamodbKey][]byte, delete []dynamodbKey) error {
+	ctx, cancel := context.WithTimeout(ctx, d.timeout)
+	defer cancel()
+	return d.ddbClient.Batch(ctx, put, delete)
+}
+
 func generateItemKey(key dynamodbKey) map[string]*dynamodb.AttributeValue {
 	resp := map[string]*dynamodb.AttributeValue{
 		primaryKey: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR tries to fix https://github.com/cortexproject/cortex/issues/6211 using a different approach of https://github.com/cortexproject/cortex/pull/6212.

https://github.com/cortexproject/cortex/pull/6212 added context timeout to `heartbeat` but there are more places missing context timeout.

This PR instead tries to enforce context timeout on DDB KV so that request to DDB KV doesn't hang forever.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
