### PR TITLE
Matching rule related errors between internal and external ruler path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [ENHANCEMENT] Ingester: Add `cortex_ingester_tsdb_head_max_timestamp` metric that re-exports the TSDB head max timestamp (`prometheus_tsdb_head_max_time`) per user, to help investigate ingestion issues like out-of-bounds (too old sample) errors. #7694
 * [ENHANCEMENT] Ingester: Include the TSDB head max time in the `out of bounds` and `too old sample` error messages, so that users can see how far behind the accepted time range a rejected sample is. #7695
 * [ENHANCEMENT] Compactor: Reduce object storage GET calls when updating the bucket index by skipping re-reading parquet converter markers for blocks that already have a valid-version parquet entry in the previous index. #7669
+* [ENHANCEMENT] Ruler: Adjust ruler frontend decoder to not wrap query error messages with execution prefix, this makes error responses consistent between internal and external ruler paths. #7741
 * [BUGFIX] Querier: Fix queryWithRetry and labelsWithRetry returning (nil, nil) on cancelled context by propagating ctx.Err(). #7370
 * [BUGFIX] Metrics Helper: Fix non-deterministic bucket order in merged histograms by sorting buckets after map iteration, matching Prometheus client library behavior. #7380
 * [BUGFIX] Distributor: Return HTTP 401 Unauthorized when tenant ID resolution fails in the Prometheus Remote Write 2.0 path. #7389

--- a/pkg/ruler/frontend_client_test.go
+++ b/pkg/ruler/frontend_client_test.go
@@ -134,7 +134,7 @@ func TestInstantQueryJsonCodec(t *testing.T) {
 					"error": "something wrong"
 				}`,
 			expected:    nil,
-			expectedErr: errors.New("failed to execute query with error: something wrong"),
+			expectedErr: errors.New("something wrong"),
 		},
 	}
 

--- a/pkg/ruler/frontend_decoder.go
+++ b/pkg/ruler/frontend_decoder.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -39,7 +38,7 @@ func (j JsonDecoder) Decode(body []byte) (promql.Vector, Warnings, error) {
 		return nil, nil, err
 	}
 	if response.Status == statusError {
-		return nil, response.Warnings, fmt.Errorf("failed to execute query with error: %s", response.Error)
+		return nil, response.Warnings, errors.New(response.Error)
 	}
 	data := struct {
 		Type   model.ValueType `json:"resultType"`
@@ -99,7 +98,7 @@ func (p ProtobufDecoder) Decode(body []byte) (promql.Vector, Warnings, error) {
 	}
 
 	if resp.Status == statusError {
-		return nil, resp.Warnings, fmt.Errorf("failed to execute query with error: %s", resp.Error)
+		return nil, resp.Warnings, errors.New(resp.Error)
 	}
 
 	switch resp.Data.ResultType {

--- a/pkg/ruler/frontend_decoder_test.go
+++ b/pkg/ruler/frontend_decoder_test.go
@@ -297,7 +297,7 @@ func TestJsonDecode(t *testing.T) {
 					"warnings": ["a","b","c"]
 				}`,
 			expectedVector:  nil,
-			expectedErr:     errors.New("failed to execute query with error: something wrong"),
+			expectedErr:     errors.New("something wrong"),
 			expectedWarning: []string{"a", "b", "c"},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

It was noticed while exploring with the ruler external querier mode that the rule evaluation failures when running through the external path with a query frontend path included prepends a string `failed to execute query with error:` before returning the error. I think this log is isolated to this specific path and has no dependencies to be an expected output for another component, so it would make sense to keep the errors between the internal and external math the same for a more seamless experience.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags


Test output:
```
go test ./pkg/ruler/ -run "TestJsonDecode|TestInstantQueryJsonCodec|TestProtobufDecode" -v
=== RUN   TestInstantQueryJsonCodec
=== RUN   TestInstantQueryJsonCodec/empty_vector
=== RUN   TestInstantQueryJsonCodec/vector_with_series
=== RUN   TestInstantQueryJsonCodec/get_scalar
=== RUN   TestInstantQueryJsonCodec/get_matrix
=== RUN   TestInstantQueryJsonCodec/get_string
=== RUN   TestInstantQueryJsonCodec/get_error
--- PASS: TestInstantQueryJsonCodec (0.00s)
    --- PASS: TestInstantQueryJsonCodec/empty_vector (0.00s)
    --- PASS: TestInstantQueryJsonCodec/vector_with_series (0.00s)
    --- PASS: TestInstantQueryJsonCodec/get_scalar (0.00s)
    --- PASS: TestInstantQueryJsonCodec/get_matrix (0.00s)
    --- PASS: TestInstantQueryJsonCodec/get_string (0.00s)
    --- PASS: TestInstantQueryJsonCodec/get_error (0.00s)
=== RUN   TestJsonDecode
=== RUN   TestJsonDecode/empty_vector
=== RUN   TestJsonDecode/vector_with_series
=== RUN   TestJsonDecode/scalar
=== RUN   TestJsonDecode/matrix
=== RUN   TestJsonDecode/string
=== RUN   TestJsonDecode/error_with_warnings
--- PASS: TestJsonDecode (0.00s)
    --- PASS: TestJsonDecode/empty_vector (0.00s)
    --- PASS: TestJsonDecode/vector_with_series (0.00s)
    --- PASS: TestJsonDecode/scalar (0.00s)
    --- PASS: TestJsonDecode/matrix (0.00s)
    --- PASS: TestJsonDecode/string (0.00s)
    --- PASS: TestJsonDecode/error_with_warnings (0.00s)
PASS
ok      [github.com/cortexproject/cortex/pkg/ruler](http://github.com/cortexproject/cortex/pkg/ruler)       1.296s
```