### PR TITLE
Fix sort series for parquet queryable

### DIFF
--- a/pkg/querier/parquet_queryable.go
+++ b/pkg/querier/parquet_queryable.go
@@ -491,6 +491,11 @@ func (q *parquetQuerierWithFallback) Select(ctx context.Context, sortSeries bool
 	if len(parquet) > 0 && len(remaining) > 0 {
 		sortSeries = true
 	}
+	// Also sort when multiple parquet blocks are being merged.
+	// We don't need to sort explicitly
+	if len(parquet) > 1 {
+		sortSeries = true
+	}
 
 	promises := make([]chan storage.SeriesSet, 0, 2)
 

--- a/pkg/querier/parquet_queryable.go
+++ b/pkg/querier/parquet_queryable.go
@@ -492,7 +492,7 @@ func (q *parquetQuerierWithFallback) Select(ctx context.Context, sortSeries bool
 		sortSeries = true
 	}
 	// Also sort when multiple parquet blocks are being merged.
-	// We don't need to sort explicitly
+	// We don't need to sort explicitly if only Store Gateway blocks as they are sorted by default.
 	if len(parquet) > 1 {
 		sortSeries = true
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Today, Parquet queryable only set `sortSeries` to true if merging from Parquet queryable and Store Gateway is required. However, when querying multiple parquet blocks, merging is also required so we also need to sort series in that case.

This PR fixes it by also set `sortSeries` to true when querying more than 1 parquet block. Note that we don't need to handle it when querying store gateway blocks only as Store Gateway always sort series.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
