### PR TITLE
chore(deps): upgrade weaveworks-common to latest master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -314,7 +314,7 @@ require (
 )
 
 // Using cortex fork of weaveworks/common
-replace github.com/weaveworks/common => github.com/cortexproject/weaveworks-common v0.0.0-20250902164925-0315015a8b9f
+replace github.com/weaveworks/common => github.com/cortexproject/weaveworks-common v0.0.0-20260508185357-75366cf4edfb
 
 // Override since git.apache.org is down.  The docs say to fetch from github.
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5z
 github.com/coreos/go-systemd/v22 v22.6.0/go.mod h1:iG+pp635Fo7ZmV/j14KUcmEyWF+0X7Lua8rrTWzYgWU=
 github.com/cortexproject/promqlsmith v0.0.0-20260205231645-0c8ef5fe46a5 h1:MTGag0oh+M3hyWWg7a1Bju2VPeFLjG2l+LWLhUCFTYI=
 github.com/cortexproject/promqlsmith v0.0.0-20260205231645-0c8ef5fe46a5/go.mod h1:GrzWqtj9aJG+n4Cl1O30Zdk8cIgjqSUc2l5nZV8BnaA=
-github.com/cortexproject/weaveworks-common v0.0.0-20250902164925-0315015a8b9f h1:hDM26bY51+giykKRIH8TUYzEy7fn62iKfTW7vfgDuNw=
-github.com/cortexproject/weaveworks-common v0.0.0-20250902164925-0315015a8b9f/go.mod h1:bls8PY13xoOKkZuRhhDdR2rNk4pfdGWCR6k2jF9s9+4=
+github.com/cortexproject/weaveworks-common v0.0.0-20260508185357-75366cf4edfb h1:3Kr+IwRd0ybfFhUYpzdkmm6jIyRWonIWMsToRcycrL4=
+github.com/cortexproject/weaveworks-common v0.0.0-20260508185357-75366cf4edfb/go.mod h1:bls8PY13xoOKkZuRhhDdR2rNk4pfdGWCR6k2jF9s9+4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cristalhq/hedgedhttp v0.9.1 h1:g68L9cf8uUyQKQJwciD0A1Vgbsz+QgCjuB1I8FAsCDs=
 github.com/cristalhq/hedgedhttp v0.9.1/go.mod h1:XkqWU6qVMutbhW68NnzjWrGtH8NUx1UfYqGYtHVKIsI=

--- a/vendor/github.com/weaveworks/common/user/grpc.go
+++ b/vendor/github.com/weaveworks/common/user/grpc.go
@@ -8,13 +8,8 @@ import (
 // ExtractFromGRPCRequest extracts the user ID from the request metadata and returns
 // the user ID and a context with the user ID injected.
 func ExtractFromGRPCRequest(ctx context.Context) (string, context.Context, error) {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return "", ctx, ErrNoOrgID
-	}
-
-	orgIDs, ok := md[lowerOrgIDHeaderName]
-	if !ok || len(orgIDs) != 1 {
+	orgIDs := metadata.ValueFromIncomingContext(ctx, lowerOrgIDHeaderName)
+	if len(orgIDs) != 1 {
 		return "", ctx, ErrNoOrgID
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1357,7 +1357,7 @@ github.com/vimeo/galaxycache/http
 github.com/vimeo/galaxycache/lru
 github.com/vimeo/galaxycache/promoter
 github.com/vimeo/galaxycache/singleflight
-# github.com/weaveworks/common v0.0.0-20230728070032-dd9e68f319d5 => github.com/cortexproject/weaveworks-common v0.0.0-20250902164925-0315015a8b9f
+# github.com/weaveworks/common v0.0.0-20230728070032-dd9e68f319d5 => github.com/cortexproject/weaveworks-common v0.0.0-20260508185357-75366cf4edfb
 ## explicit; go 1.22
 github.com/weaveworks/common/errors
 github.com/weaveworks/common/grpc
@@ -2012,7 +2012,7 @@ k8s.io/klog/v2/internal/sloghandler
 # k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 ## explicit; go 1.18
 k8s.io/utils/clock
-# github.com/weaveworks/common => github.com/cortexproject/weaveworks-common v0.0.0-20250902164925-0315015a8b9f
+# github.com/weaveworks/common => github.com/cortexproject/weaveworks-common v0.0.0-20260508185357-75366cf4edfb
 # git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 # github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe


### PR DESCRIPTION
## Summary

Upgrade `cortexproject/weaveworks-common` from `0315015a8b9f` (2025-09-02) to `75366cf4edfb` (2026-05-08).

## Changes in weaveworks-common

- Simplify `ExtractFromGRPCRequest` by using `metadata.ValueFromIncomingContext` directly instead of `FromIncomingContext` + manual key lookup. This removes an unnecessary map allocation on every gRPC request.

## Files changed

- `go.mod` — updated replace directive
- `go.sum` — updated hashes
- `vendor/github.com/weaveworks/common/user/grpc.go` — simplified metadata extraction
- `vendor/modules.txt` — updated version

Signed-off-by: Daniel Blando <ddeluigg@amazon.com>