### PR TITLE
drop digest verification fail packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [BUGFIX] Compactor: Handle not-found and access-denied errors from `Attributes()` in bucket index updater, preventing a stale cached `Get()` from causing the entire cleanup cycle to fail when `meta.json` has been deleted from object storage. #7454
 * [BUGFIX] gRPC: Fix panic when `grpc_compression` is set to `snappy` on ingester client or store-gateway client configurations. #7459
 * [BUGFIX] Config: Mask Swift, etcd, Redis, and HTTP basic-auth credentials on the `/config` endpoint. #7473
+* [BUGFIX] Memberlist: Drop incoming TCP transport packets when digest verification fails, preventing corrupted payloads from being forwarded. #7474
 
 ## 1.21.0 2026-04-24
 

--- a/pkg/ring/kv/memberlist/tcp_transport.go
+++ b/pkg/ring/kv/memberlist/tcp_transport.go
@@ -302,6 +302,7 @@ func (t *TCPTransport) handleConnection(conn net.Conn) {
 		if !bytes.Equal(receivedDigest, expectedDigest[:]) {
 			t.receivedPacketsErrors.Inc()
 			level.Warn(t.logger).Log("msg", "packet digest mismatch", "expected", fmt.Sprintf("%x", expectedDigest), "received", fmt.Sprintf("%x", receivedDigest), "data_length", len(buf), "remote", conn.RemoteAddr())
+			return
 		}
 
 		t.debugLog().Log("msg", "Received packet", "addr", addr(addrBuf), "size", len(buf), "hash", fmt.Sprintf("%x", receivedDigest))

--- a/pkg/ring/kv/memberlist/tcp_transport_test.go
+++ b/pkg/ring/kv/memberlist/tcp_transport_test.go
@@ -76,12 +76,12 @@ func TestTCPTransport_PacketDigestMismatch(t *testing.T) {
 
 	transport, err := NewTCPTransport(cfg, logger)
 	require.NoError(t, err)
-	defer transport.Shutdown()
+	defer transport.Shutdown() //nolint:errcheck
 
 	port := transport.GetAutoBindPort()
 	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	require.NoError(t, err)
-	defer conn.Close()
+	defer conn.Close() //nolint:errcheck
 
 	ourAddr := "127.0.0.1:0"
 	data := []byte("test data")

--- a/pkg/ring/kv/memberlist/tcp_transport_test.go
+++ b/pkg/ring/kv/memberlist/tcp_transport_test.go
@@ -1,7 +1,12 @@
 package memberlist
 
 import (
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
@@ -58,4 +63,57 @@ func TestTCPTransport_WriteTo_ShouldNotLogAsWarningExpectedFailures(t *testing.T
 			}
 		})
 	}
+}
+
+func TestTCPTransport_PacketDigestMismatch(t *testing.T) {
+	logs := &concurrency.SyncBuffer{}
+	logger := log.NewLogfmtLogger(logs)
+
+	cfg := TCPTransportConfig{}
+	flagext.DefaultValues(&cfg)
+	cfg.BindAddrs = []string{"127.0.0.1"}
+	cfg.BindPort = 0
+
+	transport, err := NewTCPTransport(cfg, logger)
+	require.NoError(t, err)
+	defer transport.Shutdown()
+
+	port := transport.GetAutoBindPort()
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	ourAddr := "127.0.0.1:0"
+	data := []byte("test data")
+	wrongDigest := make([]byte, md5.Size) // All zeros, incorrect digest
+
+	var buf bytes.Buffer
+	buf.WriteByte(byte(packet))
+	buf.WriteByte(byte(len(ourAddr)))
+	buf.WriteString(ourAddr)
+	buf.Write(data)
+	buf.Write(wrongDigest)
+
+	_, err = conn.Write(buf.Bytes())
+	require.NoError(t, err)
+	conn.Close() // Close connection to terminate server's io.ReadAll
+
+	packetReceived := make(chan struct{})
+	go func() {
+		select {
+		case <-transport.PacketCh():
+			close(packetReceived)
+		case <-time.After(500 * time.Millisecond):
+			// Expected timeout
+		}
+	}()
+
+	select {
+	case <-packetReceived:
+		t.Fatal("Received corrupted packet, expected it to be dropped")
+	case <-time.After(500 * time.Millisecond):
+		// Success
+	}
+
+	assert.Contains(t, logs.String(), "packet digest mismatch")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

Drop TCP packets when digest verification fails, preventing corrupted payloads from being forwarded.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
