### PR TITLE
feat(ingester): Add head-only queried series metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CHANGE] Cache: Setting `-blocks-storage.bucket-store.metadata-cache.bucket-index-content-ttl` to 0 will disable the bucket-index cache. #7446
 * [CHANGE] HA Tracker: Move `-distributor.ha-tracker.failover-timeout` from a global config to a per-tenant runtime config. The flag name and default value (30s) remain the same. #7481
 * [FEATURE] Ingester: Add experimental active series tracker that counts active series by configurable label matchers (including regex) per tenant and exposes `cortex_ingester_active_series_per_tracker` metric. Configured via `active_series_trackers` in runtime config overrides. #7476
+* [FEATURE] Ingester: Add experimental head-only queried series metric. `cortex_ingester_queried_head_series` tracks unique series queried from head via HLL. Enabled via `-ingester.head-queried-series-metrics-enabled`. #7500
 * [FEATURE] Ruler: Add per-tenant `ruler_alert_generator_url_template` runtime config option to customize alert generator URLs using Go templates. Includes a `jsonEscape` template function for safely embedding expressions in JSON-encoded URL parameters (e.g., Grafana Explore panes). Supports Grafana Explore, Perses, and other UIs. #7302
 * [FEATURE] Distributor: Add experimental `-distributor.enable-start-timestamp` flag for Prometheus Remote Write 2.0. When enabled, `StartTimestamp (ST)` is ingested. #7371
 * [FEATURE] Memberlist: Add `-memberlist.cluster-label` and `-memberlist.cluster-label-verification-disabled` to prevent accidental cross-cluster gossip joins and support rolling label rollout. #7385

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3804,6 +3804,24 @@ lifecycler:
 # CLI flag: -ingester.active-queried-series-metrics-windows
 [active_queried_series_metrics_windows: <list of duration> | default = 2h0m0s]
 
+# Experimental: Enable tracking of series queried from head only and expose them
+# as metrics.
+# CLI flag: -ingester.head-queried-series-metrics-enabled
+[head_queried_series_metrics_enabled: <boolean> | default = false]
+
+# Duration of each sub-window for head queried series tracking.
+# CLI flag: -ingester.head-queried-series-metrics-window-duration
+[head_queried_series_metrics_window_duration: <duration> | default = 15m]
+
+# Sampling rate for head queried series tracking (1.0 = 100%%).
+# CLI flag: -ingester.head-queried-series-metrics-sample-rate
+[head_queried_series_metrics_sample_rate: <float> | default = 1]
+
+# Time windows to expose head queried series metrics. Also controls how long
+# per-metric-name cardinality is reported after last query.
+# CLI flag: -ingester.head-queried-series-metrics-windows
+[head_queried_series_metrics_windows: <list of duration> | default = 2h0m0s]
+
 # Enable uploading compacted blocks.
 # CLI flag: -ingester.upload-compacted-blocks-enabled
 [upload_compacted_blocks_enabled: <boolean> | default = true]

--- a/docs/configuration/v1-guarantees.md
+++ b/docs/configuration/v1-guarantees.md
@@ -137,3 +137,9 @@ Currently experimental features are:
   - `-blocks-storage.expanded_postings_cache.head.lazy-matcher-max-cardinality` (int) CLI flag
   - `-blocks-storage.expanded_postings_cache.head.lazy-matcher-simple-cost-ratio` (int) CLI flag
   - `-blocks-storage.expanded_postings_cache.head.lazy-matcher-complex-cost-ratio` (int) CLI flag
+- Ingester: Head Queried Series Metrics
+  - Enable on Ingester via `-ingester.head-queried-series-metrics-enabled=true`
+  - Tracks unique series queried from head only (not blocks) using HLL
+  - `-ingester.head-queried-series-metrics-windows` time windows to report (default: 2h)
+  - `-ingester.head-queried-series-metrics-window-duration` HLL sub-window size
+  - `-ingester.head-queried-series-metrics-sample-rate` query sampling rate

