### PR TITLE
validate tenant IDs in IsAllowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [ENHANCEMENT] Distributor: Add HMAC-SHA256 stream authentication for `PushStream` via `-distributor.sign-write-requests-keys`. #7475
 * [ENHANCEMENT] Instrument Ingester CPU profile with source for read APIs. #7494
 * [ENHANCEMENT] Ingester: Convert expanded postings cache from FIFO to LRU eviction to retain frequently-queried entries under memory pressure. #7510
+* [ENHANCEMENT] Validate tenantID in `IsAllowed` to reject tenant IDs with unsupported characters, length exceeding 150 characters, path traversal segments (`.` or `..`), and reserved names (`__markers__`, `user-index.json.gz`). #7525
 * [BUGFIX] Querier: Fix queryWithRetry and labelsWithRetry returning (nil, nil) on cancelled context by propagating ctx.Err(). #7370
 * [BUGFIX] Metrics Helper: Fix non-deterministic bucket order in merged histograms by sorting buckets after map iteration, matching Prometheus client library behavior. #7380
 * [BUGFIX] Distributor: Return HTTP 401 Unauthorized when tenant ID resolution fails in the Prometheus Remote Write 2.0 path. #7389

--- a/pkg/util/users/allowed_tenants.go
+++ b/pkg/util/users/allowed_tenants.go
@@ -34,8 +34,7 @@ func NewAllowedTenants(enabled []string, disabled []string) *AllowedTenants {
 }
 
 func (a *AllowedTenants) IsAllowed(tenantID string) bool {
-	if tenantID == GlobalMarkersDir {
-		// __markers__ is reserved for global markers and no tenant should be allowed to have that name.
+	if err := ValidTenantID(tenantID); err != nil {
 		return false
 	}
 

--- a/pkg/util/users/allowed_tenants_test.go
+++ b/pkg/util/users/allowed_tenants_test.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -44,4 +45,27 @@ func TestAllowedTenants_Nil(t *testing.T) {
 	require.True(t, a.IsAllowed("A"))
 	require.True(t, a.IsAllowed("B"))
 	require.True(t, a.IsAllowed("C"))
+}
+
+func TestAllowedTenants_InvalidTenantID(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		tenantID string
+	}{
+		{name: "markers dir", tenantID: GlobalMarkersDir},
+		{name: "user-index", tenantID: "user-index.json.gz"},
+		{name: "dot", tenantID: "."},
+		{name: "double dot", tenantID: ".."},
+		{name: "unsupported char pipe", tenantID: "tenant|id"},
+		{name: "unsupported char space", tenantID: "tenant id"},
+		{name: "too long", tenantID: strings.Repeat("a", 151)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Invalid tenant IDs must be rejected regardless of AllowedTenants config.
+			require.False(t, NewAllowedTenants(nil, nil).IsAllowed(tc.tenantID), "NoConfig should reject invalid tenant")
+			require.False(t, NewAllowedTenants([]string{tc.tenantID}, nil).IsAllowed(tc.tenantID), "Enabled list should still reject invalid tenant")
+			var nilTenants *AllowedTenants
+			require.False(t, nilTenants.IsAllowed(tc.tenantID), "Nil AllowedTenants should reject invalid tenant")
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

Updated the `IsAllowed` method in `AllowedTenants` to call `ValidTenantID`, rejecting tenant IDs with unsupported characters, excessive length (>150 chars), path traversal segments (`.` or `..`), and reserved names (`__markers__`, `user-index.json.gz`)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
