### PR TITLE
Querier: prune bucket-scan finder per-tenant metadata for departed tenants on partial scan errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 * [BUGFIX] Ring: Fix DynamoDB KV CAS not retrying on transactional conditional check failures. `TransactWriteItems` reports condition failures as `TransactionCanceledException` with a `ConditionalCheckFailed` cancellation reason, which was not recognized as retryable, so any concurrent ring update conflict (e.g. many ingesters joining during a rolling update) failed immediately instead of re-reading and retrying. `TransactionConflict` cancellation reasons are also treated as retryable. #7706
 * [BUGFIX] Distributor: Return HTTP 499 (Client Closed Request) instead of 500 when a remote-write or OTLP push is canceled by the client, so client-side cancellations are no longer counted as server-side errors. #7717
 * [BUGFIX] Querier: Fix gRPC `codes.Canceled` errors being mapped to HTTP 500 instead of 499 when a client cancels a query. #7738
+* [BUGFIX] Querier: Fix unbounded growth of the bucket-scan blocks finder's per-tenant metadata on the partial-error scan path (used when the bucket index is disabled). Metadata for departed tenants is now pruned even while other tenants' scans keep failing, so deleted tenants no longer serve stale block references or retain memory forever. #7747
 
 ## 1.21.1 2026-06-04
 

--- a/pkg/querier/blocks_finder_bucket_scan.go
+++ b/pkg/querier/blocks_finder_bucket_scan.go
@@ -271,15 +271,14 @@ pushJobsLoop:
 	}
 	d.userMx.Unlock()
 
-	// Reconcile the cached metadata fetchers (and their per-tenant Prometheus registries and
-	// on-disk meta caches) against the set of currently active tenants, so these resources stay
-	// bounded as tenants are deleted from storage. userIDs comes from a successful ScanUsers call
-	// (we return early above if it failed), so it is the authoritative active set regardless of
+	// Reconcile the cached metadata and fetchers against the set of currently active tenants, so
+	// these resources stay bounded as tenants are deleted from storage. userIDs comes from a
+	// successful ScanUsers call (we return early above if it failed), and is valid regardless of
 	// any per-tenant scan errors collected in resErrs; we therefore reconcile even on the
 	// partial-error path, so the leak stays bounded under tenant churn. We only skip when the
 	// context has been cancelled (i.e. the service is shutting down).
 	if ctx.Err() == nil {
-		d.evictInactiveUserFetchers(userIDs)
+		d.reconcileActiveUsers(userIDs)
 	}
 
 	return resErrs.Err()
