### PR TITLE
Fix ingester panic on float histogram with zero count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * [BUGFIX] Ruler: Register xfunctions (xincrease, xrate, xdelta) in the global parser before loading rule files. #7621
 * [BUGFIX] Security: Reject empty entries in `-distributor.sign-write-requests-keys` caused by stray or trailing commas (e.g. `newkey,`). Previously these were silently accepted and produced an empty signing key, which downgraded HMAC stream-push authentication to a forgeable signature. Misconfigured flags now fail at process startup; audit your configs before upgrading. #7587
 * [BUGFIX] Querier: Fix panic due to request tracker truncating multi-byte UTF-8 character #7640
+* [BUGFIX] Ingester: Fix panic (`HistogramProtoToHistogram called with a float histogram`) when ingesting a float native histogram with a zero count (e.g. a staleness marker or empty histogram). The decoder is now selected by histogram type via `IsFloatHistogram()` instead of by count value. #7645
 
 ## 1.21.0 2026-04-24
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1591,7 +1591,14 @@ func (i *Ingester) Push(ctx context.Context, req *cortexpb.WriteRequest) (*corte
 					fh  *histogram.FloatHistogram
 				)
 
-				if hp.GetCountFloat() > 0 {
+				// Choose the decoder based on the histogram's proto type (the
+				// CountInt/CountFloat oneof), not the count value. A float
+				// histogram with a count of 0 (e.g. a staleness marker or an
+				// empty histogram) still has the CountFloat oneof set, so a
+				// value-based check (hp.GetCountFloat() > 0) would misroute it
+				// to the integer decoder, which panics. This mirrors the
+				// discriminator used everywhere else (e.g. util/validation).
+				if hp.Histogram.IsFloatHistogram() {
 					fh = cortexpb.FloatHistogramProtoToFloatHistogram(hp.Histogram)
 				} else {
 					h = cortexpb.HistogramProtoToHistogram(hp.Histogram)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1598,7 +1598,7 @@ func (i *Ingester) Push(ctx context.Context, req *cortexpb.WriteRequest) (*corte
 				// value-based check (hp.GetCountFloat() > 0) would misroute it
 				// to the integer decoder, which panics. This mirrors the
 				// discriminator used everywhere else (e.g. util/validation).
-				if hp.Histogram.IsFloatHistogram() {
+				if hp.IsFloatHistogram() {
 					fh = cortexpb.FloatHistogramProtoToFloatHistogram(hp.Histogram)
 				} else {
 					h = cortexpb.HistogramProtoToHistogram(hp.Histogram)

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -2631,6 +2632,64 @@ func TestIngester_PushNativeHistogramErrors(t *testing.T) {
 			assert.Equal(t, httpgrpc.Errorf(http.StatusBadRequest, "%s", wrapWithUser(wrappedTSDBIngestErr(tc.expectedErr, model.Time(10), metricLabelAdapters), userID).Error()), err)
 
 			require.Equal(t, testutil.ToFloat64(i.metrics.ingestedHistogramsFail), float64(1))
+		})
+	}
+}
+
+func TestIngester_Push_FloatHistogramWithZeroCount(t *testing.T) {
+	// Regression test: a float histogram with a count of 0 (e.g. a staleness
+	// marker or an empty histogram) has the CountFloat oneof set, so it IS a
+	// float histogram. A value-based discriminator (hp.GetCountFloat() > 0)
+	// misroutes it to the integer decoder cortexpb.HistogramProtoToHistogram,
+	// which panics with "HistogramProtoToHistogram called with a float
+	// histogram" and crashes the ingester. The decoder must be selected by the
+	// proto type via IsFloatHistogram() instead.
+	metricLabelAdapters := []cortexpb.LabelAdapter{{Name: labels.MetricName, Value: "test"}}
+	metricLabels := cortexpb.FromLabelAdaptersToLabels(metricLabelAdapters)
+	userID := "test"
+
+	for _, tc := range []struct {
+		name      string
+		histogram cortexpb.WrappedHistogram
+	}{
+		{
+			name:      "staleness marker float histogram with zero count",
+			histogram: cortexpb.WrapHistogram(cortexpb.FloatHistogramToHistogramProto(10, &histogram.FloatHistogram{Sum: math.Float64frombits(value.StaleNaN)})),
+		},
+		{
+			name:      "empty float histogram with zero count",
+			histogram: cortexpb.WrapHistogram(cortexpb.FloatHistogramToHistogramProto(10, &histogram.FloatHistogram{})),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := prometheus.NewRegistry()
+
+			// Create a mocked ingester
+			cfg := defaultIngesterTestConfig(t)
+			cfg.LifecyclerConfig.JoinAfter = 0
+
+			limits := defaultLimitsTestConfig()
+			limits.EnableNativeHistograms = true
+			i, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, nil, "", registry)
+			require.NoError(t, err)
+			require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+			defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
+
+			ctx := user.InjectOrgID(context.Background(), userID)
+
+			// Wait until the ingester is ACTIVE
+			test.Poll(t, 100*time.Millisecond, ring.ACTIVE, func() any {
+				return i.lifecycler.GetState()
+			})
+
+			req := cortexpb.ToWriteRequest([]labels.Labels{metricLabels}, nil, nil, []cortexpb.WrappedHistogram{tc.histogram}, cortexpb.API)
+			// Before the fix this panics inside Push; after the fix it must be
+			// ingested without error.
+			_, err = i.Push(ctx, req)
+			require.NoError(t, err)
+
+			require.Equal(t, float64(0), testutil.ToFloat64(i.metrics.ingestedHistogramsFail))
+			require.Equal(t, float64(1), testutil.ToFloat64(i.metrics.ingestedHistograms))
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does

The ingester `Push` path selected the float vs integer native-histogram decoder using a **value** check, `hp.GetCountFloat() > 0`:

```go
if hp.GetCountFloat() > 0 {
    fh = cortexpb.FloatHistogramProtoToFloatHistogram(hp.Histogram)
} else {
    h = cortexpb.HistogramProtoToHistogram(hp.Histogram)
}
```

A float histogram with a count of **0** (for example a staleness marker — `FloatHistogram{Sum: StaleNaN}` — or an empty histogram) still has the `CountFloat` oneof set, so `IsFloatHistogram()` reports `true` while `GetCountFloat() > 0` is `false`. Such samples were routed to `HistogramProtoToHistogram`, which panics:

```
panic: HistogramProtoToHistogram called with a float histogram
```

Because this runs synchronously in the gRPC `Push` handler with no `recover`, the panic crashes the whole ingester process. With many ingesters receiving the same input this can break write/read quorum across a cell.

## Fix

Select the decoder by the proto **type** via `IsFloatHistogram()`, matching the discriminator already used in `pkg/util/validation` and upstream Prometheus.

## Testing

Added `TestIngester_Push_FloatHistogramWithZeroCount` covering a staleness-marker float histogram and an empty float histogram (both count 0). Verified the test panics on master without the fix and passes with it. Full `pkg/ingester` suite passes with `-tags "netgo slicelabels"`.

## Which issue(s) this PR fixes

N/A

## Checklist
- [x] Tests updated
- [x] `CHANGELOG.md` updated - (will add with PR number)
- [ ] `docs/configuration/config-file-reference.md` updated (regenerated; no change — no config flags added)