### PR TITLE
Add SBOM generation script and update release docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -133,13 +133,11 @@ To publish a stable release:
 
 ### <a name="sing-and-sbom"></a>Sign the release artifacts and generate SBOM
 1. Make sure you have the release branch checked out, and you don't have any local modifications
-1. Create and `cd` to an empty directory not within the project directory
-1. Run `mkdir sbom`
-1. Generate SBOMs using https://github.com/kubernetes-sigs/bom
-   1. `bom generate -o sbom/go-mod.spdx -n https://github.com/cortexproject/cortex -d <cortex repo>`
-   1. `bom generate -o sbom/cortex-container-image.spdx -n https://github.com/cortexproject/cortex -i quay.io/cortexproject/cortex:<release tag>`
-   1. `bom generate -o sbom/query-tee-container-image.spdx -n https://github.com/cortexproject/cortex -i quay.io/cortexproject/query-tee:<release tag>`
-   1. `tar -zcvf  sbom.tar.gz sbom`
+1. Generate SBOMs using the provided script (requires https://github.com/kubernetes-sigs/bom):
+   ```bash
+   ./tools/generate-sbom.sh /path/to/cortex
+   ```
+   This generates SBOMs for the Go modules and all container images (cortex, query-tee, test-exporter, thanosconvert) and packages them into `dist/sbom.tar.gz`.
 1. Download the artifacts attached to the published release
    ```bash
    curl -H "Authorization: Bearer <your GitHub API token>" -s https://api.github.com/repos/cortexproject/cortex/releases/tags/<release tag> \

--- a/tools/generate-sbom.sh
+++ b/tools/generate-sbom.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RELEASE_TAG="v$(cat "${REPO_ROOT}/VERSION" | tr -d '[:space:]')"
+CORTEX_REPO="${1:-$REPO_ROOT}"
+
+mkdir -p sbom
+
+echo "Generating go-mod SBOM..."
+bom generate -o sbom/go-mod.spdx \
+  -n https://github.com/cortexproject/cortex \
+  -d "$CORTEX_REPO"
+
+echo "Generating cortex container image SBOM..."
+bom generate -o sbom/cortex-container-image.spdx \
+  -n https://github.com/cortexproject/cortex \
+  -i "quay.io/cortexproject/cortex:${RELEASE_TAG}"
+
+echo "Generating query-tee container image SBOM..."
+bom generate -o sbom/query-tee-container-image.spdx \
+  -n https://github.com/cortexproject/cortex \
+  -i "quay.io/cortexproject/query-tee:${RELEASE_TAG}"
+
+echo "Generating test-exporter container image SBOM..."
+bom generate -o sbom/test-exporter-container-image.spdx \
+  -n https://github.com/cortexproject/cortex \
+  -i "quay.io/cortexproject/test-exporter:${RELEASE_TAG}"
+
+echo "Generating thanosconvert container image SBOM..."
+bom generate -o sbom/thanosconvert-container-image.spdx \
+  -n https://github.com/cortexproject/cortex \
+  -i "quay.io/cortexproject/thanosconvert:${RELEASE_TAG}"
+
+echo "Creating sbom.tar.gz..."
+tar -zcvf "${REPO_ROOT}/dist/sbom.tar.gz" sbom
+
+echo "Done. sbom.tar.gz is at ${REPO_ROOT}/dist/sbom.tar.gz"


### PR DESCRIPTION
Add tools/generate-sbom.sh to automate SBOM generation for releases, replacing the manual steps in RELEASE.md. The script covers all container images (cortex, query-tee, test-exporter, thanosconvert) and packages the output into dist/sbom.tar.gz.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**: Simplify release signing by using a bom generation script

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
