### PR TITLE
Strengthen stream push signing mismatch test

### DIFF
--- a/integration/ingester_stream_push_test.go
+++ b/integration/ingester_stream_push_test.go
@@ -204,10 +204,9 @@ func TestIngesterStreamPushConnectionWithMismatchedSigningKey(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		series, _ := generateSeries(fmt.Sprintf("test_signing_mismatch_%d", i), now)
 		res, err := client.Push(series)
-		if err == nil {
-			require.NotEqual(t, 200, res.StatusCode,
-				"push must fail when distributor and ingester use different signing keys")
-		}
+		require.NoError(t, err)
+		require.NotEqual(t, 200, res.StatusCode,
+			"push must fail when distributor and ingester use different signing keys")
 	}
 }
 


### PR DESCRIPTION
## What this changes

- Strengthens the mismatched signing-key stream-push integration test.
- Requires the HTTP push call itself to complete successfully before checking the rejection status.
- Ensures every mismatched-key push asserts a non-200 response instead of skipping the assertion when `client.Push` returns an error.

Fixes #7580.

## Testing

- `GOCACHE=/private/tmp/cortex-go-cache GOMODCACHE=/private/tmp/cortex-go-mod-cache go test -tags requires_docker,integration ./integration -run TestIngesterStreamPushConnectionWithMismatchedSigningKey -count=0`
