### PR TITLE
fix panic on health check failure when using stream push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [ENHANCEMENT] Distributor: Add count, spans, and buckets validations for native histogram. #7072
 * [BUGFIX] Ring: Change DynamoDB KV to retry indefinitely for WatchKey. #7088
 * [BUGFIX] Ruler: Add XFunctions validation support. #7111
+* [BUGFIX] Distributor: Fix panic on health check failure when using stream push. #7116
 
 ## 1.20.0 2025-11-10
 

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -231,7 +231,10 @@ func (c *closableHealthAndIngesterClient) worker(ctx context.Context) error {
 			select {
 			case <-ctx.Done():
 				return
-			case job := <-c.streamPushChan:
+			case job, ok := <-c.streamPushChan:
+				if !ok {
+					return
+				}
 				err = stream.Send(job.req)
 				if err == io.EOF {
 					job.resp = &cortexpb.WriteResponse{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

I've found a panic would be occur in below scenario, and added test case to show it.
This PR adds channel close check logic to prevent the panic.

## Scenario
1. Ingester health check fail in pool
2. `closableHealthAndIngesterClient.Close()` called
3. `streamPushChan` closed
4. job is nil in `case job := <-c.streamPushChan`
5. get panic when `err = stream.Send(job.req)`

## Related logs:
```
ts=2025-11-14T17:01:37.161148853Z caller=pool.go:184 level=warn msg="removing ingester failing healthcheck" addr=10.240.7.140:9095 reason="rpc error: code = DeadlineExceeded desc = context deadline exceeded"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x25f81cc]

goroutine 292091 [running]:
github.com/cortexproject/cortex/pkg/ingester/client.(*closableHealthAndIngesterClient).worker.func1()
	/__w/cortex/cortex/pkg/ingester/client/client.go:235 +0xec
created by github.com/cortexproject/cortex/pkg/ingester/client.(*closableHealthAndIngesterClient).worker in goroutine 291921
	/__w/cortex/cortex/pkg/ingester/client/client.go:229 +0x117
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
