### PR TITLE
Fix flaky TestQueryFrontendResponseSizeLimit: wait for ring convergence

### DIFF
--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -989,6 +989,9 @@ func TestQueryFrontendResponseSizeLimit(t *testing.T) {
 	require.NoError(t, s.StartAndWaitReady(distributor, ingester, querier))
 	require.NoError(t, s.WaitReady(queryFrontend))
 
+	// Wait until the distributor has discovered the ingester in the ring.
+	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+
 	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", "user-1")
 	require.NoError(t, err)
 


### PR DESCRIPTION
**What this PR does:**

Wait for the distributor to discover the ingester in the ring before pushing samples in `TestQueryFrontendResponseSizeLimit`.

**Why:**

The test was flaky because `StartAndWaitReady` only ensures the HTTP endpoint is healthy, not that the distributor has discovered the ingester's tokens in the hash ring. This caused intermittent `DoBatch: InstancesCount <= 0` errors (HTTP 500 on push).

**Fix:**

Added `distributor.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total")` before the push loop, consistent with other integration tests in the same file (e.g., lines 323, 490, 583).