### PR TITLE
Skip corrupt blocks on shipper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [BUGFIX] Add `__markers__` tenant ID validation. #6761
 * [BUGFIX] Ring: Fix nil pointer exception when token is shared. #6768
 * [BUGFIX] Fix race condition in active user. #6773
+* [BUGFIX] Ingester: Allow shipper to skip corrupted blocks. #6786
 
 ## 1.19.0 2025-02-27
 

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/thanos-io/objstore v0.0.0-20250317105316-a0136a6f898d
 	github.com/thanos-io/promql-engine v0.0.0-20250522103302-dd83bd8fdb50
-	github.com/thanos-io/thanos v0.37.3-0.20250529092349-12649d8be797
+	github.com/thanos-io/thanos v0.37.3-0.20250603135757-4ad45948cd10
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/weaveworks/common v0.0.0-20230728070032-dd9e68f319d5
 	go.etcd.io/etcd/api/v3 v3.5.17

--- a/go.sum
+++ b/go.sum
@@ -1697,8 +1697,8 @@ github.com/thanos-io/objstore v0.0.0-20241111205755-d1dd89d41f97 h1:VjG0mwhN1Dkn
 github.com/thanos-io/objstore v0.0.0-20241111205755-d1dd89d41f97/go.mod h1:vyzFrBXgP+fGNG2FopEGWOO/zrIuoy7zt3LpLeezRsw=
 github.com/thanos-io/promql-engine v0.0.0-20250522103302-dd83bd8fdb50 h1:RGdaDAyFOjrFJSjaPT2z8robLvQ3KxNiNEN3DojpLOs=
 github.com/thanos-io/promql-engine v0.0.0-20250522103302-dd83bd8fdb50/go.mod h1:agUazAk1yHLYSL87MdEcRbjN12DJ9OZfSUcfFLqy+F8=
