### PR TITLE
remove limiting query rejection to only adhoc queries for ingester. T…

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -61,7 +61,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/chunkcompat"
 	"github.com/cortexproject/cortex/pkg/util/limiter"
-	"github.com/cortexproject/cortex/pkg/util/requestmeta"
 	"github.com/cortexproject/cortex/pkg/util/resource"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/test"
@@ -3228,18 +3227,11 @@ func Test_Ingester_Query_ResourceThresholdBreached(t *testing.T) {
 	}
 
 	rreq := &client.QueryRequest{}
-	ctx = requestmeta.ContextWithRequestSource(ctx, requestmeta.SourceAPI)
 	s := &mockQueryStreamServer{ctx: ctx}
 	err = i.QueryStream(rreq, s)
 	require.Error(t, err)
 	exhaustedErr := limiter.ResourceLimitReachedError{}
 	require.ErrorContains(t, err, exhaustedErr.Error())
-
-	// we shouldn't reject queries from ruler
-	ctx = requestmeta.ContextWithRequestSource(ctx, requestmeta.SourceRuler)
-	s = &mockQueryStreamServer{ctx: ctx}
-	err = i.QueryStream(rreq, s)
-	require.Nil(t, err)
 }
 
 func TestIngester_LabelValues_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {


### PR DESCRIPTION

**What this PR does**:
We have discussed that we will leave out the changes limiting resource based throttling to only adhoc queries, but accidentally left rejection for ingesters while it was removed from SGs in this PR: https://github.com/cortexproject/cortex/pull/6947. 

This PR fixes it by removing that change in ingester. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
