### PR TITLE
Fix flaky TestSchedulerShutdown_FrontendLoop

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -267,7 +267,7 @@ func TestSchedulerShutdown_FrontendLoop(t *testing.T) {
 	frontendLoop := initFrontendLoop(t, frontendClient, "frontend-12345")
 
 	// Stop the scheduler. This will disable receiving new requests from frontends.
-	scheduler.StopAsync()
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), scheduler))
 
 	// We can still send request to scheduler, but we get shutdown error back.
 	require.NoError(t, frontendLoop.Send(&schedulerpb.FrontendToScheduler{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR fixes the flaky `TestSchedulerShutdown_FrontendLoop` test. It should ensure the scheduler has been terminated.
Failed test logs:
```
--- FAIL: TestSchedulerShutdown_FrontendLoop (0.00s)
    scheduler_test.go:282: 
        	Error Trace:	/__w/cortex/cortex/pkg/scheduler/scheduler_test.go:282
        	Error:      	Should be true
        	Test:       	TestSchedulerShutdown_FrontendLoop
FAIL
```

**Which issue(s) this PR fixes**:
Fixes #6724 

**Checklist**
- [x] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
