### PR TITLE
perf(ingester): invalidate head postings cache per-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [ENHANCEMENT] Querier: Detach series label and chunk data from gRPC unmarshal buffers in store-gateway streaming path, allowing the Go GC to reclaim receive buffers. #7519
 * [ENHANCEMENT] Distributor: Added `cortex_distributor_received_histogram_buckets` metric to track number of buckets in received native histogram samples before validation, per user. #7569
 * [ENHANCEMENT] Ingester: Add lazy regex evaluation on head postings cache miss. Defers expensive regex matchers on high-cardinality labels to per-series filtering when a selective equality matcher already narrows the result set. Configured via `-blocks-storage.expanded_postings_cache.head.lazy-matcher-max-cardinality` (disabled by default). #7553
+* [ENHANCEMENT] Ingester: Improve head expanded postings cache hit rate by invalidating only the cache entries whose matched labels changed when a series is created or deleted, instead of invalidating all entries for the metric name. #7678
 * [ENHANCEMENT] Store Gateway: Resolve the parquet shard count from the bucket index instead of reading the converter mark for each block, reducing object storage calls when the bucket index is enabled. A `component` label is added to the bucket index loader metrics to distinguish store-queryable and store-gateway. #7648
 * [ENHANCEMENT] Query Frontend: Improve the slow query log with `source`, `user_agent`, `engine_type`, `block_store_type`, and query stats fields to aid slow query diagnosis. #7601
 * [ENHANCEMENT] Ring: Add ring metric to count number of duplicate tokens. #7626

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -2274,6 +2274,12 @@ blocks_storage:
       # CLI flag: -blocks-storage.expanded_postings_cache.head.lazy-matcher-complex-cost-ratio
       [lazy_matcher_complex_cost_ratio: <int> | default = 2]
 
+      # The number of counts stored in the label counter used for head cache
+      # invalidation. Note one label counter is shared by all tenants. 0 sets to
+      # the default of 4_000_000.
+      # CLI flag: -blocks-storage.expanded_postings_cache.head.label-counter-size
+      [label_counter_size: <int> | default = 4000000]
+
   users_scanner:
     # Strategy to use to scan users. Supported values are: list, user_index.
     # CLI flag: -blocks-storage.users-scanner.strategy

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -2332,6 +2332,12 @@ blocks_storage:
       # CLI flag: -blocks-storage.expanded_postings_cache.head.lazy-matcher-complex-cost-ratio
       [lazy_matcher_complex_cost_ratio: <int> | default = 2]
 
+      # The number of counts stored in the label counter used for head cache
+      # invalidation. Note one label counter is shared by all tenants. 0 sets to
+      # the default of 4_000_000.
+      # CLI flag: -blocks-storage.expanded_postings_cache.head.label-counter-size
+      [label_counter_size: <int> | default = 4000000]
+
   users_scanner:
     # Strategy to use to scan users. Supported values are: list, user_index.
     # CLI flag: -blocks-storage.users-scanner.strategy

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -2923,6 +2923,12 @@ tsdb:
     # CLI flag: -blocks-storage.expanded_postings_cache.head.lazy-matcher-complex-cost-ratio
     [lazy_matcher_complex_cost_ratio: <int> | default = 2]
 
+    # The number of counts stored in the label counter used for head cache
+    # invalidation. Note one label counter is shared by all tenants. 0 sets to
+    # the default of 4_000_000.
+    # CLI flag: -blocks-storage.expanded_postings_cache.head.label-counter-size
+    [label_counter_size: <int> | default = 4000000]
+
 users_scanner:
   # Strategy to use to scan users. Supported values are: list, user_index.
   # CLI flag: -blocks-storage.users-scanner.strategy

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -433,7 +433,8 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 	// Start dependencies.
 	consul1 := e2edb.NewConsulWithName("consul1")
 	consul2 := e2edb.NewConsulWithName("consul2")
-	require.NoError(t, s.StartAndWaitReady(consul1, consul2))
+	consul3 := e2edb.NewConsulWithName("consul3")
+	require.NoError(t, s.StartAndWaitReady(consul1, consul2, consul3))
 
 	flags1 := mergeFlags(
 		AlertmanagerLocalFlags(),
@@ -481,7 +482,9 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 			// Store-gateway.
 			"-store-gateway.sharding-enabled": "false",
 			// alert manager
-			"-alertmanager.web.external-url": "http://localhost/alertmanager",
+			"-alertmanager.web.external-url":          "http://localhost/alertmanager",
+			"-alertmanager.cluster.listen-address":    "127.0.0.1:9094",
+			"-alertmanager.cluster.advertise-address": "127.0.0.1:9094",
 		},
 	)
 	// make alert manager config dir
@@ -489,25 +492,46 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 
 	path1 := path.Join(s.SharedDir(), "cortex-1")
 	path2 := path.Join(s.SharedDir(), "cortex-2")
+	path3 := path.Join(s.SharedDir(), "cortex-3")
 
 	flags1 = mergeFlags(flags1, map[string]string{"-blocks-storage.filesystem.dir": path1})
 	flags2 = mergeFlags(flags2, map[string]string{"-blocks-storage.filesystem.dir": path2})
+	// cortex-3 matches cortex-2 but squashes the label counter to a single slot, so
+	// every (tenant, label) collides.
+	flags3 := mergeFlags(flags2, map[string]string{
+		"-blocks-storage.filesystem.dir": path3,
+		"-consul.hostname":               consul3.NetworkHTTPEndpoint(),
+		"-blocks-storage.expanded_postings_cache.head.label-counter-size": "1",
+	})
 	// Start Cortex replicas.
 	cortex1 := e2ecortex.NewSingleBinary("cortex-1", flags1, stableCortexImage)
 	cortex2 := e2ecortex.NewSingleBinary("cortex-2", flags2, "")
-	require.NoError(t, s.StartAndWaitReady(cortex1, cortex2))
+	cortex3 := e2ecortex.NewSingleBinary("cortex-3", flags3, "")
+	require.NoError(t, s.StartAndWaitReady(cortex1, cortex2, cortex3))
 
 	// Wait until Cortex replicas have updated the ring state.
 	require.NoError(t, cortex1.WaitSumMetrics(e2e.Equals(float64(512)), "cortex_ring_tokens_total"))
 	require.NoError(t, cortex2.WaitSumMetrics(e2e.Equals(float64(512)), "cortex_ring_tokens_total"))
