### PR TITLE
allow override parquet queryable block store via header

### DIFF
--- a/pkg/api/queryapi/query_api.go
+++ b/pkg/api/queryapi/query_api.go
@@ -3,6 +3,7 @@ package queryapi
 import (
 	"context"
 	"fmt"
+	"github.com/cortexproject/cortex/pkg/querier"
 	"net/http"
 	"time"
 
@@ -98,6 +99,7 @@ func (q *QueryAPI) RangeQueryHandler(r *http.Request) (result apiFuncResult) {
 	}
 
 	ctx = engine.AddEngineTypeToContext(ctx, r)
+	ctx = querier.AddBlockStoreTypeToContext(ctx, r.Header.Get(querier.BlockStoreTypeHeader))
 	qry, err := q.queryEngine.NewRangeQuery(ctx, q.queryable, opts, r.FormValue("query"), convertMsToTime(start), convertMsToTime(end), convertMsToDuration(step))
 	if err != nil {
 		return invalidParamError(httpgrpc.Errorf(http.StatusBadRequest, "%s", err.Error()), "query")
@@ -153,6 +155,7 @@ func (q *QueryAPI) InstantQueryHandler(r *http.Request) (result apiFuncResult) {
 	}
 
 	ctx = engine.AddEngineTypeToContext(ctx, r)
+	ctx = querier.AddBlockStoreTypeToContext(ctx, r.Header.Get(querier.BlockStoreTypeHeader))
 	qry, err := q.queryEngine.NewInstantQuery(ctx, q.queryable, opts, r.FormValue("query"), convertMsToTime(ts))
 	if err != nil {
 		return invalidParamError(httpgrpc.Errorf(http.StatusBadRequest, "%s", err.Error()), "query")

--- a/pkg/api/queryapi/query_api.go
+++ b/pkg/api/queryapi/query_api.go
@@ -3,7 +3,6 @@ package queryapi
 import (
 	"context"
 	"fmt"
-	"github.com/cortexproject/cortex/pkg/querier"
 	"net/http"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/cortexproject/cortex/pkg/engine"
+	"github.com/cortexproject/cortex/pkg/querier"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/api"
 )

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -1677,6 +1677,13 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			expected: errShuffleShardingLookbackLessThanQueryStoreAfter,
 		},
+		"should fail if invalid parquet queryable default block store": {
+			setup: func(cfg *Config) {
+				cfg.EnableParquetQueryable = true
+				cfg.ParquetQueryableDefaultBlockStore = "none"
+			},
+			expected: errInvalidParquetQueryableDefaultBlockStore,
+		},
 	}
 
 	for testName, testData := range tests {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR allows override block store to query in parquet queryable via HTTP header `X-Cortex-BlockStore-Type`. It can be set to either `tsdb` or `parquet`. If `tsdb`, it forces to query store gateway (TSDB). If `parquet`, it forces to query parquet blocks if possible + tsdb blocks if missing.

This can be useful for rollout and it can be enabled per request basis to test parquet storage. Note that this is block store switch is only available for Instant and Range query API as we have our own query handlers there. It is not available for labels API today.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
