### PR TITLE
ruler/decoder: ensure labels order

### DIFF
--- a/pkg/ruler/frontend_decoder.go
+++ b/pkg/ruler/frontend_decoder.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -82,6 +83,9 @@ func (j JsonDecoder) vectorToPromQLVector(vector model.Vector) promql.Vector {
 				Value: string(v),
 			})
 		}
+		sort.Slice(metric, func(i, j int) bool {
+			return metric[i].Name < metric[j].Name
+		})
 		v = append(v, promql.Sample{
 			T:      int64(sample.Timestamp),
 			F:      float64(sample.Value),

--- a/pkg/ruler/frontend_decoder_test.go
+++ b/pkg/ruler/frontend_decoder_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -12,6 +13,28 @@ import (
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 )
+
+func TestDecodeLabelOrder(t *testing.T) {
+	j := JsonDecoder{}
+
+	decoded := j.vectorToPromQLVector(
+		model.Vector{
+			{
+				Metric: model.Metric{
+					"foo": "bar",
+					"a":   "b",
+					"b":   "b",
+				},
+				Timestamp: 1724146338123,
+				Value:     1.234,
+			},
+		},
+	)
+	require.Equal(t, 1, len(decoded))
+	require.Equal(t, int64(1724146338123), decoded[0].T)
+	require.Equal(t, 1.234, decoded[0].F)
+	require.Equal(t, labels.FromStrings("a", "b", "b", "b", "foo", "bar"), decoded[0].Metric)
+}
 
 func TestProtoDecode(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Ensure that the labels are in order because we are iterating over map[string]string which has a random sorting order. I think the consequence of not sorting this is that when using a frontend directly, the write requests might have unsorted labels in them.
