### PR TITLE
Fallback to the blocks queryable if vertical sharding is enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/parquet-go/parquet-go v0.25.0
-	github.com/prometheus-community/parquet-common v0.0.0-20250528210111-72a099ba73bf
+	github.com/prometheus-community/parquet-common v0.0.0-20250528231323-eec9c3c020f0
 	github.com/prometheus/procfs v0.15.1
 	github.com/sercand/kuberesolver/v5 v5.1.1
 	github.com/tjhop/slog-gokit v0.1.3

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/parquet-go/parquet-go v0.25.0
-	github.com/prometheus-community/parquet-common v0.0.0-20250522182606-e046c038dc73
+	github.com/prometheus-community/parquet-common v0.0.0-20250527060536-18d3dd36c09e
 	github.com/prometheus/procfs v0.15.1
 	github.com/sercand/kuberesolver/v5 v5.1.1
 	github.com/tjhop/slog-gokit v0.1.3

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/parquet-go/parquet-go v0.25.0
-	github.com/prometheus-community/parquet-common v0.0.0-20250527060536-18d3dd36c09e
+	github.com/prometheus-community/parquet-common v0.0.0-20250528173345-0f445293e6c3
 	github.com/prometheus/procfs v0.15.1
 	github.com/sercand/kuberesolver/v5 v5.1.1
 	github.com/tjhop/slog-gokit v0.1.3

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/parquet-go/parquet-go v0.25.0
-	github.com/prometheus-community/parquet-common v0.0.0-20250528182644-e3db427160c2
+	github.com/prometheus-community/parquet-common v0.0.0-20250528210111-72a099ba73bf
 	github.com/prometheus/procfs v0.15.1
 	github.com/sercand/kuberesolver/v5 v5.1.1
 	github.com/tjhop/slog-gokit v0.1.3

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/parquet-go/parquet-go v0.25.0
-	github.com/prometheus-community/parquet-common v0.0.0-20250528173345-0f445293e6c3
+	github.com/prometheus-community/parquet-common v0.0.0-20250528182644-e3db427160c2
 	github.com/prometheus/procfs v0.15.1
 	github.com/sercand/kuberesolver/v5 v5.1.1
 	github.com/tjhop/slog-gokit v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -1573,8 +1573,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/prometheus-community/parquet-common v0.0.0-20250522182606-e046c038dc73 h1:AogORrmarkYfUOI7/lqOhz9atYmLZo69vPQ/SFkPSxE=
-github.com/prometheus-community/parquet-common v0.0.0-20250522182606-e046c038dc73/go.mod h1:zRW/xXBlELf8v9h9uqWvDkjOr3N5BtQGZ6LsDX9Ea/A=
+github.com/prometheus-community/parquet-common v0.0.0-20250527060536-18d3dd36c09e h1:paj+lHT5gwRPg+vKgL5Crr1lwmS3TdA1EePCFEVfaD4=
+github.com/prometheus-community/parquet-common v0.0.0-20250527060536-18d3dd36c09e/go.mod h1:zRW/xXBlELf8v9h9uqWvDkjOr3N5BtQGZ6LsDX9Ea/A=
 github.com/prometheus-community/prom-label-proxy v0.8.1-0.20240127162815-c1195f9aabc0 h1:owfYHh79h8Y5HvNMGyww+DaVwo10CKiRW1RQrrZzIwg=
 github.com/prometheus-community/prom-label-proxy v0.8.1-0.20240127162815-c1195f9aabc0/go.mod h1:rT989D4UtOcfd9tVqIZRVIM8rkg+9XbreBjFNEKXvVI=
 github.com/prometheus/alertmanager v0.28.1 h1:BK5pCoAtaKg01BYRUJhEDV1tqJMEtYBGzPw8QdvnnvA=

--- a/go.sum
+++ b/go.sum
@@ -1573,8 +1573,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/prometheus-community/parquet-common v0.0.0-20250528173345-0f445293e6c3 h1:dllPD+bFW+Gs91oZ2LMeNNtD5gZVczhwfDLiKxbs6Zo=
-github.com/prometheus-community/parquet-common v0.0.0-20250528173345-0f445293e6c3/go.mod h1:zRW/xXBlELf8v9h9uqWvDkjOr3N5BtQGZ6LsDX9Ea/A=
+github.com/prometheus-community/parquet-common v0.0.0-20250528182644-e3db427160c2 h1:NPi9L2w3NCzz5fJG5cSbINfMNrdxeJNsxumOBfN95z8=
+github.com/prometheus-community/parquet-common v0.0.0-20250528182644-e3db427160c2/go.mod h1:zRW/xXBlELf8v9h9uqWvDkjOr3N5BtQGZ6LsDX9Ea/A=
 github.com/prometheus-community/prom-label-proxy v0.8.1-0.20240127162815-c1195f9aabc0 h1:owfYHh79h8Y5HvNMGyww+DaVwo10CKiRW1RQrrZzIwg=
 github.com/prometheus-community/prom-label-proxy v0.8.1-0.20240127162815-c1195f9aabc0/go.mod h1:rT989D4UtOcfd9tVqIZRVIM8rkg+9XbreBjFNEKXvVI=
 github.com/prometheus/alertmanager v0.28.1 h1:BK5pCoAtaKg01BYRUJhEDV1tqJMEtYBGzPw8QdvnnvA=

