### PR TITLE
Ruler: Prevent counting 2xx responses as failed writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [BUGFIX] Add `__markers__` tenant ID validation. #6761
 * [BUGFIX] Ring: Fix nil pointer exception when token is shared. #6768
 * [BUGFIX] Fix race condition in active user. #6773
+* [BUGFIX] Ruler: Prevent counting 2xx responses as failed writes. #6785
 
 ## 1.19.0 2025-02-27
 

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -96,7 +96,7 @@ func (a *PusherAppender) Commit() error {
 	_, err := a.pusher.Push(user.InjectOrgID(a.ctx, a.userID), req)
 	if err != nil {
 		// Don't report errors that ended with 4xx HTTP status code (series limits, duplicate samples, out of order, etc.)
-		if resp, ok := httpgrpc.HTTPResponseFromError(err); !ok || resp.Code/100 != 4 {
+		if resp, ok := httpgrpc.HTTPResponseFromError(err); !ok || resp.Code/100 == 5 {
 			a.failedWrites.Inc()
 		}
 	}


### PR DESCRIPTION
**What this PR does**:

In some cases, the Distributor returns a 2xx with error. On the ruler side, this causes `failedWrites` to be incremented. This PR prevents `failedWrites` counter from being incremented in cases where the distributor returns a 2xx with an error

