### PR TITLE
rename metric label values for fetched-data limit rejections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## master / unreleased
+* [CHANGE] Query Frontend: Rename `cortex_rejected_queries_total` metric label `reason` values for fetched-data limit rejections. #7517
+  * Old values: `series_fetched`, `chunks_fetched`, `chunk_bytes_fetched`, `data_bytes_fetched`.
+  * New values: `fetched_series_exceeded`, `fetched_chunks_exceeded`, `fetched_chunk_bytes_exceeded`, `fetched_data_bytes_exceeded`.
 * [CHANGE] Querier: Make query time range configurations per-tenant: `query_ingesters_within`, `query_store_after`, and `shuffle_sharding_ingesters_lookback_period`. Uses `model.Duration` instead of `time.Duration` to support serialization but has minimum unit of 1ms (nanoseconds/microseconds not supported). #7160
 * [CHANGE] Cache: Setting `-blocks-storage.bucket-store.metadata-cache.bucket-index-content-ttl` to 0 will disable the bucket-index cache. #7446
 * [CHANGE] HA Tracker: Move `-distributor.ha-tracker.failover-timeout` from a global config to a per-tenant runtime config. The flag name and default value (30s) remain the same. #7481

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -49,23 +49,23 @@ var (
 )
 
 const (
-	reasonTooManyTenants           = "too_many_tenants"
-	reasonRequestBodySizeExceeded  = "request_body_size_exceeded"
-	reasonResponseBodySizeExceeded = "response_body_size_exceeded"
-	reasonTooManyRequests          = "too_many_requests"
-	reasonResourceExhausted        = "resource_exhausted"
-	reasonTimeRangeExceeded        = "time_range_exceeded"
-	reasonResponseSizeExceeded     = "response_size_exceeded"
-	reasonTooManySamples           = "too_many_samples"
-	reasonSeriesFetched            = "series_fetched"
-	reasonChunksFetched            = "chunks_fetched"
-	reasonChunkBytesFetched        = "chunk_bytes_fetched"
-	reasonDataBytesFetched         = "data_bytes_fetched"
-	reasonSeriesLimitStoreGateway  = "store_gateway_series_limit"
-	reasonChunksLimitStoreGateway  = "store_gateway_chunks_limit"
-	reasonBytesLimitStoreGateway   = "store_gateway_bytes_limit"
-	reasonUnOptimizedRegexMatcher  = `unoptimized_regex_matcher`
-	reasonQueryTooExpensive        = "query_too_expensive"
+	reasonTooManyTenants            = "too_many_tenants"
+	reasonRequestBodySizeExceeded   = "request_body_size_exceeded"
+	reasonResponseBodySizeExceeded  = "response_body_size_exceeded"
+	reasonTooManyRequests           = "too_many_requests"
+	reasonResourceExhausted         = "resource_exhausted"
+	reasonTimeRangeExceeded         = "time_range_exceeded"
+	reasonResponseSizeExceeded      = "response_size_exceeded"
+	reasonTooManySamples            = "too_many_samples"
+	reasonFetchedSeriesExceeded     = "fetched_series_exceeded"
+	reasonFetchedChunksExceeded     = "fetched_chunks_exceeded"
+	reasonFetchedChunkBytesExceeded = "fetched_chunk_bytes_exceeded"
+	reasonFetchedDataBytesExceeded  = "fetched_data_bytes_exceeded"
+	reasonSeriesLimitStoreGateway   = "store_gateway_series_limit"
+	reasonChunksLimitStoreGateway   = "store_gateway_chunks_limit"
+	reasonBytesLimitStoreGateway    = "store_gateway_bytes_limit"
+	reasonUnOptimizedRegexMatcher   = `unoptimized_regex_matcher`
+	reasonQueryTooExpensive         = "query_too_expensive"
 
 	limitTooManySamples          = `query processing would load too many samples into memory`
 	limitTimeRangeExceeded       = `the query time range exceeds the limit`
@@ -579,13 +579,13 @@ func (f *Handler) reportQueryStats(r *http.Request, source, userID string, query
 		} else if strings.Contains(errMsg, limitResponseSizeExceeded) {
 			reason = reasonResponseSizeExceeded
 		} else if strings.Contains(errMsg, limitSeriesFetched) {
-			reason = reasonSeriesFetched
+			reason = reasonFetchedSeriesExceeded
 		} else if strings.Contains(errMsg, limitChunksFetched) {
-			reason = reasonChunksFetched
+			reason = reasonFetchedChunksExceeded
 		} else if strings.Contains(errMsg, limitChunkBytesFetched) {
-			reason = reasonChunkBytesFetched
+			reason = reasonFetchedChunkBytesExceeded
 		} else if strings.Contains(errMsg, limitDataBytesFetched) {
-			reason = reasonDataBytesFetched
+			reason = reasonFetchedDataBytesExceeded
 		} else if strings.Contains(errMsg, limitSeriesStoreGateway) {
 			reason = reasonSeriesLimitStoreGateway
 		} else if strings.Contains(errMsg, limitChunksStoreGateway) {

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -272,7 +272,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			expectedStatusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:            "test handler with reasonSeriesFetched",
+			name:            "test handler with reasonFetchedSeriesExceeded",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
 			expectedMetrics: 6,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -282,13 +282,13 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				}, nil
 			}),
 			additionalMetricsCheckFunc: func(h *Handler) {
-				v := promtest.ToFloat64(h.rejectedQueries.WithLabelValues(reasonSeriesFetched, requestmeta.SourceAPI, userID))
+				v := promtest.ToFloat64(h.rejectedQueries.WithLabelValues(reasonFetchedSeriesExceeded, requestmeta.SourceAPI, userID))
 				assert.Equal(t, float64(1), v)
 			},
 			expectedStatusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:            "test handler with reasonChunksFetched",
