### PR TITLE
chore: fix ReplicasNotMatchError typo

### DIFF
--- a/pkg/ha/ha_tracker.go
+++ b/pkg/ha/ha_tracker.go
@@ -486,7 +486,7 @@ type ReplicasNotMatchError struct {
 }
 
 func (e ReplicasNotMatchError) Error() string {
-	return fmt.Sprintf("replicas did not mach, rejecting sample: replica=%s, elected=%s", e.replica, e.elected)
+	return fmt.Sprintf("replicas did not match, rejecting sample: replica=%s, elected=%s", e.replica, e.elected)
 }
 
 // Needed for errors.Is to work properly.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

Fix a `ReplicasNotMatchError` typo (`mach` ->  `match`)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
