### PR TITLE
Add check to avoid query 5xx when closing tsdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [BUGFIX] Querier: Fix marshal native histogram with empty bucket when protobuf codec is enabled. #6595
 * [BUGFIX] Query Frontend: Fix samples scanned and peak samples query stats when query hits results cache. #6591
 * [BUGFIX] Query Frontend: Fix panic caused by nil pointer dereference. #6609
+* [BUGFIX] Ingester: Add check to avoid query 5xx when closing tsdb. #6616
 
 ## 1.19.0 in progress
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
When an idle tsdb is closing, we mark the userDB as closing (or closed) and ask to close tsdb. While the tsdb is clossing and userDb is still on the ingester list, it can happen that a query request is received by the ingester and it will fail with 
```
open querier for head range head (mint: X, maxt: Y): open querier for block range head (mint: X, maxt: Y): open chunk reader: can't read from a closed head
```

To avoid this from happening, we are adding a readLock similar to the acquireAppendLock, that will make sure no query request is inflight when closing an idle tsdb and it will return a empty response if the request is received after the tsdb is already closing

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
