### PR TITLE
Changing flag from `query-parquet-files`  to 'enable_parquet_queryable'

### DIFF
--- a/integration/parquet_querier_test.go
+++ b/integration/parquet_querier_test.go
@@ -70,7 +70,7 @@ func TestParquetFuzz(t *testing.T) {
 			"-parquet-converter.conversion-interval":  "1s",
 			"-parquet-converter.enabled":              "true",
 			// Querier
-			"-querier.query-parquet-files": "true",
+			"-querier.enable-parquet-queryable": "true",
 		},
 	)
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -405,7 +405,7 @@ func (t *Cortex) initStoreQueryables() (services.Service, error) {
 		return nil, fmt.Errorf("failed to initialize querier: %v", err)
 	} else {
 		queriable = q
-		if t.Cfg.Querier.QueryParquetFiles {
+		if t.Cfg.Querier.EnableParquetQueryable {
 			pq, err := querier.NewParquetQueryable(t.Cfg.Querier, t.Cfg.BlocksStorage, t.Overrides, q, util_log.Logger, prometheus.DefaultRegisterer)
 			if err != nil {
 				return nil, fmt.Errorf("failed to initialize parquet querier: %v", err)

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -92,7 +92,7 @@ type Config struct {
 	EnablePromQLExperimentalFunctions bool `yaml:"enable_promql_experimental_functions"`
 
 	// Query Parquet files if available
-	QueryParquetFiles bool `yaml:"query_parquet_files" doc:"hidden"`
+	EnableParquetQueryable bool `yaml:"enable_parquet_queryable" doc:"hidden"`
 }
 
 var (
@@ -138,7 +138,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Int64Var(&cfg.MaxSubQuerySteps, "querier.max-subquery-steps", 0, "Max number of steps allowed for every subquery expression in query. Number of steps is calculated using subquery range / step. A value > 0 enables it.")
 	f.BoolVar(&cfg.IgnoreMaxQueryLength, "querier.ignore-max-query-length", false, "If enabled, ignore max query length check at Querier select method. Users can choose to ignore it since the validation can be done before Querier evaluation like at Query Frontend or Ruler.")
 	f.BoolVar(&cfg.EnablePromQLExperimentalFunctions, "querier.enable-promql-experimental-functions", false, "[Experimental] If true, experimental promQL functions are enabled.")
-	f.BoolVar(&cfg.QueryParquetFiles, "querier.query-parquet-files", false, "[Experimental] If true, querier will try to query the parquet files if available.")
+	f.BoolVar(&cfg.EnableParquetQueryable, "querier.enable-parquet-queryable", false, "[Experimental] If true, querier will try to query the parquet files if available.")
 }
 
 // Validate the config


### PR DESCRIPTION

**What this PR does**:

Just renaming the new flag.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
