### PR TITLE
Use distroless base image for runtime container images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [ENHANCEMENT] Metrics Helper: Add native histogram support for aggregating and merging, including dual-format histogram handling that exposes both native and classic bucket formats. #7359
 * [ENHANCEMENT] Cache: Add per-tenant TTL configuration for query results cache to control cache expiration on a per-tenant basis with separate TTLs for regular and out-of-order data. #7357
 * [ENHANCEMENT] Update build image and Go version to 1.26. #7437
+* [ENHANCEMENT] Upgraded container base images from `alpine:3.23` to `gcr.io/distroless/static-debian12`, reducing image size and attack surface. #7637
 * [ENHANCEMENT] Query Scheduler: Add `cortex_query_scheduler_tracked_requests` metric to track the current number of requests held by the scheduler. #7355
 * [ENHANCEMENT] Compactor: Prevent partition compaction to compact any blocks marked for deletion. #7391
 * [ENHANCEMENT] Distributor: Optimize memory allocations by reusing the existing capacity of these pooled slices in the Prometheus Remote Write 2.0 path. #7392

--- a/cmd/cortex/Dockerfile
+++ b/cmd/cortex/Dockerfile
@@ -1,7 +1,7 @@
-FROM       alpine:3.23
+ARG        BASEIMG=gcr.io/distroless/static-debian12:latest
+FROM       ${BASEIMG}
 ARG TARGETARCH
 
-RUN        apk add --no-cache ca-certificates
 COPY       migrations /migrations/
 COPY       cortex-$TARGETARCH /bin/cortex
 EXPOSE     80

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -1,7 +1,7 @@
-FROM       alpine:3.23
+ARG        BASEIMG=gcr.io/distroless/static-debian12:latest
+FROM       ${BASEIMG}
 ARG TARGETARCH
 
-RUN        apk add --no-cache ca-certificates
 COPY       query-tee-$TARGETARCH /query-tee
 ENTRYPOINT ["/query-tee"]
 

--- a/cmd/test-exporter/Dockerfile
+++ b/cmd/test-exporter/Dockerfile
@@ -1,6 +1,6 @@
-FROM       alpine:3.23
+ARG        BASEIMG=gcr.io/distroless/static-debian12:latest
+FROM       ${BASEIMG}
 ARG TARGETARCH
-RUN        apk add --no-cache ca-certificates
 COPY       test-exporter-$TARGETARCH /test-exporter
 ENTRYPOINT ["/test-exporter"]
 

--- a/cmd/thanosconvert/Dockerfile
+++ b/cmd/thanosconvert/Dockerfile
@@ -1,6 +1,6 @@
-FROM       alpine:3.23
+ARG        BASEIMG=gcr.io/distroless/static-debian12:latest
+FROM       ${BASEIMG}
 ARG TARGETARCH
-RUN        apk add --no-cache ca-certificates
 COPY       thanosconvert-$TARGETARCH /thanosconvert
 ENTRYPOINT ["/thanosconvert"]
 


### PR DESCRIPTION
## What this PR does

Switches the runtime container images from `alpine:3.23` to `gcr.io/distroless/static-debian12` for all four runtime binaries:

- `cmd/cortex/Dockerfile`
- `cmd/query-tee/Dockerfile`
- `cmd/thanosconvert/Dockerfile`
- `cmd/test-exporter/Dockerfile`

The Cortex binaries are already built fully static and CGO-free (`CGO_ENABLED=0`, `-extldflags "-static" -tags "netgo slicelabels"`), so they have no shell or libc dependency at runtime — a clean fit for distroless. This reduces image size and attack surface (no shell, no package manager, no busybox).

## Notes

- **CA certificates** are bundled in `gcr.io/distroless/static-debian12` (`/etc/ssl/certs/ca-certificates.crt`), so the `apk add --no-cache ca-certificates` step is dropped. TLS to object storage (S3/GCS/etc.) continues to work.
- **tzdata** is also included in distroless static (alpine did not ship it by default — minor improvement).
- The image continues to run as **root (uid 0)**, not the `:nonroot` variant. Cortex's default `server.http-listen-port` is `80`, a privileged port; staying root keeps the default config and the integration tests (which bind port 80) working with **no breaking change**. The base image is exposed as an overridable `BASEIMG` ARG so CI can pin to an immutable digest.
- No shell is needed inside the cortex image — every Cortex e2e service uses an HTTP `/ready` readiness probe.

## Checklist

- [x] CHANGELOG entry added