### PR TITLE
Cancel compaction when visit marker detects plan inconsistency

### DIFF
--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -356,7 +356,7 @@ func (c *BlocksCleaner) cleanUpActiveUsers(ctx context.Context, users []string, 
 			return nil
 		}
 		errChan := make(chan error, 1)
-		go visitMarkerManager.HeartBeat(ctx, errChan, c.cleanerVisitMarkerFileUpdateInterval, true)
+		go visitMarkerManager.HeartBeat(ctx, func() {}, errChan, c.cleanerVisitMarkerFileUpdateInterval, true)
 		defer func() {
 			errChan <- nil
 		}()
@@ -391,7 +391,7 @@ func (c *BlocksCleaner) cleanDeletedUsers(ctx context.Context, users []string) e
 			return nil
 		}
 		errChan := make(chan error, 1)
-		go visitMarkerManager.HeartBeat(ctx, errChan, c.cleanerVisitMarkerFileUpdateInterval, true)
+		go visitMarkerManager.HeartBeat(ctx, func() {}, errChan, c.cleanerVisitMarkerFileUpdateInterval, true)
 		defer func() {
 			errChan <- nil
 		}()
@@ -439,7 +439,7 @@ func (c *BlocksCleaner) scanUsers(ctx context.Context) ([]string, []string, erro
 
 func (c *BlocksCleaner) obtainVisitMarkerManager(ctx context.Context, userLogger log.Logger, userBucket objstore.InstrumentedBucket) (visitMarkerManager *VisitMarkerManager, isVisited bool, err error) {
 	cleanerVisitMarker := NewCleanerVisitMarker(c.ringLifecyclerID)
-	visitMarkerManager = NewVisitMarkerManager(userBucket, userLogger, c.ringLifecyclerID, cleanerVisitMarker)
+	visitMarkerManager = NewVisitMarkerManager(userBucket, userLogger, c.ringLifecyclerID, cleanerVisitMarker, nil)
 
 	existingCleanerVisitMarker := &CleanerVisitMarker{}
 	err = visitMarkerManager.ReadVisitMarker(ctx, existingCleanerVisitMarker)

--- a/pkg/compactor/partition_compaction_grouper.go
+++ b/pkg/compactor/partition_compaction_grouper.go
@@ -617,7 +617,7 @@ func (g *PartitionCompactionGrouper) handleEmptyPartition(partitionedGroupInfo *
 		PartitionID:        partition.PartitionID,
 		Version:            PartitionVisitMarkerVersion1,
 	}
-	visitMarkerManager := NewVisitMarkerManager(g.bkt, g.logger, g.ringLifecyclerID, visitMarker)
+	visitMarkerManager := NewVisitMarkerManager(g.bkt, g.logger, g.ringLifecyclerID, visitMarker, nil)
 	visitMarkerManager.MarkWithStatus(g.ctx, Completed)
 
 	level.Info(g.logger).Log("msg", "handled empty block in partition", "partitioned_group_id", partitionedGroupInfo.PartitionedGroupID, "partitioned_group_creation_time", partitionedGroupInfo.CreationTimeString(), "partition_count", partitionedGroupInfo.PartitionCount, "partition_id", partition.PartitionID)
@@ -632,8 +632,8 @@ func (g *PartitionCompactionGrouper) pickPartitionCompactionJob(partitionCompact
 		partitionCount := partitionedGroup.partitionedGroupInfo.PartitionCount
 		partitionID := partitionedGroup.partition.PartitionID
 		partitionedGroupLogger := log.With(g.logger, "rangeStart", partitionedGroup.rangeStartTime().String(), "rangeEnd", partitionedGroup.rangeEndTime().String(), "rangeDuration", partitionedGroup.rangeDuration().String(), "partitioned_group_id", partitionedGroupID, "partition_id", partitionID, "partition_count", partitionCount, "group_hash", groupHash)
-		visitMarker := newPartitionVisitMarker(g.ringLifecyclerID, partitionedGroupID, partitionID)
-		visitMarkerManager := NewVisitMarkerManager(g.bkt, g.logger, g.ringLifecyclerID, visitMarker)
+		visitMarker := newPartitionVisitMarker(g.ringLifecyclerID, partitionedGroupID, partitionedGroup.partitionedGroupInfo.CreationTime, partitionID)
+		visitMarkerManager := NewVisitMarkerManager(g.bkt, g.logger, g.ringLifecyclerID, visitMarker, nil)
 		if isVisited, err := g.isGroupVisited(partitionID, visitMarkerManager); err != nil {
 			level.Warn(partitionedGroupLogger).Log("msg", "unable to check if partition is visited", "err", err, "group", partitionedGroup.String())
 			continue

--- a/pkg/compactor/partition_visit_marker.go
+++ b/pkg/compactor/partition_visit_marker.go
@@ -25,21 +25,23 @@ var (
 )
 
 type partitionVisitMarker struct {
-	CompactorID        string      `json:"compactorID"`
-	Status             VisitStatus `json:"status"`
-	PartitionedGroupID uint32      `json:"partitionedGroupID"`
-	PartitionID        int         `json:"partitionID"`
+	CompactorID                  string      `json:"compactorID"`
+	Status                       VisitStatus `json:"status"`
+	PartitionedGroupID           uint32      `json:"partitionedGroupID"`
+	PartitionedGroupCreationTime int64       `json:"partitionedGroupCreationTime"`
+	PartitionID                  int         `json:"partitionID"`
 	// VisitTime is a unix timestamp of when the partition was visited (mark updated).
 	VisitTime int64 `json:"visitTime"`
 	// Version of the file.
 	Version int `json:"version"`
 }
 
-func newPartitionVisitMarker(compactorID string, partitionedGroupID uint32, partitionID int) *partitionVisitMarker {
+func newPartitionVisitMarker(compactorID string, partitionedGroupID uint32, partitionedGroupCreationTime int64, partitionID int) *partitionVisitMarker {
 	return &partitionVisitMarker{
-		CompactorID:        compactorID,
-		PartitionedGroupID: partitionedGroupID,
-		PartitionID:        partitionID,
+		CompactorID:                  compactorID,
+		PartitionedGroupID:           partitionedGroupID,
+		PartitionedGroupCreationTime: partitionedGroupCreationTime,
+		PartitionID:                  partitionID,
 	}
 }
 

--- a/pkg/compactor/partitioned_group_info.go
+++ b/pkg/compactor/partitioned_group_info.go
@@ -137,7 +137,7 @@ func (p *PartitionedGroupInfo) getPartitionedGroupStatus(
 			PartitionedGroupID: p.PartitionedGroupID,
 			PartitionID:        partition.PartitionID,
 		}
-		visitMarkerManager := NewVisitMarkerManager(userBucket, partitionedGroupLogger, "PartitionedGroupInfo.getPartitionedGroupStatus", visitMarker)
+		visitMarkerManager := NewVisitMarkerManager(userBucket, partitionedGroupLogger, "PartitionedGroupInfo.getPartitionedGroupStatus", visitMarker, nil)
 		partitionVisitMarkerExists := true
 		if err := visitMarkerManager.ReadVisitMarker(ctx, visitMarker); err != nil {
 			if errors.Is(err, errorVisitMarkerNotFound) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR adds a compaction plan consistency check in the visit marker heartbeat and cancels the compaction context if the plan is deemed inconsistent. For partition compaction jobs, inconsistency means that the partition group info creation time recorded by the visit marker is different than the creation time for the partition group info file stored in remote storage. This could happen if the partition plan was recreated by a different compactor while the current compaction is still running.

Canceling the context will abort all compactions for the user but that's ok because Cortex only does 1 user compaction job at a time so it would only affect the current job.

**Which issue(s) this PR fixes**:
Fixes #7135

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
