### PR TITLE
Add native histogram query fuzz test

### DIFF
--- a/integration/e2e/images/images.go
+++ b/integration/e2e/images/images.go
@@ -11,5 +11,5 @@ var (
 	Minio      = "minio/minio:RELEASE.2024-05-28T17-19-04Z"
 	Consul     = "consul:1.8.4"
 	ETCD       = "gcr.io/etcd-development/etcd:v3.4.7"
-	Prometheus = "quay.io/prometheus/prometheus:v2.51.0"
+	Prometheus = "quay.io/prometheus/prometheus:v3.2.1"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR adds a query fuzz test for the native histogram, It compares query result Cortex with the latest Prometheus.

**Which issue(s) this PR fixes**:
Fixes #6093 

**Checklist**
- [x] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
