### PR TITLE
fix(ruler): Fix flaky TestRuler_rules by normalizing alert state

### DIFF
--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -237,6 +237,10 @@ func stripEvaluationFields(t *testing.T, r util_api.Response) {
 			rule["health"] = "unknown"
 			rule["evaluationTime"] = 0
 			rule["lastEvaluation"] = "0001-01-01T00:00:00Z"
+			// Normalize alert state to avoid flakiness due to evaluation timing.
+			if rule["type"] == "alerting" {
+				rule["state"] = "unknown"
+			}
 			rules[i] = rule
 		}
 		group["rules"] = rules


### PR DESCRIPTION
The test was racy because the ruler's evaluation loop could transition an alert rule's state from "unknown" to "inactive" before the API response was checked. Normalize the state field in stripEvaluationFields to avoid timing-dependent assertions.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Fix flaky ruler test due to eval timing.

```
FAIL: TestRuler_rules (0.05s)
    api_test.go:306: 
        	Error Trace:	/__w/cortex/cortex/pkg/ruler/api_test.go:306
        	Error:      	Not equal: 
        	            	expected: map[string]interface {}{"data":map[string]interface {}{"groups":[]interface {}{map[string]interface {}{"evaluationTime":0, "file":"namespace1", "interval":10, "lastEvaluation":"0001-01-01T00:00:00Z", "limit":0, "name":"group1", "rules":[]interface {}{map[string]interface {}{"evaluationTime":0, "health":"unknown", "labels":map[string]interface {}{}, "lastError":"", "lastEvaluation":"0001-01-01T00:00:00Z", "name":"UP_RULE", "query":"up", "type":"recording"}, map[string]interface {}{"alerts":[]interface {}{}, "annotations":map[string]interface {}{}, "duration":0, "evaluationTime":0, "health":"unknown", "keepFiringFor":0, "labels":map[string]interface {}{}, "lastError":"", "lastEvaluation":"0001-01-01T00:00:00Z", "name":"UP_ALERT", "query":"up < 1", "state":"unknown", "type":"alerting"}}}}}, "status":"success"}
        	            	actual  : map[string]interface {}{"data":map[string]interface {}{"groups":[]interface {}{map[string]interface {}{"evaluationTime":0, "file":"namespace1", "interval":10, "lastEvaluation":"0001-01-01T00:00:00Z", "limit":0, "name":"group1", "rules":[]interface {}{map[string]interface {}{"evaluationTime":0, "health":"unknown", "labels":map[string]interface {}{}, "lastError":"", "lastEvaluation":"0001-01-01T00:00:00Z", "name":"UP_RULE", "query":"up", "type":"recording"}, map[string]interface {}{"alerts":[]interface {}{}, "annotations":map[string]interface {}{}, "duration":0, "evaluationTime":0, "health":"unknown", "keepFiringFor":0, "labels":map[string]interface {}{}, "lastError":"", "lastEvaluation":"0001-01-01T00:00:00Z", "name":"UP_ALERT", "query":"up < 1", "state":"inactive", "type":"alerting"}}}}}, "status":"success"}
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
