### PR TITLE
Cleaner should not put deletion marker for blocks with no-compact marker

### DIFF
--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -832,6 +832,8 @@ func TestBlocksCleaner_CleanPartitionedGroupInfo(t *testing.T) {
 	startTime := ts(-10)
 	endTime := ts(-8)
 	block1 := createTSDBBlock(t, bucketClient, userID, startTime, endTime, nil)
+	block2 := createTSDBBlock(t, bucketClient, userID, startTime, endTime, nil)
+	createNoCompactionMark(t, bucketClient, userID, block2)
 
 	cfg := BlocksCleanerConfig{
 		DeletionDelay:      time.Hour,
@@ -862,7 +864,7 @@ func TestBlocksCleaner_CleanPartitionedGroupInfo(t *testing.T) {
 		Partitions: []Partition{
 			{
 				PartitionID: 0,
-				Blocks:      []ulid.ULID{block1},
+				Blocks:      []ulid.ULID{block1, block2},
 			},
 		},
 		RangeStart:   startTime,
@@ -892,6 +894,10 @@ func TestBlocksCleaner_CleanPartitionedGroupInfo(t *testing.T) {
 	block1DeletionMarkerExists, err := userBucket.Exists(ctx, path.Join(block1.String(), metadata.DeletionMarkFilename))
 	require.NoError(t, err)
 	require.True(t, block1DeletionMarkerExists)
+
+	block2DeletionMarkerExists, err := userBucket.Exists(ctx, path.Join(block2.String(), metadata.DeletionMarkFilename))
+	require.NoError(t, err)
+	require.False(t, block2DeletionMarkerExists)
 
 }
 

--- a/pkg/compactor/partitioned_group_info.go
+++ b/pkg/compactor/partitioned_group_info.go
@@ -241,7 +241,7 @@ func (p *PartitionedGroupInfo) markAllBlocksForDeletion(ctx context.Context, use
 		level.Info(userLogger).Log("msg", "total number of blocks marked for deletion during partitioned group info clean up", "count", deleteBlocksCount)
 	}()
 	for _, blockID := range blocks {
-		if p.doesBlockExist(ctx, userBucket, userLogger, blockID) && !p.isBlockDeleted(ctx, userBucket, userLogger, blockID) {
+		if p.doesBlockExist(ctx, userBucket, userLogger, blockID) && !p.isBlockDeleted(ctx, userBucket, userLogger, blockID) && !p.isBlockNoCompact(ctx, userBucket, userLogger, blockID) {
 			if err := block.MarkForDeletion(ctx, userLogger, userBucket, blockID, "delete block during partitioned group completion check", blocksMarkedForDeletion.WithLabelValues(userID, reasonValueRetention)); err != nil {
 				level.Warn(userLogger).Log("msg", "unable to mark block for deletion", "partitioned_group_id", p.PartitionedGroupID, "block", blockID.String())
 				return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Cleaner supposed to mark all blocks from completed partition group for deletion. However, it will mark blocks with no-compact marker for deletion as well. This would result in no-compact blocks got deleted. This PR is fixing this issue by adding extra check to make sure no-compact blocks will not be marked for deletion during this process.

**Which issue(s) this PR fixes**:


**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
