### PR TITLE
update regex resolve cache only if known user changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [FEATURE] Memberlist: Add `-memberlist.cluster-label` and `-memberlist.cluster-label-verification-disabled` to prevent accidental cross-cluster gossip joins and support rolling label rollout. #7385
 * [FEATURE] Querier: Add timeout classification to classify query timeouts as 4XX (user error) or 5XX (system error) based on phase timing. When enabled, queries that spend most of their time in PromQL evaluation return `422 Unprocessable Entity` instead of `503 Service Unavailable`. #7374
 * [FEATURE] Querier: Implement Resource Based Throttling in Querier. #7442
+* [ENHANCEMENT] Tenant Federation: Avoid purging the regex resolver LRU cache on user-sync ticks when the set of known users has not changed. #7489
 * [ENHANCEMENT] Parquet Converter: Add a ring status page to expose the ring status. #7455
 * [ENHANCEMENT] Ingester: Add WAL record metrics to help evaluate the effectiveness of WAL compression type (e.g. snappy, zstd): `cortex_ingester_tsdb_wal_record_part_writes_total`, `cortex_ingester_tsdb_wal_record_parts_bytes_written_total`, and `cortex_ingester_tsdb_wal_record_bytes_saved_total`. #7420
 * [ENHANCEMENT] Distributor: Introduce dynamic `Symbols` slice capacity pooling. #7398 #7401

--- a/pkg/querier/tenantfederation/regex_resolver.go
+++ b/pkg/querier/tenantfederation/regex_resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -126,13 +127,14 @@ func (r *RegexResolver) running(ctx context.Context) error {
 				level.Error(r.logger).Log("msg", "failed to discover users from bucket", "err", err)
 			}
 
-			r.Lock()
-			r.knownUsers = append(active, deleting...)
-			// We keep it sort
-			sort.Strings(r.knownUsers)
+			newUsers := append(active, deleting...)
+			sort.Strings(newUsers)
 
-			// Reset the cache because the set of available users has changed.
-			if r.matchedCache != nil {
+			r.Lock()
+			changed := !slices.Equal(r.knownUsers, newUsers)
+			r.knownUsers = newUsers
+			if changed && r.matchedCache != nil {
+				// Reset the cache when the set of available users has changed.
 				r.matchedCache.Purge()
 				r.matchedCacheSize.Set(0)
 			}

--- a/pkg/querier/tenantfederation/regex_resolver_test.go
+++ b/pkg/querier/tenantfederation/regex_resolver_test.go
@@ -361,6 +361,62 @@ func Test_RegexResolver_UsesConfiguredCacheSize(t *testing.T) {
 	regexResolver.RUnlock()
 }
 
+func Test_RegexResolver_CacheNotPurgedWhenUsersUnchanged(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	existingTenants := []string{"user-1", "user-2"}
+	bucketClient := &bucket.ClientMock{}
+	bucketClient.MockIter("", existingTenants, nil)
+	bucketClient.MockIter("__markers__", []string{}, nil)
+	for _, tenant := range existingTenants {
+		bucketClient.MockExists(users.GetGlobalDeletionMarkPath(tenant), false, nil)
+		bucketClient.MockExists(users.GetLocalDeletionMarkPath(tenant), false, nil)
+	}
+
+	bucketClientFactory := func(ctx context.Context) (objstore.InstrumentedBucket, error) {
+		return bucketClient, nil
+	}
+
+	usersScannerConfig := users.UsersScannerConfig{Strategy: users.UserScanStrategyList}
+	// Short sync interval to trigger multiple ticks quickly.
+	tenantFederationConfig := Config{UserSyncInterval: 100 * time.Millisecond, MaxTenant: 0, RegexCacheSize: 10}
+	regexResolver, err := NewRegexResolver(usersScannerConfig, tenantFederationConfig, reg, bucketClientFactory, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), regexResolver))
+	defer services.StopAndAwaitTerminated(context.Background(), regexResolver) //nolint:errcheck
+
+	// Wait for initial sync.
+	test.Poll(t, time.Second*10, true, func() any {
+		return testutil.ToFloat64(regexResolver.lastUpdateUserRun) > 0 &&
+			testutil.ToFloat64(regexResolver.discoveredUsers) == float64(len(existingTenants))
+	})
+
+	// Populate the cache with a regex query.
+	ctx := user.InjectOrgID(context.Background(), "user-.+")
+	orgIDs, err := regexResolver.TenantIDs(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"user-1", "user-2"}, orgIDs)
+
+	// Verify cache is populated.
+	regexResolver.RLock()
+	require.Equal(t, 1, regexResolver.matchedCache.Len())
+	regexResolver.RUnlock()
+
+	// Record the timestamp of the first sync run.
+	firstRunTime := testutil.ToFloat64(regexResolver.lastUpdateUserRun)
+
+	// Wait for a second sync tick.
+	// so the cache should NOT be purged.
+	test.Poll(t, time.Second*10, true, func() any {
+		return testutil.ToFloat64(regexResolver.lastUpdateUserRun) > firstRunTime
+	})
+
+	// Cache must still contain the entry because users have not changed.
+	regexResolver.RLock()
+	cacheLen := regexResolver.matchedCache.Len()
+	regexResolver.RUnlock()
+	require.Equal(t, 1, cacheLen, "cache should not be purged when the set of users has not changed")
+}
+
 func BenchmarkRegexResolver_TenantIDs(b *testing.B) {
 	numUsers := 1000
 	existingTenants := make([]string, numUsers)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR avoids purging the regex resolver LRU cache when the set of known users has not changed between user-sync ticks to reduce cold misses.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
