### PR TITLE
Backport bug fixes to release-1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 1.21.0 in progress
 
+* [BUGFIX] KV store: Fix false-positive `status_code="500"` metrics for HA tracker CAS operations when using memberlist. #7408
+
 * [CHANGE] Ruler: Graduate Ruler API from experimental. #7312
   * Flag: Renamed `-experimental.ruler.enable-api` to `-ruler.enable-api`. The old flag is kept as deprecated.
   * Ruler API is no longer marked as experimental.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [BUGFIX] KV store: Fix false-positive `status_code="500"` metrics for HA tracker CAS operations when using memberlist. #7408
 * [BUGFIX] Fix nil when ingester_query_max_attempts > 1. #7369
+* [BUGFIX] Alertmanager: Fix disappearing user config and state when ring is temporarily unreachable. #7372
 
 * [CHANGE] Ruler: Graduate Ruler API from experimental. #7312
   * Flag: Renamed `-experimental.ruler.enable-api` to `-ruler.enable-api`. The old flag is kept as deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 1.21.0 in progress
 
 * [BUGFIX] KV store: Fix false-positive `status_code="500"` metrics for HA tracker CAS operations when using memberlist. #7408
+* [BUGFIX] Fix nil when ingester_query_max_attempts > 1. #7369
 
 * [CHANGE] Ruler: Graduate Ruler API from experimental. #7312
   * Flag: Renamed `-experimental.ruler.enable-api` to `-ruler.enable-api`. The old flag is kept as deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [BUGFIX] KV store: Fix false-positive `status_code="500"` metrics for HA tracker CAS operations when using memberlist. #7408
 * [BUGFIX] Fix nil when ingester_query_max_attempts > 1. #7369
 * [BUGFIX] Alertmanager: Fix disappearing user config and state when ring is temporarily unreachable. #7372
+* [BUGFIX] Fix memory leak in `ReuseWriteRequestV2` by explicitly clearing the `Symbols` backing array string pointers before returning the object to `sync.Pool`. #7373
 
 * [CHANGE] Ruler: Graduate Ruler API from experimental. #7312
   * Flag: Renamed `-experimental.ruler.enable-api` to `-ruler.enable-api`. The old flag is kept as deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 1.21.0 in progress
 
+* [BUGFIX] Tenant Federation: Fix `unsupported character` error when `tenant-federation.regex-matcher-enabled` is enabled and the input regex matches 0 or 1 existing tenant. #7424
 * [BUGFIX] KV store: Fix false-positive `status_code="500"` metrics for HA tracker CAS operations when using memberlist. #7408
 * [BUGFIX] Fix nil when ingester_query_max_attempts > 1. #7369
 * [BUGFIX] Alertmanager: Fix disappearing user config and state when ring is temporarily unreachable. #7372

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * [BUGFIX] Fix nil when ingester_query_max_attempts > 1. #7369
 * [BUGFIX] Alertmanager: Fix disappearing user config and state when ring is temporarily unreachable. #7372
 * [BUGFIX] Fix memory leak in `ReuseWriteRequestV2` by explicitly clearing the `Symbols` backing array string pointers before returning the object to `sync.Pool`. #7373
+* [BUGFIX] Querier: Fix queryWithRetry and labelsWithRetry returning (nil, nil) on cancelled context by propagating ctx.Err(). #7375
+* [BUGFIX] Fix memory leak in `ReuseWriteRequestV2` by explicitly clearing the `Symbols` backing array string pointers before returning the object to `sync.Pool`. #7373
 
 * [CHANGE] Ruler: Graduate Ruler API from experimental. #7312
   * Flag: Renamed `-experimental.ruler.enable-api` to `-ruler.enable-api`. The old flag is kept as deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 1.21.0 in progress
 
+* [BUGFIX] Memberlist: Skip nil values delivered by `WatchPrefix` when a key is deleted, preventing a panic in the HA tracker caused by a failed type assertion on a nil interface value. #7429
 * [BUGFIX] Tenant Federation: Fix `unsupported character` error when `tenant-federation.regex-matcher-enabled` is enabled and the input regex matches 0 or 1 existing tenant. #7424
 * [BUGFIX] KV store: Fix false-positive `status_code="500"` metrics for HA tracker CAS operations when using memberlist. #7408
 * [BUGFIX] Fix nil when ingester_query_max_attempts > 1. #7369

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 * [BUGFIX] Alertmanager: Fix disappearing user config and state when ring is temporarily unreachable. #7372
 * [BUGFIX] Fix memory leak in `ReuseWriteRequestV2` by explicitly clearing the `Symbols` backing array string pointers before returning the object to `sync.Pool`. #7373
 * [BUGFIX] Querier: Fix queryWithRetry and labelsWithRetry returning (nil, nil) on cancelled context by propagating ctx.Err(). #7375
