### PR TITLE
fix(ha): Fix flaky TestWatchPrefixNilPanicWithMemberlist

### DIFF
--- a/pkg/ha/ha_tracker_test.go
+++ b/pkg/ha/ha_tracker_test.go
@@ -265,10 +265,16 @@ func TestWatchPrefixNilPanicWithMemberlist(t *testing.T) {
 	replica := "replica0"
 	key := userID + "/" + cluster
 
+	// Give the WatchPrefix goroutine in loop() time to register its watcher
+	// channel in the memberlist KV before we write. Without this, the CAS
+	// notification can fire before the watcher is registered, causing the
+	// key to never appear in the elected cache.
+	time.Sleep(100 * time.Millisecond)
+
 	now := time.Now()
 	require.NoError(t, tracker.CheckReplica(ctx, userID, cluster, replica, now))
 
-	test.Poll(t, 3*time.Second, nil, func() any {
+	test.Poll(t, 5*time.Second, nil, func() any {
 		tracker.electedLock.RLock()
 		defer tracker.electedLock.RUnlock()
 		if _, ok := tracker.elected[key]; !ok {


### PR DESCRIPTION
## Summary

Fix flaky `TestWatchPrefixNilPanicWithMemberlist` test in `pkg/ha`.

## Root Cause

The test has a race condition between the `WatchPrefix` watcher registration in `loop()` and the `CheckReplica` call. When the HATracker starts, `StartAndAwaitRunning` returns as soon as the service transitions to Running state, but the `loop()` goroutine hasn't yet registered its watcher channel in the memberlist KV. If `CheckReplica`'s CAS + `notifyWatchers` fires before the watcher is registered, the notification is lost and the key never appears in the `elected` cache, causing the 3-second poll to time out.

## Fix

1. Added a 100ms sleep before `CheckReplica` to allow the `WatchPrefix` goroutine to register its watcher channel. This is the same pattern used in `pkg/ring/kv/memberlist/memberlist_client_test.go` (line 1650).
2. Increased the poll timeout from 3s to 5s for additional CI robustness.

## Testing

- Ran the test 30 consecutive times with `-count=30` — all pass.
- Full `pkg/ha` test suite passes.