### PR TITLE
bumps faillint version to 1.15 to support go 1.24

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -30,7 +30,7 @@ RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 &&\
 	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 &&\
 	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 &&\
-	go install github.com/fatih/faillint@v1.13.0 &&\
+	go install github.com/fatih/faillint@v1.15.0 &&\
 	go install github.com/campoy/embedmd@v1.0.0 &&\
 	go install --tags extended github.com/gohugoio/hugo@${HUGO_VERSION} &&\
 	rm -rf /go/pkg /go/src /root/.cache


### PR DESCRIPTION
Part of #6625 

This is a version bump for the [faillint linter](url), needed to support go 1.24.

Created because I ran into [this issue](https://github.com/cortexproject/cortex/actions/runs/13794661971/job/38583192205?pr=6637) while working on [this PR](https://github.com/cortexproject/cortex/pull/6637).
 
**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
