### PR TITLE
security: fix stored XSS in alertmanager and storegateway status pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [BUGFIX] Config: Mask Swift, etcd, Redis, and HTTP basic-auth credentials on the `/config` endpoint. #7473
 * [BUGFIX] Memberlist: Drop incoming TCP transport packets when digest verification fails, preventing corrupted payloads from being forwarded. #7474
 * [BUGFIX] Compactor: Fix stale `cortex_bucket_index_last_successful_update_timestamp_seconds` metric not being cleaned up when tenant ownership changes due to ring rebalancing. This caused false alarms on bucket index update rate when a tenant moved between compactors. #7485
+* [BUGFIX] Security: Fix stored XSS vulnerability in Alertmanager and Store Gateway status pages by replacing `text/template` with `html/template`. #7512
 
 ## 1.21.0 2026-04-24
 

--- a/pkg/alertmanager/alertmanager_http.go
+++ b/pkg/alertmanager/alertmanager_http.go
@@ -1,8 +1,8 @@
 package alertmanager
 
 import (
-	"net/http"
 	"html/template"
+	"net/http"
 
 	"github.com/go-kit/log/level"
 

--- a/pkg/alertmanager/alertmanager_http.go
+++ b/pkg/alertmanager/alertmanager_http.go
@@ -2,7 +2,7 @@ package alertmanager
 
 import (
 	"net/http"
-	"text/template"
+	"html/template"
 
 	"github.com/go-kit/log/level"
 

--- a/pkg/alertmanager/alertmanager_http_test.go
+++ b/pkg/alertmanager/alertmanager_http_test.go
@@ -1,6 +1,7 @@
 package alertmanager
 
 import (
+	"bytes"
 	"io"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +12,32 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 )
+
+func TestStatusHandler_HTMLEscaping(t *testing.T) {
+	// Verify that html/template escapes XSS payloads in the status page.
+	xssPayload := `<script>alert("xss")</script>`
+
+	var buf bytes.Buffer
+	err := statusTemplate.Execute(&buf, struct {
+		ClusterInfo map[string]any
+	}{
+		ClusterInfo: map[string]any{
+			"self": map[string]any{
+				"Name": xssPayload,
+				"Addr": "127.0.0.1",
+				"Port": "9094",
+			},
+			"members": []map[string]any{
+				{"Name": xssPayload, "Addr": "127.0.0.1:9094"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	content := buf.String()
+	require.NotContains(t, content, xssPayload, "XSS payload must be escaped by html/template")
+	require.Contains(t, content, "&lt;script&gt;", "HTML special characters must be escaped")
+}
 
 func TestMultitenantAlertmanager_GetStatusHandler(t *testing.T) {
 	ctx := t.Context()

--- a/pkg/storegateway/gateway_http.go
+++ b/pkg/storegateway/gateway_http.go
@@ -1,8 +1,8 @@
 package storegateway
 
 import (
-	"net/http"
 	"html/template"
+	"net/http"
 
 	"github.com/go-kit/log/level"
 

--- a/pkg/storegateway/gateway_http.go
+++ b/pkg/storegateway/gateway_http.go
@@ -2,7 +2,7 @@ package storegateway
 
 import (
 	"net/http"
-	"text/template"
+	"html/template"
 
 	"github.com/go-kit/log/level"
 


### PR DESCRIPTION
## What this PR does

Fixes a stored XSS vulnerability in the Alertmanager and Store Gateway HTTP status pages by replacing `text/template` with `html/template`.

### Fix

Replace `text/template` with `html/template` in:
- `pkg/alertmanager/alertmanager_http.go`
- `pkg/storegateway/gateway_http.go`

`html/template` automatically escapes values in HTML context, preventing script injection.

### Testing

Added `pkg/alertmanager/alertmanager_http_test.go` test that verifies HTML-special characters in tenant IDs are properly escaped in the rendered output.
