### PR TITLE
fix(compactor): await HeartBeat goroutine to fix flaky TestBlocksCleaner on arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [BUGFIX] Compactor: Fix stale `cortex_bucket_index_last_successful_update_timestamp_seconds` metric not being cleaned up when tenant ownership changes due to ring rebalancing. This caused false alarms on bucket index update rate when a tenant moved between compactors. #7485
 * [BUGFIX] Security: Fix stored XSS vulnerability in Alertmanager and Store Gateway status pages by replacing `text/template` with `html/template`. #7512
 * [BUGFIX] Security: Limit decompressed gzip output in `ParseProtoReader` and OTLP ingestion path. The decompressed body is now capped by `-distributor.otlp-max-recv-msg-size`. #7515
+* [BUGFIX] Compactor: Wait for the blocks cleaner `VisitMarkerManager.HeartBeat` goroutine to exit before returning from per-user cleanup callbacks, preventing a late `MarkWithStatus(Completed)` and `DeleteVisitMarker` write from racing with test teardown and causing `unlinkat: directory not empty` flakes in `TestBlocksCleaner`. #7564
 
 ## 1.21.0 2026-04-24
 

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -357,9 +357,15 @@ func (c *BlocksCleaner) cleanUpActiveUsers(ctx context.Context, users []string, 
 			return nil
 		}
 		errChan := make(chan error, 1)
-		go visitMarkerManager.HeartBeat(ctx, errChan, c.cleanerVisitMarkerFileUpdateInterval, true)
+		var hbWG sync.WaitGroup
+		hbWG.Add(1)
+		go func() {
+			defer hbWG.Done()
+			visitMarkerManager.HeartBeat(ctx, errChan, c.cleanerVisitMarkerFileUpdateInterval, true)
+		}()
 		defer func() {
 			errChan <- nil
+			hbWG.Wait()
 		}()
 		return errors.Wrapf(c.cleanUser(ctx, userLogger, userBucket, userID, firstRun), "failed to delete blocks for user: %s", userID)
 	})
@@ -392,9 +398,15 @@ func (c *BlocksCleaner) cleanDeletedUsers(ctx context.Context, users []string) e
 			return nil
 		}
 		errChan := make(chan error, 1)
-		go visitMarkerManager.HeartBeat(ctx, errChan, c.cleanerVisitMarkerFileUpdateInterval, true)
+		var hbWG sync.WaitGroup
+		hbWG.Add(1)
+		go func() {
+			defer hbWG.Done()
+			visitMarkerManager.HeartBeat(ctx, errChan, c.cleanerVisitMarkerFileUpdateInterval, true)
+		}()
 		defer func() {
 			errChan <- nil
+			hbWG.Wait()
 		}()
 		return errors.Wrapf(c.deleteUserMarkedForDeletion(ctx, userLogger, userBucket, userID), "failed to delete user marked for deletion: %s", userID)
 	})


### PR DESCRIPTION
## What this PR does

Wraps the `VisitMarkerManager.HeartBeat` goroutine in `BlocksCleaner.cleanUpActiveUsers` and `BlocksCleaner.cleanDeletedUsers` with a `sync.WaitGroup` so the per-user cleanup callback waits for the heartbeat goroutine to fully exit before returning, instead of just signalling it via `errChan <- nil` and racing on.

This is a test-flake fix only; the production behaviour change is that per-user cleanup now blocks until the heartbeat's terminal `MarkWithStatus(Completed)` + `DeleteVisitMarker` writes finish, which is what the surrounding code already assumed.

## Why

`TestBlocksCleaner` flakes intermittently on `test-no-race (arm64)` CI with:

```
--- FAIL: TestBlocksCleaner/concurrency=2,_markers_migration_enabled=false,_tenant_deletion_delay=0s (3.92s)
    objstore.go:26: 
        Error Trace: pkg/util/testutil/objstore.go:26
        Error:      Received unexpected error:
                    unlinkat /tmp/bucket3527476943: directory not empty
```

