### PR TITLE
ResultsCache Extract Histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [BUGFIX] Querier: propagate Prometheus info annotations in protobuf responses. #7132
 * [BUGFIX] Scheduler: Fix memory leak by properly cleaning up query fragment registry. #7148
 * [BUGFIX] Compactor: Add back deletion of partition group info file even if not complete #7157
+* [BUGFIX] Query Frontend: Add Native Histogram extraction logic in results cache #7167
 
 ## 1.20.1 2025-12-03
 

--- a/pkg/querier/tripperware/queryrange/results_cache.go
+++ b/pkg/querier/tripperware/queryrange/results_cache.go
@@ -842,7 +842,17 @@ func extractSampleStream(start, end int64, stream tripperware.SampleStream) (tri
 			result.Samples = append(result.Samples, sample)
 		}
 	}
-	if len(result.Samples) == 0 {
+	if stream.Histograms != nil {
+		for _, histogram := range stream.Histograms {
+			if start <= histogram.TimestampMs && histogram.TimestampMs <= end {
+				if result.Histograms == nil {
+					result.Histograms = make([]tripperware.SampleHistogramPair, 0, len(stream.Histograms))
+				}
+				result.Histograms = append(result.Histograms, histogram)
+			}
+		}
+	}
+	if len(result.Samples) == 0 && len(result.Histograms) == 0 {
 		return tripperware.SampleStream{}, false
 	}
 	return result, true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds Native Histogram extraction logic in Results Cache.

**Which issue(s) this PR fixes**:
Currently NH extraction is missing in Extract in Result Cache. This produces incorrect results when cache is hit for queries like raw histogram queries (or with aggregation like sum).

Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
