### PR TITLE
fix(e2e): Fix flaky Test_VerifyComponentsAreSuccessfullyStarted_WithRuntimeConfigLoad

### DIFF
--- a/integration/e2e/service.go
+++ b/integration/e2e/service.go
@@ -156,6 +156,12 @@ func (s *ConcreteService) Stop() error {
 	logger.Log("Stopping", s.name)
 
 	if out, err := RunCommandAndGetOutput("docker", "stop", "--time=30", s.containerName()); err != nil {
+		// If the container has already exited and been removed (e.g., started
+		// with --rm), treat it as a successful stop.
+		if strings.Contains(string(out), "No such container") {
+			s.usedNetworkName = ""
+			return nil
+		}
 		logger.Log(string(out))
 		return err
 	}
@@ -181,6 +187,12 @@ func (s *ConcreteService) Kill() error {
 	logger.Log("Killing", s.name)
 
 	if out, err := RunCommandAndGetOutput("docker", "kill", s.containerName()); err != nil {
+		// If the container has already exited and been removed (e.g., started
+		// with --rm), treat it as a successful kill.
+		if strings.Contains(string(out), "No such container") {
+			s.usedNetworkName = ""
+			return nil
+		}
 		logger.Log(string(out))
 		return err
 	}

--- a/integration/runtime_config_test.go
+++ b/integration/runtime_config_test.go
@@ -215,6 +215,10 @@ overrides:
 		"-querier.store-gateway-addresses": strings.Join([]string{storeGateway.NetworkGRPCEndpoint()}, ","),
 	}), "")
 	require.Error(t, s.StartAndWaitReady(querier))
+	// Stop the failed service to unregister it before retrying with the same name.
+	// Ignore error: if the container crashed before Start() completed, the service
+	// was never registered and Stop() returns "does not exist" which is fine.
+	_ = s.Stop(querier)
 
 	// Start Query frontend
 	queryFrontend := e2ecortex.NewQueryFrontendWithConfigFile("query-frontend", "", flags, "")
@@ -231,6 +235,8 @@ overrides:
 	// Ruler start, but fail with "-distributor.shard-by-all-labels": "false"
 	ruler := e2ecortex.NewRuler("ruler", consul.NetworkHTTPEndpoint(), mergeFlags(flags, RulerFlags()), "")
 	require.Error(t, s.StartAndWaitReady(ruler))
+	// Stop the failed service to unregister it before retrying with the same name.
+	_ = s.Stop(ruler)
 
 	// Ruler start, should success with "-distributor.shard-by-all-labels": "true"
 	ruler = e2ecortex.NewRuler("ruler", consul.NetworkHTTPEndpoint(), mergeFlags(flags, RulerFlags(), map[string]string{
@@ -249,6 +255,8 @@ overrides:
 	// Distributor start, but fail with "-distributor.shard-by-all-labels": "false"
 	distributor := e2ecortex.NewQuerier("distributor", e2ecortex.RingStoreConsul, consul.NetworkHTTPEndpoint(), mergeFlags(flags, map[string]string{}), "")
 	require.Error(t, s.StartAndWaitReady(distributor))
+	// Stop the failed service to unregister it before retrying with the same name.
+	_ = s.Stop(distributor)
 
 	// Distributor start, should success with "-distributor.shard-by-all-labels": "true"
 	distributor = e2ecortex.NewQuerier("distributor", e2ecortex.RingStoreConsul, consul.NetworkHTTPEndpoint(), mergeFlags(flags, map[string]string{


### PR DESCRIPTION
## What this PR does

Fixes a flaky integration test `Test_VerifyComponentsAreSuccessfullyStarted_WithRuntimeConfigLoad` that intermittently fails with:
```
another service with the same name 'distributor' has already been started
```

## Root Cause

The test intentionally starts services (querier, ruler, distributor) with invalid config (`-distributor.shard-by-all-labels=false`) expecting them to fail, then retries with valid config. When `StartAndWaitReady` fails during `WaitReady` (container starts but crashes), the service remains registered in the scenario's `services` slice. The subsequent attempt to start a new service with the same name fails because `isRegistered()` returns true.

This is a race condition: if the container crashes fast enough that `Start()` itself fails, the service is never registered and the retry works. But if the container starts successfully and then crashes during `WaitReady`, it stays registered.

## Fix

1. **Test fix**: Call `s.Stop()` after each expected `StartAndWaitReady` failure to properly unregister the service before retrying.
2. **Framework fix**: Make `ConcreteService.Stop()` and `Kill()` tolerant of already-removed containers (started with `--rm` flag) by treating "No such container" errors as successful operations.

## How was this tested

- `go build ./integration/...` passes
- `go test ./integration/e2e/... -count=1 -short` passes

Observed in: https://github.com/cortexproject/cortex/actions/runs/25643063397/job/75267056134