### PR TITLE
fix(integration): Fix flaky TestIngesterMetadata by waiting for missi…

### DIFF
--- a/integration/ingester_metadata_test.go
+++ b/integration/ingester_metadata_test.go
@@ -47,12 +47,14 @@ func TestIngesterMetadata(t *testing.T) {
 	// Wait until distributor has updated the ring.
 	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
 		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE")),
+		e2e.WaitMissingMetrics))
 
 	// Wait until querier has updated the ring.
 	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
 		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE")),
+		e2e.WaitMissingMetrics))
 
 	client, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
 	require.NoError(t, err)


### PR DESCRIPTION
…ng metrics

Add e2e.WaitMissingMetrics option to WaitSumMetricsWithOptions calls so the test retries when cortex_ring_members is not yet exposed, rather than failing immediately with 'metric not found'.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
