### PR TITLE
parquet: Remove sync map based constraint cache

### DIFF
--- a/pkg/querier/parquet_queryable.go
+++ b/pkg/querier/parquet_queryable.go
@@ -144,11 +144,6 @@ func NewParquetQueryable(
 	}
 
 	cDecoder := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
-	// This is a noop cache for now as we didn't expose any config to enable this cache.
-	rrConstraintsCache := search.NewConstraintRowRangeCacheSyncMap()
-	constraintCacheFunc := func(ctx context.Context) (search.RowRangesForConstraintsCache, error) {
-		return rrConstraintsCache, nil
-	}
 
 	parquetQueryableOpts := []queryable.QueryableOpts{
 		queryable.WithHonorProjectionHints(config.HonorProjectionHints),
@@ -278,7 +273,7 @@ func NewParquetQueryable(
 		}
 
 		return shards, errGroup.Wait()
-	}, constraintCacheFunc, cDecoder, parquetQueryableOpts...)
+	}, nil, cDecoder, parquetQueryableOpts...)
 
 	p := &parquetQueryableWithFallback{
 		subservices:           manager,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

The default sync map based constraint cache for parquet is bad as it doesn't have TTL so memory usage can grow forever.
We set it as the default because there is another flag to control whether to enable the constraint cache. But that flag seems not working. So passing constraint cache function as nil instead to not use cache.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
