### PR TITLE
fix(ruler): stop per-tenant notifier when rule manager creation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * [BUGFIX] Querier: Fix flake in integration tests TestQuerierWithStoreGatewayDataBytesLimits and TestQuerierWithBlocksStorageLimits by waiting for the querier to see the store-gateway ACTIVE in the ring before querying. #7614
 * [BUGFIX] Ruler: Register xfunctions (xincrease, xrate, xdelta) in the global parser before loading rule files. #7621
 * [BUGFIX] Security: Reject empty entries in `-distributor.sign-write-requests-keys` caused by stray or trailing commas (e.g. `newkey,`). Previously these were silently accepted and produced an empty signing key, which downgraded HMAC stream-push authentication to a forgeable signature. Misconfigured flags now fail at process startup; audit your configs before upgrading. #7587
+* [BUGFIX] Ruler: Stop the per-tenant notifier (and its Alertmanager service-discovery goroutines) and remove the per-user metrics registry when rule manager creation fails, instead of leaking them until process shutdown. #7597
 
 ## 1.21.0 2026-04-24
 

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -397,7 +397,10 @@ func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string, userManag
 
 	n.run()
 
-	// This should never fail, unless there's a programming mistake.
+	// r.notifierCfg is built once at startup (buildNotifierConfig) and applied
+	// unchanged to every tenant's notifier, so applyConfig does not depend on
+	// per-tenant or user input and is not expected to fail here. Handle the
+	// error defensively anyway:
 	if err := n.applyConfig(r.notifierCfg); err != nil {
 		// n.run() already started the notifier's discovery and notification
 		// goroutines, but n has not been added to r.notifiers yet, so neither

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -300,12 +300,37 @@ func (r *DefaultMultiTenantManager) newManager(ctx context.Context, userID strin
 	reg := prometheus.NewRegistry()
 	r.userManagerMetrics.AddUserRegistry(userID, reg)
 
+	// getOrCreateNotifier starts the per-user notifier (and its discovery and
+	// notification goroutines) and registers it in r.notifiers before the rule
+	// manager is created. If anything below fails, this user is never added to
+	// r.userManagers, so the removal loop in SyncRuleGroups would never stop the
+	// notifier, leaking it and its goroutines until the process exits (issue
+	// #7595). Tear the partially-initialized state down on any early return; the
+	// cleanup is disarmed once a manager is successfully returned. removeNotifier
+	// takes r.notifiersMtx while this method runs under r.userManagerMtx; those two
+	// locks are always acquired in that order (userManagerMtx, then notifiersMtx)
+	// and never the reverse, so this cannot deadlock. removeNotifier is a no-op
+	// when no notifier was registered.
+	success := false
+	defer func() {
+		if !success {
+			r.removeNotifier(userID)
+			r.userManagerMetrics.RemoveUserRegistry(userID)
+		}
+	}()
+
 	notifier, err := r.getOrCreateNotifier(userID, reg)
 	if err != nil {
 		return nil, err
 	}
 
-	return r.managerFactory(ctx, userID, notifier, r.logger, r.frontendPool, reg)
+	manager, err := r.managerFactory(ctx, userID, notifier, r.logger, r.frontendPool, reg)
+	if err != nil {
+		return nil, err
+	}
+
+	success = true
+	return manager, nil
 }
 
 func (r *DefaultMultiTenantManager) removeNotifier(userID string) {
@@ -374,6 +399,12 @@ func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string, userManag
 
 	// This should never fail, unless there's a programming mistake.
 	if err := n.applyConfig(r.notifierCfg); err != nil {
+		// n.run() already started the notifier's discovery and notification
+		// goroutines, but n has not been added to r.notifiers yet, so neither
+		// removeNotifier nor Stop would ever stop it. Stop it directly to avoid
+		// leaking those goroutines. We must not call removeNotifier here because
+		// we already hold r.notifiersMtx, which it would try to re-acquire.
+		n.stop()
 		return nil, err
 	}
 

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -1,13 +1,18 @@
 package ruler
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"runtime/pprof"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
+	config_util "github.com/prometheus/common/config"
+	promConfig "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/notifier"
@@ -302,6 +307,198 @@ func TestBackupRules(t *testing.T) {
 	m.BackUpRuleGroups(context.TODO(), userRules)
 	require.Equal(t, userRules[user1], m.GetBackupRules(user1))
 	require.Equal(t, userRules[user2], m.GetBackupRules(user2))
+}
+
+// TestSyncRuleGroupsCleansUpNotifierOnManagerFactoryError is a regression test for
+// https://github.com/cortexproject/cortex/issues/7595. When the manager factory
+// returns an error, newManager has already created and started the per-user
+// notifier (via getOrCreateNotifier -> n.run()) and registered it in r.notifiers.
+// Because the user is never added to r.userManagers, the removal loop in
+// SyncRuleGroups never stops that notifier, so it and its discovery/notification
+// goroutines used to leak until the process exited.
+func TestSyncRuleGroupsCleansUpNotifierOnManagerFactoryError(t *testing.T) {
+	dir := t.TempDir()
+	const user = "testUser"
+
+	factoryErr := errors.New("manager factory failed")
+	failingFactory := func(_ context.Context, _ string, _ *notifier.Manager, _ log.Logger, _ *client.Pool, _ prometheus.Registerer) (RulesManager, error) {
+		return nil, factoryErr
+	}
+
+	// Use a dedicated registry (not nil): a nil registry registers the notifier
+	// service-discovery metrics on the global default registerer, which can
+	// os.Exit(1) on duplicate registration when running alongside other tests.
+	m, err := NewDefaultMultiTenantManager(Config{RulePath: dir}, &ruleLimits{}, failingFactory, nil, prometheus.NewRegistry(), log.NewNopLogger())
+	require.NoError(t, err)
+	t.Cleanup(m.Stop)
+
+	// Baseline notifier-run goroutines before the (failing) sync. Assert a delta
+	// back to this baseline rather than an absolute zero so the check is robust to
+	// any unrelated notifier goroutines from other tests sharing this process.
+	before := countNotifierRunGoroutines()
+
+	userRules := map[string]rulespb.RuleGroupList{
+		user: {
+			&rulespb.RuleGroupDesc{
+				Name:      "group1",
+				Namespace: "ns",
+				Interval:  1 * time.Minute,
+				User:      user,
+			},
+		},
+	}
+	m.SyncRuleGroups(context.Background(), userRules)
+
+	// The factory failed, so the user must not be tracked as a live manager.
+	require.Nil(t, getManager(m, user))
+
+	// The notifier must have been stopped and removed from the map.
+	m.notifiersMtx.Lock()
+	_, notifierExists := m.notifiers[user]
+	m.notifiersMtx.Unlock()
+	require.False(t, notifierExists, "notifier must be removed after a managerFactory error")
+
+	// The per-user metrics registry must have been removed too.
+	require.False(t, hasUserManagerRegistry(t, m, user), "per-user metrics registry must be removed after a managerFactory error")
+
+	// Its goroutines (started by rulerNotifier.run) must not leak. removeNotifier
+	// -> stop() -> wg.Wait() is synchronous, so they are gone by now; poll back to
+	// the baseline to absorb any scheduling latency.
+	test.Poll(t, 5*time.Second, before, func() interface{} {
+		return countNotifierRunGoroutines()
+	})
+}
+
+// TestGetOrCreateNotifierStopsNotifierOnApplyConfigError is a regression test for
+// the secondary leak path in https://github.com/cortexproject/cortex/issues/7595:
+// getOrCreateNotifier starts the notifier with n.run() before calling
+// n.applyConfig. If applyConfig fails, the notifier was never inserted into
+// r.notifiers, so it must be stopped directly to avoid leaking its goroutines.
+func TestGetOrCreateNotifierStopsNotifierOnApplyConfigError(t *testing.T) {
+	const user = "testUser"
+	m, err := NewDefaultMultiTenantManager(Config{RulePath: t.TempDir()}, &ruleLimits{}, RuleManagerFactory(nil, nil), nil, prometheus.NewRegistry(), log.NewNopLogger())
+	require.NoError(t, err)
+	t.Cleanup(m.Stop)
+
+	// Force applyConfig to fail by pointing the Alertmanager TLS config at a CA
+	// file that does not exist.
+	m.notifierCfg = &promConfig.Config{
+		AlertingConfig: promConfig.AlertingConfig{
+			AlertmanagerConfigs: promConfig.AlertmanagerConfigs{
+				{
+					HTTPClientConfig: config_util.HTTPClientConfig{
+						TLSConfig: config_util.TLSConfig{CAFile: "/does/not/exist"},
+					},
+					APIVersion: promConfig.AlertmanagerAPIVersionV2,
+				},
+			},
+		},
+	}
+
+	before := countNotifierRunGoroutines()
+	_, err = m.getOrCreateNotifier(user, prometheus.NewRegistry())
+	require.Error(t, err)
+
+	m.notifiersMtx.Lock()
+	_, ok := m.notifiers[user]
+	m.notifiersMtx.Unlock()
+	require.False(t, ok, "notifier must not be registered when applyConfig fails")
+
+	test.Poll(t, 5*time.Second, before, func() interface{} {
+		return countNotifierRunGoroutines()
+	})
+}
+
+// TestSyncRuleGroupsRecoversAfterManagerFactoryError verifies that a user whose
+// first manager creation failed — and whose notifier was therefore cleaned up by
+// the fix for https://github.com/cortexproject/cortex/issues/7595 — is created
+// normally on a later sync once the factory succeeds, i.e. the failure cleanup
+// does not leave the user in an unrecoverable state.
+func TestSyncRuleGroupsRecoversAfterManagerFactoryError(t *testing.T) {
+	dir := t.TempDir()
+	const user = "testUser"
+
+	fail := atomic.NewBool(true)
+	base := RuleManagerFactory([][]*promRules.Group{{}, {}}, []time.Duration{time.Millisecond, time.Millisecond})
+	factory := func(ctx context.Context, userID string, n *notifier.Manager, logger log.Logger, p *client.Pool, reg prometheus.Registerer) (RulesManager, error) {
+		if fail.Load() {
+			return nil, errors.New("manager factory failed")
+		}
+		return base(ctx, userID, n, logger, p, reg)
+	}
+
+	m, err := NewDefaultMultiTenantManager(Config{RulePath: dir}, &ruleLimits{}, factory, nil, prometheus.NewRegistry(), log.NewNopLogger())
+	require.NoError(t, err)
+	t.Cleanup(m.Stop)
+
+	before := countNotifierRunGoroutines()
+
+	userRules := map[string]rulespb.RuleGroupList{
+		user: {
+			&rulespb.RuleGroupDesc{Name: "group1", Namespace: "ns", Interval: 1 * time.Minute, User: user},
+		},
+	}
+
+	// First sync fails: no manager is tracked and the notifier must be cleaned up.
+	m.SyncRuleGroups(context.Background(), userRules)
+	require.Nil(t, getManager(m, user))
+	m.notifiersMtx.Lock()
+	_, notifierExists := m.notifiers[user]
+	m.notifiersMtx.Unlock()
+	require.False(t, notifierExists)
+	test.Poll(t, 5*time.Second, before, func() interface{} {
+		return countNotifierRunGoroutines()
+	})
+
+	// Once the factory succeeds, the user is created normally and gets a notifier.
+	fail.Store(false)
+	m.SyncRuleGroups(context.Background(), userRules)
+	require.NotNil(t, getManager(m, user))
+	m.notifiersMtx.Lock()
+	_, notifierExists = m.notifiers[user]
+	m.notifiersMtx.Unlock()
+	require.True(t, notifierExists, "notifier should be created when the user recovers")
+}
+
+// countNotifierRunGoroutines returns the number of goroutines currently running
+// inside rulerNotifier.run (its discovery and notification loops). It is used to
+// assert that a notifier's goroutines have been stopped rather than leaked.
+func countNotifierRunGoroutines() int {
+	var buf bytes.Buffer
+	_ = pprof.Lookup("goroutine").WriteTo(&buf, 2)
+	count := 0
+	for _, stack := range bytes.Split(buf.Bytes(), []byte("\n\n")) {
+		// Matches both the run.funcN frames and the "created by ...run" line; each
+		// stack block is counted at most once, so the count stays accurate even if
+		// the closure frame is ever inlined away.
+		if bytes.Contains(stack, []byte("github.com/cortexproject/cortex/pkg/ruler.(*rulerNotifier).run")) {
+			count++
+		}
+	}
+	return count
+}
+
+// hasUserManagerRegistry reports whether a per-user metrics registry for the
+// given user is still registered with the manager's metrics aggregator. The
+// notifier registers prometheus_notifications_* metrics into that per-user
+// registry, so its presence is observable via the aggregated, user-labelled
+// output.
+func hasUserManagerRegistry(t *testing.T, m *DefaultMultiTenantManager, user string) bool {
+	t.Helper()
+	tmp := prometheus.NewRegistry()
+	tmp.MustRegister(m.userManagerMetrics)
+	mfs, err := tmp.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		for _, metric := range mf.GetMetric() {
+			for _, lp := range metric.GetLabel() {
+				if lp.GetName() == "user" && lp.GetValue() == user {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func getManager(m *DefaultMultiTenantManager, user string) RulesManager {

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -364,7 +364,7 @@ func TestSyncRuleGroupsCleansUpNotifierOnManagerFactoryError(t *testing.T) {
 	// Its goroutines (started by rulerNotifier.run) must not leak. removeNotifier
 	// -> stop() -> wg.Wait() is synchronous, so they are gone by now; poll back to
 	// the baseline to absorb any scheduling latency.
-	test.Poll(t, 5*time.Second, before, func() interface{} {
+	test.Poll(t, 5*time.Second, before, func() any {
 		return countNotifierRunGoroutines()
 	})
 }
@@ -404,7 +404,7 @@ func TestGetOrCreateNotifierStopsNotifierOnApplyConfigError(t *testing.T) {
 	m.notifiersMtx.Unlock()
 	require.False(t, ok, "notifier must not be registered when applyConfig fails")
 
-	test.Poll(t, 5*time.Second, before, func() interface{} {
+	test.Poll(t, 5*time.Second, before, func() any {
 		return countNotifierRunGoroutines()
 	})
 }
@@ -446,7 +446,7 @@ func TestSyncRuleGroupsRecoversAfterManagerFactoryError(t *testing.T) {
 	_, notifierExists := m.notifiers[user]
 	m.notifiersMtx.Unlock()
 	require.False(t, notifierExists)
-	test.Poll(t, 5*time.Second, before, func() interface{} {
+	test.Poll(t, 5*time.Second, before, func() any {
 		return countNotifierRunGoroutines()
 	})
 
@@ -467,7 +467,7 @@ func countNotifierRunGoroutines() int {
 	var buf bytes.Buffer
 	_ = pprof.Lookup("goroutine").WriteTo(&buf, 2)
 	count := 0
-	for _, stack := range bytes.Split(buf.Bytes(), []byte("\n\n")) {
+	for stack := range bytes.SplitSeq(buf.Bytes(), []byte("\n\n")) {
 		// Matches both the run.funcN frames and the "created by ...run" line; each
 		// stack block is counted at most once, so the count stays accurate even if
 		// the closure frame is ever inlined away.


### PR DESCRIPTION
## What this PR does

Fixes a per-tenant resource leak in the ruler's `DefaultMultiTenantManager` (issue #7595).

`newManager` (`pkg/ruler/manager.go`) starts a per-user notifier *before* the rule manager exists: `getOrCreateNotifier` calls `n.run()` — which spawns the Alertmanager **service-discovery** and **notification** goroutines — and registers the notifier in `r.notifiers`. It also adds a per-user metrics registry via `AddUserRegistry`. Only *after* that does it call `managerFactory`.

If `managerFactory` returns an error, `createRulesManager` logs and returns `nil`, so the user is **never added to `r.userManagers`**. The only place a notifier is stopped during normal operation is `removeNotifier`, called from the user-deletion loop in `SyncRuleGroups` — which iterates `r.userManagers`. Because the failed user isn't there, that cleanup never runs: the notifier, its two goroutines, and the per-user metrics registry **leak until the process exits**.

This PR tears the partially-initialized state down on any early return from `newManager`, and fixes the same class of leak on the `applyConfig` error path inside `getOrCreateNotifier`.

## Why this is reachable

`DefaultTenantManagerFactory` returns real errors in normal operation — e.g. `resolveFrontendClient` fails, or neither an internal PromQL engine nor a query-frontend client is configured (`pkg/ruler/compat.go`). A misconfigured or transiently-unresolvable ruler hits this on every sync for the affected tenant; under tenant churn the leaked notifiers, goroutines and registries accumulate and grow memory unbounded.

It was introduced by #6151, which changed `ManagerFactory` to return an error and made `newManager` propagate it — without adding cleanup for the notifier it had just started. (The earlier #4718 added `removeNotifier` only to the user-*removal* path.)

## How the fix resolves it

In `newManager`, a `success` flag + `defer` runs the cleanup (`removeNotifier(userID)` + `RemoveUserRegistry(userID)`) on **any** early return and is disarmed only once a manager is successfully returned, so future early-returns can't reintroduce the leak. This mirrors the existing cleanup in the `SyncRuleGroups` removal loop. It is deadlock-free: `newManager` runs under `userManagerMtx` and `removeNotifier` takes `notifiersMtx`; those two locks are always acquired in that order and never the reverse.

In `getOrCreateNotifier`, if `applyConfig` fails after `n.run()`, the notifier was started but not yet inserted into `r.notifiers`, so it is stopped directly with `n.stop()` (not `removeNotifier`, which would re-acquire the already-held `notifiersMtx`). There is no double-stop: a not-yet-inserted notifier is invisible to the `newManager` defer's `removeNotifier`.

## Tests

Three regression tests in `pkg/ruler/manager_test.go`, each verified to **fail without the fix** and pass with it (under `-race`, high `-count`):

- `TestSyncRuleGroupsCleansUpNotifierOnManagerFactoryError` — drives the real `SyncRuleGroups` → `createRulesManager` → `newManager` path with a failing factory; asserts the user is not managed, the notifier is removed from `r.notifiers`, the per-user registry is removed, and the notifier-run goroutines return to baseline.
- `TestGetOrCreateNotifierStopsNotifierOnApplyConfigError` — forces `applyConfig` to fail (bad Alertmanager TLS CA file) and asserts the notifier and its goroutines are stopped.
- `TestSyncRuleGroupsRecoversAfterManagerFactoryError` — a user whose first creation failed is created normally once the factory later succeeds (the cleanup doesn't leave it unrecoverable).

Goroutine leakage is asserted with a pprof-scoped helper that counts only `(*rulerNotifier).run` goroutines (robust against unrelated goroutines and closure inlining), using a baseline delta.

## Why not other approaches

- **Explicit cleanup on each error branch** (instead of the disarm-`defer`): equivalent today, but the `defer` also covers a panic in `managerFactory` and any future early-return added before the manager is returned.
- **Stopping the notifier from `SyncRuleGroups`**: the failed user never enters `r.userManagers`, so the existing removal loop can't see it; the cleanup has to live where the notifier was created.

## Scope

Production change is two small edits in `pkg/ruler/manager.go`; tests in `pkg/ruler/manager_test.go`; one `CHANGELOG.md` line. No flags, config, or behavior change beyond the added cleanup.

Two related items are intentionally **out of scope** (noted for follow-up):
- The pre-existing stale-notifier reuse branch in `getOrCreateNotifier` (which re-calls `run()`) becomes unreachable for the failure scenario after this fix; its now-misleading comment is left untouched to keep this PR tight.
- `syncRulesToManager` also allocates mapper rule files / external-label map entries / a `lastReloadSuccessful` series before manager creation; those likewise persist for a perpetually-failing user. That is a distinct (bounded, non-goroutine) leak and a separate change.

## Which issue(s) this PR fixes

Fixes #7595

## Checklist

- [x] `CHANGELOG.md` updated — `[BUGFIX] Ruler` entry.
- [x] Documentation updated — N/A; no flags or config changed (`make doc` not required).
- [x] Tests: three regression tests added, each fails without the fix.
- [x] Commit signed off (DCO).

## Test plan

- `gofmt -l` / `goimports -local github.com/cortexproject/cortex -l` — clean
- `go vet -tags "netgo slicelabels" ./pkg/ruler/` — clean
- `go test -tags "netgo slicelabels" -race -count=10 -run 'TestSyncRuleGroupsCleansUpNotifierOnManagerFactoryError|TestGetOrCreateNotifierStopsNotifierOnApplyConfigError|TestSyncRuleGroupsRecoversAfterManagerFactoryError' ./pkg/ruler/` — PASS
- `go test -tags "netgo slicelabels" -count=1 ./pkg/ruler/` — PASS (full package, ~35s)
- Reverting `manager.go` to `master` makes all three new tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
