### PR TITLE
Add ingester.skip-metadata-limits flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * [FEATURE] Ruler: Add support for group labels. #6665
 * [FEATURE] Support Parquet format: Implement parquet converter service to convert a TSDB block into Parquet. #6716
 * [ENHANCEMENT] Query Frontend: Change to return 400 when the tenant resolving fail. #6715
-* [ENHANCEMENT] Querier: Support query parameters to metadata api (/api/v1/metadata) to allow user to limit metadata to return. #6681
+* [ENHANCEMENT] Querier: Support query parameters to metadata api (/api/v1/metadata) to allow user to limit metadata to return. Add a `-ingester.return-all-metadata` flag to make the metadata API run when the deployment. Please set this flag to `false` to use the metadata API with the limits later. #6681 #6744
 * [ENHANCEMENT] Ingester: Add a `cortex_ingester_active_native_histogram_series` metric to track # of active NH series. #6695
 * [ENHANCEMENT] Query Frontend: Add new limit `-frontend.max-query-response-size` for total query response size after decompression in query frontend. #6607
 * [ENHANCEMENT] Alertmanager: Add nflog and silences maintenance metrics. #6659

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3267,6 +3267,10 @@ instance_limits:
 # Maximum number of entries in the regex matchers cache. 0 to disable.
 # CLI flag: -ingester.matchers-cache-max-items
 [matchers_cache_max_items: <int> | default = 0]
+
+# If enabled, the metadata API returns all metadata regardless of the limits.
+# CLI flag: -ingester.skip-metadata-limits
+[skip_metadata_limits: <boolean> | default = true]
 ```
 
 ### `ingester_client_config`

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -155,6 +155,9 @@ type Config struct {
 
 	// Maximum number of entries in the matchers cache. 0 to disable.
 	MatchersCacheMaxItems int `yaml:"matchers_cache_max_items"`
+
+	// If enabled, the metadata API returns all metadata regardless of the limits.
+	SkipMetadataLimits bool `yaml:"skip_metadata_limits"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -176,6 +179,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&cfg.DisableChunkTrimming, "ingester.disable-chunk-trimming", false, "Disable trimming of matching series chunks based on query Start and End time. When disabled, the result may contain samples outside the queried time range but select performances may be improved. Note that certain query results might change by changing this option.")
 	f.IntVar(&cfg.MatchersCacheMaxItems, "ingester.matchers-cache-max-items", 0, "Maximum number of entries in the regex matchers cache. 0 to disable.")
+	f.BoolVar(&cfg.SkipMetadataLimits, "ingester.skip-metadata-limits", true, "If enabled, the metadata API returns all metadata regardless of the limits.")
 
 	cfg.DefaultLimits.RegisterFlagsWithPrefix(f, "ingester.")
 }
@@ -3057,7 +3061,7 @@ func (i *Ingester) getOrCreateUserMetadata(userID string) *userMetricsMetadata {
 	// Ensure it was not created between switching locks.
 	userMetadata, ok := i.usersMetadata[userID]
 	if !ok {
-		userMetadata = newMetadataMap(i.limiter, i.metrics, i.validateMetrics, userID)
+		userMetadata = newMetadataMap(i.limiter, i.metrics, i.validateMetrics, userID, i.cfg.SkipMetadataLimits)
 		i.usersMetadata[userID] = userMetadata
 	}
 	return userMetadata

--- a/pkg/ingester/user_metrics_metadata.go
+++ b/pkg/ingester/user_metrics_metadata.go
@@ -11,26 +11,33 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
+const (
+	defaultLimit          = -1
+	defaultLimitPerMetric = -1
+)
+
 // userMetricsMetadata allows metric metadata of a tenant to be held by the ingester.
 // Metadata is kept as a set as it can come from multiple targets that Prometheus scrapes
 // with the same metric name.
 type userMetricsMetadata struct {
-	limiter         *Limiter
-	metrics         *ingesterMetrics
-	validateMetrics *validation.ValidateMetrics
-	userID          string
+	limiter            *Limiter
+	metrics            *ingesterMetrics
+	validateMetrics    *validation.ValidateMetrics
+	userID             string
+	skipMetadataLimits bool
 
 	mtx              sync.RWMutex
 	metricToMetadata map[string]metricMetadataSet
 }
 
-func newMetadataMap(l *Limiter, m *ingesterMetrics, v *validation.ValidateMetrics, userID string) *userMetricsMetadata {
+func newMetadataMap(l *Limiter, m *ingesterMetrics, v *validation.ValidateMetrics, userID string, skipMetadataLimits bool) *userMetricsMetadata {
 	return &userMetricsMetadata{
-		metricToMetadata: map[string]metricMetadataSet{},
-		limiter:          l,
-		metrics:          m,
-		validateMetrics:  v,
-		userID:           userID,
+		metricToMetadata:   map[string]metricMetadataSet{},
+		limiter:            l,
+		metrics:            m,
+		validateMetrics:    v,
+		userID:             userID,
+		skipMetadataLimits: skipMetadataLimits,
 	}
 }
 
@@ -88,8 +95,17 @@ func (mm *userMetricsMetadata) purge(deadline time.Time) {
 func (mm *userMetricsMetadata) toClientMetadata(req *client.MetricsMetadataRequest) []*cortexpb.MetricMetadata {
 	mm.mtx.RLock()
 	defer mm.mtx.RUnlock()
+
 	r := make([]*cortexpb.MetricMetadata, 0, len(mm.metricToMetadata))
-	if req.Limit == 0 {
+	limit := req.Limit
+	limitPerMetric := req.LimitPerMetric
+
+	if mm.skipMetadataLimits {
+		// set limit and limitPerMetric to default
+		limit = defaultLimit
+		limitPerMetric = defaultLimitPerMetric
+	}
+	if limit == 0 {
 		return r
 	}
 
@@ -99,16 +115,16 @@ func (mm *userMetricsMetadata) toClientMetadata(req *client.MetricsMetadataReque
 			return r
 		}
 
-		metadataSet.add(req.LimitPerMetric, &r)
+		metadataSet.add(limitPerMetric, &r)
 		return r
 	}
 
 	var metrics int64
 	for _, set := range mm.metricToMetadata {
-		if req.Limit > 0 && metrics >= req.Limit {
+		if limit > 0 && metrics >= limit {
 			break
 		}
-		set.add(req.LimitPerMetric, &r)
+		set.add(limitPerMetric, &r)
 		metrics++
 	}
 	return r


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

The PR #6681 implements a metadata API query parameter (limit, limit_per_metric, and metric). During a deployment when the querier is on an older version and the ingester is on a new version, the querier always passes 0 values for limits. If then, the ingester returns an empty response.
This PR adds a`-ingester.skip-metadata-limits` flag to make the ingester return metadata during the deployment. After the deployment, set this flag to `false` to use the metadata API with the limits.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
