### PR TITLE
Pass limit to merge serieset for labels API

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1878,7 +1878,7 @@ func (i *Ingester) metricsForLabelMatchersCommon(ctx context.Context, req *clien
 			seriesSet := q.Select(ctx, true, hints, matchers...)
 			sets = append(sets, seriesSet)
 		}
-		mergedSet = storage.NewMergeSeriesSet(sets, 0, storage.ChainedSeriesMerge)
+		mergedSet = storage.NewMergeSeriesSet(sets, limit, storage.ChainedSeriesMerge)
 	} else {
 		mergedSet = q.Select(ctx, false, hints, matchersSet[0]...)
 	}

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -484,9 +484,8 @@ func (q *blocksStoreQuerier) selectSorted(ctx context.Context, sp *storage.Selec
 		storage.EmptySeriesSet()
 	}
 
-	// TODO(johrry): pass limit when merging.
 	return series.NewSeriesSetWithWarnings(
-		storage.NewMergeSeriesSet(resSeriesSets, 0, storage.ChainedSeriesMerge),
+		storage.NewMergeSeriesSet(resSeriesSets, int(limit), storage.ChainedSeriesMerge),
 		resWarnings)
 }
 

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -655,12 +655,6 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 						{t: minT, v: 1},
 						{t: minT + 1, v: 2},
 					},
-				}, {
-					lbls: labels.New(metricNameLabel, series2Label),
-					values: []valueResult{
-						{t: minT, v: 1},
-						{t: minT + 1, v: 3},
-					},
 				},
 			},
 		},

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -647,7 +647,6 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			},
 			limits:       &blocksStoreLimitsMock{},
 			queryLimiter: noOpQueryLimiter,
-			// TODO (johrry): Update this after passing limit in merge
 			expectedSeries: []seriesResult{
 				{
 					lbls: labels.New(metricNameLabel, series1Label),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

See https://github.com/prometheus/prometheus/pull/14489.

`storage.NewMergeSeriesSet` can handle limit now so we can pass down limit from labels API

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
