### PR TITLE
Fix race condition in active user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [BUGFIX] Query Frontend: Fix query frontend per `user` metrics clean up. #6698
 * [BUGFIX] Add `__markers__` tenant ID validation. #6761
 * [BUGFIX] Ring: Fix nil pointer exception when token is shared. #6768
+* [BUGFIX] Fix race condition in active user. #6773
 
 ## 1.19.0 2025-02-27
 

--- a/pkg/util/active_user.go
+++ b/pkg/util/active_user.go
@@ -95,8 +95,8 @@ func (m *ActiveUsers) PurgeInactiveUsers(deadline int64) []string {
 }
 
 func (m *ActiveUsers) ActiveUsers(deadline int64) []string {
-	active := make([]string, 0, len(m.timestamps))
 	m.mu.RLock()
+	active := make([]string, 0, len(m.timestamps))
 	defer m.mu.RUnlock()
 	for userID, ts := range m.timestamps {
 		if ts.Load() > deadline {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

I have noticed a race condition in `active_user.go`. (https://github.com/cortexproject/cortex/actions/runs/15336995596/job/43156054957?pr=6763)
This PR fixes it.
The logs are:
```
WARNING: DATA RACE
Read at 0x00c00411e420 by goroutine 996:
  github.com/cortexproject/cortex/pkg/util.(*ActiveUsers).ActiveUsers()
      /__w/cortex/cortex/pkg/util/active_user.go:98 +0x87
  github.com/cortexproject/cortex/pkg/util.(*ActiveUsersCleanupService).ActiveUsers()
      /__w/cortex/cortex/pkg/util/active_user.go:146 +0x139
  github.com/cortexproject/cortex/pkg/distributor.(*Distributor).updateLabelSetMetrics()
      /__w/cortex/cortex/pkg/distributor/distributor.go:814 +0x104
  github.com/cortexproject/cortex/pkg/distributor.(*Distributor).running()
      /__w/cortex/cortex/pkg/distributor/distributor.go:489 +0x4b1
  github.com/cortexproject/cortex/pkg/distributor.(*Distributor).running-fm()
      <autogenerated>:1 +0x47
  github.com/cortexproject/cortex/pkg/util/services.(*BasicService).main()
      /__w/cortex/cortex/pkg/util/services/basic_service.go:190 +0x3ab
  github.com/cortexproject/cortex/pkg/util/services.(*BasicService).StartAsync.func1.gowrap1()
      /__w/cortex/cortex/pkg/util/services/basic_service.go:119 +0x33

Previous write at 0x00c00411e420 by goroutine 1000:
  runtime.mapassign()
      /usr/local/go/src/internal/runtime/maps/runtime_swiss.go:191 +0x0
  github.com/cortexproject/cortex/pkg/util.(*ActiveUsers).PurgeInactiveUsers()
      /__w/cortex/cortex/pkg/util/active_user.go:80 +0x3f7
  github.com/cortexproject/cortex/pkg/util.(*ActiveUsersCleanupService).iteration()
      /__w/cortex/cortex/pkg/util/active_user.go:138 +0x144
  github.com/cortexproject/cortex/pkg/util.(*ActiveUsersCleanupService).iteration-fm()
      <autogenerated>:1 +0x47
  github.com/cortexproject/cortex/pkg/util.NewActiveUsersCleanupService.NewTimerService.func1()
      /__w/cortex/cortex/pkg/util/services/services.go:33 +0x1d8
  github.com/cortexproject/cortex/pkg/util/services.(*BasicService).main()
      /__w/cortex/cortex/pkg/util/services/basic_service.go:190 +0x3ab
  github.com/cortexproject/cortex/pkg/util/services.(*BasicService).StartAsync.func1.gowrap1()
      /__w/cortex/cortex/pkg/util/services/basic_service.go:119 +0x33
```
The reason is that go-routines could access `m.timestamps` simultaneously.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
