### PR TITLE
fix(scheduler): stop FragmentTable cleanup goroutine on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [ENHANCEMENT] Distributor: Added `cortex_distributor_received_histogram_buckets` metric to track number of buckets in received native histogram samples before validation, per user. #7569
 * [ENHANCEMENT] Distributor: Add `WrappedHistogram` with configurable size limit (`-validation.max-native-histogram-size-bytes`) to cap native histogram protobuf size before unmarshalling. #7570
 * [ENHANCEMENT] Ingester: Add lazy regex evaluation on head postings cache miss. Defers expensive regex matchers on high-cardinality labels to per-series filtering when a selective equality matcher already narrows the result set. Configured via `-blocks-storage.expanded_postings_cache.head.lazy-matcher-max-cardinality` (disabled by default). #7553
+* [BUGFIX] Query Scheduler: Stop the fragment table's background cleanup goroutine (and its ticker) on shutdown; it previously had no stop mechanism and lived for the process lifetime. #7599
 * [BUGFIX] Querier: Fix queryWithRetry and labelsWithRetry returning (nil, nil) on cancelled context by propagating ctx.Err(). #7370
 * [BUGFIX] Metrics Helper: Fix non-deterministic bucket order in merged histograms by sorting buckets after map iteration, matching Prometheus client library behavior. #7380
 * [BUGFIX] Distributor: Return HTTP 401 Unauthorized when tenant ID resolution fails in the Prometheus Remote Write 2.0 path. #7389

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/tjhop/slog-gokit v0.1.4
 	go.opentelemetry.io/collector/pdata v1.45.0
 	go.uber.org/automaxprocs v1.6.0
+	go.uber.org/goleak v1.3.0
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -283,7 +284,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
-	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/pkg/scheduler/fragment_table/fragment_table.go
+++ b/pkg/scheduler/fragment_table/fragment_table.go
@@ -18,6 +18,8 @@ type FragmentTable struct {
 	mappings   map[distributed_execution.FragmentKey]*fragmentEntry
 	mu         sync.RWMutex
 	expiration time.Duration
+	done       chan struct{}
+	closeOnce  sync.Once
 }
 
 // NewFragmentTable creates a new FragmentTable with the specified expiration duration.
