### PR TITLE
Fix arm64 CI runner mismatches and stale action version comment

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -55,7 +55,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v3.pre.node20
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -203,7 +203,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             arch: arm64
             tags: integration_memberlist
-          - runner: ubuntu-24.04
+          - runner: ubuntu-24.04-arm
             arch: arm64
             tags: integration_overrides
           - runner: ubuntu-24.04-arm
@@ -221,9 +221,9 @@ jobs:
           - runner: ubuntu-24.04-arm
             arch: arm64
             tags: integration_querier
-          - runner: ubuntu-24.04
+          - runner: ubuntu-24.04-arm
             arch: arm64
-            tags: integration_querier_microservices_mode            
+            tags: integration_querier_microservices_mode
     steps:
       - name: Upgrade golang
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**: Two arm64 integration test matrix entries (integration_overrides, integration_querier_microservices_mode) were using the amd64 runner ubuntu-24.04 instead of ubuntu-24.04-arm, causing them to run on the wrong architecture.

Also fix stale version comment on actions/upload-artifact in scorecards.yml (v3.pre.node20 -> v6.0.0 to match the pinned hash).


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
