### PR TITLE
Memberlist cas error code false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [BUGFIX] Metrics Helper: Fix non-deterministic bucket order in merged histograms by sorting buckets after map iteration, matching Prometheus client library behavior. #7380
 * [BUGFIX] Fix memory leak in `ReuseWriteRequestV2` by explicitly clearing the `Symbols` backing array string pointers before returning the object to `sync.Pool`. #7373
 * [BUGFIX] Distributor: Return HTTP 401 Unauthorized when tenant ID resolution fails in the Prometheus Remote Write 2.0 path. #7389
+* [BUGFIX] KV store: Fix false-positive `status_code="500"` metrics for HA tracker CAS operations when using memberlist. #7408
 
 ## 1.21.0 in progress
 

--- a/pkg/ring/kv/metrics.go
+++ b/pkg/ring/kv/metrics.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"time"
 
@@ -33,7 +34,8 @@ func getCasErrorCode(err error) string {
 
 	// If the error has been returned to abort the CAS operation, then we shouldn't
 	// consider it an error when tracking metrics.
-	if casErr, ok := err.(interface{ IsOperationAborted() bool }); ok && casErr.IsOperationAborted() {
+	var casAborted interface{ IsOperationAborted() bool }
+	if errors.As(err, &casAborted) && casAborted.IsOperationAborted() {
 		return "200"
 	}
 

--- a/pkg/ring/kv/metrics_test.go
+++ b/pkg/ring/kv/metrics_test.go
@@ -5,12 +5,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/cortexproject/cortex/pkg/ha"
 )
 
+// operationAbortedError is a local stub that mimics ha.ReplicasNotMatchError,
+// implementing IsOperationAborted() to avoid an import cycle.
+type operationAbortedError struct{}
+
+func (e operationAbortedError) Error() string            { return "operation aborted" }
+func (e operationAbortedError) IsOperationAborted() bool { return true }
+
 func TestGetCasErrorCode(t *testing.T) {
-	replicasNotMatch := ha.ReplicasNotMatchError{} // IsOperationAborted() = true
+	abortedErr := operationAbortedError{}
 
 	tests := map[string]struct {
 		err      error
@@ -20,17 +25,17 @@ func TestGetCasErrorCode(t *testing.T) {
 			err:      nil,
 			expected: "200",
 		},
-		"ReplicasNotMatchError (direct)": {
-			err:      replicasNotMatch,
+		"operation aborted error (direct)": {
+			err:      abortedErr,
 			expected: "200",
 		},
-		"ReplicasNotMatchError (single-wrapped by memberlist)": {
-			err:      fmt.Errorf("fn returned error: %w", replicasNotMatch),
+		"operation aborted error (single-wrapped by memberlist)": {
+			err:      fmt.Errorf("fn returned error: %w", abortedErr),
 			expected: "200",
 		},
-		"ReplicasNotMatchError (double-wrapped by memberlist)": {
+		"operation aborted error (double-wrapped by memberlist)": {
 			err: fmt.Errorf("failed to CAS-update key X: %w",
-				fmt.Errorf("fn returned error: %w", replicasNotMatch)),
+				fmt.Errorf("fn returned error: %w", abortedErr)),
 			expected: "200",
 		},
 		"generic error": {

--- a/pkg/ring/kv/metrics_test.go
+++ b/pkg/ring/kv/metrics_test.go
@@ -1,0 +1,47 @@
+package kv
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cortexproject/cortex/pkg/ha"
+)
+
+func TestGetCasErrorCode(t *testing.T) {
+	replicasNotMatch := ha.ReplicasNotMatchError{} // IsOperationAborted() = true
+
+	tests := map[string]struct {
+		err      error
+		expected string
+	}{
+		"nil error": {
+			err:      nil,
+			expected: "200",
+		},
+		"ReplicasNotMatchError (direct)": {
+			err:      replicasNotMatch,
+			expected: "200",
+		},
+		"ReplicasNotMatchError (single-wrapped by memberlist)": {
+			err:      fmt.Errorf("fn returned error: %w", replicasNotMatch),
+			expected: "200",
+		},
+		"ReplicasNotMatchError (double-wrapped by memberlist)": {
+			err: fmt.Errorf("failed to CAS-update key X: %w",
+				fmt.Errorf("fn returned error: %w", replicasNotMatch)),
+			expected: "200",
+		},
+		"generic error": {
+			err:      fmt.Errorf("some real error"),
+			expected: "500",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, getCasErrorCode(tc.err))
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

`getCasErrorCode` used a direct type assertion to detect `IsOperationAborted()`, which fails when the error is wrapped by memberlist's `trySingleCas`:

```
  fmt.Errorf("fn returned error: %w", err)          // 1st wrap
  fmt.Errorf("failed to CAS-update key %s: %w", ...) // 2nd wrap
```

This caused `ReplicasNotMatchError` (normal HA deduplication) to be reported as status_code="500" in `cortex_kv_request_duration_seconds` when using `memberlist` as the HA tracker KV store, triggering false-positive `CortexKVStoreFailure` alerts.

Note: consul and etcd are unaffected because they return the callback error directly without wrapping (`return err`), so the direct type assertion worked correctly for those backends.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
