### PR TITLE
Fix multi.mirror-enabled default value

### DIFF
--- a/docs/configuration/arguments.md
+++ b/docs/configuration/arguments.md
@@ -247,7 +247,7 @@ Multi KV has the following parameters:
 
 - `multi.primary` - name of primary KV store. Same values as in `ring.store` are supported, except `multi`.
 - `multi.secondary` - name of secondary KV store.
-- `multi.mirror-enabled` - enable mirroring of values to secondary store, defaults to true
+- `multi.mirror-enabled` - enable mirroring of values to secondary store, defaults to false
 - `multi.mirror-timeout` - wait max this time for write to secondary store to finish. Defaults to 2 seconds. Errors writing to secondary store are not reported to caller, but are logged and also reported via `cortex_multikv_mirror_write_errors_total` metric.
 
 Multi KV also reacts to changes done via runtime configuration. It uses this section:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR fixes the documentation's incorrect default value of `multi.mirror-enabled` to `false`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
