### PR TITLE
ci: Upgrade golangci-linter to v2

### DIFF
--- a/.errcheck-exclude
+++ b/.errcheck-exclude
@@ -1,6 +1,0 @@
-io/ioutil.WriteFile
-io/ioutil.ReadFile
-(github.com/go-kit/log.Logger).Log
-io.Copy
-(github.com/opentracing/opentracing-go.Tracer).Inject
-(*github.com/cortexproject/cortex/pkg/util/spanlogger.SpanLogger).Error

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/cortexproject/build-image:master-281284ac1
+      image: quay.io/cortexproject/build-image:master-7ce1d1b12
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -46,7 +46,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/cortexproject/build-image:master-281284ac1
+      image: quay.io/cortexproject/build-image:master-7ce1d1b12
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -64,7 +64,7 @@ jobs:
   test-no-race:
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/cortexproject/build-image:master-281284ac1
+      image: quay.io/cortexproject/build-image:master-7ce1d1b12
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -107,7 +107,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/cortexproject/build-image:master-281284ac1
+      image: quay.io/cortexproject/build-image:master-7ce1d1b12
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -247,14 +247,14 @@ jobs:
         run: |
           touch build-image/.uptodate
           MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations
-          make BUILD_IMAGE=quay.io/cortexproject/build-image:master-281284ac1 TTY='' configs-integration-test
+          make BUILD_IMAGE=quay.io/cortexproject/build-image:master-7ce1d1b12 TTY='' configs-integration-test
 
   deploy_website:
     needs: [build, test]
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/cortexproject/build-image:master-281284ac1
+      image: quay.io/cortexproject/build-image:master-7ce1d1b12
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -296,7 +296,7 @@ jobs:
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'cortexproject/cortex'
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/cortexproject/build-image:master-281284ac1
+      image: quay.io/cortexproject/build-image:master-7ce1d1b12
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,45 +1,6 @@
-output:
-  format: line-number
-
-linters:
-  enable:
-    - goimports
-    - revive
-    - gofmt
-    - misspell
-    - depguard
-    - sloglint
-    - unused
-
-linters-settings:
-  staticcheck:
-    checks:
-      - all
-  errcheck:
-    # path to a file containing a list of functions to exclude from checking
-    # see https://github.com/kisielk/errcheck#excluding-functions for details
-    exclude: ./.errcheck-exclude
-  goimports:
-    local-prefixes: "github.com/cortexproject/cortex"
-  revive:
-    severity: error # We only want critical issues.
-  govet:
-    disable:
-      - printf
-
-  depguard:
-    rules:
-      main:
-        list-mode: lax
-        files:
-          - $all
-        deny:
-          - pkg: "github.com/go-kit/kit/log"
-            desc: Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
-
+version: "2"
 run:
   timeout: 5m
-
   # List of build tags, all linters use it.
   build-tags:
     - netgo
@@ -51,3 +12,51 @@ run:
     - integration_querier
     - integration_ruler
     - integration_query_fuzz