--- a/go.sum
+++ b/go.sum
@@ -1573,8 +1573,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/prometheus-community/parquet-common v0.0.0-20250527060536-18d3dd36c09e h1:paj+lHT5gwRPg+vKgL5Crr1lwmS3TdA1EePCFEVfaD4=
-github.com/prometheus-community/parquet-common v0.0.0-20250527060536-18d3dd36c09e/go.mod h1:zRW/xXBlELf8v9h9uqWvDkjOr3N5BtQGZ6LsDX9Ea/A=
+github.com/prometheus-community/parquet-common v0.0.0-20250528173345-0f445293e6c3 h1:dllPD+bFW+Gs91oZ2LMeNNtD5gZVczhwfDLiKxbs6Zo=
+github.com/prometheus-community/parquet-common v0.0.0-20250528173345-0f445293e6c3/go.mod h1:zRW/xXBlELf8v9h9uqWvDkjOr3N5BtQGZ6LsDX9Ea/A=
 github.com/prometheus-community/prom-label-proxy v0.8.1-0.20240127162815-c1195f9aabc0 h1:owfYHh79h8Y5HvNMGyww+DaVwo10CKiRW1RQrrZzIwg=
 github.com/prometheus-community/prom-label-proxy v0.8.1-0.20240127162815-c1195f9aabc0/go.mod h1:rT989D4UtOcfd9tVqIZRVIM8rkg+9XbreBjFNEKXvVI=
 github.com/prometheus/alertmanager v0.28.1 h1:BK5pCoAtaKg01BYRUJhEDV1tqJMEtYBGzPw8QdvnnvA=

--- a/go.sum
+++ b/go.sum
@@ -1573,8 +1573,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/prometheus-community/parquet-common v0.0.0-20250528210111-72a099ba73bf h1:eCGltfuICTRQlC/zZVWhZW4qSnfzB4aBTDUgsxiPv2o=
-github.com/prometheus-community/parquet-common v0.0.0-20250528210111-72a099ba73bf/go.mod h1:zRW/xXBlELf8v9h9uqWvDkjOr3N5BtQGZ6LsDX9Ea/A=
+github.com/prometheus-community/parquet-common v0.0.0-20250528231323-eec9c3c020f0 h1:XCSo9v3if0v0G+aAO/hSUr/Ck9KJXcUPzDFt1dJnAV8=
+github.com/prometheus-community/parquet-common v0.0.0-20250528231323-eec9c3c020f0/go.mod h1:zRW/xXBlELf8v9h9uqWvDkjOr3N5BtQGZ6LsDX9Ea/A=
 github.com/prometheus-community/prom-label-proxy v0.8.1-0.20240127162815-c1195f9aabc0 h1:owfYHh79h8Y5HvNMGyww+DaVwo10CKiRW1RQrrZzIwg=
 github.com/prometheus-community/prom-label-proxy v0.8.1-0.20240127162815-c1195f9aabc0/go.mod h1:rT989D4UtOcfd9tVqIZRVIM8rkg+9XbreBjFNEKXvVI=
 github.com/prometheus/alertmanager v0.28.1 h1:BK5pCoAtaKg01BYRUJhEDV1tqJMEtYBGzPw8QdvnnvA=

--- a/go.sum
+++ b/go.sum
@@ -1573,8 +1573,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/prometheus-community/parquet-common v0.0.0-20250528182644-e3db427160c2 h1:NPi9L2w3NCzz5fJG5cSbINfMNrdxeJNsxumOBfN95z8=
-github.com/prometheus-community/parquet-common v0.0.0-20250528182644-e3db427160c2/go.mod h1:zRW/xXBlELf8v9h9uqWvDkjOr3N5BtQGZ6LsDX9Ea/A=
+github.com/prometheus-community/parquet-common v0.0.0-20250528210111-72a099ba73bf h1:eCGltfuICTRQlC/zZVWhZW4qSnfzB4aBTDUgsxiPv2o=
+github.com/prometheus-community/parquet-common v0.0.0-20250528210111-72a099ba73bf/go.mod h1:zRW/xXBlELf8v9h9uqWvDkjOr3N5BtQGZ6LsDX9Ea/A=
 github.com/prometheus-community/prom-label-proxy v0.8.1-0.20240127162815-c1195f9aabc0 h1:owfYHh79h8Y5HvNMGyww+DaVwo10CKiRW1RQrrZzIwg=
 github.com/prometheus-community/prom-label-proxy v0.8.1-0.20240127162815-c1195f9aabc0/go.mod h1:rT989D4UtOcfd9tVqIZRVIM8rkg+9XbreBjFNEKXvVI=
 github.com/prometheus/alertmanager v0.28.1 h1:BK5pCoAtaKg01BYRUJhEDV1tqJMEtYBGzPw8QdvnnvA=

--- a/pkg/parquetconverter/converter.go
+++ b/pkg/parquetconverter/converter.go
@@ -91,7 +91,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MetaSyncConcurrency, "parquet-converter.meta-sync-concurrency", 20, "Number of Go routines to use when syncing block meta files from the long term storage.")
 	f.IntVar(&cfg.MaxRowsPerRowGroup, "parquet-converter.max-rows-per-row-group", 1e6, "Max number of rows per parquet row group.")
 	f.DurationVar(&cfg.ConversionInterval, "parquet-converter.conversion-interval", time.Minute, "The frequency at which the conversion job runs.")
