### PR TITLE
expose SelectorBatchSize config for Thanos engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master / unreleased
+* [FEATURE] Engine: Add `-querier.selector-batch-size` and `-ruler.selector-batch-size` flags to configure series batching in the Thanos promQL engine. 0 disables batching. #7763
 * [CHANGE] Querier: Make query time range configurations per-tenant: `query_ingesters_within`, `query_store_after`, and `shuffle_sharding_ingesters_lookback_period`. Uses `model.Duration` instead of `time.Duration` to support serialization but has minimum unit of 1ms (nanoseconds/microseconds not supported). #7160
 * [CHANGE] Cache: Setting `-blocks-storage.bucket-store.metadata-cache.bucket-index-content-ttl` to 0 will disable the bucket-index cache. #7446
 * [CHANGE] HA Tracker: Move `-distributor.ha-tracker.failover-timeout` from a global config to a per-tenant runtime config. The flag name and default value (30s) remain the same. #7481

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -256,6 +256,11 @@ querier:
     # CLI flag: -querier.decoding-concurrency
     [decoding_concurrency: <int> | default = 0]
 
+    # Maximum number of series processed per batch in selectors. 0 disables
+    # batching.
+    # CLI flag: -querier.selector-batch-size
+    [selector_batch_size: <int> | default = 0]
+
   # If enabled, ignore max query length check at Querier select method. Users
   # can choose to ignore it since the validation can be done before Querier
   # evaluation like at Query Frontend or Ruler.

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -5426,6 +5426,11 @@ thanos_engine:
   # CLI flag: -querier.decoding-concurrency
   [decoding_concurrency: <int> | default = 0]
 
+  # Maximum number of series processed per batch in selectors. 0 disables
+  # batching.
+  # CLI flag: -querier.selector-batch-size
+  [selector_batch_size: <int> | default = 0]
+
 # If enabled, ignore max query length check at Querier select method. Users can
 # choose to ignore it since the validation can be done before Querier evaluation
 # like at Query Frontend or Ruler.
@@ -6276,6 +6281,11 @@ thanos_engine:
   # to GOMAXPROCS / 2.
   # CLI flag: -ruler.decoding-concurrency
   [decoding_concurrency: <int> | default = 0]
+
+  # Maximum number of series processed per batch in selectors. 0 disables
+  # batching.
+  # CLI flag: -ruler.selector-batch-size
+  [selector_batch_size: <int> | default = 0]
 ```
 
 ### `ruler_storage_config`

--- a/pkg/engine/config.go
+++ b/pkg/engine/config.go
@@ -17,6 +17,7 @@ type ThanosEngineConfig struct {
 	EnableXFunctions    bool                    `yaml:"enable_x_functions"`
 	Optimizers          string                  `yaml:"optimizers"`
 	DecodingConcurrency int                     `yaml:"decoding_concurrency"`
+	SelectorBatchSize   int64                   `yaml:"selector_batch_size"`
 	LogicalOptimizers   []logicalplan.Optimizer `yaml:"-"`
 }
 
@@ -25,6 +26,7 @@ func (cfg *ThanosEngineConfig) RegisterFlagsWithPrefix(prefix string, f *flag.Fl
 	f.BoolVar(&cfg.EnableXFunctions, prefix+"enable-x-functions", false, "Enable xincrease, xdelta, xrate etc from Thanos engine.")
 	f.StringVar(&cfg.Optimizers, prefix+"optimizers", "default", "Logical plan optimizers. Multiple optimizers can be provided as a comma-separated list. Supported values: "+strings.Join(supportedOptimizers, ", "))
 	f.IntVar(&cfg.DecodingConcurrency, prefix+"decoding-concurrency", 0, "Maximum number of goroutines that can be used to decode samples. 0 defaults to GOMAXPROCS / 2.")
+	f.Int64Var(&cfg.SelectorBatchSize, prefix+"selector-batch-size", 0, "Maximum number of series processed per batch in selectors. 0 disables batching.")
 }
 
 func (cfg *ThanosEngineConfig) Validate() error {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -69,6 +69,7 @@ func New(opts promql.EngineOpts, thanosEngineCfg ThanosEngineConfig, reg prometh
 			EnableAnalysis:      true,
 			EnableXFunctions:    thanosEngineCfg.EnableXFunctions,
 			DecodingConcurrency: thanosEngineCfg.DecodingConcurrency,
+			SelectorBatchSize:   thanosEngineCfg.SelectorBatchSize,
 		})
 	}
 

--- a/schemas/cortex-config-schema.json
+++ b/schemas/cortex-config-schema.json
@@ -6875,6 +6875,12 @@
               "description": "Logical plan optimizers. Multiple optimizers can be provided as a comma-separated list. Supported values: default, all, propagate-matchers, sort-matchers, merge-selects, detect-histogram-stats, projection",
               "type": "string",
               "x-cli-flag": "querier.optimizers"
+            },
+            "selector_batch_size": {
+              "default": 0,
+              "description": "Maximum number of series processed per batch in selectors. 0 disables batching.",
+              "type": "number",
+              "x-cli-flag": "querier.selector-batch-size"
             }
           },
           "type": "object"
@@ -7916,6 +7922,12 @@
               "description": "Logical plan optimizers. Multiple optimizers can be provided as a comma-separated list. Supported values: default, all, propagate-matchers, sort-matchers, merge-selects, detect-histogram-stats, projection",
               "type": "string",
               "x-cli-flag": "ruler.optimizers"
+            },
+            "selector_batch_size": {
+              "default": 0,
+              "description": "Maximum number of series processed per batch in selectors. 0 disables batching.",
+              "type": "number",
+              "x-cli-flag": "ruler.selector-batch-size"
             }
           },
           "type": "object"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
 Expose SelectorBatchSize from the Thanos promQL engine as a configurable flag for querier and ruler:
  
  - querier.selector-batch-size
  - ruler.selector-batch-size

The Thanos promQL engine's SelectorBatchSize controls how many series are processed per batch in selectors. When set, the engine allocates iterators lazily per batch instead of all upfront, and for instant queries releases them after each batch. This reduces peak memory for high-cardinality queries.

[thanos-io/promql-engine#721](https://github.com/thanos-io/promql-engine/pull/721) enabled lazy iterator allocation and `SelectorBatchSize` for certain query patterns. This PR exposes it as a Cortex configuration option.
   
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
