### PR TITLE
Add ring metric to count number of duplicate tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [ENHANCEMENT] Distributor: Added `cortex_distributor_received_histogram_buckets` metric to track number of buckets in received native histogram samples before validation, per user. #7569
 * [ENHANCEMENT] Distributor: Add `WrappedHistogram` with configurable size limit (`-validation.max-native-histogram-size-bytes`) to cap native histogram protobuf size before unmarshalling. #7570
 * [ENHANCEMENT] Ingester: Add lazy regex evaluation on head postings cache miss. Defers expensive regex matchers on high-cardinality labels to per-series filtering when a selective equality matcher already narrows the result set. Configured via `-blocks-storage.expanded_postings_cache.head.lazy-matcher-max-cardinality` (disabled by default). #7553
+* [ENHANCEMENT] Ring: Add ring metric to count number of duplicate tokens. #7626
 * [BUGFIX] Querier: Fix queryWithRetry and labelsWithRetry returning (nil, nil) on cancelled context by propagating ctx.Err(). #7370
 * [BUGFIX] Metrics Helper: Fix non-deterministic bucket order in merged histograms by sorting buckets after map iteration, matching Prometheus client library behavior. #7380
 * [BUGFIX] Distributor: Return HTTP 401 Unauthorized when tenant ID resolution fails in the Prometheus Remote Write 2.0 path. #7389
@@ -53,7 +54,7 @@
 * [BUGFIX] Ingester: Fix inflight query counter leak when resource-based query protection rejects a request. #7539
 * [BUGFIX] Ingester: Release the TSDB appender on every early-return path in `Push` (e.g. out-of-order label set) by deferring `Rollback`. Previously such requests leaked TSDB head series references, mmap'd chunks and pending state per request, causing the `cortex_ingester_tsdb_head_active_appenders` gauge to grow unbounded. #7528
 * [BUGFIX] Ingester: Fix `panic: send on closed channel` in `ActiveQueriedSeriesService` on shutdown by removing the redundant channel close in `stopping()` and relying on `ctx.Done()` to signal worker exit. #7533
-* [BUGFIX] Ring: Fix ring token conflict resolution only applied to updated instance and make constantly token conflict check during instance observe period.
+* [BUGFIX] Ring: Fix ring token conflict resolution only applied to updated instance and make constantly token conflict check during instance observe period. #7554
 * [BUGFIX] Distributor: Fix a panic (`slice bounds out of range`) in the stream push path when the context deadline expires while the worker goroutine is still marshalling a `WriteRequest`. #7541
 * [BUGFIX] Query Frontend: Fix native histogram responses not being handled correctly in `minTime()` sort ordering for split_by_interval merge. #7555
 * [BUGFIX] Querier: Fix unbounded resource leak in the bucket-scan blocks finder (used when the bucket index is disabled). Per-tenant metadata fetchers, their Prometheus registries, and on-disk meta caches are now evicted once a tenant is no longer active, instead of being retained for the lifetime of the process. #7573

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -213,6 +213,7 @@ type Ring struct {
 	totalTokensGauge        prometheus.Gauge
 	numTokensGaugeVec       *prometheus.GaugeVec
 	oldestTimestampGaugeVec *prometheus.GaugeVec
+	duplicateTokensGauge    prometheus.Gauge
 	reportedOwners          map[string]struct{}
 
 	logger log.Logger
@@ -278,6 +279,10 @@ func NewWithStoreClientAndStrategy(cfg Config, name, key string, store kv.Client
 			Help:        "Timestamp of the oldest member in the ring.",
 			ConstLabels: map[string]string{"name": name}},
 			[]string{"state"}),
+		duplicateTokensGauge: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name:        "ring_duplicate_tokens",
+			Help:        "Number of duplicate tokens in the ring (tokens owned by multiple instances).",
+			ConstLabels: map[string]string{"name": name}}),
 		logger: logger,
 	}
 
@@ -725,6 +730,9 @@ func (r *Ring) updateRingMetrics(compareResult CompareResult) {
 	}
 
 	r.totalTokensGauge.Set(float64(len(r.ringTokens)))