-	f.BoolVar(&cfg.FileBufferEnabled, "parquet-converter.file_buffer_enabled", true, "Whether to enable buffering the writes in disk to reduce memory utilization.")
+	f.BoolVar(&cfg.FileBufferEnabled, "parquet-converter.file-buffer-enabled", true, "Whether to enable buffering the writes in disk to reduce memory utilization.")
 }
 
 func NewConverter(cfg Config, storageCfg cortex_tsdb.BlocksStorageConfig, blockRanges []int64, logger log.Logger, registerer prometheus.Registerer, limits *validation.Overrides) (*Converter, error) {
@@ -172,7 +172,7 @@ func (c *Converter) running(ctx context.Context) error {
 			rand.Shuffle(len(users), func(i, j int) {
 				users[i], users[j] = users[j], users[i]
 			})
-			
+
 			for _, userID := range users {
 				if !c.limits.ParquetConverterEnabled(userID) {
 					continue

--- a/pkg/parquetconverter/converter.go
+++ b/pkg/parquetconverter/converter.go
@@ -5,8 +5,10 @@ import (
 	"flag"
 	"fmt"
 	"hash/fnv"
+	"math/rand"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -47,6 +49,8 @@ var RingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
 type Config struct {
 	MetaSyncConcurrency int           `yaml:"meta_sync_concurrency"`
 	ConversionInterval  time.Duration `yaml:"conversion_interval"`
+	MaxRowsPerRowGroup  int           `yaml:"max_rows_per_row_group"`
+	FileBufferEnabled   bool          `yaml:"file_buffer_enabled"`
 
 	DataDir string `yaml:"data_dir"`
 
@@ -85,7 +89,9 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	f.StringVar(&cfg.DataDir, "parquet-converter.data-dir", "./data", "Data directory in which to cache blocks and process conversions.")
 	f.IntVar(&cfg.MetaSyncConcurrency, "parquet-converter.meta-sync-concurrency", 20, "Number of Go routines to use when syncing block meta files from the long term storage.")
+	f.IntVar(&cfg.MaxRowsPerRowGroup, "parquet-converter.max-rows-per-row-group", 1e6, "Max number of rows per parquet row group.")
 	f.DurationVar(&cfg.ConversionInterval, "parquet-converter.conversion-interval", time.Minute, "The frequency at which the conversion job runs.")
+	f.BoolVar(&cfg.FileBufferEnabled, "parquet-converter.file_buffer_enabled", true, "Whether to enable buffering the writes in disk to reduce memory utilization.")
 }
 
 func NewConverter(cfg Config, storageCfg cortex_tsdb.BlocksStorageConfig, blockRanges []int64, logger log.Logger, registerer prometheus.Registerer, limits *validation.Overrides) (*Converter, error) {
@@ -163,6 +169,10 @@ func (c *Converter) running(ctx context.Context) error {
 				continue
 			}
 			ownedUsers := map[string]struct{}{}
+			rand.Shuffle(len(users), func(i, j int) {
+				users[i], users[j] = users[j], users[i]
+			})
+			
 			for _, userID := range users {
 				if !c.limits.ParquetConverterEnabled(userID) {
 					continue
@@ -293,10 +303,19 @@ func (c *Converter) convertUser(ctx context.Context, logger log.Logger, ring rin
 		return errors.Wrap(err, "error creating block fetcher")
 	}
 
-	blocks, _, err := fetcher.Fetch(ctx)
+	blks, _, err := fetcher.Fetch(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch blocks for user %s", userID)
 	}
+
+	blocks := make([]*metadata.Meta, 0, len(blks))
+	for _, blk := range blks {
+		blocks = append(blocks, blk)
+	}
+
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i].MinTime > blocks[j].MinTime
+	})
 
 	for _, b := range blocks {
 		ok, err := c.ownBlock(ring, b.ULID.String())
@@ -345,22 +364,31 @@ func (c *Converter) convertUser(ctx context.Context, logger log.Logger, ring rin
 		}
 
 		level.Info(logger).Log("msg", "converting block", "block", b.ULID.String(), "dir", bdir)
+		extraOpts := []convert.ConvertOption{
+			convert.WithSortBy(labels.MetricName),
+			convert.WithColDuration(time.Hour * 8),
+			convert.WithRowGroupSize(c.cfg.MaxRowsPerRowGroup),
+			convert.WithName(b.ULID.String()),
+		}
+
+		if c.cfg.FileBufferEnabled {
+			extraOpts = append(extraOpts, convert.WithColumnPageBuffers(parquet.NewFileBufferPool(bdir, "buffers.*")))
+		}
+
 		_, err = convert.ConvertTSDBBlock(
 			ctx,
 			uBucket,
 			tsdbBlock.MinTime(),
 			tsdbBlock.MaxTime(),
 			[]convert.Convertible{tsdbBlock},
-			convert.WithSortBy(labels.MetricName),
-			convert.WithColDuration(time.Hour*8),
-			convert.WithName(b.ULID.String()),
-			convert.WithColumnPageBuffers(parquet.NewFileBufferPool(bdir, "buffers.*")),
+			extraOpts...,
 		)
 
 		_ = tsdbBlock.Close()
 
 		if err != nil {
 			level.Error(logger).Log("msg", "Error converting block", "err", err)
+			continue
 		}
 
 		err = cortex_parquet.WriteConverterMark(ctx, b.ULID, uBucket)

--- a/pkg/querier/parquet_queryable.go
+++ b/pkg/querier/parquet_queryable.go
@@ -2,6 +2,7 @@ package querier
 
 import (
 	"context"
+	"github.com/parquet-go/parquet-go"
 	"time"
 
 	"github.com/go-kit/log"
@@ -103,7 +104,16 @@ func NewParquetQueryable(
 
 		for _, block := range blocks {
 			// we always only have 1 shard - shard 0
-			shard, err := parquet_storage.OpenParquetShard(ctx, userBkt, block.ID.String(), 0)
+			shard, err := parquet_storage.OpenParquetShard(ctx,
+				userBkt,
+				block.ID.String(),
+				0,
+				parquet_storage.WithFileOptions(
+					parquet.SkipMagicBytes(true),
+					parquet.ReadBufferSize(100*1024),
+					parquet.SkipBloomFilters(true),
+				),
+			)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/querier/parquet_queryable.go
+++ b/pkg/querier/parquet_queryable.go
@@ -116,6 +116,7 @@ func NewParquetQueryable(
 						parquet.ReadBufferSize(100*1024),
 						parquet.SkipBloomFilters(true),
 					),
+					parquet_storage.WithOptimisticReader(true),
 				)
 				shards[i] = shard
 				return err

--- a/pkg/querier/parquet_queryable.go
+++ b/pkg/querier/parquet_queryable.go
@@ -2,7 +2,6 @@ package querier
 
 import (
 	"context"
-	"golang.org/x/sync/errgroup"
 	"time"
 
 	"github.com/go-kit/log"
@@ -19,6 +18,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/thanos-io/thanos/pkg/strutil"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/cortexproject/cortex/pkg/storage/bucket"
 	cortex_tsdb "github.com/cortexproject/cortex/pkg/storage/tsdb"

--- a/pkg/querier/parquet_queryable.go
+++ b/pkg/querier/parquet_queryable.go
@@ -2,12 +2,12 @@ package querier
 
 import (
 	"context"
-	"github.com/parquet-go/parquet-go"
 	"golang.org/x/sync/errgroup"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/parquet-go/parquet-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus-community/parquet-common/schema"
 	"github.com/prometheus-community/parquet-common/search"

--- a/pkg/querier/parquet_queryable.go
+++ b/pkg/querier/parquet_queryable.go
@@ -209,18 +209,6 @@ type parquetQuerierWithFallback struct {
 }
 
 func (q *parquetQuerierWithFallback) LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
-	userID, err := tenant.TenantID(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if q.limits.QueryVerticalShardSize(userID) > 1 {
-		uLogger := util_log.WithUserID(userID, q.logger)
-		level.Warn(uLogger).Log("msg", "parquet queryable enabled but vertival sharding > 0. Falling back to the block storage")
-
-		return q.blocksStoreQuerier.LabelValues(ctx, name, hints, matchers...)
-	}
-
 	remaining, parquet, err := q.getBlocks(ctx, q.minT, q.maxT)
 	if err != nil {
 		return nil, nil, err
@@ -266,18 +254,6 @@ func (q *parquetQuerierWithFallback) LabelValues(ctx context.Context, name strin
 }
 
 func (q *parquetQuerierWithFallback) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
-	userID, err := tenant.TenantID(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if q.limits.QueryVerticalShardSize(userID) > 1 {
-		uLogger := util_log.WithUserID(userID, q.logger)
-		level.Warn(uLogger).Log("msg", "parquet queryable enabled but vertival sharding > 0. Falling back to the block storage")
-
-		return q.blocksStoreQuerier.LabelNames(ctx, hints, matchers...)
-	}
-
 	remaining, parquet, err := q.getBlocks(ctx, q.minT, q.maxT)
 	if err != nil {
 		return nil, nil, err
@@ -331,7 +307,7 @@ func (q *parquetQuerierWithFallback) Select(ctx context.Context, sortSeries bool
 
 	if q.limits.QueryVerticalShardSize(userID) > 1 {
 		uLogger := util_log.WithUserID(userID, q.logger)
-		level.Warn(uLogger).Log("msg", "parquet queryable enabled but vertival sharding > 0. Falling back to the block storage")
+		level.Warn(uLogger).Log("msg", "parquet queryable enabled but vertical sharding > 1. Falling back to the block storage")
 
 		return q.blocksStoreQuerier.Select(ctx, sortSeries, hints, matchers...)
 	}

--- a/pkg/querier/parquet_queryable_test.go
+++ b/pkg/querier/parquet_queryable_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/cortexproject/cortex/pkg/querier/series"
 	"github.com/cortexproject/cortex/pkg/storage/parquet"
 	"github.com/cortexproject/cortex/pkg/storage/tsdb/bucketindex"
+	"github.com/cortexproject/cortex/pkg/util/flagext"
+	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
 func TestParquetQueryableFallbackLogic(t *testing.T) {
@@ -27,33 +29,37 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 	minT := int64(10)
 	maxT := int64(20)
 
-	stores := &blocksStoreSetMock{mockedResponses: []interface{}{
-		map[BlocksStoreClient][]ulid.ULID{
-			&storeGatewayClientMock{remoteAddr: "1.1.1.1",
-				mockedSeriesResponses: []*storepb.SeriesResponse{
-					mockSeriesResponse(labels.Labels{{Name: labels.MetricName, Value: "fromSg"}}, []cortexpb.Sample{{Value: 1, TimestampMs: minT}, {Value: 2, TimestampMs: minT + 1}}, nil, nil),
-					mockHintsResponse(block1, block2),
-				},
-				mockedLabelNamesResponse: &storepb.LabelNamesResponse{
-					Names:    namesFromSeries(labels.FromMap(map[string]string{labels.MetricName: "fromSg", "fromSg": "fromSg"})),
-					Warnings: []string{},
-					Hints:    mockNamesHints(block1, block2),
-				},
-				mockedLabelValuesResponse: &storepb.LabelValuesResponse{
-					Values:   valuesFromSeries(labels.MetricName, labels.FromMap(map[string]string{labels.MetricName: "fromSg", "fromSg": "fromSg"})),
-					Warnings: []string{},
-					Hints:    mockValuesHints(block1, block2),
-				},
-			}: {block1, block2}},
-	},
+	createStore := func() *blocksStoreSetMock {
+		return &blocksStoreSetMock{mockedResponses: []interface{}{
+			map[BlocksStoreClient][]ulid.ULID{
+				&storeGatewayClientMock{remoteAddr: "1.1.1.1",
+					mockedSeriesResponses: []*storepb.SeriesResponse{
+						mockSeriesResponse(labels.Labels{{Name: labels.MetricName, Value: "fromSg"}}, []cortexpb.Sample{{Value: 1, TimestampMs: minT}, {Value: 2, TimestampMs: minT + 1}}, nil, nil),
+						mockHintsResponse(block1, block2),
+					},
+					mockedLabelNamesResponse: &storepb.LabelNamesResponse{
+						Names:    namesFromSeries(labels.FromMap(map[string]string{labels.MetricName: "fromSg", "fromSg": "fromSg"})),
+						Warnings: []string{},
+						Hints:    mockNamesHints(block1, block2),
+					},
+					mockedLabelValuesResponse: &storepb.LabelValuesResponse{
+						Values:   valuesFromSeries(labels.MetricName, labels.FromMap(map[string]string{labels.MetricName: "fromSg", "fromSg": "fromSg"})),
+						Warnings: []string{},
+						Hints:    mockValuesHints(block1, block2),
+					},
+				}: {block1, block2}},
+		},
+		}
 	}
 
 	matchers := []*labels.Matcher{
 		labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "fromSg"),
 	}
 	ctx := user.InjectOrgID(context.Background(), "user-1")
-	t.Run("should fallback all blocks", func(t *testing.T) {
+
+	t.Run("should fallback when vertical sharding is enabled", func(t *testing.T) {
 		finder := &blocksFinderMock{}
+		stores := createStore()
 
 		q := &blocksStoreQuerier{
 			minT:        minT,
@@ -76,6 +82,68 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 			blocksStoreQuerier: q,
 			parquetQuerier:     mParquetQuerier,
 			metrics:            newParquetQueryableFallbackMetrics(prometheus.NewRegistry()),
+			limits:             defaultOverrides(t, 4),
+			logger:             log.NewNopLogger(),
+		}
+
+		finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(bucketindex.Blocks{
+			&bucketindex.Block{ID: block1, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
+			&bucketindex.Block{ID: block2, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
+		}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)
+
+		t.Run("select", func(t *testing.T) {
+			ss := pq.Select(ctx, true, nil, matchers...)
+			require.NoError(t, ss.Err())
+			require.Len(t, stores.queriedBlocks, 2)
+			require.Len(t, mParquetQuerier.queriedBlocks, 0)
+		})
+
+		t.Run("labelNames", func(t *testing.T) {
+			stores.Reset()
+			mParquetQuerier.Reset()
+			_, _, err := pq.LabelNames(ctx, nil, matchers...)
+			require.NoError(t, err)
+			require.Len(t, stores.queriedBlocks, 2)
+			require.Len(t, mParquetQuerier.queriedBlocks, 0)
+		})
+
+		t.Run("labelValues", func(t *testing.T) {
+			stores.Reset()
+			mParquetQuerier.Reset()
+			_, _, err := pq.LabelValues(ctx, labels.MetricName, nil, matchers...)
+			require.NoError(t, err)
+			require.Len(t, stores.queriedBlocks, 2)
+			require.Len(t, mParquetQuerier.queriedBlocks, 0)
+		})
+	})
+
+	t.Run("should fallback all blocks", func(t *testing.T) {
+		finder := &blocksFinderMock{}
+		stores := createStore()
+
+		q := &blocksStoreQuerier{
+			minT:        minT,
+			maxT:        maxT,
+			finder:      finder,
+			stores:      stores,
+			consistency: NewBlocksConsistencyChecker(0, 0, log.NewNopLogger(), nil),
+			logger:      log.NewNopLogger(),
+			metrics:     newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry()),
+			limits:      &blocksStoreLimitsMock{},
+
+			storeGatewayConsistencyCheckMaxAttempts: 3,
+		}
+
+		mParquetQuerier := &mockParquetQuerier{}
+		pq := &parquetQuerierWithFallback{
+			minT:               minT,
+			maxT:               maxT,
+			finder:             finder,
+			blocksStoreQuerier: q,
+			parquetQuerier:     mParquetQuerier,
+			metrics:            newParquetQueryableFallbackMetrics(prometheus.NewRegistry()),
+			limits:             defaultOverrides(t, 0),
+			logger:             log.NewNopLogger(),
 		}
 
 		finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(bucketindex.Blocks{
@@ -111,6 +179,7 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 
 	t.Run("should fallback partial blocks", func(t *testing.T) {
 		finder := &blocksFinderMock{}
+		stores := createStore()
 
 		q := &blocksStoreQuerier{
 			minT:        minT,
@@ -133,6 +202,8 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 			blocksStoreQuerier: q,
 			parquetQuerier:     mParquetQuerier,
 			metrics:            newParquetQueryableFallbackMetrics(prometheus.NewRegistry()),
+			limits:             defaultOverrides(t, 0),
+			logger:             log.NewNopLogger(),
 		}
 
 		finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(bucketindex.Blocks{
@@ -174,6 +245,7 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 
 	t.Run("should query only parquet blocks when possible", func(t *testing.T) {
 		finder := &blocksFinderMock{}
+		stores := createStore()
 
 		q := &blocksStoreQuerier{
 			minT:        minT,
@@ -196,6 +268,8 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 			blocksStoreQuerier: q,
 			parquetQuerier:     mParquetQuerier,
 			metrics:            newParquetQueryableFallbackMetrics(prometheus.NewRegistry()),
+			limits:             defaultOverrides(t, 0),
+			logger:             log.NewNopLogger(),
 		}
 
 		finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(bucketindex.Blocks{
@@ -235,6 +309,16 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 		})
 	})
 
+}
+
+func defaultOverrides(t *testing.T, queryVerticalShardSize int) *validation.Overrides {
+	limits := validation.Limits{}
+	flagext.DefaultValues(&limits)
+	limits.QueryVerticalShardSize = queryVerticalShardSize
+
+	overrides, err := validation.NewOverrides(limits, nil)
+	require.NoError(t, err)
+	return overrides
 }
 
 type mockParquetQuerier struct {

--- a/pkg/querier/parquet_queryable_test.go
+++ b/pkg/querier/parquet_queryable_test.go
@@ -97,24 +97,6 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 			require.Len(t, stores.queriedBlocks, 2)
 			require.Len(t, mParquetQuerier.queriedBlocks, 0)
 		})
-
-		t.Run("labelNames", func(t *testing.T) {
-			stores.Reset()
-			mParquetQuerier.Reset()
-			_, _, err := pq.LabelNames(ctx, nil, matchers...)
-			require.NoError(t, err)
-			require.Len(t, stores.queriedBlocks, 2)
-			require.Len(t, mParquetQuerier.queriedBlocks, 0)
-		})
-
-		t.Run("labelValues", func(t *testing.T) {
-			stores.Reset()
-			mParquetQuerier.Reset()
-			_, _, err := pq.LabelValues(ctx, labels.MetricName, nil, matchers...)
-			require.NoError(t, err)
-			require.Len(t, stores.queriedBlocks, 2)
-			require.Len(t, mParquetQuerier.queriedBlocks, 0)
-		})
 	})
 
 	t.Run("should fallback all blocks", func(t *testing.T) {

--- a/vendor/github.com/prometheus-community/parquet-common/convert/convert.go
+++ b/vendor/github.com/prometheus-community/parquet-common/convert/convert.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/efficientgo/core/errors"
 	"github.com/hashicorp/go-multierror"
 	"github.com/parquet-go/parquet-go"
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"

--- a/vendor/github.com/prometheus-community/parquet-common/convert/writer.go
+++ b/vendor/github.com/prometheus-community/parquet-common/convert/writer.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/efficientgo/core/errors"
 	"github.com/hashicorp/go-multierror"
 	"github.com/parquet-go/parquet-go"
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/util/zeropool"
 	"github.com/thanos-io/objstore"
 	"golang.org/x/sync/errgroup"

--- a/vendor/github.com/prometheus-community/parquet-common/schema/encoder.go
+++ b/vendor/github.com/prometheus-community/parquet-common/schema/encoder.go
@@ -95,11 +95,12 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 
 				chkIdx := e.schema.DataColumIdx(t)
 				reEncodedChunksAppenders[chkIdx][chunkenc.EncXOR].Append(t, v)
-				if t < reEncodedChunks[chkIdx][chunkenc.EncXOR][len(reEncodedChunks[chkIdx][chunkenc.EncXOR])-1].MinTime {
-					reEncodedChunks[chkIdx][chunkenc.EncXOR][len(reEncodedChunks[chkIdx][chunkenc.EncXOR])-1].MinTime = t
+				chunk := reEncodedChunks[chkIdx][chunkenc.EncXOR][len(reEncodedChunks[chkIdx][chunkenc.EncXOR])-1]
+				if t < chunk.MinTime {
+					chunk.MinTime = t
 				}
-				if t > reEncodedChunks[chkIdx][chunkenc.EncXOR][len(reEncodedChunks[chkIdx][chunkenc.EncXOR])-1].MaxTime {
-					reEncodedChunks[chkIdx][chunkenc.EncXOR][len(reEncodedChunks[chkIdx][chunkenc.EncXOR])-1].MaxTime = t
+				if t > chunk.MaxTime {
+					chunk.MaxTime = t
 				}
 			}
 		case chunkenc.EncFloatHistogram:
@@ -124,11 +125,12 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 					reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram])-1].Chunk = newC
 				}
 
-				if t < reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram])-1].MinTime {
-					reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram])-1].MinTime = t
+				chunk := reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram])-1]
+				if t < chunk.MinTime {
+					chunk.MinTime = t
 				}
-				if t > reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram])-1].MaxTime {
-					reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram])-1].MaxTime = t
+				if t > chunk.MaxTime {
+					chunk.MaxTime = t
 				}
 			}
 		case chunkenc.EncHistogram:
@@ -153,11 +155,12 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 					reEncodedChunks[chkIdx][chunkenc.EncHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncHistogram])-1].Chunk = newC
 				}
 
-				if t < reEncodedChunks[chkIdx][chunkenc.EncHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncHistogram])-1].MinTime {
-					reEncodedChunks[chkIdx][chunkenc.EncHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncHistogram])-1].MinTime = t
+				chunk := reEncodedChunks[chkIdx][chunkenc.EncHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncHistogram])-1]
+				if t < chunk.MinTime {
+					chunk.MinTime = t
 				}
