### PR TITLE
Fix flaky test: wait until indexes are updated

### DIFF
--- a/pkg/storage/tsdb/bucketindex/loader_test.go
+++ b/pkg/storage/tsdb/bucketindex/loader_test.go
@@ -473,7 +473,8 @@ func TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates(t *testing.T) {
 	// Wait until the next index load attempt occurs.
 	prevLoads := testutil.ToFloat64(loader.loadAttempts)
 	test.Poll(t, 3*time.Second, true, func() interface{} {
-		return testutil.ToFloat64(loader.loadAttempts) > prevLoads
+		// loadAttempts is incremented before the indexes are updated so we also check countLoadedIndexesMetric()
+		return testutil.ToFloat64(loader.loadAttempts) > prevLoads && loader.countLoadedIndexesMetric() == 0
 	})
 
 	// We expect the bucket index is not considered loaded because of the error.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Fixes flaky index loader test. Indexes are updates after the loadAttempts counter is incremented. The test only waited until loadAttempts changed. This means the test fails if the test goroutine continues before the index update method completes. Fixed by checking the indexes before continuing.

Reproducer: `go test -count=100 -run TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates ./pkg/storage/tsdb/bucketindex`

I validated locally by running the reproducer 4 times (all failed) then this fix 4 times (all passed).

**Which issue(s) this PR fixes**:
Fixes #6551

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
