### PR TITLE
fix(ci): retry docker pulls in integration Preload Images step

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -258,24 +258,42 @@ jobs:
       - name: Preload Images
         # We download docker images used by integration tests so that all images are available
         # locally and the download time doesn't account in the test execution time, which is subject
-        # to a timeout
+        # to a timeout. Each pull is wrapped in a small retry helper so a transient Docker Hub /
+        # quay.io registry hiccup (e.g. "context deadline exceeded") doesn't fail the whole job.
         run: |
-          docker pull minio/minio:RELEASE.2024-05-28T17-19-04Z
-          docker pull consul:1.8.4
-          docker pull quay.io/coreos/etcd:v3.5.29
+          # Retry a command up to 3 times with exponential backoff (5s, then 10s). A transient
+          # docker pull failure is retried; a genuine, persistent failure still fails the step
+          # because the final `return 1` propagates under `bash -e`.
+          retry() {
+            local max_attempts=3 attempt=1 delay=5
+            until "$@"; do
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                echo "ERROR: '$*' failed after ${max_attempts} attempts." >&2
+                return 1
+              fi
+              echo "WARNING: '$*' failed (attempt ${attempt}/${max_attempts}); retrying in ${delay}s..." >&2
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          retry docker pull minio/minio:RELEASE.2024-05-28T17-19-04Z
+          retry docker pull consul:1.8.4
+          retry docker pull quay.io/coreos/etcd:v3.5.29
           if [ "$TEST_TAGS" = "integration_backward_compatibility" ]; then
-            docker pull quay.io/cortexproject/cortex:v1.16.1
-            docker pull quay.io/cortexproject/cortex:v1.17.2
-            docker pull quay.io/cortexproject/cortex:v1.18.1
-            docker pull quay.io/cortexproject/cortex:v1.19.1
-            docker pull quay.io/cortexproject/cortex:v1.20.1
-            docker pull quay.io/cortexproject/cortex:v1.21.0
+            retry docker pull quay.io/cortexproject/cortex:v1.16.1
+            retry docker pull quay.io/cortexproject/cortex:v1.17.2
+            retry docker pull quay.io/cortexproject/cortex:v1.18.1
+            retry docker pull quay.io/cortexproject/cortex:v1.19.1
+            retry docker pull quay.io/cortexproject/cortex:v1.20.1
+            retry docker pull quay.io/cortexproject/cortex:v1.21.0
           elif [ "$TEST_TAGS" = "integration_query_fuzz" ]; then
-            docker pull quay.io/cortexproject/cortex:v1.20.1
-            docker pull quay.io/prometheus/prometheus:v3.8.1
+            retry docker pull quay.io/cortexproject/cortex:v1.20.1
+            retry docker pull quay.io/prometheus/prometheus:v3.8.1
           fi
-          docker pull memcached:1.6.1
-          docker pull redis:7.0.4-alpine
+          retry docker pull memcached:1.6.1
+          retry docker pull redis:7.0.4-alpine
         env:
           TEST_TAGS: ${{ matrix.tags }}
       - name: Integration Tests


### PR DESCRIPTION
_Drafted with AI assistance (Claude Code, via a panel of 6 agents) and reviewed/validated before submission, per the [Generative AI Contribution Policy](https://github.com/cortexproject/cortex/blob/master/GENAI_POLICY.md)._

## What this PR does

Wraps every `docker pull` in the `integration` job's **`Preload Images`** step (`.github/workflows/test-build-deploy.yml`) in a small inline `retry()` helper (3 attempts, 5s → 10s exponential backoff). The image set, the `TEST_TAGS` conditional branches, and the step's purpose are unchanged — only each pull's resilience to transient registry errors.

## Why this is reachable

The step ran a bare sequence of `docker pull` commands with **no retry**. Public registries occasionally return transient errors; a single one fails the whole step (`exit code 1`) and the integration job, even though the code under test is fine:

```
Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
##[error]Process completed with exit code 1.
```

Observed on a recent run: job `integration (ubuntu-24.04, amd64, integration_overrides)` failed on the very first pull (`minio/minio`), unrelated to the change under test. See #7598.

`docker login` is **not** a viable mitigation for this job: the `integration` matrix runs on pull requests **including forks**, which do not have access to repository secrets (`secrets.DOCKER_REGISTRY_USER/PASSWORD` are only used by the `deploy` job). The robust, fork-PR-safe fix is client-side retry.

## How the fix resolves it

A `retry()` shell function is defined once at the top of the `run:` block and each `docker pull` becomes `retry docker pull …`:

```bash
retry() {
  local max_attempts=3 attempt=1 delay=5
  until "$@"; do
    if [ "$attempt" -ge "$max_attempts" ]; then
      echo "ERROR: '$*' failed after ${max_attempts} attempts." >&2
      return 1
    fi
    echo "WARNING: '$*' failed (attempt ${attempt}/${max_attempts}); retrying in ${delay}s..." >&2
    sleep "$delay"
    attempt=$((attempt + 1))
    delay=$((delay * 2))
  done
}
```

Correctness under `bash -e` (GitHub Actions' default for `run:`):
- The failing `docker pull` runs as the **condition** of `until`, so an intermediate failure does **not** trip `errexit` — it just drives another retry.
- When all attempts are exhausted, `return 1` runs at a plain (non-conditional) call site, so `errexit` **does** abort the step. Genuine, persistent failures (bad tag, deleted image, real outage) still fail loudly, with a clear message naming the command and attempt count.

All pulls are wrapped (Docker Hub **and** quay.io); quay.io can blip too, and uniform retry keeps the step simple. Backoff is bounded: worst case is the `integration_backward_compatibility` branch (11 images) at ≤ 15s added sleep each ≈ 165s total — comfortably inside the job's `timeout-minutes: 50` (and the separate 45-min test step).

## Scope

In scope: retry logic for the `Preload Images` step only.

Out of scope (deliberately, to keep this focused):
- The `Load Docker Images` step (`make load-images`) does `docker load` from local artifacts — no network, so it can't hit this failure mode and needs no retry.
- The per-job `container:` image pull (`quay.io/cortexproject/build-image:…`) is performed by the runner before any `run:` step and can't be wrapped here; that's a separate, runner-level concern.
- No `docker login` / authenticated-pull changes.

## Which issue(s) this PR fixes

Fixes #7598

## Checklist

- [x] `CHANGELOG.md` — **no entry needed**: this is a CI-only change with no user-facing behavior; Cortex's CHANGELOG tracks operator/user-visible changes.
- [x] Documentation (`make doc`) — N/A; no flags or config changed.
- [x] Commit signed off (DCO).

## Test plan

A workflow flake can't be deterministically reproduced, but the change was validated:
- **YAML** parses (Psych) — the `integration` job's `Preload Images` step has the expected 13 `retry docker pull` invocations (3 base + 6 backward-compat + 2 query-fuzz + 2 trailing).
- **`bash -n`** on the extracted `run:` script — clean.
- **Control flow** under `bash -e -o pipefail` (with `sleep` stubbed): a command that fails once then succeeds is retried and the script continues (intermediate failure does not abort); a command that always fails exhausts retries and aborts the step non-zero (real failures still fail).
- The exact image set and conditional branches are byte-for-byte preserved (only `docker pull` → `retry docker pull`).
