### PR TITLE
fix(integration): log fuzz seed so failures can be reproduced

### DIFF
--- a/integration/parquet_querier_test.go
+++ b/integration/parquet_querier_test.go
@@ -5,7 +5,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -89,7 +88,7 @@ func TestParquetFuzz(t *testing.T) {
 	require.NoError(t, writeFileToSharedDir(s, "alertmanager_configs", []byte{}))
 
 	ctx := context.Background()
-	rnd := rand.New(rand.NewSource(time.Now().Unix()))
+	rnd := newFuzzRand(t)
 	dir := filepath.Join(s.SharedDir(), "data")
 	numSeries := 10
 	numSamples := 60
@@ -240,7 +239,7 @@ func TestParquetProjectionPushdownFuzz(t *testing.T) {
 	require.NoError(t, writeFileToSharedDir(s, "alertmanager_configs", []byte{}))
 
 	ctx := context.Background()
-	rnd := rand.New(rand.NewSource(time.Now().Unix()))
+	rnd := newFuzzRand(t)
 	dir := filepath.Join(s.SharedDir(), "data")
 	numSeries := 20
 	numSamples := 100

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -121,7 +121,7 @@ func TestNativeHistogramFuzz(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	rnd := rand.New(rand.NewSource(time.Now().Unix()))
+	rnd := newFuzzRand(t)
 
 	dir := filepath.Join(s.SharedDir(), "data")
 	err = os.MkdirAll(dir, os.ModePerm)
@@ -222,7 +222,7 @@ func TestExperimentalPromQLFuncsWithPrometheus(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	rnd := rand.New(rand.NewSource(time.Now().Unix()))
+	rnd := newFuzzRand(t)
 
 	dir := filepath.Join(s.SharedDir(), "data")
 	err = os.MkdirAll(dir, os.ModePerm)
@@ -357,7 +357,7 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 
 	waitUntilReady(t, context.Background(), c1, c2, `{job="test"}`, start, now)
 
-	rnd := rand.New(rand.NewSource(now.Unix()))
+	rnd := newFuzzRand(t)
 	opts := []promqlsmith.Option{
 		// @ modifier and offset disabled: known bug in Prometheus (e.g. predict_linear with @/offset can panic).
 		promqlsmith.WithEnabledFunctions(enabledFunctions),
@@ -538,7 +538,7 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 		}
 	}
 
-	rnd := rand.New(rand.NewSource(now.Unix()))
+	rnd := newFuzzRand(t)
 	opts := []promqlsmith.Option{
 		// @ modifier and offset disabled: known bug in Prometheus (e.g. predict_linear with @/offset can panic).
 		promqlsmith.WithEnabledAggrs(enabledAggrs),
@@ -767,7 +767,7 @@ func TestVerticalShardingFuzz(t *testing.T) {
 
 	waitUntilReady(t, context.Background(), c1, c2, `{job="test"}`, start, end)
 
-	rnd := rand.New(rand.NewSource(now.Unix()))
+	rnd := newFuzzRand(t)
 	opts := []promqlsmith.Option{
 		// @ modifier and offset disabled: known bug in Prometheus (e.g. predict_linear with @/offset can panic).
 		promqlsmith.WithEnabledFunctions(enabledFunctions),
@@ -883,7 +883,7 @@ func TestProtobufCodecFuzz(t *testing.T) {
 
 	waitUntilReady(t, context.Background(), c1, c2, `{job="test"}`, start, end)
 
-	rnd := rand.New(rand.NewSource(now.Unix()))
+	rnd := newFuzzRand(t)
 	opts := []promqlsmith.Option{
 		// @ modifier and offset disabled: known bug in Prometheus (e.g. predict_linear with @/offset can panic).
 		promqlsmith.WithEnabledFunctions(enabledFunctions),
@@ -1202,7 +1202,7 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzz(t *testing.T) {
 		lbls = append(lbls, labels.FromStrings(labels.MetricName, metricName, "job", "test", "series", strconv.Itoa(i%200), "status_code", statusCodes[i%5]))
 	}
 	ctx := context.Background()
-	rnd := rand.New(rand.NewSource(time.Now().Unix()))
+	rnd := newFuzzRand(t)
 
 	dir := t.TempDir()
 	storage, err := e2ecortex.NewS3ClientForMinio(minio, flags["-blocks-storage.s3.bucket-name"])
@@ -1357,7 +1357,7 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzzWithPrometheus(t *testing.T) 
 		lbls = append(lbls, labels.FromStrings(labels.MetricName, metricName, "job", "test", "series", strconv.Itoa(i%200), "status_code", statusCodes[i%5]))
 	}
 	ctx := context.Background()
-	rnd := rand.New(rand.NewSource(time.Now().Unix()))
+	rnd := newFuzzRand(t)
 
 	dir := filepath.Join(s.SharedDir(), "data")
 	err = os.MkdirAll(dir, os.ModePerm)
@@ -1590,7 +1590,7 @@ func TestBackwardCompatibilityQueryFuzz(t *testing.T) {
 	ctx := context.Background()
 	waitUntilReady(t, ctx, c1, c2, `{job="test"}`, start, end)
 
-	rnd := rand.New(rand.NewSource(now.Unix()))
+	rnd := newFuzzRand(t)
 	opts := []promqlsmith.Option{
 		// @ modifier and offset disabled: known bug in Prometheus (e.g. predict_linear with @/offset can panic).
 		promqlsmith.WithEnabledFunctions(enabledFunctions),
@@ -1662,7 +1662,7 @@ func TestPrometheusCompatibilityQueryFuzz(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	rnd := rand.New(rand.NewSource(time.Now().Unix()))
+	rnd := newFuzzRand(t)
 
 	dir := filepath.Join(s.SharedDir(), "data")
 	err = os.MkdirAll(dir, os.ModePerm)
@@ -1816,8 +1816,7 @@ func TestRW1vsRW2QueryFuzz(t *testing.T) {
 	_, err = c2.PushV2(symbols, v2Series)
 	require.NoError(t, err)
 
-	seed := now.Unix()
-	rnd := rand.New(rand.NewSource(seed))
+	rnd := newFuzzRand(t)
 
 	ctx := context.Background()
 	waitUntilReady(t, ctx, c1, c2, `{job="test"}`, start, end)
@@ -1978,6 +1977,24 @@ func shouldUseSampleNumComparer(query string) bool {
 		return true
 	}
 	return false
+}
+
+// newFuzzRand returns a *rand.Rand whose seed is logged via t.Logf so failing
+// fuzz cases can be reproduced. By default the seed is time.Now().Unix();
+// setting FUZZ_SEED to a base-10 int64 overrides the default and pins the
+// run to a specific seed.
+func newFuzzRand(t *testing.T) *rand.Rand {
+	seed := time.Now().Unix()
+	if v := os.Getenv("FUZZ_SEED"); v != "" {
+		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil {
+			t.Logf("integration fuzz random seed: overridden to %d via FUZZ_SEED", parsed)
+			seed = parsed
+		} else {
+			t.Logf("integration fuzz random seed: ignoring invalid FUZZ_SEED=%q: %v", v, err)
+		}
+	}
+	t.Logf("integration fuzz random seed: %d (override with FUZZ_SEED env var)", seed)
+	return rand.New(rand.NewSource(seed))
 }
 
 func isValidQuery(generatedQuery parser.Expr, skipBackwardIncompat bool) bool {


### PR DESCRIPTION
## What this PR does

Adds a small `newFuzzRand(t *testing.T) *rand.Rand` helper at `integration/query_fuzz_test.go:1986` that logs the random seed every fuzz test draws (via `t.Logf`), and replaces the 13 ad-hoc `rand.New(rand.NewSource(time.Now().Unix()))` / `rand.New(rand.NewSource(now.Unix()))` call sites across `integration/query_fuzz_test.go` (11 sites) and `integration/parquet_querier_test.go` (2 sites) with calls to it. A `FUZZ_SEED` environment variable overrides the default `time.Now().Unix()` so a failing CI run can be replayed locally byte-for-byte.

This is a pure observability change. It does **not** fix the underlying flake tracked in #7548 — `TestProtobufCodecFuzz` will continue to fail at whatever rate it currently does. What it changes is that the next failure log will include the exact seed used, so the run can be reproduced deterministically and classified (real Cortex/Prometheus divergence vs. another non-deterministic-set message vs. a transient harness issue).

## Why

Issue #7548 documents `TestProtobufCodecFuzz` failures in CI. Triage is currently blocked because the seed is silently consumed by `rand.New(rand.NewSource(now.Unix()))` and never surfaced in the test log, so the failing query/series combination cannot be re-generated. Every failure has to be diagnosed from the comparison output alone, which is insufficient to distinguish "real bug" from "known-class non-determinism" from "infra noise". Logging the seed (and accepting an override) is the minimum surface needed to make the next failure classifiable.

The same problem applies to every fuzz test in `integration/query_fuzz_test.go` and `integration/parquet_querier_test.go` — see "Scope expansion" below.

## How

Two pieces:

1. New helper at `integration/query_fuzz_test.go:1986`:

   ```go
   // newFuzzRand returns a *rand.Rand whose seed is logged via t.Logf so failing
   // fuzz cases can be reproduced. By default the seed is time.Now().Unix();
   // setting FUZZ_SEED to a base-10 int64 overrides the default and pins the
   // run to a specific seed.
   func newFuzzRand(t *testing.T) *rand.Rand {
       seed := time.Now().Unix()
       if v := os.Getenv("FUZZ_SEED"); v != "" {
           if parsed, err := strconv.ParseInt(v, 10, 64); err == nil {
               t.Logf("integration fuzz random seed: overridden to %d via FUZZ_SEED", parsed)
               seed = parsed
           } else {
               t.Logf("integration fuzz random seed: ignoring invalid FUZZ_SEED=%q: %v", v, err)
           }
       }
       t.Logf("integration fuzz random seed: %d (override with FUZZ_SEED env var)", seed)
       return rand.New(rand.NewSource(seed))
   }
   ```

   Invalid `FUZZ_SEED` values are logged (with the parse error) rather than silently falling back, so a typo in CI configuration surfaces immediately instead of masquerading as a successful override.

2. 13 call-site replacements — every `rand.New(rand.NewSource(time.Now().Unix()))` and `rand.New(rand.NewSource(now.Unix()))` in:

   - `integration/query_fuzz_test.go`: `TestNativeHistogramFuzz`, `TestExperimentalPromQLFuncsWithPrometheus`, `TestDisableChunkTrimmingFuzz`, `TestExpandedPostingsCacheFuzz`, `TestVerticalShardingFuzz`, `TestProtobufCodecFuzz`, `TestStoreGatewayLazyExpandedPostingsSeriesFuzz`, `TestStoreGatewayLazyExpandedPostingsSeriesFuzzWithPrometheus`, `TestBackwardCompatibilityQueryFuzz`, `TestPrometheusCompatibilityQueryFuzz`, `TestRW1vsRW2QueryFuzz` (11 sites).
   - `integration/parquet_querier_test.go`: `TestParquetFuzz`, `TestParquetProjectionPushdownFuzz` (2 sites). The unused `"math/rand"` import is also dropped from this file since the helper is in the other test file (same package).

   No production code is touched.

## Scope expansion

This PR was filed against #7548 (`TestProtobufCodecFuzz` specifically) but the helper is applied to all 13 fuzz call sites, not just `TestProtobufCodecFuzz`. This is intentional: the underlying observability gap — seed is computed from `time.Now().Unix()` and never logged — is identical for every fuzz test in the integration suite, and applying the helper everywhere is strictly less code than leaving twelve other tests with the same gap. The risk is small (test-only change, no production code, no new dependencies, the helper is ~15 lines), and the benefit when the next *different* fuzz test flakes is exactly the same as the benefit for `TestProtobufCodecFuzz` today. A reviewer who prefers a narrower change can squash the scope to the single `TestProtobufCodecFuzz` call site without functional impact, but the wider change is the recommended shape.

## Reproducing a failed seed

When a CI run fails, copy the seed from the `integration fuzz random seed: <N>` log line and replay locally:

```
FUZZ_SEED=12345 go test -v -tags=integration,requires_docker,integration_query_fuzz -timeout 2400s -count=1 ./integration/... -run "^TestProtobufCodecFuzz$"
```

Substitute the actual seed and the actual test name. The same `FUZZ_SEED` works for every fuzz test in the suite because they all draw from `newFuzzRand(t)` now.

## Which issue(s) this PR fixes

Fixes #7548

This is the final PR in a four-PR series filed against issues #7545–#7548, complementing PR #7544 (which fixes #7543). The full series:

- PR #7544 — `TestParquetFuzz` topk/bottomk tie-collapse flake (fixes #7543)
- PR #7549 — `TestExpandedPostingsCacheFuzz` inverted loop + `sres1, sres1` typo (fixes #7545)
- PR #7550 — `sameErrorClass` canonicalizer for non-deterministic bracket-list error messages (fixes #7546)
- PR #7551 — `hasOrVectorFallback` predicate against `or vector(...)` divergences in `TestVerticalShardingFuzz` (fixes #7547)
- PR #7552 (this one) — `newFuzzRand` helper to log + override fuzz seeds (fixes #7548)

Together the four PRs address the four open `integration_query_fuzz` flake issues with the minimum-surface fix that meaningfully advances each one. #7548 is intentionally an observability fix rather than a behaviour fix because the failing-case data needed to classify the underlying flake does not currently exist; this PR collects it.

## Checklist

- [x] `CHANGELOG.md` updated — not applicable; test-only change with no user-facing behaviour change.
- [x] Documentation updated — not applicable; no flags or config changed. The `FUZZ_SEED` env var is documented in the helper's godoc comment.
- [x] Tests: no new test added. The helper is exercised by every fuzz test in the suite, and its branches (default, valid override, invalid override) are simple enough that a unit test would mostly re-state the implementation. If reviewers prefer one, a `TestNewFuzzRand` with three subtests can be added in a follow-up.

## Test plan

Local (no Docker harness required):

- [x] `gofmt -l integration/query_fuzz_test.go integration/parquet_querier_test.go` — clean
- [x] `goimports -local github.com/cortexproject/cortex -l integration/query_fuzz_test.go integration/parquet_querier_test.go` — clean
- [x] `go vet -tags "netgo slicelabels integration integration_query_fuzz" ./integration/...` — clean
- [x] `go build -tags "netgo slicelabels integration integration_query_fuzz" ./integration/...` — clean

Validation that seed logging actually appears (requires Docker):

- [x] `make ./cmd/cortex/.uptodate`
- [x] `go test -v -tags=integration,requires_docker,integration_query_fuzz -timeout 2400s -count=1 ./integration/... -run "^TestProtobufCodecFuzz$"` — confirm the `integration fuzz random seed: <N> (override with FUZZ_SEED env var)` line appears in the log.
- [x] `FUZZ_SEED=42 go test -v -tags=integration,requires_docker,integration_query_fuzz -timeout 2400s -count=1 ./integration/... -run "^TestProtobufCodecFuzz$"` — confirm the override path logs `overridden to 42 via FUZZ_SEED` and the run is deterministic (two invocations with the same `FUZZ_SEED` exercise the same query set).
- [x] `FUZZ_SEED=notanint go test -v -tags=integration,requires_docker,integration_query_fuzz -timeout 2400s -count=1 ./integration/... -run "^TestProtobufCodecFuzz$"` — confirm the invalid-input path logs `ignoring invalid FUZZ_SEED="notanint"` and falls back to the time-based seed without skipping the test.