--- a/pkg/ingester/head_queried_series_querier.go
+++ b/pkg/ingester/head_queried_series_querier.go
@@ -1,0 +1,80 @@
+package ingester
+
+import (
+	"context"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+)
+
+var (
+	rangeHeadULID = ulid.MustParse("0000000000XXXXXXXRANGEHEAD")
+	headULID      = ulid.MustParse("0000000000XXXXXXXXXXXXHEAD")
+)
+
+// isHead returns true if the given BlockReader is a head block (in-order or OOO).
+func isHead(b tsdb.BlockReader) bool {
+	id := b.Meta().ULID
+	return id == rangeHeadULID || id == headULID
+}
+
+// headQueriedSeriesChunkQuerier wraps a ChunkQuerier for the head block and
+// intercepts Select calls to collect series hashes for HLL tracking.
+type headQueriedSeriesChunkQuerier struct {
+	storage.ChunkQuerier
+	headQueriedSeries          *ActiveQueriedSeries
+	activeQueriedSeriesService *ActiveQueriedSeriesService
+	userID                     string
+	sampled                    bool
+}
+
+func (q *headQueriedSeriesChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {
+	ss := q.ChunkQuerier.Select(ctx, sortSeries, hints, matchers...)
+
+	// Wrap series set for hash collection only if sampled.
+	if !q.sampled {
+		return ss
+	}
+	return &headQueriedSeriesSet{
+		ChunkSeriesSet:             ss,
+		headQueriedSeries:          q.headQueriedSeries,
+		activeQueriedSeriesService: q.activeQueriedSeriesService,
+		userID:                     q.userID,
+		hashes:                     getQueriedSeriesHashesSlice(),
+	}
+}
+
+// headQueriedSeriesSet wraps a ChunkSeriesSet to collect series label hashes
+// during iteration and flush them to the HLL tracker when iteration completes.
+type headQueriedSeriesSet struct {
+	storage.ChunkSeriesSet
+	headQueriedSeries          *ActiveQueriedSeries
+	activeQueriedSeriesService *ActiveQueriedSeriesService
+	userID                     string
+	hashes                     []uint64
+}
+
+func (s *headQueriedSeriesSet) Next() bool {
+	if !s.ChunkSeriesSet.Next() {
+		s.flush()
+		return false
+	}
+	s.hashes = append(s.hashes, s.ChunkSeriesSet.At().Labels().Hash())
+	return true
+}
+
+func (s *headQueriedSeriesSet) At() storage.ChunkSeries {
+	return s.ChunkSeriesSet.At()
+}
+
+func (s *headQueriedSeriesSet) flush() {
+	if len(s.hashes) > 0 && s.activeQueriedSeriesService != nil {
+		s.activeQueriedSeriesService.UpdateSeriesBatch(s.headQueriedSeries, s.hashes, time.Now(), s.userID)
+	} else if len(s.hashes) > 0 {
+		// If no service, return the slice to the pool.
+		putQueriedSeriesHashesSlice(s.hashes)
+	}
+}

--- a/pkg/ingester/head_queried_series_querier_test.go
+++ b/pkg/ingester/head_queried_series_querier_test.go
@@ -1,0 +1,141 @@
+package ingester
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
+	"github.com/prometheus/prometheus/util/annotations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsHead(t *testing.T) {
+	tests := []struct {
+		name     string
+		ulid     ulid.ULID
+		expected bool
+	}{
+		{"rangeHead", rangeHeadULID, true},
+		{"head", headULID, true},
+		{"random block", ulid.MustNew(1, nil), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &mockBlockReader{meta: tsdb.BlockMeta{ULID: tc.ulid}}
+			assert.Equal(t, tc.expected, isHead(b))
+		})
+	}
+}
+
+func TestHeadQueriedSeriesSet_CollectsHashes(t *testing.T) {
+	lbls1 := labels.FromStrings("__name__", "metric_a", "job", "foo")
+	lbls2 := labels.FromStrings("__name__", "metric_a", "job", "bar")
+
+	inner := &mockChunkSeriesSet{
+		series: []storage.ChunkSeries{
+			&mockChunkSeries{lbls: lbls1},
+			&mockChunkSeries{lbls: lbls2},
+		},
+	}
+
+	hll := NewActiveQueriedSeries(
+		[]time.Duration{2 * time.Hour},
+		15*time.Minute,
+		1.0,
+		nil,
+	)
+
+	// Use a real service to process the hashes.
+	svc := NewActiveQueriedSeriesService(log.NewNopLogger(), nil)
+	require.NoError(t, svc.StartAsync(context.Background()))
+	defer svc.StopAsync()
+	require.NoError(t, svc.AwaitRunning(context.Background()))
+
+	wrapper := &headQueriedSeriesChunkQuerier{
+		ChunkQuerier:               &mockChunkQuerierWithSeries{inner: inner},
+		headQueriedSeries:          hll,
+		activeQueriedSeriesService: svc,
+		userID:                     "user-1",
+		sampled:                    true,
+	}
+
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "metric_a"),
+	}
+
+	ss := wrapper.Select(context.Background(), false, nil, matchers...)
+	count := 0
+	for ss.Next() {
+		count++
+	}
+	assert.Equal(t, 2, count)
+
+	// Give the async worker time to process.
+	time.Sleep(50 * time.Millisecond)
+
+	estimate, err := hll.GetSeriesQueried(time.Now(), 2*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), estimate)
+}
+
+// Mock implementations
+
+type mockBlockReader struct {
+	meta tsdb.BlockMeta
+}
+
+func (m *mockBlockReader) Meta() tsdb.BlockMeta                   { return m.meta }
+func (m *mockBlockReader) Index() (tsdb.IndexReader, error)       { return nil, nil }
+func (m *mockBlockReader) Chunks() (tsdb.ChunkReader, error)      { return nil, nil }
+func (m *mockBlockReader) Tombstones() (tombstones.Reader, error) { return nil, nil }
+func (m *mockBlockReader) Size() int64                            { return 0 }
+func (m *mockBlockReader) String() string                         { return "" }
+func (m *mockBlockReader) MinTime() int64                         { return 0 }
+func (m *mockBlockReader) MaxTime() int64                         { return 0 }
+
+type mockChunkQuerierWithSeries struct {
+	inner *mockChunkSeriesSet
+}
+
+func (q *mockChunkQuerierWithSeries) Select(_ context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.ChunkSeriesSet {
+	return q.inner
+}
+func (q *mockChunkQuerierWithSeries) LabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (q *mockChunkQuerierWithSeries) LabelNames(_ context.Context, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (q *mockChunkQuerierWithSeries) Close() error { return nil }
+
+type mockChunkSeriesSet struct {
+	series []storage.ChunkSeries
+	idx    int
+}
+
+func (m *mockChunkSeriesSet) Next() bool {
+	if m.idx >= len(m.series) {
+		return false
+	}
+	m.idx++
+	return true
+}
+func (m *mockChunkSeriesSet) At() storage.ChunkSeries           { return m.series[m.idx-1] }
+func (m *mockChunkSeriesSet) Err() error                        { return nil }
+func (m *mockChunkSeriesSet) Warnings() annotations.Annotations { return nil }
+
+type mockChunkSeries struct {
+	lbls labels.Labels
+}
+
+func (m *mockChunkSeries) Labels() labels.Labels                      { return m.lbls }
+func (m *mockChunkSeries) Iterator(_ chunks.Iterator) chunks.Iterator { return nil }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -136,6 +136,11 @@ type Config struct {
 	ActiveQueriedSeriesMetricsSampleRate     float64                  `yaml:"active_queried_series_metrics_sample_rate"`
 	ActiveQueriedSeriesMetricsWindows        cortex_tsdb.DurationList `yaml:"active_queried_series_metrics_windows"`
 
+	HeadQueriedSeriesMetricsEnabled        bool                     `yaml:"head_queried_series_metrics_enabled"`
+	HeadQueriedSeriesMetricsWindowDuration time.Duration            `yaml:"head_queried_series_metrics_window_duration"`
+	HeadQueriedSeriesMetricsSampleRate     float64                  `yaml:"head_queried_series_metrics_sample_rate"`
+	HeadQueriedSeriesMetricsWindows        cortex_tsdb.DurationList `yaml:"head_queried_series_metrics_windows"`
+
 	// Use blocks storage.
 	BlocksStorageConfig cortex_tsdb.BlocksStorageConfig `yaml:"-"`
 
@@ -201,6 +206,12 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&cfg.ActiveQueriedSeriesMetricsSampleRate, "ingester.active-queried-series-metrics-sample-rate", 1.0, "Sampling rate for active queried series tracking (1.0 = 100% sampling, 0.1 = 10% sampling). By default, all queries are sampled.")
 	cfg.ActiveQueriedSeriesMetricsWindows = cortex_tsdb.DurationList{2 * time.Hour}
 	f.Var(&cfg.ActiveQueriedSeriesMetricsWindows, "ingester.active-queried-series-metrics-windows", "Time windows to expose queried series metric. Each window tracks queried series within that time period.")
+
+	f.BoolVar(&cfg.HeadQueriedSeriesMetricsEnabled, "ingester.head-queried-series-metrics-enabled", false, "Experimental: Enable tracking of series queried from head only and expose them as metrics.")
+	f.DurationVar(&cfg.HeadQueriedSeriesMetricsWindowDuration, "ingester.head-queried-series-metrics-window-duration", 15*time.Minute, "Duration of each sub-window for head queried series tracking.")
+	f.Float64Var(&cfg.HeadQueriedSeriesMetricsSampleRate, "ingester.head-queried-series-metrics-sample-rate", 1.0, "Sampling rate for head queried series tracking (1.0 = 100%%).")
+	cfg.HeadQueriedSeriesMetricsWindows = cortex_tsdb.DurationList{2 * time.Hour}
+	f.Var(&cfg.HeadQueriedSeriesMetricsWindows, "ingester.head-queried-series-metrics-windows", "Time windows to expose head queried series metrics. Also controls how long per-metric-name cardinality is reported after last query.")
 
 	f.BoolVar(&cfg.UploadCompactedBlocksEnabled, "ingester.upload-compacted-blocks-enabled", true, "Enable uploading compacted blocks.")
 	f.StringVar(&cfg.IgnoreSeriesLimitForMetricNames, "ingester.ignore-series-limit-for-metric-names", "", "Comma-separated list of metric names, for which -ingester.max-series-per-metric and -ingester.max-global-series-per-metric limits will be ignored. Does not affect max-series-per-user or max-global-series-per-metric limits.")
@@ -367,6 +378,7 @@ type userTSDB struct {
 	userID              string
 	activeSeries        *ActiveSeries
 	activeQueriedSeries *ActiveQueriedSeries
+	headQueriedSeries   *ActiveQueriedSeries
 	seriesInMetric      *metricCounter
 	labelSetCounter     *labelSetCounter
 	limiter             *Limiter
@@ -803,7 +815,7 @@ func New(cfg Config, limits *validation.Overrides, registerer prometheus.Registe
 		matchersCache:                storecache.NoopMatchersCache,
 	}
 
-	if cfg.ActiveQueriedSeriesMetricsEnabled {
+	if cfg.ActiveQueriedSeriesMetricsEnabled || cfg.HeadQueriedSeriesMetricsEnabled {
 		i.activeQueriedSeriesService = NewActiveQueriedSeriesService(logger, registerer)
 	}
 
@@ -820,6 +832,7 @@ func New(cfg Config, limits *validation.Overrides, registerer prometheus.Registe
 		false,
 		cfg.ActiveSeriesMetricsEnabled,
 		cfg.ActiveQueriedSeriesMetricsEnabled,
+		cfg.HeadQueriedSeriesMetricsEnabled,
 		i.getInstanceLimits,
 		i.ingestionRate,
 		&i.maxInflightPushRequests,
@@ -915,6 +928,7 @@ func NewForFlusher(cfg Config, limits *validation.Overrides, registerer promethe
 		cfg.AdminLimitMessage,
 	)
 	i.metrics = newIngesterMetrics(registerer,
+		false,
 		false,
 		false,
 		false,
@@ -1058,6 +1072,13 @@ func (i *Ingester) updateLoop(ctx context.Context) error {
 		defer t.Stop()
 	}
 
+	var headQueriedSeriesTickerChan <-chan time.Time
+	if i.cfg.HeadQueriedSeriesMetricsEnabled {
+		t := time.NewTicker(i.cfg.ActiveQueriedSeriesMetricsUpdatePeriod)
+		headQueriedSeriesTickerChan = t.C
+		defer t.Stop()
+	}
+
 	// Similarly to the above, this is a hardcoded value.
 	metadataPurgeTicker := time.NewTicker(metadataPurgePeriod)
 	defer metadataPurgeTicker.Stop()
@@ -1086,6 +1107,8 @@ func (i *Ingester) updateLoop(ctx context.Context) error {
 			i.updateActiveSeries(ctx)
 		case <-activeQueriedSeriesTickerChan:
 			i.updateActiveQueriedSeries(ctx)
+		case <-headQueriedSeriesTickerChan:
+			i.updateHeadQueriedMetrics(ctx)
 		case <-maxTrackerResetTicker.C:
 			i.maxInflightQueryRequests.Tick()
 			i.maxInflightPushRequests.Tick()
@@ -1185,6 +1208,30 @@ func (i *Ingester) updateActiveQueriedSeries(ctx context.Context) {
 			// Update metric with window label
 			i.metrics.activeQueriedSeriesPerUser.WithLabelValues(userID, windowDuration.String()).Set(float64(estimatedCount))
 		}
+	}
+}
+
+func (i *Ingester) updateHeadQueriedMetrics(ctx context.Context) {
+	now := time.Now()
+	for _, userID := range i.getTSDBUsers() {
+		userDB, err := i.getTSDB(userID)
+		if err != nil || userDB == nil {
+			continue
+		}
+
+		// Metric 1: total series queried from head (HLL)
+		if userDB.headQueriedSeries != nil {
+			userDB.headQueriedSeries.Purge(now)
+			for _, windowDuration := range i.cfg.HeadQueriedSeriesMetricsWindows {
+				estimatedCount, err := userDB.headQueriedSeries.GetSeriesQueried(now, windowDuration)
+				if err != nil {
+					level.Error(logutil.WithContext(ctx, i.logger)).Log("msg", "failed to get head queried series count", "user", userID, "window", windowDuration, "err", err)
+					continue
+				}
+				i.metrics.headQueriedSeriesPerUser.WithLabelValues(userID, windowDuration.String()).Set(float64(estimatedCount))
+			}
+		}
+
 	}
 }
 
@@ -2886,11 +2933,28 @@ func (i *Ingester) blockChunkQuerierFunc(userId string) tsdb.BlockChunkQuerierFu
 		// This occurs because the tsdb.PostingsForMatchers function can return invalid data in such scenarios.
 		// For more details, see: https://github.com/cortexproject/cortex/issues/6556
 		// TODO: alanprot: Consider removing this logic when prometheus is updated as this logic is "fixed" upstream.
+		var q storage.ChunkQuerier
 		if postingCache == nil || mint > db.Head().MaxTime() {
-			return tsdb.NewBlockChunkQuerier(b, mint, maxt)
+			q, err = tsdb.NewBlockChunkQuerier(b, mint, maxt)
+		} else {
+			q, err = cortex_tsdb.NewCachedBlockChunkQuerier(postingCache, b, mint, maxt)
+		}
+		if err != nil {
+			return nil, err
 		}
 
-		return cortex_tsdb.NewCachedBlockChunkQuerier(postingCache, b, mint, maxt)
+		// Wrap only for head queriers when head queried series metrics are enabled.
+		if i.cfg.HeadQueriedSeriesMetricsEnabled && isHead(b) && db != nil && db.headQueriedSeries != nil {
+			q = &headQueriedSeriesChunkQuerier{
+				ChunkQuerier:               q,
+				headQueriedSeries:          db.headQueriedSeries,
+				activeQueriedSeriesService: i.activeQueriedSeriesService,
+				userID:                     userId,
+				sampled:                    db.headQueriedSeries.SampleRequest(),
+			}
+		}
+
+		return q, nil
 	}
 }
 
@@ -2917,10 +2981,21 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 		)
 	}
 
+	var headQueriedSeries *ActiveQueriedSeries
+	if i.cfg.HeadQueriedSeriesMetricsEnabled {
+		headQueriedSeries = NewActiveQueriedSeries(
+			i.cfg.HeadQueriedSeriesMetricsWindows,
+			i.cfg.HeadQueriedSeriesMetricsWindowDuration,
+			i.cfg.HeadQueriedSeriesMetricsSampleRate,
+			i.logger,
+		)
+	}
+
 	userDB := &userTSDB{
 		userID:              userID,
 		activeSeries:        NewActiveSeries(),
 		activeQueriedSeries: activeQueriedSeries,
+		headQueriedSeries:   headQueriedSeries,
 		seriesInMetric:      newMetricCounter(i.limiter, i.cfg.getIgnoreSeriesLimitForMetricNamesMap()),
 		labelSetCounter:     newLabelSetCounter(i.limiter),
 		trackerCounter:      newTrackerCounter(),

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -60,6 +60,7 @@ type ingesterMetrics struct {
 	activeSeriesPerUser        *prometheus.GaugeVec
 	activeNHSeriesPerUser      *prometheus.GaugeVec
 	activeQueriedSeriesPerUser *prometheus.GaugeVec
+	headQueriedSeriesPerUser   *prometheus.GaugeVec
 	limitsPerLabelSet          *prometheus.GaugeVec
 	usagePerLabelSet           *prometheus.GaugeVec
 	activeSeriesPerTracker     *prometheus.GaugeVec
@@ -89,6 +90,7 @@ func newIngesterMetrics(r prometheus.Registerer,
 	createMetricsConflictingWithTSDB bool,
 	activeSeriesEnabled bool,
 	activeQueriedSeriesEnabled bool,
+	headQueriedSeriesEnabled bool,
 	instanceLimitsFn func() *InstanceLimits,
 	ingestionRate *util_math.EwmaRate,
 	inflightPushRequests *util_math.MaxTracker,
@@ -311,6 +313,12 @@ func newIngesterMetrics(r prometheus.Registerer,
 			Name: "cortex_ingester_active_queried_series",
 			Help: "Estimated number of currently active queried series per user (probabilistic count using HyperLogLog).",
 		}, []string{"user", "window"}),
+
+		// Not registered automatically, but only if headQueriedSeriesEnabled is true.
+		headQueriedSeriesPerUser: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_ingester_queried_head_series",
+			Help: "Estimated number of unique series queried from head within the configured time window.",
+		}, []string{"user", "window"}),
 	}
 
 	if regexMatcherLimitsEnabled {
@@ -358,6 +366,10 @@ func newIngesterMetrics(r prometheus.Registerer,
 		r.MustRegister(m.activeQueriedSeriesPerUser)
 	}
 
+	if headQueriedSeriesEnabled && r != nil {
+		r.MustRegister(m.headQueriedSeriesPerUser)
+	}
+
 	if createMetricsConflictingWithTSDB {
 		m.memSeriesCreatedTotal = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Name: memSeriesCreatedTotalName,
@@ -384,6 +396,7 @@ func (m *ingesterMetrics) deletePerUserMetrics(userID string) {
 	m.activeNHSeriesPerUser.DeleteLabelValues(userID)
 	m.activeSeriesPerTracker.DeletePartialMatch(prometheus.Labels{"user": userID})
 	m.activeQueriedSeriesPerUser.DeletePartialMatch(prometheus.Labels{"user": userID})
+	m.headQueriedSeriesPerUser.DeletePartialMatch(prometheus.Labels{"user": userID})
 	m.usagePerLabelSet.DeletePartialMatch(prometheus.Labels{"user": userID})
 	m.limitsPerLabelSet.DeletePartialMatch(prometheus.Labels{"user": userID})
 	m.pushErrorsTotal.DeletePartialMatch(prometheus.Labels{"user": userID})

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -20,7 +20,7 @@ func TestRegexMatcherLimitsMetricsFeatureFlag(t *testing.T) {
 	// Test with feature flag disabled - metrics should be nil
 	t.Run("metrics are nil when feature flag is disabled", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		m := newIngesterMetrics(reg, false, false, false,
+		m := newIngesterMetrics(reg, false, false, false, false,
 			func() *InstanceLimits { return &InstanceLimits{} },
 			ingestionRate, &inflightPushRequests, &maxInflightQueryRequests, false, false)
 
@@ -33,7 +33,7 @@ func TestRegexMatcherLimitsMetricsFeatureFlag(t *testing.T) {
 	// Test with feature flag enabled - metrics should be initialized
 	t.Run("metrics are initialized when feature flag is enabled", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		m := newIngesterMetrics(reg, false, false, false,
+		m := newIngesterMetrics(reg, false, false, false, false,
 			func() *InstanceLimits { return &InstanceLimits{} },
 			ingestionRate, &inflightPushRequests, &maxInflightQueryRequests, false, true)
 
@@ -51,7 +51,7 @@ func TestUnoptimizedRegexRejectedMetric(t *testing.T) {
 
 	t.Run("rejected metric increments correctly", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		m := newIngesterMetrics(reg, false, false, false,
+		m := newIngesterMetrics(reg, false, false, false, false,
 			func() *InstanceLimits { return &InstanceLimits{} },
 			ingestionRate, &inflightPushRequests, &maxInflightQueryRequests, false, true)
 
@@ -75,7 +75,7 @@ func TestUnoptimizedRegexRejectedMetric(t *testing.T) {
 
 	t.Run("metric cleanup works correctly", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		m := newIngesterMetrics(reg, false, false, false,
+		m := newIngesterMetrics(reg, false, false, false, false,
 			func() *InstanceLimits { return &InstanceLimits{} },
 			ingestionRate, &inflightPushRequests, &maxInflightQueryRequests, false, true)
 
@@ -109,6 +109,7 @@ func TestIngesterMetrics(t *testing.T) {
 	m := newIngesterMetrics(mainReg,
 		false,
 		true,
+		false,
 		false,
 		func() *InstanceLimits {
 			return &InstanceLimits{

--- a/pkg/ingester/user_metrics_metadata_test.go
+++ b/pkg/ingester/user_metrics_metadata_test.go
@@ -26,6 +26,7 @@ func Test_UserMetricsMetadata(t *testing.T) {
 		false,
 		false,
 		false,
+		false,
 		func() *InstanceLimits {
 			return &InstanceLimits{}
 		},

--- a/schemas/cortex-config-schema.json
+++ b/schemas/cortex-config-schema.json
@@ -4638,6 +4638,34 @@
           "type": "boolean",
           "x-cli-flag": "ingester.enable-regex-matcher-limits"
         },
+        "head_queried_series_metrics_enabled": {
+          "default": false,
+          "description": "Experimental: Enable tracking of series queried from head only and expose them as metrics.",
+          "type": "boolean",
+          "x-cli-flag": "ingester.head-queried-series-metrics-enabled"
+        },
+        "head_queried_series_metrics_sample_rate": {
+          "default": 1,
+          "description": "Sampling rate for head queried series tracking (1.0 = 100%%).",
+          "type": "number",
+          "x-cli-flag": "ingester.head-queried-series-metrics-sample-rate"
+        },
+        "head_queried_series_metrics_window_duration": {
+          "default": "15m0s",
+          "description": "Duration of each sub-window for head queried series tracking.",
+          "type": "string",
+          "x-cli-flag": "ingester.head-queried-series-metrics-window-duration",
+          "x-format": "duration"
+        },
+        "head_queried_series_metrics_windows": {
+          "default": "2h0m0s",
+          "description": "Time windows to expose head queried series metrics. Also controls how long per-metric-name cardinality is reported after last query.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-cli-flag": "ingester.head-queried-series-metrics-windows"
+        },
         "ignore_series_limit_for_metric_names": {
           "description": "Comma-separated list of metric names, for which -ingester.max-series-per-metric and -ingester.max-global-series-per-metric limits will be ignored. Does not affect max-series-per-user or max-global-series-per-metric limits.",
           "type": "string",


### PR DESCRIPTION
## What this PR does

This PR adds a new metric that tracks query activity against the TSDB **head only** (in-memory, ~2h data):

`cortex_ingester_queried_head_series` — Estimated unique series queried from head within a configurable time window (HLL-based, deduplicated across queries).

## Motivation

The existing `cortex_ingester_active_queried_series` metric tracks all queried series regardless of whether they come from head or on-disk blocks. For understanding active query patterns and resource usage, we specifically need to know what's being queried from the head (the hot, recent data).

## Implementation

- Uses a `BlockChunkQuerierFunc` wrapper that intercepts `Select` calls only for head queriers (identified by RangeHead/Head ULIDs)
- Reuses existing `ActiveQueriedSeries` HLL and `ActiveQueriedSeriesService` — no new service needed
- Sampling supported to reduce overhead on the query path

## New configuration flags (experimental)

| Flag | Default | Description |
|------|---------|-------------|
| `-ingester.head-queried-series-metrics-enabled` | `false` | Enable the feature |
| `-ingester.head-queried-series-metrics-windows` | `2h` | Time windows to report (supports multiple, e.g. `2h,24h`) |
| `-ingester.head-queried-series-metrics-window-duration` | `15m` | HLL sub-window bucket size |
| `-ingester.head-queried-series-metrics-sample-rate` | `1.0` | Query sampling rate for HLL |

## Checklist
- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated
- [x] `v1-guarantees.md` updated (experimental feature)