### PR TITLE
Add tsdb metrics to track unknown series references during wal/wbl re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [FEATURE] Querier: Allow choosing PromQL engine via header. #6777
 * [FEATURE] Querier: Support for configuring query optimizers and enabling XFunctions in the Thanos engine. #6873
 * [FEATURE] Query Frontend: Add support /api/v1/format_query API for formatting queries. #6893
+* [ENHANCEMENT] Ingester: Add `cortex_ingester_tsdb_wal_replay_unknown_refs_total` and `cortex_ingester_tsdb_wbl_replay_unknown_refs_total` metrics to track unknown series references during wal/wbl replaying. #6945
 * [ENHANCEMENT] Ruler: Emit an error message when the rule synchronization fails. #6902
 * [ENHANCEMENT] Querier: Support snappy and zstd response compression for `-querier.response-compression` flag. #6848
 * [ENHANCEMENT] Tenant Federation: Add a # of query result limit logic when the `-tenant-federation.regex-matcher-enabled` is enabled. #6845

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -240,6 +240,18 @@ func TestTSDBMetrics(t *testing.T) {
 			# TYPE cortex_ingester_tsdb_wal_corruptions_total counter
 			cortex_ingester_tsdb_wal_corruptions_total 2.676537e+06
 
+			# HELP cortex_ingester_tsdb_wal_replay_unknown_refs_total Total number of unknown series references encountered during TSDB WAL replay.
+			# TYPE cortex_ingester_tsdb_wal_replay_unknown_refs_total counter
+			cortex_ingester_tsdb_wal_replay_unknown_refs_total{type="series"} 300
+			cortex_ingester_tsdb_wal_replay_unknown_refs_total{type="samples"} 303
+			cortex_ingester_tsdb_wal_replay_unknown_refs_total{type="metadata"} 306
+
+			# HELP cortex_ingester_tsdb_wbl_replay_unknown_refs_total Total number of unknown series references encountered during TSDB WBL replay.
+			# TYPE cortex_ingester_tsdb_wbl_replay_unknown_refs_total counter
+			cortex_ingester_tsdb_wbl_replay_unknown_refs_total{type="exemplars"} 300
+			cortex_ingester_tsdb_wbl_replay_unknown_refs_total{type="histograms"} 303
+			cortex_ingester_tsdb_wbl_replay_unknown_refs_total{type="tombstones"} 306
+
 			# HELP cortex_ingester_tsdb_wal_writes_failed_total Total number of TSDB WAL writes that failed.
 			# TYPE cortex_ingester_tsdb_wal_writes_failed_total counter
 			cortex_ingester_tsdb_wal_writes_failed_total 1486965
@@ -504,6 +516,18 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 			# HELP cortex_ingester_tsdb_wal_corruptions_total Total number of TSDB WAL corruptions.
 			# TYPE cortex_ingester_tsdb_wal_corruptions_total counter
 			cortex_ingester_tsdb_wal_corruptions_total 2.676537e+06
+
+			# HELP cortex_ingester_tsdb_wal_replay_unknown_refs_total Total number of unknown series references encountered during TSDB WAL replay.
+			# TYPE cortex_ingester_tsdb_wal_replay_unknown_refs_total counter
+			cortex_ingester_tsdb_wal_replay_unknown_refs_total{type="series"} 300
+			cortex_ingester_tsdb_wal_replay_unknown_refs_total{type="samples"} 303
+			cortex_ingester_tsdb_wal_replay_unknown_refs_total{type="metadata"} 306
+
+			# HELP cortex_ingester_tsdb_wbl_replay_unknown_refs_total Total number of unknown series references encountered during TSDB WBL replay.
+			# TYPE cortex_ingester_tsdb_wbl_replay_unknown_refs_total counter
+			cortex_ingester_tsdb_wbl_replay_unknown_refs_total{type="exemplars"} 300
+			cortex_ingester_tsdb_wbl_replay_unknown_refs_total{type="histograms"} 303
+			cortex_ingester_tsdb_wbl_replay_unknown_refs_total{type="tombstones"} 306
 
 			# HELP cortex_ingester_tsdb_wal_writes_failed_total Total number of TSDB WAL writes that failed.
 			# TYPE cortex_ingester_tsdb_wal_writes_failed_total counter
@@ -882,6 +906,22 @@ func populateTSDBMetrics(base float64) *prometheus.Registry {
 		Help: "Total number snapshot replays that failed.",
 	})
 	snapshotReplayErrorTotal.Add(103)
+
+	walReplayUnknownRefsTotal := promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_wal_replay_unknown_refs_total",
+		Help: "Total number of unknown series references encountered during WAL replay.",
+	}, []string{"type"})
+	walReplayUnknownRefsTotal.WithLabelValues(typeSeries).Add(100)
+	walReplayUnknownRefsTotal.WithLabelValues(typeSamples).Add(101)
+	walReplayUnknownRefsTotal.WithLabelValues(typeMetadata).Add(102)
+
+	wblReplayUnknownRefsTotal := promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_wbl_replay_unknown_refs_total",
+		Help: "Total number of unknown series references encountered during WBL replay.",
+	}, []string{"type"})
+	wblReplayUnknownRefsTotal.WithLabelValues(typeExemplars).Add(100)
+	wblReplayUnknownRefsTotal.WithLabelValues(typeHistograms).Add(101)
+	wblReplayUnknownRefsTotal.WithLabelValues(typeTombstones).Add(102)
 
 	oooHistogram := promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 		Name: "prometheus_tsdb_sample_ooo_delta",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR adds tsdb metrics `cortex_ingester_tsdb_wal_replay_unknown_refs_total` and `cortex_ingester_tsdb_wbl_replay_unknown_refs_total` as per-user metrics to track unknown series references during wal/wbl replaying.

The Prometheus PR: https://github.com/prometheus/prometheus/pull/16166

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
