### PR TITLE
Add parquet convert failure, block delay and total block to convert metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 * [ENHANCEMENT] Compactor: Support metadata caching bucket for Cleaner. Can be enabled via `-compactor.cleaner-caching-bucket-enabled` flag. #6778
 * [ENHANCEMENT] Compactor, Store Gateway: Introduce user scanner strategy and user index. #6780
 * [ENHANCEMENT] Querier: Support chunks cache for parquet queryable. #6805
-* [ENHANCEMENT] Parquet Storage: Add some metrics for parquet blocks and converter. #6809
+* [ENHANCEMENT] Parquet Storage: Add some metrics for parquet blocks and converter. #6809 #6821
 * [ENHANCEMENT] Compactor: Optimize cleaner run time. #6815
 * [BUGFIX] Ingester: Avoid error or early throttling when READONLY ingesters are present in the ring #6517
 * [BUGFIX] Ingester: Fix labelset data race condition. #6573

--- a/integration/parquet_querier_test.go
+++ b/integration/parquet_querier_test.go
@@ -41,9 +41,10 @@ func TestParquetFuzz(t *testing.T) {
 	flags := mergeFlags(
 		baseFlags,
 		map[string]string{
-			"-target":                                    "all,parquet-converter",
-			"-blocks-storage.tsdb.ship-interval":         "1s",
-			"-blocks-storage.bucket-store.sync-interval": "1s",
+			"-target": "all,parquet-converter",
+			"-blocks-storage.tsdb.block-ranges-period":                             "1m,24h",
+			"-blocks-storage.tsdb.ship-interval":                                   "1s",
+			"-blocks-storage.bucket-store.sync-interval":                           "1s",
 			"-blocks-storage.bucket-store.metadata-cache.bucket-index-content-ttl": "1s",
 			"-blocks-storage.bucket-store.bucket-index.idle-timeout":               "1s",
 			"-blocks-storage.bucket-store.bucket-index.enabled":                    "true",

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -165,7 +165,7 @@ func NewBlocksCleaner(
 		}, commonLabels),
 		tenantParquetUnConvertedBlocks: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_bucket_parquet_unconverted_blocks_count",
-			Help: "Total number of parquet blocks in the bucket. Blocks marked for deletion are included.",
+			Help: "Total number of unconverted parquet blocks in the bucket. Blocks marked for deletion are included.",
 		}, commonLabels),
 		tenantBlocksMarkedForDelete: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_bucket_blocks_marked_for_deletion_count",

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -351,7 +351,7 @@ func testBlocksCleanerWithOptions(t *testing.T, options testBlocksCleanerOptions
 		# TYPE cortex_bucket_parquet_blocks_count gauge
 		cortex_bucket_parquet_blocks_count{user="user-5"} 0
 		cortex_bucket_parquet_blocks_count{user="user-6"} 1
-		# HELP cortex_bucket_parquet_unconverted_blocks_count Total number of parquet blocks in the bucket. Blocks marked for deletion are included.
+		# HELP cortex_bucket_parquet_unconverted_blocks_count Total number of unconverted parquet blocks in the bucket. Blocks marked for deletion are included.
 		# TYPE cortex_bucket_parquet_unconverted_blocks_count gauge
 		cortex_bucket_parquet_unconverted_blocks_count{user="user-5"} 0
 		cortex_bucket_parquet_unconverted_blocks_count{user="user-6"} 0
@@ -1121,7 +1121,7 @@ func TestBlocksCleaner_ParquetMetrics(t *testing.T) {
 	`)))
 
 	require.NoError(t, prom_testutil.CollectAndCompare(cleaner.tenantParquetUnConvertedBlocks, strings.NewReader(`
-		# HELP cortex_bucket_parquet_unconverted_blocks_count Total number of parquet blocks in the bucket. Blocks marked for deletion are included.
+		# HELP cortex_bucket_parquet_unconverted_blocks_count Total number of unconverted parquet blocks in the bucket. Blocks marked for deletion are included.
 		# TYPE cortex_bucket_parquet_unconverted_blocks_count gauge
 		cortex_bucket_parquet_unconverted_blocks_count{user="user1"} 2
 	`)))

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -80,6 +80,7 @@ func TestBlockCleaner_KeyPermissionDenied(t *testing.T) {
 		DeletionDelay:      deletionDelay,
 		CleanupInterval:    time.Minute,
 		CleanupConcurrency: 1,
+		BlockRanges:        (&tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour}).ToMilliseconds(),
 	}
 
 	logger := log.NewNopLogger()
@@ -182,6 +183,8 @@ func testBlocksCleanerWithOptions(t *testing.T, options testBlocksCleanerOptions
 
 	// Create Parquet marker
 	block13 := createTSDBBlock(t, bucketClient, "user-6", 30, 50, nil)
+	// This block should be converted to Parquet format so counted as remaining.
+	block14 := createTSDBBlock(t, bucketClient, "user-6", 30, 50, nil)
 	createParquetMarker(t, bucketClient, "user-6", block13)
 
 	// The fixtures have been created. If the bucket client wasn't wrapped to write
@@ -196,6 +199,7 @@ func testBlocksCleanerWithOptions(t *testing.T, options testBlocksCleanerOptions
 		CleanupConcurrency:                 options.concurrency,
 		BlockDeletionMarksMigrationEnabled: options.markersMigrationEnabled,
 		TenantCleanupDelay:                 options.tenantDeletionDelay,
+		BlockRanges:                        (&tsdb.DurationList{2 * time.Hour}).ToMilliseconds(),
 	}
 
 	reg := prometheus.NewPedanticRegistry()
@@ -251,6 +255,7 @@ func testBlocksCleanerWithOptions(t *testing.T, options testBlocksCleanerOptions
 		{path: path.Join("user-3", block10.String(), parquet.ConverterMarkerFileName), expectedExists: false},
 		{path: path.Join("user-4", block.DebugMetas, "meta.json"), expectedExists: options.user4FilesExist},
 		{path: path.Join("user-6", block13.String(), parquet.ConverterMarkerFileName), expectedExists: true},
+		{path: path.Join("user-6", block14.String(), parquet.ConverterMarkerFileName), expectedExists: false},
 	} {
 		exists, err := bucketClient.Exists(ctx, tc.path)
 		require.NoError(t, err)
@@ -296,6 +301,11 @@ func testBlocksCleanerWithOptions(t *testing.T, options testBlocksCleanerOptions
 		}, {
 			userID:        "user-3",
 			expectedIndex: false,
+		}, {
+			userID:         "user-6",
+			expectedIndex:  true,
+			expectedBlocks: []ulid.ULID{block13, block14},
+			expectedMarks:  []ulid.ULID{},
 		},
 	} {
 		idx, err := bucketindex.ReadIndex(ctx, bucketClient, tc.userID, nil, logger)
@@ -318,7 +328,7 @@ func testBlocksCleanerWithOptions(t *testing.T, options testBlocksCleanerOptions
 		cortex_bucket_blocks_count{user="user-1"} 2
 		cortex_bucket_blocks_count{user="user-2"} 1
 		cortex_bucket_blocks_count{user="user-5"} 2
-		cortex_bucket_blocks_count{user="user-6"} 1
+		cortex_bucket_blocks_count{user="user-6"} 2
 		# HELP cortex_bucket_blocks_marked_for_deletion_count Total number of blocks marked for deletion in the bucket.
 		# TYPE cortex_bucket_blocks_marked_for_deletion_count gauge
 		cortex_bucket_blocks_marked_for_deletion_count{user="user-1"} 1
@@ -341,9 +351,14 @@ func testBlocksCleanerWithOptions(t *testing.T, options testBlocksCleanerOptions
 		# TYPE cortex_bucket_parquet_blocks_count gauge
 		cortex_bucket_parquet_blocks_count{user="user-5"} 0
 		cortex_bucket_parquet_blocks_count{user="user-6"} 1
+		# HELP cortex_bucket_parquet_unconverted_blocks_count Total number of parquet blocks in the bucket. Blocks marked for deletion are included.
+		# TYPE cortex_bucket_parquet_unconverted_blocks_count gauge
+		cortex_bucket_parquet_unconverted_blocks_count{user="user-5"} 0
+		cortex_bucket_parquet_unconverted_blocks_count{user="user-6"} 0
 	`),
 		"cortex_bucket_blocks_count",
 		"cortex_bucket_parquet_blocks_count",
+		"cortex_bucket_parquet_unconverted_blocks_count",
 		"cortex_bucket_blocks_marked_for_deletion_count",
 		"cortex_bucket_blocks_marked_for_no_compaction_count",
 		"cortex_bucket_blocks_partials_count",
@@ -378,6 +393,7 @@ func TestBlocksCleaner_ShouldContinueOnBlockDeletionFailure(t *testing.T) {
 		DeletionDelay:      deletionDelay,
 		CleanupInterval:    time.Minute,
 		CleanupConcurrency: 1,
+		BlockRanges:        (&tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour}).ToMilliseconds(),
 	}
 
 	logger := log.NewNopLogger()
