### PR TITLE
Disable parquet projection pushdown integ test temporarily

### DIFF
--- a/integration/parquet_querier_test.go
+++ b/integration/parquet_querier_test.go
@@ -182,6 +182,8 @@ func TestParquetFuzz(t *testing.T) {
 }
 
 func TestParquetProjectionPushdownFuzz(t *testing.T) {
+	t.Skip("Disabled due to flakiness")
+
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Disable parquet projection pushdown integ test temporarily as it is very flaky.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
