### PR TITLE
Apply bytes limiter to LabelNames and LabelValuesForLabelNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [FEATURE] Querier/Ruler: Add `query_partial_data` and `rules_partial_data` limits to allow queries/rules to be evaluated with data from a single zone, if other zones are not available. #6526
+* [ENHANCEMENT] Querier: Apply bytes limiter to LabelNames and LabelValuesForLabelNames. #6568
 * [BUGFIX] Ingester: Avoid error or early throttling when READONLY ingesters are present in the ring #6517
 
 ## 1.19.0 in progress

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1400,15 +1400,15 @@ func (d *Distributor) MetricsForLabelMatchersStream(ctx context.Context, from, t
 			defer stream.CloseSend() //nolint:errcheck
 			for {
 				resp, err := stream.Recv()
-				if err := queryLimiter.AddDataBytes(resp.Size()); err != nil {
-					return nil, validation.LimitError(err.Error())
-				}
-
 				if err == io.EOF {
 					break
 				} else if err != nil {
 					return nil, err
 				}
+				if err := queryLimiter.AddDataBytes(resp.Size()); err != nil {
+					return nil, validation.LimitError(err.Error())
+				}
+
 				s := make([][]cortexpb.LabelAdapter, 0, len(resp.Metric))
 				for _, metric := range resp.Metric {
 					m := cortexpb.FromLabelAdaptersToMetricWithCopy(metric.Labels)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR is
1. Apply bytes limiter to `Distributor.LabelNames` and `Distributor.LabelValuesForLabelNames` functions, and
2. Fix a bug in `Distributor.MetricsForLabelMatchersStream` where bytes limiter was overwriting the error from the stream response

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [N/A] Tests updated
- [N/A] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
