### PR TITLE
Chore: update build image to use Go 1.24.6

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-bullseye
+FROM golang:1.24.6-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 RUN apt-get update && apt-get install -y curl file gettext jq unzip protobuf-compiler libprotobuf-dev && \


### PR DESCRIPTION
Update build image to address vulnerabilities:
* https://github.com/advisories/GHSA-j5pm-7495-qmr3 - Fixed by Go 1.24.6
* https://github.com/advisories/GHSA-wprm-fgrx-xj42 - Fixed by Go 1.24.5
* https://github.com/advisories/GHSA-6f52-wpx2-hvf2 - Fixed by Go 1.24.4
* https://github.com/advisories/GHSA-jw54-c8rr-pjpq - Fixed by Go 1.24.4
* https://github.com/advisories/GHSA-62jj-gr2r-5c34 - Fixed by Go 1.24.4


---

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
