### PR TITLE
Add wal record metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 * [FEATURE] Distributor: Add experimental `-distributor.enable-start-timestamp` flag for Prometheus Remote Write 2.0. When enabled, `StartTimestamp (ST)` is ingested. #7371
 * [FEATURE] Memberlist: Add `-memberlist.cluster-label` and `-memberlist.cluster-label-verification-disabled` to prevent accidental cross-cluster gossip joins and support rolling label rollout. #7385
+* [ENHANCEMENT] Ingester: Add WAL record metrics to help evaluate the effectiveness of WAL compression type (e.g. snappy, zstd): `cortex_ingester_tsdb_wal_record_part_writes_total`, `cortex_ingester_tsdb_wal_record_parts_bytes_written_total`, and `cortex_ingester_tsdb_wal_record_bytes_saved_total`. #7420
 * [ENHANCEMENT] Distributor: Introduce dynamic `Symbols` slice capacity pooling. #7398 #7401
 * [ENHANCEMENT] Metrics Helper: Add native histogram support for aggregating and merging, including dual-format histogram handling that exposes both native and classic bucket formats. #7359
 * [ENHANCEMENT] Cache: Add per-tenant TTL configuration for query results cache to control cache expiration on a per-tenant basis with separate TTLs for regular and out-of-order data. #7357

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -453,6 +453,11 @@ type tsdbMetrics struct {
 	checkpointCreationFail  *prometheus.Desc
 	checkpointCreationTotal *prometheus.Desc
 
+	// WAL record part metrics
+	tsdbWALRecordPartWritesTotal *prometheus.Desc
+	tsdbWALRecordPartBytesTotal  *prometheus.Desc
+	tsdbWALRecordBytesSaved      *prometheus.Desc
+
 	// These two metrics replace metrics in ingesterMetrics, as we count them differently
 	memSeriesCreatedTotal *prometheus.Desc
 	memSeriesRemovedTotal *prometheus.Desc
@@ -532,6 +537,7 @@ func newTSDBMetrics(r prometheus.Registerer) *tsdbMetrics {
 			"cortex_ingester_tsdb_wal_writes_failed_total",
 			"Total number of TSDB WAL writes that failed.",
 			nil, nil),
+
 		tsdbHeadTruncateFail: prometheus.NewDesc(
 			"cortex_ingester_tsdb_head_truncations_failed_total",
 			"Total number of TSDB head truncations that failed.",
@@ -620,6 +626,18 @@ func newTSDBMetrics(r prometheus.Registerer) *tsdbMetrics {
 			"cortex_ingester_tsdb_checkpoint_creations_total",
 			"Total number of TSDB checkpoint creations attempted.",
 			nil, nil),
+		tsdbWALRecordPartWritesTotal: prometheus.NewDesc(
+			"cortex_ingester_tsdb_wal_record_part_writes_total",
+			"Total number of WAL record parts written before flushing.",
+			nil, nil),
+		tsdbWALRecordPartBytesTotal: prometheus.NewDesc(
+			"cortex_ingester_tsdb_wal_record_parts_bytes_written_total",
+			"Total number of WAL record part bytes written before flushing, including CRC and compression headers.",
+			nil, nil),
+		tsdbWALRecordBytesSaved: prometheus.NewDesc(
+			"cortex_ingester_tsdb_wal_record_bytes_saved_total",
+			"Total number of bytes saved by the optional WAL record compression.",
+			[]string{"compression"}, nil),
 		tsdbSamplesAppended: prometheus.NewDesc(
 			"cortex_ingester_tsdb_head_samples_appended_total",
 			"Total number of appended samples.",
@@ -728,6 +746,10 @@ func (sm *tsdbMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- sm.checkpointCreationFail
 	out <- sm.checkpointCreationTotal
 
+	out <- sm.tsdbWALRecordPartWritesTotal
+	out <- sm.tsdbWALRecordPartBytesTotal
+	out <- sm.tsdbWALRecordBytesSaved
+
 	out <- sm.tsdbExemplarsTotal
 	out <- sm.tsdbExemplarsInStorage
 	out <- sm.tsdbExemplarSeriesInStorage
@@ -788,6 +810,9 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCounters(out, sm.checkpointDeleteTotal, "prometheus_tsdb_checkpoint_deletions_total")
 	data.SendSumOfCounters(out, sm.checkpointCreationFail, "prometheus_tsdb_checkpoint_creations_failed_total")
 	data.SendSumOfCounters(out, sm.checkpointCreationTotal, "prometheus_tsdb_checkpoint_creations_total")
+	data.SendSumOfCounters(out, sm.tsdbWALRecordPartWritesTotal, "prometheus_tsdb_wal_record_part_writes_total")
+	data.SendSumOfCounters(out, sm.tsdbWALRecordPartBytesTotal, "prometheus_tsdb_wal_record_parts_bytes_written_total")
+	data.SendSumOfCountersWithLabels(out, sm.tsdbWALRecordBytesSaved, "prometheus_tsdb_wal_record_bytes_saved_total", "compression")
 	data.SendSumOfCounters(out, sm.tsdbExemplarsTotal, "prometheus_tsdb_exemplar_exemplars_appended_total")
 	data.SendSumOfGauges(out, sm.tsdbExemplarsInStorage, "prometheus_tsdb_exemplar_exemplars_in_storage")
 	data.SendSumOfGaugesPerUser(out, sm.tsdbExemplarSeriesInStorage, "prometheus_tsdb_exemplar_series_with_exemplars_in_storage")

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -445,6 +445,23 @@ func TestTSDBMetrics(t *testing.T) {
 			# TYPE cortex_ingester_tsdb_checkpoint_creations_total counter
 			cortex_ingester_tsdb_checkpoint_creations_total 1883489
 
+			# HELP cortex_ingester_tsdb_wal_record_part_writes_total Total number of WAL record parts written before flushing.
+			# TYPE cortex_ingester_tsdb_wal_record_part_writes_total counter
+			# 32*(12345 + 85787 + 999)
+			cortex_ingester_tsdb_wal_record_part_writes_total 3172192
+
+			# HELP cortex_ingester_tsdb_wal_record_parts_bytes_written_total Total number of WAL record part bytes written before flushing, including CRC and compression headers.
+			# TYPE cortex_ingester_tsdb_wal_record_parts_bytes_written_total counter
+			# 33*(12345 + 85787 + 999)
+			cortex_ingester_tsdb_wal_record_parts_bytes_written_total 3271323
+
+			# HELP cortex_ingester_tsdb_wal_record_bytes_saved_total Total number of bytes saved by the optional WAL record compression.
+			# TYPE cortex_ingester_tsdb_wal_record_bytes_saved_total counter
+			# 34*(12345 + 85787 + 999)
+			cortex_ingester_tsdb_wal_record_bytes_saved_total{compression="snappy"} 3370454
+			# 35*(12345 + 85787 + 999)
+			cortex_ingester_tsdb_wal_record_bytes_saved_total{compression="zstd"} 3469585
+
 			# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
 			# TYPE cortex_ingester_memory_series_created_total counter
 			# 5 * (12345, 85787 and 999 respectively)
@@ -743,6 +760,23 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 			# HELP cortex_ingester_tsdb_checkpoint_creations_total Total number of TSDB checkpoint creations attempted.
 			# TYPE cortex_ingester_tsdb_checkpoint_creations_total counter
 			cortex_ingester_tsdb_checkpoint_creations_total 1883489
+
+			# HELP cortex_ingester_tsdb_wal_record_part_writes_total Total number of WAL record parts written before flushing.
+			# TYPE cortex_ingester_tsdb_wal_record_part_writes_total counter
+			# 32*(12345 + 85787 + 999) - counter retained after user3 removal
+			cortex_ingester_tsdb_wal_record_part_writes_total 3172192
+
+			# HELP cortex_ingester_tsdb_wal_record_parts_bytes_written_total Total number of WAL record part bytes written before flushing, including CRC and compression headers.
+			# TYPE cortex_ingester_tsdb_wal_record_parts_bytes_written_total counter
+			# 33*(12345 + 85787 + 999) - counter retained after user3 removal
+			cortex_ingester_tsdb_wal_record_parts_bytes_written_total 3271323
+
+			# HELP cortex_ingester_tsdb_wal_record_bytes_saved_total Total number of bytes saved by the optional WAL record compression.
+			# TYPE cortex_ingester_tsdb_wal_record_bytes_saved_total counter
+			# 34*(12345 + 85787 + 999) - counter retained after user3 removal
+			cortex_ingester_tsdb_wal_record_bytes_saved_total{compression="snappy"} 3370454
+			# 35*(12345 + 85787 + 999) - counter retained after user3 removal
+			cortex_ingester_tsdb_wal_record_bytes_saved_total{compression="zstd"} 3469585
 
 			# HELP cortex_ingester_memory_series_created_total The total number of series that were created per user.
 			# TYPE cortex_ingester_memory_series_created_total counter
@@ -1207,6 +1241,27 @@ func populateTSDBMetrics(base float64) *prometheus.Registry {
 		Help: "Total number of stale series in the head block.",
 	})
 	headStaleSeries.Set(31 * base)
+
+	recordPartWrites := promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_wal_record_part_writes_total",
+		Help: "Total number of record parts written before flushing.",
+	})
+	recordPartWrites.Add(32 * base)
+
+	recordPartBytes := promauto.With(r).NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_wal_record_parts_bytes_written_total",
+		Help: "Total number of record part bytes written before flushing, including" +
+			" CRC and compression headers.",
+	})
+	recordPartBytes.Add(33 * base)
+
+	recordBytesSaved := promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_wal_record_bytes_saved_total",
+		Help: "Total number of bytes saved by the optional record compression." +
+			" Use this metric to learn about the effectiveness compression.",
+	}, []string{"compression"})
+	recordBytesSaved.WithLabelValues("snappy").Add(34 * base)
+	recordBytesSaved.WithLabelValues("zstd").Add(35 * base)
 
 	return r
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

In #6232,  the `zstd` wal compression type has been added. In this PR, the three WAL record metrics are added to help evaluate the effectiveness of WAL compression type (snappy, zstd) and improve observability for the effectiveness of WAL compression.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
