### PR TITLE
fix(alertmanager): Fix flaky TestMultitenantAlertmanager_InitialSyncFailureWithSharding

### DIFF
--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -1775,7 +1775,12 @@ func TestMultitenantAlertmanager_InitialSyncFailureWithSharding(t *testing.T) {
 	err = am.AwaitRunning(ctx)
 	require.Error(t, err)
 	require.Equal(t, services.Failed, am.State())
-	require.False(t, am.ringLifecycler.IsRegistered())
+
+	// The lifecycler's background goroutine may briefly re-register the instance
+	// before the stopping function fully unregisters it. Poll until unregistered.
+	require.Eventually(t, func() bool {
+		return !am.ringLifecycler.IsRegistered()
+	}, 5*time.Second, 100*time.Millisecond)
 	require.NotNil(t, am.ring)
 }
 


### PR DESCRIPTION
## What this PR does

Fixes the flaky `TestMultitenantAlertmanager_InitialSyncFailureWithSharding` test in `pkg/alertmanager`.

## Root Cause

The test asserts `require.False(t, am.ringLifecycler.IsRegistered())` immediately after the service transitions to `Failed` state. However, the ring lifecycler has a background goroutine that detects the instance is missing from the ring and re-registers it (`"instance missing in the ring, adding it back"`). There's a race between:

1. The `stopping()` function unregistering the instance
2. The lifecycler's auto-join goroutine re-registering it
3. The test checking `IsRegistered()`

## Fix

Replace the immediate `require.False` assertion with `require.Eventually`, polling for the unregistered state with a 5s timeout and 100ms interval. This gives the stopping process time to fully unregister the instance.

## Verification

Ran the test 5 times — all pass consistently.