Observed in [run 26555111751](https://github.com/cortexproject/cortex/actions/runs/26555111751/job/78225222195).

Root cause: `cleanUpActiveUsers` / `cleanDeletedUsers` launched `visitMarkerManager.HeartBeat` in a bare `go` statement and only signalled it via `errChan <- nil` in a `defer`, never awaiting it. On receipt of the `nil`, `HeartBeat` still ran a terminal `MarkWithStatus(Completed)` using the parent `ctx` followed by `DeleteVisitMarker(context.Background())` against the bucket. In the test, the bucket is a filesystem bucket backed by a `t.TempDir()` whose `t.Cleanup` runs `os.RemoveAll`; those late writes raced with the directory teardown, producing the arm64-flaky `unlinkat: directory not empty` failure.

The arm64 scheduler exposes this race more often than amd64 does, but the bug is platform-independent — the goroutine leak / late-write window exists on every architecture.

## How

`pkg/compactor/blocks_cleaner.go` (two call sites: `cleanUpActiveUsers` and `cleanDeletedUsers`). Replace:

```go
go visitMarkerManager.HeartBeat(ctx, errChan, c.cleanerVisitMarkerFileUpdateInterval, true)
defer func() {
    errChan <- nil
}()
```

with:

```go
var hbWG sync.WaitGroup
hbWG.Add(1)
go func() {
    defer hbWG.Done()
    visitMarkerManager.HeartBeat(ctx, errChan, c.cleanerVisitMarkerFileUpdateInterval, true)
}()
defer func() {
    errChan <- nil
    hbWG.Wait()
}()
```

The same change is applied symmetrically in both call sites. `sync` is already imported in this file so no import diff is required. A CHANGELOG entry is added under master / unreleased referencing this PR.

## Why not other approaches

- **Skip the test on arm64.** Hides a real goroutine-leak / late-write window in production code; the bucket writes still happen post-callback regardless of platform.
- **Refactor `HeartBeat` to await internally.** `HeartBeat` is shared with other call sites (`partition_compaction_planner.go`, `shuffle_sharding_planner.go`) that intentionally do not wait; changing its lifetime contract risks breakage well beyond #7564. The leak is owned by the caller; fix it at the caller.
- **Use a `done` channel instead of `sync.WaitGroup`.** Functionally equivalent (this is what PR #7386 proposed). `WaitGroup` reads naturally as "wait for this goroutine to exit"; either pattern works.
- **Use `errgroup`.** Overkill for a single goroutine with no error to propagate (the existing `errChan` already carries the only signal that matters). Would expand the diff without changing the correctness story.

## Which issue(s) this PR fixes

Fixes #7564

Note: PR #7386 by another contributor proposed a similar `doneChan` fix that was marked CHANGES_REQUESTED by @friedrichg for missing the CHANGELOG entry. This PR is functionally equivalent (`sync.WaitGroup` vs `doneChan`) and includes the missing CHANGELOG.

## Checklist

- [x] `CHANGELOG.md` updated under master / unreleased
- [x] Documentation updated — N/A
- [x] Tests: existing `TestBlocksCleaner` is the regression test; runs 30/30 PASS in this worktree on amd64 (the arm64 race window is narrower so amd64 reproduction is unreliable, but the goroutine-leak window is closed regardless of platform)

## Test plan

- [x] `gofmt -l pkg/compactor/blocks_cleaner.go` — clean
- [x] `goimports -local github.com/cortexproject/cortex -l pkg/compactor/blocks_cleaner.go` — clean
- [x] `go vet -tags "netgo slicelabels" ./pkg/compactor/...` — clean
- [x] `go build -tags "netgo slicelabels" ./pkg/compactor/...` — clean
- [x] `go test -tags "netgo slicelabels" -timeout 600s -count=30 -run "^TestBlocksCleaner$/concurrency=2,_markers_migration_enabled=false,_tenant_deletion_delay=0s" ./pkg/compactor/...` — 30/30 PASS
- [x] `go test -race -tags "netgo slicelabels" -timeout 600s -run "^TestBlocksCleaner$" ./pkg/compactor/...` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)