### PR TITLE
Make lint mandatory for integration and deploy_website

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -191,8 +191,6 @@ func main() {
 	// Initialise seed for randomness usage.
 	rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	err = nil
-
 	t, err := cortex.New(cfg)
 	util_log.CheckFatal("initializing cortex", err)
 


### PR DESCRIPTION
Makes lint mandatory for integration.

This should make it easy to spot lint bugs. As they will not allow integration tests to run without it
