### PR TITLE
feat(ingester): Add cortex_ingester_head_metric_names gauge per user

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1152,6 +1152,7 @@ func (i *Ingester) updateActiveSeries(ctx context.Context) {
 		userDB.activeSeries.Purge(purgeTime)
 		i.metrics.activeSeriesPerUser.WithLabelValues(userID).Set(float64(userDB.activeSeries.Active()))
 		i.metrics.activeNHSeriesPerUser.WithLabelValues(userID).Set(float64(userDB.activeSeries.ActiveNativeHistogram()))
+		i.metrics.activeMetricNamesPerUser.WithLabelValues(userID).Set(float64(userDB.seriesInMetric.ActiveMetricNames()))
 		if err := userDB.labelSetCounter.UpdateMetric(ctx, userDB, i.metrics); err != nil {
 			level.Warn(i.logger).Log("msg", "failed to update per labelSet metrics", "user", userID, "err", err)
 		}
@@ -3041,6 +3042,7 @@ func (i *Ingester) closeAllTSDB() {
 			i.metrics.memUsers.Dec()
 			i.metrics.activeSeriesPerUser.DeleteLabelValues(userID)
 			i.metrics.activeNHSeriesPerUser.DeleteLabelValues(userID)
+			i.metrics.activeMetricNamesPerUser.DeleteLabelValues(userID)
 		}(userDB)
 	}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1152,7 +1152,7 @@ func (i *Ingester) updateActiveSeries(ctx context.Context) {
 		userDB.activeSeries.Purge(purgeTime)
 		i.metrics.activeSeriesPerUser.WithLabelValues(userID).Set(float64(userDB.activeSeries.Active()))
 		i.metrics.activeNHSeriesPerUser.WithLabelValues(userID).Set(float64(userDB.activeSeries.ActiveNativeHistogram()))
-		i.metrics.activeMetricNamesPerUser.WithLabelValues(userID).Set(float64(userDB.seriesInMetric.ActiveMetricNames()))
+		i.metrics.headMetricNamesPerUser.WithLabelValues(userID).Set(float64(userDB.seriesInMetric.ActiveMetricNames()))
 		if err := userDB.labelSetCounter.UpdateMetric(ctx, userDB, i.metrics); err != nil {
 			level.Warn(i.logger).Log("msg", "failed to update per labelSet metrics", "user", userID, "err", err)
 		}
@@ -3042,7 +3042,7 @@ func (i *Ingester) closeAllTSDB() {
 			i.metrics.memUsers.Dec()
 			i.metrics.activeSeriesPerUser.DeleteLabelValues(userID)
 			i.metrics.activeNHSeriesPerUser.DeleteLabelValues(userID)
-			i.metrics.activeMetricNamesPerUser.DeleteLabelValues(userID)
+			i.metrics.headMetricNamesPerUser.DeleteLabelValues(userID)
 		}(userDB)
 	}
 

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -57,7 +57,7 @@ type ingesterMetrics struct {
 
 	activeSeriesPerUser        *prometheus.GaugeVec
 	activeNHSeriesPerUser      *prometheus.GaugeVec
-	activeMetricNamesPerUser   *prometheus.GaugeVec
+	headMetricNamesPerUser     *prometheus.GaugeVec
 	activeQueriedSeriesPerUser *prometheus.GaugeVec
 	limitsPerLabelSet          *prometheus.GaugeVec
 	usagePerLabelSet           *prometheus.GaugeVec
@@ -300,8 +300,8 @@ func newIngesterMetrics(r prometheus.Registerer,
 		}, []string{"user"}),
 
 		// Not registered automatically, but only if activeSeriesEnabled is true.
-		activeMetricNamesPerUser: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_ingester_active_metric_names",
+		headMetricNamesPerUser: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_ingester_head_metric_names",
 			Help: "Number of unique metric names in the TSDB head per user.",
 		}, []string{"user"}),
 
@@ -356,7 +356,7 @@ func newIngesterMetrics(r prometheus.Registerer,
 	if activeSeriesEnabled && r != nil {
 		r.MustRegister(m.activeSeriesPerUser)
 		r.MustRegister(m.activeNHSeriesPerUser)
-		r.MustRegister(m.activeMetricNamesPerUser)
+		r.MustRegister(m.headMetricNamesPerUser)
 		r.MustRegister(m.activeSeriesPerTracker)
 	}
 
@@ -388,7 +388,7 @@ func (m *ingesterMetrics) deletePerUserMetrics(userID string) {
 	m.memMetadataRemovedTotal.DeleteLabelValues(userID)
 	m.activeSeriesPerUser.DeleteLabelValues(userID)
 	m.activeNHSeriesPerUser.DeleteLabelValues(userID)
-	m.activeMetricNamesPerUser.DeleteLabelValues(userID)
+	m.headMetricNamesPerUser.DeleteLabelValues(userID)
 	m.activeSeriesPerTracker.DeletePartialMatch(prometheus.Labels{"user": userID})
 	m.activeQueriedSeriesPerUser.DeletePartialMatch(prometheus.Labels{"user": userID})
 	m.usagePerLabelSet.DeletePartialMatch(prometheus.Labels{"user": userID})

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -57,6 +57,7 @@ type ingesterMetrics struct {
 
 	activeSeriesPerUser        *prometheus.GaugeVec
 	activeNHSeriesPerUser      *prometheus.GaugeVec
+	activeMetricNamesPerUser   *prometheus.GaugeVec
 	activeQueriedSeriesPerUser *prometheus.GaugeVec
 	limitsPerLabelSet          *prometheus.GaugeVec
 	usagePerLabelSet           *prometheus.GaugeVec
@@ -299,6 +300,12 @@ func newIngesterMetrics(r prometheus.Registerer,
 		}, []string{"user"}),
 
 		// Not registered automatically, but only if activeSeriesEnabled is true.
+		activeMetricNamesPerUser: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_ingester_active_metric_names",
+			Help: "Number of unique metric names in the TSDB head per user.",
+		}, []string{"user"}),
+
+		// Not registered automatically, but only if activeSeriesEnabled is true.
 		activeSeriesPerTracker: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_ingester_active_series_per_tracker",
 			Help: "Number of currently active series matching a configured tracker pattern.",
