### PR TITLE
fix flaky test TestDiscardedSeriesTracker

### DIFF
--- a/pkg/util/discardedseries/tracker.go
+++ b/pkg/util/discardedseries/tracker.go
@@ -84,9 +84,9 @@ func (t *DiscardedSeriesTracker) Track(reason string, user string, series uint64
 }
 
 func (t *DiscardedSeriesTracker) UpdateMetrics() {
-	usersToDelete := make([]string, 0)
 	t.RLock()
 	for reason, userCounter := range t.reasonUserMap {
+		usersToDelete := make([]string, 0)
 		userCounter.RLock()
 		for user, seriesCounter := range userCounter.userSeriesMap {
 			seriesCounter.Lock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->
I have found the test `TestDiscardedSeriesTracker` is flaky; the logs are:
```
--- FAIL: TestDiscardedSeriesTracker (0.00s)
    tracker_test.go:114: 
        	Error Trace:	/__w/cortex/cortex/pkg/util/discardedseries/tracker_test.go:114
        	            				/__w/cortex/cortex/pkg/util/discardedseries/tracker_test.go:81
        	Error:      	Not equal: 
        	            	expected: 0
        	            	actual  : 1
        	Test:       	TestDiscardedSeriesTracker
FAIL
```

## How to reproduce
go test -count=100 -race -run TestDiscardedSeriesTracker ./pkg/util/discardedseries


Like #7036, the `usersToDelete` should be re-initialized for each loop.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
