### PR TITLE
Fixed blocksGroupWithPartition unable to reuse functions from blocksGroup

### DIFF
--- a/pkg/compactor/partition_compaction_grouper.go
+++ b/pkg/compactor/partition_compaction_grouper.go
@@ -499,9 +499,11 @@ func (g *PartitionCompactionGrouper) partitionBlocksGroup(partitionCount int, bl
 	addToPartitionedGroups := func(blocks []*metadata.Meta, partitionID int) {
 		if _, ok := partitionedGroups[partitionID]; !ok {
 			partitionedGroups[partitionID] = blocksGroupWithPartition{
-				rangeStart: rangeStart,
-				rangeEnd:   rangeEnd,
-				blocks:     []*metadata.Meta{},
+				blocksGroup: blocksGroup{
+					rangeStart: rangeStart,
+					rangeEnd:   rangeEnd,
+					blocks:     []*metadata.Meta{},
+				},
 			}
 		}
 		partitionedGroup := partitionedGroups[partitionID]
@@ -868,9 +870,6 @@ func (t *timeRangeStatus) previousTimeRangeDuration() time.Duration {
 
 type blocksGroupWithPartition struct {
 	blocksGroup
-	rangeStart           int64 // Included.
-	rangeEnd             int64 // Excluded.
-	blocks               []*metadata.Meta
 	groupHash            uint32
 	partitionedGroupInfo *PartitionedGroupInfo
 	partition            Partition

--- a/pkg/compactor/partition_compaction_grouper_test.go
+++ b/pkg/compactor/partition_compaction_grouper_test.go
@@ -84,47 +84,53 @@ func TestPartitionCompactionGrouper_GenerateCompactionJobs(t *testing.T) {
 				{blocks: []ulid.ULID{block3, block4}, partitionCount: 1, partitionID: 0, rangeStart: 2 * H, rangeEnd: 4 * H},
 			},
 		},
-		"only level 1 blocks with replication factor 3": {
+		"only level 1 blocks with ingestion replication factor 3": {
 			ranges: []time.Duration{2 * time.Hour, 12 * time.Hour, 24 * time.Hour},
 			blocks: map[ulid.ULID]mockBlock{
 				block1: {
 					meta: &metadata.Meta{
-						BlockMeta: tsdb.BlockMeta{ULID: block1, MinTime: 0 * H, MaxTime: 2 * H, Compaction: tsdb.BlockMetaCompaction{Level: 1}},
+						BlockMeta: tsdb.BlockMeta{ULID: block1, MinTime: 0 * H, MaxTime: 2 * H, Compaction: tsdb.BlockMetaCompaction{Level: 1}, Stats: tsdb.BlockStats{NumSeries: 1}},
+						Thanos:    metadata.Thanos{Files: []metadata.File{{RelPath: thanosblock.IndexFilename, SizeBytes: 0}}},
 					},
 					timeRange:        2 * time.Hour,
 					hasNoCompactMark: false,
 				},
 				block2: {
 					meta: &metadata.Meta{
-						BlockMeta: tsdb.BlockMeta{ULID: block2, MinTime: 0 * H, MaxTime: 2 * H, Compaction: tsdb.BlockMetaCompaction{Level: 1}},
+						BlockMeta: tsdb.BlockMeta{ULID: block2, MinTime: 0 * H, MaxTime: 2 * H, Compaction: tsdb.BlockMetaCompaction{Level: 1}, Stats: tsdb.BlockStats{NumSeries: 1}},
+						Thanos:    metadata.Thanos{Files: []metadata.File{{RelPath: thanosblock.IndexFilename, SizeBytes: 0}}},
 					},
 					timeRange:        2 * time.Hour,
 					hasNoCompactMark: false,
 				},
 				block3: {
 					meta: &metadata.Meta{
-						BlockMeta: tsdb.BlockMeta{ULID: block3, MinTime: 0 * H, MaxTime: 2 * H, Compaction: tsdb.BlockMetaCompaction{Level: 1}},
+						BlockMeta: tsdb.BlockMeta{ULID: block3, MinTime: 0 * H, MaxTime: 2 * H, Compaction: tsdb.BlockMetaCompaction{Level: 1}, Stats: tsdb.BlockStats{NumSeries: 1}},
+						Thanos:    metadata.Thanos{Files: []metadata.File{{RelPath: thanosblock.IndexFilename, SizeBytes: 0}}},
 					},
 					timeRange:        2 * time.Hour,
 					hasNoCompactMark: false,
 				},
 				block4: {
 					meta: &metadata.Meta{
-						BlockMeta: tsdb.BlockMeta{ULID: block4, MinTime: 0 * H, MaxTime: 2 * H, Compaction: tsdb.BlockMetaCompaction{Level: 1}},
+						BlockMeta: tsdb.BlockMeta{ULID: block4, MinTime: 0 * H, MaxTime: 2 * H, Compaction: tsdb.BlockMetaCompaction{Level: 1}, Stats: tsdb.BlockStats{NumSeries: 1}},
+						Thanos:    metadata.Thanos{Files: []metadata.File{{RelPath: thanosblock.IndexFilename, SizeBytes: 0}}},
 					},
 					timeRange:        2 * time.Hour,
 					hasNoCompactMark: false,
 				},
 				block5: {
 					meta: &metadata.Meta{
-						BlockMeta: tsdb.BlockMeta{ULID: block5, MinTime: 2 * H, MaxTime: 4 * H, Compaction: tsdb.BlockMetaCompaction{Level: 1}},
+						BlockMeta: tsdb.BlockMeta{ULID: block5, MinTime: 0 * H, MaxTime: 2 * H, Compaction: tsdb.BlockMetaCompaction{Level: 1}, Stats: tsdb.BlockStats{NumSeries: 1}},
+						Thanos:    metadata.Thanos{Files: []metadata.File{{RelPath: thanosblock.IndexFilename, SizeBytes: 0}}},
 					},
 					timeRange:        2 * time.Hour,
 					hasNoCompactMark: false,
 				},
 				block6: {
 					meta: &metadata.Meta{
-						BlockMeta: tsdb.BlockMeta{ULID: block6, MinTime: 2 * H, MaxTime: 4 * H, Compaction: tsdb.BlockMetaCompaction{Level: 1}},
+						BlockMeta: tsdb.BlockMeta{ULID: block6, MinTime: 0 * H, MaxTime: 2 * H, Compaction: tsdb.BlockMetaCompaction{Level: 1}, Stats: tsdb.BlockStats{NumSeries: 1}},
+						Thanos:    metadata.Thanos{Files: []metadata.File{{RelPath: thanosblock.IndexFilename, SizeBytes: 0}}},
 					},
 					timeRange:        2 * time.Hour,
 					hasNoCompactMark: false,
@@ -134,7 +140,7 @@ func TestPartitionCompactionGrouper_GenerateCompactionJobs(t *testing.T) {
 			expected: []expectedCompactionJob{
 				{blocks: []ulid.ULID{block1, block2, block3, block4, block5, block6}, partitionCount: 1, partitionID: 0, rangeStart: 0 * H, rangeEnd: 2 * H},
 			},
-			replicationFactor: 3,
+			ingestionReplicationFactor: 3,
 		},
 		"only level 1 blocks, there is existing partitioned group file": {
 			ranges: []time.Duration{2 * time.Hour, 12 * time.Hour, 24 * time.Hour},
@@ -550,6 +556,65 @@ func TestPartitionCompactionGrouper_GenerateCompactionJobs(t *testing.T) {
 				{blocks: []ulid.ULID{block4, block5}, partitionCount: 1, partitionID: 0, rangeStart: 12 * H, rangeEnd: 14 * H},
 				{blocks: []ulid.ULID{block1, block2, block3}, partitionCount: 1, partitionID: 0, rangeStart: 0 * H, rangeEnd: 12 * H},
 			},
+		},
+		"level 2 blocks with ingestion replication factor 3": {
+			ranges: []time.Duration{2 * time.Hour, 12 * time.Hour, 24 * time.Hour},
+			blocks: map[ulid.ULID]mockBlock{
+				block1: {
+					meta: &metadata.Meta{
+						BlockMeta: tsdb.BlockMeta{ULID: block1, MinTime: 0 * H, MaxTime: 2 * H, Compaction: tsdb.BlockMetaCompaction{Level: 2}, Stats: tsdb.BlockStats{NumSeries: 1}},
+						Thanos:    metadata.Thanos{Extensions: cortextsdb.CortexMetaExtensions{PartitionInfo: &cortextsdb.PartitionInfo{PartitionCount: 2, PartitionID: 0}}, Files: []metadata.File{{RelPath: thanosblock.IndexFilename, SizeBytes: 0}}},
+					},
+					timeRange:        2 * time.Hour,
+					hasNoCompactMark: false,
+				},
+				block2: {
+					meta: &metadata.Meta{
+						BlockMeta: tsdb.BlockMeta{ULID: block2, MinTime: 0 * H, MaxTime: 2 * H, Compaction: tsdb.BlockMetaCompaction{Level: 2}, Stats: tsdb.BlockStats{NumSeries: 1}},
+						Thanos:    metadata.Thanos{Extensions: cortextsdb.CortexMetaExtensions{PartitionInfo: &cortextsdb.PartitionInfo{PartitionCount: 2, PartitionID: 1}}, Files: []metadata.File{{RelPath: thanosblock.IndexFilename, SizeBytes: 0}}},
+					},
+					timeRange:        2 * time.Hour,
+					hasNoCompactMark: false,
+				},
+				block3: {
+					meta: &metadata.Meta{
+						BlockMeta: tsdb.BlockMeta{ULID: block3, MinTime: 2 * H, MaxTime: 4 * H, Compaction: tsdb.BlockMetaCompaction{Level: 2}, Stats: tsdb.BlockStats{NumSeries: 1}},
+						Thanos:    metadata.Thanos{Extensions: cortextsdb.CortexMetaExtensions{PartitionInfo: &cortextsdb.PartitionInfo{PartitionCount: 2, PartitionID: 0}}, Files: []metadata.File{{RelPath: thanosblock.IndexFilename, SizeBytes: 0}}},
+					},
+					timeRange:        2 * time.Hour,
+					hasNoCompactMark: false,
+				},
+				block4: {
+					meta: &metadata.Meta{
+						BlockMeta: tsdb.BlockMeta{ULID: block4, MinTime: 2 * H, MaxTime: 4 * H, Compaction: tsdb.BlockMetaCompaction{Level: 2}, Stats: tsdb.BlockStats{NumSeries: 1}},
+						Thanos:    metadata.Thanos{Extensions: cortextsdb.CortexMetaExtensions{PartitionInfo: &cortextsdb.PartitionInfo{PartitionCount: 2, PartitionID: 1}}, Files: []metadata.File{{RelPath: thanosblock.IndexFilename, SizeBytes: 0}}},
+					},
+					timeRange:        2 * time.Hour,
+					hasNoCompactMark: false,
+				},
+				block5: {
+					meta: &metadata.Meta{
+						BlockMeta: tsdb.BlockMeta{ULID: block5, MinTime: 4 * H, MaxTime: 6 * H, Compaction: tsdb.BlockMetaCompaction{Level: 2}, Stats: tsdb.BlockStats{NumSeries: 1}},
+						Thanos:    metadata.Thanos{Extensions: cortextsdb.CortexMetaExtensions{PartitionInfo: &cortextsdb.PartitionInfo{PartitionCount: 2, PartitionID: 0}}, Files: []metadata.File{{RelPath: thanosblock.IndexFilename, SizeBytes: 0}}},
+					},
+					timeRange:        2 * time.Hour,
+					hasNoCompactMark: false,
+				},
+				block6: {
+					meta: &metadata.Meta{
+						BlockMeta: tsdb.BlockMeta{ULID: block6, MinTime: 4 * H, MaxTime: 6 * H, Compaction: tsdb.BlockMetaCompaction{Level: 2}, Stats: tsdb.BlockStats{NumSeries: 1}},
+						Thanos:    metadata.Thanos{Extensions: cortextsdb.CortexMetaExtensions{PartitionInfo: &cortextsdb.PartitionInfo{PartitionCount: 2, PartitionID: 1}}, Files: []metadata.File{{RelPath: thanosblock.IndexFilename, SizeBytes: 0}}},
+					},
+					timeRange:        2 * time.Hour,
+					hasNoCompactMark: false,
+				},
+			},
+			existingPartitionedGroups: []mockExistingPartitionedGroup{},
+			expected: []expectedCompactionJob{
+				{blocks: []ulid.ULID{block1, block3, block5}, partitionCount: 2, partitionID: 0, rangeStart: 0 * H, rangeEnd: 12 * H},
+				{blocks: []ulid.ULID{block2, block4, block6}, partitionCount: 2, partitionID: 1, rangeStart: 0 * H, rangeEnd: 12 * H},
+			},
+			ingestionReplicationFactor: 3,
 		},
 		"level 2 blocks along with level 3 blocks from some of partitions, level 1 blocks in different time range, there are partitioned group files for all groups": {
 			ranges: []time.Duration{2 * time.Hour, 12 * time.Hour, 24 * time.Hour},
@@ -2018,9 +2083,9 @@ func TestPartitionCompactionGrouper_GenerateCompactionJobs(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			replicationFactor := 1
-			if testCase.replicationFactor > 1 {
-				replicationFactor = testCase.replicationFactor
+			ingestionReplicationFactor := 1
+			if testCase.ingestionReplicationFactor > 1 {
+				ingestionReplicationFactor = testCase.ingestionReplicationFactor
 			}
 			g := NewPartitionCompactionGrouper(
 				ctx,
@@ -2044,7 +2109,7 @@ func TestPartitionCompactionGrouper_GenerateCompactionJobs(t *testing.T) {
 				false,
 				visitMarkerTimeout,
 				noCompactFilter,
-				replicationFactor,
+				ingestionReplicationFactor,
 			)
 			actual, err := g.generateCompactionJobs(testCase.getBlocks())
 			require.NoError(t, err)
@@ -2067,11 +2132,11 @@ func TestPartitionCompactionGrouper_GenerateCompactionJobs(t *testing.T) {
 }
 
 type generateCompactionJobsTestCase struct {
-	ranges                    []time.Duration
-	blocks                    map[ulid.ULID]mockBlock
-	existingPartitionedGroups []mockExistingPartitionedGroup
-	expected                  []expectedCompactionJob
-	replicationFactor         int
+	ranges                     []time.Duration
+	blocks                     map[ulid.ULID]mockBlock
+	existingPartitionedGroups  []mockExistingPartitionedGroup
+	expected                   []expectedCompactionJob
+	ingestionReplicationFactor int
 }
 
 func (g *generateCompactionJobsTestCase) setupBucketStore(t *testing.T, bkt *bucket.ClientMock, userID string, visitMarkerTimeout time.Duration) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
`blocksGroupWithPartition` extends `blocksGroup`. However, when calling functions inside `blocksGroup` from a `blocksGroupWithPartition` instance, those attributes defined inside `blocksGroup` were not set properly when initialize `blocksGroupWithPartition`. This caused unexpected value returned from `blocksGroup` functions.

The fix is removing duplicate attributes from `blocksGroupWithPartition` that already defined inside `blocksGroup`. When initializing `blocksGroupWithPartition` instance, those attributes in `blocksGroup` should be explicitly provided.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
