### PR TITLE
Split compactor cleaner metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 * [ENHANCEMENT] Query Frontend: Enhance the performance of the JSON codec. #6816
 * [ENHANCEMENT] Metadata Cache: Support inmemory and multi level cache backend. #6829
 * [ENHANCEMENT] Store Gateway: Allow to ignore syncing blocks older than certain time using `ignore_blocks_before`. #6830
-* [ENHANCEMENT] Compactor: Split cleaner logic. #6827
+* [ENHANCEMENT] Compactor: Emit partition metrics separate from cleaner job. #6827
 * [BUGFIX] Ingester: Avoid error or early throttling when READONLY ingesters are present in the ring #6517
 * [BUGFIX] Ingester: Fix labelset data race condition. #6573
 * [BUGFIX] Compactor: Cleaner should not put deletion marker for blocks with no-compact marker. #6576

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [ENHANCEMENT] Query Frontend: Enhance the performance of the JSON codec. #6816
 * [ENHANCEMENT] Metadata Cache: Support inmemory and multi level cache backend. #6829
 * [ENHANCEMENT] Store Gateway: Allow to ignore syncing blocks older than certain time using `ignore_blocks_before`. #6830
+* [ENHANCEMENT] Compactor: Split cleaner logic. #6827
 * [BUGFIX] Ingester: Avoid error or early throttling when READONLY ingesters are present in the ring #6517
 * [BUGFIX] Ingester: Fix labelset data race condition. #6573
 * [BUGFIX] Compactor: Cleaner should not put deletion marker for blocks with no-compact marker. #6576

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -1378,9 +1378,10 @@ blocks_storage:
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.bucket-index-max-size-bytes
       [bucket_index_max_size_bytes: <int> | default = 1048576]
 
-      # How long to cache list of partitioned groups for an user.
+      # How long to cache list of partitioned groups for an user. 0 disables
+      # caching
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.partitioned-groups-list-ttl
-      [partitioned_groups_list_ttl: <duration> | default = 5m]
+      [partitioned_groups_list_ttl: <duration> | default = 0s]
 
     # Maximum number of entries in the regex matchers cache. 0 to disable.
     # CLI flag: -blocks-storage.bucket-store.matchers-cache-max-items

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -1378,6 +1378,10 @@ blocks_storage:
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.bucket-index-max-size-bytes
       [bucket_index_max_size_bytes: <int> | default = 1048576]
 
+      # How long to cache list of partitioned groups for an user.
+      # CLI flag: -blocks-storage.bucket-store.metadata-cache.partitioned-groups-list-ttl
+      [partitioned_groups_list_ttl: <duration> | default = 5m]
+
     # Maximum number of entries in the regex matchers cache. 0 to disable.
     # CLI flag: -blocks-storage.bucket-store.matchers-cache-max-items
     [matchers_cache_max_items: <int> | default = 0]

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -1499,6 +1499,10 @@ blocks_storage:
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.bucket-index-max-size-bytes
       [bucket_index_max_size_bytes: <int> | default = 1048576]
 
+      # How long to cache list of partitioned groups for an user.
+      # CLI flag: -blocks-storage.bucket-store.metadata-cache.partitioned-groups-list-ttl
+      [partitioned_groups_list_ttl: <duration> | default = 5m]
+
     # Maximum number of entries in the regex matchers cache. 0 to disable.
     # CLI flag: -blocks-storage.bucket-store.matchers-cache-max-items
     [matchers_cache_max_items: <int> | default = 0]

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -1499,9 +1499,10 @@ blocks_storage:
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.bucket-index-max-size-bytes
       [bucket_index_max_size_bytes: <int> | default = 1048576]
 
-      # How long to cache list of partitioned groups for an user.
+      # How long to cache list of partitioned groups for an user. 0 disables
+      # caching
       # CLI flag: -blocks-storage.bucket-store.metadata-cache.partitioned-groups-list-ttl
