### PR TITLE
Validate tenantID on single resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 * [CHANGE] StoreGateway/Alertmanager: Add default 5s connection timeout on client. #6603
+* [CHANGE] Validate a tenantID when to use a single tenant resolver. #6727
 * [FEATURE] Query Frontend: Add dynamic interval size for query splitting. This is enabled by configuring experimental flags `querier.max-shards-per-query` and/or `querier.max-fetched-data-duration-per-query`. The split interval size is dynamically increased to maintain a number of shards and total duration fetched below the configured values. #6458
 * [FEATURE] Querier/Ruler: Add `query_partial_data` and `rules_partial_data` limits to allow queries/rules to be evaluated with data from a single zone, if other zones are not available. #6526
 * [FEATURE] Update prometheus alertmanager version to v0.28.0 and add new integration msteamsv2, jira, and rocketchat. #6590

--- a/pkg/tenant/resolver.go
+++ b/pkg/tenant/resolver.go
@@ -2,7 +2,6 @@ package tenant
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"strings"
 
@@ -67,14 +66,8 @@ type SingleResolver struct {
 // `\` can be found.
 func containsUnsafePathSegments(id string) bool {
 	// handle the relative reference to current and parent path.
-	if id == "." || id == ".." {
-		return true
-	}
-
-	return strings.ContainsAny(id, "\\/")
+	return id == "." || id == ".."
 }
-
-var errInvalidTenantID = errors.New("invalid tenant ID")
 
 func (t *SingleResolver) TenantID(ctx context.Context) (string, error) {
 	//lint:ignore faillint wrapper around upstream method
@@ -83,8 +76,8 @@ func (t *SingleResolver) TenantID(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	if containsUnsafePathSegments(id) {
-		return "", errInvalidTenantID
+	if err := ValidTenantID(id); err != nil {
+		return "", err
 	}
 
 	return id, nil
@@ -133,9 +126,6 @@ func (t *MultiResolver) TenantIDs(ctx context.Context) ([]string, error) {
 	for _, orgID := range orgIDs {
 		if err := ValidTenantID(orgID); err != nil {
 			return nil, err
-		}
-		if containsUnsafePathSegments(orgID) {
-			return nil, errInvalidTenantID
 		}
 	}
 

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	errTenantIDTooLong = errors.New("tenant ID is too long: max 150 characters")
+	errTenantIDUnsafe  = errors.New("tenant ID is '.' or '..'")
 )
 
 type errTenantIDUnsupportedCharacter struct {
@@ -63,6 +64,10 @@ func ValidTenantID(s string) error {
 
 	if len(s) > 150 {
 		return errTenantIDTooLong
+	}
+
+	if containsUnsafePathSegments(s) {
+		return errTenantIDUnsafe
 	}
 
 	return nil

--- a/pkg/tenant/tenant_test.go
+++ b/pkg/tenant/tenant_test.go
@@ -29,6 +29,14 @@ func TestValidTenantIDs(t *testing.T) {
 			name: strings.Repeat("a", 151),
 			err:  strptr("tenant ID is too long: max 150 characters"),
 		},
+		{
+			name: ".",
+			err:  strptr("tenant ID is '.' or '..'"),
+		},
+		{
+			name: "..",
+			err:  strptr("tenant ID is '.' or '..'"),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidTenantID(tc.name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

Currently, a tenantID validation has been applied only for the MultiResolver.
This PR adds a validation of the tenantID to the single resolver. The validation rules follow the [docs](https://cortexmetrics.io/docs/guides/limitations/).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [NA] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
