### PR TITLE
Add Siddarth Gundu to Triagers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,4 +17,5 @@
 | Anand Rajagopal | anand.rajagopal@icloud.com | @rajagopalanand | Amazon Web Services |
 | Daniel Sabsay   | danielsabsay.sofware@gmail.com          | @dsabsay        | Adobe               |
 | Yuxuan Chen     | sandy19890604@gmail.com    | @sandy2008      | Morgan Stanley      |
+| Siddarth Gundu  | siddarthg0910@gmail.com    | @siddarth2810   | Independent         |
 


### PR DESCRIPTION
@siddarth2810 has been contributing to Cortex for the past year, primarily in the Parquet subsystem (row-range constraints cache #7478, conversion sharding/markers) along with query-API work (`/api/v1/format_query` #6893, `parse_query` #6978) and native-histogram support. He has expressed interest in helping triage issues.

I'd like to start a vote to add him to the triage team. His commits can be found [here](https://github.com/cortexproject/cortex/commits?author=siddarth2810).

Per existing governance, 2/3 majority votes are required for the changes to pass.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
