### PR TITLE
Extend histogram bucket for parquet block convertion delay metric

### DIFF
--- a/pkg/parquetconverter/metrics.go
+++ b/pkg/parquetconverter/metrics.go
@@ -30,7 +30,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		convertParquetBlockDelay: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_parquet_converter_convert_block_delay_minutes",
 			Help:    "Delay in minutes of Parquet block to be converted from the TSDB block being uploaded to object store",
-			Buckets: []float64{5, 10, 15, 20, 30, 45, 60, 80, 100, 120},
+			Buckets: []float64{5, 10, 15, 20, 30, 45, 60, 80, 100, 120, 150, 180, 210, 240, 270, 300},
 		}),
 		ownedUsers: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_parquet_converter_users_owned",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

120 minutes upper bound seems too small for cortex_parquet_converter_convert_block_delay_minutes metric. Increasing upper bound to 300 minutes

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
