### PR TITLE
Fix flaky timing-sensitive tests in blocks_store_queryable

### DIFF
--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -307,6 +307,7 @@ func (q *BlocksStoreQueryable) Querier(mint, maxt int64) (storage.Querier, error
 		storeGatewayQueryStatsEnabled:           q.storeGatewayQueryStatsEnabled,
 		storeGatewayConsistencyCheckMaxAttempts: q.storeGatewayConsistencyCheckMaxAttempts,
 		storeGatewaySeriesBatchSize:             q.storeGatewaySeriesBatchSize,
+		nowFn:                                   time.Now,
 	}, nil
 }
 
@@ -328,6 +329,8 @@ type blocksStoreQuerier struct {
 
 	// The maximum number of series to be batched in a single gRPC response message from Store Gateways.
 	storeGatewaySeriesBatchSize int64
+
+	nowFn func() time.Time
 }
 
 // Select implements storage.Querier interface.
@@ -492,7 +495,7 @@ func (q *blocksStoreQuerier) queryWithConsistencyCheck(ctx context.Context, logg
 	// optimization is particularly important for the blocks storage because can be used to skip
 	// querying most recent not-compacted-yet blocks from the storage.
 	if queryStoreAfter > 0 {
-		now := time.Now()
+		now := q.nowFn()
 		origMaxT := maxT
 		maxT = min(maxT, util.TimeToMillis(now.Add(-queryStoreAfter)))
 

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -2432,6 +2432,7 @@ func TestBlocksStoreQuerier_SelectSortedShouldHonorQueryStoreAfter(t *testing.T)
 				logger:      log.NewNopLogger(),
 				metrics:     newBlocksStoreQueryableMetrics(nil),
 				limits:      &blocksStoreLimitsMock{queryStoreAfter: testData.queryStoreAfter},
+				nowFn:       func() time.Time { return now },
 			}
 
 			sp := &storage.SelectHints{
@@ -2447,7 +2448,7 @@ func TestBlocksStoreQuerier_SelectSortedShouldHonorQueryStoreAfter(t *testing.T)
 			} else {
 				require.Len(t, finder.Calls, 1)
 				assert.Equal(t, testData.expectedMinT, finder.Calls[0].Arguments.Get(2))
-				assert.InDelta(t, testData.expectedMaxT, finder.Calls[0].Arguments.Get(3), float64(15*time.Second.Milliseconds()))
+				assert.Equal(t, testData.expectedMaxT, finder.Calls[0].Arguments.Get(3))
 			}
 		})
 	}
@@ -3073,6 +3074,7 @@ func TestBlocksStoreQuerier_MultiTenantQueryStoreAfter(t *testing.T) {
 				logger:      log.NewNopLogger(),
 				metrics:     newBlocksStoreQueryableMetrics(nil),
 				limits:      &blocksStoreLimitsMock{queryStoreAfter: testData.queryStoreAfter},
+				nowFn:       func() time.Time { return now },
 			}
 
 			sp := &storage.SelectHints{
@@ -3088,10 +3090,7 @@ func TestBlocksStoreQuerier_MultiTenantQueryStoreAfter(t *testing.T) {
 			} else {
 				require.Len(t, finder.Calls, 1, testData.description)
 				assert.Equal(t, testData.expectedMinT, finder.Calls[0].Arguments.Get(2), testData.description)
-				// Allow 15 seconds of time drift to account for CI environment delays.
-				// The actual code calls time.Now() when manipulating query time ranges,
-				// which can differ from the test's captured 'now' value.
-				assert.InDelta(t, testData.expectedMaxT, finder.Calls[0].Arguments.Get(3), float64(15*time.Second.Milliseconds()), testData.description)
+				assert.Equal(t, testData.expectedMaxT, finder.Calls[0].Arguments.Get(3), testData.description)
 			}
 		})
 	}
@@ -3170,6 +3169,7 @@ func TestBlocksStoreQuerier_QueryStoreAfterBoundary(t *testing.T) {
 				logger:      log.NewNopLogger(),
 				metrics:     newBlocksStoreQueryableMetrics(nil),
 				limits:      &blocksStoreLimitsMock{queryStoreAfter: cutoff},
+				nowFn:       func() time.Time { return now },
 			}
 
 			sp := &storage.SelectHints{
@@ -3185,10 +3185,7 @@ func TestBlocksStoreQuerier_QueryStoreAfterBoundary(t *testing.T) {
 			} else {
 				require.Len(t, finder.Calls, 1, testData.description)
 				assert.Equal(t, testData.expectedMinT, finder.Calls[0].Arguments.Get(2), testData.description)
-				// Allow 15 seconds of time drift to account for CI environment delays.
-				// The actual code calls time.Now() when manipulating query time ranges,
-				// which can differ from the test's captured 'now' value.
-				assert.InDelta(t, testData.expectedMaxT, finder.Calls[0].Arguments.Get(3), float64(15*time.Second.Milliseconds()), testData.description)
+				assert.Equal(t, testData.expectedMaxT, finder.Calls[0].Arguments.Get(3), testData.description)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does**: Injects a `nowFn` clock into `blocksStoreQuerier` (following the existing pattern in `distributorQueryable`) so that tests can use a fixed time instead of relying on `time.Now()`. Replaces `assert.InDelta` with exact `assert.Equal` assertions, eliminating flaky failures caused by time drift on slower CI runners.

Affected tests:
- `TestBlocksStoreQuerier_SelectSortedShouldHonorQueryStoreAfter`
- `TestBlocksStoreQuerier_MultiTenantQueryStoreAfter`
- `TestBlocksStoreQuerier_QueryStoreAfterBoundary`

**Which issue(s) this PR fixes**:
Fixes #7469

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags