### PR TITLE
fix(compactor): Fix flaky TestBlocksCleaner_ShouldRemoveBlocksOutside…

### DIFF
--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -16,6 +16,7 @@ import (
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 
@@ -658,8 +659,7 @@ func TestBlocksCleaner_ListBlocksOutsideRetentionPeriod(t *testing.T) {
 }
 
 func TestBlocksCleaner_ShouldRemoveBlocksOutsideRetentionPeriod(t *testing.T) {
-	bucketClient, _ := cortex_testutil.PrepareFilesystemBucket(t)
-	bucketClient = bucketindex.BucketWithGlobalMarkers(bucketClient)
+	bucketClient := bucketindex.BucketWithGlobalMarkers(objstore.WithNoopInstr(objstore.NewInMemBucket()))
 
 	ts := func(hours int) int64 {
 		return time.Now().Add(time.Duration(hours)*time.Hour).Unix() * 1000


### PR DESCRIPTION
…RetentionPeriod

Switch from filesystem bucket to in-memory bucket in this test. The filesystem bucket's Upload is non-atomic (os.Create truncates, then io.Copy writes), creating a race window where the HeartBeat goroutine's write can be observed as an empty file by a concurrent read. The in-memory bucket's Upload is atomic (mutex-protected), eliminating the race.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Fix flaky test by switching to use an inmemory bucket to eliminate possible race condition when the visit marker is being uploaded.

```
--- FAIL: TestBlocksCleaner_ShouldRemoveBlocksOutsideRetentionPeriod (0.06s)
    blocks_cleaner_test.go:822: 
        	Error Trace:	/__w/cortex/cortex/pkg/compactor/blocks_cleaner_test.go:822
        	Error:      	Received unexpected error:
        	            	failed to read cleaner visit marker: visit marker file: markers/cleaner-visit-marker.json, content: , error: unexpected end of JSON input: unmarshal visit marker JSON
        	Test:       	TestBlocksCleaner_ShouldRemoveBlocksOutsideRetentionPeriod

```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
