### PR TITLE
Add cleaner and converter metrics for parquet

### DIFF
--- a/pkg/parquetconverter/metrics.go
+++ b/pkg/parquetconverter/metrics.go
@@ -1,0 +1,34 @@
+package parquetconverter
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type metrics struct {
+	convertedBlocks      *prometheus.CounterVec
+	convertBlockDuration *prometheus.GaugeVec
+	ownedUsers           prometheus.Gauge
+}
+
+func newMetrics(reg prometheus.Registerer) *metrics {
+	return &metrics{
+		convertedBlocks: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_parquet_converter_converted_blocks_total",
+			Help: "Total number of converted blocks per user.",
+		}, []string{"user"}),
+		convertBlockDuration: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_parquet_converter_convert_block_duration_seconds",
+			Help: "Time taken to for the latest block conversion for the user.",
+		}, []string{"user"}),
+		ownedUsers: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_parquet_converter_users_owned",
+			Help: "Number of users that the parquet converter owns.",
+		}),
+	}
+}
+
+func (m *metrics) deleteMetricsForTenant(userID string) {
+	m.convertedBlocks.DeleteLabelValues(userID)
+	m.convertBlockDuration.DeleteLabelValues(userID)
+}

--- a/pkg/storage/tsdb/bucketindex/index.go
+++ b/pkg/storage/tsdb/bucketindex/index.go
@@ -70,6 +70,16 @@ func (idx *Index) IsEmpty() bool {
 	return len(idx.Blocks) == 0 && len(idx.BlockDeletionMarks) == 0
 }
 
+func (idx *Index) ParquetBlocks() []*Block {
+	blocks := make([]*Block, 0, len(idx.Blocks))
+	for _, b := range idx.Blocks {
+		if b.Parquet != nil {
+			blocks = append(blocks, b)
+		}
+	}
+	return blocks
+}
+
 // Block holds the information about a block in the index.
 type Block struct {
 	// Block ID.

--- a/pkg/storage/tsdb/bucketindex/index_test.go
+++ b/pkg/storage/tsdb/bucketindex/index_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+
+	"github.com/cortexproject/cortex/pkg/storage/parquet"
 )
 
 func TestIndex_RemoveBlock(t *testing.T) {
@@ -406,4 +408,64 @@ func TestBlockDeletionMarks_Clone(t *testing.T) {
 	// Changes to the original shouldn't be reflected to the clone.
 	orig[0].DeletionTime = -1
 	assert.Equal(t, int64(1), clone[0].DeletionTime)
+}
+
+func TestIndex_ParquetBlocks(t *testing.T) {
+	block1 := ulid.MustNew(1, nil)
+	block2 := ulid.MustNew(2, nil)
+	block3 := ulid.MustNew(3, nil)
+
+	tests := map[string]struct {
+		index    *Index
+		expected []*Block
+	}{
+		"empty index": {
+			index:    &Index{},
+			expected: []*Block{},
+		},
+		"no parquet blocks": {
+			index: &Index{
+				Blocks: Blocks{
+					{ID: block1},
+					{ID: block2},
+					{ID: block3},
+				},
+			},
+			expected: []*Block{},
+		},
+		"some parquet blocks": {
+			index: &Index{
+				Blocks: Blocks{
+					{ID: block1, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
+					{ID: block2},
+					{ID: block3, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
+				},
+			},
+			expected: []*Block{
+				{ID: block1, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
+				{ID: block3, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
+			},
+		},
+		"all parquet blocks": {
+			index: &Index{
+				Blocks: Blocks{
+					{ID: block1, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
+					{ID: block2, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
+					{ID: block3, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
+				},
+			},
+			expected: []*Block{
+				{ID: block1, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
+				{ID: block2, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
+				{ID: block3, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actual := testData.index.ParquetBlocks()
+			assert.Equal(t, testData.expected, actual)
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Added some basic metrics for parquet. This is just a starting point and we can add more metrics for it.

Cleaner:
- cortex_bucket_parquet_blocks_count. For number of parquet blocks for the tenant

Converter:
- cortex_parquet_converter_converted_blocks_total. Number of converted blocks
- cortex_parquet_converter_convert_block_duration_seconds. Last block conversion duration
- cortex_parquet_converter_users_owned. Number of owned users for the converter instance

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
