### PR TITLE
ThanosEngine: Only enable default optimizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master / unreleased
+* [BUGFIX] ThanosEngine: Only enable default optimizers. #6776
 * [ENHANCEMENT] Distributor: Add min/max schema validation for NativeHistograms. #6766
 * [ENHANCEMENT] Ingester: Handle runtime errors in query path #6769
 * [CHANGE] Ingester: Remove EnableNativeHistograms config flag and instead gate keep through new per-tenant limit at ingestion. #6718

--- a/pkg/querier/engine_factory.go
+++ b/pkg/querier/engine_factory.go
@@ -26,7 +26,7 @@ func NewEngineFactory(opts promql.EngineOpts, enableThanosEngine bool, reg prome
 	if enableThanosEngine {
 		thanosEngine = engine.New(engine.Opts{
 			EngineOpts:        opts,
-			LogicalOptimizers: logicalplan.AllOptimizers,
+			LogicalOptimizers: logicalplan.DefaultOptimizers,
 			EnableAnalysis:    true,
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Let's only enable the default optimizers in Thanos engine. PropagateMatchersOptimizer seems to have bugs.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
