### PR TITLE
fix flaky regex resolver e2e tests

### DIFF
--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -210,11 +210,9 @@ func Test_TenantFederationRegexResolver_WhenSingleTenantMatched(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	// wait to upload blocks
-	require.NoError(t, ingester.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_ingester_shipper_uploads_total"}, e2e.WaitMissingMetrics))
 
 	// wait to update knownUsers
-	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_regex_resolver_last_update_run_timestamp_seconds"}, e2e.WaitMissingMetrics))
+	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(1), "cortex_regex_resolver_discovered_users"))
 
 	clientForMatchOneTenant, err = e2ecortex.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", "user-.+")
 	require.NoError(t, err)
@@ -377,13 +375,10 @@ func runQuerierTenantFederationTest_UseRegexResolver(t *testing.T, cfg querierTe
 		require.NoError(t, querier2.WaitSumMetrics(e2e.Equals(512*2), "cortex_ring_tokens_total"))
 	}
 
-	// wait to upload blocks
-	require.NoError(t, ingester.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_ingester_shipper_uploads_total"}, e2e.WaitMissingMetrics))
-
 	// wait to update knownUsers
-	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_regex_resolver_last_update_run_timestamp_seconds"}, e2e.WaitMissingMetrics))
+	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(float64(numUsers)), "cortex_regex_resolver_discovered_users"))
 	if cfg.shuffleShardingEnabled {
-		require.NoError(t, querier2.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_regex_resolver_last_update_run_timestamp_seconds"}, e2e.WaitMissingMetrics))
+		require.NoError(t, querier2.WaitSumMetrics(e2e.Equals(float64(numUsers)), "cortex_regex_resolver_discovered_users"))
 	}
 
 	// query all tenants

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -210,7 +210,6 @@ func Test_TenantFederationRegexResolver_WhenSingleTenantMatched(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-
 	// wait to update knownUsers
 	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(1), "cortex_regex_resolver_discovered_users"))
 

--- a/pkg/querier/tenantfederation/regex_resolver.go
+++ b/pkg/querier/tenantfederation/regex_resolver.go
@@ -212,7 +212,7 @@ func (r *RegexResolver) validateAndReturnMatched(orgID string, matched []string)
 			// when querying for a newly created orgID, the query may not
 			// work because it has not been uploaded to object storage.
 			// To make the query work (not breaking existing behavior),
-			// paas the orgID if it is valid.
+			// pass the orgID if it is valid.
 			return []string{orgID}, nil
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR fixes flaky regex resolver e2e tests. Previously, the tests waited for `cortex_regex_resolver_last_update_run_timestamp_seconds > 0`, but this metric can be updated before blocks are uploaded to the bucket, causing the test to proceed with an empty `knownUsers` list. Instead, we now wait for `cortex_regex_resolver_discovered_users == N`, which guarantees that the resolver has scanned the bucket and discovered all expected tenants.

```
    querier_tenant_federation_test.go:226: 
        	Error Trace:	/home/runner/work/cortex/cortex/integration/querier_tenant_federation_test.go:226
        	Error:      	Not equal: 
        	            	expected: model.Vector{(*model.Sample)(0xa733693d620)}
        	            	actual  : model.Vector{}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,10 +1,2 @@
        	            	-(model.Vector) (len=1) {
        	            	- (*model.Sample)({
        	            	-  Metric: (model.Metric) (len=1) {
        	            	-   (model.LabelName) (len=8) "__name__": (model.LabelValue) (len=8) "series_1"
        	            	-  },
        	            	-  Value: (model.SampleValue) 0.7491711903904605,
        	            	-  Timestamp: (model.Time) 1778498925016,
        	            	-  Histogram: (*model.SampleHistogram)(<nil>)
        	            	- })
        	            	+(model.Vector) {
        	            	 }
        	Test:       	Test_TenantFederationRegexResolver_WhenSingleTenantMatched
```
https://github.com/cortexproject/cortex/actions/runs/25666915848/job/75342583581?pr=7462

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
