### PR TITLE
Fix DNS watcher from clearing known endpoints on lookup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 * [BUGFIX] Querier: Fix parquet queryable fallback returning a nil error instead of the actual query error in `LabelValues` and `LabelNames`. #7638
 * [BUGFIX] Storage: Default the Azure `endpoint_suffix` to `blob.core.windows.net` instead of empty. Cortex builds the Thanos Azure config directly and bypasses Thanos' default, so an unset suffix produced an invalid FQDN (`<account>.`) and components hung on startup with DNS errors. #5449
 * [BUGFIX] Store Gateway: Fix misleading "no index cache backend addresses" validation error being reported for chunks-cache, metadata-cache, and parquet caches when their memcached or redis backend is configured without addresses. The message is now the cache-type-agnostic "no cache backend addresses". #7675
+* [BUGFIX] DNS: Fix DNS watcher from dropping resolved addresses on transient lookup failures. #7698
 
 ## 1.21.0 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@
 * [BUGFIX] Querier: Fix parquet queryable fallback returning a nil error instead of the actual query error in `LabelValues` and `LabelNames`. #7638
 * [BUGFIX] Storage: Default the Azure `endpoint_suffix` to `blob.core.windows.net` instead of empty. Cortex builds the Thanos Azure config directly and bypasses Thanos' default, so an unset suffix produced an invalid FQDN (`<account>.`) and components hung on startup with DNS errors. #5449
 * [BUGFIX] Store Gateway: Fix misleading "no index cache backend addresses" validation error being reported for chunks-cache, metadata-cache, and parquet caches when their memcached or redis backend is configured without addresses. The message is now the cache-type-agnostic "no cache backend addresses". #7675
-* [BUGFIX] DNS: Fix DNS watcher from dropping resolved addresses on transient lookup failures. #7698
+* [BUGFIX] Querier/Query Frontend: Fix DNS watcher dropping all query-frontend/scheduler worker connections on a transient DNS lookup failure. #7698
 
 ## 1.21.0 2026-04-24
 

--- a/pkg/util/grpcutil/dns_resolver.go
+++ b/pkg/util/grpcutil/dns_resolver.go
@@ -267,7 +267,7 @@ func (w *dnsWatcher) Next() ([]*Update, error) {
 		result := w.lookup()
 		// Next lookup should happen after an interval defined by w.r.freq.
 		w.t.Reset(w.r.freq)
-		if result != nil && len(result) > 0 {
+		if len(result) > 0 {
 			return result, nil
 		}
 	}

--- a/pkg/util/grpcutil/dns_resolver.go
+++ b/pkg/util/grpcutil/dns_resolver.go
@@ -244,6 +244,12 @@ func (w *dnsWatcher) lookup() []*Update {
 		// return any A record info available.
 		newAddrs = w.lookupHost()
 	}
+	if newAddrs == nil {
+		// Both the SRV and A record lookups failed. Keep the previously
+		// resolved addresses cached instead of removing them, so a transient
+		// DNS failure doesn't drop all currently known endpoints.
+		return nil
+	}
 	result := w.compileUpdate(newAddrs)
 	w.curAddrs = newAddrs
 	return result
@@ -261,7 +267,7 @@ func (w *dnsWatcher) Next() ([]*Update, error) {
 		result := w.lookup()
 		// Next lookup should happen after an interval defined by w.r.freq.
 		w.t.Reset(w.r.freq)
-		if len(result) > 0 {
+		if result != nil && len(result) > 0 {
 			return result, nil
 		}
 	}

--- a/pkg/util/grpcutil/dns_resolver_test.go
+++ b/pkg/util/grpcutil/dns_resolver_test.go
@@ -1,0 +1,80 @@
+package grpcutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func stubLookups(t *testing.T, host func(ctx context.Context, host string) ([]string, error)) {
+	t.Helper()
+	orig := lookupHost
+	lookupHost = host
+	t.Cleanup(func() { lookupHost = orig })
+}
+
+func newTestDNSWatcher() *dnsWatcher {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &dnsWatcher{
+		r:      &Resolver{freq: time.Hour},
+		logger: log.NewNopLogger(),
+		host:   "myhost",
+		port:   "80",
+		ctx:    ctx,
+		cancel: cancel,
+		t:      time.NewTimer(0),
+	}
+}
+
+func TestDNSWatcher_Next(t *testing.T) {
+	stubLookups(t, func(context.Context, string) ([]string, error) {
+		return []string{"1.2.3.4"}, nil
+	})
+
+	w := newTestDNSWatcher()
+	updates, err := w.Next()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []*Update{{Op: Add, Addr: "1.2.3.4:80"}}, updates)
+	assert.Equal(t, map[string]*Update{"1.2.3.4:80": {Addr: "1.2.3.4:80"}}, w.curAddrs)
+
+	// Lookup returns only 5.6.7.8, removing 1.2.3.4
+	stubLookups(t, func(context.Context, string) ([]string, error) {
+		return []string{"5.6.7.8"}, nil
+	})
+
+	// Fire the timer again so Next() performs another lookup immediately.
+	w.t.Reset(0)
+	updates, err = w.Next()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []*Update{
+		{Op: Delete, Addr: "1.2.3.4:80"},
+		{Op: Add, Addr: "5.6.7.8:80"},
+	}, updates)
+	assert.Equal(t, map[string]*Update{"5.6.7.8:80": {Addr: "5.6.7.8:80"}}, w.curAddrs)
+}
+
+func TestDNSWatcher_Lookup_TransientFailureRetainsCache(t *testing.T) {
+	// First resolution succeeds and populates curAddrs.
+	stubLookups(t, func(context.Context, string) ([]string, error) {
+		return []string{"1.2.3.4"}, nil
+	})
+
+	w := newTestDNSWatcher()
+	result := w.lookup()
+	assert.ElementsMatch(t, []*Update{{Op: Add, Addr: "1.2.3.4:80"}}, result)
+	require.Equal(t, map[string]*Update{"1.2.3.4:80": {Addr: "1.2.3.4:80"}}, w.curAddrs)
+
+	// Fail next lookup
+	stubLookups(t, func(context.Context, string) ([]string, error) {
+		return nil, errors.New("unable to resolve address")
+	})
+
+	result = w.lookup()
+	assert.Nil(t, result)
+	assert.Equal(t, map[string]*Update{"1.2.3.4:80": {Addr: "1.2.3.4:80"}}, w.curAddrs)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Components like the querier and query-frontend use the DNSWatcher to handle resolution of addresses. When DNS lookups fail (due to an issue on the DNS server, for instance), the resolved address set is set to nil, which sends a Delete for every previously known address.

This PR changes the DNSWatcher to retain all previously known addresses during DNS resolution failures, to prevent queriers (for instance) from clearing all known DNS records.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