+			name:            "test handler with reasonFetchedChunksExceeded",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
 			expectedMetrics: 6,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -298,13 +298,13 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				}, nil
 			}),
 			additionalMetricsCheckFunc: func(h *Handler) {
-				v := promtest.ToFloat64(h.rejectedQueries.WithLabelValues(reasonChunksFetched, requestmeta.SourceAPI, userID))
+				v := promtest.ToFloat64(h.rejectedQueries.WithLabelValues(reasonFetchedChunksExceeded, requestmeta.SourceAPI, userID))
 				assert.Equal(t, float64(1), v)
 			},
 			expectedStatusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:            "test handler with reasonChunkBytesFetched",
+			name:            "test handler with reasonFetchedChunkBytesExceeded",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
 			expectedMetrics: 6,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -314,13 +314,13 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				}, nil
 			}),
 			additionalMetricsCheckFunc: func(h *Handler) {
-				v := promtest.ToFloat64(h.rejectedQueries.WithLabelValues(reasonChunkBytesFetched, requestmeta.SourceAPI, userID))
+				v := promtest.ToFloat64(h.rejectedQueries.WithLabelValues(reasonFetchedChunkBytesExceeded, requestmeta.SourceAPI, userID))
 				assert.Equal(t, float64(1), v)
 			},
 			expectedStatusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:            "test handler with reasonDataBytesFetched",
+			name:            "test handler with reasonFetchedDataBytesExceeded",
 			cfg:             HandlerConfig{QueryStatsEnabled: true},
 			expectedMetrics: 6,
 			roundTripperFunc: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -330,7 +330,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				}, nil
 			}),
 			additionalMetricsCheckFunc: func(h *Handler) {
-				v := promtest.ToFloat64(h.rejectedQueries.WithLabelValues(reasonDataBytesFetched, requestmeta.SourceAPI, userID))
+				v := promtest.ToFloat64(h.rejectedQueries.WithLabelValues(reasonFetchedDataBytesExceeded, requestmeta.SourceAPI, userID))
 				assert.Equal(t, float64(1), v)
 			},
 			expectedStatusCode: http.StatusUnprocessableEntity,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR updates the naming of `cortex_rejected_queries_total` metric label values to make them more descriptive and consistent.
* Old values: `series_fetched`, `chunks_fetched`, `chunk_bytes_fetched`, `data_bytes_fetched`.
* New values: `fetched_series_exceeded`, `fetched_chunks_exceeded`, `fetched_chunk_bytes_exceeded`, `fetched_data_bytes_exceeded`.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
