### PR TITLE
Extend block finder get blocks interface with matchers

### DIFF
--- a/pkg/querier/blocks_finder_bucket_index.go
+++ b/pkg/querier/blocks_finder_bucket_index.go
@@ -8,6 +8,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/thanos-io/objstore"
 
 	"github.com/cortexproject/cortex/pkg/util/validation"
@@ -49,7 +50,7 @@ func NewBucketIndexBlocksFinder(cfg BucketIndexBlocksFinderConfig, bkt objstore.
 }
 
 // GetBlocks implements BlocksFinder.
-func (f *BucketIndexBlocksFinder) GetBlocks(ctx context.Context, userID string, minT, maxT int64) (bucketindex.Blocks, map[ulid.ULID]*bucketindex.BlockDeletionMark, error) {
+func (f *BucketIndexBlocksFinder) GetBlocks(ctx context.Context, userID string, minT, maxT int64, _ []*labels.Matcher) (bucketindex.Blocks, map[ulid.ULID]*bucketindex.BlockDeletionMark, error) {
 	if f.State() != services.Running {
 		return nil, nil, errBucketIndexBlocksFinderNotRunning
 	}

--- a/pkg/querier/blocks_finder_bucket_scan.go
+++ b/pkg/querier/blocks_finder_bucket_scan.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/model/labels"
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/thanos/pkg/block"
@@ -111,7 +112,7 @@ func NewBucketScanBlocksFinder(cfg BucketScanBlocksFinderConfig, usersScanner us
 
 // GetBlocks returns known blocks for userID containing samples within the range minT
 // and maxT (milliseconds, both included). Returned blocks are sorted by MaxTime descending.
-func (d *BucketScanBlocksFinder) GetBlocks(_ context.Context, userID string, minT, maxT int64) (bucketindex.Blocks, map[ulid.ULID]*bucketindex.BlockDeletionMark, error) {
+func (d *BucketScanBlocksFinder) GetBlocks(_ context.Context, userID string, minT, maxT int64, _ []*labels.Matcher) (bucketindex.Blocks, map[ulid.ULID]*bucketindex.BlockDeletionMark, error) {
 	// We need to ensure the initial full bucket scan succeeded.
 	if d.State() != services.Running {
 		return nil, nil, errBucketScanBlocksFinderNotRunning

--- a/pkg/querier/blocks_finder_bucket_scan_test.go
+++ b/pkg/querier/blocks_finder_bucket_scan_test.go
@@ -39,7 +39,7 @@ func TestBucketScanBlocksFinder_InitialScan(t *testing.T) {
 
 	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
-	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30)
+	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(blocks))
 	assert.Equal(t, user1Block2.ULID, blocks[0].ID)
@@ -48,7 +48,7 @@ func TestBucketScanBlocksFinder_InitialScan(t *testing.T) {
 	assert.WithinDuration(t, time.Now(), blocks[1].GetUploadedAt(), 5*time.Second)
 	assert.Empty(t, deletionMarks)
 
-	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-2", 0, 30)
+	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-2", 0, 30, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(blocks))
 	assert.Equal(t, user2Block1.ULID, blocks[0].ID)
@@ -110,7 +110,7 @@ func TestBucketScanBlocksFinder_InitialScanFailure(t *testing.T) {
 	require.NoError(t, s.StartAsync(ctx))
 	require.Error(t, s.AwaitRunning(ctx))
 
-	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30)
+	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30, nil)
 	assert.Equal(t, errBucketScanBlocksFinderNotRunning, err)
 	assert.Nil(t, blocks)
 	assert.Nil(t, deletionMarks)
@@ -233,7 +233,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsNewUser(t *testing.T) {
 
 	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
-	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30)
+	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(blocks))
 	assert.Empty(t, deletionMarks)
@@ -245,7 +245,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsNewUser(t *testing.T) {
 	// Trigger a periodic sync
 	require.NoError(t, s.scan(ctx))
 
-	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 30)
+	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 30, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(blocks))
 	assert.Equal(t, block2.ULID, blocks[0].ID)
@@ -266,7 +266,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsNewBlock(t *testing.T) {
 
 	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
-	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30)
+	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(blocks))
 	assert.Equal(t, block1.ULID, blocks[0].ID)
@@ -278,7 +278,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsNewBlock(t *testing.T) {
 	// Trigger a periodic sync
 	require.NoError(t, s.scan(ctx))
 
-	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 30)
+	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 30, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(blocks))
 	assert.Equal(t, block2.ULID, blocks[0].ID)
@@ -298,7 +298,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsBlockMarkedForDeletion(t *testi
 
 	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
-	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30)
+	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(blocks))
 	assert.Equal(t, block2.ULID, blocks[0].ID)
