### PR TITLE
Fix StringSliceCSV treating explicit empty string as a one-element list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 * [BUGFIX] Memberlist: Add `-memberlist.packet-read-timeout`, `-memberlist.max-packet-size`, and `-memberlist.max-concurrent-connections` flags to bound inbound gossip TCP connections, preventing slow-read, OOM, and connection-flood attacks on the gossip port. #7518
 * [BUGFIX] Distributor: Add `WrappedHistogram` with configurable size limit (`-validation.max-native-histogram-size-bytes`, default 16 KB) to cap native histogram protobuf size before unmarshalling, preventing memory amplification attacks via packed varint deltas. #7570
 * [BUGFIX] Distributor: Fix a panic (`slice bounds out of range`) in the stream push path when the context deadline expires while the worker goroutine is still marshalling a `WriteRequest`. #7541
+* [BUGFIX] Config: Fix CSV-list flags/YAML fields (e.g. `-compactor.enabled-tenants`, `-compactor.disabled-tenants`) treating an explicitly empty string (`""`) as a one-element list containing an empty tenant name instead of an empty list. This caused every tenant to be skipped when `enabled_tenants: ""` was set in config, since only the (nonexistent) empty-string tenant matched the allow-list. #6581
 
 ## 1.21.0 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@
 * [BUGFIX] Alertmanager: Reject the global `mattermost_webhook_url_file` setting in per-tenant configs, consistent with every other global `*_file` setting. #7768
 * [BUGFIX] Alertmanager: Tighten per-tenant config validation to reject additional file-based settings. #7767
 * [BUGFIX] Querier: Fix panic (`index out of range [-1]`) in the active request tracker when truncating a `match[]`/`query` value made entirely of invalid UTF-8 continuation bytes. The backwards scan for a rune boundary now stops at index 0 instead of underflowing. #7743
+* [BUGFIX] Config: Fix CSV-list flags/YAML fields (e.g. `-compactor.enabled-tenants`) treating an explicitly empty string as a one-element list containing an empty tenant name instead of an empty list. #7714
 
 ## 1.21.1 2026-06-04
 
@@ -126,7 +127,6 @@
 * [BUGFIX] Memberlist: Add `-memberlist.packet-read-timeout`, `-memberlist.max-packet-size`, and `-memberlist.max-concurrent-connections` flags to bound inbound gossip TCP connections, preventing slow-read, OOM, and connection-flood attacks on the gossip port. #7518
 * [BUGFIX] Distributor: Add `WrappedHistogram` with configurable size limit (`-validation.max-native-histogram-size-bytes`, default 16 KB) to cap native histogram protobuf size before unmarshalling, preventing memory amplification attacks via packed varint deltas. #7570
 * [BUGFIX] Distributor: Fix a panic (`slice bounds out of range`) in the stream push path when the context deadline expires while the worker goroutine is still marshalling a `WriteRequest`. #7541
-* [BUGFIX] Config: Fix CSV-list flags/YAML fields (e.g. `-compactor.enabled-tenants`) treating an explicitly empty string as a one-element list containing an empty tenant name instead of an empty list. #7714
 
 ## 1.21.0 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@
 * [BUGFIX] Memberlist: Add `-memberlist.packet-read-timeout`, `-memberlist.max-packet-size`, and `-memberlist.max-concurrent-connections` flags to bound inbound gossip TCP connections, preventing slow-read, OOM, and connection-flood attacks on the gossip port. #7518
 * [BUGFIX] Distributor: Add `WrappedHistogram` with configurable size limit (`-validation.max-native-histogram-size-bytes`, default 16 KB) to cap native histogram protobuf size before unmarshalling, preventing memory amplification attacks via packed varint deltas. #7570
 * [BUGFIX] Distributor: Fix a panic (`slice bounds out of range`) in the stream push path when the context deadline expires while the worker goroutine is still marshalling a `WriteRequest`. #7541
-* [BUGFIX] Config: Fix CSV-list flags/YAML fields (e.g. `-compactor.enabled-tenants`, `-compactor.disabled-tenants`) treating an explicitly empty string (`""`) as a one-element list containing an empty tenant name instead of an empty list. This caused every tenant to be skipped when `enabled_tenants: ""` was set in config, since only the (nonexistent) empty-string tenant matched the allow-list. #6581
+* [BUGFIX] Config: Fix CSV-list flags/YAML fields (e.g. `-compactor.enabled-tenants`) treating an explicitly empty string as a one-element list containing an empty tenant name instead of an empty list. #7714
 
 ## 1.21.0 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@
 * [BUGFIX] Memberlist: Add `-memberlist.packet-read-timeout`, `-memberlist.max-packet-size`, and `-memberlist.max-concurrent-connections` flags to bound inbound gossip TCP connections, preventing slow-read, OOM, and connection-flood attacks on the gossip port. #7518
 * [BUGFIX] Distributor: Add `WrappedHistogram` with configurable size limit (`-validation.max-native-histogram-size-bytes`, default 16 KB) to cap native histogram protobuf size before unmarshalling, preventing memory amplification attacks via packed varint deltas. #7570
 * [BUGFIX] Distributor: Fix a panic (`slice bounds out of range`) in the stream push path when the context deadline expires while the worker goroutine is still marshalling a `WriteRequest`. #7541
