### PR TITLE
fix(compactor): fix flaky TestCompactor_DeleteLocalSyncFiles on arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [BUGFIX] Compactor: Fix stale `cortex_bucket_index_last_successful_update_timestamp_seconds` metric not being cleaned up when tenant ownership changes due to ring rebalancing. This caused false alarms on bucket index update rate when a tenant moved between compactors. #7485
 * [BUGFIX] Security: Fix stored XSS vulnerability in Alertmanager and Store Gateway status pages by replacing `text/template` with `html/template`. #7512
 * [BUGFIX] Security: Limit decompressed gzip output in `ParseProtoReader` and OTLP ingestion path. The decompressed body is now capped by `-distributor.otlp-max-recv-msg-size`. #7515
+* [BUGFIX] Compactor: Fix flake in `TestCompactor_DeleteLocalSyncFiles` and `TestPartitionCompactor_DeleteLocalSyncFiles` by polling on user ownership rather than just the `CompactionRunsCompleted` counter, which increments even when the second compactor sees zero owned users due to a transient ring-view skew at startup. #7565
 
 ## 1.21.0 2026-04-24
 

--- a/pkg/compactor/compactor_paritioning_test.go
+++ b/pkg/compactor/compactor_paritioning_test.go
@@ -1635,7 +1635,6 @@ func TestPartitionCompactor_DeleteLocalSyncFiles(t *testing.T) {
 
 	// Let's check how many users second compactor has.
 	c2Users := len(c2.listTenantsWithMetaSyncDirectories())
-	require.NotZero(t, c2Users)
 
 	// Force new compaction cycle on first compactor. It will run the cleanup of un-owned users at the end of compaction cycle.
 	c1.compactUsers(context.Background())

--- a/pkg/compactor/compactor_paritioning_test.go
+++ b/pkg/compactor/compactor_paritioning_test.go
@@ -1622,12 +1622,14 @@ func TestPartitionCompactor_DeleteLocalSyncFiles(t *testing.T) {
 
 	// Now start second compactor, and wait until it runs compaction.
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c2))
-	// Wait until c2 has both completed a compaction cycle and observed itself owning
-	// at least one user. CompactionRunsCompleted increments even when no users were
-	// owned during the cycle (a transient ring-view skew at startup), so poll on the
-	// actual condition we depend on rather than the counter.
+	// Wait for at least two completed cycles so we sample after a steady-state
+	// ownership cycle, not mid-cycle following a zero-owned first cycle. The
+	// first cycle's CompactionRunsCompleted can increment with zero owned users
+	// due to transient ring-view skew at startup; sampling then would race with
+	// the second cycle's fetcher.NewBaseFetcher creating meta-sync directories
+	// and return a partial count.
 	cortex_testutil.Poll(t, 30*time.Second, true, func() any {
-		return prom_testutil.ToFloat64(c2.CompactionRunsCompleted) >= 1 &&
+		return prom_testutil.ToFloat64(c2.CompactionRunsCompleted) >= 2 &&
 			len(c2.listTenantsWithMetaSyncDirectories()) > 0
 	})
 

