### PR TITLE
update go to 1.24

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.2-bullseye
+FROM golang:1.24.0-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl file gettext jq unzip protobuf-compiler libprotobuf-dev && \


### PR DESCRIPTION
Updates the Dockerfile to reference go 1.24.0. Once the image is created then I will reference the new build image in the config files mentioned in https://github.com/cortexproject/cortex/blob/master/docs/contributing/how-to-update-the-build-image.md

Fixes #6625 
