### PR TITLE
Fix native histogram data loss in split_by_interval merge due to broken minTime() sort

### DIFF
--- a/pkg/querier/tripperware/merge.go
+++ b/pkg/querier/tripperware/merge.go
@@ -25,16 +25,19 @@ func (a byFirstTime) Less(i, j int) bool { return a[i].minTime() < a[j].minTime(
 func (resp *PrometheusResponse) minTime() int64 {
 	data := resp.GetData()
 	res := data.GetResult()
-	// minTime should only be called when the response is fron range query.
+	// minTime should only be called when the response is from range query.
 	matrix := res.GetMatrix()
 	sampleStreams := matrix.GetSampleStreams()
 	if len(sampleStreams) == 0 {
 		return -1
 	}
-	if len(sampleStreams[0].Samples) == 0 {
-		return -1
+	if len(sampleStreams[0].Samples) > 0 {
+		return sampleStreams[0].Samples[0].TimestampMs
 	}
-	return sampleStreams[0].Samples[0].TimestampMs
+	if len(sampleStreams[0].Histograms) > 0 {
+		return sampleStreams[0].Histograms[0].GetTimestampMs()
+	}
+	return -1
 }
 
 // MergeResponse merges multiple Response into one.

--- a/pkg/querier/tripperware/merge_test.go
+++ b/pkg/querier/tripperware/merge_test.go
@@ -681,3 +681,108 @@ func Test_sortPlanForQuery(t *testing.T) {
 		})
 	}
 }
+
+func TestMinTime(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		resp     *PrometheusResponse
+		expected int64
+	}{
+		{
+			name: "empty matrix",
+			resp: &PrometheusResponse{
+				Data: PrometheusData{
+					ResultType: "matrix",
+					Result: PrometheusQueryResult{
+						Result: &PrometheusQueryResult_Matrix{
+							Matrix: &Matrix{SampleStreams: []SampleStream{}},
+						},
+					},
+				},
+			},
+			expected: -1,
+		},
+		{
+			name: "float samples only",
+			resp: &PrometheusResponse{
+				Data: PrometheusData{
+					ResultType: "matrix",
+					Result: PrometheusQueryResult{
+						Result: &PrometheusQueryResult_Matrix{
+							Matrix: &Matrix{SampleStreams: []SampleStream{
+								{
+									Labels:  cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{"foo": "bar"})),
+									Samples: []cortexpb.Sample{{TimestampMs: 1000}, {TimestampMs: 2000}},
+								},
+							}},
+						},
+					},
+				},
+			},
+			expected: 1000,
+		},
+		{
+			name: "histograms only",
+			resp: &PrometheusResponse{
+				Data: PrometheusData{
+					ResultType: "matrix",
+					Result: PrometheusQueryResult{
+						Result: &PrometheusQueryResult_Matrix{
+							Matrix: &Matrix{SampleStreams: []SampleStream{
+								{
+									Labels:     cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{"foo": "bar"})),
+									Histograms: []SampleHistogramPair{{TimestampMs: 3000, Histogram: testHistogram1}, {TimestampMs: 4000, Histogram: testHistogram1}},
+								},
+							}},
+						},
+					},
+				},
+			},
+			expected: 3000,
+		},
+		{
+			name: "both samples and histograms - samples first",
+			resp: &PrometheusResponse{
+				Data: PrometheusData{
+					ResultType: "matrix",
+					Result: PrometheusQueryResult{
+						Result: &PrometheusQueryResult_Matrix{
+							Matrix: &Matrix{SampleStreams: []SampleStream{
+								{
+									Labels:     cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{"foo": "bar"})),
+									Samples:    []cortexpb.Sample{{TimestampMs: 1000}},
+									Histograms: []SampleHistogramPair{{TimestampMs: 5000, Histogram: testHistogram1}},
+								},
+							}},
+						},
+					},
+				},
+			},
+			expected: 1000,
+		},
+		{
+			name: "stream with empty samples and empty histograms",
+			resp: &PrometheusResponse{
+				Data: PrometheusData{
+					ResultType: "matrix",
+					Result: PrometheusQueryResult{
+						Result: &PrometheusQueryResult_Matrix{
+							Matrix: &Matrix{SampleStreams: []SampleStream{
+								{
+									Labels: cortexpb.FromLabelsToLabelAdapters(labels.FromMap(map[string]string{"foo": "bar"})),
+								},
+							}},
+						},
+					},
+				},
+			},
+			expected: -1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, tc.resp.minTime())
+		})
+	}
+}


### PR DESCRIPTION
…ordering for split_by_interval merge

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Fixes minTime() in pkg/querier/tripperware/merge.go to handle native histogram-only responses when sorting sub-interval responses before merging.

When split_by_interval splits a range query and merges the results, MergeResponse sorts responses by minTime() to ensure chronological order before the dedup/merge logic runs. However, minTime() only checked SampleStream.Samples[0] — for native histogram queries like sum(rate(nh_metric[20m])), the result is a FloatHistogram stored in SampleStream.Histograms with Samples empty. This caused minTime() to return -1 for all sub-interval responses.
  

Tests
Added TestMinTime covering: empty matrix, float-only, histogram-only, both, and empty stream cases.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
