### PR TITLE
fix(integration): Fix flaky TestGRPCCompression by waiting for missin…

### DIFF
--- a/integration/grpc_compression_test.go
+++ b/integration/grpc_compression_test.go
@@ -43,7 +43,8 @@ func TestGRPCCompression(t *testing.T) {
 
 			require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
 				labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
-				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE")),
+				e2e.WaitMissingMetrics))
 
 			c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
 			require.NoError(t, err)
@@ -95,7 +96,8 @@ func TestGRPCCompression(t *testing.T) {
 
 			require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
 				labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
-				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE")),
+				e2e.WaitMissingMetrics))
 
 			c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
 			require.NoError(t, err)


### PR DESCRIPTION
…g metrics

Add e2e.WaitMissingMetrics option to the WaitSumMetricsWithOptions call so the test retries when cortex_ring_members is not yet exposed by the distributor, rather than failing immediately with 'metric not found'.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

```
Ports for container: e2e-cortex-test-querier Mapping: map[80:32810 9095:32811]
    grpc_compression_test.go:44: 
        	Error Trace:	/home/runner/work/cortex/cortex/integration/grpc_compression_test.go:44
        	Error:      	Received unexpected error:
        	            	metric not found
        	            	github.com/cortexproject/cortex/integration/e2e.init
        	            		<autogenerated>:1
        	            	runtime.doInit1
        	            		/opt/hostedtoolcache/go/1.26.2/arm64/src/runtime/proc.go:8103
        	            	runtime.doInit
        	            		/opt/hostedtoolcache/go/1.26.2/arm64/src/runtime/proc.go:8070
        	            	runtime.main
        	            		/opt/hostedtoolcache/go/1.26.2/arm64/src/runtime/proc.go:258
        	            	runtime.goexit
        	            		/opt/hostedtoolcache/go/1.26.2/arm64/src/runtime/asm_arm64.s:1447
        	            	metric=cortex_ring_members service=distributor
        	            	github.com/cortexproject/cortex/integration/e2e.(*HTTPService).SumMetrics
        	            		/home/runner/work/cortex/cortex/integration/e2e/service.go:655
        	            	github.com/cortexproject/cortex/integration/e2e.(*HTTPService).WaitSumMetricsWithOptions
        	            		/home/runner/work/cortex/cortex/integration/e2e/service.go:611
        	            	github.com/cortexproject/cortex/integration.TestGRPCCompression.func1
        	            		/home/runner/work/cortex/cortex/integration/grpc_compression_test.go:44
        	            	testing.tRunner
        	            		/opt/hostedtoolcache/go/1.26.2/arm64/src/testing/testing.go:2036
        	            	runtime.goexit
        	            		/opt/hostedtoolcache/go/1.26.2/arm64/src/runtime/asm_arm64.s:1447
        	Test:       	TestGRPCCompression/ingester_client/gzip
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
