### PR TITLE
Fix: split interval function should return 4xx

### DIFF
--- a/pkg/querier/tripperware/queryrange/split_by_interval.go
+++ b/pkg/querier/tripperware/queryrange/split_by_interval.go
@@ -54,7 +54,7 @@ func (s splitByInterval) Do(ctx context.Context, r tripperware.Request) (tripper
 	// to line up the boundaries with step.
 	interval, err := s.interval(ctx, r)
 	if err != nil {
-		return nil, httpgrpc.Errorf(http.StatusInternalServerError, err.Error())
+		return nil, httpgrpc.Errorf(http.StatusBadRequest, err.Error())
 	}
 	reqs, err := splitQuery(r, interval)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Split interval function could return an error in three cases
- Query parsing error
- Query analyzer error
- Error retrieving tenant userId

Since all of these should be 4xx, the current behaviour of returning 5xx is wrong.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