@@ -447,6 +463,7 @@ func TestBlocksCleaner_ShouldRebuildBucketIndexOnCorruptedOne(t *testing.T) {
 		DeletionDelay:      deletionDelay,
 		CleanupInterval:    time.Minute,
 		CleanupConcurrency: 1,
+		BlockRanges:        (&tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour}).ToMilliseconds(),
 	}
 
 	logger := log.NewNopLogger()
@@ -508,6 +525,7 @@ func TestBlocksCleaner_ShouldRemoveMetricsForTenantsNotBelongingAnymoreToTheShar
 		DeletionDelay:      time.Hour,
 		CleanupInterval:    time.Minute,
 		CleanupConcurrency: 1,
+		BlockRanges:        (&tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour}).ToMilliseconds(),
 	}
 
 	ctx := context.Background()
@@ -657,6 +675,7 @@ func TestBlocksCleaner_ShouldRemoveBlocksOutsideRetentionPeriod(t *testing.T) {
 		DeletionDelay:      time.Hour,
 		CleanupInterval:    time.Minute,
 		CleanupConcurrency: 1,
+		BlockRanges:        (&tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour}).ToMilliseconds(),
 	}
 
 	ctx := context.Background()
@@ -889,6 +908,7 @@ func TestBlocksCleaner_CleanPartitionedGroupInfo(t *testing.T) {
 		CleanupConcurrency: 1,
 		ShardingStrategy:   util.ShardingStrategyShuffle,
 		CompactionStrategy: util.CompactionStrategyPartitioning,
+		BlockRanges:        (&tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour}).ToMilliseconds(),
 	}
 
 	ctx := context.Background()
