### PR TITLE
Fix flaky TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates unit…

### DIFF
--- a/pkg/storage/tsdb/bucketindex/loader_test.go
+++ b/pkg/storage/tsdb/bucketindex/loader_test.go
@@ -470,23 +470,19 @@ func TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates(t *testing.T) {
 	// Delete the bucket index.
 	require.NoError(t, DeleteIndex(ctx, bkt, "user-1", nil))
 
-	// Wait until the next index load attempt occurs.
-	prevLoads := testutil.ToFloat64(loader.loadAttempts)
-	test.Poll(t, 3*time.Second, true, func() interface{} {
-		return testutil.ToFloat64(loader.loadAttempts) > prevLoads
-	})
-
 	// We expect the bucket index is not considered loaded because of the error.
-	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+	test.Poll(t, 3*time.Second, nil, func() interface{} {
+		return testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 			# HELP cortex_bucket_index_loaded Number of bucket indexes currently loaded in-memory.
 			# TYPE cortex_bucket_index_loaded gauge
 			cortex_bucket_index_loaded 0
 		`),
-		"cortex_bucket_index_loaded",
-	))
+			"cortex_bucket_index_loaded",
+		)
+	})
 
 	// Try to get the index again. We expect no load attempt because the error has been cached.
-	prevLoads = testutil.ToFloat64(loader.loadAttempts)
+	prevLoads := testutil.ToFloat64(loader.loadAttempts)
 	actualIdx, _, err = loader.GetIndex(ctx, "user-1")
 	assert.Equal(t, ErrIndexNotFound, err)
 	assert.Nil(t, actualIdx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

I've noticed the `TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates` is flaky at https://github.com/cortexproject/cortex/actions/runs/13707366203/job/38335843714.
```
--- FAIL: TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates (0.94s)
    loader_test.go:480: 
        	Error Trace:	/__w/cortex/cortex/pkg/storage/tsdb/bucketindex/loader_test.go:480
        	Error:      	Received unexpected error:
        	            	 # HELP cortex_bucket_index_loaded Number of bucket indexes currently loaded in-memory.
        	            	 # TYPE cortex_bucket_index_loaded gauge
        	            	-cortex_bucket_index_loaded 1
        	            	+cortex_bucket_index_loaded 0
        	            	 
        	Test:       	TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates
FAIL
```

It could fail when the `loadAttempts` is increased, but the in-memory index is not updated yet. This PR fixes it by waiting until the in-memory index is updated.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
