### PR TITLE
Update query rejection blog post to reflect what api_types it current…

### DIFF
--- a/website/content/en/blog/2025/query-rejection.md
+++ b/website/content/en/blog/2025/query-rejection.md
@@ -38,7 +38,7 @@ Think of query rejection as an “emergency stop” in a factory. It sits in fro
 
 Heavy queries often share identifiable traits. Query rejection lets you match on a variety of attributes and reject only those requests. You can combine as many of these as needed:
 
-- **API type:** `query`, `query_range`, `series`, etc.
+- **API type:** `query`, `query_range`. For now, query rejection only applies to these two API types.
 - **Query string (regex):** Match by pattern, e.g., any query containing “ALERT”.
 - **Time range:** Match queries whose range falls between a configured **min** and **max**.
 - **Time window:** Match queries based on how far their time window is from now by specifying relative **min** and **max** boundaries. This is often used to distinguish queries that hit hot storage versus cold storage.


### PR DESCRIPTION

**What this PR does**:
Fix incorrect API types mentioned in the Query Rejection blog post.

The post previously listed series (and other API types) as supported, but the feature currently only supports query and query_range. Updated the text to reflect the correct scope.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
