### PR TITLE
Fix flaky TestFragmenter

### DIFF
--- a/pkg/distributed_execution/plan_fragments/fragmenter_test.go
+++ b/pkg/distributed_execution/plan_fragments/fragmenter_test.go
@@ -75,8 +75,7 @@ func TestFragmenter(t *testing.T) {
 				//   0    1
 				require.Empty(t, res[0].ChildIDs)
 				require.Empty(t, res[1].ChildIDs)
-				require.Equal(t, []uint64{res[0].FragmentID, res[1].FragmentID}, res[2].ChildIDs)
-
+				require.ElementsMatch(t, []uint64{res[0].FragmentID, res[1].FragmentID}, res[2].ChildIDs)
 			} else if len(res) == 5 {
 				// current binary split:
 				// 		   4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR changes the `TestFragmenter` to use `require.ElementsMatch` to compare slices without order.

### Reason
In `PlanFragmenter`, since child fragment IDs are collected using a map (`childFragmentIDs`), the `ChildIDs` slice is non-deterministic.
```
childFragmentIDs := make(map[uint64]bool)
children := (*current).Children()

...

childIDs := make([]uint64, 0, len(childFragmentIDs))
for fragmentID := range childFragmentIDs {
	childIDs = append(childIDs, fragmentID)
}

...
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