-github.com/thanos-io/thanos v0.37.3-0.20250529092349-12649d8be797 h1:Co+TgEgln2gBoQJ7cjzD9f8Uj3+8MmqPnp33FvNOtYw=
-github.com/thanos-io/thanos v0.37.3-0.20250529092349-12649d8be797/go.mod h1:hqWLLR6Yd7remOR33hRgVkg28Gx40Nh3mhWryB8RVJs=
+github.com/thanos-io/thanos v0.37.3-0.20250603135757-4ad45948cd10 h1:mtmcivEm0EoXeHTJAgjXTthyQSTLNFWrPTzpiovau3Y=
+github.com/thanos-io/thanos v0.37.3-0.20250603135757-4ad45948cd10/go.mod h1:2NvA8ZJtoGcOTriumDnJQzDmbxJz1ISGPovVAGGYDbg=
 github.com/tjhop/slog-gokit v0.1.4 h1:uj/vbDt3HaF0Py8bHPV4ti/s0utnO0miRbO277FLBKM=
 github.com/tjhop/slog-gokit v0.1.4/go.mod h1:Bbu5v2748qpAWH7k6gse/kw3076IJf6owJmh7yArmJs=
 github.com/trivago/tgo v1.0.7 h1:uaWH/XIy9aWYWpjm2CU3RpcqZXmX2ysQ9/Go+d9gyrM=

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -312,6 +312,7 @@ type tsdbMetrics struct {
 	dirSyncFailures *prometheus.Desc // sum(thanos_shipper_dir_sync_failures_total)
 	uploads         *prometheus.Desc // sum(thanos_shipper_uploads_total)
 	uploadFailures  *prometheus.Desc // sum(thanos_shipper_upload_failures_total)
+	corruptedBlocks *prometheus.Desc // sum(thanos_shipper_corrupted_blocks_total)
 
 	// Metrics aggregated from TSDB.
 	tsdbCompactionsTotal               *prometheus.Desc
@@ -389,6 +390,10 @@ func newTSDBMetrics(r prometheus.Registerer) *tsdbMetrics {
 		uploadFailures: prometheus.NewDesc(
 			"cortex_ingester_shipper_upload_failures_total",
 			"Total number of TSDB block upload failures",
+			nil, nil),
+		corruptedBlocks: prometheus.NewDesc(
+			"cortex_ingester_shipper_corrupted_blocks_total",
+			"Total number of TSDB blocks corrupted",
 			nil, nil),
 		tsdbCompactionsTotal: prometheus.NewDesc(
 			"cortex_ingester_tsdb_compactions_total",
@@ -579,6 +584,7 @@ func (sm *tsdbMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- sm.dirSyncFailures
 	out <- sm.uploads
 	out <- sm.uploadFailures
+	out <- sm.corruptedBlocks
 
 	out <- sm.tsdbCompactionsTotal
 	out <- sm.tsdbCompactionDuration
@@ -636,6 +642,7 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCounters(out, sm.dirSyncFailures, "thanos_shipper_dir_sync_failures_total")
 	data.SendSumOfCounters(out, sm.uploads, "thanos_shipper_uploads_total")
 	data.SendSumOfCounters(out, sm.uploadFailures, "thanos_shipper_upload_failures_total")
+	data.SendSumOfCounters(out, sm.corruptedBlocks, "thanos_shipper_corrupted_blocks_total")
 
 	data.SendSumOfCounters(out, sm.tsdbCompactionsTotal, "prometheus_tsdb_compactions_total")
 	data.SendSumOfHistograms(out, sm.tsdbCompactionDuration, "prometheus_tsdb_compaction_duration_seconds")

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -187,6 +187,11 @@ func TestTSDBMetrics(t *testing.T) {
 			# 4*(12345 + 85787 + 999)
 			cortex_ingester_shipper_upload_failures_total 396524
 
+            # HELP cortex_ingester_shipper_corrupted_blocks_total Total number of TSDB blocks corrupted
+			# TYPE cortex_ingester_shipper_corrupted_blocks_total counter
+			# 30*(12345 + 85787 + 999)
+			cortex_ingester_shipper_corrupted_blocks_total 2973930
+
 			# HELP cortex_ingester_tsdb_compactions_total Total number of TSDB compactions that were executed.
 			# TYPE cortex_ingester_tsdb_compactions_total counter
 			cortex_ingester_tsdb_compactions_total 693917
@@ -446,6 +451,12 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 			# 4*(12345 + 85787 + 999)
 			cortex_ingester_shipper_upload_failures_total 396524
 
+            # HELP cortex_ingester_shipper_corrupted_blocks_total Total number of TSDB blocks corrupted
+			# TYPE cortex_ingester_shipper_corrupted_blocks_total counter
+			# 30*(12345 + 85787 + 999)
+			cortex_ingester_shipper_corrupted_blocks_total 2973930
+
+
 			# HELP cortex_ingester_tsdb_compactions_total Total number of TSDB compactions that were executed.
 			# TYPE cortex_ingester_tsdb_compactions_total counter
 			cortex_ingester_tsdb_compactions_total 693917
@@ -687,6 +698,12 @@ func populateTSDBMetrics(base float64) *prometheus.Registry {
 		Help: "Total number of block upload failures",
 	})
 	uploadFailures.Add(4 * base)
+
+	corruptedBlocks := promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "thanos_shipper_corrupted_blocks_total",
+		Help: "Total number of corrupted blocks",
+	})
+	corruptedBlocks.Add(30 * base)
 
 	// TSDB Head
 	seriesCreated := promauto.With(r).NewCounter(prometheus.CounterOpts{

--- a/vendor/github.com/thanos-io/thanos/pkg/shipper/shipper.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/shipper/shipper.go
@@ -37,6 +37,7 @@ type metrics struct {
 	dirSyncFailures   prometheus.Counter
 	uploads           prometheus.Counter
 	uploadFailures    prometheus.Counter
+	corruptedBlocks   prometheus.Counter
 	uploadedCompacted prometheus.Gauge
 }
 
@@ -59,6 +60,10 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		Name: "thanos_shipper_upload_failures_total",
 		Help: "Total number of block upload failures",
 	})
+	m.corruptedBlocks = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "thanos_shipper_corrupted_blocks_total",
+		Help: "Total number of corrupted blocks",
+	})
 	m.uploadedCompacted = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 		Name: "thanos_shipper_upload_compacted_done",
 		Help: "If 1 it means shipper uploaded all compacted blocks from the filesystem.",
