### PR TITLE
feat(distributor): add goroutine worker pool for query fan-out to ing…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master / unreleased
+* [FEATURE] Distributor: Add experimental `-distributor.num-query-workers` flag to use a goroutine worker pool for query fan-out calls to ingesters. Reuses pre-grown goroutine stacks to eliminate the `runtime.copystack` overhead (~8% CPU) observed on rulers with wide ingester fan-out. Falls back to spawning a new goroutine when no worker is available. #7623
 * [CHANGE] Querier: Make query time range configurations per-tenant: `query_ingesters_within`, `query_store_after`, and `shuffle_sharding_ingesters_lookback_period`. Uses `model.Duration` instead of `time.Duration` to support serialization but has minimum unit of 1ms (nanoseconds/microseconds not supported). #7160
 * [CHANGE] Cache: Setting `-blocks-storage.bucket-store.metadata-cache.bucket-index-content-ttl` to 0 will disable the bucket-index cache. #7446
 * [CHANGE] HA Tracker: Move `-distributor.ha-tracker.failover-timeout` from a global config to a per-tenant runtime config. The flag name and default value (30s) remain the same. #7481

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -3572,6 +3572,14 @@ ring:
 # CLI flag: -distributor.num-push-workers
 [num_push_workers: <int> | default = 0]
 
+# EXPERIMENTAL: Number of go routines to handle query fan-out calls from
+# distributors (queriers and rulers) to ingesters. When no workers are
+# available, a new goroutine will be spawned automatically. If set to 0
+# (default), workers are disabled, and a new goroutine will be created for each
+# query request.
+# CLI flag: -distributor.num-query-workers
+[num_query_workers: <int> | default = 0]
+
 instance_limits:
   # Max ingestion rate (samples/sec) that this distributor will accept. This
   # limit is per-distributor, not per-tenant. Additional push requests will be

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -138,6 +138,7 @@ type Distributor struct {
 	validateMetrics *validation.ValidateMetrics
 
 	asyncExecutor util.AsyncExecutor
+	queryWorkers  util.AsyncExecutor
 
 	// Map to track label sets from user.
 	labelSetTracker *labelset.LabelSetTracker
@@ -184,6 +185,11 @@ type Config struct {
 	// When no workers are available, a new goroutine will be spawned automatically.
 	NumPushWorkers int `yaml:"num_push_workers"`
 
+	// Number of go routines to handle query fan-out calls from distributors (queriers/rulers) to ingesters.
+	// If set to 0 (default), workers are disabled, and a new goroutine will be created for each instance call.
+	// When no workers are available, a new goroutine will be spawned automatically.
+	NumQueryWorkers int `yaml:"num_query_workers"`
+
 	// Limits for distributor
 	InstanceLimits InstanceLimits `yaml:"instance_limits"`
 
@@ -226,6 +232,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.ExtendWrites, "distributor.extend-writes", true, "Try writing to an additional ingester in the presence of an ingester not in the ACTIVE state. It is useful to disable this along with -ingester.unregister-on-shutdown=false in order to not spread samples to extra ingesters during rolling restarts with consistent naming.")
 	f.BoolVar(&cfg.ZoneResultsQuorumMetadata, "distributor.zone-results-quorum-metadata", false, "Experimental, this flag may change in the future. If zone awareness and this both enabled, when querying metadata APIs (labels names and values for now), only results from quorum number of zones will be included.")
 	f.IntVar(&cfg.NumPushWorkers, "distributor.num-push-workers", 0, "EXPERIMENTAL: Number of go routines to handle push calls from distributors to ingesters. When no workers are available, a new goroutine will be spawned automatically. If set to 0 (default), workers are disabled, and a new goroutine will be created for each push request.")
+	f.IntVar(&cfg.NumQueryWorkers, "distributor.num-query-workers", 0, "EXPERIMENTAL: Number of go routines to handle query fan-out calls from distributors (queriers and rulers) to ingesters. When no workers are available, a new goroutine will be spawned automatically. If set to 0 (default), workers are disabled, and a new goroutine will be created for each query request.")
 	f.BoolVar(&cfg.RemoteWriteV2Enabled, "distributor.remote-writev2-enabled", false, "EXPERIMENTAL: If true, accept prometheus remote write v2 protocol push request.")
 	f.BoolVar(&cfg.AcceptUnknownRemoteWriteContentType, "distributor.accept-unknown-remote-write-content-type", false, "If true, treat requests with unknown or invalid Content-Type header as remote write v1 (legacy behavior). If false, return 415 Unsupported Media Type for non-standard content types.")
 
@@ -435,6 +442,7 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 
 		validateMetrics: validation.NewValidateMetrics(reg),
 		asyncExecutor:   util.NewNoOpExecutor(),
+		queryWorkers:    util.NewNoOpExecutor(),
 	}
 
 	d.labelSetTracker = labelset.NewLabelSetTracker()
