### PR TITLE
Update fuzz tests to use dynamic release images for improved compatibility

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -252,9 +252,12 @@ jobs:
       - name: Stage Test Data
         # The integration tests read docs/configuration/*.yaml at runtime via getCortexProjectDir()
         # in integration/util.go. Bundling these so the integration job doesn't need a checkout.
+        # The VERSION file is also read (getLatestReleaseImage) to pin backward-compatibility
+        # fuzz tests to the latest release image.
         run: |
           mkdir -p out/testdata/docs
           cp -r docs/configuration out/testdata/docs/
+          cp VERSION out/testdata/
       - name: Create Integration Tests Archive
         run: tar -C out -czvf integration-tests-${{ matrix.arch }}.tar.gz bin testdata
       - name: Upload Integration Tests Artifact
@@ -324,9 +327,10 @@ jobs:
             retry docker pull quay.io/cortexproject/cortex:v1.19.1
             retry docker pull quay.io/cortexproject/cortex:v1.20.1
             retry docker pull quay.io/cortexproject/cortex:v1.21.0
+            retry docker pull quay.io/cortexproject/cortex:v1.21.1
           elif [ "$TEST_TAGS" = "integration_query_fuzz" ]; then
-            retry docker pull quay.io/cortexproject/cortex:v1.20.1
-            retry docker pull quay.io/prometheus/prometheus:v3.8.1
+            retry docker pull quay.io/cortexproject/cortex:v$(cat testdata/VERSION)
+            retry docker pull quay.io/prometheus/prometheus:v3.9.1
           elif [ "$TEST_TAGS" = "integration_configs_db" ]; then
             retry docker pull postgres:9.6.16
           fi

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -38,6 +38,7 @@ var (
 		"quay.io/cortexproject/cortex:v1.19.1": nil,
 		"quay.io/cortexproject/cortex:v1.20.1": nil,
 		"quay.io/cortexproject/cortex:v1.21.0": nil,
+		"quay.io/cortexproject/cortex:v1.21.1": nil,
 	}
 )
 

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -425,7 +425,8 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 }
 
 func TestExpandedPostingsCacheFuzz(t *testing.T) {
-	stableCortexImage := "quay.io/cortexproject/cortex:v1.18.0"
+	stableCortexImage, err := getLatestReleaseImage()
+	require.NoError(t, err)
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()
@@ -1762,8 +1763,8 @@ var labelSetsComparer = cmp.Comparer(func(x, y []model.LabelSet) bool {
 
 // TestBackwardCompatibilityQueryFuzz compares query results with the latest Cortex release.
 func TestBackwardCompatibilityQueryFuzz(t *testing.T) {
-	// TODO: expose the image tag to be passed from Makefile or Github Action Config.
-	previousCortexReleaseImage := "quay.io/cortexproject/cortex:v1.18.1"
+	previousCortexReleaseImage, err := getLatestReleaseImage()
+	require.NoError(t, err)
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()

--- a/integration/util.go
+++ b/integration/util.go
@@ -4,9 +4,11 @@ package integration
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -32,6 +34,22 @@ func getCortexProjectDir() string {
 	}
 
 	return os.Getenv("GOPATH") + "/src/github.com/cortexproject/cortex"
+}
+
+// getLatestReleaseImage returns the Cortex image reference for the latest release,
+// derived from the VERSION file at the project root.
+func getLatestReleaseImage() (string, error) {
+	content, err := os.ReadFile(filepath.Join(getCortexProjectDir(), "VERSION"))
+	if err != nil {
+		return "", errors.Wrap(err, "unable to read VERSION file")
+	}
+
+	version := strings.TrimSpace(string(content))
+	if version == "" {
+		return "", errors.New("VERSION file is empty")
+	}
+
+	return fmt.Sprintf("quay.io/cortexproject/cortex:v%s", version), nil
 }
 
 func writeFileToSharedDir(s *e2e.Scenario, dst string, content []byte) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Derive the "latest release" Cortex image used by fuzz tests from the VERSION file instead of hardcoding the tag. This keeps the tests pinned to the current release without manual updates each release.

Update the preload Prometheus image, as we use v3.9.1 in e2e tests.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