@@ -310,7 +310,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsBlockMarkedForDeletion(t *testi
 	// Trigger a periodic sync
 	require.NoError(t, s.scan(ctx))
 
-	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 30)
+	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 30, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(blocks))
 	assert.Equal(t, block2.ULID, blocks[0].ID)
@@ -330,7 +330,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsDeletedBlock(t *testing.T) {
 
 	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
-	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30)
+	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(blocks))
 	assert.Equal(t, block2.ULID, blocks[0].ID)
@@ -342,7 +342,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsDeletedBlock(t *testing.T) {
 	// Trigger a periodic sync
 	require.NoError(t, s.scan(ctx))
 
-	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 30)
+	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 30, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(blocks))
 	assert.Equal(t, block2.ULID, blocks[0].ID)
@@ -359,7 +359,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsDeletedUser(t *testing.T) {
 
 	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
-	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30)
+	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(blocks))
 	assert.Equal(t, block2.ULID, blocks[0].ID)
@@ -371,7 +371,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsDeletedUser(t *testing.T) {
 	// Trigger a periodic sync
 	require.NoError(t, s.scan(ctx))
 
-	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 30)
+	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 30, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(blocks))
 	assert.Empty(t, deletionMarks)
@@ -387,7 +387,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsUserWhichWasPreviouslyDeleted(t
 
 	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
-	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 40)
+	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 40, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(blocks))
 	assert.Equal(t, block2.ULID, blocks[0].ID)
@@ -399,7 +399,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsUserWhichWasPreviouslyDeleted(t
 	// Trigger a periodic sync
 	require.NoError(t, s.scan(ctx))
 
-	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 40)
+	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 40, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(blocks))
 	assert.Empty(t, deletionMarks)
@@ -409,7 +409,7 @@ func TestBucketScanBlocksFinder_PeriodicScanFindsUserWhichWasPreviouslyDeleted(t
 	// Trigger a periodic sync
 	require.NoError(t, s.scan(ctx))
 
-	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 40)
+	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-1", 0, 40, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(blocks))
 	assert.Equal(t, block3.ULID, blocks[0].ID)