@@ -964,6 +984,7 @@ func TestBlocksCleaner_DeleteEmptyBucketIndex(t *testing.T) {
 		CleanupConcurrency: 1,
 		ShardingStrategy:   util.ShardingStrategyShuffle,
 		CompactionStrategy: util.CompactionStrategyPartitioning,
+		BlockRanges:        (&tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour}).ToMilliseconds(),
 	}
 
 	ctx := context.Background()
@@ -1019,6 +1040,91 @@ func TestBlocksCleaner_DeleteEmptyBucketIndex(t *testing.T) {
 
 	_, err = userBucket.WithExpectedErrs(userBucket.IsObjNotFoundErr).Get(ctx, partitionedGroupFile)
 	require.True(t, userBucket.IsObjNotFoundErr(err))
+}
+
+func TestBlocksCleaner_ParquetMetrics(t *testing.T) {
+	// Create metrics
+	reg := prometheus.NewPedanticRegistry()
+	blocksMarkedForDeletion := promauto.With(reg).NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cortex_compactor_blocks_marked_for_deletion_total",
+			Help: "Total number of blocks marked for deletion in compactor.",
+		},
+		[]string{"user", "reason"},
+	)
+	remainingPlannedCompactions := promauto.With(reg).NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "cortex_compactor_remaining_planned_compactions",
+			Help: "Total number of remaining planned compactions.",
+		},
+		[]string{"user"},
+	)
+
+	// Create the blocks cleaner
+	cleaner := NewBlocksCleaner(
+		BlocksCleanerConfig{
+			BlockRanges: (&tsdb.DurationList{
+				2 * time.Hour,
+				12 * time.Hour,
+			}).ToMilliseconds(),
+		},
+		nil, // bucket not needed
+		nil, // usersScanner not needed
+		0,
+		&mockConfigProvider{
+			parquetConverterEnabled: map[string]bool{
+				"user1": true,
+			},
+		},
+		log.NewNopLogger(),
+		"test",
+		reg,
+		0,
+		0,
+		blocksMarkedForDeletion,
+		remainingPlannedCompactions,
+	)
+
+	// Create test blocks in the index
+	now := time.Now()
+	idx := &bucketindex.Index{
+		Blocks: bucketindex.Blocks{
+			{
+				ID:      ulid.MustNew(ulid.Now(), rand.Reader),
+				MinTime: now.Add(-3 * time.Hour).UnixMilli(),
+				MaxTime: now.UnixMilli(),
+				Parquet: &parquet.ConverterMarkMeta{},
+			},
+			{
+				ID:      ulid.MustNew(ulid.Now(), rand.Reader),
+				MinTime: now.Add(-3 * time.Hour).UnixMilli(),
+				MaxTime: now.UnixMilli(),
+				Parquet: nil,
+			},
+			{
+				ID:      ulid.MustNew(ulid.Now(), rand.Reader),
+				MinTime: now.Add(-5 * time.Hour).UnixMilli(),
+				MaxTime: now.UnixMilli(),
+				Parquet: nil,
+			},
+		},
+	}
+
+	// Update metrics
+	cleaner.updateBucketMetrics("user1", true, idx, 0, 0)
+
+	// Verify metrics
+	require.NoError(t, prom_testutil.CollectAndCompare(cleaner.tenantParquetBlocks, strings.NewReader(`
+		# HELP cortex_bucket_parquet_blocks_count Total number of parquet blocks in the bucket. Blocks marked for deletion are included.
+		# TYPE cortex_bucket_parquet_blocks_count gauge
+		cortex_bucket_parquet_blocks_count{user="user1"} 1
+	`)))
+
+	require.NoError(t, prom_testutil.CollectAndCompare(cleaner.tenantParquetUnConvertedBlocks, strings.NewReader(`
+		# HELP cortex_bucket_parquet_unconverted_blocks_count Total number of parquet blocks in the bucket. Blocks marked for deletion are included.
+		# TYPE cortex_bucket_parquet_unconverted_blocks_count gauge
+		cortex_bucket_parquet_unconverted_blocks_count{user="user1"} 2
+	`)))
 }
 
 type mockConfigProvider struct {

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -752,6 +752,7 @@ func (c *Compactor) starting(ctx context.Context) error {
 		TenantCleanupDelay:                 c.compactorCfg.TenantCleanupDelay,
 		ShardingStrategy:                   c.compactorCfg.ShardingStrategy,
 		CompactionStrategy:                 c.compactorCfg.CompactionStrategy,
+		BlockRanges:                        c.compactorCfg.BlockRanges.ToMilliseconds(),
 	}, cleanerBucketClient, cleanerUsersScanner, c.compactorCfg.CompactionVisitMarkerTimeout, c.limits, c.parentLogger, cleanerRingLifecyclerID, c.registerer, c.compactorCfg.CleanerVisitMarkerTimeout, c.compactorCfg.CleanerVisitMarkerFileUpdateInterval,
 		c.compactorMetrics.syncerBlocksMarkedForDeletion, c.compactorMetrics.remainingPlannedCompactions)
 

