### PR TITLE
New metric for ingester errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [ENHANCEMENT] Distributor: Add native histograms max sample size bytes limit validation. #6834
 * [ENHANCEMENT] Querier: Support caching parquet labels file in parquet queryable. #6835
 * [ENHANCEMENT] Querier: Support query limits in parquet queryable. #6870
+* [ENHANCEMENT] Ingester: Add new metric `cortex_ingester_push_errors_total` to track reasons for ingester request failures. #6901
 * [BUGFIX] Ingester: Avoid error or early throttling when READONLY ingesters are present in the ring #6517
 * [BUGFIX] Ingester: Fix labelset data race condition. #6573
 * [BUGFIX] Compactor: Cleaner should not put deletion marker for blocks with no-compact marker. #6576

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6557,7 +6557,7 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 		require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 		# HELP cortex_ingester_push_errors_total The total number of push errors per user.
 		# TYPE cortex_ingester_push_errors_total counter
-		cortex_ingester_push_errors_total{reason="errTooManyInflightRequests",user="test"} 1
+		cortex_ingester_push_errors_total{reason="tooManyInflightRequests",user="test"} 1
 	`), "cortex_ingester_push_errors_total"))
 		return nil
 	})

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -13,6 +13,8 @@ var (
 	errMaxSeriesLimitReached          = errors.New("cannot add series: ingesters's max series limit reached")
 	errTooManyInflightPushRequests    = errors.New("cannot push: too many inflight push requests in ingester")
 	errTooManyInflightQueryRequests   = errors.New("cannot push: too many inflight query requests in ingester")
+
+	pushErrTooManyInflightRequests = "errTooManyInflightRequests"
 )
 
 // InstanceLimits describes limits used by ingester. Reaching any of these will result in error response to the call.

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -14,7 +14,7 @@ var (
 	errTooManyInflightPushRequests    = errors.New("cannot push: too many inflight push requests in ingester")
 	errTooManyInflightQueryRequests   = errors.New("cannot push: too many inflight query requests in ingester")
 
-	pushErrTooManyInflightRequests = "errTooManyInflightRequests"
+	pushErrTooManyInflightRequests = "tooManyInflightRequests"
 )
 
 // InstanceLimits describes limits used by ingester. Reaching any of these will result in error response to the call.

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -44,6 +44,7 @@ type ingesterMetrics struct {
 	memMetadataCreatedTotal *prometheus.CounterVec
 	memSeriesRemovedTotal   *prometheus.CounterVec
 	memMetadataRemovedTotal *prometheus.CounterVec
+	pushErrorsTotal         *prometheus.CounterVec
 
 	activeSeriesPerUser   *prometheus.GaugeVec
 	activeNHSeriesPerUser *prometheus.GaugeVec
@@ -165,6 +166,10 @@ func newIngesterMetrics(r prometheus.Registerer,
 			Name: "cortex_ingester_memory_metadata_removed_total",
 			Help: "The total number of metadata that were removed per user.",
 		}, []string{"user"}),
+		pushErrorsTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_ingester_push_errors_total",
+			Help: "The total number of push errors per user.",
+		}, []string{"user", "reason"}),
 
 		maxUsersGauge: promauto.With(r).NewGaugeFunc(prometheus.GaugeOpts{
 			Name:        instanceLimits,
@@ -295,6 +300,7 @@ func (m *ingesterMetrics) deletePerUserMetrics(userID string) {
 	m.activeNHSeriesPerUser.DeleteLabelValues(userID)
 	m.usagePerLabelSet.DeletePartialMatch(prometheus.Labels{"user": userID})
 	m.limitsPerLabelSet.DeletePartialMatch(prometheus.Labels{"user": userID})
+	m.pushErrorsTotal.DeletePartialMatch(prometheus.Labels{"user": userID})
 
 	if m.memSeriesCreatedTotal != nil {
 		m.memSeriesCreatedTotal.DeleteLabelValues(userID)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Introduce a new metric with reason from when ingester returns an error. Currently this will be useful for throttling customer on tooManyInflightRequests. We can expand for more error reasons as needed

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
