### PR TITLE
Avoid liveness check seg-fault in 'New' state

### DIFF
--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -586,6 +586,9 @@ func ownsRuleGroupOrDisable(g *rulespb.RuleGroupDesc, disabledRuleGroups validat
 }
 
 func (r *Ruler) LivenessCheck(_ context.Context, request *LivenessCheckRequest) (*LivenessCheckResponse, error) {
+	if r.lifecycler.ServiceContext() == nil {
+		return nil, errors.New("ruler is not yet ready")
+	}
 	if r.lifecycler.ServiceContext().Err() != nil || r.subservices.IsStopped() {
 		return nil, errors.New("ruler's context is canceled and might be stopping soon")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Fixes a bug in LivenessCheck where it can result in a seg fault when ruler is initializing and the context can be nil. 

https://github.com/cortexproject/cortex/blob/7292d8dcfc04d1d92dbaf20c70995362f9ee562b/pkg/util/services/basic_service.go#L277

When the ruler is initializing, it cannot evaluate rules since it has not loaded the rules yet. Therefore, in this case, we return an error as well which allows secondary ruler to evaluate the rule group one more time

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