+output:
+  formats:
+    text:
+      path: stdout
+      colors: false
+linters:
+  enable:
+    - depguard
+    - misspell
+    - revive
+    - sloglint
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          files:
+            - $all
+          deny:
+            - pkg: github.com/go-kit/kit/log
+              desc: Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
+    errcheck:
+      exclude-functions:
+        - io/ioutil.WriteFile
+        - io/ioutil.ReadFile
+        - io.Copy
+        - (github.com/go-kit/log.Logger).Log
+        - (*github.com/cortexproject/cortex/pkg/util/spanlogger.SpanLogger).Error
+        - (github.com/opentracing/opentracing-go.Tracer).Inject
+    govet:
+      disable:
+        - printf
+    revive:
+      severity: error
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/cortexproject/cortex

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ build-image/$(UPTODATE): build-image/*
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER := true
 BUILD_IMAGE ?= $(IMAGE_PREFIX)build-image
-LATEST_BUILD_IMAGE_TAG ?= master-281284ac1
+LATEST_BUILD_IMAGE_TAG ?= master-7ce1d1b12
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -427,9 +427,10 @@ func NewHTTPReadinessProbe(port int, path string, expectedStatusRangeStart, expe
 
 func (p *HTTPReadinessProbe) Ready(service *ConcreteService) (err error) {
 	endpoint := service.Endpoint(p.port)
-	if endpoint == "" {
+	switch endpoint {
+	case "":
 		return fmt.Errorf("cannot get service endpoint for port %d", p.port)
-	} else if endpoint == "stopped" {
+	case "stopped":
 		return errors.New("service has stopped")
 	}
 
@@ -467,9 +468,10 @@ func NewTCPReadinessProbe(port int) *TCPReadinessProbe {
 
 func (p *TCPReadinessProbe) Ready(service *ConcreteService) (err error) {
 	endpoint := service.Endpoint(p.port)
-	if endpoint == "" {
+	switch endpoint {
+	case "":
 		return fmt.Errorf("cannot get service endpoint for port %d", p.port)
-	} else if endpoint == "stopped" {
+	case "stopped":
 		return errors.New("service has stopped")
 	}
 

--- a/integration/e2ecortex/services.go
+++ b/integration/e2ecortex/services.go
@@ -42,9 +42,10 @@ func NewDistributorWithConfigFile(name string, store RingStore, address, configF
 
 	// Configure the ingesters ring backend
 	flags["-ring.store"] = string(store)
-	if store == RingStoreConsul {
+	switch store {
+	case RingStoreConsul:
 		flags["-consul.hostname"] = address
-	} else if store == RingStoreEtcd {
+	case RingStoreEtcd:
 		flags["-etcd.endpoints"] = address
 	}
 
@@ -82,10 +83,11 @@ func NewQuerierWithConfigFile(name string, store RingStore, address, configFile 
 		"-store-gateway.sharding-ring.store": string(store),
 	}
 
-	if store == RingStoreConsul {
+	switch store {
+	case RingStoreConsul:
 		ringBackendFlags["-consul.hostname"] = address
 		ringBackendFlags["-store-gateway.sharding-ring.consul.hostname"] = address
-	} else if store == RingStoreEtcd {
+	case RingStoreEtcd:
 		ringBackendFlags["-etcd.endpoints"] = address
 		ringBackendFlags["-store-gateway.sharding-ring.etcd.endpoints"] = address
 	}
@@ -130,10 +132,11 @@ func NewStoreGatewayWithConfigFile(name string, store RingStore, address string,
 		flags["-config.file"] = filepath.Join(e2e.ContainerSharedDir, configFile)
 	}
 
-	if store == RingStoreConsul {
+	switch store {
+	case RingStoreConsul:
 		flags["-consul.hostname"] = address
 		flags["-store-gateway.sharding-ring.consul.hostname"] = address
-	} else if store == RingStoreEtcd {
+	case RingStoreEtcd:
 		flags["-etcd.endpoints"] = address
 		flags["-store-gateway.sharding-ring.etcd.endpoints"] = address
 	}
@@ -173,9 +176,10 @@ func NewIngesterWithConfigFile(name string, store RingStore, address, configFile
 
 	// Configure the ingesters ring backend
 	flags["-ring.store"] = string(store)
-	if store == RingStoreConsul {
+	switch store {
+	case RingStoreConsul:
 		flags["-consul.hostname"] = address
-	} else if store == RingStoreEtcd {
+	case RingStoreEtcd:
 		flags["-etcd.endpoints"] = address
 	}
 

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -171,7 +171,7 @@ func mergeResults(tenantIDs []string, resultsPerTenant []model.Vector) model.Vec
 	var v model.Vector
 	for pos, tenantID := range tenantIDs {
 		for _, r := range resultsPerTenant[pos] {
-			var s model.Sample = *r
+			var s = *r
 			s.Metric = r.Metric.Clone()
 			s.Metric[model.LabelName("__tenant_id__")] = model.LabelValue(tenantID)
 			v = append(v, &s)

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -433,9 +433,10 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 				require.NoError(t, writeFileToSharedDir(s, "alertmanager_configs/user-1.yaml", []byte(cortexAlertmanagerUserConfigYaml)))
 
 				// Add the cache address to the flags.
-				if testCfg.indexCacheBackend == tsdb.IndexCacheBackendMemcached {
+				switch testCfg.indexCacheBackend {
+				case tsdb.IndexCacheBackendMemcached:
 					flags["-blocks-storage.bucket-store.index-cache.memcached.addresses"] = "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort)
-				} else if testCfg.indexCacheBackend == tsdb.IndexCacheBackendRedis {
+				case tsdb.IndexCacheBackendRedis:
 					flags["-blocks-storage.bucket-store.index-cache.redis.addresses"] = redis.NetworkEndpoint(e2ecache.RedisPort)
 				}
 

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -765,11 +765,12 @@ func TestVerticalShardingFuzz(t *testing.T) {
 	// Generate another set of series for testing binary expression and vector matching.
 	for i := numSeries; i < 2*numSeries; i++ {
 		prompbLabels := []prompb.Label{{Name: "job", Value: "test"}, {Name: "series", Value: strconv.Itoa(i)}}
-		if i%3 == 0 {
+		switch i % 3 {
+		case 0:
 			prompbLabels = append(prompbLabels, prompb.Label{Name: "status_code", Value: "200"})
-		} else if i%3 == 1 {
+		case 1:
 			prompbLabels = append(prompbLabels, prompb.Label{Name: "status_code", Value: "400"})
-		} else {
+		default:
 			prompbLabels = append(prompbLabels, prompb.Label{Name: "status_code", Value: "500"})
 		}
 		series := e2e.GenerateSeriesWithSamples("test_series_b", start, scrapeInterval, i*numSamples, numSamples, prompbLabels...)
@@ -882,11 +883,12 @@ func TestProtobufCodecFuzz(t *testing.T) {
 	// Generate another set of series for testing binary expression and vector matching.
 	for i := numSeries; i < 2*numSeries; i++ {
 		prompbLabels := []prompb.Label{{Name: "job", Value: "test"}, {Name: "series", Value: strconv.Itoa(i)}}
-		if i%3 == 0 {
+		switch i % 3 {
+		case 0:
 			prompbLabels = append(prompbLabels, prompb.Label{Name: "status_code", Value: "200"})
-		} else if i%3 == 1 {
+		case 1:
 			prompbLabels = append(prompbLabels, prompb.Label{Name: "status_code", Value: "400"})
-		} else {
+		default:
 			prompbLabels = append(prompbLabels, prompb.Label{Name: "status_code", Value: "500"})
 		}
 		series := e2e.GenerateSeriesWithSamples("test_series_b", start, scrapeInterval, i*numSamples, numSamples, prompbLabels...)
@@ -1578,11 +1580,12 @@ func TestBackwardCompatibilityQueryFuzz(t *testing.T) {
 	// Generate another set of series for testing binary expression and vector matching.
 	for i := numSeries; i < 2*numSeries; i++ {
 		prompbLabels := []prompb.Label{{Name: "job", Value: "test"}, {Name: "series", Value: strconv.Itoa(i)}}
-		if i%3 == 0 {
+		switch i % 3 {
+		case 0:
 			prompbLabels = append(prompbLabels, prompb.Label{Name: "status_code", Value: "200"})
-		} else if i%3 == 1 {
+		case 1:
 			prompbLabels = append(prompbLabels, prompb.Label{Name: "status_code", Value: "400"})
-		} else {
+		default:
 			prompbLabels = append(prompbLabels, prompb.Label{Name: "status_code", Value: "500"})
 		}
 		series := e2e.GenerateSeriesWithSamples("test_series_b", start, scrapeInterval, i*numSamples, numSamples, prompbLabels...)

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -76,10 +76,10 @@ func (am *MultitenantAlertmanager) GetUserConfig(w http.ResponseWriter, r *http.
 
 	cfg, err := am.store.GetAlertConfig(r.Context(), userID)
 	if err != nil {
-		switch {
-		case err == alertspb.ErrNotFound:
+		switch err {
+		case alertspb.ErrNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
-		case err == alertspb.ErrAccessDenied:
+		case alertspb.ErrAccessDenied:
 			http.Error(w, err.Error(), http.StatusForbidden)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -610,10 +610,8 @@ receivers:
 				// Ensure the server endpoint has not been called if firewall is enabled. Since the alert is delivered
 				// asynchronously, we should pool it for a short period.
 				deadline := time.Now().Add(3 * time.Second)
-				for {
-					if time.Now().After(deadline) || serverInvoked.Load() {
-						break
-					}
+				for !time.Now().After(deadline) && !serverInvoked.Load() {
+
 					time.Sleep(100 * time.Millisecond)
 				}
 

--- a/pkg/alertmanager/rate_limited_notifier_test.go
+++ b/pkg/alertmanager/rate_limited_notifier_test.go
@@ -47,12 +47,13 @@ func runNotifications(t *testing.T, rateLimitedNotifier *rateLimitedNotifier, co
 	for i := 0; i < count; i++ {
 		retry, err := rateLimitedNotifier.Notify(context.Background(), &types.Alert{})
 
-		if err == nil {
+		switch err {
+		case nil:
 			success++
-		} else if err == errRateLimited {
+		case errRateLimited:
 			rateLimited++
 			assert.False(t, retry)
-		} else {
+		default:
 			assert.NotNil(t, err)
 		}
 	}

--- a/pkg/alertmanager/state_persister_test.go
+++ b/pkg/alertmanager/state_persister_test.go
@@ -105,7 +105,7 @@ func TestStatePersister_Position0ShouldWrite(t *testing.T) {
 	{
 		time.Sleep(5 * time.Second)
 
-		assert.Equal(t, services.Starting, s.Service.State())
+		assert.Equal(t, services.Starting, s.State())
 		assert.Equal(t, 0, len(store.getWrites()))
 	}
 
@@ -139,13 +139,13 @@ func TestStatePersister_Position1ShouldNotWrite(t *testing.T) {
 
 	// Start the persister.
 	{
-		require.Equal(t, services.Starting, s.Service.State())
+		require.Equal(t, services.Starting, s.State())
 
 		state.getResult = makeTestFullState()
 		close(state.readyc)
 
 		require.NoError(t, s.AwaitRunning(context.Background()))
-		require.Equal(t, services.Running, s.Service.State())
+		require.Equal(t, services.Running, s.State())
 	}
 
 	// Should not have stored anything, having passed the interval multiple times.

--- a/pkg/alertmanager/state_replication.go
+++ b/pkg/alertmanager/state_replication.go
@@ -254,11 +254,11 @@ func (s *state) starting(ctx context.Context) error {
 
 // WaitReady is needed for the pipeline builder to know whenever we've settled and the state is up to date.
 func (s *state) WaitReady(ctx context.Context) error {
-	return s.Service.AwaitRunning(ctx)
+	return s.AwaitRunning(ctx)
 }
 
 func (s *state) Ready() bool {
-	return s.Service.State() == services.Running
+	return s.State() == services.Running
 }
 
 // mergeFullStates attempts to merge all full states received from peers during settling.

--- a/pkg/chunk/cache/memcached_client.go
+++ b/pkg/chunk/cache/memcached_client.go
@@ -141,7 +141,7 @@ func NewMemcachedClient(cfg MemcachedClientConfig, name string, r prometheus.Reg
 		}),
 	}
 	if cfg.CBFailures > 0 {
-		newClient.Client.DialContext = newClient.dialViaCircuitBreaker
+		newClient.DialContext = newClient.dialViaCircuitBreaker
 	}
 
 	if len(cfg.Addresses) > 0 {

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -271,11 +270,11 @@ func testBlocksCleanerWithOptions(t *testing.T, options testBlocksCleanerOptions
 		assert.Equal(t, tc.expectedExists, exists, tc.user)
 	}
 
-	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsStarted.WithLabelValues(activeStatus)))
-	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsCompleted.WithLabelValues(activeStatus)))
-	assert.Equal(t, float64(0), testutil.ToFloat64(cleaner.runsFailed.WithLabelValues(activeStatus)))
-	assert.Equal(t, float64(7), testutil.ToFloat64(cleaner.blocksCleanedTotal))
-	assert.Equal(t, float64(0), testutil.ToFloat64(cleaner.blocksFailedTotal))
+	assert.Equal(t, float64(1), prom_testutil.ToFloat64(cleaner.runsStarted.WithLabelValues(activeStatus)))
+	assert.Equal(t, float64(1), prom_testutil.ToFloat64(cleaner.runsCompleted.WithLabelValues(activeStatus)))
+	assert.Equal(t, float64(0), prom_testutil.ToFloat64(cleaner.runsFailed.WithLabelValues(activeStatus)))
+	assert.Equal(t, float64(7), prom_testutil.ToFloat64(cleaner.blocksCleanedTotal))
+	assert.Equal(t, float64(0), prom_testutil.ToFloat64(cleaner.blocksFailedTotal))
 
 	// Check the updated bucket index.
 	for _, tc := range []struct {
@@ -412,11 +411,11 @@ func TestBlocksCleaner_ShouldContinueOnBlockDeletionFailure(t *testing.T) {
 		assert.Equal(t, tc.expectedExists, exists, tc.path)
 	}
 
-	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsStarted.WithLabelValues(activeStatus)))
-	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsCompleted.WithLabelValues(activeStatus)))
-	assert.Equal(t, float64(0), testutil.ToFloat64(cleaner.runsFailed.WithLabelValues(activeStatus)))
-	assert.Equal(t, float64(2), testutil.ToFloat64(cleaner.blocksCleanedTotal))
-	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.blocksFailedTotal))
+	assert.Equal(t, float64(1), prom_testutil.ToFloat64(cleaner.runsStarted.WithLabelValues(activeStatus)))
+	assert.Equal(t, float64(1), prom_testutil.ToFloat64(cleaner.runsCompleted.WithLabelValues(activeStatus)))
+	assert.Equal(t, float64(0), prom_testutil.ToFloat64(cleaner.runsFailed.WithLabelValues(activeStatus)))
+	assert.Equal(t, float64(2), prom_testutil.ToFloat64(cleaner.blocksCleanedTotal))
+	assert.Equal(t, float64(1), prom_testutil.ToFloat64(cleaner.blocksFailedTotal))
 
 	// Check the updated bucket index.
 	idx, err := bucketindex.ReadIndex(ctx, bucketClient, userID, nil, logger)
@@ -480,11 +479,11 @@ func TestBlocksCleaner_ShouldRebuildBucketIndexOnCorruptedOne(t *testing.T) {
 		assert.Equal(t, tc.expectedExists, exists, tc.path)
 	}
 
-	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsStarted.WithLabelValues(activeStatus)))
-	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.runsCompleted.WithLabelValues(activeStatus)))
-	assert.Equal(t, float64(0), testutil.ToFloat64(cleaner.runsFailed.WithLabelValues(activeStatus)))
-	assert.Equal(t, float64(1), testutil.ToFloat64(cleaner.blocksCleanedTotal))
-	assert.Equal(t, float64(0), testutil.ToFloat64(cleaner.blocksFailedTotal))
+	assert.Equal(t, float64(1), prom_testutil.ToFloat64(cleaner.runsStarted.WithLabelValues(activeStatus)))
+	assert.Equal(t, float64(1), prom_testutil.ToFloat64(cleaner.runsCompleted.WithLabelValues(activeStatus)))
+	assert.Equal(t, float64(0), prom_testutil.ToFloat64(cleaner.runsFailed.WithLabelValues(activeStatus)))
+	assert.Equal(t, float64(1), prom_testutil.ToFloat64(cleaner.blocksCleanedTotal))
+	assert.Equal(t, float64(0), prom_testutil.ToFloat64(cleaner.blocksFailedTotal))
 
 	// Check the updated bucket index.
 	idx, err := bucketindex.ReadIndex(ctx, bucketClient, userID, nil, logger)

--- a/pkg/compactor/cleaner_visit_marker.go
+++ b/pkg/compactor/cleaner_visit_marker.go
@@ -36,7 +36,7 @@ func (b *CleanerVisitMarker) IsExpired(cleanerVisitMarkerTimeout time.Duration) 
 }
 
 func (b *CleanerVisitMarker) IsVisited(cleanerVisitMarkerTimeout time.Duration) bool {
-	return !(b.GetStatus() == Completed) && !(b.GetStatus() == Failed) && !b.IsExpired(cleanerVisitMarkerTimeout)
+	return !(b.GetStatus() == Completed) && !(b.GetStatus() == Failed) && !b.IsExpired(cleanerVisitMarkerTimeout) //nolint:staticcheck
 }
 
 func (b *CleanerVisitMarker) GetStatus() VisitStatus {

--- a/pkg/compactor/partition_compaction_grouper.go
+++ b/pkg/compactor/partition_compaction_grouper.go
@@ -820,7 +820,7 @@ func NewCompletenessChecker(blocks map[ulid.ULID]*metadata.Meta, groups []blocks
 					}
 				}
 			}
-			status.canTakeCompaction = !(previousTrBlocks == 0 || (previousTrBlocks == 1 && status.numActiveBlocks == 0))
+			status.canTakeCompaction = !(previousTrBlocks == 0 || (previousTrBlocks == 1 && status.numActiveBlocks == 0)) //nolint:staticcheck
 		}
 		previousTimeRanges = append(previousTimeRanges, tr)
 	}

--- a/pkg/compactor/shuffle_sharding_grouper.go
+++ b/pkg/compactor/shuffle_sharding_grouper.go
@@ -508,6 +508,6 @@ func getRangeStart(m *metadata.Meta, tr int64) int64 {
 
 func sortMetasByMinTime(metas []*metadata.Meta) {
 	sort.Slice(metas, func(i, j int) bool {
-		return metas[i].BlockMeta.MinTime < metas[j].BlockMeta.MinTime
+		return metas[i].MinTime < metas[j].MinTime
 	})
 }

--- a/pkg/configs/client/client.go
+++ b/pkg/configs/client/client.go
@@ -150,7 +150,7 @@ func doRequest(endpoint string, timeout time.Duration, tlsConfig *tls.Config, si
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Invalid response from configs server: %v", resp.StatusCode)
+		return nil, fmt.Errorf("invalid response from configs server: %v", resp.StatusCode)
 	}
 
 	var config ConfigsResponse

--- a/pkg/configs/db/dbtest/integration.go
+++ b/pkg/configs/db/dbtest/integration.go
@@ -19,7 +19,7 @@ var (
 	done          chan error
 	dbAddr        string
 	migrationsDir string
-	errRollback   = fmt.Errorf("Rolling back test data")
+	errRollback   = fmt.Errorf("rolling back test data")
 )
 
 func init() {

--- a/pkg/configs/db/postgres/postgres.go
+++ b/pkg/configs/db/postgres/postgres.go
@@ -215,7 +215,7 @@ func (d DB) SetRulesConfig(ctx context.Context, userID string, oldConfig, newCon
 		// The supplied oldConfig must match the current config. If no config
 		// exists, then oldConfig must be nil. Otherwise, it must exactly
 		// equal the existing config.
-		if !((err == sql.ErrNoRows && oldConfig.Files == nil) || oldConfig.Equal(current.Config.RulesConfig)) {
+		if !((err == sql.ErrNoRows && oldConfig.Files == nil) || oldConfig.Equal(current.Config.RulesConfig)) { //nolint:staticcheck
 			return nil
 		}
 		new := userconfig.Config{

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3349,12 +3349,12 @@ func (i *mockIngester) Push(ctx context.Context, req *cortexpb.WriteRequest, opt
 		if !ok {
 			// Make a copy because the request Timeseries are reused
 			item := cortexpb.TimeSeries{
-				Labels:  make([]cortexpb.LabelAdapter, len(series.TimeSeries.Labels)),
-				Samples: make([]cortexpb.Sample, len(series.TimeSeries.Samples)),
+				Labels:  make([]cortexpb.LabelAdapter, len(series.Labels)),
+				Samples: make([]cortexpb.Sample, len(series.Samples)),
 			}
 
-			copy(item.Labels, series.TimeSeries.Labels)
-			copy(item.Samples, series.TimeSeries.Samples)
+			copy(item.Labels, series.Labels)
+			copy(item.Samples, series.Samples)
 
 			i.timeseries[hash] = &cortexpb.PreallocTimeseries{TimeSeries: &item}
 		} else {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -3218,7 +3218,7 @@ func (i *Ingester) flushHandler(w http.ResponseWriter, r *http.Request) {
 
 	allowedUsers := util.NewAllowedTenants(tenants, nil)
 	run := func() {
-		ingCtx := i.BasicService.ServiceContext()
+		ingCtx := i.ServiceContext()
 		if ingCtx == nil || ingCtx.Err() != nil {
 			level.Info(logutil.WithContext(r.Context(), i.logger)).Log("msg", "flushing TSDB blocks: ingester not running, ignoring flush request")
 			return

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -7081,7 +7081,7 @@ func CreateBlock(t *testing.T, ctx context.Context, dir string, mint, maxt int64
 
 type panickingMatchersCache struct{}
 
-func (_ *panickingMatchersCache) GetOrSet(_ storecache.ConversionLabelMatcher, _ storecache.NewItemFunc) (*labels.Matcher, error) {
+func (*panickingMatchersCache) GetOrSet(_ storecache.ConversionLabelMatcher, _ storecache.NewItemFunc) (*labels.Matcher, error) {
 	var a []int
 	a[1] = 2 // index out of range
 	return nil, nil

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -344,7 +344,7 @@ func (q *blocksStoreQuerier) LabelNames(ctx context.Context, hints *storage.Labe
 	}
 
 	spanLog, spanCtx := spanlogger.New(ctx, "blocksStoreQuerier.LabelNames")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	minT, maxT, limit := q.minT, q.maxT, int64(0)
 
@@ -387,7 +387,7 @@ func (q *blocksStoreQuerier) LabelValues(ctx context.Context, name string, hints
 	}
 
 	spanLog, spanCtx := spanlogger.New(ctx, "blocksStoreQuerier.LabelValues")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	minT, maxT, limit := q.minT, q.maxT, int64(0)
 
@@ -434,7 +434,7 @@ func (q *blocksStoreQuerier) selectSorted(ctx context.Context, sp *storage.Selec
 	}
 
 	spanLog, spanCtx := spanlogger.New(ctx, "blocksStoreQuerier.selectSorted")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	minT, maxT, limit := q.minT, q.maxT, int64(0)
 	if sp != nil {

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -2485,9 +2485,10 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 						// Check sample timestamp is expected.
 						require.Equal(t, h.T, int64(from)+int64(i)*15000)
 						expectedH := tsdbutil.GenerateTestGaugeFloatHistogram(h.T)
-						if enc == encoding.PrometheusHistogramChunk {
+						switch enc {
+						case encoding.PrometheusHistogramChunk:
 							require.Equal(t, expectedH, h.H)
-						} else if enc == encoding.PrometheusFloatHistogramChunk {
+						case encoding.PrometheusFloatHistogramChunk:
 							require.Equal(t, expectedH, h.H)
 						}
 					}

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -98,7 +98,7 @@ type distributorQuerier struct {
 // The bool passed is ignored because the series is always sorted.
 func (q *distributorQuerier) Select(ctx context.Context, sortSeries bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 	log, ctx := spanlogger.New(ctx, "distributorQuerier.Select")
-	defer log.Span.Finish()
+	defer log.Finish()
 
 	minT, maxT := q.mint, q.maxt
 	if sp != nil {
@@ -263,7 +263,7 @@ func (q *distributorQuerier) LabelNames(ctx context.Context, hints *storage.Labe
 	}
 
 	log, ctx := spanlogger.New(ctx, "distributorQuerier.LabelNames")
-	defer log.Span.Finish()
+	defer log.Finish()
 
 	var (
 		ln  []string
@@ -318,7 +318,7 @@ func (q *distributorQuerier) labelsWithRetry(ctx context.Context, labelsFunc fun
 // labelNamesWithMatchers performs the LabelNames call by calling ingester's MetricsForLabelMatchers method
 func (q *distributorQuerier) labelNamesWithMatchers(ctx context.Context, hints *storage.LabelHints, partialDataEnabled bool, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	log, ctx := spanlogger.New(ctx, "distributorQuerier.labelNamesWithMatchers")
-	defer log.Span.Finish()
+	defer log.Finish()
 
 	var (
 		ms  []labels.Labels

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -314,7 +314,8 @@ func TestDistributorQuerier_Retry(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			d := &MockDistributor{}
 
-			if tc.api == "Select" {
+			switch tc.api {
+			case "Select":
 				promChunk := util.GenerateChunk(t, time.Second, model.TimeFromUnix(time.Now().Unix()), 10, promchunk.PrometheusXorChunk)
 				clientChunks, err := chunkcompat.ToChunks([]chunk.Chunk{promChunk})
 				require.NoError(t, err)
@@ -331,13 +332,13 @@ func TestDistributorQuerier_Retry(t *testing.T) {
 						},
 					}, err).Once()
 				}
-			} else if tc.api == "LabelNames" {
+			case "LabelNames":
 				res := []string{"foo"}
 				for _, err := range tc.errors {
 					d.On("LabelNamesStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(res, err).Once()
 					d.On("LabelNames", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(res, err).Once()
 				}
-			} else if tc.api == "LabelValues" {
+			case "LabelValues":
 				res := []string{"foo"}
 				for _, err := range tc.errors {
 					d.On("LabelValuesForLabelNameStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(res, err).Once()
@@ -366,9 +367,10 @@ func TestDistributorQuerier_Retry(t *testing.T) {
 			} else {
 				var annots annotations.Annotations
 				var err error
-				if tc.api == "LabelNames" {
+				switch tc.api {
+				case "LabelNames":
 					_, annots, err = querier.LabelNames(ctx, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
-				} else if tc.api == "LabelValues" {
+				case "LabelValues":
 					_, annots, err = querier.LabelValues(ctx, "foo", nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 				}
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -378,7 +378,7 @@ func (q querier) Select(ctx context.Context, sortSeries bool, sp *storage.Select
 	}()
 
 	log, ctx := spanlogger.New(ctx, "querier.Select")
-	defer log.Span.Finish()
+	defer log.Finish()
 
 	if sp != nil {
 		level.Debug(log).Log("start", util.TimeFromMillis(sp.Start).UTC().String(), "end", util.TimeFromMillis(sp.End).UTC().String(), "step", sp.Step, "matchers", matchers)

--- a/pkg/querier/tenantfederation/exemplar_merge_queryable.go
+++ b/pkg/querier/tenantfederation/exemplar_merge_queryable.go
@@ -140,7 +140,7 @@ type exemplarSelectJob struct {
 // Select returns aggregated exemplars within given time range for multiple tenants.
 func (m mergeExemplarQuerier) Select(start, end int64, matchers ...[]*labels.Matcher) ([]exemplar.QueryResult, error) {
 	log, ctx := spanlogger.New(m.ctx, "mergeExemplarQuerier.Select")
-	defer log.Span.Finish()
+	defer log.Finish()
 
 	// filter out tenants to query and unrelated matchers
 	allMatchedTenantIds, allUnrelatedMatchers := filterAllTenantsAndMatchers(m.idLabelName, m.tenantIds, matchers)

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -153,7 +153,7 @@ func (m *mergeQuerier) LabelValues(ctx context.Context, name string, hints *stor
 		return queriers[0].LabelValues(ctx, name, hints, matchers...)
 	}
 	log, _ := spanlogger.New(ctx, "mergeQuerier.LabelValues")
-	defer log.Span.Finish()
+	defer log.Finish()
 
 	matchedTenants, filteredMatchers := filterValuesByMatchers(m.idLabelName, ids, matchers...)
 
@@ -194,7 +194,7 @@ func (m *mergeQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints
 		return queriers[0].LabelNames(ctx, hints, matchers...)
 	}
 	log, _ := spanlogger.New(ctx, "mergeQuerier.LabelNames")
-	defer log.Span.Finish()
+	defer log.Finish()
 
 	matchedTenants, filteredMatchers := filterValuesByMatchers(m.idLabelName, ids, matchers...)
 
@@ -337,7 +337,7 @@ func (m *mergeQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 	}
 
 	log, ctx := spanlogger.New(ctx, "mergeQuerier.Select")
-	defer log.Span.Finish()
+	defer log.Finish()
 	matchedValues, filteredMatchers := filterValuesByMatchers(m.idLabelName, ids, matchers...)
 	var jobs = make([]interface{}, len(matchedValues))
 	var seriesSets = make([]storage.SeriesSet, len(matchedValues))

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -169,7 +169,7 @@ func (m mockTenantQuerier) Select(ctx context.Context, _ bool, sp *storage.Selec
 	}
 
 	log, _ := spanlogger.New(ctx, "mockTenantQuerier.select")
-	defer log.Span.Finish()
+	defer log.Finish()
 	var matrix model.Matrix
 
 	for _, s := range m.matrix(tenantIDs[0]) {
@@ -835,14 +835,14 @@ func TestMergeQueryable_LabelNames(t *testing.T) {
 
 			t.Run(scenario.labelNamesTestCase.name, func(t *testing.T) {
 				t.Parallel()
-				labelNames, warnings, err := querier.LabelNames(ctx, nil, scenario.labelNamesTestCase.matchers...)
-				if scenario.labelNamesTestCase.expectedQueryErr != nil {
-					require.EqualError(t, err, scenario.labelNamesTestCase.expectedQueryErr.Error())
+				labelNames, warnings, err := querier.LabelNames(ctx, nil, scenario.matchers...)
+				if scenario.expectedQueryErr != nil {
+					require.EqualError(t, err, scenario.expectedQueryErr.Error())
 				} else {
 					require.NoError(t, err)
 					assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(scenario.expectedMetrics), "cortex_querier_federated_tenants_per_query"))
-					assert.Equal(t, scenario.labelNamesTestCase.expectedLabelNames, labelNames)
-					assertEqualWarnings(t, scenario.labelNamesTestCase.expectedWarnings, warnings)
+					assert.Equal(t, scenario.expectedLabelNames, labelNames)
+					assertEqualWarnings(t, scenario.expectedWarnings, warnings)
 				}
 			})
 		})

--- a/pkg/querier/tenantfederation/metadata_merge_querier.go
+++ b/pkg/querier/tenantfederation/metadata_merge_querier.go
@@ -48,7 +48,7 @@ type metadataSelectJob struct {
 // MetricsMetadata returns aggregated metadata for multiple tenants
 func (m *mergeMetadataQuerier) MetricsMetadata(ctx context.Context, req *client.MetricsMetadataRequest) ([]scrape.MetricMetadata, error) {
 	log, ctx := spanlogger.New(ctx, "mergeMetadataQuerier.MetricsMetadata")
-	defer log.Span.Finish()
+	defer log.Finish()
 
 	tenantIds, err := tenant.TenantIDs(ctx)
 	if err != nil {

--- a/pkg/querier/tripperware/query_attribute_matcher.go
+++ b/pkg/querier/tripperware/query_attribute_matcher.go
@@ -17,7 +17,7 @@ import (
 const QueryRejectErrorMessage = "This query does not perform well and has been rejected by the service operator."
 
 func rejectQueryOrSetPriority(r *http.Request, now time.Time, lookbackDelta time.Duration, limits Limits, userStr string, rejectedQueriesPerTenant *prometheus.CounterVec) error {
-	if limits == nil || !(limits.QueryPriority(userStr).Enabled || limits.QueryRejection(userStr).Enabled) {
+	if limits == nil || (!limits.QueryPriority(userStr).Enabled && !limits.QueryRejection(userStr).Enabled) {
 		return nil
 	}
 	op := getOperation(r)

--- a/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
@@ -30,13 +30,14 @@ func TestRoundTrip(t *testing.T) {
 		middleware.AuthenticateUser.Wrap(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				var err error
-				if r.RequestURI == query {
+				switch r.RequestURI {
+				case query:
 					_, err = w.Write([]byte(responseBody))
-				} else if r.RequestURI == queryWithWarnings {
+				case queryWithWarnings:
 					_, err = w.Write([]byte(responseBodyWithWarnings))
-				} else if r.RequestURI == queryWithInfos {
+				case queryWithInfos:
 					_, err = w.Write([]byte(responseBodyWithInfos))
-				} else {
+				default:
 					_, err = w.Write([]byte("bar"))
 				}
 				if err != nil {

--- a/pkg/querier/tripperware/queryrange/results_cache.go
+++ b/pkg/querier/tripperware/queryrange/results_cache.go
@@ -544,10 +544,10 @@ func merge(extents []tripperware.Extent, acc *accumulator) ([]tripperware.Extent
 		return nil, err
 	}
 	return append(extents, tripperware.Extent{
-		Start:    acc.Extent.Start,
-		End:      acc.Extent.End,
+		Start:    acc.Start,
+		End:      acc.End,
 		Response: any,
-		TraceId:  acc.Extent.TraceId,
+		TraceId:  acc.TraceId,
 	}), nil
 }
 

--- a/pkg/ring/kv/consul/client.go
+++ b/pkg/ring/kv/consul/client.go
@@ -30,9 +30,6 @@ const (
 var (
 	writeOptions = &consul.WriteOptions{}
 
-	// ErrNotFound is returned by ConsulClient.Get.
-	ErrNotFound = fmt.Errorf("Not found")
-
 	backoffConfig = backoff.Config{
 		MinBackoff: 1 * time.Second,
 		MaxBackoff: 1 * time.Minute,

--- a/pkg/ring/kv/memberlist/memberlist_client_test.go
+++ b/pkg/ring/kv/memberlist/memberlist_client_test.go
@@ -1324,10 +1324,8 @@ func poll(t testing.TB, d time.Duration, want interface{}, have func() interface
 	t.Helper()
 
 	deadline := time.Now().Add(d)
-	for {
-		if time.Now().After(deadline) {
-			break
-		}
+	for !time.Now().After(deadline) {
+
 		if reflect.DeepEqual(want, have()) {
 			return
 		}

--- a/pkg/ring/kv/memberlist/memberlist_logger.go
+++ b/pkg/ring/kv/memberlist/memberlist_logger.go
@@ -71,7 +71,7 @@ func (a loggerAdapter) Write(p []byte) (int, error) {
 	if msg, ok := result["msg"]; ok {
 		keyvals = append(keyvals, "msg", msg)
 	}
-	if err := a.Logger.Log(keyvals...); err != nil {
+	if err := a.Log(keyvals...); err != nil {
 		return 0, err
 	}
 	return len(p), nil

--- a/pkg/ring/lifecycler.go
+++ b/pkg/ring/lifecycler.go
@@ -392,7 +392,7 @@ func (i *Lifecycler) setPreviousState(state InstanceState) {
 	i.stateMtx.Lock()
 	defer i.stateMtx.Unlock()
 
-	if !(state == ACTIVE || state == READONLY) {
+	if !(state == ACTIVE || state == READONLY) { //nolint:staticcheck
 		level.Error(i.logger).Log("msg", "cannot store unsupported state to disk", "new_state", state, "old_state", i.tokenFile.PreviousState)
 		return
 	}
@@ -449,7 +449,7 @@ func (i *Lifecycler) ClaimTokensFor(ctx context.Context, ingesterID string) erro
 		claimTokens := func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc, ok := in.(*Desc)
 			if !ok || ringDesc == nil {
-				return nil, false, fmt.Errorf("Cannot claim tokens in an empty ring")
+				return nil, false, fmt.Errorf("cannot claim tokens in an empty ring")
 			}
 
 			tokens = ringDesc.ClaimTokens(ingesterID, i.ID)
@@ -1025,6 +1025,7 @@ func (i *Lifecycler) updateConsul(ctx context.Context) error {
 func (i *Lifecycler) changeState(ctx context.Context, state InstanceState) error {
 	currState := i.GetState()
 	// Only the following state transitions can be triggered externally
+	//nolint:staticcheck
 	if !((currState == PENDING && state == JOINING) ||
 		(currState == JOINING && state == PENDING) ||
 		(currState == JOINING && state == ACTIVE) ||
@@ -1035,7 +1036,7 @@ func (i *Lifecycler) changeState(ctx context.Context, state InstanceState) error
 		(currState == ACTIVE && state == READONLY) || // triggered by ingester mode
 		(currState == READONLY && state == ACTIVE) || // triggered by ingester mode
 		(currState == READONLY && state == LEAVING)) { // triggered by shutdown
-		return fmt.Errorf("Changing instance state from %v -> %v is disallowed", currState, state)
+		return fmt.Errorf("changing instance state from %v -> %v is disallowed", currState, state)
 	}
 
 	level.Info(i.logger).Log("msg", "changing instance state from", "old_state", currState, "new_state", state, "ring", i.RingName)

--- a/pkg/ring/util.go
+++ b/pkg/ring/util.go
@@ -177,7 +177,7 @@ func getFirstAddressOf(names []string, logger log.Logger) (string, error) {
 		return ipAddr, nil
 	}
 	if ipAddr == "" {
-		return "", fmt.Errorf("No address found for %s", names)
+		return "", fmt.Errorf("no address found for %s", names)
 	}
 	if strings.HasPrefix(ipAddr, `169.254.`) {
 		level.Warn(logger).Log("msg", "using automatic private ip", "address", ipAddr)

--- a/pkg/ruler/frontend_client.go
+++ b/pkg/ruler/frontend_client.go
@@ -89,7 +89,7 @@ func (p *FrontendClient) makeRequest(ctx context.Context, qs string, ts time.Tim
 
 func (p *FrontendClient) InstantQuery(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
 	log, ctx := spanlogger.New(ctx, "FrontendClient.InstantQuery")
-	defer log.Span.Finish()
+	defer log.Finish()
 
 	req, err := p.makeRequest(ctx, qs, t)
 	if err != nil {

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -1806,8 +1806,8 @@ func getRulesHATest(replicationFactor int) func(t *testing.T) {
 		// Wait a bit to make sure ruler's ring is updated.
 		time.Sleep(100 * time.Millisecond)
 
-		rulerAddrMap["ruler1"].Service.StopAsync()
-		if err := rulerAddrMap["ruler1"].Service.AwaitTerminated(context.Background()); err != nil {
+		rulerAddrMap["ruler1"].StopAsync()
+		if err := rulerAddrMap["ruler1"].AwaitTerminated(context.Background()); err != nil {
 			t.Errorf("ruler %s was not terminated with error %s", "ruler1", err.Error())
 		}
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -213,10 +213,10 @@ func (s *Scheduler) FrontendLoop(frontend schedulerpb.SchedulerForFrontend_Front
 		switch msg.GetType() {
 		case schedulerpb.ENQUEUE:
 			err = s.enqueueRequest(frontendCtx, frontendAddress, msg)
-			switch {
-			case err == nil:
+			switch err {
+			case nil:
 				resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
-			case err == queue.ErrTooManyRequests:
+			case queue.ErrTooManyRequests:
 				resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.TOO_MANY_REQUESTS_PER_TENANT}
 			default:
 				resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.ERROR, Error: err.Error()}

--- a/pkg/storage/tsdb/bucketindex/storage_test.go
+++ b/pkg/storage/tsdb/bucketindex/storage_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	"github.com/cortexproject/cortex/pkg/storage/bucket/s3"
 
-	"github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"
 	cortex_testutil "github.com/cortexproject/cortex/pkg/storage/tsdb/testutil"
 )
 
@@ -64,9 +63,9 @@ func TestReadIndex_ShouldReturnTheParsedIndexOnSuccess(t *testing.T) {
 
 	// Mock some blocks in the storage.
 	bkt = BucketWithGlobalMarkers(bkt)
-	testutil.MockStorageBlock(t, bkt, userID, 10, 20)
-	testutil.MockStorageBlock(t, bkt, userID, 20, 30)
-	testutil.MockStorageDeletionMark(t, bkt, userID, testutil.MockStorageBlock(t, bkt, userID, 30, 40))
+	cortex_testutil.MockStorageBlock(t, bkt, userID, 10, 20)
+	cortex_testutil.MockStorageBlock(t, bkt, userID, 20, 30)
+	cortex_testutil.MockStorageDeletionMark(t, bkt, userID, cortex_testutil.MockStorageBlock(t, bkt, userID, 30, 40))
 
 	// Write the index.
 	u := NewUpdater(bkt, userID, nil, logger)
@@ -120,10 +119,10 @@ func BenchmarkReadIndex(b *testing.B) {
 		minT := int64(i * 10)
 		maxT := int64((i + 1) * 10)
 
-		block := testutil.MockStorageBlock(b, bkt, userID, minT, maxT)
+		block := cortex_testutil.MockStorageBlock(b, bkt, userID, minT, maxT)
 
 		if i < numBlockDeletionMarks {
-			testutil.MockStorageDeletionMark(b, bkt, userID, block)
+			cortex_testutil.MockStorageDeletionMark(b, bkt, userID, block)
 		}
 	}
 

--- a/pkg/storage/tsdb/caching_bucket.go
+++ b/pkg/storage/tsdb/caching_bucket.go
@@ -134,7 +134,7 @@ func (cfg *ChunksCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix st
 	f.DurationVar(&cfg.SubrangeTTL, prefix+"subrange-ttl", 24*time.Hour, "TTL for caching individual chunks subranges.")
 
 	// In the multi level chunk cache, backfill TTL follows subrange TTL
-	cfg.ChunkCacheBackend.MultiLevel.BackFillTTL = cfg.SubrangeTTL
+	cfg.MultiLevel.BackFillTTL = cfg.SubrangeTTL
 }
 
 func (cfg *ChunksCacheConfig) Validate() error {

--- a/pkg/storage/tsdb/index_cache.go
+++ b/pkg/storage/tsdb/index_cache.go
@@ -92,15 +92,16 @@ func (cfg *IndexCacheConfig) Validate() error {
 			return errors.WithMessagef(errDuplicatedIndexCacheBackend, "duplicated backend: %v", backend)
 		}
 
-		if backend == IndexCacheBackendMemcached {
+		switch backend {
+		case IndexCacheBackendMemcached:
 			if err := cfg.Memcached.Validate(); err != nil {
 				return err
 			}
-		} else if backend == IndexCacheBackendRedis {
+		case IndexCacheBackendRedis:
 			if err := cfg.Redis.Validate(); err != nil {
 				return err
 			}
-		} else {
+		default:
 			if err := cfg.InMemory.Validate(); err != nil {
 				return err
 			}

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -330,7 +330,7 @@ func (u *BucketStores) syncUsersBlocks(ctx context.Context, f func(context.Conte
 // Series makes a series request to the underlying user bucket store.
 func (u *BucketStores) Series(req *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
 	spanLog, spanCtx := spanlogger.New(srv.Context(), "BucketStores.Series")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	userID := getUserIDFromGRPCContext(spanCtx)
 	if userID == "" {
@@ -391,7 +391,7 @@ func (u *BucketStores) decrementInflightRequestCnt() {
 // LabelNames implements the Storegateway proto service.
 func (u *BucketStores) LabelNames(ctx context.Context, req *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
 	spanLog, spanCtx := spanlogger.New(ctx, "BucketStores.LabelNames")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	userID := getUserIDFromGRPCContext(spanCtx)
 	if userID == "" {
@@ -421,7 +421,7 @@ func (u *BucketStores) LabelNames(ctx context.Context, req *storepb.LabelNamesRe
 // LabelValues implements the Storegateway proto service.
 func (u *BucketStores) LabelValues(ctx context.Context, req *storepb.LabelValuesRequest) (*storepb.LabelValuesResponse, error) {
 	spanLog, spanCtx := spanlogger.New(ctx, "BucketStores.LabelValues")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	userID := getUserIDFromGRPCContext(spanCtx)
 	if userID == "" {

--- a/pkg/testexporter/correctness/time_flag.go
+++ b/pkg/testexporter/correctness/time_flag.go
@@ -20,7 +20,7 @@ func NewTimeValue(t time.Time) TimeValue {
 
 // String implements flag.Value
 func (v TimeValue) String() string {
-	return v.Time.Format(time.RFC3339)
+	return v.Format(time.RFC3339)
 }
 
 // Set implements flag.Value

--- a/pkg/util/extract/extract.go
+++ b/pkg/util/extract/extract.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	errNoMetricNameLabel = fmt.Errorf("No metric name label")
+	errNoMetricNameLabel = fmt.Errorf("no metric name label")
 )
 
 // MetricNameFromLabelAdapters extracts the metric name from a list of LabelPairs.

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -37,7 +37,7 @@ func GetFirstAddressOf(names []string) (string, error) {
 		return ipAddr, nil
 	}
 	if ipAddr == "" {
-		return "", fmt.Errorf("No address found for %s", names)
+		return "", fmt.Errorf("no address found for %s", names)
 	}
 	if strings.HasPrefix(ipAddr, `169.254.`) {
 		level.Warn(util_log.Logger).Log("msg", "using automatic private ip", "address", ipAddr)

--- a/pkg/util/priority_queue.go
+++ b/pkg/util/priority_queue.go
@@ -103,7 +103,7 @@ func (pq *PriorityQueue) Dequeue() PriorityOp {
 	pq.lock.Lock()
 	defer pq.lock.Unlock()
 
-	for len(pq.queue) == 0 && !(pq.closing || pq.closed) {
+	for len(pq.queue) == 0 && (!pq.closing && !pq.closed) {
 		pq.cond.Wait()
 	}
 

--- a/pkg/util/spanlogger/spanlogger.go
+++ b/pkg/util/spanlogger/spanlogger.go
@@ -89,7 +89,7 @@ func (s *SpanLogger) Log(kvps ...interface{}) error {
 	if err != nil {
 		return err
 	}
-	s.Span.LogFields(fields...)
+	s.LogFields(fields...)
 	return nil
 }
 
@@ -99,6 +99,6 @@ func (s *SpanLogger) Error(err error) error {
 		return nil
 	}
 	ext.Error.Set(s.Span, true)
-	s.Span.LogFields(otlog.Error(err))
+	s.LogFields(otlog.Error(err))
 	return err
 }

--- a/pkg/util/test/poll.go
+++ b/pkg/util/test/poll.go
@@ -10,10 +10,8 @@ import (
 func Poll(t testing.TB, d time.Duration, want interface{}, have func() interface{}) {
 	t.Helper()
 	deadline := time.Now().Add(d)
-	for {
-		if time.Now().After(deadline) {
-			break
-		}
+	for !time.Now().After(deadline) {
+
 		if reflect.DeepEqual(want, have()) {
 			return
 		}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -23,7 +23,7 @@ import (
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
-var errMaxGlobalSeriesPerUserValidation = errors.New("The ingester.max-global-series-per-user limit is unsupported if distributor.shard-by-all-labels is disabled")
+var errMaxGlobalSeriesPerUserValidation = errors.New("the ingester.max-global-series-per-user limit is unsupported if distributor.shard-by-all-labels is disabled")
 var errDuplicateQueryPriorities = errors.New("duplicate entry of priorities found. Make sure they are all unique, including the default priority")
 var errCompilingQueryPriorityRegex = errors.New("error compiling query priority regex")
 var errDuplicatePerLabelSetLimit = errors.New("duplicate per labelSet limits found. Make sure they are all unique")

--- a/tools/doc-generator/writer.go
+++ b/tools/doc-generator/writer.go
@@ -61,9 +61,10 @@ func (w *specWriter) writeConfigEntry(e *configEntry, indent int) {
 
 		// Specification
 		fieldDefault := e.fieldDefault
-		if e.fieldType == "string" {
+		switch e.fieldType {
+		case "string":
 			fieldDefault = strconv.Quote(fieldDefault)
-		} else if e.fieldType == "duration" {
+		case "duration":
 			fieldDefault = cleanupDuration(fieldDefault)
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR updates `golangci-linter` version to v2 (v2.1.6). It migrates the `.golangci.yml` to v2 and resolves some lint issues according to v2.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