--- a/pkg/parquetconverter/converter.go
+++ b/pkg/parquetconverter/converter.go
@@ -7,6 +7,7 @@ import (
 	"hash/fnv"
 	"math/rand"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -200,6 +201,9 @@ func (c *Converter) running(ctx context.Context) error {
 			})
 
 			for _, userID := range users {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
 				if !c.limits.ParquetConverterEnabled(userID) {
 					// It is possible that parquet is disabled for the userID so we
 					// need to check if the user was owned last time.
@@ -236,8 +240,10 @@ func (c *Converter) running(ctx context.Context) error {
 
 				ownedUsers[userID] = struct{}{}
 
-				err = c.convertUser(ctx, userLogger, ring, userID)
-				if err != nil {
+				if err = c.convertUser(ctx, userLogger, ring, userID); err != nil {
+					if ctx.Err() != nil {
+						return ctx.Err()
+					}
 					level.Error(userLogger).Log("msg", "failed to convert user", "err", err)
 				}
 			}
@@ -353,6 +359,9 @@ func (c *Converter) convertUser(ctx context.Context, logger log.Logger, ring rin
 	})
 
 	for _, b := range blocks {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		ok, err := c.ownBlock(ring, b.ULID.String())
 		if err != nil {
 			level.Error(logger).Log("msg", "failed to get own block", "block", b.ULID.String(), "err", err)
@@ -373,13 +382,15 @@ func (c *Converter) convertUser(ctx context.Context, logger log.Logger, ring rin
 			continue
 		}
 
-		// Do not convert 2 hours blocks
-		if getBlockTimeRange(b, c.blockRanges) == c.blockRanges[0] {
+		if !cortex_parquet.ShouldConvertBlockToParquet(b.MinTime, b.MaxTime, c.blockRanges) {
 			continue
 		}
 
 		if err := os.RemoveAll(c.compactRootDir()); err != nil {
 			level.Error(logger).Log("msg", "failed to remove work directory", "path", c.compactRootDir(), "err", err)
+			if c.checkConvertError(userID, err) {
+				return err
+			}
 			continue
 		}
 
@@ -388,13 +399,19 @@ func (c *Converter) convertUser(ctx context.Context, logger log.Logger, ring rin
 		level.Info(logger).Log("msg", "downloading block", "block", b.ULID.String(), "dir", bdir)
 
 		if err := block.Download(ctx, logger, uBucket, b.ULID, bdir, objstore.WithFetchConcurrency(10)); err != nil {
-			level.Error(logger).Log("msg", "Error downloading block", "err", err)
+			level.Error(logger).Log("msg", "failed to download block", "block", b.ULID.String(), "err", err)
+			if c.checkConvertError(userID, err) {
+				return err
+			}
 			continue
 		}
 
 		tsdbBlock, err := tsdb.OpenBlock(logutil.GoKitLogToSlog(logger), bdir, c.pool, tsdb.DefaultPostingsDecoderFactory)
 		if err != nil {
-			level.Error(logger).Log("msg", "Error opening block", "err", err)
+			level.Error(logger).Log("msg", "failed to open block", "block", b.ULID.String(), "err", err)
+			if c.checkConvertError(userID, err) {
+				return err
+			}
 			continue
 		}
 
@@ -419,7 +436,10 @@ func (c *Converter) convertUser(ctx context.Context, logger log.Logger, ring rin
 		_ = tsdbBlock.Close()
 
 		if err != nil {
-			level.Error(logger).Log("msg", "Error converting block", "block", b.ULID.String(), "err", err)
+			level.Error(logger).Log("msg", "failed to convert block", "block", b.ULID.String(), "err", err)
+			if c.checkConvertError(userID, err) {
+				return err
+			}
 			continue
 		}
 		duration := time.Since(start)
@@ -427,13 +447,36 @@ func (c *Converter) convertUser(ctx context.Context, logger log.Logger, ring rin
 		level.Info(logger).Log("msg", "successfully converted block", "block", b.ULID.String(), "duration", duration)
 
 		if err = cortex_parquet.WriteConverterMark(ctx, b.ULID, uBucket); err != nil {
-			level.Error(logger).Log("msg", "Error writing block", "block", b.ULID.String(), "err", err)
+			level.Error(logger).Log("msg", "failed to write parquet converter marker", "block", b.ULID.String(), "err", err)
+			if c.checkConvertError(userID, err) {
+				return err
+			}
 			continue
 		}
+		duration = time.Since(start)
+		level.Info(logger).Log("msg", "successfully uploaded parquet converter marker", "block", b.ULID.String(), "duration", duration)
+
 		c.metrics.convertedBlocks.WithLabelValues(userID).Inc()
+		metaAttrs, err := uBucket.Attributes(ctx, path.Join(b.ULID.String(), metadata.MetaFilename))
+		if err != nil {
+			// Don't check convert error as attributes call is not really part of the convert process.
+			level.Error(logger).Log("msg", "failed to get block meta attributes", "block", b.ULID.String(), "err", err)
+			continue
+		}
+		delayMinutes := time.Since(metaAttrs.LastModified).Minutes()
+		c.metrics.convertParquetBlockDelay.Observe(delayMinutes)
 	}
 
 	return nil
+}
+
+func (c *Converter) checkConvertError(userID string, err error) (terminate bool) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		terminate = true
+	} else {
+		c.metrics.convertBlockFailures.WithLabelValues(userID).Inc()
+	}
+	return
 }
 
 func (c *Converter) ownUser(r ring.ReadRing, userId string) (bool, error) {
@@ -508,30 +551,4 @@ func (c *Converter) listTenantsWithMetaSyncDirectories() map[string]struct{} {
 	}
 
 	return result
-}
-
-func getBlockTimeRange(b *metadata.Meta, timeRanges []int64) int64 {
-	timeRange := int64(0)
-	// fallback logic to guess block time range based
-	// on MaxTime and MinTime
-	blockRange := b.MaxTime - b.MinTime
-	for _, tr := range timeRanges {
-		rangeStart := getRangeStart(b.MinTime, tr)
-		rangeEnd := rangeStart + tr
-		if tr >= blockRange && rangeEnd >= b.MaxTime {
-			timeRange = tr
-			break
-		}
-	}
-	return timeRange
-}
-
-func getRangeStart(mint, tr int64) int64 {
-	// Compute start of aligned time range of size tr closest to the current block's start.
-	// This code has been copied from TSDB.
-	if mint >= 0 {
-		return tr * (mint / tr)
-	}
-
-	return tr * ((mint - tr + 1) / tr)
 }

--- a/pkg/parquetconverter/metrics.go
+++ b/pkg/parquetconverter/metrics.go
@@ -6,21 +6,32 @@ import (
 )
 
 type metrics struct {
-	convertedBlocks      *prometheus.CounterVec
-	convertBlockDuration *prometheus.GaugeVec
-	ownedUsers           prometheus.Gauge
+	convertedBlocks          *prometheus.CounterVec
+	convertBlockFailures     *prometheus.CounterVec
+	convertBlockDuration     *prometheus.GaugeVec
+	convertParquetBlockDelay prometheus.Histogram
+	ownedUsers               prometheus.Gauge
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
 	return &metrics{
 		convertedBlocks: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_parquet_converter_converted_blocks_total",
-			Help: "Total number of converted blocks per user.",
+			Name: "cortex_parquet_converter_blocks_converted_total",
+			Help: "Total number of blocks converted to parquet per user.",
+		}, []string{"user"}),
+		convertBlockFailures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_parquet_converter_block_convert_failures_total",
+			Help: "Total number of failed block conversions per user.",
 		}, []string{"user"}),
 		convertBlockDuration: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_parquet_converter_convert_block_duration_seconds",
 			Help: "Time taken to for the latest block conversion for the user.",
 		}, []string{"user"}),
