### PR TITLE
Increase golangci-lint timeout to 10m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  timeout: 5m
+  timeout: 10m
   # List of build tags, all linters use it.
   build-tags:
     - netgo


### PR DESCRIPTION
**What this PR does**: Increases the golangci-lint timeout from 5m to 10m in `.golangci.yml` to prevent timeouts on slower GitHub-hosted runners.

**Which issue(s) this PR fixes**:
Fixes #7469

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags