### PR TITLE
Fix metric name validation to use correct validation scheme method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [ENHANCEMENT] Distributor: Add a label references validation for remote write v2 request. #7074
 * [ENHANCEMENT] Distributor: Add count, spans, and buckets validations for native histogram. #7072
 * [BUGFIX] Compactor: Avoid race condition which allow a grouper to not compact all partitions. #7082
+* [BUGFIX] Fix bug where validating metric names uses the wrong validation logic. #7086
 
 ## 1.20.0 in progress
 

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -286,7 +286,7 @@ func ValidateLabels(validateMetrics *ValidateMetrics, limits *Limits, userID str
 			return newNoMetricNameError()
 		}
 
-		if !nameValidationScheme.IsValidLabelName(unsafeMetricName) {
+		if !nameValidationScheme.IsValidMetricName(unsafeMetricName) {
 			validateMetrics.DiscardedSamples.WithLabelValues(invalidMetricName, userID).Inc()
 			return newInvalidMetricNameError(unsafeMetricName)
 		}

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -136,7 +136,7 @@ func TestValidateLabels(t *testing.T) {
 			}, "foo "),
 		},
 		{
-			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "valid"},
+			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "valid:name"},
 			false,
 			nil,
 		},
@@ -203,7 +203,7 @@ func TestValidateLabels(t *testing.T) {
 			# HELP cortex_label_size_bytes The combined size in bytes of all labels and label values for a time series.
 			# TYPE cortex_label_size_bytes histogram
 			cortex_label_size_bytes_bucket{user="testUser",le="+Inf"} 3
-			cortex_label_size_bytes_sum{user="testUser"} 148
+			cortex_label_size_bytes_sum{user="testUser"} 153
 			cortex_label_size_bytes_count{user="testUser"} 3
 	`), "cortex_label_size_bytes"))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Fix the metric name validation logic used by distributors when processing remote write requests, by invoking validation around metric name instead of label name.

**Which issue(s) this PR fixes**:
Fixes #7086 

**Checklist**
- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
