### PR TITLE
feat: add type label to cortex_discarded_samples_total metric (#6221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [BUGFIX] Scheduler: Fix memory leak by properly cleaning up query fragment registry. #7148
 * [BUGFIX] Compactor: Add back deletion of partition group info file even if not complete #7157
 * [BUGFIX] Query Frontend: Add Native Histogram extraction logic in results cache #7167
+* [ENHANCEMENT] Distributor/Ingester: Add `type` label to `cortex_discarded_samples_total` metric to distinguish between float and native histogram samples. #6221
 
 ## 1.20.1 2025-12-03
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1618,32 +1618,32 @@ func (i *Ingester) Push(ctx context.Context, req *cortexpb.WriteRequest) (*corte
 	i.metrics.ingestedExemplarsFail.Add(float64(failedExemplarsCount))
 
 	if sampleOutOfBoundsCount > 0 {
-		i.validateMetrics.DiscardedSamples.WithLabelValues(sampleOutOfBounds, userID).Add(float64(sampleOutOfBoundsCount))
+		i.validateMetrics.DiscardedSamples.WithLabelValues(sampleOutOfBounds, userID, validation.SampleTypeFloat).Add(float64(sampleOutOfBoundsCount))
 	}
 	if sampleOutOfOrderCount > 0 {
-		i.validateMetrics.DiscardedSamples.WithLabelValues(sampleOutOfOrder, userID).Add(float64(sampleOutOfOrderCount))
+		i.validateMetrics.DiscardedSamples.WithLabelValues(sampleOutOfOrder, userID, validation.SampleTypeFloat).Add(float64(sampleOutOfOrderCount))
 	}
 	if sampleTooOldCount > 0 {
-		i.validateMetrics.DiscardedSamples.WithLabelValues(sampleTooOld, userID).Add(float64(sampleTooOldCount))
+		i.validateMetrics.DiscardedSamples.WithLabelValues(sampleTooOld, userID, validation.SampleTypeFloat).Add(float64(sampleTooOldCount))
 	}
 	if newValueForTimestampCount > 0 {
-		i.validateMetrics.DiscardedSamples.WithLabelValues(newValueForTimestamp, userID).Add(float64(newValueForTimestampCount))
+		i.validateMetrics.DiscardedSamples.WithLabelValues(newValueForTimestamp, userID, validation.SampleTypeFloat).Add(float64(newValueForTimestampCount))
 	}
 	if perUserSeriesLimitCount > 0 {
-		i.validateMetrics.DiscardedSamples.WithLabelValues(perUserSeriesLimit, userID).Add(float64(perUserSeriesLimitCount))
+		i.validateMetrics.DiscardedSamples.WithLabelValues(perUserSeriesLimit, userID, validation.SampleTypeFloat).Add(float64(perUserSeriesLimitCount))
 	}
 	if perUserNativeHistogramSeriesLimitCount > 0 {
-		i.validateMetrics.DiscardedSamples.WithLabelValues(perUserNativeHistogramSeriesLimit, userID).Add(float64(perUserNativeHistogramSeriesLimitCount))
+		i.validateMetrics.DiscardedSamples.WithLabelValues(perUserNativeHistogramSeriesLimit, userID, validation.SampleTypeHistogram).Add(float64(perUserNativeHistogramSeriesLimitCount))
 	}
 	if perMetricSeriesLimitCount > 0 {
-		i.validateMetrics.DiscardedSamples.WithLabelValues(perMetricSeriesLimit, userID).Add(float64(perMetricSeriesLimitCount))
+		i.validateMetrics.DiscardedSamples.WithLabelValues(perMetricSeriesLimit, userID, validation.SampleTypeFloat).Add(float64(perMetricSeriesLimitCount))
 	}
 	if perLabelSetSeriesLimitCount > 0 {
-		i.validateMetrics.DiscardedSamples.WithLabelValues(perLabelsetSeriesLimit, userID).Add(float64(perLabelSetSeriesLimitCount))
+		i.validateMetrics.DiscardedSamples.WithLabelValues(perLabelsetSeriesLimit, userID, validation.SampleTypeFloat).Add(float64(perLabelSetSeriesLimitCount))
 	}
 
 	if !i.limits.EnableNativeHistograms(userID) && discardedNativeHistogramCount > 0 {
-		i.validateMetrics.DiscardedSamples.WithLabelValues(nativeHistogramSample, userID).Add(float64(discardedNativeHistogramCount))
+		i.validateMetrics.DiscardedSamples.WithLabelValues(nativeHistogramSample, userID, validation.SampleTypeHistogram).Add(float64(discardedNativeHistogramCount))
 	}
 
 	for h, counter := range reasonCounter.counters {


### PR DESCRIPTION
## What this PR does

Adds a `type` label to the `cortex_discarded_samples_total` metric to distinguish between float and native histogram samples.

- `type="float"` for regular float samples
- `type="histogram"` for native histogram samples

This enhancement helps operators identify whether discarded samples are floats or native histograms, improving observability when debugging data ingestion issues.

## Which issue(s) this PR fixes

Fixes #6221

## Changes

### [pkg/util/validation/validate.go](cci:7://file:///home/linux/LFX/cortex/pkg/util/validation/validate.go:0:0-0:0)
- Added `SampleTypeFloat = "float"` and `SampleTypeHistogram = "histogram"` constants
- Updated `discardedSamples` metric definition to include `"type"` label
- Updated all `DiscardedSamples.WithLabelValues` calls in [ValidateSampleTimestamp](cci:1://file:///home/linux/LFX/cortex/pkg/util/validation/validate.go:227:0-243:1), [ValidateLabels](cci:1://file:///home/linux/LFX/cortex/pkg/util/validation/validate.go:282:0-339:1), and [ValidateNativeHistogram](cci:1://file:///home/linux/LFX/cortex/pkg/util/validation/validate.go:374:0-463:1) functions

### [pkg/ingester/ingester.go](cci:7://file:///home/linux/LFX/cortex/pkg/ingester/ingester.go:0:0-0:0)
- Updated all `DiscardedSamples.WithLabelValues` calls with appropriate sample types

### [pkg/distributor/distributor.go](cci:7://file:///home/linux/LFX/cortex/pkg/distributor/distributor.go:0:0-0:0)
- Updated all `DiscardedSamples.WithLabelValues` calls
- Split combined float+histogram counts into separate calls for accurate categorization

### [pkg/util/validation/validate_test.go](cci:7://file:///home/linux/LFX/cortex/pkg/util/validation/validate_test.go:0:0-0:0)
- Updated all test assertions to expect the new `type` label

### [CHANGELOG.md](cci:7://file:///home/linux/LFX/cortex/CHANGELOG.md:0:0-0:0)
- Added enhancement entry

## Checklist

- [x] Tests updated
- [x] CHANGELOG.md updated
- [x] Documentation: N/A (no new flags/configs)

## Breaking Change Notice

> **Warning**: This is a breaking change for dashboards and alerting rules that query `cortex_discarded_samples_total`. The metric now has an additional `type` label.

### Migration Example
```promql
# Before
cortex_discarded_samples_total{reason="sample_out_of_bounds"}

# After (to get same behavior)
sum by (reason, user) (cortex_discarded_samples_total{reason="sample_out_of_bounds"})

# Or query specific type
cortex_discarded_samples_total{type="float"}
cortex_discarded_samples_total{type="histogram"}