### PR TITLE
Disable topk and bottomk aggregation in query fuzz test

### DIFF
--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	enabledFunctions []*parser.Function
-	enabledAggrs     []parser.ItemType = []parser.ItemType{
+	enabledAggrs     = []parser.ItemType{
 		parser.SUM, parser.MIN, parser.MAX, parser.AVG, parser.GROUP, parser.COUNT, parser.COUNT_VALUES, parser.QUANTILE,
 	}
 )

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -38,7 +38,12 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/log"
 )
 
-var enabledFunctions []*parser.Function
+var (
+	enabledFunctions []*parser.Function
+	enabledAggrs     []parser.ItemType = []parser.ItemType{
+		parser.SUM, parser.MIN, parser.MAX, parser.AVG, parser.GROUP, parser.COUNT, parser.COUNT_VALUES, parser.QUANTILE,
+	}
+)
 
 func init() {
 	for _, f := range parser.Functions {
@@ -153,9 +158,7 @@ func TestNativeHistogramFuzz(t *testing.T) {
 	opts := []promqlsmith.Option{
 		promqlsmith.WithEnableOffset(true),
 		promqlsmith.WithEnableAtModifier(true),
-		promqlsmith.WithEnabledAggrs([]parser.ItemType{
-			parser.SUM, parser.MIN, parser.MAX, parser.AVG, parser.GROUP, parser.COUNT, parser.COUNT_VALUES, parser.QUANTILE,
-		}),
+		promqlsmith.WithEnabledAggrs(enabledAggrs),
 	}
 	ps := promqlsmith.New(rnd, lbls, opts...)
 
@@ -271,6 +274,7 @@ func TestExperimentalPromQLFuncsWithPrometheus(t *testing.T) {
 		promqlsmith.WithEnableOffset(true),
 		promqlsmith.WithEnableAtModifier(true),
 		promqlsmith.WithEnabledFunctions(enabledFunctions),
+		promqlsmith.WithEnabledAggrs(enabledAggrs),
 		promqlsmith.WithEnableExperimentalPromQLFunctions(true),
 	}
 	ps := promqlsmith.New(rnd, lbls, opts...)
@@ -376,6 +380,7 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 		promqlsmith.WithEnableOffset(true),
 		promqlsmith.WithEnableAtModifier(true),
 		promqlsmith.WithEnabledFunctions(enabledFunctions),
+		promqlsmith.WithEnabledAggrs(enabledAggrs),
 	}
 	ps := promqlsmith.New(rnd, lbls, opts...)
 
@@ -558,6 +563,7 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 	opts := []promqlsmith.Option{
 		promqlsmith.WithEnableOffset(true),
 		promqlsmith.WithEnableAtModifier(true),
+		promqlsmith.WithEnabledAggrs(enabledAggrs),
 	}
 	ps := promqlsmith.New(rnd, lbls, opts...)
 
@@ -788,6 +794,7 @@ func TestVerticalShardingFuzz(t *testing.T) {
 		promqlsmith.WithEnableOffset(true),
 		promqlsmith.WithEnableAtModifier(true),
 		promqlsmith.WithEnabledFunctions(enabledFunctions),
+		promqlsmith.WithEnabledAggrs(enabledAggrs),
 	}
 	ps := promqlsmith.New(rnd, lbls, opts...)
 
@@ -904,6 +911,7 @@ func TestProtobufCodecFuzz(t *testing.T) {
 		promqlsmith.WithEnableOffset(true),
 		promqlsmith.WithEnableAtModifier(true),
 		promqlsmith.WithEnabledFunctions(enabledFunctions),
+		promqlsmith.WithEnabledAggrs(enabledAggrs),
 	}
 	ps := promqlsmith.New(rnd, lbls, opts...)
 
@@ -1600,6 +1608,7 @@ func TestBackwardCompatibilityQueryFuzz(t *testing.T) {
 		promqlsmith.WithEnableOffset(true),
 		promqlsmith.WithEnableAtModifier(true),
 		promqlsmith.WithEnabledFunctions(enabledFunctions),
+		promqlsmith.WithEnabledAggrs(enabledAggrs),
 	}
 	ps := promqlsmith.New(rnd, lbls, opts...)
 
@@ -1712,6 +1721,7 @@ func TestPrometheusCompatibilityQueryFuzz(t *testing.T) {
 		promqlsmith.WithEnableOffset(true),
 		promqlsmith.WithEnableAtModifier(true),
 		promqlsmith.WithEnabledFunctions(enabledFunctions),
+		promqlsmith.WithEnabledAggrs(enabledAggrs),
 	}
 	ps := promqlsmith.New(rnd, lbls, opts...)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Disable topk and bottomk aggregation in query fuzz test since they are quite flaky

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
