### PR TITLE
[Vote] SungJin1212 as new Cortex maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,7 @@
 | Charlie Le         | chtle4@gmail.com      | @CharlieTLe   | Apple               |
 | Daniel Blando      | daniel@blando.com.br  | @danielblando | Amazon Web Services |
 | Friedrich Gonzalez | friedrichg@gmail.com  | @friedrichg   | Apple               |
+| Sungjin Lee        | tjdwls1201@gmail.com  | @SungJin1212  | KakaoEnterprise     |
 
 ### Triagers
 
@@ -14,5 +15,4 @@
 | Name            | Email                      | GitHub          | Company             |
 |-----------------|----------------------------|-----------------|---------------------|
 | Anand Rajagopal | anand.rajagopal@icloud.com | @rajagopalanand | Amazon Web Services |
-| Sungjin Lee     | tjdwls1201@gmail.com       | @SungJin1212    | KakaoEnterprise     |
 | Daniel Sabsay   | danielsabsay.sofware@gmail.com          | @dsabsay        | Adobe               |


### PR DESCRIPTION
I would like to start a vote to add @SungJin1212 as a new maintainer for Cortex.

Sungjin has became a Triager since Nov 2024. He has more than 100 PRs in total to the project and has been the most active contributor overall since he started his contributions.

You can find his contributions here: https://github.com/cortexproject/cortex/issues?q=is%3Apr+is%3Aopen+author%3ASungJin1212

Please cast your yes/no vote as comment in this PR, I will leave the vote open for 14 days (including weekends) or until all maintainer voted; whichever comes first.
