### PR TITLE
Add CI job to stress-test changed Go packages on PRs

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -97,6 +97,53 @@ jobs:
       - name: Run Tests
         run: make BUILD_IN_CONTAINER=false test-no-race
 
+  test-stress:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    container:
+      image: quay.io/cortexproject/build-image:master-fe84258322
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+      - name: Setup Git safe.directory
+        run: |
+          echo "this step is needed because when running in container, actions/checkout does not set safe.directory effectively."
+          echo "See https://github.com/actions/runner/issues/2033. We should use --system instead of --global"
+          git config --system --add safe.directory $GITHUB_WORKSPACE
+      - name: Sym Link Expected Path to Workspace
+        run: |
+          mkdir -p /go/src/github.com/cortexproject/cortex
+          ln -s $GITHUB_WORKSPACE/* /go/src/github.com/cortexproject/cortex
+      - name: Detect Changed Packages
+        id: detect
+        run: |
+          CHANGED_GO_FILES=$(git diff --name-only origin/$GITHUB_BASE_REF...HEAD -- '*.go' | grep -v '^vendor/' | grep -v '^integration/' || true)
+          if [ -z "$CHANGED_GO_FILES" ]; then
+            echo "No non-vendor, non-integration Go files changed."
+            echo "packages=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Extract unique directories from changed Go files
+          CHANGED_DIRS=$(echo "$CHANGED_GO_FILES" | xargs -I{} dirname {} | sort -u)
+          # Keep only directories that contain test files
+          PACKAGES=""
+          for dir in $CHANGED_DIRS; do
+            if ls "$dir"/*_test.go 1>/dev/null 2>&1; then
+              PACKAGES="$PACKAGES ./$dir"
+            fi
+          done
+          PACKAGES=$(echo "$PACKAGES" | xargs)
+          echo "Detected testable packages: $PACKAGES"
+          echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
+      - name: Run Stress Tests
+        if: steps.detect.outputs.packages != ''
+        run: make BUILD_IN_CONTAINER=false test-stress
+        env:
+          STRESS_TEST_PACKAGES: ${{ steps.detect.outputs.packages }}
+
   security:
     name: CodeQL
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # WARNING: do not commit to a repository!
 -include Makefile.local
 
-.PHONY: all test cover clean images protos exes dist doc clean-doc check-doc push-multiarch-build-image
+.PHONY: all test test-stress cover clean images protos exes dist doc clean-doc check-doc push-multiarch-build-image
 .DEFAULT_GOAL := all
 
 # Version number
@@ -126,7 +126,7 @@ GOVOLUMES=	-v $(shell pwd)/.cache:/go/cache:delegated,z \
 			-v $(shell pwd)/.pkg:/go/pkg:delegated,z \
 			-v $(shell pwd):/go/src/github.com/cortexproject/cortex:delegated,z
 
-exes $(EXES) protos $(PROTO_GOS) lint test cover shell mod-check check-protos doc modernize: build-image/$(UPTODATE)
+exes $(EXES) protos $(PROTO_GOS) lint test test-stress cover shell mod-check check-protos doc modernize: build-image/$(UPTODATE)
 	@mkdir -p $(shell pwd)/.pkg
 	@mkdir -p $(shell pwd)/.cache
 	@echo
@@ -217,6 +217,14 @@ test:
 
 test-no-race:
 	go test -tags "netgo slicelabels" -timeout 30m -count 1 ./...
+
+test-stress:
+	@if [ -z "$(STRESS_TEST_PACKAGES)" ]; then \
+		echo "No packages to stress test."; \
+	else \
+		echo "Stress testing packages: $(STRESS_TEST_PACKAGES)"; \
+		go test -tags "netgo slicelabels" -timeout 30m -count 5 -v $(STRESS_TEST_PACKAGES); \
+	fi
 
 cover:
 	$(eval COVERDIR := $(shell mktemp -d coverage.XXXXXXXXXX))


### PR DESCRIPTION
## Summary
- Adds a PR-only, non-blocking (`continue-on-error: true`) CI job that detects which Go packages changed and reruns their tests with `-count 5` to catch flaky/non-deterministic failures before merge
- Adds a `test-stress` Makefile target that accepts `STRESS_TEST_PACKAGES` and runs them without `-race` (the main `test` job already covers that)
- Detection filters out `vendor/` and `integration/` directories and only tests packages containing `_test.go` files

## Test plan
- [ ] Open this PR and verify the `test-stress` job appears in the CI checks
- [ ] Verify it detects the changed Makefile/workflow files correctly (should find no testable Go packages and skip)
- [ ] Push a trivial Go test file change and verify it runs stress tests on the correct package
- [ ] Verify a PR with only non-Go file changes skips the test step gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)