### PR TITLE
Fix flaky TestCompactor_RingLifecyclerShouldAutoForgetUnhealthyInstances

### DIFF
--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -2201,6 +2201,7 @@ func TestCompactor_RingLifecyclerShouldAutoForgetUnhealthyInstances(t *testing.T
 		cfg.ShardingRing.InstanceAddr = fmt.Sprintf("127.0.0.%d", i)
 		cfg.ShardingRing.WaitStabilityMinDuration = time.Second
 		cfg.ShardingRing.WaitStabilityMaxDuration = 5 * time.Second
+		cfg.ShardingRing.WaitActiveInstanceTimeout = 30 * time.Second
 		cfg.ShardingRing.KVStore.Mock = kvstore
 		cfg.ShardingRing.HeartbeatPeriod = 200 * time.Millisecond
 		cfg.ShardingRing.UnregisterOnShutdown = false


### PR DESCRIPTION
## What
Increase `WaitActiveInstanceTimeout` from 5s to 30s in `TestCompactor_RingLifecyclerShouldAutoForgetUnhealthyInstances`.

## Why
The test was flaky on CI because `WaitActiveInstanceTimeout` (5s from `prepareConfig`) was too tight when combined with `WaitStabilityMinDuration=1s` and `WaitStabilityMaxDuration=5s`. On slow CI machines, the ring lifecycler may not transition to ACTIVE within 5s, causing a `context deadline exceeded` error at `StartAndAwaitRunning` (line 2228).

## How
Override `WaitActiveInstanceTimeout` to 30s in this specific test, giving sufficient headroom for the ring to stabilize on slow CI environments.

## Testing
Ran the test 5 times locally — all passed (4-8s per run), confirming the original 5s timeout was too tight.

Fixes flaky test from: https://github.com/cortexproject/cortex/actions/runs/25645120563/job/75272471073