### PR TITLE
Fix error from resource based throttling to be retryable

### DIFF
--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -28,13 +28,15 @@ import (
 	"github.com/thanos-io/promql-engine/engine"
 	"github.com/thanos-io/promql-engine/logicalplan"
 	"github.com/thanos-io/thanos/pkg/pool"
-	"github.com/thanos-io/thanos/pkg/store/hintspb"
-	"github.com/thanos-io/thanos/pkg/store/labelpb"
-	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/cortexproject/cortex/pkg/util/resource"
+	"github.com/thanos-io/thanos/pkg/store/hintspb"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
 
 	"github.com/cortexproject/cortex/pkg/chunk/encoding"
 	"github.com/cortexproject/cortex/pkg/cortexpb"
@@ -2496,6 +2498,22 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestBlocksStoreQuerier_ShouldRetryResourceBasedThrottlingError(t *testing.T) {
+	limits := map[resource.Type]float64{
+		resource.CPU:  0.5,
+		resource.Heap: 0.5,
+	}
+
+	resourceBasedLimiter, err := limiter.NewResourceBasedLimiter(&limiter.MockMonitor{
+		CpuUtilization:  0.7,
+		HeapUtilization: 0.7,
+	}, limits, prometheus.DefaultRegisterer, "ingester")
+	require.NoError(t, err)
+
+	err = resourceBasedLimiter.AcceptNewRequest()
+	require.True(t, isRetryableError(err))
 }
 
 type blocksStoreSetMock struct {

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -28,15 +28,13 @@ import (
 	"github.com/thanos-io/promql-engine/engine"
 	"github.com/thanos-io/promql-engine/logicalplan"
 	"github.com/thanos-io/thanos/pkg/pool"
+	"github.com/thanos-io/thanos/pkg/store/hintspb"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
+	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/weaveworks/common/user"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/cortexproject/cortex/pkg/util/resource"
-	"github.com/thanos-io/thanos/pkg/store/hintspb"
-	"github.com/thanos-io/thanos/pkg/store/labelpb"
-	"github.com/thanos-io/thanos/pkg/store/storepb"
 
 	"github.com/cortexproject/cortex/pkg/chunk/encoding"
 	"github.com/cortexproject/cortex/pkg/cortexpb"
@@ -46,6 +44,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/limiter"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
+	"github.com/cortexproject/cortex/pkg/util/resource"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )

--- a/pkg/util/limiter/resource_based_limiter.go
+++ b/pkg/util/limiter/resource_based_limiter.go
@@ -64,9 +64,22 @@ func (l *ResourceBasedLimiter) AcceptNewRequest() error {
 
 		if utilization >= limit {
 			l.limitBreachedCount.WithLabelValues(string(resType)).Inc()
-			return fmt.Errorf("%s utilization limit reached (limit: %.3f, utilization: %.3f)", resType, limit, utilization)
+			return fmt.Errorf("%s utilization limit reached (limit: %.3f, utilization: %.3f): %w", resType, limit, utilization, &ResourceLimitReachedError{})
 		}
 	}
 
 	return nil
+}
+
+type MockMonitor struct {
+	CpuUtilization  float64
+	HeapUtilization float64
+}
+
+func (m *MockMonitor) GetCPUUtilization() float64 {
+	return m.CpuUtilization
+}
+
+func (m *MockMonitor) GetHeapUtilization() float64 {
+	return m.HeapUtilization
 }

--- a/pkg/util/limiter/resource_based_limiter_test.go
+++ b/pkg/util/limiter/resource_based_limiter_test.go
@@ -15,16 +15,12 @@ func Test_ResourceBasedLimiter(t *testing.T) {
 		resource.Heap: 0.5,
 	}
 
-	_, err := NewResourceBasedLimiter(&mockMonitor{}, limits, prometheus.DefaultRegisterer, "ingester")
+	limiter, err := NewResourceBasedLimiter(&MockMonitor{
+		CpuUtilization:  0.2,
+		HeapUtilization: 0.2,
+	}, limits, prometheus.DefaultRegisterer, "ingester")
 	require.NoError(t, err)
-}
 
-type mockMonitor struct{}
-
-func (m *mockMonitor) GetCPUUtilization() float64 {
-	return 0
-}
-
-func (m *mockMonitor) GetHeapUtilization() float64 {
-	return 0
+	err = limiter.AcceptNewRequest()
+	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

`isRetryableError` from blocks_store_queryable checks if the error chain includes `limiter.ResourceLimitReachedError` struct:

```
func isRetryableError(err error) bool {
	// retry upon resource exhaustion error from resource monitor
	var resourceExhaustedErr *limiter.ResourceLimitReachedError
	if errors.As(err, &resourceExhaustedErr) {
		return true
	}
```

https://github.com/cortexproject/cortex/blob/master/pkg/querier/blocks_store_queryable.go#L1206-L1211

However, resource based limiter was not returning that error struct, hence this check was returning false.

Since the goal of resource based throttling is to protect subset of pods with high resource utilization, we do want to retry them on other pods.

**Which issue(s) this PR fixes**:
n/a

**Testing**:

Before the fix:

```
=== RUN   TestBlocksStoreQuerier_ShouldRetryResourceBasedThrottlingError
    blocks_store_queryable_test.go:2516: 
        	Error Trace:	/Users/jungjust/workplace/cortex/pkg/querier/blocks_store_queryable_test.go:2516
        	Error:      	Should be true
        	Test:       	TestBlocksStoreQuerier_ShouldRetryResourceBasedThrottlingError
--- FAIL: TestBlocksStoreQuerier_ShouldRetryResourceBasedThrottlingError (0.00s)
```

After the fix:

```
=== RUN   TestBlocksStoreQuerier_ShouldRetryResourceBasedThrottlingError
--- PASS: TestBlocksStoreQuerier_ShouldRetryResourceBasedThrottlingError (0.00s)
```

**Checklist**
- [x] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

I didn't add changelog as this is a minor change in an experimental feature.