-* [BUGFIX] Fix memory leak in `ReuseWriteRequestV2` by explicitly clearing the `Symbols` backing array string pointers before returning the object to `sync.Pool`. #7373
 
 * [CHANGE] Ruler: Graduate Ruler API from experimental. #7312
   * Flag: Renamed `-experimental.ruler.enable-api` to `-ruler.enable-api`. The old flag is kept as deprecated.

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -142,7 +142,7 @@ func Test_TenantFederationRegexResolver_WhenSingleTenantMatched(t *testing.T) {
 	flags := mergeFlags(BlocksStorageFlags(), map[string]string{
 		"-querier.cache-results":                   "true",
 		"-querier.split-queries-by-interval":       "24h",
-		"-limits.query-ingesters-within":           "12h", // Required by the test on query /series out of ingesters time range
+		"-querier.query-ingesters-within":          "12h", // Required by the test on query /series out of ingesters time range
 		"-frontend.memcached.addresses":            "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
 		"-tenant-federation.enabled":               "true",
 		"-tenant-federation.regex-matcher-enabled": "true",

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -126,6 +126,146 @@ func TestRegexResolver_NewlyCreatedTenant(t *testing.T) {
 	require.Equal(t, expectedVector, result.(model.Vector))
 }
 
+// Test that when the regex resolver is enabled, and 0 or 1 tenants are matched.
+// See issue 7413, https://github.com/cortexproject/cortex/issues/7413
+func Test_TenantFederationRegexResolver_WhenSingleTenantMatched(t *testing.T) {
+	const blockRangePeriod = 5 * time.Second
+
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	memcached := e2ecache.NewMemcached()
+	consul := e2edb.NewConsul()
+	require.NoError(t, s.StartAndWaitReady(consul, memcached))
+
+	flags := mergeFlags(BlocksStorageFlags(), map[string]string{
+		"-querier.cache-results":                   "true",
+		"-querier.split-queries-by-interval":       "24h",
+		"-limits.query-ingesters-within":           "12h", // Required by the test on query /series out of ingesters time range
+		"-frontend.memcached.addresses":            "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
+		"-tenant-federation.enabled":               "true",
+		"-tenant-federation.regex-matcher-enabled": "true",
+		"-tenant-federation.user-sync-interval":    "5s",
+
+		// to upload block quickly
+		"-blocks-storage.tsdb.block-ranges-period": blockRangePeriod.String(),
+		"-blocks-storage.tsdb.ship-interval":       "1s",
+		"-blocks-storage.tsdb.retention-period":    ((blockRangePeriod * 2) - 1).String(),
+
+		// store gateway
+		"-blocks-storage.bucket-store.sync-interval": blockRangePeriod.String(),
+		"-querier.max-fetched-series-per-query":      "1",
+	})
+
+	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+	require.NoError(t, s.StartAndWaitReady(minio))
+
+	// Start ingester and distributor.
+	ingester := e2ecortex.NewIngester("ingester", e2ecortex.RingStoreConsul, consul.NetworkHTTPEndpoint(), flags, "")
+	distributor := e2ecortex.NewDistributor("distributor", e2ecortex.RingStoreConsul, consul.NetworkHTTPEndpoint(), flags, "")
+	require.NoError(t, s.StartAndWaitReady(ingester, distributor))
+
+	// Wait until distributor have updated the ring.
+	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+
+	// Start the query-frontend.
+	queryFrontend := e2ecortex.NewQueryFrontend("query-frontend", flags, "")
+	require.NoError(t, s.Start(queryFrontend))
+
+	// Start the querier and store-gateway
+	flags["-querier.frontend-address"] = queryFrontend.NetworkGRPCEndpoint()
+	storeGateway := e2ecortex.NewStoreGateway("store-gateway", e2ecortex.RingStoreConsul, consul.NetworkHTTPEndpoint(), flags, "")
+	querier := e2ecortex.NewQuerier("querier", e2ecortex.RingStoreConsul, consul.NetworkHTTPEndpoint(), flags, "")
+
+	// Start queriers.
+	require.NoError(t, s.StartAndWaitReady(querier, storeGateway))
+	require.NoError(t, s.WaitReady(queryFrontend))
+
+	// Wait until the querier and store-gateway have updated ring
+	require.NoError(t, storeGateway.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512*2), "cortex_ring_tokens_total"))
+
+	clientForMatchOneTenant, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", "user-1")
+	require.NoError(t, err)
+
+	var series []prompb.TimeSeries
+	now := time.Now()
+	series, expectedResult := generateSeries("series_1", now)
+	// To ship series_1 block
+	series2, _ := generateSeries("series_2", now.Add(blockRangePeriod*2))
+	metadata := []prompb.MetricMetadata{
+		{
+			MetricFamilyName: "series_1",
+			Help:             "help",
+			Unit:             "total",
+		},
+	}
+
+	res, err := clientForMatchOneTenant.Push(series, metadata...)
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+
+	res, err = clientForMatchOneTenant.Push(series2)
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+
+	// wait to upload blocks
+	require.NoError(t, ingester.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_ingester_shipper_uploads_total"}, e2e.WaitMissingMetrics))
+
+	// wait to update knownUsers
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_regex_resolver_last_update_run_timestamp_seconds"}, e2e.WaitMissingMetrics))
+
+	clientForMatchOneTenant, err = e2ecortex.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", "user-.+")
+	require.NoError(t, err)
+
+	// query
+	result, err := clientForMatchOneTenant.Query("series_1", now)
+	require.NoError(t, err)
+	require.Equal(t, model.ValVector, result.Type())
+	require.Equal(t, expectedResult, result.(model.Vector))
+
+	// label names
+	start := now.Add(-time.Minute * 5)
+	end := now
+	labelNames, err := clientForMatchOneTenant.LabelNames(start, end, "series_1")
+	require.NoError(t, err)
+	require.Len(t, labelNames, 1)
+
+	// label value
+	labelValues, err := clientForMatchOneTenant.LabelValues("__name__", start, end, []string{"series_1"})
+	require.NoError(t, err)
+	require.Len(t, labelValues, 1)
+
+	// metadata
+	metadataResult, err := clientForMatchOneTenant.Metadata("series_1", "")
+	require.NoError(t, err)
+	require.Len(t, metadataResult, 1)
+
+	clientForMatchZeroTenant, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", "user-11111.+")
+	require.NoError(t, err)
+
+	// query
+	result, err = clientForMatchZeroTenant.Query("series_1", now)
+	require.NoError(t, err)
+	require.Equal(t, model.ValVector, result.Type())
+
+	// label names
+	labelNames, err = clientForMatchZeroTenant.LabelNames(start, end, "series_1")
+	require.NoError(t, err)
+	require.Len(t, labelNames, 0)
+
+	// label value
+	labelValues, err = clientForMatchZeroTenant.LabelValues("__name__", start, end, []string{"series_1"})
+	require.NoError(t, err)
+	require.Len(t, labelValues, 0)
+
+	// metadata
+	metadataResult, err = clientForMatchZeroTenant.Metadata("series_1", "")
+	require.NoError(t, err)
+	require.Len(t, metadataResult, 0)
+}
+
 func runQuerierTenantFederationTest_UseRegexResolver(t *testing.T, cfg querierTenantFederationConfig) {
 	const numUsers = 10
 	const blockRangePeriod = 5 * time.Second
@@ -241,9 +381,9 @@ func runQuerierTenantFederationTest_UseRegexResolver(t *testing.T, cfg querierTe
 	require.NoError(t, ingester.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_ingester_shipper_uploads_total"}, e2e.WaitMissingMetrics))
 
 	// wait to update knownUsers
-	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_regex_resolver_last_update_run_timestamp_seconds"}), e2e.WaitMissingMetrics)
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_regex_resolver_last_update_run_timestamp_seconds"}, e2e.WaitMissingMetrics))
 	if cfg.shuffleShardingEnabled {
-		require.NoError(t, querier2.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_regex_resolver_last_update_run_timestamp_seconds"}), e2e.WaitMissingMetrics)
+		require.NoError(t, querier2.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_regex_resolver_last_update_run_timestamp_seconds"}, e2e.WaitMissingMetrics))
 	}
 
 	// query all tenants

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -714,7 +714,10 @@ func (am *MultitenantAlertmanager) userIndexUpdateLoop(ctx context.Context) {
 			level.Error(am.logger).Log("msg", "context timeout, exit user index update loop", "err", ctx.Err())
 			return
 		case <-ticker.C:
-			owned := am.isUserOwned(userID)
+			owned, err := am.isUserOwned(userID)
+			if err != nil {
+				continue
+			}
 			if !owned {
 				continue
 			}
@@ -804,7 +807,11 @@ func (am *MultitenantAlertmanager) loadAlertmanagerConfigs(ctx context.Context) 
 
 	// Filter out users not owned by this shard.
 	for _, userID := range allUserIDs {
-		if am.isUserOwned(userID) {
+		owned, err := am.isUserOwned(userID)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to check if user %s is owned", userID)
+		}
+		if owned {
 			ownedUserIDs = append(ownedUserIDs, userID)
 		}
 	}
@@ -821,24 +828,24 @@ func (am *MultitenantAlertmanager) loadAlertmanagerConfigs(ctx context.Context) 
 	return allUserIDs, configs, nil
 }
 
-func (am *MultitenantAlertmanager) isUserOwned(userID string) bool {
+func (am *MultitenantAlertmanager) isUserOwned(userID string) (bool, error) {
 	if !am.allowedTenants.IsAllowed(userID) {
-		return false
+		return false, nil
 	}
 
 	// If sharding is disabled, any alertmanager instance owns all users.
 	if !am.cfg.ShardingEnabled {
-		return true
+		return true, nil
 	}
 
 	alertmanagers, err := am.ring.Get(users.ShardByUser(userID), getSyncRingOp(am.cfg.ShardingRing.DisableReplicaSetExtension), nil, nil, nil)
 	if err != nil {
 		am.ringCheckErrors.Inc()
 		level.Error(am.logger).Log("msg", "failed to load alertmanager configuration", "user", userID, "err", err)
-		return false
+		return false, err
 	}
 
-	return alertmanagers.Includes(am.ringLifecycler.GetInstanceAddr())
+	return alertmanagers.Includes(am.ringLifecycler.GetInstanceAddr()), nil
 }
 
 func (am *MultitenantAlertmanager) syncConfigs(cfgs map[string]alertspb.AlertConfigDesc) {

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -2501,3 +2501,128 @@ func (m *mockAlertManagerLimits) AlertmanagerMaxSilencesCount(_ string) int {
 func (m *mockAlertManagerLimits) AlertmanagerMaxSilenceSizeBytes(_ string) int {
 	return m.maxSilencesSizeBytes
 }
+
+func TestMultitenantAlertmanager_isUserOwned(t *testing.T) {
+	ctx := context.Background()
+	_ = ctx
+	amConfig := mockAlertmanagerConfig(t)
+	amConfig.ShardingEnabled = true
+
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	alertStore, err := prepareInMemoryAlertStore()
+	require.NoError(t, err)
+
+	am, err := createMultitenantAlertmanager(amConfig, nil, nil, alertStore, ringStore, nil, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	// We don't start the AM, so the ring is empty.
+	// When sharding is enabled, isUserOwned will call am.ring.Get, which should fail because the ring is empty.
+	owned, err := am.isUserOwned("user-1")
+	require.Error(t, err)
+	require.Equal(t, ring.ErrEmptyRing, err)
+	require.False(t, owned)
+
+	// If sharding is disabled, it should return true, nil
+	am.cfg.ShardingEnabled = false
+	owned, err = am.isUserOwned("user-1")
+	require.NoError(t, err)
+	require.True(t, owned)
+}
+
+func TestMultitenantAlertmanager_loadAndSyncConfigs_deletesUserFromStore(t *testing.T) {
+	ctx := context.Background()
+	amConfig := mockAlertmanagerConfig(t)
+	amConfig.ShardingEnabled = true
+
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	alertStore, err := prepareInMemoryAlertStore()
+	require.NoError(t, err)
+
+	am, err := createMultitenantAlertmanager(amConfig, nil, nil, alertStore, ringStore, nil, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	// We don't start the AM. We just manually insert state, then call loadAndSyncConfigs.
+	user1 := "user-1"
+
+	// 1. Create a FullState (remote state) for user1 in the store.
+	fullState := alertspb.FullStateDesc{
+		State: &clusterpb.FullState{},
+	}
+	err = alertStore.SetFullState(ctx, user1, fullState)
+	require.NoError(t, err)
+
+	// Since we did NOT SetAlertConfig for user1, the store.ListAllUsers will return empty.
+	allUsers, err := alertStore.ListAllUsers(ctx)
+	require.NoError(t, err)
+	require.Empty(t, allUsers)
+
+	// Verify user1's FullState is written to the store.
+	_, err = alertStore.GetFullState(ctx, user1)
+	require.NoError(t, err)
+
+	// 2. Call loadAndSyncConfigs. It should fetch all users (which is empty),
+	// and since sharding is enabled, it should clean up unused remote state for any users not in the list.
+	// user1 has state but no config, so its state should be pruned.
+	err = am.loadAndSyncConfigs(ctx, reasonPeriodic)
+	require.NoError(t, err)
+
+	// 3. Verify user1's FullState is deleted from the store.
+	_, err = alertStore.GetFullState(ctx, user1)
+	require.Error(t, err)
+	require.Equal(t, alertspb.ErrNotFound, err)
+}
+
+func TestMultitenantAlertmanager_loadAndSyncConfigs_DoesNotDeleteUserFromStoreWhenRingUnreachable(t *testing.T) {
+	ctx := context.Background()
+	amConfig := mockAlertmanagerConfig(t)
+	amConfig.ShardingEnabled = true
+
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	alertStore, err := prepareInMemoryAlertStore()
+	require.NoError(t, err)
+
+	am, err := createMultitenantAlertmanager(amConfig, nil, nil, alertStore, ringStore, nil, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	user1 := "user-1"
+
+	// 1. Create a FullState (remote state) for user1 in the store.
+	fullState := alertspb.FullStateDesc{
+		State: &clusterpb.FullState{},
+	}
+	err = alertStore.SetFullState(ctx, user1, fullState)
+	require.NoError(t, err)
+
+	// Since we DO SetAlertConfig for user1, the store.ListAllUsers will return the user.
+	err = alertStore.SetAlertConfig(ctx, alertspb.AlertConfigDesc{
+		User:      user1,
+		RawConfig: simpleConfigOne,
+		Templates: []*alertspb.TemplateDesc{},
+	})
+	require.NoError(t, err)
+
+	allUsers, err := alertStore.ListAllUsers(ctx)
+	require.NoError(t, err)
+	require.Len(t, allUsers, 1)
+
+	// Verify user1's FullState is written to the store.
+	_, err = alertStore.GetFullState(ctx, user1)
+	require.NoError(t, err)
+
+	// 2. Call loadAndSyncConfigs. It should fetch all users.
+	// Since sharding is enabled but ring is empty (unreachable), isUserOwned will fail.
+	// loadAndSyncConfigs will return early with an error before pruning any states!
+	err = am.loadAndSyncConfigs(ctx, reasonPeriodic)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ring.ErrEmptyRing.Error())
+
+	// 3. Verify user1's FullState is STILL in the store.
+	_, err = alertStore.GetFullState(ctx, user1)
+	require.NoError(t, err)
+}

--- a/pkg/cortexpb/timeseriesv2.go
+++ b/pkg/cortexpb/timeseriesv2.go
@@ -77,6 +77,10 @@ func ReuseWriteRequestV2(req *PreallocWriteRequestV2) {
 		req.data = nil
 	}
 	req.Source = 0
+
+	for i := range req.Symbols {
+		req.Symbols[i] = ""
+	}
 	req.Symbols = req.Symbols[:0]
 	if req.Timeseries != nil {
 		ReuseSliceV2(req.Timeseries)

--- a/pkg/cortexpb/timeseriesv2_test.go
+++ b/pkg/cortexpb/timeseriesv2_test.go
@@ -52,6 +52,38 @@ func TestTimeseriesV2FromPool(t *testing.T) {
 	})
 }
 
+func TestReuseWriteRequestV2(t *testing.T) {
+	req := PreallocWriteRequestV2FromPool()
+
+	// Populate req with some data.
+	req.Source = RULE
+	req.Symbols = append(req.Symbols, "", "__name__", "test")
+
+	tsSlice := PreallocTimeseriesV2SliceFromPool()
+	tsSlice = append(tsSlice, PreallocTimeseriesV2{TimeSeriesV2: TimeseriesV2FromPool()})
+	req.Timeseries = tsSlice
+
+	// Capture backing array before reuse
+	symbolsBackingArray := req.Symbols[:cap(req.Symbols)]
+	require.Equal(t, "__name__", symbolsBackingArray[1])
+	require.Equal(t, "test", symbolsBackingArray[2])
+
+	// Put the request back into the pool
+	ReuseWriteRequestV2(req)
+
+	// Verify clearing directly on the backing array
+	for i, s := range symbolsBackingArray[:3] {
+		assert.Equalf(t, "", s, "symbol at index %d not cleared", i)
+	}
+
+	// Source is reset to default
+	assert.Equal(t, API, req.Source)
+	// The symbol length is properly reset to 0.
+	assert.Len(t, req.Symbols, 0)
+	// Timeseries slice is nil
+	assert.Nil(t, req.Timeseries)
+}
+
 func BenchmarkMarshallWriteRequestV2(b *testing.B) {
 	ts := PreallocTimeseriesV2SliceFromPool()
 

--- a/pkg/ha/ha_tracker_test.go
+++ b/pkg/ha/ha_tracker_test.go
@@ -223,6 +223,66 @@ func TestHATracker_CleanupDeletesArePropagatedWithMemberlist(t *testing.T) {
 	require.NotEmpty(t, broadcasts, "Cleanup Delete should generate a broadcast for tombstone propagation")
 }
 
+// TestWatchPrefixNilPanicWithMemberlist reproduces the panic at ha_tracker.go:437:
+// With memberlist, WatchPrefix delivers a nil value when a key is deleted
+// (memberlist KV.get() returns nil for deleted/tombstone keys).
+func TestWatchPrefixNilPanicWithMemberlist(t *testing.T) {
+	ctx := t.Context()
+	logger := log.NewNopLogger()
+	reg := prometheus.NewRegistry()
+
+	var kvCfg memberlist.KVConfig
+	flagext.DefaultValues(&kvCfg)
+	replicaDescCodec := GetReplicaDescCodec()
+	kvCfg.Codecs = []codec.Codec{replicaDescCodec}
+
+	mkv := memberlist.NewKV(kvCfg, logger, &dnsProviderMock{}, reg)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, mkv))
+	defer services.StopAndAwaitTerminated(ctx, mkv) //nolint:errcheck
+
+	client, err := memberlist.NewClient(mkv, replicaDescCodec)
+	require.NoError(t, err)
+
+	trackerCfg := HATrackerConfig{
+		EnableHATracker:        false, // to inject our client before starting the tracker
+		UpdateTimeout:          time.Second,
+		UpdateTimeoutJitterMax: 0,
+		FailoverTimeout:        2 * time.Second,
+		KVStore:                kv.Config{Store: "memberlist"},
+	}
+
+	tracker, err := NewHATracker(trackerCfg, nil, HATrackerStatusConfig{}, reg, "test", logger)
+	require.NoError(t, err)
+	tracker.cfg.EnableHATracker = true
+	tracker.client = client
+
+	// Start the tracker — this starts the WatchPrefix loop in loop().
+	require.NoError(t, services.StartAndAwaitRunning(ctx, tracker))
+	defer services.StopAndAwaitTerminated(ctx, tracker) //nolint:errcheck
+
+	userID := "user1"
+	cluster := "cluster1"
+	replica := "replica0"
+	key := userID + "/" + cluster
+
+	now := time.Now()
+	require.NoError(t, tracker.CheckReplica(ctx, userID, cluster, replica, now))
+
+	test.Poll(t, 3*time.Second, nil, func() any {
+		tracker.electedLock.RLock()
+		defer tracker.electedLock.RUnlock()
+		if _, ok := tracker.elected[key]; !ok {
+			return fmt.Errorf("waiting for key to appear in elected cache")
+		}
+		return nil
+	})
+
+	require.NoError(t, client.Delete(ctx, key))
+
+	time.Sleep(500 * time.Millisecond)
+	require.Equal(t, services.Running, tracker.State(), "HATracker should still be running after receiving nil value from memberlist WatchPrefix")
+}
+
 // Test that values are set in the HATracker after WatchPrefix has found it in the KVStore.
 func TestWatchPrefixAssignment(t *testing.T) {
 	t.Parallel()

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -166,6 +166,16 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, sortSeries, pa
 		return storage.ErrSeriesSet(err)
 	}
 
+	// Guard against nil results. This can happen when queryWithRetry's
+	// backoff loop exits without executing (e.g., context cancelled before
+	// the first attempt), returning (nil, nil). See #7364.
+	if results == nil {
+		if err != nil {
+			return storage.ErrSeriesSet(err)
+		}
+		return storage.EmptySeriesSet()
+	}
+
 	serieses := make([]storage.Series, 0, len(results.Chunkseries))
 	for _, result := range results.Chunkseries {
 		// Sometimes the ingester can send series that have no data.

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -166,16 +166,6 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, sortSeries, pa
 		return storage.ErrSeriesSet(err)
 	}
 
-	// Guard against nil results. This can happen when queryWithRetry's
-	// backoff loop exits without executing (e.g., context cancelled before
-	// the first attempt), returning (nil, nil). See #7364.
-	if results == nil {
-		if err != nil {
-			return storage.ErrSeriesSet(err)
-		}
-		return storage.EmptySeriesSet()
-	}
-
 	serieses := make([]storage.Series, 0, len(results.Chunkseries))
 	for _, result := range results.Chunkseries {
 		// Sometimes the ingester can send series that have no data.
@@ -234,6 +224,13 @@ func (q *distributorQuerier) queryWithRetry(ctx context.Context, queryFunc func(
 		}
 
 		retries.Wait()
+	}
+
+	// If the loop never executed (e.g. context cancelled before the first
+	// attempt), result and err are both nil. Return the context error so
+	// callers don't receive a nil result with no error.
+	if err == nil {
+		err = ctx.Err()
 	}
 
 	return result, err
@@ -299,7 +296,7 @@ func (q *distributorQuerier) LabelNames(ctx context.Context, hints *storage.Labe
 }
 
 func (q *distributorQuerier) labelsWithRetry(ctx context.Context, labelsFunc func() ([]string, error)) ([]string, error) {
-	if q.ingesterQueryMaxAttempts == 1 {
+	if q.ingesterQueryMaxAttempts <= 1 {
 		return labelsFunc()
 	}
 
@@ -320,6 +317,13 @@ func (q *distributorQuerier) labelsWithRetry(ctx context.Context, labelsFunc fun
 		}
 
 		retries.Wait()
+	}
+
+	// If the loop never executed (e.g. context cancelled before the first
+	// attempt), result and err are both nil. Return the context error so
+	// callers don't receive a nil result with no error.
+	if err == nil {
+		err = ctx.Err()
 	}
 
 	return result, err

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -387,6 +387,70 @@ func TestDistributorQuerier_Retry(t *testing.T) {
 	}
 }
 
+// TestDistributorQuerier_Select_CancelledContext_NoRetry verifies that with
+// ingesterQueryMaxAttempts=1, a cancelled context does not panic because the
+// direct code path (no retry loop) is used.
+func TestDistributorQuerier_Select_CancelledContext_NoRetry(t *testing.T) {
+	t.Parallel()
+
+	ctx := user.InjectOrgID(context.Background(), "0")
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	d := &MockDistributor{}
+	d.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&client.QueryStreamResponse{}, context.Canceled)
+
+	ingesterQueryMaxAttempts := 1
+	queryable := newDistributorQueryable(d, true, true, batch.NewChunkMergeIterator, 0, func(string) bool {
+		return true
+	}, ingesterQueryMaxAttempts)
+	querier, err := queryable.Querier(mint, maxt)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		seriesSet := querier.Select(ctx, true, &storage.SelectHints{Start: mint, End: maxt})
+		_ = seriesSet.Err()
+	})
+}
+
+// TestDistributorQuerier_Select_CancelledContext reproduces the panic described
+// in https://github.com/cortexproject/cortex/issues/7364.
+//
+// When ingesterQueryMaxAttempts > 1 and the context is cancelled before the
+// retry loop starts (e.g. query timeout or another querier goroutine failing),
+// backoff.Ongoing() returns false immediately. The result variable stays nil,
+// queryWithRetry returns (nil, nil), and streamingSelect dereferences the nil
+// result at line 169 → panic.
+func TestDistributorQuerier_Select_CancelledContext(t *testing.T) {
+	t.Parallel()
+
+	// Create a context that is already cancelled.
+	ctx := user.InjectOrgID(context.Background(), "0")
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	d := &MockDistributor{}
+	// No mock expectations needed — QueryStream should never be called
+	// because the context is already cancelled.
+
+	ingesterQueryMaxAttempts := 2
+	queryable := newDistributorQueryable(d, true, true, batch.NewChunkMergeIterator, 0, func(string) bool {
+		return true
+	}, ingesterQueryMaxAttempts)
+	querier, err := queryable.Querier(mint, maxt)
+	require.NoError(t, err)
+
+	// This should NOT panic. Before the fix, the cancelled context causes
+	// queryWithRetry to return (nil, nil), and streamingSelect dereferences
+	// the nil result: panic: runtime error: invalid memory address or nil
+	// pointer dereference [signal SIGSEGV ... addr=0x8]
+	require.NotPanics(t, func() {
+		seriesSet := querier.Select(ctx, true, &storage.SelectHints{Start: mint, End: maxt})
+		// With a cancelled context, we expect either an error or an empty result.
+		_ = seriesSet.Err()
+	})
+}
+
 func TestDistributorQuerier_LabelNames(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -418,9 +418,8 @@ func TestDistributorQuerier_Select_CancelledContext_NoRetry(t *testing.T) {
 //
 // When ingesterQueryMaxAttempts > 1 and the context is cancelled before the
 // retry loop starts (e.g. query timeout or another querier goroutine failing),
-// backoff.Ongoing() returns false immediately. The result variable stays nil,
-// queryWithRetry returns (nil, nil), and streamingSelect dereferences the nil
-// result at line 169 → panic.
+// backoff.Ongoing() returns false immediately. queryWithRetry now propagates
+// ctx.Err() so callers always see a non-nil error.
 func TestDistributorQuerier_Select_CancelledContext(t *testing.T) {
 	t.Parallel()
 
@@ -440,14 +439,37 @@ func TestDistributorQuerier_Select_CancelledContext(t *testing.T) {
 	querier, err := queryable.Querier(mint, maxt)
 	require.NoError(t, err)
 
-	// This should NOT panic. Before the fix, the cancelled context causes
-	// queryWithRetry to return (nil, nil), and streamingSelect dereferences
-	// the nil result: panic: runtime error: invalid memory address or nil
-	// pointer dereference [signal SIGSEGV ... addr=0x8]
-	require.NotPanics(t, func() {
-		seriesSet := querier.Select(ctx, true, &storage.SelectHints{Start: mint, End: maxt})
-		// With a cancelled context, we expect either an error or an empty result.
-		_ = seriesSet.Err()
+	seriesSet := querier.Select(ctx, true, &storage.SelectHints{Start: mint, End: maxt})
+	require.ErrorIs(t, seriesSet.Err(), context.Canceled)
+}
+
+// TestDistributorQuerier_Labels_CancelledContext verifies that labelsWithRetry
+// propagates ctx.Err() when the context is cancelled before the retry loop
+// executes.
+func TestDistributorQuerier_Labels_CancelledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := user.InjectOrgID(context.Background(), "0")
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	d := &MockDistributor{}
+
+	ingesterQueryMaxAttempts := 2
+	queryable := newDistributorQueryable(d, true, true, batch.NewChunkMergeIterator, 0, func(string) bool {
+		return true
+	}, ingesterQueryMaxAttempts)
+	querier, err := queryable.Querier(mint, maxt)
+	require.NoError(t, err)
+
+	t.Run("LabelNames", func(t *testing.T) {
+		_, _, err := querier.LabelNames(ctx, nil)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("LabelValues", func(t *testing.T) {
+		_, _, err := querier.LabelValues(ctx, "foo", nil)
+		require.ErrorIs(t, err, context.Canceled)
 	})
 }
 

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -161,7 +161,7 @@ func (m *mergeQuerier) LabelValues(ctx context.Context, name string, hints *stor
 
 	// by pass when only single querier is returned
 	if m.byPassWithSingleQuerier && len(queriers) == 1 {
-		return queriers[0].LabelValues(ctx, name, hints, matchers...)
+		return queriers[0].LabelValues(user.InjectOrgID(ctx, ids[0]), name, hints, matchers...)
 	}
 	log, _ := spanlogger.New(ctx, "mergeQuerier.LabelValues")
 	defer log.Finish()
@@ -202,7 +202,7 @@ func (m *mergeQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints
 
 	// by pass when only single querier is returned
 	if m.byPassWithSingleQuerier && len(queriers) == 1 {
-		return queriers[0].LabelNames(ctx, hints, matchers...)
+		return queriers[0].LabelNames(user.InjectOrgID(ctx, ids[0]), hints, matchers...)
 	}
 	log, _ := spanlogger.New(ctx, "mergeQuerier.LabelNames")
 	defer log.Finish()
@@ -349,7 +349,7 @@ func (m *mergeQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 
 	// by pass when only single querier is returned
 	if m.byPassWithSingleQuerier && len(queriers) == 1 {
-		return queriers[0].Select(ctx, sortSeries, hints, matchers...)
+		return queriers[0].Select(user.InjectOrgID(ctx, ids[0]), sortSeries, hints, matchers...)
 	}
 
 	log, ctx := spanlogger.New(ctx, "mergeQuerier.Select")

--- a/pkg/querier/tenantfederation/metadata_merge_querier.go
+++ b/pkg/querier/tenantfederation/metadata_merge_querier.go
@@ -61,7 +61,7 @@ func (m *mergeMetadataQuerier) MetricsMetadata(ctx context.Context, req *client.
 	m.tenantsPerMetadataQuery.Observe(float64(len(tenantIds)))
 
 	if len(tenantIds) == 1 {
-		return m.upstream.MetricsMetadata(ctx, req)
+		return m.upstream.MetricsMetadata(user.InjectOrgID(ctx, tenantIds[0]), req)
 	}
 
 	jobs := make([]any, len(tenantIds))

--- a/pkg/ring/kv/memberlist/memberlist_client.go
+++ b/pkg/ring/kv/memberlist/memberlist_client.go
@@ -838,6 +838,11 @@ func (m *KV) WatchPrefix(ctx context.Context, prefix string, codec codec.Codec, 
 				continue
 			}
 
+			if val == nil {
+				// Skip nil that can be returned when the key is deleted.
+				continue
+			}
+
 			if !f(key, val) {
 				return
 			}

--- a/pkg/ring/kv/metrics.go
+++ b/pkg/ring/kv/metrics.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"time"
 
@@ -33,7 +34,8 @@ func getCasErrorCode(err error) string {
 
 	// If the error has been returned to abort the CAS operation, then we shouldn't
 	// consider it an error when tracking metrics.
-	if casErr, ok := err.(interface{ IsOperationAborted() bool }); ok && casErr.IsOperationAborted() {
+	var casAborted interface{ IsOperationAborted() bool }
+	if errors.As(err, &casAborted) && casAborted.IsOperationAborted() {
 		return "200"
 	}
 

--- a/pkg/ring/kv/metrics_test.go
+++ b/pkg/ring/kv/metrics_test.go
@@ -1,0 +1,52 @@
+package kv
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// operationAbortedError is a local stub that mimics ha.ReplicasNotMatchError,
+// implementing IsOperationAborted() to avoid an import cycle.
+type operationAbortedError struct{}
+
+func (e operationAbortedError) Error() string            { return "operation aborted" }
+func (e operationAbortedError) IsOperationAborted() bool { return true }
+
+func TestGetCasErrorCode(t *testing.T) {
+	abortedErr := operationAbortedError{}
+
+	tests := map[string]struct {
+		err      error
+		expected string
+	}{
+		"nil error": {
+			err:      nil,
+			expected: "200",
+		},
+		"operation aborted error (direct)": {
+			err:      abortedErr,
+			expected: "200",
+		},
+		"operation aborted error (single-wrapped by memberlist)": {
+			err:      fmt.Errorf("fn returned error: %w", abortedErr),
+			expected: "200",
+		},
+		"operation aborted error (double-wrapped by memberlist)": {
+			err: fmt.Errorf("failed to CAS-update key X: %w",
+				fmt.Errorf("fn returned error: %w", abortedErr)),
+			expected: "200",
+		},
+		"generic error": {
+			err:      fmt.Errorf("some real error"),
+			expected: "500",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, getCasErrorCode(tc.err))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Backport of 7 bug fixes from master to `release-1.21`:

- **#7408** — KV store: Fix false-positive `status_code="500"` metrics for HA tracker CAS operations when using memberlist
- **#7369** — Fix nil panic when `ingester_query_max_attempts > 1`
- **#7372** — Fix alertmanager user config disappearing when ring is temporarily unreachable
- **#7373** — Fix memory leak in `ReuseWriteRequestV2` by explicitly clearing the `Symbols` backing array string pointers before returning the object to `sync.Pool`
- **#7375** — Fix `queryWithRetry` and `labelsWithRetry` returning `(nil, nil)` on cancelled context by propagating `ctx.Err()`
- **#7424** — Tenant Federation: Fix `unsupported character` error when `tenant-federation.regex-matcher-enabled` is enabled and the input regex matches 0 or 1 existing tenant
- **#7429** — Memberlist: Skip nil values delivered by `WatchPrefix` when a key is deleted, preventing a panic in the HA tracker

## Test plan
- [x] CI passes
- [x] Verify each fix is functionally identical to the master version