@@ -27,6 +29,7 @@ func NewFragmentTable(expiration time.Duration) *FragmentTable {
 	ft := &FragmentTable{
 		mappings:   make(map[distributed_execution.FragmentKey]*fragmentEntry),
 		expiration: expiration,
+		done:       make(chan struct{}),
 	}
 	go ft.periodicCleanup()
 	return ft
@@ -55,6 +58,14 @@ func (f *FragmentTable) GetAddrByID(queryID uint64, fragmentID uint64) (string, 
 	return "", false
 }
 
+// Close stops the background cleanup goroutine started by NewFragmentTable.
+// It is safe to call more than once.
+func (f *FragmentTable) Close() {
+	f.closeOnce.Do(func() {
+		close(f.done)
+	})
+}
+
 func (f *FragmentTable) cleanupExpired() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -73,7 +84,12 @@ func (f *FragmentTable) cleanupExpired() {
 func (f *FragmentTable) periodicCleanup() {
 	ticker := time.NewTicker(f.expiration / 2)
 	defer ticker.Stop()
-	for range ticker.C {
-		f.cleanupExpired()
+	for {
+		select {
+		case <-ticker.C:
+			f.cleanupExpired()
+		case <-f.done:
+			return
+		}
 	}
 }

--- a/pkg/scheduler/fragment_table/fragment_table_test.go
+++ b/pkg/scheduler/fragment_table/fragment_table_test.go
@@ -7,7 +7,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
+
+// TestMain runs the package tests under goleak so that any FragmentTable whose
+// cleanup goroutine is not stopped (via Close) fails the package.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestNewFragmentTable(t *testing.T) {
 	tests := []struct {
@@ -27,6 +34,7 @@ func TestNewFragmentTable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ft := NewFragmentTable(tt.expiration)
+			t.Cleanup(ft.Close)
 			require.NotNil(t, ft)
 			require.NotNil(t, ft.mappings)
 			assert.Equal(t, tt.expiration, ft.expiration)
@@ -36,6 +44,7 @@ func TestNewFragmentTable(t *testing.T) {
 
 func TestFragmentTable_AddAndGetAddress(t *testing.T) {
 	ft := NewFragmentTable(time.Hour)
+	t.Cleanup(ft.Close)
 
 	tests := []struct {
 		name      string
@@ -84,6 +93,7 @@ func TestFragmentTable_AddAndGetAddress(t *testing.T) {
 func TestFragmentTable_Expiration(t *testing.T) {
 	expiration := 100 * time.Millisecond
 	ft := NewFragmentTable(expiration)
+	t.Cleanup(ft.Close)
 
 	t.Run("entries expire after timeout", func(t *testing.T) {
 		ft.AddAddressByID(1, 1, "addr1")
@@ -106,6 +116,7 @@ func TestFragmentTable_Expiration(t *testing.T) {
 
 func TestFragmentTable_ConcurrentAccess(t *testing.T) {
 	ft := NewFragmentTable(time.Hour)
+	t.Cleanup(ft.Close)
 
 	const (
 		numGoroutines = 10
@@ -140,6 +151,7 @@ func TestFragmentTable_ConcurrentAccess(t *testing.T) {
 func TestFragmentTable_PeriodicCleanup(t *testing.T) {
 	expiration := 100 * time.Millisecond
 	ft := NewFragmentTable(expiration)
+	t.Cleanup(ft.Close)
 
 	ft.AddAddressByID(1, 1, "addr1")
 	ft.AddAddressByID(1, 2, "addr2")
@@ -162,4 +174,16 @@ func TestFragmentTable_PeriodicCleanup(t *testing.T) {
 
 	_, ok = ft.GetAddrByID(1, 2)
 	require.False(t, ok)
+}
+
+// TestFragmentTable_Close verifies that Close stops the background cleanup
+// goroutine — asserted package-wide by goleak in TestMain — and is safe to call
+// more than once.
+func TestFragmentTable_Close(t *testing.T) {
+	ft := NewFragmentTable(time.Hour)
+
+	ft.Close()
+
+	// Close is idempotent: a second call must not panic (e.g. double close).
+	require.NotPanics(t, ft.Close)
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -695,6 +695,8 @@ func (s *Scheduler) running(ctx context.Context) error {
 
 // Close the Scheduler.
 func (s *Scheduler) stopping(_ error) error {
+	// Stop the fragment table's background cleanup goroutine.
+	s.fragmentTable.Close()
 	// This will also stop the requests queue, which stop accepting new requests and errors out any tracked requests.
 	return services.StopManagerAndAwaitStopped(context.Background(), s.subservices)
 }


### PR DESCRIPTION
## What this PR does

Fixes a goroutine/ticker leak in the query-scheduler's `FragmentTable` (issue #7596).

`NewFragmentTable` (`pkg/scheduler/fragment_table/fragment_table.go`) starts a `periodicCleanup` goroutine driven by a `time.Ticker`, but it had no stop mechanism: the loop ranged over `ticker.C` forever, the deferred `ticker.Stop()` was unreachable, and `FragmentTable` had no `Close`/`Stop` method. The goroutine and ticker therefore lived for the whole process lifetime and were orphaned on scheduler shutdown.

This adds an idempotent `Close()` (a `done` channel closed once via `sync.Once`); `periodicCleanup` now `select`s on the ticker and the `done` channel. The scheduler closes the fragment table in its `stopping` hook so the goroutine is reclaimed on shutdown.

## Why

`FragmentTable` is a per-scheduler singleton (`NewScheduler` → `fragment_table.NewFragmentTable(2 * time.Minute)`), constructed unconditionally, so in production it does not leak repeatedly — but the goroutine was orphaned rather than gracefully stopped on scheduler shutdown, and it was an un-stoppable background goroutine inconsistent with the scheduler's `services.Service` lifecycle. It is also a `go.uber.org/goleak` hazard: each `NewFragmentTable` in tests leaked a goroutine with no way to stop it.

## How the fix resolves it

- `Close()` closes the `done` channel exactly once via `sync.Once`, so it is safe to call repeatedly and concurrently.
- `periodicCleanup` returns on `<-f.done`, so the deferred `ticker.Stop()` now runs and both the goroutine and the ticker are released.
- `Scheduler.stopping` calls `s.fragmentTable.Close()` before stopping the subservices manager. Closing is a non-blocking channel close, independent of subservice teardown, so the ordering is harmless and there is no deadlock. `Close()` only touches `done`/`closeOnce`, never the `mu`/`mappings` state, so it cannot race with `GetAddrByID`/`AddAddressByID`/`cleanupExpired`.

## Why not the services.Service approach

We considered making `FragmentTable` a `services.Service` (`services.NewTimerService`) registered in the scheduler's `services.Manager`. We rejected it for this fix after empirically testing both: in the one scenario where it would "help" — tests that construct a `Scheduler` via `NewScheduler` but never start it — it is a *lateral move*: it removes the `periodicCleanup` goroutine but adds a `services.Manager` listener goroutine, so those tests still leak. Meanwhile it changes behavior (cleanup runs only once the service is Started) and requires start/stop wiring across the existing fragment-table tests. The minimal `done`/`sync.Once`/`Close()` idiom preserves semantics, stays tightly scoped, and fixes the production leak identically — mirroring #7578's tight-scope-for-a-bugfix approach.

## Tests

- A package-level `goleak.VerifyTestMain` guard, plus `t.Cleanup(ft.Close)` on every existing test that constructs a table, so no `FragmentTable` leaks in the package's tests.
- `TestFragmentTable_Close`: asserts `Close` stops the cleanup goroutine (enforced by the goleak guard) and is idempotent (a second call does not panic).
- `fail-without-fix` verified: reverting only `periodicCleanup` to `for range ticker.C { ... }` (keeping `Close`/`done` so it compiles) makes the goleak guard fail, reporting the leaked `periodicCleanup` goroutine created by `NewFragmentTable`.

## Scope

Two small edits in `pkg/scheduler/fragment_table/fragment_table.go`, a one-line `Close()` call in `pkg/scheduler/scheduler.go`'s `stopping`, and `pkg/scheduler/fragment_table/fragment_table_test.go` test additions; plus one `CHANGELOG.md` line. No flags, config, or production behavior change beyond reclaiming the goroutine on shutdown.

Out of scope (pre-existing, noted for follow-up): three `TestQueryFragmentRegistry*` tests in `scheduler_test.go` construct a `Scheduler` via `NewScheduler` but never start/stop it, so they leak background goroutines in-test (the fragment-table cleanup goroutine **and** `services.Manager` listener goroutines). This is unchanged from `master` and not surfaced by CI (the `scheduler` package has no `goleak` guard); closing only the fragment table would not make those tests leak-clean — fixing them means starting/stopping the scheduler (or its manager) in those tests, a separate change.

## Which issue(s) this PR fixes

Fixes #7596

## Checklist

- [x] `CHANGELOG.md` updated — `[BUGFIX] Query Scheduler` entry.
- [x] Documentation updated — N/A; no flags or config changed (`make doc` not required).
- [x] Tests: goleak guard + regression/idempotency test; `fail-without-fix` verified.
- [x] Commit signed off (DCO).

## Test plan

- `gofmt -l` — clean; `go vet -tags "netgo slicelabels" ./pkg/scheduler/...` — clean
- `go test -tags "netgo slicelabels" -race -count=20 ./pkg/scheduler/fragment_table/...` — PASS (goleak guard runs each iteration)
- `go test -tags "netgo slicelabels" -race -count=1 ./pkg/scheduler/` — PASS (full package, exercises the scheduler start/stop → `Close()` path)
- Reverting `periodicCleanup` to the buggy `for range ticker.C` loop makes the goleak guard fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
