### PR TITLE
[BUGFIX] Ingester: close TSDB on compaction failure to prevent resource leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [BUGFIX] Compactor: Fix stale `cortex_bucket_index_last_successful_update_timestamp_seconds` metric not being cleaned up when tenant ownership changes due to ring rebalancing. This caused false alarms on bucket index update rate when a tenant moved between compactors. #7485
 * [BUGFIX] Security: Fix stored XSS vulnerability in Alertmanager and Store Gateway status pages by replacing `text/template` with `html/template`. #7512
 * [BUGFIX] Security: Limit decompressed gzip output in `ParseProtoReader` and OTLP ingestion path. The decompressed body is now capped by `-distributor.otlp-max-recv-msg-size`. #7515
+* [BUGFIX] Ingester: Close TSDB when compaction fails during `createTSDB`, preventing resource leaks (file descriptors, mmap handles) that could lead to ingester instability. #7557
 
 ## 1.21.0 2026-04-24
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2965,6 +2965,9 @@ func (i *Ingester) createTSDB(userID string) (*userTSDB, error) {
 	level.Info(userLogger).Log("msg", "Running compaction after WAL replay")
 	err = db.Compact(context.TODO())
 	if err != nil {
+		if closeErr := db.Close(); closeErr != nil {
+			level.Warn(userLogger).Log("msg", "failed to close TSDB after compact failure", "err", closeErr)
+		}
 		return nil, errors.Wrapf(err, "failed to compact TSDB: %s", udir)
 	}
 


### PR DESCRIPTION
## What this PR does

`createTSDB` opens a TSDB via `tsdb.Open()` and then runs `db.Compact()` to flush any head data into blocks after WAL replay. If `Compact()` returned an error, the function returned immediately without calling `db.Close()`, leaking the head, WAL, and mmap file handles held by the open database.

Symptom: each failed compaction permanently leaked one set of TSDB file descriptors and memory-mapped regions. Under repeated startup compaction failures for different tenants, the ingester could exhaust file descriptors (`ulimit -n`) and eventually crash or refuse to open new TSDBs.

Fix: call `db.Close()` before returning the compaction error. If `Close` itself fails, log a warning so the secondary failure is observable rather than silent. This follows the existing close-error logging pattern used in `closeAllTSDB` (line 3032).

## Which issue(s) this PR fixes

Fixes #7557

## Checklist

- [x] `CHANGELOG.md` updated — `[BUGFIX] Ingester:` entry under `master / unreleased`.
- [x] Documentation updated — not applicable, no flags or config changed (`make doc` not required).
- [x] Tests verified — no new test added (the error path requires injecting a Compact failure which is non-trivial without production code changes); existing TSDB tests confirm no regression.

## Test plan

- [x] `go build -tags "netgo slicelabels" ./pkg/ingester/...` — clean
- [x] `go vet -tags "netgo slicelabels" ./pkg/ingester/...` — clean
- [x] `goimports -l -local github.com/cortexproject/cortex ./pkg/ingester/ingester.go` — clean
- [x] `go test -timeout 300s -tags "netgo slicelabels" -count=1 ./pkg/ingester/...` — PASS (27s)
- [x] `go test -tags "netgo slicelabels" -count=1 -run "TestHeadCompactionOnStartup" ./pkg/ingester/...` — PASS (exercises the success path of the same code)
- [x] `go test -tags "netgo slicelabels" -count=1 -run "TestIngester_OpenExistingTSDBOnStartup" ./pkg/ingester/...` — PASS