### PR TITLE
Fix: prevent panic in validateAlertmanagerConfig on nil interface values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 * [BUGFIX] Distributor: Return HTTP 499 (Client Closed Request) instead of 500 when a remote-write or OTLP push is canceled by the client, so client-side cancellations are no longer counted as server-side errors. #7717
 * [BUGFIX] Querier: Fix gRPC `codes.Canceled` errors being mapped to HTTP 500 instead of 499 when a client cancels a query. #7738
 * [BUGFIX] Compactor: Fix spurious `bucket operation fail after retries` error logs emitted during partial block cleanup. #7749
+* [BUGFIX] Alertmanager: Fix panic in `validateAlertmanagerConfig` when receiver config traversal encounters nil interface values. #7751
 * [BUGFIX] Parquet Converter: Fix `auto_forget_delay` having no effect. The ring lifecycler was created without the auto-forget delegate, so unhealthy instances were never automatically removed from the ring. #7752
 
 ## 1.21.1 2026-06-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 * [BUGFIX] Distributor: Return HTTP 499 (Client Closed Request) instead of 500 when a remote-write or OTLP push is canceled by the client, so client-side cancellations are no longer counted as server-side errors. #7717
 * [BUGFIX] Querier: Fix gRPC `codes.Canceled` errors being mapped to HTTP 500 instead of 499 when a client cancels a query. #7738
 * [BUGFIX] Compactor: Fix spurious `bucket operation fail after retries` error logs emitted during partial block cleanup. #7749
+* [BUGFIX] Alertmanager: Fix panic in `validateAlertmanagerConfig` when receiver config traversal encounters nil interface values. #7751
 
 ## 1.21.1 2026-06-04
 

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -384,12 +384,12 @@ var configValidators = map[reflect.Type]func(any) error{
 // first error or nil if validation succeeds.
 func validateAlertmanagerConfig(cfg any) error {
 	v := reflect.ValueOf(cfg)
-	t := v.Type()
 
 	// Skip invalid, the zero value or a nil pointer (checked by zero value).
 	if !v.IsValid() || v.IsZero() {
 		return nil
 	}
+	t := v.Type()
 
 	// If the input config is a pointer then we need to get its value.
 	// At this point the pointer value can't be nil.

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -1367,3 +1367,39 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAlertmanagerConfig_DoesNotPanicOnNilInterfaceValues(t *testing.T) {
+	tests := map[string]any{
+		"nil root interface":        any(nil),
+		"map value nil interface":   map[string]any{"test": nil},
+		"slice value nil interface": []any{nil},
+	}
+
+	for testName, input := range tests {
+		t.Run(testName, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				err := validateAlertmanagerConfig(input)
+				assert.NoError(t, err)
+			})
+		})
+	}
+}
+
+func TestValidateAlertmanagerConfig_PagerdutyDetailsNullValue(t *testing.T) {
+	amCfg, err := config.Load(`
+route:
+  receiver: pd
+receivers:
+  - name: pd
+    pagerduty_configs:
+      - routing_key: "abc123"
+        details:
+          foo: null
+`)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		err = validateAlertmanagerConfig(amCfg)
+	})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

This PR fixes a bug in `validateAlertmanagerConfig` which could cause a panic when encountering nil interface values.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags