### PR TITLE
Set default conn timeout of 5 sec for storeGateway and alertmanager clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master / unreleased
+* [CHANGE] StoreGateway: Add default 5s connection timeout on SG client. #6603
 * [FEATURE] Query Frontend: Add dynamic interval size for query splitting. This is enabled by configuring experimental flags `querier.max-shards-per-query` and/or `querier.max-fetched-data-duration-per-query`. The split interval size is dynamically increased to maintain a number of shards and total duration fetched below the configured values. #6458
 * [FEATURE] Querier/Ruler: Add `query_partial_data` and `rules_partial_data` limits to allow queries/rules to be evaluated with data from a single zone, if other zones are not available. #6526
 * [FEATURE] Update prometheus alertmanager version to v0.28.0 and add new integration msteamsv2, jira, and rocketchat. #6590

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## master / unreleased
-* [CHANGE] StoreGateway: Add default 5s connection timeout on SG client. #6603
+* [CHANGE] StoreGateway/Alertmanager: Add default 5s connection timeout on client. #6603
 * [FEATURE] Query Frontend: Add dynamic interval size for query splitting. This is enabled by configuring experimental flags `querier.max-shards-per-query` and/or `querier.max-fetched-data-duration-per-query`. The split interval size is dynamically increased to maintain a number of shards and total duration fetched below the configured values. #6458
 * [FEATURE] Querier/Ruler: Add `query_partial_data` and `rules_partial_data` limits to allow queries/rules to be evaluated with data from a single zone, if other zones are not available. #6526
 * [FEATURE] Update prometheus alertmanager version to v0.28.0 and add new integration msteamsv2, jira, and rocketchat. #6590

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -222,6 +222,11 @@ querier:
       # CLI flag: -querier.store-gateway-client.healthcheck.timeout
       [timeout: <duration> | default = 1s]
 
+    # The maximum amount of time to establish a connection. A value of 0 means
+    # using default gRPC client connect timeout 5s.
+    # CLI flag: -querier.store-gateway-client.connect-timeout
+    [connect_timeout: <duration> | default = 5s]
+
   # If enabled, store gateway query stats will be logged using `info` log level.
   # CLI flag: -querier.store-gateway-query-stats-enabled
   [store_gateway_query_stats: <boolean> | default = true]

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -267,7 +267,7 @@ query_scheduler:
     [tls_insecure_skip_verify: <boolean> | default = false]
 
     # The maximum amount of time to establish a connection. A value of 0 means
-    # using default gRPC client connect timeout 20s.
+    # using default gRPC client connect timeout 5s.
     # CLI flag: -query-scheduler.grpc-client-config.connect-timeout
     [connect_timeout: <duration> | default = 5s]
 
@@ -502,6 +502,11 @@ alertmanager_client:
   # gRPC client max send message size (bytes).
   # CLI flag: -alertmanager.alertmanager-client.grpc-max-send-msg-size
   [max_send_msg_size: <int> | default = 4194304]
+
+  # The maximum amount of time to establish a connection. A value of 0 means
+  # using default gRPC client connect timeout 5s.
+  # CLI flag: -alertmanager.alertmanager-client.connect-timeout
+  [connect_timeout: <duration> | default = 5s]
 
 # The interval between persisting the current alertmanager state (notification
 # log and silences) to object storage. This is only used when sharding is
@@ -2995,7 +3000,7 @@ grpc_client_config:
   [tls_insecure_skip_verify: <boolean> | default = false]
 
   # The maximum amount of time to establish a connection. A value of 0 means
-  # using default gRPC client connect timeout 20s.
+  # using default gRPC client connect timeout 5s.
   # CLI flag: -querier.frontend-client.connect-timeout
   [connect_timeout: <duration> | default = 5s]
 ```
@@ -3313,7 +3318,7 @@ grpc_client_config:
   [tls_insecure_skip_verify: <boolean> | default = false]
 
   # The maximum amount of time to establish a connection. A value of 0 means
-  # using default gRPC client connect timeout 20s.
+  # using default gRPC client connect timeout 5s.
   # CLI flag: -ingester.client.connect-timeout
   [connect_timeout: <duration> | default = 5s]
 
@@ -4100,6 +4105,11 @@ store_gateway_client:
     # CLI flag: -querier.store-gateway-client.healthcheck.timeout
     [timeout: <duration> | default = 1s]
 
+  # The maximum amount of time to establish a connection. A value of 0 means
+  # using default gRPC client connect timeout 5s.
+  # CLI flag: -querier.store-gateway-client.connect-timeout
+  [connect_timeout: <duration> | default = 5s]
+
 # If enabled, store gateway query stats will be logged using `info` log level.
 # CLI flag: -querier.store-gateway-query-stats-enabled
 [store_gateway_query_stats: <boolean> | default = true]
@@ -4245,7 +4255,7 @@ grpc_client_config:
   [tls_insecure_skip_verify: <boolean> | default = false]
 
   # The maximum amount of time to establish a connection. A value of 0 means
-  # using default gRPC client connect timeout 20s.
+  # using default gRPC client connect timeout 5s.
   # CLI flag: -frontend.grpc-client-config.connect-timeout
   [connect_timeout: <duration> | default = 5s]
 
@@ -4492,7 +4502,7 @@ frontend_client:
   [tls_insecure_skip_verify: <boolean> | default = false]
 
   # The maximum amount of time to establish a connection. A value of 0 means
-  # using default gRPC client connect timeout 20s.
+  # using default gRPC client connect timeout 5s.
   # CLI flag: -ruler.frontendClient.connect-timeout
   [connect_timeout: <duration> | default = 5s]
 
@@ -4572,7 +4582,7 @@ ruler_client:
   [tls_insecure_skip_verify: <boolean> | default = false]
 
   # The maximum amount of time to establish a connection. A value of 0 means
-  # using default gRPC client connect timeout 20s.
+  # using default gRPC client connect timeout 5s.
   # CLI flag: -ruler.client.connect-timeout
   [connect_timeout: <duration> | default = 5s]
 

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -267,7 +267,7 @@ query_scheduler:
     [tls_insecure_skip_verify: <boolean> | default = false]
 
     # The maximum amount of time to establish a connection. A value of 0 means
-    # using default gRPC client connect timeout 5s.
+    # using default gRPC client connect timeout 20s.
     # CLI flag: -query-scheduler.grpc-client-config.connect-timeout
     [connect_timeout: <duration> | default = 5s]
 
@@ -3000,7 +3000,7 @@ grpc_client_config:
   [tls_insecure_skip_verify: <boolean> | default = false]
 
   # The maximum amount of time to establish a connection. A value of 0 means
-  # using default gRPC client connect timeout 5s.
+  # using default gRPC client connect timeout 20s.
   # CLI flag: -querier.frontend-client.connect-timeout
   [connect_timeout: <duration> | default = 5s]
 ```
@@ -3318,7 +3318,7 @@ grpc_client_config:
   [tls_insecure_skip_verify: <boolean> | default = false]
 
   # The maximum amount of time to establish a connection. A value of 0 means
-  # using default gRPC client connect timeout 5s.
+  # using default gRPC client connect timeout 20s.
   # CLI flag: -ingester.client.connect-timeout
   [connect_timeout: <duration> | default = 5s]
 
@@ -4255,7 +4255,7 @@ grpc_client_config:
   [tls_insecure_skip_verify: <boolean> | default = false]
 
   # The maximum amount of time to establish a connection. A value of 0 means
-  # using default gRPC client connect timeout 5s.
+  # using default gRPC client connect timeout 20s.
   # CLI flag: -frontend.grpc-client-config.connect-timeout
   [connect_timeout: <duration> | default = 5s]
 
@@ -4502,7 +4502,7 @@ frontend_client:
   [tls_insecure_skip_verify: <boolean> | default = false]
 
   # The maximum amount of time to establish a connection. A value of 0 means
-  # using default gRPC client connect timeout 5s.
+  # using default gRPC client connect timeout 20s.
   # CLI flag: -ruler.frontendClient.connect-timeout
   [connect_timeout: <duration> | default = 5s]
 
@@ -4582,7 +4582,7 @@ ruler_client:
   [tls_insecure_skip_verify: <boolean> | default = false]
 
   # The maximum amount of time to establish a connection. A value of 0 means
-  # using default gRPC client connect timeout 5s.
+  # using default gRPC client connect timeout 20s.
   # CLI flag: -ruler.client.connect-timeout
   [connect_timeout: <duration> | default = 5s]
 

--- a/pkg/alertmanager/alertmanager_client.go
+++ b/pkg/alertmanager/alertmanager_client.go
@@ -40,6 +40,7 @@ type ClientConfig struct {
 	GRPCCompression string           `yaml:"grpc_compression"`
 	MaxRecvMsgSize  int              `yaml:"max_recv_msg_size"`
 	MaxSendMsgSize  int              `yaml:"max_send_msg_size"`
+	ConnectTimeout  time.Duration    `yaml:"connect_timeout"`
 }
 
 // RegisterFlagsWithPrefix registers flags with prefix.
@@ -50,6 +51,7 @@ func (cfg *ClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet)
 	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
 	f.IntVar(&cfg.MaxRecvMsgSize, prefix+".grpc-max-recv-msg-size", 16*1024*1024, "gRPC client max receive message size (bytes).")
 	f.IntVar(&cfg.MaxSendMsgSize, prefix+".grpc-max-send-msg-size", 4*1024*1024, "gRPC client max send message size (bytes).")