@@ -76,56 +81,135 @@ type Shipper struct {
 	source           metadata.SourceType
 	metadataFilePath string
 
-	uploadCompactedFunc    func() bool
+	uploadCompacted        bool
 	allowOutOfOrderUploads bool
+	skipCorruptedBlocks    bool
 	hashFunc               metadata.HashFunc
 
 	labels func() labels.Labels
 	mtx    sync.RWMutex
 }
 
+var (
+	ErrorSyncBlockCorrupted = errors.New("corrupted blocks found")
+)
+
+type shipperOptions struct {
+	logger                 log.Logger
+	r                      prometheus.Registerer
+	source                 metadata.SourceType
+	hashFunc               metadata.HashFunc
+	metaFileName           string
+	lbls                   func() labels.Labels
+	uploadCompacted        bool
+	allowOutOfOrderUploads bool
+	skipCorruptedBlocks    bool
+}
+
+type Option func(*shipperOptions)
+
+// WithLogger sets the logger.
+func WithLogger(logger log.Logger) Option {
+	return func(o *shipperOptions) {
+		o.logger = logger
+	}
+}
+
+// WithRegisterer sets the Prometheus registerer.
+func WithRegisterer(r prometheus.Registerer) Option {
+	return func(o *shipperOptions) {
+		o.r = r
+	}
+}
+
+// WithSource sets the metadata source type.
+func WithSource(source metadata.SourceType) Option {
+	return func(o *shipperOptions) {
+		o.source = source
+	}
+}
+
+// WithHashFunc sets the hash function.
+func WithHashFunc(hashFunc metadata.HashFunc) Option {
+	return func(o *shipperOptions) {
+		o.hashFunc = hashFunc
+	}
+}
+
+// WithMetaFileName sets the meta file name.
+func WithMetaFileName(name string) Option {
+	return func(o *shipperOptions) {
+		o.metaFileName = name
+	}
+}
+
+// WithLabels sets the labels function.
+func WithLabels(lbls func() labels.Labels) Option {
+	return func(o *shipperOptions) {
+		o.lbls = lbls
+	}
+}
+
+// WithUploadCompacted sets whether to upload compacted blocks.
+func WithUploadCompacted(upload bool) Option {
+	return func(o *shipperOptions) {
+		o.uploadCompacted = upload
+	}
+}
+
+// WithAllowOutOfOrderUploads sets whether to allow out of order uploads.
+func WithAllowOutOfOrderUploads(allow bool) Option {
+	return func(o *shipperOptions) {
+		o.allowOutOfOrderUploads = allow
+	}
+}
+
+// WithSkipCorruptedBlocks sets whether to skip corrupted blocks.
+func WithSkipCorruptedBlocks(skip bool) Option {
+	return func(o *shipperOptions) {
+		o.skipCorruptedBlocks = skip
+	}
+}
+
+func applyOptions(opts []Option) *shipperOptions {
+	so := new(shipperOptions)
+	for _, o := range opts {
+		o(so)
+	}
+
+	if so.logger == nil {
+		so.logger = log.NewNopLogger()
+	}
+
+	if so.lbls == nil {
+		so.lbls = func() labels.Labels { return labels.EmptyLabels() }
+	}
+
+	if so.metaFileName == "" {
+		so.metaFileName = DefaultMetaFilename
+	}
+
+	return so
+}
+
 // New creates a new shipper that detects new TSDB blocks in dir and uploads them to
 // remote if necessary. It attaches the Thanos metadata section in each meta JSON file.
 // If uploadCompacted is enabled, it also uploads compacted blocks which are already in filesystem.
