### PR TITLE
Keep readonly state when stopping lifecycler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * [BUGFIX] Query Frontend: Fix panic caused by nil pointer dereference. #6609
 * [BUGFIX] Ingester: Add check to avoid query 5xx when closing tsdb. #6616
 * [BUGFIX] Querier: Fix panic when marshaling QueryResultRequest. #6601
-* [BUGFIX] Ingester: Avoid resharding for qquery when restart readonly ingesters. #6642
+* [BUGFIX] Ingester: Avoid resharding for query when restart readonly ingesters. #6642
 
 ## 1.19.0 2025-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [BUGFIX] Query Frontend: Fix panic caused by nil pointer dereference. #6609
 * [BUGFIX] Ingester: Add check to avoid query 5xx when closing tsdb. #6616
 * [BUGFIX] Querier: Fix panic when marshaling QueryResultRequest. #6601
+* [BUGFIX] Ingester: Avoid resharding for qquery when restart readonly ingesters. #6642
 
 ## 1.19.0 2025-02-27
 

--- a/pkg/ring/lifecycler_test.go
+++ b/pkg/ring/lifecycler_test.go
@@ -743,6 +743,94 @@ func TestRestartIngester_DisabledHeartbeat_unregister_on_shutdown_false(t *testi
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), l2))
 }
 
+func TestRestartIngester_READONLY(t *testing.T) {
+	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	var ringConfig Config
+	flagext.DefaultValues(&ringConfig)
+	ringConfig.KVStore.Mock = ringStore
+
+	r, err := New(ringConfig, "ingester", ringKey, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), r))
+
+	// poll function waits for a condition and returning actual state of the ingesters after the condition succeed.
+	poll := func(condition func(*Desc) bool) map[string]InstanceDesc {
+		var ingesters map[string]InstanceDesc
+		test.Poll(t, 5*time.Second, true, func() interface{} {
+			d, err := r.KVClient.Get(context.Background(), ringKey)
+			require.NoError(t, err)
+
+			desc, ok := d.(*Desc)
+
+			if ok {
+				ingesters = desc.Ingesters
+			}
+			return ok && condition(desc)
+		})
+
+		return ingesters
+	}
+
+	// Starts Ingester and wait it to became active
+	startIngesterAndWaitState := func(ingId string, addr string, expectedState InstanceState) *Lifecycler {
+		lifecyclerConfig := testLifecyclerConfigWithAddr(ringConfig, ingId, addr)
+		lifecycler, err := NewLifecycler(lifecyclerConfig, &noopFlushTransferer{}, "lifecycler", ringKey, true, true, log.NewNopLogger(), nil)
+		require.NoError(t, err)
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), lifecycler))
+		poll(func(desc *Desc) bool {
+			return desc.Ingesters[ingId].State == expectedState
+		})
+		return lifecycler
+	}
+
+	l1 := startIngesterAndWaitState("ing1", "0.0.0.0", ACTIVE)
+	defer services.StopAndAwaitTerminated(context.Background(), l1) //nolint:errcheck
+
+	l2 := startIngesterAndWaitState("ing2", "0.0.0.0", ACTIVE)
+	defer services.StopAndAwaitTerminated(context.Background(), l2) //nolint:errcheck
+
+	err = l2.ChangeState(context.Background(), READONLY)
+	require.NoError(t, err)
+	poll(func(desc *Desc) bool {
+		return desc.Ingesters["ing2"].State == READONLY
+	})
+
+	ingesters := poll(func(desc *Desc) bool {
+		return len(desc.Ingesters) == 2 && desc.Ingesters["ing1"].State == ACTIVE && desc.Ingesters["ing2"].State == READONLY
+	})
+
+	// Both Ingester should be active and running
+	assert.Equal(t, ACTIVE, ingesters["ing1"].State)
+	assert.Equal(t, READONLY, ingesters["ing2"].State)
+
+	// Stop ingester 1 gracefully should leave it on LEAVING STATE on the ring
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), l1))
+	// Stop ingester 2 gracefully should keep on READONLY
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), l2))
+
+	ingesters = poll(func(desc *Desc) bool {
+		return len(desc.Ingesters) == 2 && desc.Ingesters["ing1"].State == LEAVING
+	})
+
+	assert.Equal(t, LEAVING, ingesters["ing1"].State)
+	assert.Equal(t, READONLY, ingesters["ing2"].State)
+
+	// Start Ingester1 again - Should flip back to ACTIVE in the ring
+	l1 = startIngesterAndWaitState("ing1", "0.0.0.0", ACTIVE)
+
+	// Start Ingester2 again - Should keep on READONLY
+	l2 = startIngesterAndWaitState("ing2", "0.0.0.0", READONLY)
+
+	ingesters = poll(func(desc *Desc) bool {
+		return len(desc.Ingesters) == 2 && desc.Ingesters["ing1"].State == ACTIVE
+	})
+
+	assert.Equal(t, ACTIVE, ingesters["ing1"].State)
+	assert.Equal(t, READONLY, ingesters["ing2"].State)
+}
+
 func TestTokenFileOnDisk(t *testing.T) {
 	ringStore, closer := consul.NewInMemoryClient(GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
When restarting ingester which are in READONLY we can cause a resharding which this PR is trying to avoid.

When a ingester is in READONLY, we extend the shard of tenant to return more than the original value. This is done to avoid errors on Push or missing data on Query.
Problem occurs when we restart ingester. The READONLY ingester will go to LEAVING which is ok for Push but it changes the tenant shard for Query. It can lead to miss calls from querier/ruler to ingesters.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