+	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 5*time.Second, "The maximum amount of time to establish a connection. A value of 0 means using default gRPC client connect timeout 5s.")
 }
 
 type alertmanagerClientsPool struct {
@@ -67,6 +69,7 @@ func newAlertmanagerClientsPool(discovery client.PoolServiceDiscovery, amClientC
 		BackoffOnRatelimits: false,
 		TLSEnabled:          amClientCfg.TLSEnabled,
 		TLS:                 amClientCfg.TLS,
+		ConnectTimeout:      amClientCfg.ConnectTimeout,
 	}
 
 	requestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{

--- a/pkg/querier/store_gateway_client.go
+++ b/pkg/querier/store_gateway_client.go
@@ -79,6 +79,7 @@ func newStoreGatewayClientPool(discovery client.PoolServiceDiscovery, clientConf
 			BackoffOnRatelimits: false,
 			TLSEnabled:          clientConfig.TLSEnabled,
 			TLS:                 clientConfig.TLS,
+			ConnectTimeout:      clientConfig.ConnectTimeout,
 		},
 		HealthCheckConfig: clientConfig.HealthCheckConfig,
 	}
@@ -103,11 +104,13 @@ type ClientConfig struct {
 	TLS               tls.ClientConfig             `yaml:",inline"`
 	GRPCCompression   string                       `yaml:"grpc_compression"`
 	HealthCheckConfig grpcclient.HealthCheckConfig `yaml:"healthcheck_config" doc:"description=EXPERIMENTAL: If enabled, gRPC clients perform health checks for each target and fail the request if the target is marked as unhealthy."`
+	ConnectTimeout    time.Duration                `yaml:"connect_timeout"`
 }
 
 func (cfg *ClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", cfg.TLSEnabled, "Enable TLS for gRPC client connecting to store-gateway.")
 	f.StringVar(&cfg.GRPCCompression, prefix+".grpc-compression", "", "Use compression when sending messages. Supported values are: 'gzip', 'snappy' and '' (disable compression)")
+	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 5*time.Second, "The maximum amount of time to establish a connection. A value of 0 means using default gRPC client connect timeout 20s.")
 	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
 	cfg.HealthCheckConfig.RegisterFlagsWithPrefix(prefix, f)
 }

--- a/pkg/querier/store_gateway_client.go
+++ b/pkg/querier/store_gateway_client.go
@@ -110,7 +110,7 @@ type ClientConfig struct {
 func (cfg *ClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", cfg.TLSEnabled, "Enable TLS for gRPC client connecting to store-gateway.")
 	f.StringVar(&cfg.GRPCCompression, prefix+".grpc-compression", "", "Use compression when sending messages. Supported values are: 'gzip', 'snappy' and '' (disable compression)")
-	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 5*time.Second, "The maximum amount of time to establish a connection. A value of 0 means using default gRPC client connect timeout 20s.")
+	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 5*time.Second, "The maximum amount of time to establish a connection. A value of 0 means using default gRPC client connect timeout 5s.")
 	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
 	cfg.HealthCheckConfig.RegisterFlagsWithPrefix(prefix, f)
 }

--- a/pkg/util/grpcclient/grpcclient.go
+++ b/pkg/util/grpcclient/grpcclient.go
@@ -61,7 +61,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix, defaultGrpcCompression string
 	f.IntVar(&cfg.RateLimitBurst, prefix+".grpc-client-rate-limit-burst", 0, "Rate limit burst for gRPC client.")
 	f.BoolVar(&cfg.BackoffOnRatelimits, prefix+".backoff-on-ratelimits", false, "Enable backoff and retry when we hit ratelimits.")
 	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", cfg.TLSEnabled, "Enable TLS in the GRPC client. This flag needs to be enabled when any other TLS flag is set. If set to false, insecure connection to gRPC server will be used.")
-	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 5*time.Second, "The maximum amount of time to establish a connection. A value of 0 means using default gRPC client connect timeout 5s.")
+	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 5*time.Second, "The maximum amount of time to establish a connection. A value of 0 means using default gRPC client connect timeout 20s.")
 
 	cfg.BackoffConfig.RegisterFlagsWithPrefix(prefix, f)
 

--- a/pkg/util/grpcclient/grpcclient.go
+++ b/pkg/util/grpcclient/grpcclient.go
@@ -61,7 +61,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix, defaultGrpcCompression string
 	f.IntVar(&cfg.RateLimitBurst, prefix+".grpc-client-rate-limit-burst", 0, "Rate limit burst for gRPC client.")
 	f.BoolVar(&cfg.BackoffOnRatelimits, prefix+".backoff-on-ratelimits", false, "Enable backoff and retry when we hit ratelimits.")
 	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", cfg.TLSEnabled, "Enable TLS in the GRPC client. This flag needs to be enabled when any other TLS flag is set. If set to false, insecure connection to gRPC server will be used.")
-	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 5*time.Second, "The maximum amount of time to establish a connection. A value of 0 means using default gRPC client connect timeout 20s.")
+	f.DurationVar(&cfg.ConnectTimeout, prefix+".connect-timeout", 5*time.Second, "The maximum amount of time to establish a connection. A value of 0 means using default gRPC client connect timeout 5s.")
 
 	cfg.BackoffConfig.RegisterFlagsWithPrefix(prefix, f)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Continue work on https://github.com/cortexproject/cortex/pull/6523

Add the timeout to SG/Alertmanager by default

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