-func New(
-	logger log.Logger,
-	r prometheus.Registerer,
-	dir string,
-	bucket objstore.Bucket,
-	lbls func() labels.Labels,
-	source metadata.SourceType,
-	uploadCompactedFunc func() bool,
-	allowOutOfOrderUploads bool,
-	hashFunc metadata.HashFunc,
-	metaFileName string,
-) *Shipper {
-	if logger == nil {
-		logger = log.NewNopLogger()
-	}
-	if lbls == nil {
-		lbls = func() labels.Labels { return labels.EmptyLabels() }
-	}
+func New(bucket objstore.Bucket, dir string, opts ...Option) *Shipper {
+	options := applyOptions(opts)
 
-	if metaFileName == "" {
-		metaFileName = DefaultMetaFilename
-	}
-
-	if uploadCompactedFunc == nil {
-		uploadCompactedFunc = func() bool {
-			return false
-		}
-	}
 	return &Shipper{
-		logger:                 logger,
+		logger:                 options.logger,
 		dir:                    dir,
 		bucket:                 bucket,
-		labels:                 lbls,
-		metrics:                newMetrics(r),
-		source:                 source,
-		allowOutOfOrderUploads: allowOutOfOrderUploads,
-		uploadCompactedFunc:    uploadCompactedFunc,
-		hashFunc:               hashFunc,
-		metadataFilePath:       filepath.Join(dir, filepath.Clean(metaFileName)),
+		labels:                 options.lbls,
+		metrics:                newMetrics(options.r),
+		source:                 options.source,
+		allowOutOfOrderUploads: options.allowOutOfOrderUploads,
+		skipCorruptedBlocks:    options.skipCorruptedBlocks,
+		uploadCompacted:        options.uploadCompacted,
+		hashFunc:               options.hashFunc,
+		metadataFilePath:       filepath.Join(dir, filepath.Clean(options.metaFileName)),
 	}
 }
 
@@ -237,13 +321,22 @@ func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 	meta.Uploaded = nil
 
 	var (
-		checker    = newLazyOverlapChecker(s.logger, s.bucket, func() labels.Labels { return s.labels() })
-		uploadErrs int
+		checker         = newLazyOverlapChecker(s.logger, s.bucket, func() labels.Labels { return s.labels() })
+		uploadErrs      int
+		failedExecution = true
 	)
 
-	uploadCompacted := s.uploadCompactedFunc()
-	metas, err := s.blockMetasFromOldest()
-	if err != nil {
+	defer func() {
+		if failedExecution {
+			s.metrics.dirSyncFailures.Inc()
+		} else {
+			s.metrics.dirSyncs.Inc()
+		}
+	}()
+
+	metas, failedBlocks, err := s.blockMetasFromOldest()
+	// Ignore error when we should ignore failed blocks
+	if err != nil && (!errors.Is(errors.Cause(err), ErrorSyncBlockCorrupted) || !s.skipCorruptedBlocks) {
 		return 0, err
 	}
 	for _, m := range metas {
@@ -262,7 +355,7 @@ func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 
 		// We only ship of the first compacted block level as normal flow.
 		if m.Compaction.Level > 1 {
-			if !uploadCompacted {
+			if !s.uploadCompacted {
 				continue
 			}
 		}
@@ -270,7 +363,7 @@ func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 		// Check against bucket if the meta file for this block exists.
 		ok, err := s.bucket.Exists(ctx, path.Join(m.ULID.String(), block.MetaFilename))
 		if err != nil {
-			return 0, errors.Wrap(err, "check exists")
+			return uploaded, errors.Wrap(err, "check exists")
 		}
 		if ok {
 			meta.Uploaded = append(meta.Uploaded, m.ULID)
@@ -280,13 +373,13 @@ func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 		// Skip overlap check if out of order uploads is enabled.
 		if m.Compaction.Level > 1 && !s.allowOutOfOrderUploads {
 			if err := checker.IsOverlapping(ctx, m.BlockMeta); err != nil {
-				return 0, errors.Errorf("Found overlap or error during sync, cannot upload compacted block, details: %v", err)
+				return uploaded, errors.Errorf("Found overlap or error during sync, cannot upload compacted block, details: %v", err)
 			}
 		}
 
 		if err := s.upload(ctx, m); err != nil {
 			if !s.allowOutOfOrderUploads {
-				return 0, errors.Wrapf(err, "upload %v", m.ULID)
+				return uploaded, errors.Wrapf(err, "upload %v", m.ULID)
 			}
 
 			// No error returned, just log line. This is because we want other blocks to be uploaded even
@@ -303,13 +396,14 @@ func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 		level.Warn(s.logger).Log("msg", "updating meta file failed", "err", err)
 	}
 
-	s.metrics.dirSyncs.Inc()
-	if uploadErrs > 0 {
+	failedExecution = false
+	if uploadErrs > 0 || len(failedBlocks) > 0 {
 		s.metrics.uploadFailures.Add(float64(uploadErrs))
-		return uploaded, errors.Errorf("failed to sync %v blocks", uploadErrs)
+		s.metrics.corruptedBlocks.Add(float64(len(failedBlocks)))
+		return uploaded, errors.Errorf("failed to sync %v/%v blocks", uploadErrs, len(failedBlocks))
 	}
 
-	if uploadCompacted {
+	if s.uploadCompacted {
 		s.metrics.uploadedCompacted.Set(1)
 	} else {
 		s.metrics.uploadedCompacted.Set(0)
@@ -374,10 +468,10 @@ func (s *Shipper) upload(ctx context.Context, meta *metadata.Meta) error {
 
 // blockMetasFromOldest returns the block meta of each block found in dir
 // sorted by minTime asc.
-func (s *Shipper) blockMetasFromOldest() (metas []*metadata.Meta, _ error) {
+func (s *Shipper) blockMetasFromOldest() (metas []*metadata.Meta, failedBlocks []string, _ error) {
 	fis, err := os.ReadDir(s.dir)
 	if err != nil {
-		return nil, errors.Wrap(err, "read dir")
+		return nil, nil, errors.Wrap(err, "read dir")
 	}
 	names := make([]string, 0, len(fis))
 	for _, fi := range fis {
@@ -391,21 +485,35 @@ func (s *Shipper) blockMetasFromOldest() (metas []*metadata.Meta, _ error) {
 
 		fi, err := os.Stat(dir)
 		if err != nil {
-			return nil, errors.Wrapf(err, "stat block %v", dir)
+			if s.skipCorruptedBlocks {
+				level.Error(s.logger).Log("msg", "stat block", "err", err, "block", dir)
+				failedBlocks = append(failedBlocks, n)
+				continue
+			}
+			return nil, nil, errors.Wrapf(err, "stat block %v", dir)
 		}
 		if !fi.IsDir() {
 			continue
 		}
 		m, err := metadata.ReadFromDir(dir)
 		if err != nil {
-			return nil, errors.Wrapf(err, "read metadata for block %v", dir)
+			if s.skipCorruptedBlocks {
+				level.Error(s.logger).Log("msg", "read metadata for block", "err", err, "block", dir)
+				failedBlocks = append(failedBlocks, n)
+				continue
+			}
+			return nil, nil, errors.Wrapf(err, "read metadata for block %v", dir)
 		}
 		metas = append(metas, m)
 	}
 	sort.Slice(metas, func(i, j int) bool {
 		return metas[i].BlockMeta.MinTime < metas[j].BlockMeta.MinTime
 	})
-	return metas, nil
+
+	if len(failedBlocks) > 0 {
+		err = ErrorSyncBlockCorrupted
+	}
+	return metas, failedBlocks, err
 }
 
 func hardlinkBlock(src, dst string) error {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1114,7 +1114,7 @@ github.com/thanos-io/promql-engine/query
 github.com/thanos-io/promql-engine/ringbuffer
 github.com/thanos-io/promql-engine/storage
 github.com/thanos-io/promql-engine/storage/prometheus
-# github.com/thanos-io/thanos v0.37.3-0.20250529092349-12649d8be797
+# github.com/thanos-io/thanos v0.37.3-0.20250603135757-4ad45948cd10
 ## explicit; go 1.24.0
 github.com/thanos-io/thanos/pkg/api/query/querypb
 github.com/thanos-io/thanos/pkg/block


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Update thanos to version https://github.com/thanos-io/thanos/commit/4ad45948cd1098000270dc52c8d2f5f077e02076

Enable skip corrupted blocks when using shipper for ingester.

Forwarding new metric used by thanos
```
cortex_ingester_shipper_corrupted_blocks_total
```

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
