### PR TITLE
Replace `golang.org/x/exp/slices` with stdlib `slices`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,6 @@ require (
 	github.com/sercand/kuberesolver/v5 v5.1.1
 	github.com/tjhop/slog-gokit v0.1.2
 	go.opentelemetry.io/collector/pdata v1.24.0
-	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
 	google.golang.org/protobuf v1.36.4
 )
 
@@ -242,6 +241,7 @@ require (
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 // indirect
 	golang.org/x/crypto v0.35.0 // indirect
+	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect

--- a/pkg/compactor/sharded_block_populator.go
+++ b/pkg/compactor/sharded_block_populator.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/pkg/ring/lifecycler_test.go
+++ b/pkg/ring/lifecycler_test.go
@@ -3,7 +3,7 @@ package ring
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/cortexproject/cortex/pkg/ring/kv/consul"
 	"github.com/cortexproject/cortex/pkg/util/flagext"
@@ -906,8 +905,8 @@ func TestTokenFileOnDisk(t *testing.T) {
 	})
 
 	// Check for same tokens.
-	sort.Slice(expTokens, func(i, j int) bool { return expTokens[i] < expTokens[j] })
-	sort.Slice(actTokens, func(i, j int) bool { return actTokens[i] < actTokens[j] })
+	slices.Sort(expTokens)
+	slices.Sort(actTokens)
 	for i := 0; i < 512; i++ {
 		require.Equal(t, expTokens, actTokens)
 	}
@@ -1088,8 +1087,8 @@ func TestTokenFileOnDisk_WithoutAutoJoinOnStartup(t *testing.T) {
 	})
 
 	// Check for same tokens.
-	sort.Slice(expTokens, func(i, j int) bool { return expTokens[i] < expTokens[j] })
-	sort.Slice(actTokens, func(i, j int) bool { return actTokens[i] < actTokens[j] })
+	slices.Sort(expTokens)
+	slices.Sort(actTokens)
 	for i := 0; i < 512; i++ {
 		require.Equal(t, expTokens, actTokens)
 	}

--- a/pkg/storage/tsdb/multilevel_cache.go
+++ b/pkg/storage/tsdb/multilevel_cache.go
@@ -3,6 +3,7 @@ package tsdb
 import (
 	"context"
 	"errors"
+	"slices"
 
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -11,7 +12,6 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/thanos-io/thanos/pkg/cacheutil"
 	storecache "github.com/thanos-io/thanos/pkg/store/cache"
-	"golang.org/x/exp/slices"
 )
 
 type multiLevelCache struct {

--- a/pkg/storage/tsdb/users_scanner_test.go
+++ b/pkg/storage/tsdb/users_scanner_test.go
@@ -3,12 +3,12 @@ package tsdb
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
 )


### PR DESCRIPTION
**What this PR does**:

The experimental functions in `golang.org/x/exp/slices` are now available in the standard library in Go 1.21.

Reference: https://go.dev/doc/go1.21#slices

**Which issue(s) this PR fixes**:


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