@@ -442,6 +450,11 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 	if cfg.NumPushWorkers > 0 {
 		util_log.WarnExperimentalUse("Distributor: using goroutine worker pool")
 		d.asyncExecutor = util.NewWorkerPool("distributor", cfg.NumPushWorkers, reg)
+	}
+
+	if cfg.NumQueryWorkers > 0 {
+		util_log.WarnExperimentalUse("Distributor: using goroutine worker pool for query fan-out")
+		d.queryWorkers = util.NewWorkerPool("distributor-query", cfg.NumQueryWorkers, reg)
 	}
 
 	promauto.With(reg).NewGauge(prometheus.GaugeOpts{
@@ -563,6 +576,7 @@ func (d *Distributor) cleanupInactiveUser(userID string) {
 // Called after distributor is asked to stop via StopAsync.
 func (d *Distributor) stopping(_ error) error {
 	d.asyncExecutor.Stop()
+	d.queryWorkers.Stop()
 	return services.StopManagerAndAwaitStopped(context.Background(), d.subservices)
 }
 
@@ -1340,7 +1354,7 @@ func getErrorStatus(err error) string {
 
 // ForReplicationSet runs f, in parallel, for all ingesters in the input replication set.
 func (d *Distributor) ForReplicationSet(ctx context.Context, replicationSet ring.ReplicationSet, zoneResultsQuorum bool, partialDataEnabled bool, f func(context.Context, ingester_client.IngesterClient) (any, error)) ([]any, error) {
-	return replicationSet.Do(ctx, d.cfg.ExtraQueryDelay, zoneResultsQuorum, partialDataEnabled, func(ctx context.Context, ing *ring.InstanceDesc) (any, error) {
+	return replicationSet.DoWithExecutor(ctx, d.cfg.ExtraQueryDelay, zoneResultsQuorum, partialDataEnabled, d.queryWorkers, func(ctx context.Context, ing *ring.InstanceDesc) (any, error) {
 		client, err := d.ingesterPool.GetClientFor(ing.Addr)
 		if err != nil {
 			return nil, err

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -162,7 +162,7 @@ func mergeExemplarSets(a, b []cortexpb.Exemplar) []cortexpb.Exemplar {
 func (d *Distributor) queryIngestersExemplars(ctx context.Context, replicationSet ring.ReplicationSet, req *ingester_client.ExemplarQueryRequest) (*ingester_client.ExemplarQueryResponse, error) {
 	// Fetch exemplars from multiple ingesters in parallel, using the replicationSet
 	// to deal with consistency.
-	results, err := replicationSet.Do(ctx, d.cfg.ExtraQueryDelay, false, false, func(ctx context.Context, ing *ring.InstanceDesc) (any, error) {
+	results, err := replicationSet.DoWithExecutor(ctx, d.cfg.ExtraQueryDelay, false, false, d.queryWorkers, func(ctx context.Context, ing *ring.InstanceDesc) (any, error) {
 		client, err := d.ingesterPool.GetClientFor(ing.Addr)
 		if err != nil {
 			return nil, err
@@ -229,7 +229,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 	)
 
 	// Fetch samples from multiple ingesters
-	results, err := replicationSet.Do(ctx, d.cfg.ExtraQueryDelay, false, partialDataEnabled, func(ctx context.Context, ing *ring.InstanceDesc) (any, error) {
+	results, err := replicationSet.DoWithExecutor(ctx, d.cfg.ExtraQueryDelay, false, partialDataEnabled, d.queryWorkers, func(ctx context.Context, ing *ring.InstanceDesc) (any, error) {
 		client, err := d.ingesterPool.GetClientFor(ing.Addr)
 		if err != nil {
 			return nil, err

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/querier/partialdata"
+	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
 
@@ -27,7 +28,22 @@ type ReplicationSet struct {
 // Do function f in parallel for all replicas in the set, erroring is we exceed
 // MaxErrors and returning early otherwise. zoneResultsQuorum allows only include
 // results from zones that already reach quorum to improve performance.
+//
+// A new goroutine is spawned for each instance. Callers that issue a high
+// volume of small requests (e.g. the ruler/querier fanning out to many
+// ingesters) should prefer DoWithExecutor with a shared worker pool to avoid
+// the per-call cost of creating and growing goroutine stacks.
 func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, zoneResultsQuorum bool, partialDataEnabled bool, f func(context.Context, *InstanceDesc) (any, error)) ([]any, error) {
+	return r.DoWithExecutor(ctx, delay, zoneResultsQuorum, partialDataEnabled, noOpExecutor, f)
+}
+
+// DoWithExecutor is like Do but runs the per-instance work using the provided
+// AsyncExecutor. Passing a goroutine worker pool lets callers reuse goroutines
+// (with already-grown stacks) across calls, avoiding the runtime.newstack /
+// runtime.copystack cost of spawning a fresh goroutine per instance on every
+// request. When the executor has no worker available it falls back to spawning
+// a goroutine, so behavior matches Do under saturation.
+func (r ReplicationSet) DoWithExecutor(ctx context.Context, delay time.Duration, zoneResultsQuorum bool, partialDataEnabled bool, executor util.AsyncExecutor, f func(context.Context, *InstanceDesc) (any, error)) ([]any, error) {
 	type instanceResult struct {
 		res      any
 		err      error
@@ -49,9 +65,11 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, zoneResults
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Spawn a goroutine for each instance.
+	// Run f for each instance. The executor may pool goroutines to amortize
+	// stack growth; the default (no-op) executor spawns a goroutine per call.
 	for i := range r.Instances {
-		go func(i int, ing *InstanceDesc) {
+		i, ing := i, &r.Instances[i]
+		executor.Submit(func() {
 			// Wait to send extra requests. Works only when zone-awareness is disabled.
 			if delay > 0 && r.MaxUnavailableZones == 0 && i >= len(r.Instances)-r.MaxErrors {
 				after := time.NewTimer(delay)
@@ -69,7 +87,7 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, zoneResults
 				err:      err,
 				instance: ing,
 			}
-		}(i, &r.Instances[i])
+		})
 	}
 
 	for !tracker.succeeded() && !tracker.finished() {

--- a/pkg/ring/replication_set_test.go
+++ b/pkg/ring/replication_set_test.go
@@ -384,3 +384,47 @@ func TestHasReplicationSetChangedWithoutState_IgnoresTimeStampAndState(t *testin
 		})
 	}
 }
+
+func TestReplicationSet_DoWithExecutor(t *testing.T) {
+	instances := []InstanceDesc{
+		{Addr: "ingester-0"},
+		{Addr: "ingester-1"},
+		{Addr: "ingester-2"},
+	}
+
+	t.Run("uses executor for goroutine dispatch", func(t *testing.T) {
+		var submits atomic.Int32
+		executor := &countingExecutor{submits: &submits}
+
+		rs := ReplicationSet{Instances: instances, MaxErrors: 0}
+		results, err := rs.DoWithExecutor(context.Background(), 0, false, false, executor, func(ctx context.Context, inst *InstanceDesc) (any, error) {
+			return inst.Addr, nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(results))
+		assert.Equal(t, int32(3), submits.Load(), "expected 3 submits to executor")
+	})
+
+	t.Run("Do delegates to DoWithExecutor with noOpExecutor", func(t *testing.T) {
+		rs := ReplicationSet{Instances: instances, MaxErrors: 0}
+		results, err := rs.Do(context.Background(), 0, false, false, func(ctx context.Context, inst *InstanceDesc) (any, error) {
+			return inst.Addr, nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(results))
+	})
+}
+
+// countingExecutor tracks how many times Submit is called.
+type countingExecutor struct {
+	submits *atomic.Int32
+}
+
+func (e *countingExecutor) Submit(f func()) {
+	e.submits.Add(1)
+	go f()
+}
+
+func (e *countingExecutor) Stop() {}

--- a/schemas/cortex-config-schema.json
+++ b/schemas/cortex-config-schema.json
@@ -4231,6 +4231,12 @@
           "type": "number",
           "x-cli-flag": "distributor.num-push-workers"
         },
+        "num_query_workers": {
+          "default": 0,
+          "description": "EXPERIMENTAL: Number of go routines to handle query fan-out calls from distributors (queriers and rulers) to ingesters. When no workers are available, a new goroutine will be spawned automatically. If set to 0 (default), workers are disabled, and a new goroutine will be created for each query request.",
+          "type": "number",
+          "x-cli-flag": "distributor.num-query-workers"
+        },
         "otlp": {
           "properties": {
             "add_metric_suffixes": {


### PR DESCRIPTION
## What this PR does
Adds an experimental `-distributor.num-query-workers` flag to use a goroutine worker pool for the read-path fan-out from distributors (queriers and rulers) to ingesters. This is the query-path analogue of #6406 which did the same for the push path.
## Why
Looking at the ruler flame graph, we can see that `runtime.copystack` accounts for around ~8-10% of CPU:

Each query evaluation fans out to ingesters via `ReplicationSet.Do`, which spawns a fresh goroutine per instance. These goroutines start with small stacks and immediately grow them (`runtime.newstack` → `runtime.copystack`) when entering the gRPC stream setup + snappy encoding frames. With wide ingester fan-out and many concurrent evaluations, this stack-growth cost becomes significant.

A worker pool of long-lived goroutines (with already-grown stacks) amortizes this cost across requests. When no worker is available, the pool falls back to spawning a new goroutine — so behavior is identical to today under saturation (no regression risk).

## Changes
- Add `ReplicationSet.DoWithExecutor()` that accepts a `util.AsyncExecutor`
- Keep `ReplicationSet.Do()` as a backward-compatible wrapper (delegates via the existing `noOpExecutor`)
- Add `NumQueryWorkers` config field, `queryWorkers` executor, init/stop in Distributor
- Route all 3 query fan-out call sites (`queryIngestersExemplars`, `queryIngesterStream`, `ForReplicationSet`) through `DoWithExecutor`
## How to use
```yaml
distributor:
  num_query_workers: 500  # tune based on fleet; fallback metric guides sizing
```
Monitor `cortex_worker_pool_fallback_total{name="distributor-query"}` — if it's high relative to query volume, increase the worker count.
## Expected impact
~6–8% CPU reduction on rulers/queriers with wide ingester fan-out. Not a latency fix (the workload is wait-bound at peak), but reclaims meaningful fleet capacity.