### PR TITLE
Change DDB kv to watch indefinetly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [ENHANCEMENT] Distributor: Add count, spans, and buckets validations for native histogram. #7072
 * [BUGFIX] Compactor: Avoid race condition which allow a grouper to not compact all partitions. #7082
 * [BUGFIX] Fix bug where validating metric names uses the wrong validation logic. #7086
+* [BUGFIX] Ring: Change DynamoDB KV to retry indefinetly for WatchKey. #7088
 
 ## 1.20.0 in progress
 

--- a/pkg/ring/kv/dynamodb/client.go
+++ b/pkg/ring/kv/dynamodb/client.go
@@ -274,7 +274,9 @@ func (c *Client) WatchKey(ctx context.Context, key string, f func(any) bool) {
 }
 
 func (c *Client) WatchPrefix(ctx context.Context, prefix string, f func(string, any) bool) {
-	bo := backoff.New(ctx, c.backoffConfig)
+	watchBackoffConfig := c.backoffConfig
+	watchBackoffConfig.MaxRetries = 0
+	bo := backoff.New(ctx, watchBackoffConfig)
 
 	for bo.Ongoing() {
 		out, _, err := c.kv.Query(ctx, dynamodbKey{

--- a/pkg/ring/kv/dynamodb/client_test.go
+++ b/pkg/ring/kv/dynamodb/client_test.go
@@ -263,8 +263,7 @@ func Test_WatchKey_UpdateStale(t *testing.T) {
 	})
 }
 
-func Test_WatchKey_NoRetries(t *testing.T) {
-	// Test that WatchKey uses MaxRetries=0 instead of CAS backoff config
+func Test_WatchKey_AlwaysRetry(t *testing.T) {
 	casBackoffConfig := backoff.Config{
 		MinBackoff: 1 * time.Millisecond,
 		MaxBackoff: 1 * time.Millisecond,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Fix DDB WatchKey to have infinite retries. The watchKey should not stop.


**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
