### PR TITLE
Support caching bucket for cleaner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 * [ENHANCEMENT] Querier: Add `querier.ingester-query-max-attempts` to retry on partial data. #6714
 * [ENHANCEMENT] Distributor: Add min/max schema validation for NativeHistograms. #6766
 * [ENHANCEMENT] Ingester: Handle runtime errors in query path #6769
-* [ENHANCEMENT] Compactor: Support metadata caching bucket for Cleaner. #6778
+* [ENHANCEMENT] Compactor: Support metadata caching bucket for Cleaner. Can be enabled via `-compactor.cleaner-caching-bucket-enabled` flag. #6778
 * [BUGFIX] Ingester: Avoid error or early throttling when READONLY ingesters are present in the ring #6517
 * [BUGFIX] Ingester: Fix labelset data race condition. #6573
 * [BUGFIX] Compactor: Cleaner should not put deletion marker for blocks with no-compact marker. #6576

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [ENHANCEMENT] Querier: Add `querier.ingester-query-max-attempts` to retry on partial data. #6714
 * [ENHANCEMENT] Distributor: Add min/max schema validation for NativeHistograms. #6766
 * [ENHANCEMENT] Ingester: Handle runtime errors in query path #6769
+* [ENHANCEMENT] Compactor: Support metadata caching bucket for Cleaner. #6778
 * [BUGFIX] Ingester: Avoid error or early throttling when READONLY ingesters are present in the ring #6517
 * [BUGFIX] Ingester: Fix labelset data race condition. #6573
 * [BUGFIX] Compactor: Cleaner should not put deletion marker for blocks with no-compact marker. #6576

--- a/docs/blocks-storage/compactor.md
+++ b/docs/blocks-storage/compactor.md
@@ -333,4 +333,8 @@ compactor:
   # service, which serves as the source of truth for block status
   # CLI flag: -compactor.caching-bucket-enabled
   [caching_bucket_enabled: <boolean> | default = false]
+
+  # When enabled, caching bucket will be used for cleaner
+  # CLI flag: -compactor.cleaner-caching-bucket-enabled
+  [cleaner_caching_bucket_enabled: <boolean> | default = false]
 ```

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2413,6 +2413,10 @@ sharding_ring:
 # service, which serves as the source of truth for block status
 # CLI flag: -compactor.caching-bucket-enabled
 [caching_bucket_enabled: <boolean> | default = false]
+
+# When enabled, caching bucket will be used for cleaner
+# CLI flag: -compactor.cleaner-caching-bucket-enabled
+[cleaner_caching_bucket_enabled: <boolean> | default = false]
 ```
 
 ### `configs_config`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

There was an attempt before to support metadata cache for compactor in https://github.com/cortexproject/cortex/pull/5682.

It only supports compactor and ignores cleaner as it is intended for cleaner to be source of truth of the bucket.

This makes sense but Cleaner also does a lot of calls to object storage so it would be nice to explore if we can use metadata caching bucket for Cleaner.

This PR tries to cache certain objstore operations for cleaner:
- GET for block meta.json
- GET for tenant deletion marker
- Iter for list of tenants

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