@@ -436,16 +435,41 @@ func (d *BucketScanBlocksFinder) createMetaFetcher(userID string) (block.Metadat
 // block.NewMetaFetcher stores its cached meta.json files (see createMetaFetcher).
 const metaSyncerCacheDirName = "meta-syncer"
 
-// evictInactiveUserFetchers reconciles the per-tenant metadata fetchers against the set of
-// currently active tenants. For every tenant that is no longer active it removes the cached
-// fetcher, unregisters its per-tenant Prometheus registry, and deletes the fetcher's on-disk meta
-// cache. Without this, d.fetchers, d.fetchersMetrics and the on-disk cache would grow unbounded
-// for the lifetime of the process as tenants are deleted from storage.
-func (d *BucketScanBlocksFinder) evictInactiveUserFetchers(activeUserIDs []string) {
+// reconcileActiveUsers reconciles all per-tenant state against the set of currently active
+// tenants: the metadata maps (which otherwise grow unbounded on the partial-error scan path,
+// where the wholesale replacement of a fully-successful scan never runs) and the fetchers, their
+// Prometheus registries and on-disk meta caches (which would grow unbounded on every path).
+// Everything is deliberately reconciled against the same active set in one place, so the
+// individual pieces of per-tenant state cannot diverge again; if some state ever needs a
+// different liveness set, split this function deliberately rather than special-casing inside it.
+//
+// The maps are pruned in their own userMx critical section, after scanBucket's merge section has
+// released the lock: a concurrent GetBlocks may briefly observe a departed tenant between the
+// merge and the prune. That is indistinguishable from reading while a scan is still in progress,
+// and strictly better than the unbounded retention it replaces.
+func (d *BucketScanBlocksFinder) reconcileActiveUsers(activeUserIDs []string) {
 	active := make(map[string]struct{}, len(activeUserIDs))
 	for _, userID := range activeUserIDs {
 		active[userID] = struct{}{}
 	}
+
+	d.userMx.Lock()
+	for userID := range d.userMetas {
+		if _, ok := active[userID]; !ok {
+			delete(d.userMetas, userID)
+		}
+	}
+	for userID := range d.userMetasLookup {
+		if _, ok := active[userID]; !ok {
+			delete(d.userMetasLookup, userID)
+		}
+	}
+	for userID := range d.userDeletionMarks {
+		if _, ok := active[userID]; !ok {
+			delete(d.userDeletionMarks, userID)
+		}
+	}
+	d.userMx.Unlock()
 
 	// Evict the in-memory fetchers and their per-tenant Prometheus registries.
 	var evicted []string

--- a/pkg/querier/blocks_finder_bucket_scan_test.go
+++ b/pkg/querier/blocks_finder_bucket_scan_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -511,18 +513,19 @@ func TestBucketScanBlocksFinder_PeriodicScanEvictsOnlyInactiveUserFetchers(t *te
 // with an empty prefix) still succeeds.
 type failUserBucket struct {
 	objstore.InstrumentedBucket
-	failUser string
+	failUser      string
+	failScanUsers bool
 }
 
 func (b *failUserBucket) Iter(ctx context.Context, dir string, f func(string) error, options ...objstore.IterOption) error {
-	if strings.HasPrefix(dir, b.failUser) {
+	if (b.failScanUsers && dir == "") || (b.failUser != "" && strings.HasPrefix(dir, b.failUser)) {
 		return errors.New("injected listing failure")
 	}
 	return b.InstrumentedBucket.Iter(ctx, dir, f, options...)
 }
 
 func (b *failUserBucket) IterWithAttributes(ctx context.Context, dir string, f func(objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
-	if strings.HasPrefix(dir, b.failUser) {
+	if (b.failScanUsers && dir == "") || (b.failUser != "" && strings.HasPrefix(dir, b.failUser)) {
 		return errors.New("injected listing failure")
 	}
 	return b.InstrumentedBucket.IterWithAttributes(ctx, dir, f, options...)
@@ -536,12 +539,12 @@ func (b *failUserBucket) ReaderWithExpectedErrs(objstore.IsOpFailureExpectedFunc
 	return b
 }
 
-func TestBucketScanBlocksFinder_PeriodicScanEvictsInactiveUserDespiteOtherTenantScanError(t *testing.T) {
+func TestBucketScanBlocksFinder_PeriodicScanReconcilesInactiveUserDespiteOtherTenantScanError(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
 	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
-	wrapped := &failUserBucket{InstrumentedBucket: bkt, failUser: "user-2"}
+	wrapped := &failUserBucket{InstrumentedBucket: bkt}
 
 	cfg := prepareBucketScanBlocksFinderConfig()
 	cfg.CacheDir = t.TempDir()
@@ -558,32 +561,110 @@ func TestBucketScanBlocksFinder_PeriodicScanEvictsInactiveUserDespiteOtherTenant
 		require.NoError(t, s.AwaitTerminated(context.Background()))
 	})
 
-	// Only user-1 is active at startup, so the initial scan succeeds and caches its fetcher.
-	cortex_testutil.MockStorageBlock(t, bkt, "user-1", 10, 20)
+	// Both users initially scan successfully, so they have known-good metas and cached fetchers.
+	user1Block := cortex_testutil.MockStorageBlock(t, bkt, "user-1", 10, 20)
+	user2Block := cortex_testutil.MockStorageBlock(t, bkt, "user-2", 10, 20)
+	cortex_testutil.MockStorageDeletionMark(t, bkt, "user-1", user1Block)
+	user2Mark := bucketindex.BlockDeletionMarkFromThanosMarker(cortex_testutil.MockStorageDeletionMark(t, bkt, "user-2", user2Block))
 	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
 
 	s.fetchersMx.Lock()
-	require.Equal(t, 1, len(s.fetchers))
+	require.Equal(t, 2, len(s.fetchers))
 	s.fetchersMx.Unlock()
 
-	// Introduce an active-but-erroring tenant and delete user-1.
-	cortex_testutil.MockStorageBlock(t, bkt, "user-2", 10, 20)
+	// Make user-2's own scan fail while it remains active, and delete user-1.
+	wrapped.failUser = "user-2"
 	require.NoError(t, bkt.Delete(ctx, "user-1"))
 
 	// This scan collects a per-tenant error for user-2 (resErrs != 0). The failing tenant is
 	// retried with the finder's hardcoded backoff, so this scan takes a few seconds; that cost is
 	// intrinsic and must not be "optimised" with a short-deadline context, which would cancel the
-	// context and make scanBucket skip eviction entirely (eviction is gated on ctx.Err() == nil).
+	// context and make scanBucket skip reconciliation entirely (it is gated on ctx.Err() == nil).
 	require.Error(t, s.scanBucket(ctx))
 
-	// ...but eviction is decoupled from per-tenant scan errors, so the now-inactive user-1 is still
-	// evicted while the erroring (but still active) user-2 is retained.
+	// The departed user is removed from every metas map even though another user's scan failed.
+	s.userMx.RLock()
+	_, hasUser1Metas := s.userMetas["user-1"]
+	_, hasUser1Lookup := s.userMetasLookup["user-1"]
+	_, hasUser1DeletionMarks := s.userDeletionMarks["user-1"]
+	_, hasUser2Metas := s.userMetas["user-2"]
+	_, hasUser2Lookup := s.userMetasLookup["user-2"]
+	_, hasUser2DeletionMarks := s.userDeletionMarks["user-2"]
+	s.userMx.RUnlock()
+	assert.False(t, hasUser1Metas)
+	assert.False(t, hasUser1Lookup)
+	assert.False(t, hasUser1DeletionMarks)
+	assert.True(t, hasUser2Metas)
+	assert.True(t, hasUser2Lookup)
+	assert.True(t, hasUser2DeletionMarks)
+
+	// GetBlocks no longer serves stale blocks for the departed user.
+	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(blocks))
+	assert.Equal(t, 0, len(deletionMarks))
+
+	// The active user whose own scan failed keeps its previously-good metas and deletion marks.
+	blocks, deletionMarks, err = s.GetBlocks(ctx, "user-2", 0, 30, nil)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	assert.Equal(t, user2Block.ULID, blocks[0].ID)
+	assert.Equal(t, map[ulid.ULID]*bucketindex.BlockDeletionMark{user2Block.ULID: user2Mark}, deletionMarks)
+
+	// Fetchers are reconciled against the same active set: user-1 is evicted and user-2 retained.
 	s.fetchersMx.Lock()
 	_, has1 := s.fetchers["user-1"]
 	_, has2 := s.fetchers["user-2"]
 	s.fetchersMx.Unlock()
 	assert.False(t, has1)
 	assert.True(t, has2)
+}
+
+func TestBucketScanBlocksFinder_PeriodicScanPreservesMetasWhenUserScanFails(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+	wrapped := &failUserBucket{InstrumentedBucket: bkt}
+
+	cfg := prepareBucketScanBlocksFinderConfig()
+	cfg.CacheDir = t.TempDir()
+	usersScanner, err := users.NewScanner(users.UsersScannerConfig{
+		Strategy:       users.UserScanStrategyList,
+		MaxStalePeriod: time.Hour,
+		CacheTTL:       0,
+	}, wrapped, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	s := NewBucketScanBlocksFinder(cfg, usersScanner, wrapped, nil, log.NewNopLogger(), nil)
+	t.Cleanup(func() {
+		s.StopAsync()
+		require.NoError(t, s.AwaitTerminated(context.Background()))
+	})
+
+	block := cortex_testutil.MockStorageBlock(t, bkt, "user-1", 10, 20)
+	mark := bucketindex.BlockDeletionMarkFromThanosMarker(cortex_testutil.MockStorageDeletionMark(t, bkt, "user-1", block))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
+
+	// A ScanUsers failure returns before reconciliation and must not treat an unavailable listing
+	// as an authoritative empty active set.
+	wrapped.failScanUsers = true
+	require.Error(t, s.scanBucket(ctx))
+
+	s.userMx.RLock()
+	_, hasMetas := s.userMetas["user-1"]
+	_, hasLookup := s.userMetasLookup["user-1"]
+	_, hasDeletionMarks := s.userDeletionMarks["user-1"]
+	s.userMx.RUnlock()
+	assert.True(t, hasMetas)
+	assert.True(t, hasLookup)
+	assert.True(t, hasDeletionMarks)
+
+	blocks, deletionMarks, err := s.GetBlocks(ctx, "user-1", 0, 30, nil)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	assert.Equal(t, block.ULID, blocks[0].ID)
+	assert.Equal(t, map[ulid.ULID]*bucketindex.BlockDeletionMark{block.ULID: mark}, deletionMarks)
 }
 
 // TestBucketScanBlocksFinder_PeriodicScanPreservesNonMetaSyncerDataOnEviction guards the
@@ -751,4 +832,152 @@ func prepareBucketScanBlocksFinderConfig() BucketScanBlocksFinderConfig {
 		IgnoreBlocksWithin:       10 * time.Hour, // All blocks created in the last 10 hour shouldn't be scanned.
 		BlockDiscoveryStrategy:   string(cortex_tsdb.RecursiveDiscovery),
 	}
+}
+
+func TestBucketScanBlocksFinder_FullySuccessfulScanStillReplacesMapWholesale(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, bkt, _, _ := prepareBucketScanBlocksFinder(t, prepareBucketScanBlocksFinderConfig())
+
+	cortex_testutil.MockStorageBlock(t, bkt, "user-1", 10, 20)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
+
+	// Inject a stale entry for a tenant with no bucket presence at all (neither active, deleting
+	// nor deleted), simulating a leftover from the past, and alias the maps: a fully successful
+	// scan must REPLACE the maps wholesale — which also reclaims the maps' internal bucket
+	// capacity, something merge+prune never does — not merely prune the stale entry out of the
+	// old maps. The pointer-identity assertion pins the replacement itself, so the partial-error
+	// reconciliation can never silently become the only cleanup mechanism.
+	s.userMx.Lock()
+	s.userMetas["ghost"] = bucketindex.Blocks{&bucketindex.Block{ID: ulid.MustNew(1, nil)}}
+	s.userMetasLookup["ghost"] = map[ulid.ULID]*bucketindex.Block{}
+	s.userDeletionMarks["ghost"] = map[ulid.ULID]*bucketindex.BlockDeletionMark{}
+	oldMetas := s.userMetas
+	s.userMx.Unlock()
+
+	require.NoError(t, s.scanBucket(ctx))
+
+	s.userMx.RLock()
+	replaced := reflect.ValueOf(s.userMetas).Pointer() != reflect.ValueOf(oldMetas).Pointer()
+	_, hasGhostMetas := s.userMetas["ghost"]
+	_, hasGhostLookup := s.userMetasLookup["ghost"]
+	_, hasGhostMarks := s.userDeletionMarks["ghost"]
+	s.userMx.RUnlock()
+	assert.True(t, replaced, "a fully successful scan must replace the metas maps wholesale, not merge into them")
+	assert.False(t, hasGhostMetas)
+	assert.False(t, hasGhostLookup)
+	assert.False(t, hasGhostMarks)
+}
+
+// TestBucketScanBlocksFinder_PruningDoesNotRaceWithConcurrentGetBlocks verifies the lock
+// discipline between the pruning writer in reconcileActiveUsers and concurrent GetBlocks readers
+// under -race. Note the race detector can only prove the absence of unsynchronized access; the
+// transient visibility of a departed tenant between the merge and prune critical sections is
+// documented at reconcileActiveUsers and is not what this test checks. The final assertion pins
+// that pruning actually happened.
+func TestBucketScanBlocksFinder_PruningDoesNotRaceWithConcurrentGetBlocks(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+	wrapped := &failUserBucket{InstrumentedBucket: bkt, failUser: "user-2"}
+
+	cfg := prepareBucketScanBlocksFinderConfig()
+	cfg.CacheDir = t.TempDir()
+	usersScanner, err := users.NewScanner(users.UsersScannerConfig{
+		Strategy:       users.UserScanStrategyList,
+		MaxStalePeriod: time.Hour,
+		CacheTTL:       0,
+	}, wrapped, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	s := NewBucketScanBlocksFinder(cfg, usersScanner, wrapped, nil, log.NewNopLogger(), nil)
+	t.Cleanup(func() {
+		s.StopAsync()
+		require.NoError(t, s.AwaitTerminated(context.Background()))
+	})
+
+	cortex_testutil.MockStorageBlock(t, bkt, "user-1", 10, 20)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
+
+	require.NoError(t, bkt.Delete(ctx, "user-1"))
+	cortex_testutil.MockStorageBlock(t, bkt, "user-2", 10, 20)
+
+	// Hammer GetBlocks concurrently with a scan that prunes user-1 on the partial-error path, so
+	// the race detector can catch any locking gap between the pruning writer and readers.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_, _, _ = s.GetBlocks(ctx, "user-1", 0, 30, nil)
+				_, _, _ = s.GetBlocks(ctx, "user-2", 0, 30, nil)
+			}
+		}
+	})
+
+	require.Error(t, s.scanBucket(ctx))
+	close(stop)
+	wg.Wait()
+
+	s.userMx.RLock()
+	_, hasUser1 := s.userMetas["user-1"]
+	s.userMx.RUnlock()
+	assert.False(t, hasUser1)
+}
+
+// TestBucketScanBlocksFinder_FetcherCreatedDuringFailingScanIsRetained preserves the original
+// #7573 regression scenario: a tenant whose scan errors from the moment it appears still gets a
+// metadata fetcher created during the (partially failing) scan, and reconciliation must retain
+// that fetcher because the tenant is active — while a departed tenant is still evicted by the
+// same reconciliation.
+func TestBucketScanBlocksFinder_FetcherCreatedDuringFailingScanIsRetained(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+	wrapped := &failUserBucket{InstrumentedBucket: bkt, failUser: "user-2"}
+
+	cfg := prepareBucketScanBlocksFinderConfig()
+	cfg.CacheDir = t.TempDir()
+	usersScanner, err := users.NewScanner(users.UsersScannerConfig{
+		Strategy:       users.UserScanStrategyList,
+		MaxStalePeriod: time.Hour,
+		CacheTTL:       0,
+	}, wrapped, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	s := NewBucketScanBlocksFinder(cfg, usersScanner, wrapped, nil, log.NewNopLogger(), nil)
+	t.Cleanup(func() {
+		s.StopAsync()
+		require.NoError(t, s.AwaitTerminated(context.Background()))
+	})
+
+	// Only user-1 is active at startup, so the initial scan succeeds and caches its fetcher.
+	cortex_testutil.MockStorageBlock(t, bkt, "user-1", 10, 20)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
+
+	s.fetchersMx.Lock()
+	require.Equal(t, 1, len(s.fetchers))
+	s.fetchersMx.Unlock()
+
+	// Introduce an active-but-erroring tenant and delete user-1.
+	cortex_testutil.MockStorageBlock(t, bkt, "user-2", 10, 20)
+	require.NoError(t, bkt.Delete(ctx, "user-1"))
+
+	// This scan collects a per-tenant error for user-2 (resErrs != 0); the failing tenant is
+	// retried with the finder's hardcoded backoff, so this scan takes a few seconds.
+	require.Error(t, s.scanBucket(ctx))
+
+	// Reconciliation is decoupled from per-tenant scan errors: the now-inactive user-1 is evicted
+	// while user-2's fetcher — created during the failing scan — is retained.
+	s.fetchersMx.Lock()
+	_, has1 := s.fetchers["user-1"]
+	_, has2 := s.fetchers["user-2"]
+	s.fetchersMx.Unlock()
+	assert.False(t, has1)
+	assert.True(t, has2)
 }


### PR DESCRIPTION
**What this PR does**:

`BucketScanBlocksFinder.scanBucket` pruned its per-tenant maps (`userMetas`, `userMetasLookup`, `userDeletionMarks`) only when a scan completed with no errors, by replacing the maps wholesale. On the partial-error path the maps were merged via `maps.Copy` and entries were never deleted. A single permanently-failing tenant (e.g. an inaccessible customer-managed encryption key) means no scan ever fully succeeds, so:

- entries for every tenant the process has ever seen — including tenants long deleted from storage — are retained for the lifetime of the process (each `userMetas` entry holds a full `bucketindex.Blocks` slice, so this is the larger sibling of the fetcher leak #7573 fixed), and
- `GetBlocks` keeps resolving stale block references for deleted tenants, so their queries fail the store-gateway consistency check instead of returning empty results.

Since #7573 the partial path already reconciled the metadata *fetchers* against the active set, so fetcher eviction and metadata pruning diverged — the asymmetry the issue calls out.

The fix generalizes that eviction into `reconcileActiveUsers`, which reconciles **all** per-tenant state — the three metadata maps, the fetchers, their Prometheus registries and on-disk caches — against the authoritative active set from `ScanUsers`, in one place, on every scan regardless of per-tenant errors. Having a single reconciliation authority is deliberate: the bug existed precisely because two pieces of per-tenant state were reconciled in different places against different conditions.

Design notes for review:

- **Prune set is active-only, not active+deleting.** Scan jobs are only ever scheduled for active tenants, so a fully-successful wholesale replacement never contains a deleting tenant either — pruning against the active set makes the partial-error path *converge on what the success path already does*, rather than inventing a third behavior where query visibility depends on whether an unrelated tenant happened to fail. Retaining deleting tenants would actually be harmful: the finder never rescans them, while the blocks cleaner deletes their blocks incrementally, so a frozen, never-refreshed block list would keep resolving already-deleted blocks and reproduce the very consistency-check failures this fix eliminates. (An empty result for a deleting tenant is what any successful scan already produces today; serving queries throughout deletion would require changing what the scan loop iterates, which is a separate discussion.)
- **A tenant whose own scan failed is never pruned** — it is still in the active set, so its previously-good metadata is retained (covered by a test).
- **Nothing is pruned when `ScanUsers` itself fails** (no authoritative set; the scan returns before any mutation — covered by a test) or when the context is cancelled during shutdown.
- The maps are pruned under `userMx` in `reconcileActiveUsers`, a separate critical section from the merge, so a concurrent `GetBlocks` can briefly observe a departed tenant between merge and prune — momentary, and strictly better than the status quo where the entry survived forever. A `-race` test hammers `GetBlocks` against a pruning scan.
- This is orthogonal to #7727 (shared on-disk sync-dir between the querier finder and a co-located store-gateway): that issue is about the *disk* cache layout and is addressed separately; both PRs touch `blocks_finder_bucket_scan.go`, so whichever lands second will need a trivial rebase.

Testing: the regression test (partial-error scan with one permanently-failing tenant + a deleted tenant) fails on master with the deleted tenant surviving in all three maps and `GetBlocks` still returning its stale block; it passes with the fix. Additional tests pin: retention for an errored-but-active tenant, no pruning on `ScanUsers` failure, the wholesale-replacement invariant on the success path, and race-freedom of pruning vs concurrent `GetBlocks`. Full `pkg/querier` passes with `-tags "netgo slicelabels"` and with `-race`.

**Which issue(s) this PR fixes**:
Fixes #7728

**Checklist**
- [x] Tests updated
- [ ] Documentation added (n/a — no config or flag changes)
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags (n/a)

---
Per the [Generative AI Contribution Policy](https://github.com/cortexproject/cortex/blob/master/GENAI_POLICY.md): this change was developed with substantial AI assistance (multiple independent AI implementations reconciled and then adversarially cross-reviewed, under my direction). I have reviewed and validated all of it and take responsibility for its correctness.
