### PR TITLE
QFE: Add active query tracker to query frontend

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4506,6 +4506,17 @@ The `query_frontend_config` configures the Cortex query-frontend.
 # CLI flag: -frontend.enabled-ruler-query-stats
 [enabled_ruler_query_stats_log: <boolean> | default = false]
 
+# Active query tracker monitors active queries, and writes them to the file in
+# given directory. If Cortex discovers any queries in this log during startup,
+# it will log them to the log file. Setting to empty value disables active query
+# tracker, which also disables -frontend.max-concurrent option.
+# CLI flag: -frontend.active-query-tracker-dir
+[active_query_tracker_dir: <string> | default = ""]
+
+# The maximum number of concurrent queries running in query frontend.
+# CLI flag: -frontend.max-concurrent
+[max_concurrent: <int> | default = 500]
+
 # If a querier disconnects without sending notification about graceful shutdown,
 # the query-frontend will keep the querier in the tenant's shard until the
 # forget delay has passed. This feature is useful to reduce the blast radius


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Add active query tracker to query frontend with `-frontend.active-query-tracker-dir` configuration. The tracker logs during startup any previous inflight queries in the case of sudden crash.

This also introduces `-frontend.max-concurrent` configuration for max concurrency in query frontend.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
