### PR TITLE
docs: document supported architectures

### DIFF
--- a/docs/guides/supported-architectures.md
+++ b/docs/guides/supported-architectures.md
@@ -4,9 +4,9 @@ linkTitle: "Supported architectures"
 weight: 16
 ---
 
-Cortex release artifacts are built and tested for the architectures listed
-below. Use these targets when selecting container images, binary artifacts, or
-OS packages for production deployments.
+Cortex release artifacts are built for the operating systems and architectures
+listed below. Use these targets when selecting container images, binary
+artifacts, or OS packages for production deployments.
 
 ## Supported release targets
 
@@ -14,15 +14,15 @@ OS packages for production deployments.
 |---------------|------------------|---------------|
 | Container images | Linux | `amd64`, `arm64` |
 | Cortex binary | Linux | `amd64`, `arm64` |
-| Cortex binary | macOS | `amd64`, `arm64` |
-| Query tee binary | Linux | `amd64`, `arm64` |
-| Query tee binary | macOS | `amd64`, `arm64` |
+| Cortex binary | darwin (macOS) | `amd64`, `arm64` |
+| `query-tee` binary | Linux | `amd64`, `arm64` |
+| `query-tee` binary | darwin (macOS) | `amd64`, `arm64` |
 | Debian package | Linux | `amd64`, `arm64` |
 | RPM package | Linux | `amd64`, `arm64` |
 
 The CI and release pipelines build Cortex with `GOOS` and `GOARCH` targets
-matching these rows. Integration tests also run against Linux `amd64` and
-`arm64` Cortex images.
+matching these rows. Automated tests run against Linux `amd64` and `arm64`
+Cortex images.
 
 ## Unsupported targets
 

--- a/docs/guides/supported-architectures.md
+++ b/docs/guides/supported-architectures.md
@@ -1,0 +1,35 @@
+---
+title: "Supported architectures"
+linkTitle: "Supported architectures"
+weight: 16
+---
+
+Cortex release artifacts are built and tested for the architectures listed
+below. Use these targets when selecting container images, binary artifacts, or
+OS packages for production deployments.
+
+## Supported release targets
+
+| Artifact type | Operating system | Architectures |
+|---------------|------------------|---------------|
+| Container images | Linux | `amd64`, `arm64` |
+| Cortex binary | Linux | `amd64`, `arm64` |
+| Cortex binary | macOS | `amd64`, `arm64` |
+| Query tee binary | Linux | `amd64`, `arm64` |
+| Query tee binary | macOS | `amd64`, `arm64` |
+| Debian package | Linux | `amd64`, `arm64` |
+| RPM package | Linux | `amd64`, `arm64` |
+
+The CI and release pipelines build Cortex with `GOOS` and `GOARCH` targets
+matching these rows. Integration tests also run against Linux `amd64` and
+`arm64` Cortex images.
+
+## Unsupported targets
+
+Other operating systems or architectures may work when built from source, but
+they are not part of the regular Cortex release artifacts or CI matrix. Treat
+those builds as unsupported unless you validate them in your own environment.
+
+Cortex does not require architecture-specific CPU extensions such as AVX in its
+release build configuration. If you use external services or custom base images
+alongside Cortex, verify their architecture and CPU requirements separately.


### PR DESCRIPTION
**What this PR does**:

Adds a new documentation guide for Cortex's supported architectures. The page summarizes the supported release targets for container images, binaries, Debian packages, and RPM packages, and notes that other platforms should be treated as unsupported unless validated by the operator.

The documented targets were checked against the current Makefile release/build targets, CI architecture matrix, and latest published v1.21.0 release assets.

**Which issue(s) this PR fixes**:
Fixes #4753

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags

**Validation performed**:

```console
SED_BIN=gsed ./tools/cleanup-white-noise.sh docs/guides/supported-architectures.md

git diff --cached --check
# exit 0 before commit

gh release view --repo cortexproject/cortex --json tagName,assets
# confirmed latest v1.21.0 includes linux/darwin amd64/arm64 binaries and amd64/arm64 deb/rpm assets
```

I could not run the Hugo website build locally because `hugo` is not installed in this environment.

**AI assistance disclosure**:

This documentation PR was prepared with OpenAI Codex assistance. AI was used to inspect repository policy/build files, draft the documentation text, and run local validation commands. The contribution remains submitted under the DCO signoff in the commit.
