### PR TITLE
ingester: Revert stringlabels in performance critial paths

### DIFF
--- a/pkg/cortexpb/compat.go
+++ b/pkg/cortexpb/compat.go
@@ -67,13 +67,13 @@ func FromLabelAdaptersToLabels(ls []LabelAdapter) labels.Labels {
 // Do NOT use unsafe to convert between data types because this function may
 // get in input labels whose data structure is reused.
 func FromLabelAdaptersToLabelsWithCopy(input []LabelAdapter) labels.Labels {
-	return CopyLabels(input)
+	return CopyLabels(FromLabelAdaptersToLabels(input))
 }
 
 // Efficiently copies labels input slice. To be used in cases where input slice
 // can be reused, but long-term copy is needed.
-func CopyLabels(input []LabelAdapter) labels.Labels {
-	builder := labels.NewBuilder(labels.EmptyLabels())
+func CopyLabels(input []labels.Label) labels.Labels {
+	result := make(labels.Labels, len(input))
 
 	size := 0
 	for _, l := range input {
@@ -84,14 +84,12 @@ func CopyLabels(input []LabelAdapter) labels.Labels {
 	// Copy all strings into the buffer, and use 'yoloString' to convert buffer
 	// slices to strings.
 	buf := make([]byte, size)
-	var name, value string
 
-	for _, l := range input {
-		name, buf = copyStringToBuffer(l.Name, buf)
-		value, buf = copyStringToBuffer(l.Value, buf)
-		builder.Set(name, value)
+	for i, l := range input {
+		result[i].Name, buf = copyStringToBuffer(l.Name, buf)
+		result[i].Value, buf = copyStringToBuffer(l.Value, buf)
 	}
-	return builder.Labels()
+	return result
 }
 
 // Copies string to buffer (which must be big enough), and converts buffer slice containing


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
After deploying Cortex with the latest Prometheus update https://github.com/cortexproject/cortex/pull/6930, we saw an increase in 5XXs from distributor -> ingesters.
This PR reverts the suspicious change from the PR.


- `cortexpb.FromLabelAdaptersToLabelsWithCopy()` is used in Push() when a new series is created.

https://github.com/cortexproject/cortex/blob/a776fe452be652c86b119019e2ba670d0eb2b5b7/pkg/ingester/ingester.go#L1349

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
