### PR TITLE
Add query limiter support to parquet querier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -325,3 +325,5 @@ replace github.com/thanos-io/objstore => github.com/thanos-io/objstore v0.0.0-20
 
 // v3.3.1 with https://github.com/prometheus/prometheus/pull/16252. (same as thanos)
 replace github.com/prometheus/prometheus => github.com/thanos-io/thanos-prometheus v0.0.0-20250610133519-082594458a88
+
+replace github.com/prometheus-community/parquet-common => github.com/yeya24/parquet-common v0.0.0-20250709074935-71782c65c3d4

--- a/go.sum
+++ b/go.sum
@@ -778,7 +778,7 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opentracing-contrib/go-grpc v0.1.2 h1:MP16Ozc59kqqwn1v18aQxpeGZhsBanJ2iurZYaQSZ+g=
 github.com/opentracing-contrib/go-grpc v0.1.2/go.mod h1:glU6rl1Fhfp9aXUHkE36K2mR4ht8vih0ekOVlWKEUHM=
-github.com/opentracing-contrib/go-stdlib v1.1.0 h1:cZBWc4pA4e65tqTJddbflK435S0tDImj6c9BMvkdUH0=
+github.com/opentracing-contrib/go-stdlib v1.1.0 h1:hSJ8yYaiAO/k2YZUeWJWpQCPE2wRCDtxRnir0gU6wbA=
 github.com/opentracing-contrib/go-stdlib v1.1.0/go.mod h1:S0p+X9p6dcBkoMTL+Qq2VOvxKs9ys5PpYWXWqlCS0bQ=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
@@ -814,8 +814,6 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/prometheus-community/parquet-common v0.0.0-20250708210438-f89902fcd994 h1:xHR2Xex5XWYl5rQKObX8sVqykPXzlL0Rytd9mKo0sss=
-github.com/prometheus-community/parquet-common v0.0.0-20250708210438-f89902fcd994/go.mod h1:zJNGzMKctJoOESjRVaNTlPis3C9VcY3cRzNxj6ll3Is=
 github.com/prometheus-community/prom-label-proxy v0.11.1 h1:jX+m+BQCNM0z3/P6V6jVxbiDKgugvk91SaICD6bVhT4=
 github.com/prometheus-community/prom-label-proxy v0.11.1/go.mod h1:uTeQW+wZ/VPV1LL3IPfvUE++wR2nPLex+Y4RE38Cpis=
 github.com/prometheus/alertmanager v0.28.1 h1:BK5pCoAtaKg01BYRUJhEDV1tqJMEtYBGzPw8QdvnnvA=
@@ -955,6 +953,8 @@ github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
+github.com/yeya24/parquet-common v0.0.0-20250709074935-71782c65c3d4 h1:hvkx/1uPrrYN3sNhA1rdU4ri0Z7L31838nvLu2NVtD0=
+github.com/yeya24/parquet-common v0.0.0-20250709074935-71782c65c3d4/go.mod h1:zJNGzMKctJoOESjRVaNTlPis3C9VcY3cRzNxj6ll3Is=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/querier/error_translate_queryable.go
+++ b/pkg/querier/error_translate_queryable.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gogo/status"
 	"github.com/pkg/errors"
+	"github.com/prometheus-community/parquet-common/search"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
@@ -46,6 +47,11 @@ func TranslateToPromqlAPIError(err error) error {
 	default:
 		if errors.Is(err, context.Canceled) {
 			return err // 422
+		}
+
+		if search.IsResourceExhausted(err) {
+			cause := errors.Cause(err)
+			return cause // 422
 		}
 
 		s, ok := status.FromError(err)

--- a/vendor/github.com/prometheus-community/parquet-common/search/limits.go
+++ b/vendor/github.com/prometheus-community/parquet-common/search/limits.go
@@ -1,0 +1,76 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// This package is a modified copy from
+// https://github.com/thanos-io/thanos-parquet-gateway/blob/cfc1279f605d1c629c4afe8b1e2a340e8b15ecdc/internal/limits/limit.go.
+
+package search
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+type resourceExhausted struct {
+	used int64
+}
+
+func (re *resourceExhausted) Error() string {
+	return fmt.Sprintf("resource exhausted (used %d)", re.used)
+}
+
+func IsResourceExhausted(err error) bool {
+	var re *resourceExhausted
+	return errors.As(err, &re)
+}
+
+type Quota struct {
+	mu sync.Mutex
+	q  int64
+	u  int64
+}
+
+func NewQuota(n int64) *Quota {
+	return &Quota{q: n, u: n}
+}
+
+func UnlimitedQuota() *Quota {
+	return NewQuota(0)
+}
+
+func (q *Quota) Reserve(n int64) error {
+	if q.q == 0 {
+		return nil
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.u-n < 0 {
+		return &resourceExhausted{used: q.q}
+	}
+	q.u -= n
+	return nil
+}
+
+type QuotaLimitFunc func(ctx context.Context) int64
+
+func NoopQuotaLimitFunc(ctx context.Context) int64 {
+	return 0
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -947,7 +947,7 @@ github.com/planetscale/vtprotobuf/types/known/wrapperspb
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/prometheus-community/parquet-common v0.0.0-20250708210438-f89902fcd994
+# github.com/prometheus-community/parquet-common v0.0.0-20250708210438-f89902fcd994 => github.com/yeya24/parquet-common v0.0.0-20250709074935-71782c65c3d4
 ## explicit; go 1.23.4
 github.com/prometheus-community/parquet-common/convert
 github.com/prometheus-community/parquet-common/queryable
@@ -1988,3 +1988,4 @@ sigs.k8s.io/yaml/goyaml.v3
 # gopkg.in/alecthomas/kingpin.v2 => github.com/alecthomas/kingpin v1.3.8-0.20210301060133-17f40c25f497
 # github.com/thanos-io/objstore => github.com/thanos-io/objstore v0.0.0-20241111205755-d1dd89d41f97
 # github.com/prometheus/prometheus => github.com/thanos-io/thanos-prometheus v0.0.0-20250610133519-082594458a88
+# github.com/prometheus-community/parquet-common => github.com/yeya24/parquet-common v0.0.0-20250709074935-71782c65c3d4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR adds query limiter support to parquet querier. Supported limits are:
- Series count using existing query limiter which tracks unique series
- Chunk count using existing query limiter
- Chunk bytes using existing query limiter
- Data bytes using existing query limiter

Additionally there are parquet querier specific limits:
- Number of matched rows in Parquet before materializing any chunks so this might include series that doesn't actually have chunks in the time range. We use max fetched series count limit for now.
- Total size of fetched Chunk column pages. We use max fetched chunk bytes limit for now
- Total size of fetched Label column pages + Chunk column pages. We use max fetched data bytes limit for now


Note that this PR is in draft and the upstream PR for parquet common is still in progress. https://github.com/prometheus-community/parquet-common/pull/81. Also more tests are needed

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
