### PR TITLE
Optimize cleaner run time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [ENHANCEMENT] Compactor, Store Gateway: Introduce user scanner strategy and user index. #6780
 * [ENHANCEMENT] Querier: Support chunks cache for parquet queryable. #6805
 * [ENHANCEMENT] Parquet Storage: Add some metrics for parquet blocks and converter. #6809
+* [ENHANCEMENT] Compactor: Optimize cleaner run time. #6815
 * [BUGFIX] Ingester: Avoid error or early throttling when READONLY ingesters are present in the ring #6517
 * [BUGFIX] Ingester: Fix labelset data race condition. #6573
 * [BUGFIX] Compactor: Cleaner should not put deletion marker for blocks with no-compact marker. #6576

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -501,7 +501,7 @@ func (c *BlocksCleaner) deleteUserMarkedForDeletion(ctx context.Context, userLog
 		return err
 	}
 
-	if deleted, err := bucket.DeletePrefixConcurrent(ctx, userBucket, bucketindex.MarkersPathname, userLogger, defaultDeleteBlocksConcurrency); err != nil {
+	if deleted, err := bucket.DeletePrefix(ctx, userBucket, bucketindex.MarkersPathname, userLogger, defaultDeleteBlocksConcurrency); err != nil {
 		return errors.Wrap(err, "failed to delete marker files")
 	} else if deleted > 0 {
 		level.Info(userLogger).Log("msg", "deleted marker files for tenant marked for deletion", "count", deleted)
@@ -513,7 +513,7 @@ func (c *BlocksCleaner) deleteUserMarkedForDeletion(ctx context.Context, userLog
 }
 
 func (c *BlocksCleaner) deleteNonDataFiles(ctx context.Context, userLogger log.Logger, userBucket objstore.InstrumentedBucket) error {
-	if deleted, err := bucket.DeletePrefixConcurrent(ctx, userBucket, block.DebugMetas, userLogger, defaultDeleteBlocksConcurrency); err != nil {
+	if deleted, err := bucket.DeletePrefix(ctx, userBucket, block.DebugMetas, userLogger, defaultDeleteBlocksConcurrency); err != nil {
 		return errors.Wrap(err, "failed to delete "+block.DebugMetas)
 	} else if deleted > 0 {
 		level.Info(userLogger).Log("msg", "deleted files under "+block.DebugMetas+" for tenant marked for deletion", "count", deleted)
@@ -521,7 +521,7 @@ func (c *BlocksCleaner) deleteNonDataFiles(ctx context.Context, userLogger log.L
 
 	if c.cfg.CompactionStrategy == util.CompactionStrategyPartitioning {
 		// Clean up partitioned group info files
-		if deleted, err := bucket.DeletePrefixConcurrent(ctx, userBucket, PartitionedGroupDirectory, userLogger, defaultDeleteBlocksConcurrency); err != nil {
+		if deleted, err := bucket.DeletePrefix(ctx, userBucket, PartitionedGroupDirectory, userLogger, defaultDeleteBlocksConcurrency); err != nil {
 			return errors.Wrap(err, "failed to delete "+PartitionedGroupDirectory)
 		} else if deleted > 0 {
 			level.Info(userLogger).Log("msg", "deleted files under "+PartitionedGroupDirectory+" for tenant marked for deletion", "count", deleted)
@@ -781,7 +781,7 @@ func (c *BlocksCleaner) cleanPartitionedGroupInfo(ctx context.Context, userBucke
 
 		if extraInfo.status.CanDelete || extraInfo.status.DeleteVisitMarker {
 			// Remove partition visit markers
-			if _, err := bucket.DeletePrefixConcurrent(ctx, userBucket, GetPartitionVisitMarkerDirectoryPath(partitionedGroupInfo.PartitionedGroupID), userLogger, defaultDeleteBlocksConcurrency); err != nil {
+			if _, err := bucket.DeletePrefix(ctx, userBucket, GetPartitionVisitMarkerDirectoryPath(partitionedGroupInfo.PartitionedGroupID), userLogger, defaultDeleteBlocksConcurrency); err != nil {
 				level.Warn(userLogger).Log("msg", "failed to delete partition visit markers for partitioned group", "partitioned_group_info", partitionedGroupInfoFile, "err", err)
 			} else {
 				level.Info(userLogger).Log("msg", "deleted partition visit markers for partitioned group", "partitioned_group_info", partitionedGroupInfoFile)

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -243,13 +243,23 @@ func (c *BlocksCleaner) loop(ctx context.Context) error {
 				continue
 			}
 			cleanJobTimestamp := time.Now().Unix()
-			usersChan <- &cleanerJob{
+
+			select {
+			case usersChan <- &cleanerJob{
 				users:     activeUsers,
 				timestamp: cleanJobTimestamp,
+			}:
+			default:
+				level.Warn(c.logger).Log("msg", "unable to push cleaning job to usersChan")
 			}
-			deleteChan <- &cleanerJob{
+
+			select {
+			case deleteChan <- &cleanerJob{
 				users:     deletedUsers,
 				timestamp: cleanJobTimestamp,
+			}:
+			default:
+				level.Warn(c.logger).Log("msg", "unable to push deletion job to deleteChan")
 			}
 
 		case <-ctx.Done():
@@ -491,7 +501,7 @@ func (c *BlocksCleaner) deleteUserMarkedForDeletion(ctx context.Context, userLog
 		return err
 	}
 
-	if deleted, err := bucket.DeletePrefix(ctx, userBucket, bucketindex.MarkersPathname, userLogger); err != nil {
+	if deleted, err := bucket.DeletePrefixConcurrent(ctx, userBucket, bucketindex.MarkersPathname, userLogger, defaultDeleteBlocksConcurrency); err != nil {
 		return errors.Wrap(err, "failed to delete marker files")
 	} else if deleted > 0 {
 		level.Info(userLogger).Log("msg", "deleted marker files for tenant marked for deletion", "count", deleted)
@@ -503,7 +513,7 @@ func (c *BlocksCleaner) deleteUserMarkedForDeletion(ctx context.Context, userLog
 }
 
 func (c *BlocksCleaner) deleteNonDataFiles(ctx context.Context, userLogger log.Logger, userBucket objstore.InstrumentedBucket) error {
-	if deleted, err := bucket.DeletePrefix(ctx, userBucket, block.DebugMetas, userLogger); err != nil {
+	if deleted, err := bucket.DeletePrefixConcurrent(ctx, userBucket, block.DebugMetas, userLogger, defaultDeleteBlocksConcurrency); err != nil {
 		return errors.Wrap(err, "failed to delete "+block.DebugMetas)
 	} else if deleted > 0 {
 		level.Info(userLogger).Log("msg", "deleted files under "+block.DebugMetas+" for tenant marked for deletion", "count", deleted)
@@ -511,7 +521,7 @@ func (c *BlocksCleaner) deleteNonDataFiles(ctx context.Context, userLogger log.L
 
 	if c.cfg.CompactionStrategy == util.CompactionStrategyPartitioning {
 		// Clean up partitioned group info files
-		if deleted, err := bucket.DeletePrefix(ctx, userBucket, PartitionedGroupDirectory, userLogger); err != nil {
+		if deleted, err := bucket.DeletePrefixConcurrent(ctx, userBucket, PartitionedGroupDirectory, userLogger, defaultDeleteBlocksConcurrency); err != nil {
 			return errors.Wrap(err, "failed to delete "+PartitionedGroupDirectory)
 		} else if deleted > 0 {
 			level.Info(userLogger).Log("msg", "deleted files under "+PartitionedGroupDirectory+" for tenant marked for deletion", "count", deleted)
@@ -771,7 +781,7 @@ func (c *BlocksCleaner) cleanPartitionedGroupInfo(ctx context.Context, userBucke
 
 		if extraInfo.status.CanDelete || extraInfo.status.DeleteVisitMarker {
 			// Remove partition visit markers
-			if _, err := bucket.DeletePrefix(ctx, userBucket, GetPartitionVisitMarkerDirectoryPath(partitionedGroupInfo.PartitionedGroupID), userLogger); err != nil {
+			if _, err := bucket.DeletePrefixConcurrent(ctx, userBucket, GetPartitionVisitMarkerDirectoryPath(partitionedGroupInfo.PartitionedGroupID), userLogger, defaultDeleteBlocksConcurrency); err != nil {
 				level.Warn(userLogger).Log("msg", "failed to delete partition visit markers for partitioned group", "partitioned_group_info", partitionedGroupInfoFile, "err", err)
 			} else {
 				level.Info(userLogger).Log("msg", "deleted partition visit markers for partitioned group", "partitioned_group_info", partitionedGroupInfoFile)

--- a/pkg/storage/bucket/bucket_util.go
+++ b/pkg/storage/bucket/bucket_util.go
@@ -15,11 +15,7 @@ import (
 // DeletePrefix removes all objects with given prefix, recursively.
 // It returns number of deleted objects.
 // If deletion of any object fails, it returns error and stops.
-func DeletePrefix(ctx context.Context, bkt objstore.Bucket, prefix string, logger log.Logger) (int, error) {
-	return DeletePrefixConcurrent(ctx, bkt, prefix, logger, 1)
-}
-
-func DeletePrefixConcurrent(ctx context.Context, bkt objstore.Bucket, prefix string, logger log.Logger, maxConcurrency int) (int, error) {
+func DeletePrefix(ctx context.Context, bkt objstore.Bucket, prefix string, logger log.Logger, maxConcurrency int) (int, error) {
 	keys, err := ListPrefixes(ctx, bkt, prefix, logger)
 	if err != nil {
 		return 0, err

--- a/pkg/storage/bucket/bucket_util.go
+++ b/pkg/storage/bucket/bucket_util.go
@@ -7,27 +7,49 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/thanos-io/objstore"
+	"go.uber.org/atomic"
+
+	"github.com/cortexproject/cortex/pkg/util/concurrency"
 )
 
 // DeletePrefix removes all objects with given prefix, recursively.
 // It returns number of deleted objects.
 // If deletion of any object fails, it returns error and stops.
 func DeletePrefix(ctx context.Context, bkt objstore.Bucket, prefix string, logger log.Logger) (int, error) {
-	result := 0
-	err := bkt.Iter(ctx, prefix, func(name string) error {
-		if strings.HasSuffix(name, objstore.DirDelim) {
-			deleted, err := DeletePrefix(ctx, bkt, name, logger)
-			result += deleted
-			return err
-		}
+	return DeletePrefixConcurrent(ctx, bkt, prefix, logger, 1)
+}
 
+func DeletePrefixConcurrent(ctx context.Context, bkt objstore.Bucket, prefix string, logger log.Logger, maxConcurrency int) (int, error) {
+	keys, err := ListPrefixes(ctx, bkt, prefix, logger)
+	if err != nil {
+		return 0, err
+	}
+
+	result := atomic.NewInt32(0)
+	err = concurrency.ForEach(ctx, concurrency.CreateJobsFromStrings(keys), maxConcurrency, func(ctx context.Context, key interface{}) error {
+		name := key.(string)
 		if err := bkt.Delete(ctx, name); err != nil {
 			return err
 		}
-		result++
+		result.Inc()
 		level.Debug(logger).Log("msg", "deleted file", "file", name)
 		return nil
 	})
 
-	return result, err
+	return int(result.Load()), err
+}
+
+func ListPrefixes(ctx context.Context, bkt objstore.Bucket, prefix string, logger log.Logger) ([]string, error) {
+	var keys []string
+	err := bkt.Iter(ctx, prefix, func(name string) error {
+		if strings.HasSuffix(name, objstore.DirDelim) {
+			moreKeys, err := ListPrefixes(ctx, bkt, name, logger)
+			keys = append(keys, moreKeys...)
+			return err
+		}
+
+		keys = append(keys, name)
+		return nil
+	})
+	return keys, err
 }

--- a/pkg/storage/bucket/bucket_util_test.go
+++ b/pkg/storage/bucket/bucket_util_test.go
@@ -2,6 +2,7 @@ package bucket
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -24,5 +25,25 @@ func TestDeletePrefix(t *testing.T) {
 	del, err := DeletePrefix(context.Background(), mem, "prefix", log.NewNopLogger())
 	require.NoError(t, err)
 	assert.Equal(t, 4, del)
+	assert.Equal(t, 2, len(mem.Objects()))
+}
+
+func TestDeletePrefixConcurrent(t *testing.T) {
+	mem := objstore.NewInMemBucket()
+
+	require.NoError(t, mem.Upload(context.Background(), "obj", strings.NewReader("hello")))
+	require.NoError(t, mem.Upload(context.Background(), "prefix/1", strings.NewReader("hello")))
+	require.NoError(t, mem.Upload(context.Background(), "prefix/2", strings.NewReader("hello")))
+	require.NoError(t, mem.Upload(context.Background(), "prefix/sub1/3", strings.NewReader("hello")))
+	require.NoError(t, mem.Upload(context.Background(), "prefix/sub2/4", strings.NewReader("hello")))
+	require.NoError(t, mem.Upload(context.Background(), "outside/obj", strings.NewReader("hello")))
+	n := 10000
+	for i := 0; i < n; i++ {
+		require.NoError(t, mem.Upload(context.Background(), fmt.Sprintf("prefix/sub/%d", i), strings.NewReader(fmt.Sprintf("hello%d", i))))
+	}
+
+	del, err := DeletePrefixConcurrent(context.Background(), mem, "prefix", log.NewNopLogger(), 100)
+	require.NoError(t, err)
+	assert.Equal(t, 4+n, del)
 	assert.Equal(t, 2, len(mem.Objects()))
 }

--- a/pkg/storage/bucket/bucket_util_test.go
+++ b/pkg/storage/bucket/bucket_util_test.go
@@ -22,7 +22,7 @@ func TestDeletePrefix(t *testing.T) {
 	require.NoError(t, mem.Upload(context.Background(), "prefix/sub2/4", strings.NewReader("hello")))
 	require.NoError(t, mem.Upload(context.Background(), "outside/obj", strings.NewReader("hello")))
 
-	del, err := DeletePrefix(context.Background(), mem, "prefix", log.NewNopLogger())
+	del, err := DeletePrefix(context.Background(), mem, "prefix", log.NewNopLogger(), 1)
 	require.NoError(t, err)
 	assert.Equal(t, 4, del)
 	assert.Equal(t, 2, len(mem.Objects()))
@@ -42,7 +42,7 @@ func TestDeletePrefixConcurrent(t *testing.T) {
 		require.NoError(t, mem.Upload(context.Background(), fmt.Sprintf("prefix/sub/%d", i), strings.NewReader(fmt.Sprintf("hello%d", i))))
 	}
 
-	del, err := DeletePrefixConcurrent(context.Background(), mem, "prefix", log.NewNopLogger(), 100)
+	del, err := DeletePrefix(context.Background(), mem, "prefix", log.NewNopLogger(), 100)
 	require.NoError(t, err)
 	assert.Equal(t, 4+n, del)
 	assert.Equal(t, 2, len(mem.Objects()))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Two optimization being made for cleaner:
- Use non-block way to push cleaner jobs to active user channel and delete user channel. So that long run time deletion job would not block cleaning job in the next cycle.
-  Introduced concurrent way to do DeletePrefix. So it is faster to delete directory with large number of files. Tested with 1k files in one directory. Sequential deletion took 17s and Concurrent deletion took 1.3s

**Which issue(s) this PR fixes**:


**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
