### PR TITLE
Fix DynamoDB KV CAS not retrying on transactional conditional check failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 * [BUGFIX] Querier: Fix parquet queryable fallback returning a nil error instead of the actual query error in `LabelValues` and `LabelNames`. #7638
 * [BUGFIX] Storage: Default the Azure `endpoint_suffix` to `blob.core.windows.net` instead of empty. Cortex builds the Thanos Azure config directly and bypasses Thanos' default, so an unset suffix produced an invalid FQDN (`<account>.`) and components hung on startup with DNS errors. #5449
 * [BUGFIX] Store Gateway: Fix misleading "no index cache backend addresses" validation error being reported for chunks-cache, metadata-cache, and parquet caches when their memcached or redis backend is configured without addresses. The message is now the cache-type-agnostic "no cache backend addresses". #7675
+* [BUGFIX] Ring: Fix DynamoDB KV CAS not retrying on transactional conditional check failures. `TransactWriteItems` reports condition failures as `TransactionCanceledException` with a `ConditionalCheckFailed` cancellation reason, which was not recognized as retryable, so any concurrent ring update conflict (e.g. many ingesters joining during a rolling update) failed immediately instead of re-reading and retrying. `TransactionConflict` cancellation reasons are also treated as retryable. #7706
 
 ## 1.21.0 2026-04-24
 