@@ -349,6 +356,7 @@ func newIngesterMetrics(r prometheus.Registerer,
 	if activeSeriesEnabled && r != nil {
 		r.MustRegister(m.activeSeriesPerUser)
 		r.MustRegister(m.activeNHSeriesPerUser)
+		r.MustRegister(m.activeMetricNamesPerUser)
 		r.MustRegister(m.activeSeriesPerTracker)
 	}
 
@@ -380,6 +388,7 @@ func (m *ingesterMetrics) deletePerUserMetrics(userID string) {
 	m.memMetadataRemovedTotal.DeleteLabelValues(userID)
 	m.activeSeriesPerUser.DeleteLabelValues(userID)
 	m.activeNHSeriesPerUser.DeleteLabelValues(userID)
+	m.activeMetricNamesPerUser.DeleteLabelValues(userID)
 	m.activeSeriesPerTracker.DeletePartialMatch(prometheus.Labels{"user": userID})
 	m.activeQueriedSeriesPerUser.DeletePartialMatch(prometheus.Labels{"user": userID})
 	m.usagePerLabelSet.DeletePartialMatch(prometheus.Labels{"user": userID})

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -86,6 +86,17 @@ func (m *metricCounter) increaseSeriesForMetric(metric string) {
 	shard.mtx.Unlock()
 }
 
+// ActiveMetricNames returns the total number of unique metric names tracked across all shards.
+func (m *metricCounter) ActiveMetricNames() int {
+	total := 0
+	for i := range m.shards {
+		m.shards[i].mtx.Lock()
+		total += len(m.shards[i].m)
+		m.shards[i].mtx.Unlock()
+	}
+	return total
+}
+
 type labelSetCounterEntry struct {
 	count  int
 	labels labels.Labels

--- a/pkg/ingester/user_state_test.go
+++ b/pkg/ingester/user_state_test.go
@@ -378,3 +378,36 @@ func (ir *mockIndexReader) LabelNamesFor(ctx context.Context, postings index.Pos
 }
 
 func (ir *mockIndexReader) Close() error { return nil }
+
+func TestMetricCounter_ActiveMetricNames(t *testing.T) {
+	limits := validation.Limits{MaxLocalSeriesPerMetric: 100}
+	overrides := validation.NewOverrides(limits, nil)
+	limiter := NewLimiter(overrides, nil, util.ShardingStrategyDefault, true, 3, false, "")
+	mc := newMetricCounter(limiter, nil)
+
+	// Initially zero.
+	assert.Equal(t, 0, mc.ActiveMetricNames())
+
+	// Add series for 3 different metrics.
+	mc.increaseSeriesForMetric("metric_a")
+	mc.increaseSeriesForMetric("metric_a")
+	mc.increaseSeriesForMetric("metric_b")
+	mc.increaseSeriesForMetric("metric_c")
+	assert.Equal(t, 3, mc.ActiveMetricNames())
+
+	// Remove all series for metric_b.
+	mc.decreaseSeriesForMetric("metric_b")
+	assert.Equal(t, 2, mc.ActiveMetricNames())
+
+	// Remove one series for metric_a (still has one left).
+	mc.decreaseSeriesForMetric("metric_a")
+	assert.Equal(t, 2, mc.ActiveMetricNames())
+
+	// Remove last series for metric_a.
+	mc.decreaseSeriesForMetric("metric_a")
+	assert.Equal(t, 1, mc.ActiveMetricNames())
+
+	// Remove last series for metric_c.
+	mc.decreaseSeriesForMetric("metric_c")
+	assert.Equal(t, 0, mc.ActiveMetricNames())
+}


### PR DESCRIPTION
## Summary

Expose the number of unique metric names (distinct `__name__` values) per tenant in the ingester head as a new Prometheus gauge metric: `cortex_ingester_active_metric_names`.

## Motivation

Operators need visibility into metric name cardinality per tenant to detect cardinality explosions at the metric name level (as opposed to series level which `cortex_ingester_active_series` already covers).

## Changes

- **`pkg/ingester/user_state.go`**: Added `ActiveMetricNames()` method to `metricCounter` that returns the total number of unique metric names across all shards.
- **`pkg/ingester/metrics.go`**: Added `cortex_ingester_active_metric_names` GaugeVec (labels: `user`), registered under `activeSeriesEnabled` gate, with cleanup in `deletePerUserMetrics`.
- **`pkg/ingester/ingester.go`**: Set the gauge in `updateActiveSeries` loop and clean up on TSDB close.
- **`pkg/ingester/user_state_test.go`**: Unit test for `ActiveMetricNames()`.
- **`docs/configuration/v1-guarantees.md`**: Listed as experimental feature.

## How it works

The `seriesInMetric` (`metricCounter`) already tracks a sharded map of `metricName → seriesCount` maintained via TSDB `PostCreation`/`PostDeletion` callbacks. The number of keys in this map equals the number of unique metric names in the head. No new data structures or tracking overhead is introduced.

## Testing

- Unit test: `TestMetricCounter_ActiveMetricNames` — verifies count increases/decreases correctly as series are added/removed.
- Existing tests pass (pre-existing failures in `TestExpandedCachePostings_Race` and `TestIngester_Push` are unrelated race conditions on master).