### PR TITLE
Enhance the performance of the frontend JSON codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [ENHANCEMENT] Parquet Storage: Add some metrics for parquet blocks and converter. #6809 #6821
 * [ENHANCEMENT] Compactor: Optimize cleaner run time. #6815
 * [ENHANCEMENT] Parquet Storage: Allow percentage based dynamic shard size for Parquet Converter. #6817
+* [ENHANCEMENT] Query Frontend: Enhance the performance of the JSON codec. #6816
 * [BUGFIX] Ingester: Avoid error or early throttling when READONLY ingesters are present in the ring #6517
 * [BUGFIX] Ingester: Fix labelset data race condition. #6573
 * [BUGFIX] Compactor: Cleaner should not put deletion marker for blocks with no-compact marker. #6576

--- a/pkg/chunk/json_helpers.go
+++ b/pkg/chunk/json_helpers.go
@@ -10,14 +10,14 @@ import (
 )
 
 func init() {
-	jsoniter.RegisterTypeDecoderFunc("labels.Labels", decodeLabels)
-	jsoniter.RegisterTypeEncoderFunc("labels.Labels", encodeLabels, labelsIsEmpty)
+	jsoniter.RegisterTypeDecoderFunc("labels.Labels", DecodeLabels)
+	jsoniter.RegisterTypeEncoderFunc("labels.Labels", EncodeLabels, labelsIsEmpty)
 	jsoniter.RegisterTypeDecoderFunc("model.Time", decodeModelTime)
 	jsoniter.RegisterTypeEncoderFunc("model.Time", encodeModelTime, modelTimeIsEmpty)
 }
 
 // Override Prometheus' labels.Labels decoder which goes via a map
-func decodeLabels(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+func DecodeLabels(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 	labelsPtr := (*labels.Labels)(ptr)
 	*labelsPtr = make(labels.Labels, 0, 10)
 	iter.ReadMapCB(func(iter *jsoniter.Iterator, key string) bool {
@@ -31,7 +31,7 @@ func decodeLabels(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 }
 
 // Override Prometheus' labels.Labels encoder which goes via a map
-func encodeLabels(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+func EncodeLabels(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	labelsPtr := (*labels.Labels)(ptr)
 	stream.WriteObjectStart()
 	for i, v := range *labelsPtr {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Stream json encoding using existing functions, reducing CPU usage ~50%.

**Which issue(s) this PR fixes**:

After upgrading from v1.16 to v1.19, the frontend's CPU usage increased significantly. The primary cause appears to be related to JSON codec, the use of `encoding/json` and the read-and-parse process. This patch addresses both issues. However, despite applying the patch, CPU usage remains higher than it was prior to the upgrade. The exact reason for this is unclear, maybe it is due to Go 1.24 or something else, but profiling results still show that decoding labels continues to consume a substantial amount of processing time (profile below).

![Clipboard_Screenshot_1749810703](https://github.com/user-attachments/assets/bf50ef59-0d9e-451a-b85f-d4a7be26e544)

<img width="1029" alt="Clipboard_Screenshot_1749810067" src="https://github.com/user-attachments/assets/267f0dde-ab74-41e6-bc56-8ad4f6c6b2a0" />

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
