### PR TITLE
fix(compactor): correct misleading help text for cortex_compactor_garbage_collected_blocks_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [ENHANCEMENT] Ingester: Add `cortex_ingester_tsdb_head_max_timestamp` metric that re-exports the TSDB head max timestamp (`prometheus_tsdb_head_max_time`) per user, to help investigate ingestion issues like out-of-bounds (too old sample) errors. #7694
 * [ENHANCEMENT] Ingester: Include the TSDB head max time in the `out of bounds` and `too old sample` error messages, so that users can see how far behind the accepted time range a rejected sample is. #7695
 * [ENHANCEMENT] Compactor: Reduce object storage GET calls when updating the bucket index by skipping re-reading parquet converter markers for blocks that already have a valid-version parquet entry in the previous index. #7669
+* [BUGFIX] Compactor: Correct misleading help text for `cortex_compactor_garbage_collected_blocks_total` metric; it counted blocks garbage collected by the syncer, not all blocks marked for deletion. #3610
 * [BUGFIX] Querier: Fix queryWithRetry and labelsWithRetry returning (nil, nil) on cancelled context by propagating ctx.Err(). #7370
 * [BUGFIX] Metrics Helper: Fix non-deterministic bucket order in merged histograms by sorting buckets after map iteration, matching Prometheus client library behavior. #7380
 * [BUGFIX] Distributor: Return HTTP 401 Unauthorized when tenant ID resolution fails in the Prometheus Remote Write 2.0 path. #7389

--- a/pkg/compactor/compactor_metrics.go
+++ b/pkg/compactor/compactor_metrics.go
@@ -120,7 +120,7 @@ func newCompactorMetricsWithLabels(reg prometheus.Registerer, commonLabels []str
 	// Copied from Thanos, pkg/compact/compact.go.
 	m.syncerGarbageCollectedBlocks = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_compactor_garbage_collected_blocks_total",
-		Help: "Total number of blocks marked for deletion by compactor.",
+		Help: "Total number of blocks garbage collected (deleted after being marked) by the compactor syncer.",
 	}, nil)
 	m.syncerGarbageCollections = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_compactor_garbage_collection_total",

--- a/pkg/compactor/compactor_metrics_test.go
+++ b/pkg/compactor/compactor_metrics_test.go
@@ -65,7 +65,7 @@ func TestCompactorMetrics(t *testing.T) {
 			cortex_compactor_blocks_marked_for_deletion_total{reason="compaction",user="aaa"} 144430
 			cortex_compactor_blocks_marked_for_deletion_total{reason="compaction",user="bbb"} 155540
 			cortex_compactor_blocks_marked_for_deletion_total{reason="compaction",user="ccc"} 166650
-			# HELP cortex_compactor_garbage_collected_blocks_total Total number of blocks marked for deletion by compactor.
+			# HELP cortex_compactor_garbage_collected_blocks_total Total number of blocks garbage collected (deleted after being marked) by the compactor syncer.
 			# TYPE cortex_compactor_garbage_collected_blocks_total counter
 			cortex_compactor_garbage_collected_blocks_total 99990
 			# HELP cortex_compactor_garbage_collection_duration_seconds Time it took to perform garbage collection iteration.


### PR DESCRIPTION
**What this PR does**:

The metric `cortex_compactor_garbage_collected_blocks_total` had an
identical help string to `cortex_compactor_blocks_marked_for_deletion_total`
(`"Total number of blocks marked for deletion by compactor."`), which was
confusing and misleading. The two metrics track different things:

- `cortex_compactor_garbage_collected_blocks_total` — counts blocks that the
  Thanos syncer's GC pass has actually garbage-collected (i.e., deleted after
  previously being marked). Sourced from Thanos `pkg/compact/compact.go`.
- `cortex_compactor_blocks_marked_for_deletion_total` — counts blocks that
  Cortex's own logic has explicitly marked for deletion.

This PR corrects the help text to accurately describe what the metric
measures: `"Total number of blocks garbage collected (deleted after being
marked) by the compactor syncer."` The test expectation is updated to match.

**Which issue(s) this PR fixes**:
Fixes #3610

**Checklist**
- [x] Tests updated (test expectation string updated to match new help text)
- [x] `CHANGELOG.md` updated
- [ ] Documentation added (N/A — metric help text is self-documenting)

> Note: This PR was developed with AI assistance (Claude Code).