### PR TITLE
Add unit tests for histogram proto conversions

### DIFF
--- a/pkg/cortexpb/histograms_test.go
+++ b/pkg/cortexpb/histograms_test.go
@@ -98,6 +98,8 @@ func TestFloatHistogramToHistogramProtoRoundTrip(t *testing.T) {
 	assert.Equal(t, original.NegativeBuckets, result.NegativeBuckets)
 	assert.Equal(t, original.CustomValues, result.CustomValues)
 	assert.Equal(t, timestamp, proto.TimestampMs)
+	// Catch-all: ensure no fields are missed if new fields are added to histogram.FloatHistogram.
+	assert.Equal(t, original, result)
 }
 
 func TestHistogramProtoToHistogramPanicsOnFloat(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

Adds unit tests for the histogram protobuf conversion functions in `pkg/cortexpb/histograms.go`. Tests cover round-trip conversions for both integer and float histograms, panic behavior when calling conversion functions with the wrong histogram type, `HistogramPromProtoToHistogramProto` for both int and float variants, and span conversion helpers including nil input handling.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`