@@ -506,7 +506,7 @@ func TestBucketScanBlocksFinder_GetBlocks(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			metas, deletionMarks, err := s.GetBlocks(ctx, "user-1", testData.minT, testData.maxT)
+			metas, deletionMarks, err := s.GetBlocks(ctx, "user-1", testData.minT, testData.maxT, nil)
 			require.NoError(t, err)
 			require.Equal(t, len(testData.expectedMetas), len(metas))
 			require.Equal(t, testData.expectedMarks, deletionMarks)

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -1568,7 +1568,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
 			stores := &blocksStoreSetMock{mockedResponses: testData.storeSetResponses}
 			finder := &blocksFinderMock{}
-			finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(testData.finderResult, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), testData.finderErr)
+			finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT, mock.Anything).Return(testData.finderResult, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), testData.finderErr)
 
 			q := &blocksStoreQuerier{
 				minT:        minT,
@@ -1664,7 +1664,7 @@ func TestOverrideBlockDiscovery(t *testing.T) {
 	}
 	finder := &blocksFinderMock{}
 	// return block 1 and 2 on finder but only query block 1
-	finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(bucketindex.Blocks{
+	finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT, mock.Anything).Return(bucketindex.Blocks{
 		&bucketindex.Block{ID: block1},
 		&bucketindex.Block{ID: block2},
 	}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)
@@ -2213,7 +2213,7 @@ func TestBlocksStoreQuerier_Labels(t *testing.T) {
 				reg := prometheus.NewPedanticRegistry()
 				stores := &blocksStoreSetMock{mockedResponses: testData.storeSetResponses}
 				finder := &blocksFinderMock{}
-				finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(testData.finderResult, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), testData.finderErr)
+				finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT, mock.Anything).Return(testData.finderResult, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), testData.finderErr)
 
 				q := &blocksStoreQuerier{
 					minT:        minT,
@@ -2321,7 +2321,7 @@ func TestBlocksStoreQuerier_SelectSortedShouldHonorQueryStoreAfter(t *testing.T)
 
 			ctx := user.InjectOrgID(context.Background(), "user-1")
 			finder := &blocksFinderMock{}
-			finder.On("GetBlocks", mock.Anything, "user-1", mock.Anything, mock.Anything).Return(bucketindex.Blocks(nil), map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), error(nil))
+			finder.On("GetBlocks", mock.Anything, "user-1", mock.Anything, mock.Anything, mock.Anything).Return(bucketindex.Blocks(nil), map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), error(nil))
 
 			q := &blocksStoreQuerier{
 				minT:            testData.queryMinT,
@@ -2385,7 +2385,7 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 				finder := &blocksFinderMock{
 					Service: services.NewIdleService(nil, nil),
 				}
-				finder.On("GetBlocks", mock.Anything, "user-1", mock.Anything, mock.Anything).Return(bucketindex.Blocks{
+				finder.On("GetBlocks", mock.Anything, "user-1", mock.Anything, mock.Anything, mock.Anything).Return(bucketindex.Blocks{
 					&bucketindex.Block{ID: block1},
 					&bucketindex.Block{ID: block2},
 				}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), error(nil))
@@ -2535,8 +2535,8 @@ type blocksFinderMock struct {
 	mock.Mock
 }
 
-func (m *blocksFinderMock) GetBlocks(ctx context.Context, userID string, minT, maxT int64) (bucketindex.Blocks, map[ulid.ULID]*bucketindex.BlockDeletionMark, error) {
-	args := m.Called(ctx, userID, minT, maxT)
+func (m *blocksFinderMock) GetBlocks(ctx context.Context, userID string, minT, maxT int64, matchers []*labels.Matcher) (bucketindex.Blocks, map[ulid.ULID]*bucketindex.BlockDeletionMark, error) {
+	args := m.Called(ctx, userID, minT, maxT, matchers)
 	return args.Get(0).(bucketindex.Blocks), args.Get(1).(map[ulid.ULID]*bucketindex.BlockDeletionMark), args.Error(2)
 }
 

--- a/pkg/querier/parquet_queryable.go
+++ b/pkg/querier/parquet_queryable.go
@@ -396,7 +396,7 @@ func (q *parquetQuerierWithFallback) LabelNames(ctx context.Context, hints *stor
 	span, ctx := opentracing.StartSpanFromContext(ctx, "parquetQuerierWithFallback.LabelNames")
 	defer span.Finish()
 
-	remaining, parquet, err := q.getBlocks(ctx, q.minT, q.maxT)
+	remaining, parquet, err := q.getBlocks(ctx, q.minT, q.maxT, matchers)
 	defer q.incrementOpsMetric("LabelNames", remaining, parquet)
 	if err != nil {
 		return nil, nil, err
@@ -475,7 +475,7 @@ func (q *parquetQuerierWithFallback) Select(ctx context.Context, sortSeries bool
 		return storage.EmptySeriesSet()
 	}
 
-	remaining, parquet, err := q.getBlocks(ctx, mint, maxt)
+	remaining, parquet, err := q.getBlocks(ctx, mint, maxt, matchers)
 	defer q.incrementOpsMetric("Select", remaining, parquet)
 
 	if err != nil {

--- a/pkg/querier/parquet_queryable.go
+++ b/pkg/querier/parquet_queryable.go
@@ -343,7 +343,7 @@ func (q *parquetQuerierWithFallback) LabelValues(ctx context.Context, name strin
 	span, ctx := opentracing.StartSpanFromContext(ctx, "parquetQuerierWithFallback.LabelValues")
 	defer span.Finish()
 
-	remaining, parquet, err := q.getBlocks(ctx, q.minT, q.maxT)
+	remaining, parquet, err := q.getBlocks(ctx, q.minT, q.maxT, matchers)
 	defer q.incrementOpsMetric("LabelValues", remaining, parquet)
 	if err != nil {
 		return nil, nil, err
@@ -547,7 +547,7 @@ func (q *parquetQuerierWithFallback) Close() error {
 	return mErr.Err()
 }
 
-func (q *parquetQuerierWithFallback) getBlocks(ctx context.Context, minT, maxT int64) ([]*bucketindex.Block, []*bucketindex.Block, error) {
+func (q *parquetQuerierWithFallback) getBlocks(ctx context.Context, minT, maxT int64, matchers []*labels.Matcher) ([]*bucketindex.Block, []*bucketindex.Block, error) {
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -559,7 +559,7 @@ func (q *parquetQuerierWithFallback) getBlocks(ctx context.Context, minT, maxT i
 		return nil, nil, nil
 	}
 
-	blocks, _, err := q.finder.GetBlocks(ctx, userID, minT, maxT)
+	blocks, _, err := q.finder.GetBlocks(ctx, userID, minT, maxT, matchers)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/querier/parquet_queryable_test.go
+++ b/pkg/querier/parquet_queryable_test.go
@@ -108,7 +108,7 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 			defaultBlockStoreType: parquetBlockStore,
 		}
 
-		finder.On("GetBlocks", mock.Anything, "user-1", minT, mock.Anything).Return(bucketindex.Blocks{
+		finder.On("GetBlocks", mock.Anything, "user-1", minT, mock.Anything, mock.Anything).Return(bucketindex.Blocks{
 			&bucketindex.Block{ID: block1},
 			&bucketindex.Block{ID: block2},
 		}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)
@@ -169,7 +169,7 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 			defaultBlockStoreType: parquetBlockStore,
 		}
 
-		finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(bucketindex.Blocks{
+		finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT, mock.Anything).Return(bucketindex.Blocks{
 			&bucketindex.Block{ID: block1, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
 			&bucketindex.Block{ID: block2},
 		}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)
@@ -238,7 +238,7 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 			defaultBlockStoreType: parquetBlockStore,
 		}
 
-		finder.On("GetBlocks", mock.Anything, "user-1", minT, mock.Anything).Return(bucketindex.Blocks{
+		finder.On("GetBlocks", mock.Anything, "user-1", minT, mock.Anything, mock.Anything).Return(bucketindex.Blocks{
 			&bucketindex.Block{ID: block1, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
 			&bucketindex.Block{ID: block2, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
 		}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)
@@ -312,7 +312,7 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 			defaultBlockStoreType: tsdbBlockStore,
 		}
 
-		finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(bucketindex.Blocks{
+		finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT, mock.Anything).Return(bucketindex.Blocks{
 			&bucketindex.Block{ID: block1, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
 			&bucketindex.Block{ID: block2, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
 		}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)
@@ -433,7 +433,7 @@ func TestParquetQueryable_Limits(t *testing.T) {
 
 	// Create a mocked bucket index blocks finder
 	finder := &blocksFinderMock{}
-	finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(bucketindex.Blocks{
+	finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT, mock.Anything).Return(bucketindex.Blocks{
 		&bucketindex.Block{ID: blockID, Parquet: &parquet.ConverterMarkMeta{Version: parquet.CurrentVersion}},
 	}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)
 
@@ -782,7 +782,7 @@ func TestParquetQueryableFallbackDisabled(t *testing.T) {
 		}
 
 		// Set up blocks where block1 has parquet metadata but block2 doesn't
-		finder.On("GetBlocks", mock.Anything, "user-1", minT, mock.Anything).Return(bucketindex.Blocks{
+		finder.On("GetBlocks", mock.Anything, "user-1", minT, mock.Anything, mock.Anything).Return(bucketindex.Blocks{
 			&bucketindex.Block{ID: block1, Parquet: &parquet.ConverterMarkMeta{Version: 1}}, // Available as parquet
 			&bucketindex.Block{ID: block2}, // Not available as parquet
 		}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)
@@ -841,7 +841,7 @@ func TestParquetQueryableFallbackDisabled(t *testing.T) {
 		}
 
 		// Set up blocks where both blocks have parquet metadata
-		finder.On("GetBlocks", mock.Anything, "user-1", minT, mock.Anything).Return(bucketindex.Blocks{
+		finder.On("GetBlocks", mock.Anything, "user-1", minT, mock.Anything, mock.Anything).Return(bucketindex.Blocks{
 			&bucketindex.Block{ID: block1, Parquet: &parquet.ConverterMarkMeta{Version: 1}}, // Available as parquet
 			&bucketindex.Block{ID: block2, Parquet: &parquet.ConverterMarkMeta{Version: 1}}, // Available as parquet
 		}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR extends the `BlockFinder` interface's `GetBlocks` method to accept the list of query matchers. This allows downstream projects to extend the block finding strategy to allow experimenting with some different partitioning strategies.

We are testing it out with TSDB blocks partitioned by metric name. By passing the list of matchers when finding blocks, this allows us to filter out blocks that won't have the metric name at all so we query fewer blocks. We will try to upstream this soon.

There is no any user facing change in this PR other than the interface change.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
