### PR TITLE
fix(azure): default endpoint_suffix to blob.core.windows.net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 * [BUGFIX] Querier: Fix panic due to request tracker truncating multi-byte UTF-8 character #7640
 * [BUGFIX] Ingester: Fix panic (`HistogramProtoToHistogram called with a float histogram`) when ingesting a float native histogram with a zero count (e.g. a staleness marker or empty histogram). The decoder is now selected by histogram type via `IsFloatHistogram()` instead of by count value. #7645
 * [BUGFIX] Querier: Fix parquet queryable fallback returning a nil error instead of the actual query error in `LabelValues` and `LabelNames`. #7638
+* [BUGFIX] Storage: Default the Azure `endpoint_suffix` to `blob.core.windows.net` instead of empty. Cortex builds the Thanos Azure config directly and bypasses Thanos' default, so an unset suffix produced an invalid FQDN (`<account>.`) and components hung on startup with DNS errors. #5449
 
 ## 1.21.0 2026-04-24
 

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -515,7 +515,7 @@ blocks_storage:
     # Azure storage endpoint suffix without schema. The account name will be
     # prefixed to this value to create the FQDN
     # CLI flag: -blocks-storage.azure.endpoint-suffix
-    [endpoint_suffix: <string> | default = ""]
+    [endpoint_suffix: <string> | default = "blob.core.windows.net"]
 
     # Number of retries for recoverable errors
     # CLI flag: -blocks-storage.azure.max-retries

--- a/docs/blocks-storage/store-gateway.md
+++ b/docs/blocks-storage/store-gateway.md
@@ -573,7 +573,7 @@ blocks_storage:
     # Azure storage endpoint suffix without schema. The account name will be
     # prefixed to this value to create the FQDN
     # CLI flag: -blocks-storage.azure.endpoint-suffix
-    [endpoint_suffix: <string> | default = ""]
+    [endpoint_suffix: <string> | default = "blob.core.windows.net"]
 
     # Number of retries for recoverable errors
     # CLI flag: -blocks-storage.azure.max-retries

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -858,7 +858,7 @@ azure:
   # Azure storage endpoint suffix without schema. The account name will be
   # prefixed to this value to create the FQDN
   # CLI flag: -alertmanager-storage.azure.endpoint-suffix
-  [endpoint_suffix: <string> | default = ""]
+  [endpoint_suffix: <string> | default = "blob.core.windows.net"]
 
   # Number of retries for recoverable errors
   # CLI flag: -alertmanager-storage.azure.max-retries
@@ -1177,7 +1177,7 @@ azure:
   # Azure storage endpoint suffix without schema. The account name will be
   # prefixed to this value to create the FQDN
   # CLI flag: -blocks-storage.azure.endpoint-suffix
-  [endpoint_suffix: <string> | default = ""]
+  [endpoint_suffix: <string> | default = "blob.core.windows.net"]
 
   # Number of retries for recoverable errors
   # CLI flag: -blocks-storage.azure.max-retries
@@ -6303,7 +6303,7 @@ azure:
   # Azure storage endpoint suffix without schema. The account name will be
   # prefixed to this value to create the FQDN
   # CLI flag: -ruler-storage.azure.endpoint-suffix
-  [endpoint_suffix: <string> | default = ""]
+  [endpoint_suffix: <string> | default = "blob.core.windows.net"]
 
   # Number of retries for recoverable errors
   # CLI flag: -ruler-storage.azure.max-retries
@@ -6630,7 +6630,7 @@ azure:
   # Azure storage endpoint suffix without schema. The account name will be
   # prefixed to this value to create the FQDN
   # CLI flag: -runtime-config.azure.endpoint-suffix
-  [endpoint_suffix: <string> | default = ""]
+  [endpoint_suffix: <string> | default = "blob.core.windows.net"]
 
   # Number of retries for recoverable errors
   # CLI flag: -runtime-config.azure.max-retries

--- a/pkg/storage/bucket/azure/config.go
+++ b/pkg/storage/bucket/azure/config.go
@@ -33,7 +33,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Var(&cfg.StorageAccountKey, prefix+"azure.account-key", "Azure storage account key")
 	f.Var(&cfg.StorageConnectionString, prefix+"azure.connection-string", "The values of `account-name` and `endpoint-suffix` values will not be ignored if `connection-string` is set. Use this method over `account-key` if you need to authenticate via a SAS token or if you use the Azurite emulator.")
 	f.StringVar(&cfg.ContainerName, prefix+"azure.container-name", "", "Azure storage container name")
