### PR TITLE
Update ring DynamoDB Client to write in a transaction when batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [ENHANCEMENT] API: add request ID injection to context to enable tracking requests across downstream services. #6895
 * [ENHANCEMENT] gRPC: Add gRPC Channelz monitoring. #6950
 * [ENHANCEMENT] Upgrade build image and Go version to 1.24.6. #6970 #6976
+* [ENHANCEMENT] Implement versioned transactions for batch writes to Ring DynamoDB. #6986
 * [BUGFIX] Ingester: Avoid error or early throttling when READONLY ingesters are present in the ring #6517
 * [BUGFIX] Ingester: Fix labelset data race condition. #6573
 * [BUGFIX] Compactor: Cleaner should not put deletion marker for blocks with no-compact marker. #6576

--- a/pkg/ring/kv/dynamodb/client.go
+++ b/pkg/ring/kv/dynamodb/client.go
@@ -185,9 +185,12 @@ func (c *Client) CAS(ctx context.Context, key string, f func(in interface{}) (ou
 			continue
 		}
 
-		putRequests := map[dynamodbKey][]byte{}
+		putRequests := map[dynamodbKey]dynamodbItem{}
 		for childKey, bytes := range buf {
-			putRequests[dynamodbKey{primaryKey: key, sortKey: childKey}] = bytes
+			putRequests[dynamodbKey{primaryKey: key, sortKey: childKey}] = dynamodbItem{
+				data:    bytes,
+				version: resp[childKey].version,
+			}
 		}
 
 		deleteRequests := make([]dynamodbKey, 0, len(toDelete))
@@ -273,8 +276,8 @@ func (c *Client) WatchPrefix(ctx context.Context, prefix string, f func(string, 
 			continue
 		}
 
-		for key, bytes := range out {
-			decoded, err := c.codec.Decode(bytes)
+		for key, ddbItem := range out {
+			decoded, err := c.codec.Decode(ddbItem.data)
 			if err != nil {
 				level.Error(c.logger).Log("msg", "error decoding key", "key", key, "err", err)
 				continue
@@ -293,8 +296,12 @@ func (c *Client) WatchPrefix(ctx context.Context, prefix string, f func(string, 
 	}
 }
 
-func (c *Client) decodeMultikey(data map[string][]byte) (codec.MultiKey, error) {
-	res, err := c.codec.DecodeMultiKey(data)
+func (c *Client) decodeMultikey(data map[string]dynamodbItem) (codec.MultiKey, error) {
+	multiKeyData := make(map[string][]byte, len(data))
+	for key, ddbItem := range data {
+		multiKeyData[key] = ddbItem.data
+	}
+	res, err := c.codec.DecodeMultiKey(multiKeyData)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ring/kv/dynamodb/dynamodb.go
+++ b/pkg/ring/kv/dynamodb/dynamodb.go
@@ -27,10 +27,10 @@ type dynamodbKey struct {
 
 type dynamoDbClient interface {
 	List(ctx context.Context, key dynamodbKey) ([]string, float64, error)
-	Query(ctx context.Context, key dynamodbKey, isPrefix bool) (map[string][]byte, float64, error)
+	Query(ctx context.Context, key dynamodbKey, isPrefix bool) (map[string]dynamodbItem, float64, error)
 	Delete(ctx context.Context, key dynamodbKey) error
 	Put(ctx context.Context, key dynamodbKey, data []byte) error
-	Batch(ctx context.Context, put map[dynamodbKey][]byte, delete []dynamodbKey) error
+	Batch(ctx context.Context, put map[dynamodbKey]dynamodbItem, delete []dynamodbKey) error
 }
 
 type dynamodbKV struct {
@@ -40,11 +40,17 @@ type dynamodbKV struct {
 	ttlValue  time.Duration
 }
 
+type dynamodbItem struct {
+	data    []byte
+	version string
+}
+
 var (
 	primaryKey  = "RingKey"
 	sortKey     = "InstanceKey"
 	contentData = "Data"
 	timeToLive  = "ttl"
+	version     = "version"
 )
 
 func newDynamodbKV(cfg Config, logger log.Logger) (dynamodbKV, error) {
@@ -120,8 +126,8 @@ func (kv dynamodbKV) List(ctx context.Context, key dynamodbKey) ([]string, float
 	return keys, totalCapacity, nil
 }
 
-func (kv dynamodbKV) Query(ctx context.Context, key dynamodbKey, isPrefix bool) (map[string][]byte, float64, error) {
-	keys := make(map[string][]byte)
+func (kv dynamodbKV) Query(ctx context.Context, key dynamodbKey, isPrefix bool) (map[string]dynamodbItem, float64, error) {
+	keys := make(map[string]dynamodbItem)
 	var totalCapacity float64
 	co := dynamodb.ComparisonOperatorEq
 	if isPrefix {
@@ -145,7 +151,15 @@ func (kv dynamodbKV) Query(ctx context.Context, key dynamodbKey, isPrefix bool) 
 	err := kv.ddbClient.QueryPagesWithContext(ctx, input, func(output *dynamodb.QueryOutput, _ bool) bool {
 		totalCapacity += getCapacityUnits(output.ConsumedCapacity)
 		for _, item := range output.Items {
-			keys[*item[sortKey].S] = item[contentData].B
+			var itemVersion string
+			if item[version] != nil {
+				itemVersion = *item[version].N
+			}
+			keys[*item[sortKey].S] = dynamodbItem{
+				data:    item[contentData].B,
+				version: itemVersion,
+			}
+
 		}
 		return true
 	})
@@ -174,7 +188,7 @@ func (kv dynamodbKV) Put(ctx context.Context, key dynamodbKey, data []byte) (flo
 	input := &dynamodb.PutItemInput{
 		TableName:              kv.tableName,
 		ReturnConsumedCapacity: aws.String(dynamodb.ReturnConsumedCapacityTotal),
-		Item:                   kv.generatePutItemRequest(key, data),
+		Item:                   kv.generatePutItemRequest(key, dynamodbItem{data: data}),
 	}
 	totalCapacity := float64(0)
 	output, err := kv.ddbClient.PutItemWithContext(ctx, input)
@@ -184,26 +198,31 @@ func (kv dynamodbKV) Put(ctx context.Context, key dynamodbKey, data []byte) (flo
 	return totalCapacity, err
 }
 
-func (kv dynamodbKV) Batch(ctx context.Context, put map[dynamodbKey][]byte, delete []dynamodbKey) (float64, error) {
+func (kv dynamodbKV) Batch(ctx context.Context, put map[dynamodbKey]dynamodbItem, delete []dynamodbKey) (float64, error) {
 	totalCapacity := float64(0)
 	writeRequestSize := len(put) + len(delete)
 	if writeRequestSize == 0 {
 		return totalCapacity, nil
 	}
 
-	writeRequestsSlices := make([][]*dynamodb.WriteRequest, int(math.Ceil(float64(writeRequestSize)/float64(DdbBatchSizeLimit))))
+	writeRequestsSlices := make([][]*dynamodb.TransactWriteItem, int(math.Ceil(float64(writeRequestSize)/float64(DdbBatchSizeLimit))))
 	for i := 0; i < len(writeRequestsSlices); i++ {
-		writeRequestsSlices[i] = make([]*dynamodb.WriteRequest, 0, DdbBatchSizeLimit)
+		writeRequestsSlices[i] = make([]*dynamodb.TransactWriteItem, 0, DdbBatchSizeLimit)
 	}
-
 	currIdx := 0
-	for key, data := range put {
-		item := kv.generatePutItemRequest(key, data)
-		writeRequestsSlices[currIdx] = append(writeRequestsSlices[currIdx], &dynamodb.WriteRequest{
-			PutRequest: &dynamodb.PutRequest{
-				Item: item,
-			},
-		})
+	for key, ddbItem := range put {
+		item := kv.generatePutItemRequest(key, ddbItem)
+		ddbPut := &dynamodb.Put{
+			TableName: kv.tableName,
+			Item:      item,
+		}
+		if ddbItem.version != "" {
+			ddbPut.ConditionExpression = aws.String("version = :v")
+			ddbPut.ExpressionAttributeValues = map[string]*dynamodb.AttributeValue{
+				":v": {N: aws.String(ddbItem.version)},
+			}
+		}
+		writeRequestsSlices[currIdx] = append(writeRequestsSlices[currIdx], &dynamodb.TransactWriteItem{Put: ddbPut})
 		if len(writeRequestsSlices[currIdx]) == DdbBatchSizeLimit {
 			currIdx++
 		}
@@ -211,9 +230,10 @@ func (kv dynamodbKV) Batch(ctx context.Context, put map[dynamodbKey][]byte, dele
 
 	for _, key := range delete {
 		item := generateItemKey(key)
-		writeRequestsSlices[currIdx] = append(writeRequestsSlices[currIdx], &dynamodb.WriteRequest{
-			DeleteRequest: &dynamodb.DeleteRequest{
-				Key: item,
+		writeRequestsSlices[currIdx] = append(writeRequestsSlices[currIdx], &dynamodb.TransactWriteItem{
+			Delete: &dynamodb.Delete{
+				TableName: kv.tableName,
+				Key:       item,
 			},
 		})
 		if len(writeRequestsSlices[currIdx]) == DdbBatchSizeLimit {
@@ -222,33 +242,29 @@ func (kv dynamodbKV) Batch(ctx context.Context, put map[dynamodbKey][]byte, dele
 	}
 
 	for _, slice := range writeRequestsSlices {
-		input := &dynamodb.BatchWriteItemInput{
-			ReturnConsumedCapacity: aws.String(dynamodb.ReturnConsumedCapacityTotal),
-			RequestItems: map[string][]*dynamodb.WriteRequest{
-				*kv.tableName: slice,
-			},
+		transactItems := &dynamodb.TransactWriteItemsInput{
+			TransactItems: slice,
 		}
-
-		resp, err := kv.ddbClient.BatchWriteItemWithContext(ctx, input)
+		resp, err := kv.ddbClient.TransactWriteItems(transactItems)
 		if err != nil {
 			return totalCapacity, err
 		}
 		for _, consumedCapacity := range resp.ConsumedCapacity {
 			totalCapacity += getCapacityUnits(consumedCapacity)
 		}
-
-		if len(resp.UnprocessedItems) > 0 {
-			return totalCapacity, fmt.Errorf("error processing batch request for %s requests", resp.UnprocessedItems)
-		}
 	}
 
 	return totalCapacity, nil
 }
 
-func (kv dynamodbKV) generatePutItemRequest(key dynamodbKey, data []byte) map[string]*dynamodb.AttributeValue {
+func (kv dynamodbKV) generatePutItemRequest(key dynamodbKey, ddbItem dynamodbItem) map[string]*dynamodb.AttributeValue {
 	item := generateItemKey(key)
 	item[contentData] = &dynamodb.AttributeValue{
-		B: data,
+		B: ddbItem.data,
+	}
+	itemVersion := getItemVersion(ddbItem, kv)
+	item[version] = &dynamodb.AttributeValue{
+		N: aws.String(itemVersion),
 	}
 	if kv.getTTL() > 0 {
 		item[timeToLive] = &dynamodb.AttributeValue{
@@ -257,6 +273,18 @@ func (kv dynamodbKV) generatePutItemRequest(key dynamodbKey, data []byte) map[st
 	}
 
 	return item
+}
+
+func getItemVersion(ddbItem dynamodbItem, kv dynamodbKV) string {
+	if ddbItem.version != "" {
+		itemVersion, err := strconv.ParseInt(ddbItem.version, 10, 64)
+		if err != nil {
+			kv.logger.Log("msg", "error converting version to int", "version", ddbItem.version, "err", err)
+			return ""
+		}
+		return strconv.FormatInt(itemVersion+1, 10)
+	}
+	return "0"
 }
 
 type dynamodbKVWithTimeout struct {
@@ -274,7 +302,7 @@ func (d *dynamodbKVWithTimeout) List(ctx context.Context, key dynamodbKey) ([]st
 	return d.ddbClient.List(ctx, key)
 }
 
-func (d *dynamodbKVWithTimeout) Query(ctx context.Context, key dynamodbKey, isPrefix bool) (map[string][]byte, float64, error) {
+func (d *dynamodbKVWithTimeout) Query(ctx context.Context, key dynamodbKey, isPrefix bool) (map[string]dynamodbItem, float64, error) {
 	ctx, cancel := context.WithTimeout(ctx, d.timeout)
 	defer cancel()
 	return d.ddbClient.Query(ctx, key, isPrefix)
@@ -292,7 +320,7 @@ func (d *dynamodbKVWithTimeout) Put(ctx context.Context, key dynamodbKey, data [
 	return d.ddbClient.Put(ctx, key, data)
 }
 
-func (d *dynamodbKVWithTimeout) Batch(ctx context.Context, put map[dynamodbKey][]byte, delete []dynamodbKey) error {
+func (d *dynamodbKVWithTimeout) Batch(ctx context.Context, put map[dynamodbKey]dynamodbItem, delete []dynamodbKey) error {
 	ctx, cancel := context.WithTimeout(ctx, d.timeout)
 	defer cancel()
 	return d.ddbClient.Batch(ctx, put, delete)

--- a/pkg/ring/kv/dynamodb/metrics.go
+++ b/pkg/ring/kv/dynamodb/metrics.go
@@ -59,8 +59,8 @@ func (d dynamodbInstrumentation) List(ctx context.Context, key dynamodbKey) ([]s
 	return resp, totalCapacity, err
 }
 
-func (d dynamodbInstrumentation) Query(ctx context.Context, key dynamodbKey, isPrefix bool) (map[string][]byte, float64, error) {
-	var resp map[string][]byte
+func (d dynamodbInstrumentation) Query(ctx context.Context, key dynamodbKey, isPrefix bool) (map[string]dynamodbItem, float64, error) {
+	var resp map[string]dynamodbItem
 	var totalCapacity float64
 	err := instrument.CollectedRequest(ctx, "Query", d.ddbMetrics.dynamodbRequestDuration, errorCode, func(ctx context.Context) error {
 		var err error
@@ -87,7 +87,7 @@ func (d dynamodbInstrumentation) Put(ctx context.Context, key dynamodbKey, data 
 	})
 }
 
-func (d dynamodbInstrumentation) Batch(ctx context.Context, put map[dynamodbKey][]byte, delete []dynamodbKey) error {
+func (d dynamodbInstrumentation) Batch(ctx context.Context, put map[dynamodbKey]dynamodbItem, delete []dynamodbKey) error {
 	return instrument.CollectedRequest(ctx, "Batch", d.ddbMetrics.dynamodbRequestDuration, errorCode, func(ctx context.Context) error {
 		totalCapacity, err := d.kv.Batch(ctx, put, delete)
 		d.ddbMetrics.dynamodbUsageMetrics.WithLabelValues("Batch").Add(totalCapacity)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Updates the DynamoDB ring client to use versioning in it's KV store entries. Specifically
- Updates the Batch operation to use TransactWriteItems instead of BatchWriteItems because the former allows versioned optimistic locking when there are concurrent updates to the same ring entry.
- Updates the Batch operation to use a conditional expression on Put only if the version exists and matches what was previously queried.
- Updates the Query operation to return a `dynamodbItem` struct which holds the data from the queried item along with a version. If there is no version from DynamoDB for the item, the version defaults to an empty string.

**Which issue(s) this PR fixes**:
Fixes #6986

**Checklist**
- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