+
+	// Count duplicate tokens (same token owned by multiple instances).
+	r.duplicateTokensGauge.Set(float64(len(r.ringTokens) - len(r.ringInstanceByToken)))
 }
 
 // ShuffleShard returns a subring for the provided identifier (eg. a tenant ID)

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -3183,6 +3183,9 @@ func TestUpdateMetrics(t *testing.T) {
 		{
 			DetailedMetricsEnabled: true,
 			Expected: `
+		# HELP ring_duplicate_tokens Number of duplicate tokens in the ring (tokens owned by multiple instances).
+		# TYPE ring_duplicate_tokens gauge
+		ring_duplicate_tokens{name="test"} 0
 		# HELP ring_member_ownership_percent The percent ownership of the ring by member
 		# TYPE ring_member_ownership_percent gauge
 		ring_member_ownership_percent{member="A",name="test"} 0.49999999976716936
@@ -3215,6 +3218,9 @@ func TestUpdateMetrics(t *testing.T) {
 		{
 			DetailedMetricsEnabled: false,
 			Expected: `
+		# HELP ring_duplicate_tokens Number of duplicate tokens in the ring (tokens owned by multiple instances).
+		# TYPE ring_duplicate_tokens gauge
+		ring_duplicate_tokens{name="test"} 0
 		# HELP ring_members Number of members in the ring
 		# TYPE ring_members gauge
 		ring_members{name="test",state="ACTIVE",zone=""} 2
@@ -3291,6 +3297,9 @@ func TestUpdateMetricsWithRemoval(t *testing.T) {
 	ring.updateRingState(&ringDesc)
 
 	err = testutil.GatherAndCompare(registry, bytes.NewBufferString(`
+		# HELP ring_duplicate_tokens Number of duplicate tokens in the ring (tokens owned by multiple instances).
+		# TYPE ring_duplicate_tokens gauge
+		ring_duplicate_tokens{name="test"} 0
 		# HELP ring_member_ownership_percent The percent ownership of the ring by member
 		# TYPE ring_member_ownership_percent gauge
 		ring_member_ownership_percent{member="A",name="test"} 0.49999999976716936
@@ -3329,6 +3338,9 @@ func TestUpdateMetricsWithRemoval(t *testing.T) {
 	ring.updateRingState(&ringDescNew)
 
 	err = testutil.GatherAndCompare(registry, bytes.NewBufferString(`
+		# HELP ring_duplicate_tokens Number of duplicate tokens in the ring (tokens owned by multiple instances).
+		# TYPE ring_duplicate_tokens gauge
+		ring_duplicate_tokens{name="test"} 0
 		# HELP ring_member_ownership_percent The percent ownership of the ring by member
 		# TYPE ring_member_ownership_percent gauge
 		ring_member_ownership_percent{member="A",name="test"} 1
@@ -3383,6 +3395,9 @@ func TestUpdateMetricsWithZone(t *testing.T) {
 	ring.updateRingState(&ringDesc)
 
 	err = testutil.GatherAndCompare(registry, bytes.NewBufferString(`
+		# HELP ring_duplicate_tokens Number of duplicate tokens in the ring (tokens owned by multiple instances).
+		# TYPE ring_duplicate_tokens gauge
+		ring_duplicate_tokens{name="test"} 0
 		# HELP ring_member_ownership_percent The percent ownership of the ring by member
 		# TYPE ring_member_ownership_percent gauge
 		ring_member_ownership_percent{member="A",name="test"} 0.3333333332557231
@@ -3435,6 +3450,9 @@ func TestUpdateMetricsWithZone(t *testing.T) {
 	ring.updateRingState(&ringDescNew)
 
 	err = testutil.GatherAndCompare(registry, bytes.NewBufferString(`
+		# HELP ring_duplicate_tokens Number of duplicate tokens in the ring (tokens owned by multiple instances).
+		# TYPE ring_duplicate_tokens gauge
+		ring_duplicate_tokens{name="test"} 0
 		# HELP ring_member_ownership_percent The percent ownership of the ring by member
 		# TYPE ring_member_ownership_percent gauge
 		ring_member_ownership_percent{member="A",name="test"} 1
@@ -3475,3 +3493,50 @@ func TestUpdateMetricsWithZone(t *testing.T) {
 	`))
 	assert.NoError(t, err)
 }
+
+func TestUpdateMetricsDuplicateTokens(t *testing.T) {
+	cfg := Config{
+		KVStore:           kv.Config{},
+		HeartbeatTimeout:  0,
+		ReplicationFactor: 3,
+	}
+
+	registry := prometheus.NewRegistry()
+	ring, err := NewWithStoreClientAndStrategy(cfg, testRingName, testRingKey, &MockClient{}, NewDefaultReplicationStrategy(), registry, log.NewNopLogger())
+	require.NoError(t, err)
+
+	// No duplicate tokens: A owns {1, 2}, B owns {3, 4}.
+	ringDesc1 := Desc{
+		Ingesters: map[string]InstanceDesc{
+			"A": {Addr: "127.0.0.1", Timestamp: 10, Tokens: []uint32{1, 2}},
+			"B": {Addr: "127.0.0.2", Timestamp: 10, Tokens: []uint32{3, 4}},
+		},
+	}
+	ring.updateRingState(&ringDesc1)
+
+	assert.Equal(t, float64(0), testutil.ToFloat64(ring.duplicateTokensGauge))
+
+	// Duplicate tokens: A and B both own token 100, plus one shared token 200.
+	ringDesc2 := Desc{
+		Ingesters: map[string]InstanceDesc{
+			"A": {Addr: "127.0.0.1", Timestamp: 20, Tokens: []uint32{100, 200, 300}},
+			"B": {Addr: "127.0.0.2", Timestamp: 20, Tokens: []uint32{100, 200, 400}},
+		},
+	}
+	ring.updateRingState(&ringDesc2)
+
+	// Total instance tokens = 6, unique tokens = {100, 200, 300, 400} = 4, duplicates = 2.
+	assert.Equal(t, float64(2), testutil.ToFloat64(ring.duplicateTokensGauge))
+
+	// Back to no duplicates.
+	ringDesc3 := Desc{
+		Ingesters: map[string]InstanceDesc{
+			"A": {Addr: "127.0.0.1", Timestamp: 30, Tokens: []uint32{100, 200}},
+			"B": {Addr: "127.0.0.2", Timestamp: 30, Tokens: []uint32{300, 400}},
+		},
+	}
+	ring.updateRingState(&ringDesc3)
+
+	assert.Equal(t, float64(0), testutil.ToFloat64(ring.duplicateTokensGauge))
+}
+

--- a/pkg/ring/ring_test.go
+++ b/pkg/ring/ring_test.go
@@ -3539,4 +3539,3 @@ func TestUpdateMetricsDuplicateTokens(t *testing.T) {
 
 	assert.Equal(t, float64(0), testutil.ToFloat64(ring.duplicateTokensGauge))
 }
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Adds a new gauge metric ring_duplicate_tokens that reports the number of tokens in the ring that are owned by more than one instance simultaneously. The metric is labeled with the ring name (e.g., ingester, distributor) and emits 0 when healthy.

**Which issue(s) this PR fixes**:
NA

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
