### PR TITLE
Build: Enable unit tests on arm64 architecture

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -88,7 +88,7 @@ jobs:
       image: quay.io/cortexproject/build-image:master-8b48921f71
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup Git safe.directory
         run: |
           echo "this step is needed because when running in container, actions/checkout does not set safe.directory effectively."


### PR DESCRIPTION
**What this PR does**:
This PR updates the `test` job in the CI workflow to support ARM64 architecture, ensuring unit tests are run on both `amd64` and `arm64`.

Changes:
- Updated `.github/workflows/test-build-deploy.yml`
- Added a matrix strategy to the `test` job to run on `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64).

**Which issue(s) this PR fixes**:
Fixes #6897 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`