+	require.NoError(t, cortex3.WaitSumMetrics(e2e.Equals(float64(512)), "cortex_ring_tokens_total"))
 
 	var clients []*e2ecortex.Client
 	c1, err := e2ecortex.NewClient(cortex1.HTTPEndpoint(), cortex1.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 	c2, err := e2ecortex.NewClient(cortex2.HTTPEndpoint(), cortex2.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
+	c3, err := e2ecortex.NewClient(cortex3.HTTPEndpoint(), cortex3.HTTPEndpoint(), "", "", "user-1")
+	require.NoError(t, err)
 
-	clients = append(clients, c1, c2)
+	clients = append(clients, c1, c2, c3)
+
+	// c1 (no postings cache) is the oracle; every candidate must agree with it.
+	candidates := []struct {
+		name   string
+		client *e2ecortex.Client
+	}{
+		{"postings-cache", c2},
+		{"postings-cache-colliding-counter", c3},
+	}
 
 	now := time.Now()
 	// Push some series to Cortex.
@@ -517,27 +541,46 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 	numSeries := 10
 	numberOfLabelsPerSeries := 5
 	numSamples := 10
-	ss := make([]prompb.TimeSeries, numSeries*numberOfLabelsPerSeries)
-	lbls := make([]labels.Labels, numSeries*numberOfLabelsPerSeries)
+	numIterations := 5
 
-	for i := 0; i < numSeries; i++ {
-		for j := 0; j < numberOfLabelsPerSeries; j++ {
-			series := e2e.GenerateSeriesWithSamples(
-				fmt.Sprintf("test_series_%d", i),
-				start,
-				scrapeInterval,
-				i*numSamples,
-				numSamples,
-				prompb.Label{Name: "test_label", Value: fmt.Sprintf("test_label_value_%d", j)},
-			)
-			ss[i*numberOfLabelsPerSeries+j] = series
+	// Names and values that only exist from iteration k onwards, so entries cached
+	// earlier (including empty ones) invalidate only if a value-keyed slot moves.
+	lateSeriesName := func(k int) string { return fmt.Sprintf("test_series_late_%d", k) }
+	lateLabelValue := func(k int) string { return fmt.Sprintf("test_label_value_late_%d", k) }
 
-			builder := labels.NewBuilder(labels.EmptyLabels())
-			for _, lbl := range series.Labels {
-				builder.Set(lbl.Name, lbl.Value)
+	// "k" is the only label that churns, so it has to be in promqlsmith's vocabulary
+	// or no generated matcher ever constrains it.
+	lbls := make([]labels.Labels, 0, numSeries*numberOfLabelsPerSeries*numIterations+3*numIterations)
+	for i := range numSeries {
+		for j := range numberOfLabelsPerSeries {
+			for k := range numIterations {
+				lbls = append(lbls, labels.FromStrings(
+					model.MetricNameLabel, fmt.Sprintf("test_series_%d", i),
+					"test_label", fmt.Sprintf("test_label_value_%d", j),
+					"k", fmt.Sprintf("%d", k),
+				))
 			}
-			lbls[i*numberOfLabelsPerSeries+j] = builder.Labels()
 		}
+	}
+	// Late names/values need to be in the vocabulary too. The third shape omits
+	// test_label, so only matchers that can match an absent label select it.
+	for k := range numIterations {
+		lbls = append(lbls,
+			labels.FromStrings(
+				model.MetricNameLabel, lateSeriesName(k),
+				"test_label", fmt.Sprintf("test_label_value_%d", k%numberOfLabelsPerSeries),
+				"k", fmt.Sprintf("%d", k),
+			),
+			labels.FromStrings(
+				model.MetricNameLabel, fmt.Sprintf("test_series_%d", k%numSeries),
+				"test_label", lateLabelValue(k),
+				"k", fmt.Sprintf("%d", k),
+			),
+			labels.FromStrings(
+				model.MetricNameLabel, fmt.Sprintf("test_series_%d", k%numSeries),
+				"k", fmt.Sprintf("%d", k),
+			),
+		)
 	}
 
 	rnd := newFuzzRand(t)
@@ -551,7 +594,7 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 	testRun := 300
 	queries := make([]string, 0, testRun)
 	matchers := make([]string, 0, testRun)
-	for i := 0; i < testRun; i++ {
+	for i := range testRun {
 		var expr parser.Expr
 		for {
 			expr = ps.WalkRangeQuery()
@@ -568,12 +611,17 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 	}
 
 	// Lets run multiples iterations and create new series every iteration
-	for k := 0; k < 5; k++ {
+	for k := range numIterations {
 
-		nss := make([]prompb.TimeSeries, numSeries*numberOfLabelsPerSeries)
-		for i := 0; i < numSeries; i++ {
-			for j := 0; j < numberOfLabelsPerSeries; j++ {
-				nss[i*numberOfLabelsPerSeries+j] = e2e.GenerateSeriesWithSamples(
+		// Churn a subset only. Rewriting every combination moves every snapshotted
+		// slot, so entries would always invalidate and never stay valid.
+		timeSeries := make([]prompb.TimeSeries, 0, numSeries*numberOfLabelsPerSeries+numSeries+2)
+		for i := range numSeries {
+			for j := range numberOfLabelsPerSeries {
+				if (i+j+k)%3 == 0 {
+					continue
+				}
+				timeSeries = append(timeSeries, e2e.GenerateSeriesWithSamples(
 					fmt.Sprintf("test_series_%d", i),
 					start.Add(scrapeInterval*time.Duration(numSamples*j)),
 					scrapeInterval,
@@ -581,12 +629,50 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 					numSamples,
 					prompb.Label{Name: "test_label", Value: fmt.Sprintf("test_label_value_%d", j)},
 					prompb.Label{Name: "k", Value: fmt.Sprintf("%d", k)},
-				)
+				))
 			}
 		}
 
+		// First appearance of this iteration's late metric name and test_label value.
+		timeSeries = append(timeSeries,
+			e2e.GenerateSeriesWithSamples(
+				lateSeriesName(k),
+				start,
+				scrapeInterval,
+				k*numSamples,
+				numSamples,
+				prompb.Label{Name: "test_label", Value: fmt.Sprintf("test_label_value_%d", k%numberOfLabelsPerSeries)},
+				prompb.Label{Name: "k", Value: fmt.Sprintf("%d", k)},
+			),
+			e2e.GenerateSeriesWithSamples(
+				fmt.Sprintf("test_series_%d", k%numSeries),
+				start,
+				scrapeInterval,
+				k*numSamples,
+				numSamples,
+				prompb.Label{Name: "test_label", Value: lateLabelValue(k)},
+				prompb.Label{Name: "k", Value: fmt.Sprintf("%d", k)},
+			),
+		)
+
+		// Series that omit test_label. They never bump the test_label slots, which is
+		// why absent-label matchers cannot vouch for an entry.
+		for i := range numSeries {
+			if (i+k)%2 != 0 {
+				continue
+			}
+			timeSeries = append(timeSeries, e2e.GenerateSeriesWithSamples(
+				fmt.Sprintf("test_series_%d", i),
+				start,
+				scrapeInterval,
+				i*numSamples,
+				numSamples,
+				prompb.Label{Name: "k", Value: fmt.Sprintf("%d", k)},
+			))
+		}
+
 		for _, client := range clients {
-			res, err := client.Push(nss)
+			res, err := client.Push(timeSeries)
 			require.NoError(t, err)
 			require.Equal(t, 200, res.StatusCode)
 		}
@@ -594,36 +680,42 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 		type testCase struct {
 			query        string
 			qt           string
+			instance     string
 			res1, res2   model.Value
 			sres1, sres2 []model.LabelSet
 			err1, err2   error
 		}
 
-		cases := make([]*testCase, 0, len(queries)*3)
+		cases := make([]*testCase, 0, len(queries)*3*len(candidates))
 
 		for _, query := range queries {
 			fuzzyTime := time.Duration(rand.Int63n(time.Now().UnixMilli() - start.UnixMilli()))
 			queryEnd := start.Add(fuzzyTime * time.Millisecond)
-			res1, err1 := c1.Query(query, queryEnd)
-			res2, err2 := c2.Query(query, queryEnd)
-			cases = append(cases, &testCase{
-				query: query,
-				qt:    "instant",
-				res1:  res1,
-				res2:  res2,
-				err1:  err1,
-				err2:  err2,
-			})
-			res1, err1 = c1.QueryRange(query, start, queryEnd, scrapeInterval)
-			res2, err2 = c2.QueryRange(query, start, queryEnd, scrapeInterval)
-			cases = append(cases, &testCase{
-				query: query,
-				qt:    "range query",
-				res1:  res1,
-				res2:  res2,
-				err1:  err1,
-				err2:  err2,
-			})
+			// Resolve the oracle once per query and compare every candidate to it.
+			oracleInstant, oracleInstantErr := c1.Query(query, queryEnd)
+			oracleRange, oracleRangeErr := c1.QueryRange(query, start, queryEnd, scrapeInterval)
+			for _, cand := range candidates {
+				res2, err2 := cand.client.Query(query, queryEnd)
+				cases = append(cases, &testCase{
+					query:    query,
+					qt:       "instant",
+					instance: cand.name,
+					res1:     oracleInstant,
+					res2:     res2,
+					err1:     oracleInstantErr,
+					err2:     err2,
+				})
+				res2, err2 = cand.client.QueryRange(query, start, queryEnd, scrapeInterval)
+				cases = append(cases, &testCase{
+					query:    query,
+					qt:       "range query",
+					instance: cand.name,
+					res1:     oracleRange,
+					res2:     res2,
+					err1:     oracleRangeErr,
+					err2:     err2,
+				})
+			}
 		}
 
 		for _, m := range matchers {
@@ -631,33 +723,36 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 			queryEnd := start.Add(fuzzyTime * time.Millisecond)
 			res1, err := c1.Series([]string{m}, start, queryEnd)
 			require.NoError(t, err)
-			res2, err := c2.Series([]string{m}, start, queryEnd)
-			require.NoError(t, err)
-			cases = append(cases, &testCase{
-				query: m,
-				qt:    "get series",
-				sres1: res1,
-				sres2: res2,
-			})
+			for _, cand := range candidates {
+				res2, err := cand.client.Series([]string{m}, start, queryEnd)
+				require.NoError(t, err)
+				cases = append(cases, &testCase{
+					query:    m,
+					qt:       "get series",
+					instance: cand.name,
+					sres1:    res1,
+					sres2:    res2,
+				})
+			}
 		}
 
 		failures := 0
 		for i, tc := range cases {
 			if tc.err1 != nil || tc.err2 != nil {
 				if !sameErrorClass(tc.err1, tc.err2) {
-					t.Logf("case %d error mismatch.\n%s: %s\nerr1: %v\nerr2: %v\n", i, tc.qt, tc.query, tc.err1, tc.err2)
+					t.Logf("case %d [%s] error mismatch.\n%s: %s\nerr1: %v\nerr2: %v\n", i, tc.instance, tc.qt, tc.query, tc.err1, tc.err2)
 					failures++
 				}
 			} else if shouldUseSampleNumComparer(tc.query) {
 				if !cmp.Equal(tc.res1, tc.res2, sampleNumComparer) {
-					t.Logf("case %d # of samples mismatch.\n%s: %s\nres1: %s\nres2: %s\n", i, tc.qt, tc.query, tc.res1.String(), tc.res2.String())
+					t.Logf("case %d [%s] # of samples mismatch.\n%s: %s\nres1: %s\nres2: %s\n", i, tc.instance, tc.qt, tc.query, tc.res1.String(), tc.res2.String())
 					failures++
 				}
 			} else if !cmp.Equal(tc.res1, tc.res2, comparer) {
-				t.Logf("case %d results mismatch.\n%s: %s\nres1: %s\nres2: %s\n", i, tc.qt, tc.query, tc.res1.String(), tc.res2.String())
+				t.Logf("case %d [%s] results mismatch.\n%s: %s\nres1: %s\nres2: %s\n", i, tc.instance, tc.qt, tc.query, tc.res1.String(), tc.res2.String())
 				failures++
 			} else if !cmp.Equal(tc.sres1, tc.sres2, labelSetsComparer) {
-				t.Logf("case %d results mismatch.\n%s: %s\nsres1: %s\nsres2: %s\n", i, tc.qt, tc.query, tc.sres1, tc.sres2)
+				t.Logf("case %d [%s] results mismatch.\n%s: %s\nsres1: %s\nsres2: %s\n", i, tc.instance, tc.qt, tc.query, tc.sres1, tc.sres2)
 				failures++
 			}
 		}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6670,7 +6670,7 @@ func TestExpendedPostingsCacheIsolation(t *testing.T) {
 	cfg.BlocksStorageConfig.TSDB.BlockRanges = []time.Duration{2 * time.Hour}
 	cfg.LifecyclerConfig.JoinAfter = 0
 	cfg.BlocksStorageConfig.TSDB.PostingsCache = cortex_tsdb.TSDBPostingsCacheConfig{
-		SeedSize: 3, // lets make sure all metric names collide
+		LabelCounterSize: 3, // lets make sure all metric names collide
 		Head: cortex_tsdb.PostingsCacheConfig{
 			Enabled:  true,
 			Ttl:      time.Hour,
@@ -7082,9 +7082,15 @@ func TestExpendedPostingsCache(t *testing.T) {
 			extraMatcher := []struct {
 				matchers       []*client.LabelMatcher
 				expectedLenght int
+				// invalidatedByPush is true if pushing a series with a="new" below should
+				// invalidate this matcher's cached head entry. Postings are invalidated per
+				// label: an equality matcher is keyed by value, so a="new" does not touch the
+				// a="aaa1" entry; a regex matcher is keyed by name, so a="new" invalidates it.
+				invalidatedByPush bool
 			}{
 				{
-					expectedLenght: 10,
+					expectedLenght:    10,
+					invalidatedByPush: true,
 					matchers: []*client.LabelMatcher{
 						{
 							Type:  client.REGEX_MATCH,
@@ -7094,7 +7100,8 @@ func TestExpendedPostingsCache(t *testing.T) {
 					},
 				},
 				{
-					expectedLenght: 1,
+					expectedLenght:    1,
+					invalidatedByPush: false,
 					matchers: []*client.LabelMatcher{
 						{
 							Type:  client.EQUAL,
@@ -7171,9 +7178,9 @@ func TestExpendedPostingsCache(t *testing.T) {
 			// Query block and head
 			require.Equal(t, postingsForMatchersCalls.Load(), int64(c.expectedBlockPostingCall+c.expectedHeadPostingCall))
 
-			// Adding a metric for the first metric name so we expire all caches for that metric name
+			// Adding a series with the queried label "a" to expire the caches for that metric name and label
 			_, err = i.Push(ctx, cortexpb.ToWriteRequest(
-				[]labels.Labels{labels.FromStrings(labels.MetricName, metricNames[0], "extra", "1")}, []cortexpb.Sample{{Value: 2, TimestampMs: 4 * 60 * 60 * 1000}}, nil, nil, cortexpb.API))
+				[]labels.Labels{labels.FromStrings(labels.MetricName, metricNames[0], "a", "new", "extra", "1")}, []cortexpb.Sample{{Value: 2, TimestampMs: 4 * 60 * 60 * 1000}}, nil, nil, cortexpb.API))
 			require.NoError(t, err)
 
 			for in, name := range metricNames {
@@ -7182,8 +7189,11 @@ func TestExpendedPostingsCache(t *testing.T) {
 
 					require.Len(t, runQuery(t, ctx, i, append(m.matchers, &client.LabelMatcher{Type: client.EQUAL, Name: labels.MetricName, Value: name})), m.expectedLenght)
 
-					// first metric name should be expired
-					if in == 0 {
+					// Only the first metric name had a series pushed, and only matchers whose
+					// tracked slot was bumped by that push are invalidated (see invalidatedByPush).
+					// An invalidated head entry refetches; the block stays cached, so everything
+					// else is served from cache.
+					if in == 0 && m.invalidatedByPush {
 						// Query only head as the block is already cached and the head was expired
 						require.Equal(t, postingsForMatchersCalls.Load(), int64(c.expectedHeadPostingCall))
 					} else {

--- a/pkg/storage/tsdb/expanded_postings_cache.go
+++ b/pkg/storage/tsdb/expanded_postings_cache.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -15,11 +14,13 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/segmentio/fasthash/fnv1a"
+	"go.uber.org/atomic"
 
 	"github.com/cortexproject/cortex/pkg/util/extract"
 	logutil "github.com/cortexproject/cortex/pkg/util/log"
@@ -31,11 +32,8 @@ var (
 )
 
 const (
-	// size of the seed array. Each seed is a 64bits int (8 bytes)
-	// totaling 16mb
-	seedArraySize = 2 * 1024 * 1024
-
-	numOfSeedsStripes = 512
+	// size of the label-count array. Each count is a uint32 (4 bytes) totaling 16MB.
+	labelCounterArraySize = 4_000_000
 )
 
 type ExpandedPostingsCacheMetrics struct {
@@ -99,9 +97,13 @@ type TSDBPostingsCacheConfig struct {
 	// when unset.
 	LazyMatcherComplexCostRatio int `yaml:"lazy_matcher_complex_cost_ratio"`
 
+	// LabelCounterSize is the number of counts stored in the label counter used
+	// for head cache invalidation. Note one label counter is shared by all tenants.
+	// defaults to 4_000_000 when unset.
+	LabelCounterSize uint `yaml:"label_counter_size"`
+
 	// The configurations below are used only for testing purpose
 	PostingsForMatchers func(ctx context.Context, ix tsdb.IndexReader, ms ...*labels.Matcher) (index.Postings, error) `yaml:"-"`
-	SeedSize            int                                                                                           `yaml:"-"`
 	timeNow             func() time.Time                                                                              `yaml:"-"`
 }
 
@@ -118,6 +120,7 @@ func (cfg *TSDBPostingsCacheConfig) RegisterFlagsWithPrefix(prefix string, f *fl
 	f.IntVar(&cfg.LazyMatcherMaxCardinality, prefix+"expanded_postings_cache.head.lazy-matcher-max-cardinality", 0, "[EXPERIMENTAL] Maximum label cardinality for deferring regex matchers on the head block. When a regex matcher targets a label with more unique values than this threshold, it is applied lazily during iteration instead of postings lookup. 0 disables.")
 	f.IntVar(&cfg.LazyMatcherSimpleCostRatio, prefix+"expanded_postings_cache.head.lazy-matcher-simple-cost-ratio", defaultSimpleCostRatio, "[EXPERIMENTAL] Cardinality:postings ratio above which a simple regex (prefix-only, single contains) is deferred to lazy iteration. Lower = more aggressive deferral. Calibrated empirically; defaults to 6.")
 	f.IntVar(&cfg.LazyMatcherComplexCostRatio, prefix+"expanded_postings_cache.head.lazy-matcher-complex-cost-ratio", defaultComplexCostRatio, "[EXPERIMENTAL] Cardinality:postings ratio above which a complex regex (multi-substring, capture groups, character classes) is deferred. Lower = more aggressive deferral. Calibrated empirically; defaults to 2.")
+	f.UintVar(&cfg.LabelCounterSize, prefix+"expanded_postings_cache.head.label-counter-size", labelCounterArraySize, "The number of counts stored in the label counter used for head cache invalidation. Note one label counter is shared by all tenants. 0 sets to the default of 4_000_000.")
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
@@ -129,19 +132,19 @@ func (cfg *PostingsCacheConfig) RegisterFlagsWithPrefix(prefix, block string, f 
 }
 
 type ExpandedPostingsCacheFactory struct {
-	seedByHash *seedByHash
-	cfg        TSDBPostingsCacheConfig
+	labelCounter *labelCounter
+	cfg          TSDBPostingsCacheConfig
 }
 
 func NewExpandedPostingsCacheFactory(cfg TSDBPostingsCacheConfig) *ExpandedPostingsCacheFactory {
 	if cfg.Head.Enabled || cfg.Blocks.Enabled {
-		if cfg.SeedSize == 0 {
-			cfg.SeedSize = seedArraySize
+		if cfg.LabelCounterSize == 0 {
+			cfg.LabelCounterSize = labelCounterArraySize
 		}
 		logutil.WarnExperimentalUse("expanded postings cache")
 		return &ExpandedPostingsCacheFactory{
-			cfg:        cfg,
-			seedByHash: newSeedByHash(cfg.SeedSize),
+			cfg:          cfg,
+			labelCounter: newLabelCounter(cfg.LabelCounterSize),
 		}
 	}
 
@@ -149,7 +152,7 @@ func NewExpandedPostingsCacheFactory(cfg TSDBPostingsCacheConfig) *ExpandedPosti
 }
 
 func (f *ExpandedPostingsCacheFactory) NewExpandedPostingsCache(userId string, metrics *ExpandedPostingsCacheMetrics) ExpandedPostingsCache {
-	return newBlocksPostingsForMatchersCache(userId, f.cfg, metrics, f.seedByHash)
+	return newBlocksPostingsForMatchersCache(userId, f.cfg, metrics, f.labelCounter)
 }
 
 type ExpandedPostingsCache interface {
@@ -171,8 +174,8 @@ type blocksPostingsForMatchersCache struct {
 	lazyMatcherCfg        lazyMatcherConfig
 	labelCardinalityCache *expirable.LRU[string, int]
 
-	metrics    *ExpandedPostingsCacheMetrics
-	seedByHash *seedByHash
+	metrics      *ExpandedPostingsCacheMetrics
+	labelCounter *labelCounter
 }
 
 func (c *blocksPostingsForMatchersCache) Clear() {
@@ -180,7 +183,7 @@ func (c *blocksPostingsForMatchersCache) Clear() {
 	c.blocksCache.clear()
 }
 
-func newBlocksPostingsForMatchersCache(userId string, cfg TSDBPostingsCacheConfig, metrics *ExpandedPostingsCacheMetrics, seedByHash *seedByHash) ExpandedPostingsCache {
+func newBlocksPostingsForMatchersCache(userId string, cfg TSDBPostingsCacheConfig, metrics *ExpandedPostingsCacheMetrics, labelCounter *labelCounter) ExpandedPostingsCache {
 	if cfg.PostingsForMatchers == nil {
 		cfg.PostingsForMatchers = tsdb.PostingsForMatchers
 	}
@@ -201,7 +204,7 @@ func newBlocksPostingsForMatchersCache(userId string, cfg TSDBPostingsCacheConfi
 		},
 		labelCardinalityCache: newLabelCardinalityCache(),
 		metrics:               metrics,
-		seedByHash:            seedByHash,
+		labelCounter:          labelCounter,
 		userId:                userId,
 	}
 }
@@ -211,7 +214,15 @@ func (c *blocksPostingsForMatchersCache) ExpireSeries(metric labels.Labels) {
 	if err != nil {
 		return
 	}
-	c.seedByHash.incrementSeed(c.userId, metricName)
+
+	metric.Range(func(label labels.Label) {
+		if label.Name == model.MetricNameLabel {
+			c.labelCounter.increment(c.userId, metricName)
+		} else {
+			c.labelCounter.increment(c.userId, metricName, label.Name, label.Value)
+			c.labelCounter.increment(c.userId, metricName, label.Name)
+		}
+	})
 }
 
 func (c *blocksPostingsForMatchersCache) PurgeExpiredItems() {
@@ -228,15 +239,17 @@ func (c *blocksPostingsForMatchersCache) PostingsForMatchers(ctx context.Context
 }
 
 func (c *blocksPostingsForMatchersCache) fetchPostings(blockID ulid.ULID, ix tsdb.IndexReader, ms ...*labels.Matcher) func(context.Context) (index.Postings, error) {
-	var seed string
 	cache := c.blocksCache
+	isHead := isHeadBlock(blockID)
+	var metricName string
 
-	// If is a head block, lets add the seed on the cache key so we can
-	// invalidate the cache when new series are created for this metric name
-	if isHeadBlock(blockID) {
+	// If is a head block, we snapshot the per-label write counts so we can invalidate
+	// the cache when new series are created for this metric name.
+	if isHead {
 		cache = c.headCache
 		if cache.cfg.Enabled {
-			metricName, ok := metricNameFromMatcher(ms)
+			var ok bool
+			metricName, ok = metricNameFromMatcher(ms)
 			// Lets not cache head if we don;t find an equal matcher for the label __name__
 			if !ok {
 				c.metrics.NonCacheableQueries.WithLabelValues(cache.name).Inc()
@@ -244,8 +257,6 @@ func (c *blocksPostingsForMatchersCache) fetchPostings(blockID ulid.ULID, ix tsd
 					return tsdb.PostingsForMatchers(ctx, ix, ms...)
 				}
 			}
-
-			seed = c.getSeedForMetricName(metricName)
 		}
 	}
 
@@ -258,7 +269,7 @@ func (c *blocksPostingsForMatchersCache) fetchPostings(blockID ulid.ULID, ix tsd
 
 	c.metrics.CacheRequests.WithLabelValues(cache.name).Inc()
 
-	fetch := func() ([]storage.SeriesRef, int64, error) {
+	fetch := func() ([]storage.SeriesRef, int64, func() bool, error) {
 		// Use a context with timeout instead of context.Background() to prevent runaway queries.
 		// This promise is maybe shared across calls, so we can't use any single caller's context.
 		// However, we need a timeout to prevent the fetch from running indefinitely when all
@@ -270,13 +281,23 @@ func (c *blocksPostingsForMatchersCache) fetchPostings(blockID ulid.ULID, ix tsd
 			defer cancel()
 		}
 
+		// Count-based invalidation only applies to the head cache: series are created
+		// there and bump the per-label counts. Block entries are immutable, so they
+		// get a nil validator and rely solely on TTL expiry.
+		var stillValid func() bool
+		var snapshotSize int64
+		if isHead {
+			stillValid, snapshotSize = c.snapshotCounts(metricName, ms...)
+		}
+
 		// For head blocks, try to avoid expensive regex scans by splitting matchers:
 		// resolve postings with selective matchers only, then filter by regex lazily.
-		if isHeadBlock(blockID) && c.lazyMatcherCfg.MaxCardinality > 0 {
+		if isHead && c.lazyMatcherCfg.MaxCardinality > 0 {
 			selectMs, lazyMs := splitMatchersForHeadWithConfig(fetchCtx, ix, ms, c.lazyMatcherCfg, c.labelCardinalityCache)
 			if len(lazyMs) > 0 {
 				c.metrics.LazyMatcherQueries.Inc()
-				return c.fetchWithLazyMatchers(fetchCtx, ix, selectMs, lazyMs)
+				series, size, err := c.fetchWithLazyMatchers(fetchCtx, ix, selectMs, lazyMs)
+				return series, size + snapshotSize, stillValid, err
 			}
 		}
 
@@ -284,19 +305,80 @@ func (c *blocksPostingsForMatchersCache) fetchPostings(blockID ulid.ULID, ix tsd
 
 		if err == nil {
 			ids, err := index.ExpandPostings(postings)
-			return ids, int64(len(ids) * 8), err
+			return ids, int64(len(ids)*8) + snapshotSize, stillValid, err
 		}
 
-		return nil, 0, err
+		return nil, 0, stillValid, err
 	}
 
-	key := cacheKey(seed, blockID, ms...)
+	key := cacheKey(blockID, ms...)
 	promise, loaded := cache.getPromiseForKey(key, fetch)
 	if loaded {
 		c.metrics.CacheHits.WithLabelValues(cache.name).Inc()
 	}
 
 	return c.result(promise)
+}
+
+// snapshotCounts records the current per-label write counts for the matchers so the
+// cached entry can later be validated. Each matcher's slot MUST be keyed identically to
+// the increments ExpireSeries performs, or the snapshot would read a slot that never moves
+// and keep stale entries alive forever:
+//   - The __name__ matcher is keyed by (metricName) alone. Every series for the metric
+//     carries this exact value, so its value slot and name slot would be identical; we use
+//     the single slot and ExpireSeries bumps only that one for __name__.
+//   - Other equality matchers are keyed by value, (metricName, labelName, labelValue),
+//     since a matching series carries exactly that value. This lets an entry survive churn
+//     of the same label at a different value (e.g. job="api" is unaffected when a job="web"
+//     series is created).
+//   - All other matchers are keyed by name only, (metricName, labelName), since they can
+//     match many values; any series carrying the label must be able to invalidate them.
+//
+// For non-__name__ labels ExpireSeries bumps both the value slot and the name slot, so
+// whichever granularity a matcher snapshots, a matching series moves it.
+//
+// The returned stillValid closure reports whether the entry is still complete: it holds
+// as long as ANY tracked count is unchanged, because a series matching all matchers bumps
+// every tracked slot, so all-counts-changed is the only proof of a possibly-missed series.
+//
+// Empty-matching matchers (e.g. foo!="x", foo=~".*") match series that lack the label, and
+// such a series need not carry it, so their count could stay frozen while a matching series
+// was created. They cannot vouch for the entry and are skipped. The head gate guarantees an
+// equality __name__ matcher, which never matches "", so at least one snapshot always remains.
+func (c *blocksPostingsForMatchersCache) snapshotCounts(metricName string, ms ...*labels.Matcher) (func() bool, int64) {
+	snapshots := make([]countSnapshot, 0, len(ms))
+	for _, matcher := range ms {
+		// Matchers that can match an absent label cannot vouch for the entry.
+		if matcher.Matches("") {
+			continue
+		}
+
+		var slot uint32
+		if matcher.Name == model.MetricNameLabel {
+			slot = c.labelCounter.slotIndex(c.userId, metricName)
+		} else if matcher.Type == labels.MatchEqual {
+			slot = c.labelCounter.slotIndex(c.userId, metricName, matcher.Name, matcher.Value)
+		} else {
+			slot = c.labelCounter.slotIndex(c.userId, metricName, matcher.Name)
+		}
+		snapshots = append(snapshots, countSnapshot{
+			index: slot,
+			count: c.labelCounter.readSlot(slot),
+		})
+	}
+	stillValid := func() bool {
+		for _, snapshot := range snapshots {
+			newCount := c.labelCounter.readSlot(snapshot.index)
+			if newCount == snapshot.count {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	// countSnapshot is two uint32s (8 bytes total)
+	return stillValid, int64(len(snapshots) * 8)
 }
 
 func (c *blocksPostingsForMatchersCache) result(ce *cacheEntryPromise[[]storage.SeriesRef]) func(ctx context.Context) (index.Postings, error) {
@@ -381,11 +463,7 @@ func (c *blocksPostingsForMatchersCache) fetchWithLazyMatchers(ctx context.Conte
 	return filtered, int64(len(filtered) * 8), nil
 }
 
-func (c *blocksPostingsForMatchersCache) getSeedForMetricName(metricName string) string {
-	return c.seedByHash.getSeed(c.userId, metricName)
-}
-
-func cacheKey(seed string, blockID ulid.ULID, ms ...*labels.Matcher) string {
+func cacheKey(blockID ulid.ULID, ms ...*labels.Matcher) string {
 	slices.SortFunc(ms, func(i, j *labels.Matcher) int {
 		if i.Type != j.Type {
 			return int(i.Type - j.Type)
@@ -404,14 +482,12 @@ func cacheKey(seed string, blockID ulid.ULID, ms ...*labels.Matcher) string {
 		sepLen  = 1
 	)
 
-	size := len(seed) + len(blockID.String()) + 2*sepLen
+	size := len(blockID.String()) + sepLen
 	for _, m := range ms {
 		size += len(m.Name) + len(m.Value) + typeLen + sepLen
 	}
 	sb := strings.Builder{}
 	sb.Grow(size)
-	sb.WriteString(seed)
-	sb.WriteByte('|')
 	sb.WriteString(blockID.String())
 	sb.WriteByte('|')
 	for _, m := range ms {
@@ -430,7 +506,7 @@ func isHeadBlock(blockID ulid.ULID) bool {
 
 func metricNameFromMatcher(ms []*labels.Matcher) (string, bool) {
 	for _, m := range ms {
-		if m.Name == labels.MetricName && m.Type == labels.MatchEqual {
+		if m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual {
 			return m.Value, true
 		}
 	}
@@ -438,34 +514,32 @@ func metricNameFromMatcher(ms []*labels.Matcher) (string, bool) {
 	return "", false
 }
 
-type seedByHash struct {
-	strippedLock []sync.RWMutex
-	seedByHash   []int
+// labelCounter tracks, per (tenant, label) hash slot, how many times a series carrying that
+// label has been created or deleted. Cache entries snapshot these counts to detect when a
+// matching series may have been added since the entry was stored. Collisions are safe: two
+// distinct labels sharing a slot only cause extra (never missed) invalidations.
+type labelCounter struct {
+	counts []atomic.Uint32
 }
 
-func newSeedByHash(size int) *seedByHash {
-	return &seedByHash{
-		seedByHash:   make([]int, size),
-		strippedLock: make([]sync.RWMutex, numOfSeedsStripes),
+func newLabelCounter(size uint) *labelCounter {
+	return &labelCounter{
+		counts: make([]atomic.Uint32, size),
 	}
 }
 
-func (s *seedByHash) getSeed(userId string, v string) string {
-	h := memHashString(userId, v)
-	i := h % uint64(len(s.seedByHash))
-	l := i % uint64(len(s.strippedLock))
-	s.strippedLock[l].RLock()
-	defer s.strippedLock[l].RUnlock()
-	return strconv.Itoa(s.seedByHash[i])
+func (s *labelCounter) slotIndex(userId string, dimensions ...string) uint32 {
+	hash := memHashStrings(userId, dimensions...)
+	return hash % uint32(len(s.counts))
 }
 
-func (s *seedByHash) incrementSeed(userId string, v string) {
-	h := memHashString(userId, v)
-	i := h % uint64(len(s.seedByHash))
-	l := i % uint64(len(s.strippedLock))
-	s.strippedLock[l].Lock()
-	defer s.strippedLock[l].Unlock()
-	s.seedByHash[i]++
+func (s *labelCounter) readSlot(index uint32) uint32 {
+	return s.counts[index].Load()
+}
+
+func (s *labelCounter) increment(userId string, dimensions ...string) {
+	i := s.slotIndex(userId, dimensions...)
+	s.counts[i].Inc()
 }
 
 type lruCache[V any] struct {
@@ -524,14 +598,14 @@ func (c *lruCache[V]) size() int {
 	return c.cached.Len()
 }
 
-func (c *lruCache[V]) getPromiseForKey(k string, fetch func() (V, int64, error)) (*cacheEntryPromise[V], bool) {
+func (c *lruCache[V]) getPromiseForKey(k string, fetch func() (V, int64, func() bool, error)) (*cacheEntryPromise[V], bool) {
 	r := &cacheEntryPromise[V]{
 		done: make(chan struct{}),
 	}
 	defer close(r.done)
 
 	if !c.cfg.Enabled {
-		r.v, _, r.err = fetch()
+		r.v, _, _, r.err = fetch()
 		return r, false
 	}
 
@@ -539,7 +613,7 @@ func (c *lruCache[V]) getPromiseForKey(k string, fetch func() (V, int64, error))
 
 	if !ok {
 		c.metrics.CacheMiss.WithLabelValues(c.name, "miss").Inc()
-		r.v, r.sizeBytes, r.err = fetch()
+		r.v, r.sizeBytes, r.stillValid, r.err = fetch()
 		r.sizeBytes += int64(len(k))
 		r.ts = c.timeNow()
 		c.created(k, r.sizeBytes)
@@ -547,20 +621,29 @@ func (c *lruCache[V]) getPromiseForKey(k string, fetch func() (V, int64, error))
 	}
 
 	if ok {
+		entry := loaded.(*cacheEntryPromise[V])
 		// If the promise is already in the cache, lets wait it to fetch the data.
-		<-loaded.(*cacheEntryPromise[V]).done
+		<-entry.done
 
 		// LRU: move to back on access
 		c.cachedMtx.Lock()
-		if elem := loaded.(*cacheEntryPromise[V]).elem; elem != nil {
-			c.cached.MoveToBack(elem)
+		if entry.elem != nil {
+			c.cached.MoveToBack(entry.elem)
 		}
 		c.cachedMtx.Unlock()
 
-		// If is cached but is expired, lets try to replace the cache value.
-		if loaded.(*cacheEntryPromise[V]).isExpired(c.cfg.Ttl, c.timeNow()) && c.cachedValues.CompareAndSwap(k, loaded, r) {
-			c.metrics.CacheMiss.WithLabelValues(c.name, "expired").Inc()
-			r.v, r.sizeBytes, r.err = fetch()
+		// A nil stillValid means the entry has no count-based invalidation (blocks
+		// cache, or callers that don't snapshot counts); only time expiry applies.
+		invalidated := entry.stillValid != nil && !entry.stillValid()
+
+		// If is cached but is expired or invalidated, lets try to replace the cache value.
+		if (invalidated || entry.isExpired(c.cfg.Ttl, c.timeNow())) && c.cachedValues.CompareAndSwap(k, loaded, r) {
+			if invalidated {
+				c.metrics.CacheMiss.WithLabelValues(c.name, "invalidated").Inc()
+			} else {
+				c.metrics.CacheMiss.WithLabelValues(c.name, "expired").Inc()
+			}
+			r.v, r.sizeBytes, r.stillValid, r.err = fetch()
 			r.sizeBytes += int64(len(k))
 			c.updateSize(loaded.(*cacheEntryPromise[V]).sizeBytes, r.sizeBytes)
 			r.ts = c.timeNow()
@@ -644,6 +727,8 @@ type cacheEntryPromise[V any] struct {
 	sizeBytes int64
 	elem      *list.Element
 
+	stillValid func() bool
+
 	done chan struct{}
 	v    V
 	err  error
@@ -655,7 +740,15 @@ func (ce *cacheEntryPromise[V]) isExpired(ttl time.Duration, now time.Time) bool
 	return r >= ttl
 }
 
-func memHashString(userId, v string) uint64 {
-	h := fnv1a.HashString64(userId)
-	return fnv1a.AddString64(h, v)
+func memHashStrings(userId string, dimensions ...string) uint32 {
+	h := fnv1a.HashString32(userId)
+	for _, d := range dimensions {
+		h = fnv1a.AddString32(h, d)
+	}
+	return h
+}
+
+type countSnapshot struct {
+	index uint32 // slot in labelCounter
+	count uint32 // value at store time
 }

--- a/pkg/storage/tsdb/expanded_postings_cache.go
+++ b/pkg/storage/tsdb/expanded_postings_cache.go
@@ -6,15 +6,16 @@ import (
 	"errors"
 	"flag"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
@@ -31,11 +32,8 @@ var (
 )
 
 const (
-	// size of the seed array. Each seed is a 64bits int (8 bytes)
-	// totaling 16mb
-	seedArraySize = 2 * 1024 * 1024
-
-	numOfSeedsStripes = 512
+	// size of the label-count array. Each count is a uint32 (4 bytes) totaling 16MB.
+	labelCounterArraySize = 4_000_000
 )
 
 type ExpandedPostingsCacheMetrics struct {
@@ -99,9 +97,13 @@ type TSDBPostingsCacheConfig struct {
 	// when unset.
 	LazyMatcherComplexCostRatio int `yaml:"lazy_matcher_complex_cost_ratio"`
 
+	// LabelCounterSize is the number of counts stored in the label counter used
+	// for head cache invalidation. Note one label counter is shared by all tenants.
+	// defaults to 4_000_000 when unset.
+	LabelCounterSize uint `yaml:"label_counter_size"`
+
 	// The configurations below are used only for testing purpose
 	PostingsForMatchers func(ctx context.Context, ix tsdb.IndexReader, ms ...*labels.Matcher) (index.Postings, error) `yaml:"-"`
-	SeedSize            int                                                                                           `yaml:"-"`
 	timeNow             func() time.Time                                                                              `yaml:"-"`
 }
 
@@ -118,6 +120,7 @@ func (cfg *TSDBPostingsCacheConfig) RegisterFlagsWithPrefix(prefix string, f *fl
 	f.IntVar(&cfg.LazyMatcherMaxCardinality, prefix+"expanded_postings_cache.head.lazy-matcher-max-cardinality", 0, "[EXPERIMENTAL] Maximum label cardinality for deferring regex matchers on the head block. When a regex matcher targets a label with more unique values than this threshold, it is applied lazily during iteration instead of postings lookup. 0 disables.")
 	f.IntVar(&cfg.LazyMatcherSimpleCostRatio, prefix+"expanded_postings_cache.head.lazy-matcher-simple-cost-ratio", defaultSimpleCostRatio, "[EXPERIMENTAL] Cardinality:postings ratio above which a simple regex (prefix-only, single contains) is deferred to lazy iteration. Lower = more aggressive deferral. Calibrated empirically; defaults to 6.")
 	f.IntVar(&cfg.LazyMatcherComplexCostRatio, prefix+"expanded_postings_cache.head.lazy-matcher-complex-cost-ratio", defaultComplexCostRatio, "[EXPERIMENTAL] Cardinality:postings ratio above which a complex regex (multi-substring, capture groups, character classes) is deferred. Lower = more aggressive deferral. Calibrated empirically; defaults to 2.")
+	f.UintVar(&cfg.LabelCounterSize, prefix+"expanded_postings_cache.head.label-counter-size", labelCounterArraySize, "The number of counts stored in the label counter used for head cache invalidation. Note one label counter is shared by all tenants. 0 sets to the default of 4_000_000.")
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
@@ -129,19 +132,19 @@ func (cfg *PostingsCacheConfig) RegisterFlagsWithPrefix(prefix, block string, f 
 }
 
 type ExpandedPostingsCacheFactory struct {
-	seedByHash *seedByHash
-	cfg        TSDBPostingsCacheConfig
+	labelCounter *labelCounter
+	cfg          TSDBPostingsCacheConfig
 }
 
 func NewExpandedPostingsCacheFactory(cfg TSDBPostingsCacheConfig) *ExpandedPostingsCacheFactory {
 	if cfg.Head.Enabled || cfg.Blocks.Enabled {
-		if cfg.SeedSize == 0 {
-			cfg.SeedSize = seedArraySize
+		if cfg.LabelCounterSize == 0 {
+			cfg.LabelCounterSize = labelCounterArraySize
 		}
 		logutil.WarnExperimentalUse("expanded postings cache")
 		return &ExpandedPostingsCacheFactory{
-			cfg:        cfg,
-			seedByHash: newSeedByHash(cfg.SeedSize),
+			cfg:          cfg,
+			labelCounter: newLabelCounter(cfg.LabelCounterSize),
 		}
 	}
 
@@ -149,7 +152,7 @@ func NewExpandedPostingsCacheFactory(cfg TSDBPostingsCacheConfig) *ExpandedPosti
 }
 
 func (f *ExpandedPostingsCacheFactory) NewExpandedPostingsCache(userId string, metrics *ExpandedPostingsCacheMetrics) ExpandedPostingsCache {
-	return newBlocksPostingsForMatchersCache(userId, f.cfg, metrics, f.seedByHash)
+	return newBlocksPostingsForMatchersCache(userId, f.cfg, metrics, f.labelCounter)
 }
 
 type ExpandedPostingsCache interface {
@@ -171,8 +174,8 @@ type blocksPostingsForMatchersCache struct {
 	lazyMatcherCfg        lazyMatcherConfig
 	labelCardinalityCache *expirable.LRU[string, int]
 
-	metrics    *ExpandedPostingsCacheMetrics
-	seedByHash *seedByHash
+	metrics      *ExpandedPostingsCacheMetrics
+	labelCounter *labelCounter
 }
 
 func (c *blocksPostingsForMatchersCache) Clear() {
@@ -180,7 +183,7 @@ func (c *blocksPostingsForMatchersCache) Clear() {
 	c.blocksCache.clear()
 }
 
-func newBlocksPostingsForMatchersCache(userId string, cfg TSDBPostingsCacheConfig, metrics *ExpandedPostingsCacheMetrics, seedByHash *seedByHash) ExpandedPostingsCache {
+func newBlocksPostingsForMatchersCache(userId string, cfg TSDBPostingsCacheConfig, metrics *ExpandedPostingsCacheMetrics, labelCounter *labelCounter) ExpandedPostingsCache {
 	if cfg.PostingsForMatchers == nil {
 		cfg.PostingsForMatchers = tsdb.PostingsForMatchers
 	}
@@ -201,7 +204,7 @@ func newBlocksPostingsForMatchersCache(userId string, cfg TSDBPostingsCacheConfi
 		},
 		labelCardinalityCache: newLabelCardinalityCache(),
 		metrics:               metrics,
-		seedByHash:            seedByHash,
+		labelCounter:          labelCounter,
 		userId:                userId,
 	}
 }
@@ -211,7 +214,15 @@ func (c *blocksPostingsForMatchersCache) ExpireSeries(metric labels.Labels) {
 	if err != nil {
 		return
 	}
-	c.seedByHash.incrementSeed(c.userId, metricName)
+
+	metric.Range(func(label labels.Label) {
+		if label.Name == model.MetricNameLabel {
+			c.labelCounter.increment(c.userId, metricName)
+		} else {
+			c.labelCounter.increment(c.userId, metricName, label.Name, label.Value)
+			c.labelCounter.increment(c.userId, metricName, label.Name)
+		}
+	})
 }
 
 func (c *blocksPostingsForMatchersCache) PurgeExpiredItems() {
@@ -228,15 +239,17 @@ func (c *blocksPostingsForMatchersCache) PostingsForMatchers(ctx context.Context
 }
 
 func (c *blocksPostingsForMatchersCache) fetchPostings(blockID ulid.ULID, ix tsdb.IndexReader, ms ...*labels.Matcher) func(context.Context) (index.Postings, error) {
-	var seed string
 	cache := c.blocksCache
+	isHead := isHeadBlock(blockID)
+	var metricName string
 
-	// If is a head block, lets add the seed on the cache key so we can
-	// invalidate the cache when new series are created for this metric name
-	if isHeadBlock(blockID) {
+	// If is a head block, we snapshot the per-label write counts so we can invalidate
+	// the cache when new series are created for this metric name.
+	if isHead {
 		cache = c.headCache
 		if cache.cfg.Enabled {
-			metricName, ok := metricNameFromMatcher(ms)
+			var ok bool
+			metricName, ok = metricNameFromMatcher(ms)
 			// Lets not cache head if we don;t find an equal matcher for the label __name__
 			if !ok {
 				c.metrics.NonCacheableQueries.WithLabelValues(cache.name).Inc()
@@ -244,8 +257,6 @@ func (c *blocksPostingsForMatchersCache) fetchPostings(blockID ulid.ULID, ix tsd
 					return tsdb.PostingsForMatchers(ctx, ix, ms...)
 				}
 			}
-
-			seed = c.getSeedForMetricName(metricName)
 		}
 	}
 
@@ -258,7 +269,7 @@ func (c *blocksPostingsForMatchersCache) fetchPostings(blockID ulid.ULID, ix tsd
 
 	c.metrics.CacheRequests.WithLabelValues(cache.name).Inc()
 
-	fetch := func() ([]storage.SeriesRef, int64, error) {
+	fetch := func() ([]storage.SeriesRef, int64, func() bool, error) {
 		// Use a context with timeout instead of context.Background() to prevent runaway queries.
 		// This promise is maybe shared across calls, so we can't use any single caller's context.
 		// However, we need a timeout to prevent the fetch from running indefinitely when all
@@ -270,13 +281,23 @@ func (c *blocksPostingsForMatchersCache) fetchPostings(blockID ulid.ULID, ix tsd
 			defer cancel()
 		}
 
+		// Count-based invalidation only applies to the head cache: series are created
+		// there and bump the per-label counts. Block entries are immutable, so they
+		// get a nil validator and rely solely on TTL expiry.
+		var stillValid func() bool
+		var snapshotSize int64
+		if isHead {
+			stillValid, snapshotSize = c.snapshotCounts(metricName, ms...)
+		}
+
 		// For head blocks, try to avoid expensive regex scans by splitting matchers:
 		// resolve postings with selective matchers only, then filter by regex lazily.
-		if isHeadBlock(blockID) && c.lazyMatcherCfg.MaxCardinality > 0 {
+		if isHead && c.lazyMatcherCfg.MaxCardinality > 0 {
 			selectMs, lazyMs := splitMatchersForHeadWithConfig(fetchCtx, ix, ms, c.lazyMatcherCfg, c.labelCardinalityCache)
 			if len(lazyMs) > 0 {
 				c.metrics.LazyMatcherQueries.Inc()
-				return c.fetchWithLazyMatchers(fetchCtx, ix, selectMs, lazyMs)
+				series, size, err := c.fetchWithLazyMatchers(fetchCtx, ix, selectMs, lazyMs)
+				return series, size + snapshotSize, stillValid, err
 			}
 		}
 
@@ -284,19 +305,80 @@ func (c *blocksPostingsForMatchersCache) fetchPostings(blockID ulid.ULID, ix tsd
 
 		if err == nil {
 			ids, err := index.ExpandPostings(postings)
-			return ids, int64(len(ids) * 8), err
+			return ids, int64(len(ids)*8) + snapshotSize, stillValid, err
 		}
 
-		return nil, 0, err
+		return nil, 0, stillValid, err
 	}
 
-	key := cacheKey(seed, blockID, ms...)
+	key := cacheKey(blockID, ms...)
 	promise, loaded := cache.getPromiseForKey(key, fetch)
 	if loaded {
 		c.metrics.CacheHits.WithLabelValues(cache.name).Inc()
 	}
 
 	return c.result(promise)
+}
+
+// snapshotCounts records the current per-label write counts for the matchers so the
+// cached entry can later be validated. Each matcher's slot MUST be keyed identically to
+// the increments ExpireSeries performs, or the snapshot would read a slot that never moves
+// and keep stale entries alive forever:
+//   - The __name__ matcher is keyed by (metricName) alone. Every series for the metric
+//     carries this exact value, so its value slot and name slot would be identical; we use
+//     the single slot and ExpireSeries bumps only that one for __name__.
+//   - Other equality matchers are keyed by value, (metricName, labelName, labelValue),
+//     since a matching series carries exactly that value. This lets an entry survive churn
+//     of the same label at a different value (e.g. job="api" is unaffected when a job="web"
+//     series is created).
+//   - All other matchers are keyed by name only, (metricName, labelName), since they can
+//     match many values; any series carrying the label must be able to invalidate them.
+//
+// For non-__name__ labels ExpireSeries bumps both the value slot and the name slot, so
+// whichever granularity a matcher snapshots, a matching series moves it.
+//
+// The returned stillValid closure reports whether the entry is still complete: it holds
+// as long as ANY tracked count is unchanged, because a series matching all matchers bumps
+// every tracked slot, so all-counts-changed is the only proof of a possibly-missed series.
+//
+// Empty-matching matchers (e.g. foo!="x", foo=~".*") match series that lack the label, and
+// such a series need not carry it, so their count could stay frozen while a matching series
+// was created. They cannot vouch for the entry and are skipped. The head gate guarantees an
+// equality __name__ matcher, which never matches "", so at least one snapshot always remains.
+func (c *blocksPostingsForMatchersCache) snapshotCounts(metricName string, ms ...*labels.Matcher) (func() bool, int64) {
+	snapshots := make([]countSnapshot, 0, len(ms))
+	for _, matcher := range ms {
+		// Matchers that can match an absent label cannot vouch for the entry.
+		if matcher.Matches("") {
+			continue
+		}
+
+		var slot uint32
+		if matcher.Name == model.MetricNameLabel {
+			slot = c.labelCounter.slotIndex(c.userId, metricName)
+		} else if matcher.Type == labels.MatchEqual {
+			slot = c.labelCounter.slotIndex(c.userId, metricName, matcher.Name, matcher.Value)
+		} else {
+			slot = c.labelCounter.slotIndex(c.userId, metricName, matcher.Name)
+		}
+		snapshots = append(snapshots, countSnapshot{
+			index: slot,
+			count: c.labelCounter.readSlot(slot),
+		})
+	}
+	stillValid := func() bool {
+		for _, snapshot := range snapshots {
+			newCount := c.labelCounter.readSlot(snapshot.index)
+			if newCount == snapshot.count {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	// countSnapshot is two uint32s (8 bytes total)
+	return stillValid, int64(len(snapshots) * 8)
 }
 
 func (c *blocksPostingsForMatchersCache) result(ce *cacheEntryPromise[[]storage.SeriesRef]) func(ctx context.Context) (index.Postings, error) {
@@ -381,11 +463,7 @@ func (c *blocksPostingsForMatchersCache) fetchWithLazyMatchers(ctx context.Conte
 	return filtered, int64(len(filtered) * 8), nil
 }
 
-func (c *blocksPostingsForMatchersCache) getSeedForMetricName(metricName string) string {
-	return c.seedByHash.getSeed(c.userId, metricName)
-}
-
-func cacheKey(seed string, blockID ulid.ULID, ms ...*labels.Matcher) string {
+func cacheKey(blockID ulid.ULID, ms ...*labels.Matcher) string {
 	slices.SortFunc(ms, func(i, j *labels.Matcher) int {
 		if i.Type != j.Type {
 			return int(i.Type - j.Type)
@@ -404,14 +482,12 @@ func cacheKey(seed string, blockID ulid.ULID, ms ...*labels.Matcher) string {
 		sepLen  = 1
 	)
 
-	size := len(seed) + len(blockID.String()) + 2*sepLen
+	size := len(blockID.String()) + sepLen
 	for _, m := range ms {
 		size += len(m.Name) + len(m.Value) + typeLen + sepLen
 	}
 	sb := strings.Builder{}
 	sb.Grow(size)
-	sb.WriteString(seed)
-	sb.WriteByte('|')
 	sb.WriteString(blockID.String())
 	sb.WriteByte('|')
 	for _, m := range ms {
@@ -430,7 +506,7 @@ func isHeadBlock(blockID ulid.ULID) bool {
 
 func metricNameFromMatcher(ms []*labels.Matcher) (string, bool) {
 	for _, m := range ms {
-		if m.Name == labels.MetricName && m.Type == labels.MatchEqual {
+		if m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual {
 			return m.Value, true
 		}
 	}
@@ -438,34 +514,32 @@ func metricNameFromMatcher(ms []*labels.Matcher) (string, bool) {
 	return "", false
 }
 
-type seedByHash struct {
-	strippedLock []sync.RWMutex
-	seedByHash   []int
+// labelCounter tracks, per (tenant, label) hash slot, how many times a series carrying that
+// label has been created or deleted. Cache entries snapshot these counts to detect when a
+// matching series may have been added since the entry was stored. Collisions are safe: two
+// distinct labels sharing a slot only cause extra (never missed) invalidations.
+type labelCounter struct {
+	counts []atomic.Uint32
 }
 
-func newSeedByHash(size int) *seedByHash {
-	return &seedByHash{
-		seedByHash:   make([]int, size),
-		strippedLock: make([]sync.RWMutex, numOfSeedsStripes),
+func newLabelCounter(size uint) *labelCounter {
+	return &labelCounter{
+		counts: make([]atomic.Uint32, size),
 	}
 }
 
-func (s *seedByHash) getSeed(userId string, v string) string {
-	h := memHashString(userId, v)
-	i := h % uint64(len(s.seedByHash))
-	l := i % uint64(len(s.strippedLock))
-	s.strippedLock[l].RLock()
-	defer s.strippedLock[l].RUnlock()
-	return strconv.Itoa(s.seedByHash[i])
+func (s *labelCounter) slotIndex(userId string, dimensions ...string) uint32 {
+	hash := memHashStrings(userId, dimensions...)
+	return hash % uint32(len(s.counts))
 }
 
-func (s *seedByHash) incrementSeed(userId string, v string) {
-	h := memHashString(userId, v)
-	i := h % uint64(len(s.seedByHash))
-	l := i % uint64(len(s.strippedLock))
-	s.strippedLock[l].Lock()
-	defer s.strippedLock[l].Unlock()
-	s.seedByHash[i]++
+func (s *labelCounter) readSlot(index uint32) uint32 {
+	return s.counts[index].Load()
+}
+
+func (s *labelCounter) increment(userId string, dimensions ...string) {
+	i := s.slotIndex(userId, dimensions...)
+	s.counts[i].Add(1)
 }
 
 type lruCache[V any] struct {
@@ -524,14 +598,14 @@ func (c *lruCache[V]) size() int {
 	return c.cached.Len()
 }
 
-func (c *lruCache[V]) getPromiseForKey(k string, fetch func() (V, int64, error)) (*cacheEntryPromise[V], bool) {
+func (c *lruCache[V]) getPromiseForKey(k string, fetch func() (V, int64, func() bool, error)) (*cacheEntryPromise[V], bool) {
 	r := &cacheEntryPromise[V]{
 		done: make(chan struct{}),
 	}
 	defer close(r.done)
 
 	if !c.cfg.Enabled {
-		r.v, _, r.err = fetch()
+		r.v, _, _, r.err = fetch()
 		return r, false
 	}
 
@@ -539,7 +613,7 @@ func (c *lruCache[V]) getPromiseForKey(k string, fetch func() (V, int64, error))
 
 	if !ok {
 		c.metrics.CacheMiss.WithLabelValues(c.name, "miss").Inc()
-		r.v, r.sizeBytes, r.err = fetch()
+		r.v, r.sizeBytes, r.stillValid, r.err = fetch()
 		r.sizeBytes += int64(len(k))
 		r.ts = c.timeNow()
 		c.created(k, r.sizeBytes)
@@ -547,20 +621,29 @@ func (c *lruCache[V]) getPromiseForKey(k string, fetch func() (V, int64, error))
 	}
 
 	if ok {
+		entry := loaded.(*cacheEntryPromise[V])
 		// If the promise is already in the cache, lets wait it to fetch the data.
-		<-loaded.(*cacheEntryPromise[V]).done
+		<-entry.done
 
 		// LRU: move to back on access
 		c.cachedMtx.Lock()
-		if elem := loaded.(*cacheEntryPromise[V]).elem; elem != nil {
-			c.cached.MoveToBack(elem)
+		if entry.elem != nil {
+			c.cached.MoveToBack(entry.elem)
 		}
 		c.cachedMtx.Unlock()
 
-		// If is cached but is expired, lets try to replace the cache value.
-		if loaded.(*cacheEntryPromise[V]).isExpired(c.cfg.Ttl, c.timeNow()) && c.cachedValues.CompareAndSwap(k, loaded, r) {
-			c.metrics.CacheMiss.WithLabelValues(c.name, "expired").Inc()
-			r.v, r.sizeBytes, r.err = fetch()
+		// A nil stillValid means the entry has no count-based invalidation (blocks
+		// cache, or callers that don't snapshot counts); only time expiry applies.
+		invalidated := entry.stillValid != nil && !entry.stillValid()
+
+		// If is cached but is expired or invalidated, lets try to replace the cache value.
+		if (invalidated || entry.isExpired(c.cfg.Ttl, c.timeNow())) && c.cachedValues.CompareAndSwap(k, loaded, r) {
+			if invalidated {
+				c.metrics.CacheMiss.WithLabelValues(c.name, "invalidated").Inc()
+			} else {
+				c.metrics.CacheMiss.WithLabelValues(c.name, "expired").Inc()
+			}
+			r.v, r.sizeBytes, r.stillValid, r.err = fetch()
 			r.sizeBytes += int64(len(k))
 			c.updateSize(loaded.(*cacheEntryPromise[V]).sizeBytes, r.sizeBytes)
 			r.ts = c.timeNow()
@@ -644,6 +727,8 @@ type cacheEntryPromise[V any] struct {
 	sizeBytes int64
 	elem      *list.Element
 
+	stillValid func() bool
+
 	done chan struct{}
 	v    V
 	err  error
@@ -655,7 +740,15 @@ func (ce *cacheEntryPromise[V]) isExpired(ttl time.Duration, now time.Time) bool
 	return r >= ttl
 }
 
-func memHashString(userId, v string) uint64 {
-	h := fnv1a.HashString64(userId)
-	return fnv1a.AddString64(h, v)
+func memHashStrings(userId string, dimensions ...string) uint32 {
+	h := fnv1a.HashString32(userId)
+	for _, d := range dimensions {
+		h = fnv1a.AddString32(h, d)
+	}
+	return h
+}
+
+type countSnapshot struct {
+	index uint32 // slot in labelCounter
+	count uint32 // value at store time
 }

--- a/pkg/storage/tsdb/expanded_postings_cache_test.go
+++ b/pkg/storage/tsdb/expanded_postings_cache_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,6 @@ import (
 
 func TestCacheKey(t *testing.T) {
 	blockID := ulid.MustNew(1, nil)
-	seed := "seed123"
 	matchers := []*labels.Matcher{
 		{
 			Type:  labels.MatchEqual,
@@ -44,8 +44,8 @@ func TestCacheKey(t *testing.T) {
 			Value: "value_4",
 		},
 	}
-	r := cacheKey(seed, blockID, matchers...)
-	require.Equal(t, "seed123|00000000010000000000000000|name_1=value_1|name_2!=value_2|name_3=~value_4|name_5!~value_4|", r)
+	r := cacheKey(blockID, matchers...)
+	require.Equal(t, "00000000010000000000000000|name_1=value_1|name_2!=value_2|name_3=~value_4|name_5!~value_4|", r)
 }
 
 func Test_ShouldFetchPromiseOnlyOnce(t *testing.T) {
@@ -61,10 +61,10 @@ func Test_ShouldFetchPromiseOnlyOnce(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(concurrency)
 
-	fetchFunc := func() (int, int64, error) {
+	fetchFunc := func() (int, int64, func() bool, error) {
 		calls.Inc()
 		time.Sleep(100 * time.Millisecond)
-		return 0, 0, nil
+		return 0, 0, nil, nil
 	}
 
 	for range 100 {
@@ -85,8 +85,8 @@ func TestFifoCacheDisabled(t *testing.T) {
 	m := NewPostingCacheMetrics(prometheus.NewPedanticRegistry())
 	timeNow := time.Now
 	cache := newLruCache[int](cfg, "test", m, timeNow)
-	old, loaded := cache.getPromiseForKey("key1", func() (int, int64, error) {
-		return 1, 0, nil
+	old, loaded := cache.getPromiseForKey("key1", func() (int, int64, func() bool, error) {
+		return 1, 0, nil, nil
 	})
 	require.False(t, loaded)
 	require.Equal(t, 1, old.v)
@@ -131,14 +131,14 @@ func TestFifoCacheExpire(t *testing.T) {
 
 			for i := range numberOfKeys {
 				key := RepeatStringIfNeeded(fmt.Sprintf("key%d", i), keySize)
-				p, loaded := cache.getPromiseForKey(key, func() (int, int64, error) {
-					return 1, 8, nil
+				p, loaded := cache.getPromiseForKey(key, func() (int, int64, func() bool, error) {
+					return 1, 8, nil, nil
 				})
 				require.False(t, loaded)
 				require.Equal(t, 1, p.v)
 				require.True(t, cache.contains(key))
-				p, loaded = cache.getPromiseForKey(key, func() (int, int64, error) {
-					return 1, 0, nil
+				p, loaded = cache.getPromiseForKey(key, func() (int, int64, func() bool, error) {
+					return 1, 0, nil, nil
 				})
 				require.True(t, loaded)
 				require.Equal(t, 1, p.v)
@@ -173,8 +173,8 @@ func TestFifoCacheExpire(t *testing.T) {
 				for i := range numberOfKeys {
 					key := RepeatStringIfNeeded(fmt.Sprintf("key%d", i), keySize)
 					originalSize := cache.cachedBytes
-					p, loaded := cache.getPromiseForKey(key, func() (int, int64, error) {
-						return 2, 18, nil
+					p, loaded := cache.getPromiseForKey(key, func() (int, int64, func() bool, error) {
+						return 2, 18, nil, nil
 					})
 					require.False(t, loaded)
 					// New value
@@ -195,8 +195,8 @@ func TestFifoCacheExpire(t *testing.T) {
 					return timeNow().Add(5 * c.cfg.Ttl)
 				}
 
-				cache.getPromiseForKey("newKwy", func() (int, int64, error) {
-					return 2, 18, nil
+				cache.getPromiseForKey("newKwy", func() (int, int64, func() bool, error) {
+					return 2, 18, nil, nil
 				})
 
 				// Should expire all keys expired keys
@@ -214,14 +214,14 @@ func TestFifoCacheExpire(t *testing.T) {
 func Test_memHashString(test *testing.T) {
 	numberOfTenants := 200
 	numberOfMetrics := 100
-	occurrences := map[uint64]int{}
+	occurrences := map[uint32]int{}
 
 	for range 10 {
 		for j := range numberOfMetrics {
 			metricName := fmt.Sprintf("metricName%v", j)
 			for i := range numberOfTenants {
 				userId := fmt.Sprintf("user%v", i)
-				occurrences[memHashString(userId, metricName)]++
+				occurrences[memHashStrings(userId, metricName)]++
 			}
 		}
 
@@ -267,7 +267,7 @@ func TestPostingsCacheFetchTimeout(t *testing.T) {
 	}
 
 	m := NewPostingCacheMetrics(prometheus.NewPedanticRegistry())
-	cache := newBlocksPostingsForMatchersCache("user1", cfg, m, newSeedByHash(seedArraySize))
+	cache := newBlocksPostingsForMatchersCache("user1", cfg, m, newLabelCounter(labelCounterArraySize))
 
 	// Start a query that will trigger the fetch
 	blockID := headULID
@@ -306,19 +306,19 @@ func TestLruCacheEvictsLeastRecentlyUsed(t *testing.T) {
 	cache := newLruCache[int](cfg, "test", m, time.Now)
 
 	// Insert 3 entries: A, B, C
-	cache.getPromiseForKey("aaaa", func() (int, int64, error) { return 1, 8, nil })
-	cache.getPromiseForKey("bbbb", func() (int, int64, error) { return 2, 8, nil })
-	cache.getPromiseForKey("cccc", func() (int, int64, error) { return 3, 8, nil })
+	cache.getPromiseForKey("aaaa", func() (int, int64, func() bool, error) { return 1, 8, nil, nil })
+	cache.getPromiseForKey("bbbb", func() (int, int64, func() bool, error) { return 2, 8, nil, nil })
+	cache.getPromiseForKey("cccc", func() (int, int64, func() bool, error) { return 3, 8, nil, nil })
 
 	require.True(t, cache.contains("aaaa"))
 	require.True(t, cache.contains("bbbb"))
 	require.True(t, cache.contains("cccc"))
 
 	// Access A to make it recently used (B is now least recently used)
-	cache.getPromiseForKey("aaaa", func() (int, int64, error) { return 1, 8, nil })
+	cache.getPromiseForKey("aaaa", func() (int, int64, func() bool, error) { return 1, 8, nil, nil })
 
 	// Insert D — should evict B (least recently used), not A
-	cache.getPromiseForKey("dddd", func() (int, int64, error) { return 4, 8, nil })
+	cache.getPromiseForKey("dddd", func() (int, int64, func() bool, error) { return 4, 8, nil, nil })
 
 	require.True(t, cache.contains("aaaa"), "A should still be cached (recently accessed)")
 	require.False(t, cache.contains("bbbb"), "B should be evicted (least recently used)")
@@ -346,7 +346,7 @@ func BenchmarkLruCacheHitUnderPressure(b *testing.B) {
 	hotKeys := make([]string, 50)
 	for i := range hotKeys {
 		hotKeys[i] = RepeatStringIfNeeded(fmt.Sprintf("hot-%d", i), keySize)
-		cache.getPromiseForKey(hotKeys[i], func() (int, int64, error) { return i, 8, nil })
+		cache.getPromiseForKey(hotKeys[i], func() (int, int64, func() bool, error) { return i, 8, nil, nil })
 	}
 
 	coldIdx := 0
@@ -356,12 +356,12 @@ func BenchmarkLruCacheHitUnderPressure(b *testing.B) {
 		if i%3 == 0 {
 			// 1/3 of accesses are hot queries (simulating ruler every 30s)
 			key := hotKeys[i%len(hotKeys)]
-			cache.getPromiseForKey(key, func() (int, int64, error) { return 1, 8, nil })
+			cache.getPromiseForKey(key, func() (int, int64, func() bool, error) { return 1, 8, nil, nil })
 		} else {
 			// 2/3 are cold unique queries (ad-hoc from Grafana)
 			key := RepeatStringIfNeeded(fmt.Sprintf("cold-%d", coldIdx), keySize)
 			coldIdx++
-			cache.getPromiseForKey(key, func() (int, int64, error) { return 1, 8, nil })
+			cache.getPromiseForKey(key, func() (int, int64, func() bool, error) { return 1, 8, nil, nil })
 		}
 	}
 
@@ -384,15 +384,253 @@ func BenchmarkCacheGetPromise(b *testing.B) {
 	// Pre-populate 1000 keys
 	for i := range 1000 {
 		key := fmt.Sprintf("key-%04d", i)
-		cache.getPromiseForKey(key, func() (int, int64, error) { return i, 100, nil })
+		cache.getPromiseForKey(key, func() (int, int64, func() bool, error) { return i, 100, nil, nil })
 	}
 
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
 		for pb.Next() {
 			key := fmt.Sprintf("key-%04d", i%1000)
-			cache.getPromiseForKey(key, func() (int, int64, error) { return 1, 100, nil })
+			cache.getPromiseForKey(key, func() (int, int64, func() bool, error) { return 1, 100, nil, nil })
 			i++
 		}
 	})
+}
+
+// countingPostingsCache builds a head-enabled cache whose PostingsForMatchers records how
+// many times it was actually invoked, so tests can distinguish a cache hit (fetch NOT
+// re-run) from an invalidation (fetch re-run). The returned fetches pointer is bumped once
+// per underlying postings lookup.
+func countingPostingsCache(t *testing.T, labelCounter *labelCounter) (ExpandedPostingsCache, *atomic.Int64) {
+	t.Helper()
+	fetches := atomic.NewInt64(0)
+	cfg := TSDBPostingsCacheConfig{
+		Head: PostingsCacheConfig{
+			Enabled:  true,
+			Ttl:      time.Hour, // long TTL so only count invalidation can force a refetch
+			MaxBytes: 10 << 20,
+		},
+		PostingsForMatchers: func(ctx context.Context, ix tsdb.IndexReader, ms ...*labels.Matcher) (index.Postings, error) {
+			fetches.Inc()
+			return index.NewListPostings([]storage.SeriesRef{1, 2, 3}), nil
+		},
+	}
+	m := NewPostingCacheMetrics(prometheus.NewPedanticRegistry())
+	cache := newBlocksPostingsForMatchersCache("user1", cfg, m, labelCounter)
+	return cache, fetches
+}
+
+// query runs a head-block PostingsForMatchers and drains the result so any lazy error surfaces.
+func query(t *testing.T, cache ExpandedPostingsCache, ms ...*labels.Matcher) {
+	t.Helper()
+	p, err := cache.PostingsForMatchers(context.Background(), headULID, nil, ms...)
+	require.NoError(t, err)
+	// Drain so the ListPostings is fully consumed, matching real caller behaviour.
+	for p.Next() {
+	}
+	require.NoError(t, p.Err())
+}
+
+func TestExpandedPostingsCache_MatchingSeriesInvalidates(t *testing.T) {
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cache, fetches := countingPostingsCache(t, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+	jobMatcher := labels.MustNewMatcher(labels.MatchEqual, "job", "api")
+
+	// First query populates the cache.
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	// Second identical query is a pure cache hit: no new series created.
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load(), "identical query should hit the cache")
+
+	// A series that matches the query (same job value) is created. It bumps the value slots
+	// the entry tracks (metric, __name__, "http_requests") and (metric, job, "api"), so all
+	// tracked counts change and the next query refetches.
+	cache.ExpireSeries(labels.FromStrings("__name__", "http_requests", "job", "api"))
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(2), fetches.Load(), "a series matching the query must invalidate the entry")
+}
+
+func TestExpandedPostingsCache_DifferentEqualityValueKeepsEntryValid(t *testing.T) {
+	// Equality matchers are keyed by value, so churn of the same label at a different value
+	// must NOT invalidate: a job="web" series cannot match a job="api" query.
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cache, fetches := countingPostingsCache(t, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+	jobMatcher := labels.MustNewMatcher(labels.MatchEqual, "job", "api")
+
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	// New series shares the metric but has job="web". It bumps (metric, job, "web") and the
+	// name-only (metric, job), but NOT (metric, job, "api") which the entry tracks. The
+	// __name__ value slot is bumped, but one unchanged tracked count keeps the entry valid.
+	cache.ExpireSeries(labels.FromStrings("__name__", "http_requests", "job", "web"))
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load(), "different equality value must not invalidate")
+}
+
+func TestExpandedPostingsCache_StableLabelKeepsEntryValid(t *testing.T) {
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cache, fetches := countingPostingsCache(t, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+	jobMatcher := labels.MustNewMatcher(labels.MatchEqual, "job", "api")
+
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	// A new series is created for the SAME metric but with a label the query does not
+	// track (region). This bumps __name__ and (metric, region), but NOT (metric, job).
+	// Since the tracked (metric, job) count is unchanged, the entry stays valid: any
+	// series matching {__name__="http_requests", job="api"} would have bumped (metric, job).
+	cache.ExpireSeries(labels.FromStrings("__name__", "http_requests", "region", "us-east"))
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load(), "unchanged tracked label should keep the entry valid")
+}
+
+func TestExpandedPostingsCache_EmptyMatchingMatcherDoesNotVouch(t *testing.T) {
+	// A negative matcher like job!="batch" matches series that LACK a job label. Such a
+	// series bumps __name__ but not (metric, job), so the (metric, job) count must NOT be
+	// allowed to vouch for the entry. With only __name__ eligible to invalidate, any series
+	// creation for the metric must force a refetch.
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cache, fetches := countingPostingsCache(t, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+	jobMatcher := labels.MustNewMatcher(labels.MatchNotEqual, "job", "batch")
+
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	// New series for the metric WITHOUT a job label — matches job!="batch". It bumps only
+	// __name__ (and its other labels), not (metric, job). If the empty-matching job matcher
+	// were wrongly tracked, its frozen count would keep this stale entry alive.
+	cache.ExpireSeries(labels.FromStrings("__name__", "http_requests", "region", "us-east"))
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(2), fetches.Load(), "empty-matching matcher must not keep a stale entry alive")
+}
+
+func TestExpandedPostingsCache_NameOnlyQueryInvalidatesOnAnySeriesChurn(t *testing.T) {
+	// A {__name__="foo"}-only query has no selective label to track, so it degrades to the
+	// old whole-metric behaviour: any series create/delete for the metric invalidates it.
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cache, fetches := countingPostingsCache(t, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+
+	query(t, cache, nameMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	query(t, cache, nameMatcher)
+	require.Equal(t, int64(1), fetches.Load(), "identical name-only query should hit the cache")
+
+	cache.ExpireSeries(labels.FromStrings("__name__", "http_requests", "job", "api"))
+	query(t, cache, nameMatcher)
+	require.Equal(t, int64(2), fetches.Load(), "name-only query must invalidate on any series churn")
+}
+
+func TestExpandedPostingsCache_DifferentMetricDoesNotInvalidate(t *testing.T) {
+	// Series churn on an unrelated metric must not invalidate this metric's entry.
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cache, fetches := countingPostingsCache(t, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+	jobMatcher := labels.MustNewMatcher(labels.MatchEqual, "job", "api")
+
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	cache.ExpireSeries(labels.FromStrings("__name__", "other_metric", "job", "api"))
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load(), "churn on a different metric must not invalidate")
+}
+
+// TestExpandedPostingsCache_SnapshotTakenBeforePostingsRead pins the ordering guarantee:
+// the count snapshot MUST be captured before postings are read. If a series is created
+// after the snapshot but before/around the postings read, the stored postings may miss it,
+// so the stored count must be the pre-creation value and a later read must invalidate.
+//
+// The mock simulates that concurrent creation by bumping the metric's count from inside
+// PostingsForMatchers (which runs after snapshotCounts in the correct implementation). With
+// correct ordering the snapshot predates the bump, so the follow-up query refetches. If the
+// snapshot were taken after the postings read, it would capture the post-bump count and the
+// follow-up query would wrongly hit — failing this test.
+func TestExpandedPostingsCache_SnapshotTakenBeforePostingsRead(t *testing.T) {
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	fetches := atomic.NewInt64(0)
+	bumped := atomic.NewBool(false)
+
+	// cache is assigned below; the closure captures it so it can drive a real ExpireSeries
+	// from inside the fetch, exercising the exact keying production uses.
+	var cache ExpandedPostingsCache
+	cfg := TSDBPostingsCacheConfig{
+		Head: PostingsCacheConfig{
+			Enabled:  true,
+			Ttl:      time.Hour,
+			MaxBytes: 10 << 20,
+		},
+		PostingsForMatchers: func(ctx context.Context, ix tsdb.IndexReader, ms ...*labels.Matcher) (index.Postings, error) {
+			fetches.Inc()
+			// Simulate a series for this metric being created during the fetch, once, via
+			// the real invalidation path so the slot keying always matches snapshotCounts.
+			if bumped.CompareAndSwap(false, true) {
+				cache.ExpireSeries(labels.FromStrings("__name__", "http_requests"))
+			}
+			return index.NewListPostings([]storage.SeriesRef{1, 2, 3}), nil
+		},
+	}
+	m := NewPostingCacheMetrics(prometheus.NewPedanticRegistry())
+	cache = newBlocksPostingsForMatchersCache("user1", cfg, m, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+
+	// Q1 populates the cache; the mock bumps the count after the snapshot was taken.
+	query(t, cache, nameMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	// Q2 sees the bumped count vs the pre-bump snapshot and must refetch.
+	query(t, cache, nameMatcher)
+	require.Equal(t, int64(2), fetches.Load(), "snapshot must predate the postings read; a series created during the fetch must invalidate")
+
+	// Q3: the one-shot bump is done, so the Q2 snapshot now matches the live count → hit.
+	query(t, cache, nameMatcher)
+	require.Equal(t, int64(2), fetches.Load(), "with no further churn the entry should be stable again")
+}
+
+func TestSnapshotCounts_Size(t *testing.T) {
+	// snapshotCounts reports the byte cost that gets added to the cache entry's sizeBytes.
+	// Each tracked matcher is one countSnapshot (two uint32s = 8 bytes); empty-matching
+	// matchers are skipped and must contribute nothing.
+	cfg := TSDBPostingsCacheConfig{
+		Head: PostingsCacheConfig{Enabled: true, Ttl: time.Hour, MaxBytes: 1 << 20},
+	}
+	m := NewPostingCacheMetrics(prometheus.NewPedanticRegistry())
+	c := newBlocksPostingsForMatchersCache("user1", cfg, m, newLabelCounter(labelCounterArraySize)).(*blocksPostingsForMatchersCache)
+
+	name := labels.MustNewMatcher(labels.MatchEqual, "__name__", "m")
+	job := labels.MustNewMatcher(labels.MatchEqual, "job", "api")
+	// Empty-matching (matches a series lacking "job"), so it is skipped and adds no bytes.
+	neg := labels.MustNewMatcher(labels.MatchNotEqual, "job", "batch")
+	require.True(t, neg.Matches(""), "sanity: neg must be empty-matching for this test to mean anything")
+
+	tc := map[string]struct {
+		ms           []*labels.Matcher
+		expectedSize int64
+	}{
+		"name only":                         {ms: []*labels.Matcher{name}, expectedSize: 8},
+		"name + selective label":            {ms: []*labels.Matcher{name, job}, expectedSize: 16},
+		"empty-matcher contributes nothing": {ms: []*labels.Matcher{name, job, neg}, expectedSize: 16},
+	}
+
+	for title, tt := range tc {
+		t.Run(title, func(t *testing.T) {
+			_, size := c.snapshotCounts("m", tt.ms...)
+			require.Equal(t, tt.expectedSize, size)
+		})
+	}
 }

--- a/pkg/storage/tsdb/expanded_postings_cache_test.go
+++ b/pkg/storage/tsdb/expanded_postings_cache_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,6 @@ import (
 
 func TestCacheKey(t *testing.T) {
 	blockID := ulid.MustNew(1, nil)
-	seed := "seed123"
 	matchers := []*labels.Matcher{
 		{
 			Type:  labels.MatchEqual,
@@ -44,8 +44,8 @@ func TestCacheKey(t *testing.T) {
 			Value: "value_4",
 		},
 	}
-	r := cacheKey(seed, blockID, matchers...)
-	require.Equal(t, "seed123|00000000010000000000000000|name_1=value_1|name_2!=value_2|name_3=~value_4|name_5!~value_4|", r)
+	r := cacheKey(blockID, matchers...)
+	require.Equal(t, "00000000010000000000000000|name_1=value_1|name_2!=value_2|name_3=~value_4|name_5!~value_4|", r)
 }
 
 func Test_ShouldFetchPromiseOnlyOnce(t *testing.T) {
@@ -61,10 +61,10 @@ func Test_ShouldFetchPromiseOnlyOnce(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(concurrency)
 
-	fetchFunc := func() (int, int64, error) {
+	fetchFunc := func() (int, int64, func() bool, error) {
 		calls.Inc()
 		time.Sleep(100 * time.Millisecond)
-		return 0, 0, nil
+		return 0, 0, nil, nil
 	}
 
 	for range 100 {
@@ -85,8 +85,8 @@ func TestFifoCacheDisabled(t *testing.T) {
 	m := NewPostingCacheMetrics(prometheus.NewPedanticRegistry())
 	timeNow := time.Now
 	cache := newLruCache[int](cfg, "test", m, timeNow)
-	old, loaded := cache.getPromiseForKey("key1", func() (int, int64, error) {
-		return 1, 0, nil
+	old, loaded := cache.getPromiseForKey("key1", func() (int, int64, func() bool, error) {
+		return 1, 0, nil, nil
 	})
 	require.False(t, loaded)
 	require.Equal(t, 1, old.v)
@@ -131,14 +131,14 @@ func TestFifoCacheExpire(t *testing.T) {
 
 			for i := range numberOfKeys {
 				key := RepeatStringIfNeeded(fmt.Sprintf("key%d", i), keySize)
-				p, loaded := cache.getPromiseForKey(key, func() (int, int64, error) {
-					return 1, 8, nil
+				p, loaded := cache.getPromiseForKey(key, func() (int, int64, func() bool, error) {
+					return 1, 8, nil, nil
 				})
 				require.False(t, loaded)
 				require.Equal(t, 1, p.v)
 				require.True(t, cache.contains(key))
-				p, loaded = cache.getPromiseForKey(key, func() (int, int64, error) {
-					return 1, 0, nil
+				p, loaded = cache.getPromiseForKey(key, func() (int, int64, func() bool, error) {
+					return 1, 0, nil, nil
 				})
 				require.True(t, loaded)
 				require.Equal(t, 1, p.v)
@@ -173,8 +173,8 @@ func TestFifoCacheExpire(t *testing.T) {
 				for i := range numberOfKeys {
 					key := RepeatStringIfNeeded(fmt.Sprintf("key%d", i), keySize)
 					originalSize := cache.cachedBytes
-					p, loaded := cache.getPromiseForKey(key, func() (int, int64, error) {
-						return 2, 18, nil
+					p, loaded := cache.getPromiseForKey(key, func() (int, int64, func() bool, error) {
+						return 2, 18, nil, nil
 					})
 					require.False(t, loaded)
 					// New value
@@ -195,8 +195,8 @@ func TestFifoCacheExpire(t *testing.T) {
 					return timeNow().Add(5 * c.cfg.Ttl)
 				}
 
-				cache.getPromiseForKey("newKwy", func() (int, int64, error) {
-					return 2, 18, nil
+				cache.getPromiseForKey("newKwy", func() (int, int64, func() bool, error) {
+					return 2, 18, nil, nil
 				})
 
 				// Should expire all keys expired keys
@@ -214,14 +214,14 @@ func TestFifoCacheExpire(t *testing.T) {
 func Test_memHashString(test *testing.T) {
 	numberOfTenants := 200
 	numberOfMetrics := 100
-	occurrences := map[uint64]int{}
+	occurrences := map[uint32]int{}
 
 	for range 10 {
 		for j := range numberOfMetrics {
 			metricName := fmt.Sprintf("metricName%v", j)
 			for i := range numberOfTenants {
 				userId := fmt.Sprintf("user%v", i)
-				occurrences[memHashString(userId, metricName)]++
+				occurrences[memHashStrings(userId, metricName)]++
 			}
 		}
 
@@ -267,7 +267,7 @@ func TestPostingsCacheFetchTimeout(t *testing.T) {
 	}
 
 	m := NewPostingCacheMetrics(prometheus.NewPedanticRegistry())
-	cache := newBlocksPostingsForMatchersCache("user1", cfg, m, newSeedByHash(seedArraySize))
+	cache := newBlocksPostingsForMatchersCache("user1", cfg, m, newLabelCounter(labelCounterArraySize))
 
 	// Start a query that will trigger the fetch
 	blockID := headULID
@@ -306,19 +306,19 @@ func TestLruCacheEvictsLeastRecentlyUsed(t *testing.T) {
 	cache := newLruCache[int](cfg, "test", m, time.Now)
 
 	// Insert 3 entries: A, B, C
-	cache.getPromiseForKey("aaaa", func() (int, int64, error) { return 1, 8, nil })
-	cache.getPromiseForKey("bbbb", func() (int, int64, error) { return 2, 8, nil })
-	cache.getPromiseForKey("cccc", func() (int, int64, error) { return 3, 8, nil })
+	cache.getPromiseForKey("aaaa", func() (int, int64, func() bool, error) { return 1, 8, nil, nil })
+	cache.getPromiseForKey("bbbb", func() (int, int64, func() bool, error) { return 2, 8, nil, nil })
+	cache.getPromiseForKey("cccc", func() (int, int64, func() bool, error) { return 3, 8, nil, nil })
 
 	require.True(t, cache.contains("aaaa"))
 	require.True(t, cache.contains("bbbb"))
 	require.True(t, cache.contains("cccc"))
 
 	// Access A to make it recently used (B is now least recently used)
-	cache.getPromiseForKey("aaaa", func() (int, int64, error) { return 1, 8, nil })
+	cache.getPromiseForKey("aaaa", func() (int, int64, func() bool, error) { return 1, 8, nil, nil })
 
 	// Insert D — should evict B (least recently used), not A
-	cache.getPromiseForKey("dddd", func() (int, int64, error) { return 4, 8, nil })
+	cache.getPromiseForKey("dddd", func() (int, int64, func() bool, error) { return 4, 8, nil, nil })
 
 	require.True(t, cache.contains("aaaa"), "A should still be cached (recently accessed)")
 	require.False(t, cache.contains("bbbb"), "B should be evicted (least recently used)")
@@ -346,7 +346,7 @@ func BenchmarkLruCacheHitUnderPressure(b *testing.B) {
 	hotKeys := make([]string, 50)
 	for i := range hotKeys {
 		hotKeys[i] = RepeatStringIfNeeded(fmt.Sprintf("hot-%d", i), keySize)
-		cache.getPromiseForKey(hotKeys[i], func() (int, int64, error) { return i, 8, nil })
+		cache.getPromiseForKey(hotKeys[i], func() (int, int64, func() bool, error) { return i, 8, nil, nil })
 	}
 
 	coldIdx := 0
@@ -356,12 +356,12 @@ func BenchmarkLruCacheHitUnderPressure(b *testing.B) {
 		if i%3 == 0 {
 			// 1/3 of accesses are hot queries (simulating ruler every 30s)
 			key := hotKeys[i%len(hotKeys)]
-			cache.getPromiseForKey(key, func() (int, int64, error) { return 1, 8, nil })
+			cache.getPromiseForKey(key, func() (int, int64, func() bool, error) { return 1, 8, nil, nil })
 		} else {
 			// 2/3 are cold unique queries (ad-hoc from Grafana)
 			key := RepeatStringIfNeeded(fmt.Sprintf("cold-%d", coldIdx), keySize)
 			coldIdx++
-			cache.getPromiseForKey(key, func() (int, int64, error) { return 1, 8, nil })
+			cache.getPromiseForKey(key, func() (int, int64, func() bool, error) { return 1, 8, nil, nil })
 		}
 	}
 
@@ -384,15 +384,286 @@ func BenchmarkCacheGetPromise(b *testing.B) {
 	// Pre-populate 1000 keys
 	for i := range 1000 {
 		key := fmt.Sprintf("key-%04d", i)
-		cache.getPromiseForKey(key, func() (int, int64, error) { return i, 100, nil })
+		cache.getPromiseForKey(key, func() (int, int64, func() bool, error) { return i, 100, nil, nil })
 	}
 
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
 		for pb.Next() {
 			key := fmt.Sprintf("key-%04d", i%1000)
-			cache.getPromiseForKey(key, func() (int, int64, error) { return 1, 100, nil })
+			cache.getPromiseForKey(key, func() (int, int64, func() bool, error) { return 1, 100, nil, nil })
 			i++
 		}
 	})
+}
+
+// countingPostingsCache builds a head-enabled cache whose PostingsForMatchers records how
+// many times it was actually invoked, so tests can distinguish a cache hit (fetch NOT
+// re-run) from an invalidation (fetch re-run). The returned fetches pointer is bumped once
+// per underlying postings lookup.
+func countingPostingsCache(t *testing.T, labelCounter *labelCounter) (ExpandedPostingsCache, *atomic.Int64) {
+	t.Helper()
+	return countingPostingsCacheForUser(t, "user1", labelCounter)
+}
+
+// countingPostingsCacheForUser is countingPostingsCache for an explicit tenant, so a test can
+// build two caches that share one labelCounter the way the factory does in production.
+func countingPostingsCacheForUser(t *testing.T, userId string, labelCounter *labelCounter) (ExpandedPostingsCache, *atomic.Int64) {
+	t.Helper()
+	fetches := atomic.NewInt64(0)
+	cfg := TSDBPostingsCacheConfig{
+		Head: PostingsCacheConfig{
+			Enabled:  true,
+			Ttl:      time.Hour, // long TTL so only count invalidation can force a refetch
+			MaxBytes: 10 << 20,
+		},
+		PostingsForMatchers: func(ctx context.Context, ix tsdb.IndexReader, ms ...*labels.Matcher) (index.Postings, error) {
+			fetches.Inc()
+			return index.NewListPostings([]storage.SeriesRef{1, 2, 3}), nil
+		},
+	}
+	m := NewPostingCacheMetrics(prometheus.NewPedanticRegistry())
+	cache := newBlocksPostingsForMatchersCache(userId, cfg, m, labelCounter)
+	return cache, fetches
+}
+
+// query runs a head-block PostingsForMatchers and drains the result so any lazy error surfaces.
+func query(t *testing.T, cache ExpandedPostingsCache, ms ...*labels.Matcher) {
+	t.Helper()
+	p, err := cache.PostingsForMatchers(context.Background(), headULID, nil, ms...)
+	require.NoError(t, err)
+	// Drain so the ListPostings is fully consumed, matching real caller behaviour.
+	for p.Next() {
+	}
+	require.NoError(t, p.Err())
+}
+
+func TestExpandedPostingsCache_MatchingSeriesInvalidates(t *testing.T) {
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cache, fetches := countingPostingsCache(t, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+	jobMatcher := labels.MustNewMatcher(labels.MatchEqual, "job", "api")
+
+	// First query populates the cache.
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	// Second identical query is a pure cache hit: no new series created.
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load(), "identical query should hit the cache")
+
+	// A series that matches the query (same job value) is created. It bumps the value slots
+	// the entry tracks (metric, __name__, "http_requests") and (metric, job, "api"), so all
+	// tracked counts change and the next query refetches.
+	cache.ExpireSeries(labels.FromStrings("__name__", "http_requests", "job", "api"))
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(2), fetches.Load(), "a series matching the query must invalidate the entry")
+}
+
+func TestExpandedPostingsCache_DifferentEqualityValueKeepsEntryValid(t *testing.T) {
+	// Equality matchers are keyed by value, so churn of the same label at a different value
+	// must NOT invalidate: a job="web" series cannot match a job="api" query.
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cache, fetches := countingPostingsCache(t, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+	jobMatcher := labels.MustNewMatcher(labels.MatchEqual, "job", "api")
+
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	// New series shares the metric but has job="web". It bumps (metric, job, "web") and the
+	// name-only (metric, job), but NOT (metric, job, "api") which the entry tracks. The
+	// __name__ value slot is bumped, but one unchanged tracked count keeps the entry valid.
+	cache.ExpireSeries(labels.FromStrings("__name__", "http_requests", "job", "web"))
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load(), "different equality value must not invalidate")
+}
+
+func TestExpandedPostingsCache_StableLabelKeepsEntryValid(t *testing.T) {
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cache, fetches := countingPostingsCache(t, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+	jobMatcher := labels.MustNewMatcher(labels.MatchEqual, "job", "api")
+
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	// A new series is created for the SAME metric but with a label the query does not
+	// track (region). This bumps __name__ and (metric, region), but NOT (metric, job).
+	// Since the tracked (metric, job) count is unchanged, the entry stays valid: any
+	// series matching {__name__="http_requests", job="api"} would have bumped (metric, job).
+	cache.ExpireSeries(labels.FromStrings("__name__", "http_requests", "region", "us-east"))
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load(), "unchanged tracked label should keep the entry valid")
+}
+
+func TestExpandedPostingsCache_EmptyMatchingMatcherDoesNotVouch(t *testing.T) {
+	// A negative matcher like job!="batch" matches series that LACK a job label. Such a
+	// series bumps __name__ but not (metric, job), so the (metric, job) count must NOT be
+	// allowed to vouch for the entry. With only __name__ eligible to invalidate, any series
+	// creation for the metric must force a refetch.
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cache, fetches := countingPostingsCache(t, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+	jobMatcher := labels.MustNewMatcher(labels.MatchNotEqual, "job", "batch")
+
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	// New series for the metric WITHOUT a job label — matches job!="batch". It bumps only
+	// __name__ (and its other labels), not (metric, job). If the empty-matching job matcher
+	// were wrongly tracked, its frozen count would keep this stale entry alive.
+	cache.ExpireSeries(labels.FromStrings("__name__", "http_requests", "region", "us-east"))
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(2), fetches.Load(), "empty-matching matcher must not keep a stale entry alive")
+}
+
+func TestExpandedPostingsCache_NameOnlyQueryInvalidatesOnAnySeriesChurn(t *testing.T) {
+	// A {__name__="foo"}-only query has no selective label to track, so it degrades to the
+	// old whole-metric behaviour: any series create/delete for the metric invalidates it.
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cache, fetches := countingPostingsCache(t, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+
+	query(t, cache, nameMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	query(t, cache, nameMatcher)
+	require.Equal(t, int64(1), fetches.Load(), "identical name-only query should hit the cache")
+
+	cache.ExpireSeries(labels.FromStrings("__name__", "http_requests", "job", "api"))
+	query(t, cache, nameMatcher)
+	require.Equal(t, int64(2), fetches.Load(), "name-only query must invalidate on any series churn")
+}
+
+func TestExpandedPostingsCache_DifferentMetricDoesNotInvalidate(t *testing.T) {
+	// Series churn on an unrelated metric must not invalidate this metric's entry.
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cache, fetches := countingPostingsCache(t, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+	jobMatcher := labels.MustNewMatcher(labels.MatchEqual, "job", "api")
+
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	cache.ExpireSeries(labels.FromStrings("__name__", "other_metric", "job", "api"))
+	query(t, cache, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetches.Load(), "churn on a different metric must not invalidate")
+}
+
+func TestExpandedPostingsCache_TenantsShareLabelCounter(t *testing.T) {
+	// One labelCounter is shared by every tenant, so the tenant id has to be part of each
+	// slot key. Test_memHashString covers the hash itself, not that both callers pass it.
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	cacheA, fetchesA := countingPostingsCacheForUser(t, "user-a", labelCounter)
+	cacheB, fetchesB := countingPostingsCacheForUser(t, "user-b", labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+	jobMatcher := labels.MustNewMatcher(labels.MatchEqual, "job", "api")
+
+	// Both tenants cache the identical query.
+	query(t, cacheA, nameMatcher, jobMatcher)
+	query(t, cacheB, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetchesA.Load())
+	require.Equal(t, int64(1), fetchesB.Load())
+
+	// A series created for tenant A matches that query, but only for tenant A.
+	cacheA.ExpireSeries(labels.FromStrings("__name__", "http_requests", "job", "api"))
+
+	query(t, cacheB, nameMatcher, jobMatcher)
+	require.Equal(t, int64(1), fetchesB.Load(), "another tenant's series must not invalidate this tenant's entry")
+
+	query(t, cacheA, nameMatcher, jobMatcher)
+	require.Equal(t, int64(2), fetchesA.Load(), "the writing tenant's own entry must still be invalidated")
+}
+
+// TestExpandedPostingsCache_SnapshotTakenBeforePostingsRead pins the ordering guarantee:
+// the count snapshot MUST be captured before postings are read. If a series is created
+// after the snapshot but before/around the postings read, the stored postings may miss it,
+// so the stored count must be the pre-creation value and a later read must invalidate.
+//
+// The mock simulates that concurrent creation by bumping the metric's count from inside
+// PostingsForMatchers (which runs after snapshotCounts in the correct implementation). With
+// correct ordering the snapshot predates the bump, so the follow-up query refetches. If the
+// snapshot were taken after the postings read, it would capture the post-bump count and the
+// follow-up query would wrongly hit — failing this test.
+func TestExpandedPostingsCache_SnapshotTakenBeforePostingsRead(t *testing.T) {
+	labelCounter := newLabelCounter(labelCounterArraySize)
+	fetches := atomic.NewInt64(0)
+	bumped := atomic.NewBool(false)
+
+	// cache is assigned below; the closure captures it so it can drive a real ExpireSeries
+	// from inside the fetch, exercising the exact keying production uses.
+	var cache ExpandedPostingsCache
+	cfg := TSDBPostingsCacheConfig{
+		Head: PostingsCacheConfig{
+			Enabled:  true,
+			Ttl:      time.Hour,
+			MaxBytes: 10 << 20,
+		},
+		PostingsForMatchers: func(ctx context.Context, ix tsdb.IndexReader, ms ...*labels.Matcher) (index.Postings, error) {
+			fetches.Inc()
+			// Simulate a series for this metric being created during the fetch, once, via
+			// the real invalidation path so the slot keying always matches snapshotCounts.
+			if bumped.CompareAndSwap(false, true) {
+				cache.ExpireSeries(labels.FromStrings("__name__", "http_requests"))
+			}
+			return index.NewListPostings([]storage.SeriesRef{1, 2, 3}), nil
+		},
+	}
+	m := NewPostingCacheMetrics(prometheus.NewPedanticRegistry())
+	cache = newBlocksPostingsForMatchersCache("user1", cfg, m, labelCounter)
+
+	nameMatcher := labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests")
+
+	// Q1 populates the cache; the mock bumps the count after the snapshot was taken.
+	query(t, cache, nameMatcher)
+	require.Equal(t, int64(1), fetches.Load())
+
+	// Q2 sees the bumped count vs the pre-bump snapshot and must refetch.
+	query(t, cache, nameMatcher)
+	require.Equal(t, int64(2), fetches.Load(), "snapshot must predate the postings read; a series created during the fetch must invalidate")
+
+	// Q3: the one-shot bump is done, so the Q2 snapshot now matches the live count → hit.
+	query(t, cache, nameMatcher)
+	require.Equal(t, int64(2), fetches.Load(), "with no further churn the entry should be stable again")
+}
+
+func TestSnapshotCounts_Size(t *testing.T) {
+	// snapshotCounts reports the byte cost that gets added to the cache entry's sizeBytes.
+	// Each tracked matcher is one countSnapshot (two uint32s = 8 bytes); empty-matching
+	// matchers are skipped and must contribute nothing.
+	cfg := TSDBPostingsCacheConfig{
+		Head: PostingsCacheConfig{Enabled: true, Ttl: time.Hour, MaxBytes: 1 << 20},
+	}
+	m := NewPostingCacheMetrics(prometheus.NewPedanticRegistry())
+	c := newBlocksPostingsForMatchersCache("user1", cfg, m, newLabelCounter(labelCounterArraySize)).(*blocksPostingsForMatchersCache)
+
+	name := labels.MustNewMatcher(labels.MatchEqual, "__name__", "m")
+	job := labels.MustNewMatcher(labels.MatchEqual, "job", "api")
+	// Empty-matching (matches a series lacking "job"), so it is skipped and adds no bytes.
+	neg := labels.MustNewMatcher(labels.MatchNotEqual, "job", "batch")
+	require.True(t, neg.Matches(""), "sanity: neg must be empty-matching for this test to mean anything")
+
+	tc := map[string]struct {
+		ms           []*labels.Matcher
+		expectedSize int64
+	}{
+		"name only":                         {ms: []*labels.Matcher{name}, expectedSize: 8},
+		"name + selective label":            {ms: []*labels.Matcher{name, job}, expectedSize: 16},
+		"empty-matcher contributes nothing": {ms: []*labels.Matcher{name, job, neg}, expectedSize: 16},
+	}
+
+	for title, tt := range tc {
+		t.Run(title, func(t *testing.T) {
+			_, size := c.snapshotCounts("m", tt.ms...)
+			require.Equal(t, tt.expectedSize, size)
+		})
+	}
 }


### PR DESCRIPTION
The head expanded postings cache previously keyed a per-metric "seed" into the cache key, so creating or deleting any series for a metric invalidated every cached entry for that metric name, even entries whose result could not have changed.

Replace the seed with a per-(tenant, label) write counter. On series create/delete each of the series' label counts is incremented. On creation, a cache entry snapshots the counts of its matched labels and stays valid as long as at least one tracked count is unchanged. Creating or deleting a series which matches all of the tracked labels expires the cache entries.

Matchers that can match an absent label (e.g. foo!="x", foo=~".*") are excluded from the snapshot since a matching series need not carry the label, so they cannot vouch for an entry. Name-only queries fall back to the old whole-metric behaviour via the __name__ count.

The counter array is shared across tenants and namespaced by userId; it is uint32 (8MB) and read under the existing stripe locks. Adds a reason="stale" value to the cache miss metric to distinguish count invalidation from TTL expiry.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
