### PR TITLE
fix(distributor): UserStats returns error when a ring member is LEAVING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master / unreleased
+* [BUGFIX] Distributor: `UserStats` no longer returns an error when one ingester in the replication set is LEAVING or otherwise temporarily unavailable. #4936
 * [CHANGE] Querier: Make query time range configurations per-tenant: `query_ingesters_within`, `query_store_after`, and `shuffle_sharding_ingesters_lookback_period`. Uses `model.Duration` instead of `time.Duration` to support serialization but has minimum unit of 1ms (nanoseconds/microseconds not supported). #7160
 * [CHANGE] Cache: Setting `-blocks-storage.bucket-store.metadata-cache.bucket-index-content-ttl` to 0 will disable the bucket-index cache. #7446
 * [CHANGE] HA Tracker: Move `-distributor.ha-tracker.failover-timeout` from a global config to a per-tenant runtime config. The flag name and default value (30s) remain the same. #7481

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - `-ingester.max-series-per-query` (a chunks-storage limit, ignored since blocks storage; use `-querier.max-fetched-series-per-query`)
 * [CHANGE] Ingester: Formally deprecate `-blocks-storage.tsdb.max-exemplars`, scheduled for removal in v1.24.0. Use the per-tenant `max_exemplars` limit instead. The flag still works as the global fallback when `max_exemplars` is 0, but setting it now logs a warning and increments `deprecated_flags_inuse_total`. #7793
 * [CHANGE] Ingester: Graduate native histogram ingestion (`-blocks-storage.tsdb.enable-native-histograms`) from experimental. #7789
+* [BUGFIX] Distributor: `UserStats` no longer returns an error when one ingester in the replication set is LEAVING or otherwise temporarily unavailable. #4936
 * [CHANGE] Querier: Make query time range configurations per-tenant: `query_ingesters_within`, `query_store_after`, and `shuffle_sharding_ingesters_lookback_period`. Uses `model.Duration` instead of `time.Duration` to support serialization but has minimum unit of 1ms (nanoseconds/microseconds not supported). #7160
 * [CHANGE] Cache: Setting `-blocks-storage.bucket-store.metadata-cache.bucket-index-content-ttl` to 0 will disable the bucket-index cache. #7446
 * [CHANGE] HA Tracker: Move `-distributor.ha-tracker.failover-timeout` from a global config to a per-tenant runtime config. The flag name and default value (30s) remain the same. #7481

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1687,8 +1687,10 @@ func (d *Distributor) UserStats(ctx context.Context) (*ingester.UserStats, error
 		return nil, err
 	}
 
-	// Make sure we get a successful response from all of them.
-	replicationSet.MaxErrors = 0
+	// Allow a subset of ingesters to fail (e.g. during a rolling update where
+	// some are LEAVING). MaxErrors is already set by the ring to the quorum
+	// tolerance; overriding it to 0 caused the endpoint to error whenever a
+	// LEAVING ingester was in the set and returned an error (issue #4936).
 
 	req := &ingester_client.UserStatsRequest{}
 	resps, err := d.ForReplicationSet(ctx, replicationSet, false, false, func(ctx context.Context, client ingester_client.IngesterClient) (any, error) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4070,6 +4070,16 @@ func (s *metricsForLabelMatchersStream) Recv() (*client.MetricsForLabelMatchersS
 	return result, nil
 }
 
+func (i *mockIngester) UserStats(ctx context.Context, in *client.UserStatsRequest, opts ...grpc.CallOption) (*client.UserStatsResponse, error) {
+	if !i.happy.Load() {
+		return nil, errFail
+	}
+	return &client.UserStatsResponse{
+		IngestionRate: 0,
+		NumSeries:     0,
+	}, nil
+}
+
 func (i *mockIngester) AllUserStats(ctx context.Context, in *client.UserStatsRequest, opts ...grpc.CallOption) (*client.UsersStatsResponse, error) {
 	return &i.stats, nil
 }
@@ -4970,4 +4980,28 @@ func TestDistributor_ReceivedHistogramBucketsMetric(t *testing.T) {
 	require.Equal(t, uint64(1), m.GetHistogram().GetSampleCount())
 	// GenerateTestHistogram(0): 4 positive + 4 negative + 1 zero = 9 buckets
 	require.Equal(t, float64(9), m.GetHistogram().GetSampleSum())
+}
+
+
+// TestUserStats_ToleratesLeavingIngester verifies that UserStats succeeds
+// when one of the ring ingesters fails (e.g. because it is LEAVING).
+// Before the fix, MaxErrors was set to 0, causing the endpoint to return an
+// error whenever a single ingester in the replication set was unavailable.
+func TestUserStats_ToleratesLeavingIngester(t *testing.T) {
+	t.Parallel()
+
+	// 3 ingesters, RF=3, only 2 are happy — simulates one LEAVING ingester
+	// returning an error.
+	ctx := user.InjectOrgID(context.Background(), "user1")
+	distributors, _, _, _ := prepare(t, prepConfig{
+		numIngesters:    3,
+		happyIngesters:  2,
+		numDistributors: 1,
+		replicationFactor: 3,
+	})
+
+	// UserStats must succeed despite one ingester failing.
+	stats, err := distributors[0].UserStats(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, stats)
 }

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4982,7 +4982,6 @@ func TestDistributor_ReceivedHistogramBucketsMetric(t *testing.T) {
 	require.Equal(t, float64(9), m.GetHistogram().GetSampleSum())
 }
 
-
 // TestUserStats_ToleratesLeavingIngester verifies that UserStats succeeds
 // when one of the ring ingesters fails (e.g. because it is LEAVING).
 // Before the fix, MaxErrors was set to 0, causing the endpoint to return an
@@ -4994,9 +4993,9 @@ func TestUserStats_ToleratesLeavingIngester(t *testing.T) {
 	// returning an error.
 	ctx := user.InjectOrgID(context.Background(), "user1")
 	distributors, _, _, _ := prepare(t, prepConfig{
-		numIngesters:    3,
-		happyIngesters:  2,
-		numDistributors: 1,
+		numIngesters:      3,
+		happyIngesters:    2,
+		numDistributors:   1,
 		replicationFactor: 3,
 	})
 


### PR DESCRIPTION
Fixes #4936

## Proposed Changes

`UserStats` called `GetIngestersForMetadata` (which uses `ring.Read`, including `LEAVING` instances) and then explicitly set `replicationSet.MaxErrors = 0`, requiring **every** ingester in the set to respond. During a rolling update or any graceful shutdown, ingesters transition through the `LEAVING` state and may return RPC errors. With `MaxErrors = 0`, a single such failure caused the entire `/api/v1/user_stats` endpoint to return an error.

The fix removes the `MaxErrors = 0` override and lets the ring's own quorum tolerance apply (`RF/2` failures are allowed for `Read` operations). This matches the behaviour of other metadata endpoints (e.g. `LabelValuesForLabelName`) that do not override `MaxErrors`.

- :bug: Remove `replicationSet.MaxErrors = 0` in `UserStats`; add explanatory comment
- :broom: Add `UserStats` method to `mockIngester`
- :broom: Add `TestUserStats_ToleratesLeavingIngester` that confirms the endpoint succeeds with one unhappy ingester out of three

> Note: This PR was developed with AI assistance (Claude Code).

**Release Note**
```release-note
[BUGFIX] Distributor: UserStats no longer errors when one ingester in the replication set is LEAVING or temporarily unavailable.
```