### PR TITLE
Add graceful period for compaction groups

### DIFF
--- a/pkg/compactor/partition_compaction_grouper.go
+++ b/pkg/compactor/partition_compaction_grouper.go
@@ -283,7 +283,9 @@ func (g *PartitionCompactionGrouper) groupBlocksByRange(blocks []*metadata.Meta,
 		}
 
 		if len(group.blocks) > 1 {
-			ret = append(ret, group)
+			if time.UnixMilli(group.rangeEnd).Before(time.Now().Add(-2 * g.compactorCfg.CleanupInterval)) {
+				ret = append(ret, group)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Add graceful period for compaction groups to avoid compacting recently written blocks. The reason adding such graceful period is to reduce number of versions of partitioned grouped with same partitioned group ID. This allows grouping only starts when as many as blocks got uploaded. Also, the graceful period could reduce the race condition between the bucket index state and the real block states in bucket store.

**Which issue(s) this PR fixes**:
NA

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
