### PR TITLE
Graduate tenant federation from experimental

### DIFF
--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -282,7 +282,7 @@ parquet_converter:
 tenant_federation:
   # If enabled on all Cortex services, queries can be federated across multiple
   # tenants. The tenant IDs involved need to be specified separated by a `|`
-  # character in the `X-Scope-OrgID` header (experimental).
+  # character in the `X-Scope-OrgID` header.
   # CLI flag: -tenant-federation.enabled
   [enabled: <boolean> | default = false]
 

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -65,7 +65,6 @@ Currently experimental features are:
 - The block deletion marks migration support in the compactor (`-compactor.block-deletion-marks-migration-enabled`) is temporarily and will be removed in future versions
 - Blocks storage user index
 - Querier: tenant federation
-  - `-tenant-federation.enabled`
   - `-tenant-federation.regex-matcher-enabled`
   - `-tenant-federation.user-sync-interval`
 - The thanosconvert tool for converting Thanos block metadata to Cortex

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -365,7 +365,6 @@ func New(cfg Config) (*Cortex, error) {
 
 	// Swap out the default resolver to support multiple tenant IDs separated by a '|'
 	if cfg.TenantFederation.Enabled {
-		util_log.WarnExperimentalUse("tenant-federation")
 		users.WithDefaultResolver(users.NewMultiResolver())
 	}
 

--- a/pkg/querier/tenantfederation/tenant_federation.go
+++ b/pkg/querier/tenantfederation/tenant_federation.go
@@ -19,7 +19,7 @@ type Config struct {
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.BoolVar(&cfg.Enabled, "tenant-federation.enabled", false, "If enabled on all Cortex services, queries can be federated across multiple tenants. The tenant IDs involved need to be specified separated by a `|` character in the `X-Scope-OrgID` header (experimental).")
+	f.BoolVar(&cfg.Enabled, "tenant-federation.enabled", false, "If enabled on all Cortex services, queries can be federated across multiple tenants. The tenant IDs involved need to be specified separated by a `|` character in the `X-Scope-OrgID` header.")
 	f.IntVar(&cfg.MaxConcurrent, "tenant-federation.max-concurrent", defaultMaxConcurrency, "The number of workers used to process each federated query.")
 	f.IntVar(&cfg.MaxTenant, "tenant-federation.max-tenant", 0, "A maximum number of tenants to query at once. 0 means no limit.")
 	f.BoolVar(&cfg.RegexMatcherEnabled, "tenant-federation.regex-matcher-enabled", false, "[Experimental] If enabled, the `X-Scope-OrgID` header value can accept a regex and the matched tenantIDs are automatically involved. The regex matching rule follows the Prometheus, see the detail: https://prometheus.io/docs/prometheus/latest/querying/basics/#regular-expressions. The user discovery is based on scanning block storage, so new users can get queries after uploading a block (generally 2h).")

--- a/schemas/cortex-config-schema.json
+++ b/schemas/cortex-config-schema.json
@@ -9062,7 +9062,7 @@
       "properties": {
         "enabled": {
           "default": false,
-          "description": "If enabled on all Cortex services, queries can be federated across multiple tenants. The tenant IDs involved need to be specified separated by a `|` character in the `X-Scope-OrgID` header (experimental).",
+          "description": "If enabled on all Cortex services, queries can be federated across multiple tenants. The tenant IDs involved need to be specified separated by a `|` character in the `X-Scope-OrgID` header.",
           "type": "boolean",
           "x-cli-flag": "tenant-federation.enabled"
         },


### PR DESCRIPTION
## Summary
- Remove "(experimental)" from `-tenant-federation.enabled` flag description
- Remove `WarnExperimentalUse("tenant-federation")` call from `cortex.go`
- Remove `-tenant-federation.enabled` from experimental features list in v1-guarantees.md
- The regex-matcher and user-sync-interval sub-features remain experimental

## Test plan
- [ ] Verify tenant federation and cortex packages compile without errors
- [ ] Verify v1-guarantees.md renders correctly
