### PR TITLE
Add cortex_ingester_tsdb_head_max_timestamp metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [ENHANCEMENT] Query Frontend: Rename `time_taken` field to `time_taken_ms` and make it return millisecond count. #7649
 * [ENHANCEMENT] Update prometheus alertmanager version to v0.33.0. #7647
 * [ENHANCEMENT] Querier/Ingester: Detach ingester series from gRPC buffers to reduce heap. #7670
+* [ENHANCEMENT] Ingester: Add `cortex_ingester_tsdb_head_max_timestamp` metric that re-exports the TSDB head max timestamp (`prometheus_tsdb_head_max_time`) per user, to help investigate ingestion issues like out-of-bounds (too old sample) errors. #7694
 * [BUGFIX] Querier: Fix queryWithRetry and labelsWithRetry returning (nil, nil) on cancelled context by propagating ctx.Err(). #7370
 * [BUGFIX] Metrics Helper: Fix non-deterministic bucket order in merged histograms by sorting buckets after map iteration, matching Prometheus client library behavior. #7380
 * [BUGFIX] Distributor: Return HTTP 401 Unauthorized when tenant ID resolution fails in the Prometheus Remote Write 2.0 path. #7389

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -472,6 +472,7 @@ type tsdbMetrics struct {
 	tsdbHeadTruncateTotal              *prometheus.Desc
 	tsdbHeadGcDuration                 *prometheus.Desc
 	tsdbHeadStaleSeries                *prometheus.Desc
+	tsdbHeadMaxTimestamp               *prometheus.Desc
 	tsdbActiveAppenders                *prometheus.Desc
 	tsdbSeriesNotFound                 *prometheus.Desc
 	tsdbChunks                         *prometheus.Desc
@@ -608,6 +609,10 @@ func newTSDBMetrics(r prometheus.Registerer) *tsdbMetrics {
 		tsdbHeadStaleSeries: prometheus.NewDesc(
 			"cortex_ingester_tsdb_head_stale_series",
 			"Total number of stale series in the head block.",
+			[]string{"user"}, nil),
+		tsdbHeadMaxTimestamp: prometheus.NewDesc(
+			"cortex_ingester_tsdb_head_max_timestamp",
+			"Maximum timestamp of the head block, in milliseconds since epoch.",
 			[]string{"user"}, nil),
 		tsdbActiveAppenders: prometheus.NewDesc(
 			"cortex_ingester_tsdb_head_active_appenders",
@@ -775,6 +780,7 @@ func (sm *tsdbMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- sm.tsdbHeadTruncateFail
 	out <- sm.tsdbHeadTruncateTotal
 	out <- sm.tsdbHeadStaleSeries
+	out <- sm.tsdbHeadMaxTimestamp
 	out <- sm.tsdbHeadGcDuration
 	out <- sm.tsdbActiveAppenders
 	out <- sm.tsdbSeriesNotFound
@@ -841,6 +847,7 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCounters(out, sm.tsdbHeadTruncateTotal, "prometheus_tsdb_head_truncations_total")
 	data.SendSumOfSummaries(out, sm.tsdbHeadGcDuration, "prometheus_tsdb_head_gc_duration_seconds")
 	data.SendSumOfGaugesPerUser(out, sm.tsdbHeadStaleSeries, "prometheus_tsdb_head_stale_series")
+	data.SendMaxOfGaugesPerUser(out, sm.tsdbHeadMaxTimestamp, "prometheus_tsdb_head_max_time")
 	data.SendSumOfGauges(out, sm.tsdbActiveAppenders, "prometheus_tsdb_head_active_appenders")
 	data.SendSumOfCounters(out, sm.tsdbSeriesNotFound, "prometheus_tsdb_head_series_not_found_total")
 	data.SendSumOfGauges(out, sm.tsdbChunks, "prometheus_tsdb_head_chunks")

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -631,6 +631,12 @@ func TestTSDBMetrics(t *testing.T) {
 			cortex_ingester_tsdb_head_stale_series{user="user1"} 382695
 			cortex_ingester_tsdb_head_stale_series{user="user2"} 2659397
 			cortex_ingester_tsdb_head_stale_series{user="user3"} 30969
+			# HELP cortex_ingester_tsdb_head_max_timestamp Maximum timestamp of the head block, in milliseconds since epoch.
+			# TYPE cortex_ingester_tsdb_head_max_timestamp gauge
+			# 36 * base
+			cortex_ingester_tsdb_head_max_timestamp{user="user1"} 444420
+			cortex_ingester_tsdb_head_max_timestamp{user="user2"} 3088332
+			cortex_ingester_tsdb_head_max_timestamp{user="user3"} 35964
 	`))
 	require.NoError(t, err)
 }
@@ -925,6 +931,11 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 			# TYPE cortex_ingester_tsdb_head_stale_series gauge
 			cortex_ingester_tsdb_head_stale_series{user="user1"} 382695
 			cortex_ingester_tsdb_head_stale_series{user="user2"} 2659397
+			# HELP cortex_ingester_tsdb_head_max_timestamp Maximum timestamp of the head block, in milliseconds since epoch.
+			# TYPE cortex_ingester_tsdb_head_max_timestamp gauge
+			# 36 * base
+			cortex_ingester_tsdb_head_max_timestamp{user="user1"} 444420
+			cortex_ingester_tsdb_head_max_timestamp{user="user2"} 3088332
 	`))
 	require.NoError(t, err)
 }
@@ -1257,6 +1268,12 @@ func populateTSDBMetrics(base float64) *prometheus.Registry {
 		Help: "Total number of stale series in the head block.",
 	})
 	headStaleSeries.Set(31 * base)
+
+	headMaxTime := promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_head_max_time",
+		Help: "Maximum timestamp of the head block. The unit is decided by the library consumer.",
+	})
+	headMaxTime.Set(36 * base)
 
 	recordPartWrites := promauto.With(r).NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_wal_record_part_writes_total",


### PR DESCRIPTION
**What this PR does**:

TSDB exposes the max timestamp of the head block via `prometheus_tsdb_head_max_time`, but the Cortex ingester did not re-export it per tenant. This PR adds a new `cortex_ingester_tsdb_head_max_timestamp` metric (with a `user` label) that re-exports the TSDB head max timestamp per user, following the existing re-export pattern in `pkg/ingester/metrics.go` (aggregated with max across TSDBs via `SendMaxOfGaugesPerUser`). The value is in milliseconds since epoch, matching the unit Cortex uses for the TSDB head.

This improves debuggability for ingestion issues: for example, when investigating out-of-bounds ("sample too old") write errors, operators can now directly see each tenant's head max time and compare it against incoming sample timestamps.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added (not needed — metric-only change, `make doc` produces no changes)
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags (N/A — no flags introduced)
