### PR TITLE
Resource based throttling bug fixes

### DIFF
--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -357,12 +357,6 @@ store_gateway:
 
   query_protection:
     rejection:
-      # EXPERIMENTAL: Enable query rejection feature, where the component return
-      # 503 to all incoming query requests when the configured thresholds are
-      # breached.
-      # CLI flag: -store-gateway.query-protection.rejection.enabled
-      [enabled: <boolean> | default = false]
-
       threshold:
         # EXPERIMENTAL: Max CPU utilization that this ingester can reach before
         # rejecting new query request (across all tenants) in percentage,

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3731,12 +3731,6 @@ instance_limits:
 
 query_protection:
   rejection:
-    # EXPERIMENTAL: Enable query rejection feature, where the component return
-    # 503 to all incoming query requests when the configured thresholds are
-    # breached.
-    # CLI flag: -ingester.query-protection.rejection.enabled
-    [enabled: <boolean> | default = false]
-
     threshold:
       # EXPERIMENTAL: Max CPU utilization that this ingester can reach before
       # rejecting new query request (across all tenants) in percentage, between
@@ -6472,12 +6466,6 @@ sharding_ring:
 
 query_protection:
   rejection:
-    # EXPERIMENTAL: Enable query rejection feature, where the component return
-    # 503 to all incoming query requests when the configured thresholds are
-    # breached.
-    # CLI flag: -store-gateway.query-protection.rejection.enabled
-    [enabled: <boolean> | default = false]
-
     threshold:
       # EXPERIMENTAL: Max CPU utilization that this ingester can reach before
       # rejecting new query request (across all tenants) in percentage, between

--- a/pkg/configs/query_protection.go
+++ b/pkg/configs/query_protection.go
@@ -14,7 +14,6 @@ type QueryProtection struct {
 }
 
 type rejection struct {
-	Enabled   bool      `yaml:"enabled"`
 	Threshold threshold `yaml:"threshold"`
 }
 
@@ -24,7 +23,6 @@ type threshold struct {
 }
 
 func (cfg *QueryProtection) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
-	f.BoolVar(&cfg.Rejection.Enabled, prefix+"query-protection.rejection.enabled", false, "EXPERIMENTAL: Enable query rejection feature, where the component return 503 to all incoming query requests when the configured thresholds are breached.")
 	f.Float64Var(&cfg.Rejection.Threshold.CPUUtilization, prefix+"query-protection.rejection.threshold.cpu-utilization", 0, "EXPERIMENTAL: Max CPU utilization that this ingester can reach before rejecting new query request (across all tenants) in percentage, between 0 and 1. monitored_resources config must include the resource type. 0 to disable.")
 	f.Float64Var(&cfg.Rejection.Threshold.HeapUtilization, prefix+"query-protection.rejection.threshold.heap-utilization", 0, "EXPERIMENTAL: Max heap utilization that this ingester can reach before rejecting new query request (across all tenants) in percentage, between 0 and 1. monitored_resources config must include the resource type. 0 to disable.")
 }

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -584,7 +584,10 @@ func (f *Handler) reportQueryStats(r *http.Request, source, userID string, query
 			reason = reasonChunksLimitStoreGateway
 		} else if strings.Contains(errMsg, limitBytesStoreGateway) {
 			reason = reasonBytesLimitStoreGateway
-		} else if strings.Contains(errMsg, limiter.ErrResourceLimitReachedStr) {
+		}
+	} else if statusCode == http.StatusServiceUnavailable && error != nil {
+		errMsg := error.Error()
+		if strings.Contains(errMsg, limiter.ErrResourceLimitReachedStr) {
 			reason = reasonResourceExhausted
 		}
 	}

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -390,7 +390,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				resourceLimitReachedErr := &limiter.ResourceLimitReachedError{}
 				return &http.Response{
-					StatusCode: http.StatusUnprocessableEntity,
+					StatusCode: http.StatusServiceUnavailable,
 					Body:       io.NopCloser(strings.NewReader(resourceLimitReachedErr.Error())),
 				}, nil
 			}),
@@ -398,7 +398,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				v := promtest.ToFloat64(h.rejectedQueries.WithLabelValues(reasonResourceExhausted, requestmeta.SourceAPI, userID))
 				assert.Equal(t, float64(1), v)
 			},
-			expectedStatusCode: http.StatusUnprocessableEntity,
+			expectedStatusCode: http.StatusServiceUnavailable,
 		},
 		{
 			name:            "test cortex_slow_queries_total",

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -61,7 +61,6 @@ import (
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/chunkcompat"
 	"github.com/cortexproject/cortex/pkg/util/limiter"
-	"github.com/cortexproject/cortex/pkg/util/requestmeta"
 	"github.com/cortexproject/cortex/pkg/util/resource"
 	"github.com/cortexproject/cortex/pkg/util/services"
 	"github.com/cortexproject/cortex/pkg/util/test"
@@ -3228,18 +3227,11 @@ func Test_Ingester_Query_ResourceThresholdBreached(t *testing.T) {
 	}
 
 	rreq := &client.QueryRequest{}
-	ctx = requestmeta.ContextWithRequestSource(ctx, requestmeta.SourceAPI)
 	s := &mockQueryStreamServer{ctx: ctx}
 	err = i.QueryStream(rreq, s)
 	require.Error(t, err)
 	exhaustedErr := limiter.ResourceLimitReachedError{}
 	require.ErrorContains(t, err, exhaustedErr.Error())
-
-	// we shouldn't reject queries from ruler
-	ctx = requestmeta.ContextWithRequestSource(ctx, requestmeta.SourceRuler)
-	s = &mockQueryStreamServer{ctx: ctx}
-	err = i.QueryStream(rreq, s)
-	require.Nil(t, err)
 }
 
 func TestIngester_LabelValues_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {


### PR DESCRIPTION

**What this PR does**:

This PR for small fixes on resource based throttling
 - remove unused flag `query-protection.rejection.enabled`. query-protection can be disabled by utilization values, no need for extra configuration. 
 - fix `cortex_rejected_queries_total` for resource based throttling case.  

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation updated
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
