### PR TITLE
refactor: delete a NumOverrides error

### DIFF
--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -558,8 +558,7 @@ receivers:
 				flagext.DefaultValues(&limits)
 				limits.AlertmanagerReceiversBlockPrivateAddresses = firewallEnabled
 
-				overrides, err := validation.NewOverrides(limits, nil)
-				require.NoError(t, err)
+				overrides := validation.NewOverrides(limits, nil)
 
 				// Start the alertmanager.
 				reg := prometheus.NewPedanticRegistry()
@@ -1778,8 +1777,7 @@ func TestAlertmanager_StateReplicationWithSharding(t *testing.T) {
 				var limits validation.Limits
 				flagext.DefaultValues(&limits)
 
-				overrides, err := validation.NewOverrides(limits, nil)
-				require.NoError(t, err)
+				overrides := validation.NewOverrides(limits, nil)
 
 				reg := prometheus.NewPedanticRegistry()
 				am, err := createMultitenantAlertmanager(amConfig, nil, nil, mockStore, ringStore, overrides, log.NewNopLogger(), reg)
@@ -1976,8 +1974,7 @@ func TestAlertmanager_StateReplicationWithSharding_InitialSyncFromPeers(t *testi
 				var limits validation.Limits
 				flagext.DefaultValues(&limits)
 
-				overrides, err := validation.NewOverrides(limits, nil)
-				require.NoError(t, err)
+				overrides := validation.NewOverrides(limits, nil)
 
 				reg := prometheus.NewPedanticRegistry()
 				am, err := createMultitenantAlertmanager(amConfig, nil, nil, mockStore, ringStore, overrides, log.NewNopLogger(), reg)

--- a/pkg/compactor/compactor_paritioning_test.go
+++ b/pkg/compactor/compactor_paritioning_test.go
@@ -1435,8 +1435,7 @@ func prepareForPartitioning(t *testing.T, compactorCfg Config, bucketClient objs
 		flagext.DefaultValues(limits)
 	}
 
-	overrides, err := validation.NewOverrides(*limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(*limits, nil)
 
 	bucketClientFactory := func(ctx context.Context) (objstore.InstrumentedBucket, error) {
 		return bucketClient, nil

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1585,8 +1585,7 @@ func prepare(t *testing.T, compactorCfg Config, bucketClient objstore.Instrument
 		flagext.DefaultValues(limits)
 	}
 
-	overrides, err := validation.NewOverrides(*limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(*limits, nil)
 
 	bucketClientFactory := func(ctx context.Context) (objstore.InstrumentedBucket, error) {
 		return bucketClient, nil
@@ -2295,7 +2294,7 @@ func TestCompactor_GetShardSizeForUser(t *testing.T) {
 		cfg.ShardingRing.KVStore.Mock = kvstore
 
 		// Compactor will get its own temp dir for storing local files.
-		overrides, _ := validation.NewOverrides(validation.Limits{}, tenantLimits)
+		overrides := validation.NewOverrides(validation.Limits{}, tenantLimits)
 		compactor, _, tsdbPlanner, _, _ := prepare(t, cfg, inmem, nil)
 		compactor.limits = overrides
 		//compactor.limits.tenantLimits = tenantLimits
@@ -2344,7 +2343,7 @@ func TestCompactor_GetShardSizeForUser(t *testing.T) {
 		cfg.ShardingRing.KVStore.Mock = kvstore
 
 		// Compactor will get its own temp dir for storing local files.
-		overrides, _ := validation.NewOverrides(validation.Limits{}, tenantLimits)
+		overrides := validation.NewOverrides(validation.Limits{}, tenantLimits)
 		compactor, _, tsdbPlanner, _, _ := prepare(t, cfg, inmem, nil)
 		compactor.limits = overrides
 		//compactor.limits.tenantLimits = tenantLimits

--- a/pkg/compactor/partition_compaction_grouper_test.go
+++ b/pkg/compactor/partition_compaction_grouper_test.go
@@ -2048,8 +2048,7 @@ func TestPartitionCompactionGrouper_GenerateCompactionJobs(t *testing.T) {
 			limits := &validation.Limits{
 				CompactorPartitionSeriesCount: 4,
 			}
-			overrides, err := validation.NewOverrides(*limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(*limits, nil)
 
 			// Setup mocking of the ring so that the grouper will own all the shards
 			rs := ring.ReplicationSet{

--- a/pkg/compactor/shuffle_sharding_grouper_test.go
+++ b/pkg/compactor/shuffle_sharding_grouper_test.go
@@ -330,8 +330,7 @@ func TestShuffleShardingGrouper_Groups(t *testing.T) {
 			}
 
 			limits := &validation.Limits{}
-			overrides, err := validation.NewOverrides(*limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(*limits, nil)
 
 			// Setup mocking of the ring so that the grouper will own all the shards
 			rs := ring.ReplicationSet{

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -199,11 +199,11 @@ func (t *Cortex) initRuntimeConfig() (services.Service, error) {
 	return serv, err
 }
 
-func (t *Cortex) initOverrides() (serv services.Service, err error) {
-	t.Overrides, err = validation.NewOverrides(t.Cfg.LimitsConfig, t.TenantLimits)
+func (t *Cortex) initOverrides() (services.Service, error) {
+	t.Overrides = validation.NewOverrides(t.Cfg.LimitsConfig, t.TenantLimits)
 	// overrides don't have operational state, nor do they need to do anything more in starting/stopping phase,
 	// so there is no need to return any service.
-	return nil, err
+	return nil, nil
 }
 
 func (t *Cortex) initOverridesExporter() (services.Service, error) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2488,8 +2488,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 			}
 			distributorCfg.UseStreamPush = false
 
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(b, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			// Start the distributor.
 			distributor, err := New(distributorCfg, clientConfig, overrides, ingestersRing, true, prometheus.NewRegistry(), log.NewNopLogger())
@@ -3121,8 +3120,7 @@ func prepare(tb testing.TB, cfg prepConfig) ([]*Distributor, []*mockIngester, []
 			cfg.limits.HAMaxClusters = 100
 		}
 
-		overrides, err := validation.NewOverrides(*cfg.limits, nil)
-		require.NoError(tb, err)
+		overrides := validation.NewOverrides(*cfg.limits, nil)
 
 		reg := prometheus.NewPedanticRegistry()
 		d, err := New(distributorCfg, clientConfig, overrides, ingestersRing, true, reg, log.NewNopLogger())
@@ -4336,8 +4334,7 @@ func TestDistributor_PushLabelSetMetrics(t *testing.T) {
 		{Hash: 4, LabelSet: labels.FromStrings("cluster", "four")},
 		{Hash: 2, LabelSet: labels.EmptyLabels()},
 	}
-	ds[0].limits, err = validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	ds[0].limits = validation.NewOverrides(limits, nil)
 	ds[0].updateLabelSetMetrics()
 	// Old label set metrics are removed. New label set metrics will be added when
 	// new requests come in.

--- a/pkg/distributor/ingestion_rate_strategy_test.go
+++ b/pkg/distributor/ingestion_rate_strategy_test.go
@@ -97,8 +97,7 @@ func TestIngestionRateStrategy(t *testing.T) {
 			var nativeHistogramsStrategy limiter.RateLimiterStrategy
 
 			// Init limits overrides
-			overrides, err := validation.NewOverrides(testData.limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(testData.limits, nil)
 
 			// Instance the strategy
 			switch testData.limits.IngestionRateStrategy {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -4010,10 +4010,7 @@ func prepareIngesterWithBlocksStorageAndLimits(t testing.TB, ingesterCfg Config,
 
 	bucketDir := t.TempDir()
 
-	overrides, err := validation.NewOverrides(limits, tenantLimits)
-	if err != nil {
-		return nil, err
-	}
+	overrides := validation.NewOverrides(limits, tenantLimits)
 
 	ingesterCfg.BlocksStorageConfig.TSDB.Dir = dataDir
 	ingesterCfg.BlocksStorageConfig.Bucket.Backend = "filesystem"
@@ -4180,8 +4177,7 @@ func TestIngester_OpenExistingTSDBOnStartup(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			limits := defaultLimitsTestConfig()
 
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			// Create a temporary directory for TSDB
 			tempDir := t.TempDir()
@@ -5395,8 +5391,7 @@ func TestHeadCompactionOnStartup(t *testing.T) {
 
 	limits := defaultLimitsTestConfig()
 
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(limits, nil)
 
 	ingesterCfg := defaultIngesterTestConfig(t)
 	ingesterCfg.BlocksStorageConfig.TSDB.Dir = tempDir

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/validation"
@@ -221,8 +220,7 @@ func runLimiterMaxFunctionTest(
 			limits := validation.Limits{IngestionTenantShardSize: testData.shardSize}
 			applyLimits(&limits, testData.localLimit, testData.globalLimit)
 
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			// Assert on default sharding strategy.
 			limiter := NewLimiter(overrides, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, testData.ringZoneAwarenessEnabled, "")
@@ -286,11 +284,10 @@ func TestLimiter_AssertMaxSeriesPerMetric(t *testing.T) {
 			ring.On("ZonesCount").Return(1)
 
 			// Mock limits
-			limits, err := validation.NewOverrides(validation.Limits{
+			limits := validation.NewOverrides(validation.Limits{
 				MaxLocalSeriesPerMetric:  testData.maxLocalSeriesPerMetric,
 				MaxGlobalSeriesPerMetric: testData.maxGlobalSeriesPerMetric,
 			}, nil)
-			require.NoError(t, err)
 
 			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
 			actual := limiter.AssertMaxSeriesPerMetric("test", testData.series)
@@ -348,11 +345,10 @@ func TestLimiter_AssertMaxMetadataPerMetric(t *testing.T) {
 			ring.On("ZonesCount").Return(1)
 
 			// Mock limits
-			limits, err := validation.NewOverrides(validation.Limits{
+			limits := validation.NewOverrides(validation.Limits{
 				MaxLocalMetadataPerMetric:  testData.maxLocalMetadataPerMetric,
 				MaxGlobalMetadataPerMetric: testData.maxGlobalMetadataPerMetric,
 			}, nil)
-			require.NoError(t, err)
 
 			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
 			actual := limiter.AssertMaxMetadataPerMetric("test", testData.metadata)
@@ -411,11 +407,10 @@ func TestLimiter_AssertMaxSeriesPerUser(t *testing.T) {
 			ring.On("ZonesCount").Return(1)
 
 			// Mock limits
-			limits, err := validation.NewOverrides(validation.Limits{
+			limits := validation.NewOverrides(validation.Limits{
 				MaxLocalSeriesPerUser:  testData.maxLocalSeriesPerUser,
 				MaxGlobalSeriesPerUser: testData.maxGlobalSeriesPerUser,
 			}, nil)
-			require.NoError(t, err)
 
 			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
 			actual := limiter.AssertMaxSeriesPerUser("test", testData.series)
@@ -496,8 +491,7 @@ func TestLimiter_AssertMaxSeriesPerLabelSet(t *testing.T) {
 			ring.On("ZonesCount").Return(1)
 
 			// Mock limits
-			limits, err := validation.NewOverrides(testData.limits, nil)
-			require.NoError(t, err)
+			limits := validation.NewOverrides(testData.limits, nil)
 
 			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
 			actual := limiter.AssertMaxSeriesPerLabelSet("test", labels.FromStrings("foo", "bar"), func(limits []validation.LimitsPerLabelSet, limit validation.LimitsPerLabelSet) (int, error) {
@@ -558,11 +552,10 @@ func TestLimiter_AssertMaxMetricsWithMetadataPerUser(t *testing.T) {
 			ring.On("ZonesCount").Return(1)
 
 			// Mock limits
-			limits, err := validation.NewOverrides(validation.Limits{
+			limits := validation.NewOverrides(validation.Limits{
 				MaxLocalMetricsWithMetadataPerUser:  testData.maxLocalMetadataPerUser,
 				MaxGlobalMetricsWithMetadataPerUser: testData.maxGlobalMetadataPerUser,
 			}, nil)
-			require.NoError(t, err)
 
 			limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, testData.shardByAllLabels, testData.ringReplicationFactor, false, "")
 			actual := limiter.AssertMaxMetricsWithMetadataPerUser("test", testData.metadata)
@@ -579,13 +572,12 @@ func TestLimiter_FormatError(t *testing.T) {
 	ring.On("ZonesCount").Return(1)
 
 	// Mock limits
-	limits, err := validation.NewOverrides(validation.Limits{
+	limits := validation.NewOverrides(validation.Limits{
 		MaxGlobalSeriesPerUser:              100,
 		MaxGlobalSeriesPerMetric:            20,
 		MaxGlobalMetricsWithMetadataPerUser: 10,
 		MaxGlobalMetadataPerMetric:          3,
 	}, nil)
-	require.NoError(t, err)
 
 	limiter := NewLimiter(limits, ring, util.ShardingStrategyDefault, true, 3, false, "please contact administrator to raise it")
 	lbls := labels.FromStrings(labels.MetricName, "testMetric")

--- a/pkg/ingester/user_metrics_metadata_test.go
+++ b/pkg/ingester/user_metrics_metadata_test.go
@@ -34,8 +34,7 @@ func Test_UserMetricsMetadata(t *testing.T) {
 		false)
 
 	limits := validation.Limits{}
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(limits, nil)
 	limiter := NewLimiter(overrides, nil, util.ShardingStrategyDefault, true, 1, false, "")
 
 	tests := []struct {

--- a/pkg/ingester/user_state_test.go
+++ b/pkg/ingester/user_state_test.go
@@ -79,8 +79,7 @@ func TestMetricCounter(t *testing.T) {
 
 			limits := validation.Limits{MaxLocalSeriesPerMetric: tc.localLimit}
 
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			// We're testing code that's not dependent on sharding strategy, replication factor, etc. To simplify the test,
 			// we use local limit only.

--- a/pkg/parquetconverter/converter_test.go
+++ b/pkg/parquetconverter/converter_test.go
@@ -174,8 +174,7 @@ func prepare(t *testing.T, cfg Config, bucketClient objstore.InstrumentedBucket,
 		flagext.DefaultValues(limits)
 	}
 
-	overrides, err := validation.NewOverrides(*limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(*limits, nil)
 
 	scanner, err := users.NewScanner(cortex_tsdb.UsersScannerConfig{
 		Strategy: cortex_tsdb.UserScanStrategyList,
@@ -242,8 +241,7 @@ func TestConverter_BlockConversionFailure(t *testing.T) {
 	flagext.DefaultValues(&storageCfg)
 	limits := &validation.Limits{}
 	flagext.DefaultValues(limits)
-	overrides, err := validation.NewOverrides(*limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(*limits, nil)
 	limits.ParquetConverterEnabled = true
 
 	// Create a filesystem bucket for initial block upload

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -97,8 +97,7 @@ func TestDistributorQuerier_SelectShouldHonorQueryIngestersWithin(t *testing.T) 
 				require.NoError(t, err)
 
 				limits := DefaultLimitsConfig()
-				overrides, err := validation.NewOverrides(limits, nil)
-				require.NoError(t, err)
+				overrides := validation.NewOverrides(limits, nil)
 
 				start, end, err := validateQueryTimeRange(ctx, "test", testData.queryMinT, testData.queryMaxT, overrides, 0)
 				require.NoError(t, err)

--- a/pkg/querier/parquet_queryable_test.go
+++ b/pkg/querier/parquet_queryable_test.go
@@ -414,8 +414,7 @@ func defaultOverrides(t *testing.T, queryVerticalShardSize int) *validation.Over
 	flagext.DefaultValues(&limits)
 	limits.QueryVerticalShardSize = queryVerticalShardSize
 
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(limits, nil)
 	return overrides
 }
 

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -265,9 +265,8 @@ func TestShouldSortSeriesIfQueryingMultipleQueryables(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), "0")
 	var cfg Config
 	flagext.DefaultValues(&cfg)
-	overrides, err := validation.NewOverrides(DefaultLimitsConfig(), nil)
+	overrides := validation.NewOverrides(DefaultLimitsConfig(), nil)
 	const chunks = 1
-	require.NoError(t, err)
 	distributor := &MockDistributor{}
 
 	for _, enc := range encodings {
@@ -522,8 +521,7 @@ func TestLimits(t *testing.T) {
 				for _, queryable := range tc.storeQueriables {
 					wQueriables = append(wQueriables, &wrappedSampleAndChunkQueryable{QueryableWithFilter: queryable})
 				}
-				overrides, err := validation.NewOverrides(DefaultLimitsConfig(), tc.tenantLimit)
-				require.NoError(t, err)
+				overrides := validation.NewOverrides(DefaultLimitsConfig(), tc.tenantLimit)
 
 				queryable := NewQueryable(wDistributorQueriable, wQueriables, cfg, overrides)
 				opts := promql.EngineOpts{
@@ -578,8 +576,7 @@ func TestQuerier(t *testing.T) {
 					chunkStore, through := makeMockChunkStore(t, chunks, enc)
 					distributor := mockDistibutorFor(t, chunkStore.chunks)
 
-					overrides, err := validation.NewOverrides(DefaultLimitsConfig(), nil)
-					require.NoError(t, err)
+					overrides := validation.NewOverrides(DefaultLimitsConfig(), nil)
 
 					queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}
 					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger(), nil)
@@ -595,8 +592,7 @@ func TestQuerierMetric(t *testing.T) {
 	flagext.DefaultValues(&cfg)
 	cfg.MaxConcurrent = 120
 
-	overrides, err := validation.NewOverrides(DefaultLimitsConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(DefaultLimitsConfig(), nil)
 
 	chunkStore, _ := makeMockChunkStore(t, 24, promchunk.PrometheusXorChunk)
 	distributor := mockDistibutorFor(t, chunkStore.chunks)
@@ -682,8 +678,7 @@ func TestNoHistoricalQueryToIngester(t *testing.T) {
 					chunkStore, _ := makeMockChunkStore(t, 24, encoding)
 					distributor := &errDistributor{}
 
-					overrides, err := validation.NewOverrides(DefaultLimitsConfig(), nil)
-					require.NoError(t, err)
+					overrides := validation.NewOverrides(DefaultLimitsConfig(), nil)
 
 					ctx := user.InjectOrgID(context.Background(), "0")
 					queryable, _, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}, nil, log.NewNopLogger(), nil)
@@ -775,8 +770,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryIntoFuture(t *testing.T) {
 			distributor := &MockDistributor{}
 			distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&client.QueryStreamResponse{}, nil)
 
-			overrides, err := validation.NewOverrides(DefaultLimitsConfig(), nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(DefaultLimitsConfig(), nil)
 
 			ctx := user.InjectOrgID(context.Background(), "0")
 			queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}
@@ -866,8 +860,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 
 			limits := DefaultLimitsConfig()
 			limits.MaxQueryLength = model.Duration(maxQueryLength)
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			chunkStore := &emptyChunkStore{}
 			distributor := &emptyDistributor{}
@@ -905,8 +898,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength_Series(t *testing.T) {
 
 	limits := DefaultLimitsConfig()
 	limits.MaxQueryLength = model.Duration(maxQueryLength)
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(limits, nil)
 
 	chunkStore := &emptyChunkStore{}
 	distributor := &emptyDistributor{}
@@ -964,8 +956,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength_Labels(t *testing.T) {
 
 			limits := DefaultLimitsConfig()
 			limits.MaxQueryLength = model.Duration(maxQueryLength)
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			chunkStore := &emptyChunkStore{}
 			distributor := &emptyDistributor{}
@@ -1109,8 +1100,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 
 				limits := DefaultLimitsConfig()
 				limits.MaxQueryLookback = testData.maxQueryLookback
-				overrides, err := validation.NewOverrides(limits, nil)
-				require.NoError(t, err)
+				overrides := validation.NewOverrides(limits, nil)
 
 				chunkStore := &emptyChunkStore{}
 				queryables := []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}
@@ -1123,7 +1113,6 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 					distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&client.QueryStreamResponse{}, nil)
 
 					queryable, _, _ := New(cfg, overrides, distributor, queryables, nil, log.NewNopLogger(), nil)
-					require.NoError(t, err)
 
 					query, err := queryEngine.NewRangeQuery(ctx, queryable, nil, testData.query, testData.queryStartTime, testData.queryEndTime, time.Minute)
 					require.NoError(t, err)
@@ -1316,8 +1305,7 @@ func TestValidateMaxQueryLength(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			//parallel testing causes data race
 			limits := DefaultLimitsConfig()
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 			startMs, endMs, err := validateQueryTimeRange(ctx, "test", util.TimeToMillis(tc.start), util.TimeToMillis(tc.end), overrides, 0)
 			require.NoError(t, err)
 			startTime := model.Time(startMs)
@@ -1581,8 +1569,7 @@ func TestShortTermQueryToLTS(t *testing.T) {
 			chunkStore := &emptyChunkStore{}
 			distributor := &errDistributor{}
 
-			overrides, err := validation.NewOverrides(DefaultLimitsConfig(), nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(DefaultLimitsConfig(), nil)
 
 			queryable, _, _ := New(cfg, overrides, distributor, []QueryableWithFilter{UseAlwaysQueryable(NewMockStoreQueryable(chunkStore))}, nil, log.NewNopLogger(), nil)
 			ctx := user.InjectOrgID(context.Background(), "0")

--- a/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
@@ -69,8 +69,7 @@ func TestRoundTrip(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	defaultLimits, err := validation.NewOverrides(validation.Limits{}, nil)
-	require.NoError(t, err)
+	defaultLimits := validation.NewOverrides(validation.Limits{}, nil)
 
 	tw := tripperware.NewQueryTripperware(log.NewNopLogger(),
 		nil,

--- a/pkg/querier/tripperware/roundtrip_test.go
+++ b/pkg/querier/tripperware/roundtrip_test.go
@@ -123,12 +123,10 @@ func TestRoundTrip(t *testing.T) {
 		MaxQueryLength: model.Duration(time.Hour * 24 * 60),
 	}
 	flagext.DefaultValues(&limits)
-	defaultOverrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	defaultOverrides := validation.NewOverrides(limits, nil)
 
 	limitsWithVerticalSharding := validation.Limits{QueryVerticalShardSize: 3}
-	shardingOverrides, err := validation.NewOverrides(limitsWithVerticalSharding, nil)
-	require.NoError(t, err)
+	shardingOverrides := validation.NewOverrides(limitsWithVerticalSharding, nil)
 	for _, tc := range []struct {
 		path, expectedBody string
 		expectedErr        error

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -223,7 +223,7 @@ func testQueryableFunc(querierTestConfig *querier.TestConfig, reg prometheus.Reg
 		// disable active query tracking for test
 		querierTestConfig.Cfg.ActiveQueryTrackerDir = ""
 
-		overrides, _ := validation.NewOverrides(querier.DefaultLimitsConfig(), nil)
+		overrides := validation.NewOverrides(querier.DefaultLimitsConfig(), nil)
 		q, _, _ := querier.New(querierTestConfig.Cfg, overrides, querierTestConfig.Distributor, querierTestConfig.Stores, reg, logger, nil)
 		return func(mint, maxt int64) (storage.Querier, error) {
 			return q.Querier(mint, maxt)

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -371,8 +371,7 @@ func TestStoreGateway_InitialSyncWithWaitRingStability(t *testing.T) {
 					gatewayCfg.ShardingStrategy = testData.shardingStrategy
 					limits.StoreGatewayTenantShardSize = testData.tenantShardSize
 
-					overrides, err := validation.NewOverrides(limits, nil)
-					require.NoError(t, err)
+					overrides := validation.NewOverrides(limits, nil)
 
 					reg := prometheus.NewPedanticRegistry()
 					g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, overrides, mockLoggingLevel(), log.NewNopLogger(), reg, nil)
@@ -473,8 +472,7 @@ func TestStoreGateway_BlocksSyncWithDefaultSharding_RingTopologyChangedAfterScal
 		gatewayCfg.ShardingEnabled = true
 		gatewayCfg.ShardingStrategy = shardingStrategy
 
-		overrides, err := validation.NewOverrides(limits, nil)
-		require.NoError(t, err)
+		overrides := validation.NewOverrides(limits, nil)
 
 		reg := prometheus.NewPedanticRegistry()
 		g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, overrides, mockLoggingLevel(), log.NewNopLogger(), reg, nil)
@@ -1071,8 +1069,7 @@ func TestStoreGateway_SeriesQueryingShouldEnforceMaxChunksPerQueryLimit(t *testi
 			// Customise the limits.
 			limits := defaultLimitsConfig()
 			limits.MaxChunksPerQuery = testData.limit
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			// Create a store-gateway used to query back the series from the blocks.
 			gatewayCfg := mockGatewayConfig()
@@ -1160,8 +1157,7 @@ func TestStoreGateway_SeriesQueryingShouldEnforceMaxSeriesPerQueryLimit(t *testi
 			// Customise the limits.
 			limits := defaultLimitsConfig()
 			limits.MaxFetchedSeriesPerQuery = testData.limit
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			// Create a store-gateway used to query back the series from the blocks.
 			gatewayCfg := mockGatewayConfig()
@@ -1221,8 +1217,7 @@ func TestStoreGateway_SeriesThrottledByResourceMonitor(t *testing.T) {
 		},
 	}
 
-	overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsConfig(), nil)
 
 	// Create a store-gateway used to query back the series from the blocks.
 	gatewayCfg := mockGatewayConfig()
@@ -1372,8 +1367,7 @@ func defaultLimitsConfig() validation.Limits {
 }
 
 func defaultLimitsOverrides(t *testing.T) *validation.Overrides {
-	overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsConfig(), nil)
 
 	return overrides
 }

--- a/pkg/util/push/otlp_test.go
+++ b/pkg/util/push/otlp_test.go
@@ -193,8 +193,7 @@ func TestOTLPConvertToPromTS(t *testing.T) {
 			limits := validation.Limits{
 				PromoteResourceAttributes: test.PromoteResourceAttributes,
 			}
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 			tsList, metadata, err := convertToPromTS(ctx, d, test.cfg, overrides, "user-1", logger)
 			require.NoError(t, err)
 
@@ -304,8 +303,7 @@ func BenchmarkOTLPWriteHandler(b *testing.B) {
 		ConvertAllAttributes: false,
 		DisableTargetInfo:    false,
 	}
-	overrides, err := validation.NewOverrides(querier.DefaultLimitsConfig(), nil)
-	require.NoError(b, err)
+	overrides := validation.NewOverrides(querier.DefaultLimitsConfig(), nil)
 
 	exportRequest := generateOTLPWriteRequest()
 	mockPushFunc := func(context.Context, *cortexpb.WriteRequest) (*cortexpb.WriteResponse, error) {
@@ -462,8 +460,7 @@ func TestOTLPWriteHandler(t *testing.T) {
 			require.NoError(t, err)
 
 			push := verifyOTLPWriteRequestHandler(t, cortexpb.API)
-			overrides, err := validation.NewOverrides(querier.DefaultLimitsConfig(), nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(querier.DefaultLimitsConfig(), nil)
 			handler := OTLPHandler(test.maxRecvMsgSize, overrides, cfg, nil, push)
 
 			recorder := httptest.NewRecorder()

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -571,11 +571,11 @@ type Overrides struct {
 }
 
 // NewOverrides makes a new Overrides.
-func NewOverrides(defaults Limits, tenantLimits TenantLimits) (*Overrides, error) {
+func NewOverrides(defaults Limits, tenantLimits TenantLimits) *Overrides {
 	return &Overrides{
 		tenantLimits:  tenantLimits,
 		defaultLimits: &defaults,
-	}, nil
+	}
 }
 
 // IngestionRate returns the limit on ingester rate (samples per second).

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -87,8 +87,7 @@ func TestOverrides_MaxChunksPerQueryFromStore(t *testing.T) {
 	limits := Limits{}
 	flagext.DefaultValues(&limits)
 
-	overrides, err := NewOverrides(limits, nil)
-	require.NoError(t, err)
+	overrides := NewOverrides(limits, nil)
 	assert.Equal(t, 2000000, overrides.MaxChunksPerQueryFromStore("test"))
 }
 
@@ -98,8 +97,7 @@ func TestOverridesManager_GetOverrides(t *testing.T) {
 	defaults := Limits{
 		MaxLabelNamesPerSeries: 100,
 	}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
 
 	require.Equal(t, 100, ov.MaxLabelNamesPerSeries("user1"))
 	require.Equal(t, 0, ov.MaxLabelValueLength("user1"))
@@ -285,8 +283,7 @@ func TestSmallestPositiveIntPerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxQueryParallelism: 0,
 	}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
 
 	for _, tc := range []struct {
 		tenantIDs []string
@@ -317,8 +314,7 @@ func TestSmallestPositiveNonZeroFloat64PerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxQueriersPerTenant: 0,
 	}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
 
 	for _, tc := range []struct {
 		tenantIDs []string
@@ -349,8 +345,7 @@ func TestSmallestPositiveNonZeroDurationPerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxQueryLength: 0,
 	}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
 
 	for _, tc := range []struct {
 		tenantIDs []string
@@ -424,8 +419,7 @@ alertmanager_notification_rate_limit_per_integration:
 			err := yaml.Unmarshal([]byte(tc.inputYAML), &limitsYAML)
 			require.NoError(t, err, "expected to be able to unmarshal from YAML")
 
-			ov, err := NewOverrides(limitsYAML, nil)
-			require.NoError(t, err)
+			ov := NewOverrides(limitsYAML, nil)
 
 			require.Equal(t, tc.expectedRateLimit, ov.NotificationRateLimit("user", "email"))
 			require.Equal(t, tc.expectedBurstSize, ov.NotificationBurstSize("user", "email"))
@@ -566,8 +560,7 @@ testuser:
 
 			tl := newMockTenantLimits(overrides)
 
-			ov, err := NewOverrides(limitsYAML, tl)
-			require.NoError(t, err)
+			ov := NewOverrides(limitsYAML, tl)
 
 			require.Equal(t, tc.expectedRateLimit, ov.NotificationRateLimit("testuser", tc.testedIntegration))
 			require.Equal(t, tc.expectedBurstSize, ov.NotificationBurstSize("testuser", tc.testedIntegration))
@@ -599,8 +592,7 @@ tenant2:
 
 	tl := newMockTenantLimits(overrides)
 
-	ov, err := NewOverrides(l, tl)
-	require.NoError(t, err)
+	ov := NewOverrides(l, tl)
 
 	require.Equal(t, 1, ov.MaxExemplars("tenant1"))
 	require.Equal(t, 3, ov.MaxExemplars("tenant2"))
@@ -631,8 +623,7 @@ tenant2:
 
 	tl := newMockTenantLimits(overrides)
 
-	ov, err := NewOverrides(l, tl)
-	require.NoError(t, err)
+	ov := NewOverrides(l, tl)
 
 	require.Equal(t, 1, ov.MaxDownloadedBytesPerRequest("tenant1"))
 	require.Equal(t, 3, ov.MaxDownloadedBytesPerRequest("tenant2"))
@@ -662,8 +653,7 @@ tenant2:
 
 	tl := newMockTenantLimits(overrides)
 
-	ov, err := NewOverrides(l, tl)
-	require.NoError(t, err)
+	ov := NewOverrides(l, tl)
 
 	require.True(t, ov.QueryPartialData("tenant1"))
 	require.False(t, ov.RulesPartialData("tenant1"))
@@ -820,8 +810,7 @@ func TestEvaluationDelayHigherThanRulerQueryOffset(t *testing.T) {
 	}
 
 	defaults := Limits{}
-	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
 
 	rulerQueryOffset := ov.RulerQueryOffset(tenant)
 	assert.Equal(t, evaluationDelay, rulerQueryOffset)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

The `NewOverrides` always return `nil` err. So, this PR deletes it to remove the unnecessary error handling.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
