### PR TITLE
fix(ring): Fix flaky TestMinimizeSpreadTokenGenerator

### DIFF
--- a/pkg/ring/token_generator_test.go
+++ b/pkg/ring/token_generator_test.go
@@ -93,7 +93,7 @@ func TestMinimizeSpreadTokenGenerator(t *testing.T) {
 	// Should Generate tokens based on the ring state
 	for i := range 50 {
 		generateTokensForIngesters(t, rindDesc, fmt.Sprintf("minimize-%v", i), zones, minimizeTokenGenerator, dups)
-		assertDistancePerIngester(t, rindDesc, 0.01)
+		assertDistancePerIngester(t, rindDesc, 0.02)
 	}
 	require.Equal(t, mTokenGenerator.called, len(zones))
 
@@ -103,7 +103,7 @@ func TestMinimizeSpreadTokenGenerator(t *testing.T) {
 	rindDesc.AddIngester("partial", "partial", zones[0], rTokens, ACTIVE, time.Now())
 	nTokens := minimizeTokenGenerator.GenerateTokens(rindDesc, "partial", zones[0], 256, true)
 	rindDesc.AddIngester("partial", "partial", zones[0], append(rTokens, nTokens...), ACTIVE, time.Now())
-	assertDistancePerIngester(t, rindDesc, 0.01)
+	assertDistancePerIngester(t, rindDesc, 0.02)
 
 	mTokenGenerator.called = 0
 	// Should fallback to random generator when more than 1 ingester does not have tokens and force flag is set


### PR DESCRIPTION
Increase the token distribution tolerance from 0.01 (1%) to 0.02 (2%). The minimize-spread algorithm is probabilistic and can occasionally produce distributions slightly over 1% error, causing flaky failures. A 2% tolerance still validates the algorithm works correctly.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
