### PR TITLE
fix: semgrep-missing-user-entrypoint 

### DIFF
--- a/packaging/fpm/Dockerfile
+++ b/packaging/fpm/Dockerfile
@@ -13,6 +13,9 @@ RUN apk add --no-cache \
         tar \
         && gem install --no-document fpm
 
+RUN adduser -D -s /bin/sh fpm
+USER fpm
+
 COPY package.sh /
 ENTRYPOINT ["/package.sh"]
 


### PR DESCRIPTION
# Fix: Semgrep missing-user-entrypoint

## Summary
This pull request resolves the Semgrep rule violation `missing-user-entrypoint`, which warns that the Dockerfile did not specify a non-root user as the final active user. Running container processes as `root` increases security risk and may allow privilege escalation if an attacker gains control of the container.

## Change Details
### Modified File
`packaging/fpm/Dockerfile`

### Updates
- Added creation of a dedicated non-root user `fpm` using:
`RUN adduser -D -s /bin/sh fpm`
- Added:
`USER fpm`
to ensure all subsequent instructions, including the entrypoint execution, run under a non-root user.
- The entrypoint remains:
`ENTRYPOINT ["/package.sh"]`
but it now executes safely under the `fpm` user.

## Rationale
The Semgrep rule indicates that without specifying `USER`, a Docker container defaults to running as `root`, which is a security hazard. Setting a non-root user mitigates privilege escalation risks and aligns with Docker security best practices.

## Verification
- Semgrep finding is resolved.
- Dockerfile builds successfully and runs using the non-root `fpm` user.
- Entrypoint script remains executable without requiring elevated privileges.