### PR TITLE
fix(grafana-datasource): Grafana Datasource pointing to wrong service

### DIFF
--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -51,6 +51,8 @@ $ git clone https://github.com/cortexproject/cortex.git
 $ cd cortex/docs/getting-started
 ```
 
+**Note**: This guide uses `grafana-datasource-docker.yaml` which is specifically configured for the single binary Docker Compose deployment. For Kubernetes/microservices mode, use `grafana-datasource.yaml` instead.
+
 ##### Start the services
 
 ```sh
@@ -214,6 +216,8 @@ how this is configured.
 # Deploy Grafana to visualize the metrics that were sent to Cortex.
 $ helm upgrade --install --version=7.3.9 --namespace cortex grafana grafana/grafana -f grafana-values.yaml --wait
 ```
+
+**Note**: This guide uses `grafana-values.yaml` with Helm to configure Grafana datasources. Alternatively, you can manually deploy Grafana with `grafana-datasource.yaml` which is specifically configured for Kubernetes/microservices mode with the correct `cortex-nginx` endpoints.
 
 ```sh
 # Create dashboards for Cortex

--- a/docs/getting-started/docker-compose.yaml
+++ b/docs/getting-started/docker-compose.yaml
@@ -20,10 +20,10 @@ services:
     ports:
       - "9009:9009"
     healthcheck:
-        test: wget -qO- http://127.0.0.1:9009/ready
-        interval: 10s
-        timeout: 10s
-        retries: 3
+      test: wget -qO- http://127.0.0.1:9009/ready
+      interval: 10s
+      timeout: 10s
+      retries: 3
     restart: on-failure
   grafana:
     image: grafana/grafana:${GRAFANA_VERSION}
@@ -34,7 +34,7 @@ services:
       - GF_LOG_MODE=console
       - GF_LOG_LEVEL=critical
     volumes:
-      - ./grafana-datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yaml:ro
+      - ./grafana-datasource-docker.yaml:/etc/grafana/provisioning/datasources/datasource.yaml:ro
       - ./grafana-dashboard.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml:ro
       - ./dashboards/:/var/lib/grafana/dashboards/:ro
     ports:
@@ -66,7 +66,7 @@ services:
     ports:
       - "8333:8333"
     post_start:
-    - command: /seaweedfs-init.sh
+      - command: /seaweedfs-init.sh
     volumes:
       - ./seaweedfs-config.json:/workspace/seaweedfs-config.json:ro
       - ./seaweedfs-init.sh:/seaweedfs-init.sh:ro

--- a/docs/getting-started/grafana-datasource-docker.yaml
+++ b/docs/getting-started/grafana-datasource-docker.yaml
@@ -1,5 +1,5 @@
-# Grafana datasource configuration for Kubernetes/microservices mode
-# For Docker Compose mode, use grafana-datasource-docker.yaml instead
+# Grafana datasource configuration for Docker Compose/single binary mode
+# For Kubernetes mode, use grafana-datasource.yaml instead
 apiVersion: 1
 
 datasources:
@@ -7,7 +7,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://cortex-nginx/api/prom
+    url: http://cortex:9009/api/prom
     jsonData: &jsonData
       cacheLevel: None
       httpHeaderName1: X-Scope-OrgID
@@ -24,7 +24,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://cortex-nginx/api/prom
+    url: http://cortex:9009/api/prom
     jsonData: *jsonData
     secureJsonData:
       httpHeaderValue1: tenant-a
@@ -34,7 +34,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://cortex-nginx/api/prom
+    url: http://cortex:9009/api/prom
     jsonData: *jsonData
     secureJsonData:
       httpHeaderValue1: tenant-b
@@ -44,7 +44,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://cortex-nginx/api/prom
+    url: http://cortex:9009/api/prom
     jsonData: *jsonData
     secureJsonData:
       httpHeaderValue1: tenant-c
@@ -54,7 +54,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://cortex-nginx/api/prom
+    url: http://cortex:9009/api/prom
     jsonData: *jsonData
     secureJsonData:
       httpHeaderValue1: tenant-d
@@ -64,7 +64,7 @@ datasources:
     name: Cortex Alertmanager
     type: alertmanager
     access: proxy
-    url: http://cortex-nginx/
+    url: http://cortex:9009/
     jsonData:
       httpHeaderName1: X-Scope-OrgID
       implementation: cortex


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- Creates a docker compose for Grafana to point to cortex
- Set up the kind demo and verify Grafana is pointing to cortex

**Which issue(s) this PR fixes**:
Fixes #6132 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