+		convertParquetBlockDelay: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_parquet_converter_convert_block_delay_minutes",
+			Help:    "Delay in minutes of Parquet block to be converted from the TSDB block being uploaded to object store",
+			Buckets: []float64{5, 10, 15, 20, 30, 45, 60, 80, 100, 120},
+		}),
 		ownedUsers: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_parquet_converter_users_owned",
 			Help: "Number of users that the parquet converter owns.",
@@ -30,5 +41,6 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 
 func (m *metrics) deleteMetricsForTenant(userID string) {
 	m.convertedBlocks.DeleteLabelValues(userID)
+	m.convertBlockFailures.DeleteLabelValues(userID)
 	m.convertBlockDuration.DeleteLabelValues(userID)
 }

--- a/pkg/storage/parquet/util.go
+++ b/pkg/storage/parquet/util.go
@@ -1,0 +1,32 @@
+package parquet
+
+func ShouldConvertBlockToParquet(mint, maxt int64, timeRanges []int64) bool {
+	// We assume timeRanges[0] is the TSDB block duration (2h), and we don't convert them.
+	return getBlockTimeRange(mint, maxt, timeRanges) > timeRanges[0]
+}
+
+func getBlockTimeRange(mint, maxt int64, timeRanges []int64) int64 {
+	timeRange := int64(0)
+	// fallback logic to guess block time range based
+	// on MaxTime and MinTime
+	blockRange := maxt - mint
+	for _, tr := range timeRanges {
+		rangeStart := getRangeStart(mint, tr)
+		rangeEnd := rangeStart + tr
+		if tr >= blockRange && rangeEnd >= maxt {
+			timeRange = tr
+			break
+		}
+	}
+	return timeRange
+}
+
+func getRangeStart(mint, tr int64) int64 {
+	// Compute start of aligned time range of size tr closest to the current block's start.
+	// This code has been copied from TSDB.
+	if mint >= 0 {
+		return tr * (mint / tr)
+	}
+
+	return tr * ((mint - tr + 1) / tr)
+}

