### PR TITLE
Fix flaky TestBasicLifecycler_HeartbeatWhileStopping

### DIFF
--- a/pkg/ring/basic_lifecycler_test.go
+++ b/pkg/ring/basic_lifecycler_test.go
@@ -244,7 +244,7 @@ func TestBasicLifecycler_HeartbeatWhileRunning(t *testing.T) {
 	desc, _ := getInstanceFromStore(t, store, testInstanceID)
 	initialTimestamp := desc.GetTimestamp()
 
-	test.Poll(t, time.Second, true, func() interface{} {
+	test.Poll(t, time.Second*5, true, func() interface{} {
 		desc, _ := getInstanceFromStore(t, store, testInstanceID)
 		currTimestamp := desc.GetTimestamp()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR fixes a flaky test `TestBasicLifecycler_HeartbeatWhileStopping`.
The reason is that since timestamps are Unix seconds, `currTimestamp` might not accurately reflect the time.
In other words, one second is insufficient to accurately reflect the heartbeat time to `currTimestamp`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
