### PR TITLE
Add unit tests for alertspb ToProto and ParseTemplates

### DIFF
--- a/pkg/alertmanager/alertspb/compat_test.go
+++ b/pkg/alertmanager/alertspb/compat_test.go
@@ -58,9 +58,9 @@ func TestToProto(t *testing.T) {
 
 func TestParseTemplates(t *testing.T) {
 	tests := []struct {
-		name      string
-		cfg       AlertConfigDesc
-		expected  map[string]string
+		name     string
+		cfg      AlertConfigDesc
+		expected map[string]string
 	}{
 		{
 			name:     "no templates",


### PR DESCRIPTION
**What this PR does**:

Adds unit tests for `ToProto` and `ParseTemplates` in `pkg/alertmanager/alertspb`

**Which issue(s) this PR fixes**:
N/A — test coverage improvement

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`