### PR TITLE
Fix flaky TestPerLabelsetDiscardedSeriesTracker

### DIFF
--- a/pkg/util/discardedseries/perlabelset_tracker.go
+++ b/pkg/util/discardedseries/perlabelset_tracker.go
@@ -81,9 +81,9 @@ func (t *DiscardedSeriesPerLabelsetTracker) Track(user string, series uint64, ma
 
 func (t *DiscardedSeriesPerLabelsetTracker) UpdateMetrics() {
 	usersToDelete := make([]string, 0)
-	labelsetsToDelete := make([]uint64, 0)
 	t.RLock()
 	for user, labelsetCounter := range t.userLabelsetMap {
+		labelsetsToDelete := make([]uint64, 0)
 		labelsetCounter.RLock()
 		if len(labelsetCounter.labelsetSeriesMap) == 0 {
 			usersToDelete = append(usersToDelete, user)

--- a/pkg/util/discardedseries/perlabelset_tracker_test.go
+++ b/pkg/util/discardedseries/perlabelset_tracker_test.go
@@ -114,5 +114,5 @@ func TestPerLabelsetDiscardedSeriesTracker(t *testing.T) {
 
 func comparePerLabelsetSeriesVendedCount(t *testing.T, gaugeVec *prometheus.GaugeVec, user string, labelsetLimitId string, val int) {
 	gauge, _ := gaugeVec.GetMetricWithLabelValues("per_labelset_series_limit", user, labelsetLimitId)
-	require.Equal(t, testutil.ToFloat64(gauge), float64(val))
+	require.Equal(t, float64(val), testutil.ToFloat64(gauge))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

Fix flaky test `TestPerLabelsetDiscardedSeriesTracker`.

## How to reproduce
```
go test -count=100 -race -run TestPerLabelsetDiscardedSeriesTracker ./pkg/util/discardedseries

--- FAIL: TestPerLabelsetDiscardedSeriesTracker (0.00s)
    perlabelset_tracker_test.go:117: 
        	Error Trace:	/__w/cortex/cortex/pkg/util/discardedseries/perlabelset_tracker_test.go:117
        	            				/__w/cortex/cortex/pkg/util/discardedseries/perlabelset_tracker_test.go:84
        	Error:      	Not equal: 
        	            	expected: 0
        	            	actual  : 1
        	Test:       	TestPerLabelsetDiscardedSeriesTracker
FAIL
```
The reason is that all users share `labelsetsToDelete`. When processing `user2`, the labelSetId for `user1` could be deleted.
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
