### PR TITLE
Login to docker to run docker images

### DIFF
--- a/.github/workflows/scripts/install-docker.sh
+++ b/.github/workflows/scripts/install-docker.sh
@@ -28,4 +28,7 @@ mkdir -vp ~/.docker/cli-plugins/
 curl --silent -L "https://github.com/docker/buildx/releases/download/v0.31.1/buildx-v0.31.1.linux-$BUILDX_ARCH" > ~/.docker/cli-plugins/docker-buildx
 chmod a+x ~/.docker/cli-plugins/docker-buildx
 mv /tmp/docker/* /usr/bin
+if [ -n "$DOCKER_REGISTRY_PASSWORD" ]; then
+  docker login -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD"
+fi
 docker run --privileged --rm tonistiigi/binfmt --install all

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -261,7 +261,7 @@ jobs:
         run: |
           docker pull minio/minio:RELEASE.2024-05-28T17-19-04Z
           docker pull consul:1.8.4
-          docker pull gcr.io/etcd-development/etcd:v3.4.7
+          docker pull quay.io/coreos/etcd:v3.5.29
           if [ "$TEST_TAGS" = "integration_backward_compatibility" ]; then
             docker pull quay.io/cortexproject/cortex:v1.16.1
             docker pull quay.io/cortexproject/cortex:v1.17.2

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -135,6 +135,9 @@ jobs:
           git config --system --add safe.directory $GITHUB_WORKSPACE
       - name: Install Docker Client
         run: ./.github/workflows/scripts/install-docker.sh
+        env:
+          DOCKER_REGISTRY_USER: ${{secrets.DOCKER_REGISTRY_USER}}
+          DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
       - name: Sym Link Expected Path to Workspace
         run: |
           mkdir -p /go/src/github.com/cortexproject/cortex
@@ -237,8 +240,6 @@ jobs:
           go-version: 1.26.2
       - name: Checkout Repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: Install Docker Client
-        run: sudo ./.github/workflows/scripts/install-docker.sh
       - name: Sym Link Expected Path to Workspace
         run: |
           sudo mkdir -p /go/src/github.com/cortexproject/cortex
@@ -303,8 +304,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: Install Docker Client
-        run: sudo ./.github/workflows/scripts/install-docker.sh
       - name: Download Docker Images Artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -336,6 +335,9 @@ jobs:
           git config --system --add safe.directory $GITHUB_WORKSPACE
       - name: Install Docker Client
         run: ./.github/workflows/scripts/install-docker.sh
+        env:
+          DOCKER_REGISTRY_USER: ${{secrets.DOCKER_REGISTRY_USER}}
+          DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
       - name: Sym link Expected Path to Workspace
         run: |
           mkdir -p /go/src/github.com/cortexproject/cortex

--- a/integration/e2e/images/images.go
+++ b/integration/e2e/images/images.go
@@ -10,6 +10,6 @@ var (
 	Redis      = "docker.io/redis:7.0.4-alpine"
 	Minio      = "minio/minio:RELEASE.2024-05-28T17-19-04Z"
 	Consul     = "consul:1.8.4"
-	ETCD       = "gcr.io/etcd-development/etcd:v3.4.7"
+	ETCD       = "quay.io/coreos/etcd:v3.5.29"
 	Prometheus = "quay.io/prometheus/prometheus:v3.8.1"
 )


### PR DESCRIPTION
The buildx step is not needed in integration anymore.

There is no arm64 image for v3.4. so I updated the image to 3.5

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #7414

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
