### PR TITLE
Do not return partial data if 422 or half of fleet is down

### DIFF
--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -333,7 +333,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 	if partialdata.IsPartialDataError(err) {
 		level.Warn(util_log.WithContext(ctx, d.log)).Log("msg", "returning partial data", "err", err.Error())
 		d.ingesterPartialDataQueries.Inc()
-		return resp, err
+		return resp, partialdata.ErrPartialData
 	}
 
 	return resp, nil

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/extract"
 	"github.com/cortexproject/cortex/pkg/util/grpcutil"
 	"github.com/cortexproject/cortex/pkg/util/limiter"
+	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
@@ -330,7 +331,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 	reqStats.AddFetchedSamples(uint64(resp.SamplesCount()))
 
 	if partialdata.IsPartialDataError(err) {
-		level.Warn(d.log).Log("msg", "returning partial data", "err", err.Error())
+		level.Warn(util_log.WithContext(ctx, d.log)).Log("msg", "returning partial data", "err", err.Error())
 		d.ingesterPartialDataQueries.Inc()
 		return resp, err
 	}

--- a/pkg/ring/replication_set_tracker.go
+++ b/pkg/ring/replication_set_tracker.go
@@ -1,6 +1,8 @@
 package ring
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type replicationSetResultTracker interface {
 	// Signals an instance has done the execution, either successful (no error)
@@ -160,7 +162,9 @@ func (t *zoneAwareResultTracker) failed() bool {
 
 func (t *zoneAwareResultTracker) failedCompletely() bool {
 	failedZones := len(t.failuresByZone)
-	return failedZones == t.zoneCount
+	allZonesFailed := failedZones == t.zoneCount
+	atLeastHalfOfFleetFailed := len(t.errors) >= t.numInstances/2
+	return allZonesFailed || (t.failed() && atLeastHalfOfFleetFailed)
 }
 
 func (t *zoneAwareResultTracker) getResults() []interface{} {

--- a/pkg/ring/replication_set_tracker_test.go
+++ b/pkg/ring/replication_set_tracker_test.go
@@ -467,6 +467,18 @@ func TestZoneAwareResultTracker(t *testing.T) {
 				assert.True(t, tracker.failedCompletely())
 			},
 		},
+		"failedCompletely() should return true if failed() is true and half of the fleet are unavailable": {
+			instances:           []InstanceDesc{instance1, instance2, instance3, instance4, instance5, instance6},
+			maxUnavailableZones: 1,
+			run: func(t *testing.T, tracker *zoneAwareResultTracker) {
+				tracker.done(&instance1, nil, errors.New("test")) // Zone-a
+				tracker.done(&instance2, nil, errors.New("test")) // Zone-a
+				tracker.done(&instance3, nil, errors.New("test")) // Zone-b
+
+				assert.True(t, tracker.failed())
+				assert.True(t, tracker.failedCompletely())
+			},
+		},
 		"finished() should return true only if all instances are done": {
 			instances:           []InstanceDesc{instance1, instance2},
 			maxUnavailableZones: 1,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR enhances partial data feature used in ingesters and rulers with the followings:
1. If an ingester return 422, return 422 instead of partial data
2. If at least half of ingesters are down, return 5xx instead of partial data
3. Enhance partial data log with user and request info

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
