### PR TITLE
[BUGFIX] Ingester: fix inflight query counter leak on resource rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [BUGFIX] Security: Fix stored XSS vulnerability in Alertmanager and Store Gateway status pages by replacing `text/template` with `html/template`. #7512
 * [BUGFIX] Security: Limit decompressed gzip output in `ParseProtoReader` and OTLP ingestion path. The decompressed body is now capped by `-distributor.otlp-max-recv-msg-size`. #7515
 * [BUGFIX] Tenant Federation: Fix regex resolver clearing known users list when user scan fails. #7534
+* [BUGFIX] Ingester: Fix inflight query counter leak when resource-based query protection rejects a request. #7539
 
 ## 1.21.0 2026-04-24
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2515,14 +2515,14 @@ func (i *Ingester) trackInflightQueryRequest() (func(), error) {
 		}
 	}
 
-	i.maxInflightQueryRequests.Track(i.inflightQueryRequests.Inc())
-
 	if i.resourceBasedLimiter != nil {
 		if err := i.resourceBasedLimiter.AcceptNewRequest(); err != nil {
 			level.Warn(i.logger).Log("msg", "failed to accept request", "err", err)
 			return nil, limiter.ErrResourceLimitReached
 		}
 	}
+
+	i.maxInflightQueryRequests.Track(i.inflightQueryRequests.Inc())
 
 	return func() {
 		i.inflightQueryRequests.Dec()

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -3544,7 +3544,8 @@ func Test_Ingester_Query_ResourceThresholdBreached(t *testing.T) {
 		resource.CPU:  0.5,
 		resource.Heap: 0.5,
 	}
-	i.resourceBasedLimiter, err = limiter.NewResourceBasedLimiter(&mockResourceMonitor{cpu: 0.4, heap: 0.6}, limits, nil, "ingester")
+	monitor := &mockResourceMonitor{cpu: 0.4, heap: 0.6}
+	i.resourceBasedLimiter, err = limiter.NewResourceBasedLimiter(monitor, limits, nil, "ingester")
 	require.NoError(t, err)
 
 	// Wait until it's ACTIVE
@@ -3570,7 +3571,8 @@ func Test_Ingester_Query_ResourceThresholdBreached(t *testing.T) {
 	require.ErrorIs(t, err, limiter.ErrResourceLimitReached)
 	require.Equal(t, int64(0), i.inflightQueryRequests.Load())
 
-	i.resourceBasedLimiter = nil
+	// Verify that a query not blocked by the limiter still succeeds after the rejected request.
+	monitor.heap = 0.4
 	s = &mockQueryStreamServer{ctx: ctx}
 	require.NoError(t, i.QueryStream(rreq, s))
 }

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -3533,7 +3533,9 @@ func Test_Ingester_Query_ResourceThresholdBreached(t *testing.T) {
 		{labels.FromStrings("__name__", "test_1", "route", "get_user", "status", "200"), 1, 100000},
 	}
 
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), prometheus.NewRegistry())
+	cfg := defaultIngesterTestConfig(t)
+	cfg.DefaultLimits.MaxInflightQueryRequests = 1
+	i, err := prepareIngesterWithBlocksStorage(t, cfg, prometheus.NewRegistry())
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
@@ -3566,6 +3568,11 @@ func Test_Ingester_Query_ResourceThresholdBreached(t *testing.T) {
 
 	// Expected error from isRetryableError in blocks_store_queryable.go
 	require.ErrorIs(t, err, limiter.ErrResourceLimitReached)
+	require.Equal(t, int64(0), i.inflightQueryRequests.Load())
+
+	i.resourceBasedLimiter = nil
+	s = &mockQueryStreamServer{ctx: ctx}
+	require.NoError(t, i.QueryStream(rreq, s))
 }
 
 func TestIngester_LabelValues_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {


### PR DESCRIPTION
## What this PR does

`Ingester.trackInflightQueryRequest` incremented and tracked `inflightQueryRequests` before calling `resourceBasedLimiter.AcceptNewRequest()`. If the resource limiter rejected the query, the helper returned `limiter.ErrResourceLimitReached` without returning a cleanup callback or decrementing the counter.

Symptom: each resource-rejected query permanently consumed one ingester inflight-query slot. Once enough rejections accumulated to reach `MaxInflightQueryRequests`, later queries could be rejected with `errTooManyInflightQueryRequests` even after resource pressure dropped. The counter only recovered when the ingester restarted.

Fix: run the resource-based admission check before incrementing and tracking the inflight query counter. Resource-rejected queries are not admitted as inflight work, so they no longer consume max-inflight capacity or inflate the max inflight metric. The regression test now enables `MaxInflightQueryRequests`, verifies the counter remains zero after resource rejection, and verifies a later query succeeds once the resource limiter is disabled.

## Which issue(s) this PR fixes

Fixes #7538

## Checklist

- [x] `CHANGELOG.md` updated — `[BUGFIX] Ingester:` entry under `master / unreleased`.
- [x] Documentation updated — not applicable, no flags or config changed (`make doc` not required).
- [x] Tests added — `Test_Ingester_Query_ResourceThresholdBreached` now covers the leaked inflight-query counter path.

## Test plan

- [x] `git diff --check` — clean
- [x] `go test -timeout 2400s -tags "netgo slicelabels" ./pkg/ingester -run '^Test_Ingester_Query_ResourceThresholdBreached$' -count=1` — PASS
- [x] `go test -timeout 2400s -tags "netgo slicelabels" ./pkg/ingester` — PASS
- [x] `go test -timeout 2400s -tags "netgo slicelabels" ./pkg/compactor -run '^TestPartitionCompactor_DeleteLocalSyncFiles$' -count=1` — PASS locally after unrelated CI flake in `test-no-race (amd64)`
