### PR TITLE
fix(scheduler): Fix flaky TestQueueConcurrency deadlock

### DIFF
--- a/pkg/scheduler/queue/user_queues_test.go
+++ b/pkg/scheduler/queue/user_queues_test.go
@@ -481,7 +481,9 @@ func TestQueueConcurrency(t *testing.T) {
 				queue.enqueueRequest(MockRequest{})
 				q.getNextQueueForQuerier(0, "q-1")
 			} else if cnt%5 == 0 {
-				queue.dequeueRequest(0, false)
+				if queue.length() > 0 {
+					queue.dequeueRequest(0, false)
+				}
 			} else if cnt%7 == 0 {
 				q.deleteQueue("userID")
 			}


### PR DESCRIPTION
## What this PR does
Fix flaky `TestQueueConcurrency` that could deadlock due to goroutines blocking on `dequeueRequest` with an empty channel.

## Root Cause
`FIFORequestQueue.dequeueRequest` performs a blocking channel receive (`r := <-f.queue`). In the test, goroutines with `cnt=5,15,25` (odd multiples of 5) call `dequeueRequest` unconditionally. If they execute before any enqueue goroutines populate the channel, they block forever, and the `WaitGroup.Wait()` never completes — causing a 30-minute timeout.

## Fix
Guard the `dequeueRequest` call with `queue.length() > 0` to prevent blocking on an empty channel.

## How it was tested
- `go test -run TestQueueConcurrency -count=10` — 10/10 pass
- `go test -race -run TestQueueConcurrency -count=10` — clean
- Full package test suite passes