### PR TITLE
Graduate instance limits from experimental

### DIFF
--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -70,7 +70,6 @@ Currently experimental features are:
   - `-tenant-federation.user-sync-interval`
 - The thanosconvert tool for converting Thanos block metadata to Cortex
 - HA Tracker: cleanup of old replicas from KV Store.
-- Instance limits in ingester and distributor
 - Exemplar storage, currently in-memory only within the Ingester based on Prometheus exemplar storage (`-blocks-storage.tsdb.max-exemplars`)
 - Querier limits:
   - `-querier.max-fetched-chunks-per-query`

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -480,10 +480,6 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 }
 
 func (d *Distributor) starting(ctx context.Context) error {
-	if d.cfg.InstanceLimits != (InstanceLimits{}) {
-		util_log.WarnExperimentalUse("distributor instance limits")
-	}
-
 	// Only report success if all sub-services start properly
 	return services.StartManagerAndAwaitHealthy(ctx, d.subservices)
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1029,11 +1029,6 @@ func (i *Ingester) stopping(_ error) error {
 }
 
 func (i *Ingester) updateLoop(ctx context.Context) error {
-	if limits := i.getInstanceLimits(); limits != nil && *limits != (InstanceLimits{}) {
-		// This check will not cover enabling instance limits in runtime, but it will do for now.
-		logutil.WarnExperimentalUse("ingester instance limits")
-	}
-
 	rateUpdateTicker := time.NewTicker(i.cfg.RateUpdatePeriod)
 	defer rateUpdateTicker.Stop()
 


### PR DESCRIPTION
## Summary
- Remove `WarnExperimentalUse("ingester instance limits")` conditional block from ingester
- Remove `WarnExperimentalUse("distributor instance limits")` conditional block from distributor
- Remove "Instance limits in ingester and distributor" from experimental features list in v1-guarantees.md

## Test plan
- [x] Verify ingester and distributor packages compile without errors
- [x] Verify v1-guarantees.md renders correctly
