### PR TITLE
renaming tenantID limitations docs title

### DIFF
--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -27,8 +27,6 @@ Cortex strives to be 100% API compatible with Prometheus (under `/prometheus/*` 
 - Additional API around pushing metrics (under `/api/push`).
 - Additional API endpoints for management of Cortex itself, such as the ring.  These APIs are not part of the any compatibility guarantees.
 
-_For more information, please refer to the [limitations](../guides/limitations.md) doc._
-
 ## Experimental features
 
 Cortex is an actively developed project and we want to encourage the introduction of new features and capability.  As such, not everything in each release of Cortex is considered "production-ready". We don't provide any backwards compatibility guarantees on these and the config and flags might break.

--- a/docs/guides/authentication-and-authorisation.md
+++ b/docs/guides/authentication-and-authorisation.md
@@ -37,7 +37,7 @@ Note that the tenant ID that is used to write the series to the datastore
 should be the same as the one you use to query the data. If they don't match,
 you won't see any data. As of now, you can't see series from other tenants.
 
-For more information regarding the tenant ID limits, refer to: [Tenant ID limitations](./limitations.md#tenant-id-naming)
+For more information regarding the tenant ID naming conventions, refer to: [Tenant ID naming conventions](tenantID-naming-conventions.md#tenant-id-naming)
 
 ### Cortex-Tenant
 

--- a/docs/guides/glossary.md
+++ b/docs/guides/glossary.md
@@ -82,7 +82,7 @@ A tenant (also called "user" or "org") is the owner of a set of series written t
 For more information, please refer to:
 
 - [HTTP API authentication](../api/_index.md#authentication)
-- [Tenant ID limitations](./limitations.md#tenant-id-naming)
+- [Tenant ID naming conventions](tenantID-naming-conventions.md#tenant-id-naming)
 
 ### Time series
 

--- a/docs/guides/tenantID-naming-conventions.md
+++ b/docs/guides/tenantID-naming-conventions.md
@@ -1,16 +1,17 @@
 ---
-title: "Limitations"
-linkTitle: "Limitations"
+title: "Tenant ID Naming Conventions"
+linkTitle: "Tenant ID Naming Conventions"
 weight: 998
-slug: limitations
+slug: Tenant ID Naming Conventions
 ---
 
 ## Tenant ID naming
 
-The tenant ID (also called "user ID" or "org ID") is the unique identifier of a tenant within a Cortex cluster. The tenant ID is opaque information to Cortex, which doesn't make any assumptions on its format/content, but its naming has two limitations:
+The tenant ID (also called "user ID" or "org ID") is the unique identifier of a tenant within a Cortex cluster. The tenant ID is opaque information to Cortex, which doesn't make any assumptions on its format/content, but its naming has three limitations:
 
 1. Supported characters
-2. Length
+2. Invalid tenant IDs
+3. Length
 
 ### Supported characters
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR renames `Limitations` docs title to `Tenant ID Naming Conventions`. The `Limitations` title was too broad, as the content is specific to tenant ID naming rules. This change makes the document's purpose clearer.

To be:
<img width="1352" height="585" alt="스크린샷 2025-11-06 오후 2 37 11" src="https://github.com/user-attachments/assets/3b13dd0d-a89d-4dd9-8ae3-b1ec8cd0839a" />


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
