### PR TITLE
Backport: Fix false-positive CAS error metrics with memberlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 1.21.0 in progress
 
+* [BUGFIX] KV store: Fix false-positive `status_code="500"` metrics for HA tracker CAS operations when using memberlist. #7408
+
 * [CHANGE] Ruler: Graduate Ruler API from experimental. #7312
   * Flag: Renamed `-experimental.ruler.enable-api` to `-ruler.enable-api`. The old flag is kept as deprecated.
   * Ruler API is no longer marked as experimental.

--- a/pkg/ring/kv/metrics.go
+++ b/pkg/ring/kv/metrics.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"time"
 
@@ -33,7 +34,8 @@ func getCasErrorCode(err error) string {
 
 	// If the error has been returned to abort the CAS operation, then we shouldn't
 	// consider it an error when tracking metrics.
-	if casErr, ok := err.(interface{ IsOperationAborted() bool }); ok && casErr.IsOperationAborted() {
+	var casAborted interface{ IsOperationAborted() bool }
+	if errors.As(err, &casAborted) && casAborted.IsOperationAborted() {
 		return "200"
 	}
 

--- a/pkg/ring/kv/metrics_test.go
+++ b/pkg/ring/kv/metrics_test.go
@@ -1,0 +1,52 @@
+package kv
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// operationAbortedError is a local stub that mimics ha.ReplicasNotMatchError,
+// implementing IsOperationAborted() to avoid an import cycle.
+type operationAbortedError struct{}
+
+func (e operationAbortedError) Error() string            { return "operation aborted" }
+func (e operationAbortedError) IsOperationAborted() bool { return true }
+
+func TestGetCasErrorCode(t *testing.T) {
+	abortedErr := operationAbortedError{}
+
+	tests := map[string]struct {
+		err      error
+		expected string
+	}{
+		"nil error": {
+			err:      nil,
+			expected: "200",
+		},
+		"operation aborted error (direct)": {
+			err:      abortedErr,
+			expected: "200",
+		},
+		"operation aborted error (single-wrapped by memberlist)": {
+			err:      fmt.Errorf("fn returned error: %w", abortedErr),
+			expected: "200",
+		},
+		"operation aborted error (double-wrapped by memberlist)": {
+			err: fmt.Errorf("failed to CAS-update key X: %w",
+				fmt.Errorf("fn returned error: %w", abortedErr)),
+			expected: "200",
+		},
+		"generic error": {
+			err:      fmt.Errorf("some real error"),
+			expected: "500",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, getCasErrorCode(tc.err))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Cherry-pick of #7408 to `release-1.21`
- Fixes false-positive `status_code="500"` metrics for HA tracker CAS operations when using memberlist by using `errors.As` to properly unwrap memberlist-wrapped errors in `getCasErrorCode`

## Test plan
- [ ] CI passes
- [ ] Verify `getCasErrorCode` returns `"200"` for wrapped `IsOperationAborted` errors