### PR TITLE
docs: Add warning for inmemory ha-tracker to clarify its usage

### DIFF
--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -122,6 +122,8 @@ The KVStore client is used by both the Ring and HA Tracker (HA Tracker doesn't s
    The prefix for the keys in the store. Should end with a /. For example with a prefix of foo/, the key bar would be stored under foo/bar.
 - `{ring,distributor.ha-tracker}.store`
    Backend storage to use for the HA Tracker (consul, etcd, inmemory, multi).
+
+   **Warning:** The `inmemory` store will not work correctly with multiple distributors as each distributor can have a different state, causing injestion errors.
 - `{ring,distributor.ring}.store`
    Backend storage to use for the Ring (consul, etcd, inmemory, memberlist, multi).
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
The `inmemory` store will not work correctly with multiple distributors as each distributor can have a different state, causing injestion errors. The PR adds a warning to the docs to clarify this.


**Which issue(s) this PR fixes**:
Fixes #5145 

**Checklist**
- [NA] Tests updated
- [x] Documentation added
- [NA] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
