### PR TITLE
Fix NH comparer when Count is NaN

### DIFF
--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -967,7 +967,7 @@ var comparer = cmp.Comparer(func(x, y model.Value) bool {
 	}
 
 	compareHistograms := func(l, r *model.SampleHistogram) bool {
-		return l == r || (l.Count == r.Count && compareFloats(float64(l.Sum), float64(r.Sum)) && compareHistogramBuckets(l.Buckets, r.Buckets))
+		return l == r || (compareFloats(float64(l.Count), float64(r.Count)) && compareFloats(float64(l.Sum), float64(r.Sum)) && compareHistogramBuckets(l.Buckets, r.Buckets))
 	}
 
 	// count_values returns a metrics with one label {"value": "1.012321"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR fixes native histogram comparer. The current comparer fails when the `Count` is NaN.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
