### PR TITLE
Add active series limit for nativeHistograms samples

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3544,6 +3544,11 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # CLI flag: -ingester.max-series-per-metric
 [max_series_per_metric: <int> | default = 50000]
 
+# The maximum number of active nativeHistograms series per user, per ingester. 0
+# to disable.
+# CLI flag: -ingester.max-native-histograms-series-per-user
+[max_native_histograms_series_per_user: <int> | default = 5000000]
+
 # The maximum number of active series per user, across the cluster before
 # replication. 0 to disable. Supported only if -distributor.shard-by-all-labels
 # is true.
@@ -3554,6 +3559,12 @@ The `limits_config` configures default and per-tenant limits imposed by Cortex s
 # replication. 0 to disable.
 # CLI flag: -ingester.max-global-series-per-metric
 [max_global_series_per_metric: <int> | default = 0]
+
+# The maximum number of active nativeHistograms series per user, across the
+# cluster before replication. 0 to disable. Supported only if
+# -distributor.shard-by-all-labels is true.
+# CLI flag: -ingester.max-global-native-histograms-series-per-user
+[max_global_native_histograms_series_per_user: <int> | default = 0]
 
 # [Experimental] Enable limits per LabelSet. Supported limits per labelSet:
 # [max_series]

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -448,6 +448,11 @@ func (u *userTSDB) PreCreation(metric labels.Labels) error {
 		}
 	}
 