--- a/pkg/ring/kv/dynamodb/dynamodb.go
+++ b/pkg/ring/kv/dynamodb/dynamodb.go
@@ -265,8 +265,7 @@ func (kv dynamodbKV) Batch(ctx context.Context, put map[dynamodbKey]dynamodbItem
 			TransactItems: slice,
 		})
 		if err != nil {
-			var checkFailed *types.ConditionalCheckFailedException
-			isCheckFailed := errors.As(err, &checkFailed)
+			isCheckFailed := isConditionalCheckFailure(err)
 			if isCheckFailed {
 				kv.logger.Log("msg", "conditional check failed on DynamoDB Batch", "err", err)
 			}
@@ -278,6 +277,40 @@ func (kv dynamodbKV) Batch(ctx context.Context, put map[dynamodbKey]dynamodbItem
 	}
 
 	return totalCapacity, false, nil
+}
+
+// isConditionalCheckFailure returns true if the given error was caused by a
+// conditional check failure, meaning another writer updated the item between
+// our read and write. Such conflicts are retryable: the caller should re-read
+// the latest state and retry the operation.
+//
+// DynamoDB reports conditional check failures differently depending on the API:
+//   - Single-item operations (PutItem, UpdateItem, DeleteItem) return
+//     ConditionalCheckFailedException.
+//   - TransactWriteItems returns TransactionCanceledException with the failure
+//     reported in CancellationReasons with code "ConditionalCheckFailed".
+//
+// TransactionConflict cancellation reasons (another transaction is in progress
+// on the same item) are equally transient and also treated as retryable.
+func isConditionalCheckFailure(err error) bool {
+	var checkFailed *types.ConditionalCheckFailedException
+	if errors.As(err, &checkFailed) {
+		return true
+	}
+
+	var txnCanceled *types.TransactionCanceledException
+	if errors.As(err, &txnCanceled) {
+		for _, reason := range txnCanceled.CancellationReasons {
+			if reason.Code == nil {
+				continue
+			}
+			switch *reason.Code {
+			case "ConditionalCheckFailed", "TransactionConflict":
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (kv dynamodbKV) generatePutItemRequest(key dynamodbKey, ddbItem dynamodbItem) map[string]types.AttributeValue {

--- a/pkg/ring/kv/dynamodb/dynamodb.go
+++ b/pkg/ring/kv/dynamodb/dynamodb.go
@@ -293,13 +293,11 @@ func (kv dynamodbKV) Batch(ctx context.Context, put map[dynamodbKey]dynamodbItem
 // TransactionConflict cancellation reasons (another transaction is in progress
 // on the same item) are equally transient and also treated as retryable.
 func isConditionalCheckFailure(err error) bool {
-	var checkFailed *types.ConditionalCheckFailedException
-	if errors.As(err, &checkFailed) {
+	if _, ok := errors.AsType[*types.ConditionalCheckFailedException](err); ok {
 		return true
 	}
 
-	var txnCanceled *types.TransactionCanceledException
-	if errors.As(err, &txnCanceled) {
+	if txnCanceled, ok := errors.AsType[*types.TransactionCanceledException](err); ok {
 		for _, reason := range txnCanceled.CancellationReasons {
 			if reason.Code == nil {
 				continue

--- a/pkg/ring/kv/dynamodb/dynamodb_test.go
+++ b/pkg/ring/kv/dynamodb/dynamodb_test.go
@@ -170,6 +170,38 @@ func Test_Batch_Error(t *testing.T) {
 			mockError:     &types.ConditionalCheckFailedException{},
 			expectedRetry: true,
 		},
+		{
+			// TransactWriteItems reports conditional check failures as
+			// TransactionCanceledException with a ConditionalCheckFailed
+			// cancellation reason, wrapped by the SDK operation error.
+			name: "transaction_canceled_conditional_check_failed_should_retry",
+			mockError: fmt.Errorf("operation error DynamoDB: TransactWriteItems: %w", &types.TransactionCanceledException{
+				Message: aws.String("Transaction cancelled, please refer cancellation reasons for specific reasons"),
+				CancellationReasons: []types.CancellationReason{
+					{Code: aws.String("None")},
+					{Code: aws.String("ConditionalCheckFailed")},
+				},
+			}),
+			expectedRetry: true,
+		},
+		{
+			name: "transaction_canceled_transaction_conflict_should_retry",
+			mockError: fmt.Errorf("operation error DynamoDB: TransactWriteItems: %w", &types.TransactionCanceledException{
+				CancellationReasons: []types.CancellationReason{
+					{Code: aws.String("TransactionConflict")},
+				},
+			}),
+			expectedRetry: true,
+		},
+		{
+			name: "transaction_canceled_other_reason_no_retry",
+			mockError: fmt.Errorf("operation error DynamoDB: TransactWriteItems: %w", &types.TransactionCanceledException{
+				CancellationReasons: []types.CancellationReason{
+					{Code: aws.String("ValidationError")},
+				},
+			}),
+			expectedRetry: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does**:

The `Batch()` error detection in the DynamoDB KV store only matches `ConditionalCheckFailedException`, which DynamoDB returns for **single-item** operations (`PutItem`/`UpdateItem` with a `ConditionExpression`). But `Batch()` calls `TransactWriteItems`, which reports condition failures as **`TransactionCanceledException`** with a `ConditionalCheckFailed` cancellation reason instead. `TransactionCanceledException` has no `Unwrap()` and the cancellation reasons are plain data fields, so `errors.As(err, *ConditionalCheckFailedException)` can never match on this code path — the SDK's `TransactWriteItems` error deserializer doesn't even have a `ConditionalCheckFailedException` case.

As a result `retry=false` is always returned for CAS write conflicts, and the CAS loop in `client.go` gives up on the first attempt instead of re-reading the ring and retrying with a fresh version. The 10-retry backoff loop (`maxCasRetries`) is effectively dead code for the most common conflict signal.

**Production impact observed:** during rolling updates where many ingesters cycle concurrently, a joining ingester that loses the optimistic-concurrency race on the ring key fails startup with:

```
module failed: ingester subservice failed: service ingester ring lifecycler failed: failed to pick tokens in the KV store, ring: ingester, state: ACTIVE: operation error DynamoDB: TransactWriteItems, https response error StatusCode: 400, ..., TransactionCanceledException: Transaction cancelled, please refer cancellation reasons for specific reasons [ConditionalCheckFailed]
```

and the process exits (crash + kubelet restart) instead of retrying. The failure occurs ~18ms after the CAS write — no backoff ever happens. The heartbeat path survives the same error only because its caller sleeps and retries at the next heartbeat interval.

**The fix:** extract the error classification into `isConditionalCheckFailure()`, which handles both shapes:
- `ConditionalCheckFailedException` (single-item operations) — unchanged behavior
- `TransactionCanceledException` with a `ConditionalCheckFailed` cancellation reason (transactions)

`TransactionConflict` cancellation reasons (another transaction in progress on the same item) are equally transient under concurrent ring writes and are also treated as retryable.

With this fix the CAS loop does what it was designed to do on conflict: re-read the latest ring state, re-apply the mutation, and write with the fresh version condition.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added (not needed — no config/API change)
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags (not needed — no new flags)