### PR TITLE
Equalize benchmark cleanup and add fixed_capacity_2048 baseline for symbol pooling comparison

### DIFF
--- a/pkg/cortexpb/timeseriesv2_test.go
+++ b/pkg/cortexpb/timeseriesv2_test.go
@@ -240,7 +240,7 @@ func BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic(b *testing.B)
 			})
 
 			b.Run("fixed_capacity", func(b *testing.B) {
-				pool := sync.Pool{
+				fixedPool := sync.Pool{
 					New: func() any {
 						return &PreallocWriteRequestV2{
 							WriteRequestV2: WriteRequestV2{
@@ -254,22 +254,74 @@ func BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic(b *testing.B)
 				var idx int
 				for b.Loop() {
 					if idx > 0 && idx%gcInterval == 0 {
-						runtime.GC() // Periodically run GC to simulate real-world conditions where the pool may be emptied.
+						runtime.GC()
 					}
-					req := pool.Get().(*PreallocWriteRequestV2)
+					req := fixedPool.Get().(*PreallocWriteRequestV2)
 					req.Symbols = append(req.Symbols, variants[idx%numVariants]...)
 					idx++
 
-					if int64(cap(req.Symbols)) > maxSymbolsCapacity {
-						// Discard this request instead of putting it back into the pool to let GC reclaim it like the dynamic way.
+					// Same cleanup as ReuseWriteRequestV2, minus the EMA update.
+					req.Source = 0
+					symbolsCap := int64(cap(req.Symbols))
+					if symbolsCap > maxSymbolsCapacity {
+						if req.Timeseries != nil {
+							ReuseSliceV2(req.Timeseries)
+							req.Timeseries = nil
+						}
 						continue
 					}
-
 					for i := range req.Symbols {
 						req.Symbols[i] = ""
 					}
 					req.Symbols = req.Symbols[:0]
-					pool.Put(req)
+					if req.Timeseries != nil {
+						ReuseSliceV2(req.Timeseries)
+						req.Timeseries = nil
+					}
+					fixedPool.Put(req)
+				}
+			})
+
+			b.Run("fixed_capacity_2048", func(b *testing.B) {
+				fixedPool2048 := sync.Pool{
+					New: func() any {
+						return &PreallocWriteRequestV2{
+							WriteRequestV2: WriteRequestV2{
+								Symbols: make([]string, 0, 2048),
+							},
+						}
+					},
+				}
+
+				b.ReportAllocs()
+				var idx int
+				for b.Loop() {
+					if idx > 0 && idx%gcInterval == 0 {
+						runtime.GC()
+					}
+					req := fixedPool2048.Get().(*PreallocWriteRequestV2)
+					req.Symbols = append(req.Symbols, variants[idx%numVariants]...)
+					idx++
+
+					// Same cleanup as ReuseWriteRequestV2, minus the EMA update.
+					req.Source = 0
+					symbolsCap := int64(cap(req.Symbols))
+					if symbolsCap > maxSymbolsCapacity {
+						if req.Timeseries != nil {
+							ReuseSliceV2(req.Timeseries)
+							req.Timeseries = nil
+						}
+						continue
+					}
+					for i := range req.Symbols {
+						req.Symbols[i] = ""
+					}
+					req.Symbols = req.Symbols[:0]
+					if req.Timeseries != nil {
+						ReuseSliceV2(req.Timeseries)
+						req.Timeseries = nil
+					}
+					fixedPool2048.Put(req)
 				}
 			})
 		})

--- a/pkg/cortexpb/timeseriesv2_test.go
+++ b/pkg/cortexpb/timeseriesv2_test.go
@@ -1,6 +1,9 @@
 package cortexpb
 
 import (
+	"fmt"
+	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -180,6 +183,95 @@ func BenchmarkMarshallWriteRequestV2(b *testing.B) {
 				tc.clean(w)
 			}
 			b.ReportAllocs()
+		})
+	}
+}
+
+func BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic(b *testing.B) {
+	const (
+		numVariants = 10
+		gcInterval  = 100
+	)
+
+	scenarios := []struct {
+		name                 string
+		symbolMin, symbolMax int
+	}{
+		{"symbol_range_200_2000", 200, 2000},
+		{"symbol_range_1000_6000", 1000, 6000},
+		{"symbol_range_1000_20000 (exceed maxSymbolsCapacity)", 1000, 20000},
+	}
+
+	for _, sc := range scenarios {
+		variants := make([][]string, numVariants)
+		for i := range numVariants {
+			size := sc.symbolMin + (sc.symbolMax-sc.symbolMin)*i/(numVariants-1)
+			syms := make([]string, size)
+			for j := range syms {
+				syms[j] = fmt.Sprintf("label_%04d", j)
+			}
+			variants[i] = syms
+		}
+
+		b.Run(sc.name, func(b *testing.B) {
+			b.Run("dynamic_capacity", func(b *testing.B) {
+				saved := dynamicSymbolsCapacity.Load()
+				dynamicSymbolsCapacity.Store(int64(initialSymbolsCapacity))
+				defer dynamicSymbolsCapacity.Store(saved)
+
+				// Converge EMA to ensure dynamic capacity is adjusted to the range of variants.
+				for i := range 100 * numVariants {
+					req := PreallocWriteRequestV2FromPool()
+					req.Symbols = append(req.Symbols, variants[i%numVariants]...)
+					ReuseWriteRequestV2(req)
+				}
+
+				b.ReportAllocs()
+				var idx int
+				for b.Loop() {
+					if idx > 0 && idx%gcInterval == 0 {
+						runtime.GC() // Periodically run GC to simulate real-world conditions where the pool may be emptied.
+					}
+					req := PreallocWriteRequestV2FromPool()
+					req.Symbols = append(req.Symbols, variants[idx%numVariants]...)
+					idx++
+					ReuseWriteRequestV2(req)
+				}
+			})
+
+			b.Run("fixed_capacity", func(b *testing.B) {
+				pool := sync.Pool{
+					New: func() any {
+						return &PreallocWriteRequestV2{
+							WriteRequestV2: WriteRequestV2{
+								Symbols: make([]string, 0, initialSymbolsCapacity),
+							},
+						}
+					},
+				}
+
+				b.ReportAllocs()
+				var idx int
+				for b.Loop() {
+					if idx > 0 && idx%gcInterval == 0 {
+						runtime.GC() // Periodically run GC to simulate real-world conditions where the pool may be emptied.
+					}
+					req := pool.Get().(*PreallocWriteRequestV2)
+					req.Symbols = append(req.Symbols, variants[idx%numVariants]...)
+					idx++
+
+					if int64(cap(req.Symbols)) > maxSymbolsCapacity {
+						// Discard this request instead of putting it back into the pool to let GC reclaim it like the dynamic way.
+						continue
+					}
+
+					for i := range req.Symbols {
+						req.Symbols[i] = ""
+					}
+					req.Symbols = req.Symbols[:0]
+					pool.Put(req)
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
Attempting to help with https://github.com/cortexproject/cortex/pull/7403
```
root@235e43ef4223:/go/src/github.com/cortexproject/cortex# go test ./pkg/cortexpb/... -run=^$ -bench=BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic -benchtime=3s -count=1
goos: linux
goarch: arm64
pkg: github.com/cortexproject/cortex/pkg/cortexpb
BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic/symbol_range_200_2000/dynamic_capacity-8         	 1000000	      3070 ns/op	     321 B/op	       0 allocs/op
BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic/symbol_range_200_2000/fixed_capacity-8           	 1000000	      3214 ns/op	     751 B/op	       0 allocs/op
BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic/symbol_range_200_2000/fixed_capacity_2048-8      	 1000000	      3226 ns/op	     261 B/op	       0 allocs/op
BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic/symbol_range_1000_6000/dynamic_capacity-8        	  654306	      5308 ns/op	     896 B/op	       0 allocs/op
BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic/symbol_range_1000_6000/fixed_capacity-8          	  662565	      5494 ns/op	    2753 B/op	       0 allocs/op
BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic/symbol_range_1000_6000/fixed_capacity_2048-8     	  638114	      5541 ns/op	    2658 B/op	       0 allocs/op
BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic/symbol_range_1000_20000_(exceed_maxSymbolsCapacity)/dynamic_capacity-8         	   72409	     50047 ns/op	  222941 B/op	       2 allocs/op
BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic/symbol_range_1000_20000_(exceed_maxSymbolsCapacity)/fixed_capacity-8           	   70707	     50299 ns/op	  176790 B/op	       2 allocs/op
BenchmarkWriteRequestV2Pool_CompareFixedSymbolCapaWithDynamic/symbol_range_1000_20000_(exceed_maxSymbolsCapacity)/fixed_capacity_2048-8      	   74072	     47956 ns/op	  197536 B/op	       2 allocs/op
PASS
ok  	github.com/cortexproject/cortex/pkg/cortexpb	30.961s
root@235e43ef4223:/go/src/github.com/cortexproject/cortex# 

```