--- a/pkg/storage/parquet/util.go
+++ b/pkg/storage/parquet/util.go
@@ -18,6 +18,12 @@ func getBlockTimeRange(mint, maxt int64, timeRanges []int64) int64 {
 			break
 		}
 	}
+	// If the block range is too big and cannot fit any configured time range, just fallback to the final time range.
+	// This might not be accurate but should be good enough to decide if we want to convert the block to Parquet.
+	// For this to work, at least 2 block ranges are required.
+	if len(timeRanges) > 0 && timeRange == int64(0) {
+		return timeRanges[len(timeRanges)-1]
+	}
 	return timeRange
 }
 

--- a/pkg/storage/parquet/util_test.go
+++ b/pkg/storage/parquet/util_test.go
@@ -1,0 +1,67 @@
+package parquet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cortexproject/cortex/pkg/storage/tsdb"
+)
+
+func TestShouldConvertBlockToParquet(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		mint, maxt int64
+		durations  tsdb.DurationList
+		expected   bool
+	}{
+		{
+			name:      "2h block. Don't convert",
+			mint:      0,
+			maxt:      2 * time.Hour.Milliseconds(),
+			durations: tsdb.DurationList{2 * time.Hour, 12 * time.Hour},
+			expected:  false,
+		},
+		{
+			name:      "1h block. Don't convert",
+			mint:      0,
+			maxt:      1 * time.Hour.Milliseconds(),
+			durations: tsdb.DurationList{2 * time.Hour, 12 * time.Hour},
+			expected:  false,
+		},
+		{
+			name:      "3h block. Convert",
+			mint:      0,
+			maxt:      3 * time.Hour.Milliseconds(),
+			durations: tsdb.DurationList{2 * time.Hour, 12 * time.Hour},
+			expected:  true,
+		},
+		{
+			name:      "12h block. Convert",
+			mint:      0,
+			maxt:      12 * time.Hour.Milliseconds(),
+			durations: tsdb.DurationList{2 * time.Hour, 12 * time.Hour},
+			expected:  true,
+		},
+		{
+			name:      "12h block with 1h offset. Convert",
+			mint:      time.Hour.Milliseconds(),
+			maxt:      13 * time.Hour.Milliseconds(),
+			durations: tsdb.DurationList{2 * time.Hour, 12 * time.Hour},
+			expected:  true,
+		},
+		{
+			name:      "24h block. Convert",
+			mint:      0,
+			maxt:      24 * time.Hour.Milliseconds(),
+			durations: tsdb.DurationList{2 * time.Hour, 12 * time.Hour},
+			expected:  true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := ShouldConvertBlockToParquet(tc.mint, tc.maxt, (&tc.durations).ToMilliseconds())
+			require.Equal(t, tc.expected, res)
+		})
+	}
+}

