### PR TITLE
making tsdbOOOHistogram metric per tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [ENHANCEMENT] Compactor: Add partition group creation time to visit marker. #7217
 * [ENHANCEMENT] Compactor: Add concurrency for partition cleanup and mark block for deletion #7246
 * [ENHANCEMENT] Distributor: Validate metric name before removing empty labels. #7253
+* [ENHANCEMENT] Make cortex_ingester_tsdb_sample_ooo_delta metric per-tenant #7278
 * [BUGFIX] Distributor: If remote write v2 is disabled, explicitly return HTTP 415 (Unsupported Media Type) for Remote Write V2 requests instead of attempting to parse them as V1. #7238
 * [BUGFIX] Ring: Change DynamoDB KV to retry indefinitely for WatchKey. #7088
 * [BUGFIX] Ruler: Add XFunctions validation support. #7111

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -621,7 +621,7 @@ func newTSDBMetrics(r prometheus.Registerer) *tsdbMetrics {
 		tsdbOOOHistogram: prometheus.NewDesc(
 			"cortex_ingester_tsdb_sample_ooo_delta",
 			"Delta in seconds by which a sample is considered out of order (reported regardless of OOO time window and whether sample is accepted or not).",
-			nil, nil),
+			[]string{"user"}, nil),
 		tsdbMmapChunksTotal: prometheus.NewDesc(
 			"cortex_ingester_tsdb_mmap_chunks_total",
 			"Total number of chunks that were memory-mapped.",
@@ -764,7 +764,7 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCountersPerUserWithLabels(out, sm.tsdbOOOSamples, "prometheus_tsdb_out_of_order_samples_total", "type")
 	data.SendSumOfCountersPerUserWithLabels(out, sm.tsdbOutOfOrderSamplesAppended, "prometheus_tsdb_head_out_of_order_samples_appended_total", "type")
 	data.SendSumOfCounters(out, sm.tsdbSnapshotReplayErrorTotal, "prometheus_tsdb_snapshot_replay_error_total")
-	data.SendSumOfHistograms(out, sm.tsdbOOOHistogram, "prometheus_tsdb_sample_ooo_delta")
+	data.SendSumOfHistogramsPerUser(out, sm.tsdbOOOHistogram, "prometheus_tsdb_sample_ooo_delta")
 	data.SendSumOfCounters(out, sm.tsdbMmapChunksTotal, "prometheus_tsdb_mmap_chunks_total")
 	data.SendSumOfCounters(out, sm.checkpointDeleteFail, "prometheus_tsdb_checkpoint_deletions_failed_total")
 	data.SendSumOfCounters(out, sm.checkpointDeleteTotal, "prometheus_tsdb_checkpoint_deletions_total")

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -505,16 +505,36 @@ func TestTSDBMetrics(t *testing.T) {
 			cortex_ingester_tsdb_reloads_total 30
         	# HELP cortex_ingester_tsdb_sample_ooo_delta Delta in seconds by which a sample is considered out of order (reported regardless of OOO time window and whether sample is accepted or not).
         	# TYPE cortex_ingester_tsdb_sample_ooo_delta histogram
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="600"} 0
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="1800"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="3600"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="7200"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="10800"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="21600"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="43200"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="+Inf"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_sum 2700
-        	cortex_ingester_tsdb_sample_ooo_delta_count 3
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="600"} 0
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="1800"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="3600"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="7200"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="10800"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="21600"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="43200"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="+Inf"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_sum{user="user1"} 900
+            cortex_ingester_tsdb_sample_ooo_delta_count{user="user1"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="600"} 0
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="1800"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="3600"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="7200"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="10800"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="21600"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="43200"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="+Inf"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_sum{user="user2"} 900
+            cortex_ingester_tsdb_sample_ooo_delta_count{user="user2"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user3",le="600"} 0
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user3",le="1800"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user3",le="3600"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user3",le="7200"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user3",le="10800"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user3",le="21600"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user3",le="43200"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user3",le="+Inf"} 1
+            cortex_ingester_tsdb_sample_ooo_delta_sum{user="user3"} 900
+            cortex_ingester_tsdb_sample_ooo_delta_count{user="user3"} 1
         	# HELP cortex_ingester_tsdb_snapshot_replay_error_total Total number snapshot replays that failed.
         	# TYPE cortex_ingester_tsdb_snapshot_replay_error_total counter
         	cortex_ingester_tsdb_snapshot_replay_error_total 309
@@ -778,16 +798,26 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 			cortex_ingester_tsdb_reloads_total 30
         	# HELP cortex_ingester_tsdb_sample_ooo_delta Delta in seconds by which a sample is considered out of order (reported regardless of OOO time window and whether sample is accepted or not).
         	# TYPE cortex_ingester_tsdb_sample_ooo_delta histogram
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="600"} 0
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="1800"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="3600"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="7200"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="10800"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="21600"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="43200"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_bucket{le="+Inf"} 3
-        	cortex_ingester_tsdb_sample_ooo_delta_sum 2700
-        	cortex_ingester_tsdb_sample_ooo_delta_count 3
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="600"} 0
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="1800"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="3600"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="7200"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="10800"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="21600"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="43200"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user1",le="+Inf"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_sum{user="user1"} 900
+        	cortex_ingester_tsdb_sample_ooo_delta_count{user="user1"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="600"} 0
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="1800"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="3600"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="7200"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="10800"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="21600"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="43200"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_bucket{user="user2",le="+Inf"} 1
+        	cortex_ingester_tsdb_sample_ooo_delta_sum{user="user2"} 900
+        	cortex_ingester_tsdb_sample_ooo_delta_count{user="user2"} 1
         	# HELP cortex_ingester_tsdb_snapshot_replay_error_total Total number snapshot replays that failed.
         	# TYPE cortex_ingester_tsdb_snapshot_replay_error_total counter
         	cortex_ingester_tsdb_snapshot_replay_error_total 309

--- a/pkg/util/metrics_helper.go
+++ b/pkg/util/metrics_helper.go
@@ -292,6 +292,16 @@ func (d MetricFamiliesPerUser) SendSumOfSummariesPerUser(out chan<- prometheus.M
 	}
 }
 
+func (d MetricFamiliesPerUser) SendSumOfHistogramsPerUser(out chan<- prometheus.Metric, desc *prometheus.Desc, histogramName string) {
+	for _, userEntry := range d {
+		if userEntry.user == "" {
+			continue
+		}
+		hd := userEntry.metrics.SumHistograms(histogramName)
+		out <- hd.Metric(desc, userEntry.user)
+	}
+}
+
 func (d MetricFamiliesPerUser) SendSumOfHistograms(out chan<- prometheus.Metric, desc *prometheus.Desc, histogramName string) {
 	hd := HistogramData{}
 	for _, userEntry := range d {


### PR DESCRIPTION
**What this PR does**:
making `tsdbOOOHistogram` metric per tenant and adding a new function `SendSumOfHistogramsPerUser` to track the metric per tenant 
**Which issue(s) this PR fixes**:
Fixes #7278 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
