### PR TITLE
Add response compression wrapper for query api

### DIFF
--- a/pkg/api/queryapi/query_api.go
+++ b/pkg/api/queryapi/query_api.go
@@ -209,8 +209,8 @@ func (q *QueryAPI) Wrap(f apiFunc) http.HandlerFunc {
 	}
 
 	return httputil.CompressionHandler{
-			Handler: http.HandlerFunc(hf),
-		}.ServeHTTP
+		Handler: http.HandlerFunc(hf),
+	}.ServeHTTP
 }
 
 func (q *QueryAPI) respond(w http.ResponseWriter, req *http.Request, data interface{}, warnings annotations.Annotations, query string) {

--- a/pkg/api/queryapi/query_api.go
+++ b/pkg/api/queryapi/query_api.go
@@ -188,7 +188,7 @@ func (q *QueryAPI) InstantQueryHandler(r *http.Request) (result apiFuncResult) {
 }
 
 func (q *QueryAPI) Wrap(f apiFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+	hf := func(w http.ResponseWriter, r *http.Request) {
 		httputil.SetCORS(w, q.CORSOrigin, r)
 
 		result := f(r)
@@ -207,6 +207,10 @@ func (q *QueryAPI) Wrap(f apiFunc) http.HandlerFunc {
 		}
 		w.WriteHeader(http.StatusNoContent)
 	}
+
+	return httputil.CompressionHandler{
+			Handler: http.HandlerFunc(hf),
+		}.ServeHTTP
 }
 
 func (q *QueryAPI) respond(w http.ResponseWriter, req *http.Request, data interface{}, warnings annotations.Annotations, query string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
The `prometheus/web/api/v1/api.go` handler was originally used for instant and range queries in Cortex. When the handlers for both query types were moved to `pkg/api/queryapi/query_api.go`, we did not include the wrapper for compression #6763.

This is an issue because it can cause query responses to hit the configured `grpc-max-send-msg-size`. It also makes the response compression configuration non-functional.
```
# Use compression for metrics query API or instant and range query APIs.
# Supports 'gzip' and '' (disable compression)
# CLI flag: -querier.response-compression
[response_compression: <string> | default = "gzip"]
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