--- a/pkg/storage/tsdb/bucketindex/index.go
+++ b/pkg/storage/tsdb/bucketindex/index.go
@@ -70,12 +70,25 @@ func (idx *Index) IsEmpty() bool {
 	return len(idx.Blocks) == 0 && len(idx.BlockDeletionMarks) == 0
 }
 
+// ParquetBlocks returns all blocks that are available in Parquet format.
 func (idx *Index) ParquetBlocks() []*Block {
 	blocks := make([]*Block, 0, len(idx.Blocks))
 	for _, b := range idx.Blocks {
 		if b.Parquet != nil {
 			blocks = append(blocks, b)
 		}
+	}
+	return blocks
+}
+
+// NonParquetBlocks returns all blocks that are not available in Parquet format.
+func (idx *Index) NonParquetBlocks() []*Block {
+	blocks := make([]*Block, 0, len(idx.Blocks))
+	for _, b := range idx.Blocks {
+		if b.Parquet != nil {
+			continue
+		}
+		blocks = append(blocks, b)
 	}
 	return blocks
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR tries to add more Parquet metrics.

Cleaner:
- Add `cortex_bucket_parquet_unconverted_blocks_count` metric for total number of TSDB blocks that should be converted to Parquet but not available yet. This can be useful to see the backlog.

Converter:
- Add `cortex_parquet_converter_convert_block_delay_minutes` histogram metric. This is to track the delay from the time when TSDB block is uploaded to the time the block is converted to Parquet format.
- Add `cortex_parquet_converter_block_convert_failures_total` metric for number of failed block conversions. This tracks all conversion failures except context cancellation error.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