--- a/pkg/compactor/compactor_paritioning_test.go
+++ b/pkg/compactor/compactor_paritioning_test.go
@@ -1622,8 +1622,13 @@ func TestPartitionCompactor_DeleteLocalSyncFiles(t *testing.T) {
 
 	// Now start second compactor, and wait until it runs compaction.
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c2))
-	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
-		return prom_testutil.ToFloat64(c2.CompactionRunsCompleted)
+	// Wait until c2 has both completed a compaction cycle and observed itself owning
+	// at least one user. CompactionRunsCompleted increments even when no users were
+	// owned during the cycle (a transient ring-view skew at startup), so poll on the
+	// actual condition we depend on rather than the counter.
+	cortex_testutil.Poll(t, 30*time.Second, true, func() any {
+		return prom_testutil.ToFloat64(c2.CompactionRunsCompleted) >= 1 &&
+			len(c2.listTenantsWithMetaSyncDirectories()) > 0
 	})
 
 	// Let's check how many users second compactor has.

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1859,7 +1859,6 @@ func TestCompactor_DeleteLocalSyncFiles(t *testing.T) {
 
 	// Let's check how many users second compactor has.
 	c2Users := len(c2.listTenantsWithMetaSyncDirectories())
-	require.NotZero(t, c2Users)
 
 	// Force new compaction cycle on first compactor. It will run the cleanup of un-owned users at the end of compaction cycle.
 	c1.compactUsers(context.Background())

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1846,8 +1846,13 @@ func TestCompactor_DeleteLocalSyncFiles(t *testing.T) {
 
 	// Now start second compactor, and wait until it runs compaction.
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c2))
-	cortex_testutil.Poll(t, 10*time.Second, 1.0, func() any {
-		return prom_testutil.ToFloat64(c2.CompactionRunsCompleted)
+	// Wait until c2 has both completed a compaction cycle and observed itself owning
+	// at least one user. CompactionRunsCompleted increments even when no users were
+	// owned during the cycle (a transient ring-view skew at startup), so poll on the
+	// actual condition we depend on rather than the counter.
+	cortex_testutil.Poll(t, 30*time.Second, true, func() any {
+		return prom_testutil.ToFloat64(c2.CompactionRunsCompleted) >= 1 &&
+			len(c2.listTenantsWithMetaSyncDirectories()) > 0
 	})
 
 	// Let's check how many users second compactor has.

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1846,12 +1846,14 @@ func TestCompactor_DeleteLocalSyncFiles(t *testing.T) {
 
 	// Now start second compactor, and wait until it runs compaction.
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c2))
-	// Wait until c2 has both completed a compaction cycle and observed itself owning
-	// at least one user. CompactionRunsCompleted increments even when no users were
-	// owned during the cycle (a transient ring-view skew at startup), so poll on the
-	// actual condition we depend on rather than the counter.
+	// Wait for at least two completed cycles so we sample after a steady-state
+	// ownership cycle, not mid-cycle following a zero-owned first cycle. The
+	// first cycle's CompactionRunsCompleted can increment with zero owned users
+	// due to transient ring-view skew at startup; sampling then would race with
+	// the second cycle's fetcher.NewBaseFetcher creating meta-sync directories
+	// and return a partial count.
 	cortex_testutil.Poll(t, 30*time.Second, true, func() any {
-		return prom_testutil.ToFloat64(c2.CompactionRunsCompleted) >= 1 &&
+		return prom_testutil.ToFloat64(c2.CompactionRunsCompleted) >= 2 &&
 			len(c2.listTenantsWithMetaSyncDirectories()) > 0
 	})
 


### PR DESCRIPTION
## What this PR does

Fixes a flaky test in `pkg/compactor` by changing the Poll predicate in `TestCompactor_DeleteLocalSyncFiles` and its partition-compactor sibling `TestPartitionCompactor_DeleteLocalSyncFiles` so each one waits for steady-state ring ownership before sampling `c2.listTenantsWithMetaSyncDirectories()`.

Both tests previously polled `prom_testutil.ToFloat64(c2.CompactionRunsCompleted) == 1.0` and then immediately asserted `require.NotZero(t, c2Users)`. The new predicate is:

```go
prom_testutil.ToFloat64(c2.CompactionRunsCompleted) >= 2 &&
    len(c2.listTenantsWithMetaSyncDirectories()) > 0
```

with the Poll timeout raised to 30s. No production code is touched.

## Failure signature

```
--- FAIL: TestCompactor_DeleteLocalSyncFiles (2.86s)
    compactor_test.go:1855:
        Error Trace: /__w/cortex/cortex/pkg/compactor/compactor_test.go:1855
        Error:      Should not be zero, but was 0
        Test:       TestCompactor_DeleteLocalSyncFiles
```

Same `Should not be zero, but was 0` line surfaces in `TestPartitionCompactor_DeleteLocalSyncFiles` at `compactor_paritioning_test.go:1631`. Observed on `test-no-race (arm64)` in [run 26555111751](https://github.com/cortexproject/cortex/actions/runs/26555111751/job/78225222195) (PR #7563, which only modifies `MAINTAINERS.md` — confirming a pre-existing flake) and run 26491543042. Maintainers searching for that exact assertion message should land here.

## Why

`CompactionRunsCompleted` is incremented at the end of `compactUsers()` in `pkg/compactor/compactor.go:826-840` whenever the cycle returned no error — including the case where c2's ring view was momentarily skewed and `ownedUsers` was empty (non-owned tenants `continue` at `compactor.go:868-927`, which is not an error). On a slow arm64 runner the sequence:

1. c2 lifecycler writes `ACTIVE` + tokens to the shared consul KV (`ring/lifecycler.go:957-999`)
2. c2's `Ring` object refreshes its in-memory `ringInstanceByToken` map (`ring/ring.go:288-318`)

can land between c2's first `WaitRingStability` poll (1s cadence, `MaxDuration=5s` per the test fixture) and the first `compactUsers` invocation, so c1 owns all 10 tenants for that first cycle. The counter still ticks to 1.0, the Poll releases, and the assertion fires on an empty meta-sync directory.

## How `>= 2` resolves it

Requiring two completed cycles closes the mid-cycle sampling window. After the first cycle finishes, c2's ring view is fully merged; the second cycle then runs against steady-state ownership, and `listTenantsWithMetaSyncDirectories()` returns the population the test cares about (the dirs c1 created that c2 has since taken over). Conjoining `len(...) > 0` makes the Poll fail loudly with a 30s timeout instead of silently sampling between `fetcher.NewBaseFetcher` calls during cycle 2's setup — which is the failure shape a `>= 1` predicate would still leave open.

The 30s timeout is well inside test budgets (the original 10s/20s were already comfortable on amd64; arm64's slower CI is the proximate trigger) and gives the second cycle headroom on a contended runner.

## Why not other approaches

- **Tune `WaitStabilityMinDuration` / `MaxDuration` (currently 1s/5s).** Targeted at startup, but `WaitRingStability` still proceeds after `MaxDuration` regardless of whether `WatchKey` updates have settled (`pkg/ring/util.go:62-107`). Cranking it higher only narrows the race probabilistically; it doesn't close it.
- **Bump `numUsers` from 10 to 50 (Hypothesis B mitigation).** Independent fix for the rare stochastic case where all 10 fixed user IDs hash to c1 (calculated probability ≈ 0.2% per run). The flake we observe is Hypothesis A (startup ring race), which `numUsers=50` does not address. Kept as a follow-up if Hypothesis B ever surfaces.
- **Replace `cortex_testutil.Poll` with `require.Eventually`.** Out of step with the rest of `pkg/compactor/` (e.g. `compactor_test.go:973, 1164`), which uses `Poll` consistently. Switching would be a separate cleanup.
- **Skip the test on arm64.** Hides the real test gap (sampling a counter that fires before the postcondition holds). Same gap exists on amd64; arm64 just hits it more.

## Scope

Test-only. Two files changed, both under `pkg/compactor/`. No flags, no config, no production-code behaviour change.

## Follow-up

If Hypothesis B (random 512-token draw happens to map all 10 fixed tenants to c1) ever surfaces — i.e., the new Poll times out at 30s with `len(...) == 0` even after two cycles — the next step is to bump `numUsers` in the fixtures from 10 to 50. With 50 tenants × 2 instances × 512 tokens the probability of c2 owning zero tenants drops below noise. Deferred from this PR because the observed failures are all consistent with Hypothesis A and the smaller diff is the right shape to ship first; the bump is a one-line change if it becomes necessary.

## Which issue(s) this PR fixes

Fixes #7565

## Checklist

- [x] `CHANGELOG.md` updated — `[BUGFIX] Compactor` entry referencing both tests and this PR.
- [x] Documentation updated — N/A; no flags or config changed.
- [x] Tests: no new test added. The change *is* the test fix.

## Test plan

- [x] `gofmt -l pkg/compactor/compactor_test.go pkg/compactor/compactor_paritioning_test.go` — clean
- [x] `goimports -local github.com/cortexproject/cortex -l pkg/compactor/compactor_test.go pkg/compactor/compactor_paritioning_test.go` — clean
- [x] `go vet -tags "netgo slicelabels" ./pkg/compactor/...` — clean
- [x] `go build -tags "netgo slicelabels" ./pkg/compactor/...` — clean
- [x] `go test -tags "netgo slicelabels" -timeout 1200s -count=30 -run "^TestCompactor_DeleteLocalSyncFiles$" ./pkg/compactor/...` — 30/30 PASS
- [x] `go test -tags "netgo slicelabels" -timeout 1200s -count=30 -run "^TestPartitionCompactor_DeleteLocalSyncFiles$" ./pkg/compactor/...` — 30/30 PASS
- [x] `go test -race -tags "netgo slicelabels" -timeout 1200s -run "^TestCompactor_DeleteLocalSyncFiles$|^TestPartitionCompactor_DeleteLocalSyncFiles$" ./pkg/compactor/...` — PASS
- [x] arm64 CI green on `test-no-race` — verified on the PR's CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)