-      [partitioned_groups_list_ttl: <duration> | default = 5m]
+      [partitioned_groups_list_ttl: <duration> | default = 0s]
 
     # Maximum number of entries in the regex matchers cache. 0 to disable.
     # CLI flag: -blocks-storage.bucket-store.matchers-cache-max-items

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1969,6 +1969,10 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.metadata-cache.bucket-index-max-size-bytes
     [bucket_index_max_size_bytes: <int> | default = 1048576]
 
+    # How long to cache list of partitioned groups for an user.
+    # CLI flag: -blocks-storage.bucket-store.metadata-cache.partitioned-groups-list-ttl
+    [partitioned_groups_list_ttl: <duration> | default = 5m]
+
   # Maximum number of entries in the regex matchers cache. 0 to disable.
   # CLI flag: -blocks-storage.bucket-store.matchers-cache-max-items
   [matchers_cache_max_items: <int> | default = 0]

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -1969,9 +1969,10 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.metadata-cache.bucket-index-max-size-bytes
     [bucket_index_max_size_bytes: <int> | default = 1048576]
 
-    # How long to cache list of partitioned groups for an user.
+    # How long to cache list of partitioned groups for an user. 0 disables
+    # caching
     # CLI flag: -blocks-storage.bucket-store.metadata-cache.partitioned-groups-list-ttl
-    [partitioned_groups_list_ttl: <duration> | default = 5m]
+    [partitioned_groups_list_ttl: <duration> | default = 0s]
 
   # Maximum number of entries in the regex matchers cache. 0 to disable.
   # CLI flag: -blocks-storage.bucket-store.matchers-cache-max-items

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -781,7 +781,7 @@ func (c *BlocksCleaner) updateBucketMetrics(userID string, parquetEnabled bool, 
 }
 
 func (c *BlocksCleaner) cleanPartitionedGroupInfo(ctx context.Context, userBucket objstore.InstrumentedBucket, userLogger log.Logger, userID string) {
-	err, existentPartitionedGroupInfo := c.iterPartitionGroups(ctx, userBucket, userLogger)
+	existentPartitionedGroupInfo, err := c.iterPartitionGroups(ctx, userBucket, userLogger)
 	if err != nil {
 		level.Warn(userLogger).Log("msg", "error return when going through partitioned group directory", "err", err)
 	}
@@ -820,7 +820,7 @@ func (c *BlocksCleaner) cleanPartitionedGroupInfo(ctx context.Context, userBucke
 }
 
 func (c *BlocksCleaner) emitUserMetrics(ctx context.Context, userLogger log.Logger, userBucket objstore.InstrumentedBucket, userID string) {
-	err, existentPartitionedGroupInfo := c.iterPartitionGroups(ctx, userBucket, userLogger)
+	existentPartitionedGroupInfo, err := c.iterPartitionGroups(ctx, userBucket, userLogger)
 	if err != nil {
 		level.Warn(userLogger).Log("msg", "error return when going through partitioned group directory", "err", err)
 	}
@@ -849,10 +849,10 @@ func (c *BlocksCleaner) emitUserMetrics(ctx context.Context, userLogger log.Logg
 	}
 }
 
-func (c *BlocksCleaner) iterPartitionGroups(ctx context.Context, userBucket objstore.InstrumentedBucket, userLogger log.Logger) (error, map[*PartitionedGroupInfo]struct {
+func (c *BlocksCleaner) iterPartitionGroups(ctx context.Context, userBucket objstore.InstrumentedBucket, userLogger log.Logger) (map[*PartitionedGroupInfo]struct {
 	path   string
 	status PartitionedGroupStatus
-}) {
+}, error) {
 	existentPartitionedGroupInfo := make(map[*PartitionedGroupInfo]struct {
 		path   string
 		status PartitionedGroupStatus
@@ -878,7 +878,7 @@ func (c *BlocksCleaner) iterPartitionGroups(ctx context.Context, userBucket objs
 		}
 		return nil
 	})
-	return err, existentPartitionedGroupInfo
+	return existentPartitionedGroupInfo, err
 }
 
 // cleanUserPartialBlocks delete partial blocks which are safe to be deleted. The provided partials map

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -827,7 +827,6 @@ func (c *BlocksCleaner) emitUserMetrics(ctx context.Context, userLogger log.Logg
 
 	remainingCompactions := 0
 	inProgressCompactions := 0
-	completedCompaction := 0
 	var oldestPartitionGroup *PartitionedGroupInfo
 	defer func() {
 		c.remainingPlannedCompactions.WithLabelValues(userID).Set(float64(remainingCompactions))
@@ -846,9 +845,6 @@ func (c *BlocksCleaner) emitUserMetrics(ctx context.Context, userLogger log.Logg
 		inProgressCompactions += extraInfo.status.InProgressPartitions
 		if oldestPartitionGroup == nil || partitionedGroupInfo.CreationTime < oldestPartitionGroup.CreationTime {
 			oldestPartitionGroup = partitionedGroupInfo
-		}
-		if extraInfo.status.IsCompleted {
-			completedCompaction += len(partitionedGroupInfo.Partitions)
 		}
 	}
 }

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -1226,7 +1226,7 @@ func TestBlocksCleaner_EmitUserMetrics(t *testing.T) {
 	err = v4Manager.updateVisitMarker(ctx)
 	require.NoError(t, err)
 
-	cleaner.emitUserMetrics(ctx, logger, userBucket, userID)
+	cleaner.emitUserParititionMetrics(ctx, logger, userBucket, userID)
 
 	metricNames := []string{
 		"cortex_compactor_remaining_planned_compactions",

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 	"github.com/cortexproject/cortex/pkg/util/services"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 type testBlocksCleanerOptions struct {
@@ -1248,7 +1247,7 @@ func TestBlocksCleaner_EmitUserMetrics(t *testing.T) {
 		cortex_compactor_remaining_planned_compactions{user="user-1"} 3
 	`
 
-	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), metricNames...))
+	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), metricNames...))
 }
 
 type mockConfigProvider struct {

--- a/pkg/storage/tsdb/caching_bucket.go
+++ b/pkg/storage/tsdb/caching_bucket.go
@@ -146,17 +146,18 @@ func (cfg *InMemoryBucketCacheConfig) toInMemoryCacheConfig() cache.InMemoryCach
 type MetadataCacheConfig struct {
 	BucketCacheBackend `yaml:",inline"`
 
-	TenantsListTTL          time.Duration `yaml:"tenants_list_ttl"`
-	TenantBlocksListTTL     time.Duration `yaml:"tenant_blocks_list_ttl"`
-	ChunksListTTL           time.Duration `yaml:"chunks_list_ttl"`
-	MetafileExistsTTL       time.Duration `yaml:"metafile_exists_ttl"`
-	MetafileDoesntExistTTL  time.Duration `yaml:"metafile_doesnt_exist_ttl"`
-	MetafileContentTTL      time.Duration `yaml:"metafile_content_ttl"`
-	MetafileMaxSize         int           `yaml:"metafile_max_size_bytes"`
-	MetafileAttributesTTL   time.Duration `yaml:"metafile_attributes_ttl"`
-	BlockIndexAttributesTTL time.Duration `yaml:"block_index_attributes_ttl"`
-	BucketIndexContentTTL   time.Duration `yaml:"bucket_index_content_ttl"`
-	BucketIndexMaxSize      int           `yaml:"bucket_index_max_size_bytes"`
+	TenantsListTTL           time.Duration `yaml:"tenants_list_ttl"`
+	TenantBlocksListTTL      time.Duration `yaml:"tenant_blocks_list_ttl"`
+	ChunksListTTL            time.Duration `yaml:"chunks_list_ttl"`
+	MetafileExistsTTL        time.Duration `yaml:"metafile_exists_ttl"`
+	MetafileDoesntExistTTL   time.Duration `yaml:"metafile_doesnt_exist_ttl"`
+	MetafileContentTTL       time.Duration `yaml:"metafile_content_ttl"`
+	MetafileMaxSize          int           `yaml:"metafile_max_size_bytes"`
+	MetafileAttributesTTL    time.Duration `yaml:"metafile_attributes_ttl"`
+	BlockIndexAttributesTTL  time.Duration `yaml:"block_index_attributes_ttl"`
+	BucketIndexContentTTL    time.Duration `yaml:"bucket_index_content_ttl"`
+	BucketIndexMaxSize       int           `yaml:"bucket_index_max_size_bytes"`
+	PartitionedGroupsListTTL time.Duration `yaml:"partitioned_groups_list_ttl"`
 }
 
 func (cfg *MetadataCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
@@ -180,6 +181,7 @@ func (cfg *MetadataCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix 
 	f.DurationVar(&cfg.BlockIndexAttributesTTL, prefix+"block-index-attributes-ttl", 168*time.Hour, "How long to cache attributes of the block index.")
 	f.DurationVar(&cfg.BucketIndexContentTTL, prefix+"bucket-index-content-ttl", 5*time.Minute, "How long to cache content of the bucket index.")
 	f.IntVar(&cfg.BucketIndexMaxSize, prefix+"bucket-index-max-size-bytes", 1*1024*1024, "Maximum size of bucket index content to cache in bytes. Caching will be skipped if the content exceeds this size. This is useful to avoid network round trip for large content if the configured caching backend has an hard limit on cached items size (in this case, you should set this limit to the same limit in the caching backend).")
+	f.DurationVar(&cfg.PartitionedGroupsListTTL, prefix+"partitioned-groups-list-ttl", 5*time.Minute, "How long to cache list of partitioned groups for an user.")
 }
 
 func (cfg *MetadataCacheConfig) Validate() error {
@@ -259,6 +261,9 @@ func CreateCachingBucketForCompactor(metadataConfig MetadataCacheConfig, cleaner
 		} else {
 			// Cache only GET for metadata and don't cache exists and not exists.
 			cfg.CacheGet("metafile", metadataCache, matchers.GetMetafileMatcher(), metadataConfig.MetafileMaxSize, metadataConfig.MetafileContentTTL, 0, 0)
+
+			//Avoid double iter when running cleanActiveUser and emitUserMetrics
+			cfg.CacheIter("partitioned-groups-iter", metadataCache, matchers.GetPartitionedGroupsIterMatcher(), metadataConfig.PartitionedGroupsListTTL, codec, "")
 		}
 	}
 
@@ -322,6 +327,7 @@ func NewMatchers() Matchers {
 	matcherMap["tenants-iter"] = isTenantsDir
 	matcherMap["tenant-blocks-iter"] = isTenantBlocksDir
 	matcherMap["chunks-iter"] = isChunksDir
+	matcherMap["partitioned-groups-iter"] = isPartitionedGroupsDir
 	return Matchers{
 		matcherMap: matcherMap,
 	}
@@ -359,6 +365,10 @@ func (m *Matchers) SetChunksIterMatcher(f func(string) bool) {
 	m.matcherMap["chunks-iter"] = f
 }
 
+func (m *Matchers) SetPartitionedGroupsIterMatcher(f func(string) bool) {
+	m.matcherMap["partitioned-groups-iter"] = f
+}
+
 func (m *Matchers) GetChunksMatcher() func(string) bool {
 	return m.matcherMap["chunks"]
 }
@@ -389,6 +399,10 @@ func (m *Matchers) GetTenantBlocksIterMatcher() func(string) bool {
 
 func (m *Matchers) GetChunksIterMatcher() func(string) bool {
 	return m.matcherMap["chunks-iter"]
+}
+
+func (m *Matchers) GetPartitionedGroupsIterMatcher() func(string) bool {
+	return m.matcherMap["partitioned-groups-iter"]
 }
 
 var chunksMatcher = regexp.MustCompile(`^.*/chunks/\d+$`)
@@ -428,6 +442,10 @@ func isTenantBlocksDir(name string) bool {
 
 func isChunksDir(name string) bool {
 	return strings.HasSuffix(name, "/chunks")
+}
+
+func isPartitionedGroupsDir(name string) bool {
+	return strings.HasSuffix(name, "/partitioned-groups")
 }
 
 type snappyIterCodec struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
When cleanUpUser takes long it might delay compaction cleaner metrics leaving the user blind to what is happening. This approach separate metrics in another go routine which will run independently if the cleanUser is impaired

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