-	f.StringVar(&cfg.Endpoint, prefix+"azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN")
+	f.StringVar(&cfg.Endpoint, prefix+"azure.endpoint-suffix", "blob.core.windows.net", "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN")
 	f.IntVar(&cfg.MaxRetries, prefix+"azure.max-retries", 20, "Number of retries for recoverable errors")
 	f.StringVar(&cfg.MSIResource, prefix+"azure.msi-resource", "", "Deprecated: Azure storage MSI resource. It will be set automatically by Azure SDK.")
 	f.StringVar(&cfg.UserAssignedID, prefix+"azure.user-assigned-id", "", "Azure storage MSI resource managed identity client Id. If not supplied default Azure credential will be used. Set it to empty if you need to authenticate via Azure Workload Identity.")

--- a/pkg/storage/bucket/azure/config_test.go
+++ b/pkg/storage/bucket/azure/config_test.go
@@ -13,6 +13,7 @@ import (
 
 // defaultConfig should match the default flag values defined in RegisterFlagsWithPrefix.
 var defaultConfig = Config{
+	Endpoint:   "blob.core.windows.net",
 	MaxRetries: 20,
 	Config: http.Config{
 		IdleConnTimeout:       90 * time.Second,

--- a/schemas/cortex-config-schema.json
+++ b/schemas/cortex-config-schema.json
@@ -557,6 +557,7 @@
               "x-cli-flag": "alertmanager-storage.azure.container-name"
             },
             "endpoint_suffix": {
+              "default": "blob.core.windows.net",
               "description": "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN",
               "type": "string",
               "x-cli-flag": "alertmanager-storage.azure.endpoint-suffix"
@@ -983,6 +984,7 @@
               "x-cli-flag": "blocks-storage.azure.container-name"
             },
             "endpoint_suffix": {
+              "default": "blob.core.windows.net",
               "description": "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN",
               "type": "string",
               "x-cli-flag": "blocks-storage.azure.endpoint-suffix"
@@ -7803,6 +7805,7 @@
               "x-cli-flag": "ruler-storage.azure.container-name"
             },
             "endpoint_suffix": {
+              "default": "blob.core.windows.net",
               "description": "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN",
               "type": "string",
               "x-cli-flag": "ruler-storage.azure.endpoint-suffix"
@@ -8229,6 +8232,7 @@
               "x-cli-flag": "runtime-config.azure.container-name"
             },
             "endpoint_suffix": {
+              "default": "blob.core.windows.net",
               "description": "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN",
               "type": "string",
               "x-cli-flag": "runtime-config.azure.endpoint-suffix"


### PR DESCRIPTION
Motivation:
After commit da2ad99 switched Cortex's Azure bucket client to Thanos'
objstore, block-storage-dependent components (alertmanager, ruler,
store-gateway, compactor, etc.) hang on startup when `endpoint_suffix`
is left empty, failing with DNS errors and no clear message, e.g.:

    Get "https://<account>./<container>?restype=container": dial tcp:
    lookup <account>. on 192.168.5.3:53: no such host

Root cause: Cortex builds the Thanos `azure.Config` struct directly in
pkg/storage/bucket/azure/bucket_client.go and calls
`NewBucketWithConfig`, which bypasses Thanos' `parseConfig`/`DefaultConfig`
that would otherwise seed `Endpoint` with "blob.core.windows.net". Because
Cortex's own `azure.endpoint-suffix` flag defaulted to "", the resulting
FQDN was `<account>.`, which is invalid.

Approach:
Default the `azure.endpoint-suffix` flag to "blob.core.windows.net",
matching Thanos' `DefaultConfig`. This restores the pre-da2ad99
out-of-the-box behavior for Azure public cloud while still allowing the
value to be overridden for sovereign/government clouds. The
connection-string / Azurite path is unaffected because Thanos never reads
`Endpoint` when a connection string is set.

Test config default and generated config docs are updated to match.

Validation:
    go build ./...
    go test -tags "netgo slicelabels" ./pkg/storage/bucket/...
    make doc BUILD_IN_CONTAINER=false   # regenerated config docs
All passed.

Fixes #5449

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
