### PR TITLE
Assert store-gateway path in compression test

### DIFF
--- a/integration/grpc_compression_test.go
+++ b/integration/grpc_compression_test.go
@@ -118,6 +118,15 @@ func TestGRPCCompression(t *testing.T) {
 
 			// Wait until the TSDB head is shipped to storage and the store-gateway picks it up.
 			require.NoError(t, ingester.WaitSumMetrics(e2e.Greater(0), "cortex_ingester_shipper_uploads_total"))
+			require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(2), "cortex_ingester_memory_series_created_total"))
+			require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(1), "cortex_ingester_memory_series_removed_total"))
+			require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(1), "cortex_ingester_memory_series"))
+
+			// Start the compactor to create the bucket index before the store-gateway loads the shipped block.
+			compactor := e2ecortex.NewCompactor("compactor", consul.NetworkHTTPEndpoint(), flags, "")
+			require.NoError(t, s.StartAndWaitReady(compactor))
+			require.NoError(t, compactor.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_compactor_block_cleanup_completed_total"}, e2e.WaitMissingMetrics))
+
 			require.NoError(t, storeGateway.WaitSumMetrics(e2e.Greater(0), "cortex_storegateway_bucket_sync_total"))
 			require.NoError(t, storeGateway.WaitSumMetricsWithOptions(e2e.Equals(float64(1)), []string{"cortex_bucket_store_blocks_loaded"}, e2e.WaitMissingMetrics))
 

--- a/integration/grpc_compression_test.go
+++ b/integration/grpc_compression_test.go
@@ -119,12 +119,16 @@ func TestGRPCCompression(t *testing.T) {
 			// Wait until the TSDB head is shipped to storage and the store-gateway picks it up.
 			require.NoError(t, ingester.WaitSumMetrics(e2e.Greater(0), "cortex_ingester_shipper_uploads_total"))
 			require.NoError(t, storeGateway.WaitSumMetrics(e2e.Greater(0), "cortex_storegateway_bucket_sync_total"))
+			require.NoError(t, storeGateway.WaitSumMetricsWithOptions(e2e.Equals(float64(1)), []string{"cortex_bucket_store_blocks_loaded"}, e2e.WaitMissingMetrics))
 
-			// Query the first series — this goes through the store-gateway with snappy compression.
+			// Query the first series and assert the querier used the store-gateway client configured with compression.
 			result, err := c.Query("series_1", series1Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector1, result.(model.Vector))
+			require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_storegateway_client_request_duration_seconds"}, e2e.WithMetricCount, e2e.WithLabelMatchers(
+				labels.MustNewMatcher(labels.MatchEqual, "operation", "/gatewaypb.StoreGateway/Series"),
+			)))
 		})
 	}
 }


### PR DESCRIPTION
## What this changes

- Waits until the store-gateway has loaded the shipped block, not only until a bucket sync has happened.
- After querying the shipped series, asserts that the querier recorded a `/gatewaypb.StoreGateway/Series` client request.
- This makes the store-gateway compression subtest prove it exercised the `-querier.store-gateway-client.grpc-compression` path.

Fixes #7583.

## Testing

- `GOCACHE=/private/tmp/cortex-go-cache GOMODCACHE=/private/tmp/cortex-go-mod-cache go test -tags requires_docker,integration,integration_grpc ./integration -run TestGRPCCompression -count=0`
