### PR TITLE
fix: eliminate spurious "bucket operation fail after retries" logs during partial block cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@
 * [BUGFIX] Ring: Fix DynamoDB KV CAS not retrying on transactional conditional check failures. `TransactWriteItems` reports condition failures as `TransactionCanceledException` with a `ConditionalCheckFailed` cancellation reason, which was not recognized as retryable, so any concurrent ring update conflict (e.g. many ingesters joining during a rolling update) failed immediately instead of re-reading and retrying. `TransactionConflict` cancellation reasons are also treated as retryable. #7706
 * [BUGFIX] Distributor: Return HTTP 499 (Client Closed Request) instead of 500 when a remote-write or OTLP push is canceled by the client, so client-side cancellations are no longer counted as server-side errors. #7717
 * [BUGFIX] Querier: Fix gRPC `codes.Canceled` errors being mapped to HTTP 500 instead of 499 when a client cancels a query. #7738
+* [BUGFIX] Compactor: Fix spurious `bucket operation fail after retries` error logs emitted during partial block cleanup. #7749
+
 
 ## 1.21.1 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,6 @@
 * [BUGFIX] Querier: Fix gRPC `codes.Canceled` errors being mapped to HTTP 500 instead of 499 when a client cancels a query. #7738
 * [BUGFIX] Compactor: Fix spurious `bucket operation fail after retries` error logs emitted during partial block cleanup. #7749
 
-
 ## 1.21.1 2026-06-04
 
 * [BUGFIX] gRPC: Fix panic when `grpc_compression` is set to `snappy` on ingester client or store-gateway client configurations. #7459

