### PR TITLE
Add pool for allocated queried series hash slice

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2616,7 +2616,7 @@ func (i *Ingester) queryStreamChunks(ctx context.Context, userID string, db *use
 	if db.activeQueriedSeries != nil {
 		sampled = db.activeQueriedSeries.SampleRequest()
 		if sampled {
-			queriedSeriesHashes = make([]uint64, 0, 1024) // Pre-allocate with reasonable capacity
+			queriedSeriesHashes = getQueriedSeriesHashesSlice()
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

After deploying the active queried series metric, we are seeing increased CPU spent on GC in ingester.

The root cause seems due to the series hash slice we allocate for sampled query requests. Under high TPS, the allocation can be quite a lot and cause GC pressure.

It is obvious that we started to allocate more in the `queryStreamChunks` call. The first graph is after deploying the new change and the second graph is before the deployment.

<img width="1511" height="364" alt="image" src="https://github.com/user-attachments/assets/f0424d55-efd4-4dde-9d32-32576ade6083" />

<img width="1508" height="362" alt="image" src="https://github.com/user-attachments/assets/9261fa93-cd39-4f75-b656-865ca248a60e" />

This PR tries to add a pool for the slice to reduce allocations.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
