### PR TITLE
fix(queryeviction): fix flaky TestPrometheusMetrics_IncrementedCorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [BUGFIX] Ingester: Fix inflight query counter leak when resource-based query protection rejects a request. #7539
 * [BUGFIX] Ingester: Release the TSDB appender on every early-return path in `Push` (e.g. out-of-order label set) by deferring `Rollback`. Previously such requests leaked TSDB head series references, mmap'd chunks and pending state per request, causing the `cortex_ingester_tsdb_head_active_appenders` gauge to grow unbounded. #7528
 * [BUGFIX] Ingester: Fix `panic: send on closed channel` in `ActiveQueriedSeriesService` on shutdown by removing the redundant channel close in `stopping()` and relying on `ctx.Done()` to signal worker exit. #7533
+* [BUGFIX] Query Eviction: Fix flaky `TestPrometheusMetrics_IncrementedCorrectly` by polling for the `evictionsTotal` metric instead of asserting immediately after the eviction signal, which fires before the metric is incremented in the evictor's background loop. #7680
 * [BUGFIX] Ring: Fix ring token conflict resolution only applied to updated instance and make constantly token conflict check during instance observe period.
 * [BUGFIX] Distributor: Fix a panic (`slice bounds out of range`) in the stream push path when the context deadline expires while the worker goroutine is still marshalling a `WriteRequest`. #7541
 * [BUGFIX] Query Frontend: Fix native histogram responses not being handled correctly in `minTime()` sort ordering for split_by_interval merge. #7555

--- a/pkg/util/queryeviction/evictor_test.go
+++ b/pkg/util/queryeviction/evictor_test.go
@@ -207,7 +207,13 @@ func TestPrometheusMetrics_IncrementedCorrectly(t *testing.T) {
 		waitEvicted(t, evicted)
 	}
 
-	assert.Equal(t, float64(3), promtest.ToFloat64(evictor.evictionsTotal.WithLabelValues(string(resource.CPU))))
+	// The eviction signal (closing `evicted`) and the evictionsTotal increment
+	// both happen in the evictor's background loop, but the signal fires first
+	// (see running() in evictor.go: Cancel() is called before Inc()). Waiting on
+	// the signal alone races with the metric write, so poll for the metric too.
+	require.Eventually(t, func() bool {
+		return promtest.ToFloat64(evictor.evictionsTotal.WithLabelValues(string(resource.CPU))) == float64(3)
+	}, 500*time.Millisecond, 5*time.Millisecond, "expected evictionsTotal to reach 3")
 }
 
 func TestNewQueryEvictor_ReturnsNilWhenDisabled(t *testing.T) {


### PR DESCRIPTION
## What this PR does

Fixes the flaky `TestPrometheusMetrics_IncrementedCorrectly` test in `pkg/util/queryeviction`.

`QueryEvictor.running()` (`pkg/util/queryeviction/evictor.go`) calls `victim.Cancel()` — which closes
the test's `evicted` channel — *before* incrementing `evictionsTotal`:

```go
for _, victim := range victims {
    metricValue := e.registry.metric(victim.Stats)
    victim.Cancel()                                            // closes `evicted` first

    level.Warn(e.logger).Log(...)

    e.evictionsTotal.WithLabelValues(string(breachedResource)).Inc()  // metric incremented after
}
```

The test synchronizes only on the eviction signal (`waitEvicted`), not on the metric write, so the
final assertion can observe the counter before the last increment lands:

```
--- FAIL: TestPrometheusMetrics_IncrementedCorrectly (0.03s)
    evictor_test.go:210:
        Error: Not equal: expected: 3  actual: 2
```

## Verified the flake is real

Checked out the pre-fix version of `evictor_test.go` and stress-tested it directly (not just relying
on the issue report):

```
go test -count=500 -cpu=1,2,4 -run TestPrometheusMetrics_IncrementedCorrectly ./pkg/util/queryeviction/...
```

This reproduced the exact `expected: 3, actual: 2` failure from the issue — 8 failures out of 500 runs.
With the fix applied, the same 500-run stress test (`-cpu=1,2,4`, plus a separate 100-run pass under
`-race`) passes cleanly every time.

## The fix

Replace the immediate assertion with `require.Eventually`, polling for the metric to reach the
expected value instead of asserting right after the signal:

```go
require.Eventually(t, func() bool {
    return promtest.ToFloat64(evictor.evictionsTotal.WithLabelValues(string(resource.CPU))) == float64(3)
}, 500*time.Millisecond, 5*time.Millisecond, "expected evictionsTotal to reach 3")
```

Test-only change; no production behavior is affected.

## Which issue(s) this PR fixes

Fixes #7604

## Checklist

- [x] Tests updated (this PR *is* the test fix)
- [x] `CHANGELOG.md` updated
- [ ] Documentation added — N/A, no user-facing behavior change
- [ ] `docs/configuration/v1-guarantees.md` updated — N/A, no new flags

## AI-assistance disclosure

Per `GENAI_POLICY.md`: root-cause analysis of the race and the fix were drafted with Claude Code. I
reviewed the diff, understand the race (signal-before-metric ordering in `running()`), and independently
verified the flake reproduces pre-fix and is resolved post-fix using the stress-test runs described above.