--- a/pkg/compactor/block_visit_marker.go
+++ b/pkg/compactor/block_visit_marker.go
@@ -30,7 +30,6 @@ const (
 var (
 	ErrorBlockVisitMarkerNotFound  = errors.New("block visit marker not found")
 	ErrorUnmarshalBlockVisitMarker = errors.New("unmarshal block visit marker JSON")
-	ErrorNotBlockVisitMarker       = errors.New("file is not block visit marker")
 )
 
 type BlockVisitMarker struct {
@@ -148,6 +147,3 @@ func IsBlockVisitMarker(path string) bool {
 	return strings.HasSuffix(path, BlockVisitMarkerFile)
 }
 
-func IsNotBlockVisitMarkerError(err error) bool {
-	return errors.Is(err, ErrorNotBlockVisitMarker)
-}

--- a/pkg/compactor/block_visit_marker.go
+++ b/pkg/compactor/block_visit_marker.go
@@ -146,4 +146,3 @@ heartBeat:
 func IsBlockVisitMarker(path string) bool {
 	return strings.HasSuffix(path, BlockVisitMarkerFile)
 }
-

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -959,18 +959,20 @@ func (c *BlocksCleaner) cleanUserPartialBlocks(ctx context.Context, userID strin
 		// We can safely delete only partial blocks with a deletion mark.
 		err := metadata.ReadMarker(ctx, userLogger, userBucket, blockID.String(), &metadata.DeletionMark{})
 		if errors.Is(err, metadata.ErrorMarkerNotFound) {
-			//If only visit marker exists in the block, we can safely delete it.
+			// If only visit marker exists in the block, we can safely delete it.
 			isEmpty := true
-			notVisitMarkerError := userBucket.ReaderWithExpectedErrs(IsNotBlockVisitMarkerError).Iter(ctx, blockID.String(), func(file string) error {
+			hasNonVisitMarker := false
+			if iterErr := userBucket.Iter(ctx, blockID.String(), func(file string) error {
 				isEmpty = false
 				if !IsBlockVisitMarker(file) {
-					// return error here to fail iteration fast
-					// to avoid going through all files
-					return ErrorNotBlockVisitMarker
+					hasNonVisitMarker = true
 				}
 				return nil
-			})
-			if isEmpty || notVisitMarkerError != nil {
+			}); iterErr != nil {
+				level.Warn(userLogger).Log("msg", "error iterating partial block directory", "block", blockID, "err", iterErr)
+				return nil
+			}
+			if isEmpty || hasNonVisitMarker {
 				// skip deleting partial block if block directory
 				// is empty or non visit marker file exists
 				return nil

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -1390,3 +1390,106 @@ func (m *mockConfigProvider) S3SSEKMSKeyID(userID string) string {
 func (m *mockConfigProvider) S3SSEKMSEncryptionContext(userID string) string {
 	return ""
 }
+
+// TestCleanUserPartialBlocks_VisitMarkerOnly tests cleanUserPartialBlocks
+// which was fixed to use a boolean flag instead of a fast-fail error pattern
+// to avoid spurious "bucket operation fail after retries" ERROR logs.
+func TestCleanUserPartialBlocks_VisitMarkerOnly(t *testing.T) {
+	t.Parallel()
+
+	const userID = "user-1"
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	for _, tc := range []struct {
+		name          string
+		setupBlock    func(t *testing.T, bkt objstore.Bucket, blockID ulid.ULID)
+		expectDeleted bool
+	}{
+		{
+			name: "partial block with visit marker only: should be deleted",
+			setupBlock: func(t *testing.T, bkt objstore.Bucket, blockID ulid.ULID) {
+				createBlockVisitMarker(t, bkt, userID, blockID)
+			},
+			expectDeleted: true,
+		},
+		{
+			name: "partial block with deletion mark: should be deleted",
+			setupBlock: func(t *testing.T, bkt objstore.Bucket, blockID ulid.ULID) {
+				createDeletionMark(t, bkt, userID, blockID, time.Now().Add(-time.Hour))
+			},
+			expectDeleted: true,
+		},
+		{
+			name: "partial block with real data files (chunks): should not be deleted",
+			setupBlock: func(t *testing.T, bkt objstore.Bucket, blockID ulid.ULID) {
+				// visit marker + a real data file
+				createBlockVisitMarker(t, bkt, userID, blockID)
+				require.NoError(t, bkt.Upload(ctx,
+					path.Join(userID, blockID.String(), "chunks", "000001"),
+					strings.NewReader("chunk data"),
+				))
+			},
+			expectDeleted: false,
+		},
+		{
+			name: "partial block with empty directory: should not be deleted",
+			setupBlock: func(t *testing.T, bkt objstore.Bucket, blockID ulid.ULID) {
+				// upload nothing – directory is empty
+			},
+			expectDeleted: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bkt, _ := cortex_testutil.PrepareFilesystemBucket(t)
+			bkt = bucketindex.BucketWithGlobalMarkers(bkt)
+
+			blockID := ulid.MustNew(ulid.Now(), rand.Reader)
+			tc.setupBlock(t, bkt, blockID)
+
+			// partials map: block is partial because meta.json is missing
+			partials := map[ulid.ULID]error{
+				blockID: bucketindex.ErrBlockMetaNotFound,
+			}
+			idx := &bucketindex.Index{}
+
+			cfg := BlocksCleanerConfig{
+				DeletionDelay:   12 * time.Hour,
+				CleanupInterval: time.Minute,
+			}
+			reg := prometheus.NewRegistry()
+			blocksMarkedForDeletion := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: blocksMarkedForDeletionName,
+				Help: blocksMarkedForDeletionHelp,
+			}, append(commonLabels, reasonLabelName))
+			dummyGaugeVec := prometheus.NewGaugeVec(prometheus.GaugeOpts{}, []string{"test"})
+
+			cleaner := NewBlocksCleaner(cfg, bkt, nil, 60*time.Second, newMockConfigProvider(), logger, "test-cleaner", reg, time.Minute, 30*time.Second, blocksMarkedForDeletion, dummyGaugeVec)
+
+			userBucket := bucket.NewUserBucketClient(userID, bkt, cleaner.cfgProvider)
+			userLogger := util_log.WithUserID(userID, logger)
+
+			cleaner.cleanUserPartialBlocks(ctx, userID, partials, idx, userBucket, userLogger)
+
+			visitMarkerPath := path.Join(userID, blockID.String(), BlockVisitMarkerFile)
+			chunkPath := path.Join(userID, blockID.String(), "chunks", "000001")
+			deletionMarkPath := path.Join(userID, blockID.String(), metadata.DeletionMarkFilename)
+
+			if tc.expectDeleted {
+				// Block directory should be gone
+				exists, err := bkt.Exists(ctx, visitMarkerPath)
+				require.NoError(t, err)
+				assert.False(t, exists)
+			} else {
+				// At least one file that was uploaded should still exist
+				for _, p := range []string{visitMarkerPath, chunkPath, deletionMarkPath} {
+					exists, err := bkt.Exists(ctx, p)
+					require.NoError(t, err)
+					if exists {
+						return // block was not deleted – as expected
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
I've noticed spurious error logs during partial block cleanup:
```
level=error msg="bucket operation fail after retries" err="file is not block visit marker" operation="Iter {tenantID}/{BlockUUID}"
```

### Root cause
 `cleanUserPartialBlocks` returned a sentinel error (`ErrorNotBlockVisitMarker`) from the `Iter` callback to fast-fail iteration when a non-visit-marker file was detected. Since the bucket client wraps `BucketWithRetries` internally, this error triggered 5 retries before logging the error.

### Fix
Replace the sentinel error pattern with a simple boolean flag (`hasNonVisitMarker`). The callback no longer returns an error, so no retries occur.
Note: deletion behavior is unchanged, only the spurious retries and error logs are eliminated.



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