+* [BUGFIX] Config: Fix CSV-list flags/YAML fields (e.g. `-compactor.enabled-tenants`, `-compactor.disabled-tenants`) treating an explicitly empty string (`""`) as a one-element list containing an empty tenant name instead of an empty list. This caused every tenant to be skipped when `enabled_tenants: ""` was set in config, since only the (nonexistent) empty-string tenant matched the allow-list. #6581
 
 ## 1.21.0 2026-04-24
 

--- a/pkg/util/flagext/stringslicecsv.go
+++ b/pkg/util/flagext/stringslicecsv.go
@@ -13,6 +13,10 @@ func (v StringSliceCSV) String() string {
 
 // Set implements flag.Value
 func (v *StringSliceCSV) Set(s string) error {
+	if s == "" {
+		*v = nil
+		return nil
+	}
 	*v = strings.Split(s, ",")
 	return nil
 }

--- a/pkg/util/flagext/stringslicecsv_test.go
+++ b/pkg/util/flagext/stringslicecsv_test.go
@@ -32,3 +32,21 @@ func Test_StringSliceCSV(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, testStruct, testStruct2)
 }
+
+func Test_StringSliceCSV_Empty(t *testing.T) {
+	var v StringSliceCSV
+	assert.Nil(t, v.Set(""))
+	assert.Equal(t, []string(nil), []string(v))
+	assert.Len(t, v, 0)
+}
+
+func Test_StringSliceCSV_UnmarshalYAML_Empty(t *testing.T) {
+	type TestStruct struct {
+		CSV StringSliceCSV `yaml:"csv"`
+	}
+
+	var testStruct TestStruct
+	err := yaml.Unmarshal([]byte(`csv: ""`), &testStruct)
+	assert.Nil(t, err)
+	assert.Len(t, testStruct.CSV, 0)
+}


### PR DESCRIPTION
Motivation:
Issue #6581 reports that setting `compactor.enabled_tenants: ""`
explicitly in config causes the compactor to skip every tenant,
instead of behaving like the unset/omitted case (all tenants
allowed). The compactor logs "skipping user because it is not owned
by this shard" for every real tenant.

Approach:
`StringSliceCSV.Set` (pkg/util/flagext/stringslicecsv.go), which
backs `-compactor.enabled-tenants`/`-compactor.disabled-tenants` and
several other CSV-list flags (alertmanager, ruler, store-gateway,
ingester, querier, distributor, ring, limits, etc.), implemented
`Set` as `strings.Split(s, ",")`. Go's `strings.Split("", ",")`
returns `[""]`, a one-element slice containing an empty string, not
an empty/nil slice. YAML unmarshaling for `enabled_tenants: ""`
calls `Set("")`, so `EnabledTenants` ends up as `[""]` with
`len() == 1`.

`users.NewAllowedTenants` (pkg/util/users/allowed_tenants.go) treats
`len(enabled) > 0` as "only tenants in this list are allowed", so
with `enabled == [""]` only a tenant literally named `""` is
allowed and every real tenant is rejected. This same
`NewAllowedTenants` helper backs the identical enabled/disabled
tenant list pattern in the compactor, alertmanager, ruler, and
store-gateway, so all four are affected identically by explicitly
empty tenant-list config, though issue #6581 only reports it for the
compactor.

Fix `Set` to special-case an empty input string by setting the value
to nil, matching the sibling `SecretStringSliceCSV.Set`, which
already special-cases `s == ""` this same way.

Validation:
  go build ./...
  go test ./pkg/util/flagext/... ./pkg/compactor/... ./pkg/util/validation/... ./pkg/util/users/... -tags "netgo slicelabels"
All pass, including new tests in pkg/util/flagext/stringslicecsv_test.go
covering direct `Set("")` and YAML unmarshaling of `csv: ""`.

Before/after: with `enabled_tenants: ""`, no tenant was ever
compacted by any compactor replica (every tenant matched
"not owned by this shard"/was filtered out before ownership was even
checked). After this fix, an explicitly empty `enabled_tenants` (or
`disabled_tenants`) behaves identically to the field being omitted:
all tenants are eligible, subject to normal ring sharding.

Fixes #6581

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