+	// Total nativeHistograms series limit.
+	if err := u.limiter.AssertMaxNativeHistogramsSeriesPerUser(u.userID, u.activeSeries.ActiveNativeHistogram()); err != nil {
+		return err
+	}
+
 	// Total series limit.
 	if err := u.limiter.AssertMaxSeriesPerUser(u.userID, int(u.Head().NumSeries())); err != nil {
 		return err

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -12,10 +12,11 @@ import (
 )
 
 var (
-	errMaxSeriesPerMetricLimitExceeded   = errors.New("per-metric series limit exceeded")
-	errMaxMetadataPerMetricLimitExceeded = errors.New("per-metric metadata limit exceeded")
-	errMaxSeriesPerUserLimitExceeded     = errors.New("per-user series limit exceeded")
-	errMaxMetadataPerUserLimitExceeded   = errors.New("per-user metric metadata limit exceeded")
+	errMaxSeriesPerMetricLimitExceeded               = errors.New("per-metric series limit exceeded")
+	errMaxMetadataPerMetricLimitExceeded             = errors.New("per-metric metadata limit exceeded")
+	errMaxSeriesPerUserLimitExceeded                 = errors.New("per-user series limit exceeded")
+	errMaxNativeHistogramsSeriesPerUserLimitExceeded = errors.New("per-user nativeHistograms series limit exceeded")
+	errMaxMetadataPerUserLimitExceeded               = errors.New("per-user metric metadata limit exceeded")
 )
 
 type errMaxSeriesPerLabelSetLimitExceeded struct {
@@ -95,6 +96,16 @@ func (l *Limiter) AssertMaxSeriesPerUser(userID string, series int) error {
 	return errMaxSeriesPerUserLimitExceeded
 }
 
+// AssertMaxNativeHistogramsSeriesPerUser limit has not been reached compared to the current
+// number of nativeHistograms series in input and returns an error if so.
+func (l *Limiter) AssertMaxNativeHistogramsSeriesPerUser(userID string, series int) error {
+	if actualLimit := l.maxNativeHistogramsSeriesPerUser(userID); series < actualLimit {
+		return nil
+	}
+
+	return errMaxNativeHistogramsSeriesPerUserLimitExceeded
+}
+
 // AssertMaxMetricsWithMetadataPerUser limit has not been reached compared to the current
 // number of metrics with metadata in input and returns an error if so.
 func (l *Limiter) AssertMaxMetricsWithMetadataPerUser(userID string, metrics int) error {
@@ -155,6 +166,15 @@ func (l *Limiter) formatMaxSeriesPerUserError(userID string) error {
 	globalLimit := l.limits.MaxGlobalSeriesPerUser(userID)
 
 	return fmt.Errorf("per-user series limit of %d exceeded, %s (local limit: %d global limit: %d actual local limit: %d)",
+		minNonZero(localLimit, globalLimit), l.AdminLimitMessage, localLimit, globalLimit, actualLimit)
+}
+
+func (l *Limiter) formatMaxNativeHistogramsSeriesPerUserError(userID string) error {
+	actualLimit := l.maxNativeHistogramsSeriesPerUser(userID)
+	localLimit := l.limits.MaxLocalNativeHistogramsSeriesPerUser(userID)
+	globalLimit := l.limits.MaxGlobalNativeHistogramsSeriesPerUser(userID)
+
+	return fmt.Errorf("per-user nativeHistograms series limit of %d exceeded, %s (local limit: %d global limit: %d actual local limit: %d)",
 		minNonZero(localLimit, globalLimit), l.AdminLimitMessage, localLimit, globalLimit, actualLimit)
 }
 
@@ -245,6 +265,14 @@ func (l *Limiter) maxSeriesPerUser(userID string) int {
 		userID,
 		l.limits.MaxLocalSeriesPerUser,
 		l.limits.MaxGlobalSeriesPerUser,
+	)
+}
+
+func (l *Limiter) maxNativeHistogramsSeriesPerUser(userID string) int {
+	return l.maxByLocalAndGlobal(
+		userID,
+		l.limits.MaxLocalNativeHistogramsSeriesPerUser,
+		l.limits.MaxGlobalNativeHistogramsSeriesPerUser,
 	)
 }
 

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -54,6 +54,19 @@ func TestLimiter_maxSeriesPerUser(t *testing.T) {
 	runLimiterMaxFunctionTest(t, applyLimits, runMaxFn, false)
 }
 
+func TestLimiter_maxNativeHistogramsSeriesPerUser(t *testing.T) {
+	applyLimits := func(limits *validation.Limits, localLimit, globalLimit int) {
+		limits.MaxLocalNativeHistogramsSeriesPerUser = localLimit
+		limits.MaxGlobalNativeHistogramsSeriesPerUser = globalLimit
+	}
+
+	runMaxFn := func(limiter *Limiter) int {
+		return limiter.maxNativeHistogramsSeriesPerUser("test")
+	}
+
+	runLimiterMaxFunctionTest(t, applyLimits, runMaxFn, false)
+}
+
 func TestLimiter_maxMetadataPerUser(t *testing.T) {
 	applyLimits := func(limits *validation.Limits, localLimit, globalLimit int) {
 		limits.MaxLocalMetricsWithMetadataPerUser = localLimit
@@ -419,6 +432,69 @@ func TestLimiter_AssertMaxSeriesPerUser(t *testing.T) {
 
 			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
 			actual := limiter.AssertMaxSeriesPerUser("test", testData.series)
+
+			assert.Equal(t, testData.expected, actual)
+		})
+	}
+}
+
+func TestLimiter_AssertMaxNativeHistogramsSeriesPerUser(t *testing.T) {
+	tests := map[string]struct {
+		maxLocalNativeHistogramsSeriesPerUser  int
+		maxGlobalNativeHistogramsSeriesPerUser int
+		ringReplicationFactor                  int
+		ringIngesterCount                      int
+		shardByAllLabels                       bool
+		series                                 int
+		expected                               error
+	}{
+		"both local and global limit are disabled": {
+			maxLocalNativeHistogramsSeriesPerUser:  0,
+			maxGlobalNativeHistogramsSeriesPerUser: 0,
+			ringReplicationFactor:                  1,
+			ringIngesterCount:                      1,
+			shardByAllLabels:                       false,
+			series:                                 100,
+			expected:                               nil,
+		},
+		"current number of series is below the limit": {
+			maxLocalNativeHistogramsSeriesPerUser:  0,
+			maxGlobalNativeHistogramsSeriesPerUser: 1000,
+			ringReplicationFactor:                  3,
+			ringIngesterCount:                      10,
+			shardByAllLabels:                       true,
+			series:                                 299,
+			expected:                               nil,
+		},
+		"current number of series is above the limit": {
+			maxLocalNativeHistogramsSeriesPerUser:  0,
+			maxGlobalNativeHistogramsSeriesPerUser: 1000,
+			ringReplicationFactor:                  3,
+			ringIngesterCount:                      10,
+			shardByAllLabels:                       true,
+			series:                                 300,
+			expected:                               errMaxNativeHistogramsSeriesPerUserLimitExceeded,
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			// Mock the ring
+			ring := &ringCountMock{}
+			ring.On("HealthyInstancesCount").Return(testData.ringIngesterCount)
+			ring.On("ZonesCount").Return(1)
+
+			// Mock limits
+			limits, err := validation.NewOverrides(validation.Limits{
+				MaxLocalNativeHistogramsSeriesPerUser:  testData.maxLocalNativeHistogramsSeriesPerUser,
+				MaxGlobalNativeHistogramsSeriesPerUser: testData.maxGlobalNativeHistogramsSeriesPerUser,
+			}, nil)
+			require.NoError(t, err)
+
+			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
+			actual := limiter.AssertMaxNativeHistogramsSeriesPerUser("test", testData.series)
 
 			assert.Equal(t, testData.expected, actual)
 		})

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -23,7 +23,8 @@ import (
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 
-var errMaxGlobalSeriesPerUserValidation = errors.New("The ingester.max-global-series-per-user limit is unsupported if distributor.shard-by-all-labels is disabled")
+var errMaxGlobalSeriesPerUserValidation = errors.New("the ingester.max-global-series-per-user limit is unsupported if distributor.shard-by-all-labels is disabled")
+var errMaxGlobalNativeHistogramsSeriesPerUserValidation = errors.New("the ingester.max-global-native-histograms-series-per-user limit is unsupported if distributor.shard-by-all-labels is disabled")
 var errDuplicateQueryPriorities = errors.New("duplicate entry of priorities found. Make sure they are all unique, including the default priority")
 var errCompilingQueryPriorityRegex = errors.New("error compiling query priority regex")
 var errDuplicatePerLabelSetLimit = errors.New("duplicate per labelSet limits found. Make sure they are all unique")
@@ -149,12 +150,14 @@ type Limits struct {
 
 	// Ingester enforced limits.
 	// Series
-	MaxLocalSeriesPerUser    int                 `yaml:"max_series_per_user" json:"max_series_per_user"`
-	MaxLocalSeriesPerMetric  int                 `yaml:"max_series_per_metric" json:"max_series_per_metric"`
-	MaxGlobalSeriesPerUser   int                 `yaml:"max_global_series_per_user" json:"max_global_series_per_user"`
-	MaxGlobalSeriesPerMetric int                 `yaml:"max_global_series_per_metric" json:"max_global_series_per_metric"`
-	LimitsPerLabelSet        []LimitsPerLabelSet `yaml:"limits_per_label_set" json:"limits_per_label_set" doc:"nocli|description=[Experimental] Enable limits per LabelSet. Supported limits per labelSet: [max_series]"`
-	EnableNativeHistograms   bool                `yaml:"enable_native_histograms" json:"enable_native_histograms"`
+	MaxLocalSeriesPerUser                  int                 `yaml:"max_series_per_user" json:"max_series_per_user"`
+	MaxLocalSeriesPerMetric                int                 `yaml:"max_series_per_metric" json:"max_series_per_metric"`
+	MaxLocalNativeHistogramsSeriesPerUser  int                 `yaml:"max_native_histograms_series_per_user" json:"max_native_histograms_series_per_user"`
+	MaxGlobalSeriesPerUser                 int                 `yaml:"max_global_series_per_user" json:"max_global_series_per_user"`
+	MaxGlobalSeriesPerMetric               int                 `yaml:"max_global_series_per_metric" json:"max_global_series_per_metric"`
+	MaxGlobalNativeHistogramsSeriesPerUser int                 `yaml:"max_global_native_histograms_series_per_user" json:"max_global_native_histograms_series_per_user"`
+	LimitsPerLabelSet                      []LimitsPerLabelSet `yaml:"limits_per_label_set" json:"limits_per_label_set" doc:"nocli|description=[Experimental] Enable limits per LabelSet. Supported limits per labelSet: [max_series]"`
+	EnableNativeHistograms                 bool                `yaml:"enable_native_histograms" json:"enable_native_histograms"`
 
 	// Metadata
 	MaxLocalMetricsWithMetadataPerUser  int `yaml:"max_metadata_per_user" json:"max_metadata_per_user"`
@@ -267,6 +270,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLocalSeriesPerMetric, "ingester.max-series-per-metric", 50000, "The maximum number of active series per metric name, per ingester. 0 to disable.")
 	f.IntVar(&l.MaxGlobalSeriesPerUser, "ingester.max-global-series-per-user", 0, "The maximum number of active series per user, across the cluster before replication. 0 to disable. Supported only if -distributor.shard-by-all-labels is true.")
 	f.IntVar(&l.MaxGlobalSeriesPerMetric, "ingester.max-global-series-per-metric", 0, "The maximum number of active series per metric name, across the cluster before replication. 0 to disable.")
+	f.IntVar(&l.MaxLocalNativeHistogramsSeriesPerUser, "ingester.max-native-histograms-series-per-user", 5000000, "The maximum number of active nativeHistograms series per user, per ingester. 0 to disable.")
+	f.IntVar(&l.MaxGlobalNativeHistogramsSeriesPerUser, "ingester.max-global-native-histograms-series-per-user", 0, "The maximum number of active nativeHistograms series per user, across the cluster before replication. 0 to disable. Supported only if -distributor.shard-by-all-labels is true.")
 	f.BoolVar(&l.EnableNativeHistograms, "blocks-storage.tsdb.enable-native-histograms", false, "[EXPERIMENTAL] True to enable native histogram.")
 	f.IntVar(&l.MaxExemplars, "ingester.max-exemplars", 0, "Enables support for exemplars in TSDB and sets the maximum number that will be stored. less than zero means disabled. If the value is set to zero, cortex will fallback to blocks-storage.tsdb.max-exemplars value.")
 	f.Var(&l.OutOfOrderTimeWindow, "ingester.out-of-order-time-window", "[Experimental] Configures the allowed time window for ingestion of out-of-order samples. Disabled (0s) by default.")
@@ -339,6 +344,12 @@ func (l *Limits) Validate(shardByAllLabels bool) error {
 	// if shard-by-all-labels is disabled
 	if l.MaxGlobalSeriesPerUser > 0 && !shardByAllLabels {
 		return errMaxGlobalSeriesPerUserValidation
+	}
+
+	// The ingester.max-global-native-histograms-series-per-user metric is not supported
+	// if shard-by-all-labels is disabled
+	if l.MaxGlobalNativeHistogramsSeriesPerUser > 0 && !shardByAllLabels {
+		return errMaxGlobalNativeHistogramsSeriesPerUserValidation
 	}
 
 	if err := l.RulerExternalLabels.Validate(func(l labels.Label) error {
@@ -663,6 +674,11 @@ func (o *Overrides) MaxLocalSeriesPerUser(userID string) int {
 	return o.GetOverridesForUser(userID).MaxLocalSeriesPerUser
 }
 
+// MaxLocalNativeHistogramsSeriesPerUser returns the maximum number of nativeHistograms series a user is allowed to store in a single ingester.
+func (o *Overrides) MaxLocalNativeHistogramsSeriesPerUser(userID string) int {
+	return o.GetOverridesForUser(userID).MaxLocalNativeHistogramsSeriesPerUser
+}
+
 // MaxLocalSeriesPerMetric returns the maximum number of series allowed per metric in a single ingester.
 func (o *Overrides) MaxLocalSeriesPerMetric(userID string) int {
 	return o.GetOverridesForUser(userID).MaxLocalSeriesPerMetric
@@ -671,6 +687,11 @@ func (o *Overrides) MaxLocalSeriesPerMetric(userID string) int {
 // MaxGlobalSeriesPerUser returns the maximum number of series a user is allowed to store across the cluster.
 func (o *Overrides) MaxGlobalSeriesPerUser(userID string) int {
 	return o.GetOverridesForUser(userID).MaxGlobalSeriesPerUser
+}
+
+// MaxGlobalNativeHistogramsSeriesPerUser returns the maximum number of nativeHistograms series a user is allowed to store across the cluster.
+func (o *Overrides) MaxGlobalNativeHistogramsSeriesPerUser(userID string) int {
+	return o.GetOverridesForUser(userID).MaxGlobalNativeHistogramsSeriesPerUser
 }
 
 // EnableNativeHistograms returns whether the Ingester should accept NativeHistograms samples from this user.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
In addition to the current activeSeries limit on float+histogram samples, this PR adds an active series limit for specifically for nativeHistograms samples. 
This is done, b/c the ingestion of native histograms samples is much more CPU intensive than that of float samples - adding nativeHistogram samples specific ingestions limit to protect the service and to allow clients to adjust the NH series ingestion.

Currently, Prometheus doesn't provide a way to count the specific active nativeHistogram series in the head and hence this PR uses the activeNativeHistograms series count from Cortex - which differs in the way activeSeries is counted.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
