### PR TITLE
Graduate stable features from experimental docs

### DIFF
--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -61,7 +61,6 @@ Currently experimental features are:
   - `-tenant-federation.regex-matcher-enabled`
   - `-tenant-federation.user-sync-interval`
 - The thanosconvert tool for converting Thanos block metadata to Cortex
-- Instance limits in ingester and distributor
 - Alertmanager limits
   - notification rate (`-alertmanager.notification-rate-limit` and `-alertmanager.notification-rate-limit-per-integration`)
   - dispatcher groups (`-alertmanager.max-dispatcher-aggregation-groups`)


### PR DESCRIPTION
## Summary
Remove the following long-stable features from the experimental features list in v1-guarantees.md (doc-only changes, no code markers remain):

- Azure blob storage
- Zone awareness based replication
- Blocksconvert tools
- Scalable query-frontend (when using query-scheduler)
- Query-frontend: query stats tracking (`-frontend.query-stats-enabled`)
- Block deletion marks migration in compactor
- HA Tracker: cleanup of old replicas from KV Store
- Exemplar storage (`-blocks-storage.tsdb.max-exemplars`)
- Querier limits (`max-fetched-chunks/bytes/series-per-query`)
- Compactor shuffle sharding

## Test plan
- [ ] Verify v1-guarantees.md renders correctly
