### PR TITLE
Update readonly-ingester-scaling.md

### DIFF
--- a/website/content/en/blog/2025/readonly-ingester-scaling.md
+++ b/website/content/en/blog/2025/readonly-ingester-scaling.md
@@ -177,4 +177,4 @@ curl -X POST http://ingester-1:8080/ingester/mode -d '{"mode": "ACTIVE"}'
 
 The READONLY state improves Cortex's operational capabilities. This feature makes scaling operations safer, simpler, more flexible, and more performant than the traditional approach. Configuration changes across multiple components are no longer required - set ingesters to READONLY and remove them when convenient.
 
-For detailed information and examples, check out our [Ingesters Scaling Guide](../../docs/guides/ingesters-scaling-up-and-down/).
+For detailed information and examples, check out our [Ingesters Scaling Guide](../../../../../docs/guides/ingesters-scaling-up-and-down/).


### PR DESCRIPTION
The URLs for blog posts have YYYY/MM/DD in the path e.g. `https://cortexmetrics.io/blog/2025/10/17/introducing-readonly-state-gradual-and-safe-ingester-scaling/` which this relative link didn't account for.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
