### PR TITLE
docs(compactor): document global and per-tenant blocks retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [ENHANCEMENT] Ingester: Add `cortex_ingester_tsdb_head_max_timestamp` metric that re-exports the TSDB head max timestamp (`prometheus_tsdb_head_max_time`) per user, to help investigate ingestion issues like out-of-bounds (too old sample) errors. #7694
 * [ENHANCEMENT] Ingester: Include the TSDB head max time in the `out of bounds` and `too old sample` error messages, so that users can see how far behind the accepted time range a rejected sample is. #7695
 * [ENHANCEMENT] Compactor: Reduce object storage GET calls when updating the bucket index by skipping re-reading parquet converter markers for blocks that already have a valid-version parquet entry in the previous index. #7669
+* [ENHANCEMENT] Compactor: Document global and per-tenant blocks retention in the compactor guide, including runtime config overrides and the recommended `-querier.max-query-lookback` setting. #7722
 * [BUGFIX] Querier: Fix queryWithRetry and labelsWithRetry returning (nil, nil) on cancelled context by propagating ctx.Err(). #7370
 * [BUGFIX] Metrics Helper: Fix non-deterministic bucket order in merged histograms by sorting buckets after map iteration, matching Prometheus client library behavior. #7380
 * [BUGFIX] Distributor: Return HTTP 401 Unauthorized when tenant ID resolution fails in the Prometheus Remote Write 2.0 path. #7389

--- a/docs/blocks-storage/compactor.md
+++ b/docs/blocks-storage/compactor.md
@@ -73,6 +73,49 @@ min_disk_space_required = compactor.compaction-concurrency * max_compaction_rang
 
 Alternatively, assuming the largest `-compactor.block-ranges` is `24h` (default), you could consider 150GB of disk space every 10M active series owned by the largest tenant. For example, if your largest tenant has 30M active series and `-compactor.compaction-concurrency=1` we would recommend having a disk with at least 450GB available.
 
+## Blocks retention
+
+The compactor is responsible for enforcing data retention at the block level. Retention defines how long blocks containing samples older than the specified period are kept in object storage before being permanently deleted.
+
+### Global retention
+
+Global retention is configured via the `-compactor.blocks-retention-period` flag (or the `compactor.blocks_retention_period` YAML option). When set to a non-zero value, the compactor will mark for deletion any block whose maximum time is older than `now - retention_period`. A value of `0` (the default) disables retention and blocks are kept indefinitely.
+
+**Example**: to retain data for 30 days globally:
+
+```yaml
+compactor:
+  blocks_retention_period: 720h
+```
+
+### Per-tenant retention
+
+Cortex supports configuring a different retention period per tenant via the runtime configuration overrides. The per-tenant setting is controlled by the `compactor_blocks_retention_period` field under each tenant's override entry.
+
+When per-tenant retention is set, it takes precedence over the global `-compactor.blocks-retention-period` for that tenant. A value of `0` in the per-tenant override means "no retention" (blocks are kept indefinitely for that tenant), not "inherit the global default".
+
+**Example runtime configuration**:
+
+```yaml
+overrides:
+  tenant1:
+    # Keep tenant1's data for 90 days.
+    compactor_blocks_retention_period: 2160h
+  tenant2:
+    # Keep tenant2's data for 7 days.
+    compactor_blocks_retention_period: 168h
+```
+
+### Retention and querying
+
+When enabling retention, it is recommended to also set `-querier.max-query-lookback` to a value equal to or slightly greater than the longest retention period in use. This prevents the querier from attempting to fetch blocks that the compactor has already deleted, avoiding spurious errors.
+
+**Example**: for a 30-day retention, set:
+
+```
+-querier.max-query-lookback=720h
+```
+
 ## Compactor HTTP endpoints
 
 - `GET /compactor/ring`<br />

--- a/docs/blocks-storage/compactor.template
+++ b/docs/blocks-storage/compactor.template
@@ -73,6 +73,49 @@ min_disk_space_required = compactor.compaction-concurrency * max_compaction_rang
 
 Alternatively, assuming the largest `-compactor.block-ranges` is `24h` (default), you could consider 150GB of disk space every 10M active series owned by the largest tenant. For example, if your largest tenant has 30M active series and `-compactor.compaction-concurrency=1` we would recommend having a disk with at least 450GB available.
 
+## Blocks retention
+
+The compactor is responsible for enforcing data retention at the block level. Retention defines how long blocks containing samples older than the specified period are kept in object storage before being permanently deleted.
+
+### Global retention
+
+Global retention is configured via the `-compactor.blocks-retention-period` flag (or the `compactor.blocks_retention_period` YAML option). When set to a non-zero value, the compactor will mark for deletion any block whose maximum time is older than `now - retention_period`. A value of `0` (the default) disables retention and blocks are kept indefinitely.
+
+**Example**: to retain data for 30 days globally:
+
+```yaml
+compactor:
+  blocks_retention_period: 720h
+```
+
+### Per-tenant retention
+
+Cortex supports configuring a different retention period per tenant via the runtime configuration overrides. The per-tenant setting is controlled by the `compactor_blocks_retention_period` field under each tenant's override entry.
+
+When per-tenant retention is set, it takes precedence over the global `-compactor.blocks-retention-period` for that tenant. A value of `0` in the per-tenant override means "no retention" (blocks are kept indefinitely for that tenant), not "inherit the global default".
+
+**Example runtime configuration**:
+
+```yaml
+overrides:
+  tenant1:
+    # Keep tenant1's data for 90 days.
+    compactor_blocks_retention_period: 2160h
+  tenant2:
+    # Keep tenant2's data for 7 days.
+    compactor_blocks_retention_period: 168h
+```
+
+### Retention and querying
+
+When enabling retention, it is recommended to also set `-querier.max-query-lookback` to a value equal to or slightly greater than the longest retention period in use. This prevents the querier from attempting to fetch blocks that the compactor has already deleted, avoiding spurious errors.
+
+**Example**: for a 30-day retention, set:
+
+```
+-querier.max-query-lookback=720h
+```
+
 ## Compactor HTTP endpoints
 
 - `GET /compactor/ring`<br />


### PR DESCRIPTION
**What this PR does**:

Adds a new **Blocks retention** section to the compactor documentation (`docs/blocks-storage/compactor.md` and its source template) covering:

- **Global retention** — how to configure `-compactor.blocks-retention-period` with a worked YAML example.
- **Per-tenant retention** — how to set `compactor_blocks_retention_period` per tenant via the runtime config overrides, with a clear note that a value of `0` means "keep indefinitely" (not "inherit global default").
- **Retention and querying** — the recommended `-querier.max-query-lookback` setting to avoid queries reaching into already-deleted blocks.

**Which issue(s) this PR fixes**:
Fixes #3926

**Checklist**
- [x] Tests updated (no code changes; docs only)
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags (N/A — no new flags)

> Note: This PR was developed with AI assistance (Claude Code).