### PR TITLE
fix panic when the runtime config is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 * [BUGFIX] Runtime-config: Change to check tenant limit validation when loading runtime config only for `all`, `distributor`, `querier`, and `ruler` targets. #6880
 * [BUGFIX] Frontend: Fix remote read snappy input due to request string logging when query stats enabled. #7025
 * [BUGFIX] Distributor: Fix the `/distributor/all_user_stats` api to work during rolling updates on ingesters. #7026
+* [BUGFIX] Runtime-config: Fix panic when the runtime config is `null`. #7062
 
 ## 1.19.0 2025-02-27
 

--- a/pkg/cortex/runtime_config.go
+++ b/pkg/cortex/runtime_config.go
@@ -85,9 +85,11 @@ func (l runtimeConfigLoader) load(r io.Reader) (any, error) {
 		if strings.Contains(targetStr, target) {
 			// only check if target is `all`, `distributor`, "querier", and "ruler"
 			// refer to https://github.com/cortexproject/cortex/issues/6741#issuecomment-3067244929
-			for _, ul := range overrides.TenantLimits {
-				if err := ul.Validate(l.cfg.Distributor.ShardByAllLabels, l.cfg.Ingester.ActiveSeriesMetricsEnabled); err != nil {
-					return nil, err
+			if overrides != nil {
+				for _, ul := range overrides.TenantLimits {
+					if err := ul.Validate(l.cfg.Distributor.ShardByAllLabels, l.cfg.Ingester.ActiveSeriesMetricsEnabled); err != nil {
+						return nil, err
+					}
 				}
 			}
 		}

--- a/pkg/cortex/runtime_config_test.go
+++ b/pkg/cortex/runtime_config_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
+func TestLoadRuntimeConfig_ShouldNoPanicWhenNull(t *testing.T) {
+	yamlFile := strings.NewReader(`
+null
+`)
+
+	loader := runtimeConfigLoader{cfg: Config{Target: []string{All}}}
+	_, err := loader.load(yamlFile)
+	require.NoError(t, err)
+}
+
 // Given limits are usually loaded via a config file, and that
 // a configmap is limited to 1MB, we need to minimise the limits file.
 // One way to do it is via YAML anchors.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR fixes a panic that occurs when clearing all runtime configurations via a Helm chart. The panic was caused by the runtime config being `null`. This PR adds a check to handle the null case and prevent the crash.

## How to reproduce
Clear all runtime_config in the helm chart like:
```
runtimeconfigmap:
  create: true
  annotations: {}
  runtime_config:
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