-				if t > reEncodedChunks[chkIdx][chunkenc.EncHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncHistogram])-1].MaxTime {
-					reEncodedChunks[chkIdx][chunkenc.EncHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncHistogram])-1].MaxTime = t
+				if t > chunk.MaxTime {
+					chunk.MaxTime = t
 				}
 			}
 		default:

--- a/vendor/github.com/prometheus-community/parquet-common/schema/encoder.go
+++ b/vendor/github.com/prometheus-community/parquet-common/schema/encoder.go
@@ -203,7 +203,9 @@ func NewPrometheusParquetChunksDecoder(pool chunkenc.Pool) *PrometheusParquetChu
 }
 
 func (e *PrometheusParquetChunksDecoder) Decode(data []byte, mint, maxt int64) ([]chunks.Meta, error) {
-	result := make([]chunks.Meta, 0, len(data))
+	// We usually have only 1 chunk per column as the chunks got re-encoded. Lets create a slice with capacity of 5
+	// just in case of re-encoding.
+	result := make([]chunks.Meta, 0, 5)
 
 	b := bytes.NewBuffer(data)
 

--- a/vendor/github.com/prometheus-community/parquet-common/schema/schema_builder.go
+++ b/vendor/github.com/prometheus-community/parquet-common/schema/schema_builder.go
@@ -163,13 +163,14 @@ func (s *TSDBSchema) LabelsProjection() (*TSDBProjection, error) {
 		g[c[0]] = lc.Node
 	}
 	return &TSDBProjection{
-		Schema: WithCompression(parquet.NewSchema("labels-projection", g)),
+		Schema:       WithCompression(parquet.NewSchema("labels-projection", g)),
+		ExtraOptions: []parquet.WriterOption{parquet.SkipPageBounds(ColIndexes)},
 	}, nil
 }
 
 func (s *TSDBSchema) ChunksProjection() (*TSDBProjection, error) {
 	g := make(parquet.Group)
-	skipPageBoundsOpts := make([]parquet.WriterOption, 0, len(s.DataColsIndexes))
+	writeOptions := make([]parquet.WriterOption, 0, len(s.DataColsIndexes))
 
 	for _, c := range s.Schema.Columns() {
 		if ok := IsDataColumn(c[0]); !ok {
@@ -180,11 +181,11 @@ func (s *TSDBSchema) ChunksProjection() (*TSDBProjection, error) {
 			return nil, fmt.Errorf("column %v not found", c)
 		}
 		g[c[0]] = lc.Node
-		skipPageBoundsOpts = append(skipPageBoundsOpts, parquet.SkipPageBounds(c...))
+		writeOptions = append(writeOptions, parquet.SkipPageBounds(c...))
 	}
 
 	return &TSDBProjection{
 		Schema:       WithCompression(parquet.NewSchema("chunk-projection", g)),
-		ExtraOptions: skipPageBoundsOpts,
+		ExtraOptions: writeOptions,
 	}, nil
 }

--- a/vendor/github.com/prometheus-community/parquet-common/schema/schema_builder.go
+++ b/vendor/github.com/prometheus-community/parquet-common/schema/schema_builder.go
@@ -17,9 +17,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/efficientgo/core/errors"
-
 	"github.com/parquet-go/parquet-go"
+	"github.com/pkg/errors"
 )
 
 type Builder struct {

--- a/vendor/github.com/prometheus-community/parquet-common/search/parquet_queriable.go
+++ b/vendor/github.com/prometheus-community/parquet-common/search/parquet_queriable.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	prom_storage "github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/prometheus-community/parquet-common/convert"
 	"github.com/prometheus-community/parquet-common/schema"
@@ -105,15 +106,20 @@ func (p parquetQuerier) LabelValues(ctx context.Context, name string, hints *pro
 		limit = int64(hints.Limit)
 	}
 
-	resNameValues := [][]string{}
+	resNameValues := make([][]string, len(shards))
+	errGroup, ctx := errgroup.WithContext(ctx)
+	errGroup.SetLimit(p.opts.concurrency)
 
-	for _, s := range shards {
-		r, err := s.LabelValues(ctx, name, matchers)
-		if err != nil {
-			return nil, nil, err
-		}
+	for i, s := range shards {
+		errGroup.Go(func() error {
+			r, err := s.LabelValues(ctx, name, limit, matchers)
+			resNameValues[i] = r
+			return err
+		})
+	}
 
-		resNameValues = append(resNameValues, r...)
+	if err := errGroup.Wait(); err != nil {
+		return nil, nil, err
 	}
 
 	return util.MergeUnsortedSlices(int(limit), resNameValues...), nil, nil
@@ -131,15 +137,20 @@ func (p parquetQuerier) LabelNames(ctx context.Context, hints *prom_storage.Labe
 		limit = int64(hints.Limit)
 	}
 
-	resNameSets := [][]string{}
+	resNameSets := make([][]string, len(shards))
+	errGroup, ctx := errgroup.WithContext(ctx)
+	errGroup.SetLimit(p.opts.concurrency)
 
-	for _, s := range shards {
-		r, err := s.LabelNames(ctx, matchers)
-		if err != nil {
-			return nil, nil, err
-		}
+	for i, s := range shards {
+		errGroup.Go(func() error {
+			r, err := s.LabelNames(ctx, limit, matchers)
+			resNameSets[i] = r
+			return err
+		})
+	}
 
-		resNameSets = append(resNameSets, r...)
+	if err := errGroup.Wait(); err != nil {
+		return nil, nil, err
 	}
 
 	return util.MergeUnsortedSlices(int(limit), resNameSets...), nil, nil
@@ -161,14 +172,21 @@ func (p parquetQuerier) Select(ctx context.Context, sorted bool, sp *prom_storag
 		minT, maxT = sp.Start, sp.End
 	}
 	skipChunks := sp != nil && sp.Func == "series"
+	errGroup, ctx := errgroup.WithContext(ctx)
+	errGroup.SetLimit(p.opts.concurrency)
 
 	for i, shard := range shards {
-		ss, err := shard.Query(ctx, sorted, minT, maxT, skipChunks, matchers)
-		if err != nil {
-			return prom_storage.ErrSeriesSet(err)
-		}
-		seriesSet[i] = ss
+		errGroup.Go(func() error {
+			ss, err := shard.Query(ctx, sorted, minT, maxT, skipChunks, matchers)
+			seriesSet[i] = ss
+			return err
+		})
 	}
+
+	if err := errGroup.Wait(); err != nil {
+		return prom_storage.ErrSeriesSet(err)
+	}
+
 	ss := convert.NewMergeChunkSeriesSet(seriesSet, labels.Compare, prom_storage.NewConcatenatingChunkSeriesMerger())
 
 	return convert.NewSeriesSetFromChunkSeriesSet(ss, skipChunks)
@@ -240,9 +258,9 @@ func (b queryableShard) Query(ctx context.Context, sorted bool, mint, maxt int64
 	return convert.NewChunksSeriesSet(results), nil
 }
 
-func (b queryableShard) LabelNames(ctx context.Context, matchers []*labels.Matcher) ([][]string, error) {
+func (b queryableShard) LabelNames(ctx context.Context, limit int64, matchers []*labels.Matcher) ([]string, error) {
 	if len(matchers) == 0 {
-		return [][]string{b.m.MaterializeAllLabelNames()}, nil
+		return b.m.MaterializeAllLabelNames(), nil
 	}
 	cs, err := MatchersToConstraint(matchers...)
 	if err != nil {
@@ -266,12 +284,12 @@ func (b queryableShard) LabelNames(ctx context.Context, matchers []*labels.Match
 		results[i] = series
 	}
 
-	return results, nil
+	return util.MergeUnsortedSlices(int(limit), results...), nil
 }
 
-func (b queryableShard) LabelValues(ctx context.Context, name string, matchers []*labels.Matcher) ([][]string, error) {
+func (b queryableShard) LabelValues(ctx context.Context, name string, limit int64, matchers []*labels.Matcher) ([]string, error) {
 	if len(matchers) == 0 {
-		return b.allLabelValues(ctx, name)
+		return b.allLabelValues(ctx, name, limit)
 	}
 	cs, err := MatchersToConstraint(matchers...)
 	if err != nil {
@@ -295,10 +313,10 @@ func (b queryableShard) LabelValues(ctx context.Context, name string, matchers [
 		results[i] = series
 	}
 
-	return results, nil
+	return util.MergeUnsortedSlices(int(limit), results...), nil
 }
 
-func (b queryableShard) allLabelValues(ctx context.Context, name string) ([][]string, error) {
+func (b queryableShard) allLabelValues(ctx context.Context, name string, limit int64) ([]string, error) {
 	results := make([][]string, len(b.shard.LabelsFile().RowGroups()))
 	for i := range b.shard.LabelsFile().RowGroups() {
 		series, err := b.m.MaterializeAllLabelValues(ctx, name, i)
@@ -308,7 +326,7 @@ func (b queryableShard) allLabelValues(ctx context.Context, name string) ([][]st
 		results[i] = series
 	}
 
-	return results, nil
+	return util.MergeUnsortedSlices(int(limit), results...), nil
 }
 
 type byLabels []prom_storage.ChunkSeries

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -837,7 +837,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/prometheus-community/parquet-common v0.0.0-20250522182606-e046c038dc73
+# github.com/prometheus-community/parquet-common v0.0.0-20250527060536-18d3dd36c09e
 ## explicit; go 1.23.4
 github.com/prometheus-community/parquet-common/convert
 github.com/prometheus-community/parquet-common/schema

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -837,7 +837,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/prometheus-community/parquet-common v0.0.0-20250528173345-0f445293e6c3
+# github.com/prometheus-community/parquet-common v0.0.0-20250528182644-e3db427160c2
 ## explicit; go 1.23.4
 github.com/prometheus-community/parquet-common/convert
 github.com/prometheus-community/parquet-common/schema

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -837,7 +837,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/prometheus-community/parquet-common v0.0.0-20250528210111-72a099ba73bf
+# github.com/prometheus-community/parquet-common v0.0.0-20250528231323-eec9c3c020f0
 ## explicit; go 1.23.4
 github.com/prometheus-community/parquet-common/convert
 github.com/prometheus-community/parquet-common/schema

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -837,7 +837,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/prometheus-community/parquet-common v0.0.0-20250528182644-e3db427160c2
+# github.com/prometheus-community/parquet-common v0.0.0-20250528210111-72a099ba73bf
 ## explicit; go 1.23.4
 github.com/prometheus-community/parquet-common/convert
 github.com/prometheus-community/parquet-common/schema

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -837,7 +837,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/prometheus-community/parquet-common v0.0.0-20250527060536-18d3dd36c09e
+# github.com/prometheus-community/parquet-common v0.0.0-20250528173345-0f445293e6c3
 ## explicit; go 1.23.4
 github.com/prometheus-community/parquet-common/convert
 github.com/prometheus-community/parquet-common/schema


### PR DESCRIPTION
**What this PR does**:

Introduces several improvements to the Parquet implementation:
  * Adds fallback to the blocks store queryable when vertical sharding is enabled, as this is currently unsupported in the Parquet queryable.
  * Sorts blocks by timestamp in the converter to prioritize recent blocks during conversion
  * Adds support for configuring maxRowGroupSize and flag to enabled/disableon-disk buffer in the converter.
  * Randomizes tenant order during conversion to improve fairness.
  * Pull latest parquet common 
    
**Which issue(s) this PR fixes**:
Part of https://github.com/cortexproject/cortex/pull/6712

**Checklist**
- [X] Tests updated
- [NA] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
