### PR TITLE
Fix nil pointer exception in GenerateTokens

### DIFF
--- a/pkg/ring/token_generator.go
+++ b/pkg/ring/token_generator.go
@@ -136,7 +136,11 @@ func (g *MinimizeSpreadTokenGenerator) GenerateTokens(ring *Desc, id, zone strin
 	for i := 1; i <= len(zonalTokens); i++ {
 		index := i % len(zonalTokens)
 		if tokenInstanceId, ok := usedTokens[zonalTokens[index]]; ok && tokenInstanceId != id {
-			instanceDistance := tokensPerInstanceWithDistance[tokenInstanceId]
+			instanceDistance, ok := tokensPerInstanceWithDistance[tokenInstanceId]
+			if !ok {
+				continue // Same token is shared to an ingester in different zone, skip
+			}
+
 			instanceDistance.tokens = append(instanceDistance.tokens, &tokenDistanceEntry{
 				token:    zonalTokens[index],
 				prev:     zonalTokens[i-1],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Tests have been failing time to time with nil pointer exception:

```
--- FAIL: TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy (66.59s)
    --- FAIL: TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy/num_instances_=_90,_num_zones_=_3,_stable_sharding_=_false (0.05s)
        ring_test.go:2651: random generator seed: 1748469386062678254
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x18510e7]

goroutine 774 [running]:
testing.tRunner.func1.2({0x1b31d80, 0x2c96f70})
	/usr/local/go/src/testing/testing.go:1734 +0x3eb
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1737 +0x696
panic({0x1b31d80?, 0x2c96f70?})
	/usr/local/go/src/runtime/panic.go:787 +0x132
github.com/cortexproject/cortex/pkg/ring.(*MinimizeSpreadTokenGenerator).GenerateTokens(0xc000[71](https://github.com/cortexproject/cortex/actions/runs/15311310558/job/43076393758#step:6:72)b060, 0xc0000b2848, {0xc000326045, 0xb}, {0xc00032606a, 0x6}, 0x80, 0x1)
	/__w/cortex/cortex/pkg/ring/token_generator.go:140 +0x1027
github.com/cortexproject/cortex/pkg/ring.TestRing_ShuffleShardWithLookback_CorrectnessWithFuzzy.func1(0xc00009a700)
	/__w/cortex/cortex/pkg/ring/ring_test.go:2700 +0xe92
testing.tRunner(0xc00009a700, 0xc0006985a0)
	/usr/local/go/src/testing/testing.go:1792 +0x226
created by testing.(*T).Run in goroutine [72](https://github.com/cortexproject/cortex/actions/runs/15311310558/job/43076393758#step:6:73)6
	/usr/local/go/src/testing/testing.go:1851 +0x8f3
FAIL	github.com/cortexproject/cortex/pkg/ring	114.979s
```

This exception happens when a token is shared to an ingester in different zone.

**Which issue(s) this PR fixes**:
Fixes tests

**Checklist**
- [n/a] Tests updated
- [n/a] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
