### PR TITLE
Add parse query op label to queries total metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 * [ENHANCEMENT] Ingester: Add new metric `cortex_ingester_push_errors_total` to track reasons for ingester request failures. #6901
 * [ENHANCEMENT] Ring: Expose `detailed_metrics_enabled` for all rings. Default true. #6926
 * [ENHANCEMENT] Parquet Storage: Allow Parquet Queryable to disable fallback to Store Gateway. #6920
-* [ENHANCEMENT] Query Frontend: Add a `format_query` label value to the `op` label at `cortex_query_frontend_queries_total` metric. #6925
+* [ENHANCEMENT] Query Frontend: Add a `format_query` and `parse_query` labels value to the `op` label at `cortex_query_frontend_queries_total` metric. #6925 #6990
 * [ENHANCEMENT] API: add request ID injection to context to enable tracking requests across downstream services. #6895
 * [ENHANCEMENT] gRPC: Add gRPC Channelz monitoring. #6950
 * [ENHANCEMENT] Upgrade build image and Go version to 1.24.6. #6970 #6976

--- a/pkg/querier/tripperware/roundtrip.go
+++ b/pkg/querier/tripperware/roundtrip.go
@@ -47,6 +47,7 @@ const (
 	opTypeMetadata       = "metadata"
 	opTypeQueryExemplars = "query_exemplars"
 	opTypeFormatQuery    = "format_query"
+	opTypeParseQuery     = "parse_query"
 )
 
 // HandlerFunc is like http.HandlerFunc, but for Handler.
@@ -154,6 +155,7 @@ func NewQueryTripperware(
 				isMetadata := strings.HasSuffix(r.URL.Path, "/metadata")
 				isQueryExemplars := strings.HasSuffix(r.URL.Path, "/query_exemplars")
 				isFormatQuery := strings.HasSuffix(r.URL.Path, "/format_query")
+				isParseQuery := strings.HasSuffix(r.URL.Path, "/parse_query")
 
 				op := opTypeQuery
 				switch {
@@ -173,6 +175,8 @@ func NewQueryTripperware(
 					op = opTypeQueryExemplars
 				case isFormatQuery:
 					op = opTypeFormatQuery
+				case isParseQuery:
+					op = opTypeParseQuery
 				}
 
 				tenantIDs, err := tenant.TenantIDs(r.Context())

--- a/pkg/querier/tripperware/roundtrip_test.go
+++ b/pkg/querier/tripperware/roundtrip_test.go
@@ -39,6 +39,7 @@ const (
 	labelValuesQuery              = "/api/v1/label/label/values"
 	metadataQuery                 = "/api/v1/metadata"
 	formatQuery                   = "/api/v1/format_query?query=foo/bar"
+	parseQuery                    = "/api/v1/parse_query?query=foo/bar"
 
 	responseBody        = `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[1536673680,"137"],[1536673780,"137"]]}]}}`
 	instantResponseBody = `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"foo":"bar"},"values":[[1536673680,"137"],[1536673780,"137"]]}]}}`
@@ -242,6 +243,18 @@ cortex_query_frontend_queries_total{op="query_range", source="api", user="1"} 1
 # HELP cortex_query_frontend_queries_total Total queries sent per tenant.
 # TYPE cortex_query_frontend_queries_total counter
 cortex_query_frontend_queries_total{op="format_query", source="api", user="1"} 1
+`,
+		},
+		{
+			path:             parseQuery,
+			expectedBody:     "bar",
+			limits:           defaultOverrides,
+			maxSubQuerySteps: 11000,
+			userAgent:        "dummyUserAgent/1.2",
+			expectedMetric: `
+# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+# TYPE cortex_query_frontend_queries_total counter
+cortex_query_frontend_queries_total{op="parse_query", source="api", user="1"} 1
 `,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

At #6978, `api/v1/parse_query` API has been added. This PR adds `parse_query` as a label value to the `op` label at `cortex_query_frontend_queries_total `.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
