### PR TITLE
Add detailed block samples stats for partition compactor

### DIFF
--- a/pkg/compactor/sharded_block_populator.go
+++ b/pkg/compactor/sharded_block_populator.go
@@ -2,7 +2,6 @@ package compactor
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
 	"maps"
@@ -186,7 +185,7 @@ func (c ShardedBlockPopulator) PopulateBlock(ctx context.Context, metrics *tsdb.
 					case chunkenc.EncXOR:
 						meta.Stats.NumFloatSamples += samples
 					default:
-						return errors.Wrap(err, fmt.Sprintf("unknown chunk encoding %s", chk.Chunk.Encoding().String()))
+						return errors.Wrapf(err, "unknown chunk encoding %s", chk.Chunk.Encoding().String())
 					}
 				}
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Prometheus added more detailed histogram and float samples stats to each block metadata. This PR adds this stats to sharded block populator which is used by partitioning compactor. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
