### PR TITLE
fix(util): Fix flaky TestWorkerPool_TestMetric race condition

### DIFF
--- a/pkg/util/worker_pool_test.go
+++ b/pkg/util/worker_pool_test.go
@@ -32,10 +32,18 @@ func TestWorkerPool_TestMetric(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
+	// Use a channel to signal that the first job has started executing.
+	started := make(chan struct{})
+
 	// Block the first job
 	workerPool.Submit(func() {
+		close(started)
 		wg.Wait()
 	})
+
+	// Wait for the first job to actually start running on the worker,
+	// ensuring the worker is busy before we submit the next job.
+	<-started
 
 	// create an extra job to increment the metric
 	workerPool.Submit(func() {})


### PR DESCRIPTION
## What this PR does

Fixes the flaky `TestWorkerPool_TestMetric` test in `pkg/util`.

## Root Cause

The test was racy because the first `Submit()` could hit the `select default` case (fallback path) if the worker goroutine hadn't started receiving on the channel yet. Since the channel is unbuffered and `Submit` uses a non-blocking select:

```go
select {
case s.serverWorkerChannel <- f:
default:
    s.fallbackTotal.Inc()
    go f()
}
```

If the single worker goroutine wasn't ready to receive when the first job was submitted, both jobs would go through the fallback path, incrementing the counter to 2 instead of the expected 1.

## Fix

Add a `started` channel that the first job closes once it begins executing. The test waits on this channel before submitting the second job, ensuring the worker is actually busy.

## Verification

Ran the test 50 times with `-count=50` and with `-race` — all pass consistently.
