### PR TITLE
Create a `noOpInterner` in case string interning is disabled

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2386,7 +2386,7 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 
 		instanceLimitsFn:             i.getInstanceLimits,
 		instanceSeriesCount:          &i.TSDBState.seriesCount,
-		interner:                     util.NewLruInterner(),
+		interner:                     util.NewLruInterner(i.cfg.LabelsStringInterningEnabled),
 		labelsStringInterningEnabled: i.cfg.LabelsStringInterningEnabled,
 
 		blockRetentionPeriod: i.cfg.BlocksStorageConfig.TSDB.Retention.Milliseconds(),

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -157,10 +157,19 @@ type Interner interface {
 
 // NewLruInterner returns a new Interner to be used to intern strings.
 // The interner will use a LRU cache to return the deduplicated strings
-func NewLruInterner() Interner {
+func NewLruInterner(enabled bool) Interner {
+	if !enabled {
+		return &noOpInterner{}
+	}
 	return &pool{
 		lru: expirable.NewLRU[string, string](maxInternerLruCacheSize, nil, internerLruCacheTTL),
 	}
+}
+
+type noOpInterner struct{}
+
+func (n noOpInterner) Intern(s string) string {
+	return s
 }
 
 type pool struct {


### PR DESCRIPTION
**What this PR does**:

Create `noOpInterner` in case string interning is disabled.

This prevent some go routines to be created by the LRU cache.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